### PR TITLE
sycl: fix error building scheduler.cpp

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -636,15 +636,15 @@ static void buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
 
       CreateAndAddPrmDsc(Fld, PointerType);
 
-      FieldDecl *RangeFld = getFieldDeclByName(RecordDecl, {"__impl", "Range"});
+      FieldDecl *RangeFld = getFieldDeclByName(RecordDecl, {"__implx", "Range"});
       assert(RangeFld &&
              "The accessor must contain the Range from the __impl field");
       CreateAndAddPrmDsc(RangeFld, RangeFld->getType());
 
       FieldDecl *OffsetFld =
-          getFieldDeclByName(RecordDecl, {"__impl", "Offset"});
+          getFieldDeclByName(RecordDecl, {"__implx", "Offset"});
       assert(OffsetFld &&
-             "The accessor must contain the Offset from the __impl field");
+             "The accessor must contain the Offset from the __implx field");
       CreateAndAddPrmDsc(OffsetFld, OffsetFld->getType());
     } else if (Util::isSyclStreamType(ArgTy)) {
       // the parameter is a SYCL stream object
@@ -700,7 +700,7 @@ static void populateIntHeader(SYCLIntegrationHeader &H, const StringRef Name,
                      getAccessTarget(AccTmplTy), Offset);
       // ... second descriptor (translated to range kernel parameter):
       FieldDecl *RngFld =
-          getFieldDeclByName(AccTy, {"__impl", "Range"}, &Offset);
+          getFieldDeclByName(AccTy, {"__implx", "Range"}, &Offset);
       uint64_t Sz = Ctx.getTypeSizeInChars(RngFld->getType()).getQuantity();
       H.addParamDesc(SYCLIntegrationHeader::kind_std_layout,
                      static_cast<unsigned>(Sz), static_cast<unsigned>(Offset));
@@ -708,7 +708,7 @@ static void populateIntHeader(SYCLIntegrationHeader &H, const StringRef Name,
       // Get offset in bytes
       Offset = Layout.getFieldOffset(Fld->getFieldIndex()) / 8;
       FieldDecl *OffstFld =
-          getFieldDeclByName(AccTy, {"__impl", "Offset"}, &Offset);
+          getFieldDeclByName(AccTy, {"__implx", "Offset"}, &Offset);
       Sz = Ctx.getTypeSizeInChars(OffstFld->getType()).getQuantity();
       H.addParamDesc(SYCLIntegrationHeader::kind_std_layout,
                      static_cast<unsigned>(Sz), static_cast<unsigned>(Offset));

--- a/sycl/include/CL/sycl/detail/scheduler/scheduler.cpp
+++ b/sycl/include/CL/sycl/detail/scheduler/scheduler.cpp
@@ -61,9 +61,7 @@ void Node::addAccRequirement(
     accessor<dataT, dimensions, accessMode, accessTarget, isPlaceholder> &&Acc,
     int argIndex) {
   detail::buffer_impl<dataT, dimensions> *buf =
-      Acc.template accessor_base<dataT, dimensions, accessMode, accessTarget,
-                                 isPlaceholder>::__impl()
-          ->m_Buf;
+      Acc.__impl()->m_Buf;
   addBufRequirement<accessMode, accessTarget, dataT, dimensions>(*buf);
   addInteropArg(nullptr, buf->get_size(), argIndex,
                 getReqForBuffer(m_Bufs, *buf));
@@ -128,8 +126,7 @@ template <typename T, int Dimensions, access::mode mode, access::target tgt,
           access::placeholder isPlaceholder>
 void Node::addExplicitMemOp(
     accessor<T, Dimensions, mode, tgt, isPlaceholder> &Dest, T Src) {
-  auto *DestBase = Dest.template accessor_base<T, Dimensions, mode, tgt,
-                                               isPlaceholder>::__impl();
+  auto *DestBase = Dest.__impl();
   assert(DestBase != nullptr &&
          "Accessor should have an initialized accessor_base");
   detail::buffer_impl<T, Dimensions> *Buf = DestBase->m_Buf;
@@ -153,13 +150,10 @@ template <typename T_src, int dim_src, access::mode mode_src,
 void Node::addExplicitMemOp(
     accessor<T_src, dim_src, mode_src, tgt_src, isPlaceholder_src> Src,
     accessor<T_dest, dim_dest, mode_dest, tgt_dest, isPlaceholder_dest> Dest) {
-  auto *SrcBase = Src.template accessor_base<T_src, dim_src, mode_src, tgt_src,
-                                             isPlaceholder_src>::__impl();
+  auto *SrcBase = Src.__impl();
   assert(SrcBase != nullptr &&
          "Accessor should have an initialized accessor_base");
-  auto *DestBase =
-      Dest.template accessor_base<T_dest, dim_dest, mode_dest, tgt_dest,
-                                  isPlaceholder_dest>::__impl();
+  auto *DestBase = Dest.__impl();
   assert(DestBase != nullptr &&
          "Accessor should have an initialized accessor_base");
 
@@ -191,8 +185,8 @@ template <typename T, int Dimensions, access::mode mode, access::target tgt,
 void Scheduler::updateHost(
     accessor<T, Dimensions, mode, tgt, isPlaceholder> &Acc,
     cl::sycl::event &Event) {
-  auto *AccBase = Acc.template accessor_base<T, Dimensions, mode, tgt,
-                                             isPlaceholder>::__impl();
+  auto *AccBase = Acc.impl();
+
   assert(AccBase != nullptr &&
          "Accessor should have an initialized accessor_base");
   detail::buffer_impl<T, Dimensions> *Buf = AccBase->m_Buf;


### PR DESCRIPTION
On Fedora 28 with gcc version 8.2.1 20181105 (Red Hat 8.2.1-5) (GCC)
building the SYCL stack gives:
/home/airlied/devel/compute/intel/llvm/sycl/include/CL/sycl/detail/scheduler/scheduler.cpp: In member function ‘void cl::sycl::simple_scheduler::Node::addAccRequirement(cl::sycl::accessor<dataT, dimensions, accessMode, accessTarget, isPlaceholder>&&, int)’:
/home/airlied/devel/compute/intel/llvm/sycl/include/CL/sycl/detail/scheduler/scheduler.cpp:66:48: error: expected ‘,’ or ‘;’ before ‘::’ token
isPlaceholder>::__impl()

Change to ._impl() which seems to compile fine.