### PR TITLE
Fix segfault with incompatible OpenCL

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -73,8 +73,8 @@ static cl_program createBinaryProgram(const cl_context Context,
   return Program;
 }
 
-cl_program createSpirvProgram(const cl_context Context,
-                              const vector_class<char> &SpirvProg) {
+static cl_program createSpirvProgram(const cl_context Context,
+                                     const vector_class<char> &SpirvProg) {
   cl_int Err = CL_SUCCESS;
   cl_program ClProgram = clCreateProgramWithIL(Context, SpirvProg.data(),
                                                SpirvProg.size(), &Err);


### PR DESCRIPTION
`clCreateProgramWithIL` is only valid on OpenCL 2.1 and above, or when `cl_khr_il_program` is supported.

If we end up calling this function on implementations that doesn't support this, we currently trigger a SIGSEGV, which isn't great.

This is far from perfect, but hopefully better than what we do now. In particular, these details could be better:
1. checking against the " 2.1"-string is fragile, and won't work for OpenCL 2.2. The reason why I did this, is that this pattern is used elsewhere in the source already.
2. re-scanning both the extension and version-string for each call to createProgram is wasteful. Again, this is a repetition of a pre-existing pattern.

I'm mostly sending this PR to figure out if this is a direction to go down or not.

Also, this functionality might arguably belong somewhere else in the stack, but if so it's unclear to me where.