### PR TITLE
[SYCL] disable struct_kernel_param test execution on GPU.

### DIFF
--- a/sycl/test/struct_param/struct_kernel_param.cpp
+++ b/sycl/test/struct_param/struct_kernel_param.cpp
@@ -1,7 +1,8 @@
 // RUN: %clang -std=c++11 -fsycl %s -o %t.out -lstdc++ -lOpenCL -lsycl
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// TODO: Uncomment once test is fixed on GPU
+// RUNx: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
 //==-struct_kernel_param.cpp-Checks passing structs as kernel params--------==//
@@ -12,7 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: *
 #include <CL/sycl.hpp>
 #include <cstring>
 #include <iostream>


### PR DESCRIPTION
The test fails on GPU and passes on CPU. So it produces
different results on systems with diffierent combinations
of OpenCL devices. Disable execution on GPU devices to
get stable results.

Signed-off-by: Vladimir Lazarev <vladimir.lazarev@intel.com>