### PR TITLE
[SYCL] Implement cl::sycl::buffer::reinterpret

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -21,7 +21,7 @@ class queue;
 template <int dimentions> class range;
 
 template <typename T, int dimensions = 1,
-          typename AllocatorT = cl::sycl::buffer_allocator<T>>
+          typename AllocatorT = cl::sycl::buffer_allocator<char>>
 class buffer {
 public:
   using value_type = T;
@@ -30,9 +30,10 @@ public:
   using allocator_type = AllocatorT;
 
   buffer(const range<dimensions> &bufferRange,
-         const property_list &propList = {}) {
-    impl = std::make_shared<detail::buffer_impl<T, dimensions, AllocatorT>>(
-        bufferRange, propList);
+         const property_list &propList = {})
+      : Range(bufferRange) {
+    impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
+        get_count() * sizeof(T), propList);
   }
 
   // buffer(const range<dimensions> &bufferRange, AllocatorT allocator,
@@ -42,9 +43,10 @@ public:
   // }
 
   buffer(T *hostData, const range<dimensions> &bufferRange,
-         const property_list &propList = {}) {
-    impl = std::make_shared<detail::buffer_impl<T, dimensions, AllocatorT>>(
-        hostData, bufferRange, propList);
+         const property_list &propList = {})
+      : Range(bufferRange) {
+    impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
+        hostData, get_count() * sizeof(T), propList);
   }
 
   // buffer(T *hostData, const range<dimensions> &bufferRange,
@@ -54,9 +56,10 @@ public:
   // }
 
   buffer(const T *hostData, const range<dimensions> &bufferRange,
-         const property_list &propList = {}) {
-    impl = std::make_shared<detail::buffer_impl<T, dimensions, AllocatorT>>(
-        hostData, bufferRange, propList);
+         const property_list &propList = {})
+      : Range(bufferRange) {
+    impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
+        hostData, get_count() * sizeof(T), propList);
   }
 
   // buffer(const T *hostData, const range<dimensions> &bufferRange,
@@ -74,9 +77,10 @@ public:
 
   buffer(const shared_ptr_class<T> &hostData,
          const range<dimensions> &bufferRange,
-         const property_list &propList = {}) {
-    impl = std::make_shared<detail::buffer_impl<T, dimensions, AllocatorT>>(
-        hostData, bufferRange, propList);
+         const property_list &propList = {})
+      : Range(bufferRange) {
+    impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
+        hostData, get_count() * sizeof(T), propList);
   }
 
   // template <class InputIterator>
@@ -89,9 +93,10 @@ public:
   template <class InputIterator, int N = dimensions,
             typename = std::enable_if<N == 1>>
   buffer(InputIterator first, InputIterator last,
-         const property_list &propList = {}) {
-    impl = std::make_shared<detail::buffer_impl<T, dimensions, AllocatorT>>(
-        first, last, propList);
+         const property_list &propList = {})
+      : Range(range<1>(std::distance(first, last))) {
+    impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
+        first, last, get_count() * sizeof(T), propList);
   }
 
   // buffer(buffer<T, dimensions, AllocatorT> b, const id<dimensions>
@@ -102,7 +107,7 @@ public:
   template <int N = dimensions, typename = std::enable_if<N == 1>>
   buffer(cl_mem MemObject, const context &SyclContext,
          event AvailableEvent = {}) {
-    impl = std::make_shared<detail::buffer_impl<T, dimensions, AllocatorT>>(
+    impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
         MemObject, SyclContext, AvailableEvent);
   }
 
@@ -124,26 +129,27 @@ public:
 
   /* -- property interface members -- */
 
-  range<dimensions> get_range() const { return impl->get_range(); }
+  range<dimensions> get_range() const { return Range; }
 
-  size_t get_count() const { return impl->get_count(); }
+  size_t get_count() const { return Range.size(); }
 
   size_t get_size() const { return impl->get_size(); }
 
-  AllocatorT get_allocator() const { return impl->get_allocator(); }
+  // AllocatorT get_allocator() const { return impl->get_allocator(); }
 
   template <access::mode mode,
             access::target target = access::target::global_buffer>
   accessor<T, dimensions, mode, target, access::placeholder::false_t>
   get_access(handler &commandGroupHandler) {
-    return impl->template get_access<mode, target>(*this, commandGroupHandler);
+    return impl->template get_access<T, dimensions, mode, target>(
+        *this, commandGroupHandler);
   }
 
   template <access::mode mode>
   accessor<T, dimensions, mode, access::target::host_buffer,
            access::placeholder::false_t>
   get_access() {
-    return impl->template get_access<mode>(*this);
+    return impl->template get_access<T, dimensions, mode>(*this);
   }
 
   // template <access::mode mode, access::target target =
@@ -171,16 +177,29 @@ public:
 
   // bool is_sub_buffer() const { return impl->is_sub_buffer(); }
 
-  // template <typename ReinterpretT, int ReinterpretDim>
-  // buffer<ReinterpretT, ReinterpretDim, AllocatorT>
-  // reinterpret(range<ReinterpretDim> reinterpretRange) const {
-  //     return impl->reinterpret((reinterpretRange));
-  // }
+  template <typename ReinterpretT, int ReinterpretDim>
+  buffer<ReinterpretT, ReinterpretDim, AllocatorT>
+  reinterpret(range<ReinterpretDim> reinterpretRange) const {
+    if (sizeof(ReinterpretT) * reinterpretRange.size() != get_size())
+      throw cl::sycl::invalid_object_error(
+          "Total size in bytes represented by the type and range of the "
+          "reinterpreted SYCL buffer does not equal the total size in bytes "
+          "represented by the type and range of this SYCL buffer");
+    return buffer<ReinterpretT, ReinterpretDim, AllocatorT>(impl,
+                                                            reinterpretRange);
+  }
 
 private:
-  shared_ptr_class<detail::buffer_impl<T, dimensions, AllocatorT>> impl;
+  shared_ptr_class<detail::buffer_impl<AllocatorT>> impl;
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
+  template <typename A, int dims, typename C> friend class buffer;
+  range<dimensions> Range;
+
+  // Reinterpret contructor
+  buffer(shared_ptr_class<detail::buffer_impl<AllocatorT>> Impl,
+         range<dimensions> reinterpretRange)
+      : impl(Impl), Range(reinterpretRange){};
 };
 } // namespace sycl
 } // namespace cl
@@ -190,8 +209,7 @@ template <typename T, int dimensions, typename AllocatorT>
 struct hash<cl::sycl::buffer<T, dimensions, AllocatorT>> {
   size_t
   operator()(const cl::sycl::buffer<T, dimensions, AllocatorT> &b) const {
-    return hash<std::shared_ptr<
-        cl::sycl::detail::buffer_impl<T, dimensions, AllocatorT>>>()(
+    return hash<std::shared_ptr<cl::sycl::detail::buffer_impl<AllocatorT>>>()(
         cl::sycl::detail::getSyclObjImpl(b));
   }
 };

--- a/sycl/include/CL/sycl/detail/scheduler/commands.cpp
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.cpp
@@ -59,9 +59,9 @@ void ExecuteKernelCommand<
         switch (static_cast<cl::sycl::access::target>(m_KernelArgs[I].info)) {
         case cl::sycl::access::target::global_buffer:
         case cl::sycl::access::target::constant_buffer: {
-          auto *Ptr =
-              *(getParamAddress<cl::sycl::detail::buffer_impl<char, 1> *>(
-                  &m_HostKernel, m_KernelArgs[I].offset));
+          auto *Ptr = *(getParamAddress<
+                        cl::sycl::detail::buffer_impl<std::allocator<char>> *>(
+              &m_HostKernel, m_KernelArgs[I].offset));
           cl_mem CLBuf = Ptr->getOpenCLMem();
           CHECK_OCL_CODE(clSetKernelArg(m_ClKernel, I, sizeof(cl_mem), &CLBuf));
           break;

--- a/sycl/include/CL/sycl/detail/scheduler/commands.h
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.h
@@ -361,13 +361,14 @@ template <int DimSrc, int DimDest> class CopyCommand : public Command {
 public:
   CopyCommand(BufferReqPtr BufSrc, BufferReqPtr BufDest, QueueImplPtr Queue,
               range<DimSrc> SrcRange, id<DimSrc> SrcOffset,
-              id<DimDest> DestOffset, size_t SizeTySrc, size_t SizeSrc,
-              range<DimSrc> BuffSrcRange)
+              id<DimDest> DestOffset, size_t SizeTySrc, size_t SizeTyDest,
+              size_t SizeSrc, range<DimSrc> BuffSrcRange,
+              range<DimDest> BuffDestRange)
       : Command(Command::COPY, std::move(Queue)), m_BufSrc(std::move(BufSrc)),
         m_BufDest(std::move(BufDest)), m_SrcRange(std::move(SrcRange)),
         m_SrcOffset(std::move(SrcOffset)), m_DestOffset(std::move(DestOffset)),
-        m_SizeTySrc(SizeTySrc), m_SizeSrc(SizeSrc),
-        m_BuffSrcRange(BuffSrcRange) {}
+        m_SizeTySrc(SizeTySrc), m_SizeTyDest(SizeTyDest), m_SizeSrc(SizeSrc),
+        m_BuffSrcRange(BuffSrcRange), m_BuffDestRange(BuffDestRange) {}
 
   access::mode getAccessModeType() const {
     return m_BufDest->getAccessModeType();
@@ -381,8 +382,9 @@ private:
     assert(nullptr != m_BufSrc && "m_BufSrc is nullptr");
     assert(nullptr != m_BufDest && "m_BufDest is nullptr");
     m_BufDest->copy(m_Queue, std::move(DepEvents), std::move(Event), m_BufSrc,
-                    DimSrc, &m_SrcRange[0], &m_SrcOffset[0], &m_DestOffset[0],
-                    m_SizeTySrc, m_SizeSrc, &m_BuffSrcRange[0]);
+                    DimSrc, DimDest, &m_SrcRange[0], &m_SrcOffset[0],
+                    &m_DestOffset[0], m_SizeTySrc, m_SizeTyDest, m_SizeSrc,
+                    &m_BuffSrcRange[0], &m_BuffDestRange[0]);
   }
   BufferReqPtr m_BufSrc = nullptr;
   BufferReqPtr m_BufDest = nullptr;
@@ -390,8 +392,10 @@ private:
   id<DimSrc> m_SrcOffset;
   id<DimDest> m_DestOffset;
   size_t m_SizeTySrc;
+  size_t m_SizeTyDest;
   size_t m_SizeSrc;
   range<DimSrc> m_BuffSrcRange;
+  range<DimDest> m_BuffDestRange;
 };
 
 } // namespace simple_scheduler

--- a/sycl/include/CL/sycl/detail/scheduler/scheduler.cpp
+++ b/sycl/include/CL/sycl/detail/scheduler/scheduler.cpp
@@ -25,10 +25,10 @@ namespace cl {
 namespace sycl {
 namespace simple_scheduler {
 
-template <typename T, int Dimensions, typename AllocatorT>
+template <typename AllocatorT>
 static BufferReqPtr
 getReqForBuffer(const std::set<BufferReqPtr, classcomp> &BufReqs,
-                const detail::buffer_impl<T, Dimensions, AllocatorT> &Buf) {
+                const detail::buffer_impl<AllocatorT> &Buf) {
   for (const auto &Req : BufReqs) {
     if (Req->getUniqID() == &Buf) {
       return Req;
@@ -38,18 +38,16 @@ getReqForBuffer(const std::set<BufferReqPtr, classcomp> &BufReqs,
 }
 
 // Adds a buffer requirement for this node.
-template <access::mode Mode, access::target Target, typename T, int Dimensions,
-          typename AllocatorT>
-void Node::addBufRequirement(
-    detail::buffer_impl<T, Dimensions, AllocatorT> &Buf) {
+template <access::mode Mode, access::target Target, typename AllocatorT>
+void Node::addBufRequirement(detail::buffer_impl<AllocatorT> &Buf) {
   BufferReqPtr Req = getReqForBuffer(m_Bufs, Buf);
 
   // Check if there is requirement for the same buffer already.
   if (nullptr != Req) {
     Req->addAccessMode(Mode);
   } else {
-    BufferReqPtr BufStor = std::make_shared<
-        BufferStorage<T, Dimensions, AllocatorT, Mode, Target>>(Buf);
+    BufferReqPtr BufStor =
+        std::make_shared<BufferStorage<AllocatorT, Mode, Target>>(Buf);
     m_Bufs.insert(BufStor);
   }
 }
@@ -60,11 +58,11 @@ template <typename dataT, int dimensions, access::mode accessMode,
 void Node::addAccRequirement(
     accessor<dataT, dimensions, accessMode, accessTarget, isPlaceholder> &&Acc,
     int argIndex) {
-  detail::buffer_impl<dataT, dimensions> *buf =
+  detail::buffer_impl<buffer_allocator<char>> *buf =
       Acc.template accessor_base<dataT, dimensions, accessMode, accessTarget,
                                  isPlaceholder>::__impl()
           ->m_Buf;
-  addBufRequirement<accessMode, accessTarget, dataT, dimensions>(*buf);
+  addBufRequirement<accessMode, accessTarget>(*buf);
   addInteropArg(nullptr, buf->get_size(), argIndex,
                 getReqForBuffer(m_Bufs, *buf));
 }
@@ -132,7 +130,7 @@ void Node::addExplicitMemOp(
                                                isPlaceholder>::__impl();
   assert(DestBase != nullptr &&
          "Accessor should have an initialized accessor_base");
-  detail::buffer_impl<T, Dimensions> *Buf = DestBase->m_Buf;
+  detail::buffer_impl<buffer_allocator<char>> *Buf = DestBase->m_Buf;
 
   range<Dimensions> Range = DestBase->Range;
   id<Dimensions> Offset = DestBase->Offset;
@@ -163,10 +161,10 @@ void Node::addExplicitMemOp(
   assert(DestBase != nullptr &&
          "Accessor should have an initialized accessor_base");
 
-  detail::buffer_impl<T_src, dim_src> *SrcBuf = SrcBase->m_Buf;
+  detail::buffer_impl<buffer_allocator<char>> *SrcBuf = SrcBase->m_Buf;
   assert(SrcBuf != nullptr &&
          "Accessor should have an initialized buffer_impl");
-  detail::buffer_impl<T_dest, dim_dest> *DestBuf = DestBase->m_Buf;
+  detail::buffer_impl<buffer_allocator<char>> *DestBuf = DestBase->m_Buf;
   assert(DestBuf != nullptr &&
          "Accessor should have an initialized buffer_impl");
 
@@ -174,7 +172,9 @@ void Node::addExplicitMemOp(
   id<dim_src> SrcOffset = SrcBase->Offset;
   id<dim_dest> DestOffset = DestBase->Offset;
 
-  range<dim_src> BuffSrcRange = SrcBase->m_Buf->get_range();
+  // Use BufRange here
+  range<dim_src> BuffSrcRange = SrcBase->BufRange;
+  range<dim_src> BuffDestRange = DestBase->BufRange;
 
   BufferReqPtr SrcReq = getReqForBuffer(m_Bufs, *SrcBuf);
   BufferReqPtr DestReq = getReqForBuffer(m_Bufs, *DestBuf);
@@ -182,7 +182,7 @@ void Node::addExplicitMemOp(
   assert(!m_Kernel && "This node already contains an execution command");
   m_Kernel = std::make_shared<CopyCommand<dim_src, dim_dest>>(
       SrcReq, DestReq, m_Queue, SrcRange, SrcOffset, DestOffset, sizeof(T_src),
-      SrcBase->get_count(), BuffSrcRange);
+      sizeof(T_dest), SrcBase->get_count(), BuffSrcRange, BuffDestRange);
 }
 
 // Updates host data of the specified accessor
@@ -195,28 +195,25 @@ void Scheduler::updateHost(
                                              isPlaceholder>::__impl();
   assert(AccBase != nullptr &&
          "Accessor should have an initialized accessor_base");
-  detail::buffer_impl<T, Dimensions> *Buf = AccBase->m_Buf;
+  detail::buffer_impl<buffer_allocator<char>> *Buf = AccBase->m_Buf;
 
   updateHost<mode, tgt>(*Buf, Event);
 }
 
-template <access::mode Mode, access::target Target, typename T, int Dimensions,
-          typename AllocatorT>
-void Scheduler::copyBack(detail::buffer_impl<T, Dimensions, AllocatorT> &Buf) {
+template <access::mode Mode, access::target Target, typename AllocatorT>
+void Scheduler::copyBack(detail::buffer_impl<AllocatorT> &Buf) {
   cl::sycl::event Event;
   updateHost<Mode, Target>(Buf, Event);
   detail::getSyclObjImpl(Event)->waitInternal();
 }
 
 // Updates host data of the specified buffer_impl
-template <access::mode Mode, access::target Target, typename T, int Dimensions,
-          typename AllocatorT>
-void Scheduler::updateHost(detail::buffer_impl<T, Dimensions, AllocatorT> &Buf,
+template <access::mode Mode, access::target Target, typename AllocatorT>
+void Scheduler::updateHost(detail::buffer_impl<AllocatorT> &Buf,
                            cl::sycl::event &Event) {
   CommandPtr UpdateHostCmd;
   BufferReqPtr BufStor =
-      std::make_shared<BufferStorage<T, Dimensions, AllocatorT, Mode, Target>>(
-          Buf);
+      std::make_shared<BufferStorage<AllocatorT, Mode, Target>>(Buf);
 
   if (0 == m_BuffersEvolution.count(BufStor)) {
     return;
@@ -236,12 +233,11 @@ void Scheduler::updateHost(detail::buffer_impl<T, Dimensions, AllocatorT> &Buf,
   Event = EnqueueCommand(std::move(UpdateHostCmd));
 }
 
-template <typename T, int Dimensions, typename AllocatorT>
-void Scheduler::removeBuffer(
-    detail::buffer_impl<T, Dimensions, AllocatorT> &Buf) {
-  BufferReqPtr BufStor = std::make_shared<
-      BufferStorage<T, Dimensions, AllocatorT, access::mode::read_write,
-                    access::target::host_buffer>>(Buf);
+template <typename AllocatorT>
+void Scheduler::removeBuffer(detail::buffer_impl<AllocatorT> &Buf) {
+  BufferReqPtr BufStor =
+      std::make_shared<BufferStorage<AllocatorT, access::mode::read_write,
+                                     access::target::host_buffer>>(Buf);
 
   if (0 == m_BuffersEvolution.count(BufStor)) {
     return;

--- a/sycl/include/CL/sycl/detail/scheduler/scheduler.h
+++ b/sycl/include/CL/sycl/detail/scheduler/scheduler.h
@@ -49,9 +49,8 @@ public:
         m_NextOCLIndex(RHS.m_NextOCLIndex) {}
 
   // Adds a buffer requirement for this node.
-  template <access::mode Mode, access::target Target, typename T,
-            int Dimensions, typename AllocatorT>
-  void addBufRequirement(detail::buffer_impl<T, Dimensions, AllocatorT> &Buf);
+  template <access::mode Mode, access::target Target, typename AllocatorT>
+  void addBufRequirement(detail::buffer_impl<AllocatorT> &Buf);
 
   // Adds an accessor requirement for this node.
   template <typename dataT, int dimensions, access::mode accessMode,
@@ -134,15 +133,12 @@ private:
 class Scheduler {
 public:
   // Adds copying of the specified buffer_impl and waits for completion.
-  template <access::mode Mode, access::target Target, typename T,
-            int Dimensions, typename AllocatorT>
-  void copyBack(detail::buffer_impl<T, Dimensions, AllocatorT> &Buf);
+  template <access::mode Mode, access::target Target, typename AllocatorT>
+  void copyBack(detail::buffer_impl<AllocatorT> &Buf);
 
   // Updates host data of the specified buffer_impl
-  template <access::mode Mode, access::target Target, typename T,
-            int Dimensions, typename AllocatorT>
-  void updateHost(detail::buffer_impl<T, Dimensions, AllocatorT> &Buf,
-                  cl::sycl::event &Event);
+  template <access::mode Mode, access::target Target, typename AllocatorT>
+  void updateHost(detail::buffer_impl<AllocatorT> &Buf, cl::sycl::event &Event);
 
   // Updates host data of the specified accessor
   template <typename T, int Dimensions, access::mode mode, access::target tgt,
@@ -151,8 +147,8 @@ public:
                   cl::sycl::event &Event);
 
   // Frees the specified buffer_impl.
-  template <typename T, int Dimensions, typename AllocatorT>
-  void removeBuffer(detail::buffer_impl<T, Dimensions, AllocatorT> &Buf);
+  template <typename AllocatorT>
+  void removeBuffer(detail::buffer_impl<AllocatorT> &Buf);
 
   // Waits for the event passed.
   void waitForEvent(EventImplPtr Event);

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -100,7 +100,7 @@ template <typename dataT, int dimensions, access::mode accessMode,
           typename voidT>
 class accessor_impl;
 
-template <typename T, int dimensions, typename AllocatorT> class buffer_impl;
+template <typename AllocatorT> class buffer_impl;
 // Type inference of first arg from a lambda
 // auto fun = [&](item a) { a; };
 // lambda_arg_type<decltype(fun)> value; # value type is item
@@ -144,8 +144,7 @@ class handler {
             typename voidT>
   friend class detail::accessor_impl;
 
-  template <typename T, int dimensions, typename AllocatorT>
-  friend class detail::buffer_impl;
+  template <typename AllocatorT> friend class detail::buffer_impl;
 
   friend class detail::queue_impl;
 
@@ -172,9 +171,8 @@ protected:
 
   bool is_host() { return isHost; }
 
-  template <access::mode mode, access::target target, typename T,
-            int dimensions, typename AllocatorT>
-  void AddBufDep(detail::buffer_impl<T, dimensions, AllocatorT> &Buf) {
+  template <access::mode mode, access::target target, typename AllocatorT>
+  void AddBufDep(detail::buffer_impl<AllocatorT> &Buf) {
     m_Node.addBufRequirement<mode, target>(Buf);
   }
 
@@ -577,7 +575,7 @@ public:
         getAccessorRangeHelper<T_src, dim, mode, tgt,
                                isPlaceholder>::getAccessorRange(src);
     // TODO use buffer_allocator when it is possible
-    buffer<T_src, dim, std::allocator<T_src>> Buffer(
+    buffer<T_src, dim, std::allocator<char>> Buffer(
         (shared_ptr_class<T_src>)dest, Range,
         {property::buffer::use_host_ptr()});
     accessor<T_src, dim, access::mode::write, access::target::global_buffer,
@@ -598,7 +596,7 @@ public:
         getAccessorRangeHelper<T_dest, dim, mode, tgt,
                                isPlaceholder>::getAccessorRange(dest);
     // TODO use buffer_allocator when it is possible
-    buffer<T_dest, dim, std::allocator<T_dest>> Buffer(
+    buffer<T_dest, dim, std::allocator<char>> Buffer(
         (shared_ptr_class<T_dest>)src, Range,
         {property::buffer::use_host_ptr()});
     accessor<T_dest, dim, access::mode::read, access::target::global_buffer,
@@ -618,7 +616,7 @@ public:
         getAccessorRangeHelper<T_src, dim, mode, tgt,
                                isPlaceholder>::getAccessorRange(src);
     // TODO use buffer_allocator when it is possible
-    buffer<T_src, dim, std::allocator<T_src>> Buffer(
+    buffer<T_src, dim, std::allocator<char>> Buffer(
         (T_src *)dest, Range, {property::buffer::use_host_ptr()});
     accessor<T_src, dim, access::mode::write, access::target::global_buffer,
              access::placeholder::false_t>
@@ -637,7 +635,7 @@ public:
         getAccessorRangeHelper<T_dest, dim, mode, tgt,
                                isPlaceholder>::getAccessorRange(dest);
     // TODO use buffer_allocator when it is possible
-    buffer<T_dest, dim, std::allocator<T_dest>> Buffer(
+    buffer<T_dest, dim, std::allocator<char>> Buffer(
         (T_dest *)src, Range, {property::buffer::use_host_ptr()});
     accessor<T_dest, dim, access::mode::read, access::target::global_buffer,
              access::placeholder::false_t>

--- a/sycl/test/basic_tests/buffer/reinterpret.cpp
+++ b/sycl/test/basic_tests/buffer/reinterpret.cpp
@@ -1,0 +1,83 @@
+// RUN: %clang -std=c++11 -fsycl %s -o %t.out -lstdc++ -lOpenCL -lsycl
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+//==---------- reinterpret.cpp --- SYCL buffer reinterpret basic test ------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+// This tests verifies basic cases of using cl::sycl::buffer::reinterpret
+// functionality - changing buffer type and range. This test checks that
+// original buffer updates when we write to reinterpreted buffer and also checks
+// that we can't create reinterpreted buffer when total size in bytes will be
+// not same as total size in bytes of original buffer.
+
+int main() {
+
+  bool failed = false;
+  cl::sycl::queue q;
+
+  cl::sycl::range<1> r1(1);
+  cl::sycl::range<1> r2(sizeof(unsigned int) / sizeof(unsigned char));
+  cl::sycl::buffer<unsigned int, 1> buf_i(r1);
+  auto buf_char = buf_i.reinterpret<unsigned char>(r2);
+  q.submit([&](cl::sycl::handler &cgh) {
+    auto acc = buf_char.get_access<cl::sycl::access::mode::read_write>(cgh);
+    cgh.parallel_for<class chars>(
+        r2, [=](cl::sycl::id<1> i) { acc[i] = UCHAR_MAX; });
+  });
+
+  {
+    auto acc = buf_i.get_access<cl::sycl::access::mode::read>();
+    if (acc[0] != UINT_MAX) {
+      std::cout << acc[0] << std::endl;
+      std::cout << "line: " << __LINE__ << " array[" << 0 << "] is " << acc[0]
+                << " expected " << UINT_MAX << std::endl;
+      failed = true;
+    }
+  }
+
+  cl::sycl::range<1> r1d(9);
+  cl::sycl::range<2> r2d(3, 3);
+  cl::sycl::buffer<unsigned int, 1> buf_1d(r1d);
+  auto buf_2d = buf_1d.reinterpret<unsigned int>(r2d);
+  q.submit([&](cl::sycl::handler &cgh) {
+    auto acc2d = buf_2d.get_access<cl::sycl::access::mode::read_write>(cgh);
+    cgh.parallel_for<class ones>(r2d, [=](cl::sycl::item<2> itemID) {
+      size_t i = itemID.get_id(0);
+      size_t j = itemID.get_id(1);
+      if (i == j)
+        acc2d[i][j] = 1;
+      else
+        acc2d[i][j] = 0;
+    });
+  });
+
+  {
+    auto acc = buf_1d.get_access<cl::sycl::access::mode::read>();
+    for (auto i = 0u; i < r1d.size(); i++) {
+      size_t expected = (i % 4) ? 0 : 1;
+      if (acc[i] != expected) {
+        std::cout << "line: " << __LINE__ << " array[" << i << "] is " << acc[i]
+                  << " expected " << expected << std::endl;
+        failed = true;
+      }
+    }
+  }
+
+  try {
+    cl::sycl::buffer<float, 1> buf_fl(r1d);
+    auto buf_d = buf_1d.reinterpret<double>(r2d);
+  } catch (cl::sycl::invalid_object_error e) {
+    std::cout << "Expected exception has been caught: " << e.what()
+              << std::endl;
+  }
+
+  return failed;
+}


### PR DESCRIPTION
Main changes (required to implement this method):
Removed template parameters T and dimensions from buffer_impl class.
Added buffer range to accessor. Currently it done to save handler::copy
functionality but it also need to be used in multidimensional access.
Moved range from buffer_impl to buffer.
Used buffer_allocator as default allocator in buffer.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>