### PR TITLE
[SYCL] Fix linking with renamed OpenCL library.

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -32,7 +32,7 @@ set ( LLVM_INST_INC_DIRECTORY "lib${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION}/i
 find_package(OpenCL REQUIRED)
 
 include_directories(${OpenCL_INCLUDE_DIRS})
-link_libraries(OpenCL)
+link_libraries(${OpenCL_LIBRARY})
 
 # Configure SYCL version macro
 set(sycl_inc_dir ${CMAKE_CURRENT_SOURCE_DIR}/include/CL)
@@ -103,7 +103,6 @@ add_library("${SYCLLibrary}" SHARED
 
 include_directories("${SYCLLibrary}" "${includeRootPath}")
 
-target_link_libraries("${SYCLLibrary}" "${OpenCL_LIBRARIES}")
 set_target_properties("${SYCLLibrary}" PROPERTIES LINKER_LANGUAGE CXX)
 
 # Workaround for bug in GCC version 5.

--- a/sycl/tools/CMakeLists.txt
+++ b/sycl/tools/CMakeLists.txt
@@ -2,13 +2,6 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(OpenCL REQUIRED)
-
-# All projects need this include directory
-include_directories(${OpenCL_INCLUDE_DIRS})
-
-link_libraries(OpenCL)
-
 add_executable(get_device_count_by_type get_device_count_by_type.cpp)
 
 #Minimum supported version of Intel's OCL GPU and CPU devices


### PR DESCRIPTION
This change allows configuring OpenCL library name via OpenCL_LIBRARY
CMake variable.

Closes #6.