### PR TITLE
Altering SemaSYCL header gen for wider range of kernel names

### DIFF
--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -10,12 +10,17 @@
 // CHECK-NEXT: struct X;
 // CHECK-NEXT: template <typename T> struct point;
 // CHECK-NEXT: template <int a, typename T1, typename T2> class third_kernel;
+// CHECK-NEXT: namespace template_arg_ns {
+// CHECK-NEXT: template <int DimX> struct namespaced_arg;
+// CHECK-NEXT: }
+// CHECK-NEXT: template <typename ...Ts> class fourth_kernel;
 //
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
 // CHECK-NEXT:   "_ZTSZ4mainE12first_kernel",
 // CHECK-NEXT:   "_ZTSN16second_namespace13second_kernelIcEE",
 // CHECK-NEXT:   "_ZTS12third_kernelILi1Ei5pointIZ4mainE1XEE"
+// CHECK-NEXT:   "_ZTS13fourth_kernelIJN15template_arg_ns14namespaced_argILi1EEEEE"
 // CHECK-NEXT: };
 //
 // CHECK: static constexpr
@@ -41,12 +46,19 @@
 // CHECK-NEXT:   { kernel_param_kind_t::kind_std_layout, 1, 4 },
 // CHECK-NEXT:   { kernel_param_kind_t::kind_std_layout, 1, 5 },
 // CHECK-EMPTY:
+// CHECK-NEXT:   //--- _ZTS13fourth_kernelIJN15template_arg_ns14namespaced_argILi1EEEEE
+// CHECK-NEXT:   { kernel_param_kind_t::kind_std_layout, 4, 0 },
+// CHECK-NEXT:   { kernel_param_kind_t::kind_accessor, 2016, 4 },
+// CHECK-NEXT:   { kernel_param_kind_t::kind_std_layout, 1, 4 },
+// CHECK-NEXT:   { kernel_param_kind_t::kind_std_layout, 1, 5 },
+// CHECK-EMPTY:
 // CHECK-NEXT: };
 //
 // CHECK: template <class KernelNameType> struct KernelInfo;
-// CHECK: template <> struct KernelInfo<class first_kernel> {
-// CHECK: template <> struct KernelInfo<::second_namespace::second_kernel<char>> {
-// CHECK: template <> struct KernelInfo<::third_kernel<1, int, ::point<X> >> {
+// CHECK: template <> struct KernelInfo<first_kernel> {
+// CHECK: template <> struct KernelInfo<second_namespace::second_kernel<char>> {
+// CHECK: template <> struct KernelInfo<third_kernel<1, int, point<X> >> {
+// CHECK: template <> struct KernelInfo<fourth_kernel<template_arg_ns::namespaced_arg<1> >> {
 
 namespace cl {
 namespace sycl {
@@ -124,6 +136,14 @@ class second_kernel;
 template <int a, typename T1, typename T2>
 class third_kernel;
 
+namespace template_arg_ns {
+  template <int DimX>
+  struct namespaced_arg {};
+}
+
+template <typename ...Ts>
+class fourth_kernel;
+
 int main() {
 
   cl::sycl::accessor<char, 1, cl::sycl::access::mode::read> acc1;
@@ -153,6 +173,11 @@ int main() {
     }
   });
   kernel_single_task<class third_kernel<1, int,point<struct X>>>([=]() {
+    if (i == 13) {
+      acc2.use();
+    }
+  });
+  kernel_single_task<class fourth_kernel<template_arg_ns::namespaced_arg<1>>>([=]() {
     if (i == 13) {
       acc2.use();
     }

--- a/clang/test/CodeGenSYCL/kernel_functor.cpp
+++ b/clang/test/CodeGenSYCL/kernel_functor.cpp
@@ -168,7 +168,7 @@ int main() {
   cl::sycl::detail::KernelInfo<Functor1>::getName();
   // CHECK: Functor1
   cl::sycl::detail::KernelInfo<ns::Functor2>::getName();
-  // CHECK: ::ns::Functor2
+  // CHECK: ns::Functor2
   cl::sycl::detail::KernelInfo<TmplFunctor<int>>::getName();
   // CHECK: TmplFunctor<int>
   cl::sycl::detail::KernelInfo<TmplConstFunctor<int>>::getName();

--- a/sycl/test/regression/kernel_name_class.cpp
+++ b/sycl/test/regression/kernel_name_class.cpp
@@ -21,6 +21,8 @@ namespace nm1 {
 namespace nm2 {
 class C {};
 class KernelName0 : public C {};
+
+template <int X> class KernelName11 {};
 } // namespace nm2
 
 class KernelName1;
@@ -34,7 +36,11 @@ template <> class KernelName3<KernelName1>;
 template <> class KernelName4<nm1::nm2::KernelName0> {};
 template <> class KernelName4<KernelName1> {};
 
+template <typename... Ts> class KernelName10;
+
 } // namespace nm1
+
+template <typename... Ts> class KernelName12;
 
 static int NumTestCases = 0;
 
@@ -233,6 +239,19 @@ struct Wrapper {
       });
       ++NumTestCases;
 #endif
+
+      deviceQueue.submit([&](cl::sycl::handler &cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.single_task<nm1::KernelName10<nm1::nm2::KernelName11<10>>>([=]() { acc[0] += GOLD; });
+      });
+      ++NumTestCases;
+
+      deviceQueue.submit([&](cl::sycl::handler &cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.single_task<KernelName12<nm1::nm2::KernelName11<10>>>([=]() { acc[0] += GOLD; });
+      });
+      ++NumTestCases;
+
     }
     return arr[0];
   }


### PR DESCRIPTION
The goal of this patch was to allow kernel names of the type:

Example 1:

// kernel name components
namespace nm1 {
  namespace nm2 {
    template <int X> class K0 {};
  }
  template <typename... Ts> class K1;
}

// The type to be the kernel name
nm1::K1<nm1::nm2::K0<2>>

Example 2:

// kernel name components
nm {
  template <int X> class K0 {};
}
template <typename... Ts> class K1;

// The type to be the kernel name
K1<nm::K0<2>>

To do this I altered SemaSYCL.cpp to no longer use 
TypeName::getFullyQualifiedType when assigning QualType KernelNameType 
and instead just use the qualified type that is retrieved from the 
TemplateArgs itself. This seems to work. Passing all previous tests and 
failing the previous tests that it was failing before, whilst passing 
the two new additional cases I looked at. I may be missing some context 
as to why getFullyQualifiedType was used previously (it seems less 
qualified than the actual return from getAsType, missing namespace 
qualifiers on template arguments) and why there was a reliance on the :: 
global scope resolution operator i.e. ::type. So perhaps I am missing 
some information like an important use case or implementation detail 
that may make this an invalid change.

I also added another string alteration function that runs over the 
qualified name and removes class/struct where relevant in the 
specialization. This isn't needed for the newly tested way of naming a 
kernel, but the generated header seems a little more correct in the 
sense that the header specializations are no longer redefining the 
class/struct inline on the specialization and are instead reusing the 
definitions at the top of the integration header.

I made modifcations to the integration_header.cpp, kernel_functor.cpp 
and kernel_name_class.cpp. I changed integration_header.cpp and 
kernel_functor.cpp checks to test for the new/changed output of the 
integration header generation. I added new test cases to 
integration_header.cpp and kernel_name_class.cpp that reflect the test 
cases this SemaSYCL.cpp modification aims to fix.

Signed-off-by: Andrew Gozillon <andrew.gozillon@yahoo.com>