### PR TITLE
[SYCL] Remove accuracy test for native implementation of math function.

### DIFF
--- a/sycl/test/built-ins/vector_math.cpp
+++ b/sycl/test/built-ins/vector_math.cpp
@@ -33,26 +33,6 @@ int main() {
     assert(r2 == 0.4f);
   }
 
-  // native::exp
-  {
-    cl::sycl::cl_float2 r{0};
-    {
-      buffer<cl::sycl::cl_float2, 1> BufR(&r, range<1>(1));
-      queue myQueue;
-      myQueue.submit([&](handler &cgh) {
-        auto AccR = BufR.get_access<access::mode::write>(cgh);
-        cgh.single_task<class nexpF2>([=]() {
-          AccR[0] = cl::sycl::native::exp(cl::sycl::cl_float2{1.0f, 2.0f});
-        });
-      });
-    }
-    cl::sycl::cl_float r1 = r.x();
-    cl::sycl::cl_float r2 = r.y();
-    std::cout << "r1 " << r1 << " r2 " << r2 << std::endl;
-    assert(r1 > 2.718 && r1 < 2.719); // ~2.718281828459045
-    assert(r2 > 7.389 && r2 < 7.390); // ~7.38905609893065
-  }
-
   // fabs
   {
     cl::sycl::cl_float2 r{0};


### PR DESCRIPTION
Native implementation doesn't provide any accuracy guarantees, so
checking return value is not portable.
This test fails on the system with GCC 7.3 (default GCC on Ubuntu 18.04).

Signed-off-by: Alexey Bader <alexey.bader@intel.com>