### PR TITLE
[SYCL] Fixing device check in program link constructor

### DIFF
--- a/sycl/include/CL/sycl/detail/device_host.hpp
+++ b/sycl/include/CL/sycl/detail/device_host.hpp
@@ -24,6 +24,9 @@ public:
   cl_device_id get() const override {
     throw invalid_object_error("This instance of device is a host instance");
   }
+  cl_device_id &getHandleRef() override {
+    throw invalid_object_error("This instance of device is a host instance");
+  }
 
   bool is_host() const override { return true; }
 

--- a/sycl/include/CL/sycl/detail/device_impl.hpp
+++ b/sycl/include/CL/sycl/detail/device_impl.hpp
@@ -29,6 +29,12 @@ public:
 
   virtual cl_device_id get() const = 0;
 
+  // Returns underlying native device object (if any) w/o reference count
+  // modification. Caller must ensure the returned object lives on stack only.
+  // It can also be safely passed to the underlying native runtime API.
+  // Warning. Returned reference will be invalid if device_impl was destroyed.
+  virtual cl_device_id &getHandleRef() = 0;
+
   virtual bool is_host() const = 0;
 
   virtual bool is_cpu() const = 0;

--- a/sycl/include/CL/sycl/detail/device_opencl.hpp
+++ b/sycl/include/CL/sycl/detail/device_opencl.hpp
@@ -57,6 +57,10 @@ public:
     return id;
   }
 
+  cl_device_id &getHandleRef() override{
+    return id;
+  }
+
   bool is_host() const override { return false; }
 
   bool is_cpu() const override { return (type == CL_DEVICE_TYPE_CPU); }


### PR DESCRIPTION
This patch gets sycl devices via context in program
interoperability constructor and
sorts devices in program link constructor to check that
all the programs in the list use the same devices

Signed-off-by: Sindhu Chittireddy <sindhu.chittireddy@intel.com>