### PR TITLE
[SYCL] Support the cases when accessor is wrapped to some class

### DIFF
--- a/clang/test/CodeGenSYCL/wrapped-accessor.cpp
+++ b/clang/test/CodeGenSYCL/wrapped-accessor.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o %T/kernel.spv
+// RUN: FileCheck -input-file=%t.h %s
+//
+// CHECK: #include <CL/sycl/detail/kernel_desc.hpp>
+
+// CHECK: class wrapped_access;
+
+// CHECK: namespace cl {
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+
+// CHECK: static constexpr
+// CHECK-NEXT: const char* const kernel_names[] = {
+// CHECK-NEXT:   "_ZTSZ4mainE14wrapped_access"
+// CHECK-NEXT: };
+
+// CHECK: static constexpr
+// CHECK-NEXT: const kernel_param_desc_t kernel_signatures[] = {
+// CHECK-NEXT: //--- _ZTSZ4mainE14wrapped_access
+// CHECK-NEXT:   { kernel_param_kind_t::kind_std_layout, 3, 0 },
+// CHECK-NEXT:   { kernel_param_kind_t::kind_accessor, 4062, 0 },
+// CHECK-EMPTY:
+// CHECK-NEXT: };
+
+// CHECK: static constexpr
+// CHECK-NEXT: const unsigned kernel_signature_start[] = {
+// CHECK-NEXT:  0 // _ZTSZ4mainE14wrapped_access
+// CHECK-NEXT: };
+
+// CHECK: template <class KernelNameType> struct KernelInfo;
+
+// CHECK: template <> struct KernelInfo<class wrapped_access> {
+
+#include <sycl.hpp>
+
+template <typename Acc>
+struct AccWrapper { Acc accessor; };
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write> acc;
+  auto acc_wrapped = AccWrapper<decltype(acc)>{acc};
+  kernel<class wrapped_access>(
+      [=]() {
+        acc_wrapped.accessor.use();
+      });
+}

--- a/clang/test/SemaSYCL/wrapped-accessor.cpp
+++ b/clang/test/SemaSYCL/wrapped-accessor.cpp
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -I %S/Inputs -fsycl-is-device -ast-dump %s | FileCheck %s
+
+#include <sycl.hpp>
+
+template <typename Acc>
+struct AccWrapper { Acc accessor; };
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write> acc;
+  auto acc_wrapped = AccWrapper<decltype(acc)>{acc};
+  kernel<class wrapped_access>(
+      [=]() {
+        acc_wrapped.accessor.use();
+      });
+}
+
+// Check declaration of the kernel
+// CHECK: wrapped_access 'void (AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >, __global int *, range<1>, range<1>, id<1>)'
+
+// Check parameters of the kernel
+// CHECK: ParmVarDecl {{.*}} used _arg_ 'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >':'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >'
+// CHECK: ParmVarDecl {{.*}} used _arg_accessor '__global int *'
+// CHECK: ParmVarDecl {{.*}} used _arg_AccessRange 'range<1>':'cl::sycl::range<1>'
+// CHECK: ParmVarDecl {{.*}} used _arg_MemRange 'range<1>':'cl::sycl::range<1>'
+// CHECK: ParmVarDecl {{.*}} used _arg_Offset 'id<1>':'cl::sycl::id<1>'
+
+// Check that wrapper object itself is initialized with corresponding kernel argument using operator=
+// CHECK: BinaryOperator {{.*}} 'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >':'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >' lvalue '='
+
+// Left operand is the field of the kernel object
+// CHECK-NEXT: MemberExpr {{.*}} 'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >':'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >' lvalue . {{.*}}
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}wrapped-accessor.cpp:17:7)' lvalue Var {{.*}} '(lambda at {{.*}}wrapped-accessor.cpp:17:7)'
+
+// Right operand is the kernel argument
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >':'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >' <LValueToRValue>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >':'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >' lvalue ParmVar {{.*}} '_arg_' 'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >':'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >'
+
+// Check that accessor field of the wrapper object is initialized using __init method
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (__global int *, range<1>, range<1>, id<1>)' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t>':'cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t>' lvalue .accessor {{.*}}
+// CHECK-NEXT: MemberExpr {{.*}} 'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >':'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}wrapped-accessor.cpp:17:7)' lvalue Var {{.*}} '(lambda at {{.*}}wrapped-accessor.cpp:17:7)'
+
+// Parameters of the _init method
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_accessor' '__global int *'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'range<1>':'cl::sycl::range<1>' <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'range<1>':'cl::sycl::range<1>' lvalue ParmVar {{.*}} '_arg_AccessRange' 'range<1>':'cl::sycl::range<1>'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'range<1>':'cl::sycl::range<1>' <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'range<1>':'cl::sycl::range<1>' lvalue ParmVar {{.*}} '_arg_MemRange' 'range<1>':'cl::sycl::range<1>'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'id<1>':'cl::sycl::id<1>' <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'id<1>':'cl::sycl::id<1>' lvalue ParmVar {{.*}} '_arg_Offset' 'id<1>':'cl::sycl::id<1>'

--- a/sycl/test/basic_tests/accessor/accessor.cpp
+++ b/sycl/test/basic_tests/accessor/accessor.cpp
@@ -40,6 +40,27 @@ struct IdxSzT {
   operator size_t() { return x; }
 };
 
+template <typename Acc> struct AccWrapper { Acc accessor; };
+
+template <typename Acc1, typename Acc2> struct AccsWrapper {
+  int a;
+  Acc1 accessor1;
+  int b;
+  Acc2 accessor2;
+};
+
+struct Wrapper1 {
+  int a;
+  int b;
+};
+
+template <typename Acc> struct Wrapper2 {
+  Wrapper1 w1;
+  AccWrapper<Acc> wrapped;
+};
+
+template <typename Acc> struct Wrapper3 { Wrapper2<Acc> w2; };
+
 int main() {
   // Host accessor.
   {
@@ -218,6 +239,96 @@ int main() {
     } catch (cl::sycl::exception e) {
       std::cout << "SYCL exception caught: " << e.what();
       return 1;
+    }
+  }
+
+  // Check that accessor is initialized when accessor is wrapped to some class.
+  {
+    sycl::queue queue;
+    if (!queue.is_host()) {
+      int array[10] = {0};
+      {
+        sycl::buffer<int, 1> buf((int *)array, sycl::range<1>(10),
+                                 {cl::sycl::property::buffer::use_host_ptr()});
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+          auto acc_wrapped = AccWrapper<decltype(acc)>{acc};
+          cgh.parallel_for<class wrapped_access1>(
+              sycl::range<1>(buf.get_count()), [=](sycl::item<1> it) {
+                auto idx = it.get_linear_id();
+                acc_wrapped.accessor[idx] = 333;
+              });
+        });
+        queue.wait();
+      }
+      for (int i = 0; i < 10; i++) {
+        std::cout << "array[" << i << "]=" << array[i] << std::endl;
+        assert(array[i] == 333);
+      }
+    }
+  }
+
+  // Case when several accessors are wrapped to some class. Check that they are
+  // initialized in proper way and value is assigned.
+  {
+    sycl::queue queue;
+    if (!queue.is_host()) {
+      int array1[10] = {0};
+      int array2[10] = {0};
+      {
+        sycl::buffer<int, 1> buf1((int *)array1, sycl::range<1>(10),
+                                  {cl::sycl::property::buffer::use_host_ptr()});
+        sycl::buffer<int, 1> buf2((int *)array2, sycl::range<1>(10),
+                                  {cl::sycl::property::buffer::use_host_ptr()});
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc1 = buf1.get_access<sycl::access::mode::read_write>(cgh);
+          auto acc2 = buf2.get_access<sycl::access::mode::read_write>(cgh);
+          auto acc_wrapped =
+              AccsWrapper<decltype(acc1), decltype(acc2)>{10, acc1, 5, acc2};
+          cgh.parallel_for<class wrapped_access2>(
+              sycl::range<1>(10), [=](sycl::item<1> it) {
+                auto idx = it.get_linear_id();
+                acc_wrapped.accessor1[idx] = 333;
+                acc_wrapped.accessor2[idx] = 666;
+              });
+        });
+        queue.wait();
+      }
+      for (int i = 0; i < 10; i++) {
+        std::cout << "array1[" << i << "]=" << array1[i] << std::endl;
+        std::cout << "array2[" << i << "]=" << array2[i] << std::endl;
+        assert(array1[i] == 333);
+        assert(array2[i] == 666);
+      }
+    }
+  }
+
+  // Several levels of wrappers for accessor.
+  {
+    sycl::queue queue;
+    if (!queue.is_host()) {
+      int array[10] = {0};
+      {
+        sycl::buffer<int, 1> buf((int *)array, sycl::range<1>(10),
+                                 {cl::sycl::property::buffer::use_host_ptr()});
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+          auto acc_wrapped = AccWrapper<decltype(acc)>{acc};
+          Wrapper1 wr1;
+          auto wr2 = Wrapper2<decltype(acc)>{wr1, acc_wrapped};
+          auto wr3 = Wrapper3<decltype(acc)>{wr2};
+          cgh.parallel_for<class wrapped_access3>(
+              sycl::range<1>(buf.get_count()), [=](sycl::item<1> it) {
+                auto idx = it.get_linear_id();
+                wr3.w2.wrapped.accessor[idx] = 333;
+              });
+        });
+        queue.wait();
+      }
+      for (int i = 0; i < 10; i++) {
+        std::cout << "array[" << i << "]=" << array[i] << std::endl;
+        assert(array[i] == 333);
+      }
     }
   }
 }


### PR DESCRIPTION
Current implementation supports only the cases when captured accessor
is a top level object. But accessors could be wrapped to some classes.
Frontend should properly handle this case and intialize accessors using
appropriate kernel parameters.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>