### PR TITLE
[SYCL] Optimize build

### DIFF
--- a/buildbot/compile.sh
+++ b/buildbot/compile.sh
@@ -26,4 +26,4 @@ done && shift $(($OPTIND - 1))
 # we're in llvm.obj dir
 BUILD_DIR=${PWD}
 
-make -j`nproc`
+make -j`nproc` sycl-toolchain

--- a/buildbot/configure.sh
+++ b/buildbot/configure.sh
@@ -32,6 +32,7 @@ CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang \
     -DLLVM_TOOL_SYCL_BUILD=ON -DLLVM_TOOL_LLVM_SPIRV_BUILD=ON \
     -DOpenCL_INCLUDE_DIR=OpenCL-Headers \
     -DOpenCL_LIBRARY=OpenCL-ICD-Loader/build/lib/libOpenCL.so \
+    -DLLVM_BUILD_TOOLS=OFF \
     ../llvm.src/llvm"
 
 cmake ${CMAKE_ARGS}

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -27,30 +27,78 @@ endif()
 # Unlike PACKAGE_VERSION, CLANG_VERSION does not include LLVM_VERSION_SUFFIX.
 set(CLANG_VERSION "${CLANG_VERSION_MAJOR}.${CLANG_VERSION_MINOR}.${CLANG_VERSION_PATCHLEVEL}")
 
-set ( LLVM_INST_INC_DIRECTORY "lib${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION}/include" )
+set(LLVM_INST_INC_DIRECTORY "lib${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION}/include")
+set(dst_dir ${LLVM_LIBRARY_OUTPUT_INTDIR}/clang/${CLANG_VERSION}/include)
 
-find_package(OpenCL REQUIRED)
+find_package(OpenCL)
 
-include_directories(${OpenCL_INCLUDE_DIRS})
-link_libraries(${OpenCL_LIBRARY})
+include(ExternalProject)
+
+if( NOT OpenCL_INCLUDE_DIRS )
+  message ("OpenCL_INCLUDE_DIRS is missed. Try to download headers from github.com")
+  set(OpenCL_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/OpenCL/inc")
+  ExternalProject_Add(ocl-headers
+    GIT_REPOSITORY    https://github.com/KhronosGroup/OpenCL-Headers.git
+    GIT_TAG           origin/master
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/OpenCL/inc"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ${CMAKE_COMMAND} -E copy_directory ${OpenCL_INCLUDE_DIRS}/CL ${dst_dir}/CL}
+    INSTALL_COMMAND   ""
+    STEP_TARGETS      build
+    COMMENT           "Downloading OpenCL headers."
+  )
+else()
+  message("OpenCL header have been found under ${OpenCL_INCLUDE_DIRS}.")
+  add_custom_target( ocl-headers ALL
+    DEPENDS ${OpenCL_INCLUDE_DIRS}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${OpenCL_INCLUDE_DIRS}/CL ${dst_dir}/CL
+    COMMENT "Copying OpenCL headers ..."
+  )
+endif()
+
+if( NOT OpenCL_LIBRARIES )
+  message("OpenCL_LIBRARIES is missed. Try to build from GitHub sources.")
+  set(OpenCL_LIBRARIES "${LLVM_LIBRARY_OUTPUT_INTDIR}/libOpenCL.so")
+  ExternalProject_Add(ocl-icd
+    GIT_REPOSITORY    https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
+    GIT_TAG           origin/master
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/OpenCL/icd"
+    CONFIGURE_COMMAND ""
+    BUILD_IN_SOURCE   TRUE
+    BUILD_COMMAND     make C_INCLUDE_PATH=${CMAKE_CURRENT_BINARY_DIR}/OpenCL/inc
+    INSTALL_COMMAND   ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/OpenCL/icd/build/lib ${LLVM_LIBRARY_OUTPUT_INTDIR}
+    STEP_TARGETS      build,install
+    DEPENDS           ocl-headers
+  )
+else()
+  message("OpenCL loader has been found: ${OpenCL_LIBRARIES}.")
+  add_custom_target(ocl-icd
+    ${CMAKE_COMMAND} -E copy ${OpenCL_LIBRARIES}* ${LLVM_LIBRARY_OUTPUT_INTDIR}
+    COMMENT "Copying OpenCL ICD Loader ..."
+  )
+endif()
+
+set(SYCL_INCLUDE "${CMAKE_CURRENT_BINARY_DIR}/include/")
+set(OPENCL_INCLUDE "${OpenCL_INCLUDE_DIRS}")
 
 # Configure SYCL version macro
-set(sycl_inc_dir ${CMAKE_CURRENT_SOURCE_DIR}/include/CL)
+set(sycl_inc_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
 string(TIMESTAMP __SYCL_COMPILER_VERSION "%Y%m%d")
-set(version_header "${sycl_inc_dir}/sycl/version.hpp")
+set(version_header "${sycl_inc_dir}/CL/sycl/version.hpp")
 configure_file("${version_header}.in" "${version_header}")
 
 # Copy SYCL headers
-set(sycl_inc_dir ${CMAKE_CURRENT_SOURCE_DIR}/include/CL)
-set(dst_dir ${LLVM_LIBRARY_OUTPUT_INTDIR}/clang/${CLANG_VERSION}/include/CL)
 add_custom_target(sycl-headers ALL
-COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir} ${dst_dir}
+COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir}/CL ${dst_dir}/CL
 COMMENT "Copying SYCL headers ...")
 
 # Main library
 
 set(sourceRootPath "${CMAKE_CURRENT_SOURCE_DIR}/source")
 set(includeRootPath "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+include_directories(AFTER "${includeRootPath}" "${OpenCL_INCLUDE_DIRS}")
+link_libraries(${OpenCL_LIBRARIES})
 
 set(SYCLLibrary sycl)
 
@@ -67,9 +115,6 @@ set(SYCL_TESTS_BINARY_DIR ${SYCL_BINARY_DIR}/test)
 set(CLANG_IN_BUILD "${LLVM_BINARY_DIR}/bin/clang")
 
 set(LLVM_TOOLS_DIR "${LLVM_BINARY_DIR}/bin/")
-
-set(SYCL_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/include/")
-set(OPENCL_INCLUDE "${OpenCL_INCLUDE_DIRS}")
 
 add_library("${SYCLLibrary}" SHARED
   "${includeRootPath}/CL/sycl.hpp"
@@ -106,7 +151,25 @@ add_library("${SYCLLibrary}" SHARED
   "${sourceRootPath}/spirv_ops.cpp"
 )
 
-include_directories("${SYCLLibrary}" "${includeRootPath}")
+add_dependencies("${SYCLLibrary}"
+  ocl-icd
+  ocl-headers
+  sycl-headers
+)
+
+add_custom_target( sycl-toolchain
+  DEPENDS "${SYCLLibrary}"
+          clang
+          clang-offload-wrapper
+          clang-offload-bundler
+          llc
+          llvm-as
+          llvm-dis
+          llvm-spirv
+          llvm-link
+          opt
+  COMMENT "Building SYCL compiler toolchain..."
+)
 
 set_target_properties("${SYCLLibrary}" PROPERTIES LINKER_LANGUAGE CXX)
 
@@ -119,40 +182,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
 endif()
 
 install(TARGETS "${SYCLLibrary}" DESTINATION "lib" COMPONENT ${SYCLLibrary})
-install(DIRECTORY "${includeRootPath}/." DESTINATION "${LLVM_INST_INC_DIRECTORY}" COMPONENT sycl_headers)
+install(DIRECTORY "${includeRootPath}/." DESTINATION "${LLVM_INST_INC_DIRECTORY}" COMPONENT sycl-headers)
 
 add_subdirectory( test )
 add_subdirectory( tools )
-
-set(manifest_list)
-set( DEPLOY_LIST
-  sycl
-  ocl_lib
-  ocl_headers
-  sycl_headers
-  clang
-  clang-offload-wrapper
-  clang-offload-bundler
-  llc
-  llvm-as
-  llvm-dis
-  llvm-spirv
-  llvm-link
-  opt
-)
-
-foreach( comp ${DEPLOY_LIST} )
-
-  message( STATUS "Adding component ${comp} to deploy")
-
-  set (manifest ${CMAKE_CURRENT_BINARY_DIR}/install_manifest_${comp}.txt)
-  add_custom_command(OUTPUT ${manifest}
-                     COMMAND "${CMAKE_COMMAND}"
-                             "-DCMAKE_INSTALL_COMPONENT=${comp}"
-                             -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-                     COMMENT "Deploying component ${comp}"
-                     USES_TERMINAL)
-  list(APPEND manifest_list ${manifest})
-endforeach( comp )
-
-add_custom_target(deploy DEPENDS ${manifest_list})

--- a/sycl/doc/GetStartedWithSYCLCompiler.md
+++ b/sycl/doc/GetStartedWithSYCLCompiler.md
@@ -6,16 +6,7 @@ OpenCL&trade; API to offload computations to accelerators.
 
 # Before You Begin
 
-Software requirements:
-
-Installing OpenCL 2.1 compatible software stack:
-1. OpenCL headers:
-
-   a. Download the OpenCL headers from
-[github.com/KhronosGroup/OpenCL-Headers](https://github.com/KhronosGroup/OpenCL-Headers)
-to your local machine. e.g. `/usr/local/include/CL` with environment var
-`$OPENCL_HEADERS`.
-2. OpenCL runtime for CPU and GPU:
+OpenCL runtime for CPU and/or GPU:
 
    a. OpenCL runtime for GPU: follow instructions on
 [github.com/intel/compute-runtime/releases](https://github.com/intel/compute-runtime/releases)
@@ -26,7 +17,7 @@ Runtime for OpenCL. Applications 18.1 for Linux* OS (64bit only)" on
 [https://software.intel.com/en-us/articles/opencl-drivers#cpu-section](https://software.intel.com/en-us/articles/opencl-drivers#cpu-section)
 and click on orange "Download" button to download & install.
 
-# Build the SYCL compiler
+# Build the SYCL compiler and runtime
 
 Download the LLVM* repository with SYCL support to your local machine folder
 e.g. `$HOME/sycl` (assuming environment var `$SYCL_HOME`) folder using
@@ -36,23 +27,29 @@ following command:
 git clone https://github.com/intel/llvm -b sycl $HOME/sycl
 ```
 
-Follow regular LLVM build instructions under:
-[llvm.org/docs/CMake.html](https://llvm.org/docs/CMake.html). To build SYCL
-runtime use modified CMake command below:
+Build the SYCL compiler and runtime following instruction below:
 
 ```bash
 mkdir $SYCL_HOME/build
 cd $SYCL_HOME/build
-cmake -DCMAKE_BUILD_TYPE=Release -DOpenCL_INCLUDE_DIR=$OPENCL_HEADERS \
+cmake -DCMAKE_BUILD_TYPE=Release \
 -DLLVM_ENABLE_PROJECTS="clang" \
 -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=$SYCL_HOME/sycl \
 -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=$SYCL_HOME/llvm-spirv \
 -DLLVM_TOOL_SYCL_BUILD=ON -DLLVM_TOOL_LLVM_SPIRV_BUILD=ON $SYCL_HOME/llvm
-make -j`nproc` check-all
+make -j`nproc` sycl-toolchain
 ```
 
 After the build completed, the SYCL compiler/include/libraries can be found
 under `$SYCL_HOME/build` directory.
+
+# Test the SYCL compiler and runtime
+
+Run LIT testing using the command below after building SYCL compiler and runtime.
+
+```bash
+make -j`nproc` check-all
+```
 
 # Creating a simple SYCL program
 

--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -8,19 +8,9 @@ configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg
   )
 
-set(SYCL_TEST_DEPS
-  llvm-spirv
-  llvm-link
-  llc
-  clang
-  sycl-headers
-  get_device_count_by_type
-  FileCheck
-  ${SYCLLibrary}
-  )
 add_lit_testsuite(check-sycl "Running the SYCL regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   ARGS ${RT_TEST_ARGS}
-  DEPENDS ${SYCL_TEST_DEPS}
+  DEPENDS sycl-toolchain FileCheck get_device_count_by_type
   )
 set_target_properties(check-sycl PROPERTIES FOLDER "SYCL tests")

--- a/sycl/tools/CMakeLists.txt
+++ b/sycl/tools/CMakeLists.txt
@@ -3,10 +3,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(get_device_count_by_type get_device_count_by_type.cpp)
-
+add_dependencies(get_device_count_by_type ocl-headers ocl-icd)
 #Minimum supported version of Intel's OCL GPU and CPU devices
 add_definitions(-D MIN_INTEL_OCL_GPU_VERSION=\\"18.47.11882\\")
 add_definitions(-D MIN_INTEL_OCL_CPU_VERSION=\\"18.1.0.0901\\",\\"7.6.0.1202\\")
 
 add_executable(sycl-check sycl-check.cpp)
+add_dependencies(sycl-check sycl)
 target_link_libraries(sycl-check sycl)


### PR DESCRIPTION
 - Remove unused tools from the default build.
 - Use sycl target to build SYCL-related binaries.
 - Move dependencies (OpenCL ICD loader and headers)
   downloading to CMake script and do that only if no
   correspodning libraries are set in cmake command
   line or found in the system.

Signed-off-by: Vladimir Lazarev <vladimir.lazarev@intel.com>