### PR TITLE
[SYCL] Implement and use aligned allocator

### DIFF
--- a/sycl/include/CL/sycl/detail/aligned_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/aligned_allocator.hpp
@@ -1,0 +1,68 @@
+//==------------ aligned_allocator.hpp - SYCL standard header file ---------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/cl.h>
+#include <CL/sycl/detail/cnri.h>
+#include <CL/sycl/range.hpp>
+
+#include <cstring>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+namespace cl {
+namespace sycl {
+template <typename T, size_t Alignment>
+class aligned_allocator {
+public:
+  using value_type = T;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+
+public:
+  template<typename U>
+  struct rebind {
+    typedef aligned_allocator<U, Alignment> other;
+  };
+
+  // Construct an object
+  void construct(pointer Ptr, const_reference Val) {
+    new (Ptr) value_type(Val);
+  }
+
+  // Destroy an object
+  void destroy(pointer Ptr) { Ptr->~value_type(); }
+
+  pointer address(reference Val) const { return &Val; }
+  const_pointer address(const_reference Val) { return &Val; }
+
+  // Allocate aligned (to Alignment) memory
+  pointer allocate(size_t Size) {
+    Size += Alignment - Size % Alignment;
+    pointer Result = reinterpret_cast<pointer>(
+      aligned_alloc(Alignment, Size * sizeof(value_type)));
+    if (!Result)
+      throw std::bad_alloc();
+    return Result;
+  }
+
+  // Release allocated memory
+  void deallocate(pointer Ptr, size_t size) {
+    if (Ptr)
+      free(Ptr);
+  }
+
+  bool operator==(const aligned_allocator&) { return true; }
+  bool operator!=(const aligned_allocator& rhs) { return false; }
+};
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -12,6 +12,7 @@
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/aligned_allocator.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.h>
 #include <CL/sycl/event.hpp>
@@ -54,6 +55,7 @@ class queue;
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::target AccessTarget, access::placeholder IsPlaceholder>
 class accessor;
+using buffer_allocator = aligned_allocator<char, /*alignment*/ 64>;
 template <typename T, int Dimensions, typename AllocatorT> class buffer;
 namespace detail {
 
@@ -587,8 +589,7 @@ public:
     range<dim> Range =
         getAccessorRangeHelper<T_src, dim, mode, tgt,
                                isPlaceholder>::getAccessorRange(src);
-    // TODO use buffer_allocator when it is possible
-    buffer<T_src, dim, std::allocator<char>> Buffer(
+    buffer<T_src, dim, buffer_allocator> Buffer(
         (shared_ptr_class<T_src>)dest, Range,
         {property::buffer::use_host_ptr()});
     accessor<T_src, dim, access::mode::write, access::target::global_buffer,
@@ -608,8 +609,7 @@ public:
     range<dim> Range =
         getAccessorRangeHelper<T_dest, dim, mode, tgt,
                                isPlaceholder>::getAccessorRange(dest);
-    // TODO use buffer_allocator when it is possible
-    buffer<T_dest, dim, std::allocator<char>> Buffer(
+    buffer<T_dest, dim, buffer_allocator> Buffer(
         (shared_ptr_class<T_dest>)src, Range,
         {property::buffer::use_host_ptr()});
     accessor<T_dest, dim, access::mode::read, access::target::global_buffer,
@@ -628,8 +628,7 @@ public:
     range<dim> Range =
         getAccessorRangeHelper<T_src, dim, mode, tgt,
                                isPlaceholder>::getAccessorRange(src);
-    // TODO use buffer_allocator when it is possible
-    buffer<T_src, dim, std::allocator<char>> Buffer(
+    buffer<T_src, dim, buffer_allocator> Buffer(
         (T_src *)dest, Range, {property::buffer::use_host_ptr()});
     accessor<T_src, dim, access::mode::write, access::target::global_buffer,
              access::placeholder::false_t>
@@ -647,8 +646,7 @@ public:
     range<dim> Range =
         getAccessorRangeHelper<T_dest, dim, mode, tgt,
                                isPlaceholder>::getAccessorRange(dest);
-    // TODO use buffer_allocator when it is possible
-    buffer<T_dest, dim, std::allocator<char>> Buffer(
+    buffer<T_dest, dim, buffer_allocator> Buffer(
         (T_dest *)src, Range, {property::buffer::use_host_ptr()});
     accessor<T_dest, dim, access::mode::read, access::target::global_buffer,
              access::placeholder::false_t>

--- a/sycl/test/basic_tests/buffer/buffer.cpp
+++ b/sycl/test/basic_tests/buffer/buffer.cpp
@@ -330,6 +330,12 @@ int main() {
       queue myQueue;
       myQueue.submit([&](handler &cgh) {
         auto B = Buffer.get_access<access::mode::write>(cgh);
+        cgh.parallel_for<class bufferByRange2Init>(
+            range<2>{20, 20}, [=](id<2> index) { B[index] = 0; });
+      });
+
+      myQueue.submit([&](handler &cgh) {
+        auto B = Buffer.get_access<access::mode::write>(cgh);
         cgh.parallel_for<class bufferByRange2>(
             range<2>{10, 10}, [=](id<2> index) { B[index] = 1; });
       });
@@ -362,6 +368,12 @@ int main() {
       buffer<int, 2> Buffer(range<2>(20, 20));
       Buffer.set_final_data((int *)result);
       queue myQueue;
+      myQueue.submit([&](handler &cgh) {
+        auto B = Buffer.get_access<access::mode::write>(cgh);
+        cgh.parallel_for<class bufferByRangeOffsetInit>(
+            range<2>{20, 20}, [=](id<2> index) { B[index] = 0; });
+      });
+
       myQueue.submit([&](handler &cgh) {
         accessor<int, 2, access::mode::write, access::target::global_buffer,
                access::placeholder::false_t>

--- a/sycl/test/sub_group/vote.cpp
+++ b/sycl/test/sub_group/vote.cpp
@@ -25,6 +25,16 @@ void check(queue Queue, const int G, const int L, const int D, const int R) {
     buffer<int, 1> sganybuf(G);
     buffer<int, 1> sgallbuf(G);
 
+    // Initialise buffer with zeros
+    Queue.submit([&](handler &cgh) {
+      auto sganyacc = sganybuf.get_access<access::mode::read_write>(cgh);
+      auto sgallacc = sgallbuf.get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<class init>(range<1>{(unsigned)G}, [=](id<1> index) {
+        sganyacc[index] = 0;
+        sgallacc[index] = 0;
+      });
+    });
+
     Queue.submit([&](handler &cgh) {
       auto sganyacc = sganybuf.get_access<access::mode::read_write>(cgh);
       auto sgallacc = sgallbuf.get_access<access::mode::read_write>(cgh);
@@ -32,12 +42,12 @@ void check(queue Queue, const int G, const int L, const int D, const int R) {
         intel::sub_group SG = NdItem.get_sub_group();
         /* Set to 1 if any local ID in subgroup devided by D has remainder R */
         if (SG.any(SG.get_local_id().get(0) % D == R)) {
-          sganyacc[NdItem.get_global_id()]++;
+          sganyacc[NdItem.get_global_id()] = 1;
         }
         /* Set to 1 if remainder of division of subgroup local ID by D is less
          * than R for all work items in subgroup */
         if (SG.all(SG.get_local_id().get(0) % D < R)) {
-          sgallacc[NdItem.get_global_id()]++;
+          sgallacc[NdItem.get_global_id()] = 1;
         }
       });
     });


### PR DESCRIPTION
Alignment is of 64 bytes by default.
Buffer is not longer zero-initialized.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>