### PR TITLE
[SYCL] Add support for discard access modes

### DIFF
--- a/sycl/include/CL/sycl/detail/scheduler/requirements.h
+++ b/sycl/include/CL/sycl/detail/scheduler/requirements.h
@@ -105,15 +105,15 @@ public:
   void allocate(QueueImplPtr Queue, std::vector<cl::sycl::event> DepEvents,
                 EventImplPtr Event) override {
     assert(m_Buffer != nullptr && "BufferStorage::m_Buffer is nullptr");
-    m_Buffer->allocate(std::move(Queue), std::move(DepEvents), std::move(Event),
-                       Mode);
+    m_Buffer->allocate(std::move(Queue), std::move(DepEvents),
+                       std::move(Event));
   }
 
   void moveMemoryTo(QueueImplPtr Queue, std::vector<cl::sycl::event> DepEvents,
                     EventImplPtr Event) override {
     assert(m_Buffer != nullptr && "BufferStorage::m_Buffer is nullptr");
     m_Buffer->moveMemoryTo(std::move(Queue), std::move(DepEvents),
-                           std::move(Event));
+                           std::move(Event), Mode);
   }
 
   void fill(QueueImplPtr Queue, std::vector<cl::sycl::event> DepEvents,


### PR DESCRIPTION
cl::sycl::discard_write and cl::sycl::discard_read_write are now
supported. Do not proceed copying buffer from device to host and
vice versa if any of mentioned modes are set.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>