### PR TITLE
[SYCL] Fix load method of vec according to specification

### DIFF
--- a/sycl/include/CL/sycl/multi_ptr.hpp
+++ b/sycl/include/CL/sycl/multi_ptr.hpp
@@ -118,6 +118,53 @@ public:
                 Accessor)
       : multi_ptr(Accessor.get_pointer()) {}
 
+  // The following constructors are necessary to create multi_ptr<const
+  // ElementType, Space> from accessor<ElementType, ...>. Constructors above
+  // could not be used for this purpose because it will require 2 implicit
+  // conversions of user types which is not allowed by C++:
+  //    1. from accessor<ElementType, ...> to multi_ptr<ElementType, Space>
+  //    2. from multi_ptr<ElementType, Space> to multi_ptr<const ElementType,
+  //    Space>
+
+  // Only if Space == global_space and element type is const
+  template <
+      int dimensions, access::mode Mode, access::placeholder isPlaceholder,
+      access::address_space _Space = Space, typename ET = ElementType,
+      typename = typename std::enable_if<
+          _Space == Space && Space == access::address_space::global_space &&
+          std::is_const<ET>::value &&
+          std::is_same<ET, ElementType>::value>::type>
+  multi_ptr(accessor<typename std::remove_const<ET>::type, dimensions, Mode,
+                     access::target::global_buffer, isPlaceholder>
+                Accessor)
+      : multi_ptr(Accessor.get_pointer()) {}
+
+  // Only if Space == local_space and element type is const
+  template <
+      int dimensions, access::mode Mode, access::placeholder isPlaceholder,
+      access::address_space _Space = Space, typename ET = ElementType,
+      typename = typename std::enable_if<
+          _Space == Space && Space == access::address_space::local_space &&
+          std::is_const<ET>::value &&
+          std::is_same<ET, ElementType>::value>::type>
+  multi_ptr(accessor<typename std::remove_const<ET>::type, dimensions, Mode,
+                     access::target::local, isPlaceholder>
+                Accessor)
+      : multi_ptr(Accessor.get_pointer()) {}
+
+  // Only if Space == constant_space and element type is const
+  template <
+      int dimensions, access::mode Mode, access::placeholder isPlaceholder,
+      access::address_space _Space = Space, typename ET = ElementType,
+      typename = typename std::enable_if<
+          _Space == Space && Space == access::address_space::constant_space &&
+          std::is_const<ET>::value &&
+          std::is_same<ET, ElementType>::value>::type>
+  multi_ptr(accessor<typename std::remove_const<ET>::type, dimensions, Mode,
+                     access::target::constant_buffer, isPlaceholder>
+                Accessor)
+      : multi_ptr(Accessor.get_pointer()) {}
+
   // Returns the underlying OpenCL C pointer
   pointer_t get() const { return m_Pointer; }
 

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -586,14 +586,16 @@ public:
 #error "Undefine __SYCL_LOADSTORE macro"
 #endif
 #define __SYCL_LOADSTORE(Space)                                                \
-  void load(size_t Offset, multi_ptr<DataT, Space> Ptr) {                      \
+  void load(size_t Offset, multi_ptr<const DataT, Space> Ptr) {                \
     if (NumElements != 3) {                                                    \
-      m_Data = *multi_ptr<DataType, Space>(static_cast<DataType *>(            \
-          static_cast<void *>(Ptr + Offset * NumElements)));                   \
+      m_Data =                                                                 \
+          *multi_ptr<const DataType, Space>(static_cast<const DataType *>(     \
+              static_cast<const void *>(Ptr + Offset * NumElements)));         \
       return;                                                                  \
     }                                                                          \
     for (int I = 0; I < NumElements; I++) {                                    \
-      setValue(I, *multi_ptr<DataT, Space>(Ptr + Offset * NumElements + I));   \
+      setValue(                                                                \
+          I, *multi_ptr<const DataT, Space>(Ptr + Offset * NumElements + I));  \
     }                                                                          \
   }                                                                            \
   void store(size_t Offset, multi_ptr<DataT, Space> Ptr) const {               \


### PR DESCRIPTION
Load method doesn't change data pointed by multi_ptr so const should be
added to data type according to specification. This requires aditional
constructors for multi_ptr from accessor class.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>