### PR TITLE
[SYCL] Set minimum required CMake version to 3.5.

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(sycl-solution)
 # Requirements


### PR DESCRIPTION
cmake copy operation (e.g. sycl/CMakeLists.txt:76) allows to copy multiple files starting from cmake 3.5.

Signed-off-by: Vladimir Lazarev <vladimir.lazarev@intel.com>