### PR TITLE
[SYCL][NFC] Remove include 'cmath' from the headers.

### DIFF
--- a/sycl/doc/GetStartedWithSYCLCompiler.md
+++ b/sycl/doc/GetStartedWithSYCLCompiler.md
@@ -188,13 +188,7 @@ int main() {
   translation units.
 - SYCL host device is not fully supported.
 - SYCL works only with OpenCL implementations supporting out-of-order queues.
-- `math.h` header is conflicting with SYCL headers. Please use `cmath` as a
-  workaround for now like below:
 
-```c++
-//#include <math.h>  // conflicting
-#include <cmath>
-```
 
 # Find More
 

--- a/sycl/include/CL/sycl/detail/builtins.hpp
+++ b/sycl/include/CL/sycl/detail/builtins.hpp
@@ -12,9 +12,6 @@
 #include <CL/sycl/detail/generic_type_traits.hpp>
 
 #include <type_traits>
-// TODO Delete this include after solving the problems in the test
-// infrastructure.
-#include <cmath>
 
 // TODO Decide whether to mark functions with this attribute.
 #define __NOEXC /*noexcept*/

--- a/sycl/test/basic_tests/half_type.cpp
+++ b/sycl/test/basic_tests/half_type.cpp
@@ -14,6 +14,8 @@
 
 #include <CL/sycl.hpp>
 
+#include <cmath>
+
 using namespace cl::sycl;
 
 constexpr float FLT_EPSILON = 9.77e-4;


### PR DESCRIPTION
Updated GetStartedWithSYCLCompiler.md
math.h is no longer in conflict with SYCL headers.

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>