### PR TITLE
Hot fixes after new scheduler commit.

### DIFF
--- a/sycl/include/CL/sycl/handler2.hpp
+++ b/sycl/include/CL/sycl/handler2.hpp
@@ -857,7 +857,7 @@ public:
         for (int I = 1; I < Dims; ++I)
           LinearIndex += Range[I] * Index[I];
 
-        Dst[Index] = ((T_Src *)Src)[LinearIndex];
+        Dst[Index] = ((T_Dst *)Src)[LinearIndex];
       });
 
       return;

--- a/sycl/source/detail/scheduler/commands2.cpp
+++ b/sycl/source/detail/scheduler/commands2.cpp
@@ -115,7 +115,7 @@ MapMemObject::MapMemObject(Requirement SrcReq, AllocaCommand *SrcAlloca,
 cl_int MapMemObject::enqueueImp() {
   std::vector<cl_event> RawEvents =
       Command::prepareEvents(detail::getSyclObjImpl(MQueue->get_context()));
-  assert(MDstReq.getNumOfDims() == 1);
+  assert(MDstReq.MDims == 1);
 
   cl_event &Event = MEvent->getHandleRef();
   void *MappedPtr = MemoryManager::map(


### PR DESCRIPTION
Fix copy method, now it's casts pointer to a destination type.
Fix assert in commands, it was using method which doesn't exist
anymore.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>