### PR TITLE
[SYCL] Initial support of Intel FPGA loop attributes

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1387,6 +1387,42 @@ def Mode : Attr {
   let PragmaAttributeSupport = 0;
 }
 
+def IntelFPGAIVDep : Attr {
+  let Spellings = [CXX11<"intelfpga","ivdep">];
+  let Args = [IntArgument<"Safelen">];
+  let LangOpts = [SYCL];
+  let AdditionalMembers = [{
+    static const char *getName() {
+      return "ivdep";
+    }
+  }];
+  let Documentation = [IntelFPGAIVDepAttrDocs];
+}
+
+def IntelFPGAII : Attr {
+  let Spellings = [CXX11<"intelfpga","ii">];
+  let Args = [IntArgument<"Interval">];
+  let LangOpts = [SYCL];
+  let AdditionalMembers = [{
+    static const char *getName() {
+      return "ii";
+    }
+  }];
+  let Documentation = [IntelFPGAIIAttrDocs];
+}
+
+def IntelFPGAMaxConcurrency : Attr {
+  let Spellings = [CXX11<"intelfpga","max_concurrency">];
+  let Args = [IntArgument<"NThreads">];
+  let LangOpts = [SYCL];
+  let AdditionalMembers = [{
+    static const char *getName() {
+      return "max_concurrency";
+    }
+  }];
+  let Documentation = [IntelFPGAMaxConcurrencyAttrDocs];
+}
+
 def IntelFPGALocalNonConstVar : SubsetSubject<Var,
                               [{S->hasLocalStorage() &&
                                 S->getKind() != Decl::ImplicitParam &&

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1498,12 +1498,12 @@ def IntelFPGANumBanks : Attr {
   }];
 }
 
-def IntelFPGAMaxConcurrency : InheritableAttr {
-  let Spellings = [GNU<"max_concurrency">, CXX11<"intelfpga","max_concurrency">];
+def IntelFPGAMaxPrivateCopies : InheritableAttr {
+  let Spellings = [GNU<"max_private_copies">, CXX11<"intelfpga","max_private_copies">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCL];
   let Subjects = SubjectList<[IntelFPGALocalNonConstVar, Field], ErrorDiag>;
-  let Documentation = [IntelFPGAMaxConcurrencyAttrDocs];
+  let Documentation = [IntelFPGAMaxPrivateCopiesAttrDocs];
   let AdditionalMembers = [{
     static unsigned getMinValue() {
       return 0;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1729,9 +1729,9 @@ with N banks.
   }];
 }
 
-def IntelFPGAMaxConcurrencyAttrDocs : Documentation {
+def IntelFPGAMaxPrivateCopiesAttrDocs : Documentation {
   let Category = DocCatVariable;
-  let Heading = "max_concurrency (IntelFPGA)";
+  let Heading = "max_private_copies (IntelFPGA)";
   let Content = [{
 This attribute may be attached to a variable or struct member declaration and
 instructs the backend to replicate the memory generated for the variable or

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1740,6 +1740,37 @@ threads or loop iterations.
   }];
 }
 
+def IntelFPGAIVDepAttrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "ivdep";
+  let Content = [{
+This attribute applies to a loop. If no additional arguments are provided, it
+indicates that the backend may assume that the loop carries no dependences.
+If a safelen is provided then the backend may assume that all loop carried
+dependences have a dependence distance of at least that length.
+  }];
+}
+
+def IntelFPGAIIAttrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "ii";
+  let Content = [{
+This attribute applies to a loop. Indicates that the loop should be pipelined
+with an initiation interval of N. N must be a positive integer. Cannot be
+applied multiple times to the same loop.
+  }];
+}
+
+def IntelFPGAMaxConcurrencyAttrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "max_concurrency";
+  let Content = [{
+This attribute applies to a loop. Indicates that the loop should allow no more
+than N threads or iterations to execute it simultaneously. N must be a positive
+integer. Cannot be applied multiple times to the same loop.
+  }];
+}
+
 def RISCVInterruptDocs : Documentation {
   let Category = DocCatFunction;
   let Heading = "interrupt (RISCV)";

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1218,6 +1218,11 @@ def err_pragma_cannot_end_force_cuda_host_device : Error<
   "force_cuda_host_device begin">;
 } // end of Parse Issue category.
 
+// Intel FPGA pragmas and attributes support
+// Attribute ivdep, ii, max_concurrency support
+def err_intel_fpga_loop_attrs_on_non_loop : Error<
+  "intelfpga loop attributes must be applied to for, while or do statements">;
+
 let CategoryName = "Modules Issue" in {
 def err_unexpected_module_decl : Error<
   "module declaration can only appear at the top level">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -128,6 +128,8 @@ def err_attribute_argument_not_power_of_two : Error<
   "%0 attribute argument must be a constant power of two greater than zero">;
 def err_intel_fpga_memory_arg_invalid : Error<
   "%0 attribute requires either no argument or one of: %1">;
+def err_intel_fpga_loop_attr_duplication : Error<
+  "duplicate Intel FPGA loop attribute '%0'">;
 
 // C99 variable-length arrays
 def ext_vla : Extension<"variable length arrays are a C99 feature">,

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2519,8 +2519,16 @@ private:
   /// Parses opencl_unroll_hint attribute.
   /// \return false if error happens.
   bool ParseOpenCLUnrollHintAttribute(ParsedAttributes &Attrs);
-  void ParseNullabilityTypeSpecifiers(ParsedAttributes &attrs);
 
+  /// Parses intelfpga:: loop attributes if the language is SYCL
+  bool MaybeParseIntelFPGALoopAttributes(ParsedAttributes &Attrs) {
+    if (getLangOpts().SYCLIsDevice)
+      return ParseIntelFPGALoopAttributes(Attrs);
+    return true;
+  }
+  bool ParseIntelFPGALoopAttributes(ParsedAttributes &Attrs);
+
+  void ParseNullabilityTypeSpecifiers(ParsedAttributes &attrs);
   VersionTuple ParseVersionTuple(SourceRange &Range);
   void ParseAvailabilityAttribute(IdentifierInfo &Availability,
                                   SourceLocation AvailabilityLoc,

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -57,6 +57,18 @@ struct LoopAttributes {
   /// Value for llvm.loop.interleave.count metadata.
   unsigned InterleaveCount;
 
+  /// Value for llvm.loop.ivdep.enable metadata.
+  bool IVDepEnable;
+
+  /// Value for llvm.loop.ivdep.safelen metadata.
+  unsigned IVDepSafelen;
+
+  /// Value for llvm.loop.ii metadata.
+  unsigned IInterval;
+
+  /// Value for llvm.loop.max_concurrency metadata.
+  unsigned MaxConcurrencyNThreads;
+
   /// llvm.unroll.
   unsigned UnrollCount;
 
@@ -169,6 +181,20 @@ public:
 
   /// Set the interleave count for the next loop pushed.
   void setInterleaveCount(unsigned C) { StagedAttrs.InterleaveCount = C; }
+
+  /// Set flag of ivdep for the next loop pushed.
+  void setIVDepEnable() { StagedAttrs.IVDepEnable = true; }
+
+  /// Set value of safelen count for the next loop pushed.
+  void setIVDepSafelen(unsigned C) { StagedAttrs.IVDepSafelen = C; }
+
+  /// Set value of an initiation interval for the next loop pushed.
+  void setIInterval(unsigned C) { StagedAttrs.IInterval = C; }
+
+  /// Set value of threads for the next loop pushed.
+  void setMaxConcurrencyNThreads(unsigned C) {
+    StagedAttrs.MaxConcurrencyNThreads = C;
+  }
 
   /// Set the unroll count for the next loop pushed.
   void setUnrollCount(unsigned C) { StagedAttrs.UnrollCount = C; }

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3539,7 +3539,7 @@ void CodeGenModule::generateIntelFPGAAnnotation(
     llvm::APSInt BWAInt = BWA->getValue()->EvaluateKnownConstInt(getContext());
     Out << '{' << BWA->getSpelling() << ':' << BWAInt << '}';
   }
-  if (const auto *MCA = D->getAttr<IntelFPGAMaxConcurrencyAttr>()) {
+  if (const auto *MCA = D->getAttr<IntelFPGAMaxPrivateCopiesAttr>()) {
     llvm::APSInt MCAInt = MCA->getValue()->EvaluateKnownConstInt(getContext());
     Out << '{' << MCA->getSpelling() << ':' << MCAInt << '}';
   }

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -100,7 +100,8 @@ Parser::ParseStatementOrDeclaration(StmtVector &Stmts,
 
   ParsedAttributesWithRange Attrs(AttrFactory);
   MaybeParseCXX11Attributes(Attrs, nullptr, /*MightBeObjCMessageSend*/ true);
-  if (!MaybeParseOpenCLUnrollHintAttribute(Attrs))
+  if (!MaybeParseOpenCLUnrollHintAttribute(Attrs) ||
+      !MaybeParseIntelFPGALoopAttributes(Attrs))
     return StmtError();
 
   StmtResult Res = ParseStatementOrDeclarationAfterAttributes(
@@ -2366,6 +2367,24 @@ bool Parser::ParseOpenCLUnrollHintAttribute(ParsedAttributes &Attrs) {
 
   if (!(Tok.is(tok::kw_for) || Tok.is(tok::kw_while) || Tok.is(tok::kw_do))) {
     Diag(Tok, diag::err_opencl_unroll_hint_on_non_loop);
+    return false;
+  }
+  return true;
+}
+
+bool Parser::ParseIntelFPGALoopAttributes(ParsedAttributes &Attrs) {
+  MaybeParseCXX11Attributes(Attrs);
+
+  if (Attrs.empty())
+    return true;
+
+  if (Attrs.begin()->getKind() != ParsedAttr::AT_IntelFPGAIVDep &&
+      Attrs.begin()->getKind() != ParsedAttr::AT_IntelFPGAII &&
+      Attrs.begin()->getKind() != ParsedAttr::AT_IntelFPGAMaxConcurrency)
+    return true;
+
+  if (!(Tok.is(tok::kw_for) || Tok.is(tok::kw_while) || Tok.is(tok::kw_do))) {
+    Diag(Tok, diag::err_intel_fpga_loop_attrs_on_non_loop);
     return false;
   }
   return true;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3793,7 +3793,7 @@ void Sema::AddOneConstantValueAttr(SourceRange AttrRange, Decl *D, Expr *E,
     E = ICE.get();
   }
 
-  if (IntelFPGAMaxConcurrencyAttr::classof(&TmpAttr)) {
+  if (IntelFPGAMaxPrivateCopiesAttr::classof(&TmpAttr)) {
     if (!D->hasAttr<IntelFPGAMemoryAttr>())
       D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
           Context, IntelFPGAMemoryAttr::Default));
@@ -5083,7 +5083,7 @@ static bool checkIntelFPGARegisterAttrCompatibility(Sema &S, Decl *D,
     InCompat = true;
   if (checkAttrMutualExclusion<IntelFPGABankWidthAttr>(S, D, Attr))
     InCompat = true;
-  if (checkAttrMutualExclusion<IntelFPGAMaxConcurrencyAttr>(S, D, Attr))
+  if (checkAttrMutualExclusion<IntelFPGAMaxPrivateCopiesAttr>(S, D, Attr))
     InCompat = true;
   if (auto *NBA = D->getAttr<IntelFPGANumBanksAttr>())
     if (!NBA->isImplicit() &&
@@ -5122,13 +5122,13 @@ static void handleOneConstantPowerTwoValueAttr(Sema &S, Decl *D,
       Attr.getAttributeSpellingListIndex());
 }
 
-static void handleIntelFPGAMaxConcurrencyAttr(Sema &S, Decl *D,
+static void handleIntelFPGAMaxPrivateCopiesAttr(Sema &S, Decl *D,
                                               const ParsedAttr &Attr) {
-  checkForDuplicateAttribute<IntelFPGAMaxConcurrencyAttr>(S, D, Attr);
+  checkForDuplicateAttribute<IntelFPGAMaxPrivateCopiesAttr>(S, D, Attr);
   if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
     return;
 
-  S.AddOneConstantValueAttr<IntelFPGAMaxConcurrencyAttr>(
+  S.AddOneConstantValueAttr<IntelFPGAMaxPrivateCopiesAttr>(
       Attr.getRange(), D, Attr.getArgAsExpr(0),
       Attr.getAttributeSpellingListIndex());
 }
@@ -7503,8 +7503,8 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_IntelFPGANumBanks:
     handleOneConstantPowerTwoValueAttr<IntelFPGANumBanksAttr>(S, D, AL);
     break;
-  case ParsedAttr::AT_IntelFPGAMaxConcurrency:
-    handleIntelFPGAMaxConcurrencyAttr(S, D, AL);
+  case ParsedAttr::AT_IntelFPGAMaxPrivateCopies:
+    handleIntelFPGAMaxPrivateCopiesAttr(S, D, AL);
     break;
 
   case ParsedAttr::AT_AnyX86NoCallerSavedRegisters:

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -4,13 +4,13 @@
 //CHECK: [[ANN2:@.str[\.]*[0-9]*]] = {{.*}}{register:1}
 //CHECK: [[ANN3:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}
 //CHECK: [[ANN4:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{bankwidth:4}
-//CHECK: [[ANN5:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{max_concurrency:8}
+//CHECK: [[ANN5:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{max_private_copies:8}
 //CHECK: [[ANN10:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{pump:1}
 //CHECK: [[ANN11:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{pump:2}
 //CHECK: [[ANN6:@.str[\.]*[0-9]*]] = {{.*}}{memory:BLOCK_RAM}
 //CHECK: [[ANN7:@.str[\.]*[0-9]*]] = {{.*}}{memory:MLAB}
 //CHECK: [[ANN8:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{bankwidth:8}
-//CHECK: [[ANN9:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{max_concurrency:4}
+//CHECK: [[ANN9:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{max_private_copies:4}
 
 void foo() {
   //CHECK: %[[VAR_ONE:[0-9]+]] = bitcast{{.*}}var_one
@@ -36,7 +36,7 @@ struct foo_two {
   int __attribute__((register)) f2;
   int __attribute__((__memory__)) f3;
   int __attribute__((__bankwidth__(4))) f4;
-  int __attribute__((max_concurrency(8))) f5;
+  int __attribute__((max_private_copies(8))) f5;
   int __attribute__((singlepump)) f6;
   int __attribute__((doublepump)) f7;
 };
@@ -101,7 +101,7 @@ void baz() {
   //CHECK: %[[V_SEVEN:[0-9]+]] = bitcast{{.*}}v_seven
   //CHECK: %[[V_SEVEN1:v_seven[0-9]+]] = bitcast{{.*}}v_seven
   //CHECK: llvm.var.annotation{{.*}}%[[V_SEVEN1]],{{.*}}[[ANN9]]
-  int v_seven [[intelfpga::max_concurrency(4)]];
+  int v_seven [[intelfpga::max_private_copies(4)]];
   //CHECK: %[[V_EIGHT:[0-9]+]] = bitcast{{.*}}v_eight
   //CHECK: %[[V_EIGHT1:v_eight[0-9]+]] = bitcast{{.*}}v_eight
   //CHECK: llvm.var.annotation{{.*}}%[[V_EIGHT1]],{{.*}}[[ANN10]]

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -1,0 +1,57 @@
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+
+// CHECK: br label %for.cond, !llvm.loop ![[MD_A:[0-9]+]]
+// CHECK: br label %for.cond, !llvm.loop ![[MD_B:[0-9]+]]
+// CHECK: br label %for.cond, !llvm.loop ![[MD_C:[0-9]+]]
+// CHECK: br label %for.cond, !llvm.loop ![[MD_D:[0-9]+]]
+
+// CHECK: ![[MD_A]] = distinct !{![[MD_A]], ![[MD_ivdep_A:[0-9]+]]}
+// CHECK-NEXT: ![[MD_ivdep_A]] = !{!"llvm.loop.ivdep.enable"}
+void foo() {
+  int a[10];
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+// CHECK: ![[MD_B]] = distinct !{![[MD_B]], ![[MD_ivdep_B:[0-9]+]]}
+// CHECK-NEXT: ![[MD_ivdep_B]] = !{!"llvm.loop.ivdep.safelen", i32 2}
+void boo() {
+  int a[10];
+  [[intelfpga::ivdep(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+// CHECK: ![[MD_C]] = distinct !{![[MD_C]], ![[MD_ii:[0-9]+]]}
+// CHECK-NEXT: ![[MD_ii]] = !{!"llvm.loop.ii", i32 2}
+void goo() {
+  int a[10];
+  [[intelfpga::ii(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+// CHECK: ![[MD_D]] = distinct !{![[MD_D]], ![[MD_max_concurrency:[0-9]+]]}
+// CHECK-NEXT: ![[MD_max_concurrency]] = !{!"llvm.loop.max_concurrency", i32 2}
+void zoo() {
+  int a[10];
+  [[intelfpga::max_concurrency(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class kernel_function>([]() {
+    foo();
+    boo();
+    goo();
+    zoo();
+  });
+  return 0;
+}

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -79,18 +79,18 @@ void foo1()
 
   //CHECK: VarDecl{{.*}}v_seven
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGAMaxConcurrencyAttr
+  //CHECK: IntelFPGAMaxPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-  __attribute__((max_concurrency(4)))
+  __attribute__((max_private_copies(4)))
   unsigned int v_seven[64];
 
   //CHECK: VarDecl{{.*}}v_seven2
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGAMaxConcurrencyAttr
+  //CHECK: IntelFPGAMaxPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  [[intelfpga::max_concurrency(8)]] unsigned int v_seven2[64];
+  [[intelfpga::max_private_copies(8)]] unsigned int v_seven2[64];
 
   //CHECK: VarDecl{{.*}}v_fourteen
   //CHECK: IntelFPGADoublePumpAttr
@@ -179,7 +179,7 @@ void foo1()
 
   //expected-error@+2{{attributes are not compatible}}
   __attribute__((__register__))
-  __attribute__((__max_concurrency__(16)))
+  __attribute__((__max_private_copies__(16)))
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_six_two[64];
 
@@ -241,37 +241,37 @@ void foo1()
   __attribute__((__bankwidth__(0)))
   unsigned int bw_seven[64];
 
-  // max_concurrency
+  // max_private_copies_
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__max_concurrency__(16)))
+  __attribute__((__max_private_copies__(16)))
   __attribute__((__register__))
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int mc_one[64];
 
   //CHECK: VarDecl{{.*}}mc_two
-  //CHECK: IntelFPGAMaxConcurrencyAttr
+  //CHECK: IntelFPGAMaxPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  //CHECK: IntelFPGAMaxConcurrencyAttr
+  //CHECK: IntelFPGAMaxPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}16{{$}}
   //expected-warning@+2{{is already applied}}
-  __attribute__((__max_concurrency__(8)))
-  __attribute__((__max_concurrency__(16)))
+  __attribute__((__max_private_copies__(8)))
+  __attribute__((__max_private_copies__(16)))
   unsigned int mc_two[64];
 
-  //expected-error@+1{{'max_concurrency' attribute requires integer constant between 0 and 1048576 inclusive}}
-  __attribute__((__max_concurrency__(-4)))
+  //expected-error@+1{{'max_private_copies' attribute requires integer constant between 0 and 1048576 inclusive}}
+  __attribute__((__max_private_copies__(-4)))
   unsigned int mc_four[64];
 
-  int i_max_concurrency = 32; // expected-note {{declared here}}
+  int i_max_private_copies = 32; // expected-note {{declared here}}
   //expected-error@+1{{expression is not an integral constant expression}}
-  __attribute__((__max_concurrency__(i_max_concurrency)))
-  //expected-note@-1{{read of non-const variable 'i_max_concurrency' is not allowed in a constant expression}}
+  __attribute__((__max_private_copies__(i_max_private_copies)))
+  //expected-note@-1{{read of non-const variable 'i_max_private_copies' is not allowed in a constant expression}}
   unsigned int mc_five[64];
 
-  //expected-error@+1{{'__max_concurrency__' attribute takes one argument}}
-  __attribute__((__max_concurrency__(4,8)))
+  //expected-error@+1{{'__max_private_copies__' attribute takes one argument}}
+  __attribute__((__max_private_copies__(4,8)))
   unsigned int mc_six[64];
 
   // numbanks
@@ -317,17 +317,17 @@ void foo1()
 }
 
 //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
-__attribute__((__max_concurrency__(8)))
+__attribute__((__max_private_copies__(8)))
 __constant unsigned int ext_two[64] = { 1, 2, 3 };
 
 void other2()
 {
   //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
-  __attribute__((__max_concurrency__(8))) const int ext_six[64] = { 0, 1 };
+  __attribute__((__max_private_copies__(8))) const int ext_six[64] = { 0, 1 };
 }
 
 //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
-void other3(__attribute__((__max_concurrency__(8))) int pfoo) {}
+void other3(__attribute__((__max_private_copies__(8))) int pfoo) {}
 
 struct foo {
   //CHECK: FieldDecl{{.*}}v_one
@@ -378,10 +378,10 @@ struct foo {
 
   //CHECK: FieldDecl{{.*}}v_seven
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGAMaxConcurrencyAttr
+  //CHECK: IntelFPGAMaxPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-  __attribute__((__max_concurrency__(4))) unsigned int v_seven[64];
+  __attribute__((__max_private_copies__(4))) unsigned int v_seven[64];
 };
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -1,0 +1,123 @@
+// RUN: %clang_cc1 -x c++ -fsycl-is-device -std=c++11 -fsyntax-only -verify -pedantic %s
+
+// Test for Intel FPGA loop attributes applied not to a loop
+void foo() {
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while or do statements}}
+  [[intelfpga::ivdep]] int a[10];
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while or do statements}}
+  [[intelfpga::ivdep(2)]] int b[10];
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while or do statements}}
+  [[intelfpga::ii(2)]] int c[10];
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while or do statements}}
+  [[intelfpga::max_concurrency(2)]] int d[10];
+}
+
+// Test for incorrect number of arguments for Intel FPGA loop attributes
+void boo() {
+  int a[10];
+  // expected-error@+1 {{'ivdep' attribute takes no more than 1 argument}}
+  [[intelfpga::ivdep(2,2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'ii' attribute takes at least 1 argument}}
+  [[intelfpga::ii]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'ii' attribute takes no more than 1 argument}}
+  [[intelfpga::ii(2,2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'max_concurrency' attribute takes at least 1 argument}}
+  [[intelfpga::max_concurrency]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'max_concurrency' attribute takes no more than 1 argument}}
+  [[intelfpga::max_concurrency(2,2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+// Test for incorrect argument value for Intel FPGA loop attributes
+void goo() {
+  int a[10];
+  // expected-error@+1 {{'ivdep' attribute requires a positive integral compile time constant expression}}
+  [[intelfpga::ivdep(0)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'ii' attribute requires a positive integral compile time constant expression}}
+  [[intelfpga::ii(0)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'max_concurrency' attribute requires a positive integral compile time constant expression}}
+  [[intelfpga::max_concurrency(0)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'ivdep' attribute requires an integer constant}}
+  [[intelfpga::ivdep("test123")]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'ii' attribute requires an integer constant}}
+  [[intelfpga::ii("test123")]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'max_concurrency' attribute requires an integer constant}}
+  [[intelfpga::max_concurrency("test123")]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+// Test for Intel FPGA loop attributes dublication
+void zoo() {
+  int a[10];
+  // no diagnostics are expected
+  [[intelfpga::ivdep]]
+  [[intelfpga::max_concurrency(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::ivdep]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ivdep'}}
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::ivdep]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ivdep'}}
+  [[intelfpga::ivdep(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::ivdep(2)]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ivdep'}}
+  [[intelfpga::ivdep(4)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::max_concurrency(2)]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'max_concurrency'}}
+  [[intelfpga::max_concurrency(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::ii(2)]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ii'}}
+  [[intelfpga::ii(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::ii(2)]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ii'}}
+  [[intelfpga::max_concurrency(2)]]
+  [[intelfpga::ii(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class kernel_function>([]() {
+    foo();
+    boo();
+    goo();
+    zoo();
+  });
+  return 0;
+}


### PR DESCRIPTION
Following attributes are being supported:
intelfpga::ivdep(Safelen)
  Applies to a loop. Safelen is a positive integer. If no additional
  arguments are provided, it indicates that the backend may assume
  that the loop carries no dependences. If a safelen is provided then
  the backend may assume that all loop carried dependences have a
  dependence distance of at least that length.

  Metadata generated:
  No safelen provided: "llvm.loop.ivdep.enable"
  Safelen provided: "llvm.loop.ivdep.safelen", i32 Safelen

intelfpga::ii(Interval)
  Applies to a loop. Indicates that the loop should be pipelined
  with an initiation interval. Interval must be a positive integer.
  Cannot be applied multiple times to the same loop.

  Metadata generated:
  "llvm.loop.ii", i32 Interval

intefpga::max_concurrency(NThreads)
  Applies to a loop. Indicates that the loop should allow no more
  than NThreads or iterations to execute it simultaneously.
  NThreads must be a positive integer. Cannot be applied multiple
  times to the same loop.

  Metadata generated:
  "llvm.loop.max_concurrency", i32 NThreads

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>