### PR TITLE
Sync with SPIRV-LLVM-Translator 55f2041f2c

### DIFF
--- a/llvm-spirv/include/LLVMSPIRVLib.h
+++ b/llvm-spirv/include/LLVMSPIRVLib.h
@@ -79,7 +79,7 @@ bool isSpirvBinary(std::string &Img);
 bool convertSpirv(std::istream &IS, std::ostream &OS, std::string &ErrMsg,
                   bool FromText, bool ToText);
 
-/// \brief Convert SPIR-V between binary and internel text formats.
+/// \brief Convert SPIR-V between binary and internal text formats.
 /// This function is not thread safe and should not be used in multi-thread
 /// applications unless guarded by a critical section.
 bool convertSpirv(std::string &Input, std::string &Out, std::string &ErrMsg,
@@ -93,11 +93,11 @@ bool isSpirvText(std::string &Img);
 
 namespace llvm {
 
-/// \brief Translate LLVM module to SPIRV and write to ostream.
+/// \brief Translate LLVM module to SPIR-V and write to ostream.
 /// \returns true if succeeds.
 bool writeSpirv(Module *M, std::ostream &OS, std::string &ErrMsg);
 
-/// \brief Load SPIRV from istream and translate to LLVM module.
+/// \brief Load SPIR-V from istream and translate to LLVM module.
 /// \returns true if succeeds.
 bool readSpirv(LLVMContext &C, std::istream &IS, Module *&M,
                std::string &ErrMsg);

--- a/llvm-spirv/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/llvm-spirv/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -1111,7 +1111,7 @@ void OCL20ToSPIRV::visitCallReadImageWithSampler(
           assert(0 && "read_image* with unhandled number of args!");
         }
 
-        // SPIR-V intruction always returns 4-element vector
+        // SPIR-V instruction always returns 4-element vector
         if (IsRetScalar)
           Ret = VectorType::get(Ret, 4);
         return getSPIRVFuncName(OpImageSampleExplicitLod,
@@ -1687,13 +1687,14 @@ void OCL20ToSPIRV::visitSubgroupImageMediaBlockINTEL(
   spv::Op OpCode = DemangledName.rfind("read") != std::string::npos
                        ? spv::OpSubgroupImageMediaBlockReadINTEL
                        : spv::OpSubgroupImageMediaBlockWriteINTEL;
-  mutateCallInstSPIRV(M, CI,
-                      [=](CallInst *, std::vector<Value *> &Args) {
-                        // Moving the last argument to the begining.
-                        std::rotate(Args.begin(), Args.end() - 1, Args.end());
-                        return getSPIRVFuncName(OpCode, CI->getType());
-                      },
-                      &Attrs);
+  mutateCallInstSPIRV(
+      M, CI,
+      [=](CallInst *, std::vector<Value *> &Args) {
+        // Moving the last argument to the beginning.
+        std::rotate(Args.begin(), Args.end() - 1, Args.end());
+        return getSPIRVFuncName(OpCode, CI->getType());
+      },
+      &Attrs);
 }
 
 static const char *getSubgroupAVCIntelOpKind(const std::string &Name) {

--- a/llvm-spirv/lib/SPIRV/SPIRVInternal.h
+++ b/llvm-spirv/lib/SPIRV/SPIRVInternal.h
@@ -184,6 +184,7 @@ enum SPIRAddressSpace {
   SPIRAS_Local,
   SPIRAS_Generic,
   SPIRAS_Input,
+  SPIRAS_Output,
   SPIRAS_Count,
 };
 

--- a/llvm-spirv/lib/SPIRV/SPIRVReader.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVReader.cpp
@@ -2202,6 +2202,10 @@ void generateIntelFPGAAnnotation(const SPIRVEntry *E,
     Out << "{numbanks:" << Result << '}';
   if (E->hasDecorate(DecorationMaxconcurrencyINTEL, 0, &Result))
     Out << "{max_concurrency:" << Result << '}';
+  if (E->hasDecorate(DecorationSinglepumpINTEL))
+    Out << "{pump:1}";
+  if (E->hasDecorate(DecorationDoublepumpINTEL))
+    Out << "{pump:2}";
 }
 
 void generateIntelFPGAAnnotationForStructMember(
@@ -2224,6 +2228,10 @@ void generateIntelFPGAAnnotationForStructMember(
   if (E->hasMemberDecorate(DecorationMaxconcurrencyINTEL, 0, MemberNumber,
                            &Result))
     Out << "{max_concurrency:" << Result << '}';
+  if (E->hasMemberDecorate(DecorationSinglepumpINTEL, 0, MemberNumber))
+    Out << "{pump:1}";
+  if (E->hasMemberDecorate(DecorationDoublepumpINTEL, 0, MemberNumber))
+    Out << "{pump:2}";
 }
 
 void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
@@ -2904,6 +2912,7 @@ bool llvm::readSpirv(LLVMContext &C, std::istream &IS, Module *&M,
 
   IS >> *BM;
   if (!BM->isModuleValid()) {
+    BM->getError(ErrMsg);
     M = nullptr;
     return false;
   }

--- a/llvm-spirv/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVToOCL20.cpp
@@ -77,7 +77,7 @@ public:
   // appropriate calls to conversion built-ins defined by the standards.
   void visitCastInst(CastInst &CI);
 
-  /// Transform __spirv_ImageQuerySize[Lod] into vector of the same lenght
+  /// Transform __spirv_ImageQuerySize[Lod] into vector of the same length
   /// containing {[get_image_width | get_image_dim], get_image_array_size}
   /// for all images except image1d_t which is always converted into
   /// get_image_width returning scalar result.

--- a/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
@@ -1210,7 +1210,7 @@ Type *getSPIRVTypeByChangeBaseTypeName(Module *M, Type *T, StringRef OldName,
   if (isSPIRVType(T, OldName, &Postfixes))
     return getOrCreateOpaquePtrType(M, getSPIRVTypeName(NewName, Postfixes));
   LLVM_DEBUG(dbgs() << " Invalid SPIR-V type " << *T << '\n');
-  llvm_unreachable("Invalid SPIRV-V type");
+  llvm_unreachable("Invalid SPIR-V type");
   return nullptr;
 }
 

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.h
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.h
@@ -57,6 +57,7 @@
 #include "SPIRVUtil.h"
 #include "SPIRVValue.h"
 
+#include "llvm/Analysis/CallGraph.h"
 #include "llvm/IR/IntrinsicInst.h"
 
 #include <memory>
@@ -128,6 +129,7 @@ private:
   SPIRVWord SrcLang;
   SPIRVWord SrcLangVer;
   std::unique_ptr<LLVMToSPIRVDbgTran> DbgTran;
+  std::unique_ptr<CallGraph> CG;
 
   SPIRVType *mapType(Type *T, SPIRVType *BT);
   SPIRVValue *mapValue(Value *V, SPIRVValue *BV);
@@ -178,6 +180,11 @@ private:
   SPIRVId addInt32(int);
   void transFunction(Function *I);
   SPIRV::SPIRVLinkageTypeKind transLinkageType(const GlobalValue *GV);
+
+  bool isAnyFunctionReachableFromFunction(
+      const Function *FS,
+      const std::unordered_set<const Function *> Funcs) const;
+  void collectInputOutputVariables(SPIRVFunction *SF, Function *F);
 };
 
 } // namespace SPIRV

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -136,6 +136,16 @@ public:
   // Incomplete constructor
   SPIRVDecorate() : SPIRVDecorateGeneric(OC) {}
 
+  SPIRVExtSet getRequiredExtensions() const override {
+    switch (Dec) {
+    case DecorationNoSignedWrap:
+    case DecorationNoUnsignedWrap:
+      return getSet(SPV_KHR_no_integer_wrap_decoration);
+    default:
+      return SPIRVExtSet();
+    }
+  }
+
   _SPIRV_DCL_ENCDEC
   void setWordCount(SPIRVWord) override;
   void validate() const override {

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -438,17 +438,18 @@ std::istream &operator>>(std::istream &I, SPIRVEntry &E) {
 
 SPIRVEntryPoint::SPIRVEntryPoint(SPIRVModule *TheModule,
                                  SPIRVExecutionModelKind TheExecModel,
-                                 SPIRVId TheId, const std::string &TheName)
+                                 SPIRVId TheId, const std::string &TheName,
+                                 std::vector<SPIRVId> Variables)
     : SPIRVAnnotation(TheModule->get<SPIRVFunction>(TheId),
-                      getSizeInWords(TheName) + 3),
-      ExecModel(TheExecModel), Name(TheName) {}
+                      getSizeInWords(TheName) + Variables.size() + 3),
+      ExecModel(TheExecModel), Name(TheName), Variables(Variables) {}
 
 void SPIRVEntryPoint::encode(spv_ostream &O) const {
-  getEncoder(O) << ExecModel << Target << Name;
+  getEncoder(O) << ExecModel << Target << Name << Variables;
 }
 
 void SPIRVEntryPoint::decode(std::istream &I) {
-  getDecoder(I) >> ExecModel >> Target >> Name;
+  getDecoder(I) >> ExecModel >> Target >> Name >> Variables;
   Module->setName(getOrCreateTarget(), Name);
   Module->addEntryPoint(ExecModel, Target);
 }

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -288,6 +288,7 @@ public:
   Op getOpCode() const { return OpCode; }
   SPIRVModule *getModule() const { return Module; }
   virtual SPIRVCapVec getRequiredCapability() const { return SPIRVCapVec(); }
+  virtual SPIRVExtSet getRequiredExtensions() const { return SPIRVExtSet(); }
   const std::string &getName() const { return Name; }
   bool hasDecorate(Decoration Kind, size_t Index = 0,
                    SPIRVWord *Result = 0) const;
@@ -478,12 +479,16 @@ public:
 class SPIRVEntryPoint : public SPIRVAnnotation<OpEntryPoint> {
 public:
   SPIRVEntryPoint(SPIRVModule *TheModule, SPIRVExecutionModelKind,
-                  SPIRVId TheId, const std::string &TheName);
+                  SPIRVId TheId, const std::string &TheName,
+                  std::vector<SPIRVId> Variables);
   SPIRVEntryPoint() : ExecModel(ExecutionModelKernel) {}
   _SPIRV_DCL_ENCDEC
 protected:
   SPIRVExecutionModelKind ExecModel;
   std::string Name;
+
+private:
+  std::vector<SPIRVId> Variables;
 };
 
 class SPIRVName : public SPIRVAnnotation<OpName> {

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -113,6 +113,19 @@ typedef spv::GroupOperation SPIRVGroupOperationKind;
 typedef spv::Dim SPIRVImageDimKind;
 typedef std::vector<SPIRVCapabilityKind> SPIRVCapVec;
 
+enum SPIRVExtensionKind {
+  SPV_INTEL_device_side_avc_motion_estimation,
+  SPV_KHR_no_integer_wrap_decoration
+};
+
+typedef std::set<SPIRVExtensionKind> SPIRVExtSet;
+
+template <> inline void SPIRVMap<SPIRVExtensionKind, std::string>::init() {
+  add(SPV_INTEL_device_side_avc_motion_estimation,
+      "SPV_INTEL_device_side_avc_motion_estimation");
+  add(SPV_KHR_no_integer_wrap_decoration, "SPV_KHR_no_integer_wrap_decoration");
+};
+
 template <> inline void SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {
   add(SPIRVEIS_OpenCL, "OpenCL.std");
   add(SPIRVEIS_Debug, "SPIRV.debug");
@@ -343,6 +356,10 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
   ADD_VEC_INIT(DecorationNumbanksINTEL, {CapabilityFPGAMemoryAttributesINTEL});
   ADD_VEC_INIT(DecorationBankwidthINTEL, {CapabilityFPGAMemoryAttributesINTEL});
   ADD_VEC_INIT(DecorationMaxconcurrencyINTEL,
+               {CapabilityFPGAMemoryAttributesINTEL});
+  ADD_VEC_INIT(DecorationSinglepumpINTEL,
+               {CapabilityFPGAMemoryAttributesINTEL});
+  ADD_VEC_INIT(DecorationDoublepumpINTEL,
                {CapabilityFPGAMemoryAttributesINTEL});
 }
 

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -105,6 +105,15 @@ public:
     return getFunctionType()->getNumParameters();
   }
   SPIRVId getArgumentId(size_t I) const { return Parameters[I]->getId(); }
+  const std::vector<SPIRVId> getVariables() const {
+    std::vector<SPIRVId> Ids;
+    for (auto Variable : Variables)
+      Ids.push_back(Variable->getId());
+    return Ids;
+  }
+  void addVariable(const SPIRVValue *Variable) {
+    Variables.push_back(Variable);
+  }
   SPIRVFunctionParameter *getArgument(size_t I) const { return Parameters[I]; }
   void foreachArgument(std::function<void(SPIRVFunctionParameter *)> Func) {
     for (size_t I = 0, E = getNumArguments(); I != E; ++I)
@@ -170,6 +179,7 @@ private:
   SPIRVWord FCtrlMask;         // Function control mask
 
   std::vector<SPIRVFunctionParameter *> Parameters;
+  std::vector<const SPIRVValue *> Variables;
   typedef std::vector<SPIRVBasicBlock *> SPIRVLBasicBlockVector;
   SPIRVLBasicBlockVector BBVec;
 

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -2246,6 +2246,10 @@ protected:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
+
+  SPIRVExtSet getRequiredExtensions() const override {
+    return getSet(SPV_INTEL_device_side_avc_motion_estimation);
+  }
 };
 
 // Intel Subgroup AVC Motion Estimation Instructions

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -402,6 +402,8 @@ inline bool isValid(spv::Decoration V) {
   case DecorationNumbanksINTEL:
   case DecorationBankwidthINTEL:
   case DecorationMaxconcurrencyINTEL:
+  case DecorationSinglepumpINTEL:
+  case DecorationDoublepumpINTEL:
     return true;
   default:
     return false;

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -155,6 +155,7 @@ public:
   virtual void optimizeDecorates() = 0;
   virtual void setAutoAddCapability(bool E) { AutoAddCapability = E; }
   virtual void setValidateCapability(bool E) { ValidateCapability = E; }
+  virtual void setAutoAddExtensions(bool E) { AutoAddExtensions = E; }
   virtual void setGeneratorId(unsigned short) = 0;
   virtual void setGeneratorVer(unsigned short) = 0;
   virtual void resolveUnknownStructFields() = 0;
@@ -280,6 +281,7 @@ public:
     for (auto I : Caps)
       addCapability(I);
   }
+  virtual void addExtension(SPIRVExtensionKind) = 0;
   /// Used by SPIRV entries to add required capability internally.
   /// Should not be used by users directly.
   virtual void addCapabilityInternal(SPIRVCapabilityKind) = 0;
@@ -382,6 +384,7 @@ public:
 protected:
   bool AutoAddCapability;
   bool ValidateCapability;
+  bool AutoAddExtensions = true;
 
 private:
   bool IsValid;

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -336,6 +336,8 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationNumbanksINTEL, "NumbanksINTEL");
   add(DecorationBankwidthINTEL, "BankwidthINTEL");
   add(DecorationMaxconcurrencyINTEL, "MaxconcurrencyINTEL");
+  add(DecorationSinglepumpINTEL, "SinglepumpINTEL");
+  add(DecorationDoublepumpINTEL, "DoublepumpINTEL");
 }
 SPIRV_DEF_NAMEMAP(Decoration, SPIRVDecorationNameMap)
 

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -779,6 +779,10 @@ public:
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
 
+  SPIRVExtSet getRequiredExtensions() const override {
+    return getSet(SPV_INTEL_device_side_avc_motion_estimation);
+  }
+
 protected:
   SPIRVTypeImage *ImgTy;
   _SPIRV_DEF_ENCDEC2(Id, ImgTy)
@@ -828,6 +832,10 @@ public:
 
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
+  }
+
+  SPIRVExtSet getRequiredExtensions() const override {
+    return getSet(SPV_INTEL_device_side_avc_motion_estimation);
   }
 
   SPIRVValue *getOperand() { return getValue(Opn); }

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVUtil.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVUtil.h
@@ -362,6 +362,12 @@ inline std::vector<uint32_t> getVec(const std::string &Str) {
   return V;
 }
 
+template <typename T> inline std::set<T> getSet(T Op1) {
+  std::set<T> S;
+  S.insert(Op1);
+  return S;
+}
+
 template <typename T> inline std::vector<T> getVec(T Op1) {
   std::vector<T> V;
   V.push_back(Op1);

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -120,6 +120,13 @@ public:
     return Type->getRequiredCapability();
   }
 
+  SPIRVExtSet getRequiredExtensions() const override {
+    SPIRVExtSet EV;
+    if (!hasType())
+      return EV;
+    return Type->getRequiredExtensions();
+  }
+
 protected:
   void setHasNoType() { Attrib |= SPIRVEA_NOTYPE; }
   void setHasType() { Attrib &= ~SPIRVEA_NOTYPE; }

--- a/llvm-spirv/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/spirv.hpp
@@ -393,6 +393,8 @@ enum Decoration {
     DecorationNumbanksINTEL = 5827,
     DecorationBankwidthINTEL = 5828,
     DecorationMaxconcurrencyINTEL = 5829,
+    DecorationSinglepumpINTEL = 5830,
+    DecorationDoublepumpINTEL = 5831,
     DecorationMax = 0x7fffffff,
 };
 

--- a/llvm-spirv/test/NoSignedUnsignedWrap.ll
+++ b/llvm-spirv/test/NoSignedUnsignedWrap.ll
@@ -12,6 +12,8 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
+; CHECK-SPIRV: Extension "SPV_KHR_no_integer_wrap_decoration"
+
 ; CHECK-SPIRV: Decorate {{[0-9]+}} NoSignedWrap
 ; CHECK-SPIRV: Decorate {{[0-9]+}} NoUnsignedWrap
 

--- a/llvm-spirv/test/transcoding/subgroup_avc_intel_generic.ll
+++ b/llvm-spirv/test/transcoding/subgroup_avc_intel_generic.ll
@@ -52,6 +52,7 @@
 ; CHECK: Capability SubgroupAvcMotionEstimationINTEL
 ; CHECK: Capability SubgroupAvcMotionEstimationIntraINTEL
 ; CHECK: Capability SubgroupAvcMotionEstimationChromaINTEL
+; CHECK: Extension "SPV_INTEL_device_side_avc_motion_estimation"
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"

--- a/llvm-spirv/test/transcoding/subgroup_avc_intel_types.ll
+++ b/llvm-spirv/test/transcoding/subgroup_avc_intel_types.ll
@@ -24,6 +24,7 @@
 
 ; CHECK: Capability Groups
 ; CHECK: Capability SubgroupAvcMotionEstimationINTEL
+; CHECK: Extension "SPV_INTEL_device_side_avc_motion_estimation"
 
 ; CHECK: TypeAvcMcePayloadINTEL
 ; CHECK: TypeAvcImePayloadINTEL [[IME_PAYLOAD:[0-9]]]

--- a/llvm-spirv/test/transcoding/subgroup_avc_intel_vme_image.ll
+++ b/llvm-spirv/test/transcoding/subgroup_avc_intel_vme_image.ll
@@ -52,6 +52,8 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"
 
+; CHECK: Extension "SPV_INTEL_device_side_avc_motion_estimation"
+
 ; CHECK: TypeImage              [[ImageTy:[0-9]+]]
 ; CHECK: TypeSampler            [[SamplerTy:[0-9]+]]
 ; CHECK: TypeAvcImePayloadINTEL [[ImePayloadTy:[0-9]+]]

--- a/llvm-spirv/test/transcoding/subgroup_avc_intel_wrappers.ll
+++ b/llvm-spirv/test/transcoding/subgroup_avc_intel_wrappers.ll
@@ -38,6 +38,8 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"
 
+; CHECK: Extension "SPV_INTEL_device_side_avc_motion_estimation"
+
 ; CHECK: TypeAvcImePayloadINTEL [[ImePayloadTy:[0-9]+]]
 ; CHECK: TypeAvcImeResultINTEL  [[ImeResultTy:[0-9]+]]
 ; CHECK: TypeAvcRefPayloadINTEL [[RefPayloadTy:[0-9]+]]

--- a/llvm-spirv/tools/llvm-spirv/llvm-spirv.cpp
+++ b/llvm-spirv/tools/llvm-spirv/llvm-spirv.cpp
@@ -33,11 +33,11 @@
 /// \file
 ///
 ///  Common Usage:
-///  llvm-spirv          - Read LLVM bitcode from stdin, write SPIRV to stdout
+///  llvm-spirv          - Read LLVM bitcode from stdin, write SPIR-V to stdout
 ///  llvm-spirv x.bc     - Read LLVM bitcode from the x.bc file, write SPIR-V
 ///                        to x.bil file
-///  llvm-spirv -r       - Read SPIRV from stdin, write LLVM bitcode to stdout
-///  llvm-spirv -r x.bil - Read SPIRV from the x.bil file, write SPIR-V to
+///  llvm-spirv -r       - Read SPIR-V from stdin, write LLVM bitcode to stdout
+///  llvm-spirv -r x.bil - Read SPIR-V from the x.bil file, write SPIR-V to
 ///                        the x.bc file
 ///
 ///  Options:
@@ -139,14 +139,14 @@ static int convertLLVMToSPIRV() {
   std::string Err;
   bool Success = false;
   if (OutputFile != "-") {
-    std::ofstream OutFile(OutputFile);
+    std::ofstream OutFile(OutputFile, std::ios::binary);
     Success = writeSpirv(M.get(), OutFile, Err);
   } else {
     Success = writeSpirv(M.get(), std::cout, Err);
   }
 
   if (!Success) {
-    errs() << "Fails to save LLVM as SPIRV: " << Err << '\n';
+    errs() << "Fails to save LLVM as SPIR-V: " << Err << '\n';
     return -1;
   }
   return 0;
@@ -159,7 +159,7 @@ static int convertSPIRVToLLVM() {
   std::string Err;
 
   if (!readSpirv(Context, IFS, M, Err)) {
-    errs() << "Fails to load SPIRV as LLVM Module: " << Err << '\n';
+    errs() << "Fails to load SPIR-V as LLVM Module: " << Err << '\n';
     return -1;
   }
 
@@ -243,7 +243,7 @@ static int regularizeLLVM() {
 
   std::string Err;
   if (!regularizeLlvmForSpirv(M.get(), Err)) {
-    errs() << "Fails to save LLVM as SPIRV: " << Err << '\n';
+    errs() << "Fails to save LLVM as SPIR-V: " << Err << '\n';
     return -1;
   }
 


### PR DESCRIPTION
Synced with:
55f2041f2c Open SPIR-V output file as a binary file

As in sync 11e66953d1, this excludes following syncs with LLVM:
    2cdb947d4 Update LLVM to r358377
    72bcddd08 Sync with LLVM
    6183f7c486 Sync with LLVM

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>