### PR TITLE
[SYCL] Change uint to uint32_t to avoid build error on Windows

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -679,13 +679,13 @@ class accessor
   friend class cl::sycl::simple_scheduler::ExecuteKernelCommand;
 
   template <int AccessDimensions, typename KernelType>
-  friend uint cl::sycl::simple_scheduler::passGlobalAccessorAsArg(
-      uint I, int LambdaOffset, cl_kernel ClKernel,
+  friend uint32_t cl::sycl::simple_scheduler::passGlobalAccessorAsArg(
+      uint32_t I, int LambdaOffset, cl_kernel ClKernel,
       const KernelType &HostKernel);
 
   template <int AccessDimensions, typename KernelType>
-  friend uint cl::sycl::simple_scheduler::passLocalAccessorAsArg(
-      uint I, int LambdaOffset, cl_kernel ClKernel,
+  friend uint32_t cl::sycl::simple_scheduler::passLocalAccessorAsArg(
+      uint32_t I, int LambdaOffset, cl_kernel ClKernel,
       const KernelType &HostKernel);
 
   template <class Obj>

--- a/sycl/include/CL/sycl/detail/scheduler/commands.cpp
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.cpp
@@ -28,8 +28,9 @@ const Dst *getParamAddress(const Src *ptr, uint64_t Offset) {
 }
 
 template <int AccessDimensions, typename KernelType>
-uint passGlobalAccessorAsArg(uint I, int LambdaOffset, cl_kernel ClKernel,
-                             const KernelType &HostKernel) {
+uint32_t passGlobalAccessorAsArg(uint32_t I, int LambdaOffset,
+                                 cl_kernel ClKernel,
+                                 const KernelType &HostKernel) {
   using AccType = accessor<char, AccessDimensions, access::mode::read,
                            access::target::global_buffer,
                            access::placeholder::false_t>;
@@ -51,8 +52,9 @@ uint passGlobalAccessorAsArg(uint I, int LambdaOffset, cl_kernel ClKernel,
 }
 
 template <int AccessDimensions, typename KernelType>
-uint passLocalAccessorAsArg(uint I, int LambdaOffset, cl_kernel ClKernel,
-                            const KernelType &HostKernel) {
+uint32_t passLocalAccessorAsArg(uint32_t I, int LambdaOffset,
+                                cl_kernel ClKernel,
+                                const KernelType &HostKernel) {
   using AccType = accessor<char, AccessDimensions, access::mode::read,
                            access::target::local,
                            access::placeholder::false_t>;
@@ -92,7 +94,7 @@ void ExecuteKernelCommand<
   }
 
   if (m_KernelArgs != nullptr) {
-    unsigned ArgumentID = 0;
+    uint32_t ArgumentID = 0;
     for (unsigned I = 0; I < m_KernelArgsNum; ++I) {
       switch (m_KernelArgs[I].kind) {
       case csd::kernel_param_kind_t::kind_std_layout: {

--- a/sycl/include/CL/sycl/detail/scheduler/commands.h
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.h
@@ -408,11 +408,13 @@ private:
 // accessor in lambda function. 'ClKernel' is the kernel. 'HostKernel'
 // is the pointer to the lambda function.
 template <int AccessDimensions, typename KernelType>
-uint passGlobalAccessorAsArg(uint I, int LambdaOffset, cl_kernel ClKernel,
-                             const KernelType &HostKernel);
+uint32_t passGlobalAccessorAsArg(uint32_t I, int LambdaOffset,
+                                 cl_kernel ClKernel,
+                                 const KernelType &HostKernel);
 template <int AccessDimensions, typename KernelType>
-uint passLocalAccessorAsArg(uint I, int LambdaOffset, cl_kernel ClKernel,
-                            const KernelType &HostKernel);
+uint32_t passLocalAccessorAsArg(uint32_t I, int LambdaOffset,
+                                cl_kernel ClKernel,
+                                const KernelType &HostKernel);
 
 } // namespace simple_scheduler
 } // namespace sycl


### PR DESCRIPTION
Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>