### PR TITLE
[SYCL] Fix bug in sampler implementation

### DIFF
--- a/sycl/include/CL/sycl/detail/sampler_impl.hpp
+++ b/sycl/include/CL/sycl/detail/sampler_impl.hpp
@@ -27,15 +27,12 @@ public:
   __spirv::OpTypeSampler *m_Sampler;
   sampler_impl(__spirv::OpTypeSampler *Sampler) : m_Sampler(Sampler) {}
 #else
-  cl_sampler m_Sampler = nullptr;
-  context m_SyclContext;
   std::unordered_map<context, cl_sampler> m_contextToSampler;
 
 private:
   coordinate_normalization_mode m_CoordNormMode;
   addressing_mode m_AddrMode;
   filtering_mode m_FiltMode;
-  bool m_ReleaseSampler;
 
 public:
   sampler_impl(coordinate_normalization_mode normalizationMode,


### PR DESCRIPTION
When sampler was created on host with enums and passed to device we
released null sampler because in GetOrCreateSampler we set m_ReleaseSampler to
true and stored created sampler not into m_Sampler field which is released in
destructor.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>