### PR TITLE
[SYCL] Remove __attribute__((x)) spelling of FPGA attributes

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1456,7 +1456,7 @@ def IntelFPGALocalOrStaticVar : SubsetSubject<Var,
                               "local variables, static variables">;
 
 def IntelFPGADoublePump : Attr {
-  let Spellings = [GNU<"doublepump">, CXX11<"intelfpga", "doublepump">];
+  let Spellings = [CXX11<"intelfpga", "doublepump">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
   let LangOpts = [SYCL];
@@ -1464,7 +1464,7 @@ def IntelFPGADoublePump : Attr {
 }
 
 def IntelFPGASinglePump : Attr {
-  let Spellings = [GNU<"singlepump">, CXX11<"intelfpga", "singlepump">];
+  let Spellings = [CXX11<"intelfpga", "singlepump">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
   let LangOpts = [SYCL];
@@ -1472,7 +1472,7 @@ def IntelFPGASinglePump : Attr {
 }
 
 def IntelFPGAMemory : Attr {
-  let Spellings = [GNU<"memory">, CXX11<"intelfpga", "memory">];
+  let Spellings = [CXX11<"intelfpga", "memory">];
   let Args = [EnumArgument<"Kind", "MemoryKind",
                            ["MLAB", "BLOCK_RAM", ""],
                            ["MLAB", "BlockRAM", "Default"], 1>];
@@ -1492,7 +1492,7 @@ def IntelFPGAMemory : Attr {
 }
 
 def IntelFPGARegister : Attr {
-  let Spellings = [GNU<"register">, CXX11<"intelfpga", "register">];
+  let Spellings = [CXX11<"intelfpga", "register">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
   let LangOpts = [SYCL];
@@ -1501,7 +1501,7 @@ def IntelFPGARegister : Attr {
 
 // One integral argument.
 def IntelFPGABankWidth : Attr {
-  let Spellings = [GNU<"bankwidth">, CXX11<"intelfpga","bankwidth">];
+  let Spellings = [CXX11<"intelfpga","bankwidth">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticSlaveMemVar,
                               Field], ErrorDiag>;
@@ -1518,7 +1518,7 @@ def IntelFPGABankWidth : Attr {
 }
 
 def IntelFPGANumBanks : Attr {
-  let Spellings = [GNU<"numbanks">, CXX11<"intelfpga","numbanks">];
+  let Spellings = [CXX11<"intelfpga","numbanks">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticSlaveMemVar,
                               Field], ErrorDiag>;
@@ -1535,7 +1535,7 @@ def IntelFPGANumBanks : Attr {
 }
 
 def IntelFPGAMaxPrivateCopies : InheritableAttr {
-  let Spellings = [GNU<"max_private_copies">, CXX11<"intelfpga","max_private_copies">];
+  let Spellings = [CXX11<"intelfpga","max_private_copies">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCL];
   let Subjects = SubjectList<[IntelFPGALocalNonConstVar, Field], ErrorDiag>;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5013,7 +5013,7 @@ static bool checkForDuplicateAttribute(Sema &S, Decl *D,
   return false;
 }
 
-/// Handle the __doublepump__ and __singlepump__ attributes.
+/// Handle the [[intelfpga::doublepump]] and [[intelfpga::singlepump]] attributes.
 /// One but not both can be specified
 /// Both are incompatible with the __register__ attribute.
 template <typename AttrType, typename IncompatAttrType>
@@ -5033,8 +5033,8 @@ static void handleIntelFPGAPumpAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
   handleSimpleAttribute<AttrType>(S, D, Attr);
 }
 
-/// Handle the __memory__ attribute.
-/// This is incompatible with the __register__ attribute.
+/// Handle the [[intelfpga::memory]] attribute.
+/// This is incompatible with the [[intelfpga::register]] attribute.
 static void handleIntelFPGAMemoryAttr(Sema &S, Decl *D,
                                       const ParsedAttr &Attr) {
 
@@ -5093,7 +5093,7 @@ static bool checkIntelFPGARegisterAttrCompatibility(Sema &S, Decl *D,
   return InCompat;
 }
 
-/// Handle the __register__ attribute.
+/// Handle the [[intelfpga::register]] attribute.
 /// This is incompatible with most of the other memory attributes.
 static void handleIntelFPGARegisterAttr(Sema &S, Decl *D,
                                         const ParsedAttr &Attr) {
@@ -5105,7 +5105,7 @@ static void handleIntelFPGARegisterAttr(Sema &S, Decl *D,
   handleSimpleAttribute<IntelFPGARegisterAttr>(S, D, Attr);
 }
 
-/// Handle the bankwidth and numbanks attributes.
+/// Handle the [[intelfpga::bankwidth]] and [[intelfpga::numbanks]] attributes.
 /// These require a single constant power of two greater than zero.
 /// These are incompatible with the register attribute.
 /// The numbanks and bank_bits attributes are related.  If bank_bits exists

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -16,29 +16,29 @@ void foo() {
   //CHECK: %[[VAR_ONE:[0-9]+]] = bitcast{{.*}}var_one
   //CHECK: %[[VAR_ONE1:var_one[0-9]+]] = bitcast{{.*}}var_one
   //CHECK: llvm.var.annotation{{.*}}%[[VAR_ONE1]],{{.*}}[[ANN1]]
-  int __attribute__((numbanks(4))) var_one;
+  int var_one [[intelfpga::numbanks(4)]];
   //CHECK: %[[VAR_TWO:[0-9]+]] = bitcast{{.*}}var_two
   //CHECK: %[[VAR_TWO1:var_two[0-9]+]] = bitcast{{.*}}var_two
   //CHECK: llvm.var.annotation{{.*}}%[[VAR_TWO1]],{{.*}}[[ANN2]]
-  int __attribute__((register)) var_two;
+  int var_two [[intelfpga::register]];
   //CHECK: %[[VAR_THREE:[0-9]+]] = bitcast{{.*}}var_three
   //CHECK: %[[VAR_THREE1:var_three[0-9]+]] = bitcast{{.*}}var_three
   //CHECK: llvm.var.annotation{{.*}}%[[VAR_THREE1]],{{.*}}[[ANN3]]
-  int __attribute__((__memory__)) var_three;
+  int var_three [[intelfpga::memory]];
   //CHECK: %[[VAR_FOUR:[0-9]+]] = bitcast{{.*}}var_four
   //CHECK: %[[VAR_FOUR1:var_four[0-9]+]] = bitcast{{.*}}var_four
   //CHECK: llvm.var.annotation{{.*}}%[[VAR_FOUR1]],{{.*}}[[ANN4]]
-  int __attribute__((__bankwidth__(4))) var_four;
+  int var_four [[intelfpga::bankwidth(4)]];
 }
 
 struct foo_two {
-  int __attribute__((numbanks(4))) f1;
-  int __attribute__((register)) f2;
-  int __attribute__((__memory__)) f3;
-  int __attribute__((__bankwidth__(4))) f4;
-  int __attribute__((max_private_copies(8))) f5;
-  int __attribute__((singlepump)) f6;
-  int __attribute__((doublepump)) f7;
+  int f1 [[intelfpga::numbanks(4)]];
+  int f2 [[intelfpga::register]];
+  int f3 [[intelfpga::memory]];
+  int f4 [[intelfpga::bankwidth(4)]];
+  int f5 [[intelfpga::max_private_copies(8)]];
+  int f6 [[intelfpga::singlepump]];
+  int f7 [[intelfpga::doublepump]];
 };
 
 void bar() {

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -6,18 +6,11 @@ void foo1()
   //CHECK: VarDecl{{.*}}v_one
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGADoublePumpAttr
-  __attribute__((__doublepump__))
-  unsigned int v_one[64];
-
-  //CHECK: VarDecl{{.*}}v_one2
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGADoublePumpAttr
-  [[intelfpga::doublepump]] unsigned int v_one2[64];
+  [[intelfpga::doublepump]] unsigned int v_one[64];
 
   //CHECK: VarDecl{{.*}}v_two
   //CHECK: IntelFPGAMemoryAttr
-  __attribute__((__memory__))
-  unsigned int v_two[64];
+  [[intelfpga::memory]] unsigned int v_two[64];
 
   //CHECK: VarDecl{{.*}}v_two2
   //CHECK: IntelFPGAMemoryAttr{{.*}}MLAB
@@ -29,181 +22,147 @@ void foo1()
 
   //CHECK: VarDecl{{.*}}v_three
   //CHECK: IntelFPGARegisterAttr
-  __attribute__((__register__))
-  unsigned int v_three[64];
-
-  //CHECK: VarDecl{{.*}}v_three2
-  //CHECK: IntelFPGARegisterAttr
-  [[intelfpga::register]] unsigned int v_three2[32];
+  [[intelfpga::register]] unsigned int v_three[64];
 
   //CHECK: VarDecl{{.*}}v_four
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGASinglePumpAttr
-  __attribute__((__singlepump__))
-  unsigned int v_four[64];
-
-  //CHECK: VarDecl{{.*}}v_four2
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGASinglePumpAttr
-  [[intelfpga::singlepump]] unsigned int v_four2[64];
+  [[intelfpga::singlepump]] unsigned int v_four[64];
 
   //CHECK: VarDecl{{.*}}v_five
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGABankWidthAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-  __attribute__((__bankwidth__(4)))
-  unsigned int v_five[64];
-
-  //CHECK: VarDecl{{.*}}v_five2
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGABankWidthAttr
-  //CHECK-NEXT: ConstantExpr
-  //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  [[intelfpga::bankwidth(8)]] unsigned int v_five2[32];
+  [[intelfpga::bankwidth(4)]] unsigned int v_five[32];
 
   //CHECK: VarDecl{{.*}}v_six
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGANumBanksAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  __attribute__((__numbanks__(8)))
-  unsigned int v_six[64];
-
-  //CHECK: VarDecl{{.*}}v_six2
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGANumBanksAttr
-  //CHECK-NEXT: ConstantExpr
-  //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-  [[intelfpga::numbanks(4)]] unsigned int v_six2[32];
+  [[intelfpga::numbanks(8)]] unsigned int v_six[32];
 
   //CHECK: VarDecl{{.*}}v_seven
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
-  //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-  __attribute__((max_private_copies(4)))
-  unsigned int v_seven[64];
-
-  //CHECK: VarDecl{{.*}}v_seven2
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGAMaxPrivateCopiesAttr
-  //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  [[intelfpga::max_private_copies(8)]] unsigned int v_seven2[64];
+  [[intelfpga::max_private_copies(8)]] unsigned int v_seven[64];
 
   //CHECK: VarDecl{{.*}}v_fourteen
   //CHECK: IntelFPGADoublePumpAttr
   //CHECK: IntelFPGAMemoryAttr{{.*}}MLAB{{$}}
-  __attribute__((__doublepump__))
-  __attribute__((__memory__("MLAB")))
+  [[intelfpga::doublepump]]
+  [[intelfpga::memory("MLAB")]]
   unsigned int v_fourteen[64];
 
   //CHECK: VarDecl{{.*}}v_fifteen
   //CHECK: IntelFPGAMemoryAttr{{.*}}MLAB{{$}}
   //CHECK: IntelFPGADoublePumpAttr
-  __attribute__((__memory__("MLAB")))
-  __attribute__((__doublepump__))
+  [[intelfpga::memory("MLAB")]]
+  [[intelfpga::doublepump]]
   unsigned int v_fifteen[64];
 
-  int __attribute__((__register__)) A;
-  int __attribute__((__numbanks__(4), __bankwidth__(16), __singlepump__)) B;
-  int __attribute__((__numbanks__(4), __bankwidth__(16), __doublepump__)) C;
-  int __attribute__((__numbanks__(4), __bankwidth__(16))) E;
+  [[intelfpga::register]] int A;
+  [[intelfpga::numbanks(4), intelfpga::bankwidth(16), intelfpga::singlepump]] int B;
+  [[intelfpga::numbanks(4), intelfpga::bankwidth(16), intelfpga::doublepump]] int C;
+  [[intelfpga::numbanks(4), intelfpga::bankwidth(16)]] int E;
 
   // diagnostics
 
   // **doublepump
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__doublepump__))
-  __attribute__((__singlepump__))
+  [[intelfpga::doublepump]]
+  [[intelfpga::singlepump]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int dp_one[64];
 
   //expected-warning@+2{{attribute 'doublepump' is already applied}}
-  __attribute__((doublepump))
-  __attribute__((__doublepump__))
+  [[intelfpga::doublepump]]
+  [[intelfpga::doublepump]]
   unsigned int dp_two[64];
 
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__doublepump__))
-  __attribute__((__register__))
+  [[intelfpga::doublepump]]
+  [[intelfpga::register]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int dp_three[64];
 
   // **singlepump
   //expected-error@+1{{attributes are not compatible}}
-  __attribute__((__singlepump__,__doublepump__))
+  [[intelfpga::singlepump, intelfpga::doublepump]]
   //expected-note@-1 {{conflicting attribute is here}}
   unsigned int sp_one[64];
 
   //expected-warning@+2{{attribute 'singlepump' is already applied}}
-  __attribute__((singlepump))
-  __attribute__((__singlepump__))
+  [[intelfpga::singlepump]]
+  [[intelfpga::singlepump]]
   unsigned int sp_two[64];
 
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__singlepump__))
-  __attribute__((__register__))
+  [[intelfpga::singlepump]]
+  [[intelfpga::register]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int sp_three[64];
 
   // **register
   //expected-warning@+1{{attribute 'register' is already applied}}
-  __attribute__((register)) __attribute__((__register__))
+  [[intelfpga::register]] [[intelfpga::register]]
   unsigned int reg_one[64];
 
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__register__))
-  __attribute__((__singlepump__))
+  [[intelfpga::register]]
+  [[intelfpga::singlepump]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_two[64];
 
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__register__))
-  __attribute__((__doublepump__))
+  [[intelfpga::register]]
+  [[intelfpga::doublepump]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_three[64];
 
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__register__))
-  __attribute__((__memory__))
+  [[intelfpga::register]]
+  [[intelfpga::memory]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_four[64];
 
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__register__))
-  __attribute__((__bankwidth__(16)))
+  [[intelfpga::register]]
+  [[intelfpga::bankwidth(16)]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_six[64];
 
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__register__))
-  __attribute__((__max_private_copies__(16)))
+  [[intelfpga::register]]
+  [[intelfpga::max_private_copies(16)]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_six_two[64];
 
+
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__register__))
-  __attribute__((__numbanks__(8)))
+  [[intelfpga::register]]
+  [[intelfpga::numbanks(8)]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_seven[64];
 
   // **memory
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__memory__))
-  __attribute__((__register__))
+  [[intelfpga::memory]]
+  [[intelfpga::register]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int mem_one[64];
 
   //expected-warning@+1{{attribute 'memory' is already applied}}
-  __attribute__((memory)) __attribute__((__memory__))
+  [[intelfpga::memory]] [[intelfpga::memory]]
   unsigned int mem_two[64];
 
   // bankwidth
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__bankwidth__(16)))
-  __attribute__((__register__))
+  [[intelfpga::bankwidth(16)]]
+  [[intelfpga::register]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int bw_one[64];
 
@@ -215,36 +174,37 @@ void foo1()
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}16{{$}}
   //expected-warning@+2{{attribute 'bankwidth' is already applied}}
-  __attribute__((__bankwidth__(8)))
-  __attribute__((__bankwidth__(16)))
+  [[intelfpga::bankwidth(8)]]
+  [[intelfpga::bankwidth(16)]]
   unsigned int bw_two[64];
 
   //expected-error@+1{{must be a constant power of two greater than zero}}
-  __attribute__((__bankwidth__(3)))
+  [[intelfpga::bankwidth(3)]]
   unsigned int bw_three[64];
 
-  //expected-error@+1{{'bankwidth' attribute requires integer constant between 1 and 1048576 inclusive}}
-  __attribute__((__bankwidth__(-4)))
+  //expected-error@+1{{requires integer constant between 1 and 1048576}}
+  [[intelfpga::bankwidth(-4)]]
   unsigned int bw_four[64];
 
   int i_bankwidth = 32; // expected-note {{declared here}}
   //expected-error@+1{{is not an integral constant expression}}
-  __attribute__((__bankwidth__(i_bankwidth)))
+  [[intelfpga::bankwidth(i_bankwidth)]]
   //expected-note@-1{{read of non-const variable 'i_bankwidth' is not allowed in a constant expression}}
   unsigned int bw_five[64];
 
-  //expected-error@+1{{'__bankwidth__' attribute takes one argument}}
-  __attribute__((__bankwidth__(4,8)))
+  //expected-error@+1{{'bankwidth' attribute takes one argument}}
+  [[intelfpga::bankwidth(4,8)]]
   unsigned int bw_six[64];
 
-  //expected-error@+1{{'bankwidth' attribute requires integer constant between 1 and 1048576 inclusive}}
-  __attribute__((__bankwidth__(0)))
+  //expected-error@+1{{requires integer constant between 1 and 1048576}}
+  [[intelfpga::bankwidth(0)]]
   unsigned int bw_seven[64];
+
 
   // max_private_copies_
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__max_private_copies__(16)))
-  __attribute__((__register__))
+  [[intelfpga::max_private_copies(16)]]
+  [[intelfpga::register]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int mc_one[64];
 
@@ -256,28 +216,28 @@ void foo1()
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}16{{$}}
   //expected-warning@+2{{is already applied}}
-  __attribute__((__max_private_copies__(8)))
-  __attribute__((__max_private_copies__(16)))
+  [[intelfpga::max_private_copies(8)]]
+  [[intelfpga::max_private_copies(16)]]
   unsigned int mc_two[64];
 
   //expected-error@+1{{'max_private_copies' attribute requires integer constant between 0 and 1048576 inclusive}}
-  __attribute__((__max_private_copies__(-4)))
+  [[intelfpga::max_private_copies(-4)]]
   unsigned int mc_four[64];
 
   int i_max_private_copies = 32; // expected-note {{declared here}}
   //expected-error@+1{{expression is not an integral constant expression}}
-  __attribute__((__max_private_copies__(i_max_private_copies)))
+  [[intelfpga::max_private_copies(i_max_private_copies)]]
   //expected-note@-1{{read of non-const variable 'i_max_private_copies' is not allowed in a constant expression}}
   unsigned int mc_five[64];
 
-  //expected-error@+1{{'__max_private_copies__' attribute takes one argument}}
-  __attribute__((__max_private_copies__(4,8)))
+  //expected-error@+1{{'max_private_copies' attribute takes one argument}}
+  [[intelfpga::max_private_copies(4,8)]]
   unsigned int mc_six[64];
 
   // numbanks
   //expected-error@+2{{attributes are not compatible}}
-  __attribute__((__numbanks__(16)))
-  __attribute__((__register__))
+  [[intelfpga::numbanks(16)]]
+  [[intelfpga::register]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int nb_one[64];
 
@@ -289,99 +249,121 @@ void foo1()
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}16{{$}}
   //expected-warning@+2{{attribute 'numbanks' is already applied}}
-  __attribute__((__numbanks__(8)))
-  __attribute__((__numbanks__(16)))
+  [[intelfpga::numbanks(8)]]
+  [[intelfpga::numbanks(16)]]
   unsigned int nb_two[64];
 
   //expected-error@+1{{must be a constant power of two greater than zero}}
-  __attribute__((__numbanks__(15)))
+  [[intelfpga::numbanks(15)]]
   unsigned int nb_three[64];
 
-  //expected-error@+1{{attribute requires integer constant between 1 and 1048576 inclusive}}
-  __attribute__((__numbanks__(-4)))
+  //expected-error@+1{{requires integer constant between 1 and 1048576}}
+  [[intelfpga::numbanks(-4)]]
   unsigned int nb_four[64];
 
   int i_numbanks = 32; // expected-note {{declared here}}
   //expected-error@+1{{is not an integral constant expression}}
-  __attribute__((__numbanks__(i_numbanks)))
+  [[intelfpga::numbanks(i_numbanks)]]
   //expected-note@-1{{read of non-const variable 'i_numbanks' is not allowed in a constant expression}}
   unsigned int nb_five[64];
 
-  //expected-error@+1{{'__numbanks__' attribute takes one argument}}
-  __attribute__((__numbanks__(4,8)))
+  //expected-error@+1{{'numbanks' attribute takes one argument}}
+  [[intelfpga::numbanks(4,8)]]
   unsigned int nb_six[64];
 
-  //expected-error@+1{{'numbanks' attribute requires integer constant between 1 and 1048576 inclusive}}
-  __attribute__((__numbanks__(0)))
+  //expected-error@+1{{requires integer constant between 1 and 1048576}}
+  [[intelfpga::numbanks(0)]]
   unsigned int nb_seven[64];
+
+  // GNU style
+  //expected-warning@+1{{unknown attribute 'numbanks' ignored}}
+  int __attribute__((numbanks(4))) a_one;
+
+  //expected-warning@+1{{unknown attribute 'memory' ignored}}
+  unsigned int __attribute__((memory("MLAB"))) a_two;
+
+  //expected-warning@+1{{unknown attribute 'bankwidth' ignored}}
+  int __attribute__((bankwidth(8))) a_three;
+
+  //expected-warning@+1{{unknown attribute 'register' ignored}}
+  int __attribute__((register)) a_four;
+
+  //expected-warning@+1{{unknown attribute '__singlepump__' ignored}}
+  unsigned int __attribute__((__singlepump__)) a_five;
+
+  //expected-warning@+1{{unknown attribute '__doublepump__' ignored}}
+  unsigned int __attribute__((__doublepump__)) a_six;
+
+  //expected-warning@+1{{unknown attribute '__max_private_copies__' ignored}}
+  int __attribute__((__max_private_copies__(4))) a_seven;
 }
 
 //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
-__attribute__((__max_private_copies__(8)))
+[[intelfpga::max_private_copies(8)]]
 __constant unsigned int ext_two[64] = { 1, 2, 3 };
 
 void other2()
 {
   //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
-  __attribute__((__max_private_copies__(8))) const int ext_six[64] = { 0, 1 };
+  [[intelfpga::max_private_copies(8)]] const int ext_six[64] = { 0, 1 };
 }
 
 //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
-void other3(__attribute__((__max_private_copies__(8))) int pfoo) {}
+void other3([[intelfpga::max_private_copies(8)]] int pfoo) {}
 
 struct foo {
   //CHECK: FieldDecl{{.*}}v_one
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGADoublePumpAttr
-  __attribute__((__doublepump__)) unsigned int v_one[64];
+  [[intelfpga::doublepump]] unsigned int v_one[64];
 
   //CHECK: FieldDecl{{.*}}v_two
   //CHECK: IntelFPGAMemoryAttr
-  __attribute__((__memory__)) unsigned int v_two[64];
+  [[intelfpga::memory]] unsigned int v_two[64];
 
   //CHECK: FieldDecl{{.*}}v_two_A
   //CHECK: IntelFPGAMemoryAttr{{.*}}MLAB{{$}}
-  __attribute__((__memory__("MLAB"))) unsigned int v_two_A[64];
+  [[intelfpga::memory("MLAB")]] unsigned int v_two_A[64];
 
   //CHECK: FieldDecl{{.*}}v_two_B
   //CHECK: IntelFPGAMemoryAttr{{.*}}BlockRAM{{$}}
-  __attribute__((__memory__("BLOCK_RAM"))) unsigned int v_two_B[64];
+  [[intelfpga::memory("BLOCK_RAM")]] unsigned int v_two_B[64];
 
   //CHECK: FieldDecl{{.*}}v_two_C
   //CHECK: IntelFPGAMemoryAttr{{.*}}BlockRAM{{$}}
   //CHECK: IntelFPGADoublePumpAttr
-  __attribute__((__memory__("BLOCK_RAM")))
-  __attribute__((doublepump)) unsigned int v_two_C[64];
+  [[intelfpga::memory("BLOCK_RAM")]]
+  [[intelfpga::doublepump]] unsigned int v_two_C[64];
 
   //CHECK: FieldDecl{{.*}}v_three
   //CHECK: IntelFPGARegisterAttr
-  __attribute__((__register__)) unsigned int v_three[64];
+  [[intelfpga::register]] unsigned int v_three[64];
 
   //CHECK: FieldDecl{{.*}}v_four
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGASinglePumpAttr
-  __attribute__((__singlepump__)) unsigned int v_four[64];
+  [[intelfpga::singlepump]] unsigned int v_four[64];
 
   //CHECK: FieldDecl{{.*}}v_five
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGABankWidthAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-  __attribute__((__bankwidth__(4))) unsigned int v_five[64];
+  [[intelfpga::bankwidth(4)]] unsigned int v_five[64];
 
   //CHECK: FieldDecl{{.*}}v_six
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGANumBanksAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  __attribute__((__numbanks__(8))) unsigned int v_six[64];
+  [[intelfpga::numbanks(8)]] unsigned int v_six[64];
 
   //CHECK: FieldDecl{{.*}}v_seven
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-  __attribute__((__max_private_copies__(4))) unsigned int v_seven[64];
+  [[intelfpga::max_private_copies(4)]] unsigned int v_seven[64];
 };
 
 template <typename name, typename Func>


### PR DESCRIPTION
This patch solves the potential naming conflict with other vendors attributes.

Signed-off-by: Viktoria Maksimova <viktoria.maksimova@intel.com>