### PR TITLE
[SYCL] Add Windows support for device_info

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -5,6 +5,7 @@ project(sycl-solution)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 if(MSVC)
   set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -135,6 +136,7 @@ add_library("${SYCLLibrary}" SHARED
   "${sourceRootPath}/detail/program_manager/program_manager.cpp"
   "${sourceRootPath}/detail/queue_impl.cpp"
   "${sourceRootPath}/detail/os_util.cpp"
+  "${sourceRootPath}/detail/platform_util.cpp"
   "${sourceRootPath}/detail/sampler_impl.cpp"
   "${sourceRootPath}/detail/scheduler/commands.cpp"
   "${sourceRootPath}/detail/scheduler/commands2.cpp"

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -42,7 +42,7 @@ class accessor;
 template <typename T, int dimensions, typename AllocatorT> class buffer;
 class handler;
 class queue;
-template <int dimentions> class id;
+template <int dimentions> struct id;
 template <int dimentions> class range;
 using buffer_allocator = aligned_allocator<char, /*alignment*/ 64>;
 namespace detail {

--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -19,10 +19,10 @@ namespace cl {
 namespace sycl {
 class context;
 class event;
-template <int dimensions, bool with_offset> class item;
+template <int dimensions, bool with_offset> struct item;
 template <int dimensions> class group;
 template <int dimensions> class range;
-template <int dimensions> class id;
+template <int dimensions> struct id;
 template <int dimensions> class nd_item;
 namespace detail {
 class context_impl;

--- a/sycl/include/CL/sycl/detail/os_util.hpp
+++ b/sycl/include/CL/sycl/detail/os_util.hpp
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <stdlib.h>
+
 #ifdef _WIN32
 #define SYCL_RT_OS_WINDOWS
 // Windows platform
@@ -48,6 +50,9 @@ public:
   /// Module handle for the executable module - it is assumed there is always
   /// single one at most.
   static const OSModuleHandle ExeModuleHandle;
+
+  /// Returns the amount of RAM available for the operating system.
+  static size_t getOSMemSize();
 };
 
 } // namespace detail

--- a/sycl/include/CL/sycl/detail/platform_util.hpp
+++ b/sycl/include/CL/sycl/detail/platform_util.hpp
@@ -1,0 +1,40 @@
+//===-- platform_util.hpp - platform utilities ----------------*- C++ -*--===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstdint>
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+struct PlatformUtil {
+  enum class TypeIndex : unsigned int {
+    Char = 0,
+    Short = 1,
+    Int = 2,
+    Long = 3,
+    Float = 4,
+    Double = 5,
+    Half = 6
+  };
+
+  /// Returns the maximum vector width counted in elements of the given type.
+  static uint32_t getNativeVectorWidth(TypeIndex Index);
+
+  static uint32_t getMaxClockFrequency();
+
+  static uint32_t getMemCacheLineSize();
+
+  static uint64_t getMemCacheSize();
+};
+
+} // namespace detail
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -19,7 +19,7 @@
 namespace cl {
 namespace sycl {
 namespace detail {
-class Builder;
+struct Builder;
 } // namespace detail
 
 template <int dimensions = 1> class group {

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -16,8 +16,9 @@ namespace cl {
 namespace sycl {
 template <int dimensions> class range;
 template <int dimensions = 1> struct id : public detail::array<dimensions> {
-public:
+private:
   using base = detail::array<dimensions>;
+public:
   id() = default;
 
   /* The following constructor is only available in the id struct

--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -16,10 +16,10 @@
 namespace cl {
 namespace sycl {
 namespace detail {
-class Builder;
+struct Builder;
 }
 template <int dimensions> struct id;
-template <int dimensions> struct range;
+template <int dimensions> class range;
 template <int dimensions = 1, bool with_offset = true> struct item {
 
   item() = delete;
@@ -86,8 +86,9 @@ template <int dimensions = 1, bool with_offset = true> struct item {
 
 protected:
   // For call constructor inside conversion operator
-  friend class item<dimensions, false>;
-  friend class detail::Builder;
+  friend struct item<dimensions, false>;
+  friend struct item<dimensions, true>;
+  friend struct detail::Builder;
 
   template <size_t W = with_offset>
   item(typename std::enable_if<(W == true), const range<dimensions>>::type &R,

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -22,7 +22,7 @@
 namespace cl {
 namespace sycl {
 namespace detail {
-class Builder;
+struct Builder;
 }
 template <int dimensions = 1> struct nd_item {
 

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -16,8 +16,8 @@ namespace sycl {
 template <int dimensions> struct id;
 template <int dimensions = 1>
 class range : public detail::array<dimensions> {
-public:
   using base = detail::array<dimensions>;
+public:
   /* The following constructor is only available in the range class
   specialization where: dimensions==1 */
   template <int N = dimensions>

--- a/sycl/source/detail/platform_util.cpp
+++ b/sycl/source/detail/platform_util.cpp
@@ -1,0 +1,125 @@
+//===-- platform_util.cpp - Platform utilities implementation --*- C++ -*--===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl/detail/os_util.hpp>
+#include <CL/sycl/detail/platform_util.hpp>
+#include <CL/sycl/exception.hpp>
+
+#if defined(SYCL_RT_OS_LINUX)
+#include <cpuid.h>
+#elif defined(SYCL_RT_OS_WINDOWS)
+#include <intrin.h>
+#endif
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+// Used by methods that duplicate OpenCL behaviour in order to get CPU info
+static void cpuid(uint32_t *CPUInfo, uint32_t Type, uint32_t SubType = 0) {
+#if defined(SYCL_RT_OS_LINUX)
+  __cpuid_count(Type, SubType, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+#elif defined(SYCL_RT_OS_WINDOWS)
+  __cpuidex(reinterpret_cast<int *>(CPUInfo), Type, SubType);
+#endif
+}
+
+uint32_t PlatformUtil::getMaxClockFrequency() {
+  throw runtime_error(
+      "max_clock_frequency parameter is not supported for host device");
+  uint32_t CPUInfo[4];
+  string_class Buff(sizeof(CPUInfo) * 3 + 1, 0);
+  size_t Offset = 0;
+
+  for (uint32_t i = 0x80000002; i <= 0x80000004; i++) {
+    cpuid(CPUInfo, i);
+    std::copy(reinterpret_cast<char *>(CPUInfo),
+              reinterpret_cast<char *>(CPUInfo) + sizeof(CPUInfo),
+              Buff.begin() + Offset);
+    Offset += sizeof(CPUInfo);
+  }
+  std::size_t Found = Buff.rfind("Hz");
+  // Bail out if frequency is not found in CPUID string
+  if (Found == std::string::npos)
+    return 0;
+
+  Buff = Buff.substr(0, Found);
+  uint32_t Freq = 0;
+  switch (Buff[Buff.size() - 1]) {
+  case 'M':
+    Freq = 1;
+    break;
+  case 'G':
+    Freq = 1000;
+    break;
+  }
+  Buff = Buff.substr(Buff.rfind(' '), Buff.length());
+  Freq *= std::stod(Buff);
+  return Freq;
+}
+
+uint32_t PlatformUtil::getMemCacheLineSize() {
+  uint32_t CPUInfo[4];
+  cpuid(CPUInfo, 0x80000006);
+  return CPUInfo[2] & 0xff;
+}
+
+uint64_t PlatformUtil::getMemCacheSize() {
+  uint32_t CPUInfo[4];
+  cpuid(CPUInfo, 0x80000006);
+  return static_cast<uint64_t>(CPUInfo[2] >> 16) * 1024;
+}
+
+uint32_t PlatformUtil::getNativeVectorWidth(PlatformUtil::TypeIndex TIndex) {
+  // SSE4.2 has 16 byte (XMM) registers
+  static constexpr uint32_t VECTOR_WIDTH_SSE42[] = {16, 8, 4, 2, 4, 2, 0};
+  // AVX supports 32 byte (YMM) registers only for floats and doubles
+  static constexpr uint32_t VECTOR_WIDTH_AVX[] = {16, 8, 4, 2, 8, 4, 0};
+  // AVX2 has a full set of 32 byte (YMM) registers
+  static constexpr uint32_t VECTOR_WIDTH_AVX2[] = {32, 16, 8, 4, 8, 4, 0};
+  // AVX512 has 64 byte (ZMM) registers
+  static constexpr uint32_t VECTOR_WIDTH_AVX512[] = {64, 32, 16, 8, 16, 8, 0};
+
+  uint32_t Index = static_cast<uint32_t>(TIndex);
+
+#if defined(SYCL_RT_OS_LINUX)
+  if (__builtin_cpu_supports("avx512f"))
+    return VECTOR_WIDTH_AVX512[Index];
+  if (__builtin_cpu_supports("avx2"))
+    return VECTOR_WIDTH_AVX2[Index];
+  if (__builtin_cpu_supports("avx"))
+    return VECTOR_WIDTH_AVX[Index];
+#elif defined(SYCL_RT_OS_WINDOWS)
+
+  uint32_t Info[4];
+
+  // Check that CPUID func number 7 is available.
+  cpuid(Info, 0);
+  if (Info[0] >= 7) {
+    // avx512f = CPUID.7.EBX[16]
+    cpuid(Info, 7);
+    if (Info[1] & (1 << 16))
+      return VECTOR_WIDTH_AVX512[Index];
+
+    // avx2 = CPUID.7.EBX[5]
+    if (Info[1] & (1 << 5))
+      return VECTOR_WIDTH_AVX2[Index];
+  }
+  // It is assumed that CPUID func number 1 is always available.
+  // avx = CPUID.1.ECX[28]
+  cpuid(Info, 1);
+  if (Info[2] & (1 << 28))
+    return VECTOR_WIDTH_AVX[Index];
+#endif
+
+  return VECTOR_WIDTH_SSE42[Index];
+}
+
+} // namespace detail
+} // namespace sycl
+} // namespace cl


### PR DESCRIPTION
Fixed few warnings caused by inconsistent usage of class and struct keywords.
Added a macro to expose global symbols and generate sycl.lib on Windows.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>