### PR TITLE
[SYCL] Fix bug with not found alloca command.

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -379,18 +379,21 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
         break;
       }
     AllocaCommand *AllocaCmd = findAllocaForReq(Record, Req, Queue);
-    UpdateLeafs(Deps, Record, Req);
 
     for (Command *Dep : Deps) {
       NewCmd->addDep(DepDesc{Dep, Req, AllocaCmd});
-      Dep->addUser(NewCmd.get());
     }
   }
 
-  for (Requirement *Req : Reqs) {
+  // Set new command as user for dependencies and update leafs.
+  for (DepDesc &Dep : NewCmd->MDeps) {
+    Dep.MDepCommand->addUser(NewCmd.get());
+    Requirement *Req = Dep.MReq;
     MemObjRecord *Record = getMemObjRecord(Req->MSYCLMemObj);
+    UpdateLeafs({Dep.MDepCommand}, Record, Req);
     AddNodeToLeafs(Record, NewCmd.get(), Req);
   }
+
   return NewCmd.release();
 }
 


### PR DESCRIPTION
Fix bug with not found alloca in case of two accessors are created for
the same memory object. The problem is that during searching for
dependencies for the first accessor list of leaf command is modified so
it doesn't contain commands that are considered as dependencies. As a
result search for dependencies for the second accessor fails.
The fix is to update list of leafs after dependencies for all accessors
are found.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>