### PR TITLE
[SYCL] Fix check of CL_TARGET_OPENCL_VERSION macro value.

### DIFF
--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -46,7 +46,7 @@ cl_sampler sampler_impl::getOrCreateSampler(const context &Context) {
   if (m_contextToSampler[Context])
     return m_contextToSampler[Context];
 
-#ifdef CL_TARGET_OPENCL_VERSION > 120
+#if CL_TARGET_OPENCL_VERSION > 120
   const cl_sampler_properties sprops[] = {
       CL_SAMPLER_NORMALIZED_COORDS,
       static_cast<cl_sampler_properties>(m_CoordNormMode),


### PR DESCRIPTION
ifdef checks if CL_TARGET_OPENCL_VERSION is defined or not and ignores
the rest of the expression checking exact value.