### PR TITLE
[WIP] [SYCL] Move static const variables to constant address space

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3396,6 +3396,13 @@ LangAS CodeGenModule::GetGlobalVarAddressSpace(const VarDecl *D) {
     return AddrSpace;
   }
 
+  if (LangOpts.SYCLIsDevice) {
+    if (D && D->getType().isConstQualified())
+      return LangAS::opencl_constant;
+
+    return LangAS::opencl_global;
+  }
+
   if (LangOpts.CUDA && LangOpts.CUDAIsDevice) {
     if (D && D->hasAttr<CUDAConstantAttr>())
       return LangAS::cuda_constant;

--- a/clang/test/CodeGenSYCL/address-space-new.cpp
+++ b/clang/test/CodeGenSYCL/address-space-new.cpp
@@ -3,11 +3,17 @@
 
 
 void test() {
+  static const int foo = 0x42;
+  // CHECK-DEFAULT: @_ZZ4testvE3foo = internal addrspace(2) constant i32 66, align 4
+  // CHECK-NEW:     @_ZZ4testvE3foo = internal addrspace(2) constant i32 66, align 4
+
   int i = 0;
   int *pptr = &i;
   // CHECK-DEFAULT: store i32* %i, i32** %pptr
   // CHECK-NEW: %[[GEN:[0-9]+]] = addrspacecast i32* %i to i32 addrspace(4)*
   // CHECK-NEW: store i32 addrspace(4)* %[[GEN]], i32 addrspace(4)** %pptr
+
+  *pptr = foo;
 }
 
 


### PR DESCRIPTION
Previously when ENASBLE_INFER_AS is enabled (see: 1a3a53691d [SYCL]
Optionally override addrspace map for SYCL device code), static
variables were put into generic address space.

Now, if a static variable has a const qualifier, it will go to
constant address space.

Non-const variables with static storage are not supported by the SYCL
1.2.1 specification (see s6.3 "Language restrictions for kernels"),
but this patch handles this case as well by putting such variables
into global address space (we cannot do anything better in CodeGen
anyway).

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>