### PR TITLE
[SYCL] Fix several errors in accessor

### DIFF
--- a/sycl/include/CL/sycl/detail/array.hpp
+++ b/sycl/include/CL/sycl/detail/array.hpp
@@ -19,6 +19,7 @@ template <int dimensions> class range;
 namespace detail {
 
 template <int dimensions = 1> class array {
+  static_assert(dimensions >= 1, "Array cannot be 0-dimensional.");
 public:
   array() : common_array{0} {}
 

--- a/sycl/include/CL/sycl/handler2.hpp
+++ b/sycl/include/CL/sycl/handler2.hpp
@@ -234,11 +234,11 @@ private:
 
           MArgs.emplace_back(
               detail::ArgDesc(detail::kernel_param_kind_t::kind_std_layout,
-                              &(AccImpl->MRange[0]),
+                              &(AccImpl->MAccessRange[0]),
                               sizeof(size_t) * AccImpl->MDims, NextArgId + 1));
           MArgs.emplace_back(
               detail::ArgDesc(detail::kernel_param_kind_t::kind_std_layout,
-                              &AccImpl->MOrigRange[0],
+                              &AccImpl->MMemoryRange[0],
                               sizeof(size_t) * AccImpl->MDims, NextArgId + 2));
           MArgs.emplace_back(
               detail::ArgDesc(detail::kernel_param_kind_t::kind_std_layout,

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -18,6 +18,8 @@ template <int dimensions> class range;
 template <int dimensions = 1> struct id : public detail::array<dimensions> {
 private:
   using base = detail::array<dimensions>;
+  static_assert(dimensions >= 1 && dimensions <= 3,
+                "id can only be 1, 2, or 3 dimentional.");
 public:
   id() = default;
 

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -16,6 +16,8 @@ namespace sycl {
 template <int dimensions> struct id;
 template <int dimensions = 1>
 class range : public detail::array<dimensions> {
+  static_assert(dimensions >= 1 && dimensions <= 3,
+                "range can only be 1, 2, or 3 dimentional.");
   using base = detail::array<dimensions>;
 public:
   /* The following constructor is only available in the range class

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -53,9 +53,9 @@ Scheduler::GraphBuilder::getOrInsertMemObjRecord(const QueueImplPtr &Queue,
 
   // Construct requirement which describes full buffer because we allocate
   // only full-sized memory objects.
-  Requirement AllocaReq(/*Offset*/ {0, 0, 0}, Req->MOrigRange, Req->MOrigRange,
-                        access::mode::discard_write, MemObject, Req->MDims,
-                        Req->MElemSize);
+  Requirement AllocaReq(/*Offset*/ {0, 0, 0}, Req->MMemoryRange,
+                        Req->MMemoryRange, access::mode::discard_write,
+                        MemObject, Req->MDims, Req->MElemSize);
 
   AllocaCommand *AllocaCmd = new AllocaCommand(Queue, std::move(AllocaReq));
   MemObjRecord NewRecord{MemObject,
@@ -101,9 +101,9 @@ MemCpyCommand *
 Scheduler::GraphBuilder::insertMemCpyCmd(MemObjRecord *Record, Requirement *Req,
                                          const QueueImplPtr &Queue) {
 
-  Requirement FullReq(/*Offset*/ {0, 0, 0}, Req->MOrigRange, Req->MOrigRange,
-                      access::mode::read_write, Req->MSYCLMemObj, Req->MDims,
-                      Req->MElemSize);
+  Requirement FullReq(/*Offset*/ {0, 0, 0}, Req->MMemoryRange,
+                      Req->MMemoryRange, access::mode::read_write,
+                      Req->MSYCLMemObj, Req->MDims, Req->MElemSize);
 
   std::set<Command *> Deps = findDepsForReq(Record, &FullReq, Queue);
   QueueImplPtr SrcQueue = (*Deps.begin())->getQueue();
@@ -207,7 +207,7 @@ Command *Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
   // In case of memory is 1 dimensional and located on OpenCL device we
   // can use map/unmap operation.
   if (!SrcQueue->is_host() && Req->MDims == 1 &&
-      Req->MRange == Req->MOrigRange) {
+      Req->MAccessRange == Req->MMemoryRange) {
 
     std::unique_ptr<MapMemObject> MapCmdUniquePtr(
         new MapMemObject(*SrcReq, SrcAllocaCmd, Req, SrcQueue));


### PR DESCRIPTION
This patch fixes 2 constructors, fixes get_count() and get_size() methods,
adds operator== and operator!=, fixes hash implementation,
adds static_asssert to range and id classes to have early check for wrong
dimension, fixes few other errors.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>