### PR TITLE
[SYCL] Fix conversions in multi_ptr class.

### DIFF
--- a/sycl/include/CL/sycl/multi_ptr.hpp
+++ b/sycl/include/CL/sycl/multi_ptr.hpp
@@ -42,8 +42,7 @@ public:
   multi_ptr(multi_ptr &&) = default;
   multi_ptr(pointer_t pointer) : m_Pointer(pointer) {}
 #ifdef __SYCL_DEVICE_ONLY__
-  multi_ptr(ElementType *pointer)
-      : m_Pointer((pointer_t)(pointer)) {
+  multi_ptr(ElementType *pointer) : m_Pointer((pointer_t)(pointer)) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
   }
@@ -62,7 +61,7 @@ public:
   multi_ptr &operator=(ElementType *pointer) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
-    m_Pointer = reinterpret_cast<pointer_t>(pointer);
+    m_Pointer = (pointer_t)pointer;
     return *this;
   }
 #endif
@@ -93,7 +92,7 @@ public:
   multi_ptr(accessor<ElementType, dimensions, Mode,
                      access::target::global_buffer, isPlaceholder>
                 Accessor) {
-    m_Pointer = reinterpret_cast<pointer_t>(Accessor.get_pointer().m_Pointer);
+    m_Pointer = (pointer_t)(Accessor.get_pointer().m_Pointer);
   }
 
   // Only if Space == local_space
@@ -287,7 +286,7 @@ public:
   multi_ptr(multi_ptr &&) = default;
   multi_ptr(pointer_t pointer) : m_Pointer(pointer) {}
 #ifdef __SYCL_DEVICE_ONLY__
-  multi_ptr(void *pointer) : m_Pointer(reinterpret_cast<pointer_t>(pointer)) {
+  multi_ptr(void *pointer) : m_Pointer((pointer_t)pointer) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
   }
@@ -313,7 +312,7 @@ public:
   multi_ptr &operator=(void *pointer) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
-    m_Pointer = reinterpret_cast<pointer_t>(pointer);
+    m_Pointer = (pointer_t)pointer;
     return *this;
   }
 #endif
@@ -403,8 +402,7 @@ public:
   multi_ptr(multi_ptr &&) = default;
   multi_ptr(pointer_t pointer) : m_Pointer(pointer) {}
 #ifdef __SYCL_DEVICE_ONLY__
-  multi_ptr(const void *pointer)
-      : m_Pointer(reinterpret_cast<pointer_t>(pointer)) {
+  multi_ptr(const void *pointer) : m_Pointer((pointer_t)pointer) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
   }
@@ -430,7 +428,7 @@ public:
   multi_ptr &operator=(const void *pointer) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
-    m_Pointer = reinterpret_cast<pointer_t>(pointer);
+    m_Pointer = (pointer_t)pointer;
     return *this;
   }
 #endif

--- a/sycl/test/multi_ptr/multi_ptr.cpp
+++ b/sycl/test/multi_ptr/multi_ptr.cpp
@@ -77,6 +77,16 @@ template <typename T> void testMultPtr() {
         auto local_ptr = make_ptr<T, access::address_space::local_space>(
           localAccessor.get_pointer());
 
+        T *RawPtr = nullptr;
+        global_ptr<T> ptr_4(RawPtr);
+        ptr_4 = RawPtr;
+
+        global_ptr<T> ptr_5(accessorData_1);
+
+        global_ptr<void> ptr_6((void *)RawPtr);
+
+        ptr_6 = (void *)RawPtr;
+
         innerFunc<T>(wiID.get(0), ptr_1, ptr_2, local_ptr);
       });
     });


### PR DESCRIPTION
Clang doesn't allow casting address spaces using reinterpret_cast.
Replaced with C-style cast.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>