### PR TITLE
[SYCL] Enable OpenCL diagnostics for sampler in SYCL mode

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -13046,7 +13046,7 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
   bool CanOverflow = false;
 
   bool ConvertHalfVec = false;
-  if (getLangOpts().OpenCL) {
+  if (getLangOpts().OpenCL || getLangOpts().SYCLIsDevice) {
     QualType Ty = InputExpr->getType();
     // The only legal unary operation for atomics is '&'.
     if ((Opc != UO_AddrOf && Ty->isAtomicType()) ||

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -5319,9 +5319,9 @@ static bool TryOCLSamplerInitialization(Sema &S,
                                         InitializationSequence &Sequence,
                                         QualType DestType,
                                         Expr *Initializer) {
-  if (!S.getLangOpts().OpenCL || !DestType->isSamplerT() ||
+  if (!DestType->isSamplerT() ||
       (!Initializer->isIntegerConstantExpr(S.Context) &&
-      !Initializer->getType()->isSamplerT()))
+       !Initializer->getType()->isSamplerT()))
     return false;
 
   Sequence.AddOCLSamplerInitStep(DestType);
@@ -5634,6 +5634,9 @@ void InitializationSequence::InitializeFrom(Sema &S,
   bool allowObjCWritebackConversion = S.getLangOpts().ObjCAutoRefCount &&
          Entity.isParameterKind();
 
+  if (TryOCLSamplerInitialization(S, *this, DestType, Initializer))
+    return;
+
   // We're at the end of the line for C: it's either a write-back conversion
   // or it's a C assignment. There's no need to check anything else.
   if (!S.getLangOpts().CPlusPlus) {
@@ -5642,9 +5645,6 @@ void InitializationSequence::InitializeFrom(Sema &S,
         tryObjCWritebackConversion(S, *this, Entity, Initializer)) {
       return;
     }
-
-    if (TryOCLSamplerInitialization(S, *this, DestType, Initializer))
-      return;
 
     if (TryOCLZeroOpaqueTypeInitialization(S, *this, DestType, Initializer))
       return;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -809,7 +809,6 @@ static void buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
       assert(InitMethod && "sampler must have __init method");
 
       // sampler __init method has only one parameter
-      // void __init(__ocl_sampler_t *Sampler)
       auto *FuncDecl = cast<FunctionDecl>(InitMethod);
       ParmVarDecl *SamplerArg = FuncDecl->getParamDecl(0);
       assert(SamplerArg && "sampler __init method must have sampler parameter");
@@ -912,7 +911,6 @@ static void populateIntHeader(SYCLIntegrationHeader &H, const StringRef Name,
       assert(InitMethod && "sampler must have __init method");
 
       // sampler __init method has only one argument
-      // void __init(__ocl_sampler_t *Sampler)
       auto *FuncDecl = cast<FunctionDecl>(InitMethod);
       ParmVarDecl *SamplerArg = FuncDecl->getParamDecl(0);
       assert(SamplerArg && "sampler __init method must have sampler parameter");

--- a/sycl/doc/SYCL_compiler_and_runtime_design.md
+++ b/sycl/doc/SYCL_compiler_and_runtime_design.md
@@ -291,17 +291,28 @@ produced by OpenCL C front-end compiler.
 It's a regular function, which can conflict with user code produced from C++
 source.
 
-
-SYCL compiler uses solution developed for OpenCL C++ compiler prototype:
+SYCL compiler uses modified solution developed for OpenCL C++ compiler
+prototype:
 
 - Compiler: https://github.com/KhronosGroup/SPIR/tree/spirv-1.1
 - Headers: https://github.com/KhronosGroup/libclcxx
 
-SPIR-V types and operations that do not have LLVM equivalents are **declared**
+Our solution re-uses OpenCL data types like sampler, event, image types, etc,
+but we use different spelling to avoid potential conflicts with C++ code.
+Spelling convention for the OpenCL types enabled in SYCL mode is:
+
+```
+__ocl_<OpenCL_type_name> // e.g. __ocl_sampler_t, __ocl_event_t
+```
+
+Operations using OpenCL types use special naming convention described in this
+[document](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/master/docs/SPIRVRepresentationInLLVM.rst).
+This solution allows us avoid SYCL specialization in SPIR-V translator and
+leverage clang infrastructure developed for OpenCL types.
+
+SPIR-V operations that do not have LLVM equivalents are **declared**
 (but not defined) in the headers and satisfy following requirements:
 
-- the type must be pre-declared as a C++ class in `cl::__spirv` namespace
-- the type must not have actual definition in C++ program
 - the operation is expressed in C++ as `extern` function not throwing C++
   exceptions
 - the operation must not have the actual definition in C++ program
@@ -310,41 +321,16 @@ For example, the following C++ code is successfully recognized and translated
 into SPIR-V operation `OpGroupAsyncCopy`:
 
 ```C++
-namespace cl {
-  namespace __spirv {
-  // This class does not have definition, it is only predeclared here.
-  // The pointers to this class objects can be passed to or returned from
-  // SPIR-V built-in functions. Only in such cases the class is recognized
-  // as SPIR-V type OpTypeEvent.
-  class OpTypeEvent;
+template <typename dataT>
+extern __ocl_event_t
+__spirv_OpGroupAsyncCopy(int32_t Scope, __local dataT *Dest,
+                         __global dataT *Src, size_t NumElements,
+                         size_t Stride, __ocl_event_t E) noexcept;
 
-  template <typename dataT>
-  extern OpTypeEvent *OpGroupAsyncCopy(int32_t Scope, __local dataT *Dest,
-                                       __global dataT *Src, size_t NumElements,
-                                       size_t Stride, OpTypeEvent *E) noexcept;
-  } // namespace __spirv
-} // namespace cl
-
-cl::__spirv::OpTypeEvent *e =
-    cl::__spirv::OpGroupAsyncCopy<dataT>(cl::__spirv::Scope::Workgroup,
-                                         dst, src, numElements, 1, 0);
+__ocl_event_t e =
+  __spirv_OpGroupAsyncCopy(cl::__spirv::Scope::Workgroup,
+                           dst, src, numElements, 1, E);
 ```
-
-OpenCL C++ compiler uses a special module pass in clang that transforms the
-names of C++ classes, globals and functions from the namespace `cl::__spirv::`
-to
-["SPIR-V representation in LLVM IR"](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/master/docs/SPIRVRepresentationInLLVM.rst)
-which is recognized by the LLVM IR to SPIR-V translator.
-
-In the OpenCL C++ prototype project the pass is located at the directory:
-`lib/CodeGen/OclCxxRewrite`.  The file with the pass is:
-`lib/CodeGen/OclCxxRewrite/BifNameReflower.cpp`.  The other files in
-`lib/CodeGen/OclCxxRewrite` are utility files implementing Itanium demangler
-and other helping functionality.
-
-That LLVM module pass has been ported from OpenCL C++ prototype to the SYCL
-compiler as is. It made possible using simple declarations of C++ classes and
-external functions as if they were the SPIR-V specific types and operations.
 
 #### Some details and agreements on using SPIR-V special types and operations
 


### PR DESCRIPTION
Selectively enabled a few OpenCL diagnostics for sampler type as some
diagnostics trigger on SYCL use cases.

For instance, OpenCL kernel in SYCL mode initializes lambda captures with
the kernel argument values. This initialization code for sampler emits
errors because OpenCL disallows sampler on the right hand side of the
binary operators - these are supposed to be used only by built-in
functions.

Another potential issue is the lambda object itself -
captured sampler is a member of the lambda object and OpenCL doesn't
allow composite types with samplers. SPIR-V produced from SYCL should be
okay as lambda object can be removed by standard LLVM transformation
passes.