### PR TITLE
[SYCL][NFC] Remove dead code

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -685,34 +685,6 @@ static target getAccessTarget(const ClassTemplateSpecializationDecl *AccTy) {
       AccTy->getTemplateArgs()[3].getAsIntegral().getExtValue());
 }
 
-///
-static FieldDecl *getFieldDeclByName(const CXXRecordDecl *RD,
-                                     const ArrayRef<StringRef> FldExpr,
-                                     uint64_t *Offset = nullptr) {
-
-  FieldDecl *Res = nullptr;
-
-  for (const auto FldName : FldExpr) {
-    Res = nullptr;
-    assert(RD && "field lookup in non-struct type");
-
-    for (FieldDecl *Fld : RD->fields()) {
-      if (Fld->getNameAsString() == FldName) {
-        if (Offset) {
-          const ASTRecordLayout &LO =
-              RD->getASTContext().getASTRecordLayout(RD);
-          *Offset += LO.getFieldOffset(Fld->getFieldIndex()) / 8;
-        }
-        RD = Fld->getType()->getAsCXXRecordDecl();
-        Res = Fld;
-        break;
-      }
-    }
-    assert(Res && "field declaration must have been found");
-  }
-  return Res;
-}
-
 static void buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
                         SmallVectorImpl<ParamDesc> &ParamDescs) {
   const LambdaCapture *Cpt = KernelObj->captures_begin();


### PR DESCRIPTION
Clean-up after 8a95712bcc9a2a6d34ce66b6b5948c24204fa846.

    [SYCL] Get sampler and accessor types without using named fields of kernel
    object

    Using the types of the parameter variables of __init method instead