### PR TITLE
[SYCL] Disable event_profiling_info.cpp on host device.

### DIFF
--- a/sycl/test/basic_tests/event_profiling_info.cpp
+++ b/sycl/test/basic_tests/event_profiling_info.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang -std=c++11 -fsycl %s -o %t.out -lstdc++ -lOpenCL -lsycl
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+//
+// Profiling info is not supported on host device so far.
+//
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Get profiling info is not supported on host device.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>