### PR TITLE
[SYCL] Add support for info::device::sub_group_sizes

### DIFF
--- a/sycl/include/CL/sycl/detail/device_info.hpp
+++ b/sycl/include/CL/sycl/detail/device_info.hpp
@@ -265,6 +265,24 @@ struct get_device_info_cl<T, info::device::parent_device> {
   }
 };
 
+// Specialization for supported subgroup sizes
+template <>
+struct get_device_info_cl<vector_class<size_t>,
+                          info::device::sub_group_sizes> {
+  static vector_class<size_t> _(cl_device_id dev) {
+    size_t resultSize = 0;
+    CHECK_OCL_CODE(
+        clGetDeviceInfo(dev, (cl_device_info)info::device::sub_group_sizes,
+                        0, nullptr, &resultSize));
+    vector_class<size_t> result(resultSize);
+    CHECK_OCL_CODE(
+        clGetDeviceInfo(dev, (cl_device_info)info::device::sub_group_sizes,
+                        resultSize, result.data(), nullptr));
+    return result;
+  }
+};
+
+
 // SYCL host device information
 
 // Default template is disabled, all possible instantiations are
@@ -470,6 +488,9 @@ get_device_info_host<info::device::partition_type_affinity_domain>();
 template <> cl_uint get_device_info_host<info::device::reference_count>();
 
 template <> cl_uint get_device_info_host<info::device::max_num_sub_groups>();
+
+template <>
+vector_class<size_t> get_device_info_host<info::device::sub_group_sizes>();
 
 template <>
 bool get_device_info_host<

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -118,6 +118,7 @@ enum class device : cl_device_info {
   max_num_sub_groups = CL_DEVICE_MAX_NUM_SUB_GROUPS,
   sub_group_independent_forward_progress =
       CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS,
+  sub_group_sizes = CL_DEVICE_SUB_GROUP_SIZES_INTEL,
   partition_type_property
 };
 
@@ -323,6 +324,7 @@ PARAM_TRAITS_SPEC(device, partition_type_affinity_domain,
 PARAM_TRAITS_SPEC(device, reference_count, cl_uint)
 PARAM_TRAITS_SPEC(device, max_num_sub_groups, cl_uint)
 PARAM_TRAITS_SPEC(device, sub_group_independent_forward_progress, bool)
+PARAM_TRAITS_SPEC(device, sub_group_sizes, vector_class<size_t>)
 
 PARAM_TRAITS_SPEC(context, reference_count, cl_uint)
 PARAM_TRAITS_SPEC(context, platform, cl::sycl::platform)

--- a/sycl/source/detail/device_info.cpp
+++ b/sycl/source/detail/device_info.cpp
@@ -466,6 +466,12 @@ template <> cl_uint get_device_info_host<info::device::max_num_sub_groups>() {
   throw runtime_error("Sub-group feature is not supported on HOST device.");
 }
 
+template <> vector_class<size_t>
+get_device_info_host<info::device::sub_group_sizes>() {
+  // TODO update once subgroups are enabled
+  throw runtime_error("Sub-group feature is not supported on HOST device.");
+}
+
 template <>
 bool get_device_info_host<
     info::device::sub_group_independent_forward_progress>() {

--- a/sycl/test/sub_group/info.cpp
+++ b/sycl/test/sub_group/info.cpp
@@ -28,18 +28,38 @@ int main() {
       return 1;
     } catch (runtime_error e) {
       /* Expected exception. */
-      try {
-        Device.get_info<info::device::sub_group_independent_forward_progress>();
-        std::cout << "Expected exception has not been generated\n";
-        return 1;
-      } catch (runtime_error e) {
-        /* Expected exception - do nothing. */
-      }
     }
-
+    try {
+      Device.get_info<info::device::sub_group_independent_forward_progress>();
+      std::cout << "Expected exception has not been generated\n";
+      return 1;
+    } catch (runtime_error e) {
+      /* Expected exception. */
+    }
+    try {
+      Device.get_info<info::device::sub_group_sizes>();
+      std::cout << "Expected exception has not been generated\n";
+      return 1;
+    } catch (runtime_error e) {
+       /* Expected exception. */
+    }
   } else {
     Device.get_info<info::device::sub_group_independent_forward_progress>();
     Device.get_info<info::device::max_num_sub_groups>();
+    // There is no support on CPU and accelerator devices for now.
+    if ( Device.get_info<info::device::device_type>() == info::device_type::cpu ||
+         Device.get_info<info::device::device_type>() == 
+             info::device_type::accelerator) {
+      try {
+        Device.get_info<info::device::sub_group_sizes>();
+        std::cout << "Expected exception has not been generated\n";
+        return 1;
+      } catch (runtime_error e) {
+        /* Expected exception. */
+      }
+    } else {
+      Device.get_info<info::device::sub_group_sizes>();
+    }
 
     /* Basic sub-group functionality is supported as part of cl_khr_subgrou
      * extension or as core OpenCL 2.1 feature. */


### PR DESCRIPTION
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/sub_group_ndrange/sub_group_ndrange.md contains information about info::device::sub_group_sizes parameter which is missed in current implementation.

This PR introduces basic support for the parameter.


Signed-off-by: Vladimir Lazarev <vladimir.lazarev@intel.com>