### PR TITLE
[Driver][Offloader] Add getOffloadingDeviceToolChain function

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -557,6 +557,22 @@ private:
 
   /// @}
 
+  /// Retrieves a ToolChain for a particular device \p Target triple
+  ///
+  /// \param[in] HostTC is the host ToolChain paired with the device
+  ///
+  /// \param[in] Action (e.g. OFK_Cuda/OFK_OpenMP/OFK_SYCL) is an Offloading
+  /// action that is optionally passed to a ToolChain (used by CUDA, to specify
+  /// if it's used in conjunction with OpenMP)
+  ///
+  /// Will cache ToolChains for the life of the driver object, and create them
+  /// on-demand.
+  const ToolChain &getOffloadingDeviceToolChain(const llvm::opt::ArgList &Args,
+                                                const llvm::Triple &Target,
+                                                const ToolChain &HostTC,
+                                                const Action::OffloadKind
+                                                &TargetDeviceOffloadKind) const;
+
   /// Get bitmasks for which option flags to include and exclude based on
   /// the driver mode.
   std::pair<unsigned, unsigned> getIncludeExcludeOptionFlagMasks(bool IsClCompatMode) const;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -621,14 +621,12 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
     DeviceTripleStr =
         HostTriple.isArch64Bit() ? "nvptx64-nvidia-cuda" : "nvptx-nvidia-cuda";
     llvm::Triple CudaTriple(DeviceTripleStr);
-    // Use the CUDA and host triples as the key into the ToolChains map,
-    // because the device toolchain we create depends on both.
-    auto &CudaTC = ToolChains[CudaTriple.str() + "/" + HostTriple.str()];
-    if (!CudaTC) {
-      CudaTC = llvm::make_unique<toolchains::CudaToolChain>(
-          *this, CudaTriple, *HostTC, C.getInputArgs(), OFK);
-    }
-    C.addOffloadDeviceToolChain(CudaTC.get(), OFK);
+    // Use the CUDA and host triples as the key into the
+    // getOffloadingDeviceToolChain, because the device toolchain we
+    // create depends on both.
+    auto CudaTC = &getOffloadingDeviceToolChain(C.getInputArgs(), CudaTriple,
+                                                *HostTC, OFK);
+    C.addOffloadDeviceToolChain(CudaTC, OFK);
   } else if (IsHIP) {
     const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
     const llvm::Triple &HostTriple = HostTC->getTriple();
@@ -636,14 +634,12 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
     auto OFK = Action::OFK_HIP;
     DeviceTripleStr = "amdgcn-amd-amdhsa";
     llvm::Triple HIPTriple(DeviceTripleStr);
-    // Use the HIP and host triples as the key into the ToolChains map,
-    // because the device toolchain we create depends on both.
-    auto &HIPTC = ToolChains[HIPTriple.str() + "/" + HostTriple.str()];
-    if (!HIPTC) {
-      HIPTC = llvm::make_unique<toolchains::HIPToolChain>(
-          *this, HIPTriple, *HostTC, C.getInputArgs());
-    }
-    C.addOffloadDeviceToolChain(HIPTC.get(), OFK);
+    // Use the HIP and host triples as the key into
+    // getOffloadingDeviceToolChain, because the device toolchain we create
+    // depends on both.
+    auto HIPTC = &getOffloadingDeviceToolChain(C.getInputArgs(), HIPTriple,
+                                               *HostTC, OFK);
+    C.addOffloadDeviceToolChain(HIPTC, OFK);
   }
 
   //
@@ -695,12 +691,8 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
               const ToolChain *HostTC =
                   C.getSingleOffloadToolChain<Action::OFK_Host>();
               assert(HostTC && "Host toolchain should be always defined.");
-              auto &CudaTC =
-                  ToolChains[TT.str() + "/" + HostTC->getTriple().normalize()];
-              if (!CudaTC)
-                CudaTC = llvm::make_unique<toolchains::CudaToolChain>(
-                    *this, TT, *HostTC, C.getInputArgs(), Action::OFK_OpenMP);
-              TC = CudaTC.get();
+              TC = &getOffloadingDeviceToolChain(C.getInputArgs(), TT, *HostTC,
+                                                 Action::OFK_OpenMP);
             } else
               TC = &getToolChain(C.getInputArgs(), TT);
             C.addOffloadDeviceToolChain(TC, Action::OFK_OpenMP);
@@ -781,15 +773,13 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
           else {
             const ToolChain *HostTC =
                 C.getSingleOffloadToolChain<Action::OFK_Host>();
-            const llvm::Triple &HostTriple = HostTC->getTriple();
-            // Use the SYCL and host triples as the key into the ToolChains map,
-            // because the device toolchain we create depends on both.
-            auto &SYCLTC = ToolChains[TT.str() + "/" + HostTriple.str()];
-            if (!SYCLTC) {
-              SYCLTC = llvm::make_unique<toolchains::SYCLToolChain>(
-                  *this, TT, *HostTC, C.getInputArgs());
-            }
-            C.addOffloadDeviceToolChain(SYCLTC.get(), Action::OFK_SYCL);
+            // Use the SYCL and host triples as the key into
+            // getOffloadingDeviceToolChain, because the device toolchain we
+            // create depends on both.
+            auto SYCLTC = &getOffloadingDeviceToolChain(C.getInputArgs(), TT,
+                                                        *HostTC,
+                                                        Action::OFK_SYCL);
+            C.addOffloadDeviceToolChain(SYCLTC, Action::OFK_SYCL);
           }
         }
       } else {
@@ -811,15 +801,12 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
       TT.setVendor(llvm::Triple::UnknownVendor);
       TT.setOS(llvm::Triple(llvm::sys::getProcessTriple()).getOS());
       TT.setEnvironment(llvm::Triple::SYCLDevice);
-      // Use the SYCL and host triples as the key into the ToolChains map,
-      // because the device toolchain we create depends on both.
-      auto &SYCLTC = ToolChains[(TT.normalize() + Twine("/") +
-                                 HostTriple.normalize()).str()];
-      if (!SYCLTC) {
-        SYCLTC = llvm::make_unique<toolchains::SYCLToolChain>(
-            *this, TT, *HostTC, C.getInputArgs());
-      }
-      C.addOffloadDeviceToolChain(SYCLTC.get(), Action::OFK_SYCL);
+      // Use the SYCL and host triples as the key into
+      // getOffloadingDeviceToolChain, because the device toolchain we create
+      // depends on both.
+      auto SYCLTC = &getOffloadingDeviceToolChain(C.getInputArgs(), TT, *HostTC,
+                                                  Action::OFK_SYCL);
+      C.addOffloadDeviceToolChain(SYCLTC, Action::OFK_SYCL);
     }
   }
 
@@ -5130,6 +5117,49 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
   // compiles always need two toolchains, the CUDA toolchain and the host
   // toolchain.  So the only valid way to create a CUDA toolchain is via
   // CreateOffloadingDeviceToolChains.
+
+  return *TC;
+}
+
+const ToolChain &Driver::getOffloadingDeviceToolChain(const ArgList &Args,
+                  const llvm::Triple &Target, const ToolChain &HostTC,
+                  const Action::OffloadKind &TargetDeviceOffloadKind) const {
+  // Use device / host triples as the key into the ToolChains map because the
+  // device ToolChain we create depends on both.
+  auto &TC = ToolChains[Target.str() + "/" + HostTC.getTriple().str()];
+  if (!TC) {
+    // Categorized by offload kind > arch rather than OS > arch like
+    // the normal getToolChain call, as it seems a reasonable way to categorize
+    // things.
+    switch (TargetDeviceOffloadKind) {
+      case Action::OFK_Cuda:
+        TC = llvm::make_unique<toolchains::CudaToolChain>(
+          *this, Target, HostTC, Args, TargetDeviceOffloadKind);
+        break;
+      case Action::OFK_HIP:
+        TC = llvm::make_unique<toolchains::HIPToolChain>(
+          *this, Target, HostTC, Args);
+        break;
+      case Action::OFK_OpenMP:
+        // omp + nvptx
+        TC = llvm::make_unique<toolchains::CudaToolChain>(
+          *this, Target, HostTC, Args, TargetDeviceOffloadKind);
+        break;
+      case Action::OFK_SYCL:
+        switch (Target.getArch()) {
+          case llvm::Triple::spir:
+          case llvm::Triple::spir64:
+            TC = llvm::make_unique<toolchains::SYCLToolChain>(
+              *this, Target, HostTC, Args);
+            break;
+          default:
+            llvm_unreachable("Unexpected option.");
+        }
+      break;
+      default:
+        llvm_unreachable("Unexpected option.");
+    }
+  }
 
   return *TC;
 }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -767,7 +767,9 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
           FoundNormalizedTriples[NormalizedName] = Val;
 
           // If the specified target is invalid, emit a diagnostic.
-          if (TT.getArch() == llvm::Triple::UnknownArch)
+          if (TT.getArch() == llvm::Triple::UnknownArch ||
+              !(TT.getArch() == llvm::Triple::spir ||
+                TT.getArch() == llvm::Triple::spir64))
             Diag(clang::diag::err_drv_invalid_sycl_target) << Val;
           else {
             const ToolChain *HostTC =
@@ -3203,23 +3205,6 @@ class OffloadingActionBuilder final {
     }
 
     bool initialize() override {
-      // Get and check the SYCL target triples if any, if it's not a valid
-      // triple print a diagnostic and return true stating the initialization
-      // has failed
-      if (Arg *A = Args.getLastArg(options::OPT_fsycl_targets_EQ)) {
-        for (unsigned i = 0; i < A->getNumValues(); ++i) {
-          llvm::Triple TT(A->getValue(i));
-
-          if (TT.getArch() == llvm::Triple::UnknownArch ||
-              !(TT.getArch() == llvm::Triple::spir ||
-                TT.getArch() == llvm::Triple::spir64)) {
-            C.getDriver().Diag(diag::err_drv_invalid_sycl_target)
-              << A->getValue(i);
-            return true;
-          }
-        }
-      }
-
       // Get the SYCL toolchains. If we don't get any, the action builder will
       // know there is nothing to do related to SYCL offloading.
       auto SYCLTCRange = C.getOffloadToolChains<Action::OFK_SYCL>();

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -14,6 +14,13 @@
 
 /// ###########################################################################
 
+/// Check whether an invalid SYCL target is specified:
+// RUN:   %clang -### -fsycl -fsycl-targets=x86_64 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-INVALID-REAL-TARGET %s
+// CHK-INVALID-REAL-TARGET: error: SYCL target is invalid: 'x86_64'
+
+/// ###########################################################################
+
 /// Check warning for empty -fsycl-targets
 // RUN:   %clang -### -fsycl -fsycl-targets=  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-EMPTY-SYCLTARGETS %s


### PR DESCRIPTION
This pull request is in relation to: https://github.com/intel/llvm/issues/53 where I was wondering, what the best way (or the way you guys would like us to)  to integrate other ToolChains is and it was discussed a little during one of the Upstreaming meetings. 

Currently in our derivation of your implementation I've added this getOffloadingDeviceToolChain method which allows you to just add a new offloading device ToolChain for selection to the switch statement based on the passed in triple. It's reflective of getToolChain (https://github.com/intel/llvm/blob/sycl/clang/lib/Driver/Driver.cpp#L4974), except for offloading device ToolChains. You can see a rudimentary example of us adding a new ToolChain here: https://github.com/triSYCL/sycl/blob/sycl/unified/master/clang/lib/Driver/Driver.cpp#L5142

Nothing too complex, but it allows the addition of new ToolChain's very easily for new Triples and follows a similar concept to OpenMP's usage of getToolChain (although it does work differently when it's using NVPTX):  https://github.com/intel/llvm/blob/sycl/clang/lib/Driver/Driver.cpp#L705

If implementers trying to target new devices with new tools don't wish to add a new ToolChain it's still completely possible to just add new Tools to the default SYCL ToolChain by overloading (or adding to) the SelectTool method and adding their Tools to the SYCL ToolChain similar to the Myriad ToolChain: https://github.com/intel/llvm/blob/sycl/clang/lib/Driver/ToolChains/Myriad.cpp#L265 

I decided on a separate function in this case rather than merging the behavior of getToolChain and getOffloadingDeviceToolChain as offloading devices function a little differently (indexed by Host / Device triple and at least in CUDA's case require Action::OffloadKind) 

I think this method allows people to easily add new ToolChains rather than feel the need to add it all into the existing SYCL ToolChain as new Tools and alter the existing logic of the ToolChain (perhaps that's the intent though, but I imagine a single ToolChain approach could end up quite complex if it extends to a lot of architectures, I could be wrong however). It also has the minor benefit of refactoring some of the repeated logic for creating device ToolChains into a function.

Perhaps this isn't how everyone would like new ToolChains added however, or someone with more experience with the Driver (in particular the phases/action building) can see a problem in supporting ToolChains this way? Or maybe there is another direction that's better? Either-way happy for feedback! Also happy to answer any questions, especially if my description is unclear in any way. 

The commits log is a (hopefully) slightly more concise explanation of the above if more context is required!

Edit: Force pushed to add sign off