### PR TITLE
[SYCL] Fix metadata for Intel FPGA loop attributes

### DIFF
--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -422,7 +422,7 @@ MDNode *LoopInfo::createMetadata(
   // Setting ii attribute with an initiation interval
   if (Attrs.IInterval > 0) {
     LLVMContext &Ctx = Header->getContext();
-    Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.ii"),
+    Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.ii.count"),
                         ConstantAsMetadata::get(ConstantInt::get(
                             llvm::Type::getInt32Ty(Ctx), Attrs.IInterval))};
     LoopProperties.push_back(MDNode::get(Ctx, Vals));
@@ -431,7 +431,7 @@ MDNode *LoopInfo::createMetadata(
   // Setting max_concurrency attribute with number of threads
   if (Attrs.MaxConcurrencyNThreads > 0) {
     LLVMContext &Ctx = Header->getContext();
-    Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.max_concurrency"),
+    Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.max_concurrency.count"),
                         ConstantAsMetadata::get(ConstantInt::get(
                             llvm::Type::getInt32Ty(Ctx),
                             Attrs.MaxConcurrencyNThreads))};
@@ -766,9 +766,9 @@ void LoopInfoStack::push(BasicBlock *Header, clang::ASTContext &Ctx,
   // 0 - 'llvm.loop.ivdep.enable' metadata will be emitted
   // n - 'llvm.loop.ivdep.safelen, i32 n' metadata will be emitted
   // For attribute ii:
-  // n - 'llvm.loop.ii, i32 n' metadata will be emitted
+  // n - 'llvm.loop.ii.count, i32 n' metadata will be emitted
   // For attribute max_concurrency:
-  // n - 'llvm.loop.max_concurrency, i32 n' metadata will be emitted
+  // n - 'llvm.loop.max_concurrency.count, i32 n' metadata will be emitted
   for (const auto *Attr : Attrs) {
     const IntelFPGAIVDepAttr *IntelFPGAIVDep =
       dyn_cast<IntelFPGAIVDepAttr>(Attr);

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -63,10 +63,10 @@ struct LoopAttributes {
   /// Value for llvm.loop.ivdep.safelen metadata.
   unsigned IVDepSafelen;
 
-  /// Value for llvm.loop.ii metadata.
+  /// Value for llvm.loop.ii.count metadata.
   unsigned IInterval;
 
-  /// Value for llvm.loop.max_concurrency metadata.
+  /// Value for llvm.loop.max_concurrency.count metadata.
   unsigned MaxConcurrencyNThreads;
 
   /// llvm.unroll.

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -24,7 +24,7 @@ void boo() {
 }
 
 // CHECK: ![[MD_C]] = distinct !{![[MD_C]], ![[MD_ii:[0-9]+]]}
-// CHECK-NEXT: ![[MD_ii]] = !{!"llvm.loop.ii", i32 2}
+// CHECK-NEXT: ![[MD_ii]] = !{!"llvm.loop.ii.count", i32 2}
 void goo() {
   int a[10];
   [[intelfpga::ii(2)]]
@@ -33,7 +33,7 @@ void goo() {
 }
 
 // CHECK: ![[MD_D]] = distinct !{![[MD_D]], ![[MD_max_concurrency:[0-9]+]]}
-// CHECK-NEXT: ![[MD_max_concurrency]] = !{!"llvm.loop.max_concurrency", i32 2}
+// CHECK-NEXT: ![[MD_max_concurrency]] = !{!"llvm.loop.max_concurrency.count", i32 2}
 void zoo() {
   int a[10];
   [[intelfpga::max_concurrency(2)]]


### PR DESCRIPTION
llvm.loop.[ii/max_concurrency] -> llvm.loop.[ii/max_concurrency].count

Signed-off: Dmitry Sidorov <dmitry.sidorov@intel.com>