### PR TITLE
[SYCL] Non-const item operator[] removal

### DIFF
--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -28,8 +28,6 @@ template <int dimensions = 1, bool with_offset = true> struct item {
 
   size_t get_id(int dimension) const { return index[dimension]; }
 
-  size_t &operator[](int dimension) { return index[dimension]; }
-
   size_t operator[](int dimension) const { return index[dimension]; }
 
   range<dimensions> get_range() const { return extent; }

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -80,4 +80,8 @@ int main() {
   CHECK_SIZE_TYPE_F(cl::sycl::cl_float, 4);
   CHECK_SIZE_TYPE_F(cl::sycl::cl_double, 8);
   // CHECK_SIZE_TYPE_F(cl::sycl::cl_half, 2);
+
+  using value_type = decltype(std::declval<cl::sycl::item<1>>()[0]);
+  static_assert(!std::is_reference<value_type>::value,
+                "Expected a non-reference type");
 }


### PR DESCRIPTION
The non-const overload of `cl::sycl::item`'s `operator[]` has been removed from the latest SYCL specification. See page 151/152 of Revision 5 of the SYCL 1.2.1 specification [here](https://www.khronos.org/registry/SYCL/specs/sycl-1.2.1.pdf#page=151).