### PR TITLE
[SYCL] Fix the definition of const_reference in accessor

### DIFF
--- a/sycl/include/CL/sycl/accessor2.hpp
+++ b/sycl/include/CL/sycl/accessor2.hpp
@@ -333,7 +333,7 @@ class accessor :
 public:
   using value_type = DataT;
   using reference = DataT &;
-  using const_reference = const reference;
+  using const_reference = const DataT &;
 
   template <int Dims = Dimensions>
   accessor(enable_if_t<((!IsPlaceH && IsHostBuf) ||


### PR DESCRIPTION
Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>