### PR TITLE
[SYCL] Several fixes for handler methods.

### DIFF
--- a/sycl/include/CL/sycl/accessor2.hpp
+++ b/sycl/include/CL/sycl/accessor2.hpp
@@ -370,7 +370,7 @@ public:
             detail::convertToArrayOfN<3, 1>(BufferRef.MemRange), AccessMode,
             detail::getSyclObjImpl(BufferRef).get(), Dimensions,
             sizeof(DataT)) {
-    CommandGroupHandler.set_arg(/*Index=*/0, *this);
+    CommandGroupHandler.associateWithHandler(*this);
   }
 #endif
 
@@ -411,7 +411,7 @@ public:
             detail::convertToArrayOfN<3, 1>(BufferRef.MemRange), AccessMode,
             detail::getSyclObjImpl(BufferRef).get(), Dimensions,
             sizeof(DataT)) {
-    CommandGroupHandler.set_arg(/*Index=*/0, *this);
+    CommandGroupHandler.associateWithHandler(*this);
   }
 #endif
 
@@ -452,7 +452,7 @@ public:
                            detail::convertToArrayOfN<3, 1>(BufferRef.MemRange),
                            AccessMode, detail::getSyclObjImpl(BufferRef).get(),
                            Dimensions, sizeof(DataT)) {
-    CommandGroupHandler.set_arg(/*Index=*/0, *this);
+    CommandGroupHandler.associateWithHandler(*this);
   }
 #endif
 

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -30,8 +30,10 @@ public:
   kernel_impl(cl_kernel ClKernel, const context &SyclContext);
 
   kernel_impl(cl_kernel ClKernel, const context &SyclContext,
-              std::shared_ptr<program_impl> ProgramImpl)
-      : ClKernel(ClKernel), Context(SyclContext), ProgramImpl(ProgramImpl) {}
+              std::shared_ptr<program_impl> ProgramImpl,
+              bool IsCreatedFromSource)
+      : ClKernel(ClKernel), Context(SyclContext), ProgramImpl(ProgramImpl),
+        IsCreatedFromSource(IsCreatedFromSource) {}
 
   // Host kernel constructor
   kernel_impl(const context &SyclContext,
@@ -114,10 +116,13 @@ public:
 
   cl_kernel &getHandleRef() { return ClKernel; }
 
+  bool isCreatedFromSource() const;
+
 private:
   cl_kernel ClKernel;
   context Context;
   std::shared_ptr<program_impl> ProgramImpl;
+  bool IsCreatedFromSource = true;
 };
 
 template <> context kernel_impl::get_info<info::kernel::context>() const;

--- a/sycl/include/CL/sycl/detail/kernel_info.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_info.hpp
@@ -28,11 +28,11 @@ template <info::kernel Param> struct get_kernel_info_cl<string_class, Param> {
     if (ResultSize == 0) {
       return "";
     }
-    string_class Result(ResultSize, ' ');
+    vector_class<char> Result(ResultSize);
     // TODO catch an exception and put it to list of asynchronous exceptions
     CHECK_OCL_CODE(clGetKernelInfo(ClKernel, cl_kernel_info(Param), ResultSize,
-                                   &Result[0], nullptr));
-    return Result;
+                                   Result.data(), nullptr));
+    return string_class(Result.data());
   }
 };
 

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -266,7 +266,8 @@ public:
           std::make_shared<kernel_impl>(Context, PtrToSelf));
     }
     return createSyclObjFromImpl<kernel>(std::make_shared<kernel_impl>(
-        get_cl_kernel(KernelInfo<KernelT>::getName()), Context, PtrToSelf));
+        get_cl_kernel(KernelInfo<KernelT>::getName()), Context, PtrToSelf,
+        /*IsCreatedFromSource*/ false));
   }
 #endif
 
@@ -276,8 +277,9 @@ public:
     if (is_host()) {
       throw invalid_object_error("This instance of program is a host instance");
     }
-    return createSyclObjFromImpl<kernel>(std::make_shared<kernel_impl>(
-        get_cl_kernel(KernelName), Context, PtrToSelf));
+    return createSyclObjFromImpl<kernel>(
+        std::make_shared<kernel_impl>(get_cl_kernel(KernelName), Context,
+                                      PtrToSelf, /*IsCreatedFromSource*/ true));
   }
 
   template <info::program param>

--- a/sycl/include/CL/sycl/handler2.hpp
+++ b/sycl/include/CL/sycl/handler2.hpp
@@ -418,13 +418,25 @@ private:
 
   void setArgsHelper(int ArgIndex) {}
 
-  // setArgHelper version for accessor argument.
+  // setArgHelper for local accessor argument.
+  template <typename DataT, int Dims, access::mode AccessMode,
+            access::placeholder IsPlaceholder>
+  void setArgHelper(int ArgIndex,
+                    accessor<DataT, Dims, AccessMode, access::target::local,
+                             IsPlaceholder> &&Arg) {
+    detail::LocalAccessorBaseHost *LocalAccBase =
+        (detail::LocalAccessorBaseHost *)&Arg;
+    MArgs.emplace_back(detail::kernel_param_kind_t::kind_accessor, LocalAccBase,
+                       static_cast<int>(access::target::local), ArgIndex);
+  }
+
+  // setArgHelper for non local accessor argument.
   template <typename DataT, int Dims, access::mode AccessMode,
             access::target AccessTarget, access::placeholder IsPlaceholder>
-  void setArgHelper(
+  typename std::enable_if<AccessTarget != access::target::local, void>::type
+  setArgHelper(
       int ArgIndex,
       accessor<DataT, Dims, AccessMode, AccessTarget, IsPlaceholder> &&Arg) {
-    // TODO: Handle local accessor in separate method.
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Arg;
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
     detail::Requirement *Req = AccImpl.get();

--- a/sycl/include/CL/sycl/handler2.hpp
+++ b/sycl/include/CL/sycl/handler2.hpp
@@ -193,7 +193,8 @@ private:
       : MQueue(std::move(Queue)), MIsHost(IsHost) {}
 
   // Method stores copy of Arg passed to the MArgsStorage.
-  template <typename T, typename F = typename std::remove_reference<T>::type>
+  template <typename T, typename F = typename std::remove_const<
+                            typename std::remove_reference<T>::type>::type>
   F *storePlainArg(T &&Arg) {
     MArgsStorage.emplace_back(sizeof(T));
     F *Storage = (F *)MArgsStorage.back().data();

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -18,7 +18,8 @@ namespace detail {
 
 kernel_impl::kernel_impl(cl_kernel ClKernel, const context &SyclContext)
     : kernel_impl(ClKernel, SyclContext,
-                  std::make_shared<program_impl>(SyclContext, ClKernel)) {}
+                  std::make_shared<program_impl>(SyclContext, ClKernel),
+                  /*IsCreatedFromSource*/ true) {}
 
 program kernel_impl::get_program() const {
   return createSyclObjFromImpl<program>(ProgramImpl);
@@ -30,6 +31,22 @@ template <> context kernel_impl::get_info<info::kernel::context>() const {
 
 template <> program kernel_impl::get_info<info::kernel::program>() const {
   return get_program();
+}
+
+bool kernel_impl::isCreatedFromSource() const {
+  // TODO it is not clear how to understand whether the SYCL kernel is created
+  // from source code or not when the SYCL kernel is created using
+  // the interoperability constructor.
+  // Here a strange case which does not work now:
+  // context Context;
+  // program Program(Context);
+  // Program.build_with_kernel_type<class A>();
+  // kernel FirstKernel= Program.get_kernel<class A>();
+  // cl_kernel ClKernel = FirstKernel.get();
+  // kernel SecondKernel = kernel(ClKernel, Context);
+  // clReleaseKernel(ClKernel);
+  // FirstKernel.isCreatedFromSource() != FirstKernel.isCreatedFromSource();
+  return IsCreatedFromSource;
 }
 
 } // namespace detail

--- a/sycl/test/kernel-and-program/kernel-and-program.cpp
+++ b/sycl/test/kernel-and-program/kernel-and-program.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl.hpp>
+
 #include <iostream>
 #include <numeric>
 #include <string>
@@ -40,6 +41,13 @@ int main() {
         auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
         cgh.single_task<class SingleTask>(krn, [=]() { acc[0] = acc[0] + 1; });
       });
+      if (!q.is_host()) {
+        const std::string integrationHeaderKernelName =
+            cl::sycl::detail::KernelInfo<SingleTask>::getName();
+        const std::string clKerneName =
+            krn.get_info<cl::sycl::info::kernel::function_name>();
+        assert(integrationHeaderKernelName == clKerneName);
+      }
     }
     assert(data == 1);
 

--- a/sycl/test/kernel-and-program/kernel-and-program.cpp
+++ b/sycl/test/kernel-and-program/kernel-and-program.cpp
@@ -154,11 +154,12 @@ int main() {
         assert(err == CL_SUCCESS);
 
         cl::sycl::program prog(ctx);
-        prog.build_with_source("kernel void ParallelFor(global int* a) "
-                               "{a[get_global_id(0)]+=1; }\n");
+        prog.build_with_source("kernel void ParallelFor(global int* a, int v) "
+                               "{a[get_global_id(0)]+=v; }\n");
 
         q.submit([&](cl::sycl::handler &cgh) {
-          cgh.set_args(clBuffer);
+          const int value = 1;
+          cgh.set_args(clBuffer, value);
           cgh.parallel_for(cl::sycl::range<1>(10),
                            prog.get_kernel("ParallelFor"));
         });


### PR DESCRIPTION
- Made the names returned from the get_info method and from the integration header of the same kernel equal.
- Fix set_arg(s) methods to work with constant variables.
- Removed set_arg method calls from accessor constructors.
- Fixed require method: now will make dependencies in the scheduler.
- Added support set_arg for non source SYCL kernels.
- Add support for local accessors in set_arg(s) handler method.