### PR TITLE
[SYCL] Fix errors caused by unsupported __builtin_expect() on Windows

### DIFF
--- a/sycl/source/half_type.cpp
+++ b/sycl/source/half_type.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl/half_type.hpp>
+// This is included to enable __builtin_expect()
+#include <CL/sycl/detail/platform_util.hpp>
 #include <iostream>
 
 namespace cl {


### PR DESCRIPTION
Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>