### PR TITLE
[SYCL] Fix vec and SwizzleOp types on Windows

### DIFF
--- a/sycl/include/CL/sycl/swizzles.def
+++ b/sycl/include/CL/sycl/swizzles.def
@@ -18,7 +18,7 @@
 #error "Undefine __SYCL_{ACCESS, INDEXER, EXPAND, NTH_ARG, E[0-8]} macros."
 #endif
 
-#define __SYCL_INDEXER(_X) Indexer(_X)
+#define __SYCL_INDEXER(_X) Indexer<_X>::value
 
 // Accepts any number of args >= _N, but expands to just the _N-th one.
 // Make N equal to the max number of args handled + 1. Here, N == 9.


### PR DESCRIPTION
The fix adds a workaround for MSVC bug and enables vec and SwizzleOp classes
compilation for Windows. MSVC does not recognize constexpr functions
getNumElements() and Indexer() as const and thus does not let using them in
template class parameters.
The fix inlines getNumElements() and turns constexpr function Indexer(int I)
into template struct Indexer<int I>.

Also, the fix eliminates the need in duplication of the word Indexer
in swizzles.def and thus makes the file more readable.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>