### PR TITLE
[SYCL][FPGA] Add 'SYCL' lang prefix for loop attributes

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1397,7 +1397,7 @@ def Mode : Attr {
   let PragmaAttributeSupport = 0;
 }
 
-def IntelFPGAIVDep : Attr {
+def SYCLIntelFPGAIVDep : Attr {
   let Spellings = [CXX11<"intelfpga","ivdep">];
   let Args = [IntArgument<"Safelen">];
   let LangOpts = [SYCL];
@@ -1406,10 +1406,10 @@ def IntelFPGAIVDep : Attr {
       return "ivdep";
     }
   }];
-  let Documentation = [IntelFPGAIVDepAttrDocs];
+  let Documentation = [SYCLIntelFPGAIVDepAttrDocs];
 }
 
-def IntelFPGAII : Attr {
+def SYCLIntelFPGAII : Attr {
   let Spellings = [CXX11<"intelfpga","ii">];
   let Args = [IntArgument<"Interval">];
   let LangOpts = [SYCL];
@@ -1418,10 +1418,10 @@ def IntelFPGAII : Attr {
       return "ii";
     }
   }];
-  let Documentation = [IntelFPGAIIAttrDocs];
+  let Documentation = [SYCLIntelFPGAIIAttrDocs];
 }
 
-def IntelFPGAMaxConcurrency : Attr {
+def SYCLIntelFPGAMaxConcurrency : Attr {
   let Spellings = [CXX11<"intelfpga","max_concurrency">];
   let Args = [IntArgument<"NThreads">];
   let LangOpts = [SYCL];
@@ -1430,7 +1430,7 @@ def IntelFPGAMaxConcurrency : Attr {
       return "max_concurrency";
     }
   }];
-  let Documentation = [IntelFPGAMaxConcurrencyAttrDocs];
+  let Documentation = [SYCLIntelFPGAMaxConcurrencyAttrDocs];
 }
 
 def IntelFPGALocalNonConstVar : SubsetSubject<Var,

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1714,7 +1714,7 @@ threads or loop iterations.
   }];
 }
 
-def IntelFPGAIVDepAttrDocs : Documentation {
+def SYCLIntelFPGAIVDepAttrDocs : Documentation {
   let Category = DocCatVariable;
   let Heading = "ivdep";
   let Content = [{
@@ -1725,7 +1725,7 @@ dependences have a dependence distance of at least that length.
   }];
 }
 
-def IntelFPGAIIAttrDocs : Documentation {
+def SYCLIntelFPGAIIAttrDocs : Documentation {
   let Category = DocCatVariable;
   let Heading = "ii";
   let Content = [{
@@ -1735,7 +1735,7 @@ applied multiple times to the same loop.
   }];
 }
 
-def IntelFPGAMaxConcurrencyAttrDocs : Documentation {
+def SYCLIntelFPGAMaxConcurrencyAttrDocs : Documentation {
   let Category = DocCatVariable;
   let Heading = "max_concurrency";
   let Content = [{

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -58,16 +58,16 @@ struct LoopAttributes {
   unsigned InterleaveCount;
 
   /// Value for llvm.loop.ivdep.enable metadata.
-  bool IVDepEnable;
+  bool SYCLIVDepEnable;
 
   /// Value for llvm.loop.ivdep.safelen metadata.
-  unsigned IVDepSafelen;
+  unsigned SYCLIVDepSafelen;
 
   /// Value for llvm.loop.ii.count metadata.
-  unsigned IInterval;
+  unsigned SYCLIInterval;
 
   /// Value for llvm.loop.max_concurrency.count metadata.
-  unsigned MaxConcurrencyNThreads;
+  unsigned SYCLMaxConcurrencyNThreads;
 
   /// llvm.unroll.
   unsigned UnrollCount;
@@ -261,17 +261,17 @@ public:
   void setInterleaveCount(unsigned C) { StagedAttrs.InterleaveCount = C; }
 
   /// Set flag of ivdep for the next loop pushed.
-  void setIVDepEnable() { StagedAttrs.IVDepEnable = true; }
+  void setSYCLIVDepEnable() { StagedAttrs.SYCLIVDepEnable = true; }
 
   /// Set value of safelen count for the next loop pushed.
-  void setIVDepSafelen(unsigned C) { StagedAttrs.IVDepSafelen = C; }
+  void setSYCLIVDepSafelen(unsigned C) { StagedAttrs.SYCLIVDepSafelen = C; }
 
   /// Set value of an initiation interval for the next loop pushed.
-  void setIInterval(unsigned C) { StagedAttrs.IInterval = C; }
+  void setSYCLIInterval(unsigned C) { StagedAttrs.SYCLIInterval = C; }
 
   /// Set value of threads for the next loop pushed.
-  void setMaxConcurrencyNThreads(unsigned C) {
-    StagedAttrs.MaxConcurrencyNThreads = C;
+  void setSYCLMaxConcurrencyNThreads(unsigned C) {
+    StagedAttrs.SYCLMaxConcurrencyNThreads = C;
   }
 
   /// Set the unroll count for the next loop pushed.

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2382,9 +2382,9 @@ bool Parser::ParseIntelFPGALoopAttributes(ParsedAttributes &Attrs) {
   if (Attrs.empty())
     return true;
 
-  if (Attrs.begin()->getKind() != ParsedAttr::AT_IntelFPGAIVDep &&
-      Attrs.begin()->getKind() != ParsedAttr::AT_IntelFPGAII &&
-      Attrs.begin()->getKind() != ParsedAttr::AT_IntelFPGAMaxConcurrency)
+  if (Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAIVDep &&
+      Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAII &&
+      Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency)
     return true;
 
   if (!(Tok.is(tok::kw_for) || Tok.is(tok::kw_while) || Tok.is(tok::kw_do))) {

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -84,8 +84,8 @@ static Attr *handleIntelFPGALoopAttr(Sema &S, Stmt *St, const ParsedAttr &A) {
   }
 
   if (NumArgs == 0) {
-    if (A.getKind() == ParsedAttr::AT_IntelFPGAII ||
-        A.getKind() == ParsedAttr::AT_IntelFPGAMaxConcurrency) {
+    if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAII ||
+        A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency) {
       S.Diag(A.getLoc(), diag::err_attribute_too_few_arguments) << A << 1;
       return nullptr;
     }
@@ -351,10 +351,10 @@ static void
 CheckForIncompatibleFPGALoopAttributes(Sema &S,
                                        const SmallVectorImpl<const Attr *>
                                        &Attrs, SourceRange Range) {
-  CheckForDuplicationFPGALoopAttribute<IntelFPGAIVDepAttr>(S, Attrs, Range);
-  CheckForDuplicationFPGALoopAttribute<IntelFPGAIIAttr>(S, Attrs, Range);
+  CheckForDuplicationFPGALoopAttribute<SYCLIntelFPGAIVDepAttr>(S, Attrs, Range);
+  CheckForDuplicationFPGALoopAttribute<SYCLIntelFPGAIIAttr>(S, Attrs, Range);
   CheckForDuplicationFPGALoopAttribute<
-    IntelFPGAMaxConcurrencyAttr>(S, Attrs, Range);
+    SYCLIntelFPGAMaxConcurrencyAttr>(S, Attrs, Range);
 }
 
 static Attr *handleOpenCLUnrollHint(Sema &S, Stmt *St, const ParsedAttr &A,
@@ -411,12 +411,12 @@ static Attr *ProcessStmtAttribute(Sema &S, Stmt *St, const ParsedAttr &A,
     return handleFallThroughAttr(S, St, A, Range);
   case ParsedAttr::AT_LoopHint:
     return handleLoopHintAttr(S, St, A, Range);
-  case ParsedAttr::AT_IntelFPGAIVDep:
-    return handleIntelFPGALoopAttr<IntelFPGAIVDepAttr>(S, St, A);
-  case ParsedAttr::AT_IntelFPGAII:
-    return handleIntelFPGALoopAttr<IntelFPGAIIAttr>(S, St, A);
-  case ParsedAttr::AT_IntelFPGAMaxConcurrency:
-    return handleIntelFPGALoopAttr<IntelFPGAMaxConcurrencyAttr>(S, St, A);
+  case ParsedAttr::AT_SYCLIntelFPGAIVDep:
+    return handleIntelFPGALoopAttr<SYCLIntelFPGAIVDepAttr>(S, St, A);
+  case ParsedAttr::AT_SYCLIntelFPGAII:
+    return handleIntelFPGALoopAttr<SYCLIntelFPGAIIAttr>(S, St, A);
+  case ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency:
+    return handleIntelFPGALoopAttr<SYCLIntelFPGAMaxConcurrencyAttr>(S, St, A);
   case ParsedAttr::AT_OpenCLUnrollHint:
     return handleOpenCLUnrollHint(S, St, A, Range);
   case ParsedAttr::AT_Suppress:


### PR DESCRIPTION
Rename SYCL specific loop attributes to avoid potential name conflicts.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>