### PR TITLE
[SYCL] Image Class Initial Implementation.

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -130,6 +130,7 @@ add_library("${SYCLLibrary}" SHARED
   "${sourceRootPath}/detail/event_impl.cpp"
   "${sourceRootPath}/detail/force_device.cpp"
   "${sourceRootPath}/detail/helpers.cpp"
+  "${sourceRootPath}/detail/image_impl.cpp"
   "${sourceRootPath}/detail/kernel_impl.cpp"
   "${sourceRootPath}/detail/kernel_info.cpp"
   "${sourceRootPath}/detail/memory_manager.cpp"

--- a/sycl/include/CL/sycl/detail/cnri.h
+++ b/sycl/include/CL/sycl/detail/cnri.h
@@ -90,6 +90,7 @@ struct cnri_bin_desc {
 
 // TODO For now code below is a placeholder for future real implementation
 typedef cl_context cnri_context;
+typedef cl_event cnri_event;
 typedef cl_program cnri_program;
 typedef cl_kernel cnri_kernel;
 

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -8,150 +8,322 @@
 
 #pragma once
 
+#include <CL/sycl/detail/aligned_allocator.hpp>
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/memory_manager.hpp>
+#include <CL/sycl/detail/scheduler/scheduler.hpp>
+#include <CL/sycl/detail/sycl_mem_obj.hpp>
+#include <CL/sycl/property_list.hpp>
+#include <CL/sycl/range.hpp>
+#include <CL/sycl/stl.hpp>
+
 namespace cl {
 namespace sycl {
 
-enum class image_channel_order : unsigned int {
-  a,
-  r,
-  rx,
-  rg,
-  rgx,
-  ra,
-  rgb,
-  rgbx,
-  rgba,
-  argb,
-  bgra,
-  intensity,
-  luminance,
-  abgr
-};
-
-enum class image_channel_type : unsigned int {
-  snorm_int8,
-  snorm_int16,
-  unorm_int8,
-  unorm_int16,
-  unorm_short_565,
-  unorm_short_555,
-  unorm_int_101010,
-  signed_int8,
-  signed_int16,
-  signed_int32,
-  unsigned_int8,
-  unsigned_int16,
-  unsigned_int32,
-  fp16,
-  fp32
-};
+enum class image_channel_order : unsigned int;
+enum class image_channel_type : unsigned int;
 
 namespace detail {
 
-template <int dimensions, typename AllocatorT> class image_impl {
+// utility functions and typedefs for image_impl
+using image_allocator = aligned_allocator<byte, /*alignment*/ 64>;
+
+// utility function: Returns the Number of Channels for a given Order.
+uint8_t getImageNumberChannels(image_channel_order Order);
+
+// utility function: Returns the number of bytes per image element
+uint8_t getImageElementSize(uint8_t NumChannels, image_channel_type Type);
+
+// validImageDataT: cl_int4, cl_uint4, cl_float4, cl_half4
+// To be used in get_access method. Uncomment after get_access is implemented.
+// template <typename T>
+// using is_validImageDataT = typename detail::is_contained<
+//    T, type_list<cl_int4, cl_uint4, cl_float4, cl_half4>>::type;
+
+template <int Dimensions, typename AllocatorT = image_allocator>
+class image_impl : public SYCLMemObjT {
+private:
+  template <bool B>
+  using EnableIfPitchT =
+      typename std::enable_if<B, range<Dimensions - 1>>::type;
+  static_assert(Dimensions >= 1 || Dimensions <= 3,
+                "Dimensions of cl::sycl::image can be 1, 2 or 3");
+
+  void setPitches() {
+    size_t WHD[3] = {1, 1, 1}; // Width, Height, Depth.
+    for (int I = 0; I < Dimensions; I++)
+      WHD[I] = MRange[I];
+    MRowPitch = MElementSize * WHD[0];
+    MSlicePitch = MRowPitch * WHD[1];
+    MSizeInBytes = MSlicePitch * WHD[2];
+  }
+
+  template <bool B = (Dimensions > 1)>
+  void setPitches(const EnableIfPitchT<B> Pitch) {
+    MRowPitch = Pitch[0];
+    MSlicePitch =
+        (Dimensions == 3) ? Pitch[1] : MRowPitch; // Dimensions will be 2/3.
+    // NumSlices is depth when dim==3, and height when dim==2.
+    size_t NumSlices =
+        (Dimensions == 3) ? MRange[2] : MRange[1]; // Dimensions will be 2/3.
+    MSizeInBytes = MSlicePitch * NumSlices;
+  }
+
+  void handleHostData(void *HData) {
+    MUserPtr = HData;
+    // TO DO:
+    //      Populate the function MUploadDataFn.
+    //      Add the set_final_data function.
+    //      Initialise allocated memory to the data HData points to (if needed).
+    //      Some properties to be checked from MProps.
+  }
+
+  void handleHostData(const void *HData) {
+    MHostPtrReadOnly = true;
+    MUserPtr = const_cast<void *>(HData);
+    // TO DO:
+    //      Populate the function MUploadDataFn.
+    //      Initialise allocated memory to the data HData points to (if needed).
+    //      Some properties to be checked from MProps.
+  }
+
+  void handleHostData(shared_ptr_class<void> HData) {
+    // MUserPtr = HData;
+    // TO DO:
+    //      Populate the function MUploadDataFn.
+    //      Add the set_final_data function.
+    //      Initialise allocated memory to the data HData points to (if needed).
+    //      Some properties to be checked from MProps.
+    //      Check if we need this specialized function at all.
+  }
+
 public:
-  image_impl(image_channel_order order, image_channel_type type,
-             const range<dimensions> &range,
-             const property_list &propList) {
-    assert(!"Not implemented");
+  image_impl(image_channel_order Order, image_channel_type Type,
+             const range<Dimensions> &ImageRange,
+             const property_list &PropList = {})
+      : image_impl((void *)nullptr, Order, Type, ImageRange, PropList) {}
+
+  image_impl(image_channel_order Order, image_channel_type Type,
+             const range<Dimensions> &ImageRange, AllocatorT Allocator,
+             const property_list &PropList = {})
+      : image_impl((void *)nullptr, Order, Type, ImageRange, Allocator,
+                   PropList) {}
+
+  template <bool B = (Dimensions > 1)>
+  image_impl(image_channel_order Order, image_channel_type Type,
+             const range<Dimensions> &ImageRange,
+             const EnableIfPitchT<B> &Pitch, const property_list &PropList = {})
+      : image_impl((void *)nullptr, Order, Type, ImageRange, Pitch, PropList) {}
+
+  template <bool B = (Dimensions > 1)>
+  image_impl(image_channel_order Order, image_channel_type Type,
+             const range<Dimensions> &ImageRange,
+             const EnableIfPitchT<B> &Pitch, AllocatorT Allocator,
+             const property_list &PropList = {})
+      : image_impl((void *)nullptr, Order, Type, ImageRange, Pitch, Allocator,
+                   PropList) {}
+
+  image_impl(void *HData, image_channel_order Order, image_channel_type Type,
+             const range<Dimensions> &ImageRange,
+             const property_list &PropList = {})
+      : MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches();
+    handleHostData(HData);
   }
 
-  //image_impl(image_channel_order order, image_channel_type type,
-             //const range<dimensions> &range, AllocatorT allocator,
-             //const property_list &propList = {});
-
-  /* Available only when: dimensions > 1 */
-  // image_impl(image_channel_order order, image_channel_type type,
-  // const range<dimensions> &range, const range<dimensions - 1> &pitch,
-  // const property_list &propList = {});
-
-  /* Available only when: dimensions > 1 */
-  // image_impl(image_channel_order order, image_channel_type type,
-  // const range<dimensions> &range, const range<dimensions - 1> &pitch,
-  // AllocatorT allocator, const property_list &propList = {});
-
-  //image_impl(void *hostPointer, image_channel_order order,
-             //image_channel_type type, const range<dimensions> &range,
-             //const property_list &propList = {});
-
-  //image_impl(void *hostPointer, image_channel_order order,
-             //image_channel_type type, const range<dimensions> &range,
-             //AllocatorT allocator, const property_list &propList = {});
-
-  //image_impl(const void *hostPointer, image_channel_order order,
-             //image_channel_type type, const range<dimensions> &range,
-             //const property_list &propList = {});
-
-  //image_impl(const void *hostPointer, image_channel_order order,
-             //image_channel_type type, const range<dimensions> &range,
-             //AllocatorT allocator, const property_list &propList = {});
-
-  /* Available only when: dimensions > 1 */
-  // image_impl(void *hostPointer, image_channel_order order, image_channel_type
-  // type,
-  // const range<dimensions> &range, range<dimensions - 1> &pitch,
-  // const property_list &propList = {}) {assert(!"Not implemented");}
-
-  /* Available only when: dimensions > 1 */
-  // image_impl(void *hostPointer, image_channel_order order, image_channel_type
-  // type,
-  // const range<dimensions> &range, range<dimensions - 1> &pitch,
-  // AllocatorT allocator, const property_list &propList = {}) {assert(!"Not
-  // implemented");}
-
-  //image_impl(shared_ptr_class<void> &hostPointer, image_channel_order order,
-             //image_channel_type type, const range<dimensions> &range,
-             //const property_list &propList = {});
-
-  //image_impl(shared_ptr_class<void> &hostPointer, image_channel_order order,
-             //image_channel_type type, const range<dimensions> &range,
-             //AllocatorT allocator, const property_list &propList = {});
-
-  /* Available only when: dimensions > 1 */
-  // image_impl(shared_ptr_class<void> &hostPointer, image_channel_order order,
-  // image_channel_type type, const range<dimensions> &range,
-  // const range<dimensions - 1> &pitch, const property_list &propList = {})
-  // {assert(!"Not implemented");}
-
-  /* Available only when: dimensions > 1 */
-  // image_impl(shared_ptr_class<void> &hostPointer, image_channel_order order,
-  // image_channel_type type, const range<dimensions> &range,
-  // const range<dimensions - 1> &pitch, AllocatorT allocator,
-  // const property_list &propList = {}) {assert(!"Not implemented");}
-
-  //image_impl(cl_mem clMemObject, const context &syclContext,
-             //event availableEvent = {});
-
-  /* -- property interface members -- */
-
-  range<dimensions> get_range() const { assert(!"Not implemented"); }
-
-  /* Available only when: dimensions > 1 */
-  range<dimensions - 1> get_pitch() const { assert(!"Not implemented"); }
-
-  size_t get_size() const { assert(!"Not implemented"); return 0;}
-
-  size_t get_count() const { assert(!"Not implemented"); return 0; }
-
-  AllocatorT get_allocator() const { assert(!"Not implemented"); }
-
-  template <typename dataT, access::mode accessMode>
-  accessor<dataT, dimensions, accessMode, access::target::image>
-  get_access(handler &commandGroupHandler) {
-    assert(!"Not implemented");
+  image_impl(void *HData, image_channel_order Order, image_channel_type Type,
+             const range<Dimensions> &ImageRange, AllocatorT Allocator,
+             const property_list &PropList = {})
+      : MAllocator(Allocator), MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches();
+    handleHostData(HData);
   }
 
-  template <typename dataT, access::mode accessMode>
-  accessor<dataT, dimensions, accessMode, access::target::host_image>
-  get_access() {
-    assert(!"Not implemented");
+  image_impl(const void *HData, image_channel_order Order,
+             image_channel_type Type, const range<Dimensions> &ImageRange,
+             const property_list &PropList = {})
+      : MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches();
+    handleHostData(HData);
   }
 
-  // template <typename Destination = std::nullptr_t>
-  // void set_final_data(Destination finalData = std::nullptr);
+  image_impl(const void *HData, image_channel_order Order,
+             image_channel_type Type, const range<Dimensions> &ImageRange,
+             AllocatorT Allocator, const property_list &PropList = {})
+      : MAllocator(Allocator), MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches();
+    handleHostData(HData);
+  }
 
-  void set_write_back(bool flag) { assert(!"Not implemented"); }
-};
+  template <bool B = (Dimensions > 1)>
+  image_impl(void *HData, image_channel_order Order, image_channel_type Type,
+             const range<Dimensions> &ImageRange,
+             const EnableIfPitchT<B> &Pitch, const property_list &PropList = {})
+      : MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches(Pitch);
+    handleHostData(HData);
+  }
+
+  template <bool B = (Dimensions > 1)>
+  image_impl(void *HData, image_channel_order Order, image_channel_type Type,
+             const range<Dimensions> &ImageRange,
+             const EnableIfPitchT<B> &Pitch, AllocatorT Allocator,
+             const property_list &PropList = {})
+      : MAllocator(Allocator), MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches(Pitch);
+    handleHostData(HData);
+  }
+
+  image_impl(shared_ptr_class<void> &HData, image_channel_order Order,
+             image_channel_type Type, const range<Dimensions> &ImageRange,
+             const property_list &PropList = {})
+      : MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches();
+    handleHostData(HData);
+  }
+
+  image_impl(shared_ptr_class<void> &HData, image_channel_order Order,
+             image_channel_type Type, const range<Dimensions> &ImageRange,
+             AllocatorT Allocator, const property_list &PropList = {})
+      : MAllocator(Allocator), MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches();
+    handleHostData(HData);
+  }
+
+  /* Available only when: Dimensions > 1 */
+  template <bool B = (Dimensions > 1)>
+  image_impl(shared_ptr_class<void> &HData, image_channel_order Order,
+             image_channel_type Type, const range<Dimensions> &ImageRange,
+             const EnableIfPitchT<B> &Pitch, const property_list &PropList = {})
+      : MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches(Pitch);
+    handleHostData(HData);
+  }
+
+  /* Available only when: Dimensions > 1 */
+  template <bool B = (Dimensions > 1)>
+  image_impl(shared_ptr_class<void> &HData, image_channel_order Order,
+             image_channel_type Type, const range<Dimensions> &ImageRange,
+             const EnableIfPitchT<B> &Pitch, AllocatorT Allocator,
+             const property_list &PropList = {})
+      : MAllocator(Allocator), MProps(PropList), MRange(ImageRange), MOrder(Order), MType(Type),
+        MNumChannels(getImageNumberChannels(MOrder)),
+        MElementSize(getImageElementSize(MNumChannels, MType)) {
+    setPitches(Pitch);
+    handleHostData(HData);
+  }
+
+  // Return a range object representing the size of the image in terms of the
+  // number of elements in each dimension as passed to the constructor
+  range<Dimensions> get_range() const { return MRange; }
+
+  // Return a range object representing the pitch of the image in bytes.
+  // Available only when: Dimensions == 2.
+  template <bool B = (Dimensions == 2)>
+  typename std::enable_if<B, range<1>>::type get_pitch() const {
+    range<1> Temp = range<1>(MRowPitch);
+    return Temp;
+  }
+
+  // Return a range object representing the pitch of the image in bytes.
+  // Available only when: Dimensions == 3.
+  template <bool B = (Dimensions == 3)>
+  typename std::enable_if<B, range<2>>::type get_pitch() const {
+    range<2> Temp = range<2>(MRowPitch, MSlicePitch);
+    return Temp;
+  }
+
+  // Returns the size of the image storage in bytes
+  size_t get_size() const { return MSizeInBytes; }
+
+  // Returns the total number of elements in the image
+  size_t get_count() const { return MRange.size(); }
+
+  // Returns the allocator provided to the image
+  AllocatorT get_allocator() const { return MAllocator; }
+
+  template <typename propertyT> bool has_property() const {
+    return MProps.has_property<propertyT>();
+  }
+
+  template <typename propertyT> propertyT get_property() const {
+    return MProps.get_property<propertyT>();
+  }
+
+  // TODO: Implement this function.
+  void *allocateHostMem() override {
+    if (true)
+      throw cl::sycl::feature_not_supported(
+          "HostMemoryAllocation Function Not Implemented for image class");
+    return nullptr;
+    // Implementation of the pure virtual function.
+  }
+
+  // TODO: Implement this function.
+  void *allocateMem(ContextImplPtr Context, bool InitFromUserData,
+                    cnri_event &OutEventToWait) override {
+    if (true)
+      throw cl::sycl::feature_not_supported(
+          "MemoryAllocation Function Not Implemented for image class");
+    return nullptr;
+    // Implementation of the pure virtual function.
+  }
+
+  MemObjType getType() const override { return MemObjType::IMAGE; }
+
+  // TODO: Implement this function.
+  void releaseHostMem(void *Ptr) override {
+    if (true)
+      throw cl::sycl::feature_not_supported(
+          "HostMemoryRelease Function Not Implemented for Image class");
+    return;
+    // Implementation of the pure virtual function.
+  }
+
+  // TODO: Implement this function.
+  void releaseMem(ContextImplPtr Context, void *MemAllocation) override {
+    if (true)
+      throw cl::sycl::feature_not_supported(
+          "MemoryRelease Function Not Implemented for Image class");
+    return;
+    // Implementation of the pure virtual function.
+  }
+
+private:
+  bool MHostPtrReadOnly = false;
+  AllocatorT MAllocator;
+  std::function<void(void)> MUploadDataFn = nullptr;
+  void *MUserPtr = nullptr;
+
+  property_list MProps;
+  range<Dimensions> MRange;
+  image_channel_order MOrder;
+  image_channel_type MType;
+  uint8_t MNumChannels = 0; // Maximum Value - 4
+  uint8_t MElementSize = 0; // Maximum Value - 16
+  size_t MRowPitch = 0;
+  size_t MSlicePitch = 0;
+  size_t MSizeInBytes = 0;
+
+}; // class image_impl
 
 } // namespace detail
 

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -103,7 +103,9 @@ class invalid_object_error : public device_error {
 class memory_allocation_error : public device_error {};
 class platform_error : public device_error {};
 class profiling_error : public device_error {};
-class feature_not_supported : public device_error {};
+class feature_not_supported : public device_error {
+  using device_error::device_error;
+};
 
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -8,88 +8,176 @@
 
 #pragma once
 
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/generic_type_traits.hpp>
 #include <CL/sycl/detail/image_impl.hpp>
+#include <CL/sycl/stl.hpp>
+#include <CL/sycl/types.hpp>
 #include <cstddef>
 
 namespace cl {
 namespace sycl {
 
+enum class image_channel_order : unsigned int {
+  a,
+  r,
+  rx,
+  rg,
+  rgx,
+  ra,
+  rgb,
+  rgbx,
+  rgba,
+  argb,
+  bgra,
+  intensity,
+  luminance,
+  abgr
+};
+
+enum class image_channel_type : unsigned int {
+  snorm_int8,
+  snorm_int16,
+  unorm_int8,
+  unorm_int16,
+  unorm_short_565,
+  unorm_short_555,
+  unorm_int_101010,
+  signed_int8,
+  signed_int16,
+  signed_int32,
+  unsigned_int8,
+  unsigned_int16,
+  unsigned_int32,
+  fp16,
+  fp32
+};
+
 using byte = unsigned char;
 
 using image_allocator = std::allocator<byte>;
 
-template <int dimentions> class range;
-
-template <int dimensions = 1,
-          typename AllocatorT = cl::sycl::image_allocator>
+template <int Dimensions = 1, typename AllocatorT = cl::sycl::image_allocator>
 class image {
 public:
-  image(image_channel_order order, image_channel_type type,
-        const range<dimensions> &range, const property_list &propList = {}) {
-    impl = std::make_shared<detail::image_impl<dimensions, AllocatorT>>(
-        order, type, range, propList);
+  image(image_channel_order Order, image_channel_type Type,
+        const range<Dimensions> &Range, const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        Order, Type, Range, PropList);
   }
 
-  //image(image_channel_order order, image_channel_type type,
-        //const range<dimensions> &range, AllocatorT allocator,
-        //const property_list &propList = {});
+  image(image_channel_order Order, image_channel_type Type,
+        const range<Dimensions> &Range, AllocatorT Allocator,
+        const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        Order, Type, Range, Allocator, PropList);
+  }
 
-  /* Available only when: dimensions > 1 */
-  //image(image_channel_order order, image_channel_type type,
-        //const range<dimensions> &range, const range<dimensions - 1> &pitch,
-        //const property_list &propList = {});
+  /* Available only when: dimensions >1 */
+  template <bool B = (Dimensions > 1)>
+  image(image_channel_order Order, image_channel_type Type,
+        const range<Dimensions> &Range,
+        typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        Order, Type, Range, Pitch, PropList);
+  }
 
-  /* Available only when: dimensions > 1 */
-  //image(image_channel_order order, image_channel_type type,
-        //const range<dimensions> &range, const range<dimensions - 1> &pitch,
-        //AllocatorT allocator, const property_list &propList = {});
+  /* Available only when: dimensions >1 */
+  template <bool B = (Dimensions > 1)>
+  image(image_channel_order Order, image_channel_type Type,
+        const range<Dimensions> &Range,
+        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        AllocatorT Allocator, const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        Order, Type, Range, Pitch, Allocator, PropList);
+  }
 
-  //image(void *hostPointer, image_channel_order order, image_channel_type type,
-        //const range<dimensions> &range, const property_list &propList = {});
+  image(void *HostPointer, image_channel_order Order, image_channel_type Type,
+        const range<Dimensions> &Range, const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, PropList);
+  }
 
-  //image(void *hostPointer, image_channel_order order, image_channel_type type,
-        //const range<dimensions> &range, AllocatorT allocator,
-        //const property_list &propList = {});
+  image(void *HostPointer, image_channel_order Order, image_channel_type Type,
+        const range<Dimensions> &Range, AllocatorT Allocator,
+        const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, Allocator, PropList);
+  }
 
-  //image(const void *hostPointer, image_channel_order order,
-        //image_channel_type type, const range<dimensions> &range,
-        //const property_list &propList = {});
+  image(const void *HostPointer, image_channel_order Order,
+        image_channel_type Type, const range<Dimensions> &Range,
+        const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, PropList);
+  }
 
-  //image(const void *hostPointer, image_channel_order order,
-        //image_channel_type type, const range<dimensions> &range,
-        //AllocatorT allocator, const property_list &propList = {});
+  image(const void *HostPointer, image_channel_order Order,
+        image_channel_type Type, const range<Dimensions> &Range,
+        AllocatorT Allocator, const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, Allocator, PropList);
+  }
 
-  /* Available only when: dimensions > 1 */
-  //image(void *hostPointer, image_channel_order order, image_channel_type type,
-        //const range<dimensions> &range, range<dimensions - 1> &pitch,
-        //const property_list &propList = {});
+  /* Available only when: dimensions >1 */
+  template <bool B = (Dimensions > 1)>
+  image(void *HostPointer, image_channel_order Order, image_channel_type Type,
+        const range<Dimensions> &Range,
+        typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, Pitch, PropList);
+  }
 
-  /* Available only when: dimensions > 1 */
-  //image(void *hostPointer, image_channel_order order, image_channel_type type,
-        //const range<dimensions> &range, range<dimensions - 1> &pitch,
-        //AllocatorT allocator, const property_list &propList = {});
+  /* Available only when: dimensions >1 */
+  template <bool B = (Dimensions > 1)>
+  image(void *HostPointer, image_channel_order Order, image_channel_type Type,
+        const range<Dimensions> &Range,
+        typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        AllocatorT Allocator, const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, Pitch, Allocator, PropList);
+  }
 
-  //image(shared_ptr_class<void> &hostPointer, image_channel_order order,
-        //image_channel_type type, const range<dimensions> &range,
-        //const property_list &propList = {});
+  image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
+        image_channel_type Type, const range<Dimensions> &Range,
+        const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, PropList);
+  }
 
-  //image(shared_ptr_class<void> &hostPointer, image_channel_order order,
-        //image_channel_type type, const range<dimensions> &range,
-        //AllocatorT allocator, const property_list &propList = {});
+  image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
+        image_channel_type Type, const range<Dimensions> &Range,
+        AllocatorT Allocator, const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, Allocator, PropList);
+  }
 
-  /* Available only when: dimensions > 1 */
-  //image(shared_ptr_class<void> &hostPointer, image_channel_order order,
-        //image_channel_type type, const range<dimensions> &range,
-        //const range<dimensions - 1> &pitch, const property_list &propList = {});
+  /* Available only when: dimensions >1 */
+  template <bool B = (Dimensions > 1)>
+  image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
+        image_channel_type Type, const range<Dimensions> &Range,
+        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, Pitch, PropList);
+  }
 
-  /* Available only when: dimensions > 1 */
-  //image(shared_ptr_class<void> &hostPointer, image_channel_order order,
-        //image_channel_type type, const range<dimensions> &range,
-        //const range<dimensions - 1> &pitch, AllocatorT allocator,
-        //const property_list &propList = {});
+  /* Available only when: dimensions >1 */
+  template <bool B = (Dimensions > 1)>
+  image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
+        image_channel_type Type, const range<Dimensions> &Range,
+        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        AllocatorT Allocator, const property_list &PropList = {}) {
+    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+        HostPointer, Order, Type, Range, Pitch, Allocator, PropList);
+  }
 
-  image(cl_mem clMemObject, const context &syclContext,
-        event availableEvent = {});
+  image(cl_mem ClMemObject, const context &SyclContext,
+        event AvailableEvent = {});
+
+  /* -- common interface members -- */
 
   image(const image &rhs) = default;
 
@@ -105,40 +193,47 @@ public:
 
   bool operator!=(const image &rhs) const { return !(*this == rhs); }
 
-  /* -- common interface members -- */
-
   /* -- property interface members -- */
+  template <typename propertyT> bool has_property() const {
+    return impl->template has_property<propertyT>();
+  }
 
-  range<dimensions> get_range() const { return impl->get_range(); }
+  template <typename propertyT> propertyT get_property() const {
+    return impl->template get_property<propertyT>();
+  }
 
-  /* Available only when: dimensions > 1 */
-  range<dimensions - 1> get_pitch() const { return impl->get_pitch(); }
+  range<Dimensions> get_range() const { return impl->get_range(); }
 
+  /* Available only when: dimensions >1 */
+  template <bool B = (Dimensions > 1)>
+  typename std::enable_if<B, range<Dimensions - 1>>::type get_pitch() const {
+    return impl->get_pitch();
+  }
+
+  // Returns the size of the image storage in bytes
   size_t get_size() const { return impl->get_size(); }
 
+  // Returns the total number of elements in the image
   size_t get_count() const { return impl->get_count(); }
 
+  // Returns the allocator provided to the image
   AllocatorT get_allocator() const { return impl->get_allocator(); }
 
-  template <typename dataT, access::mode accessMode>
-  accessor<dataT, dimensions, accessMode, access::target::image>
-  get_access(handler &commandGroupHandler) {
-    return impl->template get_access<dataT, accessMode>();
+  template <typename Destination = std::nullptr_t>
+  void set_final_data(Destination FinalData = nullptr) {
+    if (true)
+      throw cl::sycl::feature_not_supported("Feature Not Implemented");
+    return;
   }
 
-  template <typename dataT, access::mode accessMode>
-  accessor<dataT, dimensions, accessMode, access::target::host_image>
-  get_access() {
-    return impl->template get_access<dataT, accessMode>();
+  void set_write_back(bool Flag = true) {
+    if (true)
+      throw cl::sycl::feature_not_supported("Feature Not Implemented");
+    return;
   }
-
-  //template <typename Destination = std::nullptr_t>
-  //void set_final_data(Destination finalData = std::nullptr);
-
-  void set_write_back(bool flag = true) { impl->set_write_back(flag); }
 
 private:
-  shared_ptr_class<detail::image_impl<dimensions, AllocatorT>> impl;
+  shared_ptr_class<detail::image_impl<Dimensions, AllocatorT>> impl;
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 };
@@ -147,11 +242,12 @@ private:
 } // namespace cl
 
 namespace std {
-template <int dimensions, typename AllocatorT>
-struct hash<cl::sycl::image<dimensions, AllocatorT>> {
-  size_t operator()(const cl::sycl::image<dimensions, AllocatorT> &i) const {
+template <int Dimensions, typename AllocatorT>
+struct hash<cl::sycl::image<Dimensions, AllocatorT>> {
+  size_t operator()(const cl::sycl::image<Dimensions, AllocatorT> &I) const {
     return hash<std::shared_ptr<
-        cl::sycl::detail::image_impl<dimensions, AllocatorT>>>()(i.impl);
+        cl::sycl::detail::image_impl<Dimensions, AllocatorT>>>()(
+        cl::sycl::detail::getSyclObjImpl(I));
   }
 };
 } // namespace std

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -1,0 +1,80 @@
+//==------------ image_impl.cpp --------------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl/image.hpp>
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+uint8_t getImageNumberChannels(image_channel_order Order) {
+  switch (Order) {
+  case image_channel_order::a:
+  case image_channel_order::r:
+  case image_channel_order::rx:
+  case image_channel_order::intensity:
+  case image_channel_order::luminance:
+    return 1;
+  case image_channel_order::rg:
+  case image_channel_order::rgx:
+  case image_channel_order::ra:
+    return 2;
+  case image_channel_order::rgb:
+  case image_channel_order::rgbx:
+    return 3;
+  case image_channel_order::rgba:
+  case image_channel_order::argb:
+  case image_channel_order::bgra:
+  case image_channel_order::abgr:
+    return 4;
+  }
+  assert(!"Unhandled image channel order");
+  return 0;
+}
+
+// Returns the number of bytes per image element
+uint8_t getImageElementSize(uint8_t NumChannels, image_channel_type Type) {
+  size_t Retval = 0;
+  switch (Type) {
+  case image_channel_type::snorm_int8:
+  case image_channel_type::unorm_int8:
+  case image_channel_type::signed_int8:
+  case image_channel_type::unsigned_int8:
+    Retval = NumChannels;
+    break;
+  case image_channel_type::snorm_int16:
+  case image_channel_type::unorm_int16:
+  case image_channel_type::signed_int16:
+  case image_channel_type::unsigned_int16:
+  case image_channel_type::fp16:
+    Retval = 2 * NumChannels;
+    break;
+  case image_channel_type::signed_int32:
+  case image_channel_type::unsigned_int32:
+  case image_channel_type::fp32:
+    Retval = 4 * NumChannels;
+    break;
+  case image_channel_type::unorm_short_565:
+  case image_channel_type::unorm_short_555:
+    Retval = 2;
+    break;
+  case image_channel_type::unorm_int_101010:
+    Retval = 4;
+    break;
+  default:
+    assert(!"Unhandled image channel type");
+  }
+  // OpenCL states that "The number of bits per element determined by the
+  // image_channel_type and image_channel_order must be a power of two"
+  assert(((Retval - 1) & Retval) == 0);
+  return Retval;
+}
+
+} // namespace detail
+} // namespace sycl
+} // namespace cl

--- a/sycl/test/basic_tests/image_constructors.cpp
+++ b/sycl/test/basic_tests/image_constructors.cpp
@@ -1,0 +1,378 @@
+// RUN: %clang -std=c++11 %s -o %t1.out -lstdc++ -lOpenCL -lsycl
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %clang -std=c++11 -fsycl %s -o %t2.out -lstdc++ -lOpenCL -lsycl
+// RUN: env SYCL_DEVICE_TYPE=HOST %t2.out
+// RUN: %CPU_RUN_PLACEHOLDER %t2.out
+// RUN: %GPU_RUN_PLACEHOLDER %t2.out
+// RUN: %ACC_RUN_PLACEHOLDER %t2.out
+//==-------image_constructors.cpp - SYCL image constructors basic test------==//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+#include <cassert>
+
+void no_delete(void *) {}
+
+template <int Dims>
+void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
+
+  cl::sycl::image_channel_order channelOrder =
+      cl::sycl::image_channel_order::rgbx;
+  cl::sycl::image_channel_type channelType =
+      cl::sycl::image_channel_type::signed_int32;
+  unsigned int elementSize = 12; // rgbx * i32
+  int numElems = r.size();
+  cl::sycl::property_list propList{}; // empty property list
+
+  /* Constructor (void *, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const property_list& = {})
+   */
+  {
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(imageHostPtr, channelOrder, channelType, r);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (void *, image_channel_order,
+   *              image_channel_type, const range<3>&, const property_list&)
+   */
+  {
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        imageHostPtr, channelOrder, channelType, r, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (void *, image_channel_order,
+   *              image_channel_type, const range<3>&, allocator,
+   *              const property_list& = {})
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        imageHostPtr, channelOrder, channelType, r, imgAlloc);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (void *, image_channel_order,
+   *              image_channel_type, const range<3>&, allocator,
+   *              const property_list&)
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        imageHostPtr, channelOrder, channelType, r, imgAlloc, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+  /* Constructor (const void*, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const property_list& = {})
+   */
+  {
+    const auto constHostPtr = imageHostPtr;
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(constHostPtr, channelOrder, channelType, r);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (const void*, image_channel_order,
+   *              image_channel_type, const range<3>&, const property_list&)
+   */
+  {
+    const auto constHostPtr = imageHostPtr;
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        constHostPtr, channelOrder, channelType, r, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (const void*, image_channel_order,
+   *              image_channel_type, const range<3>&, allocator,
+   *              const property_list& = {})
+   */
+  {
+    const auto constHostPtr = imageHostPtr;
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        constHostPtr, channelOrder, channelType, r, imgAlloc);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (const void*, image_channel_order,
+   *              image_channel_type, const range<3>&, allocator,
+   *              const property_list&)
+   */
+  {
+    const auto constHostPtr = imageHostPtr;
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        constHostPtr, channelOrder, channelType, r, imgAlloc, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (shared_ptr_class<void>&, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const property_list& = {})
+   */
+  {
+    auto hostPointer =
+        cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(hostPointer, channelOrder, channelType, r);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (shared_ptr_class<void>&, image_channel_order,
+   *              image_channel_type, const range<3>&, const property_list&)
+   */
+  {
+    auto hostPointer =
+        cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(hostPointer, channelOrder,
+                                                      channelType, r, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (shared_ptr_class<void>&, image_channel_order,
+   *              image_channel_type, const range<3>&, allocator,
+   *              const property_list& = {})
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    auto hostPointer =
+        cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(hostPointer, channelOrder,
+                                                      channelType, r, imgAlloc);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (shared_ptr_class<void>&, image_channel_order,
+   *              image_channel_type, const range<3>&, allocator,
+   *              const property_list&)
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    auto hostPointer =
+        cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        hostPointer, channelOrder, channelType, r, imgAlloc, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (image_channel_order, image_channel_type,
+   *              const range<3>&, const property_list& = {})
+   */
+  {
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(channelOrder, channelType, r);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (image_channel_order, image_channel_type,
+   *              const range<3>&, const property_list&)
+   */
+  {
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(channelOrder, channelType, r, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (image_channel_order, image_channel_type,
+   *              const range<3>&, allocator, const property_list& = {})
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(channelOrder, channelType, r, imgAlloc);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (image_channel_order, image_channel_type,
+   *              const range<3>&, allocator, const property_list&)
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(channelOrder, channelType, r, imgAlloc, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+}
+
+template <int Dims>
+void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-1> pitch, void *imageHostPtr) {
+
+  cl::sycl::image_channel_order channelOrder =
+      cl::sycl::image_channel_order::rgbx;
+  cl::sycl::image_channel_type channelType =
+      cl::sycl::image_channel_type::signed_int32;
+  unsigned int elementSize = 12; // rgbx * i32
+  int numElems = r.size();
+  cl::sycl::property_list propList{}; // empty property list
+
+
+  /* Constructor (void *, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const range<3 - 1>&, const property_list& = {})
+   */
+  {
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        imageHostPtr, channelOrder, channelType, r, pitch);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (void *, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const range<3 - 1>&, const property_list&)
+   */
+  {
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        imageHostPtr, channelOrder, channelType, r, pitch, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (void *, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const range<3 - 1>&, allocator,
+   *              const property_list& = {})
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        imageHostPtr, channelOrder, channelType, r, pitch, imgAlloc);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (void *, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const range<3 - 1>&, allocator, const property_list&)
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        imageHostPtr, channelOrder, channelType, r, pitch, imgAlloc, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (shared_ptr_class<void>&, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const range<3 - 1>&, const property_list& = {})
+   */
+  {
+    auto hostPointer =
+        cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(hostPointer, channelOrder, channelType, r, pitch);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (shared_ptr_class<void>&, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const range<3 - 1>&, const property_list&)
+   */
+  {
+    auto hostPointer =
+        cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        hostPointer, channelOrder, channelType, r, pitch, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (shared_ptr_class<void>&, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const range<3 - 1>&, allocator,
+   *              const property_list& = {})
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    auto hostPointer =
+        cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        hostPointer, channelOrder, channelType, r, pitch, imgAlloc);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (shared_ptr_class<void>&, image_channel_order,
+   *              image_channel_type, const range<3>&,
+   *              const range<3 - 1>&, allocator, const property_list&)
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    auto hostPointer =
+        cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        hostPointer, channelOrder, channelType, r, pitch, imgAlloc, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (image_channel_order, image_channel_type,
+   *              const range<3>&, const range<3 - 1>&,
+   *              const property_list& = {})
+   */
+  {
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(channelOrder, channelType, r, pitch);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (image_channel_order, image_channel_type,
+   *              const range<3>&, const range<3 - 1>&,
+   *              const property_list&)
+   */
+  {
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(channelOrder, channelType, r, pitch, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (image_channel_order, image_channel_type,
+   *              const range<3>&, const range<3 - 1>&, allocator,
+   *              const property_list& = {})
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img =
+        cl::sycl::image<Dims>(channelOrder, channelType, r, pitch, imgAlloc);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+
+  /* Constructor (image_channel_order, image_channel_type,
+   *              const range<3>&, const range<3 - 1>&, allocator,
+   *              const property_list&)
+   */
+  {
+    cl::sycl::image_allocator imgAlloc;
+    cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
+        channelOrder, channelType, r, pitch, imgAlloc, propList);
+    assert(img.get_size() == (numElems * elementSize));
+  }
+}
+
+int main() {
+
+  int imageHostPtr[144]; // 16*9
+  for (int i = 0; i < 144; i++)
+    imageHostPtr[i] = i; // Maximum number of elements.
+
+  // Ranges 
+  cl::sycl::range<1> r1(3);
+  cl::sycl::range<2> r2(3, 2);
+  cl::sycl::range<3> r3(3, 2, 4);
+  
+  // Pitches
+  cl::sycl::range<1> pitch2(36); // range is 3; elementSize = 12.
+  cl::sycl::range<2> pitch3(36, 72); // range is 3,2; elementSize = 12.
+  
+  // Constructors without Pitch
+  test_constructors<1>(r1, imageHostPtr);
+  test_constructors<2>(r2, imageHostPtr);
+  test_constructors<3>(r3, imageHostPtr);
+
+  // Constructors with Pitch
+  test_constructors_with_pitch<2>(r2, pitch2, imageHostPtr);
+  test_constructors_with_pitch<3>(r3, pitch3, imageHostPtr);
+
+  return 0;
+}


### PR DESCRIPTION
Patch 1: Implementation of Constructors for image class.
Files Added:
image.hpp - Includes the interface for image class.
detail/image_impl.hpp - Includes the implementation of image_impl class.
detail/image_impl.cpp - For now includes the utility functions. Will be
	expanded later as accessor and other APIs are implemented.
Next To Do:
SPIRV Code generation and accessors implementations.

Signed-off-by: Garima Gupta <garima.gupta@intel.com>