### PR TITLE
[WIP][SYCL] Disable compilation of host-only code for SYCL device

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -920,6 +920,7 @@ public:
                           void>::type
   copy(accessor<T_Src, Dims, AccessMode, AccessTarget, IsPlaceholder> Src,
        T_Dst *Dst) {
+#ifndef __SYCL_DEVICE_ONLY__
     if (MIsHost) {
       // TODO: Temporary implementation for host. Should be handled by memory
       // manger.
@@ -935,6 +936,7 @@ public:
 
       return;
     }
+#endif
     MCGType = detail::CG::COPY_ACC_TO_PTR;
 
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Src;
@@ -958,6 +960,7 @@ public:
   copy(const T_Src *Src,
        accessor<T_Dst, Dims, AccessMode, AccessTarget, IsPlaceholder> Dst) {
 
+#ifndef __SYCL_DEVICE_ONLY__
     if (MIsHost) {
       // TODO: Temporary implementation for host. Should be handled by memory
       // manger.
@@ -971,9 +974,9 @@ public:
 
         Dst[Index] = ((T_Dst *)Src)[LinearIndex];
       });
-
       return;
     }
+#endif
     MCGType = detail::CG::COPY_PTR_TO_ACC;
 
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Dst;
@@ -1011,6 +1014,7 @@ public:
                 IsPlaceholder_Dst>
            Dst) {
 
+#ifndef __SYCL_DEVICE_ONLY__
     if (MIsHost) {
       range<Dims_Src> Range = Dst.get_range();
       parallel_for< class __copyAcc2Acc< T_Src, Dims_Src, AccessMode_Src,
@@ -1024,6 +1028,7 @@ public:
 
       return;
     }
+#endif
     MCGType = detail::CG::COPY_ACC_TO_ACC;
 
     detail::AccessorBaseHost *AccBaseSrc = (detail::AccessorBaseHost *)&Src;


### PR DESCRIPTION
The code under `MIsHost' is invalid for SYCL device, because it
captures a host pointer (which cannot be accessed on a device).

This bug should probably fixed some other way, but let's have this for
now.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>