### PR TITLE
[SYCL] add support for -fsycl-link

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -235,6 +235,7 @@ def err_drv_invalid_omp_target : Error<"OpenMP target is invalid: '%0'">;
 def err_drv_invalid_sycl_target : Error<"SYCL target is invalid: '%0'">;
 def err_drv_sycl_target_conflict : Error<"The option -fsycl-targets conflicts with -fsycl-link-targets">;
 def err_drv_sycl_add_link_conflict : Error<"The option -fsycl-link-targets conflicts with -fsycl-add-targets">;
+def err_drv_sycl_link_link_targets_conflict : Error<"The option -fsycl-link-targets conflicts with -fsycl-link">;
 def err_drv_omp_host_ir_file_not_found : Error<
   "The provided host compiler IR file '%0' is required to generate code for OpenMP target regions but cannot be found.">;
 def err_drv_omp_host_target_not_supported : Error<

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1719,6 +1719,8 @@ def fsycl_use_bitcode : Flag<["-"], "fsycl-use-bitcode">,
   Flags<[CC1Option]>, HelpText<"Use LLVM bitcode instead of SPIR-V in fat objects">;
 def fno_sycl_use_bitcode : Flag<["-"], "fno-sycl-use-bitcode">,
   Flags<[CC1Option]>, HelpText<"Use SPIR-V instead of LLVM bitcode in fat objects">;
+def fsycl_link : Flag<["-"], "fsycl-link">,
+  Flags<[CC1Option]>, HelpText<"Generate partially linked device object to be used with the host link">;
 def fsyntax_only : Flag<["-"], "fsyntax-only">,
   Flags<[DriverOption,CoreOption,CC1Option]>, Group<Action_Group>;
 def ftabstop_EQ : Joined<["-"], "ftabstop=">, Group<f_Group>;

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -282,6 +282,32 @@
 
 /// ###########################################################################
 
+/// Check -fsycl-link behaviors unbundle
+// RUN:   touch %t.o
+// RUN:   %clang -### -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -o %t.out -fsycl-link %t.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-LINK-UB %s
+// CHK-LINK-UB: 0: input, "[[INPUT:.+\.o]]", object
+// CHK-LINK-UB: 1: clang-offload-unbundler, {0}, object
+// CHK-LINK-UB: 2: linker, {1}, image, (device-sycl)
+// CHK-LINK-UB: 3: clang-offload-wrapper, {2}, object, (device-sycl)
+// CHK-LINK-UB: 4: offload, "device-sycl (spir64-unknown-linux-sycldevice)" {3}, object
+
+/// ###########################################################################
+
+/// Check -fsycl-link behaviors from source
+// RUN:   %clang -### -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -o %t.out -fsycl-link %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-LINK %s
+// CHK-LINK: 0: input, "[[INPUT:.+\.c]]", c, (device-sycl)
+// CHK-LINK: 1: preprocessor, {0}, cpp-output, (device-sycl)
+// CHK-LINK: 2: compiler, {1}, ir, (device-sycl)
+// CHK-LINK: 3: backend, {2}, assembler, (device-sycl)
+// CHK-LINK: 4: assembler, {3}, object, (device-sycl)
+// CHK-LINK: 5: linker, {4}, image, (device-sycl)
+// CHK-LINK: 6: clang-offload-wrapper, {5}, object, (device-sycl)
+// CHK-LINK: 7: offload, "device-sycl (spir64-unknown-linux-sycldevice)" {6}, object
+
+/// ###########################################################################
+
 /// Check -fsycl-add-targets=<triple> behaviors unbundle
 // RUN:   touch %t.o
 // RUN:   %clang -### -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -o %t.out -fsycl-add-targets=spir64-unknown-linux-sycldevice:dummy.spv %t.o 2>&1 \


### PR DESCRIPTION
Generate a wrapped device binary that can be used independently with a host
link step.  Takes the provided fat objects or source, extracts or creates the
associated device binaries and wraps them to be used during a regular host
link step

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>