### PR TITLE
[SYCL] Fix two build time errors reported by MSVC 2019

### DIFF
--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -60,8 +60,8 @@ public:
 
 private:
   std::shared_ptr<detail::context_impl> impl;
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
   template <class T>
   friend

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -116,7 +116,7 @@ protected:
   void *getPtr() const { return const_cast<void *>(impl->MData); }
 
   template <class Obj>
-  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
+  friend decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject);
 
   AccessorImplPtr impl;
 };
@@ -150,7 +150,7 @@ public:
 
 protected:
   template <class Obj>
-  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
+  friend decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject);
 
   std::shared_ptr<LocalAccessorImplHost> impl;
 };

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -82,7 +82,7 @@ namespace detail {
 // Note! This function relies on the fact that all SYCL interface classes
 // contain "impl" field that points to implementation object. "impl" field
 // should be accessible from this function.
-template <class T> decltype(T::impl) getSyclObjImpl(const T &SyclObject) {
+template <class Obj> decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject) {
   return SyclObject.impl;
 }
 

--- a/sycl/include/CL/sycl/device.hpp
+++ b/sycl/include/CL/sycl/device.hpp
@@ -98,8 +98,8 @@ public:
 
 private:
   std::shared_ptr<detail::device_impl> impl;
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 };
 
 } // namespace sycl

--- a/sycl/include/CL/sycl/event.hpp
+++ b/sycl/include/CL/sycl/event.hpp
@@ -62,8 +62,8 @@ private:
 
   std::shared_ptr<detail::event_impl> impl;
 
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -184,7 +184,7 @@ private:
   }
 
 protected:
-  friend class detail::Builder;
+  friend struct detail::Builder;
   group(const range<dimensions> &G, const range<dimensions> &L,
         const id<dimensions> &I)
       : globalRange(G), localRange(L), index(I) {}

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -20,8 +20,8 @@ class program;
 class context;
 
 class kernel {
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -165,7 +165,7 @@ template <int dimensions = 1> struct nd_item {
   }
 
 protected:
-  friend class detail::Builder;
+  friend struct detail::Builder;
   nd_item(const item<dimensions, true> &GL, const item<dimensions, false> &L,
           const group<dimensions> &GR)
       : globalItem(GL), localItem(L), Group(GR) {}

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -63,8 +63,8 @@ public:
 
 private:
   std::shared_ptr<detail::platform_impl> impl;
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 }; // class platform
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -23,8 +23,8 @@ class device;
 class kernel;
 
 class program {
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -105,8 +105,8 @@ public:
 
 private:
   std::shared_ptr<detail::queue_impl> impl;
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 };
 
 } // namespace sycl

--- a/sycl/include/CL/sycl/sampler.hpp
+++ b/sycl/include/CL/sycl/sampler.hpp
@@ -64,8 +64,8 @@ private:
   char padding[sizeof(std::shared_ptr<detail::sampler_impl>) - sizeof(impl)];
 #else
   std::shared_ptr<detail::sampler_impl> impl;
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 #endif
 };
 } // namespace sycl

--- a/sycl/include/CL/sycl/stream.hpp
+++ b/sycl/include/CL/sycl/stream.hpp
@@ -101,8 +101,8 @@ private:
   char padding[sizeof(std::shared_ptr<detail::stream_impl>)];
 #else
   std::shared_ptr<detail::stream_impl> impl;
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 #endif
 
   // Accessor to stream buffer

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -48,6 +48,8 @@
 #include <CL/sycl/half_type.hpp>
 #include <CL/sycl/multi_ptr.hpp>
 
+#include <array>
+
 // 4.10.1: Scalar data types
 // 4.10.2: SYCL vector types
 


### PR DESCRIPTION
1) Fix error: "'detail::getSyclObjImpl': not a function".
2) Fix error: "subscript requires array or pointer type" for std::array use.
3) Fix few warnings caused by inconsistent usage of class-vs-struct keyword.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>