### PR TITLE
[SYCL] Align global_mem_cache_type values with SYCL specification.

### DIFF
--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -162,7 +162,7 @@ enum class fp_config : cl_device_fp_config {
   soft_float
 };
 
-enum class global_mem_cache_type : int { none, read_only, write_only };
+enum class global_mem_cache_type : int { none, read_only, read_write };
 
 enum class execution_capability : unsigned int {
   exec_kernel,

--- a/sycl/source/detail/device_info.cpp
+++ b/sycl/source/detail/device_info.cpp
@@ -284,7 +284,7 @@ get_device_info_host<info::device::double_fp_config>() {
 template <>
 info::global_mem_cache_type
 get_device_info_host<info::device::global_mem_cache_type>() {
-  return info::global_mem_cache_type::write_only;
+  return info::global_mem_cache_type::read_write;
 }
 
 template <>

--- a/sycl/test/basic_tests/info.cpp
+++ b/sycl/test/basic_tests/info.cpp
@@ -79,8 +79,8 @@ template <> std::string info_to_string(info::global_mem_cache_type info) {
     return "none";
   case info::global_mem_cache_type::read_only:
     return "read_only";
-  case info::global_mem_cache_type::write_only:
-    return "write_only";
+  case info::global_mem_cache_type::read_write:
+    return "read_write";
   }
 }
 


### PR DESCRIPTION
Rename global_mem_cache_type::write_only to global_mem_cache_type::read_write.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>