### PR TITLE
[SYCL] Check return of Expected<T> when reading section size content

### DIFF
--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -555,9 +555,12 @@ public:
       if (matchSectionName(SIZE_SECTION_PREFIX, *Sec, OffloadTriple)) {
         // yes, it is - parse object sizes
         Expected<StringRef> Content = Sec->getContents();
+        if (!Content) {
+          consumeError(Content.takeError());
+          return;
+        }
         unsigned int ElemSize =
             getSectionSizeTy(VMContext)->getPrimitiveSizeInBits() / 8;
-
         // the size of the size section must be a multiple of ElemSize
         if (Content->size() % ElemSize != 0)
           report_fatal_error(


### PR DESCRIPTION
Community pull down introduced Expected<T> on the return of getContents.  Apply
the needed check after return to satisfy.

From the llvm manual: All Error instances, whether success or failure, must be
either checked or moved from (via std::move or a return) before they are
destructed

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>