### PR TITLE
[SYCL] Implement hierarchical parallelism API.

### DIFF
--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -11,7 +11,6 @@
 #include <CL/__spirv/spirv_types.hpp>
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/detail/common.hpp>
-
 #include <memory>
 #include <stdexcept>
 #include <type_traits>
@@ -27,6 +26,8 @@ template <int dimensions> class range;
 template <int dimensions> struct id;
 template <int dimensions> class nd_item;
 enum class memory_order;
+template <int dimensions> class h_item;
+
 namespace detail {
 class context_impl;
 // The function returns list of events that can be passed to OpenCL API as
@@ -68,6 +69,21 @@ struct Builder {
                const cl::sycl::item<dimensions, false> &L,
                const cl::sycl::group<dimensions> &GR) {
     return cl::sycl::nd_item<dimensions>(GL, L, GR);
+  }
+
+  template <int dimensions>
+  static h_item<dimensions>
+  createHItem(const cl::sycl::item<dimensions, false> &GlobalItem,
+              const cl::sycl::item<dimensions, false> &LocalItem) {
+    return cl::sycl::h_item<dimensions>(GlobalItem, LocalItem);
+  }
+
+  template <int dimensions>
+  static h_item<dimensions>
+  createHItem(const cl::sycl::item<dimensions, false> &GlobalItem,
+              const cl::sycl::item<dimensions, false> &LocalItem,
+              const cl::sycl::range<dimensions> &FlexRange) {
+    return cl::sycl::h_item<dimensions>(GlobalItem, LocalItem, FlexRange);
   }
 };
 

--- a/sycl/include/CL/sycl/h_item.hpp
+++ b/sycl/include/CL/sycl/h_item.hpp
@@ -1,0 +1,131 @@
+//==-------------- h_item.hpp - SYCL standard header file ------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl/id.hpp>
+#include <CL/sycl/item.hpp>
+
+namespace cl {
+namespace sycl {
+
+namespace detail {
+class Builder;
+}
+
+template <int dimensions> class h_item {
+public:
+  h_item() = delete;
+
+  h_item(const h_item<dimensions> &hi) = default;
+
+  h_item<dimensions> &operator=(const h_item<dimensions> &hi) = default;
+
+  /* -- public interface members -- */
+  item<dimensions, false> get_global() const { return globalItem; }
+
+  item<dimensions, false> get_local() const { return get_logical_local(); }
+
+  item<dimensions, false> get_logical_local() const { return logicalLocalItem; }
+
+  item<dimensions, false> get_physical_local() const { return localItem; }
+
+  range<dimensions> get_global_range() const {
+    return get_global().get_range();
+  }
+
+  size_t get_global_range(int dimension) const {
+    return get_global().get_range(dimension);
+  }
+
+  id<dimensions> get_global_id() const { return get_global().get_id(); }
+
+  size_t get_global_id(int dimension) const {
+    return get_global().get_id(dimension);
+  }
+
+  range<dimensions> get_local_range() const { return get_local().get_range(); }
+
+  size_t get_local_range(int dimension) const {
+    return get_local().get_range(dimension);
+  }
+
+  id<dimensions> get_local_id() const { return get_local().get_id(); }
+
+  size_t get_local_id(int dimension) const {
+    return get_local().get_id(dimension);
+  }
+
+  range<dimensions> get_logical_local_range() const {
+    return get_logical_local().get_range();
+  }
+
+  size_t get_logical_local_range(int dimension) const {
+    return get_logical_local().get_range(dimension);
+  }
+
+  id<dimensions> get_logical_local_id() const {
+    return get_logical_local().get_id();
+  }
+
+  size_t get_logical_local_id(int dimension) const {
+    return get_logical_local().get_id(dimension);
+  }
+
+  range<dimensions> get_physical_local_range() const {
+    return get_physical_local().get_range();
+  }
+
+  size_t get_physical_local_range(int dimension) const {
+    return get_physical_local().get_range(dimension);
+  }
+
+  id<dimensions> get_physical_local_id() const {
+    return get_physical_local().get_id();
+  }
+
+  size_t get_physical_local_id(int dimension) const {
+    return get_physical_local().get_id(dimension);
+  }
+
+  bool operator==(const h_item<dimensions> &rhs) const {
+    return (rhs.localItem == localItem) && (rhs.globalItem == globalItem) &&
+           (rhs.logicalLocalItem == logicalLocalItem);
+  }
+
+  bool operator!=(const h_item<dimensions> &rhs) const {
+    return !((*this) == rhs);
+  }
+
+protected:
+  friend class detail::Builder;
+  friend class group<dimensions>;
+  h_item(const item<dimensions, false> &GL, const item<dimensions, false> &L,
+         const range<dimensions> &flexLocalRange)
+      : globalItem(GL), localItem(L),
+        logicalLocalItem(flexLocalRange, L.get_id()) {}
+
+  h_item(const item<dimensions, false> &GL, const item<dimensions, false> &L)
+      : globalItem(GL), localItem(L),
+        logicalLocalItem(localItem.get_range(), localItem.get_id()) {}
+
+  void setLogicalLocalID(const id<dimensions> &ID) {
+    logicalLocalItem.setID(ID);
+  }
+
+private:
+  /// Describles physical workgroup range and current \c h_item position in it.
+  item<dimensions, false> localItem;
+  /// Describles global range and current \c h_item position in it.
+  item<dimensions, false> globalItem;
+  /// Describles logical flexible range and current \c h_item position in it.
+  item<dimensions, false> logicalLocalItem;
+};
+
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -9,63 +9,61 @@
 #pragma once
 
 #include <CL/sycl/detail/array.hpp>
-#include <CL/sycl/item.hpp>
+#include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/range.hpp>
 
 namespace cl {
 namespace sycl {
 template <int dimensions> class range;
+template <int dimensions, bool with_offset> class item;
 template <int dimensions = 1> struct id : public detail::array<dimensions> {
 private:
   using base = detail::array<dimensions>;
   static_assert(dimensions >= 1 && dimensions <= 3,
                 "id can only be 1, 2, or 3 dimentional.");
+  template <int N, int val, typename T>
+  using ParamTy = detail::enable_if_t<(N == val), T>;
+
 public:
   id() = default;
 
   /* The following constructor is only available in the id struct
    * specialization where: dimensions==1 */
-  template <int N = dimensions>
-  id(typename std::enable_if<(N == 1), size_t>::type dim0) : base(dim0) {}
+  template <int N = dimensions> id(ParamTy<N, 1, size_t> dim0) : base(dim0) {}
 
   template <int N = dimensions>
-  id(typename std::enable_if<(N == 1), const range<dimensions> &>::type
-         range_size)
+  id(ParamTy<N, 1, const range<dimensions>> &range_size)
       : base(range_size.get(0)) {}
 
-  template <int N = dimensions>
-  id(typename std::enable_if<(N == 1), const item<dimensions> &>::type item)
+  template <int N = dimensions, bool with_offset = true>
+  id(ParamTy<N, 1, const item<dimensions, with_offset>> &item)
       : base(item.get_id(0)) {}
 
   /* The following constructor is only available in the id struct
    * specialization where: dimensions==2 */
   template <int N = dimensions>
-  id(typename std::enable_if<(N == 2), size_t>::type dim0, size_t dim1)
-      : base(dim0, dim1) {}
+  id(ParamTy<N, 2, size_t> dim0, size_t dim1) : base(dim0, dim1) {}
 
   template <int N = dimensions>
-  id(typename std::enable_if<(N == 2), const range<dimensions> &>::type
-         range_size)
+  id(ParamTy<N, 2, const range<dimensions>> &range_size)
       : base(range_size.get(0), range_size.get(1)) {}
 
-  template <int N = dimensions>
-  id(typename std::enable_if<(N == 2), const item<dimensions> &>::type item)
+  template <int N = dimensions, bool with_offset = true>
+  id(ParamTy<N, 2, const item<dimensions, with_offset>> &item)
       : base(item.get_id(0), item.get_id(1)) {}
 
   /* The following constructor is only available in the id struct
    * specialization where: dimensions==3 */
   template <int N = dimensions>
-  id(typename std::enable_if<(N == 3), size_t>::type dim0, size_t dim1,
-     size_t dim2)
+  id(ParamTy<N, 3, size_t> dim0, size_t dim1, size_t dim2)
       : base(dim0, dim1, dim2) {}
 
   template <int N = dimensions>
-  id(typename std::enable_if<(N == 3), const range<dimensions> &>::type
-         range_size)
+  id(ParamTy<N, 3, const range<dimensions>> &range_size)
       : base(range_size.get(0), range_size.get(1), range_size.get(2)) {}
 
-  template <int N = dimensions>
-  id(typename std::enable_if<(N == 3), const item<dimensions> &>::type item)
+  template <int N = dimensions, bool with_offset = true>
+  id(ParamTy<N, 3, const item<dimensions, with_offset>> &item)
       : base(item.get_id(0), item.get_id(1), item.get_id(2)) {}
 
   explicit operator range<dimensions>() const {

--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -20,6 +20,8 @@ struct Builder;
 }
 template <int dimensions> struct id;
 template <int dimensions> class range;
+template <int dimensions> class h_item;
+
 template <int dimensions = 1, bool with_offset = true> struct item {
 
   item() = delete;
@@ -86,6 +88,7 @@ protected:
   // For call constructor inside conversion operator
   friend struct item<dimensions, false>;
   friend struct item<dimensions, true>;
+  friend struct h_item<dimensions>;
   friend struct detail::Builder;
 
   template <size_t W = with_offset>
@@ -97,6 +100,8 @@ protected:
   item(typename std::enable_if<(W == false), const range<dimensions>>::type &R,
        const id<dimensions> &I)
       : extent(R), index(I), offset() {}
+
+  void setID(const id<dimensions> &ID) { index = ID; }
 
 private:
   range<dimensions> extent;

--- a/sycl/test/hier_par/hier_par_basic.cpp
+++ b/sycl/test/hier_par/hier_par_basic.cpp
@@ -1,0 +1,187 @@
+//==- hier_par_basic.cpp --- hierarchical parallelism API test -------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %clang -std=c++11 -fsycl %s -o %t.out -lOpenCL -lstdc++
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// This test checks hierarchical parallelism invocation APIs, but without any
+// data or code with side-effects between the work group and work item scopes.
+
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <memory>
+
+using namespace cl::sycl;
+
+template <typename GoldFnTy>
+bool verify(int testcase, int range_length, int *ptr, GoldFnTy get_gold) {
+  int err_cnt = 0;
+
+  for (int i = 0; i < range_length; i++) {
+    int gold = get_gold(i);
+
+    if (ptr[i] != gold) {
+      if (++err_cnt < 20) {
+        std::cout << testcase << " - ERROR at " << i << ": " << ptr[i]
+                  << " != " << gold << "(expected)\n";
+      }
+    }
+  }
+  if (err_cnt > 0)
+    std::cout << "-- Failure rate: " << err_cnt << "/" << range_length << "("
+              << err_cnt / (float)range_length * 100.f << "%)\n";
+  return err_cnt == 0;
+}
+
+int main() {
+  constexpr int N_WG = 7;
+  constexpr int WG_SIZE_PHYSICAL = 3;
+  constexpr int WG_SIZE_GREATER_THAN_PHYSICAL = 5;
+  constexpr int WG_SIZE_LESS_THAN_PHYSICAL = 2;
+  constexpr int N_ITER = 2;
+
+  constexpr size_t range_length = N_WG * WG_SIZE_PHYSICAL;
+  std::unique_ptr<int> data(new int[range_length]);
+  int *ptr = data.get();
+  bool passed = true;
+
+  try {
+    queue myQueue;
+
+    std::cout << "Running on "
+              << myQueue.get_device().get_info<cl::sycl::info::device::name>()
+              << "\n";
+    {
+      // Testcase1
+      // - handler::parallel_for_work_group w/o local size specification +
+      //   group::parallel_for_work_item w/o flexible range
+      // - h_item::get_global_id
+      // The global size is not known, so kernel code needs to adapt
+      // dynamically, hence the complex loop bound and index computation.
+      std::memset(ptr, 0, range_length * sizeof(ptr[0]));
+      buffer<int, 1> buf(ptr, range<1>(range_length));
+      myQueue.submit([&](handler &cgh) {
+        auto dev_ptr = buf.get_access<access::mode::read_write>(cgh);
+        // number of 'buf' elements per work group:
+        size_t wg_chunk = (range_length + N_WG - 1) / N_WG;
+
+        cgh.parallel_for_work_group<class hpar_simple>(
+            range<1>(N_WG), [=](group<1> g) {
+              size_t wg_offset = wg_chunk * g.get_id(0);
+              size_t wg_size = g.get_local_range(0);
+
+              for (int cnt = 0; cnt < N_ITER; cnt++) {
+                g.parallel_for_work_item([&](h_item<1> i) {
+                  // number of buf elements per work item:
+                  size_t wi_chunk = (wg_chunk + wg_size - 1) / wg_size;
+                  auto id = i.get_physical_local_id().get(0);
+                  if (id >= wg_chunk)
+                    return;
+                  size_t wi_offset = wg_offset + id * wi_chunk;
+                  size_t ub = cl::sycl::min(wi_offset + wi_chunk, range_length);
+
+                  for (size_t ind = wi_offset; ind < ub; ind++)
+                    dev_ptr[ind]++;
+                });
+              }
+            });
+      });
+      auto ptr1 = buf.get_access<access::mode::read>().get_pointer();
+      passed &=
+          verify(1, range_length, ptr1, [&](int i) -> int { return N_ITER; });
+    }
+
+    {
+      // Testcase2
+      // - handler::parallel_for_work_group with local size specification +
+      //   group::parallel_for_work_item with flexible range
+      // - h_item::get_global_id
+      std::memset(ptr, 0, range_length * sizeof(ptr[0]));
+      buffer<int, 1> buf(ptr, range<1>(range_length));
+      myQueue.submit([&](handler &cgh) {
+        auto dev_ptr = buf.get_access<access::mode::read_write>(cgh);
+
+        cgh.parallel_for_work_group<class hpar_flex>(
+            range<1>(N_WG), range<1>(WG_SIZE_PHYSICAL), [=](group<1> g) {
+              for (int cnt = 0; cnt < N_ITER; cnt++) {
+                g.parallel_for_work_item(
+                    range<1>(WG_SIZE_GREATER_THAN_PHYSICAL),
+                    [&](h_item<1> i) { dev_ptr[i.get_global_id(0)]++; });
+                g.parallel_for_work_item(
+                    range<1>(WG_SIZE_LESS_THAN_PHYSICAL),
+                    [&](h_item<1> i) { dev_ptr[i.get_global_id(0)]++; });
+              }
+            });
+      });
+      auto ptr1 = buf.get_access<access::mode::read>().get_pointer();
+      passed &= verify(2, range_length, ptr1, [&](int i) -> int {
+        // consider increments by the first PFWI:
+        int gold = (WG_SIZE_GREATER_THAN_PHYSICAL - 1) / WG_SIZE_PHYSICAL;
+        if (i % WG_SIZE_PHYSICAL <
+            WG_SIZE_GREATER_THAN_PHYSICAL % WG_SIZE_PHYSICAL) {
+          gold++;
+        }
+        // consider increments by the second PFWI:
+        if (i % WG_SIZE_PHYSICAL < WG_SIZE_LESS_THAN_PHYSICAL) {
+          gold++;
+        }
+        gold *= N_ITER;
+        return gold;
+      });
+    }
+
+    {
+      // Testcase3
+      // - handler::parallel_for_work_group with local size specification +
+      //   group::parallel_for_work_item with flexible range
+      // - h_item::get_logical_local_id,get_physical_local_id
+      std::memset(ptr, 0, range_length * sizeof(ptr[0]));
+      buffer<int, 1> buf(ptr, range<1>(range_length));
+      myQueue.submit([&](handler &cgh) {
+        auto dev_ptr = buf.get_access<access::mode::read_write>(cgh);
+
+        cgh.parallel_for_work_group<class hpar_hitem>(
+            range<1>(N_WG), range<1>(WG_SIZE_PHYSICAL), [=](group<1> g) {
+              for (int cnt = 0; cnt < N_ITER; cnt++) {
+                g.parallel_for_work_item(
+                    range<1>(WG_SIZE_GREATER_THAN_PHYSICAL), [&](h_item<1> i) {
+                      int n =
+                          i.get_logical_local_id() == i.get_physical_local_id()
+                              ? 0
+                              : 1;
+                      dev_ptr[i.get_global_id(0)] += n;
+                    });
+              }
+            });
+      });
+      auto ptr1 = buf.get_access<access::mode::read>().get_pointer();
+      passed &= verify(3, range_length, ptr1, [&](int i) -> int {
+        int gold = 0;
+        if (i % WG_SIZE_PHYSICAL <
+            WG_SIZE_GREATER_THAN_PHYSICAL % WG_SIZE_PHYSICAL) {
+          gold++;
+        }
+        gold *= N_ITER;
+        return gold;
+      });
+    }
+  } catch (cl::sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    return 2;
+  }
+
+  if (passed) {
+    std::cout << "Passed\n";
+    return 0;
+  }
+  std::cout << "FAILED\n";
+  return 1;
+}


### PR DESCRIPTION
This is the first part of SYCL hierarchical parallelism implementation. It
implements all related APIs:

- h_item class
- group::parallel_for_work_item functions
- handler::parallel_for_work_group functions

It is able to run workloads which use these APIs but do not contain data
or code with group-visible side effects between the work group and work
item scopes. Upcoming patches will implement the remaining part: private_data, data and code work-group level "scoping".

Signed-off-by: Konstantin Bobrovsky konstantin.s.bobrovsky@intel.com