### PR TITLE
[SYCL][NFC] Refactoring SYCL exception classes.

### DIFF
--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -81,9 +81,15 @@ public:
 class kernel_error : public runtime_error {
   using runtime_error::runtime_error;
 };
-class accessor_error : public runtime_error {};
-class nd_range_error : public runtime_error {};
-class event_error : public runtime_error {};
+class accessor_error : public runtime_error {
+  using runtime_error::runtime_error;
+};
+class nd_range_error : public runtime_error {
+  using runtime_error::runtime_error;
+};
+class event_error : public runtime_error {
+  using runtime_error::runtime_error;
+};
 class invalid_parameter_error : public runtime_error {
   using runtime_error::runtime_error;
 };
@@ -96,13 +102,21 @@ public:
 class compile_program_error : public device_error {
   using device_error::device_error;
 };
-class link_program_error : public device_error {};
+class link_program_error : public device_error {
+  using device_error::device_error;
+};
 class invalid_object_error : public device_error {
   using device_error::device_error;
 };
-class memory_allocation_error : public device_error {};
-class platform_error : public device_error {};
-class profiling_error : public device_error {};
+class memory_allocation_error : public device_error {
+  using device_error::device_error;
+};
+class platform_error : public device_error {
+  using device_error::device_error;
+};
+class profiling_error : public device_error {
+  using device_error::device_error;
+};
 class feature_not_supported : public device_error {
   using device_error::device_error;
 };

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -12,40 +12,45 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/stl.hpp>
-#include <exception>
 
 namespace cl {
 namespace sycl {
 
+// Forward declaration
 class context;
 
 struct exception {
   exception() = default;
 
-  const char *what() const noexcept { return MMsg.c_str(); }
+  const char *what() const noexcept;
+
   bool has_context() const;
+
   context get_context() const;
+
   cl_int get_cl_code() const;
 
 private:
-  std::string MMsg = "Message not specified";
+  string_class MMsg;
   cl_int MCLErr = CL_SUCCESS;
   shared_ptr_class<context> MContext;
 
 protected:
   exception(const char *Msg, int CLErr = CL_SUCCESS,
             shared_ptr_class<context> Context = nullptr)
-      : MMsg(std::string(Msg) + " " +
+      : MMsg(string_class(Msg) + " " +
              ((CLErr == CL_SUCCESS) ? "" : OCL_CODE_TO_STR(CLErr))),
         MCLErr(CLErr), MContext(Context) {}
 
-  exception(const std::string &Msg, int CLErr = CL_SUCCESS,
+  exception(const string_class &Msg, int CLErr = CL_SUCCESS,
             shared_ptr_class<context> Context = nullptr)
       : exception(Msg.c_str(), CLErr, Context) {}
 };
 
 // Forward declaration
-namespace detail { class queue_impl; }
+namespace detail {
+class queue_impl;
+}
 
 class exception_list : private vector_class<exception_ptr_class> {
   using list_t = vector_class<exception_ptr_class>;
@@ -75,7 +80,7 @@ class runtime_error : public exception {
 public:
   runtime_error(const char *Msg, cl_int Err = CL_SUCCESS)
       : exception(Msg, Err) {}
-  runtime_error(const std::string &Msg, cl_int Err = CL_SUCCESS)
+  runtime_error(const string_class &Msg, cl_int Err = CL_SUCCESS)
       : runtime_error(Msg.c_str(), Err) {}
 };
 class kernel_error : public runtime_error {

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -36,15 +36,14 @@ private:
   shared_ptr_class<context> MContext;
 
 protected:
-  exception(const char *Msg, int CLErr = CL_SUCCESS,
+  exception(const char *Msg, const cl_int CLErr = CL_SUCCESS,
             shared_ptr_class<context> Context = nullptr)
-      : MMsg(string_class(Msg) + " " +
-             ((CLErr == CL_SUCCESS) ? "" : OCL_CODE_TO_STR(CLErr))),
-        MCLErr(CLErr), MContext(Context) {}
+      : exception(string_class(Msg), CLErr, Context) {}
 
-  exception(const string_class &Msg, int CLErr = CL_SUCCESS,
+  exception(const string_class &Msg, const cl_int CLErr = CL_SUCCESS,
             shared_ptr_class<context> Context = nullptr)
-      : exception(Msg.c_str(), CLErr, Context) {}
+      : MMsg(Msg + " " + OCL_CODE_TO_STR(CLErr)), MCLErr(CLErr),
+        MContext(Context) {}
 };
 
 // Forward declaration
@@ -78,10 +77,13 @@ using async_handler = function_class<void(cl::sycl::exception_list)>;
 
 class runtime_error : public exception {
 public:
+  runtime_error() = default;
+
   runtime_error(const char *Msg, cl_int Err = CL_SUCCESS)
-      : exception(Msg, Err) {}
+      : runtime_error(string_class(Msg), Err) {}
+
   runtime_error(const string_class &Msg, cl_int Err = CL_SUCCESS)
-      : runtime_error(Msg.c_str(), Err) {}
+      : exception(Msg, Err) {}
 };
 class kernel_error : public runtime_error {
   using runtime_error::runtime_error;
@@ -100,9 +102,13 @@ class invalid_parameter_error : public runtime_error {
 };
 class device_error : public exception {
 public:
+  device_error() = default;
+
   device_error(const char *Msg, cl_int Err = CL_SUCCESS)
+      : device_error(string_class(Msg), Err) {}
+
+  device_error(const string_class &Msg, cl_int Err = CL_SUCCESS)
       : exception(Msg, Err) {}
-  device_error() : device_error("") {}
 };
 class compile_program_error : public device_error {
   using device_error::device_error;

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -22,26 +22,26 @@ class context;
 struct exception {
   exception() = default;
 
-  const char *what() const noexcept { return msg.c_str(); }
+  const char *what() const noexcept { return MMsg.c_str(); }
   bool has_context() const;
   context get_context() const;
   cl_int get_cl_code() const;
 
 private:
-  std::string msg = "Message not specified";
-  cl_int cl_err = CL_SUCCESS;
-  shared_ptr_class<context> Context;
+  std::string MMsg = "Message not specified";
+  cl_int MCLErr = CL_SUCCESS;
+  shared_ptr_class<context> MContext;
 
 protected:
-  exception(const char *msg, int cl_err = CL_SUCCESS,
+  exception(const char *Msg, int CLErr = CL_SUCCESS,
             shared_ptr_class<context> Context = nullptr)
-      : msg(std::string(msg) + " " +
-            ((cl_err == CL_SUCCESS) ? "" : OCL_CODE_TO_STR(cl_err))),
-        cl_err(cl_err), Context(Context) {}
+      : MMsg(std::string(Msg) + " " +
+             ((CLErr == CL_SUCCESS) ? "" : OCL_CODE_TO_STR(CLErr))),
+        MCLErr(CLErr), MContext(Context) {}
 
-  exception(const std::string &msg, int cl_err = CL_SUCCESS,
+  exception(const std::string &Msg, int CLErr = CL_SUCCESS,
             shared_ptr_class<context> Context = nullptr)
-      : exception(msg.c_str(), cl_err, Context) {}
+      : exception(Msg.c_str(), CLErr, Context) {}
 };
 
 // Forward declaration
@@ -73,10 +73,10 @@ using async_handler = function_class<void(cl::sycl::exception_list)>;
 
 class runtime_error : public exception {
 public:
-  runtime_error(const char *str, cl_int err = CL_SUCCESS)
-      : exception(str, err) {}
-  runtime_error(const std::string &str, cl_int err = CL_SUCCESS)
-      : runtime_error(str.c_str(), err) {}
+  runtime_error(const char *Msg, cl_int Err = CL_SUCCESS)
+      : exception(Msg, Err) {}
+  runtime_error(const std::string &Msg, cl_int Err = CL_SUCCESS)
+      : runtime_error(Msg.c_str(), Err) {}
 };
 class kernel_error : public runtime_error {
   using runtime_error::runtime_error;
@@ -95,8 +95,8 @@ class invalid_parameter_error : public runtime_error {
 };
 class device_error : public exception {
 public:
-  device_error(const char *str, cl_int err = CL_SUCCESS)
-      : exception(str, err) {}
+  device_error(const char *Msg, cl_int Err = CL_SUCCESS)
+      : exception(Msg, Err) {}
   device_error() : device_error("") {}
 };
 class compile_program_error : public device_error {

--- a/sycl/source/exception.cpp
+++ b/sycl/source/exception.cpp
@@ -14,15 +14,15 @@
 namespace cl {
 namespace sycl {
 
-bool exception::has_context() const { return (Context != nullptr); }
+bool exception::has_context() const { return (MContext != nullptr); }
 
 context exception::get_context() const {
   if (!has_context())
     throw invalid_object_error();
 
-  return *Context;
+  return *MContext;
 }
 
-cl_int exception::get_cl_code() const { return cl_err; }
+cl_int exception::get_cl_code() const { return MCLErr; }
 } // namespace sycl
 } // namespace cl

--- a/sycl/source/exception.cpp
+++ b/sycl/source/exception.cpp
@@ -9,10 +9,11 @@
 // 4.9.2 Exception Class Interface
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/exception.hpp>
-#include <exception>
 
 namespace cl {
 namespace sycl {
+
+const char *exception::what() const noexcept { return MMsg.c_str(); }
 
 bool exception::has_context() const { return (MContext != nullptr); }
 
@@ -24,5 +25,6 @@ context exception::get_context() const {
 }
 
 cl_int exception::get_cl_code() const { return MCLErr; }
+
 } // namespace sycl
 } // namespace cl


### PR DESCRIPTION
- Propagate base classes constructors to the derived exception classes
- Apply clang naming convention to the exception class.
- Deleted useless `#include <exception>`.
- Moved definition `exception::what` method to the library.
- Changed type of `exception::MMsg` field to string_class.
- Removed default value of `exception::MMsg` field.
- Swapped the constructors to avoid creation of extra string_class:
  `exception(const string_class &Msg, ...) : // initialization list {}`
  `exception(const char *Msg, ...) : exception(string_class(Msg)) {}`
- Added missing constructors for classes runtime_error and device_error

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>