### PR TITLE
 [SYCL] Avoid declaring unscoped enums in global namespace 

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -82,7 +82,7 @@ else()
   add_custom_target(ocl-icd DEPENDS ${OpenCL_LIBRARIES} COMMENT "Copying OpenCL ICD Loader ...")
 endif()
 
-set(SYCL_INCLUDE "${CMAKE_CURRENT_BINARY_DIR}/include/")
+set(SYCL_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/include/")
 set(OPENCL_INCLUDE "${OpenCL_INCLUDE_DIRS}")
 
 # Configure SYCL version macro

--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -14,57 +14,61 @@
 
 #ifdef __SYCL_DEVICE_ONLY__
 template <typename dataT>
-extern __ocl_event_t __spirv_GroupAsyncCopy(int32_t Scope, __local dataT *Dest,
-                                            __global dataT *Src,
-                                            size_t NumElements, size_t Stride,
-                                            __ocl_event_t E) noexcept;
+extern __ocl_event_t
+__spirv_GroupAsyncCopy(__spv::Scope Execution, __local dataT *Dest,
+                       __global dataT *Src, size_t NumElements, size_t Stride,
+                       __ocl_event_t E) noexcept;
 
 template <typename dataT>
-extern __ocl_event_t __spirv_GroupAsyncCopy(int32_t Scope, __global dataT *Dest,
-                                            __local dataT *Src,
-                                            size_t NumElements, size_t Stride,
-                                            __ocl_event_t E) noexcept;
+extern __ocl_event_t
+__spirv_GroupAsyncCopy(__spv::Scope Execution, __global dataT *Dest,
+                       __local dataT *Src, size_t NumElements, size_t Stride,
+                       __ocl_event_t E) noexcept;
 
 #define OpGroupAsyncCopyGlobalToLocal __spirv_GroupAsyncCopy
 #define OpGroupAsyncCopyLocalToGlobal __spirv_GroupAsyncCopy
 
 // Atomic SPIR-V builtins
 #define __SPIRV_ATOMIC_LOAD(AS, Type)                                          \
-  extern Type __spirv_AtomicLoad(AS const Type *P, Scope S, MemorySemantics O);
+  extern Type __spirv_AtomicLoad(AS const Type *P, __spv::Scope S,             \
+                                 __spv::MemorySemanticsMask O);
 #define __SPIRV_ATOMIC_STORE(AS, Type)                                         \
-  extern void __spirv_AtomicStore(AS Type *P, Scope S, MemorySemantics O,      \
-                                  Type V);
+  extern void __spirv_AtomicStore(AS Type *P, __spv::Scope S,                  \
+                                  __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_EXCHANGE(AS, Type)                                      \
-  extern Type __spirv_AtomicExchange(AS Type *P, Scope S, MemorySemantics O,   \
-                                     Type V);
+  extern Type __spirv_AtomicExchange(AS Type *P, __spv::Scope S,               \
+                                     __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_CMP_EXCHANGE(AS, Type)                                  \
   extern Type __spirv_AtomicCompareExchange(                                   \
-      AS Type *P, Scope S, MemorySemantics E, MemorySemantics U, Type V,       \
-      Type C);
+      AS Type *P, __spv::Scope S, __spv::MemorySemanticsMask E,                \
+      __spv::MemorySemanticsMask U, Type V, Type C);
 #define __SPIRV_ATOMIC_IADD(AS, Type)                                          \
-  extern Type __spirv_AtomicIAdd(AS Type *P, Scope S, MemorySemantics O,       \
-                                 Type V);
+  extern Type __spirv_AtomicIAdd(AS Type *P, __spv::Scope S,                   \
+                                 __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_ISUB(AS, Type)                                          \
-  extern Type __spirv_AtomicISub(AS Type *P, Scope S, MemorySemantics O,       \
-                                 Type V);
+  extern Type __spirv_AtomicISub(AS Type *P, __spv::Scope S,                   \
+                                 __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_SMIN(AS, Type)                                          \
-  extern Type __spirv_AtomicSMin(AS Type *P, Scope S, MemorySemantics O,       \
-                                 Type V);
+  extern Type __spirv_AtomicSMin(AS Type *P, __spv::Scope S,                   \
+                                 __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_UMIN(AS, Type)                                          \
-  extern Type __spirv_AtomicUMin(AS Type *P, Scope S, MemorySemantics O,       \
-                                 Type V);
+  extern Type __spirv_AtomicUMin(AS Type *P, __spv::Scope S,                   \
+                                 __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_SMAX(AS, Type)                                          \
-  extern Type __spirv_AtomicSMax(AS Type *P, Scope S, MemorySemantics O,       \
-                                 Type V);
+  extern Type __spirv_AtomicSMax(AS Type *P, __spv::Scope S,                   \
+                                 __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_UMAX(AS, Type)                                          \
-  extern Type __spirv_AtomicUMax(AS Type *P, Scope S, MemorySemantics O,       \
-                                 Type V);
+  extern Type __spirv_AtomicUMax(AS Type *P, __spv::Scope S,                   \
+                                 __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_AND(AS, Type)                                           \
-  extern Type __spirv_AtomicAnd(AS Type *P, Scope S, MemorySemantics O, Type V);
+  extern Type __spirv_AtomicAnd(AS Type *P, __spv::Scope S,                    \
+                                __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_OR(AS, Type)                                            \
-  extern Type __spirv_AtomicOr(AS Type *P, Scope S, MemorySemantics O, Type V);
+  extern Type __spirv_AtomicOr(AS Type *P, __spv::Scope S,                     \
+                               __spv::MemorySemanticsMask O, Type V);
 #define __SPIRV_ATOMIC_XOR(AS, Type)                                           \
-  extern Type __spirv_AtomicXor(AS Type *P, Scope S, MemorySemantics O, Type V);
+  extern Type __spirv_AtomicXor(AS Type *P, __spv::Scope S,                    \
+                                __spv::MemorySemanticsMask O, Type V);
 
 #define __SPIRV_ATOMIC_FLOAT(AS, Type)                                         \
   __SPIRV_ATOMIC_LOAD(AS, Type)                                                \
@@ -95,15 +99,15 @@ extern __ocl_event_t __spirv_GroupAsyncCopy(int32_t Scope, __global dataT *Dest,
 #define __SPIRV_ATOMIC_MINMAX(AS, Op)                                          \
   template <typename T>                                                        \
   typename std::enable_if<std::is_signed<T>::value, T>::type                   \
-      __spirv_Atomic##Op(AS T *Ptr, Scope Scope, MemorySemantics Semantics,    \
-                         T Value) {                                            \
-    return __spirv_AtomicS##Op(Ptr, Scope, Semantics, Value);                  \
+      __spirv_Atomic##Op(AS T *Ptr, __spv::Scope Memory,                       \
+                         __spv::MemorySemanticsMask Semantics, T Value) {      \
+    return __spirv_AtomicS##Op(Ptr, Memory, Semantics, Value);                 \
   }                                                                            \
   template <typename T>                                                        \
   typename std::enable_if<!std::is_signed<T>::value, T>::type                  \
-      __spirv_Atomic##Op(AS T *Ptr, Scope Scope, MemorySemantics Semantics,    \
-                         T Value) {                                            \
-    return __spirv_AtomicU##Op(Ptr, Scope, Semantics, Value);                  \
+      __spirv_Atomic##Op(AS T *Ptr, __spv::Scope Memory,                       \
+                         __spv::MemorySemanticsMask Semantics, T Value) {      \
+    return __spirv_AtomicU##Op(Ptr, Memory, Semantics, Value);                 \
   }
 
 #define __SPIRV_ATOMICS(macro, Arg) macro(__global, Arg) macro(__local, Arg)
@@ -118,30 +122,38 @@ __SPIRV_ATOMICS(__SPIRV_ATOMIC_UNSIGNED, unsigned long long)
 __SPIRV_ATOMICS(__SPIRV_ATOMIC_MINMAX, Min)
 __SPIRV_ATOMICS(__SPIRV_ATOMIC_MINMAX, Max)
 
-extern bool __spirv_GroupAll(int32_t Scope, bool Predicate) noexcept;
+extern bool __spirv_GroupAll(__spv::Scope Execution, bool Predicate) noexcept;
 
-extern bool __spirv_GroupAny(int32_t Scope, bool Predicate) noexcept;
+extern bool __spirv_GroupAny(__spv::Scope Execution, bool Predicate) noexcept;
 
 template <typename dataT>
-extern dataT __spirv_GroupBroadcast(int32_t Scope, dataT Value,
+extern dataT __spirv_GroupBroadcast(__spv::Scope Execution, dataT Value,
                                     uint32_t LocalId) noexcept;
 
 template <typename dataT>
-extern dataT __spirv_GroupIAdd(int32_t Scope, int32_t Op, dataT Value) noexcept;
+extern dataT __spirv_GroupIAdd(__spv::Scope Execution, __spv::GroupOperation Op,
+                               dataT Value) noexcept;
 template <typename dataT>
-extern dataT __spirv_GroupFAdd(int32_t Scope, int32_t Op, dataT Value) noexcept;
+extern dataT __spirv_GroupFAdd(__spv::Scope Execution, __spv::GroupOperation Op,
+                               dataT Value) noexcept;
 template <typename dataT>
-extern dataT __spirv_GroupUMin(int32_t Scope, int32_t Op, dataT Value) noexcept;
+extern dataT __spirv_GroupUMin(__spv::Scope Execution, __spv::GroupOperation Op,
+                               dataT Value) noexcept;
 template <typename dataT>
-extern dataT __spirv_GroupSMin(int32_t Scope, int32_t Op, dataT Value) noexcept;
+extern dataT __spirv_GroupSMin(__spv::Scope Execution, __spv::GroupOperation Op,
+                               dataT Value) noexcept;
 template <typename dataT>
-extern dataT __spirv_GroupFMin(int32_t Scope, int32_t Op, dataT Value) noexcept;
+extern dataT __spirv_GroupFMin(__spv::Scope Execution, __spv::GroupOperation Op,
+                               dataT Value) noexcept;
 template <typename dataT>
-extern dataT __spirv_GroupUMax(int32_t Scope, int32_t Op, dataT Value) noexcept;
+extern dataT __spirv_GroupUMax(__spv::Scope Execution, __spv::GroupOperation Op,
+                               dataT Value) noexcept;
 template <typename dataT>
-extern dataT __spirv_GroupSMax(int32_t Scope, int32_t Op, dataT Value) noexcept;
+extern dataT __spirv_GroupSMax(__spv::Scope Execution, __spv::GroupOperation Op,
+                               dataT Value) noexcept;
 template <typename dataT>
-extern dataT __spirv_GroupFMax(int32_t Scope, int32_t Op, dataT Value) noexcept;
+extern dataT __spirv_GroupFMax(__spv::Scope Execution, __spv::GroupOperation Op,
+                               dataT Value) noexcept;
 template <typename dataT>
 extern dataT __spirv_SubgroupShuffleINTEL(dataT Data,
                                           uint32_t InvocationId) noexcept;
@@ -178,7 +190,7 @@ extern void __spirv_ocl_prefetch(const __global char *Ptr,
 
 template <typename dataT>
 extern __ocl_event_t
-OpGroupAsyncCopyGlobalToLocal(int32_t Scope, dataT *Dest, dataT *Src,
+OpGroupAsyncCopyGlobalToLocal(__spv::Scope Execution, dataT *Dest, dataT *Src,
                               size_t NumElements, size_t Stride,
                               __ocl_event_t E) noexcept {
   for (int i = 0; i < NumElements; i++) {
@@ -190,7 +202,7 @@ OpGroupAsyncCopyGlobalToLocal(int32_t Scope, dataT *Dest, dataT *Src,
 
 template <typename dataT>
 extern __ocl_event_t
-OpGroupAsyncCopyLocalToGlobal(int32_t Scope, dataT *Dest, dataT *Src,
+OpGroupAsyncCopyLocalToGlobal(__spv::Scope Execution, dataT *Dest, dataT *Src,
                               size_t NumElements, size_t Stride,
                               __ocl_event_t E) noexcept {
   for (int i = 0; i < NumElements; i++) {
@@ -204,11 +216,12 @@ extern void __spirv_ocl_prefetch(const char *Ptr, size_t NumBytes) noexcept;
 
 #endif // !__SYCL_DEVICE_ONLY__
 
-extern void __spirv_ControlBarrier(Scope Execution, Scope Memory,
+extern void __spirv_ControlBarrier(__spv::Scope Execution, __spv::Scope Memory,
                                    uint32_t Semantics) noexcept;
 
-extern void __spirv_MemoryBarrier(Scope Memory, uint32_t Semantics) noexcept;
+extern void __spirv_MemoryBarrier(__spv::Scope Memory,
+                                  uint32_t Semantics) noexcept;
 
-extern void __spirv_GroupWaitEvents(int32_t Scope, uint32_t NumEvents,
+extern void __spirv_GroupWaitEvents(__spv::Scope Execution, uint32_t NumEvents,
                                     __ocl_event_t *WaitEvents) noexcept;
 

--- a/sycl/include/CL/__spirv/spirv_types.hpp
+++ b/sycl/include/CL/__spirv/spirv_types.hpp
@@ -13,7 +13,13 @@
 // TODO: include the header file with SPIR-V declarations from SPIRV-Headers
 // project.
 
-enum Scope {
+// Declarations of enums below is aligned with corresponding declarations in
+// SPIRV-Headers repo with a few exceptions:
+// - base types changed from uint to uint32_t
+// - spv namespace renamed to __spv
+namespace __spv {
+
+enum class Scope : uint32_t {
   CrossDevice = 0,
   Device = 1,
   Workgroup = 2,
@@ -22,7 +28,7 @@ enum Scope {
 };
 
 
-enum MemorySemantics {
+enum class MemorySemanticsMask : uint32_t {
   None = 0x0,
   Acquire = 0x2,
   Release = 0x4,
@@ -36,6 +42,14 @@ enum MemorySemantics {
   ImageMemory = 0x800,
 };
 
+enum class GroupOperation : uint32_t {
+  Reduce = 0,
+  InclusiveScan = 1,
+  ExclusiveScan = 2
+};
+
+} // namespace __spv
+
 // This class does not have definition, it is only predeclared here.
 // The pointers to this class objects can be passed to or returned from
 // SPIRV built-in functions.
@@ -44,5 +58,3 @@ enum MemorySemantics {
 typedef void* __ocl_event_t;
 typedef void* __ocl_sampler_t;
 #endif
-
-enum GroupOperation { Reduce = 0, InclusiveScan = 1, ExclusiveScan = 2 };

--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -51,16 +51,16 @@ template <cl::sycl::access::address_space AS> struct IsValidAtomicAddressSpace {
 // a SPIR-V memory scope
 template <access::address_space AS> struct GetSpirvMemoryScope {};
 template <> struct GetSpirvMemoryScope<access::address_space::global_space> {
-  static constexpr auto scope = Scope::Device;
+  static constexpr auto scope = __spv::Scope::Device;
 };
 template <> struct GetSpirvMemoryScope<access::address_space::local_space> {
-  static constexpr auto scope = Scope::Workgroup;
+  static constexpr auto scope = __spv::Scope::Workgroup;
 };
 
 // Translate the cl::sycl::memory_order to a SPIR-V builtin order
-static inline MemorySemantics
-getSpirvMemorySemantics(memory_order Order) {
-  return MemorySemantics::None;
+static inline __spv::MemorySemanticsMask
+getSpirvMemorySemanticsMask(memory_order Order) {
+  return __spv::MemorySemanticsMask::None;
 }
 
 } // namespace detail
@@ -72,11 +72,11 @@ getSpirvMemorySemantics(memory_order Order) {
 namespace cl {
 namespace sycl {
 namespace detail {
-// Translate cl::sycl::memory_order or cl::__spirv::MemorySemantics
+// Translate cl::sycl::memory_order or __spv::MemorySemanticsMask
 // into std::memory_order
 // Only relaxed memory semantics are supported currently
 static inline std::memory_order
-getStdMemoryOrder(MemorySemantics MS) {
+getStdMemoryOrder(__spv::MemorySemanticsMask MS) {
   return std::memory_order_relaxed;
 }
 static inline std::memory_order getStdMemoryOrder(::cl::sycl::memory_order MS) {
@@ -89,47 +89,56 @@ static inline std::memory_order getStdMemoryOrder(::cl::sycl::memory_order MS) {
 // std::atomic version of atomic SPIR-V builtins
 
 template <typename T>
-void __spirv_AtomicStore(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V) {
+void __spirv_AtomicStore(std::atomic<T> *Ptr, __spv::Scope S,
+                         __spv::MemorySemanticsMask MS, T V) {
   Ptr->store(V, ::cl::sycl::detail::getStdMemoryOrder(MS));
 }
 
 template <typename T>
-T __spirv_AtomicLoad(const std::atomic<T> *Ptr, Scope S, MemorySemantics MS) {
+T __spirv_AtomicLoad(const std::atomic<T> *Ptr, __spv::Scope S,
+                     __spv::MemorySemanticsMask MS) {
   return Ptr->load(::cl::sycl::detail::getStdMemoryOrder(MS));
 }
 
 template <typename T>
-T __spirv_AtomicExchange(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V) {
+T __spirv_AtomicExchange(std::atomic<T> *Ptr, __spv::Scope S,
+                         __spv::MemorySemanticsMask MS, T V) {
   return Ptr->exchange(V, ::cl::sycl::detail::getStdMemoryOrder(MS));
 }
 
 template <typename T>
-extern T __spirv_AtomicIAdd(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V) {
+extern T __spirv_AtomicIAdd(std::atomic<T> *Ptr, __spv::Scope S,
+                            __spv::MemorySemanticsMask MS, T V) {
   return Ptr->fetch_add(V, ::cl::sycl::detail::getStdMemoryOrder(MS));
 }
 
 template <typename T>
-extern T __spirv_AtomicISub(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V) {
+extern T __spirv_AtomicISub(std::atomic<T> *Ptr, __spv::Scope S,
+                            __spv::MemorySemanticsMask MS, T V) {
   return Ptr->fetch_sub(V, ::cl::sycl::detail::getStdMemoryOrder(MS));
 }
 
 template <typename T>
-extern T __spirv_AtomicAnd(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V) {
+extern T __spirv_AtomicAnd(std::atomic<T> *Ptr, __spv::Scope S,
+                           __spv::MemorySemanticsMask MS, T V) {
   return Ptr->fetch_and(V, ::cl::sycl::detail::getStdMemoryOrder(MS));
 }
 
 template <typename T>
-extern T __spirv_AtomicOr(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V) {
+extern T __spirv_AtomicOr(std::atomic<T> *Ptr, __spv::Scope S,
+                          __spv::MemorySemanticsMask MS, T V) {
   return Ptr->fetch_or(V, ::cl::sycl::detail::getStdMemoryOrder(MS));
 }
 
 template <typename T>
-extern T __spirv_AtomicXor(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V) {
+extern T __spirv_AtomicXor(std::atomic<T> *Ptr, __spv::Scope S,
+                           __spv::MemorySemanticsMask MS, T V) {
   return Ptr->fetch_xor(V, ::cl::sycl::detail::getStdMemoryOrder(MS));
 }
 
 template <typename T>
-extern T __spirv_AtomicMin(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V) {
+extern T __spirv_AtomicMin(std::atomic<T> *Ptr, __spv::Scope S,
+                           __spv::MemorySemanticsMask MS, T V) {
   std::memory_order MemoryOrder = ::cl::sycl::detail::getStdMemoryOrder(MS);
   T Val = Ptr->load(MemoryOrder);
   while (V < Val) {
@@ -141,7 +150,8 @@ extern T __spirv_AtomicMin(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V
 }
 
 template <typename T>
-extern T __spirv_AtomicMax(std::atomic<T> *Ptr, Scope S, MemorySemantics MS, T V) {
+extern T __spirv_AtomicMax(std::atomic<T> *Ptr, __spv::Scope S,
+                           __spv::MemorySemanticsMask MS, T V) {
   std::memory_order MemoryOrder = ::cl::sycl::detail::getStdMemoryOrder(MS);
   T Val = Ptr->load(MemoryOrder);
   while (V > Val) {
@@ -186,17 +196,17 @@ public:
 
   void store(T Operand, memory_order Order = memory_order::relaxed) {
     __spirv_AtomicStore(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(Order), Operand);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
   }
 
   T load(memory_order Order = memory_order::relaxed) const {
     return __spirv_AtomicLoad(Ptr, SpirvScope,
-                                       detail::getSpirvMemorySemantics(Order));
+                              detail::getSpirvMemorySemanticsMask(Order));
   }
 
   T exchange(T Operand, memory_order Order = memory_order::relaxed) {
     return __spirv_AtomicExchange(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(Order), Operand);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
   }
 
   bool
@@ -206,8 +216,8 @@ public:
     STATIC_ASSERT_NOT_FLOAT(T);
 #ifdef __SYCL_DEVICE_ONLY__
     T Value = __spirv_AtomicCompareExchange(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(SuccessOrder),
-        detail::getSpirvMemorySemantics(FailOrder), Desired, Expected);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(SuccessOrder),
+        detail::getSpirvMemorySemanticsMask(FailOrder), Desired, Expected);
     return (Value == Expected);
 #else
     return Ptr->compare_exchange_strong(Expected, Desired,
@@ -219,43 +229,43 @@ public:
   T fetch_add(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicIAdd(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(Order), Operand);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_sub(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicISub(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(Order), Operand);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_and(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicAnd(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(Order), Operand);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_or(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicOr(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(Order), Operand);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_xor(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicXor(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(Order), Operand);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_min(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicMin(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(Order), Operand);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_max(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicMax(
-        Ptr, SpirvScope, detail::getSpirvMemorySemantics(Order), Operand);
+        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
   }
 
 private:

--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -7,11 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#include <CL/sycl/access/access.hpp>
-#ifdef __SYCL_DEVICE_ONLY__
+
 #include <CL/__spirv/spirv_ops.hpp>
-#else
-#include <CL/__spirv/spirv_types.hpp>
+#include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/helpers.hpp>
+
+#ifndef __SYCL_DEVICE_ONLY__
 #include <atomic>
 #endif
 #include <type_traits>
@@ -56,12 +57,6 @@ template <> struct GetSpirvMemoryScope<access::address_space::global_space> {
 template <> struct GetSpirvMemoryScope<access::address_space::local_space> {
   static constexpr auto scope = __spv::Scope::Workgroup;
 };
-
-// Translate the cl::sycl::memory_order to a SPIR-V builtin order
-static inline __spv::MemorySemanticsMask
-getSpirvMemorySemanticsMask(memory_order Order) {
-  return __spv::MemorySemanticsMask::None;
-}
 
 } // namespace detail
 } // namespace sycl
@@ -196,17 +191,17 @@ public:
 
   void store(T Operand, memory_order Order = memory_order::relaxed) {
     __spirv_AtomicStore(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order), Operand);
   }
 
   T load(memory_order Order = memory_order::relaxed) const {
     return __spirv_AtomicLoad(Ptr, SpirvScope,
-                              detail::getSpirvMemorySemanticsMask(Order));
+                              detail::getSPIRVMemorySemanticsMask(Order));
   }
 
   T exchange(T Operand, memory_order Order = memory_order::relaxed) {
     return __spirv_AtomicExchange(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order), Operand);
   }
 
   bool
@@ -216,8 +211,8 @@ public:
     STATIC_ASSERT_NOT_FLOAT(T);
 #ifdef __SYCL_DEVICE_ONLY__
     T Value = __spirv_AtomicCompareExchange(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(SuccessOrder),
-        detail::getSpirvMemorySemanticsMask(FailOrder), Desired, Expected);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(SuccessOrder),
+        detail::getSPIRVMemorySemanticsMask(FailOrder), Desired, Expected);
     return (Value == Expected);
 #else
     return Ptr->compare_exchange_strong(Expected, Desired,
@@ -229,43 +224,43 @@ public:
   T fetch_add(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicIAdd(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_sub(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicISub(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_and(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicAnd(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_or(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicOr(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_xor(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicXor(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_min(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicMin(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order), Operand);
   }
 
   T fetch_max(T Operand, memory_order Order = memory_order::relaxed) {
     STATIC_ASSERT_NOT_FLOAT(T);
     return __spirv_AtomicMax(
-        Ptr, SpirvScope, detail::getSpirvMemorySemanticsMask(Order), Operand);
+        Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order), Operand);
   }
 
 private:

--- a/sycl/include/CL/sycl/device_event.hpp
+++ b/sycl/include/CL/sycl/device_event.hpp
@@ -27,8 +27,7 @@ public:
   device_event(__ocl_event_t *Event) : m_Event(Event) {}
 
   void wait() {
-    __spirv_GroupWaitEvents(Scope::Workgroup, 1,
-                                   m_Event);
+    __spirv_GroupWaitEvents(__spv::Scope::Workgroup, 1, m_Event);
   }
 };
 

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/__spirv/spirv_ops.hpp>
+#include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/device_event.hpp>
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/pointers.hpp>
@@ -81,25 +82,7 @@ public:
                      accessMode == access::mode::read_write,
                      access::fence_space>::type accessSpace =
                      access::fence_space::global_and_local) const {
-    uint32_t flags = static_cast<uint32_t>(
-        __spv::MemorySemanticsMask::SequentiallyConsistent);
-    switch (accessSpace) {
-    case access::fence_space::global_space:
-      flags |= static_cast<uint32_t>(
-          __spv::MemorySemanticsMask::CrossWorkgroupMemory);
-      break;
-    case access::fence_space::local_space:
-      flags |=
-          static_cast<uint32_t>(__spv::MemorySemanticsMask::WorkgroupMemory);
-      break;
-    case access::fence_space::global_and_local:
-    default:
-      flags |=
-          static_cast<uint32_t>(
-              __spv::MemorySemanticsMask::CrossWorkgroupMemory) |
-          static_cast<uint32_t>(__spv::MemorySemanticsMask::WorkgroupMemory);
-      break;
-    }
+    uint32_t flags = detail::getSPIRVMemorySemanticsMask(accessSpace);
     // TODO: currently, there is no good way in SPIRV to set the memory
     // barrier only for load operations or only for store operations.
     // The full read-and-write barrier is used and the template parameter

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -81,18 +81,23 @@ public:
                      accessMode == access::mode::read_write,
                      access::fence_space>::type accessSpace =
                      access::fence_space::global_and_local) const {
-    uint32_t flags = MemorySemantics::SequentiallyConsistent;
+    uint32_t flags = static_cast<uint32_t>(
+        __spv::MemorySemanticsMask::SequentiallyConsistent);
     switch (accessSpace) {
     case access::fence_space::global_space:
-      flags |= MemorySemantics::CrossWorkgroupMemory;
+      flags |= static_cast<uint32_t>(
+          __spv::MemorySemanticsMask::CrossWorkgroupMemory);
       break;
     case access::fence_space::local_space:
-      flags |= MemorySemantics::WorkgroupMemory;
+      flags |=
+          static_cast<uint32_t>(__spv::MemorySemanticsMask::WorkgroupMemory);
       break;
     case access::fence_space::global_and_local:
     default:
-      flags |= MemorySemantics::CrossWorkgroupMemory |
-               MemorySemantics::WorkgroupMemory;
+      flags |=
+          static_cast<uint32_t>(
+              __spv::MemorySemanticsMask::CrossWorkgroupMemory) |
+          static_cast<uint32_t>(__spv::MemorySemanticsMask::WorkgroupMemory);
       break;
     }
     // TODO: currently, there is no good way in SPIRV to set the memory
@@ -103,7 +108,7 @@ public:
     // or if we decide that 'accessMode' is the important feature then
     // we can fix this later, for example, by using OpenCL 1.2 functions
     // read_mem_fence() and write_mem_fence().
-    __spirv_MemoryBarrier(Scope::Workgroup, flags);
+    __spirv_MemoryBarrier(__spv::Scope::Workgroup, flags);
   }
 
   template <typename dataT>
@@ -112,7 +117,7 @@ public:
                                      size_t numElements) const {
     __ocl_event_t e =
         OpGroupAsyncCopyGlobalToLocal<dataT>(
-            Scope::Workgroup,
+            __spv::Scope::Workgroup,
             dest.get(), src.get(), numElements, 1, 0);
     return device_event(&e);
   }
@@ -123,7 +128,7 @@ public:
                                      size_t numElements) const {
     __ocl_event_t e =
         OpGroupAsyncCopyLocalToGlobal<dataT>(
-            Scope::Workgroup,
+            __spv::Scope::Workgroup,
             dest.get(), src.get(), numElements, 1, 0);
     return device_event(&e);
   }
@@ -135,7 +140,7 @@ public:
                                      size_t srcStride) const {
     __ocl_event_t e =
         OpGroupAsyncCopyGlobalToLocal<dataT>(
-            Scope::Workgroup,
+            __spv::Scope::Workgroup,
             dest.get(), src.get(), numElements, srcStride, 0);
     return device_event(&e);
   }
@@ -147,7 +152,7 @@ public:
                                      size_t destStride) const {
     __ocl_event_t e =
         OpGroupAsyncCopyLocalToGlobal<dataT>(
-            Scope::Workgroup,
+            __spv::Scope::Workgroup,
             dest.get(), src.get(), numElements, destStride, 0);
     return device_event(&e);
   }

--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/__spirv/spirv_vars.hpp>
 #include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/range.hpp>
 #include <CL/sycl/types.hpp>
@@ -334,25 +335,8 @@ struct sub_group {
   /* --- synchronization functions --- */
   void barrier(access::fence_space accessSpace =
                    access::fence_space::global_and_local) const {
-    uint32_t flags = static_cast<uint32_t>(
-        __spv::MemorySemanticsMask::SequentiallyConsistent);
-    switch (accessSpace) {
-    case access::fence_space::global_space:
-      flags |= static_cast<uint32_t>(
-          __spv::MemorySemanticsMask::CrossWorkgroupMemory);
-      break;
-    case access::fence_space::local_space:
-      flags |=
-          static_cast<uint32_t>(__spv::MemorySemanticsMask::SubgroupMemory);
-      break;
-    case access::fence_space::global_and_local:
-    default:
-      flags |=
-          static_cast<uint32_t>(
-              __spv::MemorySemanticsMask::CrossWorkgroupMemory) |
-          static_cast<uint32_t>(__spv::MemorySemanticsMask::SubgroupMemory);
-      break;
-    }
+    uint32_t flags = detail::getSPIRVMemorySemanticsMask(
+        accessSpace, __spv::MemorySemanticsMask::SubgroupMemory);
     __spirv_ControlBarrier(__spv::Scope::Subgroup, __spv::Scope::Workgroup,
                            flags);
   }

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -81,22 +81,27 @@ template <int dimensions = 1> struct nd_item {
 
   void barrier(access::fence_space accessSpace =
                    access::fence_space::global_and_local) const {
-    uint32_t flags = MemorySemantics::SequentiallyConsistent;
+    uint32_t flags = static_cast<uint32_t>(
+        __spv::MemorySemanticsMask::SequentiallyConsistent);
     switch (accessSpace) {
     case access::fence_space::global_space:
-      flags |= MemorySemantics::CrossWorkgroupMemory;
+      flags |= static_cast<uint32_t>(
+          __spv::MemorySemanticsMask::CrossWorkgroupMemory);
       break;
     case access::fence_space::local_space:
-      flags |= MemorySemantics::WorkgroupMemory;
+      flags |=
+          static_cast<uint32_t>(__spv::MemorySemanticsMask::WorkgroupMemory);
       break;
     case access::fence_space::global_and_local:
     default:
-      flags |= MemorySemantics::CrossWorkgroupMemory |
-               MemorySemantics::WorkgroupMemory;
+      flags |=
+          static_cast<uint32_t>(
+              __spv::MemorySemanticsMask::CrossWorkgroupMemory) |
+          static_cast<uint32_t>(__spv::MemorySemanticsMask::WorkgroupMemory);
       break;
     }
-    __spirv_ControlBarrier(Scope::Workgroup,
-                                  Scope::Workgroup, flags);
+    __spirv_ControlBarrier(__spv::Scope::Workgroup, __spv::Scope::Workgroup,
+                           flags);
   }
 
   /// Executes a work-group mem-fence with memory ordering on the local address

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -8,14 +8,16 @@
 
 #pragma once
 
+#include <CL/__spirv/spirv_ops.hpp>
 #include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/group.hpp>
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/intel/sub_group.hpp>
 #include <CL/sycl/item.hpp>
 #include <CL/sycl/nd_range.hpp>
 #include <CL/sycl/range.hpp>
-#include <CL/__spirv/spirv_ops.hpp>
+
 #include <stdexcept>
 #include <type_traits>
 
@@ -81,25 +83,7 @@ template <int dimensions = 1> struct nd_item {
 
   void barrier(access::fence_space accessSpace =
                    access::fence_space::global_and_local) const {
-    uint32_t flags = static_cast<uint32_t>(
-        __spv::MemorySemanticsMask::SequentiallyConsistent);
-    switch (accessSpace) {
-    case access::fence_space::global_space:
-      flags |= static_cast<uint32_t>(
-          __spv::MemorySemanticsMask::CrossWorkgroupMemory);
-      break;
-    case access::fence_space::local_space:
-      flags |=
-          static_cast<uint32_t>(__spv::MemorySemanticsMask::WorkgroupMemory);
-      break;
-    case access::fence_space::global_and_local:
-    default:
-      flags |=
-          static_cast<uint32_t>(
-              __spv::MemorySemanticsMask::CrossWorkgroupMemory) |
-          static_cast<uint32_t>(__spv::MemorySemanticsMask::WorkgroupMemory);
-      break;
-    }
+    uint32_t flags = detail::getSPIRVMemorySemanticsMask(accessSpace);
     __spirv_ControlBarrier(__spv::Scope::Workgroup, __spv::Scope::Workgroup,
                            flags);
   }

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/helpers.hpp>
+
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/event.hpp>
 
 #include <memory>

--- a/sycl/source/spirv_ops.cpp
+++ b/sycl/source/spirv_ops.cpp
@@ -14,17 +14,17 @@
 // This operation is NOP on HOST as all operations there are blocking and
 // by the moment this function was called, the operations generating
 // the __ocl_event_t objects had already been finished.
-void __spirv_GroupWaitEvents(int32_t Scope, uint32_t NumEvents,
+void __spirv_GroupWaitEvents(__spv::Scope Execution, uint32_t NumEvents,
                               __ocl_event_t * WaitEvents) noexcept {
 }
 
-void __spirv_ControlBarrier(Scope Execution, Scope Memory,
+void __spirv_ControlBarrier(__spv::Scope Execution, __spv::Scope Memory,
                       uint32_t Semantics) noexcept {
   throw cl::sycl::runtime_error(
       "Barrier is not supported on the host device yet.");
 }
 
-void __spirv_MemoryBarrier(Scope Memory, uint32_t Semantics) noexcept {
+void __spirv_MemoryBarrier(__spv::Scope Memory, uint32_t Semantics) noexcept {
   // 1. The 'Memory' parameter is ignored on HOST because there is no memory
   //    separation to global and local there.
   // 2. The 'Semantics' parameter is ignored because there is no need

--- a/sycl/test/regression/unable-to-redeclare-device.cpp
+++ b/sycl/test/regression/unable-to-redeclare-device.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang -I %sycl_include -std=c++11 -fsyntax-only -Xclang -verify -DCL_TARGET_OPENCL_VERSION=220 %s
+// expected-no-diagnostics
+//
+//==-- unable-to-redeclare-device.cpp --------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// This test checks that the following symbols (Device, GroupOperation) are not
+// defined in global namespace by sycl.hpp and available to user
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+
+enum GroupOperation {
+  ADD, SUB
+};
+
+int Device = 10, spv = 20;
+
+int main() { return 0; }


### PR DESCRIPTION
According to C++ spec:

> Each enumerator becomes a named constant of the enumeration's type
> (that is, name), visible in the enclosing scope, and can be used
> whenever constants are required.

Having unscoped enumerations defined in global namespace reserve some
names and prohibits it's using in user's applications. For example,
'Device' might be used as user's class name and it might cause
ambiguity.

This patch aligns declaration of enums in spirv_types.hpp with ones from
SPIRV-Headers project to avoid declaring identifiers in global namespace
and simplify transition in the future. There are few exceptions:
* uint32_t is used as base type for enum instead of unsigned.
* '__spv' namespace is used instead of 'spv'.