### PR TITLE
[SYCL] Remove outdated CMake configuration.

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -14,11 +14,10 @@ def do_configure(args):
 
     cmake_cmd = ["cmake",
                  "-DCMAKE_BUILD_TYPE={}".format(args.build_type),
-                 "-DLLVM_ENABLE_PROJECTS=clang",
+                 "-DLLVM_EXTERNAL_PROJECTS=sycl;llvm-spirv",
                  "-DLLVM_EXTERNAL_SYCL_SOURCE_DIR={}".format(sycl_dir),
                  "-DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR={}".format(spirv_dir),
-                 "-DLLVM_TOOL_SYCL_BUILD=ON",
-                 "-DLLVM_TOOL_LLVM_SPIRV_BUILD=ON",
+                 "-DLLVM_ENABLE_PROJECTS=clang;llvm-spirv;sycl",
                  "-DOpenCL_INCLUDE_DIR={}".format(ocl_header_dir),
                  "-DOpenCL_LIBRARY={}".format(icd_loader_lib),
                  "-DLLVM_BUILD_TOOLS=OFF",

--- a/llvm/projects/CMakeLists.txt
+++ b/llvm/projects/CMakeLists.txt
@@ -11,8 +11,6 @@ foreach(entry ${entries})
        (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/libunwind) AND
        (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/test-suite) AND
        (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/parallel-libs) AND
-       (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/sycl) AND
-       (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/llvm-spirv) AND
        (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/openmp) AND
        (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/debuginfo-tests))
       get_filename_component(entry_name "${entry}" NAME)
@@ -44,8 +42,6 @@ endif()
 add_llvm_external_project(dragonegg)
 add_llvm_external_project(parallel-libs)
 add_llvm_external_project(openmp)
-add_llvm_external_project(sycl)
-add_llvm_external_project(llvm-spirv)
 
 if(LLVM_INCLUDE_TESTS)
   add_llvm_external_project(debuginfo-tests)

--- a/sycl/doc/GetStartedWithSYCLCompiler.md
+++ b/sycl/doc/GetStartedWithSYCLCompiler.md
@@ -32,10 +32,11 @@ Build the SYCL compiler and runtime following instruction below:
 mkdir $SYCL_HOME/build
 cd $SYCL_HOME/build
 cmake -DCMAKE_BUILD_TYPE=Release \
--DLLVM_ENABLE_PROJECTS="clang" \
+-DLLVM_EXTERNAL_PROJECTS="llvm-spirv;sycl" \
 -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=$SYCL_HOME/sycl \
 -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=$SYCL_HOME/llvm-spirv \
--DLLVM_TOOL_SYCL_BUILD=ON -DLLVM_TOOL_LLVM_SPIRV_BUILD=ON $SYCL_HOME/llvm
+-DLLVM_ENABLE_PROJECTS="clang;llvm-spirv;sycl" \
+$SYCL_HOME/llvm
 make -j`nproc` sycl-toolchain
 ```
 


### PR DESCRIPTION
Remove CMake configuration expecting llvm-spirv and SYCL projects to be
located in LLVM source tree.
Location of external projects should be set via CMake variables.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>