### PR TITLE
[SYCL] Fix cl::sycl::group get_linear_id API name.

### DIFF
--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -48,19 +48,19 @@ public:
   size_t operator[](int dimension) const { return index[dimension]; }
 
   template <int dims = dimensions>
-  typename std::enable_if<(dims == 1), size_t>::type get_linear() const {
+  typename std::enable_if<(dims == 1), size_t>::type get_linear_id() const {
     range<dimensions> groupNum = globalRange / localRange;
     return index[0];
   }
 
   template <int dims = dimensions>
-  typename std::enable_if<(dims == 2), size_t>::type get_linear() const {
+  typename std::enable_if<(dims == 2), size_t>::type get_linear_id() const {
     range<dimensions> groupNum = globalRange / localRange;
     return index[1] * groupNum[0] + index[0];
   }
 
   template <int dims = dimensions>
-  typename std::enable_if<(dims == 3), size_t>::type get_linear() const {
+  typename std::enable_if<(dims == 3), size_t>::type get_linear_id() const {
     range<dimensions> groupNum = globalRange / localRange;
     return (index[2] * groupNum[1] * groupNum[0]) + (index[1] * groupNum[0]) +
            index[0];

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -52,7 +52,7 @@ template <int dimensions = 1> struct nd_item {
 
   size_t get_group(int dimension) const { return Group[dimension]; }
 
-  size_t get_group_linear_id() const { return Group.get_linear(); }
+  size_t get_group_linear_id() const { return Group.get_linear_id(); }
 
   range<dimensions> get_group_range() const {
     return Group.get_global_range() / Group.get_local_range();

--- a/sycl/test/basic_tests/group.cpp
+++ b/sycl/test/basic_tests/group.cpp
@@ -29,7 +29,7 @@ int main() {
   assert((one_dim.get_group_range() == cl::sycl::range<1>{4}));
   assert(one_dim.get_group_range(0) == 4);
   assert(one_dim[0] == 1);
-  assert(one_dim.get_linear() == 1);
+  assert(one_dim.get_linear_id() == 1);
 
   // two dimension group
   cl::sycl::group<2> two_dim = Builder::createGroup<2>({8, 4}, {4, 2}, {1, 1});
@@ -47,7 +47,7 @@ int main() {
   assert(two_dim.get_group_range(1) == 2);
   assert(two_dim[0] == 1);
   assert(two_dim[1] == 1);
-  assert(two_dim.get_linear() == 3);
+  assert(two_dim.get_linear_id() == 3);
 
   // three dimension group
   cl::sycl::group<3> three_dim =
@@ -71,5 +71,5 @@ int main() {
   assert(three_dim[0] == 1);
   assert(three_dim[1] == 1);
   assert(three_dim[2] == 1);
-  assert(three_dim.get_linear() == 7);
+  assert(three_dim.get_linear_id() == 7);
 }


### PR DESCRIPTION
Current API spelling is get_linear, which is wrong - should be
get_linear_id according to spec.
Fix the unit test as well.

Signed-off-by: Konstantin Bobrovsky konstantin.s.bobrovsky@intel.com