### PR TITLE
[SYCL] Enhance data types support for SYCL stream

### DIFF
--- a/sycl/include/CL/sycl/detail/stream_impl.hpp
+++ b/sycl/include/CL/sycl/detail/stream_impl.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <CL/sycl/accessor.hpp>
+#include <CL/sycl/builtins.hpp>
+#include <CL/sycl/detail/array.hpp>
 #include <CL/sycl/device_selector.hpp>
 #include <CL/sycl/queue.hpp>
 
@@ -16,6 +18,63 @@ namespace cl {
 namespace sycl {
 
 namespace detail {
+using FmtFlags = unsigned int;
+
+// Mapping from stream_manipulator to FmtFlags. Each manipulator corresponds
+// to the bit in FmtFlags.
+static constexpr FmtFlags Dec = 0x0001;
+static constexpr FmtFlags Hex = 0x0002;
+static constexpr FmtFlags Oct = 0x0004;
+static constexpr FmtFlags ShowBase = 0x0008;
+static constexpr FmtFlags ShowPos = 0x0010;
+static constexpr FmtFlags Fixed = 0x0020;
+static constexpr FmtFlags Scientific = 0x0040;
+
+// Bitmask made of the combination of the base flags. Base flags are mutually
+// exclusive, this mask is used to clean base field before setting the new
+// base flag.
+static constexpr FmtFlags BaseField = Dec | Hex | Oct;
+
+// Bitmask made of the combination of the floating point value format flags.
+// Thease flags are mutually exclusive, this mask is used to clean float field
+// before setting the new float flag.
+static constexpr FmtFlags FloatField = Scientific | Fixed;
+
+constexpr size_t MAX_FLOATING_POINT_DIGITS = 24;
+constexpr size_t MAX_INTEGRAL_DIGITS = 23;
+constexpr const char *VEC_ELEMENT_DELIMITER = ", ";
+constexpr char VEC_OPEN_BRACE = '{';
+constexpr char VEC_CLOSE_BRACE = '}';
+
+constexpr size_t MAX_DIMENSIONS = 3;
+
+// Space for integrals (up to 3), comma and space between the
+// integrals and enclosing braces.
+constexpr size_t MAX_ARRAY_SIZE =
+    MAX_INTEGRAL_DIGITS * MAX_DIMENSIONS + 2 * (MAX_DIMENSIONS - 1) + 2;
+
+template <class F, class T = void>
+using EnableIfFP = typename std::enable_if<std::is_same<F, float>::value ||
+                                               std::is_same<F, double>::value ||
+                                               std::is_same<F, half>::value,
+                                           T>::type;
+
+template <typename> struct IsSwizzleOp : std::false_type {};
+
+template <typename VecT, typename OperationLeftT, typename OperationRightT,
+          template <typename> class OperationCurrentT, int... Indexes>
+struct IsSwizzleOp<cl::sycl::detail::SwizzleOp<
+    VecT, OperationLeftT, OperationRightT, OperationCurrentT, Indexes...>>
+    : std::true_type {
+  using T = typename VecT::element_type;
+  using Type = typename cl::sycl::vec<T, (sizeof...(Indexes))>;
+};
+
+template <typename T>
+using EnableIfSwizzleVec =
+    typename std::enable_if<IsSwizzleOp<T>::value,
+                            typename IsSwizzleOp<T>::Type>::type;
+
 class stream_impl {
 public:
   using AccessorType = accessor<char, 1, cl::sycl::access::mode::read_write,
@@ -69,6 +128,447 @@ private:
   // Stream buffer
   buffer<char, 1> Buf;
 };
+
+template <typename T>
+inline typename std::make_unsigned<T>::type getAbsVal(const T Val,
+                                                      const int Base) {
+  return ((Base == 10) && (Val < 0)) ? -Val : Val;
+}
+
+inline char digitToChar(const int Digit) {
+  if (Digit < 10) {
+    return '0' + Digit;
+  } else {
+    return 'a' + Digit - 10;
+  }
+}
+
+template <typename T>
+inline typename std::enable_if<std::is_integral<T>::value, unsigned>::type
+integralToBase(T Val, int Base, char *Digits) {
+  unsigned NumDigits = 0;
+
+  do {
+    Digits[NumDigits++] = digitToChar(Val % Base);
+    Val /= Base;
+  } while (Val);
+
+  return NumDigits;
+}
+
+template <typename T>
+EnableIfFP<T, unsigned> floatingPointToDecStr(T AbsVal, char *Digits,
+                                              int Precision, bool IsSci) {
+  int Exp = 0;
+
+  // For the case that the value is larger than 10.0
+  while (AbsVal >= 10.0) {
+    ++Exp;
+    AbsVal /= 10.0;
+  }
+  // For the case that the value is less than 1.0
+  while (AbsVal > 0.0 && AbsVal < 1.0) {
+    --Exp;
+    AbsVal *= 10.0;
+  }
+
+  auto IntegralPart = static_cast<int>(AbsVal);
+  auto FractionPart = AbsVal - IntegralPart;
+
+  int FractionDigits[MAX_FLOATING_POINT_DIGITS] = {0};
+
+  // Exponent
+  int P = Precision > 0 ? Precision : 4;
+  size_t FractionLength = Exp + P;
+
+  // After normalization integral part contains 1 symbol, also there could be
+  // '.', 'e', sign of the exponent and sign of the number, overall 5 symbols.
+  // So, clamp fraction length if required according to maximum size of the
+  // buffer for floating point number.
+  if (FractionLength > MAX_FLOATING_POINT_DIGITS - 5)
+    FractionLength = MAX_FLOATING_POINT_DIGITS - 5;
+
+  for (unsigned I = 0; I < FractionLength; ++I) {
+    FractionPart *= 10.0;
+    FractionDigits[I] = static_cast<int>(FractionPart);
+    FractionPart -= static_cast<int>(FractionPart);
+  }
+
+  int Carry = FractionPart > static_cast<T>(0.5) ? 1 : 0;
+
+  // Propagate the Carry
+  for (int I = FractionLength - 1; I >= 0 && Carry; --I) {
+    auto Digit = FractionDigits[I] + Carry;
+    FractionDigits[I] = Digit % 10;
+    Carry = Digit / 10;
+  }
+
+  // Carry from the fraction part is propagated to integral part
+  IntegralPart += Carry;
+  if (IntegralPart == 10) {
+    IntegralPart = 1;
+    ++Exp;
+  }
+
+  unsigned Offset = 0;
+
+  // Assemble the final string correspondingly
+  if (IsSci) { // scientific mode
+    // Append the integral part
+    Digits[Offset++] = digitToChar(IntegralPart);
+    Digits[Offset++] = '.';
+
+    // Append all fraction
+    for (unsigned I = 0; I < FractionLength; ++I)
+      Digits[Offset++] = digitToChar(FractionDigits[I]);
+
+    // Exponent part
+    Digits[Offset++] = 'e';
+    Digits[Offset++] = Exp >= 0 ? '+' : '-';
+    Digits[Offset++] = digitToChar(abs(Exp) / 10);
+    Digits[Offset++] = digitToChar(abs(Exp) % 10);
+  } else { // normal mode
+    if (Exp < 0) {
+      Digits[Offset++] = '0';
+      Digits[Offset++] = '.';
+      while (++Exp)
+        Digits[Offset++] = '0';
+
+      // Append the integral part
+      Digits[Offset++] = digitToChar(IntegralPart);
+
+      // Append all fraction
+      for (unsigned I = 0; I < FractionLength; ++I)
+        Digits[Offset++] = digitToChar(FractionDigits[I]);
+    } else {
+      // Append the integral part
+      Digits[Offset++] = digitToChar(IntegralPart);
+      unsigned I = 0;
+      // Append the integral part first
+      for (; I < FractionLength && Exp--; ++I)
+        Digits[Offset++] = digitToChar(FractionDigits[I]);
+
+      // Put the dot
+      Digits[Offset++] = '.';
+
+      // Append the rest of fraction part, or the real fraction part
+      for (; I < FractionLength; ++I)
+        Digits[Offset++] = digitToChar(FractionDigits[I]);
+    }
+    // The normal mode requires no tailing zero digit, then we need to first
+    // find the first non-zero digit
+    while (Digits[Offset - 1] == '0')
+      Offset--;
+
+    // If dot is the last digit, it should be stripped off as well
+    if (Digits[Offset - 1] == '.')
+      Offset--;
+  }
+  return Offset;
+}
+
+// Helper method to update offset atomically according to the provided
+// operand size of the output operator. Return true if offset is updated and
+// false in case of overflow.
+inline bool updateOffset(stream_impl::OffsetAccessorType &OffsetAcc,
+                         stream_impl::AccessorType &Acc, unsigned Size,
+                         unsigned &Cur) {
+  unsigned New;
+  do {
+    Cur = OffsetAcc[0].load();
+    if (Acc.get_count() - Cur < Size)
+      // Overflow
+      return false;
+    New = Cur + Size;
+  } while (!OffsetAcc[0].compare_exchange_strong(Cur, New));
+  return true;
+}
+
+inline void write(stream_impl::OffsetAccessorType &OffsetAcc,
+                  stream_impl::AccessorType &Acc, unsigned Len, const char *Buf,
+                  unsigned Padding = 0) {
+  unsigned Cur = 0;
+  if (!updateOffset(OffsetAcc, Acc, Len + Padding, Cur))
+    return;
+
+  size_t I = 0;
+
+  // Write padding
+  for (; I < Padding; ++I)
+    Acc[I + Cur] = ' ';
+
+  for (; I < Len; I++)
+    Acc[I + Cur] = Buf[I];
+}
+
+inline void reverseBuf(char *Buf, unsigned Len) {
+  int I = Len - 1;
+  int J = 0;
+  while (I > J) {
+    int Temp = Buf[I];
+    Buf[I] = Buf[J];
+    Buf[J] = Temp;
+    I--;
+    J++;
+  }
+}
+
+inline unsigned append(char *Dst, const char *Src) {
+  unsigned Len = 0;
+  for (; Src[Len] != '\0'; ++Len)
+    ;
+
+  for (unsigned I = 0; I < Len; ++I)
+    Dst[I] = Src[I];
+  return Len;
+}
+
+// Returns number of symbols written to the buffer
+template <typename T>
+inline EnableIfFP<T, unsigned> ScalarToStr(const T &Val, char *Buf,
+                                           unsigned Flags, int Width,
+                                           int Precision = -1) {
+  T Neg = -Val;
+  auto AbsVal = Val < 0 ? Neg : Val;
+
+  unsigned Offset = 0;
+
+  if (Val < 0) {
+    Buf[Offset++] = '-';
+  } else if (Flags & ShowPos) {
+    Buf[Offset++] = '+';
+  }
+
+  bool IsSci = false;
+  if (Flags & detail::Scientific)
+    IsSci = true;
+
+  // TODO: manipulators for floating-point output - hexfloat, fixed
+  Offset += floatingPointToDecStr(AbsVal, Buf + Offset, Precision, IsSci);
+
+  return Offset;
+}
+
+// Returns number of symbols written to the buffer
+template <typename T>
+inline typename std::enable_if<std::is_integral<T>::value, unsigned>::type
+ScalarToStr(const T &Val, char *Buf, unsigned Flags, int Width,
+            int Precision = -1) {
+  int Base = 10;
+
+  // append base manipulator
+  switch (Flags & BaseField) {
+  case Dec:
+    Base = 10;
+    break;
+  case Hex:
+    Base = 16;
+    break;
+  case Oct:
+    Base = 8;
+    break;
+  default:
+    // default value is 10
+    break;
+  }
+
+  unsigned Offset = 0;
+
+  // write '+' to the stream if the base is 10 and the value is non-negative
+  // or write '-' to stream if base is 10 and the value is negative
+  if (Base == 10) {
+    if ((Flags & ShowPos) && Val >= 0)
+      Buf[Offset++] = '+';
+    else if (Val < 0)
+      Buf[Offset++] = '-';
+  }
+
+  // write 0 or 0x to the stream if base is not 10 and the manipulator is set
+  if (Base != 10 && (Flags & ShowBase)) {
+    Buf[Offset++] = '0';
+    if (Base == 16)
+      Buf[Offset++] = 'x';
+  }
+
+  auto AbsVal = getAbsVal(Val, Base);
+
+  const unsigned NumBuf = integralToBase(AbsVal, Base, Buf + Offset);
+
+  reverseBuf(Buf + Offset, NumBuf);
+  return Offset + NumBuf;
+}
+
+template <typename T>
+inline typename std::enable_if<std::is_integral<T>::value>::type
+writeIntegral(stream_impl::OffsetAccessorType &OffsetAcc,
+              stream_impl::AccessorType &Acc, unsigned Flags, int Width,
+              const T &Val) {
+  char Digits[MAX_INTEGRAL_DIGITS] = {0};
+  unsigned Len = ScalarToStr(Val, Digits, Flags, Width);
+  write(OffsetAcc, Acc, Len, Digits,
+        (Width > 0 && static_cast<unsigned>(Width) > Len)
+            ? static_cast<unsigned>(Width) - Len
+            : 0);
+}
+
+template <typename T>
+inline EnableIfFP<T>
+writeFloatingPoint(stream_impl::OffsetAccessorType &OffsetAcc,
+                   stream_impl::AccessorType &Acc, unsigned Flags, int Width,
+                   int Precision, const T &Val) {
+  char Digits[MAX_FLOATING_POINT_DIGITS] = {0};
+  unsigned Len = ScalarToStr(Val, Digits, Flags, Width, Precision);
+  write(OffsetAcc, Acc, Len, Digits,
+        (Width > 0 && static_cast<unsigned>(Width) > Len)
+            ? static_cast<unsigned>(Width) - Len
+            : 0);
+}
+
+template <typename T, int VecLength>
+typename std::enable_if<(VecLength == 1), unsigned>::type
+VecToStr(const vec<T, VecLength> &Vec, char *VecStr, unsigned Flags, int Width,
+         int Precision) {
+  return ScalarToStr(static_cast<T>(Vec.x()), VecStr, Flags, Width, Precision);
+}
+
+template <typename T, int VecLength>
+typename std::enable_if<(VecLength == 2 || VecLength == 4 || VecLength == 8 ||
+                         VecLength == 16),
+                        unsigned>::type
+VecToStr(const vec<T, VecLength> &Vec, char *VecStr, unsigned Flags, int Width,
+         int Precision) {
+  unsigned Len =
+      VecToStr<T, VecLength / 2>(Vec.lo(), VecStr, Flags, Width, Precision);
+  Len += append(VecStr + Len, VEC_ELEMENT_DELIMITER);
+  Len += VecToStr<T, VecLength / 2>(Vec.hi(), VecStr + Len, Flags, Width,
+                                    Precision);
+  return Len;
+}
+
+template <typename T, int VecLength>
+typename std::enable_if<(VecLength == 3), unsigned>::type
+VecToStr(const vec<T, VecLength> &Vec, char *VecStr, unsigned Flags, int Width,
+         int Precision) {
+  unsigned Len = VecToStr<T, 2>(Vec.lo(), VecStr, Flags, Width, Precision);
+  Len += append(VecStr + Len, VEC_ELEMENT_DELIMITER);
+  Len += VecToStr<T, 1>(Vec.z(), VecStr + Len, Flags, Width, Precision);
+  return Len;
+}
+
+template <typename T, int VecLength>
+inline void writeVec(stream_impl::OffsetAccessorType &OffsetAcc,
+                     stream_impl::AccessorType &Acc, unsigned Flags, int Width,
+                     int Precision, const vec<T, VecLength> &Vec) {
+  // Reserve space for vector elements and delimiters
+  constexpr size_t MAX_VEC_SIZE =
+      MAX_FLOATING_POINT_DIGITS * VecLength + (VecLength - 1) * 2;
+  char VecStr[MAX_VEC_SIZE] = {0};
+  unsigned Len = VecToStr<T, VecLength>(Vec, VecStr, Flags, Width, Precision);
+  write(OffsetAcc, Acc, Len, VecStr,
+        (Width > 0 && Width > Len) ? Width - Len : 0);
+}
+
+template <int ArrayLength>
+inline unsigned ArrayToStr(char *Buf, const array<ArrayLength> &Arr) {
+  unsigned Len = 0;
+  Buf[Len++] = VEC_OPEN_BRACE;
+
+  for (int I = 0; I < ArrayLength; ++I) {
+    Len += ScalarToStr(Arr[I], Buf + Len, 0 /* No flags */, -1, -1);
+    if (I != ArrayLength - 1)
+      Len += append(Buf + Len, VEC_ELEMENT_DELIMITER);
+  }
+
+  Buf[Len++] = VEC_CLOSE_BRACE;
+
+  return Len;
+}
+
+template <int ArrayLength>
+inline void writeArray(stream_impl::OffsetAccessorType &OffsetAcc,
+                       stream_impl::AccessorType &Acc,
+                       const array<ArrayLength> &Arr) {
+  char Buf[MAX_ARRAY_SIZE] = {0};
+  unsigned Len = ArrayToStr(Buf, Arr);
+  write(OffsetAcc, Acc, Len, Buf);
+}
+
+template <int Dimensions>
+inline void writeItem(stream_impl::OffsetAccessorType &OffsetAcc,
+                      stream_impl::AccessorType &Acc,
+                      const item<Dimensions> &Item) {
+  // Reserve space for 3 arrays and additional place (40 symbols) for printing
+  // the text
+  char Buf[3 * MAX_ARRAY_SIZE + 40] = {0};
+  unsigned Len = 0;
+  Len += append(Buf, "item(");
+  Len += append(Buf + Len, "range: ");
+  Len += ArrayToStr(Buf + Len, Item.get_range());
+  Len += append(Buf + Len, ", id: ");
+  Len += ArrayToStr(Buf + Len, Item.get_id());
+  Len += append(Buf + Len, ", offset: ");
+  Len += ArrayToStr(Buf + Len, Item.get_offset());
+  Buf[Len++] = ')';
+  write(OffsetAcc, Acc, Len, Buf);
+}
+
+template <int Dimensions>
+inline void writeNDRange(stream_impl::OffsetAccessorType &OffsetAcc,
+                         stream_impl::AccessorType &Acc,
+                         const nd_range<Dimensions> &ND_Range) {
+  // Reserve space for 3 arrays and additional place (50 symbols) for printing
+  // the text
+  char Buf[3 * MAX_ARRAY_SIZE + 50] = {0};
+  unsigned Len = 0;
+  Len += append(Buf, "nd_range(");
+  Len += append(Buf + Len, "global_range: ");
+  Len += ArrayToStr(Buf + Len, ND_Range.get_global_range());
+  Len += append(Buf + Len, ", local_range: ");
+  Len += ArrayToStr(Buf + Len, ND_Range.get_local_range());
+  Len += append(Buf + Len, ", offset: ");
+  Len += ArrayToStr(Buf + Len, ND_Range.get_offset());
+  Buf[Len++] = ')';
+  write(OffsetAcc, Acc, Len, Buf);
+}
+
+template <int Dimensions>
+inline void writeNDItem(stream_impl::OffsetAccessorType &OffsetAcc,
+                        stream_impl::AccessorType &Acc,
+                        const nd_item<Dimensions> &ND_Item) {
+  // Reserve space for 2 arrays and additional place (40 symbols) for printing
+  // the text
+  char Buf[2 * MAX_ARRAY_SIZE + 40] = {0};
+  unsigned Len = 0;
+  Len += append(Buf, "nd_item(");
+  Len += append(Buf + Len, "global_id: ");
+  Len += ArrayToStr(Buf + Len, ND_Item.get_global_id());
+  Len += append(Buf + Len, ", local_id: ");
+  Len += ArrayToStr(Buf + Len, ND_Item.get_local_id());
+  Buf[Len++] = ')';
+  write(OffsetAcc, Acc, Len, Buf);
+}
+
+template <int Dimensions>
+inline void writeGroup(stream_impl::OffsetAccessorType &OffsetAcc,
+                       stream_impl::AccessorType &Acc,
+                       const group<Dimensions> &Group) {
+  // Reserve space for 4 arrays and additional place (60 symbols) for printing
+  // the text
+  char Buf[4 * MAX_ARRAY_SIZE + 60] = {0};
+  unsigned Len = 0;
+  Len += append(Buf, "group(");
+  Len += append(Buf + Len, "id: ");
+  Len += ArrayToStr(Buf + Len, Group.get_id());
+  Len += append(Buf + Len, ", global_range: ");
+  Len += ArrayToStr(Buf + Len, Group.get_global_range());
+  Len += append(Buf + Len, ", local_range: ");
+  Len += ArrayToStr(Buf + Len, Group.get_local_range());
+  Len += append(Buf + Len, ", group_range: ");
+  Len += ArrayToStr(Buf + Len, Group.get_group_range());
+  Buf[Len++] = ')';
+  write(OffsetAcc, Acc, Len, Buf);
+}
+
 } // namespace detail
 } // namespace sycl
 } // namespace cl

--- a/sycl/test/basic_tests/stream.cpp
+++ b/sycl/test/basic_tests/stream.cpp
@@ -11,118 +11,242 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define SYCL_SIMPLE_SWIZZLES
 #include <CL/sycl.hpp>
 #include <CL/sycl/context.hpp>
 #include <cassert>
 
+using namespace cl::sycl;
+using sm = stream_manipulator;
+
 int main() {
   {
-    cl::sycl::default_selector Selector;
-    cl::sycl::queue Queue(Selector);
+    default_selector Selector;
+    queue Queue(Selector);
 
     // Check constructor and getters
-    Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::stream Out(1024, 80, CGH);
+    Queue.submit([&](handler &CGH) {
+      stream Out(1024, 80, CGH);
       assert(Out.get_size() == 1024);
       assert(Out.get_max_statement_size() == 80);
     });
 
     // Check common reference semantics
-    cl::sycl::hash_class<cl::sycl::stream> Hasher;
+    hash_class<stream> Hasher;
 
-    Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::stream Out1(1024, 80, CGH);
-      cl::sycl::stream Out2(Out1);
+    Queue.submit([&](handler &CGH) {
+      stream Out1(1024, 80, CGH);
+      stream Out2(Out1);
 
       assert(Out1 == Out2);
       assert(Hasher(Out1) == Hasher(Out2));
 
-      cl::sycl::stream Out3(std::move(Out1));
+      stream Out3(std::move(Out1));
 
       assert(Out2 == Out3);
       assert(Hasher(Out2) == Hasher(Out3));
     });
 
-    // Char type
-    Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::stream Out(1024, 80, CGH);
-      CGH.parallel_for<class stream_char>(
-          cl::sycl::range<1>(10), [=](cl::sycl::id<1> i) { Out << 'a'; });
-    });
-    Queue.wait();
-
-    // endl manipulator
     // TODO: support cl::sycl::endl. According to specitification endl should be
     // constant global variable in cl::sycl which is initialized with
-    // cl::sycl::stream_manipulator::endl. This approach doesn't currently work,
+    // strean_manipulator::endl. This approach doesn't currently work,
     // variable is not initialized in the kernel code, it contains some garbage
     // value.
-    Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::stream Out(1024, 80, CGH);
-      CGH.single_task<class stream_endl>(
-          [=]() { Out << cl::sycl::stream_manipulator::endl; });
+    Queue.submit([&](handler &CGH) {
+      stream Out(1024, 80, CGH);
+      CGH.single_task<class integral>([=]() {
+        // String
+        Out << "Hello, World!\n";
+// CHECK: Hello, World!
+
+        // Char
+        Out << 'a' << '\n';
+// CHECK-NEXT: a
+
+        // Boolean type
+        Out << true << sm::endl;
+        Out << false << sm::endl;
+// CHECK-NEXT: true
+// CHECK-NEXT: false
+
+        // Integral types
+        Out << static_cast<unsigned char>(123) << sm::endl;
+        Out << static_cast<signed char>(-123) << sm::endl;
+        Out << static_cast<short>(2344) << sm::endl;
+        Out << static_cast<signed short>(-2344) << sm::endl;
+        Out << 3454 << sm::endl;
+        Out << -3454 << sm::endl;
+        Out << 3454U << sm::endl;
+        Out << 3454L << sm::endl;
+        Out << 12345678901245UL << sm::endl;
+        Out << -12345678901245LL << sm::endl;
+        Out << 12345678901245ULL << sm::endl;
+// CHECK-NEXT: 123
+// CHECK-NEXT: -123
+// CHECK-NEXT: 2344
+// CHECK-NEXT: -2344
+// CHECK-NEXT: 3454
+// CHECK-NEXT: -3454
+// CHECK-NEXT: 3454
+// CHECK-NEXT: 3454
+// CHECK-NEXT: 12345678901245
+// CHECK-NEXT: -12345678901245
+// CHECK-NEXT: 12345678901245
+
+        // Floating point types
+        Out << 33.4f << sm::endl;
+        Out << 5.2 << sm::endl;
+        Out << -33.4f << sm::endl;
+        Out << -5.2 << sm::endl;
+        Out << 0.0003 << sm::endl;
+// CHECK-NEXT: 33.4
+// CHECK-NEXT: 5.2
+// CHECK-NEXT: -33.4
+// CHECK-NEXT: -5.2
+// CHECK-NEXT: 0.0003
+
+        // Manipulators for integral types
+        Out << sm::dec << 0213 << sm::endl;
+        Out << sm::dec << 0x213A << sm::endl;
+        Out << sm::oct << 139 << sm::endl;
+        Out << sm::hex << 8506 << sm::endl;
+// CHECK-NEXT: 139
+// CHECK-NEXT: 8506
+// CHECK-NEXT: 213
+// CHECK-NEXT: 213a
+
+        Out << sm::oct << sm::showbase << 8506 << ' ' << sm::noshowbase << 8506
+            << sm::endl;
+        Out << sm::hex << sm::showbase << 8506 << ' ' << sm::noshowbase << 8506
+            << sm::endl;
+        Out << sm::dec << sm::showbase << 8506 << ' ' << sm::noshowbase << 8506
+            << sm::endl;
+// CHECK-NEXT: 020472 20472
+// CHECK-NEXT: 0x213a 213a
+// CHECK-NEXT: 8506 8506
+
+        Out << sm::dec << sm::showpos << 234 << ' ' << sm::noshowpos << 234
+            << sm::endl;
+        Out << sm::hex << sm::showpos << 234 << ' ' << sm::noshowpos << 234
+            << sm::endl;
+        Out << sm::oct << sm::showpos << 234 << ' ' << sm::noshowpos << 234
+            << sm::endl;
+// CHECK-NEXT: +234 234
+// CHECK-NEXT: ea ea
+// CHECK-NEXT: 352 352
+
+        Out << sm::hex << sm::showpos << -1 << ' ' << sm::noshowpos << -1
+            << sm::endl;
+        Out << sm::oct << sm::showpos << -1 << ' ' << sm::noshowpos << -1
+            << sm::endl;
+        Out << sm::dec << sm::showpos << -1 << ' ' << sm::noshowpos << -1
+            << sm::endl;
+// CHECK-NEXT: ffffffff ffffffff
+// CHECK-NEXT: 37777777777 37777777777
+// CHECK-NEXT: -1 -1
+
+        // Pointers
+        int a = 5;
+        int *Ptr = &a;
+        Out << Ptr << sm::endl;
+        const int *const ConstPtr = &a;
+        Out << ConstPtr << sm::endl;
+        auto multiPtr = private_ptr<int>(Ptr);
+        Out << multiPtr << sm::endl;
+
+        // Vectors
+        vec<int, 1> f1(545);
+        Out << f1 << sm::endl;
+        vec<int, 2> f2(545, 645);
+        Out << f2 << sm::endl;
+        vec<int, 3> f3(545, 645, 771);
+        Out << f3 << sm::endl;
+        vec<int, 4> f4(542325, 645, 771, 1024);
+        Out << sm::hex << sm::showbase << f4 << sm::endl;
+        Out << sm::dec << f4 << sm::endl;
+        vec<float, 4> f5(542.3f, 645.3f, 771.6f, 1024.2f);
+        Out << f5 << sm::endl;
+// CHECK: 545
+// CHECK-NEXT: 545, 645
+// CHECK-NEXT: 545, 645, 771
+// CHECK-NEXT: 0x84675, 0x285, 0x303, 0x400
+// CHECK-NEXT: 542325, 645, 771, 1024
+// CHECK-NEXT: 542.3, 645.3, 771.6, 1024.2
+
+        // Swizzles
+        Out << f4.xyzw() << sm::endl;
+// CHECK-NEXT: 542325, 645, 771, 1024
+
+        // SYCL types
+        Out << id<3>(11, 12, 13) << sm::endl;
+        Out << range<3>(11, 12, 13) << sm::endl;
+        Out << cl::sycl::nd_range<3>(cl::sycl::range<3>(2, 4, 1),
+                                     cl::sycl::range<3>(1, 2, 1))
+            << sm::endl;
+// CHECK-NEXT: {11, 12, 13}
+// CHECK-NEXT: {11, 12, 13}
+// CHECK-NEXT: nd_range(global_range: {2, 4, 1}, local_range: {1, 2, 1}, offset: {0, 0, 0})
+      });
     });
     Queue.wait();
 
-    // String type
-    Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::stream Out(1024, 80, CGH);
+    // Stream in parallel_for
+    Queue.submit([&](handler &CGH) {
+      stream Out(1024, 80, CGH);
       CGH.parallel_for<class stream_string>(
-          cl::sycl::range<1>(10),
-          [=](cl::sycl::id<1> i) { Out << "Hello, World!\n"; });
+          range<1>(10), [=](id<1> i) { Out << "Hello, World!\n"; });
     });
     Queue.wait();
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
 
-    // Boolean type
-    Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::stream Out(1024, 80, CGH);
-      CGH.single_task<class stream_bool1>([=]() { Out << true; });
+    // nd_item
+    Queue.submit([&](handler &CGH) {
+      stream Out(1024, 80, CGH);
+      CGH.parallel_for<class stream_nd_range>(
+          nd_range<3>(range<3>(4, 4, 4), range<3>(2, 2, 2)),
+          [=](nd_item<3> item) {
+            if (item.get_global_id(0) == 1 && item.get_global_id(1) == 2 &&
+                item.get_global_id(2) == 3)
+              Out << item << sm::endl;
+          });
     });
     Queue.wait();
-
-    Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::stream Out(1024, 80, CGH);
-      CGH.single_task<class stream_bool2>([=]() { Out << false; });
-    });
-    Queue.wait();
+// CHECK-NEXT: nd_item(global_id: {1, 2, 3}, local_id: {1, 0, 1})
 
     // Multiple streams in command group
-    Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::stream Out1(1024, 80, CGH);
-      cl::sycl::stream Out2(500, 10, CGH);
-      CGH.parallel_for<class multiple_streams>(cl::sycl::range<1>(2),
-                                               [=](cl::sycl::id<1> i) {
-                                                 Out1 << "Hello, World!\n";
-                                                 Out2 << "Hello, World!\n";
-                                               });
+    Queue.submit([&](handler &CGH) {
+      stream Out1(1024, 80, CGH);
+      stream Out2(500, 10, CGH);
+      CGH.parallel_for<class multiple_streams>(range<1>(2), [=](id<1> i) {
+        Out1 << "Hello, World!\n";
+        Out2 << "Hello, World!\n";
+      });
     });
     Queue.wait();
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
+// CHECK-NEXT: Hello, World!
 
     // The case when stream buffer is full. To check that there is no problem
     // with end of line symbol when printing out the stream buffer.
-    Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::stream Out(10, 10, CGH);
+    Queue.submit([&](handler &CGH) {
+      stream Out(10, 10, CGH);
       CGH.parallel_for<class full_stream_buffer>(
-          cl::sycl::range<1>(2),
-          [=](cl::sycl::id<1> i) { Out << "aaaaaaaaa\n"; });
+          range<1>(2), [=](id<1> i) { Out << "aaaaaaaaa\n"; });
     });
     Queue.wait();
   }
+// CHECK-NEXT: aaaaaaaaa
+
   return 0;
 }
-// CHECK: aaaaaaaaaa
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: truefalseHello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: Hello, World!
-// CHECK-NEXT: aaaaaaaaa


### PR DESCRIPTION
The following types were supported:
1. Float (naive implementation, precision is lost)
2. Integral types
3. Vec types and swizzles
4. Pointers
5. id, range, item, group, nd_item, nd_range

Also implementation details were moved to detail namespace.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>