### PR TITLE
[SYCL] Fix forward declaration of a class inside a kernel

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -340,6 +340,12 @@ private:
       Ty = QualType{Ty->getPointeeOrArrayElementType(), 0};
 
     if (const auto *CRD = Ty->getAsCXXRecordDecl()) {
+      // If the class is a forward declaration - skip it, because otherwise we
+      // would query property of class with no definition, which results in
+      // clang crash.
+      if (!CRD->hasDefinition())
+        return true;
+
       if (CRD->isPolymorphic()) {
         SemaRef.Diag(CRD->getLocation(), diag::err_sycl_virtual_types);
         SemaRef.Diag(Loc.getBegin(), diag::note_sycl_used_here);

--- a/clang/test/SemaSYCL/forward-decl.cpp
+++ b/clang/test/SemaSYCL/forward-decl.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -x c++ -DNOVIRTUAL -fsycl-is-device -std=c++11 -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -x c++ -DVIRTUAL -fsycl-is-device -std=c++11 -fsyntax-only -verify -pedantic %s
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+#ifdef NOVIRTUAL
+  kernel_single_task<class kernel_function_1>([]() {
+      // expected-no-diagnostics
+      class Foo *F;
+  });
+#elif VIRTUAL
+  kernel_single_task<class kernel_function_2>([]() {
+      // expected-error@+2{{No class with a vtable can be used in a SYCL kernel or any code included in the kernel}}
+      // expected-note@+1{{used here}}
+      class Boo {
+      public:
+        virtual int getBoo() { return 42; }
+      };
+  });
+
+  kernel_single_task<class kernel_function_3>([]() {
+      class Boo *B;
+  });
+#endif // VIRTUAL
+  return 0;
+}


### PR DESCRIPTION
Don't query property of class with no definition (which are
forward declared classes), that results in clang crash.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>