### PR TITLE
First attempt at __unique_stable_name

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -1953,7 +1953,7 @@ and other similar allocation libraries, and are only available in C++.
 ``__unique_stable_name``
 ------------------------
 
-``__unique_stable_name()`` is a SYCL builtin that takes a type or expression and
+``__unique_stable_name()`` is a builtin that takes a type or expression and
 produces a string literal containing a unique name for the type (or type of the
 expression) that is stable across split compilations.
 

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -1950,6 +1950,30 @@ form of ``__builtin_operator_delete`` is currently available.
 These builtins are intended for use in the implementation of ``std::allocator``
 and other similar allocation libraries, and are only available in C++.
 
+``__unique_stable_name``
+------------------------
+
+``__unique_stable_name()`` is a SYCL builtin that takes a type or expression and
+produces a string literal containing a unique name for the type (or type of the
+expression) that is stable across split compilations.
+
+In cases where the split compilation needs to share a unique token for a type
+across the boundary (such as in an offloading situation), this name can be used
+for lookup purposes.
+
+This builtin is superior to RTTI for this purpose for two reasons.  First, this
+value is computed entirely at compile time, so it can be used in constant
+expressions. Second, this value encodes lambda functions based on line-number
+rather than the order in which it appears in a function. This is valuable
+because it is stable in cases where an unrelated lambda is introduced
+conditionally in the same function.
+
+The current implementation of this builtin uses a slightly modified Itanium
+Mangler to produce the unique name. The lambda ordinal is replaced with one or
+more line/column pairs in the format ``LINE->COL``, separated with a ``~``
+character. Typically, only one pair will be included, however in the case of
+macro expansions, the entire macro expansion stack is expressed.
+
 Multiprecision Arithmetic Builtins
 ----------------------------------
 

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -1844,6 +1844,7 @@ private:
            "TypeSourceInfo only valid for UniqueStableName of a Type");
     getTrailingObjects<PredefExprStorage>()->T = Info;
   }
+
   void setExpr(Expr *E) {
     assert(!hasFunctionName() && getIdentKind() == UniqueStableNameExpr &&
            "Expr only valid for UniqueStableName of an Expression.");

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -1895,7 +1895,7 @@ public:
 
   const Expr *getExpr() const {
     assert(!hasFunctionName() && getIdentKind() == UniqueStableNameExpr &&
-           "TypeSourceInfo only valid for UniqueStableName of a Type");
+           "Expr only valid for UniqueStableName of an Expression.");
     return getTrailingObjects<PredefExprStorage>()->E;
   }
 

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -151,9 +151,14 @@ public:
 };
 
 class ItaniumMangleContext : public MangleContext {
+  bool IsUniqueNameMangler = false;
 public:
   explicit ItaniumMangleContext(ASTContext &C, DiagnosticsEngine &D)
       : MangleContext(C, D, MK_Itanium) {}
+  explicit ItaniumMangleContext(ASTContext &C, DiagnosticsEngine &D,
+                                bool IsUniqueNameMangler)
+      : MangleContext(C, D, MK_Itanium),
+        IsUniqueNameMangler(IsUniqueNameMangler) {}
 
   virtual void mangleCXXVTable(const CXXRecordDecl *RD, raw_ostream &) = 0;
   virtual void mangleCXXVTT(const CXXRecordDecl *RD, raw_ostream &) = 0;
@@ -170,12 +175,17 @@ public:
   virtual void mangleCXXDtorComdat(const CXXDestructorDecl *D,
                                    raw_ostream &) = 0;
 
+  bool isUniqueNameMangler() { return IsUniqueNameMangler; }
+
   static bool classof(const MangleContext *C) {
     return C->getKind() == MK_Itanium;
   }
 
   static ItaniumMangleContext *create(ASTContext &Context,
                                       DiagnosticsEngine &Diags);
+  static ItaniumMangleContext *create(ASTContext &Context,
+                                      DiagnosticsEngine &Diags,
+                                      bool IsUniqueNameMangler);
 };
 
 class MicrosoftMangleContext : public MangleContext {

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -436,6 +436,9 @@ KEYWORD(L__FUNCSIG__                , KEYMS)
 TYPE_TRAIT_1(__is_interface_class, IsInterfaceClass, KEYMS)
 TYPE_TRAIT_1(__is_sealed, IsSealed, KEYMS)
 
+// Extensions for SYCL.
+KEYWORD(__unique_stable_name        , KEYSYCL)
+
 // MSVC12.0 / VS2013 Type Traits
 TYPE_TRAIT_1(__is_destructible, IsDestructible, KEYMS)
 TYPE_TRAIT_1(__is_trivially_destructible, IsTriviallyDestructible, KEYCXX)

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -437,7 +437,7 @@ TYPE_TRAIT_1(__is_interface_class, IsInterfaceClass, KEYMS)
 TYPE_TRAIT_1(__is_sealed, IsSealed, KEYMS)
 
 // Extensions for SYCL.
-KEYWORD(__unique_stable_name        , KEYSYCL)
+KEYWORD(__unique_stable_name        , KEYALL)
 
 // MSVC12.0 / VS2013 Type Traits
 TYPE_TRAIT_1(__is_destructible, IsDestructible, KEYMS)

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -436,9 +436,6 @@ KEYWORD(L__FUNCSIG__                , KEYMS)
 TYPE_TRAIT_1(__is_interface_class, IsInterfaceClass, KEYMS)
 TYPE_TRAIT_1(__is_sealed, IsSealed, KEYMS)
 
-// Extensions for SYCL.
-KEYWORD(__unique_stable_name        , KEYALL)
-
 // MSVC12.0 / VS2013 Type Traits
 TYPE_TRAIT_1(__is_destructible, IsDestructible, KEYMS)
 TYPE_TRAIT_1(__is_trivially_destructible, IsTriviallyDestructible, KEYCXX)
@@ -675,6 +672,7 @@ ALIAS("__char16_t"   , char16_t   , KEYCXX)
 ALIAS("__char32_t"   , char32_t   , KEYCXX)
 
 KEYWORD(__builtin_available       , KEYALL)
+KEYWORD(__unique_stable_name        , KEYALL)
 
 // Clang-specific keywords enabled only in testing.
 TESTING_KEYWORD(__unknown_anytype , KEYALL)

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1681,6 +1681,7 @@ private:
   ExprResult ParsePostfixExpressionSuffix(ExprResult LHS);
   ExprResult ParseUnaryExprOrTypeTraitExpression();
   ExprResult ParseBuiltinPrimaryExpression();
+  ExprResult ParseUniqueStableNameExpression();
 
   ExprResult ParseExprAfterUnaryExprOrTypeTrait(const Token &OpTok,
                                                      bool &isCastExpr,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4466,6 +4466,14 @@ public:
   ExprResult ActOnPredefinedExpr(SourceLocation Loc, tok::TokenKind Kind);
   ExprResult ActOnIntegerConstant(SourceLocation Loc, uint64_t Val);
 
+  ExprResult BuildUniqueStableName(SourceLocation OpLoc,
+                                   TypeSourceInfo *Operand);
+  ExprResult BuildUniqueStableName(SourceLocation OpLoc, Expr *E);
+  ExprResult ActOnUniqueStableNameExpr(SourceLocation OpLoc, SourceLocation L,
+                                       SourceLocation R, ParsedType Ty);
+  ExprResult ActOnUniqueStableNameExpr(SourceLocation OpLoc, SourceLocation L,
+                                       SourceLocation R, Expr *Operand);
+
   bool CheckLoopHintExpr(Expr *E, SourceLocation Loc);
 
   ExprResult ActOnNumericConstant(const Token &Tok, Scope *UDLScope = nullptr);

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -489,6 +489,36 @@ PredefinedExpr::PredefinedExpr(SourceLocation L, QualType FNTy, IdentKind IK,
     setFunctionName(SL);
 }
 
+PredefinedExpr::PredefinedExpr(SourceLocation L, QualType FNTy, IdentKind IK,
+                               TypeSourceInfo *Info)
+    : Expr(PredefinedExprClass, FNTy, VK_LValue, OK_Ordinary,
+           FNTy->isDependentType(), FNTy->isDependentType(),
+           FNTy->isInstantiationDependentType(),
+           /*ContainsUnexpandedParameterPack=*/false) {
+  PredefinedExprBits.Kind = IK;
+  assert((getIdentKind() == IK) &&
+         "IdentKind do not fit in PredefinedExprBitfields!");
+  assert(IK == UniqueStableNameType && "Wrong Thing!");
+  PredefinedExprBits.HasFunctionName = false;
+  PredefinedExprBits.Loc = L;
+  setTypeSourceInfo(Info);
+}
+
+PredefinedExpr::PredefinedExpr(SourceLocation L, QualType FNTy, IdentKind IK,
+                               Expr *Info)
+    : Expr(PredefinedExprClass, FNTy, VK_LValue, OK_Ordinary,
+           FNTy->isDependentType(), FNTy->isDependentType(),
+           FNTy->isInstantiationDependentType(),
+           /*ContainsUnexpandedParameterPack=*/false) {
+  PredefinedExprBits.Kind = IK;
+  assert((getIdentKind() == IK) &&
+         "IdentKind do not fit in PredefinedExprBitfields!");
+  assert(IK == UniqueStableNameExpr && "Wrong Thing!");
+  PredefinedExprBits.HasFunctionName = false;
+  PredefinedExprBits.Loc = L;
+  setExpr(Info);
+}
+
 PredefinedExpr::PredefinedExpr(EmptyShell Empty, bool HasFunctionName)
     : Expr(PredefinedExprClass, Empty) {
   PredefinedExprBits.HasFunctionName = HasFunctionName;
@@ -498,14 +528,43 @@ PredefinedExpr *PredefinedExpr::Create(const ASTContext &Ctx, SourceLocation L,
                                        QualType FNTy, IdentKind IK,
                                        StringLiteral *SL) {
   bool HasFunctionName = SL != nullptr;
-  void *Mem = Ctx.Allocate(totalSizeToAlloc<Stmt *>(HasFunctionName),
-                           alignof(PredefinedExpr));
+  void *Mem =
+      Ctx.Allocate(totalSizeToAlloc<PredefExprStorage>(HasFunctionName),
+                   alignof(PredefinedExpr));
   return new (Mem) PredefinedExpr(L, FNTy, IK, SL);
+}
+
+PredefinedExpr *PredefinedExpr::Create(const ASTContext &Ctx, SourceLocation L,
+                                       QualType FNTy, IdentKind IK,
+                                       StringLiteral *SL,
+                                       TypeSourceInfo *Info) {
+  assert(IK == UniqueStableNameType && "Wrong Type");
+  bool HasFunctionName = SL != nullptr;
+  void *Mem =
+      Ctx.Allocate(totalSizeToAlloc<PredefExprStorage>(1),
+                   alignof(PredefinedExpr));
+
+  if (HasFunctionName)
+    return new (Mem) PredefinedExpr(L, FNTy, IK, SL);
+  return new (Mem) PredefinedExpr(L, FNTy, IK, Info);
+}
+
+PredefinedExpr *PredefinedExpr::Create(const ASTContext &Ctx, SourceLocation L,
+                                       QualType FNTy, IdentKind IK,
+                                       StringLiteral *SL, Expr *E) {
+  assert(IK == UniqueStableNameExpr && "Wrong Type");
+  bool HasFunctionName = SL != nullptr;
+  void *Mem =
+      Ctx.Allocate(totalSizeToAlloc<PredefExprStorage>(1),
+                   alignof(PredefinedExpr));
+  if (HasFunctionName)
+    return new (Mem) PredefinedExpr(L, FNTy, IK, SL);
+  return new (Mem) PredefinedExpr(L, FNTy, IK, E);
 }
 
 PredefinedExpr *PredefinedExpr::CreateEmpty(const ASTContext &Ctx,
                                             bool HasFunctionName) {
-  void *Mem = Ctx.Allocate(totalSizeToAlloc<Stmt *>(HasFunctionName),
+  void *Mem = Ctx.Allocate(totalSizeToAlloc<PredefExprStorage>(HasFunctionName),
                            alignof(PredefinedExpr));
   return new (Mem) PredefinedExpr(EmptyShell(), HasFunctionName);
 }
@@ -526,10 +585,25 @@ StringRef PredefinedExpr::getIdentKindName(PredefinedExpr::IdentKind IK) {
     return "__FUNCSIG__";
   case LFuncSig:
     return "L__FUNCSIG__";
+  case UniqueStableNameType:
+  case UniqueStableNameExpr:
+    return "__unique_stable_name";
   case PrettyFunctionNoVirtual:
     break;
   }
   llvm_unreachable("Unknown ident kind for PredefinedExpr");
+}
+
+std::string PredefinedExpr::ComputeName(ASTContext &Context, IdentKind IK,
+                                        QualType Ty) {
+  std::unique_ptr<MangleContext> Ctx{
+      ItaniumMangleContext::create(Context, Context.getDiagnostics(), true)};
+  Ty = Ty.getCanonicalType();
+
+  SmallString<256> Buffer;
+  llvm::raw_svector_ostream Out(Buffer);
+  Ctx->mangleTypeName(Ty, Out);
+  return Buffer.str();
 }
 
 // FIXME: Maybe this should use DeclPrinter with a special "print predefined

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -498,7 +498,8 @@ PredefinedExpr::PredefinedExpr(SourceLocation L, QualType FNTy, IdentKind IK,
   PredefinedExprBits.Kind = IK;
   assert((getIdentKind() == IK) &&
          "IdentKind do not fit in PredefinedExprBitfields!");
-  assert(IK == UniqueStableNameType && "Wrong Thing!");
+  assert(IK == UniqueStableNameType &&
+         "Constructor only valid with UniqueStableNameType");
   PredefinedExprBits.HasFunctionName = false;
   PredefinedExprBits.Loc = L;
   setTypeSourceInfo(Info);
@@ -513,7 +514,8 @@ PredefinedExpr::PredefinedExpr(SourceLocation L, QualType FNTy, IdentKind IK,
   PredefinedExprBits.Kind = IK;
   assert((getIdentKind() == IK) &&
          "IdentKind do not fit in PredefinedExprBitfields!");
-  assert(IK == UniqueStableNameExpr && "Wrong Thing!");
+  assert(IK == UniqueStableNameExpr &&
+         "Constructor only valid with UniqueStableNameExpr");
   PredefinedExprBits.HasFunctionName = false;
   PredefinedExprBits.Loc = L;
   setExpr(Info);

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -1704,6 +1704,10 @@ void CXXNameMangler::mangleTemplateParamDecl(const NamedDecl *Decl) {
   }
 }
 
+// Handles the __unique_stable_name feature for lambdas. Instead of the ordinal
+// of the lambda in its function, this does line/column to uniquely and reliably
+// identify the lambda.  Additionally, Macro expansions are expanded as well to
+// prevent macros causing duplicates.
 static void mangleUniqueNameLambda(CXXNameMangler &Mangler, SourceManager &SM,
                                    raw_ostream &Out,
                                    const CXXRecordDecl *Lambda) {

--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -1100,6 +1100,7 @@ Parser::isExpressionOrTypeSpecifierSimple(tok::TokenKind Kind) {
   case tok::kw_L__FUNCSIG__:
   case tok::kw___PRETTY_FUNCTION__:
   case tok::kw___uuidof:
+  case tok::kw___unique_stable_name:
 #define TYPE_TRAIT(N,Spelling,K) \
   case tok::kw_##Spelling:
 #include "clang/Basic/TokenKinds.def"

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3205,6 +3205,65 @@ ExprResult Sema::BuildPredefinedExpr(SourceLocation Loc,
 
   return PredefinedExpr::Create(Context, Loc, ResTy, IK, SL);
 }
+ExprResult Sema::BuildUniqueStableName(SourceLocation OpLoc,
+                                       TypeSourceInfo *Operand) {
+  QualType ResultTy;
+  StringLiteral *SL = nullptr;
+  if (Operand->getType()->isDependentType()) {
+    ResultTy = Context.DependentTy;
+  } else {
+    std::string Str = PredefinedExpr::ComputeName(Context,
+        PredefinedExpr::UniqueStableNameType, Operand->getType());
+    llvm::APInt Length(32, Str.length()  + 1);
+    ResultTy = Context.adjustStringLiteralBaseType(Context.CharTy.withConst());
+    ResultTy = Context.getConstantArrayType(ResultTy, Length, ArrayType::Normal,
+                                           /*IndexTypeQuals*/ 0);
+    SL = StringLiteral::Create(Context, Str, StringLiteral::Ascii,
+                               /*Pascal*/ false, ResultTy, OpLoc);
+  }
+
+  return PredefinedExpr::Create(Context, OpLoc, ResultTy,
+                                PredefinedExpr::UniqueStableNameType, SL,
+                                Operand);
+}
+ExprResult Sema::BuildUniqueStableName(SourceLocation OpLoc,
+                                       Expr *E) {
+  QualType ResultTy;
+  StringLiteral *SL = nullptr;
+  if (E->getType()->isDependentType()) {
+    ResultTy = Context.DependentTy;
+  } else {
+    std::string Str = PredefinedExpr::ComputeName(Context,
+        PredefinedExpr::UniqueStableNameExpr, E->getType());
+    llvm::APInt Length(32, Str.length()  + 1);
+    ResultTy = Context.adjustStringLiteralBaseType(Context.CharTy.withConst());
+    ResultTy = Context.getConstantArrayType(ResultTy, Length, ArrayType::Normal,
+                                           /*IndexTypeQuals*/ 0);
+    SL = StringLiteral::Create(Context, Str, StringLiteral::Ascii,
+                               /*Pascal*/ false, ResultTy, OpLoc);
+  }
+
+  return PredefinedExpr::Create(Context, OpLoc, ResultTy,
+                                PredefinedExpr::UniqueStableNameExpr, SL, E);
+}
+
+ExprResult Sema::ActOnUniqueStableNameExpr(SourceLocation OpLoc,
+                                           SourceLocation L, SourceLocation R,
+                                           ParsedType Ty) {
+  TypeSourceInfo *TInfo = nullptr;
+  QualType T = GetTypeFromParser(Ty, &TInfo);
+
+  if (T.isNull()) return ExprError();
+  if (!TInfo) TInfo = Context.getTrivialTypeSourceInfo(T, OpLoc);
+
+  return BuildUniqueStableName(OpLoc, TInfo);
+}
+
+ExprResult Sema::ActOnUniqueStableNameExpr(SourceLocation OpLoc,
+                                           SourceLocation L, SourceLocation R,
+                                           Expr *E) {
+  return BuildUniqueStableName(OpLoc, E);
+}
 
 ExprResult Sema::ActOnPredefinedExpr(SourceLocation Loc, tok::TokenKind Kind) {
   PredefinedExpr::IdentKind IK;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3212,12 +3212,12 @@ ExprResult Sema::BuildUniqueStableName(SourceLocation OpLoc,
   if (Operand->getType()->isDependentType()) {
     ResultTy = Context.DependentTy;
   } else {
-    std::string Str = PredefinedExpr::ComputeName(Context,
-        PredefinedExpr::UniqueStableNameType, Operand->getType());
-    llvm::APInt Length(32, Str.length()  + 1);
+    std::string Str = PredefinedExpr::ComputeName(
+        Context, PredefinedExpr::UniqueStableNameType, Operand->getType());
+    llvm::APInt Length(32, Str.length() + 1);
     ResultTy = Context.adjustStringLiteralBaseType(Context.CharTy.withConst());
     ResultTy = Context.getConstantArrayType(ResultTy, Length, ArrayType::Normal,
-                                           /*IndexTypeQuals*/ 0);
+                                            /*IndexTypeQuals*/ 0);
     SL = StringLiteral::Create(Context, Str, StringLiteral::Ascii,
                                /*Pascal*/ false, ResultTy, OpLoc);
   }
@@ -3226,6 +3226,7 @@ ExprResult Sema::BuildUniqueStableName(SourceLocation OpLoc,
                                 PredefinedExpr::UniqueStableNameType, SL,
                                 Operand);
 }
+
 ExprResult Sema::BuildUniqueStableName(SourceLocation OpLoc,
                                        Expr *E) {
   QualType ResultTy;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3205,6 +3205,7 @@ ExprResult Sema::BuildPredefinedExpr(SourceLocation Loc,
 
   return PredefinedExpr::Create(Context, Loc, ResTy, IK, SL);
 }
+
 ExprResult Sema::BuildUniqueStableName(SourceLocation OpLoc,
                                        TypeSourceInfo *Operand) {
   QualType ResultTy;

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1193,7 +1193,9 @@ TemplateInstantiator::TransformPredefinedExpr(PredefinedExpr *E) {
       return E;
 
     return getSema().BuildUniqueStableName(E->getLocation(), SubExpr.get());
-  } else if (E->getIdentKind() == PredefinedExpr::UniqueStableNameType) {
+  }
+
+  if (E->getIdentKind() == PredefinedExpr::UniqueStableNameType) {
     TypeSourceInfo *Info = getDerived().TransformType(E->getTypeSourceInfo());
     if (!Info)
       return ExprError();

--- a/clang/test/CodeGenSYCL/unique-stable-name.cpp
+++ b/clang/test/CodeGenSYCL/unique-stable-name.cpp
@@ -1,0 +1,69 @@
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -x c++ -emit-llvm %s -o - | FileCheck %s
+// CHECK: @[[INT:[^\w]+]] = private unnamed_addr constant [[INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
+// CHECK: @[[LAMBDA_X:[^\w]+]] = private unnamed_addr constant [[LAMBDA_X_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE37->5clEvEUlvE41->16\00"
+// CHECK: @[[MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE37->5clEvEUlvE47->7~26->18\00"
+// CHECK: @[[MACRO_Y:[^\w]+]] =  private unnamed_addr constant [[MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE37->5clEvEUlvE47->7~26->41\00"
+// CHECK: @[[LAMBDA_IN_DEP_INT:[^\w]+]] = private unnamed_addr constant [[DEP_INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIiEvvEUlvE21->12\00",
+// CHECK: @[[LAMBDA_IN_DEP_X:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIZZ4mainENKUlvE37->5clEvEUlvE41->16EvvEUlvE21->12\00",
+
+extern "C" void printf(const char*);
+
+template <typename T>
+void template_param() {
+  printf(__unique_stable_name(T));
+}
+
+template <typename T>
+T getT() { return T{}; }
+
+template <typename T>
+void lambda_in_dependent_function() {
+  auto y = [] {};
+  printf(__unique_stable_name(y));
+}
+
+#define DEF_IN_MACRO()                                  \
+  auto MACRO_X = []() {};auto MACRO_Y = []() {};        \
+  printf(__unique_stable_name(MACRO_X));                \
+  printf(__unique_stable_name(MACRO_Y));
+
+template <typename KernelName, typename KernelType>
+__attribute__((sycl_kernel)) void kernel_single_task(KernelType kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class kernel>(
+    []() {
+      printf(__unique_stable_name(int));
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[INT_SIZE]], [[INT_SIZE]]* @[[INT]]
+
+      auto x = [](){};
+      printf(__unique_stable_name(x));
+      printf(__unique_stable_name(decltype(x)));
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_X_SIZE]], [[LAMBDA_X_SIZE]]* @[[LAMBDA_X]]
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_X_SIZE]], [[LAMBDA_X_SIZE]]* @[[LAMBDA_X]]
+
+      DEF_IN_MACRO();
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_SIZE]], [[MACRO_SIZE]]* @[[MACRO_X]]
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_SIZE]], [[MACRO_SIZE]]* @[[MACRO_Y]]
+
+      template_param<int>();
+      // CHECK: define linkonce_odr spir_func void @_Z14template_paramIiEvv
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[INT_SIZE]], [[INT_SIZE]]* @[[INT]]
+
+      template_param<decltype(x)>();
+      // CHECK: define internal spir_func void @"_Z14template_paramIZZ4mainENK3
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_X_SIZE]], [[LAMBDA_X_SIZE]]* @[[LAMBDA_X]]
+
+      lambda_in_dependent_function<int>();
+      // CHECK: define linkonce_odr spir_func void @_Z28lambda_in_dependent_functionIiEvv
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_INT_SIZE]], [[DEP_INT_SIZE]]* @[[LAMBDA_IN_DEP_INT]]
+
+      lambda_in_dependent_function<decltype(x)>();
+      // CHECK: define internal spir_func void @"_Z28lambda_in_dependent_functionIZZ4mainENK3$_0clEvEUlvE_Evv
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA_SIZE]], [[DEP_LAMBDA_SIZE]]* @[[LAMBDA_IN_DEP_X]]
+
+    });
+}
+


### PR DESCRIPTION
This implementation uses the keyword __unique_stable_name as an operator
that can take a type or expression, and will result in a constexpr
constant character array that (hopefully) uniquely represents the type
or type-of-expression being passed to it.

The unique representation is the normal mangled name of the type, except
in the cases of a lambda, where the ordinal "number" is just replaced
with LINE->COL.  Macro expansions are also appended with '~' followed by
the LINE->COL that it appears in.

For example, a lambda declared in
'main' would look like _ZTSZ4mainEUlvE25->12 (line 25, column 12).

A Lambda that comes from a macro looks like:
_ZTSZ4mainEUlvE45->3~18->32 (macro invoked on 45/3, lambda defined
inside the macro on line 18, column 32).

Template instantiations based on the lambda would result in a name that
contains the lambda mangling, for example:
_ZTSZ3bazIZ4mainEUlvE25->12EvvEUlvE14->12

A function template named 'baz' that is instantiated with a lambda
declared in 'main' on line 25/col 12 has another macro in it, declared
on line 14, column 12.

Signed-off-by: Erich Keane <erich.keane@intel.com>