### PR TITLE
[SYCL][Driver][Triple] Setting Appropriate LastEnviornmentType

### DIFF
--- a/llvm/include/llvm/ADT/Triple.h
+++ b/llvm/include/llvm/ADT/Triple.h
@@ -213,8 +213,8 @@ public:
     Itanium,
     Cygnus,
     CoreCLR,
-    Simulator,  // Simulator variants of other systems, e.g., Apple's iOS
     SYCLDevice,
+    Simulator,  // Simulator variants of other systems, e.g., Apple's iOS
     LastEnvironmentType = Simulator
   };
   enum ObjectFormatType {


### PR DESCRIPTION
Just setting the LastEnviornmentType to be SYCLDevice. Seems like it was just overlooked originally. I may be incorrect though and it was intended!