### PR TITLE
[SYCL] Expanded Ahead Of Time Compilation support

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -104,9 +104,9 @@ def err_drv_Xopenmp_target_missing_triple : Error<
 def err_drv_invalid_Xopenmp_target_with_args : Error<
   "invalid -Xopenmp-target argument: '%0', options requiring arguments are unsupported">;
 def err_drv_Xsycl_target_missing_triple : Error<
-  "cannot deduce implicit triple value for -Xsycl-target, specify triple using -Xsycl-target=<triple>">;
-def err_drv_invalid_Xsycl_target_with_args : Error<
-  "invalid -Xsycl-target argument: '%0', options requiring arguments are unsupported">;
+  "cannot deduce implicit triple value for '%0', specify triple using '%0=<triple>'">;
+def err_drv_invalid_Xsycl_frontend_with_args : Error<
+  "invalid -Xsycl-target-frontend argument: '%0', options requiring arguments are unsupported">;
 def err_drv_argument_only_allowed_with : Error<
   "invalid argument '%0' only allowed with '%1'">;
 def err_drv_argument_not_allowed_with : Error<

--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -73,9 +73,10 @@ public:
     OffloadUnbundlingJobClass,
     OffloadWrappingJobClass,
     SPIRVTranslatorJobClass,
+    BackendCompileJobClass,
 
     JobClassFirst = PreprocessJobClass,
-    JobClassLast = SPIRVTranslatorJobClass
+    JobClassLast = BackendCompileJobClass
   };
 
   // The offloading kind determines if this action is binded to a particular
@@ -635,6 +636,17 @@ public:
 
   static bool classof(const Action *A) {
     return A->getKind() == SPIRVTranslatorJobClass;
+  }
+};
+
+class BackendCompileJobAction : public JobAction {
+  void anchor() override;
+
+public:
+  BackendCompileJobAction(Action *Input, types::ID OutputType);
+
+  static bool classof(const Action *A) {
+    return A->getKind() == BackendCompileJobClass;
   }
 };
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -472,10 +472,20 @@ def Xopenmp_target : Separate<["-"], "Xopenmp-target">,
 def Xopenmp_target_EQ : JoinedAndSeparate<["-"], "Xopenmp-target=">,
   HelpText<"Pass <arg> to the target offloading toolchain identified by <triple>.">,
   MetaVarName<"<triple> <arg>">;
-def Xsycl_target : Separate<["-"], "Xsycl-target">,
-  HelpText<"Pass <arg> to the SYCL based target offloading toolchain.">, MetaVarName<"<arg>">;
-def Xsycl_target_EQ : JoinedAndSeparate<["-"], "Xsycl-target=">,
-  HelpText<"Pass <arg> to the SYCL based target offloading toolchain identified by <triple>.">,
+def Xsycl_backend : Separate<["-"], "Xsycl-target-backend">,
+  HelpText<"Pass <arg> to the SYCL based target backend.">, MetaVarName<"<arg>">;
+def Xsycl_backend_EQ : JoinedAndSeparate<["-"], "Xsycl-target-backend=">,
+  HelpText<"Pass <arg> to the SYCL based backend identified by <triple>.">,
+  MetaVarName<"<triple> <arg>">;
+def Xsycl_frontend : Separate<["-"], "Xsycl-target-frontend">,
+  HelpText<"Pass <arg> to the SYCL based target frontend.">, MetaVarName<"<arg>">;
+def Xsycl_frontend_EQ : JoinedAndSeparate<["-"], "Xsycl-target-frontend=">,
+  HelpText<"Pass <arg> to the SYCL based target frontend identified by <triple>.">,
+  MetaVarName<"<triple> <arg>">;
+def Xsycl_linker : Separate<["-"], "Xsycl-target-linker">,
+  HelpText<"Pass <arg> to the SYCL based target linker.">, MetaVarName<"<arg>">;
+def Xsycl_linker_EQ : JoinedAndSeparate<["-"], "Xsycl-target-linker=">,
+  HelpText<"Pass <arg> to the SYCL based target linker identified by <triple>.">,
   MetaVarName<"<triple> <arg>">;
 def z : Separate<["-"], "z">, Flags<[LinkerInput, RenderAsInput]>,
   HelpText<"Pass -z <arg> to the linker">, MetaVarName<"<arg>">,

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -139,6 +139,7 @@ private:
   mutable std::unique_ptr<Tool> OffloadBundler;
   mutable std::unique_ptr<Tool> OffloadWrapper;
   mutable std::unique_ptr<Tool> SPIRVTranslator;
+  mutable std::unique_ptr<Tool> BackendCompiler;
 
   Tool *getClang() const;
   Tool *getAssemble() const;
@@ -147,6 +148,7 @@ private:
   Tool *getOffloadBundler() const;
   Tool *getOffloadWrapper() const;
   Tool *getSPIRVTranslator() const;
+  Tool *getBackendCompiler() const;
 
   mutable std::unique_ptr<SanitizerArgs> SanitizerArguments;
   mutable std::unique_ptr<XRayArgs> XRayArguments;
@@ -170,6 +172,7 @@ protected:
 
   virtual Tool *buildAssembler() const;
   virtual Tool *buildLinker() const;
+  virtual Tool *buildBackendCompiler() const;
   virtual Tool *getTool(Action::ActionClass AC) const;
 
   /// \name Utilities for implementing subclasses.

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -44,6 +44,8 @@ const char *Action::getClassName(ActionClass AC) {
     return "clang-offload-wrapper";
   case SPIRVTranslatorJobClass:
     return "llvm-spirv";
+  case BackendCompileJobClass:
+    return "backend-compiler";
   }
 
   llvm_unreachable("invalid class");
@@ -423,3 +425,9 @@ void SPIRVTranslatorJobAction::anchor() {}
 SPIRVTranslatorJobAction::SPIRVTranslatorJobAction(Action *Input,
                                                    types::ID Type)
     : JobAction(SPIRVTranslatorJobClass, Input, Type) {}
+
+void BackendCompileJobAction::anchor() {}
+
+BackendCompileJobAction::BackendCompileJobAction(Action *Input,
+                                                 types::ID Type)
+    : JobAction(BackendCompileJobClass, Input, Type) {}

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -69,7 +69,7 @@ Compilation::getArgsForToolChain(const ToolChain *TC, StringRef BoundArch,
     SmallVector<Arg *, 4> AllocatedArgs;
     DerivedArgList *OffloadArgs = nullptr;
     // Translate offload toolchain arguments provided via the -Xopenmp-target
-    // or -Xsycl-target flags.
+    // or -Xsycl-target-frontend flags.
     if (DeviceOffloadKind == Action::OFK_OpenMP ||
         DeviceOffloadKind == Action::OFK_SYCL) {
       const ToolChain *HostTC = getSingleOffloadToolChain<Action::OFK_Host>();

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -272,6 +272,10 @@ Tool *ToolChain::buildLinker() const {
   llvm_unreachable("Linking is not supported by this toolchain");
 }
 
+Tool *ToolChain::buildBackendCompiler() const {
+  llvm_unreachable("Backend Compilation is not supported by this toolchain");
+}
+
 Tool *ToolChain::getAssemble() const {
   if (!Assemble)
     Assemble.reset(buildAssembler());
@@ -306,6 +310,12 @@ Tool *ToolChain::getSPIRVTranslator() const {
   if (!SPIRVTranslator)
     SPIRVTranslator.reset(new tools::SPIRVTranslator(*this));
   return SPIRVTranslator.get();
+}
+
+Tool *ToolChain::getBackendCompiler() const {
+  if (!BackendCompiler)
+    BackendCompiler.reset(buildBackendCompiler());
+  return BackendCompiler.get();
 }
 
 Tool *ToolChain::getTool(Action::ActionClass AC) const {
@@ -343,6 +353,9 @@ Tool *ToolChain::getTool(Action::ActionClass AC) const {
 
   case Action::SPIRVTranslatorJobClass:
     return getSPIRVTranslator();
+
+  case Action::BackendCompileJobClass:
+    return getBackendCompiler();
   }
 
   llvm_unreachable("Invalid tool kind.");
@@ -979,7 +992,7 @@ llvm::opt::DerivedArgList *ToolChain::TranslateOffloadTargetArgs(
   const OptTable &Opts = getDriver().getOpts();
   bool Modified = false;
 
-  // Handle -Xopenmp-target and -Xsycl-target flags
+  // Handle -Xopenmp-target and -Xsycl-target-frontend flags
   for (auto *A : Args) {
     // Exclude flags which may only apply to the host toolchain.
     // Do not exclude flags when the host triple (AuxTriple)
@@ -1023,15 +1036,15 @@ llvm::opt::DerivedArgList *ToolChain::TranslateOffloadTargetArgs(
       }
     } else if (DeviceOffloadKind == Action::OFK_SYCL) {
       XOffloadTargetNoTriple =
-        A->getOption().matches(options::OPT_Xsycl_target);
-      if (A->getOption().matches(options::OPT_Xsycl_target_EQ)) {
-        // Passing device args: -Xsycl-target=<triple> -opt=val.
+        A->getOption().matches(options::OPT_Xsycl_frontend);
+      if (A->getOption().matches(options::OPT_Xsycl_frontend_EQ)) {
+        // Passing device args: -Xsycl-target-frontend=<triple> -opt=val.
         if (A->getValue(0) == getTripleString())
           Index = Args.getBaseArgs().MakeIndex(A->getValue(1));
         else
           continue;
       } else if (XOffloadTargetNoTriple) {
-        // Passing device args: -Xsycl-target -opt=val.
+        // Passing device args: -Xsycl-target-frontend -opt=val.
         Index = Args.getBaseArgs().MakeIndex(A->getValue(0));
       } else {
         DAL->append(A);
@@ -1047,7 +1060,7 @@ llvm::opt::DerivedArgList *ToolChain::TranslateOffloadTargetArgs(
         getDriver().Diag(diag::err_drv_invalid_Xopenmp_target_with_args)
             << A->getAsString(Args);
       } else {
-        getDriver().Diag(diag::err_drv_invalid_Xsycl_target_with_args)
+        getDriver().Diag(diag::err_drv_invalid_Xsycl_frontend_with_args)
             << A->getAsString(Args);
       }
       continue;
@@ -1060,8 +1073,9 @@ llvm::opt::DerivedArgList *ToolChain::TranslateOffloadTargetArgs(
         getDriver().Diag(diag::err_drv_Xopenmp_target_missing_triple);
         continue;
       } else if (DeviceOffloadKind == Action::OFK_SYCL &&
-          Args.getAllArgValues(options::OPT_fsycl_targets_EQ).size() != 1) {
-        getDriver().Diag(diag::err_drv_Xsycl_target_missing_triple);
+          Args.getAllArgValues(options::OPT_fsycl_targets_EQ).size() > 1) {
+        getDriver().Diag(diag::err_drv_Xsycl_target_missing_triple)
+            << A->getSpelling();
         continue;
       }
     }

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -52,9 +52,9 @@ const char *SYCL::Linker::constructLLVMSpirvCommand(Compilation &C,
   return OutputFileName;
 }
 
-const char *SYCL::Linker::constructLLVMLinkCommand(
-    Compilation &C, const JobAction &JA, const ArgList &Args,
-    StringRef SubArchName, StringRef OutputFilePrefix,
+const char *SYCL::Linker::constructLLVMLinkCommand(Compilation &C,
+    const JobAction &JA, const InputInfo &Output, const ArgList &Args,
+    StringRef SubArchName, StringRef OutputFilePrefix, bool ToBc,
     const InputInfoList &InputFiles) const {
   ArgStringList CmdArgs;
   // Add the input bc's created by compile step.
@@ -80,13 +80,18 @@ const char *SYCL::Linker::constructLLVMLinkCommand(
     for (const auto &II : InputFiles)
       CmdArgs.push_back(II.getFilename());
 
+  // Add additional options from -Xsycl-target-linker
+  TranslateSYCLLinkerArgs(C, Args, getToolChain(), CmdArgs);
   // Add an intermediate output file.
   CmdArgs.push_back("-o");
-  SmallString<128> TmpName(C.getDriver().GetTemporaryPath(
-                           OutputFilePrefix.str() + "-linked", "bc"));
-  const char *OutputFileName =
-      C.addTempFile(C.getArgs().MakeArgString(TmpName));
-  CmdArgs.push_back(OutputFileName);
+  const char *OutputFileName = nullptr;
+  if (ToBc) {
+    SmallString<128> TmpName(C.getDriver().GetTemporaryPath(
+                             OutputFilePrefix.str() + "-linked", "bc"));
+    OutputFileName = C.addTempFile(C.getArgs().MakeArgString(TmpName));
+    CmdArgs.push_back(OutputFileName);
+  } else
+    CmdArgs.push_back(Output.getFilename());
   SmallString<128> ExecPath(C.getDriver().Dir);
   llvm::sys::path::append(ExecPath, "llvm-link");
   const char *Exec = C.getArgs().MakeArgString(ExecPath);
@@ -143,9 +148,139 @@ void SYCL::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                       LLVMSpirvOutputFile));
     }
   }
+
   const char *LLVMLinkOutputFile =
-      constructLLVMLinkCommand(C, JA, Args, SubArchName, Prefix, SpirvInputs);
+      constructLLVMLinkCommand(C, JA, Output, Args, SubArchName, Prefix, true,
+                               SpirvInputs);
   constructLLVMSpirvCommand(C, JA, Output, Prefix, false, LLVMLinkOutputFile);
+}
+
+void SYCL::TranslateSYCLTargetArgs(Compilation &C,
+   const llvm::opt::ArgList &Args, const ToolChain &TC,
+   llvm::opt::ArgStringList &CmdArgs) {
+
+  // Handle -Xsycl-target-backend flag.
+  for (auto *A : Args) {
+    bool XSYCLTargetNoTriple;
+    XSYCLTargetNoTriple = A->getOption().matches(options::OPT_Xsycl_backend);
+    if (A->getOption().matches(options::OPT_Xsycl_backend_EQ)) {
+      // Passing device args: -Xsycl-target-backend=<triple> -opt=val.
+      if (A->getValue() != TC.getTripleString())
+        // Provided triple does not match current tool chain.
+        continue;
+    } else if (!XSYCLTargetNoTriple)
+      // Don't worry about any of the other args, we only want to pass what is
+      // passed in -Xsycl-target-backend.
+      continue;
+
+    // Add the argument from -Xsycl-target-backend.
+    StringRef ArgString;
+    if (XSYCLTargetNoTriple) {
+      // With multiple -fsycl-targets, a triple is required so we know where
+      // the options should go.
+      if (Args.getAllArgValues(options::OPT_fsycl_targets_EQ).size() != 1) {
+        C.getDriver().Diag(diag::err_drv_Xsycl_target_missing_triple)
+            << A->getSpelling();
+        continue;
+      }
+      // No triple, so just add the argument.
+      ArgString = A->getValue();
+    } else
+      // Triple found, add the next argument in line.
+      ArgString = A->getValue(1);
+    // Do a simple parse of the args to pass back
+    SmallVector<StringRef, 16> TargetArgs;
+    ArgString.split(TargetArgs, ' ', -1, false);
+    for (const auto &TA : TargetArgs)
+      CmdArgs.push_back(Args.MakeArgString(TA));
+    Args.ClaimAllArgs(options::OPT_Xsycl_backend_EQ);
+    Args.ClaimAllArgs(options::OPT_Xsycl_backend);
+  }
+}
+
+void SYCL::TranslateSYCLLinkerArgs(Compilation &C,
+   const llvm::opt::ArgList &Args, const ToolChain &TC,
+   llvm::opt::ArgStringList &CmdArgs) {
+
+  // Handle -Xsycl-target-linker flag.
+  for (auto *A : Args) {
+    bool XSYCLLinkerNoTriple;
+    XSYCLLinkerNoTriple = A->getOption().matches(options::OPT_Xsycl_linker);
+    if (A->getOption().matches(options::OPT_Xsycl_linker_EQ)) {
+      // Passing llvm-link args: -Xsycl-target-linker=<triple> -opt=val.
+      if (A->getValue() != TC.getTripleString())
+        // Provided triple does not match current tool chain.
+        continue;
+    } else if (!XSYCLLinkerNoTriple)
+      // Don't worry about any of the other args, we only want to pass what is
+      // passed in -Xsycl-target-linker.
+      continue;
+
+    // Add the argument from -Xsycl-target-linker.
+    StringRef ArgString;
+    if (XSYCLLinkerNoTriple) {
+      // With multiple -fsycl-targets, a triple is required so we know where
+      // the options should go.
+      if (Args.getAllArgValues(options::OPT_fsycl_targets_EQ).size() != 1) {
+        C.getDriver().Diag(diag::err_drv_Xsycl_target_missing_triple)
+            << A->getSpelling();
+        continue;
+      }
+      // No triple, so just add the argument.
+      ArgString = A->getValue();
+    } else
+      // Triple found, add the next argument in line.
+      ArgString = A->getValue(1);
+    // Do a simple parse of the args to pass back
+    SmallVector<StringRef, 16> TargetArgs;
+    ArgString.split(TargetArgs, ' ', -1, false);
+    for (const auto &TA : TargetArgs)
+      CmdArgs.push_back(Args.MakeArgString(TA));
+    Args.ClaimAllArgs(options::OPT_Xsycl_linker_EQ);
+    Args.ClaimAllArgs(options::OPT_Xsycl_linker);
+  }
+}
+
+void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
+                                         const JobAction &JA,
+                                         const InputInfo &Output,
+                                         const InputInfoList &Inputs,
+                                         const ArgList &Args,
+                                         const char *LinkingOutput) const {
+  assert((getToolChain().getTriple().getArch() == llvm::Triple::spir ||
+          getToolChain().getTriple().getArch() == llvm::Triple::spir64) &&
+         "Unsupported target");
+  ArgStringList CmdArgs{"-o",  Output.getFilename()};
+  for (const auto &II : Inputs) {
+    CmdArgs.push_back(II.getFilename());
+  }
+  CmdArgs.push_back("-sycl");
+  TranslateSYCLTargetArgs(C, Args, getToolChain(), CmdArgs);
+
+  SmallString<128> ExecPath(getToolChain().GetProgramPath("aoc"));
+  const char *Exec = C.getArgs().MakeArgString(ExecPath);
+  C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, None));
+}
+
+void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
+                                         const JobAction &JA,
+                                         const InputInfo &Output,
+                                         const InputInfoList &Inputs,
+                                         const ArgList &Args,
+                                         const char *LinkingOutput) const {
+  assert((getToolChain().getTriple().getArch() == llvm::Triple::spir ||
+          getToolChain().getTriple().getArch() == llvm::Triple::spir64) &&
+         "Unsupported target");
+  ArgStringList CmdArgs{"-output",  Output.getFilename()};
+  for (const auto &II : Inputs) {
+    CmdArgs.push_back("-file");
+    CmdArgs.push_back(II.getFilename());
+  }
+  CmdArgs.push_back("-spirv_input");
+  TranslateSYCLTargetArgs(C, Args, getToolChain(), CmdArgs);
+  SmallString<128> ExecPath(getToolChain().GetProgramPath("ocloc"));
+  const char *Exec = C.getArgs().MakeArgString(ExecPath);
+  C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, None));
 }
 
 SYCLToolChain::SYCLToolChain(const Driver &D, const llvm::Triple &Triple,
@@ -187,6 +322,13 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
                       BoundArch);
   }
   return DAL;
+}
+
+Tool *SYCLToolChain::buildBackendCompiler() const {
+  if (getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga)
+    return new tools::SYCL::fpga::BackendCompiler(*this);
+  // fall through is GEN
+  return new tools::SYCL::gen::BackendCompiler(*this);
 }
 
 Tool *SYCLToolChain::buildLinker() const {

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -56,19 +56,19 @@
 
 /// ###########################################################################
 
-/// Check -Xsycl-target triggers error when multiple triples are used.
-// RUN:   %clang -### -no-canonical-prefixes -fsycl -fsycl-targets=spir64-unknown-linux-sycldevice,spir-unknown-linux-sycldevice -Xsycl-target -mcpu=pentium4 %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-FSYCL-TARGET-AMBIGUOUS-ERROR %s
+/// Check -Xsycl-target-frontend triggers error when multiple triples are used.
+// RUN:   %clang -### -no-canonical-prefixes -fsycl -fsycl-targets=spir64-unknown-linux-sycldevice,spir-unknown-linux-sycldevice -Xsycl-target-frontend -DFOO %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-FSYCL-COMPILER-AMBIGUOUS-ERROR %s
 
-// CHK-FSYCL-TARGET-AMBIGUOUS-ERROR: clang{{.*}} error: cannot deduce implicit triple value for -Xsycl-target, specify triple using -Xsycl-target=<triple>
+// CHK-FSYCL-COMPILER-AMBIGUOUS-ERROR: clang{{.*}} error: cannot deduce implicit triple value for '-Xsycl-target-frontend', specify triple using '-Xsycl-target-frontend=<triple>'
 
 /// ###########################################################################
 
-/// Check -Xsycl-target triggers error when an option requiring arguments is passed to it.
-// RUN:   %clang -### -no-canonical-prefixes -fsycl -fsycl-targets=spir64-unknown-linux-sycldevice -Xsycl-target -Xsycl-target -mcpu=none %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-FSYCL-TARGET-NESTED-ERROR %s
+/// Check -Xsycl-target-frontend triggers error when an option requiring arguments is passed to it.
+// RUN:   %clang -### -no-canonical-prefixes -fsycl -fsycl-targets=spir64-unknown-linux-sycldevice -Xsycl-target-frontend -Xsycl-target-frontend -mcpu=none %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-FSYCL-COMPILER-NESTED-ERROR %s
 
-// CHK-FSYCL-TARGET-NESTED-ERROR: clang{{.*}} error: invalid -Xsycl-target argument: '-Xsycl-target -Xsycl-target', options requiring arguments are unsupported
+// CHK-FSYCL-COMPILER-NESTED-ERROR: clang{{.*}} error: invalid -Xsycl-target-frontend argument: '-Xsycl-target-frontend -Xsycl-target-frontend', options requiring arguments are unsupported
 
 /// ###########################################################################
 
@@ -96,7 +96,7 @@
 // CHK-PHASES: 10: compiler, {3}, ir, (device-sycl)
 // CHK-PHASES: 11: backend, {10}, assembler, (device-sycl)
 // CHK-PHASES: 12: assembler, {11}, object, (device-sycl)
-// CHK-PHASES: 13: linker, {12}, image, (device-sycl)
+// CHK-PHASES: 13: linker, {12}, spirv, (device-sycl)
 // CHK-PHASES: 14: clang-offload-wrapper, {13}, object, (device-sycl)
 // CHK-PHASES: 15: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64-unknown-linux-sycldevice)" {14}, image
 
@@ -120,7 +120,7 @@
 // CHK-PHASES-LIB: 11: compiler, {4}, ir, (device-sycl)
 // CHK-PHASES-LIB: 12: backend, {11}, assembler, (device-sycl)
 // CHK-PHASES-LIB: 13: assembler, {12}, object, (device-sycl)
-// CHK-PHASES-LIB: 14: linker, {13}, image, (device-sycl)
+// CHK-PHASES-LIB: 14: linker, {13}, spirv, (device-sycl)
 // CHK-PHASES-LIB: 15: clang-offload-wrapper, {14}, object, (device-sycl)
 // CHK-PHASES-LIB: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-linux-sycldevice)" {15}, image
 
@@ -157,7 +157,7 @@
 // CHK-PHASES-FILES: 23: compiler, {13}, ir, (device-sycl)
 // CHK-PHASES-FILES: 24: backend, {23}, assembler, (device-sycl)
 // CHK-PHASES-FILES: 25: assembler, {24}, object, (device-sycl)
-// CHK-PHASES-FILES: 26: linker, {22, 25}, image, (device-sycl)
+// CHK-PHASES-FILES: 26: linker, {22, 25}, spirv, (device-sycl)
 // CHK-PHASES-FILES: 27: clang-offload-wrapper, {26}, object, (device-sycl)
 // CHK-PHASES-FILES: 28: offload, "host-sycl (x86_64-unknown-linux-gnu)" {19}, "device-sycl (spir64-unknown-linux-sycldevice)" {27}, image
 
@@ -191,7 +191,7 @@
 // CHK-UBACTIONS: 1: input, "[[INPUT:.+\.o]]", object, (host-sycl)
 // CHK-UBACTIONS: 2: clang-offload-unbundler, {1}, object, (host-sycl)
 // CHK-UBACTIONS: 3: linker, {0, 2}, image, (host-sycl)
-// CHK-UBACTIONS: 4: linker, {2}, image, (device-sycl)
+// CHK-UBACTIONS: 4: linker, {2}, spirv, (device-sycl)
 // CHK-UBACTIONS: 5: clang-offload-wrapper, {4}, object, (device-sycl)
 // CHK-UBACTIONS: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {3}, "device-sycl (spir64-unknown-linux-sycldevice)" {5}, image
 
@@ -217,7 +217,7 @@
 // CHK-UBUACTIONS: 13: compiler, {6}, ir, (device-sycl)
 // CHK-UBUACTIONS: 14: backend, {13}, assembler, (device-sycl)
 // CHK-UBUACTIONS: 15: assembler, {14}, object, (device-sycl)
-// CHK-UBUACTIONS: 16: linker, {2, 15}, image, (device-sycl)
+// CHK-UBUACTIONS: 16: linker, {2, 15}, spirv, (device-sycl)
 // CHK-UBUACTIONS: 17: clang-offload-wrapper, {16}, object, (device-sycl)
 // CHK-UBUACTIONS: 18: offload, "host-sycl (x86_64-unknown-linux-gnu)" {12}, "device-sycl (spir64-unknown-linux-sycldevice)" {17}, image
 
@@ -370,7 +370,7 @@
 // FOFFLOAD_STATIC_LIB_SRC: 11: compiler, {3}, ir, (device-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 12: backend, {11}, assembler, (device-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 13: assembler, {12}, object, (device-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 14: linker, {13, 9}, image, (device-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 14: linker, {13, 9}, spirv, (device-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 15: clang-offload-wrapper, {14}, object, (device-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-linux-sycldevice)" {15}, image
 
@@ -392,3 +392,106 @@
 // FOFFLOAD_STATIC_LIB_SRC3: clang-offload-bundler{{.*}} "-type=oo"
 // FOFFLOAD_STATIC_LIB_SRC3: llvm-link{{.*}} "@{{.*}}"
 // FOFFLOAD_STATIC_LIB_SRC3: ld{{(.exe)?}}" {{.*}} "-o" "output_name" {{.*}} "-lOpenCL"
+
+/// ###########################################################################
+
+/// Check -Xsycl-target-backend triggers error when multiple triples are used.
+// RUN:   %clang -### -fsycl -fsycl-targets=spir64_fpga-unknown-linux-sycldevice,spir_fpga-unknown-linux-sycldevice -Xsycl-target-backend -DFOO %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-FSYCL-TARGET-AMBIGUOUS-ERROR %s
+// CHK-FSYCL-TARGET-AMBIGUOUS-ERROR: clang{{.*}} error: cannot deduce implicit triple value for '-Xsycl-target-backend', specify triple using '-Xsycl-target-backend=<triple>'
+
+/// ###########################################################################
+
+/// Ahead of Time compilation for fpga
+// RUN:   %clang -target x86_64-unknown-linux-gnu -ccc-print-phases -fsycl -fsycl-targets=spir64_fpga-unknown-linux-sycldevice %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-PHASES-AOT,CHK-PHASES-FPGA
+/// Ahead of Time compilation for gen
+// RUN:   %clang -target x86_64-unknown-linux-gnu -ccc-print-phases -fsycl -fsycl-targets=spir64_gen-unknown-linux-sycldevice %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-PHASES-AOT,CHK-PHASES-GEN
+// CHK-PHASES-AOT: 0: input, "[[INPUT:.+\.c]]", c, (host-sycl)
+// CHK-PHASES-AOT: 1: preprocessor, {0}, cpp-output, (host-sycl)
+// CHK-PHASES-AOT: 2: input, "[[INPUT]]", c, (device-sycl)
+// CHK-PHASES-AOT: 3: preprocessor, {2}, cpp-output, (device-sycl)
+// CHK-PHASES-AOT: 4: compiler, {3}, sycl-header, (device-sycl)
+// CHK-PHASES-FPGA: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_fpga-unknown-linux-sycldevice)" {4}, cpp-output
+// CHK-PHASES-GEN: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_gen-unknown-linux-sycldevice)" {4}, cpp-output
+// CHK-PHASES-AOT: 6: compiler, {5}, ir, (host-sycl)
+// CHK-PHASES-AOT: 7: backend, {6}, assembler, (host-sycl)
+// CHK-PHASES-AOT: 8: assembler, {7}, object, (host-sycl)
+// CHK-PHASES-AOT: 9: linker, {8}, image, (host-sycl)
+// CHK-PHASES-AOT: 10: compiler, {3}, ir, (device-sycl)
+// CHK-PHASES-AOT: 11: backend, {10}, assembler, (device-sycl)
+// CHK-PHASES-AOT: 12: assembler, {11}, object, (device-sycl)
+// CHK-PHASES-AOT: 13: linker, {12}, spirv, (device-sycl)
+// CHK-PHASES-AOT: 14: backend-compiler, {13}, image, (device-sycl)
+// CHK-PHASES-AOT: 15: clang-offload-wrapper, {14}, object, (device-sycl)
+// CHK-PHASES-FPGA: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64_fpga-unknown-linux-sycldevice)" {15}, image
+// CHK-PHASES-GEN: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64_gen-unknown-linux-sycldevice)" {15}, image
+
+/// ###########################################################################
+
+/// Ahead of Time compilation for fpga - tool invocation
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-linux-sycldevice %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-FPGA
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen-unknown-linux-sycldevice %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-GEN
+// CHK-TOOLS-AOT: clang{{.*}} "-fsycl-is-device" {{.*}} "-o" "[[OUTPUT1:.+\.o]]"
+// CHK-TOOLS-AOT: llvm-link{{.*}} "[[OUTPUT1]]" "-o" "[[OUTPUT2:.+\.bc]]"
+// CHK-TOOLS-AOT: llvm-spirv{{.*}} "-o" "[[OUTPUT3:.+\.spv]]" "[[OUTPUT2]]"
+// CHK-TOOLS-FPGA: aoc{{.*}} "-o" "[[OUTPUT4:.+\.out]]" "[[OUTPUT3]]"
+// CHK-TOOLS-GEN: ocloc{{.*}} "-output" "[[OUTPUT4:.+\.out]]" {{.*}} "[[OUTPUT3]]"
+// CHK-TOOLS-AOT: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-kind=sycl" "[[OUTPUT4]]"
+// CHK-TOOLS-AOT: llc{{.*}} "-filetype=obj" "-o" "[[OUTPUT6:.+\.o]]" "[[OUTPUT5]]"
+// CHK-TOOLS-FPGA: clang{{.*}} "-triple" "spir64_fpga-unknown-linux-sycldevice" {{.*}} "-fsycl-int-header=[[INPUT1:.+\.h]]"
+// CHK-TOOLS-GEN: clang{{.*}} "-triple" "spir64_gen-unknown-linux-sycldevice" {{.*}} "-fsycl-int-header=[[INPUT1:.+\.h]]"
+// CHK-TOOLS-AOT: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-o" "[[OUTPUT7:.+\.o]]" {{.*}} "-include" "[[INPUT1]]"
+// CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT7]]" "[[OUTPUT6]]" {{.*}} "-lsycl"
+
+/// ###########################################################################
+
+/// Check -Xsycl-target-backend option passing
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-linux-sycldevice -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-TOOLS-FPGA-OPTS %s
+// CHK-TOOLS-FPGA-OPTS: aoc{{.*}} "-o" {{.*}} "-DFOO1" "-DFOO2"
+
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen-unknown-linux-sycldevice -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-TOOLS-GEN-OPTS %s
+// CHK-TOOLS-GEN-OPTS: ocloc{{.*}} "-output" {{.*}} "-DFOO1" "-DFOO2"
+
+/// ###########################################################################
+
+/// offload with multiple targets, including AOT
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64-unknown-linux-sycldevice,spir64_fpga-unknown-linux-sycldevice,spir64_gen-unknown-linux-sycldevice -###  -ccc-print-phases %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-PHASE-MULTI-TARG %s
+// CHK-PHASE-MULTI-TARG: 0: input, "[[INPUT:.+\.c]]", c, (host-sycl)
+// CHK-PHASE-MULTI-TARG: 1: preprocessor, {0}, cpp-output, (host-sycl)
+// CHK-PHASE-MULTI-TARG: 2: input, "[[INPUT]]", c, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 3: preprocessor, {2}, cpp-output, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 4: compiler, {3}, sycl-header, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64-unknown-linux-sycldevice)" {4}, cpp-output
+// CHK-PHASE-MULTI-TARG: 6: compiler, {5}, ir, (host-sycl)
+// CHK-PHASE-MULTI-TARG: 7: backend, {6}, assembler, (host-sycl)
+// CHK-PHASE-MULTI-TARG: 8: assembler, {7}, object, (host-sycl)
+// CHK-PHASE-MULTI-TARG: 9: linker, {8}, image, (host-sycl)
+// CHK-PHASE-MULTI-TARG: 10: input, "[[INPUT]]", c, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 11: preprocessor, {10}, cpp-output, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 12: compiler, {11}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 13: backend, {12}, assembler, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 14: assembler, {13}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 15: linker, {14}, spirv, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 16: clang-offload-wrapper, {15}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 17: input, "[[INPUT]]", c, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 18: preprocessor, {17}, cpp-output, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 19: compiler, {18}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 20: backend, {19}, assembler, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 21: assembler, {20}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 22: linker, {21}, spirv, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 23: backend-compiler, {22}, image, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 24: clang-offload-wrapper, {23}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 25: compiler, {3}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 26: backend, {25}, assembler, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 27: assembler, {26}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 28: linker, {27}, spirv, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 29: backend-compiler, {28}, image, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 30: clang-offload-wrapper, {29}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG: 31: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64-unknown-linux-sycldevice)" {16}, "device-sycl (spir64_fpga-unknown-linux-sycldevice)" {24}, "device-sycl (spir64_gen-unknown-linux-sycldevice)" {30}, image

--- a/llvm/include/llvm/ADT/Triple.h
+++ b/llvm/include/llvm/ADT/Triple.h
@@ -127,7 +127,10 @@ public:
     KalimbaSubArch_v4,
     KalimbaSubArch_v5,
 
-    MipsSubArch_r6
+    MipsSubArch_r6,
+
+    SPIRSubArch_fpga,
+    SPIRSubArch_gen
   };
   enum VendorType {
     UnknownVendor,

--- a/llvm/lib/Support/Triple.cpp
+++ b/llvm/lib/Support/Triple.cpp
@@ -306,8 +306,8 @@ Triple::ArchType Triple::getArchTypeForLLVMName(StringRef Name) {
     .Case("amdil64", amdil64)
     .Case("hsail", hsail)
     .Case("hsail64", hsail64)
-    .Case("spir", spir)
-    .Case("spir64", spir64)
+    .StartsWith("spir64", spir64)
+    .StartsWith("spir", spir)
     .Case("kalimba", kalimba)
     .Case("lanai", lanai)
     .Case("shave", shave)
@@ -434,8 +434,8 @@ static Triple::ArchType parseArch(StringRef ArchName) {
     .Case("amdil64", Triple::amdil64)
     .Case("hsail", Triple::hsail)
     .Case("hsail64", Triple::hsail64)
-    .Case("spir", Triple::spir)
-    .Case("spir64", Triple::spir64)
+    .StartsWith("spir64", Triple::spir64)
+    .StartsWith("spir", Triple::spir)
     .StartsWith("kalimba", Triple::kalimba)
     .Case("lanai", Triple::lanai)
     .Case("shave", Triple::shave)
@@ -562,6 +562,16 @@ static Triple::SubArchType parseSubArch(StringRef SubArchName) {
   if (SubArchName.startswith("mips") &&
       (SubArchName.endswith("r6el") || SubArchName.endswith("r6")))
     return Triple::MipsSubArch_r6;
+
+  if (SubArchName.startswith("spir")) {
+    StringRef SA(SubArchName);
+    if (SA.consume_front("spir64_") || SA.consume_front("spir_")) {
+      if (SA == "fpga")
+        return Triple::SPIRSubArch_fpga;
+      else if (SA == "gen")
+        return Triple::SPIRSubArch_gen;
+    }
+  }
 
   StringRef ARMSubArch = ARM::getCanonicalArchName(SubArchName);
 


### PR DESCRIPTION
Adds support for AOT compilation in a single pass.  Support is triggered by
using a sub architecture value in the triple.  The following 3 are supported:

spir64_fpga, spir64_x86_64, spir64_gen

When one of these are used, the respective backend compiler (aoc, ioc or cloc)
is invoked to perform the AOT compilation.  That device binary is then wrapped
and included in the final binary.

Additional options can also be added to the SYCL device compilation, the
Backend compile or the device link.  These are handled by -Xsycl-compiler,
-Xsycl-target or -Xsycl-linker respectively

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>