### PR TITLE
[SYCL] Reuse user ptr in buffer & fix default memory allocation

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -40,28 +40,32 @@ public:
          const property_list &propList = {})
       : Range(bufferRange), MemRange(bufferRange) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        get_count() * sizeof(T), propList);
+        get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
+        propList);
   }
 
   buffer(const range<dimensions> &bufferRange, AllocatorT allocator,
          const property_list &propList = {})
       : Range(bufferRange), MemRange(bufferRange) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        get_count() * sizeof(T), propList, allocator);
+        get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)), propList,
+        allocator);
   }
 
   buffer(T *hostData, const range<dimensions> &bufferRange,
          const property_list &propList = {})
       : Range(bufferRange), MemRange(bufferRange) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        hostData, get_count() * sizeof(T), propList);
+        hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
+        propList);
   }
 
   buffer(T *hostData, const range<dimensions> &bufferRange,
          AllocatorT allocator, const property_list &propList = {})
       : Range(bufferRange), MemRange(bufferRange) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        hostData, get_count() * sizeof(T), propList, allocator);
+        hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
+        propList, allocator);
   }
 
   template <typename _T = T>
@@ -70,7 +74,8 @@ public:
          const property_list &propList = {})
       : Range(bufferRange), MemRange(bufferRange) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        hostData, get_count() * sizeof(T), propList);
+        hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
+        propList);
   }
 
   template <typename _T = T>
@@ -79,7 +84,8 @@ public:
          AllocatorT allocator, const property_list &propList = {})
       : Range(bufferRange), MemRange(bufferRange) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        hostData, get_count() * sizeof(T), propList, allocator);
+        hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
+        propList, allocator);
   }
 
   buffer(const shared_ptr_class<T> &hostData,
@@ -87,7 +93,8 @@ public:
          const property_list &propList = {})
       : Range(bufferRange), MemRange(bufferRange) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        hostData, get_count() * sizeof(T), propList, allocator);
+        hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
+        propList, allocator);
   }
 
   buffer(const shared_ptr_class<T> &hostData,
@@ -95,7 +102,8 @@ public:
          const property_list &propList = {})
       : Range(bufferRange), MemRange(bufferRange) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        hostData, get_count() * sizeof(T), propList);
+        hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
+        propList);
   }
 
   template <class InputIterator, int N = dimensions,
@@ -105,7 +113,8 @@ public:
       : Range(range<1>(std::distance(first, last))),
         MemRange(range<1>(std::distance(first, last))) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        first, last, get_count() * sizeof(T), propList, allocator);
+        first, last, get_count() * sizeof(T),
+        detail::getNextPowerOfTwo(sizeof(T)), propList, allocator);
   }
 
   template <class InputIterator, int N = dimensions,
@@ -115,7 +124,8 @@ public:
       : Range(range<1>(std::distance(first, last))),
         MemRange(range<1>(std::distance(first, last))) {
     impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
-        first, last, get_count() * sizeof(T), propList);
+        first, last, get_count() * sizeof(T),
+        detail::getNextPowerOfTwo(sizeof(T)), propList);
   }
 
   buffer(buffer<T, dimensions, AllocatorT> &b, const id<dimensions> &baseIndex,

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -224,6 +224,17 @@ template <int NDIMS> struct NDLoop {
   }
 };
 
+constexpr size_t getNextPowerOfTwoHelper(size_t Var, size_t Offset) {
+  return Offset != 64
+             ? getNextPowerOfTwoHelper(Var | (Var >> Offset), Offset * 2)
+             : Var;
+}
+
+// Returns the smallest power of two not less than Var
+constexpr size_t getNextPowerOfTwo(size_t Var) {
+  return getNextPowerOfTwoHelper(Var - 1, 1) + 1;
+}
+
 } // namespace detail
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -26,7 +26,7 @@ enum class image_channel_type : unsigned int;
 namespace detail {
 
 // utility functions and typedefs for image_impl
-using image_allocator = aligned_allocator<byte, /*alignment*/ 64>;
+using image_allocator = aligned_allocator<byte>;
 
 // utility function: Returns the Number of Channels for a given Order.
 uint8_t getImageNumberChannels(image_channel_order Order);


### PR DESCRIPTION
Reuse the pointer provided by the user in the buffer constructor (even
if use_host_ptr wasn't specified) if its alignment is sufficient. Fix
default memory alocation alignment for types larger than 64 bytes.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>