### PR TITLE
[SYCL] Do not add generated integrated header to dependency info

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5356,6 +5356,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     if (!IsSYCLOffloadDevice && SYCLDeviceInput) {
       CmdArgs.push_back("-include");
       CmdArgs.push_back(SYCLDeviceInput->getFilename());
+      // When creating dependency information, filter out the generated
+      // header file.
+      CmdArgs.push_back("-dependency-filter");
+      CmdArgs.push_back(SYCLDeviceInput->getFilename());
     }
     if (IsSYCLOffloadDevice && JA.getType() == types::TY_SYCL_Header) {
       // Generating a SYCL Header

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -102,6 +102,16 @@
 
 /// ###########################################################################
 
+/// Check the compilation flow to verify that the integrated header is filtered
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -c %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=CHK-INT-HEADER
+// CHK-INT-HEADER: clang{{.*}} "-fsycl-is-device" {{.*}} "-o" "[[OUTPUT1:.+\.o]]"
+// CHK-INT-HEADER: clang{{.*}} "-triple" "spir64-unknown-linux-sycldevice" {{.*}} "-fsycl-int-header=[[INPUT1:.+\.h]]"
+// CHK-INT-HEADER: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-o" "[[OUTPUT2:.+\.o]]" {{.*}} "-include" "[[INPUT1]]" "-dependency-filter" "[[INPUT1]]"
+// CHK-INT-HEADER: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-linux-sycldevice,host-x86_64-unknown-linux-gnu" {{.*}} "-inputs=[[OUTPUT1]],[[OUTPUT2]]"
+
+/// ###########################################################################
+
 /// Check the phases also add a library to make sure it is treated as input by
 /// the device.
 // RUN:   %clang -ccc-print-phases -target x86_64-unknown-linux-gnu -lsomelib -fsycl -fsycl-targets=spir64-unknown-linux-sycldevice %s 2>&1 \


### PR DESCRIPTION
During the -fsycl compilation, a generated integrated header is included to
the host compilation.  When dependency information is generated, we do not
want this file to be included as part of that information as it is a temp
file and is not available for subsequent compilations, causing makes to always
build files due to the missing header

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>