### PR TITLE
[SYCL] Use proper vector length in Boolean type

### DIFF
--- a/sycl/include/CL/sycl/detail/boolean.hpp
+++ b/sycl/include/CL/sycl/detail/boolean.hpp
@@ -51,10 +51,10 @@ template <int N> struct alignas(N == 3 ? 4 : N) Boolean {
 
 #ifdef __SYCL_DEVICE_ONLY__
   using DataType =
-      element_type __attribute__((ext_vector_type(N == 3 ? 4 : N)));
+      element_type __attribute__((ext_vector_type(N)));
   using vector_t = DataType;
 #else
-  using DataType = element_type[N == 3 ? 4 : N];
+  using DataType = element_type[N];
 #endif
 
   Boolean() : value{false} {}


### PR DESCRIPTION
Old selection of length caused problems in select relational
built-ins for 3 vectors of length = 3: there was created use of Select
SPIRV instruction with vectors of different length in arguments which is
incorrect.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>