### PR TITLE
[SYCL] use OOO queues and will fall back to use in-order queue if OOO queue creation fails

### DIFF
--- a/sycl/test/fpga_tests/fpga_queue.cpp
+++ b/sycl/test/fpga_tests/fpga_queue.cpp
@@ -34,6 +34,18 @@ void GetCLQueue(event sycl_event, std::set<cl_command_queue>& cl_queues) {
   }
 }
 
+int getExpectedQueueNumber(cl_device_id device_id, int default_value) {
+   cl_command_queue_properties reportedProps;
+   cl_int iRet = clGetDeviceInfo(device_id,
+                                 CL_DEVICE_QUEUE_ON_HOST_PROPERTIES,
+                                 sizeof(reportedProps),
+                                 &reportedProps,
+                                 NULL);
+   assert(CL_SUCCESS == iRet && "Failed to obtain queue info from ocl device");
+   return (reportedProps & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)
+              ? 1 : default_value;
+}
+
 int main() {
   int data[dataSize] = {0};
 
@@ -98,11 +110,11 @@ int main() {
 
     int result = cl_queues.size();
     device dev = Queue.get_device();
-    int expected_result = dev.is_accelerator() ? 3 : dev.is_host() ? 0 : 1;
+    int expected_result = dev.is_host() ? 0 : getExpectedQueueNumber(dev.get(), 3);
 
     if (expected_result != result) {
       std::cout << "Result Num of queues = " << result << std::endl
-                << "Expected Num of queues = 3" << std::endl;
+                << "Expected Num of queues = "<< expected_result << std::endl;
 
       return -1;
     }
@@ -140,12 +152,11 @@ int main() {
 
     int result = cl_queues.size();
     device dev = Queue.get_device();
-    int expected_result = dev.is_accelerator() ? maxNumQueues :
-                          dev.is_host() ? 0 : 1;
+    int expected_result = dev.is_host() ? 0 : getExpectedQueueNumber(dev.get(), maxNumQueues);
 
     if (expected_result != result) {
       std::cout << "Result Num of queues = " << result << std::endl
-                << "Expected Num of queues = " << maxNumQueues << std::endl;
+                << "Expected Num of queues = " << expected_result << std::endl;
 
       return -1;
     }


### PR DESCRIPTION
      1, SYCL runtime will try to create out-of-order queue first.
      2, If it's created successfully, use this out-of-order queue.
      3, If not, fallback to the emulation approach with in-order queue.

Signed-off-by: Chunyang Dai <chunyang.dai@intel.com>