### PR TITLE
[SYCL] Add MSVC predefined type characteristics for wchar VaListKind,…

### DIFF
--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -7013,6 +7013,12 @@ static bool handleFunctionTypeAttr(TypeProcessingState &state, ParsedAttr &attr,
                << (int)Sema::CallingConventionIgnoredReason::VariadicFunction;
 
       attr.setInvalid();
+      llvm::Triple Triple = S.Context.getTargetInfo().getTriple();
+      if (S.getLangOpts().SYCLIsDevice &&
+          S.DelayedDiagnostics.shouldDelayDiagnostics())
+        // Don't issue diagnostic e.g. on Microsoft system headers and SPIR compilation
+        // FIXME: Will make this a delayed diagnostic
+        return false;
       return S.Diag(attr.getLoc(), diag::err_cconv_varargs)
              << FunctionType::getNameForCallConv(CC);
     }

--- a/clang/test/SemaSYCL/msvc-fixes.cpp
+++ b/clang/test/SemaSYCL/msvc-fixes.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -triple x86_64-windows-msvc -fsycl-is-device -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+void foo(__builtin_va_list bvl) {
+  char * VaList = bvl;
+  static_assert(sizeof(wchar_t) == 2, "sizeof wchar is 2 on Windows");
+}


### PR DESCRIPTION
… temporary workaround vectorcall problem

Signed-off-by: Melanie Blower <melanie.blower@intel.com>