### PR TITLE
[SYCL][OpenMP] Add support to remove temporary files generated by unb…

### DIFF
--- a/clang/include/clang/Driver/Compilation.h
+++ b/clang/include/clang/Driver/Compilation.h
@@ -103,7 +103,7 @@ class Compilation {
   std::map<TCArgsKey, llvm::opt::DerivedArgList *> TCArgs;
 
   /// Temporary files which should be removed on exit.
-  llvm::opt::ArgStringList TempFiles;
+  TempFileList TempFiles;
 
   /// Result files which should be removed on failure.
   ArgStringMap ResultFiles;
@@ -204,7 +204,7 @@ public:
 
   void addCommand(std::unique_ptr<Command> C) { Jobs.addJob(std::move(C)); }
 
-  const llvm::opt::ArgStringList &getTempFiles() const { return TempFiles; }
+  const TempFileList &getTempFiles() const { return TempFiles; }
 
   const ArgStringMap &getResultFiles() const { return ResultFiles; }
 
@@ -227,10 +227,13 @@ public:
   getArgsForToolChain(const ToolChain *TC, StringRef BoundArch,
                       Action::OffloadKind DeviceOffloadKind);
 
-  /// addTempFile - Add a file to remove on exit, and returns its
-  /// argument.
-  const char *addTempFile(const char *Name) {
-    TempFiles.push_back(Name);
+  /// addTempFile - Add a file to remove on exit, and returns its argument.
+  /// \param Name - Name of file to be added as a temporary file
+  /// \param Type - If specified, the type of file.  Currently the only
+  /// different type of file is of type TY_Tempfilelist
+  const char *addTempFile(const char *Name,
+                          types::ID Type = types::TY_Nothing) {
+    TempFiles.push_back(std::make_pair(Name, Type));
     return Name;
   }
 
@@ -258,7 +261,7 @@ public:
   ///
   /// \param IssueErrors - Report failures as errors.
   /// \return Whether all files were removed successfully.
-  bool CleanupFileList(const llvm::opt::ArgStringList &Files,
+  bool CleanupFileList(const TempFileList &Files,
                        bool IssueErrors = false) const;
 
   /// CleanupFileMap - Remove the files in the given map.

--- a/clang/include/clang/Driver/Util.h
+++ b/clang/include/clang/Driver/Util.h
@@ -25,6 +25,9 @@ namespace driver {
   /// ActionList - Type used for lists of actions.
   typedef SmallVector<Action*, 3> ActionList;
 
+  /// TempFileList - A list of temporary files and their types.
+  typedef SmallVector<std::pair<const char *, types::ID>, 16> TempFileList;
+
 } // end namespace driver
 } // end namespace clang
 

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
+#include <fstream>
 #include <string>
 #include <system_error>
 #include <utility>
@@ -128,11 +129,23 @@ bool Compilation::CleanupFile(const char *File, bool IssueErrors) const {
   return true;
 }
 
-bool Compilation::CleanupFileList(const llvm::opt::ArgStringList &Files,
+bool Compilation::CleanupFileList(const TempFileList &Files,
                                   bool IssueErrors) const {
   bool Success = true;
-  for (const auto &File: Files)
-    Success &= CleanupFile(File, IssueErrors);
+  for (const auto &File: Files) {
+    // Temporary file lists contain files that need to be cleaned. The
+    // file containing the information is also removed
+    if (File.second == types::TY_Tempfilelist) {
+      std::ifstream ListFile(File.first);
+      if (ListFile) {
+        // These are temporary files and need to be removed.
+        std::string TmpFileName;
+        while(std::getline(ListFile, TmpFileName) && !TmpFileName.empty())
+          Success &= CleanupFile(TmpFileName.c_str(), IssueErrors);
+      }
+    }
+    Success &= CleanupFile(File.first, IssueErrors);
+  }
   return Success;
 }
 

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -523,13 +523,10 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   // linked archives.  The unbundled information is a list of files and not
   // an actual object/archive.  Take that list and pass those to the linker
   // instead of the original object.
-  if (JA.isDeviceOffloading(Action::OFK_OpenMP) &&
-      Args.hasArg(options::OPT_foffload_static_lib_EQ)) {
+  if (JA.isDeviceOffloading(Action::OFK_OpenMP)) {
     InputInfoList UpdatedInputs;
-    // Go through the Inputs to the link.  When an object is encountered, we
+    // Go through the Inputs to the link.  When a listfile is encountered, we
     // know it is an unbundled generated list.
-    // FIXME - properly add objects from list to be removed when compilation is
-    // complete.
     for (const auto &II : Inputs) {
       if (II.getType() == types::TY_Tempfilelist) {
         // Take the unbundled list file and pass it in with '@'.

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -65,8 +65,6 @@ const char *SYCL::Linker::constructLLVMLinkCommand(
   if (JA.isDeviceOffloading(Action::OFK_SYCL)) {
     // Go through the Inputs to the link.  When a listfile is encountered, we
     // know it is an unbundled generated list.
-    // FIXME - properly add objects from list to be removed when compilation is
-    // complete.
     for (const auto &II : InputFiles) {
       if (II.getType() == types::TY_Tempfilelist) {
         // Pass the unbundled list with '@' to be processed.
@@ -75,8 +73,7 @@ const char *SYCL::Linker::constructLLVMLinkCommand(
       } else
         CmdArgs.push_back(II.getFilename());
     }
-  }
-  else
+  } else
     for (const auto &II : InputFiles)
       CmdArgs.push_back(II.getFilename());
 

--- a/clang/test/Driver/sycl-offload-tempfile.cpp
+++ b/clang/test/Driver/sycl-offload-tempfile.cpp
@@ -1,0 +1,35 @@
+// UNSUPPORTED: system-windows
+// 
+// Test to determine that temp file cleanup is working for fat static archives
+// creates a single file fat archive then uses that
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// Build static library
+// RUN: %clang -DBUILD_B -fsycl -c -o %t_obj.o %s
+// RUN: ar cr %t_lib.a %t_obj.o
+// Build main object
+// RUN: %clang -DBUILD_A -fsycl -c -o %t_main.o %s
+// Build final binary, overriding output temp location
+// RUN: env TMPDIR=%t TEMP=%t TMP=%t                                     \
+// RUN: %clang -fsycl %t_main.o -foffload-static-lib=%t_lib.a
+// RUN: not ls %t/*
+#ifdef BUILD_A
+const int VAL = 10;
+extern int run_test_b(int);
+
+int run_test_a(int v) {
+  return v*4;
+}
+
+int main(int argc, char **argv) {
+  run_test_a(VAL);
+  run_test_b(VAL);
+  return 0;
+}
+#endif // BUILD_A
+#if BUILD_B
+int run_test_b(int v) {
+  return v*3;
+}
+#endif // BUILD_B
+


### PR DESCRIPTION
…undler

When initial support of offloading with fat static archives was implemented,
we did not have a viable solution to remove the temporary files generated
from the unbundler.  These changes address that problem by creating a new
file type that is expected to be a list of files which can be removed.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>