### PR TITLE
[SYCL] Convert C++ types into OCL types when inquiring for builtins.

### DIFF
--- a/sycl/include/CL/sycl/detail/builtins.hpp
+++ b/sycl/include/CL/sycl/detail/builtins.hpp
@@ -29,41 +29,41 @@
 
 #define MAKE_CALL_ARG1(call, prefix)                                           \
   template <typename R, typename T1>                                           \
-  ALWAYS_INLINE                                                                \
-      typename cl::sycl::detail::ConvertToOpenCLType<R>::type __invoke_##call( \
-          T1 t1) __NOEXC {                                                     \
-    using Ret = typename cl::sycl::detail::ConvertToOpenCLType<R>::type;       \
-    using Arg1 = typename cl::sycl::detail::ConvertToOpenCLType<T1>::type;     \
+  ALWAYS_INLINE R __invoke_##call(T1 t1) __NOEXC {                             \
+    using Ret = cl::sycl::detail::ConvertToOpenCLType_t<R>;                    \
+    using Arg1 = cl::sycl::detail::ConvertToOpenCLType_t<T1>;                  \
     extern Ret PPCAT(prefix, call)(Arg1);                                      \
-    return PPCAT(prefix, call)(cl::sycl::detail::TryToGetPointer(t1));         \
+    Arg1 arg1 = cl::sycl::detail::convertDataToType<T1, Arg1>(t1);             \
+    Ret  ret  = PPCAT(prefix, call)(arg1);                                     \
+    return cl::sycl::detail::convertDataToType<Ret, R>(ret);                   \
   }
 
 #define MAKE_CALL_ARG2(call, prefix)                                           \
   template <typename R, typename T1, typename T2>                              \
-  ALWAYS_INLINE                                                                \
-      typename cl::sycl::detail::ConvertToOpenCLType<R>::type __invoke_##call( \
-          T1 t1, T2 t2) __NOEXC {                                              \
-    using Ret = typename cl::sycl::detail::ConvertToOpenCLType<R>::type;       \
-    using Arg1 = typename cl::sycl::detail::ConvertToOpenCLType<T1>::type;     \
-    using Arg2 = typename cl::sycl::detail::ConvertToOpenCLType<T2>::type;     \
+  ALWAYS_INLINE R __invoke_##call(T1 t1, T2 t2) __NOEXC {                      \
+    using Ret = cl::sycl::detail::ConvertToOpenCLType_t<R>;                    \
+    using Arg1 = cl::sycl::detail::ConvertToOpenCLType_t<T1>;                  \
+    using Arg2 = cl::sycl::detail::ConvertToOpenCLType_t<T2>;                  \
     extern Ret PPCAT(prefix, call)(Arg1, Arg2);                                \
-    return PPCAT(prefix, call)(cl::sycl::detail::TryToGetPointer(t1),          \
-                               cl::sycl::detail::TryToGetPointer(t2));         \
+    Arg1 arg1 = cl::sycl::detail::convertDataToType<T1, Arg1>(t1);             \
+    Arg2 arg2 = cl::sycl::detail::convertDataToType<T2, Arg2>(t2);             \
+    Ret  ret  = PPCAT(prefix, call)(arg1, arg2);                               \
+    return cl::sycl::detail::convertDataToType<Ret, R>(ret);                   \
   }
 
 #define MAKE_CALL_ARG3(call, prefix)                                           \
   template <typename R, typename T1, typename T2, typename T3>                 \
-  ALWAYS_INLINE                                                                \
-      typename cl::sycl::detail::ConvertToOpenCLType<R>::type __invoke_##call( \
-          T1 t1, T2 t2, T3 t3) __NOEXC {                                       \
-    using Ret = typename cl::sycl::detail::ConvertToOpenCLType<R>::type;       \
-    using Arg1 = typename cl::sycl::detail::ConvertToOpenCLType<T1>::type;     \
-    using Arg2 = typename cl::sycl::detail::ConvertToOpenCLType<T2>::type;     \
-    using Arg3 = typename cl::sycl::detail::ConvertToOpenCLType<T3>::type;     \
+  ALWAYS_INLINE R __invoke_##call(T1 t1, T2 t2, T3 t3) __NOEXC {               \
+    using Ret = cl::sycl::detail::ConvertToOpenCLType_t<R>;                    \
+    using Arg1 = cl::sycl::detail::ConvertToOpenCLType_t<T1>;                  \
+    using Arg2 = cl::sycl::detail::ConvertToOpenCLType_t<T2>;                  \
+    using Arg3 = cl::sycl::detail::ConvertToOpenCLType_t<T3>;                  \
     extern Ret PPCAT(prefix, call)(Arg1, Arg2, Arg3);                          \
-    return PPCAT(prefix, call)(cl::sycl::detail::TryToGetPointer(t1),          \
-                               cl::sycl::detail::TryToGetPointer(t2),          \
-                               cl::sycl::detail::TryToGetPointer(t3));         \
+    Arg1 arg1 = cl::sycl::detail::convertDataToType<T1, Arg1>(t1);             \
+    Arg2 arg2 = cl::sycl::detail::convertDataToType<T2, Arg2>(t2);             \
+    Arg3 arg3 = cl::sycl::detail::convertDataToType<T3, Arg3>(t3);             \
+    Ret  ret  = PPCAT(prefix, call)(arg1, arg2, arg3);                         \
+    return cl::sycl::detail::convertDataToType<Ret, R>(ret);                   \
   }
 
 #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -356,6 +356,16 @@ template <typename T>
 using is_gentype = std::integral_constant<bool, is_genfloat<T>::value ||
                                                     is_geninteger<T>::value>;
 
+// vgentype: vgeninteger || vgenfloat
+template <typename T>
+using is_vgentype = std::integral_constant<bool,
+    is_vgeninteger<T>::value || is_vgenfloat<T>::value>;
+
+// sgentype: sgeninteger || sgenfloat
+template <typename T>
+using is_sgentype = std::integral_constant<bool,
+    is_sgeninteger<T>::value || is_sgenfloat<T>::value>;
+
 // forward declarations
 template <typename T> class TryToGetElementType;
 
@@ -446,6 +456,67 @@ using is_genintptr =
                                      is_MultiPtrOfGLR<P, cl_int8>::value ||
                                      is_MultiPtrOfGLR<P, cl_int16>::value>;
 
+// is_genintegralptr is multi_ptr on any of intergral type including 'int'
+// and 'long long'.
+template <class P>
+using is_genintegralptr =
+  std::integral_constant<bool,
+                         is_MultiPtrOfGLR<P, cl_char>::value ||
+                         is_MultiPtrOfGLR<P, cl_char2>::value ||
+                         is_MultiPtrOfGLR<P, cl_char3>::value ||
+                         is_MultiPtrOfGLR<P, cl_char4>::value ||
+                         is_MultiPtrOfGLR<P, cl_char8>::value ||
+                         is_MultiPtrOfGLR<P, cl_char16>::value ||
+                         is_MultiPtrOfGLR<P, cl_uchar>::value ||
+                         is_MultiPtrOfGLR<P, cl_uchar2>::value ||
+                         is_MultiPtrOfGLR<P, cl_uchar3>::value ||
+                         is_MultiPtrOfGLR<P, cl_uchar4>::value ||
+                         is_MultiPtrOfGLR<P, cl_uchar8>::value ||
+                         is_MultiPtrOfGLR<P, cl_uchar16>::value ||
+                         is_MultiPtrOfGLR<P, cl_short>::value ||
+                         is_MultiPtrOfGLR<P, cl_short2>::value ||
+                         is_MultiPtrOfGLR<P, cl_short3>::value ||
+                         is_MultiPtrOfGLR<P, cl_short4>::value ||
+                         is_MultiPtrOfGLR<P, cl_short8>::value ||
+                         is_MultiPtrOfGLR<P, cl_short16>::value ||
+                         is_MultiPtrOfGLR<P, cl_ushort>::value ||
+                         is_MultiPtrOfGLR<P, cl_ushort2>::value ||
+                         is_MultiPtrOfGLR<P, cl_ushort3>::value ||
+                         is_MultiPtrOfGLR<P, cl_ushort4>::value ||
+                         is_MultiPtrOfGLR<P, cl_ushort8>::value ||
+                         is_MultiPtrOfGLR<P, cl_ushort16>::value ||
+                         is_genintptr<P>::value ||
+                         is_MultiPtrOfGLR<P, cl_uint>::value ||
+                         is_MultiPtrOfGLR<P, cl_uint2>::value ||
+                         is_MultiPtrOfGLR<P, cl_uint3>::value ||
+                         is_MultiPtrOfGLR<P, cl_uint4>::value ||
+                         is_MultiPtrOfGLR<P, cl_uint8>::value ||
+                         is_MultiPtrOfGLR<P, cl_uint16>::value ||
+                         is_MultiPtrOfGLR<P, cl_long>::value ||
+                         is_MultiPtrOfGLR<P, cl_long2>::value ||
+                         is_MultiPtrOfGLR<P, cl_long3>::value ||
+                         is_MultiPtrOfGLR<P, cl_long4>::value ||
+                         is_MultiPtrOfGLR<P, cl_long8>::value ||
+                         is_MultiPtrOfGLR<P, cl_long16>::value ||
+                         is_MultiPtrOfGLR<P, cl_ulong>::value ||
+                         is_MultiPtrOfGLR<P, cl_ulong2>::value ||
+                         is_MultiPtrOfGLR<P, cl_ulong3>::value ||
+                         is_MultiPtrOfGLR<P, cl_ulong4>::value ||
+                         is_MultiPtrOfGLR<P, cl_ulong8>::value ||
+                         is_MultiPtrOfGLR<P, cl_ulong16>::value ||
+                         is_MultiPtrOfGLR<P, longlong>::value ||
+                         is_MultiPtrOfGLR<P, longlong2>::value ||
+                         is_MultiPtrOfGLR<P, longlong3>::value ||
+                         is_MultiPtrOfGLR<P, longlong4>::value ||
+                         is_MultiPtrOfGLR<P, longlong8>::value ||
+                         is_MultiPtrOfGLR<P, longlong16>::value ||
+                         is_MultiPtrOfGLR<P, ulonglong>::value ||
+                         is_MultiPtrOfGLR<P, ulonglong2>::value ||
+                         is_MultiPtrOfGLR<P, ulonglong3>::value ||
+                         is_MultiPtrOfGLR<P, ulonglong4>::value ||
+                         is_MultiPtrOfGLR<P, ulonglong8>::value ||
+                         is_MultiPtrOfGLR<P, ulonglong16>::value>;
+  
 // genfloatptr All permutations of multi_ptr<dataT, addressSpace> where dataT is
 // all types within genfloat and addressSpace is
 // access::address_space::global_space, access::address_space::local_space and
@@ -470,6 +541,12 @@ using is_genfloatptr =
                                      is_MultiPtrOfGLR<P, cl_double4>::value ||
                                      is_MultiPtrOfGLR<P, cl_double8>::value ||
                                      is_MultiPtrOfGLR<P, cl_double16>::value>;
+
+// is_genptr = is_genintegralptr || is_genfloatptr
+template <typename T>
+using is_genptr =
+  std::integral_constant<bool, is_genintegralptr<T>::value ||
+                               is_genfloatptr<T>::value>;
 
 // Used for nan built-in
 template <typename T> struct unsign_integral_to_float_point;
@@ -830,12 +907,118 @@ T TryToGetPointer(T &t) {
   return t;
 }
 
-// Converts T to OpenCL friendly
+// Use conditional_t to improve code readablity.
+template <bool B, typename T1, typename T2>
+using conditional_t = typename std::conditional<B, T1, T2>::type;
+
+// select_apply_cl_scalar_t selects from T8/T16/T32/T64 basing on
+// sizeof(IN).  expected to handle scalar types.
+template <typename T, typename T8, typename T16, typename T32, typename T64>
+using select_apply_cl_scalar_t =
+  conditional_t<sizeof(T) == 1, T8,
+  conditional_t<sizeof(T) == 2, T16,
+  conditional_t<sizeof(T) == 4, T32, T64>>>;
+
+// Shortcuts for selecting scalar int/unsigned int/fp type.
 template <typename T>
-using ConvertToOpenCLType = std::conditional<
-    TryToGetVectorT<T>::value, typename TryToGetVectorT<T>::type,
-    typename std::conditional<TryToGetPointerT<T>::value,
-                              typename TryToGetPointerVecT<T>::type, T>::type>;
+using select_cl_scalar_intergal_signed_t =
+  select_apply_cl_scalar_t<T, cl_char, cl_short, cl_int, cl_long>;
+
+template <typename T>
+using select_cl_scalar_intergal_unsigned_t =
+  select_apply_cl_scalar_t<T, cl_uchar, cl_ushort, cl_uint, cl_ulong>;
+
+template <typename T>
+using select_cl_scalar_float_t =
+  select_apply_cl_scalar_t<T, std::false_type, cl_half, cl_float, cl_double>;
+
+template <typename T>
+using select_cl_scalar_intergal_t =
+  conditional_t<std::is_signed<T>::value,
+    select_cl_scalar_intergal_signed_t<T>,
+    select_cl_scalar_intergal_unsigned_t<T>>;
+
+// select_cl_scalar_t picks corresponding cl_* type for input
+// scalar T or returns T if T is not scalar.
+template <typename T>
+using select_cl_scalar_t =
+  conditional_t<std::is_integral<T>::value,
+    select_cl_scalar_intergal_t<T>,
+    conditional_t<std::is_floating_point<T>::value,
+      select_cl_scalar_float_t<T>, T>>;
+
+// select_cl_vector_or_scalar does cl_* type selection for element type of
+// a vector type T and does scalar type substitution.  If T is not
+// vector or scalar unmodified T is returned.
+template <typename T, typename Enable = void>
+struct select_cl_vector_or_scalar;
+
+template <typename T>
+struct select_cl_vector_or_scalar<
+  T, typename std::enable_if<is_vgentype<T>::value>::type> {
+  using type = vec<select_cl_scalar_t<typename T::element_type>,
+                   T::get_count()>;
+};
+
+template <typename T>
+struct select_cl_vector_or_scalar<
+  T, typename std::enable_if<!is_vgentype<T>::value>::type> {
+  using type = select_cl_scalar_t<T>;
+};
+
+// select_cl_mptr_or_vector_or_scalar does cl_* type selection for type
+// pointed by multi_ptr or for element type of a vector type T and does
+// scalar type substitution.  If T is not mutlti_ptr or vector or scalar
+// unmodified T is returned.
+template <typename T, typename Enable = void>
+struct select_cl_mptr_or_vector_or_scalar;
+
+template <typename T>
+struct select_cl_mptr_or_vector_or_scalar<
+  T, typename std::enable_if<is_genptr<T>::value>::type> {
+  using type = multi_ptr<
+    typename select_cl_vector_or_scalar<typename T::element_type>::type,
+    T::address_space>;
+};
+
+template <typename T>
+struct select_cl_mptr_or_vector_or_scalar<
+  T, typename std::enable_if<!is_genptr<T>::value>::type> {
+  using type = typename select_cl_vector_or_scalar<T>::type;
+};
+
+// All types converting shortcut.
+template <typename T>
+using SelectMatchingOpenCLType_t =
+  typename select_cl_mptr_or_vector_or_scalar<T>::type;
+
+// Converts T to OpenCL friendly
+//
+template <typename T>
+using ConvertToOpenCLType_t =
+  conditional_t<TryToGetVectorT<SelectMatchingOpenCLType_t<T>>::value,
+    typename TryToGetVectorT<SelectMatchingOpenCLType_t<T>>::type,
+    conditional_t<TryToGetPointerT<SelectMatchingOpenCLType_t<T>>::value,
+      typename TryToGetPointerVecT<SelectMatchingOpenCLType_t<T>>::type,
+      SelectMatchingOpenCLType_t<T>>>;
+
+// convertDataToType() function converts data from FROM type to TO type using
+// 'as' method for vector type and copy otherwise.
+template <typename FROM, typename TO>
+typename std::enable_if<is_vgentype<FROM>::value &&
+                        is_vgentype<TO>::value &&
+                        sizeof(TO) == sizeof(FROM), TO>::type
+convertDataToType(FROM t) {
+  return t.template as<TO>();
+}
+
+template <typename FROM, typename TO>
+typename std::enable_if<!(is_vgentype<FROM>::value &&
+                          is_vgentype<TO>::value) &&
+                        sizeof(TO) == sizeof(FROM), TO>::type
+convertDataToType(FROM t) {
+  return TryToGetPointer(t);
+}
 
 // Used for all,any and select relational built-in functions
 template <typename T> inline constexpr T msbMask(T) {

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -380,7 +380,7 @@ public:
     *this = Rhs.template as<vec>();
     return *this;
   }
-
+  
 #ifdef __SYCL_USE_EXT_VECTOR_TYPE__
   template <typename T = void>
   using EnableIfNotHostHalf = typename std::enable_if<

--- a/sycl/source/detail/builtins.cpp
+++ b/sycl/source/detail/builtins.cpp
@@ -1283,13 +1283,11 @@ MAKE_1V_2P(modf, s::cl_half, s::cl_half, s::cl_half)
 // nan
 cl_float nan(s::cl_uint nancode) __NOEXC { return d::quiet_NaN<float>(); }
 cl_double nan(s::cl_ulong nancode) __NOEXC { return d::quiet_NaN<double>(); }
-cl_double nan(s::ulonglong nancode) __NOEXC { return d::quiet_NaN<double>(); }
 cl_half nan(s::cl_ushort nancode) __NOEXC {
   return s::cl_half(d::quiet_NaN<float>());
 }
 MAKE_1V(nan, s::cl_float, s::cl_uint)
 MAKE_1V(nan, s::cl_double, s::cl_ulong)
-MAKE_1V(nan, s::cl_double, s::ulonglong)
 MAKE_1V(nan, s::cl_half, s::cl_ushort)
 
 // pow
@@ -1468,38 +1466,31 @@ cl_uchar u_abs(s::cl_uchar x) __NOEXC { return x; }
 cl_ushort u_abs(s::cl_ushort x) __NOEXC { return x; }
 cl_uint u_abs(s::cl_uint x) __NOEXC { return x; }
 cl_ulong u_abs(s::cl_ulong x) __NOEXC { return x; }
-s::ulonglong u_abs(s::ulonglong x) __NOEXC { return x; }
 MAKE_1V(u_abs, s::cl_uchar, s::cl_uchar)
 MAKE_1V(u_abs, s::cl_ushort, s::cl_ushort)
 MAKE_1V(u_abs, s::cl_uint, s::cl_uint)
 MAKE_1V(u_abs, s::cl_ulong, s::cl_ulong)
-MAKE_1V(u_abs, s::ulonglong, s::ulonglong)
 
 // s_abs
 cl_uchar s_abs(s::cl_char x) __NOEXC { return std::abs(x); }
 cl_ushort s_abs(s::cl_short x) __NOEXC { return std::abs(x); }
 cl_uint s_abs(s::cl_int x) __NOEXC { return std::abs(x); }
 cl_ulong s_abs(s::cl_long x) __NOEXC { return std::abs(x); }
-s::ulonglong s_abs(s::longlong x) __NOEXC { return std::abs(x); }
 MAKE_1V(s_abs, s::cl_uchar, s::cl_char)
 MAKE_1V(s_abs, s::cl_ushort, s::cl_short)
 MAKE_1V(s_abs, s::cl_uint, s::cl_int)
 MAKE_1V(s_abs, s::cl_ulong, s::cl_long)
-MAKE_1V(s_abs, s::ulonglong, s::longlong)
 
 // u_abs_diff
 cl_uchar u_abs_diff(s::cl_uchar x, s::cl_uchar y) __NOEXC { return x - y; }
 cl_ushort u_abs_diff(s::cl_ushort x, s::cl_ushort y) __NOEXC { return x - y; }
 cl_uint u_abs_diff(s::cl_uint x, s::cl_uint y) __NOEXC { return x - y; }
 cl_ulong u_abs_diff(s::cl_ulong x, s::cl_ulong y) __NOEXC { return x - y; }
-s::ulonglong u_abs_diff(s::ulonglong x, s::ulonglong y) __NOEXC {
-  return x - y;
-}
+
 MAKE_1V_2V(u_abs_diff, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_abs_diff, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_abs_diff, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_abs_diff, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V(u_abs_diff, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_abs_diff
 cl_uchar s_abs_diff(s::cl_char x, s::cl_char y) __NOEXC {
@@ -1514,14 +1505,10 @@ cl_uint s_abs_diff(s::cl_int x, s::cl_int y) __NOEXC {
 cl_ulong s_abs_diff(s::cl_long x, s::cl_long y) __NOEXC {
   return __abs_diff(x, y);
 }
-s::ulonglong s_abs_diff(s::longlong x, s::longlong y) __NOEXC {
-  return __abs_diff(x, y);
-}
 MAKE_1V_2V(s_abs_diff, s::cl_uchar, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_abs_diff, s::cl_ushort, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_abs_diff, s::cl_uint, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_abs_diff, s::cl_ulong, s::cl_long, s::cl_long)
-MAKE_1V_2V(s_abs_diff, s::ulonglong, s::longlong, s::longlong)
 
 // u_add_sat
 cl_uchar u_add_sat(s::cl_uchar x, s::cl_uchar y) __NOEXC {
@@ -1536,14 +1523,10 @@ cl_uint u_add_sat(s::cl_uint x, s::cl_uint y) __NOEXC {
 cl_ulong u_add_sat(s::cl_ulong x, s::cl_ulong y) __NOEXC {
   return __u_add_sat(x, y);
 }
-s::ulonglong u_add_sat(s::ulonglong x, s::ulonglong y) __NOEXC {
-  return __u_add_sat(x, y);
-}
 MAKE_1V_2V(u_add_sat, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_add_sat, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_add_sat, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_add_sat, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V(u_add_sat, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_add_sat
 cl_char s_add_sat(s::cl_char x, s::cl_char y) __NOEXC {
@@ -1556,14 +1539,10 @@ cl_int s_add_sat(s::cl_int x, s::cl_int y) __NOEXC { return __s_add_sat(x, y); }
 cl_long s_add_sat(s::cl_long x, s::cl_long y) __NOEXC {
   return __s_add_sat(x, y);
 }
-s::longlong s_add_sat(s::longlong x, s::longlong y) __NOEXC {
-  return __s_add_sat(x, y);
-}
 MAKE_1V_2V(s_add_sat, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_add_sat, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_add_sat, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_add_sat, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V(s_add_sat, s::longlong, s::longlong, s::longlong)
 
 // u_hadd
 cl_uchar u_hadd(s::cl_uchar x, s::cl_uchar y) __NOEXC { return __hadd(x, y); }
@@ -1572,28 +1551,20 @@ cl_ushort u_hadd(s::cl_ushort x, s::cl_ushort y) __NOEXC {
 }
 cl_uint u_hadd(s::cl_uint x, s::cl_uint y) __NOEXC { return __hadd(x, y); }
 cl_ulong u_hadd(s::cl_ulong x, s::cl_ulong y) __NOEXC { return __hadd(x, y); }
-s::ulonglong u_hadd(s::ulonglong x, s::ulonglong y) __NOEXC {
-  return __hadd(x, y);
-}
 MAKE_1V_2V(u_hadd, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_hadd, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_hadd, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_hadd, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V(u_hadd, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_hadd
 cl_char s_hadd(s::cl_char x, s::cl_char y) __NOEXC { return __hadd(x, y); }
 cl_short s_hadd(s::cl_short x, s::cl_short y) __NOEXC { return __hadd(x, y); }
 cl_int s_hadd(s::cl_int x, s::cl_int y) __NOEXC { return __hadd(x, y); }
 cl_long s_hadd(s::cl_long x, s::cl_long y) __NOEXC { return __hadd(x, y); }
-s::longlong s_hadd(s::longlong x, s::longlong y) __NOEXC {
-  return __hadd(x, y);
-}
 MAKE_1V_2V(s_hadd, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_hadd, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_hadd, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_hadd, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V(s_hadd, s::longlong, s::longlong, s::longlong)
 
 // u_rhadd
 cl_uchar u_rhadd(s::cl_uchar x, s::cl_uchar y) __NOEXC { return __rhadd(x, y); }
@@ -1602,28 +1573,20 @@ cl_ushort u_rhadd(s::cl_ushort x, s::cl_ushort y) __NOEXC {
 }
 cl_uint u_rhadd(s::cl_uint x, s::cl_uint y) __NOEXC { return __rhadd(x, y); }
 cl_ulong u_rhadd(s::cl_ulong x, s::cl_ulong y) __NOEXC { return __rhadd(x, y); }
-s::ulonglong u_rhadd(s::ulonglong x, s::ulonglong y) __NOEXC {
-  return __rhadd(x, y);
-}
 MAKE_1V_2V(u_rhadd, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_rhadd, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_rhadd, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_rhadd, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V(u_rhadd, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_rhadd
 cl_char s_rhadd(s::cl_char x, s::cl_char y) __NOEXC { return __rhadd(x, y); }
 cl_short s_rhadd(s::cl_short x, s::cl_short y) __NOEXC { return __rhadd(x, y); }
 cl_int s_rhadd(s::cl_int x, s::cl_int y) __NOEXC { return __rhadd(x, y); }
 cl_long s_rhadd(s::cl_long x, s::cl_long y) __NOEXC { return __rhadd(x, y); }
-s::longlong s_rhadd(s::longlong x, s::longlong y) __NOEXC {
-  return __rhadd(x, y);
-}
 MAKE_1V_2V(s_rhadd, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_rhadd, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_rhadd, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_rhadd, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V(s_rhadd, s::longlong, s::longlong, s::longlong)
 
 // u_clamp
 cl_uchar u_clamp(s::cl_uchar x, s::cl_uchar minval,
@@ -1641,20 +1604,14 @@ cl_ulong u_clamp(s::cl_ulong x, s::cl_ulong minval,
                  s::cl_ulong maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
-s::ulonglong u_clamp(s::ulonglong x, s::ulonglong minval,
-                     s::ulonglong maxval) __NOEXC {
-  return __clamp(x, minval, maxval);
-}
 MAKE_1V_2V_3V(u_clamp, s::cl_uchar, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V_3V(u_clamp, s::cl_ushort, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V_3V(u_clamp, s::cl_uint, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V_3V(u_clamp, s::cl_ulong, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V_3V(u_clamp, s::ulonglong, s::ulonglong, s::ulonglong, s::ulonglong)
 MAKE_1V_2S_3S(u_clamp, s::cl_uchar, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2S_3S(u_clamp, s::cl_ushort, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2S_3S(u_clamp, s::cl_uint, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2S_3S(u_clamp, s::cl_ulong, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2S_3S(u_clamp, s::ulonglong, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_clamp
 cl_char s_clamp(s::cl_char x, s::cl_char minval, s::cl_char maxval) __NOEXC {
@@ -1670,20 +1627,14 @@ cl_int s_clamp(s::cl_int x, s::cl_int minval, s::cl_int maxval) __NOEXC {
 cl_long s_clamp(s::cl_long x, s::cl_long minval, s::cl_long maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
-s::longlong s_clamp(s::longlong x, s::longlong minval,
-                    s::longlong maxval) __NOEXC {
-  return __clamp(x, minval, maxval);
-}
 MAKE_1V_2V_3V(s_clamp, s::cl_char, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V_3V(s_clamp, s::cl_short, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V_3V(s_clamp, s::cl_int, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V_3V(s_clamp, s::cl_long, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V_3V(s_clamp, s::longlong, s::longlong, s::longlong, s::longlong)
 MAKE_1V_2S_3S(s_clamp, s::cl_char, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2S_3S(s_clamp, s::cl_short, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2S_3S(s_clamp, s::cl_int, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2S_3S(s_clamp, s::cl_long, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2S_3S(s_clamp, s::longlong, s::longlong, s::longlong, s::longlong)
 
 // clz
 cl_uchar clz(s::cl_uchar x) __NOEXC { return __clz(x); }
@@ -1694,8 +1645,6 @@ cl_uint clz(s::cl_uint x) __NOEXC { return __clz(x); }
 cl_int clz(s::cl_int x) __NOEXC { return __clz(x); }
 cl_ulong clz(s::cl_ulong x) __NOEXC { return __clz(x); }
 cl_long clz(s::cl_long x) __NOEXC { return __clz(x); }
-s::ulonglong clz(s::ulonglong x) __NOEXC { return __clz(x); }
-s::longlong clz(s::longlong x) __NOEXC { return __clz(x); }
 MAKE_1V(clz, s::cl_uchar, s::cl_uchar)
 MAKE_1V(clz, s::cl_char, s::cl_char)
 MAKE_1V(clz, s::cl_ushort, s::cl_ushort)
@@ -1704,8 +1653,6 @@ MAKE_1V(clz, s::cl_uint, s::cl_uint)
 MAKE_1V(clz, s::cl_int, s::cl_int)
 MAKE_1V(clz, s::cl_ulong, s::cl_ulong)
 MAKE_1V(clz, s::cl_long, s::cl_long)
-MAKE_1V(clz, s::longlong, s::longlong)
-MAKE_1V(clz, s::ulonglong, s::ulonglong)
 
 // s_mul_hi
 cl_char s_mul_hi(cl_char a, cl_char b) { return __mul_hi(a, b); }
@@ -1714,14 +1661,10 @@ cl_int s_mul_hi(cl_int a, cl_int b) { return __mul_hi(a, b); }
 cl_long s_mul_hi(s::cl_long x, s::cl_long y) __NOEXC {
   return __long_mul_hi(x, y);
 }
-s::longlong s_mul_hi(s::longlong x, s::longlong y) __NOEXC {
-  return __long_mul_hi(x, y);
-}
 MAKE_1V_2V(s_mul_hi, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_mul_hi, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_mul_hi, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_mul_hi, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V(s_mul_hi, s::longlong, s::longlong, s::longlong)
 
 // u_mul_hi
 cl_uchar u_mul_hi(cl_uchar a, cl_uchar b) { return __mul_hi(a, b); }
@@ -1730,14 +1673,10 @@ cl_uint u_mul_hi(cl_uint a, cl_uint b) { return __mul_hi(a, b); }
 cl_ulong u_mul_hi(s::cl_ulong x, s::cl_ulong y) __NOEXC {
   return __long_mul_hi(x, y);
 }
-s::ulonglong u_mul_hi(s::ulonglong x, s::ulonglong y) __NOEXC {
-  return __long_mul_hi(x, y);
-}
 MAKE_1V_2V(u_mul_hi, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_mul_hi, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_mul_hi, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_mul_hi, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V(u_mul_hi, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_mad_hi
 cl_char s_mad_hi(s::cl_char x, s::cl_char minval, s::cl_char maxval) __NOEXC {
@@ -1753,15 +1692,10 @@ cl_int s_mad_hi(s::cl_int x, s::cl_int minval, s::cl_int maxval) __NOEXC {
 cl_long s_mad_hi(s::cl_long x, s::cl_long minval, s::cl_long maxval) __NOEXC {
   return __long_mad_hi(x, minval, maxval);
 }
-s::longlong s_mad_hi(s::longlong x, s::longlong minval,
-                     s::longlong maxval) __NOEXC {
-  return __long_mad_hi(x, minval, maxval);
-}
 MAKE_1V_2V_3V(s_mad_hi, s::cl_char, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V_3V(s_mad_hi, s::cl_short, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V_3V(s_mad_hi, s::cl_int, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V_3V(s_mad_hi, s::cl_long, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V_3V(s_mad_hi, s::longlong, s::longlong, s::longlong, s::longlong)
 
 // u_mad_hi
 cl_uchar u_mad_hi(s::cl_uchar x, s::cl_uchar minval,
@@ -1779,15 +1713,10 @@ cl_ulong u_mad_hi(s::cl_ulong x, s::cl_ulong minval,
                   s::cl_ulong maxval) __NOEXC {
   return __long_mad_hi(x, minval, maxval);
 }
-s::ulonglong u_mad_hi(s::ulonglong x, s::ulonglong minval,
-                      s::ulonglong maxval) __NOEXC {
-  return __long_mad_hi(x, minval, maxval);
-}
 MAKE_1V_2V_3V(u_mad_hi, s::cl_uchar, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V_3V(u_mad_hi, s::cl_ushort, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V_3V(u_mad_hi, s::cl_uint, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V_3V(u_mad_hi, s::cl_ulong, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V_3V(u_mad_hi, s::ulonglong, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_mad_sat
 cl_char s_mad_sat(s::cl_char a, s::cl_char b, s::cl_char c) __NOEXC {
@@ -1802,14 +1731,10 @@ cl_int s_mad_sat(s::cl_int a, s::cl_int b, s::cl_int c) __NOEXC {
 cl_long s_mad_sat(s::cl_long a, s::cl_long b, s::cl_long c) __NOEXC {
   return __s_long_mad_sat(a, b, c);
 }
-s::longlong s_mad_sat(s::longlong a, s::longlong b, s::longlong c) __NOEXC {
-  return __s_long_mad_sat(a, b, c);
-}
 MAKE_1V_2V_3V(s_mad_sat, s::cl_char, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V_3V(s_mad_sat, s::cl_short, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V_3V(s_mad_sat, s::cl_int, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V_3V(s_mad_sat, s::cl_long, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V_3V(s_mad_sat, s::longlong, s::longlong, s::longlong, s::longlong)
 
 // u_mad_sat
 cl_uchar u_mad_sat(s::cl_uchar a, s::cl_uchar b, s::cl_uchar c) __NOEXC {
@@ -1824,33 +1749,24 @@ cl_uint u_mad_sat(s::cl_uint a, s::cl_uint b, s::cl_uint c) __NOEXC {
 cl_ulong u_mad_sat(s::cl_ulong a, s::cl_ulong b, s::cl_ulong c) __NOEXC {
   return __u_long_mad_sat(a, b, c);
 }
-s::ulonglong u_mad_sat(s::ulonglong a, s::ulonglong b, s::ulonglong c) __NOEXC {
-  return __u_long_mad_sat(a, b, c);
-}
 MAKE_1V_2V_3V(u_mad_sat, s::cl_uchar, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V_3V(u_mad_sat, s::cl_ushort, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V_3V(u_mad_sat, s::cl_uint, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V_3V(u_mad_sat, s::cl_ulong, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V_3V(u_mad_sat, s::ulonglong, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_max
 cl_char s_max(s::cl_char x, s::cl_char y) __NOEXC { return std::max(x, y); }
 cl_short s_max(s::cl_short x, s::cl_short y) __NOEXC { return std::max(x, y); }
 cl_int s_max(s::cl_int x, s::cl_int y) __NOEXC { return std::max(x, y); }
 cl_long s_max(s::cl_long x, s::cl_long y) __NOEXC { return std::max(x, y); }
-s::longlong s_max(s::longlong x, s::longlong y) __NOEXC {
-  return std::max(x, y);
-}
 MAKE_1V_2V(s_max, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_max, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_max, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_max, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V(s_max, s::longlong, s::longlong, s::longlong)
 MAKE_1V_2S(s_max, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2S(s_max, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2S(s_max, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2S(s_max, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2S(s_max, s::longlong, s::longlong, s::longlong)
 
 // u_max
 cl_uchar u_max(s::cl_uchar x, s::cl_uchar y) __NOEXC { return std::max(x, y); }
@@ -1859,38 +1775,28 @@ cl_ushort u_max(s::cl_ushort x, s::cl_ushort y) __NOEXC {
 }
 cl_uint u_max(s::cl_uint x, s::cl_uint y) __NOEXC { return std::max(x, y); }
 cl_ulong u_max(s::cl_ulong x, s::cl_ulong y) __NOEXC { return std::max(x, y); }
-s::ulonglong u_max(s::ulonglong x, s::ulonglong y) __NOEXC {
-  return std::max(x, y);
-}
 MAKE_1V_2V(u_max, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_max, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_max, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_max, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V(u_max, s::ulonglong, s::ulonglong, s::ulonglong)
 MAKE_1V_2S(u_max, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2S(u_max, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2S(u_max, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2S(u_max, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2S(u_max, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_min
 cl_char s_min(s::cl_char x, s::cl_char y) __NOEXC { return std::min(x, y); }
 cl_short s_min(s::cl_short x, s::cl_short y) __NOEXC { return std::min(x, y); }
 cl_int s_min(s::cl_int x, s::cl_int y) __NOEXC { return std::min(x, y); }
 cl_long s_min(s::cl_long x, s::cl_long y) __NOEXC { return std::min(x, y); }
-s::longlong s_min(s::longlong x, s::longlong y) __NOEXC {
-  return std::min(x, y);
-}
 MAKE_1V_2V(s_min, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_min, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_min, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_min, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V(s_min, s::longlong, s::longlong, s::longlong)
 MAKE_1V_2S(s_min, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2S(s_min, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2S(s_min, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2S(s_min, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2S(s_min, s::longlong, s::longlong, s::longlong)
 
 // u_min
 cl_uchar u_min(s::cl_uchar x, s::cl_uchar y) __NOEXC { return std::min(x, y); }
@@ -1899,19 +1805,14 @@ cl_ushort u_min(s::cl_ushort x, s::cl_ushort y) __NOEXC {
 }
 cl_uint u_min(s::cl_uint x, s::cl_uint y) __NOEXC { return std::min(x, y); }
 cl_ulong u_min(s::cl_ulong x, s::cl_ulong y) __NOEXC { return std::min(x, y); }
-s::ulonglong u_min(s::ulonglong x, s::ulonglong y) __NOEXC {
-  return std::min(x, y);
-}
 MAKE_1V_2V(u_min, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_min, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_min, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_min, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V(u_min, s::ulonglong, s::ulonglong, s::ulonglong)
 MAKE_1V_2S(u_min, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2S(u_min, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2S(u_min, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2S(u_min, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2S(u_min, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // rotate
 cl_uchar rotate(s::cl_uchar x, s::cl_uchar y) __NOEXC { return __rotate(x, y); }
@@ -1920,26 +1821,18 @@ cl_ushort rotate(s::cl_ushort x, s::cl_ushort y) __NOEXC {
 }
 cl_uint rotate(s::cl_uint x, s::cl_uint y) __NOEXC { return __rotate(x, y); }
 cl_ulong rotate(s::cl_ulong x, s::cl_ulong y) __NOEXC { return __rotate(x, y); }
-s::ulonglong rotate(s::ulonglong x, s::ulonglong y) __NOEXC {
-  return __rotate(x, y);
-}
 cl_char rotate(s::cl_char x, s::cl_char y) __NOEXC { return __rotate(x, y); }
 cl_short rotate(s::cl_short x, s::cl_short y) __NOEXC { return __rotate(x, y); }
 cl_int rotate(s::cl_int x, s::cl_int y) __NOEXC { return __rotate(x, y); }
 cl_long rotate(s::cl_long x, s::cl_long y) __NOEXC { return __rotate(x, y); }
-s::longlong rotate(s::longlong x, s::longlong y) __NOEXC {
-  return __rotate(x, y);
-}
 MAKE_1V_2V(rotate, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(rotate, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(rotate, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(rotate, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V(rotate, s::ulonglong, s::ulonglong, s::ulonglong)
 MAKE_1V_2V(rotate, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(rotate, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(rotate, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(rotate, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V(rotate, s::longlong, s::longlong, s::longlong)
 
 // u_sub_sat
 cl_uchar u_sub_sat(s::cl_uchar x, s::cl_uchar y) __NOEXC {
@@ -1954,14 +1847,10 @@ cl_uint u_sub_sat(s::cl_uint x, s::cl_uint y) __NOEXC {
 cl_ulong u_sub_sat(s::cl_ulong x, s::cl_ulong y) __NOEXC {
   return __u_sub_sat(x, y);
 }
-s::ulonglong u_sub_sat(s::ulonglong x, s::ulonglong y) __NOEXC {
-  return __u_sub_sat(x, y);
-}
 MAKE_1V_2V(u_sub_sat, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_sub_sat, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_sub_sat, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_sub_sat, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_1V_2V(u_sub_sat, s::ulonglong, s::ulonglong, s::ulonglong)
 
 // s_sub_sat
 cl_char s_sub_sat(s::cl_char x, s::cl_char y) __NOEXC {
@@ -1974,14 +1863,10 @@ cl_int s_sub_sat(s::cl_int x, s::cl_int y) __NOEXC { return __s_sub_sat(x, y); }
 cl_long s_sub_sat(s::cl_long x, s::cl_long y) __NOEXC {
   return __s_sub_sat(x, y);
 }
-s::longlong s_sub_sat(s::longlong x, s::longlong y) __NOEXC {
-  return __s_sub_sat(x, y);
-}
 MAKE_1V_2V(s_sub_sat, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_sub_sat, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_sub_sat, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_sub_sat, s::cl_long, s::cl_long, s::cl_long)
-MAKE_1V_2V(s_sub_sat, s::longlong, s::longlong, s::longlong)
 
 // u_upsample
 cl_ushort u_upsample(s::cl_uchar x, s::cl_uchar y) __NOEXC {
@@ -2021,23 +1906,19 @@ cl_uchar popcount(s::cl_uchar x) __NOEXC { return __popcount(x); }
 cl_ushort popcount(s::cl_ushort x) __NOEXC { return __popcount(x); }
 cl_uint popcount(s::cl_uint x) __NOEXC { return __popcount(x); }
 cl_ulong popcount(s::cl_ulong x) __NOEXC { return __popcount(x); }
-s::ulonglong popcount(s::ulonglong x) __NOEXC { return __popcount(x); }
 MAKE_1V(popcount, s::cl_uchar, s::cl_uchar)
 MAKE_1V(popcount, s::cl_ushort, s::cl_ushort)
 MAKE_1V(popcount, s::cl_uint, s::cl_uint)
 MAKE_1V(popcount, s::cl_ulong, s::cl_ulong)
-MAKE_1V(popcount, s::ulonglong, s::ulonglong)
 
 cl_char popcount(s::cl_char x) __NOEXC { return __popcount(x); }
 cl_short popcount(s::cl_short x) __NOEXC { return __popcount(x); }
 cl_int popcount(s::cl_int x) __NOEXC { return __popcount(x); }
 cl_long popcount(s::cl_long x) __NOEXC { return __popcount(x); }
-s::longlong popcount(s::longlong x) __NOEXC { return __popcount(x); }
 MAKE_1V(popcount, s::cl_char, s::cl_char)
 MAKE_1V(popcount, s::cl_short, s::cl_short)
 MAKE_1V(popcount, s::cl_int, s::cl_int)
 MAKE_1V(popcount, s::cl_long, s::cl_long)
-MAKE_1V(popcount, s::longlong, s::longlong)
 
 // u_mad24
 cl_uint u_mad24(s::cl_uint x, s::cl_uint y, s::cl_uint z) __NOEXC {
@@ -2528,14 +2409,12 @@ MAKE_SR_1V_OR(Any, __Any, s::cl_int, s::cl_char)
 MAKE_SR_1V_OR(Any, __Any, s::cl_int, s::cl_short)
 MAKE_SR_1V_OR(Any, __Any, s::cl_int, s::cl_int)
 MAKE_SR_1V_OR(Any, __Any, s::cl_int, s::cl_long)
-MAKE_SR_1V_OR(Any, __Any, s::cl_int, s::longlong)
 
 // (All)                  // all
 MAKE_SR_1V_AND(All, __All, s::cl_int, s::cl_char)
 MAKE_SR_1V_AND(All, __All, s::cl_int, s::cl_short)
 MAKE_SR_1V_AND(All, __All, s::cl_int, s::cl_int)
 MAKE_SR_1V_AND(All, __All, s::cl_int, s::cl_long)
-MAKE_SR_1V_AND(All, __All, s::cl_int, s::longlong)
 
 // (bitselect)
 // Instantiate functions for the scalar types and vector types.
@@ -2551,9 +2430,6 @@ MAKE_SC_1V_2V_3V(bitselect, s::cl_int, s::cl_int, s::cl_int, s::cl_int)
 MAKE_SC_1V_2V_3V(bitselect, s::cl_uint, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_SC_1V_2V_3V(bitselect, s::cl_long, s::cl_long, s::cl_long, s::cl_long)
 MAKE_SC_1V_2V_3V(bitselect, s::cl_ulong, s::cl_ulong, s::cl_ulong, s::cl_ulong)
-MAKE_SC_1V_2V_3V(bitselect, s::longlong, s::longlong, s::longlong, s::longlong)
-MAKE_SC_1V_2V_3V(bitselect, s::ulonglong, s::ulonglong, s::ulonglong,
-                 s::ulonglong)
 MAKE_SC_1V_2V_3V(bitselect, s::cl_half, s::cl_half, s::cl_half, s::cl_half)
 
 // (Select) // select
@@ -2566,10 +2442,6 @@ MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_float, s::cl_uint,
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_double, s::cl_long,
                         s::cl_double, s::cl_double)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_double, s::cl_ulong,
-                        s::cl_double, s::cl_double)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_double, s::longlong,
-                        s::cl_double, s::cl_double)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_double, s::ulonglong,
                         s::cl_double, s::cl_double)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_char, s::cl_char,
                         s::cl_char, s::cl_char)
@@ -2603,14 +2475,6 @@ MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_ulong, s::cl_long,
                         s::cl_ulong, s::cl_ulong)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_ulong, s::cl_ulong,
                         s::cl_ulong, s::cl_ulong)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::longlong, s::longlong,
-                        s::longlong, s::longlong)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::longlong, s::ulonglong,
-                        s::longlong, s::longlong)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::ulonglong, s::ulonglong,
-                        s::ulonglong, s::ulonglong)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::ulonglong, s::longlong,
-                        s::ulonglong, s::ulonglong)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_half, s::cl_short,
                         s::cl_half, s::cl_half)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_half, s::cl_ushort,

--- a/sycl/test/basic_tests/generic_type_traits.cpp
+++ b/sycl/test/basic_tests/generic_type_traits.cpp
@@ -149,4 +149,47 @@ int main() {
   make_unsigned
   make_upper
   */
+
+  // checks for some type conversions.
+  static_assert(std::is_same<d::SelectMatchingOpenCLType_t<s::cl_int>,
+                s::cl_int>::value, "");
+
+  static_assert(
+    std::is_same<d::SelectMatchingOpenCLType_t<s::vec<s::cl_int, 2>>,
+    s::vec<s::cl_int, 2>>::value, "");
+
+  static_assert(
+    std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<s::cl_int,
+      s::access::address_space::global_space>>,
+    s::multi_ptr<s::cl_int,
+      s::access::address_space::global_space>>::value, "");
+
+  static_assert(
+    std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<s::vec<s::cl_int, 2>,
+      s::access::address_space::global_space>>,
+    s::multi_ptr<s::vec<s::cl_int, 2>,
+      s::access::address_space::global_space>>::value, "");
+  
+  static_assert(
+    std::is_same<d::SelectMatchingOpenCLType_t<s::longlong>,
+    s::cl_long>::value, "");
+
+  static_assert(
+    std::is_same<d::SelectMatchingOpenCLType_t<s::vec<s::longlong, 2>>,
+    s::vec<s::cl_long, 2>>::value, "");
+
+  static_assert(
+    std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<s::longlong,
+      s::access::address_space::global_space>>,
+    s::multi_ptr<s::cl_long,
+      s::access::address_space::global_space>>::value, "");
+
+  static_assert(
+    std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<s::vec<s::longlong, 2>,
+      s::access::address_space::global_space>>,
+    s::multi_ptr<s::vec<s::cl_long, 2>,
+      s::access::address_space::global_space>>::value, "");
+
+  s::multi_ptr<int, s::access::address_space::global_space> mp;
+  int * dp = mp;
 }

--- a/sycl/test/built-ins/scalar_integer.cpp
+++ b/sycl/test/built-ins/scalar_integer.cpp
@@ -60,6 +60,22 @@ int main() {
     assert(r == 2);
   }
 
+  // min (longlong)
+  {
+    s::longlong r{ 0 };
+    {
+      s::buffer<s::longlong, 1> BufR(&r, s::range<1>(1));
+      s::queue myQueue;
+      myQueue.submit([&](s::handler &cgh) {
+        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        cgh.single_task<class minSLL1SLL1>([=]() {
+          AccR[0] = s::min(s::longlong{ 5 }, s::longlong{ 2 });
+        });
+      });
+    }
+    assert(r == 2);
+  }
+
   // min
   {
     s::cl_uint r{ 0 };
@@ -76,6 +92,22 @@ int main() {
     assert(r == 2);
   }
 
+  // min (ulonglong)
+  {
+    s::ulonglong r{ 0 };
+    {
+      s::buffer<s::ulonglong, 1> BufR(&r, s::range<1>(1));
+      s::queue myQueue;
+      myQueue.submit([&](s::handler &cgh) {
+        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        cgh.single_task<class minULL1ULL1>([=]() {
+          AccR[0] = s::min(s::ulonglong{ 5 }, s::ulonglong{ 2 });
+        });
+      });
+    }
+    assert(r == 2);
+  }
+  
   // abs
   {
     s::cl_uint r{ 0 };

--- a/sycl/test/built-ins/vector_integer.cpp
+++ b/sycl/test/built-ins/vector_integer.cpp
@@ -69,6 +69,25 @@ int main() {
     assert(r2 == 3);
   }
 
+  // max (longlong2)
+  {
+    s::longlong2 r{ 0 };
+    {
+      s::buffer<s::longlong2, 1> BufR(&r, s::range<1>(1));
+      s::queue myQueue;
+      myQueue.submit([&](s::handler &cgh) {
+        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        cgh.single_task<class maxSLL2SLL1>([=]() {
+          AccR[0] = s::max(s::longlong2{ 5, 3 }, s::longlong{ 2 });
+        });
+      });
+    }
+    s::longlong r1 = r.x();
+    s::longlong r2 = r.y();
+    assert(r1 == 5);
+    assert(r2 == 3);
+  }
+
   // max
   {
     s::cl_uint2 r{ 0 };
@@ -88,6 +107,25 @@ int main() {
     assert(r2 == 3);
   }
 
+  // max (ulonglong2)
+  {
+    s::ulonglong2 r{ 0 };
+    {
+      s::buffer<s::ulonglong2, 1> BufR(&r, s::range<1>(1));
+      s::queue myQueue;
+      myQueue.submit([&](s::handler &cgh) {
+        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        cgh.single_task<class maxULL2ULL1>([=]() {
+          AccR[0] = s::max(s::ulonglong2{ 5, 3 }, s::ulonglong{ 2 });
+        });
+      });
+    }
+    s::ulonglong r1 = r.x();
+    s::ulonglong r2 = r.y();
+    assert(r1 == 5);
+    assert(r2 == 3);
+  }
+  
   // min
   {
     s::cl_int2 r{ 0 };


### PR DESCRIPTION
Delete [u]longlong builtins as they are covered with cl_[u]long builtins.

Signed-off-by: Sergey I Zverev <sergey.i.zverev@intel.com>