### PR TITLE
[SYCL] Fix two Windows/MSVC specific errors and one warning

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -105,6 +105,14 @@ using RT = cl::sycl::detail::pi;
 // Note! This function relies on the fact that all SYCL interface classes
 // contain "impl" field that points to implementation object. "impl" field
 // should be accessible from this function.
+//
+// Note that due to a bug in MSVC compilers (including MSVC2019 v19.20), it
+// may not recognize the usage of this function in friend member declarations
+// if the template parameter name there is not equal to the name used here,
+// i.e. 'Obj'. For example, using 'Obj' here and 'T' in such declaration
+// would trigger that error in MSVC:
+//   template <class T>
+//   friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
 template <class Obj> decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject) {
   return SyclObject.impl;
 }

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -28,6 +28,7 @@
 // done here, for efficiency and simplicity.
 //
 #include <CL/opencl.h>
+#include <cstdint>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sycl/include/CL/sycl/device.hpp
+++ b/sycl/include/CL/sycl/device.hpp
@@ -100,8 +100,8 @@ private:
   std::shared_ptr<detail::device_impl> impl;
   device(std::shared_ptr<detail::device_impl> impl) : impl(impl) {}
 
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 };

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -67,8 +67,8 @@ private:
 
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
-  template <class T>
-  friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
 }; // class platform
 } // namespace sycl

--- a/sycl/source/detail/builtins.cpp
+++ b/sycl/source/detail/builtins.cpp
@@ -767,7 +767,7 @@ template <typename T> inline T __sOrdered(T x, T y) {
 }
 
 template <typename T> inline T __vUnordered(T x, T y) {
-  return -(std::isunordered(x, y));
+  return -(static_cast<T>(std::isunordered(x, y)));
 }
 
 template <typename T> inline T __sUnordered(T x, T y) {


### PR DESCRIPTION
1. Fix "getSyclObjImpl is not a function" error.
2. Fix uint32_t is not a typename error.
3. Fix warning: unsafe usage of bool in arithmetic operation.

Signed-off-by: Klochkov <vyacheslav.n.klochkov@intel.com>