### PR TITLE
[SYCL] Fix spurious warnings for Intel FPGA attributes on host compile

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -291,7 +291,8 @@ class LangOpt<string name, bit negated = 0> {
 def MicrosoftExt : LangOpt<"MicrosoftExt">;
 def Borland : LangOpt<"Borland">;
 def CUDA : LangOpt<"CUDA">;
-def SYCL : LangOpt<"SYCLIsDevice">;
+def SYCLIsDevice : LangOpt<"SYCLIsDevice">;
+def SYCLIsHost : LangOpt<"SYCLIsHost">;
 def COnly : LangOpt<"CPlusPlus", 1>;
 def CPlusPlus : LangOpt<"CPlusPlus">;
 def OpenCL : LangOpt<"OpenCL">;
@@ -1006,14 +1007,14 @@ def CUDAShared : InheritableAttr {
 def SYCLDevice : InheritableAttr {
   let Spellings = [GNU<"sycl_device">];
   let Subjects = SubjectList<[Function, Var]>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice];
   let Documentation = [Undocumented];
 }
 
 def SYCLKernel : InheritableAttr {
   let Spellings = [GNU<"sycl_kernel">];
   let Subjects = SubjectList<[Function]>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice];
   let Documentation = [Undocumented];
 }
 
@@ -1049,7 +1050,7 @@ def IntelReqdSubGroupSize: InheritableAttr {
   let Args = [UnsignedArgument<"SubGroupSize">];
   let Subjects = SubjectList<[Function, CXXMethod], ErrorDiag>;
   let Documentation = [IntelReqdSubGroupSizeDocs];
-  let LangOpts = [OpenCL, SYCL];
+  let LangOpts = [OpenCL, SYCLIsDevice];
 }
 
 // This attribute is both a type attribute, and a declaration attribute (for
@@ -1400,7 +1401,7 @@ def Mode : Attr {
 def SYCLIntelFPGAIVDep : Attr {
   let Spellings = [CXX11<"intelfpga","ivdep">];
   let Args = [IntArgument<"Safelen">];
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let AdditionalMembers = [{
     static const char *getName() {
       return "ivdep";
@@ -1412,7 +1413,7 @@ def SYCLIntelFPGAIVDep : Attr {
 def SYCLIntelFPGAII : Attr {
   let Spellings = [CXX11<"intelfpga","ii">];
   let Args = [IntArgument<"Interval">];
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let AdditionalMembers = [{
     static const char *getName() {
       return "ii";
@@ -1424,7 +1425,7 @@ def SYCLIntelFPGAII : Attr {
 def SYCLIntelFPGAMaxConcurrency : Attr {
   let Spellings = [CXX11<"intelfpga","max_concurrency">];
   let Args = [IntArgument<"NThreads">];
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let AdditionalMembers = [{
     static const char *getName() {
       return "max_concurrency";
@@ -1469,7 +1470,7 @@ def IntelFPGADoublePump : Attr {
   let Spellings = [CXX11<"intelfpga", "doublepump">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Documentation = [IntelFPGADoublePumpAttrDocs];
 }
 
@@ -1477,7 +1478,7 @@ def IntelFPGASinglePump : Attr {
   let Spellings = [CXX11<"intelfpga", "singlepump">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Documentation = [IntelFPGASinglePumpAttrDocs];
 }
 
@@ -1497,7 +1498,7 @@ def IntelFPGAMemory : Attr {
   }];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticSlaveMemVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Documentation = [IntelFPGAMemoryAttrDocs];
 }
 
@@ -1505,7 +1506,7 @@ def IntelFPGARegister : Attr {
   let Spellings = [CXX11<"intelfpga", "register">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Documentation = [IntelFPGARegisterAttrDocs];
 }
 
@@ -1515,7 +1516,7 @@ def IntelFPGABankWidth : Attr {
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticSlaveMemVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Documentation = [IntelFPGABankWidthAttrDocs];
   let AdditionalMembers = [{
     static unsigned getMinValue() {
@@ -1532,7 +1533,7 @@ def IntelFPGANumBanks : Attr {
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticSlaveMemVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Documentation = [IntelFPGANumBanksAttrDocs];
   let AdditionalMembers = [{
     static unsigned getMinValue() {
@@ -1547,7 +1548,7 @@ def IntelFPGANumBanks : Attr {
 def IntelFPGAMaxPrivateCopies : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","max_private_copies">];
   let Args = [ExprArgument<"Value">];
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[IntelFPGALocalNonConstVar, Field], ErrorDiag>;
   let Documentation = [IntelFPGAMaxPrivateCopiesAttrDocs];
   let AdditionalMembers = [{
@@ -1566,7 +1567,7 @@ def IntelFPGAMerge : Attr {
   let Args = [StringArgument<"Name">, StringArgument<"Direction">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Documentation = [IntelFPGAMergeAttrDocs];
 }
 
@@ -1575,7 +1576,7 @@ def IntelFPGAMaxReplicates : Attr {
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticSlaveMemVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Documentation = [IntelFPGAMaxReplicatesAttrDocs];
   let AdditionalMembers = [{
     static unsigned getMinValue() {
@@ -1591,7 +1592,7 @@ def IntelFPGASimpleDualPort : Attr {
   let Spellings = [CXX11<"intelfpga","simple_dual_port">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticSlaveMemVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Documentation = [IntelFPGASimpleDualPortAttrDocs];
 }
 

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -221,6 +221,7 @@ LANGOPT(CUDADeviceApproxTranscendentals, 1, 0, "using approximate transcendental
 LANGOPT(GPURelocatableDeviceCode, 1, 0, "generate relocatable device code")
 
 LANGOPT(SYCLIsDevice      , 1, 0, "Generate code for SYCL device")
+LANGOPT(SYCLIsHost        , 1, 0, "SYCL host compilation")
 LANGOPT(SYCLAllowFuncPtr  , 1, 0, "Allow function pointers in SYCL device code")
 
 LANGOPT(SizedDeallocation , 1, 0, "sized deallocation")

--- a/clang/include/clang/Driver/CC1Options.td
+++ b/clang/include/clang/Driver/CC1Options.td
@@ -858,7 +858,8 @@ def fopenmp_host_ir_file_path : Separate<["-"], "fopenmp-host-ir-file-path">,
 
 def fsycl_is_device : Flag<["-"], "fsycl-is-device">,
   HelpText<"Generate code for SYCL device.">;
-
+def fsycl_is_host : Flag<["-"], "fsycl-is-host">,
+  HelpText<"SYCL host compilation">;
 def fsycl_int_header : Separate<["-"], "fsycl-int-header">,
   HelpText<"Generate SYCL integration header into this file.">;
 def fsycl_int_header_EQ : Joined<["-"], "fsycl-int-header=">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5360,6 +5360,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // header file.
       CmdArgs.push_back("-dependency-filter");
       CmdArgs.push_back(SYCLDeviceInput->getFilename());
+      // Let the FE know we are doing a SYCL offload compilation, but we are
+      // doing the host pass.
+      CmdArgs.push_back("-fsycl-is-host");
     }
     if (IsSYCLOffloadDevice && JA.getType() == types::TY_SYCL_Header) {
       // Generating a SYCL Header

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2921,6 +2921,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   }
 
   Opts.SYCLIsDevice   = Args.hasArg(options::OPT_fsycl_is_device);
+  Opts.SYCLIsHost   = Args.hasArg(options::OPT_fsycl_is_host);
   Opts.SYCLAllowFuncPtr = Args.hasFlag(options::OPT_fsycl_allow_func_ptr,
                                   options::OPT_fno_sycl_allow_func_ptr, false);
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5021,6 +5021,9 @@ static bool checkForDuplicateAttribute(Sema &S, Decl *D,
 template <typename AttrType, typename IncompatAttrType>
 static void handleIntelFPGAPumpAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
 
+  if (S.LangOpts.SYCLIsHost)
+    return;
+
   checkForDuplicateAttribute<AttrType>(S, D, Attr);
   if (checkAttrMutualExclusion<IncompatAttrType>(S, D, Attr))
     return;
@@ -5039,6 +5042,9 @@ static void handleIntelFPGAPumpAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
 /// This is incompatible with the [[intelfpga::register]] attribute.
 static void handleIntelFPGAMemoryAttr(Sema &S, Decl *D,
                                       const ParsedAttr &Attr) {
+
+  if (S.LangOpts.SYCLIsHost)
+    return;
 
   checkForDuplicateAttribute<IntelFPGAMemoryAttr>(S, D, Attr);
   if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
@@ -5106,6 +5112,9 @@ static bool checkIntelFPGARegisterAttrCompatibility(Sema &S, Decl *D,
 static void handleIntelFPGARegisterAttr(Sema &S, Decl *D,
                                         const ParsedAttr &Attr) {
 
+  if (S.LangOpts.SYCLIsHost)
+    return;
+
   checkForDuplicateAttribute<IntelFPGARegisterAttr>(S, D, Attr);
   if (checkIntelFPGARegisterAttrCompatibility(S, D, Attr))
     return;
@@ -5121,6 +5130,10 @@ static void handleIntelFPGARegisterAttr(Sema &S, Decl *D,
 template <typename AttrType>
 static void handleOneConstantPowerTwoValueAttr(Sema &S, Decl *D,
                                                const ParsedAttr &Attr) {
+
+  if (S.LangOpts.SYCLIsHost)
+    return;
+
   checkForDuplicateAttribute<AttrType>(S, D, Attr);
   if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
     return;
@@ -5132,6 +5145,9 @@ static void handleOneConstantPowerTwoValueAttr(Sema &S, Decl *D,
 
 static void handleIntelFPGASimpleDualPortAttr(Sema &S, Decl *D,
                                               const ParsedAttr &Attr) {
+  if (S.LangOpts.SYCLIsHost)
+    return;
+
   checkForDuplicateAttribute<IntelFPGASimpleDualPortAttr>(S, D, Attr);
 
   if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
@@ -5147,6 +5163,9 @@ static void handleIntelFPGASimpleDualPortAttr(Sema &S, Decl *D,
 
 static void handleIntelFPGAMaxReplicatesAttr(Sema &S, Decl *D,
                                              const ParsedAttr &Attr) {
+  if (S.LangOpts.SYCLIsHost)
+    return;
+
   checkForDuplicateAttribute<IntelFPGAMaxReplicatesAttr>(S, D, Attr);
 
   if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
@@ -5163,6 +5182,9 @@ static void handleIntelFPGAMaxReplicatesAttr(Sema &S, Decl *D,
 /// This is incompatible with the register attribute.
 static void handleIntelFPGAMergeAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
   checkForDuplicateAttribute<IntelFPGAMergeAttr>(S, D, Attr);
+
+  if (S.LangOpts.SYCLIsHost)
+    return;
 
   if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
     return;
@@ -5191,6 +5213,10 @@ static void handleIntelFPGAMergeAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
 
 static void handleIntelFPGAMaxPrivateCopiesAttr(Sema &S, Decl *D,
                                               const ParsedAttr &Attr) {
+
+  if (S.LangOpts.SYCLIsHost)
+    return;
+
   checkForDuplicateAttribute<IntelFPGAMaxPrivateCopiesAttr>(S, D, Attr);
   if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
     return;

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -77,6 +77,10 @@ static Attr *handleSuppressAttr(Sema &S, Stmt *St, const ParsedAttr &A,
 
 template <typename FPGALoopAttrT>
 static Attr *handleIntelFPGALoopAttr(Sema &S, Stmt *St, const ParsedAttr &A) {
+
+  if(S.LangOpts.SYCLIsHost)
+    return nullptr;
+
   unsigned NumArgs = A.getNumArgs();
   if (NumArgs > 1) {
     S.Diag(A.getLoc(), diag::err_attribute_too_many_arguments) << A << 1;

--- a/clang/test/SemaSYCL/spurious-host-warning.cpp
+++ b/clang/test/SemaSYCL/spurious-host-warning.cpp
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -fsycl-is-host -verify %s -DSYCLHOST
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -verify %s
+
+#ifdef SYCLHOST
+// expected-no-diagnostics
+#endif
+
+void foo()
+{
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'doublepump' attribute ignored}}
+  #endif
+  [[intelfpga::doublepump]] unsigned int v_one[64];
+
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'memory' attribute ignored}}
+  #endif
+  [[intelfpga::memory]] unsigned int v_two[64];
+
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'register' attribute ignored}}
+  #endif
+  [[intelfpga::register]] unsigned int v_three[64];
+
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'singlepump' attribute ignored}}
+  #endif
+  [[intelfpga::singlepump]] unsigned int v_four[64];
+
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'bankwidth' attribute ignored}}
+  #endif
+  [[intelfpga::bankwidth(4)]] unsigned int v_five[32];
+
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'numbanks' attribute ignored}}
+  #endif
+  [[intelfpga::numbanks(8)]] unsigned int v_six[32];
+
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'max_private_copies' attribute ignored}}
+  #endif
+  [[intelfpga::max_private_copies(8)]] unsigned int v_seven[64];
+
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'merge' attribute ignored}}
+  #endif
+  [[intelfpga::merge("mrg1","depth")]]  unsigned int v_eight[64];
+
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'max_replicates' attribute ignored}}
+  #endif
+  [[intelfpga::max_replicates(2)]]
+  unsigned int v_nine[64];
+
+  #ifndef SYCLHOST
+  // expected-warning@+2 {{'simple_dual_port' attribute ignored}}
+  #endif
+  [[intelfpga::simple_dual_port]]
+  unsigned int v_ten[64];
+}
+


### PR DESCRIPTION
Spurious warnings about unrecognized attributes are generated for Intel FPGA attributes during SYCL compile. Warnings are produced during host compilation.

This patch defines a CC1 option passed by SYCL driver to FrontEnd to denote host pass. Intel FPGA attributes are parsed and then ignored during this pass.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>