### PR TITLE
[SYCL] Enforce check for global variables outlinig

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -194,7 +194,7 @@ public:
           !VD->isStaticDataMember() && !isa<ParmVarDecl>(VD))
         SemaRef.Diag(E->getLocation(), diag::err_sycl_restrict)
             << KernelGlobalVariable;
-      if (!VD->isLocalVarDecl()) {
+      if (!VD->isLocalVarDeclOrParm() && VD->hasGlobalStorage()) {
         VD->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
         SemaRef.addSyclDeviceDecl(VD);
       }


### PR DESCRIPTION
Check that variable is not local is not enough, we could outline
declarations of function parameters. Outlininig of function parameter
declarations can produce errors since all outlined declarations must be
emitted as global declarations.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>