### PR TITLE
[SYCL] Allow for -Ldir to be used to find libraries with -foffload-st…

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6400,6 +6400,8 @@ void OffloadBundler::ConstructJobMultipleOutputs(
     // Input files consist of fat libraries and the object(s) to be unbundled.
     for (const auto &I : Inputs)
       LinkArgs.push_back(I.getFilename());
+    // Add -L<dir> search directories.
+    TCArgs.AddAllArgs(LinkArgs, options::OPT_L);
     for (const auto &A :
             TCArgs.getAllArgValues(options::OPT_foffload_static_lib_EQ))
       LinkArgs.push_back(TCArgs.MakeArgString(A));

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -341,9 +341,9 @@
 /// test behaviors of -foffload-static-lib=<lib>
 // RUN: touch %t.a
 // RUN: touch %t.o
-// RUN: %clang -fsycl -foffload-static-lib=%t.a -### %t.o 2>&1 \
+// RUN: %clang -fsycl -L/dummy/dir -foffload-static-lib=%t.a -### %t.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB
-// FOFFLOAD_STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.o]]" "[[INPUT:.+\.a]]"
+// FOFFLOAD_STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.o]]" "-L/dummy/dir" "[[INPUT:.+\.a]]"
 // FOFFLOAD_STATIC_LIB: clang-offload-bundler{{.*}} "-type=oo"
 // FOFFLOAD_STATIC_LIB: llvm-link{{.*}} "@{{.*}}"
 


### PR DESCRIPTION
…atic-lib

-foffload-static-lib=lib triggers a step that does a partial link of the
lib and any other of the objects/source passed on the command line.  We
can use the -Ldir option to improve the ability to find the lib

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>