### PR TITLE
[AST] Enable expression of OpenCL language address spaces an attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1070,27 +1070,27 @@ def OpenCLAccess : Attr {
 }
 
 def OpenCLPrivateAddressSpace : TypeAttr {
-  let Spellings = [Keyword<"__private">, Keyword<"private">];
+  let Spellings = [Keyword<"__private">, Keyword<"private">, Clang<"ocl_private">];
   let Documentation = [OpenCLAddressSpacePrivateDocs];
 }
 
 def OpenCLGlobalAddressSpace : TypeAttr {
-  let Spellings = [Keyword<"__global">, Keyword<"global">];
+  let Spellings = [Keyword<"__global">, Keyword<"global">, Clang<"ocl_global">];
   let Documentation = [OpenCLAddressSpaceGlobalDocs];
 }
 
 def OpenCLLocalAddressSpace : TypeAttr {
-  let Spellings = [Keyword<"__local">, Keyword<"local">];
+  let Spellings = [Keyword<"__local">, Keyword<"local">, Clang<"ocl_local">];
   let Documentation = [OpenCLAddressSpaceLocalDocs];
 }
 
 def OpenCLConstantAddressSpace : TypeAttr {
-  let Spellings = [Keyword<"__constant">, Keyword<"constant">];
+  let Spellings = [Keyword<"__constant">, Keyword<"constant">, Clang<"ocl_constant">];
   let Documentation = [OpenCLAddressSpaceConstantDocs];
 }
 
 def OpenCLGenericAddressSpace : TypeAttr {
-  let Spellings = [Keyword<"__generic">, Keyword<"generic">];
+  let Spellings = [Keyword<"__generic">, Keyword<"generic">, Clang<"ocl_generic">];
   let Documentation = [OpenCLAddressSpaceGenericDocs];
 }
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -7449,6 +7449,16 @@ static void HandleLifetimeBoundAttr(TypeProcessingState &State,
   }
 }
 
+static bool isAddressSpaceKind(const ParsedAttr &attr) {
+  auto attrKind = attr.getKind();
+
+  return attrKind == ParsedAttr::AT_AddressSpace ||
+         attrKind == ParsedAttr::AT_OpenCLPrivateAddressSpace ||
+         attrKind == ParsedAttr::AT_OpenCLGlobalAddressSpace ||
+         attrKind == ParsedAttr::AT_OpenCLLocalAddressSpace ||
+         attrKind == ParsedAttr::AT_OpenCLConstantAddressSpace ||
+         attrKind == ParsedAttr::AT_OpenCLGenericAddressSpace;
+}
 
 static void processTypeAttrs(TypeProcessingState &state, QualType &type,
                              TypeAttrLocation TAL,
@@ -7487,11 +7497,11 @@ static void processTypeAttrs(TypeProcessingState &state, QualType &type,
           if (!IsTypeAttr)
             continue;
         }
-      } else if (TAL != TAL_DeclChunk &&
-                 attr.getKind() != ParsedAttr::AT_AddressSpace) {
+      } else if (TAL != TAL_DeclChunk && !isAddressSpaceKind(attr)) {
         // Otherwise, only consider type processing for a C++11 attribute if
         // it's actually been applied to a type.
-        // We also allow C++11 address_space attributes to pass through.
+        // We also allow C++11 address_space and
+        // opencl language address space attributes to pass through.
         continue;
       }
     }

--- a/clang/test/AST/language_address_space_attribute.cpp
+++ b/clang/test/AST/language_address_space_attribute.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 %s -ast-dump | FileCheck %s
+
+// Verify that the language address space attribute is
+// understood correctly by clang.
+
+void langas() {
+  // CHECK: VarDecl {{.*}} x_global '__global int *'
+  __attribute__((ocl_global)) int *x_global;
+
+  // CHECK: VarDecl {{.*}} z_global '__global int *'
+  [[clang::ocl_global]] int *z_global;
+
+  // CHECK: VarDecl {{.*}} x_local '__local int *'
+  __attribute__((ocl_local)) int *x_local;
+
+  // CHECK: VarDecl {{.*}} z_local '__local int *'
+  [[clang::ocl_local]] int *z_local;
+
+  // CHECK: VarDecl {{.*}} x_constant '__constant int *'
+  __attribute__((ocl_constant)) int *x_constant;
+
+  // CHECK: VarDecl {{.*}} z_constant '__constant int *'
+  [[clang::ocl_constant]] int *z_constant;
+
+  // CHECK: VarDecl {{.*}} x_private 'int *'
+  __attribute__((ocl_private)) int *x_private;
+
+  // CHECK: VarDecl {{.*}} z_private 'int *'
+  [[clang::ocl_private]] int *z_private;
+
+  // CHECK: VarDecl {{.*}} x_generic '__generic int *'
+  __attribute__((ocl_generic)) int *x_generic;
+
+  // CHECK: VarDecl {{.*}} z_generic '__generic int *'
+  [[clang::ocl_generic]] int *z_generic;
+}

--- a/clang/test/SemaOpenCL/address-spaces.cl
+++ b/clang/test/SemaOpenCL/address-spaces.cl
@@ -241,3 +241,19 @@ void func_multiple_addr(void) {
   __private private_int_t var5; // expected-warning {{multiple identical address spaces specified for type}}
   __private private_int_t *var6;// expected-warning {{multiple identical address spaces specified for type}}
 }
+
+void func_multiple_addr2(void) {
+  typedef __private int private_int_t;
+  __private __attribute__((ocl_global)) int var1;   // expected-error {{multiple address spaces specified for type}}
+  __private __attribute__((ocl_global)) int *var2;  // expected-error {{multiple address spaces specified for type}}
+  __attribute__((ocl_global)) private_int_t var3;   // expected-error {{multiple address spaces specified for type}}
+  __attribute__((ocl_global)) private_int_t *var4;  // expected-error {{multiple address spaces specified for type}}
+  __attribute__((ocl_private)) private_int_t var5;  // expected-warning {{multiple identical address spaces specified for type}}
+  __attribute__((ocl_private)) private_int_t *var6; // expected-warning {{multiple identical address spaces specified for type}}
+#if __OPENCL_CPP_VERSION__
+  [[clang::ocl_private]] __global int var7;         // expected-error {{multiple address spaces specified for type}}
+  [[clang::ocl_private]] __global int *var8;        // expected-error {{multiple address spaces specified for type}}
+  [[clang::ocl_private]] private_int_t var9;        // expected-warning {{multiple identical address spaces specified for type}}
+  [[clang::ocl_private]] private_int_t *var10;      // expected-warning {{multiple identical address spaces specified for type}}
+#endif // !__OPENCL_CPP_VERSION__
+}


### PR DESCRIPTION
Enable a way to set OpenCL language address space using attributes
in addition to existing keywords.

Patch part of solution to solves https://github.com/intel/llvm/issues/186