### PR TITLE
[SYCL] Use new AS attributes

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -15,14 +15,14 @@
 #ifdef __SYCL_DEVICE_ONLY__
 template <typename dataT>
 extern __ocl_event_t
-__spirv_GroupAsyncCopy(__spv::Scope Execution, __local dataT *Dest,
-                       __global dataT *Src, size_t NumElements, size_t Stride,
+__spirv_GroupAsyncCopy(__spv::Scope Execution, __attribute__((ocl_local)) dataT *Dest,
+                       __attribute__((ocl_global)) dataT *Src, size_t NumElements, size_t Stride,
                        __ocl_event_t E) noexcept;
 
 template <typename dataT>
 extern __ocl_event_t
-__spirv_GroupAsyncCopy(__spv::Scope Execution, __global dataT *Dest,
-                       __local dataT *Src, size_t NumElements, size_t Stride,
+__spirv_GroupAsyncCopy(__spv::Scope Execution, __attribute__((ocl_global)) dataT *Dest,
+                       __attribute__((ocl_local)) dataT *Src, size_t NumElements, size_t Stride,
                        __ocl_event_t E) noexcept;
 
 #define OpGroupAsyncCopyGlobalToLocal __spirv_GroupAsyncCopy
@@ -110,7 +110,7 @@ __spirv_GroupAsyncCopy(__spv::Scope Execution, __global dataT *Dest,
     return __spirv_AtomicU##Op(Ptr, Memory, Semantics, Value);                 \
   }
 
-#define __SPIRV_ATOMICS(macro, Arg) macro(__global, Arg) macro(__local, Arg)
+#define __SPIRV_ATOMICS(macro, Arg) macro(__attribute__((ocl_global)), Arg) macro(__attribute__((ocl_local)), Arg)
 
 __SPIRV_ATOMICS(__SPIRV_ATOMIC_FLOAT, float)
 __SPIRV_ATOMICS(__SPIRV_ATOMIC_SIGNED, int)
@@ -169,18 +169,18 @@ extern dataT __spirv_SubgroupShuffleXorINTEL(dataT Data,
 
 template <typename dataT>
 extern dataT
-__spirv_SubgroupBlockReadINTEL(const __global uint16_t *Ptr) noexcept;
+__spirv_SubgroupBlockReadINTEL(const __attribute__((ocl_global)) uint16_t *Ptr) noexcept;
 
 template <typename dataT>
-extern void __spirv_SubgroupBlockWriteINTEL(__global uint16_t *Ptr,
+extern void __spirv_SubgroupBlockWriteINTEL(__attribute__((ocl_global)) uint16_t *Ptr,
                                             dataT Data) noexcept;
 
 template <typename dataT>
 extern dataT
-__spirv_SubgroupBlockReadINTEL(const __global uint32_t *Ptr) noexcept;
+__spirv_SubgroupBlockReadINTEL(const __attribute__((ocl_global)) uint32_t *Ptr) noexcept;
 
 template <typename dataT>
-extern void __spirv_SubgroupBlockWriteINTEL(__global uint32_t *Ptr,
+extern void __spirv_SubgroupBlockWriteINTEL(__attribute__((ocl_global)) uint32_t *Ptr,
                                             dataT Data) noexcept;
 
 template <typename dataT>
@@ -196,7 +196,7 @@ template <typename dataT>
 extern WPipeTy<dataT> __spirv_CreatePipeFromPipeStorage_write(
     const ConstantPipeStorage *Storage) noexcept;
 
-extern void __spirv_ocl_prefetch(const __global char *Ptr,
+extern void __spirv_ocl_prefetch(const __attribute__((ocl_global)) char *Ptr,
                                  size_t NumBytes) noexcept;
 #else // if !__SYCL_DEVICE_ONLY__
 

--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -11,12 +11,12 @@
 #ifdef __SYCL_DEVICE_ONLY__
 
 typedef size_t size_t_vec __attribute__((ext_vector_type(3)));
-extern "C" const __constant size_t_vec __spirv_BuiltInGlobalSize;
-extern "C" const __constant size_t_vec __spirv_BuiltInGlobalInvocationId;
-extern "C" const __constant size_t_vec __spirv_BuiltInWorkgroupSize;
-extern "C" const __constant size_t_vec __spirv_BuiltInLocalInvocationId;
-extern "C" const __constant size_t_vec __spirv_BuiltInWorkgroupId;
-extern "C" const __constant size_t_vec __spirv_BuiltInGlobalOffset;
+extern "C" const __attribute__((ocl_constant)) size_t_vec __spirv_BuiltInGlobalSize;
+extern "C" const __attribute__((ocl_constant)) size_t_vec __spirv_BuiltInGlobalInvocationId;
+extern "C" const __attribute__((ocl_constant)) size_t_vec __spirv_BuiltInWorkgroupSize;
+extern "C" const __attribute__((ocl_constant)) size_t_vec __spirv_BuiltInLocalInvocationId;
+extern "C" const __attribute__((ocl_constant)) size_t_vec __spirv_BuiltInWorkgroupId;
+extern "C" const __attribute__((ocl_constant)) size_t_vec __spirv_BuiltInGlobalOffset;
 
 #define DEFINE_INT_ID_TO_XYZ_CONVERTER(POSTFIX)                                \
   template <int ID> static size_t get##POSTFIX();                              \
@@ -37,12 +37,12 @@ DEFINE_INT_ID_TO_XYZ_CONVERTER(GlobalOffset)
 
 #undef DEFINE_INT_ID_TO_XYZ_CONVERTER
 
-extern "C" const __constant uint32_t __spirv_BuiltInSubgroupSize;
-extern "C" const __constant uint32_t __spirv_BuiltInSubgroupMaxSize;
-extern "C" const __constant uint32_t __spirv_BuiltInNumSubgroups;
-extern "C" const __constant uint32_t __spirv_BuiltInNumEnqueuedSubgroups;
-extern "C" const __constant uint32_t __spirv_BuiltInSubgroupId;
-extern "C" const __constant uint32_t __spirv_BuiltInSubgroupLocalInvocationId;
+extern "C" const __attribute__((ocl_constant)) uint32_t __spirv_BuiltInSubgroupSize;
+extern "C" const __attribute__((ocl_constant)) uint32_t __spirv_BuiltInSubgroupMaxSize;
+extern "C" const __attribute__((ocl_constant)) uint32_t __spirv_BuiltInNumSubgroups;
+extern "C" const __attribute__((ocl_constant)) uint32_t __spirv_BuiltInNumEnqueuedSubgroups;
+extern "C" const __attribute__((ocl_constant)) uint32_t __spirv_BuiltInSubgroupId;
+extern "C" const __attribute__((ocl_constant)) uint32_t __spirv_BuiltInSubgroupLocalInvocationId;
 
 #define DEFINE_INIT_SIZES(POSTFIX)                                             \
                                                                                \

--- a/sycl/include/CL/sycl/access/access.hpp
+++ b/sycl/include/CL/sycl/access/access.hpp
@@ -63,10 +63,10 @@ constexpr bool modeWritesNewData(access::mode m) {
 }
 
 #ifdef __SYCL_DEVICE_ONLY__
-#define SYCL_GLOBAL_AS __global
-#define SYCL_LOCAL_AS __local
-#define SYCL_CONSTANT_AS __constant
-#define SYCL_PRIVATE_AS __private
+#define SYCL_GLOBAL_AS __attribute__((ocl_global))
+#define SYCL_LOCAL_AS __attribute__((ocl_local))
+#define SYCL_CONSTANT_AS __attribute__((ocl_constant))
+#define SYCL_PRIVATE_AS __attribute__((ocl_private))
 #else
 #define SYCL_GLOBAL_AS
 #define SYCL_LOCAL_AS

--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -259,11 +259,11 @@ struct sub_group {
   load(const multi_ptr<T, Space> src) const {
     if (sizeof(T) == sizeof(uint32_t)) {
       uint32_t t = __spirv_SubgroupBlockReadINTEL<uint32_t>(
-          (const __global uint32_t *)src.get());
+          (const __attribute__((ocl_global)) uint32_t *)src.get());
       return *((T *)(&t));
     }
     uint16_t t = __spirv_SubgroupBlockReadINTEL<uint16_t>(
-        (const __global uint16_t *)src.get());
+        (const __attribute__((ocl_global)) uint16_t *)src.get());
     return *((T *)(&t));
   }
 
@@ -281,13 +281,13 @@ struct sub_group {
       typedef uint32_t ocl_t __attribute__((ext_vector_type(N)));
 
       ocl_t t = __spirv_SubgroupBlockReadINTEL<ocl_t>(
-          (const __global uint32_t *)src.get());
+          (const __attribute__((ocl_global)) uint32_t *)src.get());
       return *((typename vec<T, N>::vector_t *)(&t));
     }
     typedef uint16_t ocl_t __attribute__((ext_vector_type(N)));
 
     ocl_t t = __spirv_SubgroupBlockReadINTEL<ocl_t>(
-        (const __global uint16_t *)src.get());
+        (const __attribute__((ocl_global)) uint16_t *)src.get());
     return *((typename vec<T, N>::vector_t *)(&t));
   }
 
@@ -300,10 +300,10 @@ struct sub_group {
             T>::type &x) const {
     if (sizeof(T) == sizeof(uint32_t)) {
       __spirv_SubgroupBlockWriteINTEL<uint32_t>(
-          (__global uint32_t *)dst.get(), *((uint32_t *)&x));
+          (__attribute__((ocl_global)) uint32_t *)dst.get(), *((uint32_t *)&x));
     } else {
       __spirv_SubgroupBlockWriteINTEL<uint16_t>(
-          (__global uint16_t *)dst.get(), *((uint16_t *)&x));
+          (__attribute__((ocl_global)) uint16_t *)dst.get(), *((uint16_t *)&x));
     }
   }
 
@@ -324,11 +324,11 @@ struct sub_group {
                 N> &x) const {
     if (sizeof(T) == sizeof(uint32_t)) {
       typedef uint32_t ocl_t __attribute__((ext_vector_type(N)));
-      __spirv_SubgroupBlockWriteINTEL((__global uint32_t *)dst.get(),
+      __spirv_SubgroupBlockWriteINTEL((__attribute__((ocl_global)) uint32_t *)dst.get(),
                                              *((ocl_t *)&x));
     } else {
       typedef uint16_t ocl_t __attribute__((ext_vector_type(N)));
-      __spirv_SubgroupBlockWriteINTEL((__global uint16_t *)dst.get(),
+      __spirv_SubgroupBlockWriteINTEL((__attribute__((ocl_global)) uint16_t *)dst.get(),
                                              *((ocl_t *)&x));
     }
   }


### PR DESCRIPTION
SYCL makes use of __global and other similar keywords which are also
used in libc++. This patch replaces such occurrences with new attributes
in SYCL.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>