### PR TITLE
[SYCL] Support cl_khr_il_program extension

### DIFF
--- a/sycl/source/detail/pi_opencl.cpp
+++ b/sycl/source/detail/pi_opencl.cpp
@@ -102,11 +102,22 @@ pi_program OCL(piProgramCreate)(pi_context context, const void *il,
       *err = pi_cast<pi_result>(CL_INVALID_CONTEXT);
     return pi_cast<pi_program>(resProgram);
   }
+
+  cl_platform_id curPlatform;
+  ret_err = clGetDeviceInfo(devicesInCtx[0], CL_DEVICE_PLATFORM,
+                            sizeof(cl_platform_id), &curPlatform, NULL);
+
+  if (ret_err != CL_SUCCESS) {
+    if (err != nullptr)
+      *err = pi_cast<pi_result>(CL_INVALID_CONTEXT);
+    return pi_cast<pi_program>(resProgram);
+  }
+
   size_t devVerSize;
   ret_err =
-      clGetDeviceInfo(devicesInCtx[0], CL_DEVICE_VERSION, 0, NULL, &devVerSize);
+      clGetPlatformInfo(curPlatform, CL_PLATFORM_VERSION, 0, NULL, &devVerSize);
   std::string devVer(devVerSize, '\0');
-  ret_err = clGetDeviceInfo(devicesInCtx[0], CL_DEVICE_VERSION, devVerSize,
+  ret_err = clGetPlatformInfo(curPlatform, CL_PLATFORM_VERSION, devVerSize,
                             &devVer.front(), NULL);
 
   if (ret_err != CL_SUCCESS) {
@@ -121,15 +132,6 @@ pi_program OCL(piProgramCreate)(pi_context context, const void *il,
       devVer.find("OpenCL 2.0") == std::string::npos) {
     resProgram = clCreateProgramWithIL(pi_cast<cl_context>(context), il, length,
                                        pi_cast<cl_int *>(err));
-    return pi_cast<pi_program>(resProgram);
-  }
-
-  cl_platform_id curPlatform;
-  ret_err = clGetDeviceInfo(devicesInCtx[0], CL_DEVICE_PLATFORM,
-                            sizeof(cl_platform_id), &curPlatform, NULL);
-  if (ret_err != CL_SUCCESS) {
-    if (err != nullptr)
-      *err = pi_cast<pi_result>(CL_INVALID_CONTEXT);
     return pi_cast<pi_program>(resProgram);
   }
 

--- a/sycl/source/detail/pi_opencl.cpp
+++ b/sycl/source/detail/pi_opencl.cpp
@@ -199,7 +199,6 @@ _PI_CL(piMemGetInfo,        clGetMemObjectInfo)
 _PI_CL(piMemRetain,         clRetainMemObject)
 _PI_CL(piMemRelease,        clReleaseMemObject)
 // Program
-//_PI_CL(piProgramCreate,             clCreateProgramWithIL)
 _PI_CL(piclProgramCreateWithSource, clCreateProgramWithSource)
 _PI_CL(piclProgramCreateWithBinary, clCreateProgramWithBinary)
 _PI_CL(piProgramGetInfo,            clGetProgramInfo)

--- a/sycl/source/detail/pi_opencl.cpp
+++ b/sycl/source/detail/pi_opencl.cpp
@@ -84,13 +84,18 @@ pi_result OCL(piextDeviceSelectBinary)(
 pi_program OCL(piProgramCreate)(pi_context context, const void *il,
                                 size_t length, pi_result *err) {
 
-  cl_device_id devicesInCtx[10];
   size_t deviceCount;
   cl_program resProgram;
 
-  cl_int ret_err = clGetContextInfo(
-      pi_cast<cl_context>(context), CL_CONTEXT_DEVICES,
-      10 * sizeof(cl_device_id), (void *)devicesInCtx, &deviceCount);
+  cl_int ret_err = clGetContextInfo(pi_cast<cl_context>(context),
+                                    CL_CONTEXT_DEVICES, 0, NULL, &deviceCount);
+
+  std::vector<cl_device_id> devicesInCtx;
+  devicesInCtx.reserve(deviceCount);
+
+  ret_err = clGetContextInfo(pi_cast<cl_context>(context), CL_CONTEXT_DEVICES,
+                             deviceCount * sizeof(cl_device_id),
+                             devicesInCtx.data(), NULL);
 
   if (ret_err != CL_SUCCESS || deviceCount < 1) {
     if (err != nullptr)

--- a/sycl/source/detail/pi_opencl.cpp
+++ b/sycl/source/detail/pi_opencl.cpp
@@ -118,7 +118,7 @@ pi_program OCL(piProgramCreate)(pi_context context, const void *il,
       clGetPlatformInfo(curPlatform, CL_PLATFORM_VERSION, 0, NULL, &devVerSize);
   std::string devVer(devVerSize, '\0');
   ret_err = clGetPlatformInfo(curPlatform, CL_PLATFORM_VERSION, devVerSize,
-                            &devVer.front(), NULL);
+                              &devVer.front(), NULL);
 
   if (ret_err != CL_SUCCESS) {
     if (err != nullptr)

--- a/sycl/source/detail/pi_opencl.cpp
+++ b/sycl/source/detail/pi_opencl.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 #include "CL/opencl.h"
 #include <CL/sycl/detail/pi.hpp>
-#include <cstring>
 #include <cassert>
+#include <cstring>
 
 namespace cl {
 namespace sycl {
@@ -98,15 +98,16 @@ pi_program OCL(piProgramCreate)(pi_context context, const void *il,
     return pi_cast<pi_program>(resProgram);
   }
   size_t devVerSize;
-  ret_err = clGetDeviceInfo(devicesInCtx[0], CL_DEVICE_VERSION, 0, NULL, &devVerSize);
+  ret_err =
+      clGetDeviceInfo(devicesInCtx[0], CL_DEVICE_VERSION, 0, NULL, &devVerSize);
   std::string devVer(devVerSize, '\0');
   ret_err = clGetDeviceInfo(devicesInCtx[0], CL_DEVICE_VERSION, devVerSize,
-                  &devVer.front(), NULL);
+                            &devVer.front(), NULL);
 
   if (ret_err != CL_SUCCESS) {
-      if (err != nullptr)
-          *err = pi_cast<pi_result>(CL_INVALID_CONTEXT);
-      return pi_cast<pi_program>(resProgram);
+    if (err != nullptr)
+      *err = pi_cast<pi_result>(CL_INVALID_CONTEXT);
+    return pi_cast<pi_program>(resProgram);
   }
 
   if (devVer.find("OpenCL 1.0") != std::string::npos ||
@@ -136,16 +137,18 @@ pi_program OCL(piProgramCreate)(pi_context context, const void *il,
       return pi_cast<pi_program>(resProgram);
     }
 
-    using apiFuncT = cl_program (CL_API_CALL *)(cl_context, const void *, size_t, cl_int *);
+    using apiFuncT =
+        cl_program(CL_API_CALL *)(cl_context, const void *, size_t, cl_int *);
     apiFuncT funcPtr =
         reinterpret_cast<apiFuncT>(clGetExtensionFunctionAddressForPlatform(
             curPlatform, "clCreateProgramWithILKHR"));
 
     assert(funcPtr != nullptr);
-    resProgram = funcPtr(pi_cast<cl_context>(context), il, length, pi_cast<cl_int*>(err));
+    resProgram = funcPtr(pi_cast<cl_context>(context), il, length,
+                         pi_cast<cl_int *>(err));
   } else {
-    resProgram =
-        clCreateProgramWithIL(pi_cast<cl_context>(context), il, length, pi_cast<cl_int*>(err));
+    resProgram = clCreateProgramWithIL(pi_cast<cl_context>(context), il, length,
+                                       pi_cast<cl_int *>(err));
   }
 
   return pi_cast<pi_program>(resProgram);
@@ -188,7 +191,7 @@ _PI_CL(piMemGetInfo,        clGetMemObjectInfo)
 _PI_CL(piMemRetain,         clRetainMemObject)
 _PI_CL(piMemRelease,        clReleaseMemObject)
 // Program
-// _PI_CL(piProgramCreate,             ocl_piProgramCreate)
+//_PI_CL(piProgramCreate,             clCreateProgramWithIL)
 _PI_CL(piclProgramCreateWithSource, clCreateProgramWithSource)
 _PI_CL(piclProgramCreateWithBinary, clCreateProgramWithBinary)
 _PI_CL(piProgramGetInfo,            clGetProgramInfo)

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -79,8 +79,9 @@ static RT::PiProgram createSpirvProgram(const RT::PiContext Context,
                                         size_t DataLen) {
   RT::PiResult Err = PI_SUCCESS;
   RT::PiProgram Program;
-  PI_CALL((Program = pi_cast<cl_program>(pi::piProgramCreate(
-               pi_cast<pi_context>(Context), Data, DataLen, pi_cast<pi_result *>(&Err))),
+  PI_CALL((Program = pi_cast<cl_program>(
+               pi::piProgramCreate(pi_cast<pi_context>(Context), Data, DataLen,
+                                   pi_cast<pi_result *>(&Err))),
            Err));
   return Program;
 }

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -79,8 +79,9 @@ static RT::PiProgram createSpirvProgram(const RT::PiContext Context,
                                         size_t DataLen) {
   RT::PiResult Err = PI_SUCCESS;
   RT::PiProgram Program;
-  PI_CALL((Program = (cl_program)pi::piProgramCreate(
-      (pi_context)Context, Data, DataLen, (pi_result*)&Err), Err));
+  PI_CALL((Program = pi_cast<cl_program>(pi::piProgramCreate(
+               pi_cast<pi_context>(Context), Data, DataLen, pi_cast<pi_result *>(&Err))),
+           Err));
   return Program;
 }
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -79,8 +79,8 @@ static RT::PiProgram createSpirvProgram(const RT::PiContext Context,
                                         size_t DataLen) {
   RT::PiResult Err = PI_SUCCESS;
   RT::PiProgram Program;
-  PI_CALL((Program = RT::piProgramCreate(
-      Context, Data, DataLen, &Err), Err));
+  PI_CALL((Program = (cl_program)pi::piProgramCreate(
+      (pi_context)Context, Data, DataLen, (pi_result*)&Err), Err));
   return Program;
 }
 


### PR DESCRIPTION
clCreateProgramWithIL is used by SYCL, and this function is only available with OpenCL 2.1 or later. For OpenCL < 2.1 there is an extension cl_khr_il_program which makes the same function available under a different name: clCreateProgramWithILKHR. Make SYCL runtime check for its availability and use it.

Signed-off-by: Alexander Batashev alexander.batashev@intel.com