### PR TITLE
[SYCL][FPGA] Check online compilation toolchain support.

### DIFF
--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -55,6 +55,8 @@ public:
     if (!is_host()) {
       DevicesSorted = sort_devices_by_cl_device_id(Devices);
     }
+    check_device_feature_support<
+        info::device::is_linker_available>(Devices);
     for (const auto &Prg : ProgramList) {
       Prg->throw_if_state_is_not(program_state::compiled);
       if (Prg->Context != Context) {
@@ -221,6 +223,8 @@ public:
   void link(string_class LinkOptions = "") {
     throw_if_state_is_not(program_state::compiled);
     if (!is_host()) {
+      check_device_feature_support<
+          info::device::is_linker_available>(Devices);
       vector_class<RT::PiDevice> Devices(get_pi_devices());
       RT::PiResult Err;
       PI_CALL_RESULT((Program = RT::piProgramLink(
@@ -322,6 +326,17 @@ public:
   program_state get_state() const { return State; }
 
 private:
+  template <info::device param>
+  void check_device_feature_support(
+      const vector_class<device> &devices) {
+    for (const auto &device : devices) {
+      if (!device.get_info<param>()) {
+        throw feature_not_supported(
+            "Online compilation is not supported by this device");
+      }
+    }
+  }
+
   void create_cl_program_with_il(OSModuleHandle M) {
     assert(!Program && "This program already has an encapsulated PI program");
     Program = ProgramManager::getInstance().createOpenCLProgram(M, Context);
@@ -338,6 +353,8 @@ private:
   }
 
   void compile(const string_class &Options) {
+    check_device_feature_support<
+        info::device::is_compiler_available>(Devices);
     vector_class<RT::PiDevice> Devices(get_pi_devices());
     RT::PiResult Err = PI_CALL_RESULT(RT::piProgramCompile(
         Program, Devices.size(), Devices.data(), Options.c_str(),
@@ -352,6 +369,8 @@ private:
   }
 
   void build(const string_class &Options) {
+    check_device_feature_support<
+        info::device::is_compiler_available>(Devices);
     vector_class<RT::PiDevice> Devices(get_pi_devices());
     RT::PiResult Err = PI_CALL_RESULT(RT::piProgramBuild(
         Program, Devices.size(), Devices.data(), Options.c_str(),

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -129,6 +129,13 @@ void ProgramManager::build(RT::PiProgram &Program, const string_class &Options,
   }
   const char *Opts = std::getenv("SYCL_PROGRAM_BUILD_OPTIONS");
 
+  for (const auto &device_id : Devices) {
+    if (!device(device_id).get_info<info::device::is_compiler_available>()) {
+      throw feature_not_supported(
+          "Online compilation is not supported by this device");
+    }
+  }
+
   if (!Opts)
     Opts = Options.c_str();
   if (PI_CALL_RESULT(RT::piProgramBuild(


### PR DESCRIPTION
SYCL runtime should throw 'feature_not_supported' SYCL exception
when online compilation is not supported by any of the given devices.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>