### PR TITLE
[SYCL] Add support for AOT for CPU

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3228,7 +3228,8 @@ class OffloadingActionBuilder final {
           auto TT = SYCLTripleList[I];
           bool SYCLAOTCompile = (TT.getSubArch() != llvm::Triple::NoSubArch &&
                          (TT.getSubArch() == llvm::Triple::SPIRSubArch_fpga ||
-                          TT.getSubArch() == llvm::Triple::SPIRSubArch_gen));
+                          TT.getSubArch() == llvm::Triple::SPIRSubArch_gen ||
+                          TT.getSubArch() == llvm::Triple::SPIRSubArch_x86_64));
 
           // After the Link, wrap the files before the final host link
           if (SYCLAOTCompile) {
@@ -3317,9 +3318,6 @@ class OffloadingActionBuilder final {
       }
       // Gather information about the SYCL Ahead of Time targets.  The targets
       // are determined on the SubArch values passed along in the triple.
-      // The SubArch information for SYCL offload is not used during the
-      // compilation and is only used to determine additional compilation steps
-      // needed in the driver toolchain.
       Arg *SYCLTargets =
               C.getInputArgs().getLastArg(options::OPT_fsycl_targets_EQ);
       bool HasValidSYCLRuntime = C.getInputArgs().hasFlag(options::OPT_fsycl,

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -91,7 +91,24 @@ public:
                     const char *LinkingOutput) const override;
 };
 
-}
+} // end namespace gen
+
+namespace x86_64 {
+
+class LLVM_LIBRARY_VISIBILITY BackendCompiler : public Tool {
+public:
+  BackendCompiler(const ToolChain &TC)
+      : Tool("x86_64::BackendCompiler", "x86_64 compiler", TC) {}
+
+  bool hasIntegratedCPP() const override { return false; }
+
+  void ConstructJob(Compilation &C, const JobAction &JA,
+                    const InputInfo &Output, const InputInfoList &Inputs,
+                    const llvm::opt::ArgList &TCArgs,
+                    const char *LinkingOutput) const override;
+};
+
+} // end namespace x86_64
 
 } // end namespace SYCL
 } // end namespace tools

--- a/llvm/include/llvm/ADT/Triple.h
+++ b/llvm/include/llvm/ADT/Triple.h
@@ -131,7 +131,8 @@ public:
     MipsSubArch_r6,
 
     SPIRSubArch_fpga,
-    SPIRSubArch_gen
+    SPIRSubArch_gen,
+    SPIRSubArch_x86_64
   };
   enum VendorType {
     UnknownVendor,

--- a/llvm/lib/Support/Triple.cpp
+++ b/llvm/lib/Support/Triple.cpp
@@ -572,6 +572,8 @@ static Triple::SubArchType parseSubArch(StringRef SubArchName) {
         return Triple::SPIRSubArch_fpga;
       else if (SA == "gen")
         return Triple::SPIRSubArch_gen;
+      else if (SA == "x86_64")
+        return Triple::SPIRSubArch_x86_64;
     }
   }
 


### PR DESCRIPTION
This extends support for AOT, adding the CPU specific target.  This is
represented by:

spir64_x86_64

Using this triple with -fsycl-targets will trigger AOT compilation using ioc64
for the offline compilation.

Sample command line:
clang++ test.cpp -fsycl -fsycl-targets=spir64_x86_64-unknown-linux-sycldevice
        -Xsycl-target-backend "-DFOO" -lOpenCL

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>