### PR TITLE
[SYCL] remove bogus assert from -foffload-static-lib

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -293,9 +293,6 @@ void SYCLToolChain::addClangTargetOptions(
     llvm::opt::ArgStringList &CC1Args,
     Action::OffloadKind DeviceOffloadingKind) const {
   HostTC.addClangTargetOptions(DriverArgs, CC1Args, DeviceOffloadingKind);
-
-  assert(DeviceOffloadingKind == Action::OFK_SYCL &&
-         "Only SYCL offloading kinds are supported");
 }
 
 llvm::opt::DerivedArgList *


### PR DESCRIPTION
The assertion to check for SYCL offload kind is not correct for
the -foffload-static-lib case.  -foffload-static-lib effectively does
a host 'unbundle' pass when extracting the library information but we
are performing it on the device side of the toolchain.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>