### PR TITLE
[SYCL] Enable programs that include system headers on Windows

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -545,7 +545,16 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
 
   case llvm::Triple::spir: {
     if (Triple.getEnvironment() == llvm::Triple::SYCLDevice) {
-      switch (os) {
+      llvm::Triple HT(Opts.HostTriple);
+      switch (HT.getOS()) {
+      case llvm::Triple::Win32:
+        switch (HT.getEnvironment()) {
+        default: // Assume MSVC for unknown environments
+        case llvm::Triple::MSVC:
+          assert(HT.getArch() == llvm::Triple::x86 &&
+                 "Unsupported host architecture");
+          return new MicrosoftX86_32SPIRTargetInfo(Triple, Opts);
+        }
       case llvm::Triple::Linux:
         return new LinuxTargetInfo<SPIR32SYCLDeviceTargetInfo>(Triple, Opts);
       default:
@@ -557,7 +566,16 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
 
   case llvm::Triple::spir64: {
     if (Triple.getEnvironment() == llvm::Triple::SYCLDevice) {
-      switch (os) {
+      llvm::Triple HT(Opts.HostTriple);
+      switch (HT.getOS()) {
+      case llvm::Triple::Win32:
+        switch (HT.getEnvironment()) {
+        default: // Assume MSVC for unknown environments
+        case llvm::Triple::MSVC:
+          assert(HT.getArch() == llvm::Triple::x86_64 &&
+                 "Unsupported host architecture");
+          return new MicrosoftX86_64_SPIR64TargetInfo(Triple, Opts);
+        }
       case llvm::Triple::Linux:
         return new LinuxTargetInfo<SPIR64SYCLDeviceTargetInfo>(Triple, Opts);
       default:

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3433,6 +3433,10 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
   if (LangOpts.OpenMPIsDevice)
     Res.getTargetOpts().HostTriple = Res.getFrontendOpts().AuxTriple;
 
+  // Set the triple of the host for SYCL device compile.
+  if (LangOpts.SYCLIsDevice)
+    Res.getTargetOpts().HostTriple = Res.getFrontendOpts().AuxTriple;
+
   // FIXME: Override value name discarding when asan or msan is used because the
   // backend passes depend on the name of the alloca in order to print out
   // names.

--- a/clang/test/SemaSYCL/mangle-kernel.cpp
+++ b/clang/test/SemaSYCL/mangle-kernel.cpp
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -I %S/../Headers/Inputs/include/ -fsycl-is-device -ast-dump %s | FileCheck %s --check-prefix=CHECK-64
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -aux-triple x86_64-pc-windows-msvc -I %S/Inputs -I %S/../Headers/Inputs/include/ -fsycl-is-device -ast-dump %s | FileCheck %s --check-prefix=CHECK-64-WIN
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -aux-triple x86_64-unknown-linux-gnu -I %S/Inputs -I %S/../Headers/Inputs/include/ -fsycl-is-device -ast-dump %s | FileCheck %s --check-prefix=CHECK-64-LIN
 // RUN: %clang_cc1 -triple spir-unknown-linux-sycldevice -I %S/Inputs -I %S/../Headers/Inputs/include/ -fsycl-is-device -ast-dump %s | FileCheck %s --check-prefix=CHECK-32
 #include <sycl.hpp>
 #include <stdlib.h>
@@ -25,5 +26,6 @@ int main() {
 
 // CHECK: _ZTS10SimpleVaddIiE
 // CHECK: _ZTS10SimpleVaddIdE
-// CHECK-64: _ZTS10SimpleVaddImE
+// CHECK-64-WIN: _ZTS10SimpleVaddIyE
+// CHECK-64-LIN: _ZTS10SimpleVaddImE
 // CHECK-32: _ZTS10SimpleVaddIjE

--- a/clang/test/SemaSYCL/msvc-fixes.cpp
+++ b/clang/test/SemaSYCL/msvc-fixes.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -fsycl-is-device -aux-triple x86_64-pc-windows-msvc  -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+void foo(__builtin_va_list bvl) {
+  char * VaList = bvl;
+  static_assert(sizeof(wchar_t) == 2, "sizeof wchar is 2 on Windows");
+}


### PR DESCRIPTION
Add Windows-specific predefined type characteristics for wchar, builtin
VaListKind, and a temporary workaround for the vectorcall attribute
which is seen in the Microsoft headers.
We'll allow vectorcall to appear on function declarations, since they
occur in the Microsoft headers, but we won't allow or will ignore
vectorcall on function invocations from SYCL target. (The handling for
vectorcall is a work in progress.) Add Windows support for SPIR target.

Signed-off-by: Melanie Blower <melanie.blower@intel.com>