### PR TITLE
[SYCL][USM] Implement depends_on inside command group handler.

### DIFF
--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -331,8 +331,7 @@ public:
       : MType(Type), MArgsStorage(std::move(ArgsStorage)),
         MAccStorage(std::move(AccStorage)),
         MSharedPtrStorage(std::move(SharedPtrStorage)),
-        MRequirements(std::move(Requirements)),
-        MEvents(std::move(Events)) {}
+        MRequirements(std::move(Requirements)), MEvents(std::move(Events)) {}
 
   CG(CG &&CommandGroup) = default;
 

--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -326,15 +326,19 @@ public:
   CG(CGTYPE Type, std::vector<std::vector<char>> ArgsStorage,
      std::vector<detail::AccessorImplPtr> AccStorage,
      std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-     std::vector<Requirement *> Requirements)
+     std::vector<Requirement *> Requirements,
+     std::vector<detail::EventImplPtr> Events)
       : MType(Type), MArgsStorage(std::move(ArgsStorage)),
         MAccStorage(std::move(AccStorage)),
         MSharedPtrStorage(std::move(SharedPtrStorage)),
-        MRequirements(std::move(Requirements)) {}
+        MRequirements(std::move(Requirements)),
+        MEvents(std::move(Events)) {}
 
   CG(CG &&CommandGroup) = default;
 
   std::vector<Requirement *> getRequirements() const { return MRequirements; }
+
+  std::vector<detail::EventImplPtr> getEvents() const { return MEvents; }
 
   CGTYPE getType() { return MType; }
 
@@ -351,6 +355,8 @@ private:
   // List of requirements that specify which memory is needed for the command
   // group to be executed.
   std::vector<Requirement *> MRequirements;
+  // List of events that order the execution of this CG
+  std::vector<detail::EventImplPtr> MEvents;
 };
 
 // The class which represents "execute kernel" command group.
@@ -370,11 +376,13 @@ public:
                std::vector<detail::AccessorImplPtr> AccStorage,
                std::vector<std::shared_ptr<const void>> SharedPtrStorage,
                std::vector<Requirement *> Requirements,
+               std::vector<detail::EventImplPtr> Events,
                std::vector<ArgDesc> Args, std::string KernelName,
                detail::OSModuleHandle OSModuleHandle,
                std::vector<std::shared_ptr<detail::stream_impl>> Streams)
       : CG(KERNEL, std::move(ArgsStorage), std::move(AccStorage),
-           std::move(SharedPtrStorage), std::move(Requirements)),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events)),
         MNDRDesc(std::move(NDRDesc)), MHostKernel(std::move(HKernel)),
         MSyclKernel(std::move(SyclKernel)), MArgs(std::move(Args)),
         MKernelName(std::move(KernelName)), MOSModuleHandle(OSModuleHandle),
@@ -397,9 +405,11 @@ public:
          std::vector<std::vector<char>> ArgsStorage,
          std::vector<detail::AccessorImplPtr> AccStorage,
          std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-         std::vector<Requirement *> Requirements)
+         std::vector<Requirement *> Requirements,
+         std::vector<detail::EventImplPtr> Events)
       : CG(CopyType, std::move(ArgsStorage), std::move(AccStorage),
-           std::move(SharedPtrStorage), std::move(Requirements)),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events)),
         MSrc(Src), MDst(Dst) {}
   void *getSrc() { return MSrc; }
   void *getDst() { return MDst; }
@@ -415,9 +425,11 @@ public:
          std::vector<std::vector<char>> ArgsStorage,
          std::vector<detail::AccessorImplPtr> AccStorage,
          std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-         std::vector<Requirement *> Requirements)
+         std::vector<Requirement *> Requirements,
+         std::vector<detail::EventImplPtr> Events)
       : CG(FILL, std::move(ArgsStorage), std::move(AccStorage),
-           std::move(SharedPtrStorage), std::move(Requirements)),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events)),
         MPattern(std::move(Pattern)), MPtr((Requirement *)Ptr) {}
   Requirement *getReqToFill() { return MPtr; }
 };
@@ -430,9 +442,11 @@ public:
   CGUpdateHost(void *Ptr, std::vector<std::vector<char>> ArgsStorage,
                std::vector<detail::AccessorImplPtr> AccStorage,
                std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-               std::vector<Requirement *> Requirements)
+               std::vector<Requirement *> Requirements,
+               std::vector<detail::EventImplPtr> Events)
       : CG(UPDATE_HOST, std::move(ArgsStorage), std::move(AccStorage),
-           std::move(SharedPtrStorage), std::move(Requirements)),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events)),
         MPtr((Requirement *)Ptr) {}
 
   Requirement *getReqToUpdate() { return MPtr; }

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -483,6 +483,7 @@ Command *
 Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
                                QueueImplPtr Queue) {
   std::vector<Requirement *> Reqs = CommandGroup->getRequirements();
+  std::vector<detail::EventImplPtr> Events = CommandGroup->getEvents();
   std::unique_ptr<ExecCGCommand> NewCmd(
       new ExecCGCommand(std::move(CommandGroup), Queue));
   if (!NewCmd)
@@ -521,6 +522,11 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
     MemObjRecord *Record = getMemObjRecord(Req->MSYCLMemObj);
     UpdateLeafs({Dep.MDepCommand}, Record, Req);
     AddNodeToLeafs(Record, NewCmd.get(), Req);
+  }
+
+  // Register all the events as dependencies
+  for (detail::EventImplPtr e : Events) {
+    NewCmd->addDep(e);
   }
 
   return NewCmd.release();

--- a/sycl/test/usm/depends_on.cpp
+++ b/sycl/test/usm/depends_on.cpp
@@ -1,0 +1,74 @@
+// RUN: %clang -std=c++11 -fsycl %s -o %t1.out -lstdc++ -lOpenCL -lsycl
+// RUN: %CPU_RUN_PLACEHOLDER %t1.out
+//==------------------- mixed.cpp - Mixed Memory test ---------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+class foo;
+int main() {
+  int *darray = nullptr;
+  int *sarray = nullptr;
+  int *harray = nullptr;
+  const int N = 4;
+  const int MAGIC_NUM = 42;
+
+  queue q;
+  auto dev = q.get_device();
+  auto ctxt = q.get_context();
+
+  darray = (int *)malloc_device(N * sizeof(int), dev, ctxt);
+  if (darray == nullptr) {
+    return -1;
+  }
+  sarray = (int *)malloc_shared(N * sizeof(int), dev, ctxt);
+
+  if (sarray == nullptr) {
+    return -1;
+  }
+
+  harray = (int *)malloc_host(N * sizeof(int), ctxt);
+  if (harray == nullptr) {
+    return -1;
+  }
+
+  auto eInit = q.submit([&](handler &cgh) {
+    cgh.single_task<class init>([=]() {
+      for (int i = 0; i < N; i++) {
+        sarray[i] = MAGIC_NUM - 1;
+        harray[i] = 1;
+      }
+    });
+  });
+
+  auto eMemset = q.memset(darray, 0, N * sizeof(int));
+
+  auto eKernel = q.submit([=](handler &cgh) {
+    cgh.depends_on({eInit, eMemset});
+    cgh.single_task<class foo>([=]() {
+      for (int i = 0; i < N; i++) {
+        sarray[i] += darray[i] + harray[i];
+      }
+    });
+  });
+
+  eKernel.wait();
+
+  for (int i = 0; i < N; i++) {
+    if (sarray[i] != MAGIC_NUM) {
+      return -1;
+    }
+  }
+  free(darray, ctxt);
+  free(sarray, ctxt);
+  free(harray, ctxt);
+
+  return 0;
+}

--- a/sycl/test/usm/depends_on.cpp
+++ b/sycl/test/usm/depends_on.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang -std=c++11 -fsycl %s -o %t1.out -lstdc++ -lOpenCL -lsycl
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
-//==------------------- mixed.cpp - Mixed Memory test ---------------------==//
+//==----------------- depends_on.cpp - depends_on test ---------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
Adds ability to specify event or events that are required to complete before a command group may execute.

Signed-off-by: James Brodman <james.brodman@intel.com>