### PR TITLE
[SYCL] Further 'long long' type enabling for Windows.

### DIFF
--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -394,10 +394,10 @@ modf(T x, T2 iptr) __NOEXC {
 // genfloatd nan (ugenlonginteger nancode)
 template <typename T, typename = typename std::enable_if<
                           detail::is_nan_type<T>::value, T>::type>
-typename detail::unsign_integral_to_float_point<T>::type
+detail::unsign_integral_to_float_point_t<T>
 nan(T nancode) __NOEXC {
   return __sycl_std::__invoke_nan<
-      typename detail::unsign_integral_to_float_point<T>::type>(nancode);
+    detail::unsign_integral_to_float_point_t<T>>(nancode);
 }
 
 // genfloat nextafter (genfloat x, genfloat y)

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -548,7 +548,6 @@ using is_genptr =
   std::integral_constant<bool, is_genintegralptr<T>::value ||
                                is_genfloatptr<T>::value>;
 
-// Used for nan built-in
 template <typename T> struct unsign_integral_to_float_point;
 template <> struct unsign_integral_to_float_point<cl_uint> {
   using type = cl_float;
@@ -604,25 +603,6 @@ template <> struct unsign_integral_to_float_point<cl_ulong8> {
   using type = cl_double8;
 };
 template <> struct unsign_integral_to_float_point<cl_ulong16> {
-  using type = cl_double16;
-};
-
-template <> struct unsign_integral_to_float_point<ulonglong> {
-  using type = cl_double;
-};
-template <> struct unsign_integral_to_float_point<ulonglong2> {
-  using type = cl_double2;
-};
-template <> struct unsign_integral_to_float_point<ulonglong3> {
-  using type = cl_double3;
-};
-template <> struct unsign_integral_to_float_point<ulonglong4> {
-  using type = cl_double4;
-};
-template <> struct unsign_integral_to_float_point<ulonglong8> {
-  using type = cl_double8;
-};
-template <> struct unsign_integral_to_float_point<ulonglong16> {
   using type = cl_double16;
 };
 
@@ -717,77 +697,70 @@ template <> struct float_point_to_int<cl_double16> { using type = cl_int16; };
 // Used for abs and abs_diff built-in
 template <typename T> struct make_unsigned { using type = T; };
 
-template <> struct make_unsigned<cl_char> { using type = cl_uchar; };
-template <> struct make_unsigned<cl_char2> { using type = cl_uchar2; };
-template <> struct make_unsigned<cl_char3> { using type = cl_uchar3; };
-template <> struct make_unsigned<cl_char4> { using type = cl_uchar4; };
-template <> struct make_unsigned<cl_char8> { using type = cl_uchar8; };
-template <> struct make_unsigned<cl_char16> { using type = cl_uchar16; };
+template <> struct make_unsigned<signed char>                    {
+  using type = unsigned char;                                    };
+template <> struct make_unsigned<cl::sycl::vec<signed char, 2>>  {
+  using type = cl::sycl::vec<unsigned char, 2>;                  };
+template <> struct make_unsigned<cl::sycl::vec<signed char, 3>>  {
+  using type = cl::sycl::vec<unsigned char, 3>;                  };
+template <> struct make_unsigned<cl::sycl::vec<signed char, 4>>  {
+  using type = cl::sycl::vec<unsigned char, 4>;                  };
+template <> struct make_unsigned<cl::sycl::vec<signed char, 8>>  {
+  using type = cl::sycl::vec<unsigned char, 8>;                  };
+template <> struct make_unsigned<cl::sycl::vec<signed char, 16>> {
+  using type = cl::sycl::vec<unsigned char, 16>;                 };
 
-template <> struct make_unsigned<cl_short> { using type = cl_ushort; };
-template <> struct make_unsigned<cl_short2> { using type = cl_ushort2; };
-template <> struct make_unsigned<cl_short3> { using type = cl_ushort3; };
-template <> struct make_unsigned<cl_short4> { using type = cl_ushort4; };
-template <> struct make_unsigned<cl_short8> { using type = cl_ushort8; };
-template <> struct make_unsigned<cl_short16> { using type = cl_ushort16; };
+template <> struct make_unsigned<short>                    {
+  using type = unsigned short;                             };
+template <> struct make_unsigned<cl::sycl::vec<short, 2>>  {
+  using type = cl::sycl::vec<unsigned short, 2>;           };
+template <> struct make_unsigned<cl::sycl::vec<short, 3>>  {
+  using type = cl::sycl::vec<unsigned short, 3>;           };
+template <> struct make_unsigned<cl::sycl::vec<short, 4>>  {
+  using type = cl::sycl::vec<unsigned short, 4>;           };
+template <> struct make_unsigned<cl::sycl::vec<short, 8>>  {
+  using type = cl::sycl::vec<unsigned short, 8>;           };
+template <> struct make_unsigned<cl::sycl::vec<short, 16>> {
+  using type = cl::sycl::vec<unsigned short, 16>;          };
 
-template <> struct make_unsigned<cl_int> { using type = cl_uint; };
-template <> struct make_unsigned<cl_int2> { using type = cl_uint2; };
-template <> struct make_unsigned<cl_int3> { using type = cl_uint3; };
-template <> struct make_unsigned<cl_int4> { using type = cl_uint4; };
-template <> struct make_unsigned<cl_int8> { using type = cl_uint8; };
-template <> struct make_unsigned<cl_int16> { using type = cl_uint16; };
+template <> struct make_unsigned<int>                    {
+  using type = unsigned int;                             };
+template <> struct make_unsigned<cl::sycl::vec<int, 2>>  {
+  using type = cl::sycl::vec<unsigned int, 2>;           };
+template <> struct make_unsigned<cl::sycl::vec<int, 3>>  {
+  using type = cl::sycl::vec<unsigned int, 3>;           };
+template <> struct make_unsigned<cl::sycl::vec<int, 4>>  {
+  using type = cl::sycl::vec<unsigned int, 4>;           };
+template <> struct make_unsigned<cl::sycl::vec<int, 8>>  {
+  using type = cl::sycl::vec<unsigned int, 8>;           };
+template <> struct make_unsigned<cl::sycl::vec<int, 16>> {
+  using type = cl::sycl::vec<unsigned int, 16>;          };
 
-template <> struct make_unsigned<cl_long> { using type = cl_ulong; };
-template <> struct make_unsigned<cl_long2> { using type = cl_ulong2; };
-template <> struct make_unsigned<cl_long3> { using type = cl_ulong3; };
-template <> struct make_unsigned<cl_long4> { using type = cl_ulong4; };
-template <> struct make_unsigned<cl_long8> { using type = cl_ulong8; };
-template <> struct make_unsigned<cl_long16> { using type = cl_ulong16; };
+template <> struct make_unsigned<long>                    {
+  using type = unsigned long;                             };
+template <> struct make_unsigned<cl::sycl::vec<long, 2>>  {
+  using type = cl::sycl::vec<unsigned long, 2>;           };
+template <> struct make_unsigned<cl::sycl::vec<long, 3>>  {
+  using type = cl::sycl::vec<unsigned long, 3>;           };
+template <> struct make_unsigned<cl::sycl::vec<long, 4>>  {
+  using type = cl::sycl::vec<unsigned long, 4>;           };
+template <> struct make_unsigned<cl::sycl::vec<long, 8>>  {
+  using type = cl::sycl::vec<unsigned long, 8>;           };
+template <> struct make_unsigned<cl::sycl::vec<long, 16>> {
+  using type = cl::sycl::vec<unsigned long, 16>;          };
 
-template <> struct make_unsigned<longlong> { using type = ulonglong; };
-template <> struct make_unsigned<longlong2> { using type = ulonglong2; };
-template <> struct make_unsigned<longlong3> { using type = ulonglong3; };
-template <> struct make_unsigned<longlong4> { using type = ulonglong4; };
-template <> struct make_unsigned<longlong8> { using type = ulonglong8; };
-template <> struct make_unsigned<longlong16> { using type = ulonglong16; };
-
-template <typename T> struct make_signed { using type = T; };
-
-template <> struct make_signed<cl_uchar> { using type = cl_char; };
-template <> struct make_signed<cl_uchar2> { using type = cl_char2; };
-template <> struct make_signed<cl_uchar3> { using type = cl_char3; };
-template <> struct make_signed<cl_uchar4> { using type = cl_char4; };
-template <> struct make_signed<cl_uchar8> { using type = cl_char8; };
-template <> struct make_signed<cl_uchar16> { using type = cl_char16; };
-
-template <> struct make_signed<cl_ushort> { using type = cl_short; };
-template <> struct make_signed<cl_ushort2> { using type = cl_short2; };
-template <> struct make_signed<cl_ushort3> { using type = cl_short3; };
-template <> struct make_signed<cl_ushort4> { using type = cl_short4; };
-template <> struct make_signed<cl_ushort8> { using type = cl_short8; };
-template <> struct make_signed<cl_ushort16> { using type = cl_short16; };
-
-template <> struct make_signed<cl_uint> { using type = cl_int; };
-template <> struct make_signed<cl_uint2> { using type = cl_int2; };
-template <> struct make_signed<cl_uint3> { using type = cl_int3; };
-template <> struct make_signed<cl_uint4> { using type = cl_int4; };
-template <> struct make_signed<cl_uint8> { using type = cl_int8; };
-template <> struct make_signed<cl_uint16> { using type = cl_int16; };
-
-template <> struct make_signed<cl_ulong> { using type = cl_long; };
-template <> struct make_signed<cl_ulong2> { using type = cl_long2; };
-template <> struct make_signed<cl_ulong3> { using type = cl_long3; };
-template <> struct make_signed<cl_ulong4> { using type = cl_long4; };
-template <> struct make_signed<cl_ulong8> { using type = cl_long8; };
-template <> struct make_signed<cl_ulong16> { using type = cl_long16; };
-
-template <> struct make_signed<ulonglong> { using type = longlong; };
-template <> struct make_signed<ulonglong2> { using type = longlong2; };
-template <> struct make_signed<ulonglong3> { using type = longlong3; };
-template <> struct make_signed<ulonglong4> { using type = longlong4; };
-template <> struct make_signed<ulonglong8> { using type = longlong8; };
-template <> struct make_signed<ulonglong16> { using type = longlong16; };
+template <> struct make_unsigned<long long>                    {
+  using type = unsigned long long;                             };
+template <> struct make_unsigned<cl::sycl::vec<long long, 2>>  {
+  using type = cl::sycl::vec<unsigned long long, 2>;           };
+template <> struct make_unsigned<cl::sycl::vec<long long, 3>>  {
+  using type = cl::sycl::vec<unsigned long long, 3>;           };
+template <> struct make_unsigned<cl::sycl::vec<long long, 4>>  {
+  using type = cl::sycl::vec<unsigned long long, 4>;           };
+template <> struct make_unsigned<cl::sycl::vec<long long, 8>>  {
+  using type = cl::sycl::vec<unsigned long long, 8>;           };
+template <> struct make_unsigned<cl::sycl::vec<long long, 16>> {
+  using type = cl::sycl::vec<unsigned long long, 16>;          };
 
 // Used for upsample built-in
 // Bases on Table 4.93: Scalar data type aliases supported by SYCL
@@ -1019,6 +992,11 @@ typename std::enable_if<!(is_vgentype<FROM>::value &&
 convertDataToType(FROM t) {
   return TryToGetPointer(t);
 }
+
+template <typename T>
+  using unsign_integral_to_float_point_t =
+    typename unsign_integral_to_float_point<
+      SelectMatchingOpenCLType_t<T>>::type;
 
 // Used for all,any and select relational built-in functions
 template <typename T> inline constexpr T msbMask(T) {

--- a/sycl/source/detail/builtins_helper.hpp
+++ b/sycl/source/detail/builtins_helper.hpp
@@ -17,31 +17,27 @@
 #define __MAKE_1V(Fun, Call, N, Ret, Arg1)                                     \
   Ret##N Fun __NOEXC(Arg1##N x) {                                              \
     Ret##N r;                                                                  \
-    using base_t = typename Arg1##N::element_type;                             \
     detail::helper<N - 1>().run_1v(                                            \
-        r, [](base_t x) { return cl::__host_std::Call(x); }, x);               \
+      r, [](Arg1 x) {                                                          \
+        return cl::__host_std::Call(x); }, x);                                 \
     return r;                                                                  \
   }
 
 #define __MAKE_1V_2V(Fun, Call, N, Ret, Arg1, Arg2)                            \
   Ret##N Fun __NOEXC(Arg1##N x, Arg2##N y) {                                   \
     Ret##N r;                                                                  \
-    using base1_t = typename Arg1##N::element_type;                            \
-    using base2_t = typename Arg2##N::element_type;                            \
     detail::helper<N - 1>().run_1v_2v(                                         \
-        r, [](base1_t x, base2_t y) { return cl::__host_std::Call(x, y); }, x, \
-        y);                                                                    \
+        r, [](Arg1 x, Arg2 y) {                                                \
+          return cl::__host_std::Call(x, y); }, x, y);                         \
     return r;                                                                  \
   }
 
 #define __MAKE_1V_2V_RS(Fun, Call, N, Ret, Arg1, Arg2)                         \
   Ret Fun __NOEXC(Arg1##N x, Arg2##N y) {                                      \
     Ret r = Ret();                                                             \
-    using base1_t = typename Arg1##N::element_type;                            \
-    using base2_t = typename Arg2##N::element_type;                            \
     detail::helper<N - 1>().run_1v_2v_rs(                                      \
         r,                                                                     \
-        [](Ret &r, base1_t x, base2_t y) {                                     \
+        [](Ret &r, Arg1 x, Arg2 y) {                                           \
           return cl::__host_std::Call(r, x, y);                                \
         },                                                                     \
         x, y);                                                                 \
@@ -51,21 +47,18 @@
 #define __MAKE_1V_RS(Fun, Call, N, Ret, Arg1)                                  \
   Ret Fun __NOEXC(Arg1##N x) {                                                 \
     Ret r = Ret();                                                             \
-    using base1_t = typename Arg1##N::element_type;                            \
     detail::helper<N - 1>().run_1v_rs(                                         \
-        r, [](Ret &r, base1_t x) { return cl::__host_std::Call(r, x); }, x);   \
+      r, [](Ret &r, Arg1 x) {                                                  \
+        return cl::__host_std::Call(r, x); }, x);                              \
     return r;                                                                  \
   }
 
 #define __MAKE_1V_2V_3V(Fun, Call, N, Ret, Arg1, Arg2, Arg3)                   \
   Ret##N Fun __NOEXC(Arg1##N x, Arg2##N y, Arg3##N z) {                        \
     Ret##N r;                                                                  \
-    using base1_t = typename Arg1##N::element_type;                            \
-    using base2_t = typename Arg2##N::element_type;                            \
-    using base3_t = typename Arg3##N::element_type;                            \
     detail::helper<N - 1>().run_1v_2v_3v(                                      \
         r,                                                                     \
-        [](base1_t x, base2_t y, base3_t z) {                                  \
+        [](Arg1 x, Arg2 y, Arg3 z) {                                           \
           return cl::__host_std::Call(x, y, z);                                \
         },                                                                     \
         x, y, z);                                                              \
@@ -75,10 +68,9 @@
 #define __MAKE_1V_2S_3S(Fun, N, Ret, Arg1, Arg2, Arg3)                         \
   Ret##N Fun __NOEXC(Arg1##N x, Arg2 y, Arg3 z) {                              \
     Ret##N r;                                                                  \
-    using base1_t = typename Arg1##N::element_type;                            \
     detail::helper<N - 1>().run_1v_2s_3s(                                      \
         r,                                                                     \
-        [](base1_t x, Arg2 y, Arg3 z) {                                        \
+        [](Arg1 x, Arg2 y, Arg3 z) {                                           \
           return cl::__host_std::Fun(x, y, z);                                 \
         },                                                                     \
         x, y, z);                                                              \
@@ -88,50 +80,43 @@
 #define __MAKE_1V_2S(Fun, N, Ret, Arg1, Arg2)                                  \
   Ret##N Fun __NOEXC(Arg1##N x, Arg2 y) {                                      \
     Ret##N r;                                                                  \
-    using base1_t = typename Arg1##N::element_type;                            \
     detail::helper<N - 1>().run_1v_2s(                                         \
-        r, [](base1_t x, Arg2 y) { return cl::__host_std::Fun(x, y); }, x, y); \
+      r, [](Arg1 x, Arg2 y) { return cl::__host_std::Fun(x, y); },             \
+      x, y);                                                                   \
     return r;                                                                  \
   }
 
 #define __MAKE_SR_1V_AND(Fun, Call, N, Ret, Arg1)                              \
   Ret Fun __NOEXC(Arg1##N x) {                                                 \
     Ret r;                                                                     \
-    using base_t = typename Arg1##N::element_type;                             \
     detail::helper<N - 1>().run_1v_sr_and(                                     \
-        r, [](base_t x) { return cl::__host_std::Call(x); }, x);               \
+      r, [](Arg1 x) { return cl::__host_std::Call(x); }, x);                   \
     return r;                                                                  \
   }
 
 #define __MAKE_SR_1V_OR(Fun, Call, N, Ret, Arg1)                               \
   Ret Fun __NOEXC(Arg1##N x) {                                                 \
     Ret r;                                                                     \
-    using base_t = typename Arg1##N::element_type;                             \
     detail::helper<N - 1>().run_1v_sr_or(                                      \
-        r, [](base_t x) { return cl::__host_std::Call(x); }, x);               \
+      r, [](Arg1 x) { return cl::__host_std::Call(x); }, x);                   \
     return r;                                                                  \
   }
 
 #define __MAKE_1V_2P(Fun, N, Ret, Arg1, Arg2)                                  \
   Ret##N Fun __NOEXC(Arg1##N x, Arg2##N *y) {                                  \
     Ret##N r;                                                                  \
-    using base1_t = typename Arg1##N::element_type;                            \
-    using base2_t = typename Arg2##N::element_type;                            \
     detail::helper<N - 1>().run_1v_2p(                                         \
-        r, [](base1_t x, base2_t *y) { return cl::__host_std::Fun(x, y); }, x, \
-        y);                                                                    \
+      r, [](Arg1 x, Arg2 *y) {                                                 \
+        return cl::__host_std::Fun(x, y); }, x, y);                            \
     return r;                                                                  \
   }
 
 #define __MAKE_1V_2V_3P(Fun, N, Ret, Arg1, Arg2, Arg3)                         \
   Ret##N Fun __NOEXC(Arg1##N x, Arg2##N y, Arg3##N *z) {                       \
     Ret##N r;                                                                  \
-    using base1_t = typename Arg1##N::element_type;                            \
-    using base2_t = typename Arg2##N::element_type;                            \
-    using base3_t = typename Arg3##N::element_type;                            \
     detail::helper<N - 1>().run_1v_2v_3p(                                      \
         r,                                                                     \
-        [](base1_t x, base2_t y, base3_t *z) {                                 \
+        [](Arg1 x, Arg2 y, Arg3 *z) {                                          \
           return cl::__host_std::Fun(x, y, z);                                 \
         },                                                                     \
         x, y, z);                                                              \

--- a/sycl/test/built-ins/vector_integer.cpp
+++ b/sycl/test/built-ins/vector_integer.cpp
@@ -221,6 +221,25 @@ int main() {
     assert(r2 == 2);
   }
 
+  // abs (longlong)
+  {
+    s::ulonglong2 r{ 0 };
+    {
+      s::buffer<s::ulonglong2, 1> BufR(&r, s::range<1>(1));
+      s::queue myQueue;
+      myQueue.submit([&](s::handler &cgh) {
+        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        cgh.single_task<class absSL2>([=]() {
+          AccR[0] = s::abs(s::longlong2{ -5, -2 });
+        });
+      });
+    }
+    s::ulonglong r1 = r.x();
+    s::ulonglong r2 = r.y();
+    assert(r1 == 5);
+    assert(r2 == 2);
+  }
+
   // abs_diff
   {
     s::cl_uint2 r{ 0 };

--- a/sycl/test/built-ins/vector_math.cpp
+++ b/sycl/test/built-ins/vector_math.cpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cassert>
+#include <cmath>
 
 namespace s = cl::sycl;
 
@@ -200,6 +201,42 @@ int main() {
     assert(r2 > 0.1024f && r2 < 0.1026f);   // ~0.102583
     assert(i1 == 1);                        // tgamma of 10 is ~362880.0
     assert(i2 == -1); // tgamma of -2.4 is ~-1.1080299470333461
+  }
+
+  // nan (ulong)
+  {
+    s::cl_double2 r{ 0 };
+    {
+      s::buffer<s::cl_double2, 1> BufR(&r, s::range<1>(1));
+      s::queue myQueue;
+      myQueue.submit([&](s::handler &cgh) {
+        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        s::ulong2 in{1, 1};
+        cgh.single_task<class nanISUL2>([=]() { AccR[0] = s::nan(in); });
+      });
+    }
+    s::cl_double x = r.x();
+    s::cl_double y = r.y();
+    assert(std::isnan(x));
+    assert(std::isnan(y));
+  }
+
+  // nan (ulonglong)
+  {
+    s::cl_double2 r{ 0 };
+    {
+      s::buffer<s::cl_double2, 1> BufR(&r, s::range<1>(1));
+      s::queue myQueue;
+      myQueue.submit([&](s::handler &cgh) {
+        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        s::ulonglong2 in{1ULL, 1ULL};
+        cgh.single_task<class nanISULL2>([=]() { AccR[0] = s::nan(in); });
+      });
+    }
+    s::cl_double x = r.x();
+    s::cl_double y = r.y();
+    assert(std::isnan(x));
+    assert(std::isnan(y));
   }
 
   return 0;


### PR DESCRIPTION
Removed 'longlong' specializations for some templates and fixed their uses.
Switched to C++ type specializations for other templates.
Added convertions explicitly whereas the compiler can't choose.

Signed-off-by: Sergey Zverev <sergey.i.zverev@intel.com>