### PR TITLE
[SYCL] Perform correct PI initialization at first use

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -55,6 +55,9 @@ namespace pi {
   #define _PI_API(api) extern decltype(::api) * api;
   #include <CL/sycl/detail/pi.def>
 
+  // Performs PI one-time initialization.
+  void piInitialize();
+
   // The PiCall helper structure facilitates performing a call to PI.
   // It holds utilities to do the tracing and to check the returned result.
   // TODO: implement a more mature and controllable tracing of PI calls.
@@ -77,8 +80,9 @@ namespace RT = cl::sycl::detail::pi;
   RT::piAssert((cond), "assert @ " __FILE__ ":" STRINGIFY_LINE(__LINE__) msg);
 
 // This does the call, the trace and the check for no errors.
-#define PI_CALL(pi) \
-    RT::PiCall(#pi).check<cl::sycl::runtime_error>( \
+#define PI_CALL(pi)                                   \
+    RT::piInitialize(),                               \
+    RT::PiCall(#pi).check<cl::sycl::runtime_error>(   \
         RT::pi_cast<detail::RT::PiResult>(pi))
 
 // This does the trace, the call, and returns the result

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -35,7 +35,11 @@ bool piUseBackend(PiBackend Backend) {
 
 // TODO: implement real plugins (ICD-like?)
 // For now this has the effect of redirecting to built-in PI OpenCL plugin.
-bool piInitialize() {
+void piInitialize() {
+  static bool Initialized = false;
+  if (Initialized) {
+    return;
+  }
   if (!piUseBackend(SYCL_BE_PI_OPENCL)) {
     piDie("Unknown SYCL_BE");
   }
@@ -44,7 +48,7 @@ bool piInitialize() {
     api = api##OclPtr;
   #include <CL/sycl/detail/pi.def>
 
-  return true;
+  Initialized = true;
 }
 
 // Report error and no return (keeps compiler from printing warnings).
@@ -65,8 +69,6 @@ bool PiCall::m_TraceEnabled = (std::getenv("SYCL_PI_TRACE") != nullptr);
 
 // Emits trace before the start of PI call
 PiCall::PiCall(const char *Trace) {
-  static bool PiInitialized = piInitialize();
-
   if (m_TraceEnabled && Trace) {
     std::cerr << "PI ---> " << Trace << std::endl;
   }


### PR DESCRIPTION
The problem with the original code is that PI initialization (in PiCall constructor) could be run later than the actual PI call "pi" in the macro below, due to undetermined evaluation order of the two:

#define PI_CALL(pi)                                   \
    RT::PiCall(#pi).check<cl::sycl::runtime_error>(   \
        RT::pi_cast<detail::RT::PiResult>(pi))

FWIW, I am going to work on a better fix along with PI tracing (with run-time values).

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>