### PR TITLE
[SYCL] Make full copy of buffer from device to host and back.

### DIFF
--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -378,8 +378,8 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
     if (Dim == 1) {
       PI_CALL(RT::piEnqueueMemBufferFill(
           Queue->getHandleRef(), pi::pi_cast<RT::PiMem>(Mem), Pattern,
-          PatternSize, Offset[0], Range[0] * ElementSize, DepEvents.size(),
-          &DepEvents[0], &OutEvent));
+          PatternSize, Offset[0] * ElementSize, Range[0] * ElementSize,
+          DepEvents.size(), &DepEvents[0], &OutEvent));
       return;
     }
     assert(!"Not supported configuration of fill requested");

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -124,8 +124,10 @@ Scheduler::GraphBuilder::insertMemCpyCmd(MemObjRecord *Record, Requirement *Req,
 
   AllocaCommand *AllocaCmdSrc = findAllocaForReq(Record, Req, SrcQueue);
 
+  // Full copy of buffer is needed to avoid loss of data that may be caused
+  // by copying specific range form host to device and backwards.
   MemCpyCommand *MemCpyCmd = new MemCpyCommand(
-      *AllocaCmdSrc->getAllocationReq(), AllocaCmdSrc, *Req, AllocaCmdDst,
+      *AllocaCmdSrc->getAllocationReq(), AllocaCmdSrc, FullReq, AllocaCmdDst,
       AllocaCmdSrc->getQueue(), AllocaCmdDst->getQueue(), UseExclusiveQueue);
 
   for (Command *Dep : Deps) {

--- a/sycl/test/basic_tests/buffer/buffer_full_copy.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_full_copy.cpp
@@ -1,0 +1,152 @@
+// RUN: %clang -std=c++11 %s -o %t1.out -lstdc++ -lOpenCL -lsycl
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %clang -std=c++11 -fsycl %s -o %t2.out -lstdc++ -lOpenCL -lsycl
+// RUN: env SYCL_DEVICE_TYPE=HOST %t2.out
+// RUN: %CPU_RUN_PLACEHOLDER %t2.out
+// RUN: %GPU_RUN_PLACEHOLDER %t2.out
+// RUN: %ACC_RUN_PLACEHOLDER %t2.out
+//==------------- buffer_full_copy.cpp - SYCL buffer basic test ------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+#include <cassert>
+
+void check_copy_device_to_host(cl::sycl::queue &Queue) {
+  const int size = 6, offset = 2;
+
+  // Create 2d buffer
+  cl::sycl::buffer<int, 2> simple_buffer(cl::sycl::range<2>(size, size));
+
+  // Submit kernel where you'll fill the buffer
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    auto acc = simple_buffer.get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.fill(acc, 13);
+  });
+
+  // Create host accessor with range and offset
+  {
+    cl::sycl::range<2> acc_range(2, 2);
+    cl::sycl::id<2> acc_offset(offset, offset);
+    auto acc = simple_buffer.get_access<cl::sycl::access::mode::read_write>(
+        acc_range, acc_offset);
+    for (int i = 0; i < 2; ++i) {
+      for (int j = 0; j < 2; ++j)
+        acc[i][j] += 2;
+    }
+  }
+  // Create host accessor with full access range
+  // Check whether data was corrupted or not.
+  {
+    auto acc = simple_buffer.get_access<cl::sycl::access::mode::read>();
+    for (int i = 0; i < size; ++i) {
+      for (int j = 0; j < size; ++j)
+        if (offset <= i && i < offset + 2 && offset <= j && j < offset + 2) {
+          assert(acc[i][j] == 15);
+        } else {
+          assert(acc[i][j] == 13);
+        }
+    }
+  }
+}
+
+void check_copy_host_to_device(cl::sycl::queue &Queue) {
+  const int size = 6, offset = 2;
+  cl::sycl::buffer<float, 1> buf_1(size);
+  cl::sycl::buffer<float, 1> buf_2(size / 2);
+  std::vector<float> expected_res_1(size);
+  std::vector<float> expected_res_2(size / 2);
+
+  // copy acc 2 acc with offset
+  {
+    auto acc = buf_1.get_access<cl::sycl::access::mode::write>();
+    for (int i = 0; i < size; ++i) {
+      acc[i] = i + 1;
+      expected_res_1[i] = i + 1;
+    }
+  }
+
+  for (int i = 0; i < size / 2; ++i)
+    expected_res_2[i] = expected_res_1[offset + i];
+
+  auto e = Queue.submit([&](cl::sycl::handler &cgh) {
+    auto a =
+        buf_1.get_access<cl::sycl::access::mode::read>(cgh, size / 2, offset);
+    auto b = buf_2.get_access<cl::sycl::access::mode::write>(cgh, size / 2);
+    cgh.copy(a, b);
+  });
+  e.wait();
+
+  {
+    auto acc_1 = buf_1.get_access<cl::sycl::access::mode::read>();
+    auto acc_2 = buf_2.get_access<cl::sycl::access::mode::read>();
+
+    // check that there was no data corruption/loss
+    for (int i = 0; i < size; ++i)
+      assert(expected_res_1[i] == acc_1[i]);
+
+    for (int i = 0; i < size / 2; ++i)
+      assert(expected_res_2[i] == acc_2[i]);
+  }
+
+  cl::sycl::buffer<float, 2> buf_3({size, size});
+  cl::sycl::buffer<float, 2> buf_4({size / 2, size / 2});
+  std::vector<float> expected_res_3(size * size);
+  std::vector<float> expected_res_4(size * size / 4);
+
+  // copy acc 2 acc with offset for 2D buffers
+  {
+    auto acc = buf_3.get_access<cl::sycl::access::mode::write>();
+    for (int i = 0; i < size; ++i) {
+      for (int j = 0; j < size; ++j) {
+        acc[i][j] = i * size + j + 1;
+        expected_res_3[i * size + j] = i * size + j + 1;
+      }
+    }
+  }
+
+  for (int i = 0; i < size / 2; ++i)
+    for (int j = 0; j < size / 2; ++j)
+      expected_res_4[i * size / 2 + j] =
+          expected_res_3[(i + offset) * size + j + offset];
+
+  e = Queue.submit([&](cl::sycl::handler &cgh) {
+    auto a = buf_3.get_access<cl::sycl::access::mode::read>(
+        cgh, {size / 2, size / 2}, {offset, offset});
+    auto b = buf_4.get_access<cl::sycl::access::mode::write>(
+        cgh, {size / 2, size / 2});
+    cgh.copy(a, b);
+  });
+  e.wait();
+
+  {
+    auto acc_1 = buf_3.get_access<cl::sycl::access::mode::read>();
+    auto acc_2 = buf_4.get_access<cl::sycl::access::mode::read>();
+
+    // check that there was no data corruption/loss
+    for (int i = 0; i < size; ++i) {
+      for (int j = 0; j < size; ++j)
+        assert(expected_res_3[i * size + j] == acc_1[i][j]);
+    }
+
+    for (int i = 0; i < size / 2; ++i)
+      for (int j = 0; j < size / 2; ++j)
+        assert(expected_res_4[i * size / 2 + j] == acc_2[i][j]);
+  }
+}
+
+int main() {
+  try {
+    cl::sycl::queue Queue;
+    check_copy_host_to_device(Queue);
+    check_copy_device_to_host(Queue);
+  } catch (cl::sycl::exception &ex) {
+    std::cerr << ex.what() << std::endl;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Case when accessor has a smaller range than buffer causes lost
of initial data after copying data back to host.
The fix is to always copy whole buffer.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>