### PR TITLE
[SYCL] Addition of Image_accessors - get_count() and get_size() metho…

### DIFF
--- a/sycl/include/CL/sycl/detail/image_ocl_types.hpp
+++ b/sycl/include/CL/sycl/detail/image_ocl_types.hpp
@@ -5,30 +5,136 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// This file is to declare the structs with type as appropriate opencl image
-// types based on Dims, AccessMode and AccessTarget.
-// The macros essentially expand to -
-// template <>
-// struct opencl_image_type<1, access::mode::read, access::target::image> {
+// This file is to define some utility functions and declare the structs with
+// type as appropriate opencl image types based on Dims, AccessMode and
+// AccessTarget. The macros essentially expand to -
+//
+// template <> struct
+// opencl_image_type<1, access::mode::read, access::target::image> {
 //   using type = __ocl_image1d_ro_t;
 // };
-// 
+//
 // template <>
 // struct opencl_image_type<1, access::mode::write, access::target::image> {
 //   using type = __ocl_image1d_array_wo_t;
 // };
-// 
+//
 // As an example, this can be
 // used as below:
 // detail::opencl_image_type<2, access::mode::read, access::target::image>::type
 //    MyImage;
 //
+#pragma once
+
+#ifdef __SYCL_DEVICE_ONLY__
+
+#include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/generic_type_traits.hpp>
+
+#define INVOKE_SPIRV_CALL_ARG1(call)                                           \
+  template <typename R, typename T1> inline R __invoke_##call(T1 ParT1) {     \
+    using Ret = cl::sycl::detail::ConvertToOpenCLType_t<R>;                    \
+    extern Ret __spirv_##call(T1);                                             \
+    T1 Arg1 = ParT1;                                                          \
+    Ret RetVar = __spirv_##call(Arg1);                                        \
+    return cl::sycl::detail::convertDataToType<Ret, R>(RetVar);               \
+  }
+
+// The macro defines the function __invoke_ImageXXXX,
+// The functions contains the spirv call to __spirv_ImageXXXX.
+INVOKE_SPIRV_CALL_ARG1(ImageQuerySize)
+INVOKE_SPIRV_CALL_ARG1(ImageQueryFormat)
+INVOKE_SPIRV_CALL_ARG1(ImageQueryOrder)
 
 namespace cl {
 namespace sycl {
 namespace detail {
+
+// Function to return the number of channels for Image Channel Order returned by
+// SPIRV call to OpImageQueryOrder.
+// The returned int value represents an enum from Image Channel Order. The enums
+// for Image Channel Order are mapped differently in sycl and SPIRV spec.
+inline int getSPIRVNumChannels(int ImageChannelOrder) {
+  switch (ImageChannelOrder) {
+  case 0:  // R
+  case 1:  // A
+  case 10: // Rx
+  case 8:  // Intensity
+  case 9:  // Luminance
+    return 1;
+  case 2:  // RG
+  case 3:  // RA
+  case 11: // RGx
+    return 2;
+  case 4:  // RGB
+  case 12: // RGBx
+    return 3;
+  case 5:  // RGBA
+  case 6:  // BGRA
+  case 7:  // ARGB
+  case 19: // ABGR
+    return 4;
+  case 13: // Depth
+  case 14: // DepthStencil
+  case 15: // sRGB
+  case 16: // sRGBx
+  case 17: // sRGBA
+  case 18: // sBGRA
+    // TODO: Enable the below assert after assert is supported for device
+    // compiler. assert(!"Unhandled image channel order in sycl.");
+    return 0;
+  }
+}
+
+// Function to compute the Element Size for a given Image Channel Type and Image
+// Channel Order, returned by SPIRV calls to OpImageQueryFormat and
+// OpImageQueryOrder respectively.
+// The returned int value from OpImageQueryFormat represents an enum from Image
+// Channel Data Type. The enums for Image Channel Data Type are mapped
+// differently in sycl and SPIRV spec.
+inline int getSPIRVElementSize(int ImageChannelType, int ImageChannelOrder) {
+  int NumChannels = getSPIRVNumChannels(ImageChannelOrder);
+  switch (ImageChannelType) {
+  case 0:  // SnormInt8
+  case 2:  // UnormInt8
+  case 7:  // SignedInt8
+  case 10: // UnsignedInt8
+    return NumChannels;
+  case 1:  // SnormInt16
+  case 3:  // UnormInt16
+  case 8:  // SignedInt16
+  case 11: // UnsignedInt16
+  case 13: // HalfFloat
+    return 2 * NumChannels;
+  case 4: // UnormShort565
+  case 5: // UnormShort555
+    return 2;
+  case 6: // UnormInt101010
+    return 4;
+  case 9:  // SignedInt32
+  case 12: // UnsignedInt32
+  case 14: // Float
+    return 4 * NumChannels;
+  case 15: // UnormInt24
+  case 16: // UnormInt101010_2
+  default:
+    // TODO: Enable the below assert after assert is supported for device
+    // compiler. assert(!"Unhandled image channel type in sycl.");
+    return 0;
+  }
+}
+
 template <int Dimensions, access::mode AccessMode, access::target AccessTarget>
 struct opencl_image_type;
+
+// Creation of dummy ocl types for host_image targets.
+// These dummy ocl types are needed by the compiler parser for the compilation
+// of host application code with SYCL_DEVICE_ONLY macro set.
+template <int Dimensions, access::mode AccessMode>
+struct opencl_image_type<Dimensions, AccessMode, access::target::host_image> {
+  using type =
+      opencl_image_type<Dimensions, AccessMode, access::target::host_image> *;
+};
 
 #define IMAGETY_DEFINE(Dim, AccessMode, AMSuffix, Target, Ifarray_)            \
   template <>                                                                  \
@@ -47,6 +153,11 @@ struct opencl_image_type;
   IMAGETY_DEFINE(2, write, wo, image, )                                        \
   IMAGETY_DEFINE(3, write, wo, image, )
 
+#define IMAGETY_DISCARD_WRITE_3_DIM_IMAGE                                      \
+  IMAGETY_DEFINE(1, discard_write, wo, image, )                                \
+  IMAGETY_DEFINE(2, discard_write, wo, image, )                                \
+  IMAGETY_DEFINE(3, discard_write, wo, image, )
+
 #define IMAGETY_READ_2_DIM_IARRAY                                              \
   IMAGETY_DEFINE(1, read, ro, image_array, array_)                             \
   IMAGETY_DEFINE(2, read, ro, image_array, array_)
@@ -55,12 +166,26 @@ struct opencl_image_type;
   IMAGETY_DEFINE(1, write, wo, image_array, array_)                            \
   IMAGETY_DEFINE(2, write, wo, image_array, array_)
 
+#define IMAGETY_DISCARD_WRITE_2_DIM_IARRAY                                     \
+  IMAGETY_DEFINE(1, discard_write, wo, image_array, array_)                    \
+  IMAGETY_DEFINE(2, discard_write, wo, image_array, array_)
+
 IMAGETY_READ_3_DIM_IMAGE
 IMAGETY_WRITE_3_DIM_IMAGE
+IMAGETY_DISCARD_WRITE_3_DIM_IMAGE
 
 IMAGETY_READ_2_DIM_IARRAY
 IMAGETY_WRITE_2_DIM_IARRAY
+IMAGETY_DISCARD_WRITE_2_DIM_IARRAY
 
 } // namespace detail
 } // namespace sycl
 } // namespace cl
+
+#undef INVOKE_SPIRV_CALL_ARG1
+#undef IMAGETY_DEFINE
+#undef IMAGETY_READ_3_DIM_IMAGE
+#undef IMAGETY_WRITE_3_DIM_IMAGE
+#undef IMAGETY_READ_2_DIM_IARRAY
+#undef IMAGETY_WRITE_2_DIM_IARRAY
+#endif //#ifdef __SYCL_DEVICE_ONLY__


### PR DESCRIPTION

Updated Commit Message:

SYCL] Addition of Image_accessors - get_count() and get_size() metho…

…ds for SYCL Device.

- Adds members for image accessor for Device.
- Implementation of init method.
- Implementation of get_size and get_count with calls to spirv APIs:
__spirv_ImageXXXX, include utility functions (__invoke_ImageXXXX) for these calls.
- Addition of __ocl_imagexxx dataypes for access::mode::discard_write.
- Addition of dummy __ocl_imagexxx datatypes for access::target::host_image.
- Addition of operator== and != for common interface functions.
These datatypes are only needed by the compiler front end to check for
syntactical correctness of host application when SYCL_DEVICE_ONLY macro is defined.
TODO : Add test case, after Scheduler code is in.

Signed-off-by: Garima Gupta <garima.gupta@intel.com>
