### PR TITLE
[SYCL] Hierarchical parallelism - code gen for work group scope code and data.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1037,6 +1037,26 @@ def SYCLKernel : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def SYCLScope : Attr {
+  let Spellings = [GNU<"sycl_scope">];
+  let Args = [EnumArgument<"level", "Level", ["work_group", "work_item"],
+                                             ["WorkGroup", "WorkItem"]>];
+  let Subjects = SubjectList<[Function]>;
+  let LangOpts = [SYCLIsDevice];
+
+  let AdditionalMembers = [{
+    bool isWorkGroup() const {
+      return getLevel() == SYCLScopeAttr::WorkGroup;
+    }
+
+    bool isWorkItem() const {
+      return getLevel() == SYCLScopeAttr::WorkItem;
+    }
+  }];
+
+  let Documentation = [Undocumented];
+}
+
 def C11NoReturn : InheritableAttr {
   let Spellings = [Keyword<"_Noreturn">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1038,7 +1038,8 @@ def SYCLKernel : InheritableAttr {
 }
 
 def SYCLScope : Attr {
-  let Spellings = [GNU<"sycl_scope">];
+  // No spelling, as this attribute can't be created in the source code.
+  let Spellings = [];
   let Args = [EnumArgument<"level", "Level", ["work_group", "work_item"],
                                              ["WorkGroup", "WorkItem"]>];
   let Subjects = SubjectList<[Function, Var]>;

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1041,7 +1041,7 @@ def SYCLScope : Attr {
   let Spellings = [GNU<"sycl_scope">];
   let Args = [EnumArgument<"level", "Level", ["work_group", "work_item"],
                                              ["WorkGroup", "WorkItem"]>];
-  let Subjects = SubjectList<[Function]>;
+  let Subjects = SubjectList<[Function, Var]>;
   let LangOpts = [SYCLIsDevice];
 
   let AdditionalMembers = [{

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/CodeGen/BackendUtil.h"
+#include "SYCLLowerIR/LowerWGScope.h"
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/LangOptions.h"
@@ -37,6 +38,7 @@
 #include "llvm/MC/SubtargetFeature.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
+#include "llvm/SYCL/ASFixer.h"
 #include "llvm/Support/BuryPointer.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -70,7 +72,6 @@
 #include "llvm/Transforms/Utils/EntryExitInstrumenter.h"
 #include "llvm/Transforms/Utils/NameAnonGlobals.h"
 #include "llvm/Transforms/Utils/SymbolRewriter.h"
-#include "llvm/SYCL/ASFixer.h"
 #include <memory>
 
 namespace SPIRV {
@@ -819,6 +820,9 @@ void EmitAssemblyHelper::EmitAssembly(BackendAction Action,
   legacy::FunctionPassManager PerFunctionPasses(TheModule);
   PerFunctionPasses.add(
       createTargetTransformInfoWrapperPass(getTargetIRAnalysis()));
+
+  if (LangOpts.SYCLIsDevice)
+    PerModulePasses.add(createSYCLLowerWGScopePass());
 
   CreatePasses(PerModulePasses, PerFunctionPasses);
 

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1308,6 +1308,9 @@ void CodeGenFunction::EmitAutoVarDecl(const VarDecl &D) {
   AutoVarEmission emission = EmitAutoVarAlloca(D);
   EmitAutoVarInit(emission);
   EmitAutoVarCleanups(emission);
+  if (CGM.getLangOpts().SYCLIsDevice)
+    CGM.getSYCLRuntime().actOnAutoVarEmit(
+        *this, D, emission.getOriginalAllocatedAddress().getPointer());
 }
 
 /// Emit a lifetime.begin marker if some criteria are satisfied.

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -16,6 +16,7 @@
 #include "CGDebugInfo.h"
 #include "CGOpenCLRuntime.h"
 #include "CGOpenMPRuntime.h"
+#include "CGSYCLRuntime.h"
 #include "CodeGenFunction.h"
 #include "CodeGenModule.h"
 #include "ConstantEmitter.h"
@@ -188,6 +189,9 @@ void CodeGenFunction::EmitVarDecl(const VarDecl &D) {
   if (D.getType().getAddressSpace() == LangAS::opencl_local)
     return CGM.getOpenCLRuntime().EmitWorkGroupLocalVarDecl(*this, D);
 
+  if (D.getAttr<SYCLScopeAttr>() && D.getAttr<SYCLScopeAttr>()->isWorkGroup())
+    return CGM.getSYCLRuntime().emitWorkGroupLocalVarDecl(*this, D);
+
   assert(D.hasLocalStorage());
   return EmitAutoVarDecl(D);
 }
@@ -320,6 +324,25 @@ static bool hasNontrivialDestruction(QualType T) {
 llvm::GlobalVariable *
 CodeGenFunction::AddInitializerToStaticVarDecl(const VarDecl &D,
                                                llvm::GlobalVariable *GV) {
+  if (getLangOpts().SYCLIsDevice) {
+    auto *Scope = D.getAttr<SYCLScopeAttr>();
+    if (Scope && Scope->isWorkGroup()) {
+      // In SYCL device code globals which represent WG shared local variables
+      // 1) (TODO) must have initializer emitted even if it is constant, because
+      //    LLVM->SPIRV translation does not generate optional initializer for
+      //    WG shared local variables.
+      // 2) must not use guarded init because
+      //   a) guarded init uses exceptions not supported in SYCL device code
+      //   b) initialization is already safe because it happens in WG scope -
+      //      once per WG - by specification, and this will be/ enforced in
+      //       SYCL-specific Clang lowering (LowerWGScope.cpp) after CG.
+      EmitCXXGlobalVarDeclInit(D, GV, /*PerformInit*/ true);
+      // Remove const-ness, otherwise the initializer (a store into the
+      // variable) won't have effect in SPIRV due to "Constant" decoration.
+      GV->setConstant(false);
+      return GV;
+    }
+  }
   ConstantEmitter emitter(*this);
   llvm::Constant *Init = emitter.tryEmitForInitializer(D);
 

--- a/clang/lib/CodeGen/CGSYCLRuntime.cpp
+++ b/clang/lib/CodeGen/CGSYCLRuntime.cpp
@@ -1,0 +1,41 @@
+//===----- CGSYCLRuntime.cpp - Interface to SYCL Runtimes -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This provides custom clang code generation for SYCL.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CGSYCLRuntime.h"
+#include "CodeGenFunction.h"
+#include "clang/AST/Decl.h"
+#include "llvm/IR/Instructions.h"
+#include <assert.h>
+
+using namespace clang;
+using namespace CodeGen;
+
+const char *WG_SCOPE_MD_ID = "work_group_scope";
+const char *WI_SCOPE_MD_ID = "work_item_scope";
+
+bool CGSYCLRuntime::actOnFunctionStart(const FunctionDecl &FD,
+                                       llvm::Function &F) {
+  SYCLScopeAttr *Scope = FD.getAttr<SYCLScopeAttr>();
+  if (!Scope)
+    return false;
+  switch (Scope->getLevel()) {
+  case SYCLScopeAttr::Level::WorkGroup:
+    F.setMetadata(WG_SCOPE_MD_ID, llvm::MDNode::get(F.getContext(), {}));
+    break;
+  case SYCLScopeAttr::Level::WorkItem:
+    F.setMetadata(WI_SCOPE_MD_ID, llvm::MDNode::get(F.getContext(), {}));
+    break;
+  default:
+    llvm_unreachable("unknown sycl scope");
+  }
+  return true;
+}

--- a/clang/lib/CodeGen/CGSYCLRuntime.cpp
+++ b/clang/lib/CodeGen/CGSYCLRuntime.cpp
@@ -19,8 +19,37 @@
 using namespace clang;
 using namespace CodeGen;
 
+/// Various utilities.
+/// TODO partially duplicates functionality from SemaSYCL.cpp, can be shared.
+class Util {
+public:
+  using DeclContextDesc = std::pair<clang::Decl::Kind, StringRef>;
+
+  /// Checks whether given clang type is declared in the given hierarchy of
+  /// declaration contexts.
+  /// \param RecTy      the clang type being checked
+  /// \param Scopes     the declaration scopes leading from the type to the
+  ///     translation unit (excluding the latter)
+  static bool matchQualifiedTypeName(const CXXRecordDecl *RecTy,
+                                     ArrayRef<Util::DeclContextDesc> Scopes);
+};
+
+static bool isPFWI(const FunctionDecl &FD) {
+  const auto *MD = dyn_cast<CXXMethodDecl>(&FD);
+  if (!MD)
+    return false;
+  static std::array<Util::DeclContextDesc, 3> Scopes = {
+      Util::DeclContextDesc{clang::Decl::Kind::Namespace, "cl"},
+      Util::DeclContextDesc{clang::Decl::Kind::Namespace, "sycl"},
+      Util::DeclContextDesc{Decl::Kind::ClassTemplateSpecialization, "group"}};
+  if (!Util::matchQualifiedTypeName(MD->getParent(), Scopes))
+    return false;
+  return FD.getName() == "parallel_for_work_item";
+}
+
 const char *WG_SCOPE_MD_ID = "work_group_scope";
 const char *WI_SCOPE_MD_ID = "work_item_scope";
+const char *PFWI_MD_ID = "parallel_for_work_item";
 
 bool CGSYCLRuntime::actOnFunctionStart(const FunctionDecl &FD,
                                        llvm::Function &F) {
@@ -33,6 +62,10 @@ bool CGSYCLRuntime::actOnFunctionStart(const FunctionDecl &FD,
     break;
   case SYCLScopeAttr::Level::WorkItem:
     F.setMetadata(WI_SCOPE_MD_ID, llvm::MDNode::get(F.getContext(), {}));
+    if (isPFWI(FD))
+      // also emit specific marker for parallel_for_work_item, as it needs to
+      // be handled specially in the SYCL lowering pass
+      F.setMetadata(PFWI_MD_ID, llvm::MDNode::get(F.getContext(), {}));
     break;
   default:
     llvm_unreachable("unknown sycl scope");
@@ -48,5 +81,52 @@ void CGSYCLRuntime::emitWorkGroupLocalVarDecl(CodeGenFunction &CGF,
 #endif // NDEBUG
   // generate global variable in the address space selected by the clang CodeGen
   // (should be local)
-  return CGF.EmitStaticVarDecl(D, llvm::GlobalValue::InternalLinkage);
+  CGF.EmitStaticVarDecl(D, llvm::GlobalValue::InternalLinkage);
+}
+
+bool CGSYCLRuntime::actOnAutoVarEmit(CodeGenFunction &CGF, const VarDecl &D,
+                                     llvm::Value *Addr) {
+  SYCLScopeAttr *Scope = D.getAttr<SYCLScopeAttr>();
+  if (!Scope)
+    return false;
+  assert(Scope->isWorkItem() && "auto var must be of work item scope");
+  auto *AI = dyn_cast<llvm::AllocaInst>(Addr);
+  assert(AI && "AllocaInst expected as local var address");
+  AI->setMetadata(WI_SCOPE_MD_ID, llvm::MDNode::get(AI->getContext(), {}));
+  return true;
+}
+
+bool Util::matchQualifiedTypeName(const CXXRecordDecl *RecTy,
+                                  ArrayRef<Util::DeclContextDesc> Scopes) {
+  // The idea: check the declaration context chain starting from the type
+  // itself. At each step check the context is of expected kind
+  // (namespace) and name.
+  if (!RecTy)
+    return false; // only classes/structs supported
+  const auto *Ctx = dyn_cast<DeclContext>(RecTy);
+  StringRef Name = "";
+
+  for (const auto &Scope : llvm::reverse(Scopes)) {
+    clang::Decl::Kind DK = Ctx->getDeclKind();
+
+    if (DK != Scope.first)
+      return false;
+
+    switch (DK) {
+    case clang::Decl::Kind::ClassTemplateSpecialization:
+      // ClassTemplateSpecializationDecl inherits from CXXRecordDecl
+    case clang::Decl::Kind::CXXRecord:
+      Name = cast<CXXRecordDecl>(Ctx)->getName();
+      break;
+    case clang::Decl::Kind::Namespace:
+      Name = cast<NamespaceDecl>(Ctx)->getName();
+      break;
+    default:
+      llvm_unreachable("matchQualifiedTypeName: decl kind not supported");
+    }
+    if (Name != Scope.second)
+      return false;
+    Ctx = Ctx->getParent();
+  }
+  return Ctx->isTranslationUnit();
 }

--- a/clang/lib/CodeGen/CGSYCLRuntime.cpp
+++ b/clang/lib/CodeGen/CGSYCLRuntime.cpp
@@ -39,3 +39,14 @@ bool CGSYCLRuntime::actOnFunctionStart(const FunctionDecl &FD,
   }
   return true;
 }
+
+void CGSYCLRuntime::emitWorkGroupLocalVarDecl(CodeGenFunction &CGF,
+                                              const VarDecl &D) {
+#ifndef NDEBUG
+  SYCLScopeAttr *Scope = D.getAttr<SYCLScopeAttr>();
+  assert(Scope && Scope->isWorkGroup() && "work group scope expected");
+#endif // NDEBUG
+  // generate global variable in the address space selected by the clang CodeGen
+  // (should be local)
+  return CGF.EmitStaticVarDecl(D, llvm::GlobalValue::InternalLinkage);
+}

--- a/clang/lib/CodeGen/CGSYCLRuntime.h
+++ b/clang/lib/CodeGen/CGSYCLRuntime.h
@@ -1,0 +1,37 @@
+//===----- CGSYCLRuntime.h - Interface to SYCL Runtimes ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This provides custom clang code generation for SYCL.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_CODEGEN_CGSYCLRUNTIME_H
+#define LLVM_CLANG_LIB_CODEGEN_CGSYCLRUNTIME_H
+
+#include "clang/AST/Decl.h"
+#include "llvm/IR/Value.h"
+
+namespace clang {
+namespace CodeGen {
+
+class CodeGenModule;
+
+class CGSYCLRuntime {
+protected:
+  CodeGenModule &CGM;
+
+public:
+  CGSYCLRuntime(CodeGenModule &CGM) : CGM(CGM) {}
+
+  bool actOnFunctionStart(const FunctionDecl &FD, llvm::Function &F);
+};
+
+} // namespace CodeGen
+} // namespace clang
+
+#endif // LLVM_CLANG_LIB_CODEGEN_CGSYCLRUNTIME_H

--- a/clang/lib/CodeGen/CGSYCLRuntime.h
+++ b/clang/lib/CodeGen/CGSYCLRuntime.h
@@ -13,6 +13,8 @@
 #ifndef LLVM_CLANG_LIB_CODEGEN_CGSYCLRUNTIME_H
 #define LLVM_CLANG_LIB_CODEGEN_CGSYCLRUNTIME_H
 
+#include "CodeGenFunction.h"
+
 #include "clang/AST/Decl.h"
 #include "llvm/IR/Value.h"
 
@@ -29,6 +31,7 @@ public:
   CGSYCLRuntime(CodeGenModule &CGM) : CGM(CGM) {}
 
   bool actOnFunctionStart(const FunctionDecl &FD, llvm::Function &F);
+  void emitWorkGroupLocalVarDecl(CodeGenFunction &CGF, const VarDecl &D);
 };
 
 } // namespace CodeGen

--- a/clang/lib/CodeGen/CGSYCLRuntime.h
+++ b/clang/lib/CodeGen/CGSYCLRuntime.h
@@ -32,6 +32,8 @@ public:
 
   bool actOnFunctionStart(const FunctionDecl &FD, llvm::Function &F);
   void emitWorkGroupLocalVarDecl(CodeGenFunction &CGF, const VarDecl &D);
+  bool actOnAutoVarEmit(CodeGenFunction &CGF, const VarDecl &D,
+                        llvm::Value *Addr);
 };
 
 } // namespace CodeGen

--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(SYCLLowerIR)
+
 set(LLVM_LINK_COMPONENTS
   Analysis
   BitReader
@@ -108,4 +110,5 @@ add_clang_library(clangCodeGen
   clangFrontend
   clangLex
   clangSerialization
+  clangSYCLLowerIR
   )

--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -74,6 +74,7 @@ add_clang_library(clangCodeGen
   CGRecordLayoutBuilder.cpp
   CGStmt.cpp
   CGStmtOpenMP.cpp
+  CGSYCLRuntime.cpp
   CGVTT.cpp
   CGVTables.cpp
   CodeGenABITypes.cpp

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -17,6 +17,7 @@
 #include "CGCXXABI.h"
 #include "CGDebugInfo.h"
 #include "CGOpenMPRuntime.h"
+#include "CGSYCLRuntime.h"
 #include "CodeGenModule.h"
 #include "CodeGenPGO.h"
 #include "TargetInfo.h"
@@ -764,8 +765,12 @@ void CodeGenFunction::StartFunction(GlobalDecl GD,
 
   if (getLangOpts().OpenCL || getLangOpts().SYCLIsDevice) {
     // Add metadata for a kernel function.
-    if (const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(D))
+    if (const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(D)) {
       EmitOpenCLKernelMetadata(FD, Fn);
+
+      if (getLangOpts().SYCLIsDevice)
+        CGM.getSYCLRuntime().actOnFunctionStart(*FD, *Fn);
+    }
   }
 
   // If we are checking function types, emit a function type signature as

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3667,6 +3667,10 @@ LangAS CodeGenModule::GetGlobalVarAddressSpace(const VarDecl *D) {
   }
 
   if (LangOpts.SYCLIsDevice) {
+    auto *Scope = D->getAttr<SYCLScopeAttr>();
+
+    if (Scope && Scope->isWorkGroup())
+      return LangAS::opencl_local;
     if (!getenv("DISABLE_INFER_AS")) {
       if (!D || D->getType().getAddressSpace() == LangAS::Default) {
         return LangAS::opencl_global;

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -89,6 +89,7 @@ class CGObjCRuntime;
 class CGOpenCLRuntime;
 class CGOpenMPRuntime;
 class CGCUDARuntime;
+class CGSYCLRuntime;
 class BlockFieldFlags;
 class FunctionArgList;
 class CoverageMappingModuleGen;
@@ -320,6 +321,7 @@ private:
   std::unique_ptr<CGOpenCLRuntime> OpenCLRuntime;
   std::unique_ptr<CGOpenMPRuntime> OpenMPRuntime;
   std::unique_ptr<CGCUDARuntime> CUDARuntime;
+  std::unique_ptr<CGSYCLRuntime> SYCLRuntime;
   std::unique_ptr<CGDebugInfo> DebugInfo;
   std::unique_ptr<ObjCEntrypoints> ObjCData;
   llvm::MDNode *NoObjCARCExceptionsMetadata = nullptr;
@@ -495,6 +497,7 @@ private:
   void createOpenCLRuntime();
   void createOpenMPRuntime();
   void createCUDARuntime();
+  void createSYCLRuntime();
 
   bool isTriviallyRecursive(const FunctionDecl *F);
   bool shouldEmitFunction(GlobalDecl GD);
@@ -589,6 +592,12 @@ public:
   CGCUDARuntime &getCUDARuntime() {
     assert(CUDARuntime != nullptr);
     return *CUDARuntime;
+  }
+
+  /// Return a reference to the configured SYCL runtime.
+  CGSYCLRuntime &getSYCLRuntime() {
+    assert(SYCLRuntime != nullptr);
+    return *SYCLRuntime;
   }
 
   ObjCEntrypoints &getObjCEntrypoints() const {

--- a/clang/lib/CodeGen/SYCLLowerIR/CMakeLists.txt
+++ b/clang/lib/CodeGen/SYCLLowerIR/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+  )
+
+if(NOT CLANG_BUILT_STANDALONE)
+  set(tablegen_deps intrinsics_gen)
+endif()
+
+add_clang_library(clangSYCLLowerIR
+  LowerWGScope.cpp
+
+  DEPENDS
+  ${tablegen_deps}
+
+  LINK_LIBS
+  clangBasic
+  )

--- a/clang/lib/CodeGen/SYCLLowerIR/LowerWGScope.cpp
+++ b/clang/lib/CodeGen/SYCLLowerIR/LowerWGScope.cpp
@@ -1,0 +1,853 @@
+//===-- LowerWGScope.cpp - lower work group scope code and locals ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Simple work group (WG) code and data lowering pass. SYCL specification
+// requires that
+// - the code in the parallel_for_work_group (PFWG) but outside the
+//    parallel_for_work_item (PFWI) (called "work group scope" further here) is
+//    executed once per WG
+// - data declared at the work group scope is shared among work items (WIs) in
+//    a WG.
+// - private_memory<T> data declared at the work group scope remains private per
+//   physical work item and lives across all parallel_for_work_item invocations
+//
+// To enforce this semantics, this pass
+// - inserts "if (get_local_id(0)) == 0" guards ("is leader" guard) to disable
+//   WG-scope code execution in "worker" WIs
+// - transforms allocas in the PFWG lambda function; the function is identified
+//   by the "work_group_scope" string metadata added by the Front End
+//
+// There are 3 kinds of local variables in the PFWG lambda function which are
+// handled differently by the compiler:
+// 1) Local variables of type private_memory<T> declared by the user. FE marks
+//    allocas created for them with "work_item_scope" string metadata.
+// 2) Other local variables declared by the user (shared). Front end turns them
+//    into globals in the local address space - work group shared locals. There
+//    are no allocas for them in the PFWG lambda.
+// 3) Compiler-generated locals:
+//    - the PFWI lambda object (1 per PFWI) which captures variables passed into
+//      the PFWI lambda
+//    - a local copy of the PFWG lambda object parameter passed by value into
+//      the PFWG lambda
+//
+// ** Kind 2: no further transformations are needed for kind 2.
+// ** Kind 3:
+// For a kind 3 variable (alloca w/o metadata) this pass creates a WG-shared
+// local "shadow" variable. Before each PFWI invocation leader WI stores its
+// private copy of the variable into the shadow (under "is leader" guard), then
+// all WIs (ouside of "is leader" guard) load the shadow value into their
+// private copies ("materialize" the private copy). This works becase these
+// variables are uniform - i.e. have the same value in all WIs and are not
+// changed within PFWI. The only exceptions are captures of private_memory
+// isntances - see next.
+// ** Kind 1:
+// Even though WG-scope locals are supposed to be uniform, there is one
+// exception - capture of local of kind 1. It is always captured by non-const
+// reference because as there no
+// 'const T &operator()(const h_item<Dimensions> &id);' which means the result
+// of kind 1 variable's alloca is stored within the PFWI lambda.
+// Materialization of the lambda object value writes result of alloca of the
+// leader WI's private variable into the private copy of the lambda object,
+// which is wrong. So for tese variables this pass adds a write of the private
+// variable's address into the private copy of the lambda object right after its
+// materialization:
+//     if (is_leader())
+//       *PFWI_lambda_obj_shadow_addr = *PFWI_lambda_obj_alloca;
+//     barrier();
+// (1) *PFWI_lambda_obj_alloca = *PFWI_lambda_obj_shadow_addr;
+// (2) PFWI_lambda_obj_alloca->priv_var_addr = priv_var_alloca;
+//     parallel_for_work_item(..., PFWI_lambda_obj_alloca);
+//
+// (1) - materialization of a PFWI object
+// (2) - "fixup" of the private variable address.
+//
+// TODO The approach employed by this pass generates lots of barriers and data
+// copying between private and local memory, which might not be efficient. There
+// are optimization opportunities listed below. Also other aproaches can be
+// considered like
+// "Efficient Fork-Join on GPUs through Warp Specialization" by Arpith C. Jacob
+// et. al.
+//===----------------------------------------------------------------------===//
+
+#include "LowerWGScope.h"
+
+#include "clang/Basic/AddressSpaces.h"
+
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+
+#ifndef NDEBUG
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/GraphWriter.h"
+#endif
+
+using namespace llvm;
+
+#define DEBUG_TYPE "lowerwgcode"
+
+STATISTIC(LocalMemUsed, "amount of additional local memory used for sharing");
+
+static constexpr char WG_SCOPE_MD[] = "work_group_scope";
+static constexpr char WI_SCOPE_MD[] = "work_item_scope";
+static constexpr char PFWI_MD[] = "parallel_for_work_item";
+
+static cl::opt<int> Debug("sycl-lower-wg-debug", llvm::cl::Optional,
+                          llvm::cl::Hidden,
+                          llvm::cl::desc("Debug SYCL work group code lowering"),
+                          llvm::cl::init(10));
+
+namespace {
+class SYCLLowerWGScopeLegacyPass : public FunctionPass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  SYCLLowerWGScopeLegacyPass() : FunctionPass(ID) {
+    initializeSYCLLowerWGScopeLegacyPassPass(*PassRegistry::getPassRegistry());
+  }
+
+  // run the LowerWGScope pass on the specified module
+  bool runOnFunction(Function &F) override {
+    if (skipFunction(F))
+      return false;
+
+    FunctionAnalysisManager FAM;
+    auto PA = Impl.run(F, FAM);
+    return !PA.areAllPreserved();
+  }
+
+private:
+  SYCLLowerWGScopePass Impl;
+};
+} // namespace
+
+char SYCLLowerWGScopeLegacyPass::ID = 0;
+INITIALIZE_PASS(SYCLLowerWGScopeLegacyPass, "LowerWGScope",
+                "Lower Work Group Scope Code", false, false)
+
+// Public interface to the SYCLLowerWGScopePass.
+FunctionPass *llvm::createSYCLLowerWGScopePass() {
+  return new SYCLLowerWGScopeLegacyPass();
+}
+
+template <typename T> static unsigned asUInt(T val) {
+  return static_cast<unsigned>(val);
+}
+
+static IntegerType *getSizeTTy(Module &M) {
+  LLVMContext &Ctx = M.getContext();
+  auto PtrSize = M.getDataLayout().getPointerTypeSize(Type::getInt8PtrTy(Ctx));
+  return PtrSize == 8 ? Type::getInt64Ty(Ctx) : Type::getInt32Ty(Ctx);
+}
+
+// Encaplulates SPIRV-dependent code generation.
+// TODO this should be factored out into a separate project in clang
+namespace spirv {
+// There is no TargetMachine for SPIRV, so define those inline here
+enum class AddrSpace : unsigned {
+  Private = 0,
+  Global = 1,
+  Constant = 2,
+  Local = 3,
+  Generic = 4,
+  Input = 5,
+  Output = 6
+};
+
+enum class Scope : unsigned {
+  CrossDevice = 0,
+  Device = 1,
+  Workgroup = 2,
+  Subgroup = 3,
+  Invocation = 4,
+};
+
+enum class MemorySemantics : unsigned {
+  None = 0x0,
+  Acquire = 0x2,
+  Release = 0x4,
+  AcquireRelease = 0x8,
+  SequentiallyConsistent = 0x10,
+  UniformMemory = 0x40,
+  SubgroupMemory = 0x80,
+  WorkgroupMemory = 0x100,
+  CrossWorkgroupMemory = 0x200,
+  AtomicCounterMemory = 0x400,
+  ImageMemory = 0x800,
+};
+
+Instruction *genWGBarrier(Instruction &Before);
+Value *genLinearLocalID(Instruction &Before);
+Value *createWGLocalVariable(Module &M, Type *T, const Twine &Name);
+} // namespace spirv
+
+static bool isCallToAFuncMarkedWithMD(const Instruction *I, const char *MD) {
+  const CallInst *Call = dyn_cast<CallInst>(I);
+  const Function *F =
+      dyn_cast_or_null<Function>(Call ? Call->getCalledFunction() : nullptr);
+  return F && F->getMetadata(MD);
+}
+
+// Checks is this is a call to parallel_for_work_item.
+static bool isPFWICall(const Instruction *I) {
+  return isCallToAFuncMarkedWithMD(I, PFWI_MD);
+}
+
+// Checks if given instruction must be executed by all work items.
+static bool isWIScopeInst(const Instruction *I) {
+  if (I->isTerminator())
+    return true;
+
+  switch (I->getOpcode()) {
+  case Instruction::Alloca: {
+    llvm_unreachable("allocas must have been skipped");
+    return true;
+  }
+  case Instruction::PHI:
+    llvm_unreachable("PHIs must have been skipped");
+    return true;
+  case Instruction::Call:
+    return isCallToAFuncMarkedWithMD(I, WI_SCOPE_MD);
+  default:
+    return false;
+  }
+}
+
+// Checks if given instruction may have side effects visible outside current
+// work item.
+static bool mayHaveSideEffects(const Instruction *I) {
+  if (I->isTerminator())
+    return false;
+
+  switch (I->getOpcode()) {
+  case Instruction::Alloca:
+    llvm_unreachable("allocas must have been handled");
+    return false;
+  case Instruction::PHI:
+    llvm_unreachable("PHIs must have been skipped");
+    return false;
+  case Instruction::Call:
+    assert(!isPFWICall(I) && "pfwi must have been handled separately");
+    return true;
+  default:
+    return true;
+  }
+}
+
+// Generates control flow which disables execution of TrueBB in worker WIs:
+//   IfBB:
+//     ...
+//     %a = load i64, i64 addrspace(1)* @__spirv_BuiltInLocalInvocationIndex
+//     %b = icmp eq i64 %a, 0
+//     br i1 %b, label %TrueBB, label %MergeBB
+//
+//   TrueBB:
+//     ...
+//     br label %MergeBB
+//
+//   MergeBB:
+//     ...
+// IfBB's terminator instruction is replaced with the branch.
+//
+static void guardBlockWithIsLeaderCheck(BasicBlock *IfBB, BasicBlock *TrueBB,
+                                        BasicBlock *MergeBB,
+                                        const DebugLoc &DbgLoc) {
+  Value *LinearLocalID = spirv::genLinearLocalID(*IfBB->getTerminator());
+  auto *Ty = LinearLocalID->getType();
+  Value *Zero = Constant::getNullValue(Ty);
+  IRBuilder<> Builder(IfBB->getContext());
+  Builder.SetInsertPoint(IfBB->getTerminator());
+  Value *Cmp = Builder.CreateICmpEQ(LinearLocalID, Zero, "cmpz");
+  Builder.SetCurrentDebugLocation(DbgLoc);
+  Builder.CreateCondBr(Cmp, TrueBB, MergeBB);
+  IfBB->getTerminator()->eraseFromParent();
+  assert(TrueBB->getSingleSuccessor() == MergeBB && "CFG tform error");
+}
+
+static void
+shareOutputViaLocalMem(Instruction &I, BasicBlock &BBa, BasicBlock &BBb,
+                       SmallPtrSetImpl<Instruction *> &LeaderScope) {
+
+  SmallPtrSet<Instruction *, 4> Users;
+
+  for (auto User : I.users()) {
+    Instruction *UI = dyn_cast<Instruction>(User);
+    if (!UI || LeaderScope.find(UI) != LeaderScope.end())
+      // not interested in the user if it is within the scope
+      continue;
+    Users.insert(UI);
+  }
+  // Skip instruction w/o uses or if all its uses lie within the scope
+  if (Users.size() == 0)
+    return;
+  LLVMContext &Ctx = I.getContext();
+  Type *T = I.getType();
+  // 1) Create WG local variable
+  Value *WGLocal = spirv::createWGLocalVariable(*I.getModule(), T,
+                                                I.getFunction()->getName() +
+                                                    "WG_" + Twine(I.getName()));
+  // 2) Generate a store of the produced value into the WG local var
+  IRBuilder<> Bld(Ctx);
+  Bld.SetInsertPoint(I.getNextNode());
+  Bld.CreateStore(&I, WGLocal);
+  // 3) Generate a load in the "worker" BB of the value stored by the leader
+  Bld.SetInsertPoint(&BBb.front());
+  auto *WGVal = Bld.CreateLoad(WGLocal, "wg_val_" + Twine(I.getName()));
+  // 4) Finally, replace usages of I ouside the scope
+  for (auto *U : Users)
+    U->replaceUsesOfWith(&I, WGVal);
+}
+
+using InstrRange = std::pair<Instruction *, Instruction *>;
+
+// Input IR, where I1..IN is the range. I1 has uses outside the range:
+//   A
+//   %I1 = ...;
+//   ... USE1(%I1) ...
+//   %IN = ...;
+//   B
+//   ... USE2(%I1) ...
+//
+// Resulting basic blocks:
+// BBa:
+//   A
+//   %linear_id = call get_linear_local_id()
+//   %is_leader = cmp %linear_id, 0
+//   branch %is_leader LeaderBB, BB
+//
+// LeaderBB:
+//   %I1 = ...;
+//   store %I1, @WG_I1
+//   ... USE1(%I1) ...
+//   %IN = ...;
+//   store %IN, @WG_I1
+//   branch BBb
+//
+// BBb:
+//   call WG_control_barrier()
+//   %I1_new = load @WG_I1
+//   ...
+//   B
+//   ... USE2(%I1_new) ...
+static void tformRange(const InstrRange &R) {
+  // Instructions seen between the first and the last
+  SmallPtrSet<Instruction *, 16> Seen;
+  Instruction *FirstSE = R.first;
+  Instruction *LastSE = R.second;
+  LLVM_DEBUG(llvm::dbgs() << "Tform range {\n  " << *FirstSE << "\n  "
+                          << *LastSE << "\n}\n");
+  assert(FirstSE->getParent() == LastSE->getParent() && "invalid range");
+
+  for (auto *I = FirstSE; I != LastSE; I = I->getNextNode())
+    Seen.insert(I);
+  Seen.insert(LastSE);
+
+  BasicBlock *BBa = FirstSE->getParent();
+  BasicBlock *LeaderBB = BBa->splitBasicBlock(FirstSE, "wg_leader");
+  BasicBlock *BBb = LeaderBB->splitBasicBlock(LastSE->getNextNode(), "wg_cf");
+
+  // 1) insert the first "is work group leader" test (at the first split) for
+  //     the worker WIs to detour the side effects instructions
+  guardBlockWithIsLeaderCheck(BBa, LeaderBB, BBb, FirstSE->getDebugLoc());
+
+  // 2) "Share" the output values of the instructions in the range
+  for (auto *I : Seen)
+    shareOutputViaLocalMem(*I, *BBa, *BBb, Seen);
+
+  // 3) Insert work group barrier so that workers further read valid data
+  //    (before the materialization reads inserted at step 2)
+  spirv::genWGBarrier(BBb->front());
+}
+
+namespace {
+using LocalsSet = SmallPtrSet<AllocaInst *, 4>;
+}
+
+static void copyBetweenLocalAndShadow(AllocaInst *L, GlobalVariable *Shadow,
+                                      IRBuilder<> &Builder, bool Loc2Shadow) {
+  Type *T = L->getAllocatedType();
+
+  if (T->isAggregateType()) {
+    auto LocAlign = L->getAlignment();
+    auto ShdAlign = Shadow->getAlignment();
+    Module &M = *L->getModule();
+    auto SizeVal = M.getDataLayout().getTypeStoreSize(T);
+    auto Size = ConstantInt::get(getSizeTTy(M), SizeVal);
+    if (Loc2Shadow)
+      Builder.CreateMemCpy(Shadow, ShdAlign, L, LocAlign, Size);
+    else
+      Builder.CreateMemCpy(L, LocAlign, Shadow, ShdAlign, Size);
+  } else {
+    Value *Src = L;
+    Value *Dst = Shadow;
+
+    if (!Loc2Shadow)
+      std::swap(Src, Dst);
+    Value *LocalVal = Builder.CreateLoad(Src, "mat_ld");
+    Builder.CreateStore(LocalVal, Dst);
+  }
+}
+
+// Performs the following transformation for each basic block in the input map:
+//
+// BB:
+//   some_instructions
+// =>
+// TestBB:
+//   %linear_id = call get_linear_local_id()
+//   %is_leader = cmp %linear_id, 0
+//   branch %is_leader LeaderBB, OriginalBB
+//
+// LeaderBB:
+//   *@Shadow_local1 = *local1
+//   ...
+//   *@Shadow_localN = *localN
+//   branch BB
+//
+// BB:
+//   call WG_control_barrier()
+//   *local1 = *@Shadow_local1
+//   ...
+//   *localN = *@Shadow_localN
+//   some_instructions
+//
+// Where:
+// - local<i> is the set of to-be-materialized locals for OriginalBB taken from
+//   the first input map
+// - @Shadow_local<i> is the shadow workgroup-shared global variable for
+// local<i>,
+//   taken from the second input map
+//
+static void materializeLocalsInWIScopeBlocksImpl(
+    const DenseMap<BasicBlock *, std::unique_ptr<LocalsSet>> &BB2MatLocals,
+    const DenseMap<AllocaInst *, Value *> &Local2Shadow) {
+  for (auto &P : BB2MatLocals) {
+    // generate LeaderBB and local<->shadow copies in proper BBs
+    BasicBlock *LeaderBB = P.first;
+    BasicBlock *BB = LeaderBB->splitBasicBlock(&LeaderBB->front(), "LeaderMat");
+    // Add a barrier to the original block:
+    Instruction *At = spirv::genWGBarrier(*BB->getFirstNonPHI())->getNextNode();
+
+    for (AllocaInst *L : *P.second.get()) {
+      auto MapEntry = Local2Shadow.find(L);
+      assert(MapEntry != Local2Shadow.end() && "local must have a shadow");
+      auto *Shadow = dyn_cast<GlobalVariable>(MapEntry->second);
+      LLVMContext &Ctx = L->getContext();
+      IRBuilder<> Builder(Ctx);
+      // fill the leader BB:
+      // fetch data from leader's private copy (which is always up to date) into
+      // the corresponding shadow variable
+      Builder.SetInsertPoint(&LeaderBB->front());
+      copyBetweenLocalAndShadow(L, Shadow, Builder, true /*local->shadow*/);
+      // store data to the local variable - effectively "refresh" the value of
+      // the local in each work item in the work group
+      Builder.SetInsertPoint(At);
+      copyBetweenLocalAndShadow(L, Shadow, Builder, false /*shadow->local*/);
+    }
+    // now generate the TestBB and the leader WI guard
+    BasicBlock *TestBB =
+        LeaderBB->splitBasicBlock(&LeaderBB->front(), "TestMat");
+    std::swap(TestBB, LeaderBB);
+    guardBlockWithIsLeaderCheck(TestBB, LeaderBB, BB, At->getDebugLoc());
+  }
+}
+
+// Checks if there is a need to materialize value of given local in given work
+// item-scope basic block.
+static bool localMustBeMaterialized(const AllocaInst *L, const BasicBlock &BB) {
+  // TODO this is overly convervative - see speculations below.
+  return true;
+}
+
+// This function handles locals of kind 3 (see comments at the top of file).
+//
+// For each alloca the following transformation is done for each WI scope basic
+// block basic_block10 where the alloca is used:
+//
+//   T *p = alloca(T);
+//   if (is_leader) { use1(p); } // WG scope
+//   ...
+// basic_block10: // WI scope basic block (executed by all WIs)
+//   use2(p);
+// =>
+//   T *p = alloca(T);
+//   if (is_leader) { use1(p); }
+//   ...
+// // p materialization code; note that all locals in the WG scope are uniform
+//   if (is_leader) { *@Shadow_p = *p; } // store actual value of the local
+//   barrier(); // make sure workers wait till the value write above is complete
+//   branch basic_block10;
+// basic_block10: // WI scope basic block
+//   *p = *@Shadow_p; // materialize the value in the local variable before use;
+//                 // maybe skipped for the leader, but does not seem worth it
+//                 // as the leader WI is just a vector lane, so there should be
+//                 // one load per thread (subgroup) anyway.
+//   use2(p);
+//
+// NOTE:
+// Simply redirecting all the p uses (dereferences) in WI scope blocks is not
+// enough in the general case. E.g. consider this example:
+//
+//   T *p = alloca(T);
+//   T *p1 = p+10;
+//   if (is_leader) { use1(p); } // WG scope
+//   ...
+// basic_block10: // WI scope
+//   use2(p1);
+//
+// TODO. This implementation is quite ineffective. Currently it materializes
+// all locals in all WI scope basic blocks.
+// Will be improved incrementally:
+// - For each alloca: determine all derived (via GEPs) pointers and make sure
+//   they don't escape. Then check if there are reads in current WI scope BB
+//   through either of those. If none of them escape and there are no reads then
+//   materialization of this alloca in this BB is not needed.
+// - Materialization is not needed if there is dominating BB with materialized
+//   value, and there are no WG scope writes to this alloca on any path from
+//   that BB to current.
+// - Avoid unnecessary '*p = *@Shadow_p' reloads and redirect p uses them to the
+//   @Shadow_p in case it can be proved it is safe (see note above). Might not
+//   have any noticible effect, though, as reading from Shadow always goes to a
+//   register file anyway.
+//
+void materializeLocalsInWIScopeBlocks(
+    SmallPtrSetImpl<AllocaInst *> &Locals,
+    SmallPtrSetImpl<BasicBlock *> &WIScopeBBs) {
+  // maps local variable to its "shadow" workgroup-shared global:
+  DenseMap<AllocaInst *, Value *> Local2Shadow;
+  // records which locals must be materialized at the beginning of a block:
+  DenseMap<BasicBlock *, std::unique_ptr<LocalsSet>> BB2MatLocals;
+
+  // TODO: iterating over BBs first then over locals would require less
+  // book-keeping with current implementation, but later improvements will need
+  // global info like mapping BBs to locals sets to optimize.
+
+  // Fill the local-to-shadow and basic block-to-locals maps:
+  for (auto L : Locals) {
+    for (auto *BB : WIScopeBBs) {
+      if (!localMustBeMaterialized(L, *BB))
+        continue;
+      if (Local2Shadow.find(L) == Local2Shadow.end()) {
+        // lazily create a "shadow" for current local:
+        Value *Shadow = spirv::createWGLocalVariable(
+            *BB->getModule(), L->getAllocatedType(), "WGCopy");
+        Local2Shadow.insert(std::make_pair(L, Shadow));
+      }
+      auto &MatLocals = BB2MatLocals[BB];
+
+      if (!MatLocals.get()) {
+        // lazily create a locals set for current BB:
+        MatLocals.reset(new LocalsSet());
+      }
+      MatLocals->insert(L);
+    }
+  }
+  // perform the materialization
+  materializeLocalsInWIScopeBlocksImpl(BB2MatLocals, Local2Shadow);
+}
+
+#ifndef NDEBUG
+static void dumpDot(const Function &F, const Twine &Suff) {
+  std::error_code EC;
+  auto FName =
+      ("PFWG_Kernel_" + Suff + "_" + Twine(F.getValueID()) + ".dot").str();
+  raw_fd_ostream File(FName, EC, sys::fs::F_Text);
+
+  if (!EC)
+    WriteGraph(File, (const Function *)&F, false);
+  else
+    errs() << "  error opening file for writing: << " << FName << "\n";
+}
+
+static void dumpIR(const Function &F, const Twine &Suff) {
+  std::error_code EC;
+  auto FName =
+      ("PFWG_Kernel_" + Suff + "_" + Twine(F.getValueID()) + ".ll").str();
+  raw_fd_ostream File(FName, EC, sys::fs::F_Text);
+
+  if (!EC)
+    F.print(File, 0, 1, 1);
+  else
+    errs() << "  error opening file for writing: << " << FName << "\n";
+}
+#endif // NDEBUG
+
+using CaptureDesc = std::pair<AllocaInst *, GetElementPtrInst *>;
+
+// This function handles locals of kind 1 (see comments at the top of file) -
+// captures of private_memory<T> variables. It basically adds (*) instruction in
+// the pattern below.
+//     if (is_leader())
+//       *PFWI_lambda_obj_shadow_addr = *PFWI_lambda_obj_alloca;
+//     barrier();
+//     *PFWI_lambda_obj_alloca = *PFWI_lambda_obj_shadow_addr;
+// (*) PFWI_lambda_obj_alloca->priv_var_addr = priv_var_alloca;
+//     parallel_for_work_item(..., PFWI_lambda_obj_alloca);
+//
+static void fixupPrivateMemoryPFWILambdaCaptures(CallInst *PFWICall) {
+  // Lambda object is always the last argument to the PFWI lambda function:
+  auto NArgs = PFWICall->getNumArgOperands();
+  assert(PFWICall->getNumArgOperands() > 1 && "invalid PFWI call");
+  Value *LambdaObj =
+      PFWICall->getArgOperand(NArgs - 1 /*lambda object parameter*/);
+  // First go through all stores through the LambdaObj pointer - those are
+  // initialization of captures, and for each stored value find its origin -
+  // whether it is an alloca with "work_item_scope"
+  SmallVector<CaptureDesc, 4> PrivMemCaptures;
+
+  for (auto *U : LambdaObj->users()) {
+    GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(U);
+
+    if (!GEP)
+      continue;
+    assert(GEP->hasOneUse());
+    StoreInst *CaptureInit = dyn_cast<StoreInst>(*(GEP->users().begin()));
+
+    if (!CaptureInit)
+      // this can't be private_memory<T> capture, which is always captured by
+      // address via the StoreInst instruction
+      continue;
+    Value *StoredVal = CaptureInit->getValueOperand();
+    // '[=]' capture of a private_memory<T> instance is not permitted, there is
+    // no 'const T &operator()(const h_item<Dimensions> &id);', so compiler
+    // would generate an error; this means captured value is always a pointer -
+    // whether it is private_memory instance or some other type
+    if (!StoredVal->getType()->isPointerTy())
+      continue;
+
+    while (StoredVal && !isa<AllocaInst>(StoredVal)) {
+      if (auto *BC = dyn_cast<BitCastInst>(StoredVal)) {
+        StoredVal = BC->getOperand(0);
+        continue;
+      }
+      if (auto *ASC = dyn_cast<AddrSpaceCastInst>(StoredVal)) {
+        StoredVal = ASC->getOperand(0);
+        continue;
+      }
+      StoredVal = nullptr; // something else is captured
+      break;
+    }
+    auto *AI = dyn_cast_or_null<AllocaInst>(StoredVal);
+
+    // only private_memory allocations (allocas marked with "work_item_scope"
+    // are of interest here:
+    if (!AI || !AI->getMetadata(WI_SCOPE_MD))
+      continue;
+    PrivMemCaptures.push_back(CaptureDesc{AI, GEP});
+  }
+  // now rewrite the captured addresss of a private_memory variables within the
+  // PFWI lambda object:
+  for (auto &C : PrivMemCaptures) {
+    GetElementPtrInst *NewGEP = dyn_cast<GetElementPtrInst>(C.second->clone());
+    NewGEP->insertBefore(PFWICall);
+    IRBuilder<> Bld(PFWICall->getContext());
+    Bld.SetInsertPoint(PFWICall);
+    Value *Val = C.first;
+    auto ValAS = dyn_cast<PointerType>(Val->getType())->getAddressSpace();
+    auto PtrAS = dyn_cast<PointerType>(NewGEP->getResultElementType())
+                     ->getAddressSpace();
+
+    if (ValAS != PtrAS)
+      Val = Bld.CreateAddrSpaceCast(Val, NewGEP->getResultElementType());
+    Bld.CreateStore(Val, NewGEP);
+  }
+}
+
+PreservedAnalyses SYCLLowerWGScopePass::run(Function &F,
+                                            FunctionAnalysisManager &FAM) {
+  if (!F.getMetadata(WG_SCOPE_MD))
+    return PreservedAnalyses::all();
+  bool Changed = false;
+  // Ranges of "side effect" instructions
+  SmallVector<InstrRange, 16> Ranges;
+  SmallPtrSet<AllocaInst *, 16> Allocas;
+  SmallPtrSet<Instruction *, 16> WIScopeInsts;
+  SmallPtrSet<CallInst *, 4> PFWICalls;
+
+  // Collect the ranges which need transformation
+  for (auto &BB : F) {
+    // first and last instructions with side effects, which must be executed
+    // only once per work group:
+    Instruction *First = nullptr;
+    Instruction *Last = nullptr;
+
+    // Skip PHIs and allocas, as they don't have side effects and must never be
+    // guarded with the WG leader test. Note that there should be no allocas in
+    // local address space at this point - they must have been converted to
+    // globals.
+    Instruction *I = BB.getFirstNonPHI();
+
+    for (; I->getOpcode() == Instruction::Alloca; I = I->getNextNode()) {
+      auto *AllocaI = dyn_cast<AllocaInst>(I);
+      // Allocas marked with "work_item_scope" are those originating from
+      // cl::sycl::private_memory<T> variables, which must in private. No
+      // shadows/materialization is needed for them because they can be updated
+      // only within PFWIs
+      if (!AllocaI->getMetadata(WI_SCOPE_MD))
+        Allocas.insert(AllocaI);
+    }
+    for (; I && (I != BB.getTerminator()); I = I->getNextNode()) {
+      if (isWIScopeInst(I)) {
+        if (isPFWICall(I))
+          PFWICalls.insert(dyn_cast<CallInst>(I));
+        WIScopeInsts.insert(I);
+        LLVM_DEBUG(llvm::dbgs() << "+++ Exec by all: " << *I << "\n");
+        // need to split the range here, because the instruction must be
+        // executed by all work items - force range addition
+        if (First) {
+          assert(Last && "range must have been closed 1");
+          Ranges.push_back(InstrRange{First, Last});
+          First = nullptr;
+          Last = nullptr;
+        }
+        continue;
+      }
+      if (!mayHaveSideEffects(I))
+        continue;
+      LLVM_DEBUG(llvm::dbgs() << "+++ Side effects: " << *I << "\n");
+      if (!First)
+        First = I;
+      Last = I;
+    }
+    if (First) {
+      assert(Last && "range must have been closed 2");
+      Ranges.push_back(InstrRange{First, Last});
+    }
+  }
+#ifndef NDEBUG
+  bool HaveChanges = (Ranges.size() > 0) || (Allocas.size() > 0);
+
+  if (HaveChanges && Debug > 1) {
+    dumpIR(F, "before");
+    dumpDot(F, "before");
+  }
+#endif // NDEBUG
+
+  // Perform the transformation
+  for (auto &R : Ranges) {
+    tformRange(R);
+    Changed = true;
+  }
+  // There can be allocas not corresponding to any variable declared in user
+  // code but generated by the compiler - e.g. for non-trivially typed
+  // parameters passed by by value. There can be WG scope stores into such
+  // allocas, which need to be made visible to all WIs. This is done via
+  // creating a "shadow" workgroup-shared variable and using it to propagate
+  // the value of the alloca'ed variable to worker WIs from the leader.
+
+  // First collect WIScope BBs where locals will be materialized:
+  SmallPtrSet<BasicBlock *, 16> WIScopeBBs;
+
+  for (auto *I : WIScopeInsts)
+    WIScopeBBs.insert(I->getParent());
+
+  // Now materialize the locals:
+  materializeLocalsInWIScopeBlocks(Allocas, WIScopeBBs);
+
+  // Fixup captured addresses of private_memory isntances in current WI
+  for (auto *PFWICall : PFWICalls)
+    fixupPrivateMemoryPFWILambdaCaptures(PFWICall);
+
+#ifndef NDEBUG
+  if (HaveChanges && Debug > 0)
+    verifyModule(*F.getParent(), &llvm::errs());
+  if (HaveChanges && Debug > 1) {
+    dumpIR(F, "after");
+    dumpDot(F, "after");
+  }
+#endif // NDEBUG
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}
+
+Value *spirv::createWGLocalVariable(Module &M, Type *T, const Twine &Name) {
+  GlobalVariable *G =
+      new GlobalVariable(M,                              // module
+                         T,                              // type
+                         false,                          // isConstant
+                         GlobalValue::InternalLinkage,   // Linkage
+                         UndefValue::get(T),             // Initializer
+                         Name,                           // Name
+                         nullptr,                        // InsertBefore
+                         GlobalVariable::NotThreadLocal, // ThreadLocalMode
+                         asUInt(spirv::AddrSpace::Local) // AddressSpace
+      );
+  G->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+  const DataLayout &DL = M.getDataLayout();
+  G->setAlignment(DL.getPreferredAlignment(G));
+  LocalMemUsed += DL.getTypeStoreSize(G->getValueType());
+  LLVM_DEBUG(llvm::dbgs() << "Local AS Var created: " << G->getName() << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "  Local mem used: " << LocalMemUsed << "B\n");
+  return G;
+}
+
+// Functions below expose SPIRV translator-specific intrinsics to the use
+// in LLVM IR. Those calls and global references will be translated to
+// corresponding SPIRV operations and builtin variables.
+//
+// TODO generalize to support all SPIRV intrinsic operations and builtin
+//      variables
+
+// extern "C" const __constant size_t __spirv_BuiltInLocalInvocationIndex;
+// Must correspond to the code in
+// llvm-spirv/lib/SPIRV/OCL20ToSPIRV.cpp
+// OCL20ToSPIRV::transWorkItemBuiltinsToVariables()
+Value *spirv::genLinearLocalID(Instruction &Before) {
+  Module &M = *Before.getModule();
+  StringRef Name = "__spirv_BuiltInLocalInvocationIndex";
+  GlobalVariable *G = M.getGlobalVariable(Name);
+
+  if (!G) {
+    Type *T = getSizeTTy(M);
+    G = new GlobalVariable(M,                              // module
+                           T,                              // type
+                           true,                           // isConstant
+                           GlobalValue::ExternalLinkage,   // Linkage
+                           nullptr,                        // Initializer
+                           Name,                           // Name
+                           nullptr,                        // InsertBefore
+                           GlobalVariable::NotThreadLocal, // ThreadLocalMode
+                           // TODO 'Input' crashes CPU Back-End
+                           // asUInt(spirv::AddrSpace::Input) // AddressSpace
+                           asUInt(spirv::AddrSpace::Global) // AddressSpace
+    );
+    unsigned Align = M.getDataLayout().getPreferredAlignment(G);
+    G->setAlignment(Align);
+  }
+  Value *Res = new LoadInst(G, "", &Before);
+  return Res;
+}
+
+// extern void __spirv_ControlBarrier(Scope Execution, Scope Memory,
+//  uint32_t Semantics) noexcept;
+Instruction *spirv::genWGBarrier(Instruction &Before) {
+  Module &M = *Before.getModule();
+  StringRef Name = "__spirv_ControlBarrier";
+  LLVMContext &Ctx = Before.getContext();
+  Type *ScopeTy = Type::getInt32Ty(Ctx);
+  Type *SemanticsTy = Type::getInt32Ty(Ctx);
+  Type *RetTy = Type::getVoidTy(Ctx);
+
+  FunctionCallee FC =
+      M.getOrInsertFunction(Name, RetTy, ScopeTy, ScopeTy, SemanticsTy);
+  assert(FC.getCallee() && "spirv intrinsic creation failed");
+
+  IRBuilder<> Bld(Ctx);
+  Bld.SetInsertPoint(&Before);
+  auto ArgExec = ConstantInt::get(ScopeTy, asUInt(spirv::Scope::Workgroup));
+  auto ArgMem = ConstantInt::get(ScopeTy, asUInt(spirv::Scope::Workgroup));
+  auto ArgSema = ConstantInt::get(
+      ScopeTy, asUInt(spirv::MemorySemantics::SequentiallyConsistent) |
+                   asUInt(spirv::MemorySemantics::WorkgroupMemory));
+  return Bld.CreateCall(FC, {ArgExec, ArgMem, ArgSema});
+}

--- a/clang/lib/CodeGen/SYCLLowerIR/LowerWGScope.h
+++ b/clang/lib/CodeGen/SYCLLowerIR/LowerWGScope.h
@@ -1,0 +1,32 @@
+//===-- LowerWGScope.h - lower work group-scope code ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_LIB_CODEGEN_SYCLLOWERIR_LOWERWGCODE_H
+#define CLANG_LIB_CODEGEN_SYCLLOWERIR_LOWERWGCODE_H
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+/// SPIRV target specific pass to transform work group-scope code to match SIMT
+/// execution model semantics - this code must be executed once per work group.
+class SYCLLowerWGScopePass : public PassInfoMixin<SYCLLowerWGScopePass> {
+public:
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+};
+
+FunctionPass *createSYCLLowerWGScopePass();
+void initializeSYCLLowerWGScopeLegacyPassPass(PassRegistry &);
+
+} // namespace llvm
+
+#endif // CLANG_LIB_CODEGEN_SYCLLOWERIR_LOWERWGCODE_H

--- a/clang/lib/CodeGen/SYCLLowerIR/README.txt
+++ b/clang/lib/CodeGen/SYCLLowerIR/README.txt
@@ -1,0 +1,3 @@
+A collection of SYCL language-specific LLVM IR transformation passes applied to
+the result of clang code generation. They bring the IR to a valid state from
+the SYCL semantics perspective.

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++11 -disable-llvm-passes -triple spir64 -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Functor16 {
 public:

--- a/clang/test/SemaSYCL/no-vtables.cpp
+++ b/clang/test/SemaSYCL/no-vtables.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -x c++ -emit-llvm-only %s
+// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify -fsyntax-only -x c++ -emit-llvm-only %s
 // expected-no-diagnostics
 // Should never fail, since the type is never used in kernel code.
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -548,6 +548,8 @@ public:
   }
 
 #ifdef __SYCL_DEVICE_ONLY__
+  // NOTE: the name of this function - "kernel_single_task" - is used by the
+  // Front End to determine kernel invocation kind.
   template <typename KernelName, typename KernelType>
   __attribute__((sycl_kernel)) void kernel_single_task(KernelType KernelFunc) {
     KernelFunc();
@@ -565,6 +567,8 @@ public:
     KernelFunc(global_id);
   }
 
+  // NOTE: the name of this function - "kernel_parallel_for" - is used by the
+  // Front End to determine kernel invocation kind.
   template <typename KernelName, typename KernelType, int dimensions>
   __attribute__((sycl_kernel)) void kernel_parallel_for(
       typename std::enable_if<std::is_same<detail::lambda_arg_type<KernelType>,
@@ -711,6 +715,8 @@ public:
   }
 
 #ifdef __SYCL_DEVICE_ONLY__
+  // NOTE: the name of this function - "kernel_parallel_for_work_group" - is
+  // used by the Front End to determine kernel invocation kind.
   template <typename KernelName, typename KernelType, int Dims>
   __attribute__((sycl_kernel)) void
   kernel_parallel_for_work_group(KernelType KernelFunc) {

--- a/sycl/test/hier_par/hier_par_basic.cpp
+++ b/sycl/test/hier_par/hier_par_basic.cpp
@@ -9,7 +9,8 @@
 // RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// TODO temporarily disable GPU until regression in Intel Gen driver fixed.
+// R.U.N: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
 // This test checks hierarchical parallelism invocation APIs, but without any
@@ -46,12 +47,70 @@ struct MyStruct {
   int y;
 };
 
+using AccTy = accessor<int, 1, access::mode::read_write,
+                       cl::sycl::access::target::global_buffer>;
+
+struct PFWIFunctor {
+  PFWIFunctor(size_t wg_chunk, size_t wg_size, size_t wg_offset,
+              size_t range_length, int v, AccTy &dev_ptr)
+      : wg_chunk(wg_chunk), wg_size(wg_size), wg_offset(wg_offset),
+        range_length(range_length), v(v), dev_ptr(dev_ptr) {}
+
+  void operator()(h_item<1> i) {
+    // number of buf elements per work item:
+    size_t wi_chunk = (wg_chunk + wg_size - 1) / wg_size;
+    auto id = i.get_physical_local_id().get(0);
+    if (id >= wg_chunk)
+      return;
+    size_t wi_offset = wg_offset + id * wi_chunk;
+    size_t ub = cl::sycl::min(wi_offset + wi_chunk, range_length);
+
+    for (size_t ind = wi_offset; ind < ub; ind++)
+      dev_ptr[ind] += v;
+  }
+
+  size_t wg_chunk;
+  size_t wg_size;
+  size_t wg_offset;
+  size_t range_length;
+  int v;
+  AccTy &dev_ptr;
+};
+
+struct PFWGFunctor {
+  PFWGFunctor(size_t wg_chunk, size_t range_length, int addend, int n_iter,
+              AccTy &dev_ptr)
+      : wg_chunk(wg_chunk), range_length(range_length), dev_ptr(dev_ptr),
+        addend(addend), n_iter(n_iter) {}
+
+  void operator()(group<1> g) {
+    int v = addend; // to check constant initializer works too
+    size_t wg_offset = wg_chunk * g.get_id(0);
+    size_t wg_size = g.get_local_range(0);
+
+    PFWIFunctor PFWI(wg_chunk, wg_size, wg_offset, range_length, v, dev_ptr);
+
+    for (int cnt = 0; cnt < n_iter; cnt++) {
+      g.parallel_for_work_item(PFWI);
+    }
+  }
+  // Dummy operator '()' to make sure compiler can handle multiple '()'
+  // operators/ and pick the right one for PFWG kernel code generation.
+  void operator()(int ind, int val) { dev_ptr[ind] += val; }
+
+  const size_t wg_chunk;
+  const size_t range_length;
+  const int n_iter;
+  const int addend;
+  AccTy dev_ptr;
+};
+
 int main() {
   constexpr int N_WG = 7;
   constexpr int WG_SIZE_PHYSICAL = 3;
   constexpr int WG_SIZE_GREATER_THAN_PHYSICAL = 5;
   constexpr int WG_SIZE_LESS_THAN_PHYSICAL = 2;
-  constexpr int N_ITER = 1;
+  constexpr int N_ITER = 2;
 
   constexpr size_t range_length = N_WG * WG_SIZE_PHYSICAL;
   std::unique_ptr<int> data(new int[range_length]);
@@ -66,6 +125,8 @@ int main() {
               << "\n";
     {
       // Testcase1
+      // - PFWG kernel and PFWI function are represented as functor objects
+      // - PFWG functor contains extra dummy '()' operator
       // - handler::parallel_for_work_group w/o local size specification +
       //   group::parallel_for_work_item w/o flexible range
       // - h_item::get_global_id
@@ -79,32 +140,8 @@ int main() {
         auto dev_ptr = buf.get_access<access::mode::read_write>(cgh);
         // number of 'buf' elements per work group:
         size_t wg_chunk = (range_length + N_WG - 1) / N_WG;
-
-        cgh.parallel_for_work_group<class hpar_simple>(
-            range<1>(N_WG), [=](group<1> g) {
-              int v = addend; // to check constant initializer works too
-              size_t wg_offset = wg_chunk * g.get_id(0);
-              size_t wg_size = g.get_local_range(0);
-
-              // TODO: w/o full hierarchical parallelism implementation
-              // including per-WG code semantics the loop over cnt can't be
-              // used in the test, as cnt is shared and modified by all WIs.
-
-              // for (int cnt = 0; cnt < N_ITER; cnt++) {
-              g.parallel_for_work_item([&](h_item<1> i) {
-                // number of buf elements per work item:
-                size_t wi_chunk = (wg_chunk + wg_size - 1) / wg_size;
-                auto id = i.get_physical_local_id().get(0);
-                if (id >= wg_chunk)
-                  return;
-                size_t wi_offset = wg_offset + id * wi_chunk;
-                size_t ub = cl::sycl::min(wi_offset + wi_chunk, range_length);
-
-                for (size_t ind = wi_offset; ind < ub; ind++)
-                  dev_ptr[ind] += v;
-              });
-              //}
-            });
+        PFWGFunctor PFWG(wg_chunk, range_length, addend, N_ITER, dev_ptr);
+        cgh.parallel_for_work_group(range<1>(N_WG), PFWG);
       });
       auto ptr1 = buf.get_access<access::mode::read>().get_pointer();
       passed &= verify(1, range_length, ptr1,
@@ -123,14 +160,14 @@ int main() {
 
         cgh.parallel_for_work_group<class hpar_flex>(
             range<1>(N_WG), range<1>(WG_SIZE_PHYSICAL), [=](group<1> g) {
-              // for (int cnt = 0; cnt < N_ITER; cnt++) {
-              g.parallel_for_work_item(
-                  range<1>(WG_SIZE_GREATER_THAN_PHYSICAL),
-                  [&](h_item<1> i) { dev_ptr[i.get_global_id(0)]++; });
-              g.parallel_for_work_item(
-                  range<1>(WG_SIZE_LESS_THAN_PHYSICAL),
-                  [&](h_item<1> i) { dev_ptr[i.get_global_id(0)]++; });
-              //}
+              for (int cnt = 0; cnt < N_ITER; cnt++) {
+                g.parallel_for_work_item(
+                    range<1>(WG_SIZE_GREATER_THAN_PHYSICAL),
+                    [&](h_item<1> i) { dev_ptr[i.get_global_id(0)]++; });
+                g.parallel_for_work_item(
+                    range<1>(WG_SIZE_LESS_THAN_PHYSICAL),
+                    [&](h_item<1> i) { dev_ptr[i.get_global_id(0)]++; });
+              }
             });
       });
       auto ptr1 = buf.get_access<access::mode::read>().get_pointer();
@@ -162,16 +199,16 @@ int main() {
 
         cgh.parallel_for_work_group<class hpar_hitem>(
             range<1>(N_WG), range<1>(WG_SIZE_PHYSICAL), [=](group<1> g) {
-              // for (int cnt = 0; cnt < N_ITER; cnt++) {
-              g.parallel_for_work_item(
-                  range<1>(WG_SIZE_GREATER_THAN_PHYSICAL), [&](h_item<1> i) {
-                    int n =
-                        i.get_logical_local_id() == i.get_physical_local_id()
-                            ? 0
-                            : 1;
-                    dev_ptr[i.get_global_id(0)] += n;
-                  });
-              //}
+              for (int cnt = 0; cnt < N_ITER; cnt++) {
+                g.parallel_for_work_item(
+                    range<1>(WG_SIZE_GREATER_THAN_PHYSICAL), [&](h_item<1> i) {
+                      int n =
+                          i.get_logical_local_id() == i.get_physical_local_id()
+                              ? 0
+                              : 1;
+                      dev_ptr[i.get_global_id(0)] += n;
+                    });
+              }
             });
       });
       auto ptr1 = buf.get_access<access::mode::read>().get_pointer();

--- a/sycl/test/hier_par/hier_par_wgscope.cpp
+++ b/sycl/test/hier_par/hier_par_wgscope.cpp
@@ -1,0 +1,276 @@
+//==- hier_par_wgscope.cpp --- hierarchical parallelism test for WG scope---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %clang -std=c++11 -fsycl %s -o %t.out -lOpenCL -lstdc++
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// TODO temporarily disable GPU until regression in Intel Gen driver fixed.
+// R.U.N: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// This test checks correctness of hierarchical kernel execution when there is
+// code and data in the work group scope.
+
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <memory>
+
+using namespace cl::sycl;
+
+// Tests complex patterns of data and code usage at work group scope:
+// - wg scope code and data inside a loop
+// - PFWIs inside complex control flow
+static bool testWgScope(queue &Q) {
+  std::cout << "+++ Testing work group scope code and Data handling...\n";
+  const int MAX_HW_SIMD = 2;
+  const int N_WG = 3;
+  const int PHYS_WG_SIZE = MAX_HW_SIMD + 3;
+  const int FLEX_RANGE_SIZE = PHYS_WG_SIZE + 2;
+  const int N_ITER = 3;
+  const int N_INNER_ITER = 2;
+  const int N_OUTER_ITER = 3;
+  const int RangeLength = N_WG * PHYS_WG_SIZE;
+  const int VAL1 = 10;
+  const int VAL2 = 1000;
+  const int GROUP_ID_SPLIT = 2;
+
+  std::unique_ptr<int> Data(new int[RangeLength]);
+  int *Ptr = Data.get();
+  std::memset(Ptr, 0, RangeLength * sizeof(Ptr[0]));
+
+  try {
+    // 1 element per physical WI:
+    buffer<int, 1> Buf(Ptr, range<1>(RangeLength));
+    int N = N_INNER_ITER;
+
+    Q.submit([&](handler &cgh) {
+      auto DevPtr = Buf.get_access<access::mode::read_write>(cgh);
+
+      cgh.parallel_for_work_group<class hpar_hw>(
+          range<1>(N_WG), range<1>(PHYS_WG_SIZE), [=](group<1> G) {
+            // offset of group'S chunk in the 'DevPtr' array:
+            int GroupOff = PHYS_WG_SIZE * G.get_id(0);
+
+            for (int CntOuter = 0; CntOuter < N_OUTER_ITER; CntOuter++) {
+              // local group-shared array; declared inside a loop
+              int WgShared[PHYS_WG_SIZE];
+
+              // Step 0 - initialize it to VAL1
+              for (int Cnt = 0; Cnt < PHYS_WG_SIZE; Cnt++) {
+                WgShared[Cnt] = VAL1;
+              }
+
+              // Step 1 - increment array elements in each WI
+              G.parallel_for_work_item([&](h_item<1> I) {
+                int Ind = I.get_global_id(0);
+                DevPtr[Ind]++;
+              });
+
+              // only for groups with IDs 0, 1:
+              if (G.get_id(0) < GROUP_ID_SPLIT) {
+                // invoke PFWI in the loop
+                // Step 2a (1) - additionally increment 1 element per group as a
+                //   "side effect" of the increment part
+                for (int Cnt = 0; Cnt < N; Cnt++, DevPtr[GroupOff]++) {
+                  // Step 2a
+                  G.parallel_for_work_item([&](h_item<1> I) {
+                    int Ind = I.get_global_id(0);
+                    //   2a (2) add VAL1 in each physical WI
+                    DevPtr[Ind] += VAL1;
+                    //   2a (3) increment elements of the group-local shared
+                    //   array
+                    WgShared[I.get_local_id(0)]++;
+                  });
+                  // Step 3a - one more per-group increment
+                  DevPtr[GroupOff]++;
+                }
+              }
+              // only for groups with IDs 2 and up:
+              else {
+                // Step 2b - add VAL2 in each logical WI in a flexible range
+                G.parallel_for_work_item(range<1>{FLEX_RANGE_SIZE},
+                                         [&](h_item<1> I) {
+                                           int Ind = I.get_global_id(0);
+                                           DevPtr[Ind] += VAL2;
+                                         });
+              }
+              // Step 4 - store the local shared array into its chunk within the
+              // global array
+              for (int Cnt = 0; Cnt < PHYS_WG_SIZE; Cnt++) {
+                DevPtr[GroupOff + Cnt] += WgShared[Cnt];
+              }
+            }
+          });
+    });
+    Q.wait();
+  } catch (cl::sycl::exception const &E) {
+    std::cout << "SYCL exception caught: " << E.what() << '\n';
+    return 2;
+  }
+  // verify
+  int ErrCnt = 0;
+
+  for (int WG = 0; WG < N_WG; WG++) {
+    for (int WI = 0; WI < PHYS_WG_SIZE; WI++) {
+      int GlobalId = WG * PHYS_WG_SIZE + WI;
+      // Step 0
+      int Gold = VAL1;
+      // Step 1
+      Gold++;
+
+      if (WG < GROUP_ID_SPLIT) {
+        int GoldInner = 0;
+        if (WI == 0)
+          // Step 2a - 1
+          GoldInner++;
+        // Step 2a - 2
+        GoldInner += VAL1;
+        // Step 2a - 3
+        GoldInner++;
+        if (WI == 0)
+          // Step 3a
+          GoldInner++;
+        Gold += GoldInner * N_INNER_ITER;
+      } else {
+        // Step 2b
+        for (int I = 0; I < FLEX_RANGE_SIZE / PHYS_WG_SIZE; I++)
+          Gold += VAL2;
+        if (WI < FLEX_RANGE_SIZE % PHYS_WG_SIZE)
+          Gold += VAL2;
+      }
+      Gold *= N_OUTER_ITER;
+      int Val = Ptr[GlobalId];
+
+      if (Gold != Val) {
+        if (++ErrCnt < 16) {
+          std::cout << "*** ERROR at WG=" << WG << " WI=" << WI << ": " << Val
+                    << " != " << Gold << "(Gold)\n";
+        }
+      }
+    }
+  }
+
+  if (ErrCnt == 0) {
+    std::cout << "  Passed\n";
+    return true;
+  }
+  std::cout << "  Failed. Failure rate: " << ErrCnt << "/" << RangeLength << "("
+            << ErrCnt / (float)RangeLength * 100.f << "%)\n";
+  return false;
+}
+
+template <typename GoldFnTy>
+bool verify(int testcase, int RangeLength, int *Ptr, GoldFnTy get_gold) {
+  int ErrCnt = 0;
+
+  for (int I = 0; I < RangeLength; I++) {
+    int Gold = get_gold(I);
+
+    if (Ptr[I] != Gold) {
+      if (++ErrCnt < 20) {
+        std::cout << testcase << " - ERROR at " << I << ": " << Ptr[I]
+                  << " != " << Gold << "(expected)\n";
+      }
+    }
+  }
+  if (ErrCnt > 0)
+    std::cout << "-- Failure rate: " << ErrCnt << "/" << RangeLength << "("
+              << ErrCnt / (float)RangeLength * 100.f << "%)\n";
+  return ErrCnt == 0;
+}
+
+struct MyStruct {
+  size_t x;
+  size_t y;
+};
+
+// Tests complex private_memory usage:
+// - Data type is a structure
+// - two different variables are used, both are live across two PFWI scopes
+bool testPrivateMemory(queue &Q) {
+  std::cout << "+++ Testing private_memory class implementation...\n";
+  constexpr int N_ITER = 3;
+  constexpr int N_WG = 2;
+  constexpr int WG_X_SIZE = 7;
+  constexpr int WG_Y_SIZE = 3;
+  constexpr int WG_LINEAR_SIZE = WG_X_SIZE * WG_Y_SIZE;
+  constexpr int RangeLength = N_WG * WG_LINEAR_SIZE;
+  constexpr int C1 = 5;
+  constexpr int C2 = 1;
+
+  std::unique_ptr<int> Data(new int[RangeLength]);
+  int *Ptr = Data.get();
+
+  std::memset(Ptr, 0, RangeLength * sizeof(Ptr[0]));
+  buffer<int, 1> Buf(Ptr, range<1>(RangeLength));
+  Q.submit([&](handler &cgh) {
+    auto DevPtr = Buf.get_access<access::mode::read_write>(cgh);
+
+    cgh.parallel_for_work_group<class hpar_priv_mem>(
+        range<2>(N_WG, 1), range<2>(WG_X_SIZE, WG_Y_SIZE), [=](group<2> G) {
+          private_memory<MyStruct, 2> Priv1(G);
+          private_memory<MyStruct, 2> Priv2(G);
+
+          for (int Cnt = 0; Cnt < N_ITER; Cnt++) {
+            G.parallel_for_work_item(
+                range<2>(WG_X_SIZE, WG_Y_SIZE), [&](h_item<2> I) {
+                  auto GlobId = I.get_global().get_linear_id();
+                  DevPtr[GlobId]++;
+                  MyStruct &S1 = Priv1(I);
+                  S1.x = GlobId;
+                  S1.y = C1;
+                  MyStruct &S2 = Priv2(I);
+                  S2.x = C2;
+                  S2.y = GlobId;
+                });
+            G.parallel_for_work_item(range<2>(WG_X_SIZE, WG_Y_SIZE),
+                                     [&](h_item<2> I) {
+                                       MyStruct &S1 = Priv1(I);
+                                       MyStruct &S2 = Priv2(I);
+                                       DevPtr[I.get_global().get_linear_id()] +=
+                                           S1.x + S1.y + S2.x + S2.y;
+                                     });
+          }
+        });
+  });
+  auto Ptr1 = Buf.get_access<access::mode::read>().get_pointer();
+  bool Res = verify(0, RangeLength, Ptr1, [&](int I) -> int {
+    return N_ITER * (1 + C1 + C2 + 2 * I);
+  });
+  std::cout << (Res ? "  Passed\n" : "  FAILED\n");
+  return Res;
+}
+
+int main() {
+  queue Q([](exception_list L) {
+    for (auto ep : L) {
+      try {
+        std::rethrow_exception(ep);
+      } catch (std::exception &E) {
+        std::cout << "*** std exception caught:\n";
+        std::cout << E.what();
+      } catch (cl::sycl::exception const &E1) {
+        std::cout << "*** SYCL exception caught:\n";
+        std::cout << E1.what();
+      }
+    }
+  });
+  std::cout << "Using device: "
+            << Q.get_device().get_info<cl::sycl::info::device::name>() << "\n";
+
+  bool Passed = true;
+  Passed &= testWgScope(Q);
+  Passed &= testPrivateMemory(Q);
+
+  if (!Passed) {
+    std::cout << "FAILED\n";
+    return 1;
+  }
+  std::cout << "Passed\n";
+  return 0;
+}


### PR DESCRIPTION
This concludes the (unoptimized) implementation of the SYCL hierarchical parallelism.

This implementation is also of a limited functionality. Complete functionality will be implement soon. This should be enough to try the feature and pass conformance tests.

The main restriction is that ```group::parallel_for_work_item``` and ```group::wait_for``` must be syntactically immediately nested within the parallel_for_work_group. E.g. the following is not supported yet:
```
void foo(group &g) {
  g.parallel_for_work_item(...);
}

parallel_for_work_group(...,[=](group g) {
  foo(g);
});
```

Main directions for improvement:
- call graph-based analysis which identifies functions invoked from work group scope
- change the work-group scope code generation approach from
   "execute work group scope code under ```if (local_id() == 0)``` except ```parallel_for_work_item```,
     wait_for``` calls and control flow"
  to
   "execute work group scope code normally w/o any guards except code with side effects like stores to
    non-private memory"

In the presence of generic pointers, some stores can be made through a generic pointer, and it can't be (in general case) known in compile time whether it has side-effects or not. So for each store instruction through a generic pointer in a work group scope the following code needs to be generated:

```
*ptr = val;
```
=>
```
bool store_has_no_side_effects = __is_private_pointer(ptr);
if (store_has_no_side_effects || local_id() == 0) {
  *ptr = val;
}
if (!store_has_no_side_effects)
  barrier();
```
where  ```__is_private_pointer``` is a new built-in which tells whether the argument is a private pointer or not, and must be supported by the back-ends. After address space inference pass the ```store_has_no_side_effects``` may become a constant for a better performance.
There can be back-ends which don't support generic pointers, for such back-ends front-end should probably not generate generic pointers (and revert to the inference rules prescribed by SYCL spec?).

I will move this comment to an github issue for further discussion.