### PR TITLE
[SYCL][FPGA] Fix blocking pipes implementation

### DIFF
--- a/llvm-spirv/lib/SPIRV/OCLUtil.cpp
+++ b/llvm-spirv/lib/SPIRV/OCLUtil.cpp
@@ -547,6 +547,16 @@ public:
       addVoidPtrArg(1);
       addUnsignedArg(2);
       addUnsignedArg(3);
+      // OpenCL-like representation of blocking pipes
+    } else if (UnmangledName == "read_pipe_2_bl" ||
+               UnmangledName == "write_pipe_2_bl") {
+      // with 2 arguments (plus two i32 literals):
+      // int read_pipe_bl (read_only pipe gentype p, gentype *ptr)
+      // int write_pipe_bl (write_only pipe gentype p, const gentype *ptr)
+      addVoidPtrArg(1);
+      addUnsignedArg(2);
+      addUnsignedArg(3);
+
     } else if (UnmangledName == "read_pipe_4" ||
                UnmangledName == "write_pipe_4") {
       // with 4 arguments (plus two i32 literals):
@@ -764,7 +774,7 @@ bool isSamplerTy(Type *Ty) {
 
 bool isPipeBI(const StringRef MangledName) {
   return MangledName == "write_pipe_2" || MangledName == "read_pipe_2" ||
-         MangledName == "write_pipe_bl_2" || MangledName == "read_pipe_bl_2" ||
+         MangledName == "write_pipe_2_bl" || MangledName == "read_pipe_2_bl" ||
          MangledName == "write_pipe_4" || MangledName == "read_pipe_4" ||
          MangledName == "reserve_write_pipe" ||
          MangledName == "reserve_read_pipe" ||

--- a/llvm-spirv/lib/SPIRV/OCLUtil.h
+++ b/llvm-spirv/lib/SPIRV/OCLUtil.h
@@ -650,8 +650,8 @@ template <> inline void SPIRVMap<std::string, Op, SPIRVInstruction>::init() {
   // CL 2.0 pipe builtins
   _SPIRV_OP(read_pipe_2, ReadPipe)
   _SPIRV_OP(write_pipe_2, WritePipe)
-  _SPIRV_OP(read_pipe_bl_2, ReadPipeBlockingINTEL)
-  _SPIRV_OP(write_pipe_bl_2, WritePipeBlockingINTEL)
+  _SPIRV_OP(read_pipe_2_bl, ReadPipeBlockingINTEL)
+  _SPIRV_OP(write_pipe_2_bl, WritePipeBlockingINTEL)
   _SPIRV_OP(read_pipe_4, ReservedReadPipe)
   _SPIRV_OP(write_pipe_4, ReservedWritePipe)
   _SPIRV_OP(reserve_read_pipe, ReserveReadPipePackets)

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -2130,8 +2130,8 @@ protected:
 #define _SPIRV_OP(x, ...)                                                      \
   typedef SPIRVInstTemplate<SPIRVBlockingPipesIntelInst, Op##x, __VA_ARGS__>   \
       SPIRV##x;
-_SPIRV_OP(ReadPipeBlockingINTEL, true, 7)
-_SPIRV_OP(WritePipeBlockingINTEL, true, 7)
+_SPIRV_OP(ReadPipeBlockingINTEL, false, 5)
+_SPIRV_OP(WritePipeBlockingINTEL, false, 5)
 #undef _SPIRV_OP
 
 class SPIRVAtomicInstBase : public SPIRVInstTemplateBase {

--- a/llvm-spirv/test/PipeBlocking.ll
+++ b/llvm-spirv/test/PipeBlocking.ll
@@ -15,16 +15,18 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-SPIRV: 2 Capability BlockingPipesINTEL
 ; CHECK-SPIRV: 8 Extension "SPV_INTEL_blocking_pipes"
-; CHECK-SPIRV: 3 TypePipe {{[0-9]+}} 0
-; CHECK-SPIRV: 3 TypePipe {{[0-9]+}} 1
-; CHECK-SPIRV: 7 ReadPipeBlockingINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-; CHECK-SPIRV: 7 WritePipeBlockingINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 3 TypePipe [[PipeRTy:[0-9]+]] 0
+; CHECK-SPIRV: 3 TypePipe [[PipeWTy:[0-9]+]] 1
+; CHECK-SPIRV: 6 Load [[PipeRTy]] [[PipeR:[0-9]+]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 5 ReadPipeBlockingINTEL [[PipeR]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 6 Load [[PipeWTy]] [[PipeW:[0-9]+]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 5 WritePipeBlockingINTEL [[PipeW]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 
 ; CHECK-LLVM: %opencl.pipe_ro_t = type opaque
 ; CHECK-LLVM: %opencl.pipe_wo_t = type opaque
 
-; CHECK-LLVM: %{{[0-9]+}} = call spir_func i32 @__read_pipe_bl_2(%opencl.pipe_ro_t addrspace(1)* %0, i8 addrspace(4)* %{{[0-9]+}}, i32 4, i32 4)
-; CHECK-LLVM: %{{[0-9]+}} = call spir_func i32 @__write_pipe_bl_2(%opencl.pipe_wo_t addrspace(1)* %0, i8 addrspace(4)* %{{[0-9]+}}, i32 4, i32 4)
+; CHECK-LLVM: call spir_func void @__read_pipe_2_bl(%opencl.pipe_ro_t addrspace(1)* %0, i8 addrspace(4)* %{{[0-9]+}}, i32 4, i32 4)
+; CHECK-LLVM: call spir_func void @__write_pipe_2_bl(%opencl.pipe_wo_t addrspace(1)* %0, i8 addrspace(4)* %{{[0-9]+}}, i32 4, i32 4)
 
 ; Function Attrs: convergent noinline nounwind optnone
 define spir_func void @foo(%opencl.pipe_ro_t addrspace(1)* %p, i32 addrspace(1)* %ptr) #0 {
@@ -36,12 +38,12 @@ entry:
   %0 = load %opencl.pipe_ro_t addrspace(1)*, %opencl.pipe_ro_t addrspace(1)** %p.addr, align 8
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %ptr.addr, align 8
   %2 = addrspacecast i32 addrspace(1)* %1 to i8 addrspace(4)*
-  %3 = call spir_func i32 @_Z29__spirv_ReadPipeBlockingINTELIiEi8ocl_pipePT_ii(%opencl.pipe_ro_t addrspace(1)* %0, i8 addrspace(4)* %2, i32 4, i32 4)
+  call spir_func void @_Z29__spirv_ReadPipeBlockingINTELIiEv8ocl_pipePT_ii(%opencl.pipe_ro_t addrspace(1)* %0, i8 addrspace(4)* %2, i32 4, i32 4)
   ret void
 }
 
-declare dso_local spir_func i32 @_Z29__spirv_ReadPipeBlockingINTELIiEi8ocl_pipePT_ii(%opencl.pipe_ro_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
-; CHECK-LLVM: declare spir_func i32 @__read_pipe_bl_2(%opencl.pipe_ro_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
+declare dso_local spir_func void @_Z29__spirv_ReadPipeBlockingINTELIiEv8ocl_pipePT_ii(%opencl.pipe_ro_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
+; CHECK-LLVM: declare spir_func void @__read_pipe_2_bl(%opencl.pipe_ro_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
 
 ; Function Attrs: convergent noinline nounwind optnone
 define spir_func void @boo(%opencl.pipe_wo_t addrspace(1)* %p, i32 addrspace(1)* %ptr) #0 {
@@ -53,12 +55,11 @@ entry:
   %0 = load %opencl.pipe_wo_t addrspace(1)*, %opencl.pipe_wo_t addrspace(1)** %p.addr, align 8
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %ptr.addr, align 8
   %2 = addrspacecast i32 addrspace(1)* %1 to i8 addrspace(4)*
-  %3 = call spir_func i32 @_Z30__spirv_WritePipeBlockingINTELIKiEi8ocl_pipePT_ii(%opencl.pipe_wo_t addrspace(1)* %0, i8 addrspace(4)* %2, i32 4, i32 4)
+  call spir_func void @_Z30__spirv_WritePipeBlockingINTELIKiEv8ocl_pipePT_ii(%opencl.pipe_wo_t addrspace(1)* %0, i8 addrspace(4)* %2, i32 4, i32 4)
   ret void
 }
-
-declare dso_local spir_func i32 @_Z30__spirv_WritePipeBlockingINTELIKiEi8ocl_pipePT_ii(%opencl.pipe_wo_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
-; CHECK-LLVM: declare spir_func i32 @__write_pipe_bl_2(%opencl.pipe_wo_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
+declare dso_local spir_func void @_Z30__spirv_WritePipeBlockingINTELIKiEv8ocl_pipePT_ii(%opencl.pipe_wo_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
+; CHECK-LLVM: declare spir_func void @__write_pipe_2_bl(%opencl.pipe_wo_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
 
 attributes #0 = { convergent noinline nounwind optnone "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 

--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -190,13 +190,13 @@ template <typename dataT>
 extern int32_t __spirv_WritePipe(WPipeTy<dataT> Pipe, dataT *Data,
                                  int32_t Size, int32_t Alignment) noexcept;
 template <typename dataT>
-extern int32_t __spirv_ReadPipeBlockingINTEL(RPipeTy<dataT> Pipe, dataT *Data,
-                                             int32_t Size,
-                                             int32_t Alignment) noexcept;
+extern void __spirv_ReadPipeBlockingINTEL(RPipeTy<dataT> Pipe, dataT *Data,
+                                          int32_t Size,
+                                          int32_t Alignment) noexcept;
 template <typename dataT>
-extern int32_t __spirv_WritePipeBlockingINTEL(WPipeTy<dataT> Pipe, dataT *Data,
-                                              int32_t Size,
-                                              int32_t Alignment) noexcept;
+extern void __spirv_WritePipeBlockingINTEL(WPipeTy<dataT> Pipe, dataT *Data,
+                                           int32_t Size,
+                                           int32_t Alignment) noexcept;
 template <typename dataT>
 extern RPipeTy<dataT> __spirv_CreatePipeFromPipeStorage_read(
     const ConstantPipeStorage *Storage) noexcept;


### PR DESCRIPTION
SPIR-V translator:
1. Restore part of the implementation that was incidentally
removed during recent sync with Khronos repository;
2. Align implementation with the specification:
number of operands should be 5 instead of 7. That means,
that blocking pipe read/write call has no return value.

SYCL headers:
Blocking pipe read/write call must has no return value. 
