### PR TITLE
[SYCL] Fix inefficient code generation on FPGA

### DIFF
--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -49,27 +49,21 @@ extern "C" const __attribute__((ocl_constant)) uint32_t __spirv_BuiltInSubgroupL
   template <int Dim, class DstT> struct InitSizesST##POSTFIX;                  \
                                                                                \
   template <class DstT> struct InitSizesST##POSTFIX<1, DstT> {                 \
-    static void initSize(DstT &Dst) {                                          \
-      Dst[0] = get##POSTFIX<0>();                                              \
-    }                                                                          \
+    static DstT initSize() { return {get##POSTFIX<0>()}; }                     \
   };                                                                           \
                                                                                \
   template <class DstT> struct InitSizesST##POSTFIX<2, DstT> {                 \
-    static void initSize(DstT &Dst) {                                          \
-      Dst[1] = get##POSTFIX<1>();                                              \
-      InitSizesST##POSTFIX<1, DstT>::initSize(Dst);                            \
-    }                                                                          \
+    static DstT initSize() { return {get##POSTFIX<0>(), get##POSTFIX<1>()}; }  \
   };                                                                           \
                                                                                \
   template <class DstT> struct InitSizesST##POSTFIX<3, DstT> {                 \
-    static void initSize(DstT &Dst) {                                          \
-      Dst[2] = get##POSTFIX<2>();                                              \
-      InitSizesST##POSTFIX<2, DstT>::initSize(Dst);                            \
+    static DstT initSize() {                                                   \
+      return {get##POSTFIX<0>(), get##POSTFIX<1>(), get##POSTFIX<2>()};        \
     }                                                                          \
   };                                                                           \
                                                                                \
-  template <int Dims, class DstT> static void init##POSTFIX(DstT &Dst) {       \
-    InitSizesST##POSTFIX<Dims, DstT>::initSize(Dst);                           \
+  template <int Dims, class DstT> static DstT init##POSTFIX() {                \
+    return InitSizesST##POSTFIX<Dims, DstT>::initSize();                       \
   }
 
 namespace __spirv {

--- a/sycl/include/CL/sycl/detail/array.hpp
+++ b/sycl/include/CL/sycl/detail/array.hpp
@@ -1,4 +1,4 @@
-//==-------- array.hpp --- SYCL common iteration object ---------------------==//
+//==-------- array.hpp --- SYCL common iteration object --------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,9 +8,9 @@
 
 #pragma once
 #include <CL/sycl/exception.hpp>
+#include <CL/sycl/detail/type_traits.hpp>
 #include <functional>
 #include <stdexcept>
-#include <type_traits>
 
 namespace cl {
 namespace sycl {
@@ -20,8 +20,28 @@ namespace detail {
 
 template <int dimensions = 1> class array {
   static_assert(dimensions >= 1, "Array cannot be 0-dimensional.");
+
 public:
-  array() : common_array{0} {}
+  /* TODO: use common_array initialization via initialization list in
+   * constructor when memset conversion between SPIR-V and LLVM IR formats
+   * will be fixed in SPIR-V translator. */
+  template <int N = dimensions, detail::enable_if_t<(N == 1), size_t> = 0>
+  array() {
+    common_array[0] = 0;
+  }
+
+  template <int N = dimensions, detail::enable_if_t<(N == 2), size_t> = 0>
+  array() {
+    common_array[0] = 0;
+    common_array[1] = 0;
+  }
+
+  template <int N = dimensions, detail::enable_if_t<(N == 3), size_t> = 0>
+  array() {
+    common_array[0] = 0;
+    common_array[1] = 0;
+    common_array[2] = 0;
+  }
 
   /* The following constructor is only available in the array struct
    * specialization where: dimensions==1 */

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -130,15 +130,14 @@ public:
     // compilers are expected to optimize when possible
     detail::workGroupBarrier();
 #ifdef __SYCL_DEVICE_ONLY__
-    range<dimensions> GlobalSize;
-    range<dimensions> LocalSize;
-    id<dimensions> GlobalId;
-    id<dimensions> LocalId;
-
-    __spirv::initGlobalSize<dimensions>(GlobalSize);
-    __spirv::initWorkgroupSize<dimensions>(LocalSize);
-    __spirv::initGlobalInvocationId<dimensions>(GlobalId);
-    __spirv::initLocalInvocationId<dimensions>(LocalId);
+    range<dimensions> GlobalSize{
+        __spirv::initGlobalSize<dimensions, range<dimensions>>()};
+    range<dimensions> LocalSize{
+        __spirv::initWorkgroupSize<dimensions, range<dimensions>>()};
+    id<dimensions> GlobalId{
+        __spirv::initGlobalInvocationId<dimensions, id<dimensions>>()};
+    id<dimensions> LocalId{
+        __spirv::initLocalInvocationId<dimensions, id<dimensions>>()};
 
     // no 'iterate' in the device code variant, because
     // (1) this code is already invoked by each work item as a part of the
@@ -181,15 +180,14 @@ public:
                               WorkItemFunctionT Func) const {
     detail::workGroupBarrier();
 #ifdef __SYCL_DEVICE_ONLY__
-    range<dimensions> GlobalSize;
-    range<dimensions> LocalSize;
-    id<dimensions> GlobalId;
-    id<dimensions> LocalId;
-
-    __spirv::initGlobalSize<dimensions>(GlobalSize);
-    __spirv::initWorkgroupSize<dimensions>(LocalSize);
-    __spirv::initGlobalInvocationId<dimensions>(GlobalId);
-    __spirv::initLocalInvocationId<dimensions>(LocalId);
+    range<dimensions> GlobalSize{
+        __spirv::initGlobalSize<dimensions, range<dimensions>>()};
+    range<dimensions> LocalSize{
+        __spirv::initWorkgroupSize<dimensions, range<dimensions>>()};
+    id<dimensions> GlobalId{
+        __spirv::initGlobalInvocationId<dimensions, id<dimensions>>()};
+    id<dimensions> LocalId{
+        __spirv::initLocalInvocationId<dimensions, id<dimensions>>()};
 
     item<dimensions, false> GlobalItem =
         detail::Builder::createItem<dimensions, false>(GlobalSize, GlobalId);

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -571,9 +571,8 @@ public:
                                            id<dimensions>>::value &&
                                   (dimensions > 0 && dimensions < 4),
                               KernelType>::type KernelFunc) {
-    id<dimensions> global_id;
-
-    __spirv::initGlobalInvocationId<dimensions>(global_id);
+    id<dimensions> global_id{
+        __spirv::initGlobalInvocationId<dimensions, id<dimensions>>()};
 
     KernelFunc(global_id);
   }
@@ -584,11 +583,10 @@ public:
                                            item<dimensions>>::value &&
                                   (dimensions > 0 && dimensions < 4),
                               KernelType>::type KernelFunc) {
-    id<dimensions> global_id;
-    range<dimensions> global_size;
-
-    __spirv::initGlobalInvocationId<dimensions>(global_id);
-    __spirv::initGlobalSize<dimensions>(global_size);
+    id<dimensions> global_id{
+        __spirv::initGlobalInvocationId<dimensions, id<dimensions>>()};
+    range<dimensions> global_size{
+        __spirv::initGlobalSize<dimensions, range<dimensions>>()};
 
     item<dimensions, false> Item =
         detail::Builder::createItem<dimensions, false>(global_size, global_id);
@@ -601,19 +599,18 @@ public:
                                            nd_item<dimensions>>::value &&
                                   (dimensions > 0 && dimensions < 4),
                               KernelType>::type KernelFunc) {
-    range<dimensions> global_size;
-    range<dimensions> local_size;
-    id<dimensions> group_id;
-    id<dimensions> global_id;
-    id<dimensions> local_id;
-    id<dimensions> global_offset;
-
-    __spirv::initGlobalSize<dimensions>(global_size);
-    __spirv::initWorkgroupSize<dimensions>(local_size);
-    __spirv::initWorkgroupId<dimensions>(group_id);
-    __spirv::initGlobalInvocationId<dimensions>(global_id);
-    __spirv::initLocalInvocationId<dimensions>(local_id);
-    __spirv::initGlobalOffset<dimensions>(global_offset);
+    range<dimensions> global_size{
+        __spirv::initGlobalSize<dimensions, range<dimensions>>()};
+    range<dimensions> local_size{
+        __spirv::initWorkgroupSize<dimensions, range<dimensions>>()};
+    id<dimensions> group_id{
+        __spirv::initWorkgroupId<dimensions, id<dimensions>>()};
+    id<dimensions> global_id{
+        __spirv::initGlobalInvocationId<dimensions, id<dimensions>>()};
+    id<dimensions> local_id{
+        __spirv::initLocalInvocationId<dimensions, id<dimensions>>()};
+    id<dimensions> global_offset{
+        __spirv::initGlobalOffset<dimensions, id<dimensions>>()};
 
     group<dimensions> Group = detail::Builder::createGroup<dimensions>(
         global_size, local_size, group_id);
@@ -730,13 +727,9 @@ public:
   __attribute__((sycl_kernel)) void
   kernel_parallel_for_work_group(KernelType KernelFunc) {
 
-    range<Dims> GlobalSize;
-    range<Dims> LocalSize;
-    id<Dims> GroupId;
-
-    __spirv::initGlobalSize<Dims>(GlobalSize);
-    __spirv::initWorkgroupSize<Dims>(LocalSize);
-    __spirv::initWorkgroupId<Dims>(GroupId);
+    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
+    range<Dims> LocalSize{__spirv::initWorkgroupSize<Dims, range<Dims>>()};
+    id<Dims> GroupId{__spirv::initWorkgroupId<Dims, id<Dims>>()};
 
     group<Dims> G =
         detail::Builder::createGroup<Dims>(GlobalSize, LocalSize, GroupId);


### PR DESCRIPTION
The default descriptor for cl::sycl::detail::array initializes the value to 0:
  array() : common_array{0} {}
If local variable of cl::sycl::detail::array or inherited class is defined
without initialization this leads to automatical generation of loops
to initialize each element of array with 0. These loops are not automatically
unrolled on the FPGA.

The fix is to declare constructor with appropriate initialization list
explicitly and eliminate definition of cl::sycl::detail::array or inherited
class variables without initialization.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>