### PR TITLE
[SYCL] Use llvm-objcopy for creating fat object files

### DIFF
--- a/clang/test/Driver/clang-offload-bundler.c
+++ b/clang/test/Driver/clang-offload-bundler.c
@@ -230,12 +230,9 @@
 // tests.
 //
 
-// RUN: clang-offload-bundler -type=o -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -inputs=%t.o,%t.tgt1,%t.tgt2 -outputs=%t.bundle3.o -### -dump-temporary-files 2>&1 \
+// RUN: clang-offload-bundler -type=o -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -inputs=%t.o,%t.tgt1,%t.tgt2 -outputs=%t.bundle3.o -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix CK-OBJ-CMD
-// CK-OBJ-CMD: private constant [1 x i8] zeroinitializer, section "__CLANG_OFFLOAD_BUNDLE__host-powerpc64le-ibm-linux-gnu"
-// CK-OBJ-CMD: private constant [{{[0-9]+}} x i8] c"Content of device file 1{{.+}}", section "__CLANG_OFFLOAD_BUNDLE__openmp-powerpc64le-ibm-linux-gnu"
-// CK-OBJ-CMD: private constant [{{[0-9]+}} x i8] c"Content of device file 2{{.+}}", section "__CLANG_OFFLOAD_BUNDLE__openmp-x86_64-pc-linux-gnu"
-// CK-OBJ-CMD: clang{{(.exe)?}}" "-r" "-target" "powerpc64le-ibm-linux-gnu" "-o" "{{.+}}.o" "{{.+}}.o" "{{.+}}.bc" "-nostdlib"
+// CK-OBJ-CMD: llvm-objcopy{{(.exe)?}}" "--add-section=__CLANG_OFFLOAD_BUNDLE__host-powerpc64le-ibm-linux-gnu={{.+}}.tmp" "--add-section=__CLANG_OFFLOAD_BUNDLE_SIZE__host-powerpc64le-ibm-linux-gnu={{.+}}.tmp" "--add-section=__CLANG_OFFLOAD_BUNDLE__openmp-powerpc64le-ibm-linux-gnu={{.+}}.tgt1" "--add-section=__CLANG_OFFLOAD_BUNDLE_SIZE__openmp-powerpc64le-ibm-linux-gnu={{.+}}.tmp" "--add-section=__CLANG_OFFLOAD_BUNDLE__openmp-x86_64-pc-linux-gnu={{.+}}.tgt2" "--add-section=__CLANG_OFFLOAD_BUNDLE_SIZE__openmp-x86_64-pc-linux-gnu={{.+}}.tmp" "{{.+}}.o" "{{.+}}.bundle3.o"
 
 // RUN: clang-offload-bundler -type=o -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.res.o,%t.res.tgt1,%t.res.tgt2 -inputs=%t.2.o -unbundle
 // RUN: diff %t.2.o %t.res.o

--- a/clang/tools/clang-offload-bundler/CMakeLists.txt
+++ b/clang/tools/clang-offload-bundler/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LLVM_LINK_COMPONENTS BitWriter Core Object Support)
+set(LLVM_LINK_COMPONENTS Object Support)
 
 if(NOT CLANG_BUILT_STANDALONE)
   set(tablegen_deps intrinsics_gen)

--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -21,12 +21,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Triple.h"
-#include "llvm/Bitcode/BitcodeWriter.h"
-#include "llvm/IR/Constant.h"
-#include "llvm/IR/Constants.h"
-#include "llvm/IR/GlobalVariable.h"
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Module.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/Casting.h"
@@ -97,10 +91,10 @@ static cl::opt<bool> PrintExternalCommands(
              "instead of actually executing them - for testing purposes.\n"),
     cl::init(false), cl::cat(ClangOffloadBundlerCategory));
 
-static cl::opt<bool> DumpTemporaryFiles(
-    "dump-temporary-files",
-    cl::desc("Dumps any temporary files created - for testing purposes.\n"),
-    cl::init(false), cl::cat(ClangOffloadBundlerCategory));
+static cl::opt<bool>
+    SaveTemporaryFiles("save-temps",
+                       cl::desc("Saves intermediate temporary files.\n"),
+                       cl::init(false), cl::cat(ClangOffloadBundlerCategory));
 
 /// Magic string that marks the existence of offloading data.
 #define OFFLOAD_BUNDLER_MAGIC_STR "__CLANG_OFFLOAD_BUNDLE__"
@@ -121,12 +115,6 @@ static void getOffloadKindAndTriple(StringRef Target, StringRef &OffloadKind,
   auto KindTriplePair = Target.split('-');
   OffloadKind = KindTriplePair.first;
   Triple = KindTriplePair.second;
-}
-static StringRef getTriple(StringRef Target) {
-  StringRef OffloadKind;
-  StringRef Triple;
-  getOffloadKindAndTriple(Target, OffloadKind, Triple);
-  return Triple;
 }
 static bool hasHostKind(StringRef Target) {
   StringRef OffloadKind;
@@ -499,11 +487,6 @@ class ObjectFileHandler final : public FileHandler {
     return true;
   }
 
-  /// \return LLVM type representing an ELF section size.
-  static inline Type *getSectionSizeTy(LLVMContext &C) {
-    return Type::getInt64Ty(C);
-  }
-
   /// Total number of inputs.
   unsigned NumberOfInputs = 0;
 
@@ -511,18 +494,8 @@ class ObjectFileHandler final : public FileHandler {
   /// read from the buffers.
   unsigned NumberOfProcessedInputs = 0;
 
-  /// LLVM context used to create the auxiliary modules.
-  LLVMContext VMContext;
-
-  /// LLVM module used to create an object with all the bundle
-  /// components.
-  std::unique_ptr<Module> AuxModule;
-
-  /// The current triple we are working with.
-  StringRef CurrentTriple;
-
-  /// The name of the main input file.
-  StringRef MainInputFileName;
+  /// Input sizes.
+  SmallVector<uint64_t, 16u> InputSizes;
 
 public:
   ObjectFileHandler(std::unique_ptr<ObjectFile> ObjIn)
@@ -559,8 +532,8 @@ public:
           consumeError(Content.takeError());
           return;
         }
-        unsigned int ElemSize =
-            getSectionSizeTy(VMContext)->getPrimitiveSizeInBits() / 8;
+        unsigned int ElemSize = sizeof(uint64_t);
+
         // the size of the size section must be a multiple of ElemSize
         if (Content->size() % ElemSize != 0)
           report_fatal_error(
@@ -710,18 +683,14 @@ public:
     // Record number of inputs.
     NumberOfInputs = Inputs.size();
 
-    // Create an LLVM module to have the content we need to bundle.
-    auto *M = new Module("clang-offload-bundle", VMContext);
-    M->setTargetTriple(getTriple(TargetNames[HostInputIndex]));
-    AuxModule.reset(M);
+    // And input sizes.
+    for (unsigned I = 0; I < NumberOfInputs; ++I)
+      InputSizes.push_back(I == HostInputIndex ? 1u
+                                               : Inputs[I]->getBufferSize());
   }
 
   void WriteBundleStart(raw_fd_ostream &OS, StringRef TargetTriple) final {
     ++NumberOfProcessedInputs;
-
-    // Record the triple we are using, that will be used to name the section we
-    // will create.
-    CurrentTriple = TargetTriple;
   }
 
   bool WriteBundleEnd(raw_fd_ostream &OS, StringRef TargetTriple) final {
@@ -733,76 +702,96 @@ public:
     if (NumberOfProcessedInputs != NumberOfInputs)
       return false;
 
-    // Create the bitcode file name to write the resulting code to. Keep it if
-    // save-temps is active.
-    SmallString<128> BitcodeFileName;
-    if (sys::fs::createTemporaryFile("clang-offload-bundler", "bc",
-                                     BitcodeFileName)) {
-      errs() << "error: unable to create temporary file.\n";
+    // Find llvm-objcopy in order to create the bundle binary.
+    auto Objcopy = sys::findProgramByName(
+        "llvm-objcopy", sys::path::parent_path(BundlerExecutable));
+    if (Objcopy.getError()) {
+      errs() << "error: unable to find 'llvm-objcopy' in path.\n";
       return true;
     }
 
-    // Dump the contents of the temporary file if that was requested.
-    if (DumpTemporaryFiles) {
-      errs() << ";\n; Object file bundler IR file.\n;\n";
-      AuxModule.get()->print(errs(), nullptr,
-                             /*ShouldPreserveUseListOrder=*/false,
-                             /*IsForDebug=*/true);
-      errs() << '\n';
-    }
-
-    // Find clang in order to create the bundle binary.
-    StringRef Dir = sys::path::parent_path(BundlerExecutable);
-
-    auto ClangBinary = sys::findProgramByName("clang", Dir);
-    if (ClangBinary.getError()) {
-      // Remove bitcode file.
-      sys::fs::remove(BitcodeFileName);
-
-      errs() << "error: unable to find 'clang' in path.\n";
-      return true;
-    }
-
-    // Do the incremental linking. We write to the output file directly. So, we
-    // close it and use the name to pass down to clang.
+    // We write to the output file directly. So, we close it and use the name
+    // to pass down to llvm-objcopy.
     OS.close();
-    SmallString<128> TargetName = getTriple(TargetNames[HostInputIndex]);
-    std::vector<StringRef> ClangArgs = {"clang",
-                                        "-r",
-                                        "-target",
-                                        TargetName.c_str(),
-                                        "-o",
-                                        OutputFileNames.front().c_str(),
-                                        InputFileNames[HostInputIndex].c_str(),
-                                        BitcodeFileName.c_str(),
-                                        "-nostdlib"};
+
+    // Temp files that need to be removed.
+    struct Dummy : public SmallVector<std::string, 8u> {
+      ~Dummy() {
+        if (!SaveTemporaryFiles)
+          for (const auto &File : *this)
+            sys::fs::remove(File);
+        clear();
+      }
+    } TempFiles;
+
+    // Helper lambda that creates temporary file with given contents.
+    auto CreateTempFile =
+        [&TempFiles](ArrayRef<char> Contents) -> Optional<std::string> {
+      SmallString<128u> FileName;
+      if (sys::fs::createTemporaryFile("clang-offload-bundler", "tmp",
+                                       FileName)) {
+        errs() << "error: unable to create temporary file.\n";
+        return {};
+      }
+
+      TempFiles.push_back(FileName.c_str());
+
+      std::error_code EC;
+      raw_fd_ostream HostFile(FileName, EC);
+      if (EC) {
+        errs() << "can't open file for writing" << FileName << ": "
+               << EC.message() << "\n";
+        return {};
+      }
+      HostFile.write(Contents.data(), Contents.size());
+      return TempFiles.back();
+    };
+
+    // Create temp file with zero char for the host object section.
+    char Byte[] = {0};
+    auto DummyHostFile = CreateTempFile(Byte);
+    if (!DummyHostFile)
+      return true;
+
+    // Compose command line for the objcopy tool.
+    SmallVector<std::string, 16u> ObjcopyArgs = {"llvm-objcopy"};
+    for (unsigned I = 0; I < NumberOfInputs; ++I) {
+      const auto &Triple = TargetNames[I];
+      const auto &InputFile =
+          I == HostInputIndex ? DummyHostFile.getValue() : InputFileNames[I];
+
+      // Add section with target object.
+      ObjcopyArgs.push_back(std::string("--add-section=") +
+                            OFFLOAD_BUNDLER_MAGIC_STR + Triple + "=" +
+                            InputFile);
+
+      // Create temporary file with the section size contents.
+      auto SizeFile = CreateTempFile(makeArrayRef(
+          reinterpret_cast<char *>(&InputSizes[I]), sizeof(InputSizes[I])));
+      if (!SizeFile)
+        return true;
+
+      // And add one more section with target object size.
+      ObjcopyArgs.push_back(std::string("--add-section=") +
+                            SIZE_SECTION_PREFIX + Triple + "=" +
+                            SizeFile.getValue());
+    }
+
+    ObjcopyArgs.push_back(InputFileNames[HostInputIndex]);
+    ObjcopyArgs.push_back(OutputFileNames.front());
 
     // If the user asked for the commands to be printed out, we do that instead
     // of executing it.
     if (PrintExternalCommands) {
-      errs() << "\"" << ClangBinary.get() << "\"";
-      for (StringRef Arg : ClangArgs)
+      errs() << "\"" << Objcopy.get() << "\"";
+      for (StringRef Arg : ObjcopyArgs)
         errs() << " \"" << Arg << "\"";
       errs() << "\n";
     } else {
-      // Write the bitcode contents to the temporary file.
-      {
-        std::error_code EC;
-        raw_fd_ostream BitcodeFile(BitcodeFileName, EC, sys::fs::F_None);
-        if (EC) {
-          errs() << "error: unable to open temporary file.\n";
-          return true;
-        }
-        WriteBitcodeToFile(*AuxModule, BitcodeFile);
-      }
-
-      bool Failed = sys::ExecuteAndWait(ClangBinary.get(), ClangArgs);
-
-      // Remove bitcode file.
-      sys::fs::remove(BitcodeFileName);
-
-      if (Failed) {
-        errs() << "error: incremental linking by external tool failed.\n";
+      SmallVector<StringRef, 16u> Args;
+      copy(ObjcopyArgs, std::back_inserter(Args));
+      if (sys::ExecuteAndWait(Objcopy.get(), Args)) {
+        errs() << "error: llvm-objcopy tool failed.\n";
         return true;
       }
     }
@@ -810,50 +799,7 @@ public:
     return false;
   }
 
-  void WriteBundle(raw_fd_ostream &OS, MemoryBuffer &Input) final {
-    Module *M = AuxModule.get();
-
-    // Create the new section name, it will consist of the reserved prefix
-    // concatenated with the triple.
-    std::string SectionName = OFFLOAD_BUNDLER_MAGIC_STR;
-    SectionName += CurrentTriple;
-
-    // Create the constant with the content of the section. For the input we are
-    // bundling into (the host input), this is just a place-holder, so a single
-    // byte is sufficient.
-    assert(HostInputIndex != ~0u && "Host input index undefined??");
-    Constant *Content;
-
-    if (NumberOfProcessedInputs == HostInputIndex + 1) {
-      uint8_t Byte[] = {0};
-      Content = ConstantDataArray::get(VMContext, Byte);
-    } else
-      Content = ConstantDataArray::get(
-          VMContext, ArrayRef<uint8_t>(reinterpret_cast<const uint8_t *>(
-                                           Input.getBufferStart()),
-                                       Input.getBufferSize()));
-
-    // Create the global in the desired section. We don't want these globals in
-    // the symbol table, so we mark them private.
-    auto *GV = new GlobalVariable(*M, Content->getType(), /*IsConstant=*/true,
-                                  GlobalVariable::PrivateLinkage, Content);
-    GV->setSection(SectionName);
-    // Set alignment to 1 to avoid gaps between concatenated sections after
-    // linkage of a number of fat objects:
-    GV->setAlignment(1);
-
-    // Now add a section with the data section size
-    ConstantDataArray *CDA = reinterpret_cast<ConstantDataArray *>(Content);
-    auto *BufSize =
-        ConstantInt::get(getSectionSizeTy(VMContext),
-                         CDA->getNumElements() * CDA->getElementByteSize());
-    auto *SizeV =
-        new GlobalVariable(*M, Type::getInt64Ty(VMContext), /*IsConstant=*/true,
-                           GlobalVariable::PrivateLinkage, BufSize);
-    SizeV->setSection(
-        (Twine(SIZE_SECTION_PREFIX) + Twine(CurrentTriple)).str());
-    SizeV->setAlignment(1);
-  }
+  void WriteBundle(raw_fd_ostream &OS, MemoryBuffer &Input) final {}
 };
 
 /// Handler for text files. The bundled file will have the following format.

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -116,6 +116,7 @@ add_custom_target( sycl-toolchain
           llvm-dis
           llvm-spirv
           llvm-link
+          llvm-objcopy
           opt
   COMMENT "Building SYCL compiler toolchain..."
 )


### PR DESCRIPTION
clang-offload-bundler uses partial linking for creating fat object
files, but such technique cannot be used on windows due to the absence
of partial linking support in linker. This patch changes implementation
to use llvm-objcopy for merging device and host objects instead of doing
partial linking.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>