### PR TITLE
[SYCL] Fix OCL headers warnings

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -8,9 +8,6 @@
 
 #pragma once
 
-// Suppress a compiler warning about undefined CL_TARGET_OPENCL_VERSION
-// Khronos ICD supports only latest OpenCL version
-#define CL_TARGET_OPENCL_VERSION 220
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
 #include <CL/cl_ext_intel.h>

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -59,6 +59,8 @@ add_library(sycl SHARED
   "spirv_ops.cpp"
 )
 
+target_compile_definitions(sycl PRIVATE CL_TARGET_OPENCL_VERSION=220)
+
 add_dependencies(sycl
   ocl-icd
   ocl-headers


### PR DESCRIPTION
#define clause will leak the definition to user source code. Defining CL_TARGET_OPENCL_VERSION privately for SYCL project only will prevent this.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>