### PR TITLE
[SYCL] Enable programs that include system headers on Windows

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3414,6 +3414,10 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
   if (LangOpts.OpenMPIsDevice)
     Res.getTargetOpts().HostTriple = Res.getFrontendOpts().AuxTriple;
 
+  // Set the triple of the host for SYCL device compile.
+  if (LangOpts.SYCLIsDevice)
+    Res.getTargetOpts().HostTriple = Res.getFrontendOpts().AuxTriple;
+
   // FIXME: Override value name discarding when asan or msan is used because the
   // backend passes depend on the name of the alloca in order to print out
   // names.

--- a/clang/test/SemaSYCL/mangle-kernel.cpp
+++ b/clang/test/SemaSYCL/mangle-kernel.cpp
@@ -25,5 +25,5 @@ int main() {
 
 // CHECK: _ZTS10SimpleVaddIiE
 // CHECK: _ZTS10SimpleVaddIdE
-// CHECK-64: _ZTS10SimpleVaddImE
+// CHECK-64: _ZTS10SimpleVaddIyE
 // CHECK-32: _ZTS10SimpleVaddIjE

--- a/clang/test/SemaSYCL/msvc-fixes.cpp
+++ b/clang/test/SemaSYCL/msvc-fixes.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -fsycl-is-device -aux-triple x86_64-pc-windows-msvc  -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+void foo(__builtin_va_list bvl) {
+  char * VaList = bvl;
+  static_assert(sizeof(wchar_t) == 2, "sizeof wchar is 2 on Windows");
+}


### PR DESCRIPTION
Add Windows-specific predefined type characteristics for wchar, builtin
VaListKind. Add Windows support for SPIR target.

Signed-off-by: Melanie Blower <melanie.blower@intel.com>