### PR TITLE
[SYCL] Add call asynchronous error handler at destruction of a queue.

### DIFF
--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -59,6 +59,12 @@ public:
   }
 
   ~queue_impl() {
+    try {
+      throw_asynchronous();
+    } catch (...) {
+      assert(!"The asynchronous error handler should not throw exceptions from "
+              "the queue destructor.");
+    }
     if (m_OpenCLInterop) {
       PI_CALL(RT::piQueueRelease(m_CommandQueue));
     }


### PR DESCRIPTION
3.6.6 Error handling
"The asynchronous error handler for a queue is called with a cl::sycl::exception_list object, either on destruction of the context or queue that the error handler is associated with, or via an explicit wait_and_throw method call on an associated queue." _SYCL specification(Version 1.2.1, Document Revision: 5, Revision Date: April 18, 2019)_




Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>