### PR TITLE
[SYCL] Make copy commands non blocking.

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -389,19 +389,6 @@ private:
         std::move(CommandGroup), std::move(MQueue));
 
     EventRet = detail::createSyclObjFromImpl<event>(Event);
-
-    // Waiting for copy command to complete here as SYCL specification says that
-    // the SYCL runtime must ensure that data is copied to the destination once
-    // the command group has completed execution.
-    switch (MCGType) {
-    case detail::CG::COPY_ACC_TO_PTR:
-    case detail::CG::COPY_PTR_TO_ACC:
-    case detail::CG::COPY_ACC_TO_ACC:
-      EventRet.wait();
-    default:
-      break;
-    }
-
     return EventRet;
   }
 


### PR DESCRIPTION
According to SYCL specification (section 4.8.6):
"Manual copy operations can be seen as specialized kernels executing
on the device ...". Therefore kernel-like behaviour is expected.

According to section 3.6.8 of SYCL specification:
"A command group function object takes a reference to a command group handler
as a parameter and anything within that scope is immediately executed and has
to get the handler object as a parameter.

>> The intention is that a user will perform calls to SYCL functions, methods,
>> destructors and constructors inside that scope. These calls will be
>> non-blocking on the host, but enqueue operations to the queue that the
>> command group is submitted to.

All user functions within the command group scope will be called on the host as
the command group function object is executed, but any runtime SYCL
operations will be queued."

This reverts commit 07e251c650ee9549789c6e194acebd119bda6614.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>