### PR TITLE
[SYCL][NFC] Fix an array without known bound inside Indexer struct.

### DIFF
--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -1442,7 +1442,7 @@ private:
   // thus does not let using them in template parameters inside swizzle.def.
   template <int Index>
   struct Indexer {
-    static constexpr int IDXs[] = {Indexes...};
+    static constexpr int IDXs[sizeof...(Indexes)] = {Indexes...};
     static constexpr int value = IDXs[Index >= getNumElements() ? 0 : Index];
   };
 


### PR DESCRIPTION
When compiling with c++17 there was an error:
"read of element of array without known bound is not allowed in
 a constant expression."

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>