### PR TITLE
[SYCL][NFC] Fix defs of ContextImplPtr/EventImplPtr types crashing Wi…

### DIFF
--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -40,8 +40,6 @@ class handler;
 using buffer_allocator = detail::sycl_memory_object_allocator;
 
 namespace detail {
-using EventImplPtr = std::shared_ptr<detail::event_impl>;
-using ContextImplPtr = std::shared_ptr<detail::context_impl>;
 
 template <typename AllocatorT>
 class buffer_impl final : public SYCLMemObjT<AllocatorT> {

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -60,10 +60,6 @@ template <typename DataT>
 using EnableIfImgAccDataT =
     typename std::enable_if<is_validImageDataT<DataT>::value, DataT>::type;
 
-using EventImplPtr = std::shared_ptr<detail::event_impl>;
-
-using ContextImplPtr = std::shared_ptr<detail::context_impl>;
-
 template <int Dimensions, typename AllocatorT = image_allocator>
 class image_impl final : public SYCLMemObjT<AllocatorT> {
   using BaseT = SYCLMemObjT<AllocatorT>;

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -25,17 +25,16 @@ namespace sycl {
 namespace detail {
 
 // Forward declarations
-class event_impl;
 class context_impl;
+class event_impl;
+
+using ContextImplPtr = shared_ptr_class<context_impl>;
+using EventImplPtr = shared_ptr_class<event_impl>;
 
 using sycl_memory_object_allocator = detail::aligned_allocator<char>;
 
 // The class serves as a base for all SYCL memory objects.
 template <typename AllocatorT> class SYCLMemObjT : public SYCLMemObjI {
-  using EventImplPtr = shared_ptr_class<event_impl>;
-
-  using ContextImplPtr = shared_ptr_class<context_impl>;
-
   template <typename T>
   using EnableIfOutputPointerT =
       enable_if_t<is_output_iterator<T>::value && std::is_pointer<T>::value>;


### PR DESCRIPTION
…ndows build

The fix moves the declaration of ContextImplPtr and EventImplPtr out of
private section of SYCLMemObjT class to avoid confusing MSVC on Windows.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>