### PR TITLE
[SYCL][NFC] Use clang++ in two LIT tests, do not enforce c++11 on Win…

### DIFF
--- a/sycl/test/basic_tests/accessor/addrspace_exposure.cpp
+++ b/sycl/test/basic_tests/accessor/addrspace_exposure.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -std=c++11 -fsycl %s -o %t.out -lstdc++ -lOpenCL -lsycl
+// RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
 //==------- addrspace_exposure.cpp - SYCL accessor AS exposure test --------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/image_api.cpp
+++ b/sycl/test/basic_tests/image_api.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang -std=c++11 -fsycl %s -o %t1.out -lstdc++ -lOpenCL -lsycl
-// RUN: %clang -std=c++11 %s -o %t3.out -lstdc++ -lOpenCL -lsycl
+// RUN: %clangxx -fsycl %s -o %t1.out -lOpenCL
+// RUN: %clangxx %s -o %t3.out -lOpenCL -lsycl
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t3.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out


### PR DESCRIPTION
…dows

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>