### PR TITLE
[SYCL] Removing __FILE__ from use in OCL_ERROR_REPORT

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -26,8 +26,9 @@ const char *stringifyErrorCode(cl_int error);
   std::string(std::to_string(code) + " (" + stringifyErrorCode(code) + ")")
 
 #define OCL_ERROR_REPORT                                                       \
-  "OpenCL API failed. " __FILE__                                               \
-  ":" STRINGIFY_LINE(__LINE__) ": "                                            \
+  "OpenCL API failed. " /*__FILE__*/                                           \
+  /* TODO: replace __FILE__ to report only relative path*/                     \
+  /* ":" STRINGIFY_LINE(__LINE__) ": " */                                      \
                                "OpenCL API returns: "
 
 #ifndef SYCL_SUPPRESS_OCL_ERROR_REPORT


### PR DESCRIPTION
This is to avoid displaying internal path when reporting errors using
CHECK_OCL_CODE

Signed-off-by: Sindhu Chittireddy <sindhu.chittireddy@intel.com>