### PR TITLE
[SYCL] Insert addrspacecast for conditional operator

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -4139,6 +4139,52 @@ static bool isCheapEnoughToEvaluateUnconditionally(const Expr *E,
   // exist in the source-level program.
 }
 
+static Value *insertAddressSpaceCast(Value *V, unsigned NewAS) {
+  auto *VTy = cast<llvm::PointerType>(V->getType());
+  if (VTy->getAddressSpace() == NewAS)
+    return V;
+
+  llvm::PointerType *VTyNewAS =
+      llvm::PointerType::get(VTy->getElementType(), NewAS);
+
+  if (auto *Constant = dyn_cast<llvm::Constant>(V))
+    return llvm::ConstantExpr::getAddrSpaceCast(Constant, VTyNewAS);
+
+  llvm::Instruction *NewV =
+      new llvm::AddrSpaceCastInst(V, VTyNewAS, V->getName() + ".ascast");
+  NewV->insertAfter(cast<llvm::Instruction>(V));
+  return NewV;
+}
+
+static void ensureSameAddrSpace(Value *&RHS, Value *&LHS,
+                                bool CanInsertAddrspaceCast,
+                                const LangOptions &Opts,
+                                const ASTContext &Context) {
+  if (RHS->getType() == LHS->getType())
+    return;
+
+  auto *RHSTy = dyn_cast<llvm::PointerType>(RHS->getType());
+  auto *LHSTy = dyn_cast<llvm::PointerType>(LHS->getType());
+  if (!RHSTy || !LHSTy || RHSTy->getAddressSpace() == LHSTy->getAddressSpace())
+    return;
+
+  if (!CanInsertAddrspaceCast)
+    // Pointers have different address spaces and we cannot do anything with
+    // this.
+    llvm_unreachable("Pointers are expected to have the same address space.");
+
+  // Language rules define if it is legal to cast from one address space to
+  // another, and which address space we should use as a "common
+  // denominator". In SYCL, generic address space overlaps with all other
+  // address spaces.
+  if (Opts.SYCLIsDevice) {
+    unsigned GenericAS = Context.getTargetAddressSpace(LangAS::opencl_generic);
+    RHS = insertAddressSpaceCast(RHS, GenericAS);
+    LHS = insertAddressSpaceCast(LHS, GenericAS);
+  } else
+    llvm_unreachable("Unable to find a common address space for "
+                     "two pointers.");
+}
 
 Value *ScalarExprEmitter::
 VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
@@ -4235,6 +4281,15 @@ VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
       assert(!RHS && "LHS and RHS types must match");
       return nullptr;
     }
+
+    // Expressions may have the same addrspace in AST, but different address
+    // space in LLVM IR, in which case an addrspacecast should be valid.
+    bool CanInsertAddrspaceCast = rhsExpr->getType().getAddressSpace() ==
+                                  lhsExpr->getType().getAddressSpace();
+
+    ensureSameAddrSpace(RHS, LHS, CanInsertAddrspaceCast, CGF.getLangOpts(),
+                        CGF.getContext());
+
     return Builder.CreateSelect(CondV, LHS, RHS, "cond");
   }
 
@@ -4268,6 +4323,14 @@ VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
     return RHS;
   if (!RHS)
     return LHS;
+
+  // Expressions may have the same addrspace in AST, but different address
+  // space in LLVM IR, in which case an addrspacecast should be valid.
+  bool CanInsertAddrspaceCast = rhsExpr->getType().getAddressSpace() ==
+                                lhsExpr->getType().getAddressSpace();
+
+  ensureSameAddrSpace(RHS, LHS, CanInsertAddrspaceCast, CGF.getLangOpts(),
+                      CGF.getContext());
 
   // Create a PHI node for the real part.
   llvm::PHINode *PN = Builder.CreatePHI(LHS->getType(), 2, "cond");

--- a/clang/test/CodeGenSYCL/address-space-new.cpp
+++ b/clang/test/CodeGenSYCL/address-space-new.cpp
@@ -15,10 +15,46 @@ void test() {
   *pptr = foo;
 
   const char *str = "Hello, world!";
-  // CHECK-LEGACY: store i8* getelementptr inbounds ([14 x i8], [14 x i8]* @[[STR]], i64 0, i64 0), i8** %{{.*}}, align 8
-  // CHECK-NEW: store i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([14 x i8], [14 x i8]* @[[STR]], i64 0, i64 0) to i8 addrspace(4)*), i8 addrspace(4)** %{{.*}}, align 8
+  // CHECK-LEGACY: store i8* getelementptr inbounds ([14 x i8], [14 x i8]* @[[STR]], i64 0, i64 0), i8** %[[STRVAL:[a-zA-Z0-9]+]], align 8
+  // CHECK-NEW: store i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([14 x i8], [14 x i8]* @[[STR]], i64 0, i64 0) to i8 addrspace(4)*), i8 addrspace(4)** %[[STRVAL:[a-zA-Z0-9]+]], align 8
 
   i = str[0];
+
+  const char *phi_str = i > 2 ? str : "Another hello world!";
+  (void)phi_str;
+  // CHECK: %[[COND:[a-zA-Z0-9]+]] = icmp sgt i32 %{{.*}}, 2
+  // CHECK: br i1 %[[COND]], label %[[CONDTRUE:[.a-zA-Z0-9]+]], label %[[CONDFALSE:[.a-zA-Z0-9]+]]
+
+  // CHECK: [[CONDTRUE]]:
+  // CHECK-LEGACY-NEXT: %[[VALTRUE:[a-zA-Z0-9]+]] = load i8*, i8** %[[STRVAL]]
+  // CHECK-LEGACY-NEXT: br label %[[CONDEND:[.a-zA-Z0-9]+]]
+  // CHECK-NEW-NEXT: %[[VALTRUE:[a-zA-Z0-9]+]] = load i8 addrspace(4)*, i8 addrspace(4)** %[[STRVAL]]
+  // CHECK-NEW-NEXT: br label %[[CONDEND:[.a-zA-Z0-9]+]]
+
+  // CHECK: [[CONDFALSE]]:
+  // CHECK-LEGACY-NEXT: br label %[[CONDEND]]
+
+  // CHECK-LEGACY: [[CONDEND]]:
+  // CHECK-NEW: [[CONDEND]]:
+  // CHECK-NEW-NEXT: phi i8 addrspace(4)* [ %[[VALTRUE]], %[[CONDTRUE]] ], [ addrspacecast (i8* getelementptr inbounds ([21 x i8], [21 x i8]* @{{.*}}, i64 0, i64 0) to i8 addrspace(4)*), %[[CONDFALSE]] ]
+  // CHECK-LEGACY-NEXT: phi i8* [ %[[VALTRUE]], %[[CONDTRUE]] ], [ getelementptr inbounds ([21 x i8], [21 x i8]* @{{.*}}, i64 0, i64 0), %[[CONDFALSE]] ]
+
+  const char *select_null = i > 2 ? "Yet another Hello world" : nullptr;
+  (void)select_null;
+  // CHECK-LEGACY: select i1 %{{.*}}, i8* getelementptr inbounds ([24 x i8], [24 x i8]* @{{.*}}, i64 0, i64 0), i8* null
+  // CHECK-NEW: select i1 %{{.*}}, i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([24 x i8], [24 x i8]* @{{.*}}, i64 0, i64 0) to i8 addrspace(4)*), i8 addrspace(4)* null
+
+  const char *select_str_trivial1 = true ? str : "Another hello world!";
+  (void)select_str_trivial1;
+  // CHECK-LEGACY: %[[TRIVIALTRUE:[a-zA-Z0-9]+]] = load i8*, i8** %[[STRVAL]]
+  // CHECK-LEGACY: store i8* %[[TRIVIALTRUE]], i8** %{{.*}}, align 8
+  // CHECK-NEW: %[[TRIVIALTRUE:[a-zA-Z0-9]+]] = load i8 addrspace(4)*, i8 addrspace(4)** %[[STRVAL]]
+  // CHECK-NEW: store i8 addrspace(4)* %[[TRIVIALTRUE]], i8 addrspace(4)** %{{.*}}, align 8
+
+  const char *select_str_trivial2 = false ? str : "Another hello world!";
+  (void)select_str_trivial2;
+  // CHECK-LEGACY: store i8* getelementptr inbounds ([21 x i8], [21 x i8]* @{{.*}}, i64 0, i64 0), i8** %{{.*}}
+  // CHECK-NEW: store i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([21 x i8], [21 x i8]* @{{.*}}, i64 0, i64 0) to i8 addrspace(4)*), i8 addrspace(4)** %{{.*}}
 }
 
 


### PR DESCRIPTION
Pointers with the same address space in AST may end up in different
address spaces in IR. We cannot CodeGen a conditional
operator (ternary 'if') whose operands have different address spaces,
so we have to addrspacecast them to generic.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>