### PR TITLE
[SYCL] Disable sub_group info test for CPU and ACC

### DIFF
--- a/sycl/test/sub_group/info.cpp
+++ b/sycl/test/sub_group/info.cpp
@@ -1,8 +1,8 @@
 // RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUNx: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUNx: %ACC_RUN_PLACEHOLDER %t.out
 //==------------- info.cpp - SYCL sub_group parameters test ----*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>