### PR TITLE
[SYCL] add LLVM archiver to SYCL toolchain

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -113,6 +113,7 @@ add_custom_target( sycl-toolchain
           clang-offload-bundler
           llc
           llvm-as
+          llvm-ar
           llvm-dis
           llvm-no-spir-kernel
           llvm-spirv


### PR DESCRIPTION
It is needed to build SYCL CTS.

Signed-off-by: Vladimir Lazarev <vladimir.lazarev@intel.com>