### PR TITLE
Changed variable name to fix failing lit test. 

### DIFF
--- a/sycl/test/basic_tests/half_type.cpp
+++ b/sycl/test/basic_tests/half_type.cpp
@@ -18,14 +18,14 @@
 
 using namespace cl::sycl;
 
-constexpr float FLT_EPSILON = 9.77e-4;
+constexpr float flt_epsilon = 9.77e-4;
 
 constexpr size_t N = 100;
 
 template <typename T> void assert_close(const T &C, const float ref) {
   for (size_t i = 0; i < N; i++) {
     float diff = C[i] - ref;
-    assert(std::fabs(diff) < FLT_EPSILON);
+    assert(std::fabs(diff) < flt_epsilon);
   }
 }
 


### PR DESCRIPTION
FLT_EPSILON is a predefined macro in float.h. Test failed due to unintended macro substitution. Patch changes variable name in lit test to prevent this.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>