### PR TITLE
[SYCL] Check CL_TARGET_OPENCL_VERSION at run time

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -608,10 +608,10 @@ pi_result piEventRelease(pi_event event);
 //
 // Sampler
 //
-pi_sampler piSamplerCreate(
+pi_result piSamplerCreate(
   pi_context                     context,
   const cl_sampler_properties *  sampler_properties, // TODO: untie from OpenCL
-  pi_result *                    errcode_ret);
+  pi_sampler *                   result_sampler);
 
 pi_result piSamplerGetInfo(
   pi_sampler         sampler,


### PR DESCRIPTION
Replace compile time CL_TARGET_OPENCL_VERSION check with runtime.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>