### PR TITLE
[SYCL] Enable build with libc++ for SYCL runtime

### DIFF
--- a/sycl/doc/GetStartedWithSYCLCompiler.md
+++ b/sycl/doc/GetStartedWithSYCLCompiler.md
@@ -43,6 +43,18 @@ make -j`nproc` sycl-toolchain
 After the build completed, the SYCL compiler/include/libraries can be found
 under `$SYCL_HOME/build` directory.
 
+## Build the SYCL runtime with libc++ library.
+
+There is experimental support for building and linking SYCL runtime with
+libc++ library instead of libstdc++. To enable it the following cmake options
+should be used:
+
+```
+-DSYCL_USE_LIBCXX=ON \
+-DSYCL_LIBCXX_INCLUDE_PATH=<path to libc++ headers> \
+-DSYCL_LIBCXX_LIBRARY_PATH=<path to libc++ and libc++abi libraries>
+```
+
 # Test the SYCL compiler and runtime
 
 Run LIT testing using the command below after building SYCL compiler and runtime.

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -67,6 +67,19 @@ private:
   uint16_t Buf;
 };
 } // namespace half_impl
+
+// Accroding to C++ standard math functions from cmath/math.h should work only
+// on arithmetic types. We can't specify half type as arithmetic/floating
+// point(via std::is_floating_point) since only float, double and long double
+// types are "floating point" according to the standard. In order to use half
+// type with these math functions we cast half to float using template function
+// helper.
+template <typename T> inline T cast_if_host_half(T val) { return val; }
+
+inline float cast_if_host_half(half_impl::half val) {
+  return static_cast<float>(val);
+}
+
 } // namespace detail
 
 } // namespace sycl

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -68,11 +68,28 @@ add_dependencies(sycl
 
 set_target_properties(sycl PROPERTIES LINKER_LANGUAGE CXX)
 
+if (SYCL_USE_LIBCXX)
+    if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
+        (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+        target_compile_options(sycl PRIVATE -nostdinc++)
+        if ((NOT (DEFINED SYCL_LIBCXX_INCLUDE_PATH)) OR (NOT (DEFINED SYCL_LIBCXX_LIBRARY_PATH)))
+            message(FATAL_ERROR "When building with libc++ SYCL_LIBCXX_INCLUDE_PATHS and"
+                                "SYCL_LIBCXX_LIBRARY_PATH should be set")
+        endif()
+        target_include_directories(sycl PRIVATE "${SYCL_LIBCXX_INCLUDE_PATH}")
+        target_link_libraries(sycl PRIVATE "-L${SYCL_LIBCXX_LIBRARY_PATH}" -nodefaultlibs -lc++ -lc++abi -lm -lc -lgcc_s -lgcc)
+    else()
+        message(FATAL_ERROR "Build with libc++ is not yet supported for this compiler")
+    endif()
+else()
+
 # Workaround for bug in GCC version 5 and higher.
 # More information https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
     CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)
   target_link_libraries(sycl gcc_s gcc)
+endif()
+
 endif()
 
 install(TARGETS sycl DESTINATION "lib" COMPONENT sycl)

--- a/sycl/source/detail/builtins_common.cpp
+++ b/sycl/source/detail/builtins_common.cpp
@@ -52,7 +52,7 @@ template <typename T> inline T __smoothstep(T edge0, T edge1, T x) {
 }
 
 template <typename T> inline T __sign(T x) {
-  if (std::isnan(x))
+  if (std::isnan(d::cast_if_host_half(x)))
     return T(0.0);
   if (x > 0)
     return T(1.0);

--- a/sycl/source/detail/builtins_math.cpp
+++ b/sycl/source/detail/builtins_math.cpp
@@ -46,7 +46,7 @@ template <typename T> T inline __fract(T x, T *iptr) {
 
 template <typename T> inline T __lgamma_r(T x, s::cl_int *signp) {
   T g = std::tgamma(x);
-  *signp = std::signbit(g) ? -1 : 1;
+  *signp = std::signbit(d::cast_if_host_half(g)) ? -1 : 1;
   return std::log(std::abs(g));
 }
 

--- a/sycl/source/detail/builtins_relational.cpp
+++ b/sycl/source/detail/builtins_relational.cpp
@@ -64,19 +64,21 @@ template <typename T> cl_int inline __Any(T x) { return d::msbIsSet(x); }
 template <typename T> cl_int inline __All(T x) { return d::msbIsSet(x); }
 
 template <typename T> inline T __vOrdered(T x, T y) {
-  return -(!(std::isunordered(x, y)));
+  return -(
+      !(std::isunordered(d::cast_if_host_half(x), d::cast_if_host_half(y))));
 }
 
 template <typename T> inline T __sOrdered(T x, T y) {
-  return !(std::isunordered(x, y));
+  return !(std::isunordered(d::cast_if_host_half(x), d::cast_if_host_half(y)));
 }
 
 template <typename T> inline T __vUnordered(T x, T y) {
-  return -(static_cast<T>(std::isunordered(x, y)));
+  return -(static_cast<T>(
+      std::isunordered(d::cast_if_host_half(x), d::cast_if_host_half(y))));
 }
 
 template <typename T> inline T __sUnordered(T x, T y) {
-  return std::isunordered(x, y);
+  return std::isunordered(d::cast_if_host_half(x), d::cast_if_host_half(y));
 }
 
 template <typename T>
@@ -268,9 +270,11 @@ cl_int __vIsFinite(s::cl_float x) __NOEXC {
 cl_long __vIsFinite(s::cl_double x) __NOEXC {
   return -static_cast<cl_long>(std::isfinite(x));
 }
-cl_int IsFinite(s::cl_half x) __NOEXC { return std::isfinite(x); }
+cl_int IsFinite(s::cl_half x) __NOEXC {
+  return std::isfinite(d::cast_if_host_half(x));
+}
 cl_short __vIsFinite(s::cl_half x) __NOEXC {
-  return -static_cast<cl_int>(std::isfinite(x));
+  return -static_cast<cl_int>(std::isfinite(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(IsFinite, __vIsFinite, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(IsFinite, __vIsFinite, s::cl_long, s::cl_double)
@@ -285,9 +289,11 @@ cl_int __vIsInf(s::cl_float x) __NOEXC {
 cl_long __vIsInf(s::cl_double x) __NOEXC {
   return -static_cast<cl_long>(std::isinf(x));
 }
-cl_int IsInf(s::cl_half x) __NOEXC { return std::isinf(x); }
+cl_int IsInf(s::cl_half x) __NOEXC {
+  return std::isinf(d::cast_if_host_half(x));
+}
 cl_short __vIsInf(s::cl_half x) __NOEXC {
-  return -static_cast<cl_short>(std::isinf(x));
+  return -static_cast<cl_short>(std::isinf(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(IsInf, __vIsInf, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(IsInf, __vIsInf, s::cl_long, s::cl_double)
@@ -303,9 +309,11 @@ cl_long __vIsNan(s::cl_double x) __NOEXC {
   return -static_cast<cl_long>(std::isnan(x));
 }
 
-cl_int IsNan(s::cl_half x) __NOEXC { return std::isnan(x); }
+cl_int IsNan(s::cl_half x) __NOEXC {
+  return std::isnan(d::cast_if_host_half(x));
+}
 cl_short __vIsNan(s::cl_half x) __NOEXC {
-  return -static_cast<cl_short>(std::isnan(x));
+  return -static_cast<cl_short>(std::isnan(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(IsNan, __vIsNan, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(IsNan, __vIsNan, s::cl_long, s::cl_double)
@@ -320,9 +328,11 @@ cl_int __vIsNormal(s::cl_float x) __NOEXC {
 cl_long __vIsNormal(s::cl_double x) __NOEXC {
   return -static_cast<cl_long>(std::isnormal(x));
 }
-cl_int IsNormal(s::cl_half x) __NOEXC { return std::isnormal(x); }
+cl_int IsNormal(s::cl_half x) __NOEXC {
+  return std::isnormal(d::cast_if_host_half(x));
+}
 cl_short __vIsNormal(s::cl_half x) __NOEXC {
-  return -static_cast<cl_short>(std::isnormal(x));
+  return -static_cast<cl_short>(std::isnormal(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(IsNormal, __vIsNormal, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(IsNormal, __vIsNormal, s::cl_long, s::cl_double)
@@ -368,9 +378,11 @@ cl_int __vSignBitSet(s::cl_float x) __NOEXC {
 cl_long __vSignBitSet(s::cl_double x) __NOEXC {
   return -static_cast<cl_long>(std::signbit(x));
 }
-cl_int SignBitSet(s::cl_half x) __NOEXC { return std::signbit(x); }
+cl_int SignBitSet(s::cl_half x) __NOEXC {
+  return std::signbit(d::cast_if_host_half(x));
+}
 cl_short __vSignBitSet(s::cl_half x) __NOEXC {
-  return -static_cast<cl_short>(std::signbit(x));
+  return -static_cast<cl_short>(std::signbit(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(SignBitSet, __vSignBitSet, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(SignBitSet, __vSignBitSet, s::cl_long, s::cl_double)

--- a/sycl/test/usm/allocator_vector.cpp
+++ b/sycl/test/usm/allocator_vector.cpp
@@ -24,7 +24,8 @@ int main() {
 
   usm_allocator<int, usm::alloc::host> alloc(&ctxt, &dev);
 
-  std::vector<int, decltype(alloc)> vec(N, alloc);
+  std::vector<int, decltype(alloc)> vec(alloc);
+  vec.reserve(N);
 
   for (int i = 0; i < N; i++) {
     vec[i] = i;


### PR DESCRIPTION
libc++ disables several functions from cmath for non-arithmetic types.
This causes errors when host's half type is used with them.
In order to fix this, explicitly cast half type to float where it's
needed.

To make it possible to build the library with libc++ instead
of libstdc++ without any modifications added a couple of
internal cmake options:
SYCL_USE_LIBCXX=ON/OFF - whether libc++ should be used or not.
SYCL_LIBCXX_INCLUDE_PATH=<path to libc++ headers>
SYCL_LIBCXX_LIBRARY_PATH=<path to libc++ and libc++abi libraries>

Updated GetStartedWithSYCLCompiler.md with a description of these
options.

Signed-off-by: Ilya Stepykin <ilya.stepykin@intel.com>