### PR TITLE
[SYCL] minor fixes for -save-temps and --sycl

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -294,7 +294,8 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
     FinalPhase = phases::Compile;
 
     // -S only runs up to the backend.
-  } else if ((PhaseArg = DAL.getLastArg(options::OPT_S))) {
+  } else if ((PhaseArg = DAL.getLastArg(options::OPT_S)) ||
+             (PhaseArg = DAL.getLastArg(options::OPT_sycl))) {
     FinalPhase = phases::Backend;
 
     // -c compilation only runs up to the assembler.

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -521,3 +521,8 @@
 // CHK-PHASE-MULTI-TARG: 29: backend-compiler, {28}, image, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 30: clang-offload-wrapper, {29}, object, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 31: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64-unknown-linux-sycldevice)" {16}, "device-sycl (spir64_fpga-unknown-linux-sycldevice)" {24}, "device-sycl (spir64_gen-unknown-linux-sycldevice)" {30}, image
+
+/// ###########################################################################
+/// Verify that -save-temps does not crash
+// RUN: %clang -fsycl -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1
+// RUN: %clang -fsycl -fsycl-targets=spir64-unknown-linux-sycldevice -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -1,4 +1,5 @@
 // RUN: %clang -### --sycl -c %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
+// RUN: %clang -### --sycl %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
 // RUN: %clang -### --sycl -fno-sycl-use-bitcode -c %s 2>&1 | FileCheck %s --check-prefix=NO-BITCODE
 // RUN: %clang -### -target spir64-unknown-linux-sycldevice -c -emit-llvm %s 2>&1 | FileCheck %s --check-prefix=TARGET
 // RUN: %clang -### --sycl -c -emit-llvm %s 2>&1 | FileCheck %s --check-prefix=COMBINED


### PR DESCRIPTION
Fix problem with -save-temps when used with -fsycl (without -fsycl-targets)
which was causing an assertion failure

Adjust stop point for --sycl so you are not forced to use -c to generate the
file

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>