### PR TITLE
[SYCL] Initial PI API unit test setup

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -124,4 +124,5 @@ add_custom_target( sycl-toolchain
 )
 
 add_subdirectory( test )
+add_subdirectory( unittests )
 add_subdirectory( tools )

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -50,6 +50,9 @@ namespace pi {
   using PiMemImageChannelOrder = ::pi_image_channel_order;
   using PiMemImageChannelType  = ::pi_image_channel_type;
 
+  // Get a string representing a _pi_platform_info enum
+  std::string platformInfoToString(pi_platform_info info);
+
   // Report error and no return (keeps compiler happy about no return statements).
   [[noreturn]] void piDie(const char *Message);
   void piAssert(bool Condition, const char *Message = nullptr);

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -16,6 +16,24 @@ namespace sycl {
 namespace detail {
 namespace pi {
 
+std::string platformInfoToString(pi_platform_info info) {
+  switch (info) {
+  case PI_PLATFORM_INFO_PROFILE:
+    return "PI_PLATFORM_INFO_PROFILE";
+  case PI_PLATFORM_INFO_VERSION:
+    return "PI_PLATFORM_INFO_VERSION";
+  case PI_PLATFORM_INFO_NAME:
+    return "PI_PLATFORM_INFO_NAME";
+  case PI_PLATFORM_INFO_VENDOR:
+    return "PI_PLATFORM_INFO_VENDOR";
+  case PI_PLATFORM_INFO_EXTENSIONS:
+    return "PI_PLATFORM_INFO_EXTENSIONS";
+  default:
+    piDie("Unknown pi_platform_info value passed to "
+          "cl::sycl::detail::pi::platformInfoToString");
+  }
+}
+
 // Check for manually selected BE at run-time.
 bool piUseBackend(PiBackend Backend) {
   static const char *GetEnv = std::getenv("SYCL_BE");

--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_custom_target(PiUnitTests)
+set_target_properties(PiUnitTests PROPERTIES FOLDER "Tests")
+
+function(add_llvm_unittest test_dirname)
+  add_unittest(PiUnitTests ${test_dirname} ${ARGN})
+endfunction()
+
+function(add_llvm_unittest_with_input_files test_dirname)
+  add_unittest_with_input_files(PiUnitTests ${test_dirname} ${ARGN})
+endfunction()
+
+add_subdirectory(pi)

--- a/sycl/unittests/pi/CMakeLists.txt
+++ b/sycl/unittests/pi/CMakeLists.txt
@@ -2,13 +2,11 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Enable exception handling for these unit tests
+set(LLVM_REQUIRES_EH 1)
 add_llvm_unittest(PiTests
   PlatformTest.cpp
 )
 
 add_dependencies(PiTests sycl)
 target_link_libraries(PiTests PRIVATE sycl LLVMTestingSupport)
-
-if(NOT MSVC)
-  target_compile_options(PiTests PRIVATE -fexceptions)
-endif()

--- a/sycl/unittests/pi/CMakeLists.txt
+++ b/sycl/unittests/pi/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_llvm_unittest(PiTests
+  PlatformTest.cpp
+)
+
+add_dependencies(PiTests sycl)
+target_link_libraries(PiTests PRIVATE sycl LLVMTestingSupport)
+
+if(NOT MSVC)
+  target_compile_options(PiTests PRIVATE -fexceptions)
+endif()

--- a/sycl/unittests/pi/PlatformTest.cpp
+++ b/sycl/unittests/pi/PlatformTest.cpp
@@ -1,0 +1,85 @@
+//==---- PlatformTest.cpp --- PI unit tests --------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CL/sycl/detail/pi.hpp"
+#include <CL/sycl.hpp>
+#include <gtest/gtest.h>
+#include <memory>
+
+using namespace cl::sycl;
+
+namespace pi {
+class PlatformTest : public ::testing::Test {
+protected:
+
+constexpr static size_t out_string_size =
+    8192u; // Using values from OpenCL CTS clGetPlatforms test
+
+  PlatformTest() { detail::pi::piInitialize(); }
+
+  ~PlatformTest() = default;
+};
+
+TEST_F(PlatformTest, piPlatformsGet) {
+  pi_uint32 platformCount = 0;
+
+  ASSERT_EQ(PI_CALL_RESULT(RT::piPlatformsGet(0, 0, &platformCount)),
+            PI_SUCCESS)
+      << "piPlatformsGet failed";
+
+  ASSERT_GT(platformCount, 0) << "piPlatformsGet found 0 platforms.\n";
+
+  std::vector<pi_platform> platforms(platformCount);
+
+  ASSERT_EQ(PI_CALL_RESULT(
+                RT::piPlatformsGet(platformCount, platforms.data(), nullptr)),
+            PI_SUCCESS)
+      << "piPlatformsGet failed with nullptr for return size.\n";
+}
+
+TEST_F(PlatformTest, piPlatformGetInfo) {
+  auto get_info_test = [](char *out_string, pi_platform platform,
+                          _pi_platform_info info) {
+
+    auto info_name = detail::pi::platformInfoToString(info);
+
+    size_t reported_string_length = 0;
+    memset(out_string, 0, out_string_size);
+
+    ASSERT_EQ(PI_CALL_RESULT(RT::piPlatformGetInfo(platform, info,
+                                                   out_string_size, out_string,
+                                                   &reported_string_length)),
+              PI_SUCCESS)
+        << "piPlatformGetInfo for " << info_name << " failed.\n";
+
+    auto returned_string_length = strlen(out_string) + 1;
+
+    EXPECT_EQ(returned_string_length, reported_string_length)
+        << "Returned string length " << returned_string_length
+        << " does not equal reported string length " << reported_string_length
+        << ".\n";
+  };
+
+  pi_uint32 platformCount = 0;
+  PI_CALL(RT::piPlatformsGet(0, 0, &platformCount));
+  std::vector<pi_platform> platforms(platformCount);
+  PI_CALL(RT::piPlatformsGet(platformCount, platforms.data(), nullptr));
+
+  auto out_string_buffer = std::unique_ptr<char[]>(new char[out_string_size]);
+  auto out_string = out_string_buffer.get();
+
+  for (auto i = 0u; i < platformCount; ++i) {
+    const auto &platform = platforms[i];
+    get_info_test(out_string, platform, PI_PLATFORM_INFO_NAME);
+    get_info_test(out_string, platform, PI_PLATFORM_INFO_VENDOR);
+    get_info_test(out_string, platform, PI_PLATFORM_INFO_PROFILE);
+    get_info_test(out_string, platform, PI_PLATFORM_INFO_VERSION);
+    get_info_test(out_string, platform, PI_PLATFORM_INFO_EXTENSIONS);
+  }
+}
+} // Namespace


### PR DESCRIPTION
This patch introduces the initial structure for unit testing the PI API. Tests are provided for piPlatformsGet and piPlatformsGetInfo. Test stubs are defined for the piProgram functions.

Signed-off-by: Stuart Adams <stuart.adams@codeplay.com>