### PR TITLE
[SYCL][FPGA] Fix loop metadata generation

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1819,8 +1819,9 @@ def SYCLIntelFPGAMaxConcurrencyAttrDocs : Documentation {
   let Heading = "max_concurrency";
   let Content = [{
 This attribute applies to a loop. Indicates that the loop should allow no more
-than N threads or iterations to execute it simultaneously. N must be a positive
-integer. Cannot be applied multiple times to the same loop.
+than N threads or iterations to execute it simultaneously. N must be a non
+negative integer. '0' indicates the max_concurrency case to be unbounded. Cannot
+be applied multiple times to the same loop.
   }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2538,14 +2538,24 @@ def err_attribute_wrong_number_arguments : Error<
   ":requires exactly %1 arguments}1">;
 def err_attribute_too_many_arguments : Error<
   "%0 attribute takes no more than %1 argument%s1">;
+def warn_attribute_too_many_arguments : Warning<
+  "%0 attribute takes no more than %1 argument%s1 - attribute ignored">,
+ InGroup<IgnoredAttributes>;
 def err_attribute_too_few_arguments : Error<
   "%0 attribute takes at least %1 argument%s1">;
+def warn_attribute_too_few_arguments : Warning<
+  "%0 attribute takes at least %1 argument%s1 - attribute ignored">,
+ InGroup<IgnoredAttributes>;
 def err_attribute_invalid_vector_type : Error<"invalid vector element type %0">;
 def err_attribute_bad_neon_vector_size : Error<
   "Neon vector size must be 64 or 128 bits">;
 def err_attribute_requires_positive_integer : Error<
   "%0 attribute requires a %select{positive|non-negative}1 "
   "integral compile time constant expression">;
+def warn_attribute_requires_positive_integer : Warning<
+  "%0 attribute requires a %select{positive|non-negative}1 "
+  "integral compile time constant expression - attribute ignored">,
+ InGroup<IgnoredAttributes>;
 def err_attribute_requires_opencl_version : Error<
   "%0 attribute requires OpenCL version %1%select{| or above}2">;
 def warn_unsupported_target_attribute

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -66,6 +66,9 @@ struct LoopAttributes {
   /// Value for llvm.loop.ii.count metadata.
   unsigned SYCLIInterval;
 
+  /// Flag for llvm.loop.max_concurrency.count metadata.
+  bool SYCLMaxConcurrencyEnable;
+
   /// Value for llvm.loop.max_concurrency.count metadata.
   unsigned SYCLMaxConcurrencyNThreads;
 
@@ -268,6 +271,11 @@ public:
 
   /// Set value of an initiation interval for the next loop pushed.
   void setSYCLIInterval(unsigned C) { StagedAttrs.SYCLIInterval = C; }
+
+  /// Set flag of max_concurrency for the next loop pushed.
+  void setSYCLMaxConcurrencyEnable() {
+    StagedAttrs.SYCLMaxConcurrencyEnable = true;
+  }
 
   /// Set value of threads for the next loop pushed.
   void setSYCLMaxConcurrencyNThreads(unsigned C) {

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -83,14 +83,14 @@ static Attr *handleIntelFPGALoopAttr(Sema &S, Stmt *St, const ParsedAttr &A) {
 
   unsigned NumArgs = A.getNumArgs();
   if (NumArgs > 1) {
-    S.Diag(A.getLoc(), diag::err_attribute_too_many_arguments) << A << 1;
+    S.Diag(A.getLoc(), diag::warn_attribute_too_many_arguments) << A << 1;
     return nullptr;
   }
 
   if (NumArgs == 0) {
     if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAII ||
         A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency) {
-      S.Diag(A.getLoc(), diag::err_attribute_too_few_arguments) << A << 1;
+      S.Diag(A.getLoc(), diag::warn_attribute_too_few_arguments) << A << 1;
       return nullptr;
     }
   }
@@ -109,11 +109,20 @@ static Attr *handleIntelFPGALoopAttr(Sema &S, Stmt *St, const ParsedAttr &A) {
 
     int Val = ArgVal.getSExtValue();
 
-    if (Val <= 0) {
-      S.Diag(A.getRange().getBegin(),
-          diag::err_attribute_requires_positive_integer)
-        << A << /* positive */ 0;
-      return nullptr;
+    if (A.getKind() != ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency) {
+      if (Val <= 0) {
+        S.Diag(A.getRange().getBegin(),
+            diag::warn_attribute_requires_positive_integer)
+          << A << /* positive */ 0;
+        return nullptr;
+      }
+    } else {
+      if (Val < 0) {
+        S.Diag(A.getRange().getBegin(),
+            diag::warn_attribute_requires_positive_integer)
+          << A << /* non-negative */ 1;
+        return nullptr;
+      }
     }
     SafeInterval = Val;
   }

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -15,23 +15,23 @@ void foo() {
 // Test for incorrect number of arguments for Intel FPGA loop attributes
 void boo() {
   int a[10];
-  // expected-error@+1 {{'ivdep' attribute takes no more than 1 argument}}
+  // expected-warning@+1 {{'ivdep' attribute takes no more than 1 argument - attribute ignored}}
   [[intelfpga::ivdep(2,2)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+1 {{'ii' attribute takes at least 1 argument}}
+  // expected-warning@+1 {{'ii' attribute takes at least 1 argument - attribute ignored}}
   [[intelfpga::ii]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+1 {{'ii' attribute takes no more than 1 argument}}
+  // expected-warning@+1 {{'ii' attribute takes no more than 1 argument - attribute ignored}}
   [[intelfpga::ii(2,2)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+1 {{'max_concurrency' attribute takes at least 1 argument}}
+  // expected-warning@+1 {{'max_concurrency' attribute takes at least 1 argument - attribute ignored}}
   [[intelfpga::max_concurrency]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+1 {{'max_concurrency' attribute takes no more than 1 argument}}
+  // expected-warning@+1 {{'max_concurrency' attribute takes no more than 1 argument - attribute ignored}}
   [[intelfpga::max_concurrency(2,2)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
@@ -40,16 +40,20 @@ void boo() {
 // Test for incorrect argument value for Intel FPGA loop attributes
 void goo() {
   int a[10];
-  // expected-error@+1 {{'ivdep' attribute requires a positive integral compile time constant expression}}
+  // no diagnostics are expected
+  [[intelfpga::max_concurrency(0)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-warning@+1 {{'ivdep' attribute requires a positive integral compile time constant expression - attribute ignored}}
   [[intelfpga::ivdep(0)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+1 {{'ii' attribute requires a positive integral compile time constant expression}}
+  // expected-warning@+1 {{'ii' attribute requires a positive integral compile time constant expression - attribute ignored}}
   [[intelfpga::ii(0)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+1 {{'max_concurrency' attribute requires a positive integral compile time constant expression}}
-  [[intelfpga::max_concurrency(0)]]
+  // expected-warning@+1 {{'max_concurrency' attribute requires a non-negative integral compile time constant expression - attribute ignored}}
+  [[intelfpga::max_concurrency(-1)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // expected-error@+1 {{'ivdep' attribute requires an integer constant}}


### PR DESCRIPTION
FPGA loop attributes must accept '1' as attribute value.

Moreover 'max_concurrency' can accept '0', that will indicate,
that the max_concurrency case is unbounded.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>