### PR TITLE
[SYCL] Prevent SYCL Runtime from emitting all exceptions to stderr

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -58,9 +58,7 @@ static inline std::string codeToString(cl_int code){
 {                                                                              \
   auto code = expr;                                                            \
   if (code != CL_SUCCESS) {                                                    \
-    std::string errorMessage(OCL_ERROR_REPORT + codeToString(code));           \
-    std::cerr << errorMessage << std::endl;                                    \
-    throw exc(errorMessage.c_str(), (code));                                   \
+    throw exc(OCL_ERROR_REPORT + codeToString(code), code);                    \
   }                                                                            \
 }
 #define REPORT_OCL_ERR_TO_EXC_THROW(code, exc) REPORT_OCL_ERR_TO_EXC(code, exc)


### PR DESCRIPTION
Oftentimes exceptions are caught and successfully handled by the
programmer, so stderr-ing these by default is redundant for such
users. If necessary, the exceptions can be conveniently logged
by an explicit call to what() method anyway

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>