### PR TITLE
[SYCL] Verify that -std=gnu++11 can build sycl include file cleanly.

### DIFF
--- a/sycl/test/regression/sycl-include-gnu11.cpp
+++ b/sycl/test/regression/sycl-include-gnu11.cpp
@@ -1,0 +1,15 @@
+// RUN: %clangxx -std=gnu++11 -fsycl %s -o %t.out -lOpenCL
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// UNSUPPORTED: system-windows
+
+#include <CL/sycl.hpp>
+#include <iostream>
+
+int main() {
+  std::cout << "Passed" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Fixes #212.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>