### PR TITLE
[SYCL][NFC] Explicitly initialize range variables

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -135,7 +135,7 @@ public:
 
   template <int N = dimensions, typename = EnableIfOneDimension<N>>
   buffer(cl_mem MemObject, const context &SyclContext,
-         event AvailableEvent = {}) {
+         event AvailableEvent = {}) : Range{0}, MemRange{0} {
 
     size_t BufSize = 0;
     PI_CALL(detail::RT::piMemGetInfo(

--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -58,7 +58,8 @@ class NDRDescT {
   }
 
 public:
-  NDRDescT() = default;
+  NDRDescT()
+      : GlobalSize{0, 0, 0}, LocalSize{0, 0, 0}, NumWorkGroups{0, 0, 0} {}
 
   template <int Dims_> void set(sycl::range<Dims_> NumWorkItems) {
     for (int I = 0; I < Dims_; ++I) {
@@ -160,7 +161,7 @@ public:
       // needed to invoke the kernel and adjust the NDRange descriptor
       // accordingly. For some devices the work group size selection requires
       // access to the device's properties, hence such late "adjustment".
-      range<3> WGsize = {1, 1, 1}; // no better alternative for serial host?
+      range<3> WGsize{1, 1, 1}; // no better alternative for serial host?
       AdjustedRange.set(NDRDesc.Dims,
                         nd_range<3>(NDRDesc.NumWorkGroups * WGsize, WGsize));
       Adjust = true;

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -61,30 +61,30 @@ public:
   range<dimensions> &operator=(range<dimensions> &&rhs) = default;
   range() = default;
 
-  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  #define __SYCL_GEN_OPT(op)                                                   \
-    range<dimensions> operator op(const range<dimensions> &rhs) const {        \
-      range<dimensions> result;                                                \
-      for (int i = 0; i < dimensions; ++i) {                                   \
-        result.common_array[i] = this->common_array[i] op rhs.common_array[i]; \
-      }                                                                        \
-      return result;                                                           \
+// OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+#define __SYCL_GEN_OPT(op)                                                     \
+  range<dimensions> operator op(const range<dimensions> &rhs) const {          \
+    range<dimensions> result(*this);                                           \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      result.common_array[i] = this->common_array[i] op rhs.common_array[i];   \
     }                                                                          \
-    range<dimensions> operator op(const size_t &rhs) const {                   \
-      range<dimensions> result;                                                \
-      for (int i = 0; i < dimensions; ++i) {                                   \
-        result.common_array[i] = this->common_array[i] op rhs;                 \
-      }                                                                        \
-      return result;                                                           \
+    return result;                                                             \
+  }                                                                            \
+  range<dimensions> operator op(const size_t &rhs) const {                     \
+    range<dimensions> result(*this);                                           \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      result.common_array[i] = this->common_array[i] op rhs;                   \
     }                                                                          \
-    friend range<dimensions> operator op(const size_t &lhs,                    \
+    return result;                                                             \
+  }                                                                            \
+  friend range<dimensions> operator op(const size_t &lhs,                      \
                                        const range<dimensions> &rhs) {         \
-      range<dimensions> result;                                                \
-      for (int i = 0; i < dimensions; ++i) {                                   \
-        result.common_array[i] = lhs op rhs.common_array[i];                   \
-      }                                                                        \
-      return result;                                                           \
+    range<dimensions> result(rhs);                                             \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      result.common_array[i] = lhs op rhs.common_array[i];                     \
     }                                                                          \
+    return result;                                                             \
+  }
 
   __SYCL_GEN_OPT(+)
   __SYCL_GEN_OPT(-)

--- a/sycl/test/basic_tests/buffer/buffer_interop.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_interop.cpp
@@ -21,8 +21,7 @@ int main() {
     constexpr size_t Size = 32;
     int Init[Size] = {5};
     cl_int Error = CL_SUCCESS;
-    cl::sycl::range<1> InteropRange;
-    InteropRange[0] = Size;
+    cl::sycl::range<1> InteropRange{Size};
     size_t InteropSize = Size * sizeof(int);
 
     queue MyQueue;
@@ -55,7 +54,7 @@ int main() {
     int Data[Size] = {10};
     std::vector<int> Result(Size, 0);
     {
-      buffer<int, 1> BufferData{Data, range<1>(Size),
+      buffer<int, 1> BufferData{Data, range<1>{Size},
                                 {property::buffer::use_host_ptr()}};
       BufferData.set_final_data(Result.begin());
       MyQueue.submit([&](handler &CGH) {


### PR DESCRIPTION
Default `range` class constructor is not defined by the SYCL specification.