### PR TITLE
[SYCL] Do not perform mapping/unmapping for 1D images

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -219,8 +219,10 @@ Command *Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
 
   // In case of memory is 1 dimensional and located on OpenCL device we
   // can use map/unmap operation.
+  // TODO: Implement mapping/unmapping for images
   if (!SrcQueue->is_host() && Req->MDims == 1 &&
-      Req->MAccessRange == Req->MMemoryRange) {
+      Req->MAccessRange == Req->MMemoryRange &&
+      Req->MSYCLMemObj->getType() == detail::SYCLMemObjI::MemObjType::BUFFER) {
 
     std::unique_ptr<MapMemObject> MapCmdUniquePtr(
         new MapMemObject(*SrcReq, SrcAllocaCmd, Req, SrcQueue));

--- a/sycl/test/regression/image_access.cpp
+++ b/sycl/test/regression/image_access.cpp
@@ -1,8 +1,8 @@
 // RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: env SYCL_PI_TRACE=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=1 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
 
 //==-------------- image_access.cpp - SYCL image accessors test  -----------==//
 //
@@ -40,3 +40,6 @@ int main() {
   }
   return 0;
 }
+
+// CHECK: PI ---> (NewMem = RT::piMemImageCreate(TargetContext->getHandleRef(), CreationFlags, &Format, &Desc, UserPtr, &Error), Error)
+// CHECK: PI ---> RT::piEnqueueMemImageRead( Queue, SrcMem, CL_FALSE, &SrcOffset[0], &SrcAccessRange[0], RowPitch, SlicePitch, DstMem, DepEvents.size(), &DepEvents[0], &OutEvent)

--- a/sycl/test/regression/image_access.cpp
+++ b/sycl/test/regression/image_access.cpp
@@ -1,0 +1,42 @@
+// RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+//==-------------- image_access.cpp - SYCL image accessors test  -----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+int main() {
+  try {
+    cl::sycl::range<1> Range(32);
+    std::vector<cl_float> Data(Range.size() * 4, 0.0f);
+    cl::sycl::image<1> Image(Data.data(), cl::sycl::image_channel_order::rgba,
+                             cl::sycl::image_channel_type::fp32, Range);
+    cl::sycl::queue Queue;
+
+    Queue.submit([&](cl::sycl::handler &CGH) {
+      cl::sycl::accessor<cl_int4, 1, cl::sycl::access::mode::read,
+                         cl::sycl::access::target::image,
+                         cl::sycl::access::placeholder::false_t>
+          A(Image, CGH);
+      CGH.single_task<class MyKernel>([=]() {});
+    });
+    Queue.wait_and_throw();
+
+    cl::sycl::accessor<cl_int4, 1, cl::sycl::access::mode::read,
+                       cl::sycl::access::target::host_image,
+                       cl::sycl::access::placeholder::false_t>
+        A(Image);
+  } catch (cl::sycl::exception &E) {
+    std::cout << E.what();
+  }
+  return 0;
+}


### PR DESCRIPTION
Currently mapping is implemented only for buffers (clEnqueueMapBuffer).
That is why simple copy operation should be called when dealing with
images while mapping for images is not implemented.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>