### PR TITLE
[SYCL] Fixes for C++ to SYCL types translation codes.

### DIFF
--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -1670,110 +1670,81 @@ __SYCL_RELLOGOP(<=)
 __SYCL_RELLOGOP(&&)
 __SYCL_RELLOGOP(||)
 #undef __SYCL_RELLOGOP
+
+using byte = uint8_t;
+using half = ::half;
+
+using cl_bool   = ::cl_bool;
+using cl_char   = ::cl_char;
+using cl_schar  = signed char;
+using cl_uchar  = ::cl_uchar;
+using cl_short  = ::cl_short;
+using cl_ushort = ::cl_ushort;
+using cl_int    = ::cl_int;
+using cl_uint   = ::cl_uint;
+using cl_long   = ::cl_long;
+using cl_ulong  = ::cl_ulong;
+using cl_half   = half;
+using cl_float  = ::cl_float;
+using cl_double = ::cl_double;
+
 } // namespace sycl
 } // namespace cl
 
 
 #ifdef __SYCL_USE_EXT_VECTOR_TYPE__
-typedef char __char_t;
-typedef char __char2_vec_t __attribute__((ext_vector_type(2)));
-typedef char __char3_vec_t __attribute__((ext_vector_type(3)));
-typedef char __char4_vec_t __attribute__((ext_vector_type(4)));
-typedef char __char8_vec_t __attribute__((ext_vector_type(8)));
-typedef char __char16_vec_t __attribute__((ext_vector_type(16)));
-typedef signed char __schar_t;
-typedef signed char __schar2_vec_t __attribute__((ext_vector_type(2)));
-typedef signed char __schar3_vec_t __attribute__((ext_vector_type(3)));
-typedef signed char __schar4_vec_t __attribute__((ext_vector_type(4)));
-typedef signed char __schar8_vec_t __attribute__((ext_vector_type(8)));
-typedef signed char __schar16_vec_t __attribute__((ext_vector_type(16)));
-typedef unsigned char __uchar_t;
-typedef unsigned char __uchar2_vec_t __attribute__((ext_vector_type(2)));
-typedef unsigned char __uchar3_vec_t __attribute__((ext_vector_type(3)));
-typedef unsigned char __uchar4_vec_t __attribute__((ext_vector_type(4)));
-typedef unsigned char __uchar8_vec_t __attribute__((ext_vector_type(8)));
-typedef unsigned char __uchar16_vec_t __attribute__((ext_vector_type(16)));
-typedef short __short_t;
-typedef short __short2_vec_t __attribute__((ext_vector_type(2)));
-typedef short __short3_vec_t __attribute__((ext_vector_type(3)));
-typedef short __short4_vec_t __attribute__((ext_vector_type(4)));
-typedef short __short8_vec_t __attribute__((ext_vector_type(8)));
-typedef short __short16_vec_t __attribute__((ext_vector_type(16)));
-typedef unsigned short __ushort_t;
-typedef unsigned short __ushort2_vec_t __attribute__((ext_vector_type(2)));
-typedef unsigned short __ushort3_vec_t __attribute__((ext_vector_type(3)));
-typedef unsigned short __ushort4_vec_t __attribute__((ext_vector_type(4)));
-typedef unsigned short __ushort8_vec_t __attribute__((ext_vector_type(8)));
-typedef unsigned short __ushort16_vec_t __attribute__((ext_vector_type(16)));
-typedef int __int_t;
-typedef int __int2_vec_t __attribute__((ext_vector_type(2)));
-typedef int __int3_vec_t __attribute__((ext_vector_type(3)));
-typedef int __int4_vec_t __attribute__((ext_vector_type(4)));
-typedef int __int8_vec_t __attribute__((ext_vector_type(8)));
-typedef int __int16_vec_t __attribute__((ext_vector_type(16)));
-typedef unsigned int __uint_t;
-typedef unsigned int __uint2_vec_t __attribute__((ext_vector_type(2)));
-typedef unsigned int __uint3_vec_t __attribute__((ext_vector_type(3)));
-typedef unsigned int __uint4_vec_t __attribute__((ext_vector_type(4)));
-typedef unsigned int __uint8_vec_t __attribute__((ext_vector_type(8)));
-typedef unsigned int __uint16_vec_t __attribute__((ext_vector_type(16)));
-typedef long __long_t;
-typedef long __long2_vec_t __attribute__((ext_vector_type(2)));
-typedef long __long3_vec_t __attribute__((ext_vector_type(3)));
-typedef long __long4_vec_t __attribute__((ext_vector_type(4)));
-typedef long __long8_vec_t __attribute__((ext_vector_type(8)));
-typedef long __long16_vec_t __attribute__((ext_vector_type(16)));
-typedef unsigned long __ulong_t;
-typedef unsigned long __ulong2_vec_t __attribute__((ext_vector_type(2)));
-typedef unsigned long __ulong3_vec_t __attribute__((ext_vector_type(3)));
-typedef unsigned long __ulong4_vec_t __attribute__((ext_vector_type(4)));
-typedef unsigned long __ulong8_vec_t __attribute__((ext_vector_type(8)));
-typedef unsigned long __ulong16_vec_t __attribute__((ext_vector_type(16)));
-typedef long long __longlong_t;
-typedef long long __longlong2_vec_t __attribute__((ext_vector_type(2)));
-typedef long long __longlong3_vec_t __attribute__((ext_vector_type(3)));
-typedef long long __longlong4_vec_t __attribute__((ext_vector_type(4)));
-typedef long long __longlong8_vec_t __attribute__((ext_vector_type(8)));
-typedef long long __longlong16_vec_t __attribute__((ext_vector_type(16)));
-typedef unsigned long long __ulonglong_t;
-typedef unsigned long long __ulonglong2_vec_t
-    __attribute__((ext_vector_type(2)));
-typedef unsigned long long __ulonglong3_vec_t
-    __attribute__((ext_vector_type(3)));
-typedef unsigned long long __ulonglong4_vec_t
-    __attribute__((ext_vector_type(4)));
-typedef unsigned long long __ulonglong8_vec_t
-    __attribute__((ext_vector_type(8)));
-typedef unsigned long long __ulonglong16_vec_t
-    __attribute__((ext_vector_type(16)));
-typedef float __float_t;
-typedef float __float2_vec_t __attribute__((ext_vector_type(2)));
-typedef float __float3_vec_t __attribute__((ext_vector_type(3)));
-typedef float __float4_vec_t __attribute__((ext_vector_type(4)));
-typedef float __float8_vec_t __attribute__((ext_vector_type(8)));
-typedef float __float16_vec_t __attribute__((ext_vector_type(16)));
+#define DECLARE_TYPE_T(type)                           \
+using __##type##_t       = cl::sycl::cl_##type;        \
+using __##type##2_vec_t  = cl::sycl::cl_##type         \
+                 __attribute__((ext_vector_type(2)));  \
+using __##type##3_vec_t  = cl::sycl::cl_##type         \
+                 __attribute__((ext_vector_type(3)));  \
+using __##type##4_vec_t  = cl::sycl::cl_##type         \
+                 __attribute__((ext_vector_type(4)));  \
+using __##type##8_vec_t  = cl::sycl::cl_##type         \
+                 __attribute__((ext_vector_type(8)));  \
+using __##type##16_vec_t = cl::sycl::cl_##type         \
+                 __attribute__((ext_vector_type(16)));
+
+#define DECLARE_LLTYPE_T(type)                         \
+using __##type##_t       = cl::sycl::type;             \
+using __##type##2_vec_t  = cl::sycl::type              \
+                 __attribute__((ext_vector_type(2)));  \
+using __##type##3_vec_t  = cl::sycl::type              \
+                 __attribute__((ext_vector_type(3)));  \
+using __##type##4_vec_t  = cl::sycl::type              \
+                 __attribute__((ext_vector_type(4)));  \
+using __##type##8_vec_t  = cl::sycl::type              \
+                 __attribute__((ext_vector_type(8)));  \
+using __##type##16_vec_t = cl::sycl::type              \
+                 __attribute__((ext_vector_type(16)));
+
+DECLARE_TYPE_T(char);
+DECLARE_TYPE_T(schar);
+DECLARE_TYPE_T(uchar);
+DECLARE_TYPE_T(short);
+DECLARE_TYPE_T(ushort);
+DECLARE_TYPE_T(int);
+DECLARE_TYPE_T(uint);
+DECLARE_TYPE_T(long);
+DECLARE_TYPE_T(ulong);
+DECLARE_LLTYPE_T(longlong);
+DECLARE_LLTYPE_T(ulonglong);
+DECLARE_TYPE_T(float);
 // Half type is defined as custom class for host and _Float16 for device.
 // The ext_vector_type attribute is only applicable to integral and float
 // scalars so it's not possible to use attribute ext_vector_type for half on
 // host.
 #ifdef __SYCL_DEVICE_ONLY__
-typedef half __half_t;
-typedef half __half2_vec_t __attribute__((ext_vector_type(2)));
-typedef half __half3_vec_t __attribute__((ext_vector_type(3)));
-typedef half __half4_vec_t __attribute__((ext_vector_type(4)));
-typedef half __half8_vec_t __attribute__((ext_vector_type(8)));
-typedef half __half16_vec_t __attribute__((ext_vector_type(16)));
+DECLARE_TYPE_T(half);
 #endif
-typedef double __double_t;
-typedef double __double2_vec_t __attribute__((ext_vector_type(2)));
-typedef double __double3_vec_t __attribute__((ext_vector_type(3)));
-typedef double __double4_vec_t __attribute__((ext_vector_type(4)));
-typedef double __double8_vec_t __attribute__((ext_vector_type(8)));
-typedef double __double16_vec_t __attribute__((ext_vector_type(16)));
+DECLARE_TYPE_T(double);
 
 #define GET_CL_TYPE(target, num) __##target##num##_vec_t
 #define GET_SCALAR_CL_TYPE(target) target
 
+#undef DECLARE_TYPE_T
+#undef DECLARE_LLTYPE_T
 #else // __SYCL_USE_EXT_VECTOR_TYPE__
 // For signed char. OpenCL doesn't have any type about `signed char`, therefore
 // we use type alias of cl_char instead.
@@ -1809,11 +1780,47 @@ typedef half_vec<16, cl_half16> __half16_vec_t;
 
 namespace cl {
 namespace sycl {
+namespace detail {
+// Use conditional_t to improve code readablity.
+template <bool B, typename T1, typename T2>
+using conditional_t = typename std::conditional<B, T1, T2>::type;
+
+// select_apply_cl_t selects from T8/T16/T32/T64 basing on
+// sizeof(IN).  expected to handle scalar types in IN.
+template <typename T, typename T8, typename T16, typename T32, typename T64>
+using select_apply_cl_t =
+  conditional_t<sizeof(T) == 1, T8,
+  conditional_t<sizeof(T) == 2, T16,
+  conditional_t<sizeof(T) == 4, T32, T64>>>;
+} // detail
 
 #define DECLARE_CONVERTER(base, num)                                           \
   template <> class BaseCLTypeConverter<base, num> {                           \
   public:                                                                      \
     using DataType = GET_CL_TYPE(base, num);                                   \
+  };
+
+#define DECLARE_SIGNED_INTEGRAL_CONVERTER(base, num)                           \
+  template <> class BaseCLTypeConverter<base, num> {                           \
+  public:                                                                      \
+    using DataType = detail::select_apply_cl_t<base, GET_CL_TYPE(schar, num),  \
+      GET_CL_TYPE(short, num), GET_CL_TYPE(int, num), GET_CL_TYPE(long, num)>; \
+  };
+
+#define DECLARE_UNSIGNED_INTEGRAL_CONVERTER(base, num)                         \
+  template <> class BaseCLTypeConverter<base, num> {                           \
+  public:                                                                      \
+    using DataType = detail::select_apply_cl_t<base, GET_CL_TYPE(uchar, num),  \
+      GET_CL_TYPE(ushort, num), GET_CL_TYPE(uint, num),                        \
+      GET_CL_TYPE(ulong, num)>;                                                \
+  };
+
+#define DECLARE_FLOAT_CONVERTER(base, num)                                     \
+  template <> class BaseCLTypeConverter<base, num> {                           \
+  public:                                                                      \
+    using DataType = detail::select_apply_cl_t<base, std::false_type,          \
+      GET_CL_HALF_TYPE(half, num), GET_CL_TYPE(float, num),                    \
+      GET_CL_TYPE(double, num)>;                                               \
   };
 
 #define DECLARE_LONGLONG_CONVERTER(base, num)                                  \
@@ -1828,6 +1835,12 @@ namespace sycl {
     using DataType = GET_CL_HALF_TYPE(base, num);                              \
   };
 
+#define DECLARE_SCALAR_CONVERTER(base)                                         \
+  template <> class BaseCLTypeConverter<base, 1> {                             \
+  public:                                                                      \
+    using DataType = GET_SCALAR_CL_TYPE(base);                                 \
+  };
+
 #define DECLARE_VECTOR_CONVERTERS(base)                                        \
   namespace detail {                                                           \
   DECLARE_CONVERTER(base, 2)                                                   \
@@ -1835,11 +1848,39 @@ namespace sycl {
   DECLARE_CONVERTER(base, 4)                                                   \
   DECLARE_CONVERTER(base, 8)                                                   \
   DECLARE_CONVERTER(base, 16)                                                  \
-  template <> class BaseCLTypeConverter<base, 1> {                             \
-  public:                                                                      \
-    using DataType = GET_SCALAR_CL_TYPE(base);                                 \
-  };                                                                           \
+  DECLARE_SCALAR_CONVERTER(base)                                               \
   } // namespace detail
+
+#define DECLARE_SIGNED_INTEGRAL_VECTOR_CONVERTERS(base)                        \
+  namespace detail {                                                           \
+  DECLARE_SIGNED_INTEGRAL_CONVERTER(base, 2)                                   \
+  DECLARE_SIGNED_INTEGRAL_CONVERTER(base, 3)                                   \
+  DECLARE_SIGNED_INTEGRAL_CONVERTER(base, 4)                                   \
+  DECLARE_SIGNED_INTEGRAL_CONVERTER(base, 8)                                   \
+  DECLARE_SIGNED_INTEGRAL_CONVERTER(base, 16)                                  \
+  DECLARE_SCALAR_CONVERTER(base)                                               \
+  } // namespace detail
+
+#define DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(base)                      \
+  namespace detail {                                                           \
+  DECLARE_UNSIGNED_INTEGRAL_CONVERTER(base, 2)                                 \
+  DECLARE_UNSIGNED_INTEGRAL_CONVERTER(base, 3)                                 \
+  DECLARE_UNSIGNED_INTEGRAL_CONVERTER(base, 4)                                 \
+  DECLARE_UNSIGNED_INTEGRAL_CONVERTER(base, 8)                                 \
+  DECLARE_UNSIGNED_INTEGRAL_CONVERTER(base, 16)                                \
+  DECLARE_SCALAR_CONVERTER(base)                                               \
+  } // namespace detail
+
+#define DECLARE_FLOAT_VECTOR_CONVERTERS(base)                                  \
+  namespace detail {                                                           \
+  DECLARE_FLOAT_CONVERTER(base, 2)                                             \
+  DECLARE_FLOAT_CONVERTER(base, 3)                                             \
+  DECLARE_FLOAT_CONVERTER(base, 4)                                             \
+  DECLARE_FLOAT_CONVERTER(base, 8)                                             \
+  DECLARE_FLOAT_CONVERTER(base, 16)                                            \
+  DECLARE_SCALAR_CONVERTER(base)                                               \
+  } // namespace detail
+
 
 #define DECLARE_HALF_VECTOR_CONVERTERS(base)                                   \
   namespace detail {                                                           \
@@ -1868,12 +1909,11 @@ namespace sycl {
   } // namespace detail
 
 #define DECLARE_SYCL_VEC_WO_CONVERTERS(base)                                   \
-  using cl_##base##16 = vec<base, 16>;                                         \
-  using cl_##base##8 = vec<base, 8>;                                           \
-  using cl_##base##4 = vec<base, 4>;                                           \
-  using cl_##base##3 = vec<base, 3>;                                           \
-  using cl_##base##2 = vec<base, 2>;                                           \
-  using cl_##base = GET_SCALAR_CL_TYPE(base);                                  \
+  using cl_##base##16 = vec<cl_##base, 16>;                                    \
+  using cl_##base##8 = vec<cl_##base, 8>;                                      \
+  using cl_##base##4 = vec<cl_##base, 4>;                                      \
+  using cl_##base##3 = vec<cl_##base, 3>;                                      \
+  using cl_##base##2 = vec<cl_##base, 2>;                                      \
   using base##16 = cl_##base##16;                                              \
   using base##8 = cl_##base##8;                                                \
   using base##4 = cl_##base##4;                                                \
@@ -1886,7 +1926,6 @@ namespace sycl {
   using cl_char4 = vec<signed char, 4>;                                        \
   using cl_char3 = vec<signed char, 3>;                                        \
   using cl_char2 = vec<signed char, 2>;                                        \
-  using cl_char = signed char;                                                 \
   using char16 = vec<char, 16>;                                                \
   using char8 = vec<char, 8>;                                                  \
   using char4 = vec<char, 4>;                                                  \
@@ -1899,7 +1938,6 @@ namespace sycl {
   using cl_half4 = vec<half, 4>;                                               \
   using cl_half3 = vec<half, 3>;                                               \
   using cl_half2 = vec<half, 2>;                                               \
-  using cl_half = half;                                                        \
   using half16 = vec<half, 16>;                                                \
   using half8 = vec<half, 8>;                                                  \
   using half4 = vec<half, 4>;                                                  \
@@ -1914,8 +1952,16 @@ namespace sycl {
   using base##long3 = vec<base##long, 3>;                                      \
   using base##long2 = vec<base##long, 2>;
 
-#define DECLARE_SYCL_VEC(base)                                                 \
-  DECLARE_VECTOR_CONVERTERS(base)                                              \
+#define DECLARE_SYCL_SIGNED_INTEGRAL_VEC(base)                                 \
+  DECLARE_SIGNED_INTEGRAL_VECTOR_CONVERTERS(base)                              \
+  DECLARE_SYCL_VEC_WO_CONVERTERS(base)
+
+#define DECLARE_SYCL_UNSIGNED_INTEGRAL_VEC(base)                               \
+  DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(base)                            \
+  DECLARE_SYCL_VEC_WO_CONVERTERS(base)
+
+#define DECLARE_SYCL_FLOAT_VEC(base)                                           \
+  DECLARE_FLOAT_VECTOR_CONVERTERS(base)                                        \
   DECLARE_SYCL_VEC_WO_CONVERTERS(base)
 
 #define DECLARE_SYCL_VEC_CHAR                                                  \
@@ -1931,23 +1977,19 @@ namespace sycl {
   DECLARE_SYCL_VEC_HALF_WO_CONVERTERS
 
 DECLARE_SYCL_VEC_CHAR
-DECLARE_SYCL_VEC(schar)
-DECLARE_SYCL_VEC(uchar)
-DECLARE_SYCL_VEC(short)
-DECLARE_SYCL_VEC(ushort)
-DECLARE_SYCL_VEC(int)
-DECLARE_SYCL_VEC(uint)
-DECLARE_SYCL_VEC(long)
-DECLARE_SYCL_VEC(ulong)
+DECLARE_SYCL_SIGNED_INTEGRAL_VEC(schar)
+DECLARE_SYCL_UNSIGNED_INTEGRAL_VEC(uchar)
+DECLARE_SYCL_SIGNED_INTEGRAL_VEC(short)
+DECLARE_SYCL_UNSIGNED_INTEGRAL_VEC(ushort)
+DECLARE_SYCL_SIGNED_INTEGRAL_VEC(int)
+DECLARE_SYCL_UNSIGNED_INTEGRAL_VEC(uint)
+DECLARE_SYCL_SIGNED_INTEGRAL_VEC(long)
+DECLARE_SYCL_UNSIGNED_INTEGRAL_VEC(ulong)
 DECLARE_SYCL_VEC_LONGLONG(long)
 DECLARE_SYCL_VEC_LONGLONG(ulong)
 DECLARE_SYCL_VEC_HALF(half)
-DECLARE_SYCL_VEC(float)
-DECLARE_SYCL_VEC(double)
-
-using cl_bool = ::cl_bool;
-using byte = uchar;
-using half = ::half;
+DECLARE_SYCL_FLOAT_VEC(float)
+DECLARE_SYCL_FLOAT_VEC(double)
 
 #undef GET_CL_TYPE
 #undef GET_SCALAR_CL_TYPE

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -1770,7 +1770,7 @@ template <int NumElements, typename CLType> struct alignas(CLType) half_vec {
 
 typedef half __half_t;
 typedef half_vec<2, cl_half2> __half2_vec_t;
-typedef half_vec<3, cl_half3> __half3_vec_t;
+typedef half_vec<4, cl_half3> __half3_vec_t;
 typedef half_vec<4, cl_half4> __half4_vec_t;
 typedef half_vec<8, cl_half8> __half8_vec_t;
 typedef half_vec<16, cl_half16> __half16_vec_t;

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -17,11 +17,28 @@ using namespace std;
 using cl_schar = cl_char;
 using cl_schar4 = cl_char4;
 
+namespace s = cl::sycl;
+
 #define CHECK_TYPE(type)                                                       \
   static_assert(sizeof(cl_##type) == sizeof(cl::sycl::cl_##type), "Wrong "     \
                                                                   "size")
 
 #define CHECK_SIZE(T, S) static_assert(sizeof(T) == S, "Wrong size of type");
+
+#define CHECK_SIZE_VEC_N(T, n)                                \
+  static_assert(n * sizeof(T) == sizeof(cl::sycl::vec<T, n>), \
+                    "Wrong size of vec<type>");
+
+#define CHECK_SIZE_VEC_N3(T)                                  \
+  static_assert(sizeof(cl::sycl::vec<T, 3>) == sizeof(cl::sycl::vec<T, 4>), \
+                    "Wrong size of vec<cl_type3>");
+
+#define CHECK_SIZE_VEC(T) \
+  CHECK_SIZE_VEC_N(T, 2); \
+  CHECK_SIZE_VEC_N3(T);   \  
+  CHECK_SIZE_VEC_N(T, 4); \
+  CHECK_SIZE_VEC_N(T, 8); \
+  CHECK_SIZE_VEC_N(T, 16);
 
 #define CHECK_SIZE_TYPE_I(T, S)                                                \
   CHECK_SIZE(T, S)                                                             \
@@ -50,7 +67,6 @@ int main() {
   CHECK_TYPE(ulong);
   CHECK_TYPE(float);
   CHECK_TYPE(double);
-  CHECK_TYPE(bool);
   CHECK_TYPE(char2);
   CHECK_TYPE(uchar3);
   CHECK_TYPE(short4);
@@ -80,6 +96,31 @@ int main() {
   CHECK_SIZE_TYPE_F(cl::sycl::cl_float, 4);
   CHECK_SIZE_TYPE_F(cl::sycl::cl_double, 8);
   // CHECK_SIZE_TYPE_F(cl::sycl::cl_half, 2);
+
+  CHECK_SIZE_VEC(char);
+  CHECK_SIZE_VEC(short);
+  CHECK_SIZE_VEC(unsigned short);
+  CHECK_SIZE_VEC(int);
+  CHECK_SIZE_VEC(unsigned int);
+  CHECK_SIZE_VEC(long);
+  CHECK_SIZE_VEC(unsigned long);
+  CHECK_SIZE_VEC(long long);
+  CHECK_SIZE_VEC(unsigned long long);
+  CHECK_SIZE_VEC(float);
+  CHECK_SIZE_VEC(double);
+
+  CHECK_SIZE_VEC(s::cl_char);
+  CHECK_SIZE_VEC(s::cl_schar);
+  CHECK_SIZE_VEC(s::cl_uchar);
+  CHECK_SIZE_VEC(s::cl_short);
+  CHECK_SIZE_VEC(s::cl_ushort);
+  CHECK_SIZE_VEC(s::cl_half);
+  CHECK_SIZE_VEC(s::cl_int);
+  CHECK_SIZE_VEC(s::cl_uint);
+  CHECK_SIZE_VEC(s::cl_long);
+  CHECK_SIZE_VEC(s::cl_ulong);
+  CHECK_SIZE_VEC(s::cl_float);
+  CHECK_SIZE_VEC(s::cl_double);
 
   using value_type = decltype(std::declval<cl::sycl::item<1>>()[0]);
   static_assert(!std::is_reference<value_type>::value,

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -35,7 +35,7 @@ namespace s = cl::sycl;
 
 #define CHECK_SIZE_VEC(T) \
   CHECK_SIZE_VEC_N(T, 2); \
-  CHECK_SIZE_VEC_N3(T);   \  
+  CHECK_SIZE_VEC_N3(T);   \
   CHECK_SIZE_VEC_N(T, 4); \
   CHECK_SIZE_VEC_N(T, 8); \
   CHECK_SIZE_VEC_N(T, 16);


### PR DESCRIPTION
SYCL vector types are created from scalar C++ types basing
on their sizeof(), not just their names alone.

Signed-off-by: Sergey Zverev <sergey.i.zverev@intel.com>