### PR TITLE
[SYCL] Remove using std namespace as appropriate header is not included

### DIFF
--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -73,7 +73,7 @@ using make_index_sequence = __make_integer_seq<integer_sequence, size_t, N>;
 template <typename T> struct KernelInfoImpl {
 private:
   static constexpr auto n = __unique_stable_name(T);
-  template <std::size_t... I>
+  template <size_t... I>
   static KernelInfoData<n[I]...> impl(index_sequence<I...>) {
     return {};
   }


### PR DESCRIPTION
Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>