### PR TITLE
[SYCL] Optionally print Graph to file

### DIFF
--- a/sycl/doc/SYCL_environment_variables.md
+++ b/sycl/doc/SYCL_environment_variables.md
@@ -8,3 +8,17 @@ This file describes environment variables that are having effect on SYCL compile
 | ----------- | ----------- |
 | SYCL_PI_TRACE | If set forces tracing of PI calls to stdout. |
 | SYCL_BE={PI_OPENCL,PI_OTHER} | When SYCL RT is buils with PI this controls which plugin to use. |
+| SYCL_PRINT_EXECUTION_GRAPH | Print execution graph to DOT text file. Options are described below. |
+
+SYCL_PRINT_EXECUTION_GRAPH can accept one or more comma separated values from table below
+
+| Option | Description |
+| ------ | ----------- |
+| before_addCG | print graph before addCG method |
+| after_addCG | print graph after addCG method |
+| before_addCopyBack | print graph before addCopyBack method |
+| after_addCopyBack | print graph after addCopyBack method |
+| before_addHostAcc | print graph before addHostAccessor method |
+| after_addHostAcc | print graph after addHostAccessor method |
+| always | print graph before and after each of the above methods |
+

--- a/sycl/include/CL/sycl/detail/scheduler/commands.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.hpp
@@ -97,6 +97,8 @@ public:
 
   virtual ~Command() = default;
 
+  virtual void printDot(std::ostream &Stream) const = 0;
+
 protected:
   EventImplPtr MEvent;
   QueueImplPtr MQueue;
@@ -125,6 +127,8 @@ public:
   ReleaseCommand(QueueImplPtr Queue, AllocaCommandBase *AllocaCmd)
       : Command(CommandType::RELEASE, std::move(Queue)), MAllocaCmd(AllocaCmd) {
   }
+
+  void printDot(std::ostream &Stream) const override;
 
 private:
   cl_int enqueueImp() override;
@@ -162,6 +166,8 @@ public:
     addDep(DepDesc(nullptr, &MReq, this));
   }
 
+  void printDot(std::ostream &Stream) const override;
+
 private:
   cl_int enqueueImp() override final;
 
@@ -176,6 +182,8 @@ public:
         MParentAlloca(ParentAlloca) {
     addDep(DepDesc(MParentAlloca, &MReq, MParentAlloca));
   }
+
+  void printDot(std::ostream &Stream) const override;
 
 private:
   cl_int enqueueImp() override final;
@@ -193,6 +201,8 @@ public:
   Requirement *MDstAcc = nullptr;
   Requirement MDstReq;
 
+  void printDot(std::ostream &Stream) const override;
+
 private:
   cl_int enqueueImp() override;
 };
@@ -202,6 +212,8 @@ public:
   UnMapMemObject(Requirement SrcReq, AllocaCommandBase *SrcAlloca,
                  Requirement *DstAcc, QueueImplPtr Queue,
                  bool UseExclusiveQueue = false);
+
+  void printDot(std::ostream &Stream) const override;
 
 private:
   cl_int enqueueImp() override;
@@ -230,6 +242,8 @@ public:
     MAccToUpdate = AccToUpdate;
   }
 
+  void printDot(std::ostream &Stream) const override;
+
 private:
   cl_int enqueueImp() override;
 };
@@ -247,6 +261,8 @@ public:
   Requirement MDstReq;
   Requirement *MDstAcc = nullptr;
 
+  void printDot(std::ostream &Stream) const override;
+
 private:
   cl_int enqueueImp() override;
 };
@@ -259,6 +275,8 @@ public:
         MCommandGroup(std::move(CommandGroup)) {}
 
   void flushStreams();
+
+  void printDot(std::ostream &Stream) const override;
 
 private:
   // Implementation of enqueueing of ExecCGCommand.

--- a/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
@@ -69,6 +69,8 @@ private:
   // graph (e.g. add/remove edges/nodes).
   class GraphBuilder {
   public:
+    GraphBuilder();
+
     // Registers command group, adds it to the dependency graph and returns an
     // command that represents command group execution. It's called by SYCL's
     // queue::submit.
@@ -161,6 +163,19 @@ private:
 
     void markModifiedIfWrite(GraphBuilder::MemObjRecord *Record,
                              Requirement *Req);
+
+    // Print contents of graph to text file in DOT format
+    void printGraphAsDot(const char *ModeName);
+    enum PrintOptions {
+      BeforeAddCG = 0,
+      AfterAddCG,
+      BeforeAddCopyBack,
+      AfterAddCopyBack,
+      BeforeAddHostAcc,
+      AfterAddHostAcc,
+      Size
+    };
+    std::array<bool, PrintOptions::Size> MPrintOptionsArray;
   };
 
   // The class that provides interfaces for enqueueing command and its


### PR DESCRIPTION
Add means to print Graph in dot format to file.
The following parameters may be passed to SYCL_PRINT_EXECUTION_GRAPH
env variable, that controls printer behavior:

- before_addCG -- print graph before addCG method
- after_addCG -- print graph after addCG method
- before_addCopyBack -- print graph before addCopyBack method
- after_addCopyBack -- print graph after addCopyBack method
- before_addHostAcc -- print graph before addHostAccessor method
- after_addHostAcc -- print graph after addHostAccessor method
- always -- print graph before and after each of the above methods

Multiple values may be passed like this:
SYCL_PRINT_EXECUTION_GRAPH="before_addCG,before_addCopyBack"

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>