### PR TITLE
[SYCL] Avoid iteration through empty wait list in GraphProcessor

### DIFF
--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -23,14 +23,16 @@ static Command *getCommand(const EventImplPtr &Event) {
 
 std::vector<EventImplPtr>
 Scheduler::GraphProcessor::getWaitList(EventImplPtr Event) {
-  std::vector<EventImplPtr> Result;
   Command *Cmd = getCommand(Event);
-  // We can't iterate through the empty command
-  if (Cmd)
-    for (const DepDesc &Dep : Cmd->MDeps) {
-      if (Dep.MDepCommand)
-        Result.push_back(Dep.MDepCommand->getEvent());
-    }
+  // We can't iterate through the empty command. It can be empty if Event was
+  // created with default constructor and was not initialized after)
+  if (!Cmd)
+    return {};
+  std::vector<EventImplPtr> Result;
+  for (const DepDesc &Dep : Cmd->MDeps) {
+    if (Dep.MDepCommand)
+      Result.push_back(Dep.MDepCommand->getEvent());
+  }
   return Result;
 }
 

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -25,10 +25,12 @@ std::vector<EventImplPtr>
 Scheduler::GraphProcessor::getWaitList(EventImplPtr Event) {
   std::vector<EventImplPtr> Result;
   Command *Cmd = getCommand(Event);
-  for (const DepDesc &Dep : Cmd->MDeps) {
-    if (Dep.MDepCommand)
-      Result.push_back(Dep.MDepCommand->getEvent());
-  }
+  // We can't iterate through the empty command
+  if (Cmd)
+    for (const DepDesc &Dep : Cmd->MDeps) {
+      if (Dep.MDepCommand)
+        Result.push_back(Dep.MDepCommand->getEvent());
+    }
   return Result;
 }
 

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -24,8 +24,8 @@ static Command *getCommand(const EventImplPtr &Event) {
 std::vector<EventImplPtr>
 Scheduler::GraphProcessor::getWaitList(EventImplPtr Event) {
   Command *Cmd = getCommand(Event);
-  // We can't iterate through the empty command. It can be empty if Event was
-  // created with default constructor and was not initialized after)
+  // Command can be nullptr if user creates cl::sycl::event explicitly,
+  // as such event is not mapped to any SYCL task.
   if (!Cmd)
     return {};
   std::vector<EventImplPtr> Result;

--- a/sycl/test/scheduler/GetWaitList.cpp
+++ b/sycl/test/scheduler/GetWaitList.cpp
@@ -1,0 +1,25 @@
+// RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
+// RUN: %t.out
+//==------------------- GetWaitList.cpp ----------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+void foo() {
+  cl::sycl::event start;
+  start.wait_and_throw();
+  return;
+}
+
+int main() {
+  cl::sycl::queue Q;
+  Q.submit([&](cl::sycl::handler &CGH) {
+    foo();
+  });
+  return 0;
+}


### PR DESCRIPTION
Signed-off-by: Viktoria Maksimova <viktoria.maksimova@intel.com>