### PR TITLE
[SYCL] Remove redundant assertion

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -119,10 +119,9 @@ void Scheduler::removeMemoryObject(detail::SYCLMemObjI *MemObj) {
   std::lock_guard<std::mutex> lock(MGraphLock);
 
   GraphBuilder::MemObjRecord *Record = MGraphBuilder.getMemObjRecord(MemObj);
-  if (!Record) {
-    assert(false && "No operations were performed on the mem object?");
+  if (!Record)
+    // No operations were performed on the mem object
     return;
-  }
   waitForRecordToFinish(Record);
   MGraphBuilder.cleanupCommandsForRecord(Record);
   MGraphBuilder.removeRecordForMemObj(MemObj);


### PR DESCRIPTION
This assertion fails if user creates and doesn't use buffer on device, no
need to crash in this case.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>