### PR TITLE
[SYCL] Avoid stack overflow in basic_tests/device_event.cpp on Windows

### DIFF
--- a/sycl/test/basic_tests/device_event.cpp
+++ b/sycl/test/basic_tests/device_event.cpp
@@ -17,7 +17,7 @@
 using namespace cl::sycl;
 
 // Define the number of work items to enqueue.
-const int nElems = 1024*1024u;
+const int nElems = 128*1024u;
 const int workGroupSize = 16;
 
 // Check the result is correct.


### PR DESCRIPTION

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>