### PR TITLE
[SYCL] Avoid spurious error about call through function pointer

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -118,7 +118,8 @@ public:
           SemaRef.addSyclDeviceDecl(Def);
         }
       }
-    } else if (!SemaRef.getLangOpts().SYCLAllowFuncPtr)
+    } else if (!SemaRef.getLangOpts().SYCLAllowFuncPtr &&
+               !e->isTypeDependent())
       SemaRef.Diag(e->getExprLoc(), diag::err_sycl_restrict)
           << Sema::KernelCallFunctionPointer;
     return true;

--- a/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
+++ b/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -fsycl-is-device -std=c++14 -verify -fsyntax-only -x c++ %s
+// expected-no-diagnostics
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class fake_kernel>([]() {
+    auto l = [](auto f) { f(); };
+  });
+  return 0;
+}


### PR DESCRIPTION
Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>