### PR TITLE
[SYCL] Fix assertion for sycl keyword using without -fsycl option.

### DIFF
--- a/clang/lib/Basic/IdentifierTable.cpp
+++ b/clang/lib/Basic/IdentifierTable.cpp
@@ -101,7 +101,7 @@ namespace {
     KEYOPENCLCXX  = 0x400000,
     KEYMSCOMPAT   = 0x800000,
     KEYSYCL       = 0x1000000,
-    KEYALLCXX = KEYSYCL | KEYCXX | KEYCXX11 | KEYCXX2A,
+    KEYALLCXX = KEYCXX | KEYCXX11 | KEYCXX2A,
     KEYALL = (0x1ffffff & ~KEYNOMS18 &
               ~KEYNOOPENCL) // KEYNOMS18 and KEYNOOPENCL are used to exclude.
   };

--- a/clang/test/SemaSYCL/keyword.cpp
+++ b/clang/test/SemaSYCL/keyword.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -verify -fsyntax-only -std=c++11 %s
+//
+// expected-no-diagnostics 
+int foo(bool __pipe);
+int foo(bool __read_only);
+int foo(bool __write_only);


### PR DESCRIPTION
This is to fix assertion when clang compile C++ head file without -fsycl

The problem is when __pipe (one of sycl keyworld) used without
-fsycl
option, the __pipe should not be keyword and keyword status should be
KS_Disable.  But it is wrongly set to KS_Future.

The root problem is the KEYSYCL is add to KEYALLCXX:

KEYALLCXX = KEYSYCL | KEYCXX | KEYCXX11 | KEYCXX2A

It seems, we want KEYSYCL to be part of feature of C++.  But which C++
should belong: C++11 or C++2a?  (for example KEYCX2A... vs concept)

For now we should just use -fsycl option to control this.

Signed-off-by: Yu <jennifer.yu@intel.com>