### PR TITLE
[SYCL] Fix program_manager.cpp test on Windows

### DIFF
--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -77,6 +77,8 @@ OSModuleHandle OSUtil::getOSModuleHandle(const void *VirtAddr) {
      // necessary action
      return 0;
   }
+  if (PhModule == GetModuleHandleA(nullptr))
+    return OSUtil::ExeModuleHandle;
   return reinterpret_cast<OSModuleHandle>(PhModule);
 }
 #endif // SYCL_RT_OS_WINDOWS

--- a/sycl/source/detail/pi_opencl.cpp
+++ b/sycl/source/detail/pi_opencl.cpp
@@ -86,8 +86,7 @@ pi_result OCL(piProgramCreate)(pi_context context, const void *il,
   cl_int ret_err = clGetContextInfo(pi_cast<cl_context>(context),
                                     CL_CONTEXT_DEVICES, 0, NULL, &deviceCount);
 
-  std::vector<cl_device_id> devicesInCtx;
-  devicesInCtx.reserve(deviceCount);
+  std::vector<cl_device_id> devicesInCtx(deviceCount);
 
   ret_err = clGetContextInfo(pi_cast<cl_context>(context), CL_CONTEXT_DEVICES,
                              deviceCount * sizeof(cl_device_id),


### PR DESCRIPTION
There were two issues which prevented test from running. First problem
was in the OSUtil::getOSModuleHandle(). It did not return the predefined
handle for the executable's module which in turn did not allow
program manager to find the target program that was registered by
__tgt_register_lib at startup. And the second problem was in the misuse
of std::vector<...>::reserve() for increasing vector size which lead to
a write to unallocated memory.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>