### PR TITLE
[SYCL] Fix compilation error caused by void function returning a value

### DIFF
--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -140,7 +140,6 @@ void writePixel(vec<T, 4> Pixel, T *Ptr, image_channel_order Order) {
     assert(!"Unhandled image channel order");
     break;
   }
-  return Pixel;
 }
 
 // Converts read pixel data into return datatype based on the channel type of


### PR DESCRIPTION
This seems like an oversight which unfortunately breaks compilation. Since the return value isn't used anywhere I simply deleted it.