### PR TITLE
[SYCL] Don't emit exception handling code for device

### DIFF
--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -717,8 +717,8 @@ llvm::BasicBlock *CodeGenFunction::getInvokeDestImpl() {
       return nullptr;
   }
 
-  // CUDA device code doesn't have exceptions.
-  if (LO.CUDA && LO.CUDAIsDevice)
+  // CUDA and SYCL device code doesn't have exceptions.
+  if (LO.CUDA && LO.CUDAIsDevice || LO.SYCLIsDevice)
     return nullptr;
 
   // Check the innermost scope for a cached landing pad.  If this is

--- a/clang/test/CodeGenSYCL/noexcept.cpp
+++ b/clang/test/CodeGenSYCL/noexcept.cpp
@@ -1,0 +1,53 @@
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I%S -fsycl-is-device \
+// RUN:      -std=c++11 -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
+// RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-DEVICE
+//
+// RUN: %clang_cc1  -I%S -std=c++11 -fcxx-exceptions -fexceptions -disable-llvm-passes \
+// RUN:      -x c++ -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-HOST
+
+// The test checks that exception handling code is generated only for host and not for device.
+
+void f1() {}
+void f2() {}
+void f3() {}
+
+void foo_noexcept() noexcept {
+  // CHECK-DEVICE: call spir_func void @_Z2f1v()
+  // CHECK-HOST: invoke void @_Z2f1v()
+  f1();
+}
+
+void foo_throw() throw() {
+  // CHECK-DEVICE: call spir_func void @_Z2f2v()
+  // CHECK-HOST: invoke void @_Z2f2v()
+  f2();
+}
+
+struct A {
+  // Non-trivial destructor to force generation of cleanup code
+  ~A(){}
+};
+
+void foo_cleanup() {
+  A a;
+  // CHECK-DEVICE: call spir_func void @_Z2f3v()
+  // CHECK-HOST: invoke void @_Z2f3v()
+  f3();
+  // CHECK-DEVICE: call spir_func void @_ZN1AD1Ev
+  // Regular + exception cleanup
+  // CHECK-HOST: call void @_ZN1AD1Ev
+  // CHECK-HOST: call void @_ZN1AD1Ev
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class kernel>([=](){
+    foo_noexcept();
+    foo_throw();
+    foo_cleanup();
+  });
+}


### PR DESCRIPTION
In order to support exception handling, the compiler
generates additional code inside functions to perform
cleanup, catch unexpected exceptions. This is done
by calling a function that may throw using "invoke"
LLVM instruction with additional landing pad code
instead of simple "call".
Previously, when such code is generated, llvm-spirv
would fail to translate it as it doesn't know how to
handle "invoke" instruction.

There is no support for exceptions on device side,
so generation of such exception handling code
(including "invoke" instruction) can be simply disabled.

Signed-off-by: Ilya Stepykin <ilya.stepykin@intel.com>