### PR TITLE
[SYCL] Avoid trying to add metadata to nonexistent alloca

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1312,7 +1312,8 @@ void CodeGenFunction::EmitAutoVarDecl(const VarDecl &D) {
   AutoVarEmission emission = EmitAutoVarAlloca(D);
   EmitAutoVarInit(emission);
   EmitAutoVarCleanups(emission);
-  if (CGM.getLangOpts().SYCLIsDevice)
+  // No alloca in case of NRVO (named return value optimization) variable.
+  if (CGM.getLangOpts().SYCLIsDevice && !D.isNRVOVariable())
     CGM.getSYCLRuntime().actOnAutoVarEmit(
         *this, D, emission.getOriginalAllocatedAddress().getPointer());
 }


### PR DESCRIPTION
If local variable is NRVO variable, i.e. is was optimized away and hence
doesn't have an alloca instruction, no need try to do any actions on
this alloca instruction.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>