### PR TITLE
[SYCL] Fix llvm_unreachable in reqd-work-group-size test

### DIFF
--- a/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Functor32x16x16 {
 public:


### PR DESCRIPTION
We support only spir/spir64 target for SYCL device code and emit
llvm_unreachable if passed target is unsupported.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>