### PR TITLE
[SYCL] Introduce run-time PI tracing wrapper.

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -88,12 +88,12 @@ namespace pi {
   // TODO: replace PiCall completely with this one (PiTrace)
   //
   template <typename T> inline
-  void Print(T val) {
+  void print(T val) {
     std::cout << "<unknown> : " << val;
   }
 
-  template<> inline void Print<> (PiPlatform val) { std::cout << "pi_platform : " << val; }
-  template<> inline void Print<> (PiResult val) {
+  template<> inline void print<> (PiPlatform val) { std::cout << "pi_platform : " << val; }
+  template<> inline void print<> (PiResult val) {
     std::cout << "pi_result : ";
     if (val == PI_SUCCESS)
       std::cout << "PI_SUCCESS";
@@ -101,12 +101,12 @@ namespace pi {
       std::cout << val; 
   }
   
-  inline void PrintArgs(void) {}
+  inline void printArgs(void) {}
   template <typename Arg0, typename... Args>
-  void PrintArgs(Arg0 arg0, Args... args) {
+  void printArgs(Arg0 arg0, Args... args) {
     std::cout << std::endl << "       ";
-    Print(arg0);
-    PrintArgs(std::forward<Args>(args)...);
+    print(arg0);
+    printArgs(std::forward<Args>(args)...);
   }
   
   template <typename FnType>
@@ -124,14 +124,14 @@ namespace pi {
     typename std::result_of<FnType(Args...)>::type
     operator() (Args... args) {
       if (m_TraceEnabled)
-        PrintArgs(args...);
+        printArgs(args...);
 
       piInitialize();
       auto r = m_FnPtr(args...);
 
       if (m_TraceEnabled) {
         std::cout << ") ---> ";
-        std::cout << (Print(r),"") << "\n";
+        std::cout << (print(r),"") << "\n";
       }
       return r;
     }

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -62,7 +62,7 @@ void piInitialize() {
     piDie("Unknown SYCL_BE");
   }
   #define _PI_API(api)                          \
-    extern decltype(::api) * api##OclPtr; \
+    extern const decltype(::api) * api##OclPtr; \
     api = api##OclPtr;
   #include <CL/sycl/detail/pi.def>
 

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -62,7 +62,7 @@ void piInitialize() {
     piDie("Unknown SYCL_BE");
   }
   #define _PI_API(api)                          \
-    extern const decltype(::api) * api##OclPtr; \
+    extern decltype(::api) * api##OclPtr; \
     api = api##OclPtr;
   #include <CL/sycl/detail/pi.def>
 
@@ -111,7 +111,6 @@ void PiCall::check(RT::PiResult Result) {
 
 template void PiCall::check<cl::sycl::runtime_error>(RT::PiResult);
 template void PiCall::check<cl::sycl::compile_program_error>(RT::PiResult);
-
 
 } // namespace pi
 } // namespace detail

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -53,8 +53,10 @@ platform_impl_pi::get_devices(info::device_type deviceType) const {
     return res;
 
   pi_uint32 num_devices;
-  PI_CALL(RT::piDevicesGet(
-      m_platform, pi::pi_cast<RT::PiDeviceType>(deviceType), 0, 0, &num_devices));
+  PI_TRACE(RT::piDevicesGet)(
+      m_platform, pi::pi_cast<RT::PiDeviceType>(deviceType),
+      0, pi::pi_cast<RT::PiDevice *>(nullptr),
+      &num_devices);
 
   if (num_devices == 0)
     return res;


### PR DESCRIPTION
Added capability for tracing with run-time argument values printed:
Here is a sample output of the single PI call using the new tracing:

`---> RT::piDevicesGet( pi_platform : 0xdbfe68 <unknown> : 4 <unknown> : 0 <unknown> : 0 <unknown> : 0x7fff70f0b798) ---> pi_result : PI_SUCCESS`

The new "Trace" wrapper also provides robust PI initialization placeholder. 

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>