### PR TITLE
[SYCL] Fix cast of __ocl_sampler_t type in member initializer

### DIFF
--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -8096,9 +8096,10 @@ ExprResult InitializationSequence::Perform(Sema &S,
       //      1a. argument is a file-scope variable
       //      1b. argument is a function-scope variable
       //      1c. argument is one of caller function's parameters
-      //   2. variable initialization
-      //      2a. initializing a file-scope variable
-      //      2b. initializing a function-scope variable
+      //   2. member initialization from a variable
+      //   3. variable initialization
+      //      3a. initializing a file-scope variable
+      //      3b. initializing a function-scope variable
       //
       // For file-scope variables, since they cannot be initialized by function
       // call of __translate_sampler_initializer in LLVM IR, their references
@@ -8138,8 +8139,17 @@ ExprResult InitializationSequence::Perform(Sema &S,
             Var->getInit()))->getSubExpr();
           SourceType = Init->getType();
         }
+      } else if (Entity.getKind() == InitializedEntity::EK_Member &&
+                 !Entity.isImplicitMemberInitializer() &&
+                 !Entity.isDefaultMemberInitializer() &&
+                 isa<DeclRefExpr>(Init)) {
+        // Case 2: Member initialization from a variable.
+        CurInit =
+            ImplicitCastExpr::Create(S.Context, Step->Type, CK_LValueToRValue,
+                                     Init, /*BasePath=*/nullptr, VK_RValue);
+        break;
       } else {
-        // Case 2
+        // Case 3
         // Check initializer is 32 bit integer constant.
         // If the initializer is taken from global variable, do not diagnose since
         // this has already been done when parsing the variable declaration.
@@ -8177,7 +8187,7 @@ ExprResult InitializationSequence::Perform(Sema &S,
                  << "Addressing Mode";
       }
 
-      // Cases 1a, 2a and 2b
+      // Cases 1a, 3a and 3b
       // Insert cast from integer to sampler.
       CurInit = S.ImpCastExprToType(Init, S.Context.OCLSamplerTy,
                                       CK_IntToOCLSampler);

--- a/clang/test/SemaSYCL/sampler_t-member-init.cpp
+++ b/clang/test/SemaSYCL/sampler_t-member-init.cpp
@@ -1,0 +1,45 @@
+// RUN: %clang_cc1 %s -fsycl-is-device -ast-dump 2>&1 | FileCheck %s
+
+const __ocl_sampler_t Global = 0;
+
+class Foo {
+  int i;
+  __ocl_sampler_t Member;
+  __ocl_sampler_t Member2;
+  __ocl_sampler_t Member3;
+  __ocl_sampler_t Member4;
+
+  Foo(__ocl_sampler_t Param) :
+    // CHECK: CXXConstructorDecl
+    // CHECK-SAME: Foo 'void (__ocl_sampler_t)'
+    Member(Param),
+    // CHECK: CXXCtorInitializer Field
+    // CHECK-SAME: 'Member' '__ocl_sampler_t':'sampler_t'
+    // CHECK-NEXT: ImplicitCastExpr
+    // CHECK-SAME: '__ocl_sampler_t':'sampler_t' <LValueToRValue>
+    // CHECK-NEXT: DeclRefExpr
+    // CHECK-SAME: lvalue ParmVar
+    // CHECK-SAME: 'Param' '__ocl_sampler_t':'sampler_t'
+    Member2(4),
+    // CHECK: CXXCtorInitializer Field
+    // CHECK-SAME: 'Member2' '__ocl_sampler_t':'sampler_t'
+    // CHECK-NEXT: ImplicitCastExpr
+    // CHECK-SAME: 'sampler_t' <IntToOCLSampler>
+    // CHECK-NEXT: IntegerLiteral
+    // CHECK-SAME: 'int' 4
+    Member3(),
+    // CHECK: CXXCtorInitializer Field
+    // CHECK-SAME: 'Member3' '__ocl_sampler_t':'sampler_t'
+    // CHECK-NEXT: ImplicitValueInitExpr
+    // CHECK-SAME: '__ocl_sampler_t':'sampler_t'
+    Member4(Global)
+    // CHECK: CXXCtorInitializer Field
+    // CHECK-SAME: 'Member4' '__ocl_sampler_t':'sampler_t'
+    // CHECK-NEXT: ImplicitCastExpr
+    // CHECK-SAME: '__ocl_sampler_t':'sampler_t' <LValueToRValue>
+    // CHECK-NEXT: DeclRefExpr
+    // CHECK-SAME: lvalue Var
+    // CHECK-SAME: 'Global' 'const __ocl_sampler_t':'const sampler_t'
+  {}
+};
+


### PR DESCRIPTION
Since OpenCL/OpenCLCXX doesn't permit the sample_t to be used as a
struct member, Clang lacks any implementation of member initialization
in a constructor.  This results in the initializer doing an assignment
from an LValue, which causes Sema to issue a warning that binding a
reference to a stack allocated parameter (-Wdangling-field) when
attempting to initialize a member from a constructor parameter.

This warning is obviously wrong, however is a result of a malformed AST,
mostly that assigning an LValue from an LValue isn't legal.  This patch
correctly inserts an LValue to RValue cast in this situation, which
prevents the warning seen in the header and should avoid an assert in
the future if one is added to later validate this behavior.

Signed-off-by: Erich Keane <erich.keane@intel.com>