### PR TITLE
[SYCL]Fix assertion in auto var emission

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1312,7 +1312,7 @@ void CodeGenFunction::EmitAutoVarDecl(const VarDecl &D) {
   AutoVarEmission emission = EmitAutoVarAlloca(D);
   EmitAutoVarInit(emission);
   EmitAutoVarCleanups(emission);
-  if (CGM.getLangOpts().SYCLIsDevice)
+  if (CGM.getLangOpts().SYCLIsDevice && !emission.IsConstantAggregate)
     CGM.getSYCLRuntime().actOnAutoVarEmit(
         *this, D, emission.getOriginalAllocatedAddress().getPointer());
 }


### PR DESCRIPTION
In cases where a variable is emitted with a const initializer, there is
no alloca emitted, thus we cannot get the address of it.  This was
causing a crash in address-space-of-returns.cpp.

Signed-off-by: Erich Keane <erich.keane@intel.com>