### PR TITLE
[SYCL] Add template template parameter support

### DIFF
--- a/clang/test/CodeGenSYCL/template-template-parameter.cpp
+++ b/clang/test/CodeGenSYCL/template-template-parameter.cpp
@@ -1,0 +1,72 @@
+// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s
+// RUN: FileCheck -input-file=%t.h %s
+
+#include <sycl.hpp>
+
+using namespace cl::sycl;
+
+template <typename T> class Foo1;
+// CHECK: template <typename T> class Foo1;
+template <template <typename> class TT> class KernelName1;
+// CHECK: template <template <typename> class TT> class KernelName1;
+template <template <typename> class TT> void enqueue() {
+  queue q;
+  q.submit([&](handler &cgh) {
+    cgh.single_task<KernelName1<TT>>([](){});
+  });
+}
+
+template <typename TY> class Bar2;
+// CHECK: template <typename TY> class Bar2;
+template <template <typename> class TT> class Foo2;
+// CHECK: template <template <typename> class TT> class Foo2;
+template <class TTY> class KernelName2;
+// CHECK: template <class TTY> class KernelName2;
+template <class Y> void enqueue2() {
+  queue q;
+  q.submit([&](handler &cgh) {
+    cgh.single_task< KernelName2<Y> >([](){});
+  });
+}
+
+template <typename T> class Bar3;
+// CHECK: template <typename T> class Bar3;
+template <template <typename> class> class Baz3;
+// CHECK: template <template <typename> class > class Baz3;
+template <template <template <typename> class> class T> class Foo3;
+// CHECK: template <template <template <typename> class > class T> class Foo3;
+template <typename T , typename... Args> class Mist3;
+// CHECK: template <typename T, typename ...Args> class Mist3;
+template <typename T, template <typename, typename...> class, typename... Args> class Ice3;
+// CHECK: template <typename T, template <typename, typename ...> class , typename ...Args> class Ice3;
+
+int main() {
+  enqueue<Foo1>();
+
+  enqueue2<Foo2<Bar2>>();
+  
+  queue q;
+
+  q.submit([&](handler &cgh) {
+    cgh.single_task<Bar3<int>>([](){});
+  });
+
+  q.submit([&](handler &cgh) {
+    cgh.single_task<Baz3<Bar3>>([](){});
+  });
+
+  q.submit([&](handler &cgh) {
+    cgh.single_task<Foo3<Baz3>>([](){});
+  });
+
+  q.submit([&](handler &cgh) {
+    cgh.single_task<Mist3<int, float, char, double>>([](){});
+  });
+
+  q.submit([&](handler &cgh) {
+    cgh.single_task<Ice3<int, Mist3, char, short, float>>([](){});
+  });
+
+  return 0;
+}
+


### PR DESCRIPTION
During the generation of the integration header, the forward declaration of the template template parameter did not printed.

In case of template template argument it is not necessary to call emitForwardClassDecls function recursively because of the maximum nesting level of template argument is equals two.

For example:
```
template <typename T> class Bar;
template <template <typename> class> class Baz;
template <template <template <typename> class> class T> class Foo;
```
The `Baz` is a template class. 
The `Baz<Bar>` is a class. 
The class Foo should be specialized with template class, not a class. 
The correct specialization of template class Foo is `Foo<Baz>`.
The incorrect specialization of template class Foo is `Foo<Baz<Bar>>`. In this case template class Foo specialized by class `Baz<Bar>`, not a template class `template <template <typename> class> class T` as it should. 
The maximum level of template nesting in specialization is 2. 

The proposed fix prints forward declaration of Foo and Baz template classes into integration header. It's enough to prints declaration of template argument inside switch block. 

Signed-off-by: idubinov <igor.dubinov@intel.com>