### PR TITLE
[SYCL] Expand assertion for SYCL

### DIFF
--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -26,10 +26,12 @@ using namespace CodeGen;
 
 static void EmitDeclInit(CodeGenFunction &CGF, const VarDecl &D,
                          ConstantAddress DeclPtr) {
-  assert(
-      (D.hasGlobalStorage() ||
-       (D.hasLocalStorage() && CGF.getContext().getLangOpts().OpenCLCPlusPlus)) &&
-      "VarDecl must have global or local (in the case of OpenCL) storage!");
+  assert((D.hasGlobalStorage() ||
+          (D.hasLocalStorage() &&
+           (CGF.getContext().getLangOpts().OpenCLCPlusPlus ||
+            CGF.getContext().getLangOpts().SYCLIsDevice))) &&
+         "VarDecl must have global or local (in the case of OpenCL and SYCL) "
+         "storage!");
   assert(!D.getType()->isReferenceType() &&
          "Should not call EmitDeclInit on a reference!");
 


### PR DESCRIPTION
Case when function scope variable codegen-ed as global variable is
possible for both OpenCL and SYCL, for example local variables defined
by user are turned into globals in the local address space.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>