### PR TITLE
Add edges to the callgraph for C++ initializers.

### DIFF
--- a/clang/test/Analysis/cxx-callgraph.cpp
+++ b/clang/test/Analysis/cxx-callgraph.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCallGraph %s 2>&1 | FileCheck %s
+
+static int aaa() {
+  return 0;
+}
+
+static int bbb(int param=aaa()) {
+  return 1;
+}
+
+int ddd();
+
+struct c {
+  c(int param=2) : val(bbb(param)) {}
+  int val;
+  int val2 = ddd();
+};
+
+int ddd() {
+  c c;
+  return bbb();
+}
+
+// CHECK:--- Call graph Dump ---
+// CHECK-NEXT: {{Function: < root > calls: aaa bbb c::c ddd}}
+// CHECK-NEXT: {{Function: c::c calls: bbb ddd $}}
+// CHECK-NEXT: {{Function: ddd calls: c::c bbb aaa $}}
+// CHECK-NEXT: {{Function: bbb calls: $}}
+// CHECK-NEXT: {{Function: aaa calls: $}}

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -10,6 +10,8 @@ namespace std {
 namespace Check_User_Operators {
 class Fraction
 {
+    // expected-error@+2 {{SYCL kernel cannot call a recursive function}}
+    // expected-note@+1 {{function implemented using recursion declared here}}
     int gcd(int a, int b) { return b == 0 ? a : gcd(b, a % b); }
     int n, d;
 public:


### PR DESCRIPTION
This improves the accuracy of the Clang callgraph. As a result, the SYCL code does a better job of figuring out which code will actually be offloaded onto the device.

Signed-off-by: Joshua Cranmer <joshua.cranmer@intel.com>