### PR TITLE
[SYCL] Remove SubgroupMemory mask from memory barrier flag

### DIFF
--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -336,9 +336,8 @@ struct sub_group {
   /* --- synchronization functions --- */
   void barrier(access::fence_space accessSpace =
                    access::fence_space::global_and_local) const {
-    uint32_t flags = detail::getSPIRVMemorySemanticsMask(
-        accessSpace, __spv::MemorySemanticsMask::SubgroupMemory);
-    __spirv_ControlBarrier(__spv::Scope::Subgroup, __spv::Scope::Workgroup,
+    uint32_t flags = detail::getSPIRVMemorySemanticsMask(accessSpace);
+    __spirv_ControlBarrier(__spv::Scope::Subgroup, __spv::Scope::Subgroup,
                            flags);
   }
 


### PR DESCRIPTION
fence_space::local_space flag should be mapped on WorkgroupMemory
SPIR-V mask. Also, memory scope should be Subgroup.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>