### PR TITLE
[SYCL][Test] Fix MultipleDevices.cpp test to run only for CPU runtimes

### DIFF
--- a/sycl/test/scheduler/MultipleDevices.cpp
+++ b/sycl/test/scheduler/MultipleDevices.cpp
@@ -12,8 +12,6 @@
 
 #include <iostream>
 
-#include "../helpers.hpp"
-
 using namespace cl::sycl;
 
 int multidevice_test(queue MyQueue1, queue MyQueue2) {
@@ -93,17 +91,57 @@ int multidevice_test(queue MyQueue1, queue MyQueue2) {
 }
 
 int main() {
-  host_selector HOSTSelector;
-  queue MyQueue1(HOSTSelector);
-  queue MyQueue2(HOSTSelector);
+  host_selector hostSelector;
+  cpu_selector CPUSelector;
+  gpu_selector GPUSelector;
+
   int Result = -1;
   try {
-    TestQueue MyQueue1 {default_selector()};
-    Result = multidevice_test(MyQueue1, MyQueue2);
-    TestQueue MyQueue2 {default_selector()};
-    Result |= multidevice_test(MyQueue1, MyQueue2);
-  } catch (cl::sycl::invalid_parameter_error &) {
-    std::cout << "Using 2 host devices." << std::endl;
+    queue MyQueue1(hostSelector);
+    queue MyQueue2(hostSelector);
+    Result &= multidevice_test(MyQueue1, MyQueue2);
+  } catch(cl::sycl::invalid_parameter_error &) {
+    std::cout << "Skipping host and host" << std::endl;
+  }
+
+  try {
+    queue MyQueue1(hostSelector);
+    queue MyQueue2(CPUSelector);
+    Result &= multidevice_test(MyQueue1, MyQueue2);
+  } catch(cl::sycl::invalid_parameter_error &) {
+    std::cout << "Skipping host and CPU" << std::endl;
+  }
+
+  try {
+    queue MyQueue1(CPUSelector);
+    queue MyQueue2(CPUSelector);
+    Result &= multidevice_test(MyQueue1, MyQueue2);
+  } catch(cl::sycl::invalid_parameter_error &) {
+    std::cout << "Skipping CPU and CPU" << std::endl;
+  }
+
+  try {
+    queue MyQueue1(CPUSelector);
+    queue MyQueue2(GPUSelector);
+    Result &= multidevice_test(MyQueue1, MyQueue2);
+  } catch(cl::sycl::invalid_parameter_error &) {
+    std::cout << "Skipping CPU and GPU" << std::endl;
+  }
+
+  try {
+    queue MyQueue1(hostSelector);
+    queue MyQueue2(GPUSelector);
+    Result &= multidevice_test(MyQueue1, MyQueue2);
+  } catch(cl::sycl::invalid_parameter_error &) {
+    std::cout << "Skipping host and GPU" << std::endl;
+  }
+
+  try {
+    queue MyQueue1(GPUSelector);
+    queue MyQueue2(GPUSelector);
+    Result &= multidevice_test(MyQueue1, MyQueue2);
+  } catch(cl::sycl::invalid_parameter_error &) {
+    std::cout << "Skipping GPU and GPU" << std::endl;
   }
 
   return Result;

--- a/sycl/test/scheduler/MultipleDevices.cpp
+++ b/sycl/test/scheduler/MultipleDevices.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
-// RUN: %t.out
-//===- MultipleDevices.cpp - Test checkking multi-device execution --------===//
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+//===- MultipleDevices.cpp - Test checking multi-device execution --------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/test/scheduler/MultipleDevices.cpp
+++ b/sycl/test/scheduler/MultipleDevices.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %t.out
 //===- MultipleDevices.cpp - Test checking multi-device execution --------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -11,6 +11,8 @@
 #include <CL/sycl.hpp>
 
 #include <iostream>
+
+#include "../helpers.hpp"
 
 using namespace cl::sycl;
 
@@ -96,10 +98,9 @@ int main() {
   queue MyQueue2(HOSTSelector);
   int Result = -1;
   try {
-    cpu_selector CPUSelector;
-    MyQueue1 = queue(CPUSelector);
+    TestQueue MyQueue1 {default_selector()};
     Result = multidevice_test(MyQueue1, MyQueue2);
-    MyQueue2 = queue(CPUSelector);
+    TestQueue MyQueue2 {default_selector()};
     Result |= multidevice_test(MyQueue1, MyQueue2);
   } catch (cl::sycl::invalid_parameter_error &) {
     std::cout << "Using 2 host devices." << std::endl;


### PR DESCRIPTION
This test fails if you only have a GPU runtime installed. As it only 
seems to use host and CPU selectors it seems the intent is for it to 
only run when the OpenCL CPU runtime or another CPU runtime is 
installed.

Signed-off-by: Andrew Gozillon <andrew.gozillon@yahoo.com>