### PR TITLE
[SYCL] Fix LIT test on windows

### DIFF
--- a/clang/test/CodeGenSYCL/noexcept.cpp
+++ b/clang/test/CodeGenSYCL/noexcept.cpp
@@ -2,8 +2,13 @@
 // RUN:      -std=c++11 -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
 // RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-DEVICE
 //
-// RUN: %clang_cc1  -I%S -std=c++11 -fcxx-exceptions -fexceptions -disable-llvm-passes \
-// RUN:      -x c++ -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-HOST
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -I%S -std=c++11 \
+// RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
+// RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-HOST-LIN
+//
+// RUN: %clang_cc1 -triple x86_64-pc-windows-msvc -I%S -std=c++11 \
+// RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
+// RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-HOST-WIN
 
 // The test checks that exception handling code is generated only for host and not for device.
 
@@ -13,13 +18,15 @@ void f3() {}
 
 void foo_noexcept() noexcept {
   // CHECK-DEVICE: call spir_func void @_Z2f1v()
-  // CHECK-HOST: invoke void @_Z2f1v()
+  // CHECK-HOST-LIN: invoke void @_Z2f1v()
+  // CHECK-HOST-WIN: invoke void @"?f1@@YAXXZ"()
   f1();
 }
 
 void foo_throw() throw() {
   // CHECK-DEVICE: call spir_func void @_Z2f2v()
-  // CHECK-HOST: invoke void @_Z2f2v()
+  // CHECK-HOST-LIN: invoke void @_Z2f2v()
+  // CHECK-HOST-WIN: invoke void @"?f3@@YAXXZ"()
   f2();
 }
 
@@ -35,8 +42,10 @@ void foo_cleanup() {
   f3();
   // CHECK-DEVICE: call spir_func void @_ZN1AD1Ev
   // Regular + exception cleanup
-  // CHECK-HOST: call void @_ZN1AD1Ev
-  // CHECK-HOST: call void @_ZN1AD1Ev
+  // CHECK-HOST-LIN: call void @_ZN1AD1Ev
+  // CHECK-HOST-LIN: call void @_ZN1AD1Ev
+  // CHECK-HOST-WIN: call void @"??1A@@QEAA@XZ"(%struct.A* %a)
+  // CHECK-HOST-WIN: call void @"??1A@@QEAA@XZ"(%struct.A* %a) #4 [ "funclet"(token %0) ]
 }
 
 template <typename name, typename Func>


### PR DESCRIPTION
 - Clang::noexcept.cpp - use cross compilation to avoid mangling
   mismatch on windows platform.

Signed-off-by: Vladimir Lazarev <vladimir.lazarev@intel.com>