### PR TITLE
[SYCL][NFC] Fix out-of-bound access in documentation example

### DIFF
--- a/sycl/doc/SYCL_compiler_and_runtime_design.md
+++ b/sycl/doc/SYCL_compiler_and_runtime_design.md
@@ -72,7 +72,7 @@ buffer<int, 1> a{range<1>{1024}};
 Q.submit([&](handler& cgh) {
       auto A = a.get_access<access::mode::write>(cgh);
       cgh.parallel_for<init_a>(range<1>{1024}, [=](id<1> index) {
-        A[index] = index[0] * 2 + index[1] + foo(42);
+        A[index] = index[0] * 2 + foo(42);
       });
     }
 ...


### PR DESCRIPTION
`index` is one-dimensional `id`, so calling subscript operator with any
value other than `0` is a bug.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>