### PR TITLE
Disable failing test

### DIFF
--- a/clang/test/Analysis/exploded-graph-rewriter/objects_under_construction.cpp
+++ b/clang/test/Analysis/exploded-graph-rewriter/objects_under_construction.cpp
@@ -8,6 +8,9 @@
 // FIXME: Substitution doesn't seem to work on Windows.
 // UNSUPPORTED: system-windows
 
+// https://bugs.llvm.org/show_bug.cgi?id=42601
+// XFAIL: *
+
 struct S {
   S() {}
 };


### PR DESCRIPTION
Our change to CallGraph caused the issue, but it's a bug in Static
Analyzer https://bugs.llvm.org/show_bug.cgi?id=42601 .

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>