### PR TITLE
[SYCL] Fix for assertion in basic_tests/vectors/vector_operators.cpp on Windows

### DIFF
--- a/sycl/test/basic_tests/vectors/vector_operators.cpp
+++ b/sycl/test/basic_tests/vectors/vector_operators.cpp
@@ -3,8 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// TODO: SYCL specific fail - analyze and enable
-// XFAIL: windows
 
 //==---------- vector_operators.cpp - SYCL vec<> operators test ------------==//
 //
@@ -22,14 +20,14 @@ template <typename ResultVecT>
 void check_result_length_4(ResultVecT &res, ResultVecT &expected_res) {
   assert(res.get_count() == 4 && expected_res.get_count() == 4);
 
-  assert(res.template swizzle<s::elem::s0>() ==
-         expected_res.template swizzle<s::elem::s0>());
-  assert(res.template swizzle<s::elem::s1>() ==
-         expected_res.template swizzle<s::elem::s1>());
-  assert(res.template swizzle<s::elem::s2>() ==
-         expected_res.template swizzle<s::elem::s2>());
-  assert(res.template swizzle<s::elem::s3>() ==
-         expected_res.template swizzle<s::elem::s3>());
+  assert(static_cast<bool>(res.template swizzle<s::elem::s0>() ==
+                           expected_res.template swizzle<s::elem::s0>()));
+  assert(static_cast<bool>(res.template swizzle<s::elem::s1>() ==
+                           expected_res.template swizzle<s::elem::s1>()));
+  assert(static_cast<bool>(res.template swizzle<s::elem::s2>() ==
+                           expected_res.template swizzle<s::elem::s2>()));
+  assert(static_cast<bool>(res.template swizzle<s::elem::s3>() ==
+                           expected_res.template swizzle<s::elem::s3>()));
 }
 
 int main() {
@@ -53,8 +51,9 @@ int main() {
     }
     // 1-element vector operators follow vector 0/-1 logic
     vec_type expected_res(-1);
-    assert(res.template swizzle<cl::sycl::elem::s0>() ==
-           expected_res.template swizzle<cl::sycl::elem::s0>());
+    assert(
+        static_cast<bool>(res.template swizzle<cl::sycl::elem::s0>() ==
+                          expected_res.template swizzle<cl::sycl::elem::s0>()));
   }
 
   {
@@ -74,8 +73,9 @@ int main() {
     }
     // 1-element vector operators follow vector 0/-1 logic
     vec_type expected_res(-1);
-    assert(res.template swizzle<cl::sycl::elem::s0>() ==
-           expected_res.template swizzle<cl::sycl::elem::s0>());
+    assert(
+        static_cast<bool>(res.template swizzle<cl::sycl::elem::s0>() ==
+                          expected_res.template swizzle<cl::sycl::elem::s0>()));
   }
 
   /* Test different operators, different types


### PR DESCRIPTION
Assertion condition must have scalar type according to spec, but
that is not true for the assertions that compare swizzle ops.
Adding explicit cast to bool to fix that.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>