### PR TITLE
[SYCL] Prevent the runtime from crashing if static buffer d'tors exist.

### DIFF
--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
@@ -19,6 +19,7 @@ namespace detail {
 
 class event_impl;
 class context_impl;
+struct MemObjRecord;
 
 using EventImplPtr = std::shared_ptr<detail::event_impl>;
 using ContextImplPtr = std::shared_ptr<detail::context_impl>;
@@ -54,6 +55,12 @@ public:
 
   // Ptr must be a pointer returned by allocateHostMem.
   virtual void releaseHostMem(void *Ptr) = 0;
+
+protected:
+  // Pointer to the record that contains the memory commands. This is managed
+  // by the scheduler.
+  std::unique_ptr<MemObjRecord> MRecord;
+  friend class Scheduler;
 };
 
 } // namespace detail

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -217,7 +217,10 @@ public:
     if ((MUploadDataFunctor != nullptr) && MNeedWriteBack)
       MUploadDataFunctor();
 
-    Scheduler::getInstance().removeMemoryObject(this);
+    // If we're attached to a memory record, process the deletion of the memory
+    // record. We may get detached before we do this.
+    if (MRecord)
+      Scheduler::getInstance().removeMemoryObject(this);
     releaseHostMem(MShadowCopy);
 
     if (MOpenCLInterop)

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -93,49 +93,43 @@ void Scheduler::GraphBuilder::printGraphAsDot(const char *ModeName) {
 
   std::set<Command *> Visited;
 
-  for (MemObjRecord &Record : MMemObjRecords)
-    for (Command *AllocaCmd : Record.MAllocaCommands)
+  for (SYCLMemObjI *MemObject : MMemObjs)
+    for (Command *AllocaCmd : MemObject->MRecord->MAllocaCommands)
       printDotRecursive(Stream, Visited, AllocaCmd);
 
   Stream << "}" << std::endl;
 }
 
 // Returns record for the memory objects passed, nullptr if doesn't exist.
-Scheduler::GraphBuilder::MemObjRecord *
+MemObjRecord *
 Scheduler::GraphBuilder::getMemObjRecord(SYCLMemObjI *MemObject) {
-  const auto It = std::find_if(MMemObjRecords.begin(), MMemObjRecords.end(),
-                               [MemObject](const MemObjRecord &Record) {
-                                 return Record.MMemObj == MemObject;
-                               });
-  return (MMemObjRecords.end() != It) ? &*It : nullptr;
+  return MemObject->MRecord.get();
 }
 
 // Returns record for the memory object requirement refers to, if doesn't
 // exist, creates new one.
-Scheduler::GraphBuilder::MemObjRecord *
+MemObjRecord *
 Scheduler::GraphBuilder::getOrInsertMemObjRecord(const QueueImplPtr &Queue,
                                                  Requirement *Req) {
   SYCLMemObjI *MemObject = Req->MSYCLMemObj;
-  Scheduler::GraphBuilder::MemObjRecord *Record = getMemObjRecord(MemObject);
+  MemObjRecord *Record = getMemObjRecord(MemObject);
 
   if (nullptr != Record)
     return Record;
 
-  MemObjRecord NewRecord{
-    MemObject,
-    /*MWriteLeafs*/ {},
-    /*MReadLeafs*/ {},
+  MemObject->MRecord.reset(new MemObjRecord{
     /*MAllocaCommands*/ {},
-    /*MMemModified*/ false};
+    /*MReadLeafs*/ {},
+    /*MWriteLeafs*/ {},
+    /*MMemModified*/ false});
 
-  MMemObjRecords.push_back(std::move(NewRecord));
-  return &MMemObjRecords.back();
+  MMemObjs.push_back(MemObject);
+  return MemObject->MRecord.get();
 }
 
 // Helper function which removes all values in Cmds from Leafs
 void Scheduler::GraphBuilder::UpdateLeafs(
-    const std::set<Command *> &Cmds,
-    Scheduler::GraphBuilder::MemObjRecord *Record, Requirement *Req) {
+    const std::set<Command *> &Cmds, MemObjRecord *Record, Requirement *Req) {
 
   const bool ReadOnlyReq = Req->MAccessMode == access::mode::read;
   if (ReadOnlyReq)
@@ -153,8 +147,7 @@ void Scheduler::GraphBuilder::UpdateLeafs(
 }
 
 void Scheduler::GraphBuilder::AddNodeToLeafs(
-    Scheduler::GraphBuilder::MemObjRecord *Record, Command *Cmd,
-    Requirement *Req) {
+    MemObjRecord *Record, Command *Cmd, Requirement *Req) {
   if (Req->MAccessMode == access::mode::read)
     Record->MReadLeafs.push_back(Cmd);
   else
@@ -209,7 +202,7 @@ Command *Scheduler::GraphBuilder::addCopyBack(Requirement *Req) {
 
   QueueImplPtr HostQueue = Scheduler::getInstance().getDefaultHostQueue();
   SYCLMemObjI *MemObj = Req->MSYCLMemObj;
-  Scheduler::GraphBuilder::MemObjRecord *Record = getMemObjRecord(MemObj);
+  MemObjRecord *Record = getMemObjRecord(MemObj);
   if (Record && MPrintOptionsArray[BeforeAddCopyBack])
     printGraphAsDot("before_addCopyBack");
 
@@ -583,7 +576,7 @@ AllocaCommandBase *Scheduler::GraphBuilder::getOrCreateAllocaForReq(
 
 // The function sets MemModified flag in record if requirement has write access.
 void Scheduler::GraphBuilder::markModifiedIfWrite(
-    GraphBuilder::MemObjRecord *Record, Requirement *Req) {
+    MemObjRecord *Record, Requirement *Req) {
   switch (Req->MAccessMode) {
   case access::mode::write:
   case access::mode::read_write:
@@ -704,11 +697,13 @@ void Scheduler::GraphBuilder::cleanupCommands(bool CleanupReleaseCommands) {
 }
 
 void Scheduler::GraphBuilder::removeRecordForMemObj(SYCLMemObjI *MemObject) {
-  const auto It = std::find_if(MMemObjRecords.begin(), MMemObjRecords.end(),
-                               [MemObject](const MemObjRecord &Record) {
-                                 return Record.MMemObj == MemObject;
-                               });
-  MMemObjRecords.erase(It);
+  const auto It = std::find_if(MMemObjs.begin(), MMemObjs.end(),
+                                 [MemObject](const SYCLMemObjI *Obj) {
+                                   return Obj == MemObject;
+                                 });
+  if (It != MMemObjs.end())
+    MMemObjs.erase(It);
+  MemObject->MRecord.reset(nullptr);
 }
 
 } // namespace detail

--- a/sycl/test/regression/static-buffer-dtor.cpp
+++ b/sycl/test/regression/static-buffer-dtor.cpp
@@ -1,0 +1,33 @@
+//==-- static-buffer-dtor.cpp ----------------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// This checks that the runtime does not crash if there are SYCL buffer
+// destructors that run as part of program shutdown, after the runtime itself
+// would start shutting down.
+//===----------------------------------------------------------------------===//
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+
+int main() {
+  uint8_t *h_A = (uint8_t *)malloc(256);
+  static cl::sycl::buffer<uint8_t> bufs[2] = {
+    cl::sycl::range<1>(256),
+    cl::sycl::range<1>(256)
+  };
+  cl::sycl::queue q;
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.copy(h_A, bufs[0].get_access<cl::sycl::access::mode::write>(cgh));
+  });
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.copy(h_A, bufs[1].get_access<cl::sycl::access::mode::write>(cgh));
+  });
+  return 0;
+}


### PR DESCRIPTION
The actual sequence of events to cause this crash to happen is the
following:

1. Create two buffers. (One is insufficient).
2. Store these buffers in a static variable so that their destructors
   will run at shutdown.
3. Submit some write commands that involve these buffers on some queue.
4. Do not run any commands that wait for the memory operations to
   complete.
5. Exit the program, causing global destructors to start running.
6. Thanks to destructor ordering rules, Scheduler::~Scheduler() will
   generally run before the main program's static destructors.
7. Now buffer::~buffer() runs. This threads its way to a call to
   Scheduler::getInstance().removeMemoryObject().
8. Since the program has been destroyed, the static memory is generally
   filled with garbage data. In particular, the vector data for the
   MemRecord -> Command map (being a std::vector, stored in heap) is
   freed and liable to be overwritten with random data.

Signed-off-by: Joshua Cranmer <joshua.cranmer@intel.com>