### PR TITLE
[SYCL] Fix __has_builtin for __builtin_intel_fpga_reg

### DIFF
--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -1613,6 +1613,8 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
             // denotes date of behavior change to support calling arbitrary
             // usual allocation and deallocation functions. Required by libc++
             return 201802;
+          case Builtin::BI__builtin_intel_fpga_reg:
+            return LangOpts.SYCLIsDevice;
           default:
             return true;
           }

--- a/clang/test/SemaSYCL/intel-fpga-reg.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-reg.cpp
@@ -16,6 +16,7 @@ struct st {
 
 
 #ifdef __SYCL_DEVICE_ONLY__
+static_assert(__has_builtin(__builtin_intel_fpga_reg), "");
 
 struct inner {
   void (*fp)(); // expected-note {{Field with illegal type declared here}}
@@ -66,6 +67,7 @@ int main() {
 
 #else
 
+static_assert(!__has_builtin(__builtin_intel_fpga_reg), "");
 int main() {
   A a(3);
   A b = __builtin_intel_fpga_reg(a);


### PR DESCRIPTION
__has_builtin reports true on the SYCL Host, even though it is only
valid on the SYCL Device. This patch corrects that behavior.

Signed-off-by: Erich Keane <erich.keane@intel.com>