### PR TITLE
[SYCL] Use correct scalar types for vector elements on Windows

### DIFF
--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -1741,7 +1741,7 @@ DECLARE_TYPE_T(half);
 DECLARE_TYPE_T(double);
 
 #define GET_CL_TYPE(target, num) __##target##num##_vec_t
-#define GET_SCALAR_CL_TYPE(target) target
+#define GET_SCALAR_CL_TYPE(target) __##target##_t
 
 #undef DECLARE_TYPE_T
 #undef DECLARE_LLTYPE_T

--- a/sycl/test/basic_tests/vectors/vector_ulonglong.cpp
+++ b/sycl/test/basic_tests/vectors/vector_ulonglong.cpp
@@ -1,0 +1,17 @@
+// RUN: %clangxx %s -o %t.out -lOpenCL -lsycl
+// RUN: %t.out
+
+// Test that vector with 'unsigned long long' elements has enough bits to store
+// value.
+
+#define SYCL_SIMPLE_SWIZZLES
+#include <CL/sycl.hpp>
+
+int main(void) {
+  unsigned long long ref = 1ull - 2ull;
+  auto vec = cl::sycl::vec<unsigned long long, 1>(ref);
+  unsigned long long val = vec.template swizzle<cl::sycl::elem::s0>();
+
+  assert(val == ref);
+  return 0;
+}


### PR DESCRIPTION
Implementation uses wrong types for 64-bit integers on Windows for vector
elements because '[unsigned] long' is being used. But on Windows 'long'
has 32 bits as opposed to 64 bits on Linux. This patch corrects this
problem.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>