### PR TITLE
[SYCL] Fix address space in generation of llvm.invariant.start intrinsic

### DIFF
--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -164,13 +164,15 @@ void CodeGenFunction::EmitInvariantStart(llvm::Constant *Addr, CharUnits Size) {
   // Grab the llvm.invariant.start intrinsic.
   llvm::Intrinsic::ID InvStartID = llvm::Intrinsic::invariant_start;
   // Overloaded address space type.
-  llvm::Type *ObjectPtr[1] = {Int8PtrTy};
+  llvm::Type *ResTy = llvm::PointerType::getInt8PtrTy(
+      CGM.getLLVMContext(), Addr->getType()->getPointerAddressSpace());
+  llvm::Type *ObjectPtr[1] = {ResTy};
   llvm::Function *InvariantStart = CGM.getIntrinsic(InvStartID, ObjectPtr);
 
   // Emit a call with the size in bytes of the object.
   uint64_t Width = Size.getQuantity();
-  llvm::Value *Args[2] = { llvm::ConstantInt::getSigned(Int64Ty, Width),
-                           llvm::ConstantExpr::getBitCast(Addr, Int8PtrTy)};
+  llvm::Value *Args[2] = {llvm::ConstantInt::getSigned(Int64Ty, Width),
+                          llvm::ConstantExpr::getBitCast(Addr, ResTy)};
   Builder.CreateCall(InvariantStart, Args);
 }
 

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -21,6 +21,10 @@ public:
   void use(void) const {}
 };
 
+template <int dimensions = 1>
+class group {
+};
+
 namespace access {
 
 enum class target {

--- a/clang/test/CodeGenSYCL/const-wg-init.cpp
+++ b/clang/test/CodeGenSYCL/const-wg-init.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+
+#include "sycl.hpp"
+
+template <typename KernelName, typename KernelType>
+__attribute__((sycl_kernel)) void
+kernel_parallel_for_work_group(KernelType KernelFunc) {
+  cl::sycl::group<1> G;
+  KernelFunc(G);
+}
+
+int main() {
+
+  kernel_parallel_for_work_group<class kernel>([=](cl::sycl::group<1> G) {
+    const int WG_CONST = 10;
+  });
+// CHECK:  store i32 10, i32 addrspace(4)* addrspacecast (i32 addrspace(3)* @{{.*}}WG_CONST{{.*}} to i32 addrspace(4)*)
+// CHECK:  %{{[0-9]+}} = call {}* @llvm.invariant.start.p4i8(i64 4, i8 addrspace(4)* addrspacecast (i8 addrspace(3)* bitcast (i32 addrspace(3)* @{{.*}}WG_CONST{{.*}} to i8 addrspace(3)*) to i8 addrspace(4)*))
+
+  return 0;
+}


### PR DESCRIPTION
Invalid bitcast with different address spaces was emitted as arument of
llvm.invariant.start intrinsic for work group scope constants.
This problem caused assertion fail.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>