### PR TITLE
[SYCL] Add support for -fsycl-help=arg

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -440,6 +440,9 @@ public:
   /// \param ShowHidden - Show hidden options.
   void PrintHelp(bool ShowHidden) const;
 
+  /// PrintSYCLToolHelp - Print help text from offline compiler tools.
+  void PrintSYCLToolHelp(const Compilation &C) const;
+
   /// PrintVersion - Print the driver version.
   void PrintVersion(const Compilation &C, raw_ostream &OS) const;
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1753,6 +1753,11 @@ def fsycl_link : Flag<["-"], "fsycl-link">, Alias<fsycl_link_EQ>,
   HelpText<"Generate partially linked device object to be used with the host link">;
 def fsycl_unnamed_lambda : Flag<["-"], "fsycl-unnamed-lambda">,
   Flags<[CC1Option]>, HelpText<"Allow unnamed SYCL lambda kernels">;
+def fsycl_help_EQ : Joined<["-"], "fsycl-help=">,
+  Flags<[DriverOption]>, HelpText<"Emit help information from the related offline compilation tool">, Values<"all,fpga,gen,x86_64">;
+def fsycl_help : Flag<["-"], "fsycl-help">, Alias<fsycl_help_EQ>,
+  Flags<[DriverOption]>, AliasArgs<["all"]>, HelpText<"Emit help information "
+  "from all of the offline compilation tools">;
 def fsyntax_only : Flag<["-"], "fsyntax-only">,
   Flags<[DriverOption,CoreOption,CC1Option]>, Group<Action_Group>;
 def ftabstop_EQ : Joined<["-"], "ftabstop=">, Group<f_Group>;

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -11,3 +11,18 @@
 // NO-BITCODE: "{{.*}}llvm-spirv"{{.*}} "-spirv-no-deref-attr"
 // TARGET: "-triple" "spir64-unknown-linux-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-emit-llvm-bc"
 // COMBINED: "-triple" "spir64-unknown-{{.*}}-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-emit-llvm-bc"
+
+// -fsycl-help tests
+// Test with a bad argument is expected to fail
+// RUN: not %clang -fsycl-help=foo %s 2>&1 | FileCheck %s --check-prefix=SYCL-HELP-BADARG
+// RUN: %clang -### -fsycl-help=gen %s 2>&1 | FileCheck %s --check-prefix=SYCL-HELP-GEN
+// RUN: %clang -### -fsycl-help=fpga %s 2>&1 | FileCheck %s --check-prefix=SYCL-HELP-FPGA
+// RUN: %clang -### -fsycl-help=x86_64 %s 2>&1 | FileCheck %s --check-prefix=SYCL-HELP-CPU
+// RUN: %clang -### -fsycl-help %s 2>&1 | FileCheck %s --check-prefixes=SYCL-HELP-GEN,SYCL-HELP-FPGA,SYCL-HELP-CPU
+// SYCL-HELP-BADARG: unsupported argument 'foo' to option 'fsycl-help='
+// SYCL-HELP-GEN: Emitting help information for ocloc
+// SYCL-HELP-GEN: Use triple of 'spir64_gen-unknown-{{.*}}-sycldevice' to enable ahead of time compilation
+// SYCL-HELP-FPGA: Emitting help information for aoc
+// SYCL-HELP-FPGA: Use triple of 'spir64_fpga-unknown-{{.*}}-sycldevice' to enable ahead of time compilation
+// SYCL-HELP-CPU: Emitting help information for ioc64
+// SYCL-HELP-CPU: Use triple of 'spir64_x86_64-unknown-{{.*}}-sycldevice' to enable ahead of time compilation


### PR DESCRIPTION
Use -fsycl-help=arg where are is: gen, fpga, x86_64, all
These correspond to the subarch values used to trigger AOT compilation.  Use of
this option will call the corresponding offline compiler to emit the help
directly from that tool.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>