### PR TITLE
[SYCL] Emit extra addrspace cast for @llvm.ptr.annotation

### DIFF
--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -17,7 +17,7 @@
 //CHECK: [[ANN9:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{max_private_copies:4}
 
 //CHECK: @llvm.global.annotations
-//CHECK-SAME: a_one{{.*}}[[ANN1]]{{.*}}i32 159
+//CHECK-SAME: a_one{{.*}}[[ANN1]]{{.*}}i32 148
 
 void foo() {
   //CHECK: %[[VAR_ONE:[0-9]+]] = bitcast{{.*}}var_one
@@ -55,48 +55,37 @@ struct foo_two {
 void bar() {
   struct foo_two s1;
   //CHECK: %[[FIELD1:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD1]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN1]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD1]]{{.*}}[[ANN1]]
   s1.f1 = 0;
   //CHECK: %[[FIELD2:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD2]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN2]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD2]]{{.*}}[[ANN2]]
   s1.f2 = 0;
   //CHECK: %[[FIELD3:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD3]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN3]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD3]]{{.*}}[[ANN3]]
   s1.f3 = 0;
   //CHECK: %[[FIELD4:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD4]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN4]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD4]]{{.*}}[[ANN4]]
   s1.f4 = 0;
   //CHECK: %[[FIELD5:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD5]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN5]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD5]]{{.*}}[[ANN5]]
   s1.f5 = 0;
   //CHECK: %[[FIELD6:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD6]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN10]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD6]]{{.*}}[[ANN10]]
   s1.f6 = 0;
   //CHECK: %[[FIELD7:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD7]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN11]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD7]]{{.*}}[[ANN11]]
   s1.f7 = 0;
   //CHECK: %[[FIELD8:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD8]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN12]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD8]]{{.*}}[[ANN12]]
   s1.f8 = 0;
   //CHECK: %[[FIELD9:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD9]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN13]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD9]]{{.*}}[[ANN13]]
   s1.f9 = 0;
   //CHECK: %[[FIELD10:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD10]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN14]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD10]]{{.*}}[[ANN14]]
   s1.f10 = 0;
   //CHECK: %[[FIELD11:.*]] = getelementptr inbounds %struct.{{.*}}.foo_two{{.*}}
-  //CHECK: %[[CAST:.*]] = bitcast{{.*}}%[[FIELD11]]
-  //CHECK: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST]]{{.*}}[[ANN15]]
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD11]]{{.*}}[[ANN15]]
   s1.f11 = 0;
 }
 
@@ -162,6 +151,26 @@ void qux(int a) {
   a_one = a_one + a;
 }
 
+void field_addrspace_cast() {
+  struct state {
+    [[intelfpga::numbanks(2)]] int mem[8];
+
+    // The initialization code is not relevant to this example.
+    // It prevents the compiler from optimizing away access to this struct.
+    state() {
+      for (auto i = 0; i < 8; i++) {
+        mem[i] = i;
+      }
+    }
+  } state_var;
+  // CHECK: define internal {{.*}} @_ZZ20field_addrspace_castvEN5stateC2Ev
+  // CHECK: %[[MEM:[a-zA-Z0-9]+]] = getelementptr inbounds %{{.*}}, %struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)* %{{.*}}, i32 0, i32 0
+  // CHECK: %[[BITCAST:[0-9]+]] = bitcast [8 x i32] addrspace(4)* %[[MEM]] to i8 addrspace(4)*
+  // CHECK: %[[ANN16:[0-9]+]] = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)* %[[BITCAST]], {{.*}}, {{.*}})
+  // CHECK: %{{[0-9]+}} = bitcast i8 addrspace(4)* %[[ANN16]] to [8 x i32] addrspace(4)
+  state_var.mem[0] = 42;
+}
+
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   kernelFunc();
@@ -173,6 +182,7 @@ int main() {
     bar();
     baz();
     qux(42);
+    field_addrspace_cast();
   });
   return 0;
 }

--- a/llvm-spirv/test/IntelFPGAMemoryAttributesForStruct.ll
+++ b/llvm-spirv/test/IntelFPGAMemoryAttributesForStruct.ll
@@ -11,6 +11,7 @@
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 0 MemoryINTEL "DEFAULT"
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 3 MemoryINTEL "DEFAULT"
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 2 MemoryINTEL "MLAB"
+; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 0 NumbanksINTEL 2
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 0 NumbanksINTEL 4
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 3 BankwidthINTEL 8
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 4 MaxPrivateCopiesINTEL 4
@@ -26,6 +27,8 @@ target triple = "spir64-unknown-linux"
 %class.anon = type { i8 }
 %struct.foo = type { i32, i32, i32, i32, i8, i32, i32, i32, i32, i32 }
 
+%struct._ZTSZ20field_addrspace_castvE5state.state = type { [8 x i32] }
+
 ; CHECK-LLVM: [[STR1:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:4}
 ; CHECK-LLVM: [[STR2:@[0-9_.]+]] = {{.*}}{register:1}
 ; CHECK-LLVM: [[STR3:@[0-9_.]+]] = {{.*}}{memory:MLAB}
@@ -36,6 +39,7 @@ target triple = "spir64-unknown-linux"
 ; CHECK-LLVM: [[STR8:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{merge:foobar:width}
 ; CHECK-LLVM: [[STR9:@[0-9_.]+]] = {{.*}}{max_replicates:4}
 ; CHECK-LLVM: [[STR10:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{simple_dual_port:1}
+; CHECK-LLVM: [[STR11:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:2}
 @.str = private unnamed_addr constant [29 x i8] c"{memory:DEFAULT}{numbanks:4}\00", section "llvm.metadata"
 @.str.1 = private unnamed_addr constant [16 x i8] c"test_struct.cpp\00", section "llvm.metadata"
 @.str.2 = private unnamed_addr constant [13 x i8] c"{register:1}\00", section "llvm.metadata"
@@ -47,6 +51,7 @@ target triple = "spir64-unknown-linux"
 @.str.8 = private unnamed_addr constant [37 x i8] c"{memory:DEFAULT}{merge:foobar:width}\00", section "llvm.metadata"
 @.str.9 = private unnamed_addr constant [19 x i8] c"{max_replicates:4}\00", section "llvm.metadata"
 @.str.10 = private unnamed_addr constant [37 x i8] c"{memory:DEFAULT}{simple_dual_port:1}\00", section "llvm.metadata"
+@.str.11 = private unnamed_addr constant [29 x i8] c"{memory:DEFAULT}{numbanks:2}\00", section "llvm.metadata"
 
 ; Function Attrs: nounwind
 define spir_kernel void @_ZTSZ4mainE15kernel_function() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
@@ -164,8 +169,76 @@ entry:
   ret void
 }
 
+define spir_func void @_Z20field_addrspace_castv() #3 {
+entry:
+  %state_var = alloca %struct._ZTSZ20field_addrspace_castvE5state.state, align 4
+  %0 = bitcast %struct._ZTSZ20field_addrspace_castvE5state.state* %state_var to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* %0) #4
+  %1 = addrspacecast %struct._ZTSZ20field_addrspace_castvE5state.state* %state_var to %struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)*
+  call spir_func void @_ZZ20field_addrspace_castvEN5stateC2Ev(%struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)* %1)
+  %mem = getelementptr inbounds %struct._ZTSZ20field_addrspace_castvE5state.state, %struct._ZTSZ20field_addrspace_castvE5state.state* %state_var, i32 0, i32 0
+  ; CHECK-LLVM: %[[GEP:.*]] = getelementptr inbounds %struct._ZTSZ20field_addrspace_castvE5state.state, %struct._ZTSZ20field_addrspace_castvE5state.state* %state_var, i32 0, i32 0
+  ; CHECK-LLVM: %[[CAST11:.*]] = bitcast [8 x i32]* %[[GEP:.*]] to i8*
+  ; CHECK-LLVM: %{{[0-9]+}} = call i8* @llvm.ptr.annotation.p0i8(i8* %[[CAST11]]{{.*}}[[STR11]]
+  %2 = bitcast [8 x i32]* %mem to i8*
+  %3 = call i8* @llvm.ptr.annotation.p0i8(i8* %2, i8* getelementptr inbounds ([29 x i8], [29 x i8]* @.str.11, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @.str.1, i32 0, i32 0), i32 24)
+  %4 = bitcast i8* %3 to [8 x i32]*
+  %arrayidx = getelementptr inbounds [8 x i32], [8 x i32]* %4, i64 0, i64 0
+  store i32 42, i32* %arrayidx, align 4, !tbaa !9
+  %5 = bitcast %struct._ZTSZ20field_addrspace_castvE5state.state* %state_var to i8*
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* %5) #4
+  ret void
+}
+
+define internal spir_func void @_ZZ20field_addrspace_castvEN5stateC2Ev(%struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)* %this) unnamed_addr #3 align 2 {
+entry:
+  %this.addr = alloca %struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)*, align 8
+  %i = alloca i32, align 4
+  store %struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)* %this, %struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)** %this.addr, align 8, !tbaa !5
+  %this1 = load %struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)*, %struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)** %this.addr, align 8
+  %0 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #4
+  store i32 0, i32* %i, align 4, !tbaa !9
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %1 = load i32, i32* %i, align 4, !tbaa !9
+  %cmp = icmp slt i32 %1, 8
+  br i1 %cmp, label %for.body, label %for.cond.cleanup
+
+for.cond.cleanup:                                 ; preds = %for.cond
+  %2 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %2) #4
+  br label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %3 = load i32, i32* %i, align 4, !tbaa !9
+  %mem = getelementptr inbounds %struct._ZTSZ20field_addrspace_castvE5state.state, %struct._ZTSZ20field_addrspace_castvE5state.state addrspace(4)* %this1, i32 0, i32 0
+  ; FIXME: currently llvm.ptr.annotation is not emitted for c'tors, need to fix it and add a check here
+  %4 = bitcast [8 x i32] addrspace(4)* %mem to i8 addrspace(4)*
+  %5 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)* %4, i8* getelementptr inbounds ([29 x i8], [29 x i8]* @.str.11, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @.str.1, i32 0, i32 0), i32 24)
+  %6 = bitcast i8 addrspace(4)* %5 to [8 x i32] addrspace(4)*
+  %7 = load i32, i32* %i, align 4, !tbaa !9
+  %idxprom = sext i32 %7 to i64
+  %arrayidx = getelementptr inbounds [8 x i32], [8 x i32] addrspace(4)* %6, i64 0, i64 %idxprom
+  store i32 %3, i32 addrspace(4)* %arrayidx, align 4, !tbaa !9
+  br label %for.inc
+
+for.inc:                                          ; preds = %for.body
+  %8 = load i32, i32* %i, align 4, !tbaa !9
+  %inc = add nsw i32 %8, 1
+  store i32 %inc, i32* %i, align 4, !tbaa !9
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond.cleanup
+  ret void
+}
+
 ; Function Attrs: nounwind
 declare i8* @llvm.ptr.annotation.p0i8(i8*, i8*, i8*, i32) #4
+
+; Function Attrs: nounwind
+declare i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)*, i8*, i8*, i32) #4
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { argmemonly nounwind }


### PR DESCRIPTION
    When a field of a C++ struct used in a constructor, `this' resides in
    generic address space, and thus a pointer to the field also have
    generic address space.

    In this patch we ensure, that prior creating llvm.ptr.annotation call,
    we are aligning type of the intrinsic's argument with i8 private pointer.

    Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>
