### PR TITLE
[SYCL] Fix address space of a static variable initializer

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -373,7 +373,7 @@ CodeGenFunction::AddInitializerToStaticVarDecl(const VarDecl &D,
                                   OldGV->getLinkage(), Init, "",
                                   /*InsertBefore*/ OldGV,
                                   OldGV->getThreadLocalMode(),
-                           CGM.getContext().getTargetAddressSpace(D.getType()));
+                                  OldGV->getType()->getPointerAddressSpace());
     GV->setVisibility(OldGV->getVisibility());
     GV->setDSOLocal(OldGV->isDSOLocal());
     GV->setComdat(OldGV->getComdat());

--- a/clang/test/CodeGenSYCL/address-space-new.cpp
+++ b/clang/test/CodeGenSYCL/address-space-new.cpp
@@ -6,6 +6,16 @@ void test() {
   // CHECK-LEGACY: @_ZZ4testvE3foo = internal constant i32 66, align 4
   // CHECK-NEW:    @_ZZ4testvE3foo = internal addrspace(1) constant i32 66, align 4
 
+  // Intentionally leave a part of an array uninitialized. This triggers a
+  // different code path contrary to a fully initialized array.
+  static const unsigned bars[256] = {
+    0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+  };
+  (void)bars;
+  // CHECK-LEGACY: @_ZZ4testvE4bars = internal constant <{ [21 x i32], [235 x i32] }> <{ [21 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20], [235 x i32] zeroinitializer }>, align 4
+  // CHECK-NEW:    @_ZZ4testvE4bars = internal addrspace(1) constant <{ [21 x i32], [235 x i32] }> <{ [21 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20], [235 x i32] zeroinitializer }>, align 4
+
   // CHECK: @[[STR:[.a-zA-Z0-9_]+]] = private unnamed_addr constant [14 x i8] c"Hello, world!\00", align 1
 
   // CHECK: %[[ARR:[a-zA-Z0-9]+]] = alloca [42 x i32]


### PR DESCRIPTION
When a static variable is lowered from AST to LLVM IR, it can change
an address space depending on its storage class. For example, a static
variable declared in function scope may be assigned to global address
space if language rules allow.

When this happens, original address space of a variable (retuned by
D.getType()) is no longer can be used as target address space. Correct
address space for a global can be obtained from
CodeGenModule::GetGlobalVarAddressSpace function, but in this case we
just copy it from the existing global (OldGV).

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>