### PR TITLE
[SYCL] Add -reuse-exe to support FPGA recompile

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -480,4 +480,7 @@ def warn_drv_libstdcxx_not_found : Warning<
   InGroup<DiagGroup<"stdlibcxx-not-found">>;
 
 def err_drv_cannot_mix_options : Error<"cannot specify '%1' along with '%0'">;
+
+def warn_drv_reuse_exe_file_not_found : Warning<
+  "-reuse-exe file '%0' not found; ignored">, InGroup<IntelFPGA>;
 }

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1074,3 +1074,5 @@ def CrossTU : DiagGroup<"ctu">;
 def CTADMaybeUnsupported : DiagGroup<"ctad-maybe-unsupported">;
 
 def FortifySource : DiagGroup<"fortify-source">;
+
+def IntelFPGA : DiagGroup<"intel-fpga">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3271,6 +3271,10 @@ defm whole_file : BooleanFFlag<"whole-file">, Group<gfortran_Group>;
 def sycl : Flag<["--"], "sycl">,
   HelpText<"Compile SYCL kernels for device">;
 
+def reuse_exe_EQ : Joined<["-"], "reuse-exe=">,
+  HelpText<"Speed up FPGA aoc compile if the device code in <exe> is unchanged.">,
+  MetaVarName<"<exe>">;
+
 include "CC1Options.td"
 
 include "CLCompatOptions.td"

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -359,6 +359,31 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
   // on when aoc is ready.
   // CmdArgs.push_back(C.getArgs().MakeArgString(ReportOpt));
   TranslateSYCLTargetArgs(C, Args, getToolChain(), CmdArgs);
+  // Look for -reuse-exe=XX option
+  if (Arg *A = Args.getLastArg(options::OPT_reuse_exe_EQ)) {
+    StringRef reuse_exe = A->getValue();
+    Args.ClaimAllArgs(options::OPT_reuse_exe_EQ);
+    if (llvm::sys::fs::exists(reuse_exe)) {
+      SmallString<128> ExecPath(getToolChain().GetProgramPath("aocl"));
+      const char *Exec = C.getArgs().MakeArgString(ExecPath);
+      ArgStringList ExtractArgs{"do", "aocl-extract-aocx", "-i"};
+      ExtractArgs.push_back(C.getArgs().MakeArgString(reuse_exe));
+      std::string TmpName = C.getDriver().GetTemporaryPath("reused-exe", "aocx");
+      auto OutputFileName = C.addTempFile(C.getArgs().MakeArgString(TmpName));
+      ExtractArgs.push_back("-o");
+      ExtractArgs.push_back(OutputFileName);
+      Command run_extract(JA, *this, Exec, ExtractArgs, None);
+      const Command* failingCommand = nullptr;
+      auto res = C.ExecuteCommand(run_extract, failingCommand);
+      if (res == 0) {
+        // We extracted the aocx file.  Pass it to the aoc command.
+        CmdArgs.push_back(Args.MakeArgString(Twine("-reuse-aocx=") + TmpName));
+      }
+    } else {
+      const Driver &D = getToolChain().getDriver();
+      D.Diag(clang::diag::warn_drv_reuse_exe_file_not_found) << reuse_exe;
+    }
+  }
 
   SmallString<128> ExecPath(getToolChain().GetProgramPath("aoc"));
   const char *Exec = C.getArgs().MakeArgString(ExecPath);

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -44,5 +44,11 @@
 // CHK-FPGA-LINK-PHASES: 6: clang-offload-bundler, {3, 5}, object, (device-sycl)
 // CHK-FPGA-LINK-PHASES: 7: offload, "device-sycl (spir64_fpga-unknown-{{.*}}-sycldevice)" {6}, object
 
+// -fintelfpga -reuse-exe tests
+// RUN: %clang++ -### -fsycl -fintelfpga %s -reuse-exe=does_not_exist 2>&1 \
+// RUN:  | FileCheck -check-prefixes=CHK-FPGA-REUSE-EXE %s
+// CHK-FPGA-REUSE-EXE: warning: -reuse-exe file 'does_not_exist' not found; ignored
+//
+
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc


### PR DESCRIPTION
Add -reuse-exe=<executable> option to support smart recompilation for
the Intel FPGA AOT compile.  This will extract the AOCX from the
executable and pass the extracted AOCX to the 'aoc' command line.
If the device (SPIR-V) code hasn't changed from the previous compile and
all options are the same, this will avoid re-running Quartus, which will
save a lot of compilation time when compiling for the FPGA.

If the executable does not exist, a warning is printed and it is
ignored. Add a new intel-fpga diagnostic group to allow the warning to
be disabled.

Signed-off-by: Mark Mendell <mark.p.mendell@intel.com>