### PR TITLE
[SYCL] Add missed #include ...event.hpp file into "image.hpp" file.

### DIFF
--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -11,6 +11,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/generic_type_traits.hpp>
 #include <CL/sycl/detail/image_impl.hpp>
+#include <CL/sycl/event.hpp>
 #include <CL/sycl/stl.hpp>
 #include <CL/sycl/types.hpp>
 #include <cstddef>


### PR DESCRIPTION
Added explicit definition(include) of event class to image.hpp file
instead of indirect inclusion through other include files.

Signed-off-by: Garima Gupta <garima.gupta@intel.com>