### PR TITLE
[Clang][Test] Added missing dependency for llvm-objcopy tool

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -111,6 +111,7 @@ if( NOT CLANG_BUILT_STANDALONE )
     llvm-lto2
     llvm-modextract
     llvm-nm
+    llvm-objcopy
     llvm-objdump
     llvm-profdata
     llvm-readelf


### PR DESCRIPTION
llvm-objcopy is required for clang-offload-bundler tests, but it is not
listed as check-clang target dependency.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>