### PR TITLE
[SYCL] Fix for image_api lit test on Windows OS. 

### DIFF
--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -120,7 +120,8 @@ public:
   }
 
   void releaseHostMem(void *Ptr) override {
-    MAllocator.deallocate(allocator_pointer_t<AllocatorT>(Ptr), get_size());
+    if (Ptr)
+      MAllocator.deallocate(allocator_pointer_t<AllocatorT>(Ptr), get_size());
   }
 
   void releaseMem(ContextImplPtr Context, void *MemAllocation) override {
@@ -230,7 +231,8 @@ public:
   }
 
   bool canReuseHostPtr(void *HostPtr, const size_t RequiredAlign) {
-    bool Aligned = (reinterpret_cast<std::uintptr_t>(HostPtr) % RequiredAlign) == 0;
+    bool Aligned =
+        (reinterpret_cast<std::uintptr_t>(HostPtr) % RequiredAlign) == 0;
     return Aligned || useHostPtr();
   }
 

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -55,7 +55,7 @@ enum class image_channel_type : unsigned int {
 
 using byte = unsigned char;
 
-using image_allocator = std::allocator<byte>;
+using image_allocator = detail::aligned_allocator<byte>;
 
 template <int Dimensions = 1, typename AllocatorT = cl::sycl::image_allocator>
 class image {

--- a/sycl/test/basic_tests/image_api.cpp
+++ b/sycl/test/basic_tests/image_api.cpp
@@ -6,9 +6,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
 
-// TODO: SYCL specific fail - analyze and enable
-// XFAIL: windows
-
 #include <CL/sycl.hpp>
 
 #include <algorithm>


### PR DESCRIPTION
- Fixed buffer/image class for working with stl allocator.
   std::allocator::deallocate requires non-null pointer.
- Changed default image class allocator to the aligned_allocator. 
- Enabled image_api lit test on Windows OS.

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>