### PR TITLE
[SYCL] Add intelfpga vendor header files

### DIFF
--- a/sycl/doc/extensions/intel_fpga/fpga_reg.md
+++ b/sycl/doc/extensions/intel_fpga/fpga_reg.md
@@ -1,0 +1,31 @@
+# FPGA reg
+
+Intel FPGA extension fpga_reg() is implemented in header file
+`#include <CL/sycl/intel/fpga_extensions.hpp>`.
+
+fpga_reg is used to help compiler infer that at least one register is on the corresponding data path.
+
+## Implementation
+
+The implementation is a wrapper class to map fpga_reg function call to built-in \_\_builtin_intel_fpga_reg()
+only when parsing for SYCL device code.
+```c++
+#if defined(__clang__) && __has_builtin(__builtin_intel_fpga_reg)
+  return __builtin_intel_fpga_reg(t);
+#else
+  return t;
+#endif
+
+```
+
+
+## Usage
+
+```c++
+#include <CL/sycl/intel/fpga_extensions.hpp>
+...
+// force at least one register on data path
+int a = cl::sycl::intel::fpga_reg(a[k]) + b[k];
+
+...
+```

--- a/sycl/doc/extensions/intel_fpga/fpga_selector.md
+++ b/sycl/doc/extensions/intel_fpga/fpga_selector.md
@@ -1,0 +1,27 @@
+# FPGA selector
+
+Intel FPGA users can use header file: `#include<CL/sycl/intel/fpga_device_selector.hpp>` to simplify their code
+when they want to specify FPGA hardware device or FPGA emulation device.
+
+## Implementation
+
+Current implementation is based on platform name. This is useful in the most common case when user have
+one FPGA board installed in their system (one device per platform). 
+
+## Usage: select FPGA hardware device
+```c++
+#include <CL/sycl/intel/fpga_device_selector.hpp>
+...
+// force FPGA hardware device
+cl::sycl::queue deviceQueue(cl::sycl::intel::fpga_selector{});
+...
+```
+
+## Usage: select FPGA emulator device
+```c++
+#include <CL/sycl/intel/fpga_device_selector.hpp>
+...
+// force FPGA emulation device
+cl::sycl::queue deviceQueue(cl::sycl::intel::fpga_emulator_selector{});
+...
+```

--- a/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
@@ -1,0 +1,51 @@
+//==- fpga_device_selector.hpp --- SYCL FPGA device selector shortcut  -----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl.hpp>
+
+namespace cl {
+namespace sycl {
+namespace intel {
+
+class platform_selector : public default_selector {
+private:
+  std::string device_platform_name;
+
+public:
+  platform_selector(const std::string &platform_name)
+      : device_platform_name(platform_name){}
+
+  virtual int operator()(const device &device) const {
+    const platform &pf = device.get_platform();
+    const std::string &platform_name = pf.get_info<info::platform::name>();
+    if (platform_name == device_platform_name) {
+      return 10000;
+    }
+    return -1;
+  }
+};
+
+const std::string EMULATION_PLATFORM_NAME =
+    "Intel(R) FPGA Emulation Platform for OpenCL(TM)";
+const std::string HARDWARE_PLATFORM_NAME = "Intel(R) FPGA SDK for OpenCL(TM)";
+
+class fpga_selector : public platform_selector {
+public:
+  fpga_selector() : platform_selector(HARDWARE_PLATFORM_NAME){}
+};
+
+class fpga_emulator_selector : public platform_selector {
+public:
+  fpga_emulator_selector() : platform_selector(EMULATION_PLATFORM_NAME){}
+};
+
+} // namespace intel
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/intel/fpga_extensions.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_extensions.hpp
@@ -1,0 +1,11 @@
+//==----------- fpga_extensions.hpp --- SYCL FPGA Extensions ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include <CL/sycl/intel/fpga_device_selector.hpp>
+#include <CL/sycl/intel/fpga_reg.hpp>

--- a/sycl/include/CL/sycl/intel/fpga_reg.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_reg.hpp
@@ -1,0 +1,25 @@
+//==-------------- fpga_reg.hpp --- SYCL FPGA Reg Extensions ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace cl {
+namespace sycl {
+namespace intel {
+
+template <typename T> T fpga_reg(const T &t) {
+#if defined(__clang__) && __has_builtin(__builtin_intel_fpga_reg)
+  return __builtin_intel_fpga_reg(t);
+#else
+  return t;
+#endif
+}
+
+} // namespace intel
+} // namespace sycl
+} // namespace cl


### PR DESCRIPTION
With FPGA header files, users have shortcuts to access FPGA device selector and FPGA extension (fpga_reg).

Example of using FPGA device selector.
#include <CL/sycl/intel/fpga_extensions.hpp>
...
cl::sycl::queue deviceQueue(cl::sycl::intel::fpga_selector{}); // this force fpga hardware device
...

Example of using FPGA extensions.
#include <CL/sycl/intel/fpga_extensions.hpp>
...
r[k] = cl::sycl::intel::fpga_reg(a[k]) + b[k];
...
Signed-off-by: Domi Yan domi.yan@intel.com