### PR TITLE
[SYCL] Fix address space in casts from derived to base class

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -246,7 +246,9 @@ ApplyNonVirtualAndVirtualOffset(CodeGenFunction &CGF, Address addr,
 
   // Apply the base offset.
   llvm::Value *ptr = addr.getPointer();
-  ptr = CGF.Builder.CreateBitCast(ptr, CGF.Int8PtrTy);
+  llvm::Type *ResTy = llvm::PointerType::getInt8PtrTy(
+      CGF.getLLVMContext(), ptr->getType()->getPointerAddressSpace());
+  ptr = CGF.Builder.CreateBitCast(ptr, ResTy);
   ptr = CGF.Builder.CreateInBoundsGEP(ptr, baseOffset, "add.ptr");
 
   // If we have a virtual component, the alignment of the result will

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -246,9 +246,9 @@ ApplyNonVirtualAndVirtualOffset(CodeGenFunction &CGF, Address addr,
 
   // Apply the base offset.
   llvm::Value *ptr = addr.getPointer();
-  llvm::Type *ResTy = llvm::PointerType::getInt8PtrTy(
+  llvm::Type *resTy = llvm::PointerType::getInt8PtrTy(
       CGF.getLLVMContext(), ptr->getType()->getPointerAddressSpace());
-  ptr = CGF.Builder.CreateBitCast(ptr, ResTy);
+  ptr = CGF.Builder.CreateBitCast(ptr, resTy);
   ptr = CGF.Builder.CreateInBoundsGEP(ptr, baseOffset, "add.ptr");
 
   // If we have a virtual component, the alignment of the result will


### PR DESCRIPTION
In case of multiple inheritance of non-empty classes clang emits two
bitcasts and a GEP for conversion from derived to a base class. First
bitcast converts pointer to derived class to int8 pointer, then GEP
takes this int8 pointer and applies base class offset, next second
bitcast converts int8 pointer with offset to base class pointer. With
new SYCL address space rules pointer to derived class may have generic
address space. In this case two address space casts instead of bitcasts
should be emitted.
This problem caused assertion fail inside the CodeGen and invalid module
generation.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>