### PR TITLE
[SYCL][NFC] Refactor invoking kernels.

### DIFF
--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -9,9 +9,11 @@
 #pragma once
 
 #include <CL/__spirv/spirv_types.hpp>
+#include <CL/__spirv/spirv_vars.hpp>
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/type_traits.hpp>
 
 #include <memory>
 #include <stdexcept>
@@ -22,13 +24,13 @@ namespace cl {
 namespace sycl {
 class context;
 class event;
-template <int dimensions, bool with_offset> class item;
-template <int dimensions> class group;
-template <int dimensions> class range;
-template <int dimensions> class id;
-template <int dimensions> class nd_item;
+template <int Dims, bool WithOffset> class item;
+template <int Dims> class group;
+template <int Dims> class range;
+template <int Dims> class id;
+template <int Dims> class nd_item;
+template <int Dims> class h_item;
 enum class memory_order;
-template <int dimensions> class h_item;
 
 namespace detail {
 class context_impl;
@@ -43,70 +45,119 @@ void waitEvents(std::vector<cl::sycl::event> DepEvents);
 class Builder {
 public:
   Builder() = delete;
-  template <int dimensions>
-  static group<dimensions>
-  createGroup(const cl::sycl::range<dimensions> &G,
-              const cl::sycl::range<dimensions> &L,
-              const cl::sycl::range<dimensions> &GroupRange,
-              const cl::sycl::id<dimensions> &I) {
-    return cl::sycl::group<dimensions>(G, L, GroupRange, I);
+
+  template <int Dims>
+  static group<Dims>
+  createGroup(const range<Dims> &Global, const range<Dims> &Local,
+              const range<Dims> &Group, const id<Dims> &Index) {
+    return group<Dims>(Global, Local, Group, Index);
   }
 
-  template <int dimensions>
-  static group<dimensions> createGroup(const cl::sycl::range<dimensions> &G,
-                                       const cl::sycl::range<dimensions> &L,
-                                       const cl::sycl::id<dimensions> &I) {
-    return cl::sycl::group<dimensions>(G, L, G / L, I);
+  template <int Dims>
+  static group<Dims> createGroup(const range<Dims> &Global,
+                                 const range<Dims> &Local,
+                                 const id<Dims> &Index) {
+    return group<Dims>(Global, Local, Global / Local, Index);
   }
 
-  template <int dimensions, bool with_offset>
-  static item<dimensions, with_offset> createItem(
-      typename std::enable_if<(with_offset == true),
-                              const cl::sycl::range<dimensions>>::type &R,
-      const cl::sycl::id<dimensions> &I, const cl::sycl::id<dimensions> &O) {
-    return cl::sycl::item<dimensions, with_offset>(R, I, O);
+  template <int Dims, bool WithOffset>
+  static detail::enable_if_t<WithOffset, item<Dims, WithOffset>>
+  createItem(const range<Dims> &Extent, const id<Dims> &Index,
+             const id<Dims> &Offset) {
+    return item<Dims, WithOffset>(Extent, Index, Offset);
   }
 
-  template <int dimensions, bool with_offset>
-  static item<dimensions, with_offset> createItem(
-      typename std::enable_if<(with_offset == false),
-                              const cl::sycl::range<dimensions>>::type &R,
-      const cl::sycl::id<dimensions> &I) {
-    return cl::sycl::item<dimensions, with_offset>(R, I);
+  template <int Dims, bool WithOffset>
+  static detail::enable_if_t<!WithOffset, item<Dims, WithOffset>>
+  createItem(const range<Dims> &Extent, const id<Dims> &Index) {
+    return item<Dims, WithOffset>(Extent, Index);
   }
 
-  template <int dimensions, bool with_offset>
-  static void updateItemIndex(cl::sycl::item<dimensions, with_offset> &Item,
-                              const id<dimensions> &NextIndex) {
+  template <int Dims>
+  static nd_item<Dims> createNDItem(const item<Dims, true> &Global,
+                                    const item<Dims, false> &Local,
+                                    const group<Dims> &Group) {
+    return nd_item<Dims>(Global, Local, Group);
+  }
+
+  template <int Dims>
+  static h_item<Dims> createHItem(const item<Dims, false> &Global,
+                                  const item<Dims, false> &Local) {
+    return h_item<Dims>(Global, Local);
+  }
+
+  template <int Dims>
+  static h_item<Dims> createHItem(const item<Dims, false> &Global,
+                                  const item<Dims, false> &Local,
+                                  const range<Dims> &Flex) {
+    return h_item<Dims>(Global, Local, Flex);
+  }
+
+  template <int Dims, bool WithOffset>
+  static void updateItemIndex(cl::sycl::item<Dims, WithOffset> &Item,
+                              const id<Dims> &NextIndex) {
     Item.MImpl.MIndex = NextIndex;
   }
 
-  template <int dimensions>
-  static nd_item<dimensions>
-  createNDItem(const cl::sycl::item<dimensions, true> &GL,
-               const cl::sycl::item<dimensions, false> &L,
-               const cl::sycl::group<dimensions> &GR) {
-    return cl::sycl::nd_item<dimensions>(GL, L, GR);
+#ifdef __SYCL_DEVICE_ONLY__
+
+  template <int N>
+  using is_valid_dimensions = std::integral_constant<bool, (N > 0) && (N < 4)>;
+
+  template <int Dims> static const id<Dims> getId() {
+    static_assert(is_valid_dimensions<Dims>::value, "invalid dimensions");
+    return __spirv::initGlobalInvocationId<Dims, id<Dims>>();
   }
 
-  template <int dimensions>
-  static h_item<dimensions>
-  createHItem(const cl::sycl::item<dimensions, false> &GlobalItem,
-              const cl::sycl::item<dimensions, false> &LocalItem) {
-    return cl::sycl::h_item<dimensions>(GlobalItem, LocalItem);
+  template <int Dims> static const group<Dims> getGroup() {
+    static_assert(is_valid_dimensions<Dims>::value, "invalid dimensions");
+    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
+    range<Dims> LocalSize{__spirv::initWorkgroupSize<Dims, range<Dims>>()};
+    range<Dims> GroupRange{__spirv::initNumWorkgroups<Dims, range<Dims>>()};
+    id<Dims> GroupId{__spirv::initWorkgroupId<Dims, id<Dims>>()};
+    return createGroup<Dims>(GlobalSize, LocalSize, GroupRange, GroupId);
   }
 
-  template <int dimensions>
-  static h_item<dimensions>
-  createHItem(const cl::sycl::item<dimensions, false> &GlobalItem,
-              const cl::sycl::item<dimensions, false> &LocalItem,
-              const cl::sycl::range<dimensions> &FlexRange) {
-    return cl::sycl::h_item<dimensions>(GlobalItem, LocalItem, FlexRange);
+  template <int Dims, bool WithOffset>
+  static detail::enable_if_t<WithOffset, const item<Dims, WithOffset>>
+  getItem() {
+    static_assert(is_valid_dimensions<Dims>::value, "invalid dimensions");
+    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
+    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
+    id<Dims> GlobalOffset{__spirv::initGlobalOffset<Dims, id<Dims>>()};
+    return createItem<Dims, true>(GlobalSize, GlobalId, GlobalOffset);
   }
+
+  template <int Dims, bool WithOffset>
+  static detail::enable_if_t<!WithOffset, const item<Dims, WithOffset>>
+  getItem() {
+    static_assert(is_valid_dimensions<Dims>::value, "invalid dimensions");
+    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
+    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
+    return createItem<Dims, false>(GlobalSize, GlobalId);
+  }
+
+  template <int Dims> static const nd_item<Dims> getNDItem() {
+    static_assert(is_valid_dimensions<Dims>::value, "invalid dimensions");
+    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
+    range<Dims> LocalSize{__spirv::initWorkgroupSize<Dims, range<Dims>>()};
+    range<Dims> GroupRange{__spirv::initNumWorkgroups<Dims, range<Dims>>()};
+    id<Dims> GroupId{__spirv::initWorkgroupId<Dims, id<Dims>>()};
+    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
+    id<Dims> LocalId{__spirv::initLocalInvocationId<Dims, id<Dims>>()};
+    id<Dims> GlobalOffset{__spirv::initGlobalOffset<Dims, id<Dims>>()};
+    group<Dims> Group =
+        createGroup<Dims>(GlobalSize, LocalSize, GroupRange, GroupId);
+    item<Dims, true> GlobalItem =
+        createItem<Dims, true>(GlobalSize, GlobalId, GlobalOffset);
+    item<Dims, false> LocalItem = createItem<Dims, false>(LocalSize, LocalId);
+    return createNDItem<Dims>(GlobalItem, LocalItem, Group);
+  }
+#endif // __SYCL_DEVICE_ONLY__
 };
 
-inline constexpr
-__spv::MemorySemanticsMask getSPIRVMemorySemanticsMask(memory_order) {
+inline constexpr __spv::MemorySemanticsMask
+getSPIRVMemorySemanticsMask(memory_order) {
   return __spv::MemorySemanticsMask::None;
 }
 

--- a/sycl/include/CL/sycl/detail/type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/type_traits.hpp
@@ -25,6 +25,9 @@ using allocator_pointer_t = typename std::allocator_traits<T>::pointer;
 template <bool B, class T = void>
 using enable_if_t = typename std::enable_if<B, T>::type;
 
+template <bool B, class T, class F>
+using conditional_t = typename std::conditional<B, T, F>::type;
+
 template <typename T>
 using remove_pointer_t = typename std::remove_pointer<T>::type;
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -10,11 +10,11 @@
 
 #pragma once
 
-#include <CL/__spirv/spirv_vars.hpp>
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/cg.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
@@ -583,53 +583,25 @@ public:
   template <typename KernelName, typename KernelType, int Dims>
   __attribute__((sycl_kernel)) EnableIfId<KernelType, Dims>
   kernel_parallel_for(KernelType KernelFunc) {
-    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
-    KernelFunc(GlobalId);
+    KernelFunc(detail::Builder::getId<Dims>());
   }
 
   template <typename KernelName, typename KernelType, int Dims>
   __attribute__((sycl_kernel)) EnableIfItemWithoutOffset<KernelType, Dims>
   kernel_parallel_for(KernelType KernelFunc) {
-    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
-    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
-
-    item<Dims, false> Item =
-        detail::Builder::createItem<Dims, false>(GlobalSize, GlobalId);
-    KernelFunc(Item);
+    KernelFunc(detail::Builder::getItem<Dims, false>());
   }
 
   template <typename KernelName, typename KernelType, int Dims>
   __attribute__((sycl_kernel)) EnableIfItemWithOffset<KernelType, Dims>
   kernel_parallel_for(KernelType KernelFunc) {
-    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
-    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
-    id<Dims> GlobalOffset{__spirv::initGlobalOffset<Dims, id<Dims>>()};
-
-    item<Dims, true> Item = detail::Builder::createItem<Dims, true>(
-        GlobalSize, GlobalId, GlobalOffset);
-    KernelFunc(Item);
+    KernelFunc(detail::Builder::getItem<Dims, true>());
   }
 
   template <typename KernelName, typename KernelType, int Dims>
   __attribute__((sycl_kernel)) EnableIfNDItem<KernelType, Dims>
   kernel_parallel_for(KernelType KernelFunc) {
-    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
-    range<Dims> LocalSize{__spirv::initWorkgroupSize<Dims, range<Dims>>()};
-    range<Dims> GroupRange{__spirv::initNumWorkgroups<Dims, range<Dims>>()};
-    id<Dims> GroupId{__spirv::initWorkgroupId<Dims, id<Dims>>()};
-    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
-    id<Dims> LocalId{__spirv::initLocalInvocationId<Dims, id<Dims>>()};
-    id<Dims> GlobalOffset{__spirv::initGlobalOffset<Dims, id<Dims>>()};
-
-    group<Dims> Group = detail::Builder::createGroup<Dims>(
-        GlobalSize, LocalSize, GroupRange, GroupId);
-    item<Dims, true> GlobalItem = detail::Builder::createItem<Dims, true>(
-        GlobalSize, GlobalId, GlobalOffset);
-    item<Dims, false> LocalItem =
-        detail::Builder::createItem<Dims, false>(LocalSize, LocalId);
-    nd_item<Dims> NDItem =
-        detail::Builder::createNDItem<Dims>(GlobalItem, LocalItem, Group);
-    KernelFunc(NDItem);
+    KernelFunc(detail::Builder::getNDItem<Dims>());
   }
 
   // NOTE: the name of this function - "kernel_parallel_for_work_group" - is
@@ -637,14 +609,7 @@ public:
   template <typename KernelName, typename KernelType, int Dims>
   __attribute__((sycl_kernel)) void
   kernel_parallel_for_work_group(KernelType KernelFunc) {
-    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
-    range<Dims> LocalSize{__spirv::initWorkgroupSize<Dims, range<Dims>>()};
-    range<Dims> GroupRange{__spirv::initNumWorkgroups<Dims, range<Dims>>()};
-    id<Dims> GroupId{__spirv::initWorkgroupId<Dims, id<Dims>>()};
-
-    group<Dims> Group = detail::Builder::createGroup<Dims>(
-        GlobalSize, LocalSize, GroupRange, GroupId);
-    KernelFunc(Group);
+    KernelFunc(detail::Builder::getGroup<Dims>());
   }
 
 #endif

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -554,6 +554,23 @@ public:
   }
 
 #ifdef __SYCL_DEVICE_ONLY__
+
+  template <typename KernelT, typename IndexerT>
+  using EnableIfIndexer = detail::enable_if_t<
+      std::is_same<detail::lambda_arg_type<KernelT>, IndexerT>::value>;
+
+  template <typename KernelT, int Dims>
+  using EnableIfId = EnableIfIndexer<KernelT, id<Dims>>;
+
+  template <typename KernelT, int Dims>
+  using EnableIfItemWithOffset = EnableIfIndexer<KernelT, item<Dims, true>>;
+
+  template <typename KernelT, int Dims>
+  using EnableIfItemWithoutOffset = EnableIfIndexer<KernelT, item<Dims, false>>;
+
+  template <typename KernelT, int Dims>
+  using EnableIfNDItem = EnableIfIndexer<KernelT, nd_item<Dims>>;
+
   // NOTE: the name of this function - "kernel_single_task" - is used by the
   // Front End to determine kernel invocation kind.
   template <typename KernelName, typename KernelType>
@@ -561,87 +578,75 @@ public:
     KernelFunc();
   }
 
-  template <typename KernelName, typename KernelType, int dimensions>
-  __attribute__((sycl_kernel)) void kernel_parallel_for(
-      typename std::enable_if<std::is_same<detail::lambda_arg_type<KernelType>,
-                                           id<dimensions>>::value &&
-                                  (dimensions > 0 && dimensions < 4),
-                              KernelType>::type KernelFunc) {
-    id<dimensions> global_id{
-        __spirv::initGlobalInvocationId<dimensions, id<dimensions>>()};
-
-    KernelFunc(global_id);
-  }
-
-  // NOTE: the name of this function - "kernel_parallel_for" - is used by the
+  // NOTE: the name of these functions - "kernel_parallel_for" - are used by the
   // Front End to determine kernel invocation kind.
-  template <typename KernelName, typename KernelType, int dimensions>
-  __attribute__((sycl_kernel)) void kernel_parallel_for(
-      typename std::enable_if<std::is_same<detail::lambda_arg_type<KernelType>,
-                                           item<dimensions, false>>::value &&
-                                  (dimensions > 0 && dimensions < 4),
-                              KernelType>::type KernelFunc) {
-    id<dimensions> global_id{
-        __spirv::initGlobalInvocationId<dimensions, id<dimensions>>()};
-    range<dimensions> global_size{
-        __spirv::initGlobalSize<dimensions, range<dimensions>>()};
+  template <typename KernelName, typename KernelType, int Dims>
+  __attribute__((sycl_kernel)) EnableIfId<KernelType, Dims>
+  kernel_parallel_for(KernelType KernelFunc) {
+    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
+    KernelFunc(GlobalId);
+  }
 
-    item<dimensions, false> Item =
-        detail::Builder::createItem<dimensions, false>(global_size, global_id);
+  template <typename KernelName, typename KernelType, int Dims>
+  __attribute__((sycl_kernel)) EnableIfItemWithoutOffset<KernelType, Dims>
+  kernel_parallel_for(KernelType KernelFunc) {
+    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
+    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
+
+    item<Dims, false> Item =
+        detail::Builder::createItem<Dims, false>(GlobalSize, GlobalId);
     KernelFunc(Item);
   }
 
-    template <typename KernelName, typename KernelType, int dimensions>
-  __attribute__((sycl_kernel)) void kernel_parallel_for(
-      typename std::enable_if<std::is_same<detail::lambda_arg_type<KernelType>,
-                                           item<dimensions, true>>::value &&
-                                  (dimensions > 0 && dimensions < 4),
-                              KernelType>::type KernelFunc) {
-    id<dimensions> global_id{
-        __spirv::initGlobalInvocationId<dimensions, id<dimensions>>()};
-    range<dimensions> global_size{
-        __spirv::initGlobalSize<dimensions, range<dimensions>>()};
-    id<dimensions> global_offset{
-        __spirv::initGlobalOffset<dimensions, id<dimensions>>()};
+  template <typename KernelName, typename KernelType, int Dims>
+  __attribute__((sycl_kernel)) EnableIfItemWithOffset<KernelType, Dims>
+  kernel_parallel_for(KernelType KernelFunc) {
+    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
+    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
+    id<Dims> GlobalOffset{__spirv::initGlobalOffset<Dims, id<Dims>>()};
 
-    item<dimensions, true> Item = detail::Builder::createItem<dimensions, true>(
-        global_size, global_id, global_offset);
+    item<Dims, true> Item = detail::Builder::createItem<Dims, true>(
+        GlobalSize, GlobalId, GlobalOffset);
     KernelFunc(Item);
   }
 
-  template <typename KernelName, typename KernelType, int dimensions>
-  __attribute__((sycl_kernel)) void kernel_parallel_for(
-      typename std::enable_if<std::is_same<detail::lambda_arg_type<KernelType>,
-                                           nd_item<dimensions>>::value &&
-                                  (dimensions > 0 && dimensions < 4),
-                              KernelType>::type KernelFunc) {
-    range<dimensions> global_size{
-        __spirv::initGlobalSize<dimensions, range<dimensions>>()};
-    range<dimensions> local_size{
-        __spirv::initWorkgroupSize<dimensions, range<dimensions>>()};
-    range<dimensions> group_range{
-        __spirv::initNumWorkgroups<dimensions, range<dimensions>>()};
-    id<dimensions> group_id{
-        __spirv::initWorkgroupId<dimensions, id<dimensions>>()};
-    id<dimensions> global_id{
-        __spirv::initGlobalInvocationId<dimensions, id<dimensions>>()};
-    id<dimensions> local_id{
-        __spirv::initLocalInvocationId<dimensions, id<dimensions>>()};
-    id<dimensions> global_offset{
-        __spirv::initGlobalOffset<dimensions, id<dimensions>>()};
+  template <typename KernelName, typename KernelType, int Dims>
+  __attribute__((sycl_kernel)) EnableIfNDItem<KernelType, Dims>
+  kernel_parallel_for(KernelType KernelFunc) {
+    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
+    range<Dims> LocalSize{__spirv::initWorkgroupSize<Dims, range<Dims>>()};
+    range<Dims> GroupRange{__spirv::initNumWorkgroups<Dims, range<Dims>>()};
+    id<Dims> GroupId{__spirv::initWorkgroupId<Dims, id<Dims>>()};
+    id<Dims> GlobalId{__spirv::initGlobalInvocationId<Dims, id<Dims>>()};
+    id<Dims> LocalId{__spirv::initLocalInvocationId<Dims, id<Dims>>()};
+    id<Dims> GlobalOffset{__spirv::initGlobalOffset<Dims, id<Dims>>()};
 
-    group<dimensions> Group = detail::Builder::createGroup<dimensions>(
-        global_size, local_size, group_range, group_id);
-    item<dimensions, true> globalItem =
-        detail::Builder::createItem<dimensions, true>(global_size, global_id,
-                                                      global_offset);
-    item<dimensions, false> localItem =
-        detail::Builder::createItem<dimensions, false>(local_size, local_id);
-    nd_item<dimensions> Nd_item =
-        detail::Builder::createNDItem<dimensions>(globalItem, localItem, Group);
-
-    KernelFunc(Nd_item);
+    group<Dims> Group = detail::Builder::createGroup<Dims>(
+        GlobalSize, LocalSize, GroupRange, GroupId);
+    item<Dims, true> GlobalItem = detail::Builder::createItem<Dims, true>(
+        GlobalSize, GlobalId, GlobalOffset);
+    item<Dims, false> LocalItem =
+        detail::Builder::createItem<Dims, false>(LocalSize, LocalId);
+    nd_item<Dims> NDItem =
+        detail::Builder::createNDItem<Dims>(GlobalItem, LocalItem, Group);
+    KernelFunc(NDItem);
   }
+
+  // NOTE: the name of this function - "kernel_parallel_for_work_group" - is
+  // used by the Front End to determine kernel invocation kind.
+  template <typename KernelName, typename KernelType, int Dims>
+  __attribute__((sycl_kernel)) void
+  kernel_parallel_for_work_group(KernelType KernelFunc) {
+    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
+    range<Dims> LocalSize{__spirv::initWorkgroupSize<Dims, range<Dims>>()};
+    range<Dims> GroupRange{__spirv::initNumWorkgroups<Dims, range<Dims>>()};
+    id<Dims> GroupId{__spirv::initWorkgroupId<Dims, id<Dims>>()};
+
+    group<Dims> Group = detail::Builder::createGroup<Dims>(
+        GlobalSize, LocalSize, GroupRange, GroupId);
+    KernelFunc(Group);
+  }
+
 #endif
 
   // The method stores lambda to the template-free object and initializes
@@ -739,24 +744,6 @@ public:
     MCGType = detail::CG::KERNEL;
 #endif // __SYCL_DEVICE_ONLY__
   }
-
-#ifdef __SYCL_DEVICE_ONLY__
-  // NOTE: the name of this function - "kernel_parallel_for_work_group" - is
-  // used by the Front End to determine kernel invocation kind.
-  template <typename KernelName, typename KernelType, int Dims>
-  __attribute__((sycl_kernel)) void
-  kernel_parallel_for_work_group(KernelType KernelFunc) {
-
-    range<Dims> GlobalSize{__spirv::initGlobalSize<Dims, range<Dims>>()};
-    range<Dims> LocalSize{__spirv::initWorkgroupSize<Dims, range<Dims>>()};
-    range<Dims> GroupRange{__spirv::initNumWorkgroups<Dims, range<Dims>>()};
-    id<Dims> GroupId{__spirv::initWorkgroupId<Dims, id<Dims>>()};
-
-    group<Dims> G = detail::Builder::createGroup<Dims>(GlobalSize, LocalSize,
-                                                       GroupRange, GroupId);
-    KernelFunc(G);
-  }
-#endif // __SYCL_DEVICE_ONLY__
 
   template <typename KernelName = csd::auto_name, typename KernelType, int Dims>
   void parallel_for_work_group(range<Dims> NumWorkGroups,


### PR DESCRIPTION
- Made the enable_if logic more readable.
- Moved the responsibility for indexers initialization to the Builder class.
- Aligned the naming conversion.