### PR TITLE
[SYCL] Fix host's abs_diff function for unsigned types

### DIFF
--- a/sycl/source/detail/builtins_integer.cpp
+++ b/sycl/source/detail/builtins_integer.cpp
@@ -12,6 +12,7 @@
 #include "builtins_helper.hpp"
 
 #include <algorithm>
+#include <type_traits>
 
 namespace s = cl::sycl;
 namespace d = s::detail;
@@ -20,7 +21,11 @@ namespace cl {
 namespace __host_std {
 namespace {
 
-template <typename T> inline T __abs_diff(T x, T y) { return std::abs(x - y); }
+template <typename T> inline T __abs_diff(T x, T y) {
+  static_assert(std::is_integral<T>::value,
+                "Only integral types are supported");
+  return (x > y) ? (x - y) : (y - x);
+}
 
 template <typename T> inline T __u_add_sat(T x, T y) {
   return (x < (d::max_v<T>() - y) ? x + y : d::max_v<T>());
@@ -198,10 +203,18 @@ MAKE_1V(s_abs, s::cl_uint, s::cl_int)
 MAKE_1V(s_abs, s::cl_ulong, s::cl_long)
 
 // u_abs_diff
-cl_uchar u_abs_diff(s::cl_uchar x, s::cl_uchar y) __NOEXC { return x - y; }
-cl_ushort u_abs_diff(s::cl_ushort x, s::cl_ushort y) __NOEXC { return x - y; }
-cl_uint u_abs_diff(s::cl_uint x, s::cl_uint y) __NOEXC { return x - y; }
-cl_ulong u_abs_diff(s::cl_ulong x, s::cl_ulong y) __NOEXC { return x - y; }
+cl_uchar u_abs_diff(s::cl_uchar x, s::cl_uchar y) __NOEXC {
+  return __abs_diff(x, y);
+}
+cl_ushort u_abs_diff(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+  return __abs_diff(x, y);
+}
+cl_uint u_abs_diff(s::cl_uint x, s::cl_uint y) __NOEXC {
+  return __abs_diff(x, y);
+}
+cl_ulong u_abs_diff(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+  return __abs_diff(x, y);
+}
 
 MAKE_1V_2V(u_abs_diff, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_abs_diff, s::cl_ushort, s::cl_ushort, s::cl_ushort)

--- a/sycl/test/built-ins/scalar_integer.cpp
+++ b/sycl/test/built-ins/scalar_integer.cpp
@@ -107,7 +107,7 @@ int main() {
     }
     assert(r == 2);
   }
-  
+
   // abs
   {
     s::cl_uint r{ 0 };
@@ -138,6 +138,22 @@ int main() {
       });
     }
     assert(r == 4);
+  }
+
+  // abs_diff(uchar)
+  {
+    s::cl_uchar r{ 0 };
+    {
+      s::buffer<s::cl_uchar, 1> BufR(&r, s::range<1>(1));
+      s::queue myQueue;
+      myQueue.submit([&](s::handler &cgh) {
+        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        cgh.single_task<class abs_diffUC1UC1>([=]() {
+          AccR[0] = s::abs_diff(s::uchar{ 3 }, s::uchar{ 250 });
+        });
+      });
+    }
+    assert(r == 247);
   }
 
   // add_sat


### PR DESCRIPTION
Fix incorrect behavior of host's abs_diff function
in case if x - y < 0 and x and y are unsigned types.

Signed-off-by: Ilya Stepykin <ilya.stepykin@intel.com>