### PR TITLE
[SYCL] Align exception type with the SYCL specification

### DIFF
--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -27,8 +27,7 @@ device device_selector::select_device() const {
   if (res != nullptr)
     return *res;
 
-  throw cl::sycl::invalid_parameter_error(
-      "No device of requested type available.");
+  throw cl::sycl::runtime_error("No device of requested type available.");
 }
 
 int default_selector::operator()(const device &dev) const {


### PR DESCRIPTION
SYCL spec says that implementation must throw a runtime_error SYCL
exception if no device matching the requirement can be found.