### PR TITLE
[SYCL]Relax kernel-metadata.cpp test to allow downstream metadata.

### DIFF
--- a/clang/test/CodeGenSYCL/kernel-metadata.cpp
+++ b/clang/test/CodeGenSYCL/kernel-metadata.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
-// CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE15kernel_function() {{[^{]+}} !kernel_arg_addr_space ![[MD:[0-9]+]] !kernel_arg_access_qual ![[MD]] !kernel_arg_type ![[MD]] !kernel_arg_base_type ![[MD]] !kernel_arg_type_qual ![[MD]] {
+// CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE15kernel_function() {{[^{]+}} !kernel_arg_addr_space ![[MD:[0-9]+]] !kernel_arg_access_qual ![[MD]] !kernel_arg_type ![[MD]] !kernel_arg_base_type ![[MD]] !kernel_arg_type_qual ![[MD]]
 // CHECK: ![[MD]] = !{}
 
 template <typename name, typename Func>


### PR DESCRIPTION
The test kernel-metadata.cpp check-line is too specific, so it prevents
adding metadata in a downstream.  This patch just removes the '{' so
additional metadata works.

Signed-off-by: Erich Keane <erich.keane@intel.com>