### PR TITLE
[SYCL]  Solve name resolution problems due to Windows integer types

### DIFF
--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -238,8 +238,9 @@ using is_ulongn = typename is_contained<
 // ugenlong: unsigned long int, ulongn
 template <typename T>
 using is_ugenlong =
-    std::integral_constant<bool, is_contained<T, type_list<cl_ulong>>::value ||
-                                     is_ulongn<T>::value>;
+    std::integral_constant<bool,
+      is_contained<T, type_list<unsigned long, cl_ulong>>::value ||
+      is_ulongn<T>::value>;
 
 // longn: long2, long3, long4, long8, long16
 template <typename T>
@@ -249,8 +250,8 @@ using is_longn = typename is_contained<
 // genlong: long int, longn
 template <typename T>
 using is_genlong =
-    std::integral_constant<bool, is_contained<T, type_list<cl_long>>::value ||
-                                     is_longn<T>::value>;
+    std::integral_constant<bool,
+      is_contained<T, type_list<long, cl_long>>::value || is_longn<T>::value>;
 
 // ulonglongn: ulonglong2, ulonglong3, ulonglong4,ulonglong8, ulonglong16
 template <typename T>
@@ -314,7 +315,8 @@ using is_ugeninteger = std::integral_constant<
 template <typename T>
 using is_sgeninteger = typename is_contained<
     T, type_list<cl_char, cl_schar, cl_uchar, cl_short, cl_ushort, cl_int,
-                 cl_uint, cl_long, cl_ulong, longlong, ulonglong>>::type;
+                 cl_uint, cl_long, cl_ulong, long, unsigned long,
+                 longlong, ulonglong>>::type;
 
 // vgeninteger: charn, scharn, ucharn, shortn, ushortn, intn, uintn, longn,
 // ulongn, longlongn, ulonglongn
@@ -329,7 +331,8 @@ using is_vgeninteger = std::integral_constant<
 // sigeninteger: char, signed char, short, int, long int, , long long int
 template <typename T>
 using is_sigeninteger = typename is_contained<
-    T, type_list<cl_char, cl_schar, cl_short, cl_int, cl_long, longlong>>::type;
+    T, type_list<cl_char, cl_schar, cl_short, cl_int, cl_long, long,
+                 longlong>>::type;
 
 // sugeninteger: unsigned char, unsigned short,  unsigned int, unsigned long
 // int, unsigned long long int


### PR DESCRIPTION
There are 3 Windows CTS tests, math_builtin_relational_base,
math_builtin_float_double, math_builtin_integer that fail at compile
time in all 3 environments.

Here's a small reproducer showing the symptom:

The error is like this,
math_builtin_float_double.cpp:8:12: error: no matching function for call to 'nan'
auto x = cl::sycl::nan(y);
^~~~~~~~~~~~~
...include\CL/sycl/builtins.hpp:398:1: note: candidate template
ignored: requirement 'detail::integral_constant<bool, false>::value' was not satisfied [with T = int]
nan(T nancode) __NOEXC {
^
1 error generated.

Here’s a smaller version of the invoker,

int foo(void)
{
//unsigned long int y = 1; FAIL like above
//long int y = 1; FAIL like above
//int y = 1; FAIL like above
unsigned y = 1; // This one is OK
auto x = cl::sycl::nan(y);
}

Erich suggested,

https://godbolt.org/z/XkWVHg

Even on MSVC, “unsigned int” and “unsigned long” are different types, despite sizeof being the same for both.

The header itself uses __int32 and __int64, which are just aliases on MSVC for “unsigned int” and “unsigned long long”.

THUS, the list in the headers (which I copied below) doesn’t contain ANY version of “unsigned long” on Windows. Ulonglong (the other being checked) is ALSO “unsigned long long”

On linux, the list is:
cl_uint == unsigned int
cl_ulong == unsigned long
ulonglong == unsigned long long.

Thus, the whole list is covered.

I suspect that one of the checks (is_ugenlong probably ) simply needs to have “unsigned long” added to it as an option in addition to cl_ulong. Alternatively, cl_ulong could be corrected.

Either way, a header issue.

Signed-off-by: Melanie Blower <melanie.blower@intel.com>