### PR TITLE
[SYCL][NFC] Adjust names of some PI utilities.

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -139,7 +139,7 @@ public:
 
     size_t BufSize = 0;
     PI_CALL(detail::RT::piMemGetInfo(
-        detail::pi::pi_cast<detail::RT::PiMem>(MemObject), CL_MEM_SIZE,
+        detail::pi::cast<detail::RT::PiMem>(MemObject), CL_MEM_SIZE,
         sizeof(size_t), &BufSize, nullptr));
 
     Range[0] = BufSize / sizeof(T);

--- a/sycl/include/CL/sycl/detail/clusm.hpp
+++ b/sycl/include/CL/sycl/detail/clusm.hpp
@@ -122,8 +122,8 @@ inline cl::sycl::detail::usm::CLUSM *GetCLUSM() {
   }
 
   cl::sycl::detail::usm::CLUSM *retVal = nullptr;
-  if (cl::sycl::detail::pi::piUseBackend(
-          cl::sycl::detail::pi::PiBackend::SYCL_BE_PI_OPENCL)) {
+  if (cl::sycl::detail::pi::useBackend(
+          cl::sycl::detail::pi::Backend::SYCL_BE_PI_OPENCL)) {
     retVal = gCLUSM;
   }
   return retVal;

--- a/sycl/include/CL/sycl/detail/context_info.hpp
+++ b/sycl/include/CL/sycl/detail/context_info.hpp
@@ -22,7 +22,7 @@ template <info::context param> struct get_context_info {
   static RetType _(RT::PiContext ctx) {
     RetType Result = 0;
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(RT::piContextGetInfo(ctx, pi::pi_cast<pi_context_info>(param),
+    PI_CALL(RT::piContextGetInfo(ctx, pi::cast<pi_context_info>(param),
                                  sizeof(Result), &Result, nullptr));
     return Result;
   }

--- a/sycl/include/CL/sycl/detail/device_impl.hpp
+++ b/sycl/include/CL/sycl/detail/device_impl.hpp
@@ -122,7 +122,7 @@ public:
       PI_CALL(RT::piDeviceRetain(m_device));
     }
     // TODO: check that device is an OpenCL interop one
-    return pi::pi_cast<cl_device_id>(m_device);
+    return pi::cast<cl_device_id>(m_device);
   }
 
   RT::PiDevice &getHandleRef() override { return m_device; }

--- a/sycl/include/CL/sycl/detail/device_info.hpp
+++ b/sycl/include/CL/sycl/detail/device_info.hpp
@@ -49,7 +49,7 @@ template <typename T, info::device param> struct get_device_info {
   static T _(RT::PiDevice dev) {
     typename sycl_to_pi<T>::type result;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(param), sizeof(result), &result, NULL));
+      dev, pi::cast<RT::PiDeviceInfo>(param), sizeof(result), &result, NULL));
     return T(result);
   }
 };
@@ -60,7 +60,7 @@ struct get_device_info<platform, param> {
   static platform _(RT::PiDevice dev) {
     typename sycl_to_pi<platform>::type result;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(param), sizeof(result), &result, NULL));
+      dev, pi::cast<RT::PiDeviceInfo>(param), sizeof(result), &result, NULL));
     return createSyclObjFromImpl<platform>(
         std::make_shared<platform_impl_pi>(result));
   }
@@ -71,13 +71,13 @@ template <info::device param> struct get_device_info<string_class, param> {
   static string_class _(RT::PiDevice dev) {
     size_t resultSize;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(param), 0, NULL, &resultSize));
+      dev, pi::cast<RT::PiDeviceInfo>(param), 0, NULL, &resultSize));
     if (resultSize == 0) {
       return string_class();
     }
     unique_ptr_class<char[]> result(new char[resultSize]);
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(param),
+      dev, pi::cast<RT::PiDeviceInfo>(param),
       resultSize, result.get(), NULL));
 
     return string_class(result.get());
@@ -95,7 +95,7 @@ template <info::device param> struct get_device_info<id<3>, param> {
   static id<3> _(RT::PiDevice dev) {
     size_t result[3];
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(param), sizeof(result), &result, NULL));
+      dev, pi::cast<RT::PiDeviceInfo>(param), sizeof(result), &result, NULL));
     return id<3>(result[0], result[1], result[2]);
   }
 };
@@ -113,7 +113,7 @@ struct get_device_info<vector_class<info::fp_config>, param> {
     }
     cl_device_fp_config result;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(param), sizeof(result), &result, NULL));
+      dev, pi::cast<RT::PiDeviceInfo>(param), sizeof(result), &result, NULL));
     return read_fp_bitfield(result);
   }
 };
@@ -125,7 +125,7 @@ struct get_device_info<vector_class<info::fp_config>,
   static vector_class<info::fp_config> _(RT::PiDevice dev) {
     cl_device_fp_config result;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(info::device::single_fp_config),
+      dev, pi::cast<RT::PiDeviceInfo>(info::device::single_fp_config),
       sizeof(result), &result, NULL));
     return read_fp_bitfield(result);
   }
@@ -136,7 +136,7 @@ template <> struct get_device_info<bool, info::device::queue_profiling> {
   static bool _(RT::PiDevice dev) {
     cl_command_queue_properties result;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(info::device::queue_profiling),
+      dev, pi::cast<RT::PiDeviceInfo>(info::device::queue_profiling),
       sizeof(result), &result, NULL));
     return (result & CL_QUEUE_PROFILING_ENABLE);
   }
@@ -149,7 +149,7 @@ struct get_device_info<vector_class<info::execution_capability>,
   static vector_class<info::execution_capability> _(RT::PiDevice dev) {
     cl_device_exec_capabilities result;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(info::device::execution_capabilities),
+      dev, pi::cast<RT::PiDeviceInfo>(info::device::execution_capabilities),
       sizeof(result), &result, NULL));
     return read_execution_bitfield(result);
   }
@@ -183,7 +183,7 @@ struct get_device_info<vector_class<info::partition_property>,
                        info::device::partition_properties> {
   static vector_class<info::partition_property> _(RT::PiDevice dev) {
     auto info_partition =
-      pi::pi_cast<RT::PiDeviceInfo>(info::device::partition_properties);
+      pi::cast<RT::PiDeviceInfo>(info::device::partition_properties);
 
     size_t resultSize;
     PI_CALL(RT::piDeviceGetInfo(dev, info_partition, 0, NULL, &resultSize));
@@ -212,7 +212,7 @@ struct get_device_info<vector_class<info::partition_affinity_domain>,
   static vector_class<info::partition_affinity_domain> _(RT::PiDevice dev) {
     cl_device_affinity_domain result;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(info::device::partition_affinity_domains),
+      dev, pi::cast<RT::PiDeviceInfo>(info::device::partition_affinity_domains),
       sizeof(result), &result, NULL));
     return read_domain_bitfield(result);
   }
@@ -226,7 +226,7 @@ struct get_device_info<info::partition_affinity_domain,
   static info::partition_affinity_domain _(RT::PiDevice dev) {
     size_t resultSize;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(
+      dev, pi::cast<RT::PiDeviceInfo>(
              info::device::partition_type_affinity_domain),
       0, NULL, &resultSize));
     if (resultSize != 1) {
@@ -234,7 +234,7 @@ struct get_device_info<info::partition_affinity_domain,
     }
     cl_device_partition_property result;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(
+      dev, pi::cast<RT::PiDeviceInfo>(
              info::device::partition_type_affinity_domain),
       sizeof(result), &result, NULL));
     if (result == CL_DEVICE_AFFINITY_DOMAIN_NUMA ||
@@ -278,12 +278,12 @@ struct get_device_info<vector_class<size_t>,
   static vector_class<size_t> _(RT::PiDevice dev) {
     size_t resultSize = 0;
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(info::device::sub_group_sizes),
+      dev, pi::cast<RT::PiDeviceInfo>(info::device::sub_group_sizes),
       0, nullptr, &resultSize));
 
     vector_class<size_t> result(resultSize/sizeof(size_t));
     PI_CALL(RT::piDeviceGetInfo(
-      dev, pi::pi_cast<RT::PiDeviceInfo>(info::device::sub_group_sizes),
+      dev, pi::cast<RT::PiDeviceInfo>(info::device::sub_group_sizes),
       resultSize, result.data(), nullptr));
     return result;
   }

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -229,7 +229,7 @@ public:
   image_impl(cl_mem MemObject, const context &SyclContext,
              event AvailableEvent = {})
       : BaseT(MemObject, SyclContext, std::move(AvailableEvent)) {
-    RT::PiMem Mem = pi::pi_cast<RT::PiMem>(BaseT::MInteropMemObject);
+    RT::PiMem Mem = pi::cast<RT::PiMem>(BaseT::MInteropMemObject);
     PI_CALL(RT::piMemGetInfo(Mem, CL_MEM_SIZE, sizeof(size_t),
                              &(BaseT::MSizeInBytes), nullptr));
 
@@ -340,7 +340,7 @@ public:
 
 private:
   template <typename T> void getImageInfo(RT::PiMemImageInfo Info, T &Dest) {
-    RT::PiMem Mem = pi::pi_cast<RT::PiMem>(BaseT::MInteropMemObject);
+    RT::PiMem Mem = pi::cast<RT::PiMem>(BaseT::MInteropMemObject);
     PI_CALL(RT::piMemImageGetInfo(Mem, Info, sizeof(T), &Dest, nullptr));
   }
 

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -63,7 +63,7 @@ public:
       throw invalid_object_error("This instance of kernel is a host instance");
     }
     PI_CALL(RT::piKernelRetain(Kernel));
-    return pi::pi_cast<cl_kernel>(Kernel);
+    return pi::cast<cl_kernel>(Kernel);
   }
 
   bool is_host() const { return Context.is_host(); }

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -70,7 +70,7 @@ public:
     return (all_extension_names.find(extension_name) != std::string::npos);
   }
 
-  cl_platform_id get() const override { return pi::pi_cast<cl_platform_id>(m_platform); }
+  cl_platform_id get() const override { return pi::cast<cl_platform_id>(m_platform); }
 
   const RT::PiPlatform &getHandleRef() const override { return m_platform; }
 

--- a/sycl/include/CL/sycl/detail/platform_info.hpp
+++ b/sycl/include/CL/sycl/detail/platform_info.hpp
@@ -25,14 +25,14 @@ struct get_platform_info<string_class, param> {
     size_t resultSize;
     // TODO catch an exception and put it to list of asynchronous exceptions
     PI_CALL(RT::piPlatformGetInfo(
-      plt, pi::pi_cast<pi_platform_info>(param), 0, 0, &resultSize));
+      plt, pi::cast<pi_platform_info>(param), 0, 0, &resultSize));
     if (resultSize == 0) {
       return "";
     }
     unique_ptr_class<char[]> result(new char[resultSize]);
     // TODO catch an exception and put it to list of asynchronous exceptions
     PI_CALL(RT::piPlatformGetInfo(
-      plt, pi::pi_cast<pi_platform_info>(param), resultSize, result.get(), 0));
+      plt, pi::cast<pi_platform_info>(param), resultSize, result.get(), 0));
     return result.get();
   }
 };

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -169,7 +169,7 @@ public:
       throw invalid_object_error("This instance of program is a host instance");
     }
     PI_CALL(RT::piProgramRetain(Program));
-    return pi::pi_cast<cl_program>(Program);
+    return pi::cast<cl_program>(Program);
   }
 
   bool is_host() const { return Context.is_host(); }

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -45,7 +45,7 @@ public:
       : m_Context(SyclContext), m_AsyncHandler(AsyncHandler),
         m_OpenCLInterop(true), m_HostQueue(false) {
 
-    m_CommandQueue = pi::pi_cast<RT::PiQueue>(CLQueue);
+    m_CommandQueue = pi::cast<RT::PiQueue>(CLQueue);
 
     RT::PiDevice Device = nullptr;
     // TODO catch an exception and put it to list of asynchronous exceptions
@@ -73,7 +73,7 @@ public:
   cl_command_queue get() {
     if (m_OpenCLInterop) {
       PI_CALL(RT::piQueueRetain(m_CommandQueue));
-      return pi::pi_cast<cl_command_queue>(m_CommandQueue);
+      return pi::cast<cl_command_queue>(m_CommandQueue);
     }
     throw invalid_object_error(
         "This instance of queue doesn't support OpenCL interoperability");

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -84,7 +84,7 @@ public:
           "Creation of interoperability memory object using host context is "
           "not allowed");
 
-    RT::PiMem Mem = pi::pi_cast<RT::PiMem>(MInteropMemObject);
+    RT::PiMem Mem = pi::cast<RT::PiMem>(MInteropMemObject);
     RT::PiContext Context = nullptr;
     PI_CALL(RT::piMemGetInfo(Mem, CL_MEM_CONTEXT, sizeof(Context), &Context,
                              nullptr));
@@ -225,7 +225,7 @@ public:
     releaseHostMem(MShadowCopy);
 
     if (MOpenCLInterop)
-      PI_CALL(RT::piMemRelease(pi::pi_cast<RT::PiMem>(MInteropMemObject)));
+      PI_CALL(RT::piMemRelease(pi::cast<RT::PiMem>(MInteropMemObject)));
   }
 
   bool useHostPtr() {

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -28,7 +28,7 @@ class kernel {
 public:
   kernel(cl_kernel clKernel, const context &syclContext)
       : impl(std::make_shared<detail::kernel_impl>(
-            detail::pi::pi_cast<detail::RT::PiKernel>(clKernel), syclContext)) {}
+            detail::pi::cast<detail::RT::PiKernel>(clKernel), syclContext)) {}
 
   kernel(const kernel &rhs) = default;
 

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -47,7 +47,7 @@ public:
 
   program(const context &context, cl_program clProgram)
       : impl(std::make_shared<detail::program_impl>(
-            context, detail::pi::pi_cast<detail::RT::PiProgram>(clProgram))) {}
+            context, detail::pi::cast<detail::RT::PiProgram>(clProgram))) {}
 
   program(const program &rhs) = default;
 

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -50,7 +50,7 @@ context_impl::context_impl(cl_context ClContext, async_handler AsyncHandler)
     : m_AsyncHandler(AsyncHandler), m_Devices(),
       m_Platform(), m_OpenCLInterop(true), m_HostContext(false) {
 
-  m_Context = pi::pi_cast<RT::PiContext>(ClContext);
+  m_Context = pi::cast<RT::PiContext>(ClContext);
   vector_class<RT::PiDevice> DeviceIds;
   size_t DevicesNum = 0;
   // TODO catch an exception and put it to list of asynchronous exceptions
@@ -77,7 +77,7 @@ cl_context context_impl::get() const {
   if (m_OpenCLInterop) {
     // TODO catch an exception and put it to list of asynchronous exceptions
     PI_CALL(RT::piContextRetain(m_Context));
-    return pi::pi_cast<cl_context>(m_Context);
+    return pi::cast<cl_context>(m_Context);
   }
   throw invalid_object_error(
       "This instance of event doesn't support OpenCL interoperability.");

--- a/sycl/source/detail/device_info.cpp
+++ b/sycl/source/detail/device_info.cpp
@@ -30,7 +30,7 @@ device get_device_info<device, info::device::parent_device>::_(
 
   typename sycl_to_pi<device>::type result;
   PI_CALL(RT::piDeviceGetInfo(
-    dev, pi::pi_cast<RT::PiDeviceInfo>(info::device::parent_device),
+    dev, pi::cast<RT::PiDeviceInfo>(info::device::parent_device),
     sizeof(result), &result, NULL));
   if (result == nullptr)
     throw invalid_object_error(

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -22,7 +22,7 @@ bool event_impl::is_host() const { return m_HostEvent || !m_OpenCLInterop; }
 cl_event event_impl::get() const {
   if (m_OpenCLInterop) {
     PI_CALL(RT::piEventRetain(m_Event));
-    return pi::pi_cast<cl_event>(m_Event);
+    return pi::cast<cl_event>(m_Event);
   }
   throw invalid_object_error(
       "This instance of event doesn't support OpenCL interoperability.");
@@ -61,7 +61,7 @@ event_impl::event_impl(cl_event CLEvent, const context &SyclContext)
     : m_Context(detail::getSyclObjImpl(SyclContext)),
       m_OpenCLInterop(true), m_HostEvent(false) {
 
-  m_Event = pi::pi_cast<RT::PiEvent>(CLEvent);
+  m_Event = pi::cast<RT::PiEvent>(CLEvent);
 
   if (m_Context->is_host()) {
     throw cl::sycl::invalid_parameter_error(

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -49,7 +49,7 @@ void MemoryManager::releaseMemObj(ContextImplPtr TargetContext,
     return;
   }
 
-  PI_CALL(RT::piMemRelease(pi::pi_cast<RT::PiMem>(MemAllocation)));
+  PI_CALL(RT::piMemRelease(pi::cast<RT::PiMem>(MemAllocation)));
 }
 
 void *MemoryManager::allocate(ContextImplPtr TargetContext, SYCLMemObjI *MemObj,
@@ -367,18 +367,18 @@ void MemoryManager::copy(SYCLMemObjI *SYCLMemObj, void *SrcMem,
 
     else
       copyH2D(SYCLMemObj, (char *)SrcMem, std::move(SrcQueue), DimSrc, SrcSize,
-              SrcAccessRange, SrcOffset, SrcElemSize, pi::pi_cast<RT::PiMem>(DstMem),
+              SrcAccessRange, SrcOffset, SrcElemSize, pi::cast<RT::PiMem>(DstMem),
               std::move(TgtQueue), DimDst, DstSize, DstAccessRange, DstOffset,
               DstElemSize, std::move(DepEvents), UseExclusiveQueue, OutEvent);
   } else {
     if (TgtQueue->is_host())
-      copyD2H(SYCLMemObj, pi::pi_cast<RT::PiMem>(SrcMem), std::move(SrcQueue), DimSrc,
+      copyD2H(SYCLMemObj, pi::cast<RT::PiMem>(SrcMem), std::move(SrcQueue), DimSrc,
               SrcSize, SrcAccessRange, SrcOffset, SrcElemSize, (char *)DstMem,
               std::move(TgtQueue), DimDst, DstSize, DstAccessRange, DstOffset,
               DstElemSize, std::move(DepEvents), UseExclusiveQueue, OutEvent);
     else
-      copyD2D(SYCLMemObj, pi::pi_cast<RT::PiMem>(SrcMem), std::move(SrcQueue), DimSrc,
-              SrcSize, SrcAccessRange, SrcOffset, SrcElemSize, pi::pi_cast<RT::PiMem>(DstMem),
+      copyD2D(SYCLMemObj, pi::cast<RT::PiMem>(SrcMem), std::move(SrcQueue), DimSrc,
+              SrcSize, SrcAccessRange, SrcOffset, SrcElemSize, pi::cast<RT::PiMem>(DstMem),
               std::move(TgtQueue), DimDst, DstSize, DstAccessRange, DstOffset,
               DstElemSize, std::move(DepEvents), UseExclusiveQueue, OutEvent);
   }
@@ -395,7 +395,7 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
   if (SYCLMemObj->getType() == detail::SYCLMemObjI::MemObjType::BUFFER) {
     if (Dim == 1) {
       PI_CALL(RT::piEnqueueMemBufferFill(
-          Queue->getHandleRef(), pi::pi_cast<RT::PiMem>(Mem), Pattern,
+          Queue->getHandleRef(), pi::cast<RT::PiMem>(Mem), Pattern,
           PatternSize, Offset[0] * ElementSize, Range[0] * ElementSize,
           DepEvents.size(), &DepEvents[0], &OutEvent));
       return;
@@ -404,7 +404,7 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
     throw runtime_error("Not supported configuration of fill requested");
   } else {
     PI_CALL(RT::piEnqueueMemImageFill(
-        Queue->getHandleRef(), pi::pi_cast<RT::PiMem>(Mem), Pattern, &Offset[0],
+        Queue->getHandleRef(), pi::cast<RT::PiMem>(Mem), Pattern, &Offset[0],
         &Range[0], DepEvents.size(), &DepEvents[0], &OutEvent));
   }
 }
@@ -444,7 +444,7 @@ void *MemoryManager::map(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
   RT::PiResult Error = PI_SUCCESS;
   void *MappedPtr;
   PI_CALL((MappedPtr = RT::piEnqueueMemBufferMap(
-      Queue->getHandleRef(), pi::pi_cast<RT::PiMem>(Mem), CL_FALSE, Flags,
+      Queue->getHandleRef(), pi::cast<RT::PiMem>(Mem), CL_FALSE, Flags,
       AccessOffset[0], AccessRange[0], DepEvents.size(),
       DepEvents.empty() ? nullptr : &DepEvents[0], &OutEvent, &Error), Error));
   return MappedPtr;
@@ -458,7 +458,7 @@ void MemoryManager::unmap(SYCLMemObjI *SYCLMemObj, void *Mem,
   PI_CALL(RT::piEnqueueMemUnmap(
       UseExclusiveQueue ? Queue->getExclusiveQueueHandleRef()
                         : Queue->getHandleRef(),
-      pi::pi_cast<RT::PiMem>(Mem), MappedPtr, DepEvents.size(),
+      pi::cast<RT::PiMem>(Mem), MappedPtr, DepEvents.size(),
       DepEvents.empty() ? nullptr : &DepEvents[0], &OutEvent));
 }
 

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -29,21 +29,21 @@ std::string platformInfoToString(pi_platform_info info) {
   case PI_PLATFORM_INFO_EXTENSIONS:
     return "PI_PLATFORM_INFO_EXTENSIONS";
   default:
-    piDie("Unknown pi_platform_info value passed to "
-          "cl::sycl::detail::pi::platformInfoToString");
+    die("Unknown pi_platform_info value passed to "
+        "cl::sycl::detail::pi::platformInfoToString");
   }
 }
 
 // Check for manually selected BE at run-time.
-bool piUseBackend(PiBackend Backend) {
+bool useBackend(Backend TheBackend) {
   static const char *GetEnv = std::getenv("SYCL_BE");
-  static const PiBackend Use =
-    std::map<std::string, PiBackend>{
+  static const Backend Use =
+    std::map<std::string, Backend>{
       { "PI_OPENCL", SYCL_BE_PI_OPENCL },
       { "PI_OTHER",  SYCL_BE_PI_OTHER }
       // Any other value would yield PI_OPENCL (current default)
     }[ GetEnv ? GetEnv : "PI_OPENCL"];
-  return Backend == Use;
+  return TheBackend == Use;
 }
 
 // Definitions of the PI dispatch entries, they will be initialized
@@ -53,13 +53,13 @@ bool piUseBackend(PiBackend Backend) {
 
 // TODO: implement real plugins (ICD-like?)
 // For now this has the effect of redirecting to built-in PI OpenCL plugin.
-void piInitialize() {
+void initialize() {
   static bool Initialized = false;
   if (Initialized) {
     return;
   }
-  if (!piUseBackend(SYCL_BE_PI_OPENCL)) {
-    piDie("Unknown SYCL_BE");
+  if (!useBackend(SYCL_BE_PI_OPENCL)) {
+    die("Unknown SYCL_BE");
   }
   #define _PI_API(api)                          \
     extern const decltype(::api) * api##OclPtr; \
@@ -73,14 +73,14 @@ void piInitialize() {
 // TODO: Probably change that to throw a catchable exception,
 //       but for now it is useful to see every failure.
 //
-[[noreturn]] void piDie(const char *Message) {
+[[noreturn]] void die(const char *Message) {
   std::cerr << "pi_die: " << Message << std::endl;
   std::terminate();
 }
 
-void piAssert(bool Condition, const char *Message) {
+void assertion(bool Condition, const char *Message) {
   if (!Condition)
-    piDie(Message);
+    die(Message);
 }
 
 bool PiCall::m_TraceEnabled = (std::getenv("SYCL_PI_TRACE") != nullptr);

--- a/sycl/source/detail/pi_opencl.cpp
+++ b/sycl/source/detail/pi_opencl.cpp
@@ -23,17 +23,17 @@ pi_result OCL(piPlatformsGet)(pi_uint32      num_entries,
                               pi_platform *  platforms,
                               pi_uint32 *    num_platforms) {
   cl_int result =
-    clGetPlatformIDs(pi_cast<cl_uint>           (num_entries),
-                     pi_cast<cl_platform_id *>  (platforms),
-                     pi_cast<cl_uint *>         (num_platforms));
+    clGetPlatformIDs(cast<cl_uint>           (num_entries),
+                     cast<cl_platform_id *>  (platforms),
+                     cast<cl_uint *>         (num_platforms));
 
   // Absorb the CL_PLATFORM_NOT_FOUND_KHR and just return 0 in num_platforms
   if (result == CL_PLATFORM_NOT_FOUND_KHR) {
-    piAssert(num_platforms != 0);
+    assertion(num_platforms != 0);
     *num_platforms = 0;
     result = PI_SUCCESS;
   }
-  return pi_cast<pi_result>(result);
+  return cast<pi_result>(result);
 }
 
 
@@ -44,19 +44,19 @@ pi_result OCL(piDevicesGet)(pi_platform      platform,
                             pi_device *      devices,
                             pi_uint32 *      num_devices) {
   cl_int result =
-    clGetDeviceIDs(pi_cast<cl_platform_id> (platform),
-                   pi_cast<cl_device_type> (device_type),
-                   pi_cast<cl_uint>        (num_entries),
-                   pi_cast<cl_device_id *> (devices),
-                   pi_cast<cl_uint *>      (num_devices));
+    clGetDeviceIDs(cast<cl_platform_id> (platform),
+                   cast<cl_device_type> (device_type),
+                   cast<cl_uint>        (num_entries),
+                   cast<cl_device_id *> (devices),
+                   cast<cl_uint *>      (num_devices));
 
   // Absorb the CL_DEVICE_NOT_FOUND and just return 0 in num_devices
   if (result == CL_DEVICE_NOT_FOUND) {
-    piAssert(num_devices != 0);
+    assertion(num_devices != 0);
     *num_devices = 0;
     result = PI_SUCCESS;
   }
-  return pi_cast<pi_result>(result);
+  return cast<pi_result>(result);
 }
 
 pi_result OCL(piextDeviceSelectBinary)(
@@ -83,13 +83,13 @@ pi_result OCL(piQueueCreate)(pi_context context, pi_device device,
   PI_ASSERT(queue, "piQueueCreate failed, queue argument is null");
 
   cl_platform_id curPlatform;
-  cl_int ret_err = clGetDeviceInfo(pi_cast<cl_device_id>(device),
+  cl_int ret_err = clGetDeviceInfo(cast<cl_device_id>(device),
                                    CL_DEVICE_PLATFORM, sizeof(cl_platform_id),
                                    &curPlatform, NULL);
 
   if (ret_err != CL_SUCCESS) {
     *queue = nullptr;
-    return pi_cast<pi_result>(ret_err);
+    return cast<pi_result>(ret_err);
   }
 
   size_t platVerSize;
@@ -98,7 +98,7 @@ pi_result OCL(piQueueCreate)(pi_context context, pi_device device,
 
   if (ret_err != CL_SUCCESS) {
     *queue = nullptr;
-    return pi_cast<pi_result>(ret_err);
+    return cast<pi_result>(ret_err);
   }
 
   std::string platVer(platVerSize, '\0');
@@ -107,26 +107,26 @@ pi_result OCL(piQueueCreate)(pi_context context, pi_device device,
 
   if (ret_err != CL_SUCCESS) {
     *queue = nullptr;
-    return pi_cast<pi_result>(ret_err);
+    return cast<pi_result>(ret_err);
   }
 
   if (platVer.find("OpenCL 1.0") != std::string::npos ||
       platVer.find("OpenCL 1.1") != std::string::npos ||
       platVer.find("OpenCL 1.2") != std::string::npos) {
-    *queue = pi_cast<pi_queue>(clCreateCommandQueue(
-        pi_cast<cl_context>(context), pi_cast<cl_device_id>(device),
-        pi_cast<cl_command_queue_properties>(properties), &ret_err));
-    return pi_cast<pi_result>(ret_err);
+    *queue = cast<pi_queue>(clCreateCommandQueue(
+        cast<cl_context>(context), cast<cl_device_id>(device),
+        cast<cl_command_queue_properties>(properties), &ret_err));
+    return cast<pi_result>(ret_err);
   }
 
   cl_queue_properties CreationFlagProperties[] = {
-        CL_QUEUE_PROPERTIES, pi_cast<cl_command_queue_properties>(properties), 0
+        CL_QUEUE_PROPERTIES, cast<cl_command_queue_properties>(properties), 0
       };
-  *queue = pi_cast<pi_queue>(clCreateCommandQueueWithProperties(
-                              pi_cast<cl_context>(context),
-                              pi_cast<cl_device_id>(device),
+  *queue = cast<pi_queue>(clCreateCommandQueueWithProperties(
+                              cast<cl_context>(context),
+                              cast<cl_device_id>(device),
                               CreationFlagProperties, &ret_err));
-  return pi_cast<pi_result>(ret_err);
+  return cast<pi_result>(ret_err);
 }
 
 pi_result OCL(piProgramCreate)(pi_context context, const void *il,
@@ -134,19 +134,19 @@ pi_result OCL(piProgramCreate)(pi_context context, const void *il,
 
   size_t deviceCount;
 
-  cl_int ret_err = clGetContextInfo(pi_cast<cl_context>(context),
+  cl_int ret_err = clGetContextInfo(cast<cl_context>(context),
                                     CL_CONTEXT_DEVICES, 0, NULL, &deviceCount);
 
   std::vector<cl_device_id> devicesInCtx(deviceCount);
 
-  ret_err = clGetContextInfo(pi_cast<cl_context>(context), CL_CONTEXT_DEVICES,
+  ret_err = clGetContextInfo(cast<cl_context>(context), CL_CONTEXT_DEVICES,
                              deviceCount * sizeof(cl_device_id),
                              devicesInCtx.data(), NULL);
 
   if (ret_err != CL_SUCCESS || deviceCount < 1) {
     if (res_program != nullptr)
       *res_program = nullptr;
-    return pi_cast<pi_result>(CL_INVALID_CONTEXT);
+    return cast<pi_result>(CL_INVALID_CONTEXT);
   }
 
   cl_platform_id curPlatform;
@@ -156,7 +156,7 @@ pi_result OCL(piProgramCreate)(pi_context context, const void *il,
   if (ret_err != CL_SUCCESS) {
     if (res_program != nullptr)
       *res_program = nullptr;
-    return pi_cast<pi_result>(CL_INVALID_CONTEXT);
+    return cast<pi_result>(CL_INVALID_CONTEXT);
   }
 
   size_t devVerSize;
@@ -169,7 +169,7 @@ pi_result OCL(piProgramCreate)(pi_context context, const void *il,
   if (ret_err != CL_SUCCESS) {
     if (res_program != nullptr)
       *res_program = nullptr;
-    return pi_cast<pi_result>(CL_INVALID_CONTEXT);
+    return cast<pi_result>(CL_INVALID_CONTEXT);
   }
 
   pi_result err = PI_SUCCESS;
@@ -178,8 +178,8 @@ pi_result OCL(piProgramCreate)(pi_context context, const void *il,
       devVer.find("OpenCL 1.2") == std::string::npos &&
       devVer.find("OpenCL 2.0") == std::string::npos) {
     if (res_program != nullptr)
-      *res_program = pi_cast<pi_program>(clCreateProgramWithIL(
-          pi_cast<cl_context>(context), il, length, pi_cast<cl_int *>(&err)));
+      *res_program = cast<pi_program>(clCreateProgramWithIL(
+          cast<cl_context>(context), il, length, cast<cl_int *>(&err)));
     return err;
   }
 
@@ -194,7 +194,7 @@ pi_result OCL(piProgramCreate)(pi_context context, const void *il,
       extStr.find("cl_khr_il_program") == std::string::npos) {
     if (res_program != nullptr)
       *res_program = nullptr;
-    return pi_cast<pi_result>(CL_INVALID_CONTEXT);
+    return cast<pi_result>(CL_INVALID_CONTEXT);
   }
 
   using apiFuncT =
@@ -203,10 +203,10 @@ pi_result OCL(piProgramCreate)(pi_context context, const void *il,
       reinterpret_cast<apiFuncT>(clGetExtensionFunctionAddressForPlatform(
           curPlatform, "clCreateProgramWithILKHR"));
 
-  assert(funcPtr != nullptr);
+  assertion(funcPtr != nullptr);
   if (res_program != nullptr)
-    *res_program = pi_cast<pi_program>(funcPtr(
-        pi_cast<cl_context>(context), il, length, pi_cast<cl_int *>(&err)));
+    *res_program = cast<pi_program>(funcPtr(
+        cast<cl_context>(context), il, length, cast<cl_int *>(&err)));
 
   return err;
 }
@@ -235,16 +235,16 @@ pi_result OCL(piSamplerCreate)(pi_context context,
   }
 
   // Always call OpenCL 1.0 API
-  *result_sampler = pi_cast<pi_sampler>(clCreateSampler(pi_cast<cl_context>(context),
+  *result_sampler = cast<pi_sampler>(clCreateSampler(cast<cl_context>(context),
                                   normalizedCoords, addressingMode, filterMode,
-                                  pi_cast<cl_int *>(&error_code)));
+                                  cast<cl_int *>(&error_code)));
   return error_code;
 }
 
 // Forward calls to OpenCL RT.
 #define _PI_CL(pi_api, ocl_api)                     \
 const decltype(::pi_api) * pi_api##OclPtr =         \
-    detail::pi::pi_cast<decltype(&::pi_api)>(&ocl_api);
+    detail::pi::cast<decltype(&::pi_api)>(&ocl_api);
 
 // Platform
 _PI_CL(piPlatformsGet,       OCL(piPlatformsGet))

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -54,8 +54,8 @@ platform_impl_pi::get_devices(info::device_type deviceType) const {
 
   pi_uint32 num_devices;
   PI_TRACE(RT::piDevicesGet)(
-      m_platform, pi::pi_cast<RT::PiDeviceType>(deviceType),
-      0, pi::pi_cast<RT::PiDevice *>(nullptr),
+      m_platform, pi::cast<RT::PiDeviceType>(deviceType),
+      0, pi::cast<RT::PiDevice *>(nullptr),
       &num_devices);
 
   if (num_devices == 0)
@@ -64,7 +64,7 @@ platform_impl_pi::get_devices(info::device_type deviceType) const {
   vector_class<RT::PiDevice> pi_devices(num_devices);
   // TODO catch an exception and put it to list of asynchronous exceptions
   PI_CALL(RT::piDevicesGet(
-    m_platform, pi::pi_cast<RT::PiDeviceType>(deviceType), num_devices,
+    m_platform, pi::cast<RT::PiDeviceType>(deviceType), num_devices,
     pi_devices.data(), 0));
 
   std::for_each(pi_devices.begin(), pi_devices.end(),

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -77,7 +77,6 @@ static RT::PiProgram createBinaryProgram(const RT::PiContext Context,
 static RT::PiProgram createSpirvProgram(const RT::PiContext Context,
                                         const unsigned char *Data,
                                         size_t DataLen) {
-  RT::PiResult Err = PI_SUCCESS;
   RT::PiProgram Program = nullptr;
   PI_CALL(pi::piProgramCreate(Context, Data, DataLen, &Program));
   return Program;
@@ -225,7 +224,7 @@ static bool is_device_binary_type_supported(const context &C,
     return true;
 
   // OpenCL 2.1 and greater require clCreateProgramWithIL
-  if (pi::piUseBackend(pi::SYCL_BE_PI_OPENCL) &&
+  if (pi::useBackend(pi::SYCL_BE_PI_OPENCL) &&
       C.get_platform().get_info<info::platform::version>() >= "2.1")
     return true;
 
@@ -325,7 +324,7 @@ RT::PiProgram ProgramManager::loadProgram(OSModuleHandle M,
     throw runtime_error("Invalid device program image: size is zero");
   }
   size_t ImgSize = static_cast<size_t>(Img->BinaryEnd - Img->BinaryStart);
-  auto Format = pi::pi_cast<RT::PiDeviceBinaryType>(Img->Format);
+  auto Format = pi::cast<RT::PiDeviceBinaryType>(Img->Format);
 
   // Determine the format of the image if not set already
   if (Format == PI_DEVICE_BINARY_TYPE_NONE) {

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -36,7 +36,7 @@ template <> device queue_impl::get_info<info::queue::device>() const {
 event queue_impl::memset(void* ptr, int value, size_t count) {
   cl_event e;
   cl_int error;
-  cl_command_queue q = pi::pi_cast<cl_command_queue>(getHandleRef());
+  cl_command_queue q = pi::cast<cl_command_queue>(getHandleRef());
 
   error = clEnqueueMemsetINTEL(q, ptr, value, count,
                                /* sizeof waitlist */ 0, nullptr, &e);
@@ -49,7 +49,7 @@ event queue_impl::memset(void* ptr, int value, size_t count) {
 event queue_impl::memcpy(void* dest, const void* src, size_t count) {
   cl_event e;
   cl_int error;
-  cl_command_queue q = pi::pi_cast<cl_command_queue>(getHandleRef());
+  cl_command_queue q = pi::cast<cl_command_queue>(getHandleRef());
 
   error = clEnqueueMemcpyINTEL(q,
                                /* blocking */ false, dest, src, count,

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -21,7 +21,7 @@ sampler_impl::sampler_impl(coordinate_normalization_mode normalizationMode,
 
 sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
 
-  RT::PiSampler Sampler = pi::pi_cast<RT::PiSampler>(clSampler);
+  RT::PiSampler Sampler = pi::cast<RT::PiSampler>(clSampler);
   m_contextToSampler[syclContext] = Sampler;
   PI_CALL(RT::piSamplerRetain(Sampler));
   PI_CALL(RT::piSamplerGetInfo(Sampler, CL_SAMPLER_NORMALIZED_COORDS,

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -79,7 +79,7 @@ static std::string accessModeToString(access::mode Mode) {
 
 void EventCompletionClbk(RT::PiEvent, pi_int32, void *data) {
   // TODO: Handle return values. Store errors to async handler.
-  PI_CALL(RT::piEventSetStatus(pi::pi_cast<RT::PiEvent>(data), CL_COMPLETE));
+  PI_CALL(RT::piEventSetStatus(pi::cast<RT::PiEvent>(data), CL_COMPLETE));
 }
 
 // Method prepares PI event's from list sycl::event's
@@ -171,7 +171,7 @@ cl_int AllocaSubBufCommand::enqueueImp() {
       Command::prepareEvents(detail::getSyclObjImpl(MQueue->get_context()));
   RT::PiEvent &Event = MEvent->getHandleRef();
   MMemAllocation = MemoryManager::createSubBuffer(
-      pi::pi_cast<RT::PiMem>(MParentAlloca->getMemAllocation()), MReq.MElemSize,
+      pi::cast<RT::PiMem>(MParentAlloca->getMemAllocation()), MReq.MElemSize,
       MReq.MOffset, MReq.MAccessRange, std::move(RawEvents), Event);
   return CL_SUCCESS;
 }
@@ -662,7 +662,7 @@ cl_int ExecCGCommand::enqueueImp() {
         usesUSM = true;
         auto PtrToPtr = reinterpret_cast<intptr_t*>(Arg.MPtr);
         auto DerefPtr = reinterpret_cast<void*>(*PtrToPtr);
-        auto theKernel = pi::pi_cast<cl_kernel>(Kernel);
+        auto theKernel = pi::cast<cl_kernel>(Kernel);
         CHECK_OCL_CODE(clSetKernelArgMemPointerINTEL(theKernel, Arg.MIndex, DerefPtr));
         break;
       }
@@ -679,7 +679,7 @@ cl_int ExecCGCommand::enqueueImp() {
     auto clusm = GetCLUSM();
     if (usesUSM && clusm) {
       cl_bool t = CL_TRUE;
-      auto theKernel = pi::pi_cast<cl_kernel>(Kernel);
+      auto theKernel = pi::cast<cl_kernel>(Kernel);
       // Enable USM Indirect Access for Kernels
       if (clusm->useCLUSM()) {
         CHECK_OCL_CODE(clusm->setKernelExecInfo(
@@ -694,7 +694,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
         // This passes all the allocations we've tracked as SVM Pointers
         CHECK_OCL_CODE(clusm->setKernelIndirectUSMExecInfo(
-            pi::pi_cast<cl_command_queue>(MQueue->getHandleRef()), theKernel));
+            pi::cast<cl_command_queue>(MQueue->getHandleRef()), theKernel));
       } else if (clusm->isInitialized()) {
         // Sanity check that nothing went wrong setting up clusm
         CHECK_OCL_CODE(clSetKernelExecInfo(

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -23,7 +23,7 @@ void *alignedAlloc(size_t alignment, size_t size, const context *ctxt,
                    const device *dev, alloc kind) {
   cl_int error;
   cl_context c =
-      pi::pi_cast<cl_context>(detail::getSyclObjImpl(*ctxt)->getHandleRef());
+      pi::cast<cl_context>(detail::getSyclObjImpl(*ctxt)->getHandleRef());
   cl_device_id id;
 
   void *retVal = nullptr;
@@ -58,7 +58,7 @@ void *alignedAlloc(size_t alignment, size_t size, const context *ctxt,
 void free(void *ptr, const context *ctxt) {
   cl_int error;
   cl_context c =
-      pi::pi_cast<cl_context>(detail::getSyclObjImpl(*ctxt)->getHandleRef());
+      pi::cast<cl_context>(detail::getSyclObjImpl(*ctxt)->getHandleRef());
 
   error = clMemFreeINTEL(c, ptr);
 

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -27,7 +27,7 @@ device::device() : impl(std::make_shared<detail::device_host>()) {}
 
 device::device(cl_device_id deviceId)
     : impl(std::make_shared<detail::device_impl_pi>(
-      detail::pi::pi_cast<detail::RT::PiDevice>(deviceId))) {}
+      detail::pi::cast<detail::RT::PiDevice>(deviceId))) {}
 
 device::device(const device_selector &deviceSelector) {
   *this = deviceSelector.select_device();

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -19,7 +19,7 @@ platform::platform() : impl(std::make_shared<detail::platform_impl_host>()) {}
 
 platform::platform(cl_platform_id platform_id)
     : impl(std::make_shared<detail::platform_impl_pi>(
-             detail::pi::pi_cast<detail::RT::PiPlatform>(platform_id))) {}
+             detail::pi::cast<detail::RT::PiPlatform>(platform_id))) {}
 
 platform::platform(const device_selector &dev_selector) {
   *this = dev_selector.select_device().get_platform();

--- a/sycl/test/regression/memcpy-update-leafs.cpp
+++ b/sycl/test/regression/memcpy-update-leafs.cpp
@@ -40,5 +40,5 @@ int main() {
 
 // CHECK: PI ---> RT::piEnqueueMemBufferWrite( Queue, DstMem, CL_FALSE, DstOffset[0], DstAccessRange[0], SrcMem + DstOffset[0], DepEvents.size(), &DepEvents[0], &OutEvent)
 // CHECK-NOT: PI ---> RT::piEnqueueMemBufferWrite( Queue, DstMem, CL_FALSE, DstOffset[0], DstAccessRange[0], SrcMem + DstOffset[0], DepEvents.size(), &DepEvents[0], &OutEvent)
-// CHECK-NOT: PI ---> (MappedPtr = RT::piEnqueueMemBufferMap( Queue->getHandleRef(), pi::pi_cast<RT::PiMem>(Mem), CL_FALSE, Flags, AccessOffset[0], AccessRange[0], DepEvents.size(), DepEvents.empty() ? nullptr : &DepEvents[0], &OutEvent, &Error), Error)
-// CHECK-NOT: PI ---> RT::piEnqueueMemUnmap( UseExclusiveQueue ? Queue->getExclusiveQueueHandleRef() : Queue->getHandleRef(), pi::pi_cast<RT::PiMem>(Mem), MappedPtr, DepEvents.size(), DepEvents.empty() ? nullptr : &DepEvents[0], &OutEvent)
+// CHECK-NOT: PI ---> (MappedPtr = RT::piEnqueueMemBufferMap( Queue->getHandleRef(), pi::cast<RT::PiMem>(Mem), CL_FALSE, Flags, AccessOffset[0], AccessRange[0], DepEvents.size(), DepEvents.empty() ? nullptr : &DepEvents[0], &OutEvent, &Error), Error)
+// CHECK-NOT: PI ---> RT::piEnqueueMemUnmap( UseExclusiveQueue ? Queue->getExclusiveQueueHandleRef() : Queue->getHandleRef(), pi::cast<RT::PiMem>(Mem), MappedPtr, DepEvents.size(), DepEvents.empty() ? nullptr : &DepEvents[0], &OutEvent)


### PR DESCRIPTION
Removed "pi" from the names of SYCL utilities in the "pi" namespace.
Now only types and functions directly constituting the PI API have "pi" in their names.

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>