### PR TITLE
[SYCL] Fix accessor construction from a buffer.

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -741,11 +741,11 @@ public:
   using reference = DataT &;
   using const_reference = const DataT &;
 
-  template <int Dims = Dimensions>
-  accessor(
-      detail::enable_if_t<Dims == 0 && ((!IsPlaceH && IsHostBuf) ||
-                                (IsPlaceH && (IsGlobalBuf || IsConstantBuf))),
-                  buffer<DataT, 1>> &BufferRef)
+  template <int Dims = Dimensions, typename AllocatorT,
+            typename detail::enable_if_t<
+                Dims == 0 && ((!IsPlaceH && IsHostBuf) ||
+                (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>* = nullptr>
+  accessor(buffer<DataT, 1, AllocatorT> &BufferRef)
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<AdjustedDim>(), BufferRef.get_range(), BufferRef.MemRange) {
 #else
@@ -762,11 +762,11 @@ public:
 #endif
   }
 
-  template <int Dims = Dimensions>
-  accessor(
-      buffer<DataT, 1> &BufferRef,
-      detail::enable_if_t<Dims == 0 && (!IsPlaceH && (IsGlobalBuf || IsConstantBuf)),
-                  handler> &CommandGroupHandler)
+  template <int Dims = Dimensions, typename AllocatorT>
+  accessor(buffer<DataT, 1, AllocatorT> &BufferRef,
+           detail::enable_if_t<Dims == 0 &&
+                               (!IsPlaceH && (IsGlobalBuf || IsConstantBuf)),
+                               handler> &CommandGroupHandler)
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<AdjustedDim>(), BufferRef.get_range(), BufferRef.MemRange) {
   }
@@ -781,11 +781,12 @@ public:
   }
 #endif
 
-  template <int Dims = Dimensions,
-            typename = detail::enable_if_t<
+  template <int Dims = Dimensions, typename AllocatorT,
+            typename detail::enable_if_t<
                 (Dims > 0) && ((!IsPlaceH && IsHostBuf) ||
-                               (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>>
-  accessor(buffer<DataT, Dimensions> &BufferRef)
+                               (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>
+                * = nullptr>
+  accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef)
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<Dimensions>(), BufferRef.get_range(), BufferRef.MemRange) {
   }
@@ -803,10 +804,11 @@ public:
   }
 #endif
 
-  template <int Dims = Dimensions,
+  template <int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<
                 (Dims > 0) && (!IsPlaceH && (IsGlobalBuf || IsConstantBuf))>>
-  accessor(buffer<DataT, Dimensions> &BufferRef, handler &CommandGroupHandler)
+  accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+           handler &CommandGroupHandler)
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<AdjustedDim>(), BufferRef.get_range(), BufferRef.MemRange) {
   }
@@ -821,12 +823,12 @@ public:
   }
 #endif
 
-  template <int Dims = Dimensions,
+  template <int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<
                 (Dims > 0) && ((!IsPlaceH && IsHostBuf) ||
                                (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>>
-  accessor(buffer<DataT, Dimensions> &BufferRef, range<Dimensions> AccessRange,
-           id<Dimensions> AccessOffset = {})
+  accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+           range<Dimensions> AccessRange, id<Dimensions> AccessOffset = {})
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(AccessOffset, AccessRange, BufferRef.MemRange) {
   }
@@ -843,11 +845,12 @@ public:
   }
 #endif
 
-  template <int Dims = Dimensions,
+  template <int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<
                 (Dims > 0) && (!IsPlaceH && (IsGlobalBuf || IsConstantBuf))>>
-  accessor(buffer<DataT, Dimensions> &BufferRef, handler &CommandGroupHandler,
-           range<Dimensions> AccessRange, id<Dimensions> AccessOffset = {})
+  accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+           handler &CommandGroupHandler, range<Dimensions> AccessRange,
+           id<Dimensions> AccessOffset = {})
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(AccessOffset, AccessRange, BufferRef.MemRange) {
   }


### PR DESCRIPTION
Allow accessor to be constructed from a buffer with a
non-default allocator.

Signed-off-by: Ilya Stepykin <ilya.stepykin@intel.com>