### PR TITLE
[SYCL] Add clang driver option -fsycl-device-only

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3268,8 +3268,9 @@ defm stack_arrays : BooleanFFlag<"stack-arrays">, Group<gfortran_Group>;
 defm underscoring : BooleanFFlag<"underscoring">, Group<gfortran_Group>;
 defm whole_file : BooleanFFlag<"whole-file">, Group<gfortran_Group>;
 
-def sycl : Flag<["--"], "sycl">,
+def sycl_device_only : Flag<["-"], "fsycl-device-only">,
   HelpText<"Compile SYCL kernels for device">;
+def sycl : Flag<["--"], "sycl">, Alias<sycl_device_only>;
 
 include "CC1Options.td"
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -295,7 +295,7 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
 
     // -S only runs up to the backend.
   } else if ((PhaseArg = DAL.getLastArg(options::OPT_S)) ||
-             (PhaseArg = DAL.getLastArg(options::OPT_sycl))) {
+             (PhaseArg = DAL.getLastArg(options::OPT_sycl_device_only))) {
     FinalPhase = phases::Backend;
 
     // -c compilation only runs up to the assembler.
@@ -1180,7 +1180,7 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
     T.setObjectFormat(llvm::Triple::COFF);
     TargetTriple = T.str();
   }
-  if (Args.hasArg(options::OPT_sycl)) {
+  if (Args.hasArg(options::OPT_sycl_device_only)) {
     // --sycl implies spir arch and SYCL Device
     llvm::Triple T(TargetTriple);
     // FIXME: defaults to spir64, should probably have a way to set spir
@@ -4299,7 +4299,7 @@ Action *Driver::ConstructPhaseAction(
           Args.hasArg(options::OPT_S) ? types::TY_LLVM_IR : types::TY_LLVM_BC;
       return C.MakeAction<BackendJobAction>(Input, Output);
     }
-    if (Args.hasArg(options::OPT_sycl)) {
+    if (Args.hasArg(options::OPT_sycl_device_only)) {
       if (Args.hasFlag(options::OPT_fsycl_use_bitcode,
                        options::OPT_fno_sycl_use_bitcode, true))
         return C.MakeAction<BackendJobAction>(Input, types::TY_LLVM_BC);

--- a/clang/test/Driver/sycl-device.cpp
+++ b/clang/test/Driver/sycl-device.cpp
@@ -1,0 +1,9 @@
+/// Check that compiling for sycl device is disabled by default:
+// RUN:   %clang -### %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// CHECK-DEFAULT-NOT: "-fsycl-is-device"
+
+/// Check "-fsycl-is-device" is passed when compiling for device:
+// RUN:   %clang -### -fsycl-device-only %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-SYCL-DEV %s
+// CHECK-SYCL-DEV: "-fsycl-is-device"


### PR DESCRIPTION
The new option "-fsycl-device-only" is simply an alternate spelling of
"--sycl" but it was determined to be a more appropriate spelling to
propose to the LLVM community.  Supporting both options here is
intended to ease any transition of tests, etc.

Signed-off-by: Steve Merritt <steve.merritt@intel.com>