### PR TITLE
[clang-offload-bundler] Ignore non-object files when unbundling archives

### DIFF
--- a/clang/test/Driver/clang-offload-bundler.c
+++ b/clang/test/Driver/clang-offload-bundler.c
@@ -278,7 +278,8 @@
 //
 // Check archive bundle.
 //
-// RUN: llvm-ar crv %t.a %t.2.o
+// RUN: echo 'Invalid object' > %t.invalid.o
+// RUN: llvm-ar crv %t.a %t.2.o %t.invalid.o
 // RUN: clang-offload-bundler -type=ao -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.host.lst,%t.tgt1.lst,%t.tgt2.lst -inputs=%t.a -unbundle
 // RUN: wc -l %t.host.lst | FileCheck %s --check-prefix=CHECK-AR-FILE-LIST
 // RUN: wc -l %t.tgt1.lst | FileCheck %s --check-prefix=CHECK-AR-FILE-LIST

--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -955,8 +955,11 @@ public:
     Error Err = Error::success();
     for (auto &C : Ar->children(Err)) {
       auto BinOrErr = C.getAsBinary();
-      if (!BinOrErr)
-        fatalError(BinOrErr.takeError());
+      if (!BinOrErr) {
+        if (auto Err = isNotObjectErrorInvalidFileType(BinOrErr.takeError()))
+          fatalError(std::move(Err));
+        continue;
+      }
 
       auto &Bin = BinOrErr.get();
       if (!Bin->isObject())
@@ -1001,8 +1004,11 @@ public:
     Error Err = Error::success();
     for (auto &C : Ar->children(Err)) {
       auto BinOrErr = C.getAsBinary();
-      if (!BinOrErr)
-        fatalError(BinOrErr.takeError());
+      if (!BinOrErr) {
+        if (auto Err = isNotObjectErrorInvalidFileType(BinOrErr.takeError()))
+          fatalError(std::move(Err));
+        continue;
+      }
 
       auto &Bin = BinOrErr.get();
       if (!Bin->isObject())


### PR DESCRIPTION
Non-object files in static archives should be silently ignored by the bundler
instead of triggering a fatal error.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>