### PR TITLE
[SYCL] Float2Half precision requirements, convert method correction.

### DIFF
--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <iostream>
 
 namespace cl {
 namespace sycl {
@@ -95,3 +96,21 @@ template <> struct hash<cl::sycl::detail::half_impl::half> {
 };
 
 } // namespace std
+
+#ifdef __SYCL_DEVICE_ONLY__
+using half = _Float16;
+#else
+using half = cl::sycl::detail::half_impl::half;
+#endif
+
+inline std::ostream &operator<<(std::ostream &O, half const &rhs) {
+  O << static_cast<float>(rhs);
+  return O;
+}
+
+inline std::istream &operator>>(std::istream &I, half &rhs) {
+  float ValFloat = 0.0f;
+  I >> ValFloat;
+  rhs = ValFloat;
+  return I;
+}

--- a/sycl/test/basic_tests/vec_convert.cpp
+++ b/sycl/test/basic_tests/vec_convert.cpp
@@ -71,13 +71,16 @@ int main() {
       int8{2, 3, 3, -2, -3, -3, 0, 0});
   test<float, int, 8, rounding_mode::automatic>(
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
-      int8{2, 3, 3, -2, -3, -3, 0, 0});
+      int8{2, 2, 3, -2, -2, -3, 0, 0});
   test<int, float, 8, rounding_mode::automatic>(
       int8{2, 3, 3, -2, -3, -3, 0, 0},
       float8{2.f, 3.f, 3.f, -2.f, -3.f, -3.f, 0.f, 0.f});
   test<float, float, 8, rounding_mode::automatic>(
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
+  test<float, half, 8, rounding_mode::automatic>(
+      float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
+      half8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
 
   // rte
   test<int, int, 8, rounding_mode::rte>(
@@ -85,13 +88,16 @@ int main() {
       int8{2, 3, 3, -2, -3, -3, 0, 0});
   test<float, int, 8, rounding_mode::rte>(
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
-      int8{2, 3, 3, -2, -3, -3, 0, 0});
+      int8{2, 2, 3, -2, -2, -3, 0, 0});
   test<int, float, 8, rounding_mode::rte>(
       int8{2, 3, 3, -2, -3, -3, 0, 0},
       float8{2.f, 3.f, 3.f, -2.f, -3.f, -3.f, 0.f, 0.f});
   test<float, float, 8, rounding_mode::rte>(
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
+  test<float, half, 8, rounding_mode::rte>(
+      float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
+      half8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
 
   // rtz
   test<int, int, 8, rounding_mode::rtz>(
@@ -106,6 +112,9 @@ int main() {
   test<float, float, 8, rounding_mode::rtz>(
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
+  test<float, half, 8, rounding_mode::rtz>(
+      float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
+      half8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
 
   // rtp
   test<int, int, 8, rounding_mode::rtp>(
@@ -120,6 +129,9 @@ int main() {
   test<float, float, 8, rounding_mode::rtp>(
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
+  test<float, half, 8, rounding_mode::rtp>(
+      float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
+      half8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
 
   // rtn
   test<int, int, 8, rounding_mode::rtn>(
@@ -134,6 +146,9 @@ int main() {
   test<float, float, 8, rounding_mode::rtn>(
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
       float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
+  test<float, half, 8, rounding_mode::rtn>(
+      float8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f},
+      half8{+2.3f, +2.5f, +2.7f, -2.3f, -2.5f, -2.7f, 0.f, 0.f});
 
   return 0;
 }


### PR DESCRIPTION
- Added the support for output operator for half datatypes.
- Edit test case vec_convert.cpp for half datatype.
  Corrected source code for float2Half conversion.
- Correct the automatic/rte mode implementation.

Signed-off-by: Garima Gupta <garima.gupta@intel.com>