### PR TITLE
[clang-offload-wrapper] Use bundler conventions for naming target image sections

### DIFF
--- a/clang/test/Driver/clang-offload-wrapper.c
+++ b/clang/test/Driver/clang-offload-wrapper.c
@@ -32,26 +32,26 @@
 // CHECK-HELP: {{.*}}USAGE: clang-offload-wrapper [options] <input  files>
 // CHECK-HELP: {{.*}}OPTIONS:
 // CHECK-HELP: {{.*}}clang-offload-wrapper options:
-// CHECK-HELP: {{.*}}  -build-opts=<string>    - build options passed to the offload runtime
-// CHECK-HELP: {{.*}}  -desc-name=<name>       - Specifies offload descriptor symbol name: '.<offload kind>.<name>', and makes it globally visible
-// CHECK-HELP: {{.*}}  -emit-reg-funcs         - Emit [un-]registration functions
-// CHECK-HELP: {{.*}}  -format                 - device binary image formats:
-// CHECK-HELP: {{.*}}    =none                 -   not set
-// CHECK-HELP: {{.*}}    =native               -   unknown or native
-// CHECK-HELP: {{.*}}    =spirv                -   SPIRV binary
-// CHECK-HELP: {{.*}}    =llvmbc               -   LLVMIR bitcode
-// CHECK-HELP: {{.*}}  -host=<triple>          - wrapper object target triple
-// CHECK-HELP: {{.*}}  -kind                   - offload kind:
-// CHECK-HELP: {{.*}}    =unknown              -   unknown
-// CHECK-HELP: {{.*}}    =host                 -   host
-// CHECK-HELP: {{.*}}    =openmp               -   OpenMP
-// CHECK-HELP: {{.*}}    =hip                  -   HIP
-// CHECK-HELP: {{.*}}    =sycl                 -   SYCL
-// CHECK-HELP: {{.*}}  -o=<filename>           - Output filename
-// CHECK-HELP: {{.*}}  -reg-func-name=<name>   - Offload descriptor registration function name
-// CHECK-HELP: {{.*}}  -target=<string>        - offload target triple
-// CHECK-HELP: {{.*}}  -unreg-func-name=<name> - Offload descriptor un-registration function name
-// CHECK-HELP: {{.*}}  -v                      - verbose output
+// CHECK-HELP: {{.*}}  --build-opts=<string>    - build options passed to the offload runtime
+// CHECK-HELP: {{.*}}  --desc-name=<name>       - Specifies offload descriptor symbol name: '.<offload kind>.<name>', and makes it globally visible
+// CHECK-HELP: {{.*}}  --emit-reg-funcs         - Emit [un-]registration functions
+// CHECK-HELP: {{.*}}  --format=<value>         - device binary image formats:
+// CHECK-HELP: {{.*}}    =none                  -   not set
+// CHECK-HELP: {{.*}}    =native                -   unknown or native
+// CHECK-HELP: {{.*}}    =spirv                 -   SPIRV binary
+// CHECK-HELP: {{.*}}    =llvmbc                -   LLVMIR bitcode
+// CHECK-HELP: {{.*}}  --host=<triple>          - wrapper object target triple
+// CHECK-HELP: {{.*}}  --kind=<value>           - offload kind:
+// CHECK-HELP: {{.*}}    =unknown               -   unknown
+// CHECK-HELP: {{.*}}    =host                  -   host
+// CHECK-HELP: {{.*}}    =openmp                -   OpenMP
+// CHECK-HELP: {{.*}}    =hip                   -   HIP
+// CHECK-HELP: {{.*}}    =sycl                  -   SYCL
+// CHECK-HELP: {{.*}}  -o=<filename>            - Output filename
+// CHECK-HELP: {{.*}}  --reg-func-name=<name>   - Offload descriptor registration function name
+// CHECK-HELP: {{.*}}  --target=<string>        - offload target triple
+// CHECK-HELP: {{.*}}  --unreg-func-name=<name> - Offload descriptor un-registration function name
+// CHECK-HELP: {{.*}}  -v                       - verbose output
 
 // -------
 // Generate files to wrap.
@@ -159,4 +159,10 @@
 
 // CHECK-IR2: declare void @__UNREGFUNC__
 
-
+// -------
+// Check that device image can be extracted from the wrapper object by the clang-offload-bundler tool.
+//
+// RUN: clang-offload-wrapper -o %t.wrapper.bc -host=x86_64-pc-linux-gnu -kind=sycl -target=spir64-unknown-linux-sycldevice %t1.tgt
+// RUN: %clang -target x86_64-pc-linux-gnu -c %t.wrapper.bc -o %t.wrapper.o
+// RUN: clang-offload-bundler --type=o --inputs=%t.wrapper.o --targets=host-x86_64-pc-linux-gnu,sycl-spir64-unknown-linux-sycldevice --outputs=%t.host.out,%t1.out --unbundle
+// RUN: diff %t1.out %t1.tgt

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -388,24 +388,36 @@ private:
     return AutoGcBufs.back().get();
   }
 
-  // Adds given buffer as a global variable into the module and, depending on
-  // the StartEnd flag, returns either a pair of pointers to the beginning
-  // and end of the variable or a <pointer to the beginning, size> pair. The
-  // input memory buffer must outlive 'this' object.
-  std::pair<Constant *, Constant *>
-  addMemBufToModule(Module &M, MemoryBuffer *Buf, const Twine &Name) {
-    auto *Buf1 = ConstantDataArray::get(
-        C, makeArrayRef(Buf->getBufferStart(), Buf->getBufferSize()));
-    auto *Var = new GlobalVariable(M, Buf1->getType(), true,
-                                   GlobalVariable::InternalLinkage, Buf1, Name);
+  // Adds a global readonly variable that is initialized by given data to the
+  // module.
+  GlobalVariable *addGlobalArrayVariable(const Twine &Name,
+                                         ArrayRef<char> Initializer,
+                                         const Twine &Section = "") {
+    auto *Arr = ConstantDataArray::get(C, Initializer);
+    auto *Var = new GlobalVariable(M, Arr->getType(), true,
+                                   GlobalVariable::InternalLinkage, Arr, Name);
     if (Verbose)
       errs() << "  global added: " << Var->getName() << "\n";
     Var->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+
+    SmallVector<char, 32u> NameBuf;
+    auto SectionName = Section.toStringRef(NameBuf);
+    if (!SectionName.empty())
+      Var->setSection(SectionName);
+    return Var;
+  }
+
+  // Adds given buffer as a global variable into the module and returns a pair
+  // of pointers that point to the beginning and end of the variable.
+  std::pair<Constant *, Constant *>
+  addArrayToModule(ArrayRef<char> Buf, const Twine &Name,
+                   const Twine &Section = "") {
+    auto *Var = addGlobalArrayVariable(Name, Buf, Section);
     auto *Zero = ConstantInt::get(getSizeTTy(), 0u);
     Constant *ZeroZero[] = {Zero, Zero};
     auto *ImageB =
         ConstantExpr::getGetElementPtr(Var->getValueType(), Var, ZeroZero);
-    auto *Size = ConstantInt::get(getSizeTTy(), Buf->getBufferSize());
+    auto *Size = ConstantInt::get(getSizeTTy(), Buf.size());
 
     Constant *ZeroSize[] = {Zero, Size};
     auto *ImageE =
@@ -413,13 +425,40 @@ private:
     return std::make_pair(ImageB, ImageE);
   }
 
+  // Creates all necessary data objects for the given image and returns a pair
+  // of pointers that point to the beginning and end of the global variable that
+  // contains the image data.
+  std::pair<Constant *, Constant *>
+  addDeviceImageToModule(ArrayRef<char> Buf, const Twine &Name,
+                         OffloadKind Kind, StringRef TargetTriple) {
+    // Do not bother adding 'size' section if target triple was not provided
+    // since we anyway won't be able to construct what bundler expects to see in
+    // the fat object.
+    if (!TargetTriple.empty()) {
+      // Create global data object for the image size.
+      size_t BufSize = Buf.size();
+      addGlobalArrayVariable(
+          Name + ".size",
+          makeArrayRef(reinterpret_cast<char *>(&BufSize), sizeof(BufSize)),
+          "__CLANG_OFFLOAD_BUNDLE_SIZE__" + offloadKindToString(Kind) + "-" +
+              TargetTriple);
+    }
+
+    // Create global variable for the image data.
+    return addArrayToModule(Buf, Name,
+                            TargetTriple.empty()
+                                ? ""
+                                : "__CLANG_OFFLOAD_BUNDLE__" +
+                                      offloadKindToString(Kind) + "-" +
+                                      TargetTriple);
+  }
+
   // Creates a global variable of const char* type and creates an
-  // initializer that initializes it with given null-terminated string.
-  // Returns a link-time constant pointer (constant expr) to that variable.
-  Constant *addStringToModule(Module &M, const std::string &Str,
-                              const Twine &Name) {
-    Constant *Arr =
-        ConstantDataArray::get(C, makeArrayRef(Str.c_str(), Str.size() + 1));
+  // initializer that initializes it with given string (with added null
+  // terminator). Returns a link-time constant pointer (constant expr) to that
+  // variable.
+  Constant *addStringToModule(StringRef Str, const Twine &Name) {
+    auto *Arr = ConstantDataArray::getString(C, Str);
     auto *Var = new GlobalVariable(M, Arr->getType(), true,
                                    GlobalVariable::InternalLinkage, Arr, Name);
     if (Verbose)
@@ -458,6 +497,7 @@ private:
 
     SmallVector<Constant *, 4> ImagesInits;
     unsigned ImgId = 0;
+    bool AddHostBundle = false;
 
     for (const auto &ImgPtr : Pack) {
       const BinaryWrapper::Image &Img = *(ImgPtr.get());
@@ -469,9 +509,9 @@ private:
       auto *Fknd = ConstantInt::get(Type::getInt8Ty(C), Kind);
       auto *Ffmt = ConstantInt::get(Type::getInt8Ty(C), Img.Fmt);
       auto *Ftgt = addStringToModule(
-          M, Img.Tgt, Twine(OffloadKindTag) + Twine("target.") + Twine(ImgId));
+          Img.Tgt, Twine(OffloadKindTag) + Twine("target.") + Twine(ImgId));
       auto *Fopt = addStringToModule(
-          M, Img.Opts, Twine(OffloadKindTag) + Twine("opts.") + Twine(ImgId));
+          Img.Opts, Twine(OffloadKindTag) + Twine("opts.") + Twine(ImgId));
       std::pair<Constant *, Constant *> FMnf;
 
       if (Img.Manif.empty()) {
@@ -479,16 +519,22 @@ private:
         FMnf = std::make_pair(NullPtr, NullPtr);
       } else {
         MemoryBuffer *Mnf = loadFile(Img.Manif);
-        FMnf = addMemBufToModule(
-            M, Mnf, Twine(OffloadKindTag) + Twine(ImgId) + Twine(".manifest"));
+        FMnf = addArrayToModule(
+            makeArrayRef(Mnf->getBufferStart(), Mnf->getBufferSize()),
+            Twine(OffloadKindTag) + Twine(ImgId) + Twine(".manifest"));
       }
       if (Img.File.empty()) {
         errs() << "error: image file name missing\n";
         exit(1);
       }
       MemoryBuffer *Bin = loadFile(Img.File);
-      std::pair<Constant *, Constant *> Fbin = addMemBufToModule(
-          M, Bin, Twine(OffloadKindTag) + Twine(ImgId) + Twine(".data"));
+      std::pair<Constant *, Constant *> Fbin = addDeviceImageToModule(
+          makeArrayRef(Bin->getBufferStart(), Bin->getBufferSize()),
+          Twine(OffloadKindTag) + Twine(ImgId) + Twine(".data"), Kind, Img.Tgt);
+
+      // Need to add 'host' dummy bundle if target triple was specified for at
+      // least one target image.
+      AddHostBundle |= !Img.Tgt.empty();
 
       ImagesInits.push_back(ConstantStruct::get(
           getDeviceImageTy(),
@@ -496,6 +542,14 @@ private:
            Fbin.second, EntriesB, EntriesE}));
       ImgId++;
     }
+
+    if (AddHostBundle) {
+      // Add dummy image for the 'host' binary to satisfy bundler expectations
+      // for fat objects.
+      addDeviceImageToModule(0, Twine(OffloadKindTag) + Twine("host.data"),
+                             OffloadKind::Host, Target);
+    }
+
     auto *ImagesData = ConstantArray::get(
         ArrayType::get(getDeviceImageTy(), ImagesInits.size()), ImagesInits);
 


### PR DESCRIPTION
Follow bundler conventions for naming sections that contain embedded offload
target images. That allows to use bunder for extracting target image from the
wrapper object.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>