### PR TITLE
[SYCL] Fix the integration header generation for kernel with typedefs.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1299,6 +1299,7 @@ void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D) {
   // print declaration into a string:
   PrintingPolicy P(D->getASTContext().getLangOpts());
   P.adjustForCPlusPlusFwdDecl();
+  P.PrintCanonicalTypes = true;
   std::string S;
   llvm::raw_string_ostream SO(S);
   D->print(SO, P);
@@ -1511,8 +1512,11 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
         O << "', '" << c;
       O << "'> {\n";
     } else {
+      LangOptions LO;
+      PrintingPolicy P(LO);
+      P.PrintCanonicalTypes = true;
       O << "template <> struct KernelInfo<"
-        << eraseAnonNamespace(K.NameType.getAsString()) << "> {\n";
+        << eraseAnonNamespace(K.NameType.getAsString(P)) << "> {\n";
     }
     O << "  DLL_LOCAL\n";
     O << "  static constexpr const char* getName() { return \"" << K.Name

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -2,15 +2,15 @@
 // RUN: FileCheck -input-file=%t.h %s
 
 // CHECK:template <> struct KernelInfo<class KernelName> {
-// CHECK:template <> struct KernelInfo<::nm1::nm2::KernelName0> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName1> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName3< ::nm1::nm2::KernelName0>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName3< ::nm1::KernelName1>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName4< ::nm1::nm2::KernelName0>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName4< ::nm1::KernelName1>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName3<KernelName5>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName4<KernelName7>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName8< ::nm1::nm2::C>> {
+// CHECK:template <> struct KernelInfo<class nm1::nm2::KernelName0> {
+// CHECK:template <> struct KernelInfo<class nm1::KernelName1> {
+// CHECK:template <> struct KernelInfo<class nm1::KernelName3<class nm1::nm2::KernelName0>> {
+// CHECK:template <> struct KernelInfo<class nm1::KernelName3<class nm1::KernelName1>> {
+// CHECK:template <> struct KernelInfo<class nm1::KernelName4<class nm1::nm2::KernelName0>> {
+// CHECK:template <> struct KernelInfo<class nm1::KernelName4<class nm1::KernelName1>> {
+// CHECK:template <> struct KernelInfo<class nm1::KernelName3<class KernelName5>> {
+// CHECK:template <> struct KernelInfo<class nm1::KernelName4<class KernelName7>> {
+// CHECK:template <> struct KernelInfo<class nm1::KernelName8<class nm1::nm2::C>> {
 // CHECK:template <> struct KernelInfo<class TmplClassInAnonNS<class ClassInAnonNS>> {
 
 // This test checks if the SYCL device compiler is able to generate correct

--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -48,9 +48,9 @@
 // CHECK-NEXT: };
 //
 // CHECK: template <> struct KernelInfo<class first_kernel> {
-// CHECK: template <> struct KernelInfo<::second_namespace::second_kernel<char>> {
-// CHECK: template <> struct KernelInfo<::third_kernel<1, int, ::point<X> >> {
-// CHECK: template <> struct KernelInfo<::fourth_kernel< ::template_arg_ns::namespaced_arg<1> >> {
+// CHECK: template <> struct KernelInfo<class second_namespace::second_kernel<char>> {
+// CHECK: template <> struct KernelInfo<class third_kernel<1, int, struct point<struct X> >> {
+// CHECK: template <> struct KernelInfo<class fourth_kernel<struct template_arg_ns::namespaced_arg<1> >> {
 
 #include "sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/kernel_functor.cpp
+++ b/clang/test/CodeGenSYCL/kernel_functor.cpp
@@ -168,7 +168,7 @@ int main() {
   cl::sycl::detail::KernelInfo<Functor1>::getName();
   // CHECK: Functor1
   cl::sycl::detail::KernelInfo<ns::Functor2>::getName();
-  // CHECK: ::ns::Functor2
+  // CHECK: ns::Functor2
   cl::sycl::detail::KernelInfo<TmplFunctor<int>>::getName();
   // CHECK: TmplFunctor<int>
   cl::sycl::detail::KernelInfo<TmplConstFunctor<int>>::getName();

--- a/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
+++ b/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
@@ -1,0 +1,80 @@
+// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
+// RUN: FileCheck -input-file=%t.h %s
+
+// CHECK: // Forward declarations of templated kernel function types:
+// CHECK-NEXT: template <typename T, typename T2, long N, unsigned long M> struct functor1;
+// CHECK-NEXT: template <typename T, typename T2, long N, unsigned long M> struct functor2;
+// CHECK-NEXT: template <typename T, typename T2> struct functor3;
+//
+// CHECK: // Specializations of KernelInfo for kernel function types:
+// CHECK: template <> struct KernelInfo<struct functor1<long, unsigned long, 0, 1>> {
+// CHECK: template <> struct KernelInfo<struct functor2<long, unsigned long, 0, 1>> {
+// CHECK: template <> struct KernelInfo<struct functor3<int, int>> {
+// CHECK: template <> struct KernelInfo<struct functor3<long, int>> {
+// CHECK: template <> struct KernelInfo<struct functor3<int, unsigned long>> {
+// CHECK: template <> struct KernelInfo<struct functor3<long, float>> {
+// CHECK: template <> struct KernelInfo<struct functor3<float, unsigned long>> {
+// CHECK: template <> struct KernelInfo<struct functor3<long, unsigned long>> {
+
+#include "sycl.hpp"
+
+template <typename KernelName, typename KernelType>
+__attribute__((sycl_kernel)) void kernel_single_task(KernelType kernelFunc) {
+  kernelFunc();
+}
+
+typedef signed long int signed_integer_t;
+
+using unsigned_integer_t = unsigned long int;
+
+template <typename T, typename T2, signed long int N, unsigned long int M>
+struct functor1 { void operator()() {} };
+
+template <typename T, typename T2, signed_integer_t N, unsigned_integer_t M>
+struct functor2 { void operator()() {} };
+
+template <typename T, typename T2>
+struct functor3 { void operator()() {} };
+
+template <typename T>
+struct functor3<signed_integer_t, T> { void operator()() {} };
+
+template <typename T>
+struct functor3<T, unsigned_integer_t> { void operator()() {} };
+
+template <>
+struct functor3<signed_integer_t, float> { void operator()() {} };
+
+template <>
+struct functor3<float, unsigned_integer_t> { void operator()() {} };
+
+template <>
+struct functor3<signed_integer_t, unsigned_integer_t> { void operator()() {} };
+
+int main() {
+  functor1<signed long int, unsigned long int, 0L, 1UL> Functor1;
+  kernel_single_task<decltype(Functor1)>(Functor1);
+
+  functor2<signed_integer_t, unsigned_integer_t, 0L, 1UL> Functor2;
+  kernel_single_task<decltype(Functor2)>(Functor2);
+
+  functor3<int, int> Functor3;
+  kernel_single_task<decltype(Functor3)>(Functor3);
+
+  functor3<signed_integer_t, int> Functor4;
+  kernel_single_task<decltype(Functor4)>(Functor4);
+
+  functor3<int, unsigned_integer_t> Functor5;
+  kernel_single_task<decltype(Functor5)>(Functor5);
+
+  functor3<signed_integer_t, float> Functor6;
+  kernel_single_task<decltype(Functor6)>(Functor6);
+
+  functor3<float, unsigned_integer_t> Functor7;
+  kernel_single_task<decltype(Functor7)>(Functor7);
+
+  functor3<signed_integer_t, unsigned_integer_t> Functor8;
+  kernel_single_task<decltype(Functor8)>(Functor8);
+
+  return 0;
+}


### PR DESCRIPTION
Added printing policy with the canonical types flag enabled to
generation declarations of templated kernel function types and
specializations of KernelInfo for kernel function types.

Before this change for single_task/parallel_for<class kernel<T>>
where T is type alias (typedef/using) in the integration header
remained the alias without defining what it is.

Example:
//// SYCL code
using type_t = int; template<type_t N> class kernel;
single_task<class kernel<0>>(...

//// generated integration header
// This is auto-generated SYCL integration header.

// Forward declarations of templated kernel function types:
template <type_t N> class kernel;

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>