### PR TITLE
[SYCL] Insert addrspacecast for comparing operands

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -1998,8 +1998,10 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
       // in AST, but in IR one of them may be in opencl_private, and another in
       // opencl_generic address space:
       //
-      //   int arr[5]; // automatic variable, default AS in AST, private AS in
-      //   IR char* p = arr; // default AS in AST, generic AS in IR
+      //   int arr[5];    // automatic variable, default AS in AST,
+      //                  // private AS in IR
+      //
+      //   char* p = arr; // default AS in AST, generic AS in IR
       //
       if (E->getType().getAddressSpace() != DestTy.getAddressSpace())
         llvm_unreachable("wrong cast for pointers in different address spaces"
@@ -2820,6 +2822,53 @@ Value *ScalarExprEmitter::VisitUnaryImag(const UnaryOperator *E) {
 //===----------------------------------------------------------------------===//
 //                           Binary Operators
 //===----------------------------------------------------------------------===//
+
+static Value *insertAddressSpaceCast(Value *V, unsigned NewAS) {
+  auto *VTy = cast<llvm::PointerType>(V->getType());
+  if (VTy->getAddressSpace() == NewAS)
+    return V;
+
+  llvm::PointerType *VTyNewAS =
+      llvm::PointerType::get(VTy->getElementType(), NewAS);
+
+  if (auto *Constant = dyn_cast<llvm::Constant>(V))
+    return llvm::ConstantExpr::getAddrSpaceCast(Constant, VTyNewAS);
+
+  llvm::Instruction *NewV =
+      new llvm::AddrSpaceCastInst(V, VTyNewAS, V->getName() + ".ascast");
+  NewV->insertAfter(cast<llvm::Instruction>(V));
+  return NewV;
+}
+
+static void ensureSameAddrSpace(Value *&RHS, Value *&LHS,
+                                bool CanInsertAddrspaceCast,
+                                const LangOptions &Opts,
+                                const ASTContext &Context) {
+  if (RHS->getType() == LHS->getType())
+    return;
+
+  auto *RHSTy = dyn_cast<llvm::PointerType>(RHS->getType());
+  auto *LHSTy = dyn_cast<llvm::PointerType>(LHS->getType());
+  if (!RHSTy || !LHSTy || RHSTy->getAddressSpace() == LHSTy->getAddressSpace())
+    return;
+
+  if (!CanInsertAddrspaceCast)
+    // Pointers have different address spaces and we cannot do anything with
+    // this.
+    llvm_unreachable("Pointers are expected to have the same address space.");
+
+  // Language rules define if it is legal to cast from one address space to
+  // another, and which address space we should use as a "common
+  // denominator". In SYCL, generic address space overlaps with all other
+  // address spaces.
+  if (Opts.SYCLIsDevice) {
+    unsigned GenericAS = Context.getTargetAddressSpace(LangAS::opencl_generic);
+    RHS = insertAddressSpaceCast(RHS, GenericAS);
+    LHS = insertAddressSpaceCast(LHS, GenericAS);
+  } else
+    llvm_unreachable("Unable to find a common address space for "
+                     "two pointers.");
+}
 
 BinOpInfo ScalarExprEmitter::EmitBinOps(const BinaryOperator *E) {
   TestAndClearIgnoreResultAssign();
@@ -3855,6 +3904,14 @@ Value *ScalarExprEmitter::EmitCompare(const BinaryOperator *E,
           RHS = Builder.CreateStripInvariantGroup(RHS);
       }
 
+      // Expression operands may have the same addrspace in AST, but different
+      // addrspaces in LLVM IR, in which case an addrspacecast should be valid.
+      bool CanInsertAddrspaceCast =
+             LHSTy.getAddressSpace() == RHSTy.getAddressSpace();
+
+      ensureSameAddrSpace(RHS, LHS, CanInsertAddrspaceCast, CGF.getLangOpts(),
+                          CGF.getContext());
+
       Result = Builder.CreateICmp(UICmpOpc, LHS, RHS, "cmp");
     }
 
@@ -4158,53 +4215,6 @@ static bool isCheapEnoughToEvaluateUnconditionally(const Expr *E,
   // outside the lambda, that function may have returned already. Reading its
   // locals is a bad idea. Also, these reads may introduce races there didn't
   // exist in the source-level program.
-}
-
-static Value *insertAddressSpaceCast(Value *V, unsigned NewAS) {
-  auto *VTy = cast<llvm::PointerType>(V->getType());
-  if (VTy->getAddressSpace() == NewAS)
-    return V;
-
-  llvm::PointerType *VTyNewAS =
-      llvm::PointerType::get(VTy->getElementType(), NewAS);
-
-  if (auto *Constant = dyn_cast<llvm::Constant>(V))
-    return llvm::ConstantExpr::getAddrSpaceCast(Constant, VTyNewAS);
-
-  llvm::Instruction *NewV =
-      new llvm::AddrSpaceCastInst(V, VTyNewAS, V->getName() + ".ascast");
-  NewV->insertAfter(cast<llvm::Instruction>(V));
-  return NewV;
-}
-
-static void ensureSameAddrSpace(Value *&RHS, Value *&LHS,
-                                bool CanInsertAddrspaceCast,
-                                const LangOptions &Opts,
-                                const ASTContext &Context) {
-  if (RHS->getType() == LHS->getType())
-    return;
-
-  auto *RHSTy = dyn_cast<llvm::PointerType>(RHS->getType());
-  auto *LHSTy = dyn_cast<llvm::PointerType>(LHS->getType());
-  if (!RHSTy || !LHSTy || RHSTy->getAddressSpace() == LHSTy->getAddressSpace())
-    return;
-
-  if (!CanInsertAddrspaceCast)
-    // Pointers have different address spaces and we cannot do anything with
-    // this.
-    llvm_unreachable("Pointers are expected to have the same address space.");
-
-  // Language rules define if it is legal to cast from one address space to
-  // another, and which address space we should use as a "common
-  // denominator". In SYCL, generic address space overlaps with all other
-  // address spaces.
-  if (Opts.SYCLIsDevice) {
-    unsigned GenericAS = Context.getTargetAddressSpace(LangAS::opencl_generic);
-    RHS = insertAddressSpaceCast(RHS, GenericAS);
-    LHS = insertAddressSpaceCast(LHS, GenericAS);
-  } else
-    llvm_unreachable("Unable to find a common address space for "
-                     "two pointers.");
 }
 
 Value *ScalarExprEmitter::


### PR DESCRIPTION
Pointers with the same address space in AST may end up in different
address spaces in IR. We cannot CodeGen a binary compare
operator (<, >, ==, etc.) whose operands have different address spaces,
so we have to addrspacecast them to generic.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>