### PR TITLE
[SYCL] Assert that constant memory is only used with read access mode

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -651,6 +651,12 @@ class accessor :
                  AccessTarget == access::target::host_buffer),
                 "Expected buffer type");
 
+  static_assert((AccessTarget == access::target::global_buffer ||
+                 AccessTarget == access::target::host_buffer) ||
+                (AccessTarget == access::target::constant_buffer &&
+                 AccessMode == access::mode::read),
+                "Access mode can be only read for constant buffers");
+
   using AccessorCommonT = detail::accessor_common<DataT, Dimensions, AccessMode,
                                                   AccessTarget, IsPlaceholder>;
 

--- a/sycl/test/multi_ptr/multi_ptr.cpp
+++ b/sycl/test/multi_ptr/multi_ptr.cpp
@@ -115,7 +115,7 @@ void testMultPtrArrowOperator() {
       accessor<point<T>, 1, access::mode::read, access::target::global_buffer,
                access::placeholder::false_t>
           accessorData_1(bufferData_1, cgh);
-      accessor<point<T>, 1, access::mode::read_write, access::target::constant_buffer,
+      accessor<point<T>, 1, access::mode::read, access::target::constant_buffer,
                access::placeholder::false_t>
           accessorData_2(bufferData_2, cgh);
       accessor<point<T>, 1, access::mode::read_write, access::target::local,


### PR DESCRIPTION
The user usually expects an exception when a constant buffer has been used in write mode. When this occurs, the compilation should exit with this assertion.
Signed-off-by: Dounia <dounia.khaldi@intel.com>