### PR TITLE
[SYCL] Do not suppress exceptions thrown by async_handler from ~queue()

### DIFF
--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -59,12 +59,7 @@ public:
   }
 
   ~queue_impl() {
-    try {
-      throw_asynchronous();
-    } catch (...) {
-      assert(!"The asynchronous error handler should not throw exceptions from "
-              "the queue destructor.");
-    }
+    throw_asynchronous();
     if (m_OpenCLInterop) {
       PI_CALL(RT::piQueueRelease(m_CommandQueue));
     }


### PR DESCRIPTION
The spec states that the asynchronous exception handler is called on
queue destruction, so it is expected that given a throwing async_handler
an exception will be visible in that case.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>