### PR TITLE
Retain llvm.loop metadata for LoopControlINTEL instruction

### DIFF
--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVBasicBlock.cpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVBasicBlock.cpp
@@ -70,7 +70,8 @@ SPIRVBasicBlock::addInstruction(SPIRVInstruction *I,
     // If insertion of a new instruction before the one passed to the function
     // is illegal, insertion before the returned instruction is guaranteed
     // to retain correct instruction order in a block
-    if (Pos != InstVec.begin() && isa<OpLoopMerge>(*std::prev(Pos)))
+    if (Pos != InstVec.begin() && (isa<OpLoopMerge>(*std::prev(Pos)) ||
+                                   isa<OpLoopControlINTEL>(*std::prev(Pos))))
       --Pos;
     InstVec.insert(Pos, I);
   } else

--- a/llvm-spirv/test/DebugInfo/DebugUnstructuredControlFlow.cl
+++ b/llvm-spirv/test/DebugInfo/DebugUnstructuredControlFlow.cl
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -cl-std=CL2.0 -O0 -debug-info-kind=standalone -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_unstructured_loop_controls -o %t.spv
+// RUN: llvm-spirv %t.spv --to-text -o %t.spt
+// RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv -r %t.spv -o %t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+// Test that no debug info instruction is inserted between LoopControlINTEL and
+// Branch instructions. Otherwise, debug info interferes with SPIRVToLLVM
+// translation of structured flow control. Yet, Line DebugInfo instruction is
+// still presenting between LoopControlINTEL and Branch instructions.
+
+kernel
+void sample() {
+  #pragma clang loop unroll(full)
+  for(;;);
+}
+
+// CHECK-SPIRV: 2 LoopControlINTEL 1
+// CHECK-SPIRV-NOT: ExtInst
+// CHECK-SPIRV: {{[0-9]+}} Line {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+// CHECK-SPIRV: Branch
+// CHECK-LLVM: br label %{{.*}}, !dbg !{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
+// CHECK-LLVM: ![[MD]] = distinct !{![[MD]], ![[MD_unroll:[0-9]+]]}
+// CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.enable"}


### PR DESCRIPTION
In case when debug information presents in the module, the
metadata was missing with translation back of LoopControlINTEL
instruction due to incorrect instruction ID.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>