### PR TITLE
[SYCL][USM] Align malloc impl with Spec Proposal behavior.

### DIFF
--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -43,6 +43,7 @@ void *alignedAlloc(size_t Alignment, size_t Size, const context &Ctxt,
 
   // Error is for debugging purposes.
   // The spec wants a nullptr returned, not an exception.
+  if (Error != PI_SUCCESS) return nullptr;
 
   return RetVal;
 }
@@ -77,6 +78,7 @@ void *alignedAlloc(size_t Alignment, size_t Size, const context &Ctxt,
 
   // Error is for debugging purposes.
   // The spec wants a nullptr returned, not an exception.
+  if (Error != PI_SUCCESS) return nullptr;
 
   return RetVal;
 }

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -41,7 +41,8 @@ void *alignedAlloc(size_t Alignment, size_t Size, const context &Ctxt,
   }
   }
 
-  PI_CHECK(Error);
+  // Error is for debugging purposes.
+  // The spec wants a nullptr returned, not an exception.
 
   return RetVal;
 }
@@ -74,7 +75,8 @@ void *alignedAlloc(size_t Alignment, size_t Size, const context &Ctxt,
   }
   }
 
-  PI_CHECK(Error);
+  // Error is for debugging purposes.
+  // The spec wants a nullptr returned, not an exception.
 
   return RetVal;
 }


### PR DESCRIPTION
The malloc functions should return nullptr on error, not throw an exception.  The allocator *should* throw an exception, and does.

Signed-off-by: James Brodman <james.brodman@intel.com>