### PR TITLE
[clang-offload-bundler] Add single-file mode for unbundling archives

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6499,7 +6499,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   }
   if (C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment() &&
       Input.getType() == types::TY_Archive)
-    TypeArg = "ao";
+    TypeArg = "aoo";
 
   // Get the type.
   CmdArgs.push_back(TCArgs.MakeArgString(Twine("-type=") + TypeArg));

--- a/clang/test/Driver/clang-offload-bundler.c
+++ b/clang/test/Driver/clang-offload-bundler.c
@@ -48,7 +48,8 @@
 // CK-HELP: {{.*}}o {{.*}}- object
 // CK-HELP: {{.*}}gch {{.*}}- precompiled-header
 // CK-HELP: {{.*}}ast {{.*}}- clang AST file
-// CK-HELP: {{.*}}ao {{.*}}- archive; output file is a list of unbundled objects
+// CK-HELP: {{.*}}ao {{.*}}- archive with one object; output is an unbundled object
+// CK-HELP: {{.*}}aoo {{.*}}- archive; output file is a list of unbundled objects
 // CK-HELP: {{.*}}-unbundle {{.*}}- Unbundle bundled file into several output files.
 
 //
@@ -278,17 +279,34 @@
 //
 // Check archive bundle.
 //
+
+// Check file-list mode.
 // RUN: echo 'Invalid object' > %t.invalid.o
+// RUN: rm -f %t.a
 // RUN: llvm-ar crv %t.a %t.2.o %t.invalid.o
-// RUN: clang-offload-bundler -type=ao -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.host.lst,%t.tgt1.lst,%t.tgt2.lst -inputs=%t.a -unbundle
+// RUN: clang-offload-bundler -type=aoo -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.host.lst,%t.tgt1.lst,%t.tgt2.lst -inputs=%t.a -unbundle
 // RUN: wc -l %t.host.lst | FileCheck %s --check-prefix=CHECK-AR-FILE-LIST
 // RUN: wc -l %t.tgt1.lst | FileCheck %s --check-prefix=CHECK-AR-FILE-LIST
 // RUN: wc -l %t.tgt2.lst | FileCheck %s --check-prefix=CHECK-AR-FILE-LIST
 // RUN: diff %t.2.o `cat %t.host.lst`
 // RUN: diff %t.tgt1 `cat %t.tgt1.lst`
-// RUN: diff %t.tgt1 `cat %t.tgt1.lst`
+// RUN: diff %t.tgt2 `cat %t.tgt2.lst`
 
 // CHECK-AR-FILE-LIST: 1
+
+// Check single-file mode.
+// RUN: clang-offload-bundler -type=ao -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.host.out,%t.tgt1.out,%t.tgt2.out -inputs=%t.a -unbundle
+// RUN: diff %t.2.o %t.host.out
+// RUN: diff %t.tgt1 %t.tgt1.out
+// RUN: diff %t.tgt2 %t.tgt2.out
+
+// Check that bundler does not accept multi-file archive in single-file mode.
+// RUN: cp  %t.2.o  %t.3.o
+// RUN: llvm-ar crv %t.a %t.2.o  %t.3.o %t.invalid.o
+// RUN: not clang-offload-bundler -type=ao -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.host.out,%t.tgt1.out,%t.tgt2.out -inputs=%t.a -unbundle 2>&1 \
+// RUN:   | FileCheck %s --check-prefix CHECK-MULTI-FILE-AR-ERROR
+
+// CHECK-MULTI-FILE-AR-ERROR: 'ao' file type is requested, but the archive contains multiple device objects; use 'aoo' instead
 
 #ifdef EMULATE_FAT_OBJ
 #define BUNDLE_SECTION_PREFIX "__CLANG_OFFLOAD_BUNDLE__"

--- a/clang/test/Driver/sycl-offload-win.c
+++ b/clang/test/Driver/sycl-offload-win.c
@@ -13,7 +13,7 @@
 // RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -foffload-static-lib=%t.lib %t.obj -### 2>&1 \
 // RUN:   | FileCheck -DOBJ=%t.obj -DLIB=%t.lib %s -check-prefix=FOFFLOAD_STATIC_LIB
 // FOFFLOAD_STATIC_LIB: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=o"{{.+}} "-inputs=[[OBJ]]"{{.+}} "-unbundle"
-// FOFFLOAD_STATIC_LIB: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=ao"{{.+}} "-inputs=[[LIB]]"{{.+}} "-unbundle"
+// FOFFLOAD_STATIC_LIB: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=aoo"{{.+}} "-inputs=[[LIB]]"{{.+}} "-unbundle"
 // FOFFLOAD_STATIC_LIB: llvm-link{{(.exe)?}}{{.*}} "@{{.*}}"
 // FOFFLOAD_STATIC_LIB: link{{(.exe)?}}{{.+}} "-defaultlib:[[LIB]]"
 
@@ -31,7 +31,7 @@
 // FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=o"{{.+}} "-inputs=[[OBJ1]]"{{.+}} "-unbundle"
 // FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=o"{{.+}} "-inputs=[[OBJ2]]"{{.+}} "-unbundle"
 // FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=o"{{.+}} "-inputs=[[OBJ3]]"{{.+}} "-unbundle"
-// FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=ao"{{.+}} "-inputs=[[LIB]]"{{.+}} "-unbundle"
+// FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=aoo"{{.+}} "-inputs=[[LIB]]"{{.+}} "-unbundle"
 // FOFFLOAD_STATIC_LIB_MULTI_O: llvm-link{{(.exe)?}}{{.*}} "@{{.*}}"
 // FOFFLOAD_STATIC_LIB_MULTI_O: link{{(.exe)?}}{{.+}} "-defaultlib:[[LIB]]"
 
@@ -46,8 +46,8 @@
 // RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -foffload-static-lib=%t1.lib -foffload-static-lib=%t2.lib %t.obj -### 2>&1 \
 // RUN:   | FileCheck -DOBJ=%t.obj -DLIB1=%t1.lib -DLIB2=%t2.lib %s -check-prefix=FOFFLOAD_STATIC_MULTI_LIB
 // FOFFLOAD_STATIC_MULTI_LIB: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=o"{{.+}} "-inputs=[[OBJ]]"{{.+}} "-unbundle"
-// FOFFLOAD_STATIC_MULTI_LIB: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=ao"{{.+}} "-inputs=[[LIB1]]"{{.+}} "-unbundle"
-// FOFFLOAD_STATIC_MULTI_LIB: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=ao"{{.+}} "-inputs=[[LIB2]]"{{.+}} "-unbundle"
+// FOFFLOAD_STATIC_MULTI_LIB: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=aoo"{{.+}} "-inputs=[[LIB1]]"{{.+}} "-unbundle"
+// FOFFLOAD_STATIC_MULTI_LIB: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=aoo"{{.+}} "-inputs=[[LIB2]]"{{.+}} "-unbundle"
 // FOFFLOAD_STATIC_MULTI_LIB: llvm-link{{(.exe)?}}{{.*}} "@{{.*}}" "@{{.*}}"
 // FOFFLOAD_STATIC_MULTI_LIB: link{{(.exe)?}}{{.+}} "-defaultlib:[[LIB1]]" "-defaultlib:[[LIB2]]"
 
@@ -85,7 +85,7 @@
 // RUN:   | FileCheck -DLIB=%t.lib %s -check-prefix=FOFFLOAD_STATIC_LIB_SRC2
 // RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -foffload-static-lib=%t.lib %s -### 2>&1 \
 // RUN:   | FileCheck -DLIB=%t.lib %s -check-prefix=FOFFLOAD_STATIC_LIB_SRC2
-// FOFFLOAD_STATIC_LIB_SRC2: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=ao"{{.+}} "-inputs=[[LIB]]"{{.+}} "-unbundle"
+// FOFFLOAD_STATIC_LIB_SRC2: clang-offload-bundler{{(.exe)?}}{{.+}} "-type=aoo"{{.+}} "-inputs=[[LIB]]"{{.+}} "-unbundle"
 // FOFFLOAD_STATIC_LIB_SRC2: llvm-link{{(.exe)?}}{{.*}} "@{{.*}}"
 // FOFFLOAD_STATIC_LIB_SRC2: link{{(.exe)?}}{{.+}} "-defaultlib:[[LIB]]"
 

--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -82,7 +82,8 @@ static cl::opt<std::string> FilesType(
              "  oo  - object; output file is a list of unbundled objects\n"
              "  gch - precompiled-header\n"
              "  ast - clang AST file\n"
-             "  ao  - archive; output file is a list of unbundled objects\n"),
+             "  ao  - archive with one object; output is an unbundled object\n"
+             "  aoo - archive; output file is a list of unbundled objects\n"),
     cl::cat(ClangOffloadBundlerCategory));
 
 static cl::opt<bool>
@@ -933,12 +934,13 @@ class ArchiveFileHandler final : public FileHandler {
   /// Archive we are dealing with.
   std::unique_ptr<Archive> Ar;
 
-  /// Union of bundle names from all object.
-  StringSet<> Bundles;
+  /// Union of bundle names from all object. The value is a count of how many
+  /// times we've seen the bundle in the archive object(s).
+  StringMap<unsigned> Bundles;
 
   /// Iterators over the bundle names.
-  StringSet<>::iterator CurrBundle = Bundles.end();
-  StringSet<>::iterator NextBundle = Bundles.end();
+  StringMap<unsigned>::iterator CurrBundle = Bundles.end();
+  StringMap<unsigned>::iterator NextBundle = Bundles.end();
 
 public:
   ArchiveFileHandler() = default;
@@ -974,7 +976,7 @@ public:
 
       for (auto TT = OFH.ReadBundleStart(*Buf); !TT.empty();
            TT = OFH.ReadBundleStart(*Buf))
-        Bundles.insert(TT);
+        ++Bundles[TT];
     }
     if (Err)
       fatalError(std::move(Err));
@@ -993,12 +995,20 @@ public:
   void ReadBundleEnd(MemoryBuffer &Input) override {}
 
   void ReadBundle(StringRef OutName, MemoryBuffer &Input) override {
-    // Archive unbundling produces multiple files, so output file is a file list
-    // where we write the unbundled object names.
-    std::error_code EC;
-    raw_fd_ostream OS(OutName, EC);
-    if (EC)
-      fatalError(EC, Twine("can't open file for writing ") + OutName);
+    assert(CurrBundle->second && "attempt to extract nonexistent bundle");
+
+    bool FileListMode = FilesType == "aoo";
+
+    // In single-file mode we do not expect to see bundle more than once.
+    if (!FileListMode && CurrBundle->second > 1)
+      report_fatal_error(
+          "'ao' file type is requested, but the archive contains multiple "
+          "device objects; use 'aoo' instead");
+
+    // In file-list mode archive unbundling produces multiple files, so output
+    // file is a file list where we write the unbundled object names.
+    SmallVector<char, 0u> FileListBuf;
+    raw_svector_ostream FileList{FileListBuf};
 
     // Read all children.
     Error Err = Error::success();
@@ -1024,24 +1034,40 @@ public:
         if (TT != CurrBundle->first())
           continue;
 
-        // This is the bundle we are looking for. Created temporary file
-        // where the device part will be extracted.
+        // This is the bundle we are looking for. Create temporary file where
+        // the device part will be extracted if we are in the file-list mode, or
+        // write directly to the output file otherwise.
         SmallString<128u> ChildFileName;
-        auto EC =
-            sys::fs::createTemporaryFile(TempFileNameBase, "o", ChildFileName);
-        if (EC)
-          fatalError(EC, "can't create temporary file");
+        if (FileListMode) {
+          auto EC = sys::fs::createTemporaryFile(TempFileNameBase, "o",
+                                                 ChildFileName);
+          if (EC)
+            fatalError(EC, "can't create temporary file");
+        } else
+          ChildFileName = OutName;
 
         // And extract the bundle.
         OFH.ReadBundle(ChildFileName, *Buf);
         OFH.ReadBundleEnd(*Buf);
 
-        // Add temporary file name with the device part to the output file list.
-        OS << ChildFileName << "\n";
+        if (FileListMode) {
+          // Add temporary file name with the device part to the output file
+          // list.
+          FileList << ChildFileName << "\n";
+        }
       }
     }
     if (Err)
       fatalError(std::move(Err));
+
+    if (FileListMode) {
+      // Dump file list to the output file.
+      std::error_code EC;
+      raw_fd_ostream OS(OutName, EC);
+      if (EC)
+        fatalError(EC, Twine("can't open file for writing ") + OutName);
+      OS << FileList.str();
+    }
   }
 
   void ReadBundle(raw_fd_ostream &OS, MemoryBuffer &Input) override {
@@ -1111,7 +1137,7 @@ static FileHandler *CreateFileHandler(MemoryBuffer &FirstInput) {
     return new BinaryFileHandler();
   if (FilesType == "ast")
     return new BinaryFileHandler();
-  if (FilesType == "ao")
+  if (FilesType == "ao" || FilesType == "aoo")
     return new ArchiveFileHandler();
 
   errs() << "error: invalid file type specified.\n";
@@ -1122,7 +1148,7 @@ static FileHandler *CreateFileHandler(MemoryBuffer &FirstInput) {
 static bool BundleFiles() {
   std::error_code EC;
 
-  if (FilesType == "ao") {
+  if (FilesType == "ao" || FilesType == "aoo") {
     errs() << "error: bundling is not supported for archives\n";
     return true;
   }
@@ -1250,7 +1276,7 @@ static bool UnbundleFiles() {
 
       // If this entry has a host kind, copy the input file to the output file
       // except for the archive unbundling where output is a list file.
-      if (hasHostKind(E.first()) && FilesType != "ao")
+      if (hasHostKind(E.first()) && FilesType != "ao" && FilesType != "aoo")
         OutputFile.write(Input.getBufferStart(), Input.getBufferSize());
     }
     return false;


### PR DESCRIPTION
This patch renames recently added archive unbundling mode "ao" to
"aoo". In this mode output file is really a list file where bundler
writes temporary file names of extracted objects. And adds a new
archive unbundling mode under "ao" type which can be used on archives
that are composed of one fat object file only (otherwise bundler
produces an error). In such "single-file" mode extracted object is
written directly to the specified output file.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>