### PR TITLE
[SYCL][USM] Change to enabling kernel indirect info.

### DIFF
--- a/sycl/include/CL/sycl/detail/usm_dispatch.hpp
+++ b/sycl/include/CL/sycl/detail/usm_dispatch.hpp
@@ -18,8 +18,9 @@ namespace usm {
 
 class USMDispatcher {
 public:
-  USMDispatcher(cl_platform_id Platform);
-  
+  USMDispatcher(cl_platform_id Platform,
+                const vector_class<RT::PiDevice> &DeviceIds);
+
   void *hostMemAlloc(pi_context Context, cl_mem_properties_intel *Properties,
                      size_t Size, pi_uint32 Alignment, pi_result *ErrcodeRet);
   void *deviceMemAlloc(pi_context Context, pi_device Device,
@@ -51,6 +52,7 @@ public:
 
 private:
   bool mEmulated = false;
+  bool mSupported = false;
   std::unique_ptr<CLUSM> mEmulator;
 
   clHostMemAllocINTEL_fn pfn_clHostMemAllocINTEL = nullptr;

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -40,7 +40,7 @@ context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
       RT::piContextCreate(0, DeviceIds.size(), DeviceIds.data(), 0, 0, &Err),
       Err));
 
-  m_USMDispatch.reset(new usm::USMDispatcher(m_Platform.get()));
+  m_USMDispatch.reset(new usm::USMDispatcher(m_Platform.get(), DeviceIds));
 }
 
 context_impl::context_impl(cl_context ClContext, async_handler AsyncHandler)

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -635,7 +635,6 @@ cl_int ExecCGCommand::enqueueImp() {
       Kernel = detail::ProgramManager::getInstance().getOrCreateKernel(
           ExecKernel->MOSModuleHandle, Context, ExecKernel->MKernelName);
 
-    bool usesUSM = false;
     for (ArgDesc &Arg : ExecKernel->MArgs) {
       switch (Arg.MType) {
       case kernel_param_kind_t::kind_accessor: {
@@ -661,8 +660,6 @@ cl_int ExecCGCommand::enqueueImp() {
         break;
       }
       case kernel_param_kind_t::kind_pointer:  {
-        // TODO: Change to PI
-        usesUSM = true;
         std::shared_ptr<usm::USMDispatcher> USMDispatch =
             getSyclObjImpl(Context)->getUSMDispatch();
         auto PtrToPtr = reinterpret_cast<intptr_t*>(Arg.MPtr);
@@ -680,11 +677,9 @@ cl_int ExecCGCommand::enqueueImp() {
                            detail::getSyclObjImpl(
                                MQueue->get_device())->getHandleRef());
 
-    if (usesUSM) {
-      std::shared_ptr<usm::USMDispatcher> USMDispatch =
+    std::shared_ptr<usm::USMDispatcher> USMDispatch =
         getSyclObjImpl(Context)->getUSMDispatch();
-      USMDispatch->setKernelIndirectAccess(Kernel, MQueue->getHandleRef());
-    }
+    USMDispatch->setKernelIndirectAccess(Kernel, MQueue->getHandleRef());
 
     PI_CALL(RT::piEnqueueKernelLaunch(
         MQueue->getHandleRef(), Kernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],

--- a/sycl/source/detail/usm/usm_dispatch.cpp
+++ b/sycl/source/detail/usm/usm_dispatch.cpp
@@ -54,12 +54,12 @@ USMDispatcher::USMDispatcher(cl_platform_id platform,
       if (CL_TARGET_OPENCL_VERSION >= 200) {
         bool AnybodyNotSupportSVM = false;
         for (const auto &D : DeviceIds) {
-          cl_device_svm_capabilities caps;
+          cl_device_svm_capabilities Caps;
           cl_int Error = clGetDeviceInfo(
               pi::cast<cl_device_id>(D), CL_DEVICE_SVM_CAPABILITIES,
-              sizeof(cl_device_svm_capabilities), &caps, nullptr);
-          AnybodyNotSupportSVM = (Error != CL_SUCCESS) ||
-                                 (!(caps & CL_DEVICE_SVM_FINE_GRAIN_BUFFER));
+              sizeof(cl_device_svm_capabilities), &Caps, nullptr);
+          AnybodyNotSupportSVM |= ((Error != CL_SUCCESS) ||
+                                   (!(Caps & CL_DEVICE_SVM_FINE_GRAIN_BUFFER)));
         }
         mSupported = !AnybodyNotSupportSVM;
       } else {
@@ -73,8 +73,6 @@ USMDispatcher::USMDispatcher(cl_platform_id platform,
   } else {
     mSupported = false;
   }
-  
-  // Else Error?
 }
 
 void *USMDispatcher::hostMemAlloc(pi_context Context,
@@ -370,6 +368,3 @@ void USMDispatcher::memAdvise(pi_queue Queue, const void *Ptr, size_t Length,
 } // namespace detail
 } // namespace sycl
 } // namespace cl
-
-
-

--- a/sycl/source/detail/usm/usm_dispatch.cpp
+++ b/sycl/source/detail/usm/usm_dispatch.cpp
@@ -50,17 +50,22 @@ USMDispatcher::USMDispatcher(cl_platform_id platform,
       // See if every device in this context supports
       // CL_DEVICE_SVM_FINE_GRAIN_BUFFER
       // If not, disable USM
-      
-      bool AnybodyNotSupportSVM = false;
-      for (const auto &D : DeviceIds) {
-        cl_device_svm_capabilities caps;
-        cl_int Error = clGetDeviceInfo(
-            pi::cast<cl_device_id>(D), CL_DEVICE_SVM_CAPABILITIES,
-            sizeof(cl_device_svm_capabilities), &caps, nullptr);
-        AnybodyNotSupportSVM = (Error != CL_SUCCESS) ||
-                               (!(caps & CL_DEVICE_SVM_FINE_GRAIN_BUFFER));
+
+      if (CL_TARGET_OPENCL_VERSION >= 200) {
+        bool AnybodyNotSupportSVM = false;
+        for (const auto &D : DeviceIds) {
+          cl_device_svm_capabilities caps;
+          cl_int Error = clGetDeviceInfo(
+              pi::cast<cl_device_id>(D), CL_DEVICE_SVM_CAPABILITIES,
+              sizeof(cl_device_svm_capabilities), &caps, nullptr);
+          AnybodyNotSupportSVM = (Error != CL_SUCCESS) ||
+                                 (!(caps & CL_DEVICE_SVM_FINE_GRAIN_BUFFER));
+        }
+        mSupported = !AnybodyNotSupportSVM;
+      } else {
+        // USM isn't support on CL 1.2
+        mSupported = false;
       }
-      mSupported = !AnybodyNotSupportSVM;
     } else {
       // We support the CL Extension
       mSupported = true;


### PR DESCRIPTION
This change is being done as USM currently is properly being enabled in all situations.  If pointers are only passed into the kernel as members of a struct/class, the indirect modes weren't being enabled.  Given that detecting this would be hugely difficult, change the default behavior:

Ungate setting Indirect modes for Kernels in commands.cpp.
Change USM Dispatcher to better detect whether USM is supported.  If it's not, NOP the ungated methods invoked by the Scheduler.