### PR TITLE
[SYCL] Do not emit errors for TLS declarations

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -164,10 +164,6 @@ public:
     // to parse host code. So we allow compilation of exception_ptr but
     // if exceptions are used in device code we should emit a diagnostic.
     MaxAtomicInlineWidth = 32;
-    // This is workaround for mutex class.
-    // I'm not sure about this hack but I guess that mutex_class is same
-    // problem.
-    TLSSupported = true;
   }
 };
 
@@ -182,10 +178,6 @@ public:
     // to parse host code. So we allow compilation of exception_ptr but
     // if exceptions are used in device code we should emit a diagnostic.
     MaxAtomicInlineWidth = 64;
-    // This is workaround for mutex class.
-    // I'm not sure about this hack but I guess that mutex_class is same
-    // problem.
-    TLSSupported = true;
   }
 };
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -6729,6 +6729,14 @@ NamedDecl *Sema::ActOnVariableDeclarator(
         // proper storage class for other tools to use even if we're not going
         // to emit any code for it.
         NewVD->setTSCSpec(TSCS);
+      } else if (getLangOpts().SYCLIsDevice) {
+        // While SYCL does not support TLS, emitting the diagnostic here
+        // prevents the compilation of header files with TLS declarations.
+        // When TLS objects are used in kernel code, they are diagnosed.
+        // We still need to mark the variable as TLS so it shows up in AST with
+        // proper storage class for other tools to use even if we're not going
+        // to emit any code for it.
+        NewVD->setTSCSpec(TSCS);
       } else
         Diag(D.getDeclSpec().getThreadStorageClassSpecLoc(),
              diag::err_thread_unsupported);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -209,9 +209,12 @@ public:
         SemaRef.Diag(E->getExprLoc(), diag::err_sycl_restrict)
             << Sema::KernelNonConstStaticDataVariable;
       else if (!IsConst && VD->hasGlobalStorage() && !VD->isStaticLocal() &&
-          !VD->isStaticDataMember() && !isa<ParmVarDecl>(VD))
+          !VD->isStaticDataMember() && !isa<ParmVarDecl>(VD)) {
+        if (VD->getTLSKind() != VarDecl::TLS_None)
+          SemaRef.Diag(E->getLocation(), diag::err_thread_unsupported);
         SemaRef.Diag(E->getLocation(), diag::err_sycl_restrict)
             << Sema::KernelGlobalVariable;
+      }
       if (!VD->isLocalVarDeclOrParm() && VD->hasGlobalStorage()) {
         VD->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
         SemaRef.addSyclDeviceDecl(VD);

--- a/clang/test/SemaSYCL/tls_error.cpp
+++ b/clang/test/SemaSYCL/tls_error.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -verify -fsyntax-only -fsycl-is-device %s
+
+extern __thread void* __once_callable;  // expected-no-error
+extern __thread void (*__once_call)();  // expected-no-error
+
+void usage() {
+  // expected-error@+2{{thread-local storage is not supported for the current target}}
+  // expected-error@+1{{SYCL kernel cannot use a global variable}}
+  __once_callable = 0;
+  // expected-error@+3{{thread-local storage is not supported for the current target}}
+  // expected-error@+2{{SYCL kernel cannot use a global variable}}
+  // expected-error@+1{{SYCL kernel cannot call through a function pointer}}
+  __once_call();
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class fake_kernel>([]() { usage(); });
+  return 0;
+}


### PR DESCRIPTION
Use of TLS variables in SYCL code is diagnosed instead.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>