### PR TITLE
[SYCL][PI] Fix PI unittests after PI API name changes

### DIFF
--- a/sycl/unittests/pi/PlatformTest.cpp
+++ b/sycl/unittests/pi/PlatformTest.cpp
@@ -32,7 +32,7 @@ TEST_F(PlatformTest, piPlatformsGet) {
             PI_SUCCESS)
       << "piPlatformsGet failed";
 
-  ASSERT_GT(platformCount, 0) << "piPlatformsGet found 0 platforms.\n";
+  ASSERT_GT(platformCount, 0u) << "piPlatformsGet found 0 platforms.\n";
 
   std::vector<pi_platform> platforms(platformCount);
 

--- a/sycl/unittests/pi/PlatformTest.cpp
+++ b/sycl/unittests/pi/PlatformTest.cpp
@@ -20,7 +20,7 @@ protected:
 constexpr static size_t out_string_size =
     8192u; // Using values from OpenCL CTS clGetPlatforms test
 
-  PlatformTest() { detail::pi::piInitialize(); }
+  PlatformTest() { detail::pi::initialize(); }
 
   ~PlatformTest() = default;
 };


### PR DESCRIPTION
Without the CMake flag `-DLLVM_BUILD_TESTS=ON` unittests are not automatically build and run with the `check-all` target. Due to that changes in the PI API names have not been applied to the PI unittests.

This PR adapts PI API name changes to the PI unittests and fixes a compiler warning in two different commits (both signed).