### PR TITLE
[SYCL] Add FPGA Command line support for Windows

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3131,9 +3131,6 @@ class OffloadingActionBuilder final {
     /// The linker inputs obtained for each toolchain.
     SmallVector<ActionList, 8> DeviceLinkerInputs;
 
-    /// Host object list
-    ActionList HostObjectList;
-
     /// The compiler inputs obtained for each toolchain
     Action * DeviceCompilerInput = nullptr;
 
@@ -3146,7 +3143,7 @@ class OffloadingActionBuilder final {
     unsigned FPGArCount = 0;
 
     /// Type of output file for FPGA device compilation.
-    types::ID FPGAOutType = types::TY_Image;
+    types::ID FPGAOutType = types::TY_FPGA_AOCX;
 
   public:
     SYCLActionBuilder(Compilation &C, DerivedArgList &Args,
@@ -3191,51 +3188,15 @@ class OffloadingActionBuilder final {
         // for each device and link them together to a single binary that will
         // be used in a split compilation step.
         if (CompileDeviceOnly && !SYCLDeviceActions.empty()) {
-          bool SYCLAOTCompile = false;
-          unsigned I = 0;
-          for (auto SDA : SYCLDeviceActions) {
+          for (auto SDA : SYCLDeviceActions)
             SYCLLinkBinaryList.push_back(SDA);
-            auto TT = SYCLTripleList[I];
-            if (TT.getSubArch() == llvm::Triple::SPIRSubArch_fpga ||
-                TT.getSubArch() == llvm::Triple::SPIRSubArch_gen)
-              SYCLAOTCompile = true;
-            I++;
-          }
-          if (WrapDeviceOnlyBinary && !SYCLAOTCompile) {
+          if (WrapDeviceOnlyBinary) {
             auto *DeviceLinkAction =
               C.MakeAction<LinkJobAction>(SYCLLinkBinaryList, types::TY_Image);
             // Wrap the binary when -fsycl-link is given
             SYCLLinkBinary =
                 C.MakeAction<OffloadWrappingJobAction>(DeviceLinkAction,
                                                        types::TY_Object);
-          } else if (SYCLAOTCompile) {
-            // All inputs have corresponding dependency files when built with
-            // -fintelfpga.  Gather those here.
-            auto *LinkAction = C.MakeAction<LinkJobAction>(SYCLLinkBinaryList,
-                                                           types::TY_SPIRV);
-            // Do the additional Ahead of Time compilation when the specific
-            // triple calls for it (provided a valid subarch).
-            auto *DeviceBECompileAction =
-                C.MakeAction<BackendCompileJobAction>(LinkAction, FPGAOutType);
-
-            // When performing -fsycl-link with FPGA, we will take the
-            // generated device binary and bundle that with all of the host
-            // objects (partially linked together).
-            if (!HostObjectList.empty()) {
-              // Bundling job only takes a single host and target object, so
-              // perform the partial link and send that into the bundler
-              auto *PartialLinkAction =
-                  C.MakeAction<LinkJobAction>(HostObjectList,
-                                              types::TY_Object);
-              // Add the host action to the list in order to create the
-              // bundling action.
-              ActionList OffloadAL;
-              OffloadAL.push_back(DeviceBECompileAction);
-              OffloadAL.push_back(PartialLinkAction);
-
-              SYCLLinkBinary =
-                  C.MakeAction<OffloadBundlingJobAction>(OffloadAL);
-            }
           } else
             SYCLLinkBinary = C.MakeAction<LinkJobAction>(SYCLLinkBinaryList,
                                                          types::TY_Image);
@@ -3303,11 +3264,6 @@ class OffloadingActionBuilder final {
           if (IA->getType() == types::TY_Object ||
               IA->getType() == types::TY_FPGA_AOCX ||
               IA->getType() == types::TY_FPGA_AOCR) {
-            OffloadingActionBuilder OffloadBuilder(C, Args, Inputs);
-            if (Args.hasArg(options::OPT_fsycl_link_EQ)) {
-              HostObjectList.push_back(
-                C.MakeAction<InputAction>(IA->getInputArg(), types::TY_Object));
-            }
             // Keep track of the number of FPGA devices encountered
             // Only one of these is allowed at a single time.
             if (IA->getType() == types::TY_FPGA_AOCX)
@@ -3379,12 +3335,15 @@ class OffloadingActionBuilder final {
           // Perform a check for device kernels.  This is done for FPGA when an
           // aocx or aocr based file is found.
           if (FPGAxCount || FPGArCount) {
+            ActionList DeviceObjects;
             for (const auto &I : LI) {
               if (I->getType() == types::TY_Object) {
-                auto *DeviceCheckAction =
-                    C.MakeAction<SPIRCheckJobAction>(I, types::TY_Image);
-                DA.add(*DeviceCheckAction, **TC, /*BoundArch=*/nullptr,
-                       Action::OFK_SYCL);
+                // FIXME - Checker does not work well inline with the tool
+                // chain, but it needs to be here for real time checking
+                //auto *DeviceCheckAction =
+                    //C.MakeAction<SPIRCheckJobAction>(I, types::TY_Object);
+                //DeviceObjects.push_back(DeviceCheckAction);
+                DeviceObjects.push_back(I);
               } else {
                 // Do not perform a device link and only pass the aocr
                 // file to the offline compilation before wrapping.  Just
@@ -3392,7 +3351,7 @@ class OffloadingActionBuilder final {
                 Action * DeviceWrappingAction;
                 if (I->getType() == types::TY_FPGA_AOCR) {
                   auto *DeviceBECompileAction =
-                    C.MakeAction<BackendCompileJobAction>(I, types::TY_Image);
+                    C.MakeAction<BackendCompileJobAction>(I, FPGAOutType);
                   DeviceWrappingAction =
                     C.MakeAction<OffloadWrappingJobAction>(
                                 DeviceBECompileAction, types::TY_Object);
@@ -3402,6 +3361,17 @@ class OffloadingActionBuilder final {
                 DA.add(*DeviceWrappingAction, **TC, /*BoundArch=*/nullptr,
                        Action::OFK_SYCL);
               }
+            }
+            if (!DeviceObjects.empty()) {
+              // link and wrap the device binary, but do not perform the
+              // backend compile.
+              auto *DeviceLinkAction =
+                    C.MakeAction<LinkJobAction>(DeviceObjects, types::TY_SPIRV);
+              auto *DeviceWrappingAction =
+                  C.MakeAction<OffloadWrappingJobAction>(DeviceLinkAction,
+                                                         types::TY_Object);
+              DA.add(*DeviceWrappingAction, **TC, /*BoundArch=*/nullptr,
+                     Action::OFK_SYCL);
             }
             continue;
           }
@@ -3417,7 +3387,7 @@ class OffloadingActionBuilder final {
           if (SYCLAOTCompile) {
             types::ID OutType = types::TY_Image;
             if (TT.getSubArch() == llvm::Triple::SPIRSubArch_fpga)
-              OutType = types::TY_FPGA_AOCX;
+              OutType = FPGAOutType;
             // Do the additional Ahead of Time compilation when the specific
             // triple calls for it (provided a valid subarch).
             auto *DeviceBECompileAction =
@@ -3474,10 +3444,10 @@ class OffloadingActionBuilder final {
       Arg *SYCLLinkTargets = Args.getLastArg(
                                   options::OPT_fsycl_link_targets_EQ);
       WrapDeviceOnlyBinary = Args.hasArg(options::OPT_fsycl_link_EQ);
-      CompileDeviceOnly = (SYCLLinkTargets &&
-                           SYCLLinkTargets->getOption().matches(
-                              options::OPT_fsycl_link_targets_EQ)) ||
-                          WrapDeviceOnlyBinary;
+      // Device only compilation for -fsycl-link (no FPGA) and
+      // -fsycl-link-targets
+      CompileDeviceOnly = (SYCLLinkTargets || (WrapDeviceOnlyBinary &&
+                                      !Args.hasArg(options::OPT_fintelfpga)));
       Arg *SYCLAddTargets = Args.getLastArg(
                                   options::OPT_fsycl_add_targets_EQ);
       if (SYCLAddTargets) {
@@ -3687,12 +3657,13 @@ public:
 
     // Checking uses -check-section option with the input file, no output
     // file and the target triple being looked for.
-    const char *Targets = C.getArgs().MakeArgString(Twine("-targets=fpga-") +
+    const char *Targets = C.getArgs().MakeArgString(Twine("-targets=sycl-") +
                           TT.str());
     const char *Inputs = C.getArgs().MakeArgString(Twine("-inputs=") +
                          Object);
-    // Always use -type=o for aocx/aocr bundle checking.
-    const char *Type = C.getArgs().MakeArgString("-type=o");
+    // Always use -type=ao for aocx/aocr bundle checking.  The 'bundles' are
+    // actually archives.
+    const char *Type = C.getArgs().MakeArgString("-type=ao");
     std::vector<StringRef> BundlerArgs = { "clang-offload-bundler",
                                            Type,
                                            Targets,
@@ -3715,8 +3686,6 @@ public:
         else
           llvm::errs() << A << " ";
       llvm::errs() << '\n';
-      if (OutputOnly)
-        return false;
     }
     if (BundlerBinary.getError())
       return false;
@@ -3764,19 +3733,22 @@ public:
               types::TY_Object &&
             Args.hasArg(options::OPT_foffload_static_lib_EQ))) {
         ActionList HostActionList;
+        Action * A(HostAction);
         // Only check for FPGA device information when using fpga SubArch.
         if (Args.hasArg(options::OPT_fintelfpga) &&
-            HasFPGADeviceBinary(C, InputArg->getAsString(Args), true)) {
-          Action * FPGAAction =
-            C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCX);
-          HostActionList.push_back(FPGAAction);
-        } else if (Args.hasArg(options::OPT_fintelfpga) &&
-            HasFPGADeviceBinary(C, InputArg->getAsString(Args))) {
-          Action * FPGAAction =
-            C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCR);
-          HostActionList.push_back(FPGAAction);
-        } else
-          HostActionList.push_back(HostAction);
+            HostAction->getType() != types::TY_FPGA_AOCR &&
+            HostAction->getType() != types::TY_FPGA_AOCX &&
+            !(HostAction->getType() == types::TY_Object &&
+              llvm::sys::path::has_extension(InputName) &&
+              types::lookupTypeForExtension(
+               llvm::sys::path::extension(InputName).drop_front()) ==
+               types::TY_Object)) {
+          if (HasFPGADeviceBinary(C, InputArg->getAsString(Args), true))
+            A = C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCX);
+          else if (HasFPGADeviceBinary(C, InputArg->getAsString(Args)))
+            A = C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCR);
+        }
+        HostActionList.push_back(A);
         if (!HostActionList.empty()) {
           auto UnbundlingHostAction =
             C.MakeAction<OffloadUnbundlingJobAction>(HostActionList);
@@ -4230,10 +4202,35 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
           Current, InputArg, phases::Link, FinalPhase, PL);
     }
   }
+  // For an FPGA archive, we add the unbundling step above to take care of
+  // the device side, but also unbundle here to extract the host side
+  for (const auto &LI : LinkerInputs) {
+    Action *UnbundlerInput = nullptr;
+    if (auto *IA = dyn_cast<InputAction>(LI)) {
+      if (IA->getType() == types::TY_FPGA_AOCR ||
+          IA->getType() == types::TY_FPGA_AOCX) {
+        // Add to unbundler.
+        UnbundlerInput = LI;
+      }
+    }
+    if (UnbundlerInput) {
+      if (auto *IA = dyn_cast<InputAction>(UnbundlerInput)) {
+        std::string FileName = IA->getInputArg().getAsString(Args);
+        Arg *InputArg = MakeInputArg(Args, *Opts, FileName);
+        OffloadBuilder.addHostDependenceToDeviceActions(UnbundlerInput,
+                                                        InputArg, Args);
+        OffloadBuilder.addDeviceDependencesToHostAction(UnbundlerInput,
+                InputArg, phases::Link, FinalPhase, PL);
+      }
+    }
+  }
 
   // Add a link action if necessary.
   if (!LinkerInputs.empty()) {
-    Action *LA = C.MakeAction<LinkJobAction>(LinkerInputs, types::TY_Image);
+    types::ID LinkType(types::TY_Image);
+    if (Args.hasArg(options::OPT_fsycl_link_EQ))
+      LinkType = types::TY_Archive;
+    Action *LA = C.MakeAction<LinkJobAction>(LinkerInputs, LinkType);
     LA = OffloadBuilder.processHostLinkAction(LA);
     Actions.push_back(LA);
   }
@@ -5011,17 +5008,33 @@ InputInfo Driver::BuildJobsForActionNoCache(
                         C.addTempFile(C.getArgs().MakeArgString(TmpFileName),
                                       types::TY_Tempfilelist);
         CurI = InputInfo(types::TY_Tempfilelist, TmpFile, TmpFile);
-      } else if (UI.DependentOffloadKind == Action::OFK_Host &&
-             EffectiveTriple.getSubArch() == llvm::Triple::SPIRSubArch_fpga &&
-             (JA->getType() == types::TY_FPGA_AOCX ||
-              JA->getType() == types::TY_FPGA_AOCR)) {
-        // Output file from unbundle is FPGA device. Name the file accordingly.
+      } else if (JA->getType() == types::TY_FPGA_AOCX ||
+                 JA->getType() == types::TY_FPGA_AOCR) {
+        std::string Ext(types::getTypeTempSuffix(JA->getType()));
+        types::ID TI = types::TY_Object;
+        if (EffectiveTriple.getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
+          // Output file from unbundle is FPGA device. Name the file
+          // accordingly.
+          if (UI.DependentOffloadKind == Action::OFK_Host) {
+            // Do not add the current info for Host with FPGA device.  The host
+            // side isn't used
+            continue;
+          }
+        } else if (EffectiveTriple.getSubArch() !=
+                                         llvm::Triple::SPIRSubArch_fpga) {
+          if (UI.DependentOffloadKind == Action::OFK_SYCL) {
+            // Do not add the current info for device with FPGA device.  The
+            // device side isn't used
+            continue;
+          }
+          TI = types::TY_Tempfilelist;
+          Ext = "txt";
+        }
         std::string TmpFileName =
-           C.getDriver().GetTemporaryPath(llvm::sys::path::stem(BaseInput),
-                                          "o");
+          C.getDriver().GetTemporaryPath(llvm::sys::path::stem(BaseInput), Ext);
         const char *TmpFile =
                         C.addTempFile(C.getArgs().MakeArgString(TmpFileName));
-        CurI = InputInfo(types::TY_Object, TmpFile, TmpFile);
+        CurI = InputInfo(TI, TmpFile, TmpFile);
       } else {
         std::string OffloadingPrefix = Action::GetOffloadingFileNamePrefix(
           UI.DependentOffloadKind,

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -160,6 +160,14 @@ void tools::AddLinkerInputs(const ToolChain &TC, const InputInfoList &Inputs,
       // Don't try to pass LLVM inputs unless we have native support.
       D.Diag(diag::err_drv_no_linker_llvm_support) << TC.getTripleString();
 
+    if (II.getType() == types::TY_Tempfilelist) {
+      // Take the list file and pass it in with '@'.
+      std::string FileName(II.getFilename());
+      const char * ArgFile = Args.MakeArgString("@" + FileName);
+      CmdArgs.push_back(ArgFile);
+      continue;
+    }
+
     // Add filenames immediately.
     if (II.isFilename()) {
       CmdArgs.push_back(II.getFilename());

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -341,6 +341,32 @@ static bool getStatic(const ArgList &Args) {
       !Args.hasArg(options::OPT_static_pie);
 }
 
+// Create an archive with llvm-ar.  This is used to create an archive that
+// contains host objects and the wrapped FPGA device binary
+void tools::gnutools::Linker::constructLLVMARCommand(Compilation &C,
+    const JobAction &JA, const InputInfo &Output, const InputInfoList &Input,
+    const ArgList &Args) const {
+  ArgStringList CmdArgs;
+  CmdArgs.push_back("cr");
+  CmdArgs.push_back(Output.getFilename());
+  for (const auto &II : Input) {
+    if (II.getType() == types::TY_Tempfilelist) {
+      // Take the list file and pass it in with '@'.
+      std::string FileName(II.getFilename());
+      const char * ArgFile = Args.MakeArgString("@" + FileName);
+      CmdArgs.push_back(ArgFile);
+      continue;
+    }
+    if (II.isFilename())
+      CmdArgs.push_back(II.getFilename());
+  }
+
+  SmallString<128> LLVMARPath(C.getDriver().Dir);
+  llvm::sys::path::append(LLVMARPath, "llvm-ar");
+  const char *Exec = C.getArgs().MakeArgString(LLVMARPath);
+  C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, None));
+}
+
 void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                            const InputInfo &Output,
                                            const InputInfoList &Inputs,
@@ -362,6 +388,12 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       ToolChain.getTriple().hasEnvironment() ||
       (ToolChain.getTriple().getVendor() != llvm::Triple::MipsTechnologies);
 
+  // Use of -fsycl-link creates an archive.
+  if (Args.hasArg(options::OPT_fsycl_link_EQ) &&
+      JA.getType() == types::TY_Archive) {
+    constructLLVMARCommand(C, JA, Output, Inputs, Args);
+    return;
+  }
   ArgStringList CmdArgs;
 
   // Silence warning for "clang -g foo.o -o foo"

--- a/clang/lib/Driver/ToolChains/Gnu.h
+++ b/clang/lib/Driver/ToolChains/Gnu.h
@@ -70,6 +70,12 @@ public:
                     const InputInfo &Output, const InputInfoList &Inputs,
                     const llvm::opt::ArgList &TCArgs,
                     const char *LinkingOutput) const override;
+private:
+  void constructLLVMARCommand(Compilation &C, const JobAction &JA,
+                              const InputInfo &Output,
+                              const InputInfoList &InputFiles,
+                              const llvm::opt::ArgList &Args) const;
+
 };
 } // end namespace gnutools
 

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -303,12 +303,43 @@ static std::string FindVisualStudioExecutable(const ToolChain &TC,
   return llvm::sys::fs::can_execute(FilePath) ? FilePath.str() : Exe;
 }
 
+// Add a call to lib.exe to create an archive.  This is used to embed host
+// objects into the bundled fat FPGA device binary.
+void visualstudio::Linker::constructMSVCLibCommand(Compilation &C,
+    const JobAction &JA, const InputInfo &Output, const InputInfoList &Input,
+    const ArgList &Args) const {
+  ArgStringList CmdArgs;
+  for (const auto &II : Input) {
+    if (II.getType() == types::TY_Tempfilelist) {
+      // Take the list file and pass it in with '@'.
+      std::string FileName(II.getFilename());
+      const char * ArgFile = Args.MakeArgString("@" + FileName);
+      CmdArgs.push_back(ArgFile);
+      continue;
+    }
+    CmdArgs.push_back(II.getFilename());
+  }
+  CmdArgs.push_back(C.getArgs().MakeArgString(Twine("-OUT:") +
+                    Output.getFilename()));
+
+  SmallString<128> ExecPath(getToolChain().GetProgramPath("lib"));
+  const char *Exec = C.getArgs().MakeArgString(ExecPath);
+  C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, None));
+}
+
 void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                         const InputInfo &Output,
                                         const InputInfoList &Inputs,
                                         const ArgList &Args,
                                         const char *LinkingOutput) const {
   ArgStringList CmdArgs;
+
+  // Create a library with -fsycl-link
+  if (Args.hasArg(options::OPT_fsycl_link_EQ) &&
+      JA.getType() == types::TY_Archive) {
+    constructMSVCLibCommand(C, JA, Output, Inputs, Args);
+    return;
+  }
 
   auto &TC = static_cast<const toolchains::MSVCToolChain &>(getToolChain());
 
@@ -454,6 +485,13 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   // Add filenames, libraries, and other linker inputs.
   for (const auto &Input : Inputs) {
     if (Input.isFilename()) {
+      if (Input.getType() == types::TY_Tempfilelist) {
+        // Take the list file and pass it in with '@'.
+        std::string FileName(Input.getFilename());
+        const char * ArgFile = Args.MakeArgString("@" + FileName);
+        CmdArgs.push_back(ArgFile);
+        continue;
+      }
       CmdArgs.push_back(Input.getFilename());
       continue;
     }

--- a/clang/lib/Driver/ToolChains/MSVC.h
+++ b/clang/lib/Driver/ToolChains/MSVC.h
@@ -34,6 +34,11 @@ public:
                     const InputInfo &Output, const InputInfoList &Inputs,
                     const llvm::opt::ArgList &TCArgs,
                     const char *LinkingOutput) const override;
+private:
+  void constructMSVCLibCommand(Compilation &C, const JobAction &JA,
+                               const InputInfo &Output,
+                               const InputInfoList &InputFiles,
+                               const llvm::opt::ArgList &Args) const;
 };
 
 class LLVM_LIBRARY_VISIBILITY Compiler : public Tool {

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -109,21 +109,6 @@ void SYCL::Linker::constructLlcCommand(Compilation &C, const JobAction &JA,
   C.addCommand(llvm::make_unique<Command>(JA, *this, Llc, LlcArgs, None));
 }
 
-void SYCL::Linker::constructPartialLinkCommand(Compilation &C,
-    const JobAction &JA, const InputInfo &Output, const InputInfoList &Input,
-    const ArgList &Args) const {
-  ArgStringList CmdArgs;
-  CmdArgs.push_back("-r");
-  for (const auto &II : Input)
-    CmdArgs.push_back(II.getFilename());
-  CmdArgs.push_back("-o");
-  CmdArgs.push_back(Output.getFilename());
-
-  SmallString<128> ExecPath(getToolChain().GetLinkerPath());
-  const char *Exec = C.getArgs().MakeArgString(ExecPath);
-  C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, None));
-}
-
 // For SYCL the inputs of the linker job are SPIR-V binaries and output is
 // a single SPIR-V binary.  Input can also be bitcode when specified by
 // the user.
@@ -141,12 +126,6 @@ void SYCL::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Prefix for temporary file name.
   std::string Prefix = llvm::sys::path::stem(SubArchName);
-
-  // Object type, we are performing a partial link
-  if (JA.getType() == types::TY_Object) {
-    constructPartialLinkCommand(C, JA, Output, Inputs, Args);
-    return;
-  }
 
   // We want to use llvm-spirv linker to link spirv binaries before putting
   // them into the fat object.
@@ -290,6 +269,9 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
   assert((getToolChain().getTriple().getArch() == llvm::Triple::spir ||
           getToolChain().getTriple().getArch() == llvm::Triple::spir64) &&
          "Unsupported target");
+  assert((JA.getType() == types::TY_FPGA_AOCX ||
+          JA.getType() == types::TY_FPGA_AOCR) && "aoc type required");
+
   ArgStringList CmdArgs{"-o",  Output.getFilename()};
   for (const auto &II : Inputs) {
     CmdArgs.push_back(II.getFilename());
@@ -321,24 +303,22 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
 
   // Add any dependency files.
   if (!FPGADepFiles.empty()) {
-    SmallString<128> DepOpt("-input-dep-files=");
+    SmallString<128> DepOpt("-dep-files=");
     for (unsigned I = 0; I < FPGADepFiles.size(); ++I) {
       if (I)
         DepOpt += ',';
       DepOpt += FPGADepFiles[I].getFilename();
     }
-    // FIXME: -input-dep-files is not hooked up yet in aoc, turn this back
-    // on when aoc is ready.
-    // CmdArgs.push_back(C.getArgs().MakeArgString(DepOpt));
+    CmdArgs.push_back(C.getArgs().MakeArgString(DepOpt));
   }
 
   // Depending on output file designations, set the report folder
-  SmallString<128> ReportOpt("-output-report-folder=");
+  SmallString<128> ReportOptArg;
   if (Arg *FinalOutput = Args.getLastArg(options::OPT_o)) {
     SmallString<128> FN(FinalOutput->getValue());
     llvm::sys::path::replace_extension(FN, "prj");
     const char * FolderName = Args.MakeArgString(FN);
-    ReportOpt += FolderName;
+    ReportOptArg += FolderName;
   } else {
     // Output directory is based off of the first object name
     for (Arg * Cur : Args) {
@@ -350,15 +330,15 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
           continue;
         if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
           llvm::sys::path::replace_extension(AN, "prj");
-          ReportOpt += Args.MakeArgString(AN);
+          ReportOptArg += Args.MakeArgString(AN);
           break;
         }
       }
     }
   }
-  // FIXME: -output-report-folder is not hooked up yet in aoc, turn this back
-  // on when aoc is ready.
-  // CmdArgs.push_back(C.getArgs().MakeArgString(ReportOpt));
+  if (!ReportOptArg.empty())
+    CmdArgs.push_back(C.getArgs().MakeArgString(Twine("-output-report-folder=")
+                                                      + ReportOptArg));
   TranslateSYCLTargetArgs(C, Args, getToolChain(), CmdArgs);
   // Look for -reuse-exe=XX option
   if (Arg *A = Args.getLastArg(options::OPT_reuse_exe_EQ)) {

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -56,10 +56,6 @@ private:
   void constructLlcCommand(Compilation &C, const JobAction &JA,
                            const InputInfo &Output,
                            const char *InputFile) const;
-  void constructPartialLinkCommand(Compilation &C, const JobAction &JA,
-                                   const InputInfo &Output,
-                                   const InputInfoList &InputFiles,
-                                   const llvm::opt::ArgList &Args) const;
 };
 
 /// Directly call FPGA Compiler and Linker

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -17,32 +17,58 @@
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-LINK,CHK-FPGA-EARLY %s
 // RUN:  %clang++ -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga -fsycl-link=image %t.o 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-LINK,CHK-FPGA-IMAGE %s
-// CHK-FPGA-LINK: clang-offload-bundler{{.*}} "-type=o" "-targets=fpga-fpga_aocx-intel-{{.*}}-sycldevice" "-inputs=[[INPUT:.+\.o]]" "-check-section"
-// CHK-FPGA-LINK: clang-offload-bundler{{.*}} "-type=o" "-targets=fpga-fpga_aocr-intel-{{.*}}-sycldevice" "-inputs=[[INPUT]]" "-check-section"
-// CHK-FPGA-LINK: clang-offload-bundler{{.*}} "-type=o" "-targets=host-x86_64-unknown-linux-gnu,sycl-spir64_fpga-unknown-{{.*}}-sycldevice" "-inputs=[[INPUT]]" "-outputs=[[OUTPUT1:.+\.o]],[[OUTPUT2:.+\.o]]" "-unbundle"
+// CHK-FPGA-LINK-NOT: clang-offload-bundler{{.*}} "-check-section"
+// CHK-FPGA-LINK: clang-offload-bundler{{.*}} "-type=o" "-targets=host-x86_64-unknown-linux-gnu,sycl-spir64_fpga-unknown-{{.*}}-sycldevice" "-inputs=[[INPUT:.+\.o]]" "-outputs=[[OUTPUT1:.+\.o]],[[OUTPUT2:.+\.o]]" "-unbundle"
 // CHK-FPGA-LINK: llvm-link{{.*}} "[[OUTPUT2]]" "-o" "[[OUTPUT3:.+\.bc]]"
 // CHK-FPGA-LINK: llvm-spirv{{.*}} "-spirv-max-version=1.1" "-spirv-ext=+all" "-o" "[[OUTPUT4:.+\.spv]]" "[[OUTPUT3]]"
 // CHK-FPGA-EARLY: aoc{{.*}} "-o" "[[OUTPUT5:.+\.aocr]]" "[[OUTPUT4]]" "-sycl" "-rtl"
 // CHK-FPGA-IMAGE: aoc{{.*}} "-o" "[[OUTPUT5:.+\.aocx]]" "[[OUTPUT4]]" "-sycl"
-// CHK-FPGA-LINK: ld{{.*}} "-r" "[[INPUT]]" "-o" "[[OUTPUT6:.+\.o]]"
-// CHK-FPGA-EARLY: clang-offload-bundler{{.*}} "-type=o" "-targets=fpga-fpga_aocr-intel-{{.*}}-sycldevice,host-x86_64-unknown-linux-gnu" "-outputs={{.*}}" "-inputs=[[OUTPUT5]],[[OUTPUT6]]"
-// CHK-FPGA-IMAGE: clang-offload-bundler{{.*}} "-type=o" "-targets=fpga-fpga_aocx-intel-{{.*}}-sycldevice,host-x86_64-unknown-linux-gnu" "-outputs={{.*}}" "-inputs=[[OUTPUT5]],[[OUTPUT6]]"
+// CHK-FPGA-LINK: {{lib|llvm-ar}}{{.*}}
 
-/// Check Phases with -fintelfpga -fsycl-link
-// RUN:  touch %t.o
-// RUN:  %clang++ -### -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -fintelfpga -fsycl-link=image %t.o 2>&1 \
-// RUN:  | FileCheck -check-prefixes=CHK-FPGA-LINK-PHASES,CHK-FPGA-LINK-PHASES-IMAGE %s
-// RUN:  %clang++ -### -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -fintelfpga -fsycl-link=early %t.o 2>&1 \
-// RUN:  | FileCheck -check-prefixes=CHK-FPGA-LINK-PHASES,CHK-FPGA-LINK-PHASES-EARLY %s
-// CHK-FPGA-LINK-PHASES: 0: input, "[[INPUT:.+\.o]]", object
-// CHK-FPGA-LINK-PHASES: 1: clang-offload-unbundler, {0}, object
-// CHK-FPGA-LINK-PHASES: 2: linker, {1}, spirv, (device-sycl)
-// CHK-FPGA-LINK-PHASES-IMAGE: 3: backend-compiler, {2}, fpga-aocx, (device-sycl)
-// CHK-FPGA-LINK-PHASES-EARLY: 3: backend-compiler, {2}, fpga-aocr, (device-sycl)
-// CHK-FPGA-LINK-PHASES: 4: input, "[[INPUT]]", object, (device-sycl)
-// CHK-FPGA-LINK-PHASES: 5: linker, {4}, object, (device-sycl)
-// CHK-FPGA-LINK-PHASES: 6: clang-offload-bundler, {3, 5}, object, (device-sycl)
-// CHK-FPGA-LINK-PHASES: 7: offload, "device-sycl (spir64_fpga-unknown-{{.*}}-sycldevice)" {6}, object
+/// Check -fintelfpga -fsycl-link with an FPGA archive
+// Create the dummy archive
+// RUN:  echo "Dummy AOCR image" > %t.aocr
+// RUN:  echo "void foo() {}" > %t.c
+// RUN:  %clang -c %t.c
+// RUN:  clang-offload-wrapper -o %t-aocr.bc -host=x86_64-unknown-linux-gnu -kind=sycl -target=fpga_aocr-intel-linux-sycldevice %t.aocr
+// RUN:  llc -filetype=obj -o %t-aocr.o %t-aocr.bc
+// RUN:  llvm-ar crv %t.a %t.o %t-aocr.o
+// RUN:  %clang++ -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga -fsycl-link=image %t.a 2>&1 \
+// RUN:  | FileCheck -check-prefixes=CHK-FPGA-LINK-LIB,CHK-FPGA-LINK-LIB-IMAGE %s
+// RUN:  %clang++ -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga -fsycl-link=early %t.a 2>&1 \
+// RUN:  | FileCheck -check-prefixes=CHK-FPGA-LINK-LIB,CHK-FPGA-LINK-LIB-EARLY %s
+// CHK-FPGA-LINK-LIB: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-{{linux|windows}}-sycldevice" "-inputs=[[INPUT:.+\.a]]" "-check-section"
+// CHK-FPGA-LINK-LIB: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocr-intel-{{linux|windows}}-sycldevice" "-inputs=[[INPUT]]" "-check-section"
+// CHK-FPGA-LINK-LIB: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocr-intel-{{linux|windows}}-sycldevice" "-inputs=[[INPUT]]" "-outputs=[[OUTPUT2:.+\.aocr]]" "-unbundle"
+// CHK-FPGA-LINK-LIB-IMAGE: aoc{{.*}} "-o" "[[OUTPUT3:.+\.aocx]]" "[[OUTPUT2]]" "-sycl"
+// CHK-FPGA-LINK-LIB-EARLY: aoc{{.*}} "-o" "[[OUTPUT4:.+\.aocr]]" "[[OUTPUT2]]" "-sycl" "-rtl"
+// CHK-FPGA-LINK-LIB-IMAGE: clang-offload-wrapper{{.*}} "-host=x86_64-unknown-linux-gnu" "-target=fpga_aocx-intel-{{linux|windows}}-sycldevice" "-kind=sycl" "[[OUTPUT3]]"
+// CHK-FPGA-LINK-LIB-EARLY: clang-offload-wrapper{{.*}} "-host=x86_64-unknown-linux-gnu" "-target=fpga_aocr-intel-{{linux|windows}}-sycldevice" "-kind=sycl" "[[OUTPUT4]]"
+// CHK-FPGA-LINK-LIB: llc{{.*}} "-filetype=obj" "-o" "[[OUTPUT5:.+\.o]]"
+// CHK-FPGA-LINK-LIB: clang-offload-bundler{{.*}} "-type=aoo" "-targets=host-x86_64-unknown-linux-gnu" "-inputs=[[INPUT]]" "-outputs=[[OUTPUT1:.+\.txt]]" "-unbundle"
+// CHK-FPGA-LINK-LIB: llvm-ar{{.*}} "cr" {{.*}} "@[[OUTPUT1]]"
+
+/// -fintelfpga -fsycl-link from source
+// RUN: touch %t.cpp
+// RUN: %clang++ -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga -fsycl-link=early %t.cpp -ccc-print-phases 2>&1 \
+// RUN:  | FileCheck -check-prefixes=CHK-FPGA-LINK-SRC %s
+// CHK-FPGA-LINK-SRC: 0: input, "[[INPUT:.+\.cpp]]", c++, (host-sycl)
+// CHK-FPGA-LINK-SRC: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
+// CHK-FPGA-LINK-SRC: 2: input, "[[INPUT]]", c++, (device-sycl)
+// CHK-FPGA-LINK-SRC: 3: preprocessor, {2}, c++-cpp-output, (device-sycl)
+// CHK-FPGA-LINK-SRC: 4: compiler, {3}, sycl-header, (device-sycl)
+// CHK-FPGA-LINK-SRC: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_fpga-unknown-{{linux|windows}}-sycldevice)" {4}, c++-cpp-output
+// CHK-FPGA-LINK-SRC: 6: compiler, {5}, ir, (host-sycl)
+// CHK-FPGA-LINK-SRC: 7: backend, {6}, assembler, (host-sycl)
+// CHK-FPGA-LINK-SRC: 8: assembler, {7}, object, (host-sycl)
+// CHK-FPGA-LINK-SRC: 9: linker, {8}, archive, (host-sycl)
+// CHK-FPGA-LINK-SRC: 10: compiler, {3}, ir, (device-sycl)
+// CHK-FPGA-LINK-SRC: 11: backend, {10}, assembler, (device-sycl)
+// CHK-FPGA-LINK-SRC: 12: assembler, {11}, object, (device-sycl)
+// CHK-FPGA-LINK-SRC: 13: linker, {12}, spirv, (device-sycl)
+// CHK-FPGA-LINK-SRC: 14: backend-compiler, {13}, fpga-aocr, (device-sycl)
+// CHK-FPGA-LINK-SRC: 15: clang-offload-wrapper, {14}, object, (device-sycl)
+// CHK-FPGA-LINK-SRC: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64_fpga-unknown-{{linux|windows}}-sycldevice)" {15}, archive
 
 // -fintelfpga -reuse-exe tests
 // RUN: %clang++ -### -fsycl -fintelfpga %s -reuse-exe=does_not_exist 2>&1 \


### PR DESCRIPTION
Allows for FPGA CLI modifications to work on Windows, by enabling the use
of archives/libraries instead of partially linked objects.  This also impacts
the Linux side of the implementation to use archives instead of objects.

Adds support for -fsycl-link from source, which before required a 2 step
compilation to object then to FPGA device generation

Enable additional aoc options for dep input and output report
Allow for link on Windows to use tempfile list args

When unbundling with an aocr/aocx archive, be sure any additional objects
are linked and wrapped before passed to the final link

Modify -fintelfpga unbundling of FPGA archives to do single host and single
target unbundles

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>