### PR TITLE
[SYCL][NFC] Move an item class check to right place.

### DIFF
--- a/sycl/test/basic_tests/item.cpp
+++ b/sycl/test/basic_tests/item.cpp
@@ -107,5 +107,9 @@ int main() {
   cl::sycl::item<3, true> three_dim_check =
       Builder::createItem<3, true>({4, 8, 16}, {2, 4, 8}, {0, 0, 0});
   assert((three_dim_transformed == three_dim_check));
+
+  using value_type = decltype(std::declval<cl::sycl::item<1>>()[0]);
+  static_assert(!std::is_reference<value_type>::value,
+                "Expected a non-reference type");
 }
 

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -121,8 +121,4 @@ int main() {
   CHECK_SIZE_VEC(s::cl_ulong);
   CHECK_SIZE_VEC(s::cl_float);
   CHECK_SIZE_VEC(s::cl_double);
-
-  using value_type = decltype(std::declval<cl::sycl::item<1>>()[0]);
-  static_assert(!std::is_reference<value_type>::value,
-                "Expected a non-reference type");
 }


### PR DESCRIPTION
Moved the check of class item from the test file 'types.cpp'
into the test file 'item.cpp'.

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>