### PR TITLE
[SYCL][FPGA] Fix address space in generation of global Intel FPGA ann…

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2231,13 +2231,14 @@ llvm::Constant *CodeGenModule::EmitAnnotateAttr(llvm::GlobalValue *GV,
                  *UnitGV = EmitAnnotationUnit(L),
                  *LineNoCst = EmitAnnotationLineNo(L);
 
+  llvm::Type *ResType = llvm::PointerType::getInt8PtrTy(
+      this->getLLVMContext(), GV->getType()->getPointerAddressSpace());
+  llvm::Constant *C =
+      llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, ResType);
   // Create the ConstantStruct for the global annotation.
   llvm::Constant *Fields[4] = {
-    llvm::ConstantExpr::getBitCast(GV, Int8PtrTy),
-    llvm::ConstantExpr::getBitCast(AnnoGV, Int8PtrTy),
-    llvm::ConstantExpr::getBitCast(UnitGV, Int8PtrTy),
-    LineNoCst
-  };
+      C, llvm::ConstantExpr::getBitCast(AnnoGV, Int8PtrTy),
+      llvm::ConstantExpr::getBitCast(UnitGV, Int8PtrTy), LineNoCst};
   return llvm::ConstantStruct::getAnon(Fields);
 }
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2233,12 +2233,13 @@ llvm::Constant *CodeGenModule::EmitAnnotateAttr(llvm::GlobalValue *GV,
 
   llvm::Type *ResType = llvm::PointerType::getInt8PtrTy(
       this->getLLVMContext(), GV->getType()->getPointerAddressSpace());
-  llvm::Constant *C =
-      llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, ResType);
+
   // Create the ConstantStruct for the global annotation.
   llvm::Constant *Fields[4] = {
-      C, llvm::ConstantExpr::getBitCast(AnnoGV, Int8PtrTy),
-      llvm::ConstantExpr::getBitCast(UnitGV, Int8PtrTy), LineNoCst};
+      llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, ResType),
+      llvm::ConstantExpr::getBitCast(AnnoGV, Int8PtrTy),
+      llvm::ConstantExpr::getBitCast(UnitGV, Int8PtrTy),
+      LineNoCst};
   return llvm::ConstantStruct::getAnon(Fields);
 }
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3867,8 +3867,11 @@ void CodeGenModule::addGlobalIntelFPGAAnnotation(const VarDecl *VD,
                    *UnitGV = EmitAnnotationUnit(VD->getLocation()),
                    *LineNoCst = EmitAnnotationLineNo(VD->getLocation());
 
+    llvm::Type *ResType = llvm::PointerType::getInt8PtrTy(
+        this->getLLVMContext(), GV->getType()->getPointerAddressSpace());
     llvm::Constant *C =
-        llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, Int8PtrTy);
+        llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, ResType);
+
     // Create the ConstantStruct for the global annotation.
     llvm::Constant *Fields[4] = {
         C, llvm::ConstantExpr::getBitCast(AnnoGV, Int8PtrTy),

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -17,7 +17,9 @@
 //CHECK: [[ANN9:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{max_private_copies:4}
 
 //CHECK: @llvm.global.annotations
-//CHECK-SAME: a_one{{.*}}[[ANN1]]{{.*}}i32 148
+//CHECK-SAME: @_ZZ3quxiE5a_one
+//CHECK-NOT: to i8*
+//CHECK-SAME: [[ANN1]]{{.*}}i32 150
 
 void foo() {
   //CHECK: %[[VAR_ONE:[0-9]+]] = bitcast{{.*}}var_one
@@ -145,7 +147,7 @@ void baz() {
 }
 
 void qux(int a) {
-  static int a_one [[intelfpga::numbanks(2)]];
+  static int a_one [[intelfpga::numbanks(4)]];
   //CHECK: load{{.*}}a_one
   //CHECK: store{{.*}}a_one
   a_one = a_one + a;

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -18,12 +18,10 @@
 //CHECK: [[ANN16:@.str.[0-9]*]] = {{.*}}foobar
 
 //CHECK: @llvm.global.annotations
-//CHECK-SAME: @_ZZ3quxiE5a_one
-//CHECK-NOT: to i8*
-//CHECK-SAME: [[ANN1]]{{.*}}i32 154
-//CHECK-SAME: @_ZZ3quxiE5b_two
-//CHECK-NOT: to i8*
-//CHECK-SAME: [[ANN16]]{{.*}}i32 158
+//CHECK-SAME: { i8 addrspace(1)* bitcast (i32 addrspace(1)* @_ZZ3quxiE5a_one to i8 addrspace(1)*)
+//CHECK-SAME: [[ANN1]]{{.*}}i32 152
+//CHECK-SAME: { i8 addrspace(1)* bitcast (i32 addrspace(1)* @_ZZ3quxiE5b_two to i8 addrspace(1)*)
+//CHECK-SAME: [[ANN16]]{{.*}}i32 156
 
 void foo() {
   //CHECK: %[[VAR_ONE:[0-9]+]] = bitcast{{.*}}var_one

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -15,11 +15,15 @@
 //CHECK: [[ANN7:@.str[\.]*[0-9]*]] = {{.*}}{memory:MLAB}
 //CHECK: [[ANN8:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{bankwidth:8}
 //CHECK: [[ANN9:@.str[\.]*[0-9]*]] = {{.*}}{memory:DEFAULT}{max_private_copies:4}
+//CHECK: [[ANN16:@.str.[0-9]*]] = {{.*}}foobar
 
 //CHECK: @llvm.global.annotations
 //CHECK-SAME: @_ZZ3quxiE5a_one
 //CHECK-NOT: to i8*
-//CHECK-SAME: [[ANN1]]{{.*}}i32 150
+//CHECK-SAME: [[ANN1]]{{.*}}i32 154
+//CHECK-SAME: @_ZZ3quxiE5b_two
+//CHECK-NOT: to i8*
+//CHECK-SAME: [[ANN16]]{{.*}}i32 158
 
 void foo() {
   //CHECK: %[[VAR_ONE:[0-9]+]] = bitcast{{.*}}var_one
@@ -151,6 +155,10 @@ void qux(int a) {
   //CHECK: load{{.*}}a_one
   //CHECK: store{{.*}}a_one
   a_one = a_one + a;
+  static int b_two [[clang::annotate("foobar")]];
+  //CHECK: load{{.*}}b_two
+  //CHECK: store{{.*}}b_two
+  b_two = b_two + a;
 }
 
 void field_addrspace_cast() {


### PR DESCRIPTION
…otation

Invalid bitcast with different address spaces was emmitted as a first argument
of Annotations element. This problem caused assertion fail.

Signed-off-by: Viktoria Maksimova <viktoria.maksimova@intel.com>