### PR TITLE
[SYCL] Add possibility to switch off tests for CPU/GPU on Windows

### DIFF
--- a/sycl/test/basic_tests/stream.cpp
+++ b/sycl/test/basic_tests/stream.cpp
@@ -1,10 +1,9 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out | FileCheck %s
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
-// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_ON_LINUX_PLACEHOLDER %t.out %GPU_CHECK_ON_LINUX_PLACEHOLDER
 // RUN: %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
 // TODO: SYCL specific fail - analyze and enable
-// XFAIL: windows
 //==------------------ stream.cpp - SYCL stream basic test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/hier_par/hier_par_basic.cpp
+++ b/sycl/test/hier_par/hier_par_basic.cpp
@@ -8,11 +8,10 @@
 
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// TODO: SYCL specific fail - analyze and enable on Windows
+// RUN: %CPU_RUN_ON_LINUX_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_ON_LINUX_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// TODO: SYCL specific fail - analyze and enable
-// XFAIL: windows
 
 // This test checks hierarchical parallelism invocation APIs, but without any
 // data or code with side-effects between the work group and work item scopes.

--- a/sycl/test/hier_par/hier_par_wgscope.cpp
+++ b/sycl/test/hier_par/hier_par_wgscope.cpp
@@ -8,11 +8,10 @@
 
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// TODO: SYCL specific fail - analyze and enable on Windows
+// RUN: %CPU_RUN_ON_LINUX_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_ON_LINUX_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// TODO: SYCL specific fail - analyze and enable
-// XFAIL: windows
 
 // This test checks correctness of hierarchical kernel execution when there is
 // code and data in the work group scope.

--- a/sycl/test/lit.cfg
+++ b/sycl/test/lit.cfg
@@ -89,24 +89,38 @@ def getDeviceCount(device_type):
 
 
 cpu_run_substitute = "echo"
+cpu_run_on_linux_substitute = "echo "
 cpu_check_substitute = ""
+cpu_check_on_linux_substitute = ""
 if getDeviceCount("cpu"):
     print("Found available CPU device")
     cpu_run_substitute = "env SYCL_DEVICE_TYPE=CPU "
     cpu_check_substitute = "| FileCheck %s"
     config.available_features.add('cpu')
+    if platform.system() == "Linux":
+        cpu_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=CPU "
+        cpu_check_on_linux_substitute = "| FileCheck %s"
 config.substitutions.append( ('%CPU_RUN_PLACEHOLDER',  cpu_run_substitute) )
+config.substitutions.append( ('%CPU_RUN_ON_LINUX_PLACEHOLDER',  cpu_run_on_linux_substitute) )
 config.substitutions.append( ('%CPU_CHECK_PLACEHOLDER',  cpu_check_substitute) )
+config.substitutions.append( ('%CPU_CHECK_ON_LINUX_PLACEHOLDER',  cpu_check_on_linux_substitute) )
 
 gpu_run_substitute = "echo"
+gpu_run_on_linux_substitute = "echo "
 gpu_check_substitute = ""
+gpu_check_on_linux_substitute = ""
 if getDeviceCount("gpu"):
     print("Found available GPU device")
     gpu_run_substitute = " env SYCL_DEVICE_TYPE=GPU "
     gpu_check_substitute = "| FileCheck %s"
     config.available_features.add('gpu')
+    if platform.system() == "Linux":
+        gpu_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=GPU "
+        gpu_check_on_linux_substitute = "| FileCheck %s"
 config.substitutions.append( ('%GPU_RUN_PLACEHOLDER',  gpu_run_substitute) )
+config.substitutions.append( ('%GPU_RUN_ON_LINUX_PLACEHOLDER',  gpu_run_on_linux_substitute) )
 config.substitutions.append( ('%GPU_CHECK_PLACEHOLDER',  gpu_check_substitute) )
+config.substitutions.append( ('%GPU_CHECK_ON_LINUX_PLACEHOLDER',  gpu_check_on_linux_substitute) )
 
 acc_run_substitute = "echo"
 acc_check_substitute = ""


### PR DESCRIPTION
Currently it is possible to switch test off on Windows only for all
devices. Added possiblity to disable lit tests on Windows for specific
device. This could be helpful to track regressions.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>