### PR TITLE
[SYCL] Add run_on_host_intel method to handler.

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.def
+++ b/sycl/include/CL/sycl/detail/pi.def
@@ -78,6 +78,7 @@ _PI_API(piSamplerRetain)
 _PI_API(piSamplerRelease)
 // Queue commands
 _PI_API(piEnqueueKernelLaunch)
+_PI_API(piEnqueueNativeKernel)
 _PI_API(piEnqueueEventsWait)
 _PI_API(piEnqueueMemBufferRead)
 _PI_API(piEnqueueMemBufferReadRect)

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -691,6 +691,18 @@ pi_result piEnqueueKernelLaunch(
   const pi_event *  event_wait_list,
   pi_event *        event);
 
+pi_result piEnqueueNativeKernel(
+  pi_queue         queue,
+  void             (*user_func)(void *),
+  void *           args,
+  size_t           cb_args,
+  pi_uint32        num_mem_objects,
+  const pi_mem *   mem_list,
+  const void **    args_mem_loc,
+  pi_uint32        num_events_in_wait_list,
+  const pi_event * event_wait_list,
+  pi_event *       event);
+
 pi_result piEnqueueEventsWait(
   pi_queue          command_queue,
   pi_uint32         num_events_in_wait_list,

--- a/sycl/source/detail/pi_opencl.cpp
+++ b/sycl/source/detail/pi_opencl.cpp
@@ -310,6 +310,7 @@ _PI_CL(piSamplerRetain,         clRetainSampler)
 _PI_CL(piSamplerRelease,        clReleaseSampler)
 // Queue commands
 _PI_CL(piEnqueueKernelLaunch,        clEnqueueNDRangeKernel)
+_PI_CL(piEnqueueNativeKernel,        clEnqueueNativeKernel)
 _PI_CL(piEnqueueEventsWait,          clEnqueueMarkerWithWaitList)
 _PI_CL(piEnqueueMemBufferRead,       clEnqueueReadBuffer)
 _PI_CL(piEnqueueMemBufferReadRect,   clEnqueueReadBufferRect)

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -592,8 +592,8 @@ void Scheduler::GraphBuilder::markModifiedIfWrite(
 Command *
 Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
                                QueueImplPtr Queue) {
-  std::vector<Requirement *> Reqs = CommandGroup->getRequirements();
-  std::vector<detail::EventImplPtr> Events = CommandGroup->getEvents();
+  const std::vector<Requirement *> &Reqs = CommandGroup->MRequirements;
+  const std::vector<detail::EventImplPtr> &Events = CommandGroup->MEvents;
   std::unique_ptr<ExecCGCommand> NewCmd(
       new ExecCGCommand(std::move(CommandGroup), Queue));
   if (!NewCmd)

--- a/sycl/test/basic_tests/handler/run_on_host_intel.cpp
+++ b/sycl/test/basic_tests/handler/run_on_host_intel.cpp
@@ -1,0 +1,53 @@
+// RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+//==-- run_on_host_intel.cpp -----------------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CL/sycl/access/access.hpp"
+#include <CL/sycl.hpp>
+
+#include "../../helpers.hpp"
+
+using namespace cl;
+
+template <typename SrcAccType, typename DstAccType>
+void copyAndAdd(SrcAccType SrcAcc, DstAccType DstAcc, int Var) {
+  for (int I = 0; I < (int)DstAcc.get_count(); ++I)
+    DstAcc[I] = Var + SrcAcc[I];
+}
+
+int main() {
+  constexpr size_t BufSize = 4;
+  int data1[BufSize] = {-1, -1, -1, -1};
+  sycl::buffer<int, 1> SrcBuf(data1, sycl::range<1>{BufSize});
+  sycl::buffer<int, 1> DstBuf(sycl::range<1>{BufSize});
+
+  TestQueue Queue{sycl::default_selector{}};
+  Queue.submit([&](sycl::handler &CGH) {
+    auto SrcAcc = SrcBuf.get_access<sycl::access::mode::read>(CGH);
+    auto DstAcc = DstBuf.get_access<sycl::access::mode::write>(CGH);
+    const int Var = 43;
+
+    CGH.run_on_host_intel([=]() { copyAndAdd(SrcAcc, DstAcc, Var); });
+  });
+
+  auto DstAcc = DstBuf.template get_access<sycl::access::mode::read_write>();
+  const int Expected = 42;
+  for (int I = 0; I < DstAcc.get_count(); ++I)
+    if (DstAcc[I] != Expected) {
+      std::cerr << "Mismatch. Elem " << I << ". Expected: " << Expected
+                << ", Got: " << DstAcc[I] << std::endl;
+      return 1;
+    }
+
+  std::cout << "Success" << std::endl;
+
+  return 0;
+}

--- a/sycl/test/basic_tests/image_api.cpp
+++ b/sycl/test/basic_tests/image_api.cpp
@@ -130,7 +130,8 @@ int main() {
         std::move(Handler.MAccStorage), std::move(Handler.MSharedPtrStorage),
         std::move(Handler.MRequirements), /*DepsEvents*/ {},
         std::move(Handler.MArgs), std::move(Handler.MKernelName),
-        std::move(Handler.MOSModuleHandle), std::move(Handler.MStreamStorage)));
+        std::move(Handler.MOSModuleHandle), std::move(Handler.MStreamStorage),
+        d::CG::KERNEL));
 
     d::EventImplPtr Event = d::Scheduler::getInstance().addCG(
         std::move(CommandGroup), d::getSyclObjImpl(Queue));


### PR DESCRIPTION
run_on_host_intel allows inserting task which runs regular host code into a
SYCL DAG.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>