### PR TITLE
[SYCL][PI] Fix PI unittests and always build them

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -26,13 +26,14 @@ def do_configure(args):
                  "-DLLVM_EXTERNAL_PROJECTS=sycl;llvm-spirv",
                  "-DLLVM_EXTERNAL_SYCL_SOURCE_DIR={}".format(sycl_dir),
                  "-DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR={}".format(spirv_dir),
-                 "-DLLVM_ENABLE_PROJECTS=clang;llvm-spirv;sycl",
+                 "-DLLVM_ENABLE_PROJECTS=clang;sycl;llvm-spirv",
                  "-DOpenCL_INCLUDE_DIR={}".format(ocl_header_dir),
                  "-DOpenCL_LIBRARY={}".format(icd_loader_lib),
                  "-DLLVM_BUILD_TOOLS=OFF",
                  "-DSYCL_ENABLE_WERROR=ON",
                  "-DLLVM_ENABLE_ASSERTIONS=ON",
                  "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),
+                 "-DSYCL_INCLUDE_TESTS=ON", # Explicitly include all kinds of SYCL tests.
                  llvm_dir]
 
     print(cmake_cmd)

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -159,9 +159,23 @@ add_custom_target( sycl-toolchain
   COMMENT "Building SYCL compiler toolchain..."
 )
 
-add_subdirectory( test )
-add_subdirectory( unittests )
-add_subdirectory( tools )
+if (NOT DEFINED LLVM_INCLUDE_TESTS)
+  set(LLVM_INCLUDE_TESTS ON)
+endif()
+
+option(SYCL_INCLUDE_TESTS
+  "Generate build targets for the SYCL unit tests."
+  ${LLVM_INCLUDE_TESTS})
+
+add_subdirectory(tools)
+
+if(SYCL_INCLUDE_TESTS)
+  if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include/gtest/gtest.h)
+    add_subdirectory(unittests)
+    list(APPEND SYCL_TEST_DEPS SYCLUnitTests)
+  endif()
+  add_subdirectory(test)
+endif()
 
 # Package deploy support
 # Listed here are component names contributing the package

--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -4,22 +4,41 @@ set(LLVM_TOOLS_DIR "${LLVM_BINARY_DIR}/bin/")
 set(CLANG_IN_BUILD "${LLVM_BINARY_DIR}/bin/clang")
 set(CLANGXX_IN_BUILD "${LLVM_BINARY_DIR}/bin/clang++")
 
-set(SYCL_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
-set(SYCL_TESTS_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(SYCL_TESTS_BINARY_DIR ${SYCL_BINARY_DIR}/test)
+get_target_property(SYCL_BINARY_DIR sycl-toolchain BINARY_DIR)
+get_target_property(SYCL_SOURCE_DIR sycl-toolchain SOURCE_DIR)
+
+set(SYCL_INCLUDE "${dst_dir}")
 
 set(RT_TEST_ARGS ${RT_TEST_ARGS} "-v")
 
 configure_lit_site_cfg(
-  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
-  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
   MAIN_CONFIG
-  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+  )
+
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.cfg.py
+  )
+
+list(APPEND SYCL_TEST_DEPS
+  sycl-toolchain
+  FileCheck
+  get_device_count_by_type
+  llvm-config
   )
 
 add_lit_testsuite(check-sycl "Running the SYCL regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   ARGS ${RT_TEST_ARGS}
-  DEPENDS sycl-toolchain FileCheck get_device_count_by_type llvm-config
+  DEPENDS ${SYCL_TEST_DEPS}
   )
 set_target_properties(check-sycl PROPERTIES FOLDER "SYCL tests")
+
+add_lit_testsuites(SYCL ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS ${SYCL_TEST_DEPS}
+  )

--- a/sycl/test/Unit/lit.cfg.py
+++ b/sycl/test/Unit/lit.cfg.py
@@ -1,0 +1,59 @@
+# -*- Python -*-
+
+# Configuration file for the 'lit' test runner.
+
+import os
+import platform
+import subprocess
+
+import lit.formats
+import lit.util
+
+# name: The name of this test suite.
+config.name = 'SYCL-Unit'
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = []
+
+# test_source_root: The root path where tests are located.
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.sycl_obj_root, 'unittests')
+config.test_source_root = config.test_exec_root
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, 'Tests')
+
+# Propagate the temp directory. Windows requires this because it uses \Windows\
+# if none of these are present.
+if 'TMP' in os.environ:
+    config.environment['TMP'] = os.environ['TMP']
+if 'TEMP' in os.environ:
+    config.environment['TEMP'] = os.environ['TEMP']
+
+# Propagate path to symbolizer for ASan/MSan.
+for symbolizer in ['ASAN_SYMBOLIZER_PATH', 'MSAN_SYMBOLIZER_PATH']:
+    if symbolizer in os.environ:
+        config.environment[symbolizer] = os.environ[symbolizer]
+
+def find_shlibpath_var():
+    if platform.system() in ['Linux', 'FreeBSD', 'NetBSD', 'SunOS']:
+        yield 'LD_LIBRARY_PATH'
+    elif platform.system() == 'Darwin':
+        yield 'DYLD_LIBRARY_PATH'
+    elif platform.system() == 'Windows':
+        yield 'PATH'
+    elif platform.system() == 'AIX':
+        yield 'LIBPATH'
+
+for shlibpath_var in find_shlibpath_var():
+    # in stand-alone builds, shlibdir is clang's build tree
+    # while llvm_libs_dir is installed LLVM (and possibly older clang)
+    shlibpath = os.path.pathsep.join(
+        (config.shlibdir,
+         config.llvm_libs_dir,
+         config.environment.get(shlibpath_var, '')))
+    config.environment[shlibpath_var] = shlibpath
+    break
+else:
+    lit_config.warning("unable to inject shared library path on '{}'"
+                       .format(platform.system()))

--- a/sycl/test/Unit/lit.site.cfg.py.in
+++ b/sycl/test/Unit/lit.site.cfg.py.in
@@ -1,0 +1,29 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_libs_dir = "@LLVM_LIBS_DIR@"
+config.llvm_build_mode = "@LLVM_BUILD_MODE@"
+config.clang_obj_root = "@CLANG_BINARY_DIR@"
+config.enable_shared = @ENABLE_SHARED@
+config.shlibdir = "@SHLIBDIR@"
+config.target_triple = "@TARGET_TRIPLE@"
+config.sycl_obj_root = "@SYCL_BINARY_DIR@"
+
+# Support substitution of the tools_dir, libs_dirs, and build_mode with user
+# parameters. This is used when we can't determine the tool dir at
+# configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_libs_dir = config.llvm_libs_dir % lit_config.params
+    config.llvm_build_mode = config.llvm_build_mode % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@SYCL_SOURCE_DIR@/test/Unit/lit.cfg.py")

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -14,7 +14,7 @@ from lit.llvm import llvm_config
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = 'SYCLUnitTests'
+config.name = 'SYCL'
 
 # testFormat: The test format to use to interpret tests.
 #
@@ -31,7 +31,7 @@ config.excludes = ['CMakeLists.txt', 'run_tests.sh', 'README.txt']
 config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.sycl_dir, 'test')
+config.test_exec_root = os.path.join(config.sycl_obj_root, 'test')
 
 if platform.system() == "Linux":
     # Propagate 'LD_LIBRARY_PATH' through the environment.

--- a/sycl/test/lit.site.cfg.py.in
+++ b/sycl/test/lit.site.cfg.py.in
@@ -11,12 +11,11 @@ config.llvm_build_bins_dir = "@LLVM_BUILD_BINARY_DIRS@"
 config.llvm_binary_dir = "@LLVM_BINARY_DIR@"
 config.opencl_include = "@OPENCL_INCLUDE@"
 config.sycl_include = "@SYCL_INCLUDE@"
+config.sycl_obj_root = "@SYCL_BINARY_DIR@"
 
-config.sycl_tests_binary_dir = "@SYCL_TESTS_BINARY_DIR@"
-config.sycl_dir = "@SYCL_BINARY_DIR@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@SYCL_TESTS_ROOT_DIR@/lit.cfg")
+lit_config.load_config(config, "@SYCL_SOURCE_DIR@/test/lit.cfg.py")

--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -1,12 +1,29 @@
-add_custom_target(PiUnitTests)
-set_target_properties(PiUnitTests PROPERTIES FOLDER "Tests")
+add_custom_target(SYCLUnitTests)
+set_target_properties(SYCLUnitTests PROPERTIES FOLDER "SYCL tests")
 
-function(add_llvm_unittest test_dirname)
-  add_unittest(PiUnitTests ${test_dirname} ${ARGN})
-endfunction()
+# add_sycl_unittest(test_dirname file1.cpp, file2.cpp ...)
+#
+# Will compile the list of files together and link against SYCL.
+# Produces a binary names `basename(test_dirname)`.
+function(add_sycl_unittest test_dirname)
+  # Enable exception handling for these unit tests
+  set(LLVM_REQUIRES_EH 1)
 
-function(add_llvm_unittest_with_input_files test_dirname)
-  add_unittest_with_input_files(PiUnitTests ${test_dirname} ${ARGN})
+  add_unittest(SYCLUnitTests ${test_dirname} ${ARGN})
+  target_link_libraries(${test_dirname}
+    PRIVATE
+      sycl
+      LLVMTestingSupport
+      OpenCL-Headers
+    )
+  target_include_directories(${test_dirname} PRIVATE SYSTEM ${sycl_inc_dir})
+  # LLVM gtest uses LLVM utilities that require C++-14
+  # CXX_STANDARD_REQUIRED makes CXX_STANDARD a hard requirement.
+  set_target_properties(${test_dirname}
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED ON
+    )
 endfunction()
 
 add_subdirectory(pi)

--- a/sycl/unittests/pi/CMakeLists.txt
+++ b/sycl/unittests/pi/CMakeLists.txt
@@ -1,12 +1,5 @@
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Enable exception handling for these unit tests
-set(LLVM_REQUIRES_EH 1)
-add_llvm_unittest(PiTests
+add_sycl_unittest(PiTests
   PlatformTest.cpp
-)
-
-add_dependencies(PiTests sycl)
-target_link_libraries(PiTests PRIVATE sycl LLVMTestingSupport)
+  )

--- a/sycl/unittests/pi/PlatformTest.cpp
+++ b/sycl/unittests/pi/PlatformTest.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "CL/sycl/detail/pi.hpp"
 #include <CL/sycl.hpp>
+#include <CL/sycl/detail/pi.hpp>
 #include <gtest/gtest.h>
 #include <memory>
 


### PR DESCRIPTION
Enforce building of SYCL PI API unittests by default to catch build
problems due to CMake changes.

The PI API unittests use LLVM's `add_unittest` infrastructure which
only builds unittests if the CMake flag `LLVM_BUILD_TESTS` is `ON`.
The fix always sets this CMake variable locally when adding PI API
unittests.

This commit also contains other fixes required to build PI API
unittests again.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>