### PR TITLE
[SYCL][FPGA] Improve FPGA pipes testing

### DIFF
--- a/sycl/test/fpga_tests/fpga_pipes.cpp
+++ b/sycl/test/fpga_tests/fpga_pipes.cpp
@@ -10,171 +10,225 @@
 #include <CL/sycl.hpp>
 #include <iostream>
 
-// For pipes created with namespaces set
+// For simple non-blocking pipes with explicit type
+class some_nb_pipe;
+
+// For non-blocking pipes created with namespaces set
 namespace some {
-class pipe;
+class nb_pipe;
 }
 
-using namespace cl::sycl;
+// For non-blocking template pipes
+template<int N>
+class templ_nb_pipe;
 
-int main() {
+// For non-blocking multiple pipes
+template<int N>
+using PipeMulNb = cl::sycl::pipe<class templ_nb_pipe<N>, int>;
+
+// For simple blocking pipes with explicit type
+class some_bl_pipe;
+
+// For blocking pipes created with namespaces set
+namespace some {
+class bl_pipe;
+}
+
+// For blocking template pipes
+template<int N>
+class templ_bl_pipe;
+
+// For blocking multiple pipes
+template<int N>
+using PipeMulBl = cl::sycl::pipe<class templ_bl_pipe<N>, int>;
+
+// Kernel names
+template <int TestNumber, int KernelNumber = 0>
+class writer;
+template <int TestNumber, int KernelNumber = 0>
+class reader;
+
+// Test for simple non-blocking pipes
+template<typename PipeName, int TestNumber>
+int test_simple_nb_pipe(cl::sycl::queue Queue) {
   int data[] = {0};
 
-  {
-    // Test for non-blocking pipes
-    queue Queue;
-    using Pipe = pipe<class some_pipe, int, 1>;
+  using Pipe = cl::sycl::pipe<PipeName, int>;
 
-    Queue.submit([&](handler &cgh) {
-      cgh.single_task<class foo_nb>([=]() {
-        bool SuccessCode = false;
-        while (!SuccessCode)
-          Pipe::write(42, SuccessCode);
-      });
+  cl::sycl::buffer<int, 1> readBuf(data, 1);
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task<class writer<TestNumber>>([=]() {
+      bool SuccessCode = false;
+      do {
+        Pipe::write(42, SuccessCode);
+      } while (!SuccessCode);
     });
+  });
 
-    buffer<int, 1> writeBuf(data, 1);
-    Queue.submit([&](handler &cgh) {
-      auto write_acc = writeBuf.get_access<access::mode::write>(cgh);
+  cl::sycl::buffer<int, 1> writeBuf(data, 1);
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    auto write_acc = writeBuf.get_access<cl::sycl::access::mode::write>(cgh);
 
-      cgh.single_task<class goo_nb>([=]() {
-        bool SuccessCode = false;
-        while (!SuccessCode)
-          write_acc[0] = Pipe::read(SuccessCode);
-      });
+    cgh.single_task<class reader<TestNumber>>([=]() {
+      bool SuccessCode = false;
+      do {
+        write_acc[0] = Pipe::read(SuccessCode);
+      } while (!SuccessCode);
     });
+  });
 
-    auto readHostBuffer = writeBuf.get_access<access::mode::read>();
-    if (readHostBuffer[0] != 42) {
-      std::cout << "Result mismatches " << readHostBuffer[0] << " Vs expected "
-                << 42 << std::endl;
+  auto readHostBuffer = writeBuf.get_access<cl::sycl::access::mode::read>();
+  if (readHostBuffer[0] != 42) {
+    std::cout << "Test: " << TestNumber << "\nResult mismatches "
+              << readHostBuffer[0] << " Vs expected " << 42 << std::endl;
 
-      return -1;
-    }
-  }
-
-  {
-    // Test for simple non-blocking pipes with explicit type
-    queue Queue;
-
-    buffer<int, 1> readBuf(data, 1);
-    Queue.submit([&](handler &cgh) {
-      cgh.single_task<class boo_nb>([=]() {
-        bool SuccessCode;
-        while (!SuccessCode)
-          pipe<class some_pipe, int, 1>::write(42, SuccessCode);
-      });
-    });
-
-    buffer<int, 1> writeBuf(data, 1);
-    Queue.submit([&](handler &cgh) {
-      auto write_acc = writeBuf.get_access<access::mode::write>(cgh);
-
-      cgh.single_task<class zoo_nb>([=]() {
-        bool SuccessCode;
-        while (!SuccessCode)
-          write_acc[0] = pipe<class some_pipe, int, 1>::read(SuccessCode);
-      });
-    });
-
-    auto readHostBuffer = writeBuf.get_access<access::mode::read>();
-    if (readHostBuffer[0] != 42) {
-      std::cout << "Result mismatches " << readHostBuffer[0] << " Vs expected "
-                << 42 << std::endl;
-
-      return -1;
-    }
-  }
-
-  {
-    // Test for simple non-blocking pipes created with namespaces set
-    queue Queue;
-
-    buffer<int, 1> readBuf(data, 1);
-    Queue.submit([&](handler &cgh) {
-      cgh.single_task<class foo_ns>([=]() {
-        bool SuccessCode;
-        while (!SuccessCode)
-          pipe<class some::pipe, int, 1>::write(42, SuccessCode);
-      });
-    });
-
-    buffer<int, 1> writeBuf(data, 1);
-    Queue.submit([&](handler &cgh) {
-      auto write_acc = writeBuf.get_access<access::mode::write>(cgh);
-
-      cgh.single_task<class boo_ns>([=]() {
-        bool SuccessCode;
-        while (!SuccessCode)
-          write_acc[0] = pipe<class some::pipe, int, 1>::read(SuccessCode);
-      });
-    });
-
-    auto readHostBuffer = writeBuf.get_access<access::mode::read>();
-    if (readHostBuffer[0] != 42) {
-      std::cout << "Result mismatches " << readHostBuffer[0] << " Vs expected "
-                << 42 << std::endl;
-
-      return -1;
-    }
-  }
-
-  {
-    // Test for forward declared pipes
-    queue Queue;
-    class pipe_type_for_lambdas;
-
-    buffer<int, 1> readBuf(data, 1);
-    Queue.submit([&](handler &cgh) {
-      cgh.single_task<class foo_la>([=]() {
-        bool SuccessCode;
-        while (!SuccessCode)
-          pipe<class pipe_type_for_lambdas, int>::write(42, SuccessCode);
-      });
-    });
-
-    buffer<int, 1> writeBuf(data, 1);
-    Queue.submit([&](handler &cgh) {
-      cgh.single_task<class boo_la>([=]() {
-        bool SuccessCode;
-        while (!SuccessCode)
-          pipe<class pipe_type_for_lambdas, int>::read(SuccessCode);
-      });
-    });
-
-    auto readHostBuffer = writeBuf.get_access<access::mode::read>();
-    if (readHostBuffer[0] != 42) {
-      std::cout << "Result mismatches " << readHostBuffer[0] << " Vs expected "
-                << 42 << std::endl;
-
-      return -1;
-    }
-  }
-
-  {
-    // Test for blocking pipes
-    queue Queue;
-    using Pipe = pipe<class some_pipe, int, 1>;
-
-    Queue.submit([&](handler &cgh) {
-      cgh.single_task<class foo_b>([=]() { Pipe::write(42); });
-    });
-
-    buffer<int, 1> writeBuf(data, 1);
-    Queue.submit([&](handler &cgh) {
-      auto write_acc = writeBuf.get_access<access::mode::write>(cgh);
-
-      cgh.single_task<class goo_b>([=]() { write_acc[0] = Pipe::read(); });
-    });
-
-    auto readHostBuffer = writeBuf.get_access<access::mode::read>();
-    if (readHostBuffer[0] != 42) {
-      std::cout << "Result mismatches " << readHostBuffer[0] << " Vs expected "
-                << 42 << std::endl;
-
-      return -1;
-    }
+    return -1;
   }
 
   return 0;
+}
+
+// Test for multiple non-blocking pipes
+template<int TestNumber>
+int test_multiple_nb_pipe(cl::sycl::queue Queue) {
+  int data[] = {0};
+
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task<class writer<TestNumber, /*KernelNumber*/ 1>>([=]() {
+      bool SuccessCode = false;
+      do {
+        PipeMulNb<1>::write(19, SuccessCode);
+      } while (!SuccessCode);
+    });
+  });
+
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task<class writer<TestNumber, /*KernelNumber*/ 2>>([=]() {
+      bool SuccessCode = false;
+      do {
+        PipeMulNb<2>::write(23, SuccessCode);
+      } while (!SuccessCode);
+    });
+  });
+
+  cl::sycl::buffer<int, 1> writeBuf(data, 1);
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    auto write_acc = writeBuf.get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.single_task<class reader<TestNumber>>([=]() {
+      bool SuccessCodeA = false;
+      int Value = 0;
+      do {
+        Value = PipeMulNb<1>::read(SuccessCodeA);
+      } while (!SuccessCodeA);
+      write_acc[0] = Value;
+      bool SuccessCodeB = false;
+      do {
+        Value = PipeMulNb<2>::read(SuccessCodeB);
+      } while (!SuccessCodeB);
+      write_acc[0] += Value;
+    });
+  });
+
+  auto readHostBuffer = writeBuf.get_access<cl::sycl::access::mode::read>();
+  if (readHostBuffer[0] != 42) {
+    std::cout << "Test: " << TestNumber << "\nResult mismatches "
+              << readHostBuffer[0] << " Vs expected " << 42 << std::endl;
+
+    return -1;
+  }
+
+  return 0;
+}
+
+// Test for simple blocking pipes
+template<typename PipeName, int TestNumber>
+int test_simple_bl_pipe(cl::sycl::queue Queue) {
+  int data[] = {0};
+
+  using Pipe = cl::sycl::pipe<PipeName, int>;
+
+  cl::sycl::buffer<int, 1> readBuf(data, 1);
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task<class writer<TestNumber>>([=]() {
+      Pipe::write(42);
+    });
+  });
+
+  cl::sycl::buffer<int, 1> writeBuf(data, 1);
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    auto write_acc = writeBuf.get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.single_task<class reader<TestNumber>>([=]() {
+      write_acc[0] = Pipe::read();
+    });
+  });
+
+  auto readHostBuffer = writeBuf.get_access<cl::sycl::access::mode::read>();
+  if (readHostBuffer[0] != 42) {
+    std::cout << "Test: " << TestNumber << "\nResult mismatches "
+              << readHostBuffer[0] << " Vs expected " << 42 << std::endl;
+
+    return -1;
+  }
+
+  return 0;
+}
+
+// Test for multiple blocking pipes
+template<int TestNumber>
+int test_multiple_bl_pipe(cl::sycl::queue Queue) {
+  int data[] = {0};
+
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task<class writer<TestNumber, /*KernelNumber*/ 1>>([=]() {
+      PipeMulBl<1>::write(19);
+    });
+  });
+
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task<class writer<TestNumber, /*KernelNumber*/ 2>>([=]() {
+      PipeMulBl<2>::write(23);
+    });
+  });
+
+  cl::sycl::buffer<int, 1> writeBuf(data, 1);
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    auto write_acc = writeBuf.get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.single_task<class reader<TestNumber>>([=]() {
+      write_acc[0] = PipeMulBl<1>::read();
+      write_acc[0] += PipeMulBl<2>::read();
+    });
+  });
+
+  auto readHostBuffer = writeBuf.get_access<cl::sycl::access::mode::read>();
+  if (readHostBuffer[0] != 42) {
+    std::cout << "Test: " << TestNumber << "\nResult mismatches "
+              << readHostBuffer[0] << " Vs expected " << 42 << std::endl;
+
+    return -1;
+  }
+
+  return 0;
+}
+
+int main() {
+  cl::sycl::queue Queue;
+
+  // Non-blocking pipes
+  int Result = test_simple_nb_pipe<some_nb_pipe, /*test number*/ 1>(Queue);
+  Result &= test_simple_nb_pipe<some::nb_pipe, /*test number*/ 2>(Queue);
+  class forward_nb_pipe;
+  Result &= test_simple_nb_pipe<forward_nb_pipe, /*test number*/ 3>(Queue);
+  Result &= test_simple_nb_pipe<templ_nb_pipe<0>, /*test number*/ 4>(Queue);
+  Result &= test_multiple_nb_pipe</*test number*/ 5>(Queue);
+
+  // Blocking pipes
+  Result &= test_simple_bl_pipe<some_bl_pipe, /*test number*/ 6>(Queue);
+  Result &= test_simple_bl_pipe<some::bl_pipe, /*test number*/ 7>(Queue);
+  class forward_bl_pipe;
+  Result &= test_simple_bl_pipe<forward_bl_pipe, /*test number*/ 8>(Queue);
+  Result &= test_simple_bl_pipe<templ_bl_pipe<0>, /*test number*/ 9>(Queue);
+  Result &= test_multiple_bl_pipe</*test number*/ 10>(Queue);
+
+  return Result;
 }


### PR DESCRIPTION
The test itself was reworked. Also were added following cases:
1. SYCL pipe constructed from template type;
2. Multiple pipes call site;
3. Tests cases for non-blocking pipes were repeated for blocking as
   well.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>