### PR TITLE
[SYCL] Add float16 type (half) support to the collectives: broadcast,  reduce, inclusive_scan and exclusive_scan. Also the corresponding tests has been updated to reflect the change.

### DIFF
--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -226,6 +226,12 @@ template <typename T> struct LShift {
   }
 };
 
+// Add a specific is_arithmetic for SYCL types that include half FP type
+template <typename T>
+using is_arithmetic = std::integral_constant<bool,
+     std::is_arithmetic<T>::value ||
+     std::is_same<typename std::remove_const<T>::type, half>::value>;
+
 template <typename T>
 using is_floating_point =
     std::integral_constant<bool, std::is_floating_point<T>::value ||

--- a/sycl/test/sub_group/broadcast.cpp
+++ b/sycl/test/sub_group/broadcast.cpp
@@ -1,7 +1,8 @@
 // RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -D SG_GPU %s -o %t_gpu.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //==--------- broadcast.cpp - SYCL sub_group broadcast test ----*- C++ -*---==//
 //
@@ -66,6 +67,12 @@ int main() {
   check<long>(Queue);
   check<unsigned long>(Queue);
   check<float>(Queue);
+  // broadcast half type is not supported in OCL CPU RT
+#ifdef SG_GPU
+  if (Queue.get_device().has_extension("cl_khr_fp16")) {
+    check<cl::sycl::half>(Queue);
+  }
+#endif
   if (Queue.get_device().has_extension("cl_khr_fp64")) {
     check<double>(Queue);
   }

--- a/sycl/test/sub_group/reduce.cpp
+++ b/sycl/test/sub_group/reduce.cpp
@@ -1,7 +1,8 @@
 // RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -D SG_GPU %s -o %t_gpu.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //==--------------- reduce.cpp - SYCL sub_group reduce test ----*- C++ -*---==//
 //
@@ -40,7 +41,7 @@ template <typename T> void check(queue &Queue, size_t G = 240, size_t L = 60) {
     auto addacc = addbuf.template get_access<access::mode::read_write>();
     size_t sg_size = get_sg_size(Queue.get_device());
     int WGid = -1, SGid = 0;
-    T max = 0, add = 0;
+    int max = 0, add = 0;
     for (int j = 0; j < G; j++) {
       if (j % L % sg_size == 0) {
         SGid++;
@@ -75,6 +76,12 @@ int main() {
   check<long>(Queue);
   check<unsigned long>(Queue);
   check<float>(Queue);
+  // reduce half type is not supported in OCL CPU RT
+#ifdef SG_GPU
+  if (Queue.get_device().has_extension("cl_khr_fp16")) {
+    check<cl::sycl::half>(Queue);
+  }
+#endif
   if (Queue.get_device().has_extension("cl_khr_fp64")) {
     check<double>(Queue);
   }

--- a/sycl/test/sub_group/scan.cpp
+++ b/sycl/test/sub_group/scan.cpp
@@ -1,7 +1,8 @@
 // RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -D SG_GPU %s -o %t_gpu.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//
 //
@@ -16,7 +17,7 @@
 #include <limits>
 template <typename T> class sycl_subgr;
 using namespace cl::sycl;
-template <typename T> void check(queue &Queue, size_t G = 240, size_t L = 60) {
+template <typename T> void check(queue &Queue, size_t G = 120, size_t L = 60) {
   try {
     nd_range<1> NdRange(G, L);
     buffer<T> minexbuf(G);
@@ -63,7 +64,7 @@ template <typename T> void check(queue &Queue, size_t G = 240, size_t L = 60) {
 
     size_t sg_size = get_sg_size(Queue.get_device());
     int WGid = -1, SGid = 0;
-    T add = 0;
+    int add = 0;
     for (int j = 0; j < G; j++) {
       if (j % L % sg_size == 0) {
         SGid++;
@@ -102,6 +103,12 @@ int main() {
   check<long>(Queue);
   check<unsigned long>(Queue);
   check<float>(Queue);
+  // scan half type is not supported in OCL CPU RT
+#ifdef SG_GPU
+  if (Queue.get_device().has_extension("cl_khr_fp16")) {
+    check<cl::sycl::half>(Queue);
+  }
+#endif
   if (Queue.get_device().has_extension("cl_khr_fp64")) {
     check<double>(Queue);
   }


### PR DESCRIPTION
This PR adds a specific is_floating_point for SYCL that handle half type. Also, it changes the collectives to use the SYCL is_arithmetic rather than the std one.
Collective tests have been updated. there seems to be a bug in scan.cpp. This is being investigated.

Signed-off-by: Dounia <dounia.khaldi@intel.com>