### PR TITLE
[SYCL] Align aliases with SYCL specification.

### DIFF
--- a/sycl/include/CL/sycl/aliases.hpp
+++ b/sycl/include/CL/sycl/aliases.hpp
@@ -1,0 +1,111 @@
+//==----------- aliases.hpp --- SYCL type aliases --------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl/detail/common.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace cl {
+namespace sycl {
+template <typename T, int N> class vec;
+namespace detail {
+namespace half_impl {
+class half;
+} // namespace half_impl
+} // namespace detail
+} // namespace sycl
+} // namespace cl
+
+#ifdef __SYCL_DEVICE_ONLY__
+using half = _Float16;
+#else
+using half = cl::sycl::detail::half_impl::half;
+#endif
+
+#define MAKE_VECTOR_ALIAS(ALIAS, TYPE, N)                                      \
+  using ALIAS##N = cl::sycl::vec<TYPE, N>;
+
+#define MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                            \
+  MAKE_VECTOR_ALIAS(char, char, N)                                             \
+  MAKE_VECTOR_ALIAS(short, short, N)                                           \
+  MAKE_VECTOR_ALIAS(int, int, N)                                               \
+  MAKE_VECTOR_ALIAS(long, long, N)                                             \
+  MAKE_VECTOR_ALIAS(float, float, N)                                           \
+  MAKE_VECTOR_ALIAS(double, double, N)                                         \
+  MAKE_VECTOR_ALIAS(half, half, N)
+
+#define MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                                \
+  MAKE_VECTOR_ALIAS(cl_char, cl::sycl::cl_char, N)                             \
+  MAKE_VECTOR_ALIAS(cl_uchar, cl::sycl::cl_uchar, N)                           \
+  MAKE_VECTOR_ALIAS(cl_short, cl::sycl::cl_short, N)                           \
+  MAKE_VECTOR_ALIAS(cl_ushort, cl::sycl::cl_ushort, N)                         \
+  MAKE_VECTOR_ALIAS(cl_int, cl::sycl::cl_int, N)                               \
+  MAKE_VECTOR_ALIAS(cl_uint, cl::sycl::cl_uint, N)                             \
+  MAKE_VECTOR_ALIAS(cl_long, cl::sycl::cl_long, N)                             \
+  MAKE_VECTOR_ALIAS(cl_ulong, cl::sycl::cl_ulong, N)                           \
+  MAKE_VECTOR_ALIAS(cl_float, cl::sycl::cl_float, N)                           \
+  MAKE_VECTOR_ALIAS(cl_double, cl::sycl::cl_double, N)                         \
+  MAKE_VECTOR_ALIAS(cl_half, cl::sycl::cl_half, N)
+
+#define MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)                   \
+  MAKE_VECTOR_ALIAS(schar, signed char, N)                                     \
+  MAKE_VECTOR_ALIAS(uchar, unsigned char, N)                                   \
+  MAKE_VECTOR_ALIAS(ushort, unsigned short, N)                                 \
+  MAKE_VECTOR_ALIAS(uint, unsigned int, N)                                     \
+  MAKE_VECTOR_ALIAS(ulong, unsigned long, N)                                   \
+  MAKE_VECTOR_ALIAS(longlong, long long, N)                                    \
+  MAKE_VECTOR_ALIAS(ulonglong, unsigned long long, N)
+
+#define MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                               \
+  MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                                  \
+  MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                                      \
+  MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)
+
+namespace cl {
+namespace sycl {
+using byte = std::uint8_t;
+using schar = signed char;
+using uchar = unsigned char;
+using ushort = unsigned short;
+using uint = unsigned int;
+using ulong = unsigned long;
+using longlong = long long;
+using ulonglong = unsigned long long;
+using cl_bool = bool;
+using cl_char = std::int8_t;
+using cl_uchar = std::uint8_t;
+using cl_short = std::int16_t;
+using cl_ushort = std::uint16_t;
+using cl_int = std::int32_t;
+using cl_uint = std::uint32_t;
+using cl_long = std::int64_t;
+using cl_ulong = std::uint64_t;
+using cl_half = half;
+using cl_float = float;
+using cl_double = double;
+using cl_size_t = std::size_t;
+using cl_ptrdiff_t = std::ptrdiff_t;
+using cl_intptr_t = std::intptr_t;
+using cl_uintptr_t = std::uintptr_t;
+
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(2)
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(3)
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(4)
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(8)
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(16)
+} // namespace sycl
+} // namespace cl
+
+#undef MAKE_VECTOR_ALIAS
+#undef MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES
+#undef MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES
+#undef MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES
+#undef MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -160,7 +160,7 @@ using is_charn = typename is_contained<
 // scharn: schar2, schar3, schar4, schar8, schar16
 template <typename T>
 using is_scharn = typename is_contained<
-    T, type_list<cl_schar2, cl_schar3, cl_schar4, cl_schar8, cl_schar16>>::type;
+    T, type_list<schar2, schar3, schar4, schar8, schar16>>::type;
 
 // ucharn: uchar2, uchar3, uchar4, uchar8, uchar16
 template <typename T>
@@ -170,7 +170,7 @@ using is_ucharn = typename is_contained<
 // igenchar: signed char, scharn
 template <typename T>
 using is_igenchar =
-    std::integral_constant<bool, is_contained<T, type_list<cl_schar>>::value ||
+    std::integral_constant<bool, is_contained<T, type_list<schar>>::value ||
                                      is_scharn<T>::value>;
 
 // ugenchar: unsigned char, ucharn
@@ -313,7 +313,7 @@ using is_ugeninteger = std::integral_constant<
 // int
 template <typename T>
 using is_sgeninteger = typename is_contained<
-    T, type_list<cl_char, cl_schar, cl_uchar, cl_short, cl_ushort, cl_int,
+    T, type_list<cl_char, schar, cl_uchar, cl_short, cl_ushort, cl_int,
                  cl_uint, cl_long, cl_ulong, longlong, ulonglong>>::type;
 
 // vgeninteger: charn, scharn, ucharn, shortn, ushortn, intn, uintn, longn,
@@ -329,7 +329,7 @@ using is_vgeninteger = std::integral_constant<
 // sigeninteger: char, signed char, short, int, long int, , long long int
 template <typename T>
 using is_sigeninteger = typename is_contained<
-    T, type_list<cl_char, cl_schar, cl_short, cl_int, cl_long, longlong>>::type;
+    T, type_list<cl_char, schar, cl_short, cl_int, cl_long, longlong>>::type;
 
 // sugeninteger: unsigned char, unsigned short,  unsigned int, unsigned long
 // int, unsigned long long int

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -44,6 +44,7 @@
 #error "SYCL device compiler is built without ext_vector_type support"
 #endif // __HAS_EXT_VECTOR_TYPE__
 
+#include <CL/sycl/aliases.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/half_type.hpp>
@@ -89,41 +90,6 @@ struct elem {
   static constexpr int sE = 14;
   static constexpr int sF = 15;
 };
-
-/**
- * A signed 8-bit integer.
- */
-typedef signed char schar;
-
-/**
- * An unsigned 8-bit integer.
- */
-typedef unsigned char uchar;
-
-/**
- * An unsigned 16-bit integer.
- */
-typedef unsigned short ushort;
-
-/**
- * An unsigned 32-bit integer.
- */
-typedef unsigned int uint;
-
-/**
- * An unsigned 64-bit integer.
- */
-typedef unsigned long ulong;
-
-/**
- * An signed integer with width of at least 64-bit.
- */
-typedef long long longlong;
-
-/**
- * An unsigned integer with width of at least 64-bit.
- */
-typedef unsigned long long ulonglong;
 
 namespace detail {
 
@@ -456,7 +422,7 @@ public:
     *this = Rhs.template as<vec>();
     return *this;
   }
-  
+
 #ifdef __SYCL_USE_EXT_VECTOR_TYPE__
   template <typename T = void>
   using EnableIfNotHostHalf = typename std::enable_if<
@@ -524,9 +490,10 @@ public:
   // Helper type to make specific constructors available only for specific
   // number of elements.
   template <int IdxNum, typename T = void>
-  using EnableIfMultipleElems = typename std::enable_if<
-      std::is_convertible<T, DataT>::value && NumElements == IdxNum,
-      DataT>::type;
+  using EnableIfMultipleElems =
+      typename std::enable_if<std::is_convertible<T, DataT>::value &&
+                                  NumElements == IdxNum,
+                              DataT>::type;
   template <typename Ty = DataT>
   vec(const EnableIfMultipleElems<2, Ty> Arg0,
       const EnableIfNotHostHalf<Ty> Arg1)
@@ -626,10 +593,7 @@ private:
   // function would activate a bug in MSVC that is fixed only in v19.20.
   // Until then MSVC does not recognize such constexpr functions as const and
   // thus does not let using them in template parameters inside swizzle.def.
-  template <int Index>
-  struct Indexer {
-    static constexpr int value = Index;
-  };
+  template <int Index> struct Indexer { static constexpr int value = Index; };
 
 public:
 #ifdef __SYCL_ACCESS_RETURN
@@ -699,8 +663,8 @@ public:
     return *this;                                                              \
   }                                                                            \
   template <int Num = NumElements>                                             \
-  typename std::enable_if<Num != 1, vec &>::type                               \
-  operator OPASSIGN(const DataT &Rhs) {                                        \
+  typename std::enable_if<Num != 1, vec &>::type operator OPASSIGN(            \
+      const DataT &Rhs) {                                                      \
     *this = *this BINOP vec(Rhs);                                              \
     return *this;                                                              \
   }
@@ -836,8 +800,7 @@ public:
 // Use __SYCL_DEVICE_ONLY__ macro because cast to OpenCL vector type is defined
 // by SYCL device compiler only.
 #ifdef __SYCL_DEVICE_ONLY__
-    return vec{
-      (typename vec::DataType)~m_Data};
+    return vec{(typename vec::DataType) ~m_Data};
 #else
     vec Ret;
     for (size_t I = 0; I < NumElements; ++I) {
@@ -852,7 +815,7 @@ public:
 // by SYCL device compiler only.
 #ifdef __SYCL_DEVICE_ONLY__
     return vec<rel_t, NumElements>{
-      (typename vec<rel_t, NumElements>::DataType)!m_Data};
+        (typename vec<rel_t, NumElements>::DataType) !m_Data};
 #else
     vec<rel_t, NumElements> Ret;
     for (size_t I = 0; I < NumElements; ++I) {
@@ -1178,8 +1141,7 @@ public:
 #undef __SYCL_UOP
 
   template <typename T = DataT>
-  typename std::enable_if<std::is_integral<T>::value, vec_t>::type
-  operator~() {
+  typename std::enable_if<std::is_integral<T>::value, vec_t>::type operator~() {
     vec_t Tmp = *this;
     return ~Tmp;
   }
@@ -1481,8 +1443,7 @@ private:
   // function would activate a bug in MSVC that is fixed only in v19.20.
   // Until then MSVC does not recognize such constexpr functions as const and
   // thus does not let using them in template parameters inside swizzle.def.
-  template <int Index>
-  struct Indexer {
+  template <int Index> struct Indexer {
     static constexpr int IDXs[sizeof...(Indexes)] = {Indexes...};
     static constexpr int value = IDXs[Index >= getNumElements() ? 0 : Index];
   };
@@ -1624,9 +1585,10 @@ private:
           (std::is_fundamental<T>::value ||                                    \
            std::is_same<typename std::remove_const<T>::type, half>::value),    \
       vec<T1, Num>>::type                                                      \
-  operator BINOP(const T &Lhs,                                                 \
-                 const detail::SwizzleOp<VecT, OperationLeftT, OperationRightT,\
-                                         OperationCurrentT, Indexes...> &Rhs) {\
+  operator BINOP(                                                              \
+      const T &Lhs,                                                            \
+      const detail::SwizzleOp<VecT, OperationLeftT, OperationRightT,           \
+                              OperationCurrentT, Indexes...> &Rhs) {           \
     vec<T1, Num> Tmp = Rhs;                                                    \
     return Lhs BINOP Tmp;                                                      \
   }                                                                            \
@@ -1708,92 +1670,65 @@ __SYCL_RELLOGOP(&&)
 __SYCL_RELLOGOP(||)
 #undef __SYCL_RELLOGOP
 
-using byte = uint8_t;
-using half = ::half;
-
-using cl_bool   = ::cl_bool;
-using cl_char   = ::cl_char;
-using cl_schar  = signed char;
-using cl_uchar  = ::cl_uchar;
-using cl_short  = ::cl_short;
-using cl_ushort = ::cl_ushort;
-using cl_int    = ::cl_int;
-using cl_uint   = ::cl_uint;
-using cl_long   = ::cl_long;
-using cl_ulong  = ::cl_ulong;
-using cl_half   = half;
-using cl_float  = ::cl_float;
-using cl_double = ::cl_double;
-
 } // namespace sycl
 } // namespace cl
 
-
 #ifdef __SYCL_USE_EXT_VECTOR_TYPE__
-#define DECLARE_TYPE_T(type)                           \
-using __##type##_t       = cl::sycl::cl_##type;        \
-using __##type##2_vec_t  = cl::sycl::cl_##type         \
-                 __attribute__((ext_vector_type(2)));  \
-using __##type##3_vec_t  = cl::sycl::cl_##type         \
-                 __attribute__((ext_vector_type(3)));  \
-using __##type##4_vec_t  = cl::sycl::cl_##type         \
-                 __attribute__((ext_vector_type(4)));  \
-using __##type##8_vec_t  = cl::sycl::cl_##type         \
-                 __attribute__((ext_vector_type(8)));  \
-using __##type##16_vec_t = cl::sycl::cl_##type         \
-                 __attribute__((ext_vector_type(16)));
+#define DECLARE_TYPE_VIA_CL_T(type)                                            \
+  using __##type##_t = cl::sycl::cl_##type;                                    \
+  using __##type##2_vec_t =                                                    \
+      cl::sycl::cl_##type __attribute__((ext_vector_type(2)));                 \
+  using __##type##3_vec_t =                                                    \
+      cl::sycl::cl_##type __attribute__((ext_vector_type(3)));                 \
+  using __##type##4_vec_t =                                                    \
+      cl::sycl::cl_##type __attribute__((ext_vector_type(4)));                 \
+  using __##type##8_vec_t =                                                    \
+      cl::sycl::cl_##type __attribute__((ext_vector_type(8)));                 \
+  using __##type##16_vec_t =                                                   \
+      cl::sycl::cl_##type __attribute__((ext_vector_type(16)));
 
-#define DECLARE_LLTYPE_T(type)                         \
-using __##type##_t       = cl::sycl::type;             \
-using __##type##2_vec_t  = cl::sycl::type              \
-                 __attribute__((ext_vector_type(2)));  \
-using __##type##3_vec_t  = cl::sycl::type              \
-                 __attribute__((ext_vector_type(3)));  \
-using __##type##4_vec_t  = cl::sycl::type              \
-                 __attribute__((ext_vector_type(4)));  \
-using __##type##8_vec_t  = cl::sycl::type              \
-                 __attribute__((ext_vector_type(8)));  \
-using __##type##16_vec_t = cl::sycl::type              \
-                 __attribute__((ext_vector_type(16)));
+#define DECLARE_TYPE_T(type)                                                   \
+  using __##type##_t = cl::sycl::type;                                         \
+  using __##type##2_vec_t =                                                    \
+      cl::sycl::type __attribute__((ext_vector_type(2)));                      \
+  using __##type##3_vec_t =                                                    \
+      cl::sycl::type __attribute__((ext_vector_type(3)));                      \
+  using __##type##4_vec_t =                                                    \
+      cl::sycl::type __attribute__((ext_vector_type(4)));                      \
+  using __##type##8_vec_t =                                                    \
+      cl::sycl::type __attribute__((ext_vector_type(8)));                      \
+  using __##type##16_vec_t =                                                   \
+      cl::sycl::type __attribute__((ext_vector_type(16)));
 
-DECLARE_TYPE_T(char);
+DECLARE_TYPE_VIA_CL_T(char);
 DECLARE_TYPE_T(schar);
-DECLARE_TYPE_T(uchar);
-DECLARE_TYPE_T(short);
-DECLARE_TYPE_T(ushort);
-DECLARE_TYPE_T(int);
-DECLARE_TYPE_T(uint);
-DECLARE_TYPE_T(long);
-DECLARE_TYPE_T(ulong);
-DECLARE_LLTYPE_T(longlong);
-DECLARE_LLTYPE_T(ulonglong);
-DECLARE_TYPE_T(float);
+DECLARE_TYPE_VIA_CL_T(uchar);
+DECLARE_TYPE_VIA_CL_T(short);
+DECLARE_TYPE_VIA_CL_T(ushort);
+DECLARE_TYPE_VIA_CL_T(int);
+DECLARE_TYPE_VIA_CL_T(uint);
+DECLARE_TYPE_VIA_CL_T(long);
+DECLARE_TYPE_VIA_CL_T(ulong);
+DECLARE_TYPE_T(longlong);
+DECLARE_TYPE_T(ulonglong);
+DECLARE_TYPE_VIA_CL_T(float);
 // Half type is defined as custom class for host and _Float16 for device.
 // The ext_vector_type attribute is only applicable to integral and float
 // scalars so it's not possible to use attribute ext_vector_type for half on
 // host.
 #ifdef __SYCL_DEVICE_ONLY__
-DECLARE_TYPE_T(half);
+DECLARE_TYPE_VIA_CL_T(half);
 #endif
-DECLARE_TYPE_T(double);
+DECLARE_TYPE_VIA_CL_T(double);
 
 #define GET_CL_TYPE(target, num) __##target##num##_vec_t
 #define GET_SCALAR_CL_TYPE(target) target
 
+#undef DECLARE_TYPE_VIA_CL_T
 #undef DECLARE_TYPE_T
-#undef DECLARE_LLTYPE_T
 #else // __SYCL_USE_EXT_VECTOR_TYPE__
-// For signed char. OpenCL doesn't have any type about `signed char`, therefore
-// we use type alias of cl_char instead.
-using cl_schar = cl_char;
-using cl_schar2 = cl_char2;
-using cl_schar3 = cl_char3;
-using cl_schar4 = cl_char4;
-using cl_schar8 = cl_char8;
-using cl_schar16 = cl_char16;
-
-#define GET_CL_TYPE(target, num) cl_##target##num
-#define GET_SCALAR_CL_TYPE(target) cl_##target
+#define GET_CL_TYPE(target, num) ::cl_##target##num
+#define GET_SCALAR_CL_TYPE(target) ::cl_##target
 #endif // __SYCL_USE_EXT_VECTOR_TYPE__
 
 // On the host side we cannot use OpenCL cl_half# types as an underlying type
@@ -1828,10 +1763,10 @@ using conditional_t = typename std::conditional<B, T1, T2>::type;
 // sizeof(IN).  expected to handle scalar types in IN.
 template <typename T, typename T8, typename T16, typename T32, typename T64>
 using select_apply_cl_t =
-  conditional_t<sizeof(T) == 1, T8,
-  conditional_t<sizeof(T) == 2, T16,
-  conditional_t<sizeof(T) == 4, T32, T64>>>;
-} // detail
+    conditional_t<sizeof(T) == 1, T8,
+                  conditional_t<sizeof(T) == 2, T16,
+                                conditional_t<sizeof(T) == 4, T32, T64>>>;
+} // namespace detail
 
 #define DECLARE_CONVERTER(base, num)                                           \
   template <> class BaseCLTypeConverter<base, num> {                           \
@@ -1842,36 +1777,51 @@ using select_apply_cl_t =
 #define DECLARE_SIGNED_INTEGRAL_CONVERTER(base, num)                           \
   template <> class BaseCLTypeConverter<base, num> {                           \
   public:                                                                      \
-    using DataType = detail::select_apply_cl_t<base, GET_CL_TYPE(schar, num),  \
-      GET_CL_TYPE(short, num), GET_CL_TYPE(int, num), GET_CL_TYPE(long, num)>; \
+    using DataType = detail::select_apply_cl_t<                                \
+        base, GET_CL_TYPE(char, num), GET_CL_TYPE(short, num),                 \
+        GET_CL_TYPE(int, num), GET_CL_TYPE(long, num)>;                        \
   };
 
 #define DECLARE_UNSIGNED_INTEGRAL_CONVERTER(base, num)                         \
   template <> class BaseCLTypeConverter<base, num> {                           \
   public:                                                                      \
-    using DataType = detail::select_apply_cl_t<base, GET_CL_TYPE(uchar, num),  \
-      GET_CL_TYPE(ushort, num), GET_CL_TYPE(uint, num),                        \
-      GET_CL_TYPE(ulong, num)>;                                                \
+    using DataType = detail::select_apply_cl_t<                                \
+        base, GET_CL_TYPE(uchar, num), GET_CL_TYPE(ushort, num),               \
+        GET_CL_TYPE(uint, num), GET_CL_TYPE(ulong, num)>;                      \
   };
 
 #define DECLARE_FLOAT_CONVERTER(base, num)                                     \
   template <> class BaseCLTypeConverter<base, num> {                           \
   public:                                                                      \
-    using DataType = detail::select_apply_cl_t<base, std::false_type,          \
-      GET_CL_HALF_TYPE(half, num), GET_CL_TYPE(float, num),                    \
-      GET_CL_TYPE(double, num)>;                                               \
+    using DataType = detail::select_apply_cl_t<                                \
+        base, std::false_type, GET_CL_HALF_TYPE(half, num),                    \
+        GET_CL_TYPE(float, num), GET_CL_TYPE(double, num)>;                    \
   };
 
 #define DECLARE_LONGLONG_CONVERTER(base, num)                                  \
   template <> class BaseCLTypeConverter<base##long, num> {                     \
   public:                                                                      \
-    using DataType = ::GET_CL_TYPE(base, num);                                 \
+    using DataType = GET_CL_TYPE(base, num);                                   \
+  };
+
+#define DECLARE_SCHAR_CONVERTER(num)                                           \
+  template <> class BaseCLTypeConverter<schar, num> {                          \
+  public:                                                                      \
+    using DataType = detail::select_apply_cl_t<                                \
+        schar, GET_CL_TYPE(char, num), GET_CL_TYPE(short, num),                \
+        GET_CL_TYPE(int, num), GET_CL_TYPE(long, num)>;                        \
   };
 
 #define DECLARE_HALF_CONVERTER(base, num)                                      \
   template <> class BaseCLTypeConverter<base, num> {                           \
   public:                                                                      \
     using DataType = GET_CL_HALF_TYPE(base, num);                              \
+  };
+
+#define DECLARE_SCALAR_SCHAR_CONVERTER                                         \
+  template <> class BaseCLTypeConverter<schar, 1> {                            \
+  public:                                                                      \
+    using DataType = schar;                                                    \
   };
 
 #define DECLARE_SCALAR_CONVERTER(base)                                         \
@@ -1920,7 +1870,6 @@ using select_apply_cl_t =
   DECLARE_SCALAR_CONVERTER(base)                                               \
   } // namespace detail
 
-
 #define DECLARE_HALF_VECTOR_CONVERTERS(base)                                   \
   namespace detail {                                                           \
   DECLARE_HALF_CONVERTER(base, 2)                                              \
@@ -1947,108 +1896,30 @@ using select_apply_cl_t =
   };                                                                           \
   } // namespace detail
 
-#define DECLARE_SYCL_VEC_WO_CONVERTERS(base)                                   \
-  using cl_##base##16 = vec<cl_##base, 16>;                                    \
-  using cl_##base##8 = vec<cl_##base, 8>;                                      \
-  using cl_##base##4 = vec<cl_##base, 4>;                                      \
-  using cl_##base##3 = vec<cl_##base, 3>;                                      \
-  using cl_##base##2 = vec<cl_##base, 2>;                                      \
-  using base##16 = cl_##base##16;                                              \
-  using base##8 = cl_##base##8;                                                \
-  using base##4 = cl_##base##4;                                                \
-  using base##3 = cl_##base##3;                                                \
-  using base##2 = cl_##base##2;
+#define DECLARE_SCHAR_VECTOR_CONVERTERS                                        \
+  namespace detail {                                                           \
+  DECLARE_SCHAR_CONVERTER(2)                                                   \
+  DECLARE_SCHAR_CONVERTER(3)                                                   \
+  DECLARE_SCHAR_CONVERTER(4)                                                   \
+  DECLARE_SCHAR_CONVERTER(8)                                                   \
+  DECLARE_SCHAR_CONVERTER(16)                                                  \
+  DECLARE_SCALAR_SCHAR_CONVERTER                                               \
+  } // namespace detail
 
-#define DECLARE_SYCL_VEC_CHAR_WO_CONVERTERS                                    \
-  using cl_char16 = vec<signed char, 16>;                                      \
-  using cl_char8 = vec<signed char, 8>;                                        \
-  using cl_char4 = vec<signed char, 4>;                                        \
-  using cl_char3 = vec<signed char, 3>;                                        \
-  using cl_char2 = vec<signed char, 2>;                                        \
-  using char16 = vec<char, 16>;                                                \
-  using char8 = vec<char, 8>;                                                  \
-  using char4 = vec<char, 4>;                                                  \
-  using char3 = vec<char, 3>;                                                  \
-  using char2 = vec<char, 2>;
-
-#define DECLARE_SYCL_VEC_HALF_WO_CONVERTERS                                    \
-  using cl_half16 = vec<half, 16>;                                             \
-  using cl_half8 = vec<half, 8>;                                               \
-  using cl_half4 = vec<half, 4>;                                               \
-  using cl_half3 = vec<half, 3>;                                               \
-  using cl_half2 = vec<half, 2>;                                               \
-  using half16 = vec<half, 16>;                                                \
-  using half8 = vec<half, 8>;                                                  \
-  using half4 = vec<half, 4>;                                                  \
-  using half3 = vec<half, 3>;                                                  \
-  using half2 = vec<half, 2>;
-
-#define DECLARE_SYCL_VEC_LONG_WO_CONVERTERS(base)                              \
-  using cl_##base##16 = vec<cl_##base, 16>;                                    \
-  using cl_##base##8 = vec<cl_##base, 8>;                                      \
-  using cl_##base##4 = vec<cl_##base, 4>;                                      \
-  using cl_##base##3 = vec<cl_##base, 3>;                                      \
-  using cl_##base##2 = vec<cl_##base, 2>;                                      \
-  using base##16 = vec<base, 16>;                                              \
-  using base##8 = vec<base, 8>;                                                \
-  using base##4 = vec<base, 4>;                                                \
-  using base##3 = vec<base, 3>;                                                \
-  using base##2 = vec<base, 2>;
-
-// cl_longlong/cl_ulonglong are not supported in SYCL
-#define DECLARE_SYCL_VEC_LONGLONG_WO_CONVERTERS(base)                          \
-  using base##long16 = vec<base##long, 16>;                                    \
-  using base##long8 = vec<base##long, 8>;                                      \
-  using base##long4 = vec<base##long, 4>;                                      \
-  using base##long3 = vec<base##long, 3>;                                      \
-  using base##long2 = vec<base##long, 2>;
-
-#define DECLARE_SYCL_SIGNED_INTEGRAL_VEC(base)                                 \
-  DECLARE_SIGNED_INTEGRAL_VECTOR_CONVERTERS(base)                              \
-  DECLARE_SYCL_VEC_WO_CONVERTERS(base)
-
-#define DECLARE_SYCL_UNSIGNED_INTEGRAL_VEC(base)                               \
-  DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(base)                            \
-  DECLARE_SYCL_VEC_WO_CONVERTERS(base)
-
-#define DECLARE_SYCL_FLOAT_VEC(base)                                           \
-  DECLARE_FLOAT_VECTOR_CONVERTERS(base)                                        \
-  DECLARE_SYCL_VEC_WO_CONVERTERS(base)
-
-#define DECLARE_SYCL_VEC_CHAR                                                  \
-  DECLARE_VECTOR_CONVERTERS(char)                                              \
-  DECLARE_SYCL_VEC_CHAR_WO_CONVERTERS
-
-#define DECLARE_SYCL_VEC_LONG                                                  \
-  DECLARE_SIGNED_INTEGRAL_VECTOR_CONVERTERS(long)                              \
-  DECLARE_SYCL_VEC_LONG_WO_CONVERTERS(long)
-
-#define DECLARE_SYCL_VEC_ULONG                                                 \
-  DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(ulong)                           \
-  DECLARE_SYCL_VEC_LONG_WO_CONVERTERS(ulong)
-
-#define DECLARE_SYCL_VEC_LONGLONG(base)                                        \
-  DECLARE_VECTOR_LONGLONG_CONVERTERS(base)                                     \
-  DECLARE_SYCL_VEC_LONGLONG_WO_CONVERTERS(base)
-
-#define DECLARE_SYCL_VEC_HALF(base)                                            \
-  DECLARE_HALF_VECTOR_CONVERTERS(base)                                         \
-  DECLARE_SYCL_VEC_HALF_WO_CONVERTERS
-
-DECLARE_SYCL_VEC_CHAR
-DECLARE_SYCL_SIGNED_INTEGRAL_VEC(schar)
-DECLARE_SYCL_UNSIGNED_INTEGRAL_VEC(uchar)
-DECLARE_SYCL_SIGNED_INTEGRAL_VEC(short)
-DECLARE_SYCL_UNSIGNED_INTEGRAL_VEC(ushort)
-DECLARE_SYCL_SIGNED_INTEGRAL_VEC(int)
-DECLARE_SYCL_UNSIGNED_INTEGRAL_VEC(uint)
-DECLARE_SYCL_VEC_LONG
-DECLARE_SYCL_VEC_ULONG
-DECLARE_SYCL_VEC_LONGLONG(long)
-DECLARE_SYCL_VEC_LONGLONG(ulong)
-DECLARE_SYCL_VEC_HALF(half)
-DECLARE_SYCL_FLOAT_VEC(float)
-DECLARE_SYCL_FLOAT_VEC(double)
+DECLARE_VECTOR_CONVERTERS(char)
+DECLARE_SCHAR_VECTOR_CONVERTERS
+DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(uchar)
+DECLARE_SIGNED_INTEGRAL_VECTOR_CONVERTERS(short)
+DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(ushort)
+DECLARE_SIGNED_INTEGRAL_VECTOR_CONVERTERS(int)
+DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(uint)
+DECLARE_SIGNED_INTEGRAL_VECTOR_CONVERTERS(long)
+DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(ulong)
+DECLARE_VECTOR_LONGLONG_CONVERTERS(long)
+DECLARE_VECTOR_LONGLONG_CONVERTERS(ulong)
+DECLARE_HALF_VECTOR_CONVERTERS(half)
+DECLARE_FLOAT_VECTOR_CONVERTERS(float)
+DECLARE_FLOAT_VECTOR_CONVERTERS(double)
 
 #undef GET_CL_TYPE
 #undef GET_SCALAR_CL_TYPE
@@ -2056,9 +1927,9 @@ DECLARE_SYCL_FLOAT_VEC(double)
 #undef DECLARE_VECTOR_CONVERTERS
 #undef DECLARE_SYCL_VEC
 #undef DECLARE_SYCL_VEC_WO_CONVERTERS
-#undef DECLARE_SYCL_VEC_LONG_WO_CONVERTERS
-#undef DECLARE_SYCL_VEC_LONG
-#undef DECLARE_SYCL_VEC_ULONG
+#undef DECLARE_SCHAR_VECTOR_CONVERTERS
+#undef DECLARE_SCHAR_CONVERTER
+#undef DECLARE_SCALAR_SCHAR_CONVERTER
 
 } // namespace sycl
 } // namespace cl

--- a/sycl/test/basic_tests/aliases.cpp
+++ b/sycl/test/basic_tests/aliases.cpp
@@ -6,103 +6,65 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
 #include <CL/sycl.hpp>
-#include <CL/sycl/detail/common.hpp>
-#include <cassert>
-#include <iostream>
+
 #include <type_traits>
 
-using namespace std;
-
-using cl_schar = cl_char;
-using cl_schar4 = cl_char4;
-
+using std::is_same;
 namespace s = cl::sycl;
 
-#define CHECK_TYPE(TYPE)                                                       \
-  static_assert(sizeof(cl_##TYPE) == sizeof(s::cl_##TYPE), "")
+// Test to verify requirements from 4.10.2.2 Aliases
 
-#define CHECK_SIZE(TYPE, SIZE) static_assert(sizeof(TYPE) == SIZE, "");
+#define ASSERT(ALIAS, TYPE, N)                                                 \
+  static_assert(is_same<ALIAS##N, s::vec<TYPE, N>>::value, "");
 
-#define CHECK_SIZE_VEC_N(TYPE, N)                                              \
-  static_assert(N * sizeof(TYPE) == sizeof(s::vec<TYPE, N>), "");
+// char, short, int, long, float, double, half
+#define PRESENTED_AS_IS(N)                                                     \
+  ASSERT(s::char, char, N)                                                     \
+  ASSERT(s::short, short, N)                                                   \
+  ASSERT(s::int, int, N)                                                       \
+  ASSERT(s::long, long, N)                                                     \
+  ASSERT(s::float, float, N)                                                   \
+  ASSERT(s::double, double, N)                                                 \
+  ASSERT(s::half, half, N);
 
-#define CHECK_SIZE_VEC_N3(TYPE)                                                \
-  static_assert(sizeof(s::vec<TYPE, 3>) == sizeof(s::vec<TYPE, 4>), "");
+// cl_char, cl_uchar, cl_short, cl_ushort, cl_int, cl_uint, cl_long, cl_ulong,
+// cl_float, cl_double and cl_half
+#define OPENCL_INTEROPERABILITY(N)                                             \
+  ASSERT(s::cl_char, s::cl_char, N)                                            \
+  ASSERT(s::cl_uchar, s::cl_uchar, N)                                          \
+  ASSERT(s::cl_short, s::cl_short, N)                                          \
+  ASSERT(s::cl_ushort, s::cl_ushort, N)                                        \
+  ASSERT(s::cl_int, s::cl_int, N)                                              \
+  ASSERT(s::cl_uint, s::cl_uint, N)                                            \
+  ASSERT(s::cl_long, s::cl_long, N)                                            \
+  ASSERT(s::cl_ulong, s::cl_ulong, N)                                          \
+  ASSERT(s::cl_float, s::cl_float, N)                                          \
+  ASSERT(s::cl_double, s::cl_double, N)                                        \
+  ASSERT(s::cl_half, s::cl_half, N)
 
-#define CHECK_SIZE_VEC(TYPE)                                                   \
-  CHECK_SIZE_VEC_N(TYPE, 2);                                                   \
-  CHECK_SIZE_VEC_N3(TYPE);                                                     \
-  CHECK_SIZE_VEC_N(TYPE, 4);                                                   \
-  CHECK_SIZE_VEC_N(TYPE, 8);                                                   \
-  CHECK_SIZE_VEC_N(TYPE, 16);
+// schar, uchar, ushort, uint, ulong, longlong and ulonglong
+#define REPRESENTED_WITH_THE_SHORT_HAND(N)                                     \
+  ASSERT(s::schar, signed char, N)                                             \
+  ASSERT(s::uchar, unsigned char, N)                                           \
+  ASSERT(s::ushort, unsigned short, N)                                         \
+  ASSERT(s::uint, unsigned int, N)                                             \
+  ASSERT(s::ulong, unsigned long, N)                                           \
+  ASSERT(s::longlong, long long, N)                                            \
+  ASSERT(s::ulonglong, unsigned long long, N)
 
-#define CHECK_SIZE_TYPE_I(TYPE, SIZE)                                          \
-  CHECK_SIZE(TYPE, SIZE)                                                       \
-  static_assert(std::is_signed<TYPE>::value, "");
-
-#define CHECK_SIZE_TYPE_UI(TYPE, SIZE)                                         \
-  CHECK_SIZE(TYPE, SIZE)                                                       \
-  static_assert(std::is_unsigned<TYPE>::value, "");
-
-#define CHECK_SIZE_TYPE_F(TYPE, SIZE)                                          \
-  CHECK_SIZE(TYPE, SIZE)                                                       \
-  static_assert(std::numeric_limits<TYPE>::is_iec559, "");
+#define CHECK_FOR_N(N)                                                         \
+  PRESENTED_AS_IS(N)                                                           \
+  OPENCL_INTEROPERABILITY(N)                                                   \
+  REPRESENTED_WITH_THE_SHORT_HAND(N)
 
 int main() {
-  CHECK_TYPE(bool);
-  CHECK_TYPE(char);
-  CHECK_TYPE(schar);
-  CHECK_TYPE(uchar);
-  CHECK_TYPE(short);
-  CHECK_TYPE(ushort);
-  CHECK_TYPE(half);
-  CHECK_TYPE(int);
-  CHECK_TYPE(uint);
-  CHECK_TYPE(long);
-  CHECK_TYPE(ulong);
-  CHECK_TYPE(float);
-  CHECK_TYPE(double);
-  CHECK_TYPE(char2);
-  CHECK_TYPE(uchar3);
-  CHECK_TYPE(short4);
-  CHECK_TYPE(ushort8);
-  CHECK_TYPE(half16);
-  CHECK_TYPE(int2);
-  CHECK_TYPE(uint3);
-  CHECK_TYPE(long4);
-  CHECK_TYPE(schar4);
-  CHECK_TYPE(ulong8);
-  CHECK_TYPE(float16);
-  CHECK_TYPE(double2);
-
-  // Table 4.93: Scalar data type aliases supported by SYCL
-  CHECK_SIZE_TYPE_UI(s::byte, 1);
-
-  CHECK_SIZE_TYPE_I(s::cl_char, 1);
-  CHECK_SIZE_TYPE_I(s::cl_short, 2);
-  CHECK_SIZE_TYPE_I(s::cl_int, 4);
-  CHECK_SIZE_TYPE_I(s::cl_long, 8);
-
-  CHECK_SIZE_TYPE_UI(s::cl_uchar, 1);
-  CHECK_SIZE_TYPE_UI(s::cl_ushort, 2);
-  CHECK_SIZE_TYPE_UI(s::cl_uint, 4);
-  CHECK_SIZE_TYPE_UI(s::cl_ulong, 8);
-
-  CHECK_SIZE_TYPE_F(s::cl_float, 4);
-  CHECK_SIZE_TYPE_F(s::cl_double, 8);
-  CHECK_SIZE(s::cl_half, 2);
-
-  CHECK_SIZE_VEC(s::cl_char);
-  CHECK_SIZE_VEC(s::cl_schar);
-  CHECK_SIZE_VEC(s::cl_uchar);
-  CHECK_SIZE_VEC(s::cl_short);
-  CHECK_SIZE_VEC(s::cl_ushort);
-  CHECK_SIZE_VEC(s::cl_half);
-  CHECK_SIZE_VEC(s::cl_int);
-  CHECK_SIZE_VEC(s::cl_uint);
-  CHECK_SIZE_VEC(s::cl_long);
-  CHECK_SIZE_VEC(s::cl_ulong);
-  CHECK_SIZE_VEC(s::cl_float);
-  CHECK_SIZE_VEC(s::cl_double);
+  // For number of elements: 2, 3, 4, 8, 16.
+  CHECK_FOR_N(2);
+  CHECK_FOR_N(3);
+  CHECK_FOR_N(4);
+  CHECK_FOR_N(8);
+  CHECK_FOR_N(16);
+  return 0;
 }

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -9,13 +9,18 @@
 
 #include <CL/sycl.hpp>
 
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+using namespace std;
+namespace s = cl::sycl;
+
 template <typename T, int N> inline void checkVectorSizeAndAlignment() {
-  using VectorT = cl::sycl::vec<T, N>;
+  using VectorT = s::vec<T, N>;
   constexpr auto RealLength = (N != 3 ? N : 4);
-  static_assert(sizeof(VectorT) == (sizeof(T) * RealLength),
-                "Wrong size of vec<T, N>");
-  static_assert(alignof(VectorT) == (alignof(T) * RealLength),
-                "Wrong alignment of vec<T, N>");
+  static_assert(sizeof(VectorT) == (sizeof(T) * RealLength), "");
+  static_assert(alignof(VectorT) == (alignof(T) * RealLength), "");
 }
 
 template <typename T> inline void checkVectorsWithN() {
@@ -42,20 +47,75 @@ inline void checkVectors() {
   checkVectorsWithN<unsigned long>();
   checkVectorsWithN<signed long long>();
   checkVectorsWithN<unsigned long long>();
-  checkVectorsWithN<::cl_char>();
-  checkVectorsWithN<::cl_uchar>();
-  checkVectorsWithN<::cl_short>();
-  checkVectorsWithN<::cl_ushort>();
-  checkVectorsWithN<::cl_int>();
-  checkVectorsWithN<::cl_uint>();
-  checkVectorsWithN<::cl_long>();
-  checkVectorsWithN<::cl_ulong>();
-  checkVectorsWithN<::cl_half>();
-  checkVectorsWithN<::cl_float>();
-  checkVectorsWithN<::cl_double>();
+  checkVectorsWithN<s::cl_char>();
+  checkVectorsWithN<s::cl_uchar>();
+  checkVectorsWithN<s::cl_short>();
+  checkVectorsWithN<s::cl_ushort>();
+  checkVectorsWithN<s::cl_int>();
+  checkVectorsWithN<s::cl_uint>();
+  checkVectorsWithN<s::cl_long>();
+  checkVectorsWithN<s::cl_ulong>();
+  checkVectorsWithN<s::cl_half>();
+  checkVectorsWithN<s::cl_float>();
+  checkVectorsWithN<s::cl_double>();
+}
+
+template <typename T, int ExpectedSize>
+inline void checkSizeForSignedIntegral() {
+  static_assert(is_integral<T>::value, "");
+  static_assert(is_signed<T>::value, "");
+  static_assert(sizeof(T) == ExpectedSize, "");
+}
+
+template <typename T, int ExpectedSize>
+inline void checkSizeForUnsignedIntegral() {
+  static_assert(is_integral<T>::value, "");
+  static_assert(is_unsigned<T>::value, "");
+  static_assert(sizeof(T) == ExpectedSize, "");
+}
+
+template <typename T, int ExpectedSize>
+inline void checkSizeForFloatingPoint() {
+  static_assert(is_floating_point<T>::value, "");
+  static_assert(numeric_limits<T>::is_iec559, "");
+  static_assert(sizeof(T) == ExpectedSize, "");
+}
+
+template <>
+inline void checkSizeForFloatingPoint<s::cl_half, sizeof(std::int16_t)>() {
+  // TODO is_floating_point does not support sycl half now.
+  // static_assert(is_floating_point<T>::is_iec559, "");
+  // TODO numeric_limits does not support sycl half now.
+  // static_assert(numeric_limits<T>::is_iec559, "");
+  static_assert(sizeof(s::cl_half) == sizeof(std::int16_t), "");
 }
 
 int main() {
+  // Check the size and alignment of the SYCL vectors.
   checkVectors();
+
+  // Table 4.93: Additional scalar data types supported by SYCL.
+  static_assert(sizeof(s::byte) == sizeof(std::int8_t), "");
+
+  // Table 4.94: Scalar data type aliases supported by SYCL
+  static_assert(is_same<s::cl_bool, decltype(0 != 1)>::value, "");
+  checkSizeForSignedIntegral<s::cl_char, sizeof(std::int8_t)>();
+  checkSizeForUnsignedIntegral<s::cl_uchar, sizeof(std::uint8_t)>();
+  checkSizeForSignedIntegral<s::cl_short, sizeof(std::int16_t)>();
+  checkSizeForUnsignedIntegral<s::cl_ushort, sizeof(std::uint16_t)>();
+  checkSizeForSignedIntegral<s::cl_int, sizeof(std::int32_t)>();
+  checkSizeForUnsignedIntegral<s::cl_uint, sizeof(std::uint32_t)>();
+  checkSizeForSignedIntegral<s::cl_long, sizeof(std::int64_t)>();
+  checkSizeForUnsignedIntegral<s::cl_ulong, sizeof(std::uint64_t)>();
+  checkSizeForFloatingPoint<s::cl_half, sizeof(std::int16_t)>();
+  checkSizeForFloatingPoint<s::cl_float, sizeof(std::int32_t)>();
+  checkSizeForFloatingPoint<s::cl_double, sizeof(std::int64_t)>();
+
+  // Other OpenCL aliases which can be found in the SYCL specification
+  checkSizeForUnsignedIntegral<s::cl_size_t, sizeof(std::int64_t)>();
+  checkSizeForSignedIntegral<s::cl_ptrdiff_t, sizeof(std::int64_t)>();
+  checkSizeForSignedIntegral<s::cl_intptr_t, sizeof(std::int64_t)>();
+  checkSizeForUnsignedIntegral<s::cl_uintptr_t, sizeof(std::int64_t)>();
+
   return 0;
 }


### PR DESCRIPTION
Fixed aliases of some vectors to follow requirements from
SYCL specification 4.10.2.2 Aliases.
Moved to separate file(aliases.hpp).

Added cl_size_t, cl_ptrdiff_t, cl_intptr_t, cl_uintptr_t
aliases to OpenCL types.

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>