### PR TITLE
[SYCL] Pass correct GPU binary filename to wrapper for AOT compilation

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -384,7 +384,8 @@ void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
   ArgStringList CmdArgs{"-output",  Output.getFilename()};
   for (const auto &II : Inputs) {
     CmdArgs.push_back("-file");
-    CmdArgs.push_back(II.getFilename());
+    const char *Prefix = II.getFilename();
+    CmdArgs.push_back(Args.MakeArgString(Prefix + Twine("__Gen9core.bin")));
   }
   CmdArgs.push_back("-spirv_input");
   TranslateSYCLTargetArgs(C, Args, getToolChain(), CmdArgs);


### PR DESCRIPTION
Without this workaround, clang driver assumes that the output file path
specified to ocloc is the resulting path of the GPU device binary.
This is not the case, as "_Gen9core.bin" appendix is added by ocloc.

Long-term, this should be fixed on ocloc side.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>