### PR TITLE
[SYCL][NFC] Fix GCC warning about missing parentheses

### DIFF
--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -718,7 +718,7 @@ llvm::BasicBlock *CodeGenFunction::getInvokeDestImpl() {
   }
 
   // CUDA and SYCL device code doesn't have exceptions.
-  if (LO.CUDA && LO.CUDAIsDevice || LO.SYCLIsDevice)
+  if ((LO.CUDA && LO.CUDAIsDevice) || LO.SYCLIsDevice)
     return nullptr;
 
   // Check the innermost scope for a cached landing pad.  If this is


### PR DESCRIPTION
```c++
clang/lib/CodeGen/CGException.cpp:721:15: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
   if (LO.CUDA && LO.CUDAIsDevice || LO.SYCLIsDevice)
            ~~~~~~~~^~~~~~~~~~~~~~~~~~
```
