### PR TITLE
[Clang][Wrapper] Remove host bundle marker from the wrapper object

### DIFF
--- a/clang/test/Driver/clang-offload-wrapper.c
+++ b/clang/test/Driver/clang-offload-wrapper.c
@@ -164,5 +164,5 @@
 //
 // RUN: clang-offload-wrapper -o %t.wrapper.bc -host=x86_64-pc-linux-gnu -kind=sycl -target=spir64-unknown-linux-sycldevice %t1.tgt
 // RUN: %clang -target x86_64-pc-linux-gnu -c %t.wrapper.bc -o %t.wrapper.o
-// RUN: clang-offload-bundler --type=o --inputs=%t.wrapper.o --targets=host-x86_64-pc-linux-gnu,sycl-spir64-unknown-linux-sycldevice --outputs=%t.host.out,%t1.out --unbundle
+// RUN: clang-offload-bundler --type=o --inputs=%t.wrapper.o --targets=sycl-spir64-unknown-linux-sycldevice --outputs=%t1.out --unbundle
 // RUN: diff %t1.out %t1.tgt


### PR DESCRIPTION
Removed dummy host bundle from the wrapper object to comply with the recent bundler changes for packing fat objects. With that change host bundle isn't an empty byte anymore but a real host object. For wrapper object we do not need embedded host part anyway, so host bundle marker just need to be removed.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>