### PR TITLE
[SYCL] -fsycl-device-only should override -fsycl

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -718,9 +718,11 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
   //
   // We need to generate a SYCL toolchain if the user specified targets with
   // the -fsycl-targets, -fsycl-add-targets or -fsycl-link-targets option.
-  // If -fsycl is supplied without any of these we will assume SPIR-V
-  bool HasValidSYCLRuntime = C.getInputArgs().hasFlag(options::OPT_fsycl,
-                                              options::OPT_fno_sycl, false);
+  // If -fsycl is supplied without any of these we will assume SPIR-V.
+  // Use of -fsycl-device-only overrides -fsycl.
+  bool HasValidSYCLRuntime = (C.getInputArgs().hasFlag(options::OPT_fsycl,
+      options::OPT_fno_sycl, false) &&
+      !C.getInputArgs().hasArg(options::OPT_sycl_device_only));
 
   Arg *SYCLTargets =
           C.getInputArgs().getLastArg(options::OPT_fsycl_targets_EQ);

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -1,5 +1,6 @@
 // RUN: %clang -### --sycl -c %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
 // RUN: %clang -### --sycl %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
+// RUN: %clang -### -fsycl-device-only -fsycl  %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
 // RUN: %clang -### --sycl -fno-sycl-use-bitcode -c %s 2>&1 | FileCheck %s --check-prefix=NO-BITCODE
 // RUN: %clang -### -target spir64-unknown-linux-sycldevice -c -emit-llvm %s 2>&1 | FileCheck %s --check-prefix=TARGET
 // RUN: %clang -### --sycl -c -emit-llvm %s 2>&1 | FileCheck %s --check-prefix=COMBINED


### PR DESCRIPTION
Use of -fsycl-device-only should only produce device code even in the presence
of -fsycl.  The default mode of 'dpcpp' is -fsycl so the override is
necessary for -fsycl-device-only to work

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>