### PR TITLE
[SYCL] Fix asynchronous exceptions handling

### DIFF
--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -122,9 +122,10 @@ public:
 
   void throw_asynchronous() {
     if (m_AsyncHandler && m_Exceptions.size()) {
-      m_AsyncHandler(m_Exceptions);
+      exception_list Exceptions;
+      std::swap(m_Exceptions, Exceptions);
+      m_AsyncHandler(Exceptions);
     }
-    m_Exceptions.Clear();
   }
 
   RT::PiQueue createQueue() {

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -124,7 +124,7 @@ public:
     if (m_AsyncHandler && m_Exceptions.size()) {
       exception_list Exceptions;
       std::swap(m_Exceptions, Exceptions);
-      m_AsyncHandler(Exceptions);
+      m_AsyncHandler(std::move(Exceptions));
     }
   }
 


### PR DESCRIPTION
This fixes following problem:
If provided async_handler throws an exceptions from passed exception
list, this list won't be cleared and exceptions will be thrown again
from queue destructor.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>