### PR TITLE
[SYCL] Silence warning about unsupported pragma

### DIFF
--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -53,7 +53,6 @@
 #include <cmath>
 #ifndef __SYCL_DEVICE_ONLY__
 #include <cfenv>
-#pragma STDC FENV_ACCESS ON
 #endif
 
 // 4.10.1: Scalar data types


### PR DESCRIPTION
From https://en.cppreference.com/w/cpp/numeric/fenv:

> The floating-point environment access and modification is only
meaningful when #pragma STDC FENV_ACCESS is supported and is set to ON.
Otherwise the implementation is free to assume that floating-point
control modes are always the default ones and that floating-point status
flags are never tested or modified. In practice, few current compilers,
such as HP aCC, Oracle Studio, or IBM XL, support the #pragma
explicitly, but most compilers allow meaningful access to the
floating-point environment anyway.

Since this pragma is not supported by clang and gcc and we don't have a
way to check if it is supported, removing this pragma shouldn't affect
functionality at all (at least if clang and gcc are used as host
compilers)

Signed-off-by: Alexey Sachkov <alexey.sachkov@intel.com>