### PR TITLE
[SYCL][FPGA] Fix success code for non-blocking pipes

### DIFF
--- a/sycl/include/CL/sycl/pipes.hpp
+++ b/sycl/include/CL/sycl/pipes.hpp
@@ -25,7 +25,7 @@ public:
     RPipeTy<dataT> RPipe =
       __spirv_CreatePipeFromPipeStorage_read<dataT>(&m_Storage);
     dataT TempData;
-    Success = static_cast<bool>(
+    Success = !static_cast<bool>(
         __spirv_ReadPipe(RPipe, &TempData, m_Size, m_Alignment));
     return TempData;
 #else
@@ -39,7 +39,7 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     WPipeTy<dataT> WPipe =
       __spirv_CreatePipeFromPipeStorage_write<dataT>(&m_Storage);
-    Success = static_cast<bool>(
+    Success = !static_cast<bool>(
         __spirv_WritePipe(WPipe, &Data, m_Size, m_Alignment));
 #else
     assert(!"Pipes are not supported on a host device!");


### PR DESCRIPTION
SYCL pipe built-ins are mapped on SPIR-V pipe instructions.
From SPIR-V spec (3.32.23 Pipe Instructions):
OpReadPipe
  Result is 0 if the operation is successful and a negative value
  if the pipe is empty.

Same for OpWritePipe.

The bug was that SYCL API was expecting the opposite behaviour.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>