### PR TITLE
[SYCL] Improve integration of llvm-no-spir-kernel tool with -fintelfpga

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3338,12 +3338,10 @@ class OffloadingActionBuilder final {
             ActionList DeviceObjects;
             for (const auto &I : LI) {
               if (I->getType() == types::TY_Object) {
-                // FIXME - Checker does not work well inline with the tool
-                // chain, but it needs to be here for real time checking
-                // auto *DeviceCheckAction =
-                // C.MakeAction<SPIRCheckJobAction>(I, types::TY_Object);
-                // DeviceObjects.push_back(DeviceCheckAction);
-                DeviceObjects.push_back(I);
+                // Perform a check for SPIR kernel.
+                auto *DeviceCheckAction =
+                    C.MakeAction<SPIRCheckJobAction>(I, types::TY_Object);
+                DeviceObjects.push_back(DeviceCheckAction);
               } else {
                 // Do not perform a device link and only pass the aocr
                 // file to the offline compilation before wrapping.  Just

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6709,6 +6709,11 @@ void SPIRCheck::ConstructJob(Compilation &C, const JobAction &JA,
     CheckArgs.push_back(I.getFilename());
   }
 
+  // Add output file, which is just a copy of the input to better fit in the
+  // toolchain flow.
+  CheckArgs.push_back("-o");
+  CheckArgs.push_back(Output.getFilename());
+
   C.addCommand(llvm::make_unique<Command>(JA, *this,
       TCArgs.MakeArgString(getToolChain().GetProgramPath(getShortName())),
       CheckArgs, None));

--- a/llvm/tools/llvm-no-spir-kernel/llvm-no-spir-kernel.cpp
+++ b/llvm/tools/llvm-no-spir-kernel/llvm-no-spir-kernel.cpp
@@ -7,8 +7,11 @@
 //===----------------------------------------------------------------------===//
 //
 // This utility checks if the input module contains functions that is a spir
-// kernel. Return 0 if no, return 1 if yes.
-// Usage: llvm-no-spir-kernel input.bc/input.ll
+// kernel. Return 0 if no, return 1 if yes. Use of an output file is not
+// required for a successful check. It is used to allow for proper input and
+// output flow within the driver toolchain.
+//
+// Usage: llvm-no-spir-kernel input.bc/input.ll -o output.bc/output.ll
 //
 //===----------------------------------------------------------------------===//
 
@@ -26,6 +29,12 @@ static cl::opt<std::string> InputFilename(cl::Positional,
                                           cl::desc("<input bitcode file>"),
                                           cl::init("-"),
                                           cl::value_desc("filename"));
+
+// Output - The filename to output to.
+static cl::opt<std::string> Output("o",
+                                   cl::desc("<output filename>"),
+                                   cl::value_desc("filename"));
+
 
 int main(int argc, char **argv) {
   InitLLVM X(argc, argv);
@@ -46,6 +55,11 @@ int main(int argc, char **argv) {
     if (F.getCallingConv() == CallingConv::SPIR_KERNEL) {
       return 1;
     }
+  }
+
+  // When given an output file, just copy the input to the output
+  if (!Output.empty() && !InputFilename.empty()) {
+    llvm::sys::fs::copy_file(InputFilename, Output);
   }
 
   return 0;


### PR DESCRIPTION
When using FPGA device archives, any additional object passed in needs to
be scrutinized for SPIR kernel device code.  To accomplish this, the kernel
checker has been modified to work within the driver toolchain flow
(input/output).

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>