### PR TITLE
[SYCL] Avoid calling atomic_load for floats

### DIFF
--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -14,6 +14,8 @@
 
 #ifndef __SYCL_DEVICE_ONLY__
 #include <atomic>
+#else
+#include <cstring>
 #endif
 #include <type_traits>
 
@@ -206,13 +208,11 @@ public:
   load(memory_order Order = memory_order::relaxed) const {
     auto *TmpPtr =
         reinterpret_cast<typename multi_ptr<int, addressSpace>::pointer_t>(Ptr);
-    union {
-      int Int;
-      float Float;
-    } TmpVal;
-    TmpVal.Int = __spirv_AtomicLoad(TmpPtr, SpirvScope,
+    int TmpVal = __spirv_AtomicLoad(TmpPtr, SpirvScope,
                                     detail::getSPIRVMemorySemanticsMask(Order));
-    return TmpVal.Float;
+    float ResVal;
+    std::memcpy(&ResVal, &TmpVal, sizeof TmpVal);
+    return ResVal;
   }
 #else
   T load(memory_order Order = memory_order::relaxed) const {

--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -198,19 +198,20 @@ public:
 
 #ifdef __SYCL_DEVICE_ONLY__
   template <typename T2 = T>
-  detail::enable_if_t<!std::is_same<float, T2>::value, T>
+  detail::enable_if_t<!std::is_same<cl_float, T2>::value, T>
   load(memory_order Order = memory_order::relaxed) const {
     return __spirv_AtomicLoad(Ptr, SpirvScope,
                               detail::getSPIRVMemorySemanticsMask(Order));
   }
   template <typename T2 = T>
-  detail::enable_if_t<std::is_same<float, T2>::value, T>
+  detail::enable_if_t<std::is_same<cl_float, T2>::value, T>
   load(memory_order Order = memory_order::relaxed) const {
     auto *TmpPtr =
-        reinterpret_cast<typename multi_ptr<int, addressSpace>::pointer_t>(Ptr);
-    int TmpVal = __spirv_AtomicLoad(TmpPtr, SpirvScope,
-                                    detail::getSPIRVMemorySemanticsMask(Order));
-    float ResVal;
+        reinterpret_cast<typename multi_ptr<cl_int, addressSpace>::pointer_t>(
+            Ptr);
+    cl_int TmpVal = __spirv_AtomicLoad(
+        TmpPtr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order));
+    cl_float ResVal;
     std::memcpy(&ResVal, &TmpVal, sizeof TmpVal);
     return ResVal;
   }

--- a/sycl/test/regression/atomic_load.cpp
+++ b/sycl/test/regression/atomic_load.cpp
@@ -1,9 +1,5 @@
-// RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// RUN: %clangxx --sycl -S -x c++ -O0 -emit-llvm %s -o - | FileCheck %s
 #include <CL/sycl.hpp>
 using namespace cl::sycl;
 
@@ -27,15 +23,7 @@ void kernel_func(T val) {
 }
 
 int main() {
-  // CHECK: [[RES_VAL:%ResVal]] = alloca float
-  // CHECK: call spir_func i32 @_Z18__spirv_AtomicLoad{{.*}}(i32 addrspace(1)* %{{[0-9]*}}, i32 1, i32 %{{[a-zA-Z]*}})
-  // CHECK: [[CAST:%[0-9]*]] = {{.*}} [[RES_VAL]]
-  // CHECK: call void @llvm.memcpy{{.*}}[[CAST]]
-  // CHECK: [[RET_NAME:%[0-9a-zA-Z]*]] = load float{{.*}}[[RES_VAL]]
-  // CHECK: ret float [[RET_NAME]]
   kernel_func<float>(5.5);
-  // CHECK: [[RET_NAME2:%[0-9a-zA-Z]*]] = call spir_func i32 @_Z18__spirv_AtomicLoad{{.*}}(i32 addrspace(1)* %{{[0-9a-zA-Z]*}}, i32 1, i32 %{{[0-9a-zA-Z]*}})
-  // CHECK: ret i32 [[RET_NAME2]]
   kernel_func<int>(42);
   return 0;
 }

--- a/sycl/test/regression/atomic_load.cpp
+++ b/sycl/test/regression/atomic_load.cpp
@@ -27,11 +27,11 @@ void kernel_func(T val) {
 }
 
 int main() {
-  // CHECK: [[U_NAME:%[0-9a-zA-Z]*]] = alloca %union
-  // CHECK: call spir_func i32 @_Z18__spirv_AtomicLoad{{.*}}(i32 addrspace(1)* %{{[0-9a-zA-Z]*}}, i32 1, i32 %{{[0-9a-zA-Z]*}})
-  // CHECK: bitcast %union{{.*}} [[U_NAME]] to i32*
-  // CHECK: [[F_NAME:%[0-9a-zA-Z]*]] = bitcast %union{{.*}} [[U_NAME]] to float*
-  // CHECK: [[RET_NAME:%[0-9a-zA-Z]*]] = {{.*}}[[F_NAME]]
+  // CHECK: [[RES_VAL:%ResVal]] = alloca float
+  // CHECK: call spir_func i32 @_Z18__spirv_AtomicLoad{{.*}}(i32 addrspace(1)* %{{[0-9]*}}, i32 1, i32 %{{[a-zA-Z]*}})
+  // CHECK: [[CAST:%[0-9]*]] = {{.*}} [[RES_VAL]]
+  // CHECK: call void @llvm.memcpy{{.*}}[[CAST]]
+  // CHECK: [[RET_NAME:%[0-9a-zA-Z]*]] = load float{{.*}}[[RES_VAL]]
   // CHECK: ret float [[RET_NAME]]
   kernel_func<float>(5.5);
   // CHECK: [[RET_NAME2:%[0-9a-zA-Z]*]] = call spir_func i32 @_Z18__spirv_AtomicLoad{{.*}}(i32 addrspace(1)* %{{[0-9a-zA-Z]*}}, i32 1, i32 %{{[0-9a-zA-Z]*}})

--- a/sycl/test/regression/atomic_load.cpp
+++ b/sycl/test/regression/atomic_load.cpp
@@ -12,12 +12,12 @@ class foo;
 
 template<typename T>
 void kernel_func(T val) {
-  cl::sycl::queue testQueue;
+  queue testQueue;
 
   T data = val;
   buffer<T,1> buf(&data, range<1>(1));
 
-  testQueue.submit([&](cl::sycl::handler &cgh) {
+  testQueue.submit([&](handler &cgh) {
     auto GlobAcc = buf.template get_access<access::mode::atomic>(cgh);
     cgh.single_task<class foo<T>>([=]() {
       auto a = GlobAcc[0];

--- a/sycl/test/regression/atomic_load.cpp
+++ b/sycl/test/regression/atomic_load.cpp
@@ -1,0 +1,41 @@
+// RUN: %clangxx -fsycl %s -o %t.out -lOpenCL
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %clangxx --sycl -S -x c++ -O0 -emit-llvm %s -o - | FileCheck %s
+#include <CL/sycl.hpp>
+using namespace cl::sycl;
+
+template <typename T>
+class foo;
+
+template<typename T>
+void kernel_func(T val) {
+  cl::sycl::queue testQueue;
+
+  T data = val;
+  buffer<T,1> buf(&data, range<1>(1));
+
+  testQueue.submit([&](cl::sycl::handler &cgh) {
+    auto GlobAcc = buf.template get_access<access::mode::atomic>(cgh);
+    cgh.single_task<class foo<T>>([=]() {
+      auto a = GlobAcc[0];
+      T var = a.load();
+    });
+  });
+}
+
+int main() {
+  // CHECK: [[U_NAME:%[0-9a-zA-Z]*]] = alloca %union
+  // CHECK: call spir_func i32 @_Z18__spirv_AtomicLoad{{.*}}(i32 addrspace(1)* %{{[0-9a-zA-Z]*}}, i32 1, i32 %{{[0-9a-zA-Z]*}})
+  // CHECK: bitcast %union{{.*}} [[U_NAME]] to i32*
+  // CHECK: [[F_NAME:%[0-9a-zA-Z]*]] = bitcast %union{{.*}} [[U_NAME]] to float*
+  // CHECK: [[RET_NAME:%[0-9a-zA-Z]*]] = {{.*}}[[F_NAME]]
+  // CHECK: ret float [[RET_NAME]]
+  kernel_func<float>(5.5);
+  // CHECK: [[RET_NAME2:%[0-9a-zA-Z]*]] = call spir_func i32 @_Z18__spirv_AtomicLoad{{.*}}(i32 addrspace(1)* %{{[0-9a-zA-Z]*}}, i32 1, i32 %{{[0-9a-zA-Z]*}})
+  // CHECK: ret i32 [[RET_NAME2]]
+  kernel_func<int>(42);
+  return 0;
+}


### PR DESCRIPTION
There is no atomic_load builtin for floats in OpenCL 1.2.
This patch introduces calling atomic_load for integers with bitcasting of float
value to integer instead.

Signed-off-by: Viktoria Maksimova <viktoria.maksimova@intel.com>