### PR TITLE
[SYCL] Recovery align aliases with SYCL specification patch.

### DIFF
--- a/sycl/include/CL/sycl/aliases.hpp
+++ b/sycl/include/CL/sycl/aliases.hpp
@@ -1,0 +1,109 @@
+//==----------- aliases.hpp --- SYCL type aliases --------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl/detail/common.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace cl {
+namespace sycl {
+template <typename T, int N> class vec;
+namespace detail {
+namespace half_impl {
+class half;
+} // namespace half_impl
+} // namespace detail
+} // namespace sycl
+} // namespace cl
+
+#ifdef __SYCL_DEVICE_ONLY__
+using half = _Float16;
+#else
+using half = cl::sycl::detail::half_impl::half;
+#endif
+
+#define MAKE_VECTOR_ALIAS(ALIAS, TYPE, N)                                      \
+  using ALIAS##N = cl::sycl::vec<TYPE, N>;
+
+#define MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                            \
+  MAKE_VECTOR_ALIAS(char, char, N)                                             \
+  MAKE_VECTOR_ALIAS(short, short, N)                                           \
+  MAKE_VECTOR_ALIAS(int, int, N)                                               \
+  MAKE_VECTOR_ALIAS(long, long, N)                                             \
+  MAKE_VECTOR_ALIAS(float, float, N)                                           \
+  MAKE_VECTOR_ALIAS(double, double, N)                                         \
+  MAKE_VECTOR_ALIAS(half, half, N)
+
+#define MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                                \
+  MAKE_VECTOR_ALIAS(cl_char, cl::sycl::cl_char, N)                             \
+  MAKE_VECTOR_ALIAS(cl_uchar, cl::sycl::cl_uchar, N)                           \
+  MAKE_VECTOR_ALIAS(cl_short, cl::sycl::cl_short, N)                           \
+  MAKE_VECTOR_ALIAS(cl_ushort, cl::sycl::cl_ushort, N)                         \
+  MAKE_VECTOR_ALIAS(cl_int, cl::sycl::cl_int, N)                               \
+  MAKE_VECTOR_ALIAS(cl_uint, cl::sycl::cl_uint, N)                             \
+  MAKE_VECTOR_ALIAS(cl_long, cl::sycl::cl_long, N)                             \
+  MAKE_VECTOR_ALIAS(cl_ulong, cl::sycl::cl_ulong, N)                           \
+  MAKE_VECTOR_ALIAS(cl_float, cl::sycl::cl_float, N)                           \
+  MAKE_VECTOR_ALIAS(cl_double, cl::sycl::cl_double, N)                         \
+  MAKE_VECTOR_ALIAS(cl_half, cl::sycl::cl_half, N)
+
+#define MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)                   \
+  MAKE_VECTOR_ALIAS(schar, signed char, N)                                     \
+  MAKE_VECTOR_ALIAS(uchar, unsigned char, N)                                   \
+  MAKE_VECTOR_ALIAS(ushort, unsigned short, N)                                 \
+  MAKE_VECTOR_ALIAS(uint, unsigned int, N)                                     \
+  MAKE_VECTOR_ALIAS(ulong, unsigned long, N)                                   \
+  MAKE_VECTOR_ALIAS(longlong, long long, N)                                    \
+  MAKE_VECTOR_ALIAS(ulonglong, unsigned long long, N)
+
+#define MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                               \
+  MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                                  \
+  MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                                      \
+  MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)
+
+namespace cl {
+namespace sycl {
+using byte = std::uint8_t;
+using schar = signed char;
+using uchar = unsigned char;
+using ushort = unsigned short;
+using uint = unsigned int;
+using ulong = unsigned long;
+using longlong = long long;
+using ulonglong = unsigned long long;
+// TODO cl::sycl::half is not in SYCL specification, but is used by Khronos CTS.
+using half = half;
+using cl_bool = bool;
+using cl_char = std::int8_t;
+using cl_uchar = std::uint8_t;
+using cl_short = std::int16_t;
+using cl_ushort = std::uint16_t;
+using cl_int = std::int32_t;
+using cl_uint = std::uint32_t;
+using cl_long = std::int64_t;
+using cl_ulong = std::uint64_t;
+using cl_half = half;
+using cl_float = float;
+using cl_double = double;
+
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(2)
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(3)
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(4)
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(8)
+MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(16)
+} // namespace sycl
+} // namespace cl
+
+#undef MAKE_VECTOR_ALIAS
+#undef MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES
+#undef MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES
+#undef MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES
+#undef MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -160,7 +160,7 @@ using is_charn = typename is_contained<
 // scharn: schar2, schar3, schar4, schar8, schar16
 template <typename T>
 using is_scharn = typename is_contained<
-    T, type_list<cl_schar2, cl_schar3, cl_schar4, cl_schar8, cl_schar16>>::type;
+    T, type_list<schar2, schar3, schar4, schar8, schar16>>::type;
 
 // ucharn: uchar2, uchar3, uchar4, uchar8, uchar16
 template <typename T>
@@ -170,7 +170,7 @@ using is_ucharn = typename is_contained<
 // igenchar: signed char, scharn
 template <typename T>
 using is_igenchar =
-    std::integral_constant<bool, is_contained<T, type_list<cl_schar>>::value ||
+    std::integral_constant<bool, is_contained<T, type_list<schar>>::value ||
                                      is_scharn<T>::value>;
 
 // ugenchar: unsigned char, ucharn
@@ -313,7 +313,7 @@ using is_ugeninteger = std::integral_constant<
 // int
 template <typename T>
 using is_sgeninteger = typename is_contained<
-    T, type_list<cl_char, cl_schar, cl_uchar, cl_short, cl_ushort, cl_int,
+    T, type_list<cl_char, schar, cl_uchar, cl_short, cl_ushort, cl_int,
                  cl_uint, cl_long, cl_ulong, longlong, ulonglong>>::type;
 
 // vgeninteger: charn, scharn, ucharn, shortn, ushortn, intn, uintn, longn,
@@ -329,7 +329,7 @@ using is_vgeninteger = std::integral_constant<
 // sigeninteger: char, signed char, short, int, long int, , long long int
 template <typename T>
 using is_sigeninteger = typename is_contained<
-    T, type_list<cl_char, cl_schar, cl_short, cl_int, cl_long, longlong>>::type;
+    T, type_list<cl_char, schar, cl_short, cl_int, cl_long, longlong>>::type;
 
 // sugeninteger: unsigned char, unsigned short,  unsigned int, unsigned long
 // int, unsigned long long int

--- a/sycl/test/basic_tests/aliases.cpp
+++ b/sycl/test/basic_tests/aliases.cpp
@@ -6,103 +6,65 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
 #include <CL/sycl.hpp>
-#include <CL/sycl/detail/common.hpp>
-#include <cassert>
-#include <iostream>
+
 #include <type_traits>
 
-using namespace std;
-
-using cl_schar = cl_char;
-using cl_schar4 = cl_char4;
-
+using std::is_same;
 namespace s = cl::sycl;
 
-#define CHECK_TYPE(TYPE)                                                       \
-  static_assert(sizeof(cl_##TYPE) == sizeof(s::cl_##TYPE), "")
+// Test to verify requirements from 4.10.2.2 Aliases
 
-#define CHECK_SIZE(TYPE, SIZE) static_assert(sizeof(TYPE) == SIZE, "");
+#define ASSERT(ALIAS, TYPE, N)                                                 \
+  static_assert(is_same<ALIAS##N, s::vec<TYPE, N>>::value, "");
 
-#define CHECK_SIZE_VEC_N(TYPE, N)                                              \
-  static_assert(N * sizeof(TYPE) == sizeof(s::vec<TYPE, N>), "");
+// char, short, int, long, float, double, half
+#define PRESENTED_AS_IS(N)                                                     \
+  ASSERT(s::char, char, N)                                                     \
+  ASSERT(s::short, short, N)                                                   \
+  ASSERT(s::int, int, N)                                                       \
+  ASSERT(s::long, long, N)                                                     \
+  ASSERT(s::float, float, N)                                                   \
+  ASSERT(s::double, double, N)                                                 \
+  ASSERT(s::half, half, N);
 
-#define CHECK_SIZE_VEC_N3(TYPE)                                                \
-  static_assert(sizeof(s::vec<TYPE, 3>) == sizeof(s::vec<TYPE, 4>), "");
+// cl_char, cl_uchar, cl_short, cl_ushort, cl_int, cl_uint, cl_long, cl_ulong,
+// cl_float, cl_double and cl_half
+#define OPENCL_INTEROPERABILITY(N)                                             \
+  ASSERT(s::cl_char, s::cl_char, N)                                            \
+  ASSERT(s::cl_uchar, s::cl_uchar, N)                                          \
+  ASSERT(s::cl_short, s::cl_short, N)                                          \
+  ASSERT(s::cl_ushort, s::cl_ushort, N)                                        \
+  ASSERT(s::cl_int, s::cl_int, N)                                              \
+  ASSERT(s::cl_uint, s::cl_uint, N)                                            \
+  ASSERT(s::cl_long, s::cl_long, N)                                            \
+  ASSERT(s::cl_ulong, s::cl_ulong, N)                                          \
+  ASSERT(s::cl_float, s::cl_float, N)                                          \
+  ASSERT(s::cl_double, s::cl_double, N)                                        \
+  ASSERT(s::cl_half, s::cl_half, N)
 
-#define CHECK_SIZE_VEC(TYPE)                                                   \
-  CHECK_SIZE_VEC_N(TYPE, 2);                                                   \
-  CHECK_SIZE_VEC_N3(TYPE);                                                     \
-  CHECK_SIZE_VEC_N(TYPE, 4);                                                   \
-  CHECK_SIZE_VEC_N(TYPE, 8);                                                   \
-  CHECK_SIZE_VEC_N(TYPE, 16);
+// schar, uchar, ushort, uint, ulong, longlong and ulonglong
+#define REPRESENTED_WITH_THE_SHORT_HAND(N)                                     \
+  ASSERT(s::schar, signed char, N)                                             \
+  ASSERT(s::uchar, unsigned char, N)                                           \
+  ASSERT(s::ushort, unsigned short, N)                                         \
+  ASSERT(s::uint, unsigned int, N)                                             \
+  ASSERT(s::ulong, unsigned long, N)                                           \
+  ASSERT(s::longlong, long long, N)                                            \
+  ASSERT(s::ulonglong, unsigned long long, N)
 
-#define CHECK_SIZE_TYPE_I(TYPE, SIZE)                                          \
-  CHECK_SIZE(TYPE, SIZE)                                                       \
-  static_assert(std::is_signed<TYPE>::value, "");
-
-#define CHECK_SIZE_TYPE_UI(TYPE, SIZE)                                         \
-  CHECK_SIZE(TYPE, SIZE)                                                       \
-  static_assert(std::is_unsigned<TYPE>::value, "");
-
-#define CHECK_SIZE_TYPE_F(TYPE, SIZE)                                          \
-  CHECK_SIZE(TYPE, SIZE)                                                       \
-  static_assert(std::numeric_limits<TYPE>::is_iec559, "");
+#define CHECK_FOR_N(N)                                                         \
+  PRESENTED_AS_IS(N)                                                           \
+  OPENCL_INTEROPERABILITY(N)                                                   \
+  REPRESENTED_WITH_THE_SHORT_HAND(N)
 
 int main() {
-  CHECK_TYPE(bool);
-  CHECK_TYPE(char);
-  CHECK_TYPE(schar);
-  CHECK_TYPE(uchar);
-  CHECK_TYPE(short);
-  CHECK_TYPE(ushort);
-  CHECK_TYPE(half);
-  CHECK_TYPE(int);
-  CHECK_TYPE(uint);
-  CHECK_TYPE(long);
-  CHECK_TYPE(ulong);
-  CHECK_TYPE(float);
-  CHECK_TYPE(double);
-  CHECK_TYPE(char2);
-  CHECK_TYPE(uchar3);
-  CHECK_TYPE(short4);
-  CHECK_TYPE(ushort8);
-  CHECK_TYPE(half16);
-  CHECK_TYPE(int2);
-  CHECK_TYPE(uint3);
-  CHECK_TYPE(long4);
-  CHECK_TYPE(schar4);
-  CHECK_TYPE(ulong8);
-  CHECK_TYPE(float16);
-  CHECK_TYPE(double2);
-
-  // Table 4.93: Scalar data type aliases supported by SYCL
-  CHECK_SIZE_TYPE_UI(s::byte, 1);
-
-  CHECK_SIZE_TYPE_I(s::cl_char, 1);
-  CHECK_SIZE_TYPE_I(s::cl_short, 2);
-  CHECK_SIZE_TYPE_I(s::cl_int, 4);
-  CHECK_SIZE_TYPE_I(s::cl_long, 8);
-
-  CHECK_SIZE_TYPE_UI(s::cl_uchar, 1);
-  CHECK_SIZE_TYPE_UI(s::cl_ushort, 2);
-  CHECK_SIZE_TYPE_UI(s::cl_uint, 4);
-  CHECK_SIZE_TYPE_UI(s::cl_ulong, 8);
-
-  CHECK_SIZE_TYPE_F(s::cl_float, 4);
-  CHECK_SIZE_TYPE_F(s::cl_double, 8);
-  CHECK_SIZE(s::cl_half, 2);
-
-  CHECK_SIZE_VEC(s::cl_char);
-  CHECK_SIZE_VEC(s::cl_schar);
-  CHECK_SIZE_VEC(s::cl_uchar);
-  CHECK_SIZE_VEC(s::cl_short);
-  CHECK_SIZE_VEC(s::cl_ushort);
-  CHECK_SIZE_VEC(s::cl_half);
-  CHECK_SIZE_VEC(s::cl_int);
-  CHECK_SIZE_VEC(s::cl_uint);
-  CHECK_SIZE_VEC(s::cl_long);
-  CHECK_SIZE_VEC(s::cl_ulong);
-  CHECK_SIZE_VEC(s::cl_float);
-  CHECK_SIZE_VEC(s::cl_double);
+  // For number of elements: 2, 3, 4, 8, 16.
+  CHECK_FOR_N(2);
+  CHECK_FOR_N(3);
+  CHECK_FOR_N(4);
+  CHECK_FOR_N(8);
+  CHECK_FOR_N(16);
+  return 0;
 }


### PR DESCRIPTION
Fixed aliases of some vectors to follow requirements from
SYCL specification 4.10.2.2 Aliases.
Moved to separate file(aliases.hpp).

Added the half type intp cl::sycl namespace as w/a for Khronos CTS.

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>