### PR TITLE
[SYCL] Adjust adding of depfile information for FPGA AOT compilation

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -294,9 +294,8 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
           continue;
         if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
           llvm::sys::path::replace_extension(FN, "d");
-          if (llvm::sys::fs::exists(FN))
-            FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
-                  Args.MakeArgString(FN), Args.MakeArgString(FN)));
+          FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
+              Args.MakeArgString(FN), Args.MakeArgString(FN)));
         }
       }
     }

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -6,8 +6,8 @@
 /// -fintelfpga implies -g and -MMD
 // RUN:   %clang++ -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-INTELFPGA %s
-// CHK-TOOLS-INTELFPGA: clang{{.*}} "-dependency-file"
-// CHK-TOOLS-INTELFPGA: clang{{.*}} "-debug-info-kind=limited"
+// CHK-TOOLS-INTELFPGA: clang{{.*}} "-debug-info-kind=limited" {{.*}} "-dependency-file"
+// CHK-TOOLS-INTELFPGA: aoc{{.*}} "-dep-files={{.*}}"
 
 /// -fintelfpga -fsycl-link tests
 // RUN:  touch %t.o


### PR DESCRIPTION
There was a problem where the dependency file information was not being
passed to aoc when compiling from source.  This was due to a file exists
check that was being performed before the actual file is generated

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>