### PR TITLE
[SYCL][Driver] Suppress device code link warnings from llvm-link

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -90,6 +90,9 @@ const char *SYCL::Linker::constructLLVMLinkCommand(Compilation &C,
     CmdArgs.push_back(OutputFileName);
   } else
     CmdArgs.push_back(Output.getFilename());
+  // TODO: temporary workaround for a problem with warnings reported by
+  // llvm-link when driver links LLVM modules with empty modules
+  CmdArgs.push_back("--suppress-warnings");
   SmallString<128> ExecPath(C.getDriver().Dir);
   llvm::sys::path::append(ExecPath, "llvm-link");
   const char *Exec = C.getArgs().MakeArgString(ExecPath);


### PR DESCRIPTION
Driver reports following warnings each time we link `fat` object and
`non-fat` object files.

warning: Linking two modules of different data layouts:
'/tmp/main-8fa6e0.o' is '' whereas 'llvm-link' is
'e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024'

The reason is that driver "unbundles" all objects files including
"non-fat" ones to get device code. Unbundler provides an empty file as
device code of "non-fat" object file, which is linked with the device
code unbundled from the "fat" objects. `llvm-link` emits warnings if
data layout string of input LLVM modules doesn't match.

This is common case when we link host-only static library to a SYCL
application (e.g. Khronos SYCL CTS).

This warning has no value for the compiler users, but might be very
annoying. While we are working on good solution to this problem, let's
suppress `llvm-link` warnings.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>