### PR TITLE
[SYCL] Add the global namespace specifier for the kernel names if necessary.

### DIFF
--- a/clang/include/clang/AST/PrettyPrinter.h
+++ b/clang/include/clang/AST/PrettyPrinter.h
@@ -42,7 +42,7 @@ struct PrintingPolicy {
         SuppressScope(false), SuppressUnwrittenScope(false),
         SuppressInitializers(false), ConstantArraySizeAsWritten(false),
         AnonymousTagLocations(true), SuppressStrongLifetime(false),
-        SuppressLifetimeQualifiers(false),
+        SuppressLifetimeQualifiers(false), SuppressTypedefs(false),
         SuppressTemplateArgsInCXXConstructors(false), Bool(LO.Bool),
         Restrict(LO.C99), Alignof(LO.CPlusPlus11), UnderscoreAlignof(LO.C11),
         UseVoidForZeroParams(!LO.CPlusPlus), TerseOutput(false),
@@ -158,6 +158,17 @@ struct PrintingPolicy {
 
   /// When true, suppress printing of lifetime qualifier in ARC.
   unsigned SuppressLifetimeQualifiers : 1;
+
+  /// When true prints a canonical type instead of an alias. E.g.
+  ///   \code
+  ///   using SizeT = int;
+  ///   template<SizeT N> class C;
+  ///   \endcode
+  /// will be printed as
+  ///   \code
+  ///   template<int N> class C;
+  ///   \endcode
+  unsigned SuppressTypedefs : 1;
 
   /// When true, suppresses printing template arguments in names of C++
   /// constructors.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1423,7 +1423,7 @@ void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D) {
   // print declaration into a string:
   PrintingPolicy P(D->getASTContext().getLangOpts());
   P.adjustForCPlusPlusFwdDecl();
-  P.PrintCanonicalTypes = true;
+  P.SuppressTypedefs = true;
   std::string S;
   llvm::raw_string_ostream SO(S);
   D->print(SO, P);
@@ -1638,7 +1638,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     } else {
       LangOptions LO;
       PrintingPolicy P(LO);
-      P.PrintCanonicalTypes = true;
+      P.SuppressTypedefs = true;
       O << "template <> struct KernelInfo<"
         << eraseAnonNamespace(K.NameType.getAsString(P)) << "> {\n";
     }

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -2,15 +2,15 @@
 // RUN: FileCheck -input-file=%t.h %s
 
 // CHECK:template <> struct KernelInfo<class KernelName> {
-// CHECK:template <> struct KernelInfo<class nm1::nm2::KernelName0> {
-// CHECK:template <> struct KernelInfo<class nm1::KernelName1> {
-// CHECK:template <> struct KernelInfo<class nm1::KernelName3<class nm1::nm2::KernelName0>> {
-// CHECK:template <> struct KernelInfo<class nm1::KernelName3<class nm1::KernelName1>> {
-// CHECK:template <> struct KernelInfo<class nm1::KernelName4<class nm1::nm2::KernelName0>> {
-// CHECK:template <> struct KernelInfo<class nm1::KernelName4<class nm1::KernelName1>> {
-// CHECK:template <> struct KernelInfo<class nm1::KernelName3<class KernelName5>> {
-// CHECK:template <> struct KernelInfo<class nm1::KernelName4<class KernelName7>> {
-// CHECK:template <> struct KernelInfo<class nm1::KernelName8<class nm1::nm2::C>> {
+// CHECK:template <> struct KernelInfo<::nm1::nm2::KernelName0> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName1> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName3< ::nm1::nm2::KernelName0>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName3< ::nm1::KernelName1>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName4< ::nm1::nm2::KernelName0>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName4< ::nm1::KernelName1>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName3<KernelName5>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName4<KernelName7>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName8< ::nm1::nm2::C>> {
 // CHECK:template <> struct KernelInfo<class TmplClassInAnonNS<class ClassInAnonNS>> {
 
 // This test checks if the SYCL device compiler is able to generate correct

--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -48,9 +48,9 @@
 // CHECK-NEXT: };
 //
 // CHECK: template <> struct KernelInfo<class first_kernel> {
-// CHECK: template <> struct KernelInfo<class second_namespace::second_kernel<char>> {
-// CHECK: template <> struct KernelInfo<class third_kernel<1, int, struct point<struct X> >> {
-// CHECK: template <> struct KernelInfo<class fourth_kernel<struct template_arg_ns::namespaced_arg<1> >> {
+// CHECK: template <> struct KernelInfo<::second_namespace::second_kernel<char>> {
+// CHECK: template <> struct KernelInfo<::third_kernel<1, int, ::point<X> >> {
+// CHECK: template <> struct KernelInfo<::fourth_kernel< ::template_arg_ns::namespaced_arg<1> >> {
 
 #include "sycl.hpp"
 

--- a/sycl/test/regression/kernel_name_inside_sycl_namespace.cpp
+++ b/sycl/test/regression/kernel_name_inside_sycl_namespace.cpp
@@ -1,0 +1,31 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+//==------- kernel_name_inside_sycl_namespace.cpp - Regression test --------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+struct A {};
+namespace sycl {
+struct B {};
+using b_t = B;
+using a_t = A;
+} // namespace sycl
+
+int main() {
+  cl::sycl::queue Queue;
+  Queue.submit(
+      [&](cl::sycl::handler &CGH) { CGH.single_task<sycl::b_t>([=]() {}); });
+  Queue.submit(
+      [&](cl::sycl::handler &CGH) { CGH.single_task<sycl::a_t>([=]() {}); });
+  return 0;
+}


### PR DESCRIPTION
Added a fix for the integration header generation - instead of policy
`PrintCanonicalTypes`, the new policy `SuppressTypedefs `is used. Policy
`SuppressTypedefs` only works for aliases and does not violate namespaces
for non-builtin types.

The problem caused if a user will use a type from namespace `cl`, `sycl`
or `detail`. The compiler will try to found the type inside SYCL internal
namespaces, not the user namespaces.

E.g.:

```
/* integration_header.hpp */
...
// forward declarations for kernel names
namespace sycl {
  struct B;
}
...
// KernelInfo
namespace cl { namespace sycl { detail {
    ...
    // before the patch, does not work
    template <> struct KernelInfo<struct sycl::B> {
    // after the patch, works
    template <> struct KernelInfo<::sycl::B> {
    ...
}}}
...
```

C++ looks for namespaces from current to global, and in this example the
compiler finds the `sycl` namespace before it's necessary. Enforcing search
start from the global namespace resolves this problem.

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>