### PR TITLE
[SYCL][NFC] Remove reference to the file name from the assert message

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -149,7 +149,7 @@ namespace pi {
 namespace RT = cl::sycl::detail::pi;
 
 #define PI_ASSERT(cond, msg) \
-  RT::assertion((cond), "assert @ " __FILE__ ":" STRINGIFY_LINE(__LINE__) msg);
+  RT::assertion((cond), "assert: " msg);
 
 #define PI_TRACE(func) RT::Trace<decltype(func)>(func, #func)
 


### PR DESCRIPTION
To avoid embedding user file names into the generated binaries.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>
