### PR TITLE
[SYCL] Adjust adding of depfile information for FPGA AOT compilation

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1074,6 +1074,11 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
     } else if (A->getOption().matches(options::OPT_M) ||
                A->getOption().matches(options::OPT_MM)) {
       DepFile = "-";
+    } else if (A->getOption().matches(options::OPT_MMD) &&
+        Args.hasArg(options::OPT_fintelfpga)) {
+      // When generating dependency files for FPGA AOT, the output files will
+      // always be named after the source file.
+      DepFile = Args.MakeArgString(Twine(getBaseInputStem(Args, Inputs)) + ".d");
     } else {
       DepFile = getDependencyFileName(Args, Inputs);
       C.addFailureResultFile(DepFile, &JA);

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -297,9 +297,8 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
           continue;
         if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
           llvm::sys::path::replace_extension(FN, "d");
-          if (llvm::sys::fs::exists(FN))
-            FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
-                  Args.MakeArgString(FN), Args.MakeArgString(FN)));
+          FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
+              Args.MakeArgString(FN), Args.MakeArgString(FN)));
         }
       }
     }

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -6,8 +6,8 @@
 /// -fintelfpga implies -g and -MMD
 // RUN:   %clang++ -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-INTELFPGA %s
-// CHK-TOOLS-INTELFPGA: clang{{.*}} "-dependency-file"
-// CHK-TOOLS-INTELFPGA: clang{{.*}} "-debug-info-kind=limited"
+// CHK-TOOLS-INTELFPGA: clang{{.*}} "-debug-info-kind=limited" {{.*}} "-dependency-file"
+// CHK-TOOLS-INTELFPGA: aoc{{.*}} "-dep-files={{.*}}"
 
 /// -fintelfpga -fsycl-link tests
 // RUN:  touch %t.o
@@ -90,6 +90,17 @@
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-REUSE-EXE %s
 // CHK-FPGA-REUSE-EXE: warning: -reuse-exe file 'does_not_exist' not found; ignored
 //
+
+/// -fintelfpga dependency file generation test
+// RUN: touch %t-1.cpp
+// RUN: touch %t-2.cpp
+// RUN: %clang++ -### -fsycl -fintelfpga %t-1.cpp %t-2.cpp -o %t.out 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-DEP-FILES %s
+// RUN: %clang++ -### -fsycl -fintelfpga %t-1.cpp %t-2.cpp 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-DEP-FILES %s
+// CHK-FPGA-DEP-FILES: clang{{.*}} "-dependency-file" "[[INPUT1:.+\.d]]"
+// CHK-FPGA-DEP-FILES: clang{{.*}} "-dependency-file" "[[INPUT2:.+\.d]]"
+// CHK-FPGA-DEP-FILES: aoc{{.*}} "-dep-files={{.*}}[[INPUT1]],{{.*}}[[INPUT2]]"
 
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc


### PR DESCRIPTION
There was a problem where the dependency file information was not being
passed to aoc when compiling from source.  This was due to a file exists
check that was being performed before the actual file is generated

Also when generating dependency files for FPGA AOT, be sure that each file
compiled creates an individual dep file to be processed (do not use -o)

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>