### PR TITLE
[SYCL] Preserve filename passed to ocloc through -output

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -389,6 +389,8 @@ void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
     CmdArgs.push_back("-file");
     CmdArgs.push_back(II.getFilename());
   }
+  // The next line prevents ocloc from modifying the image name
+  CmdArgs.push_back("-output_no_suffix");
   CmdArgs.push_back("-spirv_input");
   TranslateSYCLTargetArgs(C, Args, getToolChain(), CmdArgs);
   SmallString<128> ExecPath(getToolChain().GetProgramPath("ocloc"));

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -530,7 +530,7 @@
 
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen-unknown-linux-sycldevice -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-GEN-OPTS %s
-// CHK-TOOLS-GEN-OPTS: ocloc{{.*}} "-output" {{.*}} "-DFOO1" "-DFOO2"
+// CHK-TOOLS-GEN-OPTS: ocloc{{.*}} "-output" {{.*}} "-output_no_suffix" {{.*}} "-DFOO1" "-DFOO2"
 
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-linux-sycldevice -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-CPU-OPTS %s


### PR DESCRIPTION
A flag "-output_no_suffix" was added to ocloc, and enabling it
prevents the tool from appending it's family name (e.g. "_Gen9core.bin")
to the filename passed through the -output option.

Meanwhile, clang-offload-bundler expects no suffixes with the binary
image name. Enabling the option ensures that our toolchain is always
able to find the image by the given name.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>