### PR TITLE
[SYCL] Fix args size passed to piEnqueueNativeKernel

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -673,7 +673,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     pi_result Error = PI_CALL_RESULT(RT::piEnqueueNativeKernel(
         MQueue->getHandleRef(), DispatchNativeKernel, (void *)ArgsBlob.data(),
-        HostTask->MArgs[0].MSize, Buffers.size(), Buffers.data(),
+        ArgsBlob.size() * sizeof(ArgsBlob[0]), Buffers.size(), Buffers.data(),
         const_cast<const void **>(MemLocs.data()), RawEvents.size(),
         RawEvents.empty() ? nullptr : RawEvents.data(), &Event));
 


### PR DESCRIPTION
Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>