### PR TITLE
[SYCL] Delete range class default constructor.

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -158,7 +158,7 @@ namespace detail {
 // DefaultValue, truncation just removes extra values.
 template <int NewDim, int DefaultValue, template <int> class T, int OldDim>
 static T<NewDim> convertToArrayOfN(T<OldDim> OldObj) {
-  T<NewDim> NewObj;
+  T<NewDim> NewObj = InitializedVal<NewDim, T>::template get<0>();
   const int CopyDims = NewDim > OldDim ? OldDim : NewDim;
   for (int I = 0; I < CopyDims; ++I)
     NewObj[I] = OldObj[I];
@@ -727,7 +727,10 @@ class accessor :
 
 public:
   // Default constructor for objects later initialized with __init member.
-  accessor() : impl({}) {}
+  accessor()
+    : impl({}, detail::InitializedVal<AdjustedDim, range>::template get<0>(),
+            detail::InitializedVal<AdjustedDim, range>::template get<0>()) {}
+
 #else
   using AccessorBaseHost::getAccessRange;
   using AccessorBaseHost::getMemoryRange;
@@ -1035,7 +1038,8 @@ class accessor<DataT, Dimensions, AccessMode, access::target::local,
 
 public:
   // Default constructor for objects later initialized with __init member.
-  accessor() : impl({}) {}
+  accessor()
+      : impl(detail::InitializedVal<AdjustedDim, range>::template get<0>()) {}
 
 private:
   PtrType getQualifiedPtr() const { return MData; }

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -45,7 +45,9 @@ public:
 
 template <int Dims> class LocalAccessorBaseDevice {
 public:
-  LocalAccessorBaseDevice(sycl::range<Dims> Size) : AccessRange(Size) {}
+  LocalAccessorBaseDevice(sycl::range<Dims> Size)
+      : AccessRange(Size),
+        MemRange(InitializedVal<Dims, range>::template get<0>()) {}
   // TODO: Actually we need only one field here, but currently compiler requires
   // all of them.
   range<Dims> AccessRange;

--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -202,7 +202,7 @@ public:
   runOnHost(const NDRDescT &NDRDesc) {
     size_t XYZ[3] = {0};
     sycl::id<Dims> ID;
-    sycl::range<Dims> Range;
+    sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
     for (int I = 0; I < Dims; ++I)
       Range[I] = NDRDesc.GlobalSize[I];
 
@@ -226,7 +226,7 @@ public:
   typename std::enable_if<
       std::is_same<ArgT, item<Dims, /*Offset=*/true>>::value>::type
   runOnHost(const NDRDescT &NDRDesc) {
-    sycl::range<Dims> Range;
+    sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
     sycl::id<Dims> Offset;
     for (int I = 0; I < Dims; ++I) {
       Range[I] = NDRDesc.GlobalSize[I];
@@ -253,7 +253,8 @@ public:
   template <class ArgT = KernelArgType>
   typename std::enable_if<std::is_same<ArgT, nd_item<Dims>>::value>::type
   runOnHost(const NDRDescT &NDRDesc) {
-    sycl::range<Dims> GroupSize;
+    sycl::range<Dims> GroupSize(
+        InitializedVal<Dims, range>::template get<0>());
     for (int I = 0; I < Dims; ++I) {
       if (NDRDesc.LocalSize[I] == 0 ||
           NDRDesc.GlobalSize[I] % NDRDesc.LocalSize[I] != 0)
@@ -261,8 +262,10 @@ public:
       GroupSize[I] = NDRDesc.GlobalSize[I] / NDRDesc.LocalSize[I];
     }
 
-    sycl::range<Dims> GlobalSize;
-    sycl::range<Dims> LocalSize;
+    sycl::range<Dims> LocalSize(
+        InitializedVal<Dims, range>::template get<0>());
+    sycl::range<Dims> GlobalSize(
+        InitializedVal<Dims, range>::template get<0>());
     sycl::id<Dims> GlobalOffset;
     for (int I = 0; I < Dims; ++I) {
       GlobalOffset[I] = NDRDesc.GlobalOffset[I];
@@ -291,7 +294,7 @@ public:
   template <typename ArgT = KernelArgType>
   enable_if_t<std::is_same<ArgT, cl::sycl::group<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    sycl::range<Dims> NGroups;
+    sycl::range<Dims> NGroups(InitializedVal<Dims, range>::template get<0>());
 
     for (int I = 0; I < Dims; ++I) {
       if (NDRDesc.LocalSize[I] == 0 ||
@@ -299,9 +302,11 @@ public:
         throw sycl::runtime_error("Invalid local size for global size");
       NGroups[I] = NDRDesc.GlobalSize[I] / NDRDesc.LocalSize[I];
     }
-    sycl::range<Dims> GlobalSize;
-    sycl::range<Dims> LocalSize;
 
+    sycl::range<Dims> LocalSize(
+      InitializedVal<Dims, range>::template get<0>());
+    sycl::range<Dims> GlobalSize(
+      InitializedVal<Dims, range>::template get<0>());
     for (int I = 0; I < Dims; ++I) {
       LocalSize[I] = NDRDesc.LocalSize[I];
       GlobalSize[I] = NDRDesc.GlobalSize[I];

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -198,7 +198,8 @@ template <int NDIMS> struct NDLoop {
         InitializedVal<NDIMS, LoopIndexTy>::template get<0>();
     const LoopBoundTy<NDIMS> Stride =
         InitializedVal<NDIMS, LoopBoundTy>::template get<1>();
-    LoopIndexTy<NDIMS> Index; // initialized down the call stack
+    LoopIndexTy<NDIMS> Index =
+        InitializedVal<NDIMS, LoopIndexTy>::template get<0>();
 
     NDLoopIterateImpl<NDIMS, NDIMS - 1, LoopBoundTy, FuncTy, LoopIndexTy>{
         LowerBound, Stride, UpperBound, f, Index};

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -228,7 +228,8 @@ public:
 
   image_impl(cl_mem MemObject, const context &SyclContext,
              event AvailableEvent = {})
-      : BaseT(MemObject, SyclContext, std::move(AvailableEvent)) {
+      : BaseT(MemObject, SyclContext, std::move(AvailableEvent)),
+        MRange(InitializedVal<Dimensions, range>::template get<0>()) {
     RT::PiMem Mem = pi::cast<RT::PiMem>(BaseT::MInteropMemObject);
     PI_CALL(RT::piMemGetInfo(Mem, CL_MEM_SIZE, sizeof(size_t),
                              &(BaseT::MSizeInBytes), nullptr));

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -68,7 +68,8 @@ public:
       : base(item.get_id(0), item.get_id(1), item.get_id(2)) {}
 
   explicit operator range<dimensions>() const {
-    range<dimensions> result;
+    range<dimensions> result(
+        detail::InitializedVal<dimensions, range>::template get<0>());
     for (int i = 0; i < dimensions; ++i) {
       result[i] = this->get(i);
     }

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -59,7 +59,7 @@ public:
   range(range<dimensions> &&rhs) = default;
   range<dimensions> &operator=(const range<dimensions> &rhs) = default;
   range<dimensions> &operator=(range<dimensions> &&rhs) = default;
-  range() = default;
+  range() = delete;
 
 // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
 #define __SYCL_GEN_OPT(op)                                                     \
@@ -133,5 +133,6 @@ public:
 
 #undef __SYCL_GEN_OPT
 };
+
 } // namespace sycl
 } // namespace cl


### PR DESCRIPTION
The SYCL specification does not provide a default constructor for
the range class.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>
Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>