### PR TITLE
Re-implement -reuse-exe for FPGA

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -480,7 +480,4 @@ def warn_drv_libstdcxx_not_found : Warning<
   InGroup<DiagGroup<"stdlibcxx-not-found">>;
 
 def err_drv_cannot_mix_options : Error<"cannot specify '%1' along with '%0'">;
-
-def warn_drv_reuse_exe_file_not_found : Warning<
-  "-reuse-exe file '%0' not found; ignored">, InGroup<IntelFPGA>;
 }

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -346,28 +346,8 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
   TranslateSYCLTargetArgs(C, Args, getToolChain(), CmdArgs);
   // Look for -reuse-exe=XX option
   if (Arg *A = Args.getLastArg(options::OPT_reuse_exe_EQ)) {
-    StringRef reuse_exe = A->getValue();
     Args.ClaimAllArgs(options::OPT_reuse_exe_EQ);
-    if (llvm::sys::fs::exists(reuse_exe)) {
-      SmallString<128> ExecPath(getToolChain().GetProgramPath("aocl"));
-      const char *Exec = C.getArgs().MakeArgString(ExecPath);
-      ArgStringList ExtractArgs{"do", "aocl-extract-aocx", "-i"};
-      ExtractArgs.push_back(C.getArgs().MakeArgString(reuse_exe));
-      std::string TmpName = C.getDriver().GetTemporaryPath("reused-exe", "aocx");
-      auto OutputFileName = C.addTempFile(C.getArgs().MakeArgString(TmpName));
-      ExtractArgs.push_back("-o");
-      ExtractArgs.push_back(OutputFileName);
-      Command run_extract(JA, *this, Exec, ExtractArgs, None);
-      const Command* failingCommand = nullptr;
-      auto res = C.ExecuteCommand(run_extract, failingCommand);
-      if (res == 0) {
-        // We extracted the aocx file.  Pass it to the aoc command.
-        CmdArgs.push_back(Args.MakeArgString(Twine("-reuse-aocx=") + TmpName));
-      }
-    } else {
-      const Driver &D = getToolChain().getDriver();
-      D.Diag(clang::diag::warn_drv_reuse_exe_file_not_found) << reuse_exe;
-    }
+    CmdArgs.push_back(Args.MakeArgString(A->getAsString(Args)));
   }
 
   SmallString<128> ExecPath(getToolChain().GetProgramPath("aoc"));

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -85,11 +85,11 @@
 // CHK-FPGA-LINK-SRC: 15: clang-offload-wrapper, {14}, object, (device-sycl)
 // CHK-FPGA-LINK-SRC: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64_fpga-unknown-{{linux|windows}}-sycldevice)" {15}, archive
 
-// -fintelfpga -reuse-exe tests
-// RUN: %clang++ -### -fsycl -fintelfpga %s -reuse-exe=does_not_exist 2>&1 \
+/// -fintelfpga with -reuse-exe=
+// RUN:  touch %t.cpp
+// RUN:  %clang++ -### -reuse-exe=testing -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t.cpp 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-REUSE-EXE %s
-// CHK-FPGA-REUSE-EXE: warning: -reuse-exe file 'does_not_exist' not found; ignored
-//
+// CHK-FPGA-REUSE-EXE: aoc{{.*}} "-o" {{.*}} "-sycl" {{.*}} "-reuse-exe=testing"
 
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc


### PR DESCRIPTION
Move the processing from clang++ to the aoc command, in order to ensure
that the aocl-extract-aocx program can be located and removing the need
for the 'aocl do' invocation. Remove the message and message group
previously added.

Signed-off-by: Mark Mendell <mark.p.mendell@intel.com>