### PR TITLE
[SYCL] Fix compare_exchange_strong to properly update Expected inout param

### DIFF
--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -236,7 +236,12 @@ public:
     T Value = __spirv_AtomicCompareExchange(
         Ptr, SpirvScope, detail::getSPIRVMemorySemanticsMask(SuccessOrder),
         detail::getSPIRVMemorySemanticsMask(FailOrder), Desired, Expected);
-    return (Value == Expected);
+
+    if (Value == Expected)
+      return true;
+
+    Expected = Value;
+    return false;
 #else
     return Ptr->compare_exchange_strong(Expected, Desired,
                                         detail::getStdMemoryOrder(SuccessOrder),

--- a/sycl/test/basic_tests/compare_exchange_strong.cpp
+++ b/sycl/test/basic_tests/compare_exchange_strong.cpp
@@ -1,0 +1,40 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+using namespace cl::sycl;
+
+int main() {
+  queue testQueue;
+
+  char testResult;
+  {
+    buffer<char, 1> resultBuf(&testResult, range<1>(1));
+
+    int32_t data = 42;
+    buffer<int32_t, 1> buf(&data, range<1>(1));
+
+    testQueue.submit([&](handler &cgh) {
+      auto globAcc = buf.template get_access<access::mode::atomic>(cgh);
+      auto resultAcc = resultBuf.template get_access<access::mode::write>(cgh);
+      cgh.single_task<class foo>([=]() {
+        auto a = globAcc[0];
+        char result = 0;
+        int32_t expected = 0; // Set to wrong value.
+        char updated = a.compare_exchange_strong(expected, 1);
+        if (updated)
+          // Update shouldn't happen, value in memory is different from
+          // expected!
+          result = 1;
+        if (expected != 42)
+          // "Expected" inout parameter wasn't updated to the value read!
+          result = 1;
+        resultAcc[0] = result;
+      });
+    });
+  }
+  assert(testResult == 0 && "Test failed!");
+  return testResult;
+}


### PR DESCRIPTION
For device code, __spirv_AtomicCompareExchange doesn't seem to update the
Expected parameter, new value is simply returned instead. However, SYCL's API
requires the updated value to be passed through inout parameter - do so.

Signed-off-by: Andrei Elovikov <andrei.elovikov@intel.com>