### PR TITLE
WIP: [SYCL] Diagnose violations from function object passed to the kernel

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -354,18 +354,6 @@ public:
     return true;
   }
   
-  bool VisitGCCAsmStmt(GCCAsmStmt *S) {
-    SemaRef.Diag(S->getBeginLoc(), diag::err_sycl_restrict)
-        << Sema::KernelUseAssembly;
-    return true;
-  }
- 
-  bool VisitMSAsmStmt(MSAsmStmt *S) {
-    SemaRef.Diag(S->getBeginLoc(), diag::err_sycl_restrict)
-        << Sema::KernelUseAssembly;
-    return true;
-  }
-
   // The call graph for this translation unit.
   CallGraph SYCLCG;
   // The set of functions called by a kernel function.

--- a/clang/test/SemaSYCL/diag-fobj-call.cpp
+++ b/clang/test/SemaSYCL/diag-fobj-call.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -fsyntax-only -verify %s
+
+void bar() { throw 5; } // expected-no-error
+void foo() { throw 10; } // expected-error {{SYCL kernel cannot use exceptions}}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  // expected-note@+1 {{called by 'operator()'}}
+  kernel_single_task<class fake_kernel>([]() { foo(); });
+  bar();
+}

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -26,6 +26,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 
 int main() {
   foo();
+  // expected-note@+1 {{called by 'operator()'}}
   kernel_single_task<class fake_kernel>([]() { bar(); });
   return 0;
 }

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -188,7 +188,6 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   kernelFunc();
   a_type ab;
   a_type *p;
-  // expected-note@+1 {{called by 'kernel_single_task'}}
   use2(ab, p);
 }
 


### PR DESCRIPTION
Scan the body of the routine passed as a function object to the SYCL
kernel.  The call graph traversed previously to emit deferred
diagnostics was missing the passed function object.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>