### PR TITLE
[SYCL] Image_accessor read with sampler for host device Part2 - Linear Filt Mode

### DIFF
--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -894,10 +894,6 @@ DataT ReadPixelDataLinearFiltMode(const cl_int8 CoordValues,
                                   void *BasePtr, const uint8_t ElementSize) {
   cl_int i0 = CoordValues.s0(), j0 = CoordValues.s1(), k0 = CoordValues.s2(),
          i1 = CoordValues.s4(), j1 = CoordValues.s5(), k1 = CoordValues.s6();
-  cl_float a = abc.x();
-  cl_float b = abc.y();
-  cl_float c = abc.z();
-  cl_float4 RetData;
 
   auto getColorInFloat =
       [&](cl_int4 V) {
@@ -924,15 +920,21 @@ DataT ReadPixelDataLinearFiltMode(const cl_int8 CoordValues,
   
   cl_float4 Ci1j1k1 = getColorInFloat(cl_int4{i1, j1, k1, 0});
 
-  RetData =
-      ((1 - a) * (1 - b) * (1 - c) * Ci0j0k0) +
-      (a * (1 - b) * (1 - c) * Ci1j0k0) +
-      ((1 - a) * b * (1 - c) * Ci0j1k0) +
-      (a * b * (1 - c) * Ci1j1k0) +
-      ((1 - a) * (1 - b) * c * Ci0j0k1) +
-      (a * (1 - b) * c * Ci1j0k1) +
-      ((1 - a) * b * c * Ci0j1k1) +
-      (a * b * c * Ci1j1k1);
+  cl_float a = abc.x();
+  cl_float b = abc.y();
+  cl_float c = abc.z();
+
+  Ci0j0k0 = (1 - a) * (1 - b) * (1 - c) * Ci0j0k0;
+  Ci1j0k0 = a * (1 - b) * (1 - c) * Ci1j0k0;
+  Ci0j1k0 = (1 - a) * b * (1 - c) * Ci0j1k0;
+  Ci1j1k0 = a * b * (1 - c) * Ci1j1k0;
+  Ci0j0k1 = (1 - a) * (1 - b) * c * Ci0j0k1;
+  Ci1j0k1 = a * (1 - b) * c * Ci1j0k1;
+  Ci0j1k1 = (1 - a) * b * c * Ci0j1k1;
+  Ci1j1k1 = a * b * c * Ci1j1k1;
+
+  cl_float4 RetData = Ci0j0k0 + Ci1j0k0 + Ci0j1k0 + Ci1j1k0 + Ci0j0k1 +
+                      Ci1j0k1 + Ci0j1k1 + Ci1j1k1;
 
   // For 2D image:k0 = 0, k1 = 0, c = 0.5
   // RetData = (1 – a) * (1 – b) * Ci0j0 + a * (1 – b) * Ci1j0 +

--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -97,6 +97,11 @@ getImageOffset(const vec<T, 4> &Coords, id<3> ImgPitch,
 // read from based on Addressing Mode for Nearest filter mode.
 cl_int4 getPixelCoordNearestFiltMode(cl_float4, addressing_mode, range<3>);
 
+// Process cl_float4 Coordinates and return the appropriate Pixel Coordinates to
+// read from based on Addressing Mode for Linear filter mode.
+cl_int8 getPixelCoordLinearFiltMode(cl_float4, addressing_mode, range<3>,
+                                    cl_float4 &);
+
 // Check if PixelCoord are out of range for Sampler with clamp adressing mode.
 bool isOutOfRange(cl_int4 PixelCoord, addressing_mode SmplAddrMode,
                   range<3> ImgRange);
@@ -359,8 +364,7 @@ void convertReadData(const vec<ChannelType, 4> PixelData,
                                0x001F /*b:bits 0-4*/, 0x0000);
     vec<cl_ushort, 4> ShiftBits(10, 5, 0, 0);
     Temp = (Temp & MaskBits) >> ShiftBits;
-    RetData =
-        (Temp.template convert<cl_float>()) / 31.0f;
+    RetData = (Temp.template convert<cl_float>()) / 31.0f;
     break;
   }
   case image_channel_type::unorm_int_101010: {
@@ -372,8 +376,7 @@ void convertReadData(const vec<ChannelType, 4> PixelData,
                              0x000003FF /*b:bits 0-9*/, 0x00000000);
     vec<cl_uint, 4> ShiftBits(20, 10, 0, 0);
     Temp = (Temp & MaskBits) >> ShiftBits;
-    RetData =
-        (Temp.template convert<cl_float>()) / 1023.0f;
+    RetData = (Temp.template convert<cl_float>()) / 1023.0f;
     break;
   }
   case image_channel_type::signed_int8:
@@ -568,7 +571,8 @@ convertWriteData(const vec<cl_float, 4> WriteData,
       // in bits 9:5 and B in bits 4:0
       PixelData.x() =
           (PixelData.x() << 10) | (PixelData.y() << 5) | PixelData.z();
-      return PixelData.convert<ChannelType>();;
+      return PixelData.convert<ChannelType>();
+      ;
     }
   case image_channel_type::unorm_int_101010:
     // min(convert_ushort_sat_rte(f * 1023.0f), 0x3ff)
@@ -580,7 +584,8 @@ convertWriteData(const vec<cl_float, 4> WriteData,
       PixelData = cl::sycl::min(PixelData, static_cast<ChannelType>(0x3ff));
       PixelData.x() =
           (PixelData.x() << 20) | (PixelData.y() << 10) | PixelData.z();
-      return PixelData.convert<ChannelType>();;
+      return PixelData.convert<ChannelType>();
+      ;
     }
   case image_channel_type::signed_int8:
   case image_channel_type::signed_int16:
@@ -747,9 +752,9 @@ void imageWriteHostImpl(const CoordT &Coords, const WriteDataT &Color,
   }
 }
 
-// Method called to read a Coord by imageReadSamplerHostImpl when filter mode in
-// the Sampler is Nearest. This method takes Unnormalized Coords - 'PixelCoord'
-// as cl_int4. Invalid Coord are denoted by 0. Steps:
+// Method called to read a Coord by getColor function when the Coord is
+// in-range. This method takes Unnormalized Coords - 'PixelCoord' as cl_int4.
+// Invalid Coord are denoted by 0. Steps:
 // 1. Compute Offset for given Unnormalised Coordinates using ImagePitch and
 // ElementSize.(getImageOffset)
 // 2. Add this Offset to BasePtr to compute the location of the Image.
@@ -758,15 +763,15 @@ void imageWriteHostImpl(const CoordT &Coords, const WriteDataT &Color,
 // 4. Read the appropriate number of channels(computed using
 // ImageChannelOrder) of the appropriate Channel datatype into Color
 // variable.(readPixel)
-// 5. Convert the Read Data into Return DataTy based on conversion rules in
+// 5. Convert the Read Data into Return DataT based on conversion rules in
 // the Spec.(convertReadData)
-// Possible DataTy are cl_int4, cl_uint4, cl_float4, cl_half4;
-template <typename DataTy>
-DataTy ReadPixelDataNearestFiltMode(cl_int4 PixelCoord, id<3> ImgPitch,
-                                    image_channel_type ImageChannelType,
-                                    image_channel_order ImageChannelOrder,
-                                    void *BasePtr, uint8_t ElementSize) {
-  DataTy Color(0);
+// Possible DataT are cl_int4, cl_uint4, cl_float4, cl_half4;
+template <typename DataT>
+DataT ReadPixelData(cl_int4 PixelCoord, id<3> ImgPitch,
+                    image_channel_type ImageChannelType,
+                    image_channel_order ImageChannelOrder, void *BasePtr,
+                    uint8_t ElementSize) {
+  DataT Color(0);
   auto Ptr = static_cast<unsigned char *>(BasePtr) +
              getImageOffset(PixelCoord, ImgPitch,
                             ElementSize); // Utility to compute offset in
@@ -853,6 +858,88 @@ DataTy ReadPixelDataNearestFiltMode(cl_int4 PixelCoord, id<3> ImgPitch,
   }
 
   return Color;
+}
+
+// Checks if the PixelCoord is out-of-range, and returns appropriate border or
+// color value at the PixelCoord.
+template <typename DataT>
+DataT getColor(cl_int4 PixelCoord, addressing_mode SmplAddrMode,
+               range<3> ImgRange, id<3> ImgPitch,
+               image_channel_type ImgChannelType,
+               image_channel_order ImgChannelOrder, void *BasePtr,
+               uint8_t ElementSize) {
+  DataT RetData;
+  if (isOutOfRange(PixelCoord, SmplAddrMode, ImgRange)) {
+    cl_float4 BorderColor = (getBorderColor(ImgChannelOrder));
+    RetData = BorderColor.convert<typename TryToGetElementType<DataT>::type>();
+  } else {
+    RetData = ReadPixelData<DataT>(PixelCoord, ImgPitch, ImgChannelType,
+                                   ImgChannelOrder, BasePtr, ElementSize);
+  }
+  return RetData;
+}
+
+// Computes and returns color value with Linear Filter Mode.
+// Steps:
+// 1. Computes the 8 coordinates using all combinations of i0/i1,j0/j1,k0/k1.
+// 2. Calls getColor() on each Coordinate.(Ci*j*k*)
+// 3. Computes the return Color Value using a,b,c and the Color values. 
+template <typename DataT>
+DataT ReadPixelDataLinearFiltMode(cl_int8 CoordValues, cl_float4 abc,
+                                  addressing_mode SmplAddrMode,
+                                  range<3> ImgRange, id<3> ImgPitch,
+                                  image_channel_type ImgChannelType,
+                                  image_channel_order ImgChannelOrder,
+                                  void *BasePtr, uint8_t ElementSize) {
+  cl_int i0 = CoordValues.s0(), j0 = CoordValues.s1(), k0 = CoordValues.s2(),
+         i1 = CoordValues.s4(), j1 = CoordValues.s5(), k1 = CoordValues.s6();
+  cl_float a = abc.x();
+  cl_float b = abc.y();
+  cl_float c = abc.z();
+  cl_float4 RetData;
+
+  // Get Color Values at each Coordinate.
+  DataT Ci0j0k0 =
+      getColor<DataT>(cl_int4{i0, j0, k0, 0}, SmplAddrMode, ImgRange, ImgPitch,
+                      ImgChannelType, ImgChannelOrder, BasePtr, ElementSize);
+  DataT Ci1j0k0 =
+      getColor<DataT>(cl_int4{i1, j0, k0, 0}, SmplAddrMode, ImgRange, ImgPitch,
+                      ImgChannelType, ImgChannelOrder, BasePtr, ElementSize);
+  DataT Ci0j1k0 =
+      getColor<DataT>(cl_int4{i0, j1, k0, 0}, SmplAddrMode, ImgRange, ImgPitch,
+                      ImgChannelType, ImgChannelOrder, BasePtr, ElementSize);
+  DataT Ci1j1k0 =
+      getColor<DataT>(cl_int4{i1, j1, k0, 0}, SmplAddrMode, ImgRange, ImgPitch,
+                      ImgChannelType, ImgChannelOrder, BasePtr, ElementSize);
+  DataT Ci0j0k1 =
+      getColor<DataT>(cl_int4{i0, j0, k1, 0}, SmplAddrMode, ImgRange, ImgPitch,
+                      ImgChannelType, ImgChannelOrder, BasePtr, ElementSize);
+  DataT Ci1j0k1 =
+      getColor<DataT>(cl_int4{i1, j0, k1, 0}, SmplAddrMode, ImgRange, ImgPitch,
+                      ImgChannelType, ImgChannelOrder, BasePtr, ElementSize);
+  DataT Ci0j1k1 =
+      getColor<DataT>(cl_int4{i0, j1, k1, 0}, SmplAddrMode, ImgRange, ImgPitch,
+                      ImgChannelType, ImgChannelOrder, BasePtr, ElementSize);
+  DataT Ci1j1k1 =
+      getColor<DataT>(cl_int4{i1, j1, k1, 0}, SmplAddrMode, ImgRange, ImgPitch,
+                      ImgChannelType, ImgChannelOrder, BasePtr, ElementSize);
+
+  RetData =
+      ((1 - a) * (1 - b) * (1 - c) * Ci0j0k0.template convert<cl_float>()) +
+      (a * (1 - b) * (1 - c) * Ci1j0k0.template convert<cl_float>()) +
+      ((1 - a) * b * (1 - c) * Ci0j1k0.template convert<cl_float>()) +
+      (a * b * (1 - c) * Ci1j1k0.template convert<cl_float>()) +
+      ((1 - a) * (1 - b) * c * Ci0j0k1.template convert<cl_float>()) +
+      (a * (1 - b) * c * Ci1j0k1.template convert<cl_float>()) +
+      ((1 - a) * b * c * Ci0j1k1.template convert<cl_float>()) +
+      (a * b * c * Ci1j1k1.template convert<cl_float>());
+
+  // For 2D image:k0 = 0, k1 = 0, c = 0.5
+  // RetData = (1 – a) * (1 – b) * Ci0j0 + a * (1 – b) * Ci1j0 +
+  //           (1 – a) * b * Ci0j1 + a * b * Ci1j1;
+  // For 1D image: j0 = 0, j1 = 0, k0 = 0, k1 = 0, b = 0.5, c = 0.5.
+  // RetData = (1 – a) * Ci0 + a * Ci1;
+  return RetData.convert<typename TryToGetElementType<DataT>::type>();
 }
 
 // imageReadSamplerHostImpl method is called by the read API in image accessors
@@ -959,34 +1046,38 @@ DataT imageReadSamplerHostImpl(const CoordT &Coords, const sampler &Smpl,
   // implementation of one common function getPixelCoordXXXMode, for any
   // datatype of CoordT passed.
   FloatCoorduvw = convertToFloat4(Coorduvw);
-  cl_int4 PixelCoord;
   switch (SmplFiltMode) {
   case filtering_mode::nearest: {
     // Get Pixel Coordinates in integers that will be read from in the Image.
+    cl_int4 PixelCoord;
     PixelCoord =
         getPixelCoordNearestFiltMode(FloatCoorduvw, SmplAddrMode, ImgRange);
 
-    // Return Border Color for out-of-range coordinates for Sampler with
-    // addressing_mode::clamp.
-
-    if (isOutOfRange(PixelCoord, SmplAddrMode, ImgRange)) {
-      cl_float4 BorderColor = (getBorderColor(ImgChannelOrder));
-      RetData = BorderColor.convert<typename TryToGetElementType<DataT>::type>();
-    } else {
-      RetData = ReadPixelDataNearestFiltMode<DataT>(
-          PixelCoord, ImgPitch, ImgChannelType, ImgChannelOrder, BasePtr,
-          ElementSize);
-    }
+    // Return Border Color for out-of-range coordinates when Sampler has
+    // addressing_mode::clamp. For all other cases and for in-range coordinates
+    // read the color and return in DataT type.
+    RetData =
+        getColor<DataT>(PixelCoord, SmplAddrMode, ImgRange, ImgPitch,
+                        ImgChannelType, ImgChannelOrder, BasePtr, ElementSize);
     break;
   }
-  case filtering_mode::linear:
-    // TO DO: To implement this function.
-    // cl_float3 ValueAbc = getPixelCoordsLinearFiltMode(
-    //     FloatCoorduvw, SmplAddrMode,
-    //    ImgRange, cl_int4 i0j0k0, cl_int4 i1j1k1); // Get total 9 variables.
-    // LoadData based on 9 returned values.
-    // Ret_Data = ReadPixelDataLinearFiltMode(...);
+  case filtering_mode::linear: {
+    cl_int8 CoordValues;
+    cl_float4 Retabc;
+    // Get Pixel Coordinates in integers that will be read from in the Image.
+    // Return i0,j0,k0,0,i1,j1,k1,0 to form 8 coordinates in a 3D image and
+    // multiplication factors a,b,c
+    CoordValues = getPixelCoordLinearFiltMode(FloatCoorduvw, SmplAddrMode,
+                                              ImgRange, Retabc);
+
+    // Find the 8 coordinates with the values in CoordValues.
+    // Computes the Color Value to return.
+    RetData = ReadPixelDataLinearFiltMode<DataT>(
+        CoordValues, Retabc, SmplAddrMode, ImgRange, ImgPitch, ImgChannelType,
+        ImgChannelOrder, BasePtr, ElementSize);
+
     break;
+  }
   }
 
   return RetData;

--- a/sycl/source/detail/image_accessor_util.cpp
+++ b/sycl/source/detail/image_accessor_util.cpp
@@ -16,8 +16,8 @@ namespace detail {
 // For Nearest Filtering mode, process cl_float4 Coordinates and return the
 // appropriate Pixel Coordinates based on Addressing Mode.
 cl_int4 getPixelCoordNearestFiltMode(cl_float4 Coorduvw,
-                                     addressing_mode SmplAddrMode,
-                                     range<3> ImgRange) {
+                                     const addressing_mode SmplAddrMode,
+                                     const range<3> ImgRange) {
   cl_int4 Coordijk(0);
   cl_int4 Rangewhd(ImgRange[0], ImgRange[1], ImgRange[2], 0);
   switch (SmplAddrMode) {
@@ -91,15 +91,14 @@ cl_int4 getPixelCoordNearestFiltMode(cl_float4 Coorduvw,
 // The caller of this function should use these values to create the 8 pixel
 // coordinates and multiplication coefficients.
 cl_int8 getPixelCoordLinearFiltMode(cl_float4 Coorduvw,
-                                    addressing_mode SmplAddrMode,
-                                    range<3> ImgRange, cl_float4 &Retabc) {
+                                    const addressing_mode SmplAddrMode,
+                                    const range<3> ImgRange, cl_float4 &Retabc) {
   cl_int4 Rangewhd(ImgRange[0], ImgRange[1], ImgRange[2], 0);
   cl_int4 Ci0j0k0(0);
   cl_int4 Ci1j1k1(0);
   cl_int4 Int_uvwsubhalf = cl::sycl::floor(Coorduvw - 0.5f).convert<cl_int>();
 
   switch (SmplAddrMode) {
-
   case addressing_mode::mirrored_repeat: {
     cl_float4 Temp;
     Temp = (cl::sycl::rint(Coorduvw * 0.5f)) * 2.0f;
@@ -172,7 +171,7 @@ bool isOutOfRange(const cl_int4 PixelCoord, const addressing_mode SmplAddrMode,
   return (CheckWidth || CheckHeight || CheckDepth);
 }
 
-cl_float4 getBorderColor(image_channel_order ImgChannelOrder) {
+cl_float4 getBorderColor(const image_channel_order ImgChannelOrder) {
 
   cl_float4 BorderColor(0.0f);
   switch (ImgChannelOrder) {

--- a/sycl/source/detail/image_accessor_util.cpp
+++ b/sycl/source/detail/image_accessor_util.cpp
@@ -84,19 +84,90 @@ cl_int4 getPixelCoordNearestFiltMode(cl_float4 Coorduvw,
   return Coordijk;
 }
 
+// For Linear Filtering mode, process Coordinates-Coord_uvw and return
+// coordinate indexes based on Addressing Mode.
+// The value returned contains (i0,j0,k0,0,i1,j1,k1,0).
+// Retabc contains the values of (a,b,c,0)
+// The caller of this function should use these values to create the 8 pixel
+// coordinates and multiplication coefficients.
+cl_int8 getPixelCoordLinearFiltMode(cl_float4 Coorduvw,
+                                    addressing_mode SmplAddrMode,
+                                    range<3> ImgRange, cl_float4 &Retabc) {
+  cl_int4 Rangewhd(ImgRange[0], ImgRange[1], ImgRange[2], 0);
+  cl_int4 Ci0j0k0(0);
+  cl_int4 Ci1j1k1(0);
+  cl_int4 Int_uvwsubhalf = cl::sycl::floor(Coorduvw - 0.5f).convert<cl_int>();
+
+  switch (SmplAddrMode) {
+
+  case addressing_mode::mirrored_repeat: {
+    cl_float4 Temp;
+    Temp = (cl::sycl::rint(Coorduvw * 0.5f)) * 2.0f;
+    Temp = cl::sycl::fabs(Coorduvw - Temp);
+    Coorduvw = Temp * Rangewhd.convert<cl_float>();
+    Int_uvwsubhalf = cl::sycl::floor(Coorduvw - 0.5f).convert<cl_int>();
+
+    Ci0j0k0 = Int_uvwsubhalf;
+    Ci1j1k1 = Ci0j0k0 + 1;
+
+    Ci0j0k0 = cl::sycl::max(Ci0j0k0, 0);
+    Ci1j1k1 = cl::sycl::min(Ci1j1k1, (Rangewhd - 1));
+  } break;
+  case addressing_mode::repeat: {
+
+    Coorduvw =
+        (Coorduvw - cl::sycl::floor(Coorduvw)) * Rangewhd.convert<cl_float>();
+    Int_uvwsubhalf = cl::sycl::floor(Coorduvw - 0.5f).convert<cl_int>();
+
+    Ci0j0k0 = Int_uvwsubhalf;
+    Ci1j1k1 = Ci0j0k0 + 1;
+
+    Ci0j0k0 =
+        cl::sycl::select(Ci0j0k0, (Ci0j0k0 + Rangewhd), Ci0j0k0 < cl_int4(0));
+    Ci1j1k1 =
+        cl::sycl::select(Ci1j1k1, (Ci1j1k1 - Rangewhd), Ci1j1k1 >= Rangewhd);
+
+  } break;
+  case addressing_mode::clamp_to_edge: {
+    Ci0j0k0 = cl::sycl::clamp(Int_uvwsubhalf, cl_int4(0), (Rangewhd - 1));
+    Ci1j1k1 = cl::sycl::clamp((Int_uvwsubhalf + 1), cl_int4(0), (Rangewhd - 1));
+    break;
+  }
+  case addressing_mode::clamp: {
+    Ci0j0k0 = cl::sycl::clamp(Int_uvwsubhalf, cl_int4(-1), Rangewhd);
+    Ci1j1k1 = cl::sycl::clamp((Int_uvwsubhalf + 1), cl_int4(-1), Rangewhd);
+    break;
+  }
+  case addressing_mode::none: {
+    Ci0j0k0 = Int_uvwsubhalf;
+    Ci1j1k1 = Ci0j0k0 + 1;
+    break;
+  }
+  }
+  Retabc = (Coorduvw - 0.5f) - (Int_uvwsubhalf.convert<cl_float>());
+  Retabc.w() = 0.0f;
+  return cl_int8(Ci0j0k0, Ci1j1k1);
+}
+
+// Function returns true when PixelCoord is out of image's range.
+// It is only valid for addressing_mode::clamp/none.
+// Note: For addressing_mode::none , spec says outofrange access is not defined.
+// This function handles this addressing_mode to avoid accessing out of bound
+// memories on host.
 bool isOutOfRange(const cl_int4 PixelCoord, const addressing_mode SmplAddrMode,
                   const range<3> ImgRange) {
 
-  if (SmplAddrMode != addressing_mode::clamp)
+  if (SmplAddrMode != addressing_mode::clamp &&
+      SmplAddrMode != addressing_mode::none)
     return false;
 
   auto CheckOutOfRange = [](cl_int Coord, cl_int Range) {
     return ((Coord < 0) || (Coord >= Range));
   };
 
-  bool CheckWidth = CheckOutOfRange(PixelCoord.x(),ImgRange[0]);
-  bool CheckHeight = CheckOutOfRange(PixelCoord.y(),ImgRange[1]);
-  bool CheckDepth = CheckOutOfRange(PixelCoord.z(),ImgRange[2]);
+  bool CheckWidth = CheckOutOfRange(PixelCoord.x(), ImgRange[0]);
+  bool CheckHeight = CheckOutOfRange(PixelCoord.y(), ImgRange[1]);
+  bool CheckDepth = CheckOutOfRange(PixelCoord.z(), ImgRange[2]);
 
   return (CheckWidth || CheckHeight || CheckDepth);
 }

--- a/sycl/test/basic_tests/image_accessor_readsampler.cpp
+++ b/sycl/test/basic_tests/image_accessor_readsampler.cpp
@@ -21,17 +21,22 @@ namespace s = cl::sycl;
 
 template <int unique_number> class kernel_class;
 
-void validateReadData(s::cl_float4 ReadData, s::cl_float4 ExpectedColor) {
-  // Maximum difference of 1.5 ULP is allowed.
+void validateReadData(s::cl_float4 ReadData, s::cl_float4 ExpectedColor,
+                      s::cl_int precision = 1) {
+  // Maximum difference of 1.5 ULP is allowed when precision = 1.
   s::cl_int4 PixelDataInt = ReadData.template as<s::cl_int4>();
   s::cl_int4 ExpectedDataInt = ExpectedColor.template as<s::cl_int4>();
   s::cl_int4 Diff = ExpectedDataInt - PixelDataInt;
 #if DEBUG_OUTPUT
   {
-    if (((s::cl_int)Diff.x() <= 1 && (s::cl_int)Diff.x() >= -1) &&
-        ((s::cl_int)Diff.y() <= 1 && (s::cl_int)Diff.y() >= -1) &&
-        ((s::cl_int)Diff.z() <= 1 && (s::cl_int)Diff.z() >= -1) &&
-        ((s::cl_int)Diff.w() <= 1 && (s::cl_int)Diff.w() >= -1)) {
+    if (((s::cl_int)Diff.x() <= precision &&
+         (s::cl_int)Diff.x() >= -precision) &&
+        ((s::cl_int)Diff.y() <= precision &&
+         (s::cl_int)Diff.y() >= -precision) &&
+        ((s::cl_int)Diff.z() <= precision &&
+         (s::cl_int)Diff.z() >= -precision) &&
+        ((s::cl_int)Diff.w() <= precision &&
+         (s::cl_int)Diff.w() >= -precision)) {
       std::cout << "Read Data is correct within precision: " << std::endl;
     } else {
       std::cout << "Read Data is WRONG/ outside precision: " << std::endl;
@@ -47,20 +52,27 @@ void validateReadData(s::cl_float4 ReadData, s::cl_float4 ExpectedColor) {
               << (float)ExpectedColor.y() * 127 << "  "
               << (float)ExpectedColor.z() * 127 << "  "
               << (float)ExpectedColor.w() * 127 << std::endl;
+
+    std::cout << "Diff: \t" << (int)Diff.x() << "  " << (int)Diff.y() << "  "
+              << (int)Diff.z() << "  " << (int)Diff.w() << std::endl;
   }
 #else
   {
-    assert((s::cl_int)Diff.x() <= 1 && (s::cl_int)Diff.x() >= -1);
-    assert((s::cl_int)Diff.y() <= 1 && (s::cl_int)Diff.y() >= -1);
-    assert((s::cl_int)Diff.z() <= 1 && (s::cl_int)Diff.z() >= -1);
-    assert((s::cl_int)Diff.w() <= 1 && (s::cl_int)Diff.w() >= -1);
+    assert((s::cl_int)Diff.x() <= precision &&
+           (s::cl_int)Diff.x() >= -precision);
+    assert((s::cl_int)Diff.y() <= precision &&
+           (s::cl_int)Diff.y() >= -precision);
+    assert((s::cl_int)Diff.z() <= precision &&
+           (s::cl_int)Diff.z() >= -precision);
+    assert((s::cl_int)Diff.w() <= precision &&
+           (s::cl_int)Diff.w() >= -precision);
   }
 #endif
 }
 
 template <int i>
 void checkReadSampler(char *host_ptr, s::sampler Sampler, s::cl_float4 Coord,
-                      s::cl_float4 ExpectedColor) {
+                      s::cl_float4 ExpectedColor, s::cl_int precision = 1) {
 
   s::cl_float4 ReadData;
   {
@@ -80,7 +92,7 @@ void checkReadSampler(char *host_ptr, s::sampler Sampler, s::cl_float4 Coord,
     });
     });
   }
-  validateReadData(ReadData, ExpectedColor);
+  validateReadData(ReadData, ExpectedColor, precision);
 }
 
 void checkSamplerNearest() {
@@ -192,12 +204,199 @@ void checkSamplerNearest() {
   }
 }
 
-void checkSamplerLinear(){
-    // TODO. Implement this code.
-};
+// Precision requirement for linear filtering mode is not defined by OpenCL
+// specification. Based on observation, Host and CPU device produce values
+// within +-1 ULP. GPU return values have been found to be varying. For this
+// reason and to allow compatibility with all OpenCL device testing, a higher
+// value of precision (in ULP) is used for Linear Filter Mode. In this case a
+// value of 15000 ULP is used.
+void checkSamplerLinear() {
+
+  // create image:
+  char host_ptr[100];
+  for (int i = 0; i < 100; i++)
+    host_ptr[i] = i;
+
+  // Calling only valid configurations.
+  // A. coordinate normalization mode::normalized
+  // addressing_mode::mirrored_repeat
+  {
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f,
+                       0.0f); // Out-of-range mirrored_repeat mode
+    auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
+                              s::addressing_mode::mirrored_repeat,
+                              s::filtering_mode::linear);
+    checkReadSampler<1>(host_ptr, Sampler, Coord,
+                        s::cl_float4((44.0f / 127.0f), (45.0f / 127.0f),
+                                     (46.0f / 127.0f),
+                                     (47.0f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+  {
+    s::cl_float4 Coord(0.0f, 0.25f, 0.55f,
+                       0.0f); // In-range mirrored_repeat mode
+    auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
+                              s::addressing_mode::mirrored_repeat,
+                              s::filtering_mode::linear);
+    checkReadSampler<1>(host_ptr, Sampler, Coord,
+                        s::cl_float4((42.8f / 127.0f), (43.8f / 127.0f),
+                                     (44.8f / 127.0f),
+                                     (45.8f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+
+  // addressing_mode::repeat
+  {
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range repeat mode
+    auto Sampler =
+        s::sampler(s::coordinate_normalization_mode::normalized,
+                   s::addressing_mode::repeat, s::filtering_mode::linear);
+    checkReadSampler<2>(host_ptr, Sampler, Coord,
+                        s::cl_float4((46.0f / 127.0f), (47.0f / 127.0f),
+                                     (48.0f / 127.0f),
+                                     (49.0f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+  {
+    s::cl_float4 Coord(0.0f, 0.25f, 0.55f, 0.0f); // In-range repeat mode
+    auto Sampler =
+        s::sampler(s::coordinate_normalization_mode::normalized,
+                   s::addressing_mode::repeat, s::filtering_mode::linear);
+    checkReadSampler<2>(host_ptr, Sampler, Coord,
+                        s::cl_float4((44.8f / 127.0f), (45.8f / 127.0f),
+                                     (46.8f / 127.0f),
+                                     (47.8f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+
+  // addressing_mode::clamp_to_edge
+  {
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range Edge Color
+    auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
+                              s::addressing_mode::clamp_to_edge,
+                              s::filtering_mode::linear);
+    checkReadSampler<3>(host_ptr, Sampler, Coord,
+                        s::cl_float4((88.0f / 127.0f), (89.0f / 127.0f),
+                                     (90.0f / 127.0f),
+                                     (91.0f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+  {
+    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f); // In-range
+    auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
+                              s::addressing_mode::clamp_to_edge,
+                              s::filtering_mode::linear);
+    checkReadSampler<3>(host_ptr, Sampler, Coord,
+                        s::cl_float4((36.8f / 127.0f), (37.8f / 127.0f),
+                                     (38.8f / 127.0f),
+                                     (39.8f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+
+  // addressing_mode::clamp
+  {
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range
+    auto Sampler =
+        s::sampler(s::coordinate_normalization_mode::normalized,
+                   s::addressing_mode::clamp, s::filtering_mode::linear);
+    checkReadSampler<4>(host_ptr, Sampler, Coord,
+                        s::cl_float4(0.0f, 0.0f, 0.0f, 0.0f) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+  {
+    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f); // In-range
+    auto Sampler =
+        s::sampler(s::coordinate_normalization_mode::normalized,
+                   s::addressing_mode::clamp, s::filtering_mode::linear);
+    checkReadSampler<4>(host_ptr, Sampler, Coord,
+                        s::cl_float4(18.4f / 127.0f, 18.9f / 127.0f,
+                                     19.4f / 127.0f,
+                                     19.9f / 127.0f) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+
+  // addressing_mode::none
+  {
+    s::cl_float4 Coord(0.5f, 0.5f, 0.5f,
+                       0.0f); // In-range for consistent return value.
+    auto Sampler =
+        s::sampler(s::coordinate_normalization_mode::normalized,
+                   s::addressing_mode::none, s::filtering_mode::linear);
+    checkReadSampler<5>(host_ptr, Sampler, Coord,
+                        s::cl_float4((46.0f / 127.0f), (47.0f / 127.0f),
+                                     (48.0f / 127.0f),
+                                     (49.0f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+
+  // B. coordinate_normalization_mode::unnormalized
+  // addressing_mode::clamp_to_edge
+  {
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range
+    auto Sampler = s::sampler(s::coordinate_normalization_mode::unnormalized,
+                              s::addressing_mode::clamp_to_edge,
+                              s::filtering_mode::linear);
+    checkReadSampler<6>(host_ptr, Sampler, Coord,
+                        s::cl_float4((56.0f / 127.0f), (57.0f / 127.0f),
+                                     (58.0f / 127.0f),
+                                     (59.0f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+  {
+    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f); // In-range
+    auto Sampler = s::sampler(s::coordinate_normalization_mode::unnormalized,
+                              s::addressing_mode::clamp_to_edge,
+                              s::filtering_mode::linear);
+    checkReadSampler<6>(host_ptr, Sampler, Coord,
+                        s::cl_float4((0.0f / 127.0f), (1.0f / 127.0f),
+                                     (2.0f / 127.0f),
+                                     (3.0f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+
+  // addressing_mode::clamp
+  {
+    s::cl_float4 Coord(0.0f, 1.5f, 1.5f, 0.0f); // Out-of-range
+    auto Sampler =
+        s::sampler(s::coordinate_normalization_mode::unnormalized,
+                   s::addressing_mode::clamp, s::filtering_mode::linear);
+    checkReadSampler<7>(host_ptr, Sampler, Coord,
+                        s::cl_float4((16.0f / 127.0f), (16.5f / 127.0f),
+                                     (17.0f / 127.0f),
+                                     (17.5f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+  {
+    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f); // In-range
+    auto Sampler =
+        s::sampler(s::coordinate_normalization_mode::unnormalized,
+                   s::addressing_mode::clamp, s::filtering_mode::linear);
+    checkReadSampler<7>(host_ptr, Sampler, Coord,
+                        s::cl_float4((0.0f / 127.0f), (0.35f / 127.0f),
+                                     (0.7f / 127.0f),
+                                     (1.05f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+
+  // addressing_mode::none
+  {
+    s::cl_float4 Coord(1.0f, 2.0f, 3.0f,
+                       0.0f); // In-range for consistent return value.
+    auto Sampler =
+        s::sampler(s::coordinate_normalization_mode::unnormalized,
+                   s::addressing_mode::none, s::filtering_mode::linear);
+    checkReadSampler<8>(host_ptr, Sampler, Coord,
+                        s::cl_float4((74.0f / 127.0f), (75.0f / 127.0f),
+                                     (76.0f / 127.0f),
+                                     (77.0f / 127.0f)) /*Expected Value*/,
+                        15000 /*Precision in ULP*/);
+  }
+}
 
 int main() {
 
+  // Note: Currently these functions only check for cl_float4 return datatype,
+  // the test case can be extended to test all return datatypes.
   checkSamplerNearest();
-  // checkSamplerLinear();
+  checkSamplerLinear();
 }

--- a/sycl/test/basic_tests/image_accessor_readsampler.cpp
+++ b/sycl/test/basic_tests/image_accessor_readsampler.cpp
@@ -27,46 +27,24 @@ void validateReadData(s::cl_float4 ReadData, s::cl_float4 ExpectedColor,
   s::cl_int4 PixelDataInt = ReadData.template as<s::cl_int4>();
   s::cl_int4 ExpectedDataInt = ExpectedColor.template as<s::cl_int4>();
   s::cl_int4 Diff = ExpectedDataInt - PixelDataInt;
+  s::cl_int DataIsCorrect =
+      s::all((Diff <= precision) && (Diff >= (-precision)));
 #if DEBUG_OUTPUT
   {
-    if (((s::cl_int)Diff.x() <= precision &&
-         (s::cl_int)Diff.x() >= -precision) &&
-        ((s::cl_int)Diff.y() <= precision &&
-         (s::cl_int)Diff.y() >= -precision) &&
-        ((s::cl_int)Diff.z() <= precision &&
-         (s::cl_int)Diff.z() >= -precision) &&
-        ((s::cl_int)Diff.w() <= precision &&
-         (s::cl_int)Diff.w() >= -precision)) {
+    if (DataIsCorrect) {
       std::cout << "Read Data is correct within precision: " << std::endl;
     } else {
       std::cout << "Read Data is WRONG/ outside precision: " << std::endl;
     }
-    std::cout << "ReadData: \t"
-              << std::setprecision(std::numeric_limits<long double>::digits10 +
-                                   1)
-              << (float)ReadData.x() * 127 << "  " << (float)ReadData.y() * 127
-              << "  " << (float)ReadData.z() * 127 << "  "
-              << (float)ReadData.w() * 127 << std::endl;
-
-    std::cout << "ExpectedColor: \t" << (float)ExpectedColor.x() * 127 << "  "
-              << (float)ExpectedColor.y() * 127 << "  "
-              << (float)ExpectedColor.z() * 127 << "  "
-              << (float)ExpectedColor.w() * 127 << std::endl;
-
-    std::cout << "Diff: \t" << (int)Diff.x() << "  " << (int)Diff.y() << "  "
-              << (int)Diff.z() << "  " << (int)Diff.w() << std::endl;
+    std::cout << "ReadData: " << std::endl;
+    (ReadData * 127).dump();
+    std::cout << "ExpectedColor: " << std::endl;
+    (ExpectedColor * 127).dump();
+    std::cout << "Diff: " << std::endl;
+    Diff.dump();
   }
 #else
-  {
-    assert((s::cl_int)Diff.x() <= precision &&
-           (s::cl_int)Diff.x() >= -precision);
-    assert((s::cl_int)Diff.y() <= precision &&
-           (s::cl_int)Diff.y() >= -precision);
-    assert((s::cl_int)Diff.z() <= precision &&
-           (s::cl_int)Diff.z() >= -precision);
-    assert((s::cl_int)Diff.w() <= precision &&
-           (s::cl_int)Diff.w() >= -precision);
-  }
+  { assert(DataIsCorrect); }
 #endif
 }
 
@@ -106,101 +84,96 @@ void checkSamplerNearest() {
   // A. coordinate normalization mode::normalized
   // addressing_mode::mirrored_repeat
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 2.5f,
-                       0.0f); // Out-of-range mirrored_repeat mode
+    // Out-of-range mirrored_repeat mode
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(56.0f, 57.0f, 58.0f, 59.0f) / 127.0f;
     auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
                               s::addressing_mode::mirrored_repeat,
                               s::filtering_mode::nearest);
-    checkReadSampler<1>(host_ptr, Sampler, Coord,
-                        s::cl_float4((56.0f / 127.0f), (57.0f / 127.0f),
-                                     (58.0f / 127.0f),
-                                     (59.0f / 127.0f)) /*Expected Value*/);
+    checkReadSampler<1>(host_ptr, Sampler, Coord, ExpectedValue);
   }
 
   // addressing_mode::repeat
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range repeat mode
+    // Out-of-range repeat mode
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(56.0f, 57.0f, 58.0f, 59.0f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::normalized,
                    s::addressing_mode::repeat, s::filtering_mode::nearest);
-    checkReadSampler<2>(host_ptr, Sampler, Coord,
-                        s::cl_float4((56.0f / 127.0f), (57.0f / 127.0f),
-                                     (58.0f / 127.0f),
-                                     (59.0f / 127.0f)) /*Expected Value*/);
+    checkReadSampler<2>(host_ptr, Sampler, Coord, ExpectedValue);
   }
 
   // addressing_mode::clamp_to_edge
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range Edge Color
+    // Out-of-range Edge Color
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(88.0f, 89.0f, 90.0f, 91.0f) / 127.0f;
     auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
                               s::addressing_mode::clamp_to_edge,
                               s::filtering_mode::nearest);
-    checkReadSampler<3>(host_ptr, Sampler, Coord,
-                        s::cl_float4((88.0f / 127.0f), (89.0f / 127.0f),
-                                     (90.0f / 127.0f),
-                                     (91.0f / 127.0f)) /*Expected Value*/);
+    checkReadSampler<3>(host_ptr, Sampler, Coord, ExpectedValue);
   }
 
   // addressing_mode::clamp
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range Border Color
+    // Out-of-range Border Color
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue = s::cl_float4(0.0f, 0.0f, 0.0f, 0.0f);
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::normalized,
                    s::addressing_mode::clamp, s::filtering_mode::nearest);
-    checkReadSampler<4>(
-        host_ptr, Sampler, Coord,
-        s::cl_float4(0.0f, 0.0f, 0.0f, 0.0f) /*Expected Value*/);
+    checkReadSampler<4>(host_ptr, Sampler, Coord, ExpectedValue);
   }
 
   // addressing_mode::none
   {
-    s::cl_float4 Coord(0.0f, 0.5f, 0.75f,
-                       0.0f); // In-range for consistent return value.
+    // In-range for consistent return value.
+    s::cl_float4 Coord(0.0f, 0.5f, 0.75f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(80.0f, 81.0f, 82.0f, 83.0f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::normalized,
                    s::addressing_mode::none, s::filtering_mode::nearest);
-    checkReadSampler<5>(host_ptr, Sampler, Coord,
-                        s::cl_float4((80.0f / 127.0f), (81.0f / 127.0f),
-                                     (82.0f / 127.0f),
-                                     (83.0f / 127.0f)) /*Expected Value*/);
+    checkReadSampler<5>(host_ptr, Sampler, Coord, ExpectedValue);
   }
 
   // B. coordinate_normalization_mode::unnormalized
   // addressing_mode::clamp_to_edge
   {
     s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(56.0f, 57.0f, 58.0f, 59.0f) / 127.0f;
     auto Sampler = s::sampler(s::coordinate_normalization_mode::unnormalized,
                               s::addressing_mode::clamp_to_edge,
                               s::filtering_mode::nearest);
-    checkReadSampler<6>(host_ptr, Sampler, Coord,
-                        s::cl_float4((56.0f / 127.0f), (57.0f / 127.0f),
-                                     (58.0f / 127.0f),
-                                     (59.0f / 127.0f)) /*Expected Value*/);
+    checkReadSampler<6>(host_ptr, Sampler, Coord, ExpectedValue);
   }
 
   // addressing_mode::clamp
   {
     s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(56.0f, 57.0f, 58.0f, 59.0f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::unnormalized,
                    s::addressing_mode::clamp, s::filtering_mode::nearest);
-    checkReadSampler<7>(host_ptr, Sampler, Coord,
-                        s::cl_float4((56.0f / 127.0f), (57.0f / 127.0f),
-                                     (58.0f / 127.0f),
-                                     (59.0f / 127.0f)) /*Expected Value*/);
+    checkReadSampler<7>(host_ptr, Sampler, Coord, ExpectedValue);
   }
 
   // addressing_mode::none
   {
-    s::cl_float4 Coord(0.0f, 1.0f, 2.0f,
-                       0.0f); // In-range for consistent return value.
+    // In-range for consistent return value.
+    s::cl_float4 Coord(0.0f, 1.0f, 2.0f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(56.0f, 57.0f, 58.0f, 59.0f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::unnormalized,
                    s::addressing_mode::none, s::filtering_mode::nearest);
-    checkReadSampler<8>(host_ptr, Sampler, Coord,
-                        s::cl_float4((56.0f / 127.0f), (57.0f / 127.0f),
-                                     (58.0f / 127.0f),
-                                     (59.0f / 127.0f)) /*Expected Value*/);
+    checkReadSampler<8>(host_ptr, Sampler, Coord, ExpectedValue);
   }
 }
 
@@ -212,6 +185,7 @@ void checkSamplerNearest() {
 // value of 15000 ULP is used.
 void checkSamplerLinear() {
 
+  const s::cl_int PrecisionInULP = 15000;
   // create image:
   char host_ptr[100];
   for (int i = 0; i < 100; i++)
@@ -221,175 +195,170 @@ void checkSamplerLinear() {
   // A. coordinate normalization mode::normalized
   // addressing_mode::mirrored_repeat
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 2.5f,
-                       0.0f); // Out-of-range mirrored_repeat mode
+    // Out-of-range mirrored_repeat mode
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(44.0f, 45.0f, 46.0f, 47.0f) / 127.0f;
     auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
                               s::addressing_mode::mirrored_repeat,
                               s::filtering_mode::linear);
-    checkReadSampler<1>(host_ptr, Sampler, Coord,
-                        s::cl_float4((44.0f / 127.0f), (45.0f / 127.0f),
-                                     (46.0f / 127.0f),
-                                     (47.0f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<1>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
   {
-    s::cl_float4 Coord(0.0f, 0.25f, 0.55f,
-                       0.0f); // In-range mirrored_repeat mode
+    // In-range mirrored_repeat mode
+    s::cl_float4 Coord(0.0f, 0.25f, 0.55f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(42.8f, 43.8f, 44.8f, 45.8f) / 127.0f;
     auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
                               s::addressing_mode::mirrored_repeat,
                               s::filtering_mode::linear);
-    checkReadSampler<1>(host_ptr, Sampler, Coord,
-                        s::cl_float4((42.8f / 127.0f), (43.8f / 127.0f),
-                                     (44.8f / 127.0f),
-                                     (45.8f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<1>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
 
   // addressing_mode::repeat
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range repeat mode
+    // Out-of-range repeat mode
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(46.0f, 47.0f, 48.0f, 49.0f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::normalized,
                    s::addressing_mode::repeat, s::filtering_mode::linear);
-    checkReadSampler<2>(host_ptr, Sampler, Coord,
-                        s::cl_float4((46.0f / 127.0f), (47.0f / 127.0f),
-                                     (48.0f / 127.0f),
-                                     (49.0f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<2>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
   {
-    s::cl_float4 Coord(0.0f, 0.25f, 0.55f, 0.0f); // In-range repeat mode
+    // In-range repeat mode
+    s::cl_float4 Coord(0.0f, 0.25f, 0.55f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(44.8f, 45.8f, 46.8f, 47.8f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::normalized,
                    s::addressing_mode::repeat, s::filtering_mode::linear);
-    checkReadSampler<2>(host_ptr, Sampler, Coord,
-                        s::cl_float4((44.8f / 127.0f), (45.8f / 127.0f),
-                                     (46.8f / 127.0f),
-                                     (47.8f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<2>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
 
   // addressing_mode::clamp_to_edge
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range Edge Color
+    // Out-of-range Edge Color
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(88.0f, 89.0f, 90.0f, 91.0f) / 127.0f;
     auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
                               s::addressing_mode::clamp_to_edge,
                               s::filtering_mode::linear);
-    checkReadSampler<3>(host_ptr, Sampler, Coord,
-                        s::cl_float4((88.0f / 127.0f), (89.0f / 127.0f),
-                                     (90.0f / 127.0f),
-                                     (91.0f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<3>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
   {
     s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f); // In-range
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(36.8f, 37.8f, 38.8f, 39.8f) / 127.0f;
     auto Sampler = s::sampler(s::coordinate_normalization_mode::normalized,
                               s::addressing_mode::clamp_to_edge,
                               s::filtering_mode::linear);
-    checkReadSampler<3>(host_ptr, Sampler, Coord,
-                        s::cl_float4((36.8f / 127.0f), (37.8f / 127.0f),
-                                     (38.8f / 127.0f),
-                                     (39.8f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<3>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
 
   // addressing_mode::clamp
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range
+    // Out-of-range
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue = s::cl_float4(0.0f, 0.0f, 0.0f, 0.0f);
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::normalized,
                    s::addressing_mode::clamp, s::filtering_mode::linear);
-    checkReadSampler<4>(host_ptr, Sampler, Coord,
-                        s::cl_float4(0.0f, 0.0f, 0.0f, 0.0f) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<4>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
   {
-    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f); // In-range
+    // In-range
+    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(18.4f, 18.9f, 19.4f, 19.9f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::normalized,
                    s::addressing_mode::clamp, s::filtering_mode::linear);
-    checkReadSampler<4>(host_ptr, Sampler, Coord,
-                        s::cl_float4(18.4f / 127.0f, 18.9f / 127.0f,
-                                     19.4f / 127.0f,
-                                     19.9f / 127.0f) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<4>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
 
   // addressing_mode::none
   {
-    s::cl_float4 Coord(0.5f, 0.5f, 0.5f,
-                       0.0f); // In-range for consistent return value.
+    // In-range for consistent return value.
+    s::cl_float4 Coord(0.5f, 0.5f, 0.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(46.0f, 47.0f, 48.0f, 49.0f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::normalized,
                    s::addressing_mode::none, s::filtering_mode::linear);
-    checkReadSampler<5>(host_ptr, Sampler, Coord,
-                        s::cl_float4((46.0f / 127.0f), (47.0f / 127.0f),
-                                     (48.0f / 127.0f),
-                                     (49.0f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<5>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
 
   // B. coordinate_normalization_mode::unnormalized
   // addressing_mode::clamp_to_edge
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f); // Out-of-range
+    // Out-of-range
+    s::cl_float4 Coord(0.0f, 1.5f, 2.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(56.0f, 57.0f, 58.0f, 59.0f) / 127.0f;
     auto Sampler = s::sampler(s::coordinate_normalization_mode::unnormalized,
                               s::addressing_mode::clamp_to_edge,
                               s::filtering_mode::linear);
-    checkReadSampler<6>(host_ptr, Sampler, Coord,
-                        s::cl_float4((56.0f / 127.0f), (57.0f / 127.0f),
-                                     (58.0f / 127.0f),
-                                     (59.0f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<6>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
   {
-    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f); // In-range
+    // In-range
+    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f);
+    s::cl_float4 ExpectedValue = s::cl_float4(0.0f, 1.0f, 2.0f, 3.0f) / 127.0f;
     auto Sampler = s::sampler(s::coordinate_normalization_mode::unnormalized,
                               s::addressing_mode::clamp_to_edge,
                               s::filtering_mode::linear);
-    checkReadSampler<6>(host_ptr, Sampler, Coord,
-                        s::cl_float4((0.0f / 127.0f), (1.0f / 127.0f),
-                                     (2.0f / 127.0f),
-                                     (3.0f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<6>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
 
   // addressing_mode::clamp
   {
-    s::cl_float4 Coord(0.0f, 1.5f, 1.5f, 0.0f); // Out-of-range
+    // Out-of-range
+    s::cl_float4 Coord(0.0f, 1.5f, 1.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(16.0f, 16.5f, 17.0f, 17.5f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::unnormalized,
                    s::addressing_mode::clamp, s::filtering_mode::linear);
-    checkReadSampler<7>(host_ptr, Sampler, Coord,
-                        s::cl_float4((16.0f / 127.0f), (16.5f / 127.0f),
-                                     (17.0f / 127.0f),
-                                     (17.5f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<7>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
   {
-    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f); // In-range
+    // In-range
+    s::cl_float4 Coord(0.0f, 0.2f, 0.5f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(0.0f, 0.35f, 0.7f, 1.05f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::unnormalized,
                    s::addressing_mode::clamp, s::filtering_mode::linear);
-    checkReadSampler<7>(host_ptr, Sampler, Coord,
-                        s::cl_float4((0.0f / 127.0f), (0.35f / 127.0f),
-                                     (0.7f / 127.0f),
-                                     (1.05f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<7>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
 
   // addressing_mode::none
   {
-    s::cl_float4 Coord(1.0f, 2.0f, 3.0f,
-                       0.0f); // In-range for consistent return value.
+    // In-range for consistent return value.
+    s::cl_float4 Coord(1.0f, 2.0f, 3.0f, 0.0f);
+    s::cl_float4 ExpectedValue =
+        s::cl_float4(74.0f, 75.0f, 76.0f, 77.0f) / 127.0f;
     auto Sampler =
         s::sampler(s::coordinate_normalization_mode::unnormalized,
                    s::addressing_mode::none, s::filtering_mode::linear);
-    checkReadSampler<8>(host_ptr, Sampler, Coord,
-                        s::cl_float4((74.0f / 127.0f), (75.0f / 127.0f),
-                                     (76.0f / 127.0f),
-                                     (77.0f / 127.0f)) /*Expected Value*/,
-                        15000 /*Precision in ULP*/);
+    checkReadSampler<8>(host_ptr, Sampler, Coord, ExpectedValue,
+                        PrecisionInULP);
   }
 }
 


### PR DESCRIPTION
    -Support added for sampler with LINEAR Filtering Mode.
    -Check if the results are consistent with the values read by CPU/GPU
     device using a test case.
    -Enabled test case to work on all platforms.