### PR TITLE
[SYCL] Make barrier flags constexpr to avoid its extra runtime translation.

### DIFF
--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -29,7 +29,7 @@ class Builder;
 // Implements a barrier accross work items within a work group.
 static inline void workGroupBarrier() {
 #ifdef __SYCL_DEVICE_ONLY__
-  uint32_t flags =
+  constexpr uint32_t flags =
       static_cast<uint32_t>(
           __spv::MemorySemanticsMask::SequentiallyConsistent) |
       static_cast<uint32_t>(__spv::MemorySemanticsMask::WorkgroupMemory);


### PR DESCRIPTION
Make the argument passed to __spirv_ControlBarrier from workGroupBarrier() is a compile-time constant for better code generation.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>