### PR TITLE
[SYCL] Propagate the env var OCL_ICD_FILENAMES to SYCL-LIT test scripts

### DIFF
--- a/sycl/test/lit.cfg
+++ b/sycl/test/lit.cfg
@@ -51,6 +51,10 @@ else:
     else:
         config.environment['PATH'] = config.llvm_build_bins_dir
 
+# propagate the environment variable OCL_ICD_FILANEMES to use proper runtime.
+if 'OCL_ICD_FILENAMES' in os.environ:
+    config.environment['OCL_ICD_FILENAMES'] = os.environ['OCL_ICD_FILENAMES']
+
 config.substitutions.append( ('%clang_cc1', ' ' + config.clang + ' -cc1 ') )
 config.substitutions.append( ('%clangxx', ' ' + config.clangxx + ' -I'+config.opencl_include ) )
 config.substitutions.append( ('%clang', ' ' + config.clang + ' -I'+config.opencl_include ) )


### PR DESCRIPTION
Setting the environment variable OCL_ICD_FILENAMES tells to OCL ICD Loader
what runtime must be loaded first. For example:
export OCL_ICD_FILENAMES=<path_to_rt>/intelocl64.dll

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>