### PR TITLE
[SYCL] Removing image_accessor_readwrite.cpp lit test execution on Accelerator.

### DIFF
--- a/sycl/test/basic_tests/image_accessor_readsampler.cpp
+++ b/sycl/test/basic_tests/image_accessor_readsampler.cpp
@@ -2,7 +2,6 @@
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
 //==------------------- image_accessor_readsampler.cpp ---------------------==//
 //==-----------------image_accessor read API test with sampler--------------==//
 //


### PR DESCRIPTION
The test does not check if the device supports images, in case of an
accelerator like FPGA it will cause failures. The OpenCL CPU and GPU
device supports images. Thus removing only Accelerator execuation of the
test.

Signed-off-by: Garima Gupta <garima.gupta@intel.com>