### PR TITLE
[SYCL] Decouple data types of SYCL builtins from OpenCL.

### DIFF
--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -32,523 +32,467 @@ namespace sycl {
 /* ----------------- 4.13.3 Math functions. ---------------------------------*/
 // genfloat acos (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-acos(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> acos(T x) __NOEXC {
   return __sycl_std::__invoke_acos<T>(x);
 }
 
 // genfloat acosh (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-acosh(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> acosh(T x) __NOEXC {
   return __sycl_std::__invoke_acosh<T>(x);
 }
 
 // genfloat acospi (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-acospi(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> acospi(T x) __NOEXC {
   return __sycl_std::__invoke_acospi<T>(x);
 }
 
 // genfloat asin (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-asin(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> asin(T x) __NOEXC {
   return __sycl_std::__invoke_asin<T>(x);
 }
 
 // genfloat asinh (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-asinh(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> asinh(T x) __NOEXC {
   return __sycl_std::__invoke_asinh<T>(x);
 }
 
 // genfloat asinpi (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-asinpi(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> asinpi(T x) __NOEXC {
   return __sycl_std::__invoke_asinpi<T>(x);
 }
 
 // genfloat atan (genfloat y_over_x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-atan(T y_over_x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> atan(T y_over_x) __NOEXC {
   return __sycl_std::__invoke_atan<T>(y_over_x);
 }
 
 // genfloat atan2 (genfloat y, genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-atan2(T y, T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> atan2(T y, T x) __NOEXC {
   return __sycl_std::__invoke_atan2<T>(y, x);
 }
 
 // genfloat atanh (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-atanh(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> atanh(T x) __NOEXC {
   return __sycl_std::__invoke_atanh<T>(x);
 }
 
 // genfloat atanpi (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-atanpi(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> atanpi(T x) __NOEXC {
   return __sycl_std::__invoke_atanpi<T>(x);
 }
 
 // genfloat atan2pi (genfloat y, genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-atan2pi(T y, T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> atan2pi(T y,
+                                                              T x) __NOEXC {
   return __sycl_std::__invoke_atan2pi<T>(y, x);
 }
 
 // genfloat cbrt (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-cbrt(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> cbrt(T x) __NOEXC {
   return __sycl_std::__invoke_cbrt<T>(x);
 }
 
 // genfloat ceil (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-ceil(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> ceil(T x) __NOEXC {
   return __sycl_std::__invoke_ceil<T>(x);
 }
 
 // genfloat copysign (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-copysign(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> copysign(T x,
+                                                               T y) __NOEXC {
   return __sycl_std::__invoke_copysign<T>(x, y);
 }
 
 // genfloat cos (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-cos(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> cos(T x) __NOEXC {
   return __sycl_std::__invoke_cos<T>(x);
 }
 
 // genfloat cosh (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-cosh(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> cosh(T x) __NOEXC {
   return __sycl_std::__invoke_cosh<T>(x);
 }
 
 // genfloat cospi (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-cospi(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> cospi(T x) __NOEXC {
   return __sycl_std::__invoke_cospi<T>(x);
 }
 
 // genfloat erfc (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-erfc(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> erfc(T x) __NOEXC {
   return __sycl_std::__invoke_erfc<T>(x);
 }
 
 // genfloat erf (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-erf(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> erf(T x) __NOEXC {
   return __sycl_std::__invoke_erf<T>(x);
 }
 
 // genfloat exp (genfloat x )
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-exp(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> exp(T x) __NOEXC {
   return __sycl_std::__invoke_exp<T>(x);
 }
 
 // genfloat exp2 (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-exp2(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> exp2(T x) __NOEXC {
   return __sycl_std::__invoke_exp2<T>(x);
 }
 
 // genfloat exp10 (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-exp10(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> exp10(T x) __NOEXC {
   return __sycl_std::__invoke_exp10<T>(x);
 }
 
 // genfloat expm1 (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-expm1(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> expm1(T x) __NOEXC {
   return __sycl_std::__invoke_expm1<T>(x);
 }
 
 // genfloat fabs (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-fabs(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> fabs(T x) __NOEXC {
   return __sycl_std::__invoke_fabs<T>(x);
 }
 
 // genfloat fdim (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-fdim(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> fdim(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fdim<T>(x, y);
 }
 
 // genfloat floor (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-floor(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> floor(T x) __NOEXC {
   return __sycl_std::__invoke_floor<T>(x);
 }
 
 // genfloat fma (genfloat a, genfloat b, genfloat c)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-fma(T a, T b, T c) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> fma(T a, T b,
+                                                          T c) __NOEXC {
   return __sycl_std::__invoke_fma<T>(a, b, c);
 }
 
 // genfloat fmax (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-fmax(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> fmax(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fmax<T>(x, y);
 }
 
 // genfloat fmax (genfloat x, sgenfloat y)
 template <typename T>
-typename std::enable_if<detail::is_vgenfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
 fmax(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_fmax<T>(x, T(y));
 }
 
 // genfloat fmin (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-fmin(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> fmin(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fmin<T>(x, y);
 }
 
 // genfloat fmin (genfloat x, sgenfloat y)
 template <typename T>
-typename std::enable_if<detail::is_vgenfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
 fmin(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_fmin<T>(x, T(y));
 }
 
 // genfloat fmod (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-fmod(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> fmod(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fmod<T>(x, y);
 }
 
 // genfloat fract (genfloat x, genfloatptr iptr)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloat<T>::value && detail::is_genfloatptr<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloat<T>::value && detail::is_genfloatptr<T2>::value, T>
 fract(T x, T2 iptr) __NOEXC {
   return __sycl_std::__invoke_fract<T>(x, iptr);
 }
 
 // genfloat frexp (genfloat x, genintptr exp)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloat<T>::value && detail::is_genintptr<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloat<T>::value && detail::is_genintptr<T2>::value, T>
 frexp(T x, T2 exp) __NOEXC {
   return __sycl_std::__invoke_frexp<T>(x, exp);
 }
 
 // genfloat hypot (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-hypot(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> hypot(T x, T y) __NOEXC {
   return __sycl_std::__invoke_hypot<T>(x, y);
 }
 
 // genint ilogb (genfloat x)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
-typename detail::float_point_to_int<T>::type ilogb(T x) __NOEXC {
-  return __sycl_std::__invoke_ilogb<
-      typename detail::float_point_to_int<T>::type>(x);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
+detail::change_base_type_t<T, int> ilogb(T x) __NOEXC {
+  return __sycl_std::__invoke_ilogb<detail::change_base_type_t<T, int>>(x);
 }
 
 // float ldexp (float x, int k)
 // double ldexp (double x, int k)
 // half ldexp (half x, int k)
 template <typename T>
-typename std::enable_if<detail::is_sgenfloat<T>::value, T>::type
-ldexp(T x, int k) __NOEXC {
+detail::enable_if_t<detail::is_sgenfloat<T>::value, T> ldexp(T x,
+                                                             int k) __NOEXC {
   return __sycl_std::__invoke_ldexp<T>(x, k);
 }
 
 // vgenfloat ldexp (vgenfloat x, int k)
 template <typename T>
-typename std::enable_if<detail::is_vgenfloat<T>::value, T>::type
-ldexp(T x, int k) __NOEXC {
-  return __sycl_std::__invoke_ldexp<T>(
-      x, cl::sycl::vec<cl::sycl::cl_int, T::get_count()>(k));
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T> ldexp(T x,
+                                                             int k) __NOEXC {
+  return __sycl_std::__invoke_ldexp<T>(x, vec<int, T::get_count()>(k));
 }
 
 // vgenfloat ldexp (vgenfloat x, genint k)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_vgenfloat<T>::value && detail::is_intn<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_vgenfloat<T>::value && detail::is_intn<T2>::value, T>
 ldexp(T x, T2 k) __NOEXC {
   return __sycl_std::__invoke_ldexp<T>(x, k);
 }
 
 // genfloat lgamma (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-lgamma(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> lgamma(T x) __NOEXC {
   return __sycl_std::__invoke_lgamma<T>(x);
 }
 
 // genfloat lgamma_r (genfloat x, genintptr signp)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloat<T>::value && detail::is_genintptr<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloat<T>::value && detail::is_genintptr<T2>::value, T>
 lgamma_r(T x, T2 signp) __NOEXC {
   return __sycl_std::__invoke_lgamma_r<T>(x, signp);
 }
 
 // genfloat log (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-log(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> log(T x) __NOEXC {
   return __sycl_std::__invoke_log<T>(x);
 }
 
 // genfloat log2 (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-log2(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> log2(T x) __NOEXC {
   return __sycl_std::__invoke_log2<T>(x);
 }
 
 // genfloat log10 (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-log10(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> log10(T x) __NOEXC {
   return __sycl_std::__invoke_log10<T>(x);
 }
 
 // genfloat log1p (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-log1p(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> log1p(T x) __NOEXC {
   return __sycl_std::__invoke_log1p<T>(x);
 }
 
 // genfloat logb (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-logb(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> logb(T x) __NOEXC {
   return __sycl_std::__invoke_logb<T>(x);
 }
 
 // genfloat mad (genfloat a, genfloat b, genfloat c)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-mad(T a, T b, T c) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> mad(T a, T b,
+                                                          T c) __NOEXC {
   return __sycl_std::__invoke_mad<T>(a, b, c);
 }
 
 // genfloat maxmag (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-maxmag(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> maxmag(T x, T y) __NOEXC {
   return __sycl_std::__invoke_maxmag<T>(x, y);
 }
 
 // genfloat minmag (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-minmag(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> minmag(T x, T y) __NOEXC {
   return __sycl_std::__invoke_minmag<T>(x, y);
 }
 
 // genfloat modf (genfloat x, genfloatptr iptr)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloat<T>::value && detail::is_genfloatptr<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloat<T>::value && detail::is_genfloatptr<T2>::value, T>
 modf(T x, T2 iptr) __NOEXC {
   return __sycl_std::__invoke_modf<T>(x, iptr);
 }
 
-// genfloath nan (ugenshort nancode)
-// genfloatf nan (ugenint nancode)
-// genfloatd nan (ugenlonginteger nancode)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_nan_type<T>::value, T>::type>
-detail::unsign_integral_to_float_point_t<T>
-nan(T nancode) __NOEXC {
-  return __sycl_std::__invoke_nan<
-    detail::unsign_integral_to_float_point_t<T>>(nancode);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_nan_type<T>::value, T>>
+detail::nan_return_t<T> nan(T nancode) __NOEXC {
+  return __sycl_std::__invoke_nan<detail::nan_return_t<T>>(
+      detail::convert_data_type<T, detail::nan_argument_base_t<T>>()(nancode));
 }
 
 // genfloat nextafter (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-nextafter(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> nextafter(T x,
+                                                                T y) __NOEXC {
   return __sycl_std::__invoke_nextafter<T>(x, y);
 }
 
 // genfloat pow (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-pow(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> pow(T x, T y) __NOEXC {
   return __sycl_std::__invoke_pow<T>(x, y);
 }
 
 // genfloat pown (genfloat x, genint y)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloat<T>::value && detail::is_genint<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloat<T>::value && detail::is_genint<T2>::value, T>
 pown(T x, T2 y) __NOEXC {
   return __sycl_std::__invoke_pown<T>(x, y);
 }
 
 // genfloat powr (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-powr(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> powr(T x, T y) __NOEXC {
   return __sycl_std::__invoke_powr<T>(x, y);
 }
 
 // genfloat remainder (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-remainder(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> remainder(T x,
+                                                                T y) __NOEXC {
   return __sycl_std::__invoke_remainder<T>(x, y);
 }
 
 // genfloat remquo (genfloat x, genfloat y, genintptr quo)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloat<T>::value && detail::is_genintptr<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloat<T>::value && detail::is_genintptr<T2>::value, T>
 remquo(T x, T y, T2 quo) __NOEXC {
   return __sycl_std::__invoke_remquo<T>(x, y, quo);
 }
 
 // genfloat rint (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-rint(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> rint(T x) __NOEXC {
   return __sycl_std::__invoke_rint<T>(x);
 }
 
 // genfloat rootn (genfloat x, genint y)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloat<T>::value && detail::is_genint<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloat<T>::value && detail::is_genint<T2>::value, T>
 rootn(T x, T2 y) __NOEXC {
   return __sycl_std::__invoke_rootn<T>(x, y);
 }
 
 // genfloat round (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-round(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> round(T x) __NOEXC {
   return __sycl_std::__invoke_round<T>(x);
 }
 
 // genfloat rsqrt (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-rsqrt(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> rsqrt(T x) __NOEXC {
   return __sycl_std::__invoke_rsqrt<T>(x);
 }
 
 // genfloat sin (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-sin(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> sin(T x) __NOEXC {
   return __sycl_std::__invoke_sin<T>(x);
 }
 
 // genfloat sincos (genfloat x, genfloatptr cosval)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloat<T>::value && detail::is_genfloatptr<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloat<T>::value && detail::is_genfloatptr<T2>::value, T>
 sincos(T x, T2 cosval) __NOEXC {
   return __sycl_std::__invoke_sincos<T>(x, cosval);
 }
 
 // genfloat sinh (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-sinh(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> sinh(T x) __NOEXC {
   return __sycl_std::__invoke_sinh<T>(x);
 }
 
 // genfloat sinpi (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-sinpi(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> sinpi(T x) __NOEXC {
   return __sycl_std::__invoke_sinpi<T>(x);
 }
 
 // genfloat sqrt (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-sqrt(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> sqrt(T x) __NOEXC {
   return __sycl_std::__invoke_sqrt<T>(x);
 }
 
 // genfloat tan (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-tan(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> tan(T x) __NOEXC {
   return __sycl_std::__invoke_tan<T>(x);
 }
 
 // genfloat tanh (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-tanh(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> tanh(T x) __NOEXC {
   return __sycl_std::__invoke_tanh<T>(x);
 }
 
 // genfloat tanpi (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-tanpi(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> tanpi(T x) __NOEXC {
   return __sycl_std::__invoke_tanpi<T>(x);
 }
 
 // genfloat tgamma (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-tgamma(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> tgamma(T x) __NOEXC {
   return __sycl_std::__invoke_tgamma<T>(x);
 }
 
 // genfloat trunc (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-trunc(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> trunc(T x) __NOEXC {
   return __sycl_std::__invoke_trunc<T>(x);
 }
 
 /* --------------- 4.13.5 Common functions. ---------------------------------*/
 // genfloat clamp (genfloat x, genfloat minval, genfloat maxval)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-clamp(T x, T minval, T maxval) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> clamp(T x, T minval,
+                                                            T maxval) __NOEXC {
   return __sycl_std::__invoke_fclamp<T>(x, minval, maxval);
 }
 
@@ -556,7 +500,7 @@ clamp(T x, T minval, T maxval) __NOEXC {
 // genfloatf clamp (genfloatf x, float minval, float maxval)
 // genfloatd clamp (genfloatd x, double minval, double maxval)
 template <typename T>
-typename std::enable_if<detail::is_vgenfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
 clamp(T x, typename T::element_type minval,
       typename T::element_type maxval) __NOEXC {
   return __sycl_std::__invoke_fclamp<T>(x, T(minval), T(maxval));
@@ -564,22 +508,20 @@ clamp(T x, typename T::element_type minval,
 
 // genfloat degrees (genfloat radians)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_genfloat<T>::value, T>
 degrees(T radians) __NOEXC {
   return __sycl_std::__invoke_degrees<T>(radians);
 }
 
 // genfloat abs (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-abs(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> abs(T x) __NOEXC {
   return __sycl_std::__invoke_fabs<T>(x);
 }
 
 // genfloat max (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-max(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> max(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fmax_common<T>(x, y);
 }
 
@@ -587,15 +529,14 @@ max(T x, T y) __NOEXC {
 // genfloatd max (genfloatd x, double y)
 // genfloath max (genfloath x, half y)
 template <typename T>
-typename std::enable_if<detail::is_vgenfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
 max(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_fmax_common<T>(x, T(y));
 }
 
 // genfloat min (genfloat x, genfloat y)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-min(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> min(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fmin_common<T>(x, y);
 }
 
@@ -603,15 +544,15 @@ min(T x, T y) __NOEXC {
 // genfloatd min (genfloatd x, double y)
 // genfloath min (genfloath x, half y)
 template <typename T>
-typename std::enable_if<detail::is_vgenfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
 min(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_fmin_common<T>(x, T(y));
 }
 
 // genfloat mix (genfloat x, genfloat y, genfloat a)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-mix(T x, T y, T a) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> mix(T x, T y,
+                                                          T a) __NOEXC {
   return __sycl_std::__invoke_mix<T>(x, y, a);
 }
 
@@ -619,22 +560,22 @@ mix(T x, T y, T a) __NOEXC {
 // genfloatd mix (genfloatd x, genfloatd y, double a)
 // genfloatd mix (genfloath x, genfloath y, half a)
 template <typename T>
-typename std::enable_if<detail::is_vgenfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
 mix(T x, T y, typename T::element_type a) __NOEXC {
   return __sycl_std::__invoke_mix<T>(x, y, T(a));
 }
 
 // genfloat radians (genfloat degrees)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_genfloat<T>::value, T>
 radians(T degrees) __NOEXC {
   return __sycl_std::__invoke_radians<T>(degrees);
 }
 
 // genfloat step (genfloat edge, genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-step(T edge, T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> step(T edge,
+                                                           T x) __NOEXC {
   return __sycl_std::__invoke_step<T>(edge, x);
 }
 
@@ -642,14 +583,14 @@ step(T edge, T x) __NOEXC {
 // genfloatd step (double edge, genfloatd x)
 // genfloatd step (half edge, genfloath x)
 template <typename T>
-typename std::enable_if<detail::is_vgenfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
 step(typename T::element_type edge, T x) __NOEXC {
   return __sycl_std::__invoke_step<T>(T(edge), x);
 }
 
 // genfloat smoothstep (genfloat edge0, genfloat edge1, genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_genfloat<T>::value, T>
 smoothstep(T edge0, T edge1, T x) __NOEXC {
   return __sycl_std::__invoke_smoothstep<T>(edge0, edge1, x);
 }
@@ -658,7 +599,7 @@ smoothstep(T edge0, T edge1, T x) __NOEXC {
 // genfloatd smoothstep (double edge0, double edge1, genfloatd x)
 // genfloath smoothstep (half edge0, half edge1, genfloath x)
 template <typename T>
-typename std::enable_if<detail::is_vgenfloat<T>::value, T>::type
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
 smoothstep(typename T::element_type edge0, typename T::element_type edge1,
            T x) __NOEXC {
   return __sycl_std::__invoke_smoothstep<T>(T(edge0), T(edge1), x);
@@ -666,102 +607,99 @@ smoothstep(typename T::element_type edge0, typename T::element_type edge1,
 
 // genfloat sign (genfloat x)
 template <typename T>
-typename std::enable_if<detail::is_genfloat<T>::value, T>::type
-sign(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> sign(T x) __NOEXC {
   return __sycl_std::__invoke_sign<T>(x);
 }
 
 /* --------------- 4.13.4 Integer functions. --------------------------------*/
 // ugeninteger abs (geninteger x)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-abs(T x) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> abs(T x) __NOEXC {
   return __sycl_std::__invoke_u_abs<T>(x);
 }
 
 // ugeninteger abs (geninteger x)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value,
-                        typename detail::make_unsigned<T>::type>::type
+detail::enable_if_t<detail::is_igeninteger<T>::value,
+                    detail::make_unsigned_t<T>>
 abs(T x) __NOEXC {
-  return __sycl_std::__invoke_s_abs<typename detail::make_unsigned<T>::type>(x);
+  return __sycl_std::__invoke_s_abs<detail::make_unsigned_t<T>>(x);
 }
 
 // ugeninteger abs_diff (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-abs_diff(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> abs_diff(T x,
+                                                                  T y) __NOEXC {
   return __sycl_std::__invoke_u_abs_diff<T>(x, y);
 }
 
 // ugeninteger abs_diff (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value,
-                        typename detail::make_unsigned<T>::type>::type
+detail::enable_if_t<detail::is_igeninteger<T>::value,
+                    detail::make_unsigned_t<T>>
 abs_diff(T x, T y) __NOEXC {
-  return __sycl_std::__invoke_s_abs_diff<
-      typename detail::make_unsigned<T>::type>(x, y);
+  return __sycl_std::__invoke_s_abs_diff<detail::make_unsigned_t<T>>(x, y);
 }
 
 // geninteger add_sat (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
-add_sat(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> add_sat(T x,
+                                                                 T y) __NOEXC {
   return __sycl_std::__invoke_s_add_sat<T>(x, y);
 }
 
 // geninteger add_sat (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-add_sat(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> add_sat(T x,
+                                                                 T y) __NOEXC {
   return __sycl_std::__invoke_u_add_sat<T>(x, y);
 }
 
 // geninteger hadd (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
-hadd(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> hadd(T x,
+                                                              T y) __NOEXC {
   return __sycl_std::__invoke_s_hadd<T>(x, y);
 }
 
 // geninteger hadd (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-hadd(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> hadd(T x,
+                                                              T y) __NOEXC {
   return __sycl_std::__invoke_u_hadd<T>(x, y);
 }
 
 // geninteger rhadd (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
-rhadd(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> rhadd(T x,
+                                                               T y) __NOEXC {
   return __sycl_std::__invoke_s_rhadd<T>(x, y);
 }
 
 // geninteger rhadd (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-rhadd(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> rhadd(T x,
+                                                               T y) __NOEXC {
   return __sycl_std::__invoke_u_rhadd<T>(x, y);
 }
 
 // geninteger clamp (geninteger x, geninteger minval, geninteger maxval)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
+detail::enable_if_t<detail::is_igeninteger<T>::value, T>
 clamp(T x, T minval, T maxval) __NOEXC {
   return __sycl_std::__invoke_s_clamp<T>(x, minval, maxval);
 }
 
 // geninteger clamp (geninteger x, geninteger minval, geninteger maxval)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T>
 clamp(T x, T minval, T maxval) __NOEXC {
   return __sycl_std::__invoke_u_clamp<T>(x, minval, maxval);
 }
 
 // geninteger clamp (geninteger x, sgeninteger minval, sgeninteger maxval)
 template <typename T>
-typename std::enable_if<detail::is_vigeninteger<T>::value, T>::type
+detail::enable_if_t<detail::is_vigeninteger<T>::value, T>
 clamp(T x, typename T::element_type minval,
       typename T::element_type maxval) __NOEXC {
   return __sycl_std::__invoke_s_clamp<T>(x, T(minval), T(maxval));
@@ -769,7 +707,7 @@ clamp(T x, typename T::element_type minval,
 
 // geninteger clamp (geninteger x, sgeninteger minval, sgeninteger maxval)
 template <typename T>
-typename std::enable_if<detail::is_vugeninteger<T>::value, T>::type
+detail::enable_if_t<detail::is_vugeninteger<T>::value, T>
 clamp(T x, typename T::element_type minval,
       typename T::element_type maxval) __NOEXC {
   return __sycl_std::__invoke_u_clamp<T>(x, T(minval), T(maxval));
@@ -777,136 +715,130 @@ clamp(T x, typename T::element_type minval,
 
 // geninteger clz (geninteger x)
 template <typename T>
-typename std::enable_if<detail::is_geninteger<T>::value, T>::type
-clz(T x) __NOEXC {
+detail::enable_if_t<detail::is_geninteger<T>::value, T> clz(T x) __NOEXC {
   return __sycl_std::__invoke_clz<T>(x);
 }
 
 namespace intel {
 // geninteger ctz (geninteger x)
 template <typename T>
-typename std::enable_if<detail::is_geninteger<T>::value, T>::type
-ctz(T x) __NOEXC {
+detail::enable_if_t<detail::is_geninteger<T>::value, T> ctz(T x) __NOEXC {
   return __sycl_std::__invoke_ctz<T>(x);
 }
-}
+} // namespace intel
 
 // geninteger mad_hi (geninteger a, geninteger b, geninteger c)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
-mad_hi(T x, T y, T z) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> mad_hi(T x, T y,
+                                                                T z) __NOEXC {
   return __sycl_std::__invoke_s_mad_hi<T>(x, y, z);
 }
 
 // geninteger mad_hi (geninteger a, geninteger b, geninteger c)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-mad_hi(T x, T y, T z) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> mad_hi(T x, T y,
+                                                                T z) __NOEXC {
   return __sycl_std::__invoke_u_mad_hi<T>(x, y, z);
 }
 
 // geninteger mad_sat (geninteger a, geninteger b, geninteger c)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
-mad_sat(T a, T b, T c) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> mad_sat(T a, T b,
+                                                                 T c) __NOEXC {
   return __sycl_std::__invoke_s_mad_sat<T>(a, b, c);
 }
 
 // geninteger mad_sat (geninteger a, geninteger b, geninteger c)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-mad_sat(T a, T b, T c) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> mad_sat(T a, T b,
+                                                                 T c) __NOEXC {
   return __sycl_std::__invoke_u_mad_sat<T>(a, b, c);
 }
 
 // igeninteger max (igeninteger x, igeninteger y)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
-max(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> max(T x, T y) __NOEXC {
   return __sycl_std::__invoke_s_max<T>(x, y);
 }
 
 // ugeninteger max (ugeninteger x, ugeninteger y)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-max(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> max(T x, T y) __NOEXC {
   return __sycl_std::__invoke_u_max<T>(x, y);
 }
 
 // igeninteger max (vigeninteger x, sigeninteger y)
 template <typename T>
-typename std::enable_if<detail::is_vigeninteger<T>::value, T>::type
+detail::enable_if_t<detail::is_vigeninteger<T>::value, T>
 max(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_s_max<T>(x, T(y));
 }
 
 // vugeninteger max (vugeninteger x, sugeninteger y)
 template <typename T>
-typename std::enable_if<detail::is_vugeninteger<T>::value, T>::type
+detail::enable_if_t<detail::is_vugeninteger<T>::value, T>
 max(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_u_max<T>(x, T(y));
 }
 
 // igeninteger min (igeninteger x, igeninteger y)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
-min(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> min(T x, T y) __NOEXC {
   return __sycl_std::__invoke_s_min<T>(x, y);
 }
 
 // ugeninteger min (ugeninteger x, ugeninteger y)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-min(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> min(T x, T y) __NOEXC {
   return __sycl_std::__invoke_u_min<T>(x, y);
 }
 
 // vigeninteger min (vigeninteger x, sigeninteger y)
 template <typename T>
-typename std::enable_if<detail::is_vigeninteger<T>::value, T>::type
+detail::enable_if_t<detail::is_vigeninteger<T>::value, T>
 min(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_s_min<T>(x, T(y));
 }
 
 // vugeninteger min (vugeninteger x, sugeninteger y)
 template <typename T>
-typename std::enable_if<detail::is_vugeninteger<T>::value, T>::type
+detail::enable_if_t<detail::is_vugeninteger<T>::value, T>
 min(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_u_min<T>(x, T(y));
 }
 
 // geninteger mul_hi (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
-mul_hi(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> mul_hi(T x,
+                                                                T y) __NOEXC {
   return __sycl_std::__invoke_s_mul_hi<T>(x, y);
 }
 
 // geninteger mul_hi (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-mul_hi(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> mul_hi(T x,
+                                                                T y) __NOEXC {
   return __sycl_std::__invoke_u_mul_hi<T>(x, y);
 }
 
 // geninteger rotate (geninteger v, geninteger i)
 template <typename T>
-typename std::enable_if<detail::is_geninteger<T>::value, T>::type
-rotate(T v, T i) __NOEXC {
+detail::enable_if_t<detail::is_geninteger<T>::value, T> rotate(T v,
+                                                               T i) __NOEXC {
   return __sycl_std::__invoke_rotate<T>(v, i);
 }
 
 // geninteger sub_sat (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger<T>::value, T>::type
-sub_sat(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> sub_sat(T x,
+                                                                 T y) __NOEXC {
   return __sycl_std::__invoke_s_sub_sat<T>(x, y);
 }
 
 // geninteger sub_sat (geninteger x, geninteger y)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger<T>::value, T>::type
-sub_sat(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> sub_sat(T x,
+                                                                 T y) __NOEXC {
   return __sycl_std::__invoke_u_sub_sat<T>(x, y);
 }
 
@@ -916,74 +848,67 @@ sub_sat(T x, T y) __NOEXC {
 
 // ugeninteger16bit upsample (ugeninteger8bit hi, ugeninteger8bit lo)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger8bit<T>::value,
-                        typename detail::make_upper<T>::type>::type
+detail::enable_if_t<detail::is_ugeninteger8bit<T>::value,
+                    detail::make_larger_t<T>>
 upsample(T hi, T lo) __NOEXC {
-  return __sycl_std::__invoke_u_upsample<typename detail::make_upper<T>::type>(
-      hi, lo);
+  return __sycl_std::__invoke_u_upsample<detail::make_larger_t<T>>(hi, lo);
 }
 
 // igeninteger16bit upsample (igeninteger8bit hi, ugeninteger8bit lo)
 template <typename T, typename T2>
-typename std::enable_if<detail::is_igeninteger8bit<T>::value &&
-                            detail::is_ugeninteger8bit<T2>::value,
-                        typename detail::make_upper<T>::type>::type
+detail::enable_if_t<detail::is_igeninteger8bit<T>::value &&
+                        detail::is_ugeninteger8bit<T2>::value,
+                    detail::make_larger_t<T>>
 upsample(T hi, T2 lo) __NOEXC {
-  return __sycl_std::__invoke_s_upsample<typename detail::make_upper<T>::type>(
-      hi, lo);
+  return __sycl_std::__invoke_s_upsample<detail::make_larger_t<T>>(hi, lo);
 }
 
 // ugeninteger32bit upsample (ugeninteger16bit hi, ugeninteger16bit lo)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger16bit<T>::value,
-                        typename detail::make_upper<T>::type>::type
+detail::enable_if_t<detail::is_ugeninteger16bit<T>::value,
+                    detail::make_larger_t<T>>
 upsample(T hi, T lo) __NOEXC {
-  return __sycl_std::__invoke_u_upsample<typename detail::make_upper<T>::type>(
-      hi, lo);
+  return __sycl_std::__invoke_u_upsample<detail::make_larger_t<T>>(hi, lo);
 }
 
 // igeninteger32bit upsample (igeninteger16bit hi, ugeninteger16bit lo)
 template <typename T, typename T2>
-typename std::enable_if<detail::is_igeninteger16bit<T>::value &&
-                            detail::is_ugeninteger16bit<T2>::value,
-                        typename detail::make_upper<T>::type>::type
+detail::enable_if_t<detail::is_igeninteger16bit<T>::value &&
+                        detail::is_ugeninteger16bit<T2>::value,
+                    detail::make_larger_t<T>>
 upsample(T hi, T2 lo) __NOEXC {
-  return __sycl_std::__invoke_s_upsample<typename detail::make_upper<T>::type>(
-      hi, lo);
+  return __sycl_std::__invoke_s_upsample<detail::make_larger_t<T>>(hi, lo);
 }
 
 // ugeninteger64bit upsample (ugeninteger32bit hi, ugeninteger32bit lo)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger32bit<T>::value,
-                        typename detail::make_upper<T>::type>::type
+detail::enable_if_t<detail::is_ugeninteger32bit<T>::value,
+                    detail::make_larger_t<T>>
 upsample(T hi, T lo) __NOEXC {
-  return __sycl_std::__invoke_u_upsample<typename detail::make_upper<T>::type>(
-      hi, lo);
+  return __sycl_std::__invoke_u_upsample<detail::make_larger_t<T>>(hi, lo);
 }
 
 // igeninteger64bit upsample (igeninteger32bit hi, ugeninteger32bit lo)
 template <typename T, typename T2>
-typename std::enable_if<detail::is_igeninteger32bit<T>::value &&
-                            detail::is_ugeninteger32bit<T2>::value,
-                        typename detail::make_upper<T>::type>::type
+detail::enable_if_t<detail::is_igeninteger32bit<T>::value &&
+                        detail::is_ugeninteger32bit<T2>::value,
+                    detail::make_larger_t<T>>
 upsample(T hi, T2 lo) __NOEXC {
-  return __sycl_std::__invoke_s_upsample<typename detail::make_upper<T>::type>(
-      hi, lo);
+  return __sycl_std::__invoke_s_upsample<detail::make_larger_t<T>>(hi, lo);
 }
 
 #undef __invoke_s_upsample
 
 // geninteger popcount (geninteger x)
 template <typename T>
-typename std::enable_if<detail::is_geninteger<T>::value, T>::type
-popcount(T x) __NOEXC {
+detail::enable_if_t<detail::is_geninteger<T>::value, T> popcount(T x) __NOEXC {
   return __sycl_std::__invoke_popcount<T>(x);
 }
 
 // geninteger32bit mad24 (geninteger32bit x, geninteger32bit y,
 // geninteger32bit z)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger32bit<T>::value, T>::type
+detail::enable_if_t<detail::is_igeninteger32bit<T>::value, T>
 mad24(T x, T y, T z) __NOEXC {
   return __sycl_std::__invoke_s_mad24<T>(x, y, z);
 }
@@ -991,21 +916,21 @@ mad24(T x, T y, T z) __NOEXC {
 // geninteger32bit mad24 (geninteger32bit x, geninteger32bit y,
 // geninteger32bit z)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger32bit<T>::value, T>::type
+detail::enable_if_t<detail::is_ugeninteger32bit<T>::value, T>
 mad24(T x, T y, T z) __NOEXC {
   return __sycl_std::__invoke_u_mad24<T>(x, y, z);
 }
 
 // geninteger32bit mul24 (geninteger32bit x, geninteger32bit y)
 template <typename T>
-typename std::enable_if<detail::is_igeninteger32bit<T>::value, T>::type
+detail::enable_if_t<detail::is_igeninteger32bit<T>::value, T>
 mul24(T x, T y) __NOEXC {
   return __sycl_std::__invoke_s_mul24<T>(x, y);
 }
 
 // geninteger32bit mul24 (geninteger32bit x, geninteger32bit y)
 template <typename T>
-typename std::enable_if<detail::is_ugeninteger32bit<T>::value, T>::type
+detail::enable_if_t<detail::is_ugeninteger32bit<T>::value, T>
 mul24(T x, T y) __NOEXC {
   return __sycl_std::__invoke_u_mul24<T>(x, y);
 }
@@ -1018,8 +943,8 @@ mul24(T x, T y) __NOEXC {
 // half3 cross (half3 p0, half3 p1)
 // half4 cross (half4 p0, half4 p1)
 template <typename T>
-typename std::enable_if<detail::is_gencrossfloat<T>::value, T>::type
-cross(T p0, T p1) __NOEXC {
+detail::enable_if_t<detail::is_gencrossfloat<T>::value, T> cross(T p0,
+                                                                 T p1) __NOEXC {
   return __sycl_std::__invoke_cross<T>(p0, p1);
 }
 
@@ -1027,136 +952,131 @@ cross(T p0, T p1) __NOEXC {
 // double dot (double p0, double p1)
 // half dot (half p0, half p1)
 template <typename T>
-typename std::enable_if<detail::is_sgenfloat<T>::value, T>::type
-dot(T p0, T p1) __NOEXC {
+detail::enable_if_t<detail::is_sgenfloat<T>::value, T> dot(T p0, T p1) __NOEXC {
   return __sycl_std::__invoke_FMul<T>(p0, p1);
 }
 
 // float dot (vgengeofloat p0, vgengeofloat p1)
 template <typename T>
-typename std::enable_if<detail::is_vgengeofloat<T>::value,
-                        cl::sycl::cl_float>::type
+detail::enable_if_t<detail::is_vgengeofloat<T>::value, float>
 dot(T p0, T p1) __NOEXC {
-  return __sycl_std::__invoke_Dot<cl::sycl::cl_float>(p0, p1);
+  return __sycl_std::__invoke_Dot<float>(p0, p1);
 }
 
 // double dot (vgengeodouble p0, vgengeodouble p1)
 template <typename T>
-typename std::enable_if<detail::is_vgengeodouble<T>::value,
-                        cl::sycl::cl_double>::type
+detail::enable_if_t<detail::is_vgengeodouble<T>::value, double>
 dot(T p0, T p1) __NOEXC {
-  return __sycl_std::__invoke_Dot<cl::sycl::cl_double>(p0, p1);
+  return __sycl_std::__invoke_Dot<double>(p0, p1);
 }
 
 // half dot (vgengeohalf p0, vgengeohalf p1)
 template <typename T>
-typename std::enable_if<detail::is_vgengeohalf<T>::value,
-                        cl::sycl::cl_half>::type
-dot(T p0, T p1) __NOEXC {
-  return __sycl_std::__invoke_Dot<cl::sycl::cl_half>(p0, p1);
+detail::enable_if_t<detail::is_vgengeohalf<T>::value, half> dot(T p0,
+                                                                T p1) __NOEXC {
+  return __sycl_std::__invoke_Dot<half>(p0, p1);
 }
 
 // float distance (gengeofloat p0, gengeofloat p1)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeofloat<T>::value, T>::type>
-cl::sycl::cl_float distance(T p0, T p1) __NOEXC {
-  return __sycl_std::__invoke_distance<cl::sycl::cl_float>(p0, p1);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeofloat<T>::value, T>>
+float distance(T p0, T p1) __NOEXC {
+  return __sycl_std::__invoke_distance<float>(p0, p1);
 }
 
 // double distance (gengeodouble p0, gengeodouble p1)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeodouble<T>::value, T>::type>
-cl::sycl::cl_double distance(T p0, T p1) __NOEXC {
-  return __sycl_std::__invoke_distance<cl::sycl::cl_double>(p0, p1);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeodouble<T>::value, T>>
+double distance(T p0, T p1) __NOEXC {
+  return __sycl_std::__invoke_distance<double>(p0, p1);
 }
 
 // half distance (gengeohalf p0, gengeohalf p1)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeohalf<T>::value, T>::type>
-cl::sycl::cl_half distance(T p0, T p1) __NOEXC {
-  return __sycl_std::__invoke_distance<cl::sycl::cl_half>(p0, p1);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeohalf<T>::value, T>>
+half distance(T p0, T p1) __NOEXC {
+  return __sycl_std::__invoke_distance<half>(p0, p1);
 }
 
 // float length (gengeofloat p)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeofloat<T>::value, T>::type>
-cl::sycl::cl_float length(T p) __NOEXC {
-  return __sycl_std::__invoke_length<cl::sycl::cl_float>(p);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeofloat<T>::value, T>>
+float length(T p) __NOEXC {
+  return __sycl_std::__invoke_length<float>(p);
 }
 
 // double length (gengeodouble p)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeodouble<T>::value, T>::type>
-cl::sycl::cl_double length(T p) __NOEXC {
-  return __sycl_std::__invoke_length<cl::sycl::cl_double>(p);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeodouble<T>::value, T>>
+double length(T p) __NOEXC {
+  return __sycl_std::__invoke_length<double>(p);
 }
 
 // half length (gengeohalf p)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeohalf<T>::value, T>::type>
-cl::sycl::cl_half length(T p) __NOEXC {
-  return __sycl_std::__invoke_length<cl::sycl::cl_half>(p);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeohalf<T>::value, T>>
+half length(T p) __NOEXC {
+  return __sycl_std::__invoke_length<half>(p);
 }
 
 // gengeofloat normalize (gengeofloat p)
 template <typename T>
-typename std::enable_if<detail::is_gengeofloat<T>::value, T>::type
+detail::enable_if_t<detail::is_gengeofloat<T>::value, T>
 normalize(T p) __NOEXC {
   return __sycl_std::__invoke_normalize<T>(p);
 }
 
 // gengeodouble normalize (gengeodouble p)
 template <typename T>
-typename std::enable_if<detail::is_gengeodouble<T>::value, T>::type
+detail::enable_if_t<detail::is_gengeodouble<T>::value, T>
 normalize(T p) __NOEXC {
   return __sycl_std::__invoke_normalize<T>(p);
 }
 
 // gengeohalf normalize (gengeohalf p)
 template <typename T>
-typename std::enable_if<detail::is_gengeohalf<T>::value, T>::type
-normalize(T p) __NOEXC {
+detail::enable_if_t<detail::is_gengeohalf<T>::value, T> normalize(T p) __NOEXC {
   return __sycl_std::__invoke_normalize<T>(p);
 }
 
 // float fast_distance (gengeofloat p0, gengeofloat p1)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeofloat<T>::value, T>::type>
-cl::sycl::cl_float fast_distance(T p0, T p1) __NOEXC {
-  return __sycl_std::__invoke_fast_distance<cl::sycl::cl_float>(p0, p1);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeofloat<T>::value, T>>
+float fast_distance(T p0, T p1) __NOEXC {
+  return __sycl_std::__invoke_fast_distance<float>(p0, p1);
 }
 
 // double fast_distance (gengeodouble p0, gengeodouble p1)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeodouble<T>::value, T>::type>
-cl::sycl::cl_double fast_distance(T p0, T p1) __NOEXC {
-  return __sycl_std::__invoke_fast_distance<cl::sycl::cl_double>(p0, p1);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeodouble<T>::value, T>>
+double fast_distance(T p0, T p1) __NOEXC {
+  return __sycl_std::__invoke_fast_distance<double>(p0, p1);
 }
 
 // float fast_length (gengeofloat p)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeofloat<T>::value, T>::type>
-cl::sycl::cl_float fast_length(T p) __NOEXC {
-  return __sycl_std::__invoke_fast_length<cl::sycl::cl_float>(p);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeofloat<T>::value, T>>
+float fast_length(T p) __NOEXC {
+  return __sycl_std::__invoke_fast_length<float>(p);
 }
 
 // double fast_length (gengeodouble p)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_gengeodouble<T>::value, T>::type>
-cl::sycl::cl_double fast_length(T p) __NOEXC {
-  return __sycl_std::__invoke_fast_length<cl::sycl::cl_double>(p);
+template <typename T,
+          typename = detail::enable_if_t<detail::is_gengeodouble<T>::value, T>>
+double fast_length(T p) __NOEXC {
+  return __sycl_std::__invoke_fast_length<double>(p);
 }
 
 // gengeofloat fast_normalize (gengeofloat p)
 template <typename T>
-typename std::enable_if<detail::is_gengeofloat<T>::value, T>::type
+detail::enable_if_t<detail::is_gengeofloat<T>::value, T>
 fast_normalize(T p) __NOEXC {
   return __sycl_std::__invoke_fast_normalize<T>(p);
 }
 
 // gengeodouble fast_normalize (gengeodouble p)
 template <typename T>
-typename std::enable_if<detail::is_gengeodouble<T>::value, T>::type
+detail::enable_if_t<detail::is_gengeodouble<T>::value, T>
 fast_normalize(T p) __NOEXC {
   return __sycl_std::__invoke_fast_normalize<T>(p);
 }
@@ -1167,8 +1087,8 @@ fast_normalize(T p) __NOEXC {
 // igeninteger32bit isequal (genfloatf x, genfloatf y)
 // int isequal (double x,double y);
 // longn isequal (doublen x, doublen y)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isequal(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdEqual<detail::rel_ret_t<T>>(x, y));
@@ -1179,8 +1099,8 @@ detail::common_rel_ret_t<T> isequal(T x, T y) __NOEXC {
 // igeninteger32bit isnotequal (genfloatf x, genfloatf y)
 // int isnotequal (double x, double y)
 // longn isnotequal (doublen x, doublen y)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isnotequal(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FUnordNotEqual<detail::rel_ret_t<T>>(x, y));
@@ -1191,8 +1111,8 @@ detail::common_rel_ret_t<T> isnotequal(T x, T y) __NOEXC {
 // igeninteger32bit isgreater (genfloatf x, genfloatf y)
 // int isgreater (double x, double y)
 // longn isgreater (doublen x, doublen y)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isgreater(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdGreaterThan<detail::rel_ret_t<T>>(x, y));
@@ -1203,8 +1123,8 @@ detail::common_rel_ret_t<T> isgreater(T x, T y) __NOEXC {
 // igeninteger32bit isgreaterequal (genfloatf x, genfloatf y)
 // int isgreaterequal (double x, double y)
 // longn isgreaterequal (doublen x, doublen y)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isgreaterequal(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdGreaterThanEqual<detail::rel_ret_t<T>>(x, y));
@@ -1215,8 +1135,8 @@ detail::common_rel_ret_t<T> isgreaterequal(T x, T y) __NOEXC {
 // igeninteger32bit isless (genfloatf x, genfloatf y)
 // int isless (long x, long y)
 // longn isless (doublen x, doublen y)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isless(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdLessThan<detail::rel_ret_t<T>>(x, y));
@@ -1227,8 +1147,8 @@ detail::common_rel_ret_t<T> isless(T x, T y) __NOEXC {
 // igeninteger32bit islessequal (genfloatf x, genfloatf y)
 // int islessequal (double x, double y)
 // longn islessequal (doublen x, doublen y)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> islessequal(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdLessThanEqual<detail::rel_ret_t<T>>(x, y));
@@ -1239,8 +1159,8 @@ detail::common_rel_ret_t<T> islessequal(T x, T y) __NOEXC {
 // igeninteger32bit islessgreater (genfloatf x, genfloatf y)
 // int islessgreater (double x, double y)
 // longn islessgreater (doublen x, doublen y)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> islessgreater(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_LessOrGreater<detail::rel_ret_t<T>>(x, y));
@@ -1251,8 +1171,8 @@ detail::common_rel_ret_t<T> islessgreater(T x, T y) __NOEXC {
 // igeninteger32bit isfinite (genfloatf x)
 // int isfinite (double x)
 // longn isfinite (doublen x)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isfinite(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_IsFinite<detail::rel_ret_t<T>>(x));
@@ -1263,8 +1183,8 @@ detail::common_rel_ret_t<T> isfinite(T x) __NOEXC {
 // igeninteger32bit isinf (genfloatf x)
 // int isinf (double x)
 // longn isinf (doublen x)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isinf(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_IsInf<detail::rel_ret_t<T>>(x));
@@ -1275,8 +1195,8 @@ detail::common_rel_ret_t<T> isinf(T x) __NOEXC {
 // igeninteger32bit isnan (genfloatf x)
 // int isnan (double x)
 // longn isnan (doublen x)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isnan(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_IsNan<detail::rel_ret_t<T>>(x));
@@ -1287,8 +1207,8 @@ detail::common_rel_ret_t<T> isnan(T x) __NOEXC {
 // igeninteger32bit isnormal (genfloatf x)
 // int isnormal (double x)
 // longn isnormal (doublen x)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isnormal(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_IsNormal<detail::rel_ret_t<T>>(x));
@@ -1299,8 +1219,8 @@ detail::common_rel_ret_t<T> isnormal(T x) __NOEXC {
 // igeninteger32bit isordered (genfloatf x, genfloatf y)
 // int isordered (double x, double y)
 // longn isordered (doublen x, doublen y)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isordered(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_Ordered<detail::rel_ret_t<T>>(x, y));
@@ -1311,8 +1231,8 @@ detail::common_rel_ret_t<T> isordered(T x, T y) __NOEXC {
 // igeninteger32bit isunordered (genfloatf x, genfloatf y)
 // int isunordered (double x, double y)
 // longn isunordered (doublen x, doublen y)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> isunordered(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_Unordered<detail::rel_ret_t<T>>(x, y));
@@ -1323,8 +1243,8 @@ detail::common_rel_ret_t<T> isunordered(T x, T y) __NOEXC {
 // igeninteger32bit signbit (genfloatf x)
 // int signbit (double)
 // longn signbit (doublen x)
-template <typename T, typename = typename std::enable_if<
-                          detail::is_genfloat<T>::value, T>::type>
+template <typename T,
+          typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::common_rel_ret_t<T> signbit(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_SignBitSet<detail::rel_ret_t<T>>(x));
@@ -1332,17 +1252,13 @@ detail::common_rel_ret_t<T> signbit(T x) __NOEXC {
 
 // int any (sigeninteger x)
 template <typename T>
-typename std::enable_if<detail::is_sigeninteger<T>::value,
-                        cl::sycl::cl_int>::type
-any(T x) __NOEXC {
-  return detail::Boolean<1>(cl::sycl::cl_int(detail::msbIsSet(x)));
+detail::enable_if_t<detail::is_sigeninteger<T>::value, int> any(T x) __NOEXC {
+  return detail::Boolean<1>(int(detail::msbIsSet(x)));
 }
 
 // int any (vigeninteger x)
 template <typename T>
-typename std::enable_if<detail::is_vigeninteger<T>::value,
-                        cl::sycl::cl_int>::type
-any(T x) __NOEXC {
+detail::enable_if_t<detail::is_vigeninteger<T>::value, int> any(T x) __NOEXC {
   return detail::rel_sign_bit_test_ret_t<T>(
       __sycl_std::__invoke_Any<detail::rel_sign_bit_test_ret_t<T>>(
           detail::rel_sign_bit_test_arg_t<T>(x)));
@@ -1350,17 +1266,13 @@ any(T x) __NOEXC {
 
 // int all (sigeninteger x)
 template <typename T>
-typename std::enable_if<detail::is_sigeninteger<T>::value,
-                        cl::sycl::cl_int>::type
-all(T x) __NOEXC {
-  return detail::Boolean<1>(cl::sycl::cl_int(detail::msbIsSet(x)));
+detail::enable_if_t<detail::is_sigeninteger<T>::value, int> all(T x) __NOEXC {
+  return detail::Boolean<1>(int(detail::msbIsSet(x)));
 }
 
 // int all (vigeninteger x)
 template <typename T>
-typename std::enable_if<detail::is_vigeninteger<T>::value,
-                        cl::sycl::cl_int>::type
-all(T x) __NOEXC {
+detail::enable_if_t<detail::is_vigeninteger<T>::value, int> all(T x) __NOEXC {
   return detail::rel_sign_bit_test_ret_t<T>(
       __sycl_std::__invoke_All<detail::rel_sign_bit_test_ret_t<T>>(
           detail::rel_sign_bit_test_arg_t<T>(x)));
@@ -1368,77 +1280,71 @@ all(T x) __NOEXC {
 
 // gentype bitselect (gentype a, gentype b, gentype c)
 template <typename T>
-typename std::enable_if<detail::is_gentype<T>::value, T>::type
-bitselect(T a, T b, T c) __NOEXC {
+detail::enable_if_t<detail::is_gentype<T>::value, T> bitselect(T a, T b,
+                                                               T c) __NOEXC {
   return __sycl_std::__invoke_bitselect<T>(a, b, c);
 }
 
 // geninteger select (geninteger a, geninteger b, igeninteger c)
 template <typename T, typename T2>
-typename std::enable_if<detail::is_geninteger<T>::value &&
-                            detail::is_igeninteger<T2>::value,
-                        T>::type
+detail::enable_if_t<
+    detail::is_geninteger<T>::value && detail::is_igeninteger<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
 // geninteger select (geninteger a, geninteger b, ugeninteger c)
 template <typename T, typename T2>
-typename std::enable_if<detail::is_geninteger<T>::value &&
-                            detail::is_ugeninteger<T2>::value,
-                        T>::type
+detail::enable_if_t<
+    detail::is_geninteger<T>::value && detail::is_ugeninteger<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
 // genfloatf select (genfloatf a, genfloatf b, genint c)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloatf<T>::value && detail::is_genint<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloatf<T>::value && detail::is_genint<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
 // genfloatf select (genfloatf a, genfloatf b, ugenint c)
 template <typename T, typename T2>
-typename std::enable_if<
-    detail::is_genfloatf<T>::value && detail::is_ugenint<T2>::value, T>::type
+detail::enable_if_t<
+    detail::is_genfloatf<T>::value && detail::is_ugenint<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
 // genfloatd select (genfloatd a, genfloatd b, igeninteger64 c)
 template <typename T, typename T2>
-typename std::enable_if<detail::is_genfloatd<T>::value &&
-                            detail::is_igeninteger64bit<T2>::value,
-                        T>::type
+detail::enable_if_t<
+    detail::is_genfloatd<T>::value && detail::is_igeninteger64bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
 // genfloatd select (genfloatd a, genfloatd b, ugeninteger64 c)
 template <typename T, typename T2>
-typename std::enable_if<detail::is_genfloatd<T>::value &&
-                            detail::is_ugeninteger64bit<T2>::value,
-                        T>::type
+detail::enable_if_t<
+    detail::is_genfloatd<T>::value && detail::is_ugeninteger64bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
 // genfloath select (genfloath a, genfloath b, igeninteger16 c)
 template <typename T, typename T2>
-typename std::enable_if<detail::is_genfloath<T>::value &&
-                            detail::is_igeninteger16bit<T2>::value,
-                        T>::type
+detail::enable_if_t<
+    detail::is_genfloath<T>::value && detail::is_igeninteger16bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
 // genfloath select (genfloath a, genfloath b, ugeninteger16 c)
 template <typename T, typename T2>
-typename std::enable_if<detail::is_genfloath<T>::value &&
-                            detail::is_ugeninteger16bit<T2>::value,
-                        T>::type
+detail::enable_if_t<
+    detail::is_genfloath<T>::value && detail::is_ugeninteger16bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
@@ -1447,99 +1353,86 @@ namespace native {
 /* ----------------- 4.13.3 Math functions. ---------------------------------*/
 // genfloatf cos (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-cos(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> cos(T x) __NOEXC {
   return __sycl_std::__invoke_native_cos<T>(x);
 }
 
 // genfloatf divide (genfloatf x, genfloatf y)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-divide(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> divide(T x,
+                                                              T y) __NOEXC {
   return __sycl_std::__invoke_native_divide<T>(x, y);
 }
 
 // genfloatf exp (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-exp(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> exp(T x) __NOEXC {
   return __sycl_std::__invoke_native_exp<T>(x);
 }
 
 // genfloatf exp2 (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-exp2(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> exp2(T x) __NOEXC {
   return __sycl_std::__invoke_native_exp2<T>(x);
 }
 
 // genfloatf exp10 (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-exp10(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> exp10(T x) __NOEXC {
   return __sycl_std::__invoke_native_exp10<T>(x);
 }
 
 // genfloatf log (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-log(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> log(T x) __NOEXC {
   return __sycl_std::__invoke_native_log<T>(x);
 }
 
 // genfloatf log2 (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-log2(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> log2(T x) __NOEXC {
   return __sycl_std::__invoke_native_log2<T>(x);
 }
 
 // genfloatf log10 (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-log10(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> log10(T x) __NOEXC {
   return __sycl_std::__invoke_native_log10<T>(x);
 }
 
 // genfloatf powr (genfloatf x, genfloatf y)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-powr(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> powr(T x, T y) __NOEXC {
   return __sycl_std::__invoke_native_powr<T>(x, y);
 }
 
 // genfloatf recip (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-recip(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> recip(T x) __NOEXC {
   return __sycl_std::__invoke_native_recip<T>(x);
 }
 
 // genfloatf rsqrt (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-rsqrt(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> rsqrt(T x) __NOEXC {
   return __sycl_std::__invoke_native_rsqrt<T>(x);
 }
 
 // genfloatf sin (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-sin(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> sin(T x) __NOEXC {
   return __sycl_std::__invoke_native_sin<T>(x);
 }
 
 // genfloatf sqrt (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-sqrt(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> sqrt(T x) __NOEXC {
   return __sycl_std::__invoke_native_sqrt<T>(x);
 }
 
 // genfloatf tan (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-tan(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> tan(T x) __NOEXC {
   return __sycl_std::__invoke_native_tan<T>(x);
 }
 
@@ -1548,99 +1441,86 @@ namespace half_precision {
 /* ----------------- 4.13.3 Math functions. ---------------------------------*/
 // genfloatf cos (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-cos(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> cos(T x) __NOEXC {
   return __sycl_std::__invoke_half_cos<T>(x);
 }
 
 // genfloatf divide (genfloatf x, genfloatf y)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-divide(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> divide(T x,
+                                                              T y) __NOEXC {
   return __sycl_std::__invoke_half_divide<T>(x, y);
 }
 
 // genfloatf exp (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-exp(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> exp(T x) __NOEXC {
   return __sycl_std::__invoke_half_exp<T>(x);
 }
 
 // genfloatf exp2 (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-exp2(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> exp2(T x) __NOEXC {
   return __sycl_std::__invoke_half_exp2<T>(x);
 }
 
 // genfloatf exp10 (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-exp10(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> exp10(T x) __NOEXC {
   return __sycl_std::__invoke_half_exp10<T>(x);
 }
 
 // genfloatf log (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-log(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> log(T x) __NOEXC {
   return __sycl_std::__invoke_half_log<T>(x);
 }
 
 // genfloatf log2 (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-log2(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> log2(T x) __NOEXC {
   return __sycl_std::__invoke_half_log2<T>(x);
 }
 
 // genfloatf log10 (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-log10(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> log10(T x) __NOEXC {
   return __sycl_std::__invoke_half_log10<T>(x);
 }
 
 // genfloatf powr (genfloatf x, genfloatf y)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-powr(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> powr(T x, T y) __NOEXC {
   return __sycl_std::__invoke_half_powr<T>(x, y);
 }
 
 // genfloatf recip (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-recip(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> recip(T x) __NOEXC {
   return __sycl_std::__invoke_half_recip<T>(x);
 }
 
 // genfloatf rsqrt (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-rsqrt(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> rsqrt(T x) __NOEXC {
   return __sycl_std::__invoke_half_rsqrt<T>(x);
 }
 
 // genfloatf sin (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-sin(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> sin(T x) __NOEXC {
   return __sycl_std::__invoke_half_sin<T>(x);
 }
 
 // genfloatf sqrt (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-sqrt(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> sqrt(T x) __NOEXC {
   return __sycl_std::__invoke_half_sqrt<T>(x);
 }
 
 // genfloatf tan (genfloatf x)
 template <typename T>
-typename std::enable_if<detail::is_genfloatf<T>::value, T>::type
-tan(T x) __NOEXC {
+detail::enable_if_t<detail::is_genfloatf<T>::value, T> tan(T x) __NOEXC {
   return __sycl_std::__invoke_half_tan<T>(x);
 }
 

--- a/sycl/include/CL/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_lists.hpp
@@ -1,0 +1,375 @@
+//==-------- generic_type_lists.hpp - SYCL Generic type lists --------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/stl_type_traits.hpp>
+#include <CL/sycl/detail/type_list.hpp>
+#include <CL/sycl/half_type.hpp>
+
+// Generic type name description, which serves as a description for all valid
+// types of parameters to kernel functions
+
+// Forward declaration
+namespace cl {
+namespace sycl {
+template <typename T, int N> class vec;
+} // namespace sycl
+} // namespace cl
+
+namespace cl {
+namespace sycl {
+namespace detail {
+namespace gtl {
+// floating point types
+using scalar_half_list = type_list<half>;
+
+using vector_half_list = type_list<vec<half, 1>, vec<half, 2>, vec<half, 3>,
+                                   vec<half, 4>, vec<half, 8>, vec<half, 16>>;
+
+using half_list = type_list<scalar_half_list, vector_half_list>;
+
+using scalar_float_list = type_list<float>;
+
+using vector_float_list =
+    type_list<vec<float, 1>, vec<float, 2>, vec<float, 3>, vec<float, 4>,
+              vec<float, 8>, vec<float, 16>>;
+
+using float_list = type_list<scalar_float_list, vector_float_list>;
+
+using scalar_double_list = type_list<double>;
+
+using vector_double_list =
+    type_list<vec<double, 1>, vec<double, 2>, vec<double, 3>, vec<double, 4>,
+              vec<double, 8>, vec<double, 16>>;
+
+using double_list = type_list<scalar_double_list, vector_double_list>;
+
+using scalar_floating_list =
+    type_list<scalar_float_list, scalar_double_list, scalar_half_list>;
+
+using vector_floating_list =
+    type_list<vector_float_list, vector_double_list, vector_half_list>;
+
+using floating_list = type_list<scalar_floating_list, vector_floating_list>;
+
+// geometric floating point types
+using scalar_geo_half_list = type_list<half>;
+
+using scalar_geo_float_list = type_list<float>;
+
+using scalar_geo_double_list = type_list<double>;
+
+using vector_geo_half_list =
+    type_list<vec<half, 1>, vec<half, 2>, vec<half, 3>, vec<half, 4>>;
+
+using vector_geo_float_list =
+    type_list<vec<float, 1>, vec<float, 2>, vec<float, 3>, vec<float, 4>>;
+
+using vector_geo_double_list =
+    type_list<vec<double, 1>, vec<double, 2>, vec<double, 3>, vec<double, 4>>;
+
+using geo_half_list = type_list<scalar_geo_half_list, vector_geo_half_list>;
+
+using geo_float_list = type_list<scalar_geo_float_list, vector_geo_float_list>;
+
+using geo_double_list =
+    type_list<scalar_geo_double_list, vector_geo_double_list>;
+
+using scalar_geo_list = type_list<scalar_geo_half_list, scalar_geo_float_list,
+                                  scalar_geo_double_list>;
+
+using vector_geo_list = type_list<vector_geo_half_list, vector_geo_float_list,
+                                  vector_geo_double_list>;
+
+using geo_list = type_list<scalar_geo_list, vector_geo_list>;
+
+// cross floating point types
+using cross_half_list = type_list<vec<half, 3>, vec<half, 4>>;
+
+using cross_float_list = type_list<vec<float, 3>, vec<float, 4>>;
+
+using cross_double_list = type_list<vec<double, 3>, vec<double, 4>>;
+
+using cross_floating_list =
+    type_list<cross_float_list, cross_double_list, cross_half_list>;
+
+using scalar_default_char_list = type_list<char>;
+
+using vector_default_char_list =
+    type_list<vec<char, 1>, vec<char, 2>, vec<char, 3>, vec<char, 4>,
+              vec<char, 8>, vec<char, 16>>;
+
+using default_char_list =
+    type_list<scalar_default_char_list, vector_default_char_list>;
+
+using scalar_signed_char_list = type_list<signed char>;
+
+using vector_signed_char_list =
+    type_list<vec<signed char, 1>, vec<signed char, 2>, vec<signed char, 3>,
+              vec<signed char, 4>, vec<signed char, 8>, vec<signed char, 16>>;
+
+using signed_char_list =
+    type_list<scalar_signed_char_list, vector_signed_char_list>;
+
+using scalar_unsigned_char_list = type_list<unsigned char>;
+
+using vector_unsigned_char_list =
+    type_list<vec<unsigned char, 1>, vec<unsigned char, 2>,
+              vec<unsigned char, 3>, vec<unsigned char, 4>,
+              vec<unsigned char, 8>, vec<unsigned char, 16>>;
+
+using unsigned_char_list =
+    type_list<scalar_unsigned_char_list, vector_unsigned_char_list>;
+
+using scalar_char_list =
+    type_list<scalar_default_char_list, scalar_signed_char_list,
+              scalar_unsigned_char_list>;
+
+using vector_char_list =
+    type_list<vector_default_char_list, vector_signed_char_list,
+              vector_unsigned_char_list>;
+
+using char_list = type_list<scalar_char_list, vector_char_list>;
+
+// short int types
+using scalar_signed_short_list = type_list<signed short>;
+
+using vector_signed_short_list =
+    type_list<vec<signed short, 1>, vec<signed short, 2>, vec<signed short, 3>,
+              vec<signed short, 4>, vec<signed short, 8>,
+              vec<signed short, 16>>;
+
+using signed_short_list =
+    type_list<scalar_signed_short_list, vector_signed_short_list>;
+
+using scalar_unsigned_short_list = type_list<unsigned short>;
+
+using vector_unsigned_short_list =
+    type_list<vec<unsigned short, 1>, vec<unsigned short, 2>,
+              vec<unsigned short, 3>, vec<unsigned short, 4>,
+              vec<unsigned short, 8>, vec<unsigned short, 16>>;
+
+using unsigned_short_list =
+    type_list<scalar_unsigned_short_list, vector_unsigned_short_list>;
+
+using scalar_short_list =
+    type_list<scalar_signed_short_list, scalar_unsigned_short_list>;
+
+using vector_short_list =
+    type_list<vector_signed_short_list, vector_unsigned_short_list>;
+
+using short_list = type_list<scalar_short_list, vector_short_list>;
+
+// int types
+using scalar_signed_int_list = type_list<signed int>;
+
+using vector_signed_int_list =
+    type_list<vec<signed int, 1>, vec<signed int, 2>, vec<signed int, 3>,
+              vec<signed int, 4>, vec<signed int, 8>, vec<signed int, 16>>;
+
+using signed_int_list =
+    type_list<scalar_signed_int_list, vector_signed_int_list>;
+
+using scalar_unsigned_int_list = type_list<unsigned int>;
+
+using vector_unsigned_int_list =
+    type_list<vec<unsigned int, 1>, vec<unsigned int, 2>, vec<unsigned int, 3>,
+              vec<unsigned int, 4>, vec<unsigned int, 8>,
+              vec<unsigned int, 16>>;
+
+using unsigned_int_list =
+    type_list<scalar_unsigned_int_list, vector_unsigned_int_list>;
+
+using scalar_int_list =
+    type_list<scalar_signed_int_list, scalar_unsigned_int_list>;
+
+using vector_int_list =
+    type_list<vector_signed_int_list, vector_unsigned_int_list>;
+
+using int_list = type_list<scalar_int_list, vector_int_list>;
+
+// long types
+using scalar_signed_long_list = type_list<signed long>;
+
+using vector_signed_long_list =
+    type_list<vec<signed long, 1>, vec<signed long, 2>, vec<signed long, 3>,
+              vec<signed long, 4>, vec<signed long, 8>, vec<signed long, 16>>;
+
+using signed_long_list =
+    type_list<scalar_signed_long_list, vector_signed_long_list>;
+
+using scalar_unsigned_long_list = type_list<unsigned long>;
+
+using vector_unsigned_long_list =
+    type_list<vec<unsigned long, 1>, vec<unsigned long, 2>,
+              vec<unsigned long, 3>, vec<unsigned long, 4>,
+              vec<unsigned long, 8>, vec<unsigned long, 16>>;
+
+using unsigned_long_list =
+    type_list<scalar_unsigned_long_list, vector_unsigned_long_list>;
+
+using scalar_long_list =
+    type_list<scalar_signed_long_list, scalar_unsigned_long_list>;
+
+using vector_long_list =
+    type_list<vector_signed_long_list, vector_unsigned_long_list>;
+
+using long_list = type_list<scalar_long_list, vector_long_list>;
+
+// long long types
+using scalar_signed_longlong_list = type_list<signed long long>;
+
+using vector_signed_longlong_list =
+    type_list<vec<signed long long, 1>, vec<signed long long, 2>,
+              vec<signed long long, 3>, vec<signed long long, 4>,
+              vec<signed long long, 8>, vec<signed long long, 16>>;
+
+using signed_longlong_list =
+    type_list<scalar_signed_longlong_list, vector_signed_longlong_list>;
+
+using scalar_unsigned_longlong_list = type_list<unsigned long long>;
+
+using vector_unsigned_longlong_list =
+    type_list<vec<unsigned long long, 1>, vec<unsigned long long, 2>,
+              vec<unsigned long long, 3>, vec<unsigned long long, 4>,
+              vec<unsigned long long, 8>, vec<unsigned long long, 16>>;
+
+using unsigned_longlong_list =
+    type_list<scalar_unsigned_longlong_list, vector_unsigned_longlong_list>;
+
+using scalar_longlong_list =
+    type_list<scalar_signed_longlong_list, scalar_unsigned_longlong_list>;
+
+using vector_longlong_list =
+    type_list<vector_signed_longlong_list, vector_unsigned_longlong_list>;
+
+using longlong_list = type_list<scalar_longlong_list, vector_longlong_list>;
+
+// long integer types
+using scalar_signed_long_integer_list =
+    type_list<scalar_signed_long_list, scalar_signed_longlong_list>;
+
+using vector_signed_long_integer_list =
+    type_list<vector_signed_long_list, vector_signed_longlong_list>;
+
+using signed_long_integer_list =
+    type_list<scalar_signed_long_integer_list, vector_signed_long_integer_list>;
+
+using scalar_unsigned_long_integer_list =
+    type_list<scalar_unsigned_long_list, scalar_unsigned_longlong_list>;
+
+using vector_unsigned_long_integer_list =
+    type_list<vector_unsigned_long_list, vector_unsigned_longlong_list>;
+
+using unsigned_long_integer_list = type_list<scalar_unsigned_long_integer_list,
+                                             vector_unsigned_long_integer_list>;
+
+using scalar_long_integer_list = type_list<scalar_signed_long_integer_list,
+                                           scalar_unsigned_long_integer_list>;
+
+using vector_long_integer_list = type_list<vector_signed_long_integer_list,
+                                           vector_unsigned_long_integer_list>;
+
+using long_integer_list =
+    type_list<scalar_long_integer_list, vector_long_integer_list>;
+
+// integer types
+using scalar_signed_integer_list = type_list<
+    conditional_t<std::is_signed<char>::value,
+                  type_list<scalar_default_char_list, scalar_signed_char_list>,
+                  scalar_signed_char_list>,
+    scalar_signed_short_list, scalar_signed_int_list, scalar_signed_long_list,
+    scalar_signed_longlong_list>;
+
+using vector_signed_integer_list = type_list<
+    conditional_t<std::is_signed<char>::value,
+                  type_list<vector_default_char_list, vector_signed_char_list>,
+                  vector_signed_char_list>,
+    vector_signed_short_list, vector_signed_int_list, vector_signed_long_list,
+    vector_signed_longlong_list>;
+
+using signed_integer_list =
+    type_list<scalar_signed_integer_list, vector_signed_integer_list>;
+
+using scalar_unsigned_integer_list =
+    type_list<conditional_t<std::is_unsigned<char>::value,
+                            type_list<scalar_default_char_list,
+                                      scalar_unsigned_char_list>,
+                            scalar_unsigned_char_list>,
+              scalar_unsigned_short_list, scalar_unsigned_int_list,
+              scalar_unsigned_long_list, scalar_unsigned_longlong_list>;
+
+using vector_unsigned_integer_list =
+    type_list<conditional_t<std::is_unsigned<char>::value,
+                            type_list<vector_default_char_list,
+                                      vector_unsigned_char_list>,
+                            vector_unsigned_char_list>,
+              vector_unsigned_short_list, vector_unsigned_int_list,
+              vector_unsigned_long_list, vector_unsigned_longlong_list>;
+
+using unsigned_integer_list =
+    type_list<scalar_unsigned_integer_list, vector_unsigned_integer_list>;
+
+using scalar_integer_list =
+    type_list<scalar_signed_integer_list, scalar_unsigned_integer_list>;
+
+using vector_integer_list =
+    type_list<vector_signed_integer_list, vector_unsigned_integer_list>;
+
+using integer_list = type_list<scalar_integer_list, vector_integer_list>;
+
+// basic types
+using scalar_signed_basic_list =
+    type_list<scalar_floating_list, scalar_signed_integer_list>;
+
+using vector_signed_basic_list =
+    type_list<vector_floating_list, vector_signed_integer_list>;
+
+using signed_basic_list =
+    type_list<scalar_signed_basic_list, vector_signed_basic_list>;
+
+using scalar_unsigned_basic_list = type_list<scalar_unsigned_integer_list>;
+
+using vector_unsigned_basic_list = type_list<vector_unsigned_integer_list>;
+
+using unsigned_basic_list =
+    type_list<scalar_unsigned_basic_list, vector_unsigned_basic_list>;
+
+using scalar_basic_list =
+    type_list<scalar_signed_basic_list, scalar_unsigned_basic_list>;
+
+using vector_basic_list =
+    type_list<vector_signed_basic_list, vector_unsigned_basic_list>;
+
+using basic_list = type_list<scalar_basic_list, vector_basic_list>;
+
+// nan builtin types
+using nan_list = type_list<gtl::unsigned_short_list, gtl::unsigned_int_list,
+                           gtl::unsigned_long_integer_list>;
+} // namespace gtl
+namespace gvl {
+// address spaces
+using all_address_space_list =
+    address_space_list<access::address_space::local_space,
+                       access::address_space::global_space,
+                       access::address_space::private_space,
+                       access::address_space::constant_space>;
+
+using nonconst_address_space_list =
+    address_space_list<access::address_space::local_space,
+                       access::address_space::global_space,
+                       access::address_space::private_space>;
+
+using nonlocal_address_space_list =
+    address_space_list<access::address_space::global_space,
+                       access::address_space::private_space,
+                       access::address_space::constant_space>;
+} // namespace gvl
+} // namespace detail
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -8,8 +8,12 @@
 
 #pragma once
 
-#include <CL/sycl/pointers.hpp>
-#include <CL/sycl/types.hpp>
+#include <CL/sycl/access/access.hpp>
+#include <CL/sycl/aliases.hpp>
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/generic_type_lists.hpp>
+#include <CL/sycl/detail/type_traits.hpp>
+#include <CL/sycl/half_type.hpp>
 
 #include <limits>
 #include <type_traits>
@@ -18,810 +22,246 @@ namespace cl {
 namespace sycl {
 namespace detail {
 
-template <typename... Types> struct type_list;
+template <typename T> using is_floatn = is_contained<T, gtl::vector_float_list>;
 
-template <typename H, typename... T> struct type_list<H, T...> {
-  using head = H;
-  using tail = type_list<T...>;
+template <typename T> using is_genfloatf = is_contained<T, gtl::float_list>;
+
+template <typename T>
+using is_doublen = is_contained<T, gtl::vector_double_list>;
+
+template <typename T> using is_genfloatd = is_contained<T, gtl::double_list>;
+
+template <typename T> using is_halfn = is_contained<T, gtl::vector_half_list>;
+
+template <typename T> using is_genfloath = is_contained<T, gtl::half_list>;
+
+template <typename T> using is_genfloat = is_contained<T, gtl::floating_list>;
+
+template <typename T>
+using is_sgenfloat = is_contained<T, gtl::scalar_floating_list>;
+
+template <typename T>
+using is_vgenfloat = is_contained<T, gtl::vector_floating_list>;
+
+template <typename T>
+using is_gengeofloat = is_contained<T, gtl::geo_float_list>;
+
+template <typename T>
+using is_gengeodouble = is_contained<T, gtl::geo_double_list>;
+
+template <typename T> using is_gengeohalf = is_contained<T, gtl::geo_half_list>;
+
+template <typename T>
+using is_vgengeofloat = is_contained<T, gtl::vector_geo_float_list>;
+
+template <typename T>
+using is_vgengeodouble = is_contained<T, gtl::vector_geo_double_list>;
+
+template <typename T>
+using is_vgengeohalf = is_contained<T, gtl::vector_geo_half_list>;
+
+template <typename T> using is_sgengeo = is_contained<T, gtl::scalar_geo_list>;
+
+template <typename T> using is_vgengeo = is_contained<T, gtl::vector_geo_list>;
+
+template <typename T>
+using is_gencrossfloat = is_contained<T, gtl::cross_float_list>;
+
+template <typename T>
+using is_gencrossdouble = is_contained<T, gtl::cross_double_list>;
+
+template <typename T>
+using is_gencrosshalf = is_contained<T, gtl::cross_half_list>;
+
+template <typename T>
+using is_gencross = is_contained<T, gtl::cross_floating_list>;
+
+template <typename T>
+using is_charn = is_contained<T, gtl::vector_default_char_list>;
+
+template <typename T>
+using is_scharn = is_contained<T, gtl::vector_signed_char_list>;
+
+template <typename T>
+using is_ucharn = is_contained<T, gtl::vector_unsigned_char_list>;
+
+template <typename T>
+using is_igenchar = is_contained<T, gtl::signed_char_list>;
+
+template <typename T>
+using is_ugenchar = is_contained<T, gtl::unsigned_char_list>;
+
+template <typename T> using is_genchar = is_contained<T, gtl::char_list>;
+
+template <typename T>
+using is_shortn = is_contained<T, gtl::vector_signed_short_list>;
+
+template <typename T>
+using is_genshort = is_contained<T, gtl::signed_short_list>;
+
+template <typename T>
+using is_ushortn = is_contained<T, gtl::vector_unsigned_short_list>;
+
+template <typename T>
+using is_ugenshort = is_contained<T, gtl::unsigned_short_list>;
+
+template <typename T>
+using is_uintn = is_contained<T, gtl::vector_unsigned_int_list>;
+
+template <typename T>
+using is_ugenint = is_contained<T, gtl::unsigned_int_list>;
+
+template <typename T>
+using is_intn = is_contained<T, gtl::vector_signed_int_list>;
+
+template <typename T> using is_genint = is_contained<T, gtl::signed_int_list>;
+
+template <typename T>
+using is_ulongn = is_contained<T, gtl::vector_unsigned_long_list>;
+
+template <typename T>
+using is_ugenlong = is_contained<T, gtl::unsigned_long_list>;
+
+template <typename T>
+using is_longn = is_contained<T, gtl::vector_signed_long_list>;
+
+template <typename T> using is_genlong = is_contained<T, gtl::signed_long_list>;
+
+template <typename T>
+using is_ulonglongn = is_contained<T, gtl::vector_unsigned_longlong_list>;
+
+template <typename T>
+using is_ugenlonglong = is_contained<T, gtl::unsigned_longlong_list>;
+
+template <typename T>
+using is_longlongn = is_contained<T, gtl::vector_signed_longlong_list>;
+
+template <typename T>
+using is_genlonglong = is_contained<T, gtl::signed_longlong_list>;
+
+template <typename T>
+using is_igenlonginteger = is_contained<T, gtl::signed_long_integer_list>;
+
+template <typename T>
+using is_ugenlonginteger = is_contained<T, gtl::unsigned_long_integer_list>;
+
+template <typename T> using is_geninteger = is_contained<T, gtl::integer_list>;
+
+template <typename T>
+using is_igeninteger = is_contained<T, gtl::signed_integer_list>;
+
+template <typename T>
+using is_ugeninteger = is_contained<T, gtl::unsigned_integer_list>;
+
+template <typename T>
+using is_sgeninteger = is_contained<T, gtl::scalar_integer_list>;
+
+template <typename T>
+using is_vgeninteger = is_contained<T, gtl::vector_integer_list>;
+
+template <typename T>
+using is_sigeninteger = is_contained<T, gtl::scalar_signed_integer_list>;
+
+template <typename T>
+using is_sugeninteger = is_contained<T, gtl::scalar_unsigned_integer_list>;
+
+template <typename T>
+using is_vigeninteger = is_contained<T, gtl::vector_signed_integer_list>;
+
+template <typename T>
+using is_vugeninteger = is_contained<T, gtl::vector_unsigned_integer_list>;
+
+template <typename T> using is_gentype = is_contained<T, gtl::basic_list>;
+
+template <typename T>
+using is_vgentype = is_contained<T, gtl::vector_basic_list>;
+
+template <typename T>
+using is_sgentype = is_contained<T, gtl::scalar_basic_list>;
+
+template <typename T>
+using is_igeninteger8bit = is_gen_based_on_type_sizeof<T, 1, is_igeninteger>;
+
+template <typename T>
+using is_igeninteger16bit = is_gen_based_on_type_sizeof<T, 2, is_igeninteger>;
+
+template <typename T>
+using is_igeninteger32bit = is_gen_based_on_type_sizeof<T, 4, is_igeninteger>;
+
+template <typename T>
+using is_igeninteger64bit = is_gen_based_on_type_sizeof<T, 8, is_igeninteger>;
+
+template <typename T>
+using is_ugeninteger8bit = is_gen_based_on_type_sizeof<T, 1, is_ugeninteger>;
+
+template <typename T>
+using is_ugeninteger16bit = is_gen_based_on_type_sizeof<T, 2, is_ugeninteger>;
+
+template <typename T>
+using is_ugeninteger32bit = is_gen_based_on_type_sizeof<T, 4, is_ugeninteger>;
+
+template <typename T>
+using is_ugeninteger64bit = is_gen_based_on_type_sizeof<T, 8, is_ugeninteger>;
+
+template <typename T>
+using is_geninteger8bit = is_gen_based_on_type_sizeof<T, 1, is_geninteger>;
+
+template <typename T>
+using is_geninteger16bit = is_gen_based_on_type_sizeof<T, 2, is_geninteger>;
+
+template <typename T>
+using is_geninteger32bit = is_gen_based_on_type_sizeof<T, 4, is_geninteger>;
+
+template <typename T>
+using is_geninteger64bit = is_gen_based_on_type_sizeof<T, 8, is_geninteger>;
+
+template <typename T>
+using is_genintptr = bool_constant<
+    is_pointer<T>::value && is_genint<remove_pointer_t<T>>::value &&
+    is_address_space_compliant<T, gvl::nonconst_address_space_list>::value>;
+
+template <typename T>
+using is_genfloatptr = bool_constant<
+    is_pointer<T>::value && is_genfloat<remove_pointer_t<T>>::value &&
+    is_address_space_compliant<T, gvl::nonconst_address_space_list>::value>;
+
+template <typename T>
+using is_genptr = bool_constant<
+    is_pointer<T>::value && is_gentype<remove_pointer_t<T>>::value &&
+    is_address_space_compliant<T, gvl::nonconst_address_space_list>::value>;
+
+template <typename T> using is_nan_type = is_contained<T, gtl::nan_list>;
+
+template <typename T> using nan_return_t = typename nan_types<T, T>::ret_type;
+
+template <typename T>
+using nan_argument_base_t = typename nan_types<T, T>::arg_type;
+
+template <typename T>
+using make_floating_point_t = make_type_t<T, gtl::scalar_floating_list>;
+
+template <typename T>
+using make_singed_integer_t = make_type_t<T, gtl::scalar_signed_integer_list>;
+
+template <typename T>
+using make_unsinged_integer_t =
+    make_type_t<T, gtl::scalar_unsigned_integer_list>;
+
+template <typename T, typename B, typename Enable = void>
+struct convert_data_type_impl;
+
+template <typename T, typename B>
+struct convert_data_type_impl<T, B, enable_if_t<is_sgentype<T>::value, T>> {
+  B operator()(T t) { return static_cast<B>(t); }
 };
 
-template <> struct type_list<> {};
-
-template <typename T, typename TL>
-struct is_contained
-    : std::conditional<std::is_same<typename std::remove_cv<T>::type,
-                                    typename TL::head>::value,
-                       std::true_type,
-                       is_contained<T, typename TL::tail>>::type {};
-
-template <typename T> struct is_contained<T, type_list<>> : std::false_type {};
-
-// floatn: float2, float3, float4, float8, float16
-template <typename T>
-using is_floatn = typename is_contained<
-    T, type_list<cl_float2, cl_float3, cl_float4, cl_float8, cl_float16>>::type;
-
-// genfloatf: float, floatn
-template <typename T>
-using is_genfloatf =
-    std::integral_constant<bool, is_contained<T, type_list<cl_float>>::value ||
-                                     is_floatn<T>::value>;
-
-// doublen: double2, double3, double4, double8, double16
-template <typename T>
-using is_doublen =
-    typename is_contained<T, type_list<cl_double2, cl_double3, cl_double4,
-                                       cl_double8, cl_double16>>::type;
-
-// genfloatd: double, doublen
-template <typename T>
-using is_genfloatd =
-    std::integral_constant<bool, is_contained<T, type_list<cl_double>>::value ||
-                                     is_doublen<T>::value>;
-
-// halfn: half2, half3, half4, half8, half16
-template <typename T>
-using is_halfn = typename is_contained<
-    T, type_list<cl_half2, cl_half3, cl_half4, cl_half8, cl_half16>>::type;
-
-// genfloath: half, halfn
-template <typename T>
-using is_genfloath =
-    std::integral_constant<bool, is_contained<T, type_list<cl_half>>::value ||
-                                     is_halfn<T>::value>;
-
-// genfloat: genfloatf, genfloatd, genfloath
-template <typename T>
-using is_genfloat = std::integral_constant<bool, is_genfloatf<T>::value ||
-                                                     is_genfloatd<T>::value ||
-                                                     is_genfloath<T>::value>;
-
-// sgenfloat: float, double, half
-template <typename T>
-using is_sgenfloat =
-    typename is_contained<T, type_list<cl_float, cl_double, cl_half>>::type;
-
-// vgenfloat: floatn, doublen, halfn
-template <typename T>
-using is_vgenfloat =
-    std::integral_constant<bool, is_floatn<T>::value || is_doublen<T>::value ||
-                                     is_halfn<T>::value>;
-
-// gengeofloat: float, float2, float3, float4
-template <typename T>
-using is_gengeofloat = typename is_contained<
-    T, type_list<cl_float, cl_float2, cl_float3, cl_float4>>::type;
-
-// gengeodouble: double, double2, double3, double4
-template <typename T>
-using is_gengeodouble = typename is_contained<
-    T, type_list<cl_double, cl_double2, cl_double3, cl_double4>>::type;
-
-// gengeohalf: half, half2, half3, half4
-template <typename T>
-using is_gengeohalf = typename is_contained<
-    T, type_list<cl_half, cl_half2, cl_half3, cl_half4>>::type;
-
-// gengeofloat: float, float2, float3, float4
-template <typename T>
-using is_vgengeofloat =
-    typename is_contained<T, type_list<cl_float2, cl_float3, cl_float4>>::type;
-
-// gengeodouble: double, double2, double3, double4
-template <typename T>
-using is_vgengeodouble =
-    typename is_contained<T,
-                          type_list<cl_double2, cl_double3, cl_double4>>::type;
-
-// gengeohalf: half2, half3, half4
-template <typename T>
-using is_vgengeohalf =
-    typename is_contained<T, type_list<cl_half2, cl_half3, cl_half4>>::type;
-
-// sgengeo: float, double, half
-template <typename T>
-using is_sgengeo = std::integral_constant<
-    bool, is_contained<T, type_list<cl_float, cl_double, cl_half>>::value>;
-
-// vgengeo: vgengeofloat, vgengeodouble, vgengeohalf
-template <typename T>
-using is_vgengeo =
-    std::integral_constant<bool, is_vgengeofloat<T>::value ||
-                                     is_vgengeodouble<T>::value ||
-                                     is_vgengeohalf<T>::value>;
-
-// gencrossfloat:  float3, float4
-template <typename T>
-using is_gencrossfloat =
-    typename is_contained<T, type_list<cl_float3, cl_float4>>::type;
-
-// gencrossdouble: double3, double4
-template <typename T>
-using is_gencrossdouble =
-    typename is_contained<T, type_list<cl_double3, cl_double4>>::type;
-
-// gencrosshalf: half3, half4
-template <typename T>
-using is_gencrosshalf =
-    typename is_contained<T, type_list<cl_half3, cl_half4>>::type;
-
-// gencross: gencrossfloat, gencrossdouble, gencrosshalf
-template <typename T>
-using is_gencross =
-    std::integral_constant<bool, is_gencrossfloat<T>::value ||
-                                     is_gencrossdouble<T>::value ||
-                                     is_gencrosshalf<T>::value>;
-
-// charn: char2, char3, char4, char8, char16
-template <typename T>
-using is_charn = typename is_contained<
-    T, type_list<cl_char2, cl_char3, cl_char4, cl_char8, cl_char16>>::type;
-
-// scharn: schar2, schar3, schar4, schar8, schar16
-template <typename T>
-using is_scharn = typename is_contained<
-    T, type_list<schar2, schar3, schar4, schar8, schar16>>::type;
-
-// ucharn: uchar2, uchar3, uchar4, uchar8, uchar16
-template <typename T>
-using is_ucharn = typename is_contained<
-    T, type_list<cl_uchar2, cl_uchar3, cl_uchar4, cl_uchar8, cl_uchar16>>::type;
-
-// igenchar: signed char, scharn
-template <typename T>
-using is_igenchar =
-    std::integral_constant<bool, is_contained<T, type_list<schar>>::value ||
-                                     is_scharn<T>::value>;
-
-// ugenchar: unsigned char, ucharn
-template <typename T>
-using is_ugenchar =
-    std::integral_constant<bool, is_contained<T, type_list<cl_uchar>>::value ||
-                                     is_ucharn<T>::value>;
-
-// genchar: char, charn, igenchar, ugenchar
-template <typename T>
-using is_genchar = std::integral_constant<
-    bool, is_contained<T, type_list<cl_char>>::value || is_charn<T>::value ||
-              is_igenchar<T>::value || is_ugenchar<T>::value>;
-
-// shortn: short2, short3, short4, short8, short16
-template <typename T>
-using is_shortn = typename is_contained<
-    T, type_list<cl_short2, cl_short3, cl_short4, cl_short8, cl_short16>>::type;
-
-// genshort: short, shortn
-template <typename T>
-using is_genshort =
-    std::integral_constant<bool, is_contained<T, type_list<cl_short>>::value ||
-                                     is_shortn<T>::value>;
-
-// ushortn: ushort2, ushort3, ushort4, ushort8, ushort16
-template <typename T>
-using is_ushortn =
-    typename is_contained<T, type_list<cl_ushort2, cl_ushort3, cl_ushort4,
-                                       cl_ushort8, cl_ushort16>>::type;
-
-// genushort: ushort, ushortn
-template <typename T>
-using is_ugenshort =
-    std::integral_constant<bool, is_contained<T, type_list<cl_ushort>>::value ||
-                                     is_ushortn<T>::value>;
-
-// uintn: uint2, uint3, uint4, uint8, uint16
-template <typename T>
-using is_uintn = typename is_contained<
-    T, type_list<cl_uint2, cl_uint3, cl_uint4, cl_uint8, cl_uint16>>::type;
-
-// ugenint: unsigned int, uintn
-template <typename T>
-using is_ugenint =
-    std::integral_constant<bool, is_contained<T, type_list<cl_uint>>::value ||
-                                     is_uintn<T>::value>;
-
-// intn: int2, int3, int4, int8, int16
-template <typename T>
-using is_intn = typename is_contained<
-    T, type_list<cl_int2, cl_int3, cl_int4, cl_int8, cl_int16>>::type;
-
-// genint: int, intn
-template <typename T>
-using is_genint =
-    std::integral_constant<bool, is_contained<T, type_list<cl_int>>::value ||
-                                     is_intn<T>::value>;
-
-// ulongn: ulong2, ulong3, ulong4, ulong8,ulong16
-template <typename T>
-using is_ulongn = typename is_contained<
-    T, type_list<ulong2, ulong3, ulong4, ulong8, ulong16>>::type;
-
-// ugenlong: unsigned long int, ulongn
-template <typename T>
-using is_ugenlong =
-    std::integral_constant<bool, is_contained<T, type_list<ulong>>::value ||
-                                     is_ulongn<T>::value>;
-
-// longn: long2, long3, long4, long8, long16
-template <typename T>
-using is_longn = typename is_contained<
-    T, type_list<long2, long3, long4, long8, long16>>::type;
-
-// genlong: long int, longn
-template <typename T>
-using is_genlong =
-    std::integral_constant<bool, is_contained<T, type_list<long>>::value ||
-                                     is_longn<T>::value>;
-
-// ulonglongn: ulonglong2, ulonglong3, ulonglong4,ulonglong8, ulonglong16
-template <typename T>
-using is_ulonglongn =
-    typename is_contained<T, type_list<ulonglong2, ulonglong3, ulonglong4,
-                                       ulonglong8, ulonglong16>>::type;
-
-// ugenlonglong: unsigned long long int, ulonglongn
-template <typename T>
-using is_ugenlonglong =
-    std::integral_constant<bool, is_contained<T, type_list<ulonglong>>::value ||
-                                     is_ulonglongn<T>::value>;
-
-// longlongn: longlong2, longlong3, longlong4,longlong8, longlong16
-template <typename T>
-using is_longlongn = typename is_contained<
-    T, type_list<longlong2, longlong3, longlong4, longlong8, longlong16>>::type;
-
-// genlonglong: long long int, longlongn
-template <typename T>
-using is_genlonglong =
-    std::integral_constant<bool, is_contained<T, type_list<longlong>>::value ||
-                                     is_longlongn<T>::value>;
-
-// igenlonginteger: genlong, genlonglong
-template <typename T>
-using is_igenlonginteger =
-    std::integral_constant<bool,
-                           is_genlong<T>::value || is_genlonglong<T>::value>;
-
-// ugenlonginteger ugenlong, ugenlonglong
-template <typename T>
-using is_ugenlonginteger =
-    std::integral_constant<bool,
-                           is_ugenlong<T>::value || is_ugenlonglong<T>::value>;
-
-// geninteger: genchar, genshort, ugenshort, genint, ugenint, igenlonginteger,
-// ugenlonginteger
-template <typename T>
-using is_geninteger = std::integral_constant<
-    bool, is_genchar<T>::value || is_genshort<T>::value ||
-              is_ugenshort<T>::value || is_genint<T>::value ||
-              is_ugenint<T>::value || is_igenlonginteger<T>::value ||
-              is_ugenlonginteger<T>::value>;
-
-// igeninteger: igenchar, genshort, genint, igenlonginteger
-template <typename T>
-using is_igeninteger = std::integral_constant<
-    bool, is_igenchar<T>::value || is_genshort<T>::value ||
-              is_genint<T>::value || is_igenlonginteger<T>::value>;
-
-// ugeninteger: ugenchar, ugenshort, ugenint, ugenlonginteger
-template <typename T>
-using is_ugeninteger = std::integral_constant<
-    bool, is_ugenchar<T>::value || is_ugenshort<T>::value ||
-              is_ugenint<T>::value || is_ugenlonginteger<T>::value>;
-
-// sgeninteger: char, signed char, unsigned char, short, unsigned short, int,
-// unsigned int, long int, unsigned long int, long long int, unsigned long long
-// int
-template <typename T>
-using is_sgeninteger = typename is_contained<
-    T, type_list<cl_char, schar, cl_uchar, cl_short, cl_ushort, cl_int,
-                 cl_uint, cl_long, cl_ulong, longlong, ulonglong>>::type;
-
-// vgeninteger: charn, scharn, ucharn, shortn, ushortn, intn, uintn, longn,
-// ulongn, longlongn, ulonglongn
-template <typename T>
-using is_vgeninteger = std::integral_constant<
-    bool, is_charn<T>::value || is_scharn<T>::value || is_ucharn<T>::value ||
-              is_shortn<T>::value || is_ushortn<T>::value ||
-              is_intn<T>::value || is_uintn<T>::value || is_longn<T>::value ||
-              is_ulongn<T>::value || is_longlongn<T>::value ||
-              is_ulonglongn<T>::value>;
-
-// sigeninteger: char, signed char, short, int, long int, , long long int
-template <typename T>
-using is_sigeninteger = typename is_contained<
-    T, type_list<cl_char, schar, cl_short, cl_int, cl_long, longlong>>::type;
-
-// sugeninteger: unsigned char, unsigned short,  unsigned int, unsigned long
-// int, unsigned long long int
-template <typename T>
-using is_sugeninteger = typename is_contained<
-    T, type_list<cl_uchar, cl_ushort, cl_uint, cl_ulong, ulonglong>>::type;
-
-// vigeninteger: charn, scharn, shortn, intn, longn, longlongn
-template <typename T>
-using is_vigeninteger =
-    std::integral_constant<bool, is_charn<T>::value || is_scharn<T>::value ||
-                                     is_shortn<T>::value || is_intn<T>::value ||
-                                     is_longn<T>::value ||
-                                     is_longlongn<T>::value>;
-
-// vugeninteger: ucharn, ushortn, uintn, ulongn, ulonglongn
-template <typename T>
-using is_vugeninteger = std::integral_constant<
-    bool, is_ucharn<T>::value || is_ushortn<T>::value || is_uintn<T>::value ||
-              is_ulongn<T>::value || is_ulonglongn<T>::value>;
-
-// gentype: genfloat, geninteger
-template <typename T>
-using is_gentype = std::integral_constant<bool, is_genfloat<T>::value ||
-                                                    is_geninteger<T>::value>;
-
-// vgentype: vgeninteger || vgenfloat
-template <typename T>
-using is_vgentype = std::integral_constant<bool,
-    is_vgeninteger<T>::value || is_vgenfloat<T>::value>;
-
-// sgentype: sgeninteger || sgenfloat
-template <typename T>
-using is_sgentype = std::integral_constant<bool,
-    is_sgeninteger<T>::value || is_sgenfloat<T>::value>;
-
-// forward declarations
-template <typename T> class TryToGetElementType;
-
-// genintegerNbit All types within geninteger whose base type are N bits in
-// size, where N = 8, 16, 32, 64
-template <typename T, int N>
-using is_igenintegerNbit = typename std::integral_constant<
-    bool, is_igeninteger<T>::value &&
-              (sizeof(typename TryToGetElementType<T>::type) == N)>;
-
-// igeninteger8bit All types within igeninteger whose base type are 8 bits in
-// size
-template <typename T> using is_igeninteger8bit = is_igenintegerNbit<T, 1>;
-
-// igeninteger16bit All types within igeninteger whose base type are 16 bits in
-// size
-template <typename T> using is_igeninteger16bit = is_igenintegerNbit<T, 2>;
-
-// igeninteger32bit All types within igeninteger whose base type are 32 bits in
-// size
-template <typename T> using is_igeninteger32bit = is_igenintegerNbit<T, 4>;
-
-// igeninteger64bit All types within igeninteger whose base type are 64 bits in
-// size
-template <typename T> using is_igeninteger64bit = is_igenintegerNbit<T, 8>;
-
-// ugenintegerNbit All types within ugeninteger whose base type are N bits in
-// size, where N = 8, 16, 32, 64.
-template <typename T, int N>
-using is_ugenintegerNbit = typename std::integral_constant<
-    bool, is_ugeninteger<T>::value &&
-              (sizeof(typename TryToGetElementType<T>::type) == N)>;
-
-// ugeninteger8bit All types within ugeninteger whose base type are 8 bits in
-// size
-template <typename T> using is_ugeninteger8bit = is_ugenintegerNbit<T, 1>;
-
-// ugeninteger16bit All types within ugeninteger whose base type are 16 bits in
-// size
-template <typename T> using is_ugeninteger16bit = is_ugenintegerNbit<T, 2>;
-
-// ugeninteger32bit All types within ugeninteger whose base type are 32 bits in
-// size
-template <typename T> using is_ugeninteger32bit = is_ugenintegerNbit<T, 4>;
-
-// ugeninteger64bit All types within ugeninteger whose base type are 64 bits in
-// size
-template <typename T> using is_ugeninteger64bit = is_ugenintegerNbit<T, 8>;
-
-// genintegerNbit All types within geninteger whose base type are N bits in
-// size, where N = 8, 16, 32, 64.
-template <typename T, int N>
-using is_genintegerNbit = typename std::integral_constant<
-    bool, is_geninteger<T>::value &&
-              (sizeof(typename TryToGetElementType<T>::type) == N)>;
-
-// geninteger8bit All types within geninteger whose base type are 8 bits in size
-template <typename T> using is_geninteger8bit = is_genintegerNbit<T, 1>;
-
-// geninteger16bit All types within geninteger whose base type are 16 bits in
-// size
-template <typename T> using is_geninteger16bit = is_genintegerNbit<T, 2>;
-
-// geninteger32bit All types within geninteger whose base type are 32 bits in
-// size
-template <typename T> using is_geninteger32bit = is_genintegerNbit<T, 4>;
-
-// geninteger64bit All types within geninteger whose base type are 64 bits in
-// size
-template <typename T> using is_geninteger64bit = is_genintegerNbit<T, 8>;
-
-template <class P, typename T>
-using is_MultiPtrOfGLR =
-    std::integral_constant<bool, std::is_same<P, global_ptr<T>>::value ||
-                                     std::is_same<P, local_ptr<T>>::value ||
-                                     std::is_same<P, private_ptr<T>>::value ||
-                                     std::is_same<P, T*>::value>;
-
-// genintptr All permutations of multi_ptr<dataT, addressSpace> where dataT is
-// all types within genint and addressSpace is
-// access::address_space::global_space, access::address_space::local_space and
-// access::address_space::private_space
-template <class P>
-using is_genintptr =
-    std::integral_constant<bool, is_MultiPtrOfGLR<P, cl_int>::value ||
-                                     is_MultiPtrOfGLR<P, cl_int2>::value ||
-                                     is_MultiPtrOfGLR<P, cl_int3>::value ||
-                                     is_MultiPtrOfGLR<P, cl_int4>::value ||
-                                     is_MultiPtrOfGLR<P, cl_int8>::value ||
-                                     is_MultiPtrOfGLR<P, cl_int16>::value>;
-
-// is_genintegralptr is multi_ptr on any of intergral type including 'int'
-// and 'long long'.
-template <class P>
-using is_genintegralptr =
-  std::integral_constant<bool,
-                         is_MultiPtrOfGLR<P, cl_char>::value ||
-                         is_MultiPtrOfGLR<P, cl_char2>::value ||
-                         is_MultiPtrOfGLR<P, cl_char3>::value ||
-                         is_MultiPtrOfGLR<P, cl_char4>::value ||
-                         is_MultiPtrOfGLR<P, cl_char8>::value ||
-                         is_MultiPtrOfGLR<P, cl_char16>::value ||
-                         is_MultiPtrOfGLR<P, cl_uchar>::value ||
-                         is_MultiPtrOfGLR<P, cl_uchar2>::value ||
-                         is_MultiPtrOfGLR<P, cl_uchar3>::value ||
-                         is_MultiPtrOfGLR<P, cl_uchar4>::value ||
-                         is_MultiPtrOfGLR<P, cl_uchar8>::value ||
-                         is_MultiPtrOfGLR<P, cl_uchar16>::value ||
-                         is_MultiPtrOfGLR<P, cl_short>::value ||
-                         is_MultiPtrOfGLR<P, cl_short2>::value ||
-                         is_MultiPtrOfGLR<P, cl_short3>::value ||
-                         is_MultiPtrOfGLR<P, cl_short4>::value ||
-                         is_MultiPtrOfGLR<P, cl_short8>::value ||
-                         is_MultiPtrOfGLR<P, cl_short16>::value ||
-                         is_MultiPtrOfGLR<P, cl_ushort>::value ||
-                         is_MultiPtrOfGLR<P, cl_ushort2>::value ||
-                         is_MultiPtrOfGLR<P, cl_ushort3>::value ||
-                         is_MultiPtrOfGLR<P, cl_ushort4>::value ||
-                         is_MultiPtrOfGLR<P, cl_ushort8>::value ||
-                         is_MultiPtrOfGLR<P, cl_ushort16>::value ||
-                         is_genintptr<P>::value ||
-                         is_MultiPtrOfGLR<P, cl_uint>::value ||
-                         is_MultiPtrOfGLR<P, cl_uint2>::value ||
-                         is_MultiPtrOfGLR<P, cl_uint3>::value ||
-                         is_MultiPtrOfGLR<P, cl_uint4>::value ||
-                         is_MultiPtrOfGLR<P, cl_uint8>::value ||
-                         is_MultiPtrOfGLR<P, cl_uint16>::value ||
-                         is_MultiPtrOfGLR<P, cl_long>::value ||
-                         is_MultiPtrOfGLR<P, cl_long2>::value ||
-                         is_MultiPtrOfGLR<P, cl_long3>::value ||
-                         is_MultiPtrOfGLR<P, cl_long4>::value ||
-                         is_MultiPtrOfGLR<P, cl_long8>::value ||
-                         is_MultiPtrOfGLR<P, cl_long16>::value ||
-                         is_MultiPtrOfGLR<P, cl_ulong>::value ||
-                         is_MultiPtrOfGLR<P, cl_ulong2>::value ||
-                         is_MultiPtrOfGLR<P, cl_ulong3>::value ||
-                         is_MultiPtrOfGLR<P, cl_ulong4>::value ||
-                         is_MultiPtrOfGLR<P, cl_ulong8>::value ||
-                         is_MultiPtrOfGLR<P, cl_ulong16>::value ||
-                         is_MultiPtrOfGLR<P, longlong>::value ||
-                         is_MultiPtrOfGLR<P, longlong2>::value ||
-                         is_MultiPtrOfGLR<P, longlong3>::value ||
-                         is_MultiPtrOfGLR<P, longlong4>::value ||
-                         is_MultiPtrOfGLR<P, longlong8>::value ||
-                         is_MultiPtrOfGLR<P, longlong16>::value ||
-                         is_MultiPtrOfGLR<P, ulonglong>::value ||
-                         is_MultiPtrOfGLR<P, ulonglong2>::value ||
-                         is_MultiPtrOfGLR<P, ulonglong3>::value ||
-                         is_MultiPtrOfGLR<P, ulonglong4>::value ||
-                         is_MultiPtrOfGLR<P, ulonglong8>::value ||
-                         is_MultiPtrOfGLR<P, ulonglong16>::value>;
-  
-// genfloatptr All permutations of multi_ptr<dataT, addressSpace> where dataT is
-// all types within genfloat and addressSpace is
-// access::address_space::global_space, access::address_space::local_space and
-// access::address_space::private_space
-template <class P>
-using is_genfloatptr =
-    std::integral_constant<bool, is_MultiPtrOfGLR<P, cl_float>::value ||
-                                     is_MultiPtrOfGLR<P, cl_float2>::value ||
-                                     is_MultiPtrOfGLR<P, cl_float3>::value ||
-                                     is_MultiPtrOfGLR<P, cl_float4>::value ||
-                                     is_MultiPtrOfGLR<P, cl_float8>::value ||
-                                     is_MultiPtrOfGLR<P, cl_float16>::value ||
-                                     is_MultiPtrOfGLR<P, cl_half>::value ||
-                                     is_MultiPtrOfGLR<P, cl_half2>::value ||
-                                     is_MultiPtrOfGLR<P, cl_half3>::value ||
-                                     is_MultiPtrOfGLR<P, cl_half4>::value ||
-                                     is_MultiPtrOfGLR<P, cl_half8>::value ||
-                                     is_MultiPtrOfGLR<P, cl_half16>::value ||
-                                     is_MultiPtrOfGLR<P, cl_double>::value ||
-                                     is_MultiPtrOfGLR<P, cl_double2>::value ||
-                                     is_MultiPtrOfGLR<P, cl_double3>::value ||
-                                     is_MultiPtrOfGLR<P, cl_double4>::value ||
-                                     is_MultiPtrOfGLR<P, cl_double8>::value ||
-                                     is_MultiPtrOfGLR<P, cl_double16>::value>;
-
-// is_genptr = is_genintegralptr || is_genfloatptr
-template <typename T>
-using is_genptr =
-  std::integral_constant<bool, is_genintegralptr<T>::value ||
-                               is_genfloatptr<T>::value>;
-
-template <typename T> struct unsign_integral_to_float_point;
-template <> struct unsign_integral_to_float_point<cl_uint> {
-  using type = cl_float;
-};
-template <> struct unsign_integral_to_float_point<cl_uint2> {
-  using type = cl_float2;
-};
-template <> struct unsign_integral_to_float_point<cl_uint3> {
-  using type = cl_float3;
-};
-template <> struct unsign_integral_to_float_point<cl_uint4> {
-  using type = cl_float4;
-};
-template <> struct unsign_integral_to_float_point<cl_uint8> {
-  using type = cl_float8;
-};
-template <> struct unsign_integral_to_float_point<cl_uint16> {
-  using type = cl_float16;
+template <typename T, typename B>
+struct convert_data_type_impl<T, B, enable_if_t<is_vgentype<T>::value, T>> {
+  vec<B, T::get_count()> operator()(T t) { return t.template convert<B>(); }
 };
 
-template <> struct unsign_integral_to_float_point<cl_ushort> {
-  using type = cl_half;
-};
-template <> struct unsign_integral_to_float_point<cl_ushort2> {
-  using type = cl_half2;
-};
-template <> struct unsign_integral_to_float_point<cl_ushort3> {
-  using type = cl_half3;
-};
-template <> struct unsign_integral_to_float_point<cl_ushort4> {
-  using type = cl_half4;
-};
-template <> struct unsign_integral_to_float_point<cl_ushort8> {
-  using type = cl_half8;
-};
-template <> struct unsign_integral_to_float_point<cl_ushort16> {
-  using type = cl_half16;
-};
-
-template <> struct unsign_integral_to_float_point<cl_ulong> {
-  using type = cl_double;
-};
-template <> struct unsign_integral_to_float_point<cl_ulong2> {
-  using type = cl_double2;
-};
-template <> struct unsign_integral_to_float_point<cl_ulong3> {
-  using type = cl_double3;
-};
-template <> struct unsign_integral_to_float_point<cl_ulong4> {
-  using type = cl_double4;
-};
-template <> struct unsign_integral_to_float_point<cl_ulong8> {
-  using type = cl_double8;
-};
-template <> struct unsign_integral_to_float_point<cl_ulong16> {
-  using type = cl_double16;
-};
-
-template <typename T>
-using is_nan_type =
-    std::integral_constant<bool, detail::is_ugenshort<T>::value ||
-                                     detail::is_ugenint<T>::value ||
-                                     detail::is_ugenlonginteger<T>::value>;
-
-// Used for some relational functions
-template <typename T> struct float_point_to_sign_integral;
-template <> struct float_point_to_sign_integral<cl_float> {
-  using type = cl_int;
-};
-template <> struct float_point_to_sign_integral<cl_float2> {
-  using type = cl_int2;
-};
-template <> struct float_point_to_sign_integral<cl_float3> {
-  using type = cl_int3;
-};
-template <> struct float_point_to_sign_integral<cl_float4> {
-  using type = cl_int4;
-};
-template <> struct float_point_to_sign_integral<cl_float8> {
-  using type = cl_int8;
-};
-template <> struct float_point_to_sign_integral<cl_float16> {
-  using type = cl_int16;
-};
-
-template <> struct float_point_to_sign_integral<cl_half> {
-  using type = cl_int;
-};
-template <> struct float_point_to_sign_integral<cl_half2> {
-  using type = cl_short2;
-};
-template <> struct float_point_to_sign_integral<cl_half3> {
-  using type = cl_short3;
-};
-template <> struct float_point_to_sign_integral<cl_half4> {
-  using type = cl_short4;
-};
-template <> struct float_point_to_sign_integral<cl_half8> {
-  using type = cl_short8;
-};
-template <> struct float_point_to_sign_integral<cl_half16> {
-  using type = cl_short16;
-};
-
-template <> struct float_point_to_sign_integral<cl_double> {
-  using type = cl_int;
-};
-template <> struct float_point_to_sign_integral<cl_double2> {
-  using type = cl_long2;
-};
-template <> struct float_point_to_sign_integral<cl_double3> {
-  using type = cl_long3;
-};
-template <> struct float_point_to_sign_integral<cl_double4> {
-  using type = cl_long4;
-};
-template <> struct float_point_to_sign_integral<cl_double8> {
-  using type = cl_long8;
-};
-template <> struct float_point_to_sign_integral<cl_double16> {
-  using type = cl_long16;
-};
-
-// Used for ilogb built-in
-template <typename T> struct float_point_to_int;
-template <> struct float_point_to_int<cl_float> { using type = cl_int; };
-template <> struct float_point_to_int<cl_float2> { using type = cl_int2; };
-template <> struct float_point_to_int<cl_float3> { using type = cl_int3; };
-template <> struct float_point_to_int<cl_float4> { using type = cl_int4; };
-template <> struct float_point_to_int<cl_float8> { using type = cl_int8; };
-template <> struct float_point_to_int<cl_float16> { using type = cl_int16; };
-
-template <> struct float_point_to_int<cl_half> { using type = cl_int; };
-template <> struct float_point_to_int<cl_half2> { using type = cl_int2; };
-template <> struct float_point_to_int<cl_half3> { using type = cl_int3; };
-template <> struct float_point_to_int<cl_half4> { using type = cl_int4; };
-template <> struct float_point_to_int<cl_half8> { using type = cl_int8; };
-template <> struct float_point_to_int<cl_half16> { using type = cl_int16; };
-
-template <> struct float_point_to_int<cl_double> { using type = cl_int; };
-template <> struct float_point_to_int<cl_double2> { using type = cl_int2; };
-template <> struct float_point_to_int<cl_double3> { using type = cl_int3; };
-template <> struct float_point_to_int<cl_double4> { using type = cl_int4; };
-template <> struct float_point_to_int<cl_double8> { using type = cl_int8; };
-template <> struct float_point_to_int<cl_double16> { using type = cl_int16; };
-
-// Used for abs and abs_diff built-in
-template <typename T> struct make_unsigned { using type = T; };
-
-template <> struct make_unsigned<signed char>                    {
-  using type = unsigned char;                                    };
-template <> struct make_unsigned<cl::sycl::vec<signed char, 2>>  {
-  using type = cl::sycl::vec<unsigned char, 2>;                  };
-template <> struct make_unsigned<cl::sycl::vec<signed char, 3>>  {
-  using type = cl::sycl::vec<unsigned char, 3>;                  };
-template <> struct make_unsigned<cl::sycl::vec<signed char, 4>>  {
-  using type = cl::sycl::vec<unsigned char, 4>;                  };
-template <> struct make_unsigned<cl::sycl::vec<signed char, 8>>  {
-  using type = cl::sycl::vec<unsigned char, 8>;                  };
-template <> struct make_unsigned<cl::sycl::vec<signed char, 16>> {
-  using type = cl::sycl::vec<unsigned char, 16>;                 };
-
-template <> struct make_unsigned<short>                    {
-  using type = unsigned short;                             };
-template <> struct make_unsigned<cl::sycl::vec<short, 2>>  {
-  using type = cl::sycl::vec<unsigned short, 2>;           };
-template <> struct make_unsigned<cl::sycl::vec<short, 3>>  {
-  using type = cl::sycl::vec<unsigned short, 3>;           };
-template <> struct make_unsigned<cl::sycl::vec<short, 4>>  {
-  using type = cl::sycl::vec<unsigned short, 4>;           };
-template <> struct make_unsigned<cl::sycl::vec<short, 8>>  {
-  using type = cl::sycl::vec<unsigned short, 8>;           };
-template <> struct make_unsigned<cl::sycl::vec<short, 16>> {
-  using type = cl::sycl::vec<unsigned short, 16>;          };
-
-template <> struct make_unsigned<int>                    {
-  using type = unsigned int;                             };
-template <> struct make_unsigned<cl::sycl::vec<int, 2>>  {
-  using type = cl::sycl::vec<unsigned int, 2>;           };
-template <> struct make_unsigned<cl::sycl::vec<int, 3>>  {
-  using type = cl::sycl::vec<unsigned int, 3>;           };
-template <> struct make_unsigned<cl::sycl::vec<int, 4>>  {
-  using type = cl::sycl::vec<unsigned int, 4>;           };
-template <> struct make_unsigned<cl::sycl::vec<int, 8>>  {
-  using type = cl::sycl::vec<unsigned int, 8>;           };
-template <> struct make_unsigned<cl::sycl::vec<int, 16>> {
-  using type = cl::sycl::vec<unsigned int, 16>;          };
-
-template <> struct make_unsigned<long>                    {
-  using type = unsigned long;                             };
-template <> struct make_unsigned<cl::sycl::vec<long, 2>>  {
-  using type = cl::sycl::vec<unsigned long, 2>;           };
-template <> struct make_unsigned<cl::sycl::vec<long, 3>>  {
-  using type = cl::sycl::vec<unsigned long, 3>;           };
-template <> struct make_unsigned<cl::sycl::vec<long, 4>>  {
-  using type = cl::sycl::vec<unsigned long, 4>;           };
-template <> struct make_unsigned<cl::sycl::vec<long, 8>>  {
-  using type = cl::sycl::vec<unsigned long, 8>;           };
-template <> struct make_unsigned<cl::sycl::vec<long, 16>> {
-  using type = cl::sycl::vec<unsigned long, 16>;          };
-
-template <> struct make_unsigned<long long>                    {
-  using type = unsigned long long;                             };
-template <> struct make_unsigned<cl::sycl::vec<long long, 2>>  {
-  using type = cl::sycl::vec<unsigned long long, 2>;           };
-template <> struct make_unsigned<cl::sycl::vec<long long, 3>>  {
-  using type = cl::sycl::vec<unsigned long long, 3>;           };
-template <> struct make_unsigned<cl::sycl::vec<long long, 4>>  {
-  using type = cl::sycl::vec<unsigned long long, 4>;           };
-template <> struct make_unsigned<cl::sycl::vec<long long, 8>>  {
-  using type = cl::sycl::vec<unsigned long long, 8>;           };
-template <> struct make_unsigned<cl::sycl::vec<long long, 16>> {
-  using type = cl::sycl::vec<unsigned long long, 16>;          };
-
-// Used for upsample built-in
-// Bases on Table 4.93: Scalar data type aliases supported by SYCL
-template <typename T> struct make_upper;
-
-template <> struct make_upper<cl_char> { using type = cl_short; };
-template <> struct make_upper<cl_char2> { using type = cl_short2; };
-template <> struct make_upper<cl_char3> { using type = cl_short3; };
-template <> struct make_upper<cl_char4> { using type = cl_short4; };
-template <> struct make_upper<cl_char8> { using type = cl_short8; };
-template <> struct make_upper<cl_char16> { using type = cl_short16; };
-
-template <> struct make_upper<cl_uchar> { using type = cl_ushort; };
-template <> struct make_upper<cl_uchar2> { using type = cl_ushort2; };
-template <> struct make_upper<cl_uchar3> { using type = cl_ushort3; };
-template <> struct make_upper<cl_uchar4> { using type = cl_ushort4; };
-template <> struct make_upper<cl_uchar8> { using type = cl_ushort8; };
-template <> struct make_upper<cl_uchar16> { using type = cl_ushort16; };
-
-template <> struct make_upper<cl_short> { using type = cl_int; };
-template <> struct make_upper<cl_short2> { using type = cl_int2; };
-template <> struct make_upper<cl_short3> { using type = cl_int3; };
-template <> struct make_upper<cl_short4> { using type = cl_int4; };
-template <> struct make_upper<cl_short8> { using type = cl_int8; };
-template <> struct make_upper<cl_short16> { using type = cl_int16; };
-
-template <> struct make_upper<cl_ushort> { using type = cl_uint; };
-template <> struct make_upper<cl_ushort2> { using type = cl_uint2; };
-template <> struct make_upper<cl_ushort3> { using type = cl_uint3; };
-template <> struct make_upper<cl_ushort4> { using type = cl_uint4; };
-template <> struct make_upper<cl_ushort8> { using type = cl_uint8; };
-template <> struct make_upper<cl_ushort16> { using type = cl_uint16; };
-
-template <> struct make_upper<cl_int> { using type = cl_long; };
-template <> struct make_upper<cl_int2> { using type = cl_long2; };
-template <> struct make_upper<cl_int3> { using type = cl_long3; };
-template <> struct make_upper<cl_int4> { using type = cl_long4; };
-template <> struct make_upper<cl_int8> { using type = cl_long8; };
-template <> struct make_upper<cl_int16> { using type = cl_long16; };
-
-template <> struct make_upper<cl_uint> { using type = cl_ulong; };
-template <> struct make_upper<cl_uint2> { using type = cl_ulong2; };
-template <> struct make_upper<cl_uint3> { using type = cl_ulong3; };
-template <> struct make_upper<cl_uint4> { using type = cl_ulong4; };
-template <> struct make_upper<cl_uint8> { using type = cl_ulong8; };
-template <> struct make_upper<cl_uint16> { using type = cl_ulong16; };
-
-template <> struct make_upper<cl_long> { using type = longlong; };
-template <> struct make_upper<cl_long2> { using type = longlong2; };
-template <> struct make_upper<cl_long3> { using type = longlong3; };
-template <> struct make_upper<cl_long4> { using type = longlong4; };
-template <> struct make_upper<cl_long8> { using type = longlong8; };
-template <> struct make_upper<cl_long16> { using type = longlong16; };
-
-template <> struct make_upper<cl_ulong> { using type = ulonglong; };
-template <> struct make_upper<cl_ulong2> { using type = ulonglong2; };
-template <> struct make_upper<cl_ulong3> { using type = ulonglong3; };
-template <> struct make_upper<cl_ulong4> { using type = ulonglong4; };
-template <> struct make_upper<cl_ulong8> { using type = ulonglong8; };
-template <> struct make_upper<cl_ulong16> { using type = ulonglong16; };
+template <typename T, typename B>
+using convert_data_type = convert_data_type_impl<T, B, T>;
 
 // Try to get pointer_t, otherwise T
 template <typename T> class TryToGetPointerT {
@@ -830,8 +270,8 @@ template <typename T> class TryToGetPointerT {
 
 public:
   using type = decltype(check(T()));
-  static constexpr bool value = std::is_pointer<T>::value ||
-                                !std::is_same<T, type>::value;
+  static constexpr bool value =
+      std::is_pointer<T>::value || !std::is_same<T, type>::value;
 };
 
 // Try to get element_type, otherwise T
@@ -854,8 +294,8 @@ public:
   static constexpr bool value = !std::is_same<T, type>::value;
 };
 
-// Try to get pointer_t (if pointer_t indicates on the type with vector_t
-// creates a pointer type on vector_t), otherwise T
+// Try to get pointer_t (if pointer_t indicates on the type with_remainder
+// vector_t creates a pointer type on vector_t), otherwise T
 template <typename T> class TryToGetPointerVecT {
   static T check(...);
   template <typename A>
@@ -864,7 +304,7 @@ template <typename T> class TryToGetPointerVecT {
       A::address_space>::type *
   check(const A &);
   template <typename A>
-  static typename TryToGetVectorT<A>::type * check(const A *);
+  static typename TryToGetVectorT<A>::type *check(const A *);
 
 public:
   using type = decltype(check(T()));
@@ -891,62 +331,59 @@ T TryToGetPointer(T &t) {
   return t;
 }
 
-// Use conditional_t to improve code readablity.
-template <bool B, typename T1, typename T2>
-using conditional_t = typename std::conditional<B, T1, T2>::type;
-
 // select_apply_cl_scalar_t selects from T8/T16/T32/T64 basing on
 // sizeof(IN).  expected to handle scalar types.
 template <typename T, typename T8, typename T16, typename T32, typename T64>
 using select_apply_cl_scalar_t =
-  conditional_t<sizeof(T) == 1, T8,
-  conditional_t<sizeof(T) == 2, T16,
-  conditional_t<sizeof(T) == 4, T32, T64>>>;
+    conditional_t<sizeof(T) == 1, T8,
+                  conditional_t<sizeof(T) == 2, T16,
+                                conditional_t<sizeof(T) == 4, T32, T64>>>;
 
 // Shortcuts for selecting scalar int/unsigned int/fp type.
 template <typename T>
 using select_cl_scalar_intergal_signed_t =
-  select_apply_cl_scalar_t<T, cl_char, cl_short, cl_int, cl_long>;
+    select_apply_cl_scalar_t<T, sycl::cl_char, sycl::cl_short, sycl::cl_int,
+                             sycl::cl_long>;
 
 template <typename T>
 using select_cl_scalar_intergal_unsigned_t =
-  select_apply_cl_scalar_t<T, cl_uchar, cl_ushort, cl_uint, cl_ulong>;
+    select_apply_cl_scalar_t<T, sycl::cl_uchar, sycl::cl_ushort, sycl::cl_uint,
+                             sycl::cl_ulong>;
 
 template <typename T>
 using select_cl_scalar_float_t =
-  select_apply_cl_scalar_t<T, std::false_type, cl_half, cl_float, cl_double>;
+    select_apply_cl_scalar_t<T, std::false_type, sycl::cl_half, sycl::cl_float,
+                             sycl::cl_double>;
 
 template <typename T>
 using select_cl_scalar_intergal_t =
-  conditional_t<std::is_signed<T>::value,
-    select_cl_scalar_intergal_signed_t<T>,
-    select_cl_scalar_intergal_unsigned_t<T>>;
+    conditional_t<std::is_signed<T>::value,
+                  select_cl_scalar_intergal_signed_t<T>,
+                  select_cl_scalar_intergal_unsigned_t<T>>;
 
 // select_cl_scalar_t picks corresponding cl_* type for input
 // scalar T or returns T if T is not scalar.
 template <typename T>
 using select_cl_scalar_t =
-  conditional_t<std::is_integral<T>::value,
-    select_cl_scalar_intergal_t<T>,
-    conditional_t<std::is_floating_point<T>::value,
-      select_cl_scalar_float_t<T>, T>>;
+    conditional_t<std::is_integral<T>::value, select_cl_scalar_intergal_t<T>,
+                  conditional_t<std::is_floating_point<T>::value,
+                                select_cl_scalar_float_t<T>, T>>;
 
 // select_cl_vector_or_scalar does cl_* type selection for element type of
 // a vector type T and does scalar type substitution.  If T is not
 // vector or scalar unmodified T is returned.
-template <typename T, typename Enable = void>
-struct select_cl_vector_or_scalar;
+template <typename T, typename Enable = void> struct select_cl_vector_or_scalar;
 
 template <typename T>
 struct select_cl_vector_or_scalar<
-  T, typename std::enable_if<is_vgentype<T>::value>::type> {
-  using type = vec<select_cl_scalar_t<typename T::element_type>,
-                   T::get_count()>;
+    T, typename std::enable_if<is_vgentype<T>::value>::type> {
+  using type =
+      vec<select_cl_scalar_t<typename T::element_type>, T::get_count()>;
 };
 
 template <typename T>
 struct select_cl_vector_or_scalar<
-  T, typename std::enable_if<!is_vgentype<T>::value>::type> {
+    T, typename std::enable_if<!is_vgentype<T>::value>::type> {
   using type = select_cl_scalar_t<T>;
 };
 
@@ -959,61 +396,57 @@ struct select_cl_mptr_or_vector_or_scalar;
 
 template <typename T>
 struct select_cl_mptr_or_vector_or_scalar<
-  T, typename std::enable_if<is_genptr<T>::value &&
-                             !std::is_pointer<T>::value>::type> {
+    T, typename std::enable_if<is_genptr<T>::value &&
+                               !std::is_pointer<T>::value>::type> {
   using type = multi_ptr<
-    typename select_cl_vector_or_scalar<typename T::element_type>::type,
-    T::address_space>;
+      typename select_cl_vector_or_scalar<typename T::element_type>::type,
+      T::address_space>;
 };
 
 template <typename T>
 struct select_cl_mptr_or_vector_or_scalar<
-  T, typename std::enable_if<!is_genptr<T>::value ||
-                             std::is_pointer<T>::value>::type> {
+    T, typename std::enable_if<!is_genptr<T>::value ||
+                               std::is_pointer<T>::value>::type> {
   using type = typename select_cl_vector_or_scalar<T>::type;
 };
 
 // All types converting shortcut.
 template <typename T>
 using SelectMatchingOpenCLType_t =
-  typename select_cl_mptr_or_vector_or_scalar<T>::type;
+    typename select_cl_mptr_or_vector_or_scalar<T>::type;
 
 // Converts T to OpenCL friendly
 //
 template <typename T>
-using ConvertToOpenCLType_t =
-  conditional_t<TryToGetVectorT<SelectMatchingOpenCLType_t<T>>::value,
+using ConvertToOpenCLType_t = conditional_t<
+    TryToGetVectorT<SelectMatchingOpenCLType_t<T>>::value,
     typename TryToGetVectorT<SelectMatchingOpenCLType_t<T>>::type,
-    conditional_t<TryToGetPointerT<SelectMatchingOpenCLType_t<T>>::value,
-      typename TryToGetPointerVecT<SelectMatchingOpenCLType_t<T>>::type,
-      SelectMatchingOpenCLType_t<T>>>;
+    conditional_t<
+        TryToGetPointerT<SelectMatchingOpenCLType_t<T>>::value,
+        typename TryToGetPointerVecT<SelectMatchingOpenCLType_t<T>>::type,
+        SelectMatchingOpenCLType_t<T>>>;
 
 // convertDataToType() function converts data from FROM type to TO type using
 // 'as' method for vector type and copy otherwise.
 template <typename FROM, typename TO>
-typename std::enable_if<is_vgentype<FROM>::value &&
-                        is_vgentype<TO>::value &&
-                        sizeof(TO) == sizeof(FROM), TO>::type
+typename std::enable_if<is_vgentype<FROM>::value && is_vgentype<TO>::value &&
+                            sizeof(TO) == sizeof(FROM),
+                        TO>::type
 convertDataToType(FROM t) {
   return t.template as<TO>();
 }
 
 template <typename FROM, typename TO>
-typename std::enable_if<!(is_vgentype<FROM>::value &&
-                          is_vgentype<TO>::value) &&
-                        sizeof(TO) == sizeof(FROM), TO>::type
+typename std::enable_if<!(is_vgentype<FROM>::value && is_vgentype<TO>::value) &&
+                            sizeof(TO) == sizeof(FROM),
+                        TO>::type
 convertDataToType(FROM t) {
   return TryToGetPointer(t);
 }
 
-template <typename T>
-  using unsign_integral_to_float_point_t =
-    typename unsign_integral_to_float_point<
-      SelectMatchingOpenCLType_t<T>>::type;
-
 // Used for all,any and select relational built-in functions
 template <typename T> inline constexpr T msbMask(T) {
-  using UT = typename std::make_unsigned<T>::type;
+  using UT = make_unsigned_t<T>;
   return T(UT(1) << (sizeof(T) * 8 - 1));
 }
 
@@ -1022,7 +455,8 @@ template <typename T> inline constexpr bool msbIsSet(const T x) {
 }
 
 template <typename T>
-using common_rel_ret_t = typename detail::float_point_to_sign_integral<T>::type;
+using common_rel_ret_t =
+    conditional_t<is_vgentype<T>::value, make_singed_integer_t<T>, int>;
 
 // forward declaration
 template <int N> struct Boolean;
@@ -1070,7 +504,7 @@ template <typename T> struct RelationalTestForSignBitType {
   using return_type = detail::Boolean<1>;
   using argument_type = detail::Boolean<TryToGetNumElements<T>::value>;
 #else
-  using return_type = cl::sycl::cl_int;
+  using return_type = int;
   using argument_type = T;
 #endif
 };

--- a/sycl/include/CL/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/stl_type_traits.hpp
@@ -1,0 +1,74 @@
+//==------- stl_type_traits.hpp - SYCL STL type traits analogs -------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <iterator>
+#include <memory>
+#include <type_traits>
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+template <bool V> using bool_constant = std::integral_constant<bool, V>;
+
+template <typename T>
+using allocator_value_type_t = typename std::allocator_traits<T>::value_type;
+
+template <typename T>
+using allocator_pointer_t = typename std::allocator_traits<T>::pointer;
+
+template <bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+template <bool B, class T, class F>
+using conditional_t = typename std::conditional<B, T, F>::type;
+
+template <typename T>
+using remove_const_t = typename std::remove_const<T>::type;
+
+template <typename T> using remove_cv_t = typename std::remove_cv<T>::type;
+
+template <typename T> using add_pointer_t = typename std::add_pointer<T>::type;
+
+template <typename T>
+using iterator_category_t = typename std::iterator_traits<T>::iterator_category;
+
+template <typename T>
+using iterator_value_type_t = typename std::iterator_traits<T>::value_type;
+
+template <typename T>
+using iterator_pointer_t = typename std::iterator_traits<T>::pointer;
+
+template <typename T>
+using iterator_to_const_type_t =
+    std::is_const<typename std::remove_pointer<iterator_pointer_t<T>>::type>;
+
+template <class...> using requirements_list = void;
+
+// TODO Align with C++ named requirements: LegacyOutputIterator
+// https://en.cppreference.com/w/cpp/named_req/OutputIterator
+template <typename T>
+using output_iterator_requirements =
+    requirements_list<iterator_category_t<T>,
+                      decltype(*std::declval<T>() =
+                                   std::declval<iterator_value_type_t<T>>())>;
+
+template <typename, typename = void> struct is_output_iterator {
+  static constexpr bool value = false;
+};
+
+template <typename T>
+struct is_output_iterator<T, output_iterator_requirements<T>> {
+  static constexpr bool value = true;
+};
+
+} // namespace detail
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/detail/type_list.hpp
+++ b/sycl/include/CL/sycl/detail/type_list.hpp
@@ -1,0 +1,140 @@
+//==----------- type_list.hpp - SYCL list of types utils -------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/stl_type_traits.hpp>
+
+#include <type_traits>
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+template <typename T> using head_t = typename T::head;
+
+template <typename T> using tail_t = typename T::tail;
+
+// type_list
+template <typename... T> class type_list;
+
+using empty_type_list = type_list<>;
+
+template <typename T>
+struct is_empty_type_list
+    : conditional_t<std::is_same<T, empty_type_list>::value, std::true_type,
+                    std::false_type> {};
+
+template <> struct type_list<> {};
+
+template <typename H, typename... T> struct type_list<H, T...> {
+  using head = H;
+  using tail = type_list<T...>;
+};
+
+template <typename H, typename... T, typename... T2>
+struct type_list<type_list<H, T...>, T2...> {
+private:
+  using remainder = tail_t<type_list<H>>;
+  static constexpr bool has_remainder = !is_empty_type_list<remainder>::value;
+  using without_remainder = type_list<T..., T2...>;
+  using with_remainder = type_list<remainder, T..., T2...>;
+
+public:
+  using head = head_t<type_list<H>>;
+  using tail = conditional_t<has_remainder, with_remainder, without_remainder>;
+};
+
+// is_contained
+template <typename T, typename L>
+struct is_contained
+    : conditional_t<std::is_same<remove_cv_t<T>, head_t<L>>::value,
+                    std::true_type, is_contained<T, tail_t<L>>> {};
+
+template <typename T>
+struct is_contained<T, empty_type_list> : std::false_type {};
+
+// value_list
+template <typename T, T... V> struct value_list;
+
+template <typename T, T H, T... V> struct value_list<T, H, V...> {
+  static constexpr T head = H;
+  using tail = value_list<T, V...>;
+};
+
+template <typename T> struct value_list<T> {};
+
+// is_contained_value
+template <typename T, T V, typename TL>
+struct is_contained_value
+    : conditional_t<V == TL::head, std::true_type,
+                    is_contained_value<T, V, tail_t<TL>>> {};
+
+template <typename T, T V>
+struct is_contained_value<T, V, value_list<T>> : std::false_type {};
+
+//  address_space_list
+template <access::address_space... V>
+using address_space_list = value_list<access::address_space, V...>;
+
+template <access::address_space AS, typename VL>
+using is_one_of_spaces = is_contained_value<access::address_space, AS, VL>;
+
+// size type predicates
+template <typename T1, typename T2>
+struct is_type_size_equal : bool_constant<(sizeof(T1) == sizeof(T2))> {};
+
+template <typename T1, typename T2>
+struct is_type_size_greater : bool_constant<(sizeof(T1) > sizeof(T2))> {};
+
+template <typename T1, typename T2>
+struct is_type_size_double_of
+    : bool_constant<(sizeof(T1) == (sizeof(T2) * 2))> {};
+
+template <typename T1, typename T2>
+struct is_type_size_less : bool_constant<(sizeof(T1) < sizeof(T2))> {};
+
+template <typename T1, typename T2>
+struct is_type_size_half_of : bool_constant<(sizeof(T1) == (sizeof(T2) / 2))> {
+};
+
+// find required type
+template <typename TL, template <typename, typename> class C, typename T>
+struct find_type {
+  using head = head_t<TL>;
+  using tail = typename find_type<tail_t<TL>, C, T>::type;
+  using type = conditional_t<C<head, T>::value, head, tail>;
+};
+
+template <template <typename, typename> class C, typename T>
+struct find_type<empty_type_list, C, T> {
+  using type = void;
+};
+
+template <typename TL, template <typename, typename> class C, typename T>
+using find_type_t = typename find_type<TL, C, T>::type;
+
+template <typename TL, typename T>
+using find_same_size_type_t = find_type_t<TL, is_type_size_equal, T>;
+
+template <typename TL, typename T>
+using find_smaller_type_t = find_type_t<TL, is_type_size_less, T>;
+
+template <typename TL, typename T>
+using find_larger_type_t = find_type_t<TL, is_type_size_greater, T>;
+
+template <typename TL, typename T>
+using find_twice_as_small_type_t = find_type_t<TL, is_type_size_half_of, T>;
+
+template <typename TL, typename T>
+using find_twice_as_large_type_t = find_type_t<TL, is_type_size_double_of, T>;
+
+} // namespace detail
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/detail/type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/type_traits.hpp
@@ -1,4 +1,4 @@
-//==--------------- type_traits - SYCL type traits -------------------------==//
+//==----------------- type_traits.hpp - SYCL type traits -------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,65 +8,274 @@
 
 #pragma once
 
-#include <iterator>
-#include <memory>
+#include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/generic_type_lists.hpp>
+#include <CL/sycl/detail/stl_type_traits.hpp>
+#include <CL/sycl/detail/type_list.hpp>
+#include <CL/sycl/half_type.hpp>
+
 #include <type_traits>
 
 namespace cl {
 namespace sycl {
+
+// Forward declaration
+template <typename ElementType, access::address_space Space> class multi_ptr;
+
 namespace detail {
 
-template <typename T>
-using allocator_value_type_t = typename std::allocator_traits<T>::value_type;
+// Contains a type that is the base type for a scalar or vector type
+template <typename T> struct get_base_type { using type = T; };
+
+template <typename T, int N> struct get_base_type<vec<T, N>> {
+  using type = T;
+};
+
+template <typename T> using get_base_type_t = typename get_base_type<T>::type;
+
+// change_base_type_t
+template <typename T, typename B> struct change_base_type { using type = B; };
+
+template <typename T, int N, typename B> struct change_base_type<vec<T, N>, B> {
+  using type = vec<B, N>;
+};
+
+template <typename T, typename B>
+using change_base_type_t = typename change_base_type<T, B>::type;
+
+// Applies the same the cv-qualifiers from T type to R type
+template <typename T, typename R> struct copy_cv_qualifiers_impl {
+  using type = R;
+};
+
+template <typename T, typename R> struct copy_cv_qualifiers_impl<const T, R> {
+  using type = const R;
+};
+
+template <typename T, typename R>
+struct copy_cv_qualifiers_impl<volatile T, R> {
+  using type = volatile R;
+};
+
+template <typename T, typename R>
+struct copy_cv_qualifiers_impl<const volatile T, R> {
+  using type = const volatile R;
+};
+
+template <typename T, typename R> struct copy_cv_qualifiers {
+  using type = typename copy_cv_qualifiers_impl<T, remove_cv_t<R>>::type;
+};
+
+template <typename T, typename R>
+using copy_cv_qualifiers_t = typename copy_cv_qualifiers<T, R>::type;
+
+// make_signed with support SYCL vec class
+
+template <typename T, typename Enable = void> struct make_signed_impl;
 
 template <typename T>
-using allocator_pointer_t = typename std::allocator_traits<T>::pointer;
-
-template <bool B, class T = void>
-using enable_if_t = typename std::enable_if<B, T>::type;
-
-template <bool B, class T, class F>
-using conditional_t = typename std::conditional<B, T, F>::type;
+using make_signed_impl_t = typename make_signed_impl<T, T>::type;
 
 template <typename T>
-using remove_pointer_t = typename std::remove_pointer<T>::type;
-
-template <typename T>
-using remove_const_t = typename std::remove_const<T>::type;
-
-template <typename T> using add_pointer_t = typename std::add_pointer<T>::type;
-
-template <typename T>
-using iterator_category_t = typename std::iterator_traits<T>::iterator_category;
-
-template <typename T>
-using iterator_value_type_t = typename std::iterator_traits<T>::value_type;
-
-template <typename T>
-using iterator_pointer_t = typename std::iterator_traits<T>::pointer;
-
-template <typename T>
-using iterator_to_const_type_t =
-    std::is_const<remove_pointer_t<iterator_pointer_t<T>>>;
-
-template <class...> using requirements_list = void;
-
-// TODO Align with C++ named requirements: LegacyOutputIterator
-// https://en.cppreference.com/w/cpp/named_req/OutputIterator
-template <typename T>
-using output_iterator_requirements =
-    requirements_list<iterator_category_t<T>,
-                      decltype(*std::declval<T>() =
-                                   std::declval<iterator_value_type_t<T>>())>;
-
-template <typename, typename = void> struct is_output_iterator {
-  static constexpr bool value = false;
+struct make_signed_impl<
+    T, enable_if_t<is_contained<T, gtl::scalar_integer_list>::value, T>> {
+  using type = typename std::make_signed<T>::type;
 };
 
 template <typename T>
-struct is_output_iterator<T, output_iterator_requirements<T>> {
-  static constexpr bool value = true;
+struct make_signed_impl<
+    T, enable_if_t<is_contained<T, gtl::vector_integer_list>::value, T>> {
+  using base_type = make_signed_impl_t<get_base_type_t<T>>;
+  using type = change_base_type_t<T, base_type>;
 };
+
+// TODO Delete this specialization after solving the problems in the test
+// infrastructure.
+template <typename T>
+struct make_signed_impl<
+    T, enable_if_t<!is_contained<T, gtl::integer_list>::value, T>> {
+  using type = T;
+};
+
+template <typename T> struct make_signed {
+  using new_type_wo_cv_qualifiers = make_signed_impl_t<remove_cv_t<T>>;
+  using type = copy_cv_qualifiers_t<T, new_type_wo_cv_qualifiers>;
+};
+
+template <typename T> using make_signed_t = typename make_signed<T>::type;
+
+// make_unsigned with support SYCL vec class
+template <typename T, typename Enable = void> struct make_unsigned_impl;
+
+template <typename T>
+using make_unsigned_impl_t = typename make_unsigned_impl<T, T>::type;
+
+template <typename T>
+struct make_unsigned_impl<
+    T, enable_if_t<is_contained<T, gtl::scalar_integer_list>::value, T>> {
+  using type = typename std::make_unsigned<T>::type;
+};
+
+template <typename T>
+struct make_unsigned_impl<
+    T, enable_if_t<is_contained<T, gtl::vector_integer_list>::value, T>> {
+  using base_type = make_unsigned_impl_t<get_base_type_t<T>>;
+  using type = change_base_type_t<T, base_type>;
+};
+
+// TODO Delete this specialization after solving the problems in the test
+// infrastructure.
+template <typename T>
+struct make_unsigned_impl<
+    T, enable_if_t<!is_contained<T, gtl::integer_list>::value, T>> {
+  using type = T;
+};
+
+template <typename T> struct make_unsigned {
+  using new_type_wo_cv_qualifiers = make_unsigned_impl_t<remove_cv_t<T>>;
+  using type = copy_cv_qualifiers_t<T, new_type_wo_cv_qualifiers>;
+};
+
+template <typename T> using make_unsigned_t = typename make_unsigned<T>::type;
+
+// Checks that sizeof base type of T equal N and T satisfies S<T>::value
+template <typename T, int N, template <typename> class S>
+using is_gen_based_on_type_sizeof =
+    bool_constant<S<T>::value && (sizeof(get_base_type_t<T>) == N)>;
+
+// is_integral
+template <typename T>
+struct is_integral : std::is_integral<get_base_type_t<T>> {};
+
+// is_floating_point
+template <typename T>
+struct is_floating_point_impl : std::is_floating_point<T> {};
+
+template <> struct is_floating_point_impl<half> : std::true_type {};
+
+template <typename T>
+struct is_floating_point
+    : is_floating_point_impl<remove_cv_t<get_base_type_t<T>>> {};
+
+// is_arithmetic
+template <typename T>
+struct is_arithmetic
+    : bool_constant<is_integral<T>::value || is_floating_point<T>::value> {};
+
+// is_pointer
+template <typename T> struct is_pointer_impl : std::false_type {};
+
+template <typename T> struct is_pointer_impl<T *> : std::true_type {};
+
+template <typename T, access::address_space Space>
+struct is_pointer_impl<multi_ptr<T, Space>> : std::true_type {};
+
+template <typename T> struct is_pointer : is_pointer_impl<remove_cv_t<T>> {};
+
+// remove_pointer_t
+template <typename T> struct remove_pointer_impl { using type = T; };
+
+template <typename T> struct remove_pointer_impl<T *> { using type = T; };
+
+template <typename T, access::address_space Space>
+struct remove_pointer_impl<multi_ptr<T, Space>> {
+  using type = T;
+};
+
+template <typename T>
+struct remove_pointer : remove_pointer_impl<remove_cv_t<T>> {};
+
+template <typename T> using remove_pointer_t = typename remove_pointer<T>::type;
+
+// is_address_space_compliant
+template <typename T, typename SpaceList>
+struct is_address_space_compliant_impl : std::false_type {};
+
+template <typename T, typename SpaceList>
+struct is_address_space_compliant_impl<T *, SpaceList> : std::true_type {};
+
+template <typename T, typename SpaceList, access::address_space Space>
+struct is_address_space_compliant_impl<multi_ptr<T, Space>, SpaceList>
+    : bool_constant<is_one_of_spaces<Space, SpaceList>::value> {};
+
+template <typename T, typename SpaceList>
+struct is_address_space_compliant
+    : is_address_space_compliant_impl<remove_cv_t<T>, SpaceList> {};
+
+// make_type_t
+template <typename T, typename TL> struct make_type_impl {
+  using type = find_same_size_type_t<TL, T>;
+};
+
+template <typename T, int N, typename TL> struct make_type_impl<vec<T, N>, TL> {
+  using scalar_type = typename make_type_impl<T, TL>::type;
+  using type = vec<scalar_type, N>;
+};
+
+template <typename T, typename TL>
+using make_type_t = typename make_type_impl<T, TL>::type;
+
+// nan_types
+template <typename T, typename Enable = void> struct nan_types;
+
+template <typename T>
+struct nan_types<
+    T, enable_if_t<is_contained<T, gtl::unsigned_short_list>::value, T>> {
+  using ret_type = change_base_type_t<T, half>;
+  using arg_type = find_same_size_type_t<gtl::scalar_unsigned_short_list, half>;
+};
+
+template <typename T>
+struct nan_types<
+    T, enable_if_t<is_contained<T, gtl::unsigned_int_list>::value, T>> {
+  using ret_type = change_base_type_t<T, float>;
+  using arg_type = find_same_size_type_t<gtl::scalar_unsigned_int_list, float>;
+};
+
+template <typename T>
+struct nan_types<
+    T,
+    enable_if_t<is_contained<T, gtl::unsigned_long_integer_list>::value, T>> {
+  using ret_type = change_base_type_t<T, double>;
+  using arg_type =
+      find_same_size_type_t<gtl::scalar_unsigned_long_integer_list, double>;
+};
+
+// make_larger_t
+template <typename T, typename Enable = void> struct make_larger_impl;
+template <typename T>
+struct make_larger_impl<
+    T, enable_if_t<is_contained<T, gtl::scalar_floating_list>::value, T>> {
+  using type = find_twice_as_large_type_t<gtl::scalar_floating_list, T>;
+};
+
+template <typename T>
+struct make_larger_impl<
+    T,
+    enable_if_t<is_contained<T, gtl::scalar_signed_integer_list>::value, T>> {
+  using type = find_twice_as_large_type_t<gtl::scalar_signed_integer_list, T>;
+};
+
+template <typename T>
+struct make_larger_impl<
+    T,
+    enable_if_t<is_contained<T, gtl::scalar_unsigned_integer_list>::value, T>> {
+  using type = find_twice_as_large_type_t<gtl::scalar_unsigned_integer_list, T>;
+};
+
+template <typename T, int N> struct make_larger_impl<vec<T, N>, vec<T, N>> {
+  using base_type = get_base_type_t<vec<T, N>>;
+  using upper_type = typename make_larger_impl<base_type, base_type>::type;
+  using new_type = vec<upper_type, N>;
+  static constexpr bool found = !std::is_same<upper_type, void>::value;
+  using type = conditional_t<found, new_type, void>;
+};
+
+template <typename T> struct make_larger {
+  using type = typename make_larger_impl<T, T>::type;
+};
+
+template <typename T> using make_larger_t = typename make_larger<T>::type;
 
 } // namespace detail
 } // namespace sycl

--- a/sycl/source/detail/builtins_geometric.cpp
+++ b/sycl/source/detail/builtins_geometric.cpp
@@ -125,49 +125,56 @@ s::cl_half4 cross(s::cl_half4 p0, s::cl_half4 p1) __NOEXC {
 }
 
 // FMul
-cl_float FMul(s::cl_float p0, s::cl_float p1) { return __FMul(p0, p1); }
-cl_double FMul(s::cl_double p0, s::cl_double p1) { return __FMul(p0, p1); }
-cl_float FMul(s::cl_half p0, s::cl_half p1) { return __FMul(p0, p1); }
+s::cl_float FMul(s::cl_float p0, s::cl_float p1) { return __FMul(p0, p1); }
+s::cl_double FMul(s::cl_double p0, s::cl_double p1) { return __FMul(p0, p1); }
+s::cl_float FMul(s::cl_half p0, s::cl_half p1) { return __FMul(p0, p1); }
 
 // Dot
 MAKE_GEO_1V_2V_RS(Dot, __FMul_impl, s::cl_float, s::cl_float, s::cl_float)
-MAKE_GEO_1V_2V_RS(Dot, __FMul_impl, s::cl_double, s::cl_double,
-                  s::cl_double)
+MAKE_GEO_1V_2V_RS(Dot, __FMul_impl, s::cl_double, s::cl_double, s::cl_double)
 MAKE_GEO_1V_2V_RS(Dot, __FMul_impl, s::cl_half, s::cl_half, s::cl_half)
 
 // length
-cl_float length(s::cl_float p) { return __length(p); }
-cl_double length(s::cl_double p) { return __length(p); }
-cl_half length(s::cl_half p) { return __length(p); }
-cl_float length(s::cl_float2 p) { return __length(p); }
-cl_float length(s::cl_float3 p) { return __length(p); }
-cl_float length(s::cl_float4 p) { return __length(p); }
-cl_double length(s::cl_double2 p) { return __length(p); }
-cl_double length(s::cl_double3 p) { return __length(p); }
-cl_double length(s::cl_double4 p) { return __length(p); }
-cl_half length(s::cl_half2 p) { return __length(p); }
-cl_half length(s::cl_half3 p) { return __length(p); }
-cl_half length(s::cl_half4 p) { return __length(p); }
+s::cl_float length(s::cl_float p) { return __length(p); }
+s::cl_double length(s::cl_double p) { return __length(p); }
+s::cl_half length(s::cl_half p) { return __length(p); }
+s::cl_float length(s::cl_float2 p) { return __length(p); }
+s::cl_float length(s::cl_float3 p) { return __length(p); }
+s::cl_float length(s::cl_float4 p) { return __length(p); }
+s::cl_double length(s::cl_double2 p) { return __length(p); }
+s::cl_double length(s::cl_double3 p) { return __length(p); }
+s::cl_double length(s::cl_double4 p) { return __length(p); }
+s::cl_half length(s::cl_half2 p) { return __length(p); }
+s::cl_half length(s::cl_half3 p) { return __length(p); }
+s::cl_half length(s::cl_half4 p) { return __length(p); }
 
 // distance
-cl_float distance(s::cl_float p0, s::cl_float p1) { return length(p0 - p1); }
-cl_float distance(s::cl_float2 p0, s::cl_float2 p1) { return length(p0 - p1); }
-cl_float distance(s::cl_float3 p0, s::cl_float3 p1) { return length(p0 - p1); }
-cl_float distance(s::cl_float4 p0, s::cl_float4 p1) { return length(p0 - p1); }
-cl_double distance(s::cl_double p0, s::cl_double p1) { return length(p0 - p1); }
-cl_double distance(s::cl_double2 p0, s::cl_double2 p1) {
+s::cl_float distance(s::cl_float p0, s::cl_float p1) { return length(p0 - p1); }
+s::cl_float distance(s::cl_float2 p0, s::cl_float2 p1) {
   return length(p0 - p1);
 }
-cl_double distance(s::cl_double3 p0, s::cl_double3 p1) {
+s::cl_float distance(s::cl_float3 p0, s::cl_float3 p1) {
   return length(p0 - p1);
 }
-cl_double distance(s::cl_double4 p0, s::cl_double4 p1) {
+s::cl_float distance(s::cl_float4 p0, s::cl_float4 p1) {
   return length(p0 - p1);
 }
-cl_half distance(s::cl_half p0, s::cl_half p1) { return length(p0 - p1); }
-cl_half distance(s::cl_half2 p0, s::cl_half2 p1) { return length(p0 - p1); }
-cl_half distance(s::cl_half3 p0, s::cl_half3 p1) { return length(p0 - p1); }
-cl_half distance(s::cl_half4 p0, s::cl_half4 p1) { return length(p0 - p1); }
+s::cl_double distance(s::cl_double p0, s::cl_double p1) {
+  return length(p0 - p1);
+}
+s::cl_double distance(s::cl_double2 p0, s::cl_double2 p1) {
+  return length(p0 - p1);
+}
+s::cl_double distance(s::cl_double3 p0, s::cl_double3 p1) {
+  return length(p0 - p1);
+}
+s::cl_double distance(s::cl_double4 p0, s::cl_double4 p1) {
+  return length(p0 - p1);
+}
+s::cl_half distance(s::cl_half p0, s::cl_half p1) { return length(p0 - p1); }
+s::cl_half distance(s::cl_half2 p0, s::cl_half2 p1) { return length(p0 - p1); }
+s::cl_half distance(s::cl_half3 p0, s::cl_half3 p1) { return length(p0 - p1); }
+s::cl_half distance(s::cl_half4 p0, s::cl_half4 p1) { return length(p0 - p1); }
 
 // normalize
 s::cl_float normalize(s::cl_float p) { return __normalize(p); }
@@ -184,10 +191,10 @@ s::cl_half3 normalize(s::cl_half3 p) { return __normalize(p); }
 s::cl_half4 normalize(s::cl_half4 p) { return __normalize(p); }
 
 // fast_length
-cl_float fast_length(s::cl_float p) { return __fast_length(p); }
-cl_float fast_length(s::cl_float2 p) { return __fast_length(p); }
-cl_float fast_length(s::cl_float3 p) { return __fast_length(p); }
-cl_float fast_length(s::cl_float4 p) { return __fast_length(p); }
+s::cl_float fast_length(s::cl_float p) { return __fast_length(p); }
+s::cl_float fast_length(s::cl_float2 p) { return __fast_length(p); }
+s::cl_float fast_length(s::cl_float3 p) { return __fast_length(p); }
+s::cl_float fast_length(s::cl_float4 p) { return __fast_length(p); }
 
 // fast_normalize
 s::cl_float fast_normalize(s::cl_float p) {
@@ -201,16 +208,16 @@ s::cl_float3 fast_normalize(s::cl_float3 p) { return __fast_normalize(p); }
 s::cl_float4 fast_normalize(s::cl_float4 p) { return __fast_normalize(p); }
 
 // fast_distance
-cl_float fast_distance(s::cl_float p0, s::cl_float p1) {
+s::cl_float fast_distance(s::cl_float p0, s::cl_float p1) {
   return fast_length(p0 - p1);
 }
-cl_float fast_distance(s::cl_float2 p0, s::cl_float2 p1) {
+s::cl_float fast_distance(s::cl_float2 p0, s::cl_float2 p1) {
   return fast_length(p0 - p1);
 }
-cl_float fast_distance(s::cl_float3 p0, s::cl_float3 p1) {
+s::cl_float fast_distance(s::cl_float3 p0, s::cl_float3 p1) {
   return fast_length(p0 - p1);
 }
-cl_float fast_distance(s::cl_float4 p0, s::cl_float4 p1) {
+s::cl_float fast_distance(s::cl_float4 p0, s::cl_float4 p1) {
   return fast_length(p0 - p1);
 }
 

--- a/sycl/source/detail/builtins_integer.cpp
+++ b/sycl/source/detail/builtins_integer.cpp
@@ -72,7 +72,7 @@ template <typename T> inline constexpr T __ctz(T x) {
 }
 
 template <typename T> T __mul_hi(T a, T b) {
-  using UPT = typename d::make_upper<T>::type;
+  using UPT = typename d::make_larger<T>::type;
   UPT a_s = a;
   UPT b_s = b;
   UPT mul = a_s * b_s;
@@ -92,7 +92,7 @@ template <typename T> inline T __get_high_half(T a0b0, T a0b1, T a1b0, T a1b1) {
 // A helper function for mul_hi built-in for long
 template <typename T>
 inline void __get_half_products(T a, T b, T &a0b0, T &a0b1, T &a1b0, T &a1b1) {
-  constexpr int halfsize = (sizeof(T) * 8) / 2;
+  constexpr s::cl_int halfsize = (sizeof(T) * 8) / 2;
   T a1 = a >> halfsize;
   T a0 = (a << halfsize) >> halfsize;
   T b1 = b >> halfsize;
@@ -151,7 +151,7 @@ template <typename T> inline T __s_long_mad_hi(T a, T b, T c) {
 }
 
 template <typename T> inline T __s_mad_sat(T a, T b, T c) {
-  using UPT = typename d::make_upper<T>::type;
+  using UPT = typename d::make_larger<T>::type;
   UPT mul = UPT(a) * UPT(b);
   const UPT max = d::max_v<T>();
   const UPT min = d::min_v<T>();
@@ -174,7 +174,7 @@ template <typename T> inline T __s_long_mad_sat(T a, T b, T c) {
 }
 
 template <typename T> inline T __u_mad_sat(T a, T b, T c) {
-  using UPT = typename d::make_upper<T>::type;
+  using UPT = typename d::make_larger<T>::type;
   UPT mul = UPT(a) * UPT(b);
   const UPT min = d::min_v<T>();
   const UPT max = d::max_v<T>();
@@ -214,8 +214,8 @@ template <typename T> inline T __s_sub_sat(T x, T y) {
 }
 
 template <typename T1, typename T2>
-typename d::make_upper<T1>::type inline __upsample(T1 hi, T2 lo) {
-  using UT = typename d::make_upper<T1>::type;
+typename d::make_larger<T1>::type inline __upsample(T1 hi, T2 lo) {
+  using UT = typename d::make_larger<T1>::type;
   return (UT(hi) << (sizeof(T1) * 8)) | lo;
 }
 
@@ -236,36 +236,36 @@ template <typename T> inline T __mul24(T x, T y) { return (x * y); }
 
 // --------------- 4.13.4 Integer functions. Host implementations --------------
 // u_abs
-cl_uchar u_abs(s::cl_uchar x) __NOEXC { return x; }
-cl_ushort u_abs(s::cl_ushort x) __NOEXC { return x; }
-cl_uint u_abs(s::cl_uint x) __NOEXC { return x; }
-cl_ulong u_abs(s::cl_ulong x) __NOEXC { return x; }
+s::cl_uchar u_abs(s::cl_uchar x) __NOEXC { return x; }
+s::cl_ushort u_abs(s::cl_ushort x) __NOEXC { return x; }
+s::cl_uint u_abs(s::cl_uint x) __NOEXC { return x; }
+s::cl_ulong u_abs(s::cl_ulong x) __NOEXC { return x; }
 MAKE_1V(u_abs, s::cl_uchar, s::cl_uchar)
 MAKE_1V(u_abs, s::cl_ushort, s::cl_ushort)
 MAKE_1V(u_abs, s::cl_uint, s::cl_uint)
 MAKE_1V(u_abs, s::cl_ulong, s::cl_ulong)
 
 // s_abs
-cl_uchar s_abs(s::cl_char x) __NOEXC { return std::abs(x); }
-cl_ushort s_abs(s::cl_short x) __NOEXC { return std::abs(x); }
-cl_uint s_abs(s::cl_int x) __NOEXC { return std::abs(x); }
-cl_ulong s_abs(s::cl_long x) __NOEXC { return std::abs(x); }
+s::cl_uchar s_abs(s::cl_char x) __NOEXC { return std::abs(x); }
+s::cl_ushort s_abs(s::cl_short x) __NOEXC { return std::abs(x); }
+s::cl_uint s_abs(s::cl_int x) __NOEXC { return std::abs(x); }
+s::cl_ulong s_abs(s::cl_long x) __NOEXC { return std::abs(x); }
 MAKE_1V(s_abs, s::cl_uchar, s::cl_char)
 MAKE_1V(s_abs, s::cl_ushort, s::cl_short)
 MAKE_1V(s_abs, s::cl_uint, s::cl_int)
 MAKE_1V(s_abs, s::cl_ulong, s::cl_long)
 
 // u_abs_diff
-cl_uchar u_abs_diff(s::cl_uchar x, s::cl_uchar y) __NOEXC {
+s::cl_uchar u_abs_diff(s::cl_uchar x, s::cl_uchar y) __NOEXC {
   return __abs_diff(x, y);
 }
-cl_ushort u_abs_diff(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+s::cl_ushort u_abs_diff(s::cl_ushort x, s::cl_ushort y) __NOEXC {
   return __abs_diff(x, y);
 }
-cl_uint u_abs_diff(s::cl_uint x, s::cl_uint y) __NOEXC {
+s::cl_uint u_abs_diff(s::cl_uint x, s::cl_uint y) __NOEXC {
   return __abs_diff(x, y);
 }
-cl_ulong u_abs_diff(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+s::cl_ulong u_abs_diff(s::cl_ulong x, s::cl_ulong y) __NOEXC {
   return __abs_diff(x, y);
 }
 
@@ -275,16 +275,16 @@ MAKE_1V_2V(u_abs_diff, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_abs_diff, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_abs_diff
-cl_uchar s_abs_diff(s::cl_char x, s::cl_char y) __NOEXC {
+s::cl_uchar s_abs_diff(s::cl_char x, s::cl_char y) __NOEXC {
   return __abs_diff(x, y);
 }
-cl_ushort s_abs_diff(s::cl_short x, s::cl_short y) __NOEXC {
+s::cl_ushort s_abs_diff(s::cl_short x, s::cl_short y) __NOEXC {
   return __abs_diff(x, y);
 }
-cl_uint s_abs_diff(s::cl_int x, s::cl_int y) __NOEXC {
+s::cl_uint s_abs_diff(s::cl_int x, s::cl_int y) __NOEXC {
   return __abs_diff(x, y);
 }
-cl_ulong s_abs_diff(s::cl_long x, s::cl_long y) __NOEXC {
+s::cl_ulong s_abs_diff(s::cl_long x, s::cl_long y) __NOEXC {
   return __abs_diff(x, y);
 }
 MAKE_1V_2V(s_abs_diff, s::cl_uchar, s::cl_char, s::cl_char)
@@ -293,16 +293,16 @@ MAKE_1V_2V(s_abs_diff, s::cl_uint, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_abs_diff, s::cl_ulong, s::cl_long, s::cl_long)
 
 // u_add_sat
-cl_uchar u_add_sat(s::cl_uchar x, s::cl_uchar y) __NOEXC {
+s::cl_uchar u_add_sat(s::cl_uchar x, s::cl_uchar y) __NOEXC {
   return __u_add_sat(x, y);
 }
-cl_ushort u_add_sat(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+s::cl_ushort u_add_sat(s::cl_ushort x, s::cl_ushort y) __NOEXC {
   return __u_add_sat(x, y);
 }
-cl_uint u_add_sat(s::cl_uint x, s::cl_uint y) __NOEXC {
+s::cl_uint u_add_sat(s::cl_uint x, s::cl_uint y) __NOEXC {
   return __u_add_sat(x, y);
 }
-cl_ulong u_add_sat(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+s::cl_ulong u_add_sat(s::cl_ulong x, s::cl_ulong y) __NOEXC {
   return __u_add_sat(x, y);
 }
 MAKE_1V_2V(u_add_sat, s::cl_uchar, s::cl_uchar, s::cl_uchar)
@@ -311,14 +311,16 @@ MAKE_1V_2V(u_add_sat, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_add_sat, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_add_sat
-cl_char s_add_sat(s::cl_char x, s::cl_char y) __NOEXC {
+s::cl_char s_add_sat(s::cl_char x, s::cl_char y) __NOEXC {
   return __s_add_sat(x, y);
 }
-cl_short s_add_sat(s::cl_short x, s::cl_short y) __NOEXC {
+s::cl_short s_add_sat(s::cl_short x, s::cl_short y) __NOEXC {
   return __s_add_sat(x, y);
 }
-cl_int s_add_sat(s::cl_int x, s::cl_int y) __NOEXC { return __s_add_sat(x, y); }
-cl_long s_add_sat(s::cl_long x, s::cl_long y) __NOEXC {
+s::cl_int s_add_sat(s::cl_int x, s::cl_int y) __NOEXC {
+  return __s_add_sat(x, y);
+}
+s::cl_long s_add_sat(s::cl_long x, s::cl_long y) __NOEXC {
   return __s_add_sat(x, y);
 }
 MAKE_1V_2V(s_add_sat, s::cl_char, s::cl_char, s::cl_char)
@@ -327,63 +329,75 @@ MAKE_1V_2V(s_add_sat, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_add_sat, s::cl_long, s::cl_long, s::cl_long)
 
 // u_hadd
-cl_uchar u_hadd(s::cl_uchar x, s::cl_uchar y) __NOEXC { return __hadd(x, y); }
-cl_ushort u_hadd(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+s::cl_uchar u_hadd(s::cl_uchar x, s::cl_uchar y) __NOEXC {
   return __hadd(x, y);
 }
-cl_uint u_hadd(s::cl_uint x, s::cl_uint y) __NOEXC { return __hadd(x, y); }
-cl_ulong u_hadd(s::cl_ulong x, s::cl_ulong y) __NOEXC { return __hadd(x, y); }
+s::cl_ushort u_hadd(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+  return __hadd(x, y);
+}
+s::cl_uint u_hadd(s::cl_uint x, s::cl_uint y) __NOEXC { return __hadd(x, y); }
+s::cl_ulong u_hadd(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+  return __hadd(x, y);
+}
 MAKE_1V_2V(u_hadd, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_hadd, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_hadd, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_hadd, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_hadd
-cl_char s_hadd(s::cl_char x, s::cl_char y) __NOEXC { return __hadd(x, y); }
-cl_short s_hadd(s::cl_short x, s::cl_short y) __NOEXC { return __hadd(x, y); }
-cl_int s_hadd(s::cl_int x, s::cl_int y) __NOEXC { return __hadd(x, y); }
-cl_long s_hadd(s::cl_long x, s::cl_long y) __NOEXC { return __hadd(x, y); }
+s::cl_char s_hadd(s::cl_char x, s::cl_char y) __NOEXC { return __hadd(x, y); }
+s::cl_short s_hadd(s::cl_short x, s::cl_short y) __NOEXC {
+  return __hadd(x, y);
+}
+s::cl_int s_hadd(s::cl_int x, s::cl_int y) __NOEXC { return __hadd(x, y); }
+s::cl_long s_hadd(s::cl_long x, s::cl_long y) __NOEXC { return __hadd(x, y); }
 MAKE_1V_2V(s_hadd, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_hadd, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_hadd, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_hadd, s::cl_long, s::cl_long, s::cl_long)
 
 // u_rhadd
-cl_uchar u_rhadd(s::cl_uchar x, s::cl_uchar y) __NOEXC { return __rhadd(x, y); }
-cl_ushort u_rhadd(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+s::cl_uchar u_rhadd(s::cl_uchar x, s::cl_uchar y) __NOEXC {
   return __rhadd(x, y);
 }
-cl_uint u_rhadd(s::cl_uint x, s::cl_uint y) __NOEXC { return __rhadd(x, y); }
-cl_ulong u_rhadd(s::cl_ulong x, s::cl_ulong y) __NOEXC { return __rhadd(x, y); }
+s::cl_ushort u_rhadd(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+  return __rhadd(x, y);
+}
+s::cl_uint u_rhadd(s::cl_uint x, s::cl_uint y) __NOEXC { return __rhadd(x, y); }
+s::cl_ulong u_rhadd(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+  return __rhadd(x, y);
+}
 MAKE_1V_2V(u_rhadd, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_rhadd, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_rhadd, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_rhadd, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_rhadd
-cl_char s_rhadd(s::cl_char x, s::cl_char y) __NOEXC { return __rhadd(x, y); }
-cl_short s_rhadd(s::cl_short x, s::cl_short y) __NOEXC { return __rhadd(x, y); }
-cl_int s_rhadd(s::cl_int x, s::cl_int y) __NOEXC { return __rhadd(x, y); }
-cl_long s_rhadd(s::cl_long x, s::cl_long y) __NOEXC { return __rhadd(x, y); }
+s::cl_char s_rhadd(s::cl_char x, s::cl_char y) __NOEXC { return __rhadd(x, y); }
+s::cl_short s_rhadd(s::cl_short x, s::cl_short y) __NOEXC {
+  return __rhadd(x, y);
+}
+s::cl_int s_rhadd(s::cl_int x, s::cl_int y) __NOEXC { return __rhadd(x, y); }
+s::cl_long s_rhadd(s::cl_long x, s::cl_long y) __NOEXC { return __rhadd(x, y); }
 MAKE_1V_2V(s_rhadd, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_rhadd, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_rhadd, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_rhadd, s::cl_long, s::cl_long, s::cl_long)
 
 // u_clamp
-cl_uchar u_clamp(s::cl_uchar x, s::cl_uchar minval,
-                 s::cl_uchar maxval) __NOEXC {
+s::cl_uchar u_clamp(s::cl_uchar x, s::cl_uchar minval,
+                    s::cl_uchar maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
-cl_ushort u_clamp(s::cl_ushort x, s::cl_ushort minval,
-                  s::cl_ushort maxval) __NOEXC {
+s::cl_ushort u_clamp(s::cl_ushort x, s::cl_ushort minval,
+                     s::cl_ushort maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
-cl_uint u_clamp(s::cl_uint x, s::cl_uint minval, s::cl_uint maxval) __NOEXC {
+s::cl_uint u_clamp(s::cl_uint x, s::cl_uint minval, s::cl_uint maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
-cl_ulong u_clamp(s::cl_ulong x, s::cl_ulong minval,
-                 s::cl_ulong maxval) __NOEXC {
+s::cl_ulong u_clamp(s::cl_ulong x, s::cl_ulong minval,
+                    s::cl_ulong maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
 MAKE_1V_2V_3V(u_clamp, s::cl_uchar, s::cl_uchar, s::cl_uchar, s::cl_uchar)
@@ -396,17 +410,17 @@ MAKE_1V_2S_3S(u_clamp, s::cl_uint, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2S_3S(u_clamp, s::cl_ulong, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_clamp
-cl_char s_clamp(s::cl_char x, s::cl_char minval, s::cl_char maxval) __NOEXC {
+s::cl_char s_clamp(s::cl_char x, s::cl_char minval, s::cl_char maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
-cl_short s_clamp(s::cl_short x, s::cl_short minval,
-                 s::cl_short maxval) __NOEXC {
+s::cl_short s_clamp(s::cl_short x, s::cl_short minval,
+                    s::cl_short maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
-cl_int s_clamp(s::cl_int x, s::cl_int minval, s::cl_int maxval) __NOEXC {
+s::cl_int s_clamp(s::cl_int x, s::cl_int minval, s::cl_int maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
-cl_long s_clamp(s::cl_long x, s::cl_long minval, s::cl_long maxval) __NOEXC {
+s::cl_long s_clamp(s::cl_long x, s::cl_long minval, s::cl_long maxval) __NOEXC {
   return __clamp(x, minval, maxval);
 }
 MAKE_1V_2V_3V(s_clamp, s::cl_char, s::cl_char, s::cl_char, s::cl_char)
@@ -419,14 +433,14 @@ MAKE_1V_2S_3S(s_clamp, s::cl_int, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2S_3S(s_clamp, s::cl_long, s::cl_long, s::cl_long, s::cl_long)
 
 // clz
-cl_uchar clz(s::cl_uchar x) __NOEXC { return __clz(x); }
-cl_char clz(s::cl_char x) __NOEXC { return __clz(x); }
-cl_ushort clz(s::cl_ushort x) __NOEXC { return __clz(x); }
-cl_short clz(s::cl_short x) __NOEXC { return __clz(x); }
-cl_uint clz(s::cl_uint x) __NOEXC { return __clz(x); }
-cl_int clz(s::cl_int x) __NOEXC { return __clz(x); }
-cl_ulong clz(s::cl_ulong x) __NOEXC { return __clz(x); }
-cl_long clz(s::cl_long x) __NOEXC { return __clz(x); }
+s::cl_uchar clz(s::cl_uchar x) __NOEXC { return __clz(x); }
+s::cl_char clz(s::cl_char x) __NOEXC { return __clz(x); }
+s::cl_ushort clz(s::cl_ushort x) __NOEXC { return __clz(x); }
+s::cl_short clz(s::cl_short x) __NOEXC { return __clz(x); }
+s::cl_uint clz(s::cl_uint x) __NOEXC { return __clz(x); }
+s::cl_int clz(s::cl_int x) __NOEXC { return __clz(x); }
+s::cl_ulong clz(s::cl_ulong x) __NOEXC { return __clz(x); }
+s::cl_long clz(s::cl_long x) __NOEXC { return __clz(x); }
 MAKE_1V(clz, s::cl_uchar, s::cl_uchar)
 MAKE_1V(clz, s::cl_char, s::cl_char)
 MAKE_1V(clz, s::cl_ushort, s::cl_ushort)
@@ -455,10 +469,10 @@ MAKE_1V(ctz, s::cl_ulong, s::cl_ulong)
 MAKE_1V(ctz, s::cl_long, s::cl_long)
 
 // s_mul_hi
-cl_char s_mul_hi(cl_char a, cl_char b) { return __mul_hi(a, b); }
-cl_short s_mul_hi(cl_short a, cl_short b) { return __mul_hi(a, b); }
-cl_int s_mul_hi(cl_int a, cl_int b) { return __mul_hi(a, b); }
-cl_long s_mul_hi(s::cl_long x, s::cl_long y) __NOEXC {
+s::cl_char s_mul_hi(s::cl_char a, s::cl_char b) { return __mul_hi(a, b); }
+s::cl_short s_mul_hi(s::cl_short a, s::cl_short b) { return __mul_hi(a, b); }
+s::cl_int s_mul_hi(s::cl_int a, s::cl_int b) { return __mul_hi(a, b); }
+s::cl_long s_mul_hi(s::cl_long x, s::cl_long y) __NOEXC {
   return __s_long_mul_hi(x, y);
 }
 MAKE_1V_2V(s_mul_hi, s::cl_char, s::cl_char, s::cl_char)
@@ -467,10 +481,10 @@ MAKE_1V_2V(s_mul_hi, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_mul_hi, s::cl_long, s::cl_long, s::cl_long)
 
 // u_mul_hi
-cl_uchar u_mul_hi(cl_uchar a, cl_uchar b) { return __mul_hi(a, b); }
-cl_ushort u_mul_hi(cl_ushort a, cl_ushort b) { return __mul_hi(a, b); }
-cl_uint u_mul_hi(cl_uint a, cl_uint b) { return __mul_hi(a, b); }
-cl_ulong u_mul_hi(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+s::cl_uchar u_mul_hi(s::cl_uchar a, s::cl_uchar b) { return __mul_hi(a, b); }
+s::cl_ushort u_mul_hi(s::cl_ushort a, s::cl_ushort b) { return __mul_hi(a, b); }
+s::cl_uint u_mul_hi(s::cl_uint a, s::cl_uint b) { return __mul_hi(a, b); }
+s::cl_ulong u_mul_hi(s::cl_ulong x, s::cl_ulong y) __NOEXC {
   return __u_long_mul_hi(x, y);
 }
 MAKE_1V_2V(u_mul_hi, s::cl_uchar, s::cl_uchar, s::cl_uchar)
@@ -479,17 +493,19 @@ MAKE_1V_2V(u_mul_hi, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_mul_hi, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_mad_hi
-cl_char s_mad_hi(s::cl_char x, s::cl_char minval, s::cl_char maxval) __NOEXC {
+s::cl_char s_mad_hi(s::cl_char x, s::cl_char minval,
+                    s::cl_char maxval) __NOEXC {
   return __mad_hi(x, minval, maxval);
 }
-cl_short s_mad_hi(s::cl_short x, s::cl_short minval,
-                  s::cl_short maxval) __NOEXC {
+s::cl_short s_mad_hi(s::cl_short x, s::cl_short minval,
+                     s::cl_short maxval) __NOEXC {
   return __mad_hi(x, minval, maxval);
 }
-cl_int s_mad_hi(s::cl_int x, s::cl_int minval, s::cl_int maxval) __NOEXC {
+s::cl_int s_mad_hi(s::cl_int x, s::cl_int minval, s::cl_int maxval) __NOEXC {
   return __mad_hi(x, minval, maxval);
 }
-cl_long s_mad_hi(s::cl_long x, s::cl_long minval, s::cl_long maxval) __NOEXC {
+s::cl_long s_mad_hi(s::cl_long x, s::cl_long minval,
+                    s::cl_long maxval) __NOEXC {
   return __s_long_mad_hi(x, minval, maxval);
 }
 MAKE_1V_2V_3V(s_mad_hi, s::cl_char, s::cl_char, s::cl_char, s::cl_char)
@@ -498,19 +514,20 @@ MAKE_1V_2V_3V(s_mad_hi, s::cl_int, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V_3V(s_mad_hi, s::cl_long, s::cl_long, s::cl_long, s::cl_long)
 
 // u_mad_hi
-cl_uchar u_mad_hi(s::cl_uchar x, s::cl_uchar minval,
-                  s::cl_uchar maxval) __NOEXC {
+s::cl_uchar u_mad_hi(s::cl_uchar x, s::cl_uchar minval,
+                     s::cl_uchar maxval) __NOEXC {
   return __mad_hi(x, minval, maxval);
 }
-cl_ushort u_mad_hi(s::cl_ushort x, s::cl_ushort minval,
-                   s::cl_ushort maxval) __NOEXC {
+s::cl_ushort u_mad_hi(s::cl_ushort x, s::cl_ushort minval,
+                      s::cl_ushort maxval) __NOEXC {
   return __mad_hi(x, minval, maxval);
 }
-cl_uint u_mad_hi(s::cl_uint x, s::cl_uint minval, s::cl_uint maxval) __NOEXC {
+s::cl_uint u_mad_hi(s::cl_uint x, s::cl_uint minval,
+                    s::cl_uint maxval) __NOEXC {
   return __mad_hi(x, minval, maxval);
 }
-cl_ulong u_mad_hi(s::cl_ulong x, s::cl_ulong minval,
-                  s::cl_ulong maxval) __NOEXC {
+s::cl_ulong u_mad_hi(s::cl_ulong x, s::cl_ulong minval,
+                     s::cl_ulong maxval) __NOEXC {
   return __u_long_mad_hi(x, minval, maxval);
 }
 MAKE_1V_2V_3V(u_mad_hi, s::cl_uchar, s::cl_uchar, s::cl_uchar, s::cl_uchar)
@@ -519,16 +536,16 @@ MAKE_1V_2V_3V(u_mad_hi, s::cl_uint, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V_3V(u_mad_hi, s::cl_ulong, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_mad_sat
-cl_char s_mad_sat(s::cl_char a, s::cl_char b, s::cl_char c) __NOEXC {
+s::cl_char s_mad_sat(s::cl_char a, s::cl_char b, s::cl_char c) __NOEXC {
   return __s_mad_sat(a, b, c);
 }
-cl_short s_mad_sat(s::cl_short a, s::cl_short b, s::cl_short c) __NOEXC {
+s::cl_short s_mad_sat(s::cl_short a, s::cl_short b, s::cl_short c) __NOEXC {
   return __s_mad_sat(a, b, c);
 }
-cl_int s_mad_sat(s::cl_int a, s::cl_int b, s::cl_int c) __NOEXC {
+s::cl_int s_mad_sat(s::cl_int a, s::cl_int b, s::cl_int c) __NOEXC {
   return __s_mad_sat(a, b, c);
 }
-cl_long s_mad_sat(s::cl_long a, s::cl_long b, s::cl_long c) __NOEXC {
+s::cl_long s_mad_sat(s::cl_long a, s::cl_long b, s::cl_long c) __NOEXC {
   return __s_long_mad_sat(a, b, c);
 }
 MAKE_1V_2V_3V(s_mad_sat, s::cl_char, s::cl_char, s::cl_char, s::cl_char)
@@ -537,16 +554,16 @@ MAKE_1V_2V_3V(s_mad_sat, s::cl_int, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V_3V(s_mad_sat, s::cl_long, s::cl_long, s::cl_long, s::cl_long)
 
 // u_mad_sat
-cl_uchar u_mad_sat(s::cl_uchar a, s::cl_uchar b, s::cl_uchar c) __NOEXC {
+s::cl_uchar u_mad_sat(s::cl_uchar a, s::cl_uchar b, s::cl_uchar c) __NOEXC {
   return __u_mad_sat(a, b, c);
 }
-cl_ushort u_mad_sat(s::cl_ushort a, s::cl_ushort b, s::cl_ushort c) __NOEXC {
+s::cl_ushort u_mad_sat(s::cl_ushort a, s::cl_ushort b, s::cl_ushort c) __NOEXC {
   return __u_mad_sat(a, b, c);
 }
-cl_uint u_mad_sat(s::cl_uint a, s::cl_uint b, s::cl_uint c) __NOEXC {
+s::cl_uint u_mad_sat(s::cl_uint a, s::cl_uint b, s::cl_uint c) __NOEXC {
   return __u_mad_sat(a, b, c);
 }
-cl_ulong u_mad_sat(s::cl_ulong a, s::cl_ulong b, s::cl_ulong c) __NOEXC {
+s::cl_ulong u_mad_sat(s::cl_ulong a, s::cl_ulong b, s::cl_ulong c) __NOEXC {
   return __u_long_mad_sat(a, b, c);
 }
 MAKE_1V_2V_3V(u_mad_sat, s::cl_uchar, s::cl_uchar, s::cl_uchar, s::cl_uchar)
@@ -555,10 +572,12 @@ MAKE_1V_2V_3V(u_mad_sat, s::cl_uint, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V_3V(u_mad_sat, s::cl_ulong, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_max
-cl_char s_max(s::cl_char x, s::cl_char y) __NOEXC { return std::max(x, y); }
-cl_short s_max(s::cl_short x, s::cl_short y) __NOEXC { return std::max(x, y); }
-cl_int s_max(s::cl_int x, s::cl_int y) __NOEXC { return std::max(x, y); }
-cl_long s_max(s::cl_long x, s::cl_long y) __NOEXC { return std::max(x, y); }
+s::cl_char s_max(s::cl_char x, s::cl_char y) __NOEXC { return std::max(x, y); }
+s::cl_short s_max(s::cl_short x, s::cl_short y) __NOEXC {
+  return std::max(x, y);
+}
+s::cl_int s_max(s::cl_int x, s::cl_int y) __NOEXC { return std::max(x, y); }
+s::cl_long s_max(s::cl_long x, s::cl_long y) __NOEXC { return std::max(x, y); }
 MAKE_1V_2V(s_max, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_max, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_max, s::cl_int, s::cl_int, s::cl_int)
@@ -569,12 +588,16 @@ MAKE_1V_2S(s_max, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2S(s_max, s::cl_long, s::cl_long, s::cl_long)
 
 // u_max
-cl_uchar u_max(s::cl_uchar x, s::cl_uchar y) __NOEXC { return std::max(x, y); }
-cl_ushort u_max(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+s::cl_uchar u_max(s::cl_uchar x, s::cl_uchar y) __NOEXC {
   return std::max(x, y);
 }
-cl_uint u_max(s::cl_uint x, s::cl_uint y) __NOEXC { return std::max(x, y); }
-cl_ulong u_max(s::cl_ulong x, s::cl_ulong y) __NOEXC { return std::max(x, y); }
+s::cl_ushort u_max(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+  return std::max(x, y);
+}
+s::cl_uint u_max(s::cl_uint x, s::cl_uint y) __NOEXC { return std::max(x, y); }
+s::cl_ulong u_max(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+  return std::max(x, y);
+}
 MAKE_1V_2V(u_max, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_max, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_max, s::cl_uint, s::cl_uint, s::cl_uint)
@@ -585,10 +608,12 @@ MAKE_1V_2S(u_max, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2S(u_max, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_min
-cl_char s_min(s::cl_char x, s::cl_char y) __NOEXC { return std::min(x, y); }
-cl_short s_min(s::cl_short x, s::cl_short y) __NOEXC { return std::min(x, y); }
-cl_int s_min(s::cl_int x, s::cl_int y) __NOEXC { return std::min(x, y); }
-cl_long s_min(s::cl_long x, s::cl_long y) __NOEXC { return std::min(x, y); }
+s::cl_char s_min(s::cl_char x, s::cl_char y) __NOEXC { return std::min(x, y); }
+s::cl_short s_min(s::cl_short x, s::cl_short y) __NOEXC {
+  return std::min(x, y);
+}
+s::cl_int s_min(s::cl_int x, s::cl_int y) __NOEXC { return std::min(x, y); }
+s::cl_long s_min(s::cl_long x, s::cl_long y) __NOEXC { return std::min(x, y); }
 MAKE_1V_2V(s_min, s::cl_char, s::cl_char, s::cl_char)
 MAKE_1V_2V(s_min, s::cl_short, s::cl_short, s::cl_short)
 MAKE_1V_2V(s_min, s::cl_int, s::cl_int, s::cl_int)
@@ -599,12 +624,16 @@ MAKE_1V_2S(s_min, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2S(s_min, s::cl_long, s::cl_long, s::cl_long)
 
 // u_min
-cl_uchar u_min(s::cl_uchar x, s::cl_uchar y) __NOEXC { return std::min(x, y); }
-cl_ushort u_min(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+s::cl_uchar u_min(s::cl_uchar x, s::cl_uchar y) __NOEXC {
   return std::min(x, y);
 }
-cl_uint u_min(s::cl_uint x, s::cl_uint y) __NOEXC { return std::min(x, y); }
-cl_ulong u_min(s::cl_ulong x, s::cl_ulong y) __NOEXC { return std::min(x, y); }
+s::cl_ushort u_min(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+  return std::min(x, y);
+}
+s::cl_uint u_min(s::cl_uint x, s::cl_uint y) __NOEXC { return std::min(x, y); }
+s::cl_ulong u_min(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+  return std::min(x, y);
+}
 MAKE_1V_2V(u_min, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(u_min, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(u_min, s::cl_uint, s::cl_uint, s::cl_uint)
@@ -615,16 +644,22 @@ MAKE_1V_2S(u_min, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2S(u_min, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // rotate
-cl_uchar rotate(s::cl_uchar x, s::cl_uchar y) __NOEXC { return __rotate(x, y); }
-cl_ushort rotate(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+s::cl_uchar rotate(s::cl_uchar x, s::cl_uchar y) __NOEXC {
   return __rotate(x, y);
 }
-cl_uint rotate(s::cl_uint x, s::cl_uint y) __NOEXC { return __rotate(x, y); }
-cl_ulong rotate(s::cl_ulong x, s::cl_ulong y) __NOEXC { return __rotate(x, y); }
-cl_char rotate(s::cl_char x, s::cl_char y) __NOEXC { return __rotate(x, y); }
-cl_short rotate(s::cl_short x, s::cl_short y) __NOEXC { return __rotate(x, y); }
-cl_int rotate(s::cl_int x, s::cl_int y) __NOEXC { return __rotate(x, y); }
-cl_long rotate(s::cl_long x, s::cl_long y) __NOEXC { return __rotate(x, y); }
+s::cl_ushort rotate(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+  return __rotate(x, y);
+}
+s::cl_uint rotate(s::cl_uint x, s::cl_uint y) __NOEXC { return __rotate(x, y); }
+s::cl_ulong rotate(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+  return __rotate(x, y);
+}
+s::cl_char rotate(s::cl_char x, s::cl_char y) __NOEXC { return __rotate(x, y); }
+s::cl_short rotate(s::cl_short x, s::cl_short y) __NOEXC {
+  return __rotate(x, y);
+}
+s::cl_int rotate(s::cl_int x, s::cl_int y) __NOEXC { return __rotate(x, y); }
+s::cl_long rotate(s::cl_long x, s::cl_long y) __NOEXC { return __rotate(x, y); }
 MAKE_1V_2V(rotate, s::cl_uchar, s::cl_uchar, s::cl_uchar)
 MAKE_1V_2V(rotate, s::cl_ushort, s::cl_ushort, s::cl_ushort)
 MAKE_1V_2V(rotate, s::cl_uint, s::cl_uint, s::cl_uint)
@@ -635,16 +670,16 @@ MAKE_1V_2V(rotate, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(rotate, s::cl_long, s::cl_long, s::cl_long)
 
 // u_sub_sat
-cl_uchar u_sub_sat(s::cl_uchar x, s::cl_uchar y) __NOEXC {
+s::cl_uchar u_sub_sat(s::cl_uchar x, s::cl_uchar y) __NOEXC {
   return __u_sub_sat(x, y);
 }
-cl_ushort u_sub_sat(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+s::cl_ushort u_sub_sat(s::cl_ushort x, s::cl_ushort y) __NOEXC {
   return __u_sub_sat(x, y);
 }
-cl_uint u_sub_sat(s::cl_uint x, s::cl_uint y) __NOEXC {
+s::cl_uint u_sub_sat(s::cl_uint x, s::cl_uint y) __NOEXC {
   return __u_sub_sat(x, y);
 }
-cl_ulong u_sub_sat(s::cl_ulong x, s::cl_ulong y) __NOEXC {
+s::cl_ulong u_sub_sat(s::cl_ulong x, s::cl_ulong y) __NOEXC {
   return __u_sub_sat(x, y);
 }
 MAKE_1V_2V(u_sub_sat, s::cl_uchar, s::cl_uchar, s::cl_uchar)
@@ -653,14 +688,16 @@ MAKE_1V_2V(u_sub_sat, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(u_sub_sat, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_sub_sat
-cl_char s_sub_sat(s::cl_char x, s::cl_char y) __NOEXC {
+s::cl_char s_sub_sat(s::cl_char x, s::cl_char y) __NOEXC {
   return __s_sub_sat(x, y);
 }
-cl_short s_sub_sat(s::cl_short x, s::cl_short y) __NOEXC {
+s::cl_short s_sub_sat(s::cl_short x, s::cl_short y) __NOEXC {
   return __s_sub_sat(x, y);
 }
-cl_int s_sub_sat(s::cl_int x, s::cl_int y) __NOEXC { return __s_sub_sat(x, y); }
-cl_long s_sub_sat(s::cl_long x, s::cl_long y) __NOEXC {
+s::cl_int s_sub_sat(s::cl_int x, s::cl_int y) __NOEXC {
+  return __s_sub_sat(x, y);
+}
+s::cl_long s_sub_sat(s::cl_long x, s::cl_long y) __NOEXC {
   return __s_sub_sat(x, y);
 }
 MAKE_1V_2V(s_sub_sat, s::cl_char, s::cl_char, s::cl_char)
@@ -669,13 +706,13 @@ MAKE_1V_2V(s_sub_sat, s::cl_int, s::cl_int, s::cl_int)
 MAKE_1V_2V(s_sub_sat, s::cl_long, s::cl_long, s::cl_long)
 
 // u_upsample
-cl_ushort u_upsample(s::cl_uchar x, s::cl_uchar y) __NOEXC {
+s::cl_ushort u_upsample(s::cl_uchar x, s::cl_uchar y) __NOEXC {
   return __upsample(x, y);
 }
-cl_uint u_upsample(s::cl_ushort x, s::cl_ushort y) __NOEXC {
+s::cl_uint u_upsample(s::cl_ushort x, s::cl_ushort y) __NOEXC {
   return __upsample(x, y);
 }
-cl_ulong u_upsample(s::cl_uint x, s::cl_uint y) __NOEXC {
+s::cl_ulong u_upsample(s::cl_uint x, s::cl_uint y) __NOEXC {
   return __upsample(x, y);
 }
 MAKE_1V_2V(u_upsample, s::cl_ushort, s::cl_uchar, s::cl_uchar)
@@ -686,13 +723,13 @@ MAKE_1V_2V(u_upsample, s::cl_ulong, s::cl_uint, s::cl_uint)
 // ExtInst ... s_upsample -> _Z8upsampleij (now _Z8upsampleii)
 #define s_upsample u_upsample
 
-cl_short s_upsample(s::cl_char x, s::cl_uchar y) __NOEXC {
+s::cl_short s_upsample(s::cl_char x, s::cl_uchar y) __NOEXC {
   return __upsample(x, y);
 }
-cl_int s_upsample(s::cl_short x, s::cl_ushort y) __NOEXC {
+s::cl_int s_upsample(s::cl_short x, s::cl_ushort y) __NOEXC {
   return __upsample(x, y);
 }
-cl_long s_upsample(s::cl_int x, s::cl_uint y) __NOEXC {
+s::cl_long s_upsample(s::cl_int x, s::cl_uint y) __NOEXC {
   return __upsample(x, y);
 }
 MAKE_1V_2V(s_upsample, s::cl_short, s::cl_char, s::cl_uchar)
@@ -702,42 +739,42 @@ MAKE_1V_2V(s_upsample, s::cl_long, s::cl_int, s::cl_uint)
 #undef s_upsample
 
 // popcount
-cl_uchar popcount(s::cl_uchar x) __NOEXC { return __popcount(x); }
-cl_ushort popcount(s::cl_ushort x) __NOEXC { return __popcount(x); }
-cl_uint popcount(s::cl_uint x) __NOEXC { return __popcount(x); }
-cl_ulong popcount(s::cl_ulong x) __NOEXC { return __popcount(x); }
+s::cl_uchar popcount(s::cl_uchar x) __NOEXC { return __popcount(x); }
+s::cl_ushort popcount(s::cl_ushort x) __NOEXC { return __popcount(x); }
+s::cl_uint popcount(s::cl_uint x) __NOEXC { return __popcount(x); }
+s::cl_ulong popcount(s::cl_ulong x) __NOEXC { return __popcount(x); }
 MAKE_1V(popcount, s::cl_uchar, s::cl_uchar)
 MAKE_1V(popcount, s::cl_ushort, s::cl_ushort)
 MAKE_1V(popcount, s::cl_uint, s::cl_uint)
 MAKE_1V(popcount, s::cl_ulong, s::cl_ulong)
 
-cl_char popcount(s::cl_char x) __NOEXC { return __popcount(x); }
-cl_short popcount(s::cl_short x) __NOEXC { return __popcount(x); }
-cl_int popcount(s::cl_int x) __NOEXC { return __popcount(x); }
-cl_long popcount(s::cl_long x) __NOEXC { return __popcount(x); }
+s::cl_char popcount(s::cl_char x) __NOEXC { return __popcount(x); }
+s::cl_short popcount(s::cl_short x) __NOEXC { return __popcount(x); }
+s::cl_int popcount(s::cl_int x) __NOEXC { return __popcount(x); }
+s::cl_long popcount(s::cl_long x) __NOEXC { return __popcount(x); }
 MAKE_1V(popcount, s::cl_char, s::cl_char)
 MAKE_1V(popcount, s::cl_short, s::cl_short)
 MAKE_1V(popcount, s::cl_int, s::cl_int)
 MAKE_1V(popcount, s::cl_long, s::cl_long)
 
 // u_mad24
-cl_uint u_mad24(s::cl_uint x, s::cl_uint y, s::cl_uint z) __NOEXC {
+s::cl_uint u_mad24(s::cl_uint x, s::cl_uint y, s::cl_uint z) __NOEXC {
   return __mad24(x, y, z);
 }
 MAKE_1V_2V_3V(u_mad24, s::cl_uint, s::cl_uint, s::cl_uint, s::cl_uint)
 
 // s_mad24
-cl_int s_mad24(s::cl_int x, s::cl_int y, s::cl_int z) __NOEXC {
+s::cl_int s_mad24(s::cl_int x, s::cl_int y, s::cl_int z) __NOEXC {
   return __mad24(x, y, z);
 }
 MAKE_1V_2V_3V(s_mad24, s::cl_int, s::cl_int, s::cl_int, s::cl_int)
 
 // u_mul24
-cl_uint u_mul24(s::cl_uint x, s::cl_uint y) __NOEXC { return __mul24(x, y); }
+s::cl_uint u_mul24(s::cl_uint x, s::cl_uint y) __NOEXC { return __mul24(x, y); }
 MAKE_1V_2V(u_mul24, s::cl_uint, s::cl_uint, s::cl_uint)
 
 // s_mul24
-cl_int s_mul24(s::cl_int x, s::cl_int y) __NOEXC { return __mul24(x, y); }
+s::cl_int s_mul24(s::cl_int x, s::cl_int y) __NOEXC { return __mul24(x, y); }
 MAKE_1V_2V(s_mul24, s::cl_int, s::cl_int, s::cl_int)
 
 } // namespace __host_std

--- a/sycl/source/detail/builtins_math.cpp
+++ b/sycl/source/detail/builtins_math.cpp
@@ -561,10 +561,14 @@ MAKE_1V_2P(modf, s::cl_double, s::cl_double, s::cl_double)
 MAKE_1V_2P(modf, s::cl_half, s::cl_half, s::cl_half)
 
 // nan
-s::cl_float nan(s::cl_uint nancode) __NOEXC { return d::quiet_NaN<float>(); }
-s::cl_double nan(s::cl_ulong nancode) __NOEXC { return d::quiet_NaN<double>(); }
+s::cl_float nan(s::cl_uint nancode) __NOEXC {
+  return d::quiet_NaN<s::cl_float>();
+}
+s::cl_double nan(s::cl_ulong nancode) __NOEXC {
+  return d::quiet_NaN<s::cl_double>();
+}
 s::cl_half nan(s::cl_ushort nancode) __NOEXC {
-  return s::cl_half(d::quiet_NaN<float>());
+  return s::cl_half(d::quiet_NaN<s::cl_float>());
 }
 MAKE_1V(nan, s::cl_float, s::cl_uint)
 MAKE_1V(nan, s::cl_double, s::cl_ulong)

--- a/sycl/source/detail/builtins_relational.cpp
+++ b/sycl/source/detail/builtins_relational.cpp
@@ -24,15 +24,11 @@ template <typename T> inline T __vFOrdEqual(T x, T y) { return -(x == y); }
 
 template <typename T> inline T __sFOrdEqual(T x, T y) { return x == y; }
 
-template <typename T> inline T __vFUnordNotEqual(T x, T y) {
-  return -(x != y);
-}
+template <typename T> inline T __vFUnordNotEqual(T x, T y) { return -(x != y); }
 
 template <typename T> inline T __sFUnordNotEqual(T x, T y) { return x != y; }
 
-template <typename T> inline T __vFOrdGreaterThan(T x, T y) {
-  return -(x > y);
-}
+template <typename T> inline T __vFOrdGreaterThan(T x, T y) { return -(x > y); }
 
 template <typename T> inline T __sFOrdGreaterThan(T x, T y) { return x > y; }
 
@@ -48,9 +44,7 @@ template <typename T> inline T __vFOrdLessThanEqual(T x, T y) {
   return -(x <= y);
 }
 
-template <typename T> inline T __sFOrdLessThanEqual(T x, T y) {
-  return x <= y;
-}
+template <typename T> inline T __sFOrdLessThanEqual(T x, T y) { return x <= y; }
 
 template <typename T> inline T __vLessOrGreater(T x, T y) {
   return -((x < y) || (x > y));
@@ -60,8 +54,8 @@ template <typename T> inline T __sLessOrGreater(T x, T y) {
   return ((x < y) || (x > y));
 }
 
-template <typename T> cl_int inline __Any(T x) { return d::msbIsSet(x); }
-template <typename T> cl_int inline __All(T x) { return d::msbIsSet(x); }
+template <typename T> s::cl_int inline __Any(T x) { return d::msbIsSet(x); }
+template <typename T> s::cl_int inline __All(T x) { return d::msbIsSet(x); }
 
 template <typename T> inline T __vOrdered(T x, T y) {
   return -(
@@ -88,28 +82,28 @@ __bitselect(T a, T b, T c) {
 }
 
 template <typename T> union databitset;
-// float
-template <> union databitset<float> {
-  static_assert(sizeof(uint32_t) == sizeof(float),
-                "size of float is not equal to 32 bits.");
-  float f;
-  uint32_t i;
+// cl_float
+template <> union databitset<s::cl_float> {
+  static_assert(sizeof(s::cl_int) == sizeof(s::cl_float),
+                "size of cl_float is not equal to 32 bits(cl_int).");
+  s::cl_float f;
+  s::cl_int i;
 };
 
-// double
-template <> union databitset<double> {
-  static_assert(sizeof(uint64_t) == sizeof(double),
-                "size of double is not equal to 64 bits.");
-  double f;
-  uint64_t i;
+// cl_double
+template <> union databitset<s::cl_double> {
+  static_assert(sizeof(s::cl_long) == sizeof(s::cl_double),
+                "size of cl_double is not equal to 64 bits(cl_long).");
+  s::cl_double f;
+  s::cl_long i;
 };
 
-// half
+// cl_half
 template <> union databitset<s::cl_half> {
-  static_assert(sizeof(uint16_t) == sizeof(s::cl_half),
-                "size of half is not equal to 16 bits.");
+  static_assert(sizeof(s::cl_short) == sizeof(s::cl_half),
+                "size of cl_half is not equal to 16 bits(cl_short).");
   s::cl_half f;
-  uint16_t i;
+  s::cl_short i;
 };
 
 template <typename T>
@@ -138,30 +132,27 @@ template <typename T, typename T2> inline T2 __vSelect(T c, T2 b, T2 a) {
 
 // ---------- 4.13.7 Relational functions. Host implementations. ---------------
 // FOrdEqual-isequal
-cl_int FOrdEqual(s::cl_float x, s::cl_float y) __NOEXC {
+s::cl_int FOrdEqual(s::cl_float x, s::cl_float y) __NOEXC {
   return __sFOrdEqual(x, y);
 }
-cl_int FOrdEqual(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_int FOrdEqual(s::cl_double x, s::cl_double y) __NOEXC {
   return __sFOrdEqual(x, y);
 }
-cl_int FOrdEqual(s::cl_half x, s::cl_half y) __NOEXC {
+s::cl_int FOrdEqual(s::cl_half x, s::cl_half y) __NOEXC {
   return __sFOrdEqual(x, y);
 }
-MAKE_1V_2V_FUNC(FOrdEqual, __vFOrdEqual, s::cl_int, s::cl_float,
-                s::cl_float)
-MAKE_1V_2V_FUNC(FOrdEqual, __vFOrdEqual, s::cl_long, s::cl_double,
-                s::cl_double)
-MAKE_1V_2V_FUNC(FOrdEqual, __vFOrdEqual, s::cl_short, s::cl_half,
-                s::cl_half)
+MAKE_1V_2V_FUNC(FOrdEqual, __vFOrdEqual, s::cl_int, s::cl_float, s::cl_float)
+MAKE_1V_2V_FUNC(FOrdEqual, __vFOrdEqual, s::cl_long, s::cl_double, s::cl_double)
+MAKE_1V_2V_FUNC(FOrdEqual, __vFOrdEqual, s::cl_short, s::cl_half, s::cl_half)
 
 // FUnordNotEqual-isnotequal
-cl_int FUnordNotEqual(s::cl_float x, s::cl_float y) __NOEXC {
+s::cl_int FUnordNotEqual(s::cl_float x, s::cl_float y) __NOEXC {
   return __sFUnordNotEqual(x, y);
 }
-cl_int FUnordNotEqual(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_int FUnordNotEqual(s::cl_double x, s::cl_double y) __NOEXC {
   return __sFUnordNotEqual(x, y);
 }
-cl_int FUnordNotEqual(s::cl_half x, s::cl_half y) __NOEXC {
+s::cl_int FUnordNotEqual(s::cl_half x, s::cl_half y) __NOEXC {
   return __sFUnordNotEqual(x, y);
 }
 MAKE_1V_2V_FUNC(FUnordNotEqual, __vFUnordNotEqual, s::cl_int, s::cl_float,
@@ -172,30 +163,30 @@ MAKE_1V_2V_FUNC(FUnordNotEqual, __vFUnordNotEqual, s::cl_short, s::cl_half,
                 s::cl_half)
 
 // (FOrdGreaterThan)      // isgreater
-cl_int FOrdGreaterThan(s::cl_float x, s::cl_float y) __NOEXC {
+s::cl_int FOrdGreaterThan(s::cl_float x, s::cl_float y) __NOEXC {
   return __sFOrdGreaterThan(x, y);
 }
-cl_int FOrdGreaterThan(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_int FOrdGreaterThan(s::cl_double x, s::cl_double y) __NOEXC {
   return __sFOrdGreaterThan(x, y);
 }
-cl_int FOrdGreaterThan(s::cl_half x, s::cl_half y) __NOEXC {
+s::cl_int FOrdGreaterThan(s::cl_half x, s::cl_half y) __NOEXC {
   return __sFOrdGreaterThan(x, y);
 }
 MAKE_1V_2V_FUNC(FOrdGreaterThan, __vFOrdGreaterThan, s::cl_int, s::cl_float,
                 s::cl_float)
-MAKE_1V_2V_FUNC(FOrdGreaterThan, __vFOrdGreaterThan, s::cl_long,
-                s::cl_double, s::cl_double)
-MAKE_1V_2V_FUNC(FOrdGreaterThan, __vFOrdGreaterThan, s::cl_short,
-                s::cl_half, s::cl_half)
+MAKE_1V_2V_FUNC(FOrdGreaterThan, __vFOrdGreaterThan, s::cl_long, s::cl_double,
+                s::cl_double)
+MAKE_1V_2V_FUNC(FOrdGreaterThan, __vFOrdGreaterThan, s::cl_short, s::cl_half,
+                s::cl_half)
 
 // (FOrdGreaterThanEqual) // isgreaterequal
-cl_int FOrdGreaterThanEqual(s::cl_float x, s::cl_float y) __NOEXC {
+s::cl_int FOrdGreaterThanEqual(s::cl_float x, s::cl_float y) __NOEXC {
   return __sFOrdGreaterThanEqual(x, y);
 }
-cl_int FOrdGreaterThanEqual(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_int FOrdGreaterThanEqual(s::cl_double x, s::cl_double y) __NOEXC {
   return __sFOrdGreaterThanEqual(x, y);
 }
-cl_int FOrdGreaterThanEqual(s::cl_half x, s::cl_half y) __NOEXC {
+s::cl_int FOrdGreaterThanEqual(s::cl_half x, s::cl_half y) __NOEXC {
   return __sFOrdGreaterThanEqual(x, y);
 }
 MAKE_1V_2V_FUNC(FOrdGreaterThanEqual, __vFOrdGreaterThanEqual, s::cl_int,
@@ -206,18 +197,18 @@ MAKE_1V_2V_FUNC(FOrdGreaterThanEqual, __vFOrdGreaterThanEqual, s::cl_short,
                 s::cl_half, s::cl_half)
 
 // (FOrdLessThan)         // isless
-cl_int FOrdLessThan(s::cl_float x, s::cl_float y) __NOEXC { return (x < y); }
-cl_int FOrdLessThan(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_int FOrdLessThan(s::cl_float x, s::cl_float y) __NOEXC { return (x < y); }
+s::cl_int FOrdLessThan(s::cl_double x, s::cl_double y) __NOEXC {
   return (x < y);
 }
-cl_int __vFOrdLessThan(s::cl_float x, s::cl_float y) __NOEXC {
+s::cl_int __vFOrdLessThan(s::cl_float x, s::cl_float y) __NOEXC {
   return -(x < y);
 }
-cl_long __vFOrdLessThan(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_long __vFOrdLessThan(s::cl_double x, s::cl_double y) __NOEXC {
   return -(x < y);
 }
-cl_int FOrdLessThan(s::cl_half x, s::cl_half y) __NOEXC { return (x < y); }
-cl_short __vFOrdLessThan(s::cl_half x, s::cl_half y) __NOEXC {
+s::cl_int FOrdLessThan(s::cl_half x, s::cl_half y) __NOEXC { return (x < y); }
+s::cl_short __vFOrdLessThan(s::cl_half x, s::cl_half y) __NOEXC {
   return -(x < y);
 }
 MAKE_1V_2V_FUNC(FOrdLessThan, __vFOrdLessThan, s::cl_int, s::cl_float,
@@ -228,30 +219,30 @@ MAKE_1V_2V_FUNC(FOrdLessThan, __vFOrdLessThan, s::cl_short, s::cl_half,
                 s::cl_half)
 
 // (FOrdLessThanEqual)    // islessequal
-cl_int FOrdLessThanEqual(s::cl_float x, s::cl_float y) __NOEXC {
+s::cl_int FOrdLessThanEqual(s::cl_float x, s::cl_float y) __NOEXC {
   return __sFOrdLessThanEqual(x, y);
 }
-cl_int FOrdLessThanEqual(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_int FOrdLessThanEqual(s::cl_double x, s::cl_double y) __NOEXC {
   return __sFOrdLessThanEqual(x, y);
 }
-cl_int FOrdLessThanEqual(s::cl_half x, s::cl_half y) __NOEXC {
+s::cl_int FOrdLessThanEqual(s::cl_half x, s::cl_half y) __NOEXC {
   return __sFOrdLessThanEqual(x, y);
 }
-MAKE_1V_2V_FUNC(FOrdLessThanEqual, __vFOrdLessThanEqual, s::cl_int,
-                s::cl_float, s::cl_float)
+MAKE_1V_2V_FUNC(FOrdLessThanEqual, __vFOrdLessThanEqual, s::cl_int, s::cl_float,
+                s::cl_float)
 MAKE_1V_2V_FUNC(FOrdLessThanEqual, __vFOrdLessThanEqual, s::cl_long,
                 s::cl_double, s::cl_double)
 MAKE_1V_2V_FUNC(FOrdLessThanEqual, __vFOrdLessThanEqual, s::cl_short,
                 s::cl_half, s::cl_half)
 
 // (LessOrGreater)        // islessgreater
-cl_int LessOrGreater(s::cl_float x, s::cl_float y) __NOEXC {
+s::cl_int LessOrGreater(s::cl_float x, s::cl_float y) __NOEXC {
   return __sLessOrGreater(x, y);
 }
-cl_int LessOrGreater(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_int LessOrGreater(s::cl_double x, s::cl_double y) __NOEXC {
   return __sLessOrGreater(x, y);
 }
-cl_int LessOrGreater(s::cl_half x, s::cl_half y) __NOEXC {
+s::cl_int LessOrGreater(s::cl_half x, s::cl_half y) __NOEXC {
   return __sLessOrGreater(x, y);
 }
 MAKE_1V_2V_FUNC(LessOrGreater, __vLessOrGreater, s::cl_int, s::cl_float,
@@ -262,90 +253,90 @@ MAKE_1V_2V_FUNC(LessOrGreater, __vLessOrGreater, s::cl_short, s::cl_half,
                 s::cl_half)
 
 // (IsFinite)             // isfinite
-cl_int IsFinite(s::cl_float x) __NOEXC { return std::isfinite(x); }
-cl_int IsFinite(s::cl_double x) __NOEXC { return std::isfinite(x); }
-cl_int __vIsFinite(s::cl_float x) __NOEXC {
-  return -static_cast<cl_int>(std::isfinite(x));
+s::cl_int IsFinite(s::cl_float x) __NOEXC { return std::isfinite(x); }
+s::cl_int IsFinite(s::cl_double x) __NOEXC { return std::isfinite(x); }
+s::cl_int __vIsFinite(s::cl_float x) __NOEXC {
+  return -static_cast<s::cl_int>(std::isfinite(x));
 }
-cl_long __vIsFinite(s::cl_double x) __NOEXC {
-  return -static_cast<cl_long>(std::isfinite(x));
+s::cl_long __vIsFinite(s::cl_double x) __NOEXC {
+  return -static_cast<s::cl_long>(std::isfinite(x));
 }
-cl_int IsFinite(s::cl_half x) __NOEXC {
+s::cl_int IsFinite(s::cl_half x) __NOEXC {
   return std::isfinite(d::cast_if_host_half(x));
 }
-cl_short __vIsFinite(s::cl_half x) __NOEXC {
-  return -static_cast<cl_int>(std::isfinite(d::cast_if_host_half(x)));
+s::cl_short __vIsFinite(s::cl_half x) __NOEXC {
+  return -static_cast<s::cl_int>(std::isfinite(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(IsFinite, __vIsFinite, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(IsFinite, __vIsFinite, s::cl_long, s::cl_double)
 MAKE_1V_FUNC(IsFinite, __vIsFinite, s::cl_short, s::cl_half)
 
 // (IsInf)                // isinf
-cl_int IsInf(s::cl_float x) __NOEXC { return std::isinf(x); }
-cl_int IsInf(s::cl_double x) __NOEXC { return std::isinf(x); }
-cl_int __vIsInf(s::cl_float x) __NOEXC {
-  return -static_cast<cl_int>(std::isinf(x));
+s::cl_int IsInf(s::cl_float x) __NOEXC { return std::isinf(x); }
+s::cl_int IsInf(s::cl_double x) __NOEXC { return std::isinf(x); }
+s::cl_int __vIsInf(s::cl_float x) __NOEXC {
+  return -static_cast<s::cl_int>(std::isinf(x));
 }
-cl_long __vIsInf(s::cl_double x) __NOEXC {
-  return -static_cast<cl_long>(std::isinf(x));
+s::cl_long __vIsInf(s::cl_double x) __NOEXC {
+  return -static_cast<s::cl_long>(std::isinf(x));
 }
-cl_int IsInf(s::cl_half x) __NOEXC {
+s::cl_int IsInf(s::cl_half x) __NOEXC {
   return std::isinf(d::cast_if_host_half(x));
 }
-cl_short __vIsInf(s::cl_half x) __NOEXC {
-  return -static_cast<cl_short>(std::isinf(d::cast_if_host_half(x)));
+s::cl_short __vIsInf(s::cl_half x) __NOEXC {
+  return -static_cast<s::cl_short>(std::isinf(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(IsInf, __vIsInf, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(IsInf, __vIsInf, s::cl_long, s::cl_double)
 MAKE_1V_FUNC(IsInf, __vIsInf, s::cl_short, s::cl_half)
 
 // (IsNan)                // isnan
-cl_int IsNan(s::cl_float x) __NOEXC { return std::isnan(x); }
-cl_int IsNan(s::cl_double x) __NOEXC { return std::isnan(x); }
-cl_int __vIsNan(s::cl_float x) __NOEXC {
-  return -static_cast<cl_int>(std::isnan(x));
+s::cl_int IsNan(s::cl_float x) __NOEXC { return std::isnan(x); }
+s::cl_int IsNan(s::cl_double x) __NOEXC { return std::isnan(x); }
+s::cl_int __vIsNan(s::cl_float x) __NOEXC {
+  return -static_cast<s::cl_int>(std::isnan(x));
 }
-cl_long __vIsNan(s::cl_double x) __NOEXC {
-  return -static_cast<cl_long>(std::isnan(x));
+s::cl_long __vIsNan(s::cl_double x) __NOEXC {
+  return -static_cast<s::cl_long>(std::isnan(x));
 }
 
-cl_int IsNan(s::cl_half x) __NOEXC {
+s::cl_int IsNan(s::cl_half x) __NOEXC {
   return std::isnan(d::cast_if_host_half(x));
 }
-cl_short __vIsNan(s::cl_half x) __NOEXC {
-  return -static_cast<cl_short>(std::isnan(d::cast_if_host_half(x)));
+s::cl_short __vIsNan(s::cl_half x) __NOEXC {
+  return -static_cast<s::cl_short>(std::isnan(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(IsNan, __vIsNan, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(IsNan, __vIsNan, s::cl_long, s::cl_double)
 MAKE_1V_FUNC(IsNan, __vIsNan, s::cl_short, s::cl_half)
 
 // (IsNormal)             // isnormal
-cl_int IsNormal(s::cl_float x) __NOEXC { return std::isnormal(x); }
-cl_int IsNormal(s::cl_double x) __NOEXC { return std::isnormal(x); }
-cl_int __vIsNormal(s::cl_float x) __NOEXC {
-  return -static_cast<cl_int>(std::isnormal(x));
+s::cl_int IsNormal(s::cl_float x) __NOEXC { return std::isnormal(x); }
+s::cl_int IsNormal(s::cl_double x) __NOEXC { return std::isnormal(x); }
+s::cl_int __vIsNormal(s::cl_float x) __NOEXC {
+  return -static_cast<s::cl_int>(std::isnormal(x));
 }
-cl_long __vIsNormal(s::cl_double x) __NOEXC {
-  return -static_cast<cl_long>(std::isnormal(x));
+s::cl_long __vIsNormal(s::cl_double x) __NOEXC {
+  return -static_cast<s::cl_long>(std::isnormal(x));
 }
-cl_int IsNormal(s::cl_half x) __NOEXC {
+s::cl_int IsNormal(s::cl_half x) __NOEXC {
   return std::isnormal(d::cast_if_host_half(x));
 }
-cl_short __vIsNormal(s::cl_half x) __NOEXC {
-  return -static_cast<cl_short>(std::isnormal(d::cast_if_host_half(x)));
+s::cl_short __vIsNormal(s::cl_half x) __NOEXC {
+  return -static_cast<s::cl_short>(std::isnormal(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(IsNormal, __vIsNormal, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(IsNormal, __vIsNormal, s::cl_long, s::cl_double)
 MAKE_1V_FUNC(IsNormal, __vIsNormal, s::cl_short, s::cl_half)
 
 // (Ordered)              // isordered
-cl_int Ordered(s::cl_float x, s::cl_float y) __NOEXC {
+s::cl_int Ordered(s::cl_float x, s::cl_float y) __NOEXC {
   return __vOrdered(x, y);
 }
-cl_int Ordered(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_int Ordered(s::cl_double x, s::cl_double y) __NOEXC {
   return __vOrdered(x, y);
 }
-cl_int Ordered(s::cl_half x, s::cl_half y) __NOEXC {
+s::cl_int Ordered(s::cl_half x, s::cl_half y) __NOEXC {
   return __vOrdered(x, y);
 }
 MAKE_1V_2V_FUNC(Ordered, __vOrdered, s::cl_int, s::cl_float, s::cl_float)
@@ -353,36 +344,33 @@ MAKE_1V_2V_FUNC(Ordered, __vOrdered, s::cl_long, s::cl_double, s::cl_double)
 MAKE_1V_2V_FUNC(Ordered, __vOrdered, s::cl_short, s::cl_half, s::cl_half)
 
 // (Unordered)            // isunordered
-cl_int Unordered(s::cl_float x, s::cl_float y) __NOEXC {
+s::cl_int Unordered(s::cl_float x, s::cl_float y) __NOEXC {
   return __sUnordered(x, y);
 }
-cl_int Unordered(s::cl_double x, s::cl_double y) __NOEXC {
+s::cl_int Unordered(s::cl_double x, s::cl_double y) __NOEXC {
   return __sUnordered(x, y);
 }
-cl_int Unordered(s::cl_half x, s::cl_half y) __NOEXC {
+s::cl_int Unordered(s::cl_half x, s::cl_half y) __NOEXC {
   return __sUnordered(x, y);
 }
-MAKE_1V_2V_FUNC(Unordered, __vUnordered, s::cl_int, s::cl_float,
-                s::cl_float)
-MAKE_1V_2V_FUNC(Unordered, __vUnordered, s::cl_long, s::cl_double,
-                s::cl_double)
-MAKE_1V_2V_FUNC(Unordered, __vUnordered, s::cl_short, s::cl_half,
-                s::cl_half)
+MAKE_1V_2V_FUNC(Unordered, __vUnordered, s::cl_int, s::cl_float, s::cl_float)
+MAKE_1V_2V_FUNC(Unordered, __vUnordered, s::cl_long, s::cl_double, s::cl_double)
+MAKE_1V_2V_FUNC(Unordered, __vUnordered, s::cl_short, s::cl_half, s::cl_half)
 
 // (SignBitSet)           // signbit
-cl_int SignBitSet(s::cl_float x) __NOEXC { return std::signbit(x); }
-cl_int SignBitSet(s::cl_double x) __NOEXC { return std::signbit(x); }
-cl_int __vSignBitSet(s::cl_float x) __NOEXC {
-  return -static_cast<cl_int>(std::signbit(x));
+s::cl_int SignBitSet(s::cl_float x) __NOEXC { return std::signbit(x); }
+s::cl_int SignBitSet(s::cl_double x) __NOEXC { return std::signbit(x); }
+s::cl_int __vSignBitSet(s::cl_float x) __NOEXC {
+  return -static_cast<s::cl_int>(std::signbit(x));
 }
-cl_long __vSignBitSet(s::cl_double x) __NOEXC {
-  return -static_cast<cl_long>(std::signbit(x));
+s::cl_long __vSignBitSet(s::cl_double x) __NOEXC {
+  return -static_cast<s::cl_long>(std::signbit(x));
 }
-cl_int SignBitSet(s::cl_half x) __NOEXC {
+s::cl_int SignBitSet(s::cl_half x) __NOEXC {
   return std::signbit(d::cast_if_host_half(x));
 }
-cl_short __vSignBitSet(s::cl_half x) __NOEXC {
-  return -static_cast<cl_short>(std::signbit(d::cast_if_host_half(x)));
+s::cl_short __vSignBitSet(s::cl_half x) __NOEXC {
+  return -static_cast<s::cl_short>(std::signbit(d::cast_if_host_half(x)));
 }
 MAKE_1V_FUNC(SignBitSet, __vSignBitSet, s::cl_int, s::cl_float)
 MAKE_1V_FUNC(SignBitSet, __vSignBitSet, s::cl_long, s::cl_double)
@@ -419,20 +407,20 @@ MAKE_SC_1V_2V_3V(bitselect, s::cl_half, s::cl_half, s::cl_half, s::cl_half)
 // (Select) // select
 // for scalar: result = c ? b : a.
 // for vector: result[i] = (MSB of c[i] is set)? b[i] : a[i]
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_float, s::cl_int,
-                        s::cl_float, s::cl_float)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_float, s::cl_uint,
-                        s::cl_float, s::cl_float)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_float, s::cl_int, s::cl_float,
+                        s::cl_float)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_float, s::cl_uint, s::cl_float,
+                        s::cl_float)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_double, s::cl_long,
                         s::cl_double, s::cl_double)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_double, s::cl_ulong,
                         s::cl_double, s::cl_double)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_char, s::cl_char,
-                        s::cl_char, s::cl_char)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_char, s::cl_uchar,
-                        s::cl_char, s::cl_char)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uchar, s::cl_char,
-                        s::cl_uchar, s::cl_uchar)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_char, s::cl_char, s::cl_char,
+                        s::cl_char)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_char, s::cl_uchar, s::cl_char,
+                        s::cl_char)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uchar, s::cl_char, s::cl_uchar,
+                        s::cl_uchar)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uchar, s::cl_uchar,
                         s::cl_uchar, s::cl_uchar)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_short, s::cl_short,
@@ -447,21 +435,21 @@ MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_int, s::cl_int, s::cl_int,
                         s::cl_int)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_int, s::cl_uint, s::cl_int,
                         s::cl_int)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uint, s::cl_int,
-                        s::cl_uint, s::cl_uint)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uint, s::cl_uint,
-                        s::cl_uint, s::cl_uint)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_long, s::cl_long,
-                        s::cl_long, s::cl_long)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_long, s::cl_ulong,
-                        s::cl_long, s::cl_long)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_ulong, s::cl_long,
-                        s::cl_ulong, s::cl_ulong)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uint, s::cl_int, s::cl_uint,
+                        s::cl_uint)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uint, s::cl_uint, s::cl_uint,
+                        s::cl_uint)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_long, s::cl_long, s::cl_long,
+                        s::cl_long)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_long, s::cl_ulong, s::cl_long,
+                        s::cl_long)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_ulong, s::cl_long, s::cl_ulong,
+                        s::cl_ulong)
 MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_ulong, s::cl_ulong,
                         s::cl_ulong, s::cl_ulong)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_half, s::cl_short,
-                        s::cl_half, s::cl_half)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_half, s::cl_ushort,
-                        s::cl_half, s::cl_half)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_half, s::cl_short, s::cl_half,
+                        s::cl_half)
+MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_half, s::cl_ushort, s::cl_half,
+                        s::cl_half)
 } // namespace __host_std
 } // namespace cl

--- a/sycl/test/basic_tests/generic_type_traits.cpp
+++ b/sycl/test/basic_tests/generic_type_traits.cpp
@@ -183,49 +183,58 @@ int main() {
   float_point_to_sign_integeral
 
   make_unsigned
-  make_upper
+  make_larger
   */
 
   // checks for some type conversions.
-  static_assert(std::is_same<d::SelectMatchingOpenCLType_t<s::cl_int>,
-                s::cl_int>::value, "");
+  static_assert(
+      std::is_same<d::SelectMatchingOpenCLType_t<s::cl_int>, s::cl_int>::value,
+      "");
 
   static_assert(
-    std::is_same<d::SelectMatchingOpenCLType_t<s::vec<s::cl_int, 2>>,
-    s::vec<s::cl_int, 2>>::value, "");
+      std::is_same<d::SelectMatchingOpenCLType_t<s::vec<s::cl_int, 2>>,
+                   s::vec<s::cl_int, 2>>::value,
+      "");
 
   static_assert(
-    std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<s::cl_int,
-      s::access::address_space::global_space>>,
-    s::multi_ptr<s::cl_int,
-      s::access::address_space::global_space>>::value, "");
+      std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<
+                       s::cl_int, s::access::address_space::global_space>>,
+                   s::multi_ptr<s::cl_int,
+                                s::access::address_space::global_space>>::value,
+      "");
 
   static_assert(
-    std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<s::vec<s::cl_int, 2>,
-      s::access::address_space::global_space>>,
-    s::multi_ptr<s::vec<s::cl_int, 2>,
-      s::access::address_space::global_space>>::value, "");
-  
-  static_assert(
-    std::is_same<d::SelectMatchingOpenCLType_t<s::longlong>,
-    s::cl_long>::value, "");
+      std::is_same<
+          d::SelectMatchingOpenCLType_t<s::multi_ptr<
+              s::vec<s::cl_int, 2>, s::access::address_space::global_space>>,
+          s::multi_ptr<s::vec<s::cl_int, 2>,
+                       s::access::address_space::global_space>>::value,
+      "");
+
+  static_assert(std::is_same<d::SelectMatchingOpenCLType_t<s::longlong>,
+                             s::cl_long>::value,
+                "");
 
   static_assert(
-    std::is_same<d::SelectMatchingOpenCLType_t<s::vec<s::longlong, 2>>,
-    s::vec<s::cl_long, 2>>::value, "");
+      std::is_same<d::SelectMatchingOpenCLType_t<s::vec<s::longlong, 2>>,
+                   s::vec<s::cl_long, 2>>::value,
+      "");
 
   static_assert(
-    std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<s::longlong,
-      s::access::address_space::global_space>>,
-    s::multi_ptr<s::cl_long,
-      s::access::address_space::global_space>>::value, "");
+      std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<
+                       s::longlong, s::access::address_space::global_space>>,
+                   s::multi_ptr<s::cl_long,
+                                s::access::address_space::global_space>>::value,
+      "");
 
   static_assert(
-    std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<s::vec<s::longlong, 2>,
-      s::access::address_space::global_space>>,
-    s::multi_ptr<s::vec<s::cl_long, 2>,
-      s::access::address_space::global_space>>::value, "");
+      std::is_same<
+          d::SelectMatchingOpenCLType_t<s::multi_ptr<
+              s::vec<s::longlong, 2>, s::access::address_space::global_space>>,
+          s::multi_ptr<s::vec<s::cl_long, 2>,
+                       s::access::address_space::global_space>>::value,
+      "");
 
   s::multi_ptr<int, s::access::address_space::global_space> mp;
-  int * dp = mp;
+  int *dp = mp;
 }

--- a/sycl/test/built-ins/nan.cpp
+++ b/sycl/test/built-ins/nan.cpp
@@ -1,0 +1,72 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -D HALF_IS_SUPPORTED %s -o %t_gpu.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+
+#include <cassert>
+
+namespace s = cl::sycl;
+using namespace std;
+
+template <typename T, typename R, bool Expected = true> void test_nan_call() {
+  static_assert(is_same<decltype(s::nan(T{0})), R>::value == Expected, "");
+}
+
+template <typename, typename> struct test;
+
+template <typename T, typename R> void check_nan(s::queue &Queue) {
+  R Data{0};
+  s::vec<R, 2> VData{0};
+  {
+    s::buffer<R, 1> Buf(&Data, s::range<1>(1));
+    s::buffer<s::vec<R, 2>, 1> VBuf(&VData, s::range<1>(1));
+    Queue.submit([&](s::handler &Cgh) {
+      auto Acc = Buf.template get_access<s::access::mode::write>(Cgh);
+      auto VAcc = VBuf.template get_access<s::access::mode::write>(Cgh);
+      Cgh.single_task<test<T, R>>([=]() {
+        Acc[0] = s::nan(T{0});
+        VAcc[0] = s::nan(s::vec<T, 2>{0});
+      });
+    });
+    Queue.wait_and_throw();
+  }
+  assert(s::isnan(Data));
+  assert(s::all(s::isnan(VData)));
+}
+
+int main() {
+  test_nan_call<s::ushort, half>();
+  test_nan_call<s::uint, float>();
+  test_nan_call<s::ulong, double>();
+  test_nan_call<s::ulonglong, double>();
+  test_nan_call<s::ushort2, s::half2>();
+  test_nan_call<s::uint2, s::float2>();
+  test_nan_call<s::ulong2, s::double2>();
+  test_nan_call<s::ulonglong2, s::double2>();
+
+  s::queue Queue([](cl::sycl::exception_list ExceptionList) {
+    for (cl::sycl::exception_ptr_class ExceptionPtr : ExceptionList) {
+      try {
+        std::rethrow_exception(ExceptionPtr);
+      } catch (cl::sycl::exception &E) {
+        std::cerr << E.what() << std::endl;
+      } catch (...) {
+        std::cerr << "Unknown async exception was caught." << std::endl;
+      }
+    }
+  });
+#ifdef HALF_IS_SUPPORTED
+  if (Queue.get_device().has_extension("cl_khr_fp16"))
+    check_nan<unsigned short, half>(Queue);
+#endif
+  check_nan<unsigned int, float>(Queue);
+  if (Queue.get_device().has_extension("cl_khr_fp64")) {
+    check_nan<unsigned long, double>(Queue);
+    check_nan<unsigned long long, double>(Queue);
+  }
+  return 0;
+}

--- a/sycl/test/built-ins/scalar_math.cpp
+++ b/sycl/test/built-ins/scalar_math.cpp
@@ -620,19 +620,5 @@ int main() {
     assert(i == -1); // tgamma of -2.4 is ~-1.1080299470333461
   }
 
-  // nan
-  {
-    s::cl_double r{ 0 };
-    {
-      s::buffer<s::cl_double, 1> BufR(&r, s::range<1>(1));
-      s::queue myQueue;
-      myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class nanIS1>([=]() { AccR[0] = s::nan(1LLU); });
-      });
-    }
-    assert(std::isnan(r));
-  }
-
   return 0;
 }

--- a/sycl/test/built-ins/vector_math.cpp
+++ b/sycl/test/built-ins/vector_math.cpp
@@ -203,47 +203,5 @@ int main() {
     assert(i2 == -1); // tgamma of -2.4 is ~-1.1080299470333461
   }
 
-  // nan (ulong)
-  {
-    // Result type depends on the ulong type size which varies across targets.
-    // It is a 64-bit type on Linux and 32-bit on Windows.
-    using res_scalar_t = std::conditional<sizeof(s::ulong) == sizeof(float),
-                                          s::cl_float, s::cl_double>::type;
-    using res_vector_t = s::vec<res_scalar_t, 2>;
-
-    res_vector_t r{ 0 };
-    {
-      s::buffer<res_vector_t, 1> BufR(&r, s::range<1>(1));
-      s::queue myQueue;
-      myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        s::ulong2 in{1, 1};
-        cgh.single_task<class nanISUL2>([=]() { AccR[0] = s::nan(in); });
-      });
-    }
-    res_scalar_t x = r.x();
-    res_scalar_t y = r.y();
-    assert(std::isnan(x));
-    assert(std::isnan(y));
-  }
-
-  // nan (ulonglong)
-  {
-    s::cl_double2 r{ 0 };
-    {
-      s::buffer<s::cl_double2, 1> BufR(&r, s::range<1>(1));
-      s::queue myQueue;
-      myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        s::ulonglong2 in{1ULL, 1ULL};
-        cgh.single_task<class nanISULL2>([=]() { AccR[0] = s::nan(in); });
-      });
-    }
-    s::cl_double x = r.x();
-    s::cl_double y = r.y();
-    assert(std::isnan(x));
-    assert(std::isnan(y));
-  }
-
   return 0;
 }

--- a/sycl/test/type_traits/integer_n_bit.cpp
+++ b/sycl/test/type_traits/integer_n_bit.cpp
@@ -1,0 +1,78 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+//==---- integer_n_bit.cpp - SYCL integerNbit type traits test -------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+namespace s = cl::sycl;
+namespace d = cl::sycl::detail;
+
+template <bool... V> using bool_list = d::value_list<bool, V...>;
+
+template <template <typename> class T, typename TL, typename BL> struct check {
+  void operator()() {
+    static_assert(T<d::head_t<TL>>::value == BL::head, "");
+    check<T, d::tail_t<TL>, d::tail_t<BL>>()();
+  }
+};
+
+template <template <typename> class T>
+struct check<T, d::type_list<>, bool_list<>> {
+  void operator()() {}
+};
+
+using TypeList =
+    d::type_list<int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t,
+                 uint64_t, s::vec<int8_t, 2>, s::vec<int16_t, 2>,
+                 s::vec<int32_t, 2>, s::vec<int64_t, 2>, s::vec<uint8_t, 2>,
+                 s::vec<uint16_t, 2>, s::vec<uint32_t, 2>, s::vec<uint64_t, 2>,
+                 bool, float, double, half, s::vec<float, 2>, s::vec<double, 2>,
+                 s::vec<half, 2>>;
+
+int main() {
+  check<d::is_igeninteger8bit, TypeList,
+        bool_list<1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+  check<d::is_igeninteger16bit, TypeList,
+        bool_list<0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+  check<d::is_igeninteger32bit, TypeList,
+        bool_list<0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+  check<d::is_igeninteger64bit, TypeList,
+        bool_list<0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+
+  check<d::is_ugeninteger8bit, TypeList,
+        bool_list<0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+  check<d::is_ugeninteger16bit, TypeList,
+        bool_list<0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+  check<d::is_ugeninteger32bit, TypeList,
+        bool_list<0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+  check<d::is_ugeninteger64bit, TypeList,
+        bool_list<0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+
+  check<d::is_geninteger8bit, TypeList,
+        bool_list<1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+  check<d::is_geninteger16bit, TypeList,
+        bool_list<0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+  check<d::is_geninteger32bit, TypeList,
+        bool_list<0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+  check<d::is_geninteger64bit, TypeList,
+        bool_list<0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+                  0, 0>>()();
+
+  return 0;
+}

--- a/sycl/test/type_traits/type_list.cpp
+++ b/sycl/test/type_traits/type_list.cpp
@@ -1,0 +1,189 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+//==---------------- type_list.cpp - SYCL type_list test -------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+#include <type_traits>
+
+using namespace std;
+
+namespace s = cl::sycl;
+namespace d = cl::sycl::detail;
+
+template <template <typename, typename> class Predicate, typename T,
+          typename T2, bool Expected = true>
+void test_predicate() {
+  static_assert(Predicate<T, T2>::value == Expected, "");
+}
+
+template <template <typename, typename> class Trait, typename TL, typename T,
+          typename ExpectedT, bool Expected = true>
+void test_trait() {
+  static_assert(is_same<Trait<TL, T>, ExpectedT>::value == Expected, "");
+}
+
+int main() {
+  // test list of types
+  using scalar_float = d::type_list<float>;
+  static_assert(is_same<scalar_float::head, float>::value, "");
+  static_assert(is_same<scalar_float::tail, d::empty_type_list>::value, "");
+
+  using vector_float = d::type_list<s::vec<float, 1>, s::vec<float, 2>>;
+  static_assert(is_same<vector_float::head, s::vec<float, 1>>::value, "");
+  static_assert(is_same<vector_float::tail::head, s::vec<float, 2>>::value, "");
+  static_assert(is_same<vector_float::tail::tail, d::empty_type_list>::value,
+                "");
+
+  using float_list = d::type_list<scalar_float, vector_float>;
+  static_assert(is_same<float_list::head, float>::value, "");
+  static_assert(is_same<float_list::tail::head, s::vec<float, 1>>::value, "");
+  static_assert(is_same<float_list::tail::tail::head, s::vec<float, 2>>::value,
+                "");
+  static_assert(
+      is_same<float_list::tail::tail::tail, d::empty_type_list>::value, "");
+
+  using scalar_double = d::type_list<double>;
+  using vector_double = d::type_list<s::vec<double, 1>, s::vec<double, 2>>;
+  using double_list = d::type_list<scalar_double, vector_double>;
+  using floating_list = d::type_list<float_list, double_list>;
+  static_assert(is_same<floating_list::head, float>::value, "");
+  static_assert(is_same<floating_list::tail::head, s::vec<float, 1>>::value,
+                "");
+  static_assert(
+      is_same<floating_list::tail::tail::head, s::vec<float, 2>>::value, "");
+  static_assert(is_same<floating_list::tail::tail::tail::head, double>::value,
+                "");
+  static_assert(is_same<floating_list::tail::tail::tail::tail::head,
+                        s::vec<double, 1>>::value,
+                "");
+  static_assert(is_same<floating_list::tail::tail::tail::tail::tail::head,
+                        s::vec<double, 2>>::value,
+                "");
+  static_assert(is_same<floating_list::tail::tail::tail::tail::tail::tail,
+                        d::empty_type_list>::value,
+                "");
+
+  using scalar_int = d::type_list<int>;
+  using scalar_long = d::type_list<long>;
+  using vector_int = d::type_list<s::vec<int, 1>, s::vec<int, 2>>;
+  using vector_long = d::type_list<s::vec<long, 1>, s::vec<long, 2>>;
+  using int_list = d::type_list<scalar_int, vector_int>;
+  using long_list = d::type_list<scalar_long, vector_long>;
+  using integer_list = d::type_list<int_list, long_list>;
+  static_assert(is_same<integer_list::head, int>::value, "");
+  static_assert(is_same<integer_list::tail::head, s::vec<int, 1>>::value, "");
+  static_assert(is_same<integer_list::tail::tail::head, s::vec<int, 2>>::value,
+                "");
+  static_assert(is_same<integer_list::tail::tail::tail::head, long>::value, "");
+  static_assert(is_same<integer_list::tail::tail::tail::tail::head,
+                        s::vec<long, 1>>::value,
+                "");
+  static_assert(is_same<integer_list::tail::tail::tail::tail::tail::head,
+                        s::vec<long, 2>>::value,
+                "");
+  static_assert(is_same<integer_list::tail::tail::tail::tail::tail::tail,
+                        d::empty_type_list>::value,
+                "");
+
+  using types = d::type_list<floating_list, integer_list>;
+  static_assert(is_same<types::head, float>::value, "");
+  static_assert(is_same<types::tail::head, s::vec<float, 1>>::value, "");
+  static_assert(is_same<types::tail::tail::head, s::vec<float, 2>>::value, "");
+  static_assert(is_same<types::tail::tail::tail::head, double>::value, "");
+  static_assert(
+      is_same<types::tail::tail::tail::tail::head, s::vec<double, 1>>::value,
+      "");
+  static_assert(is_same<types::tail::tail::tail::tail::tail::head,
+                        s::vec<double, 2>>::value,
+                "");
+  static_assert(
+      is_same<types::tail::tail::tail::tail::tail::tail::head, int>::value, "");
+  static_assert(is_same<types::tail::tail::tail::tail::tail::tail::tail::head,
+                        s::vec<int, 1>>::value,
+                "");
+  static_assert(
+      is_same<types::tail::tail::tail::tail::tail::tail::tail::tail::head,
+              s::vec<int, 2>>::value,
+      "");
+  static_assert(
+      is_same<types::tail::tail::tail::tail::tail::tail::tail::tail::tail::head,
+              long>::value,
+      "");
+  static_assert(is_same<types::tail::tail::tail::tail::tail::tail::tail::tail::
+                            tail::tail::head,
+                        s::vec<long, 1>>::value,
+                "");
+  static_assert(is_same<types::tail::tail::tail::tail::tail::tail::tail::tail::
+                            tail::tail::tail::head,
+                        s::vec<long, 2>>::value,
+                "");
+  static_assert(is_same<types::tail::tail::tail::tail::tail::tail::tail::tail::
+                            tail::tail::tail::tail,
+                        d::empty_type_list>::value,
+                "");
+
+  static_assert(d::is_contained<float, scalar_float>::value, "");
+  static_assert(d::is_contained<s::vec<float, 2>, scalar_float>::value == false,
+                "");
+  static_assert(d::is_contained<float, vector_float>::value == false, "");
+  static_assert(d::is_contained<s::vec<float, 2>, vector_float>::value, "");
+  static_assert(d::is_contained<float, types>::value, "");
+  static_assert(d::is_contained<s::vec<float, 2>, types>::value, "");
+  static_assert(d::is_contained<bool, types>::value == false, "");
+
+  // test list of non-type
+  using my_int_list = d::value_list<int, 3, 1, -2>;
+  static_assert(my_int_list::head == 3, "");
+  static_assert(my_int_list::tail::head == 1, "");
+  static_assert(my_int_list::tail::tail::head == -2, "");
+
+  using my_bool_list = d::value_list<bool, false, true, false>;
+  static_assert(my_bool_list::head == false, "");
+  static_assert(my_bool_list::tail::head == true, "");
+  static_assert(my_bool_list::tail::tail::head == false, "");
+
+  static_assert(d::is_contained_value<int, 4, my_int_list>::value == false, "");
+  static_assert(d::is_contained_value<int, 1, my_int_list>::value, "");
+  static_assert(d::is_contained_value<bool, false, my_bool_list>::value, "");
+  static_assert(d::is_contained_value<bool, true, my_bool_list>::value, "");
+
+  test_predicate<d::is_type_size_equal, int8_t, s::cl_char>();
+  test_predicate<d::is_type_size_equal, int16_t, s::cl_char, false>();
+  test_predicate<d::is_type_size_greater, int8_t, s::cl_char, false>();
+  test_predicate<d::is_type_size_greater, int32_t, s::cl_char>();
+  test_predicate<d::is_type_size_double_of, int8_t, s::cl_char, false>();
+  test_predicate<d::is_type_size_double_of, int16_t, s::cl_char>();
+  test_predicate<d::is_type_size_double_of, int32_t, s::cl_char, false>();
+  test_predicate<d::is_type_size_less, int8_t, s::cl_int>();
+  test_predicate<d::is_type_size_less, int32_t, s::cl_int, false>();
+  test_predicate<d::is_type_size_half_of, int8_t, s::cl_int, false>();
+  test_predicate<d::is_type_size_half_of, int16_t, s::cl_int>();
+  test_predicate<d::is_type_size_half_of, int32_t, s::cl_int, false>();
+
+  // if void is found, the required type is not found
+  test_trait<d::find_same_size_type_t, d::type_list<int8_t>, s::cl_char,
+             int8_t>();
+  test_trait<d::find_same_size_type_t, d::type_list<int16_t>, s::cl_char,
+             void>();
+  test_trait<d::find_larger_type_t, d::type_list<int8_t, int16_t>, s::cl_char,
+             int16_t>();
+  test_trait<d::find_larger_type_t, d::type_list<int8_t>, s::cl_char, void>();
+  test_trait<d::find_twice_as_large_type_t, d::type_list<int8_t, int16_t>,
+             s::cl_char, int16_t>();
+  test_trait<d::find_twice_as_large_type_t, d::type_list<int8_t, int32_t>,
+             s::cl_char, void>();
+  test_trait<d::find_smaller_type_t, d::type_list<int8_t>, s::cl_int, int8_t>();
+  test_trait<d::find_smaller_type_t, d::type_list<int32_t>, s::cl_int, void>();
+  test_trait<d::find_twice_as_small_type_t, d::type_list<int8_t, int16_t>,
+             s::cl_int, int16_t>();
+  test_trait<d::find_twice_as_small_type_t, d::type_list<int8_t, int32_t>,
+             s::cl_int, void>();
+
+  return 0;
+}


### PR DESCRIPTION
- Removed all use of OpenCL types from SYCL header files, aside from converting into SPIRV type.
- Removed some code dublications.
- Aligned built-in's host version with SPIRV types.
- Aligned nan built-in implementation with SYCL specification.
- Renamed detail/type_tratis.hpp to detail/std_type_tratis.hpp
- Updated SFINAE logic of intel/sub_group.hpp
- Added test for built-in's type_tratis

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>