### PR TITLE
[SYCL][Driver] Path problems when forming -fsycl-help tool calls

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1685,7 +1685,7 @@ void Driver::PrintSYCLToolHelp(const Compilation &C) const {
     llvm::Triple T;
     if (AV == "gen" || AV == "all")
       HelpArgs.push_back(std::make_tuple(makeDeviceTriple("spir64_gen"),
-                                         "ocloc", "-?"));
+                                         "ocloc", "--help"));
     if (AV == "fpga" || AV == "all")
       HelpArgs.push_back(std::make_tuple(makeDeviceTriple("spir64_fpga"),
                                          "aoc", "-help"));
@@ -1704,14 +1704,17 @@ void Driver::PrintSYCLToolHelp(const Compilation &C) const {
     llvm::outs() << "Emitting help information for " << std::get<1>(HA) << '\n'
         << "Use triple of '" << std::get<0>(HA).normalize() <<
         "' to enable ahead of time compilation\n";
-    // do not run the tools with -###.
-    if (C.getArgs().hasArg(options::OPT__HASH_HASH_HASH))
-      continue;
     std::vector<StringRef> ToolArgs = { std::get<1>(HA), std::get<2>(HA) };
-    StringRef ExecPath(C.getDefaultToolChain().GetProgramPath(std::get<1>(HA).data()));
+    SmallString<128> ExecPath(
+        C.getDefaultToolChain().GetProgramPath(std::get<1>(HA).data()));
     auto ToolBinary = llvm::sys::findProgramByName(ExecPath);
     if (ToolBinary.getError()) {
       C.getDriver().Diag(diag::err_drv_command_failure) << ExecPath;
+      continue;
+    }
+    // do not run the tools with -###.
+    if (C.getArgs().hasArg(options::OPT__HASH_HASH_HASH)) {
+      llvm::errs() << "\"" << ExecPath << "\" \"" << ToolArgs[1] << "\"\n";
       continue;
     }
     // Run the Tool.

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -22,15 +22,19 @@
 // DEFAULT-PHASES-NOT: linker
 
 // -fsycl-help tests
+// RUN: mkdir -p %t-sycl-dir
+// RUN: touch %t-sycl-dir/aoc
+// RUN: chmod +x %t-sycl-dir/aoc
 // Test with a bad argument is expected to fail
 // RUN: not %clang -fsycl-help=foo %s 2>&1 | FileCheck %s --check-prefix=SYCL-HELP-BADARG
 // RUN: %clang -### -fsycl-help=gen %s 2>&1 | FileCheck %s --check-prefix=SYCL-HELP-GEN
-// RUN: %clang -### -fsycl-help=fpga %s 2>&1 | FileCheck %s --check-prefix=SYCL-HELP-FPGA
+// RUN: env PATH=%t-sycl-dir %clang -### -fsycl-help=fpga %s 2>&1 | FileCheck %s --check-prefixes=SYCL-HELP-FPGA,SYCL-HELP-FPGA-OUT -DDIR=%t-sycl-dir
 // RUN: %clang -### -fsycl-help=x86_64 %s 2>&1 | FileCheck %s --check-prefix=SYCL-HELP-CPU
 // RUN: %clang -### -fsycl-help %s 2>&1 | FileCheck %s --check-prefixes=SYCL-HELP-GEN,SYCL-HELP-FPGA,SYCL-HELP-CPU
 // SYCL-HELP-BADARG: unsupported argument 'foo' to option 'fsycl-help='
 // SYCL-HELP-GEN: Emitting help information for ocloc
 // SYCL-HELP-GEN: Use triple of 'spir64_gen-unknown-{{.*}}-sycldevice' to enable ahead of time compilation
+// SYCL-HELP-FPGA-OUT: "[[DIR]]{{[/\\]+}}aoc" "-help"
 // SYCL-HELP-FPGA: Emitting help information for aoc
 // SYCL-HELP-FPGA: Use triple of 'spir64_fpga-unknown-{{.*}}-sycldevice' to enable ahead of time compilation
 // SYCL-HELP-CPU: Emitting help information for ioc64


### PR DESCRIPTION
When performing -fsycl-help, the strings to execute the tool were corrupted.
Adjust how the strings are handled.  Adjust output behaviors with -### with
-fsycl-help to allow for better inspection of the actual call being made.
Also fix the option to enable help output for ocloc

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>