### PR TITLE
[SYCL] Update sub-group reduce/scan syntax

### DIFF
--- a/sycl/doc/extensions/SubGroupNDRange/SubGroupNDRange.md
+++ b/sycl/doc/extensions/SubGroupNDRange/SubGroupNDRange.md
@@ -143,9 +143,12 @@ The `plus`, `minimum` and `maximum` functors in the `cl::sycl` namespace corresp
 |Member functions|Description|
 |----------------|-----------|
 | `template <typename T>T broadcast(T x, id<1> local_id) const` | Broadcast the value of `x` from the work-item with the specified id to all work-items within the sub-group. The value of `local_id` must be the same for all work-items in the sub-group. |
-| `template <typename T, class BinaryOp>T reduce(T x, T init, BinaryOp binary_op) const` | Combine the values of `x` from all work-items in the sub-group using the specified operator, which must be one of: `plus`, `minimum` or `maximum`. |
-| `template <typename T, class BinaryOp>T exclusive_scan(T x, T init, BinaryOp binary_op) const` | Perform an exclusive scan over the values of `x` from all work-items in the sub-group using the specified operator, which must be one of: `plus`, `minimum` or `maximum`. The value returned on work-item `i` is the exclusive scan of the first `i` work-items in the sub-group. |
-| `template <typename T, class BinaryOp>T inclusive_scan(T x, BinaryOp binary_op, T init) const` | Perform an inclusive scan over the values of `x` from all work-items in the sub-group using the specified operator, which must be one of: `plus`, `minimum` or `maximum`. The value returned on work-item `i` is the inclusive scan of the first `i` work-items in the sub-group. |
+| `template <typename T, class BinaryOp>T reduce(T x, BinaryOp binary_op) const` | Combine the values of `x` from all work-items in the sub-group using the specified operator, which must be one of: `plus`, `minimum` or `maximum`. |
+| `template <typename T, class BinaryOp>T reduce(T x, T init, BinaryOp binary_op) const` | Combine the values of `x` from all work-items in the sub-group using an initial value of `init` and the specified operator, which must be one of: `plus`, `minimum` or `maximum`. |
+| `template <typename T, class BinaryOp>T exclusive_scan(T x, BinaryOp binary_op) const` | Perform an exclusive scan over the values of `x` from all work-items in the sub-group using the specified operator, which must be one of: `plus`, `minimum` or `maximum`. The value returned on work-item `i` is the exclusive scan of the first `i` work-items in the sub-group. The initial value is the identity value of the operator. |
+| `template <typename T, class BinaryOp>T exclusive_scan(T x, T init, BinaryOp binary_op) const` | Perform an exclusive scan over the values of `x` from all work-items in the sub-group using the specified operator, which must be one of: `plus`, `minimum` or `maximum`. The value returned on work-item `i` is the exclusive scan of the first `i` work-items in the sub-group. The initial value is specified by `init`. |
+| `template <typename T, class BinaryOp>T inclusive_scan(T x, BinaryOp binary_op) const` | Perform an inclusive scan over the values of `x` from all work-items in the sub-group using the specified operator, which must be one of: `plus`, `minimum` or `maximum`. The value returned on work-item `i` is the inclusive scan of the first `i` work-items in the sub-group. |
+| `template <typename T, class BinaryOp>T inclusive_scan(T x, BinaryOp binary_op, T init) const` | Perform an inclusive scan over the values of `x` from all work-items in the sub-group using the specified operator, which must be one of: `plus`, `minimum` or `maximum`. The value returned on work-item `i` is the inclusive scan of the initial value `init` and the first `i` work-items in the sub-group. |
 
 ## Extended Functionality
 
@@ -215,10 +218,19 @@ struct sub_group {
     T broadcast(T x, id<1> local_id) const;
 
     template <typename T, class BinaryOp>
+    T reduce(T x, BinaryOp binary_op) const;
+
+    template <typename T, class BinaryOp>
     T reduce(T x, T init, BinaryOp binary_op) const;
 
     template <typename T, class BinaryOp>
+    T exclusive_scan(T x, BinaryOp binary_op) const;
+
+    template <typename T, class BinaryOp>
     T exclusive_scan(T x, T init, BinaryOp binary_op) const;
+
+    template <typename T, class BinaryOp>
+    T inclusive_scan(T x, BinaryOp binary_op) const;
 
     template <typename T, class BinaryOp>
     T inclusive_scan(T x, BinaryOp binary_op, T init) const;

--- a/sycl/include/CL/sycl/intel/functional.hpp
+++ b/sycl/include/CL/sycl/intel/functional.hpp
@@ -1,0 +1,51 @@
+//==----------- functional.hpp --- SYCL functional -------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace cl {
+namespace sycl {
+namespace intel {
+
+template <typename T = void> struct minimum {
+  T operator()(const T &lhs, const T &rhs) const {
+    return (lhs <= rhs) ? lhs : rhs;
+  }
+};
+
+template <> struct minimum<void> {
+  template <typename T> T operator()(const T &lhs, const T &rhs) const {
+    return (lhs <= rhs) ? lhs : rhs;
+  }
+};
+
+template <typename T = void> struct maximum {
+  T operator()(const T &lhs, const T &rhs) const {
+    return (lhs >= rhs) ? lhs : rhs;
+  }
+};
+
+template <> struct maximum<void> {
+  template <typename T> T operator()(const T &lhs, const T &rhs) const {
+    return (lhs >= rhs) ? lhs : rhs;
+  }
+};
+
+template <typename T = void> struct plus {
+  T operator()(const T &lhs, const T &rhs) const { return lhs + rhs; }
+};
+
+template <> struct plus<void> {
+  template <typename T> T operator()(const T &lhs, const T &rhs) const {
+    return lhs + rhs;
+  }
+};
+
+} // namespace intel
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -15,49 +15,13 @@
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/range.hpp>
 #include <CL/sycl/types.hpp>
+#include <CL/sycl/intel/functional.hpp>
 #include <type_traits>
 #ifdef __SYCL_DEVICE_ONLY__
 
 namespace cl {
 namespace sycl {
 template <typename T, access::address_space Space> class multi_ptr;
-namespace intel {
-
-template <typename T = void> struct minimum {
-  T operator()(const T &lhs, const T &rhs) const {
-    return (lhs <= rhs) ? lhs : rhs;
-  }
-};
-
-template <> struct minimum<void> {
-  template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return (lhs <= rhs) ? lhs : rhs;
-  }
-};
-
-template <typename T = void> struct maximum {
-  T operator()(const T &lhs, const T &rhs) const {
-    return (lhs >= rhs) ? lhs : rhs;
-  }
-};
-
-template <> struct maximum<void> {
-  template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return (lhs >= rhs) ? lhs : rhs;
-  }
-};
-
-template <typename T = void> struct plus {
-  T operator()(const T &lhs, const T &rhs) const { return lhs + rhs; }
-};
-
-template <> struct plus<void> {
-  template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return lhs + rhs;
-  }
-};
-
-} // namespace intel
 
 namespace detail {
 

--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -27,21 +27,45 @@ template <typename> struct is_vec : std::false_type {};
 template <typename T, std::size_t N>
 struct is_vec<cl::sycl::vec<T, N>> : std::true_type {};
 
-template <typename T> struct minimum {
+template <typename T = void> struct minimum {
   T operator()(const T &lhs, const T &rhs) const {
     return (lhs <= rhs) ? lhs : rhs;
   }
 };
 
-template <typename T> struct maximum {
+template <> struct minimum<void> {
+  template <typename T> T operator()(const T &lhs, const T &rhs) const {
+    return (lhs <= rhs) ? lhs : rhs;
+  }
+};
+
+template <typename T = void> struct maximum {
   T operator()(const T &lhs, const T &rhs) const {
     return (lhs >= rhs) ? lhs : rhs;
   }
 };
 
-template <typename T> struct plus {
+template <> struct maximum<void> {
+  template <typename T> T operator()(const T &lhs, const T &rhs) const {
+    return (lhs >= rhs) ? lhs : rhs;
+  }
+};
+
+template <typename T = void> struct plus {
   T operator()(const T &lhs, const T &rhs) const { return lhs + rhs; }
 };
+
+template <> struct plus<void> {
+  template <typename T> T operator()(const T &lhs, const T &rhs) const {
+    return lhs + rhs;
+  }
+};
+
+template <typename T, __spv::GroupOperation O,
+          template <typename> class BinaryOperation>
+static T calc(T x, BinaryOperation<void>) {
+  return calc<T, O>(x, BinaryOperation<T>());
+}
 
 template <typename T, __spv::GroupOperation O>
 static typename std::enable_if<

--- a/sycl/include/CL/sycl/intel/sub_group_host.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group_host.hpp
@@ -12,47 +12,13 @@
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/range.hpp>
 #include <CL/sycl/types.hpp>
+#include <CL/sycl/intel/functional.hpp>
 #ifndef __SYCL_DEVICE_ONLY__
 
 namespace cl {
 namespace sycl {
 template <typename T, access::address_space Space> class multi_ptr;
 namespace intel {
-
-template <typename T = void> struct minimum {
-  T operator()(const T &lhs, const T &rhs) const {
-    return (lhs <= rhs) ? lhs : rhs;
-  }
-};
-
-template <> struct minimum<void> {
-  template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return (lhs <= rhs) ? lhs : rhs;
-  }
-};
-
-template <typename T = void> struct maximum {
-  T operator()(const T &lhs, const T &rhs) const {
-    return (lhs >= rhs) ? lhs : rhs;
-  }
-};
-
-template <> struct maximum<void> {
-  template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return (lhs >= rhs) ? lhs : rhs;
-  }
-};
-
-template <typename T = void> struct plus {
-  T operator()(const T &lhs, const T &rhs) const { return lhs + rhs; }
-};
-
-template <> struct plus<void> {
-  template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return lhs + rhs;
-  }
-};
-
 struct sub_group {
   /* --- common interface members --- */
 

--- a/sycl/include/CL/sycl/intel/sub_group_host.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group_host.hpp
@@ -18,9 +18,22 @@ namespace cl {
 namespace sycl {
 template <typename T, access::address_space Space> class multi_ptr;
 namespace intel {
-struct minimum {};
-struct maximum {};
-struct plus {};
+
+template <typename T> struct minimum {
+  T operator()(const T &lhs, const T &rhs) const {
+    return (lhs <= rhs) ? lhs : rhs;
+  }
+};
+
+template <typename T> struct maximum {
+  T operator()(const T &lhs, const T &rhs) const {
+    return (lhs >= rhs) ? lhs : rhs;
+  }
+};
+
+template <typename T> struct plus {
+  T operator()(const T &lhs, const T &rhs) const { return lhs + rhs; }
+};
 
 struct sub_group {
   /* --- common interface members --- */
@@ -64,15 +77,33 @@ struct sub_group {
     throw runtime_error("Subgroups are not supported on host device. ");
   }
 
-  template <typename T, class BinaryOperation> T reduce(T x) const {
+  template <typename T, class BinaryOperation>
+  T reduce(T x, BinaryOperation op) const {
     throw runtime_error("Subgroups are not supported on host device. ");
   }
 
-  template <typename T, class BinaryOperation> T exclusive_scan(T x) const {
+  template <typename T, class BinaryOperation>
+  T reduce(T x, T init, BinaryOperation op) const {
     throw runtime_error("Subgroups are not supported on host device. ");
   }
 
-  template <typename T, class BinaryOperation> T inclusive_scan(T x) const {
+  template <typename T, class BinaryOperation>
+  T exclusive_scan(T x, BinaryOperation op) const {
+    throw runtime_error("Subgroups are not supported on host device. ");
+  }
+
+  template <typename T, class BinaryOperation>
+  T exclusive_scan(T x, T init, BinaryOperation op) const {
+    throw runtime_error("Subgroups are not supported on host device. ");
+  }
+
+  template <typename T, class BinaryOperation>
+  T inclusive_scan(T x, BinaryOperation op) const {
+    throw runtime_error("Subgroups are not supported on host device. ");
+  }
+
+  template <typename T, class BinaryOperation>
+  T inclusive_scan(T x, BinaryOperation op, T init) const {
     throw runtime_error("Subgroups are not supported on host device. ");
   }
 

--- a/sycl/include/CL/sycl/intel/sub_group_host.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group_host.hpp
@@ -19,20 +19,38 @@ namespace sycl {
 template <typename T, access::address_space Space> class multi_ptr;
 namespace intel {
 
-template <typename T> struct minimum {
+template <typename T = void> struct minimum {
   T operator()(const T &lhs, const T &rhs) const {
     return (lhs <= rhs) ? lhs : rhs;
   }
 };
 
-template <typename T> struct maximum {
+template <> struct minimum<void> {
+  template <typename T> T operator()(const T &lhs, const T &rhs) const {
+    return (lhs <= rhs) ? lhs : rhs;
+  }
+};
+
+template <typename T = void> struct maximum {
   T operator()(const T &lhs, const T &rhs) const {
     return (lhs >= rhs) ? lhs : rhs;
   }
 };
 
-template <typename T> struct plus {
+template <> struct maximum<void> {
+  template <typename T> T operator()(const T &lhs, const T &rhs) const {
+    return (lhs >= rhs) ? lhs : rhs;
+  }
+};
+
+template <typename T = void> struct plus {
   T operator()(const T &lhs, const T &rhs) const { return lhs + rhs; }
+};
+
+template <> struct plus<void> {
+  template <typename T> T operator()(const T &lhs, const T &rhs) const {
+    return lhs + rhs;
+  }
 };
 
 struct sub_group {

--- a/sycl/test/sub_group/reduce.cpp
+++ b/sycl/test/sub_group/reduce.cpp
@@ -14,96 +14,100 @@
 
 #include "helper.hpp"
 #include <CL/sycl.hpp>
-template <typename T, bool init> class sycl_subgr;
+
+template <typename T, class BinaryOperation> class sycl_subgr;
+
 using namespace cl::sycl;
-template <typename T, bool init>
-void check(queue &Queue, size_t G = 240, size_t L = 60) {
+
+template <typename T, class BinaryOperation>
+void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
+              size_t G = 240, size_t L = 60) {
   try {
     nd_range<1> NdRange(G, L);
-    buffer<T> minbuf(G);
-    buffer<T> maxbuf(G);
-    buffer<T> addbuf(G);
+    buffer<T> buf(G);
     Queue.submit([&](handler &cgh) {
-      auto minacc = minbuf.template get_access<access::mode::read_write>(cgh);
-      auto maxacc = maxbuf.template get_access<access::mode::read_write>(cgh);
-      auto addacc = addbuf.template get_access<access::mode::read_write>(cgh);
-      cgh.parallel_for<sycl_subgr<T, init>>(NdRange, [=](nd_item<1> NdItem) {
-        intel::sub_group sg = NdItem.get_sub_group();
-        if (init) {
-          minacc[NdItem.get_global_id()] = sg.reduce(
-              static_cast<T>(NdItem.get_global_id(0)),
-              static_cast<T>(NdItem.get_global_range(0)), intel::minimum<T>());
-          maxacc[NdItem.get_global_id()] =
-              sg.reduce(static_cast<T>(NdItem.get_global_id(0)),
-                        static_cast<T>(0), intel::maximum<T>());
-          addacc[NdItem.get_global_id()] =
-              sg.reduce(static_cast<T>(NdItem.get_global_id(0)),
-                        static_cast<T>(0), intel::plus<T>());
-        } else {
-          minacc[NdItem.get_global_id()] = sg.reduce(
-              static_cast<T>(NdItem.get_global_id(0)), intel::minimum<T>());
-          maxacc[NdItem.get_global_id()] = sg.reduce(
-              static_cast<T>(NdItem.get_global_id(0)), intel::maximum<T>());
-          addacc[NdItem.get_global_id()] = sg.reduce(
-              static_cast<T>(NdItem.get_global_id(0)), intel::plus<T>());
-        }
-      });
+      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<sycl_subgr<T, BinaryOperation>>(
+          NdRange, [=](nd_item<1> NdItem) {
+            intel::sub_group sg = NdItem.get_sub_group();
+            if (skip_init) {
+              acc[NdItem.get_global_id(0)] =
+                  sg.reduce(T(NdItem.get_global_id(0)), op);
+            } else {
+              acc[NdItem.get_global_id(0)] =
+                  sg.reduce(T(NdItem.get_global_id(0)), init, op);
+            }
+          });
     });
-    auto minacc = minbuf.template get_access<access::mode::read_write>();
-    auto maxacc = maxbuf.template get_access<access::mode::read_write>();
-    auto addacc = addbuf.template get_access<access::mode::read_write>();
+    auto acc = buf.template get_access<access::mode::read_write>();
     size_t sg_size = get_sg_size(Queue.get_device());
     int WGid = -1, SGid = 0;
-    int max = 0, add = 0;
+    T result = init;
     for (int j = 0; j < G; j++) {
       if (j % L % sg_size == 0) {
         SGid++;
-        max = 0;
-        add = 0;
+        result = init;
         for (int i = j; (i % L && i % L % sg_size) || (i == j); i++) {
-          add += i;
-          max = i;
+          result = op(result, T(i));
         }
       }
       if (j % L == 0) {
         WGid++;
         SGid = 0;
       }
-      exit_if_not_equal<T>(minacc[j], L * WGid + SGid * sg_size, "reduce_min");
-      exit_if_not_equal<T>(maxacc[j], max, "reduce_max");
-      exit_if_not_equal<T>(addacc[j], add, "reduce_add");
+      std::string name =
+          std::string("reduce_") + typeid(BinaryOperation).name();
+      exit_if_not_equal<T>(acc[j], result, name.c_str());
     }
   } catch (exception e) {
     std::cout << "SYCL exception caught: " << e.what();
     exit(1);
   }
 }
+
+template <typename T> void check(queue &Queue, size_t G = 240, size_t L = 60) {
+  // limit data range for half to avoid rounding issues
+  if (std::is_same<T, cl::sycl::half>::value) {
+    G = 64;
+    L = 32;
+  }
+
+  check_op<T>(Queue, T(L), intel::plus<T>(), false, G, L);
+  check_op<T>(Queue, T(L), intel::plus<>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::plus<T>(), true, G, L);
+  check_op<T>(Queue, T(0), intel::plus<>(), true, G, L);
+
+  check_op<T>(Queue, T(0), intel::minimum<T>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::minimum<>(), false, G, L);
+  check_op<T>(Queue, T(G), intel::minimum<T>(), true, G, L);
+  check_op<T>(Queue, T(G), intel::minimum<>(), true, G, L);
+
+  check_op<T>(Queue, T(G), intel::maximum<T>(), false, G, L);
+  check_op<T>(Queue, T(G), intel::maximum<>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::maximum<T>(), true, G, L);
+  check_op<T>(Queue, T(0), intel::maximum<>(), true, G, L);
+}
+
 int main() {
   queue Queue;
   if (!core_sg_supported(Queue.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int, true>(Queue);
-  check<int, false>(Queue);
-  check<unsigned int, true>(Queue);
-  check<unsigned int, false>(Queue);
-  check<long, true>(Queue);
-  check<long, false>(Queue);
-  check<unsigned long, true>(Queue);
-  check<unsigned long, false>(Queue);
-  check<float, true>(Queue);
-  check<float, false>(Queue);
+
+  check<int>(Queue);
+  check<unsigned int>(Queue);
+  check<long>(Queue);
+  check<unsigned long>(Queue);
+  check<float>(Queue);
   // reduce half type is not supported in OCL CPU RT
 #ifdef SG_GPU
   if (Queue.get_device().has_extension("cl_khr_fp16")) {
-    check<cl::sycl::half, true>(Queue);
-    check<cl::sycl::half, false>(Queue);
+    check<cl::sycl::half>(Queue);
   }
 #endif
   if (Queue.get_device().has_extension("cl_khr_fp64")) {
-    check<double, true>(Queue);
-    check<double, false>(Queue);
+    check<double>(Queue);
   }
   std::cout << "Test passed." << std::endl;
   return 0;

--- a/sycl/test/sub_group/scan.cpp
+++ b/sycl/test/sub_group/scan.cpp
@@ -15,131 +15,126 @@
 #include "helper.hpp"
 #include <CL/sycl.hpp>
 #include <limits>
-template <typename T, bool init> class sycl_subgr;
+
+template <typename T, class BinaryOperation> class sycl_subgr;
+
 using namespace cl::sycl;
-template <typename T, bool init>
-void check(queue &Queue, size_t G = 120, size_t L = 60) {
+
+template <typename T, class BinaryOperation>
+void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
+              size_t G = 120, size_t L = 60) {
   try {
     nd_range<1> NdRange(G, L);
-    buffer<T> minexbuf(G);
-    buffer<T> maxexbuf(G);
-    buffer<T> addexbuf(G);
-    buffer<T> mininbuf(G);
-    buffer<T> maxinbuf(G);
-    buffer<T> addinbuf(G);
+    buffer<T> exbuf(G), inbuf(G);
     Queue.submit([&](handler &cgh) {
-      auto minexacc =
-          minexbuf.template get_access<access::mode::read_write>(cgh);
-      auto maxexacc =
-          maxexbuf.template get_access<access::mode::read_write>(cgh);
-      auto addexacc =
-          addexbuf.template get_access<access::mode::read_write>(cgh);
-      auto mininacc =
-          mininbuf.template get_access<access::mode::read_write>(cgh);
-      auto maxinacc =
-          maxinbuf.template get_access<access::mode::read_write>(cgh);
-      auto addinacc =
-          addinbuf.template get_access<access::mode::read_write>(cgh);
-      cgh.parallel_for<sycl_subgr<T, init>>(NdRange, [=](nd_item<1> NdItem) {
-        intel::sub_group SG = NdItem.get_sub_group();
-        if (init) {
-          minexacc[NdItem.get_global_id()] = SG.exclusive_scan(
-              static_cast<T>(NdItem.get_global_id(0)), intel::minimum<T>());
-          maxexacc[NdItem.get_global_id()] = SG.exclusive_scan(
-              static_cast<T>(NdItem.get_global_id(0)), intel::maximum<T>());
-          addexacc[NdItem.get_global_id()] = SG.exclusive_scan(
-              static_cast<T>(NdItem.get_global_id(0)), intel::plus<T>());
-          mininacc[NdItem.get_global_id()] = SG.inclusive_scan(
-              static_cast<T>(NdItem.get_global_id(0)), intel::minimum<T>());
-          maxinacc[NdItem.get_global_id()] = SG.inclusive_scan(
-              static_cast<T>(NdItem.get_global_id(0)), intel::maximum<T>());
-          addinacc[NdItem.get_global_id()] = SG.inclusive_scan(
-              static_cast<T>(NdItem.get_global_id(0)), intel::plus<T>());
-        } else {
-          minexacc[NdItem.get_global_id()] = SG.exclusive_scan(
-              static_cast<T>(NdItem.get_global_id(0)),
-              static_cast<T>(NdItem.get_global_range(0)), intel::minimum<T>());
-          maxexacc[NdItem.get_global_id()] =
-              SG.exclusive_scan(static_cast<T>(NdItem.get_global_id(0)),
-                                static_cast<T>(0), intel::maximum<T>());
-          addexacc[NdItem.get_global_id()] =
-              SG.exclusive_scan(static_cast<T>(NdItem.get_global_id(0)),
-                                static_cast<T>(0), intel::plus<T>());
-          mininacc[NdItem.get_global_id()] = SG.inclusive_scan(
-              static_cast<T>(NdItem.get_global_id(0)), intel::minimum<T>(),
-              static_cast<T>(NdItem.get_global_range(0)));
-          maxinacc[NdItem.get_global_id()] =
-              SG.inclusive_scan(static_cast<T>(NdItem.get_global_id(0)),
-                                intel::maximum<T>(), static_cast<T>(0));
-          addinacc[NdItem.get_global_id()] =
-              SG.inclusive_scan(static_cast<T>(NdItem.get_global_id(0)),
-                                intel::plus<T>(), static_cast<T>(0));
-        }
-      });
+      auto exacc = exbuf.template get_access<access::mode::read_write>(cgh);
+      auto inacc = inbuf.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<sycl_subgr<T, BinaryOperation>>(
+          NdRange, [=](nd_item<1> NdItem) {
+            intel::sub_group sg = NdItem.get_sub_group();
+            if (skip_init) {
+              exacc[NdItem.get_global_id(0)] =
+                  sg.exclusive_scan(T(NdItem.get_global_id(0)), op);
+              inacc[NdItem.get_global_id(0)] =
+                  sg.inclusive_scan(T(NdItem.get_global_id(0)), op);
+            } else {
+              exacc[NdItem.get_global_id(0)] =
+                  sg.exclusive_scan(T(NdItem.get_global_id(0)), init, op);
+              inacc[NdItem.get_global_id(0)] =
+                  sg.inclusive_scan(T(NdItem.get_global_id(0)), op, init);
+            }
+          });
     });
-    auto minexacc = minexbuf.template get_access<access::mode::read_write>();
-    auto maxexacc = maxexbuf.template get_access<access::mode::read_write>();
-    auto addexacc = addexbuf.template get_access<access::mode::read_write>();
-    auto mininacc = mininbuf.template get_access<access::mode::read_write>();
-    auto maxinacc = maxinbuf.template get_access<access::mode::read_write>();
-    auto addinacc = addinbuf.template get_access<access::mode::read_write>();
-
+    auto exacc = exbuf.template get_access<access::mode::read_write>();
+    auto inacc = inbuf.template get_access<access::mode::read_write>();
     size_t sg_size = get_sg_size(Queue.get_device());
     int WGid = -1, SGid = 0;
-    int add = 0;
+    T result = init;
     for (int j = 0; j < G; j++) {
       if (j % L % sg_size == 0) {
         SGid++;
-        add = 0;
+        result = init;
       }
       if (j % L == 0) {
         WGid++;
         SGid = 0;
       }
-      /*skip check for empty array*/
-      if (j % L % sg_size != 0) {
-        exit_if_not_equal<T>(minexacc[j], L * WGid + SGid * sg_size,
-                             "scan_exc_min");
-        exit_if_not_equal<T>(maxexacc[j], j - 1, "scan_exc_max");
-      }
-      exit_if_not_equal<T>(addexacc[j], add, "scan_exc_add");
-      add += j;
-      exit_if_not_equal<T>(mininacc[j], L * WGid + SGid * sg_size,
-                           "scan_inc_min");
-      exit_if_not_equal<T>(maxinacc[j], j, "scan_inc_max");
-      exit_if_not_equal<T>(addinacc[j], add, "scan_inc_add");
+      std::string exname =
+          std::string("scan_exc_") + typeid(BinaryOperation).name();
+      std::string inname =
+          std::string("scan_inc_") + typeid(BinaryOperation).name();
+      exit_if_not_equal<T>(exacc[j], result, exname.c_str());
+      result = op(result, T(j));
+      exit_if_not_equal<T>(inacc[j], result, inname.c_str());
     }
   } catch (exception e) {
     std::cout << "SYCL exception caught: " << e.what();
     exit(1);
   }
 }
+
+template <typename T> void check(queue &Queue, size_t G = 120, size_t L = 60) {
+  // limit data range for half to avoid rounding issues
+  if (std::is_same<T, cl::sycl::half>::value) {
+    G = 64;
+    L = 32;
+  }
+
+  check_op<T>(Queue, T(L), intel::plus<T>(), false, G, L);
+  check_op<T>(Queue, T(L), intel::plus<>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::plus<T>(), true, G, L);
+  check_op<T>(Queue, T(0), intel::plus<>(), true, G, L);
+
+  check_op<T>(Queue, T(0), intel::minimum<T>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::minimum<>(), false, G, L);
+  if (std::is_floating_point<T>::value ||
+      std::is_same<T, cl::sycl::half>::value) {
+    check_op<T>(Queue, std::numeric_limits<T>::infinity(), intel::minimum<T>(),
+                true, G, L);
+    check_op<T>(Queue, std::numeric_limits<T>::infinity(), intel::minimum<>(),
+                true, G, L);
+  } else {
+    check_op<T>(Queue, std::numeric_limits<T>::max(), intel::minimum<T>(), true,
+                G, L);
+    check_op<T>(Queue, std::numeric_limits<T>::max(), intel::minimum<>(), true,
+                G, L);
+  }
+
+  check_op<T>(Queue, T(G), intel::maximum<T>(), false, G, L);
+  check_op<T>(Queue, T(G), intel::maximum<>(), false, G, L);
+  if (std::is_floating_point<T>::value ||
+      std::is_same<T, cl::sycl::half>::value) {
+    check_op<T>(Queue, -std::numeric_limits<T>::infinity(), intel::maximum<T>(),
+                true, G, L);
+    check_op<T>(Queue, -std::numeric_limits<T>::infinity(), intel::maximum<>(),
+                true, G, L);
+  } else {
+    check_op<T>(Queue, std::numeric_limits<T>::min(), intel::maximum<T>(), true,
+                G, L);
+    check_op<T>(Queue, std::numeric_limits<T>::min(), intel::maximum<>(), true,
+                G, L);
+  }
+}
+
 int main() {
   queue Queue;
   if (!core_sg_supported(Queue.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int, true>(Queue);
-  check<int, false>(Queue);
-  check<unsigned int, true>(Queue);
-  check<unsigned int, false>(Queue);
-  check<long, true>(Queue);
-  check<long, false>(Queue);
-  check<unsigned long, true>(Queue);
-  check<unsigned long, false>(Queue);
-  check<float, true>(Queue);
-  check<float, false>(Queue);
+  check<int>(Queue);
+  check<unsigned int>(Queue);
+  check<long>(Queue);
+  check<unsigned long>(Queue);
+  check<float>(Queue);
   // scan half type is not supported in OCL CPU RT
 #ifdef SG_GPU
   if (Queue.get_device().has_extension("cl_khr_fp16")) {
-    check<cl::sycl::half, true>(Queue);
-    check<cl::sycl::half, false>(Queue);
+    check<cl::sycl::half>(Queue);
   }
 #endif
   if (Queue.get_device().has_extension("cl_khr_fp64")) {
-    check<double, true>(Queue);
-    check<double, false>(Queue);
+    check<double>(Queue);
   }
   std::cout << "Test passed." << std::endl;
   return 0;


### PR DESCRIPTION
Aligns the sub-group implementation with the extension doc:

- Enables reduce and scan to take functors as arguments
- Adds OpenCL-like reduce(x, op) overload to extension doc

Also clarifies interpretation of init values in documentation.

Signed-off-by: John Pennycook john.pennycook@intel.com