### PR TITLE
[SYCL] Add generation of sycl-module-id attribute for kernels

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -540,8 +540,10 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   if (!FD->hasAttr<OpenCLKernelAttr>())
     return;
 
+  // TODO Module identifier is not reliable for this purpose since two modules
+  // can have the same ID, needs improvement
   if (getLangOpts().SYCLIsDevice)
-    Fn->addFnAttr("module-id", Fn->getParent()->getModuleIdentifier());
+    Fn->addFnAttr("sycl-module-id", Fn->getParent()->getModuleIdentifier());
 
   llvm::LLVMContext &Context = getLLVMContext();
 

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -540,6 +540,9 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   if (!FD->hasAttr<OpenCLKernelAttr>())
     return;
 
+  if (getLangOpts().SYCLIsDevice)
+    Fn->addFnAttr("module-id", Fn->getParent()->getModuleIdentifier());
+
   llvm::LLVMContext &Context = getLLVMContext();
 
   CGM.GenOpenCLArgMetadata(Fn, FD, this);

--- a/clang/test/CodeGenSYCL/module-id.cpp
+++ b/clang/test/CodeGenSYCL/module-id.cpp
@@ -11,4 +11,4 @@ int main() {
 }
 // CHECK: define spir_kernel void @{{.*}}kernel{{.*}}() #[[KERN_ATTR:[0-9]+]]
 
-// CHECK: #[[KERN_ATTR]] = { {{.*}}"module-id"="{{.*}}module-id.cpp"{{.*}} }
+// CHECK: #[[KERN_ATTR]] = { {{.*}}"sycl-module-id"="{{.*}}module-id.cpp"{{.*}} }

--- a/clang/test/CodeGenSYCL/module-id.cpp
+++ b/clang/test/CodeGenSYCL/module-id.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class kernel>([]() {});
+  return 0;
+}
+// CHECK: define spir_kernel void @{{.*}}kernel{{.*}}() #[[KERN_ATTR:[0-9]+]]
+
+// CHECK: #[[KERN_ATTR]] = { {{.*}}"module-id"="{{.*}}module-id.cpp"{{.*}} }


### PR DESCRIPTION
This attribute contains string with module identifier. This information
will be used to split fully linked device modules into smaller ones.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>