### PR TITLE
[SYCL] Restoring the usage of filename in SYCL error reporting

### DIFF
--- a/sycl/include/CL/sycl/detail/device_impl.hpp
+++ b/sycl/include/CL/sycl/detail/device_impl.hpp
@@ -112,7 +112,7 @@ public:
   ~device_impl_pi() {
     if (!m_isRootDevice) {
       // TODO catch an exception and put it to list of asynchronous exceptions
-      CHECK_OCL_CODE_NO_EXC(RT::piDeviceRelease(m_device));
+      CHECK_OCL_CODE_NO_EXC("device_impl.hpp", RT::piDeviceRelease(m_device));
     }
   }
 

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -148,8 +148,9 @@ namespace pi {
 
 namespace RT = cl::sycl::detail::pi;
 
-#define PI_ASSERT(cond, msg) \
-  RT::assertion((cond), "assert: " msg);
+#define PI_ASSERT(PI_ASSERT_context, cond, msg)                                \
+  RT::assertion((cond),                                                        \
+                "assert: " PI_ASSERT_context ":" STRINGIFY_LINE(__LINE__) msg);
 
 #define PI_TRACE(func) RT::Trace<decltype(func)>(func, #func)
 
@@ -177,7 +178,7 @@ namespace RT = cl::sycl::detail::pi;
 template<class To, class From>
 To pi::cast(From value) {
   // TODO: see if more sanity checks are possible.
-  PI_ASSERT(sizeof(From) == sizeof(To), "cast failed size check");
+  PI_ASSERT("pi.hpp", sizeof(From) == sizeof(To), "cast failed size check");
   return (To)(value);
 }
 

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -106,7 +106,7 @@ template<typename Exception>
 void PiCall::check(RT::PiResult Result) {
   m_Result = Result;
   // TODO: remove dependency on CHECK_OCL_CODE_THROW.
-  CHECK_OCL_CODE_THROW(Result, Exception);
+  CHECK_OCL_CODE_THROW("pi.cpp", Result, Exception);
 }
 
 template void PiCall::check<cl::sycl::runtime_error>(RT::PiResult);

--- a/sycl/source/detail/pi_opencl.cpp
+++ b/sycl/source/detail/pi_opencl.cpp
@@ -80,7 +80,8 @@ pi_result OCL(piextDeviceSelectBinary)(
 
 pi_result OCL(piQueueCreate)(pi_context context, pi_device device,
                              pi_queue_properties properties, pi_queue *queue) {
-  PI_ASSERT(queue, "piQueueCreate failed, queue argument is null");
+  PI_ASSERT("pi_opencl.cpp", queue,
+            "piQueueCreate failed, queue argument is null");
 
   cl_platform_id curPlatform;
   cl_int ret_err = clGetDeviceInfo(cast<cl_device_id>(device),
@@ -230,7 +231,7 @@ pi_result OCL(piSamplerCreate)(pi_context context,
     } else if (sampler_properties[i] == PI_SAMPLER_INFO_FILTER_MODE) {
       filterMode = static_cast<pi_sampler_filter_mode>(sampler_properties[++i]);
     } else {
-      PI_ASSERT(false, "Cannot recognize sampler property");
+      PI_ASSERT("pi_opencl.cpp", false, "Cannot recognize sampler property");
     }
   }
 
@@ -259,7 +260,7 @@ pi_result OCL(piextGetDeviceFunctionPointer)(pi_device device,
   // TODO: once we have check that device supports corresponding extension,
   // we can insert an assertion that func_ptr is not nullptr. For now, let's
   // just return an error if failed to query such function
-  // PI_ASSERT(
+  // PI_ASSERT("pi_opencl.cpp",
   //     func_ptr != nullptr,
   //     "Failed to get address of clGetDeviceFunctionPointerINTEL function");
 

--- a/sycl/source/detail/usm/usm_dispatch.cpp
+++ b/sycl/source/detail/usm/usm_dispatch.cpp
@@ -200,25 +200,25 @@ void USMDispatcher::setKernelIndirectAccess(pi_kernel Kernel, pi_queue Queue) {
       cl_bool TrueVal = CL_TRUE;
 
       if (mEmulated) {
-        CHECK_OCL_CODE(mEmulator->setKernelExecInfo(
+        CHECK_OCL_CODE("usm_dispatch.cpp", mEmulator->setKernelExecInfo(
             CLKernel, CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL,
             sizeof(cl_bool), &TrueVal));
-        CHECK_OCL_CODE(mEmulator->setKernelExecInfo(
+        CHECK_OCL_CODE("usm_dispatch.cpp", mEmulator->setKernelExecInfo(
             CLKernel, CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL,
             sizeof(cl_bool), &TrueVal));
-        CHECK_OCL_CODE(mEmulator->setKernelExecInfo(
+        CHECK_OCL_CODE("usm_dispatch.cpp", mEmulator->setKernelExecInfo(
             CLKernel, CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL,
             sizeof(cl_bool), &TrueVal));
-        CHECK_OCL_CODE(
+        CHECK_OCL_CODE("usm_dispatch.cpp",
             mEmulator->setKernelIndirectUSMExecInfo(CLQueue, CLKernel));
       } else {
-        CHECK_OCL_CODE(clSetKernelExecInfo(
+        CHECK_OCL_CODE("usm_dispatch.cpp", clSetKernelExecInfo(
             CLKernel, CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL,
             sizeof(cl_bool), &TrueVal));
-        CHECK_OCL_CODE(clSetKernelExecInfo(
+        CHECK_OCL_CODE("usm_dispatch.cpp", clSetKernelExecInfo(
             CLKernel, CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL,
             sizeof(cl_bool), &TrueVal));
-        CHECK_OCL_CODE(clSetKernelExecInfo(
+        CHECK_OCL_CODE("usm_dispatch.cpp", clSetKernelExecInfo(
             CLKernel, CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL,
             sizeof(cl_bool), &TrueVal));
       }

--- a/sycl/test/basic_tests/buffer/buffer_interop.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_interop.cpp
@@ -29,7 +29,7 @@ int main() {
     cl_mem OpenCLBuffer = clCreateBuffer(
         MyQueue.get_context().get(), CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
         Size * sizeof(int), Init, &Error);
-    CHECK_OCL_CODE(Error);
+    CHECK_OCL_CODE("buffer basic test buffer_interop.cpp", Error);
     buffer<int, 1> Buffer{OpenCLBuffer, MyQueue.get_context()};
 
     if (Buffer.get_range() != InteropRange) {
@@ -67,7 +67,7 @@ int main() {
     }
 
     Error = clReleaseMemObject(OpenCLBuffer);
-    CHECK_OCL_CODE(Error);
+    CHECK_OCL_CODE("buffer basic test buffer_interop.cpp", Error);
 
     for (size_t i = 0; i < Size; ++i) {
       if (Result[i] != 20) {
@@ -90,7 +90,7 @@ int main() {
     cl_mem OpenCLBuffer = clCreateBuffer(
         MyQueue.get_context().get(), CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
         Size * sizeof(int), Init, &Error);
-    CHECK_OCL_CODE(Error);
+    CHECK_OCL_CODE("buffer basic test buffer_interop.cpp", Error);
     {
       buffer<int, 1> Buffer{OpenCLBuffer, MyQueue.get_context()};
       Buffer.set_final_data(Result);
@@ -102,7 +102,7 @@ int main() {
       });
     }
     Error = clReleaseMemObject(OpenCLBuffer);
-    CHECK_OCL_CODE(Error);
+    CHECK_OCL_CODE("buffer basic test buffer_interop.cpp", Error);
     for (size_t i = 0; i < Size; ++i) {
       if (Result[i] != 10) {
         std::cout << " array[" << i << "] is " << Result[i] << " expected "
@@ -123,7 +123,7 @@ int main() {
     cl_mem OpenCLBuffer = clCreateBuffer(
         MyQueue.get_context().get(), CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
         Size * sizeof(int), Init, &Error);
-    CHECK_OCL_CODE(Error);
+    CHECK_OCL_CODE("buffer basic test buffer_interop.cpp", Error);
     buffer<int, 1> Buffer{OpenCLBuffer, MyQueue.get_context()};
 
     MyQueue.submit([&](handler &CGH) {
@@ -141,7 +141,7 @@ int main() {
       }
     }
     Error = clReleaseMemObject(OpenCLBuffer);
-    CHECK_OCL_CODE(Error);
+    CHECK_OCL_CODE("buffer basic test buffer_interop.cpp", Error);
   }
   return Failed;
 }

--- a/sycl/test/basic_tests/buffer/subbuffer_interop.cpp
+++ b/sycl/test/basic_tests/buffer/subbuffer_interop.cpp
@@ -74,15 +74,15 @@ int main() {
       cl_program clProgram =
           clCreateProgramWithSource(clContext, 1, SrcString, &SrcStringSize, &Error);
 
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       Error = clBuildProgram(clProgram, 1, &clDevice, NULL, NULL, NULL);
 
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       cl_kernel clKernel = clCreateKernel(clProgram, "test", &Error);
 
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       buffer<int, 1> BufA(AMem, cl::sycl::range<1>(NSize));
       buffer<int, 1> BufB(BufA, NSize / 2, NSize / 2);
@@ -139,15 +139,15 @@ int main() {
       cl_program clProgram =
           clCreateProgramWithSource(clContext, 1, SrcString, &SrcStringSize, &Error);
 
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       Error = clBuildProgram(clProgram, 1, &clDevice, NULL, NULL, NULL);
 
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       cl_kernel clKernel = clCreateKernel(clProgram, "test", &Error);
 
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       buffer<int, 1> BufA(AMem, cl::sycl::range<1>(NSize));
       buffer<int, 1> BufB(BufA, 0, NSize / 4);
@@ -218,17 +218,17 @@ int main() {
       cl_program clProgram =
           clCreateProgramWithSource(clContext, 1, SrcString, &SrcStringSize, &Error);
 
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       Error = clBuildProgram(clProgram, 1, &clDevice, NULL, NULL, NULL);
 
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       cl_kernel clKernel1 = clCreateKernel(clProgram, "test1", &Error);
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       cl_kernel clKernel2 = clCreateKernel(clProgram, "test2", &Error);
-      CHECK_OCL_CODE(Error);
+      CHECK_OCL_CODE("buffer basic test subbuffer_interop.cpp", Error);
 
       buffer<int, 1> BufA(AMem, cl::sycl::range<1>(NSize));
       buffer<int, 1> BufB(BufA, 0, NSize / 2);

--- a/sycl/test/basic_tests/kernel_interop.cpp
+++ b/sycl/test/basic_tests/kernel_interop.cpp
@@ -39,13 +39,13 @@ int main() {
     cl_int Err;
     cl_program ClProgram = clCreateProgramWithSource(ClContext, CountSources,
                                                      Sources, nullptr, &Err);
-    CHECK_OCL_CODE(Err);
+    CHECK_OCL_CODE("kernel basic test kernel_interop.cpp", Err);
 
     Err = clBuildProgram(ClProgram, 0, nullptr, nullptr, nullptr, nullptr);
-    CHECK_OCL_CODE(Err);
+    CHECK_OCL_CODE("kernel basic test kernel_interop.cpp", Err);
 
     cl_kernel ClKernel = clCreateKernel(ClProgram, "foo1", &Err);
-    CHECK_OCL_CODE(Err);
+    CHECK_OCL_CODE("kernel basic test kernel_interop.cpp", Err);
 
     // Try to create kernel with another context
     bool Pass = false;
@@ -61,9 +61,12 @@ int main() {
     kernel Kernel(ClKernel, Context);
 
 
-    CHECK_OCL_CODE(clReleaseKernel(ClKernel));
-    CHECK_OCL_CODE(clReleaseContext(ClContext));
-    CHECK_OCL_CODE(clReleaseProgram(ClProgram));
+    CHECK_OCL_CODE("kernel basic test kernel_interop.cpp",
+                   clReleaseKernen(ClKernel));
+    CHECK_OCL_CODE("kernel basic test kernel_interop.cpp",
+                   clReleaseContext(ClContext));
+    CHECK_OCL_CODE("kernel basic test kernel_interop.cpp",
+                   clReleaseProgram(ClProgram));
 
   }
   return 0;

--- a/sycl/test/basic_tests/sampler/sampler.cpp
+++ b/sycl/test/basic_tests/sampler/sampler.cpp
@@ -61,7 +61,7 @@ int main() {
     if (Err == CL_INVALID_OPERATION)
       return 0;
 
-    CHECK_OCL_CODE(Err);
+    CHECK_OCL_CODE("sampler basic test sampler.cpp", Err);
     B = sycl::sampler(ClSampler, Queue.get_context());
   } else {
     // Host sampler

--- a/sycl/test/sub_group/common_ocl.cpp
+++ b/sycl/test/sub_group/common_ocl.cpp
@@ -17,6 +17,7 @@
 #include <CL/sycl.hpp>
 #include <cstring>
 #include <iostream>
+
 using namespace cl::sycl;
 struct Data {
   unsigned int local_id;
@@ -46,8 +47,8 @@ void check(queue &Queue, const int G, const int L, const char *SpvFile) {
     int Err;
     cl_program ClProgram = clCreateProgramWithIL(Queue.get_context().get(),
                                                  Spv.data(), Spv.size(), &Err);
-    CHECK_OCL_CODE(Err);
-    CHECK_OCL_CODE(
+    CHECK_OCL_CODE("sub_group test common_ocl.cpp", Err);
+    CHECK_OCL_CODE("sub_group test common_ocl.cpp",
         clBuildProgram(ClProgram, 0, nullptr, nullptr, nullptr, nullptr));
     program Prog(Queue.get_context(), ClProgram);
     Queue.submit([&](handler &cgh) {


### PR DESCRIPTION
Adding an additional string parameter to CHECK_OCL_CODE (and its downstream
macros,) and PI_ASSERT

Signed-off-by: Sindhu Chittireddy <sindhu.chittireddy@intel.com>