### PR TITLE
[SYCL][Driver] file.lib files are not under consideration for unbundling

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5845,8 +5845,12 @@ bool clang::driver::isOptimizationLevelFast(const ArgList &Args) {
 }
 
 bool clang::driver::isObjectFile(std::string FileName) {
-  return (llvm::sys::path::has_extension(FileName) &&
-      types::lookupTypeForExtension(
-          llvm::sys::path::extension(FileName).drop_front()) ==
-          types::TY_Object);
+  if (llvm::sys::path::has_extension(FileName)) {
+    std::string Ext(llvm::sys::path::extension(FileName).drop_front());
+    // We cannot rely on lookupTypeForExtension solely as that has 'lib'
+    // marked as an object.
+    return (Ext != "lib" &&
+            types::lookupTypeForExtension(Ext) == types::TY_Object);
+  }
+  return false;
 }

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -583,5 +583,14 @@
 // FO-CHECK: clang{{.*}} "-include" "[[HEADER]]" {{.*}} "-o" "[[OUTPUT2:.+\.obj]]"
 // FO-CHECK: clang-offload-bundler{{.*}} "-outputs=somefile.obj" "-inputs=[[OUTPUT1]],[[OUTPUT2]]"
 
+/// passing of a library should not trigger the unbundler
+// RUN: touch %t.a
+// RUN: touch %t.lib
+// RUN: %clang -ccc-print-phases -fsycl %t.a %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=LIB-UNBUNDLE-CHECK %s
+// RUN: %clang_cl -ccc-print-phases -fsycl %t.lib %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=LIB-UNBUNDLE-CHECK %s
+// LIB-UNBUNDLE-CHECK-NOT: clang-offload-unbundler
+
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc


### PR DESCRIPTION
On windows, passing file.lib on the command line was triggering the use of the
unbundler.  Use of -foffload-static-lib is the way to pass libraries to use
for unbundling.  We key off of the file name extension to determine if an
object should be unbundled.  We need to do an explicit check for 'lib' with
the filename object check as there are some type lookups which rely on 'lib'
being an object

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>