### PR TITLE
[SYCL] Propagate inline namespace to integration header.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1412,7 +1412,9 @@ void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D) {
       break;
     }
     ++NamespaceCnt;
-    NSStr.insert(0, Twine("namespace " + Twine(NS->getName()) + " { ").str());
+    const StringRef NSInlinePrefix = NS->isInline() ? "inline " : "";
+    NSStr.insert(
+        0, Twine(NSInlinePrefix + "namespace " + NS->getName() + " { ").str());
     DC = NS->getDeclContext();
   }
   O << NSStr;

--- a/clang/test/CodeGenSYCL/int_header_inline_ns.cpp
+++ b/clang/test/CodeGenSYCL/int_header_inline_ns.cpp
@@ -1,0 +1,73 @@
+// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
+// RUN: FileCheck -input-file=%t.h %s
+
+// This test checks if the SYCL device compiler is able to generate correct
+// integration header when the kernel name class is wrapped in an inline
+// namespace.
+
+#include "sycl.hpp"
+
+template <typename KernelName, typename KernelType>
+__attribute__((sycl_kernel)) void kernel_single_task(KernelType kernelFunc) {
+  kernelFunc();
+}
+
+// Top-level inline namespace
+// CHECK: inline namespace ns1 {
+// CHECK-NEXT: class Foo11;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline namespace ns1 {
+// CHECK-NEXT: class Foo12;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline namespace ns1 {
+// CHECK-NEXT: class Foo13;
+// CHECK-NEXT: }
+inline namespace ns1 {
+class Foo11 {};
+class Foo12;
+class Foo13 {};
+} // namespace ns1
+
+// Nested inline namespace
+// CHECK-NEXT: namespace ns2 { inline namespace ns3 {
+// CHECK-NEXT: class Foo21;
+// CHECK-NEXT: }}
+// CHECK-NEXT: namespace ns2 { inline namespace ns3 {
+// CHECK-NEXT: class Foo22;
+// CHECK-NEXT: }}
+namespace ns2 {
+inline namespace ns3 {
+class Foo21 {};
+class Foo22;
+} // namespace ns3
+} // namespace ns2
+
+// Namespace nested inside nested inline namespace
+// CHECK-NEXT: namespace ns4 { inline namespace ns5 { namespace ns6 {
+// CHECK-NEXT: class Foo31;
+// CHECK-NEXT: }}}
+// CHECK-NEXT: namespace ns4 { inline namespace ns5 { namespace ns6 {
+// CHECK-NEXT: class Foo32;
+// CHECK-NEXT: }}}
+namespace ns4 {
+inline namespace ns5 {
+namespace ns6 {
+class Foo31 {};
+class Foo32;
+} // namespace ns6
+} // namespace ns5
+} // namespace ns4
+
+int main() {
+  kernel_single_task<Foo11>([]() {});
+  kernel_single_task<::Foo12>([]() {});
+  kernel_single_task<ns1::Foo13>([]() {});
+
+  kernel_single_task<ns2::Foo21>([]() {});
+  kernel_single_task<ns2::ns3::Foo22>([]() {});
+
+  kernel_single_task<ns4::ns6::Foo31>([]() {});
+  kernel_single_task<ns4::ns5::ns6::Foo32>([]() {});
+
+  return 0;
+}


### PR DESCRIPTION
Previously, if kernel name was declared inside inline
namespaces the compilation failed since 'inline'
keyword wasn't propagated to integration header.
This patch fixes this issue.

Signed-off-by: Ilya Stepykin <ilya.stepykin@intel.com>