### PR TITLE
[SYCL] Specify output file for ocl-icd external project.

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -104,6 +104,7 @@ if( NOT OpenCL_LIBRARIES )
                ${OPENCL_ICD_LOADER_WDK}
     STEP_TARGETS      configure,build,install
     DEPENDS           ocl-headers
+    BUILD_BYPRODUCTS ${OpenCL_LIBRARIES}
   )
 else()
   file(GLOB ICD_LOADER_SRC "${OpenCL_LIBRARIES}*")


### PR DESCRIPTION
It's needed for ninja to correctly process dependencies.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>