### PR TITLE
[SYCL] Rectified precision issue with the float->half conversion.

### DIFF
--- a/sycl/source/half_type.cpp
+++ b/sycl/source/half_type.cpp
@@ -66,7 +66,7 @@ static uint16_t float2Half(const float &Val) {
   uint16_t Ret = 0;
   Ret |= Sign;
   Ret |= Exp16 << 10;
-  Ret |= Frac16;
+  Ret += Frac16;// Add the carry bit from operation Frac16 += 1;
 
   return Ret;
 }

--- a/sycl/test/basic_tests/half_type.cpp
+++ b/sycl/test/basic_tests/half_type.cpp
@@ -233,6 +233,8 @@ int main() {
   assert(bitwise_comparison_fp16(0.0, 0));
   // -0
   assert(bitwise_comparison_fp16(-0.0, 32768));
+  // 1.9999f
+  assert(bitwise_comparison_fp16(1.9999f, 0x4000));
   // nan
   assert(bitwise_comparison_fp16(0.0 / 0.0, 32256));
   assert(bitwise_comparison_fp16(-0.0 / 0.0, 32256));


### PR DESCRIPTION
Edited the test case to include the specific scenario that was failing.

Signed-off-by: Garima Gupta <garima.gupta@intel.com>