### PR TITLE
[SYCL] Add CurContext to MemObjRecord

### DIFF
--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -80,6 +80,10 @@ public:
 
   context get_context() const { return m_Context; }
 
+  ContextImplPtr get_context_impl() const {
+    return detail::getSyclObjImpl(m_Context);
+  }
+
   device get_device() const { return m_Device; }
 
   bool is_host() const { return m_HostQueue; }

--- a/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
@@ -41,6 +41,9 @@ struct MemObjRecord {
   // Contains latest write commands working with memory object.
   std::vector<Command *> MWriteLeafs;
 
+  // The context which has the latest state of the memory object.
+  ContextImplPtr MCurContext;
+
   // The flag indicates that the content of the memory object was/will be
   // modified. Used while deciding if copy back needed.
   bool MMemModified;
@@ -154,7 +157,7 @@ private:
 
     // Searches for suitable alloca in memory record.
     AllocaCommandBase *findAllocaForReq(MemObjRecord *Record, Requirement *Req,
-                                        QueueImplPtr Queue);
+                                        const ContextImplPtr &Context);
     // Searches for suitable alloca in memory record.
     // If none found, creates new one.
     AllocaCommandBase *getOrCreateAllocaForReq(MemObjRecord *Record,


### PR DESCRIPTION
CurContext indicates context which contains latest data for the memory
object. This goal of this field is to simplify detection whether memory
copying between contexts is needed.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>