### PR TITLE
[SYCL] Fix loop metadata layout in reverse translation

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVReader.h
+++ b/llvm-spirv/lib/SPIRV/SPIRVReader.h
@@ -187,6 +187,9 @@ public:
   // which are supposed to be replaced by the real values later.
   typedef std::map<SPIRVValue *, LoadInst *> SPIRVToLLVMPlaceholderMap;
 
+  typedef std::map<const BasicBlock *, const SPIRVValue *>
+      SPIRVToLLVMLoopMetadataMap;
+
 private:
   Module *M;
   BuiltinVarMap BuiltinGVMap;
@@ -198,6 +201,11 @@ private:
   SPIRVBlockToLLVMStructMap BlockMap;
   SPIRVToLLVMPlaceholderMap PlaceholderMap;
   std::unique_ptr<SPIRVToLLVMDbgTran> DbgTran;
+
+  // Loops metadata is translated in the end of a function translation.
+  // This storage contains pairs of translated loop header basic block and loop
+  // metadata SPIR-V instruction in SPIR-V representation of this basic block.
+  SPIRVToLLVMLoopMetadataMap FuncLoopMetadataMap;
 
   Type *mapType(SPIRVType *BT, Type *T);
 
@@ -246,7 +254,8 @@ private:
   Value *oclTransConstantPipeStorage(SPIRV::SPIRVConstantPipeStorage *BCPS);
   void setName(llvm::Value *V, SPIRVValue *BV);
   template <typename LoopInstType>
-  void setLLVMLoopMetadata(LoopInstType *LM, BranchInst *BI);
+  void setLLVMLoopMetadata(const LoopInstType *LM, Instruction *BI);
+  void transLLVMLoopMetadata(const Function *F);
   inline llvm::Metadata *getMetadataFromName(std::string Name);
   inline std::vector<llvm::Metadata *>
   getMetadataFromNameAndParameter(std::string Name, SPIRVWord Parameter);

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1057,8 +1057,8 @@ public:
 
   SPIRVId getMergeBlock() { return MergeBlock; }
   SPIRVId getContinueTarget() { return ContinueTarget; }
-  SPIRVWord getLoopControl() { return LoopControl; }
-  std::vector<SPIRVWord> getLoopControlParameters() {
+  SPIRVWord getLoopControl() const { return LoopControl; }
+  std::vector<SPIRVWord> getLoopControlParameters() const {
     return LoopControlParameters;
   }
 
@@ -1105,7 +1105,7 @@ public:
     setHasNoId();
     setHasNoType();
   }
-  std::vector<SPIRVValue *> getPairs() { return getValues(Pairs); }
+  std::vector<SPIRVValue *> getPairs() const { return getValues(Pairs); }
   SPIRVValue *getSelect() const { return getValue(Select); }
   SPIRVBasicBlock *getDefault() const {
     return static_cast<SPIRVBasicBlock *>(getValue(Default));
@@ -1361,9 +1361,9 @@ public:
     setHasNoType();
   }
 
-  SPIRVWord getLoopControl() { return LoopControl; }
+  SPIRVWord getLoopControl() const { return LoopControl; }
 
-  std::vector<SPIRVWord> getLoopControlParameters() {
+  std::vector<SPIRVWord> getLoopControlParameters() const {
     return LoopControlParameters;
   }
 

--- a/llvm-spirv/test/DebugInfo/DebugControlFlow.cl
+++ b/llvm-spirv/test/DebugInfo/DebugControlFlow.cl
@@ -35,6 +35,6 @@ void sample() {
 // CHECK-SPIRV: {{[0-9]+}} LoopMerge [[MergeBlock:[0-9]+]] [[ContinueTarget:[0-9]+]] 1
 // CHECK-SPIRV-NOT: ExtInst
 // CHECK-SPIRV: Branch
-// CHECK-LLVM: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}, !dbg !{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
+// CHECK-LLVM: br label %{{.*}}, !dbg !{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
 // CHECK-LLVM: ![[MD]] = distinct !{![[MD]], ![[MD_unroll:[0-9]+]]}
 // CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.enable"}

--- a/llvm-spirv/test/InfiniteLoopMetadataPlacement.ll
+++ b/llvm-spirv/test/InfiniteLoopMetadataPlacement.ll
@@ -1,0 +1,105 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_unstructured_loop_controls %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPV
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-REV-LLVM
+
+; ModuleID = 'llvm_loop_test.cpp'
+source_filename = "llvm_loop_test.cpp"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-linux-sycldevice"
+
+$_ZTS12WhileOneTest = comdat any
+
+; CHECK-SPV: {{[0-9]+}} Name [[WH_COND:[0-9]+]] "while.cond"
+
+; Function Attrs: inlinehint nounwind
+define weak_odr dso_local spir_kernel void @_ZTS12WhileOneTest() #0 comdat !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
+entry:
+  %i = alloca i32, align 4
+  %s = alloca i32, align 4
+  %0 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #2
+  store i32 0, i32* %i, align 4, !tbaa !7
+  %1 = bitcast i32* %s to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #2
+  store i32 0, i32* %s, align 4, !tbaa !7
+  br label %while.cond
+
+; CHECK-SPV-NOT: {{[0-9]+}} LoopControlINTEL
+; CHECK-SPV-NOT: {{[0-9]+}} LoopMerge
+
+while.cond:                                       ; preds = %if.end, %entry
+; CHECK-SPV:      {{[0-9]+}} Label [[WH_COND]]
+; CHECK-SPV-NEXT: {{[0-9]+}} LoopControlINTEL 4
+; CHECK-SPV-NEXT: {{[0-9]+}} Branch
+  br label %while.body
+
+; CHECK-SPV-NOT: {{[0-9]+}} LoopControlINTEL
+; CHECK-SPV-NOT: {{[0-9]+}} LoopMerge
+
+while.body:                                       ; preds = %while.cond
+  %2 = load i32, i32* %i, align 4, !tbaa !7
+  %cmp = icmp sge i32 %2, 16
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:                                          ; preds = %while.body
+  br label %while.end
+
+if.else:                                          ; preds = %while.body
+  %3 = load i32, i32* %i, align 4, !tbaa !7
+  %4 = load i32, i32* %s, align 4, !tbaa !7
+  %add = add nsw i32 %4, %3
+  store i32 %add, i32* %s, align 4, !tbaa !7
+  br label %if.end
+
+; CHECK-REV-LLVM-NOT: br {{.*}}, !llvm.loop
+
+if.end:                                           ; preds = %if.else
+; CHECK-REV-LLVM: if.end:
+  %5 = load i32, i32* %i, align 4, !tbaa !7
+  %inc = add nsw i32 %5, 1
+  store i32 %inc, i32* %i, align 4, !tbaa !7
+  br label %while.cond, !llvm.loop !9
+; CHECK-REV-LLVM: br label %while.cond, !llvm.loop ![[MD_IVDEP:[0-9]+]]
+
+; CHECK-REV-LLVM-NOT: br {{.*}}, !llvm.loop
+
+while.end:                                        ; preds = %if.then
+  %6 = bitcast i32* %s to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %6) #2
+  %7 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %7) #2
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+attributes #0 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { argmemonly nounwind }
+attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.spir.version = !{!1}
+!spirv.Source = !{!2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{i32 4, i32 100000}
+!3 = !{!"clang version 9.0.0"}
+!4 = !{}
+!5 = !{!"omnipotent char", !6, i64 0}
+!6 = !{!"Simple C++ TBAA"}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"int", !5, i64 0}
+!9 = distinct !{!9, !10}
+!10 = !{!"llvm.loop.ivdep.enable"}
+
+; CHECK-REV-LLVM: ![[MD_IVDEP]] = distinct !{![[MD_IVDEP]], ![[MD_ivdep_enable:[0-9]+]]}
+; CHECK-REV-LLVM: ![[MD_ivdep_enable]] = !{!"llvm.loop.ivdep.enable"}

--- a/llvm-spirv/test/OpLoopMergeDontUnrollHint1.spt
+++ b/llvm-spirv/test/OpLoopMergeDontUnrollHint1.spt
@@ -83,6 +83,6 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
+; CHECK-LLVM: br label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
 ; CHECK-LLVM: ![[MD]] = distinct !{![[MD]], ![[MD_unroll:[0-9]+]]}
 ; CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.disable"}

--- a/llvm-spirv/test/OpLoopMergeNone.spt
+++ b/llvm-spirv/test/OpLoopMergeNone.spt
@@ -84,5 +84,5 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
+; CHECK-LLVM: br label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
 ; CHECK-LLVM: ![[MD]] = distinct !{![[MD]]}

--- a/llvm-spirv/test/OpLoopMergePartialUnroll.spt
+++ b/llvm-spirv/test/OpLoopMergePartialUnroll.spt
@@ -83,6 +83,6 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
+; CHECK-LLVM: br label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
 ; CHECK-LLVM: ![[MD]] = distinct !{![[MD]], ![[MD_unroll:[0-9]+]]}
 ; CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.count", i32 4}

--- a/llvm-spirv/test/OpLoopMergeUnroll.spt
+++ b/llvm-spirv/test/OpLoopMergeUnroll.spt
@@ -84,6 +84,6 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
+; CHECK-LLVM: br label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
 ; CHECK-LLVM: ![[MD]] = distinct !{![[MD]], ![[MD_unroll:[0-9]+]]}
 ; CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.enable"}

--- a/llvm-spirv/test/transcoding/FPGALoopAttr.ll
+++ b/llvm-spirv/test/transcoding/FPGALoopAttr.ll
@@ -161,11 +161,11 @@ attributes #0 = { convergent noinline nounwind optnone "correctly-rounded-divide
 !10 = !{!"llvm.loop.max_concurrency.count", i32 2}
 !11 = distinct !{!11, !8, !10}
 
-; CHECK-LLVM: br i1 %cmp, label %for.body, label %for.end, !llvm.loop ![[MD_A:[0-9]+]]
-; CHECK-LLVM: br i1 %cmp{{[0-9]+}}, label %for.body{{[0-9]+}}, label %for.end{{[0-9]+}}, !llvm.loop ![[MD_B:[0-9]+]]
-; CHECK-LLVM: br i1 %cmp{{[0-9]+}}, label %for.body{{[0-9]+}}, label %for.end{{[0-9]+}}, !llvm.loop ![[MD_C:[0-9]+]]
-; CHECK-LLVM: br i1 %cmp{{[0-9]+}}, label %for.body{{[0-9]+}}, label %for.end{{[0-9]+}}, !llvm.loop ![[MD_D:[0-9]+]]
-; CHECK-LLVM: br i1 %cmp{{[0-9]+}}, label %for.body{{[0-9]+}}, label %for.end{{[0-9]+}}, !llvm.loop ![[MD_E:[0-9]+]]
+; CHECK-LLVM: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_A:[0-9]+]]
+; CHECK-LLVM: br label %for.cond{{[0-9]+}}, !llvm.loop ![[MD_B:[0-9]+]]
+; CHECK-LLVM: br label %for.cond{{[0-9]+}}, !llvm.loop ![[MD_C:[0-9]+]]
+; CHECK-LLVM: br label %for.cond{{[0-9]+}}, !llvm.loop ![[MD_D:[0-9]+]]
+; CHECK-LLVM: br label %for.cond{{[0-9]+}}, !llvm.loop ![[MD_E:[0-9]+]]
 
 ; CHECK-LLVM: ![[MD_A]] = distinct !{![[MD_A]], ![[MD_ivdep_enable:[0-9]+]]}
 ; CHECK-LLVM: ![[MD_ivdep_enable]] = !{!"llvm.loop.ivdep.enable"}


### PR DESCRIPTION
In accordance with the SPIR-V spec loop metadata should be attached to
the header block of the loop (via OpLoopMerge or OpLoopControlINTEL)
whilst in LLVM IR it should be attached to latch block of the loop
(via llvm.loop metadata).
Fix attachment place of loop metadata in reverse translation.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>