### PR TITLE
[SYCL] WIP On kernel_args_restrict (Sema Changes)

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1091,6 +1091,12 @@ def SYCLDeviceIndirectlyCallable : InheritableAttr {
   let LangOpts = [SYCLIsDevice];
   let Documentation = [SYCLDeviceIndirectlyCallableDocs];
 }
+def IntelFPGAKernelArgsRestrict : InheritableAttr {
+  let Spellings = [ CXX11<"intelfpga", "kernel_args_restrict"> ];
+  let Subjects = SubjectList<[ FunctionLike ], ErrorDiag>;
+  let LangOpts = [ SYCLIsDevice, SYCLIsHost ];
+  let Documentation = [ IntelFPGAKernelArgsRestrictDocs ];
+}
 
 def C11NoReturn : InheritableAttr {
   let Spellings = [Keyword<"_Noreturn">];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1835,6 +1835,27 @@ loads).
   }];
 }
 
+def IntelFPGAKernelArgsRestrictDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "kernel_args_restrict";
+  let Content = [{
+The attribute ``intelfpga::kernel_args_restrict`` is legal on device functions.
+When applied to a device function that is invoked as a device kernel, the
+attribute is a hint to the compiler that no pointer argument to the kernel which
+is defined through an accessor (not USM), will alias any other pointer kernel
+argument that was defined through an accessor.  This effect is equivalent to
+annotating restrict on all kernel pointer arguments in an OpenCL or SPIR-V
+kernel.  If ``intelfpga::kernel_args_restrict`` is applied to a function called
+from a device kernel, propagation of the attribute to any caller(s), including
+up to a kernel boundary, is implementation defined and not guaranteed through
+this extension.  The attribute forms an unchecked assertion, in that
+implementations can assume maximal no-aliasing between kernel arguments, and do
+not need to check/confirm the pre-condition in any way.  If a user applies
+``intelfpga::kernel_args_restrict`` to a kernel, but there is in fact aliasing
+between kernel pointer arguments at runtime, the behavior is undefined.
+  }];
+}
+
 def SYCLIntelFPGAIVDepAttrDocs : Documentation {
   let Category = DocCatVariable;
   let Heading = "ivdep";

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -148,6 +148,13 @@ public:
     return SyntaxUsed == AS_CXX11 || isAlignasAttribute();
   }
 
+  bool isAllowedOnLambdas() const {
+    // FIXME: Eventually we want to do a list here populated via tablegen.  But
+    // we want C++ attributes to be permissible on Lambdas, and get propagated
+    // to the call operator declaration.
+    return getParsedKind() == AT_IntelFPGAKernelArgsRestrict;
+  }
+
   bool isC2xAttribute() const { return SyntaxUsed == AS_C2x; }
 
   bool isKeywordAttribute() const {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6752,6 +6752,13 @@ static void handleMSAllocatorAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 // Top Level Sema Entry Points
 //===----------------------------------------------------------------------===//
 
+static bool IsDeclLambdaCallOperator(Decl *D) {
+  if (const auto *MD = dyn_cast<CXXMethodDecl>(D))
+    return MD->getParent()->isLambda() &&
+           MD->getOverloadedOperator() == OverloadedOperatorKind::OO_Call;
+  return false;
+}
+
 /// ProcessDeclAttribute - Apply the specific attribute to the specified decl if
 /// the attribute applies to decls.  If the attribute is a type attribute, just
 /// silently ignore it if a GNU attribute.
@@ -6763,7 +6770,8 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
 
   // Ignore C++11 attributes on declarator chunks: they appertain to the type
   // instead.
-  if (AL.isCXX11Attribute() && !IncludeCXX11Attributes)
+  if (AL.isCXX11Attribute() && !IncludeCXX11Attributes &&
+      (!IsDeclLambdaCallOperator(D) || !AL.isAllowedOnLambdas()))
     return;
 
   // Unknown attributes are automatically warned on. Target-specific attributes
@@ -7515,6 +7523,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case ParsedAttr::AT_RenderScriptKernel:
     handleSimpleAttribute<RenderScriptKernelAttr>(S, D, AL);
+    break;
+  case ParsedAttr::AT_IntelFPGAKernelArgsRestrict:
+    handleSimpleAttribute<IntelFPGAKernelArgsRestrictAttr>(S, D, AL);
     break;
   // XRay attributes.
   case ParsedAttr::AT_XRayInstrument:

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -208,6 +208,11 @@ namespace {
       return chunkIndex == declarator.getNumTypeObjects();
     }
 
+    bool isProcessingLambdaExpr() const {
+      return declarator.isFunctionDeclarator() &&
+             declarator.getContext() == DeclaratorContext::LambdaExprContext;
+    }
+
     unsigned getCurrentChunkIndex() const {
       return chunkIndex;
     }
@@ -7570,7 +7575,8 @@ static void processTypeAttrs(TypeProcessingState &state, QualType &type,
     switch (attr.getKind()) {
     default:
       // A C++11 attribute on a declarator chunk must appertain to a type.
-      if (attr.isCXX11Attribute() && TAL == TAL_DeclChunk) {
+      if (attr.isCXX11Attribute() && TAL == TAL_DeclChunk &&
+          (!state.isProcessingLambdaExpr() || !attr.isAllowedOnLambdas())) {
         state.getSema().Diag(attr.getLoc(), diag::err_attribute_not_type_attr)
             << attr;
         attr.setUsedAsTypeAttr();


### PR DESCRIPTION
Sema changes to allow kernel_args_restrict on the lambda kernels.

@asavonic : Please take a look and add the codegen changes that you want out of this.