### PR TITLE
[SYCL] Add support for image with pitch but without host ptr provided.

### DIFF
--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -283,7 +283,7 @@ public:
                     RT::PiEvent &OutEventToWait) override {
     void *UserPtr = InitFromUserData ? BaseT::getUserPtr() : nullptr;
 
-    RT::PiMemImageDesc Desc = getImageDesc((bool)UserPtr);
+    RT::PiMemImageDesc Desc = getImageDesc(static_cast<bool>(UserPtr));
     assert(checkImageDesc(Desc, Context, UserPtr) &&
            "The check an image desc failed.");
 
@@ -385,8 +385,8 @@ private:
     // TODO handle cases with IMAGE1D_ARRAY and IMAGE2D_ARRAY
     Desc.image_array_size = 0;
     // Pitches must be 0 if host ptr is not provided.
-    Desc.image_row_pitch = InitFromHostPtr ? MRowPitch: 0;
-    Desc.image_slice_pitch = InitFromHostPtr ? MSlicePitch: 0;
+    Desc.image_row_pitch = InitFromHostPtr ? MRowPitch : 0;
+    Desc.image_slice_pitch = InitFromHostPtr ? MSlicePitch : 0;
 
     Desc.num_mip_levels = 0;
     Desc.num_samples = 0;

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -283,7 +283,7 @@ public:
                     RT::PiEvent &OutEventToWait) override {
     void *UserPtr = InitFromUserData ? BaseT::getUserPtr() : nullptr;
 
-    RT::PiMemImageDesc Desc = getImageDesc(static_cast<bool>(UserPtr));
+    RT::PiMemImageDesc Desc = getImageDesc(UserPtr != nullptr);
     assert(checkImageDesc(Desc, Context, UserPtr) &&
            "The check an image desc failed.");
 

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -283,7 +283,7 @@ public:
                     RT::PiEvent &OutEventToWait) override {
     void *UserPtr = InitFromUserData ? BaseT::getUserPtr() : nullptr;
 
-    RT::PiMemImageDesc Desc = getImageDesc();
+    RT::PiMemImageDesc Desc = getImageDesc((bool)UserPtr);
     assert(checkImageDesc(Desc, Context, UserPtr) &&
            "The check an image desc failed.");
 
@@ -376,7 +376,7 @@ private:
     return PI_MEM_TYPE_IMAGE3D;
   }
 
-  RT::PiMemImageDesc getImageDesc() {
+  RT::PiMemImageDesc getImageDesc(bool InitFromHostPtr) {
     RT::PiMemImageDesc Desc;
     Desc.image_type = getImageType();
     Desc.image_width = MRange[0];
@@ -384,8 +384,9 @@ private:
     Desc.image_depth = Dimensions > 2 ? MRange[2] : 1;
     // TODO handle cases with IMAGE1D_ARRAY and IMAGE2D_ARRAY
     Desc.image_array_size = 0;
-    Desc.image_row_pitch = MRowPitch;
-    Desc.image_slice_pitch = MSlicePitch;
+    // Pitches must be 0 if host ptr is not provided.
+    Desc.image_row_pitch = InitFromHostPtr ? MRowPitch: 0;
+    Desc.image_slice_pitch = InitFromHostPtr ? MSlicePitch: 0;
 
     Desc.num_mip_levels = 0;
     Desc.num_samples = 0;

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -78,7 +78,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image(image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range,
-        typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
         Order, Type, Range, Pitch, PropList);

--- a/sycl/test/basic_tests/image.cpp
+++ b/sycl/test/basic_tests/image.cpp
@@ -24,6 +24,9 @@ int main() {
   const sycl::image_channel_order ChanOrder = sycl::image_channel_order::rgba;
   const sycl::image_channel_type ChanType = sycl::image_channel_type::fp32;
 
+  constexpr auto SYCLRead = sycl::access::mode::read;
+  constexpr auto SYCLWrite = cl::sycl::access::mode::write;
+
   const sycl::range<2> Img1Size(4, 4);
   const sycl::range<2> Img2Size(4, 4);
 
@@ -35,8 +38,6 @@ int main() {
     sycl::image<2> Img2(Img2HostData.data(), ChanOrder, ChanType, Img2Size);
     TestQueue Q{sycl::default_selector()};
     Q.submit([&](sycl::handler &CGH) {
-      constexpr auto SYCLRead = sycl::access::mode::read;
-      constexpr auto SYCLWrite = cl::sycl::access::mode::write;
 
       auto Img1Acc = Img1.get_access<sycl::float4, SYCLRead>(CGH);
       auto Img2Acc = Img2.get_access<sycl::float4, SYCLWrite>(CGH);
@@ -61,6 +62,16 @@ int main() {
         return 1;
       }
     }
+
+  {
+    const sycl::range<1> ImgPitch(4 * 4 * 4 * 2);
+    sycl::image<2> Img(ChanOrder, ChanType, Img1Size, ImgPitch);
+    TestQueue Q{sycl::default_selector()};
+    Q.submit([&](sycl::handler &CGH) {
+      auto ImgAcc = Img.get_access<sycl::float4, SYCLRead>(CGH);
+      CGH.single_task<class EmptyKernel>([=]() { ImgAcc.get_size(); });
+    });
+  }
 
   std::cout << "Success" << std::endl;
   return 0;

--- a/sycl/test/basic_tests/image.cpp
+++ b/sycl/test/basic_tests/image.cpp
@@ -25,7 +25,7 @@ int main() {
   const sycl::image_channel_type ChanType = sycl::image_channel_type::fp32;
 
   constexpr auto SYCLRead = sycl::access::mode::read;
-  constexpr auto SYCLWrite = cl::sycl::access::mode::write;
+  constexpr auto SYCLWrite = sycl::access::mode::write;
 
   const sycl::range<2> Img1Size(4, 4);
   const sycl::range<2> Img2Size(4, 4);


### PR DESCRIPTION
In this case pitches passed to OpenCL must be 0.
+ Aligned image constructor with the SYCL specification.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>