### PR TITLE
[SYCL] Add empty task type of commands

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -467,6 +467,23 @@ cl_int MemCpyCommandHost::enqueueImp() {
   return CL_SUCCESS;
 }
 
+void EmptyCommand::printDot(std::ostream &Stream) const {
+  Stream << "\"" << this << "\" [style=filled, fillcolor=\"#8d8f29\", label=\"";
+
+  Stream << "ID = " << this << "\n";
+  Stream << "EMPTY NODE"
+         << "\\n";
+
+  Stream << "\"];" << std::endl;
+
+  for (const auto &Dep : MDeps) {
+    Stream << "  \"" << this << "\" -> \"" << Dep.MDepCommand << "\""
+           << " [ label = \"Access mode: "
+           << accessModeToString(Dep.MReq->MAccessMode) << "\\n"
+           << "MemObj: " << Dep.MReq->MSYCLMemObj << " \" ]" << std::endl;
+  }
+}
+
 void MemCpyCommandHost::printDot(std::ostream &Stream) const {
   Stream << "\"" << this << "\" [style=filled, fillcolor=\"#B6A2EB\", label=\"";
 


### PR DESCRIPTION
The command does nothing during enqueue. The task can be used to implement
locks in the graph, or to merge several nodes into one.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>