### PR TITLE
[SYCL][FPGA] Make pipe feature to be Intel extension

### DIFF
--- a/sycl/include/CL/sycl/intel/fpga_extensions.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_extensions.hpp
@@ -9,3 +9,4 @@
 #pragma once
 #include <CL/sycl/intel/fpga_device_selector.hpp>
 #include <CL/sycl/intel/fpga_reg.hpp>
+#include <CL/sycl/intel/pipes.hpp>

--- a/sycl/include/CL/sycl/intel/pipes.hpp
+++ b/sycl/include/CL/sycl/intel/pipes.hpp
@@ -1,0 +1,89 @@
+//==---------------- pipes.hpp - SYCL pipes ------------*- C++ -*-----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===--------------------------------------------------------------------=== //
+
+#pragma once
+
+#include <CL/__spirv/spirv_ops.hpp>
+#include <CL/__spirv/spirv_types.hpp>
+#include <CL/sycl/stl.hpp>
+
+namespace cl {
+namespace sycl {
+namespace intel {
+
+template <class name, class dataT, int32_t min_capacity = 0> class pipe {
+public:
+  // Non-blocking pipes
+  // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
+  // friendly LLVM IR.
+  static dataT read(bool &Success) {
+#ifdef __SYCL_DEVICE_ONLY__
+    RPipeTy<dataT> RPipe =
+      __spirv_CreatePipeFromPipeStorage_read<dataT>(&m_Storage);
+    dataT TempData;
+    Success = !static_cast<bool>(
+        __spirv_ReadPipe(RPipe, &TempData, m_Size, m_Alignment));
+    return TempData;
+#else
+    assert(!"Pipes are not supported on a host device!");
+#endif // __SYCL_DEVICE_ONLY__
+  }
+
+  // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
+  // friendly LLVM IR.
+  static void write(const dataT &Data, bool &Success) {
+#ifdef __SYCL_DEVICE_ONLY__
+    WPipeTy<dataT> WPipe =
+      __spirv_CreatePipeFromPipeStorage_write<dataT>(&m_Storage);
+    Success = !static_cast<bool>(
+        __spirv_WritePipe(WPipe, &Data, m_Size, m_Alignment));
+#else
+    assert(!"Pipes are not supported on a host device!");
+#endif // __SYCL_DEVICE_ONLY__
+  }
+
+  // Blocking pipes
+  // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
+  // friendly LLVM IR.
+  static dataT read() {
+#ifdef __SYCL_DEVICE_ONLY__
+    RPipeTy<dataT> RPipe =
+      __spirv_CreatePipeFromPipeStorage_read<dataT>(&m_Storage);
+    dataT TempData;
+    __spirv_ReadPipeBlockingINTEL(RPipe, &TempData, m_Size, m_Alignment);
+    return TempData;
+#else
+    assert(!"Pipes are not supported on a host device!");
+#endif // __SYCL_DEVICE_ONLY__
+  }
+
+  // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
+  // friendly LLVM IR.
+  static void write(const dataT &Data) {
+#ifdef __SYCL_DEVICE_ONLY__
+    WPipeTy<dataT> WPipe =
+      __spirv_CreatePipeFromPipeStorage_write<dataT>(&m_Storage);
+    __spirv_WritePipeBlockingINTEL(WPipe, &Data, m_Size, m_Alignment);
+#else
+    assert(!"Pipes are not supported on a host device!");
+#endif // __SYCL_DEVICE_ONLY__
+  }
+
+private:
+  static constexpr int32_t m_Size = sizeof(dataT);
+  static constexpr int32_t m_Alignment = alignof(dataT);
+  static constexpr int32_t m_Capacity = min_capacity;
+#ifdef __SYCL_DEVICE_ONLY__
+  static constexpr struct ConstantPipeStorage m_Storage = {m_Size, m_Alignment,
+                                                           m_Capacity};
+#endif // __SYCL_DEVICE_ONLY__
+};
+
+} // namespace intel
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/pipes.hpp
+++ b/sycl/include/CL/sycl/pipes.hpp
@@ -8,80 +8,11 @@
 
 #pragma once
 
-#include <CL/__spirv/spirv_ops.hpp>
-#include <CL/__spirv/spirv_types.hpp>
-#include <CL/sycl/stl.hpp>
+#include <CL/sycl/intel/pipes.hpp>
 
 namespace cl {
 namespace sycl {
-
-template <class name, class dataT, int32_t min_capacity = 0> class pipe {
-public:
-  // Non-blocking pipes
-  // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
-  // friendly LLVM IR.
-  static dataT read(bool &Success) {
-#ifdef __SYCL_DEVICE_ONLY__
-    RPipeTy<dataT> RPipe =
-      __spirv_CreatePipeFromPipeStorage_read<dataT>(&m_Storage);
-    dataT TempData;
-    Success = !static_cast<bool>(
-        __spirv_ReadPipe(RPipe, &TempData, m_Size, m_Alignment));
-    return TempData;
-#else
-    assert(!"Pipes are not supported on a host device!");
-#endif // __SYCL_DEVICE_ONLY__
-  }
-
-  // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
-  // friendly LLVM IR.
-  static void write(const dataT &Data, bool &Success) {
-#ifdef __SYCL_DEVICE_ONLY__
-    WPipeTy<dataT> WPipe =
-      __spirv_CreatePipeFromPipeStorage_write<dataT>(&m_Storage);
-    Success = !static_cast<bool>(
-        __spirv_WritePipe(WPipe, &Data, m_Size, m_Alignment));
-#else
-    assert(!"Pipes are not supported on a host device!");
-#endif // __SYCL_DEVICE_ONLY__
-  }
-
-  // Blocking pipes
-  // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
-  // friendly LLVM IR.
-  static dataT read() {
-#ifdef __SYCL_DEVICE_ONLY__
-    RPipeTy<dataT> RPipe =
-      __spirv_CreatePipeFromPipeStorage_read<dataT>(&m_Storage);
-    dataT TempData;
-    __spirv_ReadPipeBlockingINTEL(RPipe, &TempData, m_Size, m_Alignment);
-    return TempData;
-#else
-    assert(!"Pipes are not supported on a host device!");
-#endif // __SYCL_DEVICE_ONLY__
-  }
-
-  // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
-  // friendly LLVM IR.
-  static void write(const dataT &Data) {
-#ifdef __SYCL_DEVICE_ONLY__
-    WPipeTy<dataT> WPipe =
-      __spirv_CreatePipeFromPipeStorage_write<dataT>(&m_Storage);
-    __spirv_WritePipeBlockingINTEL(WPipe, &Data, m_Size, m_Alignment);
-#else
-    assert(!"Pipes are not supported on a host device!");
-#endif // __SYCL_DEVICE_ONLY__
-  }
-
-private:
-  static constexpr int32_t m_Size = sizeof(dataT);
-  static constexpr int32_t m_Alignment = alignof(dataT);
-  static constexpr int32_t m_Capacity = min_capacity;
-#ifdef __SYCL_DEVICE_ONLY__
-  static constexpr struct ConstantPipeStorage m_Storage = {m_Size, m_Alignment,
-                                                           m_Capacity};
-#endif // __SYCL_DEVICE_ONLY__
-};
-
+template <class name, class dataT, int32_t min_capacity = 0>
+using pipe = intel::pipe<name, dataT, min_capacity>;
 } // namespace sycl
 } // namespace cl

--- a/sycl/test/fpga_tests/fpga_pipes.cpp
+++ b/sycl/test/fpga_tests/fpga_pipes.cpp
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include <CL/sycl.hpp>
+#include <CL/sycl/intel/fpga_extensions.hpp>
 #include <iostream>
 
 // Size of an array passing through a pipe
@@ -27,7 +28,7 @@ class templ_nb_pipe;
 
 // For non-blocking multiple pipes
 template<int N>
-using PipeMulNb = cl::sycl::pipe<class templ_nb_pipe<N>, int>;
+using PipeMulNb = cl::sycl::intel::pipe<class templ_nb_pipe<N>, int>;
 
 // For simple blocking pipes with explicit type
 class some_bl_pipe;
@@ -43,7 +44,7 @@ class templ_bl_pipe;
 
 // For blocking multiple pipes
 template<int N>
-using PipeMulBl = cl::sycl::pipe<class templ_bl_pipe<N>, int>;
+using PipeMulBl = cl::sycl::intel::pipe<class templ_bl_pipe<N>, int>;
 
 // Kernel names
 template <int TestNumber, int KernelNumber = 0>
@@ -56,7 +57,7 @@ template<typename PipeName, int TestNumber>
 int test_simple_nb_pipe(cl::sycl::queue Queue) {
   int data[] = {0};
 
-  using Pipe = cl::sycl::pipe<PipeName, int>;
+  using Pipe = cl::sycl::intel::pipe<PipeName, int>;
 
   cl::sycl::buffer<int, 1> readBuf(data, 1);
   Queue.submit([&](cl::sycl::handler &cgh) {
@@ -147,7 +148,7 @@ int test_multiple_nb_pipe(cl::sycl::queue Queue) {
 template<int TestNumber>
 int test_array_th_nb_pipe(cl::sycl::queue Queue) {
   int data[N] = {0};
-  using AnotherNbPipe = cl::sycl::pipe<class another_nb_pipe, int>;
+  using AnotherNbPipe = cl::sycl::intel::pipe<class another_nb_pipe, int>;
 
   Queue.submit([&](cl::sycl::handler &cgh) {
     cgh.single_task<class writer<TestNumber>>([=]() {
@@ -189,7 +190,7 @@ template<typename PipeName, int TestNumber>
 int test_simple_bl_pipe(cl::sycl::queue Queue) {
   int data[] = {0};
 
-  using Pipe = cl::sycl::pipe<PipeName, int>;
+  using Pipe = cl::sycl::intel::pipe<PipeName, int>;
 
   cl::sycl::buffer<int, 1> readBuf(data, 1);
   Queue.submit([&](cl::sycl::handler &cgh) {
@@ -259,7 +260,7 @@ int test_multiple_bl_pipe(cl::sycl::queue Queue) {
 template<int TestNumber>
 int test_array_th_bl_pipe(cl::sycl::queue Queue) {
   int data[N] = {0};
-  using AnotherBlPipe = cl::sycl::pipe<class another_bl_pipe, int>;
+  using AnotherBlPipe = cl::sycl::intel::pipe<class another_bl_pipe, int>;
 
   Queue.submit([&](cl::sycl::handler &cgh) {
     cgh.single_task<class writer<TestNumber>>([=]() {

--- a/sycl/test/fpga_tests/fpga_pipes_legacy_ns.cpp
+++ b/sycl/test/fpga_tests/fpga_pipes_legacy_ns.cpp
@@ -1,0 +1,61 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+//==-------- fpga_pipes_legacy_ns.cpp - SYCL FPGA pipes test ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+#include <iostream>
+
+class some_nb_pipe;
+
+// Test for simple non-blocking pipes in legacy namespace (cl::sycl::)
+template <typename PipeName>
+int test_simple_nb_pipe(cl::sycl::queue Queue) {
+  int data[] = {0};
+
+  using Pipe = cl::sycl::pipe<PipeName, int>;
+
+  cl::sycl::buffer<int, 1> readBuf(data, 1);
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task<class writer>([=]() {
+      bool SuccessCode = false;
+      do {
+        Pipe::write(42, SuccessCode);
+      } while (!SuccessCode);
+    });
+  });
+
+  cl::sycl::buffer<int, 1> writeBuf(data, 1);
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    auto write_acc = writeBuf.get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.single_task<class reader>([=]() {
+      bool SuccessCode = false;
+      do {
+        write_acc[0] = Pipe::read(SuccessCode);
+      } while (!SuccessCode);
+    });
+  });
+
+  auto readHostBuffer = writeBuf.get_access<cl::sycl::access::mode::read>();
+  if (readHostBuffer[0] != 42) {
+    std::cout <<"Result mismatches " << readHostBuffer[0] << " Vs expected "
+              << 42 << std::endl;
+
+    return -1;
+  }
+
+  return 0;
+}
+
+
+int main() {
+  cl::sycl::queue Queue;
+
+  // Non-blocking pipes
+  return test_simple_nb_pipe<some_nb_pipe>(Queue);
+}


### PR DESCRIPTION
pipe class was moved under intel namespace and it's definition
is now placed in fpga_extensions.hpp.

Old definition was temporary left in where it was before.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>