### PR TITLE
[SYCL] Use user pointer for the first allocation of memory objects only.

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -97,6 +97,7 @@ namespace pi {
   }
 
   template<> inline void print<> (PiPlatform val) { std::cout << "pi_platform : " << val; }
+  template<> inline void print<> (void *val) { std::cout << "void *: " << std::hex << val; }
   template<> inline void print<> (PiResult val) {
     std::cout << "pi_result : ";
     if (val == PI_SUCCESS)

--- a/sycl/include/CL/sycl/detail/scheduler/commands.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.hpp
@@ -164,8 +164,7 @@ protected:
 // underlying framework.
 class AllocaCommand : public AllocaCommandBase {
 public:
-  AllocaCommand(QueueImplPtr Queue, Requirement Req,
-                bool InitFromUserData = true)
+  AllocaCommand(QueueImplPtr Queue, Requirement Req, bool InitFromUserData)
       : AllocaCommandBase(CommandType::ALLOCA, std::move(Queue), Req),
         MInitFromUserData(InitFromUserData) {
     addDep(DepDesc(nullptr, &MReq, this));

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -127,8 +127,8 @@ void *MemoryManager::allocateBufferObject(ContextImplPtr TargetContext,
 
   RT::PiResult Error = PI_SUCCESS;
   RT::PiMem NewMem;
-  PI_CALL((NewMem = RT::piMemBufferCreate(
-      TargetContext->getHandleRef(), CreationFlags, Size, UserPtr, &Error), Error));
+  NewMem = PI_TRACE(RT::piMemBufferCreate)(
+      TargetContext->getHandleRef(), CreationFlags, Size, UserPtr, &Error);
   return NewMem;
 }
 

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -608,8 +608,11 @@ AllocaCommandBase *Scheduler::GraphBuilder::getOrCreateAllocaForReq(
       AllocaCmd = new AllocaSubBufCommand(Queue, *Req, ParentAlloca);
       UpdateLeafs(findDepsForReq(Record, Req, Queue), Record,
                   access::mode::read_write);
-    } else
-      AllocaCmd = new AllocaCommand(Queue, FullReq);
+    } else {
+      // Can reuse user data for the first allocation
+      bool InitFromUserData = Record->MAllocaCommands.empty();
+      AllocaCmd = new AllocaCommand(Queue, FullReq, InitFromUserData);
+    }
 
     Record->MAllocaCommands.push_back(AllocaCmd);
     Record->MWriteLeafs.push_back(AllocaCmd);

--- a/sycl/test/scheduler/ReuseUsersPointer.cpp
+++ b/sycl/test/scheduler/ReuseUsersPointer.cpp
@@ -1,0 +1,57 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: env SYCL_PI_TRACE=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=1 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
+//==--------------------- ReuseUsersPointer.cpp ----------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+
+#include <vector>
+
+#include "../helpers.hpp"
+
+using namespace cl;
+using sycl_access_mode = cl::sycl::access::mode;
+
+int main() {
+  {
+    TestQueue Queue1(sycl::default_selector{});
+    TestQueue Queue2(sycl::default_selector{});
+
+    std::vector<int> Data(1);
+    std::cout << "User pointer = " << std::hex << (void *)Data.data()
+              << std::endl;
+    sycl::buffer<int, 1> Buf(Data.data(), Data.size(),
+                             {sycl::property::buffer::use_host_ptr()});
+
+    Queue1.submit([&](sycl::handler &CGH) {
+      auto BufAcc = Buf.get_access<sycl_access_mode::read_write>(CGH);
+      CGH.single_task<class first_kernel>([=]() { BufAcc[0] = 41; });
+    });
+
+    Queue2.submit([&](sycl::handler &CGH) {
+      auto BufAcc = Buf.get_access<sycl_access_mode::read_write>(CGH);
+      CGH.single_task<class second_kernel>([=]() { BufAcc[0] = 42; });
+    });
+  }
+
+  return 0;
+}
+// CHECK: User pointer = [[USER_PTR:0x.*]]
+// CHECK: ---> RT::piMemBufferCreate(
+// CHECK-NEXT: {{.+}}
+// CHECK-NEXT: {{.+}}
+// CHECK-NEXT: {{.+}}
+// CHECK-NEXT: void *: [[USER_PTR]]
+//
+// CHECK: ---> RT::piMemBufferCreate(
+// CHECK-NEXT: {{.+}}
+// CHECK-NEXT: {{.+}}
+// CHECK-NEXT: {{.+}}
+// CHECK-NEXT: void *: 0


### PR DESCRIPTION
It's illegal to have one host pointer bounded to more than one
OpenCL memory object.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>