### PR TITLE
[SYCL] Small adjustments of UpdateHostRequirementCommand.

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -424,9 +424,7 @@ void UpdateHostRequirementCommand::printDot(std::ostream &Stream) const {
   for (const auto &Dep : MDeps) {
     Stream << "  \"" << this << "\" -> \"" << Dep.MDepCommand << "\""
            << " [ label = \"Access mode: "
-           << accessModeToString(
-                  Dep.MAllocaCmd->getAllocationReq()->MAccessMode)
-           << "\\n"
+           << accessModeToString(Dep.MReq->MAccessMode) << "\\n"
            << "MemObj: " << Dep.MAllocaCmd->getSYCLMemObj() << " \" ]"
            << std::endl;
   }

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -167,10 +167,8 @@ UpdateHostRequirementCommand *Scheduler::GraphBuilder::insertUpdateHostReqCmd(
     UpdateCommand->addDep(DepDesc{Dep, StoredReq, AllocaCmd});
     Dep->addUser(UpdateCommand);
   }
-  // access::mode::read_write is always used here regardless of requieremnt
-  // access mode because this node shouldn't be skipped.
-  UpdateLeafs(Deps, Record, access::mode::read_write);
-  AddNodeToLeafs(Record, UpdateCommand, access::mode::read_write);
+  UpdateLeafs(Deps, Record, Req->MAccessMode);
+  AddNodeToLeafs(Record, UpdateCommand, Req->MAccessMode);
   return UpdateCommand;
 }
 


### PR DESCRIPTION
Changed dependency type for UpdateHostRequirementCommand, previously it
was always read_write, now the type depends on the type user requests
when creates host accessor.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>