### PR TITLE
[SYCL][Driver] Update lib call for Windows AOT FPGA

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -324,7 +324,7 @@ void visualstudio::Linker::constructMSVCLibCommand(Compilation &C,
   CmdArgs.push_back(
       C.getArgs().MakeArgString(Twine("-OUT:") + Output.getFilename()));
 
-  SmallString<128> ExecPath(getToolChain().GetProgramPath("lib"));
+  SmallString<128> ExecPath(getToolChain().GetProgramPath("lib.exe"));
   const char *Exec = C.getArgs().MakeArgString(ExecPath);
   C.addCommand(std::make_unique<Command>(JA, *this, Exec, CmdArgs, None));
 }

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -30,6 +30,17 @@
 // CHK-FPGA-IMAGE: aoc{{.*}} "-o" "[[OUTPUT5:.+\.aocx]]" "[[OUTPUT4]]" "-sycl"
 // CHK-FPGA-LINK: {{lib|llvm-ar}}{{.*}}
 
+/// -fintelfpga -fsycl-link clang-cl specific
+// RUN:  touch %t.obj
+// RUN:  %clang_cl -### -clang:-target -clang:x86_64-pc-windows-msvc -fsycl -fintelfpga -fsycl-link %t.obj 2>&1 \
+// RUN:  | FileCheck -check-prefixes=CHK-FPGA-LINK-WIN %s
+// CHK-FPGA-LINK-WIN: clang-offload-bundler{{.*}} "-type=o" "-targets=host-x86_64-pc-windows-msvc,sycl-spir64_fpga-unknown-{{.*}}-sycldevice{{.*}}" "-inputs=[[INPUT:.+\.obj]]" "-outputs=[[OUTPUT1:.+\.obj]],[[OUTPUT2:.+\.obj]]" "-unbundle"
+// CHK-FPGA-LINK-WIN: llvm-link{{.*}} "[[OUTPUT2]]" "-o" "[[OUTPUT3:.+\.bc]]"
+// CHK-FPGA-LINK-WIN: llvm-spirv{{.*}} "-spirv-max-version=1.1" "-spirv-ext=+all" "-o" "[[OUTPUT4:.+\.spv]]" "[[OUTPUT3]]"
+// CHK-FPGA-LINK-WIN: aoc{{.*}} "-o" "[[OUTPUT5:.+\.aocr]]" "[[OUTPUT4]]" "-sycl" "-rtl"
+// CHK-FPGA-LINK-WIN: lib.exe{{.*}}
+
+
 /// Check -fintelfpga -fsycl-link with an FPGA archive
 // Create the dummy archive
 // RUN:  echo "Dummy AOCR image" > %t.aocr


### PR DESCRIPTION
When completing the archive step on Windows, we call 'lib' with -fintelfpga
-fsycl-link.  If there is a directory with the name 'lib' in the PATH, that
lib will be picked up instead of the expected lib.exe

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>