### PR TITLE
[SYCL] Add support for blocking enqueue

### DIFF
--- a/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
@@ -81,7 +81,7 @@ public:
 
   QueueImplPtr getDefaultHostQueue() { return DefaultHostQueue; }
 
-private:
+protected:
   Scheduler();
   static Scheduler instance;
 
@@ -194,10 +194,11 @@ private:
     // Wait for the command, associated with Event passed, is completed.
     static void waitForEvent(EventImplPtr Event);
 
-    // Enqueue the command passed to the underlying device.
-    // Returns pointer to command which failed to enqueue, so this command
-    // with all commands that depend on it can be rescheduled.
-    static Command *enqueueCommand(Command *Cmd);
+    // Enqueue the command passed and all it's dependencies to the underlying
+    // device. Returns true is the command is successfully enqueued. Sets
+    // EnqueueResult to the specific status otherwise.
+    static bool enqueueCommand(Command *Cmd, EnqueueResultT &EnqueueResult,
+                               BlockingT Blocking = NON_BLOCKING);
   };
 
   void waitForRecordToFinish(MemObjRecord *Record);

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -95,11 +95,11 @@ event_impl::event_impl(std::shared_ptr<cl::sycl::detail::queue_impl> Queue) {
 void event_impl::wait(
     std::shared_ptr<cl::sycl::detail::event_impl> Self) const {
 
-  if (m_Event || m_HostEvent)
+  if (m_Event)
     // presence of m_Event means the command has been enqueued, so no need to
     // go via the slow path event waiting in the scheduler
     waitInternal();
-  else
+  else if (m_Command)
     detail::Scheduler::getInstance().waitForEvent(std::move(Self));
 }
 

--- a/sycl/test/scheduler/BlockedCommands.cpp
+++ b/sycl/test/scheduler/BlockedCommands.cpp
@@ -1,0 +1,106 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+//==------------------- BlockedCommands.cpp --------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <iostream>
+
+#include <CL/cl.h>
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+class FakeCommand : public detail::Command {
+public:
+  FakeCommand(detail::QueueImplPtr Queue)
+      : Command(detail::Command::ALLOCA, Queue) {}
+  void printDot(std::ostream &Stream) const override {}
+
+  cl_int enqueueImp() override { return MRetVal; }
+
+  cl_int MRetVal = CL_SUCCESS;
+};
+
+class TestScheduler : public detail::Scheduler {
+public:
+  static bool enqueueCommand(detail::Command *Cmd,
+                             detail::EnqueueResultT &EnqueueResult,
+                             detail::BlockingT Blocking) {
+    return GraphProcessor::enqueueCommand(Cmd, EnqueueResult, Blocking);
+  }
+};
+
+int main() {
+  cl::sycl::queue Queue;
+  FakeCommand FakeCmd(detail::getSyclObjImpl(Queue));
+
+  FakeCmd.MIsBlockable = true;
+  FakeCmd.MCanEnqueue = false;
+  FakeCmd.MRetVal = CL_DEVICE_PARTITION_EQUALLY;
+
+  {
+    detail::EnqueueResultT Res;
+    bool Enqueued =
+        TestScheduler::enqueueCommand(&FakeCmd, Res, detail::NON_BLOCKING);
+
+    if (Enqueued) {
+      std::cerr << "Blocked command should not be enqueued" << std::endl;
+      return 1;
+    }
+
+    if (detail::EnqueueResultT::BLOCKED != Res.MResult) {
+      std::cerr << "Result of enqueueing blocked command should be BLOCKED"
+                << std::endl;
+      return 1;
+    }
+  }
+
+  FakeCmd.MCanEnqueue = true;
+
+  {
+    detail::EnqueueResultT Res;
+    bool Enqueued =
+        TestScheduler::enqueueCommand(&FakeCmd, Res, detail::BLOCKING);
+
+    if (Enqueued) {
+      std::cerr << "The command is expected to fail to enqueue." << std::endl;
+      return 1;
+    }
+
+    if (detail::EnqueueResultT::FAILED != Res.MResult) {
+      std::cerr << "The command is expected to fail to enqueue." << std::endl;
+      return 1;
+    }
+
+    if (CL_DEVICE_PARTITION_EQUALLY != Res.MErrCode) {
+      std::cerr << "Expected different error code." << std::endl;
+      return 1;
+    }
+
+    if (&FakeCmd != Res.MCmd) {
+      std::cerr << "Expected different failed command." << std::endl;
+      return 1;
+    }
+  }
+
+  FakeCmd.MRetVal = CL_SUCCESS;
+
+  {
+    detail::EnqueueResultT Res;
+    bool Enqueued =
+        TestScheduler::enqueueCommand(&FakeCmd, Res, detail::BLOCKING);
+
+    if (!Enqueued || detail::EnqueueResultT::SUCCESS != Res.MResult) {
+      std::cerr << "The command is expected to be successfully enqueued."
+                << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
The patch introduces new property of the Command class: blocked from
enqueueing. This means that the command cannot be enqueued so until
it's unblocked. Places where enqueue process is initiated were updated
so all "wait for event" calls make blocking enqueue which doesn't return
until all required commands are actually enqueued.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>