### PR TITLE
[SYCL][Driver] Prevent option duplication during offload

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -416,15 +416,14 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
                              Action::OffloadKind DeviceOffloadKind) const {
   DerivedArgList *DAL =
       HostTC.TranslateArgs(Args, BoundArch, DeviceOffloadKind);
-  if (!DAL)
+
+  if (!DAL) {
     DAL = new DerivedArgList(Args.getBaseArgs());
-
-  const OptTable &Opts = getDriver().getOpts();
-
-  for (Arg *A : Args) {
-    DAL->append(A);
+    for (Arg *A : Args)
+      DAL->append(A);
   }
 
+  const OptTable &Opts = getDriver().getOpts();
   if (!BoundArch.empty()) {
     DAL->eraseArg(options::OPT_march_EQ);
     DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_march_EQ),

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -761,5 +761,10 @@
 // RUN:   | FileCheck -check-prefix=LIB-UNBUNDLE-CHECK %s
 // LIB-UNBUNDLE-CHECK-NOT: clang-offload-unbundler
 
+/// Options should not be duplicated in AOT calls
+// RUN: %clang -fsycl -### -fsycl-targets=spir64_fpga -Xsycl-target-backend "-DBLAH" %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=DUP-OPT %s
+// DUP-OPT-NOT: aoc{{.*}} "-DBLAH" {{.*}} "-DBLAH"
+
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc


### PR DESCRIPTION
Under certain circumstances, the offload compilation would pull in duplicate
arguments to the offload compilation steps.  This was being caused by some
hosts having their own translation step, adding the args to the derived arg
list before the offload translation which adds the args as well.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>