### PR TITLE
[SYCL CI] Add CMAKE_INSTALL "deploy" command in CI compile file

### DIFF
--- a/buildbot/compile.py
+++ b/buildbot/compile.py
@@ -17,6 +17,13 @@ def do_compile(args):
 
     subprocess.check_call(make_cmd, cwd=args.obj_dir)
 
+    install_dir = os.path.join(args.obj_dir, "install")
+    if not os.path.isdir(install_dir):
+        os.makedirs(install_dir)
+
+    install_cmd = ["ninja", "deploy-sycl-toolchain"]
+    subprocess.check_call(install_cmd, cwd=args.obj_dir)
+
     ret = True
     return ret
 

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -29,7 +29,7 @@ def do_configure(args):
                  "-DLLVM_ENABLE_PROJECTS=clang;sycl;llvm-spirv",
                  "-DOpenCL_INCLUDE_DIR={}".format(ocl_header_dir),
                  "-DOpenCL_LIBRARY={}".format(icd_loader_lib),
-                 "-DLLVM_BUILD_TOOLS=OFF",
+                 "-DLLVM_BUILD_TOOLS=ON",
                  "-DSYCL_ENABLE_WERROR=ON",
                  "-DLLVM_ENABLE_ASSERTIONS=ON",
                  "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),


### PR DESCRIPTION
Should turn on DLLVM_BUILD_TOOLS if we want to get llvm binary files under install/bin path.

Signed-off-by: Xiaodong, Li <xiaodong.li@intel.com>