### PR TITLE
[SYCL] Added missing dependency lib for sycl-post-link tool

### DIFF
--- a/llvm/tools/sycl-post-link/CMakeLists.txt
+++ b/llvm/tools/sycl-post-link/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   IPO
   IRReader
   Support
+  TransformUtils
   )
 
 add_llvm_tool(sycl-post-link


### PR DESCRIPTION
Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>