### PR TITLE
[SPIRV] Include <cctype> to fix error on Windows due to std::isspace …

### DIFF
--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -44,6 +44,7 @@
 #include "SPIRVExtInst.h"
 #include "SPIRVModule.h"
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <iostream>
 #include <iterator>


### PR DESCRIPTION
…usage

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>