### PR TITLE
[SYCL][Driver] Allow for files with no extensions to be unbundled lik…

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3282,7 +3282,7 @@ class OffloadingActionBuilder final {
       if (auto *IA = dyn_cast<InputAction>(HostAction)) {
         SYCLDeviceActions.clear();
 
-        std::string InputName = IA->getInputArg().getValue();
+        std::string InputName = IA->getInputArg().getAsString(Args);
         // Objects should already be consumed with -foffload-static-lib
         if (Args.hasArg(options::OPT_foffload_static_lib_EQ) &&
             IA->getType() == types::TY_Object && isObjectFile(InputName))
@@ -3764,7 +3764,7 @@ public:
     if (CanUseBundler && isa<InputAction>(HostAction) &&
         InputArg->getOption().getKind() == llvm::opt::Option::InputClass &&
         !types::isSrcFile(HostAction->getType())) {
-      std::string InputName = InputArg->getValue();
+      std::string InputName = InputArg->getAsString(Args);
       // Do not create an unbundling action for an object when we know a fat
       // static library is being used.  A separate unbundling action is created
       // for all objects and the fat static library.
@@ -5887,12 +5887,13 @@ bool clang::driver::isOptimizationLevelFast(const ArgList &Args) {
 }
 
 bool clang::driver::isObjectFile(std::string FileName) {
-  if (llvm::sys::path::has_extension(FileName)) {
-    std::string Ext(llvm::sys::path::extension(FileName).drop_front());
-    // We cannot rely on lookupTypeForExtension solely as that has 'lib'
-    // marked as an object.
-    return (Ext != "lib" &&
-            types::lookupTypeForExtension(Ext) == types::TY_Object);
-  }
-  return false;
+  if (!llvm::sys::path::has_extension(FileName))
+    // Any file with no extension should be considered an Object. Take into
+    // account -lsomelib library filenames.
+    return FileName.rfind("-l", 0) != 0;
+  std::string Ext(llvm::sys::path::extension(FileName).drop_front());
+  // We cannot rely on lookupTypeForExtension solely as that has 'lib'
+  // marked as an object.
+  return (Ext != "lib" &&
+          types::lookupTypeForExtension(Ext) == types::TY_Object);
 }

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -238,9 +238,13 @@
 /// Check separate compilation with offloading - unbundling actions
 // RUN:   touch %t.o
 // RUN:   %clang -### -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -o %t.out -lsomelib -fsycl-targets=spir64-unknown-linux-sycldevice %t.o 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-UBACTIONS %s
+// RUN:   | FileCheck -DINPUT=%t.o -check-prefix=CHK-UBACTIONS %s
+// RUN:   mkdir -p %t_dir
+// RUN:   touch %t_dir/dummy
+// RUN:   %clang -### -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -o %t.out -lsomelib -fsycl-targets=spir64-unknown-linux-sycldevice %t_dir/dummy 2>&1 \
+// RUN:   | FileCheck -DINPUT=%t_dir/dummy -check-prefix=CHK-UBACTIONS %s
 // CHK-UBACTIONS: 0: input, "somelib", object, (host-sycl)
-// CHK-UBACTIONS: 1: input, "[[INPUT:.+\.o]]", object, (host-sycl)
+// CHK-UBACTIONS: 1: input, "[[INPUT]]", object, (host-sycl)
 // CHK-UBACTIONS: 2: clang-offload-unbundler, {1}, object, (host-sycl)
 // CHK-UBACTIONS: 3: linker, {0, 2}, image, (host-sycl)
 // CHK-UBACTIONS: 4: linker, {2}, spirv, (device-sycl)


### PR DESCRIPTION
…e objects

Files with no extensions were being ignored for potential unbundling.  When no
extension is provided, go ahead and treat it as an object for unbundling.  The
rest of the driver treats non-extension files as objects, offloading should do
the same.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>