### PR TITLE
[SYCL][Driver] Finalize checks for -fsycl option presence

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -245,8 +245,8 @@ def err_drv_omp_host_target_not_supported : Error<
   "The target '%0' is not a supported OpenMP host target.">;
 def err_drv_expecting_fopenmp_with_fopenmp_targets : Error<
   "The option -fopenmp-targets must be used in conjunction with a -fopenmp option compatible with offloading, please use -fopenmp=libomp or -fopenmp=libiomp5.">;
-def err_drv_expecting_fsycl_with_fsycl_targets : Error<
-  "The option -fsycl%0targets must be used in conjunction with -fsycl to enable offloading.">;
+def err_drv_expecting_fsycl_with_sycl_opt : Error<
+  "The option %0 must be used in conjunction with -fsycl to enable offloading.">;
 def warn_drv_omp_offload_target_duplicate : Warning<
   "The OpenMP offloading target '%0' is similar to target '%1' already specified - will be ignored.">,
   InGroup<OpenMPTarget>;

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -46,11 +46,17 @@
 // RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL %s
 // CHK-NO-FSYCL: error: The option -fsycl-targets must be used in conjunction with -fsycl to enable offloading.
 // RUN:   %clang -### -fsycl-link-targets=spir64-unknown-linux-sycldevice  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-LINK %s
-// CHK-NO-FSYCL-LINK: error: The option -fsycl-link-targets must be used in conjunction with -fsycl to enable offloading.
+// RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-LINK-TGTS %s
+// CHK-NO-FSYCL-LINK-TGTS: error: The option -fsycl-link-targets must be used in conjunction with -fsycl to enable offloading.
 // RUN:   %clang -### -fsycl-add-targets=spir64-unknown-linux-sycldevice  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-ADD %s
 // CHK-NO-FSYCL-ADD: error: The option -fsycl-add-targets must be used in conjunction with -fsycl to enable offloading.
+// RUN:   %clang -### -fsycl-link  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-LINK %s
+// CHK-NO-FSYCL-LINK: error: The option -fsycl-link must be used in conjunction with -fsycl to enable offloading.
+// RUN:   %clang -### -fintelfpga  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-FINTELFPGA %s
+// CHK-NO-FSYCL-FINTELFPGA: error: The option -fintelfpga must be used in conjunction with -fsycl to enable offloading.
 
 /// ###########################################################################
 


### PR DESCRIPTION
This makes clang error out upon -fintelfpga/-fsycl-link being
provided without -fsycl (the latter is necessary to enable SYCL
offloading). Slight refactoring that allows to achieve this
should also simplify adding new SYCL compiler options.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>