### PR TITLE
[SYCL][NFC] Clean up options in aot/multiple-devices.cpp test commands

### DIFF
--- a/sycl/test/aot/multiple-devices.cpp
+++ b/sycl/test/aot/multiple-devices.cpp
@@ -9,8 +9,8 @@
 // REQUIRES: ioc64, ocloc, aoc
 
 // Produce object file, spirv
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-linux-sycldevice,spir64_gen-unknown-linux-sycldevice,spir64_fpga-unknown-linux-sycldevice %s -c -o %t.o
-// RUN: %clangxx -fsycl -fsycl-link-targets=spir64_x86_64-unknown-linux-sycldevice,spir64_gen-unknown-linux-sycldevice,spir64_fpga-unknown-linux-sycldevice %t.o -o %t.spv
+// RUN: %clangxx -fsycl %s -c -o %t.o
+// RUN: %clangxx -fsycl -fsycl-link-targets=spir64-unknown-linux-sycldevice %t.o -o %t.spv
 // AOT-compile device binary images
 // RUN: ioc64 -cmd=build -binary=%t.spv -ir=%t_cpu.ir -device=cpu
 // RUN: ocloc -file %t.spv -spirv_input -output %t_gen.out -output_no_suffix -device cfl

--- a/sycl/test/aot/multiple-devices.cpp
+++ b/sycl/test/aot/multiple-devices.cpp
@@ -8,7 +8,16 @@
 
 // REQUIRES: ioc64, ocloc, aoc
 
-// Produce object file, spirv
+// 1-command compilation case
+// Targeting CPU, GPU, FPGA
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-linux-sycldevice,spir64_gen-unknown-linux-sycldevice,spir64_fpga-unknown-linux-sycldevice -Xsycl-target-backend=spir64_gen-unknown-linux-sycldevice "-device skl" %s -o %t_all.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t_all.out
+// RUN: %CPU_RUN_PLACEHOLDER %t_all.out
+// RUN: %GPU_RUN_PLACEHOLDER %t_all.out
+// RUN: %ACC_RUN_PLACEHOLDER %t_all.out
+
+// Produce object file, spirv, device images to combine these differently
+// at link-time, thus testing various AOT-compiled images configurations
 // RUN: %clangxx -fsycl %s -c -o %t.o
 // RUN: %clangxx -fsycl -fsycl-link-targets=spir64-unknown-linux-sycldevice %t.o -o %t.spv
 // AOT-compile device binary images
@@ -33,13 +42,6 @@
 // RUN: env SYCL_DEVICE_TYPE=HOST %t_gpu_fpga.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu_fpga.out
 // RUN: %ACC_RUN_PLACEHOLDER %t_gpu_fpga.out
-
-// CPU, GPU, FPGA
-// RUN: %clangxx -fsycl -fsycl-add-targets=spir64_x86_64:%t_cpu.ir,spir64_gen:%t_gen.out,spir64_fpga:%t_fpga.aocx %t.o -o %t_all.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t_all.out
-// RUN: %CPU_RUN_PLACEHOLDER %t_all.out
-// RUN: %GPU_RUN_PLACEHOLDER %t_all.out
-// RUN: %ACC_RUN_PLACEHOLDER %t_all.out
 
 // No AOT-compiled image for CPU
 // RUN: %clangxx -fsycl -fsycl-add-targets=spir64:%t.spv,spir64_gen:%t_gen.out,spir64_fpga:%t_fpga.aocx %t.o -o %t_spv_gpu_fpga.out


### PR DESCRIPTION
Any specific AOT target triples prove obsolete for the commands that
are used to produce SPIR-V, the latter being completely device-agnostic.
Subarch-specific AOT compilers will accept it just as well.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>