### PR TITLE
fix integer type to silence comparison warning

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -227,7 +227,7 @@ extern __ocl_event_t
 OpGroupAsyncCopyGlobalToLocal(__spv::Scope Execution, dataT *Dest, dataT *Src,
                               size_t NumElements, size_t Stride,
                               __ocl_event_t E) noexcept {
-  for (int i = 0; i < NumElements; i++) {
+  for (size_t i = 0; i < NumElements; i++) {
     Dest[i] = Src[i * Stride];
   }
   // A real instance of the class is not needed, return dummy pointer.
@@ -239,7 +239,7 @@ extern __ocl_event_t
 OpGroupAsyncCopyLocalToGlobal(__spv::Scope Execution, dataT *Dest, dataT *Src,
                               size_t NumElements, size_t Stride,
                               __ocl_event_t E) noexcept {
-  for (int i = 0; i < NumElements; i++) {
+  for (size_t i = 0; i < NumElements; i++) {
     Dest[i * Stride] = Src[i];
   }
   // A real instance of the class is not needed, return dummy pointer.


### PR DESCRIPTION
```
[ 98%] Building CXX object tools/sycl/source/CMakeFiles/sycl.dir/spirv_ops.cpp.o
In file included from /Users/jrhammon/Work/OpenCL/ISYCL/llvm/sycl/source/spirv_ops.cpp:9:
/Users/jrhammon/Work/OpenCL/ISYCL/llvm/sycl/include/CL/__spirv/spirv_ops.hpp:230:21: warning: comparison of integers of different signs: 'int' and 'size_t'
      (aka 'unsigned long') [-Wsign-compare]
  for (int i = 0; i < NumElements; i++) {
                  ~ ^ ~~~~~~~~~~~
/Users/jrhammon/Work/OpenCL/ISYCL/llvm/sycl/include/CL/__spirv/spirv_ops.hpp:242:21: warning: comparison of integers of different signs: 'int' and 'size_t'
      (aka 'unsigned long') [-Wsign-compare]
  for (int i = 0; i < NumElements; i++) {
                  ~ ^ ~~~~~~~~~~~
2 warnings generated.
```
Signed-off-by: Hammond, Jeff R <jeff.r.hammond@intel.com>