### PR TITLE
[SYCL] MacOS support for os_util

### DIFF
--- a/sycl/include/CL/sycl/detail/os_util.hpp
+++ b/sycl/include/CL/sycl/detail/os_util.hpp
@@ -24,6 +24,11 @@
 #elif __linux__
 // Linux platform
 #define SYCL_RT_OS_LINUX
+#define SYCL_RT_OS_POSIX_SUPPORT
+#elif defined(__APPLE__) && defined(__MACH__)
+// Apple OSX
+#define SYCL_RT_OS_DARWIN
+#define SYCL_RT_OS_POSIX_SUPPORT
 #else
 #error "Unsupported compiler or OS"
 #endif // _WIN32
@@ -41,7 +46,7 @@
 #define __SYCL_EXPORTED __declspec(dllimport)
 #endif
 
-#elif defined(SYCL_RT_OS_LINUX)
+#elif defined(SYCL_RT_OS_POSIX_SUPPORT)
 
 #define DLL_LOCAL __attribute__((visibility("hidden")))
 #define __SYCL_EXPORTED


### PR DESCRIPTION
Slight modifications to the original implementation by @alexbatashev.

**These are sufficient for a clean build on MacOS** and I encourage them to be merged soon.  Rebasing Alex's patches is hard given the rate of change in the sycl branch.

Signed-off-by: Hammond, Jeff R <jeff.r.hammond@intel.com>
Signed-off-by: Alexander Batashev <alexander.batashev@intel.com> (please re-affirm the sign-off that was in your original patch set)