### PR TITLE
[SYCL] Add MacOS file paths to the lit.cfg file for sycl/test

### DIFF
--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -57,10 +57,9 @@ elif platform.system() == "Darwin":
     # FIXME: surely there is a more elegant way to instantiate the Xcode directories.
     if 'CPATH' in os.environ:
         config.environment['CPATH'] = os.path.pathsep.join((os.environ['CPATH'], "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"))
-        config.environment['CPATH'] = os.path.pathsep.join((config.environment['CPATH'], "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"))
     else:
         config.environment['CPATH'] = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"
-        config.environment['CPATH'] = os.path.pathsep.join((config.environment['CPATH'], "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"))
+    config.environment['CPATH'] = os.path.pathsep.join((config.environment['CPATH'], "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"))
     config.environment['DYLD_LIBRARY_PATH'] = config.llvm_build_libs_dir
 
 # propagate the environment variable OCL_ICD_FILANEMES to use proper runtime.

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -40,7 +40,8 @@ if platform.system() == "Linux":
         config.environment['LD_LIBRARY_PATH'] = os.path.pathsep.join((config.environment['LD_LIBRARY_PATH'], config.llvm_build_libs_dir))
     else:
         config.environment['LD_LIBRARY_PATH'] = config.llvm_build_libs_dir
-else:
+
+elif platform.system() == "Windows":
     config.available_features.add('windows')
     if 'LIB' in os.environ:
         config.environment['LIB'] = os.path.pathsep.join((config.environment['LIB'], config.llvm_build_libs_dir))
@@ -51,6 +52,16 @@ else:
         config.environment['PATH'] = os.path.pathsep.join((config.environment['PATH'], config.llvm_build_bins_dir))
     else:
         config.environment['PATH'] = config.llvm_build_bins_dir
+
+elif platform.system() == "Darwin":
+    # FIXME: surely there is a more elegant way to instantiate the Xcode directories.
+    if 'CPATH' in os.environ:
+        config.environment['CPATH'] = os.path.pathsep.join((os.environ['CPATH'], "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"))
+        config.environment['CPATH'] = os.path.pathsep.join((config.environment['CPATH'], "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"))
+    else:
+        config.environment['CPATH'] = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"
+        config.environment['CPATH'] = os.path.pathsep.join((config.environment['CPATH'], "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"))
+    config.environment['DYLD_LIBRARY_PATH'] = config.llvm_build_libs_dir
 
 # propagate the environment variable OCL_ICD_FILANEMES to use proper runtime.
 if 'OCL_ICD_FILENAMES' in os.environ:


### PR DESCRIPTION
The hard-coded paths need some attention from someone who understands the structure of Xcode paths.  Presumably, there is a way to capture these in a way that survives filesystem reorganization across OSX versions.
    
Trivial modification to the original implementation by @alexbatashev.
    
Signed-off-by: Hammond, Jeff R <jeff.r.hammond@intel.com>
Signed-off-by: Alexander Batashev alexander.batashev@intel.com (please re-affirm the sign-off that was in your original patch set)