### PR TITLE
[SYCL][Doc] Fix AOT-related errors in SYCLCompilerAndRuntimeDesign.md

### DIFF
--- a/sycl/doc/SYCLCompilerAndRuntimeDesign.md
+++ b/sycl/doc/SYCLCompilerAndRuntimeDesign.md
@@ -221,7 +221,7 @@ option mechanism, similar to OpenMP.
 
 For example, to support offload to Gen9/vISA3.3, the following options would be used:
 
-`-fsycl -fsycl-targets=spir64_gen-unknown-<os>-sycldevice -Xsycl-target-backend "-device skl"`
+`-fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend "-device skl"`
 
 The driver passes the `-device skl` parameter directly to the Gen device backend compiler
 without parsing it.

--- a/sycl/doc/SYCLCompilerAndRuntimeDesign.md
+++ b/sycl/doc/SYCLCompilerAndRuntimeDesign.md
@@ -217,17 +217,16 @@ and understands mnemonics designating a particular code form, for example
 architecture).  User can specify desired code format using the target-specific
 option mechanism, similar to OpenMP.
 
-`-Xsycl-target=<triple> <arg>`
+`-Xsycl-target-backend=<triple> "<arg>,<arg>"`
 
-For example, to support offload to CPU, FPGA, Gen9/vISA3.3, Gen9/SPIR-V the
-following options would be used:
+For example, to support offload to Gen9/vISA3.3, the following options would be used:
 
-`-fsycl -fsycl-targets=x86,fpga,gen9 -Xsycl-target=gen9 "-fmt:visa -fmt:spirv"`
+`-fsycl -fsycl-targets=spir64_gen-unknown-<os>-sycldevice -Xsycl-target-backend "-device skl"`
 
 The `<arg>` parameter is passed by the driver directly to the SYCL device
 compiler for the corresponding target w/o parsing it. For each target there is
 some default code form which is generated in the absence of overriding via the
-`-Xsycl-target` option.
+`-Xsycl-target-backend` option.
 
 **TBD:** Having multiple code forms for the same target in the fat binary might
 mean invoking device compiler multiple times. Multiple invocations are not

--- a/sycl/doc/SYCLCompilerAndRuntimeDesign.md
+++ b/sycl/doc/SYCLCompilerAndRuntimeDesign.md
@@ -217,16 +217,14 @@ and understands mnemonics designating a particular code form, for example
 architecture).  User can specify desired code format using the target-specific
 option mechanism, similar to OpenMP.
 
-`-Xsycl-target-backend=<triple> "<arg>,<arg>"`
+`-Xsycl-target-backend=<triple> "arg1 arg2 ..."`
 
 For example, to support offload to Gen9/vISA3.3, the following options would be used:
 
 `-fsycl -fsycl-targets=spir64_gen-unknown-<os>-sycldevice -Xsycl-target-backend "-device skl"`
 
-The `<arg>` parameter is passed by the driver directly to the SYCL device
-compiler for the corresponding target w/o parsing it. For each target there is
-some default code form which is generated in the absence of overriding via the
-`-Xsycl-target-backend` option.
+The driver passes the `-device skl` parameter directly to the Gen device backend compiler
+without parsing it.
 
 **TBD:** Having multiple code forms for the same target in the fat binary might
 mean invoking device compiler multiple times. Multiple invocations are not


### PR DESCRIPTION
1) -Xsycl-target option is non-existent. In order to pass the binary
image requirements to the device compiler, -Xsycl-target-backend should
be used (with triple specification, if multiple offload targets need to
be supported)

2) As of now, the primary way of specifying the offload target(s) is the
usage of LLVM triples (spir64<_subarch>-unknown-<os>-sycldevice). Intuitive
tokens like x86, fpga are meaningless to Clang driver, and it will happily
fail with "unsupported target" upon encountering such.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>