### PR TITLE
[SYCL] Add vector_size check for built-in's functions.

### DIFF
--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -232,6 +232,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloat<T>::value && detail::is_genfloatptr<T2>::value, T>
 fract(T x, T2 iptr) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_fract<T>(x, iptr);
 }
 
@@ -240,6 +241,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloat<T>::value && detail::is_genintptr<T2>::value, T>
 frexp(T x, T2 exp) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_frexp<T>(x, exp);
 }
 
@@ -277,6 +279,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_vgenfloat<T>::value && detail::is_intn<T2>::value, T>
 ldexp(T x, T2 k) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_ldexp<T>(x, k);
 }
 
@@ -291,6 +294,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloat<T>::value && detail::is_genintptr<T2>::value, T>
 lgamma_r(T x, T2 signp) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_lgamma_r<T>(x, signp);
 }
 
@@ -348,6 +352,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloat<T>::value && detail::is_genfloatptr<T2>::value, T>
 modf(T x, T2 iptr) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_modf<T>(x, iptr);
 }
 
@@ -376,6 +381,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloat<T>::value && detail::is_genint<T2>::value, T>
 pown(T x, T2 y) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_pown<T>(x, y);
 }
 
@@ -397,6 +403,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloat<T>::value && detail::is_genintptr<T2>::value, T>
 remquo(T x, T y, T2 quo) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_remquo<T>(x, y, quo);
 }
 
@@ -411,6 +418,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloat<T>::value && detail::is_genint<T2>::value, T>
 rootn(T x, T2 y) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_rootn<T>(x, y);
 }
 
@@ -437,6 +445,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloat<T>::value && detail::is_genfloatptr<T2>::value, T>
 sincos(T x, T2 cosval) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_sincos<T>(x, cosval);
 }
 
@@ -860,6 +869,7 @@ detail::enable_if_t<detail::is_igeninteger8bit<T>::value &&
                         detail::is_ugeninteger8bit<T2>::value,
                     detail::make_larger_t<T>>
 upsample(T hi, T2 lo) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_s_upsample<detail::make_larger_t<T>>(hi, lo);
 }
 
@@ -877,6 +887,7 @@ detail::enable_if_t<detail::is_igeninteger16bit<T>::value &&
                         detail::is_ugeninteger16bit<T2>::value,
                     detail::make_larger_t<T>>
 upsample(T hi, T2 lo) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_s_upsample<detail::make_larger_t<T>>(hi, lo);
 }
 
@@ -894,6 +905,7 @@ detail::enable_if_t<detail::is_igeninteger32bit<T>::value &&
                         detail::is_ugeninteger32bit<T2>::value,
                     detail::make_larger_t<T>>
 upsample(T hi, T2 lo) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_s_upsample<detail::make_larger_t<T>>(hi, lo);
 }
 
@@ -1290,6 +1302,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_geninteger<T>::value && detail::is_igeninteger<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
@@ -1298,6 +1311,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_geninteger<T>::value && detail::is_ugeninteger<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
@@ -1306,6 +1320,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloatf<T>::value && detail::is_genint<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
@@ -1314,6 +1329,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloatf<T>::value && detail::is_ugenint<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
@@ -1322,6 +1338,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloatd<T>::value && detail::is_igeninteger64bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
@@ -1330,6 +1347,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloatd<T>::value && detail::is_ugeninteger64bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
@@ -1338,6 +1356,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloath<T>::value && detail::is_igeninteger16bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 
@@ -1346,6 +1365,7 @@ template <typename T, typename T2>
 detail::enable_if_t<
     detail::is_genfloath<T>::value && detail::is_ugeninteger16bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
+  detail::check_vector_size<T, T2>();
   return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
 }
 

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -569,6 +569,39 @@ template <typename T> static constexpr T quiet_NaN() {
   return std::numeric_limits<T>::quiet_NaN();
 }
 
+// is_same_vector_size
+template <int FirstSize, typename... Args> struct is_same_vector_size_impl;
+
+template <int FirstSize, typename T, typename... Args>
+class is_same_vector_size_impl<FirstSize, T, Args...> {
+  using CurrentT = detail::remove_pointer_t<T>;
+  static constexpr int Size = vector_size<CurrentT>::value;
+  static constexpr bool IsSizeEqual = (Size == FirstSize);
+
+public:
+  static constexpr bool value =
+      IsSizeEqual ? is_same_vector_size_impl<FirstSize, Args...>::value
+                   : false;
+};
+
+template <int FirstSize>
+struct is_same_vector_size_impl<FirstSize> : std::true_type {};
+
+template <typename T, typename... Args> class is_same_vector_size {
+  using CurrentT = remove_pointer_t<T>;
+  static constexpr int Size = vector_size<CurrentT>::value;
+
+public:
+  static constexpr bool value = is_same_vector_size_impl<Size, Args...>::value;
+};
+
+// check_vector_size
+template <typename... Args> inline void check_vector_size() {
+  static_assert(is_same_vector_size<Args...>::value,
+                "The built-in function arguments must [point to|have] types "
+                "with the same number of elements.");
+}
+
 } // namespace detail
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/stl_type_traits.hpp
@@ -35,6 +35,9 @@ using remove_const_t = typename std::remove_const<T>::type;
 
 template <typename T> using remove_cv_t = typename std::remove_cv<T>::type;
 
+template <typename T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+
 template <typename T> using add_pointer_t = typename std::add_pointer<T>::type;
 
 template <typename T>

--- a/sycl/test/type_traits/type_traits.cpp
+++ b/sycl/test/type_traits/type_traits.cpp
@@ -46,14 +46,14 @@ void test_change_base_type_t() {
 }
 
 template <typename T, typename CheckedT, bool Expected = true>
-void test_get_base_type_t() {
-  static_assert(is_same<d::get_base_type_t<T>, CheckedT>::value == Expected,
+void test_vector_element_t() {
+  static_assert(is_same<d::vector_element_t<T>, CheckedT>::value == Expected,
                 "");
 }
 
 template <typename T, typename CheckedT, bool Expected = true>
 void test_nan_types() {
-  static_assert((sizeof(d::get_base_type_t<d::nan_return_t<T>>) ==
+  static_assert((sizeof(d::vector_element_t<d::nan_return_t<T>>) ==
                  sizeof(d::nan_argument_base_t<T>)) == Expected,
                 "");
 }
@@ -83,6 +83,15 @@ template <typename T, typename SpaceList, bool Expected = true>
 void test_is_address_space_compliant() {
   static_assert(d::is_address_space_compliant<T, SpaceList>::value == Expected,
                 "");
+}
+
+template <typename T, int Checked, bool Expected = true>
+void test_vector_size() {
+  static_assert((d::vector_size<T>::value == Checked) == Expected, "");
+}
+
+template <bool Expected, typename... Args> void test_is_same_vector_size() {
+  static_assert(d::is_same_vector_size<Args...>::value == Expected, "");
 }
 
 int main() {
@@ -162,8 +171,14 @@ int main() {
   test_change_base_type_t<long, float, float>();
   test_change_base_type_t<s::long2, float, s::float2>();
 
-  test_get_base_type_t<s::int2, int>();
-  test_get_base_type_t<int, int>();
+  test_vector_element_t<int, int>();
+  test_vector_element_t<const int, const int>();
+  test_vector_element_t<volatile int, volatile int>();
+  test_vector_element_t<const volatile int, const volatile int>();
+  test_vector_element_t<s::int2, int>();
+  test_vector_element_t<const s::int2, const int>();
+  test_vector_element_t<volatile s::int2, volatile int>();
+  test_vector_element_t<const volatile s::int2, const volatile int>();
 
   test_nan_types<s::ushort, s::ushort>();
   test_nan_types<s::uint, s::uint>();
@@ -191,6 +206,25 @@ int main() {
   test_make_unsigned_t<const s::int2, const s::uint2>();
   test_make_unsigned_t<s::uint2, s::uint2>();
   test_make_unsigned_t<const s::uint2, const s::uint2>();
+
+  test_vector_size<int, 1>();
+  test_vector_size<float, 1>();
+  test_vector_size<double, 1>();
+  test_vector_size<s::int2, 2>();
+  test_vector_size<s::float3, 3>();
+  test_vector_size<s::double4, 4>();
+  test_vector_size<s::vec<int, 1>, 1>();
+
+  test_is_same_vector_size<true, int>();
+  test_is_same_vector_size<true, s::int2>();
+  test_is_same_vector_size<true, int, float>();
+  test_is_same_vector_size<false, int, s::float2>();
+  test_is_same_vector_size<true, s::int2, s::float2>();
+  test_is_same_vector_size<false, s::int2, float>();
+  test_is_same_vector_size<true, s::constant_ptr<int>>();
+  test_is_same_vector_size<true, s::constant_ptr<s::int2>>();
+  test_is_same_vector_size<true, s::constant_ptr<s::int2>, s::int2>();
+  test_is_same_vector_size<false, s::constant_ptr<s::int2>, float>();
 
   return 0;
 }


### PR DESCRIPTION
To prevent calls of built-in functions with vectors
 of mismatched length.

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>