### PR TITLE
[SYCL] Add buffer container constructor and CTAD

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -36,7 +36,7 @@ public:
       detail::void_t<detail::enable_if_t<std::is_convertible<
                          detail::remove_pointer_t<decltype(
                              std::declval<Container>().data())> (*)[],
-                         T (*)[]>::value>,
+                         const T (*)[]>::value>,
                      decltype(std::declval<Container>().size())>;
   template <class It>
   using EnableIfItInputIterator = detail::enable_if_t<
@@ -350,6 +350,30 @@ private:
     return newRange[1] == parentRange[1] && newRange[2] == parentRange[2];
   }
 };
+
+#ifdef __cpp_deduction_guides
+template <class InputIterator, class AllocatorT>
+buffer(InputIterator, InputIterator, AllocatorT, const property_list & = {})
+    ->buffer<typename std::iterator_traits<InputIterator>::value_type, 1,
+             AllocatorT>;
+template <class InputIterator>
+buffer(InputIterator, InputIterator, const property_list & = {})
+    ->buffer<typename std::iterator_traits<InputIterator>::value_type, 1>;
+template <class Container, class AllocatorT>
+buffer(Container &, AllocatorT, const property_list & = {})
+    ->buffer<typename Container::value_type, 1, AllocatorT>;
+template <class Container>
+buffer(Container &, const property_list & = {})
+    ->buffer<typename Container::value_type, 1>;
+template <class T, int dimensions, class AllocatorT>
+buffer(const T *, const range<dimensions> &, AllocatorT,
+       const property_list & = {})
+    ->buffer<T, dimensions, AllocatorT>;
+template <class T, int dimensions>
+buffer(const T *, const range<dimensions> &, const property_list & = {})
+    ->buffer<T, dimensions>;
+#endif // __cpp_deduction_guides
+
 } // namespace sycl
 } // namespace cl
 

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -30,7 +30,18 @@ public:
   using allocator_type = AllocatorT;
   template <int dims>
   using EnableIfOneDimension = typename std::enable_if<1 == dims>::type;
-
+  // using same requirement for contiguous container as std::span
+  template <class Container>
+  using EnableIfContiguous =
+      detail::void_t<detail::enable_if_t<std::is_convertible<
+                         detail::remove_pointer_t<decltype(
+                             std::declval<Container>().data())> (*)[],
+                         T (*)[]>::value>,
+                     decltype(std::declval<Container>().size())>;
+  template <class It>
+  using EnableIfItInputIterator = detail::enable_if_t<
+      std::is_convertible<typename std::iterator_traits<It>::iterator_category,
+                          std::input_iterator_tag>::value>;
   template <typename ItA, typename ItB>
   using EnableIfSameNonConstIterators =
       typename std::enable_if<std::is_same<ItA, ItB>::value &&
@@ -107,7 +118,8 @@ public:
   }
 
   template <class InputIterator, int N = dimensions,
-            typename = EnableIfOneDimension<N>>
+            typename = EnableIfOneDimension<N>,
+            typename = EnableIfItInputIterator<InputIterator>>
   buffer(InputIterator first, InputIterator last, AllocatorT allocator,
          const property_list &propList = {})
       : Range(range<1>(std::distance(first, last))) {
@@ -117,7 +129,8 @@ public:
   }
 
   template <class InputIterator, int N = dimensions,
-            typename = EnableIfOneDimension<N>>
+            typename = EnableIfOneDimension<N>,
+            typename = EnableIfItInputIterator<InputIterator>>
   buffer(InputIterator first, InputIterator last,
          const property_list &propList = {})
       : Range(range<1>(std::distance(first, last))) {
@@ -125,6 +138,26 @@ public:
         first, last, get_count() * sizeof(T),
         detail::getNextPowerOfTwo(sizeof(T)), propList);
   }
+
+  // This constructor is a prototype for a future SYCL specification
+  template <class Container, int N = dimensions,
+            typename = EnableIfOneDimension<N>,
+            typename = EnableIfContiguous<Container>>
+  buffer(Container &container, AllocatorT allocator,
+         const property_list &propList = {})
+      : Range(range<1>(container.size())) {
+    impl = std::make_shared<detail::buffer_impl<AllocatorT>>(
+        container.data(), container.data() + container.size(),
+        get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)), propList,
+        allocator);
+  }
+
+  // This constructor is a prototype for a future SYCL specification
+  template <class Container, int N = dimensions,
+            typename = EnableIfOneDimension<N>,
+            typename = EnableIfContiguous<Container>>
+  buffer(Container &container, const property_list &propList = {})
+      : buffer(container, {}, propList) {}
 
   buffer(buffer<T, dimensions, AllocatorT> &b, const id<dimensions> &baseIndex,
          const range<dimensions> &subRange)

--- a/sycl/include/CL/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/stl_type_traits.hpp
@@ -53,15 +53,15 @@ template <typename T>
 using iterator_to_const_type_t =
     std::is_const<typename std::remove_pointer<iterator_pointer_t<T>>::type>;
 
-template <class...> using requirements_list = void;
+template <class...> using void_t = void;
 
 // TODO Align with C++ named requirements: LegacyOutputIterator
 // https://en.cppreference.com/w/cpp/named_req/OutputIterator
 template <typename T>
 using output_iterator_requirements =
-    requirements_list<iterator_category_t<T>,
-                      decltype(*std::declval<T>() =
-                                   std::declval<iterator_value_type_t<T>>())>;
+    void_t<iterator_category_t<T>,
+           decltype(*std::declval<T>() =
+                        std::declval<iterator_value_type_t<T>>())>;
 
 template <typename, typename = void> struct is_output_iterator {
   static constexpr bool value = false;

--- a/sycl/include/CL/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/stl_type_traits.hpp
@@ -16,14 +16,9 @@ namespace cl {
 namespace sycl {
 namespace detail {
 
-template <bool V> using bool_constant = std::integral_constant<bool, V>;
-
-template <typename T>
-using allocator_value_type_t = typename std::allocator_traits<T>::value_type;
-
-template <typename T>
-using allocator_pointer_t = typename std::allocator_traits<T>::pointer;
-
+// Type traits identical to those in std in newer versions. Can be removed when
+// SYCL requires a newer version of the C++ standard.
+// C++14
 template <bool B, class T = void>
 using enable_if_t = typename std::enable_if<B, T>::type;
 
@@ -40,6 +35,18 @@ using remove_reference_t = typename std::remove_reference<T>::type;
 
 template <typename T> using add_pointer_t = typename std::add_pointer<T>::type;
 
+// C++17
+template <bool V> using bool_constant = std::integral_constant<bool, V>;
+
+template <class...> using void_t = void;
+
+// Custom type traits
+template <typename T>
+using allocator_value_type_t = typename std::allocator_traits<T>::value_type;
+
+template <typename T>
+using allocator_pointer_t = typename std::allocator_traits<T>::pointer;
+
 template <typename T>
 using iterator_category_t = typename std::iterator_traits<T>::iterator_category;
 
@@ -52,8 +59,6 @@ using iterator_pointer_t = typename std::iterator_traits<T>::pointer;
 template <typename T>
 using iterator_to_const_type_t =
     std::is_const<typename std::remove_pointer<iterator_pointer_t<T>>::type>;
-
-template <class...> using void_t = void;
 
 // TODO Align with C++ named requirements: LegacyOutputIterator
 // https://en.cppreference.com/w/cpp/named_req/OutputIterator

--- a/sycl/test/basic_tests/buffer/buffer.cpp
+++ b/sycl/test/basic_tests/buffer/buffer.cpp
@@ -556,7 +556,7 @@ int main() {
       std::vector<int> data2(10, -2);
       {
         buffer<int, 1> a(data1.data(), range<1>(10));
-        buffer<int, 1> b(data2.data(), range<1>(10));
+        buffer<int, 1> b(data2);
 
         program prog(myQueue.get_context());
         prog.build_with_source("kernel void override_source(global int* Acc) "
@@ -581,7 +581,7 @@ int main() {
     std::vector<int> data2(10, -2);
     {
       buffer<int, 1> a(data1.data(), range<1>(10));
-      buffer<int, 1> b(data2.data(), range<1>(10));
+      buffer<int, 1> b(data2);
       accessor<int, 1, access::mode::read_write, access::target::global_buffer,
                access::placeholder::true_t>
           A(a);
@@ -609,7 +609,7 @@ int main() {
       std::vector<int> data2(10, -2);
       {
         buffer<int, 1> a(data1.data(), range<1>(10));
-        buffer<int, 1> b(data2.data(), range<1>(10));
+        buffer<int, 1> b(data2);
         accessor<int, 1, access::mode::read_write,
                  access::target::global_buffer, access::placeholder::true_t>
             A(a);

--- a/sycl/test/basic_tests/buffer/buffer_ctad.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_ctad.cpp
@@ -1,0 +1,40 @@
+// RUN: %clangxx -std=c++17 -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+//==------------------- buffer_ctad.cpp - SYCL buffer CTAD test ----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+#include <cassert>
+#include <memory>
+
+using namespace cl::sycl;
+
+int main() {
+  std::vector<int> v(5, 1);
+  const std::vector<int> cv(5, 1);
+  buffer b1(v.data(), range<1>(5));
+  static_assert(std::is_same_v<decltype(b1), buffer<int, 1>>);
+  buffer b1a(v.data(), range<1>(5), std::allocator<int>());
+  static_assert(
+      std::is_same_v<decltype(b1a), buffer<int, 1, std::allocator<int>>>);
+  buffer b1b(cv.data(), range<1>(5));
+  static_assert(std::is_same_v<decltype(b1b), buffer<int, 1>>);
+  buffer b1c(v.data(), range<2>(2, 2));
+  static_assert(std::is_same_v<decltype(b1c), buffer<int, 2>>);
+  buffer b2(v.begin(), v.end());
+  static_assert(std::is_same_v<decltype(b2), buffer<int, 1>>);
+  buffer b2a(v.cbegin(), v.cend());
+  static_assert(std::is_same_v<decltype(b2a), buffer<int, 1>>);
+  buffer b3(v);
+  static_assert(std::is_same_v<decltype(b3), buffer<int, 1>>);
+  buffer b3a(cv);
+  static_assert(std::is_same_v<decltype(b3a), buffer<int, 1>>);
+  shared_ptr_class<int> ptr{new int[5], [](int *p) { delete[] p; }};
+  buffer b4(ptr, range<1>(5));
+  static_assert(std::is_same_v<decltype(b4), buffer<int, 1>>);
+}


### PR DESCRIPTION
Prototype of a proposal to add a buffer constructor which takes a contiguous buffer as an argument to simplify usage and add buffer deduction guides for both iterator and container.

