### PR TITLE
[SYCL] Cache explicitly created programs

### DIFF
--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -207,8 +207,14 @@ public:
     // TODO Check for existence of kernel
     if (!is_host()) {
       OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
-      create_cl_program_with_il(M);
-      build(BuildOptions);
+      // If there are no build options, program can be safely cached
+      if (BuildOptions.empty()) {
+        Program = ProgramManager::getInstance().getBuiltOpenCLProgram(M, Context);
+        PI_CALL(RT::piProgramRetain(Program));
+      } else {
+        create_cl_program_with_il(M);
+        build(BuildOptions);
+      }
     }
     State = program_state::linked;
   }

--- a/sycl/test/kernel-and-program/program_cache.cpp
+++ b/sycl/test/kernel-and-program/program_cache.cpp
@@ -1,0 +1,26 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+//==------------- program_cache.cpp - SYCL kernel/program test -------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+class Functor {
+  public:
+  void operator()() {
+  }
+};
+
+int main() {
+  cl::sycl::queue q;
+  cl::sycl::program prog(q.get_context());
+  prog.build_with_kernel_type<Functor>();
+
+  auto *ctx = cl::sycl::detail::getRawSyclObjImpl(prog.get_context());
+  return ctx->getCachedPrograms().size() != 1;
+}


### PR DESCRIPTION
When SYCL program is created explicitly with constructor (like
`cl::sycl::program prog(q.get_context())`) and built with
`build_with_kernel_type` method without any build options, raw OpenCL
program will be cached.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>