### PR TITLE
Implement IVDep for arrays, dependent cases, general cases.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -490,6 +490,9 @@ class Attr {
   // content. Eg) It parses 3 args, but semantically takes 4 args.  Opts out of
   // common attribute error checking.
   bit HasCustomParsing = 0;
+  // Set to true if the attribute is a type attribute that has custom
+  // TreeTransform logic in order to handle template transformations.
+  bit HasCustomTypeTransform = 0;
   // Set to true if all of the attribute's arguments should be parsed in an
   // unevaluated context.
   bit ParseArgumentsAsUnevaluated = 0;
@@ -1505,11 +1508,41 @@ def Mode : Attr {
 
 def SYCLIntelFPGAIVDep : Attr {
   let Spellings = [CXX11<"intelfpga","ivdep">];
-  let Args = [IntArgument<"Safelen">];
+  let Args = [
+    ExprArgument<"SafelenExpr">, ExprArgument<"ArrayExpr">,
+    UnsignedArgument<"SafelenValue">
+  ];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let HasCustomTypeTransform = 1;
   let AdditionalMembers = [{
     static const char *getName() {
       return "ivdep";
+    }
+    bool isDependent() const {
+      return (getSafelenExpr() &&
+              getSafelenExpr()->isInstantiationDependent()) ||
+             (getArrayExpr() && getArrayExpr()->isInstantiationDependent());
+    }
+
+    const VarDecl *getArrayDecl() const {
+      return getArrayExpr()
+                 ? cast<VarDecl>(cast<DeclRefExpr>(getArrayExpr())->getDecl())
+                       ->getCanonicalDecl()
+                 : nullptr;
+    }
+
+    bool isInf() const {
+      return !getSafelenExpr();
+    }
+
+    static bool SafelenCompare(const SYCLIntelFPGAIVDepAttr *LHS,
+                               const SYCLIntelFPGAIVDepAttr *RHS) {
+      // INF < INF is false, !INF < INF is true.
+      if (!RHS->getSafelenExpr())
+        return false;
+      if (!LHS->getSafelenExpr())
+        return true;
+      return LHS->getSafelenValue() > RHS->getSafelenValue();
     }
   }];
   let Documentation = [SYCLIntelFPGAIVDepAttrDocs];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1878,8 +1878,19 @@ def SYCLIntelFPGAIVDepAttrDocs : Documentation {
   let Content = [{
 This attribute applies to a loop. If no additional arguments are provided, it
 indicates that the backend may assume that the loop carries no dependences.
-If a safelen is provided then the backend may assume that all loop carried
+If a safelen is provided then the backend may assume that all loop-carried
 dependences have a dependence distance of at least that length.
+If an array variable is provided then the backend may assume that there are
+no loop-carried dependences for this particular array within this loop.
+If both an array variable and a safelen are specified, the backend may assume
+that all loop-carried dependences for this particular array have a dependence
+distance of at least that length.
+Multiple ivdep attributes can be applied to the same loop, but only the greatest
+possible safelen will be chosen for each array, including the case where safelen
+is unspecified and is therefore considered infinite.
+In case of ivdep being applied both w/o an array variable and for a particular
+array, the array variables that were not designated a separate ivdep will receive
+the no-array ivdep's safelen, with the correspondent treatment by the backend.
   }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10127,6 +10127,17 @@ def err_sycl_attibute_cannot_be_applied_here
             "|class member function"
             "|function with a raw pointer return type"
             "|function with a raw pointer parameter type}1">;
+def err_ivdep_duplicate_arg : Error<
+  "duplicate argument to 'ivdep'. attribute requires one or both of a safelen "
+  "and array">;
+def err_ivdep_unknown_arg : Error<
+  "unknown argument to 'ivdep'. Expected integer or array variable">;
+def err_ivdep_declrefexpr_arg : Error<
+  "invalid declaration reference argument to 'ivdep'. Expected integer or array"
+  " variable">;
+def warn_ivdep_redundant : Warning <"ignoring redundant Intel FPGA loop "
+  "attribute 'ivdep': safelen %select{INF|%1}0 >= safelen %select{INF|%3}2">,
+  InGroup<IgnoredAttributes>;
 
 def err_preserve_field_info_not_field : Error<
   "__builtin_preserve_field_info argument %0 not a field access">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1657,6 +1657,9 @@ public:
   /// Same as above, but constructs the AddressSpace index if not provided.
   QualType BuildAddressSpaceAttr(QualType &T, Expr *AddrSpace,
                                  SourceLocation AttrLoc);
+  SYCLIntelFPGAIVDepAttr *
+  BuildSYCLIntelFPGAIVDepAttr(const AttributeCommonInfo &CI, Expr *Expr1,
+                              Expr *Expr2);
 
   bool CheckQualifiedFunctionForTypeId(QualType T, SourceLocation Loc);
 
@@ -4220,6 +4223,7 @@ public:
   StmtResult ActOnAttributedStmt(SourceLocation AttrLoc,
                                  ArrayRef<const Attr*> Attrs,
                                  Stmt *SubStmt);
+  bool CheckRebuiltAttributedStmtAttributes(ArrayRef<const Attr *> Attrs);
 
   class ConditionResult;
   StmtResult ActOnIfStmt(SourceLocation IfLoc, bool IsConstexpr,

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -16,6 +16,8 @@
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Metadata.h"
+
+using namespace clang;
 using namespace clang::CodeGen;
 using namespace llvm;
 

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -976,7 +976,7 @@ void LoopInfo::collectIVDepMetadata(
   MD.push_back(GlobalArrayPairItr->second);
 }
 
-void LoopInfo::AddIVDepMetadata(const ValueDecl *Array,
+void LoopInfo::addIVDepMetadata(const ValueDecl *Array,
                                 llvm::Instruction *GEP) const {
   llvm::SmallVector<llvm::Metadata *, 4> MD;
   collectIVDepMetadata(Array, MD);
@@ -995,5 +995,5 @@ void LoopInfoStack::addIVDepMetadata(const ValueDecl *Array,
   if (!hasInfo())
     return;
   const LoopInfo &L = getInfo();
-  L.AddIVDepMetadata(Array, GEP);
+  L.addIVDepMetadata(Array, GEP);
 }

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -9,6 +9,7 @@
 #include "CGLoopInfo.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
@@ -946,10 +947,10 @@ void LoopInfoStack::InsertHelper(Instruction *I) const {
   }
 }
 
-void LoopInfo::CollectIVDepMetadata(
+void LoopInfo::collectIVDepMetadata(
     const ValueDecl *Array, llvm::SmallVectorImpl<llvm::Metadata *> &MD) const {
   if (Parent)
-    Parent->CollectIVDepMetadata(Array, MD);
+    Parent->collectIVDepMetadata(Array, MD);
 
   auto ArrayIVDep =
       llvm::find_if(Attrs.ArraySYCLIVDepInfo,
@@ -976,7 +977,7 @@ void LoopInfo::CollectIVDepMetadata(
 void LoopInfo::AddIVDepMetadata(const ValueDecl *Array,
                                 llvm::Instruction *GEP) const {
   llvm::SmallVector<llvm::Metadata *, 4> MD;
-  CollectIVDepMetadata(Array, MD);
+  collectIVDepMetadata(Array, MD);
 
   if (MD.size() == 1)
     GEP->setMetadata("llvm.index.group", cast<llvm::MDNode>(MD.front()));

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -61,7 +61,7 @@ struct LoopAttributes {
   /// Value for llvm.loop.interleave.count metadata.
   unsigned InterleaveCount;
 
-  // IVDepInfo represents a group of arrays that have the same IVDep safelen to
+  // SYCLIVDepInfo represents a group of arrays that have the same IVDep safelen to
   // them. The arrays contained in it will later be referred to from the same
   // "llvm.loop.parallel_access_indices" metadata node.
   struct SYCLIVDepInfo {
@@ -150,7 +150,7 @@ public:
   llvm::MDNode *getAccessGroup() const { return AccGroup; }
 
   // Recursively adds the metadata for this Array onto this GEP.
-  void AddIVDepMetadata(const ValueDecl *Array, llvm::Instruction *GEP) const;
+  void addIVDepMetadata(const ValueDecl *Array, llvm::Instruction *GEP) const;
 
   /// Create the loop's metadata. Must be called after its nested loops have
   /// been processed.

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -221,7 +221,7 @@ private:
   createFullUnrollMetadata(const LoopAttributes &Attrs,
                            llvm::ArrayRef<llvm::Metadata *> LoopProperties,
                            bool &HasUserTransforms);
-  void CollectIVDepMetadata(const ValueDecl *Array,
+  void collectIVDepMetadata(const ValueDecl *Array,
                             llvm::SmallVectorImpl<llvm::Metadata *> &MD) const;
   /// @}
 

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -29,6 +29,7 @@ class MDNode;
 namespace clang {
 class Attr;
 class ASTContext;
+class ValueDecl;
 namespace CodeGen {
 
 /// Attributes that may be specified on loops.
@@ -60,11 +61,44 @@ struct LoopAttributes {
   /// Value for llvm.loop.interleave.count metadata.
   unsigned InterleaveCount;
 
-  /// Value for llvm.loop.ivdep.enable metadata.
-  bool SYCLIVDepEnable;
+  // Struct to contain the IVDep info.
+  struct IVDepInfo {
+    unsigned SafeLen;
+    mutable llvm::SmallVector<std::pair<const ValueDecl *, llvm::MDNode *>, 4>
+        Arrays;
+    IVDepInfo(unsigned SL) : SafeLen(SL) {}
+    IVDepInfo(unsigned SL, const ValueDecl *A, llvm::MDNode *MD) : SafeLen(SL) {
+      Arrays.emplace_back(A, MD);
+    }
 
-  /// Value for llvm.loop.ivdep.safelen metadata.
-  unsigned SYCLIVDepSafelen;
+    bool HasArray(const ValueDecl *Array) const {
+      return Arrays.end() != GetArrayPairItr(Array);
+    }
+
+    decltype(Arrays)::iterator GetArrayPairItr(const ValueDecl *Array) {
+      return find_if(Arrays,
+                     [Array](const auto &Pair) { return Pair.first == Array; });
+    }
+
+    decltype(Arrays)::iterator GetArrayPairItr(const ValueDecl *Array) const {
+      return find_if(Arrays,
+                     [Array](const auto &Pair) { return Pair.first == Array; });
+    }
+
+    void EraseArray(const ValueDecl *Array) {
+      assert(HasArray(Array) && "Precondition of EraseArray is HasArray");
+      Arrays.erase(GetArrayPairItr(Array));
+    }
+
+    bool IsSafeLenGreaterOrEqual(unsigned OtherSL) const {
+      return SafeLen == 0 || (OtherSL != 0 && SafeLen >= OtherSL);
+    }
+  };
+
+  // Value for llvm.loop.parallel_access_indices metadata, for the global item.
+  llvm::Optional<IVDepInfo> GlobalIVDepInfo;
+  // Value for llvm.loop.parallel_access_indices metadata, for array specifications.
+  llvm::SmallVector<IVDepInfo, 4> ArraySYCLIVDepInfo;
 
   /// Value for llvm.loop.ii.count metadata.
   unsigned SYCLIInterval;
@@ -110,6 +144,9 @@ public:
 
   /// Return this loop's access group or nullptr if it does not have one.
   llvm::MDNode *getAccessGroup() const { return AccGroup; }
+
+  // Recursively adds the metadata for this Array onto this GEP.
+  void AddIVDepMetadata(const ValueDecl *Array, llvm::Instruction *GEP) const;
 
   /// Create the loop's metadata. Must be called after its nested loops have
   /// been processed.
@@ -180,6 +217,8 @@ private:
   createFullUnrollMetadata(const LoopAttributes &Attrs,
                            llvm::ArrayRef<llvm::Metadata *> LoopProperties,
                            bool &HasUserTransforms);
+  void CollectIVDepMetadata(const ValueDecl *Array,
+                            llvm::SmallVectorImpl<llvm::Metadata *> &MD) const;
   /// @}
 
   /// Create a LoopID for this loop, including transformation-unspecific
@@ -271,11 +310,11 @@ public:
   /// Set the interleave count for the next loop pushed.
   void setInterleaveCount(unsigned C) { StagedAttrs.InterleaveCount = C; }
 
-  /// Set flag of ivdep for the next loop pushed.
-  void setSYCLIVDepEnable() { StagedAttrs.SYCLIVDepEnable = true; }
+  /// Add a safelen value for the next loop pushed.
+  void addSYCLIVDepInfo(llvm::LLVMContext &Ctx, unsigned SafeLen,
+                        const ValueDecl *Array);
 
-  /// Set value of safelen count for the next loop pushed.
-  void setSYCLIVDepSafelen(unsigned C) { StagedAttrs.SYCLIVDepSafelen = C; }
+  void addIVDepMetadata(const ValueDecl *Array, llvm::Instruction *GEP);
 
   /// Set value of an initiation interval for the next loop pushed.
   void setSYCLIInterval(unsigned C) { StagedAttrs.SYCLIInterval = C; }

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -953,6 +953,8 @@ namespace {
                           bool AllowInjectedClassName = false);
 
     const LoopHintAttr *TransformLoopHintAttr(const LoopHintAttr *LH);
+    const SYCLIntelFPGAIVDepAttr *
+    TransformSYCLIntelFPGAIVDepAttr(const SYCLIntelFPGAIVDepAttr *IV);
 
     ExprResult TransformPredefinedExpr(PredefinedExpr *E);
     ExprResult TransformDeclRefExpr(DeclRefExpr *E);
@@ -1341,6 +1343,21 @@ TemplateInstantiator::TransformLoopHintAttr(const LoopHintAttr *LH) {
   // non-type template parameter.
   return LoopHintAttr::CreateImplicit(getSema().Context, LH->getOption(),
                                       LH->getState(), TransformedExpr, *LH);
+}
+
+const SYCLIntelFPGAIVDepAttr *
+TemplateInstantiator::TransformSYCLIntelFPGAIVDepAttr(
+    const SYCLIntelFPGAIVDepAttr *IVDep) {
+
+  Expr *Expr1 = IVDep->getSafelenExpr()
+                    ? getDerived().TransformExpr(IVDep->getSafelenExpr()).get()
+                    : nullptr;
+  Expr *Expr2 = IVDep->getArrayExpr()
+                    ? getDerived().TransformExpr(IVDep->getArrayExpr()).get()
+                    : nullptr;
+
+  auto *Attr = getSema().BuildSYCLIntelFPGAIVDepAttr(*IVDep, Expr1, Expr2);
+  return Attr;
 }
 
 ExprResult TemplateInstantiator::transformNonTypeTemplateParmRef(

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1356,8 +1356,7 @@ TemplateInstantiator::TransformSYCLIntelFPGAIVDepAttr(
                     ? getDerived().TransformExpr(IVDep->getArrayExpr()).get()
                     : nullptr;
 
-  auto *Attr = getSema().BuildSYCLIntelFPGAIVDepAttr(*IVDep, Expr1, Expr2);
-  return Attr;
+  return getSema().BuildSYCLIntelFPGAIVDepAttr(*IVDep, Expr1, Expr2);
 }
 
 ExprResult TemplateInstantiator::transformNonTypeTemplateParmRef(

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -370,6 +370,8 @@ public:
 #define ATTR(X)
 #define PRAGMA_SPELLING_ATTR(X)                                                \
   const X##Attr *Transform##X##Attr(const X##Attr *R) { return R; }
+#define DEPENDENT_STMT_ATTR(X)                                                 \
+  const X##Attr *Transform##X##Attr(const X##Attr *R) { return R; }
 #include "clang/Basic/AttrList.inc"
 
   /// Transform the given expression.
@@ -1275,6 +1277,8 @@ public:
   StmtResult RebuildAttributedStmt(SourceLocation AttrLoc,
                                    ArrayRef<const Attr*> Attrs,
                                    Stmt *SubStmt) {
+    if (SemaRef.CheckRebuiltAttributedStmtAttributes(Attrs))
+      return StmtError();
     return SemaRef.ActOnAttributedStmt(AttrLoc, Attrs, SubStmt);
   }
 
@@ -6779,6 +6783,9 @@ const Attr *TreeTransform<Derived>::TransformAttr(const Attr *R) {
 // Transform attributes with a pragma spelling by calling TransformXXXAttr.
 #define ATTR(X)
 #define PRAGMA_SPELLING_ATTR(X)                                                \
+  case attr::X:                                                                \
+    return getDerived().Transform##X##Attr(cast<X##Attr>(R));
+#define DEPENDENT_STMT_ATTR(X)                                                 \
   case attr::X:                                                                \
     return getDerived().Transform##X##Attr(cast<X##Attr>(R));
 #include "clang/Basic/AttrList.inc"

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
@@ -220,3 +220,4 @@ int main() {
 // CHECK-DAG: ![[IVDEP_A_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_MUL_ARR_AND_GLOB]], i32 5}
 // CHECK-DAG: ![[IVDEP_B_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_B_MUL_ARR_AND_GLOB]], i32 6}
 // CHECK-DAG: ![[IVDEP_C_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_C_MUL_ARR_AND_GLOB]]}
+//

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
@@ -1,0 +1,222 @@
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+
+// Array-specific ivdep - annotate the correspondent GEPs only
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_array_no_safelenv()
+void ivdep_array_no_safelen() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep(a)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_ARR:[0-9]+]]
+    a[i] = 0;
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}{{[[:space:]]}}
+    b[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_ARR:[0-9]+]]
+  }
+}
+
+// Array-specific ivdep w/ safelen - annotate the correspondent GEPs only
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_array_with_safelenv()
+void ivdep_array_with_safelen() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep(a, 5)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_ARR_SAFELEN:[0-9]+]]
+    a[i] = 0;
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}{{[[:space:]]}}
+    b[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_ARR_SAFELEN:[0-9]+]]
+  }
+}
+
+// Multiple array-specific ivdeps - annotate the correspondent GEPs
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_multiple_arraysv()
+void ivdep_multiple_arrays() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  // CHECK: %[[ARRAY_C:[0-9a-z]+]] = alloca [10 x i32]
+  int c[10];
+  // CHECK: %[[ARRAY_D:[0-9a-z]+]] = alloca [10 x i32]
+  int d[10];
+  [[intelfpga::ivdep(a, 5)]]
+  [[intelfpga::ivdep(b, 5)]]
+  [[intelfpga::ivdep(c)]]
+  [[intelfpga::ivdep(d)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_MUL_ARR:[0-9]+]]
+    a[i] = 0;
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_MUL_ARR:[0-9]+]]
+    b[i] = 0;
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_C]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_C_MUL_ARR:[0-9]+]]
+    c[i] = 0;
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_D]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_D_MUL_ARR:[0-9]+]]
+    d[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_MUL_ARR:[0-9]+]]
+  }
+}
+
+// Global ivdep with INF safelen & array-specific ivdep with the same safelen
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_array_and_globalv()
+void ivdep_array_and_global() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep]]
+  [[intelfpga::ivdep(a)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_ARR_AND_GLOB:[0-9]+]]
+    a[i] = 0;
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_ARR_AND_GLOB:[0-9]+]]
+    b[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_ARR_AND_GLOB:[0-9]+]]
+  }
+}
+
+// Global ivdep with INF safelen & array-specific ivdep with lesser safelen
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_array_and_inf_globalv()
+void ivdep_array_and_inf_global() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep]]
+  [[intelfpga::ivdep(a, 8)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_ARR_AND_INF_GLOB:[0-9]+]]
+    a[i] = 0;
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_ARR_AND_INF_GLOB:[0-9]+]]
+    b[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_ARR_AND_INF_GLOB:[0-9]+]]
+  }
+}
+
+// Global ivdep with specified safelen & array-specific ivdep with lesser safelen
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_array_and_greater_globalv()
+void ivdep_array_and_greater_global() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep(9)]]
+  [[intelfpga::ivdep(a, 8)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_ARR_AND_GREAT_GLOB:[0-9]+]]
+    a[i] = 0;
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_ARR_AND_GREAT_GLOB:[0-9]+]]
+    b[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_ARR_AND_GREAT_GLOB:[0-9]+]]
+  }
+}
+
+// Global safelen, array-specific safelens
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_mul_arrays_and_globalv()
+void ivdep_mul_arrays_and_global() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  // CHECK: %[[ARRAY_C:[0-9a-z]+]] = alloca [10 x i32]
+  int c[10];
+  [[intelfpga::ivdep(5)]]
+  [[intelfpga::ivdep(b, 6)]]
+  [[intelfpga::ivdep(c)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_MUL_ARR_AND_GLOB:[0-9]+]]
+    a[i] = 0;
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_MUL_ARR_AND_GLOB:[0-9]+]]
+    b[i] = 0;
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_C]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_C_MUL_ARR_AND_GLOB:[0-9]+]]
+    c[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_MUL_ARR_AND_GLOB:[0-9]+]]
+  }
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class kernel_function>([]() {
+    ivdep_array_no_safelen();
+    ivdep_array_with_safelen();
+    ivdep_multiple_arrays();
+    ivdep_array_and_global();
+    ivdep_array_and_inf_global();
+    ivdep_array_and_greater_global();
+    ivdep_mul_arrays_and_global();
+  });
+  return 0;
+}
+
+/// A particular array with no safelen specified
+//
+// CHECK-DAG: ![[IDX_GROUP_ARR]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_ARR]] = distinct !{![[MD_LOOP_ARR]], ![[IVDEP_ARR:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_ARR]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_ARR]]}
+
+/// A particular array with safelen specified
+//
+// CHECK: ![[IDX_GROUP_ARR_SAFELEN]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_ARR_SAFELEN]] = distinct !{![[MD_LOOP_ARR_SAFELEN]], ![[IVDEP_ARR_SAFELEN:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_ARR_SAFELEN]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_ARR_SAFELEN]], i32 5}
+
+/// Multiple arrays.
+/// Index groups for arrays with matching safelens should be put into the same parallel_access_indices MD node
+//
+// CHECK-DAG: ![[IDX_GROUP_A_MUL_ARR]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_MUL_ARR]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_C_MUL_ARR]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_D_MUL_ARR]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_MUL_ARR]] = distinct !{![[MD_LOOP_MUL_ARR]], ![[IVDEP_MUL_ARR_VAL:[0-9]+]], ![[IVDEP_MUL_ARR_INF:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_MUL_ARR_VAL]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_MUL_ARR]], ![[IDX_GROUP_B_MUL_ARR]], i32 5}
+// CHECK-DAG: ![[IVDEP_MUL_ARR_INF]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_C_MUL_ARR]], ![[IDX_GROUP_D_MUL_ARR]]}
+
+/// Global INF safelen and specific array INF safelen
+/// The array-specific ivdep can be ignored, so it's the same as just global ivdep with safelen INF
+//
+// CHECK-DAG: ![[IDX_GROUP_A_ARR_AND_GLOB]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_ARR_AND_GLOB]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_ARR_AND_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_GLOB]], ![[IVDEP_ARR_AND_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_ARR_AND_GLOB]], ![[IDX_GROUP_B_ARR_AND_GLOB]]}
+
+/// Global INF safelen and specific array non-INF safelen
+/// The array-specific ivdep must be ignored, so it's the same as just global ivdep with safelen INF
+//
+// CHECK-DAG: ![[IDX_GROUP_A_ARR_AND_INF_GLOB]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_ARR_AND_INF_GLOB]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_ARR_AND_INF_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_INF_GLOB]], ![[IVDEP_ARR_AND_INF_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_ARR_AND_INF_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_ARR_AND_INF_GLOB]], ![[IDX_GROUP_B_ARR_AND_INF_GLOB]]}
+
+/// Global safelen and specific array with lesser safelen
+/// The array-specific ivdep must be gnored, so it's the same as just global ivdep with its safelen
+//
+// CHECK-DAG: ![[IDX_GROUP_A_ARR_AND_GREAT_GLOB]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_ARR_AND_GREAT_GLOB]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_ARR_AND_GREAT_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_GREAT_GLOB]], ![[IVDEP_ARR_AND_GREAT_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_ARR_AND_GREAT_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_ARR_AND_GREAT_GLOB]], ![[IDX_GROUP_B_ARR_AND_GREAT_GLOB]], i32 9}
+
+/// Multiple arrays with specific safelens and lesser global safelen
+/// The array-specific safelens are kept for the correspondent arrays, the global safelen applies to the rest
+//
+// CHECK-DAG: ![[IDX_GROUP_A_MUL_ARR_AND_GLOB]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_MUL_ARR_AND_GLOB]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_C_MUL_ARR_AND_GLOB]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_MUL_ARR_AND_GLOB]] = distinct !{![[MD_LOOP_MUL_ARR_AND_GLOB]], ![[IVDEP_A_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_B_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_C_MUL_ARR_AND_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_A_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_MUL_ARR_AND_GLOB]], i32 5}
+// CHECK-DAG: ![[IVDEP_B_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_B_MUL_ARR_AND_GLOB]], i32 6}
+// CHECK-DAG: ![[IVDEP_C_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_C_MUL_ARR_AND_GLOB]]}

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
@@ -1,0 +1,261 @@
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+
+// Accesses from the inner loop only, various global safelens for the outer and the inner loops.
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_inner_loop_accessv()
+void ivdep_inner_loop_access() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i) {
+    [[intelfpga::ivdep(3)]]
+    for (int j = 0; j != 10; ++j) {
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_ACCESS:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_ACCESS]]
+      a[i] = a[(i + j) % 10];
+      // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_INNER_LOOP_INNER_ACCESS:[0-9]+]]
+    }
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_OUTER_LOOP_INNER_ACCESS:[0-9]+]]
+  }
+}
+
+// Accesses from both inner and outer loop, same global (INF) safelen for both.
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_embedded_global_safelenv()
+void ivdep_embedded_global_safelen() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_OUTER_GLOB_SFLN:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_OUTER_GLOB_SFLN]]
+    a[i] = a[i % 2];
+    [[intelfpga::ivdep]]
+    for (int j = 0; j != 10; ++j) {
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_GLOB_SFLN:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_GLOB_SFLN]]
+      a[i] = a[(i + j) % 10];
+      // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_INNER_GLOB_SFLN:[0-9]+]]
+    }
+    // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_OUTER_GLOB_SFLN:[0-9]+]]
+  }
+}
+
+// Accesses from both inner and outer loop, with various safelens per loop.
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_embedded_various_safelensv()
+void ivdep_embedded_various_safelens() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  [[intelfpga::ivdep(a, 4)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_OUTER_VAR_SFLN:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_OUTER_VAR_SFLN]]
+    a[i] = a[i % 2];
+    [[intelfpga::ivdep(a, 2)]]
+    for (int j = 0; j != 10; ++j) {
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_VAR_SFLN:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_VAR_SFLN]]
+      a[i] = a[(i + j) % 10];
+      // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_INNER_VAR_SFLN:[0-9]+]]
+    }
+    // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_OUTER_VAR_SFLN:[0-9]+]]
+  }
+}
+
+// Multiple arrays accessed from both loops.
+// Outer loop: array-specific ivdeps for all arrays with various safelens
+// Inner loop: global ivdep with its own safelen
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_embedded_multiple_arraysv()
+void ivdep_embedded_multiple_arrays() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep(a, 3), intelfpga::ivdep(b, 4)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_OUTER_MUL_ARRS:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_OUTER_MUL_ARRS]]
+    a[i] = a[i % 2];
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_OUTER_MUL_ARRS:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_OUTER_MUL_ARRS]]
+    b[i] = b[i % 2];
+    [[intelfpga::ivdep(2)]]
+    for (int j = 0; j != 10; ++j) {
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_INNER_MUL_ARRS:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_INNER_MUL_ARRS:[0-9]+]]
+      a[i] = b[(i + j) % 10];
+      // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_INNER_MUL_ARRS:[0-9]+]]
+    }
+    // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_OUTER_MUL_ARRS:[0-9]+]]
+  }
+}
+
+// Multiple arrays accessed from both loops.
+// Outer loop: array-specific ivdep for one of the arrays
+// Inner loop: global ivdep (i.e. applies to all arrays)
+// As the outer loop's ivdep applies to a particular, other array(s) shouldn't be marked
+// into any index group at the outer loop level
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_embedded_multiple_arrays_globalv()
+void ivdep_embedded_multiple_arrays_global() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep(a)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB]]
+    a[i] = a[i % 2];
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}{{[[:space:]]}}
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}{{[[:space:]]}}
+    b[i] = b[i % 2];
+    [[intelfpga::ivdep]]
+    for (int j = 0; j != 10; ++j) {
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_INNER_MUL_ARRS_GLOB:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_INNER_MUL_ARRS_GLOB:[0-9]+]]
+      a[i] = b[(i + j) % 10];
+      // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_INNER_MUL_ARRS_GLOB:[0-9]+]]
+    }
+    // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_OUTER_MUL_ARRS_GLOB:[0-9]+]]
+  }
+}
+
+// Accesses within each dimension of a multi-dimensional (n > 2) loop
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_embedded_multiple_dimensionsv()
+void ivdep_embedded_multiple_dimensions() {
+  int a[10];
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_DIM_1_MUL_DIMS:[0-9]+]]
+    a[i] = i;
+    [[intelfpga::ivdep]]
+    for (int j = 0; j != 10; ++j) {
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_DIM_2_MUL_DIMS:[0-9]+]]
+      a[j] += j;
+      [[intelfpga::ivdep]]
+      for (int k = 0; k != 10; ++k) {
+	// CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_DIM_3_MUL_DIMS:[0-9]+]]
+	a[k] += k;
+        // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_DIM_3_MUL_DIMS:[0-9]+]]
+      }
+      // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_DIM_2_MUL_DIMS:[0-9]+]]
+    }
+    // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_DIM_1_MUL_DIMS:[0-9]+]]
+  }
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class kernel_function>([]() {
+    ivdep_inner_loop_access();
+    ivdep_embedded_global_safelen();
+    ivdep_embedded_various_safelens();
+    ivdep_embedded_multiple_arrays();
+    ivdep_embedded_multiple_arrays_global();
+    ivdep_embedded_multiple_dimensions();
+  });
+  return 0;
+}
+
+/// Accesses from the inner loop only, various global safelens for the outer and the inner loops.
+/// The inner loop's index group(s) should have two subnodes (outer-loop node and inner-loop node).
+//
+// Inner loop
+// CHECK-DAG: ![[IDX_GROUP_INNER_ACCESS]] = !{![[OUTER_NODE_INNER_ACCESS:[0-9]+]], ![[INNER_NODE_INNER_ACCESS:[0-9]+]]}
+// CHECK-DAG: ![[INNER_NODE_INNER_ACCESS]] = distinct !{}
+// CHECK-DAG: ![[MD_INNER_LOOP_INNER_ACCESS]] = distinct !{![[MD_INNER_LOOP_INNER_ACCESS]], ![[IVDEP_INNER_INNER_ACCESS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_INNER_INNER_ACCESS]] = !{!"llvm.loop.parallel_access_indices", ![[INNER_NODE_INNER_ACCESS]], i32 3}
+//
+// Outer loop
+// CHECK-DAG: ![[OUTER_NODE_INNER_ACCESS]] = distinct !{}
+// CHECK-DAG: ![[MD_OUTER_LOOP_INNER_ACCESS]] = distinct !{![[MD_OUTER_LOOP_INNER_ACCESS]], ![[IVDEP_OUTER_INNER_ACCESS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_OUTER_INNER_ACCESS]] = !{!"llvm.loop.parallel_access_indices", ![[OUTER_NODE_INNER_ACCESS]]}
+
+/// Accesses from both inner and outer loop, same global (INF) safelen for both.
+/// The "outer loop subnode" of the inner loop's index group points at the outer loop's index group
+//
+// Inner loop
+// CHECK-DAG: ![[IDX_GROUP_INNER_GLOB_SFLN]] = !{![[IDX_GROUP_OUTER_GLOB_SFLN]], ![[INNER_NODE_GLOB_SFLN:[0-9]+]]}
+// CHECK-DAG: ![[INNER_NODE_GLOB_SFLN]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_INNER_GLOB_SFLN]] = distinct !{![[MD_LOOP_INNER_GLOB_SFLN]], ![[IVDEP_INNER_GLOB_SFLN:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_INNER_GLOB_SFLN]] = !{!"llvm.loop.parallel_access_indices", ![[INNER_NODE_GLOB_SFLN]]}
+//
+// Outer loop
+// CHECK-DAG: ![[IDX_GROUP_OUTER_GLOB_SFLN]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_OUTER_GLOB_SFLN]] = distinct !{![[MD_LOOP_OUTER_GLOB_SFLN]], ![[IVDEP_OUTER_GLOB_SFLN:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_OUTER_GLOB_SFLN]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_OUTER_GLOB_SFLN]]}
+
+/// Accesses from both inner and outer loop, with various safelens per loop.
+/// The "outer loop subnode" of the inner loop's index group points at the outer loop's index group
+//
+// Inner loop
+// CHECK-DAG: ![[IDX_GROUP_INNER_VAR_SFLN]] = !{![[IDX_GROUP_OUTER_VAR_SFLN]], ![[INNER_NODE_VAR_SFLN:[0-9]+]]}
+// CHECK-DAG: ![[INNER_NODE_VAR_SFLN]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_INNER_VAR_SFLN]] = distinct !{![[MD_LOOP_INNER_VAR_SFLN]], ![[IVDEP_INNER_VAR_SFLN:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_INNER_VAR_SFLN]] = !{!"llvm.loop.parallel_access_indices", ![[INNER_NODE_VAR_SFLN]], i32 2}
+//
+// Outer loop
+// CHECK-DAG: ![[IDX_GROUP_OUTER_VAR_SFLN]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_OUTER_VAR_SFLN]] = distinct !{![[MD_LOOP_OUTER_VAR_SFLN]], ![[IVDEP_OUTER_VAR_SFLN:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_OUTER_VAR_SFLN]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_OUTER_VAR_SFLN]], i32 4}
+
+/// Multiple arrays accessed from both loops.
+/// The "outer loop subnode" of the inner loop's index group points at the outer loop's index group
+//
+// Inner loop
+// CHECK-DAG: ![[IDX_GROUP_A_INNER_MUL_ARRS]] = !{![[IDX_GROUP_A_OUTER_MUL_ARRS]], ![[INNER_NODE_A_MUL_ARRS:[0-9]+]]}
+// CHECK-DAG: ![[INNER_NODE_A_MUL_ARRS]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_INNER_MUL_ARRS]] = !{![[IDX_GROUP_B_OUTER_MUL_ARRS]], ![[INNER_NODE_B_MUL_ARRS:[0-9]+]]}
+// CHECK-DAG: ![[INNER_NODE_B_MUL_ARRS]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_INNER_MUL_ARRS]] = distinct !{![[MD_LOOP_INNER_MUL_ARRS]], ![[IVDEP_INNER_A_B_MUL_ARRS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_INNER_A_B_MUL_ARRS]] = !{!"llvm.loop.parallel_access_indices", ![[INNER_NODE_B_MUL_ARRS]], ![[INNER_NODE_A_MUL_ARRS]], i32 2}
+//
+// Outer loop
+// CHECK-DAG: ![[IDX_GROUP_A_OUTER_MUL_ARRS]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_OUTER_MUL_ARRS]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_OUTER_MUL_ARRS]] = distinct !{![[MD_LOOP_OUTER_MUL_ARRS]], ![[IVDEP_OUTER_A_MUL_ARRS:[0-9]+]], ![[IVDEP_OUTER_B_MUL_ARRS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_OUTER_A_MUL_ARRS]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_OUTER_MUL_ARRS]], i32 3}
+// CHECK-DAG: ![[IVDEP_OUTER_B_MUL_ARRS]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_B_OUTER_MUL_ARRS]], i32 4}
+
+/// Multiple arrays accessed from both loops.
+/// The "outer loop subnode" of the inner loop's index group points at the outer loop's index group
+//
+// Inner loop
+// CHECK-DAG: ![[IDX_GROUP_A_INNER_MUL_ARRS_GLOB]] = !{![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB]], ![[INNER_NODE_A_MUL_ARRS_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[INNER_NODE_A_MUL_ARRS_GLOB]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_INNER_MUL_ARRS_GLOB]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_INNER_MUL_ARRS_GLOB]] = distinct !{![[MD_LOOP_INNER_MUL_ARRS_GLOB]], ![[IVDEP_INNER_A_B_MUL_ARRS_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_INNER_A_B_MUL_ARRS_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_B_INNER_MUL_ARRS_GLOB]], ![[INNER_NODE_A_MUL_ARRS_GLOB]]}
+//
+// Outer loop
+// CHECK-DAG: ![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_OUTER_MUL_ARRS_GLOB]] = distinct !{![[MD_LOOP_OUTER_MUL_ARRS_GLOB]], ![[IVDEP_OUTER_A_MUL_ARRS_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_OUTER_A_MUL_ARRS_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB]]}
+
+/// Accesses within each dimension of a multi-dimensional (n > 2) loop
+/// Index group(s) of each inner loop should have a subnode that points to the containing loop's index group subnode
+/// (in case the containing loop is the outermost, to the index group itself)
+//
+// Loop dimension 3 (the innermost loop)
+// CHECK-DAG: ![[IDX_GROUP_DIM_3_MUL_DIMS]] = !{![[IDX_GROUP_DIM_1_MUL_DIMS]], ![[DIM_2_NODE_MUL_DIMS:[0-9]+]], ![[DIM_3_NODE_MUL_DIMS:[0-9]+]]}
+// CHECK-DAG: ![[DIM_3_NODE_MUL_DIMS]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_DIM_3_MUL_DIMS]] = distinct !{![[MD_LOOP_DIM_3_MUL_DIMS]], ![[IVDEP_DIM_3_MUL_DIMS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_DIM_3_MUL_DIMS]] = !{!"llvm.loop.parallel_access_indices", ![[DIM_3_NODE_MUL_DIMS]]}
+//
+// Loop dimension 2
+// CHECK-DAG: ![[IDX_GROUP_DIM_2_MUL_DIMS]] = !{![[IDX_GROUP_DIM_1_MUL_DIMS]], ![[DIM_2_NODE_MUL_DIMS]]}
+// CHECK-DAG: ![[DIM_2_NODE_MUL_DIMS]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_DIM_2_MUL_DIMS]] = distinct !{![[MD_LOOP_DIM_2_MUL_DIMS]], ![[IVDEP_DIM_2_MUL_DIMS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_DIM_2_MUL_DIMS]] = !{!"llvm.loop.parallel_access_indices", ![[DIM_2_NODE_MUL_DIMS]]}
+//
+// Loop dimension 1 (the outermost loop)
+// CHECK-DAG: ![[IDX_GROUP_DIM_1_MUL_DIMS]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_DIM_1_MUL_DIMS]] = distinct !{![[MD_LOOP_DIM_1_MUL_DIMS]], ![[IVDEP_DIM_1_MUL_DIMS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_DIM_1_MUL_DIMS]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_DIM_1_MUL_DIMS]]}

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
@@ -1,0 +1,124 @@
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+
+// Global ivdep - annotate all GEPs
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_no_paramv()
+void ivdep_no_param() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_NO_PARAM:[0-9]+]]
+    a[i] = 0;
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_NO_PARAM:[0-9]+]]
+    b[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_NO_PARAM:[0-9]+]]
+  }
+}
+
+// Global ivdep - annotate all GEPs
+// Make sure that ALL of the relevant GEPs for an array are marked into the array's index groups
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_no_param_multiple_gepsv()
+void ivdep_no_param_multiple_geps() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  // CHECK: %[[TMP:[0-9a-z]+]] = alloca i32
+  int t;
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_MUL_GEPS:[0-9]+]]
+    t = a[i];
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_MUL_GEPS:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_MUL_GEPS]]
+    a[i] = b[i];
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_MUL_GEPS]]
+    b[i] = t;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_MUL_GEPS:[0-9]+]]
+  }
+}
+
+// Global ivdep w/ safelen specified - annotate all GEPs
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_safelenv()
+void ivdep_safelen() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep(5)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_SAFELEN:[0-9]+]]
+    a[i] = 0;
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_SAFELEN:[0-9]+]]
+    b[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_SAFELEN:[0-9]+]]
+  }
+}
+
+// Global ivdep, albeit conflicting safelens - annotate all GEPs
+//
+// CHECK: define spir_func void @_Z{{[0-9]+}}ivdep_conflicting_safelenv()
+void ivdep_conflicting_safelen() {
+  // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
+  int a[10];
+  // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
+  int b[10];
+  [[intelfpga::ivdep(5)]]
+  [[intelfpga::ivdep(4)]]
+  for (int i = 0; i != 10; ++i) {
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_A]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_CONFL_SAFELEN:[0-9]+]]
+    a[i] = 0;
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], [10 x i32]* %[[ARRAY_B]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_CONFL_SAFELEN:[0-9]+]]
+    b[i] = 0;
+    // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_CONFL_SAFELEN:[0-9]+]]
+  }
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class kernel_function>([]() {
+    ivdep_no_param();
+    ivdep_no_param_multiple_geps();
+    ivdep_safelen();
+    ivdep_conflicting_safelen();
+  });
+  return 0;
+}
+
+/// Global ivdep w/o safelen specified
+/// All arrays have the same INF safelen - put access groups into the same parallel_access_indices metadata
+//
+// CHECK-DAG: ![[IDX_GROUP_A_NO_PARAM]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_NO_PARAM]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_NO_PARAM]] = distinct !{![[MD_LOOP_NO_PARAM]], ![[IVDEP_NO_PARAM:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_NO_PARAM]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_NO_PARAM]], ![[IDX_GROUP_B_NO_PARAM]]}
+//
+// CHECK-DAG: ![[IDX_GROUP_A_MUL_GEPS]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_MUL_GEPS]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_MUL_GEPS]] = distinct !{![[MD_LOOP_MUL_GEPS]], ![[IVDEP_MUL_GEPS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_MUL_GEPS]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_MUL_GEPS]], ![[IDX_GROUP_B_MUL_GEPS]]}
+
+/// Global ivdep w/ safelen specified
+/// All arrays share the same safelen - put index groups into the same parallel_access_indices MD node
+//
+// CHECK-DAG: ![[IDX_GROUP_A_SAFELEN]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_SAFELEN]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_SAFELEN]] = distinct !{![[MD_LOOP_SAFELEN]], ![[IVDEP_SAFELEN:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_SAFELEN]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_SAFELEN]], ![[IDX_GROUP_B_SAFELEN]], i32 5}
+
+/// Conflicting global ivdeps, different safelens specified
+/// The highest safelen must be used for all arrays
+//
+// CHECK-DAG: ![[IDX_GROUP_A_CONFL_SAFELEN]] = distinct !{}
+// CHECK-DAG: ![[IDX_GROUP_B_CONFL_SAFELEN]] = distinct !{}
+// CHECK-DAG: ![[MD_LOOP_CONFL_SAFELEN]] = distinct !{![[MD_LOOP_CONFL_SAFELEN]], ![[IVDEP_CONFL_SAFELEN:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_CONFL_SAFELEN]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_CONFL_SAFELEN]], ![[IDX_GROUP_B_CONFL_SAFELEN]], i32 5}

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -2,28 +2,8 @@
 
 // CHECK: br label %for.cond, !llvm.loop ![[MD_A:[0-9]+]]
 // CHECK: br label %for.cond, !llvm.loop ![[MD_B:[0-9]+]]
-// CHECK: br label %for.cond, !llvm.loop ![[MD_C:[0-9]+]]
-// CHECK: br label %for.cond, !llvm.loop ![[MD_D:[0-9]+]]
 
-// CHECK: ![[MD_A]] = distinct !{![[MD_A]], ![[MD_ivdep_A:[0-9]+]]}
-// CHECK-NEXT: ![[MD_ivdep_A]] = !{!"llvm.loop.ivdep.enable"}
-void foo() {
-  int a[10];
-  [[intelfpga::ivdep]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-}
-
-// CHECK: ![[MD_B]] = distinct !{![[MD_B]], ![[MD_ivdep_B:[0-9]+]]}
-// CHECK-NEXT: ![[MD_ivdep_B]] = !{!"llvm.loop.ivdep.safelen", i32 2}
-void boo() {
-  int a[10];
-  [[intelfpga::ivdep(2)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-}
-
-// CHECK: ![[MD_C]] = distinct !{![[MD_C]], ![[MD_ii:[0-9]+]]}
+// CHECK: ![[MD_A]] = distinct !{![[MD_A]], ![[MD_ii:[0-9]+]]}
 // CHECK-NEXT: ![[MD_ii]] = !{!"llvm.loop.ii.count", i32 2}
 void goo() {
   int a[10];
@@ -32,7 +12,7 @@ void goo() {
     a[i] = 0;
 }
 
-// CHECK: ![[MD_D]] = distinct !{![[MD_D]], ![[MD_max_concurrency:[0-9]+]]}
+// CHECK: ![[MD_B]] = distinct !{![[MD_B]], ![[MD_max_concurrency:[0-9]+]]}
 // CHECK-NEXT: ![[MD_max_concurrency]] = !{!"llvm.loop.max_concurrency.count", i32 2}
 void zoo() {
   int a[10];
@@ -48,8 +28,6 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 
 int main() {
   kernel_single_task<class kernel_function>([]() {
-    foo();
-    boo();
     goo();
     zoo();
   });

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -10,12 +10,19 @@ void foo() {
   [[intelfpga::ii(2)]] int c[10];
   // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
   [[intelfpga::max_concurrency(2)]] int d[10];
+
+  int arr[10];
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
+  [[intelfpga::ivdep(arr)]] int e[10];
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
+  [[intelfpga::ivdep(arr, 2)]] int f[10];
 }
 
 // Test for incorrect number of arguments for Intel FPGA loop attributes
 void boo() {
   int a[10];
-  // expected-warning@+1 {{'ivdep' attribute takes no more than 1 argument - attribute ignored}}
+  int b[10];
+  // expected-error@+1 {{duplicate argument to 'ivdep'. attribute requires one or both of a safelen and array}}
   [[intelfpga::ivdep(2,2)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
@@ -35,6 +42,16 @@ void boo() {
   [[intelfpga::max_concurrency(2,2)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
+
+  // expected-error@+1 {{duplicate argument to 'ivdep'. attribute requires one or both of a safelen and array}}
+  [[intelfpga::ivdep(2, 3)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // expected-error@+1 {{duplicate argument to 'ivdep'. attribute requires one or both of a safelen and array}}
+  [[intelfpga::ivdep(a, b)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
+  [[intelfpga::ivdep(2, 3.0)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 // Test for incorrect argument value for Intel FPGA loop attributes
@@ -44,7 +61,7 @@ void goo() {
   [[intelfpga::max_concurrency(0)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-warning@+1 {{'ivdep' attribute requires a positive integral compile time constant expression - attribute ignored}}
+  // expected-error@+1 {{'ivdep' attribute requires a positive integral compile time constant expression}}
   [[intelfpga::ivdep(0)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
@@ -56,7 +73,7 @@ void goo() {
   [[intelfpga::max_concurrency(-1)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+1 {{'ivdep' attribute requires an integer constant}}
+  // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
   [[intelfpga::ivdep("test123")]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
@@ -68,9 +85,18 @@ void goo() {
   [[intelfpga::max_concurrency("test123")]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
+  // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
+  [[intelfpga::ivdep("test123")]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // no diagnostics are expected
+  [[intelfpga::ivdep(a, 2)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // no diagnostics are expected
+  [[intelfpga::ivdep(2, a)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
-// Test for Intel FPGA loop attributes dublication
+// Test for Intel FPGA loop attributes duplication
 void zoo() {
   int a[10];
   // no diagnostics are expected
@@ -79,17 +105,20 @@ void zoo() {
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
   [[intelfpga::ivdep]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ivdep'}}
+  // expected-warning@+2 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen INF >= safelen INF}}
+  // expected-note@-2 {{previous attribute is here}}
   [[intelfpga::ivdep]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
   [[intelfpga::ivdep]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ivdep'}}
+  // expected-warning@+2 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen INF >= safelen 2}}
+  // expected-note@-2 {{previous attribute is here}}
   [[intelfpga::ivdep(2)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
   [[intelfpga::ivdep(2)]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ivdep'}}
+  // expected-warning@-1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 4 >= safelen 2}}
+  // expected-note@+1 {{previous attribute is here}}
   [[intelfpga::ivdep(4)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
@@ -109,6 +138,101 @@ void zoo() {
   [[intelfpga::ii(2)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
+
+  [[intelfpga::ivdep]]
+  // expected-warning@+2 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen INF >= safelen INF}}
+  // expected-note@-2 {{previous attribute is here}}
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::ivdep(2)]]
+  // expected-warning@-1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen INF >= safelen 2}}
+  // expected-note@+1 {{previous attribute is here}}
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::ivdep(a, 2)]]
+  // expected-warning@-1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen INF >= safelen 2}}
+  // expected-note@+1 {{previous attribute is here}}
+  [[intelfpga::ivdep(a)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::ivdep(2)]]
+  // expected-warning@-1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 4 >= safelen 2}}
+  // expected-note@+1 {{previous attribute is here}}
+  [[intelfpga::ivdep(4)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::ivdep(a, 2)]]
+  // expected-warning@-1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 4 >= safelen 2}}
+  // expected-note@+1 {{previous attribute is here}}
+  [[intelfpga::ivdep(a, 4)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+
+  // no diagnostics are expected
+  [[intelfpga::ivdep(a)]]
+  [[intelfpga::ivdep(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+
+  [[intelfpga::ivdep(a, 2)]]
+  // expected-warning@-1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen INF >= safelen 2}}
+  // expected-note@+1 {{previous attribute is here}}
+  [[intelfpga::ivdep]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+
+  // Ensure we only diagnose conflict with the 'worst', not all.
+  // expected-warning@+1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 5 >= safelen 3}}
+  [[intelfpga::ivdep(3)]]
+  // expected-warning@+1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 5 >= safelen 4}}
+  [[intelfpga::ivdep(4)]]
+  // expected-note@+1 2 {{previous attribute is here}}
+  [[intelfpga::ivdep(5)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+
+  [[intelfpga::ivdep(a, 2)]]
+  // expected-warning@-1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 3 >= safelen 2}}
+  // expected-note@+1 {{previous attribute is here}}
+  [[intelfpga::ivdep(a, 3)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+template<int A, int B, int C>
+void ivdep_dependent() {
+  int a[10];
+  // test this again to ensure we skip properly during instantiation.
+  [[intelfpga::ivdep(3)]]
+  // expected-warning@-1 2{{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 5 >= safelen 3}}
+  // expected-note@+1 2{{previous attribute is here}}
+  [[intelfpga::ivdep(5)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+
+  [[intelfpga::ivdep(C)]]
+  // expected-error@-1 {{'ivdep' attribute requires a positive integral compile time constant expression}}
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+
+  // expected-warning@+3 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 4 >= safelen 2}}
+  // expected-note@+1 {{previous attribute is here}}
+  [[intelfpga::ivdep(A)]]
+  [[intelfpga::ivdep(B)]]
+  // expected-warning@-2 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 4 >= safelen 2}}
+  // expected-note@-2 {{previous attribute is here}}
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+
+  (void)[]() {
+  // expected-warning@+3 2{{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen INF >= safelen INF}}
+  // expected-note@+1 2{{previous attribute is here}}
+  [[intelfpga::ivdep]]
+  [[intelfpga::ivdep]]
+    while(true);
+  };
 }
 
 template <typename name, typename Func>
@@ -122,6 +246,10 @@ int main() {
     boo();
     goo();
     zoo();
+    ivdep_dependent<4, 2, 1>();
+    //expected-note@-1 +{{in instantiation of function template specialization}}
+    ivdep_dependent<2, 4, -1>();
+    //expected-note@-1 +{{in instantiation of function template specialization}}
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -163,12 +163,6 @@ void zoo() {
   [[intelfpga::ivdep(4)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  [[intelfpga::ivdep(a, 2)]]
-  // expected-warning@-1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 4 >= safelen 2}}
-  // expected-note@+1 {{previous attribute is here}}
-  [[intelfpga::ivdep(a, 4)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
 
   // no diagnostics are expected
   [[intelfpga::ivdep(a)]]

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -2764,9 +2764,11 @@ void EmitClangAttrList(RecordKeeper &Records, raw_ostream &OS) {
   // Add defaulting macro definitions.
   Hierarchy.emitDefaultDefines(OS);
   emitDefaultDefine(OS, "PRAGMA_SPELLING_ATTR", nullptr);
+  emitDefaultDefine(OS, "DEPENDENT_STMT_ATTR", nullptr);
 
   std::vector<Record *> Attrs = Records.getAllDerivedDefinitions("Attr");
   std::vector<Record *> PragmaAttrs;
+  std::vector<Record *> DependentStmtAttrs;
   for (auto *Attr : Attrs) {
     if (!Attr->getValueAsBit("ASTNode"))
       continue;
@@ -2774,6 +2776,9 @@ void EmitClangAttrList(RecordKeeper &Records, raw_ostream &OS) {
     // Add the attribute to the ad-hoc groups.
     if (AttrHasPragmaSpelling(Attr))
       PragmaAttrs.push_back(Attr);
+
+    if (Attr->getValueAsBit("HasCustomTypeTransform"))
+      DependentStmtAttrs.push_back(Attr);
 
     // Place it in the hierarchy.
     Hierarchy.classifyAttr(Attr);
@@ -2784,6 +2789,7 @@ void EmitClangAttrList(RecordKeeper &Records, raw_ostream &OS) {
 
   // Emit the ad hoc groups.
   emitAttrList(OS, "PRAGMA_SPELLING_ATTR", PragmaAttrs);
+  emitAttrList(OS, "DEPENDENT_STMT_ATTR", DependentStmtAttrs);
 
   // Emit the attribute ranges.
   OS << "#ifdef ATTR_RANGE\n";
@@ -2792,6 +2798,7 @@ void EmitClangAttrList(RecordKeeper &Records, raw_ostream &OS) {
   OS << "#endif\n";
 
   Hierarchy.emitUndefs(OS);
+  OS << "#undef DEPENDENT_STMT_ATTR\n";
   OS << "#undef PRAGMA_SPELLING_ATTR\n";
 }
 


### PR DESCRIPTION
IVDep marks loops and arrays in a loop with a safe length. Metadata gets
applied to each array access GEP to label the safe length for that
array.

Additionally, this patch works with dependent arguments and adds the
infrastructure to do so.  This functionality doesn't currently exist for
statement attributes.

Signed-off-by: Erich Keane <erich.keane@intel.com>