### PR TITLE
[SYCL][Driver] Add -Z-reserved-lib-stdc++ to isObjectFile

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4289,8 +4289,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       // Unbundler only handles objects.
       if (auto *IA = dyn_cast<InputAction>(LI)) {
         std::string FileName = IA->getInputArg().getAsString(Args);
-        if (IA->getType() == types::TY_Object &&
-            !isObjectFile(FileName))
+        if ((IA->getType() == types::TY_Object && !isObjectFile(FileName)) ||
+            IA->getInputArg().getOption().hasFlag(options::LinkerInput))
           // Pass the Input along to linker.
           TempLinkerInputs.push_back(LI);
         else

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -585,6 +585,16 @@
 
 /// ###########################################################################
 
+// RUN: touch %t.a
+// RUN: %clang -fsycl -foffload-static-lib=%t.a -o output_name -lstdc++ -z relro -### %s 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB_SRC4
+// FOFFLOAD_STATIC_LIB_SRC4: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.a]]"
+// FOFFLOAD_STATIC_LIB_SRC4: clang-offload-bundler{{.*}} "-type=oo"
+// FOFFLOAD_STATIC_LIB_SRC4: llvm-link{{.*}} "@{{.*}}"
+// FOFFLOAD_STATIC_LIB_SRC4: ld{{(.exe)?}}" {{.*}} "-o" "output_name" {{.*}} "-lstdc++" "-z" "relro"
+
+/// ###########################################################################
+
 /// Check -Xsycl-target-backend triggers error when multiple triples are used.
 // RUN:   %clang -### -fsycl -fsycl-targets=spir64_fpga-unknown-linux-sycldevice,spir_fpga-unknown-linux-sycldevice -Xsycl-target-backend -DFOO %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-TARGET-AMBIGUOUS-ERROR %s


### PR DESCRIPTION
This fixes a problem that occurs when -lstdc++ and -foffload-static-lib are used together in a command.

In certain cases the -lstdc++ option is translated from the -lstdc++ string into an option by the Driver. This means it's not picked up by the isObjectFile check and gets passed down into the OffloadBundler's ConstructJobMultipleOutputs call, it will then get pushed into the arguments to the linkers job construction as a string. As it's not a string it's an Input (llvm::Opt) it will result in some garbage data as an argument to the linker (in the default case ld). This will cause the ld job before the OffloadBundler job to fail as it can't find the garbage argument and then kill the rest of the compilation e.g:

/usr/bin/ld: cannot find �H�: No such file or directory
clang-10: error: clang-offload-bundler command failed with exit code 1 (use -v to see invocation)

This was found as part of a problem in a larger build system but I think the issue is somewhat recreate-able if you create some empty files named random.a and random.o and invoke the following command:

$SYCL_BIN/clang++ -### -std=c++11 -fsycl random.o -foffload-static-lib=random.a -o random -lstdc++

The first ld command will look something like:

"/usr/bin/ld" "-r" "-o" "/tmp/random-prelink-643ea6.o" "random.o" "����" "random.a"

Signed-off-by: Andrew Gozillon andrew.gozillon@yahoo.com