### PR TITLE
[SYCL] Fix handler::copy [from|to] [raw|shared] pointer.

### DIFF
--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -217,13 +217,13 @@ void copyH2D(SYCLMemObjI *SYCLMemObj, char *SrcMem, QueueImplPtr SrcQueue,
       PI_CALL(RT::piEnqueueMemBufferWrite(
           Queue, DstMem,
           /*blocking_write=*/CL_FALSE, DstOffset[0], DstAccessRange[0],
-          SrcMem + DstOffset[0], DepEvents.size(), &DepEvents[0], &OutEvent));
+          SrcMem + SrcOffset[0], DepEvents.size(), &DepEvents[0], &OutEvent));
     } else {
-      size_t BufferRowPitch = (1 == DimSrc) ? 0 : SrcSize[0];
-      size_t BufferSlicePitch = (3 == DimSrc) ? SrcSize[0] * SrcSize[1] : 0;
+      size_t BufferRowPitch = (1 == DimDst) ? 0 : DstSize[0];
+      size_t BufferSlicePitch = (3 == DimDst) ? DstSize[0] * DstSize[1] : 0;
 
-      size_t HostRowPitch = (1 == DimDst) ? 0 : DstSize[0];
-      size_t HostSlicePitch = (3 == DimDst) ? DstSize[0] * DstSize[1] : 0;
+      size_t HostRowPitch = (1 == DimSrc) ? 0 : SrcSize[0];
+      size_t HostSlicePitch = (3 == DimSrc) ? SrcSize[0] * SrcSize[1] : 0;
       PI_CALL(RT::piEnqueueMemBufferWriteRect(
           Queue, DstMem,
           /*blocking_write=*/CL_FALSE, &DstOffset[0], &SrcOffset[0],
@@ -266,7 +266,7 @@ void copyD2H(SYCLMemObjI *SYCLMemObj, RT::PiMem SrcMem, QueueImplPtr SrcQueue,
     if (1 == DimDst && 1 == DimSrc) {
       PI_CALL(RT::piEnqueueMemBufferRead(
           Queue, SrcMem,
-          /*blocking_read=*/CL_FALSE, DstOffset[0], DstAccessRange[0],
+          /*blocking_read=*/CL_FALSE, SrcOffset[0], SrcAccessRange[0],
           DstMem + DstOffset[0], DepEvents.size(), &DepEvents[0], &OutEvent));
     } else {
       size_t BufferRowPitch = (1 == DimSrc) ? 0 : SrcSize[0];

--- a/sycl/test/basic_tests/handler/handler_copy_with_offset.cpp
+++ b/sycl/test/basic_tests/handler/handler_copy_with_offset.cpp
@@ -1,0 +1,77 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+//==--- handler_copy_with_offset.cpp - SYCL handler copy with offset test --==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+#include <cassert>
+#include <exception>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+using namespace cl::sycl;
+constexpr access::mode read = access::mode::read;
+constexpr access::mode write = access::mode::write;
+constexpr access::target global_buffer = access::target::global_buffer;
+
+int main() {
+  {
+    constexpr size_t Size = 8;
+
+    vector_class<char> DataRaw(Size, 'x');
+    {
+      buffer<char> Buffer{DataRaw.data(), range<1>{Size}};
+
+      vector_class<char> DataGold(Size);
+      std::iota(DataGold.begin(), DataGold.end(), '0');
+
+      queue Queue;
+      Queue.submit([&](handler &CGH) {
+        range<1> AccessRange{4};
+        id<1> AccessOffset{2};
+        auto Accessor = Buffer.get_access<write, global_buffer>(
+            CGH, AccessRange, AccessOffset);
+        CGH.copy(DataGold.data(), Accessor);
+      });
+      Queue.wait();
+    }
+
+    vector_class<char> Expected{'x', 'x', '0', '1', '2', '3', 'x', 'x'};
+    if (DataRaw != Expected)
+      throw std::runtime_error("Check of hadler.copy(ptr, acc) was failed");
+  }
+
+  {
+    constexpr size_t Size = 8;
+    vector_class<char> DataRaw(Size, 'x');
+    {
+      vector_class<char> DataGold(Size);
+      std::iota(DataGold.begin(), DataGold.end(), '0');
+      buffer<char> Buffer{DataGold.data(), range<1>{Size}};
+
+      queue Queue;
+      Queue.submit([&](handler &CGH) {
+        range<1> AccessRange{4};
+        id<1> AccessOffset{2};
+        auto Accessor = Buffer.get_access<read, global_buffer>(CGH, AccessRange,
+                                                               AccessOffset);
+        CGH.copy(Accessor, DataRaw.data());
+      });
+      Queue.wait();
+    }
+    vector_class<char> Expected{'2', '3', '4', '5', 'x', 'x', 'x', 'x'};
+    if (DataRaw != Expected)
+      throw std::runtime_error("Check of hadler.copy(acc, ptr) was failed");
+  }
+  return 0;
+}

--- a/sycl/test/regression/memcpy-update-leafs.cpp
+++ b/sycl/test/regression/memcpy-update-leafs.cpp
@@ -38,7 +38,7 @@ int main() {
   return 0;
 }
 
-// CHECK: PI ---> RT::piEnqueueMemBufferWrite( Queue, DstMem, CL_FALSE, DstOffset[0], DstAccessRange[0], SrcMem + DstOffset[0], DepEvents.size(), &DepEvents[0], &OutEvent)
-// CHECK-NOT: PI ---> RT::piEnqueueMemBufferWrite( Queue, DstMem, CL_FALSE, DstOffset[0], DstAccessRange[0], SrcMem + DstOffset[0], DepEvents.size(), &DepEvents[0], &OutEvent)
+// CHECK: PI ---> RT::piEnqueueMemBufferWrite( Queue, DstMem, CL_FALSE, DstOffset[0], DstAccessRange[0], SrcMem + SrcOffset[0], DepEvents.size(), &DepEvents[0], &OutEvent)
+// CHECK-NOT: PI ---> RT::piEnqueueMemBufferWrite( Queue, DstMem, CL_FALSE, DstOffset[0], DstAccessRange[0], SrcMem + SrcOffset[0], DepEvents.size(), &DepEvents[0], &OutEvent)
 // CHECK-NOT: PI ---> (MappedPtr = RT::piEnqueueMemBufferMap( Queue->getHandleRef(), pi::cast<RT::PiMem>(Mem), CL_FALSE, Flags, AccessOffset[0], AccessRange[0], DepEvents.size(), DepEvents.empty() ? nullptr : &DepEvents[0], &OutEvent, &Error), Error)
 // CHECK-NOT: PI ---> RT::piEnqueueMemUnmap( UseExclusiveQueue ? Queue->getExclusiveQueueHandleRef() : Queue->getHandleRef(), pi::cast<RT::PiMem>(Mem), MappedPtr, DepEvents.size(), DepEvents.empty() ? nullptr : &DepEvents[0], &OutEvent)


### PR DESCRIPTION
Case 1:
    There is a call handler copy method from a pointer (used the
    accessor range and offset of 0) to an accessor(with a range
    of 4 and an offset of 2).

    src_ptr = [0,1,2,3,4,5,6,7] // the data that the pointer points to
    dest_acc = [x,x,x,x,x,x,x,x] // the data that the accessor points to
    handler.copy(src_ptr, dest_acc<1>{range{4}, offset{2}}

    Before this patch dest_acc had: "x x 2 3 4 5 x x"
    After this patch dest_acc has:  "x x 0 1 2 3 x x"

    The root cause: the destination offset was used for the source.
    The fix: use the source offset for the source.

Case 2:
    There is a call handler copy method from an accessor(with a range
    of 4 and an offset of 2) to a pointer (used the accessor range
    and offset of 0).

    src_acc = [0,1,2,3,4,5,6,7] // // the data that the accessor points to
    dest_ptr = [x,x,x,x,x,x,x,x] // the data that the pointer points to
    handler.copy(src_acc<1>{range{4}, offset{2}, dest_ptr}

    Before this patch had dest_ptr: "0 1 2 3 x x x x"
    After this patch has dest_ptr:  "2 3 4 5 x x x x"

    The root cause: the destination offset was used for the source.
    The fix: use the source offset for the source.

Signed-off-by: Alexey Voronov <alexey.voronov@intel.com>