### PR TITLE
[SYCL] SYCL Event's Command should be reset when Command is deleted

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -712,6 +712,7 @@ void Scheduler::GraphBuilder::cleanupCommandsForRecord(MemObjRecord *Record) {
           if (UserCmd->MDeps.empty())
             RemoveQueue.push(UserCmd);
         }
+        CandidateCommand->getEvent()->setCommand(nullptr);
         delete CandidateCommand;
       }
     }


### PR DESCRIPTION
In SYCL's graph scheduler, we look at the command associated with a particular event. Even though the command may be deleted earlier, the event stills holds onto the pointer. This may sporadically cause a runtime crash. Hence, the command pointer needs to be reset to nullptr.
Signed-off-by: Arvind Sudarsanam <arvind.sudarsanam@intel.com>