### PR TITLE
[SYCL] Adopt CI scripts to use install

### DIFF
--- a/buildbot/compile.py
+++ b/buildbot/compile.py
@@ -12,7 +12,7 @@ def do_compile(args):
     if cpu_count is None:
         cpu_count = DEFAULT_CPU_COUNT
 
-    make_cmd = ["ninja", "-j", str(cpu_count), "sycl-toolchain"]
+    make_cmd = ["ninja", "-j", str(cpu_count), "deploy-sycl-toolchain"]
     print(make_cmd)
 
     subprocess.check_call(make_cmd, cwd=args.obj_dir)

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -29,7 +29,7 @@ def do_configure(args):
                  "-DLLVM_ENABLE_PROJECTS=clang;sycl;llvm-spirv",
                  "-DOpenCL_INCLUDE_DIR={}".format(ocl_header_dir),
                  "-DOpenCL_LIBRARY={}".format(icd_loader_lib),
-                 "-DLLVM_BUILD_TOOLS=OFF",
+                 "-DLLVM_BUILD_TOOLS=ON",
                  "-DSYCL_ENABLE_WERROR=ON",
                  "-DLLVM_ENABLE_ASSERTIONS=ON",
                  "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),

--- a/buildbot/dependency.py
+++ b/buildbot/dependency.py
@@ -68,13 +68,15 @@ def do_dependency(args):
     if os.path.isdir(icd_build_dir):
         shutil.rmtree(icd_build_dir)
     os.makedirs(icd_build_dir)
-
-    cmake_cmd = ["cmake", "-G", "Ninja", ".."]
+    install_dir = os.path.join(args.obj_dir, "install")
+    cmake_cmd = ["cmake", "-G", "Ninja",
+                 "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),
+                 ".." ]
     subprocess.check_call(cmake_cmd, cwd=icd_build_dir)
 
     env_tmp=os.environ
     env_tmp["C_INCLUDE_PATH"] = "{}".format(ocl_header_dir)
-    subprocess.check_call(["ninja"], env=env_tmp, cwd=icd_build_dir)
+    subprocess.check_call(["ninja", "install"], env=env_tmp, cwd=icd_build_dir)
 
     ret = True
     return ret


### PR DESCRIPTION
The buildbot scripts were updated to use install mechanism for
minimizing build artifacts stored in test infrastructure.
ICD loader is added to install directory to support CI testing.

Signed-off-by: Vladimir Lazarev <vladimir.lazarev@intel.com>