### PR TITLE
Implement llvm-foreach tool

### DIFF
--- a/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
@@ -9,10 +9,10 @@
 ; CHECK: [[FIRST:.+1.tgt]]
 ; CHECK: [[SECOND:.+2.tgt]]
 ;
-; RUN: llvm-foreach --in-replace="{}" --out-replace=%t.out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t.out
+; RUN: llvm-foreach --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
-; CHECK-LIST: [[FIRST:.+\.tmp]]
-; CHECK-LIST: [[SECOND:.+\.tmp]]
+; CHECK-LIST: [[FIRST:.+\.out]]
+; CHECK-LIST: [[SECOND:.+\.out]]
 ; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- FileCheck --input-file="{}" %s --check-prefix=CHECK-CONTENT
 ; CHECK-CONTENT: Content of
 

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
@@ -9,7 +9,7 @@
 ; CHECK: [[FIRST:.+1.tgt]]
 ; CHECK: [[SECOND:.+2.tgt]]
 ;
-; RUN: llvm-foreach --in-replace="{}" --out-replace=%t.out --in-file-list=%t.list --out-file-list=%t.out.list --out-ext=tmp -- cp "{}" %t.out
+; RUN: llvm-foreach --in-replace="{}" --out-replace=%t.out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t.out
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; CHECK-LIST: [[FIRST:.+\.tmp]]
 ; CHECK-LIST: [[SECOND:.+\.tmp]]

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
@@ -20,7 +20,7 @@
 ; RUN: echo 'something again' > %t4.tgt
 ; RUN: echo "%t3.tgt" > %t1.list
 ; RUN: echo "%t4.tgt" >> %t1.list
-; RUN: llvm-foreach --in-replace="{}" --in-replace="in" --in-file-list=%t.list --in-file-list=%t1.list -- echo "-first-part-of-arg={}" "-first-part-of-arg=in" > %t1.res
+; RUN: llvm-foreach --in-replace="{}" --in-replace="in" --in-file-list=%t.list --in-file-list=%t1.list -- echo -first-part-of-arg={}.out -first-part-of-arg=in.out > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
-; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[FIRST:.+1.tgt]] -first-part-of-arg=[[THIRD:.+3.tgt]]
-; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[SECOND:.+2.tgt]] -first-part-of-arg=[[FOURTH:.+4.tgt]]
+; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]]
+; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]]

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
@@ -1,0 +1,26 @@
+; UNSUPPORTED: system-windows
+;
+; RUN: echo 'Content of first file' > %t1.tgt
+; RUN: echo 'Content of second file' > %t2.tgt
+; RUN: echo "%t1.tgt" > %t.list
+; RUN: echo "%t2.tgt" >> %t.list
+; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
+; RUN: FileCheck < %t.res %s
+; CHECK: [[FIRST:.+1.tgt]]
+; CHECK: [[SECOND:.+2.tgt]]
+;
+; RUN: llvm-foreach --in-replace="{}" --out-replace=%t.out --in-file-list=%t.list --out-file-list=%t.out.list --out-ext=tmp -- cp "{}" %t.out
+; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
+; CHECK-LIST: [[FIRST:.+\.tmp]]
+; CHECK-LIST: [[SECOND:.+\.tmp]]
+; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- FileCheck --input-file="{}" %s --check-prefix=CHECK-CONTENT
+; CHECK-CONTENT: Content of
+
+; RUN: echo 'something' > %t3.tgt
+; RUN: echo 'something again' > %t4.tgt
+; RUN: echo "%t3.tgt" > %t1.list
+; RUN: echo "%t4.tgt" >> %t1.list
+; RUN: llvm-foreach --in-replace="{}" --in-replace="in" --in-file-list=%t.list --in-file-list=%t1.list -- echo "-first-part-of-arg={}" "-first-part-of-arg=in" > %t1.res
+; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
+; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[FIRST:.+1.tgt]] -first-part-of-arg=[[THIRD:.+3.tgt]]
+; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[SECOND:.+2.tgt]] -first-part-of-arg=[[FOURTH:.+4.tgt]]

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
@@ -4,12 +4,12 @@
 ; RUN: echo 'Content of second file' > %t2.tgt
 ; RUN: echo "%t1.tgt" > %t.list
 ; RUN: echo "%t2.tgt" >> %t.list
-; RUN: llvm-foreach --in-replace="{}" %t.list "echo {}" > %t.res
+; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
 ; RUN: FileCheck < %t.res %s
 ; CHECK: [[FIRST:.+1.tgt]]
 ; CHECK: [[SECOND:.+2.tgt]]
 ;
-; RUN: llvm-foreach --in-replace="{}" --out-replace=%t.out --in-file-list=%t.list --out-file-list=%t.out.list -- copy "{}" %t.out
+; RUN: llvm-foreach --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- copy "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; CHECK-LIST: [[FIRST:.+\.out]]
 ; CHECK-LIST: [[SECOND:.+\.out]]

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
@@ -1,0 +1,26 @@
+; REQUIRES: system-windows
+;
+; RUN: echo 'Content of first file' > %t1.tgt
+; RUN: echo 'Content of second file' > %t2.tgt
+; RUN: echo "%t1.tgt" > %t.list
+; RUN: echo "%t2.tgt" >> %t.list
+; RUN: llvm-foreach --in-replace="{}" %t.list "echo {}" > %t.res
+; RUN: FileCheck < %t.res %s
+; CHECK: [[FIRST:.+1.tgt]]
+; CHECK: [[SECOND:.+2.tgt]]
+;
+; RUN: llvm-foreach --in-replace="{}" --out-replace=%t.out --in-file-list=%t.list --out-file-list=%t.out.list --out-ext=tmp -- copy "{}" %t.out
+; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
+; CHECK-LIST: [[FIRST:.+\.out]]
+; CHECK-LIST: [[SECOND:.+\.out]]
+; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- FileCheck --input-file="{}" %s --check-prefix=CHECK-CONTENT
+; CHECK-CONTENT: Content of
+
+; RUN: echo 'something' > %t3.tgt
+; RUN: echo 'something again' > %t4.tgt
+; RUN: echo "%t3.tgt" > %t1.list
+; RUN: echo "%t4.tgt" >> %t1.list
+; RUN: llvm-foreach --in-replace="{}" --in-replace="in" --in-file-list=%t.list --in-file-list=%t1.list -- echo "-first-part-of-arg={}" "-first-part-of-arg=in" > %t1.res
+; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
+; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[FIRST:.+1.tgt]] -first-part-of-arg=[[THIRD:.+3.tgt]]
+; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[SECOND:.+2.tgt]] -first-part-of-arg=[[FOURTH:.+4.tgt]]

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
@@ -9,7 +9,7 @@
 ; CHECK: [[FIRST:.+1.tgt]]
 ; CHECK: [[SECOND:.+2.tgt]]
 ;
-; RUN: llvm-foreach --in-replace="{}" --out-replace=%t.out --in-file-list=%t.list --out-file-list=%t.out.list --out-ext=tmp -- copy "{}" %t.out
+; RUN: llvm-foreach --in-replace="{}" --out-replace=%t.out --in-file-list=%t.list --out-file-list=%t.out.list -- copy "{}" %t.out
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; CHECK-LIST: [[FIRST:.+\.out]]
 ; CHECK-LIST: [[SECOND:.+\.out]]

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
@@ -20,7 +20,7 @@
 ; RUN: echo 'something again' > %t4.tgt
 ; RUN: echo "%t3.tgt" > %t1.list
 ; RUN: echo "%t4.tgt" >> %t1.list
-; RUN: llvm-foreach --in-replace="{}" --in-replace="in" --in-file-list=%t.list --in-file-list=%t1.list -- echo "-first-part-of-arg={}" "-first-part-of-arg=in" > %t1.res
+; RUN: llvm-foreach --in-replace="{}" --in-replace="in" --in-file-list=%t.list --in-file-list=%t1.list -- echo -first-part-of-arg={}.out -first-part-of-arg=in.out > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
-; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[FIRST:.+1.tgt]] -first-part-of-arg=[[THIRD:.+3.tgt]]
-; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[SECOND:.+2.tgt]] -first-part-of-arg=[[FOURTH:.+4.tgt]]
+; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]]
+; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]]

--- a/llvm/tools/LLVMBuild.txt
+++ b/llvm/tools/LLVMBuild.txt
@@ -35,6 +35,7 @@ subdirectories =
  llvm-ifs
  llvm-exegesis
  llvm-extract
+ llvm-foreach
  llvm-jitlistener
  llvm-jitlink
  llvm-link

--- a/llvm/tools/llvm-foreach/CMakeLists.txt
+++ b/llvm/tools/llvm-foreach/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
+add_llvm_tool(llvm-foreach
+  llvm-foreach.cpp
+
+  DEPENDS
+  intrinsics_gen
+  )

--- a/llvm/tools/llvm-foreach/CMakeLists.txt
+++ b/llvm/tools/llvm-foreach/CMakeLists.txt
@@ -4,7 +4,4 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_tool(llvm-foreach
   llvm-foreach.cpp
-
-  DEPENDS
-  intrinsics_gen
-  )
+)

--- a/llvm/tools/llvm-foreach/LLVMBuild.txt
+++ b/llvm/tools/llvm-foreach/LLVMBuild.txt
@@ -1,0 +1,21 @@
+;===- ./tools/llvm-foreach/LLVMBuild.txt ---------------------*- Conf -*--===;
+;
+; Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+; See https://llvm.org/LICENSE.txt for license information.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+;===------------------------------------------------------------------------===;
+;
+; This is an LLVMBuild description file for the components in this subdirectory.
+;
+; For more information on the LLVMBuild system, please see:
+;
+;   http://llvm.org/docs/LLVMBuild.html
+;
+;===------------------------------------------------------------------------===;
+
+[component_0]
+type = Tool
+name = llvm-foreach
+parent = Tools
+required_libraries = Support

--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -51,6 +51,12 @@ static cl::opt<std::string> OutDirectory{
              "system temporary directory."),
     cl::init(""), cl::value_desc("R")};
 
+static cl::opt<std::string> OutFilesExt{
+    "out-ext",
+    cl::desc("Specify extenstion for output files; If unspecified, assume "
+             ".out"),
+    cl::init("out"), cl::value_desc("R")};
+
 // Emit list of produced files for better integration with other tools.
 static cl::opt<std::string> OutputFileList{
     "out-file-list", cl::desc("Specify filename for list of outputs."),
@@ -162,11 +168,11 @@ int main(int argc, char **argv) {
       // file list if needed.
       std::string TempFileNameBase = sys::path::stem(OutReplace);
       if (OutDirectory.empty())
-        EC =
-            sys::fs::createTemporaryFile(TempFileNameBase, /*Suffix*/ "", Path);
+        EC = sys::fs::createTemporaryFile(TempFileNameBase, OutFilesExt, Path);
       else {
         SmallString<128> PathPrefix(OutDirectory);
-        llvm::sys::path::append(PathPrefix, TempFileNameBase + "-%%%%%%");
+        llvm::sys::path::append(PathPrefix,
+                                TempFileNameBase + "-%%%%%%." + OutFilesExt);
         EC = sys::fs::createUniqueFile(PathPrefix, Path);
       }
       error(EC, "Could not create a file for command output.");

--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -1,0 +1,189 @@
+//===- llvm-foreach.cpp - Command lines execution ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This source is utility to execute command lines. The specified command will
+// be invoked as many times as necessary to use up the list of input items.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/LineIterator.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/SystemUtils.h"
+
+#include <vector>
+
+using namespace llvm;
+
+static cl::list<std::string> InputFileLists{"in-file-list", cl::OneOrMore,
+                                            cl::desc("<input list of files>"),
+                                            cl::value_desc("filename")};
+
+static cl::list<std::string> InputCommandArgs{
+    cl::Positional, cl::OneOrMore, cl::desc("<command>"),
+    cl::value_desc("command")};
+
+static cl::list<std::string> Replaces{
+    "in-replace", cl::OneOrMore,
+    cl::desc("Specify input path in input command, this will be replaced with "
+             "names read from corresponding input list of files;"),
+    cl::value_desc("R")};
+
+static cl::opt<std::string> OutReplace{
+    "out-replace",
+    cl::desc("Specify output path in input command, this will be replaced with "
+             "name of temporary file created for writing command's outputs."),
+    cl::init(""), cl::value_desc("R")};
+
+static cl::opt<std::string> OutFilesExt{
+    "out-ext",
+    cl::desc("Specify extenstion for output files; If unspecified, assume "
+             ".out"),
+    cl::init("out"), cl::value_desc("R")};
+
+// Emit list of produced files for better integration with other tools.
+static cl::opt<std::string> OutputFileList{
+    "out-file-list", cl::desc("Specify filename for list of outputs."),
+    cl::value_desc("filename"), cl::init("")};
+
+static void error(const Twine &Msg) {
+  errs() << "llvm-foreach: " << Msg << '\n';
+  exit(1);
+}
+
+static void error(std::error_code EC, const Twine &Prefix) {
+  if (EC)
+    error(Prefix + ": " + EC.message());
+}
+
+int main(int argc, char **argv) {
+
+  cl::ParseCommandLineOptions(
+      argc, argv,
+      "llvm-foreach: Execute specified command as many times as\n"
+      "necessary to use up the list of input items.\n"
+      "Usage:\n"
+      "llvm-foreach --in-file-list=a.list --in-replace='{}' -- echo '{}'\n"
+      "NOTE: commands containig redirects are not supported by llvm-foreach\n"
+      "yet.\n");
+
+  ExitOnError ExitOnErr("llvm-foreach: ");
+
+  if (InputFileLists.size() != Replaces.size())
+    error("Number of input file lists and input path replaces don't match.");
+
+  std::vector<std::unique_ptr<MemoryBuffer>> MBs;
+  for (auto &InputFileList : InputFileLists)
+    MBs.push_back(ExitOnErr(
+        errorOrToExpected(MemoryBuffer::getFileOrSTDIN(InputFileList))));
+
+
+  SmallVector<StringRef, 8> Args(InputCommandArgs.begin(),
+                                 InputCommandArgs.end());
+
+  if (Args.empty())
+    error("No command?");
+
+  // Find args to replace with filenames from input list.
+  std::vector<int> InReplaceArgs;
+  int OutReplaceArg = -1;
+  for (size_t i = 0; i < Args.size(); ++i) {
+    StringRef PossibleReplace;
+    if (Args[i].contains("=")) {
+      std::pair<StringRef, StringRef> Split = Args[i].split("=");
+      PossibleReplace = Split.second;
+    } else
+      PossibleReplace = Args[i];
+
+    for (auto &Replace : Replaces)
+      if (PossibleReplace == Replace)
+        InReplaceArgs.push_back(i);
+
+    if (PossibleReplace == OutReplace)
+      OutReplaceArg = i;
+  }
+
+  // Emit an error if user requested replace output file in the command but
+  // replace string is not found.
+  if (!OutReplace.empty() && OutReplaceArg < 0)
+    error("Couldn't find replace string for output in the command");
+
+  // Make sure that specified program exists, emit an error if not.
+  std::string Prog =
+      ExitOnErr(errorOrToExpected(sys::findProgramByName(Args[0])));
+
+  std::vector<line_iterator> LineIterators;
+  for (auto &MB : MBs)
+    LineIterators.push_back(line_iterator(*MB));
+
+
+  std::error_code EC;
+  // TODO: find a way to check that all file lists have same number of lines
+  line_iterator LI = LineIterators[0];
+  std::vector<std::string> FileNames(LineIterators.size());
+  std::string ResOutArg;
+  std::vector<std::string> ResInArgs(InReplaceArgs.size());
+  std::string FileList = "";
+  for (; !LI.is_at_eof(); ++LI) {
+    for (int i = 0; i < FileNames.size(); ++i) {
+      FileNames[i] = (LineIterators[i]->str());
+      ++LineIterators[i];
+    }
+
+    for (int i = 0; i < InReplaceArgs.size(); ++i) {
+      if (Args[InReplaceArgs[i]].contains("=")) {
+        std::pair<StringRef, StringRef> Split =
+            Args[InReplaceArgs[i]].split("=");
+        ResInArgs[i] =
+            Twine((Split.first) + Twine("=") + Twine(FileNames[i])).str();
+        Args[InReplaceArgs[i]] = ResInArgs[i];
+      } else
+        ResInArgs[i] = FileNames[i];
+      Args[InReplaceArgs[i]] = ResInArgs[i];
+    }
+
+    SmallString<128> Path;
+    if (!OutReplace.empty()) {
+      // Create a temporary file for command result. Add file name to output
+      // file list if needed.
+      std::string TempFileNameBase = sys::path::stem(OutReplace);
+      EC = sys::fs::createTemporaryFile(TempFileNameBase, OutFilesExt, Path);
+      error(EC, "Could not create a temporary file");
+      if (Args[OutReplaceArg].contains("=")) {
+        std::pair<StringRef, StringRef> Split = Args[OutReplaceArg].split("=");
+        ResOutArg = (Twine(Split.first) + Twine("=") + Twine(Path)).str();
+      } else
+        ResOutArg = Path;
+      Args[OutReplaceArg] = ResOutArg;
+
+      if (!OutputFileList.empty())
+        FileList = (Twine(FileList) + Twine(Path) + Twine("\n")).str();
+    }
+
+    std::string ErrMsg;
+    // TODO: Add possibility to execute commands in parallel.
+    int Result =
+        sys::ExecuteAndWait(Prog, Args, /*Env=*/None, /*Redirects=*/None,
+                            /*SecondsToWait=*/0, /*MemoryLimit=*/0, &ErrMsg);
+    if (Result < 0)
+      error(ErrMsg);
+  }
+
+  // Save file list if needed.
+  if (!OutputFileList.empty()) {
+    raw_fd_ostream OS{OutputFileList, EC, sys::fs::OpenFlags::OF_None};
+    error(EC, "error opening the file '" + OutputFileList + "'");
+    OS.write(FileList.data(), FileList.size());
+    OS.close();
+  }
+
+  return 0;
+}

--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -24,7 +24,9 @@
 using namespace llvm;
 
 static cl::list<std::string> InputFileLists{
-    "in-file-list", cl::OneOrMore, cl::desc("<input list of file names>"),
+    "in-file-list", cl::OneOrMore,
+    cl::desc("Input list of file names, file names must be delimited by a "
+             "newline character."),
     cl::value_desc("filename")};
 
 static cl::list<std::string> InputCommandArgs{
@@ -34,7 +36,7 @@ static cl::list<std::string> InputCommandArgs{
 static cl::list<std::string> Replaces{
     "in-replace", cl::OneOrMore,
     cl::desc("Specify input path in input command, this will be replaced with "
-             "names read from corresponding input list of files;"),
+             "names read from corresponding input list of files."),
     cl::value_desc("R")};
 
 static cl::opt<std::string> OutReplace{
@@ -122,7 +124,7 @@ int main(int argc, char **argv) {
   // Emit an error if user requested replace output file in the command but
   // replace string is not found.
   if (!OutReplace.empty() && OutReplaceArg.ArgNum < 0)
-    error("Couldn't find replace string for output in the command");
+    error("Couldn't find replace string for output in the command.");
 
   // Make sure that specified program exists, emit an error if not.
   std::string Prog =
@@ -167,7 +169,7 @@ int main(int argc, char **argv) {
         llvm::sys::path::append(PathPrefix, TempFileNameBase + "-%%%%%%");
         EC = sys::fs::createUniqueFile(PathPrefix, Path);
       }
-      error(EC, "Could not create a file for command output");
+      error(EC, "Could not create a file for command output.");
 
       ResOutArg = (Twine(OutReplaceArg.Prefix) + Twine(Path) +
                    Twine(OutReplaceArg.Postfix))

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -190,6 +190,7 @@ add_custom_target( sycl-toolchain
           llvm-spirv
           llvm-link
           llvm-objcopy
+          llvm-foreach
           opt
           sycl-post-link
   COMMENT "Building SYCL compiler toolchain..."

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -186,11 +186,11 @@ add_custom_target( sycl-toolchain
           llvm-as
           llvm-ar
           llvm-dis
+          llvm-foreach
           llvm-no-spir-kernel
           llvm-spirv
           llvm-link
           llvm-objcopy
-          llvm-foreach
           opt
           sycl-post-link
   COMMENT "Building SYCL compiler toolchain..."
@@ -228,6 +228,7 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      llvm-as
      llvm-ar
      llvm-dis
+     llvm-foreach
      llvm-no-spir-kernel
      llvm-spirv
      llvm-link


### PR DESCRIPTION
The tool has simple functionality: execute specified command for each
file in input file list.
The tool will be used in the clang driver for cases when number of
action's outputs is unknown and used tools don't support file lists.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>