### PR TITLE
[SYCL] Handle captures by ref in kernel lambda

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -989,7 +989,8 @@ static target getAccessTarget(const ClassTemplateSpecializationDecl *AccTy) {
 // Fields of kernel object must be initialized with SYCL kernel arguments so
 // in the following function we extract types of kernel object fields and add it
 // to the array with kernel parameters descriptors.
-static void buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
+// Returns true if all arguments are successfully built.
+static bool buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
                         SmallVectorImpl<ParamDesc> &ParamDescs) {
   const LambdaCapture *Cpt = KernelObj->captures_begin();
   auto CreateAndAddPrmDsc = [&](const FieldDecl *Fld, const QualType &ArgType) {
@@ -1040,6 +1041,7 @@ static void buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
             }
           };
 
+  bool AllArgsAreValid = true;
   // Run through kernel object fields and create corresponding kernel
   // parameters descriptors. There are a several possible cases:
   //   - Kernel object field is a SYCL special object (SYCL accessor or SYCL
@@ -1054,17 +1056,22 @@ static void buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
     QualType ArgTy = Fld->getType();
     if (Util::isSyclAccessorType(ArgTy) || Util::isSyclSamplerType(ArgTy)) {
       createSpecialSYCLObjParamDesc(Fld, ArgTy);
-    } else if (ArgTy->isStructureOrClassType()) {
+    } else if (!ArgTy->isStandardLayoutType()) {
       // SYCL v1.2.1 s4.8.10 p5:
       // C++ non-standard layout values must not be passed as arguments to a
       // kernel that is compiled for a device.
-      if (!ArgTy->isStandardLayoutType()) {
-        const DeclaratorDecl *V =
-            Cpt ? cast<DeclaratorDecl>(Cpt->getCapturedVar())
-                : cast<DeclaratorDecl>(Fld);
-        KernelObj->getASTContext().getDiagnostics().Report(
-            V->getLocation(), diag::err_sycl_non_std_layout_type);
-      }
+      const auto &DiagLocation =
+          Cpt ? Cpt->getLocation() : cast<DeclaratorDecl>(Fld)->getLocation();
+
+      Context.getDiagnostics().Report(DiagLocation,
+                                      diag::err_sycl_non_std_layout_type);
+
+      // Set the flag and continue processing so we can emit error for each
+      // invalid argument.
+      AllArgsAreValid = false;
+    } else if (ArgTy->isStructureOrClassType()) {
+      assert(ArgTy->isStandardLayoutType());
+
       CreateAndAddPrmDsc(Fld, ArgTy);
 
       // Create descriptors for each accessor field in the class or struct
@@ -1077,14 +1084,20 @@ static void buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
       PointeeTy = Context.getQualifiedType(PointeeTy.getUnqualifiedType(),
                                            Quals);
       QualType ModTy = Context.getPointerType(PointeeTy);
-      
+
       CreateAndAddPrmDsc(Fld, ModTy);
     } else if (ArgTy->isScalarType()) {
       CreateAndAddPrmDsc(Fld, ArgTy);
     } else {
       llvm_unreachable("Unsupported kernel parameter type");
     }
+
+    // Update capture iterator as we process arguments
+    if (Cpt && Cpt != KernelObj->captures_end())
+      ++Cpt;
   }
+
+  return AllArgsAreValid;
 }
 
 /// Adds necessary data describing given kernel to the integration header.
@@ -1238,7 +1251,8 @@ void Sema::ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc,
 
   // Build list of kernel arguments
   llvm::SmallVector<ParamDesc, 16> ParamDescs;
-  buildArgTys(getASTContext(), LE, ParamDescs);
+  if (!buildArgTys(getASTContext(), LE, ParamDescs))
+    return;
 
   // Extract name from kernel caller parameters and mangle it.
   const TemplateArgumentList *TemplateArgs =

--- a/clang/test/SemaSYCL/non-std-layout-param.cpp
+++ b/clang/test/SemaSYCL/non-std-layout-param.cpp
@@ -20,9 +20,61 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 
 
 void test() {
-  // expected-error@+1 {{kernel parameter has non-standard layout class/struct type}}
   C C0;
   C0.Y=0;
-  kernel_single_task<class MyKernel>([=] { (void)C0.Y; });
+  kernel_single_task<class MyKernel>([=] {
+    // expected-error@+1 {{kernel parameter has non-standard layout class/struct type}}
+    (void)C0.Y;
+  });
 }
 
+void test_capture_explicit_ref() {
+  int p = 0;
+  double q = 0;
+  float s = 0;
+  kernel_single_task<class kernel_capture_single_ref>([
+    // expected-error@+1 {{kernel parameter has non-standard layout class/struct type}}
+      &p,
+      q,
+    // expected-error@+1 {{kernel parameter has non-standard layout class/struct type}}
+      &s] {
+    (void) q;
+    (void) p;
+    (void) s;
+  });
+}
+
+void test_capture_implicit_refs() {
+  int p = 0;
+  double q = 0;
+  kernel_single_task<class kernel_capture_refs>([&] {
+    // expected-error@+1 {{kernel parameter has non-standard layout class/struct type}}
+    (void) p;
+    // expected-error@+1 {{kernel parameter has non-standard layout class/struct type}}
+    (void) q;
+  });
+}
+
+struct Kernel {
+  void operator()() {
+    (void) c1;
+    (void) c2;
+    (void) p;
+    (void) q;
+  }
+
+  int p;
+  // expected-error@+1 {{kernel parameter has non-standard layout class/struct type}}
+  C c1;
+
+  int q;
+
+  // expected-error@+1 {{kernel parameter has non-standard layout class/struct type}}
+  C c2;
+};
+
+void test_struct_field() {
+  Kernel k{};
+
+  kernel_single_task<class kernel_object>(k);
+}


### PR DESCRIPTION
Captures by reference wasn't properly handled
by the compiler which led to a crash.

References are not standard layout so if we
see one, emit a corresponding error as for other
non-standard layout structures/classes.

Signed-off-by: Ilya Stepykin <ilya.stepykin@intel.com>