### PR TITLE
[SYCL][Driver] fix -fsycl -lstdc++ abort problem

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3308,6 +3308,11 @@ class OffloadingActionBuilder final {
       if (auto *IA = dyn_cast<InputAction>(HostAction)) {
         SYCLDeviceActions.clear();
 
+        // Options that are considered LinkerInput are not valid input actions
+        // to the device tool chain.
+        if (IA->getInputArg().getOption().hasFlag(options::LinkerInput))
+          return ABRT_Inactive;
+
         std::string InputName = IA->getInputArg().getAsString(Args);
         // Objects should already be consumed with -foffload-static-lib
         if (Args.hasArg(options::OPT_foffload_static_lib_EQ) &&
@@ -3328,6 +3333,11 @@ class OffloadingActionBuilder final {
       if (auto *UA = dyn_cast<OffloadUnbundlingJobAction>(HostAction)) {
         SYCLDeviceActions.clear();
         if (auto *IA = dyn_cast<InputAction>(UA->getInputs().back())) {
+          // Options that are considered LinkerInput are not valid input actions
+          // to the device tool chain.
+          if (IA->getInputArg().getOption().hasFlag(options::LinkerInput))
+            return ABRT_Inactive;
+
           std::string FileName = IA->getInputArg().getAsString(Args);
           // Check if the type of the file is the same as the action. Do not
           // unbundle it if it is not. Do not unbundle .so files, for example,
@@ -3784,6 +3794,7 @@ public:
     // the input is not a bundle.
     if (CanUseBundler && isa<InputAction>(HostAction) &&
         InputArg->getOption().getKind() == llvm::opt::Option::InputClass &&
+        !InputArg->getOption().hasFlag(options::LinkerInput) &&
         !types::isSrcFile(HostAction->getType())) {
       std::string InputName = InputArg->getAsString(Args);
       // Do not create an unbundling action for an object when we know a fat

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -182,6 +182,11 @@
 // CHK-PHASES-LIB: 15: clang-offload-wrapper, {14}, object, (device-sycl)
 // CHK-PHASES-LIB: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-linux-sycldevice)" {15}, image
 
+/// Compilation check with -lstdc++ (treated differently than regular lib)
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -lstdc++ -fsycl -fsycl-targets=spir64-unknown-linux-sycldevice %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-LIB-STDCXX %s
+// CHK-LIB-STDCXX: ld{{.*}} "-lstdc++"
+
 /// ###########################################################################
 
 /// Check the phases when using and multiple source files

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -183,9 +183,11 @@
 // CHK-PHASES-LIB: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-linux-sycldevice)" {15}, image
 
 /// Compilation check with -lstdc++ (treated differently than regular lib)
-// RUN:   %clang -### -target x86_64-unknown-linux-gnu -lstdc++ -fsycl -fsycl-targets=spir64-unknown-linux-sycldevice %s 2>&1 \
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -lstdc++ -fsycl %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-LIB-STDCXX %s
 // CHK-LIB-STDCXX: ld{{.*}} "-lstdc++"
+// CHK-LIB-STDCXX-NOT: clang-offload-bundler{{.*}}
+// CHK-LIB-STDCXX-NOT: llvm-link{{.*}} "-lstdc++"
 
 /// ###########################################################################
 


### PR DESCRIPTION
Use of -fsycl -lstdc++ causes an abort when processing Input arguments
slated for unbundling.  -lstdc++ is a special case library that is transformed
to a different value.  This new input arg ends up having no actual value
negating the assumption that Input args have a value.  Any LinkerInput
options/Args are not to be considered to be unbundled.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>