### PR TITLE
[SYCL][Driver] Update directory name to integration header

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5424,12 +5424,17 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     // Host-side SYCL compilation receives the integration header file as
     // Inputs[1].  Include the header with -include
     if (!IsSYCLOffloadDevice && SYCLDeviceInput) {
+      SmallString<128> RealPath;
+      // Fixup the header path name in case there are discrepancies in the
+      // string used for the temporary directory environment variable and
+      // actual path expectations.
+      llvm::sys::fs::real_path(SYCLDeviceInput->getFilename(), RealPath);
       CmdArgs.push_back("-include");
-      CmdArgs.push_back(SYCLDeviceInput->getFilename());
+      CmdArgs.push_back(Args.MakeArgString(RealPath));
       // When creating dependency information, filter out the generated
       // header file.
       CmdArgs.push_back("-dependency-filter");
-      CmdArgs.push_back(SYCLDeviceInput->getFilename());
+      CmdArgs.push_back(Args.MakeArgString(RealPath));
       // Let the FE know we are doing a SYCL offload compilation, but we are
       // doing the host pass.
       CmdArgs.push_back("-fsycl-is-host");

--- a/clang/test/Driver/sycl-offload-header-check.cpp
+++ b/clang/test/Driver/sycl-offload-header-check.cpp
@@ -1,0 +1,11 @@
+// REQUIRES: system-windows
+// Test the integrated header file name generation.  Name should match the
+// actual path name and not the environment variable setting
+// RUN: mkdir -p %t_DiRnAmE
+// invoke the compiler overriding output temp location
+// RUN: env TMPDIR=%t_dirname TEMP=%t_dirname TMP=%t_dirname  \
+// RUN: %clang_cl -### -fsycl %s 2>&1 | \
+// RUN: FileCheck --check-prefix=CHECK-HEADER %s
+// CHECK-HEADER: clang{{.*}} "-fsycl-int-header=[[HEADER:.+\.h]]"
+// CHECK-HEADER-NOT: clang{{.*}} "-include" "[[HEADER]]"
+// CHECK-HEADER: clang{{.*}} "-include" "{{.*}}_DiRnAmE{{.+}}.h"

--- a/clang/test/Driver/sycl-offload-header-check.cpp
+++ b/clang/test/Driver/sycl-offload-header-check.cpp
@@ -3,10 +3,10 @@
 // actual path name and not the environment variable setting
 // RUN: mkdir -p %t_DiRnAmE
 // invoke the compiler overriding output temp location
-// RUN: TMP=%t_dirname  \
+// RUN: env TMP=%t_dirname  \
 // RUN: %clang_cl -### -fsycl %s 2>&1 | \
 // RUN: FileCheck --check-prefix=CHECK-HEADER %s
-// RUN: TMP=%t_dirname  \
+// RUN: env TMP=%t_dirname  \
 // RUN: %clang -### -fsycl %s 2>&1 | \
 // RUN: FileCheck --check-prefix=CHECK-HEADER %s
 // CHECK-HEADER: clang{{.*}} "-fsycl-int-header=[[HEADER:.+\.h]]"

--- a/clang/test/Driver/sycl-offload-header-check.cpp
+++ b/clang/test/Driver/sycl-offload-header-check.cpp
@@ -1,10 +1,13 @@
 // REQUIRES: system-windows
-// Test the integrated header file name generation.  Name should match the
+// Test the integration header file name generation.  Name should match the
 // actual path name and not the environment variable setting
 // RUN: mkdir -p %t_DiRnAmE
 // invoke the compiler overriding output temp location
-// RUN: env TMPDIR=%t_dirname TEMP=%t_dirname TMP=%t_dirname  \
+// RUN: TMP=%t_dirname  \
 // RUN: %clang_cl -### -fsycl %s 2>&1 | \
+// RUN: FileCheck --check-prefix=CHECK-HEADER %s
+// RUN: TMP=%t_dirname  \
+// RUN: %clang -### -fsycl %s 2>&1 | \
 // RUN: FileCheck --check-prefix=CHECK-HEADER %s
 // CHECK-HEADER: clang{{.*}} "-fsycl-int-header=[[HEADER:.+\.h]]"
 // CHECK-HEADER-NOT: clang{{.*}} "-include" "[[HEADER]]"


### PR DESCRIPTION
There is a possibility that the TMP environment variable on Windows when set
does not exactly match the real path representation of the directory via
case sensitivity.  Fixup the directory/filename to match real path expectations
to reduce the potential warnings emitted during compilation.

> clang++ -fsycl -c accessors.cpp
<built-in>:1:10: warning: non-portable path to file
      '"c\\Users\\AppData\Local\Temp\3\accessors-62b196.h"'; specified
      path differs in case from file name on disk [-Wnonportable-include-path]
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         "c\\Users\AppData\Local\Temp\3\accessors-62b196.h"

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>