### PR TITLE
[SYCL] Throw exceptions while creating sub buffer

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -134,13 +134,12 @@ public:
     if (b.is_sub_buffer())
       throw cl::sycl::invalid_object_error(
           "Cannot create sub buffer from sub buffer.");
-    // TODO: SYCL CTS are failed because not appropriate offset and range
-    // are passed to this constructor which causes a throw of exception.
-    // Some changes need to be done there.
-    // if (isOutOfBounds(baseIndex, subRange, b.Range))
-    //   throw cl::sycl::invalid_object_error("Out-of-bounds size");
-    // if (!isContiguousRegion(baseIndex, subRange, b.Range))
-    //   throw cl::sycl::invalid_object_error("Non-contiguous region");
+    if (isOutOfBounds(baseIndex, subRange, b.Range))
+      throw cl::sycl::invalid_object_error(
+          "Requested sub-buffer size exceeds the size of the parent buffer");
+    if (!isContiguousRegion(baseIndex, subRange, b.Range))
+      throw cl::sycl::invalid_object_error(
+          "Requested sub-buffer region is not contiguous");
   }
 
   template <int N = dimensions, typename = EnableIfOneDimension<N>>

--- a/sycl/test/basic_tests/buffer/subbuffer.cpp
+++ b/sycl/test/basic_tests/buffer/subbuffer.cpp
@@ -198,7 +198,6 @@ int main() {
   cl::sycl::queue q;
   check1DSubBuffer(q);
   checkHostAccessor(q);
-  // TODO! Uncomment once SYCL-CTS are fixed
-  // checkExceptions();
+  checkExceptions();
   return 0;
 }


### PR DESCRIPTION
Throw `invalid_object_error` exception if memory region of
constructed sub buffer specified by offset and sub buffer size
doesn't represent contiguous region or if it exceeds parent bounds.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>