### PR TITLE
[SYCL] Add shortcuts to launch kernels from an ordered queue.

### DIFF
--- a/sycl/include/CL/sycl/ordered_queue.hpp
+++ b/sycl/include/CL/sycl/ordered_queue.hpp
@@ -145,7 +145,7 @@ public:
     submit([&](handler &cgh) {
       cgh.template parallel_for<KernelName, KernelType, Dims>(
           NumWorkItems, WorkItemOffset, KernelFunc);
-      });
+    });
   }
 
   // parallel_for version with a kernel represented as a lambda + nd_range that

--- a/sycl/include/CL/sycl/ordered_queue.hpp
+++ b/sycl/include/CL/sycl/ordered_queue.hpp
@@ -118,6 +118,46 @@ public:
     });
   }
 
+  // single_task version with a kernel represented as a lambda.
+  template <typename KernelName = csd::auto_name, typename KernelType>
+  void single_task(KernelType KernelFunc) {
+    submit([&](handler &cgh) {
+      cgh.template single_task<KernelName, KernelType>(KernelFunc);
+    });
+  }
+
+  // parallel_for version with a kernel represented as a lambda + range that
+  // specifies global size only.
+  template <typename KernelName = csd::auto_name, typename KernelType, int Dims>
+  void parallel_for(range<Dims> NumWorkItems, KernelType KernelFunc) {
+    // By-value or By-reference for this?
+    submit([&](handler &cgh) {
+      cgh.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
+                                                              KernelFunc);
+    });
+  }
+
+  // parallel_for version with a kernel represented as a lambda + range and
+  // offset that specify global size and global offset correspondingly.
+  template <typename KernelName = csd::auto_name, typename KernelType, int Dims>
+  void parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
+                    KernelType KernelFunc) {
+    submit([&](handler &cgh) {
+      cgh.template parallel_for<KernelName, KernelType, Dims>(
+          NumWorkItems, WorkItemOffset, KernelFunc);
+      });
+  }
+
+  // parallel_for version with a kernel represented as a lambda + nd_range that
+  // specifies global, local sizes and offset.
+  template <typename KernelName = csd::auto_name, typename KernelType, int Dims>
+  void parallel_for(nd_range<Dims> ExecutionRange, KernelType KernelFunc) {
+    submit([&](handler &cgh) {
+      cgh.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
+                                                              KernelFunc);
+    });
+  }
+
 private:
   std::shared_ptr<detail::queue_impl> impl;
   template <class Obj>

--- a/sycl/test/ordered_queue/oq_kernels.cpp
+++ b/sycl/test/ordered_queue/oq_kernels.cpp
@@ -1,0 +1,67 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t.out -lOpenCL
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+//==------ oq_kernels.cpp - SYCL ordered queue kernel shortcut test --------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+#include <iostream>
+using namespace cl::sycl;
+
+int main() {
+  ordered_queue q;
+  auto dev = q.get_device();
+  auto ctx = q.get_context();
+  const int N = 8;
+
+  auto A = (int *)malloc_shared(N * sizeof(int), dev, ctx);
+
+  for (int i = 0; i < N; i++) {
+    A[i] = 1;
+  }
+
+  q.parallel_for(range<1>{N}, [=](id<1> ID) {
+    auto i = ID[0];
+    A[i]++;
+  });
+
+  q.parallel_for<class Foo>(range<1>{N}, [=](id<1> ID) {
+    auto i = ID[0];
+    A[i]++;
+  });
+
+  q.single_task<class Bar>([=]() {
+    for (int i = 0; i < N; i++) {
+      A[i]++;
+    }
+  });
+
+  id<1> offset(0);
+  q.parallel_for<class Baz>(range<1>{N}, offset, [=](id<1> ID) {
+    auto i = ID[0];
+    A[i]++;
+  });
+
+  nd_range<1> NDR(range<1>{N}, range<1>{2});
+  q.parallel_for<class NDFoo>(NDR, [=](id<1> ID) {
+    auto i = ID[0];
+    A[i]++;
+  });
+
+  q.wait();
+
+  int error = 0;
+  for (int i = 0; i < N; i++) {
+    if (A[i] != 6)
+      error = 1;
+  }
+
+  return error;
+}

--- a/sycl/test/ordered_queue/oq_kernels.cpp
+++ b/sycl/test/ordered_queue/oq_kernels.cpp
@@ -1,5 +1,6 @@
-// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t.out -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
@@ -57,11 +58,10 @@ int main() {
 
   q.wait();
 
-  int error = 0;
   for (int i = 0; i < N; i++) {
     if (A[i] != 6)
-      error = 1;
+      return 1;
   }
 
-  return error;
+  return 0;
 }


### PR DESCRIPTION
When using Ordered Queues (and USM), you really don't need the whole q.submit() business, so this adds shortcuts to call parallel_for and single_task directly from the queue.

Signed-off-by: James Brodman <james.brodman@intel.com>