### PR TITLE
[SYCL] Refactor kernel and kernel_impl classes

### DIFF
--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -11,10 +11,10 @@
 #include <CL/sycl/detail/aligned_allocator.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/generic_type_traits.hpp>
-#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_t.hpp>
+#include <CL/sycl/device.hpp>
 #include <CL/sycl/event.hpp>
 #include <CL/sycl/property_list.hpp>
 #include <CL/sycl/range.hpp>

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -11,6 +11,7 @@
 #include <CL/sycl/detail/aligned_allocator.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/generic_type_traits.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_t.hpp>

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -11,7 +11,6 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
-#include <CL/sycl/detail/kernel_info.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/info/info_desc.hpp>
@@ -33,31 +32,13 @@ public:
 
   kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
               std::shared_ptr<program_impl> ProgramImpl,
-              bool IsCreatedFromSource)
-      : Kernel(Kernel), Context(SyclContext), ProgramImpl(ProgramImpl),
-        IsCreatedFromSource(IsCreatedFromSource) {
-
-    RT::PiContext Context = nullptr;
-    PI_CALL(RT::piKernelGetInfo, Kernel, CL_KERNEL_CONTEXT, sizeof(Context),
-            &Context, nullptr);
-    auto ContextImpl = detail::getSyclObjImpl(SyclContext);
-    if (ContextImpl->getHandleRef() != Context)
-      throw cl::sycl::invalid_parameter_error(
-          "Input context must be the same as the context of cl_kernel");
-    PI_CALL(RT::piKernelRetain, Kernel);
-  }
+              bool IsCreatedFromSource);
 
   // Host kernel constructor
   kernel_impl(const context &SyclContext,
-              std::shared_ptr<program_impl> ProgramImpl)
-      : Context(SyclContext), ProgramImpl(ProgramImpl) {}
+              std::shared_ptr<program_impl> ProgramImpl);
 
-  ~kernel_impl() {
-    // TODO catch an exception and put it to list of asynchronous exceptions
-    if (!is_host()) {
-      PI_CALL(RT::piKernelRelease, Kernel);
-    }
-  }
+  ~kernel_impl();
 
   cl_kernel get() const {
     if (is_host()) {
@@ -75,55 +56,22 @@ public:
 
   template <info::kernel param>
   typename info::param_traits<info::kernel, param>::return_type
-  get_info() const {
-    if (is_host()) {
-      // TODO implement
-      assert(0 && "Not implemented");
-    }
-    return get_kernel_info<
-        typename info::param_traits<info::kernel, param>::return_type,
-        param>::_(this->getHandleRef());
-  }
+  get_info() const;
 
   template <info::kernel_work_group param>
   typename info::param_traits<info::kernel_work_group, param>::return_type
-  get_work_group_info(const device &Device) const {
-    if (is_host()) {
-      return get_kernel_work_group_info_host<param>(Device);
-    }
-    return get_kernel_work_group_info<
-        typename info::param_traits<info::kernel_work_group,
-                                    param>::return_type,
-        param>::_(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef());
-  }
+  get_work_group_info(const device &Device) const;
 
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
-  get_sub_group_info(const device &Device) const {
-    if (is_host()) {
-      throw runtime_error("Sub-group feature is not supported on HOST device.");
-    }
-    return get_kernel_sub_group_info<
-        typename info::param_traits<info::kernel_sub_group, param>::return_type,
-        param>::_(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef());
-  }
+  get_sub_group_info(const device &Device) const;
 
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(
       const device &Device,
       typename info::param_traits<info::kernel_sub_group, param>::input_type
-          Value) const {
-    if (is_host()) {
-      throw runtime_error("Sub-group feature is not supported on HOST device.");
-    }
-    return get_kernel_sub_group_info_with_input<
-        typename info::param_traits<info::kernel_sub_group, param>::return_type,
-        param,
-        typename info::param_traits<info::kernel_sub_group, param>::
-            input_type>::_(this->getHandleRef(),
-                           getSyclObjImpl(Device)->getHandleRef(), Value);
-  }
+          Value) const;
 
   RT::PiKernel &getHandleRef() { return Kernel; }
   const RT::PiKernel &getHandleRef() const { return Kernel; }
@@ -136,10 +84,6 @@ private:
   std::shared_ptr<program_impl> ProgramImpl;
   bool IsCreatedFromSource = true;
 };
-
-template <> context kernel_impl::get_info<info::kernel::context>() const;
-
-template <> program kernel_impl::get_info<info::kernel::program>() const;
 
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -30,11 +30,20 @@ class kernel_impl {
 public:
   /// Constructs a SYCL kernel instance from a PiKernel
   ///
+  /// This constructor is used for OpenCL interoperability. It always marks
+  /// kernel as being created from source and creates a new program_impl
+  /// instance.
+  ///
   /// @param Kernel is a valid PiKernel instance
   /// @param SyclContext is a valid SYCL context
   kernel_impl(RT::PiKernel Kernel, const context &SyclContext);
 
-  /// Constructs a SYCL kernel instance from a SYCL program
+  /// Constructs a SYCL kernel instance from a SYCL program and a PiKernel
+  ///
+  /// This constructor creates a new instance from PiKernel and associates it
+  /// with the provided SYCL program. If context of PiKernel differs from
+  /// context of the SYCL program, an invalid_parameter_error exception is
+  /// thrown.
   ///
   /// @param Kernel is a valid PiKernel instance
   /// @param SyclContext is a valid SYCL context
@@ -54,7 +63,7 @@ public:
 
   ~kernel_impl();
 
-  /// Gets a valid OpenCL interoperability kernel
+  /// Gets a valid OpenCL kernel handle
   ///
   /// The requirements for this method are described in section 4.3.1
   /// of the SYCL specification.
@@ -68,53 +77,42 @@ public:
     return pi::cast<cl_kernel>(MKernel);
   }
 
-  /// Check if this kernel is a SYCL host device kernel
+  /// Check if the associated SYCL context is a SYCL host context.
   ///
-  /// @return true if a kernel is a valid SYCL host device kernel
+  /// @return true if this SYCL kernel is a host kernel.
   bool is_host() const { return MContext.is_host(); }
-
-  /// Get the context that this kernel is defined for.
-  ///
-  /// The value returned must be equal to that returned by
-  /// get_info<info::kernel::context>().
-  ///
-  /// @return a valid SYCL context
-  context get_context() const { return MContext; }
-
-  /// Get the program that this kernel is defined for.
-  ///
-  /// The value returned must be equal to that returned by
-  /// get_info<info::kernel::program>().
-  ///
-  /// @return a valid SYCL program
-  program get_program() const;
 
   /// Query information from the kernel object using the info::kernel_info
   /// descriptor.
   ///
-  /// Valid template parameters are described in Table 4.84 of the SYCL
-  /// specification.
+  /// @return depends on information being queried.
   template <info::kernel param>
   typename info::param_traits<info::kernel, param>::return_type
   get_info() const;
 
-  /// Query information from the work-group from a kernel using the
+  /// Query work-group information from a kernel using the
   /// info::kernel_work_group descriptor for a specific device.
   ///
-  /// Valid template parameters are described in Table 4.85 of the SYCL
-  /// specification.
+  /// @param Deivce is a valid SYCL device.
+  /// @return depends on information being queried.
   template <info::kernel_work_group param>
   typename info::param_traits<info::kernel_work_group, param>::return_type
   get_work_group_info(const device &Device) const;
 
-  /// Query information from the sub-group from a kernel using the
+  /// Query sub-group information from a kernel using the
   /// info::kernel_sub_group descriptor for a specific device.
+  ///
+  /// @param Deivce is a valid SYCL device
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(const device &Device) const;
 
-  /// Query information from the sub-group from a kernel using the
-  /// info::kernel_sub_group descriptor for a specific device.
+  /// Query sub-group information from a kernel using the
+  /// info::kernel_sub_group descriptor for a specific device and value.
+  ///
+  /// @param Deivce is a valid SYCL device.
+  /// @param Value depends on information being queried.
+  /// @return depends on information being queried.
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -54,7 +54,7 @@ public:
 
   ~kernel_impl();
 
-  /// Get a valid OpenCL interoperability kernel
+  /// Gets a valid OpenCL interoperability kernel
   ///
   /// The requirements for this method are described in section 4.3.1
   /// of the SYCL specification.
@@ -124,11 +124,11 @@ public:
 
   /// Get a reference to a raw kernel object.
   ///
-  /// @return a reference to ai valid PiKernel instance with raw kernel object.
+  /// @return a reference to a valid PiKernel instance with raw kernel object.
   RT::PiKernel &getHandleRef() { return MKernel; }
   /// Get a constant reference to a raw kernel object.
   ///
-  /// @return a constant reference to ai valid PiKernel instance with raw kernel
+  /// @return a constant reference to a valid PiKernel instance with raw kernel
   /// object.
   const RT::PiKernel &getHandleRef() const { return MKernel; }
 

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -28,18 +28,38 @@ class program_impl;
 
 class kernel_impl {
 public:
+  /// Constructs a SYCL kernel instance from a PiKernel
+  ///
+  /// @param Kernel is a valid PiKernel instance
+  /// @param SyclContext is a valid SYCL context
   kernel_impl(RT::PiKernel Kernel, const context &SyclContext);
 
+  /// Constructs a SYCL kernel instance from a SYCL program
+  ///
+  /// @param Kernel is a valid PiKernel instance
+  /// @param SyclContext is a valid SYCL context
+  /// @param ProgramImpl is a valid instance of program_impl
+  /// @param IsCreatedFromSource is a flag that indicates whether program
+  /// is created from source code
   kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
               std::shared_ptr<program_impl> ProgramImpl,
               bool IsCreatedFromSource);
 
-  // Host kernel constructor
+  /// Constructs a SYCL kernel for host device
+  ///
+  /// @param SyclContext is a valid SYCL context
+  /// @param ProgramImpl is a valid instance of program_impl
   kernel_impl(const context &SyclContext,
               std::shared_ptr<program_impl> ProgramImpl);
 
   ~kernel_impl();
 
+  /// Get a valid OpenCL interoperability kernel
+  ///
+  /// The requirements for this method are described in section 4.3.1
+  /// of the SYCL specification.
+  ///
+  /// @return a valid cl_kernel instance
   cl_kernel get() const {
     if (is_host()) {
       throw invalid_object_error("This instance of kernel is a host instance");
@@ -48,24 +68,52 @@ public:
     return pi::cast<cl_kernel>(MKernel);
   }
 
+  /// Check if this kernel is a SYCL host device kernel
+  ///
+  /// @return true if a kernel is a valid SYCL host device kernel
   bool is_host() const { return MContext.is_host(); }
 
+  /// Get the context that this kernel is defined for.
+  ///
+  /// The value returned must be equal to that returned by
+  /// get_info<info::kernel::context>().
+  ///
+  /// @return a valid SYCL context
   context get_context() const { return MContext; }
 
+  /// Get the program that this kernel is defined for.
+  ///
+  /// The value returned must be equal to that returned by
+  /// get_info<info::kernel::program>().
+  ///
+  /// @return a valid SYCL program
   program get_program() const;
 
+  /// Query information from the kernel object using the info::kernel_info descriptor.
+  ///
+  /// Valid template parameters are described in Table 4.84 of the SYCL
+  /// specification.
   template <info::kernel param>
   typename info::param_traits<info::kernel, param>::return_type
   get_info() const;
 
+  /// Query information from the work-group from a kernel using the
+  /// info::kernel_work_group descriptor for a specific device.
+  ///
+  /// Valid template parameters are described in Table 4.85 of the SYCL
+  /// specification.
   template <info::kernel_work_group param>
   typename info::param_traits<info::kernel_work_group, param>::return_type
   get_work_group_info(const device &Device) const;
 
+  /// Query information from the sub-group from a kernel using the
+  /// info::kernel_sub_group descriptor for a specific device.
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(const device &Device) const;
 
+  /// Query information from the sub-group from a kernel using the
+  /// info::kernel_sub_group descriptor for a specific device.
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(
@@ -73,9 +121,18 @@ public:
       typename info::param_traits<info::kernel_sub_group, param>::input_type
           Value) const;
 
+  /// Get a reference to a raw kernel object.
+  ///
+  /// @return a reference to ai valid PiKernel instance with raw kernel object.
   RT::PiKernel &getHandleRef() { return MKernel; }
+  /// Get a constant reference to a raw kernel object.
+  ///
+  /// @return a constant reference to ai valid PiKernel instance with raw kernel object.
   const RT::PiKernel &getHandleRef() const { return MKernel; }
 
+  /// Check if kernel was created from a program that had been created from source.
+  ///
+  /// @return true if kernel was created from source.
   bool isCreatedFromSource() const;
 
 private:

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -65,8 +65,9 @@ public:
 
   /// Gets a valid OpenCL kernel handle
   ///
-  /// The requirements for this method are described in section 4.3.1
-  /// of the SYCL specification.
+  /// If this kernel encapsulates an instance of OpenCL kernel, a valid
+  /// cl_kernel will be returned. If this kernel is a host kernel,
+  /// an invalid_object_error exception will be thrown.
   ///
   /// @return a valid cl_kernel instance
   cl_kernel get() const {

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -44,13 +44,13 @@ public:
     if (is_host()) {
       throw invalid_object_error("This instance of kernel is a host instance");
     }
-    PI_CALL(RT::piKernelRetain, Kernel);
-    return pi::cast<cl_kernel>(Kernel);
+    PI_CALL(RT::piKernelRetain, MKernel);
+    return pi::cast<cl_kernel>(MKernel);
   }
 
-  bool is_host() const { return Context.is_host(); }
+  bool is_host() const { return MContext.is_host(); }
 
-  context get_context() const { return Context; }
+  context get_context() const { return MContext; }
 
   program get_program() const;
 
@@ -73,16 +73,16 @@ public:
       typename info::param_traits<info::kernel_sub_group, param>::input_type
           Value) const;
 
-  RT::PiKernel &getHandleRef() { return Kernel; }
-  const RT::PiKernel &getHandleRef() const { return Kernel; }
+  RT::PiKernel &getHandleRef() { return MKernel; }
+  const RT::PiKernel &getHandleRef() const { return MKernel; }
 
   bool isCreatedFromSource() const;
 
 private:
-  RT::PiKernel Kernel;
-  context Context;
-  std::shared_ptr<program_impl> ProgramImpl;
-  bool IsCreatedFromSource = true;
+  RT::PiKernel MKernel;
+  context MContext;
+  std::shared_ptr<program_impl> MProgramImpl;
+  bool MIsCreatedFromSource = true;
 };
 
 } // namespace detail

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -61,9 +61,9 @@ public:
   ///
   /// @return a valid cl_kernel instance
   cl_kernel get() const {
-    if (is_host()) {
+    if (is_host())
       throw invalid_object_error("This instance of kernel is a host instance");
-    }
+
     PI_CALL(RT::piKernelRetain, MKernel);
     return pi::cast<cl_kernel>(MKernel);
   }
@@ -142,7 +142,7 @@ private:
   RT::PiKernel MKernel;
   context MContext;
   std::shared_ptr<program_impl> MProgramImpl;
-  bool MIsCreatedFromSource = true;
+  bool MCreatedFromSource = true;
 };
 
 } // namespace detail

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -30,7 +30,7 @@ class kernel_impl {
 public:
   /// Constructs a SYCL kernel instance from a PiKernel
   ///
-  /// This constructor is used for OpenCL interoperability. It always marks
+  /// This constructor is used for plug-in interoperability. It always marks
   /// kernel as being created from source and creates a new program_impl
   /// instance.
   ///
@@ -40,8 +40,8 @@ public:
 
   /// Constructs a SYCL kernel instance from a SYCL program and a PiKernel
   ///
-  /// This constructor creates a new instance from PiKernel and associates it
-  /// with the provided SYCL program. If context of PiKernel differs from
+  /// This constructor creates a new instance from PiKernel and saves
+  /// the provided SYCL program. If context of PiKernel differs from
   /// context of the SYCL program, an invalid_parameter_error exception is
   /// thrown.
   ///
@@ -94,7 +94,7 @@ public:
   /// Query work-group information from a kernel using the
   /// info::kernel_work_group descriptor for a specific device.
   ///
-  /// @param Deivce is a valid SYCL device.
+  /// @param Device is a valid SYCL device.
   /// @return depends on information being queried.
   template <info::kernel_work_group param>
   typename info::param_traits<info::kernel_work_group, param>::return_type
@@ -103,7 +103,7 @@ public:
   /// Query sub-group information from a kernel using the
   /// info::kernel_sub_group descriptor for a specific device.
   ///
-  /// @param Deivce is a valid SYCL device
+  /// @param Device is a valid SYCL device
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(const device &Device) const;
@@ -111,7 +111,7 @@ public:
   /// Query sub-group information from a kernel using the
   /// info::kernel_sub_group descriptor for a specific device and value.
   ///
-  /// @param Deivce is a valid SYCL device.
+  /// @param Device is a valid SYCL device.
   /// @param Value depends on information being queried.
   /// @return depends on information being queried.
   template <info::kernel_sub_group param>

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -89,7 +89,8 @@ public:
   /// @return a valid SYCL program
   program get_program() const;
 
-  /// Query information from the kernel object using the info::kernel_info descriptor.
+  /// Query information from the kernel object using the info::kernel_info
+  /// descriptor.
   ///
   /// Valid template parameters are described in Table 4.84 of the SYCL
   /// specification.
@@ -127,10 +128,12 @@ public:
   RT::PiKernel &getHandleRef() { return MKernel; }
   /// Get a constant reference to a raw kernel object.
   ///
-  /// @return a constant reference to ai valid PiKernel instance with raw kernel object.
+  /// @return a constant reference to ai valid PiKernel instance with raw kernel
+  /// object.
   const RT::PiKernel &getHandleRef() const { return MKernel; }
 
-  /// Check if kernel was created from a program that had been created from source.
+  /// Check if kernel was created from a program that had been created from
+  /// source.
   ///
   /// @return true if kernel was created from source.
   bool isCreatedFromSource() const;

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -11,12 +11,14 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/program_manager/program_manager.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <fstream>
 #include <memory>
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -16,6 +16,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/event.hpp>

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -267,9 +267,9 @@ PARAM_TRAITS_SPEC(event_profiling, command_submit, cl_ulong)
 PARAM_TRAITS_SPEC(event_profiling, command_start, cl_ulong)
 PARAM_TRAITS_SPEC(event_profiling, command_end, cl_ulong)
 
+#include <CL/sycl/info/kernel_sub_group_traits.def>
 #include <CL/sycl/info/kernel_traits.def>
 #include <CL/sycl/info/kernel_work_group_traits.def>
-#include <CL/sycl/info/kernel_sub_group_traits.def>
 
 PARAM_TRAITS_SPEC(platform, profile, string_class)
 PARAM_TRAITS_SPEC(platform, version, string_class)

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -267,31 +267,9 @@ PARAM_TRAITS_SPEC(event_profiling, command_submit, cl_ulong)
 PARAM_TRAITS_SPEC(event_profiling, command_start, cl_ulong)
 PARAM_TRAITS_SPEC(event_profiling, command_end, cl_ulong)
 
-PARAM_TRAITS_SPEC(kernel, function_name, string_class)
-PARAM_TRAITS_SPEC(kernel, num_args, cl_uint)
-PARAM_TRAITS_SPEC(kernel, reference_count, cl_uint)
-PARAM_TRAITS_SPEC(kernel, attributes, string_class)
-// Shilei: The following two traits are not covered in the current version of
-// CTS (SYCL-1.2.1/master)
-PARAM_TRAITS_SPEC(kernel, context, cl::sycl::context)
-PARAM_TRAITS_SPEC(kernel, program, cl::sycl::program)
-
-PARAM_TRAITS_SPEC(kernel_work_group, compile_work_group_size,
-                  cl::sycl::range<3>)
-PARAM_TRAITS_SPEC(kernel_work_group, global_work_size, cl::sycl::range<3>)
-PARAM_TRAITS_SPEC(kernel_work_group, preferred_work_group_size_multiple, size_t)
-PARAM_TRAITS_SPEC(kernel_work_group, private_mem_size, cl_ulong)
-PARAM_TRAITS_SPEC(kernel_work_group, work_group_size, size_t)
-
-PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, max_sub_group_size_for_ndrange,
-                             size_t, cl::sycl::range<3>)
-PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, sub_group_count_for_ndrange,
-                             size_t, cl::sycl::range<3>)
-PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, local_size_for_sub_group_count,
-                             cl::sycl::range<3>, size_t)
-PARAM_TRAITS_SPEC(kernel_sub_group, max_num_sub_groups, size_t)
-PARAM_TRAITS_SPEC(kernel_sub_group, compile_num_sub_groups, size_t)
-PARAM_TRAITS_SPEC(kernel_sub_group, compile_sub_group_size, size_t)
+#include <CL/sycl/info/kernel_traits.def>
+#include <CL/sycl/info/kernel_work_group_traits.def>
+#include <CL/sycl/info/kernel_sub_group_traits.def>
 
 PARAM_TRAITS_SPEC(platform, profile, string_class)
 PARAM_TRAITS_SPEC(platform, version, string_class)
@@ -308,6 +286,7 @@ PARAM_TRAITS_SPEC(queue, context, cl::sycl::context)
 PARAM_TRAITS_SPEC(queue, device, cl::sycl::device)
 
 #undef PARAM_TRAITS_SPEC
+#undef PARAM_TRAITS_SPEC_WITH_INPUT
 
 } // namespace info
 } // namespace sycl

--- a/sycl/include/CL/sycl/info/kernel_sub_group_traits.def
+++ b/sycl/include/CL/sycl/info/kernel_sub_group_traits.def
@@ -1,0 +1,10 @@
+PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, max_sub_group_size_for_ndrange,
+                             size_t, cl::sycl::range<3>)
+PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, sub_group_count_for_ndrange,
+                             size_t, cl::sycl::range<3>)
+PARAM_TRAITS_SPEC_WITH_INPUT(kernel_sub_group, local_size_for_sub_group_count,
+                             cl::sycl::range<3>, size_t)
+PARAM_TRAITS_SPEC(kernel_sub_group, max_num_sub_groups, size_t)
+PARAM_TRAITS_SPEC(kernel_sub_group, compile_num_sub_groups, size_t)
+PARAM_TRAITS_SPEC(kernel_sub_group, compile_sub_group_size, size_t)
+

--- a/sycl/include/CL/sycl/info/kernel_traits.def
+++ b/sycl/include/CL/sycl/info/kernel_traits.def
@@ -1,0 +1,9 @@
+PARAM_TRAITS_SPEC(kernel, function_name, string_class)
+PARAM_TRAITS_SPEC(kernel, num_args, cl_uint)
+PARAM_TRAITS_SPEC(kernel, reference_count, cl_uint)
+PARAM_TRAITS_SPEC(kernel, attributes, string_class)
+// Shilei: The following two traits are not covered in the current version of
+// CTS (SYCL-1.2.1/master)
+PARAM_TRAITS_SPEC(kernel, context, cl::sycl::context)
+PARAM_TRAITS_SPEC(kernel, program, cl::sycl::program)
+

--- a/sycl/include/CL/sycl/info/kernel_traits.def
+++ b/sycl/include/CL/sycl/info/kernel_traits.def
@@ -2,8 +2,6 @@ PARAM_TRAITS_SPEC(kernel, function_name, string_class)
 PARAM_TRAITS_SPEC(kernel, num_args, cl_uint)
 PARAM_TRAITS_SPEC(kernel, reference_count, cl_uint)
 PARAM_TRAITS_SPEC(kernel, attributes, string_class)
-// Shilei: The following two traits are not covered in the current version of
-// CTS (SYCL-1.2.1/master)
 PARAM_TRAITS_SPEC(kernel, context, cl::sycl::context)
 PARAM_TRAITS_SPEC(kernel, program, cl::sycl::program)
 

--- a/sycl/include/CL/sycl/info/kernel_work_group_traits.def
+++ b/sycl/include/CL/sycl/info/kernel_work_group_traits.def
@@ -1,0 +1,7 @@
+PARAM_TRAITS_SPEC(kernel_work_group, compile_work_group_size,
+                  cl::sycl::range<3>)
+PARAM_TRAITS_SPEC(kernel_work_group, global_work_size, cl::sycl::range<3>)
+PARAM_TRAITS_SPEC(kernel_work_group, preferred_work_group_size_multiple, size_t)
+PARAM_TRAITS_SPEC(kernel_work_group, private_mem_size, cl_ulong)
+PARAM_TRAITS_SPEC(kernel_work_group, work_group_size, size_t)
+

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -46,7 +46,7 @@ public:
 
   bool operator!=(const kernel &RHS) const { return !operator==(RHS); }
 
-  /// Get a valid OpenCL interoperability kernel
+  /// Get a valid OpenCL kernel handle
   ///
   /// The requirements for this method are described in section 4.3.1
   /// of the SYCL specification.
@@ -54,9 +54,9 @@ public:
   /// @return a valid cl_kernel instance
   cl_kernel get() const;
 
-  /// Check if this kernel is a SYCL host device kernel
+  /// Check if the associated SYCL context is a SYCL host context.
   ///
-  /// @return true if a kernel is a valid SYCL host device kernel
+  /// @return true if this SYCL kernel is a host kernel.
   bool is_host() const;
 
   /// Get the context that this kernel is defined for.
@@ -78,29 +78,35 @@ public:
   /// Query information from the kernel object using the info::kernel_info
   /// descriptor.
   ///
-  /// Valid template parameters are described in Table 4.84 of the SYCL
-  /// specification.
+  /// @return depends on information being queried.
   template <info::kernel param>
   typename info::param_traits<info::kernel, param>::return_type
   get_info() const;
 
-  /// Query information from the work-group from a kernel using the
+  /// Query work-group information from a kernel using the
   /// info::kernel_work_group descriptor for a specific device.
   ///
-  /// Valid template parameters are described in Table 4.85 of the SYCL
-  /// specification.
+  /// @param Deivce is a valid SYCL device.
+  /// @return depends on information being queried.
   template <info::kernel_work_group param>
   typename info::param_traits<info::kernel_work_group, param>::return_type
   get_work_group_info(const device &Device) const;
 
-  /// Query information from the sub-group from a kernel using the
+  /// Query sub-group information from a kernel using the
   /// info::kernel_sub_group descriptor for a specific device.
+  ///
+  /// @param Deivce is a valid SYCL device.
+  /// @return depends on information being queried.
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(const device &Device) const;
 
-  /// Query information from the sub-group from a kernel using the
-  /// info::kernel_sub_group descriptor for a specific device.
+  /// Query sub-group information from a kernel using the
+  /// info::kernel_sub_group descriptor for a specific device and value.
+  ///
+  /// @param Deivce is a valid SYCL device.
+  /// @param Value depends on information being queried.
+  /// @return depends on information being queried.
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -12,6 +12,8 @@
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
+#include <memory>
+
 namespace cl {
 namespace sycl {
 // Forward declaration
@@ -22,11 +24,6 @@ class kernel_impl;
 }
 
 class kernel {
-  template <class Obj>
-  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
-  template <class T>
-  friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
-
 public:
   /// Constructs a SYCL kernel instance from an OpenCL cl_kernel
   ///
@@ -45,9 +42,9 @@ public:
 
   kernel &operator=(kernel &&RHS) = default;
 
-  bool operator==(const kernel &RHS) const;
+  bool operator==(const kernel &RHS) const { return impl == RHS.impl; }
 
-  bool operator!=(const kernel &RHS) const;
+  bool operator!=(const kernel &RHS) const { return !operator==(RHS); }
 
   /// Get a valid OpenCL interoperability kernel
   ///
@@ -116,6 +113,11 @@ private:
   kernel(std::shared_ptr<detail::kernel_impl> Impl);
 
   shared_ptr_class<detail::kernel_impl> impl;
+
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
+  template <class T>
+  friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 };
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/stl.hpp>
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 
 #include <memory>
 
@@ -18,6 +19,9 @@ namespace sycl {
 // Forward declaration
 class program;
 class context;
+namespace detail {
+class kernel_impl;
+}
 
 class kernel {
   template <class Obj>

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -12,8 +12,6 @@
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
-#include <memory>
-
 namespace cl {
 namespace sycl {
 // Forward declaration
@@ -117,7 +115,7 @@ private:
   /// Constructs a SYCL kernel object from a valid kernel_impl instance.
   kernel(std::shared_ptr<detail::kernel_impl> Impl);
 
-  std::shared_ptr<detail::kernel_impl> impl;
+  shared_ptr_class<detail::kernel_impl> impl;
 };
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <CL/sycl/stl.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/info/info_desc.hpp>
+#include <CL/sycl/stl.hpp>
 
 #include <memory>
 
@@ -80,7 +80,8 @@ public:
   /// @return a valid SYCL program
   program get_program() const;
 
-  /// Query information from the kernel object using the info::kernel_info descriptor.
+  /// Query information from the kernel object using the info::kernel_info
+  /// descriptor.
   ///
   /// Valid template parameters are described in Table 4.84 of the SYCL
   /// specification.
@@ -107,9 +108,10 @@ public:
   /// info::kernel_sub_group descriptor for a specific device.
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
-  get_sub_group_info(const device &Device,
-                     typename info::param_traits<info::kernel_sub_group,
-                                                 param>::input_type Value) const;
+  get_sub_group_info(
+      const device &Device,
+      typename info::param_traits<info::kernel_sub_group, param>::input_type
+          Value) const;
 
 private:
   /// Constructs a SYCL kernel object from a valid kernel_impl instance.

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -26,19 +26,19 @@ class kernel {
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
 public:
-  kernel(cl_kernel clKernel, const context &syclContext);
+  kernel(cl_kernel ClKernel, const context &SyclContext);
 
-  kernel(const kernel &rhs) = default;
+  kernel(const kernel &RHS) = default;
 
-  kernel(kernel &&rhs) = default;
+  kernel(kernel &&RHS) = default;
 
-  kernel &operator=(const kernel &rhs) = default;
+  kernel &operator=(const kernel &RHS) = default;
 
-  kernel &operator=(kernel &&rhs) = default;
+  kernel &operator=(kernel &&RHS) = default;
 
-  bool operator==(const kernel &rhs) const;
+  bool operator==(const kernel &RHS) const;
 
-  bool operator!=(const kernel &rhs) const;
+  bool operator!=(const kernel &RHS) const;
 
   cl_kernel get() const;
 
@@ -54,20 +54,20 @@ public:
 
   template <info::kernel_work_group param>
   typename info::param_traits<info::kernel_work_group, param>::return_type
-  get_work_group_info(const device &dev) const;
+  get_work_group_info(const device &Device) const;
 
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
-  get_sub_group_info(const device &dev) const;
+  get_sub_group_info(const device &Device) const;
 
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
-  get_sub_group_info(const device &dev,
+  get_sub_group_info(const device &Device,
                      typename info::param_traits<info::kernel_sub_group,
-                                                 param>::input_type val) const;
+                                                 param>::input_type Value) const;
 
 private:
-  kernel(std::shared_ptr<detail::kernel_impl> impl);
+  kernel(std::shared_ptr<detail::kernel_impl> Impl);
 
   std::shared_ptr<detail::kernel_impl> impl;
 };
@@ -76,9 +76,9 @@ private:
 
 namespace std {
 template <> struct hash<cl::sycl::kernel> {
-  size_t operator()(const cl::sycl::kernel &k) const {
+  size_t operator()(const cl::sycl::kernel &Kernel) const {
     return hash<std::shared_ptr<cl::sycl::detail::kernel_impl>>()(
-        cl::sycl::detail::getSyclObjImpl(k));
+        cl::sycl::detail::getSyclObjImpl(Kernel));
   }
 };
 } // namespace std

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -30,6 +30,13 @@ class kernel {
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
 public:
+  /// Constructs a SYCL kernel instance from an OpenCL cl_kernel
+  ///
+  /// The requirements for this constructor are described in section 4.3.1
+  /// of the SYCL specification.
+  ///
+  /// @param ClKernel is a valid OpenCL cl_kernel instance
+  /// @param SyclContext is a valid SYCL context
   kernel(cl_kernel ClKernel, const context &SyclContext);
 
   kernel(const kernel &RHS) = default;
@@ -44,26 +51,60 @@ public:
 
   bool operator!=(const kernel &RHS) const;
 
+  /// Get a valid OpenCL interoperability kernel
+  ///
+  /// The requirements for this method are described in section 4.3.1
+  /// of the SYCL specification.
+  ///
+  /// @return a valid cl_kernel instance
   cl_kernel get() const;
 
+  /// Check if this kernel is a SYCL host device kernel
+  ///
+  /// @return true if a kernel is a valid SYCL host device kernel
   bool is_host() const;
 
+  /// Get the context that this kernel is defined for.
+  ///
+  /// The value returned must be equal to that returned by
+  /// get_info<info::kernel::context>().
+  ///
+  /// @return a valid SYCL context
   context get_context() const;
 
+  /// Get the program that this kernel is defined for.
+  ///
+  /// The value returned must be equal to that returned by
+  /// get_info<info::kernel::program>().
+  ///
+  /// @return a valid SYCL program
   program get_program() const;
 
+  /// Query information from the kernel object using the info::kernel_info descriptor.
+  ///
+  /// Valid template parameters are described in Table 4.84 of the SYCL
+  /// specification.
   template <info::kernel param>
   typename info::param_traits<info::kernel, param>::return_type
   get_info() const;
 
+  /// Query information from the work-group from a kernel using the
+  /// info::kernel_work_group descriptor for a specific device.
+  ///
+  /// Valid template parameters are described in Table 4.85 of the SYCL
+  /// specification.
   template <info::kernel_work_group param>
   typename info::param_traits<info::kernel_work_group, param>::return_type
   get_work_group_info(const device &Device) const;
 
+  /// Query information from the sub-group from a kernel using the
+  /// info::kernel_sub_group descriptor for a specific device.
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(const device &Device) const;
 
+  /// Query information from the sub-group from a kernel using the
+  /// info::kernel_sub_group descriptor for a specific device.
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(const device &Device,
@@ -71,6 +112,7 @@ public:
                                                  param>::input_type Value) const;
 
 private:
+  /// Constructs a SYCL kernel object from a valid kernel_impl instance.
   kernel(std::shared_ptr<detail::kernel_impl> Impl);
 
   std::shared_ptr<detail::kernel_impl> impl;

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -26,9 +26,7 @@ class kernel {
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
 public:
-  kernel(cl_kernel clKernel, const context &syclContext)
-      : impl(std::make_shared<detail::kernel_impl>(
-            detail::pi::cast<detail::RT::PiKernel>(clKernel), syclContext)) {}
+  kernel(cl_kernel clKernel, const context &syclContext);
 
   kernel(const kernel &rhs) = default;
 
@@ -38,46 +36,38 @@ public:
 
   kernel &operator=(kernel &&rhs) = default;
 
-  bool operator==(const kernel &rhs) const { return impl == rhs.impl; }
+  bool operator==(const kernel &rhs) const;
 
-  bool operator!=(const kernel &rhs) const { return !operator==(rhs); }
+  bool operator!=(const kernel &rhs) const;
 
-  cl_kernel get() const { return impl->get(); }
+  cl_kernel get() const;
 
-  bool is_host() const { return impl->is_host(); }
+  bool is_host() const;
 
-  context get_context() const { return impl->get_context(); }
+  context get_context() const;
 
   program get_program() const;
 
   template <info::kernel param>
   typename info::param_traits<info::kernel, param>::return_type
-  get_info() const {
-    return impl->get_info<param>();
-  }
+  get_info() const;
 
   template <info::kernel_work_group param>
   typename info::param_traits<info::kernel_work_group, param>::return_type
-  get_work_group_info(const device &dev) const {
-    return impl->get_work_group_info<param>(dev);
-  }
+  get_work_group_info(const device &dev) const;
 
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
-  get_sub_group_info(const device &dev) const {
-    return impl->get_sub_group_info<param>(dev);
-  }
+  get_sub_group_info(const device &dev) const;
 
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
   get_sub_group_info(const device &dev,
                      typename info::param_traits<info::kernel_sub_group,
-                                                 param>::input_type val) const {
-    return impl->get_sub_group_info<param>(dev, val);
-  }
+                                                 param>::input_type val) const;
 
 private:
-  kernel(std::shared_ptr<detail::kernel_impl> impl) : impl(impl) {}
+  kernel(std::shared_ptr<detail::kernel_impl> impl);
 
   std::shared_ptr<detail::kernel_impl> impl;
 };

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -87,7 +87,7 @@ public:
   /// Query work-group information from a kernel using the
   /// info::kernel_work_group descriptor for a specific device.
   ///
-  /// @param Deivce is a valid SYCL device.
+  /// @param Device is a valid SYCL device.
   /// @return depends on information being queried.
   template <info::kernel_work_group param>
   typename info::param_traits<info::kernel_work_group, param>::return_type
@@ -96,7 +96,7 @@ public:
   /// Query sub-group information from a kernel using the
   /// info::kernel_sub_group descriptor for a specific device.
   ///
-  /// @param Deivce is a valid SYCL device.
+  /// @param Device is a valid SYCL device.
   /// @return depends on information being queried.
   template <info::kernel_sub_group param>
   typename info::param_traits<info::kernel_sub_group, param>::return_type
@@ -105,7 +105,7 @@ public:
   /// Query sub-group information from a kernel using the
   /// info::kernel_sub_group descriptor for a specific device and value.
   ///
-  /// @param Deivce is a valid SYCL device.
+  /// @param Device is a valid SYCL device.
   /// @param Value depends on information being queried.
   /// @return depends on information being queried.
   template <info::kernel_sub_group param>

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -48,8 +48,9 @@ public:
 
   /// Get a valid OpenCL kernel handle
   ///
-  /// The requirements for this method are described in section 4.3.1
-  /// of the SYCL specification.
+  /// If this kernel encapsulates an instance of OpenCL kernel, a valid
+  /// cl_kernel will be returned. If this kernel is a host kernel,
+  /// an invalid_object_error exception will be thrown.
   ///
   /// @return a valid cl_kernel instance
   cl_kernel get() const;

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -26,8 +26,9 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext)
 kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
                          std::shared_ptr<program_impl> ProgramImpl,
                          bool IsCreatedFromSource)
-    : MKernel(Kernel), MContext(SyclContext), MProgramImpl(ProgramImpl),
-      MIsCreatedFromSource(IsCreatedFromSource) {
+    : MKernel(Kernel), MContext(SyclContext),
+      MProgramImpl(std::move(ProgramImpl)),
+      MCreatedFromSource(IsCreatedFromSource) {
 
   RT::PiContext Context = nullptr;
   PI_CALL(RT::piKernelGetInfo, MKernel, CL_KERNEL_CONTEXT, sizeof(Context),
@@ -41,7 +42,7 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
 
 kernel_impl::kernel_impl(const context &SyclContext,
                          std::shared_ptr<program_impl> ProgramImpl)
-    : MContext(SyclContext), MProgramImpl(ProgramImpl) {}
+    : MContext(SyclContext), MProgramImpl(std::move(ProgramImpl)) {}
 
 kernel_impl::~kernel_impl() {
   // TODO catch an exception and put it to list of asynchronous exceptions
@@ -152,7 +153,7 @@ bool kernel_impl::isCreatedFromSource() const {
   // kernel SecondKernel = kernel(ClKernel, Context);
   // clReleaseKernel(ClKernel);
   // FirstKernel.isCreatedFromSource() != FirstKernel.isCreatedFromSource();
-  return MIsCreatedFromSource;
+  return MCreatedFromSource;
 }
 
 } // namespace detail

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -26,8 +26,8 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext)
 kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
                          std::shared_ptr<program_impl> ProgramImpl,
                          bool IsCreatedFromSource)
-    : Kernel(Kernel), Context(SyclContext), ProgramImpl(ProgramImpl),
-      IsCreatedFromSource(IsCreatedFromSource) {
+    : MKernel(Kernel), MContext(SyclContext), MProgramImpl(ProgramImpl),
+      MIsCreatedFromSource(IsCreatedFromSource) {
 
   RT::PiContext Context = nullptr;
   PI_CALL(RT::piKernelGetInfo, Kernel, CL_KERNEL_CONTEXT, sizeof(Context),
@@ -36,7 +36,7 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
   if (ContextImpl->getHandleRef() != Context)
     throw cl::sycl::invalid_parameter_error(
         "Input context must be the same as the context of cl_kernel");
-  PI_CALL(RT::piKernelRetain, Kernel);
+  PI_CALL(RT::piKernelRetain, MKernel);
 }
 
 kernel_impl::kernel_impl(const context &SyclContext,
@@ -46,12 +46,12 @@ kernel_impl::kernel_impl(const context &SyclContext,
 kernel_impl::~kernel_impl() {
   // TODO catch an exception and put it to list of asynchronous exceptions
   if (!is_host()) {
-    PI_CALL(RT::piKernelRelease, Kernel);
+    PI_CALL(RT::piKernelRelease, MKernel);
   }
 }
 
 program kernel_impl::get_program() const {
-  return createSyclObjFromImpl<program>(ProgramImpl);
+  return createSyclObjFromImpl<program>(MProgramImpl);
 }
 
 template <info::kernel param>
@@ -152,7 +152,7 @@ bool kernel_impl::isCreatedFromSource() const {
   // kernel SecondKernel = kernel(ClKernel, Context);
   // clReleaseKernel(ClKernel);
   // FirstKernel.isCreatedFromSource() != FirstKernel.isCreatedFromSource();
-  return IsCreatedFromSource;
+  return MIsCreatedFromSource;
 }
 
 } // namespace detail

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -6,10 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl/detail/kernel_impl.hpp>
-
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
+#include <CL/sycl/detail/kernel_info.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/program.hpp>
+
 #include <memory>
 
 namespace cl {
@@ -21,8 +23,47 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext)
                   std::make_shared<program_impl>(SyclContext, Kernel),
                   /*IsCreatedFromSource*/ true) {}
 
+kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
+                         std::shared_ptr<program_impl> ProgramImpl,
+                         bool IsCreatedFromSource)
+    : Kernel(Kernel), Context(SyclContext), ProgramImpl(ProgramImpl),
+      IsCreatedFromSource(IsCreatedFromSource) {
+
+  RT::PiContext Context = nullptr;
+  PI_CALL(RT::piKernelGetInfo, Kernel, CL_KERNEL_CONTEXT, sizeof(Context),
+          &Context, nullptr);
+  auto ContextImpl = detail::getSyclObjImpl(SyclContext);
+  if (ContextImpl->getHandleRef() != Context)
+    throw cl::sycl::invalid_parameter_error(
+        "Input context must be the same as the context of cl_kernel");
+  PI_CALL(RT::piKernelRetain, Kernel);
+}
+
+kernel_impl::kernel_impl(const context &SyclContext,
+                         std::shared_ptr<program_impl> ProgramImpl)
+    : Context(SyclContext), ProgramImpl(ProgramImpl) {}
+
+kernel_impl::~kernel_impl() {
+  // TODO catch an exception and put it to list of asynchronous exceptions
+  if (!is_host()) {
+    PI_CALL(RT::piKernelRelease, Kernel);
+  }
+}
+
 program kernel_impl::get_program() const {
   return createSyclObjFromImpl<program>(ProgramImpl);
+}
+
+template <info::kernel param>
+typename info::param_traits<info::kernel, param>::return_type
+kernel_impl::get_info() const {
+  if (is_host()) {
+    // TODO implement
+    assert(0 && "Not implemented");
+  }
+  return get_kernel_info<
+      typename info::param_traits<info::kernel, param>::return_type,
+      param>::_(this->getHandleRef());
 }
 
 template <> context kernel_impl::get_info<info::kernel::context>() const {
@@ -32,6 +73,71 @@ template <> context kernel_impl::get_info<info::kernel::context>() const {
 template <> program kernel_impl::get_info<info::kernel::program>() const {
   return get_program();
 }
+
+template <info::kernel_work_group param>
+typename info::param_traits<info::kernel_work_group, param>::return_type
+kernel_impl::get_work_group_info(const device &Device) const {
+  if (is_host()) {
+    return get_kernel_work_group_info_host<param>(Device);
+  }
+  return get_kernel_work_group_info<
+      typename info::param_traits<info::kernel_work_group, param>::return_type,
+      param>::_(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef());
+}
+
+template <info::kernel_sub_group param>
+typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel_impl::get_sub_group_info(const device &Device) const {
+  if (is_host()) {
+    throw runtime_error("Sub-group feature is not supported on HOST device.");
+  }
+  return get_kernel_sub_group_info<
+      typename info::param_traits<info::kernel_sub_group, param>::return_type,
+      param>::_(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef());
+}
+
+template <info::kernel_sub_group param>
+typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel_impl::get_sub_group_info(
+    const device &Device,
+    typename info::param_traits<info::kernel_sub_group, param>::input_type
+        Value) const {
+  if (is_host()) {
+    throw runtime_error("Sub-group feature is not supported on HOST device.");
+  }
+  return get_kernel_sub_group_info_with_input<
+      typename info::param_traits<info::kernel_sub_group, param>::return_type,
+      param,
+      typename info::param_traits<info::kernel_sub_group, param>::input_type>::
+      _(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(), Value);
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel_impl::get_info<info::param_type::param>() const;
+
+#include <CL/sycl/info/kernel_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel_impl::get_work_group_info<info::param_type::param>( \
+      const device &) const;
+
+#include <CL/sycl/info/kernel_work_group_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel_impl::get_sub_group_info<info::param_type::param>(  \
+      const device &) const;
+#define PARAM_TRAITS_SPEC_WITH_INPUT(param_type, param, ret_type, in_type)     \
+  template ret_type kernel_impl::get_sub_group_info<info::param_type::param>(  \
+      const device &, in_type) const;
+
+#include <CL/sycl/info/kernel_sub_group_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+#undef PARAM_TRAITS_SPEC_WITH_INPUT
 
 bool kernel_impl::isCreatedFromSource() const {
   // TODO it is not clear how to understand whether the SYCL kernel is created

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -30,7 +30,7 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
       MIsCreatedFromSource(IsCreatedFromSource) {
 
   RT::PiContext Context = nullptr;
-  PI_CALL(RT::piKernelGetInfo, Kernel, CL_KERNEL_CONTEXT, sizeof(Context),
+  PI_CALL(RT::piKernelGetInfo, MKernel, CL_KERNEL_CONTEXT, sizeof(Context),
           &Context, nullptr);
   auto ContextImpl = detail::getSyclObjImpl(SyclContext);
   if (ContextImpl->getHandleRef() != Context)
@@ -41,7 +41,7 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
 
 kernel_impl::kernel_impl(const context &SyclContext,
                          std::shared_ptr<program_impl> ProgramImpl)
-    : Context(SyclContext), ProgramImpl(ProgramImpl) {}
+    : MContext(SyclContext), MProgramImpl(ProgramImpl) {}
 
 kernel_impl::~kernel_impl() {
   // TODO catch an exception and put it to list of asynchronous exceptions

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -51,10 +51,6 @@ kernel_impl::~kernel_impl() {
   }
 }
 
-program kernel_impl::get_program() const {
-  return createSyclObjFromImpl<program>(MProgramImpl);
-}
-
 template <info::kernel param>
 typename info::param_traits<info::kernel, param>::return_type
 kernel_impl::get_info() const {
@@ -68,11 +64,11 @@ kernel_impl::get_info() const {
 }
 
 template <> context kernel_impl::get_info<info::kernel::context>() const {
-  return get_context();
+  return MContext;
 }
 
 template <> program kernel_impl::get_info<info::kernel::program>() const {
-  return get_program();
+  return createSyclObjFromImpl<program>(MProgramImpl);
 }
 
 template <info::kernel_work_group param>

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -821,7 +821,7 @@ cl_int ExecCGCommand::enqueueImp() {
     RT::PiKernel Kernel = nullptr;
 
     if (nullptr != ExecKernel->MSyclKernel) {
-      assert(ExecKernel->MSyclKernel->get_context() == Context);
+      assert(ExecKernel->MSyclKernel->get_info<info::kernel::context>() == Context);
       Kernel = ExecKernel->MSyclKernel->getHandleRef();
     } else
       Kernel = detail::ProgramManager::getInstance().getOrCreateKernel(

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -821,7 +821,7 @@ cl_int ExecCGCommand::enqueueImp() {
     RT::PiKernel Kernel = nullptr;
 
     if (nullptr != ExecKernel->MSyclKernel) {
-      assert(ExecKernel->get_context() == Context);
+      assert(ExecKernel->MSyclKernel->get_info<info::kernel::context>() == Context);
       Kernel = ExecKernel->MSyclKernel->getHandleRef();
     } else
       Kernel = detail::ProgramManager::getInstance().getOrCreateKernel(

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -821,7 +821,7 @@ cl_int ExecCGCommand::enqueueImp() {
     RT::PiKernel Kernel = nullptr;
 
     if (nullptr != ExecKernel->MSyclKernel) {
-      assert(ExecKernel->MSyclKernel->get_info<info::kernel::context>() == Context);
+      assert(ExecKernel->get_context() == Context);
       Kernel = ExecKernel->MSyclKernel->getHandleRef();
     } else
       Kernel = detail::ProgramManager::getInstance().getOrCreateKernel(

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -21,7 +21,13 @@ cl_kernel kernel::get() const { return impl->get(); }
 
 bool kernel::is_host() const { return impl->is_host(); }
 
-context kernel::get_context() const { return impl->get_context(); }
+context kernel::get_context() const {
+  return impl->get_info<info::kernel::context>();
+}
+
+program kernel::get_program() const {
+  return impl->get_info<info::kernel::program>();
+}
 
 template <info::kernel param>
 typename info::param_traits<info::kernel, param>::return_type
@@ -78,8 +84,6 @@ kernel::get_sub_group_info(
 #undef PARAM_TRAITS_SPEC_WITH_INPUT
 
 kernel::kernel(std::shared_ptr<detail::kernel_impl> Impl) : impl(Impl) {}
-
-program kernel::get_program() const { return impl->get_program(); }
 
 } // namespace sycl
 } // namespace cl

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -6,16 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/program.hpp>
-#include <CL/sycl/detail/kernel_impl.hpp>
 
 namespace cl {
 namespace sycl {
 
 kernel::kernel(cl_kernel ClKernel, const context &SyclContext)
     : impl(std::make_shared<detail::kernel_impl>(
-        detail::pi::cast<detail::RT::PiKernel>(ClKernel), SyclContext)) {}
+          detail::pi::cast<detail::RT::PiKernel>(ClKernel), SyclContext)) {}
 
 bool kernel::operator==(const kernel &RHS) const { return impl == RHS.impl; }
 
@@ -27,16 +27,14 @@ bool kernel::is_host() const { return impl->is_host(); }
 
 context kernel::get_context() const { return impl->get_context(); }
 
-
 template <info::kernel param>
 typename info::param_traits<info::kernel, param>::return_type
 kernel::get_info() const {
   return impl->get_info<param>();
 }
 
-#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
-    template \
-    ret_type kernel::get_info<info::param_type::param>() const;
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel::get_info<info::param_type::param>() const;
 
 #include <CL/sycl/info/kernel_traits.def>
 
@@ -48,9 +46,9 @@ kernel::get_work_group_info(const device &dev) const {
   return impl->get_work_group_info<param>(dev);
 }
 
-#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
-    template \
-    ret_type kernel::get_work_group_info<info::param_type::param>(const device &) const;
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel::get_work_group_info<info::param_type::param>(      \
+      const device &) const;
 
 #include <CL/sycl/info/kernel_work_group_traits.def>
 
@@ -64,18 +62,19 @@ kernel::get_sub_group_info(const device &dev) const {
 
 template <info::kernel_sub_group param>
 typename info::param_traits<info::kernel_sub_group, param>::return_type
-kernel::get_sub_group_info(const device &dev,
-                    typename info::param_traits<info::kernel_sub_group,
-                                                param>::input_type val) const {
+kernel::get_sub_group_info(
+    const device &dev,
+    typename info::param_traits<info::kernel_sub_group, param>::input_type val)
+    const {
   return impl->get_sub_group_info<param>(dev, val);
 }
 
-#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
-    template \
-    ret_type kernel::get_sub_group_info<info::param_type::param>(const device &) const;
-#define PARAM_TRAITS_SPEC_WITH_INPUT(param_type, param, ret_type, in_type) \
-    template \
-    ret_type kernel::get_sub_group_info<info::param_type::param>(const device &, in_type) const;
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type kernel::get_sub_group_info<info::param_type::param>(       \
+      const device &) const;
+#define PARAM_TRAITS_SPEC_WITH_INPUT(param_type, param, ret_type, in_type)     \
+  template ret_type kernel::get_sub_group_info<info::param_type::param>(       \
+      const device &, in_type) const;
 
 #include <CL/sycl/info/kernel_sub_group_traits.def>
 

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -13,13 +13,13 @@
 namespace cl {
 namespace sycl {
 
-kernel::kernel(cl_kernel clKernel, const context &syclContext)
+kernel::kernel(cl_kernel ClKernel, const context &SyclContext)
     : impl(std::make_shared<detail::kernel_impl>(
-        detail::pi::cast<detail::RT::PiKernel>(clKernel), syclContext)) {}
+        detail::pi::cast<detail::RT::PiKernel>(ClKernel), SyclContext)) {}
 
-bool kernel::operator==(const kernel &rhs) const { return impl == rhs.impl; }
+bool kernel::operator==(const kernel &RHS) const { return impl == RHS.impl; }
 
-bool kernel::operator!=(const kernel &rhs) const { return !operator==(rhs); }
+bool kernel::operator!=(const kernel &RHS) const { return !operator==(RHS); }
 
 cl_kernel kernel::get() const { return impl->get(); }
 
@@ -82,7 +82,7 @@ kernel::get_sub_group_info(const device &dev,
 #undef PARAM_TRAITS_SPEC
 #undef PARAM_TRAITS_SPEC_WITH_INPUT
 
-kernel::kernel(std::shared_ptr<detail::kernel_impl> impl) : impl(impl) {}
+kernel::kernel(std::shared_ptr<detail::kernel_impl> Impl) : impl(Impl) {}
 
 program kernel::get_program() const { return impl->get_program(); }
 

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/program.hpp>
-#include <CL/sycl/info/info_desc.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
 
 namespace cl {
 namespace sycl {

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -17,10 +17,6 @@ kernel::kernel(cl_kernel ClKernel, const context &SyclContext)
     : impl(std::make_shared<detail::kernel_impl>(
           detail::pi::cast<detail::RT::PiKernel>(ClKernel), SyclContext)) {}
 
-bool kernel::operator==(const kernel &RHS) const { return impl == RHS.impl; }
-
-bool kernel::operator!=(const kernel &RHS) const { return !operator==(RHS); }
-
 cl_kernel kernel::get() const { return impl->get(); }
 
 bool kernel::is_host() const { return impl->is_host(); }

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -7,11 +7,82 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl/kernel.hpp>
-
 #include <CL/sycl/program.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 
 namespace cl {
 namespace sycl {
+
+kernel::kernel(cl_kernel clKernel, const context &syclContext)
+    : impl(std::make_shared<detail::kernel_impl>(
+        detail::pi::cast<detail::RT::PiKernel>(clKernel), syclContext)) {}
+
+bool kernel::operator==(const kernel &rhs) const { return impl == rhs.impl; }
+
+bool kernel::operator!=(const kernel &rhs) const { return !operator==(rhs); }
+
+cl_kernel kernel::get() const { return impl->get(); }
+
+bool kernel::is_host() const { return impl->is_host(); }
+
+context kernel::get_context() const { return impl->get_context(); }
+
+
+template <info::kernel param>
+typename info::param_traits<info::kernel, param>::return_type
+kernel::get_info() const {
+  return impl->get_info<param>();
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
+    template \
+    ret_type kernel::get_info<info::param_type::param>() const;
+
+#include <CL/sycl/info/kernel_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+
+template <info::kernel_work_group param>
+typename info::param_traits<info::kernel_work_group, param>::return_type
+kernel::get_work_group_info(const device &dev) const {
+  return impl->get_work_group_info<param>(dev);
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
+    template \
+    ret_type kernel::get_work_group_info<info::param_type::param>(const device &) const;
+
+#include <CL/sycl/info/kernel_work_group_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+
+template <info::kernel_sub_group param>
+typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel::get_sub_group_info(const device &dev) const {
+  return impl->get_sub_group_info<param>(dev);
+}
+
+template <info::kernel_sub_group param>
+typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel::get_sub_group_info(const device &dev,
+                    typename info::param_traits<info::kernel_sub_group,
+                                                param>::input_type val) const {
+  return impl->get_sub_group_info<param>(dev, val);
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
+    template \
+    ret_type kernel::get_sub_group_info<info::param_type::param>(const device &) const;
+#define PARAM_TRAITS_SPEC_WITH_INPUT(param_type, param, ret_type, in_type) \
+    template \
+    ret_type kernel::get_sub_group_info<info::param_type::param>(const device &, in_type) const;
+
+#include <CL/sycl/info/kernel_sub_group_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+#undef PARAM_TRAITS_SPEC_WITH_INPUT
+
+kernel::kernel(std::shared_ptr<detail::kernel_impl> impl) : impl(impl) {}
 
 program kernel::get_program() const { return impl->get_program(); }
 


### PR DESCRIPTION
This patch is a part of effort to decouple SYCL Runtime library interface from its actual implementation. The goal is to improve SYCL ABI/API compatibility between different versions of library.

The following modifications were applied to kernel and kernel_impl classes:

1. Removed include of kernel_impl header from kernel.hpp and replaced it with forward declaration.
1. Move member function implementations from kernel.hpp to kernel.cpp
1. Documentation was improved for both kernel and kernel_impl
1. kernel_impl now tries to follow LLVM code style
1. Replace std::shared_ptr with shared_ptr_class for kernel class

Applying aforementioned changes requires modifying other header files. While some of those may seem as a regression, affected classes will be covered by future patches.

Signed-off-by: Alexander Batashev alexander.batashev@intel.com