### PR TITLE
[SYCL][Scheduler] Refactor data transfer scheduler commands

### DIFF
--- a/sycl/include/CL/sycl/detail/scheduler/commands.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.hpp
@@ -245,13 +245,12 @@ private:
 
 class MapMemObject : public Command {
 public:
-  MapMemObject(Requirement SrcReq, AllocaCommandBase *SrcAlloca,
-               Requirement *DstAcc, QueueImplPtr Queue);
+  MapMemObject(AllocaCommandBase *SrcAlloca, Requirement *Req, void **DstPtr,
+               QueueImplPtr Queue);
 
-  Requirement MSrcReq;
   AllocaCommandBase *MSrcAlloca = nullptr;
-  Requirement *MDstAcc = nullptr;
-  Requirement MDstReq;
+  void **MDstPtr = nullptr;
+  Requirement MReq;
 
   void printDot(std::ostream &Stream) const override;
 
@@ -261,18 +260,17 @@ private:
 
 class UnMapMemObject : public Command {
 public:
-  UnMapMemObject(Requirement SrcReq, AllocaCommandBase *SrcAlloca,
-                 Requirement *DstAcc, QueueImplPtr Queue,
-                 bool UseExclusiveQueue = false);
+  UnMapMemObject(AllocaCommandBase *DstAlloca, Requirement *Req, void **SrcPtr,
+                 QueueImplPtr Queue, bool UseExclusiveQueue = false);
 
   void printDot(std::ostream &Stream) const override;
 
 private:
   cl_int enqueueImp() override;
 
-  Requirement MSrcReq;
-  AllocaCommandBase *MSrcAlloca = nullptr;
-  Requirement *MDstAcc = nullptr;
+  AllocaCommandBase *MDstAlloca = nullptr;
+  Requirement MReq;
+  void **MSrcPtr = nullptr;
 };
 
 // The command enqueues memory copy between two instances of memory object.
@@ -304,14 +302,14 @@ private:
 class MemCpyCommandHost : public Command {
 public:
   MemCpyCommandHost(Requirement SrcReq, AllocaCommandBase *SrcAlloca,
-                    Requirement *DstAcc, QueueImplPtr SrcQueue,
+                    Requirement DstReq, void **DstPtr, QueueImplPtr SrcQueue,
                     QueueImplPtr DstQueue);
 
   QueueImplPtr MSrcQueue;
   Requirement MSrcReq;
   AllocaCommandBase *MSrcAlloca = nullptr;
   Requirement MDstReq;
-  Requirement *MDstAcc = nullptr;
+  void **MDstPtr = nullptr;
 
   void printDot(std::ostream &Stream) const override;
 
@@ -341,21 +339,20 @@ private:
 
 class UpdateHostRequirementCommand : public Command {
 public:
-  UpdateHostRequirementCommand(QueueImplPtr Queue, Requirement *Req,
-                               AllocaCommandBase *AllocaForReq)
+  UpdateHostRequirementCommand(QueueImplPtr Queue, AllocaCommandBase *AllocaCmd,
+                               Requirement *Req, void **DstPtr)
       : Command(CommandType::UPDATE_REQUIREMENT, std::move(Queue)),
-        MReqToUpdate(Req), MAllocaForReq(AllocaForReq),
-        MStoredRequirement(*Req) {}
+        MDstPtr(DstPtr), MAllocaCmd(AllocaCmd), MReq(*Req) {}
 
-  Requirement *getStoredRequirement() { return &MStoredRequirement; }
+  Requirement *getStoredRequirement() { return &MReq; }
 
 private:
   cl_int enqueueImp() override;
   void printDot(std::ostream &Stream) const override;
 
-  Requirement *MReqToUpdate = nullptr;
-  AllocaCommandBase *MAllocaForReq = nullptr;
-  Requirement MStoredRequirement;
+  void **MDstPtr = nullptr;
+  AllocaCommandBase *MAllocaCmd = nullptr;
+  Requirement MReq;
 };
 
 } // namespace detail

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -276,24 +276,22 @@ void ReleaseCommand::printDot(std::ostream &Stream) const {
   }
 }
 
-MapMemObject::MapMemObject(Requirement SrcReq, AllocaCommandBase *SrcAlloca,
-                           Requirement *DstAcc, QueueImplPtr Queue)
+MapMemObject::MapMemObject(AllocaCommandBase *SrcAlloca, Requirement *Req,
+                           void **DstPtr, QueueImplPtr Queue)
     : Command(CommandType::MAP_MEM_OBJ, std::move(Queue)),
-      MSrcReq(std::move(SrcReq)), MSrcAlloca(SrcAlloca), MDstAcc(DstAcc),
-      MDstReq(*DstAcc) {}
+      MSrcAlloca(SrcAlloca), MDstPtr(DstPtr), MReq(*Req) {}
 
 cl_int MapMemObject::enqueueImp() {
   std::vector<RT::PiEvent> RawEvents =
       Command::prepareEvents(detail::getSyclObjImpl(MQueue->get_context()));
-  assert(MDstReq.MDims == 1);
+  assert(MReq.MDims == 1);
 
   RT::PiEvent &Event = MEvent->getHandleRef();
   void *MappedPtr = MemoryManager::map(
       MSrcAlloca->getSYCLMemObj(), MSrcAlloca->getMemAllocation(), MQueue,
-      MDstReq.MAccessMode, MDstReq.MDims, MDstReq.MMemoryRange,
-      MDstReq.MAccessRange, MDstReq.MOffset, MDstReq.MElemSize,
-      std::move(RawEvents), Event);
-  MDstAcc->MData = MappedPtr;
+      MReq.MAccessMode, MReq.MDims, MReq.MMemoryRange, MReq.MAccessRange,
+      MReq.MOffset, MReq.MElemSize, std::move(RawEvents), Event);
+  *MDstPtr = MappedPtr;
   return CL_SUCCESS;
 }
 
@@ -313,19 +311,19 @@ void MapMemObject::printDot(std::ostream &Stream) const {
   }
 }
 
-UnMapMemObject::UnMapMemObject(Requirement SrcReq, AllocaCommandBase *SrcAlloca,
-                               Requirement *DstAcc, QueueImplPtr Queue,
+UnMapMemObject::UnMapMemObject(AllocaCommandBase *DstAlloca, Requirement *Req,
+                               void **SrcPtr, QueueImplPtr Queue,
                                bool UseExclusiveQueue)
     : Command(CommandType::UNMAP_MEM_OBJ, std::move(Queue), UseExclusiveQueue),
-      MSrcReq(std::move(SrcReq)), MSrcAlloca(SrcAlloca), MDstAcc(DstAcc) {}
+      MDstAlloca(DstAlloca), MReq(*Req), MSrcPtr(SrcPtr) {}
 
 cl_int UnMapMemObject::enqueueImp() {
   std::vector<RT::PiEvent> RawEvents =
       Command::prepareEvents(detail::getSyclObjImpl(MQueue->get_context()));
 
   RT::PiEvent &Event = MEvent->getHandleRef();
-  MemoryManager::unmap(MSrcAlloca->getSYCLMemObj(),
-                       MSrcAlloca->getMemAllocation(), MQueue, MDstAcc->MData,
+  MemoryManager::unmap(MDstAlloca->getSYCLMemObj(),
+                       MDstAlloca->getMemAllocation(), MQueue, *MSrcPtr,
                        std::move(RawEvents), MUseExclusiveQueue, Event);
   return CL_SUCCESS;
 }
@@ -429,9 +427,10 @@ cl_int UpdateHostRequirementCommand::enqueueImp() {
   RT::PiEvent &Event = MEvent->getHandleRef();
   Command::waitForEvents(MQueue, RawEvents, Event);
 
-  assert(MAllocaForReq && "Expected valid alloca command");
-  assert(MReqToUpdate && "Expected valid requirement");
-  MReqToUpdate->MData = MAllocaForReq->getMemAllocation();
+  assert(MAllocaCmd && "Expected valid alloca command");
+  assert(MAllocaCmd->getMemAllocation() && "Expected valid source pointer");
+  assert(MDstPtr && "Expected valid target pointer");
+  *MDstPtr = MAllocaCmd->getMemAllocation();
   return CL_SUCCESS;
 }
 
@@ -440,12 +439,11 @@ void UpdateHostRequirementCommand::printDot(std::ostream &Stream) const {
 
   Stream << "ID = " << this << "\n";
   Stream << "UPDATE REQ ON " << deviceToString(MQueue->get_device()) << "\\n";
-  bool IsReqOnBuffer = MStoredRequirement.MSYCLMemObj->getType() ==
-                       SYCLMemObjI::MemObjType::BUFFER;
+  bool IsReqOnBuffer =
+      MReq.MSYCLMemObj->getType() == SYCLMemObjI::MemObjType::BUFFER;
   Stream << "TYPE: " << (IsReqOnBuffer ? "Buffer" : "Image") << "\\n";
   if (IsReqOnBuffer)
-    Stream << "Is sub buffer: " << std::boolalpha
-           << MStoredRequirement.MIsSubBuffer << "\\n";
+    Stream << "Is sub buffer: " << std::boolalpha << MReq.MIsSubBuffer << "\\n";
 
   Stream << "\"];" << std::endl;
 
@@ -460,11 +458,12 @@ void UpdateHostRequirementCommand::printDot(std::ostream &Stream) const {
 
 MemCpyCommandHost::MemCpyCommandHost(Requirement SrcReq,
                                      AllocaCommandBase *SrcAlloca,
-                                     Requirement *DstAcc, QueueImplPtr SrcQueue,
+                                     Requirement DstReq, void **DstPtr,
+                                     QueueImplPtr SrcQueue,
                                      QueueImplPtr DstQueue)
     : Command(CommandType::COPY_MEMORY, std::move(DstQueue)),
       MSrcQueue(SrcQueue), MSrcReq(std::move(SrcReq)), MSrcAlloca(SrcAlloca),
-      MDstReq(*DstAcc), MDstAcc(DstAcc) {
+      MDstReq(std::move(DstReq)), MDstPtr(DstPtr) {
   if (!MSrcQueue->is_host())
     MEvent->setContextImpl(detail::getSyclObjImpl(MSrcQueue->get_context()));
 }
@@ -487,7 +486,7 @@ cl_int MemCpyCommandHost::enqueueImp() {
   MemoryManager::copy(
       MSrcAlloca->getSYCLMemObj(), MSrcAlloca->getMemAllocation(), MSrcQueue,
       MSrcReq.MDims, MSrcReq.MMemoryRange, MSrcReq.MAccessRange,
-      MSrcReq.MOffset, MSrcReq.MElemSize, MDstAcc->MData, MQueue, MDstReq.MDims,
+      MSrcReq.MOffset, MSrcReq.MElemSize, *MDstPtr, MQueue, MDstReq.MDims,
       MDstReq.MMemoryRange, MDstReq.MAccessRange, MDstReq.MOffset,
       MDstReq.MElemSize, std::move(RawEvents), MUseExclusiveQueue, Event);
   return CL_SUCCESS;

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -157,7 +157,7 @@ UpdateHostRequirementCommand *Scheduler::GraphBuilder::insertUpdateHostReqCmd(
       findAllocaForReq(Record, Req, Queue->get_context_impl());
   assert(AllocaCmd && "There must be alloca for requirement!");
   UpdateHostRequirementCommand *UpdateCommand =
-      new UpdateHostRequirementCommand(Queue, Req, AllocaCmd);
+      new UpdateHostRequirementCommand(Queue, AllocaCmd, Req, &Req->MData);
   // Need copy of requirement because after host accessor destructor call
   // dependencies become invalid if requirement is stored by pointer.
   Requirement *StoredReq = UpdateCommand->getStoredRequirement();
@@ -243,7 +243,7 @@ Command *Scheduler::GraphBuilder::addCopyBack(Requirement *Req) {
       findAllocaForReq(Record, Req, Record->MCurContext);
 
   std::unique_ptr<MemCpyCommandHost> MemCpyCmdUniquePtr(new MemCpyCommandHost(
-      *SrcAllocaCmd->getAllocationReq(), SrcAllocaCmd, Req,
+      *SrcAllocaCmd->getAllocationReq(), SrcAllocaCmd, *Req, &Req->MData,
       SrcAllocaCmd->getQueue(), std::move(HostQueue)));
 
   if (!MemCpyCmdUniquePtr)
@@ -286,7 +286,6 @@ Command *Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
 
   AllocaCommandBase *SrcAllocaCmd =
       getOrCreateAllocaForReq(Record, Req, SrcQueue);
-  Requirement *SrcReq = SrcAllocaCmd->getAllocationReq();
   if (SrcQueue->is_host()) {
     UpdateHostRequirementCommand *UpdateCmd =
         insertUpdateHostReqCmd(Record, Req, SrcQueue);
@@ -315,7 +314,7 @@ Command *Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
       Req->MSYCLMemObj->getType() == detail::SYCLMemObjI::MemObjType::BUFFER) {
 
     std::unique_ptr<MapMemObject> MapCmdUniquePtr(
-        new MapMemObject(*SrcReq, SrcAllocaCmd, Req, SrcQueue));
+        new MapMemObject(SrcAllocaCmd, Req, &Req->MData, SrcQueue));
 
     /*
     [SYCL] Use exclusive queues for blocked commands.
@@ -444,19 +443,19 @@ Command *Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
     */
 
     std::unique_ptr<UnMapMemObject> UnMapCmdUniquePtr(new UnMapMemObject(
-        *SrcReq, SrcAllocaCmd, Req, SrcQueue, /*UseExclusiveQueue*/ true));
+        SrcAllocaCmd, Req, &Req->MData, SrcQueue, /*UseExclusiveQueue*/ true));
 
     if (!MapCmdUniquePtr || !UnMapCmdUniquePtr)
       throw runtime_error("Out of host memory");
 
     MapMemObject *MapCmd = MapCmdUniquePtr.release();
     for (Command *Dep : Deps) {
-      MapCmd->addDep(DepDesc{Dep, &MapCmd->MDstReq, SrcAllocaCmd});
+      MapCmd->addDep(DepDesc{Dep, &MapCmd->MReq, SrcAllocaCmd});
       Dep->addUser(MapCmd);
     }
 
     Command *UnMapCmd = UnMapCmdUniquePtr.release();
-    UnMapCmd->addDep(DepDesc{MapCmd, &MapCmd->MDstReq, SrcAllocaCmd});
+    UnMapCmd->addDep(DepDesc{MapCmd, &MapCmd->MReq, SrcAllocaCmd});
     MapCmd->addUser(UnMapCmd);
 
     UpdateLeafs(Deps, Record, Req->MAccessMode);


### PR DESCRIPTION
Refactored update requirment, map and unmap commands to enable future optimizations of host memory allocations.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>