### PR TITLE
[SYCL] Define collective functors using std

### DIFF
--- a/sycl/include/CL/sycl/intel/functional.hpp
+++ b/sycl/include/CL/sycl/intel/functional.hpp
@@ -19,11 +19,18 @@ template <typename T = void> struct minimum {
   }
 };
 
+#if __cplusplus >= 201402L
 template <> struct minimum<void> {
-  template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return std::less<T>()(lhs, rhs) ? lhs : rhs;
+  struct is_transparent {};
+  template <typename T, typename U>
+  auto operator()(T &&lhs, U &&rhs) const ->
+      typename std::common_type<T &&, U &&>::type {
+    return std::less<>()(std::forward<const T>(lhs), std::forward<const U>(rhs))
+               ? std::forward<T>(lhs)
+               : std::forward<U>(rhs);
   }
 };
+#endif
 
 template <typename T = void> struct maximum {
   T operator()(const T &lhs, const T &rhs) const {
@@ -31,14 +38,20 @@ template <typename T = void> struct maximum {
   }
 };
 
+#if __cplusplus >= 201402L
 template <> struct maximum<void> {
-  template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return std::greater<T>()(lhs, rhs) ? lhs : rhs;
+  struct is_transparent {};
+  template <typename T, typename U>
+  auto operator()(T &&lhs, U &&rhs) const ->
+      typename std::common_type<T &&, U &&>::type {
+    return std::greater<>()(std::forward<const T>(lhs), std::forward<const U>(rhs))
+               ? std::forward<T>(lhs)
+               : std::forward<U>(rhs);
   }
 };
+#endif
 
-template <typename T = void>
-using plus = std::plus<T>;
+template <typename T = void> using plus = std::plus<T>;
 
 } // namespace intel
 } // namespace sycl

--- a/sycl/include/CL/sycl/intel/functional.hpp
+++ b/sycl/include/CL/sycl/intel/functional.hpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+#include <functional>
 
 namespace cl {
 namespace sycl {
@@ -14,37 +15,30 @@ namespace intel {
 
 template <typename T = void> struct minimum {
   T operator()(const T &lhs, const T &rhs) const {
-    return (lhs <= rhs) ? lhs : rhs;
+    return std::less<T>()(lhs, rhs) ? lhs : rhs;
   }
 };
 
 template <> struct minimum<void> {
   template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return (lhs <= rhs) ? lhs : rhs;
+    return std::less<T>()(lhs, rhs) ? lhs : rhs;
   }
 };
 
 template <typename T = void> struct maximum {
   T operator()(const T &lhs, const T &rhs) const {
-    return (lhs >= rhs) ? lhs : rhs;
+    return std::greater<T>()(lhs, rhs) ? lhs : rhs;
   }
 };
 
 template <> struct maximum<void> {
   template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return (lhs >= rhs) ? lhs : rhs;
+    return std::greater<T>()(lhs, rhs) ? lhs : rhs;
   }
 };
 
-template <typename T = void> struct plus {
-  T operator()(const T &lhs, const T &rhs) const { return lhs + rhs; }
-};
-
-template <> struct plus<void> {
-  template <typename T> T operator()(const T &lhs, const T &rhs) const {
-    return lhs + rhs;
-  }
-};
+template <typename T = void>
+using plus = std::plus<T>;
 
 } // namespace intel
 } // namespace sycl

--- a/sycl/test/sub_group/reduce.cpp
+++ b/sycl/test/sub_group/reduce.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %clangxx -fsycl -D SG_GPU %s -o %t_gpu.out
+// RUN: %clangxx -fsycl -std=c++14 %s -o %t.out
+// RUN: %clangxx -fsycl -std=c++14 -D SG_GPU %s -o %t_gpu.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
@@ -73,19 +73,24 @@ template <typename T> void check(queue &Queue, size_t G = 240, size_t L = 60) {
   }
 
   check_op<T>(Queue, T(L), intel::plus<T>(), false, G, L);
-  check_op<T>(Queue, T(L), intel::plus<>(), false, G, L);
   check_op<T>(Queue, T(0), intel::plus<T>(), true, G, L);
-  check_op<T>(Queue, T(0), intel::plus<>(), true, G, L);
 
   check_op<T>(Queue, T(0), intel::minimum<T>(), false, G, L);
-  check_op<T>(Queue, T(0), intel::minimum<>(), false, G, L);
   check_op<T>(Queue, T(G), intel::minimum<T>(), true, G, L);
-  check_op<T>(Queue, T(G), intel::minimum<>(), true, G, L);
 
   check_op<T>(Queue, T(G), intel::maximum<T>(), false, G, L);
-  check_op<T>(Queue, T(G), intel::maximum<>(), false, G, L);
   check_op<T>(Queue, T(0), intel::maximum<T>(), true, G, L);
+
+#if __cplusplus >= 201402L
+  check_op<T>(Queue, T(L), intel::plus<>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::plus<>(), true, G, L);
+
+  check_op<T>(Queue, T(0), intel::minimum<>(), false, G, L);
+  check_op<T>(Queue, T(G), intel::minimum<>(), true, G, L);
+
+  check_op<T>(Queue, T(G), intel::maximum<>(), false, G, L);
   check_op<T>(Queue, T(0), intel::maximum<>(), true, G, L);
+#endif
 }
 
 int main() {

--- a/sycl/test/sub_group/scan.cpp
+++ b/sycl/test/sub_group/scan.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %clangxx -fsycl -D SG_GPU %s -o %t_gpu.out
+// RUN: %clangxx -fsycl -std=c++14 %s -o %t.out
+// RUN: %clangxx -fsycl -std=c++14 -D SG_GPU %s -o %t_gpu.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
@@ -81,39 +81,52 @@ template <typename T> void check(queue &Queue, size_t G = 120, size_t L = 60) {
   }
 
   check_op<T>(Queue, T(L), intel::plus<T>(), false, G, L);
-  check_op<T>(Queue, T(L), intel::plus<>(), false, G, L);
   check_op<T>(Queue, T(0), intel::plus<T>(), true, G, L);
-  check_op<T>(Queue, T(0), intel::plus<>(), true, G, L);
 
   check_op<T>(Queue, T(0), intel::minimum<T>(), false, G, L);
-  check_op<T>(Queue, T(0), intel::minimum<>(), false, G, L);
   if (std::is_floating_point<T>::value ||
       std::is_same<T, cl::sycl::half>::value) {
     check_op<T>(Queue, std::numeric_limits<T>::infinity(), intel::minimum<T>(),
                 true, G, L);
-    check_op<T>(Queue, std::numeric_limits<T>::infinity(), intel::minimum<>(),
-                true, G, L);
   } else {
     check_op<T>(Queue, std::numeric_limits<T>::max(), intel::minimum<T>(), true,
-                G, L);
-    check_op<T>(Queue, std::numeric_limits<T>::max(), intel::minimum<>(), true,
                 G, L);
   }
 
   check_op<T>(Queue, T(G), intel::maximum<T>(), false, G, L);
-  check_op<T>(Queue, T(G), intel::maximum<>(), false, G, L);
   if (std::is_floating_point<T>::value ||
       std::is_same<T, cl::sycl::half>::value) {
     check_op<T>(Queue, -std::numeric_limits<T>::infinity(), intel::maximum<T>(),
                 true, G, L);
-    check_op<T>(Queue, -std::numeric_limits<T>::infinity(), intel::maximum<>(),
-                true, G, L);
   } else {
     check_op<T>(Queue, std::numeric_limits<T>::min(), intel::maximum<T>(), true,
                 G, L);
+  }
+
+#if __cplusplus >= 201402L
+  check_op<T>(Queue, T(L), intel::plus<>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::plus<>(), true, G, L);
+
+  check_op<T>(Queue, T(0), intel::minimum<>(), false, G, L);
+  if (std::is_floating_point<T>::value ||
+      std::is_same<T, cl::sycl::half>::value) {
+    check_op<T>(Queue, std::numeric_limits<T>::infinity(), intel::minimum<>(),
+                true, G, L);
+  } else {
+    check_op<T>(Queue, std::numeric_limits<T>::max(), intel::minimum<>(), true,
+                G, L);
+  }
+
+  check_op<T>(Queue, T(G), intel::maximum<>(), false, G, L);
+  if (std::is_floating_point<T>::value ||
+      std::is_same<T, cl::sycl::half>::value) {
+    check_op<T>(Queue, -std::numeric_limits<T>::infinity(), intel::maximum<>(),
+                true, G, L);
+  } else {
     check_op<T>(Queue, std::numeric_limits<T>::min(), intel::maximum<>(), true,
                 G, L);
   }
+#endif
 }
 
 int main() {


### PR DESCRIPTION
`intel::plus` should be an alias to `std::plus`
`intel::minimum`/`maximum` should use `std::less`/`std::greater`

Using the `<void>` specializations is now only possible using C++14.