### PR TITLE
[SYCL] Associate async errors on submit with the returned event

### DIFF
--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -22,6 +22,7 @@ namespace detail {
 class context_impl;
 using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 class queue_impl;
+using QueueImplPtr = std::shared_ptr<cl::sycl::detail::queue_impl>;
 
 // Profiling info for the host execution.
 class HostProfilingInfo {
@@ -40,7 +41,7 @@ class event_impl {
 public:
   event_impl() = default;
   event_impl(cl_event CLEvent, const context &SyclContext);
-  event_impl(std::shared_ptr<cl::sycl::detail::queue_impl> Queue);
+  event_impl(QueueImplPtr Queue);
 
   // Threat all devices that don't support interoperability as host devices to
   // avoid attempts to call method get on such events.
@@ -87,6 +88,7 @@ public:
 private:
   RT::PiEvent m_Event = nullptr;
   ContextImplPtr m_Context;
+  QueueImplPtr m_Queue;
   bool m_OpenCLInterop = false;
   bool m_HostEvent = true;
   std::unique_ptr<HostProfilingInfo> m_HostProfilingInfo;

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -95,28 +95,26 @@ public:
   template <typename T>
   event submit(T cgf, std::shared_ptr<queue_impl> self,
                std::shared_ptr<queue_impl> second_queue) {
-    event Event;
     try {
-      Event = submit_impl(cgf, self);
+      return submit_impl(cgf, self);
     } catch (...) {
       {
         std::lock_guard<mutex_class> guard(m_Mutex);
         m_Exceptions.PushBack(std::current_exception());
       }
-      Event = second_queue->submit(cgf, second_queue);
+      return second_queue->submit(cgf, second_queue);
     }
-    return Event;
   }
 
   template <typename T> event submit(T cgf, std::shared_ptr<queue_impl> self) {
-    event Event;
     try {
-      Event = submit_impl(cgf, self);
+      return submit_impl(cgf, self);
     } catch (...) {
       std::lock_guard<mutex_class> guard(m_Mutex);
       m_Exceptions.PushBack(std::current_exception());
+      return event(
+          createSyclObjFromImpl<event>(std::make_shared<event_impl>(self)));
     }
-    return Event;
   }
 
   void wait() {

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -83,7 +83,7 @@ event_impl::event_impl(cl_event CLEvent, const context &SyclContext)
   PI_CALL(RT::piEventRetain, m_Event);
 }
 
-event_impl::event_impl(std::shared_ptr<cl::sycl::detail::queue_impl> Queue) {
+event_impl::event_impl(QueueImplPtr Queue) : m_Queue(Queue) {
   if (Queue->is_host() &&
       Queue->has_property<property::queue::enable_profiling>()) {
     m_HostProfilingInfo.reset(new HostProfilingInfo());
@@ -112,6 +112,8 @@ void event_impl::wait_and_throw(
     if (Cmd)
       Cmd->getQueue()->throw_asynchronous();
   }
+  if (m_Queue)
+    m_Queue->throw_asynchronous();
 }
 
 template <>

--- a/sycl/test/basic_tests/event_async_exception.cpp
+++ b/sycl/test/basic_tests/event_async_exception.cpp
@@ -1,0 +1,39 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+
+//==---- event_async_exception.cpp - Test for event async exceptions -------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+// This test checks that if there is a submit failure, the asynchronous
+// exception is associated with the returned event.
+
+using namespace cl::sycl;
+
+class KernelName;
+
+int main() {
+  auto asyncHandler = [](exception_list el) {
+    for (auto &e : el) {
+      std::rethrow_exception(e);
+    }
+  };
+
+  queue q(asyncHandler);
+
+  // Submit a CG with no kernel or memory operation to trigger an async error
+  event e = q.submit([&](handler &cgh) {});
+
+  try {
+    e.wait_and_throw();
+    return 1;
+  } catch (runtime_error e) {
+    return 0;
+  }
+}


### PR DESCRIPTION
The asynchronous errors happening during submit were not asssociated
with the returned event if they occured before the submission gets to
scheduler. This patch fixes this issue.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>