### PR TITLE
[SYCL] Remove -fsycl-device-only alias

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3398,7 +3398,6 @@ defm whole_file : BooleanFFlag<"whole-file">, Group<gfortran_Group>;
 
 def sycl_device_only : Flag<["-"], "fsycl-device-only">, Flags<[CoreOption]>,
   HelpText<"Compile SYCL kernels for device">;
-def sycl : Flag<["--"], "sycl">, Alias<sycl_device_only>, Flags<[CoreOption]>;
 
 def reuse_exe_EQ : Joined<["-"], "reuse-exe=">,
   HelpText<"Speed up FPGA aoc compile if the device code in <exe> is unchanged.">,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1204,7 +1204,7 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
     TargetTriple = T.str();
   }
   if (Args.hasArg(options::OPT_sycl_device_only)) {
-    // --sycl implies spir arch and SYCL Device
+    // -fsycl-device-only implies spir arch and SYCL Device
     llvm::Triple T(TargetTriple);
     // FIXME: defaults to spir64, should probably have a way to set spir
     // possibly new -sycl-target option
@@ -4492,8 +4492,8 @@ Action *Driver::ConstructPhaseAction(
       if (Args.hasFlag(options::OPT_fsycl_use_bitcode,
                        options::OPT_fno_sycl_use_bitcode, true))
         return C.MakeAction<BackendJobAction>(Input, types::TY_LLVM_BC);
-      // Use of --sycl creates a bitcode file, we need to translate that to
-      // a SPIR-V file with -fno-sycl-use-bitcode
+      // Use of -fsycl-device-only creates a bitcode file, we need to translate
+      // that to a SPIR-V file with -fno-sycl-use-bitcode
       auto *BackendAction =
           C.MakeAction<BackendJobAction>(Input, types::TY_LLVM_BC);
       return C.MakeAction<SPIRVTranslatorJobAction>(BackendAction,

--- a/clang/test/CodeGenSYCL/address-space-swap.cpp
+++ b/clang/test/CodeGenSYCL/address-space-swap.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang --sycl -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang -fsycl-device-only -S -emit-llvm -x c++ %s -o - | FileCheck %s
 #include <algorithm>
 
 

--- a/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang --sycl %s -S -I %S/Inputs -emit-llvm -g -o - | FileCheck %s
+// RUN: %clang -fsycl-device-only %s -S -I %S/Inputs -emit-llvm -g -o - | FileCheck %s
 //
 // Verify the SYCL kernel routine is marked artificial and has no source
 // correlation.

--- a/clang/test/CodeGenSYCL/fpga_pipes.cpp
+++ b/clang/test/CodeGenSYCL/fpga_pipes.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang %s -S -emit-llvm --sycl -o - | FileCheck %s
+// RUN: %clang %s -S -emit-llvm -fsycl-device-only -o - | FileCheck %s
 #include "CL/sycl.hpp"
 // CHECK: %opencl.pipe_wo_t
 // CHECK: %opencl.pipe_ro_t

--- a/clang/test/CodeGenSYCL/inlining.cpp
+++ b/clang/test/CodeGenSYCL/inlining.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang --sycl %s -S -emit-llvm -o - | FileCheck %s
+// RUN: %clang -fsycl-device-only %s -S -emit-llvm -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
+// RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
 // RUN: FileCheck -input-file=%t.h %s
 
 // CHECK:template <> struct KernelInfo<class KernelName> {

--- a/clang/test/CodeGenSYCL/int_header_inline_ns.cpp
+++ b/clang/test/CodeGenSYCL/int_header_inline_ns.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
+// RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
 // RUN: FileCheck -input-file=%t.h %s
 
 // This test checks if the SYCL device compiler is able to generate correct

--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o %T/kernel.spv
+// RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o %T/kernel.spv
 // RUN: FileCheck -input-file=%t.h %s
 //
 // CHECK: #include <CL/sycl/detail/kernel_desc.hpp>

--- a/clang/test/CodeGenSYCL/intel-restrict.cpp
+++ b/clang/test/CodeGenSYCL/intel-restrict.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang %s -S -emit-llvm --sycl -o - | FileCheck %s
+// RUN: %clang %s -S -emit-llvm -fsycl-device-only -o - | FileCheck %s
 
 #include "CL/sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/kernel_functor.cpp
+++ b/clang/test/CodeGenSYCL/kernel_functor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -I %S/Inputs -std=c++11 --sycl -Xclang -fsycl-int-header=%t.h %s -c -o %t.spv
+// RUN: %clang -I %S/Inputs -std=c++11 -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o %t.spv
 // RUN: FileCheck %s --input-file=%t.h
 
 // Checks that functors are supported as SYCL kernels.

--- a/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
+++ b/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
+// RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
 // RUN: FileCheck -input-file=%t.h %s
 
 #include "sycl.hpp"

--- a/clang/test/CodeGenSYCL/skip-host-classes.cpp
+++ b/clang/test/CodeGenSYCL/skip-host-classes.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang --sycl -c %s  -o %t.ll -Xclang -fsycl-int-header=%t.hpp -emit-llvm -S
+// RUN: %clang -fsycl-device-only -c %s  -o %t.ll -Xclang -fsycl-int-header=%t.hpp -emit-llvm -S
 // RUN: FileCheck < %t.ll %s --check-prefix=CHECK
 
 // CHECK-NOT: declare dso_local spir_func void {{.+}}test{{.+}}printer{{.+}}

--- a/clang/test/CodeGenSYCL/struct_kernel_param.cpp
+++ b/clang/test/CodeGenSYCL/struct_kernel_param.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o %T/kernel.spv
+// RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o %T/kernel.spv
 // RUN: FileCheck -input-file=%t.h %s
 
 // CHECK:     const kernel_param_desc_t kernel_signatures[] = {

--- a/clang/test/CodeGenSYCL/template-template-parameter.cpp
+++ b/clang/test/CodeGenSYCL/template-template-parameter.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s
+// RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s
 // RUN: FileCheck -input-file=%t.h %s
 
 #include <sycl.hpp>

--- a/clang/test/CodeGenSYCL/usm-int-header.cpp
+++ b/clang/test/CodeGenSYCL/usm-int-header.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -std=c++11 -I %S/Inputs -fsycl-is-device -ast-dump %s | FileCheck %s
-// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
+// RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
 // RUN: FileCheck -input-file=%t.h %s --check-prefix=INT-HEADER
 
 // INT-HEADER:{ kernel_param_kind_t::kind_pointer, 8, 0 },

--- a/clang/test/CodeGenSYCL/wrapped-accessor.cpp
+++ b/clang/test/CodeGenSYCL/wrapped-accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o %T/kernel.spv
+// RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o %T/kernel.spv
 // RUN: FileCheck -input-file=%t.h %s
 //
 // CHECK: #include <CL/sycl/detail/kernel_desc.hpp>

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -1,9 +1,9 @@
-// RUN: %clang -### --sycl -c %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
-// RUN: %clang -### --sycl %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
+// RUN: %clang -### -fsycl-device-only -c %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
+// RUN: %clang -### -fsycl-device-only %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
 // RUN: %clang -### -fsycl-device-only -fsycl  %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
-// RUN: %clang -### --sycl -fno-sycl-use-bitcode -c %s 2>&1 | FileCheck %s --check-prefix=NO-BITCODE
+// RUN: %clang -### -fsycl-device-only -fno-sycl-use-bitcode -c %s 2>&1 | FileCheck %s --check-prefix=NO-BITCODE
 // RUN: %clang -### -target spir64-unknown-linux-sycldevice -c -emit-llvm %s 2>&1 | FileCheck %s --check-prefix=TARGET
-// RUN: %clang -### --sycl -c -emit-llvm %s 2>&1 | FileCheck %s --check-prefix=COMBINED
+// RUN: %clang -### -fsycl-device-only -c -emit-llvm %s 2>&1 | FileCheck %s --check-prefix=COMBINED
 // RUN: %clangxx -### -fsycl-device-only %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
 // RUN: %clang_cl -### -fsycl-device-only %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
 

--- a/clang/test/Driver/windows-compat-sycl-args.cpp
+++ b/clang/test/Driver/windows-compat-sycl-args.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -### --sycl -target x86_64-unknown-windows-msvc -c %s 2>&1 | FileCheck %s
+// RUN: %clang -### -fsycl-device-only -target x86_64-unknown-windows-msvc -c %s 2>&1 | FileCheck %s
 // CHECK: -fms-compatibility
 // CHECK: -fdelayed-template-parsing
 // expected-no-diagnostics

--- a/clang/test/SemaSYCL/intel-restrict.cpp
+++ b/clang/test/SemaSYCL/intel-restrict.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang %s -fsyntax-only --sycl -DCHECKDIAG -Xclang -verify
-// RUN: %clang %s -fsyntax-only -Xclang -ast-dump --sycl | FileCheck %s
+// RUN: %clang %s -fsyntax-only -fsycl-device-only -DCHECKDIAG -Xclang -verify
+// RUN: %clang %s -fsyntax-only -Xclang -ast-dump -fsycl-device-only | FileCheck %s
 
 [[intel::kernel_args_restrict]] // expected-warning{{'kernel_args_restrict' attribute ignored}}
 void func_ignore() {}

--- a/clang/test/SemaSYCL/sampler.cpp
+++ b/clang/test/SemaSYCL/sampler.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -S -I %S/Inputs --sycl -Xclang -ast-dump %s | FileCheck %s
+// RUN: %clang -S -I %S/Inputs -fsycl-device-only -Xclang -ast-dump %s | FileCheck %s
 
 #include <sycl.hpp>
 

--- a/sycl/test/basic_tests/valid_kernel_args.cpp
+++ b/sycl/test/basic_tests/valid_kernel_args.cpp
@@ -10,7 +10,7 @@
 // RUN: %clangxx -fsyntax-only %s
 
 // Check that the test can be compiled with device compiler as well.
-// RUN: %clangxx --sycl -fsyntax-only %s
+// RUN: %clangxx -fsycl-device-only -fsyntax-only %s
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test/check_device_code/kernel_arguments_as.cpp
+++ b/sycl/test/check_device_code/kernel_arguments_as.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx --sycl -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll
 // RUN: FileCheck %s --input-file %t.ll
 //
 // Check the address space of the pointer in accessor class.

--- a/sycl/test/kernel_from_file/hw.cpp
+++ b/sycl/test/kernel_from_file/hw.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx --sycl -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv
+// RUN: %clangxx -fsycl-device-only -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv
 // RUN: %clangxx -include %t.h -g %s -o %t.out -lsycl
 // RUN: env SYCL_USE_KERNEL_SPV=%t.spv %t.out | FileCheck %s
 // CHECK: Passed

--- a/sycl/test/separate-compile/test.cpp
+++ b/sycl/test/separate-compile/test.cpp
@@ -1,12 +1,12 @@
 // >> ---- compile src1
 // >> device compilation...
-// RUN: %clangxx --sycl -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc
 // >> host compilation...
 // RUN: %clangxx -include sycl_ihdr_a.h -g -c %s -o a.o
 //
 // >> ---- compile src2
 // >> device compilation...
-// RUN: %clangxx -DB_CPP=1 --sycl -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -c -o b_kernel.bc
+// RUN: %clangxx -DB_CPP=1 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -c -o b_kernel.bc
 // >> host compilation...
 // RUN: %clangxx -DB_CPP=1 -include sycl_ihdr_b.h -g -c %s -o b.o
 //


### PR DESCRIPTION
`--sycl` is not aligned with clang's option names for other offloading
programming model options (e.g. OpenMP options).

Signed-off-by: Alexey Bader <alexey.bader@intel.com>