### PR TITLE
[SYCL][Test] Use std::is_same<>::value instead of std::is_same_v<>

### DIFF
--- a/sycl/test/basic_tests/buffer/buffer_ctad.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_ctad.cpp
@@ -18,23 +18,23 @@ int main() {
   std::vector<int> v(5, 1);
   const std::vector<int> cv(5, 1);
   buffer b1(v.data(), range<1>(5));
-  static_assert(std::is_same_v<decltype(b1), buffer<int, 1>>);
+  static_assert(std::is_same<decltype(b1), buffer<int, 1>>::value);
   buffer b1a(v.data(), range<1>(5), std::allocator<int>());
   static_assert(
-      std::is_same_v<decltype(b1a), buffer<int, 1, std::allocator<int>>>);
+      std::is_same<decltype(b1a), buffer<int, 1, std::allocator<int>>>::value);
   buffer b1b(cv.data(), range<1>(5));
-  static_assert(std::is_same_v<decltype(b1b), buffer<int, 1>>);
+  static_assert(std::is_same<decltype(b1b), buffer<int, 1>>::value);
   buffer b1c(v.data(), range<2>(2, 2));
-  static_assert(std::is_same_v<decltype(b1c), buffer<int, 2>>);
+  static_assert(std::is_same<decltype(b1c), buffer<int, 2>>::value);
   buffer b2(v.begin(), v.end());
-  static_assert(std::is_same_v<decltype(b2), buffer<int, 1>>);
+  static_assert(std::is_same<decltype(b2), buffer<int, 1>>::value);
   buffer b2a(v.cbegin(), v.cend());
-  static_assert(std::is_same_v<decltype(b2a), buffer<int, 1>>);
+  static_assert(std::is_same<decltype(b2a), buffer<int, 1>>::value);
   buffer b3(v);
-  static_assert(std::is_same_v<decltype(b3), buffer<int, 1>>);
+  static_assert(std::is_same<decltype(b3), buffer<int, 1>>::value);
   buffer b3a(cv);
-  static_assert(std::is_same_v<decltype(b3a), buffer<int, 1>>);
+  static_assert(std::is_same<decltype(b3a), buffer<int, 1>>::value);
   shared_ptr_class<int> ptr{new int[5], [](int *p) { delete[] p; }};
   buffer b4(ptr, range<1>(5));
-  static_assert(std::is_same_v<decltype(b4), buffer<int, 1>>);
+  static_assert(std::is_same<decltype(b4), buffer<int, 1>>::value);
 }

--- a/sycl/test/basic_tests/id_ctad.cpp
+++ b/sycl/test/basic_tests/id_ctad.cpp
@@ -14,7 +14,7 @@ int main() {
   cl::sycl::id one_dim_id(64);
   cl::sycl::id two_dim_id(64, 1);
   cl::sycl::id three_dim_id(64, 1, 2);
-  static_assert(std::is_same_v<decltype(one_dim_id), cl::sycl::id<1>>);
-  static_assert(std::is_same_v<decltype(two_dim_id), cl::sycl::id<2>>);
-  static_assert(std::is_same_v<decltype(three_dim_id), cl::sycl::id<3>>);
+  static_assert(std::is_same<decltype(one_dim_id), cl::sycl::id<1>>::value);
+  static_assert(std::is_same<decltype(two_dim_id), cl::sycl::id<2>>::value);
+  static_assert(std::is_same<decltype(three_dim_id), cl::sycl::id<3>>::value);
 }

--- a/sycl/test/basic_tests/range_ctad.cpp
+++ b/sycl/test/basic_tests/range_ctad.cpp
@@ -14,16 +14,19 @@ int main() {
   cl::sycl::range one_dim_range(64);
   cl::sycl::range two_dim_range(64, 1);
   cl::sycl::range three_dim_range(64, 1, 2);
-  static_assert(std::is_same_v<decltype(one_dim_range), cl::sycl::range<1>>);
-  static_assert(std::is_same_v<decltype(two_dim_range), cl::sycl::range<2>>);
-  static_assert(std::is_same_v<decltype(three_dim_range), cl::sycl::range<3>>);
+  static_assert(
+      std::is_same<decltype(one_dim_range), cl::sycl::range<1>>::value);
+  static_assert(
+      std::is_same<decltype(two_dim_range), cl::sycl::range<2>>::value);
+  static_assert(
+      std::is_same<decltype(three_dim_range), cl::sycl::range<3>>::value);
   cl::sycl::nd_range one_dim_ndrange(one_dim_range, one_dim_range);
   cl::sycl::nd_range two_dim_ndrange(two_dim_range, two_dim_range);
   cl::sycl::nd_range three_dim_ndrange(three_dim_range, three_dim_range);
   static_assert(
-      std::is_same_v<decltype(one_dim_ndrange), cl::sycl::nd_range<1>>);
+      std::is_same<decltype(one_dim_ndrange), cl::sycl::nd_range<1>>::value);
   static_assert(
-      std::is_same_v<decltype(two_dim_ndrange), cl::sycl::nd_range<2>>);
+      std::is_same<decltype(two_dim_ndrange), cl::sycl::nd_range<2>>::value);
   static_assert(
-      std::is_same_v<decltype(three_dim_ndrange), cl::sycl::nd_range<3>>);
+      std::is_same<decltype(three_dim_ndrange), cl::sycl::nd_range<3>>::value);
 }

--- a/sycl/test/basic_tests/vectors/ctad.cpp
+++ b/sycl/test/basic_tests/vectors/ctad.cpp
@@ -13,7 +13,7 @@ namespace sycl = cl::sycl;
 
 int main() {
   sycl::vec v1(1);
-  static_assert(std::is_same_v<decltype(v1), sycl::vec<int, 1>>);
+  static_assert(std::is_same<decltype(v1), sycl::vec<int, 1>>::value);
   sycl::vec v2(1, 2);
-  static_assert(std::is_same_v<decltype(v2), sycl::vec<int, 2>>);
+  static_assert(std::is_same<decltype(v2), sycl::vec<int, 2>>::value);
 }

--- a/sycl/test/multi_ptr/ctad.cpp
+++ b/sycl/test/multi_ptr/ctad.cpp
@@ -24,7 +24,7 @@ int main() {
   using globlMPtr = sycl::multi_ptr<int, address_space::global_space>;
   using constMPtr = sycl::multi_ptr<int, address_space::constant_space>;
   using localMPtr = sycl::multi_ptr<int, address_space::local_space>;
-  static_assert(std::is_same_v<globlCTAD, globlMPtr>);
-  static_assert(std::is_same_v<constCTAD, constMPtr>);
-  static_assert(std::is_same_v<localCTAD, localMPtr>);
+  static_assert(std::is_same<globlCTAD, globlMPtr>::value);
+  static_assert(std::is_same<constCTAD, constMPtr>::value);
+  static_assert(std::is_same<localCTAD, localMPtr>::value);
 }


### PR DESCRIPTION
std::is_same_v is not supported by the GCC 5.5

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>