### PR TITLE
[SYCL] Separate jobs in sycl-post-link tool

### DIFF
--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -92,7 +92,8 @@ static void writeToFile(std::string Filename, std::string Content) {
 // with same values of the sycl-module-id attribute.
 // The function fills ResKernelModuleMap using input module M.
 static void collectKernelModuleMap(
-    Module &M, std::map<std::string, std::vector<Function *>> &ResKernelModuleMap) {
+    Module &M,
+    std::map<std::string, std::vector<Function *>> &ResKernelModuleMap) {
   for (auto &F : M.functions()) {
     if (F.getCallingConv() == CallingConv::SPIR_KERNEL) {
       if (OneKernelPerModule) {
@@ -205,12 +206,12 @@ splitModule(Module &M,
 
 // Saves specified collection of llvm IR modules to files.
 // Saves file list if user specified corresponding filename.
-static void saveResultModules(std::vector<std::unique_ptr<Module>> &ResModules) {
+static void
+saveResultModules(std::vector<std::unique_ptr<Module>> &ResModules) {
   std::string IRFilesList;
   for (size_t I = 0; I < ResModules.size(); ++I) {
     std::error_code EC;
-    std::string CurOutFileName = BaseOutputFilename + "_" +
-                                 std::to_string(I) +
+    std::string CurOutFileName = BaseOutputFilename + "_" + std::to_string(I) +
                                  ((OutputAssembly) ? ".ll" : ".bc");
 
     raw_fd_ostream Out{CurOutFileName, EC, sys::fs::OF_None};
@@ -233,8 +234,7 @@ static void saveResultModules(std::vector<std::unique_ptr<Module>> &ResModules) 
   if (!OutputIRFilesList.empty()) {
     // Just pass input module to next tools if there was nothing to split.
     if (IRFilesList.empty())
-      IRFilesList =
-          (Twine(InputFilename) + Twine("\n")).str();
+      IRFilesList = (Twine(InputFilename) + Twine("\n")).str();
     writeToFile(OutputIRFilesList, IRFilesList);
   }
 }
@@ -313,8 +313,8 @@ int main(int argc, char **argv) {
   // Default usage model of that the tool is
   // calling it twice with the same input due clang driver limitations.
   // It should not bring much extra overhead because
-  // parseIRFile and collectKernelModuleMap functions are small (would be good to
-  // estimate) compared to splitModule and saveResultModules.
+  // parseIRFile and collectKernelModuleMap functions are small (would be good
+  // to estimate) compared to splitModule and saveResultModules.
   bool NoLists = OutputIRFilesList.empty() && OutputTxtFilesList.empty();
   bool PerformSplit = !OutputIRFilesList.empty() || NoLists;
   bool CollectSymbols = !OutputTxtFilesList.empty() || NoLists;

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -305,6 +305,11 @@ int main(int argc, char **argv) {
   std::vector<std::unique_ptr<Module>> ResultModules;
   std::vector<std::string> ResultSymbolsLists;
 
+  // Default usage model of that the tool is
+  // calling it twice with the same input due clang driver limitations.
+  // It should not bring much extra overhead because
+  // parseIRFile and collectKernelsSet functions are small (would be good to
+  // estimate) compared to splitModule and saveResultModules.
   bool NoLists = OutputIRFilesList.empty() && OutputTxtFilesList.empty();
   bool PerformSplit = !OutputIRFilesList.empty() || NoLists;
   bool CollectSymbols = !OutputTxtFilesList.empty() || NoLists;

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -103,10 +103,12 @@ static void collectKernelsSet(
   }
 }
 
-// Input parameter KernelsSet is a map containing groups of kernels with same
-// values in the sycl-module-id attribute.
-// ResSymbolsLists vector is output parameter.
-// Collects set of kernel names for each group of kernels.
+// Input parameter KernelModuleMap is a map containing groups of kernels with
+// same values of the sycl-module-id attribute. ResSymbolsLists is a vector of
+// kernel name lists. Each vector element is a string with kernel names from the
+// same module separated by \n.
+// The function saves names of kernels from one group to a single std::string
+// and stores this string to the ResSymbolsLists vector.
 static void collectSymbolsLists(
     std::map<std::string, std::vector<Function *>> &KernelsSet,
     std::vector<std::string> &ResSymbolsLists) {


### PR DESCRIPTION
Clang driver will invoke sycl-post-link twice: one time for IR module
split and one time for entries list generation.
This patch makes possible do not perform same job twice in this case.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>