### PR TITLE
[SYCL][Driver] Improve diagnostic for using bad triple for AOT

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -611,7 +611,7 @@ Driver::OpenMPRuntimeKind Driver::getOpenMPRuntime(const ArgList &Args) const {
 static bool isValidSYCLTriple(llvm::Triple T) {
   // Check for invalid SYCL device triple values.
   // Non-SPIR arch.
-  if (T.getArch() == llvm::Triple::UnknownArch || !T.isSPIR())
+  if (!T.isSPIR())
     return false;
   // SPIR arch, but has invalid SubArch for AOT.
   StringRef A(T.getArchName());

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -783,7 +783,14 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
       if (SYCLTargetsValues->getNumValues()) {
         for (const char *Val : SYCLTargetsValues->getValues()) {
           llvm::Triple TT(Val);
-          if (TT.getArch() == llvm::Triple::UnknownArch || !TT.isSPIR()) {
+          // Check for invalid triple values.  For AOT, these evaluate to
+          // regular SPIR target, so catch these early.
+          StringRef A(TT.getArchName());
+          if (TT.getArch() == llvm::Triple::UnknownArch || !TT.isSPIR() ||
+              (TT.getSubArch() == llvm::Triple::NoSubArch &&
+               ((TT.getArch() == llvm::Triple::spir && !A.equals("spir")) ||
+                (TT.getArch() == llvm::Triple::spir64 &&
+                 !A.equals("spir64"))))) {
             Diag(clang::diag::err_drv_invalid_sycl_target) << Val;
             continue;
           }
@@ -821,7 +828,13 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
           std::pair<StringRef, StringRef> I = Val.split(':');
           if (!I.first.empty() && !I.second.empty()) {
             llvm::Triple TT(I.first);
-            if (TT.getArch() == llvm::Triple::UnknownArch || !TT.isSPIR()) {
+            // Check for invalid triple values.
+            StringRef A(TT.getArchName());
+            if (TT.getArch() == llvm::Triple::UnknownArch || !TT.isSPIR() ||
+                (TT.getSubArch() == llvm::Triple::NoSubArch &&
+                 ((TT.getArch() == llvm::Triple::spir && !A.equals("spir")) ||
+                  (TT.getArch() == llvm::Triple::spir64 &&
+                   !A.equals("spir64"))))) {
               Diag(clang::diag::err_drv_invalid_sycl_target) << I.first;
               continue;
             }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -610,11 +610,11 @@ Driver::OpenMPRuntimeKind Driver::getOpenMPRuntime(const ArgList &Args) const {
 
 static bool isValidSYCLTriple(llvm::Triple T) {
   // Check for invalid SYCL device triple values.
-  StringRef A(T.getArchName());
   // Non-SPIR arch.
   if (T.getArch() == llvm::Triple::UnknownArch || !T.isSPIR())
     return false;
   // SPIR arch, but has invalid SubArch for AOT.
+  StringRef A(T.getArchName());
   if (T.getSubArch() == llvm::Triple::NoSubArch &&
       ((T.getArch() == llvm::Triple::spir && !A.equals("spir")) ||
        (T.getArch() == llvm::Triple::spir64 && !A.equals("spir64"))))

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -107,19 +107,27 @@
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
 // CHK-SYCL-FPGA-TRIPLE-NOT: error: SYCL target is invalid
 
-/// Check error for -fsycl-add-targets with bad triple
+/// Check error for -fsycl-[add|link]-targets with bad triple
 // RUN:   %clang -### -fsycl-add-targets=spir64_bad-unknown-unknown-sycldevice:dummy.spv -fsycl  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-ADD-TRIPLE %s
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-ADDLINK-TRIPLE %s
 // RUN:   %clang_cl -### -fsycl-add-targets=spir64_bad-unknown-unknown-sycldevice:dummy.spv -fsycl  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-ADD-TRIPLE %s
-// CHK-SYCL-FPGA-BAD-ADD-TRIPLE: error: SYCL target is invalid: 'spir64_bad-unknown-unknown-sycldevice'
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-ADDLINK-TRIPLE %s
+// RUN:   %clang -### -fsycl-link-targets=spir64_bad-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-ADDLINK-TRIPLE %s
+// RUN:   %clang_cl -### -fsycl-link-targets=spir64_bad-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-ADDLINK-TRIPLE %s
+// CHK-SYCL-FPGA-BAD-ADDLINK-TRIPLE: error: SYCL target is invalid: 'spir64_bad-unknown-unknown-sycldevice'
 
-/// Check no error for -fsycl-add-targets with good triple
+/// Check no error for -fsycl-[add|link]-targets with good triple
 // RUN:   %clang -### -fsycl-add-targets=spir64-unknown-unknown-sycldevice:dummy.spv -fsycl  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-ADD-TRIPLE %s
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-ADDLINK-TRIPLE %s
 // RUN:   %clang_cl -### -fsycl-add-targets=spir64-unknown-unknown-sycldevice:dummy.spv -fsycl  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-ADD-TRIPLE %s
-// CHK-SYCL-FPGA-ADD-TRIPLE-NOT: error: SYCL target is invalid
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-ADDLINK-TRIPLE %s
+// RUN:   %clang -### -fsycl-link-targets=spir64-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-ADDLINK-TRIPLE %s
+// RUN:   %clang_cl -### -fsycl-link-targets=spir64-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-ADDLINK-TRIPLE %s
+// CHK-SYCL-FPGA-ADDLINK-TRIPLE-NOT: error: SYCL target is invalid
 
 /// ###########################################################################
 

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -87,6 +87,42 @@
 
 /// ###########################################################################
 
+/// Check error for -fsycl-targets with bad triple
+// RUN:   %clang -### -fsycl-targets=spir64_bad-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-TRIPLE %s
+// RUN:   %clang_cl -### -fsycl-targets=spir64_bad-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-TRIPLE %s
+// CHK-SYCL-FPGA-BAD-TRIPLE: error: SYCL target is invalid: 'spir64_bad-unknown-unknown-sycldevice'
+
+/// Check no error for -fsycl-targets with good triple
+// RUN:   %clang -### -fsycl-targets=spir-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
+// RUN:   %clang -### -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
+// RUN:   %clang -### -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
+// RUN:   %clang -### -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
+// RUN:   %clang_cl -### -fsycl-targets=spir-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
+// CHK-SYCL-FPGA-TRIPLE-NOT: error: SYCL target is invalid
+
+/// Check error for -fsycl-add-targets with bad triple
+// RUN:   %clang -### -fsycl-add-targets=spir64_bad-unknown-unknown-sycldevice:dummy.spv -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-ADD-TRIPLE %s
+// RUN:   %clang_cl -### -fsycl-add-targets=spir64_bad-unknown-unknown-sycldevice:dummy.spv -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-BAD-ADD-TRIPLE %s
+// CHK-SYCL-FPGA-BAD-ADD-TRIPLE: error: SYCL target is invalid: 'spir64_bad-unknown-unknown-sycldevice'
+
+/// Check no error for -fsycl-add-targets with good triple
+// RUN:   %clang -### -fsycl-add-targets=spir64-unknown-unknown-sycldevice:dummy.spv -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-ADD-TRIPLE %s
+// RUN:   %clang_cl -### -fsycl-add-targets=spir64-unknown-unknown-sycldevice:dummy.spv -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-ADD-TRIPLE %s
+// CHK-SYCL-FPGA-ADD-TRIPLE-NOT: error: SYCL target is invalid
+
+/// ###########################################################################
+
 /// Check warning for duplicate offloading targets.
 // RUN:   %clang -### -ccc-print-phases -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice,spir64-unknown-unknown-sycldevice  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DUPLICATES %s


### PR DESCRIPTION
When using AOT, if a user were to use a bad sub-arch, we would not catch
it and would end up using the standard spir arch (without AOT).  Catch these
cases and error, informing the user

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>