### PR TITLE
[SYCL] Allow SYCL_EXTERNAL to be applied to a function with raw pointers

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1053,7 +1053,7 @@ def OpenMPLoopForm : DiagGroup<"openmp-loop-form">;
 def OpenMPTarget : DiagGroup<"openmp-target">;
 
 // SYCL warnings
-def Sycl : DiagGroup<"sycl">;
+def SyclStrict : DiagGroup<"sycl-strict">;
 def SyclTarget : DiagGroup<"sycl-target">;
 
 // Backend warnings.

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1053,6 +1053,7 @@ def OpenMPLoopForm : DiagGroup<"openmp-loop-form">;
 def OpenMPTarget : DiagGroup<"openmp-target">;
 
 // SYCL warnings
+def Sycl : DiagGroup<"sycl">;
 def SyclTarget : DiagGroup<"sycl-target">;
 
 // Backend warnings.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10121,10 +10121,10 @@ def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "%select{static function or function in an anonymous namespace"
             "|class member function}1">;
-def warn_sycl_attibute_address_space_ext
+def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
-              "to a %select{function with a raw pointer return type"
-              "|function with a raw pointer parameter type}1">,
+              "to a function with a raw "
+              "%select{pointer return type|pointer parameter type}1">,
       InGroup<SyclStrict>, DefaultError;
 def err_ivdep_duplicate_arg : Error<
   "duplicate argument to 'ivdep'. attribute requires one or both of a safelen "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10120,9 +10120,12 @@ def err_conflicting_sycl_kernel_attributes : Error<
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "%select{static function or function in an anonymous namespace"
-            "|class member function"
-            "|function with a raw pointer return type"
-            "|function with a raw pointer parameter type}1">;
+            "|class member function}1">;
+def warn_sycl_attibute_address_space_ext
+    : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
+              "to a %select{function with a raw pointer return type"
+              "|function with a raw pointer parameter type}1">,
+      InGroup<Sycl>;
 def err_ivdep_duplicate_arg : Error<
   "duplicate argument to 'ivdep'. attribute requires one or both of a safelen "
   "and array">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10125,7 +10125,7 @@ def warn_sycl_attibute_address_space_ext
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
               "to a %select{function with a raw pointer return type"
               "|function with a raw pointer parameter type}1">,
-      InGroup<Sycl>;
+      InGroup<SyclStrict>, DefaultError;
 def err_ivdep_duplicate_arg : Error<
   "duplicate argument to 'ivdep'. attribute requires one or both of a safelen "
   "and array">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10123,8 +10123,8 @@ def err_sycl_attibute_cannot_be_applied_here
             "|class member function}1">;
 def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
-              "to a function with a raw "
-              "%select{pointer return type|pointer parameter type}1">,
+              "to a function with a raw pointer "
+              "%select{return type|parameter type}1">,
       InGroup<SyclStrict>, DefaultError;
 def err_ivdep_duplicate_arg : Error<
   "duplicate argument to 'ivdep'. attribute requires one or both of a safelen "

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4329,12 +4329,12 @@ static void handleSYCLDeviceAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     return;
   }
   if (FD->getReturnType()->isPointerType()) {
-    S.Diag(AL.getLoc(), diag::warn_sycl_attibute_address_space_ext)
+    S.Diag(AL.getLoc(), diag::warn_sycl_attibute_function_raw_ptr)
         << AL << 0 /* function with a raw pointer return type */;
   }
   for (const ParmVarDecl *Param : FD->parameters())
     if (Param->getType()->isPointerType()) {
-      S.Diag(AL.getLoc(), diag::warn_sycl_attibute_address_space_ext)
+      S.Diag(AL.getLoc(), diag::warn_sycl_attibute_function_raw_ptr)
           << AL << 1 /* function with a raw pointer parameter type */;
     }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4329,15 +4329,13 @@ static void handleSYCLDeviceAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     return;
   }
   if (FD->getReturnType()->isPointerType()) {
-    S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-        << AL << 2 /* function with a raw pointer return type */;
-    return;
+    S.Diag(AL.getLoc(), diag::warn_sycl_attibute_address_space_ext)
+        << AL << 0 /* function with a raw pointer return type */;
   }
   for (const ParmVarDecl *Param : FD->parameters())
     if (Param->getType()->isPointerType()) {
-      S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-          << AL << 3 /* function with a raw pointer parameter type */;
-      return;
+      S.Diag(AL.getLoc(), diag::warn_sycl_attibute_address_space_ext)
+          << AL << 1 /* function with a raw pointer parameter type */;
     }
 
   S.addSyclDeviceDecl(D);

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -25,10 +25,10 @@ class A {
   int func3() {}
 };
 
-__attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a function with a raw pointer return type}}
+__attribute__((sycl_device)) // expected-warning {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
 int* func3() { return nullptr; }
 
-__attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a function with a raw pointer parameter type}}
+__attribute__((sycl_device)) // expected-warning {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer parameter type}}
 void func3(int *) {}
 
 #else

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -1,6 +1,8 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 // RUN: %clang_cc1 -verify -DNO_SYCL %s
 
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -DNOT_STRICT -Wno-error=sycl-strict -Wno-sycl-strict %s
+
 #ifndef NO_SYCL
 
 __attribute__((sycl_device)) // expected-warning {{'sycl_device' attribute only applies to functions}}
@@ -25,14 +27,21 @@ class A {
   int func3() {}
 };
 
-__attribute__((sycl_device)) // expected-warning {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
+#ifndef NOT_STRICT
+__attribute__((sycl_device)) // expected-error {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
 int* func3() { return nullptr; }
 
-__attribute__((sycl_device)) // expected-warning {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer parameter type}}
+__attribute__((sycl_device)) // expected-error {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer parameter type}}
 void func3(int *) {}
-
 #else
+__attribute__((sycl_device))
+int* func3() { return nullptr; }
 
+__attribute__((sycl_device))
+void func3(int *) {}
+#endif
+
+#else // NO_SYCL
 __attribute__((sycl_device)) // expected-warning {{'sycl_device' attribute ignored}}
 void baz() {}
 

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -2,6 +2,7 @@
 // RUN: %clang_cc1 -verify -DNO_SYCL %s
 
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -DNOT_STRICT -Wno-error=sycl-strict -Wno-sycl-strict %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -DWARN_STRICT -Wno-error=sycl-strict %s
 
 #ifndef NO_SYCL
 
@@ -27,17 +28,23 @@ class A {
   int func3() {}
 };
 
-#ifndef NOT_STRICT
+#if defined(NOT_STRICT)
+__attribute__((sycl_device))
+int* func3() { return nullptr; }
+
+__attribute__((sycl_device))
+void func3(int *) {}
+#elif defined(WARN_STRICT)
+__attribute__((sycl_device)) // expected-warning {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
+int* func3() { return nullptr; }
+
+__attribute__((sycl_device)) // expected-warning {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer parameter type}}
+void func3(int *) {}
+#else
 __attribute__((sycl_device)) // expected-error {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
 int* func3() { return nullptr; }
 
 __attribute__((sycl_device)) // expected-error {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer parameter type}}
-void func3(int *) {}
-#else
-__attribute__((sycl_device))
-int* func3() { return nullptr; }
-
-__attribute__((sycl_device))
 void func3(int *) {}
 #endif
 


### PR DESCRIPTION
SYCL 1.2.1 specification does not allow SYCL_EXTERNAL to be applied to
a function with a pointer argument or with a pointer return
value. This is required to limit address space inference work to a
single translation unit.

Given that we make inference after we link all translation units
together, it should not really matter now. And there are several cases
where external functions with pointers can be useful, so this patch
tuns an error into a warning.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>