### PR TITLE
[SYCL] Fix regression with program building

### DIFF
--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -44,7 +44,7 @@ public:
   program_impl(const context &Context, vector_class<device> DeviceList)
       : Context(Context), Devices(DeviceList) {}
 
-  // Don't allow kernels caching for linked programs due to only compiled
+  // Kernels caching for linked programs won't be allowed due to only compiled
   // state of each and every program in the list and thus unknown state of
   // caching resolution
   program_impl(vector_class<std::shared_ptr<program_impl>> ProgramList,
@@ -96,7 +96,7 @@ public:
     }
   }
 
-  // Disallow kernels caching for programs created by interoperability c-tor
+  // Kernel caching for programs created by interoperability c-tor isn't allowed
   program_impl(const context &Context, RT::PiProgram Program)
       : Program(Program), Context(Context), IsLinkable(true) {
 

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -209,7 +209,7 @@ public:
     if (!is_host()) {
       OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
       // If there are no build options, program can be safely cached
-      if (is_cacheable_with_build_options(BuildOptions)) {
+      if (is_cacheable_with_options(BuildOptions)) {
         AllowKernelsCaching = true;
         Program =
             ProgramManager::getInstance().getBuiltOpenCLProgram(M, Context);
@@ -420,14 +420,14 @@ private:
   }
 
   bool is_cacheable() const {
-    return is_cacheable_with_build_options(BuildOptions) &&
-           is_cacheable_with_build_options(CompileOptions) &&
-           is_cacheable_with_build_options(LinkOptions) && AllowKernelsCaching;
+    return is_cacheable_with_options(BuildOptions) &&
+           is_cacheable_with_options(CompileOptions) &&
+           is_cacheable_with_options(LinkOptions) && AllowKernelsCaching;
   }
 
   static bool
-  is_cacheable_with_build_options(const string_class &BuildOptions) {
-    return BuildOptions.empty();
+  is_cacheable_with_options(const string_class &Options) {
+    return Options.empty();
   }
 
   RT::PiKernel get_pi_kernel(const string_class &KernelName) const {

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -210,7 +210,7 @@ public:
       OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
       // If there are no build options, program can be safely cached
       if (is_cacheable_with_options(BuildOptions)) {
-        AllowKernelsCaching = true;
+        IsProgramAndKernelCachingAllowed = true;
         Program =
             ProgramManager::getInstance().getBuiltOpenCLProgram(M, Context);
         PI_CALL(piProgramRetain)(Program);
@@ -420,9 +420,7 @@ private:
   }
 
   bool is_cacheable() const {
-    return is_cacheable_with_options(BuildOptions) &&
-           is_cacheable_with_options(CompileOptions) &&
-           is_cacheable_with_options(LinkOptions) && AllowKernelsCaching;
+    return IsProgramAndKernelCachingAllowed;
   }
 
   static bool
@@ -485,7 +483,7 @@ private:
   // Only allow kernel caching for programs constructed with context only (or
   // device list and context) and built with build_with_kernel_type with
   // default build options
-  bool AllowKernelsCaching = false;
+  bool IsProgramAndKernelCachingAllowed = false;
 };
 
 template <>


### PR DESCRIPTION
This patch fixes regression introduced by #847: programs and kernels are cached when program is built with sequence of compile_with_kernel_type()/compile_with_source() and then linked with link().

By design, caching of kernels and programs is permitted only when program is built with build_with_kernel_type() using the default options.