### PR TITLE
[SYCL] Fix sporadic failure in kernel-and-program.cpp

### DIFF
--- a/sycl/test/kernel-and-program/kernel-and-program.cpp
+++ b/sycl/test/kernel-and-program/kernel-and-program.cpp
@@ -63,6 +63,7 @@ int main() {
         err = clEnqueueWriteBuffer(clQ, clBuffer, CL_TRUE, 0, sizeof(int),
                                    &data, 0, NULL, NULL);
         assert(err == CL_SUCCESS);
+        clFinish(clQ);
         cl::sycl::program prog(ctx);
         prog.build_with_source(
             "kernel void SingleTask(global int* a) {*a+=1; }\n");


### PR DESCRIPTION
clEnqueueWriteBuffer operation with `blocking == CL_TRUE' is *not*
guaranteed to complete before it returns. It only guarantees that the
host pointer (data) can now be re-used or free'ed: an OpenCL runtime
either already completed the operation, or (the faulty case) an OpenCL
runtime copied data to an internal (temporary) memory and the
operation will be executed later.

We have to explicitly finish the operation in order to avoid a data
race when the faulty case happens.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>