### PR TITLE
[SYCL] Refactor context to enhance ABI compatibility

### DIFF
--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -10,7 +10,6 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/exception_list.hpp>
 #include <CL/sycl/info/info_desc.hpp>
-#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/stl.hpp>
 #include <type_traits>
 // 4.6.2 Context class
@@ -20,6 +19,9 @@ namespace sycl {
 // Forward declarations
 class device;
 class platform;
+namespace detail {
+class context_impl;
+}
 
 class context {
 public:

--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -8,11 +8,10 @@
 
 #pragma once
 #include <CL/sycl/detail/common.hpp>
-#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/exception_list.hpp>
 #include <CL/sycl/info/info_desc.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/stl.hpp>
-#include <memory>
 #include <type_traits>
 // 4.6.2 Context class
 
@@ -21,18 +20,19 @@ namespace sycl {
 // Forward declarations
 class device;
 class platform;
+
 class context {
 public:
-  explicit context(const async_handler &asyncHandler = {});
+  explicit context(const async_handler &AsyncHandler = {});
 
-  context(const device &dev, async_handler asyncHandler = {});
+  context(const device &Device, async_handler AsyncHandler = {});
 
-  context(const platform &plt, async_handler asyncHandler = {});
+  context(const platform &Platform, async_handler AsyncHandler = {});
 
-  context(const vector_class<device> &deviceList,
-          async_handler asyncHandler = {});
+  context(const vector_class<device> &DeviceList,
+          async_handler AsyncHandler = {});
 
-  context(cl_context clContext, async_handler asyncHandler = {});
+  context(cl_context ClContext, async_handler AsyncHandler = {});
 
   template <info::context param>
   typename info::param_traits<info::context, param>::return_type
@@ -46,9 +46,9 @@ public:
 
   context &operator=(context &&rhs) = default;
 
-  bool operator==(const context &rhs) const;
+  bool operator==(const context &rhs) const { return impl == rhs.impl; }
 
-  bool operator!=(const context &rhs) const;
+  bool operator!=(const context &rhs) const { return !(*this == rhs); }
 
   cl_context get() const;
 
@@ -59,7 +59,7 @@ public:
   vector_class<device> get_devices() const;
 
 private:
-  std::shared_ptr<detail::context_impl> impl;
+  shared_ptr_class<detail::context_impl> impl;
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
@@ -74,9 +74,9 @@ private:
 
 namespace std {
 template <> struct hash<cl::sycl::context> {
-  size_t operator()(const cl::sycl::context &c) const {
-    return hash<std::shared_ptr<cl::sycl::detail::context_impl>>()(
-        cl::sycl::detail::getSyclObjImpl(c));
+  size_t operator()(const cl::sycl::context &Context) const {
+    return hash<cl::sycl::shared_ptr_class<cl::sycl::detail::context_impl>>()(
+        cl::sycl::detail::getSyclObjImpl(Context));
   }
 };
 } // namespace std

--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -118,7 +118,7 @@ public:
 
   /// Gets devices associated with this SYCL context.
   ///
-  /// @return a list of valid SYCL device instances.
+  /// @return a vector of valid SYCL device instances.
   vector_class<device> get_devices() const;
 
 private:

--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -25,17 +25,64 @@ class context_impl;
 
 class context {
 public:
+  /// Constructs a SYCL context instance using an instance of default_selector.
+  ///
+  /// The instance of default_selector is used to select the associated platform
+  /// and device(s).
+  /// The constructed SYCL context will use the AsyncHandler parameter to handle
+  /// exceptions.
+  ///
+  /// @param AsyncHandler is an instance of async_handler.
   explicit context(const async_handler &AsyncHandler = {});
 
+  /// Constructs a SYCL context instance using the provided device.
+  ///
+  /// Newly created context is associated with the Device and the SYCL platform
+  /// that is associated with the Device.
+  /// The constructed SYCL context will use the AsyncHandler parameter to handle
+  /// exceptions.
+  ///
+  /// @param Device is an instance of SYCL device.
+  /// @param AsyncHandler is an instance of async_handler.
   context(const device &Device, async_handler AsyncHandler = {});
 
+  /// Constructs a SYCL context instance using the provided platform.
+  ///
+  /// Newly created context is associated with the Platform and with each
+  /// SYCL device that is associated with the Platform.
+  /// The constructed SYCL context will use the AsyncHandler parameter to handle
+  /// exceptions.
+  ///
+  /// @param Platform is an instance of SYCL platform.
+  /// @param AsyncHandler is an instance of async_handler.
   context(const platform &Platform, async_handler AsyncHandler = {});
 
+  /// Constructs a SYCL context instance using list of devices.
+  ///
+  /// Newly created context will be associated with each SYCL device in the
+  /// DeviceList. This requires that all SYCL devices in the list have the same
+  /// associated SYCL platform.
+  /// The constructed SYCL context will use the AsyncHandler parameter to handle
+  /// exceptions.
+  ///
+  /// @param DeviceList is a list of SYCL device instances.
+  /// @param AsyncHandler is an instance of async_handler.
   context(const vector_class<device> &DeviceList,
           async_handler AsyncHandler = {});
 
+  /// Constructs a SYCL context instance from OpenCL cl_context.
+  ///
+  /// ClContext is retained on SYCL context instantiation.
+  /// The constructed SYCL context will use the AsyncHandler parameter to handle
+  /// exceptions.
+  ///
+  /// @param ClContext is an instance of OpenCL cl_context.
+  /// @param AsyncHandler is an instance of async_handler.
   context(cl_context ClContext, async_handler AsyncHandler = {});
 
+  /// Queries this SYCL context for information.
+  ///
+  /// The return type depends on information being queried.
   template <info::context param>
   typename info::param_traits<info::context, param>::return_type
   get_info() const;
@@ -52,12 +99,26 @@ public:
 
   bool operator!=(const context &rhs) const { return !(*this == rhs); }
 
+  /// Gets OpenCL interoperability context.
+  ///
+  /// The OpenCL cl_context handle is retained on return.
+  ///
+  /// @return a valid instance of OpenCL cl_context.
   cl_context get() const;
 
+  /// Checks if this context is a SYCL host context.
+  ///
+  /// @return true if this context is a SYCL host context.
   bool is_host() const;
 
+  /// Gets platform associated with this SYCL context.
+  ///
+  /// @return a valid instance of SYCL platform.
   platform get_platform() const;
 
+  /// Gets devices associated with this SYCL context.
+  ///
+  /// @return a list of valid SYCL device instances.
   vector_class<device> get_devices() const;
 
 private:

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -11,6 +11,7 @@
 #include <CL/cl.h>
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/context.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/aligned_allocator.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/helpers.hpp>

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -117,9 +117,9 @@ public:
     return MCachedKernels;
   }
 
-  /// Gets USM dispatch.
+  /// Gets USM dispatcher.
   ///
-  /// @return a pointer to USM dispatch.
+  /// @return a pointer to USM dispatcher.
   std::shared_ptr<usm::USMDispatcher> getUSMDispatch() const;
 private:
   async_handler MAsyncHandler;

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -19,7 +19,6 @@
 
 #include <map>
 #include <memory>
-// 4.6.2 Context class
 
 namespace cl {
 namespace sycl {
@@ -28,40 +27,99 @@ class device;
 namespace detail {
 class context_impl {
 public:
+  /// Constructs a context_impl using a single SYCL devices.
+  ///
+  /// The constructed context_impl will use the AsyncHandler parameter to handle
+  /// exceptions.
+  ///
+  /// @param Device is an instance of SYCL device.
+  /// @param AsyncHandler is an instance of async_handler.
   context_impl(const device &Device, async_handler AsyncHandler);
 
+  /// Constructs a context_impl using a list of SYCL devices.
+  ///
+  /// Newly created instance will save each SYCL device in the list. This
+  /// requres that all devices in the list are associated with the same
+  /// SYCL platform.
+  /// The constructed context_impl will use the AsyncHandler parameter to handle
+  /// exceptions.
+  ///
+  /// @param DeviceList is a list of SYCL device instances.
+  /// @param AsyncHandler is an instance of async_handler.
   context_impl(const vector_class<cl::sycl::device> Devices,
                async_handler AsyncHandler);
 
+  /// Construct a context_impl using plug-in interoperability handle.
+  ///
+  /// The constructed context_impl will use the AsyncHandler parameter to handle
+  /// exceptions.
+  ///
+  /// @param PiContext is an instance of a valid plug-in context handle.
+  /// @param AsyncHandler is an instance of async_handler.
   context_impl(RT::PiContext PiContext, async_handler AsyncHandler);
 
   ~context_impl();
 
+  /// Gets OpenCL interoperability context handle.
+  ///
+  /// @return an instance of OpenCL cl_context.
   cl_context get() const;
 
+  /// Checks if this context is a host context.
+  ///
+  /// @return true if this context is a host context.
   bool is_host() const;
 
+  /// Gets asynchronous exception handler.
+  ///
+  /// @return an instance of SYCL async_handler.
   const async_handler &get_async_handler() const;
 
+  /// Queries this context for information.
+  ///
+  /// The return type depends on information being queried.
   template <info::context param>
   typename info::param_traits<info::context, param>::return_type
   get_info() const;
 
-  // Returns underlying native context object (if any) w/o reference count
-  // modification. Caller must ensure the returned object lives on stack only.
-  // It can also be safely passed to the underlying native runtime API.
-  // Warning. Returned reference will be invalid if context_impl was destroyed.
+  /// Gets the underlying context object (if any) without reference count
+  /// modification.
+  ///
+  /// Caller must ensure the returned object lives on stack only. It can also
+  /// be safely passed to the underlying native runtime API. Warning. Returned
+  /// reference will be invalid if context_impl was destroyed.
+  ///
+  /// @return an instance of raw plug-in context handle.
   RT::PiContext &getHandleRef();
+
+  /// Gets the underlying context object (if any) without reference count
+  /// modification.
+  ///
+  /// Caller must ensure the returned object lives on stack only. It can also
+  /// be safely passed to the underlying native runtime API. Warning. Returned
+  /// reference will be invalid if context_impl was destroyed.
+  ///
+  /// @return an instance of raw plug-in context handle.
   const RT::PiContext &getHandleRef() const;
 
+  /// Gets cached programs.
+  ///
+  /// @return a map of cached programs.
   std::map<OSModuleHandle, RT::PiProgram> &getCachedPrograms() {
     return MCachedPrograms;
   }
+
+  /// Gets cached kernels.
+  ///
+  /// @return a map of cached kernels.
   std::map<RT::PiProgram, std::map<string_class, RT::PiKernel>> &
   getCachedKernels() {
     return MCachedKernels;
   }
 
+  /// Gets USM dispatch.
+  ///
+  /// @return a pointer to USM dispatch.
   std::shared_ptr<usm::USMDispatcher> getUSMDispatch() const;
 private:
   async_handler MAsyncHandler;

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/os_util.hpp>

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -33,7 +33,7 @@ public:
   context_impl(const vector_class<cl::sycl::device> Devices,
                async_handler AsyncHandler);
 
-  context_impl(cl_context ClContext, async_handler AsyncHandler);
+  context_impl(RT::PiContext PiContext, async_handler AsyncHandler);
 
   ~context_impl();
 

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -41,10 +41,6 @@ public:
 
   bool is_host() const;
 
-  platform get_platform() const;
-
-  vector_class<device> get_devices() const;
-
   const async_handler &get_async_handler() const;
 
   template <info::context param>
@@ -59,24 +55,24 @@ public:
   const RT::PiContext &getHandleRef() const;
 
   std::map<OSModuleHandle, RT::PiProgram> &getCachedPrograms() {
-    return m_CachedPrograms;
+    return MCachedPrograms;
   }
   std::map<RT::PiProgram, std::map<string_class, RT::PiKernel>> &
   getCachedKernels() {
-    return m_CachedKernels;
+    return MCachedKernels;
   }
 
   std::shared_ptr<usm::USMDispatcher> getUSMDispatch() const;
 private:
-  async_handler m_AsyncHandler;
-  vector_class<device> m_Devices;
-  RT::PiContext m_Context;
-  platform m_Platform;
-  bool m_OpenCLInterop;
-  bool m_HostContext;
-  std::map<OSModuleHandle, RT::PiProgram> m_CachedPrograms;
-  std::map<RT::PiProgram, std::map<string_class, RT::PiKernel>> m_CachedKernels;
-  std::shared_ptr<usm::USMDispatcher> m_USMDispatch;
+  async_handler MAsyncHandler;
+  vector_class<device> MDevices;
+  RT::PiContext MContext;
+  platform MPlatform;
+  bool MPluginInterop;
+  bool MHostContext;
+  std::map<OSModuleHandle, RT::PiProgram> MCachedPrograms;
+  std::map<RT::PiProgram, std::map<string_class, RT::PiKernel>> MCachedKernels;
+  std::shared_ptr<usm::USMDispatcher> MUSMDispatch;
 };
 
 } // namespace detail

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+#include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/os_util.hpp>

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/detail/aligned_allocator.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/generic_type_traits.hpp>
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -353,7 +353,7 @@ private:
 
   template <info::device Param>
   bool checkImageValueRange(const ContextImplPtr Context, const size_t Value) {
-    const auto &Devices = Context->get_devices();
+    const auto &Devices = Context->get_info<info::context::devices>();
     return Value >= 1 && std::all_of(Devices.cbegin(), Devices.cend(),
                                      [Value](const device &Dev) {
                                        return Value <= Dev.get_info<Param>();

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -10,6 +10,7 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/program_manager/program_manager.hpp>

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/context.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/device.hpp>

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_i.hpp>

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <CL/sycl/detail/common.hpp>
-#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_i.hpp>

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/memory_manager.hpp>
@@ -26,7 +25,6 @@ namespace sycl {
 namespace detail {
 
 // Forward declarations
-class context_impl;
 class event_impl;
 
 using ContextImplPtr = shared_ptr_class<context_impl>;

--- a/sycl/include/CL/sycl/info/context_traits.def
+++ b/sycl/include/CL/sycl/info/context_traits.def
@@ -1,0 +1,3 @@
+PARAM_TRAITS_SPEC(context, reference_count, cl_uint)
+PARAM_TRAITS_SPEC(context, platform, cl::sycl::platform)
+PARAM_TRAITS_SPEC(context, devices, vector_class<cl::sycl::device>)

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -256,9 +256,7 @@ template <typename T, T param> class param_traits {};
 
 #include <CL/sycl/info/device_traits.def>
 
-PARAM_TRAITS_SPEC(context, reference_count, cl_uint)
-PARAM_TRAITS_SPEC(context, platform, cl::sycl::platform)
-PARAM_TRAITS_SPEC(context, devices, vector_class<cl::sycl::device>)
+#include <CL/sycl/info/context_traits.def>
 
 PARAM_TRAITS_SPEC(event, command_execution_status, event_command_status)
 PARAM_TRAITS_SPEC(event, reference_count, cl_uint)

--- a/sycl/include/CL/sycl/property_list.hpp
+++ b/sycl/include/CL/sycl/property_list.hpp
@@ -8,14 +8,13 @@
 
 #pragma once
 
+#include <CL/sycl/context.hpp>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 
 namespace cl {
 namespace sycl {
-// Forward declaration
-class context;
 
 // HOW TO ADD NEW PROPERTY INSTRUCTION:
 // 1. Add forward declaration of property class.

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -37,12 +37,11 @@ context::context(const vector_class<device> &DeviceList,
   if (DeviceList.empty()) {
     throw invalid_parameter_error("First argument deviceList is empty.");
   }
-  if (DeviceList[0].is_host()) {
+  if (DeviceList[0].is_host())
     impl = std::make_shared<detail::context_impl>(DeviceList[0], AsyncHandler);
-  } else {
+  else
     // TODO also check that devices belongs to the same platform
     impl = std::make_shared<detail::context_impl>(DeviceList, AsyncHandler);
-  }
 }
 
 context::context(cl_context ClContext, async_handler AsyncHandler) {

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -46,7 +46,8 @@ context::context(const vector_class<device> &DeviceList,
 }
 
 context::context(cl_context ClContext, async_handler AsyncHandler) {
-  impl = std::make_shared<detail::context_impl>(ClContext, AsyncHandler);
+  impl = std::make_shared<detail::context_impl>(
+          detail::pi::cast<detail::RT::PiContext>(ClContext), AsyncHandler);
 }
 
 #define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -23,59 +23,51 @@
 
 namespace cl {
 namespace sycl {
-context::context(const async_handler &asyncHandler)
-    : context(default_selector().select_device(), asyncHandler) {}
+context::context(const async_handler &AsyncHandler)
+    : context(default_selector().select_device(), AsyncHandler) {}
 
-context::context(const device &dev, async_handler asyncHandler)
-    : context(vector_class<device>(1, dev), asyncHandler) {}
+context::context(const device &Device, async_handler AsyncHandler)
+    : context(vector_class<device>(1, Device), AsyncHandler) {}
 
-context::context(const platform &plt, async_handler asyncHandler)
-    : context(plt.get_devices(), asyncHandler) {}
+context::context(const platform &Platform, async_handler AsyncHandler)
+    : context(Platform.get_devices(), AsyncHandler) {}
 
-context::context(const vector_class<device> &deviceList,
-                 async_handler asyncHandler) {
-  if (deviceList.empty()) {
+context::context(const vector_class<device> &DeviceList,
+                 async_handler AsyncHandler) {
+  if (DeviceList.empty()) {
     throw invalid_parameter_error("First argument deviceList is empty.");
   }
-  if (deviceList[0].is_host()) {
-    impl = std::make_shared<detail::context_impl>(deviceList[0], asyncHandler);
+  if (DeviceList[0].is_host()) {
+    impl = std::make_shared<detail::context_impl>(DeviceList[0], AsyncHandler);
   } else {
     // TODO also check that devices belongs to the same platform
-    impl = std::make_shared<detail::context_impl>(deviceList, asyncHandler);
+    impl = std::make_shared<detail::context_impl>(DeviceList, AsyncHandler);
   }
 }
 
-context::context(cl_context clContext, async_handler asyncHandler) {
-  impl = std::make_shared<detail::context_impl>(clContext, asyncHandler);
+context::context(cl_context ClContext, async_handler AsyncHandler) {
+  impl = std::make_shared<detail::context_impl>(ClContext, AsyncHandler);
 }
 
-template <> cl_uint context::get_info<info::context::reference_count>() const {
-  return impl->get_info<info::context::reference_count>();
-}
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template <> ret_type context::get_info<info::param_type::param>() const {    \
+    return impl->get_info<info::param_type::param>();                          \
+  }
 
-template <>
-cl::sycl::platform context::get_info<info::context::platform>() const {
-  return impl->get_info<info::context::platform>();
-}
+#include <CL/sycl/info/context_traits.def>
 
-template <>
-vector_class<cl::sycl::device>
-context::get_info<info::context::devices>() const {
-  return impl->get_info<info::context::devices>();
-}
-
-bool context::operator==(const context &rhs) const { return impl == rhs.impl; }
-
-bool context::operator!=(const context &rhs) const { return !(*this == rhs); }
+#undef PARAM_TRAITS_SPEC
 
 cl_context context::get() const { return impl->get(); }
 
 bool context::is_host() const { return impl->is_host(); }
 
-platform context::get_platform() const { return impl->get_platform(); }
+platform context::get_platform() const {
+  return impl->get_info<info::context::platform>();
+}
 
 vector_class<device> context::get_devices() const {
-  return impl->get_devices();
+  return impl->get_info<info::context::devices>();
 }
 
 } // namespace sycl

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -35,7 +35,7 @@ context::context(const platform &Platform, async_handler AsyncHandler)
 context::context(const vector_class<device> &DeviceList,
                  async_handler AsyncHandler) {
   if (DeviceList.empty()) {
-    throw invalid_parameter_error("First argument deviceList is empty.");
+    throw invalid_parameter_error("DeviceList is empty.");
   }
   if (DeviceList[0].is_host())
     impl = std::make_shared<detail::context_impl>(DeviceList[0], AsyncHandler);

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -41,11 +41,10 @@ context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
   MUSMDispatch.reset(new usm::USMDispatcher(MPlatform.get(), DeviceIds));
 }
 
-context_impl::context_impl(cl_context ClContext, async_handler AsyncHandler)
-    : MAsyncHandler(AsyncHandler), MDevices(), MPlatform(),
+context_impl::context_impl(RT::PiContext PiContext, async_handler AsyncHandler)
+    : MAsyncHandler(AsyncHandler), MDevices(), MContext(PiContext), MPlatform(),
       MPluginInterop(true), MHostContext(false) {
 
-  MContext = pi::cast<RT::PiContext>(ClContext);
   vector_class<RT::PiDevice> DeviceIds;
   size_t DevicesNum = 0;
   // TODO catch an exception and put it to list of asynchronous exceptions

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -22,74 +22,72 @@ namespace sycl {
 namespace detail {
 
 context_impl::context_impl(const device &Device, async_handler AsyncHandler)
-    : m_AsyncHandler(AsyncHandler), m_Devices(1, Device), m_Context(nullptr),
-      m_Platform(), m_OpenCLInterop(false), m_HostContext(true) {}
+    : MAsyncHandler(AsyncHandler), MDevices(1, Device), MContext(nullptr),
+      MPlatform(), MPluginInterop(false), MHostContext(true) {}
 
 context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
                            async_handler AsyncHandler)
-    : m_AsyncHandler(AsyncHandler), m_Devices(Devices), m_Context(nullptr),
-      m_Platform(), m_OpenCLInterop(true), m_HostContext(false) {
-  m_Platform = m_Devices[0].get_platform();
+    : MAsyncHandler(AsyncHandler), MDevices(Devices), MContext(nullptr),
+      MPlatform(), MPluginInterop(true), MHostContext(false) {
+  MPlatform = MDevices[0].get_platform();
   vector_class<RT::PiDevice> DeviceIds;
-  for (const auto &D : m_Devices) {
+  for (const auto &D : MDevices) {
     DeviceIds.push_back(getSyclObjImpl(D)->getHandleRef());
   }
 
   PI_CALL(piContextCreate)(nullptr, DeviceIds.size(), DeviceIds.data(), nullptr,
-                           nullptr, &m_Context);
+                           nullptr, &MContext);
 
-  m_USMDispatch.reset(new usm::USMDispatcher(m_Platform.get(), DeviceIds));
+  MUSMDispatch.reset(new usm::USMDispatcher(MPlatform.get(), DeviceIds));
 }
 
 context_impl::context_impl(cl_context ClContext, async_handler AsyncHandler)
-    : m_AsyncHandler(AsyncHandler), m_Devices(), m_Platform(),
-      m_OpenCLInterop(true), m_HostContext(false) {
+    : MAsyncHandler(AsyncHandler), MDevices(), MPlatform(),
+      MPluginInterop(true), MHostContext(false) {
 
-  m_Context = pi::cast<RT::PiContext>(ClContext);
+  MContext = pi::cast<RT::PiContext>(ClContext);
   vector_class<RT::PiDevice> DeviceIds;
   size_t DevicesNum = 0;
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piContextGetInfo)(m_Context, PI_CONTEXT_INFO_NUM_DEVICES,
+  PI_CALL(piContextGetInfo)(MContext, PI_CONTEXT_INFO_NUM_DEVICES,
                             sizeof(DevicesNum), &DevicesNum, nullptr);
   DeviceIds.resize(DevicesNum);
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piContextGetInfo)(m_Context, PI_CONTEXT_INFO_DEVICES,
+  PI_CALL(piContextGetInfo)(MContext, PI_CONTEXT_INFO_DEVICES,
                             sizeof(RT::PiDevice) * DevicesNum, &DeviceIds[0],
                             nullptr);
 
   for (auto Dev : DeviceIds) {
-    m_Devices.emplace_back(
+    MDevices.emplace_back(
         createSyclObjFromImpl<device>(std::make_shared<device_impl>(Dev)));
   }
   // TODO What if m_Devices if empty? m_Devices[0].get_platform()
-  m_Platform = platform(m_Devices[0].get_platform());
+  MPlatform = platform(MDevices[0].get_platform());
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piContextRetain)(m_Context);
+  PI_CALL(piContextRetain)(MContext);
 }
 
 cl_context context_impl::get() const {
-  if (m_OpenCLInterop) {
+  if (MPluginInterop) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piContextRetain)(m_Context);
-    return pi::cast<cl_context>(m_Context);
+    PI_CALL(piContextRetain)(MContext);
+    return pi::cast<cl_context>(MContext);
   }
   throw invalid_object_error(
       "This instance of context doesn't support OpenCL interoperability.");
 }
 
-bool context_impl::is_host() const { return m_HostContext || !m_OpenCLInterop; }
-platform context_impl::get_platform() const { return m_Platform; }
-vector_class<device> context_impl::get_devices() const { return m_Devices; }
+bool context_impl::is_host() const { return MHostContext || !MPluginInterop; }
 
 context_impl::~context_impl() {
-  if (m_OpenCLInterop) {
+  if (MPluginInterop) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piContextRelease)(m_Context);
+    PI_CALL(piContextRelease)(MContext);
   }
   // Release all programs and kernels created with this context
-  for (auto ProgIt : m_CachedPrograms) {
+  for (auto ProgIt : MCachedPrograms) {
     RT::PiProgram ToBeDeleted = ProgIt.second;
-    for (auto KernIt : m_CachedKernels[ToBeDeleted]) {
+    for (auto KernIt : MCachedKernels[ToBeDeleted]) {
       PI_CALL(piKernelRelease)(KernIt.second);
     }
     PI_CALL(piProgramRelease)(ToBeDeleted);
@@ -97,7 +95,7 @@ context_impl::~context_impl() {
 }
 
 const async_handler &context_impl::get_async_handler() const {
-  return m_AsyncHandler;
+  return MAsyncHandler;
 }
 
 template <>
@@ -109,19 +107,19 @@ cl_uint context_impl::get_info<info::context::reference_count>() const {
       this->getHandleRef());
 }
 template <> platform context_impl::get_info<info::context::platform>() const {
-  return get_platform();
+  return MPlatform;
 }
 template <>
 vector_class<cl::sycl::device>
 context_impl::get_info<info::context::devices>() const {
-  return get_devices();
+  return MDevices;
 }
 
-RT::PiContext &context_impl::getHandleRef() { return m_Context; }
-const RT::PiContext &context_impl::getHandleRef() const { return m_Context; }
+RT::PiContext &context_impl::getHandleRef() { return MContext; }
+const RT::PiContext &context_impl::getHandleRef() const { return MContext; }
 
 std::shared_ptr<usm::USMDispatcher> context_impl::getUSMDispatch() const {
-  return m_USMDispatch;
+  return MUSMDispatch;
 }
 
 } // namespace detail

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -99,9 +99,8 @@ const async_handler &context_impl::get_async_handler() const {
 
 template <>
 cl_uint context_impl::get_info<info::context::reference_count>() const {
-  if (is_host()) {
+  if (is_host())
     return 0;
-  }
   return get_context_info<info::context::reference_count>::get(
       this->getHandleRef());
 }

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/kernel_info.hpp>
 #include <CL/sycl/info/info_desc.hpp>

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -8,6 +8,7 @@
 
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/program_manager/program_manager.hpp>

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl/context.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/sampler_impl.hpp>
 
 namespace cl {

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/sampler_impl.hpp>
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -11,6 +11,7 @@
 #include "CL/sycl/access/access.hpp"
 #include <CL/cl.h>
 #include <CL/sycl/detail/clusm.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/detail/kernel_info.hpp>

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -8,6 +8,7 @@
 
 #include <CL/sycl/access/access.hpp>
 #include "detail/config.hpp"
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/queue_impl.hpp>


### PR DESCRIPTION
This patch is a part of effort to decouple SYCL Runtime library
interface from its actual implementation. The goal is to improve
SYCL ABI/API compatibility between different versions of library.

The following modifications were applied to context and context_impl
classes:

1. Removed include of context_impl header from context.hpp and replaced
it with forward declaration.
2. std::shared_ptr was replaced with shared_ptr_class for context class
3. Documentation was improved for both context and context_impl
4. context_impl now tries to follow LLVM code style

Applying aforementioned changes requires modifying other header files.
While some of those may seem as a regression, affected classes will be
covered by future patches.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>