### PR TITLE
[SYCL][FPGA] Add Intel FPGA bank_bits attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1744,6 +1744,24 @@ def SYCLFPGAPipe : TypeAttr {
   let Documentation = [SYCLFPGAPipeDocs];
 }
 
+// Variadic integral arguments.
+def IntelFPGABankBits : Attr {
+  let Spellings = [CXX11<"intelfpga", "bank_bits">];
+  let Args = [VariadicExprArgument<"Args">];
+  let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticSlaveMemVar,
+                              Field], ErrorDiag>;
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let Documentation = [IntelFPGABankBitsDocs];
+  let AdditionalMembers = [{
+    static unsigned getMinValue() {
+      return 0;
+    }
+    static unsigned getMaxValue() {
+      return 1024*1024;
+    }
+  }];
+}
+
 def Naked : InheritableAttr {
   let Spellings = [GCC<"naked">, Declspec<"naked">];
   let Subjects = SubjectList<[Function]>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1848,6 +1848,17 @@ loads).
   }];
 }
 
+def IntelFPGABankBitsDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "bank_bits (IntelFPGA)";
+  let Content = [{
+This attribute may be attached to a variable or struct member declaration and
+instructs the backend to implement the variable or struct member in a banked
+memory with 2^(N+1) banks, where the (b0, ..., bn) bits specified determine the
+pointer address bits to bank on.
+  }];
+}
+
 def SYCLIntelKernelArgsRestrictDocs : Documentation {
   let Category = DocCatVariable;
   let Heading = "kernel_args_restrict";

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -139,6 +139,10 @@ def err_loop_unroll_compatibility : Error<
   "incompatible loop unroll instructions: '%0' and '%1'">;
 def err_pipe_attribute_arg_not_allowed : Error<
   "'%0' mode for pipe attribute is not supported. Allowed modes: 'read_only', 'write_only'">;
+def err_bankbits_numbanks_conflicting : Error<
+  "the number of bank_bits must be equal to ceil(log2(numbanks))">;
+def err_bankbits_non_consecutive : Error<
+  "bank_bits must be consecutive">;
 
 // C99 variable-length arrays
 def ext_vla : Extension<"variable length arrays are a C99 feature">,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -9245,6 +9245,8 @@ public:
   template <typename AttrType>
   void AddOneConstantPowerTwoValueAttr(Decl *D, const AttributeCommonInfo &CI,
                                        Expr *E);
+  void AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
+                                Expr **Exprs, unsigned Size);
 
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3966,8 +3966,20 @@ void CodeGenModule::generateIntelFPGAAnnotation(
     Out << '{' << MCA->getSpelling() << ':' << MCAInt << '}';
   }
   if (const auto *NBA = D->getAttr<IntelFPGANumBanksAttr>()) {
-    llvm::APSInt BWAInt = NBA->getValue()->EvaluateKnownConstInt(getContext());
-    Out << '{' << NBA->getSpelling() << ':' << BWAInt << '}';
+    llvm::APSInt NBAInt = NBA->getValue()->EvaluateKnownConstInt(getContext());
+    Out << '{' << NBA->getSpelling() << ':' << NBAInt << '}';
+  }
+  if (const auto *BBA = D->getAttr<IntelFPGABankBitsAttr>()) {
+    Out << '{' << BBA->getSpelling() << ':';
+    for (IntelFPGABankBitsAttr::args_iterator I = BBA->args_begin(),
+                                              E = BBA->args_end();
+         I != E; ++I) {
+      if (I != BBA->args_begin())
+        Out << ',';
+      llvm::APSInt BBAInt = (*I)->EvaluateKnownConstInt(getContext());
+      Out << BBAInt;
+    }
+    Out << '}';
   }
   if (const auto *MRA = D->getAttr<IntelFPGAMaxReplicatesAttr>()) {
     llvm::APSInt MRAInt = MRA->getValue()->EvaluateKnownConstInt(getContext());

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3761,6 +3761,15 @@ void Sema::AddOneConstantPowerTwoValueAttr(Decl *D,
           << &TmpAttr;
       return;
     }
+    if (IntelFPGANumBanksAttr::classof(&TmpAttr)) {
+      if (auto *BBA = D->getAttr<IntelFPGABankBitsAttr>()) {
+        unsigned NumBankBits = BBA->args_size();
+        if (NumBankBits != Value.ceilLogBase2()) {
+          Diag(TmpAttr.getLocation(), diag::err_bankbits_numbanks_conflicting);
+          return;
+        }
+      }
+    }
     E = ICE.get();
   }
 
@@ -5105,6 +5114,8 @@ static bool checkIntelFPGARegisterAttrCompatibility(Sema &S, Decl *D,
     InCompat = true;
   if (checkAttrMutualExclusion<IntelFPGAMergeAttr>(S, D, Attr))
     InCompat = true;
+  if (checkAttrMutualExclusion<IntelFPGABankBitsAttr>(S, D, Attr))
+    InCompat = true;
 
   return InCompat;
 }
@@ -5207,6 +5218,92 @@ static void handleIntelFPGAMergeAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 
   D->addAttr(::new (S.Context)
                  IntelFPGAMergeAttr(S.Context, AL, Results[0], Results[1]));
+}
+
+/// Handle the bank_bits attribute.
+/// This attribute accepts a list of values greater than zero.
+/// This is incompatible with the register attribute.
+/// The numbanks and bank_bits attributes are related. If numbanks exists
+/// when handling bank_bits they are checked for consistency. If numbanks
+/// hasn't been added yet an implicit one is added with the correct value.
+/// If the user later adds a numbanks attribute the implicit one is removed.
+/// The values must be consecutive values (i.e. 3,4,5 or 2,1).
+static void handleIntelFPGABankBitsAttr(Sema &S, Decl *D,
+                                        const ParsedAttr &Attr) {
+  checkForDuplicateAttribute<IntelFPGABankBitsAttr>(S, D, Attr);
+
+  if (!checkAttributeAtLeastNumArgs(S, Attr, 1))
+    return;
+
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
+    return;
+
+  SmallVector<Expr *, 8> Args;
+  for (unsigned I = 0; I < Attr.getNumArgs(); ++I) {
+    Args.push_back(Attr.getArgAsExpr(I));
+  }
+
+  S.AddIntelFPGABankBitsAttr(D, Attr, Args.data(), Args.size());
+}
+
+void Sema::AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
+                                    Expr **Exprs, unsigned Size) {
+  IntelFPGABankBitsAttr TmpAttr(Context, CI, Exprs, Size);
+  SmallVector<Expr *, 8> Args;
+  SmallVector<int64_t, 8> Values;
+  bool ListIsValueDep = false;
+  for (auto *E : TmpAttr.args()) {
+    llvm::APSInt Value(32, /*IsUnsigned=*/false);
+    Expr::EvalResult Result;
+    ListIsValueDep = ListIsValueDep || E->isValueDependent();
+    if (!E->isValueDependent()) {
+      ExprResult ICE;
+      if (checkRangedIntegralArgument<IntelFPGABankBitsAttr>(E, &TmpAttr, ICE))
+        return;
+      if (E->EvaluateAsInt(Result, Context))
+        Value = Result.Val.getInt();
+      E = ICE.get();
+    }
+    Args.push_back(E);
+    Values.push_back(Value.getExtValue());
+  }
+
+  // Check that the list is consecutive.
+  if (!ListIsValueDep && Values.size() > 1) {
+    bool ListIsAscending = Values[0] < Values[1];
+    for (int I = 0, E = Values.size() - 1; I < E; ++I) {
+      if (Values[I + 1] != Values[I] + (ListIsAscending ? 1 : -1)) {
+        Diag(CI.getLoc(), diag::err_bankbits_non_consecutive) << &TmpAttr;
+        return;
+      }
+    }
+  }
+
+  // Check or add the related numbanks attribute.
+  if (auto *NBA = D->getAttr<IntelFPGANumBanksAttr>()) {
+    Expr *E = NBA->getValue();
+    if (!E->isValueDependent()) {
+      Expr::EvalResult Result;
+      E->EvaluateAsInt(Result, Context);
+      llvm::APSInt Value = Result.Val.getInt();
+      if (Args.size() != Value.ceilLogBase2()) {
+        Diag(TmpAttr.getLoc(), diag::err_bankbits_numbanks_conflicting);
+        return;
+      }
+    }
+  } else {
+    llvm::APInt Num(32, (unsigned)(1 << Args.size()));
+    Expr *NBE =
+        IntegerLiteral::Create(Context, Num, Context.IntTy, SourceLocation());
+    D->addAttr(IntelFPGANumBanksAttr::CreateImplicit(Context, NBE));
+  }
+
+  if (!D->hasAttr<IntelFPGAMemoryAttr>())
+    D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
+        Context, IntelFPGAMemoryAttr::Default));
+
+  D->addAttr(::new (Context)
+                 IntelFPGABankBitsAttr(Context, CI, Args.data(), Args.size()));
 }
 
 static void handleIntelFPGAMaxPrivateCopiesAttr(Sema &S, Decl *D,
@@ -7634,6 +7731,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case ParsedAttr::AT_IntelFPGAMerge:
     handleIntelFPGAMergeAttr(S, D, AL);
+    break;
+  case ParsedAttr::AT_IntelFPGABankBits:
+    handleIntelFPGABankBitsAttr(S, D, AL);
     break;
 
   case ParsedAttr::AT_AnyX86NoCallerSavedRegisters:

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -18,12 +18,15 @@
 //CHECK: [[ANN16:@.str.[0-9]*]] = {{.*}}foobar
 //CHECK: [[ANN17:@.str.[0-9]*]] = {{.*}}{memory:MLAB}{sizeinfo:4,500}
 //CHECK: [[ANN18:@.str.[0-9]*]] = {{.*}}{memory:BLOCK_RAM}{sizeinfo:4,10,2}
+//CHECK: [[ANN19:@.str.[0-9]*]] = {{.*}}{memory:DEFAULT}{sizeinfo:4}{numbanks:4}{bank_bits:4,5}
+//CHECK: [[ANN20:@.str.[0-9]*]] = {{.*}}{memory:DEFAULT}{sizeinfo:4,10,2}{bankwidth:16}{numbanks:4}{bank_bits:2,3}
+//CHECK: [[ANN21:@.str.[0-9]*]] = {{.*}}{memory:MLAB}{sizeinfo:4}{numbanks:8}{bank_bits:3,4,5}
 
 //CHECK: @llvm.global.annotations
 //CHECK-SAME: { i8 addrspace(1)* bitcast (i32 addrspace(1)* @_ZZ3quxiE5a_one to i8 addrspace(1)*)
-//CHECK-SAME: [[ANN1]]{{.*}}i32 154
+//CHECK-SAME: [[ANN1]]{{.*}}i32 157
 //CHECK-SAME: { i8 addrspace(1)* bitcast (i32 addrspace(1)* @_ZZ3quxiE5b_two to i8 addrspace(1)*)
-//CHECK-SAME: [[ANN16]]{{.*}}i32 158
+//CHECK-SAME: [[ANN16]]{{.*}}i32 161
 
 void foo() {
   //CHECK: %[[VAR_ONE:[0-9]+]] = bitcast{{.*}}var_one
@@ -172,6 +175,29 @@ void size_info() {
   [[intelfpga::memory("BLOCK_RAM")]] int var_b[10][2];
 }
 
+struct s {
+  int a [[intelfpga::bank_bits(4, 5)]];
+};
+
+void bankbits() {
+  //CHECK: %[[VAR:[0-9]+]] = bitcast{{.*}}%a
+  //CHECK: %[[VAR1:a[0-9]+]] = bitcast{{.*}}%a
+  //CHECK: @llvm.var.annotation{{.*}}%[[VAR1]],{{.*}}[[ANN19]]
+  [[intelfpga::bank_bits(4,5)]] int a;
+  //CHECK: %[[VARB:[0-9]+]] = bitcast{{.*}}%b
+  //CHECK: %[[VARB1:b[0-9]+]] = bitcast{{.*}}%b
+  //CHECK: @llvm.var.annotation{{.*}}%[[VARB1]],{{.*}}[[ANN20]]
+  [[intelfpga::bank_bits(2,3), intelfpga::bankwidth(16)]] int b[10][2];
+  //CHECK: %[[VARC:[0-9]+]] = bitcast{{.*}}%c
+  //CHECK: %[[VARC1:c[0-9]+]] = bitcast{{.*}}%c
+  //CHECK: @llvm.var.annotation{{.*}}%[[VARC1]],{{.*}}[[ANN21]]
+  [[intelfpga::bank_bits(3,4,5), intelfpga::numbanks(8), intelfpga::memory("MLAB")]] int c;
+  struct s s2;
+  //CHECK: %[[FIELD_A:.*]] = getelementptr inbounds %struct.{{.*}}.s{{.*}}
+  //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD_A]]{{.*}}[[ANN19]]
+  s2.a = 0;
+}
+
 void field_addrspace_cast() {
   struct state {
     [[intelfpga::numbanks(2)]] int mem[8];
@@ -204,6 +230,7 @@ int main() {
     baz();
     qux(42);
     size_info();
+    bankbits();
     field_addrspace_cast();
   });
   return 0;

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -19,8 +19,8 @@
 //CHECK: [[ANN17:@.str.[0-9]*]] = {{.*}}{memory:MLAB}{sizeinfo:4,500}
 //CHECK: [[ANN18:@.str.[0-9]*]] = {{.*}}{memory:BLOCK_RAM}{sizeinfo:4,10,2}
 //CHECK: [[ANN19:@.str.[0-9]*]] = {{.*}}{memory:DEFAULT}{sizeinfo:4}{numbanks:4}{bank_bits:4,5}
-//CHECK: [[ANN20:@.str.[0-9]*]] = {{.*}}{memory:DEFAULT}{sizeinfo:4,10,2}{bankwidth:16}{numbanks:4}{bank_bits:2,3}
-//CHECK: [[ANN21:@.str.[0-9]*]] = {{.*}}{memory:MLAB}{sizeinfo:4}{numbanks:8}{bank_bits:3,4,5}
+//CHECK: [[ANN20:@.str.[0-9]*]] = {{.*}}{memory:DEFAULT}{sizeinfo:4,10,2}{bankwidth:16}{numbanks:2}{bank_bits:0}
+//CHECK: [[ANN21:@.str.[0-9]*]] = {{.*}}{memory:MLAB}{sizeinfo:4}{numbanks:8}{bank_bits:5,4,3}
 
 //CHECK: @llvm.global.annotations
 //CHECK-SAME: { i8 addrspace(1)* bitcast (i32 addrspace(1)* @_ZZ3quxiE5a_one to i8 addrspace(1)*)
@@ -187,11 +187,11 @@ void bankbits() {
   //CHECK: %[[VARB:[0-9]+]] = bitcast{{.*}}%b
   //CHECK: %[[VARB1:b[0-9]+]] = bitcast{{.*}}%b
   //CHECK: @llvm.var.annotation{{.*}}%[[VARB1]],{{.*}}[[ANN20]]
-  [[intelfpga::bank_bits(2,3), intelfpga::bankwidth(16)]] int b[10][2];
+  [[intelfpga::bank_bits(0), intelfpga::bankwidth(16)]] int b[10][2];
   //CHECK: %[[VARC:[0-9]+]] = bitcast{{.*}}%c
   //CHECK: %[[VARC1:c[0-9]+]] = bitcast{{.*}}%c
   //CHECK: @llvm.var.annotation{{.*}}%[[VARC1]],{{.*}}[[ANN21]]
-  [[intelfpga::bank_bits(3,4,5), intelfpga::numbanks(8), intelfpga::memory("MLAB")]] int c;
+  [[intelfpga::bank_bits(5,4,3), intelfpga::numbanks(8), intelfpga::memory("MLAB")]] int c;
   struct s s2;
   //CHECK: %[[FIELD_A:.*]] = getelementptr inbounds %struct.{{.*}}.s{{.*}}
   //CHECK: call i32* @llvm.ptr.annotation.p0i32{{.*}}%[[FIELD_A]]{{.*}}[[ANN19]]

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -453,10 +453,6 @@ void foo1()
   [[intelfpga::bank_bits]]
   unsigned int bb_seven[4];
 
-  //expected-error@+1{{attribute takes at least 1 argument}}
-  [[intelfpga::bank_bits()]]
-  unsigned int bb_eight[4];
-
   //expected-error@+1{{requires integer constant between 0 and 1048576}}
   [[intelfpga::bank_bits(-1)]]
   unsigned int bb_ten[4];

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -62,6 +62,37 @@ void foo1()
   [[intelfpga::merge("mrg2","width")]]
   unsigned int v_eleven[64];
 
+  //CHECK: VarDecl{{.*}}v_twelve
+  //CHECK: IntelFPGANumBanksAttr{{.*}}Implicit{{$}}
+  //CHECK-NEXT: IntegerLiteral{{.*}}16{{$}}
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK: IntelFPGABankBitsAttr
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}3{{$}}
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}5{{$}}
+  [[intelfpga::bank_bits(2,3,4,5)]]
+  unsigned int v_twelve[64];
+
+  //CHECK: VarDecl{{.*}}v_thirteen
+  //CHECK-NEXT: IntelFPGANumBanksAttr{{.*}}Implicit{{$}}
+  //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
+  //CHECK-NEXT: IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK-NEXT: IntelFPGABankBitsAttr
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}3{{$}}
+  //CHECK-NEXT: IntelFPGABankWidthAttr
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}16{{$}}
+  [[intelfpga::bank_bits(2,3), intelfpga::bankwidth(16)]]
+  unsigned int v_thirteen[64];
+
   //CHECK: VarDecl{{.*}}v_fourteen
   //CHECK: IntelFPGADoublePumpAttr
   //CHECK: IntelFPGAMemoryAttr{{.*}}MLAB{{$}}
@@ -93,6 +124,7 @@ void foo1()
   [[intelfpga::numbanks(4), intelfpga::bankwidth(16), intelfpga::singlepump]] int B;
   [[intelfpga::numbanks(4), intelfpga::bankwidth(16), intelfpga::doublepump]] int C;
   [[intelfpga::numbanks(4), intelfpga::bankwidth(16)]] int E;
+  [[intelfpga::bank_bits(2,3), intelfpga::bankwidth(16)]] int F;
   [[intelfpga::max_replicates(2)]] int G;
   [[intelfpga::simple_dual_port]] int H;
 
@@ -156,7 +188,13 @@ void foo1()
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_four[64];
 
-  //expected-error@+2{{attributes are not compatible}}
+  //expected-error@+2{{'bank_bits' and 'register' attributes are not compatible}}
+  [[intelfpga::register]]
+  [[intelfpga::bank_bits(4,5)]]
+  //expected-note@-2 {{conflicting attribute is here}}
+  unsigned int reg_five[64];
+
+  //expected-error@+2{{'bankwidth' and 'register' attributes are not compatible}}
   [[intelfpga::register]]
   [[intelfpga::bankwidth(16)]]
   //expected-note@-2 {{conflicting attribute is here}}
@@ -372,6 +410,57 @@ void foo1()
   [[intelfpga::merge("mrg5","width")]]
   unsigned int mrg_six[4];
 
+  // bank_bits
+  //expected-error@+2 1{{'register' and 'bank_bits' attributes are not compatible}}
+  [[intelfpga::bank_bits(2,3)]]
+  [[intelfpga::register]]
+  //expected-note@-2 1{{conflicting attribute is here}}
+  unsigned int bb_one[4];
+
+  //CHECK: VarDecl{{.*}}bb_two
+  //CHECK: IntelFPGABankBitsAttr
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}42{{$}}
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}43{{$}}
+  //CHECK: IntelFPGABankBitsAttr
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
+  //expected-warning@+2{{attribute 'bank_bits' is already applied}}
+  [[intelfpga::bank_bits(42,43)]]
+  [[intelfpga::bank_bits(1,2)]]
+  unsigned int bb_two[4];
+
+  //expected-error@+1{{the number of bank_bits must be equal to ceil(log2(numbanks))}}
+  [[intelfpga::numbanks(8), intelfpga::bank_bits(3,4)]]
+  unsigned int bb_three[4];
+
+  //expected-error@+1{{the number of bank_bits must be equal to ceil(log2(numbanks))}}
+  [[intelfpga::bank_bits(3,4), intelfpga::numbanks(8)]]
+  unsigned int bb_four[4];
+
+  //expected-error@+1{{bank_bits must be consecutive}}
+  [[intelfpga::bank_bits(3,3,4), intelfpga::bankwidth(4)]]
+  unsigned int bb_five[4];
+
+  //expected-error@+1{{bank_bits must be consecutive}}
+  [[intelfpga::bank_bits(1,3,4), intelfpga::bankwidth(4)]]
+  unsigned int bb_six[4];
+
+  //expected-error@+1{{attribute takes at least 1 argument}}
+  [[intelfpga::bank_bits]]
+  unsigned int bb_seven[4];
+
+  //expected-error@+1{{attribute takes at least 1 argument}}
+  [[intelfpga::bank_bits()]]
+  unsigned int bb_eight[4];
+
+  //expected-error@+1{{requires integer constant between 0 and 1048576}}
+  [[intelfpga::bank_bits(-1)]]
+  unsigned int bb_ten[4];
+
   // GNU style
   //expected-warning@+1{{unknown attribute 'numbanks' ignored}}
   int __attribute__((numbanks(4))) a_one;
@@ -402,6 +491,9 @@ void foo1()
 
   //expected-warning@+1{{unknown attribute 'simple_dual_port' ignored}}
   int __attribute__((simple_dual_port)) a_ten;
+
+  //expected-warning@+1{{unknown attribute 'bank_bits' ignored}}
+  int __attribute__((bank_bits(4))) a_eleven;
 }
 
 //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
@@ -480,6 +572,15 @@ struct foo {
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMergeAttr{{.*}}"mrg2" "width"{{$}}
   [[intelfpga::merge("mrg2", "width")]] unsigned int v_eleven[64];
+
+  //CHECK: FieldDecl{{.*}}v_twelve
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK: IntelFPGABankBitsAttr
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: IntegerLiteral{{.*}}3{{$}}
+  [[intelfpga::bank_bits(2,3)]] unsigned int v_twelve[64];
 };
 
 template <typename name, typename Func>


### PR DESCRIPTION
This attribute forces the memory system to implement the variable or struct
member in a memory with 2^(N+1) banks, with (b0, ..., bn) forming the
bank-select bits.