### PR TITLE
[SYCL][FPGA] Implement kernel attribute max_work_group_size

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1123,6 +1123,17 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
   let PragmaAttributeSupport = 0;
 }
 
+def SYCLIntelMaxWorkGroupSize : InheritableAttr {
+  let Spellings = [CXX11<"intelfpga","max_work_group_size">];
+  let Args = [UnsignedArgument<"XDim">,
+              UnsignedArgument<"YDim">,
+              UnsignedArgument<"ZDim">];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Documentation = [SYCLIntelMaxWorkGroupSizeAttrDocs];
+  let PragmaAttributeSupport = 0;
+}
+
 def C11NoReturn : InheritableAttr {
   let Spellings = [Keyword<"_Noreturn">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1980,6 +1980,19 @@ device kernel, the attribute is ignored and it is not propagated to a kernel.
   }];
 }
 
+def SYCLIntelMaxWorkGroupSizeAttrDocs : Documentation {
+  let Category = DocCatFunction;
+  let Heading = "max_work_group_size (IntelFPGA)";
+  let Content = [{
+Applies to a device function/lambda function. Indicates the maximum dimensions
+of a work group. Values must be positive integers. This is similar to
+reqd_work_group_size, but allows work groups that are smaller or equal to the
+specified sizes.
+If ``intelfpga::max_work_group_size`` is applied to a function called from a
+device kernel, the attribute is ignored and it is not propagated to a kernel.
+  }];
+}
+
 def SYCLFPGAPipeDocs : Documentation {
   let Category = DocCatStmt;
   let Heading = "pipe (read_only, write_only)";

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -155,7 +155,8 @@ public:
     auto ParsedAttr = getParsedKind();
     if (ParsedAttr == AT_SYCLIntelKernelArgsRestrict ||
         (ParsedAttr == AT_ReqdWorkGroupSize && isCXX11Attribute()) ||
-        ParsedAttr == AT_SYCLIntelNumSimdWorkItems)
+        ParsedAttr == AT_SYCLIntelNumSimdWorkItems ||
+        ParsedAttr == AT_SYCLIntelMaxWorkGroupSize)
       return true;
 
     return false;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10155,6 +10155,9 @@ def err_sycl_non_std_layout_type : Error<
   "kernel parameter has non-standard layout class/struct type">;
 def err_conflicting_sycl_kernel_attributes : Error<
   "conflicting attributes applied to a SYCL kernel">;
+def err_conflicting_sycl_function_attributes : Error<
+   "%0 attribute conflicts with '%1' attribute">;
+
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "%select{static function or function in an anonymous namespace"

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -595,6 +595,16 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
     Fn->setMetadata("num_simd_work_items",
                     llvm::MDNode::get(Context, AttrMDArgs));
   }
+
+  if (const SYCLIntelMaxWorkGroupSizeAttr *A =
+      FD->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
+    llvm::Metadata *AttrMDArgs[] = {
+        llvm::ConstantAsMetadata::get(Builder.getInt32(A->getXDim())),
+        llvm::ConstantAsMetadata::get(Builder.getInt32(A->getYDim())),
+        llvm::ConstantAsMetadata::get(Builder.getInt32(A->getZDim()))};
+    Fn->setMetadata("max_work_group_size",
+                    llvm::MDNode::get(Context, AttrMDArgs));
+  }
 }
 
 /// Determine whether the function F ends with a return stmt.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -428,7 +428,6 @@ public:
         Attrs.insert(A);
       if (auto *A = FD->getAttr<ReqdWorkGroupSizeAttr>())
         Attrs.insert(A);
-
       // Allow the following kernel attributes only on lambda functions and
       // function objects that are called directly from a kernel (i.e. the one
       // passed to the parallel_for function). For all other cases,
@@ -447,6 +446,14 @@ public:
         } else {
           SemaRef.Diag(A->getLocation(), diag::warn_attribute_ignored) << A;
           FD->dropAttr<SYCLIntelNumSimdWorkItemsAttr>();
+        }
+      }
+      if (auto *A = FD->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
+        if (ParentFD == SYCLKernel) {
+          Attrs.insert(A);
+        } else {
+          SemaRef.Diag(A->getLocation(), diag::warn_attribute_ignored) << A;
+          FD->dropAttr<SYCLIntelMaxWorkGroupSizeAttr>();
         }
       }
 
@@ -1348,7 +1355,8 @@ void Sema::MarkDevice(void) {
           break;
         }
         case attr::Kind::SYCLIntelKernelArgsRestrict:
-        case attr::Kind::SYCLIntelNumSimdWorkItems: {
+        case attr::Kind::SYCLIntelNumSimdWorkItems:
+        case attr::Kind::SYCLIntelMaxWorkGroupSize: {
           SYCLKernel->addAttr(A);
           break;
         }

--- a/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+
+class Foo {
+public:
+  [[intelfpga::max_work_group_size(1, 1, 1)]] void operator()() {}
+};
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+void bar() {
+  Foo boo;
+  kernel<class kernel_name1>(boo);
+
+  kernel<class kernel_name2>(
+  []() [[intelfpga::max_work_group_size(8, 8, 8)]] {});
+}
+
+// CHECK: define spir_kernel void @{{.*}}kernel_name1() {{.*}} !max_work_group_size ![[NUM1:[0-9]+]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name2() {{.*}} !max_work_group_size ![[NUM8:[0-9]+]]
+// CHECK: ![[NUM1]] = !{i32 1, i32 1, i32 1}
+// CHECK: ![[NUM8]] = !{i32 8, i32 8, i32 8}

--- a/clang/test/SemaSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size.cpp
@@ -1,0 +1,78 @@
+// RUN: %clang %s -fsyntax-only -fsycl-device-only -DTRIGGER_ERROR -Xclang -verify
+// RUN: %clang %s -fsyntax-only -Xclang -ast-dump -fsycl-device-only | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify %s
+
+#ifndef __SYCL_DEVICE_ONLY__
+struct FuncObj {
+  [[intelfpga::max_work_group_size(1, 1, 1)]] // expected-no-diagnostics
+  void operator()() {}
+};
+
+template <typename name, typename Func>
+void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+void foo() {
+  kernel<class test_kernel1>(
+      FuncObj());
+}
+
+#else // __SYCL_DEVICE_ONLY__
+
+[[intelfpga::max_work_group_size(2, 2, 2)]] // expected-warning{{'max_work_group_size' attribute ignored}}
+void func_ignore() {}
+
+struct FuncObj {
+  [[intelfpga::max_work_group_size(4, 4, 4)]]
+  void operator()() {}
+};
+
+#ifdef TRIGGER_ERROR
+struct DAFuncObj {
+  [[intelfpga::max_work_group_size(4, 4, 4)]]
+  [[cl::reqd_work_group_size(8, 8, 4)]] // expected-error{{'reqd_work_group_size' attribute conflicts with 'max_work_group_size' attribute}}
+  void operator()() {}
+};
+#endif // TRIGGER_ERROR
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  // CHECK-LABEL: FunctionDecl {{.*}} _ZTSZ4mainE12test_kernel1
+  // CHECK:       SYCLIntelMaxWorkGroupSizeAttr {{.*}} 4 4 4
+  kernel<class test_kernel1>(
+      FuncObj());
+
+  // CHECK-LABEL: FunctionDecl {{.*}} _ZTSZ4mainE12test_kernel2
+  // CHECK:       SYCLIntelMaxWorkGroupSizeAttr {{.*}} 8 8 8
+  kernel<class test_kernel2>(
+      []() [[intelfpga::max_work_group_size(8, 8, 8)]] {});
+
+  // CHECK-LABEL: FunctionDecl {{.*}} _ZTSZ4mainE12test_kernel3
+  // CHECK-NOT:   SYCLIntelMaxWorkGroupSizeAttr {{.*}}
+  kernel<class test_kernel3>(
+      []() {func_ignore();});
+
+#ifdef TRIGGER_ERROR
+  [[intelfpga::max_work_group_size(1, 1, 1)]] int Var = 0; // expected-error{{'max_work_group_size' attribute only applies to functions}}
+
+  kernel<class test_kernel4>(
+      []() [[intelfpga::max_work_group_size(0, 1, 3)]] {}); // expected-error{{'max_work_group_size' attribute must be greater than 0}}
+
+  kernel<class test_kernel5>(
+      []() [[intelfpga::max_work_group_size(-8, 8, 1)]] {}); // expected-error{{'max_work_group_size' attribute requires a non-negative integral compile time constant expression}}
+
+  kernel<class test_kernel6>(
+      []() [[intelfpga::max_work_group_size(16, 16, 16),
+             intelfpga::max_work_group_size(2, 2, 2)]] {}); // expected-warning{{attribute 'max_work_group_size' is already applied with different parameters}}
+
+  kernel<class test_kernel7>(
+      DAFuncObj());
+
+#endif // TRIGGER_ERROR
+}
+#endif // __SYCL_DEVICE_ONLY__


### PR DESCRIPTION
Applies to a device function/lambda function. Indicates the
maximum dimensions of a work group. Values must be positive
integers. This is similar to reqd_work_group_size, but allows
work groups that are smaller or equal to the specified sizes.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>