### PR TITLE
[SYCL] Add support for platform name and platform version in device w…

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -59,11 +59,11 @@ struct DevDescT {
   const char *devDriverVer = nullptr;
   int devDriverVerSize = 0;
 
-  const char *pltName = nullptr;
-  int pltNameSize = 0;
+  const char *platformName = nullptr;
+  int platformNameSize = 0;
 
-  const char *pltVer = nullptr;
-  int pltVerSize = 0;
+  const char *platformVer = nullptr;
+  int platformVerSize = 0;
 };
 
 static std::vector<DevDescT> getWhiteListDesc() {
@@ -76,7 +76,7 @@ static std::vector<DevDescT> getWhiteListDesc() {
   std::vector<DevDescT> decDescs;
   const char devNameStr[] = "DeviceName";
   const char driverVerStr[] = "DriverVersion";
-  const char pltNameStr[] = "PlatformName";
+  const char platformNameStr[] = "PlatformName";
   const char platformVerStr[] = "PlatformVersion";
   decDescs.emplace_back();
   while ('\0' != *str) {
@@ -88,13 +88,14 @@ static std::vector<DevDescT> getWhiteListDesc() {
       valuePtr = &decDescs.back().devName;
       size = &decDescs.back().devNameSize;
       str += sizeof(devNameStr) - 1;
-    } else if (0 == strncmp(pltNameStr, str, sizeof(pltNameStr) - 1)) {
-      valuePtr = &decDescs.back().pltName;
-      size = &decDescs.back().pltNameSize;
-      str += sizeof(pltNameStr) - 1;
+    } else if (0 ==
+               strncmp(platformNameStr, str, sizeof(platformNameStr) - 1)) {
+      valuePtr = &decDescs.back().platformName;
+      size = &decDescs.back().platformNameSize;
+      str += sizeof(platformNameStr) - 1;
     } else if (0 == strncmp(platformVerStr, str, sizeof(platformVerStr) - 1)) {
-      valuePtr = &decDescs.back().pltVer;
-      size = &decDescs.back().pltVerSize;
+      valuePtr = &decDescs.back().platformVer;
+      size = &decDescs.back().platformVerSize;
       str += sizeof(platformVerStr) - 1;
     } else if (0 == strncmp(driverVerStr, str, sizeof(driverVerStr) - 1)) {
       valuePtr = &decDescs.back().devDriverVer;
@@ -149,31 +150,34 @@ static void filterWhiteList(vector_class<RT::PiDevice> &pi_devices,
   if (whiteList.empty())
     return;
 
-  const string_class pltName =
+  const string_class platformName =
       sycl::detail::get_platform_info<string_class, info::platform::name>::get(
           pi_platform);
 
-  const string_class pltVer = sycl::detail::get_platform_info<
+  const string_class platformVer = sycl::detail::get_platform_info<
       string_class, info::platform::version>::get(pi_platform);
 
   int insertIDx = 0;
   for (RT::PiDevice dev : pi_devices) {
     const string_class devName =
-        sycl::detail::get_device_info<string_class, info::device::name>::get(dev);
+        sycl::detail::get_device_info<string_class, info::device::name>::get(
+            dev);
 
     const string_class devDriverVer =
         sycl::detail::get_device_info<string_class,
                                       info::device::driver_version>::get(dev);
 
     for (const DevDescT &desc : whiteList) {
-      if (nullptr != desc.pltName &&
-          !std::regex_match(
-              pltName, std::regex(std::string(desc.pltName, desc.pltNameSize))))
+      if (nullptr != desc.platformName &&
+          !std::regex_match(platformName,
+                            std::regex(std::string(desc.platformName,
+                                                   desc.platformNameSize))))
         continue;
 
-      if (nullptr != desc.pltVer &&
+      if (nullptr != desc.platformVer &&
           !std::regex_match(
-              pltVer, std::regex(std::string(desc.pltVer, desc.pltVerSize))))
+              platformVer,
+              std::regex(std::string(desc.platformVer, desc.platformVerSize))))
         continue;
 
       if (nullptr != desc.devName &&

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -71,8 +71,6 @@ static std::vector<DevDescT> getWhiteListDesc() {
   if (!str)
     return {};
 
-
-
   std::vector<DevDescT> decDescs;
   const char devNameStr[] = "DeviceName";
   const char driverVerStr[] = "DriverVersion";

--- a/sycl/test/config/white_list.cpp
+++ b/sycl/test/config/white_list.cpp
@@ -27,11 +27,11 @@ int main() {
 
   // Expected that white list filter is not set
   if (getenv("PRINT_PLATFORM_INFO")) {
-    for (const sycl::platform &Plt : sycl::platform::get_platforms())
-      if (!Plt.is_host()) {
+    for (const sycl::platform &Platform : sycl::platform::get_platforms())
+      if (!Platform.is_host()) {
 
-        std::string Name = Plt.get_info<sycl::info::platform::name>();
-        std::string Ver = Plt.get_info<sycl::info::platform::version>();
+        std::string Name = Platform.get_info<sycl::info::platform::name>();
+        std::string Ver = Platform.get_info<sycl::info::platform::version>();
         // As a string will be used as regexp pattern, we need to get rid of
         // symbols that can be treated in a special way.
         replaceSpecialCharacters(Name);
@@ -47,9 +47,9 @@ int main() {
 
   // Expected that white list filter is not set
   if (getenv("PRINT_DEVICE_INFO")) {
-    for (const sycl::platform &Plt : sycl::platform::get_platforms())
-      if (!Plt.is_host()) {
-        const sycl::device Dev = Plt.get_devices().at(0);
+    for (const sycl::platform &Platform : sycl::platform::get_platforms())
+      if (!Platform.is_host()) {
+        const sycl::device Dev = Platform.get_devices().at(0);
         std::string Name = Dev.get_info<sycl::info::device::name>();
         std::string Ver = Dev.get_info<sycl::info::device::driver_version>();
 
@@ -68,9 +68,9 @@ int main() {
 
   // Expected white list to be set with result from "PRINT_DEVICE_INFO" run
   if (getenv("TEST_DEVICE_AVAILABLE")) {
-    for (const sycl::platform &Plt : sycl::platform::get_platforms())
-      if (!Plt.is_host()) {
-        if (Plt.get_devices().size() != 1)
+    for (const sycl::platform &Platform : sycl::platform::get_platforms())
+      if (!Platform.is_host()) {
+        if (Platform.get_devices().size() != 1)
           throw std::runtime_error("Expected only one non host device.");
 
         return 0;
@@ -80,8 +80,8 @@ int main() {
 
   // Expected white list to be set but empty
   if (getenv("TEST_DEVICE_IS_NOT_AVAILABLE")) {
-    for (const sycl::platform &Plt : sycl::platform::get_platforms())
-      if (!Plt.is_host())
+    for (const sycl::platform &Platform : sycl::platform::get_platforms())
+      if (!Platform.is_host())
         throw std::runtime_error("Expected no non host device is available");
     return 0;
   }

--- a/sycl/test/config/white_list.cpp
+++ b/sycl/test/config/white_list.cpp
@@ -18,7 +18,7 @@
 using namespace cl;
 
 static void replaceSpecialCharacters(std::string &Str) {
-  //Replace common special symbols with '.' which matches to any character
+  // Replace common special symbols with '.' which matches to any character
   std::replace_if(Str.begin(), Str.end(),
                   [](const char Sym) { return '(' == Sym || ')' == Sym; }, '.');
 }

--- a/sycl/test/config/white_list.cpp
+++ b/sycl/test/config/white_list.cpp
@@ -17,10 +17,8 @@
 
 using namespace cl;
 
-static void replaceEscapeCharacters(std::string &Str) {
-  // As a stringwill be used as regexp pattern, we need to get rid of symbols
-  // that can be treated in a special way.  Replace common special symbols with
-  // '.' which matches to any character
+static void replaceSpecialCharacters(std::string &Str) {
+  //Replace common special symbols with '.' which matches to any character
   std::replace_if(Str.begin(), Str.end(),
                   [](const char Sym) { return '(' == Sym || ')' == Sym; }, '.');
 }
@@ -33,10 +31,11 @@ int main() {
       if (!Plt.is_host()) {
 
         std::string Name = Plt.get_info<sycl::info::platform::name>();
-        const std::string Ver =
-            Plt.get_info<sycl::info::platform::version>();
-
-        replaceEscapeCharacters(Name);
+        std::string Ver = Plt.get_info<sycl::info::platform::version>();
+        // As a string will be used as regexp pattern, we need to get rid of
+        // symbols that can be treated in a special way.
+        replaceSpecialCharacters(Name);
+        replaceSpecialCharacters(Ver);
 
         std::cout << "SYCL_DEVICE_WHITE_LIST=PlatformName:{{" << Name
                   << "}},PlatformVersion:{{" << Ver << "}}";
@@ -52,10 +51,12 @@ int main() {
       if (!Plt.is_host()) {
         const sycl::device Dev = Plt.get_devices().at(0);
         std::string Name = Dev.get_info<sycl::info::device::name>();
-        const std::string Ver =
-            Dev.get_info<sycl::info::device::driver_version>();
+        std::string Ver = Dev.get_info<sycl::info::device::driver_version>();
 
-        replaceEscapeCharacters(Name);
+        // As a string will be used as regexp pattern, we need to get rid of
+        // symbols that can be treated in a special way.
+        replaceSpecialCharacters(Name);
+        replaceSpecialCharacters(Ver);
 
         std::cout << "SYCL_DEVICE_WHITE_LIST=DeviceName:{{" << Name
                   << "}},DriverVersion:{{" << Ver << "}}";


### PR DESCRIPTION
…hitelist

PlatformName and PlatformVersion are now supported keys. Also all fields
are optional now, so SYCL_DEVICE_WHITE_LIST="" matches any device

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>