### PR TITLE
[SYCL] Fix kernel attribute codegen

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -426,9 +426,9 @@ public:
 
       if (auto *A = FD->getAttr<IntelReqdSubGroupSizeAttr>())
         Attrs.insert(A);
-      else if (auto *A = FD->getAttr<ReqdWorkGroupSizeAttr>())
+      if (auto *A = FD->getAttr<ReqdWorkGroupSizeAttr>())
         Attrs.insert(A);
-      else if (auto *A = FD->getAttr<SYCLIntelKernelArgsRestrictAttr>()) {
+      if (auto *A = FD->getAttr<SYCLIntelKernelArgsRestrictAttr>()) {
         // Allow the intel::kernel_args_restrict only on the lambda (function
         // object) function, that is called directly from a kernel (i.e. the one
         // passed to the parallel_for function). Emit a warning and ignore all

--- a/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
+++ b/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Functor {
 public:
@@ -6,7 +6,7 @@ public:
 };
 
 
-template <typename name, typename Func>
+template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
   kernelFunc();
 }

--- a/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
+++ b/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+
+class Functor {
+public:
+  [[cl::intel_reqd_sub_group_size(4), cl::reqd_work_group_size(32, 16, 16)]] void operator()() {}
+};
+
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+void bar() {
+  Functor foo;
+  kernel<class kernel_name>(foo);
+}
+
+// CHECK: define spir_kernel void @{{.*}}kernel_name() {{.*}} !reqd_work_group_size ![[WGSIZE:[0-9]+]] !intel_reqd_sub_group_size ![[SGSIZE:[0-9]+]]
+// CHECK: ![[WGSIZE]] = !{i32 32, i32 16, i32 16}
+// CHECK: ![[SGSIZE]] = !{i32 4}


### PR DESCRIPTION
It was failed to process correctly a case of multiple attrs
attached to SYCL kernel.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>