### PR TITLE
[SYCL][NFC] Fix compiler warnings about not handled enum values

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -11097,6 +11097,9 @@ bool checkContext<OMP_CTX_SET_device, OMP_CTX_kind, CodeGenModule &>(
     case llvm::Triple::bpfel:
     case llvm::Triple::bpfeb:
     case llvm::Triple::hexagon:
+    case llvm::Triple::fpga_aoco:
+    case llvm::Triple::fpga_aocr:
+    case llvm::Triple::fpga_aocx:
     case llvm::Triple::mips:
     case llvm::Triple::mipsel:
     case llvm::Triple::mips64:


### PR DESCRIPTION
Signed-off-by: Alexey Bader <alexey.bader@intel.com>