### PR TITLE
[SYCL] Enqueue leaves after host accessor destruction

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -145,6 +145,19 @@ EventImplPtr Scheduler::addHostAccessor(Requirement *Req) {
 
 void Scheduler::releaseHostAccessor(Requirement *Req) {
   Req->MBlockedCmd->MCanEnqueue = true;
+  MemObjRecord* Record = Req->MSYCLMemObj->MRecord.get();
+  for (Command *Cmd : Record->MReadLeafs) {
+    EnqueueResultT Res;
+    bool Enqueued = GraphProcessor::enqueueCommand(Cmd, Res);
+    if (!Enqueued && EnqueueResultT::FAILED == Res.MResult)
+      throw runtime_error("Enqueue process failed.");
+  }
+  for (Command *Cmd : Record->MWriteLeafs) {
+    EnqueueResultT Res;
+    bool Enqueued = GraphProcessor::enqueueCommand(Cmd, Res);
+    if (!Enqueued && EnqueueResultT::FAILED == Res.MResult)
+      throw runtime_error("Enqueue process failed.");
+  }
 }
 
 Scheduler::Scheduler() {

--- a/sycl/test/scheduler/HostAccDestruction.cpp
+++ b/sycl/test/scheduler/HostAccDestruction.cpp
@@ -1,0 +1,36 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: env SYCL_PI_TRACE=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
+//==---------------------- HostAccDestruction.cpp --------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+int main() {
+  size_t size = 3;
+
+  cl::sycl::buffer<int, 1> buf(size);
+  {
+    cl::sycl::queue q;
+    auto host_acc = buf.get_access<cl::sycl::access::mode::read_write>();
+    q.submit([&](cl::sycl::handler &cgh) {
+      auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+      cgh.parallel_for<class SingleTask>(
+          cl::sycl::range<1>{size},
+          [=](cl::sycl::id<1> id) { (void)acc[id]; });
+    });
+    std::cout << "host acc destructor call" << std::endl;
+  }
+  std::cout << "end of scope" << std::endl;
+
+  return 0;
+}
+
+// CHECK:host acc destructor call
+// CHECK:---> piEnqueueKernelLaunch(
+// CHECK:end of scope

--- a/sycl/test/scheduler/HostAccDestruction.cpp
+++ b/sycl/test/scheduler/HostAccDestruction.cpp
@@ -1,5 +1,4 @@
 // RUN: %clangxx -fsycl %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: env SYCL_PI_TRACE=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
 //==---------------------- HostAccDestruction.cpp --------------------------==//
 //


### PR DESCRIPTION
Need to enqueue all leaves of the graph to start
execution after unblocking.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>