### PR TITLE
[SYCL] Refactor platform to enhance ABI compatibility

### DIFF
--- a/sycl/include/CL/sycl/detail/device_info.hpp
+++ b/sycl/include/CL/sycl/detail/device_info.hpp
@@ -9,6 +9,7 @@
 #pragma once
 #include <CL/sycl/detail/common_info.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/platform_impl.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/platform.hpp>
 

--- a/sycl/include/CL/sycl/detail/device_info.hpp
+++ b/sycl/include/CL/sycl/detail/device_info.hpp
@@ -61,7 +61,7 @@ template <info::device param> struct get_device_info<platform, param> {
     PI_CALL(piDeviceGetInfo)(dev, pi::cast<RT::PiDeviceInfo>(param),
                              sizeof(result), &result, nullptr);
     return createSyclObjFromImpl<platform>(
-        std::make_shared<platform_impl_pi>(result));
+        std::make_shared<platform_impl>(result));
   }
 };
 

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -28,7 +28,7 @@ namespace detail {
 class platform_impl {
 public:
   /// Constructs platform_impl for a SYCL host platform.
-  platform_impl() : MHostPlatform(true) {};
+  platform_impl() : MHostPlatform(true){};
 
   /// Constructs platform_impl instance using device selector.
   ///
@@ -55,7 +55,8 @@ public:
       return false;
 
     string_class all_extension_names =
-        get_platform_info<string_class, info::platform::extensions>::get(MPlatform);
+        get_platform_info<string_class, info::platform::extensions>::get(
+            MPlatform);
     return (all_extension_names.find(ExtensionName) != std::string::npos);
   }
 
@@ -103,7 +104,8 @@ public:
   /// @return a raw plug-in platform handle.
   const RT::PiPlatform &getHandleRef() const {
     if (is_host())
-      throw invalid_object_error("This instance of platform is a host instance");
+      throw invalid_object_error(
+          "This instance of platform is a host instance");
 
     return MPlatform;
   }

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -28,7 +28,7 @@ namespace detail {
 class platform_impl {
 public:
   /// Constructs platform_impl for a SYCL host platform.
-  platform_impl() : MHostPlatform(true){};
+  platform_impl() : MHostPlatform(true) {}
 
   /// Constructs platform_impl instance using device selector.
   ///

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -30,15 +30,6 @@ public:
   /// Constructs platform_impl for a SYCL host platform.
   platform_impl() : MHostPlatform(true) {}
 
-  /// Constructs platform_impl instance using device selector.
-  ///
-  /// One of the SYCL devices that is associated with the constructed SYCL
-  /// platform instance must be the SYCL device that is produced from the
-  /// provided device selector.
-  ///
-  /// @param DeviceSelector is an instance of SYCL device_selector.
-  explicit platform_impl(const device_selector &DeviceSelector);
-
   /// Constructs platform_impl from a plug-in interoperability platform handle.
   ///
   /// @param Platform is a raw plug-in platform handle.

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -45,17 +45,18 @@ public:
     if (is_host())
       return false;
 
-    string_class all_extension_names =
+    string_class AllExtensionNames =
         get_platform_info<string_class, info::platform::extensions>::get(
             MPlatform);
-    return (all_extension_names.find(ExtensionName) != std::string::npos);
+    return (AllExtensionNames.find(ExtensionName) != std::string::npos);
   }
 
   /// Returns all SYCL devices associated with this platform.
   ///
-  /// If this platform is a host platform, resulting vector contains only
-  /// a single SYCL host device. If there are no devices that match given device
-  /// type, resulting vector is empty.
+  /// If this platform is a host platform and device type requested is either
+  /// info::device_type::all or info::device_type::host, resulting vector
+  /// contains only a single SYCL host device. If there are no devices that
+  /// match given device type, resulting vector is empty.
   ///
   /// @param DeviceType is a SYCL device type.
   /// @return a vector of SYCL devices.
@@ -76,13 +77,9 @@ public:
         param>::get(this->getHandleRef());
   }
 
-  /// Checks if this platform is a host platform.
-  ///
   /// @return true if this SYCL platform is a host platform.
   bool is_host() const { return MHostPlatform; };
 
-  /// Returns an OpenCL interoperability platform.
-  ///
   /// @return an instance of OpenCL cl_platform_id.
   cl_platform_id get() const {
     if (is_host())

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -93,7 +93,13 @@ public:
   /// Gets an OpenCL interoperability platform.
   ///
   /// @return an instance of OpenCL cl_platform_id.
-  cl_platform_id get() const { return pi::cast<cl_platform_id>(MPlatform); }
+  cl_platform_id get() const {
+    if (is_host())
+      throw invalid_object_error(
+          "This instance of platform is a host instance");
+
+    return pi::cast<cl_platform_id>(MPlatform);
+  }
 
   /// Gets raw underlying plug-in platform handle.
   ///

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -109,7 +109,9 @@ public:
 
   /// Returns all available SYCL platforms in the system.
   ///
-  /// The resulting vector always contains a single SYCL host platform instance.
+  /// By default the resulting vector always contains a single SYCL host
+  /// platform instance. There are means to override this behavior for testing
+  /// purposes. See environment variables guide for up-to-date instructions.
   ///
   /// @return a vector of all available SYCL platforms.
   static vector_class<platform> get_platforms();

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -51,7 +51,7 @@ public:
     return (all_extension_names.find(ExtensionName) != std::string::npos);
   }
 
-  /// Gets all SYCL devices associated with this platform.
+  /// Returns all SYCL devices associated with this platform.
   ///
   /// If this platform is a host platform, resulting vector contains only
   /// a single SYCL host device. If there are no devices that match given device
@@ -81,7 +81,7 @@ public:
   /// @return true if this SYCL platform is a host platform.
   bool is_host() const { return MHostPlatform; };
 
-  /// Gets an OpenCL interoperability platform.
+  /// Returns an OpenCL interoperability platform.
   ///
   /// @return an instance of OpenCL cl_platform_id.
   cl_platform_id get() const {
@@ -92,7 +92,7 @@ public:
     return pi::cast<cl_platform_id>(MPlatform);
   }
 
-  /// Gets raw underlying plug-in platform handle.
+  /// Returns raw underlying plug-in platform handle.
   ///
   /// Unlike get() method, this method does not retain handler. It is caller
   /// responsibility to make sure that platform stays alive while raw handle
@@ -107,7 +107,7 @@ public:
     return MPlatform;
   }
 
-  /// Gets all available SYCL platforms in the system.
+  /// Returns all available SYCL platforms in the system.
   ///
   /// The resulting vector always contains a single SYCL host platform instance.
   ///

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -27,14 +27,29 @@ namespace detail {
 // TODO: implement parameters treatment for host device
 class platform_impl {
 public:
+  /// Constructs platform_impl for a SYCL host platform.
   platform_impl() : MHostPlatform(true) {};
 
+  /// Constructs platform_impl instance using device selector.
+  ///
+  /// One of the SYCL devices that is associated with the constructed SYCL
+  /// platform instance must be the SYCL device that is produced from the
+  /// provided device selector.
+  ///
+  /// @param DeviceSelector is an instance of SYCL device_selector.
   explicit platform_impl(const device_selector &DeviceSelector);
 
+  /// Constructs platform_impl from a plug-in interoperability platform handle.
+  ///
+  /// @param Platform is a raw plug-in platform handle.
   explicit platform_impl(RT::PiPlatform Platform) : MPlatform(Platform) {}
 
   ~platform_impl() = default;
 
+  /// Checks if this platform supports extension.
+  ///
+  /// @param ExtensionName is a string containing extension name.
+  /// @return true if platform supports specified extension.
   bool has_extension(const string_class &ExtensionName) const {
     if (is_host())
       return false;
@@ -44,9 +59,20 @@ public:
     return (all_extension_names.find(ExtensionName) != std::string::npos);
   }
 
+  /// Gets all SYCL devices associated with this platform.
+  ///
+  /// If this platform is a host platform, resulting vector contains only
+  /// a single SYCL host device. If there are no devices that match given device
+  /// type, resulting vector is empty.
+  ///
+  /// @param DeviceType is a SYCL device type.
+  /// @return a vector of SYCL devices.
   vector_class<device>
   get_devices(info::device_type DeviceType = info::device_type::all) const;
 
+  /// Queries this SYCL platform for info.
+  ///
+  /// The return type depends on information being queried.
   template <info::platform param>
   typename info::param_traits<info::platform, param>::return_type
   get_info() const {
@@ -58,11 +84,23 @@ public:
         param>::get(this->getHandleRef());
   }
 
+  /// Checks if this platform is a host platform.
+  ///
+  /// @return true if this SYCL platform is a host platform.
   bool is_host() const { return MHostPlatform; };
 
+  /// Gets an OpenCL interoperability platform.
+  ///
+  /// @return an instance of OpenCL cl_platform_id.
   cl_platform_id get() const { return pi::cast<cl_platform_id>(MPlatform); }
 
-  // Returns underlying native platform object.
+  /// Gets raw underlying plug-in platform handle.
+  ///
+  /// Unlike get() method, this method does not retain handler. It is caller
+  /// responsibility to make sure that platform stays alive while raw handle
+  /// is in use.
+  ///
+  /// @return a raw plug-in platform handle.
   const RT::PiPlatform &getHandleRef() const {
     if (is_host())
       throw invalid_object_error("This instance of platform is a host instance");
@@ -70,6 +108,11 @@ public:
     return MPlatform;
   }
 
+  /// Gets all available SYCL platforms in the system.
+  ///
+  /// The resulting vector always contains a single SYCL host platform instance.
+  ///
+  /// @return a vector of all available SYCL platforms.
   static vector_class<platform> get_platforms();
 
 private:

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -28,7 +28,7 @@ namespace detail {
 class platform_impl {
 public:
   /// Constructs platform_impl for a SYCL host platform.
-  platform_impl() : MHostPlatform(true){};
+  platform_impl() : MHostPlatform(true) {};
 
   /// Constructs platform_impl instance using device selector.
   ///
@@ -55,8 +55,7 @@ public:
       return false;
 
     string_class all_extension_names =
-        get_platform_info<string_class, info::platform::extensions>::get(
-            MPlatform);
+        get_platform_info<string_class, info::platform::extensions>::get(MPlatform);
     return (all_extension_names.find(ExtensionName) != std::string::npos);
   }
 
@@ -104,8 +103,7 @@ public:
   /// @return a raw plug-in platform handle.
   const RT::PiPlatform &getHandleRef() const {
     if (is_host())
-      throw invalid_object_error(
-          "This instance of platform is a host instance");
+      throw invalid_object_error("This instance of platform is a host instance");
 
     return MPlatform;
   }

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -266,11 +266,7 @@ template <typename T, T param> class param_traits {};
 #include <CL/sycl/info/kernel_traits.def>
 #include <CL/sycl/info/kernel_work_group_traits.def>
 
-PARAM_TRAITS_SPEC(platform, profile, string_class)
-PARAM_TRAITS_SPEC(platform, version, string_class)
-PARAM_TRAITS_SPEC(platform, name, string_class)
-PARAM_TRAITS_SPEC(platform, vendor, string_class)
-PARAM_TRAITS_SPEC(platform, extensions, vector_class<string_class>)
+#include <CL/sycl/info/platform_traits.def>
 
 PARAM_TRAITS_SPEC(program, context, cl::sycl::context)
 PARAM_TRAITS_SPEC(program, devices, vector_class<cl::sycl::device>)

--- a/sycl/include/CL/sycl/info/platform_traits.def
+++ b/sycl/include/CL/sycl/info/platform_traits.def
@@ -1,0 +1,5 @@
+PARAM_TRAITS_SPEC(platform, profile, string_class)
+PARAM_TRAITS_SPEC(platform, version, string_class)
+PARAM_TRAITS_SPEC(platform, name, string_class)
+PARAM_TRAITS_SPEC(platform, vendor, string_class)
+PARAM_TRAITS_SPEC(platform, extensions, vector_class<string_class>)

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -26,12 +26,29 @@ class platform_impl;
 
 class platform {
 public:
+  /// Constructs a SYCL platform as a host platform.
   platform();
 
+  /// Constructs a SYCL platform instance from an OpenCL cl_platform_id.
+  ///
+  /// The provided OpenCL platform handle is retained on SYCL platform
+  /// construction.
+  ///
+  /// @param PlatformId is an OpenCL cl_platform_id instance.
   explicit platform(cl_platform_id PlatformId);
 
+  /// Constructs a SYCL platform instance using device selector.
+  ///
+  /// One of the SYCL devices that is associated with the constructed SYCL
+  /// platform instance must be the SYCL device that is produced from the
+  /// provided device selector.
+  ///
+  /// @param DeviceSelector is an instance of SYCL device_selector.
   explicit platform(const device_selector &DeviceSelector);
 
+  /// Queries this SYCL platform for info.
+  ///
+  /// The return type depends on information being queried.
   template <info::platform param>
   typename info::param_traits<info::platform, param>::return_type
   get_info() const;
@@ -48,15 +65,38 @@ public:
 
   bool operator!=(const platform &rhs) const { return !(*this == rhs); }
 
+  /// Gets an OpenCL interoperability platform.
+  ///
+  /// @return an instance of OpenCL cl_platform_id.
   cl_platform_id get() const;
 
+  /// Checks if platform support specified extension.
+  ///
+  /// @param ExtensionName is a string containing extension name.
+  /// @return true if specified extension is supported by this SYCL platform.
   bool has_extension(const string_class &ExtensionName) const;
 
+  /// Checks if this SYCL platform is a host platform.
+  ///
+  /// @return true if this SYCL platform is a host platform.
   bool is_host() const;
 
+  /// Gets all SYCL devices associated with this platform.
+  ///
+  /// If this SYCL platform is a host platform, resulting vector contains only
+  /// a single SYCL host device. If there are no devices that match given device
+  /// type, resulting vector is empty.
+  ///
+  /// @param DeviceType is a SYCL device type.
+  /// @return a vector of SYCL devices.
   vector_class<device>
   get_devices(info::device_type DeviceType = info::device_type::all) const;
 
+  /// Gets all available SYCL platforms in the system.
+  ///
+  /// The resulting vector always contains a single SYCL host platform instance.
+  ///
+  /// @return a vector of all available SYCL platforms.
   static vector_class<platform> get_platforms();
 
 private:

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 #include <CL/sycl/detail/common.hpp>
-#include <CL/sycl/detail/platform_impl.hpp>
 #include <CL/sycl/detail/platform_info.hpp>
 #include <CL/sycl/stl.hpp>
+
 // 4.6.2 Platform class
 #include <utility>
 namespace cl {
@@ -20,6 +20,9 @@ namespace sycl {
 // Forward declaration
 class device_selector;
 class device;
+namespace detail {
+class platform_impl;
+}
 
 class platform {
 public:
@@ -31,9 +34,7 @@ public:
 
   template <info::platform param>
   typename info::param_traits<info::platform, param>::return_type
-  get_info() const {
-    return impl->get_info<param>();
-  }
+  get_info() const;
 
   platform(const platform &rhs) = default;
 

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -46,13 +46,6 @@ public:
   /// @param DeviceSelector is an instance of SYCL device_selector.
   explicit platform(const device_selector &DeviceSelector);
 
-  /// Queries this SYCL platform for info.
-  ///
-  /// The return type depends on information being queried.
-  template <info::platform param>
-  typename info::param_traits<info::platform, param>::return_type
-  get_info() const;
-
   platform(const platform &rhs) = default;
 
   platform(platform &&rhs) = default;
@@ -91,6 +84,13 @@ public:
   /// @return a vector of SYCL devices.
   vector_class<device>
   get_devices(info::device_type DeviceType = info::device_type::all) const;
+
+  /// Queries this SYCL platform for info.
+  ///
+  /// The return type depends on information being queried.
+  template <info::platform param>
+  typename info::param_traits<info::platform, param>::return_type
+  get_info() const;
 
   /// Gets all available SYCL platforms in the system.
   ///

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -58,7 +58,7 @@ public:
 
   bool operator!=(const platform &rhs) const { return !(*this == rhs); }
 
-  /// Gets an OpenCL interoperability platform.
+  /// Returns an OpenCL interoperability platform.
   ///
   /// @return an instance of OpenCL cl_platform_id.
   cl_platform_id get() const;
@@ -74,7 +74,7 @@ public:
   /// @return true if this SYCL platform is a host platform.
   bool is_host() const;
 
-  /// Gets all SYCL devices associated with this platform.
+  /// Returns all SYCL devices associated with this platform.
   ///
   /// If this SYCL platform is a host platform, resulting vector contains only
   /// a single SYCL host device. If there are no devices that match given device
@@ -92,7 +92,7 @@ public:
   typename info::param_traits<info::platform, param>::return_type
   get_info() const;
 
-  /// Gets all available SYCL platforms in the system.
+  /// Returns all available SYCL platforms in the system.
   ///
   /// The resulting vector always contains a single SYCL host platform instance.
   ///

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -12,7 +12,6 @@
 #include <CL/sycl/detail/platform_info.hpp>
 #include <CL/sycl/stl.hpp>
 // 4.6.2 Platform class
-#include <memory>
 #include <utility>
 namespace cl {
 namespace sycl {
@@ -26,9 +25,9 @@ class platform {
 public:
   platform();
 
-  explicit platform(cl_platform_id platform_id);
+  explicit platform(cl_platform_id PlatformId);
 
-  explicit platform(const device_selector &);
+  explicit platform(const device_selector &DeviceSelector);
 
   template <info::platform param>
   typename info::param_traits<info::platform, param>::return_type
@@ -48,22 +47,20 @@ public:
 
   bool operator!=(const platform &rhs) const { return !(*this == rhs); }
 
-  cl_platform_id get() const { return impl->get(); }
+  cl_platform_id get() const;
 
-  bool has_extension(const string_class &extension_name) const {
-    return impl->has_extension(extension_name);
-  }
+  bool has_extension(const string_class &ExtensionName) const;
 
-  bool is_host() const { return impl->is_host(); }
+  bool is_host() const;
 
   vector_class<device>
-  get_devices(info::device_type dev_type = info::device_type::all) const;
+  get_devices(info::device_type DeviceType = info::device_type::all) const;
 
   static vector_class<platform> get_platforms();
 
 private:
-  std::shared_ptr<detail::platform_impl> impl;
-  platform(std::shared_ptr<detail::platform_impl> impl) : impl(impl) {}
+  shared_ptr_class<detail::platform_impl> impl;
+  platform(shared_ptr_class<detail::platform_impl> impl) : impl(impl) {}
 
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
@@ -77,7 +74,7 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::platform> {
   size_t operator()(const cl::sycl::platform &p) const {
-    return hash<std::shared_ptr<cl::sycl::detail::platform_impl>>()(
+    return hash<cl::sycl::shared_ptr_class<cl::sycl::detail::platform_impl>>()(
         cl::sycl::detail::getSyclObjImpl(p));
   }
 };

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -63,7 +63,7 @@ public:
   /// @return an instance of OpenCL cl_platform_id.
   cl_platform_id get() const;
 
-  /// Checks if platform support specified extension.
+  /// Checks if platform supports specified extension.
   ///
   /// @param ExtensionName is a string containing extension name.
   /// @return true if specified extension is supported by this SYCL platform.

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -75,7 +75,7 @@ platform device_impl::get_platform() const {
   // particularly, equality comparison may fail for two consecutive
   // get_platform() on the same device, as it compares impl objects.
   return createSyclObjFromImpl<platform>(
-      std::make_shared<platform_impl_pi>(plt));
+      std::make_shared<platform_impl>(plt));
 }
 
 bool device_impl::has_extension(const string_class &ExtensionName) const {

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -74,8 +74,7 @@ platform device_impl::get_platform() const {
   // TODO: this possibly will violate common reference semantics,
   // particularly, equality comparison may fail for two consecutive
   // get_platform() on the same device, as it compares impl objects.
-  return createSyclObjFromImpl<platform>(
-      std::make_shared<platform_impl>(plt));
+  return createSyclObjFromImpl<platform>(std::make_shared<platform_impl>(plt));
 }
 
 bool device_impl::has_extension(const string_class &ExtensionName) const {

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -74,7 +74,8 @@ platform device_impl::get_platform() const {
   // TODO: this possibly will violate common reference semantics,
   // particularly, equality comparison may fail for two consecutive
   // get_platform() on the same device, as it compares impl objects.
-  return createSyclObjFromImpl<platform>(std::make_shared<platform_impl>(plt));
+  return createSyclObjFromImpl<platform>(
+      std::make_shared<platform_impl>(plt));
 }
 
 bool device_impl::has_extension(const string_class &ExtensionName) const {

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -19,8 +19,7 @@ namespace cl {
 namespace sycl {
 namespace detail {
 
-vector_class<platform>
-platform_impl::get_platforms() {
+vector_class<platform> platform_impl::get_platforms() {
   vector_class<platform> Platforms;
 
   pi_uint32 NumPlatforms = 0;
@@ -190,7 +189,8 @@ static void filterWhiteList(vector_class<RT::PiDevice> &pi_devices,
 vector_class<device>
 platform_impl::get_devices(info::device_type DeviceType) const {
   vector_class<device> Res;
-  if (is_host() && (DeviceType == info::device_type::host || DeviceType == info::device_type::all)) {
+  if (is_host() && (DeviceType == info::device_type::host ||
+                    DeviceType == info::device_type::all)) {
     Res.resize(1); // default device construct creates host device
     return Res;
   }

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -40,6 +40,10 @@ vector_class<platform> platform_impl::get_platforms() {
                       Platforms.push_back(Platform);
                   });
   }
+
+  if (ForcedType == info::device_type::host || ForcedType == info::device_type::all)
+    Platforms.emplace_back(platform());
+
   return Platforms;
 }
 
@@ -197,7 +201,7 @@ platform_impl::get_devices(info::device_type DeviceType) const {
 
   // If any DeviceType other than host was requested for host platform,
   // an empy vector will be returned.
-  if (is_host())
+  if (is_host() || DeviceType == info::device_type::host)
     return Res;
 
   pi_uint32 NumDevices;

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -27,16 +27,16 @@ vector_class<platform> platform_impl::get_platforms() {
   info::device_type ForcedType = detail::get_forced_type();
 
   if (NumPlatforms) {
-    vector_class<RT::PiPlatform> pi_platforms(NumPlatforms);
-    PI_CALL(piPlatformsGet)(NumPlatforms, pi_platforms.data(), nullptr);
+    vector_class<RT::PiPlatform> PiPlatforms(NumPlatforms);
+    PI_CALL(piPlatformsGet)(NumPlatforms, PiPlatforms.data(), nullptr);
 
     for (pi_uint32 i = 0; i < NumPlatforms; i++) {
 
-      platform plt = detail::createSyclObjFromImpl<platform>(
-          std::make_shared<platform_impl>(pi_platforms[i]));
+      platform Platform = detail::createSyclObjFromImpl<platform>(
+          std::make_shared<platform_impl>(PiPlatforms[i]));
       // Skip platforms which do not contain requested device types
-      if (!plt.get_devices(ForcedType).empty())
-        Platforms.push_back(plt);
+      if (!Platform.get_devices(ForcedType).empty())
+        Platforms.push_back(Platform);
     }
   }
   return Platforms;

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -219,7 +219,10 @@ platform_impl::get_devices(info::device_type DeviceType) const {
   if (SYCLConfig<SYCL_DEVICE_WHITE_LIST>::get())
     filterWhiteList(PiDevices, MPlatform);
 
-  Res.reserve(PiDevices.size());
+  size_t PlatformCount = PiDevices.size();
+  if (DeviceType == info::device_type::all) PlatformCount++;
+
+  Res.reserve(PlatformCount);
   std::transform(PiDevices.begin(), PiDevices.end(), Res.begin(),
                  [](const RT::PiDevice &PiDevice) -> device {
                    return detail::createSyclObjFromImpl<device>(

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -199,7 +199,7 @@ platform_impl::get_devices(info::device_type DeviceType) const {
   }
 
   // If any DeviceType other than host was requested for host platform,
-  // an empy vector will be returned.
+  // an empty vector will be returned.
   if (is_host() || DeviceType == info::device_type::host)
     return Res;
 
@@ -219,7 +219,7 @@ platform_impl::get_devices(info::device_type DeviceType) const {
   if (SYCLConfig<SYCL_DEVICE_WHITE_LIST>::get())
     filterWhiteList(PiDevices, MPlatform);
 
-  std::transform(PiDevices.rbegin(), PiDevices.rend(), std::front_inserter(Res),
+  std::transform(PiDevices.begin(), PiDevices.end(), std::back_inserter(Res),
                  [](const RT::PiDevice &PiDevice) -> device {
                    return detail::createSyclObjFromImpl<device>(
                        std::make_shared<device_impl>(PiDevice));

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -19,7 +19,8 @@ namespace cl {
 namespace sycl {
 namespace detail {
 
-vector_class<platform> platform_impl::get_platforms() {
+vector_class<platform>
+platform_impl::get_platforms() {
   vector_class<platform> Platforms;
 
   pi_uint32 NumPlatforms = 0;
@@ -189,25 +190,22 @@ static void filterWhiteList(vector_class<RT::PiDevice> &pi_devices,
 vector_class<device>
 platform_impl::get_devices(info::device_type DeviceType) const {
   vector_class<device> Res;
-  if (is_host() && (DeviceType == info::device_type::host ||
-                    DeviceType == info::device_type::all)) {
+  if (is_host() && (DeviceType == info::device_type::host || DeviceType == info::device_type::all)) {
     Res.resize(1); // default device construct creates host device
     return Res;
   }
 
   pi_uint32 NumDevices;
-  PI_CALL(piDevicesGet)
-  (MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), 0,
-   pi::cast<RT::PiDevice *>(nullptr), &NumDevices);
+  PI_CALL(piDevicesGet)(MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), 0,
+                        pi::cast<RT::PiDevice *>(nullptr), &NumDevices);
 
   if (NumDevices == 0)
     return Res;
 
   vector_class<RT::PiDevice> pi_devices(NumDevices);
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piDevicesGet)
-  (MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), NumDevices,
-   pi_devices.data(), nullptr);
+  PI_CALL(piDevicesGet)(MPlatform, pi::cast<RT::PiDeviceType>(DeviceType),
+                        NumDevices, pi_devices.data(), nullptr);
 
   // Filter out devices that are not present in the white list
   if (SYCLConfig<SYCL_DEVICE_WHITE_LIST>::get())

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -136,58 +136,58 @@ static std::vector<DevDescT> getWhiteListDesc() {
   return decDescs;
 }
 
-static void filterWhiteList(vector_class<RT::PiDevice> &pi_devices,
-                            RT::PiPlatform pi_platform) {
-  const std::vector<DevDescT> whiteList(getWhiteListDesc());
-  if (whiteList.empty())
+static void filterWhiteList(vector_class<RT::PiDevice> &PiDevices,
+                            RT::PiPlatform PiPlatform) {
+  const std::vector<DevDescT> WhiteList(getWhiteListDesc());
+  if (WhiteList.empty())
     return;
 
-  const string_class platformName =
+  const string_class PlatformName =
       sycl::detail::get_platform_info<string_class, info::platform::name>::get(
-          pi_platform);
+          PiPlatform);
 
-  const string_class platformVer = sycl::detail::get_platform_info<
-      string_class, info::platform::version>::get(pi_platform);
+  const string_class PlatformVer =
+      sycl::detail::get_platform_info<string_class,
+                                      info::platform::version>::get(PiPlatform);
 
-  int insertIDx = 0;
-  for (RT::PiDevice dev : pi_devices) {
-    const string_class devName =
+  int InsertIDx = 0;
+  for (RT::PiDevice Device : PiDevices) {
+    const string_class DeviceName =
         sycl::detail::get_device_info<string_class, info::device::name>::get(
-            dev);
+            Device);
 
-    const string_class devDriverVer =
-        sycl::detail::get_device_info<string_class,
-                                      info::device::driver_version>::get(dev);
+    const string_class DeviceDriverVer = sycl::detail::get_device_info<
+        string_class, info::device::driver_version>::get(Device);
 
-    for (const DevDescT &desc : whiteList) {
-      if (nullptr != desc.platformName &&
-          !std::regex_match(platformName,
-                            std::regex(std::string(desc.platformName,
-                                                   desc.platformNameSize))))
+    for (const DevDescT &Desc : WhiteList) {
+      if (nullptr != Desc.platformName &&
+          !std::regex_match(PlatformName,
+                            std::regex(std::string(Desc.platformName,
+                                                   Desc.platformNameSize))))
         continue;
 
-      if (nullptr != desc.platformVer &&
+      if (nullptr != Desc.platformVer &&
           !std::regex_match(
-              platformVer,
-              std::regex(std::string(desc.platformVer, desc.platformVerSize))))
+              PlatformVer,
+              std::regex(std::string(Desc.platformVer, Desc.platformVerSize))))
         continue;
 
-      if (nullptr != desc.devName &&
-          !std::regex_match(
-              devName, std::regex(std::string(desc.devName, desc.devNameSize))))
+      if (nullptr != Desc.devName &&
+          !std::regex_match(DeviceName, std::regex(std::string(
+                                            Desc.devName, Desc.devNameSize))))
         continue;
 
-      if (nullptr != desc.devDriverVer &&
-          !std::regex_match(devDriverVer,
-                            std::regex(std::string(desc.devDriverVer,
-                                                   desc.devDriverVerSize))))
+      if (nullptr != Desc.devDriverVer &&
+          !std::regex_match(DeviceDriverVer,
+                            std::regex(std::string(Desc.devDriverVer,
+                                                   Desc.devDriverVerSize))))
         continue;
 
-      pi_devices[insertIDx++] = dev;
+      PiDevices[InsertIDx++] = Device;
       break;
     }
   }
-  pi_devices.resize(insertIDx);
+  PiDevices.resize(InsertIDx);
 }
 
 vector_class<device>

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -219,11 +219,7 @@ platform_impl::get_devices(info::device_type DeviceType) const {
   if (SYCLConfig<SYCL_DEVICE_WHITE_LIST>::get())
     filterWhiteList(PiDevices, MPlatform);
 
-  size_t PlatformCount = PiDevices.size();
-  if (DeviceType == info::device_type::all) PlatformCount++;
-
-  Res.reserve(PlatformCount);
-  std::transform(PiDevices.begin(), PiDevices.end(), Res.begin(),
+  std::transform(PiDevices.rbegin(), PiDevices.rend(), std::front_inserter(Res),
                  [](const RT::PiDevice &PiDevice) -> device {
                    return detail::createSyclObjFromImpl<device>(
                        std::make_shared<device_impl>(PiDevice));

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -193,8 +193,12 @@ platform_impl::get_devices(info::device_type DeviceType) const {
   if (is_host() && (DeviceType == info::device_type::host ||
                     DeviceType == info::device_type::all)) {
     Res.resize(1); // default device construct creates host device
-    return Res;
   }
+
+  // If any DeviceType other than host was requested for host platform,
+  // an empy vector will be returned.
+  if (is_host())
+    return Res;
 
   pi_uint32 NumDevices;
   PI_CALL(piDevicesGet)(MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), 0,

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -19,8 +19,7 @@ namespace cl {
 namespace sycl {
 namespace detail {
 
-vector_class<platform>
-platform_impl::get_platforms() {
+vector_class<platform> platform_impl::get_platforms() {
   vector_class<platform> Platforms;
 
   pi_uint32 NumPlatforms = 0;
@@ -33,8 +32,7 @@ platform_impl::get_platforms() {
 
     for (pi_uint32 i = 0; i < NumPlatforms; i++) {
 
-      platform plt =
-        detail::createSyclObjFromImpl<platform>(
+      platform plt = detail::createSyclObjFromImpl<platform>(
           std::make_shared<platform_impl>(pi_platforms[i]));
       // Skip platforms which do not contain requested device types
       if (!plt.get_devices(ForcedType).empty())
@@ -191,22 +189,25 @@ static void filterWhiteList(vector_class<RT::PiDevice> &pi_devices,
 vector_class<device>
 platform_impl::get_devices(info::device_type DeviceType) const {
   vector_class<device> Res;
-  if (is_host() && (DeviceType == info::device_type::host || DeviceType == info::device_type::all)) {
+  if (is_host() && (DeviceType == info::device_type::host ||
+                    DeviceType == info::device_type::all)) {
     Res.resize(1); // default device construct creates host device
     return Res;
   }
 
   pi_uint32 NumDevices;
-  PI_CALL(piDevicesGet)(MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), 0,
-                        pi::cast<RT::PiDevice *>(nullptr), &NumDevices);
+  PI_CALL(piDevicesGet)
+  (MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), 0,
+   pi::cast<RT::PiDevice *>(nullptr), &NumDevices);
 
   if (NumDevices == 0)
     return Res;
 
   vector_class<RT::PiDevice> pi_devices(NumDevices);
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piDevicesGet)(MPlatform, pi::cast<RT::PiDeviceType>(DeviceType),
-                        NumDevices, pi_devices.data(), nullptr);
+  PI_CALL(piDevicesGet)
+  (MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), NumDevices,
+   pi_devices.data(), nullptr);
 
   // Filter out devices that are not present in the white list
   if (SYCLConfig<SYCL_DEVICE_WHITE_LIST>::get())

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -15,10 +15,10 @@
 namespace cl {
 namespace sycl {
 
-platform::platform() : impl(std::make_shared<detail::platform_impl_host>()) {}
+platform::platform() : impl(std::make_shared<detail::platform_impl>()) {}
 
 platform::platform(cl_platform_id PlatformId)
-    : impl(std::make_shared<detail::platform_impl_pi>(
+    : impl(std::make_shared<detail::platform_impl>(
              detail::pi::cast<detail::RT::PiPlatform>(PlatformId))) {}
 
 platform::platform(const device_selector &dev_selector) {
@@ -40,7 +40,7 @@ vector_class<device> platform::get_devices(info::device_type DeviceType) const {
 vector_class<platform> platform::get_platforms() {
 
   vector_class<platform> platforms =
-    detail::platform_impl_pi::get_platforms();
+    detail::platform_impl::get_platforms();
 
   // Add host device platform if required
   info::device_type forced_type = detail::get_forced_type();

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -20,7 +20,7 @@ platform::platform() : impl(std::make_shared<detail::platform_impl>()) {}
 
 platform::platform(cl_platform_id PlatformId)
     : impl(std::make_shared<detail::platform_impl>(
-             detail::pi::cast<detail::RT::PiPlatform>(PlatformId))) {}
+          detail::pi::cast<detail::RT::PiPlatform>(PlatformId))) {}
 
 platform::platform(const device_selector &dev_selector) {
   *this = dev_selector.select_device().get_platform();
@@ -40,8 +40,7 @@ vector_class<device> platform::get_devices(info::device_type DeviceType) const {
 
 vector_class<platform> platform::get_platforms() {
 
-  vector_class<platform> platforms =
-    detail::platform_impl::get_platforms();
+  vector_class<platform> platforms = detail::platform_impl::get_platforms();
 
   // Add host device platform if required
   info::device_type forced_type = detail::get_forced_type();
@@ -57,8 +56,8 @@ platform::get_info() const {
   return impl->get_info<param>();
 }
 
-#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
-    template ret_type platform::get_info<info::param_type::param>() const;
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type platform::get_info<info::param_type::param>() const;
 
 #include <CL/sycl/info/platform_traits.def>
 

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -10,6 +10,7 @@
 #include <CL/sycl/detail/platform_impl.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/device_selector.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/platform.hpp>
 
 namespace cl {
@@ -49,6 +50,19 @@ vector_class<platform> platform::get_platforms() {
 
   return platforms;
 }
+
+template <info::platform param>
+typename info::param_traits<info::platform, param>::return_type
+platform::get_info() const {
+  return impl->get_info<param>();
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
+    template ret_type platform::get_info<info::param_type::param>() const;
+
+#include <CL/sycl/info/platform_traits.def>
+
+#undef PARAM_TRAITS_SPEC
 
 } // namespace sycl
 } // namespace cl

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -17,16 +17,24 @@ namespace sycl {
 
 platform::platform() : impl(std::make_shared<detail::platform_impl_host>()) {}
 
-platform::platform(cl_platform_id platform_id)
+platform::platform(cl_platform_id PlatformId)
     : impl(std::make_shared<detail::platform_impl_pi>(
-             detail::pi::cast<detail::RT::PiPlatform>(platform_id))) {}
+             detail::pi::cast<detail::RT::PiPlatform>(PlatformId))) {}
 
 platform::platform(const device_selector &dev_selector) {
   *this = dev_selector.select_device().get_platform();
 }
 
-vector_class<device> platform::get_devices(info::device_type dev_type) const {
-  return impl->get_devices(dev_type);
+cl_platform_id platform::get() const { return impl->get(); }
+
+bool platform::has_extension(const string_class &ExtensionName) const {
+  return impl->has_extension(ExtensionName);
+}
+
+bool platform::is_host() const { return impl->is_host(); }
+
+vector_class<device> platform::get_devices(info::device_type DeviceType) const {
+  return impl->get_devices(DeviceType);
 }
 
 vector_class<platform> platform::get_platforms() {

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -20,7 +20,7 @@ platform::platform() : impl(std::make_shared<detail::platform_impl>()) {}
 
 platform::platform(cl_platform_id PlatformId)
     : impl(std::make_shared<detail::platform_impl>(
-          detail::pi::cast<detail::RT::PiPlatform>(PlatformId))) {}
+             detail::pi::cast<detail::RT::PiPlatform>(PlatformId))) {}
 
 platform::platform(const device_selector &dev_selector) {
   *this = dev_selector.select_device().get_platform();
@@ -40,7 +40,8 @@ vector_class<device> platform::get_devices(info::device_type DeviceType) const {
 
 vector_class<platform> platform::get_platforms() {
 
-  vector_class<platform> platforms = detail::platform_impl::get_platforms();
+  vector_class<platform> platforms =
+    detail::platform_impl::get_platforms();
 
   // Add host device platform if required
   info::device_type forced_type = detail::get_forced_type();
@@ -56,8 +57,8 @@ platform::get_info() const {
   return impl->get_info<param>();
 }
 
-#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
-  template ret_type platform::get_info<info::param_type::param>() const;
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
+    template ret_type platform::get_info<info::param_type::param>() const;
 
 #include <CL/sycl/info/platform_traits.def>
 


### PR DESCRIPTION
This patch is a part of effort to decouple SYCL Runtime library
interface from its actual implementation. The goal is to improve
SYCL ABI/API compatibility between different versions of library.

The following modifications were applied to platform and platform_impl
classes:

1. Removed include of platform_impl header from platform.hpp and replaced
it with forward declaration.
2. Move member function implementations from platform.hpp to platform.cpp
3. std::shared_ptr was replaced with shared_ptr_class for platform class
4. Documentation was improved for both platform and platform_impl
5. platform_impl now tries to follow LLVM code style

Applying aforementioned changes requires modifying other header files.
While some of those may seem as a regression, affected classes will be
covered by future patches.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>