### PR TITLE
[SYCL] Change lowering of 'cl::sycl::select' into SPIR-V

### DIFF
--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -1303,7 +1303,7 @@ detail::enable_if_t<
     detail::is_geninteger<T>::value && detail::is_igeninteger<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   detail::check_vector_size<T, T2>();
-  return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
+  return __sycl_std::__invoke_select<T>(a, b, c);
 }
 
 // geninteger select (geninteger a, geninteger b, ugeninteger c)
@@ -1312,7 +1312,7 @@ detail::enable_if_t<
     detail::is_geninteger<T>::value && detail::is_ugeninteger<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   detail::check_vector_size<T, T2>();
-  return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
+  return __sycl_std::__invoke_select<T>(a, b, c);
 }
 
 // genfloatf select (genfloatf a, genfloatf b, genint c)
@@ -1321,7 +1321,7 @@ detail::enable_if_t<
     detail::is_genfloatf<T>::value && detail::is_genint<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   detail::check_vector_size<T, T2>();
-  return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
+  return __sycl_std::__invoke_select<T>(a, b, c);
 }
 
 // genfloatf select (genfloatf a, genfloatf b, ugenint c)
@@ -1330,7 +1330,7 @@ detail::enable_if_t<
     detail::is_genfloatf<T>::value && detail::is_ugenint<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   detail::check_vector_size<T, T2>();
-  return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
+  return __sycl_std::__invoke_select<T>(a, b, c);
 }
 
 // genfloatd select (genfloatd a, genfloatd b, igeninteger64 c)
@@ -1339,7 +1339,7 @@ detail::enable_if_t<
     detail::is_genfloatd<T>::value && detail::is_igeninteger64bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   detail::check_vector_size<T, T2>();
-  return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
+  return __sycl_std::__invoke_select<T>(a, b, c);
 }
 
 // genfloatd select (genfloatd a, genfloatd b, ugeninteger64 c)
@@ -1348,7 +1348,7 @@ detail::enable_if_t<
     detail::is_genfloatd<T>::value && detail::is_ugeninteger64bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   detail::check_vector_size<T, T2>();
-  return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
+  return __sycl_std::__invoke_select<T>(a, b, c);
 }
 
 // genfloath select (genfloath a, genfloath b, igeninteger16 c)
@@ -1357,7 +1357,7 @@ detail::enable_if_t<
     detail::is_genfloath<T>::value && detail::is_igeninteger16bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   detail::check_vector_size<T, T2>();
-  return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
+  return __sycl_std::__invoke_select<T>(a, b, c);
 }
 
 // genfloath select (genfloath a, genfloath b, ugeninteger16 c)
@@ -1366,7 +1366,7 @@ detail::enable_if_t<
     detail::is_genfloath<T>::value && detail::is_ugeninteger16bit<T2>::value, T>
 select(T a, T b, T2 c) __NOEXC {
   detail::check_vector_size<T, T2>();
-  return __sycl_std::__invoke_Select<T>(detail::select_arg_c_t<T2>(c), b, a);
+  return __sycl_std::__invoke_select<T>(a, b, c);
 }
 
 namespace native {

--- a/sycl/include/CL/sycl/detail/builtins.hpp
+++ b/sycl/include/CL/sycl/detail/builtins.hpp
@@ -239,7 +239,7 @@ MAKE_CALL_ARG1(SignBitSet, __FUNC_PREFIX_CORE)           // signbit
 MAKE_CALL_ARG1(Any, __FUNC_PREFIX_CORE)                  // any
 MAKE_CALL_ARG1(All, __FUNC_PREFIX_CORE)                  // all
 MAKE_CALL_ARG3(bitselect, __FUNC_PREFIX_OCL)
-MAKE_CALL_ARG3(Select, __FUNC_PREFIX_CORE) // select
+MAKE_CALL_ARG3(select, __FUNC_PREFIX_OCL) // select
 #ifndef __SYCL_DEVICE_ONLY__
 } // namespace __host_std
 } // namespace cl

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -484,18 +484,6 @@ template <typename T> struct RelationalReturnType {
 #endif
 };
 
-// Used for select built-in function
-template <typename T> struct SelectWrapperTypeArgC {
-#ifdef __SYCL_DEVICE_ONLY__
-  using type = Boolean<TryToGetNumElements<T>::value>;
-#else
-  using type = T;
-#endif
-};
-
-template <typename T>
-using select_arg_c_t = typename SelectWrapperTypeArgC<T>::type;
-
 template <typename T> using rel_ret_t = typename RelationalReturnType<T>::type;
 
 // Used for any and all built-in functions

--- a/sycl/source/detail/builtins_relational.cpp
+++ b/sycl/source/detail/builtins_relational.cpp
@@ -121,11 +121,11 @@ typename std::enable_if<d::is_sgenfloat<T>::value, T>::type inline __bitselect(
   return br.f;
 }
 
-template <typename T, typename T2> inline T2 __Select(T c, T2 b, T2 a) {
+template <typename T, typename T2> inline T2 __select(T2 a, T2 b, T c) {
   return (c ? b : a);
 }
 
-template <typename T, typename T2> inline T2 __vSelect(T c, T2 b, T2 a) {
+template <typename T, typename T2> inline T2 __vselect(T2 a, T2 b, T c) {
   return d::msbIsSet(c) ? b : a;
 }
 } // namespace
@@ -407,49 +407,49 @@ MAKE_SC_1V_2V_3V(bitselect, s::cl_half, s::cl_half, s::cl_half, s::cl_half)
 // (Select) // select
 // for scalar: result = c ? b : a.
 // for vector: result[i] = (MSB of c[i] is set)? b[i] : a[i]
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_float, s::cl_int, s::cl_float,
-                        s::cl_float)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_float, s::cl_uint, s::cl_float,
-                        s::cl_float)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_double, s::cl_long,
-                        s::cl_double, s::cl_double)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_double, s::cl_ulong,
-                        s::cl_double, s::cl_double)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_char, s::cl_char, s::cl_char,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_float, s::cl_float,
+                        s::cl_float, s::cl_int)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_float, s::cl_float,
+                        s::cl_float, s::cl_uint)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_double, s::cl_double,
+                        s::cl_double, s::cl_long)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_double, s::cl_double,
+                        s::cl_double, s::cl_ulong)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_char, s::cl_char, s::cl_char,
                         s::cl_char)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_char, s::cl_uchar, s::cl_char,
-                        s::cl_char)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uchar, s::cl_char, s::cl_uchar,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_char, s::cl_char, s::cl_char,
                         s::cl_uchar)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uchar, s::cl_uchar,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_uchar, s::cl_uchar,
+                        s::cl_uchar, s::cl_char)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_uchar, s::cl_uchar,
                         s::cl_uchar, s::cl_uchar)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_short, s::cl_short,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_short, s::cl_short,
                         s::cl_short, s::cl_short)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_short, s::cl_ushort,
-                        s::cl_short, s::cl_short)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_ushort, s::cl_short,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_short, s::cl_short,
+                        s::cl_short, s::cl_ushort)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_ushort, s::cl_ushort,
+                        s::cl_ushort, s::cl_short)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_ushort, s::cl_ushort,
                         s::cl_ushort, s::cl_ushort)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_ushort, s::cl_ushort,
-                        s::cl_ushort, s::cl_ushort)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_int, s::cl_int, s::cl_int,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_int, s::cl_int, s::cl_int,
                         s::cl_int)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_int, s::cl_uint, s::cl_int,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_int, s::cl_int, s::cl_int,
+                        s::cl_uint)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_uint, s::cl_uint, s::cl_uint,
                         s::cl_int)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uint, s::cl_int, s::cl_uint,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_uint, s::cl_uint, s::cl_uint,
                         s::cl_uint)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_uint, s::cl_uint, s::cl_uint,
-                        s::cl_uint)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_long, s::cl_long, s::cl_long,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_long, s::cl_long, s::cl_long,
                         s::cl_long)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_long, s::cl_ulong, s::cl_long,
-                        s::cl_long)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_ulong, s::cl_long, s::cl_ulong,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_long, s::cl_long, s::cl_long,
                         s::cl_ulong)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_ulong, s::cl_ulong,
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_ulong, s::cl_ulong,
+                        s::cl_ulong, s::cl_long)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_ulong, s::cl_ulong,
                         s::cl_ulong, s::cl_ulong)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_half, s::cl_short, s::cl_half,
-                        s::cl_half)
-MAKE_SC_FSC_1V_2V_3V_FV(Select, __vSelect, s::cl_half, s::cl_ushort, s::cl_half,
-                        s::cl_half)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_half, s::cl_half, s::cl_half,
+                        s::cl_short)
+MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_half, s::cl_half, s::cl_half,
+                        s::cl_ushort)
 } // namespace __host_std
 } // namespace cl


### PR DESCRIPTION
Previously, `OpSelect` from SPIR-V core spec was used, but comparing to
the SYCL definition of 'select' built-in, it behaves
differently and even takes different arguments.

`select` instruction from OpenCL Extended Instruction Set must be used
instead.

Description of `OpSelect` from SPIR-V core spec:

> Condition must be a scalar or vector of Boolean type.
> If Condition is a scalar and true, the result is Object 1. If
> Condition is a scalar and false, the result is Object 2.
>
> If Condition is a vector, Result Type must be a vector with the same
> number of components as Condition and the result is a mix of Object 1
> and Object 2: When a component of Condition is true, the corresponding
> component in the result is taken from Object 1, otherwise it is taken
> from Object 2.

Description of `select` ExtInst:

> For each component of a vector type, the result is a if the most
> significant bit of c is zero, otherwise it is b.
>
> For a scalar type, the result is a if c is zero, otherwise it is b.
>
> c must be integer or vector(2,3,4,8,16) of integer values.

The latter perfectly matches both SYCL and OpenCL specs.

Note: previous implementation emulate ExtInst select behavior over
OpSelect by evaluating MSB of each vector compontent in C++ code, so, it
is functionally correct. However, it uses ext-vectors of booleans, which are
unsupported by OpenCL and confuse underlying OpenCL compilers sometimes
(crashes and hangs experienced in complex applications because of this).