### PR TITLE
[SYCL] Apply /MD and /MDd on Windows only to SYCL and SYCLD targets

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -127,10 +127,10 @@ if (MSVC)
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "")
   set(CMAKE_CXX_FLAGS_DEBUG "")
 
-  target_compile_options(sycl PUBLIC ${SYCL_CXX_FLAGS_RELEASE})
+  target_compile_options(sycl PRIVATE ${SYCL_CXX_FLAGS_RELEASE})
 
   add_sycl_rt_library(sycld ${SYCL_SOURCES})
-  target_compile_options(sycld PUBLIC ${SYCL_CXX_FLAGS_DEBUG})
+  target_compile_options(sycld PRIVATE ${SYCL_CXX_FLAGS_DEBUG})
 endif()
 
 install(TARGETS ${SYCL_RT_LIBS}


### PR DESCRIPTION
This patch fixes the build errors caused by RuntimeLibrary value
inconsistency for LLVM and apps/tests linked with it,
e.g. (MT_StaticRelease vs MD_DynamicRelease) in cases when
LLVM_USE_CRT_RELEASE is set to MT. In such cases /MD set for sycl lib
targets must not affect tests linked with MT version of LLVM.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>