### PR TITLE
[SYCL] Refactor event to improve ABI stability

### DIFF
--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -40,7 +40,7 @@ public:
 class event_impl {
 public:
   event_impl() = default;
-  event_impl(cl_event CLEvent, const context &SyclContext);
+  event_impl(cl_event ClEvent, const context &SyclContext);
   event_impl(QueueImplPtr Queue);
 
   // Threat all devices that don't support interoperability as host devices to
@@ -77,22 +77,20 @@ public:
   // with the cl_event object stored in this class
   void setContextImpl(const ContextImplPtr &Context);
 
-  void *getCommand() { return m_Command; }
+  void *getCommand() { return MCommand; }
 
-  void setCommand(void *Command) { m_Command = Command; }
+  void setCommand(void *Command) { MCommand = Command; }
 
-  HostProfilingInfo *getHostProfilingInfo() {
-    return m_HostProfilingInfo.get();
-  }
+  HostProfilingInfo *getHostProfilingInfo() { return MHostProfilingInfo.get(); }
 
 private:
-  RT::PiEvent m_Event = nullptr;
-  ContextImplPtr m_Context;
-  QueueImplPtr m_Queue;
-  bool m_OpenCLInterop = false;
-  bool m_HostEvent = true;
-  std::unique_ptr<HostProfilingInfo> m_HostProfilingInfo;
-  void *m_Command = nullptr;
+  RT::PiEvent MEvent = nullptr;
+  ContextImplPtr MContext;
+  QueueImplPtr MQueue;
+  bool MOpenCLInterop = false;
+  bool MHostEvent = true;
+  std::unique_ptr<HostProfilingInfo> MHostProfilingInfo;
+  void *MCommand = nullptr;
 };
 
 } // namespace detail

--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -40,7 +40,7 @@ public:
 class event_impl {
 public:
   event_impl() = default;
-  event_impl(cl_event ClEvent, const context &SyclContext);
+  event_impl(RT::PiEvent Event, const context &SyclContext);
   event_impl(QueueImplPtr Queue);
 
   // Threat all devices that don't support interoperability as host devices to

--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -24,63 +24,138 @@ using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 class queue_impl;
 using QueueImplPtr = std::shared_ptr<cl::sycl::detail::queue_impl>;
 
-// Profiling info for the host execution.
+/// Profiling info for the host execution.
 class HostProfilingInfo {
   cl_ulong StartTime = 0;
   cl_ulong EndTime = 0;
 
 public:
+  /// Returns event's start time.
+  ///
+  /// @return event's start time in nanoseconds.
   cl_ulong getStartTime() const { return StartTime; }
+  /// Returns event's end time.
+  ///
+  /// @return event's end time in nanoseconds.
   cl_ulong getEndTime() const { return EndTime; }
 
+  /// Measures event's start time.
   void start();
+  /// Measures event's end time.
   void end();
 };
 
 class event_impl {
 public:
+  /// Constructs a ready SYCL event.
+  ///
+  /// If the constructed SYCL event is waited on it will complete immediately.
   event_impl() = default;
+  /// Constructs an event instance from a plug-in event handle.
+  ///
+  /// The SyclContext must match the plug-in context associated with the ClEvent.
+  ///
+  /// @param Event is a valid instance of plug-in event.
+  /// @param SyclContext is an instance of SYCL context.
   event_impl(RT::PiEvent Event, const context &SyclContext);
   event_impl(QueueImplPtr Queue);
 
-  // Threat all devices that don't support interoperability as host devices to
-  // avoid attempts to call method get on such events.
+  /// Checks if this event is a SYCL host event.
+  ///
+  /// All devices that do not support OpenCL interoperability are treated as
+  /// host device to avoid attempts to call method get on such events.
+  //
+  /// @return true if this event is a SYCL host event.
   bool is_host() const;
 
+  /// Returns a valid OpenCL event interoperability handle.
+  ///
+  /// @return a valid instance of OpenCL cl_event.
   cl_event get() const;
 
-  // Self is needed in order to pass shared_ptr to Scheduler.
+  /// Waits for the event.
+  ///
+  /// Self is needed in order to pass shared_ptr to Scheduler.
+  ///
+  /// @param Self is a pointer to this event.
   void wait(std::shared_ptr<cl::sycl::detail::event_impl> Self) const;
 
+  /// Waits for the event.
+  ///
+  /// If any uncaught asynchronous errors occurred on the context that the event
+  /// is waiting on executions from, then call that context's asynchronous error
+  /// handler with those errors.
+  /// Self is needed in order to pass shared_ptr to Scheduler.
+  ///
+  /// @param Self is a pointer to this event.
   void wait_and_throw(std::shared_ptr<cl::sycl::detail::event_impl> Self);
 
+  /// Queries this event for profiling information.
+  ///
+  /// If the requested info is not available when this member function is called
+  /// due to incompletion of command groups associated with the event, then the
+  /// call to this member function will block until the requested info is
+  /// available. If the queue which submitted the command group this event is
+  /// associated with was not constructed with the
+  /// property::queue::enable_profiling property, an invalid_object_error SYCL
+  /// exception is thrown.
+  ///
+  /// @return depends on template parameter.
   template <info::event_profiling param>
   typename info::param_traits<info::event_profiling, param>::return_type
   get_profiling_info() const;
 
+  /// Queries this SYCL event for information.
+  ///
+  /// @return depends on the information being requested.
   template <info::event param>
   typename info::param_traits<info::event, param>::return_type get_info() const;
 
   ~event_impl();
 
+  /// Waits for the event with respect to device type.
   void waitInternal() const;
 
+  /// Marks this event as completed.
   void setComplete();
 
-  // Warning. Returned reference will be invalid if event_impl was destroyed.
+  /// Returns raw interoperability event handle. Returned reference will be]
+  /// invalid if event_impl was destroyed.
+  ///
+  /// @return a reference to an instance of plug-in event handle.
   RT::PiEvent &getHandleRef();
+  /// Returns raw interoperability event handle. Returned reference will be]
+  /// invalid if event_impl was destroyed.
+  ///
+  /// @return a const reference to an instance of plug-in event handle.
   const RT::PiEvent &getHandleRef() const;
 
+  /// Returns context that is associated with this event.
+  ///
+  /// @return a shared pointer to a valid context_impl.
   const ContextImplPtr &getContextImpl();
 
-  // Warning. Provided cl_context inside ContextImplPtr must be associated
-  // with the cl_event object stored in this class
+  /// Associate event with the context.
+  ///
+  /// Provided PiContext inside ContextImplPtr must be associated
+  /// with the PiEvent object stored in this class
+  ///
+  /// @param Context is a shared pointer to an instance of valid context_impl.
   void setContextImpl(const ContextImplPtr &Context);
 
+  /// Returns command that is associated with the event.
+  ///
+  /// @return a generic pointer to Command object instance.
   void *getCommand() { return MCommand; }
 
+  /// Associates this event with the command.
+  ///
+  /// @param Command is a generic pointer to Command object instance.
   void setCommand(void *Command) { MCommand = Command; }
 
+  /// Returns host profiling information.
+  ///
+  /// @return a pointer to HostProfilingInfo instance.
   HostProfilingInfo *getHostProfilingInfo() { return MHostProfilingInfo.get(); }
 
 private:

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -11,6 +11,7 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
+#include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/event.hpp>

--- a/sycl/include/CL/sycl/event.hpp
+++ b/sycl/include/CL/sycl/event.hpp
@@ -23,8 +23,17 @@ class event_impl;
 
 class event {
 public:
+  /// Constructs a ready SYCL event.
+  ///
+  /// If the constructed SYCL event is waited on it will complete immediately.
   event();
 
+  /// Constructs a SYCL event instance from an OpenCL cl_event.
+  ///
+  /// The SyclContext must match the OpenCL context associated with the ClEvent.
+  ///
+  /// @param ClEvent is a valid instance of OpenCL cl_event.
+  /// @param SyclContext is an instance of SYCL context.
   event(cl_event ClEvent, const context &SyclContext);
 
   event(const event &rhs) = default;
@@ -39,23 +48,65 @@ public:
 
   bool operator!=(const event &rhs) const;
 
+  /// Returns a valid OpenCL event interoperability handle.
+  ///
+  /// @return a valid instance of OpenCL cl_event.
   cl_event get();
 
+  /// Checks if this event is a SYCL host event.
+  ///
+  /// @return true if this event is a SYCL host event.
   bool is_host() const;
 
+  /// Return the list of events that this event waits for.
+  ///
+  /// Only direct dependencies are returned. Already completed events are not
+  /// included in the returned vector.
+  ///
+  /// @return a vector of SYCL events.
   vector_class<event> get_wait_list();
 
+  /// Wait for the event.
   void wait();
 
+  /// Synchronously wait on a list of events.
+  ///
+  /// @param EventList is a vector of SYCL events.
   static void wait(const vector_class<event> &EventList);
 
+  /// Wait for the event.
+  ///
+  /// If any uncaught asynchronous errors occurred on the context that the event
+  /// is waiting on executions from, then call that context's asynchronous error
+  /// handler with those errors.
   void wait_and_throw();
 
+  /// Synchronously wait on a list of events.
+  ///
+  /// If any uncaught asynchronous errors occurred on the context that the
+  /// events are waiting on executions from, then call those contexts'
+  /// asynchronous error handlers with those errors.
+  ///
+  /// @param EventList is a vector of SYCL events.
   static void wait_and_throw(const vector_class<event> &EventList);
 
+  /// Queries this SYCL event for information.
+  ///
+  /// @return depends on the information being requested.
   template <info::event param>
   typename info::param_traits<info::event, param>::return_type get_info() const;
 
+  /// Queries this SYCL event for profiling information.
+  ///
+  /// If the requested info is not available when this member function is called
+  /// due to incompletion of command groups associated with the event, then the
+  /// call to this member function will block until the requested info is
+  /// available. If the queue which submitted the command group this event is
+  /// associated with was not constructed with the
+  /// property::queue::enable_profiling property, an invalid_object_error SYCL
+  /// exception is thrown.
+  ///
+  /// @return depends on template parameter.
   template <info::event_profiling param>
   typename info::param_traits<info::event_profiling, param>::return_type
   get_profiling_info() const;

--- a/sycl/include/CL/sycl/event.hpp
+++ b/sycl/include/CL/sycl/event.hpp
@@ -25,7 +25,7 @@ class event {
 public:
   event();
 
-  event(cl_event clEvent, const context &syclContext);
+  event(cl_event ClEvent, const context &SyclContext);
 
   event(const event &rhs) = default;
 
@@ -61,7 +61,7 @@ public:
   get_profiling_info() const;
 
 private:
-  event(shared_ptr_class<detail::event_impl> event_impl);
+  event(shared_ptr_class<detail::event_impl> EventImpl);
 
   shared_ptr_class<detail::event_impl> impl;
 

--- a/sycl/include/CL/sycl/event.hpp
+++ b/sycl/include/CL/sycl/event.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <CL/sycl/detail/common.hpp>
-#include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <memory>
@@ -18,6 +17,10 @@ namespace cl {
 namespace sycl {
 // Forward declaration
 class context;
+namespace detail {
+class event_impl;
+}
+
 class event {
 public:
   event();
@@ -58,9 +61,9 @@ public:
   get_profiling_info() const;
 
 private:
-  event(std::shared_ptr<detail::event_impl> event_impl);
+  event(shared_ptr_class<detail::event_impl> event_impl);
 
-  std::shared_ptr<detail::event_impl> impl;
+  shared_ptr_class<detail::event_impl> impl;
 
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
@@ -75,7 +78,7 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::event> {
   size_t operator()(const cl::sycl::event &e) const {
-    return hash<std::shared_ptr<cl::sycl::detail::event_impl>>()(
+    return hash<cl::sycl::shared_ptr_class<cl::sycl::detail::event_impl>>()(
         cl::sycl::detail::getSyclObjImpl(e));
   }
 };

--- a/sycl/include/CL/sycl/info/event_profiling_traits.def
+++ b/sycl/include/CL/sycl/info/event_profiling_traits.def
@@ -1,0 +1,4 @@
+PARAM_TRAITS_SPEC(event_profiling, command_submit, cl_ulong)
+PARAM_TRAITS_SPEC(event_profiling, command_start, cl_ulong)
+PARAM_TRAITS_SPEC(event_profiling, command_end, cl_ulong)
+

--- a/sycl/include/CL/sycl/info/event_traits.def
+++ b/sycl/include/CL/sycl/info/event_traits.def
@@ -1,0 +1,3 @@
+PARAM_TRAITS_SPEC(event, command_execution_status, info::event_command_status)
+PARAM_TRAITS_SPEC(event, reference_count, cl_uint)
+

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -258,12 +258,9 @@ template <typename T, T param> class param_traits {};
 
 #include <CL/sycl/info/context_traits.def>
 
-PARAM_TRAITS_SPEC(event, command_execution_status, event_command_status)
-PARAM_TRAITS_SPEC(event, reference_count, cl_uint)
+#include <CL/sycl/info/event_traits.def>
 
-PARAM_TRAITS_SPEC(event_profiling, command_submit, cl_ulong)
-PARAM_TRAITS_SPEC(event_profiling, command_start, cl_ulong)
-PARAM_TRAITS_SPEC(event_profiling, command_end, cl_ulong)
+#include <CL/sycl/info/event_profiling_traits.def>
 
 #include <CL/sycl/info/kernel_sub_group_traits.def>
 #include <CL/sycl/info/kernel_traits.def>

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -19,71 +19,70 @@ namespace detail {
 
 // Threat all devices that don't support interoperability as host devices to
 // avoid attempts to call method get on such events.
-bool event_impl::is_host() const { return m_HostEvent || !m_OpenCLInterop; }
+bool event_impl::is_host() const { return MHostEvent || !MOpenCLInterop; }
 
 cl_event event_impl::get() const {
-  if (m_OpenCLInterop) {
-    PI_CALL(piEventRetain)(m_Event);
-    return pi::cast<cl_event>(m_Event);
+  if (MOpenCLInterop) {
+    PI_CALL(piEventRetain)(MEvent);
+    return pi::cast<cl_event>(MEvent);
   }
   throw invalid_object_error(
       "This instance of event doesn't support OpenCL interoperability.");
 }
 
 event_impl::~event_impl() {
-  if (m_Event) {
-    PI_CALL(piEventRelease)(m_Event);
-  }
+  if (MEvent)
+    PI_CALL(piEventRelease)(MEvent);
 }
 
 void event_impl::waitInternal() const {
-  if (!m_HostEvent) {
-    PI_CALL(piEventsWait)(1, &m_Event);
+  if (!MHostEvent) {
+    PI_CALL(piEventsWait)(1, &MEvent);
   }
   // Waiting of host events is NOP so far as all operations on host device
   // are blocking.
 }
 
-const RT::PiEvent &event_impl::getHandleRef() const { return m_Event; }
-RT::PiEvent &event_impl::getHandleRef() { return m_Event; }
+const RT::PiEvent &event_impl::getHandleRef() const { return MEvent; }
+RT::PiEvent &event_impl::getHandleRef() { return MEvent; }
 
-const ContextImplPtr &event_impl::getContextImpl() { return m_Context; }
+const ContextImplPtr &event_impl::getContextImpl() { return MContext; }
 
 void event_impl::setContextImpl(const ContextImplPtr &Context) {
-  m_HostEvent = Context->is_host();
-  m_OpenCLInterop = !m_HostEvent;
-  m_Context = Context;
+  MHostEvent = Context->is_host();
+  MOpenCLInterop = !MHostEvent;
+  MContext = Context;
 }
 
-event_impl::event_impl(cl_event CLEvent, const context &SyclContext)
-    : m_Context(detail::getSyclObjImpl(SyclContext)), m_OpenCLInterop(true),
-      m_HostEvent(false) {
+event_impl::event_impl(cl_event ClEvent, const context &SyclContext)
+    : MContext(detail::getSyclObjImpl(SyclContext)), MOpenCLInterop(true),
+      MHostEvent(false) {
 
-  m_Event = pi::cast<RT::PiEvent>(CLEvent);
+  MEvent = pi::cast<RT::PiEvent>(ClEvent);
 
-  if (m_Context->is_host()) {
+  if (MContext->is_host()) {
     throw cl::sycl::invalid_parameter_error(
         "The syclContext must match the OpenCL context associated with the "
         "clEvent.");
   }
 
   RT::PiContext TempContext;
-  PI_CALL(piEventGetInfo)(m_Event, CL_EVENT_CONTEXT, sizeof(RT::PiContext),
+  PI_CALL(piEventGetInfo)(MEvent, CL_EVENT_CONTEXT, sizeof(RT::PiContext),
                           &TempContext, nullptr);
-  if (m_Context->getHandleRef() != TempContext) {
+  if (MContext->getHandleRef() != TempContext) {
     throw cl::sycl::invalid_parameter_error(
         "The syclContext must match the OpenCL context associated with the "
         "clEvent.");
   }
 
-  PI_CALL(piEventRetain)(m_Event);
+  PI_CALL(piEventRetain)(MEvent);
 }
 
-event_impl::event_impl(QueueImplPtr Queue) : m_Queue(Queue) {
+event_impl::event_impl(QueueImplPtr Queue) : MQueue(Queue) {
   if (Queue->is_host() &&
       Queue->has_property<property::queue::enable_profiling>()) {
-    m_HostProfilingInfo.reset(new HostProfilingInfo());
-    if (!m_HostProfilingInfo)
+    MHostProfilingInfo.reset(new HostProfilingInfo());
+    if (!MHostProfilingInfo)
       throw runtime_error("Out of host memory");
   }
 }
@@ -91,11 +90,11 @@ event_impl::event_impl(QueueImplPtr Queue) : m_Queue(Queue) {
 void event_impl::wait(
     std::shared_ptr<cl::sycl::detail::event_impl> Self) const {
 
-  if (m_Event)
-    // presence of m_Event means the command has been enqueued, so no need to
+  if (MEvent)
+    // presence of MEvent means the command has been enqueued, so no need to
     // go via the slow path event waiting in the scheduler
     waitInternal();
-  else if (m_Command)
+  else if (MCommand)
     detail::Scheduler::getInstance().waitForEvent(std::move(Self));
 }
 
@@ -108,48 +107,48 @@ void event_impl::wait_and_throw(
     if (Cmd)
       Cmd->getQueue()->throw_asynchronous();
   }
-  if (m_Queue)
-    m_Queue->throw_asynchronous();
+  if (MQueue)
+    MQueue->throw_asynchronous();
 }
 
 template <>
 cl_ulong
 event_impl::get_profiling_info<info::event_profiling::command_submit>() const {
-  if (!m_HostEvent) {
+  if (!MHostEvent) {
     return get_event_profiling_info<info::event_profiling::command_submit>::get(
         this->getHandleRef());
   }
-  if (!m_HostProfilingInfo)
+  if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.");
-  return m_HostProfilingInfo->getStartTime();
+  return MHostProfilingInfo->getStartTime();
 }
 
 template <>
 cl_ulong
 event_impl::get_profiling_info<info::event_profiling::command_start>() const {
-  if (!m_HostEvent) {
+  if (!MHostEvent) {
     return get_event_profiling_info<info::event_profiling::command_start>::get(
         this->getHandleRef());
   }
-  if (!m_HostProfilingInfo)
+  if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.");
-  return m_HostProfilingInfo->getStartTime();
+  return MHostProfilingInfo->getStartTime();
 }
 
 template <>
 cl_ulong
 event_impl::get_profiling_info<info::event_profiling::command_end>() const {
-  if (!m_HostEvent) {
+  if (!MHostEvent) {
     return get_event_profiling_info<info::event_profiling::command_end>::get(
         this->getHandleRef());
   }
-  if (!m_HostProfilingInfo)
+  if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.");
-  return m_HostProfilingInfo->getEndTime();
+  return MHostProfilingInfo->getEndTime();
 }
 
 template <> cl_uint event_impl::get_info<info::event::reference_count>() const {
-  if (!m_HostEvent) {
+  if (!MHostEvent) {
     return get_event_info<info::event::reference_count>::get(
         this->getHandleRef());
   }
@@ -159,7 +158,7 @@ template <> cl_uint event_impl::get_info<info::event::reference_count>() const {
 template <>
 info::event_command_status
 event_impl::get_info<info::event::command_execution_status>() const {
-  if (!m_HostEvent) {
+  if (!MHostEvent) {
     return get_event_info<info::event::command_execution_status>::get(
         this->getHandleRef());
   }
@@ -167,8 +166,9 @@ event_impl::get_info<info::event::command_execution_status>() const {
 }
 
 static uint64_t getTimestamp() {
-  auto ts = std::chrono::high_resolution_clock::now().time_since_epoch();
-  return std::chrono::duration_cast<std::chrono::nanoseconds>(ts).count();
+  auto TimeStamp = std::chrono::high_resolution_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(TimeStamp)
+      .count();
 }
 
 void HostProfilingInfo::start() { StartTime = getTimestamp(); }

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -54,11 +54,9 @@ void event_impl::setContextImpl(const ContextImplPtr &Context) {
   MContext = Context;
 }
 
-event_impl::event_impl(cl_event ClEvent, const context &SyclContext)
-    : MContext(detail::getSyclObjImpl(SyclContext)), MOpenCLInterop(true),
-      MHostEvent(false) {
-
-  MEvent = pi::cast<RT::PiEvent>(ClEvent);
+event_impl::event_impl(RT::PiEvent Event, const context &SyclContext)
+    : MEvent(Event), MContext(detail::getSyclObjImpl(SyclContext)),
+      MOpenCLInterop(true), MHostEvent(false) {
 
   if (MContext->is_host()) {
     throw cl::sycl::invalid_parameter_error(

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -9,6 +9,7 @@
 #include <CL/sycl/detail/helpers.hpp>
 
 #include <CL/sycl/detail/context_impl.hpp>
+#include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/event.hpp>
 
 #include <memory>

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -9,6 +9,7 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
+#include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/event.hpp>
 
@@ -22,8 +23,9 @@ namespace sycl {
 
 event::event() : impl(std::make_shared<detail::event_impl>()) {}
 
-event::event(cl_event clEvent, const context &syclContext)
-    : impl(std::make_shared<detail::event_impl>(clEvent, syclContext)) {}
+event::event(cl_event ClEvent, const context &SyclContext)
+    : impl(std::make_shared<detail::event_impl>(
+          detail::pi::cast<RT::PiEvent>(ClEvent), SyclContext)) {}
 
 bool event::operator==(const event &rhs) const { return rhs.impl == impl; }
 

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -58,7 +58,7 @@ vector_class<event> event::get_wait_list() {
   return Result;
 }
 
-event::event(std::shared_ptr<detail::event_impl> event_impl)
+event::event(shared_ptr_class<detail::event_impl> event_impl)
     : impl(event_impl) {}
 
 template <> cl_uint event::get_info<info::event::reference_count>() const {

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -11,6 +11,7 @@
 #include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/event.hpp>
 
 #include <CL/sycl/stl.hpp>
@@ -63,34 +64,25 @@ vector_class<event> event::get_wait_list() {
 event::event(shared_ptr_class<detail::event_impl> event_impl)
     : impl(event_impl) {}
 
-template <> cl_uint event::get_info<info::event::reference_count>() const {
-  return impl->get_info<info::event::reference_count>();
-}
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+    template <> ret_type event::get_info<info::param_type::param>() const {    \
+      return impl->get_info<info::param_type::param>();                        \
+    }
 
-template <>
-info::event_command_status
-event::get_info<info::event::command_execution_status>() const {
-  return impl->get_info<info::event::command_execution_status>();
-}
+#include <CL/sycl/info/event_traits.def>
 
-template <>
-cl_ulong
-event::get_profiling_info<info::event_profiling::command_submit>() const {
-  impl->wait(impl);
-  return impl->get_profiling_info<info::event_profiling::command_submit>();
-}
-template <>
-cl_ulong
-event::get_profiling_info<info::event_profiling::command_start>() const {
-  impl->wait(impl);
-  return impl->get_profiling_info<info::event_profiling::command_start>();
-}
+#undef PARAM_TRAITS_SPEC
 
-template <>
-cl_ulong event::get_profiling_info<info::event_profiling::command_end>() const {
-  impl->wait(impl);
-  return impl->get_profiling_info<info::event_profiling::command_end>();
-}
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+    template <>                                                                \
+    ret_type event::get_profiling_info<info::param_type::param>() const {      \
+      impl->wait(impl);                                                        \
+      return impl->get_profiling_info<info::param_type::param>();              \
+    }
+
+#include <CL/sycl/info/event_profiling_traits.def>
+
+#undef PARAM_TRAITS_SPEC
 
 } // namespace sycl
 } // namespace cl


### PR DESCRIPTION
This patch is a part of effort to decouple SYCL Runtime library
interface from its actual implementation. The goal is to improve
SYCL ABI/API compatibility between different versions of library.

The following modifications were applied to platform and platform_impl
classes:

1. Removed include of event_impl header from event.hpp and replaced
it with forward declaration.
2. std::shared_ptr was replaced with shared_ptr_class for platform class
3. Documentation was improved for both eventand event_impl
4. Both classes now try to follow LLVM code style
5. event_impl now uses PI interface.

Applying aforementioned changes requires modifying other header files.
While some of those may seem as a regression, affected classes will be
covered by future patches.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>