### PR TITLE
[SYCL] Allow __spirv_ocl_printf vararg function

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -187,7 +187,10 @@ static bool IsSyclMathFunc(unsigned BuiltinID) {
 static bool isKnownGoodDecl(Decl *D) {
   if (FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
     IdentifierInfo *II = FD->getIdentifier();
-    if (II && II->getName().equals("__spirv_ocl_printf"))
+    if (II &&
+        FD->getDeclContext()->isTranslationUnit() &&
+        FD->getLanguageLinkage() == CXXLanguageLinkage &&
+        II->isStr("__spirv_ocl_printf"))
       return true;
   }
   return false;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -184,9 +184,9 @@ static bool IsSyclMathFunc(unsigned BuiltinID) {
   return true;
 }
 
-static bool isKnownGoodDecl(Decl *D) {
-  if (FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
-    IdentifierInfo *II = FD->getIdentifier();
+static bool isKnownGoodDecl(const Decl *D) {
+  if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
+    const IdentifierInfo *II = FD->getIdentifier();
     if (II &&
         FD->getDeclContext()->isTranslationUnit() &&
         FD->getLanguageLinkage() == CXXLanguageLinkage &&

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -187,10 +187,11 @@ static bool IsSyclMathFunc(unsigned BuiltinID) {
 static bool isKnownGoodDecl(const Decl *D) {
   if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
     const IdentifierInfo *II = FD->getIdentifier();
-    if (II &&
-        FD->getDeclContext()->isTranslationUnit() &&
+    const DeclContext *DC = FD->getDeclContext();
+    if (II && II->isStr("__spirv_ocl_printf") &&
+        !FD->isDefined() &&
         FD->getLanguageLinkage() == CXXLanguageLinkage &&
-        II->isStr("__spirv_ocl_printf"))
+        DC->getEnclosingNamespaceContext()->isTranslationUnit())
       return true;
   }
   return false;

--- a/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
@@ -1,15 +1,32 @@
 // RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -x c++ %s
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DGOOD_PRINTF -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_INVALID_DEF -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_INVALID_DECL -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_VALID1 -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_VALID2 -x c++ %s
 
-#ifdef GOOD_PRINTF
-int __spirv_ocl_printf(const char *__format, ...);
-#else
+#if defined(PRINTF_INVALID_DECL)
 extern "C" int __spirv_ocl_printf(const char *__format, ...);
 namespace A {
   int __spirv_ocl_printf(const char *__format, ...);
 }
+#elif defined(PRINTF_INVALID_DEF)
+int __spirv_ocl_printf(const char *__format, ...) {
+  return 42;
+}
+#elif defined(PRINTF_VALID1)
+class A {
+  friend int __spirv_ocl_printf(const char *__format, ...);
+};
+int __spirv_ocl_printf(const char *__format, ...);
+#elif defined(PRINTF_VALID2)
+extern "C" {
+  extern "C++" {
+    int __spirv_ocl_printf(const char *__format, ...);
+  }
+}
+#else
+int __spirv_ocl_printf(const char *__format, ...);
 #endif
-
 
 int __cdecl foo(int, ...); // expected-no-error
 
@@ -31,12 +48,15 @@ int main() {
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
   kernel_single_task<class fake_kernel>([]() { bar(9.0); });
 
-#ifdef GOOD_PRINTF
-  kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
-#else
+#if defined(PRINTF_INVALID_DECL)
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
   kernel_single_task<class fake_kernel>([]() { A::__spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
+#elif defined(PRINTF_INVALID_DEF)
+  //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
+#else
   kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
 #endif
 

--- a/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -x c++ %s
 
+extern int __spirv_ocl_printf(const char *__format, ...);
+
 int __cdecl foo(int, ...); // expected-no-error
 
 float bar(float f, ...) { return ++f; } // expected-no-error
@@ -19,6 +21,8 @@ int main() {
   kernel_single_task<class fake_kernel>([]() { foo(6); });
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
   kernel_single_task<class fake_kernel>([]() { bar(9.0); });
+  // expected-no-error@+1
+  kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
   bar();
   return 0;
 }


### PR DESCRIPTION
Vararg functions are generally not allowed in SYCL. However, printf is
a special case, because it can be mapped to a SPIR-V instruction, and
SPIR-V translator recognizes __spirv_ocl_printf function.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>