### PR TITLE
[SYCL][USM] Initial commit of flattening for kernel submission on queue

### DIFF
--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -130,6 +130,18 @@ public:
     });
   }
 
+  // single_task version with a kernel represented as a lambda.
+  // Takes an event to specify a dependence.
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event single_task(event DepEvent, KernelType KernelFunc) {
+    return submit([&](handler &CGH) {
+      CGH.depends_on(DepEvent);
+      CGH.template single_task<KernelName, KernelType>(KernelFunc);
+    });
+  }
+
+  // single_task version with a kernel represented as a lambda.
+  // Takes a vector of events to specify dependences.
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(std::vector<event> DepEvents, KernelType KernelFunc) {
     return submit([&](handler &CGH) {
@@ -149,6 +161,21 @@ public:
     });
   }
 
+  // parallel_for version with a kernel represented as a lambda + range that
+  // specifies global size only.  Takes an event to specify dependences
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, event DepEvent,
+                     KernelType KernelFunc) {
+    return submit([&](handler &CGH) {
+      CGH.depends_on(DepEvent);
+      CGH.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
+                                                              KernelFunc);
+    });
+  }
+
+  // parallel_for version with a kernel represented as a lambda + range that
+  // specifies global size only.  Takes a vector of events to specify dependences
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, std::vector<event> DepEvents,
@@ -172,6 +199,23 @@ public:
     });
   }
 
+  // parallel_for version with a kernel represented as a lambda + range and
+  // offset that specify global size and global offset correspondingly.
+  // Takes an event to specify dependences.
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
+                     event DepEvent, KernelType KernelFunc) {
+    return submit([&](handler &CGH) {
+      CGH.depends_on(DepEvent);
+      CGH.template parallel_for<KernelName, KernelType, Dims>(
+          NumWorkItems, WorkItemOffset, KernelFunc);
+    });
+  }
+
+  // parallel_for version with a kernel represented as a lambda + range and
+  // offset that specify global size and global offset correspondingly.
+  // Takes a vector of events to specify dependences.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
@@ -194,6 +238,23 @@ public:
     });
   }
 
+  // parallel_for version with a kernel represented as a lambda + nd_range that
+  // specifies global, local sizes and offset.
+  // Takes an event to specify dependences.
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for(nd_range<Dims> ExecutionRange,
+                     event DepEvent, KernelType KernelFunc) {
+    return submit([&](handler &CGH) {
+      CGH.depends_on(DepEvent);
+      CGH.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
+                                                              KernelFunc);
+    });
+  }
+
+  // parallel_for version with a kernel represented as a lambda + nd_range that
+  // specifies global, local sizes and offset.
+  // Takes a vector of events to specify dependences.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(nd_range<Dims> ExecutionRange,

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -122,7 +122,9 @@ public:
     });
   }
 
-  // single_task version with a kernel represented as a lambda.
+  /// single_task version with a kernel represented as a lambda.
+  ///
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(KernelType KernelFunc) {
     return submit([&](handler &CGH) {
@@ -130,8 +132,10 @@ public:
     });
   }
 
-  // single_task version with a kernel represented as a lambda.
-  // Takes an event to specify a dependence.
+  /// single_task version with a kernel represented as a lambda.
+  ///
+  /// @param DepEvent is an event that specifies the kernel dependences 
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(event DepEvent, KernelType KernelFunc) {
     return submit([&](handler &CGH) {
@@ -140,8 +144,10 @@ public:
     });
   }
 
-  // single_task version with a kernel represented as a lambda.
-  // Takes a vector of events to specify dependences.
+  /// single_task version with a kernel represented as a lambda.
+  ///
+  /// @param DepEvents is a vector of events that specify the kernel dependences
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(std::vector<event> DepEvents, KernelType KernelFunc) {
     return submit([&](handler &CGH) {
@@ -150,8 +156,11 @@ public:
     });
   }
 
-  // parallel_for version with a kernel represented as a lambda + range that
-  // specifies global size only.
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// @param NumWorkItems is a range that specifies the work space of the kernel
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, KernelType KernelFunc) {
@@ -161,8 +170,12 @@ public:
     });
   }
 
-  // parallel_for version with a kernel represented as a lambda + range that
-  // specifies global size only.  Takes an event to specify dependences
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.  
+  ///
+  /// @param NumWorkItems is a range that specifies the work space of the kernel
+  /// @param DepEvent is an event that specifies the kernel dependences 
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, event DepEvent,
@@ -174,8 +187,12 @@ public:
     });
   }
 
-  // parallel_for version with a kernel represented as a lambda + range that
-  // specifies global size only.  Takes a vector of events to specify dependences
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// @param NumWorkItems is a range that specifies the work space of the kernel
+  /// @param DepEvents is a vector of events that specifies the kernel dependences 
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, std::vector<event> DepEvents,
@@ -187,8 +204,12 @@ public:
     });
   }
 
-  // parallel_for version with a kernel represented as a lambda + range and
-  // offset that specify global size and global offset correspondingly.
+  /// parallel_for version with a kernel represented as a lambda + range and
+  /// offset that specify global size and global offset correspondingly.
+  ///
+  /// @param NumWorkItems is a range that specifies the work space of the kernel
+  /// @param WorkItemOffset specifies the offset for each work item id
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
@@ -199,9 +220,13 @@ public:
     });
   }
 
-  // parallel_for version with a kernel represented as a lambda + range and
-  // offset that specify global size and global offset correspondingly.
-  // Takes an event to specify dependences.
+  /// parallel_for version with a kernel represented as a lambda + range and
+  /// offset that specify global size and global offset correspondingly.
+  ///
+  /// @param NumWorkItems is a range that specifies the work space of the kernel
+  /// @param WorkItemOffset specifies the offset for each work item id
+  /// @param DepEvent is an event that specifies the kernel dependences 
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
@@ -213,9 +238,13 @@ public:
     });
   }
 
-  // parallel_for version with a kernel represented as a lambda + range and
-  // offset that specify global size and global offset correspondingly.
-  // Takes a vector of events to specify dependences.
+  /// parallel_for version with a kernel represented as a lambda + range and
+  /// offset that specify global size and global offset correspondingly.
+  ///
+  /// @param NumWorkItems is a range that specifies the work space of the kernel
+  /// @param WorkItemOffset specifies the offset for each work item id
+  /// @param DepEvents is a vector of events that specifies the kernel dependences 
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
@@ -227,8 +256,11 @@ public:
     });
   }
 
-  // parallel_for version with a kernel represented as a lambda + nd_range that
-  // specifies global, local sizes and offset.
+  /// parallel_for version with a kernel represented as a lambda + nd_range that
+  /// specifies global, local sizes and offset.
+  ///
+  /// @param ExecutionRange is a range that specifies the work space of the kernel
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(nd_range<Dims> ExecutionRange, KernelType KernelFunc) {
@@ -238,9 +270,12 @@ public:
     });
   }
 
-  // parallel_for version with a kernel represented as a lambda + nd_range that
-  // specifies global, local sizes and offset.
-  // Takes an event to specify dependences.
+  /// parallel_for version with a kernel represented as a lambda + nd_range that
+  /// specifies global, local sizes and offset.
+  ///
+  /// @param ExecutionRange is a range that specifies the work space of the kernel
+  /// @param DepEvent is an event that specifies the kernel dependences 
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(nd_range<Dims> ExecutionRange,
@@ -252,9 +287,12 @@ public:
     });
   }
 
-  // parallel_for version with a kernel represented as a lambda + nd_range that
-  // specifies global, local sizes and offset.
-  // Takes a vector of events to specify dependences.
+  /// parallel_for version with a kernel represented as a lambda + nd_range that
+  /// specifies global, local sizes and offset.
+  ///
+  /// @param ExecutionRange is a range that specifies the work space of the kernel
+  /// @param DepEvents is a vector of events that specifies the kernel dependences 
+  /// @param KernelFunc is the Kernel functor or lambda
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(nd_range<Dims> ExecutionRange,

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -125,14 +125,14 @@ public:
   // single_task version with a kernel represented as a lambda.
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(KernelType KernelFunc) {
-    return submit([&](handler &cgh) {
+    return submit([&](handler &CGH) {
       cgh.template single_task<KernelName, KernelType>(KernelFunc);
     });
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  event single_task(std::vector<event> Events, KernelType KernelFunc) {
-    return submit([&](handler &cgh) {
+  event single_task(std::vector<event> &DepEvents, KernelType KernelFunc) {
+    return submit([&](handler &CGH) {
       cgh.depends_on(Events);
       cgh.template single_task<KernelName, KernelType>(KernelFunc);
     });
@@ -143,7 +143,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, KernelType KernelFunc) {
-    return submit([&](handler &cgh) {
+    return submit([&](handler &CGH) {
       cgh.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
                                                               KernelFunc);
     });
@@ -151,9 +151,9 @@ public:
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
-  event parallel_for(range<Dims> NumWorkItems, std::vector<event> Events,
-                    KernelType KernelFunc) {
-    return submit([&](handler &cgh) {
+  event parallel_for(range<Dims> NumWorkItems, std::vector<event> &DepEvents,
+                     KernelType KernelFunc) {
+    return submit([&](handler &CGH) {
       cgh.depends_on(Events);
       cgh.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
                                                               KernelFunc);
@@ -166,7 +166,7 @@ public:
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
                     KernelType KernelFunc) {
-    return submit([&](handler &cgh) {
+    return submit([&](handler &CGH) {
       cgh.template parallel_for<KernelName, KernelType, Dims>(
           NumWorkItems, WorkItemOffset, KernelFunc);
     });
@@ -175,8 +175,8 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
-                    std::vector<event> Events, KernelType KernelFunc) {
-    return submit([&](handler &cgh) {
+                     std::vector<event> &DepEvents, KernelType KernelFunc) {
+    return submit([&](handler &CGH) {
       cgh.depends_on(Events);
       cgh.template parallel_for<KernelName, KernelType, Dims>(
           NumWorkItems, WorkItemOffset, KernelFunc);
@@ -188,7 +188,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(nd_range<Dims> ExecutionRange, KernelType KernelFunc) {
-    return submit([&](handler &cgh) {
+    return submit([&](handler &CGH) {
       cgh.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
                                                               KernelFunc);
     });
@@ -196,9 +196,9 @@ public:
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
-  event parallel_for(nd_range<Dims> ExecutionRange, std::vector<event> Events,
-                    KernelType KernelFunc) {
-    return submit([&](handler &cgh) {
+  event parallel_for(nd_range<Dims> ExecutionRange,
+                     std::vector<event> &DepEvents, KernelType KernelFunc) {
+    return submit([&](handler &CGH) {
       cgh.depends_on(Events);
       cgh.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
                                                               KernelFunc);

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -117,8 +117,8 @@ public:
   }
 
   event prefetch(const void* Ptr, size_t Count) {
-    return submit([=](handler &cgh) {
-        cgh.prefetch(Ptr, Count);
+    return submit([=](handler &CGH) {
+        CGH.prefetch(Ptr, Count);
     });
   }
 
@@ -126,15 +126,15 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(KernelType KernelFunc) {
     return submit([&](handler &CGH) {
-      cgh.template single_task<KernelName, KernelType>(KernelFunc);
+      CGH.template single_task<KernelName, KernelType>(KernelFunc);
     });
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  event single_task(std::vector<event> &DepEvents, KernelType KernelFunc) {
+  event single_task(std::vector<event> DepEvents, KernelType KernelFunc) {
     return submit([&](handler &CGH) {
-      cgh.depends_on(Events);
-      cgh.template single_task<KernelName, KernelType>(KernelFunc);
+      CGH.depends_on(DepEvents);
+      CGH.template single_task<KernelName, KernelType>(KernelFunc);
     });
   }
 
@@ -144,18 +144,18 @@ public:
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, KernelType KernelFunc) {
     return submit([&](handler &CGH) {
-      cgh.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
+      CGH.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
                                                               KernelFunc);
     });
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
-  event parallel_for(range<Dims> NumWorkItems, std::vector<event> &DepEvents,
+  event parallel_for(range<Dims> NumWorkItems, std::vector<event> DepEvents,
                      KernelType KernelFunc) {
     return submit([&](handler &CGH) {
-      cgh.depends_on(Events);
-      cgh.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
+      CGH.depends_on(DepEvents);
+      CGH.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
                                                               KernelFunc);
     });
   }
@@ -167,7 +167,7 @@ public:
   event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
                     KernelType KernelFunc) {
     return submit([&](handler &CGH) {
-      cgh.template parallel_for<KernelName, KernelType, Dims>(
+      CGH.template parallel_for<KernelName, KernelType, Dims>(
           NumWorkItems, WorkItemOffset, KernelFunc);
     });
   }
@@ -175,10 +175,10 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
-                     std::vector<event> &DepEvents, KernelType KernelFunc) {
+                     std::vector<event> DepEvents, KernelType KernelFunc) {
     return submit([&](handler &CGH) {
-      cgh.depends_on(Events);
-      cgh.template parallel_for<KernelName, KernelType, Dims>(
+      CGH.depends_on(DepEvents);
+      CGH.template parallel_for<KernelName, KernelType, Dims>(
           NumWorkItems, WorkItemOffset, KernelFunc);
     });
   }
@@ -189,7 +189,7 @@ public:
             int Dims>
   event parallel_for(nd_range<Dims> ExecutionRange, KernelType KernelFunc) {
     return submit([&](handler &CGH) {
-      cgh.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
+      CGH.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
                                                               KernelFunc);
     });
   }
@@ -197,10 +197,10 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(nd_range<Dims> ExecutionRange,
-                     std::vector<event> &DepEvents, KernelType KernelFunc) {
+                     std::vector<event> DepEvents, KernelType KernelFunc) {
     return submit([&](handler &CGH) {
-      cgh.depends_on(Events);
-      cgh.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
+      CGH.depends_on(DepEvents);
+      CGH.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
                                                               KernelFunc);
     });
   }

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -122,6 +122,89 @@ public:
     });
   }
 
+  // single_task version with a kernel represented as a lambda.
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event single_task(KernelType KernelFunc) {
+    return submit([&](handler &cgh) {
+      cgh.template single_task<KernelName, KernelType>(KernelFunc);
+    });
+  }
+
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event single_task(std::vector<event> Events, KernelType KernelFunc) {
+    return submit([&](handler &cgh) {
+      cgh.depends_on(Events);
+      cgh.template single_task<KernelName, KernelType>(KernelFunc);
+    });
+  }
+
+  // parallel_for version with a kernel represented as a lambda + range that
+  // specifies global size only.
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, KernelType KernelFunc) {
+    return submit([&](handler &cgh) {
+      cgh.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
+                                                              KernelFunc);
+    });
+  }
+
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, std::vector<event> Events,
+                    KernelType KernelFunc) {
+    return submit([&](handler &cgh) {
+      cgh.depends_on(Events);
+      cgh.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
+                                                              KernelFunc);
+    });
+  }
+
+  // parallel_for version with a kernel represented as a lambda + range and
+  // offset that specify global size and global offset correspondingly.
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
+                    KernelType KernelFunc) {
+    return submit([&](handler &cgh) {
+      cgh.template parallel_for<KernelName, KernelType, Dims>(
+          NumWorkItems, WorkItemOffset, KernelFunc);
+    });
+  }
+
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
+                    std::vector<event> Events, KernelType KernelFunc) {
+    return submit([&](handler &cgh) {
+      cgh.depends_on(Events);
+      cgh.template parallel_for<KernelName, KernelType, Dims>(
+          NumWorkItems, WorkItemOffset, KernelFunc);
+    });
+  }
+
+  // parallel_for version with a kernel represented as a lambda + nd_range that
+  // specifies global, local sizes and offset.
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for(nd_range<Dims> ExecutionRange, KernelType KernelFunc) {
+    return submit([&](handler &cgh) {
+      cgh.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
+                                                              KernelFunc);
+    });
+  }
+
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for(nd_range<Dims> ExecutionRange, std::vector<event> Events,
+                    KernelType KernelFunc) {
+    return submit([&](handler &cgh) {
+      cgh.depends_on(Events);
+      cgh.template parallel_for<KernelName, KernelType, Dims>(ExecutionRange,
+                                                              KernelFunc);
+    });
+  }
+
 private:
   std::shared_ptr<detail::queue_impl> impl;
   template <class Obj>

--- a/sycl/test/usm/pfor_flatten.cpp
+++ b/sycl/test/usm/pfor_flatten.cpp
@@ -36,7 +36,7 @@ int main() {
   });
 
 
-  auto e2 = q.parallel_for(R, {e1}, [=](id<1> ID) {
+  auto e2 = q.parallel_for(R, e1, [=](id<1> ID) {
     int i = ID[0];
     array[i] += 2;
   });

--- a/sycl/test/usm/pfor_flatten.cpp
+++ b/sycl/test/usm/pfor_flatten.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 
-//==----------------- depends_on.cpp - depends_on test ---------------------==//
+//==--------------- pfor_flatten.cpp - Kernel Launch Flattening test -------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/test/usm/pfor_flatten.cpp
+++ b/sycl/test/usm/pfor_flatten.cpp
@@ -1,0 +1,66 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t1.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %CPU_RUN_PLACEHOLDER %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+
+//==----------------- depends_on.cpp - depends_on test ---------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+class foo;
+int main() {
+  int *array = nullptr;
+  const int N = 42;
+  const int MAGIC_NUM = 42;
+
+  queue q;
+  auto ctxt = q.get_context();
+
+  array = (int *)malloc_host(N * sizeof(int), q);
+  if (array == nullptr) {
+    return -1;
+  }
+
+  range<1> R{N};
+  auto e1 = q.parallel_for(R, [=](id<1> ID) {
+    int i = ID[0];
+    array[i] = MAGIC_NUM-4;
+  });
+
+
+  auto e2 = q.parallel_for(R, {e1}, [=](id<1> ID) {
+    int i = ID[0];
+    array[i] += 2;
+  });
+
+  auto e3 =
+      q.parallel_for(nd_range<1>{R, range<1>{1}}, {e1, e2}, [=](nd_item<1> ID) {
+        int i = ID.get_global_id(0);
+        array[i]++;
+      });
+
+  q.single_task({e3}, [=]() {
+    for (int i = 0; i < N; i++) {
+      array[i]++;
+    }
+  });
+
+  q.wait();
+  
+  for (int i = 0; i < N; i++) {
+    if (array[i] != MAGIC_NUM) {
+      return -1;
+    }
+  }
+  free(array, ctxt);
+
+  return 0;
+}


### PR DESCRIPTION
Add utility methods to flatten kernel submission to 1 lambda when using USM.

Events for depends_on are passed as an extra function arg.

Signed-off-by: James Brodman <james.brodman@intel.com>