### PR TITLE
[SYCL] Fix kernel argument cast kind

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -873,7 +873,7 @@ static CompoundStmt *CreateOpenCLKernelBody(Sema &S,
                 ParamType->getPointeeType().getAddressSpace())
           DRE = ImplicitCastExpr::Create(S.Context, FieldType,
                                          CK_AddressSpaceConversion, DRE,
-                                         nullptr, VK_LValue);
+                                         nullptr, VK_RValue);
         InitializationKind InitKind =
             InitializationKind::CreateCopy(SourceLocation(), SourceLocation());
         InitializationSequence InitSeq(S, Entity, InitKind, DRE);

--- a/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
@@ -83,11 +83,9 @@ int main() {
 
 // Check that lambda fields of pointer types are initialized
 // CHECK: InitListExpr
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' lvalue <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
 // CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_' '__global int *'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' lvalue <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
 // CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_' '__global int *'
 
 // Check kernel parameters


### PR DESCRIPTION
We insert a cast in SemaSYCL only if address spaces of pointee types
are different. However, ImplicitCastExpr checks for pointee types only
if the cast is RValue.

This patch fixes a regression when this check is enabled: https://github.com/intel/llvm/commit/a29aa47106205ec95c12e0ebac4260c5de878a6a#diff-dac09655ff6a54658c320a28a6ea297cR1817

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>