### PR TITLE
[SYCL][FPGA] Implement max_global_work_dim kernel attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1135,6 +1135,15 @@ def SYCLIntelMaxWorkGroupSize : InheritableAttr {
   let PragmaAttributeSupport = 0;
 }
 
+def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
+  let Spellings = [CXX11<"intelfpga","max_global_work_dim">];
+  let Args = [UnsignedArgument<"Number">];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Documentation = [SYCLIntelMaxGlobalWorkDimAttrDocs];
+  let PragmaAttributeSupport = 0;
+}
+
 def C11NoReturn : InheritableAttr {
   let Spellings = [Keyword<"_Noreturn">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1997,10 +1997,15 @@ def SYCLIntelMaxGlobalWorkDimAttrDocs : Documentation {
   let Category = DocCatFunction;
   let Heading = "max_global_work_dim (IntelFPGA)";
   let Content = [{
-Applies to a device function/lambda function. Indicates the largest valid global
-work dimension that will be accepted when running the kernel on a device. Valid
-values are non-negative integers. A kernel with max_global_work_dim(0) must be
-invoked with a 'single_task'.
+Applies to a device function/lambda function or function call operator (of a
+function object). Indicates the largest valid global work dimension that will be
+accepted when running the kernel on a device. Valid values are integers in a
+range of [0, 3]. A kernel with max_global_work_dim(0) must be invoked with a
+'single_task' and if ``intelfpga::max_work_group_size`` or
+``cl::reqd_work_group_size`` are applied to the kernel as well - they shall
+have arguments of (1, 1, 1).
+If ``intelfpga::max_global_work_dim`` is applied to a function called from a
+device kernel, the attribute is ignored and it is not propagated to a kernel.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1993,6 +1993,17 @@ device kernel, the attribute is ignored and it is not propagated to a kernel.
   }];
 }
 
+def SYCLIntelMaxGlobalWorkDimAttrDocs : Documentation {
+  let Category = DocCatFunction;
+  let Heading = "max_global_work_dim (IntelFPGA)";
+  let Content = [{
+Applies to a device function/lambda function. Indicates the largest valid global
+work dimension that will be accepted when running the kernel on a device. Valid
+values are non-negative integers. A kernel with max_global_work_dim(0) must be
+invoked with a 'single_task'.
+  }];
+}
+
 def SYCLFPGAPipeDocs : Documentation {
   let Category = DocCatStmt;
   let Heading = "pipe (read_only, write_only)";

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -157,7 +157,8 @@ public:
         (ParsedAttr == AT_ReqdWorkGroupSize && isCXX11Attribute()) ||
         (ParsedAttr == AT_IntelReqdSubGroupSize && isCXX11Attribute()) ||
         ParsedAttr == AT_SYCLIntelNumSimdWorkItems ||
-        ParsedAttr == AT_SYCLIntelMaxWorkGroupSize)
+        ParsedAttr == AT_SYCLIntelMaxWorkGroupSize ||
+        ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim)
       return true;
 
     return false;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10165,7 +10165,10 @@ def err_conflicting_sycl_kernel_attributes : Error<
   "conflicting attributes applied to a SYCL kernel">;
 def err_conflicting_sycl_function_attributes : Error<
    "%0 attribute conflicts with '%1' attribute">;
-
+def err_sycl_x_y_z_arguments_must_be_one : Error<
+  "%0 X-, Y- and Z- sizes must be 1 when %1 attribute is used with value 0">;
+def err_intel_attribute_argument_is_not_in_range: Error<
+   "%0 attribute must be in range from 0 to 3">;
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "%select{static function or function in an anonymous namespace"

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10168,7 +10168,7 @@ def err_conflicting_sycl_function_attributes : Error<
 def err_sycl_x_y_z_arguments_must_be_one : Error<
   "%0 X-, Y- and Z- sizes must be 1 when %1 attribute is used with value 0">;
 def err_intel_attribute_argument_is_not_in_range: Error<
-   "%0 attribute must be in range from 0 to 3">;
+   "The value of %0 attribute must be in range from 0 to 3">;
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "%select{static function or function in an anonymous namespace"

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -653,6 +653,14 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
     Fn->setMetadata("max_work_group_size",
                     llvm::MDNode::get(Context, AttrMDArgs));
   }
+
+  if (const SYCLIntelMaxGlobalWorkDimAttr *A =
+      FD->getAttr<SYCLIntelMaxGlobalWorkDimAttr>()) {
+    llvm::Metadata *AttrMDArgs[] = {
+        llvm::ConstantAsMetadata::get(Builder.getInt32(A->getNumber()))};
+    Fn->setMetadata("max_global_work_dim",
+                    llvm::MDNode::get(Context, AttrMDArgs));
+  }
 }
 
 /// Determine whether the function F ends with a return stmt.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2857,32 +2857,59 @@ static void handleWeakImportAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 }
 
 // Checks correctness of mutual usage of different work_group_size attributes:
-// reqd_work_group_size, max_work_group_size. Values of reqd_work_group_size
-// arguments shall be equal or less than values coming from max_work_group_size.
+// reqd_work_group_size, max_work_group_size and max_global_work_dim.
+// Values of reqd_work_group_size arguments shall be equal or less than values
+// coming from max_work_group_size.
+// In case of 'max_global_work_dim' attribute equals to 0 we shall ensure
+// that if max_work_group_size and reqd_work_group_size attributes exist,
+// then they are equal (1, 1, 1).
 static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &Attr,
                                      uint32_t WGSize[3]) {
-  if (const SYCLIntelMaxWorkGroupSizeAttr *A =
-      D->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
+  bool Result = true;
+  auto checkZeroDim = [&S, &Attr](auto A, auto X, auto Y, auto Z,
+                                  bool ReverseAttrs = false) -> bool {
+    if (X != 1 || Y != 1 || Z != 1) {
+      if (ReverseAttrs)
+        S.Diag(Attr.getLoc(), diag::err_sycl_x_y_z_arguments_must_be_one)
+            << Attr << A;
+      else
+        S.Diag(A->getLocation(), diag::err_sycl_x_y_z_arguments_must_be_one)
+            << A << Attr;
+      return false;
+    }
+    return true;
+  };
+
+  if (Attr.getKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim) {
+    if (const auto *A = D->getAttr<SYCLIntelMaxWorkGroupSizeAttr>())
+      Result &= checkZeroDim(A, A->getXDim(), A->getYDim(), A->getZDim());
+    if (const auto *A = D->getAttr<ReqdWorkGroupSizeAttr>())
+      Result &= checkZeroDim(A, A->getXDim(), A->getYDim(), A->getZDim());
+    return Result;
+  }
+
+  if (const auto *A = D->getAttr<SYCLIntelMaxGlobalWorkDimAttr>())
+    if (A->getNumber() == 0)
+      Result &= checkZeroDim(A, WGSize[0], WGSize[1], WGSize[2],
+                             /*ReverseAttrs=*/ true);
+
+  if (const auto *A = D->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
     if (!(WGSize[0] <= A->getXDim() && WGSize[1] <= A->getYDim() &&
           WGSize[2] <= A->getZDim())) {
       S.Diag(Attr.getLoc(), diag::err_conflicting_sycl_function_attributes)
           << Attr << A->getSpelling();
-      D->setInvalidDecl();
-      return false;
+      Result &= false;
     }
   }
-
-  if (const ReqdWorkGroupSizeAttr *A = D->getAttr<ReqdWorkGroupSizeAttr>()) {
+  if (const auto *A = D->getAttr<ReqdWorkGroupSizeAttr>()) {
     if (!(WGSize[0] >= A->getXDim() && WGSize[1] >= A->getYDim() &&
           WGSize[2] >= A->getZDim())) {
       S.Diag(Attr.getLoc(), diag::err_conflicting_sycl_function_attributes)
           << Attr << A->getSpelling();
-      D->setInvalidDecl();
-      return false;
+      Result &= false;
     }
   }
-
-  return true;
+  return Result;
 }
 
 // Handles reqd_work_group_size, work_group_size_hint and max_work_group_size
@@ -2961,6 +2988,39 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
 
   D->addAttr(::new (S.Context) SYCLIntelNumSimdWorkItemsAttr(
         S.Context, Attr, NumSimdWorkItems));
+}
+
+// Handles max_global_work_dim.
+static void handleMaxGlobalWorkDimAttr(Sema &S, Decl *D,
+                                       const ParsedAttr &Attr) {
+  if (D->isInvalidDecl())
+    return;
+
+  uint32_t MaxGlobalWorkDim;
+  const Expr *E = Attr.getArgAsExpr(0);
+  if (!checkUInt32Argument(S, Attr, E, MaxGlobalWorkDim, 0,
+                           /*StrictlyUnsigned=*/true))
+    return;
+
+  if (MaxGlobalWorkDim > 3) {
+    S.Diag(Attr.getLoc(), diag::err_intel_attribute_argument_is_not_in_range)
+      << Attr;
+    return;
+  }
+
+  if (MaxGlobalWorkDim == 0) {
+    uint32_t WGSize[3] = {1, 1, 1};
+    if (!checkWorkGroupSizeValues(S, D, Attr, WGSize)) {
+      D->setInvalidDecl();
+      return;
+    }
+  }
+
+  if (D->getAttr<SYCLIntelMaxGlobalWorkDimAttr>())
+    S.Diag(Attr.getLoc(), diag::warn_duplicate_attribute) << Attr;
+
+  D->addAttr(::new (S.Context) SYCLIntelMaxGlobalWorkDimAttr(
+        S.Context, Attr, MaxGlobalWorkDim));
 }
 
 static void handleVecTypeHint(Sema &S, Decl *D, const ParsedAttr &AL) {
@@ -7485,6 +7545,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case ParsedAttr::AT_SYCLIntelNumSimdWorkItems:
     handleNumSimdWorkItemsAttr(S, D, AL);
+    break;
+  case ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim:
+    handleMaxGlobalWorkDimAttr(S, D, AL);
     break;
   case ParsedAttr::AT_VecTypeHint:
     handleVecTypeHint(S, D, AL);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2866,15 +2866,15 @@ static void handleWeakImportAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &Attr,
                                      uint32_t WGSize[3]) {
   bool Result = true;
-  auto checkZeroDim = [&S, &Attr](auto A, auto X, auto Y, auto Z,
+  auto checkZeroDim = [&S, &Attr](auto &A, size_t X, size_t Y, size_t Z,
                                   bool ReverseAttrs = false) -> bool {
     if (X != 1 || Y != 1 || Z != 1) {
+      auto Diag =
+          S.Diag(Attr.getLoc(), diag::err_sycl_x_y_z_arguments_must_be_one);
       if (ReverseAttrs)
-        S.Diag(Attr.getLoc(), diag::err_sycl_x_y_z_arguments_must_be_one)
-            << Attr << A;
+        Diag << Attr << A;
       else
-        S.Diag(A->getLocation(), diag::err_sycl_x_y_z_arguments_must_be_one)
-            << A << Attr;
+        Diag << A << Attr;
       return false;
     }
     return true;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2860,9 +2860,9 @@ static void handleWeakImportAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 // reqd_work_group_size, max_work_group_size and max_global_work_dim.
 // Values of reqd_work_group_size arguments shall be equal or less than values
 // coming from max_work_group_size.
-// In case of 'max_global_work_dim' attribute equals to 0 we shall ensure
-// that if max_work_group_size and reqd_work_group_size attributes exist,
-// then they are equal (1, 1, 1).
+// In case the value of 'max_global_work_dim' attribute equals to 0 we shall
+// ensure that if max_work_group_size and reqd_work_group_size attributes exist,
+// they hold equal values (1, 1, 1).
 static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &Attr,
                                      uint32_t WGSize[3]) {
   bool Result = true;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -473,6 +473,14 @@ public:
           FD->dropAttr<SYCLIntelMaxWorkGroupSizeAttr>();
         }
       }
+      if (auto *A = FD->getAttr<SYCLIntelMaxGlobalWorkDimAttr>()) {
+        if (ParentFD == SYCLKernel) {
+          Attrs.insert(A);
+        } else {
+          SemaRef.Diag(A->getLocation(), diag::warn_attribute_ignored) << A;
+          FD->dropAttr<SYCLIntelMaxGlobalWorkDimAttr>();
+        }
+      }
 
       // TODO: vec_len_hint should be handled here
 
@@ -1373,6 +1381,7 @@ void Sema::MarkDevice(void) {
         }
         case attr::Kind::SYCLIntelKernelArgsRestrict:
         case attr::Kind::SYCLIntelNumSimdWorkItems:
+        case attr::Kind::SYCLIntelMaxGlobalWorkDim:
         case attr::Kind::SYCLIntelMaxWorkGroupSize: {
           SYCLKernel->addAttr(A);
           break;

--- a/clang/test/CodeGenSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/CodeGenSYCL/intel-max-global-work-dim.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+
+class Foo {
+public:
+  [[intelfpga::max_global_work_dim(1)]] void operator()() {}
+};
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+void bar() {
+  Foo boo;
+  kernel<class kernel_name1>(boo);
+
+  kernel<class kernel_name2>(
+  []() [[intelfpga::max_global_work_dim(2)]] {});
+}
+
+// CHECK: define spir_kernel void @{{.*}}kernel_name1() {{.*}} !max_global_work_dim ![[NUM1:[0-9]+]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name2() {{.*}} !max_global_work_dim ![[NUM8:[0-9]+]]
+// CHECK: ![[NUM1]] = !{i32 1}
+// CHECK: ![[NUM8]] = !{i32 2}

--- a/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
@@ -99,6 +99,9 @@ int main() {
   kernel<class test_kernel8>(
       TRIFuncObjBad());
 
+  kernel<class test_kernel9>(
+      []() [[intelfpga::max_global_work_dim(4)]] {}); // expected-error{{The value of 'max_global_work_dim' attribute must be in range from 0 to 3}}
+
 #endif // TRIGGER_ERROR
 }
 #endif // __SYCL_DEVICE_ONLY__

--- a/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
@@ -1,0 +1,104 @@
+// RUN: %clang %s -fsyntax-only -fsycl-device-only -DTRIGGER_ERROR -Xclang -verify
+// RUN: %clang %s -fsyntax-only -Xclang -ast-dump -fsycl-device-only | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify %s
+
+#ifndef __SYCL_DEVICE_ONLY__
+struct FuncObj {
+  [[intelfpga::max_global_work_dim(1)]] // expected-no-diagnostics
+  void operator()() {}
+};
+
+template <typename name, typename Func>
+void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+void foo() {
+  kernel<class test_kernel1>(
+      FuncObj());
+}
+
+#else // __SYCL_DEVICE_ONLY__
+
+[[intelfpga::max_global_work_dim(2)]] // expected-warning{{'max_global_work_dim' attribute ignored}}
+void func_ignore() {}
+
+struct FuncObj {
+  [[intelfpga::max_global_work_dim(1)]]
+  void operator()() {}
+};
+
+struct TRIFuncObjGood1 {
+  [[intelfpga::max_global_work_dim(0)]]
+  [[intelfpga::max_work_group_size(1, 1, 1)]]
+  [[cl::reqd_work_group_size(1, 1, 1)]]
+  void operator()() {}
+};
+
+struct TRIFuncObjGood2 {
+  [[intelfpga::max_global_work_dim(3)]]
+  [[intelfpga::max_work_group_size(8, 1, 1)]]
+  [[cl::reqd_work_group_size(4, 1, 1)]]
+  void operator()() {}
+};
+
+#ifdef TRIGGER_ERROR
+struct TRIFuncObjBad {
+  [[intelfpga::max_global_work_dim(0)]]
+  [[intelfpga::max_work_group_size(8, 8, 8)]] // expected-error{{'max_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
+  [[cl::reqd_work_group_size(4, 4, 4)]] // expected-error{{'reqd_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
+  void operator()() {}
+};
+#endif // TRIGGER_ERROR
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  // CHECK-LABEL: FunctionDecl {{.*}} _ZTSZ4mainE12test_kernel1
+  // CHECK:       SYCLIntelMaxGlobalWorkDimAttr {{.*}} 1
+  kernel<class test_kernel1>(
+      FuncObj());
+
+  // CHECK-LABEL: FunctionDecl {{.*}} _ZTSZ4mainE12test_kernel2
+  // CHECK:       SYCLIntelMaxGlobalWorkDimAttr {{.*}} 2
+  kernel<class test_kernel2>(
+      []() [[intelfpga::max_global_work_dim(2)]] {});
+
+  // CHECK-LABEL: FunctionDecl {{.*}} _ZTSZ4mainE12test_kernel3
+  // CHECK-NOT:   SYCLIntelMaxGlobalWorkDimAttr {{.*}}
+  kernel<class test_kernel3>(
+      []() {func_ignore();});
+
+  kernel<class test_kernel4>(
+      TRIFuncObjGood1());
+  // CHECK-LABEL: FunctionDecl {{.*}} _ZTSZ4mainE12test_kernel4
+  // CHECK:       ReqdWorkGroupSizeAttr {{.*}} 1 1 1
+  // CHECK:       SYCLIntelMaxWorkGroupSizeAttr {{.*}} 1 1 1
+  // CHECK:       SYCLIntelMaxGlobalWorkDimAttr {{.*}} 0
+
+  kernel<class test_kernel5>(
+      TRIFuncObjGood2());
+  // CHECK-LABEL: FunctionDecl {{.*}} _ZTSZ4mainE12test_kernel5
+  // CHECK:       ReqdWorkGroupSizeAttr {{.*}} 4 1 1
+  // CHECK:       SYCLIntelMaxWorkGroupSizeAttr {{.*}} 8 1 1
+  // CHECK:       SYCLIntelMaxGlobalWorkDimAttr {{.*}} 3
+
+#ifdef TRIGGER_ERROR
+  [[intelfpga::max_global_work_dim(1)]] int Var = 0; // expected-error{{'max_global_work_dim' attribute only applies to functions}}
+
+  kernel<class test_kernel6>(
+      []() [[intelfpga::max_global_work_dim(-8)]] {}); // expected-error{{'max_global_work_dim' attribute requires a non-negative integral compile time constant expression}}
+
+  kernel<class test_kernel7>(
+      []() [[intelfpga::max_global_work_dim(3),
+             intelfpga::max_global_work_dim(2)]] {}); // expected-warning{{attribute 'max_global_work_dim' is already applied with different parameters}}
+
+  kernel<class test_kernel8>(
+      TRIFuncObjBad());
+
+#endif // TRIGGER_ERROR
+}
+#endif // __SYCL_DEVICE_ONLY__


### PR DESCRIPTION
Applies to a device function/lambda function. Indicates the largest valid global
work dimension that will be accepted when running the kernel on a device. Valid
values are non-negative integers. A kernel with max_global_work_dim(0) must be
invoked with a 'single_task'.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>