### PR TITLE
[SYCL] Make vec load store member functions templated

### DIFF
--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -1560,7 +1560,7 @@ public:
   // Load to vec_t and then assign to swizzle.
   template <access::address_space Space>
   void load(size_t offset, multi_ptr<DataT, Space> ptr) {
-    vec_t Tmp;                                                                 \
+    vec_t Tmp;
     Tmp.template load(offset, ptr);
     *this = Tmp;
   }


### PR DESCRIPTION
The SYCL specification mentions load and store member functions as
```cpp
template <access::address_space addressSpace>
void load(size_t offset, multi_ptr<const dataT, addressSpace> ptr);
template <access::address_space addressSpace>
void store(size_t offset, multi_ptr<dataT, addressSpace> ptr) const;
```
This patch aligns our implementation with the definition that is provided by the spec.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>