### PR TITLE
[SYCL] Don't emit extra bitcast for @llvm.ptr.annotation

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2196,15 +2196,23 @@ Address CodeGenFunction::EmitFieldAnnotations(const FieldDecl *D,
   assert(D->hasAttr<AnnotateAttr>() && "no annotate attribute");
   llvm::Value *V = Addr.getPointer();
   llvm::Type *VTy = V->getType();
+
+  // llvm.ptr.annotation intrinsic accepts a pointer to integer of any width -
+  // don't perform bitcasts if value is integer
+  if (VTy->getPointerElementType()->isIntegerTy()) {
+    llvm::Function *F = CGM.getIntrinsic(llvm::Intrinsic::ptr_annotation, VTy);
+
+    for (const auto *I : D->specific_attrs<AnnotateAttr>())
+      V = EmitAnnotationCall(F, V, I->getAnnotation(), D->getLocation());
+
+    return Address(V, Addr.getAlignment());
+  }
+
   llvm::Function *F = CGM.getIntrinsic(llvm::Intrinsic::ptr_annotation,
                                     CGM.Int8PtrTy);
 
   for (const auto *I : D->specific_attrs<AnnotateAttr>()) {
-    // FIXME Always emit the cast inst so we can differentiate between
-    // annotation on the first field of a struct and annotation on the struct
-    // itself.
-    if (VTy != CGM.Int8PtrTy)
-      V = Builder.CreateBitCast(V, CGM.Int8PtrTy);
+    V = Builder.CreateBitCast(V, CGM.Int8PtrTy);
     V = EmitAnnotationCall(F, V, I->getAnnotation(), D->getLocation());
     V = Builder.CreateBitCast(V, VTy);
   }

--- a/clang/test/CodeGen/annotations-field.c
+++ b/clang/test/CodeGen/annotations-field.c
@@ -3,9 +3,15 @@
 
 // CHECK: private unnamed_addr constant [8 x i8] c"v_ann_{{.}}\00", section "llvm.metadata"
 // CHECK: private unnamed_addr constant [8 x i8] c"v_ann_{{.}}\00", section "llvm.metadata"
+// CHECK: private unnamed_addr constant [8 x i8] c"w_ann_{{.}}\00", section "llvm.metadata"
+// CHECK: private unnamed_addr constant [8 x i8] c"w_ann_{{.}}\00", section "llvm.metadata"
+// CHECK: private unnamed_addr constant [8 x i8] c"f_ann_{{.}}\00", section "llvm.metadata"
+// CHECK: private unnamed_addr constant [8 x i8] c"f_ann_{{.}}\00", section "llvm.metadata"
 
 struct foo {
     int v __attribute__((annotate("v_ann_0"))) __attribute__((annotate("v_ann_1")));
+    char w __attribute__((annotate("w_ann_0"))) __attribute__((annotate("w_ann_1")));
+    float f __attribute__((annotate("f_ann_0"))) __attribute__((annotate("f_ann_1")));
 };
 
 static struct foo gf;
@@ -14,13 +20,25 @@ int main(int argc, char **argv) {
     struct foo f;
     f.v = argc;
 // CHECK: getelementptr inbounds %struct.foo, %struct.foo* %f, i32 0, i32 0
-// CHECK-NEXT: bitcast i32* {{.*}} to i8*
-// CHECK-NEXT: call i8* @llvm.ptr.annotation.p0i8({{.*}}str{{.*}}str{{.*}}i32 8)
-// CHECK-NEXT: bitcast i8* {{.*}} to i32*
-// CHECK-NEXT: bitcast i32* {{.*}} to i8*
-// CHECK-NEXT: call i8* @llvm.ptr.annotation.p0i8({{.*}}str{{.*}}str{{.*}}i32 8)
-// CHECK-NEXT: bitcast i8* {{.*}} to i32*
+// CHECK-NEXT: call i32* @llvm.ptr.annotation.p0i32({{.*}}str{{.*}}str{{.*}}i32 12)
+// CHECK-NEXT: call i32* @llvm.ptr.annotation.p0i32({{.*}}str{{.*}}str{{.*}}i32 12)
+    f.w = 42;
+// CHECK: getelementptr inbounds %struct.foo, %struct.foo* %f, i32 0, i32 1
+// CHECK-NEXT: call i8* @llvm.ptr.annotation.p0i8({{.*}}str{{.*}}str{{.*}}i32 13)
+// CHECK-NEXT: call i8* @llvm.ptr.annotation.p0i8({{.*}}str{{.*}}str{{.*}}i32 13)
+    f.f = 0;
+// CHECK: getelementptr inbounds %struct.foo, %struct.foo* %f, i32 0, i32 2
+// CHECK-NEXT: bitcast float* {{.*}} to i8*
+// CHECK-NEXT: call i8* @llvm.ptr.annotation.p0i8({{.*}}str{{.*}}str{{.*}}i32 14)
+// CHECK-NEXT: bitcast i8* {{.*}} to float*
+// CHECK-NEXT: bitcast float* {{.*}} to i8*
+// CHECK-NEXT: call i8* @llvm.ptr.annotation.p0i8({{.*}}str{{.*}}str{{.*}}i32 14)
+// CHECK-NEXT: bitcast i8* {{.*}} to float*
     gf.v = argc;
-// CHECK: call i8* @llvm.ptr.annotation.p0i8(i8* bitcast (%struct.foo* @gf to i8*), {{.*}}str{{.*}}str{{.*}}i32 8)
+// CHECK: call i32* @llvm.ptr.annotation.p0i32(i32* getelementptr inbounds (%struct.foo, %struct.foo* @gf, i32 0, i32 0), {{.*}}str{{.*}}str{{.*}}i32 12)
+    gf.w = 42;
+// CHECK: call i8* @llvm.ptr.annotation.p0i8(i8* getelementptr inbounds (%struct.foo, %struct.foo* @gf, i32 0, i32 1), {{.*}}str{{.*}}str{{.*}}i32 13)
+    gf.f = 0;
+// CHECK: call i8* @llvm.ptr.annotation.p0i8(i8* bitcast (float* getelementptr inbounds (%struct.foo, %struct.foo* @gf, i32 0, i32 2) to i8*), {{.*}}str{{.*}}str{{.*}}i32 14)
     return 0;
 }


### PR DESCRIPTION
llvm.ptr.annotation intrinsic has overloads for integers of any width.
So, for integer type of intrinsic argument do not create a bitcast, and
align type of the intrinsic's argument with i8 pointer in other cases.