### PR TITLE
[SYCL] Make queue::submit throw synchronous exception

### DIFF
--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -109,14 +109,7 @@ public:
   }
 
   template <typename T> event submit(T cgf, std::shared_ptr<queue_impl> self) {
-    try {
-      return submit_impl(cgf, self);
-    } catch (...) {
-      std::lock_guard<mutex_class> guard(m_Mutex);
-      m_Exceptions.PushBack(std::current_exception());
-      return event(
-          createSyclObjFromImpl<event>(std::make_shared<event_impl>(self)));
-    }
+    return submit_impl(std::move(cgf), std::move(self));
   }
 
   void wait() {

--- a/sycl/test/basic_tests/buffer/buffer.cpp
+++ b/sycl/test/basic_tests/buffer/buffer.cpp
@@ -684,6 +684,7 @@ int main() {
       assert(BK0.get_size() == sizeof(char));
       assert(AK0.get_count() == 1);
       assert(BK0.get_count() == 1);
+      CGH.single_task<class DummyKernel>([]() {});
     });
   }
 

--- a/sycl/test/basic_tests/event_async_exception.cpp
+++ b/sycl/test/basic_tests/event_async_exception.cpp
@@ -27,10 +27,10 @@ int main() {
 
   queue q(asyncHandler);
 
-  // Submit a CG with no kernel or memory operation to trigger an async error
-  event e = q.submit([&](handler &cgh) {});
-
   try {
+    // Submit a CG with no kernel or memory operation to trigger an async error
+    event e = q.submit([&](handler &cgh) {});
+
     e.wait_and_throw();
     return 1;
   } catch (runtime_error e) {

--- a/sycl/test/usm/memcpy.cpp
+++ b/sycl/test/usm/memcpy.cpp
@@ -44,11 +44,10 @@ int main() {
     assert(dest[i] == i * 2);
   }
 
-  // Copying to nullptr should throw.
-  q.submit([&](handler &cgh) {
-    cgh.memcpy(nullptr, src, sizeof(float) * count);
-  });
   try {
+    // Copying to nullptr should throw.
+    q.submit(
+        [&](handler &cgh) { cgh.memcpy(nullptr, src, sizeof(float) * count); });
     q.wait_and_throw();
     assert(false && "Expected error from copying to nullptr");
   } catch (runtime_error e) {

--- a/sycl/test/usm/memset.cpp
+++ b/sycl/test/usm/memset.cpp
@@ -40,11 +40,11 @@ int main() {
     assert(src[i] == 0x2a2a2a2a);
   }
 
-  // Filling to nullptr should throw.
-  q.submit([&](handler &cgh) {
-    cgh.memset(nullptr, 0, sizeof(uint32_t) * count);
-  });
   try {
+    // Filling to nullptr should throw.
+    q.submit([&](handler &cgh) {
+      cgh.memset(nullptr, 0, sizeof(uint32_t) * count);
+    });
     q.wait_and_throw();
     assert(false && "Expected error from writing to nullptr");
   } catch (runtime_error e) {


### PR DESCRIPTION
Changed the type of exceptions that are thrown from sycl::submit to
synchronous ones. The goal of the change is to improve user experience.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>