### PR TITLE
[SYCL] Fix diagnostic about non-globally-visible kernel name

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10654,8 +10654,9 @@ def err_builtin_launder_invalid_arg : Error<
 // SYCL-specific diagnostics
 def err_sycl_attribute_address_space_invalid : Error<
   "address space is outside the valid range of values">;
-def err_sycl_kernel_name_class_not_top_level : Error<
- "kernel needs to have a globally-visible name">;
+def err_sycl_kernel_incorrectly_named : Error<
+  "kernel %select{name is missing"
+  "|needs to have a globally-visible name}0">;
 def err_sycl_restrict : Error<
   "SYCL kernel cannot "
 "%select{use a non-const global variable"

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10655,8 +10655,7 @@ def err_builtin_launder_invalid_arg : Error<
 def err_sycl_attribute_address_space_invalid : Error<
   "address space is outside the valid range of values">;
 def err_sycl_kernel_name_class_not_top_level : Error<
- "kernel name class and its template argument classes' declarations can only "
- "nest in a namespace: %0">;
+ "kernel needs to have a globally-visible name">;
 def err_sycl_restrict : Error<
   "SYCL kernel cannot "
 "%select{use a non-const global variable"

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -329,7 +329,7 @@ public:
   ///  Signals that subsequent parameter descriptor additions will go to
   ///  the kernel with given name. Starts new kernel invocation descriptor.
   void startKernel(StringRef KernelName, QualType KernelNameType,
-                   StringRef KernelStableName);
+                   StringRef KernelStableName, SourceLocation Loc);
 
   /// Adds a kernel parameter descriptor to current kernel invocation
   /// descriptor.
@@ -367,6 +367,8 @@ private:
     /// Kernel name with stable lambda name mangling
     std::string StableName;
 
+    SourceLocation KernelLocation;
+
     /// Descriptor of kernel actual parameters.
     SmallVector<KernelParamDesc, 8> Params;
 
@@ -381,7 +383,8 @@ private:
   }
 
   /// Emits a forward declaration for given declaration.
-  void emitFwdDecl(raw_ostream &O, const Decl *D);
+  void emitFwdDecl(raw_ostream &O, const Decl *D,
+                   SourceLocation KernelLocation);
 
   /// Emits forward declarations of classes and template classes on which
   /// declaration of given type depends. See example in the comments for the
@@ -390,10 +393,14 @@ private:
   ///     stream to emit to
   /// \param T
   ///     type to emit forward declarations for
+  /// \param KernelLocation
+  ///     source location of the SYCL kernel function, used to emit nicer
+  ///     diagnostic messages if kernel name is missing
   /// \param Emitted
   ///     a set of declarations forward declrations has been emitted for already
   void emitForwardClassDecls(raw_ostream &O, QualType T,
-                             llvm::SmallPtrSetImpl<const void*> &Emitted);
+                             SourceLocation KernelLocation,
+                             llvm::SmallPtrSetImpl<const void *> &Emitted);
 
 private:
   /// Keeps invocation descriptors for each kernel invocation started by

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1504,12 +1504,18 @@ void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D,
         if (TD && TD->isCompleteDefinition() && !UnnamedLambdaSupport) {
           // defined class constituting the kernel name is not globally
           // accessible - contradicts the spec
-          Diag.Report(KernelLocation,
-                      diag::err_sycl_kernel_name_class_not_top_level);
-          if (!TD->getName().empty())
+          const bool KernelNameIsMissing = TD->getName().empty();
+          if (KernelNameIsMissing) {
+            Diag.Report(KernelLocation, diag::err_sycl_kernel_incorrectly_named)
+                << /* kernel name is missing */ 0;
             // Don't emit note if kernel name was completely omitted
+          } else {
+            Diag.Report(KernelLocation, diag::err_sycl_kernel_incorrectly_named)
+                << /* kernel name is not globally-visible */ 1;
             Diag.Report(D->getSourceRange().getBegin(),
-                        diag::note_previous_decl) << TD->getName();
+                        diag::note_previous_decl)
+                << TD->getName();
+          }
         }
       }
       break;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1056,7 +1056,7 @@ static void populateIntHeader(SYCLIntegrationHeader &H, const StringRef Name,
   const ASTRecordLayout &Layout = Ctx.getASTRecordLayout(KernelObjTy);
   const std::string StableName = PredefinedExpr::ComputeName(
       Ctx, PredefinedExpr::UniqueStableNameExpr, NameType);
-  H.startKernel(Name, NameType, StableName);
+  H.startKernel(Name, NameType, StableName, KernelObjTy->getLocation());
 
   auto populateHeaderForAccessor = [&](const QualType &ArgTy, uint64_t Offset) {
     // The parameter is a SYCL accessor object.
@@ -1485,7 +1485,8 @@ static std::string eraseAnonNamespace(std::string S) {
 }
 
 // Emits a forward declaration
-void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D) {
+void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D,
+                                        SourceLocation KernelLocation) {
   // wrap the declaration into namespaces if needed
   unsigned NamespaceCnt = 0;
   std::string NSStr = "";
@@ -1503,8 +1504,12 @@ void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D) {
         if (TD && TD->isCompleteDefinition() && !UnnamedLambdaSupport) {
           // defined class constituting the kernel name is not globally
           // accessible - contradicts the spec
-          Diag.Report(D->getSourceRange().getBegin(),
+          Diag.Report(KernelLocation,
                       diag::err_sycl_kernel_name_class_not_top_level);
+          if (!TD->getName().empty())
+            // Don't emit note if kernel name was completely omitted
+            Diag.Report(D->getSourceRange().getBegin(),
+                        diag::note_previous_decl) << TD->getName();
         }
       }
       break;
@@ -1571,7 +1576,8 @@ void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D) {
 //   template <typename T1, unsigned int N, typename ...T2> class SimpleVadd;
 //
 void SYCLIntegrationHeader::emitForwardClassDecls(
-    raw_ostream &O, QualType T, llvm::SmallPtrSetImpl<const void *> &Printed) {
+    raw_ostream &O, QualType T, SourceLocation KernelLocation,
+    llvm::SmallPtrSetImpl<const void *> &Printed) {
 
   // peel off the pointer types and get the class/struct type:
   for (; T->isPointerType(); T = T->getPointeeType())
@@ -1593,14 +1599,14 @@ void SYCLIntegrationHeader::emitForwardClassDecls(
 
       switch (Arg.getKind()) {
       case TemplateArgument::ArgKind::Type:
-        emitForwardClassDecls(O, Arg.getAsType(), Printed);
+        emitForwardClassDecls(O, Arg.getAsType(), KernelLocation, Printed);
         break;
       case TemplateArgument::ArgKind::Pack: {
         ArrayRef<TemplateArgument> Pack = Arg.getPackAsArray();
 
         for (const auto &T : Pack) {
           if (T.getKind() == TemplateArgument::ArgKind::Type) {
-            emitForwardClassDecls(O, T.getAsType(), Printed);
+            emitForwardClassDecls(O, T.getAsType(), KernelLocation, Printed);
           }
         }
         break;
@@ -1623,7 +1629,7 @@ void SYCLIntegrationHeader::emitForwardClassDecls(
         // class template <template <typename> class> class T as it should.
         TemplateDecl *TD = Arg.getAsTemplate().getAsTemplateDecl();
         if (Printed.insert(TD).second) {
-          emitFwdDecl(O, TD);
+          emitFwdDecl(O, TD, KernelLocation);
         }
         break;
       }
@@ -1637,12 +1643,12 @@ void SYCLIntegrationHeader::emitForwardClassDecls(
     assert(CTD && "template declaration must be available");
 
     if (Printed.insert(CTD).second) {
-      emitFwdDecl(O, CTD);
+      emitFwdDecl(O, CTD, KernelLocation);
     }
   } else if (Printed.insert(RD).second) {
     // emit forward declarations for "leaf" classes in the template parameter
     // tree;
-    emitFwdDecl(O, RD);
+    emitFwdDecl(O, RD, KernelLocation);
   }
 }
 
@@ -1659,7 +1665,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
 
     llvm::SmallPtrSet<const void *, 4> Printed;
     for (const KernelDesc &K : KernelDescs) {
-      emitForwardClassDecls(O, K.NameType, Printed);
+      emitForwardClassDecls(O, K.NameType, K.KernelLocation, Printed);
     }
   }
   O << "\n";
@@ -1779,11 +1785,13 @@ bool SYCLIntegrationHeader::emit(const StringRef &IntHeaderName) {
 
 void SYCLIntegrationHeader::startKernel(StringRef KernelName,
                                         QualType KernelNameType,
-                                        StringRef KernelStableName) {
+                                        StringRef KernelStableName,
+                                        SourceLocation KernelLocation) {
   KernelDescs.resize(KernelDescs.size() + 1);
   KernelDescs.back().Name = std::string(KernelName);
   KernelDescs.back().NameType = KernelNameType;
   KernelDescs.back().StableName = std::string(KernelStableName);
+  KernelDescs.back().KernelLocation = KernelLocation;
 }
 
 void SYCLIntegrationHeader::addParamDesc(kernel_param_kind_t Kind, int Info,

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -76,22 +76,6 @@ struct MyWrapper {
     // translation unit scope
     kernel_single_task<nm1::nm2::KernelName0>([=]() { acc.use(); });
 
-#ifdef LI__
-    // TODO unexpected compilation error when host code + integration header
-    // is compiled LI-- kernel name is an incomplete class forward-declared in
-    // local scope
-    class KernelName2;
-    kernel_single_task<KernelName2>([=]() { acc.use(); });
-#endif
-
-#ifdef LD__
-    // Expected compilation error.
-    // LD--
-    // kernel name is a class defined in local scope
-    class KernelName2a {};
-    kernel_single_task<KernelName2a>([=]() { acc.use(); });
-#endif
-
     // TI--
     // an incomplete class forward-declared in a namespace at
     // translation unit scope
@@ -127,16 +111,6 @@ struct MyWrapper {
     kernel_single_task<nm1::KernelName3<class KernelName5>>(
       [=]() { acc.use(); });
 
-#ifdef TILI
-    // Expected compilation error
-    // TILI
-    // an incomplete template specialization class with incomplete class as
-    // argument forward-declared locally
-    class KernelName6;
-    kernel_single_task<nm1::KernelName3<KernelName6>>(
-      [=]() { acc.use(); });
-#endif
-
     // TDPI
     // a defined template specialization class with incomplete class as
     // argument forward-declared "in-place"
@@ -148,40 +122,6 @@ struct MyWrapper {
     // as argument declared in a namespace at translation unit scope
     kernel_single_task<nm1::KernelName8<nm1::nm2::C>>(
       [=]() { acc.use(); });
-
-#ifdef TDLI
-    // TODO unexpected compilation error when host code + integration header
-    // is compiled TDLI a defined template specialization class with
-    // incomplete class as argument forward-declared locally
-    class KernelName6a;
-    kernel_single_task<nm1::KernelName4<KernelName6a>>(
-      [=]() { acc.use(); });
-#endif
-
-#ifdef TDLD
-    // Expected compilation error
-    // TDLD
-    // a defined template specialization class with a class as argument
-    // defined locally
-    class KernelName9 {};
-    kernel_single_task<nm1::KernelName4<KernelName9>>([=]() { acc.use(); });
-#endif
-
-#ifdef TICD
-    // Expected compilation error
-    // TICD
-    // an incomplete template specialization class with a defined class as
-    // argument declared in the containing class
-    kernel_single_task<nm1::KernelName3<KN100>>([=]() { acc.use(); });
-#endif
-
-#ifdef TICI
-    // Expected compilation error
-    // TICI
-    // an incomplete template specialization class with an incomplete class as
-    // argument declared in the containing class
-    kernel_single_task<nm1::KernelName3<KN101>>([=]() { acc.use(); });
-#endif
 
     // kernel name type is a templated class, both the top-level class and the
     // template argument are declared in the anonymous namespace

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -82,7 +82,7 @@ public:
 int main() {
   cl::sycl::queue q;
 #ifndef __SYCL_UNNAMED_LAMBDA__
-  // expected-error@+2 {{kernel needs to have a globally-visible name}}
+  // expected-error@+2 {{kernel name is missing}}
 #endif
   q.submit([&](cl::sycl::handler &h) { h.single_task([] {}); });
 

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -41,7 +41,7 @@ public:
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
     // expected-error@+4 {{kernel needs to have a globally-visible name}}
-    // expected-note@15 {{InvalidKernelName0 declared here}}
+    // expected-note@16 {{InvalidKernelName0 declared here}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidKernelName0>([] {});
@@ -49,7 +49,7 @@ public:
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
     // expected-error@+4 {{kernel needs to have a globally-visible name}}
-    // expected-note@16 {{InvalidKernelName3 declared here}}
+    // expected-note@17 {{InvalidKernelName3 declared here}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidKernelName3>>([] {});
@@ -63,7 +63,7 @@ public:
     using InvalidAlias = InvalidKernelName4;
 #ifndef __SYCL_UNNAMED_LAMBDA__
     // expected-error@+4 {{kernel needs to have a globally-visible name}}
-    // expected-note@17 {{InvalidKernelName4 declared here}}
+    // expected-note@18 {{InvalidKernelName4 declared here}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidAlias>([] {});
@@ -72,7 +72,7 @@ public:
     using InvalidAlias1 = InvalidKernelName5;
 #ifndef __SYCL_UNNAMED_LAMBDA__
     // expected-error@+4 {{kernel needs to have a globally-visible name}}
-    // expected-note@18 {{InvalidKernelName5 declared here}}
+    // expected-note@19 {{InvalidKernelName5 declared here}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidAlias1>>([] {});

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -7,7 +7,8 @@
 #endif
 
 namespace namespace1 {
-  template <typename T> class KernelName;
+template <typename T>
+class KernelName;
 }
 
 struct MyWrapper {

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -1,0 +1,90 @@
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -verify %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsycl-unnamed-lambda -fsyntax-only -verify %s
+#include <sycl.hpp>
+
+#ifdef __SYCL_UNNAMED_LAMBDA__
+// expected-no-diagnostics
+#endif
+
+namespace namespace1 {
+  template <typename T> class KernelName;
+}
+
+struct MyWrapper {
+private:
+  class InvalidKernelName0 {};
+  class InvalidKernelName3 {};
+  class InvalidKernelName4 {};
+  class InvalidKernelName5 {};
+
+public:
+  void test() {
+    cl::sycl::queue q;
+#ifndef __SYCL_UNNAMED_LAMBDA__
+    // expected-error@+5 {{kernel needs to have a globally-visible name}}
+    // expected-note@+2 {{InvalidKernelName1 declared here}}
+#endif
+    class InvalidKernelName1 {};
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<InvalidKernelName1>([] {});
+    });
+
+#ifndef __SYCL_UNNAMED_LAMBDA__
+    // expected-error@+5 {{kernel needs to have a globally-visible name}}
+    // expected-note@+2 {{InvalidKernelName2 declared here}}
+#endif
+    class InvalidKernelName2 {};
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<namespace1::KernelName<InvalidKernelName2>>([] {});
+    });
+
+#ifndef __SYCL_UNNAMED_LAMBDA__
+    // expected-error@+4 {{kernel needs to have a globally-visible name}}
+    // expected-note@15 {{InvalidKernelName0 declared here}}
+#endif
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<InvalidKernelName0>([] {});
+    });
+
+#ifndef __SYCL_UNNAMED_LAMBDA__
+    // expected-error@+4 {{kernel needs to have a globally-visible name}}
+    // expected-note@16 {{InvalidKernelName3 declared here}}
+#endif
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<namespace1::KernelName<InvalidKernelName3>>([] {});
+    });
+
+    using ValidAlias = MyWrapper;
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<ValidAlias>([] {});
+    });
+
+    using InvalidAlias = InvalidKernelName4;
+#ifndef __SYCL_UNNAMED_LAMBDA__
+    // expected-error@+4 {{kernel needs to have a globally-visible name}}
+    // expected-note@17 {{InvalidKernelName4 declared here}}
+#endif
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<InvalidAlias>([] {});
+    });
+
+    using InvalidAlias1 = InvalidKernelName5;
+#ifndef __SYCL_UNNAMED_LAMBDA__
+    // expected-error@+4 {{kernel needs to have a globally-visible name}}
+    // expected-note@18 {{InvalidKernelName5 declared here}}
+#endif
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<namespace1::KernelName<InvalidAlias1>>([] {});
+    });
+  }
+};
+
+int main() {
+  cl::sycl::queue q;
+#ifndef __SYCL_UNNAMED_LAMBDA__
+  // expected-error@+2 {{kernel needs to have a globally-visible name}}
+#endif
+  q.submit([&](cl::sycl::handler &h) { h.single_task([] {}); });
+
+  return 0;
+}


### PR DESCRIPTION
Moved some dead code from CodeGenSYCL/int_header1.cpp to the new test