### PR TITLE
[SYCL] Fix check-llvm dependencies

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(LLVM_TEST_DEPENDS
           llvm-elfabi
           llvm-exegesis
           llvm-extract
+          llvm-foreach
           llvm-isel-fuzzer
           llvm-ifs
           llvm-install-name-tool
@@ -107,6 +108,7 @@ set(LLVM_TEST_DEPENDS
           opt
           sancov
           sanstats
+          sycl-post-link
           verify-uselistorder
           yaml-bench
           yaml2obj


### PR DESCRIPTION
Add tools which are tested by LIT tests to dependency list.

Without the fix 3 tests below  fail on clean build: 
    LLVM :: tools/llvm-foreach/llvm-foreach-lin.ll
    LLVM :: tools/sycl-post-link/basic-module-split.ll
    LLVM :: tools/sycl-post-link/one-kernel-per-module.ll
