### PR TITLE
[SYCL] Convert sync exceptions to async inside Scheduler::addCopyBack()

### DIFF
--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -232,6 +232,11 @@ public:
                size_t Count);
   event mem_advise(const void *Ptr, size_t Length, int Advice);
 
+  void reportAsyncException(std::exception_ptr E) {
+    std::lock_guard<mutex_class> guard(m_Mutex);
+    m_Exceptions.PushBack(E);
+  }
+
 private:
   template <typename T>
   event submit_impl(T cgf, std::shared_ptr<queue_impl> self) {

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -81,10 +81,15 @@ EventImplPtr Scheduler::addCopyBack(Requirement *Req) {
   // buffer.
   if (!NewCmd)
     return nullptr;
-  EnqueueResultT Res;
-  bool Enqueued = GraphProcessor::enqueueCommand(NewCmd, Res);
-  if (!Enqueued && EnqueueResultT::FAILED == Res.MResult)
-    throw runtime_error("Enqueue process failed.");
+
+  try {
+    EnqueueResultT Res;
+    bool Enqueued = GraphProcessor::enqueueCommand(NewCmd, Res);
+    if (!Enqueued && EnqueueResultT::FAILED == Res.MResult)
+      throw runtime_error("Enqueue process failed.");
+  } catch (...) {
+    NewCmd->getQueue()->reportAsyncException(std::current_exception());
+  }
   return NewCmd->getEvent();
 }
 


### PR DESCRIPTION
This is needed to avoid throwing sync exceptions from it to destructor
of buffer_impl which must never throw as all desctructors.
That eliminates the silent runtime crashes caused by throw in/from
~buffer_impl().

Signed-off-by: Klochkov <vyacheslav.n.klochkov@intel.com>