### PR TITLE
[SYCL] Refactor program to improve ABI stability

### DIFF
--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -12,6 +12,7 @@
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/program_impl.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -15,6 +15,7 @@
 #include <CL/sycl/detail/program_manager/program_manager.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/kernel.hpp>
+#include <CL/sycl/program.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <algorithm>
@@ -24,9 +25,6 @@
 
 __SYCL_INLINE namespace cl {
 namespace sycl {
-
-enum class program_state { none, compiled, linked };
-
 namespace detail {
 
 using ContextImplPtr = std::shared_ptr<detail::context_impl>;

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -37,17 +37,18 @@ public:
 
   /// Constructs an instance of program.
   ///
-  /// The program will be created in the program_state::none state and associated
-  /// with the provided context and the devices that are associated with
-  /// the context.
+  /// The program will be created in the program_state::none state and
+  /// associated with the provided context and the devices that are associated
+  /// with the context.
   ///
   /// @param Context is a pointer to SYCL context impl.
   explicit program_impl(ContextImplPtr Context);
 
   /// Constructs an instance of SYCL program for the provided DeviceList.
   ///
-  /// The program will be created in the program_state::none state and associated
-  /// with the provided context and the devices in the provided DeviceList.
+  /// The program will be created in the program_state::none state and
+  /// associated with the provided context and the devices in the provided
+  /// DeviceList.
   ///
   /// @param Context is a pointer to SYCL context impl.
   /// @param DeviceList is a list of SYCL devices.
@@ -58,9 +59,9 @@ public:
   ///
   /// Each program in ProgramList must be in the program_state::compiled
   /// state and must be associated with the same SYCL context. Otherwise an
-  /// invalid_object_error SYCL exception will be thrown. A feature_not_supported
-  /// exception will be thrown if any device that the program is to be linked
-  /// for returns false for the device information query
+  /// invalid_object_error SYCL exception will be thrown. A
+  /// feature_not_supported exception will be thrown if any device that the
+  /// program is to be linked for returns false for the device information query
   /// info::device::is_linker_available.
   /// Kernels caching for linked programs won't be allowed due to only compiled
   /// state of each and every program in the list and thus unknown state of
@@ -131,11 +132,11 @@ public:
   /// This member function sets the state of this SYCL program to
   /// program_state::compiled.
   /// If the program was not in the program_state::none state,
-  /// an invalid_object_error SYCL exception is thrown. If the compilation fails,
-  /// a compile_program_error SYCL exception is thrown. If any device that the
-  /// program is being compiled for returns false for the device information
-  /// query info::device::is_compiler_available, a feature_not_supported
-  /// SYCL exception is thrown.
+  /// an invalid_object_error SYCL exception is thrown. If the compilation
+  /// fails, a compile_program_error SYCL exception is thrown. If any device
+  /// that the program is being compiled for returns false for the device
+  /// information query info::device::is_compiler_available, a
+  /// feature_not_supported SYCL exception is thrown.
   ///
   /// @param KernelSource is a string containing OpenCL C kernel source code.
   /// @param CompileOptions is a string containing OpenCL compile options.
@@ -147,10 +148,10 @@ public:
   /// The SYCL kernel function is defined by the kernel name.
   /// This member function sets the state of this SYCL program to
   /// program_state::linked. If the program was not in the program_state::none
-  /// state, an invalid_object_error SYCL exception is thrown. If the compilation
-  /// fails, a compile_program_error SYCL exception is thrown. If any device
-  /// that the program is being built for returns false for the device
-  /// information queries info::device::is_compiler_available or
+  /// state, an invalid_object_error SYCL exception is thrown. If the
+  /// compilation fails, a compile_program_error SYCL exception is thrown. If
+  /// any device that the program is being built for returns false for the
+  /// device information queries info::device::is_compiler_available or
   /// info::device::is_linker_available, a feature_not_supported SYCL exception
   /// is thrown.
   ///
@@ -163,8 +164,8 @@ public:
   ///
   /// This member function sets the state of this SYCL program to
   /// program_state::linked. If this program was not in program_state::none,
-  /// an invalid_object_error SYCL exception is thrown. If the compilation fails,
-  /// a compile_program_error SYCL exception is thrown. If any device
+  /// an invalid_object_error SYCL exception is thrown. If the compilation
+  /// fails, a compile_program_error SYCL exception is thrown. If any device
   /// that the program is being built for returns false for the device
   /// information queries info::device::is_compiler_available or
   /// info::device::is_linker_available, a feature_not_supported SYCL exception
@@ -178,12 +179,12 @@ public:
   /// Links encapsulated raw program.
   ///
   /// This member function sets the state of this SYCL program to
-  /// program_state::linked. If the program was not in the program_state::compiled
-  /// state, an invalid_object_error SYCL exception is thrown. If linking fails,
-  /// a compile_program_error is thrown. If any device that the program is to be
-  /// linked for returns false for the device information query
-  /// info::device::is_linker_available, a feature_not_supported exception
-  /// is thrown.
+  /// program_state::linked. If the program was not in the
+  /// program_state::compiled state, an invalid_object_error SYCL exception is
+  /// thrown. If linking fails, a compile_program_error is thrown. If any device
+  /// that the program is to be linked for returns false for the device
+  /// information query info::device::is_linker_available, a
+  /// feature_not_supported exception is thrown.
   ///
   /// @param LinkOptions is a string containing OpenCL link options.
   void link(string_class LinkOptions = "");

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -122,8 +122,6 @@ private:
   void create_pi_program_with_kernel_name(OSModuleHandle M,
                                           const string_class &KernelName);
 
-  void create_cl_program_with_il(OSModuleHandle M);
-
   void create_cl_program_with_source(const string_class &Source);
 
   void compile(const string_class &Options);

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -102,13 +102,13 @@ public:
 
   /// @return a reference to a raw PI program handle. PI program is not retained
   /// before return.
-  RT::PiProgram &getHandleRef() { return Program; }
+  RT::PiProgram &getHandleRef() { return MProgram; }
   /// @return a constant reference to a raw PI program handle. PI program is not
   /// retained before return.
-  const RT::PiProgram &getHandleRef() const { return Program; }
+  const RT::PiProgram &getHandleRef() const { return MProgram; }
 
   /// @return true if this SYCL program is a host program.
-  bool is_host() const { return Context->is_host(); }
+  bool is_host() const { return MContext->is_host(); }
 
   /// Compiles the SYCL kernel function into the encapsulated raw program.
   ///
@@ -122,7 +122,7 @@ public:
   /// exception is thrown.
   ///
   /// @param CompileOptions is a string of valid OpenCL compile options.
-  void compile_with_kernel_type(string_class KernelName,
+  void compile_with_kernel_name(string_class KernelName,
                                 string_class CompileOptions,
                                 OSModuleHandle Module);
 
@@ -156,7 +156,7 @@ public:
   ///
   /// @param KernelName is a string containing SYCL kernel name.
   /// @param BuildOptions is a string containing OpenCL compile options.
-  void build_with_kernel_type(string_class KernelName,
+  void build_with_kernel_name(string_class KernelName,
                               string_class BuildOptions, OSModuleHandle M);
 
   /// Builds the OpenCL C kernel function defined by source code.
@@ -227,11 +227,11 @@ public:
   context get_context() const {
     if (is_host())
       return context();
-    return createSyclObjFromImpl<context>(Context);
+    return createSyclObjFromImpl<context>(MContext);
   }
 
   /// @return a vector of devices that are associated with this program.
-  vector_class<device> get_devices() const { return Devices; }
+  vector_class<device> get_devices() const { return MDevices; }
 
   /// Returns compile options that were provided when the encapsulated program
   /// was explicitly compiled.
@@ -243,7 +243,7 @@ public:
   /// in the explicit compile are returned.
   ///
   /// @return a string of valid OpenCL compile options.
-  string_class get_compile_options() const { return CompileOptions; }
+  string_class get_compile_options() const { return MCompileOptions; }
 
   /// Returns compile options that were provided to the most recent invocation
   /// of link member function.
@@ -259,7 +259,7 @@ public:
   /// are returned.
   ///
   /// @return a string of valid OpenCL compile options.
-  string_class get_link_options() const { return LinkOptions; }
+  string_class get_link_options() const { return MLinkOptions; }
 
   /// Returns the compile, link, or build options, from whichever of those
   /// operations was performed most recently on the encapsulated cl_program.
@@ -269,10 +269,10 @@ public:
   /// then an empty string is returned.
   ///
   /// @return a string of valid OpenCL build options.
-  string_class get_build_options() const { return BuildOptions; }
+  string_class get_build_options() const { return MBuildOptions; }
 
   /// @return the current state of this SYCL program.
-  program_state get_state() const { return State; }
+  program_state get_state() const { return MState; }
 
 private:
   /// Checks feature support for specific devices.
@@ -317,7 +317,7 @@ private:
   vector_class<RT::PiDevice> get_pi_devices() const;
 
   /// @return true if caching is allowed for this program.
-  bool is_cacheable() const { return IsProgramAndKernelCachingAllowed; }
+  bool is_cacheable() const { return MProgramAndKernelCachingAllowed; }
 
   /// @param Options is a string containing OpenCL C build options.
   /// @return true if caching is allowed for this program and build options.
@@ -350,20 +350,20 @@ private:
   /// @param State is a program state to match against.
   void throw_if_state_is_not(program_state State) const;
 
-  RT::PiProgram Program = nullptr;
-  program_state State = program_state::none;
-  ContextImplPtr Context;
-  bool IsLinkable = false;
-  vector_class<device> Devices;
-  string_class CompileOptions;
-  string_class LinkOptions;
-  string_class BuildOptions;
-  OSModuleHandle ProgramModuleHandle = OSUtil::ExeModuleHandle;
+  RT::PiProgram MProgram = nullptr;
+  program_state MState = program_state::none;
+  ContextImplPtr MContext;
+  bool MLinkable = false;
+  vector_class<device> MDevices;
+  string_class MCompileOptions;
+  string_class MLinkOptions;
+  string_class MBuildOptions;
+  OSModuleHandle MProgramModuleHandle = OSUtil::ExeModuleHandle;
 
-  // Only allow kernel caching for programs constructed with context only (or
-  // device list and context) and built with build_with_kernel_type with
-  // default build options
-  bool IsProgramAndKernelCachingAllowed = false;
+  /// Only allow kernel caching for programs constructed with context only (or
+  /// device list and context) and built with build_with_kernel_type with
+  /// default build options
+  bool MProgramAndKernelCachingAllowed = false;
 };
 
 template <>

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -8,13 +8,11 @@
 #pragma once
 
 #include <CL/sycl/context.hpp>
-#include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/program_manager/program_manager.hpp>
 #include <CL/sycl/device.hpp>
-#include <CL/sycl/kernel.hpp>
 #include <CL/sycl/program.hpp>
 #include <CL/sycl/stl.hpp>
 
@@ -25,6 +23,10 @@
 
 __SYCL_INLINE namespace cl {
 namespace sycl {
+
+// Forward declarations
+class kernel;
+
 namespace detail {
 
 using ContextImplPtr = std::shared_ptr<detail::context_impl>;
@@ -48,131 +50,16 @@ public:
   // state of each and every program in the list and thus unknown state of
   // caching resolution
   program_impl(vector_class<std::shared_ptr<program_impl>> ProgramList,
-               string_class LinkOptions = "")
-      : State(program_state::linked), LinkOptions(LinkOptions),
-        BuildOptions(LinkOptions) {
-    // Verify arguments
-    if (ProgramList.empty()) {
-      throw runtime_error("Non-empty vector of programs expected");
-    }
-    Context = ProgramList[0]->Context;
-    Devices = ProgramList[0]->Devices;
-    std::vector<device> DevicesSorted;
-    if (!is_host()) {
-      DevicesSorted = sort_devices_by_cl_device_id(Devices);
-    }
-    check_device_feature_support<info::device::is_linker_available>(Devices);
-    for (const auto &Prg : ProgramList) {
-      Prg->throw_if_state_is_not(program_state::compiled);
-      if (Prg->Context != Context) {
-        throw invalid_object_error(
-            "Not all programs are associated with the same context");
-      }
-      if (!is_host()) {
-        std::vector<device> PrgDevicesSorted =
-            sort_devices_by_cl_device_id(Prg->Devices);
-        if (PrgDevicesSorted != DevicesSorted) {
-          throw invalid_object_error(
-              "Not all programs are associated with the same devices");
-        }
-      }
-    }
+               string_class LinkOptions = "");
 
-    if (!is_host()) {
-      vector_class<RT::PiDevice> Devices(get_pi_devices());
-      vector_class<RT::PiProgram> Programs;
-      bool NonInterOpToLink = false;
-      for (const auto &Prg : ProgramList) {
-        if (!Prg->IsLinkable && NonInterOpToLink)
-          continue;
-        NonInterOpToLink |= !Prg->IsLinkable;
-        Programs.push_back(Prg->Program);
-      }
-      PI_CALL_THROW(piProgramLink, compile_program_error)(
-          Context->getHandleRef(), Devices.size(),
-          Devices.data(), LinkOptions.c_str(), Programs.size(), Programs.data(),
-          nullptr, nullptr, &Program);
-    }
-  }
 
-  // Kernel caching for programs created by interoperability c-tor isn't allowed
-  program_impl(ContextImplPtr Context, RT::PiProgram Program)
-      : Program(Program), Context(Context), IsLinkable(true) {
+  program_impl(ContextImplPtr Context, RT::PiKernel Kernel);
 
-    // TODO handle the case when cl_program build is in progress
-    cl_uint NumDevices;
-    PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_NUM_DEVICES, sizeof(cl_uint),
-                              &NumDevices, nullptr);
-    vector_class<RT::PiDevice> PiDevices(NumDevices);
-    PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_DEVICES,
-                              sizeof(RT::PiDevice) * NumDevices,
-                              PiDevices.data(), nullptr);
-    vector_class<device> SyclContextDevices =
-        Context->get_info<info::context::devices>();
+  program_impl(const context &Context, RT::PiProgram Program);
 
-    // Keep only the subset of the devices (associated with context) that
-    // were actually used to create the program.
-    // This is possible when clCreateProgramWithBinary is used.
-    auto NewEnd = std::remove_if(
-        SyclContextDevices.begin(), SyclContextDevices.end(),
-        [&PiDevices](const sycl::device &Dev) {
-          return PiDevices.end() ==
-                 std::find(PiDevices.begin(), PiDevices.end(),
-                           detail::getSyclObjImpl(Dev)->getHandleRef());
-        });
-    SyclContextDevices.erase(NewEnd, SyclContextDevices.end());
-    Devices = SyclContextDevices;
-    RT::PiDevice Device = getSyclObjImpl(Devices[0])->getHandleRef();
-    // TODO check build for each device instead
-    cl_program_binary_type BinaryType;
-    PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BINARY_TYPE,
-                                   sizeof(cl_program_binary_type), &BinaryType,
-                                   nullptr);
-    size_t Size = 0;
-    PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_OPTIONS, 0,
-                                   nullptr, &Size);
-    std::vector<char> OptionsVector(Size);
-    PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_OPTIONS,
-                                   Size, OptionsVector.data(), nullptr);
-    string_class Options(OptionsVector.begin(), OptionsVector.end());
-    switch (BinaryType) {
-    case CL_PROGRAM_BINARY_TYPE_NONE:
-      State = program_state::none;
-      break;
-    case CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT:
-      State = program_state::compiled;
-      CompileOptions = Options;
-      BuildOptions = Options;
-      break;
-    case CL_PROGRAM_BINARY_TYPE_LIBRARY:
-    case CL_PROGRAM_BINARY_TYPE_EXECUTABLE:
-      State = program_state::linked;
-      LinkOptions = "";
-      BuildOptions = Options;
-    }
-    PI_CALL(piProgramRetain)(Program);
-  }
+  ~program_impl();
 
-  program_impl(ContextImplPtr Context, RT::PiKernel Kernel)
-      : program_impl(
-            Context,
-            ProgramManager::getInstance().getClProgramFromClKernel(Kernel)) {}
-
-  ~program_impl() {
-    // TODO catch an exception and put it to list of asynchronous exceptions
-    if (!is_host() && Program != nullptr) {
-      PI_CALL(piProgramRelease)(Program);
-    }
-  }
-
-  cl_program get() const {
-    throw_if_state_is(program_state::none);
-    if (is_host()) {
-      throw invalid_object_error("This instance of program is a host instance");
-    }
-    PI_CALL(piProgramRetain)(Program);
-    return pi::cast<cl_program>(Program);
-  }
+  cl_program get() const;
 
   RT::PiProgram &getHandleRef() { return Program; }
   const RT::PiProgram &getHandleRef() const { return Program; }
@@ -180,117 +67,30 @@ public:
   bool is_host() const { return Context->is_host(); }
 
   void compile_with_kernel_type(string_class KernelName,
-                                string_class CompileOptions = "") {
-    throw_if_state_is_not(program_state::none);
-    if (!is_host()) {
-      OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
-      create_pi_program_with_kernel_name(M, KernelInfo<KernelT>::getName());
-      compile(CompileOptions);
-    }
-    State = program_state::compiled;
-  }
+                                string_class CompileOptions = "");
 
   void compile_with_source(string_class KernelSource,
-                           string_class CompileOptions = "") {
-    throw_if_state_is_not(program_state::none);
-    // TODO should it throw if it's host?
-    if (!is_host()) {
-      create_cl_program_with_source(KernelSource);
-      compile(CompileOptions);
-    }
-    State = program_state::compiled;
-  }
+                           string_class CompileOptions = "");
 
   void build_with_kernel_type(string_class KernelName,
-                              string_class BuildOptions = "") {
-    throw_if_state_is_not(program_state::none);
-    if (!is_host()) {
-      OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
-      // If there are no build options, program can be safely cached
-      if (is_cacheable_with_options(BuildOptions)) {
-        IsProgramAndKernelCachingAllowed = true;
-        Program = ProgramManager::getInstance().getBuiltPIProgram(
-            M, get_context(), KernelInfo<KernelT>::getName());
-        PI_CALL(piProgramRetain)(Program);
-      } else {
-        create_pi_program_with_kernel_name(M, KernelInfo<KernelT>::getName());
-        build(BuildOptions);
-      }
-    }
-    State = program_state::linked;
-  }
+                              string_class BuildOptions = "");
 
   void build_with_source(string_class KernelSource,
-                         string_class BuildOptions = "") {
-    throw_if_state_is_not(program_state::none);
-    // TODO should it throw if it's host?
-    if (!is_host()) {
-      create_cl_program_with_source(KernelSource);
-      build(BuildOptions);
-    }
-    State = program_state::linked;
-  }
+                         string_class BuildOptions = "");
 
-  void link(string_class LinkOptions = "") {
-    throw_if_state_is_not(program_state::compiled);
-    if (!is_host()) {
-      check_device_feature_support<info::device::is_linker_available>(Devices);
-      vector_class<RT::PiDevice> Devices(get_pi_devices());
-      PI_CALL_THROW(piProgramLink, compile_program_error)(
-          Context->getHandleRef(), Devices.size(),
-          Devices.data(), LinkOptions.c_str(), 1, &Program, nullptr, nullptr,
-          &Program);
-      this->LinkOptions = LinkOptions;
-      BuildOptions = LinkOptions;
-    }
-    State = program_state::linked;
-  }
+  void link(string_class LinkOptions = "");
 
-  bool has_kernel(string_class KernelName, bool IsCreatedFromSource) const {
-    throw_if_state_is(program_state::none);
-    if (is_host()) {
-      return !IsCreatedFromSource;
-    }
-    return has_cl_kernel(KernelName);
-  }
+  bool has_kernel(string_class KernelName, bool IsCreatedFromSource) const;
 
   kernel get_kernel(string_class KernelName,
                     std::shared_ptr<program_impl> PtrToSelf,
-                    bool IsCreatedFromSource) const {
-    throw_if_state_is(program_state::none);
-    if (is_host()) {
-      return createSyclObjFromImpl<kernel>(
-          std::make_shared<kernel_impl>(Context, PtrToSelf));
-    }
-    return createSyclObjFromImpl<kernel>(std::make_shared<kernel_impl>(
-        get_pi_kernel(KernelName), Context, PtrToSelf,
-        /*IsCreatedFromSource*/ IsCreatedFromSource));
-  }
+                    bool IsCreatedFromSource) const;
 
   template <info::program param>
   typename info::param_traits<info::program, param>::return_type
   get_info() const;
 
-  vector_class<vector_class<char>> get_binaries() const {
-    throw_if_state_is(program_state::none);
-    vector_class<vector_class<char>> Result;
-    if (!is_host()) {
-      vector_class<size_t> BinarySizes(Devices.size());
-      PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_BINARY_SIZES,
-                                sizeof(size_t) * BinarySizes.size(),
-                                BinarySizes.data(), nullptr);
-
-      vector_class<char *> Pointers;
-      for (size_t I = 0; I < BinarySizes.size(); ++I) {
-        Result.emplace_back(BinarySizes[I]);
-        Pointers.push_back(Result[I].data());
-      }
-      PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_BINARIES,
-                                sizeof(char *) * Pointers.size(),
-                                Pointers.data(), nullptr);
-    }
-    return Result;
-  }
+  vector_class<vector_class<char>> get_binaries() const;
 
   context get_context() const {
     if (is_host())
@@ -320,58 +120,17 @@ private:
   }
 
   void create_pi_program_with_kernel_name(OSModuleHandle M,
-                                          const string_class &KernelName) {
-    assert(!Program && "This program already has an encapsulated PI program");
-    ProgramManager &PM = ProgramManager::getInstance();
-    DeviceImage &Img = PM.getDeviceImage(M, KernelName, get_context());
-    Program = PM.createPIProgram(Img, get_context());
-  }
+                                          const string_class &KernelName);
 
-  void create_cl_program_with_source(const string_class &Source) {
-    assert(!Program && "This program already has an encapsulated cl_program");
-    const char *Src = Source.c_str();
-    size_t Size = Source.size();
-    PI_CALL(piclProgramCreateWithSource)(
-        Context->getHandleRef(), 1, &Src, &Size,
-        &Program);
-  }
+  void create_cl_program_with_il(OSModuleHandle M);
 
-  void compile(const string_class &Options) {
-    check_device_feature_support<info::device::is_compiler_available>(Devices);
-    vector_class<RT::PiDevice> Devices(get_pi_devices());
-    RT::PiResult Err = PI_CALL_NOCHECK(piProgramCompile)(
-        Program, Devices.size(), Devices.data(), Options.c_str(), 0, nullptr,
-        nullptr, nullptr, nullptr);
+  void create_cl_program_with_source(const string_class &Source);
 
-    if (Err != PI_SUCCESS) {
-      throw compile_program_error("Program compilation error:\n" +
-                                  ProgramManager::getProgramBuildLog(Program));
-    }
-    CompileOptions = Options;
-    BuildOptions = Options;
-  }
+  void compile(const string_class &Options);
 
-  void build(const string_class &Options) {
-    check_device_feature_support<info::device::is_compiler_available>(Devices);
-    vector_class<RT::PiDevice> Devices(get_pi_devices());
-    RT::PiResult Err =
-        PI_CALL_NOCHECK(piProgramBuild)(Program, Devices.size(), Devices.data(),
-                                        Options.c_str(), nullptr, nullptr);
+  void build(const string_class &Options);
 
-    if (Err != PI_SUCCESS) {
-      throw compile_program_error("Program build error:\n" +
-                                  ProgramManager::getProgramBuildLog(Program));
-    }
-    BuildOptions = Options;
-  }
-
-  vector_class<RT::PiDevice> get_pi_devices() const {
-    vector_class<RT::PiDevice> PiDevices;
-    for (const auto &Device : Devices) {
-      PiDevices.push_back(getSyclObjImpl(Device)->getHandleRef());
-    }
-    return PiDevices;
-  }
+  vector_class<RT::PiDevice> get_pi_devices() const;
 
   bool is_cacheable() const { return IsProgramAndKernelCachingAllowed; }
 
@@ -379,66 +138,18 @@ private:
     return Options.empty();
   }
 
-  bool has_cl_kernel(const string_class &KernelName) const {
-    size_t Size;
-    PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_KERNEL_NAMES, 0, nullptr,
-                              &Size);
-    string_class ClResult(Size, ' ');
-    PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_KERNEL_NAMES, ClResult.size(),
-                              &ClResult[0], nullptr);
-    // Get rid of the null terminator
-    ClResult.pop_back();
-    vector_class<string_class> KernelNames(split_string(ClResult, ';'));
-    for (const auto &Name : KernelNames) {
-      if (Name == KernelName) {
-        return true;
-      }
-    }
-    return false;
-  }
+  bool has_cl_kernel(const string_class &KernelName) const;
 
-  RT::PiKernel get_pi_kernel(const string_class &KernelName) const {
-    RT::PiKernel Kernel;
+  RT::PiKernel get_pi_kernel(const string_class &KernelName) const;
 
-    if (is_cacheable()) {
-      OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
-
-      Kernel = ProgramManager::getInstance().getOrCreateKernel(M, get_context(),
-                                                               KernelName);
-    } else {
-      RT::PiResult Err =
-          PI_CALL_NOCHECK(piKernelCreate)(Program, KernelName.c_str(), &Kernel);
-      if (Err == PI_RESULT_INVALID_KERNEL_NAME) {
-        throw invalid_object_error(
-            "This instance of program does not contain the kernel requested");
-      }
-      RT::checkPiResult(Err);
-    }
-
-    return Kernel;
-  }
+  RT::PiKernel get_pi_kernel(const string_class &KernelName) const;
 
   std::vector<device>
-  sort_devices_by_cl_device_id(vector_class<device> Devices) {
-    std::sort(Devices.begin(), Devices.end(),
-              [](const device &id1, const device &id2) {
-                return (detail::getSyclObjImpl(id1)->getHandleRef() <
-                        detail::getSyclObjImpl(id2)->getHandleRef());
-              });
-    return Devices;
-  }
+  sort_devices_by_cl_device_id(vector_class<device> Devices);
 
-  void throw_if_state_is(program_state State) const {
-    if (this->State == State) {
-      throw invalid_object_error("Invalid program state");
-    }
-  }
+  void throw_if_state_is(program_state State) const;
 
-  void throw_if_state_is_not(program_state State) const {
-    if (this->State != State) {
-      throw invalid_object_error("Invalid program state");
-    }
-  }
+  void throw_if_state_is_not(program_state State) const;
 
   RT::PiProgram Program = nullptr;
   program_state State = program_state::none;

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -69,7 +69,7 @@ public:
   ///
   /// @param ProgramList is a list of program_impl instances.
   /// @param LinkOptions is a string containing valid OpenCL link options.
-  program_impl(vector_class<std::shared_ptr<program_impl>> ProgramList,
+  program_impl(vector_class<shared_ptr_class<program_impl>> ProgramList,
                string_class LinkOptions = "");
 
   /// Constructs a program instance from plugin interface interoperability
@@ -204,7 +204,7 @@ public:
   ///
   /// @return a valid instance of SYCL kernel.
   kernel get_kernel(string_class KernelName,
-                    std::shared_ptr<program_impl> PtrToSelf,
+                    shared_ptr_class<program_impl> PtrToSelf,
                     bool IsCreatedFromSource) const;
 
   /// Queries this SYCL program for information.
@@ -336,7 +336,7 @@ private:
   RT::PiKernel get_pi_kernel(const string_class &KernelName) const;
 
   /// @return a vector of sorted in ascending order SYCL devices.
-  std::vector<device>
+  vector_class<device>
   sort_devices_by_cl_device_id(vector_class<device> Devices);
 
   /// Throws an invalid_object_exception if state of this program is in the

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -31,11 +31,6 @@ namespace detail {
 
 using ContextImplPtr = std::shared_ptr<detail::context_impl>;
 
-// Used to identify the module the user code, which included this header,
-// belongs to. Incurs some marginal inefficiency - there will be one copy
-// per '#include "program_impl.hpp"'
-static void *AddressInThisModule = &AddressInThisModule;
-
 class program_impl {
 public:
   program_impl() = delete;
@@ -67,13 +62,13 @@ public:
   bool is_host() const { return Context->is_host(); }
 
   void compile_with_kernel_type(string_class KernelName,
-                                string_class CompileOptions = "");
+                                string_class CompileOptions, OSModuleHandle M);
 
   void compile_with_source(string_class KernelSource,
                            string_class CompileOptions = "");
 
   void build_with_kernel_type(string_class KernelName,
-                              string_class BuildOptions = "");
+                              string_class BuildOptions, OSModuleHandle M);
 
   void build_with_source(string_class KernelSource,
                          string_class BuildOptions = "");
@@ -155,6 +150,7 @@ private:
   string_class CompileOptions;
   string_class LinkOptions;
   string_class BuildOptions;
+  OSModuleHandle ProgramModuleHandle = OSUtil::ExeModuleHandle;
 
   // Only allow kernel caching for programs constructed with context only (or
   // device list and context) and built with build_with_kernel_type with

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -88,7 +88,10 @@ public:
 
   /// Constructs a program instance from plugin interface interoperability
   /// kernel.
-  program_impl(const context &Context, RT::PiKernel Kernel);
+  ///
+  /// @param Context is a pointer to SYCL context impl.
+  /// @param Kernel is a raw PI kernel handle.
+  program_impl(ContextImplPtr Context, RT::PiKernel Kernel);
 
   ~program_impl();
 

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -142,8 +142,6 @@ private:
 
   RT::PiKernel get_pi_kernel(const string_class &KernelName) const;
 
-  RT::PiKernel get_pi_kernel(const string_class &KernelName) const;
-
   std::vector<device>
   sort_devices_by_cl_device_id(vector_class<device> Devices);
 

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -268,9 +268,7 @@ template <typename T, T param> class param_traits {};
 
 #include <CL/sycl/info/platform_traits.def>
 
-PARAM_TRAITS_SPEC(program, context, cl::sycl::context)
-PARAM_TRAITS_SPEC(program, devices, vector_class<cl::sycl::device>)
-PARAM_TRAITS_SPEC(program, reference_count, cl_uint)
+#include <CL/sycl/info/program_traits.def>
 
 PARAM_TRAITS_SPEC(queue, reference_count, cl_uint)
 PARAM_TRAITS_SPEC(queue, context, cl::sycl::context)

--- a/sycl/include/CL/sycl/info/program_traits.def
+++ b/sycl/include/CL/sycl/info/program_traits.def
@@ -1,0 +1,4 @@
+PARAM_TRAITS_SPEC(program, context, cl::sycl::context)
+PARAM_TRAITS_SPEC(program, devices, vector_class<cl::sycl::device>)
+PARAM_TRAITS_SPEC(program, reference_count, cl_uint)
+

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -95,7 +95,7 @@ public:
 
   bool operator!=(const program &rhs) const;
 
-  /// Gets a valid cl_program instance.
+  /// Returns a valid cl_program instance.
   ///
   /// The instance of cl_program will be retained before returning.
   /// If the program is created for a SYCL host device, an invalid_object_error

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -15,8 +15,6 @@
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/stl.hpp>
 
-#include <memory>
-
 __SYCL_INLINE namespace cl {
 namespace sycl {
 
@@ -296,7 +294,7 @@ public:
   program_state get_state() const;
 
 private:
-  program(std::shared_ptr<detail::program_impl> impl);
+  program(shared_ptr_class<detail::program_impl> impl);
 
   /// Template-free version of get_kernel.
   ///

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -332,7 +332,7 @@ private:
                               string_class buildOptions,
                               detail::OSModuleHandle M);
 
-  std::shared_ptr<detail::program_impl> impl;
+  shared_ptr_class<detail::program_impl> impl;
 
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
@@ -345,7 +345,7 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::program> {
   size_t operator()(const cl::sycl::program &prg) const {
-    return hash<std::shared_ptr<cl::sycl::detail::program_impl>>()(
+    return hash<shared_ptr_class<cl::sycl::detail::program_impl>>()(
         cl::sycl::detail::getSyclObjImpl(prg));
   }
 };

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -345,7 +345,7 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::program> {
   size_t operator()(const cl::sycl::program &prg) const {
-    return hash<shared_ptr_class<cl::sycl::detail::program_impl>>()(
+    return hash<cl::sycl::shared_ptr_class<cl::sycl::detail::program_impl>>()(
         cl::sycl::detail::getSyclObjImpl(prg));
   }
 };

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
+#include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/stl.hpp>
@@ -122,7 +123,10 @@ public:
   /// @param CompileOptions is a string of valid OpenCL compile options.
   template <typename KernelT>
   void compile_with_kernel_type(string_class CompileOptions = "") {
-    compile_with_kernel_type(detail::KernelInfo<KernelT>::getName(), CompileOptions);
+    detail::OSModuleHandle M = detail::OSUtil::getOSModuleHandle(
+        detail::KernelInfo<KernelT>::getName());
+    compile_with_kernel_type(detail::KernelInfo<KernelT>::getName(),
+                             CompileOptions, M);
   }
 
   /// Compiles the OpenCL C kernel function defined by source string.
@@ -156,7 +160,10 @@ public:
   /// @param BuildOptions is a string containing OpenCL compile options.
   template <typename KernelT>
   void build_with_kernel_type(string_class BuildOptions = "") {
-    build_with_kernel_type(detail::KernelInfo<KernelT>::getName(), BuildOptions);
+    detail::OSModuleHandle M = detail::OSUtil::getOSModuleHandle(
+        detail::KernelInfo<KernelT>::getName());
+    build_with_kernel_type(detail::KernelInfo<KernelT>::getName(), BuildOptions,
+                           M);
   }
 
   /// Builds the OpenCL C kernel function defined by source code.
@@ -209,8 +216,9 @@ public:
   /// SYCL host program.
   bool has_kernel(string_class kernelName) const;
 
-  template <typename kernelT> kernel get_kernel() const {
-    return get_kernel(detail::KernelInfo<kernelT>::getName(), /*IsCreatedFromSource*/false);
+  template <typename KernelT> kernel get_kernel() const {
+    return get_kernel(detail::KernelInfo<KernelT>::getName(),
+                      /*IsCreatedFromSource*/ false);
   }
 
   kernel get_kernel(string_class kernelName) const;
@@ -240,9 +248,13 @@ private:
 
   bool has_kernel(string_class kernelName, bool IsCreatedFromSource) const;
 
-  void compile_with_kernel_type(string_class KernelName, string_class compileOptions = "");
+  void compile_with_kernel_type(string_class KernelName,
+                                string_class compileOptions,
+                                detail::OSModuleHandle M);
 
-  void build_with_kernel_type(string_class KernelName, string_class buildOptions = "");
+  void build_with_kernel_type(string_class KernelName,
+                              string_class buildOptions,
+                              detail::OSModuleHandle M);
 
   std::shared_ptr<detail::program_impl> impl;
 };

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -35,17 +35,18 @@ public:
 
   /// Constructs an instance of SYCL program.
   ///
-  /// The program will be created in the program_state::none state and associated
-  /// with the provided context and the SYCL devices that are associated with
-  /// the context.
+  /// The program will be created in the program_state::none state and
+  /// associated with the provided context and the SYCL devices that are
+  /// associated with the context.
   ///
   /// @param Context is an instance of SYCL context.
   explicit program(const context &Context);
 
   /// Constructs an instance of SYCL program for the provided DeviceList.
   ///
-  /// The program will be created in the program_state::none state and associated
-  /// with the provided context and the SYCL devices in the provided DeviceList.
+  /// The program will be created in the program_state::none state and
+  /// associated with the provided context and the SYCL devices in the provided
+  /// DeviceList.
   ///
   /// @param Context is an instance of SYCL context.
   /// @param DeviceList is a list of SYCL devices.
@@ -56,9 +57,9 @@ public:
   ///
   /// Each SYCL program in ProgramList must be in the program_state::compiled
   /// state and must be associated with the same SYCL context. Otherwise an
-  /// invalid_object_error SYCL exception will be thrown. A feature_not_supported
-  /// exception will be thrown if any device that the program is to be linked
-  /// for returns false for the device information query
+  /// invalid_object_error SYCL exception will be thrown. A
+  /// feature_not_supported exception will be thrown if any device that the
+  /// program is to be linked for returns false for the device information query
   /// info::device::is_linker_available.
   ///
   /// @param ProgramList is a list of SYCL program instances.
@@ -127,11 +128,11 @@ public:
   /// This member function sets the state of this SYCL program to
   /// program_state::compiled.
   /// If the program was not in the program_state::none state,
-  /// an invalid_object_error SYCL exception is thrown. If the compilation fails,
-  /// a compile_program_error SYCL exception is thrown. If any device that the
-  /// program is being compiled for returns false for the device information
-  /// query info::device::is_compiler_available, a feature_not_supported
-  /// SYCL exception is thrown.
+  /// an invalid_object_error SYCL exception is thrown. If the compilation
+  /// fails, a compile_program_error SYCL exception is thrown. If any device
+  /// that the program is being compiled for returns false for the device
+  /// information query info::device::is_compiler_available, a
+  /// feature_not_supported SYCL exception is thrown.
   ///
   /// @param KernelSource is a string containing OpenCL C kernel source code.
   /// @param CompileOptions is a string containing OpenCL compile options.
@@ -143,10 +144,10 @@ public:
   /// The SYCL kernel function is defined by the type KernelT.
   /// This member function sets the state of this SYCL program to
   /// program_state::linked. If the program was not in the program_state::none
-  /// state, an invalid_object_error SYCL exception is thrown. If the compilation
-  /// fails, a compile_program_error SYCL exception is thrown. If any device
-  /// that the program is being built for returns false for the device
-  /// information queries info::device::is_compiler_available or
+  /// state, an invalid_object_error SYCL exception is thrown. If the
+  /// compilation fails, a compile_program_error SYCL exception is thrown. If
+  /// any device that the program is being built for returns false for the
+  /// device information queries info::device::is_compiler_available or
   /// info::device::is_linker_available, a feature_not_supported SYCL exception
   /// is thrown.
   ///
@@ -163,8 +164,8 @@ public:
   ///
   /// This member function sets the state of this SYCL program to
   /// program_state::linked. If this program was not in program_state::none,
-  /// an invalid_object_error SYCL exception is thrown. If the compilation fails,
-  /// a compile_program_error SYCL exception is thrown. If any device
+  /// an invalid_object_error SYCL exception is thrown. If the compilation
+  /// fails, a compile_program_error SYCL exception is thrown. If any device
   /// that the program is being built for returns false for the device
   /// information queries info::device::is_compiler_available or
   /// info::device::is_linker_available, a feature_not_supported SYCL exception
@@ -178,12 +179,12 @@ public:
   /// Links encapsulated raw program.
   ///
   /// This member function sets the state of this SYCL program to
-  /// program_state::linked. If the program was not in the program_state::compiled
-  /// state, an invalid_object_error SYCL exception is thrown. If linking fails,
-  /// a compile_program_error is thrown. If any device that the program is to be
-  /// linked for returns false for the device information query
-  /// info::device::is_linker_available, a feature_not_supported exception
-  /// is thrown.
+  /// program_state::linked. If the program was not in the
+  /// program_state::compiled state, an invalid_object_error SYCL exception is
+  /// thrown. If linking fails, a compile_program_error is thrown. If any device
+  /// that the program is to be linked for returns false for the device
+  /// information query info::device::is_linker_available, a
+  /// feature_not_supported exception is thrown.
   ///
   /// @param LinkOptions is a string containing OpenCL link options.
   void link(string_class LinkOptions = "");
@@ -195,7 +196,8 @@ public:
   ///
   /// @return true if the SYCL kernel is available.
   template <typename KernelT> bool has_kernel() const {
-    return has_kernel(detail::KernelInfo<KernelT>::getName(), /*IsCreatedFromSource*/ false);
+    return has_kernel(detail::KernelInfo<KernelT>::getName(),
+                      /*IsCreatedFromSource*/ false);
   }
 
   /// Checks if kernel is available for this program.
@@ -336,7 +338,6 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
-
 };
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -30,11 +30,6 @@ class program_impl;
 enum class program_state { none, compiled, linked };
 
 class program {
-  template <class Obj>
-  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
-  template <class T>
-  friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
-
 public:
   program() = delete;
 
@@ -91,9 +86,9 @@ public:
 
   program &operator=(program &&rhs) = default;
 
-  bool operator==(const program &rhs) const;
+  bool operator==(const program &rhs) const { return impl == rhs.impl; }
 
-  bool operator!=(const program &rhs) const;
+  bool operator!=(const program &rhs) const { return impl != rhs.impl; }
 
   /// Returns a valid cl_program instance.
   ///
@@ -123,7 +118,7 @@ public:
   void compile_with_kernel_type(string_class CompileOptions = "") {
     detail::OSModuleHandle M = detail::OSUtil::getOSModuleHandle(
         detail::KernelInfo<KernelT>::getName());
-    compile_with_kernel_type(detail::KernelInfo<KernelT>::getName(),
+    compile_with_kernel_name(detail::KernelInfo<KernelT>::getName(),
                              CompileOptions, M);
   }
 
@@ -160,7 +155,7 @@ public:
   void build_with_kernel_type(string_class BuildOptions = "") {
     detail::OSModuleHandle M = detail::OSUtil::getOSModuleHandle(
         detail::KernelInfo<KernelT>::getName());
-    build_with_kernel_type(detail::KernelInfo<KernelT>::getName(), BuildOptions,
+    build_with_kernel_name(detail::KernelInfo<KernelT>::getName(), BuildOptions,
                            M);
   }
 
@@ -322,7 +317,7 @@ private:
   /// @param KernelName is a stringified kernel name.
   /// @param CompileOptions is a string of valid OpenCL compile options.
   /// @param M is a valid OS handle to the user executable or library.
-  void compile_with_kernel_type(string_class KernelName,
+  void compile_with_kernel_name(string_class KernelName,
                                 string_class CompileOptions,
                                 detail::OSModuleHandle M);
 
@@ -331,11 +326,17 @@ private:
   /// @param KernelName is a stringified kernel name.
   /// @param CompileOptions is a string of valid OpenCL compile options.
   /// @param M is a valid OS handle to the user executable or library.
-  void build_with_kernel_type(string_class KernelName,
+  void build_with_kernel_name(string_class KernelName,
                               string_class buildOptions,
                               detail::OSModuleHandle M);
 
   std::shared_ptr<detail::program_impl> impl;
+
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
+  template <class T>
+  friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
+
 };
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -22,7 +22,6 @@ namespace sycl {
 // Forward declarations
 class context;
 class device;
-class kernel;
 namespace detail {
 class program_impl;
 }

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/program_impl.hpp>
+#include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
@@ -61,7 +62,7 @@ public:
 
   template <typename kernelT>
   void compile_with_kernel_type(string_class compileOptions = "") {
-    impl->compile_with_kernel_type<kernelT>(compileOptions);
+    impl->compile_with_kernel_type(detail::KernelInfo<kernelT>::getName(), compileOptions);
   }
 
   void compile_with_source(string_class kernelSource,
@@ -69,7 +70,7 @@ public:
 
   template <typename kernelT>
   void build_with_kernel_type(string_class buildOptions = "") {
-    impl->build_with_kernel_type<kernelT>(buildOptions);
+    impl->build_with_kernel_type(detail::KernelInfo<kernelT>::getName(), buildOptions);
   }
 
   void build_with_source(string_class kernelSource,
@@ -78,13 +79,13 @@ public:
   void link(string_class linkOptions = "");
 
   template <typename kernelT> bool has_kernel() const {
-    return impl->has_kernel<kernelT>();
+    return has_kernel(detail::KernelInfo<kernelT>::getName(), /*IsCreatedFromSource*/ false);
   }
 
   bool has_kernel(string_class kernelName) const;
 
   template <typename kernelT> kernel get_kernel() const {
-    return impl->get_kernel<kernelT>(impl);
+    return get_kernel(detail::KernelInfo<kernelT>::getName(), /*IsCreatedFromSource*/false);
   }
 
   kernel get_kernel(string_class kernelName) const;
@@ -109,6 +110,10 @@ public:
 
 private:
   program(std::shared_ptr<detail::program_impl> impl);
+
+  kernel get_kernel(string_class kernelName, bool IsCreatedFromSource) const;
+
+  bool has_kernel(string_class kernelName, bool IsCreatedFromSource) const;
 
   std::shared_ptr<detail::program_impl> impl;
 };

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -18,9 +18,13 @@
 __SYCL_INLINE namespace cl {
 namespace sycl {
 
+// Forward declarations
 class context;
 class device;
 class kernel;
+/*namespace detail {
+class program_impl;
+}*/
 
 class program {
   template <class Obj>
@@ -31,26 +35,13 @@ class program {
 public:
   program() = delete;
 
-  explicit program(const context &context)
-      : impl(std::make_shared<detail::program_impl>(
-            detail::getSyclObjImpl(context))) {}
+  explicit program(const context &context);
 
-  program(const context &context, vector_class<device> deviceList)
-      : impl(std::make_shared<detail::program_impl>(
-            detail::getSyclObjImpl(context), deviceList)) {}
+  program(const context &context, vector_class<device> deviceList);
 
-  program(vector_class<program> programList, string_class linkOptions = "") {
-    std::vector<std::shared_ptr<detail::program_impl>> impls;
-    for (auto &x : programList) {
-      impls.push_back(detail::getSyclObjImpl(x));
-    }
-    impl = std::make_shared<detail::program_impl>(impls, linkOptions);
-  }
+  program(vector_class<program> programList, string_class linkOptions = "");
 
-  program(const context &context, cl_program clProgram)
-      : impl(std::make_shared<detail::program_impl>(
-            detail::getSyclObjImpl(context),
-            detail::pi::cast<detail::RT::PiProgram>(clProgram))) {}
+  program(const context &context, cl_program clProgram);
 
   program(const program &rhs) = default;
 
@@ -60,13 +51,13 @@ public:
 
   program &operator=(program &&rhs) = default;
 
-  bool operator==(const program &rhs) const { return impl == rhs.impl; }
+  bool operator==(const program &rhs) const;
 
-  bool operator!=(const program &rhs) const { return !operator==(rhs); }
+  bool operator!=(const program &rhs) const;
 
-  cl_program get() const { return impl->get(); }
+  cl_program get() const;
 
-  bool is_host() const { return impl->is_host(); }
+  bool is_host() const;
 
   template <typename kernelT>
   void compile_with_kernel_type(string_class compileOptions = "") {
@@ -74,9 +65,7 @@ public:
   }
 
   void compile_with_source(string_class kernelSource,
-                           string_class compileOptions = "") {
-    impl->compile_with_source(kernelSource, compileOptions);
-  }
+                           string_class compileOptions = "");
 
   template <typename kernelT>
   void build_with_kernel_type(string_class buildOptions = "") {
@@ -84,54 +73,42 @@ public:
   }
 
   void build_with_source(string_class kernelSource,
-                         string_class buildOptions = "") {
-    impl->build_with_source(kernelSource, buildOptions);
-  }
+                         string_class buildOptions = "");
 
-  void link(string_class linkOptions = "") { impl->link(linkOptions); }
+  void link(string_class linkOptions = "");
 
   template <typename kernelT> bool has_kernel() const {
     return impl->has_kernel<kernelT>();
   }
 
-  bool has_kernel(string_class kernelName) const {
-    return impl->has_kernel(kernelName);
-  }
+  bool has_kernel(string_class kernelName) const;
 
   template <typename kernelT> kernel get_kernel() const {
     return impl->get_kernel<kernelT>(impl);
   }
 
-  kernel get_kernel(string_class kernelName) const {
-    return impl->get_kernel(kernelName, impl);
-  }
+  kernel get_kernel(string_class kernelName) const;
 
   template <info::program param>
   typename info::param_traits<info::program, param>::return_type
-  get_info() const {
-    return impl->get_info<param>();
-  }
+  get_info() const;
 
-  vector_class<vector_class<char>> get_binaries() const {
-    return impl->get_binaries();
-  }
+  vector_class<vector_class<char>> get_binaries() const;
 
-  context get_context() const { return impl->get_context(); }
+  context get_context() const;
 
-  vector_class<device> get_devices() const { return impl->get_devices(); }
+  vector_class<device> get_devices() const;
 
-  string_class get_compile_options() const {
-    return impl->get_compile_options();
-  }
+  string_class get_compile_options() const;
 
-  string_class get_link_options() const { return impl->get_link_options(); }
+  string_class get_link_options() const;
 
-  string_class get_build_options() const { return impl->get_build_options(); }
+  string_class get_build_options() const;
 
-  program_state get_state() const { return impl->get_state(); }
+  program_state get_state() const;
 
 private:
-  program(std::shared_ptr<detail::program_impl> impl) : impl(impl) {}
+  program(std::shared_ptr<detail::program_impl> impl);
 
   std::shared_ptr<detail::program_impl> impl;
 };

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <CL/sycl/context.hpp>
-#include <CL/sycl/detail/program_impl.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/info/info_desc.hpp>
+#include <CL/sycl/kernel.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <memory>
@@ -23,9 +23,11 @@ namespace sycl {
 class context;
 class device;
 class kernel;
-/*namespace detail {
+namespace detail {
 class program_impl;
-}*/
+}
+
+enum class program_state { none, compiled, linked };
 
 class program {
   template <class Obj>
@@ -62,7 +64,7 @@ public:
 
   template <typename kernelT>
   void compile_with_kernel_type(string_class compileOptions = "") {
-    impl->compile_with_kernel_type(detail::KernelInfo<kernelT>::getName(), compileOptions);
+    compile_with_kernel_type(detail::KernelInfo<kernelT>::getName(), compileOptions);
   }
 
   void compile_with_source(string_class kernelSource,
@@ -70,7 +72,7 @@ public:
 
   template <typename kernelT>
   void build_with_kernel_type(string_class buildOptions = "") {
-    impl->build_with_kernel_type(detail::KernelInfo<kernelT>::getName(), buildOptions);
+    build_with_kernel_type(detail::KernelInfo<kernelT>::getName(), buildOptions);
   }
 
   void build_with_source(string_class kernelSource,
@@ -114,6 +116,10 @@ private:
   kernel get_kernel(string_class kernelName, bool IsCreatedFromSource) const;
 
   bool has_kernel(string_class kernelName, bool IsCreatedFromSource) const;
+
+  void compile_with_kernel_type(string_class KernelName, string_class compileOptions = "");
+
+  void build_with_kernel_type(string_class KernelName, string_class buildOptions = "");
 
   std::shared_ptr<detail::program_impl> impl;
 };

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -89,6 +89,7 @@ set(SYCL_SOURCES
     "half_type.cpp"
     "kernel.cpp"
     "platform.cpp"
+    "program.cpp"
     "queue.cpp"
     "ordered_queue.cpp"
     "sampler.cpp"

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -273,7 +273,7 @@ void program_impl::create_cl_program_with_il(OSModuleHandle M) {
 }
 
 void program_impl::create_cl_program_with_source(const string_class &Source) {
-  assert(!Program && "This program already has an encapsulated cl_program");
+  assert(!MProgram && "This program already has an encapsulated cl_program");
   const char *Src = Source.c_str();
   size_t Size = Source.size();
   PI_CALL(piclProgramCreateWithSource)(
@@ -379,7 +379,7 @@ void program_impl::throw_if_state_is_not(program_state State) const {
 
 void program_impl::create_pi_program_with_kernel_name(
     OSModuleHandle Module, const string_class &KernelName) {
-  assert(!Program && "This program already has an encapsulated PI program");
+  assert(!MProgram && "This program already has an encapsulated PI program");
   ProgramManager &PM = ProgramManager::getInstance();
   DeviceImage &Img = PM.getDeviceImage(Module, KernelName, get_context());
   MProgram = PM.createPIProgram(Img, get_context());

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -69,14 +69,14 @@ program_impl::program_impl(
       Programs.push_back(Prg->MProgram);
     }
     PI_CALL_THROW(piProgramLink, compile_program_error)(
-        MContext->getHandleRef(), Devices.size(),
-        Devices.data(), LinkOptions.c_str(), Programs.size(), Programs.data(),
-        nullptr, nullptr, &MProgram);
+        MContext->getHandleRef(), Devices.size(), Devices.data(),
+        LinkOptions.c_str(), Programs.size(), Programs.data(), nullptr, nullptr,
+        &MProgram);
   }
 }
 
 program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
-  : MProgram(Program), MContext(Context), MLinkable(true) {
+    : MProgram(Program), MContext(Context), MLinkable(true) {
 
   // TODO handle the case when cl_program build is in progress
   cl_uint NumDevices;
@@ -86,7 +86,8 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
   PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_DEVICES,
                             sizeof(RT::PiDevice) * NumDevices, PiDevices.data(),
                             nullptr);
-  vector_class<device> SyclContextDevices = MContext->get_info<info::context::devices>();
+  vector_class<device> SyclContextDevices =
+      MContext->get_info<info::context::devices>();
 
   // Keep only the subset of the devices (associated with context) that
   // were actually used to create the program.
@@ -212,9 +213,8 @@ void program_impl::link(string_class LinkOptions) {
     check_device_feature_support<info::device::is_linker_available>(MDevices);
     vector_class<RT::PiDevice> Devices(get_pi_devices());
     PI_CALL_THROW(piProgramLink, compile_program_error)(
-        MContext->getHandleRef(), Devices.size(),
-        Devices.data(), LinkOptions.c_str(), 1, &MProgram, nullptr, nullptr,
-        &MProgram);
+        MContext->getHandleRef(), Devices.size(), Devices.data(),
+        LinkOptions.c_str(), 1, &MProgram, nullptr, nullptr, &MProgram);
     MLinkOptions = LinkOptions;
     MBuildOptions = LinkOptions;
   }
@@ -271,9 +271,8 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
   assert(!MProgram && "This program already has an encapsulated cl_program");
   const char *Src = Source.c_str();
   size_t Size = Source.size();
-  PI_CALL(piclProgramCreateWithSource)(
-      MContext->getHandleRef(), 1, &Src, &Size,
-      &MProgram);
+  PI_CALL(piclProgramCreateWithSource)(MContext->getHandleRef(), 1, &Src, &Size,
+                                       &MProgram);
 }
 
 void program_impl::compile(const string_class &Options) {

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -23,32 +23,32 @@ program_impl::program_impl(const context &Context)
     : program_impl(Context, Context.get_devices()) {}
 
 program_impl::program_impl(const context &Context, vector_class<device> DeviceList)
-    : Context(Context), Devices(DeviceList) {}
+    : MContext(Context), MDevices(DeviceList) {}
 
 program_impl::program_impl(vector_class<std::shared_ptr<program_impl>> ProgramList,
              string_class LinkOptions)
-    : State(program_state::linked), LinkOptions(LinkOptions),
-      BuildOptions(LinkOptions) {
+    : MState(program_state::linked), MLinkOptions(LinkOptions),
+      MBuildOptions(LinkOptions) {
   // Verify arguments
   if (ProgramList.empty()) {
     throw runtime_error("Non-empty vector of programs expected");
   }
-  Context = ProgramList[0]->Context;
-  Devices = ProgramList[0]->Devices;
+  MContext = ProgramList[0]->MContext;
+  MDevices = ProgramList[0]->MDevices;
   std::vector<device> DevicesSorted;
   if (!is_host()) {
-    DevicesSorted = sort_devices_by_cl_device_id(Devices);
+    DevicesSorted = sort_devices_by_cl_device_id(MDevices);
   }
-  check_device_feature_support<info::device::is_linker_available>(Devices);
+  check_device_feature_support<info::device::is_linker_available>(MDevices);
   for (const auto &Prg : ProgramList) {
     Prg->throw_if_state_is_not(program_state::compiled);
-    if (Prg->Context != Context) {
+    if (Prg->MContext != MContext) {
       throw invalid_object_error(
           "Not all programs are associated with the same context");
     }
     if (!is_host()) {
       std::vector<device> PrgDevicesSorted =
-          sort_devices_by_cl_device_id(Prg->Devices);
+          sort_devices_by_cl_device_id(Prg->MDevices);
       if (PrgDevicesSorted != DevicesSorted) {
         throw invalid_object_error(
             "Not all programs are associated with the same devices");
@@ -61,20 +61,20 @@ program_impl::program_impl(vector_class<std::shared_ptr<program_impl>> ProgramLi
     vector_class<RT::PiProgram> Programs;
     bool NonInterOpToLink = false;
     for (const auto &Prg : ProgramList) {
-      if (!Prg->IsLinkable && NonInterOpToLink)
+      if (!Prg->MLinkable && NonInterOpToLink)
         continue;
-      NonInterOpToLink |= !Prg->IsLinkable;
-      Programs.push_back(Prg->Program);
+      NonInterOpToLink |= !Prg->MLinkable;
+      Programs.push_back(Prg->MProgram);
     }
     PI_CALL_THROW(piProgramLink, compile_program_error)(
-        Context->getHandleRef(), Devices.size(),
+        MContext->getHandleRef(), Devices.size(),
         Devices.data(), LinkOptions.c_str(), Programs.size(), Programs.data(),
-        nullptr, nullptr, &Program);
+        nullptr, nullptr, &MProgram);
   }
 }
 
 program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
-  : Program(Program), Context(Context), IsLinkable(true) {
+  : MProgram(Program), MContext(Context), MLinkable(true) {
 
   // TODO handle the case when cl_program build is in progress
   cl_uint NumDevices;
@@ -83,7 +83,7 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
   vector_class<RT::PiDevice> PiDevices(NumDevices);
   PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_DEVICES,
           sizeof(RT::PiDevice) * NumDevices, PiDevices.data(), nullptr);
-  vector_class<device> SyclContextDevices = Context.get_devices();
+  vector_class<device> SyclContextDevices = MContext.get_devices();
 
   // Keep only the subset of the devices (associated with context) that
   // were actually used to create the program.
@@ -96,8 +96,8 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
                          detail::getSyclObjImpl(Dev)->getHandleRef());
       });
   SyclContextDevices.erase(NewEnd, SyclContextDevices.end());
-  Devices = SyclContextDevices;
-  RT::PiDevice Device = getSyclObjImpl(Devices[0])->getHandleRef();
+  MDevices = SyclContextDevices;
+  RT::PiDevice Device = getSyclObjImpl(MDevices[0])->getHandleRef();
   // TODO check build for each device instead
   cl_program_binary_type BinaryType;
   PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BINARY_TYPE,
@@ -111,18 +111,18 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
   string_class Options(OptionsVector.begin(), OptionsVector.end());
   switch (BinaryType) {
   case CL_PROGRAM_BINARY_TYPE_NONE:
-    State = program_state::none;
+    MState = program_state::none;
     break;
   case CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT:
-    State = program_state::compiled;
-    CompileOptions = Options;
-    BuildOptions = Options;
+    MState = program_state::compiled;
+    MCompileOptions = Options;
+    MBuildOptions = Options;
     break;
   case CL_PROGRAM_BINARY_TYPE_LIBRARY:
   case CL_PROGRAM_BINARY_TYPE_EXECUTABLE:
-    State = program_state::linked;
-    LinkOptions = "";
-    BuildOptions = Options;
+    MState = program_state::linked;
+    MLinkOptions = "";
+    MBuildOptions = Options;
   }
   PI_CALL(piProgramRetain)(Program);
 }
@@ -134,8 +134,8 @@ program_impl::program_impl(ContextImplPtr &Context, RT::PiKernel Kernel)
 
 program_impl::~program_impl() {
   // TODO catch an exception and put it to list of asynchronous exceptions
-  if (!is_host() && Program != nullptr) {
-    PI_CALL(piProgramRelease)(Program);
+  if (!is_host() && MProgram != nullptr) {
+    PI_CALL(piProgramRelease)(MProgram);
   }
 }
 
@@ -144,20 +144,20 @@ cl_program program_impl::get() const {
   if (is_host()) {
     throw invalid_object_error("This instance of program is a host instance");
   }
-  PI_CALL(piProgramRetain)(Program);
-  return pi::cast<cl_program>(Program);
+  PI_CALL(piProgramRetain)(MProgram);
+  return pi::cast<cl_program>(MProgram);
 }
 
-void program_impl::compile_with_kernel_type(string_class KernelName,
+void program_impl::compile_with_kernel_name(string_class KernelName,
                                             string_class CompileOptions,
                                             OSModuleHandle M) {
   throw_if_state_is_not(program_state::none);
-  ProgramModuleHandle = M;
+  MProgramModuleHandle = M;
   if (!is_host()) {
     create_pi_program_with_kernel_name(M, KernelName);
     compile(CompileOptions);
   }
-  State = program_state::compiled;
+  MState = program_state::compiled;
 }
 
 void program_impl::compile_with_source(string_class KernelSource,
@@ -168,27 +168,27 @@ void program_impl::compile_with_source(string_class KernelSource,
     create_cl_program_with_source(KernelSource);
     compile(CompileOptions);
   }
-  State = program_state::compiled;
+  MState = program_state::compiled;
 }
 
-void program_impl::build_with_kernel_type(string_class KernelName,
+void program_impl::build_with_kernel_name(string_class KernelName,
                                           string_class BuildOptions,
-                                          OSModuleHandle M) {
+                                          OSModuleHandle Module) {
   throw_if_state_is_not(program_state::none);
-  ProgramModuleHandle = M;
+  MProgramModuleHandle = Module;
   if (!is_host()) {
     // If there are no build options, program can be safely cached
     if (is_cacheable_with_options(BuildOptions)) {
-      IsProgramAndKernelCachingAllowed = true;
-      Program = ProgramManager::getInstance().getBuiltPIProgram(
-          M, get_context(), KernelName);
-      PI_CALL(piProgramRetain)(Program);
+      MProgramAndKernelCachingAllowed = true;
+      MProgram = ProgramManager::getInstance().getBuiltPIProgram(
+          Module, get_context(), KernelName);
+      PI_CALL(piProgramRetain)(MProgram);
     } else {
-      create_pi_program_with_kernel_name(M, KernelName);
+      create_pi_program_with_kernel_name(Module, KernelName);
       build(BuildOptions);
     }
   }
-  State = program_state::linked;
+  MState = program_state::linked;
 }
 
 void program_impl::build_with_source(string_class KernelSource,
@@ -199,22 +199,22 @@ void program_impl::build_with_source(string_class KernelSource,
     create_cl_program_with_source(KernelSource);
     build(BuildOptions);
   }
-  State = program_state::linked;
+  MState = program_state::linked;
 }
 
 void program_impl::link(string_class LinkOptions) {
   throw_if_state_is_not(program_state::compiled);
   if (!is_host()) {
-    check_device_feature_support<info::device::is_linker_available>(Devices);
+    check_device_feature_support<info::device::is_linker_available>(MDevices);
     vector_class<RT::PiDevice> Devices(get_pi_devices());
     PI_CALL_THROW(piProgramLink, compile_program_error)(
-        Context->getHandleRef(), Devices.size(),
-        Devices.data(), LinkOptions.c_str(), 1, &Program, nullptr, nullptr,
-        &Program);
-    this->LinkOptions = LinkOptions;
-    BuildOptions = LinkOptions;
+        MContext->getHandleRef(), Devices.size(),
+        Devices.data(), LinkOptions.c_str(), 1, &MProgram, nullptr, nullptr,
+        &MProgram);
+    MLinkOptions = LinkOptions;
+    MBuildOptions = LinkOptions;
   }
-  State = program_state::linked;
+  MState = program_state::linked;
 }
 
 bool program_impl::has_kernel(string_class KernelName, bool IsCreatedFromSource) const {
@@ -234,10 +234,10 @@ kernel program_impl::get_kernel(string_class KernelName,
       throw invalid_object_error("This instance of program is a host instance");
 
     return createSyclObjFromImpl<kernel>(
-        std::make_shared<kernel_impl>(Context, PtrToSelf));
+        std::make_shared<kernel_impl>(MContext, PtrToSelf));
   }
   return createSyclObjFromImpl<kernel>(std::make_shared<kernel_impl>(
-      get_pi_kernel(KernelName), Context, PtrToSelf,
+      get_pi_kernel(KernelName), MContext, PtrToSelf,
       /*IsCreatedFromSource*/ IsCreatedFromSource));
 }
 
@@ -245,8 +245,8 @@ vector_class<vector_class<char>> program_impl::get_binaries() const {
   throw_if_state_is(program_state::none);
   vector_class<vector_class<char>> Result;
   if (!is_host()) {
-    vector_class<size_t> BinarySizes(Devices.size());
-    PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_BINARY_SIZES,
+    vector_class<size_t> BinarySizes(MDevices.size());
+    PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_BINARY_SIZES,
             sizeof(size_t) * BinarySizes.size(), BinarySizes.data(), nullptr);
 
     vector_class<char *> Pointers;
@@ -254,7 +254,7 @@ vector_class<vector_class<char>> program_impl::get_binaries() const {
       Result.emplace_back(BinarySizes[I]);
       Pointers.push_back(Result[I].data());
     }
-    PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_BINARIES,
+    PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_BINARIES,
             sizeof(char *) * Pointers.size(), Pointers.data(), nullptr);
   }
   return Result;
@@ -270,42 +270,42 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
   const char *Src = Source.c_str();
   size_t Size = Source.size();
   PI_CALL(piclProgramCreateWithSource)(
-      detail::getSyclObjImpl(Context)->getHandleRef(), 1, &Src, &Size,
-      &Program);
+      detail::getSyclObjImpl(MContext)->getHandleRef(), 1, &Src, &Size,
+      &MProgram);
 }
 
 void program_impl::compile(const string_class &Options) {
-  check_device_feature_support<info::device::is_compiler_available>(Devices);
+  check_device_feature_support<info::device::is_compiler_available>(MDevices);
   vector_class<RT::PiDevice> Devices(get_pi_devices());
   RT::PiResult Err = PI_CALL_NOCHECK(piProgramCompile)(
-      Program, Devices.size(), Devices.data(), Options.c_str(), 0, nullptr,
+      MProgram, Devices.size(), Devices.data(), Options.c_str(), 0, nullptr,
       nullptr, nullptr, nullptr);
 
   if (Err != PI_SUCCESS) {
     throw compile_program_error("Program compilation error:\n" +
-                                ProgramManager::getProgramBuildLog(Program));
+                                ProgramManager::getProgramBuildLog(MProgram));
   }
-  CompileOptions = Options;
-  BuildOptions = Options;
+  MCompileOptions = Options;
 }
 
 void program_impl::build(const string_class &Options) {
-  check_device_feature_support<info::device::is_compiler_available>(Devices);
+  check_device_feature_support<info::device::is_compiler_available>(MDevices);
   vector_class<RT::PiDevice> Devices(get_pi_devices());
   RT::PiResult Err =
-      PI_CALL_NOCHECK(piProgramBuild)(Program, Devices.size(), Devices.data(),
+      PI_CALL_NOCHECK(piProgramBuild)(MProgram, Devices.size(), Devices.data(),
                                       Options.c_str(), nullptr, nullptr);
 
   if (Err != PI_SUCCESS) {
     throw compile_program_error("Program build error:\n" +
-                                ProgramManager::getProgramBuildLog(Program));
+                                ProgramManager::getProgramBuildLog(MProgram));
   }
-  BuildOptions = Options;
+  MBuildOptions = Options;
+  MCompileOptions = Options;
 }
 
 vector_class<RT::PiDevice> program_impl::get_pi_devices() const {
   vector_class<RT::PiDevice> PiDevices;
-  for (const auto &Device : Devices) {
+  for (const auto &Device : MDevices) {
     PiDevices.push_back(getSyclObjImpl(Device)->getHandleRef());
   }
   return PiDevices;
@@ -313,10 +313,10 @@ vector_class<RT::PiDevice> program_impl::get_pi_devices() const {
 
 bool program_impl::has_cl_kernel(const string_class &KernelName) const {
   size_t Size;
-  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_KERNEL_NAMES, 0, nullptr,
+  PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_KERNEL_NAMES, 0, nullptr,
                             &Size);
   string_class ClResult(Size, ' ');
-  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_KERNEL_NAMES, ClResult.size(),
+  PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_KERNEL_NAMES, ClResult.size(),
                             &ClResult[0], nullptr);
   // Get rid of the null terminator
   ClResult.pop_back();
@@ -334,10 +334,10 @@ RT::PiKernel program_impl::get_pi_kernel(const string_class &KernelName) const {
 
   if (is_cacheable()) {
     Kernel = ProgramManager::getInstance().getOrCreateKernel(
-        ProgramModuleHandle, get_context(), KernelName);
+        MProgramModuleHandle, get_context(), KernelName);
   } else {
     RT::PiResult Err =
-        PI_CALL_NOCHECK(piKernelCreate)(Program, KernelName.c_str(), &Kernel);
+        PI_CALL_NOCHECK(piKernelCreate)(MProgram, KernelName.c_str(), &Kernel);
     if (Err == PI_RESULT_INVALID_KERNEL_NAME) {
       throw invalid_object_error(
           "This instance of program does not contain the kernel requested");
@@ -359,23 +359,23 @@ program_impl::sort_devices_by_cl_device_id(vector_class<device> Devices) {
 }
 
 void program_impl::throw_if_state_is(program_state State) const {
-  if (this->State == State) {
+  if (MState == State) {
     throw invalid_object_error("Invalid program state");
   }
 }
 
 void program_impl::throw_if_state_is_not(program_state State) const {
-  if (this->State != State) {
+  if (MState != State) {
     throw invalid_object_error("Invalid program state");
   }
 }
 
-void program_impl::create_pi_program_with_kernel_name(OSModuleHandle M,
+void program_impl::create_pi_program_with_kernel_name(OSModuleHandle Module,
                                         const string_class &KernelName) {
   assert(!Program && "This program already has an encapsulated PI program");
   ProgramManager &PM = ProgramManager::getInstance();
-  DeviceImage &Img = PM.getDeviceImage(M, KernelName, get_context());
-  Program = PM.createPIProgram(Img, get_context());
+  DeviceImage &Img = PM.getDeviceImage(Module, KernelName, get_context());
+  MProgram = PM.createPIProgram(Img, get_context());
 }
 
 template <>
@@ -383,10 +383,10 @@ cl_uint program_impl::get_info<info::program::reference_count>() const {
   if (is_host()) {
     throw invalid_object_error("This instance of program is a host instance");
   }
-  cl_uint result;
-  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_REFERENCE_COUNT,
-                            sizeof(cl_uint), &result, nullptr);
-  return result;
+  cl_uint Result;
+  PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_REFERENCE_COUNT,
+                            sizeof(cl_uint), &Result, nullptr);
+  return Result;
 }
 
 template <> context program_impl::get_info<info::program::context>() const {

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -149,10 +149,11 @@ cl_program program_impl::get() const {
 }
 
 void program_impl::compile_with_kernel_type(string_class KernelName,
-                              string_class CompileOptions) {
+                                            string_class CompileOptions,
+                                            OSModuleHandle M) {
   throw_if_state_is_not(program_state::none);
+  ProgramModuleHandle = M;
   if (!is_host()) {
-    OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
     create_pi_program_with_kernel_name(M, KernelName);
     compile(CompileOptions);
   }
@@ -171,10 +172,11 @@ void program_impl::compile_with_source(string_class KernelSource,
 }
 
 void program_impl::build_with_kernel_type(string_class KernelName,
-                              string_class BuildOptions) {
+                                          string_class BuildOptions,
+                                          OSModuleHandle M) {
   throw_if_state_is_not(program_state::none);
+  ProgramModuleHandle = M;
   if (!is_host()) {
-    OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
     // If there are no build options, program can be safely cached
     if (is_cacheable_with_options(BuildOptions)) {
       IsProgramAndKernelCachingAllowed = true;
@@ -331,10 +333,8 @@ RT::PiKernel program_impl::get_pi_kernel(const string_class &KernelName) const {
   RT::PiKernel Kernel;
 
   if (is_cacheable()) {
-    OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
-
-    Kernel = ProgramManager::getInstance().getOrCreateKernel(M, get_context(),
-                                                              KernelName);
+    Kernel = ProgramManager::getInstance().getOrCreateKernel(
+        ProgramModuleHandle, get_context(), KernelName);
   } else {
     RT::PiResult Err =
         PI_CALL_NOCHECK(piKernelCreate)(Program, KernelName.c_str(), &Kernel);

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -78,10 +78,10 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
 
   // TODO handle the case when cl_program build is in progress
   cl_uint NumDevices;
-  PI_CALL(RT::piProgramGetInfo)(Program, CL_PROGRAM_NUM_DEVICES,
+  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_NUM_DEVICES,
                                sizeof(cl_uint), &NumDevices, nullptr);
   vector_class<RT::PiDevice> PiDevices(NumDevices);
-  PI_CALL(RT::piProgramGetInfo)(Program, CL_PROGRAM_DEVICES,
+  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_DEVICES,
           sizeof(RT::PiDevice) * NumDevices, PiDevices.data(), nullptr);
   vector_class<device> SyclContextDevices = Context.get_devices();
 
@@ -100,13 +100,13 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
   RT::PiDevice Device = getSyclObjImpl(Devices[0])->getHandleRef();
   // TODO check build for each device instead
   cl_program_binary_type BinaryType;
-  PI_CALL(RT::piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BINARY_TYPE,
+  PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BINARY_TYPE,
           sizeof(cl_program_binary_type), &BinaryType, nullptr);
   size_t Size = 0;
-  PI_CALL(RT::piProgramGetBuildInfo)(Program, Device,
+  PI_CALL(piProgramGetBuildInfo)(Program, Device,
           CL_PROGRAM_BUILD_OPTIONS, 0, nullptr, &Size);
   std::vector<char> OptionsVector(Size);
-  PI_CALL(RT::piProgramGetBuildInfo)(Program, Device,
+  PI_CALL(piProgramGetBuildInfo)(Program, Device,
           CL_PROGRAM_BUILD_OPTIONS, Size, OptionsVector.data(), nullptr);
   string_class Options(OptionsVector.begin(), OptionsVector.end());
   switch (BinaryType) {
@@ -124,7 +124,7 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
     LinkOptions = "";
     BuildOptions = Options;
   }
-  PI_CALL(RT::piProgramRetain)(Program);
+  PI_CALL(piProgramRetain)(Program);
 }
 
 program_impl::program_impl(ContextImplPtr &Context, RT::PiKernel Kernel)
@@ -135,7 +135,7 @@ program_impl::program_impl(ContextImplPtr &Context, RT::PiKernel Kernel)
 program_impl::~program_impl() {
   // TODO catch an exception and put it to list of asynchronous exceptions
   if (!is_host() && Program != nullptr) {
-    PI_CALL(RT::piProgramRelease)(Program);
+    PI_CALL(piProgramRelease)(Program);
   }
 }
 
@@ -144,7 +144,7 @@ cl_program program_impl::get() const {
   if (is_host()) {
     throw invalid_object_error("This instance of program is a host instance");
   }
-  PI_CALL(RT::piProgramRetain)(Program);
+  PI_CALL(piProgramRetain)(Program);
   return pi::cast<cl_program>(Program);
 }
 
@@ -241,7 +241,7 @@ vector_class<vector_class<char>> program_impl::get_binaries() const {
   vector_class<vector_class<char>> Result;
   if (!is_host()) {
     vector_class<size_t> BinarySizes(Devices.size());
-    PI_CALL(RT::piProgramGetInfo)(Program, CL_PROGRAM_BINARY_SIZES,
+    PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_BINARY_SIZES,
             sizeof(size_t) * BinarySizes.size(), BinarySizes.data(), nullptr);
 
     vector_class<char *> Pointers;
@@ -249,7 +249,7 @@ vector_class<vector_class<char>> program_impl::get_binaries() const {
       Result.emplace_back(BinarySizes[I]);
       Pointers.push_back(Result[I].data());
     }
-    PI_CALL(RT::piProgramGetInfo)(Program, CL_PROGRAM_BINARIES,
+    PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_BINARIES,
             sizeof(char *) * Pointers.size(), Pointers.data(), nullptr);
   }
   return Result;

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -344,6 +344,8 @@ RT::PiKernel program_impl::get_pi_kernel(const string_class &KernelName) const {
     }
     RT::checkPiResult(Err);
   }
+
+  return Kernel;
 }
 
 std::vector<device>

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -228,6 +228,9 @@ kernel program_impl::get_kernel(string_class KernelName,
                   bool IsCreatedFromSource) const {
   throw_if_state_is(program_state::none);
   if (is_host()) {
+    if (IsCreatedFromSource)
+      throw invalid_object_error("This instance of program is a host instance");
+
     return createSyclObjFromImpl<kernel>(
         std::make_shared<kernel_impl>(Context, PtrToSelf));
   }

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -153,7 +153,7 @@ void program_impl::compile_with_kernel_type(string_class KernelName,
   throw_if_state_is_not(program_state::none);
   if (!is_host()) {
     OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
-    create_pi_program_with_kernel_name(M, KernelInfo<KernelT>::getName());
+    create_pi_program_with_kernel_name(M, KernelName);
     compile(CompileOptions);
   }
   State = program_state::compiled;
@@ -179,10 +179,10 @@ void program_impl::build_with_kernel_type(string_class KernelName,
     if (is_cacheable_with_options(BuildOptions)) {
       IsProgramAndKernelCachingAllowed = true;
       Program = ProgramManager::getInstance().getBuiltPIProgram(
-          M, get_context(), KernelInfo<KernelT>::getName());
+          M, get_context(), KernelName);
       PI_CALL(piProgramRetain)(Program);
     } else {
-      create_pi_program_with_kernel_name(M, KernelInfo<KernelT>::getName());
+      create_pi_program_with_kernel_name(M, KernelName);
       build(BuildOptions);
     }
   }
@@ -365,7 +365,7 @@ void program_impl::throw_if_state_is_not(program_state State) const {
   }
 }
 
-void pi_program::create_pi_program_with_kernel_name(OSModuleHandle M,
+void program_impl::create_pi_program_with_kernel_name(OSModuleHandle M,
                                         const string_class &KernelName) {
   assert(!Program && "This program already has an encapsulated PI program");
   ProgramManager &PM = ProgramManager::getInstance();

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -22,11 +22,13 @@ namespace detail {
 program_impl::program_impl(const context &Context)
     : program_impl(Context, Context.get_devices()) {}
 
-program_impl::program_impl(const context &Context, vector_class<device> DeviceList)
+program_impl::program_impl(const context &Context,
+                           vector_class<device> DeviceList)
     : MContext(Context), MDevices(DeviceList) {}
 
-program_impl::program_impl(vector_class<std::shared_ptr<program_impl>> ProgramList,
-             string_class LinkOptions)
+program_impl::program_impl(
+    vector_class<std::shared_ptr<program_impl>> ProgramList,
+    string_class LinkOptions)
     : MState(program_state::linked), MLinkOptions(LinkOptions),
       MBuildOptions(LinkOptions) {
   // Verify arguments
@@ -78,11 +80,12 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
 
   // TODO handle the case when cl_program build is in progress
   cl_uint NumDevices;
-  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_NUM_DEVICES,
-                               sizeof(cl_uint), &NumDevices, nullptr);
+  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_NUM_DEVICES, sizeof(cl_uint),
+                            &NumDevices, nullptr);
   vector_class<RT::PiDevice> PiDevices(NumDevices);
   PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_DEVICES,
-          sizeof(RT::PiDevice) * NumDevices, PiDevices.data(), nullptr);
+                            sizeof(RT::PiDevice) * NumDevices, PiDevices.data(),
+                            nullptr);
   vector_class<device> SyclContextDevices = MContext.get_devices();
 
   // Keep only the subset of the devices (associated with context) that
@@ -101,13 +104,14 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
   // TODO check build for each device instead
   cl_program_binary_type BinaryType;
   PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BINARY_TYPE,
-          sizeof(cl_program_binary_type), &BinaryType, nullptr);
+                                 sizeof(cl_program_binary_type), &BinaryType,
+                                 nullptr);
   size_t Size = 0;
-  PI_CALL(piProgramGetBuildInfo)(Program, Device,
-          CL_PROGRAM_BUILD_OPTIONS, 0, nullptr, &Size);
+  PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_OPTIONS, 0,
+                                 nullptr, &Size);
   std::vector<char> OptionsVector(Size);
-  PI_CALL(piProgramGetBuildInfo)(Program, Device,
-          CL_PROGRAM_BUILD_OPTIONS, Size, OptionsVector.data(), nullptr);
+  PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_OPTIONS,
+                                 Size, OptionsVector.data(), nullptr);
   string_class Options(OptionsVector.begin(), OptionsVector.end());
   switch (BinaryType) {
   case CL_PROGRAM_BINARY_TYPE_NONE:
@@ -161,7 +165,7 @@ void program_impl::compile_with_kernel_name(string_class KernelName,
 }
 
 void program_impl::compile_with_source(string_class KernelSource,
-                         string_class CompileOptions) {
+                                       string_class CompileOptions) {
   throw_if_state_is_not(program_state::none);
   // TODO should it throw if it's host?
   if (!is_host()) {
@@ -192,7 +196,7 @@ void program_impl::build_with_kernel_name(string_class KernelName,
 }
 
 void program_impl::build_with_source(string_class KernelSource,
-                       string_class BuildOptions) {
+                                     string_class BuildOptions) {
   throw_if_state_is_not(program_state::none);
   // TODO should it throw if it's host?
   if (!is_host()) {
@@ -217,7 +221,8 @@ void program_impl::link(string_class LinkOptions) {
   MState = program_state::linked;
 }
 
-bool program_impl::has_kernel(string_class KernelName, bool IsCreatedFromSource) const {
+bool program_impl::has_kernel(string_class KernelName,
+                              bool IsCreatedFromSource) const {
   throw_if_state_is(program_state::none);
   if (is_host()) {
     return !IsCreatedFromSource;
@@ -226,8 +231,8 @@ bool program_impl::has_kernel(string_class KernelName, bool IsCreatedFromSource)
 }
 
 kernel program_impl::get_kernel(string_class KernelName,
-                  std::shared_ptr<program_impl> PtrToSelf,
-                  bool IsCreatedFromSource) const {
+                                std::shared_ptr<program_impl> PtrToSelf,
+                                bool IsCreatedFromSource) const {
   throw_if_state_is(program_state::none);
   if (is_host()) {
     if (IsCreatedFromSource)
@@ -247,7 +252,8 @@ vector_class<vector_class<char>> program_impl::get_binaries() const {
   if (!is_host()) {
     vector_class<size_t> BinarySizes(MDevices.size());
     PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_BINARY_SIZES,
-            sizeof(size_t) * BinarySizes.size(), BinarySizes.data(), nullptr);
+                              sizeof(size_t) * BinarySizes.size(),
+                              BinarySizes.data(), nullptr);
 
     vector_class<char *> Pointers;
     for (size_t I = 0; I < BinarySizes.size(); ++I) {
@@ -255,7 +261,8 @@ vector_class<vector_class<char>> program_impl::get_binaries() const {
       Pointers.push_back(Result[I].data());
     }
     PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_BINARIES,
-            sizeof(char *) * Pointers.size(), Pointers.data(), nullptr);
+                              sizeof(char *) * Pointers.size(), Pointers.data(),
+                              nullptr);
   }
   return Result;
 }
@@ -370,8 +377,8 @@ void program_impl::throw_if_state_is_not(program_state State) const {
   }
 }
 
-void program_impl::create_pi_program_with_kernel_name(OSModuleHandle Module,
-                                        const string_class &KernelName) {
+void program_impl::create_pi_program_with_kernel_name(
+    OSModuleHandle Module, const string_class &KernelName) {
   assert(!Program && "This program already has an encapsulated PI program");
   ProgramManager &PM = ProgramManager::getInstance();
   DeviceImage &Img = PM.getDeviceImage(Module, KernelName, get_context());

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -27,7 +27,7 @@ program_impl::program_impl(const context &Context,
     : MContext(Context), MDevices(DeviceList) {}
 
 program_impl::program_impl(
-    vector_class<std::shared_ptr<program_impl>> ProgramList,
+    vector_class<shared_ptr_class<program_impl>> ProgramList,
     string_class LinkOptions)
     : MState(program_state::linked), MLinkOptions(LinkOptions),
       MBuildOptions(LinkOptions) {
@@ -37,7 +37,7 @@ program_impl::program_impl(
   }
   MContext = ProgramList[0]->MContext;
   MDevices = ProgramList[0]->MDevices;
-  std::vector<device> DevicesSorted;
+  vector_class<device> DevicesSorted;
   if (!is_host()) {
     DevicesSorted = sort_devices_by_cl_device_id(MDevices);
   }
@@ -49,7 +49,7 @@ program_impl::program_impl(
           "Not all programs are associated with the same context");
     }
     if (!is_host()) {
-      std::vector<device> PrgDevicesSorted =
+      vector_class<device> PrgDevicesSorted =
           sort_devices_by_cl_device_id(Prg->MDevices);
       if (PrgDevicesSorted != DevicesSorted) {
         throw invalid_object_error(
@@ -231,7 +231,7 @@ bool program_impl::has_kernel(string_class KernelName,
 }
 
 kernel program_impl::get_kernel(string_class KernelName,
-                                std::shared_ptr<program_impl> PtrToSelf,
+                                shared_ptr_class<program_impl> PtrToSelf,
                                 bool IsCreatedFromSource) const {
   throw_if_state_is(program_state::none);
   if (is_host()) {
@@ -355,7 +355,7 @@ RT::PiKernel program_impl::get_pi_kernel(const string_class &KernelName) const {
   return Kernel;
 }
 
-std::vector<device>
+vector_class<device>
 program_impl::sort_devices_by_cl_device_id(vector_class<device> Devices) {
   std::sort(Devices.begin(), Devices.end(),
             [](const device &id1, const device &id2) {

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -6,11 +6,373 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/detail/program_impl.hpp>
+#include <CL/sycl/kernel.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <memory>
 
 namespace cl {
 namespace sycl {
 namespace detail {
+
+program_impl::program_impl(const context &Context)
+    : program_impl(Context, Context.get_devices()) {}
+
+program_impl::program_impl(const context &Context, vector_class<device> DeviceList)
+    : Context(Context), Devices(DeviceList) {}
+
+program_impl::program_impl(vector_class<std::shared_ptr<program_impl>> ProgramList,
+             string_class LinkOptions)
+    : State(program_state::linked), LinkOptions(LinkOptions),
+      BuildOptions(LinkOptions) {
+  // Verify arguments
+  if (ProgramList.empty()) {
+    throw runtime_error("Non-empty vector of programs expected");
+  }
+  Context = ProgramList[0]->Context;
+  Devices = ProgramList[0]->Devices;
+  std::vector<device> DevicesSorted;
+  if (!is_host()) {
+    DevicesSorted = sort_devices_by_cl_device_id(Devices);
+  }
+  check_device_feature_support<info::device::is_linker_available>(Devices);
+  for (const auto &Prg : ProgramList) {
+    Prg->throw_if_state_is_not(program_state::compiled);
+    if (Prg->Context != Context) {
+      throw invalid_object_error(
+          "Not all programs are associated with the same context");
+    }
+    if (!is_host()) {
+      std::vector<device> PrgDevicesSorted =
+          sort_devices_by_cl_device_id(Prg->Devices);
+      if (PrgDevicesSorted != DevicesSorted) {
+        throw invalid_object_error(
+            "Not all programs are associated with the same devices");
+      }
+    }
+  }
+
+  if (!is_host()) {
+    vector_class<RT::PiDevice> Devices(get_pi_devices());
+    vector_class<RT::PiProgram> Programs;
+    bool NonInterOpToLink = false;
+    for (const auto &Prg : ProgramList) {
+      if (!Prg->IsLinkable && NonInterOpToLink)
+        continue;
+      NonInterOpToLink |= !Prg->IsLinkable;
+      Programs.push_back(Prg->Program);
+    }
+    PI_CALL_THROW(piProgramLink, compile_program_error)(
+        Context->getHandleRef(), Devices.size(),
+        Devices.data(), LinkOptions.c_str(), Programs.size(), Programs.data(),
+        nullptr, nullptr, &Program);
+  }
+}
+
+program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
+  : Program(Program), Context(Context), IsLinkable(true) {
+
+  // TODO handle the case when cl_program build is in progress
+  cl_uint NumDevices;
+  PI_CALL(RT::piProgramGetInfo)(Program, CL_PROGRAM_NUM_DEVICES,
+                               sizeof(cl_uint), &NumDevices, nullptr);
+  vector_class<RT::PiDevice> PiDevices(NumDevices);
+  PI_CALL(RT::piProgramGetInfo)(Program, CL_PROGRAM_DEVICES,
+          sizeof(RT::PiDevice) * NumDevices, PiDevices.data(), nullptr);
+  vector_class<device> SyclContextDevices = Context.get_devices();
+
+  // Keep only the subset of the devices (associated with context) that
+  // were actually used to create the program.
+  // This is possible when clCreateProgramWithBinary is used.
+  auto NewEnd = std::remove_if(
+      SyclContextDevices.begin(), SyclContextDevices.end(),
+      [&PiDevices](const sycl::device &Dev) {
+        return PiDevices.end() ==
+               std::find(PiDevices.begin(), PiDevices.end(),
+                         detail::getSyclObjImpl(Dev)->getHandleRef());
+      });
+  SyclContextDevices.erase(NewEnd, SyclContextDevices.end());
+  Devices = SyclContextDevices;
+  RT::PiDevice Device = getSyclObjImpl(Devices[0])->getHandleRef();
+  // TODO check build for each device instead
+  cl_program_binary_type BinaryType;
+  PI_CALL(RT::piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BINARY_TYPE,
+          sizeof(cl_program_binary_type), &BinaryType, nullptr);
+  size_t Size = 0;
+  PI_CALL(RT::piProgramGetBuildInfo)(Program, Device,
+          CL_PROGRAM_BUILD_OPTIONS, 0, nullptr, &Size);
+  std::vector<char> OptionsVector(Size);
+  PI_CALL(RT::piProgramGetBuildInfo)(Program, Device,
+          CL_PROGRAM_BUILD_OPTIONS, Size, OptionsVector.data(), nullptr);
+  string_class Options(OptionsVector.begin(), OptionsVector.end());
+  switch (BinaryType) {
+  case CL_PROGRAM_BINARY_TYPE_NONE:
+    State = program_state::none;
+    break;
+  case CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT:
+    State = program_state::compiled;
+    CompileOptions = Options;
+    BuildOptions = Options;
+    break;
+  case CL_PROGRAM_BINARY_TYPE_LIBRARY:
+  case CL_PROGRAM_BINARY_TYPE_EXECUTABLE:
+    State = program_state::linked;
+    LinkOptions = "";
+    BuildOptions = Options;
+  }
+  PI_CALL(RT::piProgramRetain)(Program);
+}
+
+program_impl::program_impl(ContextImplPtr &Context, RT::PiKernel Kernel)
+    : program_impl(
+          Context,
+          ProgramManager::getInstance().getClProgramFromClKernel(Kernel)) {}
+
+program_impl::~program_impl() {
+  // TODO catch an exception and put it to list of asynchronous exceptions
+  if (!is_host() && Program != nullptr) {
+    PI_CALL(RT::piProgramRelease)(Program);
+  }
+}
+
+cl_program program_impl::get() const {
+  throw_if_state_is(program_state::none);
+  if (is_host()) {
+    throw invalid_object_error("This instance of program is a host instance");
+  }
+  PI_CALL(RT::piProgramRetain)(Program);
+  return pi::cast<cl_program>(Program);
+}
+
+void program_impl::compile_with_kernel_type(string_class KernelName,
+                              string_class CompileOptions) {
+  throw_if_state_is_not(program_state::none);
+  if (!is_host()) {
+    OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
+    create_pi_program_with_kernel_name(M, KernelInfo<KernelT>::getName());
+    compile(CompileOptions);
+  }
+  State = program_state::compiled;
+}
+
+void program_impl::compile_with_source(string_class KernelSource,
+                         string_class CompileOptions) {
+  throw_if_state_is_not(program_state::none);
+  // TODO should it throw if it's host?
+  if (!is_host()) {
+    create_cl_program_with_source(KernelSource);
+    compile(CompileOptions);
+  }
+  State = program_state::compiled;
+}
+
+void program_impl::build_with_kernel_type(string_class KernelName,
+                              string_class BuildOptions) {
+  throw_if_state_is_not(program_state::none);
+  if (!is_host()) {
+    OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
+    // If there are no build options, program can be safely cached
+    if (is_cacheable_with_options(BuildOptions)) {
+      IsProgramAndKernelCachingAllowed = true;
+      Program = ProgramManager::getInstance().getBuiltPIProgram(
+          M, get_context(), KernelInfo<KernelT>::getName());
+      PI_CALL(piProgramRetain)(Program);
+    } else {
+      create_pi_program_with_kernel_name(M, KernelInfo<KernelT>::getName());
+      build(BuildOptions);
+    }
+  }
+  State = program_state::linked;
+}
+
+void program_impl::build_with_source(string_class KernelSource,
+                       string_class BuildOptions) {
+  throw_if_state_is_not(program_state::none);
+  // TODO should it throw if it's host?
+  if (!is_host()) {
+    create_cl_program_with_source(KernelSource);
+    build(BuildOptions);
+  }
+  State = program_state::linked;
+}
+
+void program_impl::link(string_class LinkOptions) {
+  throw_if_state_is_not(program_state::compiled);
+  if (!is_host()) {
+    check_device_feature_support<info::device::is_linker_available>(Devices);
+    vector_class<RT::PiDevice> Devices(get_pi_devices());
+    PI_CALL_THROW(piProgramLink, compile_program_error)(
+        Context->getHandleRef(), Devices.size(),
+        Devices.data(), LinkOptions.c_str(), 1, &Program, nullptr, nullptr,
+        &Program);
+    this->LinkOptions = LinkOptions;
+    BuildOptions = LinkOptions;
+  }
+  State = program_state::linked;
+}
+
+bool program_impl::has_kernel(string_class KernelName, bool IsCreatedFromSource) const {
+  throw_if_state_is(program_state::none);
+  if (is_host()) {
+    return !IsCreatedFromSource;
+  }
+  return has_cl_kernel(KernelName);
+}
+
+kernel program_impl::get_kernel(string_class KernelName,
+                  std::shared_ptr<program_impl> PtrToSelf,
+                  bool IsCreatedFromSource) const {
+  throw_if_state_is(program_state::none);
+  if (is_host()) {
+    return createSyclObjFromImpl<kernel>(
+        std::make_shared<kernel_impl>(Context, PtrToSelf));
+  }
+  return createSyclObjFromImpl<kernel>(std::make_shared<kernel_impl>(
+      get_pi_kernel(KernelName), Context, PtrToSelf,
+      /*IsCreatedFromSource*/ IsCreatedFromSource));
+}
+
+vector_class<vector_class<char>> program_impl::get_binaries() const {
+  throw_if_state_is(program_state::none);
+  vector_class<vector_class<char>> Result;
+  if (!is_host()) {
+    vector_class<size_t> BinarySizes(Devices.size());
+    PI_CALL(RT::piProgramGetInfo)(Program, CL_PROGRAM_BINARY_SIZES,
+            sizeof(size_t) * BinarySizes.size(), BinarySizes.data(), nullptr);
+
+    vector_class<char *> Pointers;
+    for (size_t I = 0; I < BinarySizes.size(); ++I) {
+      Result.emplace_back(BinarySizes[I]);
+      Pointers.push_back(Result[I].data());
+    }
+    PI_CALL(RT::piProgramGetInfo)(Program, CL_PROGRAM_BINARIES,
+            sizeof(char *) * Pointers.size(), Pointers.data(), nullptr);
+  }
+  return Result;
+}
+
+void program_impl::create_cl_program_with_il(OSModuleHandle M) {
+  assert(!Program && "This program already has an encapsulated PI program");
+  Program = ProgramManager::getInstance().createOpenCLProgram(M, get_context());
+}
+
+void program_impl::create_cl_program_with_source(const string_class &Source) {
+  assert(!Program && "This program already has an encapsulated cl_program");
+  const char *Src = Source.c_str();
+  size_t Size = Source.size();
+  PI_CALL(piclProgramCreateWithSource)(
+      detail::getSyclObjImpl(Context)->getHandleRef(), 1, &Src, &Size,
+      &Program);
+}
+
+void program_impl::compile(const string_class &Options) {
+  check_device_feature_support<info::device::is_compiler_available>(Devices);
+  vector_class<RT::PiDevice> Devices(get_pi_devices());
+  RT::PiResult Err = PI_CALL_NOCHECK(piProgramCompile)(
+      Program, Devices.size(), Devices.data(), Options.c_str(), 0, nullptr,
+      nullptr, nullptr, nullptr);
+
+  if (Err != PI_SUCCESS) {
+    throw compile_program_error("Program compilation error:\n" +
+                                ProgramManager::getProgramBuildLog(Program));
+  }
+  CompileOptions = Options;
+  BuildOptions = Options;
+}
+
+void program_impl::build(const string_class &Options) {
+  check_device_feature_support<info::device::is_compiler_available>(Devices);
+  vector_class<RT::PiDevice> Devices(get_pi_devices());
+  RT::PiResult Err =
+      PI_CALL_NOCHECK(piProgramBuild)(Program, Devices.size(), Devices.data(),
+                                      Options.c_str(), nullptr, nullptr);
+
+  if (Err != PI_SUCCESS) {
+    throw compile_program_error("Program build error:\n" +
+                                ProgramManager::getProgramBuildLog(Program));
+  }
+  BuildOptions = Options;
+}
+
+vector_class<RT::PiDevice> program_impl::get_pi_devices() const {
+  vector_class<RT::PiDevice> PiDevices;
+  for (const auto &Device : Devices) {
+    PiDevices.push_back(getSyclObjImpl(Device)->getHandleRef());
+  }
+  return PiDevices;
+}
+
+bool program_impl::has_cl_kernel(const string_class &KernelName) const {
+  size_t Size;
+  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_KERNEL_NAMES, 0, nullptr,
+                            &Size);
+  string_class ClResult(Size, ' ');
+  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_KERNEL_NAMES, ClResult.size(),
+                            &ClResult[0], nullptr);
+  // Get rid of the null terminator
+  ClResult.pop_back();
+  vector_class<string_class> KernelNames(split_string(ClResult, ';'));
+  for (const auto &Name : KernelNames) {
+    if (Name == KernelName) {
+      return true;
+    }
+  }
+  return false;
+}
+
+RT::PiKernel program_impl::get_pi_kernel(const string_class &KernelName) const {
+  RT::PiKernel Kernel;
+
+  if (is_cacheable()) {
+    OSModuleHandle M = OSUtil::getOSModuleHandle(AddressInThisModule);
+
+    Kernel = ProgramManager::getInstance().getOrCreateKernel(M, get_context(),
+                                                              KernelName);
+  } else {
+    RT::PiResult Err =
+        PI_CALL_NOCHECK(piKernelCreate)(Program, KernelName.c_str(), &Kernel);
+    if (Err == PI_RESULT_INVALID_KERNEL_NAME) {
+      throw invalid_object_error(
+          "This instance of program does not contain the kernel requested");
+    }
+    RT::checkPiResult(Err);
+  }
+}
+
+std::vector<device>
+program_impl::sort_devices_by_cl_device_id(vector_class<device> Devices) {
+  std::sort(Devices.begin(), Devices.end(),
+            [](const device &id1, const device &id2) {
+              return (detail::getSyclObjImpl(id1)->getHandleRef() <
+                      detail::getSyclObjImpl(id2)->getHandleRef());
+            });
+  return Devices;
+}
+
+void program_impl::throw_if_state_is(program_state State) const {
+  if (this->State == State) {
+    throw invalid_object_error("Invalid program state");
+  }
+}
+
+void program_impl::throw_if_state_is_not(program_state State) const {
+  if (this->State != State) {
+    throw invalid_object_error("Invalid program state");
+  }
+}
+
+void pi_program::create_pi_program_with_kernel_name(OSModuleHandle M,
+                                        const string_class &KernelName) {
+  assert(!Program && "This program already has an encapsulated PI program");
+  ProgramManager &PM = ProgramManager::getInstance();
+  DeviceImage &Img = PM.getDeviceImage(M, KernelName, get_context());
+  Program = PM.createPIProgram(Img, get_context());
+}
+
 template <>
 cl_uint program_impl::get_info<info::program::reference_count>() const {
   if (is_host()) {

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -51,11 +51,19 @@ void program::build_with_source(string_class kernelSource,
 void program::link(string_class linkOptions) { impl->link(linkOptions); }
 
 bool program::has_kernel(string_class kernelName) const {
-  return impl->has_kernel(kernelName);
+  return has_kernel(kernelName, /*IsCreatedFromSource*/ true);
+}
+
+bool program::has_kernel(string_class kernelName, bool IsCreatedFromSource) const {
+  return impl->has_kernel(kernelName, IsCreatedFromSource);
 }
 
 kernel program::get_kernel(string_class kernelName) const {
-  return impl->get_kernel(kernelName, impl);
+  return get_kernel(kernelName, /*IsCreatedFromSource*/ true);
+}
+
+kernel program::get_kernel(string_class kernelName, bool IsCreatedFromSource) const {
+  return impl->get_kernel(kernelName, impl, IsCreatedFromSource);
 }
 
 template <info::program param>

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -15,9 +15,11 @@ namespace cl {
 namespace sycl {
 
 program::program(const context &context)
-    : impl(std::make_shared<detail::program_impl>(detail::getSyclObjImpl(context))) {}
+    : impl(std::make_shared<detail::program_impl>(
+          detail::getSyclObjImpl(context))) {}
 program::program(const context &context, vector_class<device> deviceList)
-    : impl(std::make_shared<detail::program_impl>(detail::getSyclObjImpl(context), deviceList)) {}
+    : impl(std::make_shared<detail::program_impl>(
+          detail::getSyclObjImpl(context), deviceList)) {}
 program::program(vector_class<program> programList, string_class linkOptions) {
   std::vector<std::shared_ptr<detail::program_impl>> impls;
   for (auto &x : programList) {
@@ -27,7 +29,8 @@ program::program(vector_class<program> programList, string_class linkOptions) {
 }
 program::program(const context &context, cl_program clProgram)
     : impl(std::make_shared<detail::program_impl>(
-           detail::getSyclObjImpl(context), detail::pi::cast<detail::RT::PiProgram>(clProgram))) {}
+          detail::getSyclObjImpl(context),
+          detail::pi::cast<detail::RT::PiProgram>(clProgram))) {}
 program::program(std::shared_ptr<detail::program_impl> impl) : impl(impl) {}
 
 cl_program program::get() const { return impl->get(); }

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -48,6 +48,16 @@ void program::build_with_source(string_class kernelSource,
   impl->build_with_source(kernelSource, buildOptions);
 }
 
+void program::compile_with_kernel_type(string_class KernelName,
+                                       string_class compileOptions) {
+    impl->compile_with_kernel_type(KernelName, compileOptions);
+}
+
+void program::build_with_kernel_type(string_class KernelName,
+                                     string_class buildOptions) {
+    impl->build_with_kernel_type(KernelName, buildOptions);
+}
+
 void program::link(string_class linkOptions) { impl->link(linkOptions); }
 
 bool program::has_kernel(string_class kernelName) const {

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -30,10 +30,6 @@ program::program(const context &context, cl_program clProgram)
            detail::getSyclObjImpl(context), detail::pi::cast<detail::RT::PiProgram>(clProgram))) {}
 program::program(std::shared_ptr<detail::program_impl> impl) : impl(impl) {}
 
-bool program::operator==(const program &rhs) const { return impl == rhs.impl; }
-
-bool program::operator!=(const program &rhs) const { return !operator==(rhs); }
-
 cl_program program::get() const { return impl->get(); }
 
 bool program::is_host() const { return impl->is_host(); }
@@ -48,16 +44,16 @@ void program::build_with_source(string_class kernelSource,
   impl->build_with_source(kernelSource, buildOptions);
 }
 
-void program::compile_with_kernel_type(string_class KernelName,
+void program::compile_with_kernel_name(string_class KernelName,
                                        string_class compileOptions,
                                        detail::OSModuleHandle M) {
-  impl->compile_with_kernel_type(KernelName, compileOptions, M);
+  impl->compile_with_kernel_name(KernelName, compileOptions, M);
 }
 
-void program::build_with_kernel_type(string_class KernelName,
+void program::build_with_kernel_name(string_class KernelName,
                                      string_class buildOptions,
                                      detail::OSModuleHandle M) {
-  impl->build_with_kernel_type(KernelName, buildOptions, M);
+  impl->build_with_kernel_name(KernelName, buildOptions, M);
 }
 
 void program::link(string_class linkOptions) { impl->link(linkOptions); }

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -49,13 +49,15 @@ void program::build_with_source(string_class kernelSource,
 }
 
 void program::compile_with_kernel_type(string_class KernelName,
-                                       string_class compileOptions) {
-    impl->compile_with_kernel_type(KernelName, compileOptions);
+                                       string_class compileOptions,
+                                       detail::OSModuleHandle M) {
+  impl->compile_with_kernel_type(KernelName, compileOptions, M);
 }
 
 void program::build_with_kernel_type(string_class KernelName,
-                                     string_class buildOptions) {
-    impl->build_with_kernel_type(KernelName, buildOptions);
+                                     string_class buildOptions,
+                                     detail::OSModuleHandle M) {
+  impl->build_with_kernel_type(KernelName, buildOptions, M);
 }
 
 void program::link(string_class linkOptions) { impl->link(linkOptions); }

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -1,0 +1,92 @@
+//==--------------- program.cpp --- SYCL program ---------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl/program.hpp>
+#include <CL/sycl/detail/program_impl.hpp>
+
+#include <vector>
+
+namespace cl {
+namespace sycl {
+
+program::program(const context &context)
+    : impl(std::make_shared<detail::program_impl>(detail::getSyclObjImpl(context))) {}
+program::program(const context &context, vector_class<device> deviceList)
+    : impl(std::make_shared<detail::program_impl>(detail::getSyclObjImpl(context), deviceList)) {}
+program::program(vector_class<program> programList, string_class linkOptions) {
+  std::vector<std::shared_ptr<detail::program_impl>> impls;
+  for (auto &x : programList) {
+    impls.push_back(detail::getSyclObjImpl(x));
+  }
+  impl = std::make_shared<detail::program_impl>(impls, linkOptions);
+}
+program::program(const context &context, cl_program clProgram)
+    : impl(std::make_shared<detail::program_impl>(
+           detail::getSyclObjImpl(context), detail::pi::cast<detail::RT::PiProgram>(clProgram))) {}
+program::program(std::shared_ptr<detail::program_impl> impl) : impl(impl) {}
+
+bool program::operator==(const program &rhs) const { return impl == rhs.impl; }
+
+bool program::operator!=(const program &rhs) const { return !operator==(rhs); }
+
+cl_program program::get() const { return impl->get(); }
+
+bool program::is_host() const { return impl->is_host(); }
+
+void program::compile_with_source(string_class kernelSource,
+                        string_class compileOptions) {
+  impl->compile_with_source(kernelSource, compileOptions);
+}
+
+void program::build_with_source(string_class kernelSource,
+                        string_class buildOptions) {
+  impl->build_with_source(kernelSource, buildOptions);
+}
+
+void program::link(string_class linkOptions) { impl->link(linkOptions); }
+
+bool program::has_kernel(string_class kernelName) const {
+  return impl->has_kernel(kernelName);
+}
+
+kernel program::get_kernel(string_class kernelName) const {
+  return impl->get_kernel(kernelName, impl);
+}
+
+template <info::program param>
+typename info::param_traits<info::program, param>::return_type
+program::get_info() const {
+  return impl->get_info<param>();
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
+  template ret_type program::get_info<info::param_type::param>() const;
+
+#include <CL/sycl/info/program_traits.def>
+
+#undef PARAM_TRAITS_SPEC
+
+vector_class<vector_class<char>> program::get_binaries() const {
+  return impl->get_binaries();
+}
+
+context program::get_context() const { return impl->get_context(); }
+
+vector_class<device> program::get_devices() const { return impl->get_devices(); }
+
+string_class program::get_compile_options() const {
+  return impl->get_compile_options();
+}
+
+string_class program::get_link_options() const { return impl->get_link_options(); }
+
+string_class program::get_build_options() const { return impl->get_build_options(); }
+
+program_state program::get_state() const { return impl->get_state(); }
+}
+}

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl/program.hpp>
 #include <CL/sycl/detail/program_impl.hpp>
+#include <CL/sycl/program.hpp>
 
 #include <vector>
 
@@ -35,12 +35,12 @@ cl_program program::get() const { return impl->get(); }
 bool program::is_host() const { return impl->is_host(); }
 
 void program::compile_with_source(string_class kernelSource,
-                        string_class compileOptions) {
+                                  string_class compileOptions) {
   impl->compile_with_source(kernelSource, compileOptions);
 }
 
 void program::build_with_source(string_class kernelSource,
-                        string_class buildOptions) {
+                                string_class buildOptions) {
   impl->build_with_source(kernelSource, buildOptions);
 }
 
@@ -62,7 +62,8 @@ bool program::has_kernel(string_class kernelName) const {
   return has_kernel(kernelName, /*IsCreatedFromSource*/ true);
 }
 
-bool program::has_kernel(string_class kernelName, bool IsCreatedFromSource) const {
+bool program::has_kernel(string_class kernelName,
+                         bool IsCreatedFromSource) const {
   return impl->has_kernel(kernelName, IsCreatedFromSource);
 }
 
@@ -70,7 +71,8 @@ kernel program::get_kernel(string_class kernelName) const {
   return get_kernel(kernelName, /*IsCreatedFromSource*/ true);
 }
 
-kernel program::get_kernel(string_class kernelName, bool IsCreatedFromSource) const {
+kernel program::get_kernel(string_class kernelName,
+                           bool IsCreatedFromSource) const {
   return impl->get_kernel(kernelName, impl, IsCreatedFromSource);
 }
 
@@ -80,7 +82,7 @@ program::get_info() const {
   return impl->get_info<param>();
 }
 
-#define PARAM_TRAITS_SPEC(param_type, param, ret_type) \
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
   template ret_type program::get_info<info::param_type::param>() const;
 
 #include <CL/sycl/info/program_traits.def>
@@ -93,16 +95,22 @@ vector_class<vector_class<char>> program::get_binaries() const {
 
 context program::get_context() const { return impl->get_context(); }
 
-vector_class<device> program::get_devices() const { return impl->get_devices(); }
+vector_class<device> program::get_devices() const {
+  return impl->get_devices();
+}
 
 string_class program::get_compile_options() const {
   return impl->get_compile_options();
 }
 
-string_class program::get_link_options() const { return impl->get_link_options(); }
+string_class program::get_link_options() const {
+  return impl->get_link_options();
+}
 
-string_class program::get_build_options() const { return impl->get_build_options(); }
+string_class program::get_build_options() const {
+  return impl->get_build_options();
+}
 
 program_state program::get_state() const { return impl->get_state(); }
-}
-}
+} // namespace sycl
+} // namespace cl


### PR DESCRIPTION
This patch is a part of effort to decouple SYCL Runtime library
interface from its actual implementation. The goal is to improve
SYCL ABI/API compatibility between different versions of library.

The following modifications were applied to program and program_impl
classes:

1. Removed include of program_impl header from program.hpp and replaced
it with forward declaration.
2. Move member function implementations from program.hpp to program.cpp
3. std::shared_ptr was replaced with shared_ptr_class for program class
4. Documentation was improved for both program and program_impl
5. program_impl now tries to follow LLVM code style
6. program_impl now uses string kernel name instead of kernel type

Applying aforementioned changes requires modifying other header files.
While some of those may seem as a regression, affected classes will be
covered by future patches.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>