### PR TITLE
[SYCL][NFC] Use Impl objects instead of SYCL objects

### DIFF
--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -122,6 +122,9 @@ public:
   vector_class<device> get_devices() const;
 
 private:
+  /// Constructs a SYCL context object from a valid context_impl instance.
+  context(shared_ptr_class<detail::context_impl> Impl);
+
   shared_ptr_class<detail::context_impl> impl;
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
@@ -130,6 +133,9 @@ private:
   friend
       typename std::add_pointer<typename decltype(T::impl)::element_type>::type
       detail::getRawSyclObjImpl(const T &SyclObject);
+
+  template <class T>
+  friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 };
 
 } // namespace sycl

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -11,10 +11,10 @@
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/platform_impl.hpp>
 #include <CL/sycl/detail/usm_dispatch.hpp>
 #include <CL/sycl/exception_list.hpp>
 #include <CL/sycl/info/info_desc.hpp>
-#include <CL/sycl/platform.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <map>
@@ -25,6 +25,7 @@ namespace sycl {
 // Forward declaration
 class device;
 namespace detail {
+using PlatformImplPtr = std::shared_ptr<detail::platform_impl>;
 class context_impl {
 public:
   /// Constructs a context_impl using a single SYCL devices.
@@ -125,7 +126,7 @@ private:
   async_handler MAsyncHandler;
   vector_class<device> MDevices;
   RT::PiContext MContext;
-  platform MPlatform;
+  PlatformImplPtr MPlatform;
   bool MPluginInterop;
   bool MHostContext;
   std::map<KernelSetId, RT::PiProgram> MCachedPrograms;

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/device.hpp>
@@ -26,6 +26,8 @@ class program;
 namespace detail {
 class program_impl;
 
+using ContextImplPtr = std::shared_ptr<detail::context_impl>;
+using ProgramImplPtr = std::shared_ptr<program_impl>;
 class kernel_impl {
 public:
   /// Constructs a SYCL kernel instance from a PiKernel
@@ -36,7 +38,7 @@ public:
   ///
   /// @param Kernel is a valid PiKernel instance
   /// @param SyclContext is a valid SYCL context
-  kernel_impl(RT::PiKernel Kernel, const context &SyclContext);
+  kernel_impl(RT::PiKernel Kernel, ContextImplPtr Context);
 
   /// Constructs a SYCL kernel instance from a SYCL program and a PiKernel
   ///
@@ -50,16 +52,16 @@ public:
   /// @param ProgramImpl is a valid instance of program_impl
   /// @param IsCreatedFromSource is a flag that indicates whether program
   /// is created from source code
-  kernel_impl(RT::PiKernel Kernel, const context &SyclContext,
-              std::shared_ptr<program_impl> ProgramImpl,
+  kernel_impl(RT::PiKernel Kernel, ContextImplPtr ContextImpl,
+              ProgramImplPtr ProgramImpl,
               bool IsCreatedFromSource);
 
   /// Constructs a SYCL kernel for host device
   ///
   /// @param SyclContext is a valid SYCL context
   /// @param ProgramImpl is a valid instance of program_impl
-  kernel_impl(const context &SyclContext,
-              std::shared_ptr<program_impl> ProgramImpl);
+  kernel_impl(ContextImplPtr Context,
+              ProgramImplPtr ProgramImpl);
 
   ~kernel_impl();
 
@@ -80,7 +82,7 @@ public:
   /// Check if the associated SYCL context is a SYCL host context.
   ///
   /// @return true if this SYCL kernel is a host kernel.
-  bool is_host() const { return MContext.is_host(); }
+  bool is_host() const { return MContext->is_host(); }
 
   /// Query information from the kernel object using the info::kernel_info
   /// descriptor.
@@ -138,8 +140,8 @@ public:
 
 private:
   RT::PiKernel MKernel;
-  context MContext;
-  std::shared_ptr<program_impl> MProgramImpl;
+  const ContextImplPtr MContext;
+  const ProgramImplPtr MProgramImpl;
   bool MCreatedFromSource = true;
 };
 

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -24,6 +24,9 @@ namespace cl {
 namespace sycl {
 namespace detail {
 
+using ContextImplPtr = std::shared_ptr<detail::context_impl>;
+using DeviceImplPtr = std::shared_ptr<detail::device_impl>;
+
 // Set max number of queues supported by FPGA RT.
 const size_t MaxNumQueues = 256;
 
@@ -31,25 +34,27 @@ enum QueueOrder { Ordered, OOO };
 
 class queue_impl {
 public:
-  queue_impl(const device &SyclDevice, async_handler AsyncHandler,
+  queue_impl(DeviceImplPtr Device, async_handler AsyncHandler,
              QueueOrder Order, const property_list &PropList)
-      : queue_impl(SyclDevice, context(SyclDevice), AsyncHandler, Order,
-                   PropList){};
+      : queue_impl(Device,
+                   detail::getSyclObjImpl(
+                       context(createSyclObjFromImpl<device>(Device))),
+                   AsyncHandler, Order, PropList){};
 
-  queue_impl(const device &SyclDevice, const context &Context,
+  queue_impl(DeviceImplPtr Device, ContextImplPtr Context,
              async_handler AsyncHandler, QueueOrder Order,
              const property_list &PropList)
-      : m_Device(SyclDevice), m_Context(Context), m_AsyncHandler(AsyncHandler),
-        m_PropList(PropList), m_HostQueue(m_Device.is_host()),
+      : m_Device(Device), m_Context(Context), m_AsyncHandler(AsyncHandler),
+        m_PropList(PropList), m_HostQueue(m_Device->is_host()),
         m_OpenCLInterop(!m_HostQueue) {
     if (!m_HostQueue) {
       m_CommandQueue = createQueue(Order);
     }
   }
 
-  queue_impl(cl_command_queue CLQueue, const context &SyclContext,
+  queue_impl(cl_command_queue CLQueue, ContextImplPtr Context,
              const async_handler &AsyncHandler)
-      : m_Context(SyclContext), m_AsyncHandler(AsyncHandler),
+      : m_Context(Context), m_AsyncHandler(AsyncHandler),
         m_HostQueue(false), m_OpenCLInterop(true) {
 
     m_CommandQueue = pi::cast<RT::PiQueue>(CLQueue);
@@ -58,8 +63,7 @@ public:
     // TODO catch an exception and put it to list of asynchronous exceptions
     PI_CALL(piQueueGetInfo)(m_CommandQueue, PI_QUEUE_INFO_DEVICE,
                             sizeof(Device), &Device, nullptr);
-    m_Device =
-        createSyclObjFromImpl<device>(std::make_shared<device_impl>(Device));
+    m_Device = std::make_shared<device_impl>(Device);
 
     // TODO catch an exception and put it to list of asynchronous exceptions
     PI_CALL(piQueueRetain)(m_CommandQueue);
@@ -81,13 +85,13 @@ public:
         "This instance of queue doesn't support OpenCL interoperability");
   }
 
-  context get_context() const { return m_Context; }
+  context get_context() const { return createSyclObjFromImpl<context>(m_Context); }
 
   ContextImplPtr get_context_impl() const {
-    return detail::getSyclObjImpl(m_Context);
+    return m_Context;
   }
 
-  device get_device() const { return m_Device; }
+  device get_device() const { return createSyclObjFromImpl<device>(m_Device); }
 
   bool is_host() const { return m_HostQueue; }
 
@@ -153,8 +157,8 @@ public:
       CreationFlags |= PI_QUEUE_PROFILING_ENABLE;
     }
     RT::PiQueue Queue;
-    RT::PiContext Context = detail::getSyclObjImpl(m_Context)->getHandleRef();
-    RT::PiDevice Device = detail::getSyclObjImpl(m_Device)->getHandleRef();
+    RT::PiContext Context = m_Context->getHandleRef();
+    RT::PiDevice Device = m_Device->getHandleRef();
     RT::PiResult Error =
         PI_CALL_NOCHECK(piQueueCreate)(Context, Device, CreationFlags, &Queue);
 
@@ -241,8 +245,8 @@ private:
   // Protects all the fields that can be changed by class' methods
   mutex_class m_Mutex;
 
-  device m_Device;
-  const context m_Context;
+  DeviceImplPtr m_Device;
+  const ContextImplPtr m_Context;
   vector_class<event> m_Events;
   exception_list m_Exceptions;
   const async_handler m_AsyncHandler;

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -32,10 +32,12 @@ public:
   program() = delete;
 
   explicit program(const context &context)
-      : impl(std::make_shared<detail::program_impl>(context)) {}
+      : impl(std::make_shared<detail::program_impl>(
+            detail::getSyclObjImpl(context))) {}
 
   program(const context &context, vector_class<device> deviceList)
-      : impl(std::make_shared<detail::program_impl>(context, deviceList)) {}
+      : impl(std::make_shared<detail::program_impl>(
+            detail::getSyclObjImpl(context), deviceList)) {}
 
   program(vector_class<program> programList, string_class linkOptions = "") {
     std::vector<std::shared_ptr<detail::program_impl>> impls;
@@ -47,7 +49,8 @@ public:
 
   program(const context &context, cl_program clProgram)
       : impl(std::make_shared<detail::program_impl>(
-            context, detail::pi::cast<detail::RT::PiProgram>(clProgram))) {}
+            detail::getSyclObjImpl(context),
+            detail::pi::cast<detail::RT::PiProgram>(clProgram))) {}
 
   program(const program &rhs) = default;
 

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -70,5 +70,7 @@ vector_class<device> context::get_devices() const {
   return impl->get_info<info::context::devices>();
 }
 
+context::context(shared_ptr_class<detail::context_impl> Impl) : impl(Impl) {}
+
 } // namespace sycl
 } // namespace cl

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -29,7 +29,7 @@ context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
                            async_handler AsyncHandler)
     : MAsyncHandler(AsyncHandler), MDevices(Devices), MContext(nullptr),
       MPlatform(), MPluginInterop(true), MHostContext(false) {
-  MPlatform = MDevices[0].get_platform();
+  MPlatform = detail::getSyclObjImpl(MDevices[0].get_platform());
   vector_class<RT::PiDevice> DeviceIds;
   for (const auto &D : MDevices) {
     DeviceIds.push_back(getSyclObjImpl(D)->getHandleRef());
@@ -38,7 +38,7 @@ context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
   PI_CALL(piContextCreate)(nullptr, DeviceIds.size(), DeviceIds.data(), nullptr,
                            nullptr, &MContext);
 
-  MUSMDispatch.reset(new usm::USMDispatcher(MPlatform.get(), DeviceIds));
+  MUSMDispatch.reset(new usm::USMDispatcher(MPlatform->get(), DeviceIds));
 }
 
 context_impl::context_impl(RT::PiContext PiContext, async_handler AsyncHandler)
@@ -61,7 +61,7 @@ context_impl::context_impl(RT::PiContext PiContext, async_handler AsyncHandler)
         createSyclObjFromImpl<device>(std::make_shared<device_impl>(Dev)));
   }
   // TODO What if m_Devices if empty? m_Devices[0].get_platform()
-  MPlatform = platform(MDevices[0].get_platform());
+  MPlatform = detail::getSyclObjImpl(MDevices[0].get_platform());
   // TODO catch an exception and put it to list of asynchronous exceptions
   PI_CALL(piContextRetain)(MContext);
 }
@@ -104,7 +104,7 @@ cl_uint context_impl::get_info<info::context::reference_count>() const {
       this->getHandleRef());
 }
 template <> platform context_impl::get_info<info::context::platform>() const {
-  return MPlatform;
+  return createSyclObjFromImpl<platform>(MPlatform);
 }
 template <>
 vector_class<cl::sycl::device>

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -145,7 +145,8 @@ void Scheduler::releaseHostAccessor(Requirement *Req) {
 Scheduler::Scheduler() {
   sycl::device HostDevice;
   DefaultHostQueue = QueueImplPtr(new queue_impl(
-      HostDevice, /*AsyncHandler=*/{}, QueueOrder::Ordered, /*PropList=*/{}));
+      detail::getSyclObjImpl(HostDevice), /*AsyncHandler=*/{},
+          QueueOrder::Ordered, /*PropList=*/{}));
 }
 
 } // namespace detail

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -15,7 +15,8 @@ namespace sycl {
 
 kernel::kernel(cl_kernel ClKernel, const context &SyclContext)
     : impl(std::make_shared<detail::kernel_impl>(
-          detail::pi::cast<detail::RT::PiKernel>(ClKernel), SyclContext)) {}
+          detail::pi::cast<detail::RT::PiKernel>(ClKernel),
+              detail::getSyclObjImpl(SyclContext))) {}
 
 cl_kernel kernel::get() const { return impl->get(); }
 

--- a/sycl/source/ordered_queue.cpp
+++ b/sycl/source/ordered_queue.cpp
@@ -26,16 +26,16 @@ ordered_queue::ordered_queue(const context &syclContext,
 
   const device &syclDevice = *std::max_element(Devs.begin(), Devs.end(), Comp);
   impl = std::make_shared<detail::queue_impl>(
-      syclDevice, syclContext, asyncHandler,
-      cl::sycl::detail::QueueOrder::Ordered, propList);
+      detail::getSyclObjImpl(syclDevice), detail::getSyclObjImpl(syclContext),
+      asyncHandler, cl::sycl::detail::QueueOrder::Ordered, propList);
 }
 
 ordered_queue::ordered_queue(const device &syclDevice,
                              const async_handler &asyncHandler,
                              const property_list &propList) {
   impl = std::make_shared<detail::queue_impl>(
-      syclDevice, asyncHandler, cl::sycl::detail::QueueOrder::Ordered,
-      propList);
+      detail::getSyclObjImpl(syclDevice), asyncHandler,
+      cl::sycl::detail::QueueOrder::Ordered, propList);
 }
 
 ordered_queue::ordered_queue(cl_command_queue clQueue,
@@ -51,7 +51,8 @@ ordered_queue::ordered_queue(cl_command_queue clQueue,
         "Failed to build a sycl ordered queue from a cl OOO queue.");
 
   impl =
-      std::make_shared<detail::queue_impl>(clQueue, syclContext, asyncHandler);
+      std::make_shared<detail::queue_impl>(clQueue,
+          detail::getSyclObjImpl(syclContext), asyncHandler);
 }
 
 } // namespace sycl

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -24,20 +24,22 @@ queue::queue(const context &syclContext, const device_selector &deviceSelector,
 
   const device &syclDevice = *std::max_element(Devs.begin(), Devs.end(), Comp);
   impl = std::make_shared<detail::queue_impl>(
-      syclDevice, syclContext, asyncHandler, cl::sycl::detail::QueueOrder::OOO,
-      propList);
+      detail::getSyclObjImpl(syclDevice), detail::getSyclObjImpl(syclContext),
+      asyncHandler, cl::sycl::detail::QueueOrder::OOO, propList);
 }
 
 queue::queue(const device &syclDevice, const async_handler &asyncHandler,
              const property_list &propList) {
   impl = std::make_shared<detail::queue_impl>(
-      syclDevice, asyncHandler, cl::sycl::detail::QueueOrder::OOO, propList);
+      detail::getSyclObjImpl(syclDevice), asyncHandler,
+      cl::sycl::detail::QueueOrder::OOO, propList);
 }
 
 queue::queue(cl_command_queue clQueue, const context &syclContext,
              const async_handler &asyncHandler) {
   impl =
-      std::make_shared<detail::queue_impl>(clQueue, syclContext, asyncHandler);
+      std::make_shared<detail::queue_impl>(clQueue,
+          detail::getSyclObjImpl(syclContext), asyncHandler);
 }
 
 } // namespace sycl


### PR DESCRIPTION
Switch to use shared pointers to impl objects in fields of *_impl
classes to avoid duplication of object creation and avoiding default
constructors calls and creation context for unpredictable devices.

Signed-off-by: Vladimir Lazarev <vladimir.lazarev@intel.com>