### PR TITLE
[SYCL] Adjust local size of ND range for host device

### DIFF
--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -164,6 +164,8 @@ public:
       AdjustedRange.set(NDRDesc.Dims,
                         nd_range<3>(NDRDesc.NumWorkGroups * WGsize, WGsize));
     }
+    // If local size for host is not set explicitly, let's adjust it to 1,
+    // so nd_range_error for zero local size is not thrown.
     if (AdjustedRange.LocalSize[0] == 0)
       for (int I = 0; I < AdjustedRange.Dims; ++I)
         AdjustedRange.LocalSize[I] = 1;

--- a/sycl/test/basic_tests/parallel_for_range_host.cpp
+++ b/sycl/test/basic_tests/parallel_for_range_host.cpp
@@ -94,5 +94,17 @@ int main() {
     return 1;
   } catch (nd_range_error) {
   }
+
+  // parallel_for, 30 global, 1(implicit) local -> pass.
+  try {
+    Q.submit([&](handler &CGH) {
+        CGH.parallel_for<class g>(range<1>(30),
+            [=](nd_item<1>) {});
+    });
+    Q.wait_and_throw();
+  } catch (nd_range_error) {
+    std::cerr << "Test case 'g' failed: exception has been thrown" << std::endl;
+    return 1;
+  }
   return 0;
 }


### PR DESCRIPTION
If local size is not set explicitly for host, it will be set to 1, so
nd_range_error for zero local size is not thrown.

Signed-off-by: Viktoria Maksimova <viktoria.maksimova@intel.com>