### PR TITLE
[SYCL] Add linker script to limit exported symbols

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -20,12 +20,18 @@
 #define STRINGIFY_LINE_HELP(s) #s
 #define STRINGIFY_LINE(s) STRINGIFY_LINE_HELP(s)
 
+namespace cl {
+namespace sycl {
+namespace detail {
+
 const char *stringifyErrorCode(cl_int error);
 
 static inline std::string codeToString(cl_int code){
   return std::string(std::to_string(code) + " (" +
          stringifyErrorCode(code) + ")");
 }
+
+}}} // namespace cl::sycl::detail
 
 #ifdef __SYCL_DEVICE_ONLY__
 // TODO remove this when 'assert' is supported in device code
@@ -46,7 +52,8 @@ static inline std::string codeToString(cl_int code){
 {                                                                              \
   auto code = expr;                                                            \
   if (code != CL_SUCCESS) {                                                    \
-    std::cerr << OCL_ERROR_REPORT << codeToString(code) << std::endl;          \
+    std::cerr << OCL_ERROR_REPORT << cl::sycl::detail::codeToString(code)      \
+      << std::endl;                                                            \
   }                                                                            \
 }
 #endif
@@ -58,7 +65,7 @@ static inline std::string codeToString(cl_int code){
 {                                                                              \
   auto code = expr;                                                            \
   if (code != CL_SUCCESS) {                                                    \
-    throw exc(OCL_ERROR_REPORT + codeToString(code), code);                    \
+    throw exc(OCL_ERROR_REPORT + cl::sycl::detail::codeToString(code), code);  \
   }                                                                            \
 }
 #define REPORT_OCL_ERR_TO_EXC_THROW(code, exc) REPORT_OCL_ERR_TO_EXC(code, exc)

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -47,7 +47,7 @@ protected:
 
   exception(const string_class &Msg, const cl_int CLErr = CL_SUCCESS,
             shared_ptr_class<context> Context = nullptr)
-      : MMsg(Msg + " " + codeToString(CLErr)), MCLErr(CLErr),
+      : MMsg(Msg + " " + detail::codeToString(CLErr)), MCLErr(CLErr),
         MContext(Context) {}
 };
 

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -20,7 +20,13 @@ function(add_sycl_rt_library LIB_NAME)
   if (MSVC)
       target_compile_definitions(${LIB_NAME} PRIVATE __SYCL_BUILD_SYCL_DLL )
       target_link_libraries(${LIB_NAME} PRIVATE shlwapi)
+  else()
+      set(linker_script "${CMAKE_CURRENT_SOURCE_DIR}/ld-version-script.txt")
+      target_link_libraries(
+        ${LIB_NAME} PRIVATE "-Wl,--version-script=${linker_script}")
+      set_target_properties(${LIB_NAME} PROPERTIES LINK_DEPENDS ${linker_script})
   endif()
+
   target_include_directories(
       ${LIB_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} "${sycl_inc_dir}")
   target_link_libraries(${LIB_NAME}

--- a/sycl/source/detail/common.cpp
+++ b/sycl/source/detail/common.cpp
@@ -9,6 +9,10 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
 
+namespace cl {
+namespace sycl {
+namespace detail {
+
 const char *stringifyErrorCode(cl_int error) {
   switch (error) {
     case CL_INVALID_ACCELERATOR_INTEL:
@@ -212,10 +216,6 @@ const char *stringifyErrorCode(cl_int error) {
       return "Unknown OpenCL error code";
   }
 }
-
-namespace cl {
-namespace sycl {
-namespace detail {
 
 vector_class<string_class> split_string(const string_class &str,
                                         char delimeter) {

--- a/sycl/source/ld-version-script.txt
+++ b/sycl/source/ld-version-script.txt
@@ -1,0 +1,25 @@
+{
+  global:
+    /* Export everything from cl::sycl namespace */
+    _ZNK2cl4sycl*;  /* function */
+    _ZN2cl4sycl*;   /* function */
+    _ZTIN2cl4sycl*; /* typeinfo */
+    _ZTSN2cl4sycl*; /* typeinfo name */
+    _ZTVN2cl4sycl*; /* vtable */
+
+    /* Some functions are also in cl::__host_std, export them as well */
+    _ZN2cl10__host_std*;
+
+    /* Export SPIR-V built-ins for host device */
+    _Z23__spirv_GroupWaitEvents*;
+    _Z22__spirv_ControlBarrier*;
+    _Z21__spirv_MemoryBarrier*;
+    _Z20__spirv_ocl_prefetch*;
+
+    /* Export offload image hooks */
+    __tgt_register_lib;
+    __tgt_unregister_lib;
+
+  local:
+    *;
+};

--- a/sycl/source/ld-version-script.txt
+++ b/sycl/source/ld-version-script.txt
@@ -1,4 +1,11 @@
 {
+  /* Do not use extern "C++" matcher for C++ functions,                     */
+  /* because vtable and typeinfo symbols make extern "C++" patterns more    */
+  /* complicated than patterns against mangled names.                       */
+  /*                                                                        */
+  /* With extern "C++" we have to match for "vtable for cl::sycl::foo", but */
+  /* not match for "vtable for std::__internal<cl::sycl::foo>".             */
+
   global:
     /* Export everything from cl::sycl namespace */
     _ZNK2cl4sycl*;  /* function */


### PR DESCRIPTION
Template function instantiations from libstdc++ headers are exported
from libsycl.so as weak symbols by default, and they become a part of
libsycl.so ABI. This includes libstdc++ internal functions
(e.g. classes defined in std::__detail namespace), which, unlike
standard C++ classes (like std::vector), are not forward-compatible.

Host program is also compiled with libstdc++ headers, so it may also
contain the same weak symbols.

When libsycl.so is loaded by a host program, loader resolves its
symbols for internal libstdc++ functions to the corresponding symbols
in the host program. They may be incompatible, (e.g. when the host
program is compiled with different version of libstdc++), so
libsycl.so is going to crash or execute incorrectly.

Linker script limits symbols that we actually export from the
library. Template function instantiations become local, so loader will
no longer attempt to resolve them.

This patch does not use extern "C++" matcher for C++ functions,
because vtable and typeinfo symbols make extern "C++" patterns more
complicated than patterns against mangled names.

With extern "C++" we have to match for "vtable for cl::sycl::foo", but
not match for "vtable for std::__internal<cl::sycl::foo>".

Also cleanup functions that were never meant to be exported.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>