### PR TITLE
[SYCL] Avoid usage of deprecated LLVM API

### DIFF
--- a/clang/lib/CodeGen/SYCLLowerIR/LowerWGScope.cpp
+++ b/clang/lib/CodeGen/SYCLLowerIR/LowerWGScope.cpp
@@ -380,7 +380,7 @@ static void copyBetweenLocalAndShadow(AllocaInst *L, GlobalVariable *Shadow,
   Type *T = L->getAllocatedType();
 
   if (T->isAggregateType()) {
-    // TODO: we should use methods which directly retunr MaybeAlign once such
+    // TODO: we should use methods which directly return MaybeAlign once such
     // are added to LLVM for AllocaInst and GlobalVariable
     auto LocAlign = MaybeAlign(L->getAlignment());
     auto ShdAlign = MaybeAlign(Shadow->getAlignment());

--- a/clang/lib/CodeGen/SYCLLowerIR/LowerWGScope.cpp
+++ b/clang/lib/CodeGen/SYCLLowerIR/LowerWGScope.cpp
@@ -380,8 +380,10 @@ static void copyBetweenLocalAndShadow(AllocaInst *L, GlobalVariable *Shadow,
   Type *T = L->getAllocatedType();
 
   if (T->isAggregateType()) {
-    auto LocAlign = L->getAlignment();
-    auto ShdAlign = Shadow->getAlignment();
+    // TODO: we should use methods which directly retunr MaybeAlign once such
+    // are added to LLVM for AllocaInst and GlobalVariable
+    auto LocAlign = MaybeAlign(L->getAlignment());
+    auto ShdAlign = MaybeAlign(Shadow->getAlignment());
     Module &M = *L->getModule();
     auto SizeVal = M.getDataLayout().getTypeStoreSize(T);
     auto Size = ConstantInt::get(getSizeTTy(M), SizeVal);


### PR DESCRIPTION
LLVM commit 531c1161b97 ("Resubmit "[Alignment][NFC] Deprecate
CreateMemCpy/CreateMemMove"", 2019-12-16) deprecated the variants that
do not take `MaybeAlign` arguments.
