### PR TITLE
[WIP][SYCL] Update usage rules of SYCL_EXTERNAL

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2070,7 +2070,7 @@ This attribute can only be applied to functions and indicates that the
 function must be treated as a device function and must be emitted even if it has
 no direct uses from other SYCL device functions. However, it cannot be applied
 to functions marked as 'static', functions declared within an anonymous
-namespace or class member functions.
+namespace or virtual/pure virtual class member functions.
 
 It also means that function should be available externally and
 cannot be optimized out due to reachability analysis or by any other

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10293,7 +10293,7 @@ def err_intel_attribute_argument_is_not_in_range: Error<
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "%select{static function or function in an anonymous namespace"
-            "|class member function}1">;
+            "|virtual or pure virtual class member function}1">;
 def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
               "to a function with a raw pointer "

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -10078,6 +10078,12 @@ bool ASTContext::DeclMustBeEmitted(const Decl *D) {
       }
     }
 
+    // Methods explcitly marked with 'sycl_device' attribute (via SYCL_EXTERNAL)
+    // must be emitted regardless of number of actual uses
+    if (LangOpts.SYCLIsDevice && isa<CXXMethodDecl>(D))
+      if (auto *A = D->getAttr<SYCLDeviceAttr>())
+        return !A->isImplicit();
+
     GVALinkage Linkage = GetGVALinkageForFunction(FD);
 
     // static, static inline, always_inline, and extern inline functions can

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4488,9 +4488,9 @@ static void handleSYCLDeviceAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
         << AL << 0 /* static function or anonymous namespace */;
     return;
   }
-  if (isa<CXXMethodDecl>(FD)) {
+  if (FD->isVirtualAsWritten() || FD->isPure()) {
     S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-        << AL << 1 /* class member function */;
+        << AL << 1 /* virtual or pure virtual class member function */;
     return;
   }
   if (FD->getReturnType()->isPointerType()) {
@@ -4515,9 +4515,9 @@ static void handleSYCLDeviceIndirectlyCallableAttr(Sema &S, Decl *D,
         << AL << 0 /* static function or anonymous namespace */;
     return;
   }
-  if (isa<CXXMethodDecl>(FD)) {
+  if (FD->isVirtualAsWritten() || FD->isPure()) {
     S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-        << AL << 1 /* class member function */;
+        << AL << 1 /* virtual or pure virtual class member function */;
     return;
   }
 

--- a/clang/test/CodeGenSYCL/sycl-device.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device.cpp
@@ -3,6 +3,15 @@
 
 int bar(int b);
 
+class A {
+public:
+  // TODO: check for constructor/destructor as well
+
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1A3fooEv
+  __attribute__((sycl_device))
+  void foo() {}
+};
+
 // CHECK-DAG: define spir_func i32 @_Z3fooii
 __attribute__((sycl_device))
 int foo(int a, int b) { return a + bar(b); }

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -19,11 +19,19 @@ namespace {
 }
 
 class A {
-  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a class member function}}
+  [[intel::device_indirectly_callable]]
   A() {}
 
-  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a class member function}}
+  [[intel::device_indirectly_callable]]
   int func3() {}
+};
+
+class B {
+  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a virtual or pure virtual class member function}}
+  virtual int foo() {}
+
+  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a virtual or pure virtual class member function}}
+  virtual int bar() = 0;
 };
 
 void helper() {}

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -21,11 +21,19 @@ namespace {
 }
 
 class A {
-  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a class member function}}
+  __attribute__((sycl_device))
   A() {}
 
-  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a class member function}}
+  __attribute__((sycl_device))
   int func3() {}
+};
+
+class B {
+  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a virtual or pure virtual class member function}}
+  virtual int foo() {}
+
+  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a virtual or pure virtual class member function}}
+  virtual int bar() = 0;
 };
 
 #if defined(NOT_STRICT)


### PR DESCRIPTION
This patch allows to apply `SYCL_EXTERNAL` to class member functions,
but only if they weren't declared as virtual or as pure virtual.

The same logic was applied to `[[intel::device_indireclty_callable]]`.