### PR TITLE
[SYCL] Check if PluginInitializeFunction is NULL before accessing it.

### DIFF
--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -79,6 +79,9 @@ bool bindPlugin(void *Library) {
 
   decltype(::piPluginInit) *PluginInitializeFunction = (decltype(
       &::piPluginInit))(getOsLibraryFuncAddress(Library, "piPluginInit"));
+  if (PluginInitializeFunction == nullptr)
+    return false;
+
   int err = PluginInitializeFunction(&PluginInformation);
 
   // TODO: Compare Supported versions and check for backward compatibility.


### PR DESCRIPTION
Signed-off-by: Garima Gupta <garima.gupta@intel.com>