### PR TITLE
[SYCL] Print the execution graph as a multigraph

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -93,7 +93,7 @@ void Scheduler::GraphBuilder::printGraphAsDot(const char *ModeName) {
   Counter++;
 
   std::fstream Stream(FileName, std::ios::out);
-  Stream << "strict digraph {" << std::endl;
+  Stream << "digraph {" << std::endl;
 
   std::set<Command *> Visited;
 


### PR DESCRIPTION
Execution graph .dot dump specified the graph as strict, but a command
can have multiple dependencies on another command.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>