### PR TITLE
[SYCL] Add namespace alias for cl::sycl namespace

### DIFF
--- a/sycl/include/CL/sycl.hpp
+++ b/sycl/include/CL/sycl.hpp
@@ -40,3 +40,7 @@
 #include <CL/sycl/types.hpp>
 #include <CL/sycl/usm.hpp>
 #include <CL/sycl/version.hpp>
+
+#ifndef __SYCL_DISABLE_NAMESPACE_ALIAS__
+namespace sycl = cl::sycl;
+#endif

--- a/sycl/test/basic_tests/accessor/accessor.cpp
+++ b/sycl/test/basic_tests/accessor/accessor.cpp
@@ -13,10 +13,6 @@
 #include <CL/sycl.hpp>
 #include <cassert>
 
-namespace sycl {
-using namespace cl::sycl;
-}
-
 struct IdxID1 {
   int x;
 

--- a/sycl/test/basic_tests/sampler/sampler.cpp
+++ b/sycl/test/basic_tests/sampler/sampler.cpp
@@ -15,10 +15,6 @@
 #include <CL/sycl/context.hpp>
 #include <cassert>
 
-namespace sycl {
-using namespace cl::sycl;
-}
-
 int main() {
   // Check constructor from enums
   sycl::sampler A(sycl::coordinate_normalization_mode::unnormalized,

--- a/sycl/test/regression/kernel_name_inside_sycl_namespace.cpp
+++ b/sycl/test/regression/kernel_name_inside_sycl_namespace.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -D__SYCL_DISABLE_NAMESPACE_ALIAS__ %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
The alias is enabled by default and make using SYCL API a little bit
easier.

Unfortunately it's not compatible with the following valid C++ code:
```c++
namespace sycl {
  using namespace cl::sycl;
}
```
In order to disable namespace alias user should define
`__SYCL_DISABLE_NAMESPACE_ALIAS__` macro.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>