### PR TITLE
[clang][Bundler] Add a CMake dependency for llvm-objcopy

### DIFF
--- a/clang/tools/clang-offload-bundler/CMakeLists.txt
+++ b/clang/tools/clang-offload-bundler/CMakeLists.txt
@@ -17,6 +17,11 @@ set(CLANG_OFFLOAD_BUNDLER_LIB_DEPS
   
 add_dependencies(clang clang-offload-bundler)
 
+# A standalone clang build uses a pre-installed llvm-objcopy
+if (NOT CLANG_BUILT_STANDALONE)
+  add_dependencies(clang-offload-bundler llvm-objcopy)
+endif()
+
 clang_target_link_libraries(clang-offload-bundler
   PRIVATE
   ${CLANG_OFFLOAD_BUNDLER_LIB_DEPS}


### PR DESCRIPTION
clang-offload-bundler calls llvm-objcopy, so it has to have a
dependency on it.

We have multiple reports of build failures after #922, and this patch
should fix them. I'll commit it to llvm.org soon.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>