### PR TITLE
[SYCL] Diagnose __float128 type usage in device code, fixes and cleanups 

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12096,10 +12096,11 @@ public:
   ///
   /// Example usage:
   ///
-  /// Asm is not allowed in SYCL device code.
+  /// Variables with thread storage duration are not allowed to be used in SYCL
+  /// device code
   /// if (getLangOpts().SYCLIsDevice)
-  ///   SYCLDiagIfDeviceCode(AsmLoc, diag::err_sycl_restrict)
-  ///       << KernelUseAssembly;
+  ///   SYCLDiagIfDeviceCode(Loc, diag::err_thread_unsupported);
+  ///  // Otherwise, continue parsing as normal.
   DeviceDiagBuilder SYCLDiagIfDeviceCode(SourceLocation Loc, unsigned DiagID);
 
   /// Checks if Callee function is a device function and emits

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12100,7 +12100,6 @@ public:
   /// device code
   /// if (getLangOpts().SYCLIsDevice)
   ///   SYCLDiagIfDeviceCode(Loc, diag::err_thread_unsupported);
-  ///  // Otherwise, continue parsing as normal.
   DeviceDiagBuilder SYCLDiagIfDeviceCode(SourceLocation Loc, unsigned DiagID);
 
   /// Checks if Callee function is a device function and emits

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12079,11 +12079,33 @@ public:
     KernelCallDllimportFunction,
     KernelCallVariadicFunction
  };
-  DeviceDiagBuilder SYCLDiagIfDeviceCode(SourceLocation Loc, unsigned DiagID);
   bool isKnownGoodSYCLDecl(const Decl *D);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
   void MarkDevice(void);
-  bool CheckSYCLCall(SourceLocation Loc, FunctionDecl *Callee);
+
+  /// Creates a DeviceDiagBuilder that emits the diagnostic if the current
+  /// context is "used as device code".
+  ///
+  /// - If CurLexicalContext is a kernel function or it is known that the
+  ///   function will be emitted for the device, emits the diagnostics
+  ///   immediately.
+  /// - If CurLexicalContext is a function and we are compiling
+  ///   for the device, but we don't know that this function will be codegen'ed
+  ///   for devive yet, creates a diagnostic which is emitted if and when we
+  ///   realize that the function will be codegen'ed.
+  ///
+  /// Example usage:
+  ///
+  /// Asm is not allowed in SYCL device code.
+  /// if (getLangOpts().SYCLIsDevice)
+  ///   SYCLDiagIfDeviceCode(AsmLoc, diag::err_sycl_restrict)
+  ///       << KernelUseAssembly;
+  DeviceDiagBuilder SYCLDiagIfDeviceCode(SourceLocation Loc, unsigned DiagID);
+
+  /// Checks if Callee function is a device function and emits
+  /// diagnostics if it is known that it is a device function, adds this
+  /// function to the DeviceCallGraph otherwise.
+  void checkSYCLDeviceFunction(SourceLocation Loc, FunctionDecl *Callee);
 };
 
 /// RAII object that enters a new expression evaluation context.

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1610,6 +1610,9 @@ Sema::DeviceDiagBuilder Sema::targetDiag(SourceLocation Loc, unsigned DiagID) {
   if (getLangOpts().CUDA)
     return getLangOpts().CUDAIsDevice ? CUDADiagIfDeviceCode(Loc, DiagID)
                                       : CUDADiagIfHostCode(Loc, DiagID);
+  // TODO: analyze which usages of targetDiag could be reused for SYCL.
+  // if (getLangOpts().SYCLIsDevice)
+  //   return SYCLDiagIfDeviceCode(Loc, DiagID);
   return DeviceDiagBuilder(DeviceDiagBuilder::K_Immediate, Loc, DiagID,
                            getCurFunctionDecl(), *this);
 }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -14644,7 +14644,7 @@ Sema::BuildCXXConstructExpr(SourceLocation ConstructLoc, QualType DeclInitType,
   if (getLangOpts().CUDA && !CheckCUDACall(ConstructLoc, Constructor))
     return ExprError();
   if (getLangOpts().SYCLIsDevice)
-    CheckSYCLCall(ConstructLoc, Constructor);
+    checkSYCLDeviceFunction(ConstructLoc, Constructor);
 
   return CXXConstructExpr::Create(
       Context, DeclInitType, ConstructLoc, Constructor, Elidable,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -269,7 +269,7 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
       return true;
 
     if (getLangOpts().SYCLIsDevice)
-      CheckSYCLCall(Loc, FD);
+      checkSYCLDeviceFunction(Loc, FD);
   }
 
   if (auto *MD = dyn_cast<CXXMethodDecl>(D)) {
@@ -15649,7 +15649,7 @@ void Sema::MarkFunctionReferenced(SourceLocation Loc, FunctionDecl *Func,
   if (getLangOpts().CUDA)
     CheckCUDACall(Loc, Func);
   if (getLangOpts().SYCLIsDevice)
-    CheckSYCLCall(Loc, Func);
+    checkSYCLDeviceFunction(Loc, Func);
 
   // If we need a definition, try to create one.
   if (NeedDefinition && !Func->getBody()) {
@@ -17219,15 +17219,7 @@ namespace {
     }
 
     void VisitCXXNewExpr(CXXNewExpr *E) {
-      FunctionDecl *FD = E->getOperatorNew();
-      if (FD && S.getLangOpts().SYCLIsDevice) {
-        if (FD->isReplaceableGlobalAllocationFunction())
-          S.SYCLDiagIfDeviceCode(E->getExprLoc(), diag::err_sycl_restrict)
-              << S.KernelAllocateStorage;
-        else if (FunctionDecl *Def = FD->getDefinition())
-          S.CheckSYCLCall(E->getExprLoc(), Def);
-      }
-      if (FD)
+      if (E->getOperatorNew())
         S.MarkFunctionReferenced(E->getBeginLoc(), E->getOperatorNew());
       if (E->getOperatorDelete())
         S.MarkFunctionReferenced(E->getBeginLoc(), E->getOperatorDelete());

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2171,16 +2171,15 @@ Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
     if (DiagnoseUseOfDecl(OperatorNew, StartLoc))
       return ExprError();
     MarkFunctionReferenced(StartLoc, OperatorNew);
-    if (getLangOpts().SYCLIsDevice) {
-      CheckSYCLCall(StartLoc, OperatorNew);
-    }
+    if (getLangOpts().SYCLIsDevice &&
+        OperatorNew->isReplaceableGlobalAllocationFunction())
+      SYCLDiagIfDeviceCode(StartLoc, diag::err_sycl_restrict)
+          << KernelAllocateStorage;
   }
   if (OperatorDelete) {
     if (DiagnoseUseOfDecl(OperatorDelete, StartLoc))
       return ExprError();
     MarkFunctionReferenced(StartLoc, OperatorDelete);
-    if (getLangOpts().SYCLIsDevice)
-      CheckSYCLCall(StartLoc, OperatorDelete);
   }
 
   return CXXNewExpr::Create(Context, UseGlobal, OperatorNew, OperatorDelete,

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -12916,8 +12916,6 @@ Sema::CreateOverloadedUnaryOp(SourceLocation OpLoc, UnaryOperatorKind Opc,
                             FnDecl->getType()->castAs<FunctionProtoType>()))
         return ExprError();
 
-      if (getLangOpts().SYCLIsDevice)
-        CheckSYCLCall(OpLoc, FnDecl);
       return MaybeBindToTemporary(TheCall);
     } else {
       // We matched a built-in operator. Convert the arguments, then
@@ -13270,8 +13268,6 @@ ExprResult Sema::CreateOverloadedBinOp(SourceLocation OpLoc,
                   isa<CXXMethodDecl>(FnDecl), OpLoc, TheCall->getSourceRange(),
                   VariadicDoesNotApply);
 
-        if (getLangOpts().SYCLIsDevice)
-          CheckSYCLCall(OpLoc, FnDecl);
         ExprResult R = MaybeBindToTemporary(TheCall);
         if (R.isInvalid())
           return ExprError();
@@ -13633,8 +13629,6 @@ Sema::CreateOverloadedArraySubscriptExpr(SourceLocation LLoc,
                               Method->getType()->castAs<FunctionProtoType>()))
           return ExprError();
 
-        if (getLangOpts().SYCLIsDevice)
-          CheckSYCLCall(RLoc, FnDecl);
         return MaybeBindToTemporary(TheCall);
       } else {
         // We matched a built-in operator. Convert the arguments, then

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1403,7 +1403,7 @@ Sema::DeviceDiagBuilder Sema::SYCLDiagIfDeviceCode(SourceLocation Loc,
   DeviceDiagBuilder::Kind DiagKind = [this, FD] {
     if (ConstructingOpenCLKernel || !FD)
       return DeviceDiagBuilder::K_Nop;
-    if (FD && isKnownEmitted(*this, FD))
+    if (isKnownEmitted(*this, FD))
       return DeviceDiagBuilder::K_ImmediateWithCallStack;
     return DeviceDiagBuilder::K_Deferred;
   }();

--- a/clang/lib/Sema/SemaStmtAsm.cpp
+++ b/clang/lib/Sema/SemaStmtAsm.cpp
@@ -259,12 +259,11 @@ StmtResult Sema::ActOnGCCAsmStmt(SourceLocation AsmLoc, bool IsSimple,
   // Skip all the checks if we are compiling SYCL device code, but the function
   // is not marked to be used on device, this code won't be codegen'ed anyway.
   if (getLangOpts().SYCLIsDevice) {
-    SYCLDiagIfDeviceCode(AsmLoc, diag::err_sycl_restrict)
-        << KernelUseAssembly;
+    SYCLDiagIfDeviceCode(AsmLoc, diag::err_sycl_restrict) << KernelUseAssembly;
     return new (Context)
-      GCCAsmStmt(Context, AsmLoc, IsSimple, IsVolatile, NumOutputs,
-                 NumInputs, Names, Constraints, Exprs.data(), AsmString,
-                 NumClobbers, Clobbers, NumLabels, RParenLoc);
+        GCCAsmStmt(Context, AsmLoc, IsSimple, IsVolatile, NumOutputs, NumInputs,
+                   Names, Constraints, Exprs.data(), AsmString, NumClobbers,
+                   Clobbers, NumLabels, RParenLoc);
   }
 
   FunctionDecl *FD = dyn_cast<FunctionDecl>(getCurLexicalContext());

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1500,11 +1500,14 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
       Result = Context.DoubleTy;
     break;
   case DeclSpec::TST_float128:
-    if (!S.Context.getTargetInfo().hasFloat128Type() && 
-        !S.getLangOpts().SYCLIsDevice &&
-        !(S.getLangOpts().OpenMP && S.getLangOpts().OpenMPIsDevice))
+    if (S.getLangOpts().SYCLIsDevice)
+      S.SYCLDiagIfDeviceCode(DS.getTypeSpecTypeLoc(),
+                             diag::err_type_unsupported)
+          << "__float128";
+    else if (!S.Context.getTargetInfo().hasFloat128Type() &&
+             !(S.getLangOpts().OpenMP && S.getLangOpts().OpenMPIsDevice))
       S.Diag(DS.getTypeSpecTypeLoc(), diag::err_type_unsupported)
-        << "__float128";
+          << "__float128";
     Result = Context.Float128Ty;
     break;
   case DeclSpec::TST_bool: Result = Context.BoolTy; break; // _Bool or bool

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1500,7 +1500,8 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
       Result = Context.DoubleTy;
     break;
   case DeclSpec::TST_float128:
-    if (S.getLangOpts().SYCLIsDevice)
+    if (!S.Context.getTargetInfo().hasFloat128Type() &&
+        S.getLangOpts().SYCLIsDevice)
       S.SYCLDiagIfDeviceCode(DS.getTypeSpecTypeLoc(),
                              diag::err_type_unsupported)
           << "__float128";

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -19,7 +19,7 @@ void bar() {
 #endif // LINUX_ASM
 }
 
-template <typename name, typename Func>
+template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   // expected-note@+1 {{called by 'kernel_single_task<fake_kernel, (lambda}}
   kernelFunc();

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -16,7 +16,7 @@ void kernel3(void) {
 using myFuncDef = int(int,int);
 
 void usage3(myFuncDef functionPtr) {
-  // expected-error@+1 1{{SYCL kernel cannot allocate storage}}
+  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
   int *ip = new int;
   kernel3();
 }

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -16,6 +16,8 @@ void kernel3(void) {
 using myFuncDef = int(int,int);
 
 void usage3(myFuncDef functionPtr) {
+  // expected-error@+1 1{{SYCL kernel cannot allocate storage}}
+  int *ip = new int;
   kernel3();
 }
 
@@ -26,14 +28,14 @@ int addInt(int n, int m) {
 template <typename name, typename Func>
   // expected-note@+1 2{{function implemented using recursion declared here}}
 __attribute__((sycl_kernel)) void kernel_single_task2(Func kernelFunc) {
+  // expected-note@+1 {{called by 'kernel_single_task2}}
   kernelFunc();
-  // expected-error@+1 2{{SYCL kernel cannot allocate storage}}
-  int *ip = new int;
   // expected-error@+1 2{{SYCL kernel cannot call a recursive function}}
   kernel_single_task2<name, Func>(kernelFunc);
 }
 
 int main() {
+  // expected-note@+1 {{called by 'operator()'}}
   kernel_single_task2<class fake_kernel>([]() { usage3(  &addInt ); });
   return fib(5);
 }

--- a/clang/test/SemaSYCL/restrict-recursion4.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion4.cpp
@@ -18,6 +18,8 @@ void kernel2(void) {
 using myFuncDef = int(int,int);
 
 void usage2(myFuncDef functionPtr) {
+  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
+  int *ip = new int;
   // expected-error@+1 {{SYCL kernel cannot call a recursive function}}
   kernel2();
 }
@@ -28,12 +30,12 @@ int addInt(int n, int m) {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
-  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
-  int *ip = new int;
+  // expected-note@+1 {{called by 'kernel_single_task}}
   kernelFunc();
 }
 
 int main() {
+  // expected-note@+1 {{called by 'operator()'}}
   kernel_single_task<class fake_kernel>([]() {usage2(&addInt);});
   return fib(5);
 }

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -59,7 +59,6 @@ struct OverloadedNewDelete {
 
 bool isa_B(A *a) {
   Check_User_Operators::Fraction f1(3, 8), f2(1, 2), f3(10, 2);
-  // expected-note@+1 {{called by 'isa_B'}}
   if (f1 == f2) return false;
 
   Check_VLA_Restriction::restriction(7);
@@ -77,7 +76,6 @@ bool isa_B(A *a) {
 
 template<typename N, typename L>
 __attribute__((sycl_kernel)) void kernel1(L l) {
-  // expected-note@+1 3{{called by 'kernel1}}
   l();
 }
 }
@@ -141,7 +139,6 @@ void usage(myFuncDef functionPtr) {
     b.f();
   Check_RTTI_Restriction::kernel1<class kernel_name>([]() {
   Check_RTTI_Restriction::A *a;
-  // expected-note@+1 3{{called by 'operator()'}}
   Check_RTTI_Restriction::isa_B(a); });
 
   // expected-error@+1 {{__float128 is not supported on this target}}
@@ -180,9 +177,12 @@ int use2 ( a_type ab, a_type *abp ) {
   // expected-note@+1 {{called by 'use2'}}
   eh_not_ok();
   Check_RTTI_Restriction:: A *a;
+  // expected-note@+1 2{{called by 'use2'}}
   Check_RTTI_Restriction:: isa_B(a);
+  // expected-note@+1 {{called by 'use2'}}
   usage(&addInt);
   Check_User_Operators::Fraction f1(3, 8), f2(1, 2), f3(10, 2);
+  // expected-note@+1 {{called by 'use2'}}
   if (f1 == f2) return false;
 }
 
@@ -191,7 +191,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   kernelFunc();
   a_type ab;
   a_type *p;
-  // expected-note@+1 {{called by 'kernel_single_task'}}
+  // expected-note@+1 5{{called by 'kernel_single_task'}}
   use2(ab, p);
 }
 

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -143,6 +143,9 @@ void usage(myFuncDef functionPtr) {
   Check_RTTI_Restriction::A *a;
   // expected-note@+1 3{{called by 'operator()'}}
   Check_RTTI_Restriction::isa_B(a); });
+
+  // expected-error@+1 {{__float128 is not supported on this target}}
+  __float128 A;
 }
 
 namespace ns {

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -fno-sycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -std=c++17 %s
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -DALLOW_FP=1 -fsycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -triple spir64 -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -triple spir64 -fsycl-is-device -fno-sycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -triple spir64 -fsycl-is-device -DALLOW_FP=1 -fsycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 
 
 namespace std {

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -59,12 +59,14 @@ struct OverloadedNewDelete {
 
 bool isa_B(A *a) {
   Check_User_Operators::Fraction f1(3, 8), f2(1, 2), f3(10, 2);
+  // expected-note@+1 {{called by 'isa_B'}}
   if (f1 == f2) return false;
 
   Check_VLA_Restriction::restriction(7);
   // expected-error@+1 {{SYCL kernel cannot allocate storage}}
   int *ip = new int;
   int i; int *p3 = new(&i) int; // no error on placement new
+  // expected-note@+1 {{called by 'isa_B'}}
   OverloadedNewDelete *x = new( struct OverloadedNewDelete );
   auto y = new struct OverloadedNewDelete [5];
   // expected-error@+1 {{SYCL kernel cannot use rtti}}
@@ -75,6 +77,7 @@ bool isa_B(A *a) {
 
 template<typename N, typename L>
 __attribute__((sycl_kernel)) void kernel1(L l) {
+  // expected-note@+1 3{{called by 'kernel1}}
   l();
 }
 }
@@ -102,6 +105,7 @@ using myFuncDef = int(int,int);
 
 void eh_ok(void)
 {
+  __float128 A;
   try {
     ;
   } catch (...) {
@@ -137,6 +141,7 @@ void usage(myFuncDef functionPtr) {
     b.f();
   Check_RTTI_Restriction::kernel1<class kernel_name>([]() {
   Check_RTTI_Restriction::A *a;
+  // expected-note@+1 3{{called by 'operator()'}}
   Check_RTTI_Restriction::isa_B(a); });
 }
 


### PR DESCRIPTION
The problem is that CheckSYCLCall used to get the caller incorrectly.
getCurFunctionDecl gets the wrong thing. It will get the function
containing the lambda at definition time, rather than the lambda operator().

Additional changes:
Cleaned up unnecessary calls of CheckSYCLCall function.
Fixed diagnosing of storage allocation through deferred diagnostics
system.
Renamed CheckSYCLCall with checkSYCLDeviceFunction since we don't really
check calls as CUDA/OpenMP does.
Used deferred diagnostics to diagnose __float128 type usage.
Removed unnecessary emitting of diagnostics from SemaSYCL.
Updated tests.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>