### PR TITLE
[SYCL] Inline cl namespace to simplify SYCL API usage

### DIFF
--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -197,7 +197,7 @@ static NestedNameSpecifier *createOuterNNS(const ASTContext &Ctx, const Decl *D,
       // Ignore inline namespace;
       NS = dyn_cast<NamespaceDecl>(NS->getDeclContext());
     }
-    if (NS->getDeclName()) {
+    if (NS && NS->getDeclName()) {
       return createNestedNameSpecifier(Ctx, NS, WithGlobalNsPrefix);
     }
     return nullptr;  // no starting '::', no anonymous

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1638,6 +1638,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   O << "// This is auto-generated SYCL integration header.\n";
   O << "\n";
 
+  O << "#include <CL/sycl/detail/defines.hpp>\n";
   O << "#include <CL/sycl/detail/kernel_desc.hpp>\n";
 
   O << "\n";
@@ -1651,7 +1652,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   }
   O << "\n";
 
-  O << "namespace cl {\n";
+  O << "__SYCL_INLINE namespace cl {\n";
   O << "namespace sycl {\n";
   O << "namespace detail {\n";
 

--- a/clang/test/CodeGenSYCL/kernel-name.cpp
+++ b/clang/test/CodeGenSYCL/kernel-name.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -S -emit-llvm -x c++ %s -o - | FileCheck %s
+
+inline namespace cl {
+  namespace sycl {
+    class kernel {};
+  }
+}
+
+using namespace cl::sycl;
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+// CHECK: define spir_kernel {{.*}}2cl4sycl6kernel
+int main() {
+  kernel_single_task<class kernel>([]() {});
+  return 0;
+}

--- a/sycl/include/CL/sycl.hpp
+++ b/sycl/include/CL/sycl.hpp
@@ -40,3 +40,4 @@
 #include <CL/sycl/types.hpp>
 #include <CL/sycl/usm.hpp>
 #include <CL/sycl/version.hpp>
+

--- a/sycl/include/CL/sycl/access/access.hpp
+++ b/sycl/include/CL/sycl/access/access.hpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
-namespace cl {
+#include <CL/sycl/detail/defines.hpp>
+
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace access {
 

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -143,7 +143,7 @@
 // accessor_common contains several helpers common for both accessor(1) and
 // accessor(3)
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 template <typename DataT, int Dimensions, access::mode AccessMode,

--- a/sycl/include/CL/sycl/aliases.hpp
+++ b/sycl/include/CL/sycl/aliases.hpp
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 template <typename T, int N> class vec;
 namespace detail {
@@ -69,7 +69,7 @@ using half = cl::sycl::detail::half_impl::half;
   MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                                      \
   MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 using byte = std::uint8_t;
 using schar = signed char;

--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -23,7 +23,7 @@
   static_assert(!std::is_same<T, float>::value,                                \
                 "SYCL atomic function not available for float type")
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 enum class memory_order : int { relaxed };
@@ -66,7 +66,7 @@ template <> struct GetSpirvMemoryScope<access::address_space::local_space> {
 
 #ifndef __SYCL_DEVICE_ONLY__
 // host implementation of SYCL atomics
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 // Translate cl::sycl::memory_order or __spv::MemorySemanticsMask
@@ -161,7 +161,7 @@ extern T __spirv_AtomicMax(std::atomic<T> *Ptr, __spv::Scope S,
 
 #endif // !defined(__SYCL_DEVICE_ONLY__)
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 template <typename T, access::address_space addressSpace =

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -14,7 +14,7 @@
 
 // TODO: 4.3.4 Properties
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 class handler;
 class queue;

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -17,7 +17,7 @@
 // TODO Decide whether to mark functions with this attribute.
 #define __NOEXC /*noexcept*/
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 #ifdef __SYCL_DEVICE_ONLY__
 #define __sycl_std
@@ -27,7 +27,7 @@ namespace __sycl_std = __host_std;
 } // namespace sycl
 } // namespace cl
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 /* ----------------- 4.13.3 Math functions. ---------------------------------*/
 // genfloat acos (genfloat x)

--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -14,7 +14,7 @@
 #include <type_traits>
 // 4.6.2 Context class
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 // Forward declarations
 class device;

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -16,7 +16,7 @@
 
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/aligned_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/aligned_allocator.hpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 template <typename T> class aligned_allocator {

--- a/sycl/include/CL/sycl/detail/array.hpp
+++ b/sycl/include/CL/sycl/detail/array.hpp
@@ -12,7 +12,7 @@
 #include <functional>
 #include <stdexcept>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 template <int dimensions> class id;
 template <int dimensions> class range;

--- a/sycl/include/CL/sycl/detail/boolean.hpp
+++ b/sycl/include/CL/sycl/detail/boolean.hpp
@@ -14,7 +14,7 @@
 #include <initializer_list>
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -29,7 +29,7 @@
 #include <memory>
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 // Forward declarations
 template <typename DataT, int Dimensions, access::mode AccessMode,

--- a/sycl/include/CL/sycl/detail/builtins.hpp
+++ b/sycl/include/CL/sycl/detail/builtins.hpp
@@ -67,7 +67,7 @@
   }
 
 #ifndef __SYCL_DEVICE_ONLY__
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace __host_std {
 #endif // __SYCL_DEVICE_ONLY__
 /* ----------------- 4.13.3 Math functions. ---------------------------------*/

--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -24,7 +24,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/clusm.hpp
+++ b/sycl/include/CL/sycl/detail/clusm.hpp
@@ -17,7 +17,7 @@
 #include <mutex>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace usm {

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <CL/sycl/detail/defines.hpp>
+
 // Suppress a compiler warning about undefined CL_TARGET_OPENCL_VERSION
 // Khronos ICD supports only latest OpenCL version
 #define CL_TARGET_OPENCL_VERSION 220
@@ -20,7 +22,7 @@
 #define STRINGIFY_LINE_HELP(s) #s
 #define STRINGIFY_LINE(s) STRINGIFY_LINE_HELP(s)
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 
@@ -85,21 +87,7 @@ static inline std::string codeToString(cl_int code){
 #define CHECK_OCL_CODE_NO_EXC(X) REPORT_OCL_ERR_TO_STREAM(X)
 #endif
 
-#ifndef __has_attribute
-#define __has_attribute(x) 0
-#endif
-
-#if __has_attribute(always_inline)
-#define ALWAYS_INLINE __attribute__((always_inline))
-#else
-#define ALWAYS_INLINE
-#endif
-
-#ifndef SYCL_EXTERNAL
-#define SYCL_EXTERNAL
-#endif
-
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 
@@ -175,7 +163,7 @@ struct NDLoopIterateImpl {
   }
 };
 
-// spcialization for DIM=0 to terminate recursion
+// Specialization for DIM=0 to terminate recursion
 template <int NDIMS, template <int> class LoopBoundTy, typename FuncTy,
           template <int> class LoopIndexTy>
 struct NDLoopIterateImpl<NDIMS, 0, LoopBoundTy, FuncTy, LoopIndexTy> {

--- a/sycl/include/CL/sycl/detail/common_info.hpp
+++ b/sycl/include/CL/sycl/detail/common_info.hpp
@@ -9,7 +9,7 @@
 #pragma once
 #include <CL/sycl/stl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -22,7 +22,7 @@
 #include <map>
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 // Forward declaration
 class device;

--- a/sycl/include/CL/sycl/detail/context_info.hpp
+++ b/sycl/include/CL/sycl/detail/context_info.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/defines.hpp
+++ b/sycl/include/CL/sycl/detail/defines.hpp
@@ -1,0 +1,29 @@
+//==---------- defines.hpp ----- Preprocessor directives -------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#ifndef __SYCL_DISABLE_NAMESPACE_INLINE__
+#define __SYCL_INLINE inline
+#else
+#define __SYCL_INLINE
+#endif // __SYCL_DISABLE_NAMESPACE_INLINE__
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(always_inline)
+#define ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define ALWAYS_INLINE
+#endif
+
+#ifndef SYCL_EXTERNAL
+#define SYCL_EXTERNAL
+#endif

--- a/sycl/include/CL/sycl/detail/device_impl.hpp
+++ b/sycl/include/CL/sycl/detail/device_impl.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/stl.hpp>
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // Forward declaration

--- a/sycl/include/CL/sycl/detail/device_info.hpp
+++ b/sycl/include/CL/sycl/detail/device_info.hpp
@@ -8,12 +8,13 @@
 
 #pragma once
 #include <CL/sycl/detail/common_info.hpp>
+#include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/detail/platform_impl.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/platform.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -15,7 +15,7 @@
 
 #include <cassert>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 class context;
 namespace detail {

--- a/sycl/include/CL/sycl/detail/event_info.hpp
+++ b/sycl/include/CL/sycl/detail/event_info.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/force_device.hpp
+++ b/sycl/include/CL/sycl/detail/force_device.hpp
@@ -8,9 +8,10 @@
 
 #pragma once
 
+#include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_lists.hpp
@@ -15,13 +15,13 @@
 // types of parameters to kernel functions
 
 // Forward declaration
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 template <typename T, int N> class vec;
 } // namespace sycl
 } // namespace cl
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace gtl {

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -18,7 +18,7 @@
 #include <limits>
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 class context;
 class event;

--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -18,7 +18,7 @@
 #include <cmath>
 #include <iostream>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -21,7 +21,7 @@
 #include <CL/sycl/range.hpp>
 #include <CL/sycl/stl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // forward declarations

--- a/sycl/include/CL/sycl/detail/image_ocl_types.hpp
+++ b/sycl/include/CL/sycl/detail/image_ocl_types.hpp
@@ -100,7 +100,7 @@ static RetType __invoke__ImageReadSampler(ImageT Img, CoordT Coords,
   return cl::sycl::detail::convertDataToType<TempRetT, RetType>(Ret);
 }
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/item_base.hpp
+++ b/sycl/include/CL/sycl/detail/item_base.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/range.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 template <int dimensions> class id;
 template <int dimensions> class range;

--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/detail/os_util.hpp> // for DLL_LOCAL used in int. header
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -18,7 +18,7 @@
 #include <cassert>
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 // Forward declaration
 class program;

--- a/sycl/include/CL/sycl/detail/kernel_info.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_info.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
@@ -18,7 +18,7 @@
 #include <mutex>
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 class KernelProgramCache {

--- a/sycl/include/CL/sycl/detail/locked.hpp
+++ b/sycl/include/CL/sycl/detail/locked.hpp
@@ -8,10 +8,12 @@
 
 #pragma once
 
+#include <CL/sycl/detail/defines.hpp>
+
 #include <functional>
 #include <mutex>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
   /// Represents a reference to value with appropriate lock acquired.

--- a/sycl/include/CL/sycl/detail/memory_manager.hpp
+++ b/sycl/include/CL/sycl/detail/memory_manager.hpp
@@ -16,7 +16,7 @@
 #include <memory>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/os_util.hpp
+++ b/sycl/include/CL/sycl/detail/os_util.hpp
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <CL/sycl/detail/defines.hpp>
+
 #include <cstdint>
 #include <stdlib.h>
 #include <string>
@@ -54,7 +56,7 @@
 
 #endif
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -17,7 +17,7 @@
 #include <cassert>
 #include <string>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace pi {

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -14,7 +14,7 @@
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // Forward declaration

--- a/sycl/include/CL/sycl/detail/platform_info.hpp
+++ b/sycl/include/CL/sycl/detail/platform_info.hpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/platform_util.hpp
+++ b/sycl/include/CL/sycl/detail/platform_util.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <CL/sycl/detail/defines.hpp>
 #include <cstdint>
 
 #ifdef _MSC_VER
@@ -15,7 +16,7 @@
 #define __builtin_expect(a, b) (a)
 #endif
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -22,7 +22,7 @@
 #include <fstream>
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 enum class program_state { none, compiled, linked };

--- a/sycl/include/CL/sycl/detail/program_manager/program_manager.hpp
+++ b/sycl/include/CL/sycl/detail/program_manager/program_manager.hpp
@@ -29,7 +29,7 @@ extern "C" void __tgt_unregister_lib(pi_device_binaries desc);
 
 // +++ }
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 class context;
 namespace detail {

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -20,7 +20,7 @@
 #include <CL/sycl/handler.hpp>
 #include <CL/sycl/property_list.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/sampler_impl.hpp
+++ b/sycl/include/CL/sycl/detail/sampler_impl.hpp
@@ -13,7 +13,7 @@
 
 #include <unordered_map>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 enum class addressing_mode : unsigned int;

--- a/sycl/include/CL/sycl/detail/scheduler/commands.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.hpp
@@ -12,10 +12,11 @@
 #include <memory>
 #include <vector>
 
+#include <CL/sycl/access/access.hpp>
 #include <CL/sycl/detail/accessor_impl.hpp>
 #include <CL/sycl/detail/cg.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/stl_type_traits.hpp
@@ -12,7 +12,7 @@
 #include <memory>
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/stream_impl.hpp
+++ b/sycl/include/CL/sycl/detail/stream_impl.hpp
@@ -15,7 +15,7 @@
 #include <CL/sycl/ordered_queue.hpp>
 #include <CL/sycl/queue.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 namespace detail {

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 namespace detail {

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -19,7 +19,7 @@
 
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/type_list.hpp
+++ b/sycl/include/CL/sycl/detail/type_list.hpp
@@ -13,7 +13,7 @@
 
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/type_traits.hpp
@@ -16,7 +16,7 @@
 
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // Forward declaration

--- a/sycl/include/CL/sycl/detail/usm_dispatch.hpp
+++ b/sycl/include/CL/sycl/detail/usm_dispatch.hpp
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace usm {

--- a/sycl/include/CL/sycl/detail/usm_impl.hpp
+++ b/sycl/include/CL/sycl/detail/usm_impl.hpp
@@ -11,7 +11,7 @@
 #include <CL/cl_usm_ext.h>
 #include <CL/sycl/usm/usm_enums.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace usm {

--- a/sycl/include/CL/sycl/detail/util.hpp
+++ b/sycl/include/CL/sycl/detail/util.hpp
@@ -10,9 +10,11 @@
 
 #ifndef __SYCL_DEVICE_ONLY
 
+#include <CL/sycl/detail/defines.hpp>
+
 #include <mutex>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/device.hpp
+++ b/sycl/include/CL/sycl/device.hpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <utility>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 // Forward declarations
 class device_selector;

--- a/sycl/include/CL/sycl/device_event.hpp
+++ b/sycl/include/CL/sycl/device_event.hpp
@@ -11,7 +11,7 @@
 #include <CL/__spirv/spirv_ops.hpp>
 #include <CL/__spirv/spirv_types.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 class device_event {

--- a/sycl/include/CL/sycl/device_selector.hpp
+++ b/sycl/include/CL/sycl/device_selector.hpp
@@ -10,7 +10,7 @@
 
 // 4.6.1 Device selection class
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // Forward declarations

--- a/sycl/include/CL/sycl/event.hpp
+++ b/sycl/include/CL/sycl/event.hpp
@@ -13,7 +13,7 @@
 
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 // Forward declaration
 class context;

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -15,7 +15,7 @@
 
 #include <exception>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // Forward declaration

--- a/sycl/include/CL/sycl/exception_list.hpp
+++ b/sycl/include/CL/sycl/exception_list.hpp
@@ -10,11 +10,12 @@
 
 // 4.9.2 Exception Class Interface
 
+#include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <cstddef>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // Forward declaration

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -21,7 +21,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 class Builder;

--- a/sycl/include/CL/sycl/h_item.hpp
+++ b/sycl/include/CL/sycl/h_item.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/item.hpp>
 #include <CL/sycl/range.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 namespace detail {

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -8,13 +8,15 @@
 
 #pragma once
 
+#include <CL/sycl/detail/defines.hpp>
+
 #include <cmath>
 #include <cstdint>
 #include <functional>
 #include <iostream>
 #include <limits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace half_impl {

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -59,7 +59,7 @@ template <typename T_Src, int Dims_Src, cl::sycl::access::mode AccessMode_Src,
           cl::sycl::access::placeholder IsPlaceholder_Dst>
 class __copyAcc2Acc;
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // Forward declaration

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/range.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 template <int dimensions> class range;
 template <int dimensions, bool with_offset> class item;

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -16,7 +16,7 @@
 #include <CL/sycl/types.hpp>
 #include <cstddef>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 enum class image_channel_order : unsigned int {

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/id.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 class program;

--- a/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
@@ -10,7 +10,7 @@
 
 #include <CL/sycl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace intel {
 

--- a/sycl/include/CL/sycl/intel/fpga_reg.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_reg.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace intel {
 

--- a/sycl/include/CL/sycl/intel/function_pointer.hpp
+++ b/sycl/include/CL/sycl/intel/function_pointer.hpp
@@ -14,7 +14,7 @@
 
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace intel {
 

--- a/sycl/include/CL/sycl/intel/functional.hpp
+++ b/sycl/include/CL/sycl/intel/functional.hpp
@@ -9,7 +9,7 @@
 #pragma once
 #include <functional>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace intel {
 

--- a/sycl/include/CL/sycl/intel/pipes.hpp
+++ b/sycl/include/CL/sycl/intel/pipes.hpp
@@ -12,7 +12,7 @@
 #include <CL/__spirv/spirv_types.hpp>
 #include <CL/sycl/stl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace intel {
 

--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 #ifdef __SYCL_DEVICE_ONLY__
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 template <typename T, access::address_space Space> class multi_ptr;
 

--- a/sycl/include/CL/sycl/intel/sub_group_host.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group_host.hpp
@@ -15,7 +15,7 @@
 #include <CL/sycl/types.hpp>
 #ifndef __SYCL_DEVICE_ONLY__
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 template <typename T, access::address_space Space> class multi_ptr;
 namespace intel {

--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -14,7 +14,7 @@
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/range.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 class Builder;

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 // Forward declaration
 class program;

--- a/sycl/include/CL/sycl/multi_ptr.hpp
+++ b/sycl/include/CL/sycl/multi_ptr.hpp
@@ -13,7 +13,7 @@
 #include <cassert>
 #include <cstddef>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 // Forward declaration
 template <typename dataT, int dimensions, access::mode accessMode,

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/__spirv/spirv_ops.hpp>
 #include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/group.hpp>
 #include <CL/sycl/id.hpp>
@@ -21,7 +22,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 class Builder;

--- a/sycl/include/CL/sycl/nd_range.hpp
+++ b/sycl/include/CL/sycl/nd_range.hpp
@@ -13,7 +13,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 template <int dimensions = 1> class nd_range {

--- a/sycl/include/CL/sycl/ordered_queue.hpp
+++ b/sycl/include/CL/sycl/ordered_queue.hpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <utility>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // Forward declaration

--- a/sycl/include/CL/sycl/pipes.hpp
+++ b/sycl/include/CL/sycl/pipes.hpp
@@ -10,7 +10,7 @@
 
 #include <CL/sycl/intel/pipes.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 template <class name, class dataT, int32_t min_capacity = 0>
 using pipe = intel::pipe<name, dataT, min_capacity>;

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -13,7 +13,7 @@
 
 // 4.6.2 Platform class
 #include <utility>
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 // TODO: make code thread-safe
 

--- a/sycl/include/CL/sycl/pointers.hpp
+++ b/sycl/include/CL/sycl/pointers.hpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/access/access.hpp>
 
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 template <typename ElementType, access::address_space Space> class multi_ptr;

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -15,7 +15,7 @@
 
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 class context;

--- a/sycl/include/CL/sycl/property_list.hpp
+++ b/sycl/include/CL/sycl/property_list.hpp
@@ -13,7 +13,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // HOW TO ADD NEW PROPERTY INSTRUCTION:

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <utility>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 // Forward declaration

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -12,7 +12,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 template <int dimensions> class id;
 template <int dimensions = 1> class range : public detail::array<dimensions> {

--- a/sycl/include/CL/sycl/sampler.hpp
+++ b/sycl/include/CL/sycl/sampler.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/sampler_impl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 enum class addressing_mode : unsigned int {
   mirrored_repeat = CL_ADDRESS_MIRRORED_REPEAT,

--- a/sycl/include/CL/sycl/stl.hpp
+++ b/sycl/include/CL/sycl/stl.hpp
@@ -10,6 +10,8 @@
 
 // 4.5 C++ Standard library classes required for the interface
 
+#include <CL/sycl/detail/defines.hpp>
+
 #include <exception>
 #include <functional>
 #include <memory>
@@ -17,7 +19,7 @@
 #include <string>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
  template < class T, class Alloc = std::allocator<T> >

--- a/sycl/include/CL/sycl/stream.hpp
+++ b/sycl/include/CL/sycl/stream.hpp
@@ -10,7 +10,7 @@
 
 #include <CL/sycl/detail/stream_impl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 enum class stream_manipulator {

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -45,6 +45,7 @@
 #endif // __HAS_EXT_VECTOR_TYPE__
 
 #include <CL/sycl/aliases.hpp>
+#include <CL/sycl/access/access.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/half_type.hpp>
@@ -60,7 +61,7 @@
 // 4.10.1: Scalar data types
 // 4.10.2: SYCL vector types
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 enum class rounding_mode { automatic, rte, rtz, rtp, rtn };
@@ -1837,7 +1838,7 @@ using __half16_vec_t = half_vec<16>;
 
 #define GET_CL_HALF_TYPE(target, num) __##target##num##_vec_t
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 // select_apply_cl_t selects from T8/T16/T32/T64 basing on

--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 ///
 // Explicit USM

--- a/sycl/include/CL/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/CL/sycl/usm/usm_allocator.hpp
@@ -17,7 +17,7 @@
 #include <cstdlib>
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 template <typename T, usm::alloc AllocKind, size_t Alignment = 0>

--- a/sycl/include/CL/sycl/usm/usm_enums.hpp
+++ b/sycl/include/CL/sycl/usm/usm_enums.hpp
@@ -7,7 +7,7 @@
 // ===--------------------------------------------------------------------=== //
 #pragma once
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace usm {
 

--- a/sycl/source/detail/builtins_helper.hpp
+++ b/sycl/source/detail/builtins_helper.hpp
@@ -206,7 +206,7 @@
   __MAKE_1V_2V_3P(Fun, 8, Ret, Arg1, Arg2, Arg3)                               \
   __MAKE_1V_2V_3P(Fun, 16, Ret, Arg1, Arg2, Arg3)
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace __host_std {
 namespace detail {
 

--- a/sycl/test/regression/kernel_name_inside_sycl_namespace.cpp
+++ b/sycl/test/regression/kernel_name_inside_sycl_namespace.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -D__SYCL_DISABLE_NAMESPACE_INLINE__ %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
The inlining is enabled by default and make using SYCL API a little bit
easier.

In order to disable cl namespace inlining user should define
`__SYCL_DISABLE_NAMESPACE_INLINE__` macro.