### PR TITLE
[SYCL]Add device libraries for C math and complex

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -138,48 +138,52 @@ static bool IsSyclMathFunc(unsigned BuiltinID) {
   case Builtin::BI__builtin_truncl:
   case Builtin::BIlroundl:
   case Builtin::BI__builtin_lroundl:
+  case Builtin::BIceil:
+  case Builtin::BI__builtin_ceil:
+  case Builtin::BIcopysign:
+  case Builtin::BI__builtin_copysign:
+  case Builtin::BIfabs:
+  case Builtin::BI__builtin_fabs:
+  case Builtin::BIfloor:
+  case Builtin::BI__builtin_floor:
+  case Builtin::BIfmax:
+  case Builtin::BI__builtin_fmax:
+  case Builtin::BIfmin:
+  case Builtin::BI__builtin_fmin:
+  case Builtin::BInearbyint:
+  case Builtin::BI__builtin_nearbyint:
+  case Builtin::BIrint:
+  case Builtin::BI__builtin_rint:
+  case Builtin::BIround:
+  case Builtin::BI__builtin_round:
+  case Builtin::BItrunc:
+  case Builtin::BI__builtin_trunc:
   case Builtin::BIceilf:
   case Builtin::BI__builtin_ceilf:
   case Builtin::BIcopysignf:
   case Builtin::BI__builtin_copysignf:
-  case Builtin::BIcosf:
-  case Builtin::BI__builtin_cosf:
-  case Builtin::BIexpf:
-  case Builtin::BI__builtin_expf:
-  case Builtin::BIexp2f:
-  case Builtin::BI__builtin_exp2f:
   case Builtin::BIfabsf:
   case Builtin::BI__builtin_fabsf:
   case Builtin::BIfloorf:
   case Builtin::BI__builtin_floorf:
-  case Builtin::BIfmaf:
-  case Builtin::BI__builtin_fmaf:
   case Builtin::BIfmaxf:
   case Builtin::BI__builtin_fmaxf:
   case Builtin::BIfminf:
   case Builtin::BI__builtin_fminf:
-  case Builtin::BIfmodf:
-  case Builtin::BI__builtin_fmodf:
-  case Builtin::BIlogf:
-  case Builtin::BI__builtin_logf:
-  case Builtin::BIlog10f:
-  case Builtin::BI__builtin_log10f:
-  case Builtin::BIlog2f:
-  case Builtin::BI__builtin_log2f:
-  case Builtin::BIpowf:
-  case Builtin::BI__builtin_powf:
+  case Builtin::BInearbyintf:
+  case Builtin::BI__builtin_nearbyintf:
   case Builtin::BIrintf:
   case Builtin::BI__builtin_rintf:
   case Builtin::BIroundf:
   case Builtin::BI__builtin_roundf:
-  case Builtin::BIsinf:
-  case Builtin::BI__builtin_sinf:
-  case Builtin::BIsqrtf:
-  case Builtin::BI__builtin_sqrtf:
   case Builtin::BItruncf:
   case Builtin::BI__builtin_truncf:
   case Builtin::BIlroundf:
   case Builtin::BI__builtin_lroundf:
+  case Builtin::BI__builtin_fpclassify:
+  case Builtin::BI__builtin_isfinite:
+  case Builtin::BI__builtin_isinf:
+  case Builtin::BI__builtin_isnormal:
     return false;
   default:
     break;

--- a/clang/test/SemaSYCL/unsupported_math.cpp
+++ b/clang/test/SemaSYCL/unsupported_math.cpp
@@ -1,5 +1,14 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
-
+extern "C" float  sinf(float);
+extern "C" float  cosf(float);
+extern "C" float  logf(float);
+extern "C" float  ceilf(float);
+extern "C" float  fabsf(float);
+extern "C" double sin(double);
+extern "C" double cos(double);
+extern "C" double log(double);
+extern "C" double ceil(double);
+extern "C" double fabs(double);
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
   kernelFunc();
@@ -9,9 +18,29 @@ int main() {
   kernel<class kernel_function>([=]() {
     int acc[1] = {5};
     acc[0] *= 2;
-    acc[0] += (int)__builtin_fabsf(-1.0f);       // expected-error{{builtin is not supported on this target}}
-    acc[0] += (int)__builtin_cosf(-1.0f);        // expected-error{{builtin is not supported on this target}}
-    acc[0] += (int)__builtin_powf(-1.0f, 10.0f); // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)sinf(1.0f);                  // expected-no-error
+    acc[0] += (int)sin(1.0);                    // expected-no-error
+    acc[0] += (int)__builtin_sinf(1.0f);        // expected-no-error
+    acc[0] += (int)__builtin_sin(1.0);          // expected-no-error
+    acc[0] += (int)cosf(1.0f);                  // expected-no-error
+    acc[0] += (int)cos(1.0);                    // expected-no-error
+    acc[0] += (int)__builtin_cosf(1.0f);        // expected-no-error
+    acc[0] += (int)__builtin_cos(1.0);          // expected-no-error
+    acc[0] += (int)logf(1.0f);                  // expected-no-error
+    acc[0] += (int)log(1.0);                    // expected-no-error
+    acc[0] += (int)__builtin_logf(1.0f);        // expected-no-error
+    acc[0] += (int)__builtin_log(1.0);          // expected-no-error
+    acc[0] += (int)ceilf(1.0f);                 // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)ceil(1.0);                   // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)__builtin_ceilf(1.0f);       // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)__builtin_ceil(1.0);         // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)fabsf(-1.0f);                // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)fabs(-1.0);                  // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)__builtin_fabsf(-1.0f);      // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)__builtin_fabs(-1.0);        // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)__builtin_fabsl(-1.0);       // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)__builtin_cosl(-1.0);        // expected-error{{builtin is not supported on this target}}
+    acc[0] += (int)__builtin_powl(-1.0, 10.0);  // expected-error{{builtin is not supported on this target}}
   });
   return 0;
 }

--- a/sycl/doc/extensions/C-CXX-StandardLibrary/C-CXX-StandardLibrary.rst
+++ b/sycl/doc/extensions/C-CXX-StandardLibrary/C-CXX-StandardLibrary.rst
@@ -23,10 +23,97 @@ or, in case of Windows:
    clang++ -fsycl main.obj %SYCL_INSTALL%/lib/libsycl-msvc.o -o a.exe
 
 List of supported functions from C standard library:
-  - assert macro (from <assert.h> or <cassert>)
+  - assert macro          (from <assert.h> or <cassert>)
+  - logf, log             (from <math.h> or <cmath>)
+  - expf, exp             (from <math.h> or <cmath>)
+  - frexpf, frexp         (from <math.h> or <cmath>)
+  - ldexpf, ldexp         (from <math.h> or <cmath>)
+  - log10f, log10         (from <math.h> or <cmath>)
+  - modff, modf           (from <math.h> or <cmath>)
+  - exp2f, exp2           (from <math.h> or <cmath>)
+  - expm1f, expm1         (from <math.h> or <cmath>)
+  - ilogbf, ilogb         (from <math.h> or <cmath>)
+  - log1pf, log1p         (from <math.h> or <cmath>)
+  - log2f, log2           (from <math.h> or <cmath>)
+  - logbf, logb           (from <math.h> or <cmath>)
+  - sqrtf, sqrt           (from <math.h> or <cmath>)
+  - cbrtf, cbrt           (from <math.h> or <cmath>)
+  - hypotf, hypot         (from <math.h> or <cmath>)
+  - erff, erf             (from <math.h> or <cmath>)
+  - erfcf, erfc           (from <math.h> or <cmath>)
+  - tgammaf, tgamma       (from <math.h> or <cmath>)
+  - lgammaf, lgamma       (from <math.h> or <cmath>)
+  - fmodf, fmod           (from <math.h> or <cmath>)
+  - remainderf, remainder (from <math.h> or <cmath>)
+  - remquof, remquo       (from <math.h> or <cmath>)
+  - nextafterf, nextafter (from <math.h> or <cmath>)
+  - fdimf, fdim           (from <math.h> or <cmath>)
+  - fmaf, fma             (from <math.h> or <cmath>)
+  - sinf, sin             (from <math.h> or <cmath>)
+  - cosf, cos             (from <math.h> or <cmath>)
+  - tanf, tan             (from <math.h> or <cmath>)
+  - powf, pow             (from <math.h> or <cmath>)
+  - acosf, acos           (from <math.h> or <cmath>)
+  - asinf, asin           (from <math.h> or <cmath>)
+  - atanf, atan           (from <math.h> or <cmath>)
+  - atan2f, atan2         (from <math.h> or <cmath>)
+  - coshf, cosh           (from <math.h> or <cmath>)
+  - sinhf, sinh           (from <math.h> or <cmath>)
+  - tanhf, tanh           (from <math.h> or <cmath>)
+  - acoshf, acosh         (from <math.h> or <cmath>)
+  - asinhf, asinh         (from <math.h> or <cmath>)
+  - atanhf, atanh         (from <math.h> or <cmath>)
+  - cimagf, cimag         (from <complex.h>)
+  - crealf, creal         (from <complex.h>)
+  - cargf, carg           (from <complex.h>)
+  - cabsf, cabs           (from <complex.h>)
+  - cprojf, cproj         (from <complex.h>)
+  - cexpf, cexp           (from <complex.h>)
+  - clogf, clog           (from <complex.h>)
+  - cpowf, cpow           (from <complex.h>)
+  - cpolarf, cpolar       (from <complex.h>)
+  - csqrtf, csqrt         (from <complex.h>)
+  - csinhf, csinh         (from <complex.h>)
+  - ccoshf, ccosh         (from <complex.h>)
+  - ctanhf, ctanh         (from <complex.h>)
+  - csinf, csin           (from <complex.h>)
+  - ccosf, ccos           (from <complex.h>)
+  - ctanf, ctan           (from <complex.h>)
+  - casinhf, casinh       (from <complex.h>)
+  - cacoshf, cacosh       (from <complex.h>)
+  - catanhf, catanh       (from <complex.h>)
+  - casinf, casin         (from <complex.h>)
+  - cacosf, cacos         (from <complex.h>)
+  - catanf, catan         (from <complex.h>)
 
-NOTE: only the GNU glibc and Microsoft C libraries are currently
-supported.
+All functions are grouped into different device libraries based on
+functionalities. C and C++ standard library groups functions and
+classes by purpose(e.g. <math.h> for mathematical operations and
+transformations) and device library infrastructure uses this as
+a baseline.
+NOTE: Only the GNU glibc, Microsoft C libraries are currently
+supported. The device libraries for <math.h> and <complex.h> are
+ready for Linux and Windows support will be added in the future.
+Not all functions from <math.h> are supported right now, following
+math functions are not supported now:
+ - abs
+ - ceilf, ceil
+ - copysignf, copysign
+ - fabsf, fabs
+ - floorf, floor
+ - fmaxf, fmax
+ - fminf, fmin
+ - nextafterf, nextafter
+ - rintf, rint
+ - roundf, round
+ - truncf, trunc
+ - scalbnf, scalbn
+ - nearbyintf, nearbyint
+ - lrintf, lrint
+ - nexttowardf, nexttoward
+ - nanf, nan
+Device libraries can't support both single and double precision as some
+underlying device may not support double precision.
 
 Example of usage
 ================
@@ -57,6 +144,31 @@ Example of usage
      });
      deviceQueue.wait_and_throw();
    }
+
+
+.. code: c++
+   #include <math.h>
+   #include <CL/sycl.hpp>
+
+   void device_sin_test() {
+     cl::sycl::queue deviceQueue;
+     cl::sycl::range<1> numOfItems{1};
+     float  result_f = -1.f;
+     double result_d = -1.d;
+     {
+       cl::sycl::buffer<float, 1> buffer1(&result_f, numOfItems);
+       cl::sycl::buffer<double, 1> buffer2(&result_d, numOfItems);
+       deviceQueue.submit([&](cl::sycl::handler &cgh) {
+         auto res_access1 = buffer1.get_access<sycl_write>(cgh);
+         auto res_access2 = buffer2.get_access<sycl_write>(cgh);
+         cgh.single_task<class DeviceSin>([=]() {
+           res_access1[0] = sinf(0.f);
+           res_access2[0] = sin(0.0);
+         });
+       });
+     }
+     assert((result_f == 0.f) && (result_d == 0.0));
+  }
 
 Frontend
 ========

--- a/sycl/doc/extensions/C-CXX-StandardLibrary/DeviceLibExtensions.rst
+++ b/sycl/doc/extensions/C-CXX-StandardLibrary/DeviceLibExtensions.rst
@@ -32,3 +32,189 @@ Arguments:
 Example of a message:
 .. code:
    foo.cpp:42: void foo(int): global id: [0,0,0], local id: [0,0,0] Assertion `buf[wiID] == 0 && "Invalid value"` failed.
+
+cl_intel_devicelib_math
+==========================
+
+.. code:
+   float  __devicelib_logf(float x);
+   float  __devicelib_sinf(float x);
+   float  __devicelib_cosf(float x);
+   float  __devicelib_tanf(float x);
+   float  __devicelib_acosf(float x);
+   float  __devicelib_powf(float x, float y);
+   float  __devicelib_sqrtf(float x);
+   float  __devicelib_cbrtf(float x);
+   float  __devicelib_hypotf(float x, float y);
+   float  __devicelib_erff(float x);
+   float  __devicelib_erfcf(float x);
+   float  __devicelib_tgammaf(float x);
+   float  __devicelib_lgammaf(float x);
+   float  __devicelib_fmodf(float x, float y);
+   float  __devicelib_remainderf(float x, float y);
+   float  __devicelib_remquof(float x, float y, int *q);
+   float  __devicelib_nextafterf(float x, float y);
+   float  __devicelib_fdimf(float x, float y);
+   float  __devicelib_fmaf(float x, float y, float z);
+   float  __devicelib_asinf(float x);
+   float  __devicelib_atanf(float x);
+   float  __devicelib_atan2f(float x, float y);
+   float  __devicelib_coshf(float x);
+   float  __devicelib_sinhf(float x);
+   float  __devicelib_tanhf(float x);
+   float  __devicelib_acoshf(float x);
+   float  __devicelib_asinhf(float x);
+   float  __devicelib_atanhf(float x);
+   float  __devicelib_frexpf(float x, int *exp);
+   float  __devicelib_ldexpf(float x, int exp);
+   float  __devicelib_log10f(float x);
+   float  __devicelib_modff(float x, float *intpart);
+   float  __devicelib_expf(float x);
+   float  __devicelib_exp2f(float x);
+   float  __devicelib_expm1f(float x);
+   int    __devicelib_ilogbf(float x);
+   float  __devicelib_log1pf(float x);
+   float  __devicelib_log2f(float x);
+   float  __devicelib_logbf(float x);
+
+Semantic:
+Those __devicelib_* functions perform the same operation as the corresponding C math
+library functions for single precision. These functions do not support errno, and on
+some devices floating-point exceptions may not be raised.
+
+Arguments:
+Those __devicelib_* functions have the same argument type and return type as corresponding
+math functions from <math.h>, please refer to ISO/IEC 14882:2011 for details.
+
+cl_intel_devicelib_math_fp64
+==========================
+
+.. code:
+   double __devicelib_log(double x);
+   double __devicelib_sin(double x);
+   double __devicelib_cos(double x);
+   double __devicelib_tan(double x);
+   double __devicelib_acos(double x);
+   double __devicelib_pow(double x, double y);
+   double __devicelib_sqrt(double x);
+   double __devicelib_cbrt(double x);
+   double __devicelib_hypot(double x, double y);
+   double __devicelib_erf(double x);
+   double __devicelib_erfc(double x);
+   double __devicelib_tgamma(double x);
+   double __devicelib_lgamma(double x);
+   double __devicelib_fmod(double x, double y);
+   double __devicelib_remainder(double x, double y);
+   double __devicelib_remquo(double x, double y, int *q);
+   double __devicelib_nextafter(double x, double y);
+   double __devicelib_fdim(double x, double y);
+   double __devicelib_fma(double x, double y, double z);
+   double __devicelib_asin(double x);
+   double __devicelib_atan(double x);
+   double __devicelib_atan2(double x, double y);
+   double __devicelib_cosh(double x);
+   double __devicelib_sinh(double x);
+   double __devicelib_tanh(double x);
+   double __devicelib_acosh(double x);
+   double __devicelib_asinh(double x);
+   double __devicelib_atanh(double x);
+   double __devicelib_frexp(double x, int *exp);
+   double __devicelib_ldexp(double x, int exp);
+   double __devicelib_log10(double x);
+   double __devicelib_modf(double x, double *intpart);
+   double __devicelib_exp(double x);
+   double __devicelib_exp2(double x);
+   double __devicelib_expm1(double x);
+   int    __devicelib_ilogb(double x);
+   double __devicelib_log1p(double x);
+   double __devicelib_log2(double x);
+   double __devicelib_logb(double x);
+
+Semantic:
+Those __devicelib_* functions perform the same operation as the corresponding C math
+library functions for double precision. These functions do not support errno, and on
+some devices floating-point exceptions may not be raised.
+
+Arguments:
+Those __devicelib_* functions have the same argument type and return type as corresponding
+math functions from <math.h>, please refer to ISO/IEC 14882:2011 for details.
+
+cl_intel_devicelib_complex
+==========================
+
+.. code:
+   float  __devicelib_cimagf(float __complex__ z);
+   float  __devicelib_crealf(float __complex__ z);
+   float  __devicelib_cargf(float __complex__ z);
+   float  __devicelib_cabsf(float __complex__ z);
+   float  __complex__ __devicelib_cprojf(float __complex__ z);
+   float  __complex__ __devicelib_cexpf(float __complex__ z);
+   float  __complex__ __devicelib_clogf(float __complex__ z);
+   float  __complex__ __devicelib_cpowf(float __complex__ x, float __complex__ y);
+   float  __complex__ __devicelib_cpolarf(float x, float y);
+   float  __complex__ __devicelib_csqrtf(float __complex__ z);
+   float  __complex__ __devicelib_csinhf(float __complex__ z);
+   float  __complex__ __devicelib_ccoshf(float __complex__ z);
+   float  __complex__ __devicelib_ctanhf(float __complex__ z);
+   float  __complex__ __devicelib_csinf(float __complex__ z);
+   float  __complex__ __devicelib_ccosf(float __complex__ z);
+   float  __complex__ __devicelib_ctanf(float __complex__ z);
+   float  __complex__ __devicelib_cacosf(float __complex__ z);
+   float  __complex__ __devicelib_casinhf(float __complex__ z);
+   float  __complex__ __devicelib_casinf(float __complex__ z);
+   float  __complex__ __devicelib_cacoshf(float __complex__ z);
+   float  __complex__ __devicelib_catanhf(float __complex__ z);
+   float  __complex__ __devicelib_catanf(float __complex__ z);
+   float  __complex__ __devicelib___mulsc3(float a, float b, float c, float d);
+   float  __complex__ __devicelib___divsc3(float a, float b, float c, float d);
+
+Semantic:
+Those __devicelib_* functions perform the same operation as the corresponding C math
+library functions for single precision. These functions do not support errno, and on
+some devices floating-point exceptions may not be raised.
+
+Arguments:
+Those __devicelib_* functions have the same argument type and return type as corresponding
+complex math functions from <complex.h>, please refer to ISO/IEC 14882:2011 for details. The
+"float __complex__" type is C99 complex type and it is an alias to "struct {float, float}"
+in LLVM IR and SPIR-V.
+
+cl_intel_devicelib_complex_fp64
+==========================
+
+.. code:
+   double __devicelib_cimag(double __complex__ z);
+   double __devicelib_creal(double __complex__ z);
+   double __devicelib_carg(double __complex__ z);
+   double __devicelib_cabs(double __complex__ z);
+   double __complex__ __devicelib_cproj(double __complex__ z);
+   double __complex__ __devicelib_cexp(double __complex__ z);
+   double __complex__ __devicelib_clog(double __complex__ z);
+   double __complex__ __devicelib_cpow(double __complex__ x, double __complex__ y);
+   double __complex__ __devicelib_cpolar(double x, double y);
+   double __complex__ __devicelib_csqrt(double __complex__ z);
+   double __complex__ __devicelib_csinh(double __complex__ z);
+   double __complex__ __devicelib_ccosh(double __complex__ z);
+   double __complex__ __devicelib_ctanh(double __complex__ z);
+   double __complex__ __devicelib_csin(double __complex__ z);
+   double __complex__ __devicelib_ccos(double __complex__ z);
+   double __complex__ __devicelib_ctan(double __complex__ z);
+   double __complex__ __devicelib_cacos(double __complex__ z);
+   double __complex__ __devicelib_casinh(double __complex__ z);
+   double __complex__ __devicelib_casin(double __complex__ z);
+   double __complex__ __devicelib_cacosh(double __complex__ z);
+   double __complex__ __devicelib_catanh(double __complex__ z);
+   double __complex__ __devicelib_catan(double __complex__ z);
+   double __complex__ __devicelib___muldc3(double a, double b, double c, double d);
+   double __complex__ __devicelib___divdc3(double a, double b, double c, double d);
+
+Semantic:
+Those __devicelib_* functions perform the same operation as the corresponding C math
+library functions for double precision. These functions do not support errno, and on
+some devices floating-point exceptions may not be raised.
+
+Arguments:
+Those __devicelib_* functions have the same argument type and return type as corresponding
+complex math functions from <complex.h>, please refer to ISO/IEC 14882:2011 for details. The
+"double __complex__" type is C99 complex type and it is an alias to "struct {double, double}"
+in LLVM IR and SPIR-V.

--- a/sycl/include/CL/sycl/detail/program_manager/program_manager.hpp
+++ b/sycl/include/CL/sycl/detail/program_manager/program_manager.hpp
@@ -44,7 +44,11 @@ using DeviceImage = pi_device_binary_struct;
 struct ImageDeleter;
 
 enum DeviceLibExt {
-  cl_intel_devicelib_assert = 0
+  cl_intel_devicelib_assert = 0,
+  cl_intel_devicelib_math,
+  cl_intel_devicelib_math_fp64,
+  cl_intel_devicelib_complex,
+  cl_intel_devicelib_complex_fp64
 };
 
 // Provides single loading and building OpenCL programs with unique contexts

--- a/sycl/source/detail/devicelib/CMakeLists.txt
+++ b/sycl/source/detail/devicelib/CMakeLists.txt
@@ -36,6 +36,47 @@ else()
                        VERBATIM)
 endif()
 
+
+set(devicelib-obj-complex ${binary_dir}/libsycl-complex.o)
+add_custom_command(OUTPUT ${devicelib-obj-complex}
+                   COMMAND ${clang} -fsycl -c
+                           ${compile_opts}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/complex_wrapper.cpp
+                           -o ${devicelib-obj-complex}
+                   MAIN_DEPENDENCY complex_wrapper.cpp
+                   DEPENDS device_complex.h clang
+                   VERBATIM)
+
+set(devicelib-obj-complex-fp64 ${binary_dir}/libsycl-complex-fp64.o)
+add_custom_command(OUTPUT ${devicelib-obj-complex-fp64}
+                   COMMAND ${clang} -fsycl -c
+                           ${compile_opts}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/complex_wrapper_fp64.cpp
+                           -o ${devicelib-obj-complex-fp64}
+                   MAIN_DEPENDENCY complex_wrapper_fp64.cpp
+                   DEPENDS device_complex.h clang
+                   VERBATIM)
+
+set(devicelib-obj-cmath ${binary_dir}/libsycl-cmath.o)
+add_custom_command(OUTPUT ${devicelib-obj-cmath}
+                   COMMAND ${clang} -fsycl -c
+                           ${compile_opts}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/cmath_wrapper.cpp
+                           -o ${devicelib-obj-cmath}
+                   MAIN_DEPENDENCY cmath_wrapper.cpp
+                   DEPENDS device_complex.h clang
+                   VERBATIM)
+
+set(devicelib-obj-cmath-fp64 ${binary_dir}/libsycl-cmath-fp64.o)
+add_custom_command(OUTPUT ${devicelib-obj-cmath-fp64}
+                   COMMAND ${clang} -fsycl -c
+                           ${compile_opts}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/cmath_wrapper_fp64.cpp
+                           -o ${devicelib-obj-cmath-fp64}
+                   MAIN_DEPENDENCY cmath_wrapper_fp64.cpp
+                   DEPENDS device_math.h clang
+                   VERBATIM)
+
 add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cassert.spv
                    COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
                            ${compile_opts}
@@ -45,8 +86,52 @@ add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cassert.spv
                    DEPENDS wrapper.h clang llvm-spirv
                    VERBATIM)
 
-add_custom_target(devicelib-obj DEPENDS ${devicelib-obj-file})
-add_custom_target(devicelib-spv DEPENDS ${binary_dir}/libsycl-fallback-cassert.spv)
+add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex.spv
+                   COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
+                           ${compile_opts}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex.cpp
+                           -o ${binary_dir}/libsycl-fallback-complex.spv
+                   MAIN_DEPENDENCY fallback-complex.cpp
+                   DEPENDS device_math.h device_complex.h clang llvm-spirv
+                   VERBATIM)
+
+add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex-fp64.spv
+                   COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
+                           ${compile_opts}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex-fp64.cpp
+                           -o ${binary_dir}/libsycl-fallback-complex-fp64.spv
+                   MAIN_DEPENDENCY fallback-complex-fp64.cpp
+                   DEPENDS device_math.h device_complex.h clang llvm-spirv
+                   VERBATIM)
+
+add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath.spv
+                   COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
+                           ${compile_opts}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath.cpp
+                           -o ${binary_dir}/libsycl-fallback-cmath.spv
+                   MAIN_DEPENDENCY fallback-cmath.cpp
+                   DEPENDS device_math.h clang llvm-spirv
+                   VERBATIM)
+
+add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath-fp64.spv
+                   COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
+                           ${compile_opts}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath-fp64.cpp
+                           -o ${binary_dir}/libsycl-fallback-cmath-fp64.spv
+                   MAIN_DEPENDENCY fallback-cmath-fp64.cpp
+                   DEPENDS device_math.h clang llvm-spirv
+                   VERBATIM)
+
+add_custom_target(devicelib-obj DEPENDS ${devicelib-obj-file}
+                                        ${devicelib-obj-complex}
+					${devicelib-obj-complex-fp64}
+                                        ${devicelib-obj-cmath}
+					${devicelib-obj-cmath-fp64})
+add_custom_target(devicelib-spv DEPENDS ${binary_dir}/libsycl-fallback-cassert.spv
+                                        ${binary_dir}/libsycl-fallback-complex.spv
+					${binary_dir}/libsycl-fallback-complex-fp64.spv
+                                        ${binary_dir}/libsycl-fallback-cmath.spv
+					${binary_dir}/libsycl-fallback-cmath-fp64.spv)
 add_dependencies(sycl devicelib-obj devicelib-spv)
 if (MSVC)
     add_dependencies(sycld devicelib-obj devicelib-spv)
@@ -62,5 +147,13 @@ endif()
 
 install(FILES ${devicelib-obj-file}
               ${binary_dir}/libsycl-fallback-cassert.spv
+              ${devicelib-obj-complex}
+              ${binary_dir}/libsycl-fallback-complex.spv
+              ${devicelib-obj-complex-fp64}
+              ${binary_dir}/libsycl-fallback-complex-fp64.spv
+              ${devicelib-obj-cmath}
+              ${binary_dir}/libsycl-fallback-cmath.spv
+              ${devicelib-obj-cmath-fp64}
+              ${binary_dir}/libsycl-fallback-cmath-fp64.spv
         DESTINATION ${install_dest}
         COMPONENT sycl)

--- a/sycl/source/detail/devicelib/cmath_wrapper.cpp
+++ b/sycl/source/detail/devicelib/cmath_wrapper.cpp
@@ -1,0 +1,211 @@
+//==--- cmath_wrapper.cpp - wrappers for C math library functions ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifdef __SYCL_DEVICE_ONLY__
+#include "device_math.h"
+extern "C" {
+SYCL_EXTERNAL
+float __attribute__((weak)) scalbnf(float x, int n) {
+  return __devicelib_scalbnf(x, n);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) logf(float x) {
+  return __devicelib_logf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) expf(float x) {
+  return __devicelib_expf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) frexpf(float x, int *exp) {
+  return __devicelib_frexpf(x, exp);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) ldexpf(float x, int exp) {
+  return __devicelib_ldexpf(x, exp);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) log10f(float x) {
+  return __devicelib_log10f(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) modff(float x, float *intpart) {
+  return __devicelib_modff(x, intpart);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) exp2f(float x) {
+  return __devicelib_exp2f(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) expm1f(float x) {
+  return __devicelib_expm1f(x);
+}
+
+SYCL_EXTERNAL
+int __attribute__((weak)) ilogbf(float x) {
+  return __devicelib_ilogbf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) log1pf(float x) {
+  return __devicelib_log1pf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) log2f(float x) {
+  return __devicelib_log2f(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) logbf(float x) {
+  return __devicelib_logbf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) sqrtf(float x) {
+  return __devicelib_sqrtf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) cbrtf(float x) {
+  return __devicelib_cbrtf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) hypotf(float x, float y) {
+  return __devicelib_hypotf(x, y);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) erff(float x) {
+  return __devicelib_erff(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) erfcf(float x) {
+  return __devicelib_erfcf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) tgammaf(float x) {
+  return __devicelib_tgammaf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) lgammaf(float x) {
+  return __devicelib_lgammaf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) fmodf(float x, float y) {
+  return __devicelib_fmodf(x, y);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) remainderf(float x, float y) {
+  return __devicelib_remainderf(x, y);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) remquof(float x, float y, int *q) {
+  return __devicelib_remquof(x, y, q);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) nextafterf(float x, float y) {
+  return __devicelib_nextafterf(x, y);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) fdimf(float x, float y) {
+  return __devicelib_fdimf(x, y);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) fmaf(float x, float y, float z) {
+  return __devicelib_fmaf(x, y, z);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) sinf(float x) {
+  return __devicelib_sinf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) cosf(float x) {
+  return __devicelib_cosf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) tanf(float x) {
+  return __devicelib_tanf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) powf(float x, float y) {
+  return __devicelib_powf(x, y);
+}
+
+SYCL_EXTERNAL
+float __attribute__ ((weak)) acosf(float x) {
+  return __devicelib_acosf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) asinf(float x) {
+  return __devicelib_asinf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) atanf(float x) {
+  return __devicelib_atanf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) atan2f(float x, float y) {
+  return __devicelib_atan2f(x, y);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) coshf(float x) {
+  return __devicelib_coshf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) sinhf(float x) {
+  return __devicelib_sinhf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) tanhf(float x) {
+  return __devicelib_tanhf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) acoshf(float x) {
+  return __devicelib_acoshf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) asinhf(float x) {
+  return __devicelib_asinhf(x);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) atanhf(float x) {
+  return __devicelib_atanhf(x);
+}
+}
+#endif

--- a/sycl/source/detail/devicelib/cmath_wrapper_fp64.cpp
+++ b/sycl/source/detail/devicelib/cmath_wrapper_fp64.cpp
@@ -1,0 +1,210 @@
+//==--- cmath_wrapper.cpp - wrappers for C math library functions ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifdef __SYCL_DEVICE_ONLY__
+#include "device_math.h"
+extern "C" {
+// All exported functions in math and complex device libraries are weak
+// reference. If users provide their own math or complex functions(with
+// the prototype), functions in device libraries will be ignored and
+// overrided by users' version.
+SYCL_EXTERNAL
+double __attribute__((weak)) log(double x) {
+  return __devicelib_log(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) exp(double x) {
+  return __devicelib_exp(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) frexp(double x, int *exp) {
+  return __devicelib_frexp(x, exp);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) ldexp(double x, int exp) {
+  return __devicelib_ldexp(x, exp);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) log10(double x) {
+  return __devicelib_log10(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) modf(double x, double *intpart) {
+  return __devicelib_modf(x, intpart);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) exp2(double x) {
+  return __devicelib_exp2(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) expm1(double x) {
+  return __devicelib_expm1(x);
+}
+
+SYCL_EXTERNAL
+int __attribute__((weak)) ilogb(double x) {
+  return __devicelib_ilogb(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) log1p(double x) {
+  return __devicelib_log1p(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) log2(double x) {
+  return __devicelib_log2(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) logb(double x) {
+  return __devicelib_logb(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) sqrt(double x) {
+  return __devicelib_sqrt(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) cbrt(double x) {
+  return __devicelib_cbrt(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) hypot(double x, double y) {
+  return __devicelib_hypot(x, y);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) erf(double x) {
+  return __devicelib_erf(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) erfc(double x) {
+  return __devicelib_erfc(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) tgamma(double x) {
+  return __devicelib_tgamma(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) lgamma(double x) {
+  return __devicelib_lgamma(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) fmod(double x, double y) {
+  return __devicelib_fmod(x, y);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) remainder(double x, double y) {
+  return __devicelib_remainder(x, y);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) remquo(double x, double y, int *q) {
+  return __devicelib_remquo(x, y, q);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) nextafter(double x, double y) {
+  return __devicelib_nextafter(x, y);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) fdim(double x, double y) {
+  return __devicelib_fdim(x, y);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) fma(double x, double y, double z) {
+  return __devicelib_fma(x, y, z);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) sin(double x) {
+  return __devicelib_sin(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) cos(double x) {
+  return __devicelib_cos(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) tan(double x) {
+  return __devicelib_tan(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) pow(double x, double y) {
+  return __devicelib_pow(x, y);
+}
+
+SYCL_EXTERNAL
+double __attribute__ ((weak)) acos(double x) {
+  return __devicelib_acos(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) asin(double x) {
+  return __devicelib_asin(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) atan(double x) {
+  return __devicelib_atan(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) atan2(double x, double y) {
+  return __devicelib_atan2(x, y);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) cosh(double x) {
+  return __devicelib_cosh(x);
+}
+
+SYCL_EXTERNAL
+double  __attribute__((weak)) sinh(double x) {
+  return __devicelib_sinh(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) tanh(double x) {
+  return __devicelib_tanh(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) acosh(double x) {
+  return __devicelib_acosh(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) asinh(double x) {
+  return __devicelib_asinh(x);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) atanh(double x) {
+  return __devicelib_atanh(x);
+}
+}
+#endif

--- a/sycl/source/detail/devicelib/complex_wrapper.cpp
+++ b/sycl/source/detail/devicelib/complex_wrapper.cpp
@@ -1,0 +1,138 @@
+//==--- complex_wrapper.cpp - wrappers for C99 complex math functions ------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifdef __SYCL_DEVICE_ONLY__
+#include "device_complex.h"
+extern "C" {
+SYCL_EXTERNAL
+float __attribute__((weak)) cimagf(float __complex__ z) {
+  return __devicelib_cimagf(z);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) crealf(float __complex__ z) {
+  return __devicelib_crealf(z);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) cargf(float __complex__ z) {
+  return __devicelib_cargf(z);
+}
+
+SYCL_EXTERNAL
+float __attribute__((weak)) cabsf(float __complex__ z) {
+  return __devicelib_cabsf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) cprojf(float __complex__ z) {
+  return __devicelib_cprojf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) cexpf(float __complex__ z) {
+  return __devicelib_cexpf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) clogf(float __complex__ z) {
+  return __devicelib_clogf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) cpowf(float __complex__ x,
+                                              float __complex__ y) {
+  return __devicelib_cpowf(x, y);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) cpolarf(float rho, float theta) {
+  return __devicelib_cpolarf(rho, theta);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) csqrtf(float __complex__ z) {
+  return __devicelib_csqrtf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) csinhf(float __complex__ z) {
+  return __devicelib_csinhf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) ccoshf(float __complex__ z) {
+  return __devicelib_ccoshf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) ctanhf(float __complex__ z) {
+  return __devicelib_ctanhf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) csinf(float __complex__ z) {
+  return __devicelib_csinf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) ccosf(float __complex__ z) {
+  return __devicelib_ccosf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) ctanf(float __complex__ z) {
+  return __devicelib_ctanf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) cacosf(float __complex__ z) {
+  return __devicelib_cacosf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) casinhf(float __complex__ z) {
+  return __devicelib_casinhf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) casinf(float __complex__ z) {
+  return __devicelib_casinf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) cacoshf(float __complex__ z) {
+  return __devicelib_cacoshf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) catanhf(float __complex__ z) {
+  return __devicelib_catanhf(z);
+}
+
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) catanf(float __complex__ z) {
+  return __devicelib_catanf(z);
+}
+
+// __mulsc3
+// Returns: the product of a + ib and c + id
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) __mulsc3(float __a, float __b,
+                                                 float __c, float __d) {
+  return __devicelib___mulsc3(__a, __b, __c, __d);
+}
+
+// __divsc3
+// Returns: the quotient of (a + ib) / (c + id)
+SYCL_EXTERNAL
+float __complex__ __attribute__((weak)) __divsc3(float __a, float __b,
+                                                 float __c, float __d) {
+  return __devicelib___divsc3(__a, __b, __c, __d);
+}
+}
+#endif

--- a/sycl/source/detail/devicelib/complex_wrapper_fp64.cpp
+++ b/sycl/source/detail/devicelib/complex_wrapper_fp64.cpp
@@ -1,0 +1,139 @@
+//==--- complex_wrapper.cpp - wrappers for C99 complex math functions ------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifdef __SYCL_DEVICE_ONLY__
+#include "device_complex.h"
+extern "C" {
+SYCL_EXTERNAL
+double __attribute__((weak)) cimag(double __complex__ z) {
+  return __devicelib_cimag(z);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) creal(double __complex__ z) {
+  return __devicelib_creal(z);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) cabs(double __complex__ z) {
+  return __devicelib_cabs(z);
+}
+
+SYCL_EXTERNAL
+double __attribute__((weak)) carg(double __complex__ z) {
+  return __devicelib_carg(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) cproj(double __complex__ z) {
+  return __devicelib_cproj(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) cexp(double __complex__ z) {
+  return __devicelib_cexp(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) clog(double __complex__ z) {
+  return __devicelib_clog(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) cpow(double __complex__ x,
+                                              double __complex__ y) {
+  return __devicelib_cpow(x, y);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) cpolar(double rho, double theta) {
+  return __devicelib_cpolar(rho, theta);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) csqrt(double __complex__ z) {
+  return __devicelib_csqrt(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) csinh(double __complex__ z) {
+  return __devicelib_csinh(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) ccosh(double __complex__ z) {
+  return __devicelib_ccosh(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) ctanh(double __complex__ z) {
+  return __devicelib_ctanh(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) csin(double __complex__ z) {
+  return __devicelib_csin(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) ccos(double __complex__ z) {
+  return __devicelib_ccos(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) ctan(double __complex__ z) {
+  return __devicelib_ctan(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) cacos(double __complex__ z) {
+  return __devicelib_cacos(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) casinh(double __complex__ z) {
+  return __devicelib_casinh(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) casin(double __complex__ z) {
+  return __devicelib_casin(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) cacosh(double __complex__ z) {
+  return __devicelib_cacosh(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) catanh(double __complex__ z) {
+  return __devicelib_catanh(z);
+}
+
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) catan(double __complex__ z) {
+  return __devicelib_catan(z);
+}
+
+// __muldc3
+// Returns: the product of a + ib and c + id
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) __muldc3(double __a, double __b,
+                                                  double __c, double __d) {
+  return __devicelib___muldc3(__a, __b, __c, __d);
+}
+
+// __divdc3
+// Returns: the quotient of (a + ib) / (c + id)
+SYCL_EXTERNAL
+double __complex__ __attribute__((weak)) __divdc3(double __a, double __b,
+                                                  double __c, double __d) {
+  return __devicelib___divdc3(__a, __b, __c, __d);
+}
+
+}
+#endif

--- a/sycl/source/detail/devicelib/device_complex.h
+++ b/sycl/source/detail/devicelib/device_complex.h
@@ -1,0 +1,170 @@
+//==------- device_complex.h - complex devicelib functions declarations-----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//==------------------------------------------------------------------------==//
+#ifndef __SYCL_COMPLEX_WRAPPER_H_
+#define __SYCL_COMPLEX_WRAPPER_H_
+
+// TODO: This needs to be more robust.
+// clang doesn't recognize the c11 CMPLX macro, but it does have
+//   its own syntax extension for initializing a complex as a struct.
+#ifndef CMPLX
+#define CMPLX(r, i) ((double __complex__){ (double)r, (double)i })
+#endif
+#ifndef CMPLXF
+#define CMPLXF(r, i) ((float __complex__){ (float)r, (float)i })
+#endif
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_cimag(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_cimagf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_creal(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_crealf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_carg(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_cargf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_cabs(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_cabsf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_cproj(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_cprojf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_cexp(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_cexpf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_clog(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_clogf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_cpow(double __complex__ x,
+                                               double __complex__ y);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_cpowf(float __complex__ x,
+                                                float __complex__ y);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_cpolar(double x, double y);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_cpolarf(float x, float y);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_csqrt(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_csqrtf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_csinh(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_csinhf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_ccosh(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_ccoshf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_ctanh(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_ctanhf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_csin(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_csinf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_ccos(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_ccosf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_ctan(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_ctanf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_cacos(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_cacosf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_casinh(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_casinhf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_casin(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_casinf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_cacosh(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_cacoshf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_catanh(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_catanhf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib_catan(double __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib_catanf(float __complex__ z);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib___muldc3(double a, double b,
+                                                 double c, double d);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib___mulsc3(float a, float b,
+                                                 float c, float d);
+
+SYCL_EXTERNAL
+extern "C" double __complex__ __devicelib___divdc3(double a, double b,
+                                                 double c, double d);
+
+SYCL_EXTERNAL
+extern "C" float  __complex__ __devicelib___divsc3(float a, float b,
+                                                 float c, float d);
+#endif

--- a/sycl/source/detail/devicelib/device_math.h
+++ b/sycl/source/detail/devicelib/device_math.h
@@ -1,0 +1,356 @@
+//==------- device_math.h - math devicelib functions declarations-----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//==------------------------------------------------------------------------==//
+
+#ifndef __SYCL_CMATH_WRAPPER_H__
+#define __SYCL_CMATH_WRAPPER_H__
+
+double __spirv_ocl_log(double);
+double __spirv_ocl_sin(double);
+double __spirv_ocl_cos(double);
+double __spirv_ocl_sinh(double);
+double __spirv_ocl_cosh(double);
+double __spirv_ocl_tanh(double);
+double __spirv_ocl_exp(double);
+double __spirv_ocl_sqrt(double);
+bool   __spirv_IsInf(double);
+bool   __spirv_IsFinite(double);
+bool   __spirv_IsNan(double);
+bool   __spirv_IsNormal(double);
+bool   __spirv_SignBitSet(double);
+double __spirv_ocl_hypot(double, double);
+double __spirv_ocl_atan2(double, double);
+double __spirv_ocl_pow(double, double);
+double __spirv_ocl_ldexp(double, int);
+double __spirv_ocl_copysign(double, double);
+double __spirv_ocl_fmax(double, double);
+double __spirv_ocl_fabs(double);
+double __spirv_ocl_tan(double);
+double __spirv_ocl_acos(double);
+double __spirv_ocl_asin(double);
+double __spirv_ocl_atan(double);
+double __spirv_ocl_atan2(double, double);
+double __spirv_ocl_cosh(double);
+double __spirv_ocl_sinh(double);
+double __spirv_ocl_tanh(double);
+double __spirv_ocl_acosh(double);
+double __spirv_ocl_asinh(double);
+double __spirv_ocl_atanh(double);
+double __spirv_ocl_frexp(double, int *);
+double __spirv_ocl_log10(double);
+double __spirv_ocl_modf(double, double *);
+double __spirv_ocl_exp2(double);
+double __spirv_ocl_expm1(double);
+int    __spirv_ocl_ilogb(double);
+double __spriv_ocl_log1p(double);
+double __spirv_ocl_log2(double);
+double __spirv_ocl_logb(double);
+double __spirv_ocl_sqrt(double);
+double __spirv_ocl_cbrt(double);
+double __spirv_ocl_hypot(double);
+double __spirv_ocl_erf(double);
+double __spirv_ocl_erfc(double);
+double __spirv_ocl_tgamma(double);
+double __spirv_ocl_lgamma(double);
+double __spirv_ocl_fmod(double, double);
+double __spirv_ocl_remainder(double, double);
+double __spirv_ocl_remquo(double, double, int*);
+double __spirv_ocl_nextafter(double, double);
+double __spirv_ocl_fdim(double, double);
+double __spirv_ocl_fma(double, double, double);
+
+float  __spirv_ocl_log(float);
+float  __spirv_ocl_logb(float);
+float  __spirv_ocl_sin(float);
+float  __spirv_ocl_cos(float);
+float  __spirv_ocl_sinh(float);
+float  __spirv_ocl_cosh(float);
+float  __spirv_ocl_tanh(float);
+float  __spirv_ocl_exp(float);
+float  __spirv_ocl_sqrt(float);
+bool   __spirv_IsInf(float);
+bool   __spirv_IsFinite(float);
+bool   __spirv_IsNan(float);
+bool   __spirv_IsNormal(double);
+bool   __spirv_SignBitSet(float);
+float  __spirv_ocl_hypot(float, float);
+float  __spirv_ocl_atan2(float, float);
+float  __spirv_ocl_pow(float, float);
+float  __spirv_ocl_ldexp(float, int);
+float  __spirv_ocl_copysign(float, float);
+float  __spirv_ocl_fmax(float, float);
+float  __spirv_ocl_fabs(float);
+float  __spirv_ocl_tan(float);
+float  __spirv_ocl_acos(float);
+float  __spirv_ocl_asin(float);
+float  __spirv_ocl_atan(float);
+float  __spirv_ocl_atan2(float, float);
+float  __spirv_ocl_cosh(float);
+float  __spirv_ocl_sinh(float);
+float  __spirv_ocl_tanh(float);
+float  __spirv_ocl_acosh(float);
+float  __spirv_ocl_asinh(float);
+float  __spirv_ocl_atanh(float);
+float  __spirv_ocl_frexp(float, int *);
+float  __spirv_ocl_log10(float);
+float  __spirv_ocl_modf(float, float *);
+float  __spirv_ocl_exp2(float);
+float  __spirv_ocl_expm1(float);
+int    __spirv_ocl_ilogb(float);
+float  __spirv_ocl_log1p(float);
+float  __spirv_ocl_log2(float);
+float  __spirv_ocl_sqrt(float);
+float  __spirv_ocl_cbrt(float);
+float  __spirv_ocl_hypot(float);
+float  __spirv_ocl_erf(float);
+float  __spirv_ocl_erfc(float);
+float  __spirv_ocl_tgamma(float);
+float  __spirv_ocl_lgamma(float);
+float  __spirv_ocl_fmod(float, float);
+float  __spirv_ocl_remainder(float, float);
+float  __spirv_ocl_remquo(float, float, int*);
+float  __spirv_ocl_nextafter(float, float);
+float  __spirv_ocl_fdim(float, float);
+float  __spirv_ocl_fma(float, float, float);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_log(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_logf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_sin(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_sinf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_cos(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_cosf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_tan(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_tanf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_acos(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_acosf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_pow(double x, double y);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_powf(float x, float y);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_sqrt(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_sqrtf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_cbrt(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_cbrtf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_hypot(double x, double y);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_hypotf(float x, float y);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_erf(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_erff(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_erfc(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_erfcf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_tgamma(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_tgammaf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_lgamma(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_lgammaf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_fmod(double x, double y);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_fmodf(float x, float y);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_remainder(double x, double y);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_remainderf(float x, float y);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_remquo(double x, double y, int *q);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_remquof(float x, float y, int *q);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_nextafter(double x, double y);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_nextafterf(float x, float y);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_fdim(double x, double y);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_fdimf(float x, float y);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_fma(double x, double y, double z);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_fmaf(float x, float y, float z);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_asinf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_asin(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_atanf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_atan(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_atan2f(float x, float y);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_atan2(double x, double y);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_coshf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_cosh(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_sinhf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_sinh(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_tanhf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_tanh(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_acoshf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_acosh(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_asinhf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_asinh(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_atanhf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_atanh(double x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_frexp(double x, int *exp);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_frexpf(float x, int *exp);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_ldexp(double x, int exp);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_ldexpf(float x, int exp);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_log10(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_log10f(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_modf(double x, double *intpart);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_modff(float x, float *intpart);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_exp(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_expf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_exp2(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_exp2f(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_expm1(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_expm1f(float x);
+
+SYCL_EXTERNAL
+extern "C" int    __devicelib_ilogb(double x);
+
+SYCL_EXTERNAL
+extern "C" int    __devicelib_ilogbf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_log1p(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_log1pf(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_log2(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_log2f(float x);
+
+SYCL_EXTERNAL
+extern "C" double __devicelib_logb(double x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_logbf(float x);
+
+SYCL_EXTERNAL
+extern "C" float  __devicelib_scalbnf(float x, int n);
+#endif

--- a/sycl/source/detail/devicelib/fallback-cmath-fp64.cpp
+++ b/sycl/source/detail/devicelib/fallback-cmath-fp64.cpp
@@ -1,0 +1,206 @@
+//==--- fallback-cmath.cpp - fallback implementation of math functions -----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifdef __SYCL_DEVICE_ONLY__
+#include "device_math.h"
+extern "C" {
+SYCL_EXTERNAL
+double __devicelib_log(double x) {
+  return __spirv_ocl_log(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_exp(double x) {
+  return __spirv_ocl_exp(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_frexp(double x, int *exp) {
+  return __spirv_ocl_frexp(x, exp);
+}
+
+SYCL_EXTERNAL
+double __devicelib_ldexp(double x, int exp) {
+  return __spirv_ocl_ldexp(x, exp);
+}
+
+SYCL_EXTERNAL
+double __devicelib_log10(double x) {
+  return __spirv_ocl_log10(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_modf(double x, double *intpart) {
+  return __spirv_ocl_modf(x, intpart);
+}
+
+SYCL_EXTERNAL
+double __devicelib_exp2(double x) {
+  return __spirv_ocl_exp2(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_expm1(double x) {
+  return __spirv_ocl_expm1(x);
+}
+
+SYCL_EXTERNAL
+int __devicelib_ilogb(double x) {
+  return __spirv_ocl_ilogb(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_log1p(double x) {
+  return __spirv_ocl_log1p(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_log2(double x) {
+  return __spirv_ocl_log2(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_logb(double x) {
+  return __spirv_ocl_logb(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_sqrt(double x) {
+  return __spirv_ocl_sqrt(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_cbrt(double x) {
+  return __spirv_ocl_cbrt(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_hypot(double x, double y) {
+  return __spirv_ocl_hypot(x, y);
+}
+
+SYCL_EXTERNAL
+double __devicelib_erf(double x) {
+  return __spirv_ocl_erf(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_erfc(double x) {
+  return __spirv_ocl_erfc(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_tgamma(double x) {
+  return __spirv_ocl_tgamma(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_lgamma(double x) {
+  return __spirv_ocl_lgamma(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_fmod(double x, double y) {
+  return __spirv_ocl_fmod(x, y);
+}
+
+SYCL_EXTERNAL
+double __devicelib_remainder(double x, double y) {
+  return __spirv_ocl_remainder(x, y);
+}
+
+SYCL_EXTERNAL
+double __devicelib_remquo(double x, double y, int *q) {
+  return __spirv_ocl_remquo(x, y, q);
+}
+
+SYCL_EXTERNAL
+double __devicelib_nextafter(double x, double y) {
+  return __spirv_ocl_nextafter(x, y);
+}
+
+SYCL_EXTERNAL
+double __devicelib_fdim(double x, double y) {
+  return __spirv_ocl_fdim(x, y);
+}
+
+SYCL_EXTERNAL
+double __devicelib_fma(double x, double y, double z) {
+  return __spirv_ocl_fma(x, y, z);
+}
+
+SYCL_EXTERNAL
+double __devicelib_sin(double x) {
+  return __spirv_ocl_sin(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_cos(double x) {
+  return __spirv_ocl_cos(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_tan(double x) {
+  return __spirv_ocl_tan(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_pow(double x, double y) {
+  return __spirv_ocl_pow(x, y);
+}
+
+SYCL_EXTERNAL
+double __devicelib_acos(double x) {
+  return __spirv_ocl_acos(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_asin(double x) {
+  return __spirv_ocl_asin(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_atan(double x) {
+  return __spirv_ocl_atan(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_atan2(double x, double y) {
+  return __spirv_ocl_atan2(x, y);
+}
+
+SYCL_EXTERNAL
+double __devicelib_cosh(double x) {
+  return __spirv_ocl_cosh(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_sinh(double x) {
+  return __spirv_ocl_sinh(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_tanh(double x) {
+  return __spirv_ocl_tanh(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_acosh(double x) {
+  return __spirv_ocl_acosh(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_asinh(double x) {
+  return __spirv_ocl_asinh(x);
+}
+
+SYCL_EXTERNAL
+double __devicelib_atanh(double x) {
+  return __spirv_ocl_atanh(x);
+}
+}
+#endif

--- a/sycl/source/detail/devicelib/fallback-cmath.cpp
+++ b/sycl/source/detail/devicelib/fallback-cmath.cpp
@@ -1,0 +1,211 @@
+//==--- fallback-cmath.cpp - fallback implementation of math functions -----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifdef __SYCL_DEVICE_ONLY__
+#include "device_math.h"
+extern "C" {
+SYCL_EXTERNAL
+float __devicelib_scalbnf(float x, int n) {
+  return __spirv_ocl_ldexp(x, n);
+}
+
+SYCL_EXTERNAL
+float __devicelib_logf(float x) {
+  return __spirv_ocl_log(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_expf(float x) {
+  return __spirv_ocl_exp(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_frexpf(float x, int *exp) {
+  return __spirv_ocl_frexp(x, exp);
+}
+
+SYCL_EXTERNAL
+float __devicelib_ldexpf(float x, int exp) {
+  return __spirv_ocl_ldexp(x, exp);
+}
+
+SYCL_EXTERNAL
+float __devicelib_log10f(float x) {
+  return __spirv_ocl_log10(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_modff(float x, float *intpart) {
+  return __spirv_ocl_modf(x, intpart);
+}
+
+SYCL_EXTERNAL
+float __devicelib_exp2f(float x) {
+  return __spirv_ocl_exp2(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_expm1f(float x) {
+  return __spirv_ocl_expm1(x);
+}
+
+SYCL_EXTERNAL
+int __devicelib_ilogbf(float x) {
+  return __spirv_ocl_ilogb(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_log1pf(float x) {
+  return __spirv_ocl_log1p(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_log2f(float x) {
+  return __spirv_ocl_log2(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_logbf(float x) {
+  return __spirv_ocl_logb(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_sqrtf(float x) {
+  return __spirv_ocl_sqrt(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_cbrtf(float x) {
+  return __spirv_ocl_cbrt(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_hypotf(float x, float y) {
+  return __spirv_ocl_hypot(x, y);
+}
+
+SYCL_EXTERNAL
+float __devicelib_erff(float x) {
+  return __spirv_ocl_erf(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_erfcf(float x) {
+  return __spirv_ocl_erfc(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_tgammaf(float x) {
+  return __spirv_ocl_tgamma(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_lgammaf(float x) {
+  return __spirv_ocl_lgamma(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_fmodf(float x, float y) {
+  return __spirv_ocl_fmod(x, y);
+}
+
+SYCL_EXTERNAL
+float __devicelib_remainderf(float x, float y) {
+  return __spirv_ocl_remainder(x, y);
+}
+
+SYCL_EXTERNAL
+float __devicelib_remquof(float x, float y, int *q) {
+  return __spirv_ocl_remquo(x, y, q);
+}
+
+SYCL_EXTERNAL
+float __devicelib_nextafterf(float x, float y) {
+  return __spirv_ocl_nextafter(x, y);
+}
+
+SYCL_EXTERNAL
+float __devicelib_fdimf(float x, float y) {
+  return __spirv_ocl_fdim(x, y);
+}
+
+SYCL_EXTERNAL
+float __devicelib_fmaf(float x, float y, float z) {
+  return __spirv_ocl_fma(x, y, z);
+}
+
+SYCL_EXTERNAL
+float __devicelib_sinf(float x) {
+  return __spirv_ocl_sin(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_cosf(float x) {
+  return __spirv_ocl_cos(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_tanf(float x) {
+  return __spirv_ocl_tan(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_powf(float x, float y) {
+  return __spirv_ocl_pow(x, y);
+}
+
+SYCL_EXTERNAL
+float __devicelib_acosf(float x) {
+  return __spirv_ocl_acos(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_asinf(float x) {
+  return __spirv_ocl_asin(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_atanf(float x) {
+  return __spirv_ocl_atan(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_atan2f(float x, float y) {
+  return __spirv_ocl_atan2(x, y);
+}
+
+SYCL_EXTERNAL
+float __devicelib_coshf(float x) {
+  return  __spirv_ocl_cosh(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_sinhf(float x) {
+  return __spirv_ocl_sinh(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_tanhf(float x) {
+  return __spirv_ocl_tanh(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_acoshf(float x) {
+  return __spirv_ocl_acosh(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_asinhf(float x) {
+  return __spirv_ocl_asinh(x);
+}
+
+SYCL_EXTERNAL
+float __devicelib_atanhf(float x) {
+  return __spirv_ocl_atanh(x);
+}
+}
+#endif

--- a/sycl/source/detail/devicelib/fallback-complex-fp64.cpp
+++ b/sycl/source/detail/devicelib/fallback-complex-fp64.cpp
@@ -1,0 +1,438 @@
+//==----- fallback-complex.cpp - complex math functions for SYCL device ----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifdef __SYCL_DEVICE_ONLY__
+#include "device_math.h"
+#include "device_complex.h"
+#include <cmath>
+extern "C" {
+SYCL_EXTERNAL
+double __devicelib_creal(double __complex__ z) {
+  return __real__(z);
+}
+
+SYCL_EXTERNAL
+double __devicelib_cimag(double __complex__ z) {
+  return __imag__(z);
+}
+
+// __muldc3
+// Returns: the product of a + ib and c + id
+SYCL_EXTERNAL
+double __complex__ __devicelib___muldc3(double __a, double __b,
+                                      double __c, double __d) {
+  double __ac = __a * __c;
+  double __bd = __b * __d;
+  double __ad = __a * __d;
+  double __bc = __b * __c;
+  double __complex__ z;
+  z = CMPLX((__ac - __bd), (__ad + __bc));
+  if (__spirv_IsNan(__devicelib_creal(z)) &&
+      __spirv_IsNan(__devicelib_cimag(z))) {
+    int __recalc = 0;
+    if (__spirv_IsInf(__a) || __spirv_IsInf(__b)) {
+      __a = __spirv_ocl_copysign(__spirv_IsInf(__a) ? 1.0 : 0.0, __a);
+      __b = __spirv_ocl_copysign(__spirv_IsInf(__b) ? 1.0 : 0.0, __b);
+      if (__spirv_IsNan(__c))
+        __c = __spirv_ocl_copysign(0.0, __c);
+      if (__spirv_IsNan(__d))
+        __d = __spirv_ocl_copysign(0.0, __d);
+      __recalc = 1;
+    }
+    if (__spirv_IsInf(__c) || __spirv_IsInf(__d)) {
+      __c = __spirv_ocl_copysign(__spirv_IsInf(__c) ? 1.0 : 0.0, __c);
+      __d = __spirv_ocl_copysign(__spirv_IsInf(__d) ? 1.0 : 0.0, __d);
+      if (__spirv_IsNan(__a))
+        __a = __spirv_ocl_copysign(0.0, __a);
+      if (__spirv_IsNan(__b))
+        __b = __spirv_ocl_copysign(0.0, __b);
+      __recalc = 1;
+    }
+    if (!__recalc && (__spirv_IsInf(__ac) || __spirv_IsInf(__bd) ||
+                      __spirv_IsInf(__ad) || __spirv_IsInf(__bc))) {
+      if (__spirv_IsNan(__a))
+        __a = __spirv_ocl_copysign(0.0, __a);
+      if (__spirv_IsNan(__b))
+        __b = __spirv_ocl_copysign(0.0, __b);
+      if (__spirv_IsNan(__c))
+        __c = __spirv_ocl_copysign(0.0, __c);
+      if (__spirv_IsNan(__d))
+        __d = __spirv_ocl_copysign(0.0, __d);
+      __recalc = 1.0;
+    }
+    if (__recalc) {
+      z = CMPLX((INFINITY * (__a * __c - __b * __d)),
+                (INFINITY * (__a * __d + __b * __c)));
+    }
+  }
+  return z;
+}
+
+// __divdc3
+// Returns: the quotient of (a + ib) / (c + id)
+SYCL_EXTERNAL
+double __complex__ __devicelib___divdc3(double __a, double __b,
+                                      double __c, double __d) {
+  int __ilogbw = 0;
+  double __logbw = __spirv_ocl_logb(__spirv_ocl_fmax(__spirv_ocl_fabs(__c),
+                                                     __spirv_ocl_fabs(__d)));
+  if (__spirv_IsFinite(__logbw)) {
+    __ilogbw = (int)__logbw;
+    __c = __spirv_ocl_ldexp(__c, -__ilogbw);
+    __d = __spirv_ocl_ldexp(__d, -__ilogbw);
+  }
+  double __denom = __c * __c + __d * __d;
+  double __complex__ z;
+  double z_real = __spirv_ocl_ldexp((__a*__c+__b*__d) / __denom, -__ilogbw);
+  double z_imag = __spirv_ocl_ldexp((__b*__c-__a*__d) / __denom, -__ilogbw);
+  z = CMPLX(z_real, z_imag);
+  if (__spirv_IsNan(z_real) && __spirv_IsNan(z_imag)) {
+    if ((__denom == 0.0) && (!__spirv_IsNan(__a) || !__spirv_IsNan(__b))) {
+      z_real = __spirv_ocl_copysign((double)INFINITY, __c) * __a;
+      z_imag = __spirv_ocl_copysign((double)INFINITY, __c) * __b;
+      z = CMPLX(z_real, z_imag);
+    } else if ((__spirv_IsInf(__a) || __spirv_IsInf(__b)) &&
+               __spirv_IsFinite(__c) &&
+               __spirv_IsFinite(__d)) {
+      __a = __spirv_ocl_copysign(__spirv_IsInf(__a) ? 1.0 : 0.0, __a);
+      __b = __spirv_ocl_copysign(__spirv_IsInf(__b) ? 1.0 : 0.0, __b);
+      z_real = INFINITY * (__a * __c + __b * __d);
+      z_imag = INFINITY * (__b * __c - __a * __d);
+      z = CMPLX(z_real, z_imag);
+    } else if (__spirv_IsInf(__logbw) &&
+               __logbw > 0.0 && __spirv_IsFinite(__a) &&
+               __spirv_IsFinite(__b)) {
+      __c = __spirv_ocl_copysign(__spirv_IsInf(__c) ? 1.0 : 0.0, __c);
+      __d = __spirv_ocl_copysign(__spirv_IsInf(__d) ? 1.0 : 0.0, __d);
+      z_real = 0.0 * (__a * __c + __b * __d);
+      z_imag = 0.0 * (__b * __c - __a * __d);
+      z = CMPLX(z_real, z_imag);
+    }
+  }
+  return z;
+}
+
+SYCL_EXTERNAL
+double __devicelib_cabs(double __complex__ z) {
+  return __spirv_ocl_hypot(__devicelib_creal(z),
+                           __devicelib_cimag(z));
+}
+
+SYCL_EXTERNAL
+double __devicelib_carg(double __complex__ z) {
+  return __spirv_ocl_atan2(__devicelib_cimag(z),
+                           __devicelib_creal(z));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_cproj(double __complex__ z) {
+  double __complex__ r = z;
+  if (__spirv_IsInf(__devicelib_creal(z)) ||
+      __spirv_IsInf(__devicelib_cimag(z)))
+    r = CMPLX(INFINITY, __spirv_ocl_copysign(0.0, __devicelib_cimag(z)));
+  return r;
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_cexp(double __complex__ z) {
+  double z_imag = __devicelib_cimag(z);
+  double z_real = __devicelib_creal(z);
+  if (__spirv_IsInf(z_real)) {
+    if (z_real < 0.0) {
+      if (!__spirv_IsFinite(z_imag))
+        z_imag = 1.0;
+    } else if (z_imag == 0.0 || !__spirv_IsFinite(z_imag)) {
+      if (__spirv_IsInf(z_imag))
+        z_imag = NAN;
+      return CMPLX(z_real, z_imag);
+    }
+  } else if (__spirv_IsNan(z_real) && (z_imag == 0.0)) {
+    return z;
+  }
+  double __e = __spirv_ocl_exp(z_real);
+  return CMPLX((__e * __spirv_ocl_cos(z_imag)),
+               (__e * __spirv_ocl_sin(z_imag)));
+}
+
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_clog(double __complex__ z) {
+  return CMPLX(__spirv_ocl_log(__devicelib_cabs(z)), __devicelib_carg(z));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_cpow(double __complex__ x,
+                                    double __complex__ y) {
+  double __complex__ t = __devicelib_clog(x);
+  double __complex__ w = __devicelib___muldc3(__devicelib_creal(y),
+                                            __devicelib_cimag(y),
+                                            __devicelib_creal(t),
+                                            __devicelib_cimag(t));
+  return __devicelib_cexp(w);
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_cpolar(double rho, double theta) {
+  if (__spirv_IsNan(rho) || __spirv_SignBitSet(rho))
+    return CMPLX(NAN, NAN);
+  if (__spirv_IsNan(theta)) {
+    if (__spirv_IsInf(rho))
+      return CMPLX(rho, theta);
+    return CMPLX(theta, theta);
+  }
+  if (__spirv_IsInf(theta)) {
+    if (__spirv_IsInf(rho))
+      return CMPLX(rho, NAN);
+    return CMPLX(NAN, NAN);
+  }
+  double x = rho * __spirv_ocl_cos(theta);
+  if (__spirv_IsNan(x))
+    x = 0;
+  double y = rho * __spirv_ocl_sin(theta);
+  if (__spirv_IsNan(y))
+    y = 0;
+  return CMPLX(x, y);
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_csqrt(double __complex__ z)
+{
+  double z_real = __devicelib_creal(z);
+  double z_imag = __devicelib_cimag(z);
+  if (__spirv_IsInf(z_imag))
+    return CMPLX(INFINITY, z_imag);
+  if (__spirv_IsInf(z_real)) {
+    if (z_real > 0.0)
+      return CMPLX(z_real,
+                   __spirv_IsNan(z_imag) ? z_imag
+                                      : __spirv_ocl_copysign(0.0, z_imag));
+    return CMPLX(__spirv_IsNan(z_imag) ? z_imag : 0.0,
+                 __spirv_ocl_copysign(z_real, z_imag));
+  }
+  return __devicelib_cpolar(__spirv_ocl_sqrt(__devicelib_cabs(z)),
+                            __devicelib_carg(z) / 2.0);
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_csinh(double __complex__ z) {
+  double z_real = __devicelib_creal(z);
+  double z_imag = __devicelib_cimag(z);
+  if (__spirv_IsInf(z_real) && !__spirv_IsFinite(z_imag))
+    return CMPLX(z_real, NAN);
+  if (z_real == 0 && !__spirv_IsFinite(z_imag))
+    return CMPLX(z_real, NAN);
+  if (z_imag == 0 && !__spirv_IsFinite(z_real))
+    return z;
+  return CMPLX(__spirv_ocl_sinh(z_real) * __spirv_ocl_cos(z_imag),
+               __spirv_ocl_cosh(z_real) * __spirv_ocl_sin(z_imag));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_ccosh(double __complex__ z) {
+  double z_real = __devicelib_creal(z);
+  double z_imag = __devicelib_cimag(z);
+  if (__spirv_IsInf(z_real) && !__spirv_IsFinite(z_imag))
+    return CMPLX(__spirv_ocl_fabs(z_real), NAN);
+  if (z_real == 0 && !__spirv_IsFinite(z_imag))
+    return CMPLX(NAN, z_real);
+  if (z_real == 0 && z_imag == 0)
+    return CMPLX(1.0f, z_imag);
+  if (z_imag == 0 && !__spirv_IsFinite(z_real))
+    return CMPLX(__spirv_ocl_fabs(z_real), z_imag);
+  return CMPLX(__spirv_ocl_cosh(z_real) * __spirv_ocl_cos(z_imag),
+               __spirv_ocl_sinh(z_real) * __spirv_ocl_sin(z_imag));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_ctanh(double __complex__ z) {
+  double z_real = __devicelib_creal(z);
+  double z_imag = __devicelib_cimag(z);
+  if (__spirv_IsInf(z_real)) {
+    if (!__spirv_IsFinite(z_imag))
+      return CMPLX(1.0, 0.0);
+    return CMPLX(1.0, __spirv_ocl_copysign(0.0, __spirv_ocl_sin(2.0 * z_imag)));
+  }
+  if (__spirv_IsNan(z_real) && z_imag == 0)
+    return z;
+  double __2r(2.0 * z_real);
+  double __2i(2.0 * z_imag);
+  double __d(__spirv_ocl_cosh(__2r) + __spirv_ocl_cos(__2i));
+  double __2rsh(__spirv_ocl_sinh(__2r));
+  if (__spirv_IsInf(__2rsh) && __spirv_IsInf(__d))
+    return CMPLX(((__2rsh > 0.0) ? 1.0 : -1.0),
+                 ((__2i > 0.0) ? 0.0 : -0.0));
+  return CMPLX(__2rsh/__d, __spirv_ocl_sin(__2i)/__d);
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_csin(double __complex__ z) {
+  double __complex__ w = __devicelib_csinh(CMPLX(-__devicelib_cimag(z),
+                                                 __devicelib_creal(z)));
+  return CMPLX(__devicelib_cimag(w), -__devicelib_creal(w));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_ccos(double __complex__ z) {
+  return __devicelib_ccosh(CMPLX(-__devicelib_cimag(z),
+                                 __devicelib_creal(z)));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_ctan(double __complex__ z) {
+  double __complex__ w = __devicelib_ctanh(CMPLX(-__devicelib_cimag(z),
+                                                 __devicelib_creal(z)));
+  return CMPLX(__devicelib_cimag(w), -__devicelib_creal(w));
+}
+
+SYCL_EXTERNAL
+double __complex__ __sqr(double __complex__ z) {
+  double z_real = __devicelib_creal(z);
+  double z_imag = __devicelib_cimag(z);
+  return CMPLX((z_real + z_imag) * (z_real - z_imag),
+               2.0 * z_real * z_imag);
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_cacos(double __complex__ z) {
+  double z_real = __devicelib_creal(z);
+  double z_imag = __devicelib_cimag(z);
+  const double __pi(__spirv_ocl_atan2(+0.0, -0.0));
+  if (__spirv_IsInf(z_real)) {
+    if (__spirv_IsNan(z_imag))
+      return CMPLX(z_imag, z_real);
+    if (__spirv_IsInf(z_imag)) {
+      if (z_real < 0.0)
+        return CMPLX(0.75 * __pi, -z_imag);
+      return CMPLX(0.25 * __pi, -z_imag);
+    }
+    if (z_real < 0.0)
+      return CMPLX(__pi, __spirv_SignBitSet(z_imag) ? -z_real : z_real);
+    return CMPLX(0.0f, __spirv_SignBitSet(z_imag) ? z_real : -z_real);
+  }
+  if (__spirv_IsNan(z_real)) {
+    if (__spirv_IsInf(z_imag))
+      return CMPLX(z_real, -z_imag);
+    return CMPLX(z_real, z_real);
+  }
+  if (__spirv_IsInf(z_real))
+    return CMPLX(__pi/2.0, -z_real);
+  if (z_real == 0 && (z_imag == 0 || __spirv_IsNan(z_imag)))
+    return CMPLX(__pi/2.0, -z_imag);
+  double __complex__ w = __devicelib_clog(z +
+                         __devicelib_csqrt(__sqr(z) - 1.0));
+  if (__spirv_SignBitSet(z_imag))
+    return CMPLX(__spirv_ocl_fabs(__devicelib_cimagf(w)),
+                 __spirv_ocl_fabs(__devicelib_creal(w)));
+  return CMPLX(__spirv_ocl_fabs(__devicelib_cimagf(w)),
+               -__spirv_ocl_fabs(__devicelib_creal(w)));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_casinh(double __complex__ z) {
+  double z_real = __devicelib_creal(z);
+  double z_imag = __devicelib_cimag(z);
+  const double __pi(__spirv_ocl_atan2(+0.0, -0.0));
+  if (__spirv_IsInf(z_real)) {
+    if (__spirv_IsNan(z_imag))
+      return z;
+    if (__spirv_IsInf(z_imag))
+      return CMPLX(z_real, __spirv_ocl_copysign(__pi * 0.25, z_imag));
+    return CMPLX(z_real, __spirv_ocl_copysign(0.0, z_imag));
+  }
+  if (__spirv_IsNan(z_real)) {
+    if (__spirv_IsInf(z_imag))
+      return CMPLX(z_imag, z_real);
+    if (z_imag == 0)
+      return z;
+    return CMPLX(z_real, z_real);
+  }
+  if (__spirv_IsInf(z_imag))
+    return CMPLX(__spirv_ocl_copysign(z_imag, z_real),
+                 __spirv_ocl_copysign(__pi/2.0, z_imag));
+  double __complex__ w = __devicelib_clog(z + __devicelib_csqrt(__sqr(z)+1.0));
+  return CMPLX(__spirv_ocl_copysign(__devicelib_creal(w), z_real),
+               __spirv_ocl_copysign(__devicelib_cimag(w), z_imag));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_casin(double __complex__ z) {
+  double __complex__ w = __devicelib_casinh(CMPLX(-__devicelib_cimag(z),
+                                                  __devicelib_creal(z)));
+  return CMPLX(__devicelib_cimag(w), -__devicelib_creal(w));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_cacosh(double __complex__ z) {
+  double z_real = __devicelib_creal(z);
+  double z_imag = __devicelib_cimag(z);
+  const double __pi(__spirv_ocl_atan2(+0.0, -0.0));
+  if (__spirv_IsInf(z_real)) {
+    if (__spirv_IsNan(z_imag))
+      return CMPLX(__spirv_ocl_fabs(z_real), z_imag);
+    if (__spirv_IsInf(z_imag)) {
+      if (z_real > 0)
+        return CMPLX(z_real, __spirv_ocl_copysign(__pi * 0.25f, z_imag));
+      else
+        return CMPLX(-z_real, __spirv_ocl_copysign(__pi * 0.75f, z_imag));
+    }
+    if (z_real < 0)
+      return CMPLX(-z_real, __spirv_ocl_copysign(__pi, z_imag));
+    return CMPLX(z_real, __spirv_ocl_copysign(0.0, z_imag));
+  }
+  if (__spirv_IsNan(z_real)) {
+    if (__spirv_IsInf(z_imag))
+      return CMPLX(__spirv_ocl_fabs(z_imag), z_real);
+    return CMPLX(z_real, z_real);
+  }
+  if (__spirv_IsInf(z_imag))
+    return CMPLX(__spirv_ocl_fabs(z_imag), __spirv_ocl_copysign(__pi/2.0, z_imag));
+  double __complex__ w = __devicelib_clog(z + __devicelib_csqrt(__sqr(z) - 1.0));
+  return CMPLX(__spirv_ocl_copysign(__devicelib_creal(w), 0.0),
+               __spirv_ocl_copysign(__devicelib_cimag(w), z_imag));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_catanh(double __complex__ z) {
+  double z_real = __devicelib_creal(z);
+  double z_imag = __devicelib_cimag(z);
+  const double __pi(__spirv_ocl_atan2(+0.0, -0.0));
+  if (__spirv_IsInf(z_imag))
+    return CMPLX(__spirv_ocl_copysign(0.0, z_real),
+                 __spirv_ocl_copysign(__pi/2.0, z_imag));
+  if (__spirv_IsNan(z_imag)) {
+    if (__spirv_IsInf(z_real) || z_real == 0)
+      return CMPLX(__spirv_ocl_copysign(0.0, z_real), z_imag);
+    return CMPLX(z_imag, z_imag);
+  }
+  if (__spirv_IsNan(z_real))
+    return CMPLX(z_real, z_real);
+  if (__spirv_IsInf(z_real))
+    return CMPLX(__spirv_ocl_copysign(0.0, z_real),
+                 __spirv_ocl_copysign(__pi/2.0, z_imag));
+  if (__spirv_ocl_fabs(z_real) == 1.0 && z_imag == 0.0)
+    return CMPLX(__spirv_ocl_copysign(static_cast<double>(INFINITY), z_real),
+                 __spirv_ocl_copysign(0.0, z_imag));
+  double __complex__ t1 = 1.0 + z;
+  double __complex__ t2 = 1.0 - z;
+  double __complex__ t3 = __devicelib___divdc3(__devicelib_creal(t1),
+                                             __devicelib_cimag(t1),
+                                             __devicelib_creal(t2),
+                                             __devicelib_cimag(t2));
+  double __complex__ w = __devicelib_clog(t3) / 2.0;
+  return CMPLX(__spirv_ocl_copysign(__devicelib_creal(w), z_real),
+               __spirv_ocl_copysign(__devicelib_cimag(w), z_imag));
+}
+
+SYCL_EXTERNAL
+double __complex__ __devicelib_catan(double __complex__ z) {
+  double __complex__ w = __devicelib_catanh(CMPLX(-__devicelib_cimag(z),
+                                                  __devicelib_creal(z)));
+  return CMPLX(__devicelib_cimag(w), -__devicelib_creal(w));
+}
+
+} // extern "C"
+#endif

--- a/sycl/source/detail/devicelib/fallback-complex.cpp
+++ b/sycl/source/detail/devicelib/fallback-complex.cpp
@@ -1,0 +1,441 @@
+//==----- fallback-complex.cpp - complex math functions for SYCL device ----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifdef __SYCL_DEVICE_ONLY__
+#include "device_math.h"
+#include "device_complex.h"
+#include <cmath>
+extern "C" {
+SYCL_EXTERNAL
+float __devicelib_crealf(float __complex__ z) {
+  return __real__(z);
+}
+
+SYCL_EXTERNAL
+float __devicelib_cimagf(float __complex__ z) {
+  return __imag__(z);
+}
+
+// __mulsc3
+// Returns: the product of a + ib and c + id
+SYCL_EXTERNAL
+float __complex__ __devicelib___mulsc3(float __a, float __b,
+                                     float __c, float __d) {
+  float __ac = __a * __c;
+  float __bd = __b * __d;
+  float __ad = __a * __d;
+  float __bc = __b * __c;
+  float __complex__ z;
+  z = CMPLXF((__ac - __bd), (__ad + __bc));
+  if (__spirv_IsNan(__devicelib_crealf(z)) &&
+      __spirv_IsNan(__devicelib_cimagf(z))) {
+    int __recalc = 0;
+    if (__spirv_IsInf(__a) || __spirv_IsInf(__b)) {
+      __a = __spirv_ocl_copysign(__spirv_IsInf(__a) ? 1.0f : 0.0f, __a);
+      __b = __spirv_ocl_copysign(__spirv_IsInf(__b) ? 1.0f : 0.0f, __b);
+      if (__spirv_IsNan(__c))
+        __c = __spirv_ocl_copysign(0.0f, __c);
+      if (__spirv_IsNan(__d))
+        __d = __spirv_ocl_copysign(0.0f, __d);
+      __recalc = 1;
+    }
+    if (__spirv_IsInf(__c) || __spirv_IsInf(__d)) {
+      __c = __spirv_ocl_copysign(__spirv_IsInf(__c) ? 1.0f : 0.0f, __c);
+      __d = __spirv_ocl_copysign(__spirv_IsInf(__d) ? 1.0f : 0.0f, __d);
+      if (__spirv_IsNan(__a))
+        __a = __spirv_ocl_copysign(0.0f, __a);
+      if (__spirv_IsNan(__b))
+        __b = __spirv_ocl_copysign(0.0f, __b);
+      __recalc = 1;
+    }
+    if (!__recalc && (__spirv_IsInf(__ac) || __spirv_IsInf(__bd) ||
+                      __spirv_IsInf(__ad) || __spirv_IsInf(__bc))) {
+      if (__spirv_IsNan(__a))
+        __a = __spirv_ocl_copysign(0.0f, __a);
+      if (__spirv_IsNan(__b))
+        __b = __spirv_ocl_copysign(0.0f, __b);
+      if (__spirv_IsNan(__c))
+        __c = __spirv_ocl_copysign(0.0f, __c);
+      if (__spirv_IsNan(__d))
+        __d = __spirv_ocl_copysign(0.0f, __d);
+      __recalc = 1.0f;
+    }
+    if (__recalc) {
+      z = CMPLXF((INFINITY * (__a * __c - __b * __d)),
+                 (INFINITY * (__a * __d + __b * __c)));
+    }
+  }
+  return z;
+}
+
+// __divsc3
+// Returns: the quotient of (a + ib) / (c + id)
+// FIXME: divsc3/divdc3 have overflow issue when dealing with large number.
+// And this overflow issue is from libc++/compiler-rt's implementation.
+SYCL_EXTERNAL
+float __complex__ __devicelib___divsc3(float __a, float __b,
+                                     float __c, float __d) {
+  int __ilogbw = 0;
+  float __logbw = __spirv_ocl_logb(__spirv_ocl_fmax(__spirv_ocl_fabs(__c),
+                                                    __spirv_ocl_fabs(__d)));
+  if (__spirv_IsFinite(__logbw)) {
+    __ilogbw = (int)__logbw;
+    __c = __spirv_ocl_ldexp(__c, -__ilogbw);
+    __d = __spirv_ocl_ldexp(__d, -__ilogbw);
+  }
+  float __denom = __c * __c + __d * __d;
+  float __complex__ z;
+  float z_real = __spirv_ocl_ldexp((__a *__c+__b*__d) / __denom, -__ilogbw);
+  float z_imag = __spirv_ocl_ldexp((__b *__c-__a*__d) / __denom, -__ilogbw);
+  z = CMPLXF(z_real, z_imag);
+  if (__spirv_IsNan(z_real) && __spirv_IsNan(z_imag)) {
+    if ((__denom == 0.0f) && (!__spirv_IsNan(__a) || !__spirv_IsNan(__b))) {
+      z_real = __spirv_ocl_copysign(INFINITY, __c) * __a;
+      z_imag = __spirv_ocl_copysign(INFINITY, __c) * __b;
+      z = CMPLXF(z_real, z_imag);
+    } else if ((__spirv_IsInf(__a) || __spirv_IsInf(__b)) &&
+               __spirv_IsFinite(__c) &&
+               __spirv_IsFinite(__d)) {
+      __a = __spirv_ocl_copysign(__spirv_IsInf(__a) ? 1.0f : 0.0f, __a);
+      __b = __spirv_ocl_copysign(__spirv_IsInf(__b) ? 1.0f : 0.0f, __b);
+      z_real = INFINITY * (__a * __c + __b * __d);
+      z_imag = INFINITY * (__b * __c - __a * __d);
+      z = CMPLXF(z_real, z_imag);
+    } else if (__spirv_IsInf(__logbw) && __logbw > 0.0f &&
+               __spirv_IsFinite(__a) &&
+               __spirv_IsFinite(__b)) {
+      __c = __spirv_ocl_copysign(__spirv_IsInf(__c) ? 1.0f : 0.0f, __c);
+      __d = __spirv_ocl_copysign(__spirv_IsInf(__d) ? 1.0f : 0.0f, __d);
+      z_real = 0.0f * (__a * __c + __b * __d);
+      z_imag = 0.0f * (__b * __c - __a * __d);
+      z = CMPLXF(z_real, z_imag);
+    }
+  }
+  return z;
+}
+
+SYCL_EXTERNAL
+float __devicelib_cargf(float __complex__ z) {
+  return __spirv_ocl_atan2(__devicelib_cimagf(z),
+                           __devicelib_crealf(z));
+}
+
+SYCL_EXTERNAL
+float __devicelib_cabsf(float __complex__ z) {
+  return __spirv_ocl_hypot(__devicelib_crealf(z),
+                           __devicelib_cimagf(z));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_cprojf(float __complex__ z) {
+  float __complex__ r = z;
+  if (__spirv_IsInf(__devicelib_crealf(z)) ||
+      __spirv_IsInf(__devicelib_cimagf(z)))
+    r = CMPLXF(INFINITY, __spirv_ocl_copysign(0.0f, __devicelib_cimagf(z)));
+  return r;
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_cexpf(float __complex__ z) {
+  float z_imag = __devicelib_cimagf(z);
+  float z_real = __devicelib_crealf(z);
+  if (__spirv_IsInf(z_real)) {
+    if (z_real < 0.0f) {
+      if (!__spirv_IsFinite(z_imag))
+        z_imag = 1.0f;
+    } else if (z_imag == 0.0f || !__spirv_IsFinite(z_imag)) {
+      if (__spirv_IsInf(z_imag))
+        z_imag = NAN;
+      return CMPLXF(z_real, z_imag);
+    }
+  } else if (__spirv_IsNan(z_real) && (z_imag == 0.0f)) {
+    return z;
+  }
+  float __e = __spirv_ocl_exp(z_real);
+  return CMPLXF((__e * __spirv_ocl_cos(z_imag)),
+                (__e * __spirv_ocl_sin(z_imag)));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_clogf(float __complex__ z) {
+  return CMPLXF(__spirv_ocl_log(__devicelib_cabsf(z)), __devicelib_cargf(z));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_cpowf(float __complex__ x,
+                                    float __complex__ y) {
+  float __complex__ t = __devicelib_clogf(x);
+  float __complex__ w = __devicelib___mulsc3(__devicelib_crealf(y),
+                                           __devicelib_cimagf(y),
+                                           __devicelib_crealf(t),
+                                           __devicelib_cimagf(t));
+  return __devicelib_cexpf(w);
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_cpolarf(float rho, float theta) {
+  if (__spirv_IsNan(rho) || __spirv_SignBitSet(rho))
+    return CMPLXF(NAN, NAN);
+  if (__spirv_IsNan(theta)) {
+    if (__spirv_IsInf(rho))
+      return CMPLXF(rho, theta);
+    return CMPLXF(theta, theta);
+  }
+  if (__spirv_IsInf(theta)) {
+    if (__spirv_IsInf(rho))
+      return CMPLXF(rho, NAN);
+    return CMPLXF(NAN, NAN);
+  }
+  float x = rho * __spirv_ocl_cos(theta);
+  if (__spirv_IsNan(x))
+    x = 0;
+  float y = rho * __spirv_ocl_sin(theta);
+  if (__spirv_IsNan(y))
+    y = 0;
+  return CMPLXF(x, y);
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_csqrtf(float __complex__ z)
+{
+  float z_real = __devicelib_crealf(z);
+  float z_imag = __devicelib_cimagf(z);
+  if (__spirv_IsInf(z_imag))
+    return CMPLXF(INFINITY, z_imag);
+  if (__spirv_IsInf(z_real)) {
+    if (z_real > 0.0f)
+      return CMPLXF(z_real,
+                    __spirv_IsNan(z_imag) ? z_imag
+                                        : __spirv_ocl_copysign(0.0f, z_imag));
+    return CMPLXF(__spirv_IsNan(z_imag) ? z_imag : 0.0f,
+                  __spirv_ocl_copysign(z_real, z_imag));
+  }
+  return __devicelib_cpolarf(__spirv_ocl_sqrt(__devicelib_cabsf(z)),
+                             __devicelib_cargf(z) / 2.0f);
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_csinhf(float __complex__ z) {
+  float z_real = __devicelib_crealf(z);
+  float z_imag = __devicelib_cimagf(z);
+  if (__spirv_IsInf(z_real) && !__spirv_IsFinite(z_imag))
+    return CMPLXF(z_real, NAN);
+  if (z_real == 0 && !__spirv_IsFinite(z_imag))
+    return CMPLXF(z_real, NAN);
+  if (z_imag == 0 && !__spirv_IsFinite(z_real))
+    return z;
+  return CMPLXF(__spirv_ocl_sinh(z_real) * __spirv_ocl_cos(z_imag),
+                __spirv_ocl_cosh(z_real) * __spirv_ocl_sin(z_imag));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_ccoshf(float __complex__ z) {
+  float z_real = __devicelib_crealf(z);
+  float z_imag = __devicelib_cimagf(z);
+  if (__spirv_IsInf(z_real) && !__spirv_IsFinite(z_imag))
+    return CMPLXF(__spirv_ocl_fabs(z_real), NAN);
+  if (z_real == 0 && !__spirv_IsFinite(z_imag))
+    return CMPLXF(NAN, z_real);
+  if (z_real == 0 && z_imag == 0)
+    return CMPLXF(1.0f, z_imag);
+  if (z_imag == 0 && !__spirv_IsFinite(z_real))
+    return CMPLXF(__spirv_ocl_fabs(z_real), z_imag);
+  return CMPLXF(__spirv_ocl_cosh(z_real) * __spirv_ocl_cos(z_imag),
+                __spirv_ocl_sinh(z_real) * __spirv_ocl_sin(z_imag));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_ctanhf(float __complex__ z) {
+  float z_real = __devicelib_crealf(z);
+  float z_imag = __devicelib_cimagf(z);
+  if (__spirv_IsInf(z_real)) {
+    if (!__spirv_IsFinite(z_imag))
+      return CMPLXF(1.0f, 0.0f);
+    return CMPLXF(1.0f, __spirv_ocl_copysign(0.0f,
+                        __spirv_ocl_sin(2.0f * z_imag)));
+  }
+  if (__spirv_IsNan(z_real) && z_imag == 0)
+    return z;
+  float __2r(2.0f * z_real);
+  float __2i(2.0f * z_imag);
+  float __d(__spirv_ocl_cosh(__2r) + __spirv_ocl_cos(__2i));
+  float __2rsh(__spirv_ocl_sinh(__2r));
+  if (__spirv_IsInf(__2rsh) && __spirv_IsInf(__d))
+    return CMPLXF(((__2rsh > 0.0f) ? 1.0f : -1.0f),
+                  ((__2i > 0.0f) ? 0.0f : -0.0f));
+  return CMPLXF(__2rsh/__d, __spirv_ocl_sin(__2i)/__d);
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_csinf(float __complex__ z) {
+  float __complex__ w = __devicelib_csinhf(CMPLXF(-__devicelib_cimagf(z),
+                                                  __devicelib_crealf(z)));
+  return CMPLXF(__devicelib_cimagf(w), -__devicelib_crealf(w));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_ccosf(float __complex__ z) {
+  return __devicelib_ccoshf(CMPLXF(-__devicelib_cimagf(z),
+                                   __devicelib_crealf(z)));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_ctanf(float __complex__ z) {
+  float __complex__ w = __devicelib_ctanhf(CMPLXF(-__devicelib_cimagf(z),
+                                                  __devicelib_crealf(z)));
+  return CMPLXF(__devicelib_cimagf(w), -__devicelib_crealf(w));
+}
+
+SYCL_EXTERNAL
+float __complex__ __sqrf(float __complex__ z) {
+  float z_real = __devicelib_crealf(z);
+  float z_imag = __devicelib_cimagf(z);
+  return CMPLXF((z_real + z_imag) * (z_real - z_imag),
+                2.0 * z_real * z_imag);
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_cacosf(float __complex__ z) {
+  float z_real = __devicelib_crealf(z);
+  float z_imag = __devicelib_cimagf(z);
+  const float __pi(__spirv_ocl_atan2(+0.0f, -0.0f));
+  if (__spirv_IsInf(z_real)) {
+    if (__spirv_IsNan(z_imag))
+      return CMPLXF(z_imag, z_real);
+    if (__spirv_IsInf(z_imag)) {
+      if (z_real < 0.0f)
+        return CMPLXF(0.75f * __pi, -z_imag);
+      return CMPLXF(0.25f * __pi, -z_imag);
+    }
+    if (z_real < 0.0f)
+      return CMPLXF(__pi, __spirv_SignBitSet(z_imag) ? -z_real : z_real);
+    return CMPLXF(0.0f, __spirv_SignBitSet(z_imag) ? z_real : -z_real);
+  }
+  if (__spirv_IsNan(z_real)) {
+    if (__spirv_IsInf(z_imag))
+      return CMPLXF(z_real, -z_imag);
+    return CMPLXF(z_real, z_real);
+  }
+  if (__spirv_IsInf(z_imag))
+    return CMPLXF(__pi/2.0f, -z_imag);
+  if (z_real == 0 && (z_imag == 0 || __spirv_IsNan(z_imag)))
+    return CMPLXF(__pi/2.0f, -z_imag);
+  float __complex__ w = __devicelib_clogf(z +
+                        __devicelib_csqrtf(__sqrf(z) - 1.0f));
+  if (__spirv_SignBitSet(z_imag))
+    return CMPLXF(__spirv_ocl_fabs(__devicelib_cimagf(w)),
+                  __spirv_ocl_fabs(__devicelib_crealf(w)));
+  return CMPLXF(__spirv_ocl_fabs(__devicelib_cimagf(w)),
+                -__spirv_ocl_fabs(__devicelib_crealf(w)));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_casinhf(float __complex__ z) {
+  float z_real = __devicelib_crealf(z);
+  float z_imag = __devicelib_cimagf(z);
+  const float __pi(__spirv_ocl_atan2(+0.0f, -0.0f));
+  if (__spirv_IsInf(z_real)) {
+    if (__spirv_IsNan(z_imag))
+      return z;
+    if (__spirv_IsInf(z_imag))
+      return CMPLXF(z_real, __spirv_ocl_copysign(__pi * 0.25f, z_imag));
+    return CMPLXF(z_real, __spirv_ocl_copysign(0.0f, z_imag));
+  }
+  if (__spirv_IsNan(z_real)) {
+    if (__spirv_IsInf(z_imag))
+      return CMPLXF(z_imag, z_real);
+    if (z_imag == 0)
+      return z;
+    return CMPLXF(z_real, z_real);
+  }
+  if (__spirv_IsInf(z_imag))
+    return CMPLXF(__spirv_ocl_copysign(z_imag, z_real),
+                  __spirv_ocl_copysign(__pi/2.0f, z_imag));
+  float __complex__ w = __devicelib_clogf(z +
+                        __devicelib_csqrtf(__sqrf(z) + 1.0f));
+  return CMPLXF(__spirv_ocl_copysign(__devicelib_crealf(w), z_real),
+                __spirv_ocl_copysign(__devicelib_cimagf(w), z_imag));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_casinf(float __complex__ z) {
+  float __complex__ w = __devicelib_casinhf(CMPLXF(-__devicelib_cimagf(z),
+                                                  __devicelib_crealf(z)));
+  return CMPLXF(__devicelib_cimagf(w), -__devicelib_crealf(w));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_cacoshf(float __complex__ z) {
+  float z_real = __devicelib_crealf(z);
+  float z_imag = __devicelib_cimagf(z);
+  const float __pi(__spirv_ocl_atan2(+0.0f, -0.0f));
+  if (__spirv_IsInf(z_real)) {
+    if (__spirv_IsNan(z_imag))
+      return CMPLXF(__spirv_ocl_fabs(z_real), z_imag);
+    if (__spirv_IsInf(z_imag)) {
+      if (z_real > 0)
+        return CMPLXF(z_real, __spirv_ocl_copysign(__pi * 0.25f, z_imag));
+      else
+        return CMPLXF(-z_real, __spirv_ocl_copysign(__pi * 0.75f, z_imag));
+    }
+    if (z_real < 0)
+      return CMPLXF(-z_real, __spirv_ocl_copysign(__pi, z_imag));
+    return CMPLXF(z_real, __spirv_ocl_copysign(0.0f, z_imag));
+  }
+  if (__spirv_IsNan(z_real)) {
+    if (__spirv_IsInf(z_imag))
+      return CMPLXF(__spirv_ocl_fabs(z_imag), z_real);
+    return CMPLXF(z_real, z_real);
+  }
+  if (__spirv_IsInf(z_imag))
+    return CMPLXF(__spirv_ocl_fabs(z_imag), __spirv_ocl_copysign(__pi/2.0f, z_imag));
+  float __complex__ w = __devicelib_clogf(z + __devicelib_csqrtf(__sqrf(z) - 1.0f));
+  return CMPLXF(__spirv_ocl_copysign(__devicelib_crealf(w), 0.0f),
+                __spirv_ocl_copysign(__devicelib_cimagf(w), z_imag));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_catanhf(float __complex__ z) {
+  float z_real = __devicelib_crealf(z);
+  float z_imag = __devicelib_cimagf(z);
+  const float __pi(__spirv_ocl_atan2(+0.0f, -0.0f));
+  if (__spirv_IsInf(z_imag))
+    return CMPLXF(__spirv_ocl_copysign(0.0f, z_real),
+                  __spirv_ocl_copysign(__pi/2.0f, z_imag));
+  if (__spirv_IsNan(z_imag)) {
+    if (__spirv_IsInf(z_real) || z_real == 0)
+      return CMPLXF(__spirv_ocl_copysign(0.0f, z_real), z_imag);
+    return CMPLXF(z_imag, z_imag);
+  }
+  if (__spirv_IsNan(z_real))
+    return CMPLXF(z_real, z_real);
+  if (__spirv_IsInf(z_real))
+    return CMPLXF(__spirv_ocl_copysign(0.0f, z_real),
+                  __spirv_ocl_copysign(__pi/2.0f, z_imag));
+  if (__spirv_ocl_fabs(z_real) == 1.0f && z_imag == 0.0f)
+    return CMPLXF(__spirv_ocl_copysign(INFINITY, z_real),
+                  __spirv_ocl_copysign(0.0f, z_imag));
+  float __complex__ t1 = 1.0f + z;
+  float __complex__ t2 = 1.0f - z;
+  float __complex__ t3 = __devicelib___divsc3(__devicelib_crealf(t1),
+                                            __devicelib_cimagf(t1),
+                                            __devicelib_crealf(t2),
+                                            __devicelib_cimagf(t2));
+  float __complex__ w = __devicelib_clogf(t3) / 2.0f;
+  return CMPLXF(__spirv_ocl_copysign(__devicelib_crealf(w), z_real),
+                __spirv_ocl_copysign(__devicelib_cimagf(w), z_imag));
+}
+
+SYCL_EXTERNAL
+float __complex__ __devicelib_catanf(float __complex__ z) {
+  float __complex__ w = __devicelib_catanhf(CMPLXF(-__devicelib_cimagf(z),
+                                                   __devicelib_crealf(z)));
+  return CMPLXF(__devicelib_cimagf(w), -__devicelib_crealf(w));
+}
+
+} // extern "C"
+#endif

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -441,6 +441,14 @@ static const char* getDeviceLibFilename(DeviceLibExt Extension) {
   switch (Extension) {
   case cl_intel_devicelib_assert:
     return "libsycl-fallback-cassert.spv";
+  case cl_intel_devicelib_math:
+    return "libsycl-fallback-cmath.spv";
+  case cl_intel_devicelib_math_fp64:
+    return "libsycl-fallback-cmath-fp64.spv";
+  case cl_intel_devicelib_complex:
+    return "libsycl-fallback-complex.spv";
+  case cl_intel_devicelib_complex_fp64:
+    return "libsycl-fallback-complex-fp64.spv";
   }
   throw compile_program_error("Unhandled (new?) device library extension");
 }
@@ -449,6 +457,14 @@ static const char* getDeviceLibExtensionStr(DeviceLibExt Extension) {
   switch (Extension) {
   case cl_intel_devicelib_assert:
     return "cl_intel_devicelib_assert";
+  case cl_intel_devicelib_math:
+    return "cl_intel_devicelib_math";
+  case cl_intel_devicelib_math_fp64:
+    return "cl_intel_devicelib_math_fp64";
+  case cl_intel_devicelib_complex:
+    return "cl_intel_devicelib_complex";
+  case cl_intel_devicelib_complex_fp64:
+    return "cl_intel_devicelib_complex_fp64";
   }
   throw compile_program_error("Unhandled (new?) device library extension");
 }
@@ -586,19 +602,36 @@ DeviceImage &ProgramManager::getDeviceImage(OSModuleHandle M, KernelSetId KSId,
   return *Img;
 }
 
+// TODO: getDeviceLibPrograms should also support Windows but
+// current implementation doesn't work on Windows when multiple
+// device libraries exist and this problem should be fixed.
 static std::vector<RT::PiProgram>
 getDeviceLibPrograms(const ContextImplPtr Context,
                      const std::vector<RT::PiDevice> &Devices,
                      std::map<DeviceLibExt, RT::PiProgram> &CachedLibPrograms) {
-
   std::vector<RT::PiProgram> Programs;
 
   // TODO: SYCL compiler should generate a list of required extensions for a
   // particular program in order to allow us do a more fine-grained check here.
   // Require *all* possible devicelib extensions for now.
   std::pair<DeviceLibExt, bool> RequiredDeviceLibExt[] = {
-      {cl_intel_devicelib_assert, /* is fallback loaded? */ false}
+      {cl_intel_devicelib_assert, /* is fallback loaded? */ false},
+      {cl_intel_devicelib_math, false},
+      {cl_intel_devicelib_math_fp64, false},
+      {cl_intel_devicelib_complex, false},
+      {cl_intel_devicelib_complex_fp64, false}
   };
+
+  // Disable all devicelib extensions requiring fp64 support if at least
+  // one underlying device doesn't support cl_khr_fp64.
+  bool fp64Support = true;
+  for (RT::PiDevice Dev : Devices) {
+    std::string DevExtList =
+	get_device_info<std::string, info::device::extensions>::get(
+            Dev, Context->getPlugin());
+    fp64Support = fp64Support &&
+	          (DevExtList.npos != DevExtList.find("cl_khr_fp64"));
+  }
 
   // Load a fallback library for an extension if at least one device does not
   // support it.
@@ -611,6 +644,11 @@ getDeviceLibPrograms(const ContextImplPtr Context,
       bool &FallbackIsLoaded = Pair.second;
 
       if (FallbackIsLoaded) {
+        continue;
+      }
+
+      if ((Ext == cl_intel_devicelib_math_fp64 ||
+	  Ext == cl_intel_devicelib_complex_fp64) && !fp64Support) {
         continue;
       }
 

--- a/sycl/test/devicelib/c99_complex_math_fp64_test.cpp
+++ b/sycl/test/devicelib/c99_complex_math_fp64_test.cpp
@@ -1,0 +1,256 @@
+// UNSUPPORTED: windows
+// RUN: %clangxx -fsycl -c %s -o %t.o
+// RUN: %clangxx -fsycl %t.o %llvm_build_libs_dir/libsycl-complex-fp64.o -o %t.out
+#include <CL/sycl.hpp>
+#include <cassert>
+#include <complex.h>
+#include "math_utils.hpp"
+#ifndef CMPLX
+#define CMPLX(r, i) ((double __complex__){ (double)r, (double)i })
+#endif
+
+bool is_about_C99_CMPLX(double __complex__ x, double __complex__ y) {
+  return is_about_FP(creal(x), creal(y)) && is_about_FP(cimag(x), cimag(y));
+}
+
+namespace s = cl::sycl;
+constexpr s::access::mode sycl_read = s::access::mode::read;
+constexpr s::access::mode sycl_write = s::access::mode::write;
+
+class DeviceComplexTimes;
+
+void device_c99_complex_times(s::queue &deviceQueue) {
+  double __complex__ buf_in3[4] = {CMPLX(0, 1), CMPLX(1, 1),
+                                   CMPLX(2, 3), CMPLX(4, 5)};
+  double __complex__ buf_in4[4] = {CMPLX(1, 1), CMPLX(2, 1),
+                                   CMPLX(2, 2), CMPLX(3, 4)};
+  double __complex__ buf_out2[4];
+
+  double __complex__ ref_results2[4] = {CMPLX(-1, 1),  CMPLX(1, 3),
+                                        CMPLX(-2, 10), CMPLX(-8, 31)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<double __complex__, 1> buffer4(buf_in3, numOfItems);
+  s::buffer<double __complex__, 1> buffer5(buf_in4, numOfItems);
+  s::buffer<double __complex__, 1> buffer6(buf_out2, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in3_access = buffer4.get_access<sycl_read>(cgh);
+    auto buf_in4_access = buffer5.get_access<sycl_read>(cgh);
+    auto buf_out2_access = buffer6.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexTimes>(numOfItems, [=](s::id<1>WIid) {
+      buf_out2_access[WIid] = buf_in3_access[WIid] * buf_in4_access[WIid];
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_C99_CMPLX(buf_out2[idx], ref_results2[idx]));
+  }
+}
+
+class DeviceComplexDivides;
+
+void device_c99_complex_divides(s::queue &deviceQueue) {
+  double __complex__ buf_in3[8] = {CMPLX(-1, 1),  CMPLX(1, 3),
+                                   CMPLX(-2, 10), CMPLX(-8, 31),
+                                   CMPLX(4, 2), CMPLX(-1, 0),
+                                   CMPLX(0, 10), CMPLX(0 , 0)};
+  double __complex__ buf_in4[8] = {CMPLX(0, 1), CMPLX(1, 1),
+                                   CMPLX(2, 3), CMPLX(4, 5),
+                                   CMPLX(2, 0), CMPLX(0, 1),
+                                   CMPLX(0, 5), CMPLX(1, 0)};
+  double __complex__ ref_results2[8] = {CMPLX(1, 1), CMPLX(2, 1),
+                                        CMPLX(2, 2), CMPLX(3, 4),
+                                        CMPLX(2, 1), CMPLX(0, 1),
+                                        CMPLX(2, 0), CMPLX(0, 0)};
+  double __complex__ buf_out2[8];
+
+  s::range<1> numOfItems{8};
+  {
+  s::buffer<double __complex__, 1> buffer4(buf_in3, numOfItems);
+  s::buffer<double __complex__, 1> buffer5(buf_in4, numOfItems);
+  s::buffer<double __complex__, 1> buffer6(buf_out2, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in3_access = buffer4.get_access<sycl_read>(cgh);
+    auto buf_in4_access = buffer5.get_access<sycl_read>(cgh);
+    auto buf_out2_access = buffer6.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexDivides>(numOfItems, [=](s::id<1>WIid) {
+      buf_out2_access[WIid] = buf_in3_access[WIid] / buf_in4_access[WIid];
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 8; ++idx) {
+    assert(is_about_C99_CMPLX(buf_out2[idx], ref_results2[idx]));
+  }
+}
+
+class DeviceComplexSqrt;
+
+void device_c99_complex_sqrt(s::queue &deviceQueue) {
+  double __complex__ buf_in2[4] = {CMPLX(-1, 0), CMPLX(0, 2),
+                                   CMPLX(4, 0),  CMPLX(-5, 12)};
+  double __complex__ buf_out2[4];
+  double __complex__ ref_results2[4] = {CMPLX(0, 1), CMPLX(1, 1),
+                                        CMPLX(2, 0), CMPLX(2, 3)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<double __complex__, 1> buffer3(buf_in2, numOfItems);
+  s::buffer<double __complex__, 1> buffer4(buf_out2, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in2_access = buffer3.get_access<sycl_read>(cgh);
+    auto buf_out2_access = buffer4.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexSqrt>(numOfItems, [=](s::id<1>WIid) {
+      buf_out2_access[WIid] = csqrt(buf_in2_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_C99_CMPLX(buf_out2[idx], ref_results2[idx]));
+  }
+}
+
+class DeviceComplexAbs;
+
+void device_c99_complex_abs(s::queue &deviceQueue) {
+  double __complex__ buf_in2[4] = {CMPLX(0, 0),  CMPLX(3, 4),
+                                   CMPLX(12, 5), CMPLX(INFINITY, 1)};
+  double buf_out2[4];
+  double ref_results2[4] = {0, 5, 13, INFINITY};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<double __complex__, 1> buffer3(buf_in2, numOfItems);
+  s::buffer<double, 1> buffer4(buf_out2, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in2_access = buffer3.get_access<sycl_read>(cgh);
+    auto buf_out2_access = buffer4.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexAbs>(numOfItems, [=](s::id<1>WIid) {
+      buf_out2_access[WIid] = cabs(buf_in2_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_FP(buf_out2[idx], ref_results2[idx]));
+  }
+}
+
+class DeviceComplexExp;
+
+void device_c99_complex_exp(s::queue &deviceQueue) {
+  double __complex__ buf_in2[4] = {CMPLX(0, 0), CMPLX(0, M_PI_2),
+                                   CMPLX(0, M_PI), CMPLX(1, M_PI_2)};
+  double __complex__ buf_out2[4];
+  double __complex__ ref_results2[4] = {CMPLX(1, 0), CMPLX(0, 1),
+                                        CMPLX(-1, 0),CMPLX(0, M_E)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<double __complex__, 1> buffer3(buf_in2, numOfItems);
+  s::buffer<double __complex__, 1> buffer4(buf_out2, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in2_access = buffer3.get_access<sycl_read>(cgh);
+    auto buf_out2_access = buffer4.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexExp>(numOfItems, [=](s::id<1>WIid) {
+      buf_out2_access[WIid] = cexp(buf_in2_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_C99_CMPLX(buf_out2[idx], ref_results2[idx]));
+  }
+}
+
+class DeviceComplexLog;
+
+void device_c99_complex_log(s::queue &deviceQueue) {
+  double __complex__ buf_in2[4] = {CMPLX(1, 0),  CMPLX(0, 1),
+                                   CMPLX(-1, 0), CMPLX(0, M_E)};
+  double __complex__ buf_out2[4];
+  double __complex__ ref_results2[4] = {CMPLX(0, 0), CMPLX(0, M_PI_2),
+                                        CMPLX(0, M_PI), CMPLX(1, M_PI_2)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<double __complex__, 1> buffer3(buf_in2, numOfItems);
+  s::buffer<double __complex__, 1> buffer4(buf_out2, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in2_access = buffer3.get_access<sycl_read>(cgh);
+    auto buf_out2_access = buffer4.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexLog>(numOfItems, [=](s::id<1>WIid) {
+      buf_out2_access[WIid] = ::clog(buf_in2_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_C99_CMPLX(buf_out2[idx], ref_results2[idx]));
+  }
+}
+
+class DeviceComplexSin;
+
+void device_c99_complex_sin(s::queue &deviceQueue) {
+  double __complex__ buf_in2[2] = {CMPLX(0, 0), CMPLX(M_PI_2, 0)};
+  double __complex__ buf_out2[2];
+  double __complex__ ref_results2[2] = {CMPLX(0, 0), CMPLX(1, 0)};
+  s::range<1> numOfItems{2};
+  {
+  s::buffer<double __complex__, 1> buffer3(buf_in2, numOfItems);
+  s::buffer<double __complex__, 1> buffer4(buf_out2, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in2_access = buffer3.get_access<sycl_read>(cgh);
+    auto buf_out2_access = buffer4.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexSin>(numOfItems, [=](s::id<1>WIid) {
+      buf_out2_access[WIid] = csin(buf_in2_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 2; ++idx) {
+    assert(is_about_C99_CMPLX(buf_out2[idx], ref_results2[idx]));
+  }
+}
+
+class DeviceComplexCos;
+
+void device_c99_complex_cos(s::queue &deviceQueue) {
+  double __complex__ buf_in2[2] = {CMPLX(0, 0), CMPLX(M_PI, 0)};
+  double __complex__ buf_out2[2];
+  double __complex__ ref_results2[2] = {CMPLX(1, 0), CMPLX(-1, 0)};
+  s::range<1> numOfItems{2};
+  {
+  s::buffer<double __complex__, 1> buffer3(buf_in2, numOfItems);
+  s::buffer<double __complex__, 1> buffer4(buf_out2, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in2_access = buffer3.get_access<sycl_read>(cgh);
+    auto buf_out2_access = buffer4.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexCos>(numOfItems, [=](s::id<1>WIid) {
+      buf_out2_access[WIid] = ccos(buf_in2_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 2; ++idx) {
+    assert(is_about_C99_CMPLX(buf_out2[idx], ref_results2[idx]));
+  }
+}
+
+void device_c99_complex_test(s::queue &deviceQueue) {
+  device_c99_complex_times(deviceQueue);
+  device_c99_complex_divides(deviceQueue);
+  device_c99_complex_sqrt(deviceQueue);
+  device_c99_complex_abs(deviceQueue);
+  device_c99_complex_exp(deviceQueue);
+  device_c99_complex_log(deviceQueue);
+  device_c99_complex_sin(deviceQueue);
+  device_c99_complex_cos(deviceQueue);
+}
+
+int main() {
+  s::queue deviceQueue;
+  if (deviceQueue.get_device().has_extension("cl_khr_fp64")) {
+    device_c99_complex_test(deviceQueue);
+    std::cout << "Pass" << std::endl;
+  }
+}

--- a/sycl/test/devicelib/c99_complex_math_test.cpp
+++ b/sycl/test/devicelib/c99_complex_math_test.cpp
@@ -1,0 +1,258 @@
+// UNSUPPORTED: windows
+// RUN: %clangxx -fsycl -c %s -o %t.o
+// RUN: %clangxx -fsycl %t.o %llvm_build_libs_dir/libsycl-complex.o -o %t.out
+#include <CL/sycl.hpp>
+#include <cassert>
+#include <complex.h>
+#include "math_utils.hpp"
+
+#ifndef CMPLXF
+#define CMPLXF(r, i) ((float __complex__){ (float)r, (float)i })
+#endif
+
+bool is_about_C99_CMPLXF(float __complex__ x, float __complex__ y) {
+  return is_about_FP(crealf(x), crealf(y)) && is_about_FP(cimagf(x), cimagf(y));
+}
+
+namespace s = cl::sycl;
+constexpr s::access::mode sycl_read = s::access::mode::read;
+constexpr s::access::mode sycl_write = s::access::mode::write;
+
+class DeviceComplexTimes;
+
+void device_c99_complex_times(s::queue &deviceQueue) {
+  float __complex__ buf_in1[4] = {CMPLXF(0, 1), CMPLXF(1, 1),
+                                  CMPLXF(2, 3), CMPLXF(4, 5)};
+  float __complex__ buf_in2[4] = {CMPLXF(1, 1), CMPLXF(2, 1),
+                                  CMPLXF(2, 2), CMPLXF(3, 4)};
+  float __complex__ buf_out1[4];
+
+  float __complex__ ref_results1[4] = {CMPLXF(-1, 1),  CMPLXF(1, 3),
+                                       CMPLXF(-2, 10), CMPLXF(-8, 31)};
+
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<float __complex__, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<float __complex__, 1> buffer2(buf_in2, numOfItems);
+  s::buffer<float __complex__, 1> buffer3(buf_out1, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.get_access<sycl_read>(cgh);
+    auto buf_in2_access = buffer2.get_access<sycl_read>(cgh);
+    auto buf_out1_access = buffer3.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexTimes>(numOfItems, [=](s::id<1>WIid) {
+      buf_out1_access[WIid] = buf_in1_access[WIid] * buf_in2_access[WIid];
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_C99_CMPLXF(buf_out1[idx], ref_results1[idx]));
+  }
+}
+
+class DeviceComplexDivides;
+
+void device_c99_complex_divides(s::queue &deviceQueue) {
+  float __complex__ buf_in1[8] = {CMPLXF(-1, 1),  CMPLXF(1, 3),
+                                  CMPLXF(-2, 10), CMPLXF(-8, 31),
+                                  CMPLXF(4, 2), CMPLXF(-1, 0),
+                                  CMPLXF(0, 10), CMPLXF(0 , 0)};
+  float __complex__ buf_in2[8] = {CMPLXF(0, 1), CMPLXF(1, 1),
+                                  CMPLXF(2, 3), CMPLXF(4, 5),
+                                  CMPLXF(2, 0), CMPLXF(0, 1),
+                                  CMPLXF(0, 5), CMPLXF(1, 0)};
+  float __complex__ ref_results1[8] = {CMPLXF(1, 1), CMPLXF(2, 1),
+                                       CMPLXF(2, 2), CMPLXF(3, 4),
+                                       CMPLXF(2, 1), CMPLXF(0, 1),
+                                       CMPLXF(2, 0), CMPLXF(0, 0)};
+  float __complex__ buf_out1[8];
+
+  s::range<1> numOfItems{8};
+  {
+  s::buffer<float __complex__, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<float __complex__, 1> buffer2(buf_in2, numOfItems);
+  s::buffer<float __complex__, 1> buffer3(buf_out1,numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.get_access<sycl_read>(cgh);
+    auto buf_in2_access = buffer2.get_access<sycl_read>(cgh);
+    auto buf_out1_access = buffer3.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexDivides>(numOfItems, [=](s::id<1>WIid) {
+      buf_out1_access[WIid] = buf_in1_access[WIid] / buf_in2_access[WIid];
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 8; ++idx) {
+    assert(is_about_C99_CMPLXF(buf_out1[idx], ref_results1[idx]));
+  }
+}
+
+class DeviceComplexSqrt;
+
+void device_c99_complex_sqrt(s::queue &deviceQueue) {
+  float __complex__ buf_in1[4] = {CMPLXF(-1, 0), CMPLXF(0, 2),
+                                 CMPLXF(4, 0),  CMPLXF(-5, 12)};
+  float __complex__ buf_out1[4];
+  float __complex__ ref_results1[4] = {CMPLXF(0, 1), CMPLXF(1, 1),
+                                       CMPLXF(2, 0), CMPLXF(2, 3)};
+
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<float __complex__, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<float __complex__, 1> buffer2(buf_out1, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.get_access<sycl_read>(cgh);
+    auto buf_out1_access = buffer2.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexSqrt>(numOfItems, [=](s::id<1>WIid) {
+      buf_out1_access[WIid] = csqrtf(buf_in1_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_C99_CMPLXF(buf_out1[idx], ref_results1[idx]));
+  }
+}
+
+class DeviceComplexAbs;
+
+void device_c99_complex_abs(s::queue &deviceQueue) {
+  float __complex__ buf_in1[4] = {CMPLXF(0, 0),  CMPLXF(3, 4),
+                                  CMPLXF(12, 5), CMPLXF(INFINITY, 1)};
+  float buf_out1[4];
+  float ref_results1[4] = {0, 5, 13, INFINITY};
+
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<float __complex__, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<float, 1> buffer2(buf_out1, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.get_access<sycl_read>(cgh);
+    auto buf_out1_access = buffer2.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexAbs>(numOfItems, [=](s::id<1>WIid) {
+      buf_out1_access[WIid] = cabsf(buf_in1_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_FP(buf_out1[idx], ref_results1[idx]));
+  }
+}
+
+class DeviceComplexExp;
+
+void device_c99_complex_exp(s::queue &deviceQueue) {
+  float __complex__ buf_in1[4] = {CMPLXF(0, 0), CMPLXF(0, M_PI_2),
+                                 CMPLXF(0, M_PI), CMPLXF(1, M_PI_2)};
+  float __complex__ buf_out1[4];
+  float __complex__ ref_results1[4] = {CMPLXF(1, 0), CMPLXF(0, 1),
+                                       CMPLXF(-1, 0),CMPLXF(0, M_E)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<float __complex__, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<float __complex__, 1> buffer2(buf_out1, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.get_access<sycl_read>(cgh);
+    auto buf_out1_access = buffer2.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexExp>(numOfItems, [=](s::id<1>WIid) {
+      buf_out1_access[WIid] = cexpf(buf_in1_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_C99_CMPLXF(buf_out1[idx], ref_results1[idx]));
+  }
+}
+
+class DeviceComplexLog;
+
+void device_c99_complex_log(s::queue &deviceQueue) {
+  float __complex__ buf_in1[4] = {CMPLXF(1, 0),  CMPLXF(0, 1),
+                                  CMPLXF(-1, 0), CMPLXF(0, M_E)};
+  float __complex__ buf_out1[4];
+  float __complex__ ref_results1[4] = {CMPLXF(0, 0), CMPLXF(0, M_PI_2),
+                                       CMPLXF(0, M_PI), CMPLXF(1, M_PI_2)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<float __complex__, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<float __complex__, 1> buffer2(buf_out1, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.get_access<sycl_read>(cgh);
+    auto buf_out1_access = buffer2.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexLog>(numOfItems, [=](s::id<1>WIid) {
+      buf_out1_access[WIid] = clogf(buf_in1_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_C99_CMPLXF(buf_out1[idx], ref_results1[idx]));
+  }
+}
+
+class DeviceComplexSin;
+
+void device_c99_complex_sin(s::queue &deviceQueue) {
+  float __complex__ buf_in1[2] = {CMPLXF(0, 0), CMPLXF(M_PI_2, 0)};
+  float __complex__ buf_out1[2];
+  float __complex__ ref_results1[2] = {CMPLXF(0, 0), CMPLXF(1, 0)};
+  s::range<1> numOfItems{2};
+  {
+  s::buffer<float __complex__, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<float __complex__, 1> buffer2(buf_out1, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.get_access<sycl_read>(cgh);
+    auto buf_out1_access = buffer2.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexSin>(numOfItems, [=](s::id<1>WIid) {
+      buf_out1_access[WIid] = csinf(buf_in1_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 2; ++idx) {
+    assert(is_about_C99_CMPLXF(buf_out1[idx], ref_results1[idx]));
+  }
+}
+
+class DeviceComplexCos;
+
+void device_c99_complex_cos(s::queue &deviceQueue) {
+  float __complex__ buf_in1[2] = {CMPLXF(0, 0), CMPLXF(M_PI, 0)};
+  float __complex__ buf_out1[2];
+  float __complex__ ref_results1[2] = {CMPLXF(1, 0), CMPLXF(-1, 0)};
+  s::range<1> numOfItems{2};
+  {
+  s::buffer<float __complex__, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<float __complex__, 1> buffer2(buf_out1, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.get_access<sycl_read>(cgh);
+    auto buf_out1_access = buffer2.get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexCos>(numOfItems, [=](s::id<1>WIid) {
+      buf_out1_access[WIid] = ccosf(buf_in1_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 2; ++idx) {
+    assert(is_about_C99_CMPLXF(buf_out1[idx], ref_results1[idx]));
+  }
+}
+
+void device_c99_complex_test(s::queue &deviceQueue) {
+  device_c99_complex_times(deviceQueue);
+  device_c99_complex_divides(deviceQueue);
+  device_c99_complex_sqrt(deviceQueue);
+  device_c99_complex_abs(deviceQueue);
+  device_c99_complex_exp(deviceQueue);
+  device_c99_complex_log(deviceQueue);
+  device_c99_complex_sin(deviceQueue);
+  device_c99_complex_cos(deviceQueue);
+}
+
+int main() {
+  s::queue deviceQueue;
+  device_c99_complex_test(deviceQueue);
+  std::cout << "Pass" << std::endl;
+}

--- a/sycl/test/devicelib/cmath_test.cpp
+++ b/sycl/test/devicelib/cmath_test.cpp
@@ -1,0 +1,84 @@
+// UNSUPPORTED: windows
+// RUN: %clangxx -fsycl -c %s -o %t.o
+// RUN: %clangxx -fsycl %t.o %llvm_build_libs_dir/libsycl-cmath.o -o %t.out
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <cmath>
+
+namespace s = cl::sycl;
+constexpr s::access::mode sycl_read = s::access::mode::read;
+constexpr s::access::mode sycl_write = s::access::mode::write;
+
+template <class T>
+class DeviceCos;
+
+template <class T>
+void device_cos_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  T result = -1;
+  {
+    s::buffer<T, 1> buffer1(&result, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access = buffer1.template get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceCos<T> >([=]() {
+        res_access[0] = std::cos(0);
+      });
+    });
+  }
+
+  assert(result == 1);
+}
+
+template <class T>
+class DeviceSin;
+
+template <class T>
+void device_sin_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  T result = -1;
+  {
+    s::buffer<T, 1> buffer1(&result, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access = buffer1.template get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceSin<T> >([=]() {
+        res_access[0] = std::sin(0);
+      });
+    });
+  }
+
+  assert(result == 0);
+}
+
+template <class T>
+class DeviceLog;
+
+template <class T>
+void device_log_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  T result = -1;
+  {
+    s::buffer<T, 1> buffer1(&result, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access = buffer1.template get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceLog<T> >([=]() {
+        res_access[0] = std::log(1);
+      });
+    });
+  }
+
+  assert(result == 0);
+}
+
+template <class T>
+void device_cmath_test(s::queue &deviceQueue) {
+  device_cos_test<T>(deviceQueue);
+  device_sin_test<T>(deviceQueue);
+  device_log_test<T>(deviceQueue);
+}
+
+int main() {
+  s::queue deviceQueue;
+  device_cmath_test<float>(deviceQueue);
+  std::cout << "Pass" << std::endl;
+  return 0;
+}

--- a/sycl/test/devicelib/cmath_test_fp64.cpp
+++ b/sycl/test/devicelib/cmath_test_fp64.cpp
@@ -1,0 +1,86 @@
+// UNSUPPORTED: windows
+// RUN: %clangxx -fsycl -c %s -o %t.o
+// RUN: %clangxx -fsycl %t.o %llvm_build_libs_dir/libsycl-cmath-fp64.o -o %t.out
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <cmath>
+
+namespace s = cl::sycl;
+constexpr s::access::mode sycl_read = s::access::mode::read;
+constexpr s::access::mode sycl_write = s::access::mode::write;
+
+template <class T>
+class DeviceCos;
+
+template <class T>
+void device_cos_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  T result = -1;
+  {
+    s::buffer<T, 1> buffer1(&result, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access = buffer1.template get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceCos<T> >([=]() {
+        res_access[0] = std::cos(0);
+      });
+    });
+  }
+
+  assert(result == 1);
+}
+
+template <class T>
+class DeviceSin;
+
+template <class T>
+void device_sin_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  T result = -1;
+  {
+    s::buffer<T, 1> buffer1(&result, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access = buffer1.template get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceSin<T> >([=]() {
+        res_access[0] = std::sin(0);
+      });
+    });
+  }
+
+  assert(result == 0);
+}
+
+template <class T>
+class DeviceLog;
+
+template <class T>
+void device_log_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  T result = -1;
+  {
+    s::buffer<T, 1> buffer1(&result, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access = buffer1.template get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceLog<T> >([=]() {
+        res_access[0] = std::log(1);
+      });
+    });
+  }
+
+  assert(result == 0);
+}
+
+template <class T>
+void device_cmath_test(s::queue &deviceQueue) {
+  device_cos_test<T>(deviceQueue);
+  device_sin_test<T>(deviceQueue);
+  device_log_test<T>(deviceQueue);
+}
+
+int main() {
+  s::queue deviceQueue;
+  if (deviceQueue.get_device().has_extension("cl_khr_fp64")) {
+    device_cmath_test<double>(deviceQueue);
+    std::cout << "Pass" << std::endl;
+  }
+  return 0;
+}

--- a/sycl/test/devicelib/math_fp64_test.cpp
+++ b/sycl/test/devicelib/math_fp64_test.cpp
@@ -1,0 +1,79 @@
+// UNSUPPORTED: windows
+// RUN: %clangxx -fsycl -c %s -o %t.o
+// RUN: %clangxx -fsycl %t.o %llvm_build_libs_dir/libsycl-cmath-fp64.o -o %t.out
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <math.h>
+
+namespace s = cl::sycl;
+constexpr s::access::mode sycl_read = s::access::mode::read;
+constexpr s::access::mode sycl_write = s::access::mode::write;
+
+class DeviceSin;
+
+void device_sin_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  double result_d = -1;
+  {
+    s::buffer<double, 1> buffer1(&result_d, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access1 = buffer1.get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceSin>([=]() {
+        res_access1[0] = sin(0);
+      });
+    });
+  }
+
+  assert(result_d == 0);
+}
+
+class DeviceCos;
+
+void device_cos_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  double result_d = -1;
+  {
+    s::buffer<double, 1> buffer1(&result_d, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access1 = buffer1.get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceCos>([=]() {
+        res_access1[0] = cos(0);
+      });
+    });
+  }
+
+  assert(result_d == 1);
+}
+
+class DeviceLog;
+
+void device_log_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  double result_d = -1;
+  {
+    s::buffer<double, 1> buffer2(&result_d, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access1 = buffer2.get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceLog>([=]() {
+        res_access1[0] = log(1);
+      });
+    });
+  }
+
+  assert(result_d == 0);
+}
+
+void device_math_test(s::queue &deviceQueue) {
+  device_cos_test(deviceQueue);
+  device_sin_test(deviceQueue);
+  device_log_test(deviceQueue);
+}
+
+int main() {
+  s::queue deviceQueue;
+  if (deviceQueue.get_device().has_extension("cl_khr_fp64")) {
+    device_math_test(deviceQueue);
+    std::cout << "Pass" << std::endl;
+  }
+  return 0;
+}

--- a/sycl/test/devicelib/math_override_test.cpp
+++ b/sycl/test/devicelib/math_override_test.cpp
@@ -1,0 +1,47 @@
+// UNSUPPORTED: windows
+// RUN: %clangxx -fsycl -c %s -o %t.o
+// RUN: %clangxx -fsycl %t.o %llvm_build_libs_dir/libsycl-cmath.o -o %t.out
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <math.h>
+namespace s = cl::sycl;
+constexpr s::access::mode sycl_read = s::access::mode::read;
+constexpr s::access::mode sycl_write = s::access::mode::write;
+
+// Dummy function provided by user to override device library
+// version.
+SYCL_EXTERNAL
+extern "C" float sinf(float x) {
+  return x + 100;
+}
+
+class DeviceTest;
+
+void device_test() {
+  s::queue deviceQueue;
+  s::range<1> numOfItems{1};
+  float result_sin = 0;
+  float result_cos = 0;
+  {
+    s::buffer<float, 1> buffer1(&result_sin, numOfItems);
+    s::buffer<float, 1> buffer2(&result_cos, numOfItems);
+    deviceQueue.submit([&](s::handler &cgh) {
+      auto res_access_sin = buffer1.get_access<sycl_write>(cgh);
+      auto res_access_cos = buffer2.get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceTest>([=]() {
+        // Should use the sin function defined by user, device
+        // library version should be ignored here
+        res_access_sin[0] = sinf(0);
+        res_access_cos[0] = cosf(0);
+      });
+    });
+  }
+
+  assert(((int)result_sin == 100) && ((int)result_cos == 1));
+}
+
+int main() {
+  device_test();
+  std::cout << "Pass" << std::endl;
+  return 0;
+}

--- a/sycl/test/devicelib/math_test.cpp
+++ b/sycl/test/devicelib/math_test.cpp
@@ -1,0 +1,77 @@
+// UNSUPPORTED: windows
+// RUN: %clangxx -fsycl -c %s -o %t.o
+// RUN: %clangxx -fsycl %t.o %llvm_build_libs_dir/libsycl-cmath.o -o %t.out
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <math.h>
+
+namespace s = cl::sycl;
+constexpr s::access::mode sycl_read = s::access::mode::read;
+constexpr s::access::mode sycl_write = s::access::mode::write;
+
+class DeviceSin;
+
+void device_sin_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  float  result_f = -1;
+  {
+    s::buffer<float, 1> buffer1(&result_f, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access1 = buffer1.get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceSin>([=]() {
+        res_access1[0] = sinf(0);
+      });
+    });
+  }
+
+  assert(result_f == 0);
+}
+
+class DeviceCos;
+
+void device_cos_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  float  result_f = -1;
+  {
+    s::buffer<float, 1> buffer1(&result_f, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access1 = buffer1.get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceCos>([=]() {
+        res_access1[0] = cosf(0);
+      });
+    });
+  }
+
+  assert(result_f == 1);
+}
+
+class DeviceLog;
+
+void device_log_test(s::queue &deviceQueue) {
+  s::range<1> numOfItems{1};
+  float  result_f = -1;
+  {
+    s::buffer<float, 1> buffer1(&result_f, numOfItems);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto res_access1 = buffer1.get_access<sycl_write>(cgh);
+      cgh.single_task<class DeviceLog>([=]() {
+        res_access1[0] = logf(1);
+      });
+    });
+  }
+
+  assert(result_f == 0);
+}
+
+void device_math_test(s::queue &deviceQueue) {
+  device_cos_test(deviceQueue);
+  device_sin_test(deviceQueue);
+  device_log_test(deviceQueue);
+}
+
+int main() {
+  s::queue deviceQueue;
+  device_math_test(deviceQueue);
+  std::cout << "Pass" << std::endl;
+  return 0;
+}

--- a/sycl/test/devicelib/math_utils.hpp
+++ b/sycl/test/devicelib/math_utils.hpp
@@ -1,0 +1,25 @@
+#ifndef MATH_UTILS
+#include <complex>
+#include <limits>
+using namespace std;
+// T must be float-point type
+template <typename T>
+bool is_about_FP(T x, T y) {
+  if (x == y)
+    return true;
+  else {
+    if (x != 0 && y != 0) {
+      T max_v = fmax(abs(x), abs(y));
+      return (abs(x - y) / max_v) <
+              numeric_limits<T>::epsilon() * 100;
+    }
+    else {
+      if (x != 0)
+        return abs(x) < numeric_limits<T>::epsilon() * 100;
+      else
+        return abs(y) < numeric_limits<T>::epsilon() * 100;
+    }
+  }
+}
+
+#endif

--- a/sycl/test/devicelib/std_complex_math_fp64_test.cpp
+++ b/sycl/test/devicelib/std_complex_math_fp64_test.cpp
@@ -1,0 +1,353 @@
+// UNSUPPORTED: windows
+// RUN: %clangxx -fsycl -c %s -o %t.o
+// RUN: %clangxx -fsycl %t.o %llvm_build_libs_dir/libsycl-complex-fp64.o %llvm_build_libs_dir/libsycl-cmath-fp64.o -o %t.out
+#include <CL/sycl.hpp>
+#include <cassert>
+#include "math_utils.hpp"
+
+namespace s = cl::sycl;
+constexpr s::access::mode sycl_read = s::access::mode::read;
+constexpr s::access::mode sycl_write = s::access::mode::write;
+
+template <typename T>
+bool is_about_CMPLX(complex<T> x, complex<T> y) {
+  return is_about_FP(x.real(), y.real()) && is_about_FP(x.imag(), y.imag());
+}
+
+template <class T>
+class DeviceComplexTimes;
+
+template <class T>
+void device_complex_times(s::queue &deviceQueue) {
+  complex<T> buf_in1[4] = {complex<T>(0, 1), complex<T>(1, 1),
+                           complex<T>(2, 3), complex<T>(4, 5)};
+  complex<T> buf_in2[4] = {complex<T>(1, 1), complex<T>(2, 1),
+                           complex<T>(2, 2), complex<T>(3, 4)};
+  complex<T> buf_out[4];
+
+  complex<T> ref_results[4] = {complex<T>(-1, 1), complex<T>(1, 3),
+                               complex<T>(-2, 10), complex<T>(-8, 31)};
+
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_in2, numOfItems);
+  s::buffer<complex<T>, 1> buffer3(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_in2_access = buffer2.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer3.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexTimes<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = buf_in1_access[WIid] * buf_in2_access[WIid];
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexDivides;
+
+template <class T>
+void device_complex_divides(s::queue &deviceQueue) {
+  complex<T> buf_in1[8] = {complex<T>(-1, 1), complex<T>(1, 3),
+                           complex<T>(-2, 10), complex<T>(-8, 31),
+                           complex<T>(4, 2), complex<T>(-1, 0),
+                           complex<T>(0, 10), complex<T>(0, 0)};
+  complex<T> buf_in2[8] = {complex<T>(0, 1), complex<T>(1, 1),
+                           complex<T>(2, 3), complex<T>(4, 5),
+                           complex<T>(2, 0), complex<T>(0, 1),
+                           complex<T>(0, 5), complex<T>(1, 0)};
+  complex<T> ref_results[8] = {complex<T>(1, 1), complex<T>(2, 1),
+                               complex<T>(2, 2), complex<T>(3, 4),
+                               complex<T>(2, 1), complex<T>(0, 1),
+                               complex<T>(2, 0), complex<T>(0, 0)};
+  complex<T> buf_out[8];
+
+  s::range<1> numOfItems{8};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_in2, numOfItems);
+  s::buffer<complex<T>, 1> buffer3(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_in2_access = buffer2.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer3.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexDivides<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = buf_in1_access[WIid] / buf_in2_access[WIid];
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 8; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexSqrt;
+
+template <class T>
+void device_complex_sqrt(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = { complex<T>(-1, 0), complex<T>(0, 2),
+                           complex<T>(4, 0), complex<T>(-5, 12)};
+  complex<T> buf_out[4];
+  complex<T> ref_results[4] = {complex<T>(0, 1), complex<T>(1, 1),
+                               complex<T>(2, 0), complex<T>(2, 3)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexSqrt<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = sqrt(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexNorm;
+
+template <class T>
+void device_complex_norm(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = {complex<T>(0, 0), complex<T>(3, 4),
+                          complex<T>(12, 5), complex<T>(INFINITY, 1)};
+  T buf_out[4];
+  T ref_results[4] = {0, 25, 169, INFINITY};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<T, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexNorm<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = norm(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_FP(buf_out[idx], ref_results[idx]));
+  }
+}
+
+
+template <class T>
+class DeviceComplexAbs;
+
+template <class T>
+void device_complex_abs(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = {complex<T>(0, 0), complex<T>(3, 4),
+                          complex<T>(12, 5), complex<T>(INFINITY, 1)};
+  T buf_out[4];
+  T ref_results[4] = {0, 5, 13, INFINITY};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<T, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexAbs<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = abs(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_FP(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexExp;
+
+template <class T>
+void device_complex_exp(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = {complex<T>(0, 0), complex<T>(0, M_PI_2),
+                          complex<T>(0, M_PI), complex<T>(1, M_PI_2)};
+  complex<T> buf_out[4];
+  complex<T> ref_results[4] = {complex<T>(1, 0), complex<T>(0, 1),
+                               complex<T>(-1, 0), complex<T>(0, M_E)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexExp<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = exp(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexLog;
+
+template <class T>
+void device_complex_log(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = {complex<T>(1, 0), complex<T>(0, 1),
+                          complex<T>(-1, 0), complex<T>(0, M_E)};
+  complex<T> buf_out[4];
+  complex<T> ref_results[4] = {complex<T>(0, 0), complex<T>(0, M_PI_2),
+                               complex<T>(0, M_PI), complex<T>(1, M_PI_2)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexLog<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = log(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexLog10;
+
+template <class T>
+void device_complex_log10(s::queue &deviceQueue) {
+  complex<T> buf_in = complex<T>(0, 0);
+  complex<T> buf_out;
+  complex<T> ref_result = complex<T>(-INFINITY, 0);
+  s::range<1> numOfItems{1};
+  {
+  s::buffer<complex<T>, 1> buffer1(&buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(&buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.single_task<class DeviceComplexLog10<T>>([=]() {
+      buf_out_access[0] = log10(buf_in_access[0]);
+    });
+  });
+  }
+
+  assert(is_about_CMPLX(buf_out, ref_result));
+}
+
+template <class T>
+class DeviceComplexSin;
+
+template <class T>
+void device_complex_sin(s::queue &deviceQueue) {
+  complex<T> buf_in[2] = {complex<T>(0, 0), complex<T>(M_PI_2, 0)};
+  complex<T> buf_out[2];
+  complex<T> ref_results[2] = {complex<T>(0, 0), complex<T>(1, 0)};
+  s::range<1> numOfItems{2};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexSin<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = sin(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 2; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexCos;
+
+template <class T>
+void device_complex_cos(s::queue &deviceQueue) {
+  complex<T> buf_in[2] = {complex<T>(0, 0), complex<T>(M_PI, 0)};
+  complex<T> buf_out[2];
+  complex<T> ref_results[2] = {complex<T>(1, 0), complex<T>(-1, 0)};
+  s::range<1> numOfItems{2};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexCos<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = std::cos(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 2; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexPolar;
+
+template <class T>
+void device_complex_polar(s::queue &deviceQueue) {
+  complex<T> buf_out[4];
+  complex<T> ref_results[4] = {complex<T>(1, 0), complex<T>(10, 0),
+                               complex<T>(100, 0), complex<T>(200, 0)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_out_access = buffer1.template get_access<sycl_write>(cgh);
+    cgh.single_task<class DeviceComplexPolar<T>>([=]() {
+      buf_out_access[0] = std::polar(T(1));
+      buf_out_access[1] = std::polar(T(10), T(0));
+      buf_out_access[2] = std::polar(T(100));
+      buf_out_access[3] = std::polar(T(200), T(0));
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+void device_complex_test(s::queue &deviceQueue) {
+  device_complex_times<T>(deviceQueue);
+  device_complex_divides<T>(deviceQueue);
+  device_complex_sqrt<T>(deviceQueue);
+  device_complex_norm<T>(deviceQueue);
+  device_complex_abs<T>(deviceQueue);
+  device_complex_exp<T>(deviceQueue);
+  device_complex_log<T>(deviceQueue);
+  device_complex_log10<T>(deviceQueue);
+  device_complex_sin<T>(deviceQueue);
+  device_complex_cos<T>(deviceQueue);
+  device_complex_polar<T>(deviceQueue);
+}
+
+int main() {
+  s::queue deviceQueue;
+  if (deviceQueue.get_device().has_extension("cl_khr_fp64")) {
+    device_complex_test<double>(deviceQueue);
+    cout << "Pass" << endl;
+  }
+}

--- a/sycl/test/devicelib/std_complex_math_test.cpp
+++ b/sycl/test/devicelib/std_complex_math_test.cpp
@@ -1,0 +1,351 @@
+// UNSUPPORTED: windows
+// RUN: %clangxx -fsycl -c %s -o %t.o
+// RUN: %clangxx -fsycl %t.o %llvm_build_libs_dir/libsycl-complex.o %llvm_build_libs_dir/libsycl-cmath.o -o %t.out
+#include <CL/sycl.hpp>
+#include <cassert>
+#include "math_utils.hpp"
+
+namespace s = cl::sycl;
+constexpr s::access::mode sycl_read = s::access::mode::read;
+constexpr s::access::mode sycl_write = s::access::mode::write;
+
+template <typename T>
+bool is_about_CMPLX(complex<T> x, complex<T> y) {
+  return is_about_FP(x.real(), y.real()) && is_about_FP(x.imag(), y.imag());
+}
+
+template <class T>
+class DeviceComplexTimes;
+
+template <class T>
+void device_complex_times(s::queue &deviceQueue) {
+  complex<T> buf_in1[4] = {complex<T>(0, 1), complex<T>(1, 1),
+                           complex<T>(2, 3), complex<T>(4, 5)};
+  complex<T> buf_in2[4] = {complex<T>(1, 1), complex<T>(2, 1),
+                           complex<T>(2, 2), complex<T>(3, 4)};
+  complex<T> buf_out[4];
+
+  complex<T> ref_results[4] = {complex<T>(-1, 1), complex<T>(1, 3),
+                               complex<T>(-2, 10), complex<T>(-8, 31)};
+
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_in2, numOfItems);
+  s::buffer<complex<T>, 1> buffer3(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_in2_access = buffer2.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer3.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexTimes<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = buf_in1_access[WIid] * buf_in2_access[WIid];
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexDivides;
+
+template <class T>
+void device_complex_divides(s::queue &deviceQueue) {
+  complex<T> buf_in1[8] = {complex<T>(-1, 1), complex<T>(1, 3),
+                           complex<T>(-2, 10), complex<T>(-8, 31),
+                           complex<T>(4, 2), complex<T>(-1, 0),
+                           complex<T>(0, 10), complex<T>(0, 0)};
+  complex<T> buf_in2[8] = {complex<T>(0, 1), complex<T>(1, 1),
+                           complex<T>(2, 3), complex<T>(4, 5),
+                           complex<T>(2, 0), complex<T>(0, 1),
+                           complex<T>(0, 5), complex<T>(1, 0)};
+  complex<T> ref_results[8] = {complex<T>(1, 1), complex<T>(2, 1),
+                               complex<T>(2, 2), complex<T>(3, 4),
+                               complex<T>(2, 1), complex<T>(0, 1),
+                               complex<T>(2, 0), complex<T>(0, 0)};
+  complex<T> buf_out[8];
+
+  s::range<1> numOfItems{8};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in1, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_in2, numOfItems);
+  s::buffer<complex<T>, 1> buffer3(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in1_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_in2_access = buffer2.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer3.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexDivides<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = buf_in1_access[WIid] / buf_in2_access[WIid];
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 8; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexSqrt;
+
+template <class T>
+void device_complex_sqrt(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = { complex<T>(-1, 0), complex<T>(0, 2),
+                           complex<T>(4, 0), complex<T>(-5, 12)};
+  complex<T> buf_out[4];
+  complex<T> ref_results[4] = {complex<T>(0, 1), complex<T>(1, 1),
+                               complex<T>(2, 0), complex<T>(2, 3)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexSqrt<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = sqrt(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexNorm;
+
+template <class T>
+void device_complex_norm(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = {complex<T>(0, 0), complex<T>(3, 4),
+                          complex<T>(12, 5), complex<T>(INFINITY, 1)};
+  T buf_out[4];
+  T ref_results[4] = {0, 25, 169, INFINITY};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<T, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexNorm<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = norm(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_FP(buf_out[idx], ref_results[idx]));
+  }
+}
+
+
+template <class T>
+class DeviceComplexAbs;
+
+template <class T>
+void device_complex_abs(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = {complex<T>(0, 0), complex<T>(3, 4),
+                          complex<T>(12, 5), complex<T>(INFINITY, 1)};
+  T buf_out[4];
+  T ref_results[4] = {0, 5, 13, INFINITY};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<T, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexAbs<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = abs(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_FP(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexExp;
+
+template <class T>
+void device_complex_exp(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = {complex<T>(0, 0), complex<T>(0, M_PI_2),
+                          complex<T>(0, M_PI), complex<T>(1, M_PI_2)};
+  complex<T> buf_out[4];
+  complex<T> ref_results[4] = {complex<T>(1, 0), complex<T>(0, 1),
+                               complex<T>(-1, 0), complex<T>(0, M_E)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexExp<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = exp(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexLog;
+
+template <class T>
+void device_complex_log(s::queue &deviceQueue) {
+  complex<T> buf_in[4] = {complex<T>(1, 0), complex<T>(0, 1),
+                          complex<T>(-1, 0), complex<T>(0, M_E)};
+  complex<T> buf_out[4];
+  complex<T> ref_results[4] = {complex<T>(0, 0), complex<T>(0, M_PI_2),
+                               complex<T>(0, M_PI), complex<T>(1, M_PI_2)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexLog<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = log(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexLog10;
+
+template <class T>
+void device_complex_log10(s::queue &deviceQueue) {
+  complex<T> buf_in = complex<T>(0, 0);
+  complex<T> buf_out;
+  complex<T> ref_result = complex<T>(-INFINITY, 0);
+  s::range<1> numOfItems{1};
+  {
+  s::buffer<complex<T>, 1> buffer1(&buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(&buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.single_task<class DeviceComplexLog10<T>>([=]() {
+      buf_out_access[0] = log10(buf_in_access[0]);
+    });
+  });
+  }
+
+  assert(is_about_CMPLX(buf_out, ref_result));
+}
+
+template <class T>
+class DeviceComplexSin;
+
+template <class T>
+void device_complex_sin(s::queue &deviceQueue) {
+  complex<T> buf_in[2] = {complex<T>(0, 0), complex<T>(M_PI_2, 0)};
+  complex<T> buf_out[2];
+  complex<T> ref_results[2] = {complex<T>(0, 0), complex<T>(1, 0)};
+  s::range<1> numOfItems{2};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexSin<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = sin(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 2; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexCos;
+
+template <class T>
+void device_complex_cos(s::queue &deviceQueue) {
+  complex<T> buf_in[2] = {complex<T>(0, 0), complex<T>(M_PI, 0)};
+  complex<T> buf_out[2];
+  complex<T> ref_results[2] = {complex<T>(1, 0), complex<T>(-1, 0)};
+  s::range<1> numOfItems{2};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_in, numOfItems);
+  s::buffer<complex<T>, 1> buffer2(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_in_access = buffer1.template get_access<sycl_read>(cgh);
+    auto buf_out_access = buffer2.template get_access<sycl_write>(cgh);
+    cgh.parallel_for<class DeviceComplexCos<T>>(numOfItems, [=](s::id<1>WIid) {
+      buf_out_access[WIid] = std::cos(buf_in_access[WIid]);
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 2; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+class DeviceComplexPolar;
+
+template <class T>
+void device_complex_polar(s::queue &deviceQueue) {
+  complex<T> buf_out[4];
+  complex<T> ref_results[4] = {complex<T>(1, 0), complex<T>(10, 0),
+                               complex<T>(100, 0), complex<T>(200, 0)};
+  s::range<1> numOfItems{4};
+  {
+  s::buffer<complex<T>, 1> buffer1(buf_out, numOfItems);
+  deviceQueue.submit([&](s::handler &cgh) {
+    auto buf_out_access = buffer1.template get_access<sycl_write>(cgh);
+    cgh.single_task<class DeviceComplexPolar<T>>([=]() {
+      buf_out_access[0] = std::polar(T(1));
+      buf_out_access[1] = std::polar(T(10), T(0));
+      buf_out_access[2] = std::polar(T(100));
+      buf_out_access[3] = std::polar(T(200), T(0));
+    });
+  });
+  }
+
+  for (size_t idx = 0; idx < 4; ++idx) {
+    assert(is_about_CMPLX(buf_out[idx], ref_results[idx]));
+  }
+}
+
+template <class T>
+void device_complex_test(s::queue &deviceQueue) {
+  device_complex_times<T>(deviceQueue);
+  device_complex_divides<T>(deviceQueue);
+  device_complex_sqrt<T>(deviceQueue);
+  device_complex_norm<T>(deviceQueue);
+  device_complex_abs<T>(deviceQueue);
+  device_complex_exp<T>(deviceQueue);
+  device_complex_log<T>(deviceQueue);
+  device_complex_log10<T>(deviceQueue);
+  device_complex_sin<T>(deviceQueue);
+  device_complex_cos<T>(deviceQueue);
+  device_complex_polar<T>(deviceQueue);
+}
+
+int main() {
+  s::queue deviceQueue;
+  device_complex_test<float>(deviceQueue);
+  cout << "Pass" << endl;
+}


### PR DESCRIPTION
Add device libraries for C math and complex functions based on SYCL compiler's device library infrastructure. Fallback implementation for math and complex functions are also provided. The fallback implementation for C math functions are based on _spirv_ocl* math built-ins and the fallback implementation for C99 complex functions are based on algorithm used in libc++ std::complex. All functions supported are listed in sycl/doc/extensions/C-CXX-StandardLibrary/C-CXX-StandardLibrary.rst.