### PR TITLE
Revert "[SYCL][NFC] Remove SYCL specific TargetInfo types"

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -564,10 +564,19 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
   case llvm::Triple::spir: {
     if (Triple.getEnvironment() == llvm::Triple::SYCLDevice) {
       llvm::Triple HT(Opts.HostTriple);
-      if (HT.getOS() == llvm::Triple::Win32) {
-        assert(HT.getArch() == llvm::Triple::x86 &&
-               "Unsupported host architecture");
-        return new MicrosoftX86_32SPIRTargetInfo(Triple, Opts);
+      switch (HT.getOS()) {
+      case llvm::Triple::Win32:
+        switch (HT.getEnvironment()) {
+        default: // Assume MSVC for unknown environments
+        case llvm::Triple::MSVC:
+          assert(HT.getArch() == llvm::Triple::x86 &&
+                 "Unsupported host architecture");
+          return new MicrosoftX86_32SPIRTargetInfo(Triple, Opts);
+        }
+      case llvm::Triple::Linux:
+        return new LinuxTargetInfo<SPIR32SYCLDeviceTargetInfo>(Triple, Opts);
+      default:
+        return new SPIR32SYCLDeviceTargetInfo(Triple, Opts);
       }
     }
     return new SPIR32TargetInfo(Triple, Opts);
@@ -576,10 +585,19 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
   case llvm::Triple::spir64: {
     if (Triple.getEnvironment() == llvm::Triple::SYCLDevice) {
       llvm::Triple HT(Opts.HostTriple);
-      if (HT.getOS() == llvm::Triple::Win32) {
-        assert(HT.getArch() == llvm::Triple::x86_64 &&
-               "Unsupported host architecture");
-        return new MicrosoftX86_64_SPIR64TargetInfo(Triple, Opts);
+      switch (HT.getOS()) {
+      case llvm::Triple::Win32:
+        switch (HT.getEnvironment()) {
+        default: // Assume MSVC for unknown environments
+        case llvm::Triple::MSVC:
+          assert(HT.getArch() == llvm::Triple::x86_64 &&
+                 "Unsupported host architecture");
+          return new MicrosoftX86_64_SPIR64TargetInfo(Triple, Opts);
+        }
+      case llvm::Triple::Linux:
+        return new LinuxTargetInfo<SPIR64SYCLDeviceTargetInfo>(Triple, Opts);
+      default:
+        return new SPIR64SYCLDeviceTargetInfo(Triple, Opts);
       }
     }
     return new SPIR64TargetInfo(Triple, Opts);

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -153,12 +153,40 @@ public:
                         MacroBuilder &Builder) const override;
 };
 
+class LLVM_LIBRARY_VISIBILITY SPIR32SYCLDeviceTargetInfo
+    : public SPIR32TargetInfo {
+public:
+  SPIR32SYCLDeviceTargetInfo(const llvm::Triple &Triple,
+                             const TargetOptions &Opts)
+      : SPIR32TargetInfo(Triple, Opts) {
+    // This is workaround for exception_ptr class.
+    // Exceptions is not allowed in sycl device code but we should be able
+    // to parse host code. So we allow compilation of exception_ptr but
+    // if exceptions are used in device code we should emit a diagnostic.
+    MaxAtomicInlineWidth = 32;
+  }
+};
+
+class LLVM_LIBRARY_VISIBILITY SPIR64SYCLDeviceTargetInfo
+    : public SPIR64TargetInfo {
+public:
+  SPIR64SYCLDeviceTargetInfo(const llvm::Triple &Triple,
+                             const TargetOptions &Opts)
+      : SPIR64TargetInfo(Triple, Opts) {
+    // This is workaround for exception_ptr class.
+    // Exceptions is not allowed in sycl device code but we should be able
+    // to parse host code. So we allow compilation of exception_ptr but
+    // if exceptions are used in device code we should emit a diagnostic.
+    MaxAtomicInlineWidth = 64;
+  }
+};
+
 // x86-32 SPIR Windows target
 class LLVM_LIBRARY_VISIBILITY WindowsX86_32SPIRTargetInfo
-    : public WindowsTargetInfo<SPIR32TargetInfo> {
+    : public WindowsTargetInfo<SPIR32SYCLDeviceTargetInfo> {
 public:
   WindowsX86_32SPIRTargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
-      : WindowsTargetInfo<SPIR32TargetInfo>(Triple, Opts) {
+      : WindowsTargetInfo<SPIR32SYCLDeviceTargetInfo>(Triple, Opts) {
     DoubleAlign = LongLongAlign = 64;
     WCharType = UnsignedShort;
   }
@@ -201,10 +229,10 @@ public:
 
 // x86-64 SPIR64 Windows target
 class LLVM_LIBRARY_VISIBILITY WindowsX86_64_SPIR64TargetInfo
-    : public WindowsTargetInfo<SPIR64TargetInfo> {
+    : public WindowsTargetInfo<SPIR64SYCLDeviceTargetInfo> {
 public:
   WindowsX86_64_SPIR64TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
-      : WindowsTargetInfo<SPIR64TargetInfo>(Triple, Opts) {
+      : WindowsTargetInfo<SPIR64SYCLDeviceTargetInfo>(Triple, Opts) {
     LongWidth = LongAlign = 32;
     DoubleAlign = LongLongAlign = 64;
     IntMaxType = SignedLongLong;


### PR DESCRIPTION
Reverts intel/llvm#965

This patch effectively breaks Ubuntu 16 or any other system which has GCC < 7.1.

Before GCC 7.1, `exception_ptr` was only available if `ATOMIC_INT_LOCK_FREE > 1` (see [this commit](https://github.com/gcc-mirror/gcc/commit/c45be7f1aef92f2ea7363cbc4627f943b83ca902)), which doesn't seem to be true for `SPIR*TargetInfo`.

