### PR TITLE
[SYCL] Fix event usage in interop memory object constructors

### DIFF
--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -89,6 +89,10 @@ void *MemoryManager::allocateInteropMemObject(
   // Return cl_mem as is if contexts match.
   if (TargetContext == InteropContext) {
     OutEventToWait = InteropEvent->getHandleRef();
+    // Retain the event since it will be released during alloca command
+    // destruction
+    if (nullptr != OutEventToWait)
+      PI_CALL(piEventRetain)(OutEventToWait);
     return UserPtr;
   }
   // Allocate new cl_mem and initialize from user provided one.


### PR DESCRIPTION
Retain the event passed to the buffer/image interoperability
constructors: this event is stored in the corresponding allocation
command and is released once the command is destroyed.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>