### PR TITLE
[SYCL][Test] Clang tests clean up

### DIFF
--- a/clang/test/CodeGenSYCL/address-space-cond-op.cpp
+++ b/clang/test/CodeGenSYCL/address-space-cond-op.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: [[STYPE:%.+]] = type { i16 }
 struct S {

--- a/clang/test/CodeGenSYCL/address-space-cond-op.cpp
+++ b/clang/test/CodeGenSYCL/address-space-cond-op.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: [[STYPE:%.+]] = type { i16 }
 struct S {

--- a/clang/test/CodeGenSYCL/address-space-cond-op.cpp
+++ b/clang/test/CodeGenSYCL/address-space-cond-op.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: [[STYPE:%.+]] = type { i16 }
 struct S {

--- a/clang/test/CodeGenSYCL/address-space-new.cpp
+++ b/clang/test/CodeGenSYCL/address-space-new.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -std=c++11 -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
 
 struct SpaceWaster {
   int i, j;

--- a/clang/test/CodeGenSYCL/address-space-new.cpp
+++ b/clang/test/CodeGenSYCL/address-space-new.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 struct SpaceWaster {
   int i, j;

--- a/clang/test/CodeGenSYCL/address-space-new.cpp
+++ b/clang/test/CodeGenSYCL/address-space-new.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 struct SpaceWaster {
   int i, j;

--- a/clang/test/CodeGenSYCL/address-space-new.cpp
+++ b/clang/test/CodeGenSYCL/address-space-new.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 struct SpaceWaster {
   int i, j;

--- a/clang/test/CodeGenSYCL/address-space-of-returns.cpp
+++ b/clang/test/CodeGenSYCL/address-space-of-returns.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 struct A {
   int B[42];

--- a/clang/test/CodeGenSYCL/address-space-of-returns.cpp
+++ b/clang/test/CodeGenSYCL/address-space-of-returns.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 
 struct A {
   int B[42];

--- a/clang/test/CodeGenSYCL/address-space-of-returns.cpp
+++ b/clang/test/CodeGenSYCL/address-space-of-returns.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 struct A {
   int B[42];

--- a/clang/test/CodeGenSYCL/address-space-of-returns.cpp
+++ b/clang/test/CodeGenSYCL/address-space-of-returns.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
 struct A {
   int B[42];

--- a/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 void bar(int & Data) {}
 // CHECK-DAG: define spir_func void @[[RAW_REF:[a-zA-Z0-9_]+]](i32 addrspace(4)* dereferenceable(4) %
 void bar2(int & Data) {}

--- a/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -std=c++11 -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
 void bar(int & Data) {}
 // CHECK-DAG: define spir_func void @[[RAW_REF:[a-zA-Z0-9_]+]](i32 addrspace(4)* dereferenceable(4) %
 void bar2(int & Data) {}

--- a/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 void bar(int & Data) {}
 // CHECK-DAG: define spir_func void @[[RAW_REF:[a-zA-Z0-9_]+]](i32 addrspace(4)* dereferenceable(4) %
 void bar2(int & Data) {}

--- a/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 void bar(int & Data) {}
 // CHECK-DAG: define spir_func void @[[RAW_REF:[a-zA-Z0-9_]+]](i32 addrspace(4)* dereferenceable(4) %
 void bar2(int & Data) {}

--- a/clang/test/CodeGenSYCL/address-space-swap.cpp
+++ b/clang/test/CodeGenSYCL/address-space-swap.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -fsycl-device-only -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang -fsycl-device-only -S -emit-llvm %s -o - | FileCheck %s
 #include <algorithm>
 
 

--- a/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 // This test checks that compiler generates correct kernel wrapper for basic
 // case.

--- a/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 
 // This test checks that compiler generates correct kernel wrapper for basic
 // case.

--- a/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 // This test checks that compiler generates correct kernel wrapper for basic
 // case.

--- a/clang/test/CodeGenSYCL/bool-vectors.cpp
+++ b/clang/test/CodeGenSYCL/bool-vectors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/bool-vectors.cpp
+++ b/clang/test/CodeGenSYCL/bool-vectors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -std=c++11 -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/bool-vectors.cpp
+++ b/clang/test/CodeGenSYCL/bool-vectors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/bool-vectors.cpp
+++ b/clang/test/CodeGenSYCL/bool-vectors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/const-wg-init.cpp
+++ b/clang/test/CodeGenSYCL/const-wg-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
 #include "sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/const-wg-init.cpp
+++ b/clang/test/CodeGenSYCL/const-wg-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 
 #include "sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/const-wg-init.cpp
+++ b/clang/test/CodeGenSYCL/const-wg-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 #include "sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/const-wg-init.cpp
+++ b/clang/test/CodeGenSYCL/const-wg-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 #include "sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/device-functions.cpp
+++ b/clang/test/CodeGenSYCL/device-functions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename T>
 T bar(T arg);

--- a/clang/test/CodeGenSYCL/device-functions.cpp
+++ b/clang/test/CodeGenSYCL/device-functions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
 template <typename T>
 T bar(T arg);

--- a/clang/test/CodeGenSYCL/device-functions.cpp
+++ b/clang/test/CodeGenSYCL/device-functions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename T>
 T bar(T arg);

--- a/clang/test/CodeGenSYCL/device-functions.cpp
+++ b/clang/test/CodeGenSYCL/device-functions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 
 template <typename T>
 T bar(T arg);

--- a/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 void helper() {}
 

--- a/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
 void helper() {}
 

--- a/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 
 void helper() {}
 

--- a/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 void helper() {}
 

--- a/clang/test/CodeGenSYCL/device-variables.cpp
+++ b/clang/test/CodeGenSYCL/device-variables.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 enum class test_type { value1, value2, value3 };
 

--- a/clang/test/CodeGenSYCL/device-variables.cpp
+++ b/clang/test/CodeGenSYCL/device-variables.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 
 enum class test_type { value1, value2, value3 };
 

--- a/clang/test/CodeGenSYCL/device-variables.cpp
+++ b/clang/test/CodeGenSYCL/device-variables.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -I %S/Inputs -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 enum class test_type { value1, value2, value3 };
 

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -std=c++11 -fsycl-is-device -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -emit-llvm -x c++ %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -std=c++11 -fsycl-is-device -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice  -fsycl-is-device -emit-llvm -x c++ %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/fpga_pipes.cpp
+++ b/clang/test/CodeGenSYCL/fpga_pipes.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang %s -S -emit-llvm -fsycl-device-only -o - | FileCheck %s
+// RUN: %clang_cc1 %s -emit-llvm -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -o - | FileCheck %s
 // CHECK: %opencl.pipe_wo_t
 // CHECK: %opencl.pipe_ro_t
 

--- a/clang/test/CodeGenSYCL/fpga_pipes.cpp
+++ b/clang/test/CodeGenSYCL/fpga_pipes.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -emit-llvm -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -o - | FileCheck %s
+// RUN: %clang_cc1 %s -emit-llvm -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -o - | FileCheck %s
 // CHECK: %opencl.pipe_wo_t
 // CHECK: %opencl.pipe_ro_t
 

--- a/clang/test/CodeGenSYCL/image_accessor.cpp
+++ b/clang/test/CodeGenSYCL/image_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs  -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o %t.ll
 // RUN: FileCheck < %t.ll --enable-var-scope %s --check-prefix=CHECK-1DRO
 // RUN: FileCheck < %t.ll --enable-var-scope %s --check-prefix=CHECK-2DRO
 // RUN: FileCheck < %t.ll --enable-var-scope %s --check-prefix=CHECK-3DRO

--- a/clang/test/CodeGenSYCL/image_accessor.cpp
+++ b/clang/test/CodeGenSYCL/image_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o %t.ll
 // RUN: FileCheck < %t.ll --enable-var-scope %s --check-prefix=CHECK-1DRO
 // RUN: FileCheck < %t.ll --enable-var-scope %s --check-prefix=CHECK-2DRO
 // RUN: FileCheck < %t.ll --enable-var-scope %s --check-prefix=CHECK-3DRO

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // Array-specific ivdep - annotate the correspondent GEPs only
 //

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // Array-specific ivdep - annotate the correspondent GEPs only
 //

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // Array-specific ivdep - annotate the correspondent GEPs only
 //

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // Accesses from the inner loop only, various global safelens for the outer and the inner loops.
 //

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // Accesses from the inner loop only, various global safelens for the outer and the inner loops.
 //

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // Accesses from the inner loop only, various global safelens for the outer and the inner loops.
 //

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // Global ivdep - annotate all GEPs
 //

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // Global ivdep - annotate all GEPs
 //

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // Global ivdep - annotate all GEPs
 //

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-unknown-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-DEVICE,CHECK-BOTH
-// RUN: %clang_cc1 -x c++ -triple x86_64-unknown-linux-gnu -std=c++11 -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-HOST,CHECK-BOTH
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-DEVICE,CHECK-BOTH
+// RUN: %clang_cc1 -x c++ -triple x86_64-unknown-linux-gnu -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-HOST,CHECK-BOTH
 
 // CHECK-DEVICE: [[ANN1:@.str]] = {{.*}}{memory:DEFAULT}{sizeinfo:4}{numbanks:4}
 // CHECK-DEVICE: [[ANN2:@.str.[0-9]*]] = {{.*}}{register:1}

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-DEVICE,CHECK-BOTH
-// RUN: %clang_cc1 -x c++ -triple x86_64-unknown-linux-gnu -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-HOST,CHECK-BOTH
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-DEVICE,CHECK-BOTH
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-HOST,CHECK-BOTH
 
 // CHECK-DEVICE: [[ANN1:@.str]] = {{.*}}{memory:DEFAULT}{sizeinfo:4}{numbanks:4}
 // CHECK-DEVICE: [[ANN2:@.str.[0-9]*]] = {{.*}}{register:1}

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: br label %for.cond, !llvm.loop ![[MD_A:[0-9]+]]
 // CHECK: br label %for.cond, !llvm.loop ![[MD_B:[0-9]+]]

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: br label %for.cond, !llvm.loop ![[MD_A:[0-9]+]]
 // CHECK: br label %for.cond, !llvm.loop ![[MD_B:[0-9]+]]

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: br label %for.cond, !llvm.loop ![[MD_A:[0-9]+]]
 // CHECK: br label %for.cond, !llvm.loop ![[MD_B:[0-9]+]]

--- a/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 struct st {
   int a;

--- a/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 struct st {
   int a;

--- a/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
 struct st {
   int a;

--- a/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 
 struct st {
   int a;

--- a/clang/test/CodeGenSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/CodeGenSYCL/intel-max-global-work-dim.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Foo {
 public:

--- a/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Foo {
 public:

--- a/clang/test/CodeGenSYCL/intel-restrict.cpp
+++ b/clang/test/CodeGenSYCL/intel-restrict.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang %s -S -emit-llvm -fsycl-device-only -o - | FileCheck %s
+// RUN: %clang_cc1 %s -emit-llvm -triple spir64-unknown-linux-sycldevice -fsycl-is-device -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
@@ -11,7 +11,7 @@ int main() {
   int *c;
   kernel<class kernel_restrict>(
       [a,b,c]() [[intel::kernel_args_restrict]] { c[0] = a[0] + b[0];});
-// CHECK: define {{.*}} spir_kernel {{.*}}kernel_restrict{{.*}}(i32 addrspace(1)* noalias %{{.*}} i32 addrspace(1)* noalias %{{.*}}, i32 addrspace(1)* noalias %{{.*}})
+// CHECK: define spir_kernel {{.*}}kernel_restrict(i32 addrspace(1)* noalias %{{.*}}, i32 addrspace(1)* noalias %{{.*}}, i32 addrspace(1)* noalias %{{.*}})
 
   int *d;
   int *e;
@@ -19,10 +19,10 @@ int main() {
 
   kernel<class kernel_norestrict>(
       [d,e,f]() { f[0] = d[0] + e[0];});
-// CHECK: define {{.*}} spir_kernel {{.*}}kernel_norestrict{{.*}}(i32 addrspace(1)* %{{.*}} i32 addrspace(1)* %{{.*}}, i32 addrspace(1)* %{{.*}})
+// CHECK: define spir_kernel {{.*}}kernel_norestrict(i32 addrspace(1)* %{{.*}}, i32 addrspace(1)* %{{.*}}, i32 addrspace(1)* %{{.*}})
 
   int g = 42;
   kernel<class kernel_restrict_other_types>(
       [a,b,c,g]() [[intel::kernel_args_restrict]] { c[0] = a[0] + b[0] + g;});
-// CHECK: define {{.*}} spir_kernel {{.*}}kernel_restrict_other_types{{.*}}(i32 addrspace(1)* noalias %{{.*}} i32 addrspace(1)* noalias %{{.*}}, i32 addrspace(1)* noalias %{{.*}}, i32 %{{.*}})
+// CHECK: define spir_kernel {{.*}}kernel_restrict_other_types(i32 addrspace(1)* noalias %{{.*}}, i32 addrspace(1)* noalias %{{.*}}, i32 addrspace(1)* noalias %{{.*}}, i32 %{{.*}})
 }

--- a/clang/test/CodeGenSYCL/intel-restrict.cpp
+++ b/clang/test/CodeGenSYCL/intel-restrict.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -emit-llvm -triple spir64-unknown-linux-sycldevice -fsycl-is-device -o - | FileCheck %s
+// RUN: %clang_cc1 %s -emit-llvm -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/kernel-metadata.cpp
+++ b/clang/test/CodeGenSYCL/kernel-metadata.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE15kernel_function() {{[^{]+}} !kernel_arg_addr_space ![[MD:[0-9]+]] !kernel_arg_access_qual ![[MD]] !kernel_arg_type ![[MD]] !kernel_arg_base_type ![[MD]] !kernel_arg_type_qual ![[MD]]
 // CHECK: ![[MD]] = !{}

--- a/clang/test/CodeGenSYCL/kernel-metadata.cpp
+++ b/clang/test/CodeGenSYCL/kernel-metadata.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE15kernel_function() {{[^{]+}} !kernel_arg_addr_space ![[MD:[0-9]+]] !kernel_arg_access_qual ![[MD]] !kernel_arg_type ![[MD]] !kernel_arg_base_type ![[MD]] !kernel_arg_type_qual ![[MD]]
 // CHECK: ![[MD]] = !{}

--- a/clang/test/CodeGenSYCL/kernel-metadata.cpp
+++ b/clang/test/CodeGenSYCL/kernel-metadata.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -S -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE15kernel_function() {{[^{]+}} !kernel_arg_addr_space ![[MD:[0-9]+]] !kernel_arg_access_qual ![[MD]] !kernel_arg_type ![[MD]] !kernel_arg_base_type ![[MD]] !kernel_arg_type_qual ![[MD]]
 // CHECK: ![[MD]] = !{}

--- a/clang/test/CodeGenSYCL/kernel-metadata.cpp
+++ b/clang/test/CodeGenSYCL/kernel-metadata.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
 // CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE15kernel_function() {{[^{]+}} !kernel_arg_addr_space ![[MD:[0-9]+]] !kernel_arg_access_qual ![[MD]] !kernel_arg_type ![[MD]] !kernel_arg_base_type ![[MD]] !kernel_arg_type_qual ![[MD]]
 // CHECK: ![[MD]] = !{}

--- a/clang/test/CodeGenSYCL/kernel_functor.cpp
+++ b/clang/test/CodeGenSYCL/kernel_functor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -I %S/Inputs -std=c++11 -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o %t.spv
+// RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o %t.spv
 // RUN: FileCheck %s --input-file=%t.h
 
 // Checks that functors are supported as SYCL kernels.

--- a/clang/test/CodeGenSYCL/loop_unroll.cpp
+++ b/clang/test/CodeGenSYCL/loop_unroll.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -std=c++11 -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: br label %for.cond, !llvm.loop ![[COUNT:[0-9]+]]
 // CHECK: br label %while.cond, !llvm.loop ![[DISABLE:[0-9]+]]

--- a/clang/test/CodeGenSYCL/loop_unroll.cpp
+++ b/clang/test/CodeGenSYCL/loop_unroll.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: br label %for.cond, !llvm.loop ![[COUNT:[0-9]+]]
 // CHECK: br label %while.cond, !llvm.loop ![[DISABLE:[0-9]+]]

--- a/clang/test/CodeGenSYCL/loop_unroll.cpp
+++ b/clang/test/CodeGenSYCL/loop_unroll.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: br label %for.cond, !llvm.loop ![[COUNT:[0-9]+]]
 // CHECK: br label %while.cond, !llvm.loop ![[DISABLE:[0-9]+]]

--- a/clang/test/CodeGenSYCL/loop_unroll_host.cpp
+++ b/clang/test/CodeGenSYCL/loop_unroll_host.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -c -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -emit-llvm %s -o - | FileCheck %s
 // CHECK: br label %{{.*}}, !llvm.loop ![[COUNT:[0-9]+]]
 // CHECK: br label %{{.*}}, !llvm.loop ![[DISABLE:[0-9]+]]
 // CHECK: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}, !llvm.loop ![[ENABLE:[0-9]+]]

--- a/clang/test/CodeGenSYCL/module-id.cpp
+++ b/clang/test/CodeGenSYCL/module-id.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/module-id.cpp
+++ b/clang/test/CodeGenSYCL/module-id.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/module-id.cpp
+++ b/clang/test/CodeGenSYCL/module-id.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/module-id.cpp
+++ b/clang/test/CodeGenSYCL/module-id.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/noexcept.cpp
+++ b/clang/test/CodeGenSYCL/noexcept.cpp
@@ -1,13 +1,13 @@
 // RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I%S -fsycl-is-device \
-// RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
+// RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes \
 // RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-DEVICE
 //
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -I%S \
-// RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
+// RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes \
 // RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-HOST-LIN
 //
 // RUN: %clang_cc1 -triple x86_64-pc-windows-msvc -I%S \
-// RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
+// RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes \
 // RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-HOST-WIN
 
 // The test checks that exception handling code is generated only for host and not for device.

--- a/clang/test/CodeGenSYCL/noexcept.cpp
+++ b/clang/test/CodeGenSYCL/noexcept.cpp
@@ -1,12 +1,12 @@
 // RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I%S -fsycl-is-device \
-// RUN:      -std=c++11 -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
+// RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
 // RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-DEVICE
 //
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -I%S -std=c++11 \
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -I%S \
 // RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
 // RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-HOST-LIN
 //
-// RUN: %clang_cc1 -triple x86_64-pc-windows-msvc -I%S -std=c++11 \
+// RUN: %clang_cc1 -triple x86_64-pc-windows-msvc -I%S \
 // RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes -x c++ \
 // RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-HOST-WIN
 

--- a/clang/test/CodeGenSYCL/noexcept.cpp
+++ b/clang/test/CodeGenSYCL/noexcept.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I%S -fsycl-is-device \
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -I%S -fsycl-is-device \
 // RUN:      -fcxx-exceptions -fexceptions -disable-llvm-passes \
 // RUN:      -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-DEVICE
 //

--- a/clang/test/CodeGenSYCL/num-simd-work-items.cpp
+++ b/clang/test/CodeGenSYCL/num-simd-work-items.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Foo {
 public:

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -disable-llvm-passes -triple spir64 -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Functor16 {
 public:

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -disable-llvm-passes -triple spir64 -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -disable-llvm-passes -triple spir64 -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Functor16 {
 public:

--- a/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Functor32x16x16 {
 public:

--- a/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Functor32x16x16 {
 public:

--- a/clang/test/CodeGenSYCL/sampler.cpp
+++ b/clang/test/CodeGenSYCL/sampler.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck --enable-var-scope %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck --enable-var-scope %s
 // CHECK: define spir_kernel void @{{[a-zA-Z0-9_]+}}(%opencl.sampler_t addrspace(2)* [[SAMPLER_ARG:%[a-zA-Z0-9_]+]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[SAMPLER_ARG]].addr = alloca %opencl.sampler_t addrspace(2)*, align 8

--- a/clang/test/CodeGenSYCL/sampler.cpp
+++ b/clang/test/CodeGenSYCL/sampler.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -I %S/Inputs  -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck --enable-var-scope %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs  -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck --enable-var-scope %s
 // CHECK: define spir_kernel void @{{[a-zA-Z0-9_]+}}(%opencl.sampler_t addrspace(2)* [[SAMPLER_ARG:%[a-zA-Z0-9_]+]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[SAMPLER_ARG]].addr = alloca %opencl.sampler_t addrspace(2)*, align 8

--- a/clang/test/CodeGenSYCL/sampler.cpp
+++ b/clang/test/CodeGenSYCL/sampler.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs  -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck --enable-var-scope %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck --enable-var-scope %s
 // CHECK: define spir_kernel void @{{[a-zA-Z0-9_]+}}(%opencl.sampler_t addrspace(2)* [[SAMPLER_ARG:%[a-zA-Z0-9_]+]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[SAMPLER_ARG]].addr = alloca %opencl.sampler_t addrspace(2)*, align 8

--- a/clang/test/CodeGenSYCL/sampler.cpp
+++ b/clang/test/CodeGenSYCL/sampler.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs  -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck --enable-var-scope %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs  -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck --enable-var-scope %s
 // CHECK: define spir_kernel void @{{[a-zA-Z0-9_]+}}(%opencl.sampler_t addrspace(2)* [[SAMPLER_ARG:%[a-zA-Z0-9_]+]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[SAMPLER_ARG]].addr = alloca %opencl.sampler_t addrspace(2)*, align 8

--- a/clang/test/CodeGenSYCL/spir-calling-conv.cpp
+++ b/clang/test/CodeGenSYCL/spir-calling-conv.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/spir-calling-conv.cpp
+++ b/clang/test/CodeGenSYCL/spir-calling-conv.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/spir-calling-conv.cpp
+++ b/clang/test/CodeGenSYCL/spir-calling-conv.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/spir-calling-conv.cpp
+++ b/clang/test/CodeGenSYCL/spir-calling-conv.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/spir-enum.cpp
+++ b/clang/test/CodeGenSYCL/spir-enum.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device  -disable-llvm-optzns -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/spir-opencl-version.cpp
+++ b/clang/test/CodeGenSYCL/spir-opencl-version.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/spir-opencl-version.cpp
+++ b/clang/test/CodeGenSYCL/spir-opencl-version.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -S -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/spir-opencl-version.cpp
+++ b/clang/test/CodeGenSYCL/spir-opencl-version.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/spir-opencl-version.cpp
+++ b/clang/test/CodeGenSYCL/spir-opencl-version.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {

--- a/clang/test/CodeGenSYCL/sycl-device.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
 // Test code generation for sycl_device attribute.
 
 int bar(int b);

--- a/clang/test/CodeGenSYCL/sycl-device.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 // Test code generation for sycl_device attribute.
 
 int bar(int b);

--- a/clang/test/CodeGenSYCL/sycl-device.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 // Test code generation for sycl_device attribute.
 
 int bar(int b);

--- a/clang/test/CodeGenSYCL/sycl-device.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -S -emit-llvm %s -o - | FileCheck %s
 // Test code generation for sycl_device attribute.
 
 int bar(int b);

--- a/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
+++ b/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
 
 class Functor {
 public:

--- a/clang/test/CodeGenSYCL/unique-stable-name.cpp
+++ b/clang/test/CodeGenSYCL/unique-stable-name.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 // CHECK: @[[INT:[^\w]+]] = private unnamed_addr constant [[INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
 // CHECK: @[[LAMBDA_X:[^\w]+]] = private unnamed_addr constant [[LAMBDA_X_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE42->5clEvEUlvE46->16\00"
 // CHECK: @[[MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE42->5clEvEUlvE52->7~28->18\00"

--- a/clang/test/CodeGenSYCL/unique-stable-name.cpp
+++ b/clang/test/CodeGenSYCL/unique-stable-name.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -x c++ -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 // CHECK: @[[INT:[^\w]+]] = private unnamed_addr constant [[INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
 // CHECK: @[[LAMBDA_X:[^\w]+]] = private unnamed_addr constant [[LAMBDA_X_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE42->5clEvEUlvE46->16\00"
 // CHECK: @[[MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE42->5clEvEUlvE52->7~28->18\00"

--- a/clang/test/CodeGenSYCL/usm-int-header.cpp
+++ b/clang/test/CodeGenSYCL/usm-int-header.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -I %S/Inputs -fsycl-is-device -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl-is-device -ast-dump %s | FileCheck %s
 // RUN: %clang -I %S/Inputs -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
 // RUN: FileCheck -input-file=%t.h %s --check-prefix=INT-HEADER
 

--- a/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -cc1 -fsycl-is-device -verify -fsyntax-only -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -x c++ %s
 
 void bar(int & Data) {}
 void bar2(int & Data) {}

--- a/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s
 
 void bar(int & Data) {}
 void bar2(int & Data) {}

--- a/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -I %S/Inputs -fsycl-is-device -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl-is-device -ast-dump %s | FileCheck %s
 
 // This test checks that compiler generates correct kernel wrapper for basic
 // case.

--- a/clang/test/SemaSYCL/forward-decl.cpp
+++ b/clang/test/SemaSYCL/forward-decl.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -fsycl-is-device -std=c++11 -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -x c++ -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 // expected-no-diagnostics
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/forward-decl.cpp
+++ b/clang/test/SemaSYCL/forward-decl.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -fsycl-is-device -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 // expected-no-diagnostics
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/fpga_pipes.cpp
+++ b/clang/test/SemaSYCL/fpga_pipes.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -fsycl-is-device -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 // no error expected
 using type1 = __attribute__((pipe("read_only"))) const int;

--- a/clang/test/SemaSYCL/fpga_pipes.cpp
+++ b/clang/test/SemaSYCL/fpga_pipes.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -fsycl-is-device -std=c++11 -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -x c++ -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 // no error expected
 using type1 = __attribute__((pipe("read_only"))) const int;

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -Wno-return-type -fsycl-is-device -std=c++11 -fcxx-exceptions -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+// RUN: %clang_cc1 -x c++ -Wno-return-type -fsycl-is-device -fcxx-exceptions -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
 
 //CHECK: FunctionDecl{{.*}}foo1
 void foo1()

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -Wno-return-type -fsycl-is-device -fcxx-exceptions -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+// RUN: %clang_cc1 -Wno-return-type -fsycl-is-device -fcxx-exceptions -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
 
 //CHECK: FunctionDecl{{.*}}foo1
 void foo1()

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -fsycl-is-device -std=c++11 -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -x c++ -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 // Test for Intel FPGA loop attributes applied not to a loop
 void foo() {

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -fsycl-is-device -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 // Test for Intel FPGA loop attributes applied not to a loop
 void foo() {

--- a/clang/test/SemaSYCL/intel-fpga-reg.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-reg.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -pedantic -fsyntax-only -x c++ %s
-// RUN: %clang_cc1 -verify -pedantic -fsyntax-only -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -pedantic -fsyntax-only %s
+// RUN: %clang_cc1 -verify -pedantic -fsyntax-only %s
 
 class A {
 public:

--- a/clang/test/SemaSYCL/kernel-attribute-on-non-sycl.cpp
+++ b/clang/test/SemaSYCL/kernel-attribute-on-non-sycl.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -std=c++11 -fsyntax-only -fsycl-is-device -verify %s
-// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify -x c++ %s
+// RUN: %clang_cc1 -fsyntax-only -fsycl-is-device -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify -x c++ %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 // expected-warning@+7 {{'sycl_kernel' attribute ignored}}

--- a/clang/test/SemaSYCL/kernel-attribute-on-non-sycl.cpp
+++ b/clang/test/SemaSYCL/kernel-attribute-on-non-sycl.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -fsycl-is-device -verify %s
-// RUN: %clang_cc1 -fsyntax-only -verify -x c++ %s
+// RUN: %clang_cc1 -fsyntax-only -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 // expected-warning@+7 {{'sycl_kernel' attribute ignored}}

--- a/clang/test/SemaSYCL/kernel-attribute.cpp
+++ b/clang/test/SemaSYCL/kernel-attribute.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -fsyntax-only -fsycl-is-device -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fsycl-is-device -verify %s
 
 // Only function templates
 [[clang::sycl_kernel]] int gv2 = 0; // expected-warning {{'sycl_kernel' attribute only applies to function templates}}

--- a/clang/test/SemaSYCL/keyword.cpp
+++ b/clang/test/SemaSYCL/keyword.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -verify -fsyntax-only -std=c++11 %s
+// RUN: %clang_cc1 -verify -fsyntax-only %s
 //
 // expected-no-diagnostics 
 int foo(bool __pipe);

--- a/clang/test/SemaSYCL/loop_unroll.cpp
+++ b/clang/test/SemaSYCL/loop_unroll.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -fsycl-is-device -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 void foo() {
   // expected-error@+1 {{clang loop attributes must be applied to for, while, or do statements}}

--- a/clang/test/SemaSYCL/loop_unroll.cpp
+++ b/clang/test/SemaSYCL/loop_unroll.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x c++ -fsycl-is-device -std=c++11 -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -x c++ -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 void foo() {
   // expected-error@+1 {{clang loop attributes must be applied to for, while, or do statements}}

--- a/clang/test/SemaSYCL/mangle-unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/mangle-unnamed-kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -I %S/Inputs -fsycl-is-device -fsycl-unnamed-lambda -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -I %S/Inputs -fsycl-is-device -fsycl-unnamed-lambda -ast-dump %s | FileCheck %s
 #include <sycl.hpp>
 
 int main() {

--- a/clang/test/SemaSYCL/markfunction-astconsumer.cpp
+++ b/clang/test/SemaSYCL/markfunction-astconsumer.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -x c++ -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 void bar();
 
 template<typename T>

--- a/clang/test/SemaSYCL/no-vtables.cpp
+++ b/clang/test/SemaSYCL/no-vtables.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify -fsyntax-only -x c++ -emit-llvm-only %s
+// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify -fsyntax-only -emit-llvm-only %s
 // expected-no-diagnostics
 // Should never fail, since the type is never used in kernel code.
 

--- a/clang/test/SemaSYCL/no-vtables.cpp
+++ b/clang/test/SemaSYCL/no-vtables.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify -fsyntax-only -emit-llvm-only %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -verify -fsyntax-only -emit-llvm-only %s
 // expected-no-diagnostics
 // Should never fail, since the type is never used in kernel code.
 

--- a/clang/test/SemaSYCL/no-vtables2.cpp
+++ b/clang/test/SemaSYCL/no-vtables2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -Wno-return-type -verify -fsyntax-only -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -Wno-return-type -verify -fsyntax-only %s
 
 struct Base {
   virtual void f() const {}

--- a/clang/test/SemaSYCL/non-std-layout-param.cpp
+++ b/clang/test/SemaSYCL/non-std-layout-param.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -std=c++11 %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // non-standard layout struct object as SYCL kernel parameter.

--- a/clang/test/SemaSYCL/restrict-recursion.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -x c++ -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion2.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -x c++ -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -x c++ -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion4.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion4.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -x c++ -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
+++ b/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
@@ -3,7 +3,7 @@
 // RUN: -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s 
 // check random triple aux-triple with sycl-device
 
-// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice  -fsyntax-only \
+// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -fsyntax-only \
 // RUN: -fms-extensions -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s 
 // check without -aux-triple but sycl-device
 

--- a/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
+++ b/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fms-extensions \
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fms-extensions \
 // RUN: -aux-triple x86_64-unknown-linux-gnu -fsycl-is-device  -fsyntax-only \
 // RUN: -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s 
 // check random triple aux-triple with sycl-device

--- a/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
+++ b/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -std=c++14 -verify -fsyntax-only -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -std=c++14 -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
+++ b/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s
 
 template <typename functor_t>
 struct functor_wrapper{

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -x c++ -std=c++17 %s
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -fno-sycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -x c++ -std=c++17 %s
-// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -DALLOW_FP=1 -fsycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -x c++ -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -fno-sycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -DALLOW_FP=1 -fsycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 
 
 namespace std {

--- a/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
@@ -1,8 +1,8 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -x c++ %s
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_INVALID_DEF -x c++ %s
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_INVALID_DECL -x c++ %s
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_VALID1 -x c++ %s
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_VALID2 -x c++ %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_INVALID_DEF %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_INVALID_DECL %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_VALID1 %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -DPRINTF_VALID2 %s
 
 #if defined(PRINTF_INVALID_DECL)
 extern "C" int __spirv_ocl_printf(const char *__format, ...);


### PR DESCRIPTION
- Remove unnecessary options
- Move spir-enum.cpp from SemaSYCL to CodeGenSYCL directory
- Unify target triple for SYCL tests
