### PR TITLE
[SYCL][NFC] Fix a warning about mismatch tag in type_list declaration and definition

### DIFF
--- a/sycl/include/CL/sycl/detail/type_list.hpp
+++ b/sycl/include/CL/sycl/detail/type_list.hpp
@@ -22,7 +22,7 @@ template <typename T> using head_t = typename T::head;
 template <typename T> using tail_t = typename T::tail;
 
 // type_list
-template <typename... T> class type_list;
+template <typename... T> struct type_list;
 
 using empty_type_list = type_list<>;
 


### PR DESCRIPTION
Compiling user code with -Wall provides compilation warnings from SYCL headers.
In some cases (-Werror or smth like that is enabled) it may not allow to compile user code.