### PR TITLE
[SYCL] Add __SYCL_INLINE attribute to cl namespace in library sources

### DIFF
--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -21,7 +21,7 @@
 
 // 4.6.2 Context class
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 context::context(const async_handler &AsyncHandler)
     : context(default_selector().select_device(), AsyncHandler) {}

--- a/sycl/source/detail/accessor_impl.cpp
+++ b/sycl/source/detail/accessor_impl.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/accessor_impl.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/builtins_common.cpp
+++ b/sycl/source/detail/builtins_common.cpp
@@ -22,7 +22,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace __host_std {
 namespace {
 

--- a/sycl/source/detail/builtins_geometric.cpp
+++ b/sycl/source/detail/builtins_geometric.cpp
@@ -16,7 +16,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace __host_std {
 
 s::cl_float Dot(s::cl_float2, s::cl_float2);

--- a/sycl/source/detail/builtins_integer.cpp
+++ b/sycl/source/detail/builtins_integer.cpp
@@ -17,7 +17,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace __host_std {
 namespace {
 

--- a/sycl/source/detail/builtins_math.cpp
+++ b/sycl/source/detail/builtins_math.cpp
@@ -22,7 +22,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace __host_std {
 
 namespace {

--- a/sycl/source/detail/builtins_relational.cpp
+++ b/sycl/source/detail/builtins_relational.cpp
@@ -16,7 +16,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace __host_std {
 namespace {
 

--- a/sycl/source/detail/common.cpp
+++ b/sycl/source/detail/common.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -17,7 +17,7 @@
 #define STRINGIFY_LINE_HELP(s) #s
 #define STRINGIFY_LINE(s) STRINGIFY_LINE_HELP(s)
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -10,7 +10,7 @@
 
 #include <cstdlib>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -17,7 +17,7 @@
 #include <CL/sycl/platform.hpp>
 #include <CL/sycl/stl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/device_info.cpp
+++ b/sycl/source/detail/device_info.cpp
@@ -19,7 +19,7 @@
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/error_handling/enqueue_kernel.cpp
+++ b/sycl/source/detail/error_handling/enqueue_kernel.cpp
@@ -14,7 +14,7 @@
 
 #include <CL/sycl/detail/pi.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/error_handling/error_handling.hpp
+++ b/sycl/source/detail/error_handling/error_handling.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/detail/pi.h>
 #include <CL/sycl/detail/cg.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -13,7 +13,7 @@
 
 #include <chrono>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/force_device.cpp
+++ b/sycl/source/detail/force_device.cpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/stl.hpp>
 #include <cstdlib>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 namespace detail {

--- a/sycl/source/detail/image_accessor_util.cpp
+++ b/sycl/source/detail/image_accessor_util.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/accessor.hpp>
 #include <CL/sycl/builtins.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/image.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -15,7 +15,7 @@
 
 #include <memory>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/kernel_info.cpp
+++ b/sycl/source/detail/kernel_info.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/kernel_info.hpp>
 #include <CL/sycl/device.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 template <>

--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/detail/kernel_program_cache.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 KernelProgramCache::~KernelProgramCache() {

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -17,7 +17,7 @@
 #include <cstring>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -44,7 +44,7 @@
 
 #endif // SYCL_RT_OS
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -15,7 +15,7 @@
 #include <stddef.h>
 #include <string>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace pi {

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -15,7 +15,7 @@
 #include <cstring>
 #include <regex>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/platform_info.cpp
+++ b/sycl/source/detail/platform_info.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/detail/platform_info.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/platform_util.cpp
+++ b/sycl/source/detail/platform_util.cpp
@@ -16,7 +16,7 @@
 #include <intrin.h>
 #endif
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/posix_pi.cpp
+++ b/sycl/source/detail/posix_pi.cpp
@@ -1,3 +1,11 @@
+//==---------------- posix_pi.cpp ------------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include <CL/sycl/detail/defines.hpp>
 
 #include <dlfcn.h>

--- a/sycl/source/detail/posix_pi.cpp
+++ b/sycl/source/detail/posix_pi.cpp
@@ -1,7 +1,9 @@
+#include <CL/sycl/detail/defines.hpp>
+
 #include <dlfcn.h>
 #include <string>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace pi {

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/detail/program_impl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 template <>

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -27,7 +27,7 @@
 #include <mutex>
 #include <sstream>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -16,7 +16,7 @@
 
 #include <cstring>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 template <> cl_uint queue_impl::get_info<info::queue::reference_count>() const {

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/sampler_impl.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -32,7 +32,7 @@
 #include <memory>
 #endif
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -22,7 +22,7 @@
 #include <set>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -13,7 +13,7 @@
 #include <memory>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -16,7 +16,7 @@
 #include <set>
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/stream_impl.cpp
+++ b/sycl/source/detail/stream_impl.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/stream_impl.hpp>
 #include <cstdio>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/usm/clusm.cpp
+++ b/sycl/source/detail/usm/clusm.cpp
@@ -19,7 +19,7 @@
 
 cl::sycl::detail::usm::CLUSM *gCLUSM = nullptr;
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace usm {

--- a/sycl/source/detail/usm/usm_dispatch.cpp
+++ b/sycl/source/detail/usm/usm_dispatch.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/detail/usm_dispatch.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace usm {

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -15,7 +15,7 @@
 
 #include <cstdlib>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 using alloc = cl::sycl::usm::alloc;

--- a/sycl/source/detail/util.cpp
+++ b/sycl/source/detail/util.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/detail/util.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/windows_pi.cpp
+++ b/sycl/source/detail/windows_pi.cpp
@@ -1,8 +1,10 @@
+#include <CL/sycl/detail/defines.hpp>
+
 #include <windows.h>
 #include <winreg.h>
 #include <string>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 namespace pi {

--- a/sycl/source/detail/windows_pi.cpp
+++ b/sycl/source/detail/windows_pi.cpp
@@ -1,3 +1,11 @@
+//==---------------- windows_pi.cpp ----------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include <CL/sycl/detail/defines.hpp>
 
 #include <windows.h>

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/device_selector.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 void force_type(info::device_type &t, const info::device_type &ft) {

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/stl.hpp>
 // 4.6.1 Device selection class
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 device device_selector::select_device() const {
   vector_class<device> devices = device::get_devices();

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <unordered_set>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 event::event() : impl(std::make_shared<detail::event_impl>()) {}

--- a/sycl/source/exception.cpp
+++ b/sycl/source/exception.cpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/exception.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 const char *exception::what() const noexcept { return MMsg.c_str(); }

--- a/sycl/source/exception_list.cpp
+++ b/sycl/source/exception_list.cpp
@@ -11,7 +11,7 @@
 
 #include <utility>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 exception_list::size_type exception_list::size() const { return MList.size(); }

--- a/sycl/source/half_type.cpp
+++ b/sycl/source/half_type.cpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/detail/platform_util.hpp>
 #include <cstring>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/program.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 kernel::kernel(cl_kernel ClKernel, const context &SyclContext)

--- a/sycl/source/ordered_queue.cpp
+++ b/sycl/source/ordered_queue.cpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 ordered_queue::ordered_queue(const context &syclContext,
                              const device_selector &deviceSelector,

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/platform.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 platform::platform() : impl(std::make_shared<detail::platform_impl>()) {}

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 queue::queue(const context &syclContext, const device_selector &deviceSelector,
              const async_handler &asyncHandler, const property_list &propList) {

--- a/sycl/source/sampler.cpp
+++ b/sycl/source/sampler.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/sampler.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 sampler::sampler(coordinate_normalization_mode normalizationMode,
                  addressing_mode addressingMode, filtering_mode filteringMode)

--- a/sycl/source/stream.cpp
+++ b/sycl/source/stream.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/stream.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 stream::stream(size_t BufferSize, size_t MaxStatementSize, handler &CGH)

--- a/sycl/test/basic_tests/sycl-namespace.cpp
+++ b/sycl/test/basic_tests/sycl-namespace.cpp
@@ -1,0 +1,20 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+
+int main() {
+  ::sycl::queue q;
+  int r = 0;
+  {
+    sycl::buffer<int, 1> b(&r, 1);
+    q.submit([&](sycl::handler &h) {
+      auto a = b.get_access<sycl::access::mode::write>(h);
+      h.single_task<class T>([=]() { a[0] = 42; });
+    });
+  }
+  return r - 42;
+}


### PR DESCRIPTION
This change aligns class/functions definitions with the declarations in the headers.