### PR TITLE
[SYCL] Refactor handler to improve ABI stability

### DIFF
--- a/sycl/include/CL/sycl/event.hpp
+++ b/sycl/include/CL/sycl/event.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <memory>

--- a/sycl/include/CL/sycl/event.hpp
+++ b/sycl/include/CL/sycl/event.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/stl.hpp>
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -31,7 +31,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <memory>
 #include <type_traits>
 
 template <typename DataT, int Dimensions, cl::sycl::access::mode AccessMode,
@@ -136,29 +135,29 @@ template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {
 
 // 4.8.3 Command group handler class
 class handler {
-  std::shared_ptr<detail::queue_impl> MQueue;
+  shared_ptr_class<detail::queue_impl> MQueue;
   // The storage for the arguments passed.
   // We need to store a copy of values that are passed explicitly through
   // set_arg, require and so on, because we need them to be alive after
   // we exit the method they are passed in.
-  std::vector<std::vector<char>> MArgsStorage;
-  std::vector<detail::AccessorImplPtr> MAccStorage;
-  std::vector<detail::LocalAccessorImplPtr> MLocalAccStorage;
-  std::vector<std::shared_ptr<detail::stream_impl>> MStreamStorage;
-  std::vector<std::shared_ptr<const void>> MSharedPtrStorage;
+  vector_class<vector_class<char>> MArgsStorage;
+  vector_class<detail::AccessorImplPtr> MAccStorage;
+  vector_class<detail::LocalAccessorImplPtr> MLocalAccStorage;
+  vector_class<shared_ptr_class<detail::stream_impl>> MStreamStorage;
+  vector_class<shared_ptr_class<const void>> MSharedPtrStorage;
   // The list of arguments for the kernel.
-  std::vector<detail::ArgDesc> MArgs;
+  vector_class<detail::ArgDesc> MArgs;
   // The list of associated accessors with this handler.
   // These accessors were created with this handler as argument or
   // have become required for this handler via require method.
-  std::vector<detail::ArgDesc> MAssociatedAccesors;
+  vector_class<detail::ArgDesc> MAssociatedAccesors;
   // The list of requirements to the memory objects for the scheduling.
-  std::vector<detail::Requirement *> MRequirements;
+  vector_class<detail::Requirement *> MRequirements;
   // Struct that encodes global size, local size, ...
   detail::NDRDescT MNDRDesc;
   std::string MKernelName;
   // Storage for a sycl::kernel object.
-  std::shared_ptr<detail::kernel_impl> MSyclKernel;
+  shared_ptr_class<detail::kernel_impl> MSyclKernel;
   // Type of the command group, e.g. kernel, fill.
   detail::CG::CGTYPE MCGType = detail::CG::NONE;
   // Pointer to the source host memory or accessor(depending on command type).
@@ -168,17 +167,17 @@ class handler {
   // Length to copy or fill (for USM operations).
   size_t MLength = 0;
   // Pattern that is used to fill memory object in case command type is fill.
-  std::vector<char> MPattern;
+  vector_class<char> MPattern;
   // Storage for a lambda or function object.
   std::unique_ptr<detail::HostKernelBase> MHostKernel;
   detail::OSModuleHandle MOSModuleHandle;
   // The list of events that order this operation
-  std::vector<detail::EventImplPtr> MEvents;
+  vector_class<detail::EventImplPtr> MEvents;
 
   bool MIsHost = false;
 
 private:
-  handler(std::shared_ptr<detail::queue_impl> Queue, bool IsHost)
+  handler(shared_ptr_class<detail::queue_impl> Queue, bool IsHost)
       : MQueue(std::move(Queue)), MIsHost(IsHost) {}
 
   // Method stores copy of Arg passed to the MArgsStorage.
@@ -234,7 +233,7 @@ private:
 
   // Save streams associated with this handler. Streams are then forwarded to
   // command group and flushed in the scheduler.
-  void addStream(std::shared_ptr<detail::stream_impl> s) {
+  void addStream(shared_ptr_class<detail::stream_impl> s) {
     MStreamStorage.push_back(std::move(s));
   }
 
@@ -423,7 +422,7 @@ public:
     MEvents.push_back(std::move(detail::getSyclObjImpl(e)));
   }
 
-  void depends_on(std::vector<event> Events) {
+  void depends_on(vector_class<event> Events) {
     for (event e : Events) {
       depends_on(e);
     }

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -133,47 +133,6 @@ template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {
 /// "finalization" it constructs CG object, that represents specific operation,
 /// passing fields that are required only.
 class handler {
-  shared_ptr_class<detail::queue_impl> MQueue;
-  /// The storage for the arguments passed.
-  /// We need to store a copy of values that are passed explicitly through
-  /// set_arg, require and so on, because we need them to be alive after
-  /// we exit the method they are passed in.
-  vector_class<vector_class<char>> MArgsStorage;
-  vector_class<detail::AccessorImplPtr> MAccStorage;
-  vector_class<detail::LocalAccessorImplPtr> MLocalAccStorage;
-  vector_class<shared_ptr_class<detail::stream_impl>> MStreamStorage;
-  vector_class<shared_ptr_class<const void>> MSharedPtrStorage;
-  /// The list of arguments for the kernel.
-  vector_class<detail::ArgDesc> MArgs;
-  /// The list of associated accessors with this handler.
-  /// These accessors were created with this handler as argument or
-  /// have become required for this handler via require method.
-  vector_class<detail::ArgDesc> MAssociatedAccesors;
-  /// The list of requirements to the memory objects for the scheduling.
-  vector_class<detail::Requirement *> MRequirements;
-  /// Struct that encodes global size, local size, ...
-  detail::NDRDescT MNDRDesc;
-  string_class MKernelName;
-  /// Storage for a sycl::kernel object.
-  unique_ptr_class<kernel> MSyclKernel;
-  /// Type of the command group, e.g. kernel, fill.
-  detail::CG::CGTYPE MCGType = detail::CG::NONE;
-  /// Pointer to the source host memory or accessor(depending on command type).
-  void *MSrcPtr = nullptr;
-  /// Pointer to the dest host memory or accessor(depends on command type).
-  void *MDstPtr = nullptr;
-  /// Length to copy or fill (for USM operations).
-  size_t MLength = 0;
-  /// Pattern that is used to fill memory object in case command type is fill.
-  vector_class<char> MPattern;
-  /// Storage for a lambda or function object.
-  unique_ptr_class<detail::HostKernelBase> MHostKernel;
-  detail::OSModuleHandle MOSModuleHandle;
-  /// The list of events that order this operation.
-  vector_class<detail::EventImplPtr> MEvents;
-
-  bool MIsHost = false;
-
 private:
   /// Constructs SYCL handler from queue.
   ///
@@ -414,20 +373,6 @@ private:
   isValidTargetForExplicitOp(access::target AccessTarget) {
     return isConstOrGlobal(AccessTarget) || isImageOrImageArray(AccessTarget);
   }
-
-  // Make queue_impl class friend to be able to call finalize method.
-  friend class detail::queue_impl;
-  // Make accessor class friend to keep the list of associated accessors.
-  template <typename DataT, int Dims, access::mode AccMode,
-            access::target AccTarget, access::placeholder isPlaceholder>
-  friend class accessor;
-
-  template <typename DataT, int Dimensions, access::mode AccessMode,
-            access::target AccessTarget, access::placeholder IsPlaceholder>
-  friend class detail::image_accessor;
-  // Make stream class friend to be able to keep the list of associated streams
-  friend class stream;
-  friend class detail::stream_impl;
 
 public:
   handler(const handler &) = delete;
@@ -1170,6 +1115,62 @@ public:
     MLength = Count;
     MCGType = detail::CG::PREFETCH_USM;
   }
+
+private:
+  shared_ptr_class<detail::queue_impl> MQueue;
+  /// The storage for the arguments passed.
+  /// We need to store a copy of values that are passed explicitly through
+  /// set_arg, require and so on, because we need them to be alive after
+  /// we exit the method they are passed in.
+  vector_class<vector_class<char>> MArgsStorage;
+  vector_class<detail::AccessorImplPtr> MAccStorage;
+  vector_class<detail::LocalAccessorImplPtr> MLocalAccStorage;
+  vector_class<shared_ptr_class<detail::stream_impl>> MStreamStorage;
+  vector_class<shared_ptr_class<const void>> MSharedPtrStorage;
+  /// The list of arguments for the kernel.
+  vector_class<detail::ArgDesc> MArgs;
+  /// The list of associated accessors with this handler.
+  /// These accessors were created with this handler as argument or
+  /// have become required for this handler via require method.
+  vector_class<detail::ArgDesc> MAssociatedAccesors;
+  /// The list of requirements to the memory objects for the scheduling.
+  vector_class<detail::Requirement *> MRequirements;
+  /// Struct that encodes global size, local size, ...
+  detail::NDRDescT MNDRDesc;
+  string_class MKernelName;
+  /// Storage for a sycl::kernel object.
+  unique_ptr_class<kernel> MSyclKernel;
+  /// Type of the command group, e.g. kernel, fill.
+  detail::CG::CGTYPE MCGType = detail::CG::NONE;
+  /// Pointer to the source host memory or accessor(depending on command type).
+  void *MSrcPtr = nullptr;
+  /// Pointer to the dest host memory or accessor(depends on command type).
+  void *MDstPtr = nullptr;
+  /// Length to copy or fill (for USM operations).
+  size_t MLength = 0;
+  /// Pattern that is used to fill memory object in case command type is fill.
+  vector_class<char> MPattern;
+  /// Storage for a lambda or function object.
+  unique_ptr_class<detail::HostKernelBase> MHostKernel;
+  detail::OSModuleHandle MOSModuleHandle;
+  /// The list of events that order this operation.
+  vector_class<detail::EventImplPtr> MEvents;
+
+  bool MIsHost = false;
+
+  // Make queue_impl class friend to be able to call finalize method.
+  friend class detail::queue_impl;
+  // Make accessor class friend to keep the list of associated accessors.
+  template <typename DataT, int Dims, access::mode AccMode,
+            access::target AccTarget, access::placeholder isPlaceholder>
+  friend class accessor;
+
+  template <typename DataT, int Dimensions, access::mode AccessMode,
+            access::target AccessTarget, access::placeholder IsPlaceholder>
+  friend class detail::image_accessor;
+  // Make stream class friend to be able to keep the list of associated streams
+  friend class stream;
+  friend class detail::stream_impl;
 };
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -576,8 +576,10 @@ public:
 #endif
   }
 
-  // Similar to single_task, but passed lambda will be executed on host.
-  /// Invokes a function on host.
+  /// Defines and invokes a SYCL kernel on host device.
+  ///
+  /// @param Func is a SYCL kernel function defined by lambda function or a
+  /// named function object type.
   template <typename FuncT> void run_on_host_intel(FuncT Func) {
     throwIfActionIsCreated();
     MNDRDesc.set(range<1>{1});
@@ -744,9 +746,12 @@ public:
     extractArgsAndReqs();
   }
 
-  // single_task version which takes two "kernels". One is a lambda which is
-  // used if device, queue is bound to, is host device. Second is a sycl::kernel
-  // which is used otherwise.
+  /// Defines and invokes a SYCL kernel function.
+  ///
+  /// @param SyclKernel is a SYCL kernel that is executed on a SYCL device
+  /// (except for the host device).
+  /// @param KernelFunc is a lambda that is uesd if device, queue is bound to,
+  /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType>
   void single_task(kernel SyclKernel, KernelType KernelFunc) {
     throwIfActionIsCreated();

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -682,10 +682,6 @@ public:
     extractArgsAndReqs();
   }
 
-  // Note: the kernel invocation methods below are only planned to be added
-  // to the spec as of v1.2.1 rev. 3, despite already being present in SYCL
-  // conformance tests.
-
   // single_task version which takes two "kernels". One is a lambda which is
   // used if device, queue is bound to, is host device. Second is a sycl::kernel
   // which is used otherwise.

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -344,10 +344,10 @@ private:
     }
   }
 
-  // Checks whether it is possible to copy the source shape to the destination
-  // shape(the shapes are described by the accessor ranges) by using
-  // copying by regions of memory and not copying element by element
-  // Shapes can be 1, 2 or 3 dimensional rectangles.
+  /// Checks whether it is possible to copy the source shape to the destination
+  /// shape(the shapes are described by the accessor ranges) by using
+  /// copying by regions of memory and not copying element by element
+  /// Shapes can be 1, 2 or 3 dimensional rectangles.
   template <int Dims_Src, int Dims_Dst>
   static bool IsCopyingRectRegionAvailable(const range<Dims_Src> Src,
                                            const range<Dims_Dst> Dst) {

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -203,155 +203,15 @@ private:
   // integration header.
   void
   extractArgsAndReqsFromLambda(char *LambdaPtr, size_t KernelArgsNum,
-                               const detail::kernel_param_desc_t *KernelArgs) {
-    const bool IsKernelCreatedFromSource = false;
-    size_t IndexShift = 0;
-    for (size_t I = 0; I < KernelArgsNum; ++I) {
-      void *Ptr = LambdaPtr + KernelArgs[I].offset;
-      const detail::kernel_param_kind_t &Kind = KernelArgs[I].kind;
-      const int &Size = KernelArgs[I].info;
-      if (Kind == detail::kernel_param_kind_t::kind_accessor) {
-        // For args kind of accessor Size is information about accessor.
-        // The first 11 bits of Size encodes the accessor target.
-        const access::target AccTarget =
-            static_cast<access::target>(Size & 0x7ff);
-        if ((AccTarget == access::target::global_buffer ||
-             AccTarget == access::target::constant_buffer) ||
-            (AccTarget == access::target::image ||
-             AccTarget == access::target::image_array)) {
-          detail::AccessorBaseHost *AccBase =
-              static_cast<detail::AccessorBaseHost *>(Ptr);
-          Ptr = detail::getSyclObjImpl(*AccBase).get();
-        } else if (AccTarget == access::target::local) {
-          detail::LocalAccessorBaseHost *LocalAccBase =
-              static_cast<detail::LocalAccessorBaseHost *>(Ptr);
-          Ptr = detail::getSyclObjImpl(*LocalAccBase).get();
-        }
-      }
-      processArg(Ptr, Kind, Size, I, IndexShift, IsKernelCreatedFromSource);
-    }
-  }
+                               const detail::kernel_param_desc_t *KernelArgs);
 
   // The method extracts and prepares kernel arguments that were set
   // via set_arg(s)
-  void extractArgsAndReqs() {
-    assert(MSyclKernel && "MSyclKernel is not initialized");
-    std::vector<detail::ArgDesc> UnPreparedArgs = std::move(MArgs);
-    MArgs.clear();
-
-    std::sort(UnPreparedArgs.begin(), UnPreparedArgs.end(),
-              [](const detail::ArgDesc &first, const detail::ArgDesc &second)
-                  -> bool { return (first.MIndex < second.MIndex); });
-
-    const bool IsKernelCreatedFromSource = MSyclKernel->isCreatedFromSource();
-
-    size_t IndexShift = 0;
-    for (size_t I = 0; I < UnPreparedArgs.size(); ++I) {
-      void *Ptr = UnPreparedArgs[I].MPtr;
-      const detail::kernel_param_kind_t &Kind = UnPreparedArgs[I].MType;
-      const int &Size = UnPreparedArgs[I].MSize;
-      const int Index = UnPreparedArgs[I].MIndex;
-      processArg(Ptr, Kind, Size, Index, IndexShift, IsKernelCreatedFromSource);
-    }
-  }
+  void extractArgsAndReqs();
 
   void processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
                   const int Size, const size_t Index, size_t &IndexShift,
-                  bool IsKernelCreatedFromSource) {
-    const auto kind_std_layout = detail::kernel_param_kind_t::kind_std_layout;
-    const auto kind_accessor = detail::kernel_param_kind_t::kind_accessor;
-    const auto kind_sampler = detail::kernel_param_kind_t::kind_sampler;
-    const auto kind_pointer = detail::kernel_param_kind_t::kind_pointer;
-
-    switch (Kind) {
-    case kind_std_layout:
-    case kind_pointer: {
-      MArgs.emplace_back(Kind, Ptr, Size, Index + IndexShift);
-      break;
-    }
-    case kind_accessor: {
-      // For args kind of accessor Size is information about accessor.
-      // The first 11 bits of Size encodes the accessor target.
-      const access::target AccTarget =
-          static_cast<access::target>(Size & 0x7ff);
-      switch (AccTarget) {
-      case access::target::global_buffer:
-      case access::target::constant_buffer: {
-        detail::Requirement *AccImpl = static_cast<detail::Requirement *>(Ptr);
-        MArgs.emplace_back(Kind, AccImpl, Size, Index + IndexShift);
-        if (!IsKernelCreatedFromSource) {
-          // Dimensionality of the buffer is 1 when dimensionality of the
-          // accessor is 0.
-          const size_t SizeAccField =
-              sizeof(size_t) * (AccImpl->MDims == 0 ? 1 : AccImpl->MDims);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &AccImpl->MAccessRange[0],
-                             SizeAccField, Index + IndexShift);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &AccImpl->MMemoryRange[0],
-                             SizeAccField, Index + IndexShift);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &AccImpl->MOffset[0],
-                             SizeAccField, Index + IndexShift);
-        }
-        break;
-      }
-      case access::target::local: {
-        detail::LocalAccessorImplHost *LAcc =
-            static_cast<detail::LocalAccessorImplHost *>(Ptr);
-        // Stream implementation creates local accessor with size per work item
-        // in work group. Number of work items is not available during stream
-        // construction, that is why size of the accessor is updated here using
-        // information about number of work items in the work group.
-        if (LAcc->PerWI)
-          LAcc->resize(MNDRDesc.LocalSize.size(), MNDRDesc.GlobalSize.size());
-        range<3> &Size = LAcc->MSize;
-        const int Dims = LAcc->MDims;
-        int SizeInBytes = LAcc->MElemSize;
-        for (int I = 0; I < Dims; ++I)
-          SizeInBytes *= Size[I];
-        MArgs.emplace_back(kind_std_layout, nullptr, SizeInBytes,
-                           Index + IndexShift);
-        if (!IsKernelCreatedFromSource) {
-          ++IndexShift;
-          const size_t SizeAccField = Dims * sizeof(Size[0]);
-          MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
-                             Index + IndexShift);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
-                             Index + IndexShift);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
-                             Index + IndexShift);
-        }
-        break;
-      }
-      case access::target::image:
-      case access::target::image_array: {
-        detail::Requirement *AccImpl = static_cast<detail::Requirement *>(Ptr);
-        MArgs.emplace_back(Kind, AccImpl, Size, Index + IndexShift);
-        if (!IsKernelCreatedFromSource) {
-          // TODO Handle additional kernel arguments for image class
-          // if the compiler front-end adds them.
-        }
-        break;
-      }
-      case access::target::host_image:
-      case access::target::host_buffer: {
-        throw cl::sycl::invalid_parameter_error(
-            "Unsupported accessor target case.");
-        break;
-      }
-      }
-      break;
-    }
-    case kind_sampler: {
-      MArgs.emplace_back(kind_sampler, Ptr, sizeof(sampler),
-                         Index + IndexShift);
-      break;
-    }
-    }
-  }
+                  bool IsKernelCreatedFromSource);
 
   template <typename LambdaName> bool lambdaAndKernelHaveEqualName() {
     // TODO It is unclear a kernel and a lambda/functor must to be equal or not
@@ -370,70 +230,7 @@ private:
   // returns sycl::event object representing the command group.
   // It's expected that the method is the latest method executed before
   // object destruction.
-  event finalize() {
-    sycl::event EventRet;
-    std::unique_ptr<detail::CG> CommandGroup;
-    switch (MCGType) {
-    case detail::CG::KERNEL:
-    case detail::CG::RUN_ON_HOST_INTEL:
-      CommandGroup.reset(new detail::CGExecKernel(
-          std::move(MNDRDesc), std::move(MHostKernel), std::move(MSyclKernel),
-          std::move(MArgsStorage), std::move(MAccStorage),
-          std::move(MSharedPtrStorage), std::move(MRequirements),
-          std::move(MEvents), std::move(MArgs), std::move(MKernelName),
-          std::move(MOSModuleHandle), std::move(MStreamStorage), MCGType));
-      break;
-    case detail::CG::COPY_ACC_TO_PTR:
-    case detail::CG::COPY_PTR_TO_ACC:
-    case detail::CG::COPY_ACC_TO_ACC:
-      CommandGroup.reset(new detail::CGCopy(
-          MCGType, MSrcPtr, MDstPtr, std::move(MArgsStorage),
-          std::move(MAccStorage), std::move(MSharedPtrStorage),
-          std::move(MRequirements), std::move(MEvents)));
-      break;
-    case detail::CG::FILL:
-      CommandGroup.reset(new detail::CGFill(
-          std::move(MPattern), MDstPtr, std::move(MArgsStorage),
-          std::move(MAccStorage), std::move(MSharedPtrStorage),
-          std::move(MRequirements), std::move(MEvents)));
-      break;
-    case detail::CG::UPDATE_HOST:
-      CommandGroup.reset(new detail::CGUpdateHost(
-          MDstPtr, std::move(MArgsStorage), std::move(MAccStorage),
-          std::move(MSharedPtrStorage), std::move(MRequirements),
-          std::move(MEvents)));
-      break;
-    case detail::CG::COPY_USM:
-      CommandGroup.reset(new detail::CGCopyUSM(
-          MSrcPtr, MDstPtr, MLength, std::move(MArgsStorage),
-          std::move(MAccStorage), std::move(MSharedPtrStorage),
-          std::move(MRequirements), std::move(MEvents)));
-      break;
-    case detail::CG::FILL_USM:
-      CommandGroup.reset(new detail::CGFillUSM(
-          std::move(MPattern), MDstPtr, MLength, std::move(MArgsStorage),
-          std::move(MAccStorage), std::move(MSharedPtrStorage),
-          std::move(MRequirements), std::move(MEvents)));
-      break;
-    case detail::CG::PREFETCH_USM:
-      CommandGroup.reset(new detail::CGPrefetchUSM(
-          MDstPtr, MLength, std::move(MArgsStorage), std::move(MAccStorage),
-          std::move(MSharedPtrStorage), std::move(MRequirements),
-          std::move(MEvents)));
-      break;
-    case detail::CG::NONE:
-      throw runtime_error("Command group submitted without a kernel or a "
-                          "explicit memory operation.");
-    default:
-      throw runtime_error("Unhandled type of command group");
-    }
-
-    detail::EventImplPtr Event = detail::Scheduler::getInstance().addCG(
-        std::move(CommandGroup), std::move(MQueue));
-
-    EventRet = detail::createSyclObjFromImpl<event>(Event);
-    return EventRet;
-  }
+  event finalize();
 
   // Save streams associated with this handler. Streams are then forwarded to
   // command group and flushed in the scheduler.
@@ -534,6 +331,49 @@ private:
     }
     if (SyclKernel.is_host()) {
       throw invalid_object_error("Invalid kernel type, OpenCL expected");
+    }
+  }
+
+  static id<1> getDelinearizedIndex(const range<1> Range, const size_t Index) {
+    return {Index};
+  }
+
+  static id<2> getDelinearizedIndex(const range<2> Range, const size_t Index) {
+    size_t x = Index / Range[1];
+    size_t y = Index % Range[1];
+    return {x, y};
+  }
+
+  static id<3> getDelinearizedIndex(const range<3> Range, const size_t Index) {
+    size_t x = Index / (Range[1] * Range[2]);
+    size_t y = (Index / Range[2]) % Range[1];
+    size_t z = Index % Range[2];
+    return {x, y, z};
+  }
+
+  // The method stores lambda to the template-free object and initializes
+  // kernel name, list of arguments and requirements using information from
+  // integration header.
+  template <typename KernelName, typename KernelType, int Dims,
+            typename LambdaArgType = sycl::detail::lambda_arg_type<KernelType>>
+  void StoreLambda(KernelType KernelFunc) {
+    MHostKernel.reset(
+        new detail::HostKernel<KernelType, LambdaArgType, Dims>(KernelFunc));
+
+    using KI = sycl::detail::KernelInfo<KernelName>;
+    // Empty name indicates that the compilation happens without integration
+    // header, so don't perform things that require it.
+    if (KI::getName() != "") {
+      MArgs.clear();
+      extractArgsAndReqsFromLambda(MHostKernel->getPtr(), KI::getNumParams(),
+                                   &KI::getParamDesc(0));
+      MKernelName = KI::getName();
+      MOSModuleHandle = detail::OSUtil::getOSModuleHandle(KI::getName());
+    } else {
+      // In case w/o the integration header it is necessary to process
+      // accessors from the list(which are associated with this handler) as
+      // arguments.
+      MArgs = std::move(MAssociatedAccesors);
     }
   }
 
@@ -660,32 +500,6 @@ public:
   }
 
 #endif
-
-  // The method stores lambda to the template-free object and initializes
-  // kernel name, list of arguments and requirements using information from
-  // integration header.
-  template <typename KernelName, typename KernelType, int Dims,
-            typename LambdaArgType = sycl::detail::lambda_arg_type<KernelType>>
-  void StoreLambda(KernelType KernelFunc) {
-    MHostKernel.reset(
-        new detail::HostKernel<KernelType, LambdaArgType, Dims>(KernelFunc));
-
-    using KI = sycl::detail::KernelInfo<KernelName>;
-    // Empty name indicates that the compilation happens without integration
-    // header, so don't perform things that require it.
-    if (KI::getName() != "") {
-      MArgs.clear();
-      extractArgsAndReqsFromLambda(MHostKernel->getPtr(), KI::getNumParams(),
-                                   &KI::getParamDesc(0));
-      MKernelName = KI::getName();
-      MOSModuleHandle = detail::OSUtil::getOSModuleHandle(KI::getName());
-    } else {
-      // In case w/o the integration header it is necessary to process
-      // accessors from the list(which are associated with this handler) as
-      // arguments.
-      MArgs = std::move(MAssociatedAccesors);
-    }
-  }
 
   // single_task version with a kernel represented as a lambda.
   template <typename KernelName = detail::auto_name, typename KernelType>
@@ -1112,23 +926,6 @@ public:
     // Store copy of accessor to the local storage to make sure it is alive
     // until we finish
     MAccStorage.push_back(std::move(AccImpl));
-  }
-
-  static id<1> getDelinearizedIndex(const range<1> Range, const size_t Index) {
-    return {Index};
-  }
-
-  static id<2> getDelinearizedIndex(const range<2> Range, const size_t Index) {
-    size_t x = Index / Range[1];
-    size_t y = Index % Range[1];
-    return {x, y};
-  }
-
-  static id<3> getDelinearizedIndex(const range<3> Range, const size_t Index) {
-    size_t x = Index / (Range[1] * Range[2]);
-    size_t y = (Index / Range[2]) % Range[1];
-    size_t z = Index % Range[2];
-    return {x, y, z};
   }
 
   // Checks whether it is possible to copy the source shape to the destination

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -165,7 +165,7 @@ private:
   extractArgsAndReqsFromLambda(char *LambdaPtr, size_t KernelArgsNum,
                                const detail::kernel_param_desc_t *KernelArgs);
 
-  /// Extracts and prepares kernel arguments that were set via set_arg(s).
+  /// Extracts and prepares kernel arguments set via set_arg(s).
   void extractArgsAndReqs();
 
   void processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
@@ -185,7 +185,7 @@ private:
     return lambdaName == kernelName;
   }
 
-  /// Constructs CG object of specific type, pass it to Scheduler and
+  /// Constructs CG object of specific type, passes it to Scheduler and
   /// returns sycl::event object representing the command group.
   /// It's expected that the method is the latest method executed before
   /// object destruction.
@@ -502,8 +502,7 @@ public:
     setArgsHelper(0, std::move(Args)...);
   }
 
-  /// Defines and invokes a SYCL kernel function as a lambda function
-  /// or a named function object type.
+  /// Defines and invokes a SYCL kernel function as a function object type.
   ///
   /// If it is a named function object and the function object type is
   /// globally visible, there is no need for the developer to provide

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -481,8 +481,8 @@ public:
   ///
   /// @param Event is a vector of valid SYCL events to wait on.
   void depends_on(vector_class<event> Events) {
-    for (event &e : Events) {
-      depends_on(e);
+    for (event &Event : Events) {
+      MEvents.push_back(std::move(detail::getSyclObjImpl(Event)));
     }
   }
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -620,6 +620,16 @@ public:
 #endif
   }
 
+  /// Hierarchical kernel invocation method of a kernel defined as a lambda
+  /// encoding the body of each work-group to launch.
+  ///
+  /// Lambda may contain multiple calls to parallel_for_work_item(...) methods
+  /// representing the execution on each work-item. Launches NumWorkGroups
+  /// work-groups of runtime-defined size.
+  ///
+  /// @param NumWorkGroups is a range describing the number of work-groups in
+  /// each dimension.
+  /// @param KernelFunc is a lambda representing kernel.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for_work_group(range<Dims> NumWorkGroups,
@@ -636,6 +646,18 @@ public:
 #endif // __SYCL_DEVICE_ONLY__
   }
 
+  /// Hierarchical kernel invocation method of a kernel defined as a lambda
+  /// encoding the body of each work-group to launch.
+  ///
+  /// Lambda may contain multiple calls to parallel_for_work_item(...) methods
+  /// representing the execution on each work-item. Launches NumWorkGroups
+  /// work-groups of WorkGroupSize size.
+  ///
+  /// @param NumWorkGroups is a range describing the number of work-groups in
+  /// each dimension.
+  /// @param WorkGroupSize is a range describing the size of work-groups in
+  /// each dimension.
+  /// @param KernelFunc is a lambda representing kernel.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for_work_group(range<Dims> NumWorkGroups,
@@ -653,8 +675,12 @@ public:
 #endif // __SYCL_DEVICE_ONLY__
   }
 
-  // single_task version with a kernel represented as a sycl::kernel.
-  // The kernel invocation method has no functors and cannot be called on host.
+  /// Invokes a SYCL kernel.
+  ///
+  /// Executes exactly once. The kernel invocation method has no functors and
+  /// cannot be called on host.
+  ///
+  /// @param SyclKernel is a SYCL kernel object.
   void single_task(kernel SyclKernel) {
     throwIfActionIsCreated();
     verifySyclKernelInvoc(SyclKernel);
@@ -664,12 +690,10 @@ public:
     extractArgsAndReqs();
   }
 
-  // parallel_for version with a kernel represented as a sycl::kernel + range
-  // that specifies global size only. The kernel invocation method has no
-  // functors and cannot be called on host.
   /// Defines and invokes a SYCL kernel function for the specified range.
   ///
-  /// The SYCL kernel function is defined as SYCL kernel object.
+  /// The SYCL kernel function is defined as SYCL kernel object. The kernel
+  /// invocation method has no functors and cannot be called on host.
   ///
   /// @param NumWorkItems is a range defining indexing space.
   /// @param WorkItemOffset is an offset to be applied to each work item index.
@@ -725,7 +749,7 @@ public:
   ///
   /// @param SyclKernel is a SYCL kernel that is executed on a SYCL device
   /// (except for the host device).
-  /// @param KernelFunc is a lambda that is uesd if device, queue is bound to,
+  /// @param KernelFunc is a lambda that is used if device, queue is bound to,
   /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType>
   void single_task(kernel SyclKernel, KernelType KernelFunc) {
@@ -745,9 +769,13 @@ public:
 #endif
   }
 
-  // parallel_for version which takes two "kernels". One is a lambda which is
-  // used if device, queue is bound to, is host device. Second is a sycl::kernel
-  // which is used otherwise. range argument specifies global size.
+  /// Defines and invokes a SYCL kernel function for the specified range.
+  ///
+  /// @param SyclKernel is a SYCL kernel that is executed on a SYCL device
+  /// (except for the host device).
+  /// @param NumWorkItems is a range defining indexing space.
+  /// @param KernelFunc is a lambda that is used if device, queue is bound to,
+  /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(kernel SyclKernel, range<Dims> NumWorkItems,
@@ -768,9 +796,15 @@ public:
 #endif
   }
 
-  // parallel_for version which takes two "kernels". One is a lambda which is
-  // used if device, queue is bound to, is host device. Second is a sycl::kernel
-  // which is used otherwise. range and id specify global size and offset.
+  /// Defines and invokes a SYCL kernel function for the specified range and
+  /// offsets.
+  ///
+  /// @param SyclKernel is a SYCL kernel that is executed on a SYCL device
+  /// (except for the host device).
+  /// @param NumWorkItems is a range defining indexing space.
+  /// @param WorkItemOffset is an offset to be applied to each work item index.
+  /// @param KernelFunc is a lambda that is used if device, queue is bound to,
+  /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(kernel SyclKernel, range<Dims> NumWorkItems,
@@ -791,9 +825,15 @@ public:
 #endif
   }
 
-  // parallel_for version which takes two "kernels". One is a lambda which is
-  // used if device, queue is bound to, is host device. Second is a sycl::kernel
-  // which is used otherwise. nd_range specifies global, local size and offset.
+  /// Defines and invokes a SYCL kernel function for the specified range and
+  /// offsets.
+  ///
+  /// @param SyclKernel is a SYCL kernel that is executed on a SYCL device
+  /// (except for the host device).
+  /// @param NumWorkItems is a range defining indexing space.
+  /// @param WorkItemOffset is an offset to be applied to each work item index.
+  /// @param KernelFunc is a lambda that is used if device, queue is bound to,
+  /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(kernel SyclKernel, nd_range<Dims> NDRange,
@@ -814,12 +854,19 @@ public:
 #endif
   }
 
+  /// Hierarchical kernel invocation method of a kernel.
+  ///
   /// This version of \c parallel_for_work_group takes two parameters
   /// representing the same kernel. The first one - \c syclKernel - is a
   /// compiled form of the second one - \c kernelFunc, which is the source form
   /// of the kernel. The same source kernel can be compiled multiple times
   /// yielding multiple kernel class objects accessible via the \c program class
   /// interface.
+  ///
+  /// @param SyclKernel is a compiled SYCL kernel.
+  /// @param NumWorkGroups is a range describing the number of work-groups in
+  /// each dimension.
+  /// @param KernelFunc is a lambda representing kernel.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for_work_group(kernel SyclKernel, range<Dims> NumWorkGroups,
@@ -837,8 +884,21 @@ public:
 #endif // __SYCL_DEVICE_ONLY__
   }
 
-  /// Two-kernel version of the \c parallel_for_work_group with group and local
-  /// range.
+  /// Hierarchical kernel invocation method of a kernel.
+  ///
+  /// This version of \c parallel_for_work_group takes two parameters
+  /// representing the same kernel. The first one - \c syclKernel - is a
+  /// compiled form of the second one - \c kernelFunc, which is the source form
+  /// of the kernel. The same source kernel can be compiled multiple times
+  /// yielding multiple kernel class objects accessible via the \c program class
+  /// interface.
+  ///
+  /// @param SyclKernel is a compiled SYCL kernel.
+  /// @param NumWorkGroups is a range describing the number of work-groups in
+  /// each dimension.
+  /// @param WorkGroupSize is a range describing the size of work-groups in
+  /// each dimension.
+  /// @param KernelFunc is a lambda representing kernel.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for_work_group(kernel SyclKernel, range<Dims> NumWorkGroups,
@@ -859,7 +919,13 @@ public:
 
   // Explicit copy operations API
 
-  // copy memory pointed by accessor to host memory pointed by shared_ptr
+  /// Copies the contents of memory object accessed by Src into the memory
+  /// pointed by Dst.
+  ///
+  /// Source must have at least as many bytes as the range accessed by Dst.
+  ///
+  /// @param Src is a source SYCL accessor.
+  /// @param Dst is a smart pointer to destination memory.
   template <typename T_Src, typename T_Dst, int Dims, access::mode AccessMode,
             access::target AccessTarget,
             access::placeholder IsPlaceholder = access::placeholder::false_t>
@@ -875,7 +941,13 @@ public:
     copy(Src, RawDstPtr);
   }
 
-  // copy memory pointer by shared_ptr to host memory pointed by accessor
+  /// Copies the contents of memory pointed by Src into the memory object
+  /// accessed by Dst.
+  ///
+  /// Source must have at least as many bytes as the range accessed by Dst.
+  ///
+  /// @param Src is a smart pointer to source memory.
+  /// @param Dst is a destination SYCL accessor.
   template <typename T_Src, typename T_Dst, int Dims, access::mode AccessMode,
             access::target AccessTarget,
             access::placeholder IsPlaceholder = access::placeholder::false_t>
@@ -892,7 +964,13 @@ public:
     copy(RawSrcPtr, Dst);
   }
 
-  // copy memory pointed by accessor to host memory pointed by raw pointer
+  /// Copies the contents of memory object accessed by Src into the memory
+  /// pointed by Dst.
+  ///
+  /// Source must have at least as many bytes as the range accessed by Dst.
+  ///
+  /// @param Src is a source SYCL accessor.
+  /// @param Dst is a pointer to destination memory.
   template <typename T_Src, typename T_Dst, int Dims, access::mode AccessMode,
             access::target AccessTarget,
             access::placeholder IsPlaceholder = access::placeholder::false_t>
@@ -931,7 +1009,13 @@ public:
     MAccStorage.push_back(std::move(AccImpl));
   }
 
-  // copy memory pointed by raw pointer to host memory pointed by accessor
+  /// Copies the contents of memory pointed by Src into the memory object
+  /// accessed by Dst.
+  ///
+  /// Source must have at least as many bytes as the range accessed by Dst.
+  ///
+  /// @param Src is a pointer to source memory.
+  /// @param Dst is a destination SYCL accessor.
   template <typename T_Src, typename T_Dst, int Dims, access::mode AccessMode,
             access::target AccessTarget,
             access::placeholder IsPlaceholder = access::placeholder::false_t>
@@ -971,7 +1055,13 @@ public:
     MAccStorage.push_back(std::move(AccImpl));
   }
 
-  // copy memory pointed by accessor to the memory pointed by another accessor
+  /// Copies the contents of memory object accessed by Src to the memory
+  /// object accessed by Dst.
+  ///
+  /// Source must have at least as many bytes as the range accessed by Dst.
+  ///
+  /// @param Src is a source SYCL accessor.
+  /// @param Dst is a destination SYCL accessor.
   template <
       typename T_Src, int Dims_Src, access::mode AccessMode_Src,
       access::target AccessTarget_Src, typename T_Dst, int Dims_Dst,
@@ -1033,6 +1123,10 @@ public:
     MAccStorage.push_back(std::move(AccImplDst));
   }
 
+  /// Provides guarantees that the memory object accessed via Acc is updated
+  /// on the host after command group object execution is complete.
+  ///
+  /// @param Acc is a SYCL accessor that needs to be updated on host.
   template <typename T, int Dims, access::mode AccessMode,
             access::target AccessTarget,
             access::placeholder IsPlaceholder = access::placeholder::false_t>
@@ -1051,10 +1145,14 @@ public:
     MAccStorage.push_back(std::move(AccImpl));
   }
 
-  // Fill memory pointed by accessor with the pattern given.
-  // If the operation is submitted to queue associated with OpenCL device and
-  // accessor points to one dimensional memory object then use special type for
-  // filling. Otherwise fill using regular kernel.
+  /// Fills memory pointed by accessor with the pattern given.
+  ///
+  /// If the operation is submitted to queue associated with OpenCL device and
+  /// accessor points to one dimensional memory object then use special type for
+  /// filling. Otherwise fill using regular kernel.
+  ///
+  /// @param Dst is a destination SYCL accessor.
+  /// @param Pattern is a value to be used to fill the memory.
   template <typename T, int Dims, access::mode AccessMode,
             access::target AccessTarget,
             access::placeholder IsPlaceholder = access::placeholder::false_t>
@@ -1090,7 +1188,12 @@ public:
     }
   }
 
-  // Copy memory from the source to the destination.
+  /// Copies data from one memory region to another, both pointed by
+  /// USM pointers.
+  ///
+  /// @param Dest is a USM pointer to the destination memory.
+  /// @param Src is a USM pointer to the source memory.
+  /// @param Count is a number of bytes to copy.
   void memcpy(void *Dest, const void *Src, size_t Count) {
     throwIfActionIsCreated();
     MSrcPtr = const_cast<void *>(Src);
@@ -1099,7 +1202,11 @@ public:
     MCGType = detail::CG::COPY_USM;
   }
 
-  // Fill the memory pointed to by the destination with the given bytes.
+  /// Fills the memory pointed by a USM pointer with the value specified.
+  ///
+  /// @param Dest is a USM pointer to the memory to fill.
+  /// @param Value is a value to be set. Value is cast as an unsigned char.
+  /// @param Count is a number of bytes to fill.
   void memset(void *Dest, int Value, size_t Count) {
     throwIfActionIsCreated();
     MDstPtr = Dest;
@@ -1108,7 +1215,12 @@ public:
     MCGType = detail::CG::FILL_USM;
   }
 
-  // Prefetch the memory pointed to by the pointer.
+  /// Provides hints to the runtime library that data should be made available
+  /// on a device earlier than Unified Shared Memory would normally require it
+  /// to be available.
+  ///
+  /// @param Ptr is a USM pointer to the memory to be prefetched to the device.
+  /// @param Count is a number of bytes to be prefetched.
   void prefetch(const void *Ptr, size_t Count) {
     throwIfActionIsCreated();
     MDstPtr = const_cast<void *>(Ptr);

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -13,11 +13,7 @@
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/cg.hpp>
-#include <CL/sycl/detail/common.hpp>
-#include <CL/sycl/detail/helpers.hpp>
-#include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/detail/os_util.hpp>
-#include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/event.hpp>
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/kernel.hpp>

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -16,7 +16,6 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
-//#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/event.hpp>
@@ -114,7 +113,7 @@ template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {
 // kernel, requirements to the memory, arguments for the kernel.
 //
 // sycl::queue::submit([](handler &CGH){
-//   CGH.require(Accessor1);   // Adds a requirement to the memory object.
+///   CGH.require(Accessor1);   // Adds a requirement to the memory object.
 //   CGH.setArg(0, Accessor2); // Registers accessor given as an argument to the
 //                             // kernel + adds a requirement to the memory
 //                             // object.
@@ -134,7 +133,7 @@ template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {
 // "finalization" it constructs CG object, that represents specific operation,
 // passing fields that are required only.
 
-// 4.8.3 Command group handler class
+/// 4.8.3 Command group handler class
 class handler {
   shared_ptr_class<detail::queue_impl> MQueue;
   // The storage for the arguments passed.
@@ -156,7 +155,7 @@ class handler {
   vector_class<detail::Requirement *> MRequirements;
   // Struct that encodes global size, local size, ...
   detail::NDRDescT MNDRDesc;
-  std::string MKernelName;
+  string_class MKernelName;
   // Storage for a sycl::kernel object.
   unique_ptr_class<kernel> MSyclKernel;
   // Type of the command group, e.g. kernel, fill.
@@ -170,7 +169,7 @@ class handler {
   // Pattern that is used to fill memory object in case command type is fill.
   vector_class<char> MPattern;
   // Storage for a lambda or function object.
-  std::unique_ptr<detail::HostKernelBase> MHostKernel;
+  unique_ptr_class<detail::HostKernelBase> MHostKernel;
   detail::OSModuleHandle MOSModuleHandle;
   // The list of events that order this operation
   vector_class<detail::EventImplPtr> MEvents;
@@ -220,8 +219,8 @@ private:
     // kernel. Else it is necessary use set_atg(s) for resolve the order and
     // values of arguments for the kernel.
     assert(MSyclKernel && "MSyclKernel is not initialized");
-    const std::string lambdaName = detail::KernelInfo<LambdaName>::getName();
-    const std::string kernelName =
+    const string_class lambdaName = detail::KernelInfo<LambdaName>::getName();
+    const string_class kernelName =
         MSyclKernel->get_info<info::kernel::function_name>();
     return lambdaName == kernelName;
   }

--- a/sycl/include/CL/sycl/intel/function_pointer.hpp
+++ b/sycl/include/CL/sycl/intel/function_pointer.hpp
@@ -11,6 +11,7 @@
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/program.hpp>
 #include <CL/sycl/stl.hpp>
+#include <CL/sycl/detail/program_impl.hpp>
 
 #include <type_traits>
 

--- a/sycl/include/CL/sycl/intel/function_pointer.hpp
+++ b/sycl/include/CL/sycl/intel/function_pointer.hpp
@@ -8,10 +8,10 @@
 
 #pragma once
 
+#include <CL/sycl/detail/program_impl.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/program.hpp>
 #include <CL/sycl/stl.hpp>
-#include <CL/sycl/detail/program_impl.hpp>
 
 #include <type_traits>
 

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -87,6 +87,7 @@ set(SYCL_SOURCES
     "exception.cpp"
     "exception_list.cpp"
     "half_type.cpp"
+    "handler.cpp"
     "kernel.cpp"
     "platform.cpp"
     "program.cpp"

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -14,6 +14,7 @@
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/kernel_info.hpp>
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/program_manager/program_manager.hpp>

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -17,7 +17,7 @@
 #include <CL/sycl/handler.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 event handler::finalize() {
   sycl::event EventRet;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -8,13 +8,13 @@
 //
 // ===--------------------------------------------------------------------=== //
 
-#include <CL/sycl/event.hpp>
-#include <CL/sycl/handler.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
+#include <CL/sycl/event.hpp>
+#include <CL/sycl/handler.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
 namespace cl {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -88,18 +88,15 @@ event handler::finalize() {
 void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
                          const int Size, const size_t Index, size_t &IndexShift,
                          bool IsKernelCreatedFromSource) {
-  const auto kind_std_layout_v = detail::kernel_param_kind_t::kind_std_layout;
-  const auto kind_accessor_v = detail::kernel_param_kind_t::kind_accessor;
-  const auto kind_sampler_v = detail::kernel_param_kind_t::kind_sampler;
-  const auto kind_pointer_v = detail::kernel_param_kind_t::kind_pointer;
+  using detail::kernel_param_kind_t;
 
   switch (Kind) {
-  case kind_std_layout_v:
-  case kind_pointer_v: {
+  case kernel_param_kind_t::kind_std_layout:
+  case kernel_param_kind_t::kind_pointer: {
     MArgs.emplace_back(Kind, Ptr, Size, Index + IndexShift);
     break;
   }
-  case kind_accessor_v: {
+  case kernel_param_kind_t::kind_accessor: {
     // For args kind of accessor Size is information about accessor.
     // The first 11 bits of Size encodes the accessor target.
     const access::target AccTarget = static_cast<access::target>(Size & 0x7ff);
@@ -114,14 +111,17 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
         const size_t SizeAccField =
             sizeof(size_t) * (AccImpl->MDims == 0 ? 1 : AccImpl->MDims);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout_v, &AccImpl->MAccessRange[0],
-                           SizeAccField, Index + IndexShift);
+        MArgs.emplace_back(kernel_param_kind_t::kind_std_layout,
+                           &AccImpl->MAccessRange[0], SizeAccField,
+                           Index + IndexShift);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout_v, &AccImpl->MMemoryRange[0],
-                           SizeAccField, Index + IndexShift);
+        MArgs.emplace_back(kernel_param_kind_t::kind_std_layout,
+                           &AccImpl->MMemoryRange[0], SizeAccField,
+                           Index + IndexShift);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout_v, &AccImpl->MOffset[0],
-                           SizeAccField, Index + IndexShift);
+        MArgs.emplace_back(kernel_param_kind_t::kind_std_layout,
+                           &AccImpl->MOffset[0], SizeAccField,
+                           Index + IndexShift);
       }
       break;
     }
@@ -139,19 +139,19 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
       int SizeInBytes = LAcc->MElemSize;
       for (int I = 0; I < Dims; ++I)
         SizeInBytes *= Size[I];
-      MArgs.emplace_back(kind_std_layout_v, nullptr, SizeInBytes,
-                         Index + IndexShift);
+      MArgs.emplace_back(kernel_param_kind_t::kind_std_layout, nullptr,
+                         SizeInBytes, Index + IndexShift);
       if (!IsKernelCreatedFromSource) {
         ++IndexShift;
         const size_t SizeAccField = Dims * sizeof(Size[0]);
-        MArgs.emplace_back(kind_std_layout_v, &Size, SizeAccField,
-                           Index + IndexShift);
+        MArgs.emplace_back(kernel_param_kind_t::kind_std_layout, &Size,
+                           SizeAccField, Index + IndexShift);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout_v, &Size, SizeAccField,
-                           Index + IndexShift);
+        MArgs.emplace_back(kernel_param_kind_t::kind_std_layout, &Size,
+                           SizeAccField, Index + IndexShift);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout_v, &Size, SizeAccField,
-                           Index + IndexShift);
+        MArgs.emplace_back(kernel_param_kind_t::kind_std_layout, &Size,
+                           SizeAccField, Index + IndexShift);
       }
       break;
     }
@@ -174,8 +174,8 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
     }
     break;
   }
-  case kind_sampler_v: {
-    MArgs.emplace_back(kind_sampler_v, Ptr, sizeof(sampler),
+  case kernel_param_kind_t::kind_sampler: {
+    MArgs.emplace_back(kernel_param_kind_t::kind_sampler, Ptr, sizeof(sampler),
                        Index + IndexShift);
     break;
   }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -88,18 +88,18 @@ event handler::finalize() {
 void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
                          const int Size, const size_t Index, size_t &IndexShift,
                          bool IsKernelCreatedFromSource) {
-  const auto kind_std_layout = detail::kernel_param_kind_t::kind_std_layout;
-  const auto kind_accessor = detail::kernel_param_kind_t::kind_accessor;
-  const auto kind_sampler = detail::kernel_param_kind_t::kind_sampler;
-  const auto kind_pointer = detail::kernel_param_kind_t::kind_pointer;
+  const auto kind_std_layout_v = detail::kernel_param_kind_t::kind_std_layout;
+  const auto kind_accessor_v = detail::kernel_param_kind_t::kind_accessor;
+  const auto kind_sampler_v = detail::kernel_param_kind_t::kind_sampler;
+  const auto kind_pointer_v = detail::kernel_param_kind_t::kind_pointer;
 
   switch (Kind) {
-  case kind_std_layout:
-  case kind_pointer: {
+  case kind_std_layout_v:
+  case kind_pointer_v: {
     MArgs.emplace_back(Kind, Ptr, Size, Index + IndexShift);
     break;
   }
-  case kind_accessor: {
+  case kind_accessor_v: {
     // For args kind of accessor Size is information about accessor.
     // The first 11 bits of Size encodes the accessor target.
     const access::target AccTarget = static_cast<access::target>(Size & 0x7ff);
@@ -114,14 +114,14 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
         const size_t SizeAccField =
             sizeof(size_t) * (AccImpl->MDims == 0 ? 1 : AccImpl->MDims);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout, &AccImpl->MAccessRange[0],
+        MArgs.emplace_back(kind_std_layout_v, &AccImpl->MAccessRange[0],
                            SizeAccField, Index + IndexShift);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout, &AccImpl->MMemoryRange[0],
+        MArgs.emplace_back(kind_std_layout_v, &AccImpl->MMemoryRange[0],
                            SizeAccField, Index + IndexShift);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout, &AccImpl->MOffset[0], SizeAccField,
-                           Index + IndexShift);
+        MArgs.emplace_back(kind_std_layout_v, &AccImpl->MOffset[0],
+                           SizeAccField, Index + IndexShift);
       }
       break;
     }
@@ -139,18 +139,18 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
       int SizeInBytes = LAcc->MElemSize;
       for (int I = 0; I < Dims; ++I)
         SizeInBytes *= Size[I];
-      MArgs.emplace_back(kind_std_layout, nullptr, SizeInBytes,
+      MArgs.emplace_back(kind_std_layout_v, nullptr, SizeInBytes,
                          Index + IndexShift);
       if (!IsKernelCreatedFromSource) {
         ++IndexShift;
         const size_t SizeAccField = Dims * sizeof(Size[0]);
-        MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
+        MArgs.emplace_back(kind_std_layout_v, &Size, SizeAccField,
                            Index + IndexShift);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
+        MArgs.emplace_back(kind_std_layout_v, &Size, SizeAccField,
                            Index + IndexShift);
         ++IndexShift;
-        MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
+        MArgs.emplace_back(kind_std_layout_v, &Size, SizeAccField,
                            Index + IndexShift);
       }
       break;
@@ -174,8 +174,9 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
     }
     break;
   }
-  case kind_sampler: {
-    MArgs.emplace_back(kind_sampler, Ptr, sizeof(sampler), Index + IndexShift);
+  case kind_sampler_v: {
+    MArgs.emplace_back(kind_sampler_v, Ptr, sizeof(sampler),
+                       Index + IndexShift);
     break;
   }
   }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -1,0 +1,223 @@
+#include <CL/sycl/event.hpp>
+#include <CL/sycl/handler.hpp>
+
+namespace cl {
+namespace sycl {
+event handler::finalize() {
+  sycl::event EventRet;
+  std::unique_ptr<detail::CG> CommandGroup;
+  switch (MCGType) {
+  case detail::CG::KERNEL:
+  case detail::CG::RUN_ON_HOST_INTEL:
+    CommandGroup.reset(new detail::CGExecKernel(
+        std::move(MNDRDesc), std::move(MHostKernel), std::move(MSyclKernel),
+        std::move(MArgsStorage), std::move(MAccStorage),
+        std::move(MSharedPtrStorage), std::move(MRequirements),
+        std::move(MEvents), std::move(MArgs), std::move(MKernelName),
+        std::move(MOSModuleHandle), std::move(MStreamStorage), MCGType));
+    break;
+  case detail::CG::COPY_ACC_TO_PTR:
+  case detail::CG::COPY_PTR_TO_ACC:
+  case detail::CG::COPY_ACC_TO_ACC:
+    CommandGroup.reset(
+        new detail::CGCopy(MCGType, MSrcPtr, MDstPtr, std::move(MArgsStorage),
+                           std::move(MAccStorage), std::move(MSharedPtrStorage),
+                           std::move(MRequirements), std::move(MEvents)));
+    break;
+  case detail::CG::FILL:
+    CommandGroup.reset(new detail::CGFill(
+        std::move(MPattern), MDstPtr, std::move(MArgsStorage),
+        std::move(MAccStorage), std::move(MSharedPtrStorage),
+        std::move(MRequirements), std::move(MEvents)));
+    break;
+  case detail::CG::UPDATE_HOST:
+    CommandGroup.reset(new detail::CGUpdateHost(
+        MDstPtr, std::move(MArgsStorage), std::move(MAccStorage),
+        std::move(MSharedPtrStorage), std::move(MRequirements),
+        std::move(MEvents)));
+    break;
+  case detail::CG::COPY_USM:
+    CommandGroup.reset(new detail::CGCopyUSM(
+        MSrcPtr, MDstPtr, MLength, std::move(MArgsStorage),
+        std::move(MAccStorage), std::move(MSharedPtrStorage),
+        std::move(MRequirements), std::move(MEvents)));
+    break;
+  case detail::CG::FILL_USM:
+    CommandGroup.reset(new detail::CGFillUSM(
+        std::move(MPattern), MDstPtr, MLength, std::move(MArgsStorage),
+        std::move(MAccStorage), std::move(MSharedPtrStorage),
+        std::move(MRequirements), std::move(MEvents)));
+    break;
+  case detail::CG::PREFETCH_USM:
+    CommandGroup.reset(new detail::CGPrefetchUSM(
+        MDstPtr, MLength, std::move(MArgsStorage), std::move(MAccStorage),
+        std::move(MSharedPtrStorage), std::move(MRequirements),
+        std::move(MEvents)));
+    break;
+  case detail::CG::NONE:
+    throw runtime_error("Command group submitted without a kernel or a "
+                        "explicit memory operation.");
+  default:
+    throw runtime_error("Unhandled type of command group");
+  }
+
+  detail::EventImplPtr Event = detail::Scheduler::getInstance().addCG(
+      std::move(CommandGroup), std::move(MQueue));
+
+  EventRet = detail::createSyclObjFromImpl<event>(Event);
+  return EventRet;
+}
+
+void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
+                         const int Size, const size_t Index, size_t &IndexShift,
+                         bool IsKernelCreatedFromSource) {
+    const auto kind_std_layout = detail::kernel_param_kind_t::kind_std_layout;
+    const auto kind_accessor = detail::kernel_param_kind_t::kind_accessor;
+    const auto kind_sampler = detail::kernel_param_kind_t::kind_sampler;
+    const auto kind_pointer = detail::kernel_param_kind_t::kind_pointer;
+
+    switch (Kind) {
+    case kind_std_layout:
+    case kind_pointer: {
+      MArgs.emplace_back(Kind, Ptr, Size, Index + IndexShift);
+      break;
+    }
+    case kind_accessor: {
+      // For args kind of accessor Size is information about accessor.
+      // The first 11 bits of Size encodes the accessor target.
+      const access::target AccTarget =
+          static_cast<access::target>(Size & 0x7ff);
+      switch (AccTarget) {
+      case access::target::global_buffer:
+      case access::target::constant_buffer: {
+        detail::Requirement *AccImpl = static_cast<detail::Requirement *>(Ptr);
+        MArgs.emplace_back(Kind, AccImpl, Size, Index + IndexShift);
+        if (!IsKernelCreatedFromSource) {
+          // Dimensionality of the buffer is 1 when dimensionality of the
+          // accessor is 0.
+          const size_t SizeAccField =
+              sizeof(size_t) * (AccImpl->MDims == 0 ? 1 : AccImpl->MDims);
+          ++IndexShift;
+          MArgs.emplace_back(kind_std_layout, &AccImpl->MAccessRange[0],
+                             SizeAccField, Index + IndexShift);
+          ++IndexShift;
+          MArgs.emplace_back(kind_std_layout, &AccImpl->MMemoryRange[0],
+                             SizeAccField, Index + IndexShift);
+          ++IndexShift;
+          MArgs.emplace_back(kind_std_layout, &AccImpl->MOffset[0],
+                             SizeAccField, Index + IndexShift);
+        }
+        break;
+      }
+      case access::target::local: {
+        detail::LocalAccessorImplHost *LAcc =
+            static_cast<detail::LocalAccessorImplHost *>(Ptr);
+        // Stream implementation creates local accessor with size per work item
+        // in work group. Number of work items is not available during stream
+        // construction, that is why size of the accessor is updated here using
+        // information about number of work items in the work group.
+        if (LAcc->PerWI)
+          LAcc->resize(MNDRDesc.LocalSize.size(), MNDRDesc.GlobalSize.size());
+        range<3> &Size = LAcc->MSize;
+        const int Dims = LAcc->MDims;
+        int SizeInBytes = LAcc->MElemSize;
+        for (int I = 0; I < Dims; ++I)
+          SizeInBytes *= Size[I];
+        MArgs.emplace_back(kind_std_layout, nullptr, SizeInBytes,
+                           Index + IndexShift);
+        if (!IsKernelCreatedFromSource) {
+          ++IndexShift;
+          const size_t SizeAccField = Dims * sizeof(Size[0]);
+          MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
+                             Index + IndexShift);
+          ++IndexShift;
+          MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
+                             Index + IndexShift);
+          ++IndexShift;
+          MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
+                             Index + IndexShift);
+        }
+        break;
+      }
+      case access::target::image:
+      case access::target::image_array: {
+        detail::Requirement *AccImpl = static_cast<detail::Requirement *>(Ptr);
+        MArgs.emplace_back(Kind, AccImpl, Size, Index + IndexShift);
+        if (!IsKernelCreatedFromSource) {
+          // TODO Handle additional kernel arguments for image class
+          // if the compiler front-end adds them.
+        }
+        break;
+      }
+      case access::target::host_image:
+      case access::target::host_buffer: {
+        throw cl::sycl::invalid_parameter_error(
+            "Unsupported accessor target case.");
+        break;
+      }
+      }
+      break;
+    }
+    case kind_sampler: {
+      MArgs.emplace_back(kind_sampler, Ptr, sizeof(sampler),
+                         Index + IndexShift);
+      break;
+    }
+    }
+}
+
+void handler::extractArgsAndReqs() {
+  assert(MSyclKernel && "MSyclKernel is not initialized");
+  std::vector<detail::ArgDesc> UnPreparedArgs = std::move(MArgs);
+  MArgs.clear();
+
+  std::sort(
+      UnPreparedArgs.begin(), UnPreparedArgs.end(),
+      [](const detail::ArgDesc &first, const detail::ArgDesc &second) -> bool {
+        return (first.MIndex < second.MIndex);
+      });
+
+  const bool IsKernelCreatedFromSource = MSyclKernel->isCreatedFromSource();
+
+  size_t IndexShift = 0;
+  for (size_t I = 0; I < UnPreparedArgs.size(); ++I) {
+    void *Ptr = UnPreparedArgs[I].MPtr;
+    const detail::kernel_param_kind_t &Kind = UnPreparedArgs[I].MType;
+    const int &Size = UnPreparedArgs[I].MSize;
+    const int Index = UnPreparedArgs[I].MIndex;
+    processArg(Ptr, Kind, Size, Index, IndexShift, IsKernelCreatedFromSource);
+  }
+}
+
+void handler::extractArgsAndReqsFromLambda(
+    char *LambdaPtr, size_t KernelArgsNum,
+    const detail::kernel_param_desc_t *KernelArgs) {
+  const bool IsKernelCreatedFromSource = false;
+  size_t IndexShift = 0;
+  for (size_t I = 0; I < KernelArgsNum; ++I) {
+    void *Ptr = LambdaPtr + KernelArgs[I].offset;
+    const detail::kernel_param_kind_t &Kind = KernelArgs[I].kind;
+    const int &Size = KernelArgs[I].info;
+    if (Kind == detail::kernel_param_kind_t::kind_accessor) {
+      // For args kind of accessor Size is information about accessor.
+      // The first 11 bits of Size encodes the accessor target.
+      const access::target AccTarget =
+          static_cast<access::target>(Size & 0x7ff);
+      if ((AccTarget == access::target::global_buffer ||
+           AccTarget == access::target::constant_buffer) ||
+          (AccTarget == access::target::image ||
+           AccTarget == access::target::image_array)) {
+        detail::AccessorBaseHost *AccBase =
+            static_cast<detail::AccessorBaseHost *>(Ptr);
+        Ptr = detail::getSyclObjImpl(*AccBase).get();
+    } else if (AccTarget == access::target::local) {
+        detail::LocalAccessorBaseHost *LocalAccBase =
+            static_cast<detail::LocalAccessorBaseHost *>(Ptr);
+        Ptr = detail::getSyclObjImpl(*LocalAccBase).get();
+    }
+    }
+    processArg(Ptr, Kind, Size, I, IndexShift, IsKernelCreatedFromSource);
+  }
+}
+} // namespace sycl
+} // namespace cl

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -1,3 +1,13 @@
+//==-------- handler.cpp --- SYCL command group handler --------*- C++ -*---==//
+//
+// Copyright (C) 2019 Intel Corporation. All rights reserved.
+//
+// The information and source code contained herein is the exclusive property
+// of Intel Corporation and may not be disclosed, examined or reproduced in
+// whole or in part without explicit written authorization from the company.
+//
+// ===--------------------------------------------------------------------=== //
+
 #include <CL/sycl/event.hpp>
 #include <CL/sycl/handler.hpp>
 #include <CL/sycl/detail/common.hpp>

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -1,6 +1,10 @@
-#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/event.hpp>
 #include <CL/sycl/handler.hpp>
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/helpers.hpp>
+#include <CL/sycl/detail/kernel_desc.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
+#include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
 namespace cl {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -1,3 +1,4 @@
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/event.hpp>
 #include <CL/sycl/handler.hpp>
 

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -91,99 +91,97 @@ event handler::finalize() {
 void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
                          const int Size, const size_t Index, size_t &IndexShift,
                          bool IsKernelCreatedFromSource) {
-    const auto kind_std_layout = detail::kernel_param_kind_t::kind_std_layout;
-    const auto kind_accessor = detail::kernel_param_kind_t::kind_accessor;
-    const auto kind_sampler = detail::kernel_param_kind_t::kind_sampler;
-    const auto kind_pointer = detail::kernel_param_kind_t::kind_pointer;
+  const auto kind_std_layout = detail::kernel_param_kind_t::kind_std_layout;
+  const auto kind_accessor = detail::kernel_param_kind_t::kind_accessor;
+  const auto kind_sampler = detail::kernel_param_kind_t::kind_sampler;
+  const auto kind_pointer = detail::kernel_param_kind_t::kind_pointer;
 
-    switch (Kind) {
-    case kind_std_layout:
-    case kind_pointer: {
-      MArgs.emplace_back(Kind, Ptr, Size, Index + IndexShift);
-      break;
-    }
-    case kind_accessor: {
-      // For args kind of accessor Size is information about accessor.
-      // The first 11 bits of Size encodes the accessor target.
-      const access::target AccTarget =
-          static_cast<access::target>(Size & 0x7ff);
-      switch (AccTarget) {
-      case access::target::global_buffer:
-      case access::target::constant_buffer: {
-        detail::Requirement *AccImpl = static_cast<detail::Requirement *>(Ptr);
-        MArgs.emplace_back(Kind, AccImpl, Size, Index + IndexShift);
-        if (!IsKernelCreatedFromSource) {
-          // Dimensionality of the buffer is 1 when dimensionality of the
-          // accessor is 0.
-          const size_t SizeAccField =
-              sizeof(size_t) * (AccImpl->MDims == 0 ? 1 : AccImpl->MDims);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &AccImpl->MAccessRange[0],
-                             SizeAccField, Index + IndexShift);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &AccImpl->MMemoryRange[0],
-                             SizeAccField, Index + IndexShift);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &AccImpl->MOffset[0],
-                             SizeAccField, Index + IndexShift);
-        }
-        break;
-      }
-      case access::target::local: {
-        detail::LocalAccessorImplHost *LAcc =
-            static_cast<detail::LocalAccessorImplHost *>(Ptr);
-        // Stream implementation creates local accessor with size per work item
-        // in work group. Number of work items is not available during stream
-        // construction, that is why size of the accessor is updated here using
-        // information about number of work items in the work group.
-        if (LAcc->PerWI)
-          LAcc->resize(MNDRDesc.LocalSize.size(), MNDRDesc.GlobalSize.size());
-        range<3> &Size = LAcc->MSize;
-        const int Dims = LAcc->MDims;
-        int SizeInBytes = LAcc->MElemSize;
-        for (int I = 0; I < Dims; ++I)
-          SizeInBytes *= Size[I];
-        MArgs.emplace_back(kind_std_layout, nullptr, SizeInBytes,
+  switch (Kind) {
+  case kind_std_layout:
+  case kind_pointer: {
+    MArgs.emplace_back(Kind, Ptr, Size, Index + IndexShift);
+    break;
+  }
+  case kind_accessor: {
+    // For args kind of accessor Size is information about accessor.
+    // The first 11 bits of Size encodes the accessor target.
+    const access::target AccTarget = static_cast<access::target>(Size & 0x7ff);
+    switch (AccTarget) {
+    case access::target::global_buffer:
+    case access::target::constant_buffer: {
+      detail::Requirement *AccImpl = static_cast<detail::Requirement *>(Ptr);
+      MArgs.emplace_back(Kind, AccImpl, Size, Index + IndexShift);
+      if (!IsKernelCreatedFromSource) {
+        // Dimensionality of the buffer is 1 when dimensionality of the
+        // accessor is 0.
+        const size_t SizeAccField =
+            sizeof(size_t) * (AccImpl->MDims == 0 ? 1 : AccImpl->MDims);
+        ++IndexShift;
+        MArgs.emplace_back(kind_std_layout, &AccImpl->MAccessRange[0],
+                           SizeAccField, Index + IndexShift);
+        ++IndexShift;
+        MArgs.emplace_back(kind_std_layout, &AccImpl->MMemoryRange[0],
+                           SizeAccField, Index + IndexShift);
+        ++IndexShift;
+        MArgs.emplace_back(kind_std_layout, &AccImpl->MOffset[0], SizeAccField,
                            Index + IndexShift);
-        if (!IsKernelCreatedFromSource) {
-          ++IndexShift;
-          const size_t SizeAccField = Dims * sizeof(Size[0]);
-          MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
-                             Index + IndexShift);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
-                             Index + IndexShift);
-          ++IndexShift;
-          MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
-                             Index + IndexShift);
-        }
-        break;
-      }
-      case access::target::image:
-      case access::target::image_array: {
-        detail::Requirement *AccImpl = static_cast<detail::Requirement *>(Ptr);
-        MArgs.emplace_back(Kind, AccImpl, Size, Index + IndexShift);
-        if (!IsKernelCreatedFromSource) {
-          // TODO Handle additional kernel arguments for image class
-          // if the compiler front-end adds them.
-        }
-        break;
-      }
-      case access::target::host_image:
-      case access::target::host_buffer: {
-        throw cl::sycl::invalid_parameter_error(
-            "Unsupported accessor target case.");
-        break;
-      }
       }
       break;
     }
-    case kind_sampler: {
-      MArgs.emplace_back(kind_sampler, Ptr, sizeof(sampler),
+    case access::target::local: {
+      detail::LocalAccessorImplHost *LAcc =
+          static_cast<detail::LocalAccessorImplHost *>(Ptr);
+      // Stream implementation creates local accessor with size per work item
+      // in work group. Number of work items is not available during stream
+      // construction, that is why size of the accessor is updated here using
+      // information about number of work items in the work group.
+      if (LAcc->PerWI)
+        LAcc->resize(MNDRDesc.LocalSize.size(), MNDRDesc.GlobalSize.size());
+      range<3> &Size = LAcc->MSize;
+      const int Dims = LAcc->MDims;
+      int SizeInBytes = LAcc->MElemSize;
+      for (int I = 0; I < Dims; ++I)
+        SizeInBytes *= Size[I];
+      MArgs.emplace_back(kind_std_layout, nullptr, SizeInBytes,
                          Index + IndexShift);
+      if (!IsKernelCreatedFromSource) {
+        ++IndexShift;
+        const size_t SizeAccField = Dims * sizeof(Size[0]);
+        MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
+                           Index + IndexShift);
+        ++IndexShift;
+        MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
+                           Index + IndexShift);
+        ++IndexShift;
+        MArgs.emplace_back(kind_std_layout, &Size, SizeAccField,
+                           Index + IndexShift);
+      }
+      break;
+    }
+    case access::target::image:
+    case access::target::image_array: {
+      detail::Requirement *AccImpl = static_cast<detail::Requirement *>(Ptr);
+      MArgs.emplace_back(Kind, AccImpl, Size, Index + IndexShift);
+      if (!IsKernelCreatedFromSource) {
+        // TODO Handle additional kernel arguments for image class
+        // if the compiler front-end adds them.
+      }
+      break;
+    }
+    case access::target::host_image:
+    case access::target::host_buffer: {
+      throw cl::sycl::invalid_parameter_error(
+          "Unsupported accessor target case.");
       break;
     }
     }
+    break;
+  }
+  case kind_sampler: {
+    MArgs.emplace_back(kind_sampler, Ptr, sizeof(sampler), Index + IndexShift);
+    break;
+  }
+  }
 }
 
 void handler::extractArgsAndReqs() {
@@ -231,11 +229,11 @@ void handler::extractArgsAndReqsFromLambda(
         detail::AccessorBaseHost *AccBase =
             static_cast<detail::AccessorBaseHost *>(Ptr);
         Ptr = detail::getSyclObjImpl(*AccBase).get();
-    } else if (AccTarget == access::target::local) {
+      } else if (AccTarget == access::target::local) {
         detail::LocalAccessorBaseHost *LocalAccBase =
             static_cast<detail::LocalAccessorBaseHost *>(Ptr);
         Ptr = detail::getSyclObjImpl(*LocalAccBase).get();
-    }
+      }
     }
     processArg(Ptr, Kind, Size, I, IndexShift, IsKernelCreatedFromSource);
   }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -21,11 +21,11 @@ namespace cl {
 namespace sycl {
 event handler::finalize() {
   sycl::event EventRet;
-  std::unique_ptr<detail::CG> CommandGroup;
+  unique_ptr_class<detail::CG> CommandGroup;
   switch (MCGType) {
   case detail::CG::KERNEL:
   case detail::CG::RUN_ON_HOST_INTEL: {
-    std::shared_ptr<detail::kernel_impl> KernelImpl = nullptr;
+    shared_ptr_class<detail::kernel_impl> KernelImpl = nullptr;
     if (MSyclKernel)
       KernelImpl = detail::getSyclObjImpl(*MSyclKernel);
     CommandGroup.reset(new detail::CGExecKernel(


### PR DESCRIPTION
This patch is a part of effort to decouple SYCL Runtime library
interface from its actual implementation. The goal is to improve
SYCL ABI/API compatibility between different versions of library.

The following modifications were applied to handler class:

1. Moved as much code as possible inside the runtime library.
2. Replaced STD containers with SYCL variants.
3. Removed internal methods from public scope.
4. Replaced usages of kernel_impl with kernel.

Applying aforementioned changes requires modifying other header files.
While some of those may seem as a regression, affected classes will be
covered by future patches.

Signed-off-by: Alexander Batashev alexander.batashev@intel.com