### PR TITLE
[SYCL][USM] Make host device return nullptr for bad mallocs (huge, 0, etc)

### DIFF
--- a/sycl/include/CL/sycl/detail/aligned_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/aligned_allocator.hpp
@@ -53,10 +53,12 @@ public:
   pointer allocate(size_t Size) {
     size_t NumBytes = Size * sizeof(value_type);
     NumBytes = ((NumBytes - 1) | (MAlignment - 1)) + 1;
+    if (0 == NumBytes)
+      throw std::bad_alloc();
 
     pointer Result = reinterpret_cast<pointer>(
         detail::OSUtil::alignedAlloc(MAlignment, NumBytes));
-    if (!Result || NumBytes == 0)
+    if (!Result)
       throw std::bad_alloc();
     return Result;
   }

--- a/sycl/include/CL/sycl/detail/aligned_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/aligned_allocator.hpp
@@ -53,7 +53,7 @@ public:
   pointer allocate(size_t Size) {
     size_t NumBytes = Size * sizeof(value_type);
     NumBytes = ((NumBytes - 1) | (MAlignment - 1)) + 1;
-    if (0 == NumBytes)
+    if (Size > NumBytes)
       throw std::bad_alloc();
 
     pointer Result = reinterpret_cast<pointer>(

--- a/sycl/include/CL/sycl/detail/aligned_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/aligned_allocator.hpp
@@ -56,7 +56,7 @@ public:
 
     pointer Result = reinterpret_cast<pointer>(
         detail::OSUtil::alignedAlloc(MAlignment, NumBytes));
-    if (!Result)
+    if (!Result || NumBytes == 0)
       throw std::bad_alloc();
     return Result;
   }

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -71,17 +71,21 @@ void *alignedAlloc(size_t Alignment, size_t Size, const context &Ctxt,
                    const device &Dev, alloc Kind) {
   void *RetVal = nullptr;
   if (Ctxt.is_host()) {
-    if (!Alignment) {
-      // worst case default
-      Alignment = 128;
-    }
-
-    aligned_allocator<char> Alloc(Alignment);
-    try {
-      RetVal = Alloc.allocate(Size);
-    } catch (const std::bad_alloc &) {
-      // Conform with Specification behavior
+    if (Kind == alloc::unknown) {
       RetVal = nullptr;
+    } else {
+      if (!Alignment) {
+        // worst case default
+        Alignment = 128;
+      }
+
+      aligned_allocator<char> Alloc(Alignment);
+      try {
+        RetVal = Alloc.allocate(Size);
+      } catch (const std::bad_alloc &) {
+        // Conform with Specification behavior
+        RetVal = nullptr;
+      }
     }
   } else {
     std::shared_ptr<context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);

--- a/sycl/test/usm/badmalloc.cpp
+++ b/sycl/test/usm/badmalloc.cpp
@@ -23,31 +23,41 @@ int main(int argc, char *argv[]) {
 
   // Good size, bad type
   auto p = malloc(8, q, usm::alloc::unknown);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 1;
 
   // Bad size, host
   p = malloc(-1, q, usm::alloc::host);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 2;
   p = malloc(-1, q, usm::alloc::device);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 3;
   p = malloc(-1, q, usm::alloc::shared);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 4;
   p = malloc(-1, q, usm::alloc::unknown);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 5;
 
   // Bad size, auto aligned
   p = aligned_alloc(0, -1, q,  usm::alloc::host);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 6;
   p = aligned_alloc(0, -1, q,  usm::alloc::device);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 7;
   p = aligned_alloc(0, -1, q,  usm::alloc::shared);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 8;
   p = aligned_alloc(0, -1, q,  usm::alloc::unknown);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 9;
 
   // Allocs of 0 undefined, but bad type
   p = aligned_alloc(4, 0, q,  usm::alloc::unknown);
-  assert(p == nullptr);
+  if (p != nullptr)
+    return 10;
 
   return 0;
 }

--- a/sycl/test/usm/badmalloc.cpp
+++ b/sycl/test/usm/badmalloc.cpp
@@ -15,6 +15,7 @@
 // This test verifies that things fail in the proper way when they should.
 
 #include <CL/sycl.hpp>
+#include <iostream>
 
 using namespace cl::sycl;
 
@@ -28,34 +29,43 @@ int main(int argc, char *argv[]) {
 
   // Bad size, host
   p = malloc(-1, q, usm::alloc::host);
+  std::cout << "p = " << p << std::endl;
   if (p != nullptr)
     return 2;
   p = malloc(-1, q, usm::alloc::device);
+  std::cout << "p = " << p << std::endl;
   if (p != nullptr)
     return 3;
   p = malloc(-1, q, usm::alloc::shared);
+  std::cout << "p = " << p << std::endl;
   if (p != nullptr)
     return 4;
   p = malloc(-1, q, usm::alloc::unknown);
+  std::cout << "p = " << p << std::endl;
   if (p != nullptr)
     return 5;
 
   // Bad size, auto aligned
   p = aligned_alloc(0, -1, q,  usm::alloc::host);
+  std::cout << "p = " << p << std::endl;
   if (p != nullptr)
     return 6;
   p = aligned_alloc(0, -1, q,  usm::alloc::device);
+  std::cout << "p = " << p << std::endl;
   if (p != nullptr)
     return 7;
   p = aligned_alloc(0, -1, q,  usm::alloc::shared);
+  std::cout << "p = " << p << std::endl;
   if (p != nullptr)
     return 8;
   p = aligned_alloc(0, -1, q,  usm::alloc::unknown);
+  std::cout << "p = " << p << std::endl;
   if (p != nullptr)
     return 9;
 
   // Allocs of 0 undefined, but bad type
   p = aligned_alloc(4, 0, q,  usm::alloc::unknown);
+  std::cout << "p = " << p << std::endl;
   if (p != nullptr)
     return 10;
 

--- a/sycl/test/usm/badmalloc.cpp
+++ b/sycl/test/usm/badmalloc.cpp
@@ -1,0 +1,45 @@
+// RUN: %clangxx -fsycl %s -o %t1.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %CPU_RUN_PLACEHOLDER %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+
+//==----------------- badmalloc.cpp - Bad Mallocs test ---------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+
+// This test verifies that things fail in the proper way when they should.
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main(int argc, char *argv[]) {
+  queue q;
+
+  // Good size, bad type
+  auto p = malloc(8, q, usm::alloc::unknown);
+  assert(p == nullptr);
+
+  // Bad size, host
+  p = malloc(-1, q, usm::alloc::host);
+  assert(p == nullptr);
+
+  // Bad size, device
+  p = malloc(-1, q, usm::alloc::device);
+  assert(p == nullptr);
+
+  // Bad size, shared
+  p = malloc(-1, q, usm::alloc::shared);
+  assert(p == nullptr);
+
+  // Bad size, unknown
+  p = malloc(-1, q, usm::alloc::unknown);
+  assert(p == nullptr);
+
+  return 0;
+}

--- a/sycl/test/usm/badmalloc.cpp
+++ b/sycl/test/usm/badmalloc.cpp
@@ -41,5 +41,18 @@ int main(int argc, char *argv[]) {
   p = malloc(-1, q, usm::alloc::unknown);
   assert(p == nullptr);
 
+  // Bad combos for aligned
+  p = aligned_alloc(1, 0, q, usm::alloc::host);
+  assert(p == nullptr);
+
+  p = aligned_alloc(1, 0, q, usm::alloc::device);
+  assert(p == nullptr);
+
+  p = aligned_alloc(1, 0, q, usm::alloc::shared);
+  assert(p == nullptr);
+
+  p = aligned_alloc(1, 0, q, usm::alloc::unknown);
+  assert(p == nullptr);
+
   return 0;
 }

--- a/sycl/test/usm/badmalloc.cpp
+++ b/sycl/test/usm/badmalloc.cpp
@@ -28,17 +28,25 @@ int main(int argc, char *argv[]) {
   // Bad size, host
   p = malloc(-1, q, usm::alloc::host);
   assert(p == nullptr);
-
-  // Bad size, device
   p = malloc(-1, q, usm::alloc::device);
   assert(p == nullptr);
-
-  // Bad size, shared
   p = malloc(-1, q, usm::alloc::shared);
   assert(p == nullptr);
-
-  // Bad size, unknown
   p = malloc(-1, q, usm::alloc::unknown);
+  assert(p == nullptr);
+
+  // Bad size, auto aligned
+  p = aligned_alloc(0, -1, q,  usm::alloc::host);
+  assert(p == nullptr);
+  p = aligned_alloc(0, -1, q,  usm::alloc::device);
+  assert(p == nullptr);
+  p = aligned_alloc(0, -1, q,  usm::alloc::shared);
+  assert(p == nullptr);
+  p = aligned_alloc(0, -1, q,  usm::alloc::unknown);
+  assert(p == nullptr);
+
+  // Allocs of 0 undefined, but bad type
+  p = aligned_alloc(4, 0, q,  usm::alloc::unknown);
   assert(p == nullptr);
 
   return 0;

--- a/sycl/test/usm/badmalloc.cpp
+++ b/sycl/test/usm/badmalloc.cpp
@@ -41,18 +41,5 @@ int main(int argc, char *argv[]) {
   p = malloc(-1, q, usm::alloc::unknown);
   assert(p == nullptr);
 
-  // Bad combos for aligned
-  p = aligned_alloc(1, 0, q, usm::alloc::host);
-  assert(p == nullptr);
-
-  p = aligned_alloc(1, 0, q, usm::alloc::device);
-  assert(p == nullptr);
-
-  p = aligned_alloc(1, 0, q, usm::alloc::shared);
-  assert(p == nullptr);
-
-  p = aligned_alloc(1, 0, q, usm::alloc::unknown);
-  assert(p == nullptr);
-
   return 0;
 }

--- a/sycl/test/usm/badmalloc.cpp
+++ b/sycl/test/usm/badmalloc.cpp
@@ -3,6 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 
+// UNSUPPORTED: windows
+
 //==----------------- badmalloc.cpp - Bad Mallocs test ---------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
Host device wasn't properly handling alloc::unknown.
Also, aligned allocator wasn't failing when it really should, so check to throw an error.

Signed-off-by: James Brodman <james.brodman@intel.com>