### PR TITLE
[SYCL] Refactor code in platform_impl.cpp.

### DIFF
--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -10,7 +10,6 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/force_device.hpp>
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/platform_info.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -41,15 +41,7 @@ public:
   ///
   /// @param ExtensionName is a string containing extension name.
   /// @return true if platform supports specified extension.
-  bool has_extension(const string_class &ExtensionName) const {
-    if (is_host())
-      return false;
-
-    string_class AllExtensionNames =
-        get_platform_info<string_class, info::platform::extensions>::get(
-            MPlatform);
-    return (AllExtensionNames.find(ExtensionName) != std::string::npos);
-  }
+  bool has_extension(const string_class &ExtensionName) const;
 
   /// Returns all SYCL devices associated with this platform.
   ///
@@ -68,26 +60,13 @@ public:
   /// The return type depends on information being queried.
   template <info::platform param>
   typename info::param_traits<info::platform, param>::return_type
-  get_info() const {
-    if (is_host())
-      return get_platform_info_host<param>();
-
-    return get_platform_info<
-        typename info::param_traits<info::platform, param>::return_type,
-        param>::get(this->getHandleRef());
-  }
+  get_info() const;
 
   /// @return true if this SYCL platform is a host platform.
   bool is_host() const { return MHostPlatform; };
 
   /// @return an instance of OpenCL cl_platform_id.
-  cl_platform_id get() const {
-    if (is_host())
-      throw invalid_object_error(
-          "This instance of platform is a host instance");
-
-    return pi::cast<cl_platform_id>(MPlatform);
-  }
+  cl_platform_id get() const;
 
   /// Returns raw underlying plug-in platform handle.
   ///
@@ -96,13 +75,7 @@ public:
   /// is in use.
   ///
   /// @return a raw plug-in platform handle.
-  const RT::PiPlatform &getHandleRef() const {
-    if (is_host())
-      throw invalid_object_error(
-          "This instance of platform is a host instance");
-
-    return MPlatform;
-  }
+  const RT::PiPlatform &getHandleRef() const;
 
   /// Returns all available SYCL platforms in the system.
   ///

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -66,7 +66,13 @@ public:
   bool is_host() const { return MHostPlatform; };
 
   /// @return an instance of OpenCL cl_platform_id.
-  cl_platform_id get() const;
+  cl_platform_id get() const {
+    if (is_host())
+      throw invalid_object_error(
+          "This instance of platform is a host instance");
+
+    return pi::cast<cl_platform_id>(MPlatform);
+  }
 
   /// Returns raw underlying plug-in platform handle.
   ///
@@ -75,7 +81,13 @@ public:
   /// is in use.
   ///
   /// @return a raw plug-in platform handle.
-  const RT::PiPlatform &getHandleRef() const;
+  const RT::PiPlatform &getHandleRef() const {
+    if (is_host())
+      throw invalid_object_error(
+          "This instance of platform is a host instance");
+
+    return MPlatform;
+  }
 
   /// Returns all available SYCL platforms in the system.
   ///

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -8,6 +8,7 @@
 
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/platform_impl.hpp>
+#include <CL/sycl/detail/platform_info.hpp>
 #include <CL/sycl/device.hpp>
 #include <detail/config.hpp>
 
@@ -227,6 +228,48 @@ platform_impl::get_devices(info::device_type DeviceType) const {
 
   return Res;
 }
+
+bool platform_impl::has_extension(const string_class &ExtensionName) const {
+  if (is_host())
+    return false;
+
+  string_class AllExtensionNames =
+      get_platform_info<string_class, info::platform::extensions>::get(
+          MPlatform);
+  return (AllExtensionNames.find(ExtensionName) != std::string::npos);
+}
+
+template <info::platform param>
+typename info::param_traits<info::platform, param>::return_type
+platform_impl::get_info() const {
+  if (is_host())
+    return get_platform_info_host<param>();
+
+  return get_platform_info<
+      typename info::param_traits<info::platform, param>::return_type,
+      param>::get(this->getHandleRef());
+}
+
+cl_platform_id platform_impl::get() const {
+  if (is_host())
+    throw invalid_object_error("This instance of platform is a host instance");
+
+  return pi::cast<cl_platform_id>(MPlatform);
+}
+
+const RT::PiPlatform &platform_impl::getHandleRef() const {
+  if (is_host())
+    throw invalid_object_error("This instance of platform is a host instance");
+
+  return MPlatform;
+}
+
+#define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
+  template ret_type platform_impl::get_info<info::param_type::param>() const;
+
+#include <CL/sycl/info/platform_traits.def>
+#undef PARAM_TRAITS_SPEC
+
 } // namespace detail
 } // namespace sycl
 } // namespace cl

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -250,20 +250,6 @@ platform_impl::get_info() const {
       param>::get(this->getHandleRef());
 }
 
-cl_platform_id platform_impl::get() const {
-  if (is_host())
-    throw invalid_object_error("This instance of platform is a host instance");
-
-  return pi::cast<cl_platform_id>(MPlatform);
-}
-
-const RT::PiPlatform &platform_impl::getHandleRef() const {
-  if (is_host())
-    throw invalid_object_error("This instance of platform is a host instance");
-
-  return MPlatform;
-}
-
 #define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \
   template ret_type platform_impl::get_info<info::param_type::param>() const;
 


### PR DESCRIPTION
Moved all platform_impl.hpp definitions into .cpp code.
This is required to remove dependency of platform_info.hpp in
platform_impl.hpp.
We need to avoid circular file dependency of the files when
platform_impl.hpp is included in platform_info.hpp.
We need to use platform_impl class and it's members in get_info method.

Signed-off-by: Garima Gupta <garima.gupta@intel.com>