### PR TITLE
[SYCL] Enable vtable emission in Clang CodeGen

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -2491,7 +2491,8 @@ void CodeGenFunction::InitializeVTablePointer(const VPtr &Vptr) {
       llvm::FunctionType::get(CGM.Int32Ty, /*isVarArg=*/true)
           ->getPointerTo()
           ->getPointerTo();
-  VTableField = Builder.CreateBitCast(VTableField, VTablePtrTy->getPointerTo());
+  VTableField = Builder.CreateBitCast(VTableField, VTablePtrTy->getPointerTo(
+      VTableField.getType()->getAddressSpace()));
   VTableAddressPoint = Builder.CreateBitCast(VTableAddressPoint, VTablePtrTy);
 
   llvm::StoreInst *Store = Builder.CreateStore(VTableAddressPoint, VTableField);

--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -749,10 +749,6 @@ llvm::StructType *CodeGenTypes::ConvertRecordDeclType(const RecordDecl *RD) {
     return Ty;
   }
 
-  assert((!Context.getLangOpts().SYCLIsDevice || !isa<CXXRecordDecl>(RD) ||
-          !dyn_cast<CXXRecordDecl>(RD)->isPolymorphic()) &&
-         "Types with virtual functions not allowed in SYCL");
-
   // Okay, this is a definition of a type.  Compile the implementation now.
   bool InsertResult = RecordsBeingLaidOut.insert(Key).second;
   (void)InsertResult;

--- a/clang/test/CodeGenSYCL/virtual-types.cpp
+++ b/clang/test/CodeGenSYCL/virtual-types.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+struct Struct {
+  virtual void foo() {}
+  void bar() {}
+};
+
+int main() {
+  kernel_single_task<class kernel_function>([]() {
+                                            Struct S;
+                                            S.bar(); });
+  return 0;
+}
+
+
+// Struct layout big enough for vtable.
+// CHECK: %struct._ZTS6Struct.Struct = type { i32 (...)** }
+// VTable:
+// CHECK: @_ZTV6Struct = linkonce_odr unnamed_addr constant { [3 x i8*] } { [3 x i8*] [i8* null, i8* bitcast ({ i8*, i8* }* @_ZTI6Struct to i8*), i8* bitcast (void (%struct._ZTS6Struct.Struct addrspace(4)*)* @_ZN6Struct3fooEv to i8*)] }, comdat, align 8
+// CHECK: @[[TYPEINFO:.+]] = external global i8*
+// TypeInfo Name:
+// CHECK: @_ZTS6Struct = linkonce_odr constant [8 x i8] c"6Struct\00", comdat, align 1
+// TypeInfo:
+// CHECK: @_ZTI6Struct = linkonce_odr constant { i8*, i8* } { i8* bitcast (i8** getelementptr inbounds (i8*, i8** @[[TYPEINFO]], i64 2) to i8*), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @_ZTS6Struct, i32 0, i32 0) }, comdat, align 8


### PR DESCRIPTION
My previous patch started permitting types with vtables to pass through
semantic analysis, however the vtable emission for the types had a pair
of asserts.  This removes the 1, and fixes the other, which was that
vtables assumed AS0.

Signed-off-by: Erich Keane <erich.keane@intel.com>