### PR TITLE
[SYCL] Make host device and host platform always available, even when forcin…

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -40,8 +40,8 @@ vector_class<platform> platform_impl::get_platforms() {
     }
   }
 
-  if (ForcedType == info::device_type::host || ForcedType == info::device_type::all)
-    Platforms.emplace_back(platform());
+  // The host platform should always be available.
+  Platforms.emplace_back(platform());
 
   return Platforms;
 }

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -46,10 +46,8 @@ vector_class<device> device::get_devices(info::device_type deviceType) {
         vector_class<device> host_device(
             plt.get_devices(info::device_type::host));
         if (!host_device.empty())
-          devices.insert(devices.end(), host_device.begin(),
-                         host_device.end());
-      }
-      else {
+          devices.insert(devices.end(), host_device.begin(), host_device.end());
+      } else {
         vector_class<device> found_devices(plt.get_devices(deviceType));
         if (!found_devices.empty())
           devices.insert(devices.end(), found_devices.begin(),

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -41,10 +41,20 @@ vector_class<device> device::get_devices(info::device_type deviceType) {
   if (detail::match_types(deviceType, forced_type)) {
     detail::force_type(deviceType, forced_type);
     for (const auto &plt : platform::get_platforms()) {
-      vector_class<device> found_devices(plt.get_devices(deviceType));
-      if (!found_devices.empty())
-        devices.insert(devices.end(), found_devices.begin(),
-                       found_devices.end());
+      // Host device must always be available.
+      if (plt.is_host()) {
+        vector_class<device> host_device(
+            plt.get_devices(info::device_type::host));
+        if (!host_device.empty())
+          devices.insert(devices.end(), host_device.begin(),
+                         host_device.end());
+      }
+      else {
+        vector_class<device> found_devices(plt.get_devices(deviceType));
+        if (!found_devices.empty())
+          devices.insert(devices.end(), found_devices.begin(),
+                         found_devices.end());
+      }
     }
   }
   return devices;

--- a/sycl/test/basic_tests/host_always_works.cpp
+++ b/sycl/test/basic_tests/host_always_works.cpp
@@ -1,0 +1,23 @@
+// RUN: %clangxx -fsycl %s -o %t1.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %CPU_RUN_PLACEHOLDER %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+
+//==------ host_always_works.cpp - Host Device Availability test -----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+class foo;
+int main() {
+  device(host_selector{});
+  
+  return 0;
+}

--- a/sycl/test/basic_tests/host_always_works.cpp
+++ b/sycl/test/basic_tests/host_always_works.cpp
@@ -2,6 +2,7 @@
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
+// RUN: %ACC_RUN_PLACEHOLDER %t1.out
 
 //==------ host_always_works.cpp - Host Device Availability test -----------==//
 //

--- a/sycl/test/basic_tests/host_always_works.cpp
+++ b/sycl/test/basic_tests/host_always_works.cpp
@@ -16,7 +16,6 @@
 
 using namespace cl::sycl;
 
-class foo;
 int main() {
   device(host_selector{});
   

--- a/sycl/test/basic_tests/host_platform_avail.cpp
+++ b/sycl/test/basic_tests/host_platform_avail.cpp
@@ -1,0 +1,41 @@
+// RUN: %clangxx -fsycl %s -o %t1.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %CPU_RUN_PLACEHOLDER %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+
+//==------ host_platform_avail.cpp - Host Platform Availability test -------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+class foo;
+int main() {
+  queue q;
+  auto dev = q.get_device();
+  auto dev_platform = dev.get_platform();
+
+  if (!dev_platform.is_host()) {
+    auto plats = platform::get_platforms();
+    bool found_host = false;
+
+    // Look for a host platform
+    for (const auto &plat : plats)  {
+      if (plat.is_host()) {
+        found_host = true;
+      }
+    }
+    // Fail if we didn't find a host platform
+    if (!found_host)
+      return 1;
+  }
+
+  // Found a host platform, all is well
+  return 0;
+}

--- a/sycl/test/basic_tests/host_platform_avail.cpp
+++ b/sycl/test/basic_tests/host_platform_avail.cpp
@@ -2,6 +2,7 @@
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
+// RUN: %ACC_RUN_PLACEHOLDER %t1.out
 
 //==------ host_platform_avail.cpp - Host Platform Availability test -------==//
 //

--- a/sycl/test/basic_tests/host_platform_avail.cpp
+++ b/sycl/test/basic_tests/host_platform_avail.cpp
@@ -16,27 +16,17 @@
 
 using namespace cl::sycl;
 
-class foo;
 int main() {
-  queue q;
-  auto dev = q.get_device();
-  auto dev_platform = dev.get_platform();
+  auto plats = platform::get_platforms();
+  bool found_host = false;
 
-  if (!dev_platform.is_host()) {
-    auto plats = platform::get_platforms();
-    bool found_host = false;
-
-    // Look for a host platform
-    for (const auto &plat : plats)  {
-      if (plat.is_host()) {
-        found_host = true;
-      }
+  // Look for a host platform
+  for (const auto &plat : plats)  {
+    if (plat.is_host()) {
+      found_host = true;
     }
-    // Fail if we didn't find a host platform
-    if (!found_host)
-      return 1;
   }
 
-  // Found a host platform, all is well
-  return 0;
+  // Fail if we didn't find a host platform
+  return (!found_host);
 }


### PR DESCRIPTION
…g a device type with SYCL_DEVICE_TYPE

The current behavior violates the SYCL Specification.  The host device/platform should always be available.

int main() { 
  device myHost(host_selector{});
  return 0;
}

That fails when run with SYCL_DEVICE_TYPE=CPU/GPU/ACC and it shouldn't.

Signed-off-by: James Brodman <james.brodman@intel.com>