### PR TITLE
[SYCL][FPGA] Changing the attribute max_private_copies to private_copes

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1721,12 +1721,12 @@ def IntelFPGANumBanks : Attr {
   }];
 }
 
-def IntelFPGAMaxPrivateCopies : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","max_private_copies">];
+def IntelFPGAPrivateCopies : InheritableAttr {
+  let Spellings = [CXX11<"intelfpga","private_copies">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[IntelFPGALocalNonConstVar, Field], ErrorDiag>;
-  let Documentation = [IntelFPGAMaxPrivateCopiesAttrDocs];
+  let Documentation = [IntelFPGAPrivateCopiesAttrDocs];
   let AdditionalMembers = [{
     static unsigned getMinValue() {
       return 0;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1876,9 +1876,9 @@ with N banks.
   }];
 }
 
-def IntelFPGAMaxPrivateCopiesAttrDocs : Documentation {
+def IntelFPGAPrivateCopiesAttrDocs : Documentation {
   let Category = DocCatVariable;
-  let Heading = "max_private_copies (IntelFPGA)";
+  let Heading = "private_copies (IntelFPGA)";
   let Content = [{
 This attribute may be attached to a variable or struct member declaration and
 instructs the backend to replicate the memory generated for the variable or

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3975,9 +3975,9 @@ void CodeGenModule::generateIntelFPGAAnnotation(
     llvm::APSInt BWAInt = BWA->getValue()->EvaluateKnownConstInt(getContext());
     Out << '{' << BWA->getSpelling() << ':' << BWAInt << '}';
   }
-  if (const auto *MCA = D->getAttr<IntelFPGAMaxPrivateCopiesAttr>()) {
+  if (const auto *MCA = D->getAttr<IntelFPGAPrivateCopiesAttr>()) {
     llvm::APSInt MCAInt = MCA->getValue()->EvaluateKnownConstInt(getContext());
-    Out << '{' << MCA->getSpelling() << ':' << MCAInt << '}';
+    Out << "{max_private_copies:" << MCAInt << '}';
   }
   if (const auto *NBA = D->getAttr<IntelFPGANumBanksAttr>()) {
     llvm::APSInt NBAInt = NBA->getValue()->EvaluateKnownConstInt(getContext());

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3877,7 +3877,7 @@ void Sema::AddOneConstantValueAttr(Decl *D, const AttributeCommonInfo &CI,
     E = ICE.get();
   }
 
-  if (IntelFPGAMaxPrivateCopiesAttr::classof(&TmpAttr)) {
+  if (IntelFPGAPrivateCopiesAttr::classof(&TmpAttr)) {
     if (!D->hasAttr<IntelFPGAMemoryAttr>())
       D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
           Context, IntelFPGAMemoryAttr::Default));
@@ -5243,7 +5243,7 @@ static bool checkIntelFPGARegisterAttrCompatibility(Sema &S, Decl *D,
     InCompat = true;
   if (checkAttrMutualExclusion<IntelFPGABankWidthAttr>(S, D, Attr))
     InCompat = true;
-  if (checkAttrMutualExclusion<IntelFPGAMaxPrivateCopiesAttr>(S, D, Attr))
+  if (checkAttrMutualExclusion<IntelFPGAPrivateCopiesAttr>(S, D, Attr))
     InCompat = true;
   if (auto *NBA = D->getAttr<IntelFPGANumBanksAttr>())
     if (!NBA->isImplicit() &&
@@ -5447,17 +5447,17 @@ void Sema::AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
                  IntelFPGABankBitsAttr(Context, CI, Args.data(), Args.size()));
 }
 
-static void handleIntelFPGAMaxPrivateCopiesAttr(Sema &S, Decl *D,
+static void handleIntelFPGAPrivateCopiesAttr(Sema &S, Decl *D,
                                               const ParsedAttr &Attr) {
 
   if (S.LangOpts.SYCLIsHost)
     return;
 
-  checkForDuplicateAttribute<IntelFPGAMaxPrivateCopiesAttr>(S, D, Attr);
+  checkForDuplicateAttribute<IntelFPGAPrivateCopiesAttr>(S, D, Attr);
   if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
     return;
 
-  S.AddOneConstantValueAttr<IntelFPGAMaxPrivateCopiesAttr>(
+  S.AddOneConstantValueAttr<IntelFPGAPrivateCopiesAttr>(
       D, Attr, Attr.getArgAsExpr(0));
 }
 
@@ -7965,8 +7965,8 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_IntelFPGANumBanks:
     handleOneConstantPowerTwoValueAttr<IntelFPGANumBanksAttr>(S, D, AL);
     break;
-  case ParsedAttr::AT_IntelFPGAMaxPrivateCopies:
-    handleIntelFPGAMaxPrivateCopiesAttr(S, D, AL);
+  case ParsedAttr::AT_IntelFPGAPrivateCopies:
+    handleIntelFPGAPrivateCopiesAttr(S, D, AL);
     break;
   case ParsedAttr::AT_IntelFPGAMaxReplicates:
     handleIntelFPGAMaxReplicatesAttr(S, D, AL);

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -56,7 +56,7 @@ struct foo_two {
   int f2 [[intelfpga::register]];
   int f3 [[intelfpga::memory]];
   int f4 [[intelfpga::bankwidth(4)]];
-  int f5 [[intelfpga::max_private_copies(8)]];
+  int f5 [[intelfpga::private_copies(8)]];
   int f6 [[intelfpga::singlepump]];
   int f7 [[intelfpga::doublepump]];
   int f8 [[intelfpga::merge("foo", "depth")]];
@@ -130,7 +130,7 @@ void baz() {
   // CHECK-DEVICE: %[[V_SEVEN:[0-9]+]] = bitcast{{.*}}v_seven
   // CHECK-DEVICE: %[[V_SEVEN1:v_seven[0-9]+]] = bitcast{{.*}}v_seven
   // CHECK-DEVICE: llvm.var.annotation{{.*}}%[[V_SEVEN1]],{{.*}}[[ANN9]]
-  int v_seven [[intelfpga::max_private_copies(4)]];
+  int v_seven [[intelfpga::private_copies(4)]];
   // CHECK-DEVICE: %[[V_EIGHT:[0-9]+]] = bitcast{{.*}}v_eight
   // CHECK-DEVICE: %[[V_EIGHT1:v_eight[0-9]+]] = bitcast{{.*}}v_eight
   // CHECK-DEVICE: llvm.var.annotation{{.*}}%[[V_EIGHT1]],{{.*}}[[ANN10]]

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -45,10 +45,10 @@ void foo1()
 
   //CHECK: VarDecl{{.*}}v_seven
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGAMaxPrivateCopiesAttr
+  //CHECK: IntelFPGAPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  [[intelfpga::max_private_copies(8)]] unsigned int v_seven[64];
+  [[intelfpga::private_copies(8)]] unsigned int v_seven[64];
 
   //CHECK: VarDecl{{.*}}v_ten
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
@@ -202,7 +202,7 @@ void foo1()
 
   //expected-error@+2{{attributes are not compatible}}
   [[intelfpga::register]]
-  [[intelfpga::max_private_copies(16)]]
+  [[intelfpga::private_copies(16)]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_six_two[64];
 
@@ -304,37 +304,37 @@ void foo1()
   unsigned int bw_seven[64];
 
 
-  // max_private_copies_
+  // private_copies_
   //expected-error@+2{{attributes are not compatible}}
-  [[intelfpga::max_private_copies(16)]]
+  [[intelfpga::private_copies(16)]]
   [[intelfpga::register]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int mc_one[64];
 
   //CHECK: VarDecl{{.*}}mc_two
-  //CHECK: IntelFPGAMaxPrivateCopiesAttr
+  //CHECK: IntelFPGAPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  //CHECK: IntelFPGAMaxPrivateCopiesAttr
+  //CHECK: IntelFPGAPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}16{{$}}
   //expected-warning@+2{{is already applied}}
-  [[intelfpga::max_private_copies(8)]]
-  [[intelfpga::max_private_copies(16)]]
+  [[intelfpga::private_copies(8)]]
+  [[intelfpga::private_copies(16)]]
   unsigned int mc_two[64];
 
-  //expected-error@+1{{'max_private_copies' attribute requires integer constant between 0 and 1048576 inclusive}}
-  [[intelfpga::max_private_copies(-4)]]
+  //expected-error@+1{{'private_copies' attribute requires integer constant between 0 and 1048576 inclusive}}
+  [[intelfpga::private_copies(-4)]]
   unsigned int mc_four[64];
 
-  int i_max_private_copies = 32; // expected-note {{declared here}}
+  int i_private_copies = 32; // expected-note {{declared here}}
   //expected-error@+1{{expression is not an integral constant expression}}
-  [[intelfpga::max_private_copies(i_max_private_copies)]]
-  //expected-note@-1{{read of non-const variable 'i_max_private_copies' is not allowed in a constant expression}}
+  [[intelfpga::private_copies(i_private_copies)]]
+  //expected-note@-1{{read of non-const variable 'i_private_copies' is not allowed in a constant expression}}
   unsigned int mc_five[64];
 
-  //expected-error@+1{{'max_private_copies' attribute takes one argument}}
-  [[intelfpga::max_private_copies(4,8)]]
+  //expected-error@+1{{'private_copies' attribute takes one argument}}
+  [[intelfpga::private_copies(4,8)]]
   unsigned int mc_six[64];
 
   // numbanks
@@ -476,8 +476,8 @@ void foo1()
   //expected-warning@+1{{unknown attribute '__doublepump__' ignored}}
   unsigned int __attribute__((__doublepump__)) a_six;
 
-  //expected-warning@+1{{unknown attribute '__max_private_copies__' ignored}}
-  int __attribute__((__max_private_copies__(4))) a_seven;
+  //expected-warning@+1{{unknown attribute '__private_copies__' ignored}}
+  int __attribute__((__private_copies__(4))) a_seven;
 
   //expected-warning@+1{{unknown attribute '__merge__' ignored}}
   int __attribute__((__merge__("mrg1","depth"))) a_eight;
@@ -493,17 +493,17 @@ void foo1()
 }
 
 //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
-[[intelfpga::max_private_copies(8)]]
+[[intelfpga::private_copies(8)]]
 __attribute__((opencl_constant)) unsigned int ext_two[64] = { 1, 2, 3 };
 
 void other2()
 {
   //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
-  [[intelfpga::max_private_copies(8)]] const int ext_six[64] = { 0, 1 };
+  [[intelfpga::private_copies(8)]] const int ext_six[64] = { 0, 1 };
 }
 
 //expected-error@+1{{attribute only applies to local non-const variables and non-static data members}}
-void other3([[intelfpga::max_private_copies(8)]] int pfoo) {}
+void other3([[intelfpga::private_copies(8)]] int pfoo) {}
 
 struct foo {
   //CHECK: FieldDecl{{.*}}v_one
@@ -554,10 +554,10 @@ struct foo {
 
   //CHECK: FieldDecl{{.*}}v_seven
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
-  //CHECK: IntelFPGAMaxPrivateCopiesAttr
+  //CHECK: IntelFPGAPrivateCopiesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-  [[intelfpga::max_private_copies(4)]] unsigned int v_seven[64];
+  [[intelfpga::private_copies(4)]] unsigned int v_seven[64];
 
   //CHECK: FieldDecl{{.*}}v_ten
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit

--- a/clang/test/SemaSYCL/spurious-host-warning.cpp
+++ b/clang/test/SemaSYCL/spurious-host-warning.cpp
@@ -38,9 +38,9 @@ void foo()
   [[intelfpga::numbanks(8)]] unsigned int v_six[32];
 
   #ifndef SYCLHOST
-  // expected-warning@+2 {{'max_private_copies' attribute ignored}}
+  // expected-warning@+2 {{'private_copies' attribute ignored}}
   #endif
-  [[intelfpga::max_private_copies(8)]] unsigned int v_seven[64];
+  [[intelfpga::private_copies(8)]] unsigned int v_seven[64];
 
   #ifndef SYCLHOST
   // expected-warning@+2 {{'merge' attribute ignored}}


### PR DESCRIPTION
The IR coming out of this does not change. This allows the llvm-spirv
translator to not be affected. This should probably be fixed in the future
(in the SPIRV spec) for consistency.