### PR TITLE
[SYCL] Fix requirements for aot tests

### DIFF
--- a/sycl/test/aot/accelerator.cpp
+++ b/sycl/test/aot/accelerator.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aoc
+// REQUIRES: aoc, accelerator
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out

--- a/sycl/test/aot/cpu.cpp
+++ b/sycl/test/aot/cpu.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: opencl-aot
+// REQUIRES: opencl-aot, cpu
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out

--- a/sycl/test/aot/gpu.cpp
+++ b/sycl/test/aot/gpu.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: ocloc
+// REQUIRES: ocloc, gpu
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out

--- a/sycl/test/aot/multiple-devices.cpp
+++ b/sycl/test/aot/multiple-devices.cpp
@@ -6,7 +6,7 @@
 //
 //===------------------------------------------------------------------------===//
 
-// REQUIRES: opencl-aot, ocloc, aoc
+// REQUIRES: opencl-aot, ocloc, aoc, cpu, gpu, accelerator
 
 // 1-command compilation case
 // Targeting CPU, GPU, FPGA

--- a/sycl/test/device-code-split/aot-accelerator.cpp
+++ b/sycl/test/device-code-split/aot-accelerator.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aoc
+// REQUIRES: aoc, accelerator
 
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice -I %S/Inputs -o %t.out %S/split-per-source-main.cpp %S/Inputs/split-per-source-second-file.cpp
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/device-code-split/aot-gpu.cpp
+++ b/sycl/test/device-code-split/aot-gpu.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: ocloc
+// REQUIRES: ocloc, gpu
 
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" -I %S/Inputs -o %t.out %S/split-per-source-main.cpp %S/Inputs/split-per-source-second-file.cpp
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -150,6 +150,7 @@ if getDeviceCount("accelerator"):
     print("Found available accelerator device")
     acc_run_substitute = " env SYCL_DEVICE_TYPE=ACC "
     acc_check_substitute = "| FileCheck %s"
+    config.available_features.add('accelerator')
 config.substitutions.append( ('%ACC_RUN_PLACEHOLDER',  acc_run_substitute) )
 config.substitutions.append( ('%ACC_CHECK_PLACEHOLDER',  acc_check_substitute) )
 


### PR DESCRIPTION
Currently tests for aot require only existence of the tools for aot in
the PATH. But this is not enough, for successful aot compilation
corresponding platform must be available.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>