### PR TITLE
[SYCL] Change a check for a device compiler availability

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -197,21 +197,26 @@ static bool isDeviceBinaryTypeSupported(const context &C,
   if (Format != PI_DEVICE_BINARY_TYPE_SPIRV)
     return true;
 
+  vector_class<device> Devices = C.get_devices();
+
+  // Program type is SPIR-V, so we need a device compiler to do JIT.
+  for (const device &D : Devices) {
+    if (!D.get_info<info::device::is_compiler_available>())
+      return false;
+  }
+
   // OpenCL 2.1 and greater require clCreateProgramWithIL
   if (pi::useBackend(pi::SYCL_BE_PI_OPENCL) &&
       C.get_platform().get_info<info::platform::version>() >= "2.1")
     return true;
 
-  for (const device &D : C.get_devices()) {
+  for (const device &D : Devices) {
     // We need cl_khr_il_program extension to be present
     // and we can call clCreateProgramWithILKHR using the extension
     vector_class<string_class> Extensions =
         D.get_info<info::device::extensions>();
     if (Extensions.end() ==
         std::find(Extensions.begin(), Extensions.end(), "cl_khr_il_program"))
-      return false;
-
-    if (!D.get_info<info::device::is_compiler_available>())
       return false;
   }
 


### PR DESCRIPTION
Before this patch we checked for a device compiler in
ProgramManager::build, but this function is called for AOT compiled
programs as well as required by the OpenCL specification:

    clBuildProgram must be called for program created using either
    clCreateProgramWithSource or clCreateProgramWithBinary to build
    the program executable for one or more devices associated with
    program.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>