### PR TITLE
[SYCL] Move variadic call diagnostics to delayed diagnostics, fixes.

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12015,6 +12015,11 @@ private:
   // is associated with.
   std::unique_ptr<SYCLIntegrationHeader> SyclIntHeader;
 
+  // Used to suppress diagnostics during kernel construction, since these were
+  // already emitted earlier. Diagnosing during Kernel emissions also skips the
+  // useful notes that shows where the kernel was called.
+  bool ConstructingOpenCLKernel = false;
+
 public:
   void addSyclDeviceDecl(Decl *d) { SyclDeviceDecls.push_back(d); }
   SmallVectorImpl<Decl *> &syclDeviceDecls() { return SyclDeviceDecls; }
@@ -12041,6 +12046,7 @@ public:
     KernelCallVariadicFunction
  };
   DeviceDiagBuilder SYCLDiagIfDeviceCode(SourceLocation Loc, unsigned DiagID);
+  bool isKnownGoodSYCLDecl(const Decl *D);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
   void MarkDevice(void);
   bool CheckSYCLCall(SourceLocation Loc, FunctionDecl *Callee);

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5380,6 +5380,12 @@ bool Sema::GatherArgumentsForCall(SourceLocation CallLoc, FunctionDecl *FDecl,
 
     // Otherwise do argument promotion, (C99 6.5.2.2p7).
     } else {
+      // Diagnose variadic calls in SYCL.
+      if (getLangOpts().SYCLIsDevice && !isUnevaluatedContext() &&
+          !isKnownGoodSYCLDecl(FDecl))
+        SYCLDiagIfDeviceCode(CallLoc, diag::err_sycl_restrict)
+            << Sema::KernelCallVariadicFunction;
+
       for (Expr *A : Args.slice(ArgIx)) {
         ExprResult Arg = DefaultVariadicArgumentPromotion(A, CallType, FDecl);
         Invalid |= Arg.isInvalid();

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -14027,6 +14027,11 @@ Sema::BuildCallToObjectOfClassType(Scope *S, Expr *Obj,
 
   // If this is a variadic call, handle args passed through "...".
   if (Proto->isVariadic()) {
+    // Diagnose variadic calls in SYCL.
+    if (getLangOpts().SYCLIsDevice && !isUnevaluatedContext())
+      SYCLDiagIfDeviceCode(LParenLoc, diag::err_sycl_restrict)
+          << Sema::KernelCallVariadicFunction;
+
     // Promote the arguments (C99 6.5.2.2p7).
     for (unsigned i = NumParams, e = Args.size(); i < e; i++) {
       ExprResult Arg = DefaultVariadicArgumentPromotion(Args[i], VariadicMethod,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1407,7 +1407,7 @@ Sema::DeviceDiagBuilder Sema::SYCLDiagIfDeviceCode(SourceLocation Loc,
                                                    unsigned DiagID) {
   assert(getLangOpts().SYCLIsDevice &&
          "Should only be called during SYCL compilation");
-  FunctionDecl *FD = dyn_cast<FunctionDecl>(CurContext);
+  FunctionDecl *FD = dyn_cast<FunctionDecl>(getCurLexicalContext());
   DeviceDiagBuilder::Kind DiagKind = [this, FD] {
     if (ConstructingOpenCLKernel || (FD && FD->isDependentContext()))
       return DeviceDiagBuilder::K_Nop;

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -4685,7 +4685,6 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         // OpenCL doesn't support variadic functions and blocks
         // (s6.9.e and s6.12.5 OpenCL v2.0) except for printf.
         // We also allow here any toolchain reserved identifiers.
-        // FIXME: Use deferred diagnostics engine to skip host side issues.
         if (FTI.isVariadic &&
             !LangOpts.SYCLIsDevice &&
             !(D.getIdentifier() &&

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -21,11 +21,13 @@ void bar() {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  // expected-note@+1 {{called by 'kernel_single_task<fake_kernel, (lambda}}
   kernelFunc();
 }
 
 int main() {
   foo();
+  // expected-note@+1 {{called by 'operator()'}}
   kernel_single_task<class fake_kernel>([]() { bar(); });
   return 0;
 }

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -8,7 +8,7 @@ __inline __cdecl __attribute__((sycl_device)) int foo() { return 0; }
 __inline __cdecl int moo() { return 0; }
 
 void bar() {
-  printf("hello\n"); // expected-no-error
+  //printf("hello\n"); // expected-no-error
 }
 
 template <typename name, typename Func>
@@ -18,10 +18,12 @@ __cdecl __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   printf("cannot call from here\n");
   // expected-no-error@+1
   moo();
+  // expected-note@+1{{called by}}
   kernelFunc();
 }
 
 int main() {
+  //expected-note@+2 {{in instantiation of}}
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
   kernel_single_task<class fake_kernel>([]() { printf("world\n"); });
   bar();

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -8,7 +8,7 @@ __inline __cdecl __attribute__((sycl_device)) int foo() { return 0; }
 __inline __cdecl int moo() { return 0; }
 
 void bar() {
-  //printf("hello\n"); // expected-no-error
+  printf("hello\n"); // expected-no-error
 }
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -124,6 +124,7 @@ void eh_not_ok(void)
 
 void usage(myFuncDef functionPtr) {
 
+  // expected-note@+1 {{called by 'usage'}}
   eh_not_ok();
 
 #if ALLOW_FP
@@ -169,7 +170,6 @@ int use2 ( a_type ab, a_type *abp ) {
   return ns::glob +
   // expected-error@+1 {{SYCL kernel cannot use a global variable}}
     AnotherNS::moar_globals;
-  // expected-note@+1 {{called by 'use2'}}
   eh_not_ok();
   Check_RTTI_Restriction:: A *a;
   Check_RTTI_Restriction:: isa_B(a);
@@ -180,15 +180,16 @@ int use2 ( a_type ab, a_type *abp ) {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  // expected-note@+1 {{called by 'kernel_single_task}}
   kernelFunc();
   a_type ab;
   a_type *p;
-  // expected-note@+1 {{called by 'kernel_single_task'}}
   use2(ab, p);
 }
 
 int main() {
   a_type ab;
+  // expected-note@+1 {{called by 'operator()'}}
   kernel_single_task<class fake_kernel>([]() { usage(  &addInt ); });
   return 0;
 }

--- a/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
@@ -39,7 +39,7 @@ void bar() {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
-  kernelFunc();
+  kernelFunc(); //expected-note 2+ {{called by 'kernel_single_task}}
 }
 
 int main() {

--- a/clang/test/SemaSYCL/variadic-func-call.cpp
+++ b/clang/test/SemaSYCL/variadic-func-call.cpp
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -fsycl-is-device -fsyntax-only -verify %s
+
+void variadic(int, ...);
+namespace NS {
+void variadic(int, ...);
+}
+
+struct S {
+  S(int, ...);
+  void operator()(int, ...);
+};
+
+void foo() {
+  auto x = [](int, ...) {};
+  x(5, 10); //expected-error{{SYCL kernel cannot call a variadic function}}
+}
+
+void overloaded(int, int);
+void overloaded(int, ...);
+template <typename, typename Func>
+__attribute__((sycl_kernel)) void task(Func KF) {
+  KF(); // expected-note 2 {{called by 'task}}
+}
+
+int main() {
+  task<class FK>([]() {
+    variadic(5);        //expected-error{{SYCL kernel cannot call a variadic function}}
+    variadic(5, 2);     //expected-error{{SYCL kernel cannot call a variadic function}}
+    NS::variadic(5, 3); //expected-error{{SYCL kernel cannot call a variadic function}}
+    S s(5, 4);          //expected-error{{SYCL kernel cannot call a variadic function}}
+    S s2(5);            //expected-error{{SYCL kernel cannot call a variadic function}}
+    s(5, 5);            //expected-error{{SYCL kernel cannot call a variadic function}}
+    s2(5);              //expected-error{{SYCL kernel cannot call a variadic function}}
+    foo();              //expected-note{{called by 'operator()'}}
+    overloaded(5, 6);   //expected-no-error
+    overloaded(5, s);   //expected-error{{SYCL kernel cannot call a variadic function}}
+    overloaded(5);      //expected-error{{SYCL kernel cannot call a variadic function}}
+  });
+}


### PR DESCRIPTION
One of our downstreams requires using the variadic call diagnostics from
SYCL, however the SemaSYCL AST walker ends up being messy. This patch
initially removes the check from the AST walker and instead implements
its in normal SEMA via the delayed diagnostics mechanism.

However, while evaluating this, we discovered that there are quite a few
issues with how the diagnostics are emitted, so this patch includes
quite a few cleanups to make sure the diagnostics are emitted properly.
This results in some additional notes in some of the test.

Additionally, the asm checks were previously implemented in BOTH delayed
diagnostics as well as the AST walker, since the bugs in each aligned to
have full coverage.  This patch ends up removing it from the AST walking
code since the other bugs were fixed.

Signed-off-by: Erich Keane <erich.keane@intel.com>