### PR TITLE
[SYCL][NFC] Add missing __SYCL_INLINE

### DIFF
--- a/sycl/include/CL/sycl/intel/builtins.hpp
+++ b/sycl/include/CL/sycl/intel/builtins.hpp
@@ -18,7 +18,7 @@ extern int __spirv_ocl_printf(const CONSTANT_AS char *__format, ...);
 #define CONSTANT_AS
 #endif
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 namespace intel {
 namespace experimental {

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -11,7 +11,7 @@
 
 #include <vector>
 
-namespace cl {
+__SYCL_INLINE namespace cl {
 namespace sycl {
 
 program::program(const context &context)


### PR DESCRIPTION
One of the missed spots was introduced in intel/llvm#835, another one
was missed in intel/llvm#986

Signed-off-by: Alexey Sachkov <alexey.sachkov@intel.com>