### PR TITLE
[SYCL] Fix segfault upon initial complex call to set_final_data(null)

### DIFF
--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -165,11 +165,14 @@ public:
 
   template <typename Destination>
   EnableIfOutputPointerT<Destination> set_final_data(Destination FinalData) {
-    MUploadDataFunctor = [this, FinalData]() {
-      EventImplPtr Event = updateHostMemory(FinalData);
-      if (Event)
-        Event->wait(Event);
-    };
+    if (!FinalData)
+      MUploadDataFunctor = nullptr;
+    else
+      MUploadDataFunctor = [this, FinalData]() {
+        EventImplPtr Event = updateHostMemory(FinalData);
+        if (Event)
+          Event->wait(Event);
+      };
   }
 
   template <typename Destination>

--- a/sycl/test/basic_tests/image.cpp
+++ b/sycl/test/basic_tests/image.cpp
@@ -75,13 +75,12 @@ int main() {
 
   // image wioth write accessor to it in kernel
   {
-    int NX = 1024;
-    int NY = 1024;
+    int NX = 32;
+    int NY = 32;
 
     sycl::image<2> Img(sycl::image_channel_order::rgba,
                        sycl::image_channel_type::fp32,
                        sycl::range<2>(NX, NY));
-    //img.set_final_data();
 
     sycl::queue Q;
     Q.submit([&](sycl::handler &CGH) {

--- a/sycl/test/basic_tests/image.cpp
+++ b/sycl/test/basic_tests/image.cpp
@@ -73,7 +73,7 @@ int main() {
     });
   }
 
-  // image wioth write accessor to it in kernel
+  // image with write accessor to it in kernel
   {
     int NX = 32;
     int NY = 32;


### PR DESCRIPTION
A complex call is:
-- snip start --
char *ptr = reinterpret_cast<char *>(nullptr);
sycl_obj.set_final_data(ptr);
-- snip end --

Signed-off-by: Sergey Kanaev <sergey.kanaev@intel.com>