### PR TITLE
[SYCL][Driver] Prevent duplication of error diagnostics for -fsycl

### DIFF
--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -214,10 +214,11 @@ static bool ActionFailed(const Action *A,
   if (FailingCommands.empty())
     return false;
 
-  // CUDA/HIP can have the same input source code compiled multiple times so do
-  // not compiled again if there are already failures. It is OK to abort the
-  // CUDA pipeline on errors.
-  if (A->isOffloading(Action::OFK_Cuda) || A->isOffloading(Action::OFK_HIP))
+  // CUDA/HIP/SYCL can have the same input source code compiled multiple times
+  // so do not compile again if there are already failures. It is OK to abort
+  // the CUDA pipeline on errors.
+  if (A->isOffloading(Action::OFK_Cuda) || A->isOffloading(Action::OFK_HIP) ||
+      A->isOffloading(Action::OFK_SYCL))
     return true;
 
   for (const auto &CI : FailingCommands)

--- a/clang/test/Driver/sycl-offload-dup-error.cpp
+++ b/clang/test/Driver/sycl-offload-dup-error.cpp
@@ -1,0 +1,12 @@
+// Tests to make sure that there is no duplicate error messaging for host
+// REQUIRES: x86-registered-target
+// RUN: not %clangxx -c -target x86_64-unknown-linux-gnu -fsycl %s \
+// RUN: 2>&1 | FileCheck %s
+
+void foo() {
+  foobar s;
+}
+
+// CHECK: error: unknown type name 'foobar'
+// CHECK-NOT: error: unknown type name 'foobar'
+


### PR DESCRIPTION
When performing -fsycl compilations, we compile a single file
multiple times.  If that file errors out, we should stop compiling as
opposed to trying to compile the file again.  This effectively reduces
duplication of the error diagnostic.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>