### PR TITLE
[SYCL][USM] Add support for pointer query APIs

### DIFF
--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -145,5 +145,19 @@ T *aligned_alloc(size_t Alignment, size_t Count, const queue &Q,
                           Kind);
 }
 
+// Pointer queries
+/// Query the allocation type from a USM pointer
+///
+/// @param ptr is the USM pointer to query
+/// @param ctxt is the sycl context the ptr was allocated in
+usm::alloc get_pointer_type(const void *ptr, const context &ctxt);
+
+/// Queries the device against which the pointer was allocated
+/// Throws an invalid_object_error if ptr is a host allocation.
+///
+/// @param ptr is the USM pointer to query
+/// @param ctxt is the sycl context the ptr was allocated in
+device get_pointer_device(const void *ptr, const context &ctxt);
+
 } // namespace sycl
 } // namespace cl

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -298,9 +298,9 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
                                    sizeof(pi_device), &DeviceId, nullptr);
 
   for (const device &Dev : CtxImpl->getDevices()) {
-    // Try to find the vreal sycl device used in the context
-    if (detail::getSyclObjImpl(Dev)->getHandleRef()) == DeviceId)
-      return D;
+    // Try to find the real sycl device used in the context
+    if (detail::getSyclObjImpl(Dev)->getHandleRef() == DeviceId)
+      return Dev;
   }
 
   throw runtime_error("Cannot find device associated with USM allocation!");

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -275,7 +275,7 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
 
   // Check if ptr is a host allocation
   if (get_pointer_type(Ptr, Ctxt) == alloc::host)
-    return device::get_devices(info::device_type::host)[0];
+    return device();
 
   std::shared_ptr<detail::context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
   pi_context C = CtxImpl->getHandleRef();

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -297,9 +297,9 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
   PI_CALL(piextUSMGetMemAllocInfo)(PICtx, Ptr, PI_MEM_ALLOC_DEVICE,
                                    sizeof(pi_device), &DeviceId, nullptr);
 
-  for (const auto D : CtxImpl->getDevices()) {
-    // Try to find the real sycl device used in the context
-    if (detail::pi::cast<pi_device>(D.get()) == DeviceId)
+  for (const device &Dev : CtxImpl->getDevices()) {
+    // Try to find the vreal sycl device used in the context
+    if (detail::getSyclObjImpl(Dev)->getHandleRef()) == DeviceId)
       return D;
   }
 

--- a/sycl/test/usm/pointer_query.cpp
+++ b/sycl/test/usm/pointer_query.cpp
@@ -1,7 +1,5 @@
 // RUN: %clangxx -fsycl %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
-// RUN: %CPU_RUN_PLACEHOLDER %t1.out
-// RUN: %GPU_RUN_PLACEHOLDER %t1.out
 
 //==-------------- pointer_query.cpp - Pointer Query test ------------------==//
 //

--- a/sycl/test/usm/pointer_query.cpp
+++ b/sycl/test/usm/pointer_query.cpp
@@ -86,7 +86,10 @@ int main() {
     return 10;
   }
   D = get_pointer_device(array, ctxt);
-  if (!D.is_host()) {
+  auto Devs = ctxt.get_devices();
+  auto result = std::find(Devs.begin(), Devs.end(), D);
+  if (result == Devs.end()) {
+    // Returned device was not in queried context
     return 11;
   }
   free(array, ctxt);

--- a/sycl/test/usm/pointer_query.cpp
+++ b/sycl/test/usm/pointer_query.cpp
@@ -1,0 +1,95 @@
+// RUN: %clangxx -fsycl %s -o %t1.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %CPU_RUN_PLACEHOLDER %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+
+//==-------------- pointer_query.cpp - Pointer Query test ------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main() {
+  int *array = nullptr;
+  const int N = 4;
+  queue q;
+  auto dev = q.get_device();
+  auto ctxt = q.get_context();
+
+  if (!(dev.get_info<info::device::usm_device_allocations>() &&
+        dev.get_info<info::device::usm_shared_allocations>() &&
+        dev.get_info<info::device::usm_host_allocations>()))
+    return 0;
+
+  usm::alloc Kind;
+  device D;
+
+  // Test device allocs
+  array = (int *)malloc_device(N * sizeof(int), q);
+  if (array == nullptr) {
+    return 1;
+  }
+  Kind = get_pointer_type(array, ctxt);
+  if (ctxt.is_host()) {
+    // for now, host device treats all allocations
+    // as host allocations
+    if (Kind != usm::alloc::host) {
+      return 2;
+    }
+  } else {
+    if (Kind != usm::alloc::device) {
+      return 3;
+    }
+  }
+  D = get_pointer_device(array, ctxt);
+  if (D != dev) {
+    return 4;
+  }
+  free(array, ctxt);
+
+  // Test shared allocs
+  array = (int *)malloc_shared(N * sizeof(int), q);
+  if (array == nullptr) {
+    return 5;
+  }
+  Kind = get_pointer_type(array, ctxt);
+  if (ctxt.is_host()) {
+    // for now, host device treats all allocations
+    // as host allocations
+    if (Kind != usm::alloc::host) {
+      return 6;
+    }
+  } else {
+    if (Kind != usm::alloc::shared) {
+      return 7;
+    }
+  }
+  D = get_pointer_device(array, ctxt);
+  if (D != dev) {
+    return 8;
+  }
+  free(array, ctxt);
+
+  // Test host allocs
+  array = (int *)malloc_host(N * sizeof(int), q);
+  if (array == nullptr) {
+    return 9;
+  }
+  Kind = get_pointer_type(array, ctxt);
+  if (Kind != usm::alloc::host) {
+    return 10;
+  }
+  D = get_pointer_device(array, ctxt);
+  if (!D.is_host()) {
+    return 11;
+  }
+  free(array, ctxt);
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds support for APIs that query properties of USM pointers.
In particular, this PR enables asking the allocation type of a USM pointer (host/device/shared) and the device against which it was allocated (if applicable).

Host allocations return host devices.
Host devices treat all pointers as host allocs.

This PR replaces #902 