### PR TITLE
[SYCL] Fix regression introduced by f537293/part of #1018 fix.

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4458,6 +4458,12 @@ void Sema::checkCall(NamedDecl *FDecl, const FunctionProtoType *Proto,
 
   if (FD)
     diagnoseArgDependentDiagnoseIfAttrs(FD, ThisArg, Args, Loc);
+
+  // Diagnose variadic calls in SYCL.
+  if (FD && FD ->isVariadic() && getLangOpts().SYCLIsDevice &&
+      !isUnevaluatedContext() && !isKnownGoodSYCLDecl(FD))
+    SYCLDiagIfDeviceCode(Loc, diag::err_sycl_restrict)
+        << Sema::KernelCallVariadicFunction;
 }
 
 /// CheckConstructorCall - Check a constructor call for correctness and safety

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5404,12 +5404,6 @@ bool Sema::GatherArgumentsForCall(SourceLocation CallLoc, FunctionDecl *FDecl,
 
     // Otherwise do argument promotion, (C99 6.5.2.2p7).
     } else {
-      // Diagnose variadic calls in SYCL.
-      if (getLangOpts().SYCLIsDevice && !isUnevaluatedContext() &&
-          !isKnownGoodSYCLDecl(FDecl))
-        SYCLDiagIfDeviceCode(CallLoc, diag::err_sycl_restrict)
-            << Sema::KernelCallVariadicFunction;
-
       for (Expr *A : Args.slice(ArgIx)) {
         ExprResult Arg = DefaultVariadicArgumentPromotion(A, CallType, FDecl);
         Invalid |= Arg.isInvalid();

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -14230,11 +14230,6 @@ Sema::BuildCallToObjectOfClassType(Scope *S, Expr *Obj,
 
   // If this is a variadic call, handle args passed through "...".
   if (Proto->isVariadic()) {
-    // Diagnose variadic calls in SYCL.
-    if (getLangOpts().SYCLIsDevice && !isUnevaluatedContext())
-      SYCLDiagIfDeviceCode(LParenLoc, diag::err_sycl_restrict)
-          << Sema::KernelCallVariadicFunction;
-
     // Promote the arguments (C99 6.5.2.2p7).
     for (unsigned i = NumParams, e = Args.size(); i < e; i++) {
       ExprResult Arg = DefaultVariadicArgumentPromotion(Args[i], VariadicMethod,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1391,10 +1391,6 @@ static bool isKnownEmitted(Sema &S, FunctionDecl *FD) {
   if (!FD)
     return true; // Seen in LIT testing
 
-  // Templates are emitted when they're instantiated.
-  if (FD->isDependentContext())
-    return false;
-
   if (FD->hasAttr<SYCLDeviceAttr>() || FD->hasAttr<SYCLKernelAttr>())
     return true;
 
@@ -1409,7 +1405,7 @@ Sema::DeviceDiagBuilder Sema::SYCLDiagIfDeviceCode(SourceLocation Loc,
          "Should only be called during SYCL compilation");
   FunctionDecl *FD = dyn_cast<FunctionDecl>(getCurLexicalContext());
   DeviceDiagBuilder::Kind DiagKind = [this, FD] {
-    if (ConstructingOpenCLKernel || (FD && FD->isDependentContext()))
+    if (ConstructingOpenCLKernel)
       return DeviceDiagBuilder::K_Nop;
     else if (isKnownEmitted(*this, FD))
       return DeviceDiagBuilder::K_ImmediateWithCallStack;

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -23,6 +23,11 @@ template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   // expected-note@+1 {{called by 'kernel_single_task<fake_kernel, (lambda}}
   kernelFunc();
+#ifdef LINUX_ASM
+   __asm__("int3");  // expected-error {{SYCL kernel cannot use inline assembly}}
+#else
+   __asm int 3 // expected-error {{SYCL kernel cannot use inline assembly}}
+#endif // LINUX_ASM
 }
 
 int main() {

--- a/clang/test/SemaSYCL/sycl-callstack.cpp
+++ b/clang/test/SemaSYCL/sycl-callstack.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -fcxx-exceptions -fsycl-is-device -verify -fsyntax-only -std=c++17 %s
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel))
+void kernel_single_task(Func kernelFunc) {
+  // expected-note@+1 {{called by 'kernel_single_task}}
+    kernelFunc();
+}
+
+void foo() {
+    // expected-error@+1 {{SYCL kernel cannot use exceptions}}
+   throw 3;
+}
+
+int main() {
+// expected-note@+1 {{called by 'operator()'}}
+kernel_single_task<class fake_kernel>([]() { foo(); });
+}

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -124,7 +124,6 @@ void eh_not_ok(void)
 
 void usage(myFuncDef functionPtr) {
 
-  // expected-note@+1 {{called by 'usage'}}
   eh_not_ok();
 
 #if ALLOW_FP
@@ -170,6 +169,7 @@ int use2 ( a_type ab, a_type *abp ) {
   return ns::glob +
   // expected-error@+1 {{SYCL kernel cannot use a global variable}}
     AnotherNS::moar_globals;
+  // expected-note@+1 {{called by 'use2'}}
   eh_not_ok();
   Check_RTTI_Restriction:: A *a;
   Check_RTTI_Restriction:: isa_B(a);
@@ -180,16 +180,15 @@ int use2 ( a_type ab, a_type *abp ) {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
-  // expected-note@+1 {{called by 'kernel_single_task}}
   kernelFunc();
   a_type ab;
   a_type *p;
+  // expected-note@+1 {{called by 'kernel_single_task'}}
   use2(ab, p);
 }
 
 int main() {
   a_type ab;
-  // expected-note@+1 {{called by 'operator()'}}
   kernel_single_task<class fake_kernel>([]() { usage(  &addInt ); });
   return 0;
 }


### PR DESCRIPTION
This fixes the immediate problem, where diagnostics were being missed
in kernels.  The problem ends up being that diagnostics can happen
at three different times during translation for templates:

1- During Phase 1
2- During Phase 2 instantiation
3- During ConstructOpenCLKernels.

f537293 suppressed 3, and did a better job at suppressing 1. However,
CallExprs are always rebuilt during instantation (for technical
reasons).  The result was the variadic call was being diagnosed in all 3
while developing f537293.  I erronously thought the best way was to
simply wait for instantiation to diagnose all SYCL diagnostics.

Unfortunately, this was short-sighted. Not everything in tree-transform
gets rebuilt every time.  One perfect example is the inline-asm (see the
added example). It doesn't get rebuilt in some cases, so it was never
diagnosed during instantiation.  Because I had fixed Phase
1/ConstructOpenCLKernels, this left no time for it to be diagnosed!

The fix was to keep suppressing 3, and simply fix the call-expr check by
moving the check to Sema::checkCall. This is how Clang works around this
issue for warnings. The downside is that the diagnostics will happen
slightly later for this (see the sycl-restrict.cpp test, which reverted
to the previous version before f537293), but invalid programs still
won't be accepted.

Signed-off-by: Erich Keane <erich.keane@intel.com>