### PR TITLE
[SYCL] Set lexical context for generated OpenCL kernel function

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1285,6 +1285,8 @@ void Sema::ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc,
   FunctionDecl *OpenCLKernel =
       CreateOpenCLKernelDeclaration(getASTContext(), Name, ParamDescs);
 
+  ContextRAII FuncContext(*this, OpenCLKernel);
+
   // Let's copy source location of a functor/lambda to emit nicer diagnostics
   OpenCLKernel->setLocation(LE->getLocation());
 


### PR DESCRIPTION
When doing ConstructOpenCLKernel, we don't set the current 
function/lexical context correctly, so getCurLexicalContext 
(or getCurFunctionDecl) fails, as we're in the TU-level at that point. 
This function should set the function for diagnostics purposes (and 
other analysis purposes).

At the moment, this isn't causing any problems (particularly since the
diagnostic changes previously made don't try to diagnose during this),
however this is likely something we would notice later.

Start a RAII container to set the current function decl to the kernel.

Fixes #1015.

Signed-off-by: Erich Keane <erich.keane@intel.com>