### PR TITLE
[SYCL][NFC] Eliminate struct/class definition/declaration and static/static-inlined function warnings.

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -8,14 +8,21 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 option(SYCL_ENABLE_WERROR "Treat all warnings as errors in SYCL project" OFF)
 
+# enable all warnings by default
+if (MSVC)
+  set(CMAKE_CXX_FLAGS "/W4 ${CMAKE_CXX_FLAGS}")
+else ()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-deprecated-declarations")
+endif()
+
 if(SYCL_ENABLE_WERROR)
   if(MSVC)
-    set(CMAKE_CXX_FLAGS "/W4 /WX ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "/WX ${CMAKE_CXX_FLAGS}")
     add_definitions(
       -wd4996 # Suppress 'function': was declared deprecated'
     )
   else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Wno-deprecated-declarations")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
   endif()
 endif()
 

--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -20,7 +20,7 @@ extern "C" const __attribute__((opencl_constant)) size_t_vec __spirv_BuiltInWork
 extern "C" const __attribute__((opencl_constant)) size_t_vec __spirv_BuiltInGlobalOffset;
 
 #define DEFINE_INT_ID_TO_XYZ_CONVERTER(POSTFIX)                                \
-  template <int ID> static size_t get##POSTFIX();                              \
+  template <int ID> static inline size_t get##POSTFIX();                       \
   template <> size_t get##POSTFIX<0>() { return __spirv_BuiltIn##POSTFIX.x; }  \
   template <> size_t get##POSTFIX<1>() { return __spirv_BuiltIn##POSTFIX.y; }  \
   template <> size_t get##POSTFIX<2>() { return __spirv_BuiltIn##POSTFIX.z; }

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -558,10 +558,10 @@ template <typename T> static constexpr T quiet_NaN() {
 }
 
 // is_same_vector_size
-template <int FirstSize, typename... Args> struct is_same_vector_size_impl;
+template <int FirstSize, typename... Args> class is_same_vector_size_impl;
 
 template <int FirstSize, typename T, typename... Args>
-struct is_same_vector_size_impl<FirstSize, T, Args...> {
+class is_same_vector_size_impl<FirstSize, T, Args...> {
 private:
   using CurrentT = detail::remove_pointer_t<T>;
   static constexpr int Size = vector_size<CurrentT>::value;
@@ -574,7 +574,7 @@ public:
 };
 
 template <int FirstSize>
-struct is_same_vector_size_impl<FirstSize> : std::true_type {};
+class is_same_vector_size_impl<FirstSize> : public std::true_type {};
 
 template <typename T, typename... Args> class is_same_vector_size {
   using CurrentT = remove_pointer_t<T>;

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -462,7 +462,7 @@ using common_rel_ret_t =
 template <int N> struct Boolean;
 
 // Try to get vector element count or 1 otherwise
-template <typename T, typename Enable = void> class TryToGetNumElements;
+template <typename T, typename Enable = void> struct TryToGetNumElements;
 
 template <typename T>
 struct TryToGetNumElements<
@@ -561,7 +561,8 @@ template <typename T> static constexpr T quiet_NaN() {
 template <int FirstSize, typename... Args> struct is_same_vector_size_impl;
 
 template <int FirstSize, typename T, typename... Args>
-class is_same_vector_size_impl<FirstSize, T, Args...> {
+struct is_same_vector_size_impl<FirstSize, T, Args...> {
+private:
   using CurrentT = detail::remove_pointer_t<T>;
   static constexpr int Size = vector_size<CurrentT>::value;
   static constexpr bool IsSizeEqual = (Size == FirstSize);

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -562,7 +562,6 @@ template <int FirstSize, typename... Args> class is_same_vector_size_impl;
 
 template <int FirstSize, typename T, typename... Args>
 class is_same_vector_size_impl<FirstSize, T, Args...> {
-private:
   using CurrentT = detail::remove_pointer_t<T>;
   static constexpr int Size = vector_size<CurrentT>::value;
   static constexpr bool IsSizeEqual = (Size == FirstSize);

--- a/sycl/test/warnings/warnings.cpp
+++ b/sycl/test/warnings/warnings.cpp
@@ -1,0 +1,21 @@
+// RUN: %clangxx -Wall -Wpessimizing-move -Wunused-variable -Wmismatched-tags -Wunneeded-internal-declaration -Werror -fsycl %s -o %t.out
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main(void) {
+  // add a very simple kernel to see if compilation succeeds with -Werror
+  int data1[10] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+
+  buffer<int, 1> B(data1, range<1>(10), {property::buffer::use_host_ptr()});
+  queue Q;
+  Q.submit([&](handler &CGH) {
+    auto Accessor = B.get_access<access::mode::read_write>(CGH);
+    CGH.parallel_for<class TheSimpleKernel>(range<1>{10}, [=](id<1> Item) {
+      Accessor[Item] = 0;
+    });
+  });
+
+  return 0;
+}


### PR DESCRIPTION

Compiling user code with -Wall provides compilation warnings from SYCL headers.
In some cases (-Werror or smth like that is enabled) it may not allow to compile user code.

```
CL/sycl/detail/generic_type_traits.hpp:468:1: warning: 'TryToGetNumElements' defined as a struct template here but previously declared as a class template; this is valid,  but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
struct TryToGetNumElements<
```

It's common to #983

Also, a multiple of:
```
CL/__spirv/spirv_vars.hpp:36:1: warning: 'static' function 'getGlobalOffset' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
```
warnings was eliminated.
 
Signed-off-by: Sergey Kanaev <sergey.kanaev@intel.com>