### PR TITLE
[SYCL] Diagnose invalid data types in image accessor

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -310,6 +310,13 @@ private:
   constexpr static bool IsImageAccessAnyRead =
       (IsImageAccessReadOnly || AccessMode == access::mode::read_write);
 
+  static_assert(std::is_same<DataT, cl_int4>::value ||
+                      std::is_same<DataT, cl_uint4>::value ||
+                      std::is_same<DataT, cl_float4>::value ||
+                      std::is_same<DataT, cl_half4>::value,
+                  "The data type of an image accessor must be only cl_int4, "
+                  "cl_uint4, cl_float4 or cl_half4 from SYCL namespace");
+
   static_assert(IsImageAcc || IsHostImageAcc || IsImageArrayAcc,
                 "Expected image type");
 

--- a/sycl/test/basic_tests/image_accessor_types.cpp
+++ b/sycl/test/basic_tests/image_accessor_types.cpp
@@ -1,0 +1,31 @@
+// RUN: not %clangxx -fsyntax-only %s 2>&1 | FileCheck %s
+#include <CL/sycl.hpp>
+#include <iostream>
+
+using namespace cl::sycl;
+class mod_image;
+int main() {
+  half4 src[16];
+  image<2> srcImage(src, image_channel_order::rgba, image_channel_type::fp16,
+                    range<2>(4, 4));
+  queue myQueue;
+  myQueue.submit([&](handler &cgh) {
+    accessor<float, 2, access::mode::read, access::target::image> NotValidType1(
+        srcImage, cgh);
+    // CHECK: The data type of an image accessor must be only cl_int4, cl_uint4,
+    // CHECK-SAME:  cl_float4 or cl_half4
+    accessor<int2, 2, access::mode::read, access::target::image> NotValidType2(
+        srcImage, cgh);
+    // CHECK: The data type of an image accessor must be only cl_int4, cl_uint4,
+    // CHECK-SAME:  cl_float4 or cl_half4
+    accessor<float4, 2, access::mode::read, access::target::image>
+        ValidSYCLFloat(srcImage, cgh);
+    accessor<int4, 2, access::mode::read, access::target::image> ValidSYCLInt(
+        srcImage, cgh);
+    accessor<uint4, 2, access::mode::read, access::target::image>
+        ValidSYCLUnsigned(srcImage, cgh);
+    accessor<half4, 2, access::mode::read, access::target::image> ValidSYCLHalf(
+        srcImage, cgh);
+  });
+  return 0;
+}

--- a/sycl/test/regression/image_access.cpp
+++ b/sycl/test/regression/image_access.cpp
@@ -24,7 +24,7 @@ int main() {
     cl::sycl::queue Queue;
 
     Queue.submit([&](cl::sycl::handler &CGH) {
-      cl::sycl::accessor<cl_int4, 1, cl::sycl::access::mode::read,
+      cl::sycl::accessor<cl::sycl::cl_int4, 1, cl::sycl::access::mode::read,
                          cl::sycl::access::target::image,
                          cl::sycl::access::placeholder::false_t>
           A(Image, CGH);
@@ -32,7 +32,7 @@ int main() {
     });
     Queue.wait_and_throw();
 
-    cl::sycl::accessor<cl_int4, 1, cl::sycl::access::mode::read,
+    cl::sycl::accessor<cl::sycl::cl_int4, 1, cl::sycl::access::mode::read,
                        cl::sycl::access::target::host_image,
                        cl::sycl::access::placeholder::false_t>
         A(Image);


### PR DESCRIPTION
The data type for the accessor of image should be half4, float4, uint4 or int4. This patch report error, if data type is invalid.

Signed-off-by: Ilya Mashkov ilya.mashkov@intel.com