### PR TITLE
[SYCL][PI] Removal of PI_CALL family of macros & implementation of Plugin_impl class

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -195,7 +195,7 @@ public:
       : Range{0} {
 
     size_t BufSize = 0;
-    auto Plugin = detail::getSyclObjImpl(SyclContext)->getPlugin();
+    const detail::plugin &Plugin = detail::getSyclObjImpl(SyclContext)->getPlugin();
     Plugin.call<detail::PiApiKind::piMemGetInfo>(
         detail::pi::cast<detail::RT::PiMem>(MemObject), CL_MEM_SIZE,
         sizeof(size_t), &BufSize, nullptr);

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -195,8 +195,10 @@ public:
       : Range{0} {
 
     size_t BufSize = 0;
-    PI_CALL(piMemGetInfo)(detail::pi::cast<detail::RT::PiMem>(MemObject),
-                          CL_MEM_SIZE, sizeof(size_t), &BufSize, nullptr);
+    auto Plugin = detail::getSyclObjImpl(SyclContext)->getPlugin();
+    Plugin.call<detail::PiApiKind::piMemGetInfo>(
+        detail::pi::cast<detail::RT::PiMem>(MemObject), CL_MEM_SIZE,
+        sizeof(size_t), &BufSize, nullptr);
 
     Range[0] = BufSize / sizeof(T);
     impl = std::make_shared<detail::buffer_impl>(

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -59,6 +59,8 @@ public:
   ///
   /// @param PiContext is an instance of a valid plug-in context handle.
   /// @param AsyncHandler is an instance of async_handler.
+  /// @param &Plugin is the reference to the underlying Plugin that this context
+  /// is associated with.
   context_impl(RT::PiContext PiContext, async_handler AsyncHandler,
                const plugin &Plugin);
 

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -60,7 +60,7 @@ public:
   /// @param PiContext is an instance of a valid plug-in context handle.
   /// @param AsyncHandler is an instance of async_handler.
   context_impl(RT::PiContext PiContext, async_handler AsyncHandler,
-               const plugin_impl &Plugin);
+               const plugin &Plugin);
 
   ~context_impl();
 
@@ -80,7 +80,7 @@ public:
   const async_handler &get_async_handler() const;
 
   /// @return the Plugin associated with the platform of this context.
-  const plugin_impl &getPlugin() const { return MPlatform->getPlugin(); }
+  const plugin &getPlugin() const { return MPlatform->getPlugin(); }
 
   /// @return the PlatformImpl associated with this context.
   PlatformImplPtr getPlatformImpl() const { return MPlatform; }

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -59,7 +59,8 @@ public:
   ///
   /// @param PiContext is an instance of a valid plug-in context handle.
   /// @param AsyncHandler is an instance of async_handler.
-  context_impl(RT::PiContext PiContext, async_handler AsyncHandler);
+  context_impl(RT::PiContext PiContext, async_handler AsyncHandler,
+               const plugin_impl &Plugin);
 
   ~context_impl();
 
@@ -77,6 +78,12 @@ public:
   ///
   /// @return an instance of SYCL async_handler.
   const async_handler &get_async_handler() const;
+
+  /// @return the Plugin associated with the platform of this context.
+  const plugin_impl &getPlugin() const { return MPlatform->getPlugin(); }
+
+  /// @return the PlatformImpl associated with this context.
+  PlatformImplPtr getPlatformImpl() const { return MPlatform; }
 
   /// Queries this context for information.
   ///

--- a/sycl/include/CL/sycl/detail/context_info.hpp
+++ b/sycl/include/CL/sycl/detail/context_info.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
 __SYCL_INLINE namespace cl {
@@ -19,11 +20,12 @@ template <info::context param> struct get_context_info {
   using RetType =
       typename info::param_traits<info::context, param>::return_type;
 
-  static RetType get(RT::PiContext ctx) {
+  static RetType get(RT::PiContext ctx, const plugin_impl &Plugin) {
     RetType Result = 0;
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piContextGetInfo)(ctx, pi::cast<pi_context_info>(param),
-                              sizeof(Result), &Result, nullptr);
+    Plugin.call<PiApiKind::piContextGetInfo>(ctx,
+                                             pi::cast<pi_context_info>(param),
+                                             sizeof(Result), &Result, nullptr);
     return Result;
   }
 };

--- a/sycl/include/CL/sycl/detail/context_info.hpp
+++ b/sycl/include/CL/sycl/detail/context_info.hpp
@@ -20,7 +20,7 @@ template <info::context param> struct get_context_info {
   using RetType =
       typename info::param_traits<info::context, param>::return_type;
 
-  static RetType get(RT::PiContext ctx, const plugin_impl &Plugin) {
+  static RetType get(RT::PiContext ctx, const plugin &Plugin) {
     RetType Result = 0;
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piContextGetInfo>(ctx,

--- a/sycl/include/CL/sycl/detail/device_impl.hpp
+++ b/sycl/include/CL/sycl/detail/device_impl.hpp
@@ -37,7 +37,7 @@ public:
 
   /// Constructs a SYCL device instance using the provided
   /// PI device instance.
-  explicit device_impl(RT::PiDevice Device, const plugin_impl &Plugin);
+  explicit device_impl(RT::PiDevice Device, const plugin &Plugin);
 
   ~device_impl();
 
@@ -106,7 +106,7 @@ public:
   platform get_platform() const;
 
   /// @return the associated plugin with this device.
-  const plugin_impl &getPlugin() const { return MPlatform->getPlugin(); }
+  const plugin &getPlugin() const { return MPlatform->getPlugin(); }
 
   /// Check SYCL extension support by device
   ///
@@ -185,7 +185,7 @@ public:
 
 private:
   explicit device_impl(RT::PiDevice Device, PlatformImplPtr Platform,
-                       const plugin_impl &Plugin);
+                       const plugin &Plugin);
   RT::PiDevice MDevice = 0;
   RT::PiDeviceType MType;
   bool MIsRootDevice = false;

--- a/sycl/include/CL/sycl/detail/device_impl.hpp
+++ b/sycl/include/CL/sycl/detail/device_impl.hpp
@@ -23,16 +23,21 @@ namespace detail {
 
 // Forward declaration
 class platform_impl;
-class platform_impl_pi;
+using PlatformImplPtr = std::shared_ptr<platform_impl>;
 
 // TODO: Make code thread-safe
 class device_impl {
 public:
   /// Constructs a SYCL device instance as a host device.
   device_impl();
+
   /// Constructs a SYCL device instance using the provided
   /// PI device instance.
-  explicit device_impl(RT::PiDevice Device);
+  explicit device_impl(RT::PiDevice Device, PlatformImplPtr Platform);
+
+  /// Constructs a SYCL device instance using the provided
+  /// PI device instance.
+  explicit device_impl(RT::PiDevice Device, const plugin_impl &Plugin);
 
   ~device_impl();
 
@@ -100,6 +105,9 @@ public:
   /// @return The associated SYCL platform.
   platform get_platform() const;
 
+  /// @return the associated plugin with this device.
+  const plugin_impl &getPlugin() const { return MPlatform->getPlugin(); }
+
   /// Check SYCL extension support by device
   ///
   /// @param ExtensionName is a name of queried extension.
@@ -165,7 +173,7 @@ public:
     }
     return get_device_info<
         typename info::param_traits<info::device, param>::return_type,
-        param>::get(this->getHandleRef());
+        param>::get(this->getHandleRef(), this->getPlugin());
   }
 
   /// Check if affinity partitioning by specified domain is supported by device
@@ -176,10 +184,13 @@ public:
   is_affinity_supported(info::partition_affinity_domain AffinityDomain) const;
 
 private:
+  explicit device_impl(RT::PiDevice Device, PlatformImplPtr Platform,
+                       const plugin_impl &Plugin);
   RT::PiDevice MDevice = 0;
   RT::PiDeviceType MType;
   bool MIsRootDevice = false;
   bool MIsHostDevice;
+  PlatformImplPtr MPlatform;
 }; // class device_impl
 
 } // namespace detail

--- a/sycl/include/CL/sycl/detail/device_info.hpp
+++ b/sycl/include/CL/sycl/detail/device_info.hpp
@@ -48,37 +48,43 @@ template <> struct check_fp_support<info::device::double_fp_config> {
 // TODO: get rid of remaining uses of OpenCL directly
 //
 template <typename T, info::device param> struct get_device_info {
-  static T get(RT::PiDevice dev) {
+  static T get(RT::PiDevice dev, const plugin_impl &Plugin) {
     typename sycl_to_pi<T>::type result;
-    PI_CALL(piDeviceGetInfo)(dev, pi::cast<RT::PiDeviceInfo>(param),
-                             sizeof(result), &result, nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(dev,
+                                            pi::cast<RT::PiDeviceInfo>(param),
+                                            sizeof(result), &result, nullptr);
     return T(result);
   }
 };
 
 // Specialization for platform
 template <info::device param> struct get_device_info<platform, param> {
-  static platform get(RT::PiDevice dev) {
+  static platform get(RT::PiDevice dev, const plugin_impl &Plugin) {
     typename sycl_to_pi<platform>::type result;
-    PI_CALL(piDeviceGetInfo)(dev, pi::cast<RT::PiDeviceInfo>(param),
-                             sizeof(result), &result, nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(dev,
+                                            pi::cast<RT::PiDeviceInfo>(param),
+                                            sizeof(result), &result, nullptr);
+    // TODO: Change PiDevice to device_impl.
+    // Use the Plugin from the device_impl class after plugin details
+    // are added to the class.
     return createSyclObjFromImpl<platform>(
-        std::make_shared<platform_impl>(result));
+        std::make_shared<platform_impl>(result, RT::GlobalPlugin));
   }
 };
 
 // Specialization for string return type, variable return size
 template <info::device param> struct get_device_info<string_class, param> {
-  static string_class get(RT::PiDevice dev) {
+  static string_class get(RT::PiDevice dev, const plugin_impl &Plugin) {
     size_t resultSize;
-    PI_CALL(piDeviceGetInfo)(dev, pi::cast<RT::PiDeviceInfo>(param), 0, nullptr,
-                             &resultSize);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
+        dev, pi::cast<RT::PiDeviceInfo>(param), 0, nullptr, &resultSize);
     if (resultSize == 0) {
       return string_class();
     }
     unique_ptr_class<char[]> result(new char[resultSize]);
-    PI_CALL(piDeviceGetInfo)(dev, pi::cast<RT::PiDeviceInfo>(param), resultSize,
-                             result.get(), nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(dev,
+                                            pi::cast<RT::PiDeviceInfo>(param),
+                                            resultSize, result.get(), nullptr);
 
     return string_class(result.get());
   }
@@ -86,15 +92,16 @@ template <info::device param> struct get_device_info<string_class, param> {
 
 // Specialization for parent device
 template <typename T> struct get_device_info<T, info::device::parent_device> {
-  static T get(RT::PiDevice dev);
+  static T get(RT::PiDevice dev, const plugin_impl &Plugin);
 };
 
 // Specialization for id return type
 template <info::device param> struct get_device_info<id<3>, param> {
-  static id<3> get(RT::PiDevice dev) {
+  static id<3> get(RT::PiDevice dev, const plugin_impl &Plugin) {
     size_t result[3];
-    PI_CALL(piDeviceGetInfo)(dev, pi::cast<RT::PiDeviceInfo>(param),
-                             sizeof(result), &result, nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(dev,
+                                            pi::cast<RT::PiDeviceInfo>(param),
+                                            sizeof(result), &result, nullptr);
     return id<3>(result[0], result[1], result[2]);
   }
 };
@@ -102,17 +109,19 @@ template <info::device param> struct get_device_info<id<3>, param> {
 // Specialization for fp_config types, checks the corresponding fp type support
 template <info::device param>
 struct get_device_info<vector_class<info::fp_config>, param> {
-  static vector_class<info::fp_config> get(RT::PiDevice dev) {
+  static vector_class<info::fp_config> get(RT::PiDevice dev,
+                                           const plugin_impl &Plugin) {
     // Check if fp type is supported
     if (!get_device_info<
             typename info::param_traits<
                 info::device, check_fp_support<param>::value>::return_type,
-            check_fp_support<param>::value>::get(dev)) {
+            check_fp_support<param>::value>::get(dev, Plugin)) {
       return {};
     }
     cl_device_fp_config result;
-    PI_CALL(piDeviceGetInfo)(dev, pi::cast<RT::PiDeviceInfo>(param),
-                             sizeof(result), &result, nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(dev,
+                                            pi::cast<RT::PiDeviceInfo>(param),
+                                            sizeof(result), &result, nullptr);
     return read_fp_bitfield(result);
   }
 };
@@ -121,9 +130,10 @@ struct get_device_info<vector_class<info::fp_config>, param> {
 template <>
 struct get_device_info<vector_class<info::fp_config>,
                        info::device::single_fp_config> {
-  static vector_class<info::fp_config> get(RT::PiDevice dev) {
+  static vector_class<info::fp_config> get(RT::PiDevice dev,
+                                           const plugin_impl &Plugin) {
     cl_device_fp_config result;
-    PI_CALL(piDeviceGetInfo)(
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::single_fp_config),
         sizeof(result), &result, nullptr);
     return read_fp_bitfield(result);
@@ -132,9 +142,9 @@ struct get_device_info<vector_class<info::fp_config>,
 
 // Specialization for queue_profiling, OpenCL returns a bitfield
 template <> struct get_device_info<bool, info::device::queue_profiling> {
-  static bool get(RT::PiDevice dev) {
+  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
     cl_command_queue_properties result;
-    PI_CALL(piDeviceGetInfo)(
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::queue_profiling),
         sizeof(result), &result, nullptr);
     return (result & CL_QUEUE_PROFILING_ENABLE);
@@ -145,9 +155,10 @@ template <> struct get_device_info<bool, info::device::queue_profiling> {
 template <>
 struct get_device_info<vector_class<info::execution_capability>,
                        info::device::execution_capabilities> {
-  static vector_class<info::execution_capability> get(RT::PiDevice dev) {
+  static vector_class<info::execution_capability>
+  get(RT::PiDevice dev, const plugin_impl &Plugin) {
     cl_device_exec_capabilities result;
-    PI_CALL(piDeviceGetInfo)(
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::execution_capabilities),
         sizeof(result), &result, nullptr);
     return read_execution_bitfield(result);
@@ -158,9 +169,11 @@ struct get_device_info<vector_class<info::execution_capability>,
 template <>
 struct get_device_info<vector_class<string_class>,
                        info::device::built_in_kernels> {
-  static vector_class<string_class> get(RT::PiDevice dev) {
+  static vector_class<string_class> get(RT::PiDevice dev,
+                                        const plugin_impl &Plugin) {
     string_class result =
-        get_device_info<string_class, info::device::built_in_kernels>::get(dev);
+        get_device_info<string_class, info::device::built_in_kernels>::get(
+            dev, Plugin);
     return split_string(result, ';');
   }
 };
@@ -168,9 +181,11 @@ struct get_device_info<vector_class<string_class>,
 // Specialization for extensions, splits the string returned by OpenCL
 template <>
 struct get_device_info<vector_class<string_class>, info::device::extensions> {
-  static vector_class<string_class> get(RT::PiDevice dev) {
+  static vector_class<string_class> get(RT::PiDevice dev,
+                                        const plugin_impl &Plugin) {
     string_class result =
-        get_device_info<string_class, info::device::extensions>::get(dev);
+        get_device_info<string_class, info::device::extensions>::get(dev,
+                                                                     Plugin);
     return split_string(result, ' ');
   }
 };
@@ -179,12 +194,14 @@ struct get_device_info<vector_class<string_class>, info::device::extensions> {
 template <>
 struct get_device_info<vector_class<info::partition_property>,
                        info::device::partition_properties> {
-  static vector_class<info::partition_property> get(RT::PiDevice dev) {
+  static vector_class<info::partition_property> get(RT::PiDevice dev,
+                                                    const plugin_impl &Plugin) {
     auto info_partition =
         pi::cast<RT::PiDeviceInfo>(info::device::partition_properties);
 
     size_t resultSize;
-    PI_CALL(piDeviceGetInfo)(dev, info_partition, 0, nullptr, &resultSize);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(dev, info_partition, 0, nullptr,
+                                            &resultSize);
 
     size_t arrayLength = resultSize / sizeof(cl_device_partition_property);
     if (arrayLength == 0) {
@@ -192,8 +209,8 @@ struct get_device_info<vector_class<info::partition_property>,
     }
     unique_ptr_class<cl_device_partition_property[]> arrayResult(
         new cl_device_partition_property[arrayLength]);
-    PI_CALL(piDeviceGetInfo)(dev, info_partition, resultSize, arrayResult.get(),
-                             nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(dev, info_partition, resultSize,
+                                            arrayResult.get(), nullptr);
 
     vector_class<info::partition_property> result;
     for (size_t i = 0; i < arrayLength - 1; ++i) {
@@ -207,9 +224,10 @@ struct get_device_info<vector_class<info::partition_property>,
 template <>
 struct get_device_info<vector_class<info::partition_affinity_domain>,
                        info::device::partition_affinity_domains> {
-  static vector_class<info::partition_affinity_domain> get(RT::PiDevice dev) {
+  static vector_class<info::partition_affinity_domain>
+  get(RT::PiDevice dev, const plugin_impl &Plugin) {
     cl_device_affinity_domain result;
-    PI_CALL(piDeviceGetInfo)(
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev,
         pi::cast<RT::PiDeviceInfo>(info::device::partition_affinity_domains),
         sizeof(result), &result, nullptr);
@@ -222,20 +240,23 @@ struct get_device_info<vector_class<info::partition_affinity_domain>,
 template <>
 struct get_device_info<info::partition_affinity_domain,
                        info::device::partition_type_affinity_domain> {
-  static info::partition_affinity_domain get(RT::PiDevice dev) {
+  static info::partition_affinity_domain get(RT::PiDevice dev,
+                                             const plugin_impl &Plugin) {
     size_t resultSize;
-    PI_CALL(piDeviceGetInfo)(dev,
-                             pi::cast<RT::PiDeviceInfo>(
-                                 info::device::partition_type_affinity_domain),
-                             0, nullptr, &resultSize);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
+        dev,
+        pi::cast<RT::PiDeviceInfo>(
+            info::device::partition_type_affinity_domain),
+        0, nullptr, &resultSize);
     if (resultSize != 1) {
       return info::partition_affinity_domain::not_applicable;
     }
     cl_device_partition_property result;
-    PI_CALL(piDeviceGetInfo)(dev,
-                             pi::cast<RT::PiDeviceInfo>(
-                                 info::device::partition_type_affinity_domain),
-                             sizeof(result), &result, nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
+        dev,
+        pi::cast<RT::PiDeviceInfo>(
+            info::device::partition_type_affinity_domain),
+        sizeof(result), &result, nullptr);
     if (result == CL_DEVICE_AFFINITY_DOMAIN_NUMA ||
         result == CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE ||
         result == CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE ||
@@ -252,10 +273,11 @@ struct get_device_info<info::partition_affinity_domain,
 template <>
 struct get_device_info<info::partition_property,
                        info::device::partition_type_property> {
-  static info::partition_property get(RT::PiDevice dev) {
+  static info::partition_property get(RT::PiDevice dev,
+                                      const plugin_impl &Plugin) {
     size_t resultSize;
-    PI_CALL(piDeviceGetInfo)(dev, PI_DEVICE_INFO_PARTITION_TYPE, 0, nullptr,
-                             &resultSize);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(dev, PI_DEVICE_INFO_PARTITION_TYPE,
+                                            0, nullptr, &resultSize);
     if (!resultSize)
       return info::partition_property::no_partition;
 
@@ -263,8 +285,9 @@ struct get_device_info<info::partition_property,
 
     unique_ptr_class<cl_device_partition_property[]> arrayResult(
         new cl_device_partition_property[arrayLength]);
-    PI_CALL(piDeviceGetInfo)(dev, PI_DEVICE_INFO_PARTITION_TYPE, resultSize,
-                             arrayResult.get(), nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(dev, PI_DEVICE_INFO_PARTITION_TYPE,
+                                            resultSize, arrayResult.get(),
+                                            nullptr);
     if (!arrayResult[0])
       return info::partition_property::no_partition;
     return info::partition_property(arrayResult[0]);
@@ -273,14 +296,14 @@ struct get_device_info<info::partition_property,
 // Specialization for supported subgroup sizes
 template <>
 struct get_device_info<vector_class<size_t>, info::device::sub_group_sizes> {
-  static vector_class<size_t> get(RT::PiDevice dev) {
+  static vector_class<size_t> get(RT::PiDevice dev, const plugin_impl &Plugin) {
     size_t resultSize = 0;
-    PI_CALL(piDeviceGetInfo)(
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::sub_group_sizes), 0,
         nullptr, &resultSize);
 
     vector_class<size_t> result(resultSize / sizeof(size_t));
-    PI_CALL(piDeviceGetInfo)(
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::sub_group_sizes),
         resultSize, result.data(), nullptr);
     return result;
@@ -292,10 +315,11 @@ struct get_device_info<vector_class<size_t>, info::device::sub_group_sizes> {
 // enum for global pipes feature.
 template <>
 struct get_device_info<bool, info::device::kernel_kernel_pipe_support> {
-  static bool get(RT::PiDevice dev) {
+  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
     // We claim, that all Intel FPGA devices support kernel to kernel pipe
     // feature (at least at the scope of SYCL_INTEL_data_flow_pipes extension).
-    platform plt = get_device_info<platform, info::device::platform>::get(dev);
+    platform plt =
+        get_device_info<platform, info::device::platform>::get(dev, Plugin);
     string_class platform_name = plt.get_info<info::platform::name>();
     if (platform_name == "Intel(R) FPGA Emulation Platform for OpenCL(TM)" ||
         platform_name == "Intel(R) FPGA SDK for OpenCL(TM)")
@@ -331,9 +355,9 @@ cl_uint get_native_vector_width(size_t idx);
 // Specialization for device usm query.
 template <>
 struct get_device_info<bool, info::device::usm_device_allocations> {
-  static bool get(RT::PiDevice dev) {
+  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
     pi_usm_capabilities caps;
-    pi_result Err = PI_CALL_NOCHECK(piDeviceGetInfo)(
+    pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::usm_device_allocations),
         sizeof(pi_usm_capabilities), &caps, nullptr);
 
@@ -344,9 +368,9 @@ struct get_device_info<bool, info::device::usm_device_allocations> {
 // Specialization for host usm query.
 template <>
 struct get_device_info<bool, info::device::usm_host_allocations> {
-  static bool get(RT::PiDevice dev) {
+  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
     pi_usm_capabilities caps;
-    pi_result Err = PI_CALL_NOCHECK(piDeviceGetInfo)(
+    pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::usm_host_allocations),
         sizeof(pi_usm_capabilities), &caps, nullptr);
 
@@ -357,9 +381,9 @@ struct get_device_info<bool, info::device::usm_host_allocations> {
 // Specialization for shared usm query.
 template <>
 struct get_device_info<bool, info::device::usm_shared_allocations> {
-  static bool get(RT::PiDevice dev) {
+  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
     pi_usm_capabilities caps;
-    pi_result Err = PI_CALL_NOCHECK(piDeviceGetInfo)(
+    pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::usm_shared_allocations),
         sizeof(pi_usm_capabilities), &caps, nullptr);
     return (Err != PI_SUCCESS) ? false : (caps & PI_USM_ACCESS);
@@ -369,9 +393,9 @@ struct get_device_info<bool, info::device::usm_shared_allocations> {
 // Specialization for restricted usm query
 template <>
 struct get_device_info<bool, info::device::usm_restricted_shared_allocations> {
-  static bool get(RT::PiDevice dev) {
+  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
     pi_usm_capabilities caps;
-    pi_result Err = PI_CALL_NOCHECK(piDeviceGetInfo)(
+    pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev,
         pi::cast<RT::PiDeviceInfo>(
             info::device::usm_restricted_shared_allocations),
@@ -386,9 +410,9 @@ struct get_device_info<bool, info::device::usm_restricted_shared_allocations> {
 // Specialization for system usm query
 template <>
 struct get_device_info<bool, info::device::usm_system_allocator> {
-  static bool get(RT::PiDevice dev) {
+  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
     pi_usm_capabilities caps;
-    pi_result Err = PI_CALL_NOCHECK(piDeviceGetInfo)(
+    pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::usm_system_allocator),
         sizeof(pi_usm_capabilities), &caps, nullptr);
     return (Err != PI_SUCCESS) ? false : (caps & PI_USM_ACCESS);

--- a/sycl/include/CL/sycl/detail/device_info.hpp
+++ b/sycl/include/CL/sycl/detail/device_info.hpp
@@ -48,7 +48,7 @@ template <> struct check_fp_support<info::device::double_fp_config> {
 // TODO: get rid of remaining uses of OpenCL directly
 //
 template <typename T, info::device param> struct get_device_info {
-  static T get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static T get(RT::PiDevice dev, const plugin &Plugin) {
     typename sycl_to_pi<T>::type result;
     Plugin.call<PiApiKind::piDeviceGetInfo>(dev,
                                             pi::cast<RT::PiDeviceInfo>(param),
@@ -59,7 +59,7 @@ template <typename T, info::device param> struct get_device_info {
 
 // Specialization for platform
 template <info::device param> struct get_device_info<platform, param> {
-  static platform get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static platform get(RT::PiDevice dev, const plugin &Plugin) {
     typename sycl_to_pi<platform>::type result;
     Plugin.call<PiApiKind::piDeviceGetInfo>(dev,
                                             pi::cast<RT::PiDeviceInfo>(param),
@@ -74,7 +74,7 @@ template <info::device param> struct get_device_info<platform, param> {
 
 // Specialization for string return type, variable return size
 template <info::device param> struct get_device_info<string_class, param> {
-  static string_class get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static string_class get(RT::PiDevice dev, const plugin &Plugin) {
     size_t resultSize;
     Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(param), 0, nullptr, &resultSize);
@@ -92,12 +92,12 @@ template <info::device param> struct get_device_info<string_class, param> {
 
 // Specialization for parent device
 template <typename T> struct get_device_info<T, info::device::parent_device> {
-  static T get(RT::PiDevice dev, const plugin_impl &Plugin);
+  static T get(RT::PiDevice dev, const plugin &Plugin);
 };
 
 // Specialization for id return type
 template <info::device param> struct get_device_info<id<3>, param> {
-  static id<3> get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static id<3> get(RT::PiDevice dev, const plugin &Plugin) {
     size_t result[3];
     Plugin.call<PiApiKind::piDeviceGetInfo>(dev,
                                             pi::cast<RT::PiDeviceInfo>(param),
@@ -110,7 +110,7 @@ template <info::device param> struct get_device_info<id<3>, param> {
 template <info::device param>
 struct get_device_info<vector_class<info::fp_config>, param> {
   static vector_class<info::fp_config> get(RT::PiDevice dev,
-                                           const plugin_impl &Plugin) {
+                                           const plugin &Plugin) {
     // Check if fp type is supported
     if (!get_device_info<
             typename info::param_traits<
@@ -131,7 +131,7 @@ template <>
 struct get_device_info<vector_class<info::fp_config>,
                        info::device::single_fp_config> {
   static vector_class<info::fp_config> get(RT::PiDevice dev,
-                                           const plugin_impl &Plugin) {
+                                           const plugin &Plugin) {
     cl_device_fp_config result;
     Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::single_fp_config),
@@ -142,7 +142,7 @@ struct get_device_info<vector_class<info::fp_config>,
 
 // Specialization for queue_profiling, OpenCL returns a bitfield
 template <> struct get_device_info<bool, info::device::queue_profiling> {
-  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static bool get(RT::PiDevice dev, const plugin &Plugin) {
     cl_command_queue_properties result;
     Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::queue_profiling),
@@ -156,7 +156,7 @@ template <>
 struct get_device_info<vector_class<info::execution_capability>,
                        info::device::execution_capabilities> {
   static vector_class<info::execution_capability>
-  get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  get(RT::PiDevice dev, const plugin &Plugin) {
     cl_device_exec_capabilities result;
     Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::execution_capabilities),
@@ -170,7 +170,7 @@ template <>
 struct get_device_info<vector_class<string_class>,
                        info::device::built_in_kernels> {
   static vector_class<string_class> get(RT::PiDevice dev,
-                                        const plugin_impl &Plugin) {
+                                        const plugin &Plugin) {
     string_class result =
         get_device_info<string_class, info::device::built_in_kernels>::get(
             dev, Plugin);
@@ -182,7 +182,7 @@ struct get_device_info<vector_class<string_class>,
 template <>
 struct get_device_info<vector_class<string_class>, info::device::extensions> {
   static vector_class<string_class> get(RT::PiDevice dev,
-                                        const plugin_impl &Plugin) {
+                                        const plugin &Plugin) {
     string_class result =
         get_device_info<string_class, info::device::extensions>::get(dev,
                                                                      Plugin);
@@ -195,7 +195,7 @@ template <>
 struct get_device_info<vector_class<info::partition_property>,
                        info::device::partition_properties> {
   static vector_class<info::partition_property> get(RT::PiDevice dev,
-                                                    const plugin_impl &Plugin) {
+                                                    const plugin &Plugin) {
     auto info_partition =
         pi::cast<RT::PiDeviceInfo>(info::device::partition_properties);
 
@@ -225,7 +225,7 @@ template <>
 struct get_device_info<vector_class<info::partition_affinity_domain>,
                        info::device::partition_affinity_domains> {
   static vector_class<info::partition_affinity_domain>
-  get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  get(RT::PiDevice dev, const plugin &Plugin) {
     cl_device_affinity_domain result;
     Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev,
@@ -241,7 +241,7 @@ template <>
 struct get_device_info<info::partition_affinity_domain,
                        info::device::partition_type_affinity_domain> {
   static info::partition_affinity_domain get(RT::PiDevice dev,
-                                             const plugin_impl &Plugin) {
+                                             const plugin &Plugin) {
     size_t resultSize;
     Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev,
@@ -274,7 +274,7 @@ template <>
 struct get_device_info<info::partition_property,
                        info::device::partition_type_property> {
   static info::partition_property get(RT::PiDevice dev,
-                                      const plugin_impl &Plugin) {
+                                      const plugin &Plugin) {
     size_t resultSize;
     Plugin.call<PiApiKind::piDeviceGetInfo>(dev, PI_DEVICE_INFO_PARTITION_TYPE,
                                             0, nullptr, &resultSize);
@@ -296,7 +296,7 @@ struct get_device_info<info::partition_property,
 // Specialization for supported subgroup sizes
 template <>
 struct get_device_info<vector_class<size_t>, info::device::sub_group_sizes> {
-  static vector_class<size_t> get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static vector_class<size_t> get(RT::PiDevice dev, const plugin &Plugin) {
     size_t resultSize = 0;
     Plugin.call<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::sub_group_sizes), 0,
@@ -315,7 +315,7 @@ struct get_device_info<vector_class<size_t>, info::device::sub_group_sizes> {
 // enum for global pipes feature.
 template <>
 struct get_device_info<bool, info::device::kernel_kernel_pipe_support> {
-  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static bool get(RT::PiDevice dev, const plugin &Plugin) {
     // We claim, that all Intel FPGA devices support kernel to kernel pipe
     // feature (at least at the scope of SYCL_INTEL_data_flow_pipes extension).
     platform plt =
@@ -355,7 +355,7 @@ cl_uint get_native_vector_width(size_t idx);
 // Specialization for device usm query.
 template <>
 struct get_device_info<bool, info::device::usm_device_allocations> {
-  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static bool get(RT::PiDevice dev, const plugin &Plugin) {
     pi_usm_capabilities caps;
     pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::usm_device_allocations),
@@ -368,7 +368,7 @@ struct get_device_info<bool, info::device::usm_device_allocations> {
 // Specialization for host usm query.
 template <>
 struct get_device_info<bool, info::device::usm_host_allocations> {
-  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static bool get(RT::PiDevice dev, const plugin &Plugin) {
     pi_usm_capabilities caps;
     pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::usm_host_allocations),
@@ -381,7 +381,7 @@ struct get_device_info<bool, info::device::usm_host_allocations> {
 // Specialization for shared usm query.
 template <>
 struct get_device_info<bool, info::device::usm_shared_allocations> {
-  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static bool get(RT::PiDevice dev, const plugin &Plugin) {
     pi_usm_capabilities caps;
     pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::usm_shared_allocations),
@@ -393,7 +393,7 @@ struct get_device_info<bool, info::device::usm_shared_allocations> {
 // Specialization for restricted usm query
 template <>
 struct get_device_info<bool, info::device::usm_restricted_shared_allocations> {
-  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static bool get(RT::PiDevice dev, const plugin &Plugin) {
     pi_usm_capabilities caps;
     pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev,
@@ -410,7 +410,7 @@ struct get_device_info<bool, info::device::usm_restricted_shared_allocations> {
 // Specialization for system usm query
 template <>
 struct get_device_info<bool, info::device::usm_system_allocator> {
-  static bool get(RT::PiDevice dev, const plugin_impl &Plugin) {
+  static bool get(RT::PiDevice dev, const plugin &Plugin) {
     pi_usm_capabilities caps;
     pi_result Err = Plugin.call_nocheck<PiApiKind::piDeviceGetInfo>(
         dev, pi::cast<RT::PiDeviceInfo>(info::device::usm_system_allocator),

--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -10,7 +10,6 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 

--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -9,8 +9,9 @@
 #pragma once
 
 #include <CL/sycl/detail/common.hpp>
-#include <CL/sycl/detail/event_info.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
 #include <cassert>
@@ -19,6 +20,7 @@ __SYCL_INLINE namespace cl {
 namespace sycl {
 class context;
 namespace detail {
+class plugin_impl;
 class context_impl;
 using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 class queue_impl;
@@ -134,6 +136,10 @@ public:
   ///
   /// @return a shared pointer to a valid context_impl.
   const ContextImplPtr &getContextImpl();
+
+  // @return the Plugin associated with the context of this event.
+  // Should be called when this is not a Host Event.
+  const plugin_impl &getPlugin() const;
 
   /// Associate event with the context.
   ///

--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -10,7 +10,7 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
@@ -20,7 +20,7 @@ __SYCL_INLINE namespace cl {
 namespace sycl {
 class context;
 namespace detail {
-class plugin_impl;
+class plugin;
 class context_impl;
 using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 class queue_impl;
@@ -139,7 +139,7 @@ public:
 
   // @return the Plugin associated with the context of this event.
   // Should be called when this is not a Host Event.
-  const plugin_impl &getPlugin() const;
+  const plugin &getPlugin() const;
 
   /// Associate event with the context.
   ///

--- a/sycl/include/CL/sycl/detail/event_info.hpp
+++ b/sycl/include/CL/sycl/detail/event_info.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
 __SYCL_INLINE namespace cl {
@@ -19,11 +20,11 @@ template <info::event_profiling Param> struct get_event_profiling_info {
   using RetType =
       typename info::param_traits<info::event_profiling, Param>::return_type;
 
-  static RetType get(RT::PiEvent Event) {
+  static RetType get(RT::PiEvent Event, const plugin_impl &Plugin) {
     RetType Result = 0;
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piEventGetProfilingInfo)(Event, cl_profiling_info(Param),
-                                     sizeof(Result), &Result, nullptr);
+    Plugin.call<PiApiKind::piEventGetProfilingInfo>(
+        Event, cl_profiling_info(Param), sizeof(Result), &Result, nullptr);
     return Result;
   }
 };
@@ -31,11 +32,11 @@ template <info::event_profiling Param> struct get_event_profiling_info {
 template <info::event Param> struct get_event_info {
   using RetType = typename info::param_traits<info::event, Param>::return_type;
 
-  static RetType get(RT::PiEvent Event) {
+  static RetType get(RT::PiEvent Event, const plugin_impl &Plugin) {
     RetType Result = (RetType)0;
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piEventGetInfo)(Event, cl_profiling_info(Param), sizeof(Result),
-                            &Result, nullptr);
+    Plugin.call<PiApiKind::piEventGetInfo>(Event, cl_profiling_info(Param),
+                                           sizeof(Result), &Result, nullptr);
     return Result;
   }
 };

--- a/sycl/include/CL/sycl/detail/event_info.hpp
+++ b/sycl/include/CL/sycl/detail/event_info.hpp
@@ -20,7 +20,7 @@ template <info::event_profiling Param> struct get_event_profiling_info {
   using RetType =
       typename info::param_traits<info::event_profiling, Param>::return_type;
 
-  static RetType get(RT::PiEvent Event, const plugin_impl &Plugin) {
+  static RetType get(RT::PiEvent Event, const plugin &Plugin) {
     RetType Result = 0;
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piEventGetProfilingInfo>(
@@ -32,7 +32,7 @@ template <info::event_profiling Param> struct get_event_profiling_info {
 template <info::event Param> struct get_event_info {
   using RetType = typename info::param_traits<info::event, Param>::return_type;
 
-  static RetType get(RT::PiEvent Event, const plugin_impl &Plugin) {
+  static RetType get(RT::PiEvent Event, const plugin &Plugin) {
     RetType Result = (RetType)0;
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piEventGetInfo>(Event, cl_profiling_info(Param),

--- a/sycl/include/CL/sycl/detail/event_info.hpp
+++ b/sycl/include/CL/sycl/detail/event_info.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
 __SYCL_INLINE namespace cl {

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -222,7 +222,7 @@ private:
   template <typename T>
   void getImageInfo(const ContextImplPtr Context, RT::PiMemImageInfo Info,
                     T &Dest) {
-    auto Plugin = Context->getPlugin();
+    const detail::plugin &Plugin = Context->getPlugin();
     RT::PiMem Mem = pi::cast<RT::PiMem>(BaseT::MInteropMemObject);
     Plugin.call<PiApiKind::piMemImageGetInfo>(Mem, Info, sizeof(T), &Dest,
                                               nullptr);

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -219,9 +219,13 @@ public:
   ~image_impl() { BaseT::updateHostMemory(); }
 
 private:
-  template <typename T> void getImageInfo(RT::PiMemImageInfo Info, T &Dest) {
+  template <typename T>
+  void getImageInfo(const ContextImplPtr Context, RT::PiMemImageInfo Info,
+                    T &Dest) {
+    auto Plugin = Context->getPlugin();
     RT::PiMem Mem = pi::cast<RT::PiMem>(BaseT::MInteropMemObject);
-    PI_CALL(piMemImageGetInfo)(Mem, Info, sizeof(T), &Dest, nullptr);
+    Plugin.call<PiApiKind::piMemImageGetInfo>(Mem, Info, sizeof(T), &Dest,
+                                              nullptr);
   }
 
   vector_class<device> getDevices(const ContextImplPtr Context);

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -76,7 +76,7 @@ public:
   cl_kernel get() const {
     if (is_host())
       throw invalid_object_error("This instance of kernel is a host instance");
-    PI_CALL(piKernelRetain)(MKernel);
+    getPlugin().call<PiApiKind::piKernelRetain>(MKernel);
     return pi::cast<cl_kernel>(MKernel);
   }
 
@@ -84,6 +84,8 @@ public:
   ///
   /// @return true if this SYCL kernel is a host kernel.
   bool is_host() const { return MContext->is_host(); }
+
+  const plugin_impl &getPlugin() const { return MContext->getPlugin(); }
 
   /// Query information from the kernel object using the info::kernel_info
   /// descriptor.

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -85,7 +85,7 @@ public:
   /// @return true if this SYCL kernel is a host kernel.
   bool is_host() const { return MContext->is_host(); }
 
-  const plugin_impl &getPlugin() const { return MContext->getPlugin(); }
+  const plugin &getPlugin() const { return MContext->getPlugin(); }
 
   /// Query information from the kernel object using the info::kernel_info
   /// descriptor.

--- a/sycl/include/CL/sycl/detail/kernel_info.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_info.hpp
@@ -22,7 +22,7 @@ namespace detail {
 template <typename T, info::kernel Param> struct get_kernel_info {};
 
 template <info::kernel Param> struct get_kernel_info<string_class, Param> {
-  static string_class get(RT::PiKernel Kernel, const plugin_impl &Plugin) {
+  static string_class get(RT::PiKernel Kernel, const plugin &Plugin) {
     size_t ResultSize;
 
     // TODO catch an exception and put it to list of asynchronous exceptions
@@ -40,7 +40,7 @@ template <info::kernel Param> struct get_kernel_info<string_class, Param> {
 };
 
 template <info::kernel Param> struct get_kernel_info<cl_uint, Param> {
-  static cl_uint get(RT::PiKernel Kernel, const plugin_impl &Plugin) {
+  static cl_uint get(RT::PiKernel Kernel, const plugin &Plugin) {
     cl_uint Result;
 
     // TODO catch an exception and put it to list of asynchronous exceptions
@@ -55,7 +55,7 @@ template <info::kernel Param> struct get_kernel_info<cl_uint, Param> {
 template <typename T, info::kernel_work_group Param>
 struct get_kernel_work_group_info {
   static T get(RT::PiKernel Kernel, RT::PiDevice Device,
-               const plugin_impl &Plugin) {
+               const plugin &Plugin) {
     T Result;
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piKernelGetGroupInfo>(
@@ -68,7 +68,7 @@ struct get_kernel_work_group_info {
 template <info::kernel_work_group Param>
 struct get_kernel_work_group_info<cl::sycl::range<3>, Param> {
   static cl::sycl::range<3> get(RT::PiKernel Kernel, RT::PiDevice Device,
-                                const plugin_impl &Plugin) {
+                                const plugin &Plugin) {
     size_t Result[3];
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piKernelGetGroupInfo>(
@@ -112,7 +112,7 @@ get_kernel_work_group_info_host<info::kernel_work_group::private_mem_size>(
 template <typename TOut, info::kernel_sub_group Param>
 struct get_kernel_sub_group_info {
   static TOut get(RT::PiKernel Kernel, RT::PiDevice Device,
-                  const plugin_impl &Plugin) {
+                  const plugin &Plugin) {
     TOut Result;
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piKernelGetSubGroupInfo>(
@@ -125,7 +125,7 @@ struct get_kernel_sub_group_info {
 template <typename TOut, info::kernel_sub_group Param, typename TIn>
 struct get_kernel_sub_group_info_with_input {
   static TOut get(RT::PiKernel Kernel, RT::PiDevice Device, TIn In,
-                  const plugin_impl &Plugin) {
+                  const plugin &Plugin) {
     TOut Result;
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piKernelGetSubGroupInfo>(
@@ -138,7 +138,7 @@ struct get_kernel_sub_group_info_with_input {
 template <info::kernel_sub_group Param>
 struct get_kernel_sub_group_info_with_input<cl::sycl::range<3>, Param, size_t> {
   static cl::sycl::range<3> get(RT::PiKernel Kernel, RT::PiDevice Device,
-                                size_t In, const plugin_impl &Plugin) {
+                                size_t In, const plugin &Plugin) {
     size_t Result[3];
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piKernelGetSubGroupInfo>(
@@ -151,7 +151,7 @@ struct get_kernel_sub_group_info_with_input<cl::sycl::range<3>, Param, size_t> {
 template <info::kernel_sub_group Param>
 struct get_kernel_sub_group_info_with_input<size_t, Param, cl::sycl::range<3>> {
   static size_t get(RT::PiKernel Kernel, RT::PiDevice Device,
-                    cl::sycl::range<3> In, const plugin_impl &Plugin) {
+                    cl::sycl::range<3> In, const plugin &Plugin) {
     size_t Input[3] = {In[0], In[1], In[2]};
     size_t Result;
     // TODO catch an exception and put it to list of asynchronous exceptions

--- a/sycl/include/CL/sycl/detail/kernel_info.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_info.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
+#include <CL/sycl/detail/kernel_impl.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
@@ -21,28 +22,30 @@ namespace detail {
 template <typename T, info::kernel Param> struct get_kernel_info {};
 
 template <info::kernel Param> struct get_kernel_info<string_class, Param> {
-  static string_class get(RT::PiKernel Kernel) {
+  static string_class get(RT::PiKernel Kernel, const plugin_impl &Plugin) {
     size_t ResultSize;
+
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piKernelGetInfo)(Kernel, cl_kernel_info(Param), 0, nullptr,
-                             &ResultSize);
+    Plugin.call<PiApiKind::piKernelGetInfo>(Kernel, cl_kernel_info(Param), 0,
+                                            nullptr, &ResultSize);
     if (ResultSize == 0) {
       return "";
     }
     vector_class<char> Result(ResultSize);
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piKernelGetInfo)(Kernel, cl_kernel_info(Param), ResultSize,
-                             Result.data(), nullptr);
+    Plugin.call<PiApiKind::piKernelGetInfo>(Kernel, cl_kernel_info(Param),
+                                            ResultSize, Result.data(), nullptr);
     return string_class(Result.data());
   }
 };
 
 template <info::kernel Param> struct get_kernel_info<cl_uint, Param> {
-  static cl_uint get(RT::PiKernel Kernel) {
+  static cl_uint get(RT::PiKernel Kernel, const plugin_impl &Plugin) {
     cl_uint Result;
+
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piKernelGetInfo)(Kernel, cl_kernel_info(Param), sizeof(cl_uint),
-                             &Result, nullptr);
+    Plugin.call<PiApiKind::piKernelGetInfo>(Kernel, cl_kernel_info(Param),
+                                            sizeof(cl_uint), &Result, nullptr);
     return Result;
   }
 };
@@ -51,24 +54,26 @@ template <info::kernel Param> struct get_kernel_info<cl_uint, Param> {
 
 template <typename T, info::kernel_work_group Param>
 struct get_kernel_work_group_info {
-  static T get(RT::PiKernel Kernel, RT::PiDevice Device) {
+  static T get(RT::PiKernel Kernel, RT::PiDevice Device,
+               const plugin_impl &Plugin) {
     T Result;
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piKernelGetGroupInfo)(Kernel, Device,
-                                  cl_kernel_work_group_info(Param), sizeof(T),
-                                  &Result, nullptr);
+    Plugin.call<PiApiKind::piKernelGetGroupInfo>(
+        Kernel, Device, cl_kernel_work_group_info(Param), sizeof(T), &Result,
+        nullptr);
     return Result;
   }
 };
 
 template <info::kernel_work_group Param>
 struct get_kernel_work_group_info<cl::sycl::range<3>, Param> {
-  static cl::sycl::range<3> get(RT::PiKernel Kernel, RT::PiDevice Device) {
+  static cl::sycl::range<3> get(RT::PiKernel Kernel, RT::PiDevice Device,
+                                const plugin_impl &Plugin) {
     size_t Result[3];
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piKernelGetGroupInfo)(Kernel, Device,
-                                  cl_kernel_work_group_info(Param),
-                                  sizeof(size_t) * 3, Result, nullptr);
+    Plugin.call<PiApiKind::piKernelGetGroupInfo>(
+        Kernel, Device, cl_kernel_work_group_info(Param), sizeof(size_t) * 3,
+        Result, nullptr);
     return cl::sycl::range<3>(Result[0], Result[1], Result[2]);
   }
 };
@@ -106,22 +111,24 @@ get_kernel_work_group_info_host<info::kernel_work_group::private_mem_size>(
 
 template <typename TOut, info::kernel_sub_group Param>
 struct get_kernel_sub_group_info {
-  static TOut get(RT::PiKernel Kernel, RT::PiDevice Device) {
+  static TOut get(RT::PiKernel Kernel, RT::PiDevice Device,
+                  const plugin_impl &Plugin) {
     TOut Result;
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piKernelGetSubGroupInfo)(Kernel, Device,
-                                     cl_kernel_sub_group_info(Param), 0,
-                                     nullptr, sizeof(TOut), &Result, nullptr);
+    Plugin.call<PiApiKind::piKernelGetSubGroupInfo>(
+        Kernel, Device, cl_kernel_sub_group_info(Param), 0, nullptr,
+        sizeof(TOut), &Result, nullptr);
     return Result;
   }
 };
 
 template <typename TOut, info::kernel_sub_group Param, typename TIn>
 struct get_kernel_sub_group_info_with_input {
-  static TOut get(RT::PiKernel Kernel, RT::PiDevice Device, TIn In) {
+  static TOut get(RT::PiKernel Kernel, RT::PiDevice Device, TIn In,
+                  const plugin_impl &Plugin) {
     TOut Result;
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piKernelGetSubGroupInfo)(
+    Plugin.call<PiApiKind::piKernelGetSubGroupInfo>(
         Kernel, Device, cl_kernel_sub_group_info(Param), sizeof(TIn), &In,
         sizeof(TOut), &Result, nullptr);
     return Result;
@@ -129,13 +136,12 @@ struct get_kernel_sub_group_info_with_input {
 };
 
 template <info::kernel_sub_group Param>
-struct get_kernel_sub_group_info_with_input<cl::sycl::range<3>, Param,
-                                            size_t> {
+struct get_kernel_sub_group_info_with_input<cl::sycl::range<3>, Param, size_t> {
   static cl::sycl::range<3> get(RT::PiKernel Kernel, RT::PiDevice Device,
-                                size_t In) {
+                                size_t In, const plugin_impl &Plugin) {
     size_t Result[3];
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piKernelGetSubGroupInfo)(
+    Plugin.call<PiApiKind::piKernelGetSubGroupInfo>(
         Kernel, Device, cl_kernel_sub_group_info(Param), sizeof(size_t), &In,
         sizeof(size_t) * 3, Result, nullptr);
     return cl::sycl::range<3>(Result[0], Result[1], Result[2]);
@@ -143,14 +149,13 @@ struct get_kernel_sub_group_info_with_input<cl::sycl::range<3>, Param,
 };
 
 template <info::kernel_sub_group Param>
-struct get_kernel_sub_group_info_with_input<size_t, Param,
-                                            cl::sycl::range<3>> {
+struct get_kernel_sub_group_info_with_input<size_t, Param, cl::sycl::range<3>> {
   static size_t get(RT::PiKernel Kernel, RT::PiDevice Device,
-                    cl::sycl::range<3> In) {
+                    cl::sycl::range<3> In, const plugin_impl &Plugin) {
     size_t Input[3] = {In[0], In[1], In[2]};
     size_t Result;
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piKernelGetSubGroupInfo)(
+    Plugin.call<PiApiKind::piKernelGetSubGroupInfo>(
         Kernel, Device, cl_kernel_sub_group_info(Param), sizeof(size_t) * 3,
         Input, sizeof(size_t), &Result, nullptr);
     return Result;

--- a/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
@@ -22,6 +22,7 @@
 __SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
+class context_impl;
 class KernelProgramCache {
 public:
   /// Denotes pointer to some entity with its state.

--- a/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
@@ -11,6 +11,7 @@
 #include <CL/sycl/detail/locked.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/platform_impl.hpp>
 
 #include <atomic>
 #include <condition_variable>
@@ -41,6 +42,7 @@ public:
   using PiProgramPtrT = std::atomic<PiProgramT *>;
   using ProgramWithBuildStateT = EntityWithState<PiProgramT>;
   using ProgramCacheT = std::map<OSModuleHandle, ProgramWithBuildStateT>;
+  using PlatformImplPtr = std::shared_ptr<platform_impl>;
 
   using PiKernelT = std::remove_pointer<RT::PiKernel>::type;
   using PiKernelPtrT = std::atomic<PiKernelT *>;
@@ -49,6 +51,8 @@ public:
   using KernelCacheT = std::map<RT::PiProgram, KernelByNameT>;
 
   ~KernelProgramCache();
+
+  void setPlatformImpl(PlatformImplPtr APlatform) { MPlatform = APlatform; }
 
   Locked<ProgramCacheT> acquireCachedPrograms() {
     return {MCachedPrograms, MProgramCacheMutex};
@@ -78,6 +82,7 @@ private:
 
   ProgramCacheT MCachedPrograms;
   KernelCacheT MKernelsPerProgramCache;
+  PlatformImplPtr MPlatform;
 };
 }
 }

--- a/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
@@ -52,7 +52,7 @@ public:
 
   ~KernelProgramCache();
 
-  void setPlatformImpl(PlatformImplPtr APlatform) { MPlatform = APlatform; }
+  void setPlatformImpl(const PlatformImplPtr &APlatform) { MPlatform = APlatform; }
 
   Locked<ProgramCacheT> acquireCachedPrograms() {
     return {MCachedPrograms, MProgramCacheMutex};

--- a/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
@@ -42,7 +42,7 @@ public:
   using PiProgramPtrT = std::atomic<PiProgramT *>;
   using ProgramWithBuildStateT = EntityWithState<PiProgramT>;
   using ProgramCacheT = std::map<OSModuleHandle, ProgramWithBuildStateT>;
-  using PlatformImplPtr = std::shared_ptr<platform_impl>;
+  using ContextPtr = context_impl *;
 
   using PiKernelT = std::remove_pointer<RT::PiKernel>::type;
   using PiKernelPtrT = std::atomic<PiKernelT *>;
@@ -52,7 +52,7 @@ public:
 
   ~KernelProgramCache();
 
-  void setPlatformImpl(const PlatformImplPtr &APlatform) { MPlatform = APlatform; }
+  void setContextPtr(const ContextPtr &AContext) { MParentContext = AContext; }
 
   Locked<ProgramCacheT> acquireCachedPrograms() {
     return {MCachedPrograms, MProgramCacheMutex};
@@ -82,7 +82,7 @@ private:
 
   ProgramCacheT MCachedPrograms;
   KernelCacheT MKernelsPerProgramCache;
-  PlatformImplPtr MPlatform;
+  ContextPtr MParentContext;
 };
 }
 }

--- a/sycl/include/CL/sycl/detail/memory_manager.hpp
+++ b/sycl/include/CL/sycl/detail/memory_manager.hpp
@@ -36,14 +36,14 @@ public:
   // The following method releases memory allocation of memory object.
   // Depending on the context it releases memory on host or on device.
   static void release(ContextImplPtr TargetContext, SYCLMemObjI *MemObj,
-                      void *MemAllocation, std::vector<RT::PiEvent> DepEvents,
+                      void *MemAllocation, std::vector<EventImplPtr> DepEvents,
                       RT::PiEvent &OutEvent);
 
   // The following method allocates memory allocation of memory object.
   // Depending on the context it allocates memory on host or on device.
   static void *allocate(ContextImplPtr TargetContext, SYCLMemObjI *MemObj,
                         bool InitFromUserData, void *HostPtr,
-                        std::vector<RT::PiEvent> DepEvents,
+                        std::vector<EventImplPtr> DepEvents,
                         RT::PiEvent &OutEvent);
 
   // The following method creates OpenCL sub buffer for specified
@@ -51,7 +51,7 @@ public:
   static void *allocateMemSubBuffer(ContextImplPtr TargetContext,
                                     void *ParentMemObj, size_t ElemSize,
                                     size_t Offset, range<3> Range,
-                                    std::vector<RT::PiEvent> DepEvents,
+                                    std::vector<EventImplPtr> DepEvents,
                                     RT::PiEvent &OutEvent);
 
   // Allocates buffer in specified context taking into account situations such

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -20,20 +20,13 @@
 __SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
+
+enum class PiApiKind {
+#define _PI_API(api) api,
+#include <CL/sycl/detail/pi.def>
+};
+class plugin_impl;
 namespace pi {
-
-// Function to load the shared library
-// Implementation is OS dependent.
-void *loadOsLibrary(const std::string &Library);
-
-// Function to get Address of a symbol defined in the shared
-// library, implementation is OS dependent.
-void *getOsLibraryFuncAddress(void *Library, const std::string &FunctionName);
-
-// For selection of SYCL RT back-end, now manually through the "SYCL_BE"
-// environment variable.
-//
-enum Backend { SYCL_BE_PI_OPENCL, SYCL_BE_PI_OTHER };
 
 #ifdef SYCL_RT_OS_WINDOWS
 #define PLUGIN_NAME "pi_opencl.dll"
@@ -41,9 +34,7 @@ enum Backend { SYCL_BE_PI_OPENCL, SYCL_BE_PI_OTHER };
 #define PLUGIN_NAME "libpi_opencl.so"
 #endif
 
-// Check for manually selected BE at run-time.
-bool useBackend(Backend Backend);
-
+using PiPlugin = ::pi_plugin;
 using PiResult = ::pi_result;
 using PiPlatform = ::pi_platform;
 using PiDevice = ::pi_device;
@@ -70,40 +61,69 @@ using PiMemObjectType = ::pi_mem_type;
 using PiMemImageChannelOrder = ::pi_image_channel_order;
 using PiMemImageChannelType = ::pi_image_channel_type;
 
+// Function to load the shared library
+// Implementation is OS dependent.
+void *loadOsLibrary(const std::string &Library);
+
+// Function to get Address of a symbol defined in the shared
+// library, implementation is OS dependent.
+void *getOsLibraryFuncAddress(void *Library, const std::string &FunctionName);
+
+// For selection of SYCL RT back-end, now manually through the "SYCL_BE"
+// environment variable.
+enum Backend { SYCL_BE_PI_OPENCL, SYCL_BE_PI_OTHER };
+
+// Check for manually selected BE at run-time.
+bool useBackend(Backend Backend);
+
 // Get a string representing a _pi_platform_info enum
 std::string platformInfoToString(pi_platform_info info);
 
 // Report error and no return (keeps compiler happy about no return statements).
 [[noreturn]] void die(const char *Message);
+
 void assertion(bool Condition, const char *Message = nullptr);
 
 // Want all the needed casts be explicit, do not define conversion operators.
 template <class To, class From> To cast(From value);
 
 // Holds the PluginInformation for the plugin that is bound.
-// TODO: Move this into sycl::platform. Currenlty, we have only a single Plugin
-// connection possible.
-extern pi_plugin PluginInformation;
+// Currently a global varaible is used to store OpenCL plugin information to be
+// used with SYCL Interoperability Constructors.
+extern std::shared_ptr<plugin_impl> GlobalPlugin;
 
 // Performs PI one-time initialization.
-void initialize();
+vector_class<plugin_impl> initialize();
 
+// Utility Functions to get Function Name for a PI Api.
+template <PiApiKind PiApiOffset> struct PiFuncInfo {};
+
+#define _PI_API(api)                                                           \
+  template <> struct PiFuncInfo<PiApiKind::api> {                              \
+    inline std::string getFuncName() { return #api; }                          \
+    inline decltype(&::api) getFuncPtr(PiPlugin MPlugin) {                     \
+      return MPlugin.PiFunctionTable.api;                                      \
+    }                                                                          \
+  };
+#include <CL/sycl/detail/pi.def>
+
+// Helper utilities for PI Tracing
 // The run-time tracing of PI calls.
 // Print functions used by Trace class.
 template <typename T> inline void print(T val) {
-  std::cout << "<unknown> : " << val;
+  std::cout << "<unknown> : " << val << std::endl;
 }
 
 template <> inline void print<>(PiPlatform val) {
-  std::cout << "pi_platform : " << val;
+  std::cout << "pi_platform : " << val << std::endl;
 }
 
 template <> inline void print<>(PiResult val) {
   std::cout << "pi_result : ";
   if (val == PI_SUCCESS)
-    std::cout << "PI_SUCCESS";
+    std::cout << "PI_SUCCESS" << std::endl;
   else
-    std::cout << val;
+    std::cout << val << std::endl;
 }
 
 // cout does not resolve a nullptr.
@@ -112,123 +132,19 @@ template <> inline void print<>(std::nullptr_t val) { print<void *>(val); }
 inline void printArgs(void) {}
 template <typename Arg0, typename... Args>
 void printArgs(Arg0 arg0, Args... args) {
-  std::cout << std::endl << "       ";
+  std::cout << "       ";
   print(arg0);
   printArgs(std::forward<Args>(args)...);
 }
-
-// Utility function to check return from pi calls.
-// Throws if pi_result is not a PI_SUCCESS.
-template <typename Exception = cl::sycl::runtime_error>
-inline void checkPiResult(PiResult pi_result) {
-  CHECK_OCL_CODE_THROW(pi_result, Exception);
-}
-
-// Class to call PI API, trace and get the result.
-// To Trace : Set SYCL_PI_TRACE environment variable.
-// Template Arguments:
-//    FnType  - Type of Function pointer to the PI API.
-//    FnOffset- Offset to the Function Pointer in the piPlugin::FunctionPointers
-//    structure. Used to differentiate between APIs with same pointer type,
-//    E.g.: piDeviceRelease and piDeviceRetain. Differentiation needed to avoid
-//    redefinition error during explicit specialization of class in pi.cpp.
-// Members: Initialized in default constructor in Class Template Specialization.
-// Usage:
-// Operator() - Call, Trace and Get result
-// Use Macro PI_CALL_NOCHECK call the constructor directly.
-template <typename FnType, size_t FnOffset> class CallPi {
-private:
-  FnType MFnPtr;
-  std::string MFnName;
-  static bool MEnableTrace;
-
-public:
-  CallPi();
-  template <typename... Args> PiResult operator()(Args... args) {
-    if (MEnableTrace) {
-      std::cout << "---> " << MFnName << "(";
-      printArgs(args...);
-    }
-
-    PiResult r = MFnPtr(args...);
-
-    if (MEnableTrace) {
-      std::cout << ") ---> ";
-      std::cout << (print(r), "") << std::endl;
-    }
-    return r;
-  }
-};
-
-template <typename FnType, size_t FnOffset>
-bool CallPi<FnType, FnOffset>::MEnableTrace = (std::getenv("SYCL_PI_TRACE") !=
-                                               nullptr);
-
-// Class to call PI API, trace, check the return result and throw Exception.
-// To Trace : Set SYCL_PI_TRACE environment variable.
-// Template Arguments:
-//    FnType, FnOffset - for CallPi Class.
-//    Exception - The type of exception to throw if PiResult of a call is not
-//    PI_SUCCESS. Default value is cl::sycl::runtime_error.
-// Usage:
-// Operator() - Call, Trace, check Result and Throw Exception.
-// Use Macro PI_CALL and PI_CALL_THROW to call the constructor directly.
-template <typename FnType, size_t FnOffset,
-          typename Exception = cl::sycl::runtime_error>
-class CallPiAndCheck : private CallPi<FnType, FnOffset> {
-public:
-  CallPiAndCheck() : CallPi<FnType, FnOffset>(){};
-
-  template <typename... Args> void operator()(Args... args) {
-    PiResult Err = (CallPi<FnType, FnOffset>::operator()(args...));
-    checkPiResult<Exception>(Err);
-  }
-};
-
-// Explicit specialization declarations for Trace class for every FnType.
-// The offsetof is used as a template argument to uniquely identify every
-// api.
-#define _PI_API(api)                                                           \
-  template <>                                                                  \
-  CallPi<decltype(&::api),                                                     \
-         (offsetof(pi_plugin::FunctionPointers, api))>::CallPi();
-
-#include <CL/sycl/detail/pi.def>
-
 } // namespace pi
 
 namespace RT = cl::sycl::detail::pi;
-
-// Use this macro to call the API, trace the call, check the return and throw a
-// runtime_error exception.
-// Usage: PI_CALL(pi)(Args);
-#define PI_CALL(pi)                                                            \
-  RT::CallPiAndCheck<decltype(&::pi),                                          \
-                     (offsetof(pi_plugin::FunctionPointers, pi))>()
-
-// Use this macro to call the API, trace the call and return the result.
-// To check the result use checkPiResult.
-// Usage:
-// PiResult Err = PI_CALL_NOCHECK(pi)(args);
-// RT::checkPiResult(Err); <- Checks Result and throws a runtime_error
-// exception.
-#define PI_CALL_NOCHECK(pi)                                                    \
-  RT::CallPi<decltype(&::pi), (offsetof(pi_plugin::FunctionPointers, pi))>()
-
-// Use this macro to call the API, trace the call, check the return and throw an
-// Exception as given in the MACRO.
-// Usage: PI_CALL_THROW(pi, compile_program_error)(args);
-#define PI_CALL_THROW(pi, Exception)                                           \
-  RT::CallPiAndCheck<decltype(&::pi),                                          \
-                     (offsetof(pi_plugin::FunctionPointers, pi)), Exception>()
-
-#define PI_ASSERT(cond, msg) RT::assertion((cond), "assert: " msg);
 
 // Want all the needed casts be explicit, do not define conversion
 // operators.
 template <class To, class From> To pi::cast(From value) {
   // TODO: see if more sanity checks are possible.
-  PI_ASSERT(sizeof(From) == sizeof(To), "cast failed size check");
+  RT::assertion((sizeof(From) == sizeof(To)), "assert: cast failed size check");
   return (To)(value);
 }
 

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -25,7 +25,7 @@ enum class PiApiKind {
 #define _PI_API(api) api,
 #include <CL/sycl/detail/pi.def>
 };
-class plugin_impl;
+class plugin;
 namespace pi {
 
 #ifdef SYCL_RT_OS_WINDOWS
@@ -90,10 +90,10 @@ template <class To, class From> To cast(From value);
 // Holds the PluginInformation for the plugin that is bound.
 // Currently a global varaible is used to store OpenCL plugin information to be
 // used with SYCL Interoperability Constructors.
-extern std::shared_ptr<plugin_impl> GlobalPlugin;
+extern std::shared_ptr<plugin> GlobalPlugin;
 
 // Performs PI one-time initialization.
-vector_class<plugin_impl> initialize();
+vector_class<plugin> initialize();
 
 // Utility Functions to get Function Name for a PI Api.
 template <PiApiKind PiApiOffset> struct PiFuncInfo {};

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -10,6 +10,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/force_device.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/plugin_impl.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
@@ -32,7 +33,11 @@ public:
   /// Constructs platform_impl from a plug-in interoperability platform handle.
   ///
   /// @param Platform is a raw plug-in platform handle.
-  explicit platform_impl(RT::PiPlatform Platform) : MPlatform(Platform) {}
+  explicit platform_impl(RT::PiPlatform APlatform, const plugin_impl &APlugin)
+      : MPlatform(APlatform), MPlugin(std::make_shared<plugin_impl>(APlugin)) {}
+
+  explicit platform_impl(RT::PiPlatform APlatform, std::shared_ptr<plugin_impl> APlugin)
+      : MPlatform(APlatform), MPlugin(APlugin) {}
 
   ~platform_impl() = default;
 
@@ -97,9 +102,16 @@ public:
   /// @return a vector of all available SYCL platforms.
   static vector_class<platform> get_platforms();
 
+  // @return the Plugin associated with this platform.
+  const plugin_impl &getPlugin() const {
+    assert(!MHostPlatform && "Plugin is not available for Host.");
+    return *MPlugin;
+  }
+
 private:
   bool MHostPlatform = false;
   RT::PiPlatform MPlatform = 0;
+  std::shared_ptr<plugin_impl> MPlugin;
 };
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/force_device.hpp>
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
@@ -33,10 +33,10 @@ public:
   /// Constructs platform_impl from a plug-in interoperability platform handle.
   ///
   /// @param Platform is a raw plug-in platform handle.
-  explicit platform_impl(RT::PiPlatform APlatform, const plugin_impl &APlugin)
-      : MPlatform(APlatform), MPlugin(std::make_shared<plugin_impl>(APlugin)) {}
+  explicit platform_impl(RT::PiPlatform APlatform, const plugin &APlugin)
+      : MPlatform(APlatform), MPlugin(std::make_shared<plugin>(APlugin)) {}
 
-  explicit platform_impl(RT::PiPlatform APlatform, std::shared_ptr<plugin_impl> APlugin)
+  explicit platform_impl(RT::PiPlatform APlatform, std::shared_ptr<plugin> APlugin)
       : MPlatform(APlatform), MPlugin(APlugin) {}
 
   ~platform_impl() = default;
@@ -103,7 +103,7 @@ public:
   static vector_class<platform> get_platforms();
 
   // @return the Plugin associated with this platform.
-  const plugin_impl &getPlugin() const {
+  const plugin &getPlugin() const {
     assert(!MHostPlatform && "Plugin is not available for Host.");
     return *MPlugin;
   }
@@ -111,7 +111,7 @@ public:
 private:
   bool MHostPlatform = false;
   RT::PiPlatform MPlatform = 0;
-  std::shared_ptr<plugin_impl> MPlugin;
+  std::shared_ptr<plugin> MPlugin;
 };
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/detail/platform_info.hpp
+++ b/sycl/include/CL/sycl/detail/platform_info.hpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
 __SYCL_INLINE namespace cl {
@@ -22,7 +22,7 @@ template <typename T, info::platform param> struct get_platform_info {};
 
 template <info::platform param>
 struct get_platform_info<string_class, param> {
-  static string_class get(RT::PiPlatform plt, const plugin_impl &Plugin) {
+  static string_class get(RT::PiPlatform plt, const plugin &Plugin) {
     size_t resultSize;
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piPlatformGetInfo>(
@@ -43,7 +43,7 @@ template <>
 struct get_platform_info<vector_class<string_class>,
                          info::platform::extensions> {
   static vector_class<string_class> get(RT::PiPlatform plt,
-                                        const plugin_impl &Plugin) {
+                                        const plugin &Plugin) {
     string_class result =
         get_platform_info<string_class, info::platform::extensions>::get(
             plt, Plugin);

--- a/sycl/include/CL/sycl/detail/platform_info.hpp
+++ b/sycl/include/CL/sycl/detail/platform_info.hpp
@@ -10,6 +10,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/plugin_impl.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
 __SYCL_INLINE namespace cl {
@@ -21,18 +22,19 @@ template <typename T, info::platform param> struct get_platform_info {};
 
 template <info::platform param>
 struct get_platform_info<string_class, param> {
-  static string_class get(RT::PiPlatform plt) {
+  static string_class get(RT::PiPlatform plt, const plugin_impl &Plugin) {
     size_t resultSize;
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piPlatformGetInfo)(plt, pi::cast<pi_platform_info>(param), 0,
-                               nullptr, &resultSize);
+    Plugin.call<PiApiKind::piPlatformGetInfo>(
+        plt, pi::cast<pi_platform_info>(param), 0, nullptr, &resultSize);
     if (resultSize == 0) {
       return "";
     }
     unique_ptr_class<char[]> result(new char[resultSize]);
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piPlatformGetInfo)(plt, pi::cast<pi_platform_info>(param),
-                               resultSize, result.get(), nullptr);
+    Plugin.call<PiApiKind::piPlatformGetInfo>(
+        plt, pi::cast<pi_platform_info>(param), resultSize, result.get(),
+        nullptr);
     return result.get();
   }
 };
@@ -40,9 +42,11 @@ struct get_platform_info<string_class, param> {
 template <>
 struct get_platform_info<vector_class<string_class>,
                          info::platform::extensions> {
-  static vector_class<string_class> get(RT::PiPlatform plt) {
+  static vector_class<string_class> get(RT::PiPlatform plt,
+                                        const plugin_impl &Plugin) {
     string_class result =
-        get_platform_info<string_class, info::platform::extensions>::get(plt);
+        get_platform_info<string_class, info::platform::extensions>::get(
+            plt, Plugin);
     return split_string(result, ' ');
   }
 };

--- a/sycl/include/CL/sycl/detail/plugin.hpp
+++ b/sycl/include/CL/sycl/detail/plugin.hpp
@@ -43,8 +43,8 @@ public:
   template <PiApiKind PiApiOffset, typename... ArgsT>
   RT::PiResult call_nocheck(ArgsT... Args) const {
     RT::PiFuncInfo<PiApiOffset> PiCallInfo;
-    std::string FnName = PiCallInfo.getFuncName();
     if (MPiEnableTrace) {
+      std::string FnName = PiCallInfo.getFuncName();
       std::cout << "---> " << FnName << "(" << std::endl;
       RT::printArgs(Args...);
     }
@@ -63,7 +63,8 @@ public:
     RT::PiResult Err = call_nocheck<PiApiOffset>(Args...);
     checkPiResult(Err);
   }
-  // TODO: Make this private.
+  // TODO: Make this private. Currently used in program_manager to create a
+  // pointer to PiProgram.
   RT::PiPlugin MPlugin;
 
 private:

--- a/sycl/include/CL/sycl/detail/plugin.hpp
+++ b/sycl/include/CL/sycl/detail/plugin.hpp
@@ -1,4 +1,4 @@
-//==--------------------- plugin_impl.hpp - SYCL platform-------------------==//
+//==--------------------- plugin.hpp - SYCL platform-------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -15,15 +15,15 @@ __SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 
-class plugin_impl {
+class plugin {
 public:
-  plugin_impl() = delete;
+  plugin() = delete;
 
-  plugin_impl(RT::PiPlugin Plugin) : MPlugin(Plugin) {
+  plugin(RT::PiPlugin Plugin) : MPlugin(Plugin) {
     MPiEnableTrace = (std::getenv("SYCL_PI_TRACE") != nullptr);
   }
 
-  ~plugin_impl() = default;
+  ~plugin() = default;
 
   // Utility function to check return from PI calls.
   // Throws if pi_result is not a PI_SUCCESS.
@@ -69,7 +69,7 @@ public:
 private:
   bool MPiEnableTrace;
 
-}; // class plugin_impl
+}; // class plugin
 } // namespace detail
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/detail/plugin_impl.hpp
+++ b/sycl/include/CL/sycl/detail/plugin_impl.hpp
@@ -1,0 +1,75 @@
+//==--------------------- plugin_impl.hpp - SYCL platform-------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/stl.hpp>
+
+__SYCL_INLINE namespace cl {
+namespace sycl {
+namespace detail {
+
+class plugin_impl {
+public:
+  plugin_impl() = delete;
+
+  plugin_impl(RT::PiPlugin Plugin) : MPlugin(Plugin) {
+    MPiEnableTrace = (std::getenv("SYCL_PI_TRACE") != nullptr);
+  }
+
+  ~plugin_impl() = default;
+
+  // Utility function to check return from PI calls.
+  // Throws if pi_result is not a PI_SUCCESS.
+  // Exception - The type of exception to throw if PiResult of a call is not
+  // PI_SUCCESS. Default value is cl::sycl::runtime_error.
+  template <typename Exception = cl::sycl::runtime_error>
+  void checkPiResult(RT::PiResult pi_result) const {
+    CHECK_OCL_CODE_THROW(pi_result, Exception);
+  }
+
+  // Call the PiApi, trace the call and return the result.
+  // To check the result use checkPiResult.
+  // Usage:
+  // PiResult Err = plugin.call<PiApiKind::pi>(Args);
+  // Plugin.checkPiResult(Err); <- Checks Result and throws a runtime_error
+  // exception.
+  template <PiApiKind PiApiOffset, typename... ArgsT>
+  RT::PiResult call_nocheck(ArgsT... Args) const {
+    RT::PiFuncInfo<PiApiOffset> PiCallInfo;
+    std::string FnName = PiCallInfo.getFuncName();
+    if (MPiEnableTrace) {
+      std::cout << "---> " << FnName << "(" << std::endl;
+      RT::printArgs(Args...);
+    }
+    RT::PiResult R = PiCallInfo.getFuncPtr(MPlugin)(Args...);
+    if (MPiEnableTrace) {
+      std::cout << ") ---> ";
+      RT::printArgs(R);
+    }
+    return R;
+  }
+
+  // Call the API, trace the call, check the result and throw
+  // a runtime_error Exception
+  template <PiApiKind PiApiOffset, typename... ArgsT>
+  void call(ArgsT... Args) const {
+    RT::PiResult Err = call_nocheck<PiApiOffset>(Args...);
+    checkPiResult(Err);
+  }
+  // TODO: Make this private.
+  RT::PiPlugin MPlugin;
+
+private:
+  bool MPiEnableTrace;
+
+}; // class plugin_impl
+} // namespace detail
+} // namespace sycl
+} // namespace cl

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -235,7 +235,7 @@ public:
   }
 
   // @return the Plugin associated withh the context of this program.
-  const plugin_impl &getPlugin() const {
+  const plugin &getPlugin() const {
     assert(!is_host() && "Plugin is not available for Host.");
     return MContext->getPlugin();
   }

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -234,6 +234,12 @@ public:
     return createSyclObjFromImpl<context>(MContext);
   }
 
+  // @return the Plugin associated withh the context of this program.
+  const plugin_impl &getPlugin() const {
+    assert(!is_host() && "Plugin is not available for Host.");
+    return MContext->getPlugin();
+  }
+
   /// @return a vector of devices that are associated with this program.
   vector_class<device> get_devices() const { return MDevices; }
 

--- a/sycl/include/CL/sycl/detail/program_manager/program_manager.hpp
+++ b/sycl/include/CL/sycl/detail/program_manager/program_manager.hpp
@@ -34,6 +34,8 @@ namespace sycl {
 class context;
 namespace detail {
 
+class context_impl;
+using ContextImplPtr = std::shared_ptr<context_impl>;
 using DeviceImage = pi_device_binary_struct;
 
 // Custom deleter for the DeviceImage. Must only be called for "orphan" images
@@ -58,13 +60,15 @@ public:
   RT::PiProgram getBuiltPIProgram(OSModuleHandle M, const context &Context,
                                   const string_class &KernelName);
   RT::PiKernel getOrCreateKernel(OSModuleHandle M, const context &Context,
-                                  const string_class &KernelName);
-  RT::PiProgram getClProgramFromClKernel(RT::PiKernel Kernel);
+                                 const string_class &KernelName);
+  RT::PiProgram getClProgramFromClKernel(RT::PiKernel Kernel,
+                                         const ContextImplPtr Context);
 
   void addImages(pi_device_binaries DeviceImages);
   void debugDumpBinaryImages() const;
   void debugDumpBinaryImage(const DeviceImage *Img) const;
-  static string_class getProgramBuildLog(const RT::PiProgram &Program);
+  static string_class getProgramBuildLog(const RT::PiProgram &Program,
+                                         const ContextImplPtr Context);
 
 private:
   ProgramManager();
@@ -76,7 +80,7 @@ private:
                               const context &Context);
   using ProgramPtr = unique_ptr_class<remove_pointer_t<RT::PiProgram>,
                                       decltype(&::piProgramRelease)>;
-  ProgramPtr build(ProgramPtr Program, RT::PiContext Context,
+  ProgramPtr build(ProgramPtr Program, const ContextImplPtr Context,
                    const string_class &CompileOptions,
                    const string_class &LinkOptions,
                    const std::vector<RT::PiDevice> &Devices,

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -88,7 +88,7 @@ public:
     MCommandQueue = pi::cast<RT::PiQueue>(PiQueue);
 
     RT::PiDevice Device = nullptr;
-    auto Plugin = getPlugin();
+    const detail::plugin &Plugin = getPlugin();
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piQueueGetInfo>(MCommandQueue, PI_QUEUE_INFO_DEVICE,
                                            sizeof(Device), &Device, nullptr);
@@ -231,7 +231,7 @@ public:
     RT::PiQueue Queue;
     RT::PiContext Context = MContext->getHandleRef();
     RT::PiDevice Device = MDevice->getHandleRef();
-    auto Plugin = getPlugin();
+    const detail::plugin &Plugin = getPlugin();
     RT::PiResult Error = Plugin.call_nocheck<PiApiKind::piQueueCreate>(
         Context, Device, CreationFlags, &Queue);
 

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/event.hpp>
@@ -121,7 +121,7 @@ public:
     return createSyclObjFromImpl<context>(MContext);
   }
 
-  const plugin_impl &getPlugin() const { return MContext->getPlugin(); }
+  const plugin &getPlugin() const { return MContext->getPlugin(); }
 
   ContextImplPtr getContextImplPtr() const { return MContext; }
 

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -12,6 +12,7 @@
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
+#include <CL/sycl/detail/plugin_impl.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/event.hpp>
@@ -25,8 +26,8 @@ __SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 
-using ContextImplPtr = shared_ptr_class<detail::context_impl>;
-using DeviceImplPtr = shared_ptr_class<detail::device_impl>;
+using ContextImplPtr = std::shared_ptr<detail::context_impl>;
+using DeviceImplPtr = std::shared_ptr<detail::device_impl>;
 
 /// Sets max number of queues supported by FPGA RT.
 const size_t MaxNumQueues = 256;
@@ -87,26 +88,28 @@ public:
     MCommandQueue = pi::cast<RT::PiQueue>(PiQueue);
 
     RT::PiDevice Device = nullptr;
+    auto Plugin = getPlugin();
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piQueueGetInfo)(MCommandQueue, PI_QUEUE_INFO_DEVICE, sizeof(Device),
-                            &Device, nullptr);
-    MDevice = std::make_shared<device_impl>(Device);
+    Plugin.call<PiApiKind::piQueueGetInfo>(MCommandQueue, PI_QUEUE_INFO_DEVICE,
+                                           sizeof(Device), &Device, nullptr);
+    MDevice =
+        std::make_shared<device_impl>(Device, Context->getPlatformImpl());
 
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piQueueRetain)(MCommandQueue);
+    Plugin.call<PiApiKind::piQueueRetain>(MCommandQueue);
   }
 
   ~queue_impl() {
     throw_asynchronous();
     if (MOpenCLInterop) {
-      PI_CALL(piQueueRelease)(MCommandQueue);
+      getPlugin().call<PiApiKind::piQueueRelease>(MCommandQueue);
     }
   }
 
   /// @return an OpenCL interoperability queue handle.
   cl_command_queue get() {
     if (MOpenCLInterop) {
-      PI_CALL(piQueueRetain)(MCommandQueue);
+      getPlugin().call<PiApiKind::piQueueRetain>(MCommandQueue);
       return pi::cast<cl_command_queue>(MCommandQueue);
     }
     throw invalid_object_error(
@@ -117,6 +120,8 @@ public:
   context get_context() const {
     return createSyclObjFromImpl<context>(MContext);
   }
+
+  const plugin_impl &getPlugin() const { return MContext->getPlugin(); }
 
   ContextImplPtr getContextImplPtr() const { return MContext; }
 
@@ -226,8 +231,9 @@ public:
     RT::PiQueue Queue;
     RT::PiContext Context = MContext->getHandleRef();
     RT::PiDevice Device = MDevice->getHandleRef();
-    RT::PiResult Error =
-        PI_CALL_NOCHECK(piQueueCreate)(Context, Device, CreationFlags, &Queue);
+    auto Plugin = getPlugin();
+    RT::PiResult Error = Plugin.call_nocheck<PiApiKind::piQueueCreate>(
+        Context, Device, CreationFlags, &Queue);
 
     // If creating out-of-order queue failed and this property is not
     // supported (for example, on FPGA), it will return
@@ -236,7 +242,7 @@ public:
       MSupportOOO = false;
       Queue = createQueue(QueueOrder::Ordered);
     } else {
-      RT::checkPiResult(Error);
+      Plugin.checkPiResult(Error);
     }
 
     return Queue;
@@ -260,7 +266,7 @@ public:
     MQueueNumber %= MaxNumQueues;
     size_t FreeQueueNum = MQueueNumber++;
 
-    PI_CALL(piQueueFinish)(MQueues[FreeQueueNum]);
+    getPlugin().call<PiApiKind::piQueueFinish>(MQueues[FreeQueueNum]);
     return MQueues[FreeQueueNum];
   }
 

--- a/sycl/include/CL/sycl/detail/scheduler/commands.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.hpp
@@ -131,9 +131,9 @@ protected:
   QueueImplPtr MQueue;
   std::vector<EventImplPtr> MDepsEvents;
 
-  void waitForEvents(QueueImplPtr Queue, std::vector<RT::PiEvent> &RawEvents,
+  void waitForEvents(QueueImplPtr Queue, std::vector<EventImplPtr> &RawEvents,
                      RT::PiEvent &Event);
-  std::vector<RT::PiEvent> prepareEvents(ContextImplPtr Context);
+  std::vector<EventImplPtr> prepareEvents(ContextImplPtr Context);
 
   // Private interface. Derived classes should implement this method.
   virtual cl_int enqueueImp() = 0;

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -83,7 +83,11 @@ public:
 
   virtual ~SYCLMemObjT() = default;
 
-  const plugin &getPlugin() const { return MInteropContext->getPlugin(); }
+  const plugin &getPlugin() const {
+    assert((MInteropContext != nullptr) &&
+           "Trying to get Plugin from SYCLMemObjT with nullptr ContextImpl.");
+    return (MInteropContext->getPlugin());
+  }
   size_t getSize() const override { return MSizeInBytes; }
   size_t get_count() const {
     size_t AllocatorValueSize = MAllocator->getValueSize();

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -10,7 +10,7 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_allocator.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_i.hpp>
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/event.hpp>
@@ -71,8 +71,35 @@ public:
       : SYCLMemObjT(/*SizeInBytes*/ 0, Props, std::move(Allocator)) {}
 
   SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
+<<<<<<< HEAD
               const size_t SizeInBytes, event AvailableEvent,
               unique_ptr_class<SYCLMemObjAllocator> Allocator);
+=======
+              const size_t SizeInBytes, event AvailableEvent)
+      : MAllocator(), MProps(),
+        MInteropEvent(detail::getSyclObjImpl(std::move(AvailableEvent))),
+        MInteropContext(detail::getSyclObjImpl(SyclContext)),
+        MInteropMemObject(MemObject), MOpenCLInterop(true),
+        MHostPtrReadOnly(false), MNeedWriteBack(true),
+        MSizeInBytes(SizeInBytes), MUserPtr(nullptr), MShadowCopy(nullptr),
+        MUploadDataFunctor(nullptr), MSharedPtrStorage(nullptr) {
+    if (MInteropContext->is_host())
+      throw cl::sycl::invalid_parameter_error(
+          "Creation of interoperability memory object using host context is "
+          "not allowed");
+
+    RT::PiMem Mem = pi::cast<RT::PiMem>(MInteropMemObject);
+    RT::PiContext Context = nullptr;
+    const plugin &Plugin = getPlugin();
+    Plugin.call<PiApiKind::piMemGetInfo>(Mem, CL_MEM_CONTEXT, sizeof(Context),
+                                         &Context, nullptr);
+
+    if (MInteropContext->getHandleRef() != Context)
+      throw cl::sycl::invalid_parameter_error(
+          "Input context must be the same as the context of cl_mem");
+    Plugin.call<PiApiKind::piMemRetain>(Mem);
+  }
+>>>>>>> [SYCL][PI] Renamed plugin_impl to plugin class.
 
   SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
               event AvailableEvent,
@@ -82,7 +109,7 @@ public:
 
   virtual ~SYCLMemObjT() = default;
 
-  const plugin_impl &getPlugin() const { return MInteropContext->getPlugin(); }
+  const plugin &getPlugin() const { return MInteropContext->getPlugin(); }
   size_t getSize() const override { return MSizeInBytes; }
   size_t get_count() const {
     size_t AllocatorValueSize = MAllocator->getValueSize();
@@ -174,7 +201,26 @@ public:
   // the memory object is allowed. This method is executed from child's
   // destructor. This cannot be done in SYCLMemObjT's destructor as child's
   // members must be alive.
+<<<<<<< HEAD
   void updateHostMemory();
+=======
+  void updateHostMemory() {
+    if ((MUploadDataFunctor != nullptr) && MNeedWriteBack)
+      MUploadDataFunctor();
+
+    // If we're attached to a memory record, process the deletion of the memory
+    // record. We may get detached before we do this.
+    if (MRecord)
+      Scheduler::getInstance().removeMemoryObject(this);
+    releaseHostMem(MShadowCopy);
+
+    if (MOpenCLInterop) {
+      const plugin &Plugin = getPlugin();
+      Plugin.call<PiApiKind::piMemRelease>(
+          pi::cast<RT::PiMem>(MInteropMemObject));
+    }
+  }
+>>>>>>> [SYCL][PI] Renamed plugin_impl to plugin class.
 
   bool useHostPtr() {
     return has_property<property::buffer::use_host_ptr>() ||

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_allocator.hpp>
+#include <CL/sycl/detail/plugin_impl.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_i.hpp>
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/event.hpp>
@@ -81,6 +82,7 @@ public:
 
   virtual ~SYCLMemObjT() = default;
 
+  const plugin_impl &getPlugin() const { return MInteropContext->getPlugin(); }
   size_t getSize() const override { return MSizeInBytes; }
   size_t get_count() const {
     size_t AllocatorValueSize = MAllocator->getValueSize();

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_allocator.hpp>
 #include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_i.hpp>
@@ -71,35 +72,8 @@ public:
       : SYCLMemObjT(/*SizeInBytes*/ 0, Props, std::move(Allocator)) {}
 
   SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
-<<<<<<< HEAD
               const size_t SizeInBytes, event AvailableEvent,
               unique_ptr_class<SYCLMemObjAllocator> Allocator);
-=======
-              const size_t SizeInBytes, event AvailableEvent)
-      : MAllocator(), MProps(),
-        MInteropEvent(detail::getSyclObjImpl(std::move(AvailableEvent))),
-        MInteropContext(detail::getSyclObjImpl(SyclContext)),
-        MInteropMemObject(MemObject), MOpenCLInterop(true),
-        MHostPtrReadOnly(false), MNeedWriteBack(true),
-        MSizeInBytes(SizeInBytes), MUserPtr(nullptr), MShadowCopy(nullptr),
-        MUploadDataFunctor(nullptr), MSharedPtrStorage(nullptr) {
-    if (MInteropContext->is_host())
-      throw cl::sycl::invalid_parameter_error(
-          "Creation of interoperability memory object using host context is "
-          "not allowed");
-
-    RT::PiMem Mem = pi::cast<RT::PiMem>(MInteropMemObject);
-    RT::PiContext Context = nullptr;
-    const plugin &Plugin = getPlugin();
-    Plugin.call<PiApiKind::piMemGetInfo>(Mem, CL_MEM_CONTEXT, sizeof(Context),
-                                         &Context, nullptr);
-
-    if (MInteropContext->getHandleRef() != Context)
-      throw cl::sycl::invalid_parameter_error(
-          "Input context must be the same as the context of cl_mem");
-    Plugin.call<PiApiKind::piMemRetain>(Mem);
-  }
->>>>>>> [SYCL][PI] Renamed plugin_impl to plugin class.
 
   SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
               event AvailableEvent,
@@ -201,26 +175,7 @@ public:
   // the memory object is allowed. This method is executed from child's
   // destructor. This cannot be done in SYCLMemObjT's destructor as child's
   // members must be alive.
-<<<<<<< HEAD
   void updateHostMemory();
-=======
-  void updateHostMemory() {
-    if ((MUploadDataFunctor != nullptr) && MNeedWriteBack)
-      MUploadDataFunctor();
-
-    // If we're attached to a memory record, process the deletion of the memory
-    // record. We may get detached before we do this.
-    if (MRecord)
-      Scheduler::getInstance().removeMemoryObject(this);
-    releaseHostMem(MShadowCopy);
-
-    if (MOpenCLInterop) {
-      const plugin &Plugin = getPlugin();
-      Plugin.call<PiApiKind::piMemRelease>(
-          pi::cast<RT::PiMem>(MInteropMemObject));
-    }
-  }
->>>>>>> [SYCL][PI] Renamed plugin_impl to plugin class.
 
   bool useHostPtr() {
     return has_property<property::buffer::use_host_ptr>() ||

--- a/sycl/include/CL/sycl/detail/usm_dispatch.hpp
+++ b/sycl/include/CL/sycl/detail/usm_dispatch.hpp
@@ -51,7 +51,8 @@ public:
                  pi_event *Event);
   pi_result enqueuePrefetch(pi_queue Queue, void *Ptr, size_t Size,
                             pi_uint32 NumEventsInWaitList,
-                            const pi_event *EventWaitList, pi_event *Event);
+                            const pi_event *EventWaitList, pi_event *Event,
+                            const plugin_impl &Plugin);
 
 private:
   bool mEmulated = false;

--- a/sycl/include/CL/sycl/detail/usm_dispatch.hpp
+++ b/sycl/include/CL/sycl/detail/usm_dispatch.hpp
@@ -52,7 +52,7 @@ public:
   pi_result enqueuePrefetch(pi_queue Queue, void *Ptr, size_t Size,
                             pi_uint32 NumEventsInWaitList,
                             const pi_event *EventWaitList, pi_event *Event,
-                            const plugin_impl &Plugin);
+                            const plugin &Plugin);
 
 private:
   bool mEmulated = false;

--- a/sycl/include/CL/sycl/intel/function_pointer.hpp
+++ b/sycl/include/CL/sycl/intel/function_pointer.hpp
@@ -27,66 +27,65 @@ cl_ulong getDeviceFunctionPointerImpl(device &D, program &P,
 }
 namespace intel {
 
-  // This is a preview extension implementation, intended to provide early
-  // access to a feature for review and community feedback.
-  //
-  // Because the interfaces defined by this header file are not final and are
-  // subject to change they are not intended to be used by shipping software
-  // products. If you are interested in using this feature in your software
-  // product, please let us know!
+// This is a preview extension implementation, intended to provide early
+// access to a feature for review and community feedback.
+//
+// Because the interfaces defined by this header file are not final and are
+// subject to change they are not intended to be used by shipping software
+// products. If you are interested in using this feature in your software
+// product, please let us know!
 
 using device_func_ptr_holder_t = cl_ulong;
 
-  /// \brief this function performs a cast from device_func_ptr_holder_t type
-  /// to the provided function pointer type.
-  template <
-      class FuncType,
-      typename FuncPtrType = typename std::add_pointer<FuncType>::type,
-      typename std::enable_if<std::is_function<FuncType>::value, int>::type = 0>
-  inline FuncPtrType to_device_func_ptr(device_func_ptr_holder_t FptrHolder) {
-    return reinterpret_cast<FuncPtrType>(FptrHolder);
+/// \brief this function performs a cast from device_func_ptr_holder_t type
+/// to the provided function pointer type.
+template <
+    class FuncType,
+    typename FuncPtrType = typename std::add_pointer<FuncType>::type,
+    typename std::enable_if<std::is_function<FuncType>::value, int>::type = 0>
+inline FuncPtrType to_device_func_ptr(device_func_ptr_holder_t FptrHolder) {
+  return reinterpret_cast<FuncPtrType>(FptrHolder);
+}
+
+template <class FuncType>
+using enable_if_is_function_pointer_t = typename std::enable_if<
+    std::is_pointer<FuncType>::value &&
+        std::is_function<typename std::remove_pointer<FuncType>::type>::value,
+    int>::type;
+
+/// \brief this function can be used only on host side to obtain device
+/// function pointer for the specified function.
+///
+/// \param F - pointer to function to make it work for SYCL Host device
+/// \param FuncName - name of the function. Please note that by default names
+/// of functions are mangled since SYCL is a C++. To avoid the need ot
+/// specifying mangled name here, use `extern "C"` \param P - sycl::program
+/// object which will be used to extract device function pointer \param D -
+/// sycl::device object which will be used to extract device function pointer
+///
+/// \returns device_func_ptr_holder_t object which can be used inside a device
+/// code. This object must be converted back to a function pointer using
+/// `to_device_func_ptr` prior to actual usage.
+///
+/// Returned value is valid only within device code which was compiled for the
+/// specified program and device. Returned value invalidates whenever program
+/// is released or re-built
+template <class FuncType, enable_if_is_function_pointer_t<FuncType> = 0>
+device_func_ptr_holder_t get_device_func_ptr(FuncType F, const char *FuncName,
+                                             program &P, device &D) {
+  // TODO: drop function name argument and map host function pointer directly
+  // to a device function pointer
+  if (D.is_host()) {
+    return reinterpret_cast<device_func_ptr_holder_t>(F);
   }
 
-  template <class FuncType>
-  using enable_if_is_function_pointer_t = typename std::enable_if<
-      std::is_pointer<FuncType>::value &&
-          std::is_function<typename std::remove_pointer<FuncType>::type>::value,
-      int>::type;
-
-  /// \brief this function can be used only on host side to obtain device
-  /// function pointer for the specified function.
-  ///
-  /// \param F - pointer to function to make it work for SYCL Host device
-  /// \param FuncName - name of the function. Please note that by default names
-  /// of functions are mangled since SYCL is a C++. To avoid the need ot
-  /// specifying mangled name here, use `extern "C"` \param P - sycl::program
-  /// object which will be used to extract device function pointer \param D -
-  /// sycl::device object which will be used to extract device function pointer
-  ///
-  /// \returns device_func_ptr_holder_t object which can be used inside a device
-  /// code. This object must be converted back to a function pointer using
-  /// `to_device_func_ptr` prior to actual usage.
-  ///
-  /// Returned value is valid only within device code which was compiled for the
-  /// specified program and device. Returned value invalidates whenever program
-  /// is released or re-built
-  template <class FuncType, enable_if_is_function_pointer_t<FuncType> = 0>
-  device_func_ptr_holder_t get_device_func_ptr(FuncType F, const char *FuncName,
-                                               program &P, device &D) {
-    // TODO: drop function name argument and map host function pointer directly
-    // to a device function pointer
-    if (D.is_host()) {
-      return reinterpret_cast<device_func_ptr_holder_t>(F);
-    }
-
-    if (program_state::linked != P.get_state()) {
-      throw invalid_parameter_error(
-          "Program must be built before passing to get_device_func_ptr");
-    }
+  if (program_state::linked != P.get_state()) {
+    throw invalid_parameter_error(
+        "Program must be built before passing to get_device_func_ptr");
+  }
 
   return detail::getDeviceFunctionPointerImpl(D, P, FuncName);
 }
-
 } // namespace intel
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/intel/function_pointer.hpp
+++ b/sycl/include/CL/sycl/intel/function_pointer.hpp
@@ -8,11 +8,7 @@
 
 #pragma once
 
-<<<<<<< HEAD
-=======
-#include <CL/sycl/detail/program_impl.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
->>>>>>> [SYCL][PI] Removal of PI_CALL family of macros & implementation of Plugin_Impl
+#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/program.hpp>
 #include <CL/sycl/stl.hpp>

--- a/sycl/include/CL/sycl/intel/function_pointer.hpp
+++ b/sycl/include/CL/sycl/intel/function_pointer.hpp
@@ -8,6 +8,11 @@
 
 #pragma once
 
+<<<<<<< HEAD
+=======
+#include <CL/sycl/detail/program_impl.hpp>
+#include <CL/sycl/detail/plugin_impl.hpp>
+>>>>>>> [SYCL][PI] Removal of PI_CALL family of macros & implementation of Plugin_Impl
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/program.hpp>
 #include <CL/sycl/stl.hpp>
@@ -22,64 +27,62 @@ cl_ulong getDeviceFunctionPointerImpl(device &D, program &P,
 }
 namespace intel {
 
-// This is a preview extension implementation, intended to provide early access
-// to a feature for review and community feedback.
-//
-// Because the interfaces defined by this header file are not final and are
-// subject to change they are not intended to be used by shipping software
-// products. If you are interested in using this feature in your software
-// product, please let us know!
+  // This is a preview extension implementation, intended to provide early
+  // access to a feature for review and community feedback.
+  //
+  // Because the interfaces defined by this header file are not final and are
+  // subject to change they are not intended to be used by shipping software
+  // products. If you are interested in using this feature in your software
+  // product, please let us know!
 
 using device_func_ptr_holder_t = cl_ulong;
 
-/// \brief this function performs a cast from device_func_ptr_holder_t type
-/// to the provided function pointer type.
-template <
-    class FuncType,
-    typename FuncPtrType = typename std::add_pointer<FuncType>::type,
-    typename std::enable_if<std::is_function<FuncType>::value, int>::type = 0>
-inline FuncPtrType to_device_func_ptr(device_func_ptr_holder_t FptrHolder) {
-  return reinterpret_cast<FuncPtrType>(FptrHolder);
-}
-
-template <class FuncType>
-using enable_if_is_function_pointer_t = typename std::enable_if<
-    std::is_pointer<FuncType>::value &&
-        std::is_function<typename std::remove_pointer<FuncType>::type>::value,
-    int>::type;
-
-/// \brief this function can be used only on host side to obtain device function
-/// pointer for the specified function.
-///
-/// \param F - pointer to function to make it work for SYCL Host device
-/// \param FuncName - name of the function. Please note that by default names of
-/// functions are mangled since SYCL is a C++. To avoid the need ot specifying
-/// mangled name here, use `extern "C"`
-/// \param P - sycl::program object which will be used to extract device
-/// function pointer
-/// \param D - sycl::device object which will be used to extract device
-/// function pointer
-///
-/// \returns device_func_ptr_holder_t object which can be used inside a device
-/// code. This object must be converted back to a function pointer using
-/// `to_device_func_ptr` prior to actual usage.
-///
-/// Returned value is valid only within device code which was compiled for the
-/// specified program and device. Returned value invalidates whenever program
-/// is released or re-built
-template <class FuncType, enable_if_is_function_pointer_t<FuncType> = 0>
-device_func_ptr_holder_t get_device_func_ptr(FuncType F, const char *FuncName,
-                                             program &P, device &D) {
-  // TODO: drop function name argument and map host function pointer directly to
-  // a device function pointer
-  if (D.is_host()) {
-    return reinterpret_cast<device_func_ptr_holder_t>(F);
+  /// \brief this function performs a cast from device_func_ptr_holder_t type
+  /// to the provided function pointer type.
+  template <
+      class FuncType,
+      typename FuncPtrType = typename std::add_pointer<FuncType>::type,
+      typename std::enable_if<std::is_function<FuncType>::value, int>::type = 0>
+  inline FuncPtrType to_device_func_ptr(device_func_ptr_holder_t FptrHolder) {
+    return reinterpret_cast<FuncPtrType>(FptrHolder);
   }
 
-  if (program_state::linked != P.get_state()) {
-    throw invalid_parameter_error(
-        "Program must be built before passing to get_device_func_ptr");
-  }
+  template <class FuncType>
+  using enable_if_is_function_pointer_t = typename std::enable_if<
+      std::is_pointer<FuncType>::value &&
+          std::is_function<typename std::remove_pointer<FuncType>::type>::value,
+      int>::type;
+
+  /// \brief this function can be used only on host side to obtain device
+  /// function pointer for the specified function.
+  ///
+  /// \param F - pointer to function to make it work for SYCL Host device
+  /// \param FuncName - name of the function. Please note that by default names
+  /// of functions are mangled since SYCL is a C++. To avoid the need ot
+  /// specifying mangled name here, use `extern "C"` \param P - sycl::program
+  /// object which will be used to extract device function pointer \param D -
+  /// sycl::device object which will be used to extract device function pointer
+  ///
+  /// \returns device_func_ptr_holder_t object which can be used inside a device
+  /// code. This object must be converted back to a function pointer using
+  /// `to_device_func_ptr` prior to actual usage.
+  ///
+  /// Returned value is valid only within device code which was compiled for the
+  /// specified program and device. Returned value invalidates whenever program
+  /// is released or re-built
+  template <class FuncType, enable_if_is_function_pointer_t<FuncType> = 0>
+  device_func_ptr_holder_t get_device_func_ptr(FuncType F, const char *FuncName,
+                                               program &P, device &D) {
+    // TODO: drop function name argument and map host function pointer directly
+    // to a device function pointer
+    if (D.is_host()) {
+      return reinterpret_cast<device_func_ptr_holder_t>(F);
+    }
+
+    if (program_state::linked != P.get_state()) {
+      throw invalid_parameter_error(
+          "Program must be built before passing to get_device_func_ptr");
+    }
 
   return detail::getDeviceFunctionPointerImpl(D, P, FuncName);
 }

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -60,7 +60,8 @@ context::context(const vector_class<device> &DeviceList,
 }
 context::context(cl_context ClContext, async_handler AsyncHandler) {
   impl = std::make_shared<detail::context_impl>(
-          detail::pi::cast<detail::RT::PiContext>(ClContext), AsyncHandler);
+      detail::pi::cast<detail::RT::PiContext>(ClContext), AsyncHandler,
+      *RT::GlobalPlugin);
 }
 
 #define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -23,7 +23,9 @@ namespace detail {
 
 context_impl::context_impl(const device &Device, async_handler AsyncHandler)
     : MAsyncHandler(AsyncHandler), MDevices(1, Device), MContext(nullptr),
-      MPlatform(), MPluginInterop(false), MHostContext(true) {}
+      MPlatform(), MPluginInterop(false), MHostContext(true) {
+  MKernelProgramCache.setPlatformImpl(MPlatform);
+}
 
 context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
                            async_handler AsyncHandler)
@@ -35,39 +37,46 @@ context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
     DeviceIds.push_back(getSyclObjImpl(D)->getHandleRef());
   }
 
-  PI_CALL(piContextCreate)(nullptr, DeviceIds.size(), DeviceIds.data(), nullptr,
-                           nullptr, &MContext);
+  getPlugin().call<PiApiKind::piContextCreate>(
+      nullptr, DeviceIds.size(), DeviceIds.data(), nullptr, nullptr, &MContext);
+
+  MKernelProgramCache.setPlatformImpl(MPlatform);
 }
 
-context_impl::context_impl(RT::PiContext PiContext, async_handler AsyncHandler)
+context_impl::context_impl(RT::PiContext PiContext, async_handler AsyncHandler,
+                           const plugin_impl &Plugin)
     : MAsyncHandler(AsyncHandler), MDevices(), MContext(PiContext), MPlatform(),
       MPluginInterop(true), MHostContext(false) {
 
   vector_class<RT::PiDevice> DeviceIds;
   size_t DevicesNum = 0;
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piContextGetInfo)(MContext, PI_CONTEXT_INFO_NUM_DEVICES,
-                            sizeof(DevicesNum), &DevicesNum, nullptr);
+  Plugin.call<PiApiKind::piContextGetInfo>(
+      MContext, PI_CONTEXT_INFO_NUM_DEVICES, sizeof(DevicesNum), &DevicesNum,
+      nullptr);
   DeviceIds.resize(DevicesNum);
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piContextGetInfo)(MContext, PI_CONTEXT_INFO_DEVICES,
-                            sizeof(RT::PiDevice) * DevicesNum, &DeviceIds[0],
-                            nullptr);
+  Plugin.call<PiApiKind::piContextGetInfo>(MContext, PI_CONTEXT_INFO_DEVICES,
+                                           sizeof(RT::PiDevice) * DevicesNum,
+                                           &DeviceIds[0], nullptr);
 
   for (auto Dev : DeviceIds) {
-    MDevices.emplace_back(
-        createSyclObjFromImpl<device>(std::make_shared<device_impl>(Dev)));
+    MDevices.emplace_back(createSyclObjFromImpl<device>(
+        std::make_shared<device_impl>(Dev, Plugin)));
   }
   // TODO What if m_Devices if empty? m_Devices[0].get_platform()
   MPlatform = detail::getSyclObjImpl(MDevices[0].get_platform());
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piContextRetain)(MContext);
+  // getPlugin() will be the same as the Plugin passed. This should be taken
+  // care of when creating device object.
+  getPlugin().call<PiApiKind::piContextRetain>(MContext);
+  MKernelProgramCache.setPlatformImpl(MPlatform);
 }
 
 cl_context context_impl::get() const {
   if (MPluginInterop) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piContextRetain)(MContext);
+    getPlugin().call<PiApiKind::piContextRetain>(MContext);
     return pi::cast<cl_context>(MContext);
   }
   throw invalid_object_error(
@@ -79,11 +88,11 @@ bool context_impl::is_host() const { return MHostContext || !MPluginInterop; }
 context_impl::~context_impl() {
   if (MPluginInterop) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piContextRelease)(MContext);
+    getPlugin().call<PiApiKind::piContextRelease>(MContext);
   }
   for (auto LibProg : MCachedLibPrograms) {
     assert(LibProg.second && "Null program must not be kept in the cache");
-    PI_CALL(piProgramRelease)(LibProg.second);
+    getPlugin().call<PiApiKind::piProgramRelease>(LibProg.second);
   }
 }
 
@@ -96,7 +105,7 @@ cl_uint context_impl::get_info<info::context::reference_count>() const {
   if (is_host())
     return 0;
   return get_context_info<info::context::reference_count>::get(
-      this->getHandleRef());
+      this->getHandleRef(), this->getPlugin());
 }
 template <> platform context_impl::get_info<info::context::platform>() const {
   if (is_host())

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -44,7 +44,7 @@ context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
 }
 
 context_impl::context_impl(RT::PiContext PiContext, async_handler AsyncHandler,
-                           const plugin_impl &Plugin)
+                           const plugin &Plugin)
     : MAsyncHandler(AsyncHandler), MDevices(), MContext(PiContext), MPlatform(),
       MPluginInterop(true), MHostContext(false) {
 

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -24,7 +24,7 @@ namespace detail {
 context_impl::context_impl(const device &Device, async_handler AsyncHandler)
     : MAsyncHandler(AsyncHandler), MDevices(1, Device), MContext(nullptr),
       MPlatform(), MPluginInterop(false), MHostContext(true) {
-  MKernelProgramCache.setPlatformImpl(MPlatform);
+  MKernelProgramCache.setContextPtr(this);
 }
 
 context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
@@ -40,7 +40,7 @@ context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
   getPlugin().call<PiApiKind::piContextCreate>(
       nullptr, DeviceIds.size(), DeviceIds.data(), nullptr, nullptr, &MContext);
 
-  MKernelProgramCache.setPlatformImpl(MPlatform);
+  MKernelProgramCache.setContextPtr(this);
 }
 
 context_impl::context_impl(RT::PiContext PiContext, async_handler AsyncHandler,
@@ -70,7 +70,7 @@ context_impl::context_impl(RT::PiContext PiContext, async_handler AsyncHandler,
   // getPlugin() will be the same as the Plugin passed. This should be taken
   // care of when creating device object.
   getPlugin().call<PiApiKind::piContextRetain>(MContext);
-  MKernelProgramCache.setPlatformImpl(MPlatform);
+  MKernelProgramCache.setContextPtr(this);
 }
 
 cl_context context_impl::get() const {

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -22,11 +22,11 @@ device_impl::device_impl()
 device_impl::device_impl(RT::PiDevice Device, PlatformImplPtr Platform)
     : device_impl(Device, Platform, Platform->getPlugin()) {}
 
-device_impl::device_impl(RT::PiDevice Device, const plugin_impl &Plugin)
+device_impl::device_impl(RT::PiDevice Device, const plugin &Plugin)
     : device_impl(Device, nullptr, Plugin) {}
 
 device_impl::device_impl(RT::PiDevice Device, PlatformImplPtr Platform,
-                         const plugin_impl &Plugin)
+                         const plugin &Plugin)
     : MDevice(Device), MIsHostDevice(false) {
   // TODO catch an exception and put it to list of asynchronous exceptions
   Plugin.call<PiApiKind::piDeviceGetInfo>(

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -15,31 +15,51 @@ __SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 
-device_impl::device_impl() : MIsHostDevice(true) {}
+device_impl::device_impl()
+    : MIsHostDevice(true),
+      MPlatform(std::make_shared<platform_impl>(platform_impl())) {}
 
-device_impl::device_impl(RT::PiDevice Device)
+device_impl::device_impl(RT::PiDevice Device, PlatformImplPtr Platform)
+    : device_impl(Device, Platform, Platform->getPlugin()) {}
+
+device_impl::device_impl(RT::PiDevice Device, const plugin_impl &Plugin)
+    : device_impl(Device, nullptr, Plugin) {}
+
+device_impl::device_impl(RT::PiDevice Device, PlatformImplPtr Platform,
+                         const plugin_impl &Plugin)
     : MDevice(Device), MIsHostDevice(false) {
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piDeviceGetInfo)(MDevice, PI_DEVICE_INFO_TYPE,
-                           sizeof(RT::PiDeviceType), &MType, nullptr);
+  Plugin.call<PiApiKind::piDeviceGetInfo>(
+      MDevice, PI_DEVICE_INFO_TYPE, sizeof(RT::PiDeviceType), &MType, nullptr);
 
   RT::PiDevice parent = nullptr;
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piDeviceGetInfo)(MDevice, PI_DEVICE_INFO_PARENT, sizeof(RT::PiDevice),
-                           &parent, nullptr);
+  Plugin.call<PiApiKind::piDeviceGetInfo>(
+      MDevice, PI_DEVICE_INFO_PARENT, sizeof(RT::PiDevice), &parent, nullptr);
 
   MIsRootDevice = (nullptr == parent);
   if (!MIsRootDevice) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piDeviceRetain)(MDevice);
+    Plugin.call<PiApiKind::piDeviceRetain>(MDevice);
   }
+
+  // set MPlatform
+  if (!Platform) {
+    RT::PiPlatform plt = nullptr; // TODO catch an exception and put it to list
+                                  // of asynchronous exceptions
+    Plugin.call<PiApiKind::piDeviceGetInfo>(Device, PI_DEVICE_INFO_PLATFORM,
+                                            sizeof(plt), &plt, nullptr);
+    Platform = std::make_shared<platform_impl>(plt, Plugin);
+  }
+  MPlatform = Platform;
 }
 
 device_impl::~device_impl() {
   if (!MIsRootDevice && !MIsHostDevice) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    CHECK_OCL_CODE_NO_EXC(
-        RT::PluginInformation.PiFunctionTable.piDeviceRelease(MDevice));
+    auto Plugin = getPlugin();
+    RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piDeviceRelease>(MDevice);
+    CHECK_OCL_CODE_NO_EXC(Err);
   }
 }
 
@@ -56,25 +76,15 @@ cl_device_id device_impl::get() const {
 
   if (!MIsRootDevice) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    PI_CALL(piDeviceRetain)(MDevice);
+    auto Plugin = getPlugin();
+    Plugin.call<PiApiKind::piDeviceRetain>(MDevice);
   }
   // TODO: check that device is an OpenCL interop one
   return pi::cast<cl_device_id>(MDevice);
 }
 
 platform device_impl::get_platform() const {
-  if (MIsHostDevice)
-    return platform();
-
-  RT::PiPlatform plt = nullptr; // TODO catch an exception and put it to list of
-                      // asynchronous exceptions
-  PI_CALL(piDeviceGetInfo)(MDevice, PI_DEVICE_INFO_PLATFORM, sizeof(plt), &plt,
-                           nullptr);
-
-  // TODO: this possibly will violate common reference semantics,
-  // particularly, equality comparison may fail for two consecutive
-  // get_platform() on the same device, as it compares impl objects.
-  return createSyclObjFromImpl<platform>(std::make_shared<platform_impl>(plt));
+  return createSyclObjFromImpl<platform>(MPlatform);
 }
 
 bool device_impl::has_extension(const string_class &ExtensionName) const {
@@ -83,7 +93,8 @@ bool device_impl::has_extension(const string_class &ExtensionName) const {
     return false;
 
   string_class AllExtensionNames =
-      get_device_info<string_class, info::device::extensions>::get(MDevice);
+      get_device_info<string_class, info::device::extensions>::get(
+          this->getHandleRef(), this->getPlugin());
   return (AllExtensionNames.find(ExtensionName) != std::string::npos);
 }
 
@@ -99,8 +110,10 @@ device_impl::create_sub_devices(const cl_device_partition_property *Properties,
 
   vector_class<RT::PiDevice> SubDevices(SubDevicesCount);
   pi_uint32 ReturnedSubDevices = 0;
-  PI_CALL(piDevicePartition)(MDevice, Properties, SubDevicesCount,
-                             SubDevices.data(), &ReturnedSubDevices);
+  auto Plugin = getPlugin();
+  Plugin.call<PiApiKind::piDevicePartition>(MDevice, Properties,
+                                            SubDevicesCount, SubDevices.data(),
+                                            &ReturnedSubDevices);
   // TODO: check that returned number of sub-devices matches what was
   // requested, otherwise this walk below is wrong.
   //
@@ -110,9 +123,9 @@ device_impl::create_sub_devices(const cl_device_partition_property *Properties,
   //
   vector_class<device> res;
   std::for_each(SubDevices.begin(), SubDevices.end(),
-                [&res](const RT::PiDevice &a_pi_device) {
+                [&res, this](const RT::PiDevice &a_pi_device) {
                   device sycl_device = detail::createSyclObjFromImpl<device>(
-                      std::make_shared<device_impl>(a_pi_device));
+                      std::make_shared<device_impl>(a_pi_device, MPlatform));
                   res.push_back(sycl_device);
                 });
   return res;

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -57,7 +57,7 @@ device_impl::device_impl(RT::PiDevice Device, PlatformImplPtr Platform,
 device_impl::~device_impl() {
   if (!MIsRootDevice && !MIsHostDevice) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    auto Plugin = getPlugin();
+    const detail::plugin &Plugin = getPlugin();
     RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piDeviceRelease>(MDevice);
     CHECK_OCL_CODE_NO_EXC(Err);
   }
@@ -76,7 +76,7 @@ cl_device_id device_impl::get() const {
 
   if (!MIsRootDevice) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    auto Plugin = getPlugin();
+    const detail::plugin &Plugin = getPlugin();
     Plugin.call<PiApiKind::piDeviceRetain>(MDevice);
   }
   // TODO: check that device is an OpenCL interop one
@@ -110,7 +110,7 @@ device_impl::create_sub_devices(const cl_device_partition_property *Properties,
 
   vector_class<RT::PiDevice> SubDevices(SubDevicesCount);
   pi_uint32 ReturnedSubDevices = 0;
-  auto Plugin = getPlugin();
+  const detail::plugin &Plugin = getPlugin();
   Plugin.call<PiApiKind::piDevicePartition>(MDevice, Properties,
                                             SubDevicesCount, SubDevices.data(),
                                             &ReturnedSubDevices);

--- a/sycl/source/detail/device_info.cpp
+++ b/sycl/source/detail/device_info.cpp
@@ -26,7 +26,7 @@ namespace detail {
 // Specialization for parent device
 template <>
 device get_device_info<device, info::device::parent_device>::get(
-    RT::PiDevice dev, const plugin_impl &Plugin) {
+    RT::PiDevice dev, const plugin &Plugin) {
 
   typename sycl_to_pi<device>::type result;
   Plugin.call<PiApiKind::piDeviceGetInfo>(

--- a/sycl/source/detail/device_info.cpp
+++ b/sycl/source/detail/device_info.cpp
@@ -25,18 +25,19 @@ namespace detail {
 
 // Specialization for parent device
 template <>
-device
-get_device_info<device, info::device::parent_device>::get(RT::PiDevice dev) {
+device get_device_info<device, info::device::parent_device>::get(
+    RT::PiDevice dev, const plugin_impl &Plugin) {
 
   typename sycl_to_pi<device>::type result;
-  PI_CALL(piDeviceGetInfo)(
+  Plugin.call<PiApiKind::piDeviceGetInfo>(
       dev, pi::cast<RT::PiDeviceInfo>(info::device::parent_device),
       sizeof(result), &result, nullptr);
   if (result == nullptr)
     throw invalid_object_error(
         "No parent for device because it is not a subdevice");
 
-  return createSyclObjFromImpl<device>(std::make_shared<device_impl>(result));
+  return createSyclObjFromImpl<device>(
+      std::make_shared<device_impl>(result, Plugin));
 }
 
 vector_class<info::fp_config> read_fp_bitfield(cl_device_fp_config bits) {

--- a/sycl/source/detail/error_handling/enqueue_kernel.cpp
+++ b/sycl/source/detail/error_handling/enqueue_kernel.cpp
@@ -13,7 +13,7 @@
 #include "error_handling.hpp"
 
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 
 __SYCL_INLINE namespace cl {
 namespace sycl {
@@ -25,7 +25,7 @@ bool handleInvalidWorkGroupSize(const device_impl &DeviceImpl, pi_kernel Kernel,
                                 const NDRDescT &NDRDesc) {
   const bool HasLocalSize = (NDRDesc.LocalSize[0] != 0);
 
-  const plugin_impl &Plugin = DeviceImpl.getPlugin();
+  const plugin &Plugin = DeviceImpl.getPlugin();
   RT::PiDevice Device = DeviceImpl.getHandleRef();
 
   size_t VerSize = 0;

--- a/sycl/source/detail/error_handling/enqueue_kernel.cpp
+++ b/sycl/source/detail/error_handling/enqueue_kernel.cpp
@@ -13,6 +13,7 @@
 #include "error_handling.hpp"
 
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/plugin_impl.hpp>
 
 __SYCL_INLINE namespace cl {
 namespace sycl {
@@ -20,24 +21,27 @@ namespace detail {
 
 namespace enqueue_kernel_launch {
 
-bool handleInvalidWorkGroupSize(pi_device Device, pi_kernel Kernel,
+bool handleInvalidWorkGroupSize(const device_impl &DeviceImpl, pi_kernel Kernel,
                                 const NDRDescT &NDRDesc) {
   const bool HasLocalSize = (NDRDesc.LocalSize[0] != 0);
 
+  const plugin_impl &Plugin = DeviceImpl.getPlugin();
+  RT::PiDevice Device = DeviceImpl.getHandleRef();
+
   size_t VerSize = 0;
-  PI_CALL(piDeviceGetInfo)(Device, PI_DEVICE_INFO_VERSION, 0, nullptr,
-                           &VerSize);
+  Plugin.call<PiApiKind::piDeviceGetInfo>(Device, PI_DEVICE_INFO_VERSION, 0,
+                                          nullptr, &VerSize);
   assert(VerSize >= 10 &&
          "Unexpected device version string"); // strlen("OpenCL X.Y")
   string_class VerStr(VerSize, '\0');
-  PI_CALL(piDeviceGetInfo)(Device, PI_DEVICE_INFO_VERSION, VerSize,
-                           &VerStr.front(), nullptr);
+  Plugin.call<PiApiKind::piDeviceGetInfo>(Device, PI_DEVICE_INFO_VERSION,
+                                          VerSize, &VerStr.front(), nullptr);
   const char *Ver = &VerStr[7]; // strlen("OpenCL ")
 
   size_t CompileWGSize[3] = {0};
-  PI_CALL(piKernelGetGroupInfo)(Kernel, Device,
-                                CL_KERNEL_COMPILE_WORK_GROUP_SIZE,
-                                sizeof(size_t) * 3, CompileWGSize, nullptr);
+  Plugin.call<PiApiKind::piKernelGetGroupInfo>(
+      Kernel, Device, CL_KERNEL_COMPILE_WORK_GROUP_SIZE, sizeof(size_t) * 3,
+      CompileWGSize, nullptr);
 
   if (CompileWGSize[0] != 0) {
     // OpenCL 1.x && 2.0:
@@ -70,8 +74,9 @@ bool handleInvalidWorkGroupSize(pi_device Device, pi_kernel Kernel,
     // than the value specified by CL_DEVICE_MAX_WORK_GROUP_SIZE in
     // table 4.3
     size_t MaxWGSize = 0;
-    PI_CALL(piDeviceGetInfo)(Device, PI_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
-                             sizeof(size_t), &MaxWGSize, nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(
+        Device, PI_DEVICE_INFO_MAX_WORK_GROUP_SIZE, sizeof(size_t), &MaxWGSize,
+        nullptr);
     const size_t TotalNumberOfWIs =
         NDRDesc.LocalSize[0] * NDRDesc.LocalSize[1] * NDRDesc.LocalSize[2];
     if (TotalNumberOfWIs > MaxWGSize)
@@ -87,8 +92,9 @@ bool handleInvalidWorkGroupSize(pi_device Device, pi_kernel Kernel,
     // local_work_size[0] * ... * local_work_size[work_dim – 1] is greater
     // than the value specified by CL_KERNEL_WORK_GROUP_SIZE in table 5.21.
     size_t KernelWGSize = 0;
-    PI_CALL(piKernelGetGroupInfo)(Kernel, Device, CL_KERNEL_WORK_GROUP_SIZE,
-                                  sizeof(size_t), &KernelWGSize, nullptr);
+    Plugin.call<PiApiKind::piKernelGetGroupInfo>(
+        Kernel, Device, CL_KERNEL_WORK_GROUP_SIZE, sizeof(size_t),
+        &KernelWGSize, nullptr);
     const size_t TotalNumberOfWIs =
         NDRDesc.LocalSize[0] * NDRDesc.LocalSize[1] * NDRDesc.LocalSize[2];
     if (TotalNumberOfWIs > KernelWGSize)
@@ -126,14 +132,15 @@ bool handleInvalidWorkGroupSize(pi_device Device, pi_kernel Kernel,
       // given by local_work_size
 
       pi_program Program = nullptr;
-      PI_CALL(piKernelGetInfo)(Kernel, CL_KERNEL_PROGRAM, sizeof(pi_program),
-                               &Program, nullptr);
+      Plugin.call<PiApiKind::piKernelGetInfo>(
+          Kernel, CL_KERNEL_PROGRAM, sizeof(pi_program), &Program, nullptr);
       size_t OptsSize = 0;
-      PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_OPTIONS,
-                                     0, nullptr, &OptsSize);
+      Plugin.call<PiApiKind::piProgramGetBuildInfo>(
+          Program, Device, CL_PROGRAM_BUILD_OPTIONS, 0, nullptr, &OptsSize);
       string_class Opts(OptsSize, '\0');
-      PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_OPTIONS,
-                                     OptsSize, &Opts.front(), nullptr);
+      Plugin.call<PiApiKind::piProgramGetBuildInfo>(
+          Program, Device, CL_PROGRAM_BUILD_OPTIONS, OptsSize, &Opts.front(),
+          nullptr);
       if (NonUniformWGs) {
         const bool HasStd20 = Opts.find("-cl-std=CL2.0") != string_class::npos;
         if (!HasStd20)
@@ -163,13 +170,13 @@ bool handleInvalidWorkGroupSize(pi_device Device, pi_kernel Kernel,
       "OpenCL API failed. OpenCL API returns: " + codeToString(Error), Error);
 }
 
-bool handleError(pi_result Error, pi_device Device, pi_kernel Kernel,
-                 const NDRDescT &NDRDesc) {
+bool handleError(pi_result Error, const device_impl &DeviceImpl,
+                 pi_kernel Kernel, const NDRDescT &NDRDesc) {
   assert(Error != PI_SUCCESS &&
          "Success is expected to be handled on caller side");
   switch (Error) {
   case PI_INVALID_WORK_GROUP_SIZE:
-    return handleInvalidWorkGroupSize(Device, Kernel, NDRDesc);
+    return handleInvalidWorkGroupSize(DeviceImpl, Kernel, NDRDesc);
   // TODO: Handle other error codes
   default:
     throw runtime_error(

--- a/sycl/source/detail/error_handling/error_handling.hpp
+++ b/sycl/source/detail/error_handling/error_handling.hpp
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include <CL/sycl/detail/pi.h>
 #include <CL/sycl/detail/cg.hpp>
+#include <CL/sycl/detail/device_impl.hpp>
+#include <CL/sycl/detail/pi.h>
 
 __SYCL_INLINE namespace cl {
 namespace sycl {
@@ -24,7 +25,7 @@ namespace enqueue_kernel_launch {
 ///
 /// This function actually never returns and always throws an exception with
 /// error description.
-bool handleError(pi_result, pi_device, pi_kernel, const NDRDescT &);
+bool handleError(pi_result, const device_impl &, pi_kernel, const NDRDescT &);
 } // namespace enqueue_kernel_launch
 
 } // namespace detail

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -8,6 +8,7 @@
 
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
+#include <CL/sycl/detail/event_info.hpp>
 #include <CL/sycl/detail/queue_impl.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 
@@ -23,7 +24,7 @@ bool event_impl::is_host() const { return MHostEvent || !MOpenCLInterop; }
 
 cl_event event_impl::get() const {
   if (MOpenCLInterop) {
-    PI_CALL(piEventRetain)(MEvent);
+    getPlugin().call<PiApiKind::piEventRetain>(MEvent);
     return pi::cast<cl_event>(MEvent);
   }
   throw invalid_object_error(
@@ -32,12 +33,12 @@ cl_event event_impl::get() const {
 
 event_impl::~event_impl() {
   if (MEvent)
-    PI_CALL(piEventRelease)(MEvent);
+    getPlugin().call<PiApiKind::piEventRelease>(MEvent);
 }
 
 void event_impl::waitInternal() const {
   if (!MHostEvent) {
-    PI_CALL(piEventsWait)(1, &MEvent);
+    getPlugin().call<PiApiKind::piEventsWait>(1, &MEvent);
   }
   // Waiting of host events is NOP so far as all operations on host device
   // are blocking.
@@ -47,6 +48,10 @@ const RT::PiEvent &event_impl::getHandleRef() const { return MEvent; }
 RT::PiEvent &event_impl::getHandleRef() { return MEvent; }
 
 const ContextImplPtr &event_impl::getContextImpl() { return MContext; }
+
+const plugin_impl &event_impl::getPlugin() const {
+  return MContext->getPlugin();
+}
 
 void event_impl::setContextImpl(const ContextImplPtr &Context) {
   MHostEvent = Context->is_host();
@@ -65,15 +70,15 @@ event_impl::event_impl(RT::PiEvent Event, const context &SyclContext)
   }
 
   RT::PiContext TempContext;
-  PI_CALL(piEventGetInfo)(MEvent, CL_EVENT_CONTEXT, sizeof(RT::PiContext),
-                          &TempContext, nullptr);
+  getPlugin().call<PiApiKind::piEventGetInfo>(
+      MEvent, CL_EVENT_CONTEXT, sizeof(RT::PiContext), &TempContext, nullptr);
   if (MContext->getHandleRef() != TempContext) {
     throw cl::sycl::invalid_parameter_error(
         "The syclContext must match the OpenCL context associated with the "
         "clEvent.");
   }
 
-  PI_CALL(piEventRetain)(MEvent);
+  getPlugin().call<PiApiKind::piEventRetain>(MEvent);
 }
 
 event_impl::event_impl(QueueImplPtr Queue) : MQueue(Queue) {
@@ -114,7 +119,7 @@ cl_ulong
 event_impl::get_profiling_info<info::event_profiling::command_submit>() const {
   if (!MHostEvent) {
     return get_event_profiling_info<info::event_profiling::command_submit>::get(
-        this->getHandleRef());
+        this->getHandleRef(), this->getPlugin());
   }
   if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.");
@@ -126,7 +131,7 @@ cl_ulong
 event_impl::get_profiling_info<info::event_profiling::command_start>() const {
   if (!MHostEvent) {
     return get_event_profiling_info<info::event_profiling::command_start>::get(
-        this->getHandleRef());
+        this->getHandleRef(), this->getPlugin());
   }
   if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.");
@@ -138,7 +143,7 @@ cl_ulong
 event_impl::get_profiling_info<info::event_profiling::command_end>() const {
   if (!MHostEvent) {
     return get_event_profiling_info<info::event_profiling::command_end>::get(
-        this->getHandleRef());
+        this->getHandleRef(), this->getPlugin());
   }
   if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.");
@@ -148,7 +153,7 @@ event_impl::get_profiling_info<info::event_profiling::command_end>() const {
 template <> cl_uint event_impl::get_info<info::event::reference_count>() const {
   if (!MHostEvent) {
     return get_event_info<info::event::reference_count>::get(
-        this->getHandleRef());
+        this->getHandleRef(), this->getPlugin());
   }
   return 0;
 }
@@ -158,7 +163,7 @@ info::event_command_status
 event_impl::get_info<info::event::command_execution_status>() const {
   if (!MHostEvent) {
     return get_event_info<info::event::command_execution_status>::get(
-        this->getHandleRef());
+        this->getHandleRef(), this->getPlugin());
   }
   return info::event_command_status::complete;
 }

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -9,6 +9,7 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/detail/event_info.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/detail/queue_impl.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -49,7 +49,7 @@ RT::PiEvent &event_impl::getHandleRef() { return MEvent; }
 
 const ContextImplPtr &event_impl::getContextImpl() { return MContext; }
 
-const plugin_impl &event_impl::getPlugin() const {
+const plugin &event_impl::getPlugin() const {
   return MContext->getPlugin();
 }
 

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -240,8 +240,10 @@ image_impl<Dimensions>::image_impl(
             std::move(Allocator)),
       MRange(InitializedVal<Dimensions, range>::template get<0>()) {
   RT::PiMem Mem = pi::cast<RT::PiMem>(BaseT::MInteropMemObject);
-  PI_CALL(piMemGetInfo)(Mem, CL_MEM_SIZE, sizeof(size_t),
-                        &(BaseT::MSizeInBytes), nullptr);
+  const ContextImplPtr Context = getSyclObjImpl(SyclContext);
+  auto Plugin = Context->getPlugin();
+  Plugin.call<PiApiKind::piMemGetInfo>(Mem, CL_MEM_SIZE, sizeof(size_t),
+                                       &(BaseT::MSizeInBytes), nullptr);
 
   RT::PiMemImageFormat Format;
   getImageInfo(PI_IMAGE_INFO_FORMAT, Format);

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -241,7 +241,7 @@ image_impl<Dimensions>::image_impl(
       MRange(InitializedVal<Dimensions, range>::template get<0>()) {
   RT::PiMem Mem = pi::cast<RT::PiMem>(BaseT::MInteropMemObject);
   const ContextImplPtr Context = getSyclObjImpl(SyclContext);
-  auto Plugin = Context->getPlugin();
+  const detail::plugin &Plugin = Context->getPlugin();
   Plugin.call<PiApiKind::piMemGetInfo>(Mem, CL_MEM_SIZE, sizeof(size_t),
                                        &(BaseT::MSizeInBytes), nullptr);
 

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -246,26 +246,26 @@ image_impl<Dimensions>::image_impl(
                                        &(BaseT::MSizeInBytes), nullptr);
 
   RT::PiMemImageFormat Format;
-  getImageInfo(PI_IMAGE_INFO_FORMAT, Format);
+  getImageInfo(Context, PI_IMAGE_INFO_FORMAT, Format);
   MOrder = detail::convertChannelOrder(Format.image_channel_order);
   MType = detail::convertChannelType(Format.image_channel_data_type);
   MNumChannels = getImageNumberChannels(MOrder);
 
-  getImageInfo(PI_IMAGE_INFO_ELEMENT_SIZE, MElementSize);
+  getImageInfo(Context, PI_IMAGE_INFO_ELEMENT_SIZE, MElementSize);
   assert(getImageElementSize(MNumChannels, MType) == MElementSize);
 
-  getImageInfo(PI_IMAGE_INFO_ROW_PITCH, MRowPitch);
-  getImageInfo(PI_IMAGE_INFO_SLICE_PITCH, MSlicePitch);
+  getImageInfo(Context, PI_IMAGE_INFO_ROW_PITCH, MRowPitch);
+  getImageInfo(Context, PI_IMAGE_INFO_SLICE_PITCH, MSlicePitch);
 
   switch (Dimensions) {
   case 3:
-    getImageInfo(PI_IMAGE_INFO_DEPTH, MRange[2]);
+    getImageInfo(Context, PI_IMAGE_INFO_DEPTH, MRange[2]);
     // fall through
   case 2:
-    getImageInfo(PI_IMAGE_INFO_HEIGHT, MRange[1]);
+    getImageInfo(Context, PI_IMAGE_INFO_HEIGHT, MRange[1]);
     // fall through
   case 1:
-    getImageInfo(PI_IMAGE_INFO_WIDTH, MRange[0]);
+    getImageInfo(Context, PI_IMAGE_INFO_WIDTH, MRange[0]);
   }
 }
 

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -32,12 +32,13 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, ContextImplPtr ContextImpl,
       MCreatedFromSource(IsCreatedFromSource) {
 
   RT::PiContext Context = nullptr;
-  PI_CALL(piKernelGetInfo)(MKernel, CL_KERNEL_CONTEXT, sizeof(Context),
-                           &Context, nullptr);
+  // Using the plugin from the passed ContextImpl
+  getPlugin().call<PiApiKind::piKernelGetInfo>(
+      MKernel, CL_KERNEL_CONTEXT, sizeof(Context), &Context, nullptr);
   if (ContextImpl->getHandleRef() != Context)
     throw cl::sycl::invalid_parameter_error(
         "Input context must be the same as the context of cl_kernel");
-  PI_CALL(piKernelRetain)(MKernel);
+  getPlugin().call<PiApiKind::piKernelRetain>(MKernel);
 }
 
 kernel_impl::kernel_impl(ContextImplPtr Context,
@@ -47,7 +48,7 @@ kernel_impl::kernel_impl(ContextImplPtr Context,
 kernel_impl::~kernel_impl() {
   // TODO catch an exception and put it to list of asynchronous exceptions
   if (!is_host()) {
-    PI_CALL(piKernelRelease)(MKernel);
+    getPlugin().call<PiApiKind::piKernelRelease>(MKernel);
   }
 }
 
@@ -60,7 +61,7 @@ kernel_impl::get_info() const {
   }
   return get_kernel_info<
       typename info::param_traits<info::kernel, param>::return_type,
-      param>::get(this->getHandleRef());
+      param>::get(this->getHandleRef(), getPlugin());
 }
 
 template <> context kernel_impl::get_info<info::kernel::context>() const {
@@ -79,7 +80,8 @@ kernel_impl::get_work_group_info(const device &Device) const {
   }
   return get_kernel_work_group_info<
       typename info::param_traits<info::kernel_work_group, param>::return_type,
-      param>::get(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef());
+      param>::get(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(),
+                  getPlugin());
 }
 
 template <info::kernel_sub_group param>
@@ -90,7 +92,8 @@ kernel_impl::get_sub_group_info(const device &Device) const {
   }
   return get_kernel_sub_group_info<
       typename info::param_traits<info::kernel_sub_group, param>::return_type,
-      param>::get(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef());
+      param>::get(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(),
+                  getPlugin());
 }
 
 template <info::kernel_sub_group param>
@@ -106,7 +109,8 @@ kernel_impl::get_sub_group_info(
       typename info::param_traits<info::kernel_sub_group, param>::return_type,
       param,
       typename info::param_traits<info::kernel_sub_group, param>::input_type>::
-      get(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(), Value);
+      get(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(), Value,
+          getPlugin());
 }
 
 #define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \

--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -28,11 +28,14 @@ KernelProgramCache::~KernelProgramCache() {
       KernelWithBuildStateT &KernelWithState = p.second;
       PiKernelT *Kern = KernelWithState.Ptr.load();
 
-      if (Kern)
-        PI_CALL(piKernelRelease)(Kern);
+      if (Kern) {
+        auto Plugin = MPlatform->getPlugin();
+        Plugin.call<PiApiKind::piKernelRelease>(Kern);
+      }
     }
 
-    PI_CALL(piProgramRelease)(ToBeDeleted);
+    auto Plugin = MPlatform->getPlugin();
+    Plugin.call<PiApiKind::piProgramRelease>(ToBeDeleted);
   }
 }
 }

--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -29,12 +29,12 @@ KernelProgramCache::~KernelProgramCache() {
       PiKernelT *Kern = KernelWithState.Ptr.load();
 
       if (Kern) {
-        auto Plugin = MPlatform->getPlugin();
+        auto Plugin = MParentContext->getPlugin();
         Plugin.call<PiApiKind::piKernelRelease>(Kern);
       }
     }
 
-    auto Plugin = MPlatform->getPlugin();
+    auto Plugin = MParentContext->getPlugin();
     Plugin.call<PiApiKind::piProgramRelease>(ToBeDeleted);
   }
 }

--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/kernel_program_cache.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 
 __SYCL_INLINE namespace cl {
 namespace sycl {

--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -31,12 +31,12 @@ KernelProgramCache::~KernelProgramCache() {
       PiKernelT *Kern = KernelWithState.Ptr.load();
 
       if (Kern) {
-        auto Plugin = MParentContext->getPlugin();
+        const detail::plugin &Plugin = MParentContext->getPlugin();
         Plugin.call<PiApiKind::piKernelRelease>(Kern);
       }
     }
 
-    auto Plugin = MParentContext->getPlugin();
+    const detail::plugin &Plugin = MParentContext->getPlugin();
     Plugin.call<PiApiKind::piProgramRelease>(ToBeDeleted);
   }
 }

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -26,7 +26,7 @@ static void waitForEvents(const std::vector<EventImplPtr> &Events) {
   // devices associated with the same Backend.
   if (!Events.empty()) {
     auto Plugin = Events[0]->getPlugin();
-    std::vector<RT::PiEvent> PiEvents;
+    std::vector<RT::PiEvent> PiEvents(Events.size());
     std::transform(Events.begin(), Events.end(), PiEvents.begin(),
                    [](const EventImplPtr &EventImpl) {
                      return EventImpl->getHandleRef();

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -51,7 +51,7 @@ bool useBackend(Backend TheBackend) {
 }
 
 // GlobalPlugin is a global Plugin used with Interoperability constructors that
-// use OpenCL objects as the
+// use OpenCL objects to construct SYCL class objects.
 std::shared_ptr<plugin> GlobalPlugin;
 
 // Find the plugin at the appropriate location and return the location.
@@ -128,8 +128,9 @@ vector_class<plugin> initialize() {
     }
     Plugins.push_back(plugin(PluginInformation));
   }
-  GlobalPlugin = std::make_shared<plugin>(
-      PluginInformation); // Correct the logic for this.
+  // TODO: Correct the logic to store the appropriate plugin into GlobalPlugin
+  // variable. Currently it saves the last plugin found.
+  GlobalPlugin = std::make_shared<plugin>(PluginInformation);
   return Plugins;
 }
 

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 
 #include <cstdarg>
 #include <cstring>
@@ -52,7 +52,7 @@ bool useBackend(Backend TheBackend) {
 
 // GlobalPlugin is a global Plugin used with Interoperability constructors that
 // use OpenCL objects as the
-std::shared_ptr<plugin_impl> GlobalPlugin;
+std::shared_ptr<plugin> GlobalPlugin;
 
 // Find the plugin at the appropriate location and return the location.
 // TODO: Change the function appropriately when there are multiple plugins.
@@ -99,8 +99,8 @@ bool bindPlugin(void *Library, PiPlugin *PluginInformation) {
 // TODO: Currently only accepting OpenCL plugins. Edit it to identify and load
 // other kinds of plugins, do the required changes in the findPlugins,
 // loadPlugin and bindPlugin functions.
-vector_class<plugin_impl> initialize() {
-  vector_class<plugin_impl> Plugins;
+vector_class<plugin> initialize() {
+  vector_class<plugin> Plugins;
 
   if (!useBackend(SYCL_BE_PI_OPENCL)) {
     die("Unknown SYCL_BE");
@@ -126,9 +126,9 @@ vector_class<plugin_impl> initialize() {
       std::cerr << "Failed to bind PI APIs to the plugin: " << PluginNames[I]
                 << std::endl;
     }
-    Plugins.push_back(plugin_impl(PluginInformation));
+    Plugins.push_back(plugin(PluginInformation));
   }
-  GlobalPlugin = std::make_shared<plugin_impl>(
+  GlobalPlugin = std::make_shared<plugin>(
       PluginInformation); // Correct the logic for this.
   return Plugins;
 }

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -22,22 +22,26 @@ namespace detail {
 
 vector_class<platform> platform_impl::get_platforms() {
   vector_class<platform> Platforms;
+  vector_class<plugin_impl> Plugins = RT::initialize();
 
-  pi_uint32 NumPlatforms = 0;
-  PI_CALL(piPlatformsGet)(0, nullptr, &NumPlatforms);
   info::device_type ForcedType = detail::get_forced_type();
+  for (unsigned int i = 0; i < Plugins.size(); i++) {
 
-  if (NumPlatforms) {
-    vector_class<RT::PiPlatform> PiPlatforms(NumPlatforms);
-    PI_CALL(piPlatformsGet)(NumPlatforms, PiPlatforms.data(), nullptr);
+    pi_uint32 NumPlatforms = 0;
+    Plugins[i].call<PiApiKind::piPlatformsGet>(0, nullptr, &NumPlatforms);
 
-    for (const auto &PiPlatform : PiPlatforms) {
-      platform Platform = detail::createSyclObjFromImpl<platform>(
-          std::make_shared<platform_impl>(PiPlatform));
-      // Skip platforms which do not contain requested device
-      // types
-      if (!Platform.get_devices(ForcedType).empty())
-        Platforms.push_back(Platform);
+    if (NumPlatforms) {
+      vector_class<RT::PiPlatform> PiPlatforms(NumPlatforms);
+      Plugins[i].call<PiApiKind::piPlatformsGet>(NumPlatforms,
+                                                 PiPlatforms.data(), nullptr);
+
+      for (const auto &PiPlatform : PiPlatforms) {
+        platform Platform = detail::createSyclObjFromImpl<platform>(
+            std::make_shared<platform_impl>(PiPlatform, Plugins[i]));
+        // Skip platforms which do not contain requested device types
+        if (!Platform.get_devices(ForcedType).empty())
+          Platforms.push_back(Platform);
+      }
     }
   }
 
@@ -138,27 +142,29 @@ static std::vector<DevDescT> getWhiteListDesc() {
 }
 
 static void filterWhiteList(vector_class<RT::PiDevice> &PiDevices,
-                            RT::PiPlatform PiPlatform) {
+                            RT::PiPlatform PiPlatform,
+                            const plugin_impl &Plugin) {
   const std::vector<DevDescT> WhiteList(getWhiteListDesc());
   if (WhiteList.empty())
     return;
 
   const string_class PlatformName =
       sycl::detail::get_platform_info<string_class, info::platform::name>::get(
-          PiPlatform);
+          PiPlatform, Plugin);
 
   const string_class PlatformVer =
       sycl::detail::get_platform_info<string_class,
-                                      info::platform::version>::get(PiPlatform);
+                                      info::platform::version>::get(PiPlatform,
+                                                                    Plugin);
 
   int InsertIDx = 0;
   for (RT::PiDevice Device : PiDevices) {
     const string_class DeviceName =
         sycl::detail::get_device_info<string_class, info::device::name>::get(
-            Device);
+            Device, Plugin);
 
     const string_class DeviceDriverVer = sycl::detail::get_device_info<
-        string_class, info::device::driver_version>::get(Device);
+        string_class, info::device::driver_version>::get(Device, Plugin);
 
     for (const DevDescT &Desc : WhiteList) {
       if (nullptr != Desc.platformName &&
@@ -205,25 +211,29 @@ platform_impl::get_devices(info::device_type DeviceType) const {
     return Res;
 
   pi_uint32 NumDevices;
-  PI_CALL(piDevicesGet)(MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), 0,
-                        pi::cast<RT::PiDevice *>(nullptr), &NumDevices);
+  auto Plugin = getPlugin();
+  Plugin.call<PiApiKind::piDevicesGet>(
+      MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), 0,
+      pi::cast<RT::PiDevice *>(nullptr), &NumDevices);
 
   if (NumDevices == 0)
     return Res;
 
   vector_class<RT::PiDevice> PiDevices(NumDevices);
   // TODO catch an exception and put it to list of asynchronous exceptions
-  PI_CALL(piDevicesGet)(MPlatform, pi::cast<RT::PiDeviceType>(DeviceType),
-                        NumDevices, PiDevices.data(), nullptr);
+  Plugin.call<PiApiKind::piDevicesGet>(MPlatform,
+                                       pi::cast<RT::PiDeviceType>(DeviceType),
+                                       NumDevices, PiDevices.data(), nullptr);
 
   // Filter out devices that are not present in the white list
   if (SYCLConfig<SYCL_DEVICE_ALLOWLIST>::get())
-    filterWhiteList(PiDevices, MPlatform);
+    filterWhiteList(PiDevices, MPlatform, this->getPlugin());
 
   std::transform(PiDevices.begin(), PiDevices.end(), std::back_inserter(Res),
-                 [](const RT::PiDevice &PiDevice) -> device {
+                 [this](const RT::PiDevice &PiDevice) -> device {
                    return detail::createSyclObjFromImpl<device>(
-                       std::make_shared<device_impl>(PiDevice));
+                       std::make_shared<device_impl>(
+                           PiDevice, std::make_shared<platform_impl>(*this)));
                  });
 
   return Res;
@@ -235,7 +245,7 @@ bool platform_impl::has_extension(const string_class &ExtensionName) const {
 
   string_class AllExtensionNames =
       get_platform_info<string_class, info::platform::extensions>::get(
-          MPlatform);
+          MPlatform, getPlugin());
   return (AllExtensionNames.find(ExtensionName) != std::string::npos);
 }
 
@@ -247,7 +257,7 @@ platform_impl::get_info() const {
 
   return get_platform_info<
       typename info::param_traits<info::platform, param>::return_type,
-      param>::get(this->getHandleRef());
+      param>::get(this->getHandleRef(), getPlugin());
 }
 
 #define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -22,7 +22,7 @@ namespace detail {
 
 vector_class<platform> platform_impl::get_platforms() {
   vector_class<platform> Platforms;
-  vector_class<plugin_impl> Plugins = RT::initialize();
+  vector_class<plugin> Plugins = RT::initialize();
 
   info::device_type ForcedType = detail::get_forced_type();
   for (unsigned int i = 0; i < Plugins.size(); i++) {
@@ -143,7 +143,7 @@ static std::vector<DevDescT> getWhiteListDesc() {
 
 static void filterWhiteList(vector_class<RT::PiDevice> &PiDevices,
                             RT::PiPlatform PiPlatform,
-                            const plugin_impl &Plugin) {
+                            const plugin &Plugin) {
   const std::vector<DevDescT> WhiteList(getWhiteListDesc());
   if (WhiteList.empty())
     return;

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -211,7 +211,7 @@ platform_impl::get_devices(info::device_type DeviceType) const {
     return Res;
 
   pi_uint32 NumDevices;
-  auto Plugin = getPlugin();
+  const detail::plugin &Plugin = getPlugin();
   Plugin.call<PiApiKind::piDevicesGet>(
       MPlatform, pi::cast<RT::PiDeviceType>(DeviceType), 0,
       pi::cast<RT::PiDevice *>(nullptr), &NumDevices);

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -68,10 +68,12 @@ program_impl::program_impl(
       NonInterOpToLink |= !Prg->MLinkable;
       Programs.push_back(Prg->MProgram);
     }
-    PI_CALL_THROW(piProgramLink, compile_program_error)(
+    auto Plugin = getPlugin();
+    RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramLink>(
         MContext->getHandleRef(), Devices.size(), Devices.data(),
         LinkOptions.c_str(), Programs.size(), Programs.data(), nullptr, nullptr,
         &MProgram);
+    Plugin.checkPiResult<compile_program_error>(Err);
   }
 }
 
@@ -80,12 +82,13 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
 
   // TODO handle the case when cl_program build is in progress
   cl_uint NumDevices;
-  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_NUM_DEVICES, sizeof(cl_uint),
-                            &NumDevices, nullptr);
+  auto Plugin = getPlugin();
+  Plugin.call<PiApiKind::piProgramGetInfo>(
+      Program, CL_PROGRAM_NUM_DEVICES, sizeof(cl_uint), &NumDevices, nullptr);
   vector_class<RT::PiDevice> PiDevices(NumDevices);
-  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_DEVICES,
-                            sizeof(RT::PiDevice) * NumDevices, PiDevices.data(),
-                            nullptr);
+  Plugin.call<PiApiKind::piProgramGetInfo>(Program, CL_PROGRAM_DEVICES,
+                                           sizeof(RT::PiDevice) * NumDevices,
+                                           PiDevices.data(), nullptr);
   vector_class<device> SyclContextDevices =
       MContext->get_info<info::context::devices>();
 
@@ -104,15 +107,16 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
   RT::PiDevice Device = getSyclObjImpl(MDevices[0])->getHandleRef();
   // TODO check build for each device instead
   cl_program_binary_type BinaryType;
-  PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BINARY_TYPE,
-                                 sizeof(cl_program_binary_type), &BinaryType,
-                                 nullptr);
+  Plugin.call<PiApiKind::piProgramGetBuildInfo>(
+      Program, Device, CL_PROGRAM_BINARY_TYPE, sizeof(cl_program_binary_type),
+      &BinaryType, nullptr);
   size_t Size = 0;
-  PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_OPTIONS, 0,
-                                 nullptr, &Size);
+  Plugin.call<PiApiKind::piProgramGetBuildInfo>(
+      Program, Device, CL_PROGRAM_BUILD_OPTIONS, 0, nullptr, &Size);
   std::vector<char> OptionsVector(Size);
-  PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_OPTIONS,
-                                 Size, OptionsVector.data(), nullptr);
+  Plugin.call<PiApiKind::piProgramGetBuildInfo>(Program, Device,
+                                                CL_PROGRAM_BUILD_OPTIONS, Size,
+                                                OptionsVector.data(), nullptr);
   string_class Options(OptionsVector.begin(), OptionsVector.end());
   switch (BinaryType) {
   case CL_PROGRAM_BINARY_TYPE_NONE:
@@ -129,18 +133,19 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
     MLinkOptions = "";
     MBuildOptions = Options;
   }
-  PI_CALL(piProgramRetain)(Program);
+  Plugin.call<PiApiKind::piProgramRetain>(Program);
 }
 
 program_impl::program_impl(ContextImplPtr Context, RT::PiKernel Kernel)
-    : program_impl(
-          Context,
-          ProgramManager::getInstance().getClProgramFromClKernel(Kernel)) {}
+    : program_impl(Context,
+                   ProgramManager::getInstance().getClProgramFromClKernel(
+                       Kernel, Context)) {}
 
 program_impl::~program_impl() {
   // TODO catch an exception and put it to list of asynchronous exceptions
   if (!is_host() && MProgram != nullptr) {
-    PI_CALL(piProgramRelease)(MProgram);
+    auto Plugin = getPlugin();
+    Plugin.call<PiApiKind::piProgramRelease>(MProgram);
   }
 }
 
@@ -149,7 +154,8 @@ cl_program program_impl::get() const {
   if (is_host()) {
     throw invalid_object_error("This instance of program is a host instance");
   }
-  PI_CALL(piProgramRetain)(MProgram);
+  auto Plugin = getPlugin();
+  Plugin.call<PiApiKind::piProgramRetain>(MProgram);
   return pi::cast<cl_program>(MProgram);
 }
 
@@ -187,7 +193,8 @@ void program_impl::build_with_kernel_name(string_class KernelName,
       MProgramAndKernelCachingAllowed = true;
       MProgram = ProgramManager::getInstance().getBuiltPIProgram(
           Module, get_context(), KernelName);
-      PI_CALL(piProgramRetain)(MProgram);
+      auto Plugin = getPlugin();
+      Plugin.call<PiApiKind::piProgramRetain>(MProgram);
     } else {
       create_pi_program_with_kernel_name(Module, KernelName);
       build(BuildOptions);
@@ -212,9 +219,11 @@ void program_impl::link(string_class LinkOptions) {
   if (!is_host()) {
     check_device_feature_support<info::device::is_linker_available>(MDevices);
     vector_class<RT::PiDevice> Devices(get_pi_devices());
-    PI_CALL_THROW(piProgramLink, compile_program_error)(
+    auto Plugin = getPlugin();
+    RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramLink>(
         MContext->getHandleRef(), Devices.size(), Devices.data(),
         LinkOptions.c_str(), 1, &MProgram, nullptr, nullptr, &MProgram);
+    Plugin.checkPiResult<compile_program_error>(Err);
     MLinkOptions = LinkOptions;
     MBuildOptions = LinkOptions;
   }
@@ -249,20 +258,21 @@ kernel program_impl::get_kernel(string_class KernelName,
 vector_class<vector_class<char>> program_impl::get_binaries() const {
   throw_if_state_is(program_state::none);
   vector_class<vector_class<char>> Result;
+  auto Plugin = getPlugin();
   if (!is_host()) {
     vector_class<size_t> BinarySizes(MDevices.size());
-    PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_BINARY_SIZES,
-                              sizeof(size_t) * BinarySizes.size(),
-                              BinarySizes.data(), nullptr);
+    Plugin.call<PiApiKind::piProgramGetInfo>(
+        MProgram, CL_PROGRAM_BINARY_SIZES, sizeof(size_t) * BinarySizes.size(),
+        BinarySizes.data(), nullptr);
 
     vector_class<char *> Pointers;
     for (size_t I = 0; I < BinarySizes.size(); ++I) {
       Result.emplace_back(BinarySizes[I]);
       Pointers.push_back(Result[I].data());
     }
-    PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_BINARIES,
-                              sizeof(char *) * Pointers.size(), Pointers.data(),
-                              nullptr);
+    Plugin.call<PiApiKind::piProgramGetInfo>(MProgram, CL_PROGRAM_BINARIES,
+                                             sizeof(char *) * Pointers.size(),
+                                             Pointers.data(), nullptr);
   }
   return Result;
 }
@@ -271,20 +281,23 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
   assert(!MProgram && "This program already has an encapsulated cl_program");
   const char *Src = Source.c_str();
   size_t Size = Source.size();
-  PI_CALL(piclProgramCreateWithSource)(MContext->getHandleRef(), 1, &Src, &Size,
-                                       &MProgram);
+  auto Plugin = getPlugin();
+  Plugin.call<PiApiKind::piclProgramCreateWithSource>(
+      MContext->getHandleRef(), 1, &Src, &Size, &MProgram);
 }
 
 void program_impl::compile(const string_class &Options) {
   check_device_feature_support<info::device::is_compiler_available>(MDevices);
   vector_class<RT::PiDevice> Devices(get_pi_devices());
-  RT::PiResult Err = PI_CALL_NOCHECK(piProgramCompile)(
+  auto Plugin = getPlugin();
+  RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramCompile>(
       MProgram, Devices.size(), Devices.data(), Options.c_str(), 0, nullptr,
       nullptr, nullptr, nullptr);
 
   if (Err != PI_SUCCESS) {
-    throw compile_program_error("Program compilation error:\n" +
-                                ProgramManager::getProgramBuildLog(MProgram));
+    throw compile_program_error(
+        "Program compilation error:\n" +
+        ProgramManager::getProgramBuildLog(MProgram, MContext));
   }
   MCompileOptions = Options;
 }
@@ -292,13 +305,15 @@ void program_impl::compile(const string_class &Options) {
 void program_impl::build(const string_class &Options) {
   check_device_feature_support<info::device::is_compiler_available>(MDevices);
   vector_class<RT::PiDevice> Devices(get_pi_devices());
-  RT::PiResult Err =
-      PI_CALL_NOCHECK(piProgramBuild)(MProgram, Devices.size(), Devices.data(),
-                                      Options.c_str(), nullptr, nullptr);
+  auto Plugin = getPlugin();
+  RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramBuild>(
+      MProgram, Devices.size(), Devices.data(), Options.c_str(), nullptr,
+      nullptr);
 
   if (Err != PI_SUCCESS) {
-    throw compile_program_error("Program build error:\n" +
-                                ProgramManager::getProgramBuildLog(MProgram));
+    throw compile_program_error(
+        "Program build error:\n" +
+        ProgramManager::getProgramBuildLog(MProgram, MContext));
   }
   MBuildOptions = Options;
   MCompileOptions = Options;
@@ -314,11 +329,13 @@ vector_class<RT::PiDevice> program_impl::get_pi_devices() const {
 
 bool program_impl::has_cl_kernel(const string_class &KernelName) const {
   size_t Size;
-  PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_KERNEL_NAMES, 0, nullptr,
-                            &Size);
+  auto Plugin = getPlugin();
+  Plugin.call<PiApiKind::piProgramGetInfo>(MProgram, CL_PROGRAM_KERNEL_NAMES, 0,
+                                           nullptr, &Size);
   string_class ClResult(Size, ' ');
-  PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_KERNEL_NAMES, ClResult.size(),
-                            &ClResult[0], nullptr);
+  Plugin.call<PiApiKind::piProgramGetInfo>(MProgram, CL_PROGRAM_KERNEL_NAMES,
+                                           ClResult.size(), &ClResult[0],
+                                           nullptr);
   // Get rid of the null terminator
   ClResult.pop_back();
   vector_class<string_class> KernelNames(split_string(ClResult, ';'));
@@ -337,13 +354,14 @@ RT::PiKernel program_impl::get_pi_kernel(const string_class &KernelName) const {
     Kernel = ProgramManager::getInstance().getOrCreateKernel(
         MProgramModuleHandle, get_context(), KernelName);
   } else {
-    RT::PiResult Err =
-        PI_CALL_NOCHECK(piKernelCreate)(MProgram, KernelName.c_str(), &Kernel);
+    auto Plugin = getPlugin();
+    RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piKernelCreate>(
+        MProgram, KernelName.c_str(), &Kernel);
     if (Err == PI_RESULT_INVALID_KERNEL_NAME) {
       throw invalid_object_error(
           "This instance of program does not contain the kernel requested");
     }
-    RT::checkPiResult(Err);
+    Plugin.checkPiResult(Err);
   }
 
   return Kernel;
@@ -385,8 +403,9 @@ cl_uint program_impl::get_info<info::program::reference_count>() const {
     throw invalid_object_error("This instance of program is a host instance");
   }
   cl_uint Result;
-  PI_CALL(piProgramGetInfo)(MProgram, CL_PROGRAM_REFERENCE_COUNT,
-                            sizeof(cl_uint), &Result, nullptr);
+  auto Plugin = getPlugin();
+  Plugin.call<PiApiKind::piProgramGetInfo>(MProgram, CL_PROGRAM_REFERENCE_COUNT,
+                                           sizeof(cl_uint), &Result, nullptr);
   return Result;
 }
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -31,6 +31,8 @@ __SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 
+using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
+
 static constexpr int DbgProgMgr = 0;
 
 enum BuildState { BS_InProgress, BS_Done, BS_Failed };
@@ -43,32 +45,36 @@ ProgramManager &ProgramManager::getInstance() {
   return Instance;
 }
 
-static RT::PiDevice getFirstDevice(RT::PiContext Context) {
+static RT::PiDevice getFirstDevice(const ContextImplPtr &Context) {
   cl_uint NumDevices = 0;
-  PI_CALL(piContextGetInfo)(Context, PI_CONTEXT_INFO_NUM_DEVICES,
-                            sizeof(NumDevices), &NumDevices,
-                            /*param_value_size_ret=*/nullptr);
+  auto Plugin = Context->getPlugin();
+  Plugin.call<PiApiKind::piContextGetInfo>(Context->getHandleRef(),
+                                           PI_CONTEXT_INFO_NUM_DEVICES,
+                                           sizeof(NumDevices), &NumDevices,
+                                           /*param_value_size_ret=*/nullptr);
   assert(NumDevices > 0 && "Context without devices?");
 
   vector_class<RT::PiDevice> Devices(NumDevices);
   size_t ParamValueSize = 0;
-  PI_CALL(piContextGetInfo)(Context, PI_CONTEXT_INFO_DEVICES,
-                            sizeof(cl_device_id) * NumDevices, &Devices[0],
-                            &ParamValueSize);
+  Plugin.call<PiApiKind::piContextGetInfo>(
+      Context->getHandleRef(), PI_CONTEXT_INFO_DEVICES,
+      sizeof(cl_device_id) * NumDevices, &Devices[0], &ParamValueSize);
   assert(ParamValueSize == sizeof(cl_device_id) * NumDevices &&
          "Number of CL_CONTEXT_DEVICES should match CL_CONTEXT_NUM_DEVICES.");
   return Devices[0];
 }
 
-static RT::PiProgram createBinaryProgram(const RT::PiContext Context,
+static RT::PiProgram createBinaryProgram(const ContextImplPtr Context,
                                          const unsigned char *Data,
                                          size_t DataLen) {
   // FIXME: we don't yet support multiple devices with a single binary.
+  auto Plugin = Context->getPlugin();
 #ifndef _NDEBUG
   cl_uint NumDevices = 0;
-  PI_CALL(piContextGetInfo)(Context, PI_CONTEXT_INFO_NUM_DEVICES,
-                            sizeof(NumDevices), &NumDevices,
-                            /*param_value_size_ret=*/nullptr);
+  Plugin.call<PiApiKind::piContextGetInfo>(Context->getHandleRef(),
+                                           PI_CONTEXT_INFO_NUM_DEVICES,
+                                           sizeof(NumDevices), &NumDevices,
+                                           /*param_value_size_ret=*/nullptr);
   assert(NumDevices > 0 &&
          "Only a single device is supported for AOT compilation");
 #endif
@@ -76,17 +82,19 @@ static RT::PiProgram createBinaryProgram(const RT::PiContext Context,
   RT::PiDevice Device = getFirstDevice(Context);
   pi_int32 BinaryStatus = CL_SUCCESS;
   RT::PiProgram Program;
-  PI_CALL(piclProgramCreateWithBinary)(Context, 1 /*one binary*/, &Device,
-                                       &DataLen, &Data, &BinaryStatus,
-                                       &Program);
+  Plugin.call<PiApiKind::piclProgramCreateWithBinary>(
+      Context->getHandleRef(), 1 /*one binary*/, &Device, &DataLen, &Data,
+      &BinaryStatus, &Program);
   return Program;
 }
 
-static RT::PiProgram createSpirvProgram(const RT::PiContext Context,
+static RT::PiProgram createSpirvProgram(const ContextImplPtr Context,
                                         const unsigned char *Data,
                                         size_t DataLen) {
   RT::PiProgram Program = nullptr;
-  PI_CALL(piProgramCreate)(Context, Data, DataLen, &Program);
+  auto Plugin = Context->getPlugin();
+  Plugin.call<PiApiKind::piProgramCreate>(Context->getHandleRef(), Data,
+                                          DataLen, &Program);
   return Program;
 }
 
@@ -267,7 +275,7 @@ RT::PiProgram ProgramManager::createPIProgram(const DeviceImage &Img,
         "Online compilation is not supported in this context");
 
   // Load the image
-  const RT::PiContext &Ctx = getRawSyclObjImpl(Context)->getHandleRef();
+  const ContextImplPtr Ctx = getSyclObjImpl(Context);
   RT::PiProgram Res = Format == PI_DEVICE_BINARY_TYPE_SPIRV
                           ? createSpirvProgram(Ctx, Img.BinaryStart, ImgSize)
                           : createBinaryProgram(Ctx, Img.BinaryStart, ImgSize);
@@ -284,7 +292,7 @@ ProgramManager::getBuiltPIProgram(OSModuleHandle M, const context &Context,
                                   const string_class &KernelName) {
   KernelSetId KSId = getKernelSetId(M, KernelName);
 
-  std::shared_ptr<context_impl> Ctx = getSyclObjImpl(Context);
+  const ContextImplPtr Ctx = getSyclObjImpl(Context);
 
   using PiProgramT = KernelProgramCache::PiProgramT;
   using ProgramCacheT = KernelProgramCache::ProgramCacheT;
@@ -300,17 +308,17 @@ ProgramManager::getBuiltPIProgram(OSModuleHandle M, const context &Context,
   auto BuildF = [this, &M, &KSId, &Context] {
     const DeviceImage &Img = getDeviceImage(M, KSId, Context);
 
+    ContextImplPtr ContextImpl = getSyclObjImpl(Context);
+    auto Plugin = ContextImpl->getPlugin();
     RT::PiProgram Prg = createPIProgram(Img, Context);
-    ProgramPtr ProgramManaged(
-          Prg, RT::PluginInformation.PiFunctionTable.piProgramRelease);
+    ProgramPtr ProgramManaged(Prg,
+                              Plugin.MPlugin.PiFunctionTable.piProgramRelease);
 
     // Link a fallback implementation of device libraries if they are not
     // supported by a device compiler.
     // Pre-compiled programs are supposed to be already linked.
     const bool LinkDeviceLibs = getFormat(Img) == PI_DEVICE_BINARY_TYPE_SPIRV;
 
-    context_impl *ContextImpl = getRawSyclObjImpl(Context);
-    RT::PiContext PiContext = ContextImpl->getHandleRef();
     const std::vector<device> &Devices = ContextImpl->getDevices();
     std::vector<RT::PiDevice> PiDevices(Devices.size());
     std::transform(
@@ -318,7 +326,7 @@ ProgramManager::getBuiltPIProgram(OSModuleHandle M, const context &Context,
         [](const device Dev) { return getRawSyclObjImpl(Dev)->getHandleRef(); });
 
     ProgramPtr BuiltProgram =
-        build(std::move(ProgramManaged), PiContext, Img.CompileOptions,
+        build(std::move(ProgramManaged), ContextImpl, Img.CompileOptions,
               Img.LinkOptions, PiDevices, ContextImpl->getCachedLibPrograms(),
               LinkDeviceLibs);
 
@@ -338,7 +346,7 @@ RT::PiKernel ProgramManager::getOrCreateKernel(OSModuleHandle M,
   }
 
   RT::PiProgram Program = getBuiltPIProgram(M, Context, KernelName);
-  std::shared_ptr<context_impl> Ctx = getSyclObjImpl(Context);
+  const ContextImplPtr Ctx = getSyclObjImpl(Context);
 
   using PiKernelT = KernelProgramCache::PiKernelT;
   using KernelCacheT = KernelProgramCache::KernelCacheT;
@@ -352,12 +360,14 @@ RT::PiKernel ProgramManager::getOrCreateKernel(OSModuleHandle M,
   auto GetF = [&Program] (const Locked<KernelCacheT> &LockedCache) -> KernelByNameT& {
     return LockedCache.get()[Program];
   };
-  auto BuildF = [this, &Program, &KernelName] {
+  auto BuildF = [this, &Program, &KernelName, &Ctx] {
     PiKernelT *Result = nullptr;
 
     // TODO need some user-friendly error/exception
     // instead of currently obscure one
-    PI_CALL(piKernelCreate)(Program, KernelName.c_str(), &Result);
+    auto Plugin = Ctx->getPlugin();
+    Plugin.call<PiApiKind::piKernelCreate>(Program, KernelName.c_str(),
+                                           &Result);
 
     return Result;
   };
@@ -366,31 +376,39 @@ RT::PiKernel ProgramManager::getOrCreateKernel(OSModuleHandle M,
         Cache, KernelName, AcquireF, GetF, BuildF);
 }
 
-RT::PiProgram ProgramManager::getClProgramFromClKernel(RT::PiKernel Kernel) {
+RT::PiProgram
+ProgramManager::getClProgramFromClKernel(RT::PiKernel Kernel,
+                                         const ContextImplPtr Context) {
   RT::PiProgram Program;
-  PI_CALL(piKernelGetInfo)(Kernel, CL_KERNEL_PROGRAM, sizeof(cl_program),
-                           &Program, nullptr);
+  auto Plugin = Context->getPlugin();
+  Plugin.call<PiApiKind::piKernelGetInfo>(
+      Kernel, CL_KERNEL_PROGRAM, sizeof(cl_program), &Program, nullptr);
   return Program;
 }
 
-string_class ProgramManager::getProgramBuildLog(const RT::PiProgram &Program) {
+string_class ProgramManager::getProgramBuildLog(const RT::PiProgram &Program,
+                                                const ContextImplPtr Context) {
   size_t Size = 0;
-  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_DEVICES, 0, nullptr, &Size);
+  auto Plugin = Context->getPlugin();
+  Plugin.call<PiApiKind::piProgramGetInfo>(Program, CL_PROGRAM_DEVICES, 0,
+                                           nullptr, &Size);
   vector_class<RT::PiDevice> PIDevices(Size / sizeof(RT::PiDevice));
-  PI_CALL(piProgramGetInfo)(Program, CL_PROGRAM_DEVICES, Size, PIDevices.data(),
-                            nullptr);
+  Plugin.call<PiApiKind::piProgramGetInfo>(Program, CL_PROGRAM_DEVICES, Size,
+                                           PIDevices.data(), nullptr);
   string_class Log = "The program was built for " +
                      std::to_string(PIDevices.size()) + " devices";
   for (RT::PiDevice &Device : PIDevices) {
-    PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_LOG, 0,
-                                   nullptr, &Size);
+    Plugin.call<PiApiKind::piProgramGetBuildInfo>(
+        Program, Device, CL_PROGRAM_BUILD_LOG, 0, nullptr, &Size);
     vector_class<char> DeviceBuildInfo(Size);
-    PI_CALL(piProgramGetBuildInfo)(Program, Device, CL_PROGRAM_BUILD_LOG, Size,
-                                   DeviceBuildInfo.data(), nullptr);
-    PI_CALL(piDeviceGetInfo)(Device, PI_DEVICE_INFO_NAME, 0, nullptr, &Size);
+    Plugin.call<PiApiKind::piProgramGetBuildInfo>(
+        Program, Device, CL_PROGRAM_BUILD_LOG, Size, DeviceBuildInfo.data(),
+        nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(Device, PI_DEVICE_INFO_NAME, 0,
+                                            nullptr, &Size);
     vector_class<char> DeviceName(Size);
-    PI_CALL(piDeviceGetInfo)(Device, PI_DEVICE_INFO_NAME, Size,
-                             DeviceName.data(), nullptr);
+    Plugin.call<PiApiKind::piDeviceGetInfo>(Device, PI_DEVICE_INFO_NAME, Size,
+                                            DeviceName.data(), nullptr);
 
     Log += "\nBuild program log for '" + string_class(DeviceName.data()) +
            "':\n" + string_class(DeviceBuildInfo.data());
@@ -398,7 +416,7 @@ string_class ProgramManager::getProgramBuildLog(const RT::PiProgram &Program) {
   return Log;
 }
 
-static bool loadDeviceLib(const RT::PiContext &Context, const char *Name,
+static bool loadDeviceLib(const ContextImplPtr Context, const char *Name,
                           RT::PiProgram &Prog) {
   std::string LibSyclDir = OSUtil::getCurrentDSODir();
   std::ifstream File(LibSyclDir + OSUtil::DirSep + Name,
@@ -435,10 +453,8 @@ static const char* getDeviceLibExtensionStr(DeviceLibExt Extension) {
   throw compile_program_error("Unhandled (new?) device library extension");
 }
 
-static RT::PiProgram
-loadDeviceLibFallback(
-    const RT::PiContext &Context,
-    DeviceLibExt Extension,
+static RT::PiProgram loadDeviceLibFallback(
+    const ContextImplPtr Context, DeviceLibExt Extension,
     const std::vector<RT::PiDevice> &Devices,
     std::map<DeviceLibExt, RT::PiProgram> &CachedLibPrograms) {
 
@@ -458,7 +474,8 @@ loadDeviceLibFallback(
     throw compile_program_error(std::string("Failed to load ") + LibFileName);
   }
 
-  RT::PiResult Error = PI_CALL_NOCHECK(piProgramCompile)(
+  auto Plugin = Context->getPlugin();
+  RT::PiResult Error = Plugin.call_nocheck<PiApiKind::piProgramCompile>(
       LibProg,
       // Assume that Devices contains all devices from Context.
       Devices.size(), Devices.data(),
@@ -469,7 +486,8 @@ loadDeviceLibFallback(
       "", 0, nullptr, nullptr, nullptr, nullptr);
   if (Error != PI_SUCCESS) {
     CachedLibPrograms.erase(LibProgIt);
-    throw compile_program_error(ProgramManager::getProgramBuildLog(LibProg));
+    throw compile_program_error(
+        ProgramManager::getProgramBuildLog(LibProg, Context));
   }
 
   return LibProg;
@@ -541,7 +559,7 @@ DeviceImage &ProgramManager::getDeviceImage(OSModuleHandle M, KernelSetId KSId,
               << "\", " << getRawSyclObjImpl(Context) << ")\n";
   std::lock_guard<std::mutex> Guard(Sync::getGlobalLock());
   std::vector<DeviceImage *> &Imgs = *m_DeviceImages[KSId];
-  const RT::PiContext &Ctx = getRawSyclObjImpl(Context)->getHandleRef();
+  const ContextImplPtr Ctx = getSyclObjImpl(Context);
   DeviceImage *Img = nullptr;
 
   // TODO: There may be cases with cl::sycl::program class usage in source code
@@ -551,8 +569,8 @@ DeviceImage &ProgramManager::getDeviceImage(OSModuleHandle M, KernelSetId KSId,
   // Ask the native runtime under the given context to choose the device image
   // it prefers.
   if (Imgs.size() > 1) {
-    PI_CALL(piextDeviceSelectBinary)(getFirstDevice(Ctx), Imgs.data(),
-                                     (cl_uint)Imgs.size(), &Img);
+    Ctx->getPlugin().call<PiApiKind::piextDeviceSelectBinary>(
+        getFirstDevice(Ctx), Imgs.data(), (cl_uint)Imgs.size(), &Img);
   } else
     Img = Imgs[0];
 
@@ -568,10 +586,10 @@ DeviceImage &ProgramManager::getDeviceImage(OSModuleHandle M, KernelSetId KSId,
   return *Img;
 }
 
-static std::vector<RT::PiProgram> getDeviceLibPrograms(
-    const RT::PiContext Context,
-    const std::vector<RT::PiDevice> &Devices,
-    std::map<DeviceLibExt, RT::PiProgram> &CachedLibPrograms) {
+static std::vector<RT::PiProgram>
+getDeviceLibPrograms(const ContextImplPtr Context,
+                     const std::vector<RT::PiDevice> &Devices,
+                     std::map<DeviceLibExt, RT::PiProgram> &CachedLibPrograms) {
 
   std::vector<RT::PiProgram> Programs;
 
@@ -586,7 +604,8 @@ static std::vector<RT::PiProgram> getDeviceLibPrograms(
   // support it.
   for (RT::PiDevice Dev : Devices) {
     std::string DevExtList =
-        get_device_info<std::string, info::device::extensions>::get(Dev);
+        get_device_info<std::string, info::device::extensions>::get(
+            Dev, Context->getPlugin());
     for (auto &Pair : RequiredDeviceLibExt) {
       DeviceLibExt Ext = Pair.first;
       bool &FallbackIsLoaded = Pair.second;
@@ -615,7 +634,7 @@ static std::vector<RT::PiProgram> getDeviceLibPrograms(
 }
 
 ProgramManager::ProgramPtr
-ProgramManager::build(ProgramPtr Program, RT::PiContext Context,
+ProgramManager::build(ProgramPtr Program, const ContextImplPtr Context,
                       const string_class &CompileOptions,
                       const string_class &LinkOptions,
                       const std::vector<RT::PiDevice> &Devices,
@@ -642,29 +661,30 @@ ProgramManager::build(ProgramPtr Program, RT::PiContext Context,
     LinkPrograms = getDeviceLibPrograms(Context, Devices, CachedLibPrograms);
   }
 
+  auto Plugin = Context->getPlugin();
   if (LinkPrograms.empty()) {
     std::string Opts(CompileOpts);
     Opts += " ";
     Opts += LinkOpts;
 
-    RT::PiResult Error = PI_CALL_NOCHECK(piProgramBuild)(
-        Program.get(), Devices.size(), Devices.data(), Opts.c_str(), nullptr,
+    RT::PiResult Error = Plugin.call_nocheck<PiApiKind::piProgramBuild>(
+        Program.get(), Devices.size(), Devices.data(), Opts.c_str, nullptr,
         nullptr);
     if (Error != PI_SUCCESS)
-      throw compile_program_error(getProgramBuildLog(Program.get()));
+      throw compile_program_error(getProgramBuildLog(Program.get(), Context));
     return Program;
   }
 
   // Include the main program and compile/link everything together
-  PI_CALL(piProgramCompile)(Program.get(), Devices.size(), Devices.data(),
-                            CompileOpts, 0, nullptr, nullptr, nullptr, nullptr);
+  Plugin.call<PiApiKind::piProgramCompile>(Program.get(), Devices.size(),
+                                           Devices.data(), CompileOpts, 0,
+                                           nullptr, nullptr, nullptr, nullptr);
   LinkPrograms.push_back(Program.get());
 
   RT::PiProgram LinkedProg = nullptr;
-
-  RT::PiResult Error = PI_CALL_NOCHECK(piProgramLink)(
-      Context, Devices.size(), Devices.data(), LinkOpts, LinkPrograms.size(),
-      LinkPrograms.data(), nullptr, nullptr, &LinkedProg);
+  RT::PiResult Error = Plugin.call_nocheck<PiApiKind::piProgramLink>(
+      Context->getHandleRef(), Devices.size(), Devices.data(), LinkOpts,
+      LinkPrograms.size(), LinkPrograms.data(), nullptr, nullptr, &LinkedProg);
 
   // Link program call returns a new program object if all parameters are valid,
   // or NULL otherwise. Release the original (user) program.
@@ -673,9 +693,9 @@ ProgramManager::build(ProgramPtr Program, RT::PiContext Context,
     if (LinkedProg) {
       // A non-trivial error occurred during linkage: get a build log, release
       // an incomplete (but valid) LinkedProg, and throw.
-      throw compile_program_error(getProgramBuildLog(LinkedProg));
+      throw compile_program_error(getProgramBuildLog(LinkedProg, Context));
     }
-    pi::checkPiResult(Error);
+    Plugin.checkPiResult(Error);
   }
   return Program;
 }

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -47,7 +47,7 @@ ProgramManager &ProgramManager::getInstance() {
 
 static RT::PiDevice getFirstDevice(const ContextImplPtr &Context) {
   cl_uint NumDevices = 0;
-  auto Plugin = Context->getPlugin();
+  const detail::plugin &Plugin = Context->getPlugin();
   Plugin.call<PiApiKind::piContextGetInfo>(Context->getHandleRef(),
                                            PI_CONTEXT_INFO_NUM_DEVICES,
                                            sizeof(NumDevices), &NumDevices,
@@ -68,7 +68,7 @@ static RT::PiProgram createBinaryProgram(const ContextImplPtr Context,
                                          const unsigned char *Data,
                                          size_t DataLen) {
   // FIXME: we don't yet support multiple devices with a single binary.
-  auto Plugin = Context->getPlugin();
+  const detail::plugin &Plugin = Context->getPlugin();
 #ifndef _NDEBUG
   cl_uint NumDevices = 0;
   Plugin.call<PiApiKind::piContextGetInfo>(Context->getHandleRef(),
@@ -92,7 +92,7 @@ static RT::PiProgram createSpirvProgram(const ContextImplPtr Context,
                                         const unsigned char *Data,
                                         size_t DataLen) {
   RT::PiProgram Program = nullptr;
-  auto Plugin = Context->getPlugin();
+  const detail::plugin &Plugin = Context->getPlugin();
   Plugin.call<PiApiKind::piProgramCreate>(Context->getHandleRef(), Data,
                                           DataLen, &Program);
   return Program;
@@ -309,7 +309,7 @@ ProgramManager::getBuiltPIProgram(OSModuleHandle M, const context &Context,
     const DeviceImage &Img = getDeviceImage(M, KSId, Context);
 
     ContextImplPtr ContextImpl = getSyclObjImpl(Context);
-    auto Plugin = ContextImpl->getPlugin();
+    const detail::plugin &Plugin = ContextImpl->getPlugin();
     RT::PiProgram Prg = createPIProgram(Img, Context);
     ProgramPtr ProgramManaged(Prg,
                               Plugin.MPlugin.PiFunctionTable.piProgramRelease);
@@ -365,7 +365,7 @@ RT::PiKernel ProgramManager::getOrCreateKernel(OSModuleHandle M,
 
     // TODO need some user-friendly error/exception
     // instead of currently obscure one
-    auto Plugin = Ctx->getPlugin();
+    const detail::plugin &Plugin = Ctx->getPlugin();
     Plugin.call<PiApiKind::piKernelCreate>(Program, KernelName.c_str(),
                                            &Result);
 
@@ -380,7 +380,7 @@ RT::PiProgram
 ProgramManager::getClProgramFromClKernel(RT::PiKernel Kernel,
                                          const ContextImplPtr Context) {
   RT::PiProgram Program;
-  auto Plugin = Context->getPlugin();
+  const detail::plugin &Plugin = Context->getPlugin();
   Plugin.call<PiApiKind::piKernelGetInfo>(
       Kernel, CL_KERNEL_PROGRAM, sizeof(cl_program), &Program, nullptr);
   return Program;
@@ -389,7 +389,7 @@ ProgramManager::getClProgramFromClKernel(RT::PiKernel Kernel,
 string_class ProgramManager::getProgramBuildLog(const RT::PiProgram &Program,
                                                 const ContextImplPtr Context) {
   size_t Size = 0;
-  auto Plugin = Context->getPlugin();
+  const detail::plugin &Plugin = Context->getPlugin();
   Plugin.call<PiApiKind::piProgramGetInfo>(Program, CL_PROGRAM_DEVICES, 0,
                                            nullptr, &Size);
   vector_class<RT::PiDevice> PIDevices(Size / sizeof(RT::PiDevice));
@@ -474,7 +474,7 @@ static RT::PiProgram loadDeviceLibFallback(
     throw compile_program_error(std::string("Failed to load ") + LibFileName);
   }
 
-  auto Plugin = Context->getPlugin();
+  const detail::plugin &Plugin = Context->getPlugin();
   RT::PiResult Error = Plugin.call_nocheck<PiApiKind::piProgramCompile>(
       LibProg,
       // Assume that Devices contains all devices from Context.
@@ -661,7 +661,7 @@ ProgramManager::build(ProgramPtr Program, const ContextImplPtr Context,
     LinkPrograms = getDeviceLibPrograms(Context, Devices, CachedLibPrograms);
   }
 
-  auto Plugin = Context->getPlugin();
+  const detail::plugin &Plugin = Context->getPlugin();
   if (LinkPrograms.empty()) {
     std::string Opts(CompileOpts);
     Opts += " ";

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -668,7 +668,7 @@ ProgramManager::build(ProgramPtr Program, const ContextImplPtr Context,
     Opts += LinkOpts;
 
     RT::PiResult Error = Plugin.call_nocheck<PiApiKind::piProgramBuild>(
-        Program.get(), Devices.size(), Devices.data(), Opts.c_str, nullptr,
+        Program.get(), Devices.size(), Devices.data(), Opts.c_str(), nullptr,
         nullptr);
     if (Error != PI_SUCCESS)
       throw compile_program_error(getProgramBuildLog(Program.get(), Context));

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -68,7 +68,7 @@ event queue_impl::mem_advise(const void *Ptr, size_t Length, int Advice) {
 
   // non-Host device
   RT::PiEvent Event = nullptr;
-  auto Plugin = getPlugin();
+  const detail::plugin &Plugin = getPlugin();
   Plugin.call<PiApiKind::piextUSMEnqueueMemAdvise>(getHandleRef(), Ptr, Length,
                                                    Advice, &Event);
 

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -22,8 +22,9 @@ namespace detail {
 template <> cl_uint queue_impl::get_info<info::queue::reference_count>() const {
   RT::PiResult result = PI_SUCCESS;
   if (!is_host())
-    PI_CALL(piQueueGetInfo)(MCommandQueue, PI_QUEUE_INFO_REFERENCE_COUNT,
-                            sizeof(result), &result, nullptr);
+    getPlugin().call<PiApiKind::piQueueGetInfo>(
+        MCommandQueue, PI_QUEUE_INFO_REFERENCE_COUNT, sizeof(result), &result,
+        nullptr);
   return result;
 }
 
@@ -67,8 +68,9 @@ event queue_impl::mem_advise(const void *Ptr, size_t Length, int Advice) {
 
   // non-Host device
   RT::PiEvent Event = nullptr;
-  PI_CALL(piextUSMEnqueueMemAdvise)(getHandleRef(), Ptr, Length, Advice,
-                                    &Event);
+  auto Plugin = getPlugin();
+  Plugin.call<PiApiKind::piextUSMEnqueueMemAdvise>(getHandleRef(), Ptr, Length,
+                                                   Advice, &Event);
 
   return event(pi::cast<cl_event>(Event), Context);
 }

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -23,21 +23,24 @@ sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
 
   RT::PiSampler Sampler = pi::cast<RT::PiSampler>(clSampler);
   m_contextToSampler[syclContext] = Sampler;
-  PI_CALL(piSamplerRetain)(Sampler);
-  PI_CALL(piSamplerGetInfo)(Sampler, PI_SAMPLER_INFO_NORMALIZED_COORDS,
-                            sizeof(pi_bool), &m_CoordNormMode, nullptr);
-  PI_CALL(piSamplerGetInfo)(Sampler, PI_SAMPLER_INFO_ADDRESSING_MODE,
-                            sizeof(pi_sampler_addressing_mode), &m_AddrMode,
-                            nullptr);
-  PI_CALL(piSamplerGetInfo)(Sampler, PI_SAMPLER_INFO_FILTER_MODE,
-                            sizeof(pi_sampler_filter_mode), &m_FiltMode,
-                            nullptr);
+  auto Plugin = getSyclObjImpl(syclContext)->getPlugin();
+  Plugin.call<PiApiKind::piSamplerRetain>(Sampler);
+  Plugin.call<PiApiKind::piSamplerGetInfo>(
+      Sampler, PI_SAMPLER_INFO_NORMALIZED_COORDS, sizeof(pi_bool),
+      &m_CoordNormMode, nullptr);
+  Plugin.call<PiApiKind::piSamplerGetInfo>(
+      Sampler, PI_SAMPLER_INFO_ADDRESSING_MODE,
+      sizeof(pi_sampler_addressing_mode), &m_AddrMode, nullptr);
+  Plugin.call<PiApiKind::piSamplerGetInfo>(Sampler, PI_SAMPLER_INFO_FILTER_MODE,
+                                           sizeof(pi_sampler_filter_mode),
+                                           &m_FiltMode, nullptr);
 }
 
 sampler_impl::~sampler_impl() {
   for (auto &Iter : m_contextToSampler) {
     // TODO catch an exception and add it to the list of asynchronous exceptions
-    PI_CALL(piSamplerRelease)(Iter.second);
+    auto Plugin = getSyclObjImpl(Iter.first)->getPlugin();
+    Plugin.call<PiApiKind::piSamplerRelease>(Iter.second);
   }
 }
 
@@ -56,13 +59,15 @@ RT::PiSampler sampler_impl::getOrCreateSampler(const context &Context) {
 
   RT::PiResult errcode_ret = PI_SUCCESS;
   RT::PiSampler resultSampler = nullptr;
-  errcode_ret = PI_CALL_NOCHECK(piSamplerCreate)(
+  auto Plugin = getSyclObjImpl(Context)->getPlugin();
+
+  errcode_ret = Plugin.call_nocheck<PiApiKind::piSamplerCreate>(
       getSyclObjImpl(Context)->getHandleRef(), sprops, &resultSampler);
 
   if (errcode_ret == PI_INVALID_OPERATION)
     throw feature_not_supported("Images are not supported by this device.");
 
-  RT::checkPiResult(errcode_ret);
+  Plugin.checkPiResult(errcode_ret);
   m_contextToSampler[Context] = resultSampler;
 
   return m_contextToSampler[Context];

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -23,7 +23,7 @@ sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
 
   RT::PiSampler Sampler = pi::cast<RT::PiSampler>(clSampler);
   m_contextToSampler[syclContext] = Sampler;
-  auto Plugin = getSyclObjImpl(syclContext)->getPlugin();
+  const detail::plugin &Plugin = getSyclObjImpl(syclContext)->getPlugin();
   Plugin.call<PiApiKind::piSamplerRetain>(Sampler);
   Plugin.call<PiApiKind::piSamplerGetInfo>(
       Sampler, PI_SAMPLER_INFO_NORMALIZED_COORDS, sizeof(pi_bool),
@@ -39,7 +39,7 @@ sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
 sampler_impl::~sampler_impl() {
   for (auto &Iter : m_contextToSampler) {
     // TODO catch an exception and add it to the list of asynchronous exceptions
-    auto Plugin = getSyclObjImpl(Iter.first)->getPlugin();
+    const detail::plugin &Plugin = getSyclObjImpl(Iter.first)->getPlugin();
     Plugin.call<PiApiKind::piSamplerRelease>(Iter.second);
   }
 }
@@ -59,7 +59,7 @@ RT::PiSampler sampler_impl::getOrCreateSampler(const context &Context) {
 
   RT::PiResult errcode_ret = PI_SUCCESS;
   RT::PiSampler resultSampler = nullptr;
-  auto Plugin = getSyclObjImpl(Context)->getPlugin();
+  const detail::plugin &Plugin = getSyclObjImpl(Context)->getPlugin();
 
   errcode_ret = Plugin.call_nocheck<PiApiKind::piSamplerCreate>(
       getSyclObjImpl(Context)->getHandleRef(), sprops, &resultSampler);

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -144,12 +144,11 @@ void Command::waitForEvents(QueueImplPtr Queue,
                             RT::PiEvent &Event) {
 
   if (!EventImpls.empty()) {
+    std::vector<RT::PiEvent> RawEvents = getPiEvents(EventImpls);
     if (Queue->is_host()) {
-      std::vector<RT::PiEvent> RawEvents = getPiEvents(EventImpls);
       auto Plugin = EventImpls[0]->getPlugin();
       Plugin.call<PiApiKind::piEventsWait>(RawEvents.size(), &RawEvents[0]);
     } else {
-      std::vector<RT::PiEvent> RawEvents = getPiEvents(EventImpls);
       auto Plugin = Queue->getPlugin();
       Plugin.call<PiApiKind::piEnqueueEventsWait>(
           Queue->getHandleRef(), RawEvents.size(), &RawEvents[0], &Event);

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -94,7 +94,7 @@ void EventCompletionClbk(RT::PiEvent, pi_int32, void *data) {
   // TODO: Handle return values. Store errors to async handler.
   EventImplPtr *Event = (reinterpret_cast<EventImplPtr *>(data));
   RT::PiEvent &EventHandle = (*Event)->getHandleRef();
-  auto Plugin = (*Event)->getPlugin();
+  const detail::plugin &Plugin = (*Event)->getPlugin();
   Plugin.call<PiApiKind::piEventSetStatus>(EventHandle, CL_COMPLETE);
   delete (Event);
 }
@@ -115,7 +115,7 @@ std::vector<EventImplPtr> Command::prepareEvents(ContextImplPtr Context) {
       continue;
     }
     ContextImplPtr EventContext = Event->getContextImpl();
-    auto Plugin = Event->getPlugin();
+    const detail::plugin &Plugin = Event->getPlugin();
     // If contexts don't match - connect them using user event
     if (EventContext != Context && !Context->is_host()) {
 
@@ -146,10 +146,10 @@ void Command::waitForEvents(QueueImplPtr Queue,
   if (!EventImpls.empty()) {
     std::vector<RT::PiEvent> RawEvents = getPiEvents(EventImpls);
     if (Queue->is_host()) {
-      auto Plugin = EventImpls[0]->getPlugin();
+      const detail::plugin &Plugin = EventImpls[0]->getPlugin();
       Plugin.call<PiApiKind::piEventsWait>(RawEvents.size(), &RawEvents[0]);
     } else {
-      auto Plugin = Queue->getPlugin();
+      const detail::plugin &Plugin = Queue->getPlugin();
       Plugin.call<PiApiKind::piEnqueueEventsWait>(
           Queue->getHandleRef(), RawEvents.size(), &RawEvents[0], &Event);
     }
@@ -848,7 +848,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
       if (!RawEvents.empty()) {
         // Assuming that the events are for devices to the same Plugin.
-        auto Plugin = EventImpls[0]->getPlugin();
+        const detail::plugin &Plugin = EventImpls[0]->getPlugin();
         Plugin.call<PiApiKind::piEventsWait>(RawEvents.size(), &RawEvents[0]);
       }
       DispatchNativeKernel((void *)ArgsBlob.data());
@@ -872,7 +872,7 @@ cl_int ExecCGCommand::enqueueImp() {
       MemLocs.push_back(NextArg);
       NextArg++;
     }
-    auto Plugin = MQueue->getPlugin();
+    const detail::plugin &Plugin = MQueue->getPlugin();
     pi_result Error = Plugin.call_nocheck<PiApiKind::piEnqueueNativeKernel>(
         MQueue->getHandleRef(), DispatchNativeKernel, (void *)ArgsBlob.data(),
         ArgsBlob.size() * sizeof(ArgsBlob[0]), Buffers.size(), Buffers.data(),
@@ -904,7 +904,7 @@ cl_int ExecCGCommand::enqueueImp() {
         }
       if (!RawEvents.empty()) {
         // Assuming that the events are for devices to the same Plugin.
-        auto Plugin = EventImpls[0]->getPlugin();
+        const detail::plugin &Plugin = EventImpls[0]->getPlugin();
         Plugin.call<PiApiKind::piEventsWait>(RawEvents.size(), &RawEvents[0]);
       }
       ExecKernel->MHostKernel->call(NDRDesc,
@@ -914,7 +914,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     // Run OpenCL kernel
     sycl::context Context = MQueue->get_context();
-    auto Plugin = MQueue->getPlugin();
+    const detail::plugin &Plugin = MQueue->getPlugin();
     RT::PiKernel Kernel = nullptr;
 
     if (nullptr != ExecKernel->MSyclKernel) {

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -145,11 +145,9 @@ void Command::waitForEvents(QueueImplPtr Queue,
 
   if (!EventImpls.empty()) {
     if (Queue->is_host()) {
-      for (auto &EventImpl : EventImpls) {
-        auto Plugin = EventImpl->getPlugin();
-        auto EventHandle = EventImpl->getHandleRef();
-        Plugin.call<PiApiKind::piEventsWait>(1, &EventHandle);
-      }
+      std::vector<RT::PiEvent> RawEvents = getPiEvents(EventImpls);
+      auto Plugin = EventImpls[0]->getPlugin();
+      Plugin.call<PiApiKind::piEventsWait>(RawEvents.size(), &RawEvents[0]);
     } else {
       std::vector<RT::PiEvent> RawEvents = getPiEvents(EventImpls);
       auto Plugin = Queue->getPlugin();

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -321,7 +321,10 @@ cl_int ReleaseCommand::enqueueImp() {
                                     ? MAllocaCmd->MLinkedAllocaCmd->getQueue()
                                     : MAllocaCmd->getQueue();
 
-    RT::PiEvent UnmapEvent = nullptr;
+    EventImplPtr UnmapEventImpl(new event_impl(Queue));
+    UnmapEventImpl->setContextImpl(
+        detail::getSyclObjImpl(Queue->get_context()));
+    RT::PiEvent &UnmapEvent = UnmapEventImpl->getHandleRef();
 
     void *Src = CurAllocaIsHost
                     ? MAllocaCmd->getMemAllocation()
@@ -336,8 +339,6 @@ cl_int ReleaseCommand::enqueueImp() {
 
     std::swap(MAllocaCmd->MIsActive, MAllocaCmd->MLinkedAllocaCmd->MIsActive);
     EventImpls.clear();
-    EventImplPtr UnmapEventImpl(
-        new event_impl(UnmapEvent, Queue->get_context()));
     EventImpls.push_back(UnmapEventImpl);
   }
   RT::PiEvent &Event = MEvent->getHandleRef();

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -47,7 +47,7 @@ void Scheduler::GraphProcessor::waitForEvent(EventImplPtr Event) {
 
   RT::PiEvent &CLEvent = Cmd->getEvent()->getHandleRef();
   if (CLEvent) {
-    auto Plugin = Event->getPlugin();
+    const detail::plugin &Plugin = Event->getPlugin();
     Plugin.call<PiApiKind::piEventsWait>(1, &CLEvent);
   }
 }

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -46,8 +46,10 @@ void Scheduler::GraphProcessor::waitForEvent(EventImplPtr Event) {
     throw runtime_error("Enqueue process failed.");
 
   RT::PiEvent &CLEvent = Cmd->getEvent()->getHandleRef();
-  if (CLEvent)
-    PI_CALL(piEventsWait)(1, &CLEvent);
+  if (CLEvent) {
+    auto Plugin = Event->getPlugin();
+    Plugin.call<PiApiKind::piEventsWait>(1, &CLEvent);
+  }
 }
 
 bool Scheduler::GraphProcessor::enqueueCommand(Command *Cmd,

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -31,13 +31,14 @@ SYCLMemObjT::SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
 
   RT::PiMem Mem = pi::cast<RT::PiMem>(MInteropMemObject);
   RT::PiContext Context = nullptr;
-  PI_CALL(piMemGetInfo)(Mem, CL_MEM_CONTEXT, sizeof(Context), &Context,
-                        nullptr);
+  const plugin_impl &Plugin = getPlugin();
+  Plugin.call<PiApiKind::piMemGetInfo>(Mem, CL_MEM_CONTEXT, sizeof(Context),
+                                         &Context, nullptr);
 
   if (MInteropContext->getHandleRef() != Context)
     throw cl::sycl::invalid_parameter_error(
         "Input context must be the same as the context of cl_mem");
-  PI_CALL(piMemRetain)(Mem);
+  Plugin.call<PiApiKind::piMemRetain>(Mem);
 }
 
 void SYCLMemObjT::releaseMem(ContextImplPtr Context, void *MemAllocation) {
@@ -73,8 +74,11 @@ void SYCLMemObjT::updateHostMemory() {
     Scheduler::getInstance().removeMemoryObject(this);
   releaseHostMem(MShadowCopy);
 
-  if (MOpenCLInterop)
-    PI_CALL(piMemRelease)(pi::cast<RT::PiMem>(MInteropMemObject));
+  if (MOpenCLInterop) {
+    const plugin_impl &Plugin = getPlugin();
+    Plugin.call<PiApiKind::piMemRelease>(
+        pi::cast<RT::PiMem>(MInteropMemObject));
+  }
 }
 } // namespace detail
 } // namespace sycl

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -31,7 +31,7 @@ SYCLMemObjT::SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
 
   RT::PiMem Mem = pi::cast<RT::PiMem>(MInteropMemObject);
   RT::PiContext Context = nullptr;
-  const plugin_impl &Plugin = getPlugin();
+  const plugin &Plugin = getPlugin();
   Plugin.call<PiApiKind::piMemGetInfo>(Mem, CL_MEM_CONTEXT, sizeof(Context),
                                          &Context, nullptr);
 
@@ -75,7 +75,7 @@ void SYCLMemObjT::updateHostMemory() {
   releaseHostMem(MShadowCopy);
 
   if (MOpenCLInterop) {
-    const plugin_impl &Plugin = getPlugin();
+    const plugin &Plugin = getPlugin();
     Plugin.call<PiApiKind::piMemRelease>(
         pi::cast<RT::PiMem>(MInteropMemObject));
   }

--- a/sycl/source/detail/usm/usm_dispatch.cpp
+++ b/sycl/source/detail/usm/usm_dispatch.cpp
@@ -7,12 +7,13 @@
 // ===--------------------------------------------------------------------=== //
 
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/plugin_impl.hpp>
 #include <CL/sycl/detail/usm_dispatch.hpp>
 
 __SYCL_INLINE namespace cl {
-namespace sycl {
-namespace detail {
-namespace usm {
+  namespace sycl {
+  namespace detail {
+  namespace usm {
 
 /***
 
@@ -297,11 +298,12 @@ pi_result USMDispatcher::enqueueMigrateMem(pi_queue Queue, const void *Ptr,
     if (mEmulated) {
       // We could check for OpenCL 2.1 and call the SVM migrate
       // functions, but for now we'll just enqueue a marker.
+      // TODO: Implement a PI call for this openCL API
       RetVal = pi::cast<pi_result>(clEnqueueMarkerWithWaitList(
           CLQueue, NumEventsInWaitList,
           reinterpret_cast<const cl_event *>(EventWaitList),
           reinterpret_cast<cl_event *>(Event)));
-      pi::checkPiResult(RetVal);
+      RT::GlobalPlugin->checkPiResult(RetVal);
     } else {
       RetVal = pi::cast<pi_result>(pfn_clEnqueueMigrateMemINTEL(
           CLQueue, Ptr, Size, Flags, NumEventsInWaitList,
@@ -349,19 +351,21 @@ void USMDispatcher::memAdvise(pi_queue Queue, const void *Ptr, size_t Length,
     if (mEmulated) {
       // memAdvise does nothing here
       // TODO: Implement a PI call for this openCL API
-      RT::checkPiResult(RT::cast<RT::PiResult>(clEnqueueMarkerWithWaitList(
-          CLQueue, 0, nullptr, reinterpret_cast<cl_event *>(Event))));
+      RT::GlobalPlugin->checkPiResult(
+          RT::cast<RT::PiResult>(clEnqueueMarkerWithWaitList(
+              CLQueue, 0, nullptr, reinterpret_cast<cl_event *>(Event))));
     } else {
       // Temporary until driver supports
       // memAdvise doesn't do anything on an iGPU anyway
       // TODO: Implement a PI call for this openCL API
-      RT::checkPiResult(RT::cast<RT::PiResult>(clEnqueueMarkerWithWaitList(
-          CLQueue, 0, nullptr, reinterpret_cast<cl_event *>(Event))));
+      RT::GlobalPlugin->checkPiResult(
+          RT::cast<RT::PiResult>(clEnqueueMarkerWithWaitList(
+              CLQueue, 0, nullptr, reinterpret_cast<cl_event *>(Event))));
       /*
       // Enable once this is supported in the driver
       auto CLAdvice = *reinterpret_cast<cl_mem_advice_intel *>(&Advice);
       // TODO: Implement a PI call for this openCL API
-      RT::checkPiResult(RT::cast<RT::PiResult>(pfn_clEnqueueMemAdviseINTEL(
+      RT::GlobalPlugin->checkPiResult(RT::cast<RT::PiResult>(pfn_clEnqueueMemAdviseINTEL(
           CLQueue, Ptr, Length, CLAdvice, 0, nullptr,
           reinterpret_cast<cl_event *>(Event))));
       */
@@ -372,19 +376,20 @@ void USMDispatcher::memAdvise(pi_queue Queue, const void *Ptr, size_t Length,
 pi_result USMDispatcher::enqueuePrefetch(pi_queue Queue, void *Ptr, size_t Size,
                                          pi_uint32 NumEventsInWaitList,
                                          const pi_event *EventWaitList,
-                                         pi_event *Event) {
+                                         pi_event *Event,
+                                         const plugin_impl &Plugin) {
   pi_result RetVal = PI_INVALID_OPERATION;
 
   if (pi::useBackend(pi::Backend::SYCL_BE_PI_OPENCL)) {
     if (mEmulated) {
       // Prefetch is a hint, so ignoring it is always safe.
-      RetVal = PI_CALL_NOCHECK(piEnqueueEventsWait)(Queue, NumEventsInWaitList,
-                                                    EventWaitList, Event);
+      RetVal = Plugin.call_nocheck<PiApiKind::piEnqueueEventsWait>(
+          Queue, NumEventsInWaitList, EventWaitList, Event);
     } else {
       // TODO: Replace this with real prefetch support when the driver enables
       // it.
-      RetVal = PI_CALL_NOCHECK(piEnqueueEventsWait)(Queue, NumEventsInWaitList,
-                                                    EventWaitList, Event);
+      RetVal = Plugin.call_nocheck<PiApiKind::piEnqueueEventsWait>(
+          Queue, NumEventsInWaitList, EventWaitList, Event);
     }
   }
 

--- a/sycl/source/detail/usm/usm_dispatch.cpp
+++ b/sycl/source/detail/usm/usm_dispatch.cpp
@@ -7,7 +7,7 @@
 // ===--------------------------------------------------------------------=== //
 
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/detail/usm_dispatch.hpp>
 
 __SYCL_INLINE namespace cl {
@@ -377,7 +377,7 @@ pi_result USMDispatcher::enqueuePrefetch(pi_queue Queue, void *Ptr, size_t Size,
                                          pi_uint32 NumEventsInWaitList,
                                          const pi_event *EventWaitList,
                                          pi_event *Event,
-                                         const plugin_impl &Plugin) {
+                                         const plugin &Plugin) {
   pi_result RetVal = PI_INVALID_OPERATION;
 
   if (pi::useBackend(pi::Backend::SYCL_BE_PI_OPENCL)) {

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -43,12 +43,13 @@ void *alignedAllocHost(size_t Alignment, size_t Size, const context &Ctxt,
   } else {
     std::shared_ptr<context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
     pi_context C = CtxImpl->getHandleRef();
+    auto Plugin = CtxImpl->getPlugin();
     pi_result Error;
 
     switch (Kind) {
     case alloc::host: {
-      Error = PI_CALL_NOCHECK(piextUSMHostAlloc)(&RetVal, C, nullptr, Size,
-                                                 Alignment);
+      Error = Plugin.call_nocheck<PiApiKind::piextUSMHostAlloc>(
+          &RetVal, C, nullptr, Size, Alignment);
       break;
     }
     case alloc::device:
@@ -91,20 +92,21 @@ void *alignedAlloc(size_t Alignment, size_t Size, const context &Ctxt,
   } else {
     std::shared_ptr<context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
     pi_context C = CtxImpl->getHandleRef();
+    auto Plugin = CtxImpl->getPlugin();
     pi_result Error;
     pi_device Id;
 
     switch (Kind) {
     case alloc::device: {
       Id = detail::getSyclObjImpl(Dev)->getHandleRef();
-      Error = PI_CALL_NOCHECK(piextUSMDeviceAlloc)(&RetVal, C, Id, nullptr,
-                                                   Size, Alignment);
+      Error = Plugin.call_nocheck<PiApiKind::piextUSMDeviceAlloc>(
+          &RetVal, C, Id, nullptr, Size, Alignment);
       break;
     }
     case alloc::shared: {
       Id = detail::getSyclObjImpl(Dev)->getHandleRef();
-      Error = PI_CALL_NOCHECK(piextUSMSharedAlloc)(&RetVal, C, Id, nullptr,
-                                                   Size, Alignment);
+      Error = Plugin.call_nocheck<PiApiKind::piextUSMSharedAlloc>(
+          &RetVal, C, Id, nullptr, Size, Alignment);
       break;
     }
     case alloc::host:
@@ -130,7 +132,8 @@ void free(void *Ptr, const context &Ctxt) {
   } else {
     std::shared_ptr<context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
     pi_context C = CtxImpl->getHandleRef();
-    PI_CALL(piextUSMFree)(C, Ptr);
+    auto Plugin = CtxImpl->getPlugin();
+    Plugin.call<PiApiKind::piextUSMFree>(C, Ptr);
   }
 }
 

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -250,8 +250,9 @@ alloc get_pointer_type(const void *Ptr, const context &Ctxt) {
   pi_usm_type AllocTy;
 
   // query type using PI function
-  PI_CALL(piextUSMGetMemAllocInfo)(PICtx, Ptr, PI_MEM_ALLOC_TYPE,
-                                   sizeof(pi_usm_type), &AllocTy, nullptr);
+  const detail::plugin &Plugin = CtxImpl->getPlugin();
+  Plugin.call<detail::PiApiKind::piextUSMGetMemAllocInfo>(
+      PICtx, Ptr, PI_MEM_ALLOC_TYPE, sizeof(pi_usm_type), &AllocTy, nullptr);
 
   alloc ResultAlloc;
   switch (AllocTy) {
@@ -297,8 +298,9 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
   pi_device DeviceId;
 
   // query device using PI function
-  PI_CALL(piextUSMGetMemAllocInfo)(PICtx, Ptr, PI_MEM_ALLOC_DEVICE,
-                                   sizeof(pi_device), &DeviceId, nullptr);
+  const detail::plugin &Plugin = CtxImpl->getPlugin();
+  Plugin.call<detail::PiApiKind::piextUSMGetMemAllocInfo>(
+      PICtx, Ptr, PI_MEM_ALLOC_DEVICE, sizeof(pi_device), &DeviceId, nullptr);
 
   for (const device &Dev : CtxImpl->getDevices()) {
     // Try to find the real sycl device used in the context

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -43,7 +43,7 @@ void *alignedAllocHost(size_t Alignment, size_t Size, const context &Ctxt,
   } else {
     std::shared_ptr<context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
     pi_context C = CtxImpl->getHandleRef();
-    auto Plugin = CtxImpl->getPlugin();
+    const detail::plugin &Plugin = CtxImpl->getPlugin();
     pi_result Error;
 
     switch (Kind) {
@@ -92,7 +92,7 @@ void *alignedAlloc(size_t Alignment, size_t Size, const context &Ctxt,
   } else {
     std::shared_ptr<context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
     pi_context C = CtxImpl->getHandleRef();
-    auto Plugin = CtxImpl->getPlugin();
+    const detail::plugin &Plugin = CtxImpl->getPlugin();
     pi_result Error;
     pi_device Id;
 
@@ -132,7 +132,7 @@ void free(void *Ptr, const context &Ctxt) {
   } else {
     std::shared_ptr<context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
     pi_context C = CtxImpl->getHandleRef();
-    auto Plugin = CtxImpl->getPlugin();
+    const detail::plugin &Plugin = CtxImpl->getPlugin();
     Plugin.call<PiApiKind::piextUSMFree>(C, Ptr);
   }
 }

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -28,7 +28,8 @@ device::device() : impl(std::make_shared<detail::device_impl>()) {}
 
 device::device(cl_device_id deviceId)
     : impl(std::make_shared<detail::device_impl>(
-          detail::pi::cast<detail::RT::PiDevice>(deviceId))) {}
+          detail::pi::cast<detail::RT::PiDevice>(deviceId),
+          *RT::GlobalPlugin)) {}
 
 device::device(const device_selector &deviceSelector) {
   *this = deviceSelector.select_device();

--- a/sycl/source/function_pointer.cpp
+++ b/sycl/source/function_pointer.cpp
@@ -18,7 +18,7 @@ getDeviceFunctionPointerImpl(device &D, program &P, const char *FuncName) {
   intel::device_func_ptr_holder_t FPtr = 0;
   // FIXME: return value must be checked here, but since we cannot yet check
   // if corresponding extension is supported, let's silently ignore it here.
-  auto Plugin = detail::getSyclObjImpl(P)->getPlugin();
+  const detail::plugin &Plugin = detail::getSyclObjImpl(P)->getPlugin();
   Plugin.call<cl::sycl::detail::PiApiKind::piextGetDeviceFunctionPointer>(
       detail::pi::cast<pi_device>(detail::getSyclObjImpl(D)->getHandleRef()),
       detail::pi::cast<pi_program>(detail::getSyclObjImpl(P)->getHandleRef()),

--- a/sycl/source/function_pointer.cpp
+++ b/sycl/source/function_pointer.cpp
@@ -18,7 +18,8 @@ getDeviceFunctionPointerImpl(device &D, program &P, const char *FuncName) {
   intel::device_func_ptr_holder_t FPtr = 0;
   // FIXME: return value must be checked here, but since we cannot yet check
   // if corresponding extension is supported, let's silently ignore it here.
-  PI_CALL(piextGetDeviceFunctionPointer)(
+  auto Plugin = detail::getSyclObjImpl(P)->getPlugin();
+  Plugin.call<cl::sycl::detail::PiApiKind::piextGetDeviceFunctionPointer>(
       detail::pi::cast<pi_device>(detail::getSyclObjImpl(D)->getHandleRef()),
       detail::pi::cast<pi_program>(detail::getSyclObjImpl(P)->getHandleRef()),
       FuncName, &FPtr);

--- a/sycl/source/ordered_queue.cpp
+++ b/sycl/source/ordered_queue.cpp
@@ -50,7 +50,7 @@ ordered_queue::ordered_queue(cl_command_queue clQueue,
                              const async_handler &asyncHandler) {
   cl_command_queue_properties reportedProps;
   RT::PiQueue m_CommandQueue = detail::pi::cast<detail::RT::PiQueue>(clQueue);
-  auto Plugin = detail::getSyclObjImpl(syclContext)->getPlugin();
+  const detail::plugin &Plugin = detail::getSyclObjImpl(syclContext)->getPlugin();
   Plugin.call<detail::PiApiKind::piQueueGetInfo>(
       m_CommandQueue, PI_QUEUE_INFO_DEVICE, sizeof(reportedProps),
       &reportedProps, nullptr);

--- a/sycl/source/ordered_queue.cpp
+++ b/sycl/source/ordered_queue.cpp
@@ -50,9 +50,10 @@ ordered_queue::ordered_queue(cl_command_queue clQueue,
                              const async_handler &asyncHandler) {
   cl_command_queue_properties reportedProps;
   RT::PiQueue m_CommandQueue = detail::pi::cast<detail::RT::PiQueue>(clQueue);
-  PI_CALL(piQueueGetInfo)
-  (m_CommandQueue, PI_QUEUE_INFO_DEVICE, sizeof(reportedProps), &reportedProps,
-   nullptr);
+  auto Plugin = detail::getSyclObjImpl(syclContext)->getPlugin();
+  Plugin.call<detail::PiApiKind::piQueueGetInfo>(
+      m_CommandQueue, PI_QUEUE_INFO_DEVICE, sizeof(reportedProps),
+      &reportedProps, nullptr);
   if (reportedProps & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)
     throw runtime_error(
         "Failed to build a sycl ordered queue from a cl OOO queue.");

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -20,7 +20,8 @@ platform::platform() : impl(std::make_shared<detail::platform_impl>()) {}
 
 platform::platform(cl_platform_id PlatformId)
     : impl(std::make_shared<detail::platform_impl>(
-          detail::pi::cast<detail::RT::PiPlatform>(PlatformId))) {}
+          detail::pi::cast<detail::RT::PiPlatform>(PlatformId),
+          RT::GlobalPlugin)) {}
 
 platform::platform(const device_selector &dev_selector) {
   *this = dev_selector.select_device().get_platform();

--- a/sycl/unittests/pi/PlatformTest.cpp
+++ b/sycl/unittests/pi/PlatformTest.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/plugin_impl.hpp>
+#include <CL/sycl/detail/plugin.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -18,7 +18,7 @@ using namespace cl::sycl;
 class PlatformTest : public ::testing::Test {
 protected:
   std::vector<pi_platform> _platforms;
-  std::vector<detail::plugin_impl> Plugins;
+  std::vector<detail::plugin> Plugins;
   PlatformTest() : _platforms{} { Plugins = detail::pi::initialize(); };
 
   ~PlatformTest() override = default;

--- a/sycl/unittests/pi/PlatformTest.cpp
+++ b/sycl/unittests/pi/PlatformTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/plugin_impl.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -17,8 +18,8 @@ using namespace cl::sycl;
 class PlatformTest : public ::testing::Test {
 protected:
   std::vector<pi_platform> _platforms;
-
-  PlatformTest() : _platforms{} { detail::pi::initialize(); };
+  std::vector<detail::plugin_impl> Plugins;
+  PlatformTest() : _platforms{} { Plugins = detail::pi::initialize(); };
 
   ~PlatformTest() override = default;
 
@@ -32,7 +33,10 @@ protected:
     // Initialize the logged number of platforms before the following assertion.
     RecordProperty(platform_count_key, platform_count);
 
-    ASSERT_EQ((PI_CALL_NOCHECK(piPlatformsGet)(0, nullptr, &platform_count)),
+    // TODO: Change the test to check this for all plugins present.
+    // Currently, it is only checking for the first plugin attached.
+    ASSERT_EQ((Plugins[0].call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  0, nullptr, &platform_count)),
               PI_SUCCESS);
 
     // Overwrite previous log value with queried number of platforms.
@@ -49,8 +53,8 @@ protected:
 
     _platforms.resize(platform_count, nullptr);
 
-    ASSERT_EQ((PI_CALL_NOCHECK(piPlatformsGet)(_platforms.size(),
-                                               _platforms.data(), nullptr)),
+    ASSERT_EQ((Plugins[0].call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  _platforms.size(), _platforms.data(), nullptr)),
               PI_SUCCESS);
   }
 };
@@ -61,17 +65,17 @@ TEST_F(PlatformTest, piPlatformsGet) {
 }
 
 TEST_F(PlatformTest, piPlatformGetInfo) {
-  auto get_info_test = [](pi_platform platform, _pi_platform_info info) {
+  auto get_info_test = [&](pi_platform platform, _pi_platform_info info) {
     size_t reported_string_length = 0;
-    EXPECT_EQ((PI_CALL_NOCHECK(piPlatformGetInfo)(platform, info, 0u, nullptr,
-                                                  &reported_string_length)),
+    EXPECT_EQ((Plugins[0].call_nocheck<detail::PiApiKind::piPlatformGetInfo>(
+                  platform, info, 0u, nullptr, &reported_string_length)),
               PI_SUCCESS);
 
     // Create a larger result string to catch overwrites.
     std::vector<char> param_value(reported_string_length * 2u, '\0');
     EXPECT_EQ(
-        (PI_CALL_NOCHECK(piPlatformGetInfo)(platform, info, param_value.size(),
-                                            param_value.data(), nullptr)),
+        (Plugins[0].call_nocheck<detail::PiApiKind::piPlatformGetInfo>(
+            platform, info, param_value.size(), param_value.data(), nullptr)),
         PI_SUCCESS)
         << "piPlatformGetInfo for " << RT::platformInfoToString(info)
         << " failed.\n";


### PR DESCRIPTION
 The changeset removes the family of PI_CALL macros, and replaces them with
 call API in a new plugin_impl class. The object of this class is stored in
 Platform class. When multiple platforms are associated with the same Plugin,
 they will have shared_ptr to the same plugin_impl object. Eg: An OpenCLPlugin
 can have multiple platforms attached to it.

 To effectively use this change, following additional fetaures/changes
 were added:

 - To make access to the plugin_impl class easy, getPlugin() API has been
   introduced to some *_impl classes, that eventually call the
   platform_impl->getPlugin() API. It has been included in context_impl,
   event_impl, kernel_impl, platform_impl, program_impl, queue_impl. Is not
   present in accessor_impl(Does not call PI), buffer_impl (Needs only in the
   constructor where context is passed), sampler_impl (Does not have a single
   context), stream_impl (Does not call PI), usm_impl (Has no member sycl_impl
   objects.) The API returns const reference to plugin_impl class.
 - Use of PiApiKind enum to uniquely identify the PI API.
 - PI API calls are done using : plugin_impl.call, plugin_impl.call_nocheck,
   plugin_impl.checkPiResult<Exception>
 - GlobalPlugin is a SharedPtr to a globally available Plugin for the use with
   Interoperability Constructors. It is used as a shared_ptr to avoid making
   copies of it.
 - Changes in *_info structs and get() methods. They now take a const
   plugin_impl& argument.
 - To make Pi Api calls by host to check if certain events are finished on a
   device, the plugin_impl class is needed. At such places, event_impl is passed
   instead of a PiEvent. Eg: memory_manager.cpp
 - The use of Global variable has been restricted to only the GlobalPlugin now.

Signed-off-by: Garima Gupta <garima.gupta@intel.com>

NOTE TO REVIEWERS:
- Only platform_impl has ownership of the Plugin_impl object. Others only call the getPlugin() method on the platform_impl object.
- RT::initialize() is called only once in getPlatforms() now. It recognizes all platforms associated with all attached plugins.
- GlobalPlugin is a SharedPtr because if a global variable is kept, we will have to pass it by value or a pointer, thus making a shared_ptr takes care of managing the copies. This is the only global we have now for PI.
- *_info structs and get methods: They now take a const Plugin_impl& argument. The methods were not changed to take *_impl objects because the structs::get methods seem to be utility functions to get information given a Pi* Object. Eg: get_kernel_info<info::kernel::program>::get(PiKernel) method. To make these methods take *impl objects, some places may require creating a new *_impl object which would be incorrect.
- memory_manager.cpp changes: Need to get the plugin information from individual events, since a host Context may wait on events of other devices; To enable this, event_impls are passed where a PI_CALL is needed.
- Note that the plugin_information is only passed as const reference to any function if a sycl *_impl is not already available.
- Test case that exists: llvm/sycl/unittests/pi/PlatformTest.cpp.
- Please pay attention to any wrong extraction of plugin_information. Eg: A PI_CALL on event can be called on a host_context. I may have missed similar things at other places. Please point them out if you see any issue.

This patch does not take care of the following.
- The code currently cannot connect to multiple plugins/or recognize and choose one among many. It will be enabled in the next few patches.
- Next set of patches :
	*To add the config file mechanism to find attached Plugins, as has been mentioned in intel/llvm#680
	*To add better tracing and debugging.
	*Format the code in Doxygen friendly-way and move the implementation into cpp files if possible.