### PR TITLE
[SYCL] Refactor sub-group built-ins implementation

### DIFF
--- a/sycl/include/CL/sycl/detail/type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/type_traits.hpp
@@ -157,6 +157,10 @@ template <typename T, int N, template <typename> class S>
 using is_gen_based_on_type_sizeof =
     bool_constant<S<T>::value && (sizeof(vector_element_t<T>) == N)>;
 
+template <typename> struct is_vec : std::false_type {};
+template <typename T, std::size_t N>
+struct is_vec<cl::sycl::vec<T, N>> : std::true_type {};
+
 // is_integral
 template <typename T>
 struct is_integral : std::is_integral<vector_element_t<T>> {};


### PR DESCRIPTION
Main motivation and idea of this change is to use existing utility
functions for mapping from SYCL types to corresponding SPIR-V types,
which will automatically allows to use wide range of types in sub-group
built-ins (like `char` or `bool`)

List of changes:
- used existing `ConvertToOpenCLType_t` to map SYCL types to OpenCL
  types
- added bunch of helper functions to reduce the code
- refactored bunch of `enable_if`s to use the same style (on return
  value)