### PR TITLE
[SYCL][FPGA] Implementing __builtin_intel_fpga_mem()

### DIFF
--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -1569,6 +1569,7 @@ BUILTIN(__builtin_ms_va_copy, "vc*&c*&", "n")
 
 // Builtins for Intel FPGA
 BUILTIN(__builtin_intel_fpga_reg, "v.", "nt")
+BUILTIN(__builtin_intel_fpga_mem, "v.", "nt")
 
 #undef BUILTIN
 #undef LIBBUILTIN

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -143,6 +143,15 @@ def err_bankbits_numbanks_conflicting : Error<
   "the number of bank_bits must be equal to ceil(log2(numbanks))">;
 def err_bankbits_non_consecutive : Error<
   "bank_bits must be consecutive">;
+def err_intel_fpga_mem_limitations
+    : Error<
+          "illegal %select{pointer argument of type %1 |field in type pointed "
+          "to by pointer argument}0 to __builtin_intel_fpga_mem. Only pointers "
+          "to a first class lvalue or to an rvalue are allowed">;
+def err_intel_fpga_mem_arg_mismatch
+    : Error<"builtin parameter must be %select{"
+            "a pointer"
+            "|a non-negative integer constant}0">;
 
 // C99 variable-length arrays
 def ext_vla : Extension<"variable length arrays are a C99 feature">,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11701,7 +11701,8 @@ private:
   bool CheckX86BuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall);
   bool CheckPPCBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall);
 
-  bool CheckIntelFPGABuiltinFunctionCall(unsigned BuiltinID, CallExpr *Call);
+  bool CheckIntelFPGARegBuiltinFunctionCall(unsigned BuiltinID, CallExpr *Call);
+  bool CheckIntelFPGAMemBuiltinFunctionCall(CallExpr *Call);
 
   bool SemaBuiltinVAStart(unsigned BuiltinID, CallExpr *TheCall);
   bool SemaBuiltinVAStartARMMicrosoft(CallExpr *Call);

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3790,7 +3790,9 @@ public:
                                           const CallExpr *E);
   llvm::Value *EmitHexagonBuiltinExpr(unsigned BuiltinID, const CallExpr *E);
 
-  RValue EmitIntelFPGARegBuiltin(const CallExpr *E, ReturnValueSlot ReturnValue);
+  RValue EmitIntelFPGARegBuiltin(const CallExpr *E,
+                                 ReturnValueSlot ReturnValue);
+  RValue EmitIntelFPGAMemBuiltin(const CallExpr *E);
 
 private:
   enum class MSVCIntrin;

--- a/clang/test/CodeGenSYCL/intel-fpga-mem-builtin.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-mem-builtin.cpp
@@ -1,0 +1,86 @@
+// RUN: %clang_cc1 -triple spir64-unknown-linux-sycldevice -std=c++11 -fsycl-is-device -disable-llvm-passes -S -emit-llvm -x c++ %s -o - | FileCheck %s
+
+#define PARAM_1 1U << 7
+#define PARAM_2 1U << 8
+
+// CHECK: [[STRUCT:%.*]] = type { i32, float }
+struct State {
+  int x;
+  float y;
+};
+
+// CHECK: [[ANN1:@.str[\.]*[0-9]*]] = {{.*}}{params:384}{cache-size:0}
+// CHECK: [[ANN2:@.str[\.]*[0-9]*]] = {{.*}}{params:384}{cache-size:127}
+
+// CHECK: define spir_func void @{{.*}}(float addrspace(4)* %A, i32 addrspace(4)* %B, [[STRUCT]] addrspace(4)* %C, [[STRUCT]] addrspace(4)*{{.*}}%D)
+void foo(float *A, int *B, State *C, State &D) {
+  float *x;
+  int *y;
+  State *z;
+  double F = 0.0;
+  double *f;
+
+  // CHECK-DAG: [[Aaddr:%.*]] = alloca float addrspace(4)*
+  // CHECK-DAG: [[Baddr:%.*]] = alloca i32 addrspace(4)*
+  // CHECK-DAG: [[Caddr:%.*]] = alloca [[STRUCT]] addrspace(4)*
+  // CHECK-DAG: [[Daddr:%.*]] = alloca [[STRUCT]] addrspace(4)*
+  // CHECK-DAG: [[F:%.*]] = alloca double
+  // CHECK-DAG: [[f:%.*]] = alloca double addrspace(4)*
+
+  // CHECK-DAG: [[A:%[0-9]+]] = load float addrspace(4)*, float addrspace(4)** [[Aaddr]]
+  // CHECK-DAG: [[PTR1:%[0-9]+]] = call float addrspace(4)* @llvm.ptr.annotation{{.*}}[[A]]{{.*}}[[ANN1]]{{.*}}[[ATT:#[0-9]+]]
+  // CHECK-DAG: store float addrspace(4)* [[PTR1]], float addrspace(4)** %x
+  x = __builtin_intel_fpga_mem(A, PARAM_1 | PARAM_2, 0);
+
+  // CHECK-DAG: [[B:%[0-9]+]] = load i32 addrspace(4)*, i32 addrspace(4)** [[Baddr]]
+  // CHECK-DAG: [[PTR2:%[0-9]+]] = call i32 addrspace(4)* @llvm.ptr.annotation{{.*}}[[B]]{{.*}}[[ANN1]]{{.*}}[[ATT:#[0-9]+]]
+  // CHECK-DAG: store i32 addrspace(4)* [[PTR2]], i32 addrspace(4)** %y
+  y = __builtin_intel_fpga_mem(B, PARAM_1 | PARAM_2, 0);
+
+  // CHECK-DAG: [[C:%[0-9]+]] = load [[STRUCT]] addrspace(4)*, [[STRUCT]] addrspace(4)** [[Caddr]]
+  // CHECK-DAG: [[PTR3:%[0-9]+]] = call [[STRUCT]] addrspace(4)* @llvm.ptr.annotation{{.*}}[[C]]{{.*}}[[ANN1]]{{.*}}[[ATT:#[0-9]+]]
+  // CHECK-DAG: store [[STRUCT]] addrspace(4)* [[PTR3]], [[STRUCT]] addrspace(4)** %z
+  z = __builtin_intel_fpga_mem(C, PARAM_1 | PARAM_2, 0);
+
+  // CHECK-DAG: [[A2:%[0-9]+]] = load float addrspace(4)*, float addrspace(4)** [[Aaddr]]
+  // CHECK-DAG: [[PTR4:%[0-9]+]] = call float addrspace(4)* @llvm.ptr.annotation{{.*}}[[A2]]{{.*}}[[ANN2]]{{.*}}[[ATT:#[0-9]+]]
+  // CHECK-DAG: store float addrspace(4)* [[PTR4]], float addrspace(4)** %x
+  x = __builtin_intel_fpga_mem(A, PARAM_1 | PARAM_2, 127);
+
+  // CHECK-DAG: [[B2:%[0-9]+]] = load i32 addrspace(4)*, i32 addrspace(4)** [[Baddr]]
+  // CHECK-DAG: [[PTR5:%[0-9]+]] = call i32 addrspace(4)* @llvm.ptr.annotation{{.*}}[[B2]]{{.*}}[[ANN2]]{{.*}}[[ATT:#[0-9]+]]
+  // CHECK-DAG: store i32 addrspace(4)* [[PTR5]], i32 addrspace(4)** %y
+  y = __builtin_intel_fpga_mem(B, PARAM_1 | PARAM_2, 127);
+
+  // CHECK-DAG: [[C2:%[0-9]+]] = load [[STRUCT]] addrspace(4)*, [[STRUCT]] addrspace(4)** [[Caddr]]
+  // CHECK-DAG: [[PTR6:%[0-9]+]] = call [[STRUCT]] addrspace(4)* @llvm.ptr.annotation{{.*}}[[C2]]{{.*}}[[ANN2]]{{.*}}[[ATT:#[0-9]+]]
+  // CHECK-DAG: store [[STRUCT]] addrspace(4)* [[PTR6]], [[STRUCT]] addrspace(4)** %z
+  z = __builtin_intel_fpga_mem(C, PARAM_1 | PARAM_2, 127);
+
+  // CHECK-DAG: [[D:%[0-9]+]] = load [[STRUCT]] addrspace(4)*, [[STRUCT]] addrspace(4)** [[Daddr]]
+  // CHECK-DAG: [[PTR7:%[0-9]+]] = call [[STRUCT]] addrspace(4)* @llvm.ptr.annotation{{.*}}[[D]]{{.*}}[[ANN2]]{{.*}}[[ATT:#[0-9]+]]
+  // CHECK-DAG: store [[STRUCT]] addrspace(4)* [[PTR7]], [[STRUCT]] addrspace(4)** %z
+  z = __builtin_intel_fpga_mem(&D, PARAM_1 | PARAM_2, 127);
+
+  // CHECK-DAG: [[PTR8:%[0-9]+]] = call double* @llvm.ptr.annotation{{.*}}[[F]]{{.*}}[[ANN2]]{{.*}}[[ATT:#[0-9]+]]
+  // CHECK-DAG: [[ASCAST:%[0-9]+]] = addrspacecast double* [[PTR8]] to double addrspace(4)*
+  // CHECK-DAG: store double addrspace(4)* [[ASCAST]], double addrspace(4)** [[f]]
+  f = __builtin_intel_fpga_mem(&F, PARAM_1 | PARAM_2, 127);
+}
+
+// CHECK-DAG: attributes [[ATT]] = { readnone }
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class fake_kernel>([]() {
+    float *A;
+    int *B;
+    State *C;
+    State D;
+    foo(A, B, C, D); });
+  return 0;
+}

--- a/clang/test/SemaSYCL/intel-fpga-mem-builtin.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-mem-builtin.cpp
@@ -1,0 +1,82 @@
+// RUN: %clang_cc1 -fsycl-is-device -verify -pedantic -fsyntax-only -x c++ %s
+// RUN: %clang_cc1 -verify -pedantic -fsyntax-only -x c++ %s
+
+#define PARAM_1 1U << 7
+#define PARAM_2 1U << 8
+
+#ifdef __SYCL_DEVICE_ONLY__
+static_assert(__has_builtin(__builtin_intel_fpga_mem), "");
+struct State {
+  int x;
+  float y;
+};
+
+struct inner {
+  void (*fp)(); // expected-note {{Field with illegal type declared here}}
+};
+
+struct outer {
+  inner A;
+};
+
+void foo(float *A, int *B, State *C) {
+  float *x;
+  int *y;
+  State *z;
+  int i = 0;
+  void *U;
+
+  x = __builtin_intel_fpga_mem(A, PARAM_1 | PARAM_2, -1);
+  // expected-error@-1{{builtin parameter must be a non-negative integer constant}}
+  x = __builtin_intel_fpga_mem(A, PARAM_1 | PARAM_2);
+  // expected-error@-1{{too few arguments to function call, expected 3, have 2}}
+  x = __builtin_intel_fpga_mem(A, PARAM_1 | PARAM_2, 1, 1);
+  // expected-error@-1{{too many arguments to function call, expected 3, have 4}}
+  y = __builtin_intel_fpga_mem(B, 0, i);
+  // expected-error@-1{{argument to '__builtin_intel_fpga_mem' must be a constant integer}}
+  z = __builtin_intel_fpga_mem(C, i, 0);
+  // expected-error@-1{{argument to '__builtin_intel_fpga_mem' must be a constant integer}}
+  z = __builtin_intel_fpga_mem(U, 0, 0);
+  // expected-error@-1{{illegal pointer argument of type 'void *'  to __builtin_intel_fpga_mem. Only pointers to a first class lvalue or to an rvalue are allowed}}
+
+  int intArr[10] = {0};
+  int *k1 = __builtin_intel_fpga_mem(intArr, 0, 0);
+  // expected-error@-1{{builtin parameter must be a pointer}}
+
+  int **k2 = __builtin_intel_fpga_mem(&intArr, 0, 0);
+  // expected-error@-1{{illegal pointer argument of type 'int (*)[10]'  to __builtin_intel_fpga_mem. Only pointers to a first class lvalue or to an rvalue are allowed}}
+
+  void (*fp1)();
+  void (*fp2)() = __builtin_intel_fpga_mem(fp1, 0, 0);
+  // expected-error@-1{{illegal pointer argument of type 'void (*)()'  to __builtin_intel_fpga_mem. Only pointers to a first class lvalue or to an rvalue are allowed}}
+
+  struct outer *iii;
+  struct outer *iv = __builtin_intel_fpga_mem(iii, 0, 0);
+  // expected-error@-1{{illegal field in type pointed to by pointer argument to __builtin_intel_fpga_mem. Only pointers to a first class lvalue or to an rvalue are allowed}}
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+int main() {
+  kernel_single_task<class fake_kernel>([]() {
+      float *A;
+      int *B;
+      State *C;
+      foo(A, B, C); });
+  return 0;
+}
+
+#else
+void bar(float *A) {
+  float *x = __builtin_intel_fpga_mem(A, PARAM_1 | PARAM_2, 127);
+  // expected-error@-1{{'__builtin_intel_fpga_mem' is only available in SYCL device}}
+}
+
+int main() {
+  float *A;
+  bar(A);
+  return 0;
+}
+#endif


### PR DESCRIPTION
This patch creates and implements the __builtin_intel_fpga_mem builtin for
FPGA SYCL device. The builtin is used to indicate the characteristics of
the load-store unit (LSU) to be used when de-referencing the pointer.

The builtin accepts 3 arguments:
1. A pointer to a first class lvalue or to an rvalue.
2. A integer bitmask that encodes various LSU parameters. These will be
   added for each language in separate libraries.
3. An integer value indicating the size of the LSU cache.

The effect of this is observable only through the FPGA hardware
generated. It lowers to an assignment in all other contexts.

Implementation strategy: In CodeGen, we generate a pointer annotation:
T* llvm.ptr.annotation.*(T*, "{params:..}{cachesize:..}", ...)

Signed-off-by: Mohammad Fawaz <mohammad.fawaz@intel.com>