### PR TITLE
WIP: [SYCL] Defer diagnostics about __float128 type usage

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12083,6 +12083,30 @@ public:
     ConstructorDestructor,
     BuiltinFunction
   };
+
+  /// Creates a DeviceDiagBuilder that emits the diagnostic if the current
+  /// context is "used as device code".
+  ///
+  /// - If CurLexicalContext is a kernel function or it is known that the
+  ///   function will be emitted for the device, emits the diagnostics
+  ///   immediately.
+  /// - If CurLexicalContext is a function and we are compiling
+  ///   for the device, but we don't know that this function will be codegen'ed
+  ///   for devive yet, creates a diagnostic which is emitted if and when we
+  ///   realize that the function will be codegen'ed.
+  ///
+  /// Example usage:
+  ///
+  /// Variables with thread storage duration are not allowed to be used in SYCL
+  /// device code
+  /// if (getLangOpts().SYCLIsDevice)
+  ///   SYCLDiagIfDeviceCode(Loc, diag::err_thread_unsupported);
+  DeviceDiagBuilder SYCLDiagIfDeviceCode(SourceLocation Loc, unsigned DiagID);
+
+  /// Checks if Callee function is a device function and emits
+  /// diagnostics if it is known that it is a device function, adds this
+  /// function to the DeviceCallGraph otherwise.
+  void checkSYCLDeviceFunction(SourceLocation Loc, FunctionDecl *Callee);
 };
 
 /// RAII object that enters a new expression evaluation context.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12092,15 +12092,16 @@ public:
   ///   immediately.
   /// - If CurLexicalContext is a function and we are compiling
   ///   for the device, but we don't know that this function will be codegen'ed
-  ///   for devive yet, creates a diagnostic which is emitted if and when we
+  ///   for device yet, creates a diagnostic which is emitted if and when we
   ///   realize that the function will be codegen'ed.
   ///
   /// Example usage:
   ///
-  /// Variables with thread storage duration are not allowed to be used in SYCL
-  /// device code
-  /// if (getLangOpts().SYCLIsDevice)
-  ///   SYCLDiagIfDeviceCode(Loc, diag::err_thread_unsupported);
+  /// Diagnose __float128 type usage only from SYCL device code if the current
+  /// target doesn't support it
+  /// if (!S.Context.getTargetInfo().hasFloat128Type() &&
+  ///     S.getLangOpts().SYCLIsDevice)
+  ///   SYCLDiagIfDeviceCode(Loc, diag::err_type_unsupported) << "__float128";
   DeviceDiagBuilder SYCLDiagIfDeviceCode(SourceLocation Loc, unsigned DiagID);
 
   /// Checks if Callee function is a device function and emits

--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -59,6 +59,7 @@ add_clang_library(clangSema
   SemaStmt.cpp
   SemaStmtAsm.cpp
   SemaStmtAttr.cpp
+  SemaSYCL.cpp
   SemaTemplate.cpp
   SemaTemplateDeduction.cpp
   SemaTemplateInstantiate.cpp

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1616,9 +1616,6 @@ Sema::DeviceDiagBuilder Sema::targetDiag(SourceLocation Loc, unsigned DiagID) {
   if (getLangOpts().CUDA)
     return getLangOpts().CUDAIsDevice ? CUDADiagIfDeviceCode(Loc, DiagID)
                                       : CUDADiagIfHostCode(Loc, DiagID);
-  // TODO: analyze which usages of targetDiag could be reused for SYCL.
-  // if (getLangOpts().SYCLIsDevice)
-  //   return SYCLDiagIfDeviceCode(Loc, DiagID);
   return DeviceDiagBuilder(DeviceDiagBuilder::K_Immediate, Loc, DiagID,
                            getCurFunctionDecl(), *this);
 }

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1616,6 +1616,9 @@ Sema::DeviceDiagBuilder Sema::targetDiag(SourceLocation Loc, unsigned DiagID) {
   if (getLangOpts().CUDA)
     return getLangOpts().CUDAIsDevice ? CUDADiagIfDeviceCode(Loc, DiagID)
                                       : CUDADiagIfHostCode(Loc, DiagID);
+  // TODO: analyze which usages of targetDiag could be reused for SYCL.
+  // if (getLangOpts().SYCLIsDevice)
+  //   return SYCLDiagIfDeviceCode(Loc, DiagID);
   return DeviceDiagBuilder(DeviceDiagBuilder::K_Immediate, Loc, DiagID,
                            getCurFunctionDecl(), *this);
 }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -14684,6 +14684,8 @@ Sema::BuildCXXConstructExpr(SourceLocation ConstructLoc, QualType DeclInitType,
   MarkFunctionReferenced(ConstructLoc, Constructor);
   if (getLangOpts().CUDA && !CheckCUDACall(ConstructLoc, Constructor))
     return ExprError();
+  if (getLangOpts().SYCLIsDevice)
+    checkSYCLDeviceFunction(ConstructLoc, Constructor);
 
   return CXXConstructExpr::Create(
       Context, DeclInitType, ConstructLoc, Constructor, Elidable,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -291,6 +291,9 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
 
     if (getLangOpts().CUDA && !CheckCUDACall(Loc, FD))
       return true;
+
+    if (getLangOpts().SYCLIsDevice)
+      checkSYCLDeviceFunction(Loc, FD);
   }
 
   if (auto *MD = dyn_cast<CXXMethodDecl>(D)) {
@@ -15756,6 +15759,9 @@ void Sema::MarkFunctionReferenced(SourceLocation Loc, FunctionDecl *Func,
 
   if (getLangOpts().CUDA)
     CheckCUDACall(Loc, Func);
+
+  if (getLangOpts().SYCLIsDevice)
+    checkSYCLDeviceFunction(Loc, Func);
 
   // If we need a definition, try to create one.
   if (NeedDefinition && !Func->getBody()) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -33,7 +33,7 @@ Sema::DeviceDiagBuilder Sema::SYCLDiagIfDeviceCode(SourceLocation Loc,
          "Should only be called during SYCL compilation");
   FunctionDecl *FD = dyn_cast<FunctionDecl>(getCurLexicalContext());
   DeviceDiagBuilder::Kind DiagKind = [this, FD] {
-    if (!FD)
+    if (!FD || isUnevaluatedContext())
       return DeviceDiagBuilder::K_Nop;
     if (isKnownEmitted(*this, FD))
       return DeviceDiagBuilder::K_ImmediateWithCallStack;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1,0 +1,55 @@
+//===- SemaSYCL.cpp - Semantic Analysis for SYCL constructs ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// This implements Semantic Analysis for SYCL constructs.
+//===----------------------------------------------------------------------===//
+
+#include "clang/Sema/Sema.h"
+
+using namespace clang;
+// -----------------------------------------------------------------------------
+// SYCL device specific diagnostics implementation
+// -----------------------------------------------------------------------------
+
+// Do we know that we will eventually codegen the given function?
+static bool isKnownEmitted(Sema &S, FunctionDecl *FD) {
+  assert(FD && "Given function may not be null.");
+
+  if (FD->hasAttr<SYCLKernelAttr>())
+    return true;
+
+  // Otherwise, the function is known-emitted if it's in our set of
+  // known-emitted functions.
+  return S.DeviceKnownEmittedFns.count(FD) > 0;
+}
+
+Sema::DeviceDiagBuilder Sema::SYCLDiagIfDeviceCode(SourceLocation Loc,
+                                                   unsigned DiagID) {
+  assert(getLangOpts().SYCLIsDevice &&
+         "Should only be called during SYCL compilation");
+  FunctionDecl *FD = dyn_cast<FunctionDecl>(getCurLexicalContext());
+  DeviceDiagBuilder::Kind DiagKind = [this, FD] {
+    if (!FD)
+      return DeviceDiagBuilder::K_Nop;
+    if (isKnownEmitted(*this, FD))
+      return DeviceDiagBuilder::K_ImmediateWithCallStack;
+    return DeviceDiagBuilder::K_Deferred;
+  }();
+  return DeviceDiagBuilder(DiagKind, Loc, DiagID, FD, *this);
+}
+
+void Sema::checkSYCLDeviceFunction(SourceLocation Loc, FunctionDecl *Callee) {
+  assert(Callee && "Callee may not be null.");
+  FunctionDecl *Caller = dyn_cast<FunctionDecl>(getCurLexicalContext());
+
+  // If the caller is known-emitted, mark the callee as known-emitted.
+  // Otherwise, mark the call in our call graph so we can traverse it later.
+  if (Caller && isKnownEmitted(*this, Caller))
+    markKnownEmitted(*this, Caller, Callee, Loc, isKnownEmitted);
+  else if (Caller)
+    DeviceCallGraph[Caller].insert({Callee, Loc});
+}

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -46,6 +46,11 @@ void Sema::checkSYCLDeviceFunction(SourceLocation Loc, FunctionDecl *Callee) {
   assert(Callee && "Callee may not be null.");
   FunctionDecl *Caller = dyn_cast<FunctionDecl>(getCurLexicalContext());
 
+  // Errors in unevaluated context don't need to be generated,
+  // so we can safely skip them.
+  if (isUnevaluatedContext())
+    return;
+
   // If the caller is known-emitted, mark the callee as known-emitted.
   // Otherwise, mark the call in our call graph so we can traverse it later.
   if (Caller && isKnownEmitted(*this, Caller))

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -4712,6 +4712,9 @@ Sema::DeduceAutoType(TypeLoc Type, Expr *&Init, QualType &Result,
     }
   }
 
+  if (!Context.getTargetInfo().hasFloat128Type() &&
+      (Result->isFloat128Type()) && getLangOpts().SYCLIsDevice)
+    SYCLDiagIfDeviceCode(Loc, diag::err_type_unsupported) << "__float128";
   return DAR_Succeeded;
 }
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1516,9 +1516,14 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
     break;
   case DeclSpec::TST_float128:
     if (!S.Context.getTargetInfo().hasFloat128Type() &&
-        !(S.getLangOpts().OpenMP && S.getLangOpts().OpenMPIsDevice))
+        S.getLangOpts().SYCLIsDevice)
+      S.SYCLDiagIfDeviceCode(DS.getTypeSpecTypeLoc(),
+                             diag::err_type_unsupported)
+          << "__float128";
+    else if (!S.Context.getTargetInfo().hasFloat128Type() &&
+             !(S.getLangOpts().OpenMP && S.getLangOpts().OpenMPIsDevice))
       S.Diag(DS.getTypeSpecTypeLoc(), diag::err_type_unsupported)
-        << "__float128";
+          << "__float128";
     Result = Context.Float128Ty;
     break;
   case DeclSpec::TST_bool: Result = Context.BoolTy; break; // _Bool or bool

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -1,23 +1,72 @@
 // RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify -fsyntax-only %s
 
-void eh_ok(void)
-{
+template <class T>
+class Z {
+public:
+  T field;
+// TODO
+// Restriction usages inside class declarations is not diagnosed because in
+// this case getCurLexicalContext() returns record decl and we can diagnose only
+// inside function decls
+  __float128 field1;
+};
+
+void eh_ok(void) {
   __float128 A;
+  int B = sizeof(__float128);
+  Z<__float128> C;
+}
+
+template <typename T>
+T bar(T t) {
+  return t;
+}
+__float128 foo1() { return 0; }
+
+template<typename t> void foo2(){};
+
+// TODO
+// Function parameters and return values is not diagnosed because in this case
+// getCurLexicalContext() returns translation unit decl and we can diagnose only
+// inside function decls
+__float128 foo(__float128 P) {
+  // expected-error@+1 {{__float128 is not supported on this target}}
+  Z<__float128> A;
+  bar(P);
+  bar(A);
+  // expected-error@+1 {{__float128 is not supported on this target}}
+  __float128 B;
+  bar(B);
+  // expected-error@+1 {{__float128 is not supported on this target}}
+  bar((__float128)0);
+
+  // TODO
+  // NOT ANALYZED PROBLEM
+  // expected-error@+1 {{__float128 is not supported on this target}}
+  foo2<__float128>();
+  return P;
 }
 
 void usage() {
   // expected-error@+1 {{__float128 is not supported on this target}}
   __float128 A;
+  // expected-note@+1{{called by 'usage'}}
+  auto B = foo(A);
+  int E = sizeof(__float128);
+
+  // NOT ANALYZED PROBLEM
+  decltype(A) C;
+  decltype(foo1()) D;
 }
 
-template <typename name, typename Func>
+template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
-// expected-note@+1{{called by 'kernel_single_task}}
+  // expected-note@+1 2{{called by 'kernel_single_task}}
   kernelFunc();
 }
 
 int main() {
-// expected-note@+1{{called by 'operator()'}}
+  // expected-note@+1 2{{called by 'operator()'}}
   kernel_single_task<class fake_kernel>([]() { usage(); });
   return 0;
 }

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify -fsyntax-only %s
+
+void eh_ok(void)
+{
+  __float128 A;
+}
+
+void usage() {
+  // expected-error@+1 {{__float128 is not supported on this target}}
+  __float128 A;
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+// expected-note@+1{{called by 'kernel_single_task}}
+  kernelFunc();
+}
+
+int main() {
+// expected-note@+1{{called by 'operator()'}}
+  kernel_single_task<class fake_kernel>([]() { usage(); });
+  return 0;
+}
+


### PR DESCRIPTION
### This pull request is created to gather SYCL working group internal feedback before uploading the patch to LLVM phabricator.

Reuse deferred diagnostic interface for SYCL.