### PR TITLE
[SYCL] Use SYCL aliases for STL types in cg.hpp

### DIFF
--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -320,11 +320,11 @@ public:
     PREFETCH_USM
   };
 
-  CG(CGTYPE Type, std::vector<std::vector<char>> ArgsStorage,
-     std::vector<detail::AccessorImplPtr> AccStorage,
-     std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-     std::vector<Requirement *> Requirements,
-     std::vector<detail::EventImplPtr> Events)
+  CG(CGTYPE Type, vector_class<vector_class<char>> ArgsStorage,
+     vector_class<detail::AccessorImplPtr> AccStorage,
+     vector_class<shared_ptr_class<const void>> SharedPtrStorage,
+     vector_class<Requirement *> Requirements,
+     vector_class<detail::EventImplPtr> Events)
       : MType(Type), MArgsStorage(std::move(ArgsStorage)),
         MAccStorage(std::move(AccStorage)),
         MSharedPtrStorage(std::move(SharedPtrStorage)),
@@ -341,41 +341,41 @@ private:
   // The following storages needed to ensure that arguments won't die while
   // we are using them.
   // Storage for standard layout arguments.
-  std::vector<std::vector<char>> MArgsStorage;
+  vector_class<vector_class<char>> MArgsStorage;
   // Storage for accessors.
-  std::vector<detail::AccessorImplPtr> MAccStorage;
+  vector_class<detail::AccessorImplPtr> MAccStorage;
   // Storage for shared_ptrs.
-  std::vector<std::shared_ptr<const void>> MSharedPtrStorage;
+  vector_class<shared_ptr_class<const void>> MSharedPtrStorage;
 
 public:
   // List of requirements that specify which memory is needed for the command
   // group to be executed.
-  std::vector<Requirement *> MRequirements;
+  vector_class<Requirement *> MRequirements;
   // List of events that order the execution of this CG
-  std::vector<detail::EventImplPtr> MEvents;
+  vector_class<detail::EventImplPtr> MEvents;
 };
 
 // The class which represents "execute kernel" command group.
 class CGExecKernel : public CG {
 public:
   NDRDescT MNDRDesc;
-  std::unique_ptr<HostKernelBase> MHostKernel;
-  std::shared_ptr<detail::kernel_impl> MSyclKernel;
-  std::vector<ArgDesc> MArgs;
-  std::string MKernelName;
+  unique_ptr_class<HostKernelBase> MHostKernel;
+  shared_ptr_class<detail::kernel_impl> MSyclKernel;
+  vector_class<ArgDesc> MArgs;
+  string_class MKernelName;
   detail::OSModuleHandle MOSModuleHandle;
-  std::vector<std::shared_ptr<detail::stream_impl>> MStreams;
+  vector_class<shared_ptr_class<detail::stream_impl>> MStreams;
 
-  CGExecKernel(NDRDescT NDRDesc, std::unique_ptr<HostKernelBase> HKernel,
-               std::shared_ptr<detail::kernel_impl> SyclKernel,
-               std::vector<std::vector<char>> ArgsStorage,
-               std::vector<detail::AccessorImplPtr> AccStorage,
-               std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-               std::vector<Requirement *> Requirements,
-               std::vector<detail::EventImplPtr> Events,
-               std::vector<ArgDesc> Args, std::string KernelName,
+  CGExecKernel(NDRDescT NDRDesc, unique_ptr_class<HostKernelBase> HKernel,
+               shared_ptr_class<detail::kernel_impl> SyclKernel,
+               vector_class<vector_class<char>> ArgsStorage,
+               vector_class<detail::AccessorImplPtr> AccStorage,
+               vector_class<shared_ptr_class<const void>> SharedPtrStorage,
+               vector_class<Requirement *> Requirements,
+               vector_class<detail::EventImplPtr> Events,
+               vector_class<ArgDesc> Args, string_class KernelName,
                detail::OSModuleHandle OSModuleHandle,
-               std::vector<std::shared_ptr<detail::stream_impl>> Streams,
+               vector_class<shared_ptr_class<detail::stream_impl>> Streams,
                CGTYPE Type)
       : CG(Type, std::move(ArgsStorage), std::move(AccStorage),
            std::move(SharedPtrStorage), std::move(Requirements),
@@ -388,9 +388,9 @@ public:
            "Wrong type of exec kernel CG.");
   }
 
-  std::vector<ArgDesc> getArguments() const { return MArgs; }
-  std::string getKernelName() const { return MKernelName; }
-  std::vector<std::shared_ptr<detail::stream_impl>> getStreams() const {
+  vector_class<ArgDesc> getArguments() const { return MArgs; }
+  string_class getKernelName() const { return MKernelName; }
+  vector_class<shared_ptr_class<detail::stream_impl>> getStreams() const {
     return MStreams;
   }
 };
@@ -402,11 +402,11 @@ class CGCopy : public CG {
 
 public:
   CGCopy(CGTYPE CopyType, void *Src, void *Dst,
-         std::vector<std::vector<char>> ArgsStorage,
-         std::vector<detail::AccessorImplPtr> AccStorage,
-         std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-         std::vector<Requirement *> Requirements,
-         std::vector<detail::EventImplPtr> Events)
+         vector_class<vector_class<char>> ArgsStorage,
+         vector_class<detail::AccessorImplPtr> AccStorage,
+         vector_class<shared_ptr_class<const void>> SharedPtrStorage,
+         vector_class<Requirement *> Requirements,
+         vector_class<detail::EventImplPtr> Events)
       : CG(CopyType, std::move(ArgsStorage), std::move(AccStorage),
            std::move(SharedPtrStorage), std::move(Requirements),
            std::move(Events)),
@@ -418,15 +418,15 @@ public:
 // The class which represents "fill" command group.
 class CGFill : public CG {
 public:
-  std::vector<char> MPattern;
+  vector_class<char> MPattern;
   Requirement *MPtr;
 
-  CGFill(std::vector<char> Pattern, void *Ptr,
-         std::vector<std::vector<char>> ArgsStorage,
-         std::vector<detail::AccessorImplPtr> AccStorage,
-         std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-         std::vector<Requirement *> Requirements,
-         std::vector<detail::EventImplPtr> Events)
+  CGFill(vector_class<char> Pattern, void *Ptr,
+         vector_class<vector_class<char>> ArgsStorage,
+         vector_class<detail::AccessorImplPtr> AccStorage,
+         vector_class<shared_ptr_class<const void>> SharedPtrStorage,
+         vector_class<Requirement *> Requirements,
+         vector_class<detail::EventImplPtr> Events)
       : CG(FILL, std::move(ArgsStorage), std::move(AccStorage),
            std::move(SharedPtrStorage), std::move(Requirements),
            std::move(Events)),
@@ -439,11 +439,11 @@ class CGUpdateHost : public CG {
   Requirement *MPtr;
 
 public:
-  CGUpdateHost(void *Ptr, std::vector<std::vector<char>> ArgsStorage,
-               std::vector<detail::AccessorImplPtr> AccStorage,
-               std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-               std::vector<Requirement *> Requirements,
-               std::vector<detail::EventImplPtr> Events)
+  CGUpdateHost(void *Ptr, vector_class<vector_class<char>> ArgsStorage,
+               vector_class<detail::AccessorImplPtr> AccStorage,
+               vector_class<shared_ptr_class<const void>> SharedPtrStorage,
+               vector_class<Requirement *> Requirements,
+               vector_class<detail::EventImplPtr> Events)
       : CG(UPDATE_HOST, std::move(ArgsStorage), std::move(AccStorage),
            std::move(SharedPtrStorage), std::move(Requirements),
            std::move(Events)),
@@ -460,11 +460,11 @@ class CGCopyUSM : public CG {
 
 public:
   CGCopyUSM(void *Src, void *Dst, size_t Length,
-            std::vector<std::vector<char>> ArgsStorage,
-            std::vector<detail::AccessorImplPtr> AccStorage,
-            std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-            std::vector<Requirement *> Requirements,
-            std::vector<detail::EventImplPtr> Events)
+            vector_class<vector_class<char>> ArgsStorage,
+            vector_class<detail::AccessorImplPtr> AccStorage,
+            vector_class<shared_ptr_class<const void>> SharedPtrStorage,
+            vector_class<Requirement *> Requirements,
+            vector_class<detail::EventImplPtr> Events)
       : CG(COPY_USM, std::move(ArgsStorage), std::move(AccStorage),
            std::move(SharedPtrStorage), std::move(Requirements),
            std::move(Events)),
@@ -477,17 +477,17 @@ public:
 
 // The class which represents "fill" command group for USM pointers.
 class CGFillUSM : public CG {
-  std::vector<char> MPattern;
+  vector_class<char> MPattern;
   void *MDst;
   size_t MLength;
 
 public:
-  CGFillUSM(std::vector<char> Pattern, void *DstPtr, size_t Length,
-            std::vector<std::vector<char>> ArgsStorage,
-            std::vector<detail::AccessorImplPtr> AccStorage,
-            std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-            std::vector<Requirement *> Requirements,
-            std::vector<detail::EventImplPtr> Events)
+  CGFillUSM(vector_class<char> Pattern, void *DstPtr, size_t Length,
+            vector_class<vector_class<char>> ArgsStorage,
+            vector_class<detail::AccessorImplPtr> AccStorage,
+            vector_class<shared_ptr_class<const void>> SharedPtrStorage,
+            vector_class<Requirement *> Requirements,
+            vector_class<detail::EventImplPtr> Events)
       : CG(FILL_USM, std::move(ArgsStorage), std::move(AccStorage),
            std::move(SharedPtrStorage), std::move(Requirements),
            std::move(Events)),
@@ -504,11 +504,11 @@ class CGPrefetchUSM : public CG {
 
 public:
   CGPrefetchUSM(void *DstPtr, size_t Length,
-                std::vector<std::vector<char>> ArgsStorage,
-                std::vector<detail::AccessorImplPtr> AccStorage,
-                std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-                std::vector<Requirement *> Requirements,
-                std::vector<detail::EventImplPtr> Events)
+                vector_class<vector_class<char>> ArgsStorage,
+                vector_class<detail::AccessorImplPtr> AccStorage,
+                vector_class<shared_ptr_class<const void>> SharedPtrStorage,
+                vector_class<Requirement *> Requirements,
+                vector_class<detail::EventImplPtr> Events)
       : CG(PREFETCH_USM, std::move(ArgsStorage), std::move(AccStorage),
            std::move(SharedPtrStorage), std::move(Requirements),
            std::move(Events)),


### PR DESCRIPTION
Since handler.hpp uses a lot of templates by design, it is very hard to
eliminate usage of cg.hpp there. This patch makes header file
public-friendly by using SYCL '_class' containers instead of std ones.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>