### PR TITLE
[SYCL] Addition of get_range() method

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -458,9 +458,7 @@ public:
 
 #ifdef __SYCL_DEVICE_ONLY__
 
-  size_t get_count() const {
-    return get_range<Dimensions>().size();
-  }
+  size_t get_count() const { return get_range<Dimensions>().size(); }
 
   template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 1>>
   range<1> get_range() const {
@@ -481,27 +479,11 @@ public:
 #else
   size_t get_count() const { return MImageCount; };
 
-  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 1>>
-  range<1> get_range() const {
-    range<1> RetRange(0);
-    RetRange[0] = getAccessRange()[0];
-    return RetRange;
+  template <int Dims = Dimensions, typename = detail::enable_if_t<(Dims > 0)>>
+  range<Dims> get_range() const {
+    return detail::convertToArrayOfN<Dims, 1>(getAccessRange());
   }
-  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 2>>
-  range<2> get_range() const {
-    range<2> RetRange(0, 0);
-    RetRange[0] = getAccessRange()[0];
-    RetRange[1] = getAccessRange()[1];
-    return RetRange;
-  }
-  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 3>>
-  range<3> get_range() const {
-    range<3> RetRange(0, 0, 0);
-    RetRange[0] = getAccessRange()[0];
-    RetRange[1] = getAccessRange()[1];
-    RetRange[2] = getAccessRange()[2];
-    return RetRange;
-  }
+
 #endif
 
   // Available only when:
@@ -648,15 +630,10 @@ public:
     return MBaseAcc.MImageCount / MBaseAcc.getAccessRange()[Dimensions];
   }
 
-  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 1>>
-  range<1> get_range() const {
-    return range<1>(MBaseAcc.getAccessRange()[0]);
-  }
-
-  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 2>>
-  range<2> get_range() const {
-    range<3> BaseAccessRange = MBaseAcc.getAccessRange();
-    return range<2>(BaseAccessRange[0], BaseAccessRange[1]);
+  template <int Dims = Dimensions,
+            typename = detail::enable_if_t<(Dims == 1 || Dims == 2)>>
+  range<Dims> get_range() const {
+    return detail::convertToArrayOfN<Dims, 1>(MBaseAcc.getAccessRange());
   }
 
 #endif
@@ -1130,8 +1107,8 @@ public:
   size_t get_count() const { return getSize().size(); }
 
   template <int Dims = Dimensions, typename = detail::enable_if_t<(Dims > 0)>>
-  range<Dimensions> get_range() const {
-    return getSize();
+  range<Dims> get_range() const {
+    return detail::convertToArrayOfN<Dims, 1>(getSize());
   }
 
   template <int Dims = Dimensions,

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -267,7 +267,6 @@ class image_accessor
 #ifndef __SYCL_DEVICE_ONLY__
     : public detail::AccessorBaseHost {
   size_t MImageCount;
-  size_t MImageSize;
   image_channel_order MImgChannelOrder;
   image_channel_type MImgChannelType;
 #else
@@ -277,9 +276,8 @@ class image_accessor
                                                         AccessTarget>::type;
   OCLImageTy MImageObj;
   char MPadding[sizeof(detail::AccessorBaseHost) +
-                sizeof(size_t /*MImageSize*/) + sizeof(size_t /*MImageCount*/) +
-                sizeof(image_channel_order) + sizeof(image_channel_type) -
-                sizeof(OCLImageTy)];
+                sizeof(size_t /*MImageCount*/) + sizeof(image_channel_order) +
+                sizeof(image_channel_type) - sizeof(OCLImageTy)];
 
 protected:
   void imageAccessorInit(OCLImageTy Image) { MImageObj = Image; }
@@ -342,7 +340,7 @@ private:
 
 #ifdef __SYCL_DEVICE_ONLY__
 
-  sycl::vec<int, Dimensions> getCountInternal() const {
+  sycl::vec<int, Dimensions> getRangeInternal() const {
     return __invoke_ImageQuerySize<sycl::vec<int, Dimensions>, OCLImageTy>(
         MImageObj);
   }
@@ -356,10 +354,10 @@ private:
 
 #else
 
-  sycl::vec<int, Dimensions> getCountInternal() const {
+  sycl::vec<int, Dimensions> getRangeInternal() const {
     // TODO: Implement for host.
     throw runtime_error(
-        "image::getCountInternal() is not implemented for host");
+        "image::getRangeInternal() is not implemented for host");
     return sycl::vec<int, Dimensions>{1};
   }
 
@@ -397,7 +395,6 @@ public:
                          AccessMode, detail::getSyclObjImpl(ImageRef).get(),
                          Dimensions, ImageElementSize),
         MImageCount(ImageRef.get_count()),
-        MImageSize(MImageCount * ImageElementSize),
         MImgChannelOrder(detail::getSyclObjImpl(ImageRef)->getChannelOrder()),
         MImgChannelType(detail::getSyclObjImpl(ImageRef)->getChannelType()) {
     detail::EventImplPtr Event =
@@ -429,7 +426,6 @@ public:
                          AccessMode, detail::getSyclObjImpl(ImageRef).get(),
                          Dimensions, ImageElementSize),
         MImageCount(ImageRef.get_count()),
-        MImageSize(MImageCount * ImageElementSize),
         MImgChannelOrder(detail::getSyclObjImpl(ImageRef)->getChannelOrder()),
         MImgChannelType(detail::getSyclObjImpl(ImageRef)->getChannelType()) {
     checkDeviceFeatureSupported<info::device::image_support>(
@@ -455,32 +451,57 @@ public:
   // get_count() method : Returns the number of elements of the SYCL image this
   // SYCL accessor is accessing.
   //
-  // get_size() method :  Returns the size in bytes of the SYCL image this SYCL
-  // accessor is accessing. Returns ElementSize*get_count().
+  // get_range() method :  Returns a range object which represents the number of
+  // elements of dataT per dimension that this accessor may access.
+  // The range object returned must equal to the range of the image this
+  // accessor is associated with.
 
 #ifdef __SYCL_DEVICE_ONLY__
-  size_t get_size() const {
-    int ChannelType = __invoke_ImageQueryFormat<int, OCLImageTy>(MImageObj);
-    int ChannelOrder = __invoke_ImageQueryOrder<int, OCLImageTy>(MImageObj);
-    int ElementSize = getSPIRVElementSize(ChannelType, ChannelOrder);
-    return (ElementSize * get_count());
+
+  size_t get_count() const {
+    return get_range<Dimensions>().size();
   }
 
-  template <int Dims = Dimensions> size_t get_count() const;
-
-  template <> size_t get_count<1>() const { return getCountInternal(); }
-  template <> size_t get_count<2>() const {
-    cl_int2 Count = getCountInternal();
-    return (Count.x() * Count.y());
-  };
-  template <> size_t get_count<3>() const {
-    cl_int3 Count = getCountInternal();
-    return (Count.x() * Count.y() * Count.z());
-  };
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 1>>
+  range<1> get_range() const {
+    cl_int Range = getRangeInternal();
+    return range<1>(Range);
+  }
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 2>>
+  range<2> get_range() const {
+    cl_int2 Range = getRangeInternal();
+    return range<2>(Range[0], Range[1]);
+  }
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 3>>
+  range<3> get_range() const {
+    cl_int3 Range = getRangeInternal();
+    return range<3>(Range[0], Range[1], Range[3]);
+  }
 
 #else
-  size_t get_size() const { return MImageSize; };
   size_t get_count() const { return MImageCount; };
+
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 1>>
+  range<1> get_range() const {
+    range<1> RetRange(0);
+    RetRange[0] = getAccessRange()[0];
+    return RetRange;
+  }
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 2>>
+  range<2> get_range() const {
+    range<2> RetRange(0, 0);
+    RetRange[0] = getAccessRange()[0];
+    RetRange[1] = getAccessRange()[1];
+    return RetRange;
+  }
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 3>>
+  range<3> get_range() const {
+    range<3> RetRange(0, 0, 0);
+    RetRange[0] = getAccessRange()[0];
+    RetRange[1] = getAccessRange()[1];
+    RetRange[2] = getAccessRange()[2];
+    return RetRange;
+  }
 #endif
 
   // Available only when:
@@ -566,7 +587,7 @@ class __image_array_slice__ {
     CoordElemType LastCoord = 0;
 
     if (std::is_same<float, CoordElemType>::value) {
-      sycl::vec<int, Dimensions + 1> Size = MBaseAcc.getCountInternal();
+      sycl::vec<int, Dimensions + 1> Size = MBaseAcc.getRangeInternal();
       LastCoord =
           MIdx / static_cast<float>(Size.template swizzle<Dimensions>());
     } else {
@@ -608,27 +629,36 @@ public:
   }
 
 #ifdef __SYCL_DEVICE_ONLY__
-  size_t get_size() const { return MBaseAcc.getElementSize() * get_count(); }
+  size_t get_count() const { return get_range<Dimensions>().size(); }
 
-  template <int Dims = Dimensions> size_t get_count() const;
-
-  template <> size_t get_count<1>() const {
-    cl_int2 Count = MBaseAcc.getCountInternal();
-    return Count.x();
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 1>>
+  range<1> get_range() const {
+    cl_int2 Count = MBaseAcc.getRangeInternal();
+    return range<1>(Count.x());
   }
-  template <> size_t get_count<2>() const {
-    cl_int3 Count = MBaseAcc.getCountInternal();
-    return (Count.x() * Count.y());
-  };
-#else
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 2>>
+  range<2> get_range() const {
+    cl_int3 Count = MBaseAcc.getRangeInternal();
+    return range<2>(Count.x(), Count.y());
+  }
 
-  size_t get_size() const {
-    return MBaseAcc.MImageSize / MBaseAcc.getAccessRange()[Dimensions];
-  };
+#else
 
   size_t get_count() const {
     return MBaseAcc.MImageCount / MBaseAcc.getAccessRange()[Dimensions];
-  };
+  }
+
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 1>>
+  range<1> get_range() const {
+    return range<1>(MBaseAcc.getAccessRange()[0]);
+  }
+
+  template <int Dims = Dimensions, typename = detail::enable_if_t<Dims == 2>>
+  range<2> get_range() const {
+    range<3> BaseAccessRange = MBaseAcc.getAccessRange();
+    return range<2>(BaseAccessRange[0], BaseAccessRange[1]);
+  }
+
 #endif
 
 private:
@@ -1098,6 +1128,11 @@ public:
   size_t get_size() const { return getSize().size() * sizeof(DataT); }
 
   size_t get_count() const { return getSize().size(); }
+
+  template <int Dims = Dimensions, typename = detail::enable_if_t<(Dims > 0)>>
+  range<Dimensions> get_range() const {
+    return getSize();
+  }
 
   template <int Dims = Dimensions,
             typename = detail::enable_if_t<Dims == 0 && IsAccessAnyWrite>>

--- a/sycl/test/basic_tests/device_event.cpp
+++ b/sycl/test/basic_tests/device_event.cpp
@@ -95,7 +95,8 @@ int test_strideN(size_t stride) {
         // that are not supposed to happen, but who knows..., c) to see those
         // values at the end if something goes wrong during the ASYNC MEM COPY.
         out_ptr[item.get_global_id()[0]] = item.get_global_id()[0] + 700;
-
+        // Just a check of get_range() API.
+        local_acc.get_range();
         item.barrier();
 
         // Copy from local memory to global memory.

--- a/sycl/test/basic_tests/image.cpp
+++ b/sycl/test/basic_tests/image.cpp
@@ -69,7 +69,7 @@ int main() {
     TestQueue Q{sycl::default_selector()};
     Q.submit([&](sycl::handler &CGH) {
       auto ImgAcc = Img.get_access<sycl::float4, SYCLRead>(CGH);
-      CGH.single_task<class EmptyKernel>([=]() { ImgAcc.get_size(); });
+      CGH.single_task<class EmptyKernel>([=]() { ImgAcc.get_range(); });
     });
   }
 

--- a/sycl/test/basic_tests/image_array.cpp
+++ b/sycl/test/basic_tests/image_array.cpp
@@ -32,7 +32,7 @@ int main() {
     READ_I = 0,
     READ_SAMPLER_F = 0,
     READ_SAMPLER_I = 0,
-    GET_SIZE,
+    GET_RANGE,
     GET_COUNT,
     WRITE1,
     WRITE2,
@@ -96,11 +96,11 @@ int main() {
           ResAcc[READ_SAMPLER_F] |= sycl::any(sycl::isnotequal(Val, ValRef));
         }
 
-        // Check that the size and count of 1D image in 1D image array == width
+        // Check that the range and count of 1D image in 1D image array == width
         // of 2d image.
 
-        ResAcc[GET_SIZE] |= (ImgAcc.get_size() / ImgSize[1]) !=
-                            ImgArrayAcc[CoordI.y()].get_size();
+        ResAcc[GET_RANGE] |= sycl::range<1>(ImgAcc.get_range()[0]) !=
+                             ImgArrayAcc[CoordI.y()].get_range();
 
         ResAcc[GET_COUNT] |= (ImgAcc.get_count() / ImgSize[1]) !=
                              ImgArrayAcc[CoordI.y()].get_count();

--- a/sycl/test/basic_tests/image_constructors.cpp
+++ b/sycl/test/basic_tests/image_constructors.cpp
@@ -5,12 +5,14 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t2.out
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out
 // RUN: %ACC_RUN_PLACEHOLDER %t2.out
+//
 //==-------image_constructors.cpp - SYCL image constructors basic test------==//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// Tests the constructors, get_count and get_range APIs.
 
 #include <CL/sycl.hpp>
 #include <cassert>
@@ -35,7 +37,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
   {
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(imageHostPtr, channelOrder, channelType, r);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (void *, image_channel_order,
@@ -44,7 +47,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
   {
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         imageHostPtr, channelOrder, channelType, r, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (void *, image_channel_order,
@@ -55,7 +59,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         imageHostPtr, channelOrder, channelType, r, imgAlloc);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (void *, image_channel_order,
@@ -66,7 +71,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         imageHostPtr, channelOrder, channelType, r, imgAlloc, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
   /* Constructor (const void*, image_channel_order,
    *              image_channel_type, const range<Dims>&,
@@ -76,7 +82,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
     const auto constHostPtr = imageHostPtr;
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(constHostPtr, channelOrder, channelType, r);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (const void*, image_channel_order,
@@ -86,7 +93,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
     const auto constHostPtr = imageHostPtr;
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         constHostPtr, channelOrder, channelType, r, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (const void*, image_channel_order,
@@ -98,7 +106,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         constHostPtr, channelOrder, channelType, r, imgAlloc);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (const void*, image_channel_order,
@@ -110,7 +119,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         constHostPtr, channelOrder, channelType, r, imgAlloc, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (shared_ptr_class<void>&, image_channel_order,
@@ -122,7 +132,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(hostPointer, channelOrder, channelType, r);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (shared_ptr_class<void>&, image_channel_order,
@@ -133,7 +144,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(hostPointer, channelOrder,
                                                       channelType, r, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (shared_ptr_class<void>&, image_channel_order,
@@ -146,7 +158,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(hostPointer, channelOrder,
                                                       channelType, r, imgAlloc);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (shared_ptr_class<void>&, image_channel_order,
@@ -159,7 +172,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         hostPointer, channelOrder, channelType, r, imgAlloc, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (image_channel_order, image_channel_type,
@@ -168,7 +182,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
   {
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(channelOrder, channelType, r);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (image_channel_order, image_channel_type,
@@ -177,7 +192,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
   {
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(channelOrder, channelType, r, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (image_channel_order, image_channel_type,
@@ -187,7 +203,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(channelOrder, channelType, r, imgAlloc);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (image_channel_order, image_channel_type,
@@ -197,7 +214,8 @@ void test_constructors(cl::sycl::range<Dims> r, void *imageHostPtr) {
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(channelOrder, channelType, r, imgAlloc, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 }
 
@@ -220,7 +238,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
   {
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         imageHostPtr, channelOrder, channelType, r, pitch);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (void *, image_channel_order,
@@ -230,7 +249,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
   {
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         imageHostPtr, channelOrder, channelType, r, pitch, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (void *, image_channel_order,
@@ -242,7 +262,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         imageHostPtr, channelOrder, channelType, r, pitch, imgAlloc);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (void *, image_channel_order,
@@ -253,7 +274,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         imageHostPtr, channelOrder, channelType, r, pitch, imgAlloc, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (shared_ptr_class<void>&, image_channel_order,
@@ -265,7 +287,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(hostPointer, channelOrder, channelType, r, pitch);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (shared_ptr_class<void>&, image_channel_order,
@@ -277,7 +300,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         hostPointer, channelOrder, channelType, r, pitch, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (shared_ptr_class<void>&, image_channel_order,
@@ -291,7 +315,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         hostPointer, channelOrder, channelType, r, pitch, imgAlloc);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (shared_ptr_class<void>&, image_channel_order,
@@ -304,7 +329,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         hostPointer, channelOrder, channelType, r, pitch, imgAlloc, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (image_channel_order, image_channel_type,
@@ -314,7 +340,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
   {
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(channelOrder, channelType, r, pitch);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (image_channel_order, image_channel_type,
@@ -324,7 +351,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
   {
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(channelOrder, channelType, r, pitch, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (image_channel_order, image_channel_type,
@@ -335,7 +363,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img =
         cl::sycl::image<Dims>(channelOrder, channelType, r, pitch, imgAlloc);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 
   /* Constructor (image_channel_order, image_channel_type,
@@ -346,7 +375,8 @@ void test_constructors_with_pitch(cl::sycl::range<Dims> r, cl::sycl::range<Dims-
     cl::sycl::image_allocator imgAlloc;
     cl::sycl::image<Dims> img = cl::sycl::image<Dims>(
         channelOrder, channelType, r, pitch, imgAlloc, propList);
-    assert(img.get_size() == (numElems * elementSize));
+    assert(img.get_count() == numElems);
+    assert(img.get_range() == r);
   }
 }
 


### PR DESCRIPTION
The change in the spec @
 https://github.com/KhronosGroup/SYCL-Docs/pull/31
has added the following functional changes to accessors:
Image Accessors: Removed get_size() method and added get_range() method.
Local Accessors: Added get_range() method.

Fixes #1023.

Signed-off-by: Garima Gupta <garima.gupta@intel.com>