### PR TITLE
[SYCL] Fix hierarchical parallelism bug - private var address shared locally.

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -832,7 +832,7 @@ void EmitAssemblyHelper::EmitAssembly(BackendAction Action,
       createTargetTransformInfoWrapperPass(getTargetIRAnalysis()));
 
   if (LangOpts.SYCLIsDevice)
-    PerModulePasses.add(createSYCLLowerWGScopePass());
+    PerFunctionPasses.add(createSYCLLowerWGScopePass());
 
   CreatePasses(PerModulePasses, PerFunctionPasses);
 

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -23,6 +23,8 @@ public:
 
 template <int dimensions = 1>
 class group {
+public:
+  group() = default; // fake constructor
 };
 
 namespace access {
@@ -251,6 +253,12 @@ kernel_parallel_for(KernelType KernelFunc) {
   KernelFunc(id<Dims>());
 }
 
+template <typename KernelName, typename KernelType, int Dims>
+ATTR_SYCL_KERNEL void
+kernel_parallel_for_work_group(KernelType KernelFunc) {
+  KernelFunc(group<Dims>());
+}
+
 class handler {
 public:
   template <typename KernelName = auto_name, typename KernelType, int Dims>
@@ -260,6 +268,17 @@ public:
     kernel_parallel_for<NameT, KernelType, Dims>(kernelFunc);
 #else
     kernelFunc();
+#endif
+  }
+
+  template <typename KernelName = auto_name, typename KernelType, int Dims>
+  void parallel_for_work_group(range<Dims> numWorkGroups, range<Dims> WorkGroupSize, KernelType kernelFunc) {
+    using NameT = typename get_kernel_name_t<KernelName, KernelType>::name;
+#ifdef __SYCL_DEVICE_ONLY__
+    kernel_parallel_for_work_group<NameT, KernelType, Dims>(kernelFunc);
+#else
+    group<Dims> G;
+    kernelFunc(G);
 #endif
   }
 

--- a/clang/test/CodeGenSYCL/hier_par.cpp
+++ b/clang/test/CodeGenSYCL/hier_par.cpp
@@ -1,0 +1,43 @@
+//==- hier_par.cpp --- hierarchical parallelism regression tests -----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %clangxx -O2 -I %S/Inputs -fsycl -fsycl-device-only -c -Xclang -emit-llvm -o %t.ll %s
+// RUN: cat %t.ll | FileCheck %s
+
+// This test checks for bug fix regressions related to hierarchical parallelism.
+// - bug1: private var's (cl::sycl::group argument) address shared locally
+//   the test checks that a "shadow" local variable is generated for the group
+//   argument
+//
+// This is compile-only test for now.
+//
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+
+void foo() {
+  int *ptr = nullptr;
+
+  queue myQueue;
+  buffer<int, 1> buf(ptr, range<1>(1));
+
+  myQueue.submit([&](handler &cgh) {
+    auto dev_ptr = buf.get_access<access::mode::read_write>(cgh);
+
+    cgh.parallel_for_work_group<class hpar_hw>(
+        range<1>(1), range<1>(1), [=](group<1> g) {
+// CHECK: @[[SHADOW:[a-zA-Z0-9]+]] = internal unnamed_addr addrspace(3) global %[[GROUP_CLASS:"[^"]+"]] undef, align [[ALIGN:[0-9]+]]
+// CHECK: define {{.*}} spir_func void @{{"[^"]+"}}({{[^,]+}}, %[[GROUP_CLASS]]* byval(%[[GROUP_CLASS]]) align {{[0-9]+}} %[[GROUP_OBJ:[A-Za-z_0-9]+]]) {{.*}}!work_group_scope{{.*}} {
+// CHECK-NOT: {{^[ \t]*define}}
+// CHECK: %[[TMP:[A-Za-z_0-9]+]] = bitcast %[[GROUP_CLASS]] addrspace(3)* @[[SHADOW]] to i8 addrspace(3)*
+// CHECK:  %[[OBJ:[A-Za-z_0-9]+]] = bitcast %[[GROUP_CLASS]]* %[[GROUP_OBJ]] to i8*
+// CHECK:  call void @llvm.memcpy.p3i8.p0i8.i64(i8 addrspace(3)* align [[ALIGN]] %[[TMP]], {{[^,]+}} %[[OBJ]], {{[^)]+}})
+        });
+  });
+}


### PR DESCRIPTION
Parameters passed by value into parallel_for_work_group lambda
(cl::sycl::group object) are actually passed as pointers to a locally
created copy within the leader WI, which is always in address space 0.
Then such pointers are shared with all work-items, which is incorrect.
The fix is to copy such variables into "shadow" local shared variables
(in address space 3) and use (share) the address of the shared variable
instead.
    
Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>
