### PR TITLE
[SYCL] Don't emit 'typename' for aliases in integration header.

### DIFF
--- a/clang/include/clang/AST/PrettyPrinter.h
+++ b/clang/include/clang/AST/PrettyPrinter.h
@@ -169,10 +169,13 @@ struct PrintingPolicy {
   /// When true, suppress printing of lifetime qualifier in ARC.
   unsigned SuppressLifetimeQualifiers : 1;
 
-  /// When true prints a canonical type instead of an alias. E.g.
+  /// When true prints a canonical type instead of an alias.
+  /// Also removes preceeding keywords if there is one. E.g.
   ///   \code
-  ///   using SizeT = int;
-  ///   template<SizeT N> class C;
+  ///   namespace NS {
+  ///      using SizeT = int;
+  ///   }
+  ///   template<typename NS::SizeT N> class C;
   ///   \endcode
   /// will be printed as
   ///   \code

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -1327,9 +1327,14 @@ void TypePrinter::printElaboratedBefore(const ElaboratedType *T,
   // The tag definition will take care of these.
   if (!Policy.IncludeTagDefinition)
   {
-    OS << TypeWithKeyword::getKeywordName(T->getKeyword());
-    if (T->getKeyword() != ETK_None)
-      OS << " ";
+    // When removing aliases don't print keywords to avoid having things
+    // like 'typename int'
+    if (!Policy.SuppressTypedefs)
+    {
+       OS << TypeWithKeyword::getKeywordName(T->getKeyword());
+       if (T->getKeyword() != ETK_None)
+         OS << " ";
+    }
     NestedNameSpecifier *Qualifier = T->getQualifier();
     if (Qualifier && !(Policy.SuppressTypedefs &&
                        T->getNamedType()->getTypeClass() == Type::Typedef))

--- a/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
+++ b/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
@@ -85,6 +85,18 @@ struct kernel_name2<space::clong_t, volatile space::culong_t> {};
 template <>
 struct kernel_name2<space::a_t, volatile space::b_t> {};
 
+// CHECK: template <long T> struct kernel_name3;
+template <typename space::long_t T>
+struct kernel_name3;
+
+struct foo {
+  using type = long;
+};
+
+// CHECK: template <long T> struct kernel_name4;
+template <typename foo::type T>
+struct kernel_name4;
+
 int main() {
   dummy_functor f;
   // non-type template arguments
@@ -116,5 +128,10 @@ int main() {
   single_task<kernel_name2<space::clong_t, volatile space::culong_t>>(f);
   // CHECK: template <> struct KernelInfo<::kernel_name2< ::A, volatile ::space::B>> {
   single_task<kernel_name2<space::a_t, volatile space::b_t>>(f);
+  // CHECK: template <> struct KernelInfo<::kernel_name3<1>> {
+  single_task<kernel_name3<1>>(f);
+  // CHECK: template <> struct KernelInfo<::kernel_name4<1>> {
+  single_task<kernel_name4<1>>(f);
+
   return 0;
 }


### PR DESCRIPTION
Skip keyword printing if SuppressTypedefs policy is used.

Signed-off-by: Ilya Stepykin <ilya.stepykin@intel.com>