### PR TITLE
[SYCL] Use qualified name of template function call

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -163,7 +163,7 @@ template <typename Arg0, typename... Args>
 void printArgs(Arg0 arg0, Args... args) {
   std::cout << "       ";
   print(arg0);
-  printArgs(std::forward<Args>(args)...);
+  pi::printArgs(std::forward<Args>(args)...);
 }
 } // namespace pi
 

--- a/sycl/test/regression/print_args.cpp
+++ b/sycl/test/regression/print_args.cpp
@@ -1,0 +1,16 @@
+// RUN: %clangxx -fsycl %s -c
+
+// Regression tests for https://github.com/intel/llvm/issues/1011
+// Checks that SYCL headers call internal templated function 'printArgs'
+// with fully quilified name to not confuse ADL.
+//
+
+template <typename TArg0, typename... TArgs>
+auto printArgs(TArg0 arg, TArgs... args) {
+}
+
+#include <CL/sycl.hpp>
+
+int main() {
+  return 0;
+}


### PR DESCRIPTION
This is to fix https://github.com/intel/llvm/issues/1011.

The reason for name conflict is ADL (https://en.cppreference.com/w/cpp/language/adl)
The only reliable way to fix this is to use qualified name.

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>