### PR TITLE
[SYCL] Refactor memory objects to improve ABI stability

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -229,7 +229,9 @@ public:
 
   size_t get_size() const { return get_count() * sizeof(T); }
 
-  AllocatorT get_allocator() const { return impl->get_allocator<AllocatorT>(); }
+  AllocatorT get_allocator() const {
+    return impl->template get_allocator<AllocatorT>();
+  }
 
   template <access::mode Mode,
             access::target Target = access::target::global_buffer>

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -215,19 +215,20 @@ public:
 
   AllocatorT get_allocator() const { return impl->get_allocator<AllocatorT>(); }
 
-  template <access::mode mode,
-            access::target target = access::target::global_buffer>
-  accessor<T, dimensions, mode, target, access::placeholder::false_t>
-  get_access(handler &commandGroupHandler) {
-    return impl->template get_access<T, dimensions, mode, target, AllocatorT>(
-        *this, commandGroupHandler);
+  template <access::mode Mode,
+            access::target Target = access::target::global_buffer>
+  accessor<T, dimensions, Mode, Target, access::placeholder::false_t>
+  get_access(handler &CommandGroupHandler) {
+    return accessor<T, dimensions, Mode, Target, access::placeholder::false_t>(
+        *this, CommandGroupHandler);
   }
 
   template <access::mode mode>
   accessor<T, dimensions, mode, access::target::host_buffer,
            access::placeholder::false_t>
   get_access() {
-    return impl->template get_access<T, dimensions, mode, AllocatorT>(*this);
+    return accessor<T, dimensions, mode, access::target::host_buffer,
+                    access::placeholder::false_t>(*this);
   }
 
   template <access::mode mode,
@@ -235,7 +236,7 @@ public:
   accessor<T, dimensions, mode, target, access::placeholder::false_t>
   get_access(handler &commandGroupHandler, range<dimensions> accessRange,
              id<dimensions> accessOffset = {}) {
-    return impl->template get_access<T, dimensions, mode, target, AllocatorT>(
+    return accessor<T, dimensions, mode, target, access::placeholder::false_t>(
         *this, commandGroupHandler, accessRange, accessOffset);
   }
 
@@ -243,8 +244,9 @@ public:
   accessor<T, dimensions, mode, access::target::host_buffer,
            access::placeholder::false_t>
   get_access(range<dimensions> accessRange, id<dimensions> accessOffset = {}) {
-    return impl->template get_access<T, dimensions, mode, AllocatorT>(
-        *this, accessRange, accessOffset);
+    return accessor<T, dimensions, mode, access::target::host_buffer,
+                    access::placeholder::false_t>(*this, accessRange,
+                                                  accessOffset);
   }
 
   template <typename Destination = std::nullptr_t>

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -60,7 +60,8 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)), propList,
-        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            allocator));
   }
 
   buffer(T *hostData, const range<dimensions> &bufferRange,
@@ -68,7 +69,8 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList, make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
+        propList,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   buffer(T *hostData, const range<dimensions> &bufferRange,
@@ -76,7 +78,9 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
+        propList,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            allocator));
   }
 
   template <typename _T = T>
@@ -86,7 +90,8 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
+        propList,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   template <typename _T = T>
@@ -96,7 +101,9 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
+        propList,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            allocator));
   }
 
   buffer(const shared_ptr_class<T> &hostData,
@@ -105,7 +112,9 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
+        propList,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            allocator));
   }
 
   buffer(const shared_ptr_class<T> &hostData,
@@ -114,7 +123,8 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
+        propList,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   template <class InputIterator, int N = dimensions,
@@ -125,7 +135,9 @@ public:
       : Range(range<1>(std::distance(first, last))) {
     impl = std::make_shared<detail::buffer_impl>(
         first, last, get_count() * sizeof(T),
-        detail::getNextPowerOfTwo(sizeof(T)), propList, make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
+        detail::getNextPowerOfTwo(sizeof(T)), propList,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            allocator));
   }
 
   template <class InputIterator, int N = dimensions,
@@ -136,7 +148,8 @@ public:
       : Range(range<1>(std::distance(first, last))) {
     impl = std::make_shared<detail::buffer_impl>(
         first, last, get_count() * sizeof(T),
-        detail::getNextPowerOfTwo(sizeof(T)), propList, make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
+        detail::getNextPowerOfTwo(sizeof(T)), propList,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   // This constructor is a prototype for a future SYCL specification
@@ -149,7 +162,8 @@ public:
     impl = std::make_shared<detail::buffer_impl>(
         container.data(), container.data() + container.size(),
         get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)), propList,
-         make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            allocator));
   }
 
   // This constructor is a prototype for a future SYCL specification
@@ -186,7 +200,9 @@ public:
 
     Range[0] = BufSize / sizeof(T);
     impl = std::make_shared<detail::buffer_impl>(
-        MemObject, SyclContext, BufSize,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), AvailableEvent);
+        MemObject, SyclContext, BufSize,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(),
+        AvailableEvent);
   }
 
   buffer(const buffer &rhs) = default;

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -52,7 +52,7 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)), propList,
-        AllocatorT());
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   buffer(const range<dimensions> &bufferRange, AllocatorT allocator,
@@ -60,7 +60,7 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)), propList,
-        allocator);
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
   }
 
   buffer(T *hostData, const range<dimensions> &bufferRange,
@@ -68,7 +68,7 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList, AllocatorT());
+        propList, make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   buffer(T *hostData, const range<dimensions> &bufferRange,
@@ -76,7 +76,7 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList, allocator);
+        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
   }
 
   template <typename _T = T>
@@ -86,7 +86,7 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList, AllocatorT());
+        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   template <typename _T = T>
@@ -96,7 +96,7 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList, allocator);
+        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
   }
 
   buffer(const shared_ptr_class<T> &hostData,
@@ -105,7 +105,7 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList, allocator);
+        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
   }
 
   buffer(const shared_ptr_class<T> &hostData,
@@ -114,7 +114,7 @@ public:
       : Range(bufferRange) {
     impl = std::make_shared<detail::buffer_impl>(
         hostData, get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)),
-        propList, AllocatorT());
+        propList,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   template <class InputIterator, int N = dimensions,
@@ -125,7 +125,7 @@ public:
       : Range(range<1>(std::distance(first, last))) {
     impl = std::make_shared<detail::buffer_impl>(
         first, last, get_count() * sizeof(T),
-        detail::getNextPowerOfTwo(sizeof(T)), propList, allocator);
+        detail::getNextPowerOfTwo(sizeof(T)), propList, make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
   }
 
   template <class InputIterator, int N = dimensions,
@@ -136,7 +136,7 @@ public:
       : Range(range<1>(std::distance(first, last))) {
     impl = std::make_shared<detail::buffer_impl>(
         first, last, get_count() * sizeof(T),
-        detail::getNextPowerOfTwo(sizeof(T)), propList, AllocatorT());
+        detail::getNextPowerOfTwo(sizeof(T)), propList, make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   // This constructor is a prototype for a future SYCL specification
@@ -149,7 +149,7 @@ public:
     impl = std::make_shared<detail::buffer_impl>(
         container.data(), container.data() + container.size(),
         get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)), propList,
-        allocator);
+         make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(allocator));
   }
 
   // This constructor is a prototype for a future SYCL specification
@@ -186,7 +186,7 @@ public:
 
     Range[0] = BufSize / sizeof(T);
     impl = std::make_shared<detail::buffer_impl>(
-        MemObject, SyclContext, BufSize, AllocatorT(), AvailableEvent);
+        MemObject, SyclContext, BufSize,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), AvailableEvent);
   }
 
   buffer(const buffer &rhs) = default;

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -11,13 +11,10 @@
 #include <CL/cl.h>
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/context.hpp>
-#include <CL/sycl/detail/context_impl.hpp>
-#include <CL/sycl/detail/aligned_allocator.hpp>
+//#include <CL/sycl/detail/aligned_allocator.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/helpers.hpp>
-#include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/pi.hpp>
-#include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_t.hpp>
 #include <CL/sycl/handler.hpp>
 #include <CL/sycl/property_list.hpp>
@@ -147,23 +144,7 @@ public:
   }
 
   void *allocateMem(ContextImplPtr Context, bool InitFromUserData,
-                    void *HostPtr, RT::PiEvent &OutEventToWait) override {
-
-    assert(!(InitFromUserData && HostPtr) &&
-           "Cannot init from user data and reuse host ptr provided "
-           "simultaneously");
-
-    void *UserPtr = InitFromUserData ? BaseT::getUserPtr() : HostPtr;
-
-    assert(!(nullptr == UserPtr && BaseT::useHostPtr() && Context->is_host()) &&
-           "Internal error. Allocating memory on the host "
-           "while having use_host_ptr property");
-
-    return MemoryManager::allocateMemBuffer(
-        std::move(Context), this, UserPtr, BaseT::MHostPtrReadOnly,
-        BaseT::getSize(), BaseT::MInteropEvent, BaseT::MInteropContext,
-        OutEventToWait);
-  }
+                   void *HostPtr, RT::PiEvent &OutEventToWait) override;
 
   MemObjType getType() const override { return MemObjType::BUFFER; }
 

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -44,17 +44,17 @@ class buffer_impl final : public SYCLMemObjT {
 
 public:
   buffer_impl(size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, SYCLMemObjAllocator Allocator)
+              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {}
 
   buffer_impl(void *HostData, size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, SYCLMemObjAllocator Allocator)
+              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(HostData, RequiredAlign);
   }
 
   buffer_impl(const void *HostData, size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, SYCLMemObjAllocator Allocator)
+              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(HostData, RequiredAlign);
   }
@@ -62,7 +62,7 @@ public:
   template <typename T>
   buffer_impl(const shared_ptr_class<T> &HostData, const size_t SizeInBytes,
               size_t RequiredAlign, const property_list &Props,
-              SYCLMemObjAllocator Allocator)
+              unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(HostData, RequiredAlign);
   }
@@ -74,7 +74,7 @@ public:
   template <class InputIterator>
   buffer_impl(EnableIfNotConstIterator<InputIterator> First, InputIterator Last,
               const size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, SYCLMemObjAllocator Allocator)
+              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(First, Last, RequiredAlign);
     // TODO: There is contradiction in the spec, in one place it says
@@ -92,13 +92,13 @@ public:
   template <class InputIterator>
   buffer_impl(EnableIfConstIterator<InputIterator> First, InputIterator Last,
               const size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, SYCLMemObjAllocator Allocator)
+              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(First, Last, RequiredAlign);
   }
 
   buffer_impl(cl_mem MemObject, const context &SyclContext,
-              const size_t SizeInBytes, SYCLMemObjAllocator Allocator,
+              const size_t SizeInBytes, unique_ptr_class<SYCLMemObjAllocator> Allocator,
               event AvailableEvent)
       : BaseT(MemObject, SyclContext, SizeInBytes, std::move(AvailableEvent),
               std::move(Allocator)) {}

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -103,45 +103,6 @@ public:
       : BaseT(MemObject, SyclContext, SizeInBytes, std::move(AvailableEvent),
               std::move(Allocator)) {}
 
-  template <typename T, int Dimensions, access::mode Mode,
-            access::target Target = access::target::global_buffer,
-            typename AllocatorT>
-  accessor<T, Dimensions, Mode, Target, access::placeholder::false_t>
-  get_access(buffer<T, Dimensions, AllocatorT> &Buffer,
-             handler &CommandGroupHandler) {
-    return accessor<T, Dimensions, Mode, Target, access::placeholder::false_t>(
-        Buffer, CommandGroupHandler);
-  }
-
-  template <typename T, int Dimensions, access::mode Mode, typename AllocatorT>
-  accessor<T, Dimensions, Mode, access::target::host_buffer,
-           access::placeholder::false_t>
-  get_access(buffer<T, Dimensions, AllocatorT> &Buffer) {
-    return accessor<T, Dimensions, Mode, access::target::host_buffer,
-                    access::placeholder::false_t>(Buffer);
-  }
-
-  template <typename T, int dimensions, access::mode mode,
-            access::target target = access::target::global_buffer,
-            typename AllocatorT>
-  accessor<T, dimensions, mode, target, access::placeholder::false_t>
-  get_access(buffer<T, dimensions, AllocatorT> &Buffer,
-             handler &commandGroupHandler, range<dimensions> accessRange,
-             id<dimensions> accessOffset) {
-    return accessor<T, dimensions, mode, target, access::placeholder::false_t>(
-        Buffer, commandGroupHandler, accessRange, accessOffset);
-  }
-
-  template <typename T, int dimensions, access::mode mode, typename AllocatorT>
-  accessor<T, dimensions, mode, access::target::host_buffer,
-           access::placeholder::false_t>
-  get_access(buffer<T, dimensions, AllocatorT> &Buffer,
-             range<dimensions> accessRange, id<dimensions> accessOffset) {
-    return accessor<T, dimensions, mode, access::target::host_buffer,
-                    access::placeholder::false_t>(Buffer, accessRange,
-                                                  accessOffset);
-  }
-
   void *allocateMem(ContextImplPtr Context, bool InitFromUserData,
                    void *HostPtr, RT::PiEvent &OutEventToWait) override;
 

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -13,7 +13,6 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/helpers.hpp>
-#include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_t.hpp>
 #include <CL/sycl/handler.hpp>
 #include <CL/sycl/property_list.hpp>

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -44,17 +44,20 @@ class buffer_impl final : public SYCLMemObjT {
 
 public:
   buffer_impl(size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
+              const property_list &Props,
+              unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {}
 
   buffer_impl(void *HostData, size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
+              const property_list &Props,
+              unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(HostData, RequiredAlign);
   }
 
   buffer_impl(const void *HostData, size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
+              const property_list &Props,
+              unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(HostData, RequiredAlign);
   }
@@ -74,7 +77,8 @@ public:
   template <class InputIterator>
   buffer_impl(EnableIfNotConstIterator<InputIterator> First, InputIterator Last,
               const size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
+              const property_list &Props,
+              unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(First, Last, RequiredAlign);
     // TODO: There is contradiction in the spec, in one place it says
@@ -92,13 +96,15 @@ public:
   template <class InputIterator>
   buffer_impl(EnableIfConstIterator<InputIterator> First, InputIterator Last,
               const size_t SizeInBytes, size_t RequiredAlign,
-              const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
+              const property_list &Props,
+              unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(First, Last, RequiredAlign);
   }
 
   buffer_impl(cl_mem MemObject, const context &SyclContext,
-              const size_t SizeInBytes, unique_ptr_class<SYCLMemObjAllocator> Allocator,
+              const size_t SizeInBytes,
+              unique_ptr_class<SYCLMemObjAllocator> Allocator,
               event AvailableEvent)
       : BaseT(MemObject, SyclContext, SizeInBytes, std::move(AvailableEvent),
               std::move(Allocator)) {}

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -11,7 +11,6 @@
 #include <CL/cl.h>
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/context.hpp>
-//#include <CL/sycl/detail/aligned_allocator.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/detail/pi.hpp>

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -192,7 +192,7 @@ public:
   size_t get_count() const { return MRange.size(); }
 
   void *allocateMem(ContextImplPtr Context, bool InitFromUserData,
-                    void *HostPtr, RT::PiEvent &OutEventToWait);
+                    void *HostPtr, RT::PiEvent &OutEventToWait) override;
 
   MemObjType getType() const override { return MemObjType::IMAGE; }
 
@@ -288,10 +288,6 @@ private:
   size_t MRowPitch = 0;
   size_t MSlicePitch = 0;
 };
-
-template class image_impl<1>;
-template class image_impl<2>;
-template class image_impl<3>;
 } // namespace detail
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -196,31 +196,6 @@ public:
 
   MemObjType getType() const override { return MemObjType::IMAGE; }
 
-  // Returns a valid accessor to the image with the specified access mode and
-  // target. The only valid types for dataT are cl_int4, cl_uint4, cl_float4 and
-  // cl_half4.
-  template <typename DataT, typename AllocatorT, access::mode AccessMode,
-            typename = EnableIfImgAccDataT<DataT>>
-  accessor<DataT, Dimensions, AccessMode, access::target::image,
-           access::placeholder::false_t>
-  get_access(image<Dimensions, AllocatorT> &Image,
-             handler &CommandGroupHandler) {
-    return accessor<DataT, Dimensions, AccessMode, access::target::image,
-                    access::placeholder::false_t>(Image, CommandGroupHandler);
-  }
-
-  // Returns a valid accessor to the image immediately on the host with the
-  // specified access mode and target. The only valid types for dataT are
-  // cl_int4, cl_uint4, cl_float4 and cl_half4.
-  template <typename DataT, typename AllocatorT,
-            access::mode AccessMode> //, typename = EnableIfImgAccDataT<DataT>>
-  accessor<DataT, Dimensions, AccessMode, access::target::host_image,
-           access::placeholder::false_t>
-  get_access(image<Dimensions, AllocatorT> &Image) {
-    return accessor<DataT, Dimensions, AccessMode, access::target::host_image,
-                    access::placeholder::false_t>(Image);
-  }
-
   // This utility api is currently used by accessor to get the element size of
   // the image. Element size is dependent on num of channels and channel type.
   // This information is not accessible from the image using any public API.

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -92,7 +92,8 @@ private:
 
 public:
   image_impl(image_channel_order Order, image_channel_type Type,
-             const range<Dimensions> &ImageRange, unique_ptr_class<SYCLMemObjAllocator> Allocator,
+             const range<Dimensions> &ImageRange,
+             unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : image_impl((void *)nullptr, Order, Type, ImageRange,
                    std::move(Allocator), PropList) {}
@@ -100,13 +101,15 @@ public:
   template <bool B = (Dimensions > 1)>
   image_impl(image_channel_order Order, image_channel_type Type,
              const range<Dimensions> &ImageRange,
-             const EnableIfPitchT<B> &Pitch, unique_ptr_class<SYCLMemObjAllocator> Allocator,
+             const EnableIfPitchT<B> &Pitch,
+             unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : image_impl((void *)nullptr, Order, Type, ImageRange, Pitch,
                    std::move(Allocator), PropList) {}
 
   image_impl(void *HData, image_channel_order Order, image_channel_type Type,
-             const range<Dimensions> &ImageRange, unique_ptr_class<SYCLMemObjAllocator> Allocator,
+             const range<Dimensions> &ImageRange,
+             unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),
@@ -118,7 +121,8 @@ public:
 
   image_impl(const void *HData, image_channel_order Order,
              image_channel_type Type, const range<Dimensions> &ImageRange,
-             unique_ptr_class<SYCLMemObjAllocator> Allocator, const property_list &PropList = {})
+             unique_ptr_class<SYCLMemObjAllocator> Allocator,
+             const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),
         MNumChannels(getImageNumberChannels(MOrder)),
@@ -130,7 +134,8 @@ public:
   template <bool B = (Dimensions > 1)>
   image_impl(void *HData, image_channel_order Order, image_channel_type Type,
              const range<Dimensions> &ImageRange,
-             const EnableIfPitchT<B> &Pitch, unique_ptr_class<SYCLMemObjAllocator> Allocator,
+             const EnableIfPitchT<B> &Pitch,
+             unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),
@@ -142,7 +147,8 @@ public:
 
   image_impl(shared_ptr_class<void> &HData, image_channel_order Order,
              image_channel_type Type, const range<Dimensions> &ImageRange,
-             unique_ptr_class<SYCLMemObjAllocator> Allocator, const property_list &PropList = {})
+             unique_ptr_class<SYCLMemObjAllocator> Allocator,
+             const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),
         MNumChannels(getImageNumberChannels(MOrder)),
@@ -155,7 +161,8 @@ public:
   template <bool B = (Dimensions > 1)>
   image_impl(shared_ptr_class<void> &HData, image_channel_order Order,
              image_channel_type Type, const range<Dimensions> &ImageRange,
-             const EnableIfPitchT<B> &Pitch, unique_ptr_class<SYCLMemObjAllocator> Allocator,
+             const EnableIfPitchT<B> &Pitch,
+             unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -224,9 +224,11 @@ private:
     PI_CALL(piMemImageGetInfo)(Mem, Info, sizeof(T), &Dest, nullptr);
   }
 
+  vector_class<device> getDevices(const ContextImplPtr Context);
+
   template <info::device Param>
   bool checkImageValueRange(const ContextImplPtr Context, const size_t Value) {
-    const auto &Devices = Context->get_info<info::context::devices>();
+    const auto &Devices = getDevices(Context);
     return Value >= 1 && std::all_of(Devices.cbegin(), Devices.cend(),
                                      [Value](const device &Dev) {
                                        return Value <= Dev.get_info<Param>();

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -92,7 +92,7 @@ private:
 
 public:
   image_impl(image_channel_order Order, image_channel_type Type,
-             const range<Dimensions> &ImageRange, SYCLMemObjAllocator Allocator,
+             const range<Dimensions> &ImageRange, unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : image_impl((void *)nullptr, Order, Type, ImageRange,
                    std::move(Allocator), PropList) {}
@@ -100,13 +100,13 @@ public:
   template <bool B = (Dimensions > 1)>
   image_impl(image_channel_order Order, image_channel_type Type,
              const range<Dimensions> &ImageRange,
-             const EnableIfPitchT<B> &Pitch, SYCLMemObjAllocator Allocator,
+             const EnableIfPitchT<B> &Pitch, unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : image_impl((void *)nullptr, Order, Type, ImageRange, Pitch,
                    std::move(Allocator), PropList) {}
 
   image_impl(void *HData, image_channel_order Order, image_channel_type Type,
-             const range<Dimensions> &ImageRange, SYCLMemObjAllocator Allocator,
+             const range<Dimensions> &ImageRange, unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),
@@ -118,7 +118,7 @@ public:
 
   image_impl(const void *HData, image_channel_order Order,
              image_channel_type Type, const range<Dimensions> &ImageRange,
-             SYCLMemObjAllocator Allocator, const property_list &PropList = {})
+             unique_ptr_class<SYCLMemObjAllocator> Allocator, const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),
         MNumChannels(getImageNumberChannels(MOrder)),
@@ -130,7 +130,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image_impl(void *HData, image_channel_order Order, image_channel_type Type,
              const range<Dimensions> &ImageRange,
-             const EnableIfPitchT<B> &Pitch, SYCLMemObjAllocator Allocator,
+             const EnableIfPitchT<B> &Pitch, unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),
@@ -142,7 +142,7 @@ public:
 
   image_impl(shared_ptr_class<void> &HData, image_channel_order Order,
              image_channel_type Type, const range<Dimensions> &ImageRange,
-             SYCLMemObjAllocator Allocator, const property_list &PropList = {})
+             unique_ptr_class<SYCLMemObjAllocator> Allocator, const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),
         MNumChannels(getImageNumberChannels(MOrder)),
@@ -155,7 +155,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image_impl(shared_ptr_class<void> &HData, image_channel_order Order,
              image_channel_type Type, const range<Dimensions> &ImageRange,
-             const EnableIfPitchT<B> &Pitch, SYCLMemObjAllocator Allocator,
+             const EnableIfPitchT<B> &Pitch, unique_ptr_class<SYCLMemObjAllocator> Allocator,
              const property_list &PropList = {})
       : BaseT(PropList, std::move(Allocator)), MRange(ImageRange),
         MOrder(Order), MType(Type),
@@ -166,7 +166,7 @@ public:
   }
 
   image_impl(cl_mem MemObject, const context &SyclContext, event AvailableEvent,
-             SYCLMemObjAllocator Allocator);
+             unique_ptr_class<SYCLMemObjAllocator> Allocator);
 
   // Return a range object representing the size of the image in terms of the
   // number of elements in each dimension as passed to the constructor

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
@@ -16,19 +16,8 @@ template <typename T>
 class aligned_allocator;
 
 class SYCLMemObjAllocator {
-/*  class holder_base {
-  public:
-    virtual ~holder_base() = default;
-    virtual void *allocate(std::size_t) = 0;
-    virtual void deallocate(void *, std::size_t) = 0;
-    virtual void setAlignment(std::size_t) = 0;
-    virtual void *getAllocator() = 0;
-    virtual std::size_t getValueSize() const = 0;
-  };
-*/
 
 protected:
-//    virtual void setAlignmentImpl(std::size_t) = 0;
     virtual void* getAllocatorImpl() = 0;
 public:
     virtual ~SYCLMemObjAllocator() = default;
@@ -39,34 +28,6 @@ public:
   template <typename AllocatorT> AllocatorT getAllocator() {
     return *reinterpret_cast<AllocatorT *>(getAllocatorImpl());
   }
-/*  template <typename AllocatorT>
-  SYCLMemObjAllocator(AllocatorT Allocator)
-      : MAllocator(std::unique_ptr<holder_base>(
-            new holder<AllocatorT>(Allocator))){}
-
-  template <typename AllocatorT>
-  SYCLMemObjAllocator()
-      : MAllocator(std::unique_ptr<holder_base>(
-            new holder<AllocatorT>(AllocatorT()))){}
-
-  void *allocate(std::size_t Count) { return MAllocator->allocate(Count); }
-
-  void deallocate(void *Ptr, std::size_t Count) {
-    MAllocator->deallocate(Ptr, Count);
-  }
-
-  void setAlignment(std::size_t RequiredAlignment) {
-    MAllocator->setAlignment(RequiredAlignment);
-  }
-
-  template <typename AllocatorT> AllocatorT getAllocator() {
-    return *reinterpret_cast<AllocatorT *>(MAllocator->getAllocator());
-  }
-
-  std::size_t getValueSize() const { return MAllocator->getValueSize(); }
-
-private:
-  std::unique_ptr<holder_base> MAllocator;*/
 };
 
   template <typename AllocatorT> class SYCLMemObjAllocatorHolder

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
@@ -18,73 +18,74 @@ class aligned_allocator;
 class SYCLMemObjAllocator {
 
 protected:
-    virtual void* getAllocatorImpl() = 0;
+  virtual void *getAllocatorImpl() = 0;
+
 public:
-    virtual ~SYCLMemObjAllocator() = default;
-    virtual void *allocate(std::size_t) = 0;
-    virtual void deallocate(void *, std::size_t) = 0;
-    virtual std::size_t getValueSize() const = 0;
-    virtual void setAlignment(std::size_t RequiredAlign) = 0;
+  virtual ~SYCLMemObjAllocator() = default;
+  virtual void *allocate(std::size_t) = 0;
+  virtual void deallocate(void *, std::size_t) = 0;
+  virtual std::size_t getValueSize() const = 0;
+  virtual void setAlignment(std::size_t RequiredAlign) = 0;
   template <typename AllocatorT> AllocatorT getAllocator() {
     return *reinterpret_cast<AllocatorT *>(getAllocatorImpl());
   }
 };
 
-  template <typename AllocatorT> class SYCLMemObjAllocatorHolder
-    : public SYCLMemObjAllocator {
-    using sycl_memory_object_allocator = detail::aligned_allocator<char>;
+template <typename AllocatorT>
+class SYCLMemObjAllocatorHolder : public SYCLMemObjAllocator {
+  using sycl_memory_object_allocator = detail::aligned_allocator<char>;
 
-    template <typename T>
-    using EnableIfDefaultAllocator =
-        enable_if_t<std::is_same<T, sycl_memory_object_allocator>::value>;
+  template <typename T>
+  using EnableIfDefaultAllocator =
+      enable_if_t<std::is_same<T, sycl_memory_object_allocator>::value>;
 
-    template <typename T>
-    using EnableIfNonDefaultAllocator =
-        enable_if_t<!std::is_same<T, sycl_memory_object_allocator>::value>;
+  template <typename T>
+  using EnableIfNonDefaultAllocator =
+      enable_if_t<!std::is_same<T, sycl_memory_object_allocator>::value>;
 
-  public:
-    SYCLMemObjAllocatorHolder(AllocatorT Allocator)
-        : MAllocator(Allocator),
-          MValueSize(sizeof(typename AllocatorT::value_type)){}
+public:
+  SYCLMemObjAllocatorHolder(AllocatorT Allocator)
+      : MAllocator(Allocator),
+        MValueSize(sizeof(typename AllocatorT::value_type)) {}
 
-    SYCLMemObjAllocatorHolder()
-        : MAllocator(AllocatorT()),
-          MValueSize(sizeof(typename AllocatorT::value_type)){}
+  SYCLMemObjAllocatorHolder()
+      : MAllocator(AllocatorT()),
+        MValueSize(sizeof(typename AllocatorT::value_type)) {}
 
-    ~SYCLMemObjAllocatorHolder() = default;
+  ~SYCLMemObjAllocatorHolder() = default;
 
-    virtual void *allocate(std::size_t Count) override {
-      return reinterpret_cast<void *>(MAllocator.allocate(Count));
-    }
+  virtual void *allocate(std::size_t Count) override {
+    return reinterpret_cast<void *>(MAllocator.allocate(Count));
+  }
 
-    virtual void deallocate(void *Ptr, std::size_t Count) override {
-      MAllocator.deallocate(
-          reinterpret_cast<typename AllocatorT::value_type *>(Ptr), Count);
-    }
+  virtual void deallocate(void *Ptr, std::size_t Count) override {
+    MAllocator.deallocate(
+        reinterpret_cast<typename AllocatorT::value_type *>(Ptr), Count);
+  }
 
-    void setAlignment(std::size_t RequiredAlign) override {
-      setAlignImpl(RequiredAlign);
-    }
+  void setAlignment(std::size_t RequiredAlign) override {
+    setAlignImpl(RequiredAlign);
+  }
 
-    virtual std::size_t getValueSize() const override { return MValueSize; }
+  virtual std::size_t getValueSize() const override { return MValueSize; }
 
-  protected:
-    virtual void *getAllocatorImpl() override { return &MAllocator; }
+protected:
+  virtual void *getAllocatorImpl() override { return &MAllocator; }
 
-  private:
-    template <typename T = AllocatorT>
-    EnableIfNonDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
-      // Do nothing in case of user's allocator.
-    }
+private:
+  template <typename T = AllocatorT>
+  EnableIfNonDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
+    // Do nothing in case of user's allocator.
+  }
 
-    template <typename T = AllocatorT>
-    EnableIfDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
-      MAllocator.setAlignment(std::max<size_t>(RequiredAlign, 64));
-    }
+  template <typename T = AllocatorT>
+  EnableIfDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
+    MAllocator.setAlignment(std::max<size_t>(RequiredAlign, 64));
+  }
 
-    AllocatorT MAllocator;
-    std::size_t MValueSize;
-  };
+  AllocatorT MAllocator;
+  std::size_t MValueSize;
+};
 } // namespace detail
 } // namespace sycl
 }

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
@@ -40,11 +40,14 @@ class SYCLMemObjAllocator {
   public:
     holder(AllocatorT Allocator)
         : MAllocator(Allocator),
-          MValueSize(sizeof(typename AllocatorT::value_type)){};
+          MValueSize(sizeof(typename AllocatorT::value_type)){}
+
     ~holder() = default;
+
     virtual void *allocate(std::size_t Count) override {
       return reinterpret_cast<void *>(MAllocator.allocate(Count));
     }
+
     virtual void deallocate(void *Ptr, std::size_t Count) override {
       MAllocator.deallocate(
           reinterpret_cast<typename AllocatorT::value_type *>(Ptr), Count);
@@ -68,6 +71,7 @@ class SYCLMemObjAllocator {
     EnableIfDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
       MAllocator.setAlignment(std::max<size_t>(RequiredAlign, 64));
     }
+
     AllocatorT MAllocator;
     std::size_t MValueSize;
   };

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+__SYCL_INLINE namespace cl {
+  namespace sycl {
+
+  namespace detail {
+
+  class SYCLMemObjAllocator {
+    class holder_base {
+    public:
+      virtual ~holder_base() = default;
+      virtual void *allocate(std::size_t) = 0;
+      virtual void deallocate(void *, std::size_t) = 0;
+      virtual void setAlignment(std::size_t) = 0;
+      virtual void *getAllocator() = 0;
+      virtual std::size_t getValueSize() const = 0;
+    };
+
+    template <typename AllocatorT> class holder : public holder_base {
+      using sycl_memory_object_allocator = detail::aligned_allocator<char>;
+
+      template <typename T>
+      using EnableIfDefaultAllocator =
+          enable_if_t<std::is_same<T, sycl_memory_object_allocator>::value>;
+
+      template <typename T>
+      using EnableIfNonDefaultAllocator =
+          enable_if_t<!std::is_same<T, sycl_memory_object_allocator>::value>;
+
+    public:
+      holder(AllocatorT Allocator)
+          : MAllocator(Allocator),
+            MValueSize(sizeof(typename AllocatorT::value_type)){};
+      ~holder() = default;
+      virtual void *allocate(std::size_t Count) override {
+        return reinterpret_cast<void *>(MAllocator.allocate(Count));
+      }
+      virtual void deallocate(void *Ptr, std::size_t Count) override {
+        MAllocator.deallocate(
+            reinterpret_cast<typename AllocatorT::value_type *>(Ptr), Count);
+      }
+
+      void setAlignment(std::size_t RequiredAlign) override {
+        setAlignImpl(RequiredAlign);
+      }
+
+      virtual void *getAllocator() override { return &MAllocator; }
+
+      virtual std::size_t getValueSize() const override { return MValueSize; }
+
+    private:
+      template <typename T = AllocatorT>
+      EnableIfNonDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
+        // Do nothing in case of user's allocator.
+      }
+
+      template <typename T = AllocatorT>
+      EnableIfDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
+        MAllocator.setAlignment(std::max<size_t>(RequiredAlign, 64));
+      }
+      AllocatorT MAllocator;
+      std::size_t MValueSize;
+    };
+
+  public:
+    template <typename AllocatorT>
+    SYCLMemObjAllocator(AllocatorT Allocator)
+        : MAllocator(std::unique_ptr<holder_base>(
+              new holder<AllocatorT>(Allocator))){};
+
+    template <typename AllocatorT>
+    SYCLMemObjAllocator()
+        : MAllocator(std::unique_ptr<holder_base>(
+              new holder<AllocatorT>(AllocatorT()))){};
+
+    void *allocate(std::size_t Count) { return MAllocator->allocate(Count); }
+
+    void deallocate(void *Ptr, std::size_t Count) {
+      MAllocator->deallocate(Ptr, Count);
+    }
+
+    void setAlignment(std::size_t RequiredAlignment) {
+      MAllocator->setAlignment(RequiredAlignment);
+    }
+
+    template <typename AllocatorT> AllocatorT getAllocator() {
+      return *reinterpret_cast<AllocatorT *>(MAllocator->getAllocator());
+    }
+
+    std::size_t getValueSize() const { return MAllocator->getValueSize(); }
+
+  private:
+    std::unique_ptr<holder_base> MAllocator;
+  };
+
+  } // namespace detail
+  } // namespace sycl
+}

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
@@ -1,98 +1,108 @@
+//==------- sycl_mem_obj_allocator.hpp - SYCL standard header file ---------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #pragma once
 
 __SYCL_INLINE namespace cl {
-  namespace sycl {
+namespace sycl {
+namespace detail {
 
-  namespace detail {
+template <typename T>
+class aligned_allocator;
 
-  class SYCLMemObjAllocator {
-    class holder_base {
-    public:
-      virtual ~holder_base() = default;
-      virtual void *allocate(std::size_t) = 0;
-      virtual void deallocate(void *, std::size_t) = 0;
-      virtual void setAlignment(std::size_t) = 0;
-      virtual void *getAllocator() = 0;
-      virtual std::size_t getValueSize() const = 0;
-    };
-
-    template <typename AllocatorT> class holder : public holder_base {
-      using sycl_memory_object_allocator = detail::aligned_allocator<char>;
-
-      template <typename T>
-      using EnableIfDefaultAllocator =
-          enable_if_t<std::is_same<T, sycl_memory_object_allocator>::value>;
-
-      template <typename T>
-      using EnableIfNonDefaultAllocator =
-          enable_if_t<!std::is_same<T, sycl_memory_object_allocator>::value>;
-
-    public:
-      holder(AllocatorT Allocator)
-          : MAllocator(Allocator),
-            MValueSize(sizeof(typename AllocatorT::value_type)){};
-      ~holder() = default;
-      virtual void *allocate(std::size_t Count) override {
-        return reinterpret_cast<void *>(MAllocator.allocate(Count));
-      }
-      virtual void deallocate(void *Ptr, std::size_t Count) override {
-        MAllocator.deallocate(
-            reinterpret_cast<typename AllocatorT::value_type *>(Ptr), Count);
-      }
-
-      void setAlignment(std::size_t RequiredAlign) override {
-        setAlignImpl(RequiredAlign);
-      }
-
-      virtual void *getAllocator() override { return &MAllocator; }
-
-      virtual std::size_t getValueSize() const override { return MValueSize; }
-
-    private:
-      template <typename T = AllocatorT>
-      EnableIfNonDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
-        // Do nothing in case of user's allocator.
-      }
-
-      template <typename T = AllocatorT>
-      EnableIfDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
-        MAllocator.setAlignment(std::max<size_t>(RequiredAlign, 64));
-      }
-      AllocatorT MAllocator;
-      std::size_t MValueSize;
-    };
-
+class SYCLMemObjAllocator {
+  class holder_base {
   public:
-    template <typename AllocatorT>
-    SYCLMemObjAllocator(AllocatorT Allocator)
-        : MAllocator(std::unique_ptr<holder_base>(
-              new holder<AllocatorT>(Allocator))){};
-
-    template <typename AllocatorT>
-    SYCLMemObjAllocator()
-        : MAllocator(std::unique_ptr<holder_base>(
-              new holder<AllocatorT>(AllocatorT()))){};
-
-    void *allocate(std::size_t Count) { return MAllocator->allocate(Count); }
-
-    void deallocate(void *Ptr, std::size_t Count) {
-      MAllocator->deallocate(Ptr, Count);
-    }
-
-    void setAlignment(std::size_t RequiredAlignment) {
-      MAllocator->setAlignment(RequiredAlignment);
-    }
-
-    template <typename AllocatorT> AllocatorT getAllocator() {
-      return *reinterpret_cast<AllocatorT *>(MAllocator->getAllocator());
-    }
-
-    std::size_t getValueSize() const { return MAllocator->getValueSize(); }
-
-  private:
-    std::unique_ptr<holder_base> MAllocator;
+    virtual ~holder_base() = default;
+    virtual void *allocate(std::size_t) = 0;
+    virtual void deallocate(void *, std::size_t) = 0;
+    virtual void setAlignment(std::size_t) = 0;
+    virtual void *getAllocator() = 0;
+    virtual std::size_t getValueSize() const = 0;
   };
 
-  } // namespace detail
-  } // namespace sycl
+  template <typename AllocatorT> class holder : public holder_base {
+    using sycl_memory_object_allocator = detail::aligned_allocator<char>;
+
+    template <typename T>
+    using EnableIfDefaultAllocator =
+        enable_if_t<std::is_same<T, sycl_memory_object_allocator>::value>;
+
+    template <typename T>
+    using EnableIfNonDefaultAllocator =
+        enable_if_t<!std::is_same<T, sycl_memory_object_allocator>::value>;
+
+  public:
+    holder(AllocatorT Allocator)
+        : MAllocator(Allocator),
+          MValueSize(sizeof(typename AllocatorT::value_type)){};
+    ~holder() = default;
+    virtual void *allocate(std::size_t Count) override {
+      return reinterpret_cast<void *>(MAllocator.allocate(Count));
+    }
+    virtual void deallocate(void *Ptr, std::size_t Count) override {
+      MAllocator.deallocate(
+          reinterpret_cast<typename AllocatorT::value_type *>(Ptr), Count);
+    }
+
+    void setAlignment(std::size_t RequiredAlign) override {
+      setAlignImpl(RequiredAlign);
+    }
+
+    virtual void *getAllocator() override { return &MAllocator; }
+
+    virtual std::size_t getValueSize() const override { return MValueSize; }
+
+  private:
+    template <typename T = AllocatorT>
+    EnableIfNonDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
+      // Do nothing in case of user's allocator.
+    }
+
+    template <typename T = AllocatorT>
+    EnableIfDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
+      MAllocator.setAlignment(std::max<size_t>(RequiredAlign, 64));
+    }
+    AllocatorT MAllocator;
+    std::size_t MValueSize;
+  };
+
+public:
+  template <typename AllocatorT>
+  SYCLMemObjAllocator(AllocatorT Allocator)
+      : MAllocator(std::unique_ptr<holder_base>(
+            new holder<AllocatorT>(Allocator))){};
+
+  template <typename AllocatorT>
+  SYCLMemObjAllocator()
+      : MAllocator(std::unique_ptr<holder_base>(
+            new holder<AllocatorT>(AllocatorT()))){};
+
+  void *allocate(std::size_t Count) { return MAllocator->allocate(Count); }
+
+  void deallocate(void *Ptr, std::size_t Count) {
+    MAllocator->deallocate(Ptr, Count);
+  }
+
+  void setAlignment(std::size_t RequiredAlignment) {
+    MAllocator->setAlignment(RequiredAlignment);
+  }
+
+  template <typename AllocatorT> AllocatorT getAllocator() {
+    return *reinterpret_cast<AllocatorT *>(MAllocator->getAllocator());
+  }
+
+  std::size_t getValueSize() const { return MAllocator->getValueSize(); }
+
+private:
+  std::unique_ptr<holder_base> MAllocator;
+};
+
+} // namespace detail
+} // namespace sycl
 }

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
@@ -80,12 +80,12 @@ public:
   template <typename AllocatorT>
   SYCLMemObjAllocator(AllocatorT Allocator)
       : MAllocator(std::unique_ptr<holder_base>(
-            new holder<AllocatorT>(Allocator))){};
+            new holder<AllocatorT>(Allocator))){}
 
   template <typename AllocatorT>
   SYCLMemObjAllocator()
       : MAllocator(std::unique_ptr<holder_base>(
-            new holder<AllocatorT>(AllocatorT()))){};
+            new holder<AllocatorT>(AllocatorT()))){}
 
   void *allocate(std::size_t Count) { return MAllocator->allocate(Count); }
 

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <CL/cl.h>
 #include <CL/sycl/detail/pi.hpp>
 #include <memory>
 

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
@@ -28,6 +28,8 @@ using ContextImplPtr = std::shared_ptr<detail::context_impl>;
 // objects.
 class SYCLMemObjI {
 public:
+  virtual ~SYCLMemObjI() = default;
+
   enum MemObjType { BUFFER, IMAGE };
 
   virtual MemObjType getType() const = 0;

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -16,8 +16,8 @@
 #include <CL/sycl/property_list.hpp>
 #include <CL/sycl/stl.hpp>
 
-#include <type_traits>
 #include <cstring>
+#include <type_traits>
 
 __SYCL_INLINE namespace cl {
 namespace sycl {

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -16,8 +16,6 @@
 #include <CL/sycl/property_list.hpp>
 #include <CL/sycl/stl.hpp>
 
-#include <CL/sycl/detail/event_impl.hpp>
-
 #include <type_traits>
 #include <cstring>
 

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -79,6 +79,8 @@ public:
       : SYCLMemObjT(MemObject, SyclContext, /*SizeInBytes*/ 0, AvailableEvent,
                     std::move(Allocator)) {}
 
+  virtual ~SYCLMemObjT() = default;
+
   size_t getSize() const override { return MSizeInBytes; }
   size_t get_count() const {
     size_t AllocatorValueSize = MAllocator.getValueSize();

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -16,7 +16,10 @@
 #include <CL/sycl/property_list.hpp>
 #include <CL/sycl/stl.hpp>
 
+#include <CL/sycl/detail/event_impl.hpp>
+
 #include <type_traits>
+#include <cstring>
 
 __SYCL_INLINE namespace cl {
 namespace sycl {

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -67,7 +67,8 @@ public:
         MSizeInBytes(SizeInBytes), MUserPtr(nullptr), MShadowCopy(nullptr),
         MUploadDataFunctor(nullptr), MSharedPtrStorage(nullptr) {}
 
-  SYCLMemObjT(const property_list &Props, unique_ptr_class<SYCLMemObjAllocator> Allocator)
+  SYCLMemObjT(const property_list &Props,
+              unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : SYCLMemObjT(/*SizeInBytes*/ 0, Props, std::move(Allocator)) {}
 
   SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
@@ -75,7 +76,8 @@ public:
               unique_ptr_class<SYCLMemObjAllocator> Allocator);
 
   SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
-              event AvailableEvent, unique_ptr_class<SYCLMemObjAllocator> Allocator)
+              event AvailableEvent,
+              unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : SYCLMemObjT(MemObject, SyclContext, /*SizeInBytes*/ 0, AvailableEvent,
                     std::move(Allocator)) {}
 

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -277,7 +277,7 @@ protected:
   // Copy of memory passed by user to constructor.
   void *MShadowCopy;
   // Function which update host with final data on memory object destruction.
-  std::function<void(void)> MUploadDataFunctor;
+  function_class<void(void)> MUploadDataFunctor;
   // Field which holds user's shared_ptr in case of memory object is created
   // using constructor with shared_ptr.
   shared_ptr_class<const void> MSharedPtrStorage;

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -124,9 +124,7 @@ public:
   template <typename T> void set_final_data(weak_ptr_class<T> FinalData) {
     MUploadDataFunctor = [this, FinalData]() {
       if (shared_ptr_class<T> LockedFinalData = FinalData.lock()) {
-        EventImplPtr Event = updateHostMemory(LockedFinalData.get());
-        if (Event)
-          Event->wait(Event);
+        updateHostMemory(LockedFinalData.get());
       }
     };
   }
@@ -135,9 +133,7 @@ public:
     MUploadDataFunctor = [this]() {
       if (!MSharedPtrStorage.unique()) {
         void *FinalData = const_cast<void *>(MSharedPtrStorage.get());
-        EventImplPtr Event = updateHostMemory(FinalData);
-        if (Event)
-          Event->wait(Event);
+        updateHostMemory(FinalData);
       }
     };
   }
@@ -148,9 +144,7 @@ public:
       MUploadDataFunctor = nullptr;
     else
       MUploadDataFunctor = [this, FinalData]() {
-        EventImplPtr Event = updateHostMemory(FinalData);
-        if (Event)
-          Event->wait(Event);
+        updateHostMemory(FinalData);
       };
   }
 
@@ -163,16 +157,13 @@ public:
       // continuous data.
       const size_t Size = MSizeInBytes / sizeof(DestinationValueT);
       vector_class<DestinationValueT> ContiguousStorage(Size);
-      EventImplPtr Event = updateHostMemory(ContiguousStorage.data());
-      if (Event) {
-        Event->wait(Event);
-        std::copy(ContiguousStorage.cbegin(), ContiguousStorage.cend(),
-                  FinalData);
-      }
+      updateHostMemory(ContiguousStorage.data());
+      std::copy(ContiguousStorage.cbegin(), ContiguousStorage.cend(),
+                FinalData);
     };
   }
 
-  EventImplPtr updateHostMemory(void *const Ptr);
+  void updateHostMemory(void *const Ptr);
 
   // Update host with the latest data + notify scheduler that the memory object
   // is going to die. After this method is finished no further operations with

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -63,14 +63,14 @@ class image {
 public:
   image(image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
-        Order, Type, Range, PropList);
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
+        Order, Type, Range, AllocatorT(), PropList);
   }
 
   image(image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, AllocatorT Allocator,
         const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
         Order, Type, Range, Allocator, PropList);
   }
 
@@ -80,8 +80,8 @@ public:
         const range<Dimensions> &Range,
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
-        Order, Type, Range, Pitch, PropList);
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
+        Order, Type, Range, Pitch, AllocatorT(), PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -90,34 +90,34 @@ public:
         const range<Dimensions> &Range,
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
         Order, Type, Range, Pitch, Allocator, PropList);
   }
 
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
-        HostPointer, Order, Type, Range, PropList);
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
+        HostPointer, Order, Type, Range, AllocatorT(), PropList);
   }
 
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, AllocatorT Allocator,
         const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Allocator, PropList);
   }
 
   image(const void *HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
-        HostPointer, Order, Type, Range, PropList);
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
+        HostPointer, Order, Type, Range, AllocatorT(), PropList);
   }
 
   image(const void *HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         AllocatorT Allocator, const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Allocator, PropList);
   }
 
@@ -127,8 +127,8 @@ public:
         const range<Dimensions> &Range,
         typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
-        HostPointer, Order, Type, Range, Pitch, PropList);
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
+        HostPointer, Order, Type, Range, Pitch, AllocatorT(), PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -137,21 +137,21 @@ public:
         const range<Dimensions> &Range,
         typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Pitch, Allocator, PropList);
   }
 
   image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
-        HostPointer, Order, Type, Range, PropList);
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
+        HostPointer, Order, Type, Range, AllocatorT(), PropList);
   }
 
   image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         AllocatorT Allocator, const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Allocator, PropList);
   }
 
@@ -161,8 +161,8 @@ public:
         image_channel_type Type, const range<Dimensions> &Range,
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
-        HostPointer, Order, Type, Range, Pitch, PropList);
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
+        HostPointer, Order, Type, Range, Pitch, AllocatorT(), PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -171,14 +171,14 @@ public:
         image_channel_type Type, const range<Dimensions> &Range,
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Pitch, Allocator, PropList);
   }
 
   image(cl_mem ClMemObject, const context &SyclContext,
         event AvailableEvent = {}) {
-    impl = std::make_shared<detail::image_impl<Dimensions, AllocatorT>>(
-        ClMemObject, SyclContext, AvailableEvent);
+    impl = std::make_shared<detail::image_impl<Dimensions>>(
+        ClMemObject, SyclContext, AvailableEvent, AllocatorT());
   }
 
   /* -- common interface members -- */
@@ -227,15 +227,15 @@ public:
   accessor<detail::EnableIfImgAccDataT<DataT>, Dimensions, AccessMode,
            access::target::image, access::placeholder::false_t>
   get_access(handler &commandGroupHandler) {
-    return impl->template get_access<DataT, AccessMode>(*this,
-                                                        commandGroupHandler);
+    return impl->template get_access<DataT, AllocatorT, AccessMode>(
+        *this, commandGroupHandler);
   }
 
   template <typename DataT, access::mode AccessMode>
   accessor<detail::EnableIfImgAccDataT<DataT>, Dimensions, AccessMode,
            access::target::host_image, access::placeholder::false_t>
   get_access() {
-    return impl->template get_access<DataT, AccessMode>(*this);
+    return impl->template get_access<DataT, AllocatorT, AccessMode>(*this);
   }
 
   template <typename Destination = std::nullptr_t>
@@ -246,7 +246,7 @@ public:
   void set_write_back(bool flag = true) { impl->set_write_back(flag); }
 
 private:
-  shared_ptr_class<detail::image_impl<Dimensions, AllocatorT>> impl;
+  shared_ptr_class<detail::image_impl<Dimensions>> impl;
 
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
@@ -259,8 +259,7 @@ namespace std {
 template <int Dimensions, typename AllocatorT>
 struct hash<cl::sycl::image<Dimensions, AllocatorT>> {
   size_t operator()(const cl::sycl::image<Dimensions, AllocatorT> &I) const {
-    return hash<std::shared_ptr<
-        cl::sycl::detail::image_impl<Dimensions, AllocatorT>>>()(
+    return hash<std::shared_ptr<cl::sycl::detail::image_impl<Dimensions>>>()(
         cl::sycl::detail::getSyclObjImpl(I));
   }
 };

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -227,15 +227,16 @@ public:
   accessor<detail::EnableIfImgAccDataT<DataT>, Dimensions, AccessMode,
            access::target::image, access::placeholder::false_t>
   get_access(handler &commandGroupHandler) {
-    return impl->template get_access<DataT, AllocatorT, AccessMode>(
-        *this, commandGroupHandler);
+    return accessor<DataT, Dimensions, AccessMode, access::target::image,
+                    access::placeholder::false_t>(*this, commandGroupHandler);
   }
 
   template <typename DataT, access::mode AccessMode>
   accessor<detail::EnableIfImgAccDataT<DataT>, Dimensions, AccessMode,
            access::target::host_image, access::placeholder::false_t>
   get_access() {
-    return impl->template get_access<DataT, AllocatorT, AccessMode>(*this);
+    return accessor<DataT, Dimensions, AccessMode, access::target::host_image,
+                    access::placeholder::false_t>(*this);
   }
 
   template <typename Destination = std::nullptr_t>

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -64,14 +64,14 @@ public:
   image(image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        Order, Type, Range, AllocatorT(), PropList);
+        Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
   }
 
   image(image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, AllocatorT Allocator,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        Order, Type, Range, Allocator, PropList);
+        Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -81,7 +81,7 @@ public:
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        Order, Type, Range, Pitch, AllocatorT(), PropList);
+        Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -91,34 +91,34 @@ public:
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        Order, Type, Range, Pitch, Allocator, PropList);
+        Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
   }
 
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, AllocatorT(), PropList);
+        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
   }
 
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, AllocatorT Allocator,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Allocator, PropList);
+        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
   }
 
   image(const void *HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, AllocatorT(), PropList);
+        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
   }
 
   image(const void *HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Allocator, PropList);
+        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -128,7 +128,7 @@ public:
         typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Pitch, AllocatorT(), PropList);
+        HostPointer, Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -138,21 +138,21 @@ public:
         typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Pitch, Allocator, PropList);
+        HostPointer, Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
   }
 
   image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, AllocatorT(), PropList);
+        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
   }
 
   image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Allocator, PropList);
+        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -162,7 +162,7 @@ public:
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Pitch, AllocatorT(), PropList);
+        HostPointer, Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -172,13 +172,13 @@ public:
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Pitch, Allocator, PropList);
+        HostPointer, Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
   }
 
   image(cl_mem ClMemObject, const context &SyclContext,
         event AvailableEvent = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        ClMemObject, SyclContext, AvailableEvent, AllocatorT());
+        ClMemObject, SyclContext, AvailableEvent,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   /* -- common interface members -- */

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -257,7 +257,9 @@ public:
   size_t get_count() const { return impl->get_count(); }
 
   // Returns the allocator provided to the image
-  AllocatorT get_allocator() const { return impl->get_allocator(); }
+  AllocatorT get_allocator() const {
+    return impl->template get_allocator<AllocatorT>();
+  }
 
   template <typename DataT, access::mode AccessMode>
   accessor<detail::EnableIfImgAccDataT<DataT>, Dimensions, AccessMode,

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -64,14 +64,19 @@ public:
   image(image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
+        Order, Type, Range,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(),
+        PropList);
   }
 
   image(image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, AllocatorT Allocator,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
+        Order, Type, Range,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            Allocator),
+        PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -81,7 +86,9 @@ public:
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
+        Order, Type, Range, Pitch,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(),
+        PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -91,34 +98,47 @@ public:
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
+        Order, Type, Range, Pitch,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            Allocator),
+        PropList);
   }
 
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
+        HostPointer, Order, Type, Range,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(),
+        PropList);
   }
 
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range, AllocatorT Allocator,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
+        HostPointer, Order, Type, Range,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            Allocator),
+        PropList);
   }
 
   image(const void *HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
+        HostPointer, Order, Type, Range,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(),
+        PropList);
   }
 
   image(const void *HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
+        HostPointer, Order, Type, Range,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            Allocator),
+        PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -128,7 +148,9 @@ public:
         typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
+        HostPointer, Order, Type, Range, Pitch,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(),
+        PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -138,21 +160,29 @@ public:
         typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
+        HostPointer, Order, Type, Range, Pitch,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            Allocator),
+        PropList);
   }
 
   image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
+        HostPointer, Order, Type, Range,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(),
+        PropList);
   }
 
   image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
+        HostPointer, Order, Type, Range,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            Allocator),
+        PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -162,7 +192,9 @@ public:
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(), PropList);
+        HostPointer, Order, Type, Range, Pitch,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(),
+        PropList);
   }
 
   /* Available only when: dimensions >1 */
@@ -172,13 +204,17 @@ public:
         const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        HostPointer, Order, Type, Range, Pitch,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(Allocator), PropList);
+        HostPointer, Order, Type, Range, Pitch,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
+            Allocator),
+        PropList);
   }
 
   image(cl_mem ClMemObject, const context &SyclContext,
         event AvailableEvent = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
-        ClMemObject, SyclContext, AvailableEvent,  make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
+        ClMemObject, SyclContext, AvailableEvent,
+        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
   }
 
   /* -- common interface members -- */

--- a/sycl/include/CL/sycl/stl.hpp
+++ b/sycl/include/CL/sycl/stl.hpp
@@ -47,7 +47,7 @@ namespace sycl {
  using exception_ptr_class = std::exception_ptr;
 
  template <typename T, typename... ArgsT>
- unique_ptr_class<T> make_unique_ptr(ArgsT && ... Args) {
+ unique_ptr_class<T> make_unique_ptr(ArgsT &&... Args) {
    return unique_ptr_class<T>(new T(std::forward<ArgsT>(Args)...));
  }
 } // sycl

--- a/sycl/include/CL/sycl/stl.hpp
+++ b/sycl/include/CL/sycl/stl.hpp
@@ -46,6 +46,10 @@ namespace sycl {
 
  using exception_ptr_class = std::exception_ptr;
 
+ template <typename T, typename... ArgsT>
+ unique_ptr_class<T> make_unique_ptr(ArgsT && ... Args) {
+   return unique_ptr_class<T>(new T(std::forward<ArgsT>(Args)...));
+ }
 } // sycl
 } // cl
 

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -42,6 +42,7 @@ endfunction(add_sycl_rt_library)
 set(SYCL_SOURCES
     "${sycl_inc_dir}/CL/sycl.hpp"
     "detail/accessor_impl.cpp"
+    "detail/buffer_impl.cpp"
     "detail/builtins_common.cpp"
     "detail/builtins_geometric.cpp"
     "detail/builtins_integer.cpp"

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -76,6 +76,7 @@ set(SYCL_SOURCES
     "detail/scheduler/scheduler.cpp"
     "detail/scheduler/graph_processor.cpp"
     "detail/scheduler/graph_builder.cpp"
+    "detail/sycl_mem_obj_t.cpp"
     "detail/usm/clusm.cpp"
     "detail/usm/usm_dispatch.cpp"
     "detail/usm/usm_impl.cpp"

--- a/sycl/source/detail/buffer_impl.cpp
+++ b/sycl/source/detail/buffer_impl.cpp
@@ -1,0 +1,37 @@
+//==----------------- buffer_impl.cpp - SYCL standard header file ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl/detail/buffer_impl.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
+#include <CL/sycl/detail/memory_manager.hpp>
+#include <CL/sycl/detail/scheduler/scheduler.hpp>
+
+__SYCL_INLINE namespace cl {
+namespace sycl {
+namespace detail {
+void *buffer_impl::allocateMem(ContextImplPtr Context, bool InitFromUserData,
+                  void *HostPtr, RT::PiEvent &OutEventToWait) {
+
+  assert(!(InitFromUserData && HostPtr) &&
+          "Cannot init from user data and reuse host ptr provided "
+          "simultaneously");
+
+  void *UserPtr = InitFromUserData ? BaseT::getUserPtr() : HostPtr;
+
+  assert(!(nullptr == UserPtr && BaseT::useHostPtr() && Context->is_host()) &&
+          "Internal error. Allocating memory on the host "
+          "while having use_host_ptr property");
+
+  return MemoryManager::allocateMemBuffer(
+      std::move(Context), this, UserPtr, BaseT::MHostPtrReadOnly,
+      BaseT::getSize(), BaseT::MInteropEvent, BaseT::MInteropContext,
+      OutEventToWait);
+}
+} // namespace detail
+} // namespace sycl
+} // namespace cl

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -404,6 +404,12 @@ bool image_impl<Dimensions>::checkImageFormat(
   return true;
 }
 
+template <int Dimensions>
+vector_class<device>
+image_impl<Dimensions>::getDevices(const ContextImplPtr Context) {
+  return Context->get_info<info::context::devices>();
+}
+
 template class image_impl<1>;
 template class image_impl<2>;
 template class image_impl<3>;

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -233,9 +233,9 @@ image_channel_type convertChannelType(RT::PiMemImageChannelType Type) {
 }
 
 template <int Dimensions>
-image_impl<Dimensions>::image_impl(cl_mem MemObject, const context &SyclContext,
-                                   event AvailableEvent,
-                                   unique_ptr_class<SYCLMemObjAllocator> Allocator)
+image_impl<Dimensions>::image_impl(
+    cl_mem MemObject, const context &SyclContext, event AvailableEvent,
+    unique_ptr_class<SYCLMemObjAllocator> Allocator)
     : BaseT(MemObject, SyclContext, std::move(AvailableEvent),
             std::move(Allocator)),
       MRange(InitializedVal<Dimensions, range>::template get<0>()) {

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/sycl/detail/context_impl.hpp>
+#include <CL/sycl/detail/image_impl.hpp>
+#include <CL/sycl/detail/memory_manager.hpp>
+#include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/image.hpp>
 
 __SYCL_INLINE namespace cl {
@@ -228,6 +232,175 @@ image_channel_type convertChannelType(RT::PiMemImageChannelType Type) {
   }
 }
 
+template <int Dimensions>
+image_impl<Dimensions>::image_impl(cl_mem MemObject, const context &SyclContext,
+                                   event AvailableEvent,
+                                   SYCLMemObjAllocator Allocator)
+    : BaseT(MemObject, SyclContext, std::move(AvailableEvent),
+            std::move(Allocator)),
+      MRange(InitializedVal<Dimensions, range>::template get<0>()) {
+  RT::PiMem Mem = pi::cast<RT::PiMem>(BaseT::MInteropMemObject);
+  PI_CALL(piMemGetInfo)(Mem, CL_MEM_SIZE, sizeof(size_t),
+                        &(BaseT::MSizeInBytes), nullptr);
+
+  RT::PiMemImageFormat Format;
+  getImageInfo(PI_IMAGE_INFO_FORMAT, Format);
+  MOrder = detail::convertChannelOrder(Format.image_channel_order);
+  MType = detail::convertChannelType(Format.image_channel_data_type);
+  MNumChannels = getImageNumberChannels(MOrder);
+
+  getImageInfo(PI_IMAGE_INFO_ELEMENT_SIZE, MElementSize);
+  assert(getImageElementSize(MNumChannels, MType) == MElementSize);
+
+  getImageInfo(PI_IMAGE_INFO_ROW_PITCH, MRowPitch);
+  getImageInfo(PI_IMAGE_INFO_SLICE_PITCH, MSlicePitch);
+
+  switch (Dimensions) {
+  case 3:
+    getImageInfo(PI_IMAGE_INFO_DEPTH, MRange[2]);
+  case 2:
+    getImageInfo(PI_IMAGE_INFO_HEIGHT, MRange[1]);
+  case 1:
+    getImageInfo(PI_IMAGE_INFO_WIDTH, MRange[0]);
+  }
+}
+
+template <int Dimensions>
+void *image_impl<Dimensions>::allocateMem(ContextImplPtr Context,
+                                          bool InitFromUserData, void *HostPtr,
+                                          RT::PiEvent &OutEventToWait) {
+
+  assert(!(InitFromUserData && HostPtr) &&
+         "Cannot init from user data and reuse host ptr provided "
+         "simultaneously");
+
+  void *UserPtr = InitFromUserData ? BaseT::getUserPtr() : HostPtr;
+
+  RT::PiMemImageDesc Desc = getImageDesc(UserPtr != nullptr);
+  assert(checkImageDesc(Desc, Context, UserPtr) &&
+         "The check an image desc failed.");
+
+  RT::PiMemImageFormat Format = getImageFormat();
+  assert(checkImageFormat(Format, Context) &&
+         "The check an image format failed.");
+
+  return MemoryManager::allocateMemImage(
+      std::move(Context), this, UserPtr, BaseT::MHostPtrReadOnly,
+      BaseT::getSize(), Desc, Format, BaseT::MInteropEvent,
+      BaseT::MInteropContext, OutEventToWait);
+}
+
+template <int Dimensions>
+bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
+                                            ContextImplPtr Context,
+                                            void *UserPtr) {
+  if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE1D, PI_MEM_TYPE_IMAGE1D_ARRAY,
+               PI_MEM_TYPE_IMAGE2D_ARRAY, PI_MEM_TYPE_IMAGE2D) &&
+      !checkImageValueRange<info::device::image2d_max_width>(Context,
+                                                             Desc.image_width))
+    throw invalid_parameter_error(
+        "For a 1D/2D image/image array, the width must be a Value >= 1 and "
+        "<= CL_DEVICE_IMAGE2D_MAX_WIDTH.");
+
+  if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE3D) &&
+      !checkImageValueRange<info::device::image3d_max_width>(Context,
+                                                             Desc.image_width))
+    throw invalid_parameter_error(
+        "For a 3D image, the width must be a Value >= 1 and <= "
+        "CL_DEVICE_IMAGE3D_MAX_WIDTH");
+
+  if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE2D,
+               PI_MEM_TYPE_IMAGE2D_ARRAY) &&
+      !checkImageValueRange<info::device::image2d_max_height>(
+          Context, Desc.image_height))
+    throw invalid_parameter_error("For a 2D image or image array, the height "
+                                  "must be a Value >= 1 and <= "
+                                  "CL_DEVICE_IMAGE2D_MAX_HEIGHT");
+
+  if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE3D) &&
+      !checkImageValueRange<info::device::image3d_max_height>(
+          Context, Desc.image_height))
+    throw invalid_parameter_error(
+        "For a 3D image, the heightmust be a Value >= 1 and <= "
+        "CL_DEVICE_IMAGE3D_MAX_HEIGHT");
+
+  if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE3D) &&
+      !checkImageValueRange<info::device::image3d_max_depth>(Context,
+                                                             Desc.image_depth))
+    throw invalid_parameter_error(
+        "For a 3D image, the depth must be a Value >= 1 and <= "
+        "CL_DEVICE_IMAGE3D_MAX_DEPTH");
+
+  if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE1D_ARRAY,
+               PI_MEM_TYPE_IMAGE2D_ARRAY) &&
+      !checkImageValueRange<info::device::image_max_array_size>(
+          Context, Desc.image_array_size))
+    throw invalid_parameter_error(
+        "For a 1D and 2D image array, the array_size must be a "
+        "Value >= 1 and <= "
+        "CL_DEVICE_IMAGE_MAX_ARRAY_SIZE.");
+
+  if ((nullptr == UserPtr) && (0 != Desc.image_row_pitch))
+    throw invalid_parameter_error(
+        "The row_pitch must be 0 if host_ptr is nullptr.");
+
+  if ((nullptr == UserPtr) && (0 != Desc.image_slice_pitch))
+    throw invalid_parameter_error(
+        "The slice_pitch must be 0 if host_ptr is nullptr.");
+
+  if (0 != Desc.num_mip_levels)
+    throw invalid_parameter_error("The mip_levels must be 0.");
+
+  if (0 != Desc.num_samples)
+    throw invalid_parameter_error("The num_samples must be 0.");
+
+  if (nullptr != Desc.buffer)
+    throw invalid_parameter_error(
+        "The buffer must be nullptr, because SYCL does not support "
+        "image creation from memory objects.");
+
+  return true;
+}
+
+template <int Dimensions>
+bool image_impl<Dimensions>::checkImageFormat(
+    const RT::PiMemImageFormat &Format, ContextImplPtr Context) {
+  if (checkAny(Format.image_channel_order, PI_IMAGE_CHANNEL_ORDER_INTENSITY,
+               PI_IMAGE_CHANNEL_ORDER_LUMINANCE) &&
+      !checkAny(
+          Format.image_channel_data_type, PI_IMAGE_CHANNEL_TYPE_UNORM_INT8,
+          PI_IMAGE_CHANNEL_TYPE_UNORM_INT16, PI_IMAGE_CHANNEL_TYPE_SNORM_INT8,
+          PI_IMAGE_CHANNEL_TYPE_SNORM_INT16, PI_IMAGE_CHANNEL_TYPE_HALF_FLOAT,
+          PI_IMAGE_CHANNEL_TYPE_FLOAT))
+    throw invalid_parameter_error(
+        "CL_INTENSITY or CL_LUMINANCE format can only be used if channel "
+        "data type = CL_UNORM_INT8, CL_UNORM_INT16, CL_SNORM_INT8, "
+        "CL_SNORM_INT16, CL_HALF_FLOAT, or CL_FLOAT. ");
+
+  if (checkAny(Format.image_channel_order, PI_IMAGE_CHANNEL_ORDER_RGB,
+               PI_IMAGE_CHANNEL_ORDER_RGBx) &&
+      !checkAny(Format.image_channel_data_type,
+                PI_IMAGE_CHANNEL_TYPE_UNORM_SHORT_565,
+                PI_IMAGE_CHANNEL_TYPE_UNORM_SHORT_555,
+                PI_IMAGE_CHANNEL_TYPE_UNORM_INT_101010))
+    throw invalid_parameter_error(
+        "CL_RGB or CL_RGBx	These formats can only be used if channel data "
+        "type = CL_UNORM_SHORT_565, CL_UNORM_SHORT_555 or "
+        "CL_UNORM_INT_101010. ");
+
+  if (checkAny(Format.image_channel_order, PI_IMAGE_CHANNEL_ORDER_ARGB,
+               PI_IMAGE_CHANNEL_ORDER_BGRA, PI_IMAGE_CHANNEL_ORDER_ABGR) &&
+      !checkAny(
+          Format.image_channel_data_type, PI_IMAGE_CHANNEL_TYPE_UNORM_INT8,
+          PI_IMAGE_CHANNEL_TYPE_SNORM_INT8, PI_IMAGE_CHANNEL_TYPE_SIGNED_INT8,
+          PI_IMAGE_CHANNEL_TYPE_UNSIGNED_INT8))
+    throw invalid_parameter_error(
+        "CL_ARGB, CL_BGRA, CL_ABGR	These formats can only be used if "
+        "channel data type = CL_UNORM_INT8, CL_SNORM_INT8, CL_SIGNED_INT8 "
+        "or CL_UNSIGNED_INT8.");
+
+  return true;
+}
 } // namespace detail
 } // namespace sycl
 } // namespace cl

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -235,7 +235,7 @@ image_channel_type convertChannelType(RT::PiMemImageChannelType Type) {
 template <int Dimensions>
 image_impl<Dimensions>::image_impl(cl_mem MemObject, const context &SyclContext,
                                    event AvailableEvent,
-                                   SYCLMemObjAllocator Allocator)
+                                   unique_ptr_class<SYCLMemObjAllocator> Allocator)
     : BaseT(MemObject, SyclContext, std::move(AvailableEvent),
             std::move(Allocator)),
       MRange(InitializedVal<Dimensions, range>::template get<0>()) {

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -258,8 +258,10 @@ image_impl<Dimensions>::image_impl(cl_mem MemObject, const context &SyclContext,
   switch (Dimensions) {
   case 3:
     getImageInfo(PI_IMAGE_INFO_DEPTH, MRange[2]);
+    // fall through
   case 2:
     getImageInfo(PI_IMAGE_INFO_HEIGHT, MRange[1]);
+    // fall through
   case 1:
     getImageInfo(PI_IMAGE_INFO_WIDTH, MRange[0]);
   }
@@ -401,6 +403,11 @@ bool image_impl<Dimensions>::checkImageFormat(
 
   return true;
 }
+
+template class image_impl<1>;
+template class image_impl<2>;
+template class image_impl<3>;
+
 } // namespace detail
 } // namespace sycl
 } // namespace cl

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -45,7 +45,7 @@ void SYCLMemObjT::releaseMem(ContextImplPtr Context, void *MemAllocation) {
   return MemoryManager::releaseMemObj(Context, this, MemAllocation, Ptr);
 }
 
-EventImplPtr SYCLMemObjT::updateHostMemory(void *const Ptr) {
+void SYCLMemObjT::updateHostMemory(void *const Ptr) {
   const id<3> Offset{0, 0, 0};
   const range<3> AccessRange{MSizeInBytes, 1, 1};
   const range<3> MemoryRange{MSizeInBytes, 1, 1};
@@ -59,7 +59,8 @@ EventImplPtr SYCLMemObjT::updateHostMemory(void *const Ptr) {
   Req.MData = Ptr;
 
   EventImplPtr Event = Scheduler::getInstance().addCopyBack(&Req);
-  return Event;
+  if (Event)
+    Event->wait(Event);
 }
 
 void SYCLMemObjT::updateHostMemory() {

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -15,15 +15,15 @@ __SYCL_INLINE namespace cl {
 namespace sycl {
 namespace detail {
 SYCLMemObjT::SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
-            const size_t SizeInBytes, event AvailableEvent,
-            unique_ptr_class<SYCLMemObjAllocator> Allocator)
+                         const size_t SizeInBytes, event AvailableEvent,
+                         unique_ptr_class<SYCLMemObjAllocator> Allocator)
     : MAllocator(std::move(Allocator)), MProps(),
       MInteropEvent(detail::getSyclObjImpl(std::move(AvailableEvent))),
       MInteropContext(detail::getSyclObjImpl(SyclContext)),
       MInteropMemObject(MemObject), MOpenCLInterop(true),
-      MHostPtrReadOnly(false), MNeedWriteBack(true),
-      MSizeInBytes(SizeInBytes), MUserPtr(nullptr), MShadowCopy(nullptr),
-      MUploadDataFunctor(nullptr), MSharedPtrStorage(nullptr) {
+      MHostPtrReadOnly(false), MNeedWriteBack(true), MSizeInBytes(SizeInBytes),
+      MUserPtr(nullptr), MShadowCopy(nullptr), MUploadDataFunctor(nullptr),
+      MSharedPtrStorage(nullptr) {
   if (MInteropContext->is_host())
     throw cl::sycl::invalid_parameter_error(
         "Creation of interoperability memory object using host context is "

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -1,0 +1,80 @@
+//==------------ sycl_mem_obj_t.cpp - SYCL standard header file ------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl/detail/memory_manager.hpp>
+#include <CL/sycl/detail/scheduler/scheduler.hpp>
+#include <CL/sycl/detail/sycl_mem_obj_t.hpp>
+#include <CL/sycl/detail/context_impl.hpp>
+
+__SYCL_INLINE namespace cl {
+namespace sycl {
+namespace detail {
+SYCLMemObjT::SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
+            const size_t SizeInBytes, event AvailableEvent,
+            SYCLMemObjAllocator Allocator)
+    : MAllocator(std::move(Allocator)), MProps(),
+      MInteropEvent(detail::getSyclObjImpl(std::move(AvailableEvent))),
+      MInteropContext(detail::getSyclObjImpl(SyclContext)),
+      MInteropMemObject(MemObject), MOpenCLInterop(true),
+      MHostPtrReadOnly(false), MNeedWriteBack(true),
+      MSizeInBytes(SizeInBytes), MUserPtr(nullptr), MShadowCopy(nullptr),
+      MUploadDataFunctor(nullptr), MSharedPtrStorage(nullptr) {
+  if (MInteropContext->is_host())
+    throw cl::sycl::invalid_parameter_error(
+        "Creation of interoperability memory object using host context is "
+        "not allowed");
+
+  RT::PiMem Mem = pi::cast<RT::PiMem>(MInteropMemObject);
+  RT::PiContext Context = nullptr;
+  PI_CALL(piMemGetInfo)(Mem, CL_MEM_CONTEXT, sizeof(Context), &Context,
+                        nullptr);
+
+  if (MInteropContext->getHandleRef() != Context)
+    throw cl::sycl::invalid_parameter_error(
+        "Input context must be the same as the context of cl_mem");
+  PI_CALL(piMemRetain)(Mem);
+}
+
+void SYCLMemObjT::releaseMem(ContextImplPtr Context, void *MemAllocation) {
+  void *Ptr = getUserPtr();
+  return MemoryManager::releaseMemObj(Context, this, MemAllocation, Ptr);
+}
+
+EventImplPtr SYCLMemObjT::updateHostMemory(void *const Ptr) {
+  const id<3> Offset{0, 0, 0};
+  const range<3> AccessRange{MSizeInBytes, 1, 1};
+  const range<3> MemoryRange{MSizeInBytes, 1, 1};
+  const access::mode AccessMode = access::mode::read;
+  SYCLMemObjI *SYCLMemObject = this;
+  const int Dims = 1;
+  const int ElemSize = 1;
+
+  Requirement Req(Offset, AccessRange, MemoryRange, AccessMode, SYCLMemObject,
+                  Dims, ElemSize);
+  Req.MData = Ptr;
+
+  EventImplPtr Event = Scheduler::getInstance().addCopyBack(&Req);
+  return Event;
+}
+
+void SYCLMemObjT::updateHostMemory() {
+  if ((MUploadDataFunctor != nullptr) && MNeedWriteBack)
+    MUploadDataFunctor();
+
+  // If we're attached to a memory record, process the deletion of the memory
+  // record. We may get detached before we do this.
+  if (MRecord)
+    Scheduler::getInstance().removeMemoryObject(this);
+  releaseHostMem(MShadowCopy);
+
+  if (MOpenCLInterop)
+    PI_CALL(piMemRelease)(pi::cast<RT::PiMem>(MInteropMemObject));
+}
+} // namespace detail
+} // namespace sycl
+} // namespace cl

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -16,7 +16,7 @@ namespace sycl {
 namespace detail {
 SYCLMemObjT::SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
             const size_t SizeInBytes, event AvailableEvent,
-            SYCLMemObjAllocator Allocator)
+            unique_ptr_class<SYCLMemObjAllocator> Allocator)
     : MAllocator(std::move(Allocator)), MProps(),
       MInteropEvent(detail::getSyclObjImpl(std::move(AvailableEvent))),
       MInteropContext(detail::getSyclObjImpl(SyclContext)),


### PR DESCRIPTION
This patch is a part of effort to decouple SYCL Runtime library
interface from its actual implementation. The goal is to improve
SYCL ABI/API compatibility between different versions of library.

The following changes were applied to SYCLMemObjT, as well as
buffer and image classes:

1. Introduced a type-erased allocator. This allowed removal of 
templates for SYCLMemObjT, buffer_impl, and image_imp.
2. sycl_mem_obj_t.hpp, image_impl.hpp, and buffer_impl.hpp
were refactored to use public APIs only. All usages of private
APIs were moved to cpp files.
3. get_access member functions were moved from image_impl
and buffer_impl to image and buffer accordingly, since they
did not use any private APIs at all.

Signed-off-by: Alexander Batashev alexander.batashev@intel.com