### PR TITLE
[SYCL][Driver][NFC] Cleanup temporary files when split is enabled

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7119,8 +7119,8 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     if (!ForeachArgs.empty()) {
       std::string ForeachOutName =
           C.getDriver().GetTemporaryPath("wrapper-linker", "txt");
-      const char *ForeachOutput =
-          C.addTempFile(C.getArgs().MakeArgString(ForeachOutName));
+      const char *ForeachOutput = C.addTempFile(
+          C.getArgs().MakeArgString(ForeachOutName), types::TY_Tempfilelist);
       SmallString<128> OutOpt("--out-file-list=");
       OutOpt += ForeachOutput;
 

--- a/clang/test/Driver/sycl-offload-tempfile.cpp
+++ b/clang/test/Driver/sycl-offload-tempfile.cpp
@@ -10,3 +10,11 @@
 // RUN: not ls %t_dir/*
 // CHECK-TEMPFILE: clang-offload-bundler{{.*}} "-type=oo" "-targets=host-x86_64-unknown-linux-gnu,sycl-spir64-unknown-unknown-sycldevice" "-inputs=[[DIRNAME]]{{.*}}" "-outputs={{.*}},[[DIRNAME]]{{\/|\\}}[[OUTPUT3:.+\.txt]]" "-unbundle"
 // CHECK-TEMPFILE: llvm-link{{.*}} "@[[DIRNAME]]{{\/|\\}}[[OUTPUT3]]"
+
+// RUN: mkdir -p %t_dir
+// RUN: env TMPDIR=%t_dir TEMP=%t_dir TMP=%t_dir                           \
+// RUN: %clang -### -fsycl -fsycl-device-code-split %s 2>&1 | \
+// RUN:       FileCheck -DDIRNAME=%t_dir --check-prefix=CHECK-TEMPFILE-SPLIT %s
+// RUN: not ls %t_dir/*
+// CHECK-TEMPFILE-SPLIT: llvm-foreach{{.*}} "--out-file-list=[[DIRNAME]]{{\/|\\}}[[OUTPUT:.+\.txt]]" {{.*}}clang-offload-wrapper{{.*}}
+// CHECK-TEMPFILE-SPLIT: llvm-link{{.*}} "@[[DIRNAME]]{{\/|\\}}[[OUTPUT]]"


### PR DESCRIPTION
Driver removed file list file but didn't clean up files from this list
because it does so only if type of file is specified as temporary file
list.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>