### PR TITLE
[SYCL][USM] Add templated forms of USM mallocs

### DIFF
--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -43,8 +43,9 @@ void *aligned_alloc_shared(size_t alignment, size_t size, const device &dev,
                            const context &ctxt);
 void *aligned_alloc_shared(size_t alignment, size_t size, const queue &q);
 
+///
 // single form
-
+///
 void *malloc(size_t size, const device &dev, const context &ctxt,
              usm::alloc kind);
 void *malloc(size_t size, const queue &q, usm::alloc kind);
@@ -53,6 +54,96 @@ void *aligned_alloc(size_t alignment, size_t size, const device &dev,
                     const context &ctxt, usm::alloc kind);
 void *aligned_alloc(size_t alignment, size_t size, const queue &q,
                     usm::alloc kind);
+
+///
+// Template forms
+///
+template <typename T>
+T *malloc_device(size_t Count, const device &Dev, const context &Ctxt) {
+  return static_cast<T *>(malloc_device(Count*sizeof(T), Dev, Ctxt));
+}
+
+template <typename T> T *malloc_device(size_t Count, const queue &Q) {
+  return malloc_device<T>(Count, Q.get_device(), Q.get_context());
+}
+
+template <typename T>
+T *aligned_alloc_device(size_t Alignment, size_t Count, const device &Dev,
+                        const context &Ctxt) {
+  return static_cast<T *>(
+      aligned_alloc_device(Alignment, Count * sizeof(T), Dev, Ctxt));
+}
+
+template <typename T>
+T *aligned_alloc_device(size_t Alignment, size_t Count, const queue &Q) {
+  return aligned_alloc_device<T>(Alignment, Count, Q.get_device(),
+                                 Q.get_context());
+}
+
+template <typename T> T *malloc_host(size_t Count, const context &Ctxt) {
+  return static_cast<T *>(malloc_host(Count * sizeof(T), Ctxt));
+}
+
+template <typename T> T *malloc_host(size_t Count, const queue &Q) {
+  return malloc_host<T>(Count, Q.get_context());
+}
+
+template <typename T>
+T *malloc_shared(size_t Count, const device &Dev, const context &Ctxt) {
+  return static_cast<T *>(malloc_shared(Count * sizeof(T), Dev, Ctxt));
+}
+
+template <typename T> T *malloc_shared(size_t Count, const queue &Q) {
+  return malloc_shared<T>(Count, Q.get_device(), Q.get_context());
+}
+
+template <typename T>
+T *aligned_alloc_host(size_t Alignment, size_t Count, const context &Ctxt) {
+  return static_cast<T *>(
+      aligned_alloc_host(Alignment, Count * sizeof(T), Ctxt));
+}
+
+template <typename T>
+T *aligned_alloc_host(size_t Alignment, size_t Count, const queue &Q) {
+  return aligned_alloc_host<T>(Alignment, Count, Q.get_context());
+}
+
+template <typename T>
+T *aligned_alloc_shared(size_t Alignment, size_t Count, const device &Dev,
+                        const context &Ctxt) {
+  return static_cast<T *>(
+      aligned_alloc_shared(Alignment, Count * sizeof(T), Dev, Ctxt));
+}
+
+template <typename T>
+T *aligned_alloc_shared(size_t Alignment, size_t Count, const queue &Q) {
+  return aligned_alloc_shared<T>(Alignment, Count, Q.get_device(),
+                                 Q.get_context());
+}
+
+template <typename T>
+T *malloc(size_t Count, const device &Dev, const context &Ctxt,
+          usm::alloc Kind) {
+  return static_cast<T *>(malloc(Count * sizeof(T), Dev, Ctxt, Kind));
+}
+
+template <typename T> T *malloc(size_t Count, const queue &Q, usm::alloc Kind) {
+  return malloc<T>(Count, Q.get_device(), Q.get_context(), Kind);
+}
+
+template <typename T>
+T *aligned_alloc(size_t Alignment, size_t Count, const device &Dev,
+                 const context &Ctxt, usm::alloc Kind) {
+  return static_cast<T *>(
+      aligned_alloc(Alignment, Count * sizeof(T), Dev, Ctxt, Kind));
+}
+
+template <typename T>
+T *aligned_alloc(size_t Alignment, size_t Count, const queue &Q,
+                 usm::alloc Kind) {
+  return aligned_alloc<T>(Alignment, Count, Q.get_device(), Q.get_context(),
+                          Kind);
+}
 
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -60,7 +60,7 @@ void *aligned_alloc(size_t alignment, size_t size, const queue &q,
 ///
 template <typename T>
 T *malloc_device(size_t Count, const device &Dev, const context &Ctxt) {
-  return static_cast<T *>(malloc_device(Count*sizeof(T), Dev, Ctxt));
+  return static_cast<T *>(malloc_device(Count * sizeof(T), Dev, Ctxt));
 }
 
 template <typename T> T *malloc_device(size_t Count, const queue &Q) {

--- a/sycl/test/usm/mixed2template.cpp
+++ b/sycl/test/usm/mixed2template.cpp
@@ -1,0 +1,87 @@
+// RUN: %clangxx -fsycl %s -o %t1.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %CPU_RUN_PLACEHOLDER %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+
+//==---------- mixed2template.cpp - Mixed Memory with Templatestest --------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+class foo;
+int main() {
+  const int N = 4;
+  const int MAGIC_NUM = 42;
+
+  queue q;
+  auto dev = q.get_device();
+  auto ctxt = q.get_context();
+
+  if (!(dev.get_info<info::device::usm_device_allocations>() &&
+        dev.get_info<info::device::usm_shared_allocations>() &&
+        dev.get_info<info::device::usm_host_allocations>()))
+    return 0;
+
+  int *darray = malloc<int>(N, dev, ctxt, usm::alloc::device);
+  if (darray == nullptr) {
+    return -1;
+  }
+  int *sarray = malloc<int>(N, dev, ctxt, usm::alloc::shared);
+
+  if (sarray == nullptr) {
+    return -1;
+  }
+
+  int *harray = malloc<int>(N, dev, ctxt, usm::alloc::host);
+  if (harray == nullptr) {
+    return -1;
+  }
+  for (int i = 0; i < N; i++) {
+    sarray[i] = MAGIC_NUM - 1;
+    harray[i] = 1;
+  }
+
+  auto e0 = q.memset(darray, 0, N * sizeof(int));
+  e0.wait();
+
+  auto e1 = q.submit([=](handler &cgh) {
+    cgh.single_task<class foo>([=]() {
+      for (int i = 0; i < N; i++) {
+        sarray[i] += darray[i] + harray[i];
+      }
+    });
+  });
+
+  e1.wait();
+
+  for (int i = 0; i < N; i++) {
+    if (sarray[i] != MAGIC_NUM) {
+      return -2;
+    }
+  }
+  free(darray, ctxt);
+  free(sarray, ctxt);
+  free(harray, ctxt);
+
+  float *hfarray = malloc<float>(N, q, usm::alloc::host);
+  if (hfarray == nullptr)
+    return -3;
+
+  free(hfarray, ctxt);
+
+  double *sdarray =
+      aligned_alloc<double>(alignof(double), N, q, usm::alloc::shared);
+  if (sdarray == nullptr)
+    return -4;
+
+  free(sdarray, ctxt);
+  
+  return 0;
+}


### PR DESCRIPTION
C++ programmers prefer nice clean templates over void *.

Signed-off-by: James Brodman <james.brodman@intel.com>