### PR TITLE
[SYCL] Remove dependency on event_impl from cg.hpp

### DIFF
--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <CL/sycl/access/access.hpp>
-#include <CL/sycl/detail/event_impl.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_i.hpp>
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/range.hpp>

--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -11,6 +11,7 @@
 #include <CL/sycl/detail/accessor_impl.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/helpers.hpp>
+#include <CL/sycl/detail/host_profiling_info.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/group.hpp>

--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -12,6 +12,7 @@
 #include <CL/sycl/detail/event_info.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/stl.hpp>
+#include <CL/sycl/detail/host_profiling_info.hpp>
 
 #include <cassert>
 
@@ -23,27 +24,6 @@ class context_impl;
 using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 class queue_impl;
 using QueueImplPtr = std::shared_ptr<cl::sycl::detail::queue_impl>;
-
-/// Profiling info for the host execution.
-class HostProfilingInfo {
-  cl_ulong StartTime = 0;
-  cl_ulong EndTime = 0;
-
-public:
-  /// Returns event's start time.
-  ///
-  /// @return event's start time in nanoseconds.
-  cl_ulong getStartTime() const { return StartTime; }
-  /// Returns event's end time.
-  ///
-  /// @return event's end time in nanoseconds.
-  cl_ulong getEndTime() const { return EndTime; }
-
-  /// Measures event's start time.
-  void start();
-  /// Measures event's end time.
-  void end();
-};
 
 class event_impl {
 public:

--- a/sycl/include/CL/sycl/detail/host_profiling_info.hpp
+++ b/sycl/include/CL/sycl/detail/host_profiling_info.hpp
@@ -1,0 +1,39 @@
+//==---------- host_profiling_info.hpp - SYCL host profiling ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl/detail/common.hpp>
+
+__SYCL_INLINE namespace cl {
+namespace sycl {
+namespace detail {
+
+/// Profiling info for the host execution.
+class HostProfilingInfo {
+  cl_ulong StartTime = 0;
+  cl_ulong EndTime = 0;
+
+public:
+  /// Returns event's start time.
+  ///
+  /// @return event's start time in nanoseconds.
+  cl_ulong getStartTime() const { return StartTime; }
+  /// Returns event's end time.
+  ///
+  /// @return event's end time in nanoseconds.
+  cl_ulong getEndTime() const { return EndTime; }
+
+  /// Measures event's start time.
+  void start();
+  /// Measures event's end time.
+  void end();
+};
+} // namespace detail
+} // namespace sycl
+} // namespace cl

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -10,6 +10,7 @@
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_t.hpp>
 #include <CL/sycl/detail/context_impl.hpp>
+#include <CL/sycl/detail/event_impl.hpp>
 
 __SYCL_INLINE namespace cl {
 namespace sycl {


### PR DESCRIPTION
This patch is a part of effort to decouple SYCL Runtime library
interface from its actual implementation. The goal is to improve
SYCL ABI/API compatibility between different versions of library.

This patch moves HostProfilingInfo into a separate export-friendly
header file. It also removes the event_impl header from unwanted
places.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>