### PR TITLE
[SYCL] Fix attribute usage

### DIFF
--- a/sycl/include/CL/sycl/detail/defines.hpp
+++ b/sycl/include/CL/sycl/detail/defines.hpp
@@ -27,3 +27,13 @@
 #ifndef SYCL_EXTERNAL
 #define SYCL_EXTERNAL
 #endif
+
+#if __cplusplus >= 201402
+  #define __SYCL_DEPRECATED__                                                  \
+    [[deprecated("Replaced by in_order queue property")]]
+#elif !defined _MSC_VER
+  #define __SYCL_DEPRECATED__ __attribute__                                    \
+    ((deprecated("Replaced by in_order queue property")))
+#else
+  #define __SYCL_DEPRECATED__
+#endif

--- a/sycl/include/CL/sycl/ordered_queue.hpp
+++ b/sycl/include/CL/sycl/ordered_queue.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/device_selector.hpp>
 #include <CL/sycl/exception_list.hpp>
 #include <CL/sycl/info/info_desc.hpp>
@@ -16,15 +17,6 @@
 
 #include <memory>
 #include <utility>
-
-#ifdef __has_cpp_attribute
-  #if __has_cpp_attribute(deprecated)
-    #define __SYCL_DEPRECATED__ [[deprecated("Replaced by in_order queue property")]]
-  #endif
-#endif
-#ifndef __SYCL_DEPRECATED__
-  #define __SYCL_DEPRECATED__
-#endif
 
 __SYCL_INLINE namespace cl {
 namespace sycl {


### PR DESCRIPTION
[[deprecated]] is C++14 attribute, use it if C++14 is supported.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>