### PR TITLE
[SYCL] Avoid using std::memcpy in device code

### DIFF
--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -212,7 +212,7 @@ public:
     cl_int TmpVal = __spirv_AtomicLoad(
         TmpPtr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order));
     cl_float ResVal;
-    std::memcpy(&ResVal, &TmpVal, sizeof TmpVal);
+    detail::memcpy(&ResVal, &TmpVal, sizeof(TmpVal));
     return ResVal;
   }
 #else

--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -33,6 +33,14 @@ template <int Dims> class h_item;
 enum class memory_order;
 
 namespace detail {
+inline void memcpy(void *Dst, const void *Src, size_t Size) {
+  char *Destination = reinterpret_cast<char *>(Dst);
+  const char *Source = reinterpret_cast<const char *>(Src);
+  for (size_t I = 0; I < Size; ++I) {
+    Destination[I] = Source[I];
+  }
+}
+
 class context_impl;
 // The function returns list of events that can be passed to OpenCL API as
 // dependency list and waits for others.

--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -19,7 +19,6 @@
 #include <CL/sycl/range.hpp>
 #include <CL/sycl/types.hpp>
 
-#include <cstring> // std::memcpy
 #include <numeric> // std::bit_cast
 #include <type_traits>
 
@@ -86,7 +85,7 @@ template <typename To, typename From> To bit_cast(const From &from) {
   return __builtin_bit_cast(To, from);
 #else
   To to;
-  std::memcpy(&to, &from, sizeof(To));
+  detail::memcpy(&to, &from, sizeof(To));
   return to;
 #endif // __has_builtin(__builtin_bit_cast)
 #endif // __cpp_lib_bit_cast

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -47,6 +47,7 @@
 #include <CL/sycl/aliases.hpp>
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/half_type.hpp>
 #include <CL/sycl/multi_ptr.hpp>
@@ -593,7 +594,7 @@ public:
         "asT must be SYCL vec of a different element type and "
         "number of elements specified by asT");
     asT Result;
-    std::memcpy(&Result.m_Data, &m_Data, sizeof(decltype(Result.m_Data)));
+    detail::memcpy(&Result.m_Data, &m_Data, sizeof(decltype(Result.m_Data)));
     return Result;
   }
 

--- a/sycl/test/regression/memcpy-in-vec-as.cpp
+++ b/sycl/test/regression/memcpy-in-vec-as.cpp
@@ -1,0 +1,25 @@
+// RUN: %clangxx -fsycl -D_FORTIFY_SOURCE=2 %s -o %t.out
+#include <CL/sycl.hpp>
+#include <iostream>
+
+int main() {
+  using res_vec_type = cl::sycl::vec<cl::sycl::cl_ushort, 4>;
+  res_vec_type res;
+
+  cl::sycl::vec<cl::sycl::cl_uchar, 8> RefData(1, 2, 3, 4, 5, 6, 7, 8);
+  {
+    cl::sycl::buffer<res_vec_type, 1> OutBuf(&res, cl::sycl::range<1>(1));
+    cl::sycl::buffer<decltype(RefData), 1> InBuf(&RefData,
+                                                 cl::sycl::range<1>(1));
+    cl::sycl::queue Queue;
+    Queue.submit([&](cl::sycl::handler &cgh) {
+      auto In = InBuf.get_access<cl::sycl::access::mode::write>(cgh);
+      auto Out = OutBuf.get_access<cl::sycl::access::mode::read>(cgh);
+      cgh.single_task<class as_op>(
+          [=]() { Out[0] = In[0].as<res_vec_type>(); });
+    });
+  }
+  std::cout << res.s0() << " " << res.s1() << " " << res.s2() << " " << res.s3()
+            << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Under certain circumstances (`-D_FORTIFY_SOURCES=2`), `std::memcpy` is not
directly lowered into `@llvm.memcpy.*` instrinsic, but instead is implemented
via combination of `@llvm.objectsize.*` + `@__memcpy_chk`

The problem is that `@llvm.objectsize.*` cannot be translated into
SPIR-V and causes crash during compilation.

Replaced `std::memcpy` with a simple loop instead to avoid the crash.