### PR TITLE
[SYCL][NFC] Refactor __SYCL_INLINE macro

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1672,7 +1672,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   }
   O << "\n";
 
-  O << "__SYCL_INLINE namespace cl {\n";
+  O << "__SYCL_INLINE_NAMESPACE(cl) {\n";
   O << "namespace sycl {\n";
   O << "namespace detail {\n";
 
@@ -1765,7 +1765,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   O << "\n";
   O << "} // namespace detail\n";
   O << "} // namespace sycl\n";
-  O << "} // namespace cl\n";
+  O << "} // __SYCL_INLINE_NAMESPACE(cl)\n";
   O << "\n";
 }
 

--- a/clang/test/CodeGenSYCL/wrapped-accessor.cpp
+++ b/clang/test/CodeGenSYCL/wrapped-accessor.cpp
@@ -5,7 +5,7 @@
 
 // CHECK: class wrapped_access;
 
-// CHECK: namespace cl {
+// CHECK: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 

--- a/sycl/.clang-format
+++ b/sycl/.clang-format
@@ -1,2 +1,3 @@
 BasedOnStyle: LLVM
 TypenameMacros: ['PI_CALL' ,'PI_CALL_THROW', 'PI_CALL_NOCHECK']
+NamespaceMacros: ['__SYCL_INLINE_NAMESPACE']

--- a/sycl/include/CL/sycl/access/access.hpp
+++ b/sycl/include/CL/sycl/access/access.hpp
@@ -9,7 +9,7 @@
 
 #include <CL/sycl/detail/defines.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace access {
 
@@ -180,4 +180,4 @@ struct remove_AS<__OPENCL_CONSTANT_AS__ T> {
 } // namespace detail
 
 }  // namespace sycl
-}  // namespace cl
+}  // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -143,7 +143,7 @@
 // accessor_common contains several helpers common for both accessor(1) and
 // accessor(3)
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 template <typename DataT, int Dimensions, access::mode AccessMode,
@@ -1264,7 +1264,7 @@ public:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <typename DataT, int Dimensions, cl::sycl::access::mode AccessMode,

--- a/sycl/include/CL/sycl/aliases.hpp
+++ b/sycl/include/CL/sycl/aliases.hpp
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 template <typename T, int N> class vec;
 namespace detail {
@@ -22,7 +22,7 @@ class half;
 } // namespace half_impl
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 // FIXME: line below exports 'half' into global namespace, which seems incorrect
 // However, SYCL 1.2.1 spec considers 'half' to be a fundamental C++ data type
@@ -69,7 +69,7 @@ using half = cl::sycl::detail::half_impl::half;
   MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                                      \
   MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 using byte = std::uint8_t;
 using schar = signed char;
@@ -101,7 +101,7 @@ MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(4)
 MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(8)
 MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(16)
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 #undef MAKE_VECTOR_ALIAS
 #undef MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES

--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -23,7 +23,7 @@
   static_assert(!std::is_same<T, float>::value,                                \
                 "SYCL atomic function not available for float type")
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 enum class memory_order : int { relaxed };
@@ -62,11 +62,11 @@ template <> struct GetSpirvMemoryScope<access::address_space::local_space> {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 #ifndef __SYCL_DEVICE_ONLY__
 // host implementation of SYCL atomics
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 // Translate cl::sycl::memory_order or __spv::MemorySemanticsMask
@@ -81,7 +81,7 @@ static inline std::memory_order getStdMemoryOrder(::cl::sycl::memory_order MS) {
 }
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 // std::atomic version of atomic SPIR-V builtins
 
@@ -161,7 +161,7 @@ extern T __spirv_AtomicMax(std::atomic<T> *Ptr, __spv::Scope S,
 
 #endif // !defined(__SYCL_DEVICE_ONLY__)
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 template <typename T, access::address_space addressSpace =
@@ -369,6 +369,6 @@ T atomic_fetch_max(atomic<T, addressSpace> Object, T Operand,
 }
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 #undef STATIC_ASSERT_NOT_FLOAT

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -14,7 +14,7 @@
 
 // TODO: 4.3.4 Properties
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 class handler;
 class queue;
@@ -396,7 +396,7 @@ buffer(const T *, const range<dimensions> &, const property_list & = {})
 #endif // __cpp_deduction_guides
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <typename T, int dimensions, typename AllocatorT>

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -17,7 +17,7 @@
 // TODO Decide whether to mark functions with this attribute.
 #define __NOEXC /*noexcept*/
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 #ifdef __SYCL_DEVICE_ONLY__
 #define __sycl_std
@@ -25,9 +25,9 @@ namespace sycl {
 namespace __sycl_std = __host_std;
 #endif
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 /* ----------------- 4.13.3 Math functions. ---------------------------------*/
 // genfloat acos (genfloat x)
@@ -1546,6 +1546,6 @@ detail::enable_if_t<detail::is_genfloatf<T>::value, T> tan(T x) __NOEXC {
 
 } // namespace half_precision
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 #undef __NOEXC

--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -14,7 +14,7 @@
 #include <type_traits>
 // 4.6.2 Context class
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declarations
 class device;
@@ -139,7 +139,7 @@ private:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <> struct hash<cl::sycl::context> {

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -14,7 +14,7 @@
 #include <CL/sycl/range.hpp>
 #include <CL/sycl/stl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -187,4 +187,4 @@ using Requirement = AccessorImplHost;
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/aligned_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/aligned_allocator.hpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 template <typename T> class aligned_allocator {
@@ -80,4 +80,4 @@ private:
 };
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/array.hpp
+++ b/sycl/include/CL/sycl/detail/array.hpp
@@ -12,7 +12,7 @@
 #include <functional>
 #include <stdexcept>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 template <int dimensions> class id;
 template <int dimensions> class range;
@@ -119,4 +119,4 @@ protected:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/boolean.hpp
+++ b/sycl/include/CL/sycl/detail/boolean.hpp
@@ -14,7 +14,7 @@
 #include <initializer_list>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -140,4 +140,4 @@ private:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declarations
 template <typename DataT, int Dimensions, access::mode AccessMode,
@@ -118,4 +118,4 @@ public:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/builtins.hpp
+++ b/sycl/include/CL/sycl/detail/builtins.hpp
@@ -67,7 +67,7 @@
   }
 
 #ifndef __SYCL_DEVICE_ONLY__
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace __host_std {
 #endif // __SYCL_DEVICE_ONLY__
 /* ----------------- 4.13.3 Math functions. ---------------------------------*/
@@ -242,7 +242,7 @@ MAKE_CALL_ARG3(bitselect, __FUNC_PREFIX_OCL)
 MAKE_CALL_ARG3(select, __FUNC_PREFIX_OCL) // select
 #ifndef __SYCL_DEVICE_ONLY__
 } // namespace __host_std
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 #endif
 
 #undef __NOEXC

--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -25,7 +25,7 @@
 #include <type_traits>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -520,4 +520,4 @@ public:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/circular_buffer.hpp
+++ b/sycl/include/CL/sycl/detail/circular_buffer.hpp
@@ -14,7 +14,7 @@
 #include <deque>
 #include <utility>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -96,4 +96,4 @@ private:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/clusm.hpp
+++ b/sycl/include/CL/sycl/detail/clusm.hpp
@@ -17,7 +17,7 @@
 #include <mutex>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace usm {
@@ -97,4 +97,4 @@ private:
 } // namespace usm
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -22,7 +22,7 @@
 #define STRINGIFY_LINE_HELP(s) #s
 #define STRINGIFY_LINE(s) STRINGIFY_LINE_HELP(s)
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -33,7 +33,7 @@ static inline std::string codeToString(cl_int code){
          stringifyErrorCode(code) + ")");
 }
 
-}}} // namespace cl::sycl::detail
+}}} // __SYCL_INLINE_NAMESPACE(cl)::sycl::detail
 
 #ifdef __SYCL_DEVICE_ONLY__
 // TODO remove this when 'assert' is supported in device code
@@ -87,7 +87,7 @@ static inline std::string codeToString(cl_int code){
 #define CHECK_OCL_CODE_NO_EXC(X) REPORT_OCL_ERR_TO_STREAM(X)
 #endif
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -252,4 +252,4 @@ constexpr KernelSetId LastKSId = SpvFileKSId;
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/common_info.hpp
+++ b/sycl/include/CL/sycl/detail/common_info.hpp
@@ -9,7 +9,7 @@
 #pragma once
 #include <CL/sycl/stl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -18,4 +18,4 @@ vector_class<string_class> split_string(const string_class &str,
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/context_impl.hpp
+++ b/sycl/include/CL/sycl/detail/context_impl.hpp
@@ -22,7 +22,7 @@
 #include <map>
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declaration
 class device;
@@ -151,4 +151,4 @@ private:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/context_info.hpp
+++ b/sycl/include/CL/sycl/detail/context_info.hpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -32,4 +32,4 @@ template <info::context param> struct get_context_info {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/defines.hpp
+++ b/sycl/include/CL/sycl/detail/defines.hpp
@@ -9,9 +9,9 @@
 #pragma once
 
 #ifndef __SYCL_DISABLE_NAMESPACE_INLINE__
-#define __SYCL_INLINE inline
+#define __SYCL_INLINE_NAMESPACE(X) inline namespace X
 #else
-#define __SYCL_INLINE
+#define __SYCL_INLINE_NAMESPACE(X) namespace X
 #endif // __SYCL_DISABLE_NAMESPACE_INLINE__
 
 #ifndef __has_attribute

--- a/sycl/include/CL/sycl/detail/device_impl.hpp
+++ b/sycl/include/CL/sycl/detail/device_impl.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/stl.hpp>
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declaration
@@ -195,4 +195,4 @@ private:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/device_info.hpp
+++ b/sycl/include/CL/sycl/detail/device_info.hpp
@@ -14,7 +14,7 @@
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/platform.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -421,4 +421,4 @@ struct get_device_info<bool, info::device::usm_system_allocator> {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/event_impl.hpp
+++ b/sycl/include/CL/sycl/detail/event_impl.hpp
@@ -16,7 +16,7 @@
 
 #include <cassert>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 class context;
 namespace detail {
@@ -155,4 +155,4 @@ private:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/event_info.hpp
+++ b/sycl/include/CL/sycl/detail/event_info.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -44,4 +44,4 @@ template <info::event Param> struct get_event_info {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/force_device.hpp
+++ b/sycl/include/CL/sycl/detail/force_device.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -21,4 +21,4 @@ info::device_type get_forced_type();
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_lists.hpp
@@ -16,7 +16,7 @@
 // types of parameters to kernel functions
 
 // Forward declarations
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 template <typename T, int N> class vec;
 namespace detail {
@@ -26,9 +26,9 @@ class half;
 } // namespace detail
 using half = detail::half_impl::half;
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace gtl {
@@ -379,4 +379,4 @@ using nonlocal_address_space_list =
 } // namespace gvl
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -18,7 +18,7 @@
 #include <limits>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -628,4 +628,4 @@ template <typename... Args> inline void check_vector_size() {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 class context;
 class event;
@@ -216,4 +216,4 @@ getSPIRVMemorySemanticsMask(const access::fence_space AccessSpace,
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/host_profiling_info.hpp
+++ b/sycl/include/CL/sycl/detail/host_profiling_info.hpp
@@ -10,7 +10,7 @@
 
 #include <CL/sycl/detail/common.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -36,4 +36,4 @@ public:
 };
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -21,7 +21,7 @@
 #include <cmath>
 #include <iostream>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -1083,5 +1083,5 @@ DataT imageReadSamplerHostImpl(const CoordT &Coords, const sampler &Smpl,
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 #endif

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -18,7 +18,7 @@
 #include <CL/sycl/range.hpp>
 #include <CL/sycl/stl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // forward declarations
@@ -303,4 +303,4 @@ private:
 };
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/image_ocl_types.hpp
+++ b/sycl/include/CL/sycl/detail/image_ocl_types.hpp
@@ -100,7 +100,7 @@ static RetType __invoke__ImageReadSampler(ImageT Img, CoordT Coords,
   return cl::sycl::detail::convertDataToType<TempRetT, RetType>(Ret);
 }
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -235,7 +235,7 @@ IMAGETY_DISCARD_WRITE_2_DIM_IARRAY
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 #undef INVOKE_SPIRV_CALL_ARG1
 #undef IMAGETY_DEFINE

--- a/sycl/include/CL/sycl/detail/item_base.hpp
+++ b/sycl/include/CL/sycl/detail/item_base.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/range.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 template <int dimensions> class id;
 template <int dimensions> class range;
@@ -73,4 +73,4 @@ template <int Dims> struct ItemBase<Dims, false> {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/detail/os_util.hpp> // for DLL_LOCAL used in int. header
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -83,4 +83,4 @@ template <typename T> using KernelInfo = typename KernelInfoImpl<T>::type;
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/kernel_impl.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_impl.hpp
@@ -19,7 +19,7 @@
 #include <cassert>
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declaration
 class program;
@@ -150,4 +150,4 @@ private:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/kernel_info.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_info.hpp
@@ -14,7 +14,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -163,4 +163,4 @@ struct get_kernel_sub_group_info_with_input<size_t, Param, cl::sycl::range<3>> {
 };
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_program_cache.hpp
@@ -19,7 +19,7 @@
 #include <mutex>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 class context_impl;

--- a/sycl/include/CL/sycl/detail/locked.hpp
+++ b/sycl/include/CL/sycl/detail/locked.hpp
@@ -13,7 +13,7 @@
 #include <functional>
 #include <mutex>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
   /// Represents a reference to value with appropriate lock acquired.

--- a/sycl/include/CL/sycl/detail/memory_manager.hpp
+++ b/sycl/include/CL/sycl/detail/memory_manager.hpp
@@ -16,7 +16,7 @@
 #include <memory>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -137,4 +137,4 @@ public:
 };
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/os_util.hpp
+++ b/sycl/include/CL/sycl/detail/os_util.hpp
@@ -56,7 +56,7 @@
 
 #endif
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -99,4 +99,4 @@ public:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -17,7 +17,7 @@
 #include <cassert>
 #include <string>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -154,4 +154,4 @@ template <class To, class From> To pi::cast(From value) {
 namespace RT = cl::sycl::detail::pi;
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/platform_impl.hpp
+++ b/sycl/include/CL/sycl/detail/platform_impl.hpp
@@ -14,7 +14,7 @@
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declaration
@@ -115,4 +115,4 @@ private:
 };
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/platform_info.hpp
+++ b/sycl/include/CL/sycl/detail/platform_info.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -69,4 +69,4 @@ vector_class<string_class> get_platform_info_host<info::platform::extensions>();
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/platform_util.hpp
+++ b/sycl/include/CL/sycl/detail/platform_util.hpp
@@ -16,7 +16,7 @@
 #define __builtin_expect(a, b) (a)
 #endif
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -45,4 +45,4 @@ struct PlatformUtil {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/plugin.hpp
+++ b/sycl/include/CL/sycl/detail/plugin.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/stl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -73,4 +73,4 @@ private:
 }; // class plugin
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/program_impl.hpp
+++ b/sycl/include/CL/sycl/detail/program_impl.hpp
@@ -21,7 +21,7 @@
 #include <fstream>
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declarations
@@ -386,4 +386,4 @@ vector_class<device> program_impl::get_info<info::program::devices>() const;
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/program_manager/program_manager.hpp
+++ b/sycl/include/CL/sycl/detail/program_manager/program_manager.hpp
@@ -29,7 +29,7 @@ extern "C" void __sycl_unregister_lib(pi_device_binaries desc);
 
 // +++ }
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 class context;
 namespace detail {
@@ -144,4 +144,4 @@ private:
 };
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/queue_impl.hpp
+++ b/sycl/include/CL/sycl/detail/queue_impl.hpp
@@ -22,7 +22,7 @@
 #include <CL/sycl/property_list.hpp>
 #include <CL/sycl/stl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -381,4 +381,4 @@ private:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/sampler_impl.hpp
+++ b/sycl/include/CL/sycl/detail/sampler_impl.hpp
@@ -13,7 +13,7 @@
 
 #include <unordered_map>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 enum class addressing_mode : unsigned int;
@@ -59,4 +59,4 @@ public:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/scheduler/commands.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.hpp
@@ -16,7 +16,7 @@
 #include <CL/sycl/detail/accessor_impl.hpp>
 #include <CL/sycl/detail/cg.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -384,4 +384,4 @@ private:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
@@ -19,7 +19,7 @@
 #include <set>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -230,4 +230,4 @@ protected:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/stl_type_traits.hpp
@@ -12,7 +12,7 @@
 #include <memory>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -79,4 +79,4 @@ struct is_output_iterator<T, output_iterator_requirements<T>> {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/stream_impl.hpp
+++ b/sycl/include/CL/sycl/detail/stream_impl.hpp
@@ -15,7 +15,7 @@
 #include <CL/sycl/ordered_queue.hpp>
 #include <CL/sycl/queue.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 namespace detail {
@@ -686,4 +686,4 @@ inline void writeHItem(stream_impl::FlushBufAccessorT &FlushBufs,
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_allocator.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 namespace detail {
@@ -70,4 +70,4 @@ protected:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -21,7 +21,7 @@
 #include <cstring>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -294,4 +294,4 @@ protected:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/type_list.hpp
+++ b/sycl/include/CL/sycl/detail/type_list.hpp
@@ -13,7 +13,7 @@
 
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -137,4 +137,4 @@ using find_twice_as_large_type_t = find_type_t<TL, is_type_size_double_of, T>;
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/type_traits.hpp
@@ -15,7 +15,7 @@
 
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace half_impl {
@@ -286,4 +286,4 @@ template <typename T> using make_larger_t = typename make_larger<T>::type;
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/usm_dispatch.hpp
+++ b/sycl/include/CL/sycl/detail/usm_dispatch.hpp
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace usm {
@@ -74,4 +74,4 @@ private:
 } // namespace usm
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/usm_impl.hpp
+++ b/sycl/include/CL/sycl/detail/usm_impl.hpp
@@ -11,7 +11,7 @@
 #include <CL/cl_usm_ext.h>
 #include <CL/sycl/usm/usm_enums.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace usm {
@@ -27,4 +27,4 @@ void free(void *Ptr, const context &Ctxt);
 } // namespace usm
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/util.hpp
+++ b/sycl/include/CL/sycl/detail/util.hpp
@@ -14,7 +14,7 @@
 
 #include <mutex>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -32,6 +32,6 @@ private:
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 #endif //__SYCL_DEVICE_ONLY

--- a/sycl/include/CL/sycl/device.hpp
+++ b/sycl/include/CL/sycl/device.hpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <utility>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declarations
 class device_selector;
@@ -167,7 +167,7 @@ private:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <> struct hash<cl::sycl::device> {

--- a/sycl/include/CL/sycl/device_event.hpp
+++ b/sycl/include/CL/sycl/device_event.hpp
@@ -11,7 +11,7 @@
 #include <CL/__spirv/spirv_ops.hpp>
 #include <CL/__spirv/spirv_types.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 class device_event {
@@ -32,4 +32,4 @@ public:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/device_selector.hpp
+++ b/sycl/include/CL/sycl/device_selector.hpp
@@ -10,7 +10,7 @@
 
 // 4.6.1 Device selection class
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declarations
@@ -51,4 +51,4 @@ public:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/event.hpp
+++ b/sycl/include/CL/sycl/event.hpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declaration
 class context;
@@ -125,7 +125,7 @@ private:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <> struct hash<cl::sycl::event> {

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -15,7 +15,7 @@
 
 #include <exception>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declaration
@@ -109,4 +109,4 @@ class feature_not_supported : public device_error {
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/exception_list.hpp
+++ b/sycl/include/CL/sycl/exception_list.hpp
@@ -15,7 +15,7 @@
 
 #include <cstddef>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declaration
@@ -49,4 +49,4 @@ private:
 using async_handler = function_class<void(cl::sycl::exception_list)>;
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -21,7 +21,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 class Builder;
@@ -355,4 +355,4 @@ protected:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/h_item.hpp
+++ b/sycl/include/CL/sycl/h_item.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/item.hpp>
 #include <CL/sycl/range.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 namespace detail {
@@ -130,4 +130,4 @@ private:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <limits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace host_half_impl {
@@ -209,7 +209,7 @@ inline float cast_if_host_half(half_impl::half val) {
 } // namespace detail
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 using half = cl::sycl::detail::half_impl::half;
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -54,7 +54,7 @@ template <typename T_Src, int Dims_Src, cl::sycl::access::mode AccessMode_Src,
           cl::sycl::access::placeholder IsPlaceholder_Dst>
 class __copyAcc2Acc;
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declaration
@@ -1287,4 +1287,4 @@ private:
   friend class detail::stream_impl;
 };
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/range.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
   namespace sycl {
   template <int dimensions> class range;
   template <int dimensions, bool with_offset> class item;
@@ -271,4 +271,4 @@ __SYCL_INLINE namespace cl {
 #endif
 
   } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -16,7 +16,7 @@
 #include <CL/sycl/types.hpp>
 #include <cstddef>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 enum class image_channel_order : unsigned int {
@@ -292,7 +292,7 @@ private:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <int Dimensions, typename AllocatorT>

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/id.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 class program;
@@ -283,4 +283,4 @@ template <typename T, T param> class param_traits {};
 
 } // namespace info
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/intel/builtins.hpp
+++ b/sycl/include/CL/sycl/intel/builtins.hpp
@@ -18,7 +18,7 @@ extern int __spirv_ocl_printf(const CONSTANT_AS char *__format, ...);
 #define CONSTANT_AS
 #endif
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace intel {
 namespace experimental {
@@ -72,6 +72,6 @@ int printf(const CONSTANT_AS char *__format, Args... args) {
 } // namespace experimental
 } // namespace intel
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 #undef CONSTANT_AS

--- a/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
@@ -10,7 +10,7 @@
 
 #include <CL/sycl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace intel {
 
@@ -48,4 +48,4 @@ public:
 
 } // namespace intel
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/intel/fpga_reg.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_reg.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace intel {
 
@@ -22,7 +22,7 @@ template <typename T> T fpga_reg(const T &t) {
 
 } // namespace intel
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 // Keep it consistent with FPGA attributes like intelfpga::memory()
 // Currently clang does not support nested namespace for attributes

--- a/sycl/include/CL/sycl/intel/function_pointer.hpp
+++ b/sycl/include/CL/sycl/intel/function_pointer.hpp
@@ -15,7 +15,7 @@
 
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 cl_ulong getDeviceFunctionPointerImpl(device &D, program &P,
@@ -84,4 +84,4 @@ device_func_ptr_holder_t get_device_func_ptr(FuncType F, const char *FuncName,
 }
 } // namespace intel
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/intel/functional.hpp
+++ b/sycl/include/CL/sycl/intel/functional.hpp
@@ -9,7 +9,7 @@
 #pragma once
 #include <functional>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace intel {
 
@@ -55,4 +55,4 @@ template <typename T = void> using plus = std::plus<T>;
 
 } // namespace intel
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/intel/pipes.hpp
+++ b/sycl/include/CL/sycl/intel/pipes.hpp
@@ -12,7 +12,7 @@
 #include <CL/__spirv/spirv_types.hpp>
 #include <CL/sycl/stl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace intel {
 
@@ -86,4 +86,4 @@ private:
 
 } // namespace intel
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -24,7 +24,7 @@
 
 #ifdef __SYCL_DEVICE_ONLY__
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 template <typename T, access::address_space Space> class multi_ptr;
 
@@ -373,7 +373,7 @@ protected:
 };
 } // namespace intel
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 #else
 #include <CL/sycl/intel/sub_group_host.hpp>
 #endif

--- a/sycl/include/CL/sycl/intel/sub_group_host.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group_host.hpp
@@ -15,7 +15,7 @@
 #include <CL/sycl/types.hpp>
 #ifndef __SYCL_DEVICE_ONLY__
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 template <typename T, access::address_space Space> class multi_ptr;
 namespace intel {
@@ -159,5 +159,5 @@ protected:
 };
 } // namespace intel
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 #endif

--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -14,7 +14,7 @@
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/range.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 class Builder;
@@ -84,4 +84,4 @@ private:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declaration
 class program;
@@ -127,7 +127,7 @@ private:
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 };
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <> struct hash<cl::sycl::kernel> {

--- a/sycl/include/CL/sycl/multi_ptr.hpp
+++ b/sycl/include/CL/sycl/multi_ptr.hpp
@@ -14,7 +14,7 @@
 #include <cassert>
 #include <cstddef>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declaration
 template <typename dataT, int dimensions, access::mode accessMode,
@@ -637,4 +637,4 @@ bool operator<=(std::nullptr_t lhs, const multi_ptr<ElementType, Space> &rhs) {
 }
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -22,7 +22,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 class Builder;
@@ -166,4 +166,4 @@ private:
   group<dimensions> Group;
 };
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/nd_range.hpp
+++ b/sycl/include/CL/sycl/nd_range.hpp
@@ -13,7 +13,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 template <int dimensions = 1> class nd_range {
@@ -55,4 +55,4 @@ public:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/ordered_queue.hpp
+++ b/sycl/include/CL/sycl/ordered_queue.hpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <utility>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declaration
@@ -168,7 +168,7 @@ private:
 #undef __SYCL_DEPRECATED__
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <> struct hash<cl::sycl::ordered_queue> {

--- a/sycl/include/CL/sycl/pipes.hpp
+++ b/sycl/include/CL/sycl/pipes.hpp
@@ -10,9 +10,9 @@
 
 #include <CL/sycl/intel/pipes.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 template <class name, class dataT, int32_t min_capacity = 0>
 using pipe = intel::pipe<name, dataT, min_capacity>;
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -13,7 +13,7 @@
 
 // 4.6.2 Platform class
 #include <utility>
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // TODO: make code thread-safe
 
@@ -110,7 +110,7 @@ private:
 
 }; // class platform
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <> struct hash<cl::sycl::platform> {

--- a/sycl/include/CL/sycl/pointers.hpp
+++ b/sycl/include/CL/sycl/pointers.hpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/access/access.hpp>
 
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 template <typename ElementType, access::address_space Space> class multi_ptr;
@@ -31,4 +31,4 @@ using private_ptr =
     multi_ptr<ElementType, access::address_space::private_space>;
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -15,7 +15,7 @@
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/stl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declarations
@@ -338,7 +338,7 @@ private:
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 };
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <> struct hash<cl::sycl::program> {

--- a/sycl/include/CL/sycl/property_list.hpp
+++ b/sycl/include/CL/sycl/property_list.hpp
@@ -13,7 +13,7 @@
 #include <type_traits>
 #include <utility>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // HOW TO ADD NEW PROPERTY INSTRUCTION:
@@ -249,4 +249,4 @@ private:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -18,7 +18,7 @@
 
 #include <utility>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declaration
@@ -441,7 +441,7 @@ private:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <> struct hash<cl::sycl::queue> {

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -12,7 +12,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 template <int dimensions> class id;
 template <int dimensions = 1> class range : public detail::array<dimensions> {
@@ -141,4 +141,4 @@ range(size_t, size_t, size_t)->range<3>;
 #endif
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/sampler.hpp
+++ b/sycl/include/CL/sycl/sampler.hpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/sampler_impl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 enum class addressing_mode : unsigned int {
   mirrored_repeat = CL_ADDRESS_MIRRORED_REPEAT,
@@ -84,7 +84,7 @@ private:
   friend class detail::image_accessor;
 };
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
 template <> struct hash<cl::sycl::sampler> {

--- a/sycl/include/CL/sycl/stl.hpp
+++ b/sycl/include/CL/sycl/stl.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
  template < class T, class Alloc = std::allocator<T> >

--- a/sycl/include/CL/sycl/stream.hpp
+++ b/sycl/include/CL/sycl/stream.hpp
@@ -10,7 +10,7 @@
 
 #include <CL/sycl/detail/stream_impl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 enum class stream_manipulator {
@@ -477,7 +477,7 @@ inline const stream &operator<<(const stream &Out, const T &RHS) {
 }
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 namespace std {
 template <> struct hash<cl::sycl::stream> {
   size_t operator()(const cl::sycl::stream &S) const {

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -62,7 +62,7 @@
 // 4.10.1: Scalar data types
 // 4.10.2: SYCL vector types
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 enum class rounding_mode { automatic, rte, rtz, rtp, rtn };
@@ -1755,7 +1755,7 @@ __SYCL_RELLOGOP(||)
 #undef __SYCL_RELLOGOP
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 
 #ifdef __SYCL_USE_EXT_VECTOR_TYPE__
@@ -1819,7 +1819,7 @@ using __half8_vec_t = cl::sycl::detail::half_impl::Vec8StorageT;
 using __half16_vec_t = cl::sycl::detail::half_impl::Vec16StorageT;
 #define GET_CL_HALF_TYPE(target, num) __##target##num##_vec_t
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 // select_apply_cl_t selects from T8/T16/T32/T64 basing on
@@ -1995,6 +1995,6 @@ DECLARE_FLOAT_VECTOR_CONVERTERS(double)
 #undef DECLARE_SCALAR_SCHAR_CONVERTER
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 #undef SYCL_ALIGNAS

--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 ///
 // Explicit USM
@@ -160,4 +160,4 @@ usm::alloc get_pointer_type(const void *ptr, const context &ctxt);
 device get_pointer_device(const void *ptr, const context &ctxt);
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/CL/sycl/usm/usm_allocator.hpp
@@ -16,7 +16,7 @@
 #include <cstdlib>
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 // Forward declarations.
@@ -163,4 +163,4 @@ private:
 };
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/usm/usm_enums.hpp
+++ b/sycl/include/CL/sycl/usm/usm_enums.hpp
@@ -7,7 +7,7 @@
 // ===--------------------------------------------------------------------=== //
 #pragma once
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace usm {
 
@@ -15,4 +15,4 @@ enum class alloc { host, device, shared, unknown };
 
 } // namespace usm
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -21,7 +21,7 @@
 
 // 4.6.2 Context class
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 context::context(const async_handler &AsyncHandler)
     : context(default_selector().select_device(), AsyncHandler) {}
@@ -88,4 +88,4 @@ vector_class<device> context::get_devices() const {
 context::context(shared_ptr_class<detail::context_impl> Impl) : impl(Impl) {}
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/accessor_impl.cpp
+++ b/sycl/source/detail/accessor_impl.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/accessor_impl.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 

--- a/sycl/source/detail/buffer_impl.cpp
+++ b/sycl/source/detail/buffer_impl.cpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 void *buffer_impl::allocateMem(ContextImplPtr Context, bool InitFromUserData,
@@ -34,4 +34,4 @@ void *buffer_impl::allocateMem(ContextImplPtr Context, bool InitFromUserData,
 }
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/builtins_common.cpp
+++ b/sycl/source/detail/builtins_common.cpp
@@ -22,7 +22,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace __host_std {
 namespace {
 
@@ -184,4 +184,4 @@ MAKE_1V(sign, s::cl_double, s::cl_double)
 MAKE_1V(sign, s::cl_half, s::cl_half)
 
 } // namespace __host_std
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/builtins_geometric.cpp
+++ b/sycl/source/detail/builtins_geometric.cpp
@@ -16,7 +16,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace __host_std {
 
 s::cl_float Dot(s::cl_float2, s::cl_float2);
@@ -222,4 +222,4 @@ s::cl_float fast_distance(s::cl_float4 p0, s::cl_float4 p1) {
 }
 
 } // namespace __host_std
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/builtins_helper.hpp
+++ b/sycl/source/detail/builtins_helper.hpp
@@ -206,7 +206,7 @@
   __MAKE_1V_2V_3P(Fun, 8, Ret, Arg1, Arg2, Arg3)                               \
   __MAKE_1V_2V_3P(Fun, 16, Ret, Arg1, Arg2, Arg3)
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace __host_std {
 namespace detail {
 
@@ -357,4 +357,4 @@ template <> struct helper<0> {
 
 } // namespace detail
 } // namespace __host_std
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/builtins_integer.cpp
+++ b/sycl/source/detail/builtins_integer.cpp
@@ -17,7 +17,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace __host_std {
 namespace {
 
@@ -779,4 +779,4 @@ s::cl_int s_mul24(s::cl_int x, s::cl_int y) __NOEXC { return __mul24(x, y); }
 MAKE_1V_2V(s_mul24, s::cl_int, s::cl_int, s::cl_int)
 
 } // namespace __host_std
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/builtins_math.cpp
+++ b/sycl/source/detail/builtins_math.cpp
@@ -22,7 +22,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace __host_std {
 
 namespace {
@@ -871,4 +871,4 @@ s::cl_float half_tan(s::cl_float x) __NOEXC { return std::tan(x); }
 MAKE_1V(half_tan, s::cl_float, s::cl_float)
 
 } // namespace __host_std
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/builtins_relational.cpp
+++ b/sycl/source/detail/builtins_relational.cpp
@@ -16,7 +16,7 @@
 namespace s = cl::sycl;
 namespace d = s::detail;
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace __host_std {
 namespace {
 
@@ -452,4 +452,4 @@ MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_half, s::cl_half, s::cl_half,
 MAKE_SC_FSC_1V_2V_3V_FV(select, __vselect, s::cl_half, s::cl_half, s::cl_half,
                         s::cl_ushort)
 } // namespace __host_std
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/common.cpp
+++ b/sycl/source/detail/common.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/common_info.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -239,4 +239,4 @@ vector_class<string_class> split_string(const string_class &str,
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -17,7 +17,7 @@
 #define STRINGIFY_LINE_HELP(s) #s
 #define STRINGIFY_LINE(s) STRINGIFY_LINE_HELP(s)
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -111,7 +111,7 @@ void dumpConfig() {
 #undef CONFIG
 }
 
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 } // namespace sycl
 } // namespace detail
 

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -10,7 +10,7 @@
 
 #include <cstdlib>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -98,6 +98,6 @@ private:
   }
 };
 
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 } // namespace sycl
 } // namespace detail

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -17,7 +17,7 @@
 #include <CL/sycl/platform.hpp>
 #include <CL/sycl/stl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -127,4 +127,4 @@ KernelProgramCache &context_impl::getKernelProgramCache() const {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -198,4 +198,4 @@ vector_class<device> device_impl::create_sub_devices(
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/device_info.cpp
+++ b/sycl/source/detail/device_info.cpp
@@ -19,7 +19,7 @@
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -525,4 +525,4 @@ template <> bool get_device_info_host<info::device::usm_system_allocator>() {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/error_handling/enqueue_kernel.cpp
+++ b/sycl/source/detail/error_handling/enqueue_kernel.cpp
@@ -15,7 +15,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/detail/plugin.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -188,4 +188,4 @@ bool handleError(pi_result Error, const device_impl &DeviceImpl,
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/error_handling/error_handling.hpp
+++ b/sycl/source/detail/error_handling/error_handling.hpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/pi.h>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -30,4 +30,4 @@ bool handleError(pi_result, const device_impl &, pi_kernel, const NDRDescT &);
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -15,7 +15,7 @@
 
 #include <chrono>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -181,4 +181,4 @@ void HostProfilingInfo::end() { EndTime = getTimestamp(); }
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/force_device.cpp
+++ b/sycl/source/detail/force_device.cpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/stl.hpp>
 #include <cstdlib>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -39,4 +39,4 @@ info::device_type get_forced_type() {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 namespace detail {
@@ -41,4 +41,4 @@ void waitEvents(std::vector<cl::sycl::event> DepEvents) {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/image_accessor_util.cpp
+++ b/sycl/source/detail/image_accessor_util.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/accessor.hpp>
 #include <CL/sycl/builtins.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -189,4 +189,4 @@ cl_float4 getBorderColor(const image_channel_order ImgChannelOrder) {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/detail/scheduler/scheduler.hpp>
 #include <CL/sycl/image.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -418,4 +418,4 @@ template class image_impl<3>;
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -15,7 +15,7 @@
 
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -158,4 +158,4 @@ bool kernel_impl::isCreatedFromSource() const {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/kernel_info.cpp
+++ b/sycl/source/detail/kernel_info.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/kernel_info.hpp>
 #include <CL/sycl/device.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 template <>
@@ -50,4 +50,4 @@ get_kernel_work_group_info_host<info::kernel_work_group::private_mem_size>(
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/detail/kernel_program_cache.hpp>
 #include <CL/sycl/detail/plugin.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 KernelProgramCache::~KernelProgramCache() {

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -17,7 +17,7 @@
 #include <cstring>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -545,4 +545,4 @@ void MemoryManager::prefetch_usm(void *Mem, QueueImplPtr Queue, size_t Length,
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -44,7 +44,7 @@
 
 #endif // SYCL_RT_OS
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -261,4 +261,4 @@ void OSUtil::alignedFree(void *Ptr) {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -16,7 +16,7 @@
 #include <stddef.h>
 #include <string>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace pi {
@@ -151,4 +151,4 @@ void assertion(bool Condition, const char *Message) {
 } // namespace pi
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -16,7 +16,7 @@
 #include <cstring>
 #include <regex>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -268,4 +268,4 @@ platform_impl::get_info() const {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/platform_info.cpp
+++ b/sycl/source/detail/platform_info.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/detail/platform_info.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -37,4 +37,4 @@ get_platform_info_host<info::platform::extensions>() {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/platform_util.cpp
+++ b/sycl/source/detail/platform_util.cpp
@@ -16,7 +16,7 @@
 #include <intrin.h>
 #endif
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -143,4 +143,4 @@ void PlatformUtil::prefetch(const char *Ptr, size_t NumBytes) {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/posix_pi.cpp
+++ b/sycl/source/detail/posix_pi.cpp
@@ -11,7 +11,7 @@
 #include <dlfcn.h>
 #include <string>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace pi {
@@ -29,4 +29,4 @@ void *getOsLibraryFuncAddress(void *Library, const std::string &FunctionName) {
 } // namespace pi
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -15,7 +15,7 @@
 #include <fstream>
 #include <memory>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -420,4 +420,4 @@ vector_class<device> program_impl::get_info<info::program::devices>() const {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -27,7 +27,7 @@
 #include <mutex>
 #include <sstream>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -904,7 +904,7 @@ void ProgramManager::dumpImage(const DeviceImage &Img, KernelSetId KSId) const {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 extern "C" void __sycl_register_lib(pi_device_binaries desc) {
   cl::sycl::detail::ProgramManager::getInstance().addImages(desc);

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -16,7 +16,7 @@
 
 #include <cstring>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 template <> cl_uint queue_impl::get_info<info::queue::reference_count>() const {
@@ -76,4 +76,4 @@ event queue_impl::mem_advise(const void *Ptr, size_t Length, int Advice) {
 }
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/sampler_impl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -84,4 +84,4 @@ sampler_impl::get_coordinate_normalization_mode() const {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -33,7 +33,7 @@
 #include <memory>
 #endif
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -1013,4 +1013,4 @@ cl_int ExecCGCommand::enqueueImp() {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -23,7 +23,7 @@
 #include <set>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -717,4 +717,4 @@ void Scheduler::GraphBuilder::removeRecordForMemObj(SYCLMemObjI *MemObject) {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -13,7 +13,7 @@
 #include <memory>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -90,4 +90,4 @@ bool Scheduler::GraphProcessor::enqueueCommand(Command *Cmd,
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -16,7 +16,7 @@
 #include <set>
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -167,4 +167,4 @@ Scheduler::Scheduler() {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/stream_impl.cpp
+++ b/sycl/source/detail/stream_impl.cpp
@@ -9,7 +9,7 @@
 #include <CL/sycl/detail/stream_impl.hpp>
 #include <cstdio>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -42,5 +42,5 @@ void stream_impl::flush() {
 }
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/detail/context_impl.hpp>
 #include <CL/sycl/detail/event_impl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 SYCLMemObjT::SYCLMemObjT(cl_mem MemObject, const context &SyclContext,
@@ -83,4 +83,4 @@ void SYCLMemObjT::updateHostMemory() {
 }
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/usm/clusm.cpp
+++ b/sycl/source/detail/usm/clusm.cpp
@@ -19,7 +19,7 @@
 
 cl::sycl::detail::usm::CLUSM *gCLUSM = nullptr;
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace usm {
@@ -379,4 +379,4 @@ cl_int CLUSM::writeParamToMemory(size_t param_value_size, T param,
 } // namespace usm
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/usm/usm_dispatch.cpp
+++ b/sycl/source/detail/usm/usm_dispatch.cpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/detail/plugin.hpp>
 #include <CL/sycl/detail/usm_dispatch.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
   namespace sycl {
   namespace detail {
   namespace usm {
@@ -399,4 +399,4 @@ pi_result USMDispatcher::enqueuePrefetch(pi_queue Queue, void *Ptr, size_t Size,
 } // namespace usm
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -16,7 +16,7 @@
 
 #include <cstdlib>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 using alloc = cl::sycl::usm::alloc;
@@ -312,4 +312,4 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
 }
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/util.cpp
+++ b/sycl/source/detail/util.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/detail/util.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -20,4 +20,4 @@ Sync &Sync::getInstance() {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/windows_pi.cpp
+++ b/sycl/source/detail/windows_pi.cpp
@@ -12,7 +12,7 @@
 #include <winreg.h>
 #include <string>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace pi {
@@ -28,4 +28,4 @@ void *getOsLibraryFuncAddress(void *Library, const std::string &FunctionName) {
 } // namespace pi
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/device_selector.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 void force_type(info::device_type &t, const info::device_type &ft) {
@@ -115,4 +115,4 @@ device::get_info() const {
 #undef PARAM_TRAITS_SPEC
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -12,7 +12,7 @@
 #include <CL/sycl/stl.hpp>
 // 4.6.1 Device selection class
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 device device_selector::select_device() const {
   vector_class<device> devices = device::get_devices();
@@ -63,4 +63,4 @@ int host_selector::operator()(const device &dev) const {
 }
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <unordered_set>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 event::event() : impl(std::make_shared<detail::event_impl>()) {}
@@ -85,4 +85,4 @@ event::event(shared_ptr_class<detail::event_impl> event_impl)
 #undef PARAM_TRAITS_SPEC
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/exception.cpp
+++ b/sycl/source/exception.cpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/exception.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 const char *exception::what() const noexcept { return MMsg.c_str(); }
@@ -27,4 +27,4 @@ context exception::get_context() const {
 cl_int exception::get_cl_code() const { return MCLErr; }
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/exception_list.cpp
+++ b/sycl/source/exception_list.cpp
@@ -11,7 +11,7 @@
 
 #include <utility>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 exception_list::size_type exception_list::size() const { return MList.size(); }
@@ -27,4 +27,4 @@ void exception_list::PushBack(value_type&& Value) { MList.emplace_back(std::move
 void exception_list::Clear() noexcept { MList.clear(); }
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/function_pointer.cpp
+++ b/sycl/source/function_pointer.cpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/detail/device_impl.hpp>
 #include <CL/sycl/detail/program_impl.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 intel::device_func_ptr_holder_t
@@ -28,4 +28,4 @@ getDeviceFunctionPointerImpl(device &D, program &P, const char *FuncName) {
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/half_type.cpp
+++ b/sycl/source/half_type.cpp
@@ -11,7 +11,7 @@
 #include <CL/sycl/detail/platform_util.hpp>
 #include <cstring>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -184,4 +184,4 @@ bool operator!=(const half &LHS, const half &RHS) { return !(LHS == RHS); }
 
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -17,7 +17,7 @@
 #include <CL/sycl/handler.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 event handler::finalize() {
   sycl::event EventRet;
@@ -243,4 +243,4 @@ string_class handler::getKernelName() {
   return MSyclKernel->get_info<info::kernel::function_name>();
 }
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/program.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 kernel::kernel(cl_kernel ClKernel, const context &SyclContext)
@@ -87,4 +87,4 @@ kernel::get_sub_group_info(
 kernel::kernel(std::shared_ptr<detail::kernel_impl> Impl) : impl(Impl) {}
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/ordered_queue.cpp
+++ b/sycl/source/ordered_queue.cpp
@@ -12,7 +12,7 @@
 
 #include <algorithm>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 ordered_queue::ordered_queue(const context &syclContext,
                              const device_selector &deviceSelector,
@@ -119,4 +119,4 @@ ordered_queue::has_property<property::queue::enable_profiling>() const;
 template property::queue::enable_profiling
 ordered_queue::get_property<property::queue::enable_profiling>() const;
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -13,7 +13,7 @@
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/platform.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 platform::platform() : impl(std::make_shared<detail::platform_impl>()) {}
@@ -57,4 +57,4 @@ platform::get_info() const {
 #undef PARAM_TRAITS_SPEC
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -11,7 +11,7 @@
 
 #include <vector>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 program::program(const context &context)
@@ -116,4 +116,4 @@ string_class program::get_build_options() const {
 
 program_state program::get_state() const { return impl->get_state(); }
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -15,7 +15,7 @@
 
 #include <algorithm>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 namespace detail {
@@ -126,4 +126,4 @@ template property::queue::enable_profiling
 queue::get_property<property::queue::enable_profiling>() const;
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/sampler.cpp
+++ b/sycl/source/sampler.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/sampler.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 sampler::sampler(coordinate_normalization_mode normalizationMode,
                  addressing_mode addressingMode, filtering_mode filteringMode)
@@ -40,4 +40,4 @@ bool sampler::operator!=(const sampler &rhs) const {
 }
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/stream.cpp
+++ b/sycl/source/stream.cpp
@@ -8,7 +8,7 @@
 
 #include <CL/sycl/stream.hpp>
 
-__SYCL_INLINE namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
 stream::stream(size_t BufferSize, size_t MaxStatementSize, handler &CGH)
@@ -53,5 +53,5 @@ bool stream::operator==(const stream &RHS) const { return (impl == RHS.impl); }
 bool stream::operator!=(const stream &RHS) const { return !(impl == RHS.impl); }
 
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 


### PR DESCRIPTION
The problem with previous definition of macro is that clang-format
insert additional indentation:

Original code:
```c++
__SYCL_INLINE namespace cl {
// some code
```

When applied clang-format:
```c++
__SYCL_INLINE namespace cl {
  // some code
```

Replaced `__SYCL_INLINE` with `__SYCL_INLINE_NAMESPACE(X)` which defines
either inline or regular namespace and marked it as `NamespaceMacro` in
clang-format config file to avoid dealing with broken formatting while
adding new code