### PR TITLE
[SYCL] id<1> to size_t conversion refactoring

### DIFF
--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -14,80 +14,159 @@
 #include <CL/sycl/range.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
-  namespace sycl {
-  template <int dimensions> class range;
-  template <int dimensions, bool with_offset> class item;
+namespace sycl {
+template <int dimensions> class range;
+template <int dimensions, bool with_offset> class item;
 
-  template <int dimensions = 1> class id : public detail::array<dimensions> {
-  private:
-    using base = detail::array<dimensions>;
-    static_assert(dimensions >= 1 && dimensions <= 3,
-                  "id can only be 1, 2, or 3 dimensional.");
-    template <int N, int val, typename T>
-    using ParamTy = detail::enable_if_t<(N == val), T>;
+template <int dimensions = 1> class id : public detail::array<dimensions> {
+private:
+  using base = detail::array<dimensions>;
+  static_assert(dimensions >= 1 && dimensions <= 3,
+                "id can only be 1, 2, or 3 dimensional.");
+  template <int N, int val, typename T>
+  using ParamTy = detail::enable_if_t<(N == val), T>;
 
-  public:
-    id() = default;
+#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+  /* Helper class for conversion operator. Void type is not suitable. User
+   * cannot even try to get address of the operator __private_class(). User
+   * may try to get an address of operator void() and will get the
+   * compile-time error */
+  class __private_class;
 
-#ifdef __SYCL_DISABLE_ID_TO_INT_CONV__
-    /* The following constructor is only available in the id struct
-     * specialization where: dimensions==1 */
-    template <int N = dimensions> id(ParamTy<N, 1, size_t> dim0) : base(dim0) {}
-
-    template <int N = dimensions>
-    id(ParamTy<N, 1, const range<dimensions>> &range_size)
-        : base(range_size.get(0)) {}
-
-    template <int N = dimensions, bool with_offset = true>
-    id(ParamTy<N, 1, const item<dimensions, with_offset>> &item)
-        : base(item.get_id(0)) {}
+  template <typename N, typename T>
+  using EnableIfIntegral  = detail::enable_if_t<std::is_integral<N>::value, T>;
+  template <bool B, typename T>
+  using EnableIfT = detail::conditional_t<B, T, __private_class>;
 #endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 
-    /* The following constructor is only available in the id struct
-     * specialization where: dimensions==2 */
-    template <int N = dimensions>
-    id(ParamTy<N, 2, size_t> dim0, size_t dim1) : base(dim0, dim1) {}
+public:
+  id() = default;
 
-    template <int N = dimensions>
-    id(ParamTy<N, 2, const range<dimensions>> &range_size)
-        : base(range_size.get(0), range_size.get(1)) {}
+  /* The following constructor is only available in the id struct
+   * specialization where: dimensions==1 */
+  template <int N = dimensions> id(ParamTy<N, 1, size_t> dim0) : base(dim0) {}
 
-    template <int N = dimensions, bool with_offset = true>
-    id(ParamTy<N, 2, const item<dimensions, with_offset>> &item)
-        : base(item.get_id(0), item.get_id(1)) {}
+  template <int N = dimensions>
+  id(ParamTy<N, 1, const range<dimensions>> &range_size)
+      : base(range_size.get(0)) {}
 
-    /* The following constructor is only available in the id struct
-     * specialization where: dimensions==3 */
-    template <int N = dimensions>
-    id(ParamTy<N, 3, size_t> dim0, size_t dim1, size_t dim2)
-        : base(dim0, dim1, dim2) {}
+  template <int N = dimensions, bool with_offset = true>
+  id(ParamTy<N, 1, const item<dimensions, with_offset>> &item)
+      : base(item.get_id(0)) {}
 
-    template <int N = dimensions>
-    id(ParamTy<N, 3, const range<dimensions>> &range_size)
-        : base(range_size.get(0), range_size.get(1), range_size.get(2)) {}
+  /* The following constructor is only available in the id struct
+   * specialization where: dimensions==2 */
+  template <int N = dimensions>
+  id(ParamTy<N, 2, size_t> dim0, size_t dim1) : base(dim0, dim1) {}
 
-    template <int N = dimensions, bool with_offset = true>
-    id(ParamTy<N, 3, const item<dimensions, with_offset>> &item)
-        : base(item.get_id(0), item.get_id(1), item.get_id(2)) {}
+  template <int N = dimensions>
+  id(ParamTy<N, 2, const range<dimensions>> &range_size)
+      : base(range_size.get(0), range_size.get(1)) {}
 
-    explicit operator range<dimensions>() const {
-      range<dimensions> result(
-          detail::InitializedVal<dimensions, range>::template get<0>());
-      for (int i = 0; i < dimensions; ++i) {
-        result[i] = this->get(i);
-      }
-      return result;
+  template <int N = dimensions, bool with_offset = true>
+  id(ParamTy<N, 2, const item<dimensions, with_offset>> &item)
+      : base(item.get_id(0), item.get_id(1)) {}
+
+  /* The following constructor is only available in the id struct
+   * specialization where: dimensions==3 */
+  template <int N = dimensions>
+  id(ParamTy<N, 3, size_t> dim0, size_t dim1, size_t dim2)
+      : base(dim0, dim1, dim2) {}
+
+  template <int N = dimensions>
+  id(ParamTy<N, 3, const range<dimensions>> &range_size)
+      : base(range_size.get(0), range_size.get(1), range_size.get(2)) {}
+
+  template <int N = dimensions, bool with_offset = true>
+  id(ParamTy<N, 3, const item<dimensions, with_offset>> &item)
+      : base(item.get_id(0), item.get_id(1), item.get_id(2)) {}
+
+  explicit operator range<dimensions>() const {
+    range<dimensions> result(
+        detail::InitializedVal<dimensions, range>::template get<0>());
+    for (int i = 0; i < dimensions; ++i) {
+      result[i] = this->get(i);
     }
+    return result;
+  }
+
+#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+  /* Template operator is not allowed because it disables further type
+   * conversion. For example, the next code will not work in case of template
+   * conversion:
+   * int a = id<1>(value); */
+
+  operator EnableIfT<(dimensions == 1), size_t>() const {
+    return this->common_array[0];
+  }
+#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
+
+// OP is: ==, !=
+#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+  using detail::array<dimensions>::operator==;
+  using detail::array<dimensions>::operator!=;
+
+  /* Enable operators with integral types.
+   * Template operators take precedence than type conversion. In the case of
+   * non-template operators, ambiguity appears: "id op size_t" may refer
+   * "size_t op size_t" and "id op size_t". In case of template operators it
+   * will be "id op size_t"*/
+#define __SYCL_GEN_OPT(op)                                                     \
+  template <typename T>                                                        \
+  EnableIfIntegral <T, bool> operator op(const T &rhs) const {                 \
+    if (this->common_array[0] != rhs)                                          \
+      return false op true;                                                    \
+    return true op true;                                                       \
+  }                                                                            \
+  template <typename T>                                                        \
+  friend EnableIfIntegral <T, bool> operator op(const T &lhs,                  \
+                                           const id<dimensions> &rhs) {        \
+    if (lhs != rhs.common_array[0])                                            \
+      return false op true;                                                    \
+    return true op true;                                                       \
+  }
+
+  __SYCL_GEN_OPT(==)
+  __SYCL_GEN_OPT(!=)
+
+#undef __SYCL_GEN_OPT
+
+#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 
 // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-#define __SYCL_GEN_OPT(op)                                                     \
+#define __SYCL_GEN_OPT_BASE(op)                                                \
   id<dimensions> operator op(const id<dimensions> &rhs) const {                \
     id<dimensions> result;                                                     \
     for (int i = 0; i < dimensions; ++i) {                                     \
       result.common_array[i] = this->common_array[i] op rhs.common_array[i];   \
     }                                                                          \
     return result;                                                             \
+  }
+
+#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+// Enable operators with integral types only
+#define __SYCL_GEN_OPT(op)                                                     \
+  __SYCL_GEN_OPT_BASE(op)                                                      \
+  template <typename T>                                                        \
+  EnableIfIntegral <T, id<dimensions>> operator op(const T &rhs) const {       \
+    id<dimensions> result;                                                     \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      result.common_array[i] = this->common_array[i] op rhs;                   \
+    }                                                                          \
+    return result;                                                             \
   }                                                                            \
+  template <typename T>                                                        \
+  friend EnableIfIntegral <T, id<dimensions>> operator op(                     \
+      const T &lhs, const id<dimensions> &rhs) {                               \
+    id<dimensions> result;                                                     \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      result.common_array[i] = lhs op rhs.common_array[i];                     \
+    }                                                                          \
+    return result;                                                             \
+  }
+#else
+#define __SYCL_GEN_OPT(op)                                                     \
+  __SYCL_GEN_OPT_BASE(op)                                                      \
   id<dimensions> operator op(const size_t &rhs) const {                        \
     id<dimensions> result;                                                     \
     for (int i = 0; i < dimensions; ++i) {                                     \
@@ -103,25 +182,27 @@ __SYCL_INLINE_NAMESPACE(cl) {
     }                                                                          \
     return result;                                                             \
   }
+#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 
-    __SYCL_GEN_OPT(+)
-    __SYCL_GEN_OPT(-)
-    __SYCL_GEN_OPT(*)
-    __SYCL_GEN_OPT(/)
-    __SYCL_GEN_OPT(%)
-    __SYCL_GEN_OPT(<<)
-    __SYCL_GEN_OPT(>>)
-    __SYCL_GEN_OPT(&)
-    __SYCL_GEN_OPT(|)
-    __SYCL_GEN_OPT(^)
-    __SYCL_GEN_OPT(&&)
-    __SYCL_GEN_OPT(||)
-    __SYCL_GEN_OPT(<)
-    __SYCL_GEN_OPT(>)
-    __SYCL_GEN_OPT(<=)
-    __SYCL_GEN_OPT(>=)
+  __SYCL_GEN_OPT(+)
+  __SYCL_GEN_OPT(-)
+  __SYCL_GEN_OPT(*)
+  __SYCL_GEN_OPT(/)
+  __SYCL_GEN_OPT(%)
+  __SYCL_GEN_OPT(<<)
+  __SYCL_GEN_OPT(>>)
+  __SYCL_GEN_OPT(&)
+  __SYCL_GEN_OPT(|)
+  __SYCL_GEN_OPT(^)
+  __SYCL_GEN_OPT(&&)
+  __SYCL_GEN_OPT(||)
+  __SYCL_GEN_OPT(<)
+  __SYCL_GEN_OPT(>)
+  __SYCL_GEN_OPT(<=)
+  __SYCL_GEN_OPT(>=)
 
 #undef __SYCL_GEN_OPT
+#undef __SYCL_GEN_OPT_BASE
 
 // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
 #define __SYCL_GEN_OPT(op)                                                     \
@@ -138,137 +219,38 @@ __SYCL_INLINE_NAMESPACE(cl) {
     return *this;                                                              \
   }
 
-    __SYCL_GEN_OPT(+=)
-    __SYCL_GEN_OPT(-=)
-    __SYCL_GEN_OPT(*=)
-    __SYCL_GEN_OPT(/=)
-    __SYCL_GEN_OPT(%=)
-    __SYCL_GEN_OPT(<<=)
-    __SYCL_GEN_OPT(>>=)
-    __SYCL_GEN_OPT(&=)
-    __SYCL_GEN_OPT(|=)
-    __SYCL_GEN_OPT(^=)
+  __SYCL_GEN_OPT(+=)
+  __SYCL_GEN_OPT(-=)
+  __SYCL_GEN_OPT(*=)
+  __SYCL_GEN_OPT(/=)
+  __SYCL_GEN_OPT(%=)
+  __SYCL_GEN_OPT(<<=)
+  __SYCL_GEN_OPT(>>=)
+  __SYCL_GEN_OPT(&=)
+  __SYCL_GEN_OPT(|=)
+  __SYCL_GEN_OPT(^=)
 
 #undef __SYCL_GEN_OPT
-  };
+};
 
-#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
-  template <> class id<1> : public detail::array<1> {
-  private:
-    using base = detail::array<1>;
-
-  public:
-    id() = default;
-
-    /* The following constructor is only available in the id struct
-     * specialization where: dimensions==1 */
-    id<1>(size_t dim0) : base(dim0) {}
-
-    id<1>(const range<1> &range_size) : base(range_size.get(0)) {}
-
-    template <bool with_offset = true>
-    id<1>(const item<1, with_offset> &item) : base(item.get_id(0)) {}
-
-    explicit operator range<1>() const {
-      range<1> result(detail::InitializedVal<1, range>::template get<0>());
-      result[0] = this->get(0);
-      return result;
-    }
-
-    operator size_t() const { return this->get(0); }
-
-// OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-#define __SYCL_GEN_OPT(op)                                                     \
-  id<1> operator op(const id<1> &rhs) const {                                  \
-    id<1> result;                                                              \
-    result.common_array[0] = this->common_array[0] op rhs.common_array[0];     \
-    return result;                                                             \
-  }                                                                            \
-  template <typename T> id<1> operator op(const T &rhs) const {                \
-    id<1> result;                                                              \
-    result.common_array[0] = this->common_array[0] op rhs;                     \
-    return result;                                                             \
-  }                                                                            \
-  template <typename T>                                                        \
-  friend id<1> operator op(const T &lhs, const id<1> &rhs) {                   \
-    id<1> result;                                                              \
-    result.common_array[0] = lhs op rhs.common_array[0];                       \
-    return result;                                                             \
-  }                                                                            \
-  id<1> operator op(const range<1> &rhs) const {                               \
-    id<1> result;                                                              \
-    result.common_array[0] = this->common_array[0] op rhs[0];                  \
-    return result;                                                             \
-  }                                                                            \
-  friend id<1> operator op(const range<1> &lhs, const id<1> &rhs) {            \
-    id<1> result;                                                              \
-    result.common_array[0] = lhs[0] op rhs.common_array[0];                    \
-    return result;                                                             \
-  }
-
-    __SYCL_GEN_OPT(+)
-    __SYCL_GEN_OPT(-)
-    __SYCL_GEN_OPT(*)
-    __SYCL_GEN_OPT(/)
-    __SYCL_GEN_OPT(%)
-    __SYCL_GEN_OPT(<<)
-    __SYCL_GEN_OPT(>>)
-    __SYCL_GEN_OPT(&)
-    __SYCL_GEN_OPT(|)
-    __SYCL_GEN_OPT(^)
-    __SYCL_GEN_OPT(&&)
-    __SYCL_GEN_OPT(||)
-    __SYCL_GEN_OPT(<)
-    __SYCL_GEN_OPT(>)
-    __SYCL_GEN_OPT(<=)
-    __SYCL_GEN_OPT(>=)
-
-#undef __SYCL_GEN_OPT
-
-// OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
-#define __SYCL_GEN_OPT(op)                                                     \
-  id<1> &operator op(const id<1> &rhs) {                                       \
-    this->common_array[0] op rhs.common_array[0];                              \
-    return *this;                                                              \
-  }                                                                            \
-  id<1> &operator op(const size_t &rhs) {                                      \
-    this->common_array[0] op rhs;                                              \
-    return *this;                                                              \
-  }
-
-    __SYCL_GEN_OPT(+=)
-    __SYCL_GEN_OPT(-=)
-    __SYCL_GEN_OPT(*=)
-    __SYCL_GEN_OPT(/=)
-    __SYCL_GEN_OPT(%=)
-    __SYCL_GEN_OPT(<<=)
-    __SYCL_GEN_OPT(>>=)
-    __SYCL_GEN_OPT(&=)
-    __SYCL_GEN_OPT(|=)
-    __SYCL_GEN_OPT(^=)
-
-#undef __SYCL_GEN_OPT
-  };
-#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
-
-  namespace detail {
-  template <int dimensions>
-  size_t getOffsetForId(range<dimensions> Range, id<dimensions> Id,
-                        id<dimensions> Offset) {
-    size_t offset = 0;
-    for (int i = 0; i < dimensions; ++i)
-      offset = offset * Range[i] + Offset[i] + Id[i];
-    return offset;
-  }
-  } // namespace detail
+namespace detail {
+template <int dimensions>
+size_t getOffsetForId(range<dimensions> Range, id<dimensions> Id,
+                      id<dimensions> Offset) {
+  size_t offset = 0;
+  for (int i = 0; i < dimensions; ++i)
+    offset = offset * Range[i] + Offset[i] + Id[i];
+  return offset;
+}
+} // namespace detail
 
 // C++ feature test macros are supported by all supported compilers
 // with the exception of MSVC 1914. It doesn't support deduction guides.
 #ifdef __cpp_deduction_guides
-  id(size_t)->id<1>;
-  id(size_t, size_t)->id<2>;
-  id(size_t, size_t, size_t)->id<3>;
+id(size_t)->id<1>;
+id(size_t, size_t)->id<2>;
+id(size_t, size_t, size_t)->id<3>;
 #endif
 
-  } // namespace sycl
+} // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -19,6 +19,8 @@ template <int dimensions = 1> class range : public detail::array<dimensions> {
   static_assert(dimensions >= 1 && dimensions <= 3,
                 "range can only be 1, 2, or 3 dimensional.");
   using base = detail::array<dimensions>;
+  template <typename N, typename T>
+  using IntegralType = detail::enable_if_t<std::is_integral<N>::value, T>;
 
 public:
   /* The following constructor is only available in the range class
@@ -70,15 +72,17 @@ public:
     }                                                                          \
     return result;                                                             \
   }                                                                            \
-  range<dimensions> operator op(const size_t &rhs) const {                     \
+  template <typename T>                                                        \
+  IntegralType<T, range<dimensions>> operator op(const T &rhs) const {         \
     range<dimensions> result(*this);                                           \
     for (int i = 0; i < dimensions; ++i) {                                     \
       result.common_array[i] = this->common_array[i] op rhs;                   \
     }                                                                          \
     return result;                                                             \
   }                                                                            \
-  friend range<dimensions> operator op(const size_t &lhs,                      \
-                                       const range<dimensions> &rhs) {         \
+  template <typename T>                                                        \
+  friend IntegralType<T, range<dimensions>> operator op(                       \
+      const T &lhs, const range<dimensions> &rhs) {                            \
     range<dimensions> result(rhs);                                             \
     for (int i = 0; i < dimensions; ++i) {                                     \
       result.common_array[i] = lhs op rhs.common_array[i];                     \

--- a/sycl/test/basic_tests/id.cpp
+++ b/sycl/test/basic_tests/id.cpp
@@ -88,37 +88,155 @@ int main() {
   assert(three_dim_id_brackets[0] == 64 && three_dim_id_brackets[1] == 1 &&
          three_dim_id_brackets[2] == 2);
 
-/* size_t &operator[](int dimension)const
- * Return a reference to the requested dimension of the id object. */
+  /* size_t &operator[](int dimension)const
+   * Return a reference to the requested dimension of the id object. */
 
-/* id<dimensions> operatorOP(const id<dimensions> &rhs) const
- * Where OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=.
- * Constructs and returns a new instance of the SYCL id class template with
- * the same dimensionality as this SYCL id, where each element of the new SYCL
- * id instance is the result of an element-wise OP operator between each
- * element of this SYCL id and each element of the rhs id. If the operator
- * returns a bool the result is the cast to size_t */
-#define oneLeftValue 10
+  /* bool operatorOP(const id<dimensions> &rhs) const
+   * Where OP is: ==, !=.
+   * Common by-value semantics.
+   * T must be equality comparable on the host application and within SYCL
+   * kernel functions. Equality between two instances of T (i.e. a == b) must be
+   * true if the value of all members are equal and non-equality between two
+   * instances of T (i.e. a != b) must be true if the value of any members are
+   * not equal, unless either instance has become invalidated by a move
+   * operation. Where T is id<dimensions>. */
+  {
+#define firstOneValue 10
+#define secondOneValue 19
+#define firstTwoValue 15
+#define secondTwoValue 12
+#define firstThreeValue 3
+#define secondThreeValue 22
+
+    cl::sycl::id<1> one_dim_op_one(firstOneValue);
+    cl::sycl::id<1> one_dim_op_two(secondOneValue);
+    cl::sycl::id<1> one_dim_op_another_one(firstOneValue);
+
+    cl::sycl::id<2> two_dim_op_one(firstOneValue, firstTwoValue);
+    cl::sycl::id<2> two_dim_op_two(secondOneValue, secondTwoValue);
+    cl::sycl::id<2> two_dim_op_another_one(firstOneValue, firstTwoValue);
+
+    cl::sycl::id<3> three_dim_op_one(firstOneValue, firstTwoValue,
+                                     firstThreeValue);
+    cl::sycl::id<3> three_dim_op_two(secondOneValue, secondTwoValue,
+                                     secondThreeValue);
+    cl::sycl::id<3> three_dim_op_another_one(firstOneValue, firstTwoValue,
+                                             firstThreeValue);
+
+    // OP : ==
+    // id<1> == id<1>
+    assert((one_dim_op_one == one_dim_op_two) ==
+           (firstOneValue == secondOneValue));
+    assert((one_dim_op_one == one_dim_op_another_one) ==
+           (firstOneValue == firstOneValue));
+    // id<2> == id<2>
+    assert((two_dim_op_one == two_dim_op_two) ==
+           ((firstOneValue == secondOneValue) &&
+            (firstTwoValue == secondTwoValue)));
+    assert(
+        (two_dim_op_one == two_dim_op_another_one) ==
+        ((firstOneValue == firstOneValue) && (firstTwoValue == firstTwoValue)));
+    // id<3> == id<3>
+    assert((three_dim_op_one == three_dim_op_two) ==
+           ((firstOneValue == secondOneValue) &&
+            (firstTwoValue == secondTwoValue) &&
+            (firstThreeValue == secondThreeValue)));
+    assert((three_dim_op_one == three_dim_op_another_one) ==
+           ((firstOneValue == firstOneValue) &&
+            (firstTwoValue == firstTwoValue) &&
+            (firstThreeValue == firstThreeValue)));
+    // id<1> == size_t
+    assert((one_dim_op_one == secondOneValue) ==
+           (firstOneValue == secondOneValue));
+    assert((one_dim_op_one == firstOneValue) ==
+           (firstOneValue == firstOneValue));
+
+#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+    // size_t == id<1>
+    assert((firstOneValue == one_dim_op_two) ==
+           (firstOneValue == secondOneValue));
+    assert((firstOneValue == one_dim_op_another_one) ==
+           (firstOneValue == firstOneValue));
+#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
+
+    // OP : !=
+    // id<1> != id<1>
+    assert((one_dim_op_one != one_dim_op_two) ==
+           (firstOneValue != secondOneValue));
+    assert((one_dim_op_one != one_dim_op_another_one) ==
+           (firstOneValue != firstOneValue));
+    // id<2> != id<2>
+    assert(((two_dim_op_one != two_dim_op_two) ==
+            (firstOneValue != secondOneValue)) ||
+           (firstTwoValue != secondTwoValue));
+    assert(((two_dim_op_one != two_dim_op_another_one) ==
+            (firstOneValue != firstOneValue)) ||
+           (firstTwoValue != firstTwoValue));
+    // id<3> != id<3>
+    assert((three_dim_op_one != three_dim_op_two) ==
+           ((firstOneValue != secondOneValue) ||
+            (firstTwoValue != secondTwoValue) ||
+            (firstThreeValue != secondThreeValue)));
+    assert((three_dim_op_one != three_dim_op_another_one) ==
+           ((firstOneValue != firstOneValue) ||
+            (firstTwoValue != firstTwoValue) ||
+            (firstThreeValue != firstThreeValue)));
+    // id<1> != size_t
+    assert((one_dim_op_one != secondOneValue) ==
+           (firstOneValue != secondOneValue));
+    assert((one_dim_op_one != firstOneValue) ==
+           (firstOneValue != firstOneValue));
+
+#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+    // size_t != id<1>
+    assert((firstOneValue != one_dim_op_two) ==
+           (firstOneValue != secondOneValue));
+    assert((firstOneValue != one_dim_op_another_one) ==
+           (firstOneValue != firstOneValue));
+#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
+
+#undef firstOneValue
+#undef secondOneValue
+#undef firstTwoValue
+#undef secondTwoValue
+#undef firstThreeValue
+#undef secondThreeValue
+  }
+
+  /* id<dimensions> operatorOP(const id<dimensions> &rhs) const
+   * Where OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=.
+   * Constructs and returns a new instance of the SYCL id class template with
+   * the same dimensionality as this SYCL id, where each element of the new SYCL
+   * id instance is the result of an element-wise OP operator between each
+   * element of this SYCL id and each element of the rhs id. If the operator
+   * returns a bool the result is the cast to size_t */
+  {
+    size_t value_1 = 10;
+    size_t value_2 = 15;
+    size_t value_3 = 3;
+
+#define oneLeftValue value_1
 #define oneRightValue 2
-#define twoLeftValue 15
+#define twoLeftValue value_2
 #define twoRightValue 7
-#define threeLeftValue 3
+#define threeLeftValue value_3
 #define threeRightValue 9
 
-  cl::sycl::id<1> one_dim_op_left(oneLeftValue);
-  cl::sycl::id<1> one_dim_op_right(oneRightValue);
-  cl::sycl::range<1> one_dim_op_range(oneRightValue);
+    cl::sycl::id<1> one_dim_op_left(oneLeftValue);
+    cl::sycl::id<1> one_dim_op_right(oneRightValue);
+    cl::sycl::range<1> one_dim_op_range(oneRightValue);
 
-  cl::sycl::id<2> two_dim_op_left(oneLeftValue, twoLeftValue);
-  cl::sycl::id<2> two_dim_op_right(oneRightValue, twoRightValue);
-  cl::sycl::range<2> two_dim_op_range(oneRightValue, twoRightValue);
+    cl::sycl::id<2> two_dim_op_left(oneLeftValue, twoLeftValue);
+    cl::sycl::id<2> two_dim_op_right(oneRightValue, twoRightValue);
+    cl::sycl::range<2> two_dim_op_range(oneRightValue, twoRightValue);
 
-  cl::sycl::id<3> three_dim_op_left(oneLeftValue, twoLeftValue, threeLeftValue);
-  cl::sycl::id<3> three_dim_op_right(oneRightValue, twoRightValue,
-                                     threeRightValue);
-  cl::sycl::range<3> three_dim_op_range(oneRightValue, twoRightValue,
-                                        threeRightValue);
-#define OPERATOR_TEST_BASIC(op)                                                \
+    cl::sycl::id<3> three_dim_op_left(oneLeftValue, twoLeftValue,
+                                      threeLeftValue);
+    cl::sycl::id<3> three_dim_op_right(oneRightValue, twoRightValue,
+                                       threeRightValue);
+    cl::sycl::range<3> three_dim_op_range(oneRightValue, twoRightValue,
+                                          threeRightValue);
+#define OPERATOR_TEST(op)                                                      \
   assert((one_dim_op_left op one_dim_op_right)[0] ==                           \
          (oneLeftValue op oneRightValue));                                     \
   assert((one_dim_op_right op one_dim_op_left)[0] ==                           \
@@ -146,48 +264,82 @@ int main() {
          ((twoLeftValue op three_dim_op_right)[1] ==                           \
           (twoLeftValue op twoRightValue)) &&                                  \
          ((three_dim_op_left op threeRightValue)[2] ==                         \
-          (threeLeftValue op threeRightValue)));
-
-#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
-#define OPERATOR_TEST(op)                                                      \
-  OPERATOR_TEST_BASIC(op)                                                      \
+          (threeLeftValue op threeRightValue)));                               \
   assert((one_dim_op_left op one_dim_op_range)[0] ==                           \
          (oneLeftValue op oneRightValue));                                     \
-  assert((one_dim_op_range op one_dim_op_left)[0] ==                           \
-         (oneRightValue op oneLeftValue));
-#else
-#define OPERATOR_TEST(op) OPERATOR_TEST_BASIC(op)
-#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
+  assert(((two_dim_op_left op two_dim_op_range)[0] ==                          \
+          (oneLeftValue op oneRightValue)) &&                                  \
+         ((two_dim_op_left op two_dim_op_range)[1] ==                          \
+          (twoLeftValue op twoRightValue)));                                   \
+  assert(((three_dim_op_left op three_dim_op_range)[0] ==                      \
+          (oneLeftValue op oneRightValue)) &&                                  \
+         ((three_dim_op_left op three_dim_op_range)[1] ==                      \
+          (twoLeftValue op twoRightValue)) &&                                  \
+         ((three_dim_op_left op three_dim_op_range)[2] ==                      \
+          (threeLeftValue op threeRightValue)));
 
-  OPERATOR_TEST(+)
-  OPERATOR_TEST(-)
-  OPERATOR_TEST(*)
-  OPERATOR_TEST(/)
-  OPERATOR_TEST(%)
-  OPERATOR_TEST(<<)
-  OPERATOR_TEST(>>)
-  OPERATOR_TEST(&)
-  OPERATOR_TEST(|)
-  OPERATOR_TEST(^)
-  OPERATOR_TEST(&&)
-  OPERATOR_TEST(||)
-  OPERATOR_TEST(<)
-  OPERATOR_TEST(>)
-  OPERATOR_TEST(<=)
-  OPERATOR_TEST(>=)
+    OPERATOR_TEST(+)
+    OPERATOR_TEST(-)
+    OPERATOR_TEST(*)
+    OPERATOR_TEST(/)
+    OPERATOR_TEST(%)
+    OPERATOR_TEST(<<)
+    OPERATOR_TEST(>>)
+    OPERATOR_TEST(&)
+    OPERATOR_TEST(|)
+    OPERATOR_TEST(^)
+    OPERATOR_TEST(&&)
+    OPERATOR_TEST(||)
+    OPERATOR_TEST(<)
+    OPERATOR_TEST(>)
+    OPERATOR_TEST(<=)
+    OPERATOR_TEST(>=)
 
 #undef OPERATOR_TEST
 #undef OPERATOR_TEST_BASIC
 
-  /* id<dimensions> operatorOP(const id<dimensions> &rhs) const
-   * Where OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=.
-   * Constructs and returns a new instance of the SYCL id class template with
-   * the same dimensionality as this SYCL id, where each element of the new SYCL
-   * id instance is the result of an element-wise OP operator between each
-   * element of this SYCL id and each element of the rhs id. If the operator
-   * returns a bool the result is the cast to size_t */
+#undef oneLeftValue
+#undef oneRightValue
+#undef twoLeftValue
+#undef twoRightValue
+#undef threeLeftValue
+#undef threeRightValue
+  }
 
-#define OPERATOR_TEST_BASIC(op)                                                \
+  /* id<dimensions> operatorOP(const id<dimensions> &rhs) const
+   * Where OP is: +, -, *, /, %, <<, >>, &, |, ^.
+   * Assigns each element of this SYCL id instance with the result of an
+   * element-wise OP operator between each element of this SYCL id and each
+   * element of the rhs id and returns a reference to this SYCL id. If the
+   * operator returns a bool the result is the cast to size_t */
+  {
+    size_t value_1 = 10;
+    size_t value_2 = 15;
+    size_t value_3 = 3;
+
+#define oneLeftValue value_1
+#define oneRightValue 2
+#define twoLeftValue value_2
+#define twoRightValue 7
+#define threeLeftValue value_3
+#define threeRightValue 9
+
+    cl::sycl::id<1> one_dim_op_left(oneLeftValue);
+    cl::sycl::id<1> one_dim_op_right(oneRightValue);
+    cl::sycl::range<1> one_dim_op_range(oneRightValue);
+
+    cl::sycl::id<2> two_dim_op_left(oneLeftValue, twoLeftValue);
+    cl::sycl::id<2> two_dim_op_right(oneRightValue, twoRightValue);
+    cl::sycl::range<2> two_dim_op_range(oneRightValue, twoRightValue);
+
+    cl::sycl::id<3> three_dim_op_left(oneLeftValue, twoLeftValue,
+                                      threeLeftValue);
+    cl::sycl::id<3> three_dim_op_right(oneRightValue, twoRightValue,
+                                       threeRightValue);
+    cl::sycl::range<3> three_dim_op_range(oneRightValue, twoRightValue,
+                                          threeRightValue);
+
+#define OPERATOR_TEST(op)                                                      \
   one_dim_op_left[0] = oneLeftValue;                                           \
   one_dim_op_right[0] = oneRightValue;                                         \
   assert((one_dim_op_left op## = one_dim_op_right)[0] ==                       \
@@ -223,32 +375,39 @@ int main() {
   assert(((three_dim_op_left op## = oneRightValue)[0] ==                       \
           (oneLeftValue op oneRightValue)) &&                                  \
          (three_dim_op_left[1] == (twoLeftValue op oneRightValue)) &&          \
-         (three_dim_op_left[2] == (threeLeftValue op oneRightValue)));
-
-#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
-#define OPERATOR_TEST(op)                                                      \
-  OPERATOR_TEST_BASIC(op)                                                      \
+         (three_dim_op_left[2] == (threeLeftValue op oneRightValue)));         \
   one_dim_op_left[0] = oneLeftValue;                                           \
+  one_dim_op_range[0] = oneRightValue;                                         \
   assert((one_dim_op_left op## = one_dim_op_range)[0] ==                       \
          (oneLeftValue op oneRightValue));                                     \
   two_dim_op_left[0] = oneLeftValue;                                           \
   two_dim_op_left[1] = twoLeftValue;                                           \
   two_dim_op_range[0] = oneRightValue;                                         \
-  two_dim_op_range[1] = twoRightValue;
-#else
-#define OPERATOR_TEST(op) OPERATOR_TEST_BASIC(op)
-#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
+  two_dim_op_range[1] = twoRightValue;                                         \
+  assert(((two_dim_op_left op## = two_dim_op_range)[0] ==                      \
+          (oneLeftValue op oneRightValue)) &&                                  \
+         (two_dim_op_left[1] == (twoLeftValue op twoRightValue)));             \
+  three_dim_op_left[0] = oneLeftValue;                                         \
+  three_dim_op_left[1] = twoLeftValue;                                         \
+  three_dim_op_left[2] = threeLeftValue;                                       \
+  three_dim_op_range[0] = oneRightValue;                                       \
+  three_dim_op_range[1] = twoRightValue;                                       \
+  three_dim_op_range[2] = threeRightValue;                                     \
+  assert(((three_dim_op_left op## = three_dim_op_range)[0] ==                  \
+          (oneLeftValue op oneRightValue)) &&                                  \
+         (three_dim_op_left[1] == (twoLeftValue op twoRightValue)) &&          \
+         (three_dim_op_left[2] == (threeLeftValue op threeRightValue)));
 
-  OPERATOR_TEST(+)
-  OPERATOR_TEST(-)
-  OPERATOR_TEST(*)
-  OPERATOR_TEST(/)
-  OPERATOR_TEST(%)
-  OPERATOR_TEST(<<)
-  OPERATOR_TEST(>>)
-  OPERATOR_TEST(&)
-  OPERATOR_TEST(|)
-  OPERATOR_TEST(^)
+    OPERATOR_TEST(+)
+    OPERATOR_TEST(-)
+    OPERATOR_TEST(*)
+    OPERATOR_TEST(/)
+    OPERATOR_TEST(%)
+    OPERATOR_TEST(<<)
+    OPERATOR_TEST(>>)
+    OPERATOR_TEST(&)
+    OPERATOR_TEST(|)
+    OPERATOR_TEST(^)
 
 #undef OPERATOR_TEST
 #undef OPERATOR_TEST_BASIC
@@ -259,21 +418,24 @@ int main() {
 #undef twoRightValue
 #undef threeLeftValue
 #undef threeRightValue
+  }
 
 #ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
 /* operator size_t() const
  * Test implicit cast from id<1> to size_t and int value
  * Should fails on cast from id<2> and id<3> */
 #define numValue 16
-  cl::sycl::id<1> one_dim_id_cast_to_num(numValue);
-  size_t number1 = one_dim_id_cast_to_num;
-  int number2 = one_dim_id_cast_to_num;
-  size_t number3 = (size_t)one_dim_id_cast_to_num;
-  int number4 = (int)one_dim_id_cast_to_num;
-  size_t number5 = (int)one_dim_id_cast_to_num;
-  assert((number1 == numValue) && (number2 == numValue) &&
-         (number3 == numValue) && (number4 == numValue) &&
-         (number5 == numValue));
+  {
+    cl::sycl::id<1> one_dim_id_cast_to_num(numValue);
+    size_t number_1 = one_dim_id_cast_to_num;
+    int number_2 = one_dim_id_cast_to_num;
+    size_t number_3 = (size_t)one_dim_id_cast_to_num;
+    int number_4 = (int)one_dim_id_cast_to_num;
+    size_t number_5 = (int)one_dim_id_cast_to_num;
+    assert((number_1 == numValue) && (number_2 == numValue) &&
+          (number_3 == numValue) && (number_4 == numValue) &&
+          (number_5 == numValue));
+  }
 
 #undef numValue
 #endif // __SYCL_DISABLE_ID_TO_INT_CONV__

--- a/sycl/test/basic_tests/stream/stream.cpp
+++ b/sycl/test/basic_tests/stream/stream.cpp
@@ -191,11 +191,15 @@ int main() {
 // CHECK-NEXT: 542325, 645, 771, 1024
 
         // SYCL types
+        Out << id<1>(23) << endl;
+        Out << range<1>(32) << endl;
         Out << id<3>(11, 12, 13) << endl;
         Out << range<3>(11, 12, 13) << endl;
         Out << cl::sycl::nd_range<3>(cl::sycl::range<3>(2, 4, 1),
                                      cl::sycl::range<3>(1, 2, 1))
             << endl;
+// CHECK-NEXT: {23}
+// CHECK-NEXT: {32}
 // CHECK-NEXT: {11, 12, 13}
 // CHECK-NEXT: {11, 12, 13}
 // CHECK-NEXT: nd_range(global_range: {2, 4, 1}, local_range: {1, 2, 1}, offset: {0, 0, 0})


### PR DESCRIPTION
Avoid id<1> class specialization
Fix equal operator
Add tests for stream operator (<< )

Signed-off-by: Igor Dubinov <igor.dubinov@intel.com>