### PR TITLE
[SYCL][NFC] Align graph builder functions with the LLVM coding style

### DIFF
--- a/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/scheduler.hpp
@@ -155,11 +155,11 @@ protected:
     void removeRecordForMemObj(SYCLMemObjI *MemObject);
 
     // Add new command to leaves if needed.
-    void AddNodeToLeaves(MemObjRecord *Record, Command *Cmd,
+    void addNodeToLeaves(MemObjRecord *Record, Command *Cmd,
                          access::mode AccessMode);
 
     // Removes commands from leaves.
-    void UpdateLeaves(const std::set<Command *> &Cmds, MemObjRecord *Record,
+    void updateLeaves(const std::set<Command *> &Cmds, MemObjRecord *Record,
                       access::mode AccessMode);
 
     std::vector<SYCLMemObjI *> MMemObjs;

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -130,7 +130,7 @@ Scheduler::GraphBuilder::getOrInsertMemObjRecord(const QueueImplPtr &Queue,
 }
 
 // Helper function which removes all values in Cmds from Leaves
-void Scheduler::GraphBuilder::UpdateLeaves(const std::set<Command *> &Cmds,
+void Scheduler::GraphBuilder::updateLeaves(const std::set<Command *> &Cmds,
                                            MemObjRecord *Record,
                                            access::mode AccessMode) {
 
@@ -151,7 +151,7 @@ void Scheduler::GraphBuilder::UpdateLeaves(const std::set<Command *> &Cmds,
   }
 }
 
-void Scheduler::GraphBuilder::AddNodeToLeaves(MemObjRecord *Record,
+void Scheduler::GraphBuilder::addNodeToLeaves(MemObjRecord *Record,
                                               Command *Cmd,
                                               access::mode AccessMode) {
   CircularBuffer<Command *> &Leaves{AccessMode == access::mode::read
@@ -191,8 +191,8 @@ UpdateHostRequirementCommand *Scheduler::GraphBuilder::insertUpdateHostReqCmd(
     UpdateCommand->addDep(DepDesc{Dep, StoredReq, AllocaCmd});
     Dep->addUser(UpdateCommand);
   }
-  UpdateLeaves(Deps, Record, Req->MAccessMode);
-  AddNodeToLeaves(Record, UpdateCommand, Req->MAccessMode);
+  updateLeaves(Deps, Record, Req->MAccessMode);
+  addNodeToLeaves(Record, UpdateCommand, Req->MAccessMode);
   return UpdateCommand;
 }
 
@@ -292,8 +292,8 @@ Command *Scheduler::GraphBuilder::insertMemoryMove(MemObjRecord *Record,
     NewCmd->addDep(DepDesc{Dep, NewCmd->getRequirement(), AllocaCmdDst});
     Dep->addUser(NewCmd);
   }
-  UpdateLeaves(Deps, Record, access::mode::read_write);
-  AddNodeToLeaves(Record, NewCmd, access::mode::read_write);
+  updateLeaves(Deps, Record, access::mode::read_write);
+  addNodeToLeaves(Record, NewCmd, access::mode::read_write);
   Record->MCurContext = Queue->getContextImplPtr();
   return NewCmd;
 }
@@ -330,8 +330,8 @@ Command *Scheduler::GraphBuilder::addCopyBack(Requirement *Req) {
     Dep->addUser(MemCpyCmd);
   }
 
-  UpdateLeaves(Deps, Record, Req->MAccessMode);
-  AddNodeToLeaves(Record, MemCpyCmd, Req->MAccessMode);
+  updateLeaves(Deps, Record, Req->MAccessMode);
+  addNodeToLeaves(Record, MemCpyCmd, Req->MAccessMode);
   if (MPrintOptionsArray[AfterAddCopyBack])
     printGraphAsDot("after_addCopyBack");
   return MemCpyCmd;
@@ -367,8 +367,8 @@ Command *Scheduler::GraphBuilder::addHostAccessor(Requirement *Req) {
   EmptyCmd->MCanEnqueue = false;
   EmptyCmd->MBlockReason = "A Buffer is locked by the host accessor";
 
-  UpdateLeaves({UpdateHostAccCmd}, Record, Req->MAccessMode);
-  AddNodeToLeaves(Record, EmptyCmd, Req->MAccessMode);
+  updateLeaves({UpdateHostAccCmd}, Record, Req->MAccessMode);
+  addNodeToLeaves(Record, EmptyCmd, Req->MAccessMode);
 
   Req->MBlockedCmd = EmptyCmd;
 
@@ -504,7 +504,7 @@ AllocaCommandBase *Scheduler::GraphBuilder::getOrCreateAllocaForReq(
       auto *ParentAlloca =
           getOrCreateAllocaForReq(Record, &ParentRequirement, Queue);
       AllocaCmd = new AllocaSubBufCommand(Queue, *Req, ParentAlloca);
-      UpdateLeaves(findDepsForReq(Record, Req, Queue->getContextImplPtr()),
+      updateLeaves(findDepsForReq(Record, Req, Queue->getContextImplPtr()),
                    Record, access::mode::read_write);
     } else {
 
@@ -624,8 +624,8 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
     Dep.MDepCommand->addUser(NewCmd.get());
     const Requirement *Req = Dep.MDepRequirement;
     MemObjRecord *Record = getMemObjRecord(Req->MSYCLMemObj);
-    UpdateLeaves({Dep.MDepCommand}, Record, Req->MAccessMode);
-    AddNodeToLeaves(Record, NewCmd.get(), Req->MAccessMode);
+    updateLeaves({Dep.MDepCommand}, Record, Req->MAccessMode);
+    addNodeToLeaves(Record, NewCmd.get(), Req->MAccessMode);
   }
 
   // Register all the events as dependencies

--- a/sycl/test/scheduler/FinishedCmdCleanup.cpp
+++ b/sycl/test/scheduler/FinishedCmdCleanup.cpp
@@ -60,11 +60,11 @@ int main() {
 
   FakeCommand LeafB{detail::getSyclObjImpl(Queue), FakeReqB};
   addEdge(&LeafB, &AllocaB, &AllocaB);
-  TS.AddNodeToLeaves(RecC, &LeafB);
+  TS.addNodeToLeaves(RecC, &LeafB);
 
   FakeCommand LeafA{detail::getSyclObjImpl(Queue), FakeReqA};
   addEdge(&LeafA, InnerC, &AllocaA);
-  TS.AddNodeToLeaves(RecC, &LeafA);
+  TS.addNodeToLeaves(RecC, &LeafA);
 
   FakeCommand *InnerB = new FakeCommandWithCallback(
       detail::getSyclObjImpl(Queue), FakeReqB, Callback);

--- a/sycl/test/scheduler/LeafLimit.cpp
+++ b/sycl/test/scheduler/LeafLimit.cpp
@@ -43,7 +43,7 @@ int main() {
   }
   // Add edges as leaves and exceed the leaf limit
   for (auto LeafPtr : LeavesToAdd) {
-    TS.AddNodeToLeaves(Rec, LeafPtr);
+    TS.addNodeToLeaves(Rec, LeafPtr);
   }
   // Check that the oldest leaf has been removed from the leaf list
   // and added as a dependency of the newest one instead

--- a/sycl/test/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/test/scheduler/SchedulerTestUtils.hpp
@@ -55,10 +55,10 @@ public:
     MGraphBuilder.cleanupCommandsForRecord(Rec);
   }
 
-  void AddNodeToLeaves(
+  void addNodeToLeaves(
       cl::sycl::detail::MemObjRecord *Rec, cl::sycl::detail::Command *Cmd,
       cl::sycl::access::mode Mode = cl::sycl::access::mode::read_write) {
-    return MGraphBuilder.AddNodeToLeaves(Rec, Cmd, Mode);
+    return MGraphBuilder.addNodeToLeaves(Rec, Cmd, Mode);
   }
 };
 


### PR DESCRIPTION
Change function names to camelCase.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>