### PR TITLE
[SYCL] Add buffer dimensions restriction

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -370,6 +370,10 @@ private:
       return newRange[0] == 1 && newRange[2] == parentRange[2];
     return newRange[1] == parentRange[1] && newRange[2] == parentRange[2];
   }
+
+  static_assert (dimensions > 0 && dimensions <= 3,
+		  "Dimensions can be 1/2/3 for buffer.");
+
 };
 
 #ifdef __cpp_deduction_guides

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -372,7 +372,7 @@ private:
   }
 
   static_assert (dimensions > 0 && dimensions <= 3,
-		  "Range can only be 1/2/3 dimensional.");
+		  "Range of the buffer can only be 1/2/3 dimensional.");
 
 };
 

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -372,7 +372,7 @@ private:
   }
 
   static_assert (dimensions > 0 && dimensions <= 3,
-		  "Dimensions can be 1/2/3 for buffer.");
+		  "Range can only be 1/2/3 dimensional.");
 
 };
 


### PR DESCRIPTION
Adding a static_assert to the buffer dimensions.

Signed-off-by: amochalo <anastasiya.mochalova@intel.com>