### PR TITLE
[SYCL] Disallow zero length arrays in SYCL kernels

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10429,6 +10429,8 @@ def err_conflicting_sycl_kernel_attributes : Error<
   "conflicting attributes applied to a SYCL kernel">;
 def err_conflicting_sycl_function_attributes : Error<
    "%0 attribute conflicts with '%1' attribute">;
+def err_sycl_typecheck_zero_array_size : Error<
+  "zero-length arrays are not permitted in SYCL kernels">;
 def err_sycl_x_y_z_arguments_must_be_one : Error<
   "%0 X-, Y- and Z- sizes must be 1 when %1 attribute is used with value 0">;
 def err_intel_attribute_argument_is_not_in_range: Error<

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -2340,6 +2340,13 @@ QualType Sema::BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
             << ArraySize->getSourceRange();
         ASM = ArrayType::Normal;
       }
+
+      // SYCL kernels reject zero length arrays
+      if (getLangOpts().SYCLIsDevice) {
+        SYCLDiagIfDeviceCode(ArraySize->getBeginLoc(),
+                             diag::err_sycl_typecheck_zero_array_size)
+            << ArraySize->getSourceRange();
+      }
     } else if (!T->isDependentType() && !T->isVariablyModifiedType() &&
                !T->isIncompleteType() && !T->isUndeducedType()) {
       // Is the array too large?

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -143,6 +143,9 @@ void usage(myFuncDef functionPtr) {
 
   // expected-error@+1 {{__float128 is not supported on this target}}
   __float128 A;
+
+  // expected-error@+1 {{zero-length arrays are not permitted in SYCL kernels}}
+  int BadArray[0];
 }
 
 namespace ns {


### PR DESCRIPTION
zero length arrays in SYCL kernels are not allowed.  Adding code to issue a deferred diagnostic error.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>