### PR TITLE
[SYCL] Enable assertions in Release mode

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -32,6 +32,7 @@ def do_configure(args):
                  "-DLLVM_BUILD_TOOLS=ON",
                  "-DSYCL_ENABLE_WERROR=ON",
                  "-DLLVM_ENABLE_ASSERTIONS=ON",
+                 "-DSYCL_ENABLE_ASSERTIONS=ON",
                  "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),
                  "-DSYCL_INCLUDE_TESTS=ON", # Explicitly include all kinds of SYCL tests.
                  llvm_dir]

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -7,6 +7,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 option(SYCL_ENABLE_WERROR "Treat all warnings as errors in SYCL project" OFF)
+option(SYCL_ENABLE_ASSERTIONS OFF "Enable assertions in SYCL Runtime")
+
+if (CMAKE_BUILD_TYPE MATCHES "Debug" OR CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
+  set(SYCL_ENABLE_ASSERTIONS ON CACHE BOOL "Enable assertions in SYCL Runtime")
+endif()
 
 # enable all warnings by default
 if (MSVC)

--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -385,8 +385,8 @@ public:
         MSyclKernel(std::move(SyclKernel)), MArgs(std::move(Args)),
         MKernelName(std::move(KernelName)), MOSModuleHandle(OSModuleHandle),
         MStreams(std::move(Streams)) {
-    assert((getType() == RUN_ON_HOST_INTEL || getType() == KERNEL) &&
-           "Wrong type of exec kernel CG.");
+    __SYCL_ASSERT(getType() == RUN_ON_HOST_INTEL || getType() == KERNEL,
+                  "Wrong type of exec kernel CG.");
   }
 
   vector_class<ArgDesc> getArguments() const { return MArgs; }

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/detail/defines.hpp>
+#include <CL/sycl/detail/sycl_assert.hpp>
 
 // Suppress a compiler warning about undefined CL_TARGET_OPENCL_VERSION
 // Khronos ICD supports only latest OpenCL version
@@ -34,13 +35,6 @@ static inline std::string codeToString(cl_int code){
 }
 
 }}} // __SYCL_INLINE_NAMESPACE(cl)::sycl::detail
-
-#ifdef __SYCL_DEVICE_ONLY__
-// TODO remove this when 'assert' is supported in device code
-#define __SYCL_ASSERT(x)
-#else
-#define __SYCL_ASSERT(x) assert(x)
-#endif // #ifdef __SYCL_DEVICE_ONLY__
 
 #define OCL_ERROR_REPORT                                                       \
   "OpenCL API failed. " /*__FILE__*/                                           \

--- a/sycl/include/CL/sycl/detail/scheduler/commands.hpp
+++ b/sycl/include/CL/sycl/detail/scheduler/commands.hpp
@@ -121,7 +121,8 @@ public:
   virtual void printDot(std::ostream &Stream) const = 0;
 
   virtual const Requirement *getRequirement() const {
-    assert(!"Internal Error. The command has no stored requirement");
+    __SYCL_ASSERT(false,
+                  "Internal Error. The command has no stored requirement");
     return nullptr;
   }
 

--- a/sycl/include/CL/sycl/detail/sycl_assert.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_assert.hpp
@@ -1,5 +1,14 @@
+//==----------- sycl_assert.hpp - SYCL standard header file ----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include <CL/sycl/detail/defines.hpp>
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 
@@ -7,28 +16,13 @@
 #ifndef __SYCL_DEVICE_ONLY__
 #define __SYCL_STR(X) #X
 #define __SYCL_XSTR(X) __SYCL_STR(X)
-#ifdef WIN32
-#define _SEP '\\'
-#else
-#define _SEP '/'
-#endif
-#define __SYCL_FILE__                                                          \
-  ({                                                                           \
-    static const int32_t Idx = sycl::detail::filename(__FILE__);               \
-    __FILE__ ":" __SYCL_XSTR(__LINE__) + Idx;                                  \
-  })
+#define __SYCL_FILE__ __FILE__ ":" __LINE__ 
 #define __SYCL_ASSERT(X, ...)                                                  \
   sycl::detail::sycl_assert(__SYCL_FILE__, X, __SYCL_XSTR(X), __VA_ARGS__)
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
-constexpr int32_t filename(const char *const Path, const int32_t Idx = 0,
-                           const int32_t SlashIdx = -1) {
-  return Path[Idx] ? (Path[Idx] == _SEP ? filename(Path, Idx + 1, Idx)
-                                       : filename(Path, Idx + 1, SlashIdx))
-                   : SlashIdx + 1;
-}
 template <typename... Args>
 void sycl_assert(const std::string &FileName, bool Cond,
                  const std::string &CondStr, Args &&... Messages) {
@@ -43,10 +37,10 @@ void sycl_assert(const std::string &FileName, bool Cond,
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
-#undef _SEP
-#else
+#else // #ifdef __SYCL_DEVICE_ONLY__
 #define __SYCL_ASSERT(X, ...) assert(X)
 #endif // #ifdef __SYCL_DEVICE_ONLY__
 #else  // #ifdef __SYCL_ENABLE_ASSERTIONS__
 #define __SYCL_ASSERT(X, ...)
 #endif // #ifdef __SYCL_ENABLE_ASSERTIONS__
+

--- a/sycl/include/CL/sycl/detail/sycl_assert.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_assert.hpp
@@ -16,7 +16,7 @@
 #ifndef __SYCL_DEVICE_ONLY__
 #define __SYCL_STR(X) #X
 #define __SYCL_XSTR(X) __SYCL_STR(X)
-#define __SYCL_FILE__ __FILE__ ":" __LINE__ 
+#define __SYCL_FILE__ __FILE__ ":" __SYCL_XSTR(__LINE__)
 #define __SYCL_ASSERT(X, ...)                                                  \
   sycl::detail::sycl_assert(__SYCL_FILE__, X, __SYCL_XSTR(X), __VA_ARGS__)
 

--- a/sycl/include/CL/sycl/detail/sycl_assert.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_assert.hpp
@@ -7,6 +7,11 @@
 #ifndef __SYCL_DEVICE_ONLY__
 #define __SYCL_STR(X) #X
 #define __SYCL_XSTR(X) __SYCL_STR(X)
+#ifdef WIN32
+#define _SEP '\\'
+#else
+#define _SEP '/'
+#endif
 #define __SYCL_FILE__                                                          \
   ({                                                                           \
     static const int32_t Idx = sycl::detail::filename(__FILE__);               \
@@ -20,7 +25,7 @@ namespace sycl {
 namespace detail {
 constexpr int32_t filename(const char *const Path, const int32_t Idx = 0,
                            const int32_t SlashIdx = -1) {
-  return Path[Idx] ? (Path[Idx] == '/' ? filename(Path, Idx + 1, Idx)
+  return Path[Idx] ? (Path[Idx] == _SEP ? filename(Path, Idx + 1, Idx)
                                        : filename(Path, Idx + 1, SlashIdx))
                    : SlashIdx + 1;
 }
@@ -38,6 +43,7 @@ void sycl_assert(const std::string &FileName, bool Cond,
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
+#undef _SEP
 #else
 #define __SYCL_ASSERT(X, ...) assert(X)
 #endif // #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/detail/sycl_assert.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_assert.hpp
@@ -1,0 +1,46 @@
+#include <CL/sycl/detail/defines.hpp>
+
+#include <iostream>
+#include <string>
+
+#ifdef __SYCL_ENABLE_ASSERTIONS__
+#ifndef __SYCL_DEVICE_ONLY__
+#define __SYCL_STR(X) #X
+#define __SYCL_XSTR(X) __SYCL_STR(X)
+#define __SYCL_FILE__                                                          \
+  ({                                                                           \
+    static const int32_t Idx = sycl::detail::filename(__FILE__);               \
+    __FILE__ ":" __SYCL_XSTR(__LINE__) + Idx;                                  \
+  })
+#define __SYCL_ASSERT(X, ...)                                                  \
+  sycl::detail::sycl_assert(__SYCL_FILE__, X, __SYCL_XSTR(X), __VA_ARGS__)
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace detail {
+constexpr int32_t filename(const char *const Path, const int32_t Idx = 0,
+                           const int32_t SlashIdx = -1) {
+  return Path[Idx] ? (Path[Idx] == '/' ? filename(Path, Idx + 1, Idx)
+                                       : filename(Path, Idx + 1, SlashIdx))
+                   : SlashIdx + 1;
+}
+template <typename... Args>
+void sycl_assert(const std::string &FileName, bool Cond,
+                 const std::string &CondStr, Args &&... Messages) {
+  if (!Cond) {
+    std::cerr << "Assertion \"" << CondStr << "\" at (" << FileName << "): ";
+    using Expander = int[];
+    (void)Expander{
+        0, (void(std::cerr << std::forward<Args>(Messages) << " "), 0)...};
+    exit(-1);
+  }
+}
+} // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)
+#else
+#define __SYCL_ASSERT(X, ...) assert(X)
+#endif // #ifdef __SYCL_DEVICE_ONLY__
+#else  // #ifdef __SYCL_ENABLE_ASSERTIONS__
+#define __SYCL_ASSERT(X, ...)
+#endif // #ifdef __SYCL_ENABLE_ASSERTIONS__

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -314,7 +314,7 @@ public:
   bool operator==(const group<dimensions> &rhs) const {
     bool Result = (rhs.globalRange == globalRange) &&
                   (rhs.localRange == localRange) && (rhs.index == index);
-    __SYCL_ASSERT(rhs.groupRange == groupRange &&
+    __SYCL_ASSERT(rhs.groupRange == groupRange,
                   "inconsistent group class fields");
     return Result;
   }
@@ -345,13 +345,7 @@ protected:
   friend class detail::Builder;
   group(const range<dimensions> &G, const range<dimensions> &L,
         const range<dimensions> GroupRange, const id<dimensions> &I)
-      : globalRange(G), localRange(L), groupRange(GroupRange), index(I) {
-    // Make sure local range divides global without remainder:
-    __SYCL_ASSERT(((G % L).size() == 0) &&
-                  "global range is not multiple of local");
-    __SYCL_ASSERT((((G / L) - GroupRange).size() == 0) &&
-                  "inconsistent group constructor arguments");
-  }
+      : globalRange(G), localRange(L), groupRange(GroupRange), index(I) {}
 };
 
 } // namespace sycl

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -182,7 +182,7 @@ private:
     // Now if they are equal we extract argumets from lambda/functor for the
     // kernel. Else it is necessary use set_atg(s) for resolve the order and
     // values of arguments for the kernel.
-    assert(MSyclKernel && "MSyclKernel is not initialized");
+    __SYCL_ASSERT(MSyclKernel != nullptr, "MSyclKernel is not initialized");
     const string_class LambdaName = detail::KernelInfo<LambdaNameT>::getName();
     const string_class KernelName = getKernelName();
     return LambdaName == KernelName;
@@ -1082,9 +1082,9 @@ public:
     static_assert(isValidTargetForExplicitOp(AccessTarget_Dst),
                   "Invalid destination accessor target for the copy method.");
     // TODO replace to get_size() when it will provide correct values.
-    assert(
+    __SYCL_ASSERT(
         (Dst.get_range().size() * sizeof(T_Dst) >=
-         Src.get_range().size() * sizeof(T_Src)) &&
+         Src.get_range().size() * sizeof(T_Src)),
         "dest must have at least as many bytes as the range accessed by src.");
     if (MIsHost ||
         !IsCopyingRectRegionAvailable(Src.get_range(), Dst.get_range())) {

--- a/sycl/include/CL/sycl/intel/pipes.hpp
+++ b/sycl/include/CL/sycl/intel/pipes.hpp
@@ -30,7 +30,7 @@ public:
         __spirv_ReadPipe(RPipe, &TempData, m_Size, m_Alignment));
     return TempData;
 #else
-    assert(!"Pipes are not supported on a host device!");
+    __SYCL_ASSERT(false, "Pipes are not supported on a host device!");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -43,7 +43,7 @@ public:
     Success = !static_cast<bool>(
         __spirv_WritePipe(WPipe, &Data, m_Size, m_Alignment));
 #else
-    assert(!"Pipes are not supported on a host device!");
+    __SYCL_ASSERT(false, "Pipes are not supported on a host device!");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -58,7 +58,7 @@ public:
     __spirv_ReadPipeBlockingINTEL(RPipe, &TempData, m_Size, m_Alignment);
     return TempData;
 #else
-    assert(!"Pipes are not supported on a host device!");
+    __SYCL_ASSERT(false, "Pipes are not supported on a host device!");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -70,7 +70,7 @@ public:
       __spirv_CreatePipeFromPipeStorage_write<dataT>(&m_Storage);
     __spirv_WritePipeBlockingINTEL(WPipe, &Data, m_Size, m_Alignment);
 #else
-    assert(!"Pipes are not supported on a host device!");
+    __SYCL_ASSERT(false, "Pipes are not supported on a host device!");
 #endif // __SYCL_DEVICE_ONLY__
   }
 

--- a/sycl/include/CL/sycl/property_list.hpp
+++ b/sycl/include/CL/sycl/property_list.hpp
@@ -79,7 +79,7 @@ public:
   }
 
   const T &getProp() const {
-    assert(true == m_Initialized && "Property was not set!");
+    __SYCL_ASSERT(m_Initialized, "Property was not set!");
     return *(const T *)m_Mem;
   }
   bool isInitialized() const { return m_Initialized; }

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -260,7 +260,7 @@ detail::enable_if_t<is_float_to_int<T, R>::value, R> convertImpl(T Value) {
   case rounding_mode::rtn:
     return std::floor(Value);
   default:
-    assert(!"Unsupported rounding mode!");
+    __SYCL_ASSERT(false, "Unsupported rounding mode!");
     return static_cast<R>(Value);
   };
 #else

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -27,6 +27,10 @@ function(add_sycl_rt_library LIB_NAME)
       set_target_properties(${LIB_NAME} PROPERTIES LINK_DEPENDS ${linker_script})
   endif()
 
+  if (SYCL_ENABLE_ASSERTIONS)
+    target_compile_definitions(${LIB_NAME} PRIVATE __SYCL_ENABLE_ASSERTIONS__)
+  endif()
+
   target_include_directories(
       ${LIB_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} "${sycl_inc_dir}")
   target_link_libraries(${LIB_NAME}


### PR DESCRIPTION
New CMake option SYCL_ENABLE_ASSERTIONS enforces assertions in Release and RelWithDebInfo build modes.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>