### PR TITLE
[SYCL] Update the kernel parameter rule to is-trivially-copy-construc…

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10491,7 +10491,7 @@ def err_sycl_virtual_types : Error<
 def note_sycl_used_here : Note<"used here">;
 def note_sycl_recursive_function_declared_here: Note<"function implemented using recursion declared here">;
 def err_sycl_non_trivially_copyable_type : Error<
-  "kernel parameter has non-trivially copyable class/struct type %0">;
+  "kernel parameter has non-trivially copy constructible class/struct type %0">;
 def err_sycl_non_std_layout_type : Error<
   "kernel parameter has non-standard layout class/struct type %0">;
 def err_conflicting_sycl_kernel_attributes : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10490,8 +10490,9 @@ def err_sycl_virtual_types : Error<
   "No class with a vtable can be used in a SYCL kernel or any code included in the kernel">;
 def note_sycl_used_here : Note<"used here">;
 def note_sycl_recursive_function_declared_here: Note<"function implemented using recursion declared here">;
-def err_sycl_non_trivially_copyable_type : Error<
-  "kernel parameter has non-trivially copy constructible class/struct type %0">;
+def err_sycl_non_trivially_copy_ctor_dtor_type
+    : Error<"kernel parameter has non-trivially %select{copy "
+            "constructible|destructible}0 class/struct type %1">;
 def err_sycl_non_std_layout_type : Error<
   "kernel parameter has non-standard layout class/struct type %0">;
 def err_conflicting_sycl_kernel_attributes : Error<

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1069,7 +1069,10 @@ static bool buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
           continue;
         }
       }
-      if (!ArgTy.isTriviallyCopyableType(Context)) {
+
+      CXXRecordDecl *RD =
+          cast<CXXRecordDecl>(ArgTy->getAs<RecordType>()->getDecl());
+      if (!RD->hasTrivialCopyConstructor()) {
         Context.getDiagnostics().Report(
             Fld->getLocation(), diag::err_sycl_non_trivially_copyable_type)
             << ArgTy;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1074,8 +1074,17 @@ static bool buildArgTys(ASTContext &Context, CXXRecordDecl *KernelObj,
           cast<CXXRecordDecl>(ArgTy->getAs<RecordType>()->getDecl());
       if (!RD->hasTrivialCopyConstructor()) {
         Context.getDiagnostics().Report(
-            Fld->getLocation(), diag::err_sycl_non_trivially_copyable_type)
-            << ArgTy;
+            Fld->getLocation(),
+            diag::err_sycl_non_trivially_copy_ctor_dtor_type)
+            << 0 << ArgTy;
+        AllArgsAreValid = false;
+        continue;
+      }
+      if (!RD->hasTrivialDestructor()) {
+        Context.getDiagnostics().Report(
+            Fld->getLocation(),
+            diag::err_sycl_non_trivially_copy_ctor_dtor_type)
+            << 1 << ArgTy;
         AllArgsAreValid = false;
         continue;
       }

--- a/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
+++ b/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
@@ -11,6 +11,11 @@ struct B {
   B (const B& x) : i(x.i) {}
 };
 
+struct C : A {
+  const A C2;
+  C() : A{0}, C2{2}{}
+};
+
 template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   kernelFunc();
@@ -20,9 +25,11 @@ void test() {
   A IamGood;
   IamGood.i = 0;
   B IamBad(1);
+  C IamAlsoGood;
   kernel_single_task<class kernel_capture_refs>([=] {
     int a = IamGood.i;
-    // expected-error@+1 {{kernel parameter has non-trivially copyable class/struct type}}
+    // expected-error@+1 {{kernel parameter has non-trivially copy constructible class/struct type}}
     int b = IamBad.i;
+    int C = IamAlsoGood.i;
   });
 }

--- a/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
+++ b/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
@@ -16,6 +16,11 @@ struct C : A {
   C() : A{0}, C2{2}{}
 };
 
+struct D {
+  int i;
+  ~D();
+};
+
 template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   kernelFunc();
@@ -26,10 +31,13 @@ void test() {
   IamGood.i = 0;
   B IamBad(1);
   C IamAlsoGood;
+  D IamAlsoBad{0};
   kernel_single_task<class kernel_capture_refs>([=] {
     int a = IamGood.i;
     // expected-error@+1 {{kernel parameter has non-trivially copy constructible class/struct type}}
     int b = IamBad.i;
-    int C = IamAlsoGood.i;
+    int c = IamAlsoGood.i;
+    // expected-error@+1 {{kernel parameter has non-trivially destructible class/struct type}}
+    int d = IamAlsoBad.i;
   });
 }


### PR DESCRIPTION
…tible.

Since we really just want to be able to memcpy the type to the device,
'is-trivially-copyable' is not the correct trait. Since CWG1734, If we want
to support trivially copyable types, we would be required to create 1 of 4
different mechanisms for having a type on the device (depending on the
way the type is structured). Additionally, 2 of these ways require us to
ALSO have the type be default constructible.

This patch transitions to trivially-copy-constructible , so that we can
simply memcpy from the existing one into new memory.

Signed-off-by: Erich Keane <erich.keane@intel.com>