### PR TITLE
[SYCL] Add buffer dimensions restriction

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -796,7 +796,7 @@ public:
             typename = typename detail::enable_if_t<
                 (Dims > 0) && ((!IsPlaceH && IsHostBuf) ||
                                (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>>
-	accessor(buffer<DataT, Dims, AllocatorT> &BufferRef)
+  accessor(buffer<DataT, Dims, AllocatorT> &BufferRef)
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<Dimensions>(), BufferRef.get_range(), BufferRef.get_range()) {
   }
@@ -931,9 +931,9 @@ public:
   }
 
   template <int Dims = Dimensions>
-  operator typename detail::enable_if_t<Dims == 0 &&
-                                       AccessMode == access::mode::atomic,
-                                   atomic<DataT, AS>>() const {
+  operator typename detail::enable_if_t<
+      Dims == 0 && AccessMode == access::mode::atomic, atomic<DataT, AS>>()
+      const {
     const size_t LinearIndex = getLinearIndex(id<AdjustedDim>());
     return atomic<DataT, AS>(
         multi_ptr<DataT, AS>(getQualifiedPtr() + LinearIndex));
@@ -941,7 +941,7 @@ public:
 
   template <int Dims = Dimensions>
   typename detail::enable_if_t<(Dims > 0) && AccessMode == access::mode::atomic,
-                          atomic<DataT, AS>>
+                               atomic<DataT, AS>>
   operator[](id<Dimensions> Index) const {
     const size_t LinearIndex = getLinearIndex(Index);
     return atomic<DataT, AS>(

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -774,10 +774,10 @@ public:
   }
 
   template <int Dims = Dimensions, typename AllocatorT,
-	   typename = typename std::enable_if<
+	   typename = typename detail::enable_if_t<
 		   (Dims == 0) && 
                     (!IsPlaceH && (IsGlobalBuf || IsConstantBuf))>
-		    			::type>
+		    			>
   accessor(buffer<DataT,1,AllocatorT> &BufferRef,
 		  handler &CommandGroupHandler)
    
@@ -796,9 +796,9 @@ public:
 #endif
 
   template <int Dims = Dimensions, typename AllocatorT,
-            typename = typename std::enable_if<
+            typename = typename detail::enable_if_t<
                 (Dims > 0) && ((!IsPlaceH && IsHostBuf) ||
-                               (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>::type>
+                               (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>>
 	accessor(buffer<DataT, Dims, AllocatorT> &BufferRef)
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<Dimensions>(), BufferRef.get_range(), BufferRef.get_range()) {
@@ -934,17 +934,17 @@ public:
   }
 
   template <int Dims = Dimensions>
-  operator typename std::enable_if<Dims == 0 &&
+  operator typename detail::enable_if_t<Dims == 0 &&
                                        AccessMode == access::mode::atomic,
-                                   atomic<DataT, AS>>::type() const {
+                                   atomic<DataT, AS>>() const {
     const size_t LinearIndex = getLinearIndex(id<AdjustedDim>());
     return atomic<DataT, AS>(
         multi_ptr<DataT, AS>(getQualifiedPtr() + LinearIndex));
   }
 
   template <int Dims = Dimensions>
-  typename std::enable_if<(Dims > 0) && AccessMode == access::mode::atomic,
-                          atomic<DataT, AS>>::type
+  typename detail::enable_if_t<(Dims > 0) && AccessMode == access::mode::atomic,
+                          atomic<DataT, AS>>
   operator[](id<Dimensions> Index) const {
     const size_t LinearIndex = getLinearIndex(Index);
     return atomic<DataT, AS>(
@@ -953,7 +953,7 @@ public:
 
   template <int Dims = Dimensions>
   typename detail::enable_if_t<Dims == 1 && AccessMode == access::mode::atomic,
-                               atomic<DataT, AS>>::type
+                               atomic<DataT, AS>>
   operator[](size_t Index) const {
     const size_t LinearIndex = getLinearIndex(id<AdjustedDim>(Index));
     return atomic<DataT, AS>(

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -793,9 +793,10 @@ public:
 #endif
 
   template <int Dims = Dimensions, typename AllocatorT,
-            typename = typename detail::enable_if_t<
-                (Dims > 0) && ((!IsPlaceH && IsHostBuf) ||
-                               (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>>
+            typename = detail::enable_if_t<(Dims > 0) && (Dims == Dimensions) &&
+                                           ((!IsPlaceH && IsHostBuf) ||
+                                            (IsPlaceH &&
+                                             (IsGlobalBuf || IsConstantBuf)))>>
   accessor(buffer<DataT, Dims, AllocatorT> &BufferRef)
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<Dimensions>(), BufferRef.get_range(), BufferRef.get_range()) {
@@ -813,8 +814,9 @@ public:
 #endif
 
   template <int Dims = Dimensions, typename AllocatorT,
-            typename = detail::enable_if_t<
-                (Dims > 0) && (!IsPlaceH && (IsGlobalBuf || IsConstantBuf))>>
+            typename = detail::enable_if_t<(Dims > 0) && (Dims == Dimensions) &&
+                                           (!IsPlaceH &&
+                                            (IsGlobalBuf || IsConstantBuf))>>
   accessor(buffer<DataT, Dims, AllocatorT> &BufferRef,
            handler &CommandGroupHandler)
 #ifdef __SYCL_DEVICE_ONLY__
@@ -832,9 +834,10 @@ public:
 #endif
 
   template <int Dims = Dimensions, typename AllocatorT,
-            typename = detail::enable_if_t<
-                (Dims > 0) && ((!IsPlaceH && IsHostBuf) ||
-                               (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>>
+            typename = detail::enable_if_t<(Dims > 0) && (Dims == Dimensions) &&
+                                           ((!IsPlaceH && IsHostBuf) ||
+                                            (IsPlaceH &&
+                                             (IsGlobalBuf || IsConstantBuf)))>>
   accessor(buffer<DataT, Dims, AllocatorT> &BufferRef,
            range<Dimensions> AccessRange, id<Dimensions> AccessOffset = {})
 #ifdef __SYCL_DEVICE_ONLY__
@@ -853,8 +856,9 @@ public:
 #endif
 
   template <int Dims = Dimensions, typename AllocatorT,
-            typename = detail::enable_if_t<
-                (Dims > 0) && (!IsPlaceH && (IsGlobalBuf || IsConstantBuf))>>
+            typename = detail::enable_if_t<(Dims > 0) && (Dims == Dimensions) &&
+                                           (!IsPlaceH &&
+                                            (IsGlobalBuf || IsConstantBuf))>>
   accessor(buffer<DataT, Dims, AllocatorT> &BufferRef,
            handler &CommandGroupHandler, range<Dimensions> AccessRange,
            id<Dimensions> AccessOffset = {})

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -763,8 +763,7 @@ public:
       : impl(id<AdjustedDim>(), range<1>{1}, BufferRef.get_range()) {
 #else
       : AccessorBaseHost(
-            /*Offset=*/{0, 0, 0},
-            detail::convertToArrayOfN<3, 1>(range<1>{1}),
+            /*Offset=*/{0, 0, 0}, detail::convertToArrayOfN<3, 1>(range<1>{1}),
             detail::convertToArrayOfN<3, 1>(BufferRef.get_range()), AccessMode,
             detail::getSyclObjImpl(BufferRef).get(), AdjustedDim, sizeof(DataT),
             BufferRef.OffsetInBytes, BufferRef.IsSubBuffer) {
@@ -780,14 +779,12 @@ public:
 		    			>
   accessor(buffer<DataT,1,AllocatorT> &BufferRef,
 		  handler &CommandGroupHandler)
-   
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<AdjustedDim>(), range<1>{1}, BufferRef.get_range()) {
   }
 #else
       : AccessorBaseHost(
-            /*Offset=*/{0, 0, 0},
-            detail::convertToArrayOfN<3, 1>(range<1>{1}),
+            /*Offset=*/{0, 0, 0}, detail::convertToArrayOfN<3, 1>(range<1>{1}),
             detail::convertToArrayOfN<3, 1>(BufferRef.get_range()), AccessMode,
             detail::getSyclObjImpl(BufferRef).get(), Dimensions, sizeof(DataT),
             BufferRef.OffsetInBytes, BufferRef.IsSubBuffer) {
@@ -1276,4 +1273,4 @@ struct hash<cl::sycl::accessor<DataT, Dimensions, AccessMode, AccessTarget,
   }
 };
 
-} // namespace std
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -773,11 +773,14 @@ public:
 #endif
   }
 
-  template <int Dims = Dimensions, typename AllocatorT>
-  accessor(buffer<DataT, 1, AllocatorT> &BufferRef,
-           detail::enable_if_t<Dims == 0 &&
-                               (!IsPlaceH && (IsGlobalBuf || IsConstantBuf)),
-                               handler> &CommandGroupHandler)
+  template <int Dims = Dimensions, typename AllocatorT,
+	   typename = typename std::enable_if<
+		   (Dims == 0) && 
+                    (!IsPlaceH && (IsGlobalBuf || IsConstantBuf))>
+		    			::type>
+  accessor(buffer<DataT,1,AllocatorT> &BufferRef,
+		  handler &CommandGroupHandler)
+   
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<AdjustedDim>(), range<1>{1}, BufferRef.get_range()) {
   }
@@ -793,11 +796,10 @@ public:
 #endif
 
   template <int Dims = Dimensions, typename AllocatorT,
-            typename detail::enable_if_t<
+            typename = typename std::enable_if<
                 (Dims > 0) && ((!IsPlaceH && IsHostBuf) ||
-                               (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>
-                * = nullptr>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef)
+                               (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>::type>
+	accessor(buffer<DataT, Dims, AllocatorT> &BufferRef)
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<Dimensions>(), BufferRef.get_range(), BufferRef.get_range()) {
   }
@@ -816,7 +818,7 @@ public:
   template <int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<
                 (Dims > 0) && (!IsPlaceH && (IsGlobalBuf || IsConstantBuf))>>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+  accessor(buffer<DataT, Dims, AllocatorT> &BufferRef,
            handler &CommandGroupHandler)
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(id<AdjustedDim>(), BufferRef.get_range(), BufferRef.get_range()) {
@@ -836,7 +838,7 @@ public:
             typename = detail::enable_if_t<
                 (Dims > 0) && ((!IsPlaceH && IsHostBuf) ||
                                (IsPlaceH && (IsGlobalBuf || IsConstantBuf)))>>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+  accessor(buffer<DataT, Dims, AllocatorT> &BufferRef,
            range<Dimensions> AccessRange, id<Dimensions> AccessOffset = {})
 #ifdef __SYCL_DEVICE_ONLY__
       : impl(AccessOffset, AccessRange, BufferRef.get_range()) {
@@ -856,7 +858,7 @@ public:
   template <int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<
                 (Dims > 0) && (!IsPlaceH && (IsGlobalBuf || IsConstantBuf))>>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+  accessor(buffer<DataT, Dims, AllocatorT> &BufferRef,
            handler &CommandGroupHandler, range<Dimensions> AccessRange,
            id<Dimensions> AccessOffset = {})
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -1273,4 +1273,4 @@ struct hash<cl::sycl::accessor<DataT, Dimensions, AccessMode, AccessTarget,
   }
 };
 
-} // __SYCL_INLINE_NAMESPACE(cl)
+} // namespace std

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -22,7 +22,8 @@ template <int dimensions> class range;
 
 template <typename T, int dimensions = 1,
           typename AllocatorT = cl::sycl::buffer_allocator,
-	  typename = typename std::enable_if<(dimensions >0)&&(dimensions <= 3)>::type											>
+          typename = typename std::enable_if<(dimensions > 0) &&
+                                             (dimensions <= 3)>::type>
 class buffer {
 public:
   using value_type = T;
@@ -301,9 +302,10 @@ private:
   shared_ptr_class<detail::buffer_impl> impl;
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
-  template <typename A, int dims, typename C,typename Enable> friend class buffer;
-  template <typename DataT, int dims, access::mode mode,
-            access::target target, access::placeholder isPlaceholder>
+  template <typename A, int dims, typename C, typename Enable>
+  friend class buffer;
+  template <typename DataT, int dims, access::mode mode, access::target target,
+            access::placeholder isPlaceholder>
   friend class accessor;
   range<dimensions> Range;
   // Offset field specifies the origin of the sub buffer inside the parent

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -21,7 +21,8 @@ class queue;
 template <int dimensions> class range;
 
 template <typename T, int dimensions = 1,
-          typename AllocatorT = cl::sycl::buffer_allocator>
+          typename AllocatorT = cl::sycl::buffer_allocator,
+	  typename = typename std::enable_if<(dimensions >0)&&(dimensions <= 3)>::type											>
 class buffer {
 public:
   using value_type = T;
@@ -300,7 +301,7 @@ private:
   shared_ptr_class<detail::buffer_impl> impl;
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
-  template <typename A, int dims, typename C> friend class buffer;
+  template <typename A, int dims, typename C,typename Enable> friend class buffer;
   template <typename DataT, int dims, access::mode mode,
             access::target target, access::placeholder isPlaceholder>
   friend class accessor;

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -30,7 +30,8 @@ namespace sycl {
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::target AccessTarget, access::placeholder IsPlaceholder>
 class accessor;
-template <typename T, int Dimensions, typename AllocatorT, typename Enable> class buffer;
+template <typename T, int Dimensions, typename AllocatorT, typename Enable>
+class buffer;
 class handler;
 
 using buffer_allocator = detail::sycl_memory_object_allocator;

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -30,7 +30,7 @@ namespace sycl {
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::target AccessTarget, access::placeholder IsPlaceholder>
 class accessor;
-template <typename T, int Dimensions, typename AllocatorT> class buffer;
+template <typename T, int Dimensions, typename AllocatorT, typename Enable> class buffer;
 class handler;
 
 using buffer_allocator = detail::sycl_memory_object_allocator;

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -60,7 +60,7 @@ namespace sycl {
 // Forward declaration
 
 class handler;
-template <typename T, int Dimensions, typename AllocatorT> class buffer;
+template <typename T, int Dimensions, typename AllocatorT, typename Enable> class buffer;
 namespace detail {
 
 /// This class is the default KernelName template parameter type for kernel

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -60,7 +60,8 @@ namespace sycl {
 // Forward declaration
 
 class handler;
-template <typename T, int Dimensions, typename AllocatorT, typename Enable> class buffer;
+template <typename T, int Dimensions, typename AllocatorT, typename Enable>
+class buffer;
 namespace detail {
 
 /// This class is the default KernelName template parameter type for kernel


### PR DESCRIPTION
According to the specification, a buffer can have dimensions of only 1, 2, and 3. In the old version, "static_assert" was used to limit it, which did not throw an exception when creating a pointer to a buffer with an incorrect dimension. In this patch it is impossible to create not only an object of the buffer class with incorrect dimensions, but also a link to it.
Also, constructor calls in the accessos class that tried to instantiate a buffer with a zero dimension were fixed.


Signed-off-by: amochalo <anastasiya.mochalova@intel.com>