### PR TITLE
[SYCL] Fix build issues for Debug configuration on Windows

### DIFF
--- a/buildbot/dependency.py
+++ b/buildbot/dependency.py
@@ -71,6 +71,7 @@ def do_dependency(args):
     install_dir = os.path.join(args.obj_dir, "install")
     cmake_cmd = ["cmake", "-G", "Ninja",
                  "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),
+                 "-DOPENCL_ICD_LOADER_HEADERS_DIR={}".format(ocl_header_dir),
                  ".." ]
     subprocess.check_call(cmake_cmd, cwd=icd_build_dir)
 

--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -9,6 +9,7 @@ if (MSVC)
   set_source_files_properties(SemaExprCXX.cpp PROPERTIES COMPILE_FLAGS /bigobj)
   set_source_files_properties(SemaSYCL.cpp PROPERTIES COMPILE_FLAGS /bigobj)
   set_source_files_properties(SemaTemplate.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+  set_source_files_properties(SemaTemplateDeduction.cpp PROPERTIES COMPILE_FLAGS /bigobj)
 endif()
 
 clang_tablegen(OpenCLBuiltins.inc -gen-clang-opencl-builtins


### PR DESCRIPTION
During the building x64 Debug configuration of Windows using scripts from buildbot folder, there were two issues:
1. OpenCL ICD Loader failed to build because of the missing OpenCL headers
2. Fatal error C1128: clang\lib\Sema\SemaTemplateDeduction.cpp : number of sections exceeded object file format limit: compile with /bigobj

Signed-off-by: Dmitry Vodopyanov <dmitry.vodopyanov@intel.com>