### PR TITLE
[SYCL] Fix __spirv_GroupBroadcast overloads

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -142,7 +142,14 @@ extern bool __spirv_GroupAny(__spv::Scope Execution, bool Predicate) noexcept;
 
 template <typename dataT>
 extern dataT __spirv_GroupBroadcast(__spv::Scope Execution, dataT Value,
-                                    uint32_t LocalId) noexcept;
+                                    size_t LocalId) noexcept;
+
+template <typename dataT>
+extern dataT __spirv_GroupBroadcast(__spv::Scope Execution, dataT Value,
+                                    __ocl_vec_t<size_t, 2> LocalId) noexcept;
+template <typename dataT>
+extern dataT __spirv_GroupBroadcast(__spv::Scope Execution, dataT Value,
+                                    __ocl_vec_t<size_t, 3> LocalId) noexcept;
 
 template <typename dataT>
 extern dataT __spirv_GroupIAdd(__spv::Scope Execution, __spv::GroupOperation Op,

--- a/sycl/include/CL/__spirv/spirv_types.hpp
+++ b/sycl/include/CL/__spirv/spirv_types.hpp
@@ -63,6 +63,10 @@ using RPipeTy = __attribute__((pipe("read_only"))) const dataT;
 template <typename dataT>
 using WPipeTy = __attribute__((pipe("write_only"))) const dataT;
 
+// OpenCL vector types
+template <typename dataT, int dims>
+using __ocl_vec_t = dataT __attribute__((ext_vector_type(dims)));
+
 // Struct representing layout of pipe storage
 struct ConstantPipeStorage {
   int32_t _PacketSize;


### PR DESCRIPTION
SPIR-V OpGroupBroadcast accepts three forms of local ID:
- scalar integer
- vector integer with 2 components
- vector integer with 3 components

Signed-off-by: John Pennycook <john.pennycook@intel.com>