### PR TITLE
[SYCL] Add llvm/Demangle link dependency for llvm-no-spir-kernel

### DIFF
--- a/llvm/tools/llvm-no-spir-kernel/CMakeLists.txt
+++ b/llvm/tools/llvm-no-spir-kernel/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LLVM_LINK_COMPONENTS
   Core
+  Demangle
   IRReader
   Support
   )


### PR DESCRIPTION
After #1068 has included the Demangle header, this fix to CMakeLists
should guarantee successful builds in all configurations

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>