### PR TITLE
[CI] Remove invalid type triggers

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
     - sycl
-    types: [open, edit, reopen, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
Event type triggers are misspelled "open"->"opened", etc.
Default event type triggers should work fine.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>