### PR TITLE
[SYCL] Change which constructor is gated for devices

### DIFF
--- a/sycl/include/CL/sycl/multi_ptr.hpp
+++ b/sycl/include/CL/sycl/multi_ptr.hpp
@@ -44,13 +44,15 @@ public:
   multi_ptr() : m_Pointer(nullptr) {}
   multi_ptr(const multi_ptr &rhs) = default;
   multi_ptr(multi_ptr &&) = default;
-  multi_ptr(pointer_t pointer) : m_Pointer(pointer) {}
 #ifdef __SYCL_DEVICE_ONLY__
+  multi_ptr(pointer_t pointer) : m_Pointer(pointer) {}
+#endif
+
   multi_ptr(ElementType *pointer) : m_Pointer((pointer_t)(pointer)) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
   }
-#endif
+
   multi_ptr(std::nullptr_t) : m_Pointer(nullptr) {}
   ~multi_ptr() = default;
 

--- a/sycl/include/CL/sycl/multi_ptr.hpp
+++ b/sycl/include/CL/sycl/multi_ptr.hpp
@@ -59,18 +59,21 @@ public:
   // Assignment and access operators
   multi_ptr &operator=(const multi_ptr &) = default;
   multi_ptr &operator=(multi_ptr &&) = default;
+
+#ifdef __SYCL_DEVICE_ONLY__
   multi_ptr &operator=(pointer_t pointer) {
     m_Pointer = pointer;
     return *this;
   }
-#ifdef __SYCL_DEVICE_ONLY__
+#endif
+
   multi_ptr &operator=(ElementType *pointer) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
     m_Pointer = (pointer_t)pointer;
     return *this;
   }
-#endif
+
   multi_ptr &operator=(std::nullptr_t) {
     m_Pointer = nullptr;
     return *this;


### PR DESCRIPTION
SYCL 1.2.1 includes a constructor for `multi_ptr` from `T*`, available on both the host and device.  The current implementation disables this constructor on the host to avoid conflicting definitions for constructors using `pointer_t` and `T*`.

Making this constructor available enables implicit conversions between pointer types and `multi_ptr` classes, and addresses requests such as #849. 

Signed-off-by: James Brodman <james.brodman@intel.com>