### PR TITLE
[CI] Fix commit range for clang-format check

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Run clang-format for the patch
       run: |
-        git diff -U0 --no-color origin/${{github.base_ref}}..HEAD | ./clang/tools/clang-format/clang-format-diff.py -p1 -binary clang-format-9 > ./clang-format.patch
+        git diff -U0 --no-color origin/${{github.base_ref}}...HEAD | ./clang/tools/clang-format/clang-format-diff.py -p1 -binary clang-format-9 > ./clang-format.patch
 
     # Add patch with formatting fixes to CI job artifacts
     - uses: actions/upload-artifact@v1


### PR DESCRIPTION
It turns out that my original implementation was correct and I just
mis-understand the double dot commit range description from ProGit
https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>