### PR TITLE
[SYCL] Do not remove commands from leaves lists on subuffer creation

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -505,8 +505,6 @@ AllocaCommandBase *Scheduler::GraphBuilder::getOrCreateAllocaForReq(
       auto *ParentAlloca =
           getOrCreateAllocaForReq(Record, &ParentRequirement, Queue);
       AllocaCmd = new AllocaSubBufCommand(Queue, *Req, ParentAlloca);
-      updateLeaves(findDepsForReq(Record, Req, Queue->getContextImplPtr()),
-                   Record, access::mode::read_write);
     } else {
 
       const Requirement FullReq(/*Offset*/ {0, 0, 0}, Req->MMemoryRange,


### PR DESCRIPTION
It's not correct to remove commands from leaves that we are not
depending on.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>