### PR TITLE
[SYCL] Fix program::get_compile/build_options

### DIFF
--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -300,6 +300,7 @@ void program_impl::compile(const string_class &Options) {
         ProgramManager::getProgramBuildLog(MProgram, MContext));
   }
   MCompileOptions = Options;
+  MBuildOptions = Options;
 }
 
 void program_impl::build(const string_class &Options) {
@@ -316,7 +317,6 @@ void program_impl::build(const string_class &Options) {
         ProgramManager::getProgramBuildLog(MProgram, MContext));
   }
   MBuildOptions = Options;
-  MCompileOptions = Options;
 }
 
 vector_class<RT::PiDevice> program_impl::get_pi_devices() const {

--- a/sycl/test/kernel-and-program/get-options.cpp
+++ b/sycl/test/kernel-and-program/get-options.cpp
@@ -1,0 +1,45 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+
+#include <cassert>
+
+// Check program::get_compile/link/build_options functions
+
+class KernelName;
+void submitKernel() {
+  cl::sycl::queue q;
+  q.submit(
+      [&](cl::sycl::handler &cgh) { cgh.single_task<KernelName>([]() {}); });
+}
+
+int main() {
+  const cl::sycl::string_class CompileOpts{"-cl-opt-disable"};
+  const cl::sycl::string_class LinkOpts{"-cl-fast-relaxed-math"};
+  const cl::sycl::string_class BuildOpts{
+      "-cl-opt-disable -cl-fast-relaxed-math"};
+
+  cl::sycl::context Ctx;
+  cl::sycl::program PrgA{Ctx};
+  assert(PrgA.get_compile_options().empty());
+  assert(PrgA.get_link_options().empty());
+  assert(PrgA.get_build_options().empty());
+
+  PrgA.build_with_kernel_type<KernelName>(BuildOpts);
+  assert(PrgA.get_compile_options().empty());
+  assert(PrgA.get_link_options().empty());
+  assert(PrgA.get_build_options() == (PrgA.is_host() ? "" : BuildOpts));
+
+  cl::sycl::program PrgB{Ctx};
+  PrgB.compile_with_kernel_type<KernelName>(CompileOpts);
+  assert(PrgB.get_compile_options() == (PrgB.is_host() ? "" : CompileOpts));
+  assert(PrgB.get_link_options().empty());
+  assert(PrgB.get_build_options() == (PrgB.is_host() ? "" : CompileOpts));
+
+  PrgB.link(LinkOpts);
+  assert(PrgB.get_compile_options() == (PrgB.is_host() ? "" : CompileOpts));
+  assert(PrgB.get_link_options() == (PrgB.is_host() ? "" : LinkOpts));
+  assert(PrgB.get_build_options() == (PrgB.is_host() ? "" : LinkOpts));
+}


### PR DESCRIPTION
get_build_options should return compile options for a program in a
compiled state and not the other way around.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>