### PR TITLE
[SYCL] Fix dependencies for Doxygen job

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -17,7 +17,7 @@ jobs:
         repository: intel/llvm-docs
         path: docs
     - name: Install deps
-      run: sudo apt-get install -y doxygen graphviz ssh
+      run: sudo apt-get install -y doxygen graphviz ssh ninja-build
     - name: Build Docs
       run: |
         mkdir -p $GITHUB_WORKSPACE/build

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,8 +1,6 @@
 name: Generate Doxygen documentation
 
-on:
-  schedule:
-  - cron: 0 1 * * *
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,6 +1,8 @@
 name: Generate Doxygen documentation
 
-on: [pull_request]
+on:
+  schedule:
+  - cron: 0 1 * * *
 
 jobs:
   build:


### PR DESCRIPTION
configure.py requires Ninja to be installed on build machine, which is
missing from default GitHub Actions Linux environments. Install
ninja-build package before proceeding to CMake configuration.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>