### PR TITLE
[SYCL] Fix mismatch between sub_group headers

### DIFF
--- a/sycl/include/CL/sycl/intel/sub_group_host.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group_host.hpp
@@ -136,7 +136,7 @@ struct sub_group {
   }
 
   template <typename T, access::address_space Space>
-  void store(multi_ptr<T, Space> dst, T &x) const {
+  void store(multi_ptr<T, Space> dst, const T &x) const {
     throw runtime_error("Subgroups are not supported on host device. ");
   }
 

--- a/sycl/test/regression/sub-group-store-const-ref.cpp
+++ b/sycl/test/regression/sub-group-store-const-ref.cpp
@@ -1,0 +1,19 @@
+// RUN: %clangxx -I %sycl_include -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+//
+//==-- sub-group-store-const-ref.cpp ---------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// This test checks that sub_group::store supports const reference.
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+using namespace sycl;
+
+void test(intel::sub_group sg, global_ptr<int> ptr)
+{
+    sg.store(ptr, 1);
+}

--- a/sycl/test/regression/sub-group-store-const-ref.cpp
+++ b/sycl/test/regression/sub-group-store-const-ref.cpp
@@ -13,7 +13,4 @@
 #include <CL/sycl.hpp>
 using namespace sycl;
 
-void test(intel::sub_group sg, global_ptr<int> ptr)
-{
-    sg.store(ptr, 1);
-}
+void test(intel::sub_group sg, global_ptr<int> ptr) { sg.store(ptr, 1); }


### PR DESCRIPTION
sub_group::store took T& for host and const T& for device.

Signed-off-by: John Pennycook <john.pennycook@intel.com>