### PR TITLE
[SYCL] Add clang-format configuration file for LIT tests

### DIFF
--- a/sycl/test/.clang-format
+++ b/sycl/test/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+ColumnLimit: 0


### PR DESCRIPTION
By default LLVM style limit code lines size to 80 characters. It should
not be applied to LIT tests as clang-format can't preserve LIT commands
semantic written in the code comments.

This configuration file was shamelessly copied from the clang project.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>