### PR TITLE
[SYCL][Driver] Set -aux-target-cpu for SYCL offload device compilation

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4742,6 +4742,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   // `--gpu-use-aux-triple-only` is specified.
   if (!Args.getLastArg(options::OPT_gpu_use_aux_triple_only) &&
       ((IsCuda && JA.isDeviceOffloading(Action::OFK_Cuda)) ||
+       (IsSYCL && IsSYCLOffloadDevice) ||
        (IsHIP && JA.isDeviceOffloading(Action::OFK_HIP)))) {
     const ArgList &HostArgs =
         C.getArgsForToolChain(nullptr, StringRef(), Action::OFK_None);

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -1,0 +1,16 @@
+/// Check "-aux-target-cpu" and "target-cpu" are passed when compiling for SYCL offload device and host codes:
+//  RUN:  %clang -### -fsycl -c %s 2>&1 | FileCheck -check-prefix=CHECK-OFFLOAD %s
+//  CHECK-OFFLOAD: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-device"
+//  CHECK-OFFLOAD-SAME: "-aux-target-cpu" "x86-64"
+//  CHECK-OFFLOAD-NEXT: clang{{.*}} "-cc1" {{.*}}
+//  CHECK-OFFLOAD-NEXT-SAME: "-fsycl-is-host"
+//  CHECK-OFFLOAD-NEXT-SAME: "-target-cpu" "x86-64"
+
+/// Check "-aux-target-cpu" with "-aux-target-feature" and "-target-cpu" with "-target-feature" are passed
+/// when compiling for SYCL offload device and host codes:
+//  RUN:  %clang -fsycl -mavx -c %s -### -o %t.o 2>&1 | FileCheck -check-prefix=OFFLOAD-AVX %s
+//  OFFLOAD-AVX: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-device"
+//  OFFLOAD-AVX-SAME: "-aux-target-cpu" "x86-64" "-aux-target-feature" "+avx"
+//  OFFLOAD-AVX-NEXT: clang{{.*}} "-cc1" {{.*}}
+//  OFFLOAD-AVX-NEXT-SAME: "-fsycl-is-host"
+//  OFFLOAD-AVX-NEXT-SAME: "-target-cpu" "x86-64" "-target-feature" "+avx"


### PR DESCRIPTION
This patch adds -aux-target-cpu that will set AVX and other necessary macros
for the SYCL offload device compilation based on -aux-target-cpu target.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>