### PR TITLE
[SYCL] Fixes circular reference between events and queues

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -114,8 +114,9 @@ void event_impl::wait_and_throw(
     if (Cmd)
       Cmd->getQueue()->throw_asynchronous();
   }
-  if (MQueue)
-    MQueue->throw_asynchronous();
+  QueueImplPtr Queue = MQueue.lock();
+  if (Queue)
+    Queue->throw_asynchronous();
 }
 
 template <>

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -25,6 +25,7 @@ class context_impl;
 using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 class queue_impl;
 using QueueImplPtr = std::shared_ptr<cl::sycl::detail::queue_impl>;
+using QueueImplWPtr = std::weak_ptr<cl::sycl::detail::queue_impl>;
 
 class event_impl {
 public:
@@ -147,7 +148,7 @@ public:
 private:
   RT::PiEvent MEvent = nullptr;
   ContextImplPtr MContext;
-  QueueImplPtr MQueue;
+  QueueImplWPtr MQueue;
   bool MOpenCLInterop = false;
   bool MHostEvent = true;
   std::unique_ptr<HostProfilingInfo> MHostProfilingInfo;


### PR DESCRIPTION
There is a potential circular reference between queues and events as a queue can hold a collection of shared pointers to events and events may have a shared pointer to a queue. If a circular reference is created, the only way to currently break the circle is to call `wait` on the queue, which is not ensured to happen.

To mitigate this, this PR changes makes the reference from an event to a queue a weak pointer. Effectively this will mean that if all remaining references to a queue are from events the queue will die. This affects only an events ability to throw asynchronous errors through the `async_handler` of the queue if it is destroyed prematurely.

Signed-off-by: Steffen Larsen <steffen.larsen@codeplay.com>