### PR TITLE
Use SSH to deploy GitHub Pages

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -12,10 +12,6 @@ jobs:
       with:
         ref: sycl
         path: repo
-    - uses: actions/checkout@v2
-      with:
-        repository: intel/llvm-docs
-        path: docs
     - name: Install deps
       run: sudo apt-get install -y doxygen graphviz ssh ninja-build
     - name: Build Docs
@@ -34,6 +30,7 @@ jobs:
         chmod 600 ~/.ssh/id_rsa
         eval "$(ssh-agent -s)"
         ssh-add -k ~/.ssh/id_rsa
+        git clone git@github.com:intel/llvm-docs.git docs
         cd $GITHUB_WORKSPACE/docs
         yes | \cp -rf $GITHUB_WORKSPACE/build/tools/sycl/doc/doxygen/html/* .
         git config --global user.name "iclsrc"


### PR DESCRIPTION
GitHub's checkout@v2 action uses HTTPS and REST API to check out the repository. This makes SSH key auth fail when automation tries to push changes to external repo. Replace action with explicit SSH git checkout.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>