### PR TITLE
[SYCL] Fix device::get_devices() with a non-host device type

### DIFF
--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -37,13 +37,15 @@ device::device(const device_selector &deviceSelector) {
 
 vector_class<device> device::get_devices(info::device_type deviceType) {
   vector_class<device> devices;
+  // Host device availability should not depend on the forced type
+  const bool includeHost =
+      detail::match_types(deviceType, info::device_type::host);
   info::device_type forced_type = detail::get_forced_type();
   // Exclude devices which do not match requested device type
   if (detail::match_types(deviceType, forced_type)) {
     detail::force_type(deviceType, forced_type);
     for (const auto &plt : platform::get_platforms()) {
-      // Host device must always be available.
-      if (plt.is_host()) {
+      if (includeHost && plt.is_host()) {
         vector_class<device> host_device(
             plt.get_devices(info::device_type::host));
         if (!host_device.empty())

--- a/sycl/test/basic_tests/get_nonhost_devices.cpp
+++ b/sycl/test/basic_tests/get_nonhost_devices.cpp
@@ -1,0 +1,25 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %t.out
+
+// Check that the host device is not included in devices returned by
+// get_devices() if a non-host device type is specified.
+
+#include <CL/sycl.hpp>
+
+#include <cassert>
+
+using namespace cl::sycl;
+
+void check(info::device_type DT) {
+  vector_class<device> Devices = device::get_devices(DT);
+  for (const auto &Device : Devices)
+    assert(!Device.is_host());
+}
+
+int main() {
+  check(info::device_type::cpu);
+  check(info::device_type::gpu);
+  check(info::device_type::accelerator);
+  check(info::device_type::custom);
+  check(info::device_type::automatic);
+}


### PR DESCRIPTION
This patches fixes a bug where a host device was always included
in the device list returned by device::get_devices().

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>