### PR TITLE
[SYCL] Fix undefined symbols in async_work_group_copy

### DIFF
--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -12,6 +12,7 @@
 #include <CL/__spirv/spirv_types.hpp>
 #include <CL/__spirv/spirv_vars.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/generic_type_traits.hpp>
 #include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/device_event.hpp>
 #include <CL/sycl/h_item.hpp>
@@ -264,10 +265,13 @@ public:
   device_event async_work_group_copy(local_ptr<dataT> dest,
                                      global_ptr<dataT> src,
                                      size_t numElements) const {
-    __ocl_event_t e =
-        OpGroupAsyncCopyGlobalToLocal<dataT>(
-            __spv::Scope::Workgroup,
-            dest.get(), src.get(), numElements, 1, 0);
+    using T = detail::ConvertToOpenCLType_t<dataT>;
+    using Local = detail::ConvertToOpenCLType_t<local_ptr<dataT>>;
+    using Global = detail::ConvertToOpenCLType_t<global_ptr<dataT>>;
+
+    __ocl_event_t e = OpGroupAsyncCopyGlobalToLocal<T>(
+        __spv::Scope::Workgroup, Local(dest.get()), Global(src.get()),
+        numElements, 1, 0);
     return device_event(&e);
   }
 
@@ -275,10 +279,13 @@ public:
   device_event async_work_group_copy(global_ptr<dataT> dest,
                                      local_ptr<dataT> src,
                                      size_t numElements) const {
-    __ocl_event_t e =
-        OpGroupAsyncCopyLocalToGlobal<dataT>(
-            __spv::Scope::Workgroup,
-            dest.get(), src.get(), numElements, 1, 0);
+    using T = detail::ConvertToOpenCLType_t<dataT>;
+    using Local = detail::ConvertToOpenCLType_t<local_ptr<dataT>>;
+    using Global = detail::ConvertToOpenCLType_t<global_ptr<dataT>>;
+
+    __ocl_event_t e = OpGroupAsyncCopyLocalToGlobal<T>(
+        __spv::Scope::Workgroup, Global(dest.get()), Local(src.get()),
+        numElements, 1, 0);
     return device_event(&e);
   }
 
@@ -287,10 +294,13 @@ public:
                                      global_ptr<dataT> src,
                                      size_t numElements,
                                      size_t srcStride) const {
-    __ocl_event_t e =
-        OpGroupAsyncCopyGlobalToLocal<dataT>(
-            __spv::Scope::Workgroup,
-            dest.get(), src.get(), numElements, srcStride, 0);
+    using T = detail::ConvertToOpenCLType_t<dataT>;
+    using Local = detail::ConvertToOpenCLType_t<local_ptr<dataT>>;
+    using Global = detail::ConvertToOpenCLType_t<global_ptr<dataT>>;
+
+    __ocl_event_t e = OpGroupAsyncCopyGlobalToLocal<T>(
+        __spv::Scope::Workgroup, Local(dest.get()), Global(src.get()),
+        numElements, srcStride, 0);
     return device_event(&e);
   }
 
@@ -299,10 +309,13 @@ public:
                                      local_ptr<dataT> src,
                                      size_t numElements,
                                      size_t destStride) const {
-    __ocl_event_t e =
-        OpGroupAsyncCopyLocalToGlobal<dataT>(
-            __spv::Scope::Workgroup,
-            dest.get(), src.get(), numElements, destStride, 0);
+    using T = detail::ConvertToOpenCLType_t<dataT>;
+    using Local = detail::ConvertToOpenCLType_t<local_ptr<dataT>>;
+    using Global = detail::ConvertToOpenCLType_t<global_ptr<dataT>>;
+
+    __ocl_event_t e = OpGroupAsyncCopyLocalToGlobal<T>(
+        __spv::Scope::Workgroup, Global(dest.get()), Local(src.get()),
+        numElements, destStride, 0);
     return device_event(&e);
   }
 

--- a/sycl/test/regression/group.cpp
+++ b/sycl/test/regression/group.cpp
@@ -162,10 +162,77 @@ bool group__get_linear_id() {
   return Pass;
 }
 
+// Tests group::async_work_group_copy()
+bool group__async_work_group_copy() {
+  std::cout << "+++ Running group::async_work_group_copy() test...\n";
+  constexpr int DIMS = 2;
+  const range<DIMS> LocalRange{3, 1};
+  const range<DIMS> GroupRange{2, 3};
+  const range<DIMS> GlobalRange = LocalRange * GroupRange;
+  using DataType = vec<size_t, DIMS>;
+  const int DataLen = GlobalRange.size();
+  std::unique_ptr<DataType[]> Data(new DataType[DataLen]);
+  std::memset(Data.get(), 0, DataLen * sizeof(DataType));
+
+  try {
+    buffer<DataType, 1> Buf(Data.get(), DataLen);
+    queue Q(AsyncHandler{});
+
+    Q.submit([&](handler &cgh) {
+      auto AccGlobal = Buf.get_access<access::mode::read_write>(cgh);
+      accessor<DataType, DIMS, access::mode::read_write, access::target::local>
+          AccLocal(LocalRange, cgh);
+
+      cgh.parallel_for<class group__async_work_group_copy>(
+          nd_range<2>{GlobalRange, LocalRange}, [=](nd_item<DIMS> I) {
+            const auto Group = I.get_group();
+            const auto NumElem = AccLocal.get_count();
+            const auto Off = Group[0] * I.get_group_range(1) * NumElem + Group[1];
+            const auto Stride = I.get_global_range(1);
+            auto PtrGlobal = AccGlobal.get_pointer() + Off;
+            auto PtrLocal = AccLocal.get_pointer();
+            Group.async_work_group_copy(PtrLocal, PtrGlobal, NumElem, Stride);
+            AccLocal[I.get_local_id()][0] += I.get_global_id(0);
+            AccLocal[I.get_local_id()][1] += I.get_global_id(1);
+            Group.async_work_group_copy(PtrGlobal, PtrLocal, NumElem, Stride);
+          });
+    });
+  } catch (cl::sycl::exception const &E) {
+    std::cout << "SYCL exception caught: " << E.what() << '\n';
+    return 2;
+  }
+  const size_t SIZE_Y = GlobalRange.get(0);
+  const size_t SIZE_X = GlobalRange.get(1);
+  bool Pass = true;
+  int ErrCnt = 0;
+
+  for (size_t Y = 0; Y < SIZE_Y; Y++) {
+    for (size_t X = 0; X < SIZE_X; X++) {
+      const size_t Ind = Y * SIZE_X + X;
+      const auto Test0 = Data[Ind][0];
+      const auto Test1 = Data[Ind][1];
+      const auto Gold0 = Y;
+      const auto Gold1 = X;
+      const bool Ok = (Test0 == Gold0 && Test1 == Gold1);
+      Pass &= Ok;
+
+      if (!Ok && ErrCnt++ < 10) {
+        std::cout << "*** ERROR at [" << Y << "][" << X << "]: ";
+        std::cout << Test0 << " " << Test1 << " != ";
+        std::cout << Gold0 << " " << Gold1 << "\n";
+      }
+    }
+  }
+  if (Pass)
+    std::cout << "    pass\n";
+  return Pass;
+}
+
 int main() {
   bool Pass = 1;
   Pass &= group__get_group_range();
   Pass &= group__get_linear_id();
+  Pass &= group__async_work_group_copy();
 
   if (!Pass) {
     std::cout << "FAILED\n";


### PR DESCRIPTION
Ensure proper name mangling by casting from SYCL types (namely cl::sycl::vec) to cl_* when calling OpenCL.

Signed-off-by: Mokhov, Dmitri N <dmitri.n.mokhov@intel.com>