### PR TITLE
[SYCL] Fix devicelib assert LIT test

### DIFF
--- a/sycl/test/devicelib/assert-windows.cpp
+++ b/sycl/test/devicelib/assert-windows.cpp
@@ -14,11 +14,13 @@
 // explicitly. Since the test is going to crash, we'll have to follow a similar
 // approach as on Linux - call the test in a subprocess.
 //
-// RUN: env SYCL_PI_TRACE=1 SYCL_DEVICELIB_INHIBIT_NATIVE=1 SYCL_DEVICE_TYPE=CPU CL_CONFIG_USE_VECTORIZER=False %t.out >%t.stdout.fallback 2>%t.stderr.fallback
-// RUN: FileCheck %s --check-prefix=CHECK-MESSAGE --input-file %t.stdout.fallback
+// RUN: env SYCL_PI_TRACE=1 SYCL_DEVICELIB_INHIBIT_NATIVE=1 CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU %t.out >%t.stdout.pi.fallback
+// RUN: env SHOULD_CRASH=1 SYCL_DEVICELIB_INHIBIT_NATIVE=1 CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU %t.out >%t.stdout.msg.fallback
+//
+// RUN: FileCheck %s --check-prefix=CHECK-MESSAGE --input-file %t.stdout.msg.fallback
 // CHECK-MESSAGE: {{.*}}assert-windows.cpp:{{[0-9]+}}: (null): global id: [{{[0-3]}},0,0], local id: [{{[0-3]}},0,0] Assertion `accessorC[wiID] == 0 && "Invalid value"` failed.
 //
-// RUN: FileCheck %s --input-file %t.stdout.fallback --check-prefix=CHECK-FALLBACK
+// RUN: FileCheck %s --input-file %t.stdout.pi.fallback --check-prefix=CHECK-FALLBACK
 // CHECK-FALLBACK: ---> piProgramLink
 
 #include <CL/sycl.hpp>
@@ -45,6 +47,8 @@ void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
     }
   });
 
+  int shouldCrash = getenv("SHOULD_CRASH") ? 1 : 0;
+
   cl::sycl::range<1> numOfItems{N};
   cl::sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
   cl::sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
@@ -57,7 +61,9 @@ void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
 
     cgh.parallel_for<class SimpleVaddT>(numOfItems, [=](cl::sycl::id<1> wiID) {
       accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
-      assert(accessorC[wiID] == 0 && "Invalid value");
+      if (shouldCrash) {
+        assert(accessorC[wiID] == 0 && "Invalid value");
+      }
     });
   });
   deviceQueue.wait_and_throw();

--- a/sycl/test/devicelib/assert.cpp
+++ b/sycl/test/devicelib/assert.cpp
@@ -56,6 +56,11 @@
 //      the message can still be buffered by stdio. We turn the bufferization
 //      off explicitly.
 //
+//   4. We want to check both compilation flow in (1) and the message in (3),
+//      but these messages can interleave and fail to match. To avoid this,
+//      first run with SYCL_PI_TRACE and collect a trace, and then with
+//      SHOULD_CRASH (without SYCL_PI_TRACE) to collect an error message.
+//
 // SYCL_DEVICELIB_INHIBIT_NATIVE=1 environment variable is used to force a mode
 // in SYCL Runtime, so it doesn't look into a device extensions list and always
 // link the fallback library.
@@ -70,12 +75,14 @@
 //
 // Overall this sounds stable enough. What could possibly go wrong?
 //
-// RUN: env SYCL_PI_TRACE=1 CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGABRT SKIP_IF_NO_EXT=1 %t.out 2>%t.stderr.native >%t.stdout.native
+// RUN: env SYCL_PI_TRACE=1 SHOULD_CRASH=1 CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGABRT SKIP_IF_NO_EXT=1 %t.out 2>%t.stderr.native >%t.stdout.native
 // RUN: FileCheck %s --input-file %t.stdout.native --check-prefixes=CHECK-NATIVE || FileCheck %s --input-file %t.stderr.native --check-prefix CHECK-NOTSUPPORTED
 // RUN: FileCheck %s --input-file %t.stderr.native --check-prefixes=CHECK-MESSAGE || FileCheck %s --input-file %t.stderr.native --check-prefix CHECK-NOTSUPPORTED
 //
-// RUN: env SYCL_PI_TRACE=1 SYCL_DEVICELIB_INHIBIT_NATIVE=cl_intel_devicelib_assert CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGSEGV %t.out 2>%t.stderr.fallback >%t.stdout.fallback
-// RUN: FileCheck %s --input-file %t.stdout.fallback --check-prefixes=CHECK-FALLBACK,CHECK-MESSAGE
+// RUN: env SYCL_PI_TRACE=1 SYCL_DEVICELIB_INHIBIT_NATIVE=cl_intel_devicelib_assert CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGSEGV %t.out >%t.stdout.pi.fallback
+// RUN: env SHOULD_CRASH=1 SYCL_DEVICELIB_INHIBIT_NATIVE=cl_intel_devicelib_assert CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGSEGV %t.out >%t.stdout.msg.fallback
+// RUN: FileCheck %s --input-file %t.stdout.pi.fallback --check-prefixes=CHECK-FALLBACK
+// RUN: FileCheck %s --input-file %t.stdout.msg.fallback --check-prefixes=CHECK-MESSAGE
 //
 // CHECK-NATIVE:   ---> piProgramBuild
 // CHECK-FALLBACK: ---> piProgramLink
@@ -134,6 +141,8 @@ void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
     exit(EXIT_SKIP_TEST);
   }
 
+  int shouldCrash = getenv("SHOULD_CRASH") ? 1 : 0;
+
   cl::sycl::range<1> numOfItems{N};
   cl::sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
   cl::sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
@@ -146,7 +155,9 @@ void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
 
     cgh.parallel_for<class SimpleVaddT>(numOfItems, [=](cl::sycl::id<1> wiID) {
       accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
-      assert(accessorC[wiID] == 0 && "Invalid value");
+      if (shouldCrash) {
+        assert(accessorC[wiID] == 0 && "Invalid value");
+      }
     });
   });
   deviceQueue.wait_and_throw();
@@ -160,9 +171,19 @@ int main() {
     if (WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SKIP_TEST) {
       return 0;
     }
-    if (!WIFSIGNALED(status)) {
-      fprintf(stderr, "error: process did not terminate by a signal\n");
-      return 1;
+    if (getenv("SHOULD_CRASH")) {
+      if (!WIFSIGNALED(status)) {
+        fprintf(stderr, "error: process did not terminate by a signal\n");
+        return 1;
+      }
+    } else {
+      if (WIFSIGNALED(status)) {
+        fprintf(stderr, "error: process should not terminate\n");
+        return 1;
+      }
+      // We should not check anything if the child finished successful and this
+      // was expected.
+      return 0;
     }
     int sig = WTERMSIG(status);
     int expected = 0;


### PR DESCRIPTION
Split PI_TRACE output and an assert error message into different
files. Otherwise they sometimes interleave and fail to match.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>