### PR TITLE
[SYCL][CUDA] Implements the program kernel names query

### DIFF
--- a/sycl/test/basic_tests/kernel_info.cpp
+++ b/sycl/test/basic_tests/kernel_info.cpp
@@ -33,6 +33,7 @@ int main() {
   program prg(q.get_context());
 
   prg.build_with_kernel_type<class SingleTask>();
+  CHECK(prg.has_kernel<class SingleTask>());
   kernel krn = prg.get_kernel<class SingleTask>();
 
   q.submit([&](handler &cgh) {


### PR DESCRIPTION
Implements the `PI_PROGRAM_INFO_KERNEL_NAMES` for the CUDA backend.

Signed-off-by: Steffen Larsen <steffen.larsen@codeplay.com>