### PR TITLE
[SYCL][Driver] Emit a warning when appending to an existing archive

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -324,6 +324,8 @@ def warn_drv_treating_input_as_cxx : Warning<
   InGroup<Deprecated>;
 def warn_drv_pch_not_first_include : Warning<
   "precompiled header '%0' was ignored because '%1' is not first '-include'">;
+def warn_drv_existing_archive_append: Warning<
+  "appending to an existing archive '%0'">, InGroup<DiagGroup<"archive-append">>;
 def warn_missing_sysroot : Warning<"no such sysroot directory: '%0'">,
   InGroup<DiagGroup<"missing-sysroot">>;
 def warn_incompatible_sysroot : Warning<"using sysroot for '%0' but targeting '%1'">,

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -348,7 +348,12 @@ void tools::gnutools::Linker::constructLLVMARCommand(
     const InputInfoList &Input, const ArgList &Args) const {
   ArgStringList CmdArgs;
   CmdArgs.push_back("cr");
-  CmdArgs.push_back(Output.getFilename());
+  const char *OutputFilename = Output.getFilename();
+  if (llvm::sys::fs::exists(OutputFilename)) {
+    C.getDriver().Diag(clang::diag::warn_drv_existing_archive_append)
+        << OutputFilename;
+  }
+  CmdArgs.push_back(OutputFilename);
   for (const auto &II : Input) {
     if (II.getType() == types::TY_Tempfilelist) {
       // Take the list file and pass it in with '@'.

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -78,6 +78,14 @@
 // CHK-FPGA-LINK-LIB: clang-offload-bundler{{.*}} "-type=aoo" "-targets=host-x86_64-unknown-linux-gnu" "-inputs=[[INPUT]]" "-outputs=[[OUTPUT1:.+\.txt]]" "-unbundle"
 // CHK-FPGA-LINK-LIB: llvm-ar{{.*}} "cr" {{.*}} "@[[OUTPUT1]]"
 
+/// Check the warning's emission for -fsycl-link's appending behavior
+// RUN: touch dummy.a
+// RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %s -o dummy.a -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHK-FPGA-LINK-WARN
+// RUN: %clangxx -fsycl -fintelfpga -fsycl-link=early %s -o dummy.a -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHK-FPGA-LINK-WARN
+// CHK-FPGA-LINK-WARN: warning: appending to an existing archive 'dummy.a'
+
 /// -fintelfpga with AOCR library and additional object
 // RUN:  touch %t2.o
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t.a %t2.o 2>&1 \


### PR DESCRIPTION
When llvm-ar is invoked by the driver and the designated output
archive already exists, the behavior is to simply append the new
objects. As such, this GCC-consistent behavior can be quite
useful: e.g. in our SYCL FPGA flow, the user could look to store
a host object file in an archive, then produce an AOT-compiled
device object and append it to the archive via -fsycl-link.

However, if the archive already contains an AOT-compiled device
object, appending a new device object would imminently crash
the further compilation stages. Therefore, a warning is now
provided in case the existing device object-containing archive
under the same name was accindentally left over by the developer.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>