### PR TITLE
[SYCL] Temporarily disable hier_par test

### DIFF
--- a/clang/test/CodeGenSYCL/hier_par.cpp
+++ b/clang/test/CodeGenSYCL/hier_par.cpp
@@ -15,8 +15,11 @@
 //   argument
 //
 // This is compile-only test for now.
-//
-// XFAIL:* 
+
+// Disable this test until the behavior is stablized.
+// '*' doesn't work here.
+// UNSUPPORTED: windows, linux, darwin 
+
 #include "sycl.hpp"
 
 using namespace cl::sycl;


### PR DESCRIPTION
The CodeGenSYCL/hier_par.cpp test is exhibiting inconsistent behavior.
This patch marks that test as UNSUPPORTED. When hierarchical parallelism
is stabilized the test should be re-enabled.

Signed-off-by: Andy Kaylor <andrew.kaylor@intel.com>