### PR TITLE
[SYCL] Generate volatile load/store/memcpy instructions in LowerWGScope

### DIFF
--- a/sycl/test/hier_par/hier_par_basic.cpp
+++ b/sycl/test/hier_par/hier_par_basic.cpp
@@ -12,9 +12,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// TODO: ptxas fatal   : Unresolved extern function '__spirv_ControlBarrier'
-// XFAIL: cuda
-
 // This test checks hierarchical parallelism invocation APIs, but without any
 // data or code with side-effects between the work group and work item scopes.
 

--- a/sycl/test/hier_par/hier_par_wgscope.cpp
+++ b/sycl/test/hier_par/hier_par_wgscope.cpp
@@ -12,14 +12,11 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// RUN: %clangxx -O0 -fsycl %s -o %t.out
+// RUN: %clangxx -O0 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-
-// TODO: ptxas fatal   : Unresolved extern function '__spirv_ControlBarrier'
-// UNSUPPORTED: cuda
 
 // This test checks correctness of hierarchical kernel execution when there is
 // code and data in the work group scope.


### PR DESCRIPTION
LowerWGScope pass generates copies between private and shared memory.
Logic is to share private value from leader work item to other work
items through shared memory. Example in pseudo code:
```

...
if (Leader work item)
  store %PrivateValue to @SharedGlobal -> leader shares the value
memory_barrier()
load %PrivateValue from @SharedGlobal -> all WIs load the shared value
...
```

Generated load/store operations are not supposed to be moved across
memory barrier but barrier intrinsics like  @llvm.nvvm.barrier0() are
not handled specially by LLVM middle end passes and recognized only by
PTX backend. So, middle end optimizations could perform code movement
resulting in load before store. For example, GVN could perform LoadPRE
based on GlobalsAA:

```
...
crit_edge:
  load %PrivateValue from @SharedGlobal -> all WIs load the shared value

if (Leader work item)
  store %PrivateValue to @SharedGlobal -> leader shares the value
memory_barrier()
...
```

That is why generate volatile memory accesses in LowerWGScope pass to
guarantee that such optimizations are not performed by llvm passes.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>