### PR TITLE
[SYCL][CUDA] Add missing component to libclc's prepare_builtins tool

### DIFF
--- a/libclc/utils/CMakeLists.txt
+++ b/libclc/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ set( LLVM_VERSION_DEFINE "-DHAVE_LLVM=0x${LLVM_VERSION_MAJOR}0${LLVM_VERSION_MIN
 # Setup prepare_builtins tools
 set(LLVM_LINK_COMPONENTS
   BitWriter
+  BitReader
   Core
   IRReader
   Support


### PR DESCRIPTION
Fix libclc build with BUILD_SHARED_LIBS=ON

Fixes #1169 

Signed-off-by: Victor Lomuller <victor@codeplay.com>