### PR TITLE
[SYCL][CUDA] Add missing dependency on OpenCL headers

### DIFF
--- a/sycl/plugins/cuda/CMakeLists.txt
+++ b/sycl/plugins/cuda/CMakeLists.txt
@@ -21,6 +21,10 @@ add_library(pi_cuda SHARED
   "pi_cuda.cpp"
 )
 
+add_dependencies(pi_cuda
+  ocl-headers
+)
+
 add_dependencies(sycl-toolchain pi_cuda)
 
 set_target_properties(pi_cuda PROPERTIES LINKER_LANGUAGE CXX)


### PR DESCRIPTION
This should fix the build process, where `make sycl-toolchain -j` would sometimes fail due to `pi_cuda` and `ocl-headers` building in parallel.