### PR TITLE
[SYCL][CUDA] Add the CUDA backend to the deploy-sycl-toolchain target

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -271,8 +271,8 @@ if(SYCL_BUILD_PI_CUDA)
         "CUDA support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
 
-  add_dependencies(sycl-toolchain libspirv-builtins)
-  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins)
+  add_dependencies(sycl-toolchain libspirv-builtins pi_cuda)
+  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins pi_cuda)
 endif()
 
 


### PR DESCRIPTION
If building of `libpi_cuda.so` is enabled, include it in the installation performed by `make deploy-sycl-toolchain`.