### PR TITLE
[Driver][SYCL][FPGA] Adjust the output location for the project report

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -278,9 +278,14 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
         if (Ty == types::TY_INVALID)
           continue;
         if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
-          llvm::sys::path::replace_extension(AN, "prj");
-          ReportOptArg += Args.MakeArgString(AN);
-          break;
+          // Output is based on the filename only so strip off any directory
+          // information if provided with the source/object file.
+          AN = llvm::sys::path::filename(AN);
+          if (!AN.empty()) {
+            llvm::sys::path::replace_extension(AN, "prj");
+            ReportOptArg += Args.MakeArgString(AN);
+            break;
+          }
         }
       }
     }

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -271,21 +271,22 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
   } else {
     // Output directory is based off of the first object name
     for (Arg * Cur : Args) {
-      if (Cur->getOption().getKind() == Option::InputClass) {
-        SmallString<128> ArgName = Cur->getSpelling();
-        StringRef Ext(llvm::sys::path::extension(ArgName));
-        if (!Ext.empty()) {
-          types::ID Ty =
-              getToolChain().LookupTypeForExtension(Ext.drop_front());
-          if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
-            // Project report should be saved into CWD, so strip off any
-            // directory information if provided with the input file.
-            ArgName = llvm::sys::path::filename(ArgName);
-            llvm::sys::path::replace_extension(ArgName, "prj");
-            ReportOptArg += Args.MakeArgString(ArgName);
-            break;
-          }
-        }
+      if (Cur->getOption().getKind() != Option::InputClass)
+        continue;
+      SmallString<128> ArgName = Cur->getSpelling();
+      StringRef Ext(llvm::sys::path::extension(ArgName));
+      if (Ext.empty())
+        continue;
+      types::ID Ty = getToolChain().LookupTypeForExtension(Ext.drop_front());
+      if (Ty == types::TY_INVALID)
+        continue;
+      if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
+        // Project report should be saved into CWD, so strip off any
+        // directory information if provided with the input file.
+        ArgName = llvm::sys::path::filename(ArgName);
+        llvm::sys::path::replace_extension(ArgName, "prj");
+        ReportOptArg += Args.MakeArgString(ArgName);
+        break;
       }
     }
   }

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -271,19 +271,20 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
   } else {
     // Output directory is based off of the first object name
     for (Arg * Cur : Args) {
-      SmallString<128> AN = Cur->getSpelling();
-      StringRef Ext(llvm::sys::path::extension(AN));
-      if (!Ext.empty()) {
-        types::ID Ty = getToolChain().LookupTypeForExtension(Ext.drop_front());
-        if (Ty == types::TY_INVALID)
-          continue;
-        if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
-          // Output is based on the filename only so strip off any directory
-          // information if provided with the source/object file.
-          AN = llvm::sys::path::filename(AN);
-          if (!AN.empty()) {
-            llvm::sys::path::replace_extension(AN, "prj");
-            ReportOptArg += Args.MakeArgString(AN);
+      if (Cur->getOption().getKind() == Option::InputClass) {
+        SmallString<128> ArgName = Cur->getSpelling();
+        StringRef Ext(llvm::sys::path::extension(ArgName));
+        if (!Ext.empty()) {
+          types::ID Ty =
+              getToolChain().LookupTypeForExtension(Ext.drop_front());
+          if (Ty == types::TY_INVALID)
+            continue;
+          if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
+            // Project report should be saved into CWD, so strip off any
+            // directory information if provided with the input file.
+            ArgName = llvm::sys::path::filename(ArgName);
+            llvm::sys::path::replace_extension(ArgName, "prj");
+            ReportOptArg += Args.MakeArgString(ArgName);
             break;
           }
         }

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -277,8 +277,6 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
         if (!Ext.empty()) {
           types::ID Ty =
               getToolChain().LookupTypeForExtension(Ext.drop_front());
-          if (Ty == types::TY_INVALID)
-            continue;
           if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
             // Project report should be saved into CWD, so strip off any
             // directory information if provided with the input file.

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -171,6 +171,16 @@
 // RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-OPT %s
 // CHK-FPGA-REPORT-OPT: aoc{{.*}} "-sycl" {{.*}} "-output-report-folder=[[OUTDIR]]{{/|\\\\}}file.prj"
 
+/// -fintelfpga output report file from dir/source
+// RUN: mkdir -p %t_dir
+// RUN: touch %t_dir/dummy.cpp
+// RUN: %clangxx -### -fsycl -fintelfpga %t_dir/dummy.cpp  2>&1 \
+// RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-OPT2 %s
+// RUN: %clang_cl -### -fsycl -fintelfpga %t_dir/dummy.cpp 2>&1 \
+// RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-OPT2 %s
+// CHK-FPGA-REPORT-OPT2: aoc{{.*}} "-sycl" {{.*}} "-output-report-folder=dummy.prj"
+// CHK-FPGA-REPORT-OPT2-NOT: aoc{{.*}} "-sycl" {{.*}} "-output-report-folder=[[OUTDIR]]{{.*}}"
+
 /// -fintelfpga static lib (aoco)
 // RUN:  echo "Dummy AOCO image" > %t.aoco
 // RUN:  echo "void foo() {}" > %t.c


### PR DESCRIPTION
When no output specifier is given on the command line, create the output
project report location in the $CWD as opposed to matching the source location
if it was specified with a directory.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>