### PR TITLE
[SYCL][Driver][FPGA] Remove arch designator from default output file …

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5525,10 +5525,10 @@ InputInfo Driver::BuildJobsForActionNoCache(
     std::string OffloadingPrefix;
     // When generating binaries with -fsycl-link-target or -fsycl-link, the
     // output file prefix is the triple arch only.  Do not add the arch when
-    // compiling for FPGA with -fsycl-link.
-    if (Args.getLastArg(options::OPT_fsycl_link_targets_EQ) ||
-        (Args.hasArg(options::OPT_fsycl_link_EQ) &&
-         !Args.hasArg(options::OPT_fintelfpga))) {
+    // compiling for host.
+    if (!A->getOffloadingHostActiveKinds() &&
+        (Args.getLastArg(options::OPT_fsycl_link_targets_EQ) ||
+         Args.hasArg(options::OPT_fsycl_link_EQ))) {
       OffloadingPrefix = "-";
       OffloadingPrefix += TC->getTriple().getArchName();
     } else {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5524,9 +5524,11 @@ InputInfo Driver::BuildJobsForActionNoCache(
   else {
     std::string OffloadingPrefix;
     // When generating binaries with -fsycl-link-target or -fsycl-link, the
-    // output file prefix is the triple arch only.
+    // output file prefix is the triple arch only.  Do not add the arch when
+    // compiling for FPGA with -fsycl-link.
     if (Args.getLastArg(options::OPT_fsycl_link_targets_EQ) ||
-        Args.hasArg(options::OPT_fsycl_link_EQ)) {
+        (Args.hasArg(options::OPT_fsycl_link_EQ) &&
+         !Args.hasArg(options::OPT_fintelfpga))) {
       OffloadingPrefix = "-";
       OffloadingPrefix += TC->getTriple().getArchName();
     } else {

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -86,6 +86,16 @@
 // RUN: | FileCheck %s --check-prefix=CHK-FPGA-LINK-WARN
 // CHK-FPGA-LINK-WARN: warning: appending to an existing archive 'dummy.a'
 
+/// -fintelfpga -fsycl-link name creation without output file specified
+// RUN: mkdir -p %t_dir
+// RUN: touch %t_dir/dummy_file.cpp
+// RUN: %clang++ -### -fsycl -fintelfpga -fsycl-link %t_dir/dummy_file.cpp 2>&1 \
+// RUN: | FileCheck -check-prefixes=CHK-SYCL-LINK-LIN -DINPUTSRC=dummy_file %s
+// RUN: %clang_cl -### -fsycl -fintelfpga -fsycl-link %t_dir/dummy_file.cpp 2>&1 \
+// RUN: | FileCheck -check-prefixes=CHK-SYCL-LINK-WIN -DINPUTSRC=dummy_file %s
+// CHK-SYCL-LINK-LIN: llvm-ar{{.*}} "cr" "[[INPUTSRC]].a"
+// CHK-SYCL-LINK-WIN: lib.exe{{.*}} "-OUT:[[INPUTSRC]].a"
+
 /// -fintelfpga with AOCR library and additional object
 // RUN:  touch %t2.o
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t.a %t2.o 2>&1 \


### PR DESCRIPTION
…with -fsycl-link

When using -fsycl-link the default output file (when no -o is given) was
adding the arch to the output name.  This is not desired and should be just
a flat name based on the first input file.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>