### PR TITLE
[SYCL] Implement thread-local storage restriction, move vardecl checks

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7060,10 +7060,13 @@ NamedDecl *Sema::ActOnVariableDeclarator(
 
   // Static variables declared inside SYCL device code must be const or
   // constexpr
-  if (getLangOpts().SYCLIsDevice && SCSpec == DeclSpec::SCS_static &&
-      !R.isConstant(Context))
+  if (getLangOpts().SYCLIsDevice) {
+    if (SCSpec == DeclSpec::SCS_static && !R.isConstant(Context))
     SYCLDiagIfDeviceCode(D.getIdentifierLoc(), diag::err_sycl_restrict)
         << Sema::KernelNonConstStaticDataVariable;
+    else if (NewVD->getTSCSpec() == DeclSpec::TSCS_thread_local)
+      SYCLDiagIfDeviceCode(D.getIdentifierLoc(), diag::err_thread_unsupported);
+  }
 
   switch (D.getDeclSpec().getConstexprSpecifier()) {
   case CSK_unspecified:

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7062,8 +7062,8 @@ NamedDecl *Sema::ActOnVariableDeclarator(
   // constexpr
   if (getLangOpts().SYCLIsDevice) {
     if (SCSpec == DeclSpec::SCS_static && !R.isConstant(Context))
-    SYCLDiagIfDeviceCode(D.getIdentifierLoc(), diag::err_sycl_restrict)
-        << Sema::KernelNonConstStaticDataVariable;
+      SYCLDiagIfDeviceCode(D.getIdentifierLoc(), diag::err_sycl_restrict)
+          << Sema::KernelNonConstStaticDataVariable;
     else if (NewVD->getTSCSpec() == DeclSpec::TSCS_thread_local)
       SYCLDiagIfDeviceCode(D.getIdentifierLoc(), diag::err_thread_unsupported);
   }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -216,11 +216,10 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
       if (VD->getTLSKind() != VarDecl::TLS_None)
         SYCLDiagIfDeviceCode(*Locs.begin(), diag::err_thread_unsupported);
 
-      if (VD->getStorageClass() == SC_Static &&
-          !IsConst)
+      if (!IsConst && VD->getStorageClass() == SC_Static)
         SYCLDiagIfDeviceCode(*Locs.begin(), diag::err_sycl_restrict)
             << Sema::KernelNonConstStaticDataVariable;
-      else if (VD->hasGlobalStorage() && !isa<ParmVarDecl>(VD) && !IsConst)
+      else if (!IsConst && VD->hasGlobalStorage() && !isa<ParmVarDecl>(VD))
         SYCLDiagIfDeviceCode(*Locs.begin(), diag::err_sycl_restrict)
             << Sema::KernelGlobalVariable;
     }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -322,14 +322,6 @@ public:
 
     CheckSYCLType(E->getType(), E->getSourceRange());
     if (VarDecl *VD = dyn_cast<VarDecl>(D)) {
-      bool IsConst = VD->getType().getNonReferenceType().isConstQualified();
-      if (!IsConst && VD->hasGlobalStorage() && !VD->isStaticLocal() &&
-          !VD->isStaticDataMember() && !isa<ParmVarDecl>(VD)) {
-        if (VD->getTLSKind() != VarDecl::TLS_None)
-          SemaRef.Diag(E->getLocation(), diag::err_thread_unsupported);
-        SemaRef.Diag(E->getLocation(), diag::err_sycl_restrict)
-            << Sema::KernelGlobalVariable;
-      }
       if (!VD->isLocalVarDeclOrParm() && VD->hasGlobalStorage()) {
         VD->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
         SemaRef.addSyclDeviceDecl(VD);

--- a/clang/test/SemaSYCL/prohibit-thread-local.cpp
+++ b/clang/test/SemaSYCL/prohibit-thread-local.cpp
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -std=c++17 %s
+
+thread_local const int prohobit_ns_scope = 0;
+thread_local int prohobit_ns_scope2 = 0;
+thread_local const int allow_ns_scope = 0;
+
+struct S {
+  static const thread_local int prohibit_static_member;
+  static thread_local int prohibit_static_member2;
+};
+
+struct T {
+  static const thread_local int allow_static_member;
+};
+
+void foo() {
+  // expected-error@+1{{thread-local storage is not supported for the current target}}
+  thread_local const int prohibit_local = 0;
+  // expected-error@+1{{thread-local storage is not supported for the current target}}
+  thread_local int prohibit_local2;
+}
+
+void bar() { thread_local int allow_local; }
+
+void usage() {
+  // expected-note@+1 {{called by}}
+  foo();
+  // expected-error@+1 {{thread-local storage is not supported for the current target}}
+  (void)prohobit_ns_scope;
+  // expected-error@+2 {{SYCL kernel cannot use a non-const global variable}}
+  // expected-error@+1 {{thread-local storage is not supported for the current target}}
+  (void)prohobit_ns_scope2;
+  // expected-error@+1 {{thread-local storage is not supported for the current target}}
+  (void)S::prohibit_static_member;
+  // expected-error@+2 {{SYCL kernel cannot use a non-const static data variable}}
+  // expected-error@+1 {{thread-local storage is not supported for the current target}}
+  (void)S::prohibit_static_member2;
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel))
+// expected-note@+1 2{{called by}}
+void kernel_single_task(Func kernelFunc) { kernelFunc(); }
+
+int main() {
+  // expected-note@+1 2{{called by}}
+  kernel_single_task<class fake_kernel>([](){ usage(); } );
+  return 0;
+}

--- a/clang/test/SemaSYCL/prohibit-thread-local.cpp
+++ b/clang/test/SemaSYCL/prohibit-thread-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s
 
 thread_local const int prohobit_ns_scope = 0;
 thread_local int prohobit_ns_scope2 = 0;
@@ -39,11 +39,12 @@ void usage() {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel))
-// expected-note@+1 2{{called by}}
-void kernel_single_task(Func kernelFunc) { kernelFunc(); }
+// expected-note@+2 2{{called by}}
+void
+kernel_single_task(Func kernelFunc) { kernelFunc(); }
 
 int main() {
   // expected-note@+1 2{{called by}}
-  kernel_single_task<class fake_kernel>([](){ usage(); } );
+  kernel_single_task<class fake_kernel>([]() { usage(); });
   return 0;
 }

--- a/clang/test/SemaSYCL/tls_error.cpp
+++ b/clang/test/SemaSYCL/tls_error.cpp
@@ -15,10 +15,12 @@ void usage() {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  //expected-note@+1{{called by}}
   kernelFunc();
 }
 
 int main() {
+  //expected-note@+1{{called by}}
   kernel_single_task<class fake_kernel>([]() { usage(); });
   return 0;
 }


### PR DESCRIPTION
The SYCL spec was recently clarified to prohibit thread local storage,
so this commit ensures an error is always emitted in these cases.

Additionally, the DeclRefExpr to a VarDecl were switched to delayed
diagnostics.

Signed-off-by: Erich Keane <erich.keane@intel.com>