### PR TITLE
[SYCL] Prevent implicit conversion from device to queue.

### DIFF
--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -80,7 +80,7 @@ public:
   /// \param AsyncHandler is a SYCL asynchronous exception handler.
   /// \param PropList is a list of properties for queue construction.
   explicit queue(const device &SyclDevice, const async_handler &AsyncHandler,
-        const property_list &PropList = {});
+                 const property_list &PropList = {});
 
   /// Constructs a SYCL queue instance that is associated with the context
   /// provided, using the device returned by the device selector.

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -70,7 +70,7 @@ public:
   ///
   /// \param SyclDevice is an instance of SYCL device.
   /// \param PropList is a list of properties for queue construction.
-  queue(const device &SyclDevice, const property_list &PropList = {})
+  explicit queue(const device &SyclDevice, const property_list &PropList = {})
       : queue(SyclDevice, async_handler{}, PropList) {}
 
   /// Constructs a SYCL queue instance with an async_handler using the device
@@ -79,7 +79,7 @@ public:
   /// \param SyclDevice is an instance of SYCL device.
   /// \param AsyncHandler is a SYCL asynchronous exception handler.
   /// \param PropList is a list of properties for queue construction.
-  queue(const device &SyclDevice, const async_handler &AsyncHandler,
+  explicit queue(const device &SyclDevice, const async_handler &AsyncHandler,
         const property_list &PropList = {});
 
   /// Constructs a SYCL queue instance that is associated with the context

--- a/sycl/test/basic_tests/implicit_conversion_error.cpp
+++ b/sycl/test/basic_tests/implicit_conversion_error.cpp
@@ -1,22 +1,21 @@
 // RUN: %clangxx -fsyntax-only -Xclang -verify  %s -Xclang -verify-ignore-unexpected=note,warning
-//==--------------- ctad.cpp - SYCL vector CTAD fail test ------------------==//
+//==-- implicit_conversion_error.cpp - Unintended implicit conversion check --==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===-----------------------------------------------------------------------===//
 #include <CL/sycl.hpp>
-
 
 int main() {
   cl::sycl::queue q;
   cl::sycl::context cxt = q.get_context();
   cl::sycl::device dev = q.get_device();
 
-  cl::sycl::context cxt2 { dev };
+  cl::sycl::context cxt2{dev};
   cl::sycl::context cxt3 = dev; // expected-error {{no viable conversion from 'cl::sycl::device' to 'cl::sycl::context'}}
 
-  cl::sycl::queue q2 { dev };
+  cl::sycl::queue q2{dev};
   cl::sycl::queue q3 = dev; // expected-error {{no viable conversion from 'cl::sycl::device' to 'cl::sycl::queue'}}
 }

--- a/sycl/test/basic_tests/implicit_conversion_error.cpp
+++ b/sycl/test/basic_tests/implicit_conversion_error.cpp
@@ -1,0 +1,22 @@
+// RUN: %clangxx -fsyntax-only -Xclang -verify  %s -Xclang -verify-ignore-unexpected=note,warning
+//==--------------- ctad.cpp - SYCL vector CTAD fail test ------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+
+
+int main() {
+  cl::sycl::queue q;
+  cl::sycl::context cxt = q.get_context();
+  cl::sycl::device dev = q.get_device();
+
+  cl::sycl::context cxt2 { dev };
+  cl::sycl::context cxt3 = dev; // expected-error {{no viable conversion from 'cl::sycl::device' to 'cl::sycl::context'}}
+
+  cl::sycl::queue q2 { dev };
+  cl::sycl::queue q3 = dev; // expected-error {{no viable conversion from 'cl::sycl::device' to 'cl::sycl::queue'}}
+}


### PR DESCRIPTION
Constuctors have been marked as explicit.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>