### PR TITLE
[SYCL] Allow SYCL_EXTERNAL for class member functions

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2097,8 +2097,8 @@ def SYCLDeviceIndirectlyCallableDocs : Documentation {
 This attribute can only be applied to functions and indicates that the
 function must be treated as a device function and must be emitted even if it has
 no direct uses from other SYCL device functions. However, it cannot be applied
-to functions marked as 'static', functions declared within an anonymous
-namespace or virtual/pure virtual class member functions.
+to functions marked as 'static' and functions declared within an anonymous
+namespace.
 
 It also means that function should be available externally and
 cannot be optimized out due to reachability analysis or by any other

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2098,7 +2098,7 @@ This attribute can only be applied to functions and indicates that the
 function must be treated as a device function and must be emitted even if it has
 no direct uses from other SYCL device functions. However, it cannot be applied
 to functions marked as 'static', functions declared within an anonymous
-namespace or class member functions.
+namespace or virtual/pure virtual class member functions.
 
 It also means that function should be available externally and
 cannot be optimized out due to reachability analysis or by any other

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10694,8 +10694,7 @@ def warn_boolean_attribute_argument_is_not_valid: Warning<
    InGroup<AdjustedAttributes>;
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
-            "%select{static function or function in an anonymous namespace"
-            "|virtual or pure virtual class member function}1">;
+            "static function or function in an anonymous namespace">;
 def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
               "to a function with a raw pointer "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10695,7 +10695,7 @@ def warn_boolean_attribute_argument_is_not_valid: Warning<
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "%select{static function or function in an anonymous namespace"
-            "|class member function}1">;
+            "|virtual or pure virtual class member function}1">;
 def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
               "to a function with a raw pointer "

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -10156,6 +10156,10 @@ bool ASTContext::DeclMustBeEmitted(const Decl *D) {
   if (D->hasAttr<AliasAttr>() || D->hasAttr<UsedAttr>())
     return true;
 
+  if (LangOpts.SYCLIsDevice && !D->hasAttr<OpenCLKernelAttr>() &&
+      !D->hasAttr<SYCLDeviceAttr>())
+    return false;
+
   if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
     // Forward declarations aren't required.
     if (!FD->doesThisDeclarationHaveABody())
@@ -10179,10 +10183,14 @@ bool ASTContext::DeclMustBeEmitted(const Decl *D) {
     }
 
     // Methods explcitly marked with 'sycl_device' attribute (via SYCL_EXTERNAL)
-    // must be emitted regardless of number of actual uses
-    if (LangOpts.SYCLIsDevice && isa<CXXMethodDecl>(D))
+    // or `indirectly_callable' attribute must be emitted regardless of number
+    // of actual uses
+    if (LangOpts.SYCLIsDevice && isa<CXXMethodDecl>(D)) {
+      if (auto *A = D->getAttr<SYCLDeviceIndirectlyCallableAttr>())
+        return !A->isImplicit();
       if (auto *A = D->getAttr<SYCLDeviceAttr>())
         return !A->isImplicit();
+    }
 
     GVALinkage Linkage = GetGVALinkageForFunction(FD);
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -10178,6 +10178,12 @@ bool ASTContext::DeclMustBeEmitted(const Decl *D) {
       }
     }
 
+    // Methods explcitly marked with 'sycl_device' attribute (via SYCL_EXTERNAL)
+    // must be emitted regardless of number of actual uses
+    if (LangOpts.SYCLIsDevice && isa<CXXMethodDecl>(D))
+      if (auto *A = D->getAttr<SYCLDeviceAttr>())
+        return !A->isImplicit();
+
     GVALinkage Linkage = GetGVALinkageForFunction(FD);
 
     // static, static inline, always_inline, and extern inline functions can

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2516,11 +2516,6 @@ void CodeGenModule::EmitGlobal(GlobalDecl GD) {
   if (Global->hasAttr<IFuncAttr>())
     return emitIFuncDefinition(GD);
 
-  if (LangOpts.SYCLIsDevice) {
-    if (!Global->hasAttr<SYCLDeviceAttr>())
-      return;
-  }
-
   // If this is a cpu_dispatch multiversion function, emit the resolver.
   if (Global->hasAttr<CPUDispatchAttr>())
     return emitCPUDispatchDefinition(GD);
@@ -2563,6 +2558,11 @@ void CodeGenModule::EmitGlobal(GlobalDecl GD) {
         EmitOMPDeclareMapper(DMD);
       return;
     }
+  }
+
+  if (LangOpts.SYCLIsDevice && MustBeEmitted(Global)) {
+    addDeferredDeclToEmit(GD);
+    return;
   }
 
   // Ignore declarations, they will be emitted on their first use.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4441,7 +4441,6 @@ static void handleSYCLDeviceAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
           << AL << 1 /* function with a raw pointer parameter type */;
     }
 
-  S.addSyclDeviceDecl(D);
   handleSimpleAttribute<SYCLDeviceAttr>(S, D, AL);
 }
 
@@ -4453,7 +4452,6 @@ static void handleSYCLDeviceIndirectlyCallableAttr(Sema &S, Decl *D,
     return;
   }
 
-  S.addSyclDeviceDecl(D);
   D->addAttr(SYCLDeviceAttr::CreateImplicit(S.Context));
   handleSimpleAttribute<SYCLDeviceIndirectlyCallableAttr>(S, D, AL);
 }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4428,13 +4428,7 @@ static void handleOptimizeNoneAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 static void handleSYCLDeviceAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   auto *FD = cast<FunctionDecl>(D);
   if (!FD->isExternallyVisible()) {
-    S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-        << AL << 0 /* static function or anonymous namespace */;
-    return;
-  }
-  if (FD->isVirtualAsWritten() || FD->isPure()) {
-    S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-        << AL << 1 /* virtual or pure virtual class member function */;
+    S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here) << AL;
     return;
   }
   if (FD->getReturnType()->isPointerType()) {
@@ -4455,13 +4449,7 @@ static void handleSYCLDeviceIndirectlyCallableAttr(Sema &S, Decl *D,
                                                    const ParsedAttr &AL) {
   auto *FD = cast<FunctionDecl>(D);
   if (!FD->isExternallyVisible()) {
-    S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-        << AL << 0 /* static function or anonymous namespace */;
-    return;
-  }
-  if (FD->isVirtualAsWritten() || FD->isPure()) {
-    S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-        << AL << 1 /* virtual or pure virtual class member function */;
+    S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here) << AL;
     return;
   }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4432,9 +4432,9 @@ static void handleSYCLDeviceAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
         << AL << 0 /* static function or anonymous namespace */;
     return;
   }
-  if (isa<CXXMethodDecl>(FD)) {
+  if (FD->isVirtualAsWritten() || FD->isPure()) {
     S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-        << AL << 1 /* class member function */;
+        << AL << 1 /* virtual or pure virtual class member function */;
     return;
   }
   if (FD->getReturnType()->isPointerType()) {
@@ -4459,9 +4459,9 @@ static void handleSYCLDeviceIndirectlyCallableAttr(Sema &S, Decl *D,
         << AL << 0 /* static function or anonymous namespace */;
     return;
   }
-  if (isa<CXXMethodDecl>(FD)) {
+  if (FD->isVirtualAsWritten() || FD->isPure()) {
     S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here)
-        << AL << 1 /* class member function */;
+        << AL << 1 /* virtual or pure virtual class member function */;
     return;
   }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -298,12 +298,6 @@ public:
       return true;
 
     CheckSYCLType(E->getType(), E->getSourceRange());
-    if (VarDecl *VD = dyn_cast<VarDecl>(D)) {
-      if (!VD->isLocalVarDeclOrParm() && VD->hasGlobalStorage()) {
-        VD->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
-        SemaRef.addSyclDeviceDecl(VD);
-      }
-    }
     return true;
   }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -228,12 +228,6 @@ public:
 
       CheckSYCLType(Callee->getReturnType(), Callee->getSourceRange());
 
-      if (FunctionDecl *Def = Callee->getDefinition()) {
-        if (!Def->hasAttr<SYCLDeviceAttr>()) {
-          Def->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
-          SemaRef.addSyclDeviceDecl(Def);
-        }
-      }
       if (auto const *FD = dyn_cast<FunctionDecl>(Callee)) {
         // FIXME: We need check all target specified attributes for error if
         // that function with attribute can not be called from sycl kernel.  The
@@ -265,23 +259,6 @@ public:
   bool VisitCXXConstructExpr(CXXConstructExpr *E) {
     for (const auto &Arg : E->arguments())
       CheckSYCLType(Arg->getType(), Arg->getSourceRange());
-
-    CXXConstructorDecl *Ctor = E->getConstructor();
-
-    if (FunctionDecl *Def = Ctor->getDefinition()) {
-      Def->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
-      SemaRef.addSyclDeviceDecl(Def);
-    }
-
-    const auto *ConstructedType = Ctor->getParent();
-    if (ConstructedType->hasUserDeclaredDestructor()) {
-      CXXDestructorDecl *Dtor = ConstructedType->getDestructor();
-
-      if (FunctionDecl *Def = Dtor->getDefinition()) {
-        Def->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
-        SemaRef.addSyclDeviceDecl(Def);
-      }
-    }
     return true;
   }
 
@@ -325,25 +302,6 @@ public:
       if (!VD->isLocalVarDeclOrParm() && VD->hasGlobalStorage()) {
         VD->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
         SemaRef.addSyclDeviceDecl(VD);
-      }
-    }
-    return true;
-  }
-
-  bool VisitCXXNewExpr(CXXNewExpr *E) {
-    // Memory storage allocation is not allowed in kernels.
-    // All memory allocation for the device is done on
-    // the host using accessor classes. Consequently, the default
-    // allocation operator new overloads that allocate
-    // storage are disallowed in a SYCL kernel. The placement
-    // new operator and any user-defined overloads that
-    // do not allocate storage are permitted.
-    if (FunctionDecl *FD = E->getOperatorNew()) {
-      if (FunctionDecl *Def = FD->getDefinition()) {
-        if (!Def->hasAttr<SYCLDeviceAttr>()) {
-          Def->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
-          SemaRef.addSyclDeviceDecl(Def);
-        }
       }
     }
     return true;
@@ -1389,13 +1347,8 @@ void Sema::MarkDevice(void) {
     }
   }
   for (const auto &elt : Marker.KernelSet) {
-    if (FunctionDecl *Def = elt->getDefinition()) {
-      if (!Def->hasAttr<SYCLDeviceAttr>()) {
-        Def->addAttr(SYCLDeviceAttr::CreateImplicit(Context));
-        addSyclDeviceDecl(Def);
-      }
+    if (FunctionDecl *Def = elt->getDefinition())
       Marker.TraverseStmt(Def->getBody());
-    }
   }
 }
 
@@ -1465,10 +1418,6 @@ static void emitCallToUndefinedFnDiag(Sema &SemaRef, const FunctionDecl *Callee,
   // Somehow an unspecialized template appears to be in callgraph or list of
   // device functions. We don't want to emit diagnostic here.
   if (Callee->getTemplatedKind() == FunctionDecl::TK_FunctionTemplate)
-    return;
-
-  // Don't emit diagnostic for functions not called from device code
-  if (!Caller->hasAttr<SYCLDeviceAttr>() && !Caller->hasAttr<SYCLKernelAttr>())
     return;
 
   bool RedeclHasAttr = false;

--- a/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
@@ -35,18 +35,17 @@ public:
   [[intel::device_indirectly_callable]] void AFoo<int>(int t) {}
 };
 
-
 struct Base {
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN4Base12BaseWithAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
- [[intel::device_indirectly_callable]] virtual void BaseWithAttr() { int a = 10; }
-  virtual void BaseWithoutAttr() {int b = 20; }
+  [[intel::device_indirectly_callable]] virtual void BaseWithAttr() { int a = 10; }
+  virtual void BaseWithoutAttr() { int b = 20; }
 };
 
 struct Overrider : Base {
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN9Overrider12BaseWithAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
- [[intel::device_indirectly_callable]] void BaseWithAttr() override { int a = 20; }
+  [[intel::device_indirectly_callable]] void BaseWithAttr() override { int a = 20; }
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN9Overrider15BaseWithoutAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
- [[intel::device_indirectly_callable]] void BaseWithoutAttr() override { int b = 30; }
+  [[intel::device_indirectly_callable]] void BaseWithoutAttr() override { int b = 30; }
 };
 
 struct Overrider1 : Base {
@@ -54,12 +53,11 @@ struct Overrider1 : Base {
   void BaseWithAttr() override { int a = 20; }
 };
 
-
 struct Finalizer : Base {
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN9Finalizer12BaseWithAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
- [[intel::device_indirectly_callable]] void BaseWithAttr() final { int a = 20; }
+  [[intel::device_indirectly_callable]] void BaseWithAttr() final { int a = 20; }
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN9Finalizer15BaseWithoutAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
- [[intel::device_indirectly_callable]] void BaseWithoutAttr() final { int b = 30; }
+  [[intel::device_indirectly_callable]] void BaseWithoutAttr() final { int b = 30; }
 };
 
 struct Finalizer1 : Base {

--- a/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
@@ -7,10 +7,65 @@ void foo() {
   helper();
 }
 
-// CHECK: define spir_func void @{{.*foo.*}}() #[[ATTRS_FOO:[0-9]+]]
+// CHECK: define spir_func void @{{.*foo.*}}() #[[ATTRS_INDIR_CALL:[0-9]+]]
 // CHECK: call spir_func void @{{.*helper.*}}()
 //
-// CHECK: define spir_func void @{{.*helper.*}}() #[[ATTRS_HELPER:[0-9]+]]
+// CHECK: define spir_func void @{{.*helper.*}}() #[[ATTRS_NOT_INDIR_CALL:[0-9]+]]
 //
-// CHECK: attributes #[[ATTRS_FOO]] = { {{.*}} "referenced-indirectly"
-// CHECK-NOT: attributes #[[ATTRS_HELPER]] = { {{.*}} "referenced-indirectly"
+
+int bar20(int a) { return a + 20; }
+
+class A {
+public:
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1A3fooEv{{.*}}#[[ATTRS_INDIR_CALL]]
+  // CHECK-DAG: define spir_func i32 @_Z5bar20{{.*}}#[[ATTRS_NOT_INDIR_CALL]]
+  [[intel::device_indirectly_callable]] void foo() { bar20(10); }
+
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AC1Ev{{.*}}#[[ATTRS_INDIR_CALL]]
+  [[intel::device_indirectly_callable]] A() {}
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AD1Ev{{.*}}#[[ATTRS_INDIR_CALL]]
+  [[intel::device_indirectly_callable]] ~A() {}
+
+  template <typename T>
+  [[intel::device_indirectly_callable]] void AFoo(T t) {}
+
+  // Templates are emitted when they are instantiated
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1A4AFooIiEEvT_{{.*}}#[[ATTRS_INDIR_CALL]]
+  template <>
+  [[intel::device_indirectly_callable]] void AFoo<int>(int t) {}
+};
+
+
+struct Base {
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN4Base12BaseWithAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
+ [[intel::device_indirectly_callable]] virtual void BaseWithAttr() { int a = 10; }
+  virtual void BaseWithoutAttr() {int b = 20; }
+};
+
+struct Overrider : Base {
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN9Overrider12BaseWithAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
+ [[intel::device_indirectly_callable]] void BaseWithAttr() override { int a = 20; }
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN9Overrider15BaseWithoutAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
+ [[intel::device_indirectly_callable]] void BaseWithoutAttr() override { int b = 30; }
+};
+
+struct Overrider1 : Base {
+  // CHECK-NOT: define linkonce_odr spir_func void @_ZN10Overrider112BaseWithAttrEv
+  void BaseWithAttr() override { int a = 20; }
+};
+
+
+struct Finalizer : Base {
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN9Finalizer12BaseWithAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
+ [[intel::device_indirectly_callable]] void BaseWithAttr() final { int a = 20; }
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN9Finalizer15BaseWithoutAttrEv{{.*}}#[[ATTRS_INDIR_CALL]]
+ [[intel::device_indirectly_callable]] void BaseWithoutAttr() final { int b = 30; }
+};
+
+struct Finalizer1 : Base {
+  // CHECK-NOT: define linkonce_odr spir_func void @_ZN10Finalizer112BaseWithAttrEv
+  void BaseWithAttr() final { int a = 20; }
+};
+
+// CHECK: attributes #[[ATTRS_INDIR_CALL]] = { {{.*}} "referenced-indirectly"
+// CHECK-NOT: attributes #[[ATTRS_NOT_INDIR_CALL]] = { {{.*}} "referenced-indirectly"

--- a/clang/test/CodeGenSYCL/sycl-device.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device.cpp
@@ -3,6 +3,15 @@
 
 int bar(int b);
 
+class A {
+public:
+  // TODO: check for constructor/destructor as well
+
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1A3fooEv
+  __attribute__((sycl_device))
+  void foo() {}
+};
+
 // CHECK-DAG: define spir_func i32 @_Z3fooii
 __attribute__((sycl_device))
 int foo(int a, int b) { return a + bar(b); }

--- a/clang/test/CodeGenSYCL/sycl-device.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device.cpp
@@ -13,9 +13,9 @@ public:
   __attribute__((sycl_device)) void foo() { bar20(10); }
 
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AC1Ev
+  // CHECK-DAG: define spir_func i32 @_Z5bar10i
   __attribute__((sycl_device))
   A() { bar10(10); }
-  // CHECK-DAG: define spir_func i32 @_Z5bar10i
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AD1Ev
   __attribute__((sycl_device)) ~A() {}
 
@@ -26,6 +26,12 @@ public:
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN1A4AFooIiEEvT_
   template <>
   __attribute__((sycl_device)) void AFoo<int>(int t) {}
+
+  // CHECK-DAG: define linkonce_odr spir_func i32 @_ZN1A13non_annotatedEv
+  int non_annotated() { return 1; }
+
+  // CHECK-DAG: define linkonce_odr spir_func i32 @_ZN1A9annotatedEv
+  __attribute__((sycl_device)) int annotated() { return non_annotated() + 1; }
 };
 
 template <typename T>

--- a/clang/test/CodeGenSYCL/sycl-device.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device.cpp
@@ -48,7 +48,7 @@ struct B<int> {
 struct Base {
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN4Base12BaseWithAttrEv
   __attribute__((sycl_device)) virtual void BaseWithAttr() { int a = 10; }
-  virtual void BaseWithoutAttr() {int b = 20; }
+  virtual void BaseWithoutAttr() { int b = 20; }
 };
 
 struct Overrider : Base {
@@ -62,7 +62,6 @@ struct Overrider1 : Base {
   // CHECK-NOT: define linkonce_odr spir_func void @_ZN10Overrider112BaseWithAttrEv
   void BaseWithAttr() override { int a = 20; }
 };
-
 
 struct Finalizer : Base {
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN9Finalizer12BaseWithAttrEv

--- a/clang/test/CodeGenSYCL/sycl-device.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device.cpp
@@ -5,11 +5,39 @@ int bar(int b);
 
 class A {
 public:
-  // TODO: check for constructor/destructor as well
-
   // CHECK-DAG: define linkonce_odr spir_func void @_ZN1A3fooEv
+  __attribute__((sycl_device)) void foo() {}
+
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AC1Ev
   __attribute__((sycl_device))
-  void foo() {}
+  A() {}
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AD1Ev
+  __attribute__((sycl_device)) ~A() {}
+
+  template <typename T>
+  __attribute__((sycl_device)) void AFoo(T t) {}
+
+  // Templates are emitted when they are instantiated
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1A4AFooIiEEvT_
+  template <>
+  __attribute__((sycl_device)) void AFoo<int>(int t) {}
+};
+
+template <typename T>
+struct B {
+  T data;
+  B(T _data) : data(_data) {}
+
+  __attribute__((sycl_device)) void BFoo(T t) {}
+};
+
+template <>
+struct B<int> {
+  int data;
+  B(int _data) : data(_data) {}
+
+  // CHECK-DAG: _ZN1BIiE4BFooEi
+  __attribute__((sycl_device)) void BFoo(int t) {}
 };
 
 // CHECK-DAG: define spir_func i32 @_Z3fooii

--- a/clang/test/SemaSYCL/call-to-undefined-function.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function.cpp
@@ -92,6 +92,9 @@ void forwardDeclFn() {
 }
 
 int main() {
+  // No problems in host code
+  undefined();
+
   kernel_single_task<class CallToUndefinedFnTester>([]() {
     // expected-note@-1 {{called by 'operator()'}}
     // expected-note@-2 {{called by 'operator()'}}

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -19,11 +19,19 @@ namespace {
 }
 
 class A {
-  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a class member function}}
+  [[intel::device_indirectly_callable]]
   A() {}
 
-  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a class member function}}
+  [[intel::device_indirectly_callable]]
   int func3() {}
+};
+
+class B {
+  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a virtual or pure virtual class member function}}
+  virtual int foo() {}
+
+  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a virtual or pure virtual class member function}}
+  virtual int bar() = 0;
 };
 
 void helper() {}

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -45,7 +45,6 @@ void baz() {}
 #endif // NO_SYCL
 
 // CHECK: FunctionDecl {{.*}} helper
-// CHECK: SYCLDeviceAttr
 //
 // CHECK: FunctionDecl {{.*}} foo
 // CHECK: SYCLDeviceAttr

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -19,19 +19,15 @@ namespace {
 }
 
 class A {
-  [[intel::device_indirectly_callable]]
-  A() {}
+  [[intel::device_indirectly_callable]] A() {}
 
-  [[intel::device_indirectly_callable]]
-  int func3() {}
+  [[intel::device_indirectly_callable]] int func3() {}
 };
 
 class B {
-  [[intel::device_indirectly_callable]]
-  virtual int foo() {}
+  [[intel::device_indirectly_callable]] virtual int foo(){}
 
-  [[intel::device_indirectly_callable]]
-  virtual int bar() = 0;
+  [[intel::device_indirectly_callable]] virtual int bar() = 0;
 };
 
 void helper() {}

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -27,10 +27,10 @@ class A {
 };
 
 class B {
-  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a virtual or pure virtual class member function}}
+  [[intel::device_indirectly_callable]]
   virtual int foo() {}
 
-  [[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a virtual or pure virtual class member function}}
+  [[intel::device_indirectly_callable]]
   virtual int bar() = 0;
 };
 

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -25,7 +25,7 @@ class A {
 };
 
 class B {
-  [[intel::device_indirectly_callable]] virtual int foo(){}
+  [[intel::device_indirectly_callable]] virtual int foo() {}
 
   [[intel::device_indirectly_callable]] virtual int bar() = 0;
 };

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -21,11 +21,19 @@ namespace {
 }
 
 class A {
-  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a class member function}}
+  __attribute__((sycl_device))
   A() {}
 
-  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a class member function}}
+  __attribute__((sycl_device))
   int func3() {}
+};
+
+class B {
+  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a virtual or pure virtual class member function}}
+  virtual int foo() {}
+
+  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a virtual or pure virtual class member function}}
+  virtual int bar() = 0;
 };
 
 #if defined(NOT_STRICT)

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -24,16 +24,14 @@ class A {
   __attribute__((sycl_device))
   A() {}
 
-  __attribute__((sycl_device))
-  int func3() {}
+  __attribute__((sycl_device)) void func3() {}
 };
 
 class B {
-  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a virtual or pure virtual class member function}}
-  virtual int foo() {}
+public:
+  __attribute__((sycl_device)) virtual void foo() {}
 
-  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a virtual or pure virtual class member function}}
-  virtual int bar() = 0;
+  __attribute__((sycl_device)) virtual void bar() = 0;
 };
 
 #if defined(NOT_STRICT)


### PR DESCRIPTION
This patch allows to apply sycl_device attribute and therefore SYCL_EXTERNAL macro to class member functions.

The same logic was applied to [[intel::device_indireclty_callable]].