### PR TITLE
[SYCL] Allow to run deploy LIT tests from particular directory

### DIFF
--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -54,6 +54,13 @@ add_lit_testsuites(SYCL ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${SYCL_TEST_DEPS}
   )
 
+add_lit_testsuites(SYCL-DEPLOY ${CMAKE_CURRENT_SOURCE_DIR}
+  ARGS ${DEPLOY_RT_TEST_ARGS}
+  PARAMS "SYCL_BE=PI_OPENCL"
+  DEPENDS ${SYCL_DEPLOY_TEST_DEPS}
+  EXCLUDE_FROM_CHECK_ALL
+  )
+
 if(SYCL_BUILD_PI_CUDA)
   add_lit_testsuite(check-sycl-cuda "Running the SYCL regression tests for CUDA"
     ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
i.e. for example building of the target like
`check-sycl-deploy-device-code-split` will run tests only from
`device-code-split` directory.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>