### PR TITLE
[SYCL][PI][CUDA] Implement profiling info queries

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -440,6 +440,13 @@ constexpr pi_sampler_properties PI_SAMPLER_PROPERTIES_ADDRESSING_MODE =
 constexpr pi_sampler_properties PI_SAMPLER_PROPERTIES_FILTER_MODE =
     CL_SAMPLER_FILTER_MODE;
 
+typedef enum {
+  PI_PROFILING_INFO_COMMAND_QUEUED = CL_PROFILING_COMMAND_QUEUED,
+  PI_PROFILING_INFO_COMMAND_SUBMIT = CL_PROFILING_COMMAND_SUBMIT,
+  PI_PROFILING_INFO_COMMAND_START = CL_PROFILING_COMMAND_START,
+  PI_PROFILING_INFO_COMMAND_END = CL_PROFILING_COMMAND_END
+} _pi_profiling_info;
+
 // NOTE: this is made 64-bit to match the size of cl_mem_flags to
 // make the translation to OpenCL transparent.
 // TODO: populate
@@ -488,6 +495,7 @@ using pi_event_status = _pi_event_status;
 using pi_program_build_info = _pi_program_build_info;
 using pi_program_build_status = _pi_program_build_status;
 using pi_kernel_info = _pi_kernel_info;
+using pi_profiling_info = _pi_profiling_info;
 
 // For compatibility with OpenCL define this not as enum.
 using pi_device_partition_property = intptr_t;
@@ -915,11 +923,9 @@ pi_result piEventGetInfo(pi_event event,
                          size_t param_value_size, void *param_value,
                          size_t *param_value_size_ret);
 
-pi_result
-piEventGetProfilingInfo(pi_event event,
-                        cl_profiling_info param_name, // TODO: untie from OpenCL
-                        size_t param_value_size, void *param_value,
-                        size_t *param_value_size_ret);
+pi_result piEventGetProfilingInfo(pi_event event, pi_profiling_info param_name,
+                                  size_t param_value_size, void *param_value,
+                                  size_t *param_value_size_ret);
 
 pi_result piEventsWait(pi_uint32 num_events, const pi_event *event_list);
 

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -72,11 +72,13 @@ struct _pi_context {
   _pi_device *deviceId_;
   std::atomic_uint32_t refCount_;
 
+  CUevent evBase_; // CUDA event used as base counter
+
   _pi_context(kind k, CUcontext ctxt, _pi_device *devId)
-      : kind_{k}, cuContext_{ctxt}, deviceId_{devId}, refCount_{1} {
+      : kind_{k}, cuContext_{ctxt}, deviceId_{devId}, refCount_{1},
+        evBase_(nullptr) {
     cuda_piDeviceRetain(deviceId_);
   };
-
 
   ~_pi_context() { cuda_piDeviceRelease(deviceId_); }
 
@@ -238,7 +240,7 @@ public:
 
   pi_result start();
 
-  native_type get() const noexcept { return event_; };
+  native_type get() const noexcept { return evEnd_; };
 
   pi_result set_user_event_complete() noexcept {
 
@@ -280,8 +282,15 @@ public:
 
   pi_uint32 decrement_reference_count() { return --refCount_; }
 
-  // Returns the elapsed time in nano-seconds since the command(s)
-  // associated with the event have completed
+  // Returns the counter time when the associated command(s) were enqueued
+  //
+  pi_uint64 get_queued_time() const;
+
+  // Returns the counter time when the associated command(s) started execution
+  //
+  pi_uint64 get_start_time() const;
+
+  // Returns the counter time when the associated command(s) completed
   //
   pi_uint64 get_end_time() const;
 
@@ -315,10 +324,13 @@ private:
   bool isStarted_; // Signifies wether the operation associated with the
                    // PI event has started or not
 
-  native_type event_; // CUDA event handle. If this _pi_event represents a user
+  native_type evEnd_; // CUDA event handle. If this _pi_event represents a user
                       // event, this will be nullptr.
 
   native_type evStart_; // CUDA event handle associated with the start
+
+  native_type evQueued_; // CUDA event handle associated with the time
+                         // the command was enqueued
 
   pi_queue queue_; // pi_queue associated with the event. If this is a user
                    // event, this will be nullptr.

--- a/sycl/source/detail/event_info.hpp
+++ b/sycl/source/detail/event_info.hpp
@@ -25,7 +25,7 @@ template <info::event_profiling Param> struct get_event_profiling_info {
     RetType Result = 0;
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piEventGetProfilingInfo>(
-        Event, cl_profiling_info(Param), sizeof(Result), &Result, nullptr);
+        Event, pi_profiling_info(Param), sizeof(Result), &Result, nullptr);
     return Result;
   }
 };

--- a/sycl/test/basic_tests/event_profiling_info.cpp
+++ b/sycl/test/basic_tests/event_profiling_info.cpp
@@ -6,9 +6,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// XFAIL: cuda
-// TODO: fails cuda due to unimplemented param_name 4737 in
-//       cuda_piEventGetProfilingInfo
 //==------------------- event_profiling_info.cpp ---------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
Implements profiling info queries for PI_PROFILING_COMMAND_QUEUED,
PI_PROFILING_COMMAND_SUBMIT, and PI_PROFILING_COMMAND_START in
piEventGetProfilingInfo for the CUDA backend.

Signed-off-by: Steffen Larsen <steffen.larsen@codeplay.com>