### PR TITLE
[SYCL][CUDA] Fix LIT testing with CUDA devices

### DIFF
--- a/sycl/plugins/cuda/CMakeLists.txt
+++ b/sycl/plugins/cuda/CMakeLists.txt
@@ -6,7 +6,8 @@ message(STATUS "Including the PI API CUDA backend.")
 
 find_package(CUDA 10.1 REQUIRED)
 
-add_library(cudadrv SHARED IMPORTED)
+# Make imported library global to use it within the project.
+add_library(cudadrv SHARED IMPORTED GLOBAL)
 
 set_target_properties(
   cudadrv PROPERTIES 

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -69,6 +69,7 @@ llvm_config.use_clang()
 llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 
 backend=lit_config.params.get('SYCL_BE', "PI_OPENCL")
+lit_config.note("Backend: {BACKEND}".format(BACKEND=backend))
 
 get_device_count_by_type_path = os.path.join(config.llvm_tools_dir, "get_device_count_by_type")
 
@@ -119,11 +120,11 @@ cpu_check_on_linux_substitute = ""
 if getDeviceCount("cpu")[0]:
     found_at_least_one_device = True
     lit_config.note("Found available CPU device")
-    cpu_run_substitute = "env SYCL_DEVICE_TYPE=CPU "
+    cpu_run_substitute = "env SYCL_DEVICE_TYPE=CPU SYCL_BE={SYCL_BE} ".format(SYCL_BE=backend)
     cpu_check_substitute = "| FileCheck %s"
     config.available_features.add('cpu')
     if platform.system() == "Linux":
-        cpu_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=CPU "
+        cpu_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=CPU SYCL_BE={SYCL_BE} ".format(SYCL_BE=backend)
         cpu_check_on_linux_substitute = "| FileCheck %s"
 else:
     lit_config.warning("CPU device not found")
@@ -144,18 +145,15 @@ cuda = False
 if gpu_count > 0:
     found_at_least_one_device = True
     lit_config.note("Found available GPU device")
-    gpu_run_substitute = " env SYCL_DEVICE_TYPE=GPU "
+    gpu_run_substitute = " env SYCL_DEVICE_TYPE=GPU SYCL_BE={SYCL_BE} ".format(SYCL_BE=backend)
     gpu_check_substitute = "| FileCheck %s"
     config.available_features.add('gpu')
     if cuda:
        config.available_features.add('cuda')
-       gpu_run_substitute += " SYCL_BE=PI_CUDA "
 
     if platform.system() == "Linux":
-        gpu_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=GPU "
+        gpu_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=GPU SYCL_BE={SYCL_BE} ".format(SYCL_BE=backend)
         gpu_check_on_linux_substitute = "| FileCheck %s"
-        if cuda:
-            gpu_run_on_linux_substitute += " SYCL_BE=PI_CUDA "
 else:
     lit_config.warning("GPU device not found")
 

--- a/sycl/tools/CMakeLists.txt
+++ b/sycl/tools/CMakeLists.txt
@@ -5,45 +5,29 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_executable(get_device_count_by_type get_device_count_by_type.cpp)
 add_dependencies(get_device_count_by_type ocl-headers ocl-icd)
 
-if( SYCL_BUILD_PI_CUDA )
-  find_package(CUDA 10.1 REQUIRED)
-
-  add_library(cudadrv SHARED IMPORTED)
-
-  set_target_properties(
-    cudadrv PROPERTIES
-      IMPORTED_LOCATION             ${CUDA_CUDA_LIBRARY}
-      INTERFACE_INCLUDE_DIRECTORIES ${CUDA_INCLUDE_DIRS}
-  )
-
-  target_compile_definitions(get_device_count_by_type
-      PUBLIC $<$<BOOL:${SYCL_BUILD_PI_CUDA}>:USE_PI_CUDA>
-  )
-
-  target_include_directories( get_device_count_by_type
-    PUBLIC
-      ${CUDA_INCLUDE_DIRS}
-  )
-  target_link_libraries(get_device_count_by_type
-    PUBLIC OpenCL-Headers cudadrv
-)
-endif()
-
 target_link_libraries(get_device_count_by_type
-    PRIVATE OpenCL::Headers
-    PRIVATE ${OpenCL_LIBRARIES}
+  PRIVATE
+    OpenCL::Headers
+    ${OpenCL_LIBRARIES}
+    $<$<BOOL:${SYCL_BUILD_PI_CUDA}>:cudadrv>
+)
+target_compile_definitions(get_device_count_by_type
+  PRIVATE
+    $<$<BOOL:${SYCL_BUILD_PI_CUDA}>:USE_PI_CUDA>
 )
 
 add_executable(sycl-check sycl-check.cpp)
 add_dependencies(sycl-check sycl)
 target_include_directories(sycl-check PRIVATE "${sycl_inc_dir}")
 target_link_libraries(sycl-check
-    PRIVATE sycl
-    PRIVATE OpenCL::Headers
-    PRIVATE ${OpenCL_LIBRARIES})
+  PRIVATE
+    sycl
+    OpenCL::Headers
+    ${OpenCL_LIBRARIES})
 
 #Minimum supported version of Intel's OCL GPU and CPU devices
 target_compile_definitions(sycl-check
-     PRIVATE  MIN_INTEL_OCL_GPU_VERSION=\"18.47.11882\"
-     PRIVATE  MIN_INTEL_OCL_CPU_VERSION=\"18.1.0.0901\",\"7.6.0.1202\"
+  PRIVATE
+    MIN_INTEL_OCL_GPU_VERSION=\"18.47.11882\"
+    MIN_INTEL_OCL_CPU_VERSION=\"18.1.0.0901\",\"7.6.0.1202\"
 )

--- a/sycl/tools/get_device_count_by_type.cpp
+++ b/sycl/tools/get_device_count_by_type.cpp
@@ -1,3 +1,4 @@
+
 //==-- get_device_count_by_type.cpp - Get device count by type -------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -11,9 +12,13 @@
 
 #ifdef USE_PI_CUDA
 #include <cuda.h>
-#endif  // USE_PI_CUDA
+// #include <cuda_device_runtime_api.h>
+#endif // USE_PI_CUDA
 
+#include <algorithm>
+#include <cstdlib>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -24,92 +29,198 @@ static const std::string help =
     "   Supported backends: PI_CUDA/PI_OPENCL \n"
     "   Output format: <number_of_devices>:<additional_Information>";
 
-int main(int argc, char* argv[]) {
-    if (argc < 3) {
-        std::cout  
-            << "0:Please set a device type and backend to find" << std::endl
-            << help << std::endl;
-        return 0;
+// Return the string with all characters translated to lower case.
+std::string lowerString(const std::string &str) {
+  std::string result(str);
+  std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+  return result;
+}
+
+const char *deviceTypeToString(cl_device_type deviceType) {
+  const char *str = "unknown";
+  switch (deviceType) {
+  case CL_DEVICE_TYPE_CPU:
+    str = "cpu";
+    break;
+  case CL_DEVICE_TYPE_GPU:
+    str = "gpu";
+    break;
+  case CL_DEVICE_TYPE_ACCELERATOR:
+    str = "accelerator";
+    break;
+  case CL_DEVICE_TYPE_CUSTOM:
+    str = "custom";
+    break;
+  case CL_DEVICE_TYPE_DEFAULT:
+    str = "default";
+    break;
+  case CL_DEVICE_TYPE_ALL:
+    str = "all";
+    break;
+  default:
+    // str already set to express unknown device type.
+    break;
+  }
+
+  return str;
+}
+
+static bool queryOpenCL(cl_device_type deviceType, cl_uint &deviceCount,
+                        std::string &msg) {
+  deviceCount = 0u;
+  cl_int iRet = CL_SUCCESS;
+  cl_uint platformCount = 0;
+
+  iRet = clGetPlatformIDs(0, nullptr, &platformCount);
+  if (iRet != CL_SUCCESS) {
+    if (iRet == CL_PLATFORM_NOT_FOUND_KHR) {
+      msg = "ERROR: OpenCL error runtime not found";
+    } else {
+      std::stringstream stream;
+      stream << "ERROR: OpenCL error calling clGetPlatformIDs " << iRet
+             << std::endl;
+      msg = stream.str();
     }
+    return false;
+  }
 
-    std::string type = argv[1];
-    std::string backend{argv[2]};
+  std::vector<cl_platform_id> platforms(platformCount);
+  iRet = clGetPlatformIDs(platformCount, &platforms[0], nullptr);
+  if (iRet != CL_SUCCESS) {
+    std::stringstream stream;
+    stream << "ERROR: OpenCL error calling clGetPlatformIDs " << iRet
+           << std::endl;
+    msg = stream.str();
+    return false;
+  }
 
-    cl_uint deviceCount = 0;
+  for (cl_uint i = 0; i < platformCount; i++) {
+    cl_uint deviceCountPart = 0;
+    iRet =
+        clGetDeviceIDs(platforms[i], deviceType, 0, nullptr, &deviceCountPart);
+    if (iRet == CL_SUCCESS || iRet == CL_DEVICE_NOT_FOUND) {
+      deviceCount += deviceCountPart;
+    } else {
+      deviceCount = 0u;
+      std::stringstream stream;
+      stream << "ERROR: OpenCL error calling clGetDeviceIDs " << iRet
+             << std::endl;
+      msg = stream.str();
+      return false;
+    }
+  }
 
+  msg = "opencl ";
+  msg += deviceTypeToString(deviceType);
+  return true;
+}
+
+static bool queryCUDA(cl_device_type deviceType, cl_uint &deviceCount,
+                      std::string &msg) {
+  deviceCount = 0u;
 #ifdef USE_PI_CUDA
-    if (backend == "PI_CUDA") {
-      std::string msg{""};
+  const unsigned int defaultFlag = 0;
+  CUresult err = cuInit(defaultFlag);
+  if (err != CUDA_SUCCESS) {
+    msg = "ERROR: CUDA initialization error";
+    return false;
+  }
 
-      int runtime_version = 0;
+  const int minRuntimeVersion = 10010;
+  int runtimeVersion = 0;
+  err = cuDriverGetVersion(&runtimeVersion);
+  if (err != CUDA_SUCCESS) {
+    msg = "ERROR: CUDA error querying driver version";
+    return false;
+  }
 
-      auto err = cuDriverGetVersion(&runtime_version);
-      if (runtime_version < 9020 || err != CUDA_SUCCESS) {
-        std::cout << deviceCount << ":Unsupported CUDA Runtime " << std::endl;
-        return 1;
-      }
+  if (runtimeVersion < minRuntimeVersion) {
+    std::stringstream stream;
+    stream << "ERROR: CUDA version must be at least " << minRuntimeVersion
+           << " but is only " << runtimeVersion;
+    msg = stream.str();
+    return false;
+  }
 
-      if (type == "gpu") {
-        deviceCount = 1;
-        msg = "cuda";
-      } else {
-        msg = "Unsupported device type for CUDA backend";
-        msg += " type: ";
-        msg += type;
-      }
-      std::cout << deviceCount << ":" << msg << std::endl;
-      return 0;
+  switch (deviceType) {
+  case CL_DEVICE_TYPE_DEFAULT: // Fall through.
+  case CL_DEVICE_TYPE_ALL:     // Fall through.
+  case CL_DEVICE_TYPE_GPU: {
+    int count = 0;
+    CUresult err = cuDeviceGetCount(&count);
+    if (err != CUDA_SUCCESS || count < 0) {
+      msg = "ERROR: CUDA error querying device count";
+      return false;
     }
-#endif  // USE_PI_CUDA
-
-    cl_device_type device_type;
-    if (type == "cpu") {
-        device_type = CL_DEVICE_TYPE_CPU;
-    } else if (type == "gpu") {
-        device_type = CL_DEVICE_TYPE_GPU;
-    } else if (type == "accelerator") {
-        device_type = CL_DEVICE_TYPE_ACCELERATOR;
-    } else if (type == "default") {
-        device_type = CL_DEVICE_TYPE_DEFAULT;
-    } else if (type == "all") {
-        device_type = CL_DEVICE_TYPE_ALL;
-    } else  {
-        std::cout << "0:Incorrect device type." << std::endl
-            << help << std::endl;
-        return 0;
+    if (count < 1) {
+      msg = "ERROR: CUDA no device found";
+      return false;
     }
+    deviceCount = static_cast<cl_uint>(count);
+    msg = "cuda ";
+    msg += deviceTypeToString(deviceType);
+    return true;
+  } break;
+  default:
+    msg = "WARNING: CUDA unsupported device type ";
+    msg += deviceTypeToString(deviceType);
+    return true;
+  }
+#else
+  msg = "ERROR: CUDA not supported";
+  deviceCount = 0u;
 
-    cl_int iRet = CL_SUCCESS;
-    cl_uint platformCount = 0;
+  return false;
+#endif
+}
 
-    iRet = clGetPlatformIDs(0, nullptr, &platformCount);
-    if (iRet != CL_SUCCESS) {
-        if (iRet == CL_PLATFORM_NOT_FOUND_KHR) {
-            std::cout << "0:OpenCL runtime not found " << std::endl;
-        } else {
-            std::cout << "0:A problem at calling function clGetPlatformIDs count "
-                << iRet << std::endl;
-        }
-        return 0;
-    }
+int main(int argc, char *argv[]) {
+  if (argc < 3) {
+    std::cout << "0:ERROR: Please set a device type and backend to find"
+              << std::endl
+              << help << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    std::vector<cl_platform_id> platforms(platformCount);
+  // Normalize all arguments to lower case.
+  std::string type{lowerString(argv[1])};
+  std::string backend{lowerString(argv[2])};
 
-    iRet = clGetPlatformIDs(platformCount, &platforms[0], nullptr);
-    if (iRet != CL_SUCCESS) {
-        std::cout << "0:A problem at when calling function clGetPlatformIDs ids " << iRet << std::endl;
-        return 0;
-    }
+  cl_device_type deviceType = CL_DEVICE_TYPE_DEFAULT;
+  if (type == "cpu") {
+    deviceType = CL_DEVICE_TYPE_CPU;
+  } else if (type == "gpu") {
+    deviceType = CL_DEVICE_TYPE_GPU;
+  } else if (type == "accelerator") {
+    deviceType = CL_DEVICE_TYPE_ACCELERATOR;
+  } else if (type == "default") {
+    deviceType = CL_DEVICE_TYPE_DEFAULT;
+  } else if (type == "all") {
+    deviceType = CL_DEVICE_TYPE_ALL;
+  } else {
+    std::cout << "0:ERROR: Incorrect device type " << type << "\n"
+              << help << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    for (cl_uint i = 0; i < platformCount; i++) {
-        cl_uint deviceCountPart = 0;
-        iRet = clGetDeviceIDs(platforms[i], device_type, 0, nullptr, &deviceCountPart);
-        if (iRet == CL_SUCCESS) {
-            deviceCount += deviceCountPart;
-        }
-    }
+  std::string msg;
+  cl_uint deviceCount = 0;
 
-    std::cout << deviceCount << ":" << std::endl;
+  bool querySuccess = false;
 
-    return 0;
+  if (backend == "opencl" || backend == "pi_opencl") {
+    querySuccess = queryOpenCL(deviceType, deviceCount, msg);
+  } else if (backend == "cuda" || backend == "pi_cuda") {
+    querySuccess = queryCUDA(deviceType, deviceCount, msg);
+  } else {
+    msg + "ERROR: Unknown backend " + backend + "\n" + help + "\n";
+  }
+
+  std::cout << deviceCount << ":" << msg << std::endl;
+
+  if (!querySuccess) {
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Build the `get_device_count_by_type` tool with the required preprocessor
definitions to enable CUDA, and link with CUDA.

Passed correct backend name to the `get_device_count_by_type` tool to
is required to run tests with PI OpenCL instead of PI CUDA.

Clean up the `get_device_count_by_type` tool code to make it harder to
call it with the wrong backend and get unexpected query results back.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>