### PR TITLE
[SYCL][CUDA] Fix CMake warning

### DIFF
--- a/sycl/plugins/cuda/CMakeLists.txt
+++ b/sycl/plugins/cuda/CMakeLists.txt
@@ -29,21 +29,22 @@ add_dependencies(sycl-toolchain pi_cuda)
 
 set_target_properties(pi_cuda PROPERTIES LINKER_LANGUAGE CXX)
 
-target_include_directories(pi_cuda PRIVATE "${sycl_inc_dir}")
-
-target_include_directories(pi_cuda INTERFACE ${CUDA_INCLUDE_DIRS})
+target_include_directories(pi_cuda
+  PRIVATE
+    ${sycl_inc_dir}
+  PUBLIC
+    ${CUDA_INCLUDE_DIRS}
+)
 
 target_link_libraries(pi_cuda PUBLIC OpenCL-Headers cudadrv)
 
-target_link_libraries(sycl INTERFACE pi_cuda)
-
 add_common_options(pi_cuda)
-
-target_compile_definitions(
-  sycl PUBLIC USE_PI_CUDA
-)
 
 install(TARGETS pi_cuda
   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT pi_cuda
   RUNTIME DESTINATION "bin" COMPONENT pi_cuda
 )
+
+# `sycl/source/CMakeLists.txt` adapted when SYCL_BUILD_PI_CUDA is defined:
+# target_link_libraries(sycl PUBLIC pi_cuda)
+# target_compile_definitions(sycl PUBLIC USE_PI_CUDA)

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -48,10 +48,17 @@ function(add_sycl_rt_library LIB_NAME)
   target_include_directories(
       ${LIB_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} "${sycl_inc_dir}")
   target_link_libraries(${LIB_NAME}
-      PRIVATE OpenCL::Headers
-      PRIVATE ${OpenCL_LIBRARIES}
-      PRIVATE ${CMAKE_DL_LIBS}
+      PRIVATE
+        OpenCL::Headers
+        ${OpenCL_LIBRARIES}
+        ${CMAKE_DL_LIBS}
+      PUBLIC
+        $<$<BOOL:${SYCL_BUILD_PI_CUDA}>:pi_cuda>
   )
+
+  target_compile_definitions(${LIB_NAME}
+    PUBLIC
+      $<$<BOOL:${SYCL_BUILD_PI_CUDA}>:USE_PI_CUDA>)
 
   add_common_options(${LIB_NAME})
 


### PR DESCRIPTION
Stop calling target_link_libraries for a target from a different scope/
directory.

Fixes CMake warning:
```sh
-- Including the PI API CUDA backend.
CMake Warning (dev) at /home/bjoern/Dev/stateray/wip/llvm/sycl/plugins/cuda/CMakeLists.txt:39 (target_link_libraries):
  Policy CMP0079 is not set: target_link_libraries allows use with targets in
  other directories.  Run "cmake --help-policy CMP0079" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  Target

    sycl

  is not created in this directory.  For compatibility with older versions of
  CMake, link library

    pi_cuda

  will be looked up in the directory in which the target was created rather
  than in this calling directory.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>