### PR TITLE
[SYCL][CUDA] Replace assert with CHECK

### DIFF
--- a/sycl/test/basic_tests/accessor/accessor.cpp
+++ b/sycl/test/basic_tests/accessor/accessor.cpp
@@ -11,8 +11,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "../../helpers.hpp"
 #include <CL/sycl.hpp>
-#include <cassert>
 
 namespace sycl {
 using namespace cl::sycl;
@@ -77,19 +77,19 @@ int main() {
     auto acc_src = buf_src.get_access<sycl::access::mode::read>();
     auto acc_dst = buf_dst.get_access<sycl::access::mode::read_write>();
 
-    assert(!acc_src.is_placeholder());
-    assert(acc_src.get_size() == sizeof(src));
-    assert(acc_src.get_count() == 2);
-    assert(acc_src.get_range() == sycl::range<1>(2));
+    CHECK(!acc_src.is_placeholder());
+    CHECK(acc_src.get_size() == sizeof(src));
+    CHECK(acc_src.get_count() == 2);
+    CHECK(acc_src.get_range() == sycl::range<1>(2));
 
     // Make sure that operator[] is defined for both size_t and id<1>.
     // Implicit conversion from IdxSzT to size_t guarantees that no
     // implicit conversion from size_t to id<1> will happen.
-    assert(acc_src[IdxSzT(0)] + acc_src[IdxID1(1)] == 10);
+    CHECK(acc_src[IdxSzT(0)] + acc_src[IdxID1(1)] == 10);
 
     acc_dst[0] = acc_src[0] + acc_src[IdxID1(0)];
     acc_dst[id1] = acc_src[1] + acc_src[IdxSzT(1)];
-    assert(dst[0] == 6 && dst[1] == 14);
+    CHECK(dst[0] == 6 && dst[1] == 14);
   }
 
   // Three-dimensional host accessor.
@@ -101,10 +101,10 @@ int main() {
       sycl::buffer<int, 3> buf(data, sycl::range<3>(2, 3, 4));
       auto acc = buf.get_access<sycl::access::mode::read_write>();
 
-      assert(!acc.is_placeholder());
-      assert(acc.get_size() == sizeof(data));
-      assert(acc.get_count() == 24);
-      assert(acc.get_range() == sycl::range<3>(2, 3, 4));
+      CHECK(!acc.is_placeholder());
+      CHECK(acc.get_size() == sizeof(data));
+      CHECK(acc.get_count() == 24);
+      CHECK(acc.get_range() == sycl::range<3>(2, 3, 4));
 
       for (int i = 0; i < 2; ++i)
         for (int j = 0; j < 3; ++j)
@@ -112,7 +112,7 @@ int main() {
             acc[IdxID3(i, j, k)] += acc[sycl::id<3>(i, j, k)];
     }
     for (int i = 0; i < 24; ++i) {
-      assert(data[i] == 2 * i);
+      CHECK(data[i] == 2 * i);
     }
   }
   int data = 5;
@@ -125,16 +125,16 @@ int main() {
 
     Queue.submit([&](sycl::handler &cgh) {
       auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
-      assert(!acc.is_placeholder());
-      assert(acc.get_size() == sizeof(int));
-      assert(acc.get_count() == 1);
-      assert(acc.get_range() == sycl::range<1>(1));
+      CHECK(!acc.is_placeholder());
+      CHECK(acc.get_size() == sizeof(int));
+      CHECK(acc.get_count() == 1);
+      CHECK(acc.get_range() == sycl::range<1>(1));
       cgh.single_task<class kernel>(
           [=]() { acc[IdxSzT(0)] += acc[IdxID1(0)]; });
     });
     Queue.wait();
   }
-  assert(data == 10);
+  CHECK(data == 10);
 
   // Device accessor with 2-dimensional subscript operators.
   {
@@ -158,7 +158,7 @@ int main() {
         for (int j = 0; j < 3; j++) {
           std::cout << "array[" << i << "][" << j << "]=" << array[i][j]
                     << std::endl;
-          assert(array[i][j] == i * 3 + j);
+          CHECK(array[i][j] == i * 3 + j);
         }
       }
     }
@@ -188,7 +188,7 @@ int main() {
           for (int k = 0; k < 4; k++) {
             std::cout << "array[" << i << "][" << j << "][" << k
                       << "]=" << array[i][j][k] << std::endl;
-            assert(array[i][j][k] == k + 4 * (j + 3 * i));
+            CHECK(array[i][j][k] == k + 4 * (j + 3 * i));
           }
         }
       }
@@ -211,7 +211,7 @@ int main() {
 
       auto host_acc = buf.get_access<sycl::access::mode::read>();
       for (int i = 0; i != 3; ++i)
-        assert(host_acc[i] == 42);
+        CHECK(host_acc[i] == 42);
 
     } catch (cl::sycl::exception e) {
       std::cout << "SYCL exception caught: " << e.what();
@@ -262,7 +262,7 @@ int main() {
       }
       for (int i = 0; i < 10; i++) {
         std::cout << "array[" << i << "]=" << array[i] << std::endl;
-        assert(array[i] == 333);
+        CHECK(array[i] == 333);
       }
     }
   }
@@ -296,8 +296,8 @@ int main() {
       for (int i = 0; i < 10; i++) {
         std::cout << "array1[" << i << "]=" << array1[i] << std::endl;
         std::cout << "array2[" << i << "]=" << array2[i] << std::endl;
-        assert(array1[i] == 333);
-        assert(array2[i] == 666);
+        CHECK(array1[i] == 333);
+        CHECK(array2[i] == 666);
       }
     }
   }
@@ -326,7 +326,7 @@ int main() {
       }
       for (int i = 0; i < 10; i++) {
         std::cout << "array[" << i << "]=" << array[i] << std::endl;
-        assert(array[i] == 333);
+        CHECK(array[i] == 333);
       }
     }
   }
@@ -374,7 +374,7 @@ int main() {
           });
         });
       }
-      assert(data == 399);
+      CHECK(data == 399);
     } catch (sycl::exception e) {
       std::cout << "SYCL exception caught: " << e.what();
       return 1;
@@ -424,8 +424,8 @@ int main() {
                    sycl::access::target::host_buffer>
         acc6(buf3, sycl::range<1>(1));
 
-    assert(acc4 == 2);
-    assert(acc5[0] == 4);
-    assert(acc6[0] == 6);
+    CHECK(acc4 == 2);
+    CHECK(acc5[0] == 4);
+    CHECK(acc6[0] == 6);
   }
 }

--- a/sycl/test/basic_tests/buffer/buffer_full_copy.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_full_copy.cpp
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
+#include "../../helpers.hpp"
 #include <CL/sycl.hpp>
 #include <cassert>
 
@@ -50,9 +50,9 @@ void check_copy_device_to_host(cl::sycl::queue &Queue) {
     for (int i = 0; i < size; ++i) {
       for (int j = 0; j < size; ++j)
         if (offset <= i && i < offset + 2 && offset <= j && j < offset + 2) {
-          assert(acc[i][j] == 15);
+          CHECK(acc[i][j] == 15);
         } else {
-          assert(acc[i][j] == 13);
+          CHECK(acc[i][j] == 13);
         }
     }
   }
@@ -84,7 +84,7 @@ void check_fill(cl::sycl::queue &Queue) {
   {
     auto acc_1 = buf_1.get_access<cl::sycl::access::mode::read>();
     for (int i = 0; i < size; ++i)
-      assert(expected_res_1[i] == acc_1[i]);
+      CHECK(expected_res_1[i] == acc_1[i]);
   }
 }
 
@@ -121,10 +121,10 @@ void check_copy_host_to_device(cl::sycl::queue &Queue) {
 
     // check that there was no data corruption/loss
     for (int i = 0; i < size; ++i)
-      assert(expected_res_1[i] == acc_1[i]);
+      CHECK(expected_res_1[i] == acc_1[i]);
 
     for (int i = 0; i < size / 2; ++i)
-      assert(expected_res_2[i] == acc_2[i]);
+      CHECK(expected_res_2[i] == acc_2[i]);
   }
 
   cl::sycl::buffer<float, 2> buf_3({size, size});

--- a/sycl/test/basic_tests/buffer/reinterpret.cpp
+++ b/sycl/test/basic_tests/buffer/reinterpret.cpp
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "../../helpers.hpp"
 #include <CL/sycl.hpp>
-
 #include <climits>
 
 // This tests verifies basic cases of using cl::sycl::buffer::reinterpret
@@ -130,7 +130,7 @@ int main() {
         cl::sycl::id<1>{offset}, cl::sycl::range<1>{sub_buf_size}, val);
 
     for (std::size_t i = 0; i < sub_buf_size + offset; ++i) {
-      assert(data[i] == expected_data[i] &&
+      CHECK(data[i] == expected_data[i] &&
              "1D sub buffer int->char reinterpret failed");
     }
   }
@@ -153,7 +153,7 @@ int main() {
         cl::sycl::id<1>{offset}, cl::sycl::range<1>{sub_buf_size}, val);
 
     for (std::size_t i = 0; i < sub_buf_size + offset; ++i) {
-      assert(data[i] == expected_data[i] &&
+      CHECK(data[i] == expected_data[i] &&
              "1D sub buffer char->int reinterpret failed");
     }
   }
@@ -199,7 +199,7 @@ int main() {
 
     for (std::size_t i = 0; i < rows; ++i)
       for (std::size_t j = 0; j < cols; ++j)
-        assert(data[i * cols + j] == expected_data[i * cols + j] &&
+        CHECK(data[i * cols + j] == expected_data[i * cols + j] &&
                "2D->1D->sub buffer reinterpret failed");
   }
 
@@ -227,7 +227,7 @@ int main() {
 
     for (std::size_t i = 0; i < buf_row; ++i)
       for (std::size_t j = 0; j < buf_col; ++j)
-        assert(data[i * buf_col + j] == expected_data[i * buf_col + j] &&
+        CHECK(data[i * buf_col + j] == expected_data[i * buf_col + j] &&
                "2D sub buffer int->char reinterpret failed");
   }
 
@@ -252,8 +252,8 @@ int main() {
 
     for (std::size_t i = 0; i < buf_row; ++i)
       for (std::size_t j = 0; j < buf_col; ++j)
-        assert(data[i * buf_col + j] == expected_data[i * buf_col + j] &&
-               "2D sub buffer int->char reinterpret failed");
+        CHECK(data[i * buf_col + j] == expected_data[i * buf_col + j] &&
+              "2D sub buffer int->char reinterpret failed");
   }
 
   return failed;

--- a/sycl/test/basic_tests/buffer/subbuffer.cpp
+++ b/sycl/test/basic_tests/buffer/subbuffer.cpp
@@ -18,6 +18,7 @@
 // 1) Correct results after usage of different type of accessors to sub buffer
 // 2) Exceptions if we trying to create sub buffer not according to spec
 
+#include "../../helpers.hpp"
 #include <CL/sycl.hpp>
 
 #include <algorithm>
@@ -53,12 +54,12 @@ void checkHostAccessor(cl::sycl::queue &q) {
     {
       auto host_acc = subbuf.get_access<cl::sycl::access::mode::read>();
       for (int i = 0; i < 10; ++i)
-        assert(host_acc[i] == ((size / 2 + i) * -100) &&
-               "Sub buffer host accessor test failed.");
+        CHECK(host_acc[i] == ((size / 2 + i) * -100) &&
+              "Sub buffer host accessor test failed.");
     }
   }
-  assert(data[0] == 0 && data[size - 1] == (size - 1) &&
-         data[size / 2] == (size / 2 * -100) && "Loss of data");
+  CHECK(data[0] == 0 && data[size - 1] == (size - 1) &&
+        data[size / 2] == (size / 2 * -100) && "Loss of data");
 }
 
 void check1DSubBuffer(cl::sycl::queue &q) {
@@ -108,16 +109,16 @@ void check1DSubBuffer(cl::sycl::queue &q) {
 
   } catch (const cl::sycl::exception &e) {
     std::cerr << e.what() << std::endl;
-    assert(false && "Exception was caught");
+    CHECK(false && "Exception was caught");
   }
 
   for (int i = offset; i < subbuf_size; ++i)
-    assert(vec[i] == (i > 34 ? i * 10 : i * -10) &&
-           "Invalid result in 1d sub buffer");
+    CHECK(vec[i] == (i > 34 ? i * 10 : i * -10) &&
+          "Invalid result in 1d sub buffer");
 
   for (int i = 0; i < subbuf_size; ++i)
-    assert(vec2[i] == (i < 3 ? (32 + i) : (32 + i) * -1) &&
-           "Invalid result in 1d sub buffer");
+    CHECK(vec2[i] == (i < 3 ? (32 + i) : (32 + i) * -1) &&
+          "Invalid result in 1d sub buffer");
 }
 
 void checkExceptions() {
@@ -130,7 +131,7 @@ void checkExceptions() {
   try {
     cl::sycl::buffer<int, 2> sub_buf{buf2d, /*offset*/ cl::sycl::range<2>{2, 0},
                                      /*size*/ cl::sycl::range<2>{2, 2}};
-    assert(!"non contiguous region exception wasn't caught");
+    CHECK(!"non contiguous region exception wasn't caught");
   } catch (const cl::sycl::invalid_object_error &e) {
     std::cerr << e.what() << std::endl;
   }
@@ -138,7 +139,7 @@ void checkExceptions() {
   try {
     cl::sycl::buffer<int, 2> sub_buf{buf2d, /*offset*/ cl::sycl::range<2>{2, 2},
                                      /*size*/ cl::sycl::range<2>{2, 6}};
-    assert(!"non contiguous region exception wasn't caught");
+    CHECK(!"non contiguous region exception wasn't caught");
   } catch (const cl::sycl::invalid_object_error &e) {
     std::cerr << e.what() << std::endl;
   }
@@ -147,7 +148,7 @@ void checkExceptions() {
     cl::sycl::buffer<int, 3> sub_buf{buf3d,
                                      /*offset*/ cl::sycl::range<3>{0, 2, 1},
                                      /*size*/ cl::sycl::range<3>{1, 2, 3}};
-    assert(!"non contiguous region exception wasn't caught");
+    CHECK(!"non contiguous region exception wasn't caught");
   } catch (const cl::sycl::invalid_object_error &e) {
     std::cerr << e.what() << std::endl;
   }
@@ -156,7 +157,7 @@ void checkExceptions() {
     cl::sycl::buffer<int, 3> sub_buf{buf3d,
                                      /*offset*/ cl::sycl::range<3>{0, 0, 0},
                                      /*size*/ cl::sycl::range<3>{2, 3, 4}};
-    assert(!"non contiguous region exception wasn't caught");
+    CHECK(!"non contiguous region exception wasn't caught");
   } catch (const cl::sycl::invalid_object_error &e) {
     std::cerr << e.what() << std::endl;
   }
@@ -165,7 +166,7 @@ void checkExceptions() {
   try {
     cl::sycl::buffer<int, 2> sub_buf{buf2d, /*offset*/ cl::sycl::range<2>{2, 2},
                                      /*size*/ cl::sycl::range<2>{2, 8}};
-    assert(!"out of bounds exception wasn't caught");
+    CHECK(!"out of bounds exception wasn't caught");
   } catch (const cl::sycl::invalid_object_error &e) {
     std::cerr << e.what() << std::endl;
   }
@@ -174,7 +175,7 @@ void checkExceptions() {
     cl::sycl::buffer<int, 3> sub_buf{buf3d,
                                      /*offset*/ cl::sycl::range<3>{1, 1, 1},
                                      /*size*/ cl::sycl::range<3>{1, 1, 4}};
-    assert(!"out of bounds exception wasn't caught");
+    CHECK(!"out of bounds exception wasn't caught");
   } catch (const cl::sycl::invalid_object_error &e) {
     std::cerr << e.what() << std::endl;
   }
@@ -183,7 +184,7 @@ void checkExceptions() {
     cl::sycl::buffer<int, 3> sub_buf{buf3d,
                                      /*offset*/ cl::sycl::range<3>{3, 3, 0},
                                      /*size*/ cl::sycl::range<3>{1, 2, 4}};
-    assert(!"out of bounds exception wasn't caught");
+    CHECK(!"out of bounds exception wasn't caught");
   } catch (const cl::sycl::invalid_object_error &e) {
     std::cerr << e.what() << std::endl;
   }
@@ -194,7 +195,7 @@ void checkExceptions() {
                                      /*size*/ cl::sycl::range<2>{2, 8}};
     cl::sycl::buffer<int, 2> sub_sub_buf(sub_buf, cl::sycl::range<2>{0, 0},
                                          /*size*/ cl::sycl::range<2>{0, 0});
-    assert(!"invalid subbuffer exception wasn't caught");
+    CHECK(!"invalid subbuffer exception wasn't caught");
   } catch (const cl::sycl::invalid_object_error &e) {
     std::cerr << e.what() << std::endl;
   }
@@ -243,12 +244,13 @@ void copyBlock() {
       auto *V = BlockB.get_access<mode::read>().get_pointer();
 
       for (size_t Idx2 = 0; Idx2 < BlockSize; ++Idx2) {
-        assert(V[Idx2] == Idx2 + BlockSize * Idx &&
-               "Invalid data in block buffer");
+        CHECK(V[Idx2] == Idx2 + BlockSize * Idx &&
+              "Invalid data in block buffer");
       }
     }
-  } catch (cl::sycl::exception &ex) {
-    assert(false && "Unexpected exception captured!");
+  }
+  catch (cl::sycl::exception& ex) {
+    CHECK(false && "Unexpected exception captured!");
   }
 }
 
@@ -274,7 +276,7 @@ void checkMultipleContexts() {
           sycl::range<1>(N / 2), [=](sycl::id<1> idx) { bufacc[idx[0]] = 2; });
     });
   }
-  assert(a[N / 2 - 1] == 1 && a[N / 2] == 2 && "Sub buffer data loss");
+  CHECK(a[N / 2 - 1] == 1 && a[N / 2] == 2 && "Sub buffer data loss");
 }
 
 int main() {

--- a/sycl/test/basic_tests/buffer/subbuffer_interop.cpp
+++ b/sycl/test/basic_tests/buffer/subbuffer_interop.cpp
@@ -13,9 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "../../helpers.hpp"
 #include <CL/sycl.hpp>
-
-#include <cassert>
 #include <memory>
 #include <numeric>
 
@@ -111,12 +110,12 @@ int main() {
       if (i < NSize / 2 && AMem[i] != i) {
         std::cout << " array[" << i << "] is " << AMem[i] << " expected " << i
                   << std::endl;
-        assert(false);
+        CHECK(false);
         Failed = true;
       } else if (i >= NSize / 2 && AMem[i] != 0) {
         std::cout << " array[" << i << "] is " << AMem[i] << " expected " << 0
                   << std::endl;
-        assert(false);
+        CHECK(false);
         Failed = true;
       }
     }
@@ -179,22 +178,22 @@ int main() {
       if (i < NSize / 4 && AMem[i] != 0) {
         std::cout << " array[" << i << "] is " << AMem[i] << " expected " << 0
                   << std::endl;
-        assert(false);
+        CHECK(false);
         Failed = true;
       } else if (i >= NSize / 4 && i < 2 * NSize / 4 && AMem[i] != i) {
         std::cout << " array[" << i << "] is " << AMem[i] << " expected " << i
                   << std::endl;
-        assert(false);
+        CHECK(false);
         Failed = true;
       } else if (i >= 2 * NSize / 4 && i < 3 * NSize / 4 && AMem[i] != 0) {
         std::cout << " array[" << i << "] is " << AMem[i] << " expected " << 0
                   << std::endl;
-        assert(false);
+        CHECK(false);
         Failed = true;
       } else if (i >= 3 * NSize / 4 && AMem[i] != i) {
         std::cout << " array[" << i << "] is " << AMem[i] << " expected " << i
                   << std::endl;
-        assert(false);
+        CHECK(false);
         Failed = true;
       }
     }
@@ -269,17 +268,17 @@ int main() {
       if (i < NSize / 4 && AMem[i] != 0) {
         std::cout << " array[" << i << "] is " << AMem[i] << " expected " << 0
                   << std::endl;
-        assert(false);
+        CHECK(false);
         Failed = true;
       } else if (i >= NSize / 4 && i < 2 * NSize / 4 && AMem[i] != 1) {
         std::cout << " array[" << i << "] is " << AMem[i] << " expected " << i
                   << std::endl;
-        assert(false);
+        CHECK(false);
         Failed = true;
       } else if (i >= 2 * NSize / 4 && AMem[i] != i) {
         std::cout << " array[" << i << "] is " << AMem[i] << " expected " << i
                   << std::endl;
-        assert(false);
+        CHECK(false);
         Failed = true;
       }
     }
@@ -317,7 +316,7 @@ int main() {
     {
       auto host_acc = subbuf_copy->get_access<cl::sycl::access::mode::read>();
       std::cout << "On host: offset = " << host_acc[0] << std::endl;
-      assert(host_acc[0] == 256 && "Invalid subbuffer origin");
+      CHECK(host_acc[0] == 256 && "Invalid subbuffer origin");
     }
 
     Q.submit([&](cl::sycl::handler &cgh) {
@@ -331,7 +330,7 @@ int main() {
     {
       auto host_acc = subbuf_copy->get_access<cl::sycl::access::mode::read>();
       std::cout << "On host: offset = " << host_acc[0] << std::endl;
-      assert(host_acc[0] == 256 * 3 && "Invalid subbuffer origin");
+      CHECK(host_acc[0] == 256 * 3 && "Invalid subbuffer origin");
     }
   }
 

--- a/sycl/test/basic_tests/context.cpp
+++ b/sycl/test/basic_tests/context.cpp
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
 #include <iostream>
 
@@ -29,10 +30,10 @@ int main() {
     context Context(deviceA);
     size_t hash = hash_class<context>()(Context);
     context MovedContext(std::move(Context));
-    assert(hash == hash_class<context>()(MovedContext));
-    assert(deviceA.is_host() == MovedContext.is_host());
+    CHECK(hash == hash_class<context>()(MovedContext));
+    CHECK(deviceA.is_host() == MovedContext.is_host());
     if (!deviceA.is_host()) {
-      assert(MovedContext.get() != nullptr);
+      CHECK(MovedContext.get() != nullptr);
     }
   }
   {
@@ -41,10 +42,10 @@ int main() {
     size_t hash = hash_class<context>()(Context);
     context WillMovedContext(deviceB);
     WillMovedContext = std::move(Context);
-    assert(hash == hash_class<context>()(WillMovedContext));
-    assert(deviceA.is_host() == WillMovedContext.is_host());
+    CHECK(hash == hash_class<context>()(WillMovedContext));
+    CHECK(deviceA.is_host() == WillMovedContext.is_host());
     if (!deviceA.is_host()) {
-      assert(WillMovedContext.get() != nullptr);
+      CHECK(WillMovedContext.get() != nullptr);
     }
   }
   {
@@ -52,10 +53,10 @@ int main() {
     context Context(deviceA);
     size_t hash = hash_class<context>()(Context);
     context ContextCopy(Context);
-    assert(hash == hash_class<context>()(Context));
-    assert(hash == hash_class<context>()(ContextCopy));
-    assert(Context == ContextCopy);
-    assert(Context.is_host() == ContextCopy.is_host());
+    CHECK(hash == hash_class<context>()(Context));
+    CHECK(hash == hash_class<context>()(ContextCopy));
+    CHECK(Context == ContextCopy);
+    CHECK(Context.is_host() == ContextCopy.is_host());
   }
   {
     std::cout << "copy assignment operator" << std::endl;
@@ -63,9 +64,11 @@ int main() {
     size_t hash = hash_class<context>()(Context);
     context WillContextCopy(deviceB);
     WillContextCopy = Context;
-    assert(hash == hash_class<context>()(Context));
-    assert(hash == hash_class<context>()(WillContextCopy));
-    assert(Context == WillContextCopy);
-    assert(Context.is_host() == WillContextCopy.is_host());
+    CHECK(hash == hash_class<context>()(Context));
+    CHECK(hash == hash_class<context>()(WillContextCopy));
+    CHECK(Context == WillContextCopy);
+    CHECK(Context.is_host() == WillContextCopy.is_host());
   }
+
+  return 0;
 }

--- a/sycl/test/basic_tests/diagnostics/handler.cpp
+++ b/sycl/test/basic_tests/diagnostics/handler.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
+#include "../../helpers.hpp"
 #include <CL/sycl.hpp>
 
 using namespace cl;
@@ -30,8 +30,12 @@ int main() {
       CGH.single_task<class Dummy2>([]() {});
     });
     Queue.throw_asynchronous();
-  } catch (sycl::exception &E) {
+    CHECK(!"Expected exception not caught");
+  } catch (sycl::exception &ExpectedException) {
     // CHECK: Attempt to set multiple actions for the command group
-    std::cout << E.what() << std::endl;
+    // Using std::cout as input for FileCheck.
+    std::cout << ExpectedException.what() << std::endl;
   }
+
+  return 0;
 }

--- a/sycl/test/basic_tests/event.cpp
+++ b/sycl/test/basic_tests/event.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
 #include <iostream>
 
@@ -40,7 +41,7 @@ int main() {
     cl::sycl::event Event;
     size_t hash = std::hash<cl::sycl::event>()(Event);
     cl::sycl::event MovedEvent(std::move(Event));
-    assert(hash == std::hash<cl::sycl::event>()(MovedEvent));
+    CHECK(hash == std::hash<cl::sycl::event>()(MovedEvent));
   }
 
   {
@@ -49,7 +50,7 @@ int main() {
     size_t hash = std::hash<cl::sycl::event>()(Event);
     cl::sycl::event WillMovedEvent;
     WillMovedEvent = std::move(Event);
-    assert(hash == std::hash<cl::sycl::event>()(WillMovedEvent));
+    CHECK(hash == std::hash<cl::sycl::event>()(WillMovedEvent));
   }
 
   {
@@ -57,9 +58,9 @@ int main() {
     cl::sycl::event Event;
     size_t hash = std::hash<cl::sycl::event>()(Event);
     cl::sycl::event EventCopy(Event);
-    assert(hash == std::hash<cl::sycl::event>()(Event));
-    assert(hash == std::hash<cl::sycl::event>()(EventCopy));
-    assert(Event == EventCopy);
+    CHECK(hash == std::hash<cl::sycl::event>()(Event));
+    CHECK(hash == std::hash<cl::sycl::event>()(EventCopy));
+    CHECK(Event == EventCopy);
   }
 
   {
@@ -68,9 +69,9 @@ int main() {
     size_t hash = std::hash<cl::sycl::event>()(Event);
     cl::sycl::event WillEventCopy;
     WillEventCopy = Event;
-    assert(hash == std::hash<cl::sycl::event>()(Event));
-    assert(hash == std::hash<cl::sycl::event>()(WillEventCopy));
-    assert(Event == WillEventCopy);
+    CHECK(hash == std::hash<cl::sycl::event>()(Event));
+    CHECK(hash == std::hash<cl::sycl::event>()(WillEventCopy));
+    CHECK(Event == WillEventCopy);
   }
 
   // Check wait and wait_and_throw methods do not crash

--- a/sycl/test/basic_tests/image_accessor_readwrite.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite.cpp
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
-#include <cassert>
 #include <iomanip>
 #if DEBUG_OUTPUT
 #include <iostream>
@@ -46,10 +46,10 @@ void check_write_data(PixelDataType *HostDataPtr, PixelDataT ExpectedData) {
               << "  " << (float)ExpectedData.w() << std::endl;
   }
 #else
-  assert(HostDataPtr[0] == (PixelDataType)ExpectedData.x());
-  assert(HostDataPtr[1] == (PixelDataType)ExpectedData.y());
-  assert(HostDataPtr[2] == (PixelDataType)ExpectedData.z());
-  assert(HostDataPtr[3] == (PixelDataType)ExpectedData.w());
+  CHECK(HostDataPtr[0] == (PixelDataType)ExpectedData.x());
+  CHECK(HostDataPtr[1] == (PixelDataType)ExpectedData.y());
+  CHECK(HostDataPtr[2] == (PixelDataType)ExpectedData.z());
+  CHECK(HostDataPtr[3] == (PixelDataType)ExpectedData.w());
 #endif
 }
 
@@ -73,10 +73,10 @@ void check_write_data(s::cl_half *HostDataPtr, s::cl_half4 ExpectedData) {
               << "  " << (float)ExpectedData.w() << std::endl;
   }
 #else
-  assert(HostDataPtr[0] == (float)ExpectedData.x());
-  assert(HostDataPtr[1] == (float)ExpectedData.y());
-  assert(HostDataPtr[2] == (float)ExpectedData.z());
-  assert(HostDataPtr[3] == (float)ExpectedData.w());
+  CHECK(HostDataPtr[0] == (float)ExpectedData.x());
+  CHECK(HostDataPtr[1] == (float)ExpectedData.y());
+  CHECK(HostDataPtr[2] == (float)ExpectedData.z());
+  CHECK(HostDataPtr[3] == (float)ExpectedData.w());
 #endif
 }
 
@@ -114,10 +114,10 @@ void check_read_data(ReadDataT ReadData, ReadDataT ExpectedColor) {
   }
 #else
   {
-    assert((ReadDataType)ReadData.x() == (ReadDataType)ExpectedColor.x());
-    assert((ReadDataType)ReadData.y() == (ReadDataType)ExpectedColor.y());
-    assert((ReadDataType)ReadData.z() == (ReadDataType)ExpectedColor.z());
-    assert((ReadDataType)ReadData.w() == (ReadDataType)ExpectedColor.w());
+    CHECK((ReadDataType)ReadData.x() == (ReadDataType)ExpectedColor.x());
+    CHECK((ReadDataType)ReadData.y() == (ReadDataType)ExpectedColor.y());
+    CHECK((ReadDataType)ReadData.z() == (ReadDataType)ExpectedColor.z());
+    CHECK((ReadDataType)ReadData.w() == (ReadDataType)ExpectedColor.w());
   }
 #endif
 }
@@ -153,10 +153,10 @@ void check_read_data(s::cl_float4 ReadData, s::cl_float4 ExpectedColor) {
   }
 #else
   {
-    assert((s::cl_int)Diff.x() <= 1 && (s::cl_int)Diff.x() >= -1);
-    assert((s::cl_int)Diff.y() <= 1 && (s::cl_int)Diff.y() >= -1);
-    assert((s::cl_int)Diff.z() <= 1 && (s::cl_int)Diff.z() >= -1);
-    assert((s::cl_int)Diff.w() <= 1 && (s::cl_int)Diff.w() >= -1);
+    CHECK((s::cl_int)Diff.x() <= 1 && (s::cl_int)Diff.x() >= -1);
+    CHECK((s::cl_int)Diff.y() <= 1 && (s::cl_int)Diff.y() >= -1);
+    CHECK((s::cl_int)Diff.z() <= 1 && (s::cl_int)Diff.z() >= -1);
+    CHECK((s::cl_int)Diff.w() <= 1 && (s::cl_int)Diff.w() >= -1);
   }
 #endif
 }

--- a/sycl/test/basic_tests/image_api.cpp
+++ b/sycl/test/basic_tests/image_api.cpp
@@ -13,9 +13,9 @@
 #include <detail/kernel_impl.hpp>
 #include <detail/scheduler/scheduler.hpp>
 
+#include "../helpers.hpp"
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <iostream>
 #include <memory>
 #include <utility>

--- a/sycl/test/basic_tests/info.cpp
+++ b/sycl/test/basic_tests/info.cpp
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
 #include <iostream>
 #include <string>
@@ -314,6 +315,7 @@ int main() {
   if (!dev.is_host()) {
     try {
       print_info<info::device::parent_device, device>(dev, "Parent device");
+      CHECK(!"Expected exception has not been caught");
     } catch (invalid_object_error e) {
       std::cout << "Expected exception has been caught: " << e.what()
                 << std::endl;

--- a/sycl/test/basic_tests/kernel_interop.cpp
+++ b/sycl/test/basic_tests/kernel_interop.cpp
@@ -12,9 +12,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
-
-#include <cassert>
 
 using namespace cl::sycl;
 
@@ -55,10 +54,11 @@ int main() {
     context Context1 = Queue1.get_context();
     try {
       kernel Kernel(ClKernel, Context1);
-    } catch (cl::sycl::invalid_parameter_error e) {
-      Pass = true;
+      CHECK(!"Expected exception not caught");
+    } catch (cl::sycl::invalid_parameter_error ExpectedException) {
+      std::cout << "Expected exception caught " << ExpectedException.what()
+                << std::endl;
     }
-    assert(Pass);
 
     kernel Kernel(ClKernel, Context);
 

--- a/sycl/test/basic_tests/parallel_for_range.cpp
+++ b/sycl/test/basic_tests/parallel_for_range.cpp
@@ -4,8 +4,8 @@
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 // XFAIL: cuda
 
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
-
 #include <iostream>
 
 using namespace cl::sycl;
@@ -38,7 +38,7 @@ int main() {
     Q.wait_and_throw();
     std::cerr << "Test case ReqdWGSizeNegativeA failed: no exception has been "
                  "thrown\n";
-    return 1; // We shouldn't be here, exception is expected
+    CHECK(!"Expected exception not caught");
   } catch (nd_range_error &E) {
     if (string_class(E.what()).find(
             "Specified local size doesn't match the required work-group size "
@@ -60,7 +60,7 @@ int main() {
   }
 
   string_class OCLVersionStr = D.get_info<info::device::version>();
-  assert(OCLVersionStr.size() >= 10 &&
+  CHECK(OCLVersionStr.size() >= 10 &&
          "Unexpected device version string"); // strlen("OpenCL X.Y")
   const char *OCLVersion = &OCLVersionStr[7]; // strlen("OpenCL ")
   if (OCLVersion[0] == '1' || (OCLVersion[0] == '2' && OCLVersion[2] == '0')) {
@@ -75,7 +75,7 @@ int main() {
       std::cerr
           << "Test case ReqdWGSizeNegativeB failed: no exception has been "
              "thrown\n";
-      return 1; // We shouldn't be here, exception is expected
+      CHECK(!"Expected exception not caught");
     } catch (nd_range_error &E) {
       if (string_class(E.what()).find(
               "OpenCL 1.x and 2.0 requires to pass local size argument even if "
@@ -145,7 +145,7 @@ int main() {
         std::cerr
             << "Test case OpenCL1XNegativeA failed: no exception has been "
                "thrown\n";
-        return 1; // We shouldn't be here, exception is expected
+        CHECK(!"Expected exception not caught");
       }
     } catch (nd_range_error &E) {
       if (string_class(E.what()).find("Non-uniform work-groups are not "
@@ -182,7 +182,7 @@ int main() {
         std::cerr
             << "Test case OpenCL1XNegativeB failed: no exception has been "
                "thrown\n";
-        return 1; // We shouldn't be here, exception is expected
+        CHECK(!"Expected exception not caught");
       }
     } catch (nd_range_error &E) {
       if (string_class(E.what()).find("Non-uniform work-groups are not "
@@ -220,7 +220,7 @@ int main() {
       Q.wait_and_throw();
       std::cerr << "Test case OpenCL1XNegativeC failed: no exception has been "
                    "thrown\n";
-      return 1; // We shouldn't be here, exception is expected
+      CHECK(!"Expected exception not caught");
     } catch (nd_range_error &E) {
       if (string_class(E.what()).find(
               "Total number of work-items in a work-group cannot exceed "
@@ -269,7 +269,7 @@ int main() {
         std::cerr
             << "Test case OpenCL2XNegativeA failed: no exception has been "
                "thrown\n";
-        return 1; // We shouldn't be here, exception is expected
+        CHECK(!"Expected exception not caught");
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
                 "Total number of work-items in a work-group cannot exceed "
@@ -314,7 +314,7 @@ int main() {
           std::cerr
               << "Test case OpenCL2XNegativeB failed: no exception has been "
                  "thrown\n";
-          return 1; // We shouldn't be here, exception is expected
+          CHECK(!"Expected exception not caught");
         }
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
@@ -354,7 +354,7 @@ int main() {
           std::cerr
               << "Test case OpenCL2XNegativeC failed: no exception has been "
                  "thrown\n";
-          return 1; // We shouldn't be here, exception is expected
+          CHECK(!"Expected exception not caught");
         }
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
@@ -468,7 +468,7 @@ int main() {
           std::cerr
               << "Test case OpenCL2XNegativeD failed: no exception has been "
                  "thrown\n";
-          return 1; // We shouldn't be here, exception is expected
+          CHECK(!"Expected exception not caught");
         }
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
@@ -515,7 +515,7 @@ int main() {
           std::cerr
               << "Test case OpenCL2XNegativeE failed: no exception has been "
                  "thrown\n";
-          return 1; // We shouldn't be here, exception is expected
+          CHECK(!"Expected exception not caught");
         }
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
@@ -551,8 +551,10 @@ int main() {
     Q.wait_and_throw();
     std::cerr << "Test case NegativeA failed: no exception has been "
                  "thrown\n";
-    return 1; // We shouldn't be here, exception is expected
-  } catch (runtime_error) {
+    CHECK(!"Expected exception not caught");
+  } catch (runtime_error ExpectedException) {
+    std::cout << "Expected exception caught " << ExpectedException.what()
+              << std::endl;
   }
 
   // parallel_for_work_group with 0-based local range
@@ -564,8 +566,10 @@ int main() {
     Q.wait_and_throw();
     std::cerr << "Test case NegativeB failed: no exception has been "
                  "thrown\n";
-    return 1; // We shouldn't be here, exception is expected
-  } catch (runtime_error) {
+    CHECK(!"Expected exception not caught");
+  } catch (runtime_error ExpectedException) {
+    std::cout << "Expected exception caught " << ExpectedException.what()
+              << std::endl;
   }
 
   return 0;

--- a/sycl/test/basic_tests/parallel_for_range_host.cpp
+++ b/sycl/test/basic_tests/parallel_for_range_host.cpp
@@ -1,8 +1,8 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
-
 #include <iostream>
 
 using namespace cl::sycl;
@@ -25,7 +25,7 @@ int main() {
     Q.wait_and_throw();
     std::cerr << "Test case 'a' failed: no exception has been thrown"
               << std::endl;
-    return 1;
+    CHECK(!"Expected exception not caught");
   } catch (nd_range_error) {
     // We expect an error to be thrown!
   }
@@ -65,7 +65,7 @@ int main() {
     Q.wait_and_throw();
     std::cerr << "Test case 'd' failed: no exception has been thrown"
               << std::endl;
-    return 1;
+    CHECK(!"Expected exception not caught");
   } catch (nd_range_error) {
   }
 
@@ -78,7 +78,7 @@ int main() {
     Q.wait_and_throw();
     std::cerr << "Test case 'e' failed: no exception has been thrown"
               << std::endl;
-    return 1;
+    CHECK(!"Expected exception not caught");
   } catch (nd_range_error) {
   }
 
@@ -91,7 +91,7 @@ int main() {
     Q.wait_and_throw();
     std::cerr << "Test case 'f' failed: no exception has been thrown"
               << std::endl;
-    return 1;
+    CHECK(!"Expected exception not caught");
   } catch (nd_range_error) {
   }
 

--- a/sycl/test/basic_tests/queue.cpp
+++ b/sycl/test/basic_tests/queue.cpp
@@ -8,6 +8,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
 #include <iostream>
 
@@ -42,10 +43,10 @@ int main() {
     queue Queue(deviceA);
     size_t hash = hash_class<queue>()(Queue);
     queue MovedQueue(std::move(Queue));
-    assert(hash == hash_class<queue>()(MovedQueue));
-    assert(deviceA.is_host() == MovedQueue.is_host());
+    CHECK(hash == hash_class<queue>()(MovedQueue));
+    CHECK(deviceA.is_host() == MovedQueue.is_host());
     if (!deviceA.is_host()) {
-      assert(MovedQueue.get() != nullptr);
+      CHECK(MovedQueue.get() != nullptr);
     }
   }
   {
@@ -54,10 +55,10 @@ int main() {
     size_t hash = hash_class<queue>()(Queue);
     queue WillMovedQueue(deviceB);
     WillMovedQueue = std::move(Queue);
-    assert(hash == hash_class<queue>()(WillMovedQueue));
-    assert(deviceA.is_host() == WillMovedQueue.is_host());
+    CHECK(hash == hash_class<queue>()(WillMovedQueue));
+    CHECK(deviceA.is_host() == WillMovedQueue.is_host());
     if (!deviceA.is_host()) {
-      assert(WillMovedQueue.get() != nullptr);
+      CHECK(WillMovedQueue.get() != nullptr);
     }
   }
   {
@@ -65,10 +66,10 @@ int main() {
     queue Queue(deviceA);
     size_t hash = hash_class<queue>()(Queue);
     queue QueueCopy(Queue);
-    assert(hash == hash_class<queue>()(Queue));
-    assert(hash == hash_class<queue>()(QueueCopy));
-    assert(Queue == QueueCopy);
-    assert(Queue.is_host() == QueueCopy.is_host());
+    CHECK(hash == hash_class<queue>()(Queue));
+    CHECK(hash == hash_class<queue>()(QueueCopy));
+    CHECK(Queue == QueueCopy);
+    CHECK(Queue.is_host() == QueueCopy.is_host());
   }
   {
     std::cout << "copy assignment operator" << std::endl;
@@ -76,10 +77,10 @@ int main() {
     size_t hash = hash_class<queue>()(Queue);
     queue WillQueueCopy(deviceB);
     WillQueueCopy = Queue;
-    assert(hash == hash_class<queue>()(Queue));
-    assert(hash == hash_class<queue>()(WillQueueCopy));
-    assert(Queue == WillQueueCopy);
-    assert(Queue.is_host() == WillQueueCopy.is_host());
+    CHECK(hash == hash_class<queue>()(Queue));
+    CHECK(hash == hash_class<queue>()(WillQueueCopy));
+    CHECK(Queue == WillQueueCopy);
+    CHECK(Queue.is_host() == WillQueueCopy.is_host());
   }
 
   {
@@ -99,7 +100,7 @@ int main() {
     device Device = Selector.select_device();
     context Context(Device);
     queue Queue(Context, Selector);
-    assert(Context == Queue.get_context());
+    CHECK(Context == Queue.get_context());
   }
 
   {

--- a/sycl/test/built-ins/nan.cpp
+++ b/sycl/test/built-ins/nan.cpp
@@ -5,9 +5,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 // XFAIL: cuda
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
-
-#include <cassert>
 
 namespace s = cl::sycl;
 using namespace std;
@@ -34,8 +33,8 @@ template <typename T, typename R> void check_nan(s::queue &Queue) {
     });
     Queue.wait_and_throw();
   }
-  assert(s::isnan(Data));
-  assert(s::all(s::isnan(VData)));
+  CHECK(s::isnan(Data));
+  CHECK(s::all(s::isnan(VData)));
 }
 
 int main() {

--- a/sycl/test/fpga_tests/fpga_queue.cpp
+++ b/sycl/test/fpga_tests/fpga_queue.cpp
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
 #include <iostream>
 #include <set>
@@ -42,9 +43,10 @@ int getExpectedQueueNumber(cl_device_id device_id, int default_value) {
                                  sizeof(reportedProps),
                                  &reportedProps,
                                  NULL);
-   assert(CL_SUCCESS == iRet && "Failed to obtain queue info from ocl device");
+   CHECK(CL_SUCCESS == iRet && "Failed to obtain queue info from ocl device");
    return (reportedProps & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)
-              ? 1 : default_value;
+              ? 1
+              : default_value;
 }
 
 int main() {

--- a/sycl/test/helpers.hpp
+++ b/sycl/test/helpers.hpp
@@ -7,9 +7,19 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl.hpp>
-
+#include <cstdlib>
 
 using namespace cl;
+
+void check(bool condition, const char *conditionString, const char *filename,
+           const long line) noexcept {
+  if (!condition) {
+    std::cerr << "CHECK failed in " << filename << "#" << line << " " << conditionString << "\n";
+    std::abort();
+  }
+}
+
+#define CHECK(CONDITION) check(CONDITION, #CONDITION, __FILE__, __LINE__)
 
 template <class VecT, int EndIdx = VecT::get_count(), int StartIdx = 0>
 class VecPrinter {
@@ -68,7 +78,7 @@ public:
                           std::cerr << E.what() << std::endl;
                         }
                       }
-                      abort();
+                      std::abort();
                     },
                     PropList) {}
 

--- a/sycl/test/usm/memcpy.cpp
+++ b/sycl/test/usm/memcpy.cpp
@@ -10,6 +10,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 // XFAIL: cuda
 
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
 
 using namespace cl::sycl;
@@ -42,7 +43,7 @@ int main() {
     q.wait_and_throw();
 
     for (int i = 0; i < count; i++) {
-      assert(dest[i] == i * 2);
+      CHECK(dest[i] == i * 2);
     }
 
     try {
@@ -51,7 +52,7 @@ int main() {
         cgh.memcpy(nullptr, src, sizeof(float) * count);
       });
       q.wait_and_throw();
-      assert(false && "Expected error from copying to nullptr");
+      CHECK(false && "Expected error from copying to nullptr");
     } catch (runtime_error e) {
     }
   }

--- a/sycl/test/usm/memset.cpp
+++ b/sycl/test/usm/memset.cpp
@@ -10,6 +10,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 // XFAIL: cuda
 
+#include "../helpers.hpp"
 #include <CL/sycl.hpp>
 
 using namespace cl::sycl;
@@ -38,7 +39,7 @@ int main() {
     q.wait_and_throw();
 
     for (int i = 0; i < count; i++) {
-      assert(src[i] == 0x2a2a2a2a);
+      CHECK(src[i] == 0x2a2a2a2a);
     }
 
     try {
@@ -47,7 +48,7 @@ int main() {
         cgh.memset(nullptr, 0, sizeof(uint32_t) * count);
       });
       q.wait_and_throw();
-      assert(false && "Expected error from writing to nullptr");
+      CHECK(false && "Expected error from writing to nullptr");
     } catch (runtime_error e) {
     }
   }


### PR DESCRIPTION
Fix LIT tests that are not compiled with assertions enabled but call
assert.

Only done for LIT tests that requires fixes during work on CUDA.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>