### PR TITLE
[SYCL] Improve missing/inappropriate kernel name message

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10628,8 +10628,7 @@ def err_builtin_launder_invalid_arg : Error<
 def err_sycl_attribute_address_space_invalid : Error<
   "address space is outside the valid range of values">;
 def err_sycl_kernel_name_class_not_top_level : Error<
- "kernel name class and its template argument classes' declarations can only "
- "nest in a namespace: %0">;
+ "kernel name missing or not globally accessible type name">;
 def err_sycl_restrict : Error<
   "SYCL kernel cannot "
 "%select{use a non-const global variable"


### PR DESCRIPTION
Signed-off-by: Chris Perkins <chris.perkins@intel.com>

The error diagnostic that we throw in SemaSYCL.cpp is `err_sycl_kernel_name_class_not_top_level` and it is exercised in one place only (  SemaSYCL.cpp line 1560 ).
```
if (TD && TD->isCompleteDefinition() && !UnnamedLambdaSupport) {
          // defined class constituting the kernel name is not globally
          // accessible - contradicts the spec
          Diag.Report(D->getSourceRange().getBegin(),
                      diag::err_sycl_kernel_name_class_not_top_level);
        }
```

But the text that is output for that message is a little confusing. Right now it is `kernel name class and its template argument classes' declarations can only nest in a namespace` which seems a bit obtuse.  I think the simplest solution is to just reword the error message. 