### PR TITLE
[SYCL] Move implementation details under sycl_private namespace

### DIFF
--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -20,8 +20,10 @@ namespace sycl {
 class device;
 class platform;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class context_impl;
 }
+} // namespace detail
 
 class context {
 public:
@@ -135,9 +137,9 @@ public:
 
 private:
   /// Constructs a SYCL context object from a valid context_impl instance.
-  context(shared_ptr_class<detail::context_impl> Impl);
+  context(shared_ptr_class<detail::sycl_private::context_impl> Impl);
 
-  shared_ptr_class<detail::context_impl> impl;
+  shared_ptr_class<detail::sycl_private::context_impl> impl;
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
@@ -156,7 +158,8 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::context> {
   size_t operator()(const cl::sycl::context &Context) const {
-    return hash<cl::sycl::shared_ptr_class<cl::sycl::detail::context_impl>>()(
+    return hash<cl::sycl::shared_ptr_class<
+        cl::sycl::detail::sycl_private::context_impl>>()(
         cl::sycl::detail::getSyclObjImpl(Context));
   }
 };

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -18,7 +18,10 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
+__SYCL_INLINE_NAMESPACE(sycl_private) {
+struct MemObjRecord;
 class Command;
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 
 // The class describes a requirement to access a SYCL memory object such as
 // sycl::buffer and sycl::image. For example, each accessor used in a kernel,
@@ -37,8 +40,7 @@ public:
   range<Dims> MemRange;
 
   bool operator==(const AccessorImplDevice &Rhs) const {
-    return (Offset == Rhs.Offset &&
-            AccessRange == Rhs.AccessRange &&
+    return (Offset == Rhs.Offset && AccessRange == Rhs.AccessRange &&
             MemRange == Rhs.MemRange);
   }
 };
@@ -95,7 +97,7 @@ public:
 
   void *MData = nullptr;
 
-  Command *MBlockedCmd = nullptr;
+  sycl_private::Command *MBlockedCmd = nullptr;
 };
 
 using AccessorImplPtr = shared_ptr_class<AccessorImplHost>;

--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -420,14 +420,14 @@ class CGExecKernel : public CG {
 public:
   NDRDescT MNDRDesc;
   unique_ptr_class<HostKernelBase> MHostKernel;
-  shared_ptr_class<detail::kernel_impl> MSyclKernel;
+  shared_ptr_class<detail::sycl_private::kernel_impl> MSyclKernel;
   vector_class<ArgDesc> MArgs;
   string_class MKernelName;
   detail::OSModuleHandle MOSModuleHandle;
   vector_class<shared_ptr_class<detail::stream_impl>> MStreams;
 
   CGExecKernel(NDRDescT NDRDesc, unique_ptr_class<HostKernelBase> HKernel,
-               shared_ptr_class<detail::kernel_impl> SyclKernel,
+               shared_ptr_class<detail::sycl_private::kernel_impl> SyclKernel,
                vector_class<vector_class<char>> ArgsStorage,
                vector_class<detail::AccessorImplPtr> AccStorage,
                vector_class<shared_ptr_class<const void>> SharedPtrStorage,

--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -41,12 +41,14 @@ inline void memcpy(void *Dst, const void *Src, size_t Size) {
   }
 }
 
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class context_impl;
+}
 // The function returns list of events that can be passed to OpenCL API as
 // dependency list and waits for others.
-std::vector<RT::PiEvent>
-getOrWaitEvents(std::vector<cl::sycl::event> DepEvents,
-                std::shared_ptr<cl::sycl::detail::context_impl> Context);
+std::vector<RT::PiEvent> getOrWaitEvents(
+    std::vector<cl::sycl::event> DepEvents,
+    std::shared_ptr<cl::sycl::detail::sycl_private::context_impl> Context);
 
 void waitEvents(std::vector<cl::sycl::event> DepEvents);
 

--- a/sycl/include/CL/sycl/detail/memory_manager.hpp
+++ b/sycl/include/CL/sycl/detail/memory_manager.hpp
@@ -20,13 +20,15 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class queue_impl;
 class event_impl;
 class context_impl;
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 
-using QueueImplPtr = std::shared_ptr<detail::queue_impl>;
-using EventImplPtr = std::shared_ptr<detail::event_impl>;
-using ContextImplPtr = std::shared_ptr<detail::context_impl>;
+using QueueImplPtr = std::shared_ptr<detail::sycl_private::queue_impl>;
+using EventImplPtr = std::shared_ptr<detail::sycl_private::event_impl>;
+using ContextImplPtr = std::shared_ptr<detail::sycl_private::context_impl>;
 
 // The class contains methods that work with memory. All operations with
 // device memory should go through MemoryManager.
@@ -133,7 +135,6 @@ public:
   static void prefetch_usm(void *Ptr, QueueImplPtr Queue, size_t Len,
                            std::vector<RT::PiEvent> DepEvents,
                            RT::PiEvent &OutEvent);
-
 };
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -33,7 +33,9 @@ enum class PiApiKind {
 #define _PI_API(api) api,
 #include <CL/sycl/detail/pi.def>
 };
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class plugin;
+}
 namespace pi {
 
 #ifdef SYCL_RT_OS_WINDOWS
@@ -116,10 +118,10 @@ template <class To, class From> To cast(From value);
 // Holds the PluginInformation for the plugin that is bound.
 // Currently a global varaible is used to store OpenCL plugin information to be
 // used with SYCL Interoperability Constructors.
-extern std::shared_ptr<plugin> GlobalPlugin;
+extern std::shared_ptr<sycl_private::plugin> GlobalPlugin;
 
 // Performs PI one-time initialization.
-vector_class<plugin> initialize();
+vector_class<sycl_private::plugin> initialize();
 
 // Utility Functions to get Function Name for a PI Api.
 template <PiApiKind PiApiOffset> struct PiFuncInfo {};

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
@@ -16,12 +16,15 @@ namespace sycl {
 
 namespace detail {
 
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class event_impl;
 class context_impl;
 struct MemObjRecord;
+class Scheduler;
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 
-using EventImplPtr = shared_ptr_class<detail::event_impl>;
-using ContextImplPtr = shared_ptr_class<detail::context_impl>;
+using EventImplPtr = shared_ptr_class<detail::sycl_private::event_impl>;
+using ContextImplPtr = shared_ptr_class<detail::sycl_private::context_impl>;
 
 // The class serves as an interface in the scheduler for all SYCL memory
 // objects.
@@ -67,8 +70,8 @@ protected:
   // fixme replace with unique_ptr_class once it is implemented. Standard
   // unique_ptr requires knowlege of sizeof(MemObjRecord) at compile time
   // which is unavailable.
-  shared_ptr_class<MemObjRecord> MRecord;
-  friend class Scheduler;
+  shared_ptr_class<sycl_private::MemObjRecord> MRecord;
+  friend class sycl_private::Scheduler;
 };
 
 } // namespace detail

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -24,15 +24,16 @@ namespace sycl {
 namespace detail {
 
 // Forward declarations
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class context_impl;
 class event_impl;
 class plugin;
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 
-using ContextImplPtr = shared_ptr_class<context_impl>;
-using EventImplPtr = shared_ptr_class<event_impl>;
+using ContextImplPtr = shared_ptr_class<sycl_private::context_impl>;
+using EventImplPtr = shared_ptr_class<sycl_private::event_impl>;
 
-template <typename T>
-class aligned_allocator;
+template <typename T> class aligned_allocator;
 using sycl_memory_object_allocator = aligned_allocator<char>;
 
 // The class serves as a base for all SYCL memory objects.
@@ -83,7 +84,7 @@ public:
 
   virtual ~SYCLMemObjT() = default;
 
-  const plugin &getPlugin() const;
+  const sycl_private::plugin &getPlugin() const;
 
   size_t getSize() const override { return MSizeInBytes; }
   size_t get_count() const {
@@ -149,9 +150,7 @@ public:
     if (!FinalData)
       MUploadDataFunctor = nullptr;
     else
-      MUploadDataFunctor = [this, FinalData]() {
-        updateHostMemory(FinalData);
-      };
+      MUploadDataFunctor = [this, FinalData]() { updateHostMemory(FinalData); };
   }
 
   template <typename Destination>

--- a/sycl/include/CL/sycl/device.hpp
+++ b/sycl/include/CL/sycl/device.hpp
@@ -20,8 +20,10 @@ namespace sycl {
 // Forward declarations
 class device_selector;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class device_impl;
 }
+} // namespace detail
 class device {
 public:
   /// Constructs a SYCL device instance as a host device.
@@ -164,8 +166,9 @@ public:
   get_devices(info::device_type deviceType = info::device_type::all);
 
 private:
-  shared_ptr_class<detail::device_impl> impl;
-  device(shared_ptr_class<detail::device_impl> impl) : impl(impl) {}
+  shared_ptr_class<detail::sycl_private::device_impl> impl;
+  device(shared_ptr_class<detail::sycl_private::device_impl> impl)
+      : impl(impl) {}
 
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
@@ -185,7 +188,8 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::device> {
   size_t operator()(const cl::sycl::device &Device) const {
-    return hash<cl::sycl::shared_ptr_class<cl::sycl::detail::device_impl>>()(
+    return hash<cl::sycl::shared_ptr_class<
+        cl::sycl::detail::sycl_private::device_impl>>()(
         cl::sycl::detail::getSyclObjImpl(Device));
   }
 };

--- a/sycl/include/CL/sycl/event.hpp
+++ b/sycl/include/CL/sycl/event.hpp
@@ -19,8 +19,10 @@ namespace sycl {
 // Forward declaration
 class context;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class event_impl;
 }
+} // namespace detail
 
 class event {
 public:
@@ -113,9 +115,9 @@ public:
   get_profiling_info() const;
 
 private:
-  event(shared_ptr_class<detail::event_impl> EventImpl);
+  event(shared_ptr_class<detail::sycl_private::event_impl> EventImpl);
 
-  shared_ptr_class<detail::event_impl> impl;
+  shared_ptr_class<detail::sycl_private::event_impl> impl;
 
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
@@ -130,7 +132,8 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::event> {
   size_t operator()(const cl::sycl::event &e) const {
-    return hash<cl::sycl::shared_ptr_class<cl::sycl::detail::event_impl>>()(
+    return hash<cl::sycl::shared_ptr_class<
+        cl::sycl::detail::sycl_private::event_impl>>()(
         cl::sycl::detail::getSyclObjImpl(e));
   }
 };

--- a/sycl/include/CL/sycl/exception_list.hpp
+++ b/sycl/include/CL/sycl/exception_list.hpp
@@ -20,8 +20,10 @@ namespace sycl {
 
 // Forward declaration
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class queue_impl;
 }
+} // namespace detail
 
 class exception_list {
 public:
@@ -39,9 +41,9 @@ public:
   iterator end() const;
 
 private:
-  friend class detail::queue_impl;
+  friend class detail::sycl_private::queue_impl;
   void PushBack(const_reference Value);
-  void PushBack(value_type&& Value);
+  void PushBack(value_type &&Value);
   void Clear() noexcept;
   vector_class<exception_ptr_class> MList;
 };

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -66,8 +66,10 @@ namespace detail {
 /// invocation APIs such as single_task.
 class auto_name {};
 
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class kernel_impl;
 class queue_impl;
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 class stream_impl;
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::target AccessTarget, access::placeholder IsPlaceholder>
@@ -140,7 +142,7 @@ private:
   ///
   /// \param Queue is a SYCL queue.
   /// \param IsHost indicates if this handler is created for SYCL host device.
-  handler(shared_ptr_class<detail::queue_impl> Queue, bool IsHost)
+  handler(shared_ptr_class<detail::sycl_private::queue_impl> Queue, bool IsHost)
       : MQueue(std::move(Queue)), MIsHost(IsHost) {}
 
   /// Stores copy of Arg passed to the MArgsStorage.
@@ -1242,7 +1244,7 @@ public:
   }
 
 private:
-  shared_ptr_class<detail::queue_impl> MQueue;
+  shared_ptr_class<detail::sycl_private::queue_impl> MQueue;
   /// The storage for the arguments passed.
   /// We need to store a copy of values that are passed explicitly through
   /// set_arg, require and so on, because we need them to be alive after
@@ -1264,7 +1266,7 @@ private:
   detail::NDRDescT MNDRDesc;
   string_class MKernelName;
   /// Storage for a sycl::kernel object.
-  shared_ptr_class<detail::kernel_impl> MKernel;
+  shared_ptr_class<detail::sycl_private::kernel_impl> MKernel;
   /// Type of the command group, e.g. kernel, fill.
   detail::CG::CGTYPE MCGType = detail::CG::NONE;
   /// Pointer to the source host memory or accessor(depending on command type).
@@ -1286,7 +1288,7 @@ private:
   bool MIsHost = false;
 
   // Make queue_impl class friend to be able to call finalize method.
-  friend class detail::queue_impl;
+  friend class detail::sycl_private::queue_impl;
   // Make accessor class friend to keep the list of associated accessors.
   template <typename DataT, int Dims, access::mode AccMode,
             access::target AccTarget, access::placeholder isPlaceholder>

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -20,8 +20,10 @@ namespace sycl {
 class program;
 class context;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class kernel_impl;
 }
+} // namespace detail
 
 class kernel {
 public:
@@ -117,9 +119,9 @@ public:
 
 private:
   /// Constructs a SYCL kernel object from a valid kernel_impl instance.
-  kernel(std::shared_ptr<detail::kernel_impl> Impl);
+  kernel(std::shared_ptr<detail::sycl_private::kernel_impl> Impl);
 
-  shared_ptr_class<detail::kernel_impl> impl;
+  shared_ptr_class<detail::sycl_private::kernel_impl> impl;
 
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
@@ -132,7 +134,7 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::kernel> {
   size_t operator()(const cl::sycl::kernel &Kernel) const {
-    return hash<std::shared_ptr<cl::sycl::detail::kernel_impl>>()(
+    return hash<std::shared_ptr<cl::sycl::detail::sycl_private::kernel_impl>>()(
         cl::sycl::detail::getSyclObjImpl(Kernel));
   }
 };

--- a/sycl/include/CL/sycl/ordered_queue.hpp
+++ b/sycl/include/CL/sycl/ordered_queue.hpp
@@ -25,8 +25,10 @@ namespace sycl {
 class context;
 class device;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class queue_impl;
 }
+} // namespace detail
 
 class __SYCL_DEPRECATED__ ordered_queue {
 
@@ -246,7 +248,7 @@ public:
   }
 
 private:
-  shared_ptr_class<detail::queue_impl> impl;
+  shared_ptr_class<detail::sycl_private::queue_impl> impl;
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
@@ -265,7 +267,8 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::ordered_queue> {
   size_t operator()(const cl::sycl::ordered_queue &q) const {
-    return std::hash<std::shared_ptr<cl::sycl::detail::queue_impl>>()(
+    return std::hash<
+        std::shared_ptr<cl::sycl::detail::sycl_private::queue_impl>>()(
         cl::sycl::detail::getSyclObjImpl(q));
   }
 };

--- a/sycl/include/CL/sycl/platform.hpp
+++ b/sycl/include/CL/sycl/platform.hpp
@@ -20,8 +20,10 @@ namespace sycl {
 class device_selector;
 class device;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class platform_impl;
 }
+} // namespace detail
 
 class platform {
 public:
@@ -99,8 +101,9 @@ public:
   static vector_class<platform> get_platforms();
 
 private:
-  shared_ptr_class<detail::platform_impl> impl;
-  platform(shared_ptr_class<detail::platform_impl> impl) : impl(impl) {}
+  shared_ptr_class<detail::sycl_private::platform_impl> impl;
+  platform(shared_ptr_class<detail::sycl_private::platform_impl> impl)
+      : impl(impl) {}
 
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
@@ -114,7 +117,8 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::platform> {
   size_t operator()(const cl::sycl::platform &p) const {
-    return hash<cl::sycl::shared_ptr_class<cl::sycl::detail::platform_impl>>()(
+    return hash<cl::sycl::shared_ptr_class<
+        cl::sycl::detail::sycl_private::platform_impl>>()(
         cl::sycl::detail::getSyclObjImpl(p));
   }
 };

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -22,8 +22,10 @@ namespace sycl {
 class context;
 class device;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class program_impl;
 }
+} // namespace detail
 
 enum class program_state { none, compiled, linked };
 
@@ -294,7 +296,7 @@ public:
   program_state get_state() const;
 
 private:
-  program(shared_ptr_class<detail::program_impl> impl);
+  program(shared_ptr_class<detail::sycl_private::program_impl> impl);
 
   /// Template-free version of get_kernel.
   ///
@@ -330,7 +332,7 @@ private:
                               string_class buildOptions,
                               detail::OSModuleHandle M);
 
-  shared_ptr_class<detail::program_impl> impl;
+  shared_ptr_class<detail::sycl_private::program_impl> impl;
 
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
@@ -343,7 +345,8 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::program> {
   size_t operator()(const cl::sycl::program &prg) const {
-    return hash<cl::sycl::shared_ptr_class<cl::sycl::detail::program_impl>>()(
+    return hash<cl::sycl::shared_ptr_class<
+        cl::sycl::detail::sycl_private::program_impl>>()(
         cl::sycl::detail::getSyclObjImpl(prg));
   }
 };

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -27,8 +27,10 @@ namespace sycl {
 class context;
 class device;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class queue_impl;
 }
+} // namespace detail
 
 class queue {
 public:
@@ -298,7 +300,7 @@ public:
   ///
   /// \param Ptr is a USM pointer to the memory to be prefetched to the device.
   /// \param Count is a number of bytes to be prefetched.
-  event prefetch(const void* Ptr, size_t Count) {
+  event prefetch(const void *Ptr, size_t Count) {
     return submit([=](handler &CGH) { CGH.prefetch(Ptr, Count); });
   }
 
@@ -638,7 +640,7 @@ public:
   bool is_in_order() const;
 
 private:
-  shared_ptr_class<detail::queue_impl> impl;
+  shared_ptr_class<detail::sycl_private::queue_impl> impl;
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
@@ -656,8 +658,8 @@ private:
 namespace std {
 template <> struct hash<cl::sycl::queue> {
   size_t operator()(const cl::sycl::queue &q) const {
-    return std::hash<
-        cl::sycl::shared_ptr_class<cl::sycl::detail::queue_impl>>()(
+    return std::hash<cl::sycl::shared_ptr_class<
+        cl::sycl::detail::sycl_private::queue_impl>>()(
         cl::sycl::detail::getSyclObjImpl(q));
   }
 };

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -27,6 +27,7 @@ namespace sycl {
 // Forward declaration
 class device;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 using PlatformImplPtr = std::shared_ptr<detail::platform_impl>;
 class context_impl {
 public:
@@ -157,6 +158,7 @@ private:
   mutable KernelProgramCache MKernelProgramCache;
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/context_info.hpp
+++ b/sycl/source/detail/context_info.hpp
@@ -15,6 +15,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 template <info::context param> struct get_context_info {
   using RetType =
@@ -30,6 +31,7 @@ template <info::context param> struct get_context_info {
   }
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -14,6 +14,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 device_impl::device_impl()
     : MIsHostDevice(true),
@@ -34,8 +35,9 @@ device_impl::device_impl(RT::PiDevice Device, PlatformImplPtr Platform,
 
   RT::PiDevice parent = nullptr;
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Plugin.call<PiApiKind::piDeviceGetInfo>(
-      MDevice, PI_DEVICE_INFO_PARENT_DEVICE, sizeof(RT::PiDevice), &parent, nullptr);
+  Plugin.call<PiApiKind::piDeviceGetInfo>(MDevice, PI_DEVICE_INFO_PARENT_DEVICE,
+                                          sizeof(RT::PiDevice), &parent,
+                                          nullptr);
 
   MIsRootDevice = (nullptr == parent);
   if (!MIsRootDevice) {
@@ -161,13 +163,11 @@ device_impl::create_sub_devices(const vector_class<size_t> &Counts) const {
         "Partitioning to subdevices of the host device is not implemented yet",
         PI_INVALID_DEVICE);
 
-  if (!is_partition_supported(
-          info::partition_property::partition_by_counts)) {
+  if (!is_partition_supported(info::partition_property::partition_by_counts)) {
     throw cl::sycl::feature_not_supported();
   }
   static const cl_device_partition_property P[] = {
-      CL_DEVICE_PARTITION_BY_COUNTS, CL_DEVICE_PARTITION_BY_COUNTS_LIST_END,
-      0};
+      CL_DEVICE_PARTITION_BY_COUNTS, CL_DEVICE_PARTITION_BY_COUNTS_LIST_END, 0};
   vector_class<cl_device_partition_property> Properties(P, P + 3);
   Properties.insert(Properties.begin() + 1, Counts.begin(), Counts.end());
   return create_sub_devices(Properties.data(), Counts.size());
@@ -190,11 +190,11 @@ vector_class<device> device_impl::create_sub_devices(
   const cl_device_partition_property Properties[3] = {
       CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN,
       (cl_device_partition_property)AffinityDomain, 0};
-  size_t SubDevicesCount =
-      get_info<info::device::partition_max_sub_devices>();
+  size_t SubDevicesCount = get_info<info::device::partition_max_sub_devices>();
   return create_sub_devices(Properties, SubDevicesCount);
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -22,6 +22,7 @@ namespace sycl {
 class platform;
 
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 // Forward declaration
 class platform_impl;
@@ -205,6 +206,7 @@ private:
   PlatformImplPtr MPlatform;
 }; // class device_impl
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/device_info.cpp
+++ b/sycl/source/detail/device_info.cpp
@@ -23,6 +23,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 // Specialization for parent device
 template <>
@@ -488,8 +489,8 @@ template <> cl_uint get_device_info_host<info::device::max_num_sub_groups>() {
                       PI_INVALID_DEVICE);
 }
 
-template <> vector_class<size_t>
-get_device_info_host<info::device::sub_group_sizes>() {
+template <>
+vector_class<size_t> get_device_info_host<info::device::sub_group_sizes>() {
   // TODO update once subgroups are enabled
   throw runtime_error("Sub-group feature is not supported on HOST device.",
                       PI_INVALID_DEVICE);
@@ -529,6 +530,7 @@ template <> bool get_device_info_host<info::device::usm_system_allocator>() {
   return true;
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -17,6 +17,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 vector_class<info::fp_config> read_fp_bitfield(cl_device_fp_config bits);
 
@@ -427,6 +428,7 @@ template <> struct get_device_info<bool, info::device::usm_system_allocator> {
   }
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -26,10 +26,10 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
-__SYCL_INLINE_NAMESPACE(sycl_private) {
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 extern xpti::trace_event_data_t *GSYCLGraphEvent;
 #endif
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 // Threat all devices that don't support interoperability as host devices to
 // avoid attempts to call method get on such events.

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -26,6 +26,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 extern xpti::trace_event_data_t *GSYCLGraphEvent;
 #endif
@@ -62,9 +63,7 @@ RT::PiEvent &event_impl::getHandleRef() { return MEvent; }
 
 const ContextImplPtr &event_impl::getContextImpl() { return MContext; }
 
-const plugin &event_impl::getPlugin() const {
-  return MContext->getPlugin();
-}
+const plugin &event_impl::getPlugin() const { return MContext->getPlugin(); }
 
 void event_impl::setContextImpl(const ContextImplPtr &Context) {
   MHostEvent = Context->is_host();
@@ -255,10 +254,11 @@ static uint64_t getTimestamp() {
       .count();
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
+
 void HostProfilingInfo::start() { StartTime = getTimestamp(); }
 
 void HostProfilingInfo::end() { EndTime = getTimestamp(); }
-
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -20,10 +20,14 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 class context;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
+
+// Forward declarations
 class plugin;
 class context_impl;
-using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 class queue_impl;
+
+using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 using QueueImplPtr = std::shared_ptr<cl::sycl::detail::queue_impl>;
 using QueueImplWPtr = std::weak_ptr<cl::sycl::detail::queue_impl>;
 
@@ -163,6 +167,7 @@ private:
   void *MCommand = nullptr;
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/event_info.hpp
+++ b/sycl/source/detail/event_info.hpp
@@ -16,6 +16,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 template <info::event_profiling Param> struct get_event_profiling_info {
   using RetType =
@@ -42,6 +43,7 @@ template <info::event Param> struct get_event_info {
   }
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -18,6 +18,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 kernel_impl::kernel_impl(RT::PiKernel Kernel, ContextImplPtr Context)
     : kernel_impl(Kernel, Context,
@@ -25,8 +26,7 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, ContextImplPtr Context)
                   /*IsCreatedFromSource*/ true) {}
 
 kernel_impl::kernel_impl(RT::PiKernel Kernel, ContextImplPtr ContextImpl,
-                         ProgramImplPtr ProgramImpl,
-                         bool IsCreatedFromSource)
+                         ProgramImplPtr ProgramImpl, bool IsCreatedFromSource)
     : MKernel(Kernel), MContext(ContextImpl),
       MProgramImpl(std::move(ProgramImpl)),
       MCreatedFromSource(IsCreatedFromSource) {
@@ -42,8 +42,7 @@ kernel_impl::kernel_impl(RT::PiKernel Kernel, ContextImplPtr ContextImpl,
   getPlugin().call<PiApiKind::piKernelRetain>(MKernel);
 }
 
-kernel_impl::kernel_impl(ContextImplPtr Context,
-                         ProgramImplPtr ProgramImpl)
+kernel_impl::kernel_impl(ContextImplPtr Context, ProgramImplPtr ProgramImpl)
     : MContext(Context), MProgramImpl(std::move(ProgramImpl)) {}
 
 kernel_impl::~kernel_impl() {
@@ -159,6 +158,7 @@ bool kernel_impl::isCreatedFromSource() const {
   return MCreatedFromSource;
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/kernel_impl.hpp
+++ b/sycl/source/detail/kernel_impl.hpp
@@ -25,6 +25,7 @@ namespace sycl {
 class program;
 
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 class program_impl;
 
 using ContextImplPtr = std::shared_ptr<detail::context_impl>;
@@ -147,6 +148,7 @@ private:
   bool MCreatedFromSource = true;
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/kernel_info.cpp
+++ b/sycl/source/detail/kernel_info.cpp
@@ -12,6 +12,8 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
+
 template <>
 cl::sycl::range<3>
 get_kernel_work_group_info_host<info::kernel_work_group::global_work_size>(
@@ -49,6 +51,7 @@ get_kernel_work_group_info_host<info::kernel_work_group::private_mem_size>(
   return 0;
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -17,6 +17,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 // OpenCL kernel information methods
 template <typename T, info::kernel Param> struct get_kernel_info {};
@@ -58,8 +59,8 @@ struct get_kernel_work_group_info {
     T Result;
     // TODO catch an exception and put it to list of asynchronous exceptions
     Plugin.call<PiApiKind::piKernelGetGroupInfo>(
-        Kernel, Device, pi::cast<pi_kernel_group_info>(Param), sizeof(T), &Result,
-        nullptr);
+        Kernel, Device, pi::cast<pi_kernel_group_info>(Param), sizeof(T),
+        &Result, nullptr);
     return Result;
   }
 };
@@ -160,6 +161,7 @@ struct get_kernel_sub_group_info_with_input<size_t, Param, cl::sycl::range<3>> {
     return Result;
   }
 };
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -13,6 +13,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 KernelProgramCache::~KernelProgramCache() {
   for (auto &ProgIt : MCachedPrograms) {
     ProgramWithBuildStateT &ProgWithState = ProgIt.second;
@@ -40,6 +41,7 @@ KernelProgramCache::~KernelProgramCache() {
     Plugin.call<PiApiKind::piProgramRelease>(ToBeDeleted);
   }
 }
-}
-}
-}
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
+} // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -22,6 +22,8 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
+
 class context_impl;
 class KernelProgramCache {
 public:
@@ -31,21 +33,19 @@ public:
     std::string Msg;
     pi_int32 Code;
 
-    bool isFilledIn() const {
-      return !Msg.empty();
-    }
+    bool isFilledIn() const { return !Msg.empty(); }
   };
 
   /// Denotes pointer to some entity with its general state and build error.
   /// The pointer is not null if and only if the entity is usable.
   /// State of the entity is provided by the user of cache instance.
   /// Currently there is only a single user - ProgramManager class.
-  template<typename T> struct BuildResult {
+  template <typename T> struct BuildResult {
     std::atomic<T *> Ptr;
     std::atomic<int> State;
     BuildError Error;
 
-    BuildResult(T* P, int S) : Ptr{P}, State{S}, Error{"", 0} {}
+    BuildResult(T *P, int S) : Ptr{P}, State{S}, Error{"", 0} {}
   };
 
   using PiProgramT = std::remove_pointer<RT::PiProgram>::type;
@@ -91,6 +91,7 @@ private:
   KernelCacheT MKernelsPerProgramCache;
   ContextPtr MParentContext;
 };
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -19,6 +19,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 vector_class<platform> platform_impl::get_platforms() {
   vector_class<platform> Platforms;
@@ -146,8 +147,7 @@ static std::vector<DevDescT> getWhiteListDesc() {
 }
 
 static void filterWhiteList(vector_class<RT::PiDevice> &PiDevices,
-                            RT::PiPlatform PiPlatform,
-                            const plugin &Plugin) {
+                            RT::PiPlatform PiPlatform, const plugin &Plugin) {
   const std::vector<DevDescT> WhiteList(getWhiteListDesc());
   if (WhiteList.empty())
     return;
@@ -270,6 +270,7 @@ platform_impl::get_info() const {
 #include <CL/sycl/info/platform_traits.def>
 #undef PARAM_TRAITS_SPEC
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -12,8 +12,8 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/stl.hpp>
-#include <detail/plugin.hpp>
 #include <detail/platform_info.hpp>
+#include <detail/plugin.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -23,6 +23,7 @@ class device_selector;
 class device;
 
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 // TODO: implement extension management for host device
 // TODO: implement parameters treatment for host device
@@ -125,6 +126,7 @@ private:
   RT::PiPlatform MPlatform = 0;
   std::shared_ptr<plugin> MPlugin;
 };
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/platform_info.cpp
+++ b/sycl/source/detail/platform_info.cpp
@@ -1,4 +1,5 @@
-//==----------- platform_info.cpp -----------------------------------------------==//
+//==----------- platform_info.cpp
+//-----------------------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,6 +12,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 template <> string_class get_platform_info_host<info::platform::profile>() {
   return "FULL PROFILE";
@@ -35,6 +37,7 @@ get_platform_info_host<info::platform::extensions>() {
   return {};
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/platform_info.hpp
+++ b/sycl/source/detail/platform_info.hpp
@@ -16,6 +16,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 // The platform information methods
 template <typename T, info::platform param> struct get_platform_info {};
@@ -66,6 +67,7 @@ template <> string_class get_platform_info_host<info::platform::vendor>();
 template <>
 vector_class<string_class> get_platform_info_host<info::platform::extensions>();
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/platform_util.cpp
+++ b/sycl/source/detail/platform_util.cpp
@@ -19,6 +19,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 // Used by methods that duplicate OpenCL behaviour in order to get CPU info
 static void cpuid(uint32_t *CPUInfo, uint32_t Type, uint32_t SubType = 0) {
@@ -131,8 +132,8 @@ void PlatformUtil::prefetch(const char *Ptr, size_t NumBytes) {
   const char *PtrEnd = Ptr + NumBytes;
 
   // Set the pointer to the beginning of the current cache line.
-  Ptr = reinterpret_cast<const char *>(
-            reinterpret_cast<size_t>(Ptr) & CacheLineMask);
+  Ptr = reinterpret_cast<const char *>(reinterpret_cast<size_t>(Ptr) &
+                                       CacheLineMask);
   for (; Ptr < PtrEnd; Ptr += CacheLineSize) {
 #if defined(SYCL_RT_OS_LINUX)
     __builtin_prefetch(Ptr);
@@ -142,6 +143,7 @@ void PlatformUtil::prefetch(const char *Ptr, size_t NumBytes) {
   }
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/platform_util.hpp
+++ b/sycl/source/detail/platform_util.hpp
@@ -19,6 +19,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 struct PlatformUtil {
   enum class TypeIndex : unsigned int {
@@ -43,6 +44,7 @@ struct PlatformUtil {
   static void prefetch(const char *Ptr, size_t NumBytes);
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -14,6 +14,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 class plugin {
 public:
@@ -71,6 +72,7 @@ private:
   bool MPiEnableTrace;
 
 }; // class plugin
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -18,6 +18,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 program_impl::program_impl(ContextImplPtr Context)
     : program_impl(Context, Context->get_info<info::context::devices>()) {}
@@ -86,8 +87,9 @@ program_impl::program_impl(ContextImplPtr Context, RT::PiProgram Program)
   // TODO handle the case when cl_program build is in progress
   cl_uint NumDevices;
   const detail::plugin &Plugin = getPlugin();
-  Plugin.call<PiApiKind::piProgramGetInfo>(
-      Program, PI_PROGRAM_INFO_NUM_DEVICES, sizeof(cl_uint), &NumDevices, nullptr);
+  Plugin.call<PiApiKind::piProgramGetInfo>(Program, PI_PROGRAM_INFO_NUM_DEVICES,
+                                           sizeof(cl_uint), &NumDevices,
+                                           nullptr);
   vector_class<RT::PiDevice> PiDevices(NumDevices);
   Plugin.call<PiApiKind::piProgramGetInfo>(Program, PI_PROGRAM_INFO_DEVICES,
                                            sizeof(RT::PiDevice) * NumDevices,
@@ -267,8 +269,8 @@ vector_class<vector_class<char>> program_impl::get_binaries() const {
   if (!is_host()) {
     vector_class<size_t> BinarySizes(MDevices.size());
     Plugin.call<PiApiKind::piProgramGetInfo>(
-        MProgram, PI_PROGRAM_INFO_BINARY_SIZES, sizeof(size_t) * BinarySizes.size(),
-        BinarySizes.data(), nullptr);
+        MProgram, PI_PROGRAM_INFO_BINARY_SIZES,
+        sizeof(size_t) * BinarySizes.size(), BinarySizes.data(), nullptr);
 
     vector_class<char *> Pointers;
     for (size_t I = 0; I < BinarySizes.size(); ++I) {
@@ -337,12 +339,12 @@ vector_class<RT::PiDevice> program_impl::get_pi_devices() const {
 bool program_impl::has_cl_kernel(const string_class &KernelName) const {
   size_t Size;
   const detail::plugin &Plugin = getPlugin();
-  Plugin.call<PiApiKind::piProgramGetInfo>(MProgram, PI_PROGRAM_INFO_KERNEL_NAMES, 0,
-                                           nullptr, &Size);
+  Plugin.call<PiApiKind::piProgramGetInfo>(
+      MProgram, PI_PROGRAM_INFO_KERNEL_NAMES, 0, nullptr, &Size);
   string_class ClResult(Size, ' ');
-  Plugin.call<PiApiKind::piProgramGetInfo>(MProgram, PI_PROGRAM_INFO_KERNEL_NAMES,
-                                           ClResult.size(), &ClResult[0],
-                                           nullptr);
+  Plugin.call<PiApiKind::piProgramGetInfo>(
+      MProgram, PI_PROGRAM_INFO_KERNEL_NAMES, ClResult.size(), &ClResult[0],
+      nullptr);
   // Get rid of the null terminator
   ClResult.pop_back();
   vector_class<string_class> KernelNames(split_string(ClResult, ';'));
@@ -413,7 +415,8 @@ cl_uint program_impl::get_info<info::program::reference_count>() const {
   }
   cl_uint Result;
   const detail::plugin &Plugin = getPlugin();
-  Plugin.call<PiApiKind::piProgramGetInfo>(MProgram, PI_PROGRAM_INFO_REFERENCE_COUNT,
+  Plugin.call<PiApiKind::piProgramGetInfo>(MProgram,
+                                           PI_PROGRAM_INFO_REFERENCE_COUNT,
                                            sizeof(cl_uint), &Result, nullptr);
   return Result;
 }
@@ -427,6 +430,7 @@ vector_class<device> program_impl::get_info<info::program::devices>() const {
   return get_devices();
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/program_impl.hpp
+++ b/sycl/source/detail/program_impl.hpp
@@ -28,6 +28,7 @@ namespace sycl {
 class kernel;
 
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 using ContextImplPtr = std::shared_ptr<detail::context_impl>;
 
@@ -390,6 +391,7 @@ template <> context program_impl::get_info<info::program::context>() const;
 template <>
 vector_class<device> program_impl::get_info<info::program::devices>() const;
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -34,8 +34,10 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 class context;
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 class context_impl;
+
 using ContextImplPtr = std::shared_ptr<context_impl>;
 using DeviceImage = pi_device_binary_struct;
 
@@ -142,6 +144,7 @@ private:
   /// True iff a SPIRV file has been specified with an environment variable
   bool m_UseSpvFile = false;
 };
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -24,6 +24,8 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
+
 template <> cl_uint queue_impl::get_info<info::queue::reference_count>() const {
   RT::PiResult result = PI_SUCCESS;
   if (!is_host())
@@ -185,6 +187,7 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
 #endif
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -25,6 +25,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 using ContextImplPtr = std::shared_ptr<detail::context_impl>;
 using DeviceImplPtr = shared_ptr_class<detail::device_impl>;
@@ -400,6 +401,7 @@ private:
   bool MSupportOOO = true;
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -41,11 +41,11 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
-__SYCL_INLINE_NAMESPACE(sycl_private) {
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 // Global graph for the application
 extern xpti::trace_event_data_t *GSYCLGraphEvent;
 #endif
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 #ifdef __GNUG__
 struct DemangleHandle {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -22,6 +22,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 class queue_impl;
 class event_impl;
@@ -429,6 +430,7 @@ private:
   void **MDstPtr = nullptr;
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -26,6 +26,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 // The function checks whether two requirements overlaps or not. This
 // information can be used to prove that executing two kernels that
@@ -340,7 +341,7 @@ Command *Scheduler::GraphBuilder::addCopyBack(Requirement *Req) {
 // The function implements SYCL host accessor logic: host accessor
 // should provide access to the buffer in user space.
 Command *Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
-                                                const bool destructor) {
+                                                  const bool destructor) {
 
   const QueueImplPtr &HostQueue = getInstance().getDefaultHostQueue();
 
@@ -545,8 +546,8 @@ AllocaCommandBase *Scheduler::GraphBuilder::getOrCreateAllocaForReq(
 
         // To ensure that the leader allocation is removed first
         AllocaCmd->getReleaseCmd()->addDep(
-            DepDesc(LinkedAllocaCmd->getReleaseCmd(), AllocaCmd->getRequirement(),
-                    LinkedAllocaCmd));
+            DepDesc(LinkedAllocaCmd->getReleaseCmd(),
+                    AllocaCmd->getRequirement(), LinkedAllocaCmd));
 
         // Device allocation takes ownership of the host ptr during
         // construction, host allocation doesn't. So, device allocation should
@@ -767,6 +768,7 @@ void Scheduler::GraphBuilder::removeRecordForMemObj(SYCLMemObjI *MemObject) {
   MemObject->MRecord.reset();
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -16,6 +16,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 static Command *getCommand(const EventImplPtr &Event) {
   return (Command *)Event->getCommand();
@@ -88,6 +89,7 @@ bool Scheduler::GraphProcessor::enqueueCommand(Command *Cmd,
   return Cmd->enqueue(EnqueueResult, Blocking);
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -19,11 +19,12 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 EventImplPtr addHostAccessorToSchedulerInstance(Requirement *Req,
                                                 const bool destructor) {
-  return cl::sycl::detail::Scheduler::getInstance().
-                                              addHostAccessor(Req, destructor);
+  return cl::sycl::detail::Scheduler::getInstance().addHostAccessor(Req,
+                                                                    destructor);
 }
 
 void Scheduler::waitForRecordToFinish(MemObjRecord *Record) {
@@ -121,14 +122,12 @@ EventImplPtr Scheduler::addCopyBack(Requirement *Req) {
 // else that has no priority set, or has a priority higher than 2000).
 Scheduler Scheduler::instance __attribute__((init_priority(2000)));
 #else
-#pragma warning(disable:4073)
+#pragma warning(disable : 4073)
 #pragma init_seg(lib)
 Scheduler Scheduler::instance;
 #endif
 
-Scheduler &Scheduler::getInstance() {
-  return instance;
-}
+Scheduler &Scheduler::getInstance() { return instance; }
 
 std::vector<EventImplPtr> Scheduler::getWaitList(EventImplPtr Event) {
   std::lock_guard<std::mutex> lock(MGraphLock);
@@ -178,7 +177,7 @@ EventImplPtr Scheduler::addHostAccessor(Requirement *Req,
 
 void Scheduler::releaseHostAccessor(Requirement *Req) {
   Req->MBlockedCmd->MCanEnqueue = true;
-  MemObjRecord* Record = Req->MSYCLMemObj->MRecord.get();
+  MemObjRecord *Record = Req->MSYCLMemObj->MRecord.get();
   auto EnqueueLeaves = [](CircularBuffer<Command *> &Leaves) {
     for (Command *Cmd : Leaves) {
       EnqueueResultT Res;
@@ -193,11 +192,12 @@ void Scheduler::releaseHostAccessor(Requirement *Req) {
 
 Scheduler::Scheduler() {
   sycl::device HostDevice;
-  DefaultHostQueue = QueueImplPtr(new queue_impl(
-      detail::getSyclObjImpl(HostDevice), /*AsyncHandler=*/{},
-          QueueOrder::Ordered, /*PropList=*/{}));
+  DefaultHostQueue = QueueImplPtr(
+      new queue_impl(detail::getSyclObjImpl(HostDevice), /*AsyncHandler=*/{},
+                     QueueOrder::Ordered, /*PropList=*/{}));
 }
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -22,6 +22,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+__SYCL_INLINE_NAMESPACE(sycl_private) {
 
 class queue_impl;
 class event_impl;
@@ -234,6 +235,7 @@ protected:
   QueueImplPtr DefaultHostQueue;
 };
 
+} // __SYCL_INLINE_NAMESPACE(sycl_private)
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)


### PR DESCRIPTION
ABI tests require a way to differentiate private and publicly accessible
symbols. Wrap symbols that are not be accessible from user application
in sycl_private namespace to exclude them from ABI checks.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>