### PR TITLE
[SYCL][FPGA] Enable a set of loop attributes

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1654,6 +1654,57 @@ def SYCLIntelFPGAMaxConcurrency : Attr {
   let Documentation = [SYCLIntelFPGAMaxConcurrencyAttrDocs];
 }
 
+def SYCLIntelFPGALoopCoalesce : Attr {
+  let Spellings = [CXX11<"intelfpga","loop_coalesce">];
+  let Args = [ExprArgument<"NExpr">];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let HasCustomTypeTransform = 1;
+  let AdditionalMembers = [{
+    static const char *getName() {
+      return "loop_coalesce";
+    }
+  }];
+  let Documentation = [SYCLIntelFPGALoopCoalesceAttrDocs];
+}
+
+def SYCLIntelFPGADisableLoopPipelining : Attr {
+  let Spellings = [CXX11<"intelfpga","disable_loop_pipelining">];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let HasCustomTypeTransform = 1;
+  let AdditionalMembers = [{
+    static const char *getName() {
+      return "disable_loop_pipelining";
+    }
+  }];
+  let Documentation = [SYCLIntelFPGADisableLoopPipeliningAttrDocs];
+}
+
+def SYCLIntelFPGAMaxInterleaving : Attr {
+  let Spellings = [CXX11<"intelfpga","max_interleaving">];
+  let Args = [ExprArgument<"NExpr">];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let HasCustomTypeTransform = 1;
+  let AdditionalMembers = [{
+    static const char *getName() {
+      return "max_interleaving";
+    }
+  }];
+  let Documentation = [SYCLIntelFPGAMaxInterleavingAttrDocs];
+}
+
+def SYCLIntelFPGASpeculatedIterations : Attr {
+  let Spellings = [CXX11<"intelfpga","speculated_iterations">];
+  let Args = [ExprArgument<"NExpr">];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let HasCustomTypeTransform = 1;
+  let AdditionalMembers = [{
+    static const char *getName() {
+      return "speculated_iterations";
+    }
+  }];
+  let Documentation = [SYCLIntelFPGASpeculatedIterationsAttrDocs];
+}
+
 def IntelFPGALocalNonConstVar : SubsetSubject<Var,
                               [{S->hasLocalStorage() &&
                                 S->getKind() != Decl::ImplicitParam &&

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2096,7 +2096,7 @@ def SYCLIntelFPGALoopCoalesceAttrDocs : Documentation {
   let Content = [{
 This attribute applies to a loop. Indicates that the loop nest should be
 coalesced into a single loop without affecting functionality. Parameter N is
-optional. If specified, it must be a positive integer, and indicates how many
+optional. If specified, it shall be a positive integer, and indicates how many
 of the nested loop levels should be coalesced.
   }];
 }
@@ -2120,7 +2120,7 @@ This attribute applies to a loop. Places a maximum limit N on the number of
 interleaved invocations of an inner loop by an outer loop (note, this does not
 mean that this attribute can only be applied to inner loops in user code - outer
 loops in user code may still be contained in an implicit loop due to NDRange).
-Parameter N is mandatory, and may either b 0, or a positive integer. Cannot be
+Parameter N is mandatory, and shall be non-negative integer. Cannot be
 used on the same loop in conjunction with disable_loop_pipelining.
   }];
 }
@@ -2130,8 +2130,8 @@ def SYCLIntelFPGASpeculatedIterationsAttrDocs : Documentation {
   let Heading = "speculated_iterations";
   let Content = [{
 This attribute applies to a loop. Specifies the number of concurrent speculated
-iterations that will be in flight (iterations that are in flight where the exit
-condition for that iteration has not yet been evaluated) for a loop invocation.
+iterations that will be in flight for a loop invocation (i.e. the exit
+condition for these iterations will not have been evaluated yet).
 Parameter N is mandatory, and may either be 0, or a positive integer. Cannot be
 used on the same loop in conjunction with disable_loop_pipelining.
   }];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2090,6 +2090,53 @@ be applied multiple times to the same loop.
   }];
 }
 
+def SYCLIntelFPGALoopCoalesceAttrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "loop_coalesce";
+  let Content = [{
+This attribute applies to a loop. Indicates that the loop nest should be
+coalesced into a single loop without affecting functionality. Parameter N is
+optional. If specified, it must be a positive integer, and indicates how many
+of the nested loop levels should be coalesced.
+  }];
+}
+
+def SYCLIntelFPGADisableLoopPipeliningAttrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "disable_loop_pipelining";
+  let Content = [{
+This attribute applies to a loop. Disables pipelining of the loop data path,
+causing the loop to be executed serially. Cannot be used on the same loop in
+conjunction with max_interleaving, speculated_iterations, max_concurrency, ii
+or ivdep.
+  }];
+}
+
+def SYCLIntelFPGAMaxInterleavingAttrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "max_interleaving";
+  let Content = [{
+This attribute applies to a loop. Places a maximum limit N on the number of
+interleaved invocations of an inner loop by an outer loop (note, this does not
+mean that this attribute can only be applied to inner loops in user code - outer
+loops in user code may still be contained in an implicit loop due to NDRange).
+Parameter N is mandatory, and may either b 0, or a positive integer. Cannot be
+used on the same loop in conjunction with disable_loop_pipelining.
+  }];
+}
+
+def SYCLIntelFPGASpeculatedIterationsAttrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "speculated_iterations";
+  let Content = [{
+This attribute applies to a loop. Specifies the number of concurrent speculated
+iterations that will be in flight (iterations that are in flight where the exit
+condition for that iteration has not yet been evaluated) for a loop invocation.
+Parameter N is mandatory, and may either be 0, or a positive integer. Cannot be
+used on the same loop in conjunction with disable_loop_pipelining.
+  }];
+}
+
 def SYCLDeviceIndirectlyCallableDocs : Documentation {
   let Category = DocCatFunction;
   let Heading = "intel::device_indirectly_callable";

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1719,7 +1719,7 @@ public:
                               Expr *Expr2);
   template <typename FPGALoopAttrT>
   FPGALoopAttrT *BuildSYCLIntelFPGALoopAttr(const AttributeCommonInfo &A,
-                                            Expr *E);
+                                            Expr *E = nullptr);
 
   LoopUnrollHintAttr *BuildLoopUnrollHintAttr(const AttributeCommonInfo &A,
                                               Expr *E);

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -535,6 +535,8 @@ MDNode *LoopInfo::createMetadata(
     LoopProperties.push_back(MDNode::get(Ctx, Vals));
   }
 
+  // disable_loop_pipelining attribute corresponds to
+  // 'llvm.loop.intel.pipelining.enable, i32 0' metadata
   if (Attrs.SYCLLoopPipeliningDisable) {
     Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.intel.pipelining.enable"),
                         ConstantAsMetadata::get(

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -507,7 +507,6 @@ MDNode *LoopInfo::createMetadata(
 
   // Setting ii attribute with an initiation interval
   if (Attrs.SYCLIInterval > 0) {
-    LLVMContext &Ctx = Header->getContext();
     Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.ii.count"),
                         ConstantAsMetadata::get(ConstantInt::get(
                             llvm::Type::getInt32Ty(Ctx), Attrs.SYCLIInterval))};
@@ -516,7 +515,6 @@ MDNode *LoopInfo::createMetadata(
 
   // Setting max_concurrency attribute with number of threads
   if (Attrs.SYCLMaxConcurrencyEnable) {
-    LLVMContext &Ctx = Header->getContext();
     Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.max_concurrency.count"),
                         ConstantAsMetadata::get(ConstantInt::get(
                             llvm::Type::getInt32Ty(Ctx),
@@ -525,13 +523,11 @@ MDNode *LoopInfo::createMetadata(
   }
 
   if (Attrs.SYCLLoopCoalesceEnable) {
-    LLVMContext &Ctx = Header->getContext();
     Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.coalesce.enable")};
     LoopProperties.push_back(MDNode::get(Ctx, Vals));
   }
 
   if (Attrs.SYCLLoopCoalesceNLevels > 0) {
-    LLVMContext &Ctx = Header->getContext();
     Metadata *Vals[] = {
         MDString::get(Ctx, "llvm.loop.coalesce.count"),
         ConstantAsMetadata::get(ConstantInt::get(
@@ -540,7 +536,6 @@ MDNode *LoopInfo::createMetadata(
   }
 
   if (Attrs.SYCLLoopPipeliningDisable) {
-    LLVMContext &Ctx = Header->getContext();
     Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.intel.pipelining.enable"),
                         ConstantAsMetadata::get(
                             ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0))};
@@ -548,7 +543,6 @@ MDNode *LoopInfo::createMetadata(
   }
 
   if (Attrs.SYCLMaxInterleavingEnable) {
-    LLVMContext &Ctx = Header->getContext();
     Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.max_interleaving.count"),
                         ConstantAsMetadata::get(ConstantInt::get(
                             llvm::Type::getInt32Ty(Ctx),
@@ -557,7 +551,6 @@ MDNode *LoopInfo::createMetadata(
   }
 
   if (Attrs.SYCLSpeculatedIterationsEnable) {
-    LLVMContext &Ctx = Header->getContext();
     Metadata *Vals[] = {
         MDString::get(Ctx, "llvm.loop.intel.speculated.iterations.count"),
         ConstantAsMetadata::get(

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -541,10 +541,9 @@ MDNode *LoopInfo::createMetadata(
 
   if (Attrs.SYCLLoopPipeliningDisable) {
     LLVMContext &Ctx = Header->getContext();
-    Metadata *Vals[] = {
-        MDString::get(Ctx, "llvm.loop.intel.pipelining.enable"),
-        ConstantAsMetadata::get(ConstantInt::get(
-            llvm::Type::getInt32Ty(Ctx), 0))};
+    Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.intel.pipelining.enable"),
+                        ConstantAsMetadata::get(
+                            ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0))};
     LoopProperties.push_back(MDNode::get(Ctx, Vals));
   }
 

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -113,6 +113,27 @@ struct LoopAttributes {
   /// Value for llvm.loop.max_concurrency.count metadata.
   unsigned SYCLMaxConcurrencyNThreads;
 
+  /// Flag for llvm.loop.coalesce metadata.
+  bool SYCLLoopCoalesceEnable;
+
+  /// Value for llvm.loop.coalesce.count metadata.
+  unsigned SYCLLoopCoalesceNLevels;
+
+  /// Flag for llvm.loop.intel.pipelining.enable, i32 0 metadata.
+  bool SYCLLoopPipeliningDisable;
+
+  /// Flag for llvm.loop.max_interleaving.count metadata.
+  bool SYCLMaxInterleavingEnable;
+
+  /// Value for llvm.loop.max_interleaving.count metadata.
+  unsigned SYCLMaxInterleavingNInvocations;
+
+  /// Flag for llvm.loop.intel.speculated.iterations.count metadata.
+  bool SYCLSpeculatedIterationsEnable;
+
+  /// Value for llvm.loop.intel.speculated.iterations.count metadata.
+  unsigned SYCLSpeculatedIterationsNIterations;
+
   /// llvm.unroll.
   unsigned UnrollCount;
 
@@ -331,6 +352,41 @@ public:
   /// Set value of threads for the next loop pushed.
   void setSYCLMaxConcurrencyNThreads(unsigned C) {
     StagedAttrs.SYCLMaxConcurrencyNThreads = C;
+  }
+
+  /// Set flag of loop_coalesce for the next loop pushed.
+  void setSYCLLoopCoalesceEnable() {
+    StagedAttrs.SYCLLoopCoalesceEnable = true;
+  }
+
+  /// Set value of coalesced levels for the next loop pushed.
+  void setSYCLLoopCoalesceNLevels(unsigned C) {
+    StagedAttrs.SYCLLoopCoalesceNLevels = C;
+  }
+
+  /// Set flag of disable_loop_pipelining for the next loop pushed.
+  void setSYCLLoopPipeliningDisable() {
+    StagedAttrs.SYCLLoopPipeliningDisable = true;
+  }
+
+  /// Set flag of max_interleaving for the next loop pushed.
+  void setSYCLMaxInterleavingEnable() {
+    StagedAttrs.SYCLMaxInterleavingEnable = true;
+  }
+
+  /// Set value of max interleaved invocations for the next loop pushed.
+  void setSYCLMaxInterleavingNInvocations(unsigned C) {
+    StagedAttrs.SYCLMaxInterleavingNInvocations = C;
+  }
+
+  /// Set flag of speculated_iterations for the next loop pushed.
+  void setSYCLSpeculatedIterationsEnable() {
+    StagedAttrs.SYCLSpeculatedIterationsEnable = true;
+  }
+
+  /// Set value of concurrent speculated iterations for the next loop pushed.
+  void setSYCLSpeculatedIterationsNIterations(unsigned C) {
+    StagedAttrs.SYCLSpeculatedIterationsNIterations = C;
   }
 
   /// Set the unroll count for the next loop pushed.

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2519,6 +2519,12 @@ bool Parser::ParseSYCLLoopAttributes(ParsedAttributes &Attrs) {
   if (Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAIVDep &&
       Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAII &&
       Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency &&
+      Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGALoopCoalesce &&
+      Attrs.begin()->getKind() !=
+          ParsedAttr::AT_SYCLIntelFPGADisableLoopPipelining &&
+      Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAMaxInterleaving &&
+      Attrs.begin()->getKind() !=
+          ParsedAttr::AT_SYCLIntelFPGASpeculatedIterations &&
       Attrs.begin()->getKind() != ParsedAttr::AT_LoopUnrollHint)
     return true;
 

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -559,8 +559,7 @@ static void CheckMutualExclusionSYCLLoopAttribute(
       LoopAttr2 = cast<LoopAttrT2>(I);
     if (LoopAttr && LoopAttr2) {
       S.Diag(Range.getBegin(), diag::err_attributes_are_not_compatible)
-          << "'" + std::string(LoopAttr->getName()) + "'"
-          << "'" + std::string(LoopAttr2->getName()) + "'";
+          << LoopAttr->getSpelling() << LoopAttr2->getSpelling();
     }
   }
 }

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -86,13 +86,31 @@ static Attr *handleIntelFPGALoopAttr(Sema &S, const ParsedAttr &A) {
 
   if (NumArgs == 0) {
     if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAII ||
-        A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency) {
+        A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency ||
+        A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxInterleaving ||
+        A.getKind() == ParsedAttr::AT_SYCLIntelFPGASpeculatedIterations) {
       S.Diag(A.getLoc(), diag::warn_attribute_too_few_arguments) << A << 1;
       return nullptr;
     }
   }
 
-  return S.BuildSYCLIntelFPGALoopAttr<FPGALoopAttrT>(A, A.getArgAsExpr(0));
+  return S.BuildSYCLIntelFPGALoopAttr<FPGALoopAttrT>(
+      A, A.getNumArgs() ? A.getArgAsExpr(0) : nullptr);
+}
+
+template <>
+Attr *handleIntelFPGALoopAttr<SYCLIntelFPGADisableLoopPipeliningAttr>(
+    Sema &S, const ParsedAttr &A) {
+  if (S.LangOpts.SYCLIsHost)
+    return nullptr;
+
+  unsigned NumArgs = A.getNumArgs();
+  if (NumArgs > 0) {
+    S.Diag(A.getLoc(), diag::warn_attribute_too_many_arguments) << A << 0;
+    return nullptr;
+  }
+
+  return new (S.Context) SYCLIntelFPGADisableLoopPipeliningAttr(S.Context, A);
 }
 
 static bool checkSYCLIntelFPGAIVDepSafeLen(Sema &S, llvm::APSInt &Value,
@@ -177,10 +195,10 @@ Sema::BuildSYCLIntelFPGAIVDepAttr(const AttributeCommonInfo &CI, Expr *Expr1,
 template <typename FPGALoopAttrT>
 FPGALoopAttrT *Sema::BuildSYCLIntelFPGALoopAttr(const AttributeCommonInfo &A,
                                                 Expr *E) {
-  if (!E)
+  if (!E && !(A.getParsedKind() == ParsedAttr::AT_SYCLIntelFPGALoopCoalesce))
     return nullptr;
 
-  if (!E->isInstantiationDependent()) {
+  if (E && !E->isInstantiationDependent()) {
     llvm::APSInt ArgVal(32);
 
     if (!E->isIntegerConstantExpr(ArgVal, getASTContext())) {
@@ -192,17 +210,22 @@ FPGALoopAttrT *Sema::BuildSYCLIntelFPGALoopAttr(const AttributeCommonInfo &A,
 
     int Val = ArgVal.getSExtValue();
 
-    if (A.getParsedKind() == ParsedAttr::AT_SYCLIntelFPGAII) {
+    if (A.getParsedKind() == ParsedAttr::AT_SYCLIntelFPGAII ||
+        A.getParsedKind() == ParsedAttr::AT_SYCLIntelFPGALoopCoalesce) {
       if (Val <= 0) {
         Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
-            << "'ii'" << /* positive */ 0;
+            << A.getAttrName() << /* positive */ 0;
         return nullptr;
       }
     } else if (A.getParsedKind() ==
-               ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency) {
+                   ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency ||
+               A.getParsedKind() ==
+                   ParsedAttr::AT_SYCLIntelFPGAMaxInterleaving ||
+               A.getParsedKind() ==
+                   ParsedAttr::AT_SYCLIntelFPGASpeculatedIterations) {
       if (Val < 0) {
         Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
-            << "'max_concurrency'" << /* non-negative */ 1;
+            << A.getAttrName() << /* non-negative */ 1;
         return nullptr;
       }
     } else {
@@ -521,13 +544,57 @@ static void CheckForDuplicationSYCLLoopAttribute(
   }
 }
 
+/// Diagnose mutually exclusive attributes when present on a given
+/// declaration. Returns true if diagnosed.
+template <typename LoopAttrT, typename LoopAttrT2>
+static void CheckMutualExclusionSYCLLoopAttribute(
+    Sema &S, const SmallVectorImpl<const Attr *> &Attrs, SourceRange Range) {
+  const LoopAttrT *LoopAttr = nullptr;
+  const LoopAttrT2 *LoopAttr2 = nullptr;
+
+  for (const auto *I : Attrs) {
+    if (isa<LoopAttrT>(I))
+      LoopAttr = cast<LoopAttrT>(I);
+    if (isa<LoopAttrT2>(I))
+      LoopAttr2 = cast<LoopAttrT2>(I);
+    if (LoopAttr && LoopAttr2) {
+      S.Diag(Range.getBegin(), diag::err_attributes_are_not_compatible)
+          << "'" + std::string(LoopAttr->getName()) + "'"
+          << "'" + std::string(LoopAttr2->getName()) + "'";
+    }
+  }
+}
+
 static void CheckForIncompatibleSYCLLoopAttributes(
     Sema &S, const SmallVectorImpl<const Attr *> &Attrs, SourceRange Range) {
   CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAIIAttr>(S, Attrs, Range);
   CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAMaxConcurrencyAttr>(
       S, Attrs, Range);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGALoopCoalesceAttr>(S, Attrs,
+                                                                      Range);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr>(
+      S, Attrs, Range);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAMaxInterleavingAttr>(
+      S, Attrs, Range);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGASpeculatedIterationsAttr>(
+      S, Attrs, Range);
   CheckForDuplicationSYCLLoopAttribute<LoopUnrollHintAttr>(S, Attrs, Range,
                                                            false);
+  CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
+                                        SYCLIntelFPGAMaxInterleavingAttr>(
+      S, Attrs, Range);
+  CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
+                                        SYCLIntelFPGASpeculatedIterationsAttr>(
+      S, Attrs, Range);
+  CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
+                                        SYCLIntelFPGAIIAttr>(S, Attrs, Range);
+  CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
+                                        SYCLIntelFPGAIVDepAttr>(S, Attrs,
+                                                                Range);
+  CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
+                                        SYCLIntelFPGAMaxConcurrencyAttr>(
+      S, Attrs, Range);
+
   CheckRedundantSYCLIntelFPGAIVDepAttrs(S, Attrs);
 }
 
@@ -638,6 +705,15 @@ static Attr *ProcessStmtAttribute(Sema &S, Stmt *St, const ParsedAttr &A,
     return handleIntelFPGALoopAttr<SYCLIntelFPGAIIAttr>(S, A);
   case ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency:
     return handleIntelFPGALoopAttr<SYCLIntelFPGAMaxConcurrencyAttr>(S, A);
+  case ParsedAttr::AT_SYCLIntelFPGALoopCoalesce:
+    return handleIntelFPGALoopAttr<SYCLIntelFPGALoopCoalesceAttr>(S, A);
+  case ParsedAttr::AT_SYCLIntelFPGADisableLoopPipelining:
+    return handleIntelFPGALoopAttr<SYCLIntelFPGADisableLoopPipeliningAttr>(S,
+                                                                           A);
+  case ParsedAttr::AT_SYCLIntelFPGAMaxInterleaving:
+    return handleIntelFPGALoopAttr<SYCLIntelFPGAMaxInterleavingAttr>(S, A);
+  case ParsedAttr::AT_SYCLIntelFPGASpeculatedIterations:
+    return handleIntelFPGALoopAttr<SYCLIntelFPGASpeculatedIterationsAttr>(S, A);
   case ParsedAttr::AT_OpenCLUnrollHint:
   case ParsedAttr::AT_LoopUnrollHint:
     return handleLoopUnrollHint(S, St, A, Range);

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1058,6 +1058,14 @@ namespace {
         const SYCLIntelFPGAMaxConcurrencyAttr *MC);
     const LoopUnrollHintAttr *
     TransformLoopUnrollHintAttr(const LoopUnrollHintAttr *LU);
+    const SYCLIntelFPGALoopCoalesceAttr *TransformSYCLIntelFPGALoopCoalesceAttr(
+        const SYCLIntelFPGALoopCoalesceAttr *LC);
+    const SYCLIntelFPGAMaxInterleavingAttr *
+    TransformSYCLIntelFPGAMaxInterleavingAttr(
+        const SYCLIntelFPGAMaxInterleavingAttr *MI);
+    const SYCLIntelFPGASpeculatedIterationsAttr *
+    TransformSYCLIntelFPGASpeculatedIterationsAttr(
+        const SYCLIntelFPGASpeculatedIterationsAttr *SI);
 
     ExprResult TransformPredefinedExpr(PredefinedExpr *E);
     ExprResult TransformDeclRefExpr(DeclRefExpr *E);
@@ -1522,6 +1530,31 @@ TemplateInstantiator::TransformSYCLIntelFPGAMaxConcurrencyAttr(
       getDerived().TransformExpr(MC->getNThreadsExpr()).get();
   return getSema().BuildSYCLIntelFPGALoopAttr<SYCLIntelFPGAMaxConcurrencyAttr>(
       *MC, TransformedExpr);
+}
+
+const SYCLIntelFPGALoopCoalesceAttr *
+TemplateInstantiator::TransformSYCLIntelFPGALoopCoalesceAttr(
+    const SYCLIntelFPGALoopCoalesceAttr *LC) {
+  Expr *TransformedExpr = getDerived().TransformExpr(LC->getNExpr()).get();
+  return getSema().BuildSYCLIntelFPGALoopAttr<SYCLIntelFPGALoopCoalesceAttr>(
+      *LC, TransformedExpr);
+}
+
+const SYCLIntelFPGAMaxInterleavingAttr *
+TemplateInstantiator::TransformSYCLIntelFPGAMaxInterleavingAttr(
+    const SYCLIntelFPGAMaxInterleavingAttr *MI) {
+  Expr *TransformedExpr = getDerived().TransformExpr(MI->getNExpr()).get();
+  return getSema().BuildSYCLIntelFPGALoopAttr<SYCLIntelFPGAMaxInterleavingAttr>(
+      *MI, TransformedExpr);
+}
+
+const SYCLIntelFPGASpeculatedIterationsAttr *
+TemplateInstantiator::TransformSYCLIntelFPGASpeculatedIterationsAttr(
+    const SYCLIntelFPGASpeculatedIterationsAttr *SI) {
+  Expr *TransformedExpr = getDerived().TransformExpr(SI->getNExpr()).get();
+  return getSema()
+      .BuildSYCLIntelFPGALoopAttr<SYCLIntelFPGASpeculatedIterationsAttr>(
+          *SI, TransformedExpr);
 }
 
 const LoopUnrollHintAttr *TemplateInstantiator::TransformLoopUnrollHintAttr(

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -17,9 +17,8 @@ void disable_loop_pipelining() {
   int a[10];
   // CHECK: ![[MD_DLP]] = distinct !{![[MD_DLP]], ![[MD_dlp:[0-9]+]]}
   // CHECK-NEXT: ![[MD_dlp]] = !{!"llvm.loop.intel.pipelining.enable", i32 0}
-  [[intelfpga::disable_loop_pipelining]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 template <int A>
@@ -57,19 +56,16 @@ void loop_coalesce() {
   int a[10];
   // CHECK: ![[MD_LC]] = distinct !{![[MD_LC]], ![[MD_loop_coalesce:[0-9]+]]}
   // CHECK-NEXT: ![[MD_loop_coalesce]] = !{!"llvm.loop.coalesce.count", i32 2}
-  [[intelfpga::loop_coalesce(A)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::loop_coalesce(A)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // CHECK: ![[MD_LC_2]] = distinct !{![[MD_LC_2]], ![[MD_loop_coalesce_2:[0-9]+]]}
   // CHECK-NEXT: ![[MD_loop_coalesce_2]] = !{!"llvm.loop.coalesce.count", i32 4}
-  [[intelfpga::loop_coalesce(4)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::loop_coalesce(4)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // CHECK: ![[MD_LC_3]] = distinct !{![[MD_LC_3]], ![[MD_loop_coalesce_3:[0-9]+]]}
   // CHECK-NEXT: ![[MD_loop_coalesce_3]] = !{!"llvm.loop.coalesce.enable"}
-  [[intelfpga::loop_coalesce]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::loop_coalesce]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 template <int A>
@@ -77,14 +73,12 @@ void max_interleaving() {
   int a[10];
   // CHECK: ![[MD_MI]] = distinct !{![[MD_MI]], ![[MD_max_interleaving:[0-9]+]]}
   // CHECK-NEXT: ![[MD_max_interleaving]] = !{!"llvm.loop.max_interleaving.count", i32 3}
-  [[intelfpga::max_interleaving(A)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_interleaving(A)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // CHECK: ![[MD_MI_2]] = distinct !{![[MD_MI_2]], ![[MD_max_interleaving_2:[0-9]+]]}
   // CHECK-NEXT: ![[MD_max_interleaving_2]] = !{!"llvm.loop.max_interleaving.count", i32 2}
-  [[intelfpga::max_interleaving(2)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_interleaving(2)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 template <int A>
@@ -92,14 +86,12 @@ void speculated_iterations() {
   int a[10];
   // CHECK: ![[MD_SI]] = distinct !{![[MD_SI]], ![[MD_speculated_iterations:[0-9]+]]}
   // CHECK-NEXT: ![[MD_speculated_iterations]] = !{!"llvm.loop.intel.speculated.iterations.count", i32 4}
-  [[intelfpga::speculated_iterations(A)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::speculated_iterations(A)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // CHECK: ![[MD_SI_2]] = distinct !{![[MD_SI_2]], ![[MD_speculated_iterations_2:[0-9]+]]}
   // CHECK-NEXT: ![[MD_speculated_iterations_2]] = !{!"llvm.loop.intel.speculated.iterations.count", i32 5}
-  [[intelfpga::speculated_iterations(5)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::speculated_iterations(5)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 template <typename name, typename Func>

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -1,9 +1,26 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
-// CHECK: br label %for.cond,  !llvm.loop ![[MD_II:[0-9]+]]
-// CHECK: br label %for.cond2, !llvm.loop ![[MD_II_2:[0-9]+]]
-// CHECK: br label %for.cond,  !llvm.loop ![[MD_MC:[0-9]+]]
-// CHECK: br label %for.cond2, !llvm.loop ![[MD_MC_2:[0-9]+]]
+// CHECK: br label %for.cond,   !llvm.loop ![[MD_DLP:[0-9]+]]
+// CHECK: br label %for.cond,   !llvm.loop ![[MD_II:[0-9]+]]
+// CHECK: br label %for.cond2,  !llvm.loop ![[MD_II_2:[0-9]+]]
+// CHECK: br label %for.cond,   !llvm.loop ![[MD_MC:[0-9]+]]
+// CHECK: br label %for.cond2,  !llvm.loop ![[MD_MC_2:[0-9]+]]
+// CHECK: br label %for.cond,   !llvm.loop ![[MD_LC:[0-9]+]]
+// CHECK: br label %for.cond2,  !llvm.loop ![[MD_LC_2:[0-9]+]]
+// CHECK: br label %for.cond12, !llvm.loop ![[MD_LC_3:[0-9]+]]
+// CHECK: br label %for.cond,   !llvm.loop ![[MD_MI:[0-9]+]]
+// CHECK: br label %for.cond2,  !llvm.loop ![[MD_MI_2:[0-9]+]]
+// CHECK: br label %for.cond,   !llvm.loop ![[MD_SI:[0-9]+]]
+// CHECK: br label %for.cond2,  !llvm.loop ![[MD_SI_2:[0-9]+]]
+
+void disable_loop_pipelining() {
+  int a[10];
+  // CHECK: ![[MD_DLP]] = distinct !{![[MD_DLP]], ![[MD_dlp:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_dlp]] = !{!"llvm.loop.intel.pipelining.enable", i32 0}
+  [[intelfpga::disable_loop_pipelining]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
 
 template <int A>
 void ii() {
@@ -35,6 +52,56 @@ void max_concurrency() {
     a[i] = 0;
 }
 
+template <int A>
+void loop_coalesce() {
+  int a[10];
+  // CHECK: ![[MD_LC]] = distinct !{![[MD_LC]], ![[MD_loop_coalesce:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_loop_coalesce]] = !{!"llvm.loop.coalesce.count", i32 2}
+  [[intelfpga::loop_coalesce(A)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // CHECK: ![[MD_LC_2]] = distinct !{![[MD_LC_2]], ![[MD_loop_coalesce_2:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_loop_coalesce_2]] = !{!"llvm.loop.coalesce.count", i32 4}
+  [[intelfpga::loop_coalesce(4)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // CHECK: ![[MD_LC_3]] = distinct !{![[MD_LC_3]], ![[MD_loop_coalesce_3:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_loop_coalesce_3]] = !{!"llvm.loop.coalesce.enable"}
+  [[intelfpga::loop_coalesce]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+template <int A>
+void max_interleaving() {
+  int a[10];
+  // CHECK: ![[MD_MI]] = distinct !{![[MD_MI]], ![[MD_max_interleaving:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_max_interleaving]] = !{!"llvm.loop.max_interleaving.count", i32 3}
+  [[intelfpga::max_interleaving(A)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // CHECK: ![[MD_MI_2]] = distinct !{![[MD_MI_2]], ![[MD_max_interleaving_2:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_max_interleaving_2]] = !{!"llvm.loop.max_interleaving.count", i32 2}
+  [[intelfpga::max_interleaving(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+template <int A>
+void speculated_iterations() {
+  int a[10];
+  // CHECK: ![[MD_SI]] = distinct !{![[MD_SI]], ![[MD_speculated_iterations:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_speculated_iterations]] = !{!"llvm.loop.intel.speculated.iterations.count", i32 4}
+  [[intelfpga::speculated_iterations(A)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // CHECK: ![[MD_SI_2]] = distinct !{![[MD_SI_2]], ![[MD_speculated_iterations_2:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_speculated_iterations_2]] = !{!"llvm.loop.intel.speculated.iterations.count", i32 5}
+  [[intelfpga::speculated_iterations(5)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   kernelFunc();
@@ -42,8 +109,12 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 
 int main() {
   kernel_single_task<class kernel_function>([]() {
+    disable_loop_pipelining();
     ii<4>();
     max_concurrency<0>();
+    loop_coalesce<2>();
+    max_interleaving<3>();
+    speculated_iterations<4>();
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -261,7 +261,7 @@ void zoo() {
 }
 
 // Test for Intel FPGA loop attributes compatibility
-void woo() {
+void loop_attrs_compatibility() {
   int a[10];
   // no diagnostics are expected
   [[intelfpga::disable_loop_pipelining]]
@@ -364,7 +364,7 @@ int main() {
     boo();
     goo();
     zoo();
-    woo();
+    loop_attrs_compatibility();
     ivdep_dependent<4, 2, 1>();
     //expected-note@-1 +{{in instantiation of function template specialization}}
     ivdep_dependent<2, 4, -1>();

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -267,23 +267,23 @@ void woo() {
   [[intelfpga::disable_loop_pipelining]]
   [[intelfpga::loop_coalesce]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'disable_loop_pipelining' and 'max_interleaving' attributes are not compatible}}
+  // expected-error@+1 {{disable_loop_pipelining and max_interleaving attributes are not compatible}}
   [[intelfpga::disable_loop_pipelining]]
   [[intelfpga::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
+  // expected-error@+1 {{disable_loop_pipelining and speculated_iterations attributes are not compatible}}
   [[intelfpga::speculated_iterations(0)]]
   [[intelfpga::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'disable_loop_pipelining' and 'max_concurrency' attributes are not compatible}}
+  // expected-error@+1 {{disable_loop_pipelining and max_concurrency attributes are not compatible}}
   [[intelfpga::disable_loop_pipelining]]
   [[intelfpga::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'disable_loop_pipelining' and 'ii' attributes are not compatible}}
+  // expected-error@+1 {{disable_loop_pipelining and ii attributes are not compatible}}
   [[intelfpga::ii(10)]]
   [[intelfpga::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'disable_loop_pipelining' and 'ivdep' attributes are not compatible}}
+  // expected-error@+1 {{disable_loop_pipelining and ivdep attributes are not compatible}}
   [[intelfpga::disable_loop_pipelining]]
   [[intelfpga::ivdep]] for (int i = 0; i != 10; ++i)
       a[i] = 0;

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -16,6 +16,15 @@ void foo() {
   [[intelfpga::ivdep(arr)]] int e[10];
   // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
   [[intelfpga::ivdep(arr, 2)]] int f[10];
+
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
+  [[intelfpga::disable_loop_pipelining]] int g[10];
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
+  [[intelfpga::loop_coalesce(2)]] int h[10];
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
+  [[intelfpga::max_interleaving(4)]] int i[10];
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
+  [[intelfpga::speculated_iterations(6)]] int j[10];
 }
 
 // Test for incorrect number of arguments for Intel FPGA loop attributes
@@ -52,11 +61,40 @@ void boo() {
   // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
   [[intelfpga::ivdep(2, 3.0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+  // expected-warning@+1 {{'disable_loop_pipelining' attribute takes no more than 0 arguments - attribute ignored}}
+  [[intelfpga::disable_loop_pipelining(0)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-warning@+1 {{'loop_coalesce' attribute takes no more than 1 argument - attribute ignored}}
+  [[intelfpga::loop_coalesce(2,3)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-warning@+1 {{'max_interleaving' attribute takes at least 1 argument - attribute ignored}}
+  [[intelfpga::max_interleaving]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-warning@+1 {{'max_interleaving' attribute takes no more than 1 argument - attribute ignored}}
+  [[intelfpga::max_interleaving(2,4)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-warning@+1 {{'speculated_iterations' attribute takes at least 1 argument - attribute ignored}}
+  [[intelfpga::speculated_iterations]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-warning@+1 {{'speculated_iterations' attribute takes no more than 1 argument - attribute ignored}}
+  [[intelfpga::speculated_iterations(1,2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 }
 
 // Test for incorrect argument value for Intel FPGA loop attributes
 void goo() {
   int a[10];
+  // no diagnostics are expected
+  [[intelfpga::disable_loop_pipelining]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
   // no diagnostics are expected
   [[intelfpga::max_concurrency(0)]]
   for (int i = 0; i != 10; ++i)
@@ -73,6 +111,18 @@ void goo() {
   [[intelfpga::max_concurrency(-1)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
+  // expected-error@+1 {{'loop_coalesce' attribute requires a positive integral compile time constant expression}}
+  [[intelfpga::loop_coalesce(0)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'max_interleaving' attribute requires a non-negative integral compile time constant expression}}
+  [[intelfpga::max_interleaving(-1)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'speculated_iterations' attribute requires a non-negative integral compile time constant expression}}
+  [[intelfpga::speculated_iterations(-1)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
   // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
   [[intelfpga::ivdep("test123")]]
   for (int i = 0; i != 10; ++i)
@@ -83,6 +133,18 @@ void goo() {
     a[i] = 0;
   // expected-error@+1 {{'max_concurrency' attribute requires an integer constant}}
   [[intelfpga::max_concurrency("test123")]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'loop_coalesce' attribute requires an integer constant}}
+  [[intelfpga::loop_coalesce("test123")]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'max_interleaving' attribute requires an integer constant}}
+  [[intelfpga::max_interleaving("test123")]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'speculated_iterations' attribute requires an integer constant}}
+  [[intelfpga::speculated_iterations("test123")]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
@@ -138,6 +200,29 @@ void zoo() {
   [[intelfpga::ii(2)]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
+  [[intelfpga::disable_loop_pipelining]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'disable_loop_pipelining'}}
+  [[intelfpga::disable_loop_pipelining]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::loop_coalesce(2)]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'loop_coalesce'}}
+  [[intelfpga::max_interleaving(1)]]
+  [[intelfpga::loop_coalesce]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::max_interleaving(1)]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'max_interleaving'}}
+  [[intelfpga::speculated_iterations(1)]]
+  [[intelfpga::max_interleaving(4)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intelfpga::speculated_iterations(1)]]
+  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'speculated_iterations'}}
+  [[intelfpga::loop_coalesce]]
+  [[intelfpga::speculated_iterations(2)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 
   [[intelfpga::ivdep]]
   // expected-warning@+2 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen INF >= safelen INF}}
@@ -191,6 +276,41 @@ void zoo() {
   // expected-warning@-1 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen 3 >= safelen 2}}
   // expected-note@+1 {{previous attribute is here}}
   [[intelfpga::ivdep(a, 3)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+}
+
+// Test for Intel FPGA loop attributes compatibility
+void woo() {
+  int a[10];
+  // no diagnostics are expected
+  [[intelfpga::disable_loop_pipelining]]
+  [[intelfpga::loop_coalesce]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'disable_loop_pipelining' and 'max_interleaving' attributes are not compatible}}
+  [[intelfpga::disable_loop_pipelining]]
+  [[intelfpga::max_interleaving(0)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
+  [[intelfpga::speculated_iterations(0)]]
+  [[intelfpga::disable_loop_pipelining]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'disable_loop_pipelining' and 'max_concurrency' attributes are not compatible}}
+  [[intelfpga::disable_loop_pipelining]]
+  [[intelfpga::max_concurrency(0)]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'disable_loop_pipelining' and 'ii' attributes are not compatible}}
+  [[intelfpga::ii(10)]]
+  [[intelfpga::disable_loop_pipelining]]
+  for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // expected-error@+1 {{'disable_loop_pipelining' and 'ivdep' attributes are not compatible}}
+  [[intelfpga::disable_loop_pipelining]]
+  [[intelfpga::ivdep]]
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
 }
@@ -270,6 +390,7 @@ int main() {
     boo();
     goo();
     zoo();
+    woo();
     ivdep_dependent<4, 2, 1>();
     //expected-note@-1 +{{in instantiation of function template specialization}}
     ivdep_dependent<2, 4, -1>();

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -63,38 +63,31 @@ void boo() {
       a[i] = 0;
 
   // expected-warning@+1 {{'disable_loop_pipelining' attribute takes no more than 0 arguments - attribute ignored}}
-  [[intelfpga::disable_loop_pipelining(0)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::disable_loop_pipelining(0)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-warning@+1 {{'loop_coalesce' attribute takes no more than 1 argument - attribute ignored}}
-  [[intelfpga::loop_coalesce(2,3)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::loop_coalesce(2, 3)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-warning@+1 {{'max_interleaving' attribute takes at least 1 argument - attribute ignored}}
-  [[intelfpga::max_interleaving]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_interleaving]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-warning@+1 {{'max_interleaving' attribute takes no more than 1 argument - attribute ignored}}
-  [[intelfpga::max_interleaving(2,4)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_interleaving(2, 4)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-warning@+1 {{'speculated_iterations' attribute takes at least 1 argument - attribute ignored}}
-  [[intelfpga::speculated_iterations]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::speculated_iterations]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-warning@+1 {{'speculated_iterations' attribute takes no more than 1 argument - attribute ignored}}
-  [[intelfpga::speculated_iterations(1,2)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::speculated_iterations(1, 2)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 // Test for incorrect argument value for Intel FPGA loop attributes
 void goo() {
   int a[10];
   // no diagnostics are expected
-  [[intelfpga::disable_loop_pipelining]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // no diagnostics are expected
   [[intelfpga::max_concurrency(0)]]
   for (int i = 0; i != 10; ++i)
@@ -108,21 +101,17 @@ void goo() {
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // expected-error@+1 {{'max_concurrency' attribute requires a non-negative integral compile time constant expression}}
-  [[intelfpga::max_concurrency(-1)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_concurrency(-1)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'loop_coalesce' attribute requires a positive integral compile time constant expression}}
-  [[intelfpga::loop_coalesce(0)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::loop_coalesce(0)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'max_interleaving' attribute requires a non-negative integral compile time constant expression}}
-  [[intelfpga::max_interleaving(-1)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_interleaving(-1)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'speculated_iterations' attribute requires a non-negative integral compile time constant expression}}
-  [[intelfpga::speculated_iterations(-1)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::speculated_iterations(-1)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
   [[intelfpga::ivdep("test123")]]
   for (int i = 0; i != 10; ++i)
@@ -132,21 +121,17 @@ void goo() {
   for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // expected-error@+1 {{'max_concurrency' attribute requires an integer constant}}
-  [[intelfpga::max_concurrency("test123")]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_concurrency("test123")]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'loop_coalesce' attribute requires an integer constant}}
-  [[intelfpga::loop_coalesce("test123")]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::loop_coalesce("test123")]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'max_interleaving' attribute requires an integer constant}}
-  [[intelfpga::max_interleaving("test123")]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_interleaving("test123")]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'speculated_iterations' attribute requires an integer constant}}
-  [[intelfpga::speculated_iterations("test123")]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::speculated_iterations("test123")]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
   [[intelfpga::ivdep("test123")]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
@@ -197,32 +182,27 @@ void zoo() {
   [[intelfpga::ii(2)]]
   // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ii'}}
   [[intelfpga::max_concurrency(2)]]
-  [[intelfpga::ii(2)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::ii(2)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   [[intelfpga::disable_loop_pipelining]]
   // expected-error@-1 {{duplicate Intel FPGA loop attribute 'disable_loop_pipelining'}}
-  [[intelfpga::disable_loop_pipelining]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   [[intelfpga::loop_coalesce(2)]]
   // expected-error@-1 {{duplicate Intel FPGA loop attribute 'loop_coalesce'}}
   [[intelfpga::max_interleaving(1)]]
-  [[intelfpga::loop_coalesce]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::loop_coalesce]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   [[intelfpga::max_interleaving(1)]]
   // expected-error@-1 {{duplicate Intel FPGA loop attribute 'max_interleaving'}}
   [[intelfpga::speculated_iterations(1)]]
-  [[intelfpga::max_interleaving(4)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_interleaving(4)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   [[intelfpga::speculated_iterations(1)]]
   // expected-error@-1 {{duplicate Intel FPGA loop attribute 'speculated_iterations'}}
   [[intelfpga::loop_coalesce]]
-  [[intelfpga::speculated_iterations(2)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::speculated_iterations(2)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 
   [[intelfpga::ivdep]]
   // expected-warning@+2 {{ignoring redundant Intel FPGA loop attribute 'ivdep': safelen INF >= safelen INF}}
@@ -285,34 +265,28 @@ void woo() {
   int a[10];
   // no diagnostics are expected
   [[intelfpga::disable_loop_pipelining]]
-  [[intelfpga::loop_coalesce]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::loop_coalesce]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'disable_loop_pipelining' and 'max_interleaving' attributes are not compatible}}
   [[intelfpga::disable_loop_pipelining]]
-  [[intelfpga::max_interleaving(0)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
   [[intelfpga::speculated_iterations(0)]]
-  [[intelfpga::disable_loop_pipelining]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'disable_loop_pipelining' and 'max_concurrency' attributes are not compatible}}
   [[intelfpga::disable_loop_pipelining]]
-  [[intelfpga::max_concurrency(0)]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'disable_loop_pipelining' and 'ii' attributes are not compatible}}
   [[intelfpga::ii(10)]]
-  [[intelfpga::disable_loop_pipelining]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
   // expected-error@+1 {{'disable_loop_pipelining' and 'ivdep' attributes are not compatible}}
   [[intelfpga::disable_loop_pipelining]]
-  [[intelfpga::ivdep]]
-  for (int i = 0; i != 10; ++i)
-    a[i] = 0;
+  [[intelfpga::ivdep]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 template<int A, int B, int C>


### PR DESCRIPTION
This patch introduces the following loop attributes:
- loop_coalesce:
  Indicates that the loop nest should be coalesced into a single loop without
  affecting functionality
- speculated_iterations:
  Specifies the number of concurrent speculated iterations that will be in
  flight for a loop invocation
- disable_loop_pipelining:
  Disables pipelining of the loop data path, causing the loop to be executed
  serially
- max_interleaving:
  Places a maximum limit N on the number of interleaved invocations of an inner
  loop by an outer loop

Signed-off-by: Viktoria Maksimova <viktoria.maksimova@intel.com>