### PR TITLE
[CI] Allow builds without pre-downloaded OpenCL in configure.py

### DIFF
--- a/.github/workflows/linux_post_commit.yml
+++ b/.github/workflows/linux_post_commit.yml
@@ -1,9 +1,6 @@
 name: Linux Post Commit Checks
 
 on:
-  pull_request:
-    branches:
-      - sycl
   push:
     branches:
       - sycl

--- a/.github/workflows/linux_post_commit.yml
+++ b/.github/workflows/linux_post_commit.yml
@@ -1,6 +1,9 @@
 name: Linux Post Commit Checks
 
 on:
+  pull_request:
+    branches:
+      - sycl
   push:
     branches:
       - sycl

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -55,8 +55,6 @@ def do_configure(args):
         "-DLLVM_EXTERNAL_XPTI_SOURCE_DIR={}".format(xpti_dir),
         "-DLLVM_ENABLE_PROJECTS={}".format(llvm_enable_projects),
         "-DLIBCLC_TARGETS_TO_BUILD={}".format(libclc_targets_to_build),
-        "-DOpenCL_INCLUDE_DIR={}".format(ocl_header_dir),
-        "-DOpenCL_LIBRARY={}".format(icd_loader_lib),
         "-DSYCL_BUILD_PI_CUDA={}".format(sycl_build_pi_cuda),
         "-DLLVM_BUILD_TOOLS=ON",
         "-DSYCL_ENABLE_WERROR=ON",


### PR DESCRIPTION
Fixes incorrect merge conflict resolution for #1313.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>