### PR TITLE
[SYCL][NFC] Fix dependencies for SYCLLowerIR

### DIFF
--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -13,6 +13,7 @@ set( LLVM_LINK_COMPONENTS
   Option
   ScalarOpts
   Support
+  SYCLLowerIR
   TransformUtils
   Vectorize
   )

--- a/llvm/lib/SYCLLowerIR/LLVMBuild.txt
+++ b/llvm/lib/SYCLLowerIR/LLVMBuild.txt
@@ -15,6 +15,7 @@
 ;===------------------------------------------------------------------------===;
 
 [component_0]
-type = Group
+type = Library
 name = SYCLLowerIR
 parent = Libraries
+required_libraries = Core Support


### PR DESCRIPTION
Mark SYCLLowerIR as a library and add explicit dependencies of SYCLLowerIR on other LLVM libraries; and of clang on SYCLLowerIR.