### PR TITLE
[SPIR-V][NFC] Fix for building llvm-spirv with -DLLVM_LINK_LLVM_DYLIB=ON

### DIFF
--- a/llvm-spirv/tools/llvm-spirv/CMakeLists.txt
+++ b/llvm-spirv/tools/llvm-spirv/CMakeLists.txt
@@ -14,7 +14,7 @@ add_llvm_tool(llvm-spirv
   NO_INSTALL_RPATH
 )
 
-if (LLVM_SPIRV_BUILD_EXTERNAL)
+if (LLVM_SPIRV_BUILD_EXTERNAL OR LLVM_LINK_LLVM_DYLIB)
   target_link_libraries(llvm-spirv PRIVATE LLVMSPIRVLib)
 endif()
 


### PR DESCRIPTION
Explicitly link `llvm-spirv` with the `libLLVMSPIRVLib.a` static library even if building LLVM/clang with `-DLLVM_LINK_LLVM_DYLIB=ON` .
