### PR TITLE
[SYCL][CUDA] Fix CUDA plug-in build with enabled assertions

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -3162,7 +3162,7 @@ pi_result cuda_piextUSMHostAlloc(void **result_ptr, pi_context context,
   } catch (pi_result error) {
     result = error;
   }
-  assert(*result_ptr % alignment == 0);
+  assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0);
   return result;
 }
 
@@ -3181,7 +3181,7 @@ pi_result cuda_piextUSMDeviceAlloc(void **result_ptr, pi_context context,
   } catch (pi_result error) {
     result = error;
   }
-  assert(*result_ptr % alignment == 0);
+  assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0);
   return result;
 }
 
@@ -3201,7 +3201,7 @@ pi_result cuda_piextUSMSharedAlloc(void **result_ptr, pi_context context,
   } catch (pi_result error) {
     result = error;
   }
-  assert(*result_ptr % alignment == 0);
+  assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0);
   return result;
 }
 


### PR DESCRIPTION
The change fixes build error below for CUDA BE:
llvm.src/sycl/plugins/cuda/pi_cuda.cpp:3165:22: error: invalid operands of types 'void*' and 'pi_uint32 {aka unsigned int}' to binary 'operator%'
     assert(*result_ptr % alignment == 0);

Signed-off-by: Vladimir Lazarev <vladimir.lazarev@intel.com>