### PR TITLE
[Driver][SYCL][FPGA] generated dep files for AOT should be picked up …

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -255,7 +255,8 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
         SmallString<128> DepName(ArgName);
         llvm::sys::path::replace_extension(DepName, "d");
         FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
-          Args.MakeArgString(DepName), Args.MakeArgString(DepName)));
+                                         Args.MakeArgString(DepName),
+                                         Args.MakeArgString(DepName)));
       }
       if (createdReportName.empty()) {
         // Project report should be saved into CWD, so strip off any

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -232,20 +232,36 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
       ForeachExt = "aocr";
     }
 
+  StringRef createdReportName;
   for (auto *A : Args) {
-    // Any input file is assumed to have a dependency file associated
-    if (A->getOption().getKind() == Option::InputClass) {
-      SmallString<128> FN(A->getSpelling());
-      StringRef Ext(llvm::sys::path::extension(FN));
-      if (!Ext.empty()) {
-        types::ID Ty = getToolChain().LookupTypeForExtension(Ext.drop_front());
-        if (Ty == types::TY_INVALID)
-          continue;
-        if (types::isSrcFile(Ty)) {
-          llvm::sys::path::replace_extension(FN, "d");
-          FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
-              Args.MakeArgString(FN), Args.MakeArgString(FN)));
-        }
+    // Any input file is assumed to have a dependency file associated and
+    // the report folder can also be named based on the first input.
+    if (A->getOption().getKind() != Option::InputClass)
+      continue;
+    SmallString<128> ArgName(A->getSpelling());
+    StringRef Ext(llvm::sys::path::extension(ArgName));
+    if (Ext.empty())
+      continue;
+    types::ID Ty = getToolChain().LookupTypeForExtension(Ext.drop_front());
+    if (Ty == types::TY_INVALID)
+      continue;
+    if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
+      // Dependency files and the project report are created in CWD, so strip
+      // off any directory information if provided with the input file.
+      // TODO - Use temporary files for dependency file creation and
+      // usage with -fintelfpga.
+      ArgName = llvm::sys::path::filename(ArgName);
+      if (types::isSrcFile(Ty)) {
+        SmallString<128> DepName(ArgName);
+        llvm::sys::path::replace_extension(DepName, "d");
+        FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
+          Args.MakeArgString(DepName), Args.MakeArgString(DepName)));
+      }
+      if (createdReportName.empty()) {
+        // Project report should be saved into CWD, so strip off any
+        // directory information if provided with the input file.
+        llvm::sys::path::replace_extension(ArgName, "prj");
+        createdReportName = Args.MakeArgString(ArgName);
       }
     }
   }
@@ -270,26 +286,10 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
     const char * FolderName = Args.MakeArgString(FN);
     ReportOptArg += FolderName;
   } else {
-    // Output directory is based off of the first object name
-    for (Arg * Cur : Args) {
-      if (Cur->getOption().getKind() != Option::InputClass)
-        continue;
-      SmallString<128> ArgName = Cur->getSpelling();
-      StringRef Ext(llvm::sys::path::extension(ArgName));
-      if (Ext.empty())
-        continue;
-      types::ID Ty = getToolChain().LookupTypeForExtension(Ext.drop_front());
-      if (Ty == types::TY_INVALID)
-        continue;
-      if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
-        // Project report should be saved into CWD, so strip off any
-        // directory information if provided with the input file.
-        ArgName = llvm::sys::path::filename(ArgName);
-        llvm::sys::path::replace_extension(ArgName, "prj");
-        ReportOptArg += Args.MakeArgString(ArgName);
-        break;
-      }
-    }
+    // Output directory is based off of the first object name as captured
+    // above.
+    if (!createdReportName.empty())
+      ReportOptArg += createdReportName;
   }
   if (!ReportOptArg.empty())
     CmdArgs.push_back(C.getArgs().MakeArgString(

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -260,11 +260,13 @@
 // RUN: touch %t_dir/dummy1.o
 // RUN: touch %t_dir/dummy2.o
 // RUN: %clangxx -### -fsycl -fintelfpga %t_dir/dummy2.o %t_dir/dummy1.cpp  2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-REPORT-NAME %s
 // RUN: %clangxx -### -fsycl -fintelfpga %t_dir/dummy2.cpp %t_dir/dummy1.o  2>&1 \
-// RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-NAME %s
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-REPORT-NAME %s
 // RUN: %clang_cl -### -fsycl -fintelfpga %t_dir/dummy2.o %t_dir/dummy1.cpp 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-REPORT-NAME %s
 // RUN: %clang_cl -### -fsycl -fintelfpga %t_dir/dummy2.cpp %t_dir/dummy1.o 2>&1 \
-// RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-NAME %s
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-REPORT-NAME %s
 // CHK-FPGA-REPORT-NAME: aoc{{.*}} "-sycl"{{.*}} "-output-report-folder=dummy2.prj"
 
 /// -fintelfpga static lib (aoco)

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -253,6 +253,20 @@
 // CHK-FPGA-REPORT-OPT2: aoc{{.*}} "-sycl"{{.*}} "-dep-files=dummy.d" "-output-report-folder=dummy.prj"
 // CHK-FPGA-REPORT-OPT2-NOT: aoc{{.*}} "-sycl" {{.*}}[[OUTDIR]]{{.*}}
 
+/// -fintelfpga output report file should be based on first input (src/obj)
+// RUN: mkdir -p %t_dir
+// RUN: touch %t_dir/dummy1.cpp
+// RUN: touch %t_dir/dummy2.cpp
+// RUN: touch %t_dir/dummy1.o
+// RUN: touch %t_dir/dummy2.o
+// RUN: %clangxx -### -fsycl -fintelfpga %t_dir/dummy2.o %t_dir/dummy1.cpp  2>&1 \
+// RUN: %clangxx -### -fsycl -fintelfpga %t_dir/dummy2.cpp %t_dir/dummy1.o  2>&1 \
+// RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-NAME %s
+// RUN: %clang_cl -### -fsycl -fintelfpga %t_dir/dummy2.o %t_dir/dummy1.cpp 2>&1 \
+// RUN: %clang_cl -### -fsycl -fintelfpga %t_dir/dummy2.cpp %t_dir/dummy1.o 2>&1 \
+// RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-NAME %s
+// CHK-FPGA-REPORT-NAME: aoc{{.*}} "-sycl"{{.*}} "-output-report-folder=dummy2.prj"
+
 /// -fintelfpga static lib (aoco)
 // RUN:  echo "Dummy AOCO image" > %t.aoco
 // RUN:  echo "void foo() {}" > %t.c

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -243,14 +243,15 @@
 // CHK-FPGA-REPORT-OPT: aoc{{.*}} "-sycl" {{.*}} "-output-report-folder=[[OUTDIR]]{{/|\\\\}}file.prj"
 
 /// -fintelfpga output report file from dir/source
+/// check dependency file from dir/source
 // RUN: mkdir -p %t_dir
 // RUN: touch %t_dir/dummy.cpp
 // RUN: %clangxx -### -fsycl -fintelfpga %t_dir/dummy.cpp  2>&1 \
 // RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-OPT2 %s
 // RUN: %clang_cl -### -fsycl -fintelfpga %t_dir/dummy.cpp 2>&1 \
 // RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-OPT2 %s
-// CHK-FPGA-REPORT-OPT2: aoc{{.*}} "-sycl" {{.*}} "-output-report-folder=dummy.prj"
-// CHK-FPGA-REPORT-OPT2-NOT: aoc{{.*}} "-sycl" {{.*}} "-output-report-folder=[[OUTDIR]]{{.*}}"
+// CHK-FPGA-REPORT-OPT2: aoc{{.*}} "-sycl"{{.*}} "-dep-files=dummy.d" "-output-report-folder=dummy.prj"
+// CHK-FPGA-REPORT-OPT2-NOT: aoc{{.*}} "-sycl" {{.*}}[[OUTDIR]]{{.*}}
 
 /// -fintelfpga static lib (aoco)
 // RUN:  echo "Dummy AOCO image" > %t.aoco


### PR DESCRIPTION
…in CWD

When adding the .d files to be picked up by the aoc tool call, the generated
.d files are created in CWD when the input file is in CWD/dir/file.cpp.  This
was wrong where we assumed generation was in CWD/dir

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>