### PR TITLE
[SYCL]Resolve min/max conflict

### DIFF
--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -17,8 +17,6 @@
 // TODO Decide whether to mark functions with this attribute.
 #define __NOEXC /*noexcept*/
 
-#undef min
-#undef max
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 #ifdef __SYCL_DEVICE_ONLY__
@@ -532,7 +530,7 @@ detail::enable_if_t<detail::is_genfloat<T>::value, T> abs(T x) __NOEXC {
 
 // genfloat max (genfloat x, genfloat y)
 template <typename T>
-detail::enable_if_t<detail::is_genfloat<T>::value, T> max(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> (max)(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fmax_common<T>(x, y);
 }
 
@@ -541,13 +539,13 @@ detail::enable_if_t<detail::is_genfloat<T>::value, T> max(T x, T y) __NOEXC {
 // genfloath max (genfloath x, half y)
 template <typename T>
 detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
-max(T x, typename T::element_type y) __NOEXC {
+(max)(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_fmax_common<T>(x, T(y));
 }
 
 // genfloat min (genfloat x, genfloat y)
 template <typename T>
-detail::enable_if_t<detail::is_genfloat<T>::value, T> min(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T> (min)(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fmin_common<T>(x, y);
 }
 
@@ -556,7 +554,7 @@ detail::enable_if_t<detail::is_genfloat<T>::value, T> min(T x, T y) __NOEXC {
 // genfloath min (genfloath x, half y)
 template <typename T>
 detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
-min(T x, typename T::element_type y) __NOEXC {
+(min)(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_fmin_common<T>(x, T(y));
 }
 
@@ -768,60 +766,60 @@ detail::enable_if_t<detail::is_ugeninteger<T>::value, T> mad_sat(T a, T b,
 
 // igeninteger max (igeninteger x, igeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_igeninteger<T>::value, T> max(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> (max)(T x, T y) __NOEXC {
   return __sycl_std::__invoke_s_max<T>(x, y);
 }
 
 // ugeninteger max (ugeninteger x, ugeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_ugeninteger<T>::value, T> max(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> (max)(T x, T y) __NOEXC {
   return __sycl_std::__invoke_u_max<T>(x, y);
 }
 
 // igeninteger max (vigeninteger x, sigeninteger y)
 template <typename T>
 detail::enable_if_t<detail::is_vigeninteger<T>::value, T>
-max(T x, typename T::element_type y) __NOEXC {
+(max)(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_s_max<T>(x, T(y));
 }
 
 // vugeninteger max (vugeninteger x, sugeninteger y)
 template <typename T>
 detail::enable_if_t<detail::is_vugeninteger<T>::value, T>
-max(T x, typename T::element_type y) __NOEXC {
+(max)(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_u_max<T>(x, T(y));
 }
 
 // igeninteger min (igeninteger x, igeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_igeninteger<T>::value, T> min(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T> (min)(T x, T y) __NOEXC {
   return __sycl_std::__invoke_s_min<T>(x, y);
 }
 
 // ugeninteger min (ugeninteger x, ugeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_ugeninteger<T>::value, T> min(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T> (min)(T x, T y) __NOEXC {
   return __sycl_std::__invoke_u_min<T>(x, y);
 }
 
 // vigeninteger min (vigeninteger x, sigeninteger y)
 template <typename T>
 detail::enable_if_t<detail::is_vigeninteger<T>::value, T>
-min(T x, typename T::element_type y) __NOEXC {
+(min)(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_s_min<T>(x, T(y));
 }
 
 // vugeninteger min (vugeninteger x, sugeninteger y)
 template <typename T>
 detail::enable_if_t<detail::is_vugeninteger<T>::value, T>
-min(T x, typename T::element_type y) __NOEXC {
+(min)(T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_u_min<T>(x, T(y));
 }
 
 // geninteger mul_hi (geninteger x, geninteger y)
 template <typename T>
 detail::enable_if_t<detail::is_igeninteger<T>::value, T> mul_hi(T x,
-                                                                T y) __NOEXC {
+                                                               T y) __NOEXC {
   return __sycl_std::__invoke_s_mul_hi<T>(x, y);
 }
 

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -17,6 +17,8 @@
 // TODO Decide whether to mark functions with this attribute.
 #define __NOEXC /*noexcept*/
 
+#undef min
+#undef max
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -530,7 +530,7 @@ detail::enable_if_t<detail::is_genfloat<T>::value, T> abs(T x) __NOEXC {
 
 // genfloat max (genfloat x, genfloat y)
 template <typename T>
-detail::enable_if_t<detail::is_genfloat<T>::value, T> (max)(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T>(max)(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fmax_common<T>(x, y);
 }
 
@@ -766,7 +766,8 @@ detail::enable_if_t<detail::is_ugeninteger<T>::value, T> mad_sat(T a, T b,
 
 // igeninteger max (igeninteger x, igeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_igeninteger<T>::value, T> (max)(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T>(max)(T x,
+                                                              T y) __NOEXC {
   return __sycl_std::__invoke_s_max<T>(x, y);
 }
 

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -538,14 +538,14 @@ detail::enable_if_t<detail::is_genfloat<T>::value, T> (max)(T x, T y) __NOEXC {
 // genfloatd max (genfloatd x, double y)
 // genfloath max (genfloath x, half y)
 template <typename T>
-detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
-(max)(T x, typename T::element_type y) __NOEXC {
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>(max)(
+    T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_fmax_common<T>(x, T(y));
 }
 
 // genfloat min (genfloat x, genfloat y)
 template <typename T>
-detail::enable_if_t<detail::is_genfloat<T>::value, T> (min)(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_genfloat<T>::value, T>(min)(T x, T y) __NOEXC {
   return __sycl_std::__invoke_fmin_common<T>(x, y);
 }
 
@@ -553,8 +553,8 @@ detail::enable_if_t<detail::is_genfloat<T>::value, T> (min)(T x, T y) __NOEXC {
 // genfloatd min (genfloatd x, double y)
 // genfloath min (genfloath x, half y)
 template <typename T>
-detail::enable_if_t<detail::is_vgenfloat<T>::value, T>
-(min)(T x, typename T::element_type y) __NOEXC {
+detail::enable_if_t<detail::is_vgenfloat<T>::value, T>(min)(
+    T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_fmin_common<T>(x, T(y));
 }
 
@@ -772,54 +772,57 @@ detail::enable_if_t<detail::is_igeninteger<T>::value, T> (max)(T x, T y) __NOEXC
 
 // ugeninteger max (ugeninteger x, ugeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_ugeninteger<T>::value, T> (max)(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T>(max)(T x,
+                                                              T y) __NOEXC {
   return __sycl_std::__invoke_u_max<T>(x, y);
 }
 
 // igeninteger max (vigeninteger x, sigeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_vigeninteger<T>::value, T>
-(max)(T x, typename T::element_type y) __NOEXC {
+detail::enable_if_t<detail::is_vigeninteger<T>::value, T>(max)(
+    T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_s_max<T>(x, T(y));
 }
 
 // vugeninteger max (vugeninteger x, sugeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_vugeninteger<T>::value, T>
-(max)(T x, typename T::element_type y) __NOEXC {
+detail::enable_if_t<detail::is_vugeninteger<T>::value, T>(max)(
+    T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_u_max<T>(x, T(y));
 }
 
 // igeninteger min (igeninteger x, igeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_igeninteger<T>::value, T> (min)(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_igeninteger<T>::value, T>(min)(T x,
+                                                              T y) __NOEXC {
   return __sycl_std::__invoke_s_min<T>(x, y);
 }
 
 // ugeninteger min (ugeninteger x, ugeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_ugeninteger<T>::value, T> (min)(T x, T y) __NOEXC {
+detail::enable_if_t<detail::is_ugeninteger<T>::value, T>(min)(T x,
+                                                              T y) __NOEXC {
   return __sycl_std::__invoke_u_min<T>(x, y);
 }
 
 // vigeninteger min (vigeninteger x, sigeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_vigeninteger<T>::value, T>
-(min)(T x, typename T::element_type y) __NOEXC {
+detail::enable_if_t<detail::is_vigeninteger<T>::value, T>(min)(
+    T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_s_min<T>(x, T(y));
 }
 
 // vugeninteger min (vugeninteger x, sugeninteger y)
 template <typename T>
-detail::enable_if_t<detail::is_vugeninteger<T>::value, T>
-(min)(T x, typename T::element_type y) __NOEXC {
+detail::enable_if_t<detail::is_vugeninteger<T>::value, T>(min)(
+    T x, typename T::element_type y) __NOEXC {
   return __sycl_std::__invoke_u_min<T>(x, T(y));
 }
 
 // geninteger mul_hi (geninteger x, geninteger y)
 template <typename T>
 detail::enable_if_t<detail::is_igeninteger<T>::value, T> mul_hi(T x,
-                                                               T y) __NOEXC {
+                                                                T y) __NOEXC {
   return __sycl_std::__invoke_s_mul_hi<T>(x, y);
 }
 

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -18,8 +18,6 @@
 #include <limits>
 #include <type_traits>
 
-#undef min
-#undef max
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -585,11 +583,11 @@ struct RelConverter<
 };
 
 template <typename T> static constexpr T max_v() {
-  return std::numeric_limits<T>::max();
+  return (std::numeric_limits<T>::max)();
 }
 
 template <typename T> static constexpr T min_v() {
-  return std::numeric_limits<T>::min();
+  return (std::numeric_limits<T>::min)();
 }
 
 template <typename T> static constexpr T quiet_NaN() {

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -18,7 +18,6 @@
 #include <limits>
 #include <type_traits>
 
-
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -18,6 +18,9 @@
 #include <limits>
 #include <type_traits>
 
+#undef min
+#undef max
+
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -306,11 +306,11 @@ template <> struct numeric_limits<half> {
 
   static constexpr const float_round_style round_style = round_to_nearest;
 
-  static __SYCL_CONSTEXPR_ON_DEVICE const half (min)() noexcept {
+  static __SYCL_CONSTEXPR_ON_DEVICE const half(min)() noexcept {
     return SYCL_HLF_MIN;
   }
 
-  static __SYCL_CONSTEXPR_ON_DEVICE const half (max)() noexcept {
+  static __SYCL_CONSTEXPR_ON_DEVICE const half(max)() noexcept {
     return SYCL_HLF_MAX;
   }
 

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -25,6 +25,8 @@
 #else
 #define __SYCL_CONSTEXPR_ON_DEVICE
 #endif
+#undef min
+#undef max
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -25,8 +25,6 @@
 #else
 #define __SYCL_CONSTEXPR_ON_DEVICE
 #endif
-#undef min
-#undef max
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -308,11 +306,11 @@ template <> struct numeric_limits<half> {
 
   static constexpr const float_round_style round_style = round_to_nearest;
 
-  static __SYCL_CONSTEXPR_ON_DEVICE const half min() noexcept {
+  static __SYCL_CONSTEXPR_ON_DEVICE const half (min)() noexcept {
     return SYCL_HLF_MIN;
   }
 
-  static __SYCL_CONSTEXPR_ON_DEVICE const half max() noexcept {
+  static __SYCL_CONSTEXPR_ON_DEVICE const half (max)() noexcept {
     return SYCL_HLF_MAX;
   }
 

--- a/sycl/include/CL/sycl/intel/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/intel/group_algorithm.hpp
@@ -98,7 +98,7 @@ template <typename T, typename V> struct identity<T, intel::plus<V>> {
 };
 
 template <typename T, typename V> struct identity<T, intel::minimum<V>> {
-  static constexpr T value = std::numeric_limits<T>::max();
+  static constexpr T value = (std::numeric_limits<T>::max)();
 };
 
 template <typename T, typename V> struct identity<T, intel::maximum<V>> {

--- a/sycl/test/basic_tests/min_max_test.cpp
+++ b/sycl/test/basic_tests/min_max_test.cpp
@@ -1,12 +1,11 @@
 // REQUIRES: windows
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsyntax-only -Xclang -verify %s -I %sycl_include -Xclang
+// expected-no-diagnostics
 
 #include "windows.h"
 #include "CL/sycl.hpp"
 
 int main() {
-
-  sycl::device device{sycl::default_selector()};
   int tmp = min(1, 4);
   return 0;
 }

--- a/sycl/test/basic_tests/min_max_test.cpp
+++ b/sycl/test/basic_tests/min_max_test.cpp
@@ -3,6 +3,7 @@
 // expected-no-diagnostics
 
 #include "windows.h"
+
 #include "CL/sycl.hpp"
 
 int main() {

--- a/sycl/test/basic_tests/min_max_test.cpp
+++ b/sycl/test/basic_tests/min_max_test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: windows
-// RUN: %clangxx -fsyntax-only -Xclang -verify %s -I %sycl_include -Xclang
+// RUN: %clangxx -fsyntax-only -Xclang -verify %s -I %sycl_include
 // expected-no-diagnostics
 
 #include "windows.h"

--- a/sycl/test/basic_tests/min_max_test.cpp
+++ b/sycl/test/basic_tests/min_max_test.cpp
@@ -3,7 +3,7 @@
 
 int main() {
 
-sycl::device device{ sycl::default_selector()};
-int tmp = min(1,4);
-return 0;}
-
+  sycl::device device{sycl::default_selector()};
+  int tmp = min(1, 4);
+  return 0;
+}

--- a/sycl/test/basic_tests/min_max_test.cpp
+++ b/sycl/test/basic_tests/min_max_test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: windows
-// RUN: %clangxx -fsycl -fsycl-device-only -Xclang -verify %s -I %sycl_include
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify %s -I %sycl_include
 // expected-no-diagnostics
 
 #include "windows.h"

--- a/sycl/test/basic_tests/min_max_test.cpp
+++ b/sycl/test/basic_tests/min_max_test.cpp
@@ -1,0 +1,9 @@
+#include "windows.h"
+#include "CL/sycl.hpp"
+
+int main() {
+
+sycl::device device{ sycl::default_selector()};
+int tmp = min(1,4);
+return 0;}
+

--- a/sycl/test/basic_tests/min_max_test.cpp
+++ b/sycl/test/basic_tests/min_max_test.cpp
@@ -1,3 +1,6 @@
+// REQUIRES: windows
+// RUN: %clangxx -fsycl %s -o %t.out
+
 #include "windows.h"
 #include "CL/sycl.hpp"
 

--- a/sycl/test/basic_tests/min_max_test.cpp
+++ b/sycl/test/basic_tests/min_max_test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: windows
-// RUN: %clangxx -fsyntax-only -Xclang -verify %s -I %sycl_include
+// RUN: %clangxx -fsycl -fsycl-device-only -Xclang -verify %s -I %sycl_include
 // expected-no-diagnostics
 
 #include "windows.h"


### PR DESCRIPTION
Adding #undef macros to resolve conflict between definitions of the min
and max function in the CL/sycl.h and windows.h or another min and max
define.

Signed-off-by: Mochalova <anastasiya.mochalova@intel.com>