### PR TITLE
[Driver][SYCL][FPGA] Proper dependency output location when given /Fo…

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6792,12 +6792,12 @@ const char *Clang::getDependencyFileName(const ArgList &Args,
 
   if (Arg *OutputOpt =
           Args.getLastArg(options::OPT_o, options::OPT__SLASH_Fo)) {
-    SmallString<128> OutputFilename(OutputOpt->getValue());
-    if (llvm::sys::path::is_separator(OutputFilename.back()))
+    SmallString<128> OutputArgument(OutputOpt->getValue());
+    if (llvm::sys::path::is_separator(OutputArgument.back()))
       // If the argument is a directory, output to BaseName in that dir.
-      llvm::sys::path::append(OutputFilename, getBaseInputStem(Args, Inputs));
-    llvm::sys::path::replace_extension(OutputFilename, llvm::Twine('d'));
-    return Args.MakeArgString(OutputFilename);
+      llvm::sys::path::append(OutputArgument, getBaseInputStem(Args, Inputs));
+    llvm::sys::path::replace_extension(OutputArgument, llvm::Twine('d'));
+    return Args.MakeArgString(OutputArgument);
   }
 
   return Args.MakeArgString(Twine(getBaseInputStem(Args, Inputs)) + ".d");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6793,6 +6793,9 @@ const char *Clang::getDependencyFileName(const ArgList &Args,
   if (Arg *OutputOpt =
           Args.getLastArg(options::OPT_o, options::OPT__SLASH_Fo)) {
     SmallString<128> OutputFilename(OutputOpt->getValue());
+    if (llvm::sys::path::is_separator(OutputFilename.back()))
+      // If the argument is a directory, output to BaseName in that dir.
+      llvm::sys::path::append(OutputFilename, getBaseInputStem(Args, Inputs));
     llvm::sys::path::replace_extension(OutputFilename, llvm::Twine('d'));
     return Args.MakeArgString(OutputFilename);
   }

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -255,9 +255,9 @@
 /// -fintelfpga output dep file using -Fo<dir>
 // RUN: mkdir -p %t_dir
 // RUN: %clang_cl -### -c -fsycl -fintelfpga -Fo%t_dir/ %s 2>&1 \
-// RUN:  | FileCheck -check-prefix=CHK-FPGA-DEP-DIR %s
-// CHK-FPGA-DEP-DIR: clang{{.*}} "-dependency-file" "[[DEPFILE:.+\.d]]"
-// CHK-FPGA-DEP-DIR: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,{{.*}}.obj,[[DEPFILE]]"
+// RUN:  | FileCheck -DDEPDIR=%t_dir/ -check-prefix=CHK-FPGA-DEP-DIR %s
+// CHK-FPGA-DEP-DIR: clang{{.*}} "-dependency-file" "[[DEPDIR]][[DEPFILE:.+\.d]]"
+// CHK-FPGA-DEP-DIR: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,{{.*}}.obj,[[DEPDIR]][[DEPFILE]]"
 
 /// -fintelfpga static lib (aoco)
 // RUN:  echo "Dummy AOCO image" > %t.aoco

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -252,6 +252,13 @@
 // CHK-FPGA-REPORT-OPT2: aoc{{.*}} "-sycl" {{.*}} "-output-report-folder=dummy.prj"
 // CHK-FPGA-REPORT-OPT2-NOT: aoc{{.*}} "-sycl" {{.*}} "-output-report-folder=[[OUTDIR]]{{.*}}"
 
+/// -fintelfpga output dep file using -Fo<dir>
+// RUN: mkdir -p %t_dir
+// RUN: %clang_cl -### -c -fsycl -fintelfpga -Fo%t_dir/ %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-DEP-DIR %s
+// CHK-FPGA-DEP-DIR: clang{{.*}} "-dependency-file" "[[DEPFILE:.+\.d]]"
+// CHK-FPGA-DEP-DIR: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,{{.*}}.obj,[[DEPFILE]]"
+
 /// -fintelfpga static lib (aoco)
 // RUN:  echo "Dummy AOCO image" > %t.aoco
 // RUN:  echo "void foo() {}" > %t.c


### PR DESCRIPTION
…<dir>

When using /Fo<dir> the improper dependency file name was generated, causing
the bundle step to not be able to locate the dependency file when compiling
to object

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>