### PR TITLE
[SYCL][NFC] Fix compilation warnings

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -782,9 +782,9 @@ pi_result cuda_piextDeviceSelectBinary(pi_device device,
 }
 
 pi_result cuda_piextGetDeviceFunctionPointer(pi_device device,
-                                       pi_device_binary *binaries,
-                                       pi_uint32 num_binaries,
-                                       pi_device_binary *selected_binary) {
+                                             pi_program program,
+                                             const char *function_name,
+                                             pi_uint64 *function_pointer_ret) {
   cl::sycl::detail::pi::die("cuda_piextGetDeviceFunctionPointer not implemented");
   return {};
 }

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -834,7 +834,7 @@ pi_result OCL(piextUSMEnqueueMemset)(pi_queue queue, void *ptr, pi_int32 value,
 /// \param event is the event that represents this operation
 pi_result OCL(piextUSMEnqueueMemcpy)(pi_queue queue, pi_bool blocking,
                                      void *dst_ptr, const void *src_ptr,
-                                     pi_int32 size,
+                                     size_t size,
                                      pi_uint32 num_events_in_waitlist,
                                      const pi_event *events_waitlist,
                                      pi_event *event) {


### PR DESCRIPTION
Fix two compilation warnings:

```
.../sycl/plugins/cuda/pi_cuda.cpp: In function 'pi_result piPluginInit(pi_plugin*)':
.../sycl/plugins/cuda/pi_cuda.cpp:3491:73: error: cast between incompatible function types from 'pi_result (*)(pi_device, pi_device_binary_struct**, pi_uint32, pi_device_binary_struct**)' {aka '_pi_result (*)(_pi_device*, pi_device_binary_struct**, unsigned int, pi_device_binary_struct**)'} to 'pi_result (*)(pi_device, pi_program, const char*, pi_uint64*)' {aka '_pi_result (*)(_pi_device*, _pi_program*, const char*, long unsigned int*)'} [-Werror=cast-function-type]
   (PluginInit->PiFunctionTable).pi_api = (decltype(&::pi_api))(&cuda_api);
                                                                         ^
.../sycl/plugins/cuda/pi_cuda.cpp:3504:3: note: in expansion of macro '_PI_CL'
   _PI_CL(piextGetDeviceFunctionPointer, cuda_piextGetDeviceFunctionPointer)
   ^~~~~~
```

and


```
.../sycl/plugins/opencl/pi_opencl.cpp: In function 'pi_result piPluginInit(pi_plugin*)':
.../sycl/plugins/opencl/pi_opencl.cpp:1028:72: error: cast between incompatible function types from 'pi_result (*)(pi_queue, pi_bool, void*, const void*, pi_int32, pi_uint32, _pi_event* const*, _pi_event**)' {aka '_pi_result (*)(_pi_queue*, unsigned int, void*, const void*, int, unsigned int, _pi_event* const*, _pi_event**)'} to 'pi_result (*)(pi_queue, pi_bool, void*, const void*, size_t, pi_uint32, _pi_event* const*, _pi_event**)' {aka '_pi_result (*)(_pi_queue*, unsigned int, void*, const void*, long unsigned int, unsigned int, _pi_event* const*, _pi_event**)'} [-Werror=cast-function-type]
   (PluginInit->PiFunctionTable).pi_api = (decltype(&::pi_api))(&ocl_api);
                                                                        ^
.../sycl/plugins/opencl/pi_opencl.cpp:1120:3: note: in expansion of macro '_PI_CL'
   _PI_CL(piextUSMEnqueueMemcpy, OCL(piextUSMEnqueueMemcpy))
   ^~~~~~
```