### PR TITLE
[SYCL] remove float type functions in fallback library for fp64 complex

### DIFF
--- a/libdevice/fallback-complex-fp64.cpp
+++ b/libdevice/fallback-complex-fp64.cpp
@@ -313,9 +313,9 @@ double __complex__ __devicelib_cacos(double __complex__ z) {
   double __complex__ w =
       __devicelib_clog(z + __devicelib_csqrt(__sqr(z) - 1.0));
   if (__spirv_SignBitSet(z_imag))
-    return CMPLX(__spirv_ocl_fabs(__devicelib_cimagf(w)),
+    return CMPLX(__spirv_ocl_fabs(__devicelib_cimag(w)),
                  __spirv_ocl_fabs(__devicelib_creal(w)));
-  return CMPLX(__spirv_ocl_fabs(__devicelib_cimagf(w)),
+  return CMPLX(__spirv_ocl_fabs(__devicelib_cimag(w)),
                -__spirv_ocl_fabs(__devicelib_creal(w)));
 }
 


### PR DESCRIPTION
Signed-off-by: gejin <ge.jin@intel.com>
Fix a bug in fallback-complex-fp64.spv, we need to remove all float related code in the file. This bug hasn't led to serious problems in jit compilation but will be a potential block for AOT support.