### PR TITLE
[SPIR-V] Add most SPIR-V definitions to clang builtin lookup

### DIFF
--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -1817,6 +1817,7 @@ std::string Qualifiers::getAddrSpaceAsString(LangAS AS) {
   case LangAS::sycl_constant:
     return "__constant";
   case LangAS::opencl_generic:
+  case LangAS::sycl_generic:
     return "__generic";
   case LangAS::cuda_device:
     return "__device__";

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -467,6 +467,10 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
       Builder.defineMacro("CL_SYCL_LANGUAGE_VERSION", "121");
   }
 
+  if (LangOpts.DeclareSPIRVBuiltins) {
+    Builder.defineMacro("__SPIRV_BUILTIN_DECLARATIONS__");
+  }
+
   // Not "standard" per se, but available even with the -undef flag.
   if (LangOpts.AsmPreprocessor)
     Builder.defineMacro("__ASSEMBLER__");

--- a/clang/lib/Sema/SPIRVBuiltins.td
+++ b/clang/lib/Sema/SPIRVBuiltins.td
@@ -30,6 +30,10 @@ def SPIRVAll : Version<  0>;
 class AddressSpace<string _AS> {
   string Name = _AS;
 }
+// Default is important for the frontend as there is not necessarily
+// an automatic conversion from this address space to
+// the one it will be lowered to.
+// This file assumes it will get lowered to generic or private.
 def DefaultAS    : AddressSpace<"clang::LangAS::Default">;
 def PrivateAS    : AddressSpace<"clang::LangAS::sycl_private">;
 def GlobalAS     : AddressSpace<"clang::LangAS::sycl_global">;
@@ -267,19 +271,40 @@ class Builtin<string _Name, list<Type> _Signature, list<bit> _Attributes = Attr.
 
 // Helper to declare SPIR-V Core builtins.
 class SPVBuiltin<string _Name, list<Type> _Signature, list<bit> _Attributes = Attr.None> :
-Builtin<"__spirv_" # _Name, _Signature, _Attributes> {} 
+  Builtin<"__spirv_" # _Name, _Signature, _Attributes> {}
 
 // Helper to declare OpenCL SPIR-V extended set builtins.
 class OCLSPVBuiltin<string _Name, list<Type> _Signature, list<bit> _Attributes = Attr.None> :
-SPVBuiltin<"ocl_" # _Name, _Signature, _Attributes> {} 
+  SPVBuiltin<"ocl_" # _Name, _Signature, _Attributes> {}
+
+class ConstOCLSPVBuiltin<string _Name, list<Type> _Signature> :
+  OCLSPVBuiltin<_Name, _Signature, Attr.Const> {}
 
 //===----------------------------------------------------------------------===//
 //                 Definitions of types
 //===----------------------------------------------------------------------===//
 
+// OpenCL v1.0/1.2/2.0 s6.1.1: Built-in Scalar Data Types.
+def Bool      : IntType<"bool",   QualType<"BoolTy">, 1>;
+def TrueChar      : IntType<"char",      QualType<"CharTy", 0, 1>, 8>;
+def Char      : IntType<"schar",      QualType<"SignedCharTy", 0, 1>, 8>;
+def SChar     : IntType<"schar",     QualType<"SignedCharTy", 0, 1>, 8>;
+def UChar     : UIntType<"uchar",     QualType<"UnsignedCharTy">, 8>;
+def Short     : IntType<"short",     QualType<"ShortTy", 0, 1>, 16>;
+def UShort    : UIntType<"ushort",    QualType<"UnsignedShortTy">, 16>;
+def Int       : IntType<"int",       QualType<"IntTy", 0, 1>, 32>;
+def UInt      : UIntType<"uint",      QualType<"UnsignedIntTy">, 32>;
+def Long      : IntType<"long",      QualType<"LongTy", 0, 1>, 64>;
+def ULong     : UIntType<"ulong",     QualType<"UnsignedLongTy">, 64>;
 def Float     : FPType<"float",     QualType<"FloatTy">, 32>;
 def Double    : FPType<"double",    QualType<"DoubleTy">, 64>;
 def Half      : FPType<"half",      QualType<"Float16Ty">, 16>;
+def Void      : Type<"void",      QualType<"VoidTy">>;
+// FIXME: ensure this is portable...
+def Size      : Type<"size_t",    QualType<"getSizeType()">>;
+
+def Sampler               : Type<"sampler_t", QualType<"OCLSamplerTy">>;
+def Event                 : Type<"event_t", QualType<"OCLEventTy">>;
 
 //===----------------------------------------------------------------------===//
 //                 Definitions of gentype variants
@@ -287,14 +312,77 @@ def Half      : FPType<"half",      QualType<"Float16Ty">, 16>;
 
 // Vector width lists.
 def VecAndScalar: IntList<"VecAndScalar", [1, 2, 3, 4, 8, 16]>;
+def VecNoScalar : IntList<"VecNoScalar", [2, 3, 4, 8, 16]>;
+def Vec1        : IntList<"Vec1", [1]>;
+def Vec2        : IntList<"Vec2", [2]>;
+def Vec4        : IntList<"Vec4", [4]>;
+def Vec8        : IntList<"Vec8", [8]>;
+def Vec16       : IntList<"Vec16", [16]>;
+def Vec1234     : IntList<"Vec1234", [1, 2, 3, 4]>;
 
 // Type lists.
+def TLAll           : TypeList<[Char,  UChar, Short,  UShort, Int,  UInt, Long,  ULong, Float, Double, Half]>;
+def TLAllUnsigned   : TypeList<[UChar, UChar, UShort, UShort, UInt, UInt, ULong, ULong, UInt,  ULong,  UShort]>;
 def TLFloat         : TypeList<[Float, Double, Half]>;
+// FIXME: handle properly char (signed or unsigned depending on host)
+def TLSignedInts    : TypeList<[Char, Short, Int, Long]>;
+def TLUnsignedInts  : TypeList<[UChar, UShort, UInt, ULong]>;
 
+// Signed to Unsigned conversion
+// FIXME: handle properly char (signed or unsigned depending on host)
+def TLSToUSignedInts    : TypeList<[Char, Short, Int, Long]>;
+def TLSToUUnsignedInts  : TypeList<[UChar, UShort, UInt, ULong]>;
+
+def TLIntLongFloats : TypeList<[Int, UInt, Long, ULong, Float, Double, Half]>;
+
+// All unsigned integer types twice, to facilitate unsigned return types for e.g.
+// uchar abs(char) and
+// uchar abs(uchar).
+def TLAllUIntsTwice : TypeList<[UChar, UChar, UChar, UShort, UShort, UInt, UInt, ULong, ULong]>;
+
+def TLAllInts       : TypeList<[Char, UChar, Short, UShort, Int, UInt, Long, ULong]>;
+
+// GenType definitions for multiple base types (e.g. all floating point types,
+// or all integer types).
+// All types
+def AGenType1              : GenericType<"AGenType1", TLAll, Vec1>;
+def AGenTypeN              : GenericType<"AGenTypeN", TLAll, VecAndScalar>;
+def AGenTypeNNoScalar      : GenericType<"AGenTypeNNoScalar", TLAll, VecNoScalar>;
+// All integer
+def AIGenType1             : GenericType<"AIGenType1", TLAllInts, Vec1>;
+def AIGenTypeN             : GenericType<"AIGenTypeN", TLAllInts, VecAndScalar>;
+def AUIGenTypeN             : GenericType<"AUIGenTypeN", TLUnsignedInts, VecAndScalar>;
+def ASIGenTypeN             : GenericType<"ASIGenTypeN", TLSignedInts, VecAndScalar>;
+def AIGenTypeNNoScalar     : GenericType<"AIGenTypeNNoScalar", TLAllInts, VecNoScalar>;
+// All integer to unsigned
+def AI2UGenTypeN           : GenericType<"AI2UGenTypeN", TLAllUIntsTwice, VecAndScalar>;
+// Signed integer
+def SGenTypeN              : GenericType<"SGenTypeN", TLSignedInts, VecAndScalar>;
+// Unsigned integer
+def UGenTypeN              : GenericType<"UGenTypeN", TLUnsignedInts, VecAndScalar>;
 // Float
 def FGenTypeN              : GenericType<"FGenTypeN", TLFloat, VecAndScalar>;
+// (u)int, (u)long, and all floats
+def IntLongFloatGenType1   : GenericType<"IntLongFloatGenType1", TLIntLongFloats, Vec1>;
 
+// GenType definitions for every single base type (e.g. fp32 only).
+// Names are like: GenTypeFloatVecAndScalar.
+foreach Type = [Bool, Char, UChar, Short, UShort,
+                Int, UInt, Long, ULong,
+                Float, Double, Half] in {
+  foreach VecSizes = [VecAndScalar, VecNoScalar] in {
+    def "GenType" # Type # VecSizes :
+              GenericType<"GenType" # Type # VecSizes,
+                          TypeList<[Type]>, VecSizes>;
+  }
+}
 
+// GenType definitions for vec1234.
+foreach Type = [Float, Double, Half] in {
+  def "GenType" # Type # Vec1234 :
+              GenericType<"GenType" # Type # Vec1234,
+                          TypeList<[Type]>, Vec1234>;
+}
 
 //===----------------------------------------------------------------------===//
 //                 Definitions of builtins
@@ -303,5 +391,513 @@ def FGenTypeN              : GenericType<"FGenTypeN", TLFloat, VecAndScalar>;
 
 // 2.1. Math extended instructions
 
-def : OCLSPVBuiltin<"acos", [FGenTypeN, FGenTypeN], Attr.Const>;
 
+foreach name  = ["acos", "acosh", "acospi",
+                 "asin", "asinh", "asinpi",
+                 "atan", "atanh", "atanpi",
+                 "cbrt", "ceil", "cos",
+                 "cosh", "cospi",
+                 "erfc", "erf",
+                 "exp", "exp2", "exp10",
+                 "expm1", "fabs", "floor", "lgamma",
+                 "log", "log2", "log10", "log1p", "logb",
+                 "rint", "round", "rsqrt",
+                 "sin", "sinh", "sinpi",
+                 "sqrt",
+                 "tan", "tanh", "tanpi",
+                 "tgamma", "trunc"] in {
+  def : ConstOCLSPVBuiltin<name, [FGenTypeN, FGenTypeN]>;
+}
+
+foreach name  = ["fmax", "fmin", "fmod",
+                 "atan2", "atan2pi",
+                 "copysign", "fdim", "hypot",
+                 "maxmag", "minmag", "nextafter",
+                 "pow", "powr", "remainder"] in {
+  def : ConstOCLSPVBuiltin<name, [FGenTypeN, FGenTypeN, FGenTypeN]>;
+}
+
+foreach name = ["fma", "mad"] in {
+  def : ConstOCLSPVBuiltin<name, [FGenTypeN, FGenTypeN, FGenTypeN, FGenTypeN]>;
+}
+
+foreach AS = [GlobalAS, LocalAS, PrivateAS, GenericAS, DefaultAS] in {
+  foreach name = ["fract", "modf"] in {
+    def : OCLSPVBuiltin<name, [FGenTypeN, FGenTypeN, PointerType<FGenTypeN, AS>]>;
+  }
+
+  foreach name = ["frexp", "lgamma_r"] in {
+    foreach Type = [GenTypeFloatVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeHalfVecAndScalar] in {
+      def : OCLSPVBuiltin<name, [Type, Type, PointerType<GenTypeIntVecAndScalar, AS>]>;
+    }
+  }
+}
+
+foreach name = ["ilogb"] in {
+  def : ConstOCLSPVBuiltin<name, [GenTypeIntVecAndScalar, GenTypeFloatVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeIntVecAndScalar, GenTypeDoubleVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeIntVecAndScalar, GenTypeHalfVecAndScalar]>;
+}
+
+foreach name = ["ldexp"] in {
+  foreach Type = [GenTypeFloatVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeHalfVecAndScalar] in {
+    def : ConstOCLSPVBuiltin<name, [Type, Type, GenTypeIntVecAndScalar]>;
+    def : ConstOCLSPVBuiltin<name, [Type, Type, GenTypeUIntVecAndScalar]>;
+  }
+}
+
+foreach name = ["nan"] in {
+  def : ConstOCLSPVBuiltin<name, [GenTypeHalfVecAndScalar, GenTypeShortVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeHalfVecAndScalar, GenTypeUShortVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeFloatVecAndScalar, GenTypeIntVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeFloatVecAndScalar, GenTypeUIntVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeDoubleVecAndScalar, GenTypeLongVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeDoubleVecAndScalar, GenTypeULongVecAndScalar]>;
+}
+
+foreach name = ["pown"] in {
+  def : ConstOCLSPVBuiltin<name, [GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar, GenTypeIntVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeDoubleVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeIntVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeHalfVecAndScalar, GenTypeHalfVecAndScalar, GenTypeIntVecAndScalar]>;
+}
+
+foreach AS = [GlobalAS, LocalAS, PrivateAS, GenericAS, DefaultAS] in {
+  foreach name = ["remquo"] in {
+    foreach Type = [GenTypeFloatVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeHalfVecAndScalar] in {
+      def : OCLSPVBuiltin<name, [Type, Type, Type, PointerType<GenTypeIntVecAndScalar, AS>]>;
+    }
+  }
+}
+
+foreach name = ["rootn"] in {
+  def : ConstOCLSPVBuiltin<name, [GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar, GenTypeIntVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeDoubleVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeIntVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeHalfVecAndScalar, GenTypeHalfVecAndScalar, GenTypeIntVecAndScalar]>;
+}
+
+foreach AS = [GlobalAS, LocalAS, PrivateAS, GenericAS, DefaultAS] in {
+  foreach name = ["sincos"] in {
+    def : OCLSPVBuiltin<name, [FGenTypeN, FGenTypeN, PointerType<FGenTypeN, AS>]>;
+  }
+}
+
+foreach name = ["half_cos",
+                "half_exp", "half_exp2", "half_exp10",
+                "half_log", "half_log2", "half_log10",
+                "half_recip", "half_rsqrt",
+                "half_sin", "half_sqrt", "half_tan"] in {
+  def : ConstOCLSPVBuiltin<name, [GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar]>;
+}
+
+foreach name = ["half_divide", "half_powr"] in {
+  def : ConstOCLSPVBuiltin<name, [GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar]>;
+}
+
+foreach name = ["native_cos", "native_exp", "native_exp2", "native_exp10",
+                "native_log", "native_log2", "native_log10",
+                "native_recip", "native_rsqrt",
+                "native_sin", "native_sqrt", "native_tan"] in {
+  def : ConstOCLSPVBuiltin<name, [FGenTypeN, FGenTypeN]>;
+}
+
+foreach name = ["native_divide", "native_powr"] in {
+  def : ConstOCLSPVBuiltin<name, [FGenTypeN, FGenTypeN, FGenTypeN]>;
+}
+
+// 2.2. Integer instructions
+
+foreach name = ["clz", "ctz", "popcount"] in {
+  def : ConstOCLSPVBuiltin<name, [AIGenTypeN, AIGenTypeN]>;
+}
+
+def : ConstOCLSPVBuiltin<"rotate", [AIGenTypeN, AIGenTypeN, AIGenTypeN]>;
+
+def : ConstOCLSPVBuiltin<"s_abs", [AUIGenTypeN, ASIGenTypeN]>;
+
+def : ConstOCLSPVBuiltin<"s_abs_diff", [AUIGenTypeN, ASIGenTypeN, ASIGenTypeN]>;
+
+foreach name = ["s_add_sat",
+                "s_hadd", "s_rhadd",
+                "s_max", "s_min",
+                "s_mul_hi", "s_sub_sat"] in {
+  def : ConstOCLSPVBuiltin<name, [ASIGenTypeN, ASIGenTypeN, ASIGenTypeN]>;
+}
+
+foreach name = ["s_clamp", "s_mad_hi", "s_mad_sat"] in {
+ def : ConstOCLSPVBuiltin<name, [ASIGenTypeN, ASIGenTypeN, ASIGenTypeN, ASIGenTypeN]>;
+}
+
+foreach name = ["s_upsample"] in {
+  def : ConstOCLSPVBuiltin<name, [GenTypeShortVecAndScalar, GenTypeCharVecAndScalar, GenTypeUCharVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeIntVecAndScalar, GenTypeShortVecAndScalar, GenTypeUShortVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeLongVecAndScalar, GenTypeIntVecAndScalar, GenTypeUIntVecAndScalar]>;
+}
+
+def : ConstOCLSPVBuiltin<"s_mad24", [GenTypeIntVecAndScalar, GenTypeIntVecAndScalar, GenTypeIntVecAndScalar, GenTypeIntVecAndScalar]>;
+
+def : ConstOCLSPVBuiltin<"s_mul24", [GenTypeIntVecAndScalar, GenTypeIntVecAndScalar, GenTypeIntVecAndScalar]>;
+
+foreach name = ["u_add_sat", "u_hadd",
+                "u_rhadd",
+                "u_max", "u_min", "u_sub_sat",
+                "u_abs_diff", "u_mul_hi"] in {
+  def : ConstOCLSPVBuiltin<name, [AUIGenTypeN, AUIGenTypeN, AUIGenTypeN]>;
+}
+
+foreach name = ["u_clamp", "u_mad_sat", "u_mad_hi"] in {
+  def : ConstOCLSPVBuiltin<name, [AUIGenTypeN, AUIGenTypeN, AUIGenTypeN, AUIGenTypeN]>;
+}
+
+foreach name = ["u_upsample"] in {
+  def : ConstOCLSPVBuiltin<name, [GenTypeUShortVecAndScalar, GenTypeUCharVecAndScalar, GenTypeUCharVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeUIntVecAndScalar, GenTypeUShortVecAndScalar, GenTypeUShortVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeULongVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar]>;
+}
+
+def : ConstOCLSPVBuiltin<"u_mad24", [GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar]>;
+
+def : ConstOCLSPVBuiltin<"u_mul24", [GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar, GenTypeUIntVecAndScalar]>;
+
+def : ConstOCLSPVBuiltin<"u_abs", [AUIGenTypeN, AUIGenTypeN]>;
+
+// 2.3. Common instructions
+
+foreach name = ["degrees", "radians", "sign"] in {
+  def : ConstOCLSPVBuiltin<name, [FGenTypeN, FGenTypeN]>;
+}
+
+foreach name = ["fmax_common", "fmin_common", "step"] in {
+  def : ConstOCLSPVBuiltin<name, [FGenTypeN, FGenTypeN, FGenTypeN]>;
+}
+
+foreach name = ["fclamp", "mix", "smoothstep"] in {
+  def : ConstOCLSPVBuiltin<name, [FGenTypeN, FGenTypeN, FGenTypeN, FGenTypeN]>;
+}
+
+// 2.4. Geometric instructions
+
+foreach name = ["cross"] in {
+  foreach VSize = [3, 4] in {
+    def : ConstOCLSPVBuiltin<name, [VectorType<Float, VSize>, VectorType<Float, VSize>, VectorType<Float, VSize>]>;
+    def : ConstOCLSPVBuiltin<name, [VectorType<Double, VSize>, VectorType<Double, VSize>, VectorType<Double, VSize>]>;
+    def : ConstOCLSPVBuiltin<name, [VectorType<Half, VSize>, VectorType<Half, VSize>, VectorType<Half, VSize>]>;
+  }
+}
+
+foreach name = ["distance"] in {
+  def : ConstOCLSPVBuiltin<name, [Float, GenTypeFloatVec1234, GenTypeFloatVec1234]>;
+  def : ConstOCLSPVBuiltin<name, [Double, GenTypeDoubleVec1234, GenTypeDoubleVec1234]>;
+  def : ConstOCLSPVBuiltin<name, [Half, GenTypeHalfVec1234, GenTypeHalfVec1234]>;
+}
+
+foreach name = ["length"] in {
+  def : ConstOCLSPVBuiltin<name, [Float, GenTypeFloatVec1234]>;
+  def : ConstOCLSPVBuiltin<name, [Double, GenTypeDoubleVec1234]>;
+  def : ConstOCLSPVBuiltin<name, [Half, GenTypeHalfVec1234]>;
+}
+
+foreach name = ["normalize"] in {
+  def : ConstOCLSPVBuiltin<name, [GenTypeFloatVec1234, GenTypeFloatVec1234]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeDoubleVec1234, GenTypeDoubleVec1234]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeHalfVec1234, GenTypeHalfVec1234]>;
+}
+
+def : ConstOCLSPVBuiltin<"fast_distance", [Float, GenTypeFloatVec1234, GenTypeFloatVec1234]>;
+
+def : ConstOCLSPVBuiltin<"fast_length", [Float, GenTypeFloatVec1234]>;
+
+def : ConstOCLSPVBuiltin<"fast_normalize", [GenTypeFloatVec1234, GenTypeFloatVec1234]>;
+
+// 2.5. Relational instructions
+
+def : ConstOCLSPVBuiltin<"bitselect", [AGenTypeN, AGenTypeN, AGenTypeN, AGenTypeN]>;
+
+foreach name = ["select"] in {
+  def : ConstOCLSPVBuiltin<name, [SGenTypeN, SGenTypeN, SGenTypeN, SGenTypeN]>;
+  def : ConstOCLSPVBuiltin<name, [SGenTypeN, SGenTypeN, SGenTypeN, UGenTypeN]>;
+  def : ConstOCLSPVBuiltin<name, [UGenTypeN, UGenTypeN, UGenTypeN, UGenTypeN]>;
+  def : ConstOCLSPVBuiltin<name, [UGenTypeN, UGenTypeN, UGenTypeN, SGenTypeN]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar, GenTypeUIntVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeDoubleVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeULongVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeHalfVecAndScalar, GenTypeHalfVecAndScalar, GenTypeHalfVecAndScalar, GenTypeUShortVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar, GenTypeIntVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeDoubleVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeLongVecAndScalar]>;
+  def : ConstOCLSPVBuiltin<name, [GenTypeHalfVecAndScalar, GenTypeHalfVecAndScalar, GenTypeHalfVecAndScalar, GenTypeShortVecAndScalar]>;
+}
+
+// 2.6. Vector Data Load and Store instructions
+
+foreach VSize = [2, 3, 4, 8, 16] in {
+  foreach AS = [GlobalAS, LocalAS, PrivateAS, ConstantAS, GenericAS, DefaultAS] in {
+    foreach Ty = TLAll.List in {
+      foreach name = ["vloadn"] in {
+        def : OCLSPVBuiltin<name # "_R" # Ty.Name # VSize, [VectorType<Ty, VSize>, Size, PointerType<ConstType<Ty>, AS>]>;
+      }
+    }
+    foreach name = ["vloada_halfn", "vload_halfn"] in {
+      def : OCLSPVBuiltin<name, [VectorType<Float, VSize>, Size, PointerType<ConstType<Half>, AS>]>;
+    }
+  }
+  foreach AS = [GlobalAS, LocalAS, PrivateAS, GenericAS, DefaultAS] in {
+    foreach Ty = TLAll.List in {
+      foreach name = ["vstoren"] in {
+        def : OCLSPVBuiltin<name, [Void, VectorType<Ty, VSize>, Size, PointerType<ConstType<Ty>, AS>]>;
+      }
+    }
+    foreach rnd = ["", "_rte", "_rtz", "_rtp", "_rtn"] in {
+      foreach name = ["vstore_halfn" # rnd, "vstorea_halfn" # rnd] in {
+        def : OCLSPVBuiltin<name, [Void, VectorType<Float, VSize>, Size, PointerType<Half, AS>]>;
+        def : OCLSPVBuiltin<name, [Void, VectorType<Double, VSize>, Size, PointerType<Half, AS>]>;
+      }
+    }
+  }
+}
+
+foreach AS = [GlobalAS, LocalAS, PrivateAS, ConstantAS, GenericAS, DefaultAS] in {
+  foreach name = ["vload_half"] in {
+    def : OCLSPVBuiltin<name, [Float, Size, PointerType<ConstType<Half>, AS>]>;
+  }
+}
+
+foreach AS = [GlobalAS, LocalAS, PrivateAS, GenericAS, DefaultAS] in {
+  foreach rnd = ["", "_rte", "_rtz", "_rtp", "_rtn"] in {
+    foreach name = ["vstore_half" # rnd] in {
+      def : OCLSPVBuiltin<name, [Void, Float, Size, PointerType<Half, AS>]>;
+      def : OCLSPVBuiltin<name, [Void, Double, Size, PointerType<Half, AS>]>;
+    }
+  }
+}
+
+// 2.7. Miscellaneous Vector instructions
+
+foreach VSize1 = [Vec2, Vec4, Vec8, Vec16] in {
+  foreach VSize2 = [Vec2, Vec4, Vec8, Vec16] in {
+    def : OCLSPVBuiltin<"shuffle", [GenericType<"TLAll" # VSize1.Name, TLAll, VSize1>,
+                              GenericType<"TLAll" # VSize2.Name, TLAll, VSize2>,
+                              GenericType<"TLAllUnsigned" # VSize1.Name, TLAllUnsigned, VSize1>],
+                  Attr.Const>;
+  }
+}
+foreach VSize1 = [Vec2, Vec4, Vec8, Vec16] in {
+  foreach VSize2 = [Vec2, Vec4, Vec8, Vec16] in {
+    def : OCLSPVBuiltin<"shuffle2", [GenericType<"TLAll" # VSize1.Name, TLAll, VSize1>,
+                               GenericType<"TLAll" # VSize2.Name, TLAll, VSize2>,
+                               GenericType<"TLAll" # VSize2.Name, TLAll, VSize2>,
+                               GenericType<"TLAllUnsigned" # VSize1.Name, TLAllUnsigned, VSize1>],
+                  Attr.Const>;
+  }
+}
+
+// 2.8. Misc instructions
+
+let IsVariadic = 1 in {
+  foreach name = ["printf"] in {
+    def : OCLSPVBuiltin<name, [Int, PointerType<ConstType<TrueChar>, ConstantAS>]>;
+  }
+}
+
+foreach name = ["prefetch"] in {
+  def : OCLSPVBuiltin<name, [Void, PointerType<ConstType<AGenTypeN>, GlobalAS>, Size]>;
+}
+
+
+// Core builtins
+
+// 3.32.8. Memory Instructions
+
+foreach name = ["GenericPtrMemSemantics"] in {
+  def : SPVBuiltin<name, [Int, PointerType<ConstType<Int>, GenericAS>], Attr.Const>;
+}
+
+// 3.32.11. Conversion Instructions
+
+foreach IType = [UChar, UShort, UInt, ULong] in {
+  foreach FType = [Float, Double, Half] in {
+    def : SPVBuiltin<"ConvertFToU_R" # IType.Name, [IType, FType], Attr.Const>;
+    def : SPVBuiltin<"ConvertUToF_R" # FType.Name, [FType, IType], Attr.Const>;
+    foreach v = [2, 3, 4, 8, 16] in {
+      def : SPVBuiltin<"ConvertFToU_R" # IType.Name # v,
+                       [VectorType<IType, v>, VectorType<FType, v>],
+                       Attr.Const>;
+      def : SPVBuiltin<"ConvertUToF_R" # FType.Name # v,
+                       [VectorType<FType, v>, VectorType<IType, v>],
+                       Attr.Const>;
+    }
+  }
+}
+
+foreach IType = [Char, Short, Int, Long] in {
+  foreach FType = [Float, Double, Half] in {
+    def : SPVBuiltin<"ConvertFToS_R" # IType.Name, [IType, FType], Attr.Const>;
+    def : SPVBuiltin<"ConvertSToF_R" # FType.Name, [FType, IType], Attr.Const>;
+    foreach v = [2, 3, 4, 8, 16] in {
+      def : SPVBuiltin<"ConvertFToS_R" # IType.Name # v,
+                       [VectorType<IType, v>, VectorType<FType, v>],
+                       Attr.Const>;
+      def : SPVBuiltin<"ConvertSToF_R" # FType.Name # v,
+                       [VectorType<FType, v>, VectorType<IType, v>],
+                       Attr.Const>;
+    }
+  }
+}
+
+foreach InType = TLAll.List in {
+  foreach OutType = TLUnsignedInts.List in {
+    if !ne(OutType.ElementSize, InType.ElementSize) then {
+      def : SPVBuiltin<"UConvert_R" # OutType.Name, [OutType, InType], Attr.Const>;
+      foreach v = [2, 3, 4, 8, 16] in {
+        def : SPVBuiltin<"UConvert_R" # OutType.Name # v,
+                         [VectorType<OutType, v>, VectorType<InType, v>],
+                         Attr.Const>;
+      }
+    }
+  }
+  foreach OutType = TLSignedInts.List in {
+    if !ne(OutType.ElementSize, InType.ElementSize) then {
+      def : SPVBuiltin<"SConvert_R" # OutType.Name, [OutType, InType], Attr.Const>;
+      foreach v = [2, 3, 4, 8, 16] in {
+        def : SPVBuiltin<"SConvert_R" # OutType.Name # v,
+                         [VectorType<OutType, v>, VectorType<InType, v>],
+                         Attr.Const>;
+      }
+    }
+  }
+}
+
+foreach InType = TLFloat.List in {
+  foreach OutType = TLFloat.List in {
+    if !ne(OutType.ElementSize, InType.ElementSize) then {
+      def : SPVBuiltin<"FConvert_R" # OutType.Name, [OutType, InType], Attr.Const>;
+      foreach v = [2, 3, 4, 8, 16] in {
+        def : SPVBuiltin<"FConvert_R" # OutType.Name # v,
+                         [VectorType<OutType, v>, VectorType<InType, v>],
+                         Attr.Const>;
+      }
+    }
+  }
+}
+
+foreach InType = TLSignedInts.List in {
+  foreach OutType = TLUnsignedInts.List in {
+    def : SPVBuiltin<"SatConvertSToU_R" # OutType.Name, [OutType, InType], Attr.Const>;
+    foreach v = [2, 3, 4, 8, 16] in {
+      def : SPVBuiltin<"SatConvertSToU_R" # OutType.Name # v,
+                       [VectorType<OutType, v>, VectorType<InType, v>],
+                       Attr.Const>;
+    }
+  }
+}
+
+foreach InType = TLUnsignedInts.List in {
+  foreach OutType = TLSignedInts.List in {
+    def : SPVBuiltin<"SatConvertUToS_R" # OutType.Name, [OutType, InType], Attr.Const>;
+    foreach v = [2, 3, 4, 8, 16] in {
+      def : SPVBuiltin<"SatConvertUToS_R" # OutType.Name # v,
+                       [VectorType<OutType, v>, VectorType<InType, v>],
+                       Attr.Const>;
+    }
+  }
+}
+
+foreach AS = [GlobalAS, LocalAS, PrivateAS] in {
+  def : SPVBuiltin<"GenericCastToPtrExplicit", [PointerType<Char, AS>, PointerType<Char, GenericAS>], Attr.Const>;
+}
+
+foreach Type = TLFloat.List in {
+  foreach v = [2, 3, 4, 8, 16] in {
+    def : SPVBuiltin<"VectorTimesScalar", [VectorType<Type, v>, VectorType<Type, v>, Type]>;
+  }
+}
+
+foreach name = ["Dot"] in {
+  def : SPVBuiltin<name, [Float, GenTypeFloatVecNoScalar, GenTypeFloatVecNoScalar], Attr.Const>;
+  def : SPVBuiltin<name, [Double, GenTypeDoubleVecNoScalar, GenTypeDoubleVecNoScalar], Attr.Const>;
+  def : SPVBuiltin<name, [Half, GenTypeHalfVecNoScalar, GenTypeHalfVecNoScalar], Attr.Const>;
+}
+
+foreach name = ["Any", "All"] in {
+  def : SPVBuiltin<name, [Bool, GenTypeBoolVecAndScalar], Attr.Const>;
+}
+
+foreach name = ["IsNan", "IsInf", "IsFinite", "IsNormal", "SignBitSet"] in {
+  def : SPVBuiltin<name, [GenTypeBoolVecAndScalar, GenTypeFloatVecAndScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeBoolVecAndScalar, GenTypeDoubleVecAndScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeBoolVecAndScalar, GenTypeHalfVecAndScalar], Attr.Const>;
+}
+
+foreach name = ["LessOrGreater",
+                "Ordered", "Unordered",
+                "FOrdEqual", "FUnordEqual",
+                "FOrdNotEqual", "FUnordNotEqual",
+                "FOrdLessThan", "FUnordLessThan",
+                "FOrdGreaterThan", "FUnordGreaterThan",
+                "FOrdLessThanEqual", "FUnordLessThanEqual",
+                "FOrdGreaterThanEqual", "FUnordGreaterThanEqual"] in {
+  def : SPVBuiltin<name, [GenTypeBoolVecAndScalar, GenTypeFloatVecAndScalar, GenTypeFloatVecAndScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeBoolVecAndScalar, GenTypeDoubleVecAndScalar, GenTypeDoubleVecAndScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeBoolVecAndScalar, GenTypeHalfVecAndScalar, GenTypeHalfVecAndScalar], Attr.Const>;
+}
+
+foreach name = ["BitCount"] in {
+  def : SPVBuiltin<name, [AIGenTypeN, AIGenTypeN], Attr.Const>;
+}
+
+// 3.32.20. Barrier Instructions
+
+foreach name = ["ControlBarrier"] in {
+  // TODO: Allow enum flags instead of UInt ?
+  // TODO: We should enforce that the UInt must be a literal.
+  def : SPVBuiltin<name, [Void, UInt, UInt, UInt], Attr.Convergent>;
+}
+
+foreach name = ["MemoryBarrier"] in {
+  // TODO: Allow enum flags instead of UInt ?
+  // TODO: We should enforce that the UInt must be a literal.
+  def : SPVBuiltin<name, [Void, UInt, UInt]>;
+}
+
+// 3.32.21. Group and Subgroup Instructions
+
+foreach name = ["GroupAsyncCopy"] in {
+  // TODO: Allow enum flags instead of UInt ?
+  // TODO: We should enforce that the UInt must be a literal.
+  def : SPVBuiltin<name, [Event, UInt, PointerType<AGenTypeN, LocalAS>, PointerType<ConstType<AGenTypeN>, GlobalAS>, Size, Size, Event], Attr.Convergent>;
+  def : SPVBuiltin<name, [Event, UInt, PointerType<AGenTypeN, GlobalAS>, PointerType<ConstType<AGenTypeN>, LocalAS>, Size, Size, Event], Attr.Convergent>;
+}
+
+foreach name = ["GroupWaitEvents"] in {
+  def : SPVBuiltin<name, [Void, UInt, Int, PointerType<Event, DefaultAS>], Attr.Convergent>;
+  def : SPVBuiltin<name, [Void, UInt, Int, PointerType<Event, PrivateAS>], Attr.Convergent>;
+  def : SPVBuiltin<name, [Void, UInt, Int, PointerType<Event, GenericAS>], Attr.Convergent>;
+}
+
+foreach name = ["GroupAll", "GroupAny"] in {
+  def : SPVBuiltin<name, [Bool, UInt, Bool], Attr.Convergent>;
+}
+
+foreach name = ["GroupBroadcast"] in {
+  foreach IDType = TLAllInts.List in {
+    def : SPVBuiltin<name, [AGenType1, UInt, AGenType1, IDType], Attr.Convergent>;
+    def : SPVBuiltin<name, [AGenType1, UInt, AGenType1, VectorType<IDType, 2>], Attr.Convergent>;
+    def : SPVBuiltin<name, [AGenType1, UInt, AGenType1, VectorType<IDType, 3>], Attr.Convergent>;
+    def : SPVBuiltin<name, [Bool, UInt, Bool, IDType], Attr.Convergent>;
+    def : SPVBuiltin<name, [Bool, UInt, Bool, VectorType<IDType, 2>], Attr.Convergent>;
+    def : SPVBuiltin<name, [Bool, UInt, Bool, VectorType<IDType, 3>], Attr.Convergent>;
+  }
+}
+
+foreach name = ["GroupIAdd"] in {
+  def : SPVBuiltin<name, [AIGenTypeN, UInt, UInt, AIGenTypeN], Attr.Convergent>;
+}
+
+foreach name = ["GroupFAdd", "GroupFMin", "GroupFMax"] in {
+  def : SPVBuiltin<name, [FGenTypeN, UInt, UInt, FGenTypeN], Attr.Convergent>;
+}
+
+foreach name = ["GroupUMin", "GroupUMax"] in {
+  def : SPVBuiltin<name, [AUIGenTypeN, UInt, UInt, AUIGenTypeN], Attr.Convergent>;
+}
+
+foreach name = ["GroupSMin", "GroupSMax"] in {
+  def : SPVBuiltin<name, [ASIGenTypeN, UInt, UInt, ASIGenTypeN], Attr.Convergent>;
+}

--- a/clang/test/Preprocessor/spirv-macro.cpp
+++ b/clang/test/Preprocessor/spirv-macro.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 %s -E -dM | FileCheck %s
+// RUN: %clang_cc1 %s  -fdeclare-spirv-builtins  -E -dM | FileCheck --check-prefix=CHECK-SPIRV %s
+
+// CHECK-NOT:#define __SPIRV_BUILTIN_DECLARATIONS__
+
+// CHECK-SPIRV:#define __SPIRV_BUILTIN_DECLARATIONS__

--- a/clang/test/SemaSYCL/spirv-builtin-lookup.cpp
+++ b/clang/test/SemaSYCL/spirv-builtin-lookup.cpp
@@ -10,3 +10,20 @@ float acos(float val) {
 double acos(double val) {
   return __spirv_ocl_acos(val);
 }
+
+typedef int int4 __attribute__((ext_vector_type(4)));
+typedef float float4 __attribute__((ext_vector_type(4)));
+
+int4 ilogb() {
+  float4 f4 = {0.f, 0.f, 0.f, 0.f};
+  int4 i4 = __spirv_ocl_ilogb(f4);
+  return i4;
+}
+
+double sincos(double val, double *res) {
+  return __spirv_ocl_sincos(val, res);
+}
+
+double dot(float4 v1, float4 v2) {
+  return __spirv_Dot(v1, v2);
+}


### PR DESCRIPTION
This patch adds most of the SPIR-V kernel builtin definitions:
- All builtins from the OpenCL SPIR-V extended set
- Kernel core SPIR-V builtins not covered by LLVM instructions or instrinsinc, expect for Image, Pipe, Atomic, device side enqueue and vendor extension builtins

Signed-off-by: Victor Lomuller <victor@codeplay.com>