### PR TITLE
[SYCL][FPGA] Emit multiple IR variants for the IVDep attribute

### DIFF
--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -476,11 +476,12 @@ EmitIVDepLoopMetadata(LLVMContext &Ctx,
   LoopProperties.push_back(MDNode::get(Ctx, MD));
 }
 
-/// Setting the legacy LLVM IR representation of the ivdep attribute
+/// Setting the legacy LLVM IR representation of the ivdep attribute.
 static void EmitLegacyIVDepLoopMetadata(
     LLVMContext &Ctx, llvm::SmallVectorImpl<llvm::Metadata *> &LoopProperties,
     const LoopAttributes::SYCLIVDepInfo &I) {
-  // Emit "enable" metadata upon the infinite safelen specification
+  // Only emit the "enable" metadata if the safelen is set to 0, implying
+  // infinite safe length.
   if (I.SafeLen == 0) {
     Metadata *EnableMDs[] = {MDString::get(Ctx, "llvm.loop.ivdep.enable")};
     LoopProperties.push_back(MDNode::get(Ctx, EnableMDs));

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
@@ -186,12 +186,15 @@ int main() {
 // CHECK-DAG: ![[IVDEP_MUL_ARR_VAL]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_MUL_ARR]], ![[IDX_GROUP_B_MUL_ARR]], i32 5}
 // CHECK-DAG: ![[IVDEP_MUL_ARR_INF]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_C_MUL_ARR]], ![[IDX_GROUP_D_MUL_ARR]]}
 
+// Find the single instance of a legacy "IVDep enable" MD node
+// CHECK-DAG: ![[IVDEP_LEGACY_ENABLE:[0-9]+]] = !{!"llvm.loop.ivdep.enable"}
+
 /// Global INF safelen and specific array INF safelen
 /// The array-specific ivdep can be ignored, so it's the same as just global ivdep with safelen INF
 //
 // CHECK-DAG: ![[IDX_GROUP_A_ARR_AND_GLOB]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_ARR_AND_GLOB]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_ARR_AND_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_GLOB]], ![[IVDEP_ARR_AND_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_ARR_AND_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_GLOB]], ![[IVDEP_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_ARR_AND_GLOB]], ![[IDX_GROUP_B_ARR_AND_GLOB]]}
 
 /// Global INF safelen and specific array non-INF safelen
@@ -199,7 +202,7 @@ int main() {
 //
 // CHECK-DAG: ![[IDX_GROUP_A_ARR_AND_INF_GLOB]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_ARR_AND_INF_GLOB]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_ARR_AND_INF_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_INF_GLOB]], ![[IVDEP_ARR_AND_INF_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_ARR_AND_INF_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_INF_GLOB]], ![[IVDEP_ARR_AND_INF_GLOB:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_ARR_AND_INF_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_ARR_AND_INF_GLOB]], ![[IDX_GROUP_B_ARR_AND_INF_GLOB]]}
 
 /// Global safelen and specific array with lesser safelen
@@ -207,7 +210,8 @@ int main() {
 //
 // CHECK-DAG: ![[IDX_GROUP_A_ARR_AND_GREAT_GLOB]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_ARR_AND_GREAT_GLOB]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_ARR_AND_GREAT_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_GREAT_GLOB]], ![[IVDEP_ARR_AND_GREAT_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_ARR_AND_GREAT_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_GREAT_GLOB]], ![[IVDEP_ARR_AND_GREAT_GLOB:[0-9]+]], ![[IVDEP_LEGACY_ARR_AND_GREAT_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_LEGACY_ARR_AND_GREAT_GLOB]] = !{!"llvm.loop.ivdep.safelen", i32 9}
 // CHECK-DAG: ![[IVDEP_ARR_AND_GREAT_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_ARR_AND_GREAT_GLOB]], ![[IDX_GROUP_B_ARR_AND_GREAT_GLOB]], i32 9}
 
 /// Multiple arrays with specific safelens and lesser global safelen
@@ -216,8 +220,8 @@ int main() {
 // CHECK-DAG: ![[IDX_GROUP_A_MUL_ARR_AND_GLOB]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_MUL_ARR_AND_GLOB]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_C_MUL_ARR_AND_GLOB]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_MUL_ARR_AND_GLOB]] = distinct !{![[MD_LOOP_MUL_ARR_AND_GLOB]], ![[IVDEP_A_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_B_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_C_MUL_ARR_AND_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_MUL_ARR_AND_GLOB]] = distinct !{![[MD_LOOP_MUL_ARR_AND_GLOB]], ![[IVDEP_A_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_LEGACY_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_B_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_C_MUL_ARR_AND_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_LEGACY_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.ivdep.safelen", i32 5}
 // CHECK-DAG: ![[IVDEP_A_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_MUL_ARR_AND_GLOB]], i32 5}
 // CHECK-DAG: ![[IVDEP_B_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_B_MUL_ARR_AND_GLOB]], i32 6}
 // CHECK-DAG: ![[IVDEP_C_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_C_MUL_ARR_AND_GLOB]]}
-//

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
@@ -186,7 +186,7 @@ int main() {
 // CHECK-DAG: ![[IVDEP_MUL_ARR_VAL]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_MUL_ARR]], ![[IDX_GROUP_B_MUL_ARR]], i32 5}
 // CHECK-DAG: ![[IVDEP_MUL_ARR_INF]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_C_MUL_ARR]], ![[IDX_GROUP_D_MUL_ARR]]}
 
-// Find the single instance of a legacy "IVDep enable" MD node
+// Find the single instance of a legacy "IVDep enable" MD node.
 // CHECK-DAG: ![[IVDEP_LEGACY_ENABLE:[0-9]+]] = !{!"llvm.loop.ivdep.enable"}
 
 /// Global INF safelen and specific array INF safelen

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
@@ -164,7 +164,7 @@ int main() {
   return 0;
 }
 
-// Find the single instance of a legacy "IVDep enable" MD node
+// Find the single instance of a legacy "IVDep enable" MD node.
 // CHECK-DAG: ![[IVDEP_LEGACY_ENABLE:[0-9]+]] = !{!"llvm.loop.ivdep.enable"}
 
 /// Accesses from the inner loop only, various global safelens for the outer and the inner loops.

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
@@ -164,18 +164,22 @@ int main() {
   return 0;
 }
 
+// Find the single instance of a legacy "IVDep enable" MD node
+// CHECK-DAG: ![[IVDEP_LEGACY_ENABLE:[0-9]+]] = !{!"llvm.loop.ivdep.enable"}
+
 /// Accesses from the inner loop only, various global safelens for the outer and the inner loops.
 /// The inner loop's index group(s) should have two subnodes (outer-loop node and inner-loop node).
 //
 // Inner loop
 // CHECK-DAG: ![[IDX_GROUP_INNER_ACCESS]] = !{![[OUTER_NODE_INNER_ACCESS:[0-9]+]], ![[INNER_NODE_INNER_ACCESS:[0-9]+]]}
 // CHECK-DAG: ![[INNER_NODE_INNER_ACCESS]] = distinct !{}
-// CHECK-DAG: ![[MD_INNER_LOOP_INNER_ACCESS]] = distinct !{![[MD_INNER_LOOP_INNER_ACCESS]], ![[IVDEP_INNER_INNER_ACCESS:[0-9]+]]}
+// CHECK-DAG: ![[MD_INNER_LOOP_INNER_ACCESS]] = distinct !{![[MD_INNER_LOOP_INNER_ACCESS]], ![[IVDEP_INNER_INNER_ACCESS:[0-9]+]], ![[IVDEP_LEGACY_INNER_INNER_ACCESS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_LEGACY_INNER_INNER_ACCESS]] = !{!"llvm.loop.ivdep.safelen", i32 3}
 // CHECK-DAG: ![[IVDEP_INNER_INNER_ACCESS]] = !{!"llvm.loop.parallel_access_indices", ![[INNER_NODE_INNER_ACCESS]], i32 3}
 //
 // Outer loop
 // CHECK-DAG: ![[OUTER_NODE_INNER_ACCESS]] = distinct !{}
-// CHECK-DAG: ![[MD_OUTER_LOOP_INNER_ACCESS]] = distinct !{![[MD_OUTER_LOOP_INNER_ACCESS]], ![[IVDEP_OUTER_INNER_ACCESS:[0-9]+]]}
+// CHECK-DAG: ![[MD_OUTER_LOOP_INNER_ACCESS]] = distinct !{![[MD_OUTER_LOOP_INNER_ACCESS]], ![[IVDEP_OUTER_INNER_ACCESS:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_OUTER_INNER_ACCESS]] = !{!"llvm.loop.parallel_access_indices", ![[OUTER_NODE_INNER_ACCESS]]}
 
 /// Accesses from both inner and outer loop, same global (INF) safelen for both.
@@ -184,12 +188,12 @@ int main() {
 // Inner loop
 // CHECK-DAG: ![[IDX_GROUP_INNER_GLOB_SFLN]] = !{![[IDX_GROUP_OUTER_GLOB_SFLN]], ![[INNER_NODE_GLOB_SFLN:[0-9]+]]}
 // CHECK-DAG: ![[INNER_NODE_GLOB_SFLN]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_INNER_GLOB_SFLN]] = distinct !{![[MD_LOOP_INNER_GLOB_SFLN]], ![[IVDEP_INNER_GLOB_SFLN:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_INNER_GLOB_SFLN]] = distinct !{![[MD_LOOP_INNER_GLOB_SFLN]], ![[IVDEP_INNER_GLOB_SFLN:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_INNER_GLOB_SFLN]] = !{!"llvm.loop.parallel_access_indices", ![[INNER_NODE_GLOB_SFLN]]}
 //
 // Outer loop
 // CHECK-DAG: ![[IDX_GROUP_OUTER_GLOB_SFLN]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_OUTER_GLOB_SFLN]] = distinct !{![[MD_LOOP_OUTER_GLOB_SFLN]], ![[IVDEP_OUTER_GLOB_SFLN:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_OUTER_GLOB_SFLN]] = distinct !{![[MD_LOOP_OUTER_GLOB_SFLN]], ![[IVDEP_OUTER_GLOB_SFLN:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_OUTER_GLOB_SFLN]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_OUTER_GLOB_SFLN]]}
 
 /// Accesses from both inner and outer loop, with various safelens per loop.
@@ -214,7 +218,8 @@ int main() {
 // CHECK-DAG: ![[INNER_NODE_A_MUL_ARRS]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_INNER_MUL_ARRS]] = !{![[IDX_GROUP_B_OUTER_MUL_ARRS]], ![[INNER_NODE_B_MUL_ARRS:[0-9]+]]}
 // CHECK-DAG: ![[INNER_NODE_B_MUL_ARRS]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_INNER_MUL_ARRS]] = distinct !{![[MD_LOOP_INNER_MUL_ARRS]], ![[IVDEP_INNER_A_B_MUL_ARRS:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_INNER_MUL_ARRS]] = distinct !{![[MD_LOOP_INNER_MUL_ARRS]], ![[IVDEP_INNER_A_B_MUL_ARRS:[0-9]+]], ![[IVDEP_LEGACY_INNER_MUL_ARRS:[0-9]+]]}
+// CHECK-DAG: ![[IVDEP_LEGACY_INNER_MUL_ARRS]] = !{!"llvm.loop.ivdep.safelen", i32 2}
 // CHECK-DAG: ![[IVDEP_INNER_A_B_MUL_ARRS]] = !{!"llvm.loop.parallel_access_indices", ![[INNER_NODE_B_MUL_ARRS]], ![[INNER_NODE_A_MUL_ARRS]], i32 2}
 //
 // Outer loop
@@ -231,7 +236,7 @@ int main() {
 // CHECK-DAG: ![[IDX_GROUP_A_INNER_MUL_ARRS_GLOB]] = !{![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB]], ![[INNER_NODE_A_MUL_ARRS_GLOB:[0-9]+]]}
 // CHECK-DAG: ![[INNER_NODE_A_MUL_ARRS_GLOB]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_INNER_MUL_ARRS_GLOB]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_INNER_MUL_ARRS_GLOB]] = distinct !{![[MD_LOOP_INNER_MUL_ARRS_GLOB]], ![[IVDEP_INNER_A_B_MUL_ARRS_GLOB:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_INNER_MUL_ARRS_GLOB]] = distinct !{![[MD_LOOP_INNER_MUL_ARRS_GLOB]], ![[IVDEP_INNER_A_B_MUL_ARRS_GLOB:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_INNER_A_B_MUL_ARRS_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_B_INNER_MUL_ARRS_GLOB]], ![[INNER_NODE_A_MUL_ARRS_GLOB]]}
 //
 // Outer loop
@@ -246,16 +251,16 @@ int main() {
 // Loop dimension 3 (the innermost loop)
 // CHECK-DAG: ![[IDX_GROUP_DIM_3_MUL_DIMS]] = !{![[IDX_GROUP_DIM_1_MUL_DIMS]], ![[DIM_2_NODE_MUL_DIMS:[0-9]+]], ![[DIM_3_NODE_MUL_DIMS:[0-9]+]]}
 // CHECK-DAG: ![[DIM_3_NODE_MUL_DIMS]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_DIM_3_MUL_DIMS]] = distinct !{![[MD_LOOP_DIM_3_MUL_DIMS]], ![[IVDEP_DIM_3_MUL_DIMS:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_DIM_3_MUL_DIMS]] = distinct !{![[MD_LOOP_DIM_3_MUL_DIMS]], ![[IVDEP_DIM_3_MUL_DIMS:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_DIM_3_MUL_DIMS]] = !{!"llvm.loop.parallel_access_indices", ![[DIM_3_NODE_MUL_DIMS]]}
 //
 // Loop dimension 2
 // CHECK-DAG: ![[IDX_GROUP_DIM_2_MUL_DIMS]] = !{![[IDX_GROUP_DIM_1_MUL_DIMS]], ![[DIM_2_NODE_MUL_DIMS]]}
 // CHECK-DAG: ![[DIM_2_NODE_MUL_DIMS]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_DIM_2_MUL_DIMS]] = distinct !{![[MD_LOOP_DIM_2_MUL_DIMS]], ![[IVDEP_DIM_2_MUL_DIMS:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_DIM_2_MUL_DIMS]] = distinct !{![[MD_LOOP_DIM_2_MUL_DIMS]], ![[IVDEP_DIM_2_MUL_DIMS:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_DIM_2_MUL_DIMS]] = !{!"llvm.loop.parallel_access_indices", ![[DIM_2_NODE_MUL_DIMS]]}
 //
 // Loop dimension 1 (the outermost loop)
 // CHECK-DAG: ![[IDX_GROUP_DIM_1_MUL_DIMS]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_DIM_1_MUL_DIMS]] = distinct !{![[MD_LOOP_DIM_1_MUL_DIMS]], ![[IVDEP_DIM_1_MUL_DIMS:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_DIM_1_MUL_DIMS]] = distinct !{![[MD_LOOP_DIM_1_MUL_DIMS]], ![[IVDEP_DIM_1_MUL_DIMS:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_DIM_1_MUL_DIMS]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_DIM_1_MUL_DIMS]]}

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
@@ -94,17 +94,21 @@ int main() {
   return 0;
 }
 
+// Find recurring instances of legacy "IVDep enable/safelen" MD nodes
+// CHECK-DAG: ![[IVDEP_LEGACY_ENABLE:[0-9]+]] = !{!"llvm.loop.ivdep.enable"}
+// CHECK-DAG: ![[IVDEP_LEGACY_SAFELEN_5:[0-9]+]] = !{!"llvm.loop.ivdep.safelen", i32 5}
+
 /// Global ivdep w/o safelen specified
 /// All arrays have the same INF safelen - put access groups into the same parallel_access_indices metadata
 //
 // CHECK-DAG: ![[IDX_GROUP_A_NO_PARAM]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_NO_PARAM]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_NO_PARAM]] = distinct !{![[MD_LOOP_NO_PARAM]], ![[IVDEP_NO_PARAM:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_NO_PARAM]] = distinct !{![[MD_LOOP_NO_PARAM]], ![[IVDEP_NO_PARAM:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_NO_PARAM]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_NO_PARAM]], ![[IDX_GROUP_B_NO_PARAM]]}
 //
 // CHECK-DAG: ![[IDX_GROUP_A_MUL_GEPS]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_MUL_GEPS]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_MUL_GEPS]] = distinct !{![[MD_LOOP_MUL_GEPS]], ![[IVDEP_MUL_GEPS:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_MUL_GEPS]] = distinct !{![[MD_LOOP_MUL_GEPS]], ![[IVDEP_MUL_GEPS:[0-9]+]], ![[IVDEP_LEGACY_ENABLE]]}
 // CHECK-DAG: ![[IVDEP_MUL_GEPS]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_MUL_GEPS]], ![[IDX_GROUP_B_MUL_GEPS]]}
 
 /// Global ivdep w/ safelen specified
@@ -112,7 +116,7 @@ int main() {
 //
 // CHECK-DAG: ![[IDX_GROUP_A_SAFELEN]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_SAFELEN]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_SAFELEN]] = distinct !{![[MD_LOOP_SAFELEN]], ![[IVDEP_SAFELEN:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_SAFELEN]] = distinct !{![[MD_LOOP_SAFELEN]], ![[IVDEP_SAFELEN:[0-9]+]], ![[IVDEP_LEGACY_SAFELEN_5]]}
 // CHECK-DAG: ![[IVDEP_SAFELEN]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_SAFELEN]], ![[IDX_GROUP_B_SAFELEN]], i32 5}
 
 /// Conflicting global ivdeps, different safelens specified
@@ -120,5 +124,5 @@ int main() {
 //
 // CHECK-DAG: ![[IDX_GROUP_A_CONFL_SAFELEN]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_CONFL_SAFELEN]] = distinct !{}
-// CHECK-DAG: ![[MD_LOOP_CONFL_SAFELEN]] = distinct !{![[MD_LOOP_CONFL_SAFELEN]], ![[IVDEP_CONFL_SAFELEN:[0-9]+]]}
+// CHECK-DAG: ![[MD_LOOP_CONFL_SAFELEN]] = distinct !{![[MD_LOOP_CONFL_SAFELEN]], ![[IVDEP_CONFL_SAFELEN:[0-9]+]], ![[IVDEP_LEGACY_SAFELEN_5]]}
 // CHECK-DAG: ![[IVDEP_CONFL_SAFELEN]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_CONFL_SAFELEN]], ![[IDX_GROUP_B_CONFL_SAFELEN]], i32 5}

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
@@ -94,7 +94,7 @@ int main() {
   return 0;
 }
 
-// Find recurring instances of legacy "IVDep enable/safelen" MD nodes
+// Find recurring instances of legacy "IVDep enable/safelen" MD nodes.
 // CHECK-DAG: ![[IVDEP_LEGACY_ENABLE:[0-9]+]] = !{!"llvm.loop.ivdep.enable"}
 // CHECK-DAG: ![[IVDEP_LEGACY_SAFELEN_5:[0-9]+]] = !{!"llvm.loop.ivdep.safelen", i32 5}
 


### PR DESCRIPTION
By emitting the legacy variant of the LLVM IR alongside the newer
representation of the attribute, backwards compatibility with any
existing BE implementation. A smooth transition period is thus
achieved for the aforementiond BE - until it's able to consume the
new LLVM IR, it has an option to simply ignore the unknown metadata.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>