### PR TITLE
[SYCL] Fixed sub-buffer alloca search

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -240,9 +240,6 @@ Command *Scheduler::GraphBuilder::insertMemoryMove(MemObjRecord *Record,
     if (AllocaCmdDst->getType() == Command::CommandType::ALLOCA_SUB_BUF)
       AllocaCmdDst =
           static_cast<AllocaSubBufCommand *>(AllocaCmdDst)->getParentAlloca();
-    else
-      assert(
-          !"Inappropriate alloca command. AllocaSubBufCommand was expected.");
   }
 
   AllocaCommandBase *AllocaCmdSrc =


### PR DESCRIPTION
If found alloca command is not sub-buffer alloca, then
it's parent alloca which has same context and SYCLMemObj

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>