### PR TITLE
[SYCL] Fix buffer constructor using iterators

### DIFF
--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -85,7 +85,7 @@ public:
     // using this c'tor, another section says that the data will be
     // copied back if iterators passed are not const ( 4.7.2.3 Buffer
     // Synchronization Rules and this constructor description)
-    BaseT::set_final_data(First);
+    //BaseT::set_final_data(First);
   }
 
   template <typename T>

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -80,12 +80,6 @@ public:
               unique_ptr_class<SYCLMemObjAllocator> Allocator)
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     BaseT::handleHostData(First, Last, RequiredAlign);
-    // TODO: There is contradiction in the spec, in one place it says
-    // the data is not copied back at all if the buffer is construted
-    // using this c'tor, another section says that the data will be
-    // copied back if iterators passed are not const ( 4.7.2.3 Buffer
-    // Synchronization Rules and this constructor description)
-    //BaseT::set_final_data(First);
   }
 
   template <typename T>

--- a/sycl/test/basic_tests/buffer/buffer.cpp
+++ b/sycl/test/basic_tests/buffer/buffer.cpp
@@ -434,7 +434,7 @@ int main() {
             range<1>{3}, [=](id<1> index) { B[index] = 20; });
       });
     }
-    // Data is not copied back in the desctruction of the buffer created
+    // Data is not copied back in the destruction of the buffer created
     // from a pair of non-const iterators
     for (int i = 0; i < 10; i++)
       assert(data1[i] == -1);

--- a/sycl/test/basic_tests/buffer/buffer.cpp
+++ b/sycl/test/basic_tests/buffer/buffer.cpp
@@ -434,13 +434,9 @@ int main() {
             range<1>{3}, [=](id<1> index) { B[index] = 20; });
       });
     }
-    // Data is copied back in the desctruction of the buffer created from
-    // pair of non-const iterators
-    for (int i = 0; i < 2; i++)
-      assert(data1[i] == -1);
-    for (int i = 2; i < 5; i++)
-      assert(data1[i] == 20);
-    for (int i = 5; i < 10; i++)
+    // Data is not copied back in the desctruction of the buffer created
+    // from a pair of non-const iterators
+    for (int i = 0; i < 10; i++)
       assert(data1[i] == -1);
   }
 


### PR DESCRIPTION
Fixed the buffer constructor called with a pair of iterators.
The current implementation has a problem due to ambiguous spec.
The buffer should never write back data unless there is a call to set_final_data(), but the current implementation does it.
I corrected the spec in KhronosGroup/SYCL-Docs#76.
So, now we can change the buffer implementation according to the clarified spec.

The test case buffer.cpp also needed change because of this change.
The user should not expect the automatic write-back of data upon destruction of buffer.

Signed-off-by: Byoungro So byoungro.so@intel.com