### PR TITLE
[SYCL] Enable non-read-write memory object mapping in scheduler

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -828,9 +828,11 @@ void ReleaseCommand::printDot(std::ostream &Stream) const {
 }
 
 MapMemObject::MapMemObject(AllocaCommandBase *SrcAllocaCmd, Requirement Req,
-                           void **DstPtr, QueueImplPtr Queue)
+                           void **DstPtr, QueueImplPtr Queue,
+                           access::mode MapMode)
     : Command(CommandType::MAP_MEM_OBJ, std::move(Queue)),
-      MSrcAllocaCmd(SrcAllocaCmd), MSrcReq(std::move(Req)), MDstPtr(DstPtr) {
+      MSrcAllocaCmd(SrcAllocaCmd), MSrcReq(std::move(Req)), MDstPtr(DstPtr),
+      MMapMode(MapMode) {
   emitInstrumentationDataProxy();
 }
 
@@ -861,9 +863,8 @@ cl_int MapMemObject::enqueueImp() {
   RT::PiEvent &Event = MEvent->getHandleRef();
   *MDstPtr = MemoryManager::map(
       MSrcAllocaCmd->getSYCLMemObj(), MSrcAllocaCmd->getMemAllocation(), MQueue,
-      MSrcReq.MAccessMode, MSrcReq.MDims, MSrcReq.MMemoryRange,
-      MSrcReq.MAccessRange, MSrcReq.MOffset, MSrcReq.MElemSize,
-      std::move(RawEvents), Event);
+      MMapMode, MSrcReq.MDims, MSrcReq.MMemoryRange, MSrcReq.MAccessRange,
+      MSrcReq.MOffset, MSrcReq.MElemSize, std::move(RawEvents), Event);
   return CL_SUCCESS;
 }
 

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -321,7 +321,7 @@ private:
 class MapMemObject : public Command {
 public:
   MapMemObject(AllocaCommandBase *SrcAllocaCmd, Requirement Req, void **DstPtr,
-               QueueImplPtr Queue);
+               QueueImplPtr Queue, access::mode MapMode);
 
   void printDot(std::ostream &Stream) const final;
   const Requirement *getRequirement() const final { return &MSrcReq; }
@@ -333,6 +333,7 @@ private:
   AllocaCommandBase *MSrcAllocaCmd = nullptr;
   Requirement MSrcReq;
   void **MDstPtr = nullptr;
+  access::mode MMapMode;
 };
 
 class UnMapMemObject : public Command {

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -50,6 +50,10 @@ struct MemObjRecord {
   // The context which has the latest state of the memory object.
   ContextImplPtr MCurContext;
 
+  // The mode this object can be accessed with from the host context.
+  // Valid only if the current context is host.
+  access::mode MHostAccess = access::mode::read_write;
+
   // The flag indicates that the content of the memory object was/will be
   // modified. Used while deciding if copy back needed.
   bool MMemModified = false;
@@ -170,6 +174,11 @@ protected:
     // and destination.
     Command *insertMemoryMove(MemObjRecord *Record, Requirement *Req,
                               const QueueImplPtr &Queue);
+
+    // Inserts commands required to remap the memory object to its current host
+    // context so that the required access mode becomes valid.
+    Command *remapMemoryObject(MemObjRecord *Record, Requirement *Req,
+                               AllocaCommandBase *HostAllocaCmd);
 
     UpdateHostRequirementCommand *
     insertUpdateHostReqCmd(MemObjRecord *Record, Requirement *Req,

--- a/sycl/test/scheduler/MemObjRemapping.cpp
+++ b/sycl/test/scheduler/MemObjRemapping.cpp
@@ -1,0 +1,58 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_PI_TRACE=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=1 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
+#include <CL/sycl.hpp>
+#include <cassert>
+#include <cstddef>
+
+using namespace cl::sycl;
+
+class Foo;
+class Bar;
+
+// This test checks that memory objects are remapped on requesting an access mode
+// incompatible with the current mapping.
+int main() {
+  queue Q;
+
+  std::size_t Size = 1024;
+  range<1> Range{Size};
+  buffer<int, 1> Buf{Range};
+
+  Q.submit([&](handler &Cgh){
+    auto Acc = Buf.get_access<access::mode::read_write>(Cgh);
+    Cgh.parallel_for<Foo>(Range, [=](id<1> Idx){
+      Acc[Idx] = Idx[0];
+    });
+  });
+
+  {
+    // CHECK: piEnqueueMemBufferMap
+    auto Acc = Buf.get_access<access::mode::read>();
+    for (std::size_t I = 0; I < Size; ++I)
+      assert(Acc[I] == I);
+  }
+  {
+    // CHECK: piEnqueueMemUnmap
+    // CHECK: piEnqueueMemBufferMap
+    auto Acc = Buf.get_access<access::mode::write>();
+    for (std::size_t I = 0; I < Size; ++I)
+      Acc[I] = 2 * I;
+  }
+
+  queue HostQ{host_selector()};
+  // CHECK: piEnqueueMemUnmap
+  // CHECK: piEnqueueMemBufferMap
+  HostQ.submit([&](handler &Cgh){
+    auto Acc = Buf.get_access<access::mode::read_write>(Cgh);
+    Cgh.parallel_for<Bar>(Range, [=](id<1> Idx){
+      Acc[Idx] *= 2;
+    });
+  });
+
+  // CHECK-NOT: piEnqueueMemBufferMap
+  auto Acc = Buf.get_access<access::mode::read>();
+  for (std::size_t I = 0; I < Size; ++I)
+    assert(Acc[I] == 4 * I);
+}

--- a/sycl/test/scheduler/MemObjRemapping.cpp
+++ b/sycl/test/scheduler/MemObjRemapping.cpp
@@ -20,9 +20,9 @@ int main() {
   range<1> Range{Size};
   buffer<int, 1> Buf{Range};
 
-  Q.submit([&](handler &Cgh){
+  Q.submit([&](handler &Cgh) {
     auto Acc = Buf.get_access<access::mode::read_write>(Cgh);
-    Cgh.parallel_for<Foo>(Range, [=](id<1> Idx){
+    Cgh.parallel_for<Foo>(Range, [=](id<1> Idx) {
       Acc[Idx] = Idx[0];
     });
   });
@@ -44,9 +44,9 @@ int main() {
   queue HostQ{host_selector()};
   // CHECK: piEnqueueMemUnmap
   // CHECK: piEnqueueMemBufferMap
-  HostQ.submit([&](handler &Cgh){
+  HostQ.submit([&](handler &Cgh) {
     auto Acc = Buf.get_access<access::mode::read_write>(Cgh);
-    Cgh.parallel_for<Bar>(Range, [=](id<1> Idx){
+    Cgh.parallel_for<Bar>(Range, [=](id<1> Idx) {
       Acc[Idx] *= 2;
     });
   });

--- a/sycl/test/scheduler/MemObjRemapping.cpp
+++ b/sycl/test/scheduler/MemObjRemapping.cpp
@@ -1,7 +1,5 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_PI_TRACE=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
-// RUN: env SYCL_PI_TRACE=1 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
-// RUN: env SYCL_PI_TRACE=1 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
 #include <CL/sycl.hpp>
 #include <cassert>
 #include <cstddef>
@@ -12,47 +10,74 @@ class Foo;
 class Bar;
 
 // This test checks that memory objects are remapped on requesting an access mode
-// incompatible with the current mapping.
+// incompatible with the current mapping. Write access is mapped as read-write.
 int main() {
   queue Q;
 
-  std::size_t Size = 1024;
+  std::size_t Size = 64;
   range<1> Range{Size};
-  buffer<int, 1> Buf{Range};
+  buffer<int, 1> BufA{Range};
+  buffer<int, 1> BufB{Range};
 
   Q.submit([&](handler &Cgh) {
-    auto Acc = Buf.get_access<access::mode::read_write>(Cgh);
+    auto AccA = BufA.get_access<access::mode::read_write>(Cgh);
+    auto AccB = BufB.get_access<access::mode::read_write>(Cgh);
     Cgh.parallel_for<Foo>(Range, [=](id<1> Idx) {
-      Acc[Idx] = Idx[0];
+      AccA[Idx] = Idx[0];
+      AccB[Idx] = Idx[0];
     });
   });
 
   {
+    // Check access mode flags
     // CHECK: piEnqueueMemBufferMap
-    auto Acc = Buf.get_access<access::mode::read>();
-    for (std::size_t I = 0; I < Size; ++I)
-      assert(Acc[I] == I);
+    // CHECK-NEXT: :
+    // CHECK-NEXT: :
+    // CHECK-NEXT: :
+    // CHECK-NEXT: : 1
+    // CHECK: piEnqueueMemBufferMap
+    // CHECK-NEXT: :
+    // CHECK-NEXT: :
+    // CHECK-NEXT: :
+    // CHECK-NEXT: : 1
+    auto AccA = BufA.get_access<access::mode::read>();
+    auto AccB = BufB.get_access<access::mode::read>();
+    for (std::size_t I = 0; I < Size; ++I) {
+      assert(AccA[I] == I);
+      assert(AccB[I] == I);
+    }
   }
   {
     // CHECK: piEnqueueMemUnmap
     // CHECK: piEnqueueMemBufferMap
-    auto Acc = Buf.get_access<access::mode::write>();
+    // CHECK-NEXT: :
+    // CHECK-NEXT: :
+    // CHECK-NEXT: :
+    // CHECK-NEXT: : 3
+    auto AccA = BufA.get_access<access::mode::write>();
     for (std::size_t I = 0; I < Size; ++I)
-      Acc[I] = 2 * I;
+      AccA[I] = 2 * I;
   }
 
   queue HostQ{host_selector()};
   // CHECK: piEnqueueMemUnmap
   // CHECK: piEnqueueMemBufferMap
+  // CHECK-NEXT: :
+  // CHECK-NEXT: :
+  // CHECK-NEXT: :
+  // CHECK-NEXT: : 3
   HostQ.submit([&](handler &Cgh) {
-    auto Acc = Buf.get_access<access::mode::read_write>(Cgh);
+    auto AccB = BufB.get_access<access::mode::write>(Cgh);
     Cgh.parallel_for<Bar>(Range, [=](id<1> Idx) {
-      Acc[Idx] *= 2;
+      AccB[Idx] = 2 * Idx[0];
     });
   });
 
   // CHECK-NOT: piEnqueueMemBufferMap
-  auto Acc = Buf.get_access<access::mode::read>();
-  for (std::size_t I = 0; I < Size; ++I)
-    assert(Acc[I] == 4 * I);
+  auto AccA = BufA.get_access<access::mode::read>();
+  auto AccB = BufB.get_access<access::mode::read>();
+  for (std::size_t I = 0; I < Size; ++I) {
+    assert(AccA[I] == 2 * I);
+    assert(AccB[I] == 2 * I);
+  }
 }


### PR DESCRIPTION
Previously all memory objects were mapped with read-write access
whenever they were requested on host so that they were fully
accessible on host until their unmapping. This patch changes this
behaviour: now memory objects are mapped with just the required access
mode. If an incompatible access mode is requested on host afterwards,
the object is remapped.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>