### PR TITLE
[SYCL][NFC] Set dependency versions

### DIFF
--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -1,0 +1,20 @@
+[VERSIONS]
+ocl_cpu_rt_ver=2020.10.3.0.04
+ocl_cpu_rt_ver_win=2020.10.3.0.04
+ocl_gpu_rt_ver=20.06.15619
+ocl_gpu_rt_ver_win=26.20.100.7870
+intel_sycl_ver=build
+tbb_ver=20200121_111047
+tbb_ver_win=20200124_000000
+fpga_ver=20200216_000000
+fpga_ver_win=20200216_000000
+mkl_ver=2019u4
+mkldnn_ver=2021.1.2.022
+
+[DRIVER VERSIONS]
+cpu_driver_lin=2020.10.3.0.04
+cpu_driver_win=2020.10.3.0.04
+gpu_driver_lin=20.06.15619
+gpu_driver_win=26.20.100.7870
+fpga_driver_lin=2020.9.2.0
+fpga_driver_win=2020.9.2.0


### PR DESCRIPTION
The change was done to store dependency versions used for testing in LLVM repo to simplify:
 - trace back for dependency changes;
 - verification of dependency changes;
 - reproducucing of problems.

The CTS failure happens after recent change in hierarchical_implicit_reduce. I looking into the issue. 
