### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,15 @@
+clang/ @erichkeane, @Fznamznon
+
+llvm-spirv/ @AlexeySotkin, @AlexeySachkov
+
+opencl-aot/ @dm-vodopyanov
+
+sycl/doc/extensions/ @mkinsner, @jbrodman
+
+sycl/doc/ @pvchupin, @kbobrovs
+
+sycl/ @romanovvlad
+
+xpti/ @tovinkere
+
+* @bader

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,5 +1,8 @@
 clang/ @erichkeane, @Fznamznon
 
+clang/include/clang/Driver/ @mdtoguchi @AGindinson
+clang/lib/Driver/ @mdtoguchi @AGindinson
+
 llvm-spirv/ @AlexeySotkin, @AlexeySachkov
 
 opencl-aot/ @dm-vodopyanov

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -14,6 +14,6 @@ sycl/doc/ @pvchupin, @kbobrovs
 
 sycl/ @romanovvlad, @bader
 
-xpti/ @tovinkere
+xpti/ @tovinkere, @andykaylor
 
 * @bader

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -5,7 +5,7 @@ clang/lib/Driver/ @mdtoguchi @AGindinson
 
 llvm-spirv/ @AlexeySotkin, @AlexeySachkov
 
-opencl-aot/ @dm-vodopyanov
+opencl-aot/ @dm-vodopyanov, @AlexeySachkov, @romanovvlad
 
 libdevice/ @asavonic, @vzakhari
 
@@ -13,7 +13,7 @@ sycl/doc/extensions/ @mkinsner, @jbrodman
 
 sycl/doc/ @pvchupin, @kbobrovs
 
-sycl/ @romanovvlad
+sycl/ @romanovvlad, @bader
 
 xpti/ @tovinkere
 

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,7 +1,6 @@
 clang/ @erichkeane, @Fznamznon
 
-clang/include/clang/Driver/ @mdtoguchi @AGindinson
-clang/lib/Driver/ @mdtoguchi @AGindinson
+clang/**/Driver @mdtoguchi @AGindinson
 
 llvm-spirv/ @AlexeySotkin, @AlexeySachkov
 

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -7,6 +7,8 @@ llvm-spirv/ @AlexeySotkin, @AlexeySachkov
 
 opencl-aot/ @dm-vodopyanov
 
+libdevice/ @asavonic, @vzakhari
+
 sycl/doc/extensions/ @mkinsner, @jbrodman
 
 sycl/doc/ @pvchupin, @kbobrovs


### PR DESCRIPTION
Let's use code owners to facilitate code review process.
Using this file reviewers will be assigned automatically.

More information can be found on the GitHub documentation
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

Signed-off-by: Alexey Bader <alexey.bader@intel.com>