### PR TITLE
[SYCL] Re-enable spec constant test on CPU.

### DIFF
--- a/sycl/test/spec_const/spec_const_hw.cpp
+++ b/sycl/test/spec_const/spec_const_hw.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
 // TODO: re-enable after OpenCL RT is fixed:
-// RUNx: %CPU_RUN_PLACEHOLDER %t.out
 // RUNx: %GPU_RUN_PLACEHOLDER %t.out
 // RUNx: %ACC_RUN_PLACEHOLDER %t.out
 //


### PR DESCRIPTION
Tested with Intel CPU OpenCL runtime build 20200308_000000.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>