### PR TITLE
[SYCL] Support for array kernel parameters

### DIFF
--- a/clang/test/SemaSYCL/array-kernel-param-neg.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param-neg.cpp
@@ -1,0 +1,44 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -fsyntax-only %s
+
+// This test checks if compiler reports compilation error on an attempt to pass
+// a struct with non-trivially copyable type as SYCL kernel parameter.
+
+struct A {
+  int i;
+};
+
+struct B {
+  int i;
+  B(int _i) : i(_i) {}
+  B(const B &x) : i(x.i) {}
+};
+
+struct C : A {
+  const A C2;
+  C() : A{0}, C2{2} {}
+};
+
+struct D {
+  int i;
+  ~D();
+};
+
+template <typename Name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+void test() {
+  A cs1[10];
+  B nsl1[4] = {1, 2, 3, 4};
+  C cs2[6];
+  D nsl2[5];
+  kernel_single_task<class kernel_capture_refs>([=] {
+    int a = cs1[6].i;
+    // expected-error@+1 {{kernel parameter has non-trivially copy constructible class/struct type}}
+    int b = nsl1[2].i;
+    int c = cs2[0].i;
+    // expected-error@+1 {{kernel parameter has non-trivially destructible class/struct type}}
+    int d = nsl2[4].i;
+  });
+}

--- a/clang/test/SemaSYCL/array-kernel-param.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param.cpp
@@ -1,0 +1,107 @@
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -ast-dump %s | FileCheck %s
+
+// This test checks that compiler generates correct kernel wrapper arguments for
+// different accessors targets.
+
+#include <sycl.hpp>
+
+using namespace cl::sycl;
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void a_kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+
+  using Accessor =
+      accessor<int, 1, access::mode::read_write, access::target::global_buffer>;
+
+  Accessor acc[2];
+  int a[100];
+#if 1
+  struct struct_acc_t {
+    Accessor member_acc[4];
+  } struct_acc;
+#endif
+
+#if 1
+  a_kernel<class kernel_A>(
+      [=]() {
+        acc[1].use();
+      });
+#endif
+
+#if 1
+  a_kernel<class kernel_B>(
+      [=]() {
+        int local = a[3];
+      });
+#endif
+
+#if 1
+  a_kernel<class kernel_C>(
+      [=]() {
+        struct_acc.member_acc[2].use();
+      });
+  struct struct_acc_t array_acc_struct[10];
+  a_kernel<class kernel_D>(
+      [=]() {
+        array_acc_struct[4].member_acc[2].use();
+      });
+#endif
+}
+
+// Check kernel_A parameters
+// CHECK: FunctionDecl {{.*}}kernel_A{{.*}} 'void (__global int *, cl::sycl::range<1>, cl::sycl::range<1>, cl::sycl::id<1>, __global int *, cl::sycl::range<1>, cl::sycl::range<1>, cl::sycl::id<1>)'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ '__global int *'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'cl::sycl::id<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ '__global int *'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'cl::sycl::id<1>'
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}}__init
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}}__init
+
+// Check kernel_B parameters
+// CHECK: FunctionDecl {{.*}}kernel_B{{.*}} 'void (wrapped_array)'
+// CHECK-NEXT: ParmVarDecl {{.*}} 'wrapped_array'
+// CHECK-NEXT: CompoundStmt
+// CHECK-NEXT: DeclStmt
+// CHECK-NEXT: VarDecl
+// CHECK-NEXT: InitListExpr
+// CHECK-NEXT: ArrayInitLoopExpr {{.*}} 'int [100]'
+
+// Check kernel_C parameters
+// CHECK: FunctionDecl {{.*}}kernel_C{{.*}} 'void (struct {{.*}}, __global int *, cl::sycl::range<1>, cl::sycl::range<1>, cl::sycl::id<1>, __global int *, cl::sycl::range<1>, cl::sycl::range<1>, cl::sycl::id<1>, __global int *, cl::sycl::range<1>, cl::sycl::range<1>, cl::sycl::id<1>, __global int *, cl::sycl::range<1>, cl::sycl::range<1>, cl::sycl::id<1>)'
+// CHECK-NEXT: ParmVarDecl {{.*}} 'struct {{.*}}'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc '__global int *'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::id<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc '__global int *'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::id<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc '__global int *'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::id<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc '__global int *'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::range<1>'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::id<1>'
+
+// Check that four accessor init functions are called
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}}__init
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}}__init
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}}__init
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}}__init

--- a/sycl/test/array_param/array-kernel-param-run.cpp
+++ b/sycl/test/array_param/array-kernel-param-run.cpp
@@ -1,0 +1,250 @@
+// This test checks array kernel parameters
+
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+#include <iostream>
+
+using namespace cl::sycl;
+
+constexpr size_t c_num_items = 100;
+range<1> num_items{c_num_items}; // range<1>(num_items)
+
+// Change if tests are added/removed
+static int testCount = 5;
+static int passCount;
+
+template <typename T>
+static bool verify_1D(const char *name, int X, T A, T A_ref) {
+  int ErrCnt = 0;
+
+  for (int i = 0; i < X; i++) {
+    if (A_ref[i] != A[i]) {
+      if (++ErrCnt < 10) {
+        std::cout << name << " mismatch at " << i << ". Expected " << A_ref[i]
+                  << " result is " << A[i] << "\n";
+      }
+    }
+  }
+
+  if (ErrCnt == 0) {
+    return true;
+  }
+  std::cout << "  Failed. Failure rate: " << ErrCnt << "/" << X << "("
+            << ErrCnt / (float)X * 100.f << "%)\n";
+  return false;
+}
+
+template <typename T>
+void init(T &A, int value, int increment) {
+  for (int i = 0; i < c_num_items; i++) {
+    A[i] = value;
+    value += increment;
+  }
+}
+
+bool test_one_array(queue &myQueue) {
+  int input1[c_num_items];
+  int output[c_num_items];
+  int ref[c_num_items];
+  init(input1, 1, 1);
+  init(output, 51, 1);
+  init(ref, 2, 1);
+
+  auto out_buffer = buffer<int, 1>(&output[0], num_items);
+
+  myQueue.submit([&](handler &cgh) {
+    auto output_accessor = out_buffer.get_access<access::mode::write>(cgh);
+
+    cgh.parallel_for<class one_array>(num_items, [=](cl::sycl::id<1> index) {
+      output_accessor[index] = input1[index] + 1;
+    });
+  });
+  const auto HostAccessor = out_buffer.get_access<cl::sycl::access::mode::read>();
+
+  return verify_1D<int *>("One array", c_num_items, output, ref);
+}
+
+bool test_two_arrays(queue &myQueue) {
+  int input1[c_num_items];
+  int input2[c_num_items];
+  int output[c_num_items];
+  int ref[c_num_items];
+  init(input1, 1, 1);
+  init(input2, 22, 1);
+  init(ref, 23, 2);
+
+  auto out_buffer = buffer<int, 1>(&output[0], num_items);
+
+  myQueue.submit([&](handler &cgh) {
+    auto output_accessor = out_buffer.get_access<access::mode::write>(cgh);
+
+    cgh.parallel_for<class two_arrays>(num_items, [=](cl::sycl::id<1> index) {
+      output_accessor[index] = input1[index] + input2[index];
+    });
+  });
+  const auto HostAccessor = out_buffer.get_access<cl::sycl::access::mode::read>();
+
+  return verify_1D<int *>("Two arrays", c_num_items, output, ref);
+}
+
+bool test_accessor_arrays_1(queue &myQueue) {
+  std::array<int, c_num_items> input1;
+  std::array<int, c_num_items> input2;
+  std::array<int, c_num_items> ref;
+  init(input1, 1, 1);
+  init(input2, 22, 1);
+  init(ref, 24, 1);
+
+  auto in_buffer1 = buffer<int, 1>(input1.data(), num_items);
+  auto in_buffer2 = buffer<int, 1>(input2.data(), num_items);
+
+  myQueue.submit([&](handler &cgh) {
+    using Accessor =
+        accessor<int, 1, access::mode::read_write, access::target::global_buffer>;
+    Accessor a[2] = {
+        in_buffer1.get_access<access::mode::read_write>(cgh),
+        in_buffer2.get_access<access::mode::read_write>(cgh),
+    };
+
+    cgh.parallel_for<class accessor_arrays_1>(num_items, [=](cl::sycl::id<1> index) {
+      a[0][index] = a[1][index] + 2;
+    });
+  });
+  const auto HostAccessor = in_buffer1.get_access<cl::sycl::access::mode::read>();
+
+  return verify_1D<std::array<int, c_num_items>>("Accessor arrays 1", c_num_items, input1, ref);
+}
+
+bool test_accessor_arrays_2(queue &myQueue) {
+  std::array<int, c_num_items> input1;
+  std::array<int, c_num_items> input2;
+  std::array<int, c_num_items> output;
+  std::array<int, c_num_items> ref;
+  init(input1, 1, 1);
+  init(input2, 22, 1);
+  init(ref, 23, 2);
+
+  auto in_buffer1 = buffer<int, 1>(input1.data(), num_items);
+  auto in_buffer2 = buffer<int, 1>(input2.data(), num_items);
+  auto out_buffer = buffer<int, 1>(output.data(), num_items);
+
+  myQueue.submit([&](handler &cgh) {
+    using Accessor =
+        accessor<int, 1, access::mode::read_write, access::target::global_buffer>;
+    Accessor a[4] = {in_buffer1.get_access<access::mode::read_write>(cgh),
+                     in_buffer2.get_access<access::mode::read_write>(cgh),
+                     in_buffer1.get_access<access::mode::read_write>(cgh),
+                     in_buffer2.get_access<access::mode::read_write>(cgh)};
+    auto output_accessor = out_buffer.get_access<access::mode::write>(cgh);
+
+    cgh.parallel_for<class accessor_arrays_2>(num_items, [=](cl::sycl::id<1> index) {
+      output_accessor[index] = a[0][index] + a[3][index];
+    });
+  });
+  const auto HostAccessor = out_buffer.get_access<cl::sycl::access::mode::read>();
+
+  return verify_1D<std::array<int, c_num_items>>("Accessor arrays 2", c_num_items, output, ref);
+}
+
+bool test_accessor_array_in_struct(queue &myQueue) {
+  std::array<int, c_num_items> input1;
+  std::array<int, c_num_items> input2;
+  std::array<int, c_num_items> output;
+  std::array<int, c_num_items> ref;
+  init(input1, 1, 1);
+  init(input2, 22, 1);
+  init(ref, 35, 2);
+
+  auto in_buffer1 = buffer<int, 1>(input1.data(), num_items);
+  auto in_buffer2 = buffer<int, 1>(input2.data(), num_items);
+  auto out_buffer = buffer<int, 1>(output.data(), num_items);
+
+  myQueue.submit([&](handler &cgh) {
+    using Accessor =
+        accessor<int, 1, access::mode::read_write, access::target::global_buffer>;
+    struct S {
+      int w;
+      int x;
+      Accessor a[2];
+      int y;
+      int z;
+    } S = {
+        3, 3, {in_buffer1.get_access<access::mode::read_write>(cgh), in_buffer2.get_access<access::mode::read_write>(cgh)}, 7, 7};
+    auto output_accessor = out_buffer.get_access<access::mode::write>(cgh);
+
+    cgh.parallel_for<class accessor_array_in_struct>(num_items, [=](cl::sycl::id<1> index) {
+      S.a[0][index]++;
+      S.a[1][index]++;
+      output_accessor[index] = S.a[0][index] + S.a[1][index] + S.x + S.y;
+    });
+  });
+  const auto HostAccessor = out_buffer.get_access<cl::sycl::access::mode::read>();
+
+  return verify_1D("Accessor array in struct", c_num_items, output, ref);
+}
+
+bool run_tests() {
+  queue Q([](exception_list L) {
+    for (auto ep : L) {
+      try {
+        std::rethrow_exception(ep);
+      } catch (std::exception &E) {
+        std::cout << "*** std exception caught:\n";
+        std::cout << E.what();
+      } catch (cl::sycl::exception const &E1) {
+        std::cout << "*** SYCL exception caught:\n";
+        std::cout << E1.what();
+      }
+    }
+  });
+
+  passCount = 0;
+  if (test_one_array(Q)) {
+    ++passCount;
+  }
+  if (test_two_arrays(Q)) {
+    ++passCount;
+  }
+  if (test_accessor_arrays_1(Q)) {
+    ++passCount;
+  }
+  if (test_accessor_arrays_2(Q)) {
+    ++passCount;
+  }
+  if (test_accessor_array_in_struct(Q)) {
+    ++passCount;
+  }
+
+  auto D = Q.get_device();
+  const char *devType = D.is_host() ? "Host" : D.is_cpu() ? "CPU" : "GPU";
+  std::cout << passCount << " of " << testCount << " tests passed on "
+            << devType << "\n";
+
+  return (testCount == passCount);
+}
+
+int main(int argc, char *argv[]) {
+  bool passed = true;
+  default_selector selector{};
+  auto D = selector.select_device();
+  const char *devType = D.is_host() ? "Host" : D.is_cpu() ? "CPU" : "GPU";
+  std::cout << "Running on device " << devType << " ("
+            << D.get_info<cl::sycl::info::device::name>() << ")\n";
+  try {
+    passed &= run_tests();
+  } catch (exception e) {
+    std::cout << e.what();
+  }
+
+  if (!passed) {
+    std::cout << "FAILED\n";
+    return 1;
+  }
+  std::cout << "PASSED\n";
+  return 0;
+}


### PR DESCRIPTION
Signed-off-by: rdeodhar <rajiv.deodhar@intel.com>
This PR adds support for:
1. standard-layout arrays as kernel parameters
2. arrays of Accessors as kernel parameters
3. structs containing arrays of Accessors

The design is described in the attached document.
[Array_Kernel_Parameters.txt](https://github.com/intel/llvm/files/4396519/Array_Kernel_Parameters.txt)
