### PR TITLE
[SYCL][NFC] Use the non-deprecated setAlignment() in LowerWGScope

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerWGScope.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerWGScope.cpp
@@ -926,7 +926,7 @@ Value *spirv::genPseudoLocalID(Instruction &Before, const Triple &TT) {
                              asUInt(spirv::AddrSpace::Global) // AddressSpace
       );
       unsigned Align = M.getDataLayout().getPreferredAlignment(G);
-      G->setAlignment(Align);
+      G->setAlignment(MaybeAlign(Align));
     }
     Value *Res = new LoadInst(G, "", &Before);
     return Res;


### PR DESCRIPTION
The commit switches to using the `MaybeAlign` overload directly,
which addresses:

```
*/llvm/llvm/lib/SYCLLowerIR/LowerWGScope.cpp: In function 'llvm::Value* spirv::genPseudoLocalID(llvm::Instruction&, const llvm::Triple&)':
*/llvm/llvm/lib/SYCLLowerIR/LowerWGScope.cpp:929:28: warning: 'void llvm::GlobalObject::setAlignment(unsigned int)' is deprecated [-Wdeprecated-declarations]
       G->setAlignment(Align);
                            ^
In file included from */llvm/llvm/include/llvm/Support/ErrorHandling.h:17:0,
                 from */llvm/llvm/include/llvm/ADT/Hashing.h:48,
                 from */llvm/llvm/include/llvm/ADT/ArrayRef.h:12,
                 from */llvm/llvm/include/llvm/ADT/DenseMapInfo.h:16,
                 from */llvm/llvm/include/llvm/ADT/DenseMap.h:16,
                 from */llvm/llvm/include/llvm/ADT/DenseSet.h:16,
                 from */llvm/llvm/include/llvm/IR/Function.h:20,
                 from */llvm/llvm/include/llvm/SYCLLowerIR/LowerWGScope.h:15,
                 from */llvm/llvm/lib/SYCLLowerIR/LowerWGScope.cpp:76:
*/llvm/llvm/include/llvm/IR/GlobalObject.h:86:34: note: declared here
   LLVM_ATTRIBUTE_DEPRECATED(void setAlignment(unsigned Align),
```

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>