### PR TITLE
[BuildBot] Add --cmake-opts option to configure.py script

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -4,6 +4,10 @@ import subprocess
 import sys
 import platform
 
+# TODO:
+# 1. Add support for relative paths (e.g. relative path to source directory)
+# 2. Create obj_dir from the script if it doesn't exist
+
 def do_configure(args):
     ret = False
 
@@ -68,6 +72,7 @@ def do_configure(args):
         "-DLLVM_ENABLE_SPHINX={}".format(llvm_enable_sphinx),
         "-DBUILD_SHARED_LIBS={}".format(llvm_build_shared_libs),
         "-DSYCL_ENABLE_XPTI_TRACING=ON", # Explicitly turn on XPTI tracing
+        "{}".format(args.cmake_opts),
         llvm_dir
     ]
 
@@ -91,7 +96,7 @@ def do_configure(args):
 
 def main():
     parser = argparse.ArgumentParser(prog="configure.py",
-                                     description="script to do configure",
+                                     description="Generate build files from CMake configuration files",
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-n", "--build-number", metavar="BUILD_NUM", help="build number")
     parser.add_argument("-b", "--branch", metavar="BRANCH", help="pull request branch")
@@ -108,6 +113,7 @@ def main():
     parser.add_argument("--docs", action='store_true', help="build Doxygen documentation")
     parser.add_argument("--no-ocl", action='store_true', help="download OpenCL deps via CMake")
     parser.add_argument("--shared-libs", action='store_true', help="Build shared libraries")
+    parser.add_argument("--cmake-opts", metavar="CMAKE_OPTS", help="Additional CMake options not configured via script parameters")
 
     args = parser.parse_args()
 

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -68,10 +68,12 @@ cd %DPCPP_HOME%\build
 
 ## Build DPC++ toolchain
 
-The easiest way to get started is to use the buildbot [configure](../../buildbot/configure.py)
-and [compile](../../buildbot/configure.py) scripts.
+The easiest way to get started is to use the buildbot
+[configure](../../buildbot/configure.py) and
+[compile](../../buildbot/compile.py) scripts.
 
-In case you want to configure CMake manually the up-to-date reference for variables is in these files.
+In case you want to configure CMake manually the up-to-date reference for
+variables is in these files.
 
 **Linux**
 
@@ -95,7 +97,6 @@ You can use the following flags with `configure.py`:
  * `--cuda` -> use the cuda backend (see [Nvidia CUDA](#build-dpc-toolchain-with-support-for-nvidia-cuda))
  * `--shared-libs` -> Build shared libraries
  * `-t` -> Build type (debug or release)
-
 
 Ahead-of-time compilation for the Intel&reg; processors is enabled by default.
 For more, see [opencl-aot documentation](../../opencl-aot/README.md).


### PR DESCRIPTION
Useful option to pass additional CMake parameters w/o changing
configure.py script sources.
Added a couple of ideas on how configure.py script can simplify usage.

Fixed patch to the compile.py script in GetStartedGuide.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>