### PR TITLE
[SYCL][NFC] Move SYCL pipe metadata call to be inside the null check …

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3690,8 +3690,8 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName,
       }
     }
 
-  if (LangOpts.SYCLIsDevice)
-    maybeEmitPipeStorageMetadata(D, GV, *this);
+    if (LangOpts.SYCLIsDevice)
+      maybeEmitPipeStorageMetadata(D, GV, *this);
   }
 
   if (GV->isDeclaration())

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3689,6 +3689,9 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName,
         }
       }
     }
+
+  if (LangOpts.SYCLIsDevice)
+    maybeEmitPipeStorageMetadata(D, GV, *this);
   }
 
   if (GV->isDeclaration())
@@ -3699,9 +3702,6 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName,
         : (LangOpts.OpenCL ? LangAS::opencl_global : LangAS::Default);
   assert(getContext().getTargetAddressSpace(ExpectedAS) ==
          Ty->getPointerAddressSpace());
-
-  if (LangOpts.SYCLIsDevice)
-    maybeEmitPipeStorageMetadata(D, GV, *this);
 
   if (AddrSpace != ExpectedAS)
     return getTargetCodeGenInfo().performAddrSpaceCast(*this, GV, AddrSpace,


### PR DESCRIPTION
…for D

Found by a static analysis tool, maybeEmitPipeStorageMetadata
immediately dereferences the "D" parameter. However, the current branch
is in a situation where "D" could be nullptr.  This patch moves it up
into the checked section so that we don't risk this crash.

Signed-off-by: Erich Keane <erich.keane@intel.com>