### PR TITLE
[SYCL] Fix command dependency handling when adding a command group

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -686,7 +686,10 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
   }
 
   // Set new command as user for dependencies and update leaves.
-  for (DepDesc &Dep : NewCmd->MDeps) {
+  // Node dependencies can be modified further when adding the node to leaves,
+  // iterate over their copy.
+  std::vector<DepDesc> Deps = NewCmd->MDeps;
+  for (DepDesc &Dep : Deps) {
     Dep.MDepCommand->addUser(NewCmd.get());
     const Requirement *Req = Dep.MDepRequirement;
     MemObjRecord *Record = getMemObjRecord(Req->MSYCLMemObj);


### PR DESCRIPTION
Fixes an issue where a dependency vector that was iterated over could
have its iterators invalidated inside of the loop.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>