### PR TITLE
[SYCL-PTX] Fix mangling of __spirv_AtomicCompareExchange

### DIFF
--- a/libclc/generic/include/spirv/atomic/atomic_cmpxchg.h
+++ b/libclc/generic/include/spirv/atomic/atomic_cmpxchg.h
@@ -8,37 +8,37 @@
 
 // TODO: Stop manually mangling this name. Need C++ namespaces to get the exact mangling.
 _CLC_DECL int
-_Z29__spirv_AtomicCompareExchangePU3AS3iN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_ii(
+_Z29__spirv_AtomicCompareExchangePU3AS3iN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_ii(
     volatile local int *, enum Scope, enum MemorySemanticsMask,
     enum MemorySemanticsMask, int, int);
 _CLC_DECL int
-_Z29__spirv_AtomicCompareExchangePU3AS1iN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_ii(
+_Z29__spirv_AtomicCompareExchangePU3AS1iN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_ii(
     volatile global int *, enum Scope, enum MemorySemanticsMask,
     enum MemorySemanticsMask, int, int);
 _CLC_DECL uint
-_Z29__spirv_AtomicCompareExchangePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_jj(
+_Z29__spirv_AtomicCompareExchangePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_jj(
     volatile local uint *, enum Scope, enum MemorySemanticsMask,
     enum MemorySemanticsMask, uint, uint);
 _CLC_DECL uint
-_Z29__spirv_AtomicCompareExchangePU3AS1jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_jj(
+_Z29__spirv_AtomicCompareExchangePU3AS1jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_jj(
     volatile global uint *, enum Scope, enum MemorySemanticsMask,
     enum MemorySemanticsMask, uint, uint);
 
 #ifdef cl_khr_int64_base_atomics
 _CLC_DECL long
-_Z29__spirv_AtomicCompareExchangePU3AS3lN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_ll(
+_Z29__spirv_AtomicCompareExchangePU3AS3lN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_ll(
     volatile local long *, enum Scope, enum MemorySemanticsMask,
     enum MemorySemanticsMask, long, long);
 _CLC_DECL long
-_Z29__spirv_AtomicCompareExchangePU3AS1lN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_ll(
+_Z29__spirv_AtomicCompareExchangePU3AS1lN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_ll(
     volatile global long *, enum Scope, enum MemorySemanticsMask,
     enum MemorySemanticsMask, long, long);
 _CLC_DECL unsigned long
-_Z29__spirv_AtomicCompareExchangePU3AS3mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_mm(
+_Z29__spirv_AtomicCompareExchangePU3AS3mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_mm(
     volatile local unsigned long *, enum Scope, enum MemorySemanticsMask,
     enum MemorySemanticsMask, unsigned long, unsigned long);
 _CLC_DECL unsigned long
-_Z29__spirv_AtomicCompareExchangePU3AS1mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_mm(
+_Z29__spirv_AtomicCompareExchangePU3AS1mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_mm(
     volatile global unsigned long *, enum Scope, enum MemorySemanticsMask,
     enum MemorySemanticsMask, unsigned long, unsigned long);
 #endif

--- a/libclc/generic/lib/atomic/atomic_cmpxchg.cl
+++ b/libclc/generic/lib/atomic/atomic_cmpxchg.cl
@@ -6,7 +6,7 @@
                                              TYPE val) {                                                                                                      \
     /* TODO: Stop manually mangling this name. Need C++ namespaces to get the                                                                                 \
      * exact mangling. */                                                                                                                                     \
-    return _Z29__spirv_AtomicCompareExchangePU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_##TYPE_MANGLED##TYPE_MANGLED( \
+    return _Z29__spirv_AtomicCompareExchangePU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_##TYPE_MANGLED##TYPE_MANGLED( \
         p, Device, SequentiallyConsistent, SequentiallyConsistent, val, cmp);                                                                                 \
   }
 

--- a/libclc/generic/lib/cl_khr_int64_base_atomics/atom_cmpxchg.cl
+++ b/libclc/generic/lib/cl_khr_int64_base_atomics/atom_cmpxchg.cl
@@ -6,7 +6,7 @@
 #define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED)                                                                                                              \
   _CLC_OVERLOAD _CLC_DEF TYPE atom_cmpxchg(volatile AS TYPE *p, TYPE cmp,                                                                                     \
                                            TYPE val) {                                                                                                        \
-    return _Z29__spirv_AtomicCompareExchangePU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_##TYPE_MANGLED##TYPE_MANGLED( \
+    return _Z29__spirv_AtomicCompareExchangePU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_##TYPE_MANGLED##TYPE_MANGLED( \
         p, Device, SequentiallyConsistent, SequentiallyConsistent, cmp, val);                                                                                 \
   }
 

--- a/libclc/generic/libspirv/atomic/atomic_cmpxchg.cl
+++ b/libclc/generic/libspirv/atomic/atomic_cmpxchg.cl
@@ -11,28 +11,28 @@
 // TODO: Stop manually mangling this name. Need C++ namespaces to get the exact mangling.
 
 _CLC_DEF int
-_Z29__spirv_AtomicCompareExchangePU3AS3iN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_ii(
+_Z29__spirv_AtomicCompareExchangePU3AS3iN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_ii(
     volatile local int *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, int val, int cmp) {
   return __sync_val_compare_and_swap(p, cmp, val);
 }
 
 _CLC_DEF int
-_Z29__spirv_AtomicCompareExchangePU3AS1iN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_ii(
+_Z29__spirv_AtomicCompareExchangePU3AS1iN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_ii(
     volatile global int *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, int val, int cmp) {
   return __sync_val_compare_and_swap(p, cmp, val);
 }
 
 _CLC_DEF uint
-_Z29__spirv_AtomicCompareExchangePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_jj(
+_Z29__spirv_AtomicCompareExchangePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_jj(
     volatile local uint *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, uint val, uint cmp) {
   return __sync_val_compare_and_swap(p, cmp, val);
 }
 
 _CLC_DEF uint
-_Z29__spirv_AtomicCompareExchangePU3AS1jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_jj(
+_Z29__spirv_AtomicCompareExchangePU3AS1jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_jj(
     volatile global uint *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, uint val, uint cmp) {
   return __sync_val_compare_and_swap(p, cmp, val);
@@ -40,56 +40,56 @@ _Z29__spirv_AtomicCompareExchangePU3AS1jN5__spv5Scope4FlagENS1_19MemorySemantics
 
 #ifdef cl_khr_int64_base_atomics
 _CLC_DEF long
-_Z29__spirv_AtomicCompareExchangePU3AS3lN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_ll(
+_Z29__spirv_AtomicCompareExchangePU3AS3lN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_ll(
     volatile local long *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, long val, long cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
 _CLC_DEF long
-_Z29__spirv_AtomicCompareExchangePU3AS1lN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_ll(
+_Z29__spirv_AtomicCompareExchangePU3AS1lN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_ll(
     volatile global long *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, long val, long cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
 _CLC_DEF ulong
-_Z29__spirv_AtomicCompareExchangePU3AS3mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_mm(
+_Z29__spirv_AtomicCompareExchangePU3AS3mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_mm(
     volatile local ulong *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, ulong val, ulong cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
 _CLC_DEF ulong
-_Z29__spirv_AtomicCompareExchangePU3AS1mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_mm(
+_Z29__spirv_AtomicCompareExchangePU3AS1mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_mm(
     volatile global ulong *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, ulong val, ulong cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
 _CLC_DEF long
-_Z29__spirv_AtomicCompareExchangePU3AS3xN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_xx(
+_Z29__spirv_AtomicCompareExchangePU3AS3xN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_xx(
     volatile local long *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, long val, long cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
 _CLC_DEF long
-_Z29__spirv_AtomicCompareExchangePU3AS1xN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_xx(
+_Z29__spirv_AtomicCompareExchangePU3AS1xN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_xx(
     volatile global long *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, long val, long cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
 _CLC_DEF ulong
-_Z29__spirv_AtomicCompareExchangePU3AS3yN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_yy(
+_Z29__spirv_AtomicCompareExchangePU3AS3yN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_yy(
     volatile local ulong *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, ulong val, ulong cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
 _CLC_DEF ulong
-_Z29__spirv_AtomicCompareExchangePU3AS1yN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES3_yy(
+_Z29__spirv_AtomicCompareExchangePU3AS1yN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_yy(
     volatile global ulong *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, ulong val, ulong cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);


### PR DESCRIPTION
AtomicCompareExchange 4th argument was mangled as `Scope` instead of `MemorySemanticsMask` 

Signed-off-by: Victor Lomuller <victor@codeplay.com>