### PR TITLE
[SYCL][NFC] Refactor lit.cfg.py

### DIFF
--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -26,7 +26,7 @@ config.test_format = lit.formats.ShTest()
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.c', '.cpp'] #add .spv. Currently not clear what to do with those
 
-config.excludes = ['CMakeLists.txt', 'run_tests.sh', 'README.txt', 'Inputs']
+config.excludes = ['Inputs']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
@@ -34,41 +34,28 @@ config.test_source_root = os.path.dirname(__file__)
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.sycl_obj_root, 'test')
 
+# Propagate some variables from the host environment.
+llvm_config.with_system_environment(['PATH', 'OCL_ICD_FILENAME', 'SYCL_DEVICE_ALLOWLIST', 'SYCL_CONFIG_FILE_NAME'])
+
+# Configure LD_LIBRARY_PATH or corresponding os-specific alternatives
 if platform.system() == "Linux":
     config.available_features.add('linux')
-    # Propagate 'LD_LIBRARY_PATH' through the environment.
-    if 'LD_LIBRARY_PATH' in os.environ:
-        config.environment['LD_LIBRARY_PATH'] = os.path.pathsep.join((config.environment['LD_LIBRARY_PATH'], config.sycl_libs_dir))
-    else:
-        config.environment['LD_LIBRARY_PATH'] = config.sycl_libs_dir
+    llvm_config.with_system_environment('LD_LIBRARY_PATH')
+    llvm_config.with_environment('LD_LIBRARY_PATH', config.sycl_libs_dir, append_path=True)
 
 elif platform.system() == "Windows":
     config.available_features.add('windows')
-    if 'LIB' in os.environ:
-        config.environment['LIB'] = os.path.pathsep.join((config.environment['LIB'], config.sycl_libs_dir))
-    else:
-        config.environment['LIB'] = config.sycl_libs_dir
-
-    if 'PATH' in os.environ:
-        config.environment['PATH'] = os.path.pathsep.join((config.environment['PATH'], config.sycl_tools_dir))
-    else:
-        config.environment['PATH'] = config.sycl_tools_dir
+    llvm_config.with_system_environment('LIB')
+    llvm_config.with_environment('LIB', config.sycl_libs_dir, append_path=True)
 
 elif platform.system() == "Darwin":
     # FIXME: surely there is a more elegant way to instantiate the Xcode directories.
-    if 'CPATH' in os.environ:
-        config.environment['CPATH'] = os.path.pathsep.join((os.environ['CPATH'], "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"))
-    else:
-        config.environment['CPATH'] = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"
-    config.environment['CPATH'] = os.path.pathsep.join((config.environment['CPATH'], "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"))
-    config.environment['DYLD_LIBRARY_PATH'] = config.sycl_libs_dir
+    llvm_config.with_system_environment('CPATH')
+    llvm_config.with_environment('CPATH', "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1", append_path=True)
+    llvm_config.with_environment('CPATH', "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/", append_path=True)
+    llvm_config.with_environment('DYLD_LIBRARY_PATH', config.sycl_libs_dir)
 
-# propagate the environment variable OCL_ICD_FILANEMES to use proper runtime.
-if 'OCL_ICD_FILENAMES' in os.environ:
-    config.environment['OCL_ICD_FILENAMES'] = os.environ['OCL_ICD_FILENAMES']
-
-if 'SYCL_DEVICE_ALLOWLIST' in os.environ:
-    config.environment['SYCL_DEVICE_ALLOWLIST'] = os.environ['SYCL_DEVICE_ALLOWLIST']
+llvm_config.with_environment('PATH', config.sycl_tools_dir, append_path=True)
 
 config.substitutions.append( ('%sycl_libs_dir',  config.sycl_libs_dir ) )
 config.substitutions.append( ('%sycl_include',  config.sycl_include ) )
@@ -79,14 +66,7 @@ config.substitutions.append( ('%cuda_toolkit_include',  config.cuda_toolkit_incl
 
 llvm_config.use_clang()
 
-tools = ['llvm-spirv']
-tool_dirs = [config.sycl_tools_dir]
-llvm_config.add_tool_substitutions(tools, tool_dirs)
-
-if "opencl-aot" in config.llvm_enable_projects:
-    if 'PATH' in os.environ:
-        print("Adding path to opencl-aot tool to PATH")
-        os.environ['PATH'] = os.path.pathsep.join((os.getenv('PATH'), config.sycl_tools_dir))
+llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 
 backend=lit_config.params.get('SYCL_BE', "PI_OPENCL")
 
@@ -98,29 +78,38 @@ def getDeviceCount(device_type):
         stdout=subprocess.PIPE)
     (output, err) = process.communicate()
     exit_code = process.wait()
+
     if exit_code != 0:
-        print("getDeviceCount {TYPE}:Non-zero exit code {CODE}".format(
-            TYPE=device_type, CODE=exit_code))
+        lit_config.error("getDeviceCount {TYPE} {BACKEND}: Non-zero exit code {CODE}".format(
+            TYPE=device_type, BACKEND=backend, CODE=exit_code))
         return [0,False]
+
     result = output.decode().replace('\n', '').split(':', 1)
     try:
         value = int(result[0])
     except ValueError:
         value = 0
-        print("getDeviceCount {TYPE}:Cannot get value from output.".format(
-            TYPE=device_type))
-    if len(result) > 1 and len(result[1]):
-        print("getDeviceCount {TYPE}:{MSG}".format(
-            TYPE=device_type, MSG=result[1]))
+        lit_config.error("getDeviceCount {TYPE} {BACKEND}: Cannot get value from output: {OUT}".format(
+            TYPE=device_type, BACKEND=backend, OUT=result[0]))
+
+    # if we have found gpu and there is additional information, let's check
+    # whether this is CUDA device or not
+    if device_type == "gpu" and value > 0 and len(result[1]):
         if re.match(r".*cuda", result[1]):
             is_cuda = True;
+
     if err:
-        print("getDeviceCount {TYPE}:{ERR}".format(
-            TYPE=device_type, ERR=err))
+        lit_config.warning("getDeviceCount {TYPE} {BACKEND} stderr:{ERR}".format(
+            TYPE=device_type, BACKEND=backend, ERR=err))
     return [value,is_cuda]
 
 # Every SYCL implementation provides a host implementation.
 config.available_features.add('host')
+
+# Configure device-specific substitutions based on availability of corresponding
+# devices/runtimes
+
+found_at_least_one_device = False
 
 cpu_run_substitute = "true"
 cpu_run_on_linux_substitute = "true "
@@ -128,13 +117,17 @@ cpu_check_substitute = ""
 cpu_check_on_linux_substitute = ""
 
 if getDeviceCount("cpu")[0]:
-    print("Found available CPU device")
+    found_at_least_one_device = True
+    lit_config.note("Found available CPU device")
     cpu_run_substitute = "env SYCL_DEVICE_TYPE=CPU "
     cpu_check_substitute = "| FileCheck %s"
     config.available_features.add('cpu')
     if platform.system() == "Linux":
         cpu_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=CPU "
         cpu_check_on_linux_substitute = "| FileCheck %s"
+else:
+    lit_config.warning("CPU device not found")
+
 config.substitutions.append( ('%CPU_RUN_PLACEHOLDER',  cpu_run_substitute) )
 config.substitutions.append( ('%CPU_RUN_ON_LINUX_PLACEHOLDER',  cpu_run_on_linux_substitute) )
 config.substitutions.append( ('%CPU_CHECK_PLACEHOLDER',  cpu_check_substitute) )
@@ -149,7 +142,8 @@ cuda = False
 [gpu_count, cuda] = getDeviceCount("gpu")
 
 if gpu_count > 0:
-    print("Found available GPU device")
+    found_at_least_one_device = True
+    lit_config.note("Found available GPU device")
     gpu_run_substitute = " env SYCL_DEVICE_TYPE=GPU "
     gpu_check_substitute = "| FileCheck %s"
     config.available_features.add('gpu')
@@ -162,47 +156,53 @@ if gpu_count > 0:
         gpu_check_on_linux_substitute = "| FileCheck %s"
         if cuda:
             gpu_run_on_linux_substitute += " SYCL_BE=PI_CUDA "
+else:
+    lit_config.warning("GPU device not found")
 
 config.substitutions.append( ('%GPU_RUN_PLACEHOLDER',  gpu_run_substitute) )
 config.substitutions.append( ('%GPU_RUN_ON_LINUX_PLACEHOLDER',  gpu_run_on_linux_substitute) )
 config.substitutions.append( ('%GPU_CHECK_PLACEHOLDER',  gpu_check_substitute) )
 config.substitutions.append( ('%GPU_CHECK_ON_LINUX_PLACEHOLDER',  gpu_check_on_linux_substitute) )
 
+acc_run_substitute = "true"
+acc_check_substitute = ""
+if getDeviceCount("accelerator")[0] and platform.system() == "Linux":
+    found_at_least_one_device = True
+    lit_config.note("Found available accelerator device")
+    acc_run_substitute = " env SYCL_DEVICE_TYPE=ACC "
+    acc_check_substitute = "| FileCheck %s"
+    config.available_features.add('accelerator')
+else:
+    lit_config.warning("Accelerator device not found")
+config.substitutions.append( ('%ACC_RUN_PLACEHOLDER',  acc_run_substitute) )
+config.substitutions.append( ('%ACC_CHECK_PLACEHOLDER',  acc_check_substitute) )
+
+# PI API either supports OpenCL or CUDA.
+if not cuda and found_at_least_one_device:
+    config.available_features.add('opencl')
+
 if cuda:
     config.substitutions.append( ('%sycl_triple',  "nvptx64-nvidia-cuda-sycldevice" ) )
 else:
     config.substitutions.append( ('%sycl_triple',  "spir64-unknown-linux-sycldevice" ) )
 
-acc_run_substitute = "true"
-acc_check_substitute = ""
-if getDeviceCount("accelerator")[0] and platform.system() == "Linux":
-    print("Found available accelerator device")
-    acc_run_substitute = " env SYCL_DEVICE_TYPE=ACC "
-    acc_check_substitute = "| FileCheck %s"
-    config.available_features.add('accelerator')
-config.substitutions.append( ('%ACC_RUN_PLACEHOLDER',  acc_run_substitute) )
-config.substitutions.append( ('%ACC_CHECK_PLACEHOLDER',  acc_check_substitute) )
-
-# PI API either supports OpenCL or CUDA.
-opencl = False
-if not cuda:
-    opencl = True
-    config.available_features.add('opencl')
-
-
-path = config.environment['PATH']
-path = os.path.pathsep.join((config.sycl_tools_dir, path))
-config.environment['PATH'] = path
+if "opencl-aot" in config.llvm_enable_projects:
+    lit_config.note("Using opencl-aot version which is built as part of the project")
+    config.available_features.add("opencl-aot")
+    llvm_config.add_tool_substitutions(['opencl-aot'], [config.sycl_tools_dir])
 
 # Device AOT compilation tools aren't part of the SYCL project,
 # so they need to be pre-installed on the machine
-aot_tools = ["opencl-aot", "ocloc", "aoc"]
+aot_tools = ["ocloc", "aoc"]
+if "opencl-aot" not in config.llvm_enable_projects:
+    aot_tools.append('opencl-aot')
+
 for aot_tool in aot_tools:
     if find_executable(aot_tool) is not None:
-        print("Found AOT device compiler " + aot_tool)
+        lit_config.note("Found pre-installed AOT device compiler " + aot_tool)
         config.available_features.add(aot_tool)
     else:
-        print("Could not find AOT device compiler " + aot_tool)
+        lit_config.warning("Couldn't find pre-installed AOT device compiler " + aot_tool)
 
 # Set timeout for test = 10 mins
 try:

--- a/sycl/tools/get_device_count_by_type.cpp
+++ b/sycl/tools/get_device_count_by_type.cpp
@@ -18,11 +18,11 @@
 #include <vector>
 
 static const std::string help =
-"   Help\n"
-"   Example: ./get_device_count_by_type cpu opencl\n"
-"   Support types: cpu/gpu/accelerator/default/all\n"
-"   Support backends: cuda/opencl \n"
-"   Output format: <number_of_devices>:<additional_Information>";
+    "   Help\n"
+    "   Example: ./get_device_count_by_type cpu opencl\n"
+    "   Supported device types: cpu/gpu/accelerator/default/all\n"
+    "   Supported backends: PI_CUDA/PI_OPENCL \n"
+    "   Output format: <number_of_devices>:<additional_Information>";
 
 int main(int argc, char* argv[]) {
     if (argc < 3) {
@@ -45,7 +45,8 @@ int main(int argc, char* argv[]) {
 
       auto err = cuDriverGetVersion(&runtime_version);
       if (runtime_version < 9020 || err != CUDA_SUCCESS) {
-        std::cout << deviceCount << " :Unsupported CUDA Runtime " << std::endl;
+        std::cout << deviceCount << ":Unsupported CUDA Runtime " << std::endl;
+        return 1;
       }
 
       if (type == "gpu") {
@@ -56,7 +57,7 @@ int main(int argc, char* argv[]) {
         msg += " type: ";
         msg += type;
       }
-      std::cout << deviceCount << " : " << msg << std::endl;
+      std::cout << deviceCount << ":" << msg << std::endl;
       return 0;
     }
 #endif  // USE_PI_CUDA
@@ -108,7 +109,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    std::cout << deviceCount << ":" << backend << std::endl;
+    std::cout << deviceCount << ":" << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
Switched to use "lit_config.note" instead of just "print": this emits
potentially more usefult message, because it shows particular file and
line where it was emitted, something like:

```
llvm-lit: /sycl/test/lit.cfg.py:117: note: Found available CPU device
llvm-lit: /sycl/test/lit.cfg.py:154: warning: GPU device not found
llvm-lit: /sycl/test/lit.cfg.py:169: warning: Accelerator device not found
llvm-lit: /sycl/test/lit.cfg.py:198: warning: Couldn't find pre-installed AOT device compiler ocloc
llvm-lit: /sycl/test/lit.cfg.py:198: warning: Couldn't find pre-installed AOT device compiler aoc
llvm-lit: /sycl/test/lit.cfg.py:198: warning: Couldn't find pre-installed AOT device compiler opencl-aot
```

It also should be possible now to suppress this output via "-q" option
to llvm-lit

Removed extra items from "config.excludes" list since they were ignored
anyway based on content of "config.suffixes"

Simplified environment propagation by re-using existing helper functions

Updated logic of `getDeviceCount` function to avoid printing useless
messages

Removed duplicated handling of path to SYCL tools directory

Refactored handling of "opencl-aot" tool: now if it was built together
with product, version from build directory will be used rather than a
system one
