### PR TITLE
Revert "[SYCL] XFAIL LIT test due to duplicate diagnostic"

### DIFF
--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -2,9 +2,6 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify %s -DLINUX_ASM -DSPIR_CHECK -triple spir64-unknown-unknown-sycldevice
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -triple x86_64-windows -fasm-blocks %s
 
-// Invalid output constraint diagnistic is duplicated
-// XFAIL:*
-
 #ifndef SPIR_CHECK
 //expected-no-diagnostics
 #endif // SPIR_CHECK
@@ -25,7 +22,7 @@ static __inline unsigned int
 asm_func_2(unsigned int __leaf, unsigned long __d[]) {
   unsigned int __result;
 #ifdef SPIR_CHECK
-  //expected-error@+2 {{invalid output constraint '=a' in asm}}
+  //expected-error@+2 2{{invalid output constraint '=a' in asm}}
   __asm__("enclu"
           : "=a"(__result), "=b"(__d[0]), "=c"(__d[1]), "=d"(__d[2])
           : "a"(__leaf), "b"(__d[0]), "c"(__d[1]), "d"(__d[2])
@@ -61,7 +58,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 #ifdef SPIR_CHECK
   unsigned int i = 3;
   unsigned long d[4];
-  //expected-note@+1 {{called by 'kernel_single_task'}}
+  //expected-note@+1 2{{called by 'kernel_single_task}}
   asm_func_2(i, d);
 #endif // SPIR_CHECK
 #else


### PR DESCRIPTION
This reverts commit a28778c2a686f503fad805ca4de963e5a39fdeb6
and fixes the test.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>