### PR TITLE
[SYCL] moving type checks to later in Semantic Analysis lifecycle

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12455,7 +12455,7 @@ public:
   };
 
   bool isKnownGoodSYCLDecl(const Decl *D);
-  void checkSYCLVarDeclIfInKernel(VarDecl *Var);
+  void checkSYCLDeviceVarDecl(VarDecl *Var);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
   void MarkDevice();
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12455,6 +12455,7 @@ public:
   };
 
   bool isKnownGoodSYCLDecl(const Decl *D);
+  void CheckVarDeclOKIfInKernel(VarDecl *var);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
   void MarkDevice();
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12455,7 +12455,7 @@ public:
   };
 
   bool isKnownGoodSYCLDecl(const Decl *D);
-  void CheckVarDeclOKIfInKernel(VarDecl *var);
+  void checkSYCLVarDeclIfInKernel(VarDecl *Var);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
   void MarkDevice();
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -12661,7 +12661,7 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
   }
 
   if (getLangOpts().SYCLIsDevice)
-    CheckVarDeclOKIfInKernel(var);
+    checkSYCLVarDeclIfInKernel(var);
 
   // In Objective-C, don't allow jumps past the implicit initialization of a
   // local retaining variable.

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -12661,7 +12661,7 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
   }
 
   if (getLangOpts().SYCLIsDevice)
-    checkSYCLVarDeclIfInKernel(var);
+    checkSYCLDeviceVarDecl(var);
 
   // In Objective-C, don't allow jumps past the implicit initialization of a
   // local retaining variable.

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -12660,6 +12660,9 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
     }
   }
 
+  if (getLangOpts().SYCLIsDevice)
+    CheckVarDeclOKIfInKernel(var);
+
   // In Objective-C, don't allow jumps past the implicit initialization of a
   // local retaining variable.
   if (getLangOpts().ObjC &&

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -264,15 +264,13 @@ static void checkSYCLVarType(Sema &S, QualType Ty, SourceRange Loc,
     if (!CRD->hasDefinition())
       return;
 
-    for (const auto &Field : CRD->fields()) {
+    for (const auto &Field : CRD->fields())
       checkSYCLVarType(S, Field->getType(), Field->getSourceRange(), Visited,
                        Loc);
-    }
   } else if (const auto *RD = Ty->getAsRecordDecl()) {
-    for (const auto &Field : RD->fields()) {
+    for (const auto &Field : RD->fields())
       checkSYCLVarType(S, Field->getType(), Field->getSourceRange(), Visited,
                        Loc);
-    }
   } else if (const auto *FPTy = dyn_cast<FunctionProtoType>(Ty)) {
     for (const auto &ParamTy : FPTy->param_types())
       checkSYCLVarType(S, ParamTy, Loc, Visited);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -28,7 +28,6 @@
 
 #include <array>
 
-
 using namespace clang;
 
 using KernelParamKind = SYCLIntegrationHeader::kernel_param_kind_t;
@@ -237,8 +236,6 @@ void Sema::CheckVarDeclOKIfInKernel(VarDecl *var) {
   }
 }
 
-
-
 class MarkDeviceFunction : public RecursiveASTVisitor<MarkDeviceFunction> {
 public:
   MarkDeviceFunction(Sema &S)
@@ -268,7 +265,6 @@ public:
         if (Method->isVirtual())
           SemaRef.Diag(e->getExprLoc(), diag::err_sycl_restrict)
               << Sema::KernelCallVirtualFunction;
-       
       CheckSYCLType(Callee->getReturnType(), Callee->getSourceRange());
 
       if (auto const *FD = dyn_cast<FunctionDecl>(Callee)) {
@@ -339,7 +335,6 @@ public:
     Decl *D = E->getDecl();
     if (SemaRef.isKnownGoodSYCLDecl(D))
       return true;
-    
     CheckSYCLType(E->getType(), E->getSourceRange());
     return true;
   }
@@ -474,12 +469,10 @@ private:
 
   bool CheckSYCLType(QualType Ty, SourceRange Loc,
                      llvm::DenseSet<QualType> &Visited) {
-    
     if (Ty->isVariableArrayType()) {
       SemaRef.Diag(Loc.getBegin(), diag::err_vla_unsupported);
       return false;
     }
-    
     while (Ty->isAnyPointerType() || Ty->isArrayType())
       Ty = QualType{Ty->getPointeeOrArrayElementType(), 0};
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -206,9 +206,9 @@ static bool isZeroSizedArray(QualType Ty) {
   return false;
 }
 
-static Sema::DeviceDiagBuilder emitDeferredDiagnosticAndNote(Sema &S, SourceRange Loc,
-                                                      unsigned DiagID,
-                                                      SourceRange UsedAtLoc) {
+static Sema::DeviceDiagBuilder
+emitDeferredDiagnosticAndNote(Sema &S, SourceRange Loc, unsigned DiagID,
+                              SourceRange UsedAtLoc) {
   Sema::DeviceDiagBuilder builder =
       S.SYCLDiagIfDeviceCode(Loc.getBegin(), DiagID);
   if (UsedAtLoc.isValid())

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -240,17 +240,13 @@ static void checkSYCLVarType(Sema &S, QualType Ty, SourceRange Loc,
   while (Ty->isAnyPointerType() || Ty->isArrayType())
     Ty = QualType{Ty->getPointeeOrArrayElementType(), 0};
 
-  // __int128, __int128_t, __uint128_t
+  // __int128, __int128_t, __uint128_t, __float128
   if (Ty->isSpecificBuiltinType(BuiltinType::Int128) ||
-      Ty->isSpecificBuiltinType(BuiltinType::UInt128))
+      Ty->isSpecificBuiltinType(BuiltinType::UInt128) ||
+      (Ty->isSpecificBuiltinType(BuiltinType::Float128) &&
+       !S.Context.getTargetInfo().hasFloat128Type()))
     emitDeferredDiagnosticAndNote(S, Loc, diag::err_type_unsupported, UsedAtLoc)
         << Ty.getUnqualifiedType().getCanonicalType();
-
-  // QuadType __float128
-  if (Ty->isSpecificBuiltinType(BuiltinType::Float128) &&
-      !S.Context.getTargetInfo().hasFloat128Type())
-    emitDeferredDiagnosticAndNote(S, Loc, diag::err_type_unsupported, UsedAtLoc)
-        << S.Context.Float128Ty;
 
   //--- now recurse ---
   // Pointers complicate recursion. Add this type to Visited.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -220,25 +220,26 @@ static void checkSYCLVarType(Sema &S, QualType Ty, SourceRange Loc,
                              llvm::DenseSet<QualType> Visited,
                              SourceRange UsedAtLoc = SourceRange()) {
   // Not all variable types are supported inside SYCL kernels,
-  // for example, the quad type __float128, will cause the resulting
+  // for example the quad type __float128 will cause the resulting
   // SPIR-V to not link.
-  // Here we check any potentially unsupported decl and issue
-  // a deferred diagnostic, which will be emitted iff the decl
+  // Here we check any potentially unsupported declaration and issue
+  // a deferred diagnostic, which will be emitted iff the declaration
   // is discovered to reside in kernel code.
   // The optional UsedAtLoc param is used when the SYCL usage is at a
   // different location than the variable declaration and we need to
-  // inform the user of both, e.g. struct member usage vs declaration
+  // inform the user of both, e.g. struct member usage vs declaration.
+
+  //--- check types ---
 
   // zero length arrays
   if (isZeroSizedArray(Ty))
     emitDeferredDiagnosticAndNote(S, Loc, diag::err_typecheck_zero_array_size,
                                   UsedAtLoc);
 
-  // sub-reference
+  // Sub-reference array or pointer, then proceed with that type.
   while (Ty->isAnyPointerType() || Ty->isArrayType())
     Ty = QualType{Ty->getPointeeOrArrayElementType(), 0};
 
-  // check types
   // __int128, __int128_t, __uint128_t
   if (Ty->isSpecificBuiltinType(BuiltinType::Int128) ||
       Ty->isSpecificBuiltinType(BuiltinType::UInt128))

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -200,7 +200,7 @@ bool Sema::isKnownGoodSYCLDecl(const Decl *D) {
   return false;
 }
 
-bool isArraySizedZero(QualType Ty) {
+bool isZeroSizedArray(QualType Ty) {
   if (const auto *CATy = dyn_cast<ConstantArrayType>(Ty)) {
     const llvm::APInt size = CATy->getSize();
     return size == 0;
@@ -208,12 +208,12 @@ bool isArraySizedZero(QualType Ty) {
   return false;
 }
 
-void Sema::CheckVarDeclOKIfInKernel(VarDecl *var) {
+void Sema::checkSYCLVarDeclIfInKernel(VarDecl *Var) {
   // not all variable types supported in kernel contexts
   // if not we record a deferred diagnostic.
   if (getLangOpts().SYCLIsDevice) {
-    QualType Ty = var->getType();
-    SourceRange Loc = var->getLocation();
+    QualType Ty = Var->getType();
+    SourceRange Loc = Var->getLocation();
 
     // __int128, __int128_t, __uint128_t
     if (Ty->isSpecificBuiltinType(BuiltinType::Int128) ||
@@ -228,7 +228,7 @@ void Sema::CheckVarDeclOKIfInKernel(VarDecl *var) {
           << "__float128";
 
     // zero length arrays
-    if (Ty->isArrayType() && isArraySizedZero(Ty))
+    if (Ty->isArrayType() && isZeroSizedArray(Ty))
       SYCLDiagIfDeviceCode(Loc.getBegin(), diag::err_typecheck_zero_array_size);
 
     // TODO: check type of accessor

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -257,8 +257,8 @@ static void checkSYCLVarType(Sema &S, QualType Ty, SourceRange Loc,
   if (const auto *ATy = dyn_cast<AttributedType>(Ty))
     return checkSYCLVarType(S, ATy->getModifiedType(), Loc, Visited);
 
-  if (const auto *CRD = Ty->getAsCXXRecordDecl()) {
-    for (const auto &Field : CRD->fields())
+  if (const auto *RD = Ty->getAsRecordDecl()) {
+    for (const auto &Field : RD->fields())
       checkSYCLVarType(S, Field->getType(), Field->getSourceRange(), Visited,
                        Loc);
   } else if (const auto *FPTy = dyn_cast<FunctionProtoType>(Ty)) {

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -37,6 +37,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
 
+
 using namespace clang;
 
 enum TypeDiagSelector {
@@ -1520,19 +1521,16 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
   case DeclSpec::TST_half:    Result = Context.HalfTy; break;
   case DeclSpec::TST_float:   Result = Context.FloatTy; break;
   case DeclSpec::TST_double:
-    if (DS.getTypeSpecWidth() == DeclSpec::TSW_long)
+    if (DS.getTypeSpecWidth() == DeclSpec::TSW_long) {
       Result = Context.LongDoubleTy;
-    else
+    } else {
       Result = Context.DoubleTy;
+    }
     break;
   case DeclSpec::TST_float128:
-    if (!S.Context.getTargetInfo().hasFloat128Type() &&
-        S.getLangOpts().SYCLIsDevice)
-      S.SYCLDiagIfDeviceCode(DS.getTypeSpecTypeLoc(),
-                             diag::err_type_unsupported)
-          << "__float128";
-    else if (!S.Context.getTargetInfo().hasFloat128Type() &&
-             !(S.getLangOpts().OpenMP && S.getLangOpts().OpenMPIsDevice))
+     if (!S.Context.getTargetInfo().hasFloat128Type() && 
+        !S.getLangOpts().SYCLIsDevice &&
+        !(S.getLangOpts().OpenMP && S.getLangOpts().OpenMPIsDevice))
       S.Diag(DS.getTypeSpecTypeLoc(), diag::err_type_unsupported)
           << "__float128";
     Result = Context.Float128Ty;
@@ -2350,12 +2348,6 @@ QualType Sema::BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
             << ArraySize->getSourceRange();
         ASM = ArrayType::Normal;
       }
-
-      // Zero length arrays are disallowed in SYCL device code.
-      if (getLangOpts().SYCLIsDevice)
-        SYCLDiagIfDeviceCode(ArraySize->getBeginLoc(),
-                             diag::err_typecheck_zero_array_size)
-            << ArraySize->getSourceRange();
     } else if (!T->isDependentType() && !T->isVariablyModifiedType() &&
                !T->isIncompleteType() && !T->isUndeducedType()) {
       // Is the array too large?

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -37,7 +37,6 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
 
-
 using namespace clang;
 
 enum TypeDiagSelector {
@@ -1528,7 +1527,7 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
     }
     break;
   case DeclSpec::TST_float128:
-     if (!S.Context.getTargetInfo().hasFloat128Type() && 
+    if (!S.Context.getTargetInfo().hasFloat128Type() &&
         !S.getLangOpts().SYCLIsDevice &&
         !(S.getLangOpts().OpenMP && S.getLangOpts().OpenMPIsDevice))
       S.Diag(DS.getTypeSpecTypeLoc(), diag::err_type_unsupported)

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1520,11 +1520,10 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
   case DeclSpec::TST_half:    Result = Context.HalfTy; break;
   case DeclSpec::TST_float:   Result = Context.FloatTy; break;
   case DeclSpec::TST_double:
-    if (DS.getTypeSpecWidth() == DeclSpec::TSW_long) {
+    if (DS.getTypeSpecWidth() == DeclSpec::TSW_long)
       Result = Context.LongDoubleTy;
-    } else {
+    else
       Result = Context.DoubleTy;
-    }
     break;
   case DeclSpec::TST_float128:
     if (!S.Context.getTargetInfo().hasFloat128Type() &&

--- a/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
@@ -2,13 +2,18 @@
 //
 // Ensure that the SYCL diagnostics that are typically deferred are correctly emitted.
 
+namespace std {
+class type_info;
+typedef __typeof__(sizeof(int)) size_t;
+} // namespace std
+
 // testing that the deferred diagnostics work in conjunction with the SYCL namespaces.
 inline namespace cl {
 namespace sycl {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
-  // expected-note@+1 2{{called by 'kernel_single_task<AName, (lambda}}
+  // expected-note@+1 3{{called by 'kernel_single_task<AName, (lambda}}
   kernelFunc();
 }
 
@@ -18,6 +23,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 //variadic functions from SYCL kernels emit a deferred diagnostic
 void variadic(int, ...) {}
 
+// there are more types like this checked in sycl-restrict.cpp
 int calledFromKernel(int a) {
   // expected-error@+1 {{zero-length arrays are not permitted in C++}}
   int MalArray[0];
@@ -31,21 +37,105 @@ int calledFromKernel(int a) {
   return a + 20;
 }
 
+// defines (early and late)
+#define floatDef   __float128
+#define int128Def  __int128
+#define int128tDef  __int128_t
+#define intDef     int
+ 
+//typedefs (late )
+typedef const __uint128_t megeType;
+typedef const __float128  trickyFloatType;
+typedef const __int128    tricky128Type;
+
+//templated type (late)
+template<typename T> T bar(){ return T(); };
+
+//false positive. early incorrectly catches
+template<typename t> void foo(){};
+
 //  template used to specialize a function that contains a lambda that should
 //  result in a deferred diagnostic being emitted.
-//  HOWEVER, this is not working presently.
-//  TODO: re-test after new deferred diagnostic system is merged.
-//        restore the "FIX!!" tests below
+
 
 template <typename T>
 void setup_sycl_operation(const T VA[]) {
 
   cl::sycl::kernel_single_task<class AName>([]() {
-    // FIX!!  xpected-error@+1 {{zero-length arrays are not permitted in C++}}
-    int OverlookedBadArray[0];
+    
+    // ======= Zero Length Arrays Not Allowed in Kernel ==========
+    // expected-error@+1 {{zero-length arrays are not permitted in C++}}
+    int MalArray[0]; 
+    // expected-error@+1 {{zero-length arrays are not permitted in C++}}
+    intDef MalArrayDef[0];    
+    // ---- false positive tests. These should not generate any errors.
+    foo<int[0]>();    
+    std::size_t arrSz = sizeof(int[0]); 
 
-    // FIX!!   xpected-error@+1 {{__float128 is not supported on this target}}
-    __float128 overlookedBadFloat = 40;
+    // ======= Float128 Not Allowed in Kernel ==========
+    // expected-error@+1 {{__float128 is not supported on this target}}
+    __float128 malFloat = 40; 
+    // expected-error@+1 {{__float128 is not supported on this target}}
+    trickyFloatType malFloatTrick = 41;
+    // expected-error@+1 {{__float128 is not supported on this target}}
+    floatDef        malFloatDef = 44;
+    // expected-error@+1 {{__float128 is not supported on this target}}
+    auto whatFloat = malFloat;
+    // expected-error@+1 {{__float128 is not supported on this target}}
+    auto malAutoTemp5 = bar<__float128>();
+    // expected-error@+1 {{__float128 is not supported on this target}}       
+    auto malAutoTemp6 = bar<trickyFloatType>();   
+    // expected-error@+1 {{__float128 is not supported on this target}}
+    decltype(malFloat) malDeclFloat = 42;
+    // ---- false positive tests
+    std::size_t someSz = sizeof(__float128);   
+    foo<__float128>();
+
+    // ======= __int128 Not Allowed in Kernel ==========
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    __int128   malIntent = 2; 
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    tricky128Type mal128Trick = 2;
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    int128Def     malIntDef = 9;
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    auto whatInt128 = malIntent;
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    auto malAutoTemp = bar<__int128>();
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    auto malAutoTemp2 = bar<tricky128Type>();
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    decltype(malIntent) malDeclInt = 2;
+
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    __int128_t  malInt128 = 2;
+    // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+    __uint128_t malUInt128 = 3;
+    // expected-error@+1 {{unsigned __int128 is not supported on this target}}                            
+    megeType   malTypeDefTrick = 4; 
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    int128tDef  malInt2Def = 6;
+    // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+    auto whatUInt = malUInt128;
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    auto malAutoTemp3 = bar<__int128_t>();
+    // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+    auto malAutoTemp4 = bar<megeType>();
+    // expected-error@+1 {{__int128 is not supported on this target}}
+    decltype(malInt128) malDeclInt128 = 5;
+
+    // ---- false positive tests These should not generate any errors. 
+    std::size_t i128Sz = sizeof(__int128);                              
+    foo<__int128>();
+    std::size_t u128Sz = sizeof(__uint128_t);
+    foo<__int128_t>();
+
+
+    // ========= variadic
+    //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+    variadic(5);
+
+
   });
 }
 

--- a/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
@@ -28,7 +28,7 @@ int calledFromKernel(int a) {
   // expected-error@+1 {{zero-length arrays are not permitted in C++}}
   int MalArray[0];
 
-  // expected-error@+1 {{__float128 is not supported on this target}}
+  // expected-error@+1 {{'__float128' is not supported on this target}}
   __float128 malFloat = 40;
 
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
@@ -73,55 +73,55 @@ void setup_sycl_operation(const T VA[]) {
     std::size_t arrSz = sizeof(int[0]);
 
     // ======= Float128 Not Allowed in Kernel ==========
-    // expected-error@+1 {{__float128 is not supported on this target}}
+    // expected-error@+1 {{'__float128' is not supported on this target}}
     __float128 malFloat = 40;
-    // expected-error@+1 {{__float128 is not supported on this target}}
+    // expected-error@+1 {{'__float128' is not supported on this target}}
     trickyFloatType malFloatTrick = 41;
-    // expected-error@+1 {{__float128 is not supported on this target}}
+    // expected-error@+1 {{'__float128' is not supported on this target}}
     floatDef malFloatDef = 44;
-    // expected-error@+1 {{__float128 is not supported on this target}}
+    // expected-error@+1 {{'__float128' is not supported on this target}}
     auto whatFloat = malFloat;
-    // expected-error@+1 {{__float128 is not supported on this target}}
+    // expected-error@+1 {{'__float128' is not supported on this target}}
     auto malAutoTemp5 = bar<__float128>();
-    // expected-error@+1 {{__float128 is not supported on this target}}
+    // expected-error@+1 {{'__float128' is not supported on this target}}
     auto malAutoTemp6 = bar<trickyFloatType>();
-    // expected-error@+1 {{__float128 is not supported on this target}}
+    // expected-error@+1 {{'__float128' is not supported on this target}}
     decltype(malFloat) malDeclFloat = 42;
     // ---- false positive tests
     std::size_t someSz = sizeof(__float128);
     foo<__float128>();
 
     // ======= __int128 Not Allowed in Kernel ==========
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     __int128 malIntent = 2;
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     tricky128Type mal128Trick = 2;
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     int128Def malIntDef = 9;
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     auto whatInt128 = malIntent;
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     auto malAutoTemp = bar<__int128>();
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     auto malAutoTemp2 = bar<tricky128Type>();
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     decltype(malIntent) malDeclInt = 2;
 
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     __int128_t malInt128 = 2;
-    // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+    // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
     __uint128_t malUInt128 = 3;
-    // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+    // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
     megeType malTypeDefTrick = 4;
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     int128tDef malInt2Def = 6;
-    // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+    // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
     auto whatUInt = malUInt128;
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     auto malAutoTemp3 = bar<__int128_t>();
-    // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+    // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
     auto malAutoTemp4 = bar<megeType>();
-    // expected-error@+1 {{__int128 is not supported on this target}}
+    // expected-error@+1 {{'__int128' is not supported on this target}}
     decltype(malInt128) malDeclInt128 = 5;
 
     // ---- false positive tests These should not generate any errors.
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
     // expected-error@+1 {{zero-length arrays are not permitted in C++}}
     int BadArray[0];
 
-    // expected-error@+1 {{__float128 is not supported on this target}}
+    // expected-error@+1 {{'__float128' is not supported on this target}}
     __float128 badFloat = 40; // this SHOULD  trigger a diagnostic
 
     //expected-error@+1 {{SYCL kernel cannot call a variadic function}}

--- a/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
@@ -42,18 +42,18 @@ int calledFromKernel(int a) {
 #define int128Def __int128
 #define int128tDef __int128_t
 #define intDef int
- 
+
 //typedefs (late )
 typedef const __uint128_t megeType;
 typedef const __float128 trickyFloatType;
 typedef const __int128 tricky128Type;
 
 //templated type (late)
-template<typename T>
-T bar(){ return T(); };
+template <typename T>
+T bar() { return T(); };
 
 //false positive. early incorrectly catches
-template<typename t>
+template <typename t>
 void foo(){};
 
 //  template used to specialize a function that contains a lambda that should
@@ -78,7 +78,7 @@ void setup_sycl_operation(const T VA[]) {
     // expected-error@+1 {{__float128 is not supported on this target}}
     trickyFloatType malFloatTrick = 41;
     // expected-error@+1 {{__float128 is not supported on this target}}
-    floatDef        malFloatDef = 44;
+    floatDef malFloatDef = 44;
     // expected-error@+1 {{__float128 is not supported on this target}}
     auto whatFloat = malFloat;
     // expected-error@+1 {{__float128 is not supported on this target}}
@@ -93,11 +93,11 @@ void setup_sycl_operation(const T VA[]) {
 
     // ======= __int128 Not Allowed in Kernel ==========
     // expected-error@+1 {{__int128 is not supported on this target}}
-    __int128   malIntent = 2;
+    __int128 malIntent = 2;
     // expected-error@+1 {{__int128 is not supported on this target}}
     tricky128Type mal128Trick = 2;
     // expected-error@+1 {{__int128 is not supported on this target}}
-    int128Def     malIntDef = 9;
+    int128Def malIntDef = 9;
     // expected-error@+1 {{__int128 is not supported on this target}}
     auto whatInt128 = malIntent;
     // expected-error@+1 {{__int128 is not supported on this target}}
@@ -108,13 +108,13 @@ void setup_sycl_operation(const T VA[]) {
     decltype(malIntent) malDeclInt = 2;
 
     // expected-error@+1 {{__int128 is not supported on this target}}
-    __int128_t  malInt128 = 2;
+    __int128_t malInt128 = 2;
     // expected-error@+1 {{unsigned __int128 is not supported on this target}}
     __uint128_t malUInt128 = 3;
     // expected-error@+1 {{unsigned __int128 is not supported on this target}}
-    megeType   malTypeDefTrick = 4;
+    megeType malTypeDefTrick = 4;
     // expected-error@+1 {{__int128 is not supported on this target}}
-    int128tDef  malInt2Def = 6;
+    int128tDef malInt2Def = 6;
     // expected-error@+1 {{unsigned __int128 is not supported on this target}}
     auto whatUInt = malUInt128;
     // expected-error@+1 {{__int128 is not supported on this target}}

--- a/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
@@ -38,43 +38,43 @@ int calledFromKernel(int a) {
 }
 
 // defines (early and late)
-#define floatDef   __float128
-#define int128Def  __int128
-#define int128tDef  __int128_t
-#define intDef     int
+#define floatDef __float128
+#define int128Def __int128
+#define int128tDef __int128_t
+#define intDef int
  
 //typedefs (late )
 typedef const __uint128_t megeType;
-typedef const __float128  trickyFloatType;
-typedef const __int128    tricky128Type;
+typedef const __float128 trickyFloatType;
+typedef const __int128 tricky128Type;
 
 //templated type (late)
-template<typename T> T bar(){ return T(); };
+template<typename T>
+T bar(){ return T(); };
 
 //false positive. early incorrectly catches
-template<typename t> void foo(){};
+template<typename t>
+void foo(){};
 
 //  template used to specialize a function that contains a lambda that should
 //  result in a deferred diagnostic being emitted.
-
 
 template <typename T>
 void setup_sycl_operation(const T VA[]) {
 
   cl::sycl::kernel_single_task<class AName>([]() {
-    
     // ======= Zero Length Arrays Not Allowed in Kernel ==========
     // expected-error@+1 {{zero-length arrays are not permitted in C++}}
-    int MalArray[0]; 
+    int MalArray[0];
     // expected-error@+1 {{zero-length arrays are not permitted in C++}}
-    intDef MalArrayDef[0];    
+    intDef MalArrayDef[0];
     // ---- false positive tests. These should not generate any errors.
-    foo<int[0]>();    
-    std::size_t arrSz = sizeof(int[0]); 
+    foo<int[0]>();
+    std::size_t arrSz = sizeof(int[0]);
 
     // ======= Float128 Not Allowed in Kernel ==========
     // expected-error@+1 {{__float128 is not supported on this target}}
-    __float128 malFloat = 40; 
+    __float128 malFloat = 40;
     // expected-error@+1 {{__float128 is not supported on this target}}
     trickyFloatType malFloatTrick = 41;
     // expected-error@+1 {{__float128 is not supported on this target}}
@@ -83,17 +83,17 @@ void setup_sycl_operation(const T VA[]) {
     auto whatFloat = malFloat;
     // expected-error@+1 {{__float128 is not supported on this target}}
     auto malAutoTemp5 = bar<__float128>();
-    // expected-error@+1 {{__float128 is not supported on this target}}       
-    auto malAutoTemp6 = bar<trickyFloatType>();   
+    // expected-error@+1 {{__float128 is not supported on this target}}
+    auto malAutoTemp6 = bar<trickyFloatType>();
     // expected-error@+1 {{__float128 is not supported on this target}}
     decltype(malFloat) malDeclFloat = 42;
     // ---- false positive tests
-    std::size_t someSz = sizeof(__float128);   
+    std::size_t someSz = sizeof(__float128);
     foo<__float128>();
 
     // ======= __int128 Not Allowed in Kernel ==========
     // expected-error@+1 {{__int128 is not supported on this target}}
-    __int128   malIntent = 2; 
+    __int128   malIntent = 2;
     // expected-error@+1 {{__int128 is not supported on this target}}
     tricky128Type mal128Trick = 2;
     // expected-error@+1 {{__int128 is not supported on this target}}
@@ -111,8 +111,8 @@ void setup_sycl_operation(const T VA[]) {
     __int128_t  malInt128 = 2;
     // expected-error@+1 {{unsigned __int128 is not supported on this target}}
     __uint128_t malUInt128 = 3;
-    // expected-error@+1 {{unsigned __int128 is not supported on this target}}                            
-    megeType   malTypeDefTrick = 4; 
+    // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+    megeType   malTypeDefTrick = 4;
     // expected-error@+1 {{__int128 is not supported on this target}}
     int128tDef  malInt2Def = 6;
     // expected-error@+1 {{unsigned __int128 is not supported on this target}}
@@ -124,18 +124,15 @@ void setup_sycl_operation(const T VA[]) {
     // expected-error@+1 {{__int128 is not supported on this target}}
     decltype(malInt128) malDeclInt128 = 5;
 
-    // ---- false positive tests These should not generate any errors. 
-    std::size_t i128Sz = sizeof(__int128);                              
+    // ---- false positive tests These should not generate any errors.
+    std::size_t i128Sz = sizeof(__int128);
     foo<__int128>();
     std::size_t u128Sz = sizeof(__uint128_t);
     foo<__int128_t>();
 
-
     // ========= variadic
     //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
     variadic(5);
-
-
   });
 }
 

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -273,7 +273,6 @@ int main() {
   __int128_t  acceptable = 30;
   __uint128_t whatever = 50;
 
-
   kernel_single_task<class fake_kernel>([=]() {
     usage(&addInt); // expected-note 5{{called by 'operator()'}}
     a_type *p;

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -70,10 +70,10 @@ bool isa_B(A *a) {
   Check_VLA_Restriction::restriction(7);
   int *ip = new int; // expected-error 2{{SYCL kernel cannot allocate storage}}
   int i;
-  int *p3 = new (&i) int; // no error on placement new
+  int *p3 = new (&i) int;                                    // no error on placement new
   OverloadedNewDelete *x = new (struct OverloadedNewDelete); // expected-note 2{{called by 'isa_B'}}
   auto y = new struct OverloadedNewDelete[5];
-  (void)typeid(int); // expected-error {{SYCL kernel cannot use rtti}}
+  (void)typeid(int);                // expected-error {{SYCL kernel cannot use rtti}}
   return dynamic_cast<B *>(a) != 0; // expected-error {{SYCL kernel cannot use rtti}}
 }
 
@@ -106,18 +106,18 @@ using myFuncDef = int(int, int);
 #define int128Def __int128
 #define int128tDef __int128_t
 #define intDef int
- 
+
 //typedefs (late )
 typedef const __uint128_t megeType;
 typedef const __float128 trickyFloatType;
 typedef const __int128 tricky128Type;
 
 //templated type (late)
-template<typename T>
-T bar(){ return T(); };
+template <typename T>
+T bar() { return T(); };
 
 //false positive. early incorrectly catches
-template<typename t>
+template <typename t>
 void foo(){};
 
 void eh_ok(void) {
@@ -152,8 +152,9 @@ void usage(myFuncDef functionPtr) {
     b.f(); // expected-error {{SYCL kernel cannot call a virtual function}}
 
   Check_RTTI_Restriction::kernel1<class kernel_name>([]() { // expected-note 3{{called by 'usage'}}
-  Check_RTTI_Restriction::A *a;
-  Check_RTTI_Restriction::isa_B(a); }); // expected-note 6{{called by 'operator()'}}
+    Check_RTTI_Restriction::A *a;
+    Check_RTTI_Restriction::isa_B(a);
+  }); // expected-note 6{{called by 'operator()'}}
 
   // ======= Float128 Not Allowed in Kernel ==========
   // expected-error@+1 {{__float128 is not supported on this target}}
@@ -181,15 +182,15 @@ void usage(myFuncDef functionPtr) {
   intDef MalArrayDef[0];
   // ---- false positive tests. These should not generate any errors.
   foo<int[0]>();
-  std::size_t arrSz = sizeof(int[0]); 
+  std::size_t arrSz = sizeof(int[0]);
 
   // ======= __int128 Not Allowed in Kernel ==========
   // expected-error@+1 {{__int128 is not supported on this target}}
-  __int128   malIntent = 2;
+  __int128 malIntent = 2;
   // expected-error@+1 {{__int128 is not supported on this target}}
   tricky128Type mal128Trick = 2;
   // expected-error@+1 {{__int128 is not supported on this target}}
-  int128Def     malIntDef = 9;
+  int128Def malIntDef = 9;
   // expected-error@+1 {{__int128 is not supported on this target}}
   auto whatInt128 = malIntent;
   // expected-error@+1 {{__int128 is not supported on this target}}
@@ -200,13 +201,13 @@ void usage(myFuncDef functionPtr) {
   decltype(malIntent) malDeclInt = 2;
 
   // expected-error@+1 {{__int128 is not supported on this target}}
-  __int128_t  malInt128 = 2;
+  __int128_t malInt128 = 2;
   // expected-error@+1 {{unsigned __int128 is not supported on this target}}
   __uint128_t malUInt128 = 3;
   // expected-error@+1 {{unsigned __int128 is not supported on this target}}
-  megeType   malTypeDefTrick = 4;
+  megeType malTypeDefTrick = 4;
   // expected-error@+1 {{__int128 is not supported on this target}}
-  int128tDef  malInt2Def = 6;
+  int128tDef malInt2Def = 6;
   // expected-error@+1 {{unsigned __int128 is not supported on this target}}
   auto whatUInt = malUInt128;
   // expected-error@+1 {{__int128 is not supported on this target}}
@@ -220,8 +221,7 @@ void usage(myFuncDef functionPtr) {
   std::size_t i128Sz = sizeof(__int128);
   foo<__int128>();
   std::size_t u128Sz = sizeof(__uint128_t);
-  foo<__int128_t>();                                
-   
+  foo<__int128_t>();
 }
 
 namespace ns {
@@ -244,7 +244,7 @@ int use2(a_type ab, a_type *abp) {
     return 2;
   if (ab.const_stat_member)
     return 1;
-  if (ab.stat_member)  // expected-error {{SYCL kernel cannot use a non-const static data variable}}
+  if (ab.stat_member) // expected-error {{SYCL kernel cannot use a non-const static data variable}}
     return 0;
   if (abp->stat_member) // expected-error {{SYCL kernel cannot use a non-const static data variable}}
     return 0;
@@ -253,7 +253,7 @@ int use2(a_type ab, a_type *abp) {
 
   return another_global; // expected-error {{SYCL kernel cannot use a non-const global variable}}
 
-  return ns::glob + // expected-error {{SYCL kernel cannot use a non-const global variable}}
+  return ns::glob +               // expected-error {{SYCL kernel cannot use a non-const global variable}}
          AnotherNS::moar_globals; // expected-error {{SYCL kernel cannot use a non-const global variable}}
 }
 
@@ -265,7 +265,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 int main() {
   // Outside Kernel, these should not generate errors.
   a_type ab;
-  
+
   int PassOver[0];
   __float128 okFloat = 40;
   __int128 fineInt = 20;

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -154,7 +154,7 @@ void usage(myFuncDef functionPtr) {
   Check_RTTI_Restriction::kernel1<class kernel_name>([]() { // expected-note 3{{called by 'usage'}}
     Check_RTTI_Restriction::A *a;
     Check_RTTI_Restriction::isa_B(a); // expected-note 6{{called by 'operator()'}}
-  }); 
+  });
 
   // ======= Float128 Not Allowed in Kernel ==========
   // expected-error@+1 {{__float128 is not supported on this target}}

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -153,6 +153,11 @@ struct trickyStruct {
   tricky128Type trickyStructInt;
 };
 
+// function return type and argument both unsupported
+__int128 commitInfraction(__int128 a) {
+  return 0;
+}
+
 void eh_ok(void) {
   __float128 A;
   try {
@@ -271,6 +276,10 @@ void usage(myFuncDef functionPtr) {
   frankenStruct strikesFear; // expected-note 3{{used here}}
   trickyStruct incitesPanic; // expected-note 2{{used here}}
 
+  // ======= Function Prototype Checked  =======
+  // expected-error@+1 2{{'__int128' is not supported on this target}}
+  auto notAllowed = &commitInfraction;
+
   // ---- false positive tests These should not generate any errors.
   std::size_t i128Sz = sizeof(__int128);
   foo<__int128>();
@@ -328,6 +337,7 @@ int main() {
   __uint128_t whatever = 50;
   frankenStruct noProblem;
   trickyStruct noTrouble;
+  auto notACrime = &commitInfraction;
 
   kernel_single_task<class fake_kernel>([=]() {
     usage(&addInt); // expected-note 5{{called by 'operator()'}}

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -153,8 +153,8 @@ void usage(myFuncDef functionPtr) {
 
   Check_RTTI_Restriction::kernel1<class kernel_name>([]() { // expected-note 3{{called by 'usage'}}
     Check_RTTI_Restriction::A *a;
-    Check_RTTI_Restriction::isa_B(a);
-  }); // expected-note 6{{called by 'operator()'}}
+    Check_RTTI_Restriction::isa_B(a); // expected-note 6{{called by 'operator()'}}
+  }); 
 
   // ======= Float128 Not Allowed in Kernel ==========
   // expected-error@+1 {{__float128 is not supported on this target}}

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -108,17 +108,50 @@ using myFuncDef = int(int, int);
 #define intDef int
 
 //typedefs (late )
-typedef const __uint128_t megeType;
-typedef const __float128 trickyFloatType;
-typedef const __int128 tricky128Type;
+typedef __uint128_t megeType;
+typedef __float128 trickyFloatType;
+typedef __int128 tricky128Type;
 
-//templated type (late)
+//templated return type
 template <typename T>
 T bar() { return T(); };
+
+//variable template
+template <class T>
+constexpr T solutionToEverything = T(42);
+
+//alias template
+template <typename...>
+using floatalias_t = __float128;
+
+//alias template
+template <typename...>
+using int128alias_t = __int128;
 
 //false positive. early incorrectly catches
 template <typename t>
 void foo(){};
+//false positive template alias
+template <typename...>
+using safealias_t = int;
+
+//struct
+struct frankenStruct {
+  // expected-error@+1 {{zero-length arrays are not permitted in C++}}
+  int mosterArr[0];
+  // expected-error@+1 {{'__float128' is not supported on this target}}
+  __float128 scaryQuad;
+  // expected-error@+1 {{'__int128' is not supported on this target}}
+  __int128 frightenInt;
+};
+
+//struct
+struct trickyStruct {
+  // expected-error@+1 {{'__float128' is not supported on this target}}
+  trickyFloatType trickySructQuad;
+  // expected-error@+1 {{'__int128' is not supported on this target}}
+  tricky128Type trickyStructInt;
+};
 
 void eh_ok(void) {
   __float128 A;
@@ -157,23 +190,30 @@ void usage(myFuncDef functionPtr) {
   });
 
   // ======= Float128 Not Allowed in Kernel ==========
-  // expected-error@+1 {{__float128 is not supported on this target}}
+  // expected-error@+1 {{'__float128' is not supported on this target}}
   __float128 malFloat = 40;
-  // expected-error@+1 {{__float128 is not supported on this target}}
+  // expected-error@+1 {{'__float128' is not supported on this target}}
   trickyFloatType malFloatTrick = 41;
-  // expected-error@+1 {{__float128 is not supported on this target}}
+  // expected-error@+1 {{'__float128' is not supported on this target}}
   floatDef malFloatDef = 44;
-  // expected-error@+1 {{__float128 is not supported on this target}}
+  // expected-error@+1 {{'__float128' is not supported on this target}}
   auto whatFloat = malFloat;
-  // expected-error@+1 {{__float128 is not supported on this target}}
+  // expected-error@+1 {{'__float128' is not supported on this target}}
   auto malAutoTemp5 = bar<__float128>();
-  // expected-error@+1 {{__float128 is not supported on this target}}
+  // expected-error@+1 {{'__float128' is not supported on this target}}
   auto malAutoTemp6 = bar<trickyFloatType>();
-  // expected-error@+1 {{__float128 is not supported on this target}}
+  // expected-error@+1 {{'__float128' is not supported on this target}}
   decltype(malFloat) malDeclFloat = 42;
+  // expected-error@+1 {{'__float128' is not supported on this target}}
+  auto malFloatTemplateVar = solutionToEverything<__float128>;
+  // expected-error@+1 {{'__float128' is not supported on this target}}
+  auto malTrifectaFloat = solutionToEverything<trickyFloatType>;
+  // expected-error@+1 {{'__float128' is not supported on this target}}
+  floatalias_t<void> aliasedFloat = 42;
   // ---- false positive tests
   std::size_t someSz = sizeof(__float128);
   foo<__float128>();
+  safealias_t<__float128> notAFloat = 3;
 
   // ======= Zero Length Arrays Not Allowed in Kernel ==========
   // expected-error@+1 {{zero-length arrays are not permitted in C++}}
@@ -185,43 +225,58 @@ void usage(myFuncDef functionPtr) {
   std::size_t arrSz = sizeof(int[0]);
 
   // ======= __int128 Not Allowed in Kernel ==========
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   __int128 malIntent = 2;
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   tricky128Type mal128Trick = 2;
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   int128Def malIntDef = 9;
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   auto whatInt128 = malIntent;
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   auto malAutoTemp = bar<__int128>();
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   auto malAutoTemp2 = bar<tricky128Type>();
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   decltype(malIntent) malDeclInt = 2;
+  // expected-error@+1 {{'__int128' is not supported on this target}}
+  auto mal128TemplateVar = solutionToEverything<__int128>;
+  // expected-error@+1 {{'__int128' is not supported on this target}}
+  auto malTrifecta128 = solutionToEverything<tricky128Type>;
+  // expected-error@+1 {{'__int128' is not supported on this target}}
+  int128alias_t<void> aliasedInt128 = 79;
 
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   __int128_t malInt128 = 2;
-  // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+  // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
   __uint128_t malUInt128 = 3;
-  // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+  // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
   megeType malTypeDefTrick = 4;
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   int128tDef malInt2Def = 6;
-  // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+  // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
   auto whatUInt = malUInt128;
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   auto malAutoTemp3 = bar<__int128_t>();
-  // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+  // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
   auto malAutoTemp4 = bar<megeType>();
-  // expected-error@+1 {{__int128 is not supported on this target}}
+  // expected-error@+1 {{'__int128' is not supported on this target}}
   decltype(malInt128) malDeclInt128 = 5;
+  // expected-error@+1 {{'__int128' is not supported on this target}}
+  auto mal128TIntTemplateVar = solutionToEverything<__int128_t>;
+  // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
+  auto malTrifectaInt128T = solutionToEverything<megeType>;
+
+  // ======= Struct Members Checked  =======
+  frankenStruct strikesFear; // expected-note 3{{used here}}
+  trickyStruct incitesPanic; // expected-note 2{{used here}}
 
   // ---- false positive tests These should not generate any errors.
   std::size_t i128Sz = sizeof(__int128);
   foo<__int128>();
   std::size_t u128Sz = sizeof(__uint128_t);
   foo<__int128_t>();
+  safealias_t<__int128> notAnInt128 = 3;
 }
 
 namespace ns {
@@ -271,6 +326,8 @@ int main() {
   __int128 fineInt = 20;
   __int128_t acceptable = 30;
   __uint128_t whatever = 50;
+  frankenStruct noProblem;
+  trickyStruct noTrouble;
 
   kernel_single_task<class fake_kernel>([=]() {
     usage(&addInt); // expected-note 5{{called by 'operator()'}}

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -102,23 +102,23 @@ b_type b;
 using myFuncDef = int(int, int);
 
 // defines (early and late)
-#define floatDef   __float128
-#define int128Def  __int128
-#define int128tDef  __int128_t
-#define intDef     int
+#define floatDef __float128
+#define int128Def __int128
+#define int128tDef __int128_t
+#define intDef int
  
 //typedefs (late )
 typedef const __uint128_t megeType;
-typedef const __float128  trickyFloatType;
-typedef const __int128    tricky128Type;
+typedef const __float128 trickyFloatType;
+typedef const __int128 tricky128Type;
 
 //templated type (late)
-template<typename T> T bar(){ return T(); };
+template<typename T>
+T bar(){ return T(); };
 
 //false positive. early incorrectly catches
-template<typename t> void foo(){};
-
-
+template<typename t>
+void foo(){};
 
 void eh_ok(void) {
   __float128 A;
@@ -155,38 +155,37 @@ void usage(myFuncDef functionPtr) {
   Check_RTTI_Restriction::A *a;
   Check_RTTI_Restriction::isa_B(a); }); // expected-note 6{{called by 'operator()'}}
 
-
   // ======= Float128 Not Allowed in Kernel ==========
   // expected-error@+1 {{__float128 is not supported on this target}}
-  __float128 malFloat = 40; 
+  __float128 malFloat = 40;
   // expected-error@+1 {{__float128 is not supported on this target}}
   trickyFloatType malFloatTrick = 41;
   // expected-error@+1 {{__float128 is not supported on this target}}
-  floatDef        malFloatDef = 44;
+  floatDef malFloatDef = 44;
   // expected-error@+1 {{__float128 is not supported on this target}}
   auto whatFloat = malFloat;
   // expected-error@+1 {{__float128 is not supported on this target}}
   auto malAutoTemp5 = bar<__float128>();
-  // expected-error@+1 {{__float128 is not supported on this target}}       
-  auto malAutoTemp6 = bar<trickyFloatType>();   
+  // expected-error@+1 {{__float128 is not supported on this target}}
+  auto malAutoTemp6 = bar<trickyFloatType>();
   // expected-error@+1 {{__float128 is not supported on this target}}
   decltype(malFloat) malDeclFloat = 42;
   // ---- false positive tests
-  std::size_t someSz = sizeof(__float128);   
+  std::size_t someSz = sizeof(__float128);
   foo<__float128>();
 
   // ======= Zero Length Arrays Not Allowed in Kernel ==========
   // expected-error@+1 {{zero-length arrays are not permitted in C++}}
-  int MalArray[0]; 
+  int MalArray[0];
   // expected-error@+1 {{zero-length arrays are not permitted in C++}}
-  intDef MalArrayDef[0];    
+  intDef MalArrayDef[0];
   // ---- false positive tests. These should not generate any errors.
-  foo<int[0]>();    
+  foo<int[0]>();
   std::size_t arrSz = sizeof(int[0]); 
 
   // ======= __int128 Not Allowed in Kernel ==========
   // expected-error@+1 {{__int128 is not supported on this target}}
-  __int128   malIntent = 2; 
+  __int128   malIntent = 2;
   // expected-error@+1 {{__int128 is not supported on this target}}
   tricky128Type mal128Trick = 2;
   // expected-error@+1 {{__int128 is not supported on this target}}
@@ -204,8 +203,8 @@ void usage(myFuncDef functionPtr) {
   __int128_t  malInt128 = 2;
   // expected-error@+1 {{unsigned __int128 is not supported on this target}}
   __uint128_t malUInt128 = 3;
-  // expected-error@+1 {{unsigned __int128 is not supported on this target}}                            
-  megeType   malTypeDefTrick = 4; 
+  // expected-error@+1 {{unsigned __int128 is not supported on this target}}
+  megeType   malTypeDefTrick = 4;
   // expected-error@+1 {{__int128 is not supported on this target}}
   int128tDef  malInt2Def = 6;
   // expected-error@+1 {{unsigned __int128 is not supported on this target}}
@@ -217,8 +216,8 @@ void usage(myFuncDef functionPtr) {
   // expected-error@+1 {{__int128 is not supported on this target}}
   decltype(malInt128) malDeclInt128 = 5;
 
-  // ---- false positive tests These should not generate any errors. 
-  std::size_t i128Sz = sizeof(__int128);                              
+  // ---- false positive tests These should not generate any errors.
+  std::size_t i128Sz = sizeof(__int128);
   foo<__int128>();
   std::size_t u128Sz = sizeof(__uint128_t);
   foo<__int128_t>();                                
@@ -264,13 +263,13 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 }
 
 int main() {
-  // Outside Kernel, these should not generate errors. 
+  // Outside Kernel, these should not generate errors.
   a_type ab;
   
-  int         PassOver[0];  
-  __float128  okFloat = 40; 
-  __int128    fineInt = 20;
-  __int128_t  acceptable = 30;
+  int PassOver[0];
+  __float128 okFloat = 40;
+  __int128 fineInt = 20;
+  __int128_t acceptable = 30;
   __uint128_t whatever = 50;
 
   kernel_single_task<class fake_kernel>([=]() {


### PR DESCRIPTION
SPIR_V  won't support certain types ( quad type, __int128, zero length arrays and other).  So we check any code that is running on the kernel for those types and emit an error if they are encountered.  

Presently, these checks are done in `ConvertDeclSpecToType` in SemaType.cpp, but this is too early in the Sema lifecycle. It can catch only the most straightforward type declarations. We need to also catch types that use `auto` declarations, `typedef`, templating and more.  To do that, the type checking must occur a little later in the Semantic Analysis lifecycle.

Here I am calling the checks from `CheckCompleteVariableDeclaration` in SemaDecl.cpp. This is called just after the parsing is finished and seems to work well.    Also, these checks now avoid the problems we encountered with deferred diagnostics getting confused by templated functions. So, no further change is needed to the deferred diagnostic system (as far as these checks are concerned).

Expanded the testing as well. 

Signed-off-by: Chris Perkins <chris.perkins@intel.com>