### PR TITLE
[CI] Update CODEOWNERS matching rules order

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+* @bader
+
 clang/ @erichkeane @Fznamznon
 
 clang/**/Driver @mdtoguchi @AGindinson
@@ -8,12 +10,10 @@ opencl-aot/ @dm-vodopyanov @AlexeySachkov @romanovvlad
 
 libdevice/ @asavonic @vzakhari
 
-sycl/doc/extensions/ @mkinsner @jbrodman
+sycl/ @romanovvlad @bader
 
 sycl/doc/ @pvchupin @kbobrovs
 
-sycl/ @romanovvlad @bader
+sycl/doc/extensions/ @mkinsner @jbrodman
 
 xpti/ @tovinkere @andykaylor
-
-* @bader


### PR DESCRIPTION
According to the documentation the latest match has highest priority,
which makes bader the only code owner.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>