### PR TITLE
Enable cfg-printer LLVM lit tests only if LLVM linked statically

### DIFF
--- a/llvm/test/Other/cfg-printer-branch-weights.ll
+++ b/llvm/test/Other/cfg-printer-branch-weights.ll
@@ -1,7 +1,7 @@
 ;RUN: opt < %s -analyze -dot-cfg -cfg-dot-filename-prefix=%t 2>/dev/null
 ;RUN: FileCheck %s -input-file=%t.f.dot
 
-;TODO: Investigate why this test doesn't work with dinamically linked libraries
+;TODO: Investigate why this test doesn't work with dynamically linked libraries
 ;REQUIRES: static-libs
 
 define void @f(i32) {

--- a/llvm/test/Other/cfg-printer-branch-weights.ll
+++ b/llvm/test/Other/cfg-printer-branch-weights.ll
@@ -1,6 +1,9 @@
 ;RUN: opt < %s -analyze -dot-cfg -cfg-dot-filename-prefix=%t 2>/dev/null
 ;RUN: FileCheck %s -input-file=%t.f.dot
 
+;TODO: Investigate why this test doesn't work with dinamically linked libraries
+;REQUIRES: static-libs
+
 define void @f(i32) {
 entry:
   %check = icmp sgt i32 %0, 0

--- a/llvm/test/Other/cfg_deopt_unreach.ll
+++ b/llvm/test/Other/cfg_deopt_unreach.ll
@@ -9,6 +9,9 @@
 ; RUN: opt < %s -analyze -dot-cfg -cfg-hide-unreachable-paths -cfg-hide-deoptimize-paths -cfg-dot-filename-prefix=%t/both-flags 2>/dev/null
 ; RUN: FileCheck %s -input-file=%t/both-flags.callee.dot -check-prefix=BOTH-FLAGS
 
+; TODO: Investigate why this test doesn't work with dinamically linked libraries
+; REQUIRES: static-libs
+
 declare i8 @llvm.experimental.deoptimize.i8(...)
 
 define i8 @callee(i1* %c) alwaysinline {

--- a/llvm/test/Other/cfg_deopt_unreach.ll
+++ b/llvm/test/Other/cfg_deopt_unreach.ll
@@ -9,7 +9,7 @@
 ; RUN: opt < %s -analyze -dot-cfg -cfg-hide-unreachable-paths -cfg-hide-deoptimize-paths -cfg-dot-filename-prefix=%t/both-flags 2>/dev/null
 ; RUN: FileCheck %s -input-file=%t/both-flags.callee.dot -check-prefix=BOTH-FLAGS
 
-; TODO: Investigate why this test doesn't work with dinamically linked libraries
+; TODO: Investigate why this test doesn't work with dynamically linked libraries
 ; REQUIRES: static-libs
 
 declare i8 @llvm.experimental.deoptimize.i8(...)


### PR DESCRIPTION
Issue with dynamically lined libraries is tracked here: https://github.com/intel/llvm/issues/1478.