### PR TITLE
[SYCL] Fix sub_group::broadcast

### DIFF
--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -178,7 +178,7 @@ struct sub_group {
   template <typename T>
   __SYCL_DEPRECATED__("Use sycl::intel::broadcast instead.")
   EnableIfIsScalarArithmetic<T> broadcast(T x, id<1> local_id) const {
-    return detail::spirv::GroupBroadcast<__spv::Scope::Subgroup>(x, local_id);
+    return detail::spirv::GroupBroadcast<sub_group>(x, local_id);
   }
 
   template <typename T, class BinaryOperation>


### PR DESCRIPTION
Previous refactoring of GroupBroadcast broke sub_group::broadcast.
Wasn't picked up by tests because sub_group::broadcast is deprecated.

Signed-off-by: John Pennycook <john.pennycook@intel.com>