### PR TITLE
[SYCL] Fixed sub-buffer memory allocation update

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -694,7 +694,9 @@ void AllocaSubBufCommand::emitInstrumentationData() {
 #endif
 }
 
-cl_int AllocaSubBufCommand::enqueueImp() {
+cl_int AllocaSubBufCommand::enqueueImp() { return CL_SUCCESS; }
+
+void AllocaSubBufCommand::updateMemAllocation() {
   std::vector<EventImplPtr> EventImpls =
       Command::prepareEvents(detail::getSyclObjImpl(MQueue->get_context()));
   RT::PiEvent &Event = MEvent->getHandleRef();
@@ -704,7 +706,6 @@ cl_int AllocaSubBufCommand::enqueueImp() {
       MParentAlloca->getMemAllocation(), MRequirement.MElemSize,
       MRequirement.MOffsetInBytes, MRequirement.MAccessRange,
       std::move(EventImpls), Event);
-  return CL_SUCCESS;
 }
 
 void AllocaSubBufCommand::printDot(std::ostream &Stream) const {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -264,7 +264,7 @@ public:
 
   SYCLMemObjI *getSYCLMemObj() const { return MRequirement.MSYCLMemObj; }
 
-  void *getMemAllocation() const { return MMemAllocation; }
+  virtual void *getMemAllocation() = 0;
 
   const Requirement *getRequirement() const final { return &MRequirement; }
 
@@ -298,6 +298,7 @@ public:
                 bool InitFromUserData = true,
                 AllocaCommandBase *LinkedAllocaCmd = nullptr);
 
+  void *getMemAllocation() final { return MMemAllocation; }
   void printDot(std::ostream &Stream) const final;
   void emitInstrumentationData();
 
@@ -314,14 +315,26 @@ public:
   AllocaSubBufCommand(QueueImplPtr Queue, Requirement Req,
                       AllocaCommandBase *ParentAlloca);
 
+  void *getMemAllocation() final {
+    // In some cases parent`s memory allocation might change (e.g., after
+    // map/unmap operations). If parent`s memory allocation changes, sub-buffer
+    // memory allocation should be changed as well.
+    if (MParentMemCache != MParentAlloca->getMemAllocation()) {
+      MParentMemCache = MParentAlloca->getMemAllocation();
+      updateMemAllocation();
+    }
+    return MMemAllocation;
+  }
   void printDot(std::ostream &Stream) const final;
   AllocaCommandBase *getParentAlloca() { return MParentAlloca; }
   void emitInstrumentationData();
 
 private:
   cl_int enqueueImp() final;
+  void updateMemAllocation();
 
   AllocaCommandBase *MParentAlloca = nullptr;
+  void *MParentMemCache = nullptr;
 };
 
 class MapMemObject : public Command {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -264,7 +264,7 @@ public:
 
   SYCLMemObjI *getSYCLMemObj() const { return MRequirement.MSYCLMemObj; }
 
-  virtual void *getMemAllocation() = 0;
+  virtual void *getMemAllocation() const = 0;
 
   const Requirement *getRequirement() const final { return &MRequirement; }
 
@@ -298,7 +298,7 @@ public:
                 bool InitFromUserData = true,
                 AllocaCommandBase *LinkedAllocaCmd = nullptr);
 
-  void *getMemAllocation() final { return MMemAllocation; }
+  void *getMemAllocation() const final { return MMemAllocation; }
   void printDot(std::ostream &Stream) const final;
   void emitInstrumentationData();
 
@@ -315,26 +315,15 @@ public:
   AllocaSubBufCommand(QueueImplPtr Queue, Requirement Req,
                       AllocaCommandBase *ParentAlloca);
 
-  void *getMemAllocation() final {
-    // In some cases parent`s memory allocation might change (e.g., after
-    // map/unmap operations). If parent`s memory allocation changes, sub-buffer
-    // memory allocation should be changed as well.
-    if (MParentMemCache != MParentAlloca->getMemAllocation()) {
-      MParentMemCache = MParentAlloca->getMemAllocation();
-      updateMemAllocation();
-    }
-    return MMemAllocation;
-  }
+  void *getMemAllocation() const final;
   void printDot(std::ostream &Stream) const final;
   AllocaCommandBase *getParentAlloca() { return MParentAlloca; }
   void emitInstrumentationData();
 
 private:
   cl_int enqueueImp() final;
-  void updateMemAllocation();
 
   AllocaCommandBase *MParentAlloca = nullptr;
-  void *MParentMemCache = nullptr;
 };
 
 class MapMemObject : public Command {

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -533,6 +533,7 @@ AllocaCommandBase *Scheduler::GraphBuilder::findAllocaForReq(
     bool Res = sameCtx(AllocaCmd->getQueue()->getContextImplPtr(), Context);
     if (IsSuitableSubReq(Req)) {
       const Requirement *TmpReq = AllocaCmd->getRequirement();
+      Res &= AllocaCmd->getType() == Command::CommandType::ALLOCA_SUB_BUF;
       Res &= TmpReq->MOffsetInBytes == Req->MOffsetInBytes;
       Res &= TmpReq->MSYCLMemObj->getSize() == Req->MSYCLMemObj->getSize();
     }

--- a/sycl/test/basic_tests/buffer/subbuffer.cpp
+++ b/sycl/test/basic_tests/buffer/subbuffer.cpp
@@ -279,7 +279,7 @@ void checkMultipleContexts() {
   {
     sycl::queue queue1;
     sycl::buffer<int, 1> buf(a, sycl::range<1>(N));
-    sycl::buffer<int, 1> subbuf1(buf, sycl::id<1>(0), sycl::range<1>(N / 2));
+    sycl::buffer<int, 1> subbuf1(buf, sycl::id<1>(N / 2), sycl::range<1>(N / 2));
     queue1.submit([&](sycl::handler &cgh) {
       auto bufacc = subbuf1.get_access<sycl::access::mode::read_write>(cgh);
       cgh.parallel_for<class sub_buffer_3>(


### PR DESCRIPTION
In some cases parent`s memory allocation might change (e.g., after
map/unmap operations). If parent`s memory allocation changes, sub-buffer
memory allocation should be changed as well.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>