### PR TITLE
[SYCL] Disable spec_const_redefine.cpp on all devices but HOST.

### DIFF
--- a/sycl/test/spec_const/spec_const_redefine.cpp
+++ b/sycl/test/spec_const/spec_const_redefine.cpp
@@ -3,9 +3,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// TODO the test currently fails as program recompilation based on spec
-//      constants set change is not complete yet.
-// XFAIL: *
+// TODO the test currently fails on non-HOST devices as program recompilation
+//      based on spec constants set change is not complete yet.
+// XFAIL: cpu,gpu,acc,cuda
 //
 //==----------- spec_const_redefine.cpp ------------------------------------==//
 //


### PR DESCRIPTION
Program recompilation based on spec constant value set change is not
complete yet.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>