### PR TITLE
[Driver][SYCL] Move include/sycl header before other system header lo…

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1217,9 +1217,9 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
   if (JA.isOffloading(Action::OFK_Cuda))
     getToolChain().AddCudaIncludeArgs(Args, CmdArgs);
 
-  if (Args.hasArg(options::OPT_fsycl_device_only)) {
+  if (JA.isOffloading(Action::OFK_SYCL) ||
+      Args.hasArg(options::OPT_fsycl_device_only))
     toolchains::SYCLToolChain::AddSYCLIncludeArgs(D, Args, CmdArgs);
-  }
 
   // If we are offloading to a target via OpenMP we need to include the
   // openmp_wrappers folder which contains alternative system headers.

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -545,7 +545,6 @@ void SYCLToolChain::AddSYCLIncludeArgs(const clang::driver::Driver &Driver,
 
 void SYCLToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
                                               ArgStringList &CC1Args) const {
-  AddSYCLIncludeArgs(getDriver(), DriverArgs, CC1Args);
   HostTC.AddClangSystemIncludeArgs(DriverArgs, CC1Args);
 }
 

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -43,6 +43,11 @@
 // COMBINED: "-triple" "spir64-unknown-{{.*}}-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-emit-llvm-bc"
 // TEXTUAL: "-triple" "spir64-unknown-{{.*}}-sycldevice{{.*}}" "-fsycl-is-device"{{.*}} "-emit-llvm"
 
+/// Verify that the sycl header directory is before /usr/include
+// RUN: %clangxx -### -fsycl-device-only %s 2>&1 | FileCheck %s --check-prefix=HEADER_ORDER
+// RUN: %clangxx -### -fsycl %s 2>&1 | FileCheck %s --check-prefix=HEADER_ORDER
+// HEADER_ORDER-NOT: clang{{.*}} "/usr/include"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}
+
 /// Verify -fsycl-device-only phases
 // RUN: %clang -### -ccc-print-phases -fsycl-device-only %s 2>&1 | FileCheck %s --check-prefix=DEFAULT-PHASES
 // DEFAULT-PHASES: 0: input, "{{.*}}", c


### PR DESCRIPTION
…cations

The location in which the include/sycl headers are added are too late in
the ordering sequence.  This is causing the possibility of the wrong version
of the OpenCL headers to be picked up (i.e. from /usr/include)

Improve the ordering by putting the dirs much earlier in the command line
instead of relying on the ToolChain addition.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>