### PR TITLE
[SYCL] Fix library build on Windows

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -148,10 +148,10 @@ if (MSVC)
   foreach(flag_var
       CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
       CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    string(REGEX REPLACE "/MD" "" ${flag_var} "${${flag_var}}")
-    string(REGEX REPLACE "/MT" "" ${flag_var} "${${flag_var}}")
     string(REGEX REPLACE "/MDd" "" ${flag_var} "${${flag_var}}")
     string(REGEX REPLACE "/MTd" "" ${flag_var} "${${flag_var}}")
+    string(REGEX REPLACE "/MD" "" ${flag_var} "${${flag_var}}")
+    string(REGEX REPLACE "/MT" "" ${flag_var} "${${flag_var}}")
   endforeach()
 
   if (SYCL_ENABLE_XPTI_TRACING)


### PR DESCRIPTION
Fix removal of /MDd and /MTd flags.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>