### PR TITLE
[Driver][SYCL] Consider .lo files as static archives

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -41,11 +41,11 @@
 #include "ToolChains/PPCLinux.h"
 #include "ToolChains/PS4CPU.h"
 #include "ToolChains/RISCVToolchain.h"
+#include "ToolChains/SYCL.h"
 #include "ToolChains/Solaris.h"
 #include "ToolChains/TCE.h"
 #include "ToolChains/WebAssembly.h"
 #include "ToolChains/XCore.h"
-#include "ToolChains/SYCL.h"
 #include "clang/Basic/Version.h"
 #include "clang/Config/config.h"
 #include "clang/Driver/Action.h"
@@ -62,6 +62,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
@@ -6594,8 +6595,11 @@ bool clang::driver::isStaticArchiveFile(const StringRef &FileName) {
     // Any file with no extension should not be considered an Archive.
     return false;
   StringRef Ext(llvm::sys::path::extension(FileName).drop_front());
-  // Only .lib and .a files are to be considered.
-  return (Ext == "lib" || Ext == "a");
+  llvm::file_magic Magic;
+  llvm::identify_magic(FileName, Magic);
+  // Only .lib, .a and .lo files are to be considered.
+  return (Ext == "lib" ||
+          ((Ext == "a" || Ext == "lo") && Magic == llvm::file_magic::archive));
 }
 
 bool clang::driver::willEmitRemarks(const ArgList &Args) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6597,9 +6597,8 @@ bool clang::driver::isStaticArchiveFile(const StringRef &FileName) {
   StringRef Ext(llvm::sys::path::extension(FileName).drop_front());
   llvm::file_magic Magic;
   llvm::identify_magic(FileName, Magic);
-  // Only .lib, .a and .lo files are to be considered.
-  return (Ext == "lib" ||
-          ((Ext == "a" || Ext == "lo") && Magic == llvm::file_magic::archive));
+  // Only .lib and archive files are to be considered.
+  return (Ext == "lib" || Magic == llvm::file_magic::archive);
 }
 
 bool clang::driver::willEmitRemarks(const ArgList &Args) {

--- a/clang/test/Driver/sycl-offload-static-lib-2.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib-2.cpp
@@ -15,22 +15,16 @@
 // RUN: llvm-ar cr %t_2.a %t1_bundle.o
 //
 // RUN: touch %t.a
+// RUN: touch %t.lo
 // RUN: touch %t.o
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.a -### %t.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB -DINPUTA=%t.a -DINPUTO=%t.o
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.lo -### %t.o 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=STATIC_LIB -DINPUTA=%t.lo -DINPUTO=%t.o
 // STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" "[[INPUTLD:[^ ]+\.o]]" {{.*}} "-L/dummy/dir"{{.*}} "[[INPUTO]]" "[[INPUTA]]"
 // STATIC_LIB: clang-offload-bundler{{.*}} "-type=oo" {{.*}} "-inputs=[[INPUTLD]]" "-outputs=[[LISTFILE:.+\.txt]]"
 // STATIC_LIB: llvm-link{{.*}} "@[[LISTFILE]]"
 // STATIC_LIB: ld{{.*}} "[[INPUTA]]" "[[INPUTO]]"
-
-// RUN: touch %t.lo
-// RUN: touch %t.o
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.lo -### %t.o 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=STATIC_LIB_LO -DINPUTLO=%t.lo -DINPUTO=%t.o
-// STATIC_LIB_LO: ld{{(.exe)?}}" "-r" "-o" "[[INPUTLD:[^ ]+\.o]]" {{.*}} "-L/dummy/dir"{{.*}} "[[INPUTO]]" "[[INPUTLO]]"
-// STATIC_LIB_LO: clang-offload-bundler{{.*}} "-type=oo" {{.*}} "-inputs=[[INPUTLD]]" "-outputs=[[LISTFILE:.+\.txt]]"
-// STATIC_LIB_LO: llvm-link{{.*}} "@[[LISTFILE]]"
-// STATIC_LIB_LO: ld{{.*}} "[[INPUTLO]]" "[[INPUTO]]"
 
 /// ###########################################################################
 
@@ -106,11 +100,10 @@
 
 /// test behaviors of static lib with no source/object
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.a -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefixes=STATIC_LIB_NOSRC,STATIC_LIB_NOSRC_A
+// RUN:   | FileCheck %s -check-prefix=STATIC_LIB_NOSRC -DINPUTLIB=%t.a
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.lo -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefixes=STATIC_LIB_NOSRC,STATIC_LIB_NOSRC_LO
-// STATIC_LIB_NOSRC_A: clang-offload-bundler{{.*}} "-type=ao" "-targets=host-x86_64-unknown-linux-gnu" "-inputs=[[INPUTLIB:.+\.a]]" "-check-section"
-// STATIC_LIB_NOSRC_LO: clang-offload-bundler{{.*}} "-type=ao" "-targets=host-x86_64-unknown-linux-gnu" "-inputs=[[INPUTLIB:.+\.lo]]" "-check-section"
+// RUN:   | FileCheck %s -check-prefix=STATIC_LIB_NOSRC -DINPUTLIB=%t.lo
+// STATIC_LIB_NOSRC: clang-offload-bundler{{.*}} "-type=ao" "-targets=host-x86_64-unknown-linux-gnu" "-inputs=[[INPUTLIB]]" "-check-section"
 // STATIC_LIB_NOSRC: ld{{.*}} "-r" "-o" "[[PARTIALOBJ:.+\.o]]" "{{.*}}crt1.o" {{.*}} "-L/dummy/dir" {{.*}} "[[INPUTLIB]]"
 // STATIC_LIB_NOSRC: clang-offload-bundler{{.*}} "-type=oo" "-targets=sycl-spir64-unknown-unknown-sycldevice" "-inputs=[[PARTIALOBJ]]" "-outputs=[[DEVICELIST:.+\.txt]]" "-unbundle"
 // STATIC_LIB_NOSRC: llvm-link{{.*}} "@[[DEVICELIST]]" "-o" "[[BCFILE:.+\.bc]]"

--- a/clang/test/Driver/sycl-offload-static-lib-2.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib-2.cpp
@@ -15,6 +15,7 @@
 // RUN: llvm-ar cr %t_2.a %t1_bundle.o
 //
 // RUN: touch %t.a
+// RUN: touch %t.o
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.a -### %t.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB -DINPUTA=%t.a -DINPUTO=%t.o
 // STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" "[[INPUTLD:[^ ]+\.o]]" {{.*}} "-L/dummy/dir"{{.*}} "[[INPUTO]]" "[[INPUTA]]"
@@ -23,6 +24,7 @@
 // STATIC_LIB: ld{{.*}} "[[INPUTA]]" "[[INPUTO]]"
 
 // RUN: touch %t.lo
+// RUN: touch %t.o
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.lo -### %t.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_LO -DINPUTLO=%t.lo -DINPUTO=%t.o
 // STATIC_LIB_LO: ld{{(.exe)?}}" "-r" "-o" "[[INPUTLD:[^ ]+\.o]]" {{.*}} "-L/dummy/dir"{{.*}} "[[INPUTO]]" "[[INPUTLO]]"

--- a/clang/test/Driver/sycl-offload-static-lib-2.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib-2.cpp
@@ -10,15 +10,25 @@
 // Build a fat static lib that will be used for all tests
 // RUN: echo "void foo(void) {}" > %t1.cpp
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t1.cpp -c -o %t1_bundle.o
-// RUN: llvm-ar crv %t.a %t1_bundle.o
+// RUN: llvm-ar cr %t.a %t1_bundle.o
+// RUN: llvm-ar cr %t.lo %t1_bundle.o
+// RUN: llvm-ar cr %t_2.a %t1_bundle.o
 //
 // RUN: touch %t.a
-// RUN: touch %t.o
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.a -### %t.o 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=STATIC_LIB
-// STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.o]]" "-L/dummy/dir"{{.*}} "[[INPUT:.+\.a]]"
-// STATIC_LIB: clang-offload-bundler{{.*}} "-type=oo"
-// STATIC_LIB: llvm-link{{.*}} "@{{.*}}"
+// RUN:   | FileCheck %s -check-prefix=STATIC_LIB -DINPUTA=%t.a -DINPUTO=%t.o
+// STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" "[[INPUTLD:[^ ]+\.o]]" {{.*}} "-L/dummy/dir"{{.*}} "[[INPUTO]]" "[[INPUTA]]"
+// STATIC_LIB: clang-offload-bundler{{.*}} "-type=oo" {{.*}} "-inputs=[[INPUTLD]]" "-outputs=[[LISTFILE:.+\.txt]]"
+// STATIC_LIB: llvm-link{{.*}} "@[[LISTFILE]]"
+// STATIC_LIB: ld{{.*}} "[[INPUTA]]" "[[INPUTO]]"
+
+// RUN: touch %t.lo
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.lo -### %t.o 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=STATIC_LIB_LO -DINPUTLO=%t.lo -DINPUTO=%t.o
+// STATIC_LIB_LO: ld{{(.exe)?}}" "-r" "-o" "[[INPUTLD:[^ ]+\.o]]" {{.*}} "-L/dummy/dir"{{.*}} "[[INPUTO]]" "[[INPUTLO]]"
+// STATIC_LIB_LO: clang-offload-bundler{{.*}} "-type=oo" {{.*}} "-inputs=[[INPUTLD]]" "-outputs=[[LISTFILE:.+\.txt]]"
+// STATIC_LIB_LO: llvm-link{{.*}} "@[[LISTFILE]]"
+// STATIC_LIB_LO: ld{{.*}} "[[INPUTLO]]" "[[INPUTO]]"
 
 /// ###########################################################################
 
@@ -94,8 +104,11 @@
 
 /// test behaviors of static lib with no source/object
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.a -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefixes=STATIC_LIB_NOSRC
-// STATIC_LIB_NOSRC: clang-offload-bundler{{.*}} "-type=ao" "-targets=host-x86_64-unknown-linux-gnu" "-inputs=[[INPUTLIB:.+\.a]]" "-check-section"
+// RUN:   | FileCheck %s -check-prefixes=STATIC_LIB_NOSRC,STATIC_LIB_NOSRC_A
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t.lo -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefixes=STATIC_LIB_NOSRC,STATIC_LIB_NOSRC_LO
+// STATIC_LIB_NOSRC_A: clang-offload-bundler{{.*}} "-type=ao" "-targets=host-x86_64-unknown-linux-gnu" "-inputs=[[INPUTLIB:.+\.a]]" "-check-section"
+// STATIC_LIB_NOSRC_LO: clang-offload-bundler{{.*}} "-type=ao" "-targets=host-x86_64-unknown-linux-gnu" "-inputs=[[INPUTLIB:.+\.lo]]" "-check-section"
 // STATIC_LIB_NOSRC: ld{{.*}} "-r" "-o" "[[PARTIALOBJ:.+\.o]]" "{{.*}}crt1.o" {{.*}} "-L/dummy/dir" {{.*}} "[[INPUTLIB]]"
 // STATIC_LIB_NOSRC: clang-offload-bundler{{.*}} "-type=oo" "-targets=sycl-spir64-unknown-unknown-sycldevice" "-inputs=[[PARTIALOBJ]]" "-outputs=[[DEVICELIST:.+\.txt]]" "-unbundle"
 // STATIC_LIB_NOSRC: llvm-link{{.*}} "@[[DEVICELIST]]" "-o" "[[BCFILE:.+\.bc]]"

--- a/clang/test/Driver/sycl-offload-static-lib.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib.cpp
@@ -9,7 +9,6 @@
 // RUN: echo "void foo(void) {}" > %t1.cpp
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t1.cpp -c -o %t1_bundle.o
 // RUN: llvm-ar cr %t.a %t1_bundle.o
-// RUN: llvm-ar cr %t.lo %t1_bundle.o
 // RUN: llvm-ar cr %t_2.a %t1_bundle.o
 
 /// ###########################################################################

--- a/clang/test/Driver/sycl-offload-static-lib.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib.cpp
@@ -4,6 +4,14 @@
 // REQUIRES: clang-driver
 // REQUIRES: x86-registered-target
 
+/// test behaviors of passing a fat static lib
+// Build a fat static lib that will be used for all tests
+// RUN: echo "void foo(void) {}" > %t1.cpp
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t1.cpp -c -o %t1_bundle.o
+// RUN: llvm-ar cr %t.a %t1_bundle.o
+// RUN: llvm-ar cr %t.lo %t1_bundle.o
+// RUN: llvm-ar cr %t_2.a %t1_bundle.o
+
 /// ###########################################################################
 
 /// test behaviors of -foffload-static-lib=<lib>


### PR DESCRIPTION
In certain build situations, *.lo files are created that are static archives.
Adjust the detection of static archives to include these, and also perform
a more strict check against known file extensions for archives.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>