### PR TITLE
[SYCL] Remove operator name keywords

### DIFF
--- a/sycl/include/CL/sycl/intel/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/intel/group_algorithm.hpp
@@ -217,7 +217,7 @@ template <typename Group> bool none_of(Group g, bool pred) {
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
 #ifdef __SYCL_DEVICE_ONLY__
-  return detail::spirv::GroupAll<Group>(not pred);
+  return detail::spirv::GroupAll<Group>(!pred);
 #else
   throw runtime_error("Group algorithms are not supported on host device.",
                       PI_INVALID_DEVICE);
@@ -239,7 +239,7 @@ EnableIfIsPointer<Ptr, bool> none_of(Group g, Ptr first, Ptr last,
   static_assert(detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
-  return not any_of(g, first, last, pred);
+  return !any_of(g, first, last, pred);
 #else
   throw runtime_error("Group algorithms are not supported on host device.",
                       PI_INVALID_DEVICE);

--- a/sycl/test/regression/operator-names.cpp
+++ b/sycl/test/regression/operator-names.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx -fsycl -c %s -o %t.out -Wno-deprecated -fno-operator-names
+//
+//===----------------------------------------------------------------------===//
+// This test checks if any SYCL header files use C++ operator name keywords
+// e.g. and, or, not
+//
+// This test does not use -fsyntax-only because it does not appear to respect
+// the -fno-operator-names option
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>


### PR DESCRIPTION
Some libraries require -fno-operator-names, and so we should avoid using
operator name keywords in SYCL headers.

Signed-off-by: John Pennycook <john.pennycook@intel.com>