### PR TITLE
Support more image_channel_types in image_accessors read/write API for half4 datatype on host device.

### DIFF
--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -465,8 +465,8 @@ void convertReadData(const vec<ChannelType, 4> PixelData,
         "image_channel_type of the image.",
         PI_INVALID_VALUE);
   case image_channel_type::fp16:
-    RetDataFloat = PixelData.template convert<cl_float>();
-    break;
+    RetData = PixelData.template convert<cl_half>();
+    return;
   case image_channel_type::fp32:
     throw cl::sycl::invalid_parameter_error(
         "Datatype to read - cl_half4 is incompatible with the "
@@ -639,17 +639,6 @@ convertWriteData(const vec<cl_float, 4> WriteData,
     break;
   }
 }
-
-/*
-template <typename ChannelType>
-vec<ChannelType, 4> processHalfDataToPixel(vec<cl_half, 4> WriteData,
-                                            float MulFactor) {
-  vec<cl_half, 4> Temp = WriteData * MulFactor;
-  vec<cl_int, 4> TempInInt = Temp.convert<int, rounding_mode::rte>();
-  vec<cl_int, 4> TempInIntSaturated =
-      cl::sycl::clamp(TempInInt, min_v<ChannelType>(), max_v<ChannelType>());
-  return TempInIntSaturated.convert<ChannelType>();
-}*/
 
 template <typename ChannelType>
 vec<ChannelType, 4>

--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -554,10 +554,10 @@ template <typename ChannelType>
 vec<ChannelType, 4> processFloatDataToPixel(vec<cl_float, 4> WriteData,
                                             float MulFactor) {
   vec<cl_float, 4> Temp = WriteData * MulFactor;
-  vec<cl_int, 4> TempInInt = Temp.template convert<int, rounding_mode::rte>();
+  vec<cl_int, 4> TempInInt = Temp.convert<int, rounding_mode::rte>();
   vec<cl_int, 4> TempInIntSaturated =
       cl::sycl::clamp(TempInInt, min_v<ChannelType>(), max_v<ChannelType>());
-  return TempInIntSaturated.template convert<ChannelType>();
+  return TempInIntSaturated.convert<ChannelType>();
 }
 
 template <typename ChannelType>

--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -655,7 +655,7 @@ template <typename ChannelType>
 vec<ChannelType, 4>
 convertWriteData(const vec<cl_half, 4> WriteData,
                  const image_channel_type ImageChannelType) {
-  vec<cl_float, 4> WriteDataFloat = WriteData.convert<cl_float>(); 
+  vec<cl_float, 4> WriteDataFloat = WriteData.convert<cl_float>();
   switch (ImageChannelType) {
   case image_channel_type::snorm_int8:
     // convert_char_sat_rte(h * 127.0f)

--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -423,12 +423,26 @@ template <typename ChannelType>
 void convertReadData(const vec<ChannelType, 4> PixelData,
                      const image_channel_type ImageChannelType,
                      vec<cl_half, 4> &RetData) {
-
+  vec<cl_float, 4> RetDataFloat;
   switch (ImageChannelType) {
   case image_channel_type::snorm_int8:
+    //  max(-1.0f, (half)c / 127.0f)
+    RetDataFloat = (PixelData.template convert<cl_float>()) / 127.0f;
+    RetDataFloat = cl::sycl::fmax(RetDataFloat, -1);
+    break;
   case image_channel_type::snorm_int16:
+    // max(-1.0f, (half)c / 32767.0f)
+    RetDataFloat = (PixelData.template convert<cl_float>()) / 32767.0f;
+    RetDataFloat = cl::sycl::fmax(RetDataFloat, -1);
+    break;
   case image_channel_type::unorm_int8:
+    // (half)c / 255.0f
+    RetDataFloat = (PixelData.template convert<cl_float>()) / 255.0f;
+    break;
   case image_channel_type::unorm_int16:
+    // (half)c / 65535.0f
+    RetDataFloat = (PixelData.template convert<cl_float>()) / 65535.0f;
+    break;
   case image_channel_type::unorm_short_565:
   case image_channel_type::unorm_short_555:
   case image_channel_type::unorm_int_101010:
@@ -451,7 +465,7 @@ void convertReadData(const vec<ChannelType, 4> PixelData,
         "image_channel_type of the image.",
         PI_INVALID_VALUE);
   case image_channel_type::fp16:
-    RetData = PixelData.template convert<cl_half>();
+    RetDataFloat = PixelData.template convert<cl_float>();
     break;
   case image_channel_type::fp32:
     throw cl::sycl::invalid_parameter_error(
@@ -461,6 +475,7 @@ void convertReadData(const vec<ChannelType, 4> PixelData,
   default:
     break;
   }
+  RetData = RetDataFloat.template convert<cl_half>();
 }
 
 // Converts data to write into appropriate datatype based on the channel of the
@@ -539,10 +554,10 @@ template <typename ChannelType>
 vec<ChannelType, 4> processFloatDataToPixel(vec<cl_float, 4> WriteData,
                                             float MulFactor) {
   vec<cl_float, 4> Temp = WriteData * MulFactor;
-  vec<cl_int, 4> TempInInt = Temp.convert<int, rounding_mode::rte>();
+  vec<cl_int, 4> TempInInt = Temp.template convert<int, rounding_mode::rte>();
   vec<cl_int, 4> TempInIntSaturated =
       cl::sycl::clamp(TempInInt, min_v<ChannelType>(), max_v<ChannelType>());
-  return TempInIntSaturated.convert<ChannelType>();
+  return TempInIntSaturated.template convert<ChannelType>();
 }
 
 template <typename ChannelType>
@@ -625,16 +640,35 @@ convertWriteData(const vec<cl_float, 4> WriteData,
   }
 }
 
+/*
+template <typename ChannelType>
+vec<ChannelType, 4> processHalfDataToPixel(vec<cl_half, 4> WriteData,
+                                            float MulFactor) {
+  vec<cl_half, 4> Temp = WriteData * MulFactor;
+  vec<cl_int, 4> TempInInt = Temp.convert<int, rounding_mode::rte>();
+  vec<cl_int, 4> TempInIntSaturated =
+      cl::sycl::clamp(TempInInt, min_v<ChannelType>(), max_v<ChannelType>());
+  return TempInIntSaturated.convert<ChannelType>();
+}*/
+
 template <typename ChannelType>
 vec<ChannelType, 4>
 convertWriteData(const vec<cl_half, 4> WriteData,
                  const image_channel_type ImageChannelType) {
-
+  vec<cl_float, 4> WriteDataFloat = WriteData.convert<cl_float>(); 
   switch (ImageChannelType) {
   case image_channel_type::snorm_int8:
+    // convert_char_sat_rte(h * 127.0f)
+    return processFloatDataToPixel<ChannelType>(WriteDataFloat, 127.0f);
   case image_channel_type::snorm_int16:
+    // convert_short_sat_rte(h * 32767.0f)
+    return processFloatDataToPixel<ChannelType>(WriteDataFloat, 32767.0f);
   case image_channel_type::unorm_int8:
+    // convert_uchar_sat_rte(h * 255.0f)
+    return processFloatDataToPixel<ChannelType>(WriteDataFloat, 255.0f);
   case image_channel_type::unorm_int16:
+    // convert_ushort_sat_rte(h * 65535.0f)
+    return processFloatDataToPixel<ChannelType>(WriteDataFloat, 65535.0f);
   case image_channel_type::unorm_short_565:
   case image_channel_type::unorm_short_555:
   case image_channel_type::unorm_int_101010:
@@ -994,10 +1028,13 @@ DataT ReadPixelDataLinearFiltMode(const cl_int8 CoordValues,
 //     ImgChannelType.
 //   Convert to DataT as per conversion rules in section 8.3 in OpenCL Spec.
 //
-// TODO:
-// Extend support for Step2 and Step3 for Linear Filtering Mode.
-// Extend support to find out of bounds Coordinates and return appropriate
-// value based on Addressing Mode.
+// TODO: Add additional check for half datatype read.
+// Based on OpenCL spec 2.0:
+// "The read_imageh calls that take integer coordinates must use a sampler with
+// filter mode set to CLK_FILTER_NEAREST, normalized coordinates set to
+// CLK_NORMALIZED_COORDS_FALSE and addressing mode set to
+// CLK_ADDRESS_CLAMP_TO_EDGE, CLK_ADDRESS_CLAMP or CLK_ADDRESS_NONE; otherwise
+// the values returned are undefined."
 
 template <typename CoordT, typename DataT>
 DataT imageReadSamplerHostImpl(const CoordT &Coords, const sampler &Smpl,

--- a/sycl/test/basic_tests/image_accessor_readwrite.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite.cpp
@@ -1,8 +1,7 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUNx: %GPU_RUN_PLACEHOLDER %t.out
-// RUNx: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 //==--------------------image_accessor_readwrite.cpp ----------------------==//
 //==----------image_accessor read without sampler & write API test---------==//
 //
@@ -23,102 +22,42 @@ namespace s = cl::sycl;
 
 template <typename WriteDataT, int ImgType, int read_write> class kernel_class;
 
-template <typename PixelDataType, typename PixelDataT,
-          typename = typename std::enable_if<
-              (!(std::is_same<PixelDataT, s::cl_half4>::value))>::type>
-void check_write_data(PixelDataType *HostDataPtr, PixelDataT ExpectedData) {
-#if DEBUG_OUTPUT
-  {
-    if ((HostDataPtr[0] == (PixelDataType)ExpectedData.x()) &&
-        (HostDataPtr[1] == (PixelDataType)ExpectedData.y()) &&
-        (HostDataPtr[2] == (PixelDataType)ExpectedData.z()) &&
-        (HostDataPtr[3] == (PixelDataType)ExpectedData.w())) {
-      std::cout << "Data written is correct: " << std::endl;
-    } else {
-      std::cout << "Data written is WRONG: " << std::endl;
-    }
-    std::cout << "HostDataPtr: \t" << (float)HostDataPtr[0] << "  "
-              << (float)HostDataPtr[1] << "  " << (float)HostDataPtr[2] << "  "
-              << (float)HostDataPtr[3] << std::endl;
-
-    std::cout << "ExpectedData: \t" << (float)ExpectedData.x() << "  "
-              << (float)ExpectedData.y() << "  " << (float)ExpectedData.z()
-              << "  " << (float)ExpectedData.w() << std::endl;
-  }
-#else
-  assert(HostDataPtr[0] == (PixelDataType)ExpectedData.x());
-  assert(HostDataPtr[1] == (PixelDataType)ExpectedData.y());
-  assert(HostDataPtr[2] == (PixelDataType)ExpectedData.z());
-  assert(HostDataPtr[3] == (PixelDataType)ExpectedData.w());
-#endif
-}
-
-void check_write_data(s::cl_half *HostDataPtr, s::cl_half4 ExpectedData) {
-#if DEBUG_OUTPUT
-  {
-    if ((HostDataPtr[0] == (float)ExpectedData.x()) &&
-        (HostDataPtr[1] == (float)ExpectedData.y()) &&
-        (HostDataPtr[2] == (float)ExpectedData.z()) &&
-        (HostDataPtr[3] == (float)ExpectedData.w())) {
-      std::cout << "Data written is correct: " << std::endl;
-    } else {
-      std::cout << "Data written is WRONG: " << std::endl;
-    }
-    std::cout << "HostDataPtr: \t" << (float)HostDataPtr[0] << "  "
-              << (float)HostDataPtr[1] << "  " << (float)HostDataPtr[2] << "  "
-              << (float)HostDataPtr[3] << std::endl;
-
-    std::cout << "ExpectedData: \t" << (float)ExpectedData.x() << "  "
-              << (float)ExpectedData.y() << "  " << (float)ExpectedData.z()
-              << "  " << (float)ExpectedData.w() << std::endl;
-  }
-#else
-  assert(HostDataPtr[0] == (float)ExpectedData.x());
-  assert(HostDataPtr[1] == (float)ExpectedData.y());
-  assert(HostDataPtr[2] == (float)ExpectedData.z());
-  assert(HostDataPtr[3] == (float)ExpectedData.w());
-#endif
-}
-
 template <typename ReadDataT,
           typename = typename std::enable_if<
               (!(std::is_same<ReadDataT, s::cl_float4>::value) &&
                !(std::is_same<ReadDataT, s::cl_half4>::value))>::type>
 void check_read_data(ReadDataT ReadData, ReadDataT ExpectedColor) {
   using ReadDataType = typename s::detail::TryToGetElementType<ReadDataT>::type;
-#if DEBUG_OUTPUT
-  {
-    if (((ReadDataType)ReadData.x() == (ReadDataType)ExpectedColor.x()) &&
-        ((ReadDataType)ReadData.y() == (ReadDataType)ExpectedColor.y()) &&
-        ((ReadDataType)ReadData.z() == (ReadDataType)ExpectedColor.z()) &&
-        ((ReadDataType)ReadData.w() == (ReadDataType)ExpectedColor.w())) {
-      std::cout << "Read Data is correct: " << std::endl;
-    } else {
-      std::cout << "Read Data is WRONG: " << std::endl;
-    }
-    std::cout << "ReadData: \t"
-              << std::setprecision(std::numeric_limits<long double>::digits10 +
-                                   1)
-              << (ReadDataType)ReadData.x() << "  "
-              << (ReadDataType)ReadData.y() << "  "
-              << (ReadDataType)ReadData.z() << "  "
-              << (ReadDataType)ReadData.w() << std::endl;
+  bool CorrectData = false;
+  if ((ReadData.x() == ExpectedColor.x()) &&
+      (ReadData.y() == ExpectedColor.y()) &&
+      (ReadData.z() == ExpectedColor.z()) &&
+      (ReadData.w() == ExpectedColor.w()))
+    CorrectData = true;
 
-    std::cout << "ExpectedColor: \t"
-              << std::setprecision(std::numeric_limits<long double>::digits10 +
-                                   1)
-              << (ReadDataType)ExpectedColor.x() << "  "
-              << (ReadDataType)ExpectedColor.y() << "  "
-              << (ReadDataType)ExpectedColor.z() << "  "
-              << (ReadDataType)ExpectedColor.w() << std::endl;
-  }
+#if DEBUG_OUTPUT
+  if (CorrectData)
+    std::cout << "Read Data is correct: " << std::endl;
+  else
+    std::cout << "Read Data is WRONG: " << std::endl;
+
+  std::cout << "ReadData: \t"
+            << std::setprecision(std::numeric_limits<long double>::digits10 +
+                                 1)
+            << ReadData.x() << "  "
+            << ReadData.y() << "  "
+            << ReadData.z() << "  "
+            << ReadData.w() << std::endl;
+
+  std::cout << "ExpectedColor: \t"
+            << std::setprecision(std::numeric_limits<long double>::digits10 +
+                                 1)
+            << ExpectedColor.x() << "  "
+            << ExpectedColor.y() << "  "
+            << ExpectedColor.z() << "  "
+            << ExpectedColor.w() << std::endl;
 #else
-  {
-    assert((ReadDataType)ReadData.x() == (ReadDataType)ExpectedColor.x());
-    assert((ReadDataType)ReadData.y() == (ReadDataType)ExpectedColor.y());
-    assert((ReadDataType)ReadData.z() == (ReadDataType)ExpectedColor.z());
-    assert((ReadDataType)ReadData.w() == (ReadDataType)ExpectedColor.w());
-  }
+  assert(CorrectData);
 #endif
 }
 
@@ -127,37 +66,34 @@ void check_read_data(s::cl_float4 ReadData, s::cl_float4 ExpectedColor) {
   s::cl_int4 PixelDataInt = ReadData.template as<s::cl_int4>();
   s::cl_int4 ExpectedDataInt = ExpectedColor.template as<s::cl_int4>();
   s::cl_int4 Diff = ExpectedDataInt - PixelDataInt;
-#if DEBUG_OUTPUT
-  {
-    if (((s::cl_int)Diff.x() <= 1 && (s::cl_int)Diff.x() >= -1) &&
-        ((s::cl_int)Diff.y() <= 1 && (s::cl_int)Diff.y() >= -1) &&
-        ((s::cl_int)Diff.z() <= 1 && (s::cl_int)Diff.z() >= -1) &&
-        ((s::cl_int)Diff.w() <= 1 && (s::cl_int)Diff.w() >= -1)) {
-      std::cout << "Read Data is correct within precision: " << std::endl;
-    } else {
-      std::cout << "Read Data is WRONG/ outside precision: " << std::endl;
-    }
-    std::cout << "ReadData: \t"
-              << std::setprecision(std::numeric_limits<long double>::digits10 +
-                                   1)
-              << (float)ReadData.x() << "  " << (float)ReadData.y() << "  "
-              << (float)ReadData.z() << "  " << (float)ReadData.w()
-              << std::endl;
+  bool CorrectData = false;
+  if ((Diff.x() <= 1 && Diff.x() >= -1) &&
+      (Diff.y() <= 1 && Diff.y() >= -1) &&
+      (Diff.z() <= 1 && Diff.z() >= -1) &&
+      (Diff.w() <= 1 && Diff.w() >= -1))
+    CorrectData = true;
 
-    std::cout << "ExpectedColor: \t"
-              << std::setprecision(std::numeric_limits<long double>::digits10 +
-                                   1)
-              << (float)ExpectedColor.x() << "  " << (float)ExpectedColor.y()
-              << "  " << (float)ExpectedColor.z() << "  "
-              << (float)ExpectedColor.w() << std::endl;
-  }
+#if DEBUG_OUTPUT
+  if (CorrectData)
+    std::cout << "Read Data is correct within precision: " << std::endl;
+  else
+    std::cout << "Read Data is WRONG/ outside precision: " << std::endl;
+
+  std::cout << "ReadData: \t"
+            << std::setprecision(std::numeric_limits<long double>::digits10 +
+                                 1)
+            << ReadData.x() << "  " << ReadData.y() << "  "
+            << ReadData.z() << "  " << ReadData.w()
+            << std::endl;
+
+  std::cout << "ExpectedColor: \t"
+            << std::setprecision(std::numeric_limits<long double>::digits10 +
+                                 1)
+            << ExpectedColor.x() << "  " << ExpectedColor.y()
+            << "  " << ExpectedColor.z() << "  "
+            << ExpectedColor.w() << std::endl;
 #else
-  {
-    assert((s::cl_int)Diff.x() <= 1 && (s::cl_int)Diff.x() >= -1);
-    assert((s::cl_int)Diff.y() <= 1 && (s::cl_int)Diff.y() >= -1);
-    assert((s::cl_int)Diff.z() <= 1 && (s::cl_int)Diff.z() >= -1);
-    assert((s::cl_int)Diff.w() <= 1 && (s::cl_int)Diff.w() >= -1);
-  }
+  assert(CorrectData);
 #endif
 }
 
@@ -168,11 +104,10 @@ void check_read_data(s::cl_half4 ReadData, s::cl_half4 ExpectedColor) {
   check_read_data(ReadDatafloat, ExpectedColorfloat);
 }
 
-template <typename WriteDataT, s::image_channel_type ImgType,
-          typename PixelDataType>
-void check_write_type_order(char *HostPtr,
-                            const s::image_channel_order ImgOrder,
-                            WriteDataT Color, PixelDataType ExpectedData) {
+template <typename WriteDataT, s::image_channel_type ImgType>
+void write_type_order(char *HostPtr,
+                      const s::image_channel_order ImgOrder,
+                      WriteDataT Color) {
 
   int Coord(2);
   {
@@ -186,17 +121,6 @@ void check_write_type_order(char *HostPtr,
     });
     });
   }
-
-  // Check Written Data.
-  using PixelElementType =
-      typename s::detail::TryToGetElementType<PixelDataType>::type;
-  int NumChannels = 4;
-  HostPtr =
-      HostPtr + (2 * s::detail::getImageElementSize(NumChannels, ImgType));
-  // auto HostDataPtr = reinterpret_cast<PixelElementType *>(HostPtr);
-  auto HostDataPtr = (PixelElementType *)(HostPtr);
-
-  check_write_data((PixelElementType *)(HostPtr), ExpectedData);
 }
 
 template <typename ReadDataT, s::image_channel_type ImgType>
@@ -229,37 +153,28 @@ template <typename T> void check(char *);
 template <> void check<s::cl_int4>(char *HostPtr) {
   // valid channel types:
   // s::image_channel_type::signed_int8,
-  check_write_type_order<s::cl_int4, s::image_channel_type::signed_int8,
-                         s::cl_char4>(
+  write_type_order<s::cl_int4, s::image_channel_type::signed_int8>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_int4(std::numeric_limits<s::cl_int>::max(),
-                 std::numeric_limits<s::cl_int>::min(), 123, 0),
-      s::cl_char4(std::numeric_limits<s::cl_char>::max(),
-                  std::numeric_limits<s::cl_char>::min(), 123, 0));
+                 std::numeric_limits<s::cl_int>::min(), 123, 0));
   check_read_type_order<s::cl_int4, s::image_channel_type::signed_int8>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_int4(std::numeric_limits<s::cl_char>::max(),
                  std::numeric_limits<s::cl_char>::min(), 123, 0));
 
   // s::image_channel_type::signed_int16,
-  check_write_type_order<s::cl_int4, s::image_channel_type::signed_int16,
-                         s::cl_short4>(
+  write_type_order<s::cl_int4, s::image_channel_type::signed_int16>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_int4(std::numeric_limits<s::cl_int>::max(),
-                 std::numeric_limits<s::cl_int>::min(), 123, 0),
-      s::cl_short4(std::numeric_limits<s::cl_short>::max(),
-                   std::numeric_limits<s::cl_short>::min(), 123, 0));
+                 std::numeric_limits<s::cl_int>::min(), 123, 0));
   check_read_type_order<s::cl_int4, s::image_channel_type::signed_int16>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_int4(std::numeric_limits<s::cl_short>::max(),
                  std::numeric_limits<s::cl_short>::min(), 123, 0));
 
   // s::image_channel_type::signed_int32.
-  check_write_type_order<s::cl_int4, s::image_channel_type::signed_int32,
-                         s::cl_int4>(
+  write_type_order<s::cl_int4, s::image_channel_type::signed_int32>(
       HostPtr, s::image_channel_order::rgba,
-      s::cl_int4(std::numeric_limits<s::cl_int>::max(),
-                 std::numeric_limits<s::cl_int>::min(), 123, 0),
       s::cl_int4(std::numeric_limits<s::cl_int>::max(),
                  std::numeric_limits<s::cl_int>::min(), 123, 0));
   check_read_type_order<s::cl_int4, s::image_channel_type::signed_int32>(
@@ -271,37 +186,28 @@ template <> void check<s::cl_int4>(char *HostPtr) {
 template <> void check<s::cl_uint4>(char *HostPtr) {
   // Calling only valid channel types with s::cl_uint4.
   // s::image_channel_type::signed_int8
-  check_write_type_order<s::cl_uint4, s::image_channel_type::unsigned_int8,
-                         s::cl_uchar4>(
+  write_type_order<s::cl_uint4, s::image_channel_type::unsigned_int8>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_uint4(std::numeric_limits<s::cl_uint>::max(),
-                  std::numeric_limits<s::cl_uint>::min(), 123, 0),
-      s::cl_uchar4(std::numeric_limits<s::cl_uchar>::max(),
-                   std::numeric_limits<s::cl_uchar>::min(), 123, 0));
+                  std::numeric_limits<s::cl_uint>::min(), 123, 0));
   check_read_type_order<s::cl_uint4, s::image_channel_type::unsigned_int8>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_uint4(std::numeric_limits<s::cl_uchar>::max(),
                   std::numeric_limits<s::cl_uchar>::min(), 123, 0));
 
   // s::image_channel_type::signed_int16
-  check_write_type_order<s::cl_uint4, s::image_channel_type::unsigned_int16,
-                         s::cl_ushort4>(
+  write_type_order<s::cl_uint4, s::image_channel_type::unsigned_int16>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_uint4(std::numeric_limits<s::cl_uint>::max(),
-                  std::numeric_limits<s::cl_uint>::min(), 123, 0),
-      s::cl_ushort4(std::numeric_limits<s::cl_ushort>::max(),
-                    std::numeric_limits<s::cl_ushort>::min(), 123, 0));
+                  std::numeric_limits<s::cl_uint>::min(), 123, 0));
   check_read_type_order<s::cl_uint4, s::image_channel_type::unsigned_int16>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_uint4(std::numeric_limits<s::cl_ushort>::max(),
                   std::numeric_limits<s::cl_ushort>::min(), 123, 0));
 
   // s::image_channel_type::signed_int32
-  check_write_type_order<s::cl_uint4, s::image_channel_type::unsigned_int32,
-                         s::cl_uint4>(
+  write_type_order<s::cl_uint4, s::image_channel_type::unsigned_int32>(
       HostPtr, s::image_channel_order::rgba,
-      s::cl_uint4(std::numeric_limits<s::cl_uint>::max(),
-                  std::numeric_limits<s::cl_uint>::min(), 123, 0),
       s::cl_uint4(std::numeric_limits<s::cl_uint>::max(),
                   std::numeric_limits<s::cl_uint>::min(), 123, 0));
   check_read_type_order<s::cl_uint4, s::image_channel_type::unsigned_int32>(
@@ -314,41 +220,29 @@ template <> void check<s::cl_float4>(char *HostPtr) {
   // Calling only valid channel types with s::cl_float4.
   // TODO: Correct the values below.
   // s::image_channel_type::snorm_int8,
-  check_write_type_order<s::cl_float4, s::image_channel_type::snorm_int8,
-                         s::cl_char4>(
-      HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0),
-      s::cl_char4(std::numeric_limits<s::cl_char>::max(),
-                  std::numeric_limits<s::cl_char>::min(), 48, 0));
+  write_type_order<s::cl_float4, s::image_channel_type::snorm_int8>(
+      HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0));
   check_read_type_order<s::cl_float4, s::image_channel_type::snorm_int8>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_float4(1, -1, ((float)48 / 127) /*0.3779527544975280762f*/, 0));
 
   // s::image_channel_type::snorm_int16,
-  check_write_type_order<s::cl_float4, s::image_channel_type::snorm_int16,
-                         s::cl_short4>(
-      HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0),
-      s::cl_short4(std::numeric_limits<s::cl_short>::max(),
-                   std::numeric_limits<s::cl_short>::min(), 12288, 0));
+  write_type_order<s::cl_float4, s::image_channel_type::snorm_int16>(
+      HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0));
   check_read_type_order<s::cl_float4, s::image_channel_type::snorm_int16>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_float4(1, -1, ((float)12288 / 32767) /*0.375011444091796875f*/, 0));
 
   // s::image_channel_type::unorm_int8,
-  check_write_type_order<s::cl_float4, s::image_channel_type::unorm_int8,
-                         s::cl_uchar4>(
-      HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0),
-      s::cl_uchar4(std::numeric_limits<s::cl_uchar>::max(),
-                   std::numeric_limits<s::cl_uchar>::min(), 96, 0));
+  write_type_order<s::cl_float4, s::image_channel_type::unorm_int8>(
+      HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0));
   check_read_type_order<s::cl_float4, s::image_channel_type::unorm_int8>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_float4(1, 0, ((float)96 / 255) /*0.3764705955982208252f*/, 0));
 
   // s::image_channel_type::unorm_int16
-  check_write_type_order<s::cl_float4, s::image_channel_type::unorm_int16,
-                         s::cl_ushort4>(
-      HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0),
-      s::cl_ushort4(std::numeric_limits<s::cl_ushort>::max(),
-                    std::numeric_limits<s::cl_ushort>::min(), 24576, 0));
+  write_type_order<s::cl_float4, s::image_channel_type::unorm_int16>(
+      HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0));
   check_read_type_order<s::cl_float4, s::image_channel_type::unorm_int16>(
       HostPtr, s::image_channel_order::rgba,
       s::cl_float4(1, 0, ((float)24576 / 65535) /*0.3750057220458984375f*/, 0));
@@ -356,57 +250,35 @@ template <> void check<s::cl_float4>(char *HostPtr) {
   // s::image_channel_type::unorm_short_565, order::rgbx
   // Currently unsupported since OpenCL has no information on this.
 
-  // TODO: Enable the below call, causing an error in scheduler
+  // TODO: Enable the below call, causing a runtime error in OpenCL CPU/GPU:
+  // OpenCL API returns: -10 (CL_IMAGE_FORMAT_NOT_SUPPORTED) -10 (CL_IMAGE_FORMAT_NOT_SUPPORTED)
   // s::image_channel_type::unorm_short_555, order::rgbx
   /*
-  check_write_type_order<s::cl_float4, s::image_channel_type::unorm_short_555,
-      s::cl_short4>(
-      HostPtr, s::image_channel_order::rgbx, s::cl_float4(2, -2, 0.375f, 0),
-      s::cl_short4(std::numeric_limits<s::cl_short>::max(),
-                std::numeric_limits<s::cl_short>::min(), 3, 0));
+  write_type_order<s::cl_float4, s::image_channel_type::unorm_short_555>(
+      HostPtr, s::image_channel_order::rgbx, s::cl_float4(2, -2, 0.375f, 0));
 
   // s::image_channel_type::unorm_int_101010, order::rgbx
-  check_write_type_order<s::cl_float4, s::image_channel_type::unorm_int_101010,
-                         s::cl_uint4>(
-      HostPtr, s::image_channel_order::rgbx, s::cl_float4(2, -2, 0.375f, 0),
-      s::cl_uint4(std::numeric_limits<s::cl_uint>::max(),
-               std::numeric_limits<s::cl_uint>::min(), 3, 0));
+  write_type_order<s::cl_float4, s::image_channel_type::unorm_int_101010>(
+      HostPtr, s::image_channel_order::rgbx, s::cl_float4(2, -2, 0.375f, 0));
   */
 
   // s::image_channel_type::fp16
-  check_write_type_order<s::cl_float4, s::image_channel_type::fp16,
-                         s::cl_half4>(HostPtr, s::image_channel_order::rgba,
-                                      s::cl_float4(2, -2, 0.375f, 0),
-                                      s::cl_half4(2, -2, 0.375, 0));
+  write_type_order<s::cl_float4, s::image_channel_type::fp16>(HostPtr, s::image_channel_order::rgba,
+                                                              s::cl_float4(2, -2, 0.375f, 0));
   check_read_type_order<s::cl_float4, s::image_channel_type::fp16>(
       HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0));
 
   // s::image_channel_type::fp32
-  check_write_type_order<s::cl_float4, s::image_channel_type::fp32,
-                         s::cl_float4>(HostPtr, s::image_channel_order::rgba,
-                                       s::cl_float4(2, -2, 0.375f, 0),
-                                       s::cl_float4(2, -2, 0.375f, 0));
+  write_type_order<s::cl_float4, s::image_channel_type::fp32>(HostPtr, s::image_channel_order::rgba,
+                                                              s::cl_float4(2, -2, 0.375f, 0));
   check_read_type_order<s::cl_float4, s::image_channel_type::fp32>(
       HostPtr, s::image_channel_order::rgba, s::cl_float4(2, -2, 0.375f, 0));
 };
-/*
-template <> void check<s::cl_half4>(char *HostPtr) {
-
-  // Calling only valid channel types with s::cl_half4.
-  // s::image_channel_type::fp16
-  // TODO: Enable the below call. Currently it doesn't work because of
-s::cl_half
-  // Datatype explicit conversion issues on stmt 71-74
-  check_write_type_order<s::cl_half4, s::image_channel_type::fp16, s::cl_half4>(
-      HostPtr, s::image_channel_order::rgba, s::cl_half4(2, -2, 0.375f, 0),
-      s::cl_half4(2, -2, 0.375, 0));
-  check_read_type_order<s::cl_half4, s::image_channel_type::fp16>(
-      HostPtr, s::image_channel_order::rgba, s::cl_half4(2, -2, 0.375f, 0));
-};*/
 
 int main() {
   // Checking only for dimension=1.
   // 4 datatypes possible: s::cl_uint4, s::cl_int4, s::cl_float4, s::cl_half4.
+  // half4 datatype is checked in a different test case.
   // create image:
   char HostPtr[100];
   for (int i = 0; i < 100; i++)
@@ -415,5 +287,4 @@ int main() {
   check<s::cl_int4>(HostPtr);
   check<s::cl_uint4>(HostPtr);
   check<s::cl_float4>(HostPtr);
-  // check<s::cl_half4>(HostPtr);
 }

--- a/sycl/test/basic_tests/image_accessor_readwrite.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite.cpp
@@ -2,6 +2,9 @@
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+// TODO: No CUDA image support
+// XFAIL: cuda
 //==--------------------image_accessor_readwrite.cpp ----------------------==//
 //==----------image_accessor read without sampler & write API test---------==//
 //

--- a/sycl/test/basic_tests/image_accessor_readwrite.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite.cpp
@@ -3,8 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// TODO: No CUDA image support
-// XFAIL: cuda
+// UNSUPPORTED: cuda
 //==--------------------image_accessor_readwrite.cpp ----------------------==//
 //==----------image_accessor read without sampler & write API test---------==//
 //

--- a/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
@@ -3,8 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// TODO: No CUDA image support
-// XFAIL: cuda
 //==--------------------image_accessor_readwrite_half.cpp -------------------==//
 //==-image_accessor read (without sampler)& write API test for half datatype-==//
 //

--- a/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUNx: %CPU_RUN_PLACEHOLDER %t.out // OpenCL CPU backend does not support half datatype reads and writes for 1D images.
 
 // TODO: No CUDA image support
 // XFAIL: cuda
@@ -152,6 +152,14 @@ void check_half4(char *HostPtr) {
 };
 
 int main() {
+  // Checking if default selected device supports half datatype.
+  // Same device will be selected in the write/read functions.
+  s::device Dev{s::default_selector()};
+  if (!Dev.is_host() && !Dev.has_extension("cl_khr_fp16")) {
+    std::cout << "This device doesn't support the extension cl_khr_fp16"
+              << std::endl;
+    return 0;
+  }
   // Checking only for dimension=1.
   // create image:
   char HostPtr[100];

--- a/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
@@ -3,6 +3,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUNx: %CPU_RUN_PLACEHOLDER %t.out // OpenCL CPU backend does not support half datatype reads and writes for 1D images.
 
+// TODO: No CUDA image support
+// XFAIL: cuda
 //==--------------------image_accessor_readwrite_half.cpp -------------------==//
 //==-image_accessor read (without sampler)& write API test for half datatype-==//
 //
@@ -67,8 +69,7 @@ void check_read_data(s::cl_half4 ReadData, s::cl_half4 ExpectedColor) {
   check_read_data(ReadDatafloat, ExpectedColorfloat);
 }
 
-template <typename WriteDataT, s::image_channel_type ImgType,
-          typename PixelDataType>
+template <typename WriteDataT, s::image_channel_type ImgType>
 void write_type_order(char *HostPtr,
                       const s::image_channel_order ImgOrder,
                       WriteDataT Color) {

--- a/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
@@ -3,6 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// UNSUPPORTED: cuda
 //==--------------------image_accessor_readwrite_half.cpp -------------------==//
 //==-image_accessor read (without sampler)& write API test for half datatype-==//
 //

--- a/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
@@ -1,0 +1,161 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUNx: %CPU_RUN_PLACEHOLDER %t.out // OpenCL CPU backend does not support half datatype reads and writes for 1D images.
+
+//==--------------------image_accessor_readwrite_half.cpp -------------------==//
+//==-image_accessor read (without sampler)& write API test for half datatype-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+#include <cassert>
+#include <iomanip>
+#if DEBUG_OUTPUT
+#include <iostream>
+#endif
+
+namespace s = cl::sycl;
+
+template <typename WriteDataT, int ImgType, int read_write>
+class kernel_class;
+
+void check_read_data(s::cl_float4 ReadData, s::cl_float4 ExpectedColor) {
+  // Maximum difference of 1.5 ULP is allowed.
+  s::cl_int4 PixelDataInt = ReadData.template as<s::cl_int4>();
+  s::cl_int4 ExpectedDataInt = ExpectedColor.template as<s::cl_int4>();
+  s::cl_int4 Diff = ExpectedDataInt - PixelDataInt;
+  bool CorrectData = false;
+  if (((s::cl_int)Diff.x() <= 1 && (s::cl_int)Diff.x() >= -1) &&
+      ((s::cl_int)Diff.y() <= 1 && (s::cl_int)Diff.y() >= -1) &&
+      ((s::cl_int)Diff.z() <= 1 && (s::cl_int)Diff.z() >= -1) &&
+      ((s::cl_int)Diff.w() <= 1 && (s::cl_int)Diff.w() >= -1))
+    CorrectData = true;
+
+#if DEBUG_OUTPUT
+  if (CorrectData)
+    std::cout << "Read Data is correct within precision: " << std::endl;
+  else
+    std::cout << "Read Data is WRONG/ outside precision: " << std::endl;
+
+  std::cout << "ReadData: \t"
+            << std::setprecision(std::numeric_limits<long double>::digits10 +
+                                 1)
+            << ReadData.x() << "  " << ReadData.y() << "  "
+            << ReadData.z() << "  " << ReadData.w()
+            << std::endl;
+
+  std::cout << "ExpectedColor: \t"
+            << std::setprecision(std::numeric_limits<long double>::digits10 +
+                                 1)
+            << ExpectedColor.x() << "  " << ExpectedColor.y()
+            << "  " << ExpectedColor.z() << "  "
+            << ExpectedColor.w() << std::endl;
+
+#else
+  assert(CorrectData);
+#endif
+}
+
+void check_read_data(s::cl_half4 ReadData, s::cl_half4 ExpectedColor) {
+  s::cl_float4 ReadDatafloat = ReadData.convert<float>();
+  s::cl_float4 ExpectedColorfloat = ExpectedColor.convert<float>();
+  check_read_data(ReadDatafloat, ExpectedColorfloat);
+}
+
+template <typename WriteDataT, s::image_channel_type ImgType,
+          typename PixelDataType>
+void write_type_order(char *HostPtr,
+                      const s::image_channel_order ImgOrder,
+                      WriteDataT Color) {
+
+  int Coord(2);
+  {
+    // image with dim = 1;
+    s::image<1> Img(HostPtr, ImgOrder, ImgType, s::range<1>{10});
+    s::queue Queue;
+    Queue.submit([&](s::handler &cgh) {
+      auto WriteAcc = Img.get_access<WriteDataT, s::access::mode::write>(cgh);
+    cgh.single_task<class kernel_class<WriteDataT, static_cast<int>(ImgType), 0>>([=](){
+      WriteAcc.write(Coord, Color);
+    });
+    });
+  }
+}
+
+template <typename ReadDataT, s::image_channel_type ImgType>
+void check_read_type_order(char *HostPtr, const s::image_channel_order ImgOrder,
+                           ReadDataT ExpectedColor) {
+
+  int Coord(2);
+  ReadDataT ReadData;
+  {
+    // image with dim = 1
+    s::image<1> Img(HostPtr, ImgOrder, ImgType, s::range<1>{10});
+    s::queue Queue;
+    s::buffer<ReadDataT, 1> ReadDataBuf(&ReadData, s::range<1>(1));
+    Queue.submit([&](s::handler &cgh) {
+      auto ReadAcc = Img.get_access<ReadDataT, s::access::mode::read>(cgh);
+      s::accessor<ReadDataT, 1, s::access::mode::write> ReadDataBufAcc(
+          ReadDataBuf, cgh);
+
+    cgh.single_task<class kernel_class<ReadDataT, static_cast<int>(ImgType), 1>>([=](){
+      ReadDataT RetColor = ReadAcc.read(Coord);
+      ReadDataBufAcc[0] = RetColor;
+    });
+    });
+  }
+  check_read_data(ReadData, ExpectedColor);
+}
+
+void check_half4(char *HostPtr) {
+
+  // Calling only valid channel types with s::cl_half4.
+  // s::image_channel_type::snorm_int8,
+  write_type_order<s::cl_half4, s::image_channel_type::snorm_int8>(
+      HostPtr, s::image_channel_order::rgba, s::cl_half4(2, -2, 0.375f, 0));
+  check_read_type_order<s::cl_half4, s::image_channel_type::snorm_int8>(
+      HostPtr, s::image_channel_order::rgba,
+      s::cl_half4(1, -1, ((float)48 / 127) /*0.3779527544975280762f*/, 0));
+
+  // s::image_channel_type::snorm_int16,
+  write_type_order<s::cl_half4, s::image_channel_type::snorm_int16>(
+      HostPtr, s::image_channel_order::rgba, s::cl_half4(2, -2, 0.375f, 0));
+  check_read_type_order<s::cl_half4, s::image_channel_type::snorm_int16>(
+      HostPtr, s::image_channel_order::rgba,
+      s::cl_half4(1, -1, ((float)12288 / 32767) /*0.375011444091796875f*/, 0));
+
+  // s::image_channel_type::unorm_int8,
+  write_type_order<s::cl_half4, s::image_channel_type::unorm_int8>(
+      HostPtr, s::image_channel_order::rgba, s::cl_half4(2, -2, 0.375f, 0));
+  check_read_type_order<s::cl_half4, s::image_channel_type::unorm_int8>(
+      HostPtr, s::image_channel_order::rgba,
+      s::cl_half4(1, 0, ((float)96 / 255) /*0.3764705955982208252f*/, 0));
+
+  // s::image_channel_type::unorm_int16
+  write_type_order<s::cl_half4, s::image_channel_type::unorm_int16>(
+      HostPtr, s::image_channel_order::rgba, s::cl_half4(1, -1, 0.375f, 0));
+  check_read_type_order<s::cl_half4, s::image_channel_type::unorm_int16>(
+      HostPtr, s::image_channel_order::rgba,
+      s::cl_half4(1, 0, ((float)24576 / 65535) /*0.3750057220458984375f*/, 0));
+
+  // s::image_channel_type::fp16
+  write_type_order<s::cl_half4, s::image_channel_type::fp16>(
+      HostPtr, s::image_channel_order::rgba, s::cl_half4(2, -2, 0.375f, 0));
+  check_read_type_order<s::cl_half4, s::image_channel_type::fp16>(
+      HostPtr, s::image_channel_order::rgba, s::cl_half4(2, -2, 0.375f, 0));
+};
+
+int main() {
+  // Checking only for dimension=1.
+  // create image:
+  char HostPtr[100];
+  for (int i = 0; i < 100; i++)
+    HostPtr[i] = i;
+
+  check_half4(HostPtr);
+}


### PR DESCRIPTION
Also, clean up done of image_accessor_readwrite test to enable it for GPU.