### PR TITLE
[SYCL] Fix check-sycl test suite on systems w/o OpenCL

### DIFF
--- a/sycl/tools/get_device_count_by_type.cpp
+++ b/sycl/tools/get_device_count_by_type.cpp
@@ -56,10 +56,9 @@ static const char *deviceTypeToString(cl_device_type deviceType) {
 static bool queryOpenCL(cl_device_type deviceType, cl_uint &deviceCount,
                         std::string &msg) {
   deviceCount = 0u;
-  cl_int iRet = CL_SUCCESS;
-  cl_uint platformCount = 0;
 
-  iRet = clGetPlatformIDs(0, nullptr, &platformCount);
+  cl_uint platformCount = 0;
+  cl_int iRet = clGetPlatformIDs(0, nullptr, &platformCount);
   if (iRet != CL_SUCCESS) {
     if (iRet == CL_PLATFORM_NOT_FOUND_KHR) {
       msg = "OpenCL error runtime not found";
@@ -69,7 +68,7 @@ static bool queryOpenCL(cl_device_type deviceType, cl_uint &deviceCount,
     stream << "ERROR: OpenCL error calling clGetPlatformIDs " << iRet
            << std::endl;
     msg = stream.str();
-    return false;
+    return true;
   }
 
   std::vector<cl_platform_id> platforms(platformCount);
@@ -79,7 +78,7 @@ static bool queryOpenCL(cl_device_type deviceType, cl_uint &deviceCount,
     stream << "ERROR: OpenCL error calling clGetPlatformIDs " << iRet
            << std::endl;
     msg = stream.str();
-    return false;
+    return true;
   }
 
   for (cl_uint i = 0; i < platformCount; i++) {
@@ -88,13 +87,6 @@ static bool queryOpenCL(cl_device_type deviceType, cl_uint &deviceCount,
         clGetDeviceIDs(platforms[i], deviceType, 0, nullptr, &deviceCountPart);
     if (iRet == CL_SUCCESS || iRet == CL_DEVICE_NOT_FOUND) {
       deviceCount += deviceCountPart;
-    } else {
-      deviceCount = 0u;
-      std::stringstream stream;
-      stream << "ERROR: OpenCL error calling clGetDeviceIDs " << iRet
-             << std::endl;
-      msg = stream.str();
-      return false;
     }
   }
 

--- a/sycl/tools/get_device_count_by_type.cpp
+++ b/sycl/tools/get_device_count_by_type.cpp
@@ -1,4 +1,3 @@
-
 //==-- get_device_count_by_type.cpp - Get device count by type -------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -12,7 +11,6 @@
 
 #ifdef USE_PI_CUDA
 #include <cuda.h>
-// #include <cuda_device_runtime_api.h>
 #endif // USE_PI_CUDA
 
 #include <algorithm>
@@ -36,33 +34,23 @@ std::string lowerString(const std::string &str) {
   return result;
 }
 
-const char *deviceTypeToString(cl_device_type deviceType) {
-  const char *str = "unknown";
+static const char *deviceTypeToString(cl_device_type deviceType) {
   switch (deviceType) {
   case CL_DEVICE_TYPE_CPU:
-    str = "cpu";
-    break;
+    return "cpu";
   case CL_DEVICE_TYPE_GPU:
-    str = "gpu";
-    break;
+    return "gpu";
   case CL_DEVICE_TYPE_ACCELERATOR:
-    str = "accelerator";
-    break;
+    return "accelerator";
   case CL_DEVICE_TYPE_CUSTOM:
-    str = "custom";
-    break;
+    return "custom";
   case CL_DEVICE_TYPE_DEFAULT:
-    str = "default";
-    break;
+    return "default";
   case CL_DEVICE_TYPE_ALL:
-    str = "all";
-    break;
-  default:
-    // str already set to express unknown device type.
-    break;
+    return "all";
   }
 
-  return str;
+  return "unknown";
 }
 
 static bool queryOpenCL(cl_device_type deviceType, cl_uint &deviceCount,
@@ -74,13 +62,13 @@ static bool queryOpenCL(cl_device_type deviceType, cl_uint &deviceCount,
   iRet = clGetPlatformIDs(0, nullptr, &platformCount);
   if (iRet != CL_SUCCESS) {
     if (iRet == CL_PLATFORM_NOT_FOUND_KHR) {
-      msg = "ERROR: OpenCL error runtime not found";
-    } else {
-      std::stringstream stream;
-      stream << "ERROR: OpenCL error calling clGetPlatformIDs " << iRet
-             << std::endl;
-      msg = stream.str();
+      msg = "OpenCL error runtime not found";
+      return true;
     }
+    std::stringstream stream;
+    stream << "ERROR: OpenCL error calling clGetPlatformIDs " << iRet
+           << std::endl;
+    msg = stream.str();
     return false;
   }
 


### PR DESCRIPTION
get_device_count_by_type cpu opencl return error code if there is OpenCL
runtime on the system. This causes LIT config script for check-sycl test
suite to report an error w/o running the test suite on the host device.

This change makes get_device_cout_by_type return 0 on the system w/o
OpenCL runtime to let script handle this situation as normal case.

Some code is cleaned up.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>