### PR TITLE
[SYCL] Do not force LLVM_INCLUDE_TESTS variable

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -228,14 +228,9 @@ if (SYCL_ENABLE_XPTI_TRACING)
   endif()
 endif()
 
-if (NOT DEFINED LLVM_INCLUDE_TESTS)
-  set(LLVM_INCLUDE_TESTS ON)
-endif()
-
 option(SYCL_INCLUDE_TESTS
   "Generate build targets for the SYCL unit tests."
   ${LLVM_INCLUDE_TESTS})
-
 
 # Plugin Library
 add_subdirectory( plugins )
@@ -274,7 +269,6 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      libsycldevice
 )
 
-
 if(SYCL_BUILD_PI_CUDA)
   # Ensure that libclc is enabled.
   list(FIND LLVM_ENABLE_PROJECTS libclc LIBCLC_FOUND)
@@ -286,7 +280,6 @@ if(SYCL_BUILD_PI_CUDA)
   add_dependencies(sycl-toolchain libspirv-builtins pi_cuda)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins pi_cuda)
 endif()
-
 
 # Use it as fake dependency in order to force another command(s) to execute.
 add_custom_command(OUTPUT __force_it


### PR DESCRIPTION
This variable must be set by the developers only.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>