### PR TITLE
[SYCL][NFC] Remove a dropped environment variable from a test

### DIFF
--- a/sycl/test/program_manager/env_vars.cpp
+++ b/sycl/test/program_manager/env_vars.cpp
@@ -3,10 +3,6 @@
 //
 // RUN: %clangxx -O0 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -lsycl
 //
-// Deprecated SYCL_PROGRAM_BUILD_OPTIONS should work as an alias to
-// SYCL_PROGRAM_COMPILE_OPTIONS:
-// RUN: %CPU_RUN_PLACEHOLDER SYCL_PROGRAM_BUILD_OPTIONS="-g" %t.out
-// RUN: %GPU_RUN_PLACEHOLDER SYCL_PROGRAM_BUILD_OPTIONS="-g" %t.out
 // RUN: %CPU_RUN_PLACEHOLDER SYCL_PROGRAM_COMPILE_OPTIONS="-g" %t.out
 // RUN: %GPU_RUN_PLACEHOLDER SYCL_PROGRAM_COMPILE_OPTIONS="-g" %t.out
 // RUN: %CPU_RUN_PLACEHOLDER SYCL_PROGRAM_LINK_OPTIONS="-enable-link-options -cl-denorms-are-zero" %t.out


### PR DESCRIPTION
Remove SYCL_PROGRAM_BUILD_OPTIONS from the env_vars LIT test.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>