### PR TITLE
Uplift intel/llvm deps version to align with current SYCLOS

### DIFF
--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -1,0 +1,20 @@
+[VERSIONS]
+ocl_cpu_rt_ver=2020.10.3.0.04
+ocl_cpu_rt_ver_win=2020.10.3.0.04
+ocl_gpu_rt_ver=20.12.16259
+ocl_gpu_rt_ver_win=l0-ci-neo-015900
+intel_sycl_ver=build
+tbb_ver=20200121_111047
+tbb_ver_win=20200124_000000
+fpga_ver=20200216_000000
+fpga_ver_win=20200216_000000
+mkl_ver=2019u4
+mkldnn_ver=2021.1.2.022
+
+[DRIVER VERSIONS]
+cpu_driver_lin=2020.10.3.0.04
+cpu_driver_win=2020.10.3.0.04
+gpu_driver_lin=20.12.16259
+gpu_driver_win=l0-ci-neo-015900
+fpga_driver_lin=2020.9.2.0
+fpga_driver_win=2020.9.2.0


### PR DESCRIPTION
Uplift intel/llvm deps:
ocl_cpu_rt_ver=2020.10.3.0.04
ocl_cpu_rt_ver_win=2020.10.3.0.04
ocl_gpu_rt_ver=20.12.16259
ocl_gpu_rt_ver_win=l0-ci-neo-015900
tbb_ver=20200121_111047
tbb_ver_win=20200124_000000
fpga_ver=20200216_000000
fpga_ver_win=20200216_000000