### PR TITLE
[SYCL] no more ast visitor usage for variable type checks.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -236,6 +236,10 @@ static void checkSYCLVarType(Sema &S, QualType Ty, SourceRange Loc,
     emitDeferredDiagnosticAndNote(S, Loc, diag::err_typecheck_zero_array_size,
                                   UsedAtLoc);
 
+  // variable length arrays
+  if (Ty->isVariableArrayType())
+      emitDeferredDiagnosticAndNote(S, Loc, diag::err_vla_unsupported, UsedAtLoc);
+
   // Sub-reference array or pointer, then proceed with that type.
   while (Ty->isAnyPointerType() || Ty->isArrayType())
     Ty = QualType{Ty->getPointeeOrArrayElementType(), 0};
@@ -508,11 +512,16 @@ public:
 private:
   bool CheckSYCLType(QualType Ty, SourceRange Loc) {
     llvm::DenseSet<QualType> visited;
-    return CheckSYCLType(Ty, Loc, visited);
+    return true;
+    //return CheckSYCLType(Ty, Loc, visited);
   }
 
   bool CheckSYCLType(QualType Ty, SourceRange Loc,
                      llvm::DenseSet<QualType> &Visited) {
+
+    return true;
+
+    
     if (Ty->isVariableArrayType()) {
       SemaRef.Diag(Loc.getBegin(), diag::err_vla_unsupported);
       return false;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -238,7 +238,7 @@ static void checkSYCLVarType(Sema &S, QualType Ty, SourceRange Loc,
 
   // variable length arrays
   if (Ty->isVariableArrayType())
-      emitDeferredDiagnosticAndNote(S, Loc, diag::err_vla_unsupported, UsedAtLoc);
+    emitDeferredDiagnosticAndNote(S, Loc, diag::err_vla_unsupported, UsedAtLoc);
 
   // Sub-reference array or pointer, then proceed with that type.
   while (Ty->isAnyPointerType() || Ty->isArrayType())

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -38,7 +38,7 @@ void no_restriction(int p) {
 void restriction(int p) {
   // This particular violation is nested under two kernels with intermediate function calls.
   // e.g. main -> 1stkernel -> usage -> 2ndkernel -> isa_B -> restriction -> !!
-  // Because the error is in two different kernels, we are given helpful notes for the origination of the error, twice. 
+  // Because the error is in two different kernels, we are given helpful notes for the origination of the error, twice.
   // expected-note@#call_usage {{called by 'operator()'}}
   // expected-note@#call_kernelFunc {{called by 'kernel_single_task<fake_kernel, (lambda at}}
   // expected-note@#call_isa_B 2{{called by 'operator()'}}
@@ -77,7 +77,7 @@ bool isa_B(A *a) {
     return false;
 
   Check_VLA_Restriction::restriction(7); //#call_vla
-  int *ip = new int; // expected-error 2{{SYCL kernel cannot allocate storage}}
+  int *ip = new int;                     // expected-error 2{{SYCL kernel cannot allocate storage}}
   int i;
   int *p3 = new (&i) int;                                    // no error on placement new
   OverloadedNewDelete *x = new (struct OverloadedNewDelete); // expected-note 2{{called by 'isa_B'}}

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -36,7 +36,7 @@ void no_restriction(int p) {
   int index[p + 2];
 }
 void restriction(int p) {
-  int index[p + 2]; // expected-error {{variable length arrays are not supported for the current target}}
+  int index[p + 2]; // expected-error 2{{variable length arrays are not supported for the current target}}
 }
 } // namespace Check_VLA_Restriction
 
@@ -67,7 +67,7 @@ bool isa_B(A *a) {
   if (f1 == f2) // expected-note 2{{called by 'isa_B'}}
     return false;
 
-  Check_VLA_Restriction::restriction(7);
+  Check_VLA_Restriction::restriction(7); // expected-note 2{{called by 'isa_B'}}
   int *ip = new int; // expected-error 2{{SYCL kernel cannot allocate storage}}
   int i;
   int *p3 = new (&i) int;                                    // no error on placement new
@@ -79,7 +79,7 @@ bool isa_B(A *a) {
 
 template <typename N, typename L>
 __attribute__((sycl_kernel)) void kernel1(L l) {
-  l(); // expected-note 6{{called by 'kernel1<kernel_name, (lambda at }}
+  l(); // expected-note 8{{called by 'kernel1<kernel_name, (lambda at }}
 }
 } // namespace Check_RTTI_Restriction
 
@@ -189,9 +189,9 @@ void usage(myFuncDef functionPtr) {
     // expected-error@+1 {{SYCL kernel cannot use a non-const global variable}}
     b.f(); // expected-error {{SYCL kernel cannot call a virtual function}}
 
-  Check_RTTI_Restriction::kernel1<class kernel_name>([]() { // expected-note 3{{called by 'usage'}}
+  Check_RTTI_Restriction::kernel1<class kernel_name>([]() { // expected-note 4{{called by 'usage'}}
     Check_RTTI_Restriction::A *a;
-    Check_RTTI_Restriction::isa_B(a); // expected-note 6{{called by 'operator()'}}
+    Check_RTTI_Restriction::isa_B(a); // expected-note 8{{called by 'operator()'}}
   });
 
   // ======= Float128 Not Allowed in Kernel ==========
@@ -323,7 +323,7 @@ int use2(a_type ab, a_type *abp) {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
-  kernelFunc(); // expected-note 7{{called by 'kernel_single_task<fake_kernel, (lambda at}}
+  kernelFunc(); // expected-note 8{{called by 'kernel_single_task<fake_kernel, (lambda at}}
 }
 
 int main() {
@@ -340,7 +340,7 @@ int main() {
   auto notACrime = &commitInfraction;
 
   kernel_single_task<class fake_kernel>([=]() {
-    usage(&addInt); // expected-note 5{{called by 'operator()'}}
+    usage(&addInt); // expected-note 6{{called by 'operator()'}}
     a_type *p;
     use2(ab, p); // expected-note 2{{called by 'operator()'}}
   });


### PR DESCRIPTION
The various type checks have been steadily moving out of `CheckSYCLType` which is called by most of the AST Visitor methods.  Here we finally move the last lingering type check (for VLAs) into the `CheckSYCLVarType` function and delete `CheckSYCLType` and most of its AST Visitor method callers. 

Some few of the AST Visitor methods are still used for other checks. 