### PR TITLE
[SYCL][NFC] Align nd_item members with constructor initialization list

### DIFF
--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -161,8 +161,8 @@ protected:
       : globalItem(GL), localItem(L), Group(GR) {}
 
 private:
-  item<dimensions, false> localItem;
   item<dimensions, true> globalItem;
+  item<dimensions, false> localItem;
   group<dimensions> Group;
 };
 } // namespace sycl


### PR DESCRIPTION
Signed-off-by: Alexey Bader <alexey.bader@intel.com>