### PR TITLE
[SYCL] Fix sycl-post-link to work when a spec const is referenced twice.

### DIFF
--- a/llvm/test/tools/sycl-post-link/sc_sym_two_refs.ll
+++ b/llvm/test/tools/sycl-post-link/sc_sym_two_refs.ll
@@ -1,0 +1,27 @@
+; This test checks that the tool does not crash and removes the unused spec
+; constant global symbol when it is referenced more than once.
+
+; RUN: sycl-post-link -spec-const=rt --ir-output-only %s -S -o - \
+; RUN: | FileCheck %s 
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown-sycldevice"
+
+%"sycl::experimental::spec_constant" = type { i8 }
+
+@SCSymID = private unnamed_addr constant [10 x i8] c"SpecConst\00", align 1
+; CHECK-NOT: @SCSymID
+
+declare dso_local spir_func float @_Z27__sycl_getSpecConstantValueIfET_PKc(i8 addrspace(4)*)
+
+; Function Attrs: norecurse
+define weak_odr dso_local spir_kernel void @Kernel() {
+  %1 = call spir_func float @_Z27__sycl_getSpecConstantValueIfET_PKc(i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([10 x i8], [10 x i8]* @SCSymID, i64 0, i64 0) to i8 addrspace(4)*))
+  ret void
+}
+
+; Function Attrs: norecurse
+define dso_local spir_func float @foo_float(%"sycl::experimental::spec_constant" addrspace(4)* nocapture readnone dereferenceable(1) %0) local_unnamed_addr #3 {
+  %2 = tail call spir_func float @_Z27__sycl_getSpecConstantValueIfET_PKc(i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([10 x i8], [10 x i8]* @SCSymID, i64 0, i64 0) to i8 addrspace(4)*))
+  ret float %2
+}

--- a/llvm/test/tools/sycl-post-link/spec_const_O0.ll
+++ b/llvm/test/tools/sycl-post-link/spec_const_O0.ll
@@ -26,7 +26,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
 
 ; Function Attrs: norecurse
-define linkonce_odr dso_local spir_func zeroext i1 @FOO(%"UserSpecConstIDType" addrspace(4)* %0) comdat align 2 {
+define spir_func zeroext i1 @FOO(%"UserSpecConstIDType" addrspace(4)* %0) comdat align 2 {
   %2 = alloca %"UserSpecConstIDType" addrspace(4)*, align 8
   %3 = alloca i8 addrspace(4)*, align 8
   store %"UserSpecConstIDType" addrspace(4)* %0, %"UserSpecConstIDType" addrspace(4)** %2, align 8, !tbaa !8

--- a/llvm/test/tools/sycl-post-link/spec_const_and_split.ll
+++ b/llvm/test/tools/sycl-post-link/spec_const_and_split.ll
@@ -1,0 +1,26 @@
+; This test checks that the post-link tool works correctly when both
+; device code splitting and specialization constant processing are
+; requested.
+;
+; RUN: sycl-post-link -split=kernel -spec-const=rt -S %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefixes CHECK0,CHECK
+; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefixes CHECK1,CHECK
+
+@SCSymID = private unnamed_addr constant [10 x i8] c"SpecConst\00", align 1
+; CHECK-NOT: @SCSymID
+
+declare dso_local spir_func zeroext i1 @_Z27__sycl_getSpecConstantValueIbET_PKc(i8 addrspace(4)*)
+
+define dso_local spir_kernel void @KERNEL_AAA() {
+  %1 = call spir_func zeroext i1 @_Z27__sycl_getSpecConstantValueIbET_PKc(i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([10 x i8], [10 x i8]* @SCSymID, i64 0, i64 0) to i8 addrspace(4)*))
+; CHECK0: %{{[0-9]+}} = call i1 @_Z20__spirv_SpecConstantib(i32 0, i1 false), !SYCL_SPEC_CONST_SYM_ID ![[MD_ID:[0-9]+]]
+  ret void
+}
+
+define dso_local spir_kernel void @KERNEL_BBB() {
+  %1 = call spir_func zeroext i1 @_Z27__sycl_getSpecConstantValueIbET_PKc(i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([10 x i8], [10 x i8]* @SCSymID, i64 0, i64 0) to i8 addrspace(4)*))
+; CHECK1: %{{[0-9]+}} = call i1 @_Z20__spirv_SpecConstantib(i32 0, i1 false), !SYCL_SPEC_CONST_SYM_ID ![[MD_ID:[0-9]+]]
+  ret void
+}
+
+; CHECK: ![[MD_ID]] = !{!"SpecConst", i32 0}

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -31,6 +31,7 @@
 #include "llvm/Support/SystemUtils.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Transforms/IPO.h"
+#include "llvm/Transforms/IPO/GlobalDCE.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include <memory>
 
@@ -427,6 +428,9 @@ int main(int argc, char **argv) {
     // Register required analysis
     MAM.registerPass([&] { return PassInstrumentationAnalysis(); });
     RunSpecConst.addPass(SCP);
+    if (!DoSplit)
+      // This pass deletes unreachable globals. Code splitter runs it later.
+      RunSpecConst.addPass(GlobalDCEPass());
     PreservedAnalyses Res = RunSpecConst.run(*MPtr, MAM);
     SpecConstsMet = !Res.areAllPreserved();
   }


### PR DESCRIPTION
Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>