### PR TITLE
[SYCL][NFC] Temporarily disable sporadically failing test

### DIFF
--- a/sycl/test/basic_tests/buffer/buffer_dev_to_dev.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_dev_to_dev.cpp
@@ -1,3 +1,7 @@
+// The test fails sporadically on cuda.
+// See https://github.com/intel/llvm/issues/1508 for more details.
+// UNSUPPORTED: cuda
+
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
The issue is tracked here: https://github.com/intel/llvm/issues/1508

Signed-off-by: Alexey Bader <alexey.bader@intel.com>