### PR TITLE
[SYCL] Use correct macro name in export.hpp

### DIFF
--- a/sycl/include/CL/sycl/detail/export.hpp
+++ b/sycl/include/CL/sycl/detail/export.hpp
@@ -38,5 +38,6 @@
 #else
 #ifndef __SYCL_EXPORT
 #define __SYCL_EXPORT
+#define __SYCL_EXPORT_DEPRECATED(x)
 #endif
 #endif // __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/detail/export.hpp
+++ b/sycl/include/CL/sycl/detail/export.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#ifndef SYCL_DEVICE_ONLY
+#ifndef __SYCL_DEVICE_ONLY__
 #ifndef __SYCL_EXPORT
 #ifdef _WIN32
 

--- a/sycl/include/CL/sycl/detail/export.hpp
+++ b/sycl/include/CL/sycl/detail/export.hpp
@@ -25,14 +25,18 @@
 #else
 #define __SYCL_EXPORT __declspec(dllimport)
 #define __SYCL_EXPORT_DEPRECATED(x) __declspec(dllimport, deprecated(x))
-#endif
-#else
+#endif //__SYCL_BUILD_SYCL_DLL
+#else // _WIN32
 
 #define DLL_LOCAL __attribute__((visibility("hidden")))
 
 #define __SYCL_EXPORT __attribute__((visibility("default")))
 #define __SYCL_EXPORT_DEPRECATED(x)                                            \
   __attribute__((visibility("default"), deprecated(x)))
+#endif // _WIN32
+#endif // __SYCL_EXPORT
+#else
+#ifndef __SYCL_EXPORT
+#define __SYCL_EXPORT
 #endif
-#endif
-#endif
+#endif // __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/detail/export.hpp
+++ b/sycl/include/CL/sycl/detail/export.hpp
@@ -26,7 +26,7 @@
 #define __SYCL_EXPORT __declspec(dllimport)
 #define __SYCL_EXPORT_DEPRECATED(x) __declspec(dllimport, deprecated(x))
 #endif //__SYCL_BUILD_SYCL_DLL
-#else // _WIN32
+#else  // _WIN32
 
 #define DLL_LOCAL __attribute__((visibility("hidden")))
 

--- a/sycl/include/CL/sycl/detail/image_ocl_types.hpp
+++ b/sycl/include/CL/sycl/detail/image_ocl_types.hpp
@@ -185,7 +185,7 @@ struct opencl_image_type;
 
 // Creation of dummy ocl types for host_image targets.
 // These dummy ocl types are needed by the compiler parser for the compilation
-// of host application code with SYCL_DEVICE_ONLY macro set.
+// of host application code with __SYCL_DEVICE_ONLY__ macro set.
 template <int Dimensions, access::mode AccessMode>
 struct opencl_image_type<Dimensions, AccessMode, access::target::host_image> {
   using type =


### PR DESCRIPTION
Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>