### PR TITLE
[SYCL] Adjust codeowners for sycl directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,7 +75,6 @@ sycl/source/half_type.cpp @AlexeySachkov
 sycl/include/CL/sycl/swizzles.def @turinevgeny
 sycl/include/CL/sycl/types.hpp @turinevgeny
 
-sycl/ReleaseNotes.md @pvchupin
 
 sycl/doc/ @pvchupin @kbobrovs
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,72 @@ opencl-aot/ @dm-vodopyanov @AlexeySachkov @romanovvlad
 
 libdevice/ @asavonic @vzakhari
 
-sycl/ @romanovvlad @bader
+sycl/ @intel/llvm-reviewers-runtime
+
+sycl/ReleaseNotes.md @pvchupin
+
+# USM
+sycl/include/CL/sycl/detail/clusm.hpp @jbrodman
+sycl/include/CL/sycl/detail/usm_impl.hpp @jbrodman
+sycl/include/CL/sycl/usm/ @jbrodman
+sycl/include/CL/sycl/ordered_queue.hpp @jbrodman
+sycl/include/CL/sycl/usm.hpp @jbrodman
+sycl/include/CL/cl_usm_ext.h @jbrodman
+sycl/source/detail/usm/ @jbrodman
+sycl/source/ordered_queue.cpp @jbrodman
+
+# Sub-groups
+sycl/include/CL/sycl/detail/spirv.hpp @Pennycook @AlexeySachkov
+sycl/include/CL/sycl/intel/group_algorithm.hpp @Pennycook @AlexeySachkov
+sycl/include/CL/sycl/intel/sub_group.hpp @Pennycook @AlexeySachkov
+sycl/include/CL/sycl/intel/sub_group_host.hpp @Pennycook @AlexeySachkov
+
+# PI API
+sycl/include/CL/sycl/detail/pi.def @smaslov-intel
+sycl/include/CL/sycl/detail/pi.h   @smaslov-intel
+sycl/include/CL/sycl/detail/pi.hpp @smaslov-intel
+sycl/include/CL/sycl/detail/pi* @smaslov-intel
+sycl/plugins/ @smaslov-intel
+sycl/source/detail/pi.cpp @smaslov-intel
+sycl/source/detail/plugin.hpp @smaslov-intel
+sycl/source/detail/posix_pi.cpp @smaslov-intel
+sycl/source/detail/windows_pi.cpp @smaslov-intel
+
+# Stream
+sycl/include/CL/sycl/detail/stream_impl.hpp @againull
+sycl/include/CL/sycl/stream.hpp @againull
+sycl/source/detail/stream_impl.cpp @againull
+sycl/source/stream.cpp @againull
+
+# Specialization constant
+sycl/include/CL/sycl/detail/sycl_fe_intrins.hpp @kbobrovs
+sycl/include/CL/sycl/detail/spec_constant_impl.hpp @kbobrovs
+sycl/include/CL/sycl/experimental/spec_constant.hpp @kbobrovs
+
+# Program manager
+sycl/source/detail/program_manager @kbobrovs
+sycl/source/detail/spec_constant_impl.cpp @kbobrovs
+
+# FPGA extensions
+sycl/include/CL/sycl/intel/fpga_device_selector.hpp @MrSidims
+sycl/include/CL/sycl/intel/fpga_extensions.hpp @MrSidims
+sycl/include/CL/sycl/intel/fpga_reg.hpp @MrSidims
+sycl/include/CL/sycl/intel/pipes.hpp @MrSidims
+sycl/include/CL/sycl/pipes.hpp @MrSidims
+
+# Function pointers
+sycl/include/CL/sycl/intel/function_pointer.hpp @AlexeySachkov
+sycl/source/function_pointer.cpp @AlexeySachkov
+
+# Half Type
+sycl/include/CL/sycl/half_type.hpp @AlexeySachkov
+sycl/source/half_type.cpp @AlexeySachkov
+
+# vec and swizzles
+sycl/include/CL/sycl/swizzles.def @turinevgeny
+sycl/include/CL/sycl/types.hpp @turinevgeny
+
+sycl/ReleaseNotes.md @pvchupin
 
 sycl/doc/ @pvchupin @kbobrovs
 


### PR DESCRIPTION
Added llvm-reviewers-runtime as codeowner of the sycl directory.
Added more codeowners for specific files of the sycl directory.

Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>