### PR TITLE
Add __SYCL_EXPORT to declaration of contextSetExtendedDeleter

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -100,8 +100,8 @@ using PiMemImageChannelOrder = ::pi_image_channel_order;
 using PiMemImageChannelType = ::pi_image_channel_type;
 
 __SYCL_EXPORT void contextSetExtendedDeleter(const cl::sycl::context &constext,
-                               pi_context_extended_deleter func,
-                               void *user_data);
+                                             pi_context_extended_deleter func,
+                                             void *user_data);
 
 // Function to load the shared library
 // Implementation is OS dependent.

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -99,7 +99,7 @@ using PiMemObjectType = ::pi_mem_type;
 using PiMemImageChannelOrder = ::pi_image_channel_order;
 using PiMemImageChannelType = ::pi_image_channel_type;
 
-void contextSetExtendedDeleter(const cl::sycl::context &constext,
+__SYCL_EXPORT void contextSetExtendedDeleter(const cl::sycl::context &constext,
                                pi_context_extended_deleter func,
                                void *user_data);
 


### PR DESCRIPTION
Bug fix. __SYCL_EXPORT attribute missing from contextSetExtendedDeleter definition, meaning it was not publically visible.