### PR TITLE
[SYCL] [xmethods] Allow replacing xmethod script

### DIFF
--- a/sycl/xmethods/libsycl.so-gdb.py
+++ b/sycl/xmethods/libsycl.so-gdb.py
@@ -133,4 +133,4 @@ class AccessorOpIndexMatcher(gdb.xmethod.XMethodMatcher):
         return methods
 
 
-gdb.xmethod.register_xmethod_matcher(None, AccessorOpIndexMatcher())
+gdb.xmethod.register_xmethod_matcher(None, AccessorOpIndexMatcher(), replace=True)


### PR DESCRIPTION
Previous version didn't work when `run` command was issued multiple
times in GDB without terminating the session, as it reloads
libsycl-gdb.py each time shared library is loaded. Explicitly allowing
to replace previous version fixes the problem.

Signed-off-by: Mihails Strasuns <mihails.strasuns@intel.com>