### PR TITLE
[SYCL] Add a regression test for the crash during spec constants processing

### DIFF
--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -194,6 +194,12 @@ public:
   }
 };
 
+namespace experimental {
+
+template <typename T, typename ID = T>
+class spec_constant {};
+} // namespace experimental
+
 } // namespace sycl
 } // namespace cl
 

--- a/clang/test/SemaSYCL/spec_const_and_accesor_crash.cpp
+++ b/clang/test/SemaSYCL/spec_const_and_accesor_crash.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -I %S/Inputs -ast-dump %s | FileCheck %s
+// The test checks that Clang doesn't crash if a specialization constant gets
+// into the kernel capture list before an accessor
+
+#include <sycl.hpp>
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  cl::sycl::experimental::spec_constant<char, class MyInt32Const> spec_const;
+  cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write> accessor;
+  // CHECK: FieldDecl {{.*}} implicit referenced 'cl::sycl::experimental::spec_constant<char, class MyInt32Const>'
+  // CHECK: FieldDecl {{.*}} implicit referenced 'cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write>'
+  kernel<class MyKernel>([spec_const, accessor]() {});
+  return 0;
+}


### PR DESCRIPTION
In case a SYCL kernel captures specialization constants and more than
one accessor it crashes. I think the crash happens due to an extra
increment of KernelFuncParam, in CreateOpenCLKernelBody() method.

Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>