### PR TITLE
[Driver][SYCL][FPGA] Improve expected triple and link behaviors for A…

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7282,6 +7282,8 @@ void OffloadBundler::ConstructJobMultipleOutputs(
         TT.setVendorName("intel");
         TT.setOS(getToolChain().getTriple().getOS());
         TT.setEnvironment(llvm::Triple::SYCLDevice);
+        if (C.getDriver().IsCLMode())
+          TT.setObjectFormat(llvm::Triple::COFF);
         Triples += "sycl-";
         Triples += TT.normalize();
       } else if (getToolChain().getTriple().getSubArch() !=

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -126,9 +126,12 @@
 // RUN:  clang-offload-wrapper -o %t-aocx.bc -host=x86_64-unknown-linux-gnu -kind=sycl -target=fpga_aocx-intel-unknown-sycldevice %t.aocx
 // RUN:  llc -filetype=obj -o %t-aocx.o %t-aocx.bc
 // RUN:  llvm-ar crv %t_aocx.a %t.o %t-aocx.o
+// RUN:  clang-offload-wrapper -o %t-aocx_cl.bc -host=x86_64-unknown-linux-gnu -kind=sycl -target=fpga_aocx-intel-unknown-sycldevice-coff %t.aocx
+// RUN:  llc -filetype=obj -o %t-aocx_cl.o %t-aocx_cl.bc
+// RUN:  llvm-ar crv %t_aocx_cl.a %t.o %t-aocx_cl.o
 // RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t_aocx.a -ccc-print-phases 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-PHASES %s
-// RUN:  %clang_cl -fsycl -fintelfpga %t_aocx.a -ccc-print-phases 2>&1 \
+// RUN:  %clang_cl -fsycl -fintelfpga %t_aocx_cl.a -ccc-print-phases 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-PHASES %s
 // CHK-FPGA-AOCX-PHASES: 0: input, "{{.*}}", fpga_aocx, (host-sycl)
 // CHK-FPGA-AOCX-PHASES: 1: linker, {0}, image, (host-sycl)
@@ -138,9 +141,9 @@
 
 // RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t_aocx.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX,CHK-FPGA-AOCX-LIN %s
-// RUN:  %clang_cl -fsycl -fintelfpga %t_aocx.a -### 2>&1 \
+// RUN:  %clang_cl -fsycl -fintelfpga %t_aocx_cl.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX,CHK-FPGA-AOCX-WIN %s
-// CHK-FPGA-AOCX: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
+// CHK-FPGA-AOCX: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice{{(-coff)?}}" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
 // CHK-FPGA-AOCX: clang-offload-wrapper{{.*}} "-o=[[WRAPOUT:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "[[BUNDLEOUT]]"
 // CHK-FPGA-AOCX-LIN: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT:.+\.o]]" "[[WRAPOUT]]"
 // CHK-FPGA-AOCX-WIN: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT2:.+\.obj]]" "[[WRAPOUT]]"
@@ -150,9 +153,9 @@
 /// AOCX with source
 // RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %s %t_aocx.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-SRC,CHK-FPGA-AOCX-SRC-LIN %s
-// RUN:  %clang_cl -fsycl -fintelfpga %s %t_aocx.a -### 2>&1 \
+// RUN:  %clang_cl -fsycl -fintelfpga %s %t_aocx_cl.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-SRC,CHK-FPGA-AOCX-SRC-WIN %s
-// CHK-FPGA-AOCX-SRC: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
+// CHK-FPGA-AOCX-SRC: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice{{(-coff)?}}" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
 // CHK-FPGA-AOCX-SRC: clang-offload-wrapper{{.*}} "-o=[[WRAPOUT:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "[[BUNDLEOUT]]"
 // CHK-FPGA-AOCX-SRC: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT:.+\.(o|obj)]]" "[[WRAPOUT]]"
 // CHK-FPGA-AOCX-SRC: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-device" {{.*}} "-o" "[[DEVICEBC:.+\.bc]]"
@@ -168,9 +171,9 @@
 // RUN: touch %t.o
 // RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t.o %t_aocx.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-OBJ,CHK-FPGA-AOCX-OBJ-LIN %s
-// RUN:  %clang_cl -fsycl -fintelfpga %t.o %t_aocx.a -### 2>&1 \
+// RUN:  %clang_cl -fsycl -fintelfpga %t.o %t_aocx_cl.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-OBJ,CHK-FPGA-AOCX-OBJ-WIN %s
-// CHK-FPGA-AOCX-OBJ: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
+// CHK-FPGA-AOCX-OBJ: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice{{(-coff)?}}" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
 // CHK-FPGA-AOCX-OBJ: clang-offload-wrapper{{.*}} "-o=[[WRAPOUT:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "[[BUNDLEOUT]]"
 // CHK-FPGA-AOCX-OBJ: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT:.+\.(o|obj)]]" "[[WRAPOUT]]"
 // CHK-FPGA-AOCX-OBJ: clang-offload-bundler{{.*}} "-type=o" {{.*}} "-outputs=[[HOSTOBJ:.+\.(o|obj)]],[[DEVICEOBJ:.+\.(o|obj)]]" "-unbundle"
@@ -332,8 +335,10 @@
 // RUN:  %clang_cl -fsycl -c -o %t2_cl.o %t2.c
 // RUN:  clang-offload-wrapper -o %t-aoco.bc -host=x86_64-unknown-linux-gnu -kind=sycl -target=fpga_aoco-intel-unknown-sycldevice %t.aoco
 // RUN:  llc -filetype=obj -o %t-aoco.o %t-aoco.bc
+// RUN:  clang-offload-wrapper -o %t-aoco_cl.bc -host=x86_64-unknown-linux-gnu -kind=sycl -target=fpga_aoco-intel-unknown-sycldevice-coff %t.aoco
+// RUN:  llc -filetype=obj -o %t-aoco_cl.o %t-aoco_cl.bc
 // RUN:  llvm-ar crv %t_aoco.a %t.o %t2.o %t-aoco.o
-// RUN:  llvm-ar crv %t_aoco_cl.a %t.o %t2_cl.o %t-aoco.o
+// RUN:  llvm-ar crv %t_aoco_cl.a %t.o %t2_cl.o %t-aoco_cl.o
 // RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga -foffload-static-lib=%t_aoco.a %s -### -ccc-print-phases 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK-FPGA-AOCO-PHASES %s
 // CHK-FPGA-AOCO-PHASES: 0: input, "[[INPUTA:.+\.a]]", object, (host-sycl)

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -148,6 +148,7 @@
 // CHK-FPGA-AOCX: clang-offload-wrapper{{.*}} "-o=[[WRAPOUT:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "[[BUNDLEOUT]]"
 // CHK-FPGA-AOCX-LIN: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT:.+\.o]]" "[[WRAPOUT]]"
 // CHK-FPGA-AOCX-WIN: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT2:.+\.obj]]" "[[WRAPOUT]]"
+// CHK-FPGA-AOCX-NOT: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice{{(-coff)?}}"
 // CHK-FPGA-AOCX-LIN: ld{{.*}} "[[LIBINPUT]]" "[[LLCOUT]]"
 // CHK-FPGA-AOCX-WIN: link{{.*}} "[[LIBINPUT]]" "[[LLCOUT2]]"
 

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -156,7 +156,8 @@
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-SRC,CHK-FPGA-AOCX-SRC-LIN %s
 // RUN:  %clang_cl -fsycl -fintelfpga %s %t_aocx_cl.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-SRC,CHK-FPGA-AOCX-SRC-WIN %s
-// CHK-FPGA-AOCX-SRC: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice{{(-coff)?}}" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
+// CHK-FPGA-AOCX-SRC-LIN: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
+// CHK-FPGA-AOCX-SRC-WIN: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice-coff" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
 // CHK-FPGA-AOCX-SRC: clang-offload-wrapper{{.*}} "-o=[[WRAPOUT:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "[[BUNDLEOUT]]"
 // CHK-FPGA-AOCX-SRC: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT:.+\.(o|obj)]]" "[[WRAPOUT]]"
 // CHK-FPGA-AOCX-SRC: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-device" {{.*}} "-o" "[[DEVICEBC:.+\.bc]]"
@@ -174,7 +175,8 @@
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-OBJ,CHK-FPGA-AOCX-OBJ-LIN %s
 // RUN:  %clang_cl -fsycl -fintelfpga %t.o %t_aocx_cl.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX-OBJ,CHK-FPGA-AOCX-OBJ-WIN %s
-// CHK-FPGA-AOCX-OBJ: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice{{(-coff)?}}" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
+// CHK-FPGA-AOCX-OBJ-LIN: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
+// CHK-FPGA-AOCX-OBJ-WIN: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice-coff" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
 // CHK-FPGA-AOCX-OBJ: clang-offload-wrapper{{.*}} "-o=[[WRAPOUT:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "[[BUNDLEOUT]]"
 // CHK-FPGA-AOCX-OBJ: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT:.+\.(o|obj)]]" "[[WRAPOUT]]"
 // CHK-FPGA-AOCX-OBJ: clang-offload-bundler{{.*}} "-type=o" {{.*}} "-outputs=[[HOSTOBJ:.+\.(o|obj)]],[[DEVICEOBJ:.+\.(o|obj)]]" "-unbundle"

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -143,7 +143,8 @@
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX,CHK-FPGA-AOCX-LIN %s
 // RUN:  %clang_cl -fsycl -fintelfpga %t_aocx_cl.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCX,CHK-FPGA-AOCX-WIN %s
-// CHK-FPGA-AOCX: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice{{(-coff)?}}" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
+// CHK-FPGA-AOCX-LIN: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
+// CHK-FPGA-AOCX-WIN: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aocx-intel-unknown-sycldevice-coff" "-inputs=[[LIBINPUT:.+\.a]]" "-outputs=[[BUNDLEOUT:.+\.aocx]]" "-unbundle"
 // CHK-FPGA-AOCX: clang-offload-wrapper{{.*}} "-o=[[WRAPOUT:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "[[BUNDLEOUT]]"
 // CHK-FPGA-AOCX-LIN: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT:.+\.o]]" "[[WRAPOUT]]"
 // CHK-FPGA-AOCX-WIN: llc{{.*}} "-filetype=obj" "-o" "[[LLCOUT2:.+\.obj]]" "[[WRAPOUT]]"
@@ -408,7 +409,8 @@
 // CHK-FPGA-AOCO: llvm-link{{.*}} "@{{.*}}" "-o" "[[LINKEDBC:.+\.bc]]"
 // CHK-FPGA-AOCO: sycl-post-link{{.*}} "-ir-output-only" "-spec-const=default" "-o" "[[PLINKEDBC:.+\.bc]]" "[[LINKEDBC]]"
 // CHK-FPGA-AOCO: llvm-spirv{{.*}} "-o" "[[TARGSPV:.+\.spv]]" {{.*}} "[[PLINKEDBC]]"
-// CHK-FPGA-AOCO: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-fpga_aoco-intel-unknown-sycldevice" "-inputs=[[INPUTLIB]]" "-outputs=[[AOCOLIST:.+\.txt]]" "-unbundle"
+// CHK-FPGA-AOCO-LIN: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-fpga_aoco-intel-unknown-sycldevice" "-inputs=[[INPUTLIB]]" "-outputs=[[AOCOLIST:.+\.txt]]" "-unbundle"
+// CHK-FPGA-AOCO-WIN: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-fpga_aoco-intel-unknown-sycldevice-coff" "-inputs=[[INPUTLIB]]" "-outputs=[[AOCOLIST:.+\.txt]]" "-unbundle"
 // CHK-FPGA-AOCO: aoc{{.*}} "-o" "[[AOCXOUT:.+\.aocx]]" "[[TARGSPV]]" "-library-list=[[AOCOLIST]]" "-sycl"
 // CHK-FPGA-AOCO: clang-offload-wrapper{{.*}} "-o=[[FINALBC:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "[[AOCXOUT]]"
 // CHK-FPGA-AOCO-LIN: llc{{.*}} "-filetype=obj" "-o" "[[FINALOBJL:.+\.o]]" "[[FINALBC]]"

--- a/sycl/test/fpga_tests/Inputs/fpga_device.cpp
+++ b/sycl/test/fpga_tests/Inputs/fpga_device.cpp
@@ -1,0 +1,25 @@
+//==--------------- fpga_device.cpp - AOT compilation for fpga -------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CL/sycl.hpp"
+#include <iostream>
+
+using namespace cl::sycl;
+
+const double big[] = {3, 2, 1, 5, 6, 7};
+void foo(double &result, queue q, int x) {
+  buffer<double> buf(&result, 1);
+  buffer<double, 1> big_buf(big, sizeof(big) / sizeof(double));
+  q.submit([&](handler &cgh) {
+    auto acc = buf.get_access<access::mode::discard_write>(cgh);
+    auto big_acc = big_buf.get_access<access::mode::read>(cgh);
+    cgh.single_task<class test>([=]() {
+      acc[0] = big_acc[x];
+    });
+  });
+}

--- a/sycl/test/fpga_tests/Inputs/fpga_device.cpp
+++ b/sycl/test/fpga_tests/Inputs/fpga_device.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "CL/sycl.hpp"
-#include <iostream>
 
 using namespace cl::sycl;
 

--- a/sycl/test/fpga_tests/Inputs/fpga_host.cpp
+++ b/sycl/test/fpga_tests/Inputs/fpga_host.cpp
@@ -1,0 +1,22 @@
+//==--------------- fpga_host.cpp - AOT compilation for fpga ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CL/sycl.hpp"
+#include <iostream>
+
+using namespace cl::sycl;
+
+void foo(double &, queue q, int x);
+
+int main(void) {
+  queue q(accelerator_selector{});
+
+  double result;
+  foo(result, q, 3);
+  std::cout << "Result: " << result << "\n";
+}

--- a/sycl/test/fpga_tests/Inputs/fpga_host.cpp
+++ b/sycl/test/fpga_tests/Inputs/fpga_host.cpp
@@ -18,5 +18,6 @@ int main(void) {
 
   double result;
   foo(result, q, 3);
-  std::cout << "Result: " << result << "\n";
+  assert(result == 5);
+  return 0;
 }

--- a/sycl/test/fpga_tests/Inputs/fpga_host.cpp
+++ b/sycl/test/fpga_tests/Inputs/fpga_host.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CL/sycl.hpp"
-#include <iostream>
+#include <cassert>
 
 using namespace cl::sycl;
 

--- a/sycl/test/fpga_tests/fpga_aocx.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx.cpp
@@ -10,50 +10,14 @@
 
 /// E2E test for AOCX creation/use/run for FPGA
 // Produce an archive with device (AOCX) image
-// RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image -DDEVICE_PART %s -o %t_image.a
+// RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
 // Produce a host object
-// RUN: %clangxx -fsycl -fintelfpga -DHOST_PART %s -c -o %t.o
+// RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp -c -o %t.o
 
 // AOCX with source
-// RUN: %clangxx -fsycl -fintelfpga -DHOST_PART %s %t_image.a -o %t_aocx_src.out
+// RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp %t_image.a -o %t_aocx_src.out
 // AOCX with object
 // RUN: %clangxx -fsycl -fintelfpga %t.o %t_image.a -o %t_aocx_obj.out
 //
 // RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_src.out
 // RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_obj.out
-
-#include "CL/sycl.hpp"
-#include <iostream>
-
-using namespace cl::sycl;
-
-#ifdef DEVICE_PART
-
-const double big[] = {3, 2, 1, 5, 6, 7};
-void foo(double &result, queue q, int x) {
-  buffer<double> buf(&result, 1);
-  buffer<double, 1> big_buf(big, sizeof(big) / sizeof(double));
-  q.submit([&](handler &cgh) {
-    auto acc = buf.get_access<access::mode::discard_write>(cgh);
-    auto big_acc = big_buf.get_access<access::mode::read>(cgh);
-    cgh.single_task<class test>([=]() {
-      acc[0] = big_acc[x];
-    });
-  });
-}
-
-#endif // DEVICE_PART
-
-#ifdef HOST_PART
-
-void foo(double &, queue q, int x);
-
-int main(void) {
-  queue q(accelerator_selector{});
-
-  double result;
-  foo(result, q, 3);
-  std::cout << "Result: " << result << "\n";
-}
-
-#endif // HOST_PART

--- a/sycl/test/fpga_tests/fpga_aocx_win.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx_win.cpp
@@ -1,0 +1,60 @@
+//==--- fpga_aocx_win.cpp - AOT compilation for fpga using aoc with aocx ---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: aoc, accelerator
+// REQUIRES: system-windows
+
+/// E2E test for AOCX creation/use/run for FPGA
+// Produce an archive with device (AOCX) image
+// RUN: %clang_cl -fsycl -fintelfpga -fsycl-link=image -DDEVICE_PART %s -o %t_image_cl.a
+// Produce a host object
+// RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %s -c -o %t.o
+
+// AOCX with source
+// RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %s %t_image_cl.a -o %t_aocx_src.out
+// AOCX with object
+// RUN: %clang_cl -fsycl -fintelfpga %t.o %t_image_cl.a -o %t_aocx_obj.out
+//
+// RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_src.out
+// RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_obj.out
+
+#include "CL/sycl.hpp"
+#include <iostream>
+
+using namespace cl::sycl;
+
+#ifdef DEVICE_PART
+
+const double big[] = {3, 2, 1, 5, 6, 7};
+void foo(double &result, queue q, int x) {
+  buffer<double> buf(&result, 1);
+  buffer<double, 1> big_buf(big, sizeof(big) / sizeof(double));
+  q.submit([&](handler &cgh) {
+    auto acc = buf.get_access<access::mode::discard_write>(cgh);
+    auto big_acc = big_buf.get_access<access::mode::read>(cgh);
+    cgh.single_task<class test>([=]() {
+      acc[0] = big_acc[x];
+    });
+  });
+}
+
+#endif // DEVICE_PART
+
+#ifdef HOST_PART
+
+void foo(double &, queue q, int x);
+
+int main(void) {
+  queue q(accelerator_selector{});
+
+  double result;
+  foo(result, q, 3);
+  std::cout << "Result: " << result << "\n";
+}
+
+#endif // HOST_PART

--- a/sycl/test/fpga_tests/fpga_aocx_win.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx_win.cpp
@@ -11,50 +11,14 @@
 
 /// E2E test for AOCX creation/use/run for FPGA
 // Produce an archive with device (AOCX) image
-// RUN: %clang_cl -fsycl -fintelfpga -fsycl-link=image -DDEVICE_PART %s -o %t_image_cl.a
+// RUN: %clang_cl -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
 // Produce a host object
-// RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %s -c -o %t.o
+// RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj
 
 // AOCX with source
-// RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %s %t_image_cl.a -o %t_aocx_src.out
+// RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp %t_image.lib -o %t_aocx_src.out
 // AOCX with object
-// RUN: %clang_cl -fsycl -fintelfpga %t.o %t_image_cl.a -o %t_aocx_obj.out
+// RUN: %clang_cl -fsycl -fintelfpga %t.obj %t_image.lib -o %t_aocx_obj.out
 //
 // RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_src.out
 // RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_obj.out
-
-#include "CL/sycl.hpp"
-#include <iostream>
-
-using namespace cl::sycl;
-
-#ifdef DEVICE_PART
-
-const double big[] = {3, 2, 1, 5, 6, 7};
-void foo(double &result, queue q, int x) {
-  buffer<double> buf(&result, 1);
-  buffer<double, 1> big_buf(big, sizeof(big) / sizeof(double));
-  q.submit([&](handler &cgh) {
-    auto acc = buf.get_access<access::mode::discard_write>(cgh);
-    auto big_acc = big_buf.get_access<access::mode::read>(cgh);
-    cgh.single_task<class test>([=]() {
-      acc[0] = big_acc[x];
-    });
-  });
-}
-
-#endif // DEVICE_PART
-
-#ifdef HOST_PART
-
-void foo(double &, queue q, int x);
-
-int main(void) {
-  queue q(accelerator_selector{});
-
-  double result;
-  foo(result, q, 3);
-  std::cout << "Result: " << result << "\n";
-}
-
-#endif // HOST_PART


### PR DESCRIPTION
…OCX files

When performing -fsycl-link=image behaviors on Windows, there was a mismatch
of triples being used when checking for existence of the AOCX binary.  This
caused a problem when using clang-cl as the triples do not properly match.
We also do not want to do any additional unbundling of any AOCX archive, which
was causing a conflict of expected FPGA archives.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>