### PR TITLE
[SYCL][Experimental] Reduce the set of optimizations for SYCL device

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -136,7 +136,7 @@ public:
     SizeType = TargetInfo::UnsignedInt;
     PtrDiffType = IntPtrType = TargetInfo::SignedInt;
     resetDataLayout("e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-"
-                    "v96:128-v192:256-v256:256-v512:512-v1024:1024");
+                    "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64");
   }
 
   void getTargetDefines(const LangOptions &Opts,
@@ -152,7 +152,7 @@ public:
     PtrDiffType = IntPtrType = TargetInfo::SignedLong;
 
     resetDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-"
-                    "v96:128-v192:256-v256:256-v512:512-v1024:1024");
+                    "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64");
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -135,8 +135,9 @@ public:
     PointerWidth = PointerAlign = 32;
     SizeType = TargetInfo::UnsignedInt;
     PtrDiffType = IntPtrType = TargetInfo::SignedInt;
-    resetDataLayout("e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-"
-                    "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64");
+    resetDataLayout(
+        "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-"
+        "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64");
   }
 
   void getTargetDefines(const LangOptions &Opts,
@@ -151,8 +152,9 @@ public:
     SizeType = TargetInfo::UnsignedLong;
     PtrDiffType = IntPtrType = TargetInfo::SignedLong;
 
-    resetDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-"
-                    "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64");
+    resetDataLayout(
+        "e-i64:64-v16:16-v24:32-v32:32-v48:64-"
+        "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64");
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -898,9 +898,8 @@ void EmitAssemblyHelper::EmitAssembly(BackendAction Action,
   std::unique_ptr<llvm::ToolOutputFile> ThinLinkOS, DwoOS;
 
   // Clean-up SYCL device code if LLVM passes are disabled
-  if (LangOpts.SYCLIsDevice && CodeGenOpts.DisableLLVMPasses) {
+  if (LangOpts.SYCLIsDevice && CodeGenOpts.DisableLLVMPasses)
     PerModulePasses.add(createDeadCodeEliminationPass());
-  }
 
   switch (Action) {
   case Backend_EmitNothing:

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -612,7 +612,7 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
   // NOTE: We use "normal" inliner (i.e. from O2/O3), but limit the rest of
   // optimization pipeline. Inliner is a must for enabling size reduction
   // optimizations.
-  if (LangOpts.SYCLIsDevice) {
+  if (LangOpts.SYCLIsDevice && TargetTriple.isSPIR()) {
     PMBuilder.OptLevel = 1;
     PMBuilder.SizeLevel = 2;
     PMBuilder.SLPVectorize = false;

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -600,10 +600,10 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
   }
 
   // FIXME: This code is a workaround for a number of problems with optimized
-  // SYCL code for SPIR target. This change trying to balance between doing too
-  // little and too much optimizations. Current approach is to disable as much
-  // as possible just to keep the compiler functional. Eventually we can
-  // consider allowing -On option to configure optimization set for the FE
+  // SYCL code for the SPIR target. This change trying to balance between doing
+  // too few and too many optimizations. The current approach is to disable as
+  // much as possible just to keep the compiler functional. Eventually we can
+  // consider allowing -On option to configure the optimization set for the FE
   // device compiler as well, but before that we must fix all the functional and
   // performance issues caused by LLVM transformantions.
   // E.g. LLVM optimizations make use of llvm intrinsics, instructions, data

--- a/clang/test/CodeGen/target-data.c
+++ b/clang/test/CodeGen/target-data.c
@@ -237,11 +237,11 @@
 
 // RUN: %clang_cc1 -triple spir-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SPIR
-// SPIR: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+// SPIR: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 
 // RUN: %clang_cc1 -triple spir64-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SPIR64
-// SPIR64: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+// SPIR64: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 
 // RUN: %clang_cc1 -triple bpfel -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=BPFEL

--- a/clang/test/CodeGenOpenCL/convergent.cl
+++ b/clang/test/CodeGenOpenCL/convergent.cl
@@ -121,7 +121,7 @@ void test_unroll() {
 
 // The new PM produces a slightly different IR for the loop from the legacy PM,
 // but the test still checks that the loop is not unrolled.
-// CHECK-LEGACY:  br i1 %{{.+}}, label %[[for_body]], label %[[for_cond_cleanup]]
+// CHECK-LEGACY:  br i1 %{{.+}}, label %[[for_cond_cleanup]], label %[[for_body]]
 // CHECK-NEW:     br i1 %{{.+}}, label %[[for_body_crit_edge:.+]], label %[[for_cond_cleanup]]
 // CHECK-NEW:     [[for_body_crit_edge]]:
 

--- a/clang/test/CodeGenSYCL/address-space-swap.cpp
+++ b/clang/test/CodeGenSYCL/address-space-swap.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -fsycl-device-only -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang -fsycl-device-only -S -Xclang -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 #include <algorithm>
 
 void test() {

--- a/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -fsycl-device-only %s -S -I %S/Inputs -emit-llvm -g -o - | FileCheck %s
+// RUN: %clang -fsycl-device-only %s -S -emit-llvm -O0 -I %S/Inputs -g -o - | FileCheck %s
 //
 // Verify the SYCL kernel routine is marked artificial and has no source
 // correlation.

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -1310,6 +1310,10 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
   if (CallInst *CI = dyn_cast<CallInst>(V))
     return mapValue(V, transCallInst(CI, BB));
 
+  // FIXME: this is not valid translation of freeze instruction
+  if (FreezeInst *FI = dyn_cast<FreezeInst>(V))
+    return mapValue(V, transValue(FI->getOperand(0), BB));
+
   llvm_unreachable("Not implemented");
   return nullptr;
 }
@@ -1825,6 +1829,7 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
   case Intrinsic::invariant_start:
   case Intrinsic::invariant_end:
   case Intrinsic::dbg_label:
+  case Intrinsic::assume:
     return nullptr;
   default:
     if (SPIRVAllowUnknownIntrinsics)


### PR DESCRIPTION
This is patch limits the set of optimizations aiming to reduce the size of
generated device module.

Optimizations are currently disabled by default as they cause multiple
sorts of issues. Some of the issues are addressed within this patch, but
not all of them.

Optimizations can be enabled with `-fsycl-enable-optimizaions` front-end
option (or `-Xclang -fsycl-enable-optimizaions` driver option).

Signed-off-by: Alexey Bader <alexey.bader@intel.com>