### PR TITLE
[SYCL] Make queue's non-USM event ownership temporary

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -49,7 +49,7 @@ event queue_impl::memset(shared_ptr_class<detail::queue_impl> Impl, void *Ptr,
     return event();
 
   event ResEvent{pi::cast<cl_event>(Event), Context};
-  addEvent(ResEvent);
+  addUSMEvent(ResEvent);
   return ResEvent;
 }
 
@@ -63,7 +63,7 @@ event queue_impl::memcpy(shared_ptr_class<detail::queue_impl> Impl, void *Dest,
     return event();
 
   event ResEvent{pi::cast<cl_event>(Event), Context};
-  addEvent(ResEvent);
+  addUSMEvent(ResEvent);
   return ResEvent;
 }
 
@@ -81,13 +81,19 @@ event queue_impl::mem_advise(const void *Ptr, size_t Length,
                                                    Advice, &Event);
 
   event ResEvent{pi::cast<cl_event>(Event), Context};
-  addEvent(ResEvent);
+  addUSMEvent(ResEvent);
   return ResEvent;
 }
 
 void queue_impl::addEvent(event Event) {
+  std::weak_ptr<event_impl> EventWeakPtr{getSyclObjImpl(Event)};
   std::lock_guard<mutex_class> Guard(MMutex);
-  MEvents.push_back(std::move(Event));
+  MEvents.push_back(std::move(EventWeakPtr));
+}
+
+void queue_impl::addUSMEvent(event Event) {
+  std::lock_guard<mutex_class> Guard(MMutex);
+  MUSMEvents.push_back(std::move(Event));
 }
 
 void *queue_impl::instrumentationProlog(const detail::code_location &CodeLoc,
@@ -175,8 +181,13 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
 #endif
 
   std::lock_guard<mutex_class> Guard(MMutex);
-  for (auto &Event : MEvents)
+  for (std::weak_ptr<event_impl> &EventImplWeakPtr : MEvents) {
+    if (std::shared_ptr<event_impl> EventImplPtr = EventImplWeakPtr.lock())
+      EventImplPtr->wait(EventImplPtr);
+  }
+  for (event &Event : MUSMEvents) {
     Event.wait();
+  }
   MEvents.clear();
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -382,12 +382,20 @@ private:
   /// \param Event is the event to be stored
   void addEvent(event Event);
 
+  /// Stores a USM operation event that should be associated with the queue
+  ///
+  /// \param Event is the event to be stored
+  void addUSMEvent(event Event);
+
   /// Protects all the fields that can be changed by class' methods.
   mutex_class MMutex;
 
   DeviceImplPtr MDevice;
   const ContextImplPtr MContext;
-  vector_class<event> MEvents;
+  vector_class<std::weak_ptr<event_impl>> MEvents;
+  // USM operations are not added to the scheduler command graph,
+  // queue is the only owner on the runtime side.
+  vector_class<event> MUSMEvents;
   exception_list MExceptions;
   const async_handler MAsyncHandler;
   const property_list MPropList;

--- a/sycl/test/basic_tests/event_release.cpp
+++ b/sycl/test/basic_tests/event_release.cpp
@@ -1,0 +1,36 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_PI_TRACE=1 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
+#include <CL/sycl.hpp>
+#include <cassert>
+
+// The test checks that pi_events are released without queue destruction
+// or call to queue::wait, when the corresponding commands are cleaned up.
+
+using namespace cl::sycl;
+
+class Foo;
+
+int main() {
+  int Val = 0;
+  int Gold = 42;
+
+  // Check event releasing without queue destruction
+  queue *QPtr = new queue{};
+
+  {
+    buffer<int, 1> Buf{&Val, range<1>(1)};
+    QPtr->submit([&](handler &Cgh) {
+      auto Acc = Buf.get_access<access::mode::discard_write>(Cgh);
+      Cgh.single_task<Foo>([=]() {
+        Acc[0] = Gold;
+      });
+    });
+  }
+
+  // Buffer destruction triggers execution graph cleanup, check that both
+  // events (one for launching the kernel and one for memory transfer to host)
+  // are released.
+  // CHECK: piEventRelease
+  // CHECK: piEventRelease
+  assert(Val == Gold);
+}


### PR DESCRIPTION
Previously, queues shared ownership of non-USM events with the
command dependency graph, so such events were not released until:
1. The command associated with the event was cleaned up.
2. The associated queue was destroyed or its wait method was called.
3. All copies of the event on the application side were destroyed.

This patch changes queue's shared event pointers to weak ones in order
to drop the second requirement and allow releasing finished events earlier.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>