### PR TITLE
[SYCL][Doc] Add parallel_for simplification extension

### DIFF
--- a/sycl/doc/extensions/ParallelForSimpification/SYCL_INTEL_parallel_for_simplification.asciidoc
+++ b/sycl/doc/extensions/ParallelForSimpification/SYCL_INTEL_parallel_for_simplification.asciidoc
@@ -1,0 +1,471 @@
+= SYCL_INTEL_parallel_for_simplification
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+
+
+:blank: pass:[ +]
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+== Introduction
+IMPORTANT: This specification is a draft.
+
+NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by permission by Khronos.
+
+NOTE: This document is better viewed when rendered as html with asciidoctor.  GitHub does not render image icons.
+
+This document describes an extension that adds features for SYCL handler parallel_for API simplification.
+
+
+== Name Strings
+
++SYCL_INTEL_parallel_for_simplification+
+
+== Notice
+
+Copyright (c) 2020 Intel Corporation.  All rights reserved.
+
+== Status
+
+Working Draft
+
+This is a preview extension specification, intended to provide early access to a feature for review and community feedback. When the feature matures, this specification may be released as a formal extension.
+
+Because the interfaces defined by this specification are not final and are subject to change they are not intended to be used by shipping software products.
+
+== Version
+
+Built On: {docdate} +
+Revision: 1
+
+== Contact
+Ruslan Arutyunyan, Intel (ruslan 'dot' arutyunyan 'at' intel 'dot' com)
+
+== Dependencies
+
+This extension is written against the SYCL 1.2.1 specification, Revision 6.
+
+== Overview
+
+SYCL 1.2.1 is based on {cpp}11. This extension describes the following features necessary to allow `parallel_for` simplification:
+
+* Allow parallel_for call with number or *braced-init-list* as the first argument, i.e. +
+`parallel_for(5, _some_kernel_)` is equivalent to `parallel_for(range<1>{5}, _some_kernel_)` +
+`parallel_for({5}, _some_kernel_)` is equivalent to `parallel_for(range<1>{5}, _some_kernel_)` +
+`parallel_for({5, 5}, _some_kernel_)` is equivalent to `parallel_for(range<2>{5, 5}, _some_kernel_)` +
+`parallel_for({5, 5, 5}, _some_kernel_)` is equivalent to `parallel_for(range<3>{5, 5, 5}, _some_kernel_)`
+
+* Allow {cpp}14 *Generic lambda expression* as the kernel for `parallel_for`, i.e `[](auto){}`
+
+* Allow {cpp}14 *Generic lambda expression* as the kernel for `parallel_for_work_group`
+
+* Allow integral type as the kernel argument for `parallel_for` called with `range<1>`, e.g. `[](int i){}`
+
+* Allow `item<1>` to `size_t` implicit conversion
+
+* Resolve ambiguity for `accessor::operator[]` when the argument for it is an `item`
+
+* `parallel_for` kernel shall always take `item` as an argument (not `item` or `id`)
+
+SYCL 1.2.1 example:
+
+[source,c++,UsageFrom,linenums]
+----
+int main() {
+    constexpr int N = 32;
+    sycl::buffer<int> B(N);
+    sycl::queue{}.submit([&](auto &h) {
+        auto a = B.get_access<sycl::access::mode::write>(h);
+        h.parallel_for(sycl::range(N), [=](cl::sycl::id<1> i) {
+            a[i] = i[0];
+        });
+    });
+}
+----
+
+Same example, but with this extension applied:
+
+[source,c++,UsageTo,linenums]
+----
+int main() {
+    constexpr int N = 32;
+    sycl::buffer<int> B(N);
+    sycl::queue{}.submit([&](auto &h) {
+        auto a = B.get_access<sycl::access::mode::write>(h);
+        h.parallel_for(N, [=](auto i) {
+            a[i] = i;
+        });
+    });
+}
+----
+
+== Enabling the extension
+
+This extension is enabled for any {cpp}11 compliant compiler except *generic lambda expressions* simplification that requires {cpp}14. The {cpp}14 compilation mode flag is implementation defined (e.g. `-std=c{plus}{plus}14` or `/std:c{plus}{plus}14`).
+
+== Modifications of SYCL 1.2.1 specification
+
+=== Changes in 4.8.5 (SYCL functions for invoking kernels)
+
+==== Table 4.78
+
+===== From
+
+|===
+|Member function | Description
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename KernelType,
+          int dimensions>
+void parallel_for(range<dimensions> numWorkItems,
+                  KernelType kernelFunc)
+---- |
+Defines and invokes a SYCL kernel function as a lambda function or a named function object type, for the specified range and given an id or item for indexing in the indexing space defined by range. If it is a named function object and the function object type is globally visible there is no need for the developer to provide a kernel name (`typename KernelName`) for it, as described in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename KernelType,
+          int dimensions>
+void parallel_for(range<dimensions> numWorkItems,
+                  id<dimensions> workItemOffset,
+                  KernelType kernelFunc)
+---- |
+Defines and invokes a SYCL kernel function as a lambda function or a named function object type, for the specified range and offset and given an id or item for indexing in the indexing space defined by range. If it is a named function object and the function object type is globally visible there is no need for the developer to provide a kernel name (`typename KernelName`) for it, as described in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename KernelType,
+          int dimensions>
+void parallel_for(nd_range<dimensions> executionRange,
+                  KernelType kernelFunc)
+---- |
+Defines and invokes a SYCL kernel functionas a lambda function or a named function
+object type, for the specified `nd-range` and given an `nd-item` for indexing in the indexing space defined by the `nd-range`. If it is a named function object and the function object type is globally visible there is no need for the developer to provide a kernel name (`typename KernelName`) for it, as described in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename WorkgroupFunctionType,
+          int dimensions>
+void parallel_for_work_group(range<dimensions> numWorkGroups,
+                             WorkgroupFunctionType kernelFunc)
+---- |
+Hierarchical kernel invocation method of a kernel defined as a lambda encoding the body of each work-group to launch. May contain multiple calls to `parallel_for_work_item(..)` methods representing the execution on each workitem. Launches num_work_groups workgroups of runtime-defined size. Described in detail in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename WorkgroupFunctionType,
+          int dimensions>
+void parallel_for_work_group(range<dimensions> numWorkGroups,
+                             range<dimensions> workGroupSize,
+                             WorkgroupFunctionType kernelFunc)
+---- |
+Hierarchical kernel invocation method of a kernel defined as a lambda encoding the body of each work-group to launch. May contain multiple calls to `parallel_for_work_item` methods representing the execution on each work-item.
+Launches num_work_groups work-groups of `work_group_size` work-items each. Described in detail in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <int dimensions>
+void parallel_for(range<dimensions> numWorkItems,
+                  kernel syclKernel)
+---- |
+Kernel invocation method of a pre-compiled kernel defined by SYCL `sycl-kernel-function` instance, for the specified range and given an id or item for indexing in the indexing space defined by range, described in detail in 4.8.5
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <int dimensions>
+void parallel_for(range<dimensions> numWorkItems,
+                  id<dimensions> workItemOffset,
+                  kernel syclKernel)
+---- |
+Kernel invocation method of a pre-compiled kernel defined by SYCL `sycl-kernel-function` instance, for the specified range and offset and given an id or item for indexing in the indexing space defined by range, described in detail in 4.8.5
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <int dimensions>
+void parallel_for(nd_range<dimensions> ndRange,
+                  kernel syclKernel)
+---- |
+Kernel invocation method of a pre-compiled kernel defined by SYCL kernel instance,
+for the specified `nd-range` and given an `nd_item` for indexing in the indexing space
+defined by the `nd_range`, described in detail in 4.8.5
+|===
+
+
+===== To
+
+|===
+|Member function | Description
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename KernelType,
+          int dimensions>
+void parallel_for(range<dimensions> numWorkItems,
+                  KernelType kernelFunc)
+---- |
+Defines and invokes a SYCL kernel function as a lambda function or a named function object type, for the specified range and given an `item` or integral type (e.g `int`, `size_t`), if range is 1-dimensional, for indexing in the indexing space defined by range. Generic kernel functions are permitted, in that case the argument type is an `item`. If it is a named function object and the function object type is globally visible there is no need for the developer to provide a kernel name (`typename KernelName`) for it, as described in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename KernelType,
+          int dimensions>
+void parallel_for(range<dimensions> numWorkItems,
+                  id<dimensions> workItemOffset,
+                  KernelType kernelFunc)
+---- |
+Defines and invokes a SYCL kernel function as a lambda function or a named function object type, for the specified range and offset and given an `item` or integral type (e.g `int`, `size_t`), if range is 1-dimensional, for indexing in the indexing space defined by range. Generic kernel functions are permitted, in that case the argument type is an `item`. If it is a named function object and the function object type is globally visible there is no need for the developer to provide a kernel name (`typename KernelName`) for it, as described in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename KernelType,
+          int dimensions>
+void parallel_for(nd_range<dimensions> executionRange,
+                  KernelType kernelFunc)
+---- |
+Defines and invokes a SYCL kernel functionas a lambda function or a named function
+object type, for the specified `nd-range` and given an `nd-item` for indexing in the indexing space defined by the `nd-range` Generic kernel functions are permitted, in that case the argument type is an `nd_item`. If it is a named function object and the function object type is globally visible there is no need for the developer to provide a kernel name (`typename KernelName`) for it, as described in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename WorkgroupFunctionType,
+          int dimensions>
+void parallel_for_work_group(range<dimensions> numWorkGroups,
+                             WorkgroupFunctionType kernelFunc)
+---- |
+Hierarchical kernel invocation method of a kernel defined as a lambda encoding the body of each work-group to launch. Generic kernel functions are permitted, in that case the argument type is a `group`. May contain multiple calls to `parallel_for_work_item(..)` methods representing the execution on each workitem. Launches num_work_groups workgroups of runtime-defined size. Described in detail in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <typename KernelName,
+          typename WorkgroupFunctionType,
+          int dimensions>
+void parallel_for_work_group(range<dimensions> numWorkGroups,
+                             range<dimensions> workGroupSize,
+                             WorkgroupFunctionType kernelFunc)
+---- |
+Hierarchical kernel invocation method of a kernel defined as a lambda encoding the body of each work-group to launch. Generic kernel functions are permitted, in that case the argument type is a `group`. May contain multiple calls to `parallel_for_work_item` methods representing the execution on each work-item.
+Launches num_work_groups work-groups of `work_group_size` work-items each. Described in detail in 4.8.5.
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <int dimensions>
+void parallel_for(range<dimensions> numWorkItems,
+                  kernel syclKernel)
+---- |
+Kernel invocation method of a pre-compiled kernel defined by SYCL `sycl-kernel-function` instance for the specified range and given an `item` or integral type (e.g `int`, `size_t`), if range is 1-dimensional, for indexing in the indexing space defined by range. Generic kernel functions are permitted, in that case the argument type is an `item`. Described in detail in 4.8.5
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <int dimensions>
+void parallel_for(range<dimensions> numWorkItems,
+                  id<dimensions> workItemOffset,
+                  kernel syclKernel)
+---- |
+Kernel invocation method of a pre-compiled kernel defined by SYCL `sycl-kernel-function` instance for the specified range and offset and given an `item` or integral type (e.g `int`, `size_t`), if range is 1-dimensional, for indexing in the indexing space defined by range. Generic kernel functions are permitted, in that case the argument type is an `item`. Described in detail in 4.8.5
+
+a|
+[source,c++,multiptr,linenums]
+----
+template <int dimensions>
+void parallel_for(nd_range<dimensions> ndRange,
+                  kernel syclKernel)
+---- |
+Kernel invocation method of a pre-compiled kernel defined by SYCL kernel instance
+for the specified `nd-range` and given an `nd_item` for indexing in the indexing space
+defined by the `nd_range`. Generic kernel functions are permitted, in that case the argument type is an `nd_item`. Described in detail in 4.8.5
+|===
+
+=== Changes in 4.8.5.2 (parallel_for invoke)
+
+==== The following paragraph changes
+
+===== From
+
+For the simplest case, users need only provide the global range (the total number of work-items in the index space) via a SYCL `range` parameter, and the SYCL runtime will select a local range (the number of work-items in each work-group). The local range chosen by the SYCL runtime is entirely implementation defined. In this case the function object that represents the SYCL kernel function must take either a single SYCL `id` parameter, or a single SYCL `item` parameter, representing the currently executing work-item within the range specified by the range parameter.
+
+===== To
+
+For the simplest case, users need only provide the global range (the total number of work-items in the index space) via a SYCL `range` parameter, and the SYCL runtime will select a local range (the number of work-items in each work-group). The local range chosen by the SYCL runtime is entirely implementation defined. In this case the function object that represents the SYCL kernel function must take one of: 1) a single SYCL `item` parameter, 2) single generic parameter (template parameter or `auto`), treated as `item` 3) single integral parameter (e.g. `int`, `size_t`) if `range` is 1-dimensional, representing the currently executing work-item within the range specified by the range parameter.
+
+==== Remove the following paragraph with example
+
+Below is an example of invoking a SYCL kernel function with `parallel_for` using a lambda function, and passing a SYCL `id` parameter. In this case only the global id is available. This variant of `parallel_for` is designed for when it is not necessary to query the global range of the index space being executed across, or the local (workgroup) size chosen by the implementation.
+
+[source,c++,multiptr,linenums]
+----
+myQueue.submit([&](handler & cgh) {
+    auto acc = myBuffer.get_access<access::mode::write>(cgh);
+    cgh.parallel_for<class myKernel>(range<1>(numWorkItems), [=] (id<1> index) {
+        acc[index] = 42.0f;
+    });
+});
+----
+
+==== Add the following paragraph with example
+
+Below is an example of invoking a SYCL kernel function with `parallel_for` using a lambda function and passing `auto` parameter, treated as `item`. In this case both the global id and global range are queryable. The same effect can be achieved using `class` with template `operator()`. This variant of `parallel_for` is designed for when it is necessary to query the global range within which the global id will vary.
+No information is queryable on the local (work-group) size chosen by the implementation.
+[source,c++,multiptr,linenums]
+----
+myQueue.submit([&](handler & cgh) {
+    auto acc = myBuffer.get_access<access::mode::write>(cgh);
+    cgh.parallel_for<class myKernel>(range<1>(numWorkItems), [=] (auto item) {
+        size_t index = item.get_linear_id();
+        acc[index] = 42.0f;
+    });
+});
+----
+
+==== Add the following paragraph with example
+
+Below is an example of invoking a SYCL kernel function with `parallel_for` using a lambda function and passing integral type (e.g. `int`, `size_t`) parameter. This example is only valid when calling `parallel_for` with `range<1>`. In this case only the global id is available. This variant of `parallel_for` is designed for
+when it is not necessary to query the global range of the index space being executed across, or the local (workgroup) size chosen by the implementation.
+[source,c++,multiptr,linenums]
+----
+myQueue.submit([&](handler & cgh) {
+    auto acc = myBuffer.get_access<access::mode::write>(cgh);
+    cgh.parallel_for<class myKernel>(range<1>(numWorkItems), [=] (size_t index) {
+        acc[index] = 42.0f;
+    });
+});
+----
+
+==== Add the following paragraph with example
+
+The `parallel_for` overload without offset can be called with either number or `braced-init-list` with 1-3 elements. If the case the following calls are equivalent:
+
+* `parallel_for<class MyKernel>(N, _some_kernel_)` has same effect as `parallel_for<class MyKernel>(range<1>(N), _some_kernel_)`
+
+* `parallel_for<class MyKernel>({N}, _some_kernel_)` has same effect as `parallel_for<class MyKernel>(range<1>(N), _some_kernel_)`
+
+* `parallel_for<class MyKernel>({N1, N2}, _some_kernel_)` has same effect as `parallel_for<class MyKernel>(range<2>(N1, N2), _some_kernel_)`
+
+* `parallel_for<class MyKernel>({N1, N2, N3}, _some_kernel_)` has same effect as `parallel_for<class MyKernel>(range<3>(N1, N2, N3), _some_kernel_)`
+
+[source,c++,multiptr,linenums]
+----
+myQueue.submit([&](handler & cgh) {
+    auto acc = myBuffer.get_access<access::mode::write>(cgh);
+    cgh.parallel_for<class myKernel>(numWorkItems, [=] (auto item) {
+        size_t index = item.get_linear_id();
+        acc[index] = 42.0f;
+    });
+});
+----
+
+== Changes in 4.8.1.5 (Item interface)
+
+=== Changes in synopsis
+
+==== Add the following public method with description
+
+[source,c++,multiptr,linenums]
+----
+// only available if dimensions == 1
+operator size_t() const;
+----
+
+=== Changes in Table 4.70
+
+==== Add the following row
+
+|===
+a|
+[source,c++,multiptr,linenums]
+----
+operator size_t() const
+---- |
+Returns the index representing the work-item position in the iteration space. +
+This member function is only available if `dimensions` is equal to `1`
+|===
+
+== Changes in 4.7.6.6 (Buffer accessor interface)
+
+=== Changes in synopsis
+
+==== Remove the following public method with description
+
+[source,c++,multiptr,linenums]
+----
+/* Available only when: (accessMode == access::mode::write || accessMode ==
+access::mode::read_write || accessMode == access::mode::discard_write ||
+accessMode == access::mode::discard_read_write) && dimensions == 1) */
+dataT &operator[](size_t index) const;
+----
+
+=== Changes in Table 4.45
+
+==== Delete the following row
+
+|===
+|`dataT &operator[](size_t index) const` |
+Available only when: `(accessMode == access::mode::write \|\| accessMode == access::mode::read_write \|\| accessMode == access::mode::discard_write \|\| accessMode == access::mode::discard_read_write) && dimensions == 1)``. +
+Returns a reference to the element stored within the SYCL buffer this SYCL
+accessor is accessing at the index specified by index.
+|===
+
+== Prototype implementation
+
+https://github.com/otcshare/llvm/pull/1054
+
+== Issues
+
+None.
+
+//. asd
+//+
+//--
+//*RESOLUTION*: Not resolved.
+//--
+
+== Revision History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Rev|Date|Author|Changes
+|1|2020-17-04|Ruslan Arutyunyan|*Initial public working draft*
+|========================================
+
+//************************************************************************
+//Other formatting suggestions:
+//
+//* Use *bold* text for host APIs, or [source] syntax highlighting.
+//* Use +mono+ text for device APIs, or [source] syntax highlighting.
+//* Use +mono+ text for extension names, types, or enum values.
+//* Use _italics_ for parameters.
+//************************************************************************


### PR DESCRIPTION
Signed-off-by: Ruslan Arutyunyan <ruslan.arutyunyan@intel.com>

Contains the following features:

- Allow ``parallel_for`` call with number or ``braced-init-list`` as the first argument, i.e.
- Allow C++14 Generic lambda expression as the kernel for ``parallel_for``, i.e ``[](auto){}``
- Allow C++14 Generic lambda expression as the kernel for ``parallel_for_work_group``
- Allow integral type as the kernel argument for parallel_for called with ``range<1>``, e.g. ``[](int i){}``
- Allow ``item<1>`` to ``size_t`` conversion
- Resolve ambiguity for ``accessor::operator[]`` when the argument for it is an ``item``
- (optional) ``parallel_for`` kernel shall always take item as an argument (not item or id)