### PR TITLE
[SYCL][DOC] add new math array extension

### DIFF
--- a/sycl/doc/extensions/MathArray/README.md
+++ b/sycl/doc/extensions/MathArray/README.md
@@ -1,0 +1,3 @@
+# SYCL_INTEL_math_array
+
+Provides an alternative for `cl::sycl::vec` class with the `sycl::marray` class, which provides simplified storage format based on `std::array` and exposes math function overloads similar to `std::valarray` and `sycl::vec`

--- a/sycl/doc/extensions/MathArray/SYCL_INTEL_math_array.asciidoc
+++ b/sycl/doc/extensions/MathArray/SYCL_INTEL_math_array.asciidoc
@@ -1,0 +1,837 @@
+= SYCL_INTEL_math_array
+
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+
+:blank: pass:[ +]
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+// This is necessary for asciidoc, but not for asciidoctor
+:cpp: C++
+
+== Introduction
+IMPORTANT: This specification is a draft.
+
+NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by permission by Khronos.
+
+NOTE: This document is better viewed when rendered as html with asciidoctor.  GitHub does not render image icons.
+
+This document describes an extension that provides an alternative for +cl::sycl::vec+ class with the +cl::sycl::marray+ class, which provides simplified storage format based on +std::array+ and exposes math function overloads similar to +std::valarray+ and +cl::sycl::vec+.
+
+== Name Strings
+
++SYCL_INTEL_math_array+
+
+== Notice
+
+Copyright (c) 2020 Intel Corporation.  All rights reserved.
+
+== Status
+
+Working Draft
+
+This is a preview extension specification, intended to provide early access to a feature for review and community feedback.
+When the feature matures, this specification may be released as a formal extension.
+
+Because the interfaces defined by this specification are not final and are subject to change they are not intended to be used by shipping software products.
+
+== Version
+
+Built On: {docdate} +
+Revision: 1
+
+== Contact
+Ilya Burylov, Intel (ilya 'dot' burylov 'at' intel 'dot' com)
+
+== Dependencies
+
+This extension is written against the SYCL 1.2.1 specification, Revision 6.
+
+== Overview
+
+The SYCL vector class template (+cl::sycl::vec+) is designed for two purposes, that conflict in design
+and that can confuse developers and maintainers of code. First, the +vec+ class is designed to express
+data level parallelism inside each work-item.
+At the same time, +cl::sycl::vec+ is mostly used a short vector container with a set of useful built-in functions,
+while parallelism is primarily expressed via the work-items in a work-group.
+
+This extension introduces an alternative class template (+cl::sycl::intel::marray+) focused on containing an array of values of fixed size.
+
+=== Math array types
+
+This extension introduces `+marray<typename dataT, size_t numElements>+` class template
+to represent a contiguous fixed-size container.  This type
+allows sharing of containers between the host and its SYCL devices.
+
+The `marray` class is templated on its its element type and number of elements.
+The number of elements parameter, `numElements`, is a positive value of the `size_t` type.
+The element type parameter, `dataT`, must be a _Numeric type_ as it is defined by {cpp} standard.
+
+An instance of the `marray` class template can also be
+implicitly converted to an instance of the data type when the number of
+elements is `1` in order to allow single element arrays and
+scalars to be convertible with each other.
+
+Logical and comparison operators for `marray` class template return `marray<bool, numElements>`.
+
+==== Math array interface
+
+[source,c++]
+----
+template <typename dataT, size_t numElements>
+class marray {
+ public:
+  using value_type = dataT;
+  using reference = dataT&;
+  using const_reference = const dataT&;
+  using iterator = dataT*;
+  using const_iterator = const dataT*;
+
+  marray();
+
+  explicit marray(const dataT &arg);
+
+  template <typename... argTN>
+  marray(const argTN&... args);
+
+  marray(const marray<dataT, numElements> &rhs);
+  marray(marray<dataT, numElements> &&rhs);
+
+  // Available only when: numElements == 1
+  operator dataT() const;
+
+  static constexpr size_t size();
+
+  // subscript operator
+  reference operator[](size_t index);
+  const_reference operator[](size_t index) const;
+
+  marray &operator=(const marray<dataT, numElements> &rhs);
+  marray &operator=(const dataT &rhs);
+};
+
+// iterator functions
+iterator begin(marray &v);
+const_iterator begin(const marray &v);
+
+iterator end(marray &v);
+const_iterator end(const marray &v);
+
+// OP is: +, -, *, /, %
+/* When OP is % available only when: dataT != float && dataT != double && dataT != half. */
+marray operatorOP(const marray &lhs, const marray &rhs) { /* ... */ }
+marray operatorOP(const marray &lhs, const dataT &rhs) { /* ... */ }
+
+// OP is: +=, -=, *=, /=, %=
+/* When OP is %= available only when: dataT != float && dataT != double && dataT != half. */
+marray &operatorOP(marray &lhs, const marray &rhs) { /* ... */ }
+marray &operatorOP(marray &lhs, const dataT &rhs) { /* ... */ }
+
+// OP is: ++, --
+marray &operatorOP(marray &lhs) { /* ... */ }
+marray operatorOP(marray& lhs, int) { /* ... */ }
+
+// OP is: +, -
+marray operatorOP(marray &lhs) const { /* ... */ }
+
+// OP is: &, |, ^
+/* Available only when: dataT != float && dataT != double && dataT != half. */
+marray operatorOP(const marray &lhs, const marray &rhs) { /* ... */ }
+marray operatorOP(const marray &lhs, const dataT &rhs) { /* ... */ }
+
+// OP is: &=, |=, ^=
+/* Available only when: dataT != float && dataT != double && dataT != half. */
+marray &operatorOP(marray &lhs, const marray &rhs) { /* ... */ }
+marray &operatorOP(marray &lhs, const dataT &rhs) { /* ... */ }
+
+// OP is: &&, ||
+marray<bool, numElements> operatorOP(const marray &lhs, const marray &rhs) { /* ... */ }
+marray<bool, numElements> operatorOP(const marray& lhs, const dataT &rhs) { /* ... */ }
+
+// OP is: <<, >>
+/* Available only when: dataT != float && dataT != double && dataT != half. */
+marray operatorOP(const marray &lhs, const marray &rhs) { /* ... */ }
+marray operatorOP(const marray &lhs, const dataT &rhs) { /* ... */ }
+
+// OP is: <<=, >>=
+/* Available only when: dataT != float && dataT != double && dataT != half. */
+marray &operatorOP(marray &lhs, const marray &rhs) { /* ... */ }
+marray &operatorOP(marray &lhs, const dataT &rhs) { /* ... */ }
+
+// OP is: ==, !=, <, >, <=, >=
+marray<bool, numElements> operatorOP(const marray &lhs, const marray &rhs) { /* ... */ }
+marray<bool, numElements> operatorOP(const marray &lhs, const dataT &rhs) { /* ... */ }
+
+/* Available only when: dataT != float && dataT != double && dataT != half. */
+marray operator~(const marray &v) { /* ... */ }
+marray<bool, numElements> operator!(const marray &v) { /* ... */ }
+
+// OP is: +, -, *, /, %
+/* operator% is only available when: dataT != float && dataT != double && dataT != half. */
+marray operatorOP(const dataT &lhs, const marray &rhs) { /* ... */ }
+
+// OP is: &, |, ^
+/* Available only when: dataT != float && dataT != double
+&& dataT != half. */
+marray operatorOP(const dataT &lhs, const marray &rhs) { /* ... */ }
+
+// OP is: &&, ||
+marray<bool, numElements> operatorOP(const dataT &lhs, const marray &rhs) { /* ... */ }
+
+// OP is: <<, >>
+/* Available only when: dataT != float && dataT != double && dataT != half. */
+marray operatorOP(const dataT &lhs, const marray &rhs) { /* ... */ }
+
+// OP is: ==, !=, <, >, <=, >=
+marray<bool, numElements> operatorOP(const dataT &lhs, const marray &rhs) { /* ... */ }
+
+marray operator~(const marray &v) const { /* ... */ }
+
+marray<bool, numElements> operator!(const marray &v) const { /* ... */ }
+----
+
+.Constructors of the `marray` class template
+|===
+|Constructor |Description
+
+a|`marray()`
+| Default construct an array with element type `dataT` and with `numElements` dimensions by default construction of each of its elements.
+
+a|`explicit marray(const dataT &arg)`
+| Construct an array of element type `dataT` and `numElements` dimensions by setting each value to `arg` by assignment.
+
+a|
+----
+template <typename... argTN>
+marray(const argTN&... args)
+----
+| Construct a `marray` instance from any combination of scalar and `marray` parameters of the same element type,
+providing the total number of elements for all parameters sum to `numElements` of this `marray` specialization.
+
+a|`marray(const marray<dataT, numElements> &rhs)}`
+|Construct an array of element type `dataT` and number of elements `numElements` by copy from another similar array.
+
+a|`marray(marray<dataT, numElements> &&rhs)}`
+|Construct an array of element type `dataT` and number of elements `numElements` by applying move sematics for each element of another similar array.
+|===
+
+
+.Member functions for the `marray` class template}
+|===
+|Member function |Description
+
+a|`operator dataT() const`
+|
+Available only when: `numElements == 1`.
+
+Converts this `marray` instance to an instance of `dataT` with
+the value of the single element in this `marray` instance.
+
+The `marray` instance shall be implicitly convertible to the same data types,
+to which `dataT` is implicitly convertible.
+Note that conversion operator shall not be templated
+to allow standard conversion sequence for implicit conversion.
+
+a|`static constexpr int size()`
+| Returns the number of elements of this `marray`.
+
+a|`reference operator[](size_t index)`
+| Returns a reference to the element stored within this `marray` at the index specified by `index`.
+
+a|`const_reference operator[](size_t index) const`
+| Returns a const reference to the element stored within this `marray` at the index specified by `index`.
+
+a|`marray &operator=(const marray &rhs)`
+| Assign each element of the `rhs` `marray` to each element of this `marray` and return a reference to this `marray`.
+
+a|`marray &operator=(const dataT &rhs)`
+| Assign each element of the `rhs` scalar to each element of this `marray` and return a reference to this `marray`.
+
+|===
+
+
+.Non-member functions of the `marray` class template
+|===
+|Non-member function |Description
+
+a|`iterator begin(marray &v);`
+|Returns an iterator referring to the first element stored within the `v` `marray`.
+
+a|`const_iterator begin(const marray &v);`
+|Returns a const iterator referring to the first element stored within the `v` `marray`.
+
+a|`iterator end(marray &v);`
+|Returns an iterator referring to the one past the last element stored within the `v` `marray`.
+
+a|`const_iterator end(const marray &v);`
+|Returns a const iterator referring to the one past the last element stored within the `v` `marray`.
+
+a|`marray operatorOP(const marray &lhs, const marray &rhs)`
+|  
+When `OP` is ``%`` available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with the same template parameters as `lhs` `marray` with each element of the new `marray` instance the result of an element-wise `OP` arithmetic operation between each element of `lhs` `marray` and each element of the `rhs` `marray`.
+
+Where `OP` is: ``+``, ``-``, ``*``, ``/``, ``%``.
+
+a|`marray operatorOP(const marray &lhs, const dataT &rhs)`
+|
+When `OP` is ``%`` available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with the same template parameters as `lhs` `marray` with each element of the new `marray` instance the result of an element-wise `OP` arithmetic operation between each element of `lhs` `marray` and the `rhs` scalar.
+
+Where `OP` is: ``+``, ``-``, ``*``, ``/``, ``%``.
+
+a|`marray &operatorOP(marray &lhs, const marray &rhs)`
+|
+When `OP` is \codeinline{\%=} available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Perform an in-place element-wise `OP` arithmetic operation between each element of `lhs` `marray` and each element of the `rhs` `marray` and return `lhs` `marray`.
+
+Where `OP` is: \codeinline{+=}, \codeinline{-=}, \codeinline{*=}, \codeinline{/=}, \codeinline{\%=}.
+
+a|`marray &operatorOP(marray &lhs, const dataT &rhs)`
+| 
+When `OP` is \codeinline{\%=} available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Perform an in-place element-wise `OP` arithmetic operation between each element of `lhs` `marray` and `rhs` scalar and return `lhs` `marray`.
+
+Where `OP` is: \codeinline{+=}, \codeinline{-=}, \codeinline{*=}, \codeinline{/=}, \codeinline{\%=}.
+
+a|`marray &operatorOP(marray &v)`
+|
+Perform an in-place element-wise `OP` prefix arithmetic operation on each element of `lhs` `marray`, assigning the result of each element to the corresponding element of `lhs` `marray` and return `lhs` `marray`.
+
+Where `OP` is: ``++``, ``--``. 
+
+a|`marray operatorOP(marray &v, int)`
+|
+Perform an in-place element-wise `OP` post-fix arithmetic operation on each element of `lhs` `marray`, assigning the result of each element to the corresponding element of `lhs` `marray` and returns a copy of `lhs` `marray` before the operation is performed.
+
+Where `OP` is: ``++``, ``--``.
+
+a|`marray operatorOP(marray &v)`
+|
+Construct a new instance of the `marray` class template with the same template parameters as this `marray` with each element of the new `marray` instance the result of an element-wise `OP` unary arithmetic operation on each element of this `marray`.
+
+Where `OP` is: ``+``, ``-``.
+
+a|`marray operatorOP(const marray &lhs, const marray &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with the same template parameters as `lhs` `marray` with each element of the new `marray` instance the result of an element-wise `OP` bitwise operation between each element of `lhs` `marray` and each element of the `rhs` `marray`.
+Where `OP` is: ``&``, ``\|``, ``^``.
+
+a|`marray operatorOP(const marray &lhs, const dataT &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with the same template parameters as `lhs` `marray` with each element of the new `marray` instance the result of an element-wise `OP` bitwise operation between each element of `lhs` `marray` and the `rhs` scalar.
+
+Where `OP` is: ``&``, ``\|``, ``^``.
+
+a|`marray &operatorOP(marray &lhs, const marray &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Perform an in-place element-wise `OP` bitwise operation between each element of `lhs` `marray` and the `rhs` `marray` and return `lhs` `marray`.
+
+Where `OP` is: ``&=``, ``\|=``, ``^=``.
+
+a|`marray &operatorOP(marray &lhs, const dataT &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Perform an in-place element-wise `OP` bitwise operation between each element of `lhs` `marray` and the `rhs` scalar and return a `lhs` `marray`.
+
+Where `OP` is: ``&=``, ``\|=``, ``^=``. 
+
+a|`marray<bool, numElements> operatorOP(const marray &lhs, const marray &rhs)`
+|
+Construct a new instance of the `marray` class template with ``dataT = bool`` and same numElements as `lhs` `marray` with each element of the new `marray` instance the result of an element-wise `OP` logical operation between each element of `lhs` `marray` and each element of the `rhs` `marray`.
+
+Where `OP` is: ``&&``, ``\|\|``.
+
+a|`marray<bool, numElements> operatorOP(const marray &lhs, const dataT &rhs)`
+|
+Construct a new instance of the `marray` class template with ``dataT = bool`` and same numElements as `lhs` `marray` with each element of the new `marray` instance the result of an element-wise `OP` logical operation between each element of `lhs` `marray` and the `rhs` scalar.
+                
+Where `OP` is: ``&&``, ``\|\|``.
+
+a|`marray operatorOP(const marray &lhs, const marray &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with the same template parameters as `lhs` `marray`
+with each element of the new `marray` instance the result of an element-wise `OP` bitshift operation between each element of `lhs` `marray`
+and each element of the `rhs` `marray`.
+If `OP` is ``>>``, `dataT` is a signed type and `lhs` `marray` has a negative value any vacated bits viewed as an unsigned integer
+must be assigned the value `1`, otherwise any vacated bits viewed as an unsigned integer must be assigned the value `0`.
+
+Where `OP` is: ``<<``, ``>>``.
+
+a|`marray operatorOP(const marray &lhs, const dataT &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with the same template parameters as `lhs` `marray`
+with each element of the new `marray` instance the result of an element-wise `OP` bitshift operation between each element of `lhs` `marray`
+and the `rhs` scalar.
+If `OP` is ``>>``, `dataT` is a signed type and `lhs` `marray` has a negative value any vacated bits viewed as an unsigned integer
+must be assigned the value `1`, otherwise any vacated bits viewed as an unsigned integer must be assigned the value `0`.
+
+Where `OP` is: ``<<``, ``>>``.
+  
+a|`marray &operatorOP(marray &lhs, const marray &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Perform an in-place element-wise `OP` bitshift operation between each element of `lhs` `marray` and the `rhs` `marray` and returns `lhs` `marray`.
+If `OP` is ``>>=``, `dataT` is a signed type and `lhs` `marray` has a negative value any vacated bits viewed as an unsigned integer
+must be assigned the value `1`, otherwise any vacated bits viewed as an unsigned integer must be assigned the value `0`.
+
+Where `OP` is: ``<\<=``, ``>>=``.
+
+a|`marray &operatorOP(marray &lhs, const dataT &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Perform an in-place element-wise `OP` bitshift operation between each element of `lhs` `marray` and the `rhs` scalar and returns a reference to this `marray`.
+If `OP` is ``>>=``, `dataT` is a signed type and `lhs` `marray` has a negative value any vacated bits viewed as an unsigned integer
+must be assigned the value `1`, otherwise any vacated bits viewed as an unsigned integer must be assigned the value `0`.
+
+Where `OP` is: ``<\<=``, ``>>=``.
+
+a|`marray<bool, numElements> operatorOP(const marray& lhs, const marray &rhs)`
+|
+Construct a new instance of the `marray` class template with ``dataT = bool`` and same numElements as `lhs` `marray`
+with each element of the new `marray` instance the result of an element-wise `OP` relational operation between each element of `lhs` `marray`
+and each element of the `rhs` `marray`.
+Corresponding element of the `marray` that is returned must be `false` if the operation results is a NaN.
+
+Where `OP` is: ``==``, ``!=``, ``<``, ``>``, ``<=``, ``>=``.
+
+a|`marray<bool, numElements> operatorOP(const marray &lhs, const dataT &rhs)`
+|
+Construct a new instance of the `marray` class template with ``dataT = bool`` and same numElements as `lhs` `marray`
+with each element of the new `marray` instance the result of an element-wise `OP` relational operation between each element of `lhs` `marray`
+and the `rhs` scalar.
+Corresponding element of the `marray` that is returned must be `false` if the operation results is a NaN.
+
+Where `OP` is: ``==``, ``!=``, ``<``, ``>``, ``<=``, ``>=``. 
+
+a|`marray operatorOP(const dataT &lhs, const marray &rhs)`
+|
+When `OP` is ``%`` available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with the same template parameters as the `rhs` `marray` with each element of the new `marray` instance the result of an element-wise `OP` arithmetic operation between the `lhs` scalar and each element of the `rhs` `marray`.
+
+Where `OP` is: ``+``, ``-``, ``*``, ``/``, ``%``.
+
+a|`marray operatorOP(const dataT &lhs, const marray &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with the same template parameters as the `rhs` `marray` with each element of the new `marray` instance the result of an element-wise `OP` bitwise operation between the \codeinline{lhs} scalar and each element of the `rhs` `marray`.
+
+Where `OP` is: ``&``, ``\|``, ``^``.
+
+a|`marray<bool, numElements> operatorOP(const dataT &lhs, const marray &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with ``dataT = bool`` and same numElements as `lhs` `marray` with each element of the new `marray` instance the result of an element-wise `OP` logical operation between the \codeinline{lhs} scalar and each element of the `rhs` `marray`.
+
+Where `OP` is: ``&&``, ``\|\|``.
+
+a|`marray operatorOP(const dataT &lhs, const marray &rhs)`
+|
+Construct a new instance of the `marray` class template with 
+the same template parameters as the `rhs` `marray`
+with each element of the new `marray` instance the result of
+an element-wise `OP` bitshift operation between the `lhs` scalar and each element of the `rhs` `marray`.
+If `OP` is ``>>``, `dataT` is a signed type
+and this `marray` has a negative value any vacated bits viewed
+as an unsigned integer must be assigned the value `1`, otherwise
+any vacated bits viewed as an unsigned integer must be assigned the value `0`.
+
+Where `OP` is: ``<<``, ``>>``.
+
+a|`marray<bool, numElements> operatorOP(const dataT &lhs, const marray &rhs)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with ``dataT = bool`` and same numElements as `lhs` `marray` 
+with each element of the new SYCL `marray` instance the result of an element-wise `OP`
+relational operation between the `lhs` scalar and each element of the `rhs` `marray`.
+Corresponding element of the `marray` that is returned must be `false` if the operation results is a NaN.
+
+Where `OP` is: ``==``, ``!=``, ``<``, ``>``, ``<=``, ``>=``.
+
+a|`marray &operator~(const marray &v)`
+|
+Available only when: ``dataT != float && dataT != double && dataT != half``.
+
+Construct a new instance of the `marray` class template with the same template parameters as `v` `marray`
+with each element of the new `marray` instance the result of an element-wise `OP` bitwise operation on each element of `v` `marray`.
+  
+a|`marray<bool, numElements> operator!(const marray &v)`
+|
+Construct a new instance of the `marray` class template with ``dataT = bool`` and same numElements as `v` `marray`
+with each element of the new `marray` instance the result of an element-wise logical `!` operation on each element of `v` `marray`.
+
+Corresponding element of the `marray` that is returned must be `false` if the operation results is a NaN.
+
+|===
+
+==== Aliases
+
+The extension API provides all permutations of the type alias:
+
+[source,c++]
+----
+using m<type><elems> = marray<<storage-type>, <elems>>
+----
+
+where `<elems>` is `2`, `3`, `4`, `8` and `16`,
+and pairings of `<type>` and `<storage-type>` for integral types are
+`char` and `int8_t`, `uchar` and `uint8_t`, `short` and `int16_t`, `ushort` and
+`uint16_t`, `int` and `int32_t`, `uint` and `uint32_t`, `long` and
+`int64_t`, `ulong` and `uint64_t`, for floating point types are `half`, `float`
+and `double`, and for boolean type `bool`.
+
+For example `muint4` is the alias to `marray<uint64_t, 4>` 
+and `mfloat16` is the alias to `marray<float, 16>`.
+
+==== Memory layout and alignment
+
+The elements of an instance of the `marray` class template as if stored in `std::array<dataT, numElements>`.
+
+=== Modifications of SYCL 1.2.1 specification
+
+==== Modify paragraph in Section of 4.13.1 SYCL built-in functions for SYCL host and device
+
+*Change from:*
+
+All of the OpenCL built-in types are available in the namespace `cl::sycl`. For the purposes of this document we
+use generic type names for describing sets of valid SYCL types. The generic type names themselves are not valid
+SYCL types, but they represent a set of valid types, as defined in `Tables 4.108`. Each generic type within a section
+is comprised of a combination of scalar and/or SYCL `vec` class specializations. Note that any reference to the
+base type refers to the type of a scalar or the element type of a SYCL `vec` specialization.
+
+*To:*
+
+All of the OpenCL built-in types are available in the namespace `cl::sycl`. For the purposes of this document we
+use generic type names for describing sets of valid SYCL types. The generic type names themselves are not valid
+SYCL types, but they represent a set of valid types, as defined in `Tables 4.108`. Each generic type within a section
+is comprised of a combination of scalar, SYCL `vec` and/or `marray` class specializations. Note that any reference to the
+base type refers to the type of a scalar or the element type of a SYCL `vec` or `marray` specialization.
+
+==== Replace Table 4.108: Generic type name description, which serves as a description for all valid types of parameters to kernel functions.
+
+*With:*
+
+.Generic type name description, which serves as a description for all valid types of parameters to kernel functions
+|===
+|Generic type name |Description
+
+| floatn    | float{n}, mfloat{n}, marray<{N},float>
+| genfloatf | float, floatn
+| doublen   | double{n}, mdouble{n}, marray<{N},double>
+| genfloatd | double, doublen
+| halfn     | half{n}, mhalf{n}, marray<{N},half>
+| genfloath | half, halfn
+| genfloat  | genfloatf, genfloatd, genfloath
+| sgenfloat | float, double, half
+| gengeofloat | float, float2, float3, float4, mfloat2, mfloat3, mfloat4
+| gengeodouble | double, double2, double3, double4, mdouble2, mdouble3, mdouble4
+| charn | char{n}, mchar{n}, marray<{N},char>
+| scharn | schar{n}, mschar{n}, marray<{N},signed char>
+| ucharn | uchar{n}, muchar{n}, marray<{N},unsigned char>
+| igenchar | signed char, scharn
+| ugenchar | unsigned char, ucharn
+| genchar | char, charn, igenchar, ugenchar
+| shortn | short{n}, mshort{n}, marray<{N},short>
+| genshort | short, shortn
+| ushortn | ushort{n}, mushort{n}, marray<{N},unsigned short>
+| ugenshort | unsigned short, ushortn
+| uintn | uint{n}, muint{n}, marray<{N},unsigned int>
+| ugenint | unsigned int, uintn
+| intn | int{n}, mint{n}, marray<{N},int>
+| genint | int, intn
+| ulongn | ulong{n}, mulong{n}, marray<{N},unsigned long int>
+| ugenlong | unsigned long int, ulongn
+| longn | long{n}, mlong{n}, marray<{N},long int>
+| genlong | long int, longn
+| ulonglongn | ulonglong{n}, mulonglong{n}, marray<{N},unsigned long long int>
+| ugenlonglong | unsigned long long int, ulonglongn
+| longlongn | longlong{n}, mlonglong{n}, marray<{N},long long int>
+| genlonglong | long long int, longlongn
+| igenlonginteger | genlong, genlonglong
+| ugenlonginteger | ugenlong, ugenlonglong
+| geninteger | genchar, genshort, ugenshort, genint, ugenint, igenlonginteger, ugenlonginteger
+| genintegerNbit | All types within geninteger whose base type are N bits in size, where N = 8, 16, 32, 64.
+| igeninteger | igenchar, genshort, genint, igenlonginteger
+| igenintegerNbit | All types within igeninteger whose base type are N bits in size, where N = 8, 16, 32, 64.
+| ugeninteger | ugenchar, ugenshort, ugenint, ugenlonginteger
+| ugenintegerNbit | All types within ugeninteger whose base type are N bits in size, where N = 8, 16, 32, 64.
+| sgeninteger | char, signed char, unsigned char, short, unsigned short, int, unsigned int, long int, unsigned long int, long long int, unsigned long long int
+| gentype | genfloat, geninteger
+| genfloatptr | All permutations of `multi_ptr<dataT, addressSpace>` where `dataT` is all types within `genfloat` and `addressSpace` is `access::address_space::global_space`, `access::address_space::local_space` and `access::address_space::private_space`.
+| genintptr | All permutations of `multi_ptr<dataT, addressSpace>` where `dataT` is all types within `genint` and `addressSpace` is `access::address_space::global_space`, `access::address_space::local_space` and `access::address_space::private_space`.
+| booln | marray<{N},bool>
+| genbool | bool, booln
+|===
+
+Note: {n} means 2,3,4,8,16, {N} means any positive value of size_t type.
+
+==== Modify paragraph in Section of 4.13.3 Math functions
+
+*Change from:*
+
+In SYCL the OpenCL math functions are available in the namespace cl::sycl on host and device with the same
+precision guarantees as defined in the OpenCL 1.2 specification document [1, ch. 7] for host and device. For a
+SYCL platform the numerical requirements for host need to match the numerical requirements of the OpenCL
+math built-in functions. The built-in functions can take as input float or optionally double and their vec counterparts,
+for dimensions 1, 2, 3, 4, 8 and 16. On the host the vector types use the vec class and on an OpenCL device
+use the corresponding OpenCL vector types.
+
+*To:*
+
+In SYCL the math functions are available in the namespace cl::sycl on host and device with the same
+precision guarantees as defined in the OpenCL 1.2 specification document [1, ch. 7] for host and device. For a
+SYCL platform the numerical requirements for host need to match the numerical requirements of the OpenCL
+math built-in functions. The built-in functions can take as input float or optionally double and
+their vec and marray counterparts, for all supported dimensions including dimension 1.
+
+==== Modify paragraph in Section of 4.13.4 Integer functions
+
+*Change from:*
+
+In SYCL the OpenCL integer math functions are available in the namespace cl::sycl on host and device as
+defined in the OpenCL 1.2 specification document [1, par. 6.12.3]. The built-in functions can take as input char
+, unsigned char, short, unsigned short, int, unsigned int, long long int, unsigned long long int and
+their vec counterparts, for dimensions 2, 3, 4, 8 and 16. On the host the vector types use the vec class and on an
+OpenCL device use the corresponding OpenCL vector types. The supported integer math functions are described
+in Table 4.112.
+
+*To:*
+
+In SYCL the integer math functions are available in the namespace cl::sycl on host and device as
+defined in the OpenCL 1.2 specification document [1, par. 6.12.3]. The built-in functions can take as input char
+, unsigned char, short, unsigned short, int, unsigned int, long long int, unsigned long long int and
+their `vec` and `marray` counterparts. The supported integer math functions are described
+in Table 4.112.
+
+==== Modify paragraph in Section of 4.13.5 Common functions
+
+*Change from:*
+
+In SYCL the OpenCL common functions are available in the namespace cl::sycl on host and device as defined
+in the OpenCL 1.2 specification document [1, par. 6.12.4]. They are described here in Table 4.113. The built-in
+functions can take as input float or optionally double and their vec counterparts, for dimensions 2, 3, 4, 8 and
+16. On the host the vector types use the vec class and on an OpenCL device use the corresponding OpenCL vector
+types.
+
+*To:*
+
+In SYCL the common functions are available in the namespace cl::sycl on host and device as defined
+in the OpenCL 1.2 specification document [1, par. 6.12.4]. They are described here in Table 4.113. The built-in
+functions can take as input float or optionally double and their `vec` and `marray` counterparts.
+
+==== Modify paragraph in Section of 4.13.6 Geometric Functions
+
+*Change from:*
+
+In SYCL the OpenCL geometric functions are available in the namespace cl::sycl on host and device as defined
+in the OpenCL 1.2 specification document [1, par. 6.12.5]. The built-in functions can take as input float or
+optionally double and their vec counterparts, for dimensions 2, 3 and 4. On the host the vector types use the vec
+class and on an OpenCL device use the corresponding OpenCL vector types. All of the geometric functions use
+round-to-nearest-even rounding mode. Table 4.114 contains the definitions of supported geometric functions.
+
+*To:*
+
+In SYCL the geometric functions are available in the namespace cl::sycl on host and device as defined
+in the OpenCL 1.2 specification document [1, par. 6.12.5]. The built-in functions can take as input float or
+optionally double and their `vec` and `marray` counterparts, for dimensions 2, 3 and 4.
+All of the geometric functions use round-to-nearest-even rounding mode.
+Table 4.114 contains the definitions of supported geometric functions.
+
+==== Modify the row in Table 4.114 Geometric functions which work on SYCL Host and device, are available in the cl::sycl namespace.
+
+*Change from:*
+
+.Generic type name description, which serves as a description for all valid types of parameters to kernel functions
+|===
+|Geometric function |Description
+
+a|
+----
+float4 cross (float4 p0, float4 p1)
+float3 cross (float3 p0, float3 p1)
+double4 cross (double4 p0, double4 p1)
+double3 cross (double3 p0, double3 p1)
+----
+| Returns the cross product of p0.xyz and p1.xyz. The w component of float4 result returned will be 0.0.
+|===
+
+*To:*
+
+.Generic type name description, which serves as a description for all valid types of parameters to kernel functions
+|===
+|Geometric function |Description
+
+a|
+----
+float4 cross (float4 p0, float4 p1)
+float3 cross (float3 p0, float3 p1)
+mfloat4 cross (mfloat4 p0, mfloat4 p1)
+mfloat3 cross (mfloat3 p0, mfloat3 p1)
+
+double4 cross (double4 p0, double4 p1)
+double3 cross (double3 p0, double3 p1)
+mdouble4 cross (mdouble4 p0, mdouble4 p1)
+mdouble3 cross (mdouble3 p0, mdouble3 p1)
+----
+| Returns the cross product of first 3 components of p0 and p1. The 4th component of result returned will be 0.0.
+|===
+
+==== Modify paragraph in Section of 4.13.7 Relational functions
+
+*Change from:*
+
+In SYCL the OpenCL relational functions are available in the namespace cl::sycl on host and device as defined
+in the OpenCL 1.2 specification document [1, par. 6.12.6]. The built-in functions can take as input char, unsigned
+char, short, unsigned short, int, unsigned int, long, unsigned long, float or optionally double and their
+vec counterparts, for dimensions 2,3,4,8, and 16. On the host the vector types use the vec class and on an OpenCL
+device use the corresponding OpenCL vector types. The relational operators are available on both host and device.
+The relational functions are provided in addition to the the operators and will return 0 if the conditional is false
+and 1 otherwise. The available built-in functions are described in Tables 4.115
+
+*To:*
+
+In SYCL the relational functions are available in the namespace cl::sycl on host and device as defined
+in the OpenCL 1.2 specification document [1, par. 6.12.6]. The built-in functions can take as input char, unsigned
+char, short, unsigned short, int, unsigned int, long, unsigned long, float or optionally double and their
+`vec` and `marray` counterparts. The relational functions are provided in addition to the the operators
+and will return 0 if the conditional is false and 1 otherwise.
+
+The available built-in functions for `vec` template class are described in Tables 4.115
+
+==== Modify the Title of Tables 4.115
+
+*Change from:*
+
+Relational functions which work on SYCL Host and device, are available in the `sycl` namespace. They correspond to Table 6.14
+of the OpenCL 1.2 specification [1]
+
+*To:*
+
+Relational functions for `vec` template class which work on SYCL Host and device, are available in the `sycl` namespace. They correspond to Table 6.14
+of the OpenCL 1.2 specification [1]
+
+==== Add to Section of 4.13.7 Relational functions after Tables 4.115
+
+
+.Relational functions scalar data types and `marray` template class which work on SYCL Host and device, are available in the `sycl` namespace.
+|===
+|Relational function |Description
+
+a|`genbool isequal (genfloat x, genfloat y)`
+| Returns the component-wise compare of `x == y`.
+
+a|`genbool isnotequal (genfloat x, genfloat y)`
+| Returns the component-wise compare of `x != y`.
+
+a|`genbool isgreater (genfloat x, genfloat y)`
+| Returns the component-wise compare of `x > y`.
+
+a|`genbool isgreaterequal (genfloat x, genfloat y)`
+| Returns the component-wise compare of `x >= y`.
+
+a|`genbool isless (genfloat x, genfloat y)`
+| Returns the component-wise compare of `x < y`.
+
+a|`genbool islessequal (genfloat x, genfloat y)`
+| Returns the component-wise compare of `x \<= y`.
+
+a|`genbool islessgreater (genfloat x, genfloat y)`
+| Returns the component-wise compare of `(x < y) \|\| (x > y)`.
+
+a|`genbool isfinite (genfloat x)`
+| Test for finite value.
+
+a|`genbool isinf (genfloat x)`
+| Test for infinity value (positive or negative).
+
+a|`genbool isnan (genfloat x)`
+| Test for a `NaN`.
+
+a|`genbool isnormal (genfloat x)`
+| Test for a normal value.
+
+a|`genbool isordered (genfloat x, genfloat y)`
+| Test if arguments are ordered. `isordered()` takes arguments `x` and `y`, and returns the result
+`isequal(x, x) && isequal(y, y)`.
+
+a|`genbool isunordered (genfloat x, genfloat y)`
+| Test if arguments are unordered. isunordered() takes arguments x and y, returning non-zero if x or y is NaN, and zero otherwise.
+
+a|`genbool signbit (genfloat x)`
+| Test for sign bit. The scalar version of the function returns a `true` if the sign bit in the float is set
+else returns `false`.
+
+a|`bool any (genbool x)`
+| Returns `true` if any component of x is `true`; otherwise returns `false`.
+
+a|`bool all (genbool x)`
+| Returns `true` if all components of x are `true`; otherwise returns `false`.
+
+a|`gentype bitselect (gentype a, gentype b, gentype c)`
+| Each bit of the result is the corresponding bit of `a` if the corresponding bit of `c` is `0`. Otherwise it is the corresponding bit of `b`.
+
+a|`gentype select (gentype a, gentype b, genbool c)`
+a| Returns the component-wise `result = c ? b : a`.
+|===
+
+
+== Issues
+
+. From design perspective `std::array` is considered as a storage model for the new type.  `std::array` is an aggregate.
+  Having aggregate model we can avoid friend functions.
+  Shall the new type be an aggregate as well?
++
+--
+*UNRESOLVED*:
+--
+
+== Revision History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Rev|Date|Author|Changes
+|1|2020-04-14|Ilya Burylov|*Initial public working draft*
+|========================================
+
+//************************************************************************
+//Other formatting suggestions:
+//
+//* Use *bold* text for host APIs, or [source] syntax highlighting.
+//* Use +mono+ text for device APIs, or [source] syntax highlighting.
+//* Use +mono+ text for extension names, types, or enum values.
+//* Use _italics_ for parameters.
+//************************************************************************


### PR DESCRIPTION
The SYCL vector class template (cl::sycl::vec) defined in SYCL 1.2.1 is designed to express data level parallelism inside each work-item. At the same time, cl::sycl::vec is mostly used a short vector container with a set of usefull built-in functions, while parallelism is primarily expressed via work-groups.

This extension introduces an alternative class template (cl::sycl::intel::marray) focused on containing an array of values of fixed size.

Signed-off-by: iburylov <ilya.burylov@intel.com>