### PR TITLE
[Driver][SYCL] Improve -Xsycl-target option parsing

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -422,14 +422,14 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
   return DAL;
 }
 
-void parseTargetOpts(StringRef ArgString, const llvm::opt::ArgList &Args,
-                     llvm::opt::ArgStringList &CmdArgs) {
+static void parseTargetOpts(StringRef ArgString, const llvm::opt::ArgList &Args,
+                            llvm::opt::ArgStringList &CmdArgs) {
   // Tokenize the string.
   SmallVector<const char *, 8> TargetArgs;
   llvm::BumpPtrAllocator A;
   llvm::StringSaver S(A);
   llvm::cl::TokenizeGNUCommandLine(ArgString, S, TargetArgs);
-  for (StringRef const &TA : TargetArgs)
+  for (StringRef TA : TargetArgs)
     CmdArgs.push_back(Args.MakeArgString(TA));
 }
 

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -671,6 +671,10 @@
 // CHK-TOOLS-CPU-OPTS: opencl-aot{{.*}} "-DFOO1" "-DFOO2"
 // CHK-TOOLS-CPU-OPTS-NOT: clang-offload-wrapper{{.*}} "-compile-opts={{.*}}
 
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -Xsycl-target-backend "--bo='\"-DFOO1 -DFOO2\"'" %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-TOOLS-CPU-OPTS3 %s
+// CHK-TOOLS-CPU-OPTS3: opencl-aot{{.*}} "--bo=\"-DFOO1 -DFOO2\""
+
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-OPTS %s
 // CHK-TOOLS-OPTS: clang-offload-wrapper{{.*}} "-compile-opts=\"-DFOO1 -DFOO2\""


### PR DESCRIPTION
Initial implementation of -Xsycl-target-backend "opts" had a simple parsing
of relying on spaces.  Any more complex option passing that requires args
containing spaces did not pass correctly.  Update parsing to be a bit
smarter.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>