### PR TITLE
[SPIR-V][DOC] Add SPV_INTEL_optimization_hints extension spec

### DIFF
--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
@@ -138,15 +138,13 @@ The type of _Condition_ must be a scalar _Boolean_.
 [cols="6", width="100%"]
 |=====
 5+^|*OpExpectINTEL* +
+This instruction behaves the same as _OpCopyObject_ by making a copy of _Value_,
+except it also provides information to the optimizer that the most probable
+value of _Value_ is _ExpectedValue_.
 
-Provides information for optimizers that the most probable value of _Value_ is
-_ExpectedValue_ and makes a copy of _Value_.
+_Result Type_ must be a scalar or vector of _Integer type_ or _Boolean type_.
 
-This instruction can be safely replaced with an entityi referenced by _Value_.
-
-The type of _Value_ and _ExpectedValue_ must be the same as _Result Type_,
-which must be of _Integer_ or _Boolean_ type.
-
+The type of _Value_ and _ExpectedValue_ must be the same as _Result Type_.
 | Capability:
 *OptimizationHintsINTEL*
 

--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
@@ -44,8 +44,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2020-05-12
-| Revision           | G
+| Last Modified Date | 2020-06-07
+| Revision           | H
 |========================================
 
 Dependencies
@@ -128,7 +128,7 @@ The instruction allows the optimizer to assume that the provided _Condition_ is
 always true whenever the control flow reaches the instruction. If the
 _Condition_ is violated during execution, the behavior is undefined.
 
-The type of _Condition_ must be _Boolean_.
+The type of _Condition_ must be a scalar _Boolean_.
 | Capability:
 *OptimizationHintsINTEL*
 
@@ -140,8 +140,9 @@ The type of _Condition_ must be _Boolean_.
 5+^|*OpExpectINTEL* +
 
 Provides information for optimizers that the most probable value of _Value_ is
-_ExpectedValue_. This instruction can be safely replaced with an entity
-referenced by _Value_.
+_ExpectedValue_ and makes a copy of _Value_.
+
+This instruction can be safely replaced with an entityi referenced by _Value_.
 
 The type of _Value_ and _ExpectedValue_ must be the same as _Result Type_,
 which must be of _Integer_ or _Boolean_ type.
@@ -180,5 +181,6 @@ Revision History
 |E|2020-04-08|Dmitry Sidorov|Assign reserved values
 |F|2020-04-30|Dmitry Sidorov|Switch AssumeTrue from Decoration to instruction
 |G|2020-05-12|Dmitry Sidorov|Fix typos
+|H|2020-06-07|Dmitry Sidorov|Update instructions' descriptions
 |========================================
 

--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
@@ -1,0 +1,193 @@
+SPV_INTEL_optimization_hints
+============================
+
+Name Strings
+------------
+
+SPV_INTEL_optimization_hints
+
+Contact
+-------
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/KhronosGroup/SPIRV-Headers
+
+Contributors
+------------
+
+- Dmitry Sidorov, Intel
+- Alexey Sachkov, Intel
+- Alexey Sotkin, Intel
+- Ben Ashbaugh, Intel
+
+Notice
+------
+
+Copyright (c) 2020 Intel Corporation.  All rights reserved.
+
+Status
+------
+
+Working Draft
+
+This is a preview extension specification, intended to provide early access to a
+feature for review and community feedback. When the feature matures, this
+specification may be released as a formal extension.
+
+Because the interfaces defined by this specification are not final and are
+subject to change they are not intended to be used by shipping software
+products.
+
+Version
+-------
+
+[width="40%",cols="25,25"]
+|========================================
+| Last Modified Date | 2020-04-27
+| Revision           | E
+|========================================
+
+Dependencies
+------------
+
+This extension is written against the SPIR-V Specification,
+Version 1.5 Revision 2.
+
+This extension requires SPIR-V 1.0.
+
+Overview
+--------
+
+This extension adds a decoration *AssumeTrueINTEL* and an instruction
+*OpExpectINTEL* that are appropriately mapped on ‘llvm.assume’ and ‘llvm.expect’
+intrinsics. That is required to save optimization hints through LLVM IR to
+SPIR-V transformation.
+
+Extension Name
+--------------
+
+To use this extension within a SPIR-V module, the following *OpExtension* must
+be present in the module:
+
+----
+OpExtension "SPV_INTEL_optimization_hints"
+----
+
+New Capabilities
+----------------
+This extension introduces a new capability:
+
+----
+OptimizationHintsINTEL
+----
+
+New Instructions
+----------------
+Instructions added under the *OptimizationHintsINTEL* capability:
+
+----
+ExpectINTEL
+----
+
+New Decorations
+---------------
+Decorations added under the *OptimizationHintsINTEL* capability:
+
+----
+AssumeTrueINTEL
+----
+
+Token Number Assignments
+------------------------
+[width="45%",cols="30,15"]
+|===============================
+| OptimizationHintsINTEL | 5629
+| AssumeTrueINTEL        | 5630
+| OpExpectINTEL          | 5631
+|===============================
+
+Modifications to the SPIR-V Specification, Version 1.5
+------------------------------------------------------
+
+Decorations
+~~~~~~~~~~~
+
+In section 3.20 "Decoration", update or add
+
+--
+[options="header"]
+|====
+2+^| Decoration	^| Enabling Capabilities
+| TBD | *AssumeTrueINTEL* +
+Applies to a _Condition_ of a _Boolean Type_. Allows an optimizer to assume that
+the provided _Condition_ is true.
+| *OptimizationHintsINTEL*
+|====
+--
+
+Capabilities
+~~~~~~~~~~~~
+
+Modify Section 3.31, "Capability", adding these rows to the Capability table:
+
+--
+[options="header"]
+|====
+2+^| Capability ^| Depends On
+| TBD | *OptimizationHintsINTEL* +
+Allow to use AssumeTrueINTEL decoration and ExpectINTEL instruction |
+|====
+--
+
+Instructions
+~~~~~~~~~~~~
+
+In section 3.32.1, Miscellaneous Instructions, add a new instruction:
+
+[cols="6", width="100%"]
+|=====
+5+^|*OpExpectINTEL* +
+
+Provides information for optimizers that the most probable value of _Value_ is
+_ExpectedValue_. This instruction can be safely replaced with an entity
+referenced by _Value_.
+
+The type of _Value_ and _ExpectedValue_ must be the same as _Result Type_,
+which shall be of _Integer_ or _Boolean_ type.
+
+| Capability:
+*OptimizationHintsINTEL*
+
+| 5 | TBD | <id> +
+Result Type | Result <id> | Value <id> | ExpectedValue <id>
+|=====
+
+
+Issues
+------
+
+1) From https://llvm.org/docs/LangRef.html#llvm-expect-intrinsic
+_This is an overloaded intrinsic. You can use llvm.expect on any integer bit
+width._
+Shall we put a dependency on SPV_INTEL_arbitrary_precision_integers extension?
+
+Resolution:
+
+No need.
+
+Revision History
+----------------
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Rev|Date|Author|Changes
+|A|2020-04-02|Dmitry Sidorov|Initial revision
+|B|2020-04-03|Dmitry Sidorov|Switch Expected from Decoration to instruction
+|C|2020-04-07|Dmitry Sidorov|Apply Alexey's suggestions
+|D|2020-04-08|Dmitry Sidorov|Rename the extension to SPV_INTEL_optimization_hints
+|E|2020-04-08|Dmitry Sidorov|Assign reserved values
+|========================================
+

--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
@@ -119,7 +119,7 @@ In section 3.20 "Decoration", update or add
 [options="header"]
 |====
 2+^| Decoration	^| Enabling Capabilities
-| TBD | *AssumeTrueINTEL* +
+| 5630 | *AssumeTrueINTEL* +
 Applies to a _Condition_ of a _Boolean Type_. Allows an optimizer to assume that
 the provided _Condition_ is true.
 | *OptimizationHintsINTEL*
@@ -135,7 +135,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 [options="header"]
 |====
 2+^| Capability ^| Depends On
-| TBD | *OptimizationHintsINTEL* +
+| 5629 | *OptimizationHintsINTEL* +
 Allow to use AssumeTrueINTEL decoration and ExpectINTEL instruction |
 |====
 --
@@ -159,7 +159,7 @@ which shall be of _Integer_ or _Boolean_ type.
 | Capability:
 *OptimizationHintsINTEL*
 
-| 5 | TBD | <id> +
+| 5 | 5631 | <id> +
 Result Type | Result <id> | Value <id> | ExpectedValue <id>
 |=====
 

--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
@@ -110,22 +110,6 @@ Token Number Assignments
 Modifications to the SPIR-V Specification, Version 1.5
 ------------------------------------------------------
 
-Decorations
-~~~~~~~~~~~
-
-In section 3.20 "Decoration", update or add
-
---
-[options="header"]
-|====
-2+^| Decoration	^| Enabling Capabilities
-| 5630 | *AssumeTrueINTEL* +
-Applies to a _Condition_ of a _Boolean Type_. Allows an optimizer to assume that
-the provided _Condition_ is true.
-| *OptimizationHintsINTEL*
-|====
---
-
 Capabilities
 ~~~~~~~~~~~~
 
@@ -145,6 +129,20 @@ Instructions
 
 In section 3.32.1, Miscellaneous Instructions, add a new instruction:
 
+[cols="3", width="100%"]
+|=====
+2+^|*OpAssumeTrueINTEL* +
+The instruction allows the optimizer to assume that the provided _Condition_ is
+always true whenever the control flow reaches the instruction call. If the
+_Condition_ is violated during execution, the behavior is undefined.
+
+The type of _Condition_ shall be _Boolean_.
+| Capability:
+*OptimizationHintsINTEL*
+
+| 2 | 5630 | Condition <id>
+|=====
+
 [cols="6", width="100%"]
 |=====
 5+^|*OpExpectINTEL* +
@@ -162,7 +160,6 @@ which shall be of _Integer_ or _Boolean_ type.
 | 5 | 5631 | <id> +
 Result Type | Result <id> | Value <id> | ExpectedValue <id>
 |=====
-
 
 Issues
 ------
@@ -189,5 +186,6 @@ Revision History
 |C|2020-04-07|Dmitry Sidorov|Apply Alexey's suggestions
 |D|2020-04-08|Dmitry Sidorov|Rename the extension to SPV_INTEL_optimization_hints
 |E|2020-04-08|Dmitry Sidorov|Assign reserved values
+|F|2020-04-30|Dmitry Sidorov|Switch AssumeTrue from Decoration to instruction
 |========================================
 

--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
@@ -44,8 +44,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2020-04-27
-| Revision           | E
+| Last Modified Date | 2020-05-12
+| Revision           | G
 |========================================
 
 Dependencies
@@ -59,8 +59,8 @@ This extension requires SPIR-V 1.0.
 Overview
 --------
 
-This extension adds *AssumeTrueINTEL* and *OpExpectINTEL* instructions that are
-appropriately mapped on ‘llvm.assume’ and ‘llvm.expect’ intrinsics. That is
+This extension adds *OpAssumeTrueINTEL* and *OpExpectINTEL* instructions that
+are mapped to ‘llvm.assume’ and ‘llvm.expect’ intrinsics respectively. That is
 required to save optimization hints through LLVM IR to SPIR-V transformation.
 
 Extension Name
@@ -86,8 +86,8 @@ New Instructions
 Instructions added under the *OptimizationHintsINTEL* capability:
 
 ----
-ExpectINTEL
-AssumeTrueINTEL
+OpExpectINTEL
+OpAssumeTrueINTEL
 ----
 
 Token Number Assignments
@@ -95,7 +95,7 @@ Token Number Assignments
 [width="45%",cols="30,15"]
 |===============================
 | OptimizationHintsINTEL | 5629
-| AssumeTrueINTEL        | 5630
+| OpAssumeTrueINTEL      | 5630
 | OpExpectINTEL          | 5631
 |===============================
 
@@ -112,7 +112,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 |====
 2+^| Capability ^| Depends On
 | 5629 | *OptimizationHintsINTEL* +
-Allow to use AssumeTrueINTEL and ExpectINTEL instructions |
+Allow to use OpAssumeTrueINTEL and OpExpectINTEL instructions |
 |====
 --
 
@@ -125,7 +125,7 @@ In section 3.32.1, Miscellaneous Instructions, add a new instruction:
 |=====
 2+^|*OpAssumeTrueINTEL* +
 The instruction allows the optimizer to assume that the provided _Condition_ is
-always true whenever the control flow reaches the instruction call. If the
+always true whenever the control flow reaches the instruction. If the
 _Condition_ is violated during execution, the behavior is undefined.
 
 The type of _Condition_ shall be _Boolean_.
@@ -179,5 +179,6 @@ Revision History
 |D|2020-04-08|Dmitry Sidorov|Rename the extension to SPV_INTEL_optimization_hints
 |E|2020-04-08|Dmitry Sidorov|Assign reserved values
 |F|2020-04-30|Dmitry Sidorov|Switch AssumeTrue from Decoration to instruction
+|G|2020-05-12|Dmitry Sidorov|Fix typos
 |========================================
 

--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
@@ -59,10 +59,9 @@ This extension requires SPIR-V 1.0.
 Overview
 --------
 
-This extension adds a decoration *AssumeTrueINTEL* and an instruction
-*OpExpectINTEL* that are appropriately mapped on ‘llvm.assume’ and ‘llvm.expect’
-intrinsics. That is required to save optimization hints through LLVM IR to
-SPIR-V transformation.
+This extension adds *AssumeTrueINTEL* and *OpExpectINTEL* instructions that are
+appropriately mapped on ‘llvm.assume’ and ‘llvm.expect’ intrinsics. That is
+required to save optimization hints through LLVM IR to SPIR-V transformation.
 
 Extension Name
 --------------
@@ -88,13 +87,6 @@ Instructions added under the *OptimizationHintsINTEL* capability:
 
 ----
 ExpectINTEL
-----
-
-New Decorations
----------------
-Decorations added under the *OptimizationHintsINTEL* capability:
-
-----
 AssumeTrueINTEL
 ----
 
@@ -120,7 +112,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 |====
 2+^| Capability ^| Depends On
 | 5629 | *OptimizationHintsINTEL* +
-Allow to use AssumeTrueINTEL decoration and ExpectINTEL instruction |
+Allow to use AssumeTrueINTEL and ExpectINTEL instructions |
 |====
 --
 

--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_optimization_hints.asciidoc
@@ -128,7 +128,7 @@ The instruction allows the optimizer to assume that the provided _Condition_ is
 always true whenever the control flow reaches the instruction. If the
 _Condition_ is violated during execution, the behavior is undefined.
 
-The type of _Condition_ shall be _Boolean_.
+The type of _Condition_ must be _Boolean_.
 | Capability:
 *OptimizationHintsINTEL*
 
@@ -144,7 +144,7 @@ _ExpectedValue_. This instruction can be safely replaced with an entity
 referenced by _Value_.
 
 The type of _Value_ and _ExpectedValue_ must be the same as _Result Type_,
-which shall be of _Integer_ or _Boolean_ type.
+which must be of _Integer_ or _Boolean_ type.
 
 | Capability:
 *OptimizationHintsINTEL*


### PR DESCRIPTION
This extension enables analogs of llvm.assume and llvm.expect
intrinsics in SPIR-V.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>