### PR TITLE
[SYCL] Refactored scheduler unit tests

### DIFF
--- a/sycl/unittests/scheduler/FailedCommands.cpp
+++ b/sycl/unittests/scheduler/FailedCommands.cpp
@@ -7,38 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "SchedulerTest.hpp"
-
-#include <CL/cl.h>
-#include <CL/sycl.hpp>
-#include <detail/scheduler/scheduler.hpp>
-
-#include <gtest/gtest.h>
+#include "SchedulerTestUtils.hpp"
 
 using namespace cl::sycl;
 
-class MockCommand : public detail::Command {
-public:
-  MockCommand(detail::QueueImplPtr Queue)
-      : Command(detail::Command::ALLOCA, Queue) {}
-  void printDot(std::ostream &Stream) const override {}
-  void emitInstrumentationData() override {}
-  cl_int enqueueImp() override { return CL_SUCCESS; }
-};
-
-class MockScheduler : public detail::Scheduler {
-public:
-  static bool enqueueCommand(detail::Command *Cmd,
-                             detail::EnqueueResultT &EnqueueResult,
-                             detail::BlockingT Blocking) {
-    return GraphProcessor::enqueueCommand(Cmd, EnqueueResult, Blocking);
-  }
-};
-
 TEST_F(SchedulerTest, FailedDependency) {
-  detail::Requirement MockReq(/*Offset*/ {0, 0, 0}, /*AccessRange*/ {1, 1, 1},
-                              /*MemoryRange*/ {1, 1, 1},
-                              access::mode::read_write, /*SYCLMemObjT*/ nullptr,
-                              /*Dims*/ 1, /*ElementSize*/ 1);
+  detail::Requirement MockReq = getMockRequirement();
   MockCommand MDep(detail::getSyclObjImpl(MQueue));
   MockCommand MUser(detail::getSyclObjImpl(MQueue));
   MDep.addUser(&MUser);

--- a/sycl/unittests/scheduler/utils.cpp
+++ b/sycl/unittests/scheduler/utils.cpp
@@ -13,3 +13,13 @@ void addEdge(cl::sycl::detail::Command *User, cl::sycl::detail::Command *Dep,
   User->addDep(cl::sycl::detail::DepDesc{Dep, User->getRequirement(), Alloca});
   Dep->addUser(User);
 }
+
+cl::sycl::detail::Requirement getMockRequirement() {
+  return {/*Offset*/ {0, 0, 0},
+          /*AccessRange*/ {0, 0, 0},
+          /*MemoryRange*/ {0, 0, 0},
+          /*AccessMode*/ cl::sycl::access::mode::read_write,
+          /*SYCLMemObj*/ nullptr,
+          /*Dims*/ 0,
+          /*ElementSize*/ 0};
+}


### PR DESCRIPTION
In all test cases almost the same structures which represents
the same object/entity (e.g. MockCommand) are used.
Test cases should reuse what already exists.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>