### PR TITLE
[SYCL] Fix failing ABI tests when LLVM_LIBDIR_SUFFIX is set

### DIFF
--- a/sycl/test/abi/sycl_symbols_linux.dump
+++ b/sycl/test/abi/sycl_symbols_linux.dump
@@ -1,4 +1,4 @@
-# RUN: env LLVM_BIN_PATH=%llvm_build_bin_dir python %sycl_tools_src_dir/abi_check.py --mode check_symbols --reference %s %llvm_build_lib_dir/libsycl.so
+# RUN: env LLVM_BIN_PATH=%llvm_build_bin_dir python %sycl_tools_src_dir/abi_check.py --mode check_symbols --reference %s %sycl_libs_dir/libsycl.so
 # REQUIRES: linux
 
 _Z20__spirv_ocl_prefetchPKcm

--- a/sycl/test/tools/abi_check_negative.dump
+++ b/sycl/test/tools/abi_check_negative.dump
@@ -1,4 +1,4 @@
-# RUN: not env LLVM_BIN_PATH=%llvm_build_bin_dir python %sycl_tools_src_dir/abi_check.py --mode check_symbols --reference %s %llvm_build_lib_dir/libsycl.so | FileCheck %s
+# RUN: not env LLVM_BIN_PATH=%llvm_build_bin_dir python %sycl_tools_src_dir/abi_check.py --mode check_symbols --reference %s %sycl_libs_dir/libsycl.so | FileCheck %s
 # REQUIRES: linux
 
 # CHECK: The following symbols are missing from the new object file:


### PR DESCRIPTION
Make ABI tests look for libsycl in the correct directory.