### PR TITLE
[SYCL][AOT] Define CL_TARGET_OPENCL_VERSION to OpenCL 2.2

### DIFF
--- a/opencl-aot/CMakeLists.txt
+++ b/opencl-aot/CMakeLists.txt
@@ -25,6 +25,7 @@ if (NOT OpenCL_INCLUDE_DIRS)
             STEP_TARGETS build
             COMMENT "Downloading OpenCL headers."
             )
+    add_definitions(-DCL_TARGET_OPENCL_VERSION=220)
 else ()
     add_custom_target(opencl-headers ALL
             DEPENDS ${OpenCL_INCLUDE_DIRS}

--- a/opencl-aot/source/utils.cpp
+++ b/opencl-aot/source/utils.cpp
@@ -140,14 +140,18 @@ std::string getOpenCLErrorNameByErrorCode(cl_int CLErr) {
     return "CL_INVALID_LINKER_OPTIONS";
   case CL_INVALID_DEVICE_PARTITION_COUNT:
     return "CL_INVALID_DEVICE_PARTITION_COUNT";
+#ifdef CL_VERSION_2_0
   case CL_INVALID_PIPE_SIZE:
     return "CL_INVALID_PIPE_SIZE";
   case CL_INVALID_DEVICE_QUEUE:
     return "CL_INVALID_DEVICE_QUEUE";
+#endif
+#ifdef CL_VERSION_2_2
   case CL_INVALID_SPEC_ID:
     return "CL_INVALID_SPEC_ID";
   case CL_MAX_SIZE_RESTRICTION_EXCEEDED:
     return "CL_MAX_SIZE_RESTRICTION_EXCEEDED";
+#endif
   default:
     return "Unknown error code";
   }

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -82,6 +82,7 @@ if( NOT OpenCL_INCLUDE_DIRS )
     STEP_TARGETS      build
     COMMENT           "Downloading OpenCL headers."
   )
+  add_definitions(-DCL_TARGET_OPENCL_VERSION=220)
 else()
   add_custom_target( ocl-headers ALL
     DEPENDS ${OpenCL_INCLUDE_DIRS}

--- a/sycl/include/CL/sycl/backend/opencl.hpp
+++ b/sycl/include/CL/sycl/backend/opencl.hpp
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include <CL/cl.h>
 #include <CL/sycl/accessor.hpp>
 #include <CL/sycl/backend_types.hpp>
+#include <CL/sycl/detail/cl.h>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {

--- a/sycl/include/CL/sycl/detail/aligned_allocator.hpp
+++ b/sycl/include/CL/sycl/detail/aligned_allocator.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <CL/cl.h>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/range.hpp>

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <CL/cl.h>
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common.hpp>

--- a/sycl/include/CL/sycl/detail/cl.h
+++ b/sycl/include/CL/sycl/detail/cl.h
@@ -1,0 +1,18 @@
+//==---------------- cl.h - Include OpenCL headers -------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+// Suppress a compiler message about undefined CL_TARGET_OPENCL_VERSION
+// and define all symbols up to OpenCL 2.2
+#ifndef CL_TARGET_OPENCL_VERSION
+#define CL_TARGET_OPENCL_VERSION 220
+#endif
+
+#include <CL/cl.h>
+#include <CL/cl_ext.h>

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -8,12 +8,10 @@
 
 #pragma once
 
+#include <CL/cl_ext_intel.h>
+#include <CL/sycl/detail/cl.h>
 #include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/detail/export.hpp>
-
-#include <CL/cl.h>
-#include <CL/cl_ext.h>
-#include <CL/cl_ext_intel.h>
 
 #include <cstdint>
 #include <string>

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -11,9 +11,6 @@
 #include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/detail/export.hpp>
 
-// Suppress a compiler warning about undefined CL_TARGET_OPENCL_VERSION
-// Khronos ICD supports only latest OpenCL version
-#define CL_TARGET_OPENCL_VERSION 220
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
 #include <CL/cl_ext_intel.h>

--- a/sycl/include/CL/sycl/detail/memory_manager.hpp
+++ b/sycl/include/CL/sycl/detail/memory_manager.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <CL/cl.h>
 #include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/cl.h>
 #include <CL/sycl/detail/export.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_i.hpp>
 #include <CL/sycl/range.hpp>

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -45,9 +45,9 @@
 // TODO: we need a mapping of PI to OpenCL somewhere, and this can be done
 // elsewhere, e.g. in the pi_opencl, but constants/enums mapping is now
 // done here, for efficiency and simplicity.
-//
+
 #include <CL/cl_usm_ext.h>
-#include <CL/opencl.h>
+#include <CL/sycl/detail/cl.h>
 #include <cstdint>
 
 #ifdef __cplusplus

--- a/sycl/include/CL/sycl/detail/usm_impl.hpp
+++ b/sycl/include/CL/sycl/detail/usm_impl.hpp
@@ -7,8 +7,8 @@
 // ===--------------------------------------------------------------------=== //
 #pragma once
 
-#include <CL/cl.h>
 #include <CL/cl_usm_ext.h>
+#include <CL/sycl/detail/cl.h>
 #include <CL/sycl/detail/export.hpp>
 #include <CL/sycl/usm/usm_enums.hpp>
 

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -14,7 +14,7 @@
 ///
 /// \ingroup sycl_pi_ocl
 
-#include "CL/opencl.h"
+#include <CL/sycl/detail/cl.h>
 #include <CL/sycl/detail/pi.h>
 
 #include <cassert>

--- a/sycl/source/detail/common.cpp
+++ b/sycl/source/detail/common.cpp
@@ -160,14 +160,18 @@ const char *stringifyErrorCode(cl_int error) {
       return "CL_INVALID_LINKER_OPTIONS";
     case CL_INVALID_DEVICE_PARTITION_COUNT:
       return "CL_INVALID_DEVICE_PARTITION_COUNT";
+#ifdef CL_VERSION_2_0
     case CL_INVALID_PIPE_SIZE:
       return "CL_INVALID_PIPE_SIZE";
     case CL_INVALID_DEVICE_QUEUE:
       return "CL_INVALID_DEVICE_QUEUE";
+#endif
+#ifdef CL_VERSION_2_2
     case CL_INVALID_SPEC_ID:
       return "CL_INVALID_SPEC_ID";
     case CL_MAX_SIZE_RESTRICTION_EXCEEDED:
       return "CL_MAX_SIZE_RESTRICTION_EXCEEDED";
+#endif
     /*
         case CL_BUILD_NONE:
           return "CL_BUILD_NONE";

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -9,8 +9,8 @@
 #include <detail/error_handling/error_handling.hpp>
 
 #include "CL/sycl/access/access.hpp"
-#include <CL/cl.h>
 #include <CL/sycl/backend_types.hpp>
+#include <CL/sycl/detail/cl.h>
 #include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/detail/stream_impl.hpp>

--- a/sycl/tools/get_device_count_by_type.cpp
+++ b/sycl/tools/get_device_count_by_type.cpp
@@ -6,6 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Suppress a compiler warning about undefined CL_TARGET_OPENCL_VERSION
+// and define all symbols up to OpenCL 2.2
+#ifndef CL_TARGET_OPENCL_VERSION
+#define CL_TARGET_OPENCL_VERSION 220
+#endif
+
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
 

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#include <CL/cl.h>
 #include <CL/sycl.hpp>
+#include <CL/sycl/detail/cl.h>
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/scheduler.hpp>
 


### PR DESCRIPTION
When using the Khronos OpenCL headers from GitHub, set the preprocessor
symbol CL_TARGET_OPENCL_VERSION=220 to silence the compilation warning
from the OpenCL header files, and define all OpenCL 2.2 symbols.

Include the OpenCL headers through CL/sycl/detail/cl.h, and define
the CL_TARGET_OPENCL_VERSION to 220 (OpenCL 2.2) by default.

Protect the use of OpenCL 2.0 and 2.2 symbols with the relevant #ifdef.