### PR TITLE
[NFC][SYCL] Improve kernel metadata test

### DIFF
--- a/clang/test/CodeGenSYCL/kernel-metadata.cpp
+++ b/clang/test/CodeGenSYCL/kernel-metadata.cpp
@@ -16,8 +16,8 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 int main() {
   cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write> accessorA;
   kernel_single_task<class kernel_function>(
-    [=]() {
-      accessorA.use();
-  });
+      [=]() {
+        accessorA.use();
+      });
   return 0;
 }

--- a/clang/test/CodeGenSYCL/kernel-metadata.cpp
+++ b/clang/test/CodeGenSYCL/kernel-metadata.cpp
@@ -8,14 +8,9 @@
 
 #include "sycl.hpp"
 
-template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
-  kernelFunc();
-}
-
 int main() {
   cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write> accessorA;
-  kernel_single_task<class kernel_function>(
+  cl::sycl::kernel_single_task<class kernel_function>(
       [=]() {
         accessorA.use();
       });

--- a/clang/test/CodeGenSYCL/kernel-metadata.cpp
+++ b/clang/test/CodeGenSYCL/kernel-metadata.cpp
@@ -1,7 +1,12 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -I %S/Inputs -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
 
-// CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE15kernel_function() {{[^{]+}} !kernel_arg_addr_space ![[MD:[0-9]+]] !kernel_arg_access_qual ![[MD]] !kernel_arg_type ![[MD]] !kernel_arg_base_type ![[MD]] !kernel_arg_type_qual ![[MD]]
-// CHECK: ![[MD]] = !{}
+// CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE15kernel_function{{.*}} !kernel_arg_addr_space ![[MDAS:[0-9]+]] !kernel_arg_access_qual ![[MDAC:[0-9]+]] !kernel_arg_type ![[MDAT:[0-9]+]] !kernel_arg_base_type ![[MDAT:[0-9]+]] !kernel_arg_type_qual ![[MDATQ:[0-9]+]]
+// CHECK: ![[MDAS]] = !{i32 1, i32 0, i32 0, i32 0}
+// CHECK: ![[MDAC]] = !{!"none", !"none", !"none", !"none"}
+// CHECK: ![[MDAT]] = !{!"int*", !"cl::sycl::range<1>", !"cl::sycl::range<1>", !"cl::sycl::id<1>"}
+// CHECK: ![[MDATQ]] = !{!"", !"", !"", !""}
+
+#include "sycl.hpp"
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
@@ -9,6 +14,10 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 }
 
 int main() {
-  kernel_single_task<class kernel_function>([]() {});
+  cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write> accessorA;
+  kernel_single_task<class kernel_function>(
+    [=]() {
+      accessorA.use();
+  });
   return 0;
 }


### PR DESCRIPTION
There was a bug in kernel_arg_addr_space metadata generation
(SYCL addr spaces were ignored), that was fixed in ac94b1eb537.
Expand the test accordingly.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>