### PR TITLE
[SYCL][CUDA] Fix LIT fails on machines without non-NVIDIA OpenCL

### DIFF
--- a/sycl/test/Unit/lit.cfg.py
+++ b/sycl/test/Unit/lit.cfg.py
@@ -66,3 +66,6 @@ for shlibpath_var in find_shlibpath_var():
 else:
     lit_config.warning("unable to inject shared library path on '{}'"
                        .format(platform.system()))
+
+config.environment['SYCL_BE'] = lit_config.params.get('SYCL_BE', "PI_OPENCL")
+lit_config.note("Backend (SYCL_BE): {}".format(config.environment['SYCL_BE']))

--- a/sycl/test/basic_tests/diagnostics/device-check.cpp
+++ b/sycl/test/basic_tests/diagnostics/device-check.cpp
@@ -1,17 +1,17 @@
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=cpu %t.out
-// RUN: env SYCL_DEVICE_TYPE=gpu %t.out
-// RUN: env SYCL_DEVICE_TYPE=acc %t.out
-// RUN: env SYCL_DEVICE_TYPE=host %t.out
-// RUN: env SYCL_DEVICE_TYPE=CPU %t.out
-// RUN: env SYCL_DEVICE_TYPE=GPU %t.out
-// RUN: env SYCL_DEVICE_TYPE=ACC %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: env SYCL_DEVICE_TYPE=Cpu %t.out
-// RUN: env SYCL_DEVICE_TYPE=Gpu %t.out
-// RUN: env SYCL_DEVICE_TYPE=Acc %t.out
-// RUN: env SYCL_DEVICE_TYPE=Host %t.out
-// RUN: env SYCL_DEVICE_TYPE=XPU %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=cpu %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=gpu %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=acc %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=host %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=CPU %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=GPU %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=ACC %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=Cpu %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=Gpu %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=Acc %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=Host %t.out
+// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=XPU %t.out
 
 //==------------------- device-check.cpp --------------------------==//
 // This is a diagnostic test which ensures that

--- a/sycl/test/basic_tests/diagnostics/handler.cpp
+++ b/sycl/test/basic_tests/diagnostics/handler.cpp
@@ -1,10 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out | FileCheck %s
-// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
-// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// RUN: %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
+// RUN: env SYCL_BE=%sycl_be %t.out | FileCheck %s
 //==------------------- handler.cpp ----------------------------------------==//
-//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -12,12 +8,11 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl.hpp>
+#include <cassert>
 
 using namespace cl;
 
 int main() {
-
-  bool Failed = false;
 
   sycl::queue Queue([](sycl::exception_list ExceptionList) {
     if (ExceptionList.size() != 1) {
@@ -33,8 +28,9 @@ int main() {
       CGH.single_task<class Dummy2>([]() {});
     });
     Queue.throw_asynchronous();
-  } catch (sycl::exception &E) {
+    assert(!"Expected exception not caught");
+  } catch (sycl::exception &ExpectedException) {
     // CHECK: Attempt to set multiple actions for the command group
-    std::cout << E.what() << std::endl;
+    std::cout << ExpectedException.what() << std::endl;
   }
 }

--- a/sycl/test/basic_tests/diagnostics/handler.cpp
+++ b/sycl/test/basic_tests/diagnostics/handler.cpp
@@ -1,5 +1,8 @@
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %t.out | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out | FileCheck %s
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
 //==------------------- handler.cpp ----------------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/get_nonhost_devices.cpp
+++ b/sycl/test/basic_tests/get_nonhost_devices.cpp
@@ -1,6 +1,6 @@
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %t.out
-
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_BE=%sycl_be %t.out
+//
 // Check that the host device is not included in devices returned by
 // get_devices() if a non-host device type is specified.
 

--- a/sycl/test/basic_tests/queue.cpp
+++ b/sycl/test/basic_tests/queue.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
 //==--------------- queue.cpp - SYCL queue test ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/queue.cpp
+++ b/sycl/test/basic_tests/queue.cpp
@@ -1,8 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: env SYCL_BE=%sycl_be %t.out
 //==--------------- queue.cpp - SYCL queue test ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -74,6 +74,7 @@ llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 
 backend=lit_config.params.get('SYCL_BE', "PI_OPENCL")
 lit_config.note("Backend: {BACKEND}".format(BACKEND=backend))
+config.substitutions.append( ('%sycl_be', backend) )
 
 get_device_count_by_type_path = os.path.join(config.llvm_tools_dir, "get_device_count_by_type")
 

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -73,7 +73,7 @@ llvm_config.use_clang()
 llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 
 backend=lit_config.params.get('SYCL_BE', "PI_OPENCL")
-lit_config.note("Backend: {BACKEND}".format(BACKEND=backend))
+lit_config.note("Backend (SYCL_BE): {}".format(backend))
 config.substitutions.append( ('%sycl_be', backend) )
 
 get_device_count_by_type_path = os.path.join(config.llvm_tools_dir, "get_device_count_by_type")


### PR DESCRIPTION
We are observing LIT fails on machines that only have the NVIDIA OpenCL, even if running for the SYCL PI CUDA backend.

These commits try to fix the problem but still require testing.