### PR TITLE
[SYCL] Load PI plugins only once

### DIFF
--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -197,7 +197,12 @@ bool trace(TraceLevel Level) {
 
 // Initializes all available Plugins.
 vector_class<plugin> initialize() {
-  vector_class<plugin> Plugins;
+  static bool PluginsInitDone = false;
+  static vector_class<plugin> Plugins;
+  if (PluginsInitDone) {
+    return Plugins;
+  }
+
   vector_class<std::pair<std::string, backend>> PluginNames;
   findPlugins(PluginNames);
 
@@ -244,6 +249,7 @@ vector_class<plugin> initialize() {
                 << "Plugin found and successfully loaded: "
                 << PluginNames[I].first << std::endl;
   }
+  PluginsInitDone = true;
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   if (!(xptiTraceEnabled() && !XPTIInitDone))


### PR DESCRIPTION
Stop re-loading PI plugins on every invocation of get_platforms().
Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>