### PR TITLE
[SYCL] Add separate codeowner for CUDA plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,6 +75,7 @@ sycl/source/half_type.cpp @AlexeySachkov
 sycl/include/CL/sycl/swizzles.def @turinevgeny
 sycl/include/CL/sycl/types.hpp @turinevgeny
 
+sycl/plugins/cuda/ @intel/llvm-reviewers-cuda
 
 sycl/doc/ @pvchupin @kbobrovs
 


### PR DESCRIPTION
Signed-off-by: Vlad Romanov <vlad.romanov@intel.com>