### PR TITLE
[SYCL][CUDA] Triage and clean LIT

### DIFF
--- a/sycl/test/basic_tests/image.cpp
+++ b/sycl/test/basic_tests/image.cpp
@@ -1,11 +1,10 @@
+// UNSUPPORTED: cuda
+// CUDA cannot support SYCL 1.2.1 images.
+//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-
-// TODO: No CUDA image support
-// TODO: ptxas fatal   : Unresolved extern function '_Z17__spirv_ImageReadIDv4_f14ocl_image2d_roDv2_iET_T0_T1_'
-// XFAIL: cuda
 
 //==------------------- image.cpp - SYCL image basic test -----------------==//
 //

--- a/sycl/test/basic_tests/image_accessor_readsampler.cpp
+++ b/sycl/test/basic_tests/image_accessor_readsampler.cpp
@@ -1,8 +1,10 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// UNSUPPORTED: cuda
+// CUDA cannot support SYCL 1.2.1 images.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// REQUIRES: opencl
 //==------------------- image_accessor_readsampler.cpp ---------------------==//
 //==-----------------image_accessor read API test with sampler--------------==//
 //

--- a/sycl/test/basic_tests/image_accessor_readwrite.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite.cpp
@@ -1,9 +1,11 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// UNSUPPORTED: cuda
+// CUDA cannot support SYCL 1.2.1 images.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: cuda
 //==--------------------image_accessor_readwrite.cpp ----------------------==//
 //==----------image_accessor read without sampler & write API test---------==//
 //

--- a/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
+++ b/sycl/test/basic_tests/image_accessor_readwrite_half.cpp
@@ -1,9 +1,11 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// UNSUPPORTED: cuda
+// CUDA cannot support SYCL 1.2.1 images.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: cuda
 //==--------------------image_accessor_readwrite_half.cpp -------------------==//
 //==-image_accessor read (without sampler)& write API test for half datatype-==//
 //

--- a/sycl/test/basic_tests/image_array.cpp
+++ b/sycl/test/basic_tests/image_array.cpp
@@ -1,11 +1,10 @@
+// UNSUPPORTED: cuda
+// CUDA cannot support SYCL 1.2.1 images.
+//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUNx: %GPU_RUN_PLACEHOLDER %t.out
-
-// TODO: No CUDA image support
-// TODO: ptxas fatal   : Unresolved extern function '_Z17__spirv_ImageReadIDv4_f14ocl_image2d_roDv2_iET_T0_T1_'
-// XFAIL: cuda
 
 //==------------------- image.cpp - SYCL image basic test -----------------==//
 //

--- a/sycl/test/basic_tests/image_constructors.cpp
+++ b/sycl/test/basic_tests/image_constructors.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: cuda
+// CUDA cannot support SYCL 1.2.1 images.
+//
 // RUN: %clangxx %s -o %t1.out -lsycl -I %sycl_include
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out

--- a/sycl/test/basic_tests/stream/auto_flush.cpp
+++ b/sycl/test/basic_tests/stream/auto_flush.cpp
@@ -1,10 +1,8 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // TODO: Enable on host when commands cleanup will be implemented in scheduler
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_ON_LINUX_PLACEHOLDER %t.out %GPU_CHECK_ON_LINUX_PLACEHOLDER
 // RUN: %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
-// XFAIL: cuda
-// cuda fail due to unimplemented param_name 4131 in cuda_piDeviceGetInfo
 //==-------------- copy.cpp - SYCL stream obect auto flushing test ---------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/built-ins/printf.cpp
+++ b/sycl/test/built-ins/printf.cpp
@@ -1,10 +1,11 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// UNSUPPORTED: cuda
+// CUDA does not support printf.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out | FileCheck %s
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
-
-// XFAIL: cuda
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test/device-code-split/aot-gpu.cpp
+++ b/sycl/test/device-code-split/aot-gpu.cpp
@@ -1,6 +1,11 @@
 // REQUIRES: ocloc, gpu
-
-// RUN: %clangxx -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" -I %S/Inputs -o %t.out %S/split-per-source-main.cpp %S/Inputs/split-per-source-second-file.cpp
+// UNSUPPORTED: cuda
+// CUDA does neither support device code splitting nor SPIR.
+//
+// RUN: %clangxx -fsycl -fsycl-device-code-split=per_source \
+// RUN:   -fsycl-targets=spir64_gen-unknown-unknown-sycldevice \
+// RUN:   -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice \
+// RUN:   "-device skl" -I %S/Inputs -o %t.out \
+// RUN:   %S/split-per-source-main.cpp \
+// RUN:   %S/Inputs/split-per-source-second-file.cpp
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-
-// XFAIL: cuda

--- a/sycl/test/device-code-split/split-per-kernel.cpp
+++ b/sycl/test/device-code-split/split-per-kernel.cpp
@@ -1,9 +1,10 @@
-// RUN: %clangxx -fsycl -fsycl-device-code-split=per_kernel -o %t.out %s
+// UNSUPPORTED: cuda
+// CUDA does not support device code splitting.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-device-code-split=per_kernel -o %t.out %s
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-
-// XFAIL: cuda
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test/device-code-split/split-per-source-main.cpp
+++ b/sycl/test/device-code-split/split-per-source-main.cpp
@@ -1,9 +1,10 @@
-// RUN: %clangxx -fsycl -fsycl-device-code-split=per_source -I %S/Inputs -o %t.out %s %S/Inputs/split-per-source-second-file.cpp
+// UNSUPPORTED: cuda
+// CUDA does not support device code splitting.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-device-code-split=per_source -I %S/Inputs -o %t.out %s %S/Inputs/split-per-source-second-file.cpp
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-
-// XFAIL: cuda
 
 #include "Inputs/split-per-source.h"
 

--- a/sycl/test/ordered_queue/oq_kernels.cpp
+++ b/sycl/test/ordered_queue/oq_kernels.cpp
@@ -1,9 +1,11 @@
-// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t.out
+// UNSUPPORTED: cuda
+// CUDA does not support unnamed lambdas.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-unnamed-lambda %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// XFAIL: cuda
 
 //==------ oq_kernels.cpp - SYCL ordered queue kernel shortcut test --------==//
 //

--- a/sycl/test/ordered_queue/ordered_buffs.cpp
+++ b/sycl/test/ordered_queue/ordered_buffs.cpp
@@ -1,10 +1,9 @@
 // REQUIRES: opencl
 
-// RUN: %clangxx -fsycl %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// XFAIL: cuda
 //==-------- ordered_buffs.cpp - SYCL buffers in ordered queues test--------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/ordered_queue/ordered_dmemll.cpp
+++ b/sycl/test/ordered_queue/ordered_dmemll.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl
 
-// RUN: %clangxx -fsycl %s -o %t1.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out -L %opencl_libs_dir -lOpenCL
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 //==----------- ordered_dmemll.cpp - Device Memory Linked List test --------==//

--- a/sycl/test/ordered_queue/ordered_queue.cpp
+++ b/sycl/test/ordered_queue/ordered_queue.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl
 //
-// RUN: %clangxx -fsycl %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 //==---------- ordered_queue.cpp - SYCL ordered queue test -----------------==//
 //

--- a/sycl/test/ordered_queue/prop.cpp
+++ b/sycl/test/ordered_queue/prop.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl
 
-// RUN: %clangxx -fsycl %s -o %t1.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out -L %opencl_libs_dir -lOpenCL
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 

--- a/sycl/test/separate-compile/sycl-external.cpp
+++ b/sycl/test/separate-compile/sycl-external.cpp
@@ -1,8 +1,8 @@
 // Test1 - check that kernel can call a SYCL_EXTERNAL function defined in a
 // different object file.
-// RUN: %clangxx -fsycl -DSOURCE1 -c %s -o %t1.o
-// RUN: %clangxx -fsycl -DSOURCE2 -c %s -o %t2.o
-// RUN: %clangxx -fsycl %t1.o %t2.o -o %t.exe
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSOURCE1 -c %s -o %t1.o
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSOURCE2 -c %s -o %t2.o
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %t1.o %t2.o -o %t.exe
 // RUN: %CPU_RUN_PLACEHOLDER %t.exe
 // RUN: %GPU_RUN_PLACEHOLDER %t.exe
 // RUN: %ACC_RUN_PLACEHOLDER %t.exe
@@ -11,11 +11,10 @@
 // static library.
 // RUN: rm -f %t.a
 // RUN: llvm-ar crv %t.a %t1.o
-// RUN: %clangxx -fsycl %t2.o -foffload-static-lib=%t.a -o %t.exe
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %t2.o -foffload-static-lib=%t.a -o %t.exe
 // RUN: %CPU_RUN_PLACEHOLDER %t.exe
 // RUN: %GPU_RUN_PLACEHOLDER %t.exe
 // RUN: %ACC_RUN_PLACEHOLDER %t.exe
-// XFAIL: cuda
 
 #include <CL/sycl.hpp>
 #include <iostream>


### PR DESCRIPTION
Fix some lit tests failing for CUDA by providing the -fsycl-targets
parameter.

Mark LIT tests failing due to features unsupported by CUDA as
UNSUPPORTED instead of XFAIL.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>