### PR TITLE
[SYCL] PI: correct default interoperability plugin selection

### DIFF
--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -228,12 +228,17 @@ vector_class<plugin> initialize() {
       continue;
     }
     backend *BE = SYCLConfig<SYCL_BE>::get();
-    if (!BE || (*BE == backend::opencl &&
-                PluginNames[I].first.find("opencl") != std::string::npos)) {
+    // Use OpenCL as the default interoperability plugin.
+    // This will go away when we make backend interoperability selection
+    // explicit in SYCL-2020.
+    backend InteropBE = BE ? *BE : backend::opencl;
+
+    if (InteropBE == backend::opencl &&
+        PluginNames[I].first.find("opencl") != std::string::npos) {
       // Use the OpenCL plugin as the GlobalPlugin
       GlobalPlugin =
           std::make_shared<plugin>(PluginInformation, backend::opencl);
-    } else if (*BE == backend::cuda &&
+    } else if (InteropBE == backend::cuda &&
                PluginNames[I].first.find("cuda") != std::string::npos) {
       // Use the CUDA plugin as the GlobalPlugin
       GlobalPlugin = std::make_shared<plugin>(PluginInformation, backend::cuda);


### PR DESCRIPTION
Fix the broken logic for the case when SYCL_BE is not specified.
Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>