### PR TITLE
[SYCL] Fix compilation warnings in libdevice

### DIFF
--- a/libdevice/device.h
+++ b/libdevice/device.h
@@ -9,10 +9,6 @@
 #ifndef __LIBDEVICE_DEVICE_H__
 #define __LIBDEVICE_DEVICE_H__
 
-// We need the following header to ensure the definition of all spirv variables
-// required by the wrapper libraries.
-#include "spirv_vars.hpp"
-
 #ifdef __cplusplus
 #define EXTERN_C extern "C"
 #else // __cplusplus
@@ -36,5 +32,9 @@
 #endif // CL_SYCL_LANGUAGE_VERSION
 
 #define DEVICE_EXTERN_C DEVICE_EXTERNAL EXTERN_C
+
+// We need the following header to ensure the definition of all spirv variables
+// required by the wrapper libraries.
+#include "spirv_vars.hpp"
 
 #endif // __LIBDEVICE_DEVICE_H__

--- a/libdevice/spirv_vars.hpp
+++ b/libdevice/spirv_vars.hpp
@@ -15,13 +15,13 @@
 
 #ifdef __SYCL_NVPTX__
 
-SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_x();
-SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_y();
-SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_z();
+DEVICE_EXTERNAL size_t __spirv_GlobalInvocationId_x();
+DEVICE_EXTERNAL size_t __spirv_GlobalInvocationId_y();
+DEVICE_EXTERNAL size_t __spirv_GlobalInvocationId_z();
 
-SYCL_EXTERNAL size_t __spirv_LocalInvocationId_x();
-SYCL_EXTERNAL size_t __spirv_LocalInvocationId_y();
-SYCL_EXTERNAL size_t __spirv_LocalInvocationId_z();
+DEVICE_EXTERNAL size_t __spirv_LocalInvocationId_x();
+DEVICE_EXTERNAL size_t __spirv_LocalInvocationId_y();
+DEVICE_EXTERNAL size_t __spirv_LocalInvocationId_z();
 
 #else // __SYCL_NVPTX__
 
@@ -29,23 +29,23 @@ typedef size_t size_t_vec __attribute__((ext_vector_type(3)));
 extern "C" const size_t_vec __spirv_BuiltInGlobalInvocationId;
 extern "C" const size_t_vec __spirv_BuiltInLocalInvocationId;
 
-SYCL_EXTERNAL inline size_t __spirv_GlobalInvocationId_x() {
+DEVICE_EXTERNAL inline size_t __spirv_GlobalInvocationId_x() {
   return __spirv_BuiltInGlobalInvocationId.x;
 }
-SYCL_EXTERNAL inline size_t __spirv_GlobalInvocationId_y() {
+DEVICE_EXTERNAL inline size_t __spirv_GlobalInvocationId_y() {
   return __spirv_BuiltInGlobalInvocationId.y;
 }
-SYCL_EXTERNAL inline size_t __spirv_GlobalInvocationId_z() {
+DEVICE_EXTERNAL inline size_t __spirv_GlobalInvocationId_z() {
   return __spirv_BuiltInGlobalInvocationId.z;
 }
 
-SYCL_EXTERNAL inline size_t __spirv_LocalInvocationId_x() {
+DEVICE_EXTERNAL inline size_t __spirv_LocalInvocationId_x() {
   return __spirv_BuiltInLocalInvocationId.x;
 }
-SYCL_EXTERNAL inline size_t __spirv_LocalInvocationId_y() {
+DEVICE_EXTERNAL inline size_t __spirv_LocalInvocationId_y() {
   return __spirv_BuiltInLocalInvocationId.y;
 }
-SYCL_EXTERNAL inline size_t __spirv_LocalInvocationId_z() {
+DEVICE_EXTERNAL inline size_t __spirv_LocalInvocationId_z() {
   return __spirv_BuiltInLocalInvocationId.z;
 }
 


### PR DESCRIPTION
Apply the `DEVICE_EXERNAL` attribute also to the function definitions,
not only to the function declarations.

Signed-off-by: Andrea Bocci <andrea.bocci@cern.ch>