### PR TITLE
[SYCL] Fix GCC 8 compilation warnings

### DIFF
--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -27,7 +27,7 @@ namespace detail {
 
 #define CONFIG(Name, MaxSize, CompileTimeDef)                                  \
   const char *SYCLConfigBase<Name>::MValueFromFile = nullptr;                  \
-  char SYCLConfigBase<Name>::MStorage[MaxSize];                                \
+  char SYCLConfigBase<Name>::MStorage[MaxSize + 1];                            \
   const char *const SYCLConfigBase<Name>::MCompileTimeDef =                    \
       getStrOrNullptr(STRINGIFY_LINE(CompileTimeDef));                         \
   const char *const SYCLConfigBase<Name>::MConfigName = STRINGIFY_LINE(Name);
@@ -40,6 +40,7 @@ static void initValue(const char *Key, const char *Value) {
 #define CONFIG(Name, MaxSize, CompileTimeDef)                                  \
   if (0 == strncmp(Key, SYCLConfigBase<Name>::MConfigName, MAX_CONFIG_NAME)) { \
     strncpy(SYCLConfigBase<Name>::MStorage, Value, MaxSize);                   \
+    SYCLConfigBase<Name>::MStorage[MaxSize] = '\0';                            \
     SYCLConfigBase<Name>::MValueFromFile = SYCLConfigBase<Name>::MStorage;     \
     return;                                                                    \
   }

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -63,7 +63,7 @@ template <ConfigID Config> class SYCLConfigBase;
   public:                                                                      \
     /*Preallocated storage for config value which is extracted from a config   \
      * file*/                                                                  \
-    static char MStorage[MaxSize];                                             \
+    static char MStorage[MaxSize + 1];                                         \
     /*Points to the storage if config is set in the file, nullptr otherwise*/  \
     static const char *MValueFromFile;                                         \
     /*The name of the config*/                                                 \


### PR DESCRIPTION
GCC 8 introduces a warning when strncpy may truncate a string, leaving
it without the terminating NULL character [-Wstringop-truncation].

To guarantee that the terminator is present:
  - increase the size of the target buffer by 1;
  - set the last character of the buffer to NULL.

Signed-off-by: Andrea Bocci <andrea.bocci@cern.ch>