### PR TITLE
[SYCL] Specialization constants: fix scope, allow redefinition and AOT.

### DIFF
--- a/sycl/include/CL/sycl/detail/device_binary_image.hpp
+++ b/sycl/include/CL/sycl/detail/device_binary_image.hpp
@@ -1,0 +1,64 @@
+//==----- device_binary_image.hpp --- SYCL device binary image abstraction -==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include <CL/sycl/detail/os_util.hpp>
+#include <CL/sycl/detail/pi.hpp>
+
+#include <memory>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace detail {
+
+// SYCL RT wrapper over PI binary image.
+class RTDeviceBinaryImage : public pi::DeviceBinaryImage {
+public:
+  RTDeviceBinaryImage(OSModuleHandle ModuleHandle)
+      : pi::DeviceBinaryImage(), ModuleHandle(ModuleHandle) {}
+  RTDeviceBinaryImage(pi_device_binary Bin, OSModuleHandle ModuleHandle)
+      : pi::DeviceBinaryImage(Bin), ModuleHandle(ModuleHandle) {}
+  OSModuleHandle getOSModuleHandle() const { return ModuleHandle; }
+
+  ~RTDeviceBinaryImage() override {}
+
+  bool supportsSpecConstants() const {
+    return getFormat() == PI_DEVICE_BINARY_TYPE_SPIRV;
+  }
+
+  const pi_device_binary_struct &getRawData() const { return *get(); }
+
+  void print() const override {
+    pi::DeviceBinaryImage::print();
+    std::cerr << "    OSModuleHandle=" << ModuleHandle << "\n";
+  }
+
+protected:
+  OSModuleHandle ModuleHandle;
+};
+
+// Dynamically allocated device binary image, which de-allocates its binary
+// data in destructor.
+class DynRTDeviceBinaryImage : public RTDeviceBinaryImage {
+public:
+  DynRTDeviceBinaryImage(std::unique_ptr<char[]> &&DataPtr, size_t DataSize,
+                         OSModuleHandle M);
+  ~DynRTDeviceBinaryImage() override;
+
+  void print() const override {
+    RTDeviceBinaryImage::print();
+    std::cerr << "    DYNAMICALLY CREATED\n";
+  }
+
+protected:
+  std::unique_ptr<char[]> Data;
+};
+
+} // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/spec_constant_impl.hpp
+++ b/sycl/include/CL/sycl/detail/spec_constant_impl.hpp
@@ -9,37 +9,43 @@
 #pragma once
 
 #include <CL/sycl/detail/defines.hpp>
+#include <CL/sycl/detail/util.hpp>
+#include <CL/sycl/stl.hpp>
 
 #include <iostream>
+#include <map>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
-// Represents a specialization constant in SYCL runtime.
+// Represents a specialization constant value in SYCL runtime.
 class spec_constant_impl {
 public:
-  spec_constant_impl(unsigned int ID) : ID(ID), Size(0), Bytes{0} {}
+  spec_constant_impl() = default;
 
-  spec_constant_impl(unsigned int ID, size_t Size, const void *Val) : ID(ID) {
-    set(Size, Val);
-  }
+  spec_constant_impl(size_t Size, const void *Val) { set(Size, Val); }
 
   void set(size_t Size, const void *Val);
 
-  unsigned int getID() const { return ID; }
   size_t getSize() const { return Size; }
   const unsigned char *getValuePtr() const { return Bytes; }
   bool isSet() const { return Size != 0; }
 
 private:
-  unsigned int ID; // specialization constant's ID (equals to SPIRV ID)
-  size_t Size;     // size of its value
+  size_t Size; // size of its value
   // TODO invent more flexible approach to support values of arbitrary type:
   unsigned char Bytes[8]; // memory to hold the value bytes
 };
 
 std::ostream &operator<<(std::ostream &Out, const spec_constant_impl &V);
+
+// Used to define specialization constant registry. Must be ordered map, since
+// the order of entries matters in stableSerializeSpecConstRegistry.
+using SpecConstRegistryT = std::map<string_class, spec_constant_impl>;
+
+void stableSerializeSpecConstRegistry(const SpecConstRegistryT &Reg,
+                                      SerializedObj &Dst);
 
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/detail/spec_constant_impl.hpp
+++ b/sycl/include/CL/sycl/detail/spec_constant_impl.hpp
@@ -22,7 +22,7 @@ namespace detail {
 // Represents a specialization constant value in SYCL runtime.
 class spec_constant_impl {
 public:
-  spec_constant_impl() = default;
+  spec_constant_impl() : Size(0), Bytes{0} {};
 
   spec_constant_impl(size_t Size, const void *Val) { set(Size, Val); }
 
@@ -33,7 +33,7 @@ public:
   bool isSet() const { return Size != 0; }
 
 private:
-  size_t Size; // size of its value
+  size_t Size; // the size of the spec constant value
   // TODO invent more flexible approach to support values of arbitrary type:
   unsigned char Bytes[8]; // memory to hold the value bytes
 };

--- a/sycl/include/CL/sycl/detail/util.hpp
+++ b/sycl/include/CL/sycl/detail/util.hpp
@@ -11,6 +11,7 @@
 #ifndef __SYCL_DEVICE_ONLY
 
 #include <CL/sycl/detail/defines.hpp>
+#include <CL/sycl/stl.hpp>
 
 #include <cstring>
 #include <mutex>
@@ -52,12 +53,7 @@ struct CmpCStr {
   }
 };
 
-// Interface to iterate via C strings.
-class CStringIterator {
-public:
-  // Get the next string. Returns next string's pointer or nullptr.
-  virtual const char *next() = 0;
-};
+using SerializedObj = sycl::vector_class<unsigned char>;
 
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/experimental/spec_constant.hpp
+++ b/sycl/include/CL/sycl/experimental/spec_constant.hpp
@@ -24,7 +24,9 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace experimental {
 
-class spec_const_error : public compile_program_error {};
+class spec_const_error : public compile_program_error {
+  using compile_program_error::compile_program_error;
+};
 
 template <typename T, typename ID = T> class spec_constant {
 private:

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -106,6 +106,7 @@ set(SYCL_SOURCES
     "detail/common.cpp"
     "detail/config.cpp"
     "detail/context_impl.cpp"
+    "detail/device_binary_image.cpp"
     "detail/device_impl.cpp"
     "detail/error_handling/enqueue_kernel.cpp"
     "detail/event_impl.cpp"

--- a/sycl/source/detail/device_binary_image.cpp
+++ b/sycl/source/detail/device_binary_image.cpp
@@ -1,0 +1,40 @@
+//==----- device_binary_image.cpp --- SYCL device binary image abstraction -==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl/detail/pi.hpp>
+
+#include <memory>
+
+#include <CL/sycl/detail/device_binary_image.hpp>
+
+using namespace sycl::detail;
+
+DynRTDeviceBinaryImage::DynRTDeviceBinaryImage(
+    std::unique_ptr<char[]> &&DataPtr, size_t DataSize, OSModuleHandle M)
+    : RTDeviceBinaryImage(M) {
+  Data = std::move(DataPtr);
+  Bin = new pi_device_binary_struct();
+  Bin->Version = PI_DEVICE_BINARY_VERSION;
+  Bin->Kind = PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL;
+  Bin->DeviceTargetSpec = PI_DEVICE_BINARY_TARGET_UNKNOWN;
+  Bin->CompileOptions = "";
+  Bin->LinkOptions = "";
+  Bin->ManifestStart = nullptr;
+  Bin->ManifestEnd = nullptr;
+  Bin->BinaryStart = reinterpret_cast<unsigned char *>(Data.get());
+  Bin->BinaryEnd = Bin->BinaryStart + DataSize;
+  Bin->EntriesBegin = nullptr;
+  Bin->EntriesEnd = nullptr;
+  Bin->Format = pi::getBinaryImageFormat(Bin->BinaryStart, DataSize);
+  init(Bin);
+}
+
+DynRTDeviceBinaryImage::~DynRTDeviceBinaryImage() {
+  delete Bin;
+  Bin = nullptr;
+}

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -8,9 +8,11 @@
 
 #pragma once
 
+#include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/locked.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/util.hpp>
 #include <detail/platform_impl.hpp>
 
 #include <atomic>
@@ -51,7 +53,8 @@ public:
   using PiProgramT = std::remove_pointer<RT::PiProgram>::type;
   using PiProgramPtrT = std::atomic<PiProgramT *>;
   using ProgramWithBuildStateT = BuildResult<PiProgramT>;
-  using ProgramCacheT = std::map<OSModuleHandle, ProgramWithBuildStateT>;
+  using ProgramCacheKeyT = std::pair<SerializedObj, KernelSetId>;
+  using ProgramCacheT = std::map<ProgramCacheKeyT, ProgramWithBuildStateT>;
   using ContextPtr = context_impl *;
 
   using PiKernelT = std::remove_pointer<RT::PiKernel>::type;

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -485,7 +485,7 @@ void program_impl::flush_spec_constants(const RTDeviceBinaryImage &Img,
 
   auto LockGuard = Ctx->getKernelProgramCache().acquireCachedPrograms();
 
-  for (SCItTy SCIt = SCRange.begin(); SCIt != SCRange.end(); SCIt++) {
+  for (SCItTy SCIt : SCRange) {
     const char *SCName = (*SCIt)->Name;
     auto SCEntry = SpecConstRegistry.find(SCName);
     if (SCEntry == SpecConstRegistry.end())

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -495,7 +495,7 @@ void program_impl::flush_spec_constants(const RTDeviceBinaryImage &Img,
     assert(SC.isSet() && "uninitialized spec constant");
     pi_device_binary_property SCProp = *SCIt;
     pi_uint32 ID = pi::DeviceBinaryProperty(SCProp).asUint32();
-    NativePrg = NativePrg ? NativePrg : pi::cast<pi::PiProgram>(get());
+    NativePrg = NativePrg ? NativePrg : getHandleRef();
     Ctx->getPlugin().call<PiApiKind::piextProgramSetSpecializationConstant>(
         NativePrg, ID, SC.getSize(), SC.getValuePtr());
   }

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -332,7 +332,6 @@ void program_impl::compile(const string_class &Options) {
   check_device_feature_support<info::device::is_compiler_available>(MDevices);
   vector_class<RT::PiDevice> Devices(get_pi_devices());
   const detail::plugin &Plugin = getPlugin();
-  ProgramManager::getInstance().flushSpecConstants(*this);
   RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramCompile>(
       MProgram, Devices.size(), Devices.data(), Options.c_str(), 0, nullptr,
       nullptr, nullptr, nullptr);

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -231,7 +231,7 @@ void program_impl::build_with_kernel_name(string_class KernelName,
     if (is_cacheable_with_options(BuildOptions)) {
       MProgramAndKernelCachingAllowed = true;
       MProgram = ProgramManager::getInstance().getBuiltPIProgram(
-          Module, get_context(), KernelName);
+          Module, get_context(), KernelName, this);
       const detail::plugin &Plugin = getPlugin();
       Plugin.call<PiApiKind::piProgramRetain>(MProgram);
     } else {
@@ -332,7 +332,7 @@ void program_impl::compile(const string_class &Options) {
   check_device_feature_support<info::device::is_compiler_available>(MDevices);
   vector_class<RT::PiDevice> Devices(get_pi_devices());
   const detail::plugin &Plugin = getPlugin();
-  ProgramManager::getInstance().flushSpecConstants(MProgram, *MContext);
+  ProgramManager::getInstance().flushSpecConstants(*this);
   RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramCompile>(
       MProgram, Devices.size(), Devices.data(), Options.c_str(), 0, nullptr,
       nullptr, nullptr, nullptr);
@@ -351,7 +351,7 @@ void program_impl::build(const string_class &Options) {
   check_device_feature_support<info::device::is_compiler_available>(MDevices);
   vector_class<RT::PiDevice> Devices(get_pi_devices());
   const detail::plugin &Plugin = getPlugin();
-  ProgramManager::getInstance().flushSpecConstants(MProgram, *MContext);
+  ProgramManager::getInstance().flushSpecConstants(*this);
   RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramBuild>(
       MProgram, Devices.size(), Devices.data(), Options.c_str(), nullptr,
       nullptr);
@@ -398,7 +398,7 @@ RT::PiKernel program_impl::get_pi_kernel(const string_class &KernelName) const {
 
   if (is_cacheable()) {
     Kernel = ProgramManager::getInstance().getOrCreateKernel(
-        MProgramModuleHandle, get_context(), KernelName);
+        MProgramModuleHandle, get_context(), KernelName, this);
   } else {
     const detail::plugin &Plugin = getPlugin();
     RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piKernelCreate>(
@@ -470,9 +470,36 @@ vector_class<device> program_impl::get_info<info::program::devices>() const {
 
 void program_impl::set_spec_constant_impl(const char *Name, const void *ValAddr,
                                           size_t ValSize) {
-  spec_constant_impl &SC =
-      ProgramManager::getInstance().resolveSpecConstant(this, Name);
+  // Reuse cached programs lock as opposed to introducing a new lock.
+  auto LockGuard = MContext->getKernelProgramCache().acquireCachedPrograms();
+  spec_constant_impl &SC = SpecConstRegistry[Name];
   SC.set(ValSize, ValAddr);
+}
+
+void program_impl::flush_spec_constants(const RTDeviceBinaryImage &Img,
+                                        RT::PiProgram NativePrg) const {
+  // iterate via all specialization constants the program's image depends on,
+  // and set each to current runtime value (if any)
+  const pi::DeviceBinaryImage::PropertyRange &SCRange = Img.getSpecConstants();
+  ContextImplPtr Ctx = getSyclObjImpl(get_context());
+  using SCItTy = pi::DeviceBinaryImage::PropertyRange::ConstIterator;
+
+  auto LockGuard = Ctx->getKernelProgramCache().acquireCachedPrograms();
+
+  for (SCItTy SCIt = SCRange.begin(); SCIt != SCRange.end(); SCIt++) {
+    const char *SCName = (*SCIt)->Name;
+    auto SCEntry = SpecConstRegistry.find(SCName);
+    if (SCEntry == SpecConstRegistry.end())
+      // spec constant has not been set in user code - SPIRV will use default
+      continue;
+    const spec_constant_impl &SC = SCEntry->second;
+    assert(SC.isSet() && "uninitialized spec constant");
+    pi_device_binary_property SCProp = *SCIt;
+    pi_uint32 ID = pi::DeviceBinaryProperty(SCProp).asUint32();
+    NativePrg = NativePrg ? NativePrg : pi::cast<pi::PiProgram>(get());
+    Ctx->getPlugin().call<PiApiKind::piextProgramSetSpecializationConstant>(
+        NativePrg, ID, SC.getSize(), SC.getValuePtr());
+  }
 }
 
 } // namespace detail

--- a/sycl/source/detail/program_impl.hpp
+++ b/sycl/source/detail/program_impl.hpp
@@ -315,6 +315,9 @@ public:
     detail::stableSerializeSpecConstRegistry(SpecConstRegistry, Dst);
   }
 
+  /// Tells whether a specialization constant has been set for this program.
+  bool hasSetSpecConstants() const { return !SpecConstRegistry.empty(); }
+
 private:
   // Deligating Constructor used in Implementation.
   program_impl(ContextImplPtr Context, pi_native_handle InteropProgram,

--- a/sycl/source/detail/program_impl.hpp
+++ b/sycl/source/detail/program_impl.hpp
@@ -10,6 +10,7 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/common_info.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
+#include <CL/sycl/detail/spec_constant_impl.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/program.hpp>
 #include <CL/sycl/stl.hpp>
@@ -292,12 +293,27 @@ public:
   void set_spec_constant_impl(const char *Name, const void *ValAddr,
                               size_t ValSize);
 
+  /// Takes current values of specialization constants and "injects" them into
+  /// the underlying native program program via specialization constant
+  /// managemment PI APIs. The native program passed as non-null argument
+  /// overrides the MProgram native program field.
+  /// \param Img device binary image corresponding to this program, used to
+  ///        resolve spec constant name to SPIRV integer ID
+  /// \param NativePrg if not null, used as the flush target, otherwise MProgram
+  ///        is used
+  void flush_spec_constants(const RTDeviceBinaryImage &Img,
+                            RT::PiProgram NativePrg = nullptr) const;
+
   /// Returns the OS module handle this program belongs to. A program belongs to
   /// an OS module if it was built from device image(s) belonging to that
   /// module.
   /// TODO Some programs can be linked from images belonging to different
   ///      modules. May need a special fake handle for the resulting program.
   OSModuleHandle getOSModuleHandle() const { return MProgramModuleHandle; }
+
+  void stableSerializeSpecConstRegistry(SerializedObj &Dst) const {
+    detail::stableSerializeSpecConstRegistry(SpecConstRegistry, Dst);
+  }
 
 private:
   // Deligating Constructor used in Implementation.
@@ -389,6 +405,12 @@ private:
   string_class MLinkOptions;
   string_class MBuildOptions;
   OSModuleHandle MProgramModuleHandle = OSUtil::ExeModuleHandle;
+
+  // Keeps specialization constant map for this program. Spec constant name
+  // resolution to actual SPIRV integer ID happens at build time, where the
+  // device binary image is available. Access is guarded by this context's
+  // program cache lock.
+  SpecConstRegistryT SpecConstRegistry;
 
   /// Only allow kernel caching for programs constructed with context only (or
   /// device list and context) and built with build_with_kernel_type with

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/device_binary_image.hpp>
 #include <CL/sycl/detail/export.hpp>
 #include <CL/sycl/detail/os_util.hpp>
 #include <CL/sycl/detail/pi.hpp>
@@ -49,49 +50,6 @@ enum DeviceLibExt {
   cl_intel_devicelib_math_fp64,
   cl_intel_devicelib_complex,
   cl_intel_devicelib_complex_fp64
-};
-
-// SYCL RT wrapper over PI binary image.
-class RTDeviceBinaryImage : public pi::DeviceBinaryImage {
-public:
-  RTDeviceBinaryImage(OSModuleHandle ModuleHandle)
-      : pi::DeviceBinaryImage(), ModuleHandle(ModuleHandle) {}
-  RTDeviceBinaryImage(pi_device_binary Bin, OSModuleHandle ModuleHandle)
-      : pi::DeviceBinaryImage(Bin), ModuleHandle(ModuleHandle) {}
-  OSModuleHandle getOSModuleHandle() const { return ModuleHandle; }
-
-  ~RTDeviceBinaryImage() override {}
-
-  bool supportsSpecConstants() const {
-    return getFormat() == PI_DEVICE_BINARY_TYPE_SPIRV;
-  }
-
-  const pi_device_binary_struct &getRawData() const { return *get(); }
-
-  void print() const override {
-    pi::DeviceBinaryImage::print();
-    std::cerr << "    OSModuleHandle=" << ModuleHandle << "\n";
-  }
-
-protected:
-  OSModuleHandle ModuleHandle;
-};
-
-// Dynamically allocated device binary image, which de-allocates its binary data
-// in destructor.
-class DynRTDeviceBinaryImage : public RTDeviceBinaryImage {
-public:
-  DynRTDeviceBinaryImage(std::unique_ptr<char[]> &&DataPtr, size_t DataSize,
-                         OSModuleHandle M);
-  ~DynRTDeviceBinaryImage() override;
-
-  void print() const override {
-    RTDeviceBinaryImage::print();
-    std::cerr << "    DYNAMICALLY CREATED\n";
-  }
-
-protected:
-  std::unique_ptr<char[]> Data;
 };
 
 // Provides single loading and building OpenCL programs with unique contexts

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -17,6 +17,7 @@
 #include <CL/sycl/stl.hpp>
 
 #include <map>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
@@ -105,10 +106,22 @@ public:
                                       const context &Context);
   RT::PiProgram createPIProgram(const RTDeviceBinaryImage &Img,
                                 const context &Context);
+  /// Builds or retrieves from cache a program defining the kernel with given
+  /// name.
+  /// \param M idenfies the OS module the kernel comes from (multiple OS modules
+  ///          may have kernels with the same name)
+  /// \param Context the context to build the program with
+  /// \param KernelName the kernel's name
+  /// \param ProgramImpl provides build context information, such as
+  ///        current specialization constants settings; can be nullptr.
+  ///        Passing as a raw pointer is OK, since it is not captured anywhere
+  ///        once the function returns.
   RT::PiProgram getBuiltPIProgram(OSModuleHandle M, const context &Context,
-                                  const string_class &KernelName);
+                                  const string_class &KernelName,
+                                  const program_impl *Prg = nullptr);
   RT::PiKernel getOrCreateKernel(OSModuleHandle M, const context &Context,
-                                 const string_class &KernelName);
+                                 const string_class &KernelName,
+                                 const program_impl *Prg);
   RT::PiProgram getPiProgramFromPiKernel(RT::PiKernel Kernel,
                                          const ContextImplPtr Context);
 
@@ -117,12 +130,20 @@ public:
   static string_class getProgramBuildLog(const RT::PiProgram &Program,
                                          const ContextImplPtr Context);
 
-  spec_constant_impl &resolveSpecConstant(const program_impl *P,
-                                          const char *Name);
-
-  // Takes current values of specialization constants and "injects" them into
-  // the program via specialization constant managemment PI APIs
-  void flushSpecConstants(pi::PiProgram Prg, context_impl &Ctx);
+  /// Resolves given program to a device binary image and requests the program
+  /// to flush constants the image depends on.
+  /// \param Prg the program object to get spec constant settings from.
+  ///        Passing program_impl by raw reference is OK, since it is not
+  ///        captured anywhere once the function returns.
+  /// \param NativePrg the native program, target for spec constant setting; if
+  ///        not null then overrides the native program in Prg
+  /// \param Img A source of the information about which constants need
+  ///        setting and symboling->integer spec constnant ID mapping. If not
+  ///        null, overrides native program->binary image binding maintained by
+  ///        the program manager.
+  void flushSpecConstants(const program_impl &Prg,
+                          pi::PiProgram NativePrg = nullptr,
+                          const RTDeviceBinaryImage *Img = nullptr);
 
 private:
   ProgramManager();
@@ -148,9 +169,6 @@ private:
                              const string_class &KernelName) const;
   /// Dumps image to current directory
   void dumpImage(const RTDeviceBinaryImage &Img, KernelSetId KSId) const;
-
-  void populateSpecConstRegistryImpl(const RTDeviceBinaryImage &Img);
-  void populateSpecConstRegistry();
 
   /// The three maps below are used during kernel resolution. Any kernel is
   /// identified by its name and the OS module it's coming from, allowing
@@ -186,21 +204,6 @@ private:
   /// Such images are assumed to contain all kernel associated with the module.
   /// Access must be guarded by the \ref Sync::getGlobalLock()
   std::unordered_map<OSModuleHandle, KernelSetId> m_OSModuleKernelSets;
-
-  // Maps specialization constant symbolic name to its integer ID.
-  // NOTE: a key in this map is a pointer into some existing device binary image
-  // and it is invalidated once the encompassing OS module gets unloaded.
-  using SpecConstMapTy =
-      std::unordered_map<const char *, spec_constant_impl, HashCStr, CmpCStr>;
-
-  // Keeps specialization constant map for each operating system module.
-  // The base approach is that there is a global name->id spec constant map for
-  // each OS module. This map is populated from the name->id pairs found in
-  // device binary image upon registration at startup for this OS module.
-  // If multiple images beloning to the same OS module have a specialization
-  // constant with the same name, its corresponding numeric id must also match.
-  // It is modified (populated) once at startup, so no locks are necessary.
-  std::unordered_map<OSModuleHandle, SpecConstMapTy> SpecConstRegistry;
 
   // Keeps track of pi_program to image correspondence. Needed for:
   // - knowing which specialization constants are used in the program and

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -112,7 +112,7 @@ public:
   ///          may have kernels with the same name)
   /// \param Context the context to build the program with
   /// \param KernelName the kernel's name
-  /// \param ProgramImpl provides build context information, such as
+  /// \param Prg provides build context information, such as
   ///        current specialization constants settings; can be nullptr.
   ///        Passing as a raw pointer is OK, since it is not captured anywhere
   ///        once the function returns.

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1665,7 +1665,8 @@ cl_int ExecCGCommand::enqueueImp() {
       Kernel = ExecKernel->MSyclKernel->getHandleRef();
     } else
       Kernel = detail::ProgramManager::getInstance().getOrCreateKernel(
-          ExecKernel->MOSModuleHandle, Context, ExecKernel->MKernelName);
+          ExecKernel->MOSModuleHandle, Context, ExecKernel->MKernelName,
+          nullptr);
 
     for (ArgDesc &Arg : ExecKernel->MArgs) {
       switch (Arg.MType) {

--- a/sycl/source/detail/spec_constant_impl.cpp
+++ b/sycl/source/detail/spec_constant_impl.cpp
@@ -8,7 +8,9 @@
 
 #include <CL/sycl/detail/spec_constant_impl.hpp>
 
+#include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/detail/pi.h>
+#include <CL/sycl/detail/util.hpp>
 #include <CL/sycl/exception.hpp>
 
 #include <cstring>
@@ -25,9 +27,18 @@ void spec_constant_impl::set(size_t Size, const void *Val) {
   std::memcpy(Bytes, Val, Size);
 }
 
+void stableSerializeSpecConstRegistry(const SpecConstRegistryT &Reg,
+                                      SerializedObj &Dst) {
+  for (const auto &E : Reg) {
+    Dst.insert(Dst.end(), E.first.begin(), E.first.end());
+    const spec_constant_impl &SC = E.second;
+    Dst.insert(Dst.end(), SC.getValuePtr(), SC.getValuePtr() + SC.getSize());
+  }
+}
+
 std::ostream &operator<<(std::ostream &Out, const spec_constant_impl &V) {
-  Out << "spec_constant_impl" << V.getID() << "{ Size=" << V.getSize()
-      << " IsSet=" << V.isSet() << " Val=[";
+  Out << "spec_constant_impl"
+      << " { Size=" << V.getSize() << " IsSet=" << V.isSet() << " Val=[";
   std::ios_base::fmtflags FlagsSav = Out.flags();
   Out << std::hex;
   for (unsigned I = 0; I < V.getSize(); ++I) {

--- a/sycl/test/aot/spec_const_aot.cpp
+++ b/sycl/test/aot/spec_const_aot.cpp
@@ -2,14 +2,7 @@
 //
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// XFAIL: *
-//==----------- spec_const_aot.cpp -----------------------------------------==//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
 // The test checks that the specialization constant feature works with ahead
 // of time compilation.
 

--- a/sycl/test/spec_const/spec_const_hw.cpp
+++ b/sycl/test/spec_const/spec_const_hw.cpp
@@ -73,7 +73,9 @@ int main(int argc, char **argv) {
       program2.set_spec_constant<MyFloatConst>(goldf);
 
   program1.build_with_kernel_type<KernelAAAi>();
-  program2.build_with_kernel_type<KernelBBBf>();
+  // Use an option (does not matter which exactly) to test different internal
+  // SYCL RT execution path
+  program2.build_with_kernel_type<KernelBBBf>("-cl-fast-relaxed-math");
 
   std::vector<int> veci(1);
   std::vector<float> vecf(1);

--- a/sycl/test/spec_const/spec_const_hw.cpp
+++ b/sycl/test/spec_const/spec_const_hw.cpp
@@ -1,9 +1,11 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// TODO: re-enable after OpenCL RT is fixed:
-// RUNx: %CPU_RUN_PLACEHOLDER %t.out
-// RUNx: %GPU_RUN_PLACEHOLDER %t.out
-// RUNx: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// TODO: re-enable after CI drivers are updated to newer which support spec
+// constants:
+// XFAIL: acc,cpu,cuda,gen
 //
 //==----------- spec_const_hw.cpp ------------------------------------------==//
 //

--- a/sycl/test/spec_const/spec_const_redefine.cpp
+++ b/sycl/test/spec_const/spec_const_redefine.cpp
@@ -1,11 +1,10 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
-// TODO the test currently fails on non-HOST devices as program recompilation
-//      based on spec constants set change is not complete yet.
-// XFAIL: cpu,gpu,acc,cuda
+// RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
+// TODO the test currently fails on devices these devices:
+// XFAIL: acc,cuda
 //
 //==----------- spec_const_redefine.cpp ------------------------------------==//
 //
@@ -14,27 +13,30 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// The test checks that the specialization constant can be redifined and correct
-// new value is used after redefinition.
+// The test checks that:
+// - a specialization constant can be redifined and correct new value is used
+//   after redefinition.
+// - the program is JITted only once per a unique set of specialization
+//   constants values.
 
 #include <CL/sycl.hpp>
 
 #include <iostream>
 #include <vector>
 
-class MyInt32Const;
+class SC0;
+class SC1;
+class KernelAAA;
 
 using namespace sycl;
 
-class KernelAAAi;
-
-int val = 10;
+int val = 0;
 
 // Fetch a value at runtime.
 int get_value() { return val; }
 
 int main(int argc, char **argv) {
-  val = argc + 16;
+  val = argc;
 
   cl::sycl::queue q(default_selector{}, [](exception_list l) {
     for (auto ep : l) {
@@ -52,36 +54,47 @@ int main(int argc, char **argv) {
 
   std::cout << "Running on " << q.get_device().get_info<info::device::name>()
             << "\n";
-  std::cout << "val = " << val << "\n";
   bool passed = true;
+  int x = get_value();
 
-  for (int i = 0; i < 2; i++) {
+  const int sc_vals[][2] = {
+      {1 + x, 2 + x},
+      {2 + x, 3 + x},
+      {1 + x, 2 + x}, // same as first - program in cache must be used
+      {2 + x, 3 + x}  // same as second - program in cache must be used
+  };
+  constexpr int n_sc_sets = sizeof(sc_vals) / sizeof(sc_vals[0]);
+  std::vector<int> vec(n_sc_sets);
+
+  for (int i = 0; i < n_sc_sets; i++) {
     cl::sycl::program program(q.get_context());
-    int gold = (int)get_value() + i;
-    // The same constant - MyInt32Const - is set to different value with the
-    // same kernel each loop iteration. SYCL RT must rebuild the underlying
-    // program.
-    cl::sycl::experimental::spec_constant<int32_t, MyInt32Const> i32 =
-        program.set_spec_constant<MyInt32Const>(gold);
-    program.build_with_kernel_type<KernelAAAi>();
-    std::vector<int> vec(1);
+    const int *sc_set = &sc_vals[i][0];
+    cl::sycl::experimental::spec_constant<int32_t, SC0> sc0 =
+        program.set_spec_constant<SC0>(sc_set[0]);
+    cl::sycl::experimental::spec_constant<int32_t, SC1> sc1 =
+        program.set_spec_constant<SC1>(sc_set[1]);
+
+    program.build_with_kernel_type<KernelAAA>();
 
     try {
       cl::sycl::buffer<int, 1> buf(vec.data(), vec.size());
 
       q.submit([&](cl::sycl::handler &cgh) {
         auto acc = buf.get_access<cl::sycl::access::mode::write>(cgh);
-        cgh.single_task<KernelAAAi>(
-            program.get_kernel<KernelAAAi>(),
+        cgh.single_task<KernelAAA>(
+            program.get_kernel<KernelAAA>(),
             [=]() {
-              acc[0] = i32.get();
+              acc[i] = sc0.get() + sc1.get();
             });
       });
     } catch (cl::sycl::exception &e) {
       std::cout << "*** Exception caught: " << e.what() << "\n";
       return 1;
     }
-    int val = vec[0];
+    int val = vec[i];
+    int gold = sc_set[0] + sc_set[1];
+
+    std::cout << "val = " << val << " gold = " << gold << "\n";
 
     if (val != gold) {
       std::cout << "*** ERROR[" << i << "]: " << val << " != " << gold << "(gold)\n";
@@ -91,3 +104,11 @@ int main(int argc, char **argv) {
   std::cout << (passed ? "passed\n" : "FAILED\n");
   return passed ? 0 : 1;
 }
+
+// --- Check that only two JIT compilation happened:
+// CHECK-NOT: ---> piProgramLink
+// CHECK: ---> piProgramLink
+// CHECK: ---> piProgramLink
+// CHECK-NOT: ---> piProgramLink
+// --- Check that the test completed with expected results:
+// CHECK: passed

--- a/sycl/test/spec_const/spec_const_redefine.cpp
+++ b/sycl/test/spec_const/spec_const_redefine.cpp
@@ -1,11 +1,11 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// TODO re-enable CPU device test once CI CPU OCL RT is updated:
-// RUNx: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
-// TODO the test currently fails on these devices:
-// XFAIL: acc,cuda
+// TODO: re-enable after CI drivers are updated to newer which support spec
+// constants:
+// XFAIL: acc,cpu,cuda,gen
 //
 //==----------- spec_const_redefine.cpp ------------------------------------==//
 //

--- a/sycl/test/spec_const/spec_const_redefine.cpp
+++ b/sycl/test/spec_const/spec_const_redefine.cpp
@@ -1,9 +1,10 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
+// TODO re-enable CPU device test once CI CPU OCL RT is updated:
+// RUNx: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
-// TODO the test currently fails on devices these devices:
+// TODO the test currently fails on these devices:
 // XFAIL: acc,cuda
 //
 //==----------- spec_const_redefine.cpp ------------------------------------==//


### PR DESCRIPTION
- Specialization constants are now per-program, as the implemented spec
  requires.
- Program's specialization constant set is added to the program
  compilation cache key, it gets recompiled on new specialization
  constant combination.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>