### PR TITLE
[SYCL][CUDA] Reduction ext unsupported

### DIFF
--- a/sycl/test/reduction/reduction_nd_conditional.cpp
+++ b/sycl/test/reduction/reduction_nd_conditional.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: cuda
+// Reductions use work-group builtins not yet supported by CUDA.
+//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_s0_dw.cpp
+++ b/sycl/test/reduction/reduction_nd_s0_dw.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: cuda
+// Reductions use work-group builtins not yet supported by CUDA.
+//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_s0_rw.cpp
+++ b/sycl/test/reduction/reduction_nd_s0_rw.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: cuda
+// Reductions use work-group builtins not yet supported by CUDA.
+//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_s1_dw.cpp
+++ b/sycl/test/reduction/reduction_nd_s1_dw.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: cuda
+// Reductions use work-group builtins not yet supported by CUDA.
+//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_s1_rw.cpp
+++ b/sycl/test/reduction/reduction_nd_s1_rw.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: cuda
+// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
+//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
The reduction extension is not yet supported by CUDA. Mark LIT tests as
unsupported.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>