### PR TITLE
[SYCL] Force Clang to emit complete object constructor for SYCLMemObjT

### DIFF
--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
@@ -29,7 +29,7 @@ class SYCLMemObjI {
 public:
   virtual ~SYCLMemObjI() = default;
 
-  enum MemObjType { BUFFER, IMAGE };
+  enum MemObjType { BUFFER, IMAGE, UNDEFINED };
 
   virtual MemObjType getType() const = 0;
 

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -18,7 +18,6 @@
 #include <CL/sycl/stl.hpp>
 
 #include <cstring>
-#include <stdexcept>
 #include <type_traits>
 
 __SYCL_INLINE_NAMESPACE(cl) {
@@ -264,7 +263,7 @@ public:
 
   void *allocateMem(ContextImplPtr Context, bool InitFromUserData,
                     void *HostPtr, RT::PiEvent &InteropEvent) override {
-    throw std::runtime_error("Not implemented");
+    throw runtime_error("Not implemented", PI_INVALID_OPERATION);
   }
 
   MemObjType getType() const override { return UNDEFINED; }

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -18,6 +18,7 @@
 #include <CL/sycl/stl.hpp>
 
 #include <cstring>
+#include <stdexcept>
 #include <type_traits>
 
 __SYCL_INLINE_NAMESPACE(cl) {
@@ -260,6 +261,13 @@ public:
 
   static size_t getBufSizeForContext(const ContextImplPtr &Context,
                                      cl_mem MemObject);
+
+  void *allocateMem(ContextImplPtr Context, bool InitFromUserData,
+                    void *HostPtr, RT::PiEvent &InteropEvent) override {
+    throw std::runtime_error("Not implemented");
+  }
+
+  MemObjType getType() const override { return UNDEFINED; }
 
 protected:
   // Allocator used for allocation memory on host.


### PR DESCRIPTION
GCC produces two symbols for one of SYCLMemObjT's constructors:
```
_ZN2cl4sycl6detail11SYCLMemObjTC1EP7_cl_memRKNS0_7contextEmNS0_5eventESt10unique_ptrINS1_19SYCLMemObjAllocatorESt14default_deleteISA_E
_ZN2cl4sycl6detail11SYCLMemObjTC2EP7_cl_memRKNS0_7contextEmNS0_5eventESt10unique_ptrINS1_19SYCLMemObjAllocatorESt14default_deleteISA_E
```

Those are complete object constructor and base object constructor. The
difference is that complete object constructor initializes vtable, while
base object constructor accepts it from a derived class.

On the other hand, Clang is smart enough to see that SYCLMemObjT is a
pure virtual class, and its complete object constructor can be dropped.

This patch adds dumb implementation for missing member functions to SYCLMemObjT
to force Clang behave the same way GCC does.