### PR TITLE
[SYCL][CUDA][LIT] Extend test for non-OpenCL

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2267,8 +2267,70 @@ pi_result cuda_piEnqueueKernelLaunch(
   assert(command_queue != nullptr);
   assert(command_queue->get_context() == kernel->get_context());
   assert(kernel != nullptr);
+  assert(global_work_offset != nullptr);
   assert(work_dim > 0);
   assert(work_dim < 4);
+
+  // Set the number of threads per block to the number of threads per warp
+  // by default unless user has provided a better number
+  int threadsPerBlock[3] = {32, 1, 1};
+
+  {
+    size_t maxThreadsPerBlock[3] = {};
+    pi_result retError = cuda_piDeviceGetInfo(
+        command_queue->device_, PI_DEVICE_INFO_MAX_WORK_ITEM_SIZES,
+        sizeof(maxThreadsPerBlock), maxThreadsPerBlock, nullptr);
+    assert(retError == PI_SUCCESS);
+    (void)retError;
+    size_t maxWorkGroupSize = 0;
+    retError = cuda_piDeviceGetInfo(
+        command_queue->device_, PI_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
+        sizeof(maxWorkGroupSize), &maxWorkGroupSize, nullptr);
+    assert(retError == PI_SUCCESS);
+
+    if (local_work_size) {
+      for (size_t i = 0; i < work_dim; i++) {
+        if (local_work_size[i] > maxThreadsPerBlock[i])
+          return PI_INVALID_WORK_ITEM_SIZE;
+        // Checks that local work sizes are a divisor of the global work sizes
+        // which includes that the local work sizes are neither larger than the
+        // global work sizes and not 0.
+        if (0u == local_work_size[i])
+          return PI_INVALID_WORK_GROUP_SIZE;
+        if (0u != (global_work_size[i] % local_work_size[i]))
+          return PI_INVALID_WORK_GROUP_SIZE;
+        threadsPerBlock[i] = static_cast<int>(local_work_size[i]);
+      }
+      if (maxWorkGroupSize < size_t(threadsPerBlock[0] * threadsPerBlock[1] *
+                                    threadsPerBlock[2])) {
+        return PI_INVALID_WORK_GROUP_SIZE;
+      }
+    } else {
+      // Determine local work sizes that result in uniform work groups.
+      // The default threadsPerBlock only require handling the first work_dim
+      // dimension.
+      threadsPerBlock[0] =
+          std::min(static_cast<int>(maxThreadsPerBlock[0]),
+                   std::min(static_cast<int>(global_work_size[0]),
+                            static_cast<int>(threadsPerBlock[0])));
+      // Find a local work group size that is a divisor of the global
+      // work group size to produce uniform work groups.
+      while (0u != (global_work_size[0] % threadsPerBlock[0])) {
+        --threadsPerBlock[0];
+      }
+      assert(
+          maxWorkGroupSize >=
+          size_t(threadsPerBlock[0] * threadsPerBlock[1] * threadsPerBlock[2]));
+    }
+  }
+
+  int blocksPerGrid[3] = {1, 1, 1};
+
+  for (size_t i = 0; i < work_dim; i++) {
+    blocksPerGrid[i] =
+        static_cast<int>(global_work_size[i] + threadsPerBlock[i] - 1) /
+        threadsPerBlock[i];
+  }
 
   pi_result retError = PI_SUCCESS;
   std::unique_ptr<_pi_event> retImplEv{nullptr};
@@ -2295,41 +2357,6 @@ pi_result cuda_piEnqueueKernelLaunch(
       }
       kernel->set_implicit_offset_arg(sizeof(cuda_implicit_offset),
                                       cuda_implicit_offset);
-    }
-
-    // Set the number of threads per block to the number of threads per warp
-    // by default unless user has provided a better number
-    int threadsPerBlock[3] = {32, 1, 1};
-
-    if (local_work_size) {
-      for (size_t i = 0; i < work_dim; i++) {
-        threadsPerBlock[i] = static_cast<int>(local_work_size[i]);
-      }
-    } else {
-      for (size_t i = 0; i < work_dim; i++) {
-        threadsPerBlock[i] = std::min(static_cast<int>(global_work_size[i]),
-                                      static_cast<int>(threadsPerBlock[i]));
-      }
-    }
-
-    size_t maxThreadsPerBlock[3] = {};
-    retError = cuda_piDeviceGetInfo(
-        command_queue->device_, PI_DEVICE_INFO_MAX_WORK_ITEM_SIZES,
-        sizeof(maxThreadsPerBlock), maxThreadsPerBlock, nullptr);
-    assert(retError == PI_SUCCESS);
-
-    for (size_t i = 0; i < work_dim; i++) {
-      if (size_t(threadsPerBlock[i]) > maxThreadsPerBlock[i]) {
-        return PI_INVALID_WORK_GROUP_SIZE;
-      }
-    }
-
-    int blocksPerGrid[3] = {1, 1, 1};
-
-    for (size_t i = 0; i < work_dim; i++) {
-      blocksPerGrid[i] =
-          static_cast<int>(global_work_size[i] + threadsPerBlock[i] - 1) /
-          threadsPerBlock[i];
     }
 
     auto argIndices = kernel->get_arg_indices();

--- a/sycl/test/basic_tests/parallel_for_range.cpp
+++ b/sycl/test/basic_tests/parallel_for_range.cpp
@@ -1,5 +1,6 @@
-// XFAIL: cuda || level_zero
-// CUDA exposes broken hierarchical parallelism.
+// XFAIL: level_zero
+// UNSUPPORTED: windows
+// Level0 testing times out on Windows.
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
@@ -29,106 +30,111 @@ int main() {
   string_class DeviceVendorName = D.get_info<info::device::vendor>();
   auto DeviceType = D.get_info<info::device::device_type>();
 
-  // parallel_for, (16, 16, 16) global, (8, 8, 8) local, reqd_wg_size(4, 4, 4)
-  // -> fail
-  try {
-    Q.submit([&](handler &CGH) {
-      CGH.parallel_for<class ReqdWGSizeNegativeA>(
-          nd_range<3>(range<3>(16, 16, 16), range<3>(8, 8, 8)),
-          [=](nd_item<3>) { reqd_wg_size_helper(); });
-    });
-    Q.wait_and_throw();
-    std::cerr << "Test case ReqdWGSizeNegativeA failed: no exception has been "
-                 "thrown\n";
-    return 1; // We shouldn't be here, exception is expected
-  } catch (nd_range_error &E) {
-    if (string_class(E.what()).find(
-            "Specified local size doesn't match the required work-group size "
-            "specified in the program source") == string_class::npos) {
-      std::cerr
-          << "Test case ReqdWGSizeNegativeA failed: unexpected exception: "
-          << E.what() << std::endl;
-      return 1;
-    }
-  } catch (runtime_error &E) {
-    std::cerr << "Test case ReqdWGSizeNegativeA failed: unexpected exception: "
-              << E.what() << std::endl;
-    return 1;
-  } catch (...) {
-    std::cerr << "Test case ReqdWGSizeNegativeA failed: something unexpected "
-                 "has been caught"
-              << std::endl;
-    return 1;
-  }
-
   string_class OCLVersionStr = D.get_info<info::device::version>();
-  assert(OCLVersionStr.size() >= 10 &&
+  const bool OCLBackend = (OCLVersionStr.find("OpenCL") != string_class::npos);
+  assert((!OCLBackend || (OCLVersionStr.size() >= 10)) &&
          "Unexpected device version string"); // strlen("OpenCL X.Y")
   const char *OCLVersion = &OCLVersionStr[7]; // strlen("OpenCL ")
-  if (OCLVersion[0] == '1' || (OCLVersion[0] == '2' && OCLVersion[2] == '0')) {
-    // parallel_for, (16, 16, 16) global, null local, reqd_wg_size(4, 4, 4) //
+
+  // reqd_work_group_size is OpenCL specific.
+  if (OCLBackend) {
+    if (OCLVersion[0] == '1' || (OCLVersion[0] == '2' && OCLVersion[2] == '0')) {
+    // parallel_for, (16, 16, 16) global, (8, 8, 8) local, reqd_wg_size(4, 4, 4)
     // -> fail
     try {
       Q.submit([&](handler &CGH) {
-        CGH.parallel_for<class ReqdWGSizeNegativeB>(
-            range<3>(16, 16, 16), [=](item<3>) { reqd_wg_size_helper(); });
+        CGH.parallel_for<class ReqdWGSizeNegativeA>(
+            nd_range<3>(range<3>(16, 16, 16), range<3>(8, 8, 8)),
+            [=](nd_item<3>) { reqd_wg_size_helper(); });
       });
       Q.wait_and_throw();
-      std::cerr
-          << "Test case ReqdWGSizeNegativeB failed: no exception has been "
-             "thrown\n";
+      std::cerr << "Test case ReqdWGSizeNegativeA failed: no exception has been "
+                   "thrown\n";
       return 1; // We shouldn't be here, exception is expected
     } catch (nd_range_error &E) {
       if (string_class(E.what()).find(
-              "OpenCL 1.x and 2.0 requires to pass local size argument even if "
-              "required work-group size was specified in the program source") ==
-          string_class::npos) {
+              "Specified local size doesn't match the required work-group size "
+              "specified in the program source") == string_class::npos) {
         std::cerr
-            << "Test case ReqdWGSizeNegativeB failed: unexpected exception: "
+            << "Test case ReqdWGSizeNegativeA failed: unexpected exception: "
             << E.what() << std::endl;
         return 1;
       }
     } catch (runtime_error &E) {
-      std::cerr
-          << "Test case ReqdWGSizeNegativeB failed: unexpected exception: "
-          << E.what() << std::endl;
+      std::cerr << "Test case ReqdWGSizeNegativeA failed: unexpected exception: "
+                << E.what() << std::endl;
       return 1;
     } catch (...) {
-      std::cerr << "Test case ReqdWGSizeNegativeB failed: something unexpected "
+      std::cerr << "Test case ReqdWGSizeNegativeA failed: something unexpected "
                    "has been caught"
                 << std::endl;
       return 1;
     }
-  }
 
-  // Positive test-cases that should pass on any underlying OpenCL runtime
-
-  // parallel_for, (8, 8, 8) global, (4, 4, 4) local, reqd_wg_size(4, 4, 4) ->
-  // pass
-  try {
-    Q.submit([&](handler &CGH) {
-      CGH.parallel_for<class ReqdWGSizePositiveA>(
-          nd_range<3>(range<3>(8, 8, 8), range<3>(4, 4, 4)),
-          [=](nd_item<3>) { reqd_wg_size_helper(); });
-    });
-    Q.wait_and_throw();
-  } catch (nd_range_error &E) {
-    std::cerr << "Test case ReqdWGSizePositiveA failed: unexpected exception: "
+      // parallel_for, (16, 16, 16) global, null local, reqd_wg_size(4, 4, 4) //
+      // -> fail
+      try {
+        Q.submit([&](handler &CGH) {
+          CGH.parallel_for<class ReqdWGSizeNegativeB>(
+              range<3>(16, 16, 16), [=](item<3>) { reqd_wg_size_helper(); });
+        });
+        Q.wait_and_throw();
+        std::cerr
+            << "Test case ReqdWGSizeNegativeB failed: no exception has been "
+               "thrown\n";
+        return 1; // We shouldn't be here, exception is expected
+      } catch (nd_range_error &E) {
+        if (string_class(E.what()).find(
+                "OpenCL 1.x and 2.0 requires to pass local size argument even if "
+                "required work-group size was specified in the program source") ==
+            string_class::npos) {
+          std::cerr
+              << "Test case ReqdWGSizeNegativeB failed: unexpected exception: "
               << E.what() << std::endl;
-    return 1;
-  } catch (runtime_error &E) {
-    std::cerr << "Test case ReqdWGSizePositiveA failed: unexpected exception: "
-              << E.what() << std::endl;
-    return 1;
-  } catch (...) {
-    std::cerr << "Test case ReqdWGSizePositiveA failed: something unexpected "
-                 "has been caught"
-              << std::endl;
-    return 1;
-  }
+          return 1;
+        }
+      } catch (runtime_error &E) {
+        std::cerr
+            << "Test case ReqdWGSizeNegativeB failed: unexpected exception: "
+            << E.what() << std::endl;
+        return 1;
+      } catch (...) {
+        std::cerr << "Test case ReqdWGSizeNegativeB failed: something unexpected "
+                     "has been caught"
+                  << std::endl;
+        return 1;
+      }
+    }
 
-  if (OCLVersion[0] == '1') {
-    // OpenCL 1.x
+    // Positive test-cases that should pass on any underlying OpenCL runtime
+
+    // parallel_for, (8, 8, 8) global, (4, 4, 4) local, reqd_wg_size(4, 4, 4) ->
+    // pass
+    try {
+      Q.submit([&](handler &CGH) {
+        CGH.parallel_for<class ReqdWGSizePositiveA>(
+            nd_range<3>(range<3>(8, 8, 8), range<3>(4, 4, 4)),
+            [=](nd_item<3>) { reqd_wg_size_helper(); });
+      });
+      Q.wait_and_throw();
+    } catch (nd_range_error &E) {
+      std::cerr << "Test case ReqdWGSizePositiveA failed: unexpected exception: "
+                << E.what() << std::endl;
+      return 1;
+    } catch (runtime_error &E) {
+      std::cerr << "Test case ReqdWGSizePositiveA failed: unexpected exception: "
+                << E.what() << std::endl;
+      return 1;
+    } catch (...) {
+      std::cerr << "Test case ReqdWGSizePositiveA failed: something unexpected "
+                   "has been caught"
+                << std::endl;
+      return 1;
+    }
+  } // if  (OCLBackend)
+
+  if (!OCLBackend || (OCLVersion[0] == '1')) {
+    // OpenCL 1.x or non-OpenCL backends which behave like OpenCl 1.2 in SYCL.
 
     // CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified and
     // number of workitems specified by global_work_size is not evenly
@@ -227,7 +233,8 @@ int main() {
         return 1; // We shouldn't be here, exception is expected
       }
     } catch (nd_range_error &E) {
-      if (string_class(E.what()).find("Local workgroup size cannot be greater than global range in any dimension") == string_class::npos) {
+      if ((string_class(E.what()).find("Local workgroup size cannot be greater than global range in any dimension") == string_class::npos) &&
+          (string_class(E.what()).find("Non-uniform work-groups are not supported by the target device") == string_class::npos)) {
         std::cerr
             << "Test case OpenCL1XNegativeA2 failed: unexpected exception: "
             << E.what() << std::endl;
@@ -264,7 +271,8 @@ int main() {
         return 1; // We shouldn't be here, exception is expected
       }
     } catch (nd_range_error &E) {
-      if (string_class(E.what()).find("Local workgroup size cannot be greater than global range in any dimension") == string_class::npos) {
+      if ((string_class(E.what()).find("Local workgroup size cannot be greater than global range in any dimension") == string_class::npos) &&
+          (string_class(E.what()).find("Non-uniform work-groups are not supported by the target device") == string_class::npos)) {
         std::cerr
             << "Test case OpenCL1XNegativeB2 failed: unexpected exception: "
             << E.what() << std::endl;
@@ -299,9 +307,10 @@ int main() {
                    "thrown\n";
       return 1; // We shouldn't be here, exception is expected
     } catch (nd_range_error &E) {
-      if (string_class(E.what()).find(
+      if ((string_class(E.what()).find(
               "Total number of work-items in a work-group cannot exceed " +
-              std::to_string(MaxDeviceWGSize)) == string_class::npos) {
+              std::to_string(MaxDeviceWGSize)) == string_class::npos) &&
+          (string_class(E.what()).find("Non-uniform work-groups are not supported by the target device") == string_class::npos)) {
         std::cerr
             << "Test case OpenCL1XNegativeC failed: unexpected exception: "
             << E.what() << std::endl;
@@ -317,7 +326,7 @@ int main() {
                 << std::endl;
       return 1;
     }
-  } else if (OCLVersion[0] == '2') {
+  } else if (OCLBackend && (OCLVersion[0] == '2')) {
     // OpenCL 2.x
 
     // OpenCL 2.x:

--- a/sycl/test/basic_tests/parallel_for_range.cpp
+++ b/sycl/test/basic_tests/parallel_for_range.cpp
@@ -38,38 +38,44 @@ int main() {
 
   // reqd_work_group_size is OpenCL specific.
   if (OCLBackend) {
-    if (OCLVersion[0] == '1' || (OCLVersion[0] == '2' && OCLVersion[2] == '0')) {
-    // parallel_for, (16, 16, 16) global, (8, 8, 8) local, reqd_wg_size(4, 4, 4)
-    // -> fail
-    try {
-      Q.submit([&](handler &CGH) {
-        CGH.parallel_for<class ReqdWGSizeNegativeA>(
-            nd_range<3>(range<3>(16, 16, 16), range<3>(8, 8, 8)),
-            [=](nd_item<3>) { reqd_wg_size_helper(); });
-      });
-      Q.wait_and_throw();
-      std::cerr << "Test case ReqdWGSizeNegativeA failed: no exception has been "
-                   "thrown\n";
-      return 1; // We shouldn't be here, exception is expected
-    } catch (nd_range_error &E) {
-      if (string_class(E.what()).find(
-              "Specified local size doesn't match the required work-group size "
-              "specified in the program source") == string_class::npos) {
+    if (OCLVersion[0] == '1' ||
+        (OCLVersion[0] == '2' && OCLVersion[2] == '0')) {
+      // parallel_for, (16, 16, 16) global, (8, 8, 8) local, reqd_wg_size(4, 4,
+      // 4)
+      // -> fail
+      try {
+        Q.submit([&](handler &CGH) {
+          CGH.parallel_for<class ReqdWGSizeNegativeA>(
+              nd_range<3>(range<3>(16, 16, 16), range<3>(8, 8, 8)),
+              [=](nd_item<3>) { reqd_wg_size_helper(); });
+        });
+        Q.wait_and_throw();
+        std::cerr
+            << "Test case ReqdWGSizeNegativeA failed: no exception has been "
+               "thrown\n";
+        return 1; // We shouldn't be here, exception is expected
+      } catch (nd_range_error &E) {
+        if (string_class(E.what()).find("Specified local size doesn't match "
+                                        "the required work-group size "
+                                        "specified in the program source") ==
+            string_class::npos) {
+          std::cerr
+              << "Test case ReqdWGSizeNegativeA failed: unexpected exception: "
+              << E.what() << std::endl;
+          return 1;
+        }
+      } catch (runtime_error &E) {
         std::cerr
             << "Test case ReqdWGSizeNegativeA failed: unexpected exception: "
             << E.what() << std::endl;
         return 1;
+      } catch (...) {
+        std::cerr
+            << "Test case ReqdWGSizeNegativeA failed: something unexpected "
+               "has been caught"
+            << std::endl;
+        return 1;
       }
-    } catch (runtime_error &E) {
-      std::cerr << "Test case ReqdWGSizeNegativeA failed: unexpected exception: "
-                << E.what() << std::endl;
-      return 1;
-    } catch (...) {
-      std::cerr << "Test case ReqdWGSizeNegativeA failed: something unexpected "
-                   "has been caught"
-                << std::endl;
-      return 1;
-    }
 
       // parallel_for, (16, 16, 16) global, null local, reqd_wg_size(4, 4, 4) //
       // -> fail
@@ -84,9 +90,10 @@ int main() {
                "thrown\n";
         return 1; // We shouldn't be here, exception is expected
       } catch (nd_range_error &E) {
-        if (string_class(E.what()).find(
-                "OpenCL 1.x and 2.0 requires to pass local size argument even if "
-                "required work-group size was specified in the program source") ==
+        if (string_class(E.what()).find("OpenCL 1.x and 2.0 requires to pass "
+                                        "local size argument even if "
+                                        "required work-group size was "
+                                        "specified in the program source") ==
             string_class::npos) {
           std::cerr
               << "Test case ReqdWGSizeNegativeB failed: unexpected exception: "
@@ -99,9 +106,10 @@ int main() {
             << E.what() << std::endl;
         return 1;
       } catch (...) {
-        std::cerr << "Test case ReqdWGSizeNegativeB failed: something unexpected "
-                     "has been caught"
-                  << std::endl;
+        std::cerr
+            << "Test case ReqdWGSizeNegativeB failed: something unexpected "
+               "has been caught"
+            << std::endl;
         return 1;
       }
     }
@@ -118,12 +126,14 @@ int main() {
       });
       Q.wait_and_throw();
     } catch (nd_range_error &E) {
-      std::cerr << "Test case ReqdWGSizePositiveA failed: unexpected exception: "
-                << E.what() << std::endl;
+      std::cerr
+          << "Test case ReqdWGSizePositiveA failed: unexpected exception: "
+          << E.what() << std::endl;
       return 1;
     } catch (runtime_error &E) {
-      std::cerr << "Test case ReqdWGSizePositiveA failed: unexpected exception: "
-                << E.what() << std::endl;
+      std::cerr
+          << "Test case ReqdWGSizePositiveA failed: unexpected exception: "
+          << E.what() << std::endl;
       return 1;
     } catch (...) {
       std::cerr << "Test case ReqdWGSizePositiveA failed: something unexpected "
@@ -233,8 +243,12 @@ int main() {
         return 1; // We shouldn't be here, exception is expected
       }
     } catch (nd_range_error &E) {
-      if ((string_class(E.what()).find("Local workgroup size cannot be greater than global range in any dimension") == string_class::npos) &&
-          (string_class(E.what()).find("Non-uniform work-groups are not supported by the target device") == string_class::npos)) {
+      if ((string_class(E.what()).find("Local workgroup size cannot be greater "
+                                       "than global range in any dimension") ==
+           string_class::npos) &&
+          (string_class(E.what()).find("Non-uniform work-groups are not "
+                                       "supported by the target device") ==
+           string_class::npos)) {
         std::cerr
             << "Test case OpenCL1XNegativeA2 failed: unexpected exception: "
             << E.what() << std::endl;
@@ -271,8 +285,12 @@ int main() {
         return 1; // We shouldn't be here, exception is expected
       }
     } catch (nd_range_error &E) {
-      if ((string_class(E.what()).find("Local workgroup size cannot be greater than global range in any dimension") == string_class::npos) &&
-          (string_class(E.what()).find("Non-uniform work-groups are not supported by the target device") == string_class::npos)) {
+      if ((string_class(E.what()).find("Local workgroup size cannot be greater "
+                                       "than global range in any dimension") ==
+           string_class::npos) &&
+          (string_class(E.what()).find("Non-uniform work-groups are not "
+                                       "supported by the target device") ==
+           string_class::npos)) {
         std::cerr
             << "Test case OpenCL1XNegativeB2 failed: unexpected exception: "
             << E.what() << std::endl;
@@ -308,9 +326,11 @@ int main() {
       return 1; // We shouldn't be here, exception is expected
     } catch (nd_range_error &E) {
       if ((string_class(E.what()).find(
-              "Total number of work-items in a work-group cannot exceed " +
-              std::to_string(MaxDeviceWGSize)) == string_class::npos) &&
-          (string_class(E.what()).find("Non-uniform work-groups are not supported by the target device") == string_class::npos)) {
+               "Total number of work-items in a work-group cannot exceed " +
+               std::to_string(MaxDeviceWGSize)) == string_class::npos) &&
+          (string_class(E.what()).find("Non-uniform work-groups are not "
+                                       "supported by the target device") ==
+           string_class::npos)) {
         std::cerr
             << "Test case OpenCL1XNegativeC failed: unexpected exception: "
             << E.what() << std::endl;
@@ -488,9 +508,11 @@ int main() {
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
                 "Local workgroup size greater than global range size. "
-                "Non-uniform work-groups are not allowed by default. Underlying "
+                "Non-uniform work-groups are not allowed by default. "
+                "Underlying "
                 "OpenCL 2.x implementation supports this feature and to enable "
-                "it, build device program with -cl-std=CL2.0") == string_class::npos) {
+                "it, build device program with -cl-std=CL2.0") ==
+            string_class::npos) {
           std::cerr
               << "Test case OpenCL2XNegativeB2 failed: unexpected exception: "
               << E.what() << std::endl;
@@ -502,9 +524,10 @@ int main() {
             << E.what() << std::endl;
         return 1;
       } catch (...) {
-        std::cerr << "Test case OpenCL2XNegativeB2 failed: something unexpected "
-                     "has been caught"
-                  << std::endl;
+        std::cerr
+            << "Test case OpenCL2XNegativeB2 failed: something unexpected "
+               "has been caught"
+            << std::endl;
         return 1;
       }
 
@@ -545,9 +568,10 @@ int main() {
             << E.what() << std::endl;
         return 1;
       } catch (...) {
-        std::cerr << "Test case OpenCL2XNegativeC2 failed: something unexpected "
-                     "has been caught"
-                  << std::endl;
+        std::cerr
+            << "Test case OpenCL2XNegativeC2 failed: something unexpected "
+               "has been caught"
+            << std::endl;
         return 1;
       }
     }
@@ -645,9 +669,12 @@ int main() {
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
                 "Global_work_size not evenly divisible by local_work_size. "
-                "Non-uniform work-groups are not allowed by when -cl-uniform-work-group-size flag is used. Underlying "
-                "OpenCL 2.x implementation supports this feature, but it is being "
-                "disabled by -cl-uniform-work-group-size build flag") == string_class::npos) {
+                "Non-uniform work-groups are not allowed by when "
+                "-cl-uniform-work-group-size flag is used. Underlying "
+                "OpenCL 2.x implementation supports this feature, but it is "
+                "being "
+                "disabled by -cl-uniform-work-group-size build flag") ==
+            string_class::npos) {
           std::cerr
               << "Test case OpenCL2XNegativeD failed: unexpected exception: "
               << E.what() << std::endl;
@@ -692,9 +719,12 @@ int main() {
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
                 "Global_work_size not evenly divisible by local_work_size. "
-                "Non-uniform work-groups are not allowed by when -cl-uniform-work-group-size flag is used. Underlying "
-                "OpenCL 2.x implementation supports this feature, but it is being "
-                "disabled by -cl-uniform-work-group-size build flag") == string_class::npos) {
+                "Non-uniform work-groups are not allowed by when "
+                "-cl-uniform-work-group-size flag is used. Underlying "
+                "OpenCL 2.x implementation supports this feature, but it is "
+                "being "
+                "disabled by -cl-uniform-work-group-size build flag") ==
+            string_class::npos) {
           std::cerr
               << "Test case OpenCL2XNegativeE failed: unexpected exception: "
               << E.what() << std::endl;
@@ -713,10 +743,10 @@ int main() {
       }
     }
 
-    // Local Size larger than Global, -cl-std=CL2.0 -cl-uniform-work-group-size flag used
-    // CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified as larger
-    // than the global size, then a different error string is used.
-    // This is a sub-case of the more general 'non-uniform work group'
+    // Local Size larger than Global, -cl-std=CL2.0 -cl-uniform-work-group-size
+    // flag used CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified as
+    // larger than the global size, then a different error string is used. This
+    // is a sub-case of the more general 'non-uniform work group'
     {
       program P(Q.get_context());
       P.build_with_kernel_type<class OpenCL2XNegativeD2>(
@@ -742,9 +772,12 @@ int main() {
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
                 "Local workgroup size greater than global range size. "
-                "Non-uniform work-groups are not allowed by when -cl-uniform-work-group-size flag is used. Underlying "
-                "OpenCL 2.x implementation supports this feature, but it is being "
-                "disabled by -cl-uniform-work-group-size build flag") == string_class::npos) {
+                "Non-uniform work-groups are not allowed by when "
+                "-cl-uniform-work-group-size flag is used. Underlying "
+                "OpenCL 2.x implementation supports this feature, but it is "
+                "being "
+                "disabled by -cl-uniform-work-group-size build flag") ==
+            string_class::npos) {
           std::cerr
               << "Test case OpenCL2XNegativeD2 failed: unexpected exception: "
               << E.what() << std::endl;
@@ -756,9 +789,10 @@ int main() {
             << E.what() << std::endl;
         return 1;
       } catch (...) {
-        std::cerr << "Test case OpenCL2XNegativeD2 failed: something unexpected "
-                     "has been caught"
-                  << std::endl;
+        std::cerr
+            << "Test case OpenCL2XNegativeD2 failed: something unexpected "
+               "has been caught"
+            << std::endl;
         return 1;
       }
     }
@@ -789,9 +823,12 @@ int main() {
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
                 "Local workgroup size greater than global range size. "
-                "Non-uniform work-groups are not allowed by when -cl-uniform-work-group-size flag is used. Underlying "
-                "OpenCL 2.x implementation supports this feature, but it is being "
-                "disabled by -cl-uniform-work-group-size build flag") == string_class::npos) {
+                "Non-uniform work-groups are not allowed by when "
+                "-cl-uniform-work-group-size flag is used. Underlying "
+                "OpenCL 2.x implementation supports this feature, but it is "
+                "being "
+                "disabled by -cl-uniform-work-group-size build flag") ==
+            string_class::npos) {
           std::cerr
               << "Test case OpenCL2XNegativeE2 failed: unexpected exception: "
               << E.what() << std::endl;
@@ -803,9 +840,10 @@ int main() {
             << E.what() << std::endl;
         return 1;
       } catch (...) {
-        std::cerr << "Test case OpenCL2XNegativeE2 failed: something unexpected "
-                     "has been caught"
-                  << std::endl;
+        std::cerr
+            << "Test case OpenCL2XNegativeE2 failed: something unexpected "
+               "has been caught"
+            << std::endl;
         return 1;
       }
     }


### PR DESCRIPTION
Mark LIT test that uses cl::reqd_work_group_size as unsupported by
CUDA.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>