### PR TITLE
[SYCL] Implement USM vars and placeholder accessors passed to reduction

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -856,7 +856,7 @@ public:
   parallel_for(nd_range<Dims> Range, Reduction &Redu, KernelType KernelFunc) {
     if (Reduction::is_usm)
       Redu.associateWithHandler(*this);
-    auto QueueCopy = MQueue;
+    shared_ptr_class<detail::queue_impl> QueueCopy = MQueue;
     auto Acc = Redu.getUserAccessor();
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu, Acc);
 
@@ -887,7 +887,7 @@ public:
   detail::enable_if_t<Reduction::accessor_mode == access::mode::discard_write &&
                       Reduction::has_fast_atomics>
   parallel_for(nd_range<Dims> Range, Reduction &Redu, KernelType KernelFunc) {
-    auto QueueCopy = MQueue;
+    shared_ptr_class<detail::queue_impl> QueueCopy = MQueue;
     auto RWAcc = Redu.getReadWriteScalarAcc(*this);
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
                                           RWAcc);
@@ -940,7 +940,7 @@ public:
     if (Reduction::is_usm && NWorkGroups == 1)
       Redu.associateWithHandler(*this);
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu);
-    auto QueueCopy = MQueue;
+    shared_ptr_class<detail::queue_impl> QueueCopy = MQueue;
     this->finalize();
 
     // 2. Run the additional aux kernel as many times as needed to reduce

--- a/sycl/include/CL/sycl/intel/reduction.hpp
+++ b/sycl/include/CL/sycl/intel/reduction.hpp
@@ -376,21 +376,21 @@ public:
   template <
       typename _T = T, class _BinaryOperation = BinaryOperation,
       enable_if_t<IsKnownIdentityOp<_T, _BinaryOperation>::value> * = nullptr>
-  reduction_impl(T &VarRef)
+  reduction_impl(T *VarPtr)
       : MIdentity(getIdentity()),
         MUSMBufPtr(
-            std::make_shared<buffer<T, buffer_dim>>(&VarRef, range<1>(1))),
-        MAcc(accessor_type(*MUSMBufPtr)), MUSMPointer(&VarRef) {}
+            std::make_shared<buffer<T, buffer_dim>>(VarPtr, range<1>(1))),
+        MAcc(accessor_type(*MUSMBufPtr)), MUSMPointer(VarPtr) {}
 
   /// Constructs reduction_impl when the identity value is statically known,
   /// and user still passed the identity value.
   template <
       typename _T = T, class _BinaryOperation = BinaryOperation,
       enable_if_t<IsKnownIdentityOp<_T, _BinaryOperation>::value> * = nullptr>
-  reduction_impl(T &VarRef, const T &Identity)
+  reduction_impl(T *VarPtr, const T &Identity)
       : MIdentity(Identity), MUSMBufPtr(std::make_shared<buffer<T, buffer_dim>>(
-                                 &VarRef, range<1>(1))),
-        MAcc(accessor_type(*MUSMBufPtr)), MUSMPointer(&VarRef) {
+                                 VarPtr, range<1>(1))),
+        MAcc(accessor_type(*MUSMBufPtr)), MUSMPointer(VarPtr) {
     // For operations with known identity value the operator == is defined.
     // It is sort of dilemma here: from one point of view - user may set
     // such identity that would be enough for his data, i.e. identity=100 for
@@ -405,10 +405,10 @@ public:
   template <
       typename _T = T, class _BinaryOperation = BinaryOperation,
       enable_if_t<!IsKnownIdentityOp<_T, _BinaryOperation>::value> * = nullptr>
-  reduction_impl(T &VarRef, const T &Identity)
+  reduction_impl(T *VarPtr, const T &Identity)
       : MIdentity(Identity), MUSMBufPtr(std::make_shared<buffer<T, buffer_dim>>(
-                                 &VarRef, range<1>(1))),
-        MAcc(accessor_type(*MUSMBufPtr)), MUSMPointer(&VarRef) {}
+                                 VarPtr, range<1>(1))),
+        MAcc(accessor_type(*MUSMBufPtr)), MUSMPointer(VarPtr) {}
 
   /// Associates reduction accessor with the given handler and saves reduction
   /// buffer so that it is alive until the command group finishes the work.
@@ -1045,11 +1045,11 @@ reduction(accessor<T, Dims, AccMode, access::target::global_buffer, IsPH> &Acc,
 template <typename T, class BinaryOperation>
 detail::reduction_impl<T, BinaryOperation, 0, true, access::mode::read_write,
                        access::placeholder::true_t>
-reduction(T &VarRef, const T &Identity, BinaryOperation Combiner) {
+reduction(T *VarPtr, const T &Identity, BinaryOperation Combiner) {
   // The Combiner argument was needed only to define the BinaryOperation param.
   return detail::reduction_impl<T, BinaryOperation, 0, true,
                                 access::mode::read_write,
-                                access::placeholder::true_t>(VarRef, Identity);
+                                access::placeholder::true_t>(VarPtr, Identity);
 }
 
 /// Creates and returns an object implementing the reduction functionality.
@@ -1063,11 +1063,11 @@ detail::enable_if_t<detail::IsKnownIdentityOp<T, BinaryOperation>::value,
                     detail::reduction_impl<T, BinaryOperation, 0, true,
                                            access::mode::read_write,
                                            access::placeholder::true_t>>
-reduction(T &VarRef, BinaryOperation Combiner) {
+reduction(T *VarPtr, BinaryOperation Combiner) {
   // The Combiner argument was needed only to define the BinaryOperation param.
   return detail::reduction_impl<T, BinaryOperation, 0, true,
                                 access::mode::read_write,
-                                access::placeholder::true_t>(VarRef);
+                                access::placeholder::true_t>(VarPtr);
 }
 
 } // namespace intel

--- a/sycl/test/reduction/reduction_placeholder.cpp
+++ b/sycl/test/reduction/reduction_placeholder.cpp
@@ -6,6 +6,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // TODO: Enable the test for HOST when it supports intel::reduce() and barrier()
 
 // This test performs basic checks of parallel_for(nd_range, reduction, func)

--- a/sycl/test/reduction/reduction_placeholder.cpp
+++ b/sycl/test/reduction/reduction_placeholder.cpp
@@ -2,10 +2,11 @@
 // Reductions use work-group builtins not yet supported by CUDA.
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// TODO: Enable the test for HOST when it supports intel::reduce() and barrier()
 
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reductions initialized with a placeholder accessor.

--- a/sycl/test/reduction/reduction_placeholder.cpp
+++ b/sycl/test/reduction/reduction_placeholder.cpp
@@ -1,0 +1,83 @@
+// UNSUPPORTED: cuda
+// Reductions use work-group builtins not yet supported by CUDA.
+
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// This test performs basic checks of parallel_for(nd_range, reduction, func)
+// with reductions initialized with a placeholder accessor.
+
+#include "reduction_utils.hpp"
+#include <CL/sycl.hpp>
+#include <cassert>
+
+using namespace cl::sycl;
+
+template <typename T, int Dim, class BinaryOperation>
+class SomeClass;
+
+template <typename T, int Dim, class BinaryOperation>
+void test(T Identity, size_t WGSize, size_t NWItems) {
+  // Initialize.
+  T CorrectOut;
+  BinaryOperation BOp;
+
+  buffer<T, 1> OutBuf(1);
+  buffer<T, 1> InBuf(NWItems);
+  initInputData(InBuf, CorrectOut, Identity, BOp, NWItems);
+
+  (OutBuf.template get_access<access::mode::write>())[0] = Identity;
+
+  auto Out = accessor<T, Dim, access::mode::read_write,
+                      access::target::global_buffer,
+                      access::placeholder::true_t>(OutBuf);
+  // Compute.
+  queue Q;
+  Q.submit([&](handler &CGH) {
+    auto In = InBuf.template get_access<access::mode::read>(CGH);
+    CGH.require(Out);
+    auto Redu = intel::reduction(Out, Identity, BinaryOperation());
+    range<1> GlobalRange(NWItems);
+    range<1> LocalRange(WGSize);
+    nd_range<1> NDRange(GlobalRange, LocalRange);
+    CGH.parallel_for<SomeClass<T, Dim, BinaryOperation>>(
+        NDRange, Redu, [=](nd_item<1> NDIt, auto &Sum) {
+          Sum.combine(In[NDIt.get_global_linear_id()]);
+        });
+  });
+  Q.wait();
+
+  // Check correctness.
+  T ReduVar = (OutBuf.template get_access<access::mode::read>())[0];
+  if (ReduVar != CorrectOut) {
+    std::cout << "NWItems = " << NWItems << ", WGSize = " << WGSize << "\n";
+    std::cout << "Computed value: " << ReduVar
+              << ", Expected value: " << CorrectOut << "\n";
+    assert(0 && "Wrong value.");
+  }
+}
+
+int main() {
+  // fast atomics and fast reduce
+  test<int, 1, intel::plus<int>>(0, 49, 49 * 5);
+  test<int, 0, intel::plus<int>>(0, 8, 8);
+
+  // fast atomics
+  test<int, 0, intel::bit_or<int>>(0, 7, 7 * 3);
+  test<int, 1, intel::bit_or<int>>(0, 4, 128);
+
+  // fast reduce
+  test<float, 1, intel::minimum<float>>(std::numeric_limits<float>::max(), 5, 5 * 7);
+  test<float, 0, intel::maximum<float>>(std::numeric_limits<float>::min(), 4, 128);
+
+  // generic algorithm
+  test<int, 0, std::multiplies<int>>(1, 7, 7 * 5);
+  test<int, 1, std::multiplies<int>>(1, 8, 16);
+  test<CustomVec<short>, 0, CustomVecPlus<short>>(CustomVec<short>(0), 8, 8 * 3);
+
+  std::cout << "Test passed\n";
+  return 0;
+}

--- a/sycl/test/reduction/reduction_usm.cpp
+++ b/sycl/test/reduction/reduction_usm.cpp
@@ -1,11 +1,15 @@
 // UNSUPPORTED: cuda
 // Reductions use work-group builtins not yet supported by CUDA.
 
+// UNSUPPORTED: linux
+// TODO: Enable the test for Linux when CI uses GPU driver 20.06.15619 or newer.
+
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// TODO: Enable the test for HOST when it supports intel::reduce() and barrier()
 
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reductions initialized with USM var.

--- a/sycl/test/reduction/reduction_usm.cpp
+++ b/sycl/test/reduction/reduction_usm.cpp
@@ -1,0 +1,77 @@
+// UNSUPPORTED: cuda
+// Reductions use work-group builtins not yet supported by CUDA.
+
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// This test performs basic checks of parallel_for(nd_range, reduction, func)
+// with reductions initialized with USM var.
+
+#include "reduction_utils.hpp"
+#include <CL/sycl.hpp>
+#include <cassert>
+
+using namespace cl::sycl;
+
+template <typename T, int Dim, class BinaryOperation>
+class SomeClass;
+
+template <typename T, int Dim, class BinaryOperation>
+void test(T Identity, size_t WGSize, size_t NWItems) {
+  // Initialize.
+  T CorrectOut;
+  BinaryOperation BOp;
+
+  buffer<T, 1> InBuf(NWItems);
+  initInputData(InBuf, CorrectOut, Identity, BOp, NWItems);
+
+  T ReduVar = Identity;
+
+  // Compute.
+  queue Q;
+  Q.submit([&](handler &CGH) {
+    auto In = InBuf.template get_access<access::mode::read>(CGH);
+    auto Redu = intel::reduction(ReduVar, Identity, BOp);
+    range<1> GlobalRange(NWItems);
+    range<1> LocalRange(WGSize);
+    nd_range<1> NDRange(GlobalRange, LocalRange);
+    CGH.parallel_for<SomeClass<T, Dim, BinaryOperation>>(
+        NDRange, Redu, [=](nd_item<1> NDIt, auto &Sum) {
+          Sum.combine(In[NDIt.get_global_linear_id()]);
+        });
+  });
+  Q.wait();
+
+  // Check correctness.
+  if (ReduVar != CorrectOut) {
+    std::cout << "NWItems = " << NWItems << ", WGSize = " << WGSize << "\n";
+    std::cout << "Computed value: " << ReduVar
+              << ", Expected value: " << CorrectOut << "\n";
+    assert(0 && "Wrong value.");
+  }
+}
+
+int main() {
+  // fast atomics and fast reduce
+  test<int, 1, intel::plus<int>>(0, 49, 49 * 5);
+  test<int, 0, intel::plus<int>>(0, 8, 128);
+
+  // fast atomics
+  test<int, 0, intel::bit_or<int>>(0, 7, 7 * 3);
+  test<int, 1, intel::bit_or<int>>(0, 4, 128);
+
+  // fast reduce
+  test<float, 1, intel::minimum<float>>(std::numeric_limits<float>::max(), 5, 5 * 7);
+  test<float, 0, intel::maximum<float>>(std::numeric_limits<float>::min(), 4, 128);
+
+  // generic algorithm
+  test<int, 0, std::multiplies<int>>(1, 7, 7 * 5);
+  test<int, 1, std::multiplies<int>>(1, 8, 16);
+  test<CustomVec<short>, 0, CustomVecPlus<short>>(CustomVec<short>(0), 8, 8 * 3);
+
+  std::cout << "Test passed\n";
+  return 0;
+}


### PR DESCRIPTION
In order to support USM vars/pointers passed to reduction
the placeholder accessors to global buffers were used.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>