### PR TITLE
[SYCL] diagnose any pointers captured into sycl kernel

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10814,6 +10814,8 @@ def err_sycl_non_trivially_copy_ctor_dtor_type
             "constructible|destructible}0 class/struct type %1">;
 def err_sycl_non_std_layout_type : Error<
   "kernel parameter has non-standard layout class/struct type %0">;
+def err_sycl_illegal_memory_reference : Error<
+  "Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.">;
 def err_conflicting_sycl_kernel_attributes : Error<
   "conflicting attributes applied to a SYCL kernel">;
 def err_conflicting_sycl_function_attributes : Error<

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12595,6 +12595,8 @@ public:
 
   bool isKnownGoodSYCLDecl(const Decl *D);
   void checkSYCLDeviceVarDecl(VarDecl *Var);
+  void checkSYCLDevicePointerCapture(VarDecl *Var, SourceLocation CaptureLoc);
+  void diagSYCLDevicePointerCaptures(FunctionDecl *FD);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
   void MarkDevice();
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14439,7 +14439,7 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
     DiscardCleanupsInEvaluationContext();
   }
 
-  if (LangOpts.SYCLIsDevice)
+  if (LangOpts.SYCLIsDevice && FD && Body)
     diagSYCLDevicePointerCaptures(FD);
 
   if (LangOpts.OpenMP || LangOpts.CUDA || LangOpts.SYCLIsDevice) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14439,7 +14439,7 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
     DiscardCleanupsInEvaluationContext();
   }
 
-  if(LangOpts.SYCLIsDevice)
+  if (LangOpts.SYCLIsDevice)
     diagSYCLDevicePointerCaptures(FD);
 
   if (LangOpts.OpenMP || LangOpts.CUDA || LangOpts.SYCLIsDevice) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14439,6 +14439,9 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
     DiscardCleanupsInEvaluationContext();
   }
 
+  if(LangOpts.SYCLIsDevice)
+    diagSYCLDevicePointerCaptures(FD);
+
   if (LangOpts.OpenMP || LangOpts.CUDA || LangOpts.SYCLIsDevice) {
     auto ES = getEmissionStatus(FD);
     if (ES == Sema::FunctionEmissionStatus::Emitted ||

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -16759,6 +16759,10 @@ static bool isVariableCapturable(CapturingScopeInfo *CSI, VarDecl *Var,
       S.Diag(Loc, diag::err_opencl_block_ref_block);
     return false;
   }
+  // SYCL: Emit diagnostics for any illegal pointer derefs.
+  if (Diagnose && IsLambda && S.getLangOpts().SYCLIsDevice &&
+      Var->getType()->isAnyPointerType())
+    S.checkSYCLDevicePointerCapture(Var, Loc);
 
   return true;
 }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -465,10 +465,6 @@ void Sema::diagSYCLDevicePointerCaptures(FunctionDecl *ParentFD) {
             const StringLiteral *SL = dyn_cast<StringLiteral>(Init);
             if (SL)
               howAllocated = WillCrash;
-
-            const UnaryOperator *UO = dyn_cast<UnaryOperator>(Init);
-            if (UO && (UO->getOpcode() == UO_AddrOf))
-              howAllocated = WillCrash;
           }
         }
         // else: Var does not have local initialization, might be parameter,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -27,6 +27,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <array>
+#include <unordered_map>
 
 using namespace clang;
 
@@ -281,6 +282,216 @@ void Sema::checkSYCLDeviceVarDecl(VarDecl *Var) {
   llvm::DenseSet<QualType> Visited;
 
   checkSYCLVarType(*this, Ty, Loc, Visited);
+}
+
+bool isVarInExpr(VarDecl *V, std::function<bool(const Expr *)> AF,
+                 const Expr *E) {
+  // We have a variable declaration and want to know if it is referenced
+  // anywhere in this expression. If the variable is found, but having its value
+  // changed via assignment, the AF function can decide whether to match or not.
+  if (!E) {
+    return false;
+  }
+
+  E = E->IgnoreCasts();
+
+  switch (E->getStmtClass()) {
+  case Stmt::StmtClass::CallExprClass: {
+    const CallExpr *CCE = dyn_cast<CallExpr>(E);
+    CallExpr *CE = const_cast<CallExpr *>(CCE);
+    Expr **CallArgs = CE->getArgs();
+    auto num = CE->getNumArgs();
+    bool match = false;
+    for (unsigned i = 0; i < num; i++) {
+      Expr *Arg = CallArgs[i];
+      Arg = Arg->IgnoreCasts();
+      match = isVarInExpr(V, AF, Arg);
+      if (match) {
+        return match;
+      }
+    }
+    return match;
+  }
+
+  case Stmt::StmtClass::BinaryOperatorClass: {
+    const BinaryOperator *BO = dyn_cast<BinaryOperator>(E);
+    bool match = false;
+    const Expr *LHS = BO->getLHS();
+    const Expr *RHS = BO->getRHS();
+    match = isVarInExpr(V, AF, LHS);
+    if (match) {
+      if (BO->isAssignmentOp() && AF &&
+          AF(RHS)) // Run the assignment func. If it returns true, pretend we
+                   // didn't find a match so as to continue searching.
+        return false;
+      else
+        return match;
+    }
+    match = isVarInExpr(V, AF, RHS);
+    return match;
+  }
+
+  case Stmt::StmtClass::UnaryOperatorClass: {
+    const UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
+    const Expr *Sub = UO->getSubExpr();
+    return isVarInExpr(V, AF, Sub);
+  }
+
+  case Stmt::StmtClass::DeclRefExprClass: {
+    const DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E);
+    const ValueDecl *VD = DRE->getDecl();
+    return (VD == V);
+  }
+
+  default:
+    break;
+  }
+  return false;
+}
+
+bool isVarInStmt(VarDecl *V, std::function<bool(const Expr *)> AssignF,
+                 const Stmt *St) {
+  // We have a variable declaration and want to know if it is referenced
+  // in this statment or its children, if any.
+  if (!St)
+    return false;
+
+  const Expr *E = dyn_cast<Expr>(St);
+  if (E)
+    return isVarInExpr(V, AssignF, E);
+  else {
+    for (const Stmt *SubStmt : St->children()) {
+      bool match = isVarInStmt(V, AssignF, SubStmt);
+      if (match)
+        return match;
+    }
+  }
+  return false;
+}
+
+typedef std::tuple<VarDecl *, SourceLocation, FunctionDecl *> CaptureTuple;
+typedef std::unordered_multimap<FunctionDecl *, CaptureTuple> CaptureMMap;
+
+CaptureMMap PotentialCapturesMM;
+
+void Sema::checkSYCLDevicePointerCapture(VarDecl *Var,
+                                         SourceLocation CaptureLoc) {
+  // Proper diagnoses of a captured lambda variable can't be performed until the
+  // parent function's body is ready.  So we file the potential capture under
+  // its parent FunctionDecl, and diagnose it when that function is finished.
+  assert(getLangOpts().SYCLIsDevice &&
+         "Should only be called during SYCL compilation");
+  assert(Var->getType()->isAnyPointerType() &&
+         "Should only be called for pointer types being captured.");
+
+  FunctionDecl *LambdaFD = dyn_cast<FunctionDecl>(getCurLexicalContext());
+  DeclContext *DC = LambdaFD->getParentFunctionOrMethod();
+  FunctionDecl *ParentFD = dyn_cast_or_null<FunctionDecl>(DC);
+
+  PotentialCapturesMM.insert(
+      std::make_pair(ParentFD, std::make_tuple(Var, CaptureLoc, LambdaFD)));
+}
+
+void Sema::diagSYCLDevicePointerCaptures(FunctionDecl *CallFD) {
+  // Any pointer captured into the SYCL kernel lambda will fail when
+  // dereferenced...except USM. If it weren't for USM we could just emit a
+  // deferred diagnostic for every pointer capture. Instead, we attempt to
+  // identify which pointers are USM, and which are definitely not (and will
+  // crash). For those that will crash, we emit an error. For those that are
+  // unknown, we _could_ emit a gentle note suggesting the user double check
+  // that they are using USM.  But at this time we do not. For safe USM
+  // pointers, we do nothing.
+  if (PotentialCapturesMM.empty()) {
+    return;
+  }
+
+  auto PCs = PotentialCapturesMM.equal_range(CallFD);
+
+  for_each(PCs.first, PCs.second, [this](CaptureMMap::value_type &CapVal) {
+    CaptureTuple CT = CapVal.second;
+    VarDecl *Var = std::get<0>(CT);
+    SourceLocation CaptureLoc = std::get<1>(CT);
+    FunctionDecl *FDCap = std::get<2>(CT);
+
+    enum ExprAllocation { Unknown, USM, WillCrash };
+    ExprAllocation howAllocated = Unknown;
+
+    // We will use this to check declarations and assignments.
+    auto VetteCallExpr = [&howAllocated](const Expr *E) {
+      E = E->IgnoreCasts();
+      const CallExpr *CE = dyn_cast<CallExpr>(E);
+      bool updated = false;
+      if (CE) {
+        const FunctionDecl *func = CE->getDirectCallee();
+        auto FullName = func->getQualifiedNameAsString();
+        // Check to see if this function call is one of the USM allocators.
+        if ((FullName.rfind("cl::sycl::malloc", 0) == 0) ||
+            (FullName.rfind("cl::sycl::aligned_alloc", 0) == 0)) {
+          howAllocated = USM;
+          updated = true;
+        } else if (howAllocated == Unknown &&
+                   ((FullName.compare("malloc") == 0) ||
+                    (FullName.compare("calloc") == 0))) {
+          howAllocated = WillCrash;
+          updated = true;
+        }
+      }
+      return updated;
+    };
+    std::function<bool(const Expr *)> AssignF = VetteCallExpr;
+
+    SourceLocation DecLoc = SourceLocation();
+
+    // Try to determine provenance of this Var.
+    const Expr *Init = Var->getAnyInitializer();
+    if (Init) {
+      Init = Init->IgnoreCasts();
+      DecLoc = Init->getExprLoc();
+
+      const CallExpr *CE = dyn_cast<CallExpr>(Init);
+      if (CE) {
+        VetteCallExpr(CE); // Modifies howAllocated via side-effect.
+      } else {
+        // Var has initialization, but not as return result of a function,
+        // disqualify any other obvious bad initialization expressions.
+        const StringLiteral *SL = dyn_cast<StringLiteral>(Init);
+        if (SL)
+          howAllocated = WillCrash;
+
+        const UnaryOperator *UO = dyn_cast<UnaryOperator>(Init);
+        if (UO && (UO->getOpcode() == UO_AddrOf))
+          howAllocated = WillCrash;
+      }
+    }
+    // else: Var does not have local initialization, might be parameter, etc.
+
+    // We may have identified some initialization as unsafe. But that variable
+    // is subject to change. So we look through the statements to see if that
+    // variable is otherwise referenced before capture, or if reassigned it is
+    // assessed with AssignF.
+    DeclContext *DC = Var->getParentFunctionOrMethod();
+    const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(DC);
+    if (FD && FD->hasBody()) {
+      Stmt *TopStmt = FD->getBody(FD);
+      bool match = isVarInStmt(Var, AssignF, TopStmt);
+      if (match)
+        howAllocated = Unknown;
+    } else {
+      howAllocated = Unknown;
+    }
+
+    // Emit diagnostics.   We use long form because we need to pass in the
+    // captured FunctionDecl.
+    if (howAllocated == WillCrash) {
+      Sema::DeviceDiagBuilder(Sema::DeviceDiagBuilder::K_Deferred, CaptureLoc,
+                              diag::err_sycl_illegal_memory_reference, FDCap,
+                              *this);
+      if (DecLoc.isValid())
+        Sema::DeviceDiagBuilder(Sema::DeviceDiagBuilder::K_Deferred, DecLoc,
+                                diag::note_declared_at, FDCap, *this);
+    }
+  }); // for_each
+  PotentialCapturesMM.erase(CallFD);
 }
 
 class MarkDeviceFunction : public RecursiveASTVisitor<MarkDeviceFunction> {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -481,7 +481,7 @@ void Sema::checkSYCLDevicePointerCapture(VarDecl *Var,
   assert(Var->getType()->isAnyPointerType() &&
          "Should only be called for pointer types being captured.");
 
-  FunctionDecl *LambdaFD = dyn_cast<FunctionDecl>(getCurLexicalContext());
+  FunctionDecl *LambdaFD = dyn_cast<FunctionDecl>(getCurLexicalContext());  
   DeclContext *DC = LambdaFD->getParentFunctionOrMethod();
   FunctionDecl *ParentFD = dyn_cast_or_null<FunctionDecl>(DC);
 
@@ -504,7 +504,7 @@ void Sema::diagSYCLDevicePointerCaptures(FunctionDecl *CallFD) {
 
   auto PCs = PotentialCapturesMM.equal_range(CallFD);
 
-  for_each(PCs.first, PCs.second, [this](CaptureMMap::value_type &CapVal) {
+  for_each(PCs.first, PCs.second, [this, CallFD](CaptureMMap::value_type &CapVal) {
     CaptureTuple CT = CapVal.second;
     VarDecl *Var = std::get<0>(CT);
     SourceLocation CaptureLoc = std::get<1>(CT);
@@ -586,6 +586,10 @@ void Sema::diagSYCLDevicePointerCaptures(FunctionDecl *CallFD) {
     
     DeclContext *DC = Var->getParentFunctionOrMethod();
     const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(DC);
+    if(FD && !FD->hasBody()){
+      std::cout << "FD has no body - " << FD->willHaveBody() << std::endl;
+      FD = CallFD;
+    }
     //std::cout << Var->getNameAsString() << std::endl;
     //std::cout << Var->getNameAsString() << "  FD: " << FD->getSourceRange().printToString(getSourceManager())
     //          << " FDCap: " << FDCap->getSourceRange().printToString(getSourceManager()) << std::endl;
@@ -600,7 +604,7 @@ void Sema::diagSYCLDevicePointerCaptures(FunctionDecl *CallFD) {
       }
       
     } else {
-      std::cout << "no boyd" << std::endl;
+      //std::cout << "no boyd" << std::endl;
       howAllocated = Unknown;
     }
     //std::cout << std::endl;

--- a/clang/test/CodeGenSYCL/int_header_spec_const.cpp
+++ b/clang/test/CodeGenSYCL/int_header_spec_const.cpp
@@ -18,7 +18,7 @@ class MyUInt32Const;
 class MyFloatConst;
 class MyDoubleConst;
 
-double* mockUSMAlloc();
+double *mockUSMAlloc();
 
 int main() {
   // Create specialization constants.

--- a/clang/test/CodeGenSYCL/int_header_spec_const.cpp
+++ b/clang/test/CodeGenSYCL/int_header_spec_const.cpp
@@ -18,6 +18,8 @@ class MyUInt32Const;
 class MyFloatConst;
 class MyDoubleConst;
 
+double* mockUSMAlloc();
+
 int main() {
   // Create specialization constants.
   cl::sycl::experimental::spec_constant<bool, MyBoolConst> i1(false);
@@ -33,8 +35,7 @@ int main() {
   cl::sycl::experimental::spec_constant<float, MyFloatConst> f32(0);
   cl::sycl::experimental::spec_constant<double, MyDoubleConst> f64(0);
 
-  double val;
-  double *ptr = &val; // to avoid "unused" warnings
+  double *ptr = mockUSMAlloc(); // to avoid "unused" warnings
 
   cl::sycl::kernel_single_task<SpecializedKernel>([=]() {
     *ptr = i1.get() +

--- a/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
@@ -25,8 +25,8 @@ int *unknownFunc();
 
 int main() {
   int data = 5;
-  int* data_addr = unknownFunc();
-  int* new_data_addr = unknownFunc();
+  int *data_addr = unknownFunc();
+  int *new_data_addr = unknownFunc();
   test_struct s;
   s.data = data;
   kernel<class kernel_int>(

--- a/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
@@ -21,10 +21,12 @@ void test(const int some_const) {
       });
 }
 
+int *unknownFunc();
+
 int main() {
   int data = 5;
-  int* data_addr = &data;
-  int* new_data_addr = nullptr;
+  int* data_addr = unknownFunc();
+  int* new_data_addr = unknownFunc();
   test_struct s;
   s.data = data;
   kernel<class kernel_int>(

--- a/clang/test/SemaSYCL/sycl-pointer-capture-diagnostics.cpp
+++ b/clang/test/SemaSYCL/sycl-pointer-capture-diagnostics.cpp
@@ -1,0 +1,287 @@
+// RUN: %clang_cc1  -fsycl -triple spir64 -fsycl-is-device -verify -fsyntax-only  %s
+//
+// Pointer variables captured by kernel lambda are checked.
+// Ensure those diagnostics are working correctly.
+
+namespace std {
+class type_info;
+typedef __typeof__(sizeof(int)) size_t;
+} // namespace std
+
+inline namespace cl {
+namespace sycl {
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc(); //#call_kernelFunc
+}
+
+typedef int device;
+typedef int context;
+typedef double queue;
+
+//-- Mock USM memory allocation functions.
+namespace usm {
+enum class alloc { host,
+                   device,
+                   shared,
+                   unknown };
+} // namespace usm
+
+void *malloc(std::size_t sz, const device &dev, const context &ctxt, cl::sycl::usm::alloc kind);
+void *malloc(std::size_t sz, const queue &q, cl::sycl::usm::alloc kind);
+void *malloc_device(std::size_t sz, const device &dev, const context &ctxt);
+void *malloc_device(std::size_t sz, const queue &q);
+void *malloc_shared(std::size_t sz, const device &dev, const context &ctxt);
+void *malloc_shared(std::size_t sz, const queue &q);
+void *malloc_host(std::size_t sz, const context &ctxt);
+void *malloc_host(std::size_t sz, const queue &q);
+void *aligned_alloc(std::size_t alignment, std::size_t sz, const device &dev, const context &ctxt, cl::sycl::usm::alloc kind);
+void *aligned_alloc(std::size_t alignment, std::size_t sz, const queue &q, cl::sycl::usm::alloc kind);
+void *aligned_alloc_device(std::size_t alignment, std::size_t sz, const device &dev, const context &ctxt);
+void *aligned_alloc_device(std::size_t alignment, std::size_t sz, const queue &q);
+void *aligned_alloc_shared(std::size_t alignment, std::size_t sz, const device &dev, const context &ctxt);
+void *aligned_alloc_shared(std::size_t alignment, std::size_t sz, const queue &q);
+void *aligned_alloc_host(std::size_t alignment, std::size_t sz, const context &ctxt);
+void *aligned_alloc_host(std::size_t alignment, std::size_t sz, const queue &q);
+
+//template form
+template <typename T>
+T *malloc_shared(std::size_t Count, const device &Dev, const context &Ctxt) {
+  return static_cast<T *>(malloc_shared(Count * sizeof(T), Dev, Ctxt));
+}
+
+} // namespace sycl
+} // namespace cl
+
+void *malloc(std::size_t sz);
+void *calloc(std::size_t num, std::size_t sz);
+//-- End Mocks
+
+struct Mesh {
+  float a;
+};
+
+// User functions that might allocate memory in some way unknown to us.
+float *unknownFunc();
+Mesh *unknownMeshF();
+
+void allocateUSMByHandle(float **pointerHandle, std::size_t sz, sycl::device &dev, sycl::context &ctxt) {
+  float *mem = sycl::malloc_shared<float>(sz, dev, ctxt);
+  *pointerHandle = mem;
+}
+
+float calledFromLambda(float *first) {
+  return first[0];
+}
+
+int something(float *fromParam) {
+
+  int device = 0, context = 0;
+  double queue = 0;
+
+  //-- Declarations
+
+  //-- various bad pointers
+  float stackFloat = 20.0;
+  float *stackFloatP = &stackFloat; //#decl_stackFloatP
+  float *neverInitialized;
+
+  // std::string is already caught by 'non-trivially copy constructible' check.
+  // so we only worry about literal strings.
+  auto stringLiteral = "omgwtf"; //#decl_stringLiteral
+
+  //-- various 'unknown' pointers.
+  // No message or error. Up to dev to ensure they don't crash.
+
+  //fromParam
+
+  float *apocryphal = unknownFunc(); //#decl_apocryphal
+  float *usmByHandle;
+  allocateUSMByHandle(&usmByHandle, 10, device, context);
+
+  //this one initialized as bad, but later changed. No error emitted
+  float *firstBadLaterGood = &stackFloat;
+  firstBadLaterGood = sycl::malloc_shared<float>(1, device, context);
+
+  //-- structs
+  Mesh stackMesh;
+  stackMesh.a = 31.0;
+  Mesh *stackMeshP = &stackMesh; //#decl_stackMeshP
+  Mesh *neverInitializedMeshP;
+  Mesh *mallocMeshP = static_cast<Mesh *>(malloc(sizeof(Mesh)));  //#decl_mallocMeshP
+  Mesh *mallocMeshP2 = static_cast<Mesh *>(malloc(sizeof(Mesh))); //#decl_mallocMeshP2
+  Mesh *unknownMeshP = unknownMeshF();
+  Mesh *usmMeshP = static_cast<Mesh *>(sycl::malloc_shared(sizeof(Mesh), device, context)); //#decl_usmMeshP
+  Mesh *usmMeshP2 = sycl::malloc_shared<Mesh>(1, device, context);                          //#decl_usmMeshP2
+
+  //-- malloc
+  float *mallocFloatP = static_cast<float *>(malloc(sizeof(float) * 2));  //#decl_mallocFloatP
+  float *mallocFloatP2 = static_cast<float *>(malloc(sizeof(float) * 2)); //#decl_mallocFloatP2
+  float *callocFloatP = static_cast<float *>(calloc(2, sizeof(float)));   //#decl_callocFloatP
+  float *callocFloatP2 = static_cast<float *>(calloc(2, sizeof(float)));  //#decl_callocFloatP2
+
+  //usm
+  float *usmSharedP = static_cast<float *>(sycl::malloc_shared(sizeof(float), device, context));
+  float *usmSharedP2 = static_cast<float *>(sycl::malloc_shared(sizeof(float), queue));
+  float *usmSharedP3 = static_cast<float *>(sycl::malloc(sizeof(float), device, context, cl::sycl::usm::alloc::shared));
+  float *usmSharedP4 = static_cast<float *>(sycl::malloc(sizeof(float), queue, cl::sycl::usm::alloc::shared));
+  float *usmSharedP5 = sycl::malloc_shared<float>(2, device, context);
+
+  float *usmShAlignP = static_cast<float *>(sycl::aligned_alloc_shared(1, sizeof(float), device, context));
+  float *usmShAlignP2 = static_cast<float *>(sycl::aligned_alloc_shared(1, sizeof(float), queue));
+  float *usmShAlignP3 = static_cast<float *>(sycl::aligned_alloc(1, sizeof(float), device, context, cl::sycl::usm::alloc::shared));
+  float *usmShAlignP4 = static_cast<float *>(sycl::aligned_alloc(1, sizeof(float), queue, cl::sycl::usm::alloc::shared));
+
+  float *usmHostP = static_cast<float *>(sycl::malloc_host(sizeof(float), context));
+  float *usmHostP2 = static_cast<float *>(sycl::malloc_host(sizeof(float), queue));
+  float *usmHostP3 = static_cast<float *>(sycl::malloc(sizeof(float), device, context, cl::sycl::usm::alloc::host));
+  float *usmHostP4 = static_cast<float *>(sycl::malloc(sizeof(float), queue, cl::sycl::usm::alloc::host));
+
+  float *usmHoAlignP = static_cast<float *>(sycl::aligned_alloc_host(1, sizeof(float), context));
+  float *usmHoAlignP2 = static_cast<float *>(sycl::aligned_alloc_host(1, sizeof(float), queue));
+  float *usmHoAlignP3 = static_cast<float *>(sycl::aligned_alloc(1, sizeof(float), device, context, cl::sycl::usm::alloc::host));
+  float *usmHoAlignP4 = static_cast<float *>(sycl::aligned_alloc(1, sizeof(float), queue, cl::sycl::usm::alloc::host));
+
+  float *usmDeviceP = static_cast<float *>(sycl::malloc_device(sizeof(float), device, context));
+  float *usmDeviceP2 = static_cast<float *>(sycl::malloc_device(sizeof(float), queue));
+  float *usmDeviceP3 = static_cast<float *>(sycl::malloc(sizeof(float), device, context, cl::sycl::usm::alloc::device));
+  float *usmDeviceP4 = static_cast<float *>(sycl::malloc(sizeof(float), queue, cl::sycl::usm::alloc::device));
+
+  float *okPRValueInit = usmSharedP5++;
+
+  cl::sycl::kernel_single_task<class AName>([=]() {
+    // --- Captures
+
+    //-- various bad pointers
+    //    all of these will cause crashes if not caught.
+
+    // expected-note@#call_kernelFunc {{called by 'kernel_single_task<AName, (lambda}}
+    // expected-note@#decl_mallocFloatP {{declared here}}
+    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
+    calledFromLambda(mallocFloatP);
+
+    // expected-note@#decl_stackFloatP {{declared here}}
+    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
+    stackFloatP[0] = 30.0;
+
+    neverInitialized[0] = 31.0; //will crash, not caught presently.
+
+    // expected-note@#decl_stringLiteral {{declared here}}
+    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
+    char x = stringLiteral[0];
+
+    //-- various 'unknown' pointers.
+    // No message or error. Up to dev to ensure they don't crash.
+    fromParam[0] = 70.0;
+
+    apocryphal[0] = 71.0;
+
+    usmByHandle[0] = 72.0;
+
+    firstBadLaterGood[0] = 73.0;
+
+    //-- struct pointers
+    //    various bad struct pointer derefs will cause crashes if not caught.
+
+    // expected-note@#decl_stackMeshP {{declared here}}
+    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
+    float smpa = stackMeshP->a;
+
+    neverInitializedMeshP->a = 34.0; //will crash, not caught presently.
+
+    // expected-note@#decl_mallocMeshP {{declared here}}
+    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
+    float mmpa = mallocMeshP->a;
+
+    // expected-note@#decl_mallocMeshP2 {{declared here}}
+    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
+    mallocMeshP2->a = 45.0;
+
+    //     unknown struct -- Nothing emitted. Up to developer to ensure it doesn't crash.
+    unknownMeshP->a = 72.0;
+
+    //     usm struct  -- OK
+    float umpa = usmMeshP->a;
+    usmMeshP2->a = 61.0;
+
+    float sma = stackMesh.a; // Struct itself is copyable, so perfectly safe to capture it.
+
+    //-- malloc
+    //   all will crash if uncaught.
+
+    // expected-note@#decl_mallocFloatP2 {{declared here}}
+    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
+    mallocFloatP2[0] = 80;
+
+    // expected-note@#decl_callocFloatP {{declared here}}
+    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
+    callocFloatP[0] = 80;
+
+    // expected-note@#decl_callocFloatP2 {{declared here}}
+    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
+    float someValue = *callocFloatP2;
+
+    // --- Only the first capture of a pointer emits anything. So these accesses will NOT emit redundant diagnostics.
+    calledFromLambda(mallocFloatP);
+    stackFloatP[0] = 31.0;
+    char y = stringLiteral[0];
+    apocryphal[0] = 88.1;
+    float smpa2 = stackMeshP->a;
+    neverInitializedMeshP->a = 34.2;
+    float mmpa2 = mallocMeshP->a;
+    mallocMeshP2->a = 45.2;
+    mallocFloatP2[0] = 81;
+    callocFloatP[0] = 81;
+    float someOtherValue = *callocFloatP2;
+
+    // --- These captures all use USM, and should pass without any notes or errors.
+    calledFromLambda(usmSharedP);
+    umpa = usmMeshP->a;
+    usmMeshP2->a = 61.0;
+    usmSharedP[0] = 1;
+    usmSharedP2[0] = 1;
+    usmSharedP3[0] = 1;
+    usmSharedP4[0] = 1;
+    usmSharedP5[0] = 1;
+    usmShAlignP[0] = 1;
+    usmShAlignP2[0] = 1;
+    usmShAlignP3[0] = 1;
+    usmShAlignP4[0] = 1;
+    usmHostP[0] = 1;
+    usmHostP2[0] = 1;
+    usmHostP3[0] = 1;
+    usmHostP4[0] = 1;
+    usmHoAlignP[0] = 1;
+    usmHoAlignP2[0] = 1;
+    usmHoAlignP3[0] = 1;
+    usmHoAlignP4[0] = 1;
+    usmDeviceP[0] = 1;
+    usmDeviceP2[0] = 1;
+    usmDeviceP3[0] = 1;
+    usmDeviceP4[0] = 1;
+    //
+    okPRValueInit[0] = 81;
+  });
+
+  auto noProblemLambda = [=]() {
+    // --- Outside a SYCL context no errors are emitted.
+    calledFromLambda(mallocFloatP);
+    calledFromLambda(usmSharedP);
+    stackFloatP[0] = 30.0;
+    fromParam[0] = 70.0;
+    char x = stringLiteral[0];
+    apocryphal[0] = 89.0;
+    usmByHandle[0] = 90.0;
+    float smpa = stackMeshP->a;
+    neverInitializedMeshP->a = 34.0;
+    float mmpa = mallocMeshP->a;
+    mallocMeshP2->a = 45.0;
+    mallocFloatP2[0] = 80;
+    callocFloatP[0] = 80;
+    float someValue = *callocFloatP2;
+  };
+  noProblemLambda();
+
+  return 0;
+}

--- a/clang/test/SemaSYCL/sycl-pointer-capture-diagnostics.cpp
+++ b/clang/test/SemaSYCL/sycl-pointer-capture-diagnostics.cpp
@@ -163,9 +163,7 @@ int something(float *fromParam) {
     // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
     calledFromLambda(mallocFloatP);
 
-    // expected-note@#decl_stackFloatP {{declared here}}
-    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
-    stackFloatP[0] = 30.0;
+    stackFloatP[0] = 30.0; //will crash, not caught presently
 
     neverInitialized[0] = 31.0; //will crash, not caught presently.
 
@@ -186,9 +184,7 @@ int something(float *fromParam) {
     //-- struct pointers
     //    various bad struct pointer derefs will cause crashes if not caught.
 
-    // expected-note@#decl_stackMeshP {{declared here}}
-    // expected-error@+1 {{Illegal memory reference in SYCL device kernel. Use USM (malloc_shared, etc) instead.}}
-    float smpa = stackMeshP->a;
+    float smpa = stackMeshP->a; //will crash, not caught presently.
 
     neverInitializedMeshP->a = 34.0; //will crash, not caught presently.
 

--- a/clang/test/SemaSYCL/sycl-pointer-capture-diagnostics.cpp
+++ b/clang/test/SemaSYCL/sycl-pointer-capture-diagnostics.cpp
@@ -119,9 +119,9 @@ int something(float *fromParam) {
   //-- malloc
   float *mallocFloatP = static_cast<float *>(malloc(sizeof(float) * 2));  //#decl_mallocFloatP
   float *mallocFloatP2 = static_cast<float *>(malloc(sizeof(float) * 2)); //#decl_mallocFloatP2
-  float *mallocFloatP3 = static_cast<float *>(malloc(sizeof(float) * 2)); 
-  float *callocFloatP = static_cast<float *>(calloc(2, sizeof(float)));   //#decl_callocFloatP
-  float *callocFloatP2 = static_cast<float *>(calloc(2, sizeof(float)));  //#decl_callocFloatP2
+  float *mallocFloatP3 = static_cast<float *>(malloc(sizeof(float) * 2));
+  float *callocFloatP = static_cast<float *>(calloc(2, sizeof(float)));  //#decl_callocFloatP
+  float *callocFloatP2 = static_cast<float *>(calloc(2, sizeof(float))); //#decl_callocFloatP2
 
   //usm
   float *usmSharedP = static_cast<float *>(sycl::malloc_shared(sizeof(float), device, context));
@@ -269,7 +269,7 @@ int something(float *fromParam) {
   auto noProblemLambda = [=]() {
     // --- Outside a SYCL context no errors are emitted.
     mallocFloatP3[0] = -1.0;
-    stackFloatP2[0] = -2.0; 
+    stackFloatP2[0] = -2.0;
   };
   noProblemLambda();
 

--- a/clang/test/SemaSYCL/sycl-pointer-capture-diagnostics.cpp
+++ b/clang/test/SemaSYCL/sycl-pointer-capture-diagnostics.cpp
@@ -86,6 +86,7 @@ int something(float *fromParam) {
   float stackFloat = 20.0;
   float *stackFloatP = &stackFloat; //#decl_stackFloatP
   float *neverInitialized;
+  float *stackFloatP2 = &stackFloat;
 
   // std::string is already caught by 'non-trivially copy constructible' check.
   // so we only worry about literal strings.
@@ -118,6 +119,7 @@ int something(float *fromParam) {
   //-- malloc
   float *mallocFloatP = static_cast<float *>(malloc(sizeof(float) * 2));  //#decl_mallocFloatP
   float *mallocFloatP2 = static_cast<float *>(malloc(sizeof(float) * 2)); //#decl_mallocFloatP2
+  float *mallocFloatP3 = static_cast<float *>(malloc(sizeof(float) * 2)); 
   float *callocFloatP = static_cast<float *>(calloc(2, sizeof(float)));   //#decl_callocFloatP
   float *callocFloatP2 = static_cast<float *>(calloc(2, sizeof(float)));  //#decl_callocFloatP2
 
@@ -266,20 +268,8 @@ int something(float *fromParam) {
 
   auto noProblemLambda = [=]() {
     // --- Outside a SYCL context no errors are emitted.
-    calledFromLambda(mallocFloatP);
-    calledFromLambda(usmSharedP);
-    stackFloatP[0] = 30.0;
-    fromParam[0] = 70.0;
-    char x = stringLiteral[0];
-    apocryphal[0] = 89.0;
-    usmByHandle[0] = 90.0;
-    float smpa = stackMeshP->a;
-    neverInitializedMeshP->a = 34.0;
-    float mmpa = mallocMeshP->a;
-    mallocMeshP2->a = 45.0;
-    mallocFloatP2[0] = 80;
-    callocFloatP[0] = 80;
-    float someValue = *callocFloatP2;
+    mallocFloatP3[0] = -1.0;
+    stackFloatP2[0] = -2.0; 
   };
   noProblemLambda();
 


### PR DESCRIPTION
Signed-off-by: Chris Perkins <chris.perkins@intel.com>

 Any pointer captured into the SYCL kernel lambda will fail when dereferenced...except USM. If it weren't for USM we could just emit a diagnostic for every pointer capture. Instead, we attempt to identify which pointers are USM, and which are definitely not (and will crash). For those that will crash, we emit an error. For those that are unknown, we _could_ emit a gentle note suggesting the user double check that they are using USM.  But at this time we do not. 
For safe USM pointers, we do nothing.

The analysis of the capture must be done after the parent function has an intact body, but the Sema call to check captures comes before that, when the lambda is being built.  So we have two calls: one that records any captures that need checking, and another that performs the diagnostics when the parent function is being finished. 