### PR TITLE
[Driver][SYCL] Make -std=c++17 the default for DPC++

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5078,6 +5078,13 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                                  options::OPT_fno_trigraphs))
       if (A != Std)
         A->render(Args, CmdArgs);
+  } else if (IsSYCL && types::isCXX(InputType)) {
+    // For DPC++, we default to -std=c++17 for all compilations.  Use of -std
+    // on the command line will override.
+    CmdArgs.push_back("-std=c++17");
+
+    Args.AddLastArg(CmdArgs, options::OPT_ftrigraphs,
+                    options::OPT_fno_trigraphs);
   } else {
     // Honor -std-default.
     //

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5078,13 +5078,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                                  options::OPT_fno_trigraphs))
       if (A != Std)
         A->render(Args, CmdArgs);
-  } else if (IsSYCL && types::isCXX(InputType)) {
-    // For DPC++, we default to -std=c++17 for all compilations.  Use of -std
-    // on the command line will override.
-    CmdArgs.push_back("-std=c++17");
-
-    Args.AddLastArg(CmdArgs, options::OPT_ftrigraphs,
-                    options::OPT_fno_trigraphs);
   } else {
     // Honor -std-default.
     //
@@ -5097,6 +5090,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                                 /*Joined=*/true);
     else if (IsWindowsMSVC)
       ImplyVCPPCXXVer = true;
+    else if (IsSYCL)
+      // For DPC++, we default to -std=c++17 for all compilations.  Use of -std
+      // on the command line will override.
+      CmdArgs.push_back("-std=c++17");
 
     Args.AddLastArg(CmdArgs, options::OPT_ftrigraphs,
                     options::OPT_fno_trigraphs);
@@ -5665,7 +5662,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
     if (LanguageStandard.empty()) {
       if (IsMSVC2015Compatible)
-        LanguageStandard = "-std=c++14";
+        if (IsSYCL)
+          // For DPC++, C++17 is the default.
+          LanguageStandard = "-std=c++17";
+        else
+          LanguageStandard = "-std=c++14";
       else
         LanguageStandard = "-std=c++11";
     }

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -821,5 +821,11 @@
 // CHECK-STD: clang{{.*}} "-fsyntax-only" {{.*}} "-std=c++17"
 // CHECK-STD: clang{{.*}} "-emit-obj" {{.*}} "-std=c++17"
 
+// -std=c++17 override check
+// RUN: %clangxx -### -c -fsycl -std=c++14 -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
+// RUN: %clang_cl -### -c -fsycl /std:c++14 -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
+// CHECK-STD-OVR: clang{{.*}} "-std=c++14"
+// CHECK-STD-OVR-NOT: clang{{.*}} "-std=c++17"
+
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -814,5 +814,12 @@
 // RUN: %clangxx -### -c -fsycl -xc-header %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
 // CHECK_XC_FSYCL: The option -x c{{.*}} must not be used in conjunction with -fsycl{{.*}}
 
+// -std=c++17 check (check all 3 compilations)
+// RUN: %clangxx -### -c -fsycl -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD %s
+// RUN: %clang_cl -### -c -fsycl -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD %s
+// CHECK-STD: clang{{.*}} "-emit-llvm-bc" {{.*}} "-std=c++17"
+// CHECK-STD: clang{{.*}} "-fsyntax-only" {{.*}} "-std=c++17"
+// CHECK-STD: clang{{.*}} "-emit-obj" {{.*}} "-std=c++17"
+
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc

--- a/sycl/doc/FAQ.md
+++ b/sycl/doc/FAQ.md
@@ -19,7 +19,7 @@ set up a proper environment. To learn more about using the DPC++ compiler,
 please refer to [Users Manual](UsersManual.md). If using a special compiler
 is not an option for you and/or you would like to experiment without offloading
 code to non-host devices, you can exploit SYCL's host device feature. This
-gives you the ability to use any C++14 compiler. You will need to link your
+gives you the ability to use any C++17 compiler. You will need to link your
 application with the DPC++ Runtime library and provide a path to the SYCL
 headers directory. Please, refer to your compiler manual to learn about
 specific build options.

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -516,7 +516,7 @@ class CUDASelector : public cl::sycl::device_selector {
 ## C++ standard
 
 - DPC++ runtime is built as C++14 library.
-- DPC++ compiler is building apps as C++14 apps by default.
+- DPC++ compiler is building apps as C++17 apps by default.
 
 ## Known Issues and Limitations
 

--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -16,7 +16,7 @@
 // CHECK-NEXT: FieldDecl {{.*}} MAssociatedAccesors 'vector_class<detail::ArgDesc>':'std::vector<cl::sycl::detail::ArgDesc, std::allocator<cl::sycl::detail::ArgDesc>>'
 // CHECK-NEXT: FieldDecl {{.*}} MRequirements 'vector_class<detail::Requirement *>':'std::vector<cl::sycl::detail::AccessorImplHost *, std::allocator<cl::sycl::detail::AccessorImplHost *>>'
 // CHECK-NEXT: FieldDecl {{.*}} MNDRDesc 'detail::NDRDescT':'cl::sycl::detail::NDRDescT'
-// CHECK-NEXT: FieldDecl {{.*}} MKernelName 'cl::sycl::string_class':'std::__cxx11::basic_string<char>'
+// CHECK-NEXT: FieldDecl {{.*}} MKernelName 'cl::sycl::string_class':'std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>'
 // CHECK-NEXT: FieldDecl {{.*}} MKernel 'shared_ptr_class<detail::kernel_impl>':'std::shared_ptr<cl::sycl::detail::kernel_impl>'
 // CHECK-NEXT: FieldDecl {{.*}} MCGType 'detail::CG::CGTYPE':'cl::sycl::detail::CG::CGTYPE'
 // CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::detail::CG::CGTYPE' EnumConstant {{.*}} 'NONE' 'cl::sycl::detail::CG::CGTYPE'


### PR DESCRIPTION
This forces -std=c++17 for DPC++ when no -std* option is provided on
the command line.  Only enabled with -fsycl

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>