### PR TITLE
[Driver][SYCL][FPGA] Update dependency file handling for -fintelfpga

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -635,6 +635,9 @@ private:
   bool checkForOffloadStaticLib(Compilation &C,
                                 llvm::opt::DerivedArgList &Args) const;
 
+  /// Track filename used for the FPGA dependency info.
+  mutable llvm::StringMap<const std::string> FPGATempDepFiles;
+
 public:
   /// GetReleaseVersion - Parse (([0-9]+)(.([0-9]+)(.([0-9]+)?))?)? and
   /// return the grouped values as integers. Numbers which are not
@@ -658,6 +661,20 @@ public:
   static void getDefaultModuleCachePath(SmallVectorImpl<char> &Result);
 
   bool getOffloadStaticLibSeen() const { return OffloadStaticLibSeen; };
+
+  /// addFPGATempDepFile - Add a file to be added to the bundling step of
+  /// an FPGA object.
+  std::string addFPGATempDepFile(const std::string &Name,
+                                 const std::string &JA) const {
+    std::pair<std::string, std::string> TP(JA, Name);
+    FPGATempDepFiles.insert(TP);
+    return Name;
+  }
+  /// getFPGATempDepFile - Get a file to be added to the bundling step of
+  /// an FPGA object.
+  const std::string getFPGATempDepFile(const std::string &JA) const {
+    return FPGATempDepFiles[JA];
+  }
 };
 
 /// \return True if the last defined optimization level is -Ofast.

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -664,15 +664,14 @@ public:
 
   /// addFPGATempDepFile - Add a file to be added to the bundling step of
   /// an FPGA object.
-  void addFPGATempDepFile(const std::string &Name,
-                          const std::string &JA) const {
-    std::pair<std::string, std::string> TP(JA, Name);
-    FPGATempDepFiles.insert(TP);
+  void addFPGATempDepFile(const std::string &DepName,
+                          const std::string &FileName) const {
+    FPGATempDepFiles.insert({FileName, DepName});
   }
   /// getFPGATempDepFile - Get a file to be added to the bundling step of
   /// an FPGA object.
-  const std::string getFPGATempDepFile(const std::string &JA) const {
-    return FPGATempDepFiles[JA];
+  const std::string getFPGATempDepFile(const std::string &FileName) const {
+    return FPGATempDepFiles[FileName];
   }
 };
 

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -664,11 +664,10 @@ public:
 
   /// addFPGATempDepFile - Add a file to be added to the bundling step of
   /// an FPGA object.
-  std::string addFPGATempDepFile(const std::string &Name,
-                                 const std::string &JA) const {
+  void addFPGATempDepFile(const std::string &Name,
+                          const std::string &JA) const {
     std::pair<std::string, std::string> TP(JA, Name);
     FPGATempDepFiles.insert(TP);
-    return Name;
   }
   /// getFPGATempDepFile - Get a file to be added to the bundling step of
   /// an FPGA object.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1143,9 +1143,8 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
     } else if (ArgMD->getOption().matches(options::OPT_MMD) &&
                Args.hasArg(options::OPT_fintelfpga) &&
                JA.isDeviceOffloading(Action::OFK_SYCL)) {
-      // When generating dependency files for FPGA AOT, the output files will
-      // always be temporary.  Generate here, which will be used for the aoc
-      // call as well as bundling.
+      // Generate dependency files as temporary. These will be used for the
+      // aoc call/bundled during fat object creation
       std::string BaseName(Clang::getBaseInputName(Args, Inputs[0]));
       std::string DepTmpName =
           C.getDriver().GetTemporaryPath(llvm::sys::path::stem(BaseName), "d");
@@ -7217,8 +7216,10 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
   if (IsFPGADepBundle) {
     const char *BaseName = Clang::getBaseInputName(TCArgs, Inputs[0]);
     SmallString<128> DepFile(C.getDriver().getFPGATempDepFile(BaseName));
-    UB += ',';
-    UB += DepFile;
+    if (!DepFile.empty()) {
+      UB += ',';
+      UB += DepFile;
+    }
   }
   CmdArgs.push_back(TCArgs.MakeArgString(UB));
 

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -252,10 +252,11 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
       ArgName = llvm::sys::path::filename(ArgName);
       if (types::isSrcFile(Ty)) {
         SmallString<128> DepName(
-            C.getDriver().getFPGATempDepFile(StringRef(ArgName).str()));
-        FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
-                                         Args.MakeArgString(DepName),
-                                         Args.MakeArgString(DepName)));
+            C.getDriver().getFPGATempDepFile(std::string(ArgName)));
+        if (!DepName.empty())
+          FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
+                                           Args.MakeArgString(DepName),
+                                           Args.MakeArgString(DepName)));
       }
       if (createdReportName.empty()) {
         // Project report should be saved into CWD, so strip off any

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -247,14 +247,12 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
     if (Ty == types::TY_INVALID)
       continue;
     if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
-      // Dependency files and the project report are created in CWD, so strip
-      // off any directory information if provided with the input file.
-      // TODO - Use temporary files for dependency file creation and
-      // usage with -fintelfpga.
+      // The project report is created in CWD, so strip off any directory
+      // information if provided with the input file.
       ArgName = llvm::sys::path::filename(ArgName);
       if (types::isSrcFile(Ty)) {
-        SmallString<128> DepName(ArgName);
-        llvm::sys::path::replace_extension(DepName, "d");
+        SmallString<128> DepName(
+            C.getDriver().getFPGATempDepFile(StringRef(ArgName).str()));
         FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
                                          Args.MakeArgString(DepName),
                                          Args.MakeArgString(DepName)));

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -298,7 +298,7 @@
 // RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-OPT2 %s
 // RUN: %clang_cl -### -fsycl -fintelfpga %t_dir/dummy.cpp 2>&1 \
 // RUN:  | FileCheck -DOUTDIR=%t_dir -check-prefix=CHK-FPGA-REPORT-OPT2 %s
-// CHK-FPGA-REPORT-OPT2: aoc{{.*}} "-sycl"{{.*}} "-dep-files=dummy.d" "-output-report-folder=dummy.prj"
+// CHK-FPGA-REPORT-OPT2: aoc{{.*}} "-sycl"{{.*}} "-dep-files={{.+}}dummy-{{.+}}.d" "-output-report-folder=dummy.prj"
 // CHK-FPGA-REPORT-OPT2-NOT: aoc{{.*}} "-sycl" {{.*}}[[OUTDIR]]{{.*}}
 
 /// -fintelfpga output report file should be based on first input (src/obj)
@@ -320,9 +320,9 @@
 /// -fintelfpga output dep file using -Fo<dir>
 // RUN: mkdir -p %t_dir
 // RUN: %clang_cl -### -c -fsycl -fintelfpga -Fo%t_dir/ %s 2>&1 \
-// RUN:  | FileCheck -DDEPDIR=%t_dir/ -check-prefix=CHK-FPGA-DEP-DIR %s
-// CHK-FPGA-DEP-DIR: clang{{.*}} "-dependency-file" "[[DEPDIR]][[DEPFILE:.+\.d]]"
-// CHK-FPGA-DEP-DIR: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,{{.*}}.obj,[[DEPDIR]][[DEPFILE]]"
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-DEP-DIR %s
+// CHK-FPGA-DEP-DIR: clang{{.*}} "-dependency-file" "[[DEPFILE:.+\.d]]"
+// CHK-FPGA-DEP-DIR: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,{{.*}}.obj,[[DEPFILE]]"
 
 /// -fintelfpga static lib (aoco)
 // RUN:  echo "Dummy AOCO image" > %t.aoco

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -301,6 +301,14 @@
 // CHK-FPGA-REPORT-OPT2: aoc{{.*}} "-sycl"{{.*}} "-dep-files={{.+}}dummy-{{.+}}.d" "-output-report-folder=dummy.prj"
 // CHK-FPGA-REPORT-OPT2-NOT: aoc{{.*}} "-sycl" {{.*}}[[OUTDIR]]{{.*}}
 
+/// -fintelfpga dependency files from multiple source
+// RUN: touch dummy2.cpp
+// RUN: %clangxx -### -fsycl -fintelfpga %t_dir/dummy.cpp dummy2.cpp 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-MULTI-DEPS %s
+// RUN: %clang_cl -### -fsycl -fintelfpga %t_dir/dummy.cpp dummy2.cpp 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK-FPGA-MULTI-DEPS %s
+// CHK-FPGA-MULTI-DEPS: aoc{{.*}} "-sycl"{{.*}} "-dep-files={{.+}}dummy-{{.+}}.d,{{.+}}dummy2-{{.+}}.d" "-output-report-folder=dummy.prj"
+
 /// -fintelfpga output report file should be based on first input (src/obj)
 // RUN: mkdir -p %t_dir
 // RUN: touch %t_dir/dummy1.cpp
@@ -316,13 +324,6 @@
 // RUN: %clang_cl -### -fsycl -fintelfpga %t_dir/dummy2.cpp %t_dir/dummy1.o 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK-FPGA-REPORT-NAME %s
 // CHK-FPGA-REPORT-NAME: aoc{{.*}} "-sycl"{{.*}} "-output-report-folder=dummy2.prj"
-
-/// -fintelfpga output dep file using -Fo<dir>
-// RUN: mkdir -p %t_dir
-// RUN: %clang_cl -### -c -fsycl -fintelfpga -Fo%t_dir/ %s 2>&1 \
-// RUN:  | FileCheck -check-prefix=CHK-FPGA-DEP-DIR %s
-// CHK-FPGA-DEP-DIR: clang{{.*}} "-dependency-file" "[[DEPFILE:.+\.d]]"
-// CHK-FPGA-DEP-DIR: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,{{.*}}.obj,[[DEPFILE]]"
 
 /// -fintelfpga static lib (aoco)
 // RUN:  echo "Dummy AOCO image" > %t.aoco


### PR DESCRIPTION
When generating dependency files for FPGA, create to a temporary file instead
of a CWD file based on the input source.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>