### PR TITLE
[Buildbot][NFC] Simplify configure.py script

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -99,6 +99,8 @@ def do_configure(args):
             os.remove(cmake_cache)
         subprocess.check_call(cmake_cmd, cwd=abs_obj_dir)
 
+    return True
+
 def main():
     parser = argparse.ArgumentParser(prog="configure.py",
                                      description="Generate build files from CMake configuration files",
@@ -130,5 +132,4 @@ def main():
 
     do_configure(args)
 
-if __name__ == "__main__":
-    sys.exist(0)
+    sys.exit(0)

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -129,3 +129,5 @@ def main():
     print("args:{}".format(args))
 
     do_configure(args)
+
+    sys.exist(0)

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -130,6 +130,9 @@ def main():
 
     print("args:{}".format(args))
 
-    do_configure(args)
+    return do_configure(args)
 
-    sys.exit(0)
+if __name__ == "__main__":
+    ret = main()
+    exit_code = 0 if ret else 1
+    sys.exit(exit_code)

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -1,22 +1,15 @@
 import argparse
 import os
+import platform
 import subprocess
 import sys
-import platform
 
 def do_configure(args):
-    ret = False
-
     # Get absolute path to source directory
-    if args.src_dir:
-      abs_src_dir = os.path.abspath(args.src_dir)
-    else:
-      abs_src_dir = os.path.abspath(os.path.join(__file__, "../.."))
+    abs_src_dir = os.path.abspath(args.src_dir if args.src_dir else os.path.join(__file__, "../.."))
     # Get absolute path to build directory
-    if args.obj_dir:
-      abs_obj_dir = os.path.abspath(args.obj_dir)
-    else:
-      abs_obj_dir = os.path.join(abs_src_dir, "build")
+    abs_obj_dir = os.path.abspath(args.obj_dir if args.obj_dir else abs_src_dir, "build")
+    # Create build directory if it doesn't exist
     if not os.path.isdir(abs_obj_dir):
       os.makedirs(abs_obj_dir)
 
@@ -37,10 +30,7 @@ def do_configure(args):
     llvm_enable_sphinx = 'OFF'
     llvm_build_shared_libs = 'OFF'
 
-    if platform.system() == 'Linux':
-        icd_loader_lib = os.path.join(icd_loader_lib, "libOpenCL.so")
-    else:
-        icd_loader_lib = os.path.join(icd_loader_lib, "OpenCL.lib")
+    icd_loader_lib = os.path.join(icd_loader_lib, "libOpenCL.so" if platform.system() == 'Linux' else "OpenCL.lib")
 
     if args.cuda:
         llvm_targets_to_build += ';NVPTX'
@@ -109,19 +99,18 @@ def do_configure(args):
             os.remove(cmake_cache)
         subprocess.check_call(cmake_cmd, cwd=abs_obj_dir)
 
-    ret = True
-    return ret
-
 def main():
     parser = argparse.ArgumentParser(prog="configure.py",
                                      description="Generate build files from CMake configuration files",
                                      formatter_class=argparse.RawTextHelpFormatter)
+    # CI system options
     parser.add_argument("-n", "--build-number", metavar="BUILD_NUM", help="build number")
     parser.add_argument("-b", "--branch", metavar="BRANCH", help="pull request branch")
     parser.add_argument("-d", "--base-branch", metavar="BASE_BRANCH", help="pull request base branch")
     parser.add_argument("-r", "--pr-number", metavar="PR_NUM", help="pull request number")
     parser.add_argument("-w", "--builder-dir", metavar="BUILDER_DIR",
                         help="builder directory, which is the directory contains source and build directories")
+    # User options
     parser.add_argument("-s", "--src-dir", metavar="SRC_DIR", help="source directory (autodetected by default)")
     parser.add_argument("-o", "--obj-dir", metavar="OBJ_DIR", help="build directory. (<src>/build by default)")
     parser.add_argument("-t", "--build-type",
@@ -139,9 +128,4 @@ def main():
 
     print("args:{}".format(args))
 
-    return do_configure(args)
-
-if __name__ == "__main__":
-    ret = main()
-    exit_code = 0 if ret else 1
-    sys.exit(exit_code)
+    do_configure(args)

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -8,7 +8,7 @@ def do_configure(args):
     # Get absolute path to source directory
     abs_src_dir = os.path.abspath(args.src_dir if args.src_dir else os.path.join(__file__, "../.."))
     # Get absolute path to build directory
-    abs_obj_dir = os.path.abspath(args.obj_dir if args.obj_dir else abs_src_dir, "build")
+    abs_obj_dir = os.path.abspath(args.obj_dir) if args.obj_dir else os.path.join(abs_src_dir, "build")
     # Create build directory if it doesn't exist
     if not os.path.isdir(abs_obj_dir):
       os.makedirs(abs_obj_dir)

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -130,4 +130,5 @@ def main():
 
     do_configure(args)
 
+if __name__ == "__main__":
     sys.exist(0)


### PR DESCRIPTION
Remove error code handling as script doesn't return any errors.
Use "if-else" python idiom to make the script more readable.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>