### PR TITLE
[SYCL] Add support for kernel name types templated using enums.

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -283,15 +283,16 @@ public:
   /// Creating this name is expensive, so it should be called only when
   /// performance doesn't matter.
   void printQualifiedName(raw_ostream &OS) const;
-  void printQualifiedName(raw_ostream &OS, const PrintingPolicy &Policy) const;
+  void printQualifiedName(raw_ostream &OS, const PrintingPolicy &Policy,
+                          bool WithGlobalNsPrefix = false) const;
 
   /// Print only the nested name specifier part of a fully-qualified name,
   /// including the '::' at the end. E.g.
   ///    when `printQualifiedName(D)` prints "A::B::i",
   ///    this function prints "A::B::".
   void printNestedNameSpecifier(raw_ostream &OS) const;
-  void printNestedNameSpecifier(raw_ostream &OS,
-                                const PrintingPolicy &Policy) const;
+  void printNestedNameSpecifier(raw_ostream &OS, const PrintingPolicy &Policy,
+                                bool WithGlobalNsPrefix = false) const;
 
   // FIXME: Remove string version.
   std::string getQualifiedNameAsString() const;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10762,7 +10762,7 @@ def err_builtin_launder_invalid_arg : Error<
 def err_sycl_kernel_incorrectly_named : Error<
   "kernel %select{name is missing"
   "|needs to have a globally-visible name"
-  "|name cannot be templated using unscoped enum without fixed underlying type"
+  "|name is invalid. Unscoped enum requires fixed underlying type"
   "}0">;
 def err_sycl_restrict : Error<
   "SYCL kernel cannot "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10761,7 +10761,9 @@ def err_builtin_launder_invalid_arg : Error<
 // SYCL-specific diagnostics
 def err_sycl_kernel_incorrectly_named : Error<
   "kernel %select{name is missing"
-  "|needs to have a globally-visible name}0">;
+  "|needs to have a globally-visible name"
+  "|name cannot be templated using unscoped enum without fixed underlying type"
+  "}0">;
 def err_sycl_restrict : Error<
   "SYCL kernel cannot "
 "%select{use a non-const global variable"

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1594,9 +1594,8 @@ void NamedDecl::printNestedNameSpecifier(raw_ostream &OS,
     Ctx = Ctx->getParent();
   }
 
-  if (WithGlobalNsPrefix) {
+  if (WithGlobalNsPrefix)
     OS << "::";
-  }
 
   for (const DeclContext *DC : llvm::reverse(Contexts)) {
     if (const auto *Spec = dyn_cast<ClassTemplateSpecializationDecl>(DC)) {

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1594,9 +1594,8 @@ void NamedDecl::printNestedNameSpecifier(raw_ostream &OS,
     Ctx = Ctx->getParent();
   }
 
-  if (Contexts.empty() && WithGlobalNsPrefix) {
-    if (getDeclContext()->isTranslationUnit())
-      OS << "::";
+  if (WithGlobalNsPrefix) {
+    OS << "::";
   }
 
   for (const DeclContext *DC : llvm::reverse(Contexts)) {
@@ -1611,10 +1610,7 @@ void NamedDecl::printNestedNameSpecifier(raw_ostream &OS,
       if (ND->isAnonymousNamespace()) {
         OS << (P.MSVCFormatting ? "`anonymous namespace\'"
                                 : "(anonymous namespace)");
-      } else if (WithGlobalNsPrefix &&
-                 ND->getDeclContext()->isTranslationUnit())
-        OS << "::" << *ND;
-      else
+      } else
         OS << *ND;
     } else if (const auto *RD = dyn_cast<RecordDecl>(DC)) {
       if (!RD->getIdentifier())

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1698,6 +1698,10 @@ void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D,
 
   if (const auto *ED = dyn_cast<EnumDecl>(D)) {
     QualType T = ED->getIntegerType();
+    // Backup since getIntegerType() returns null for enum forward
+    // declaration with no fixed underlying type
+    if (!T)
+      T = ED->getPromotionType();
     O << " : " << T.getAsString() << ";\n";
   } else
     O << ";\n";

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1644,9 +1644,9 @@ static bool checkEnumTemplateParameter(const EnumDecl *ED,
     Diag.Report(KernelLocation, diag::err_sycl_kernel_incorrectly_named) << 2;
     Diag.Report(ED->getSourceRange().getBegin(), diag::note_entity_declared_at)
         << ED;
-    return false;
+    return true;
   }
-  return true;
+  return false;
 }
 
 // Emits a forward declaration
@@ -1794,7 +1794,7 @@ void SYCLIntegrationHeader::emitForwardClassDecls(
         // Handle Kernel Name Type templated using enum type and value.
         if (const auto *ET = T->getAs<EnumType>()) {
           const EnumDecl *ED = ET->getDecl();
-          if (checkEnumTemplateParameter(ED, Diag, KernelLocation))
+          if (!checkEnumTemplateParameter(ED, Diag, KernelLocation))
             emitFwdDecl(O, ED, KernelLocation);
         } else if (Arg.getKind() == TemplateArgument::ArgKind::Type)
           emitForwardClassDecls(O, T, KernelLocation, Printed);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1711,6 +1711,7 @@ void SYCLIntegrationHeader::emitFwdDecl(raw_ostream &O, const Decl *D,
   PrintingPolicy P(D->getASTContext().getLangOpts());
   P.adjustForCPlusPlusFwdDecl();
   P.SuppressTypedefs = true;
+  P.SuppressUnwrittenScope = true;
   std::string S;
   llvm::raw_string_ostream SO(S);
   D->print(SO, P);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1884,14 +1884,11 @@ static void printArgument(ASTContext &Ctx, raw_ostream &ArgOS,
 static void printArguments(ASTContext &Ctx, raw_ostream &ArgOS,
                            ArrayRef<TemplateArgument> Args,
                            const PrintingPolicy &P) {
-  bool FirstArg = true;
-  const char *Comma = ", ";
-
   for (unsigned I = 0; I < Args.size(); I++) {
     const TemplateArgument &Arg = Args[I];
 
-    if (!FirstArg)
-      ArgOS << Comma;
+    if (I != 0)
+      ArgOS << ", ";
 
     printArgument(Ctx, ArgOS, Arg, P);
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1892,7 +1892,6 @@ static void printArguments(ASTContext &Ctx, raw_ostream &ArgOS,
 
     printArgument(Ctx, ArgOS, Arg, P);
 
-    FirstArg = false;
   }
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1891,7 +1891,6 @@ static void printArguments(ASTContext &Ctx, raw_ostream &ArgOS,
       ArgOS << ", ";
 
     printArgument(Ctx, ArgOS, Arg, P);
-
   }
 }
 

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -4,14 +4,14 @@
 // CHECK:template <> struct KernelInfo<class KernelName> {
 // CHECK:template <> struct KernelInfo<::nm1::nm2::KernelName0> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName1> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName3< ::nm1::nm2::KernelName0>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName3< ::nm1::KernelName1>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName4< ::nm1::nm2::KernelName0>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName4< ::nm1::KernelName1>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName3<KernelName5>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName4<KernelName7>> {
-// CHECK:template <> struct KernelInfo<::nm1::KernelName8< ::nm1::nm2::C>> {
-// CHECK:template <> struct KernelInfo<class TmplClassInAnonNS<class ClassInAnonNS>> {
+// CHECK:template <> struct KernelInfo<nm1::KernelName3<nm1::nm2::KernelName0>> {
+// CHECK:template <> struct KernelInfo<nm1::KernelName3<nm1::KernelName1>> {
+// CHECK:template <> struct KernelInfo<nm1::KernelName4<nm1::nm2::KernelName0>> {
+// CHECK:template <> struct KernelInfo<nm1::KernelName4<nm1::KernelName1>> {
+// CHECK:template <> struct KernelInfo<nm1::KernelName3<KernelName5>> {
+// CHECK:template <> struct KernelInfo<nm1::KernelName4<KernelName7>> {
+// CHECK:template <> struct KernelInfo<nm1::KernelName8<::nm1::nm2::C>> {
+// CHECK:template <> struct KernelInfo<TmplClassInAnonNS<ClassInAnonNS>> {
 
 // This test checks if the SYCL device compiler is able to generate correct
 // integration header when the kernel name class is expressed in different

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -11,7 +11,7 @@
 // CHECK:template <> struct KernelInfo<::nm1::KernelName3<KernelName5>> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName4<KernelName7>> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName8<::nm1::nm2::C>> {
-// CHECK:template <> struct KernelInfo<TmplClassInAnonNS<ClassInAnonNS>> {
+// CHECK:template <> struct KernelInfo<::TmplClassInAnonNS<ClassInAnonNS>> {
 
 // This test checks if the SYCL device compiler is able to generate correct
 // integration header when the kernel name class is expressed in different

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -4,13 +4,13 @@
 // CHECK:template <> struct KernelInfo<class KernelName> {
 // CHECK:template <> struct KernelInfo<::nm1::nm2::KernelName0> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName1> {
-// CHECK:template <> struct KernelInfo<nm1::KernelName3<nm1::nm2::KernelName0>> {
-// CHECK:template <> struct KernelInfo<nm1::KernelName3<nm1::KernelName1>> {
-// CHECK:template <> struct KernelInfo<nm1::KernelName4<nm1::nm2::KernelName0>> {
-// CHECK:template <> struct KernelInfo<nm1::KernelName4<nm1::KernelName1>> {
-// CHECK:template <> struct KernelInfo<nm1::KernelName3<KernelName5>> {
-// CHECK:template <> struct KernelInfo<nm1::KernelName4<KernelName7>> {
-// CHECK:template <> struct KernelInfo<nm1::KernelName8<::nm1::nm2::C>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName3<::nm1::nm2::KernelName0>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName3<::nm1::KernelName1>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName4<::nm1::nm2::KernelName0>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName4<::nm1::KernelName1>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName3<KernelName5>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName4<KernelName7>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName8<::nm1::nm2::C>> {
 // CHECK:template <> struct KernelInfo<TmplClassInAnonNS<ClassInAnonNS>> {
 
 // This test checks if the SYCL device compiler is able to generate correct

--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -56,9 +56,9 @@
 // CHECK-NEXT: };
 //
 // CHECK: template <> struct KernelInfo<class first_kernel> {
-// CHECK: template <> struct KernelInfo<::second_namespace::second_kernel<char>> {
-// CHECK: template <> struct KernelInfo<::third_kernel<1, int, ::point<X> >> {
-// CHECK: template <> struct KernelInfo<::fourth_kernel< ::template_arg_ns::namespaced_arg<1> >> {
+// CHECK: template <> struct KernelInfo<second_namespace::second_kernel<char>> {
+// CHECK: template <> struct KernelInfo<third_kernel<1, int, point<X>>> {
+// CHECK: template <> struct KernelInfo<fourth_kernel<::template_arg_ns::namespaced_arg<1>>> {
 
 #include "sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -56,9 +56,9 @@
 // CHECK-NEXT: };
 //
 // CHECK: template <> struct KernelInfo<class first_kernel> {
-// CHECK: template <> struct KernelInfo<second_namespace::second_kernel<char>> {
-// CHECK: template <> struct KernelInfo<third_kernel<1, int, point<X>>> {
-// CHECK: template <> struct KernelInfo<fourth_kernel<::template_arg_ns::namespaced_arg<1>>> {
+// CHECK: template <> struct KernelInfo<::second_namespace::second_kernel<char>> {
+// CHECK: template <> struct KernelInfo<::third_kernel<1, int, ::point<X>>> {
+// CHECK: template <> struct KernelInfo<::fourth_kernel<::template_arg_ns::namespaced_arg<1>>> {
 
 #include "sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
+++ b/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
@@ -100,37 +100,37 @@ struct kernel_name4;
 int main() {
   dummy_functor f;
   // non-type template arguments
-  // CHECK: template <> struct KernelInfo<kernel_name1<1, 1>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name1<1, 1>> {
   single_task<kernel_name1<1, 1>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name1v1<1, 1>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name1v1<1, 1>> {
   single_task<kernel_name1v1<1, 1>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name1v2<1, 1>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name1v2<1, 1>> {
   single_task<kernel_name1v2<1, 1>>(f);
   // partial template specialization
-  // CHECK: template <> struct KernelInfo<kernel_name2<int, int>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<int, int>> {
   single_task<kernel_name2<int_t, int>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name2<const int, char>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<const int, char>> {
   single_task<kernel_name2<cint_t, char>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name2<long, float>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<long, float>> {
   single_task<kernel_name2<space::long_t, float>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name2<const long, A>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<const long, ::A>> {
   single_task<kernel_name2<const space::long_t, space::a_t>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name2<const volatile long, const space::B>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<const volatile long, const ::space::B>> {
   single_task<kernel_name2<volatile space::clong_t, const space::b_t>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name2<A, long>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<::A, long>> {
   single_task<kernel_name2<space::a_t, space::long_t>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name2<space::B, int>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<::space::B, int>> {
   single_task<kernel_name2<space::b_t, int_t>>(f);
   // full template specialization
-  // CHECK: template <> struct KernelInfo<kernel_name2<int, const unsigned int>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<int, const unsigned int>> {
   single_task<kernel_name2<int_t, const uint_t>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name2<const long, const volatile unsigned long>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<const long, const volatile unsigned long>> {
   single_task<kernel_name2<space::clong_t, volatile space::culong_t>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name2<A, volatile space::B>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name2<::A, volatile ::space::B>> {
   single_task<kernel_name2<space::a_t, volatile space::b_t>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name3<1>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name3<1>> {
   single_task<kernel_name3<1>>(f);
-  // CHECK: template <> struct KernelInfo<kernel_name4<1>> {
+  // CHECK: template <> struct KernelInfo<::kernel_name4<1>> {
   single_task<kernel_name4<1>>(f);
 
   return 0;

--- a/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
+++ b/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
@@ -100,37 +100,37 @@ struct kernel_name4;
 int main() {
   dummy_functor f;
   // non-type template arguments
-  // CHECK: template <> struct KernelInfo<::kernel_name1<1, 1>> {
+  // CHECK: template <> struct KernelInfo<kernel_name1<1, 1>> {
   single_task<kernel_name1<1, 1>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name1v1<1, 1>> {
+  // CHECK: template <> struct KernelInfo<kernel_name1v1<1, 1>> {
   single_task<kernel_name1v1<1, 1>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name1v2<1, 1>> {
+  // CHECK: template <> struct KernelInfo<kernel_name1v2<1, 1>> {
   single_task<kernel_name1v2<1, 1>>(f);
   // partial template specialization
-  // CHECK: template <> struct KernelInfo<::kernel_name2<int, int>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<int, int>> {
   single_task<kernel_name2<int_t, int>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name2<const int, char>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<const int, char>> {
   single_task<kernel_name2<cint_t, char>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name2<long, float>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<long, float>> {
   single_task<kernel_name2<space::long_t, float>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name2<const long, ::A>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<const long, A>> {
   single_task<kernel_name2<const space::long_t, space::a_t>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name2<const volatile long, const ::space::B>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<const volatile long, const space::B>> {
   single_task<kernel_name2<volatile space::clong_t, const space::b_t>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name2< ::A, long>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<A, long>> {
   single_task<kernel_name2<space::a_t, space::long_t>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name2< ::space::B, int>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<space::B, int>> {
   single_task<kernel_name2<space::b_t, int_t>>(f);
   // full template specialization
-  // CHECK: template <> struct KernelInfo<::kernel_name2<int, const unsigned int>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<int, const unsigned int>> {
   single_task<kernel_name2<int_t, const uint_t>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name2<const long, volatile const unsigned long>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<const long, const volatile unsigned long>> {
   single_task<kernel_name2<space::clong_t, volatile space::culong_t>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name2< ::A, volatile ::space::B>> {
+  // CHECK: template <> struct KernelInfo<kernel_name2<A, volatile space::B>> {
   single_task<kernel_name2<space::a_t, volatile space::b_t>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name3<1>> {
+  // CHECK: template <> struct KernelInfo<kernel_name3<1>> {
   single_task<kernel_name3<1>>(f);
-  // CHECK: template <> struct KernelInfo<::kernel_name4<1>> {
+  // CHECK: template <> struct KernelInfo<kernel_name4<1>> {
   single_task<kernel_name4<1>>(f);
 
   return 0;

--- a/clang/test/CodeGenSYCL/kernelname-enum.cpp
+++ b/clang/test/CodeGenSYCL/kernelname-enum.cpp
@@ -20,6 +20,13 @@ enum class namespace_short : short {
 };
 }
 
+namespace {
+enum class enum_in_anonNS : short {
+  val_1,
+  val_2
+};
+}
+
 template <no_namespace_int EnumType>
 class dummy_functor_1 {
 public:
@@ -38,11 +45,18 @@ public:
   void operator()() {}
 };
 
+template <enum_in_anonNS EnumType>
+class dummy_functor_4 {
+public:
+  void operator()() {}
+};
+
 int main() {
 
   dummy_functor_1<no_namespace_int::val_1> f1;
   dummy_functor_2<no_namespace_short::val_2> f2;
   dummy_functor_3<internal::namespace_short::val_2> f3;
+  dummy_functor_4<enum_in_anonNS::val_2> f4;
 
   cl::sycl::queue q;
 
@@ -58,6 +72,10 @@ int main() {
     cgh.single_task(f3);
   });
 
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f4);
+  });
+
   return 0;
 }
 
@@ -70,8 +88,13 @@ int main() {
 // CHECK-NEXT: enum class namespace_short : short;
 // CHECK-NEXT: }
 // CHECK: template <internal::namespace_short EnumType> class dummy_functor_3;
+// CHECK: namespace  {
+// CHECK-NEXT: enum class enum_in_anonNS : short;
+// CHECK-NEXT: }
+// CHECK: template <enum_in_anonNS EnumType> class dummy_functor_4;
 
 // CHECK: Specializations of KernelInfo for kernel function types:
 // CHECK: template <> struct KernelInfo<dummy_functor_1<(no_namespace_int)0>>
 // CHECK: template <> struct KernelInfo<dummy_functor_2<(no_namespace_short)1>>
 // CHECK: template <> struct KernelInfo<dummy_functor_3<(internal::namespace_short)1>>
+// CHECK: template <> struct KernelInfo<dummy_functor_4<(enum_in_anonNS)1>>

--- a/clang/test/CodeGenSYCL/kernelname-enum.cpp
+++ b/clang/test/CodeGenSYCL/kernelname-enum.cpp
@@ -3,6 +3,16 @@
 
 #include "sycl.hpp"
 
+enum unscoped_enum : int {
+  val_1,
+  val_2
+};
+
+enum unscoped_enum_no_type_set {
+  val_3,
+  val_4
+};
+
 enum class no_namespace_int : int {
   val_1,
   val_2
@@ -62,6 +72,18 @@ public:
   void operator()() {}
 };
 
+template <unscoped_enum EnumType>
+class dummy_functor_6 {
+public:
+  void operator()() {}
+};
+
+template <unscoped_enum_no_type_set EnumType>
+class dummy_functor_7 {
+public:
+  void operator()() {}
+};
+
 int main() {
 
   dummy_functor_1<no_namespace_int::val_1> f1;
@@ -69,6 +91,8 @@ int main() {
   dummy_functor_3<internal::namespace_short::val_2> f3;
   dummy_functor_4<enum_in_anonNS::val_2> f4;
   dummy_functor_5<no_type_set::val_1> f5;
+  dummy_functor_6<unscoped_enum::val_1> f6;
+  dummy_functor_7<unscoped_enum_no_type_set::val_4> f7;
 
   cl::sycl::queue q;
 
@@ -92,6 +116,14 @@ int main() {
     cgh.single_task(f5);
   });
 
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f6);
+  });
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f7);
+  });
+
   return 0;
 }
 
@@ -110,6 +142,10 @@ int main() {
 // CHECK: template <enum_in_anonNS EnumType> class dummy_functor_4;
 // CHECK: enum class no_type_set : int;
 // CHECK: template <no_type_set EnumType> class dummy_functor_5;
+// CHECK: enum unscoped_enum : int;
+// CHECK: template <unscoped_enum EnumType> class dummy_functor_6;
+// CHECK: enum unscoped_enum_no_type_set : unsigned int;
+// CHECK: template <unscoped_enum_no_type_set EnumType> class dummy_functor_7;
 
 // CHECK: Specializations of KernelInfo for kernel function types:
 // CHECK: template <> struct KernelInfo<::dummy_functor_1<(no_namespace_int)0>>
@@ -117,3 +153,5 @@ int main() {
 // CHECK: template <> struct KernelInfo<::dummy_functor_3<(internal::namespace_short)1>>
 // CHECK: template <> struct KernelInfo<::dummy_functor_4<(enum_in_anonNS)1>>
 // CHECK: template <> struct KernelInfo<::dummy_functor_5<(no_type_set)0>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_6<(unscoped_enum)0>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_7<(unscoped_enum_no_type_set)1>>

--- a/clang/test/CodeGenSYCL/kernelname-enum.cpp
+++ b/clang/test/CodeGenSYCL/kernelname-enum.cpp
@@ -1,0 +1,77 @@
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -fsycl-int-header=%t.h %s -fsyntax-only
+// RUN: FileCheck -input-file=%t.h %s
+
+#include "sycl.hpp"
+
+enum class no_namespace_int : int {
+  val_1,
+  val_2
+};
+
+enum class no_namespace_short : short {
+  val_1,
+  val_2
+};
+
+namespace internal {
+enum class namespace_short : short {
+  val_1,
+  val_2
+};
+}
+
+template <no_namespace_int EnumType>
+class dummy_functor_1 {
+public:
+  void operator()() {}
+};
+
+template <no_namespace_short EnumType>
+class dummy_functor_2 {
+public:
+  void operator()() {}
+};
+
+template <internal::namespace_short EnumType>
+class dummy_functor_3 {
+public:
+  void operator()() {}
+};
+
+int main() {
+
+  dummy_functor_1<no_namespace_int::val_1> f1;
+  dummy_functor_2<no_namespace_short::val_2> f2;
+  dummy_functor_3<internal::namespace_short::val_2> f3;
+
+  cl::sycl::queue q;
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f1);
+  });
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f2);
+  });
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f3);
+  });
+
+  return 0;
+}
+
+// CHECK: Forward declarations of templated kernel function types:
+// CHECK: enum class no_namespace_int : int;
+// CHECK: template <no_namespace_int EnumType> class dummy_functor_1;
+// CHECK: enum class no_namespace_short : short;
+// CHECK: template <no_namespace_short EnumType> class dummy_functor_2;
+// CHECK: namespace internal {
+// CHECK-NEXT: enum class namespace_short : short;
+// CHECK-NEXT: }
+// CHECK: template <internal::namespace_short EnumType> class dummy_functor_3;
+
+// CHECK: Specializations of KernelInfo for kernel function types:
+// CHECK: template <> struct KernelInfo<dummy_functor_1<(no_namespace_int)0>>
+// CHECK: template <> struct KernelInfo<dummy_functor_2<(no_namespace_short)1>>
+// CHECK: template <> struct KernelInfo<dummy_functor_3<(internal::namespace_short)1>>

--- a/clang/test/CodeGenSYCL/kernelname-enum.cpp
+++ b/clang/test/CodeGenSYCL/kernelname-enum.cpp
@@ -27,6 +27,11 @@ enum class enum_in_anonNS : short {
 };
 }
 
+enum class no_type_set {
+  val_1,
+  val_2
+};
+
 template <no_namespace_int EnumType>
 class dummy_functor_1 {
 public:
@@ -51,12 +56,19 @@ public:
   void operator()() {}
 };
 
+template <no_type_set EnumType>
+class dummy_functor_5 {
+public:
+  void operator()() {}
+};
+
 int main() {
 
   dummy_functor_1<no_namespace_int::val_1> f1;
   dummy_functor_2<no_namespace_short::val_2> f2;
   dummy_functor_3<internal::namespace_short::val_2> f3;
   dummy_functor_4<enum_in_anonNS::val_2> f4;
+  dummy_functor_5<no_type_set::val_1> f5;
 
   cl::sycl::queue q;
 
@@ -76,6 +88,10 @@ int main() {
     cgh.single_task(f4);
   });
 
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f5);
+  });
+
   return 0;
 }
 
@@ -92,9 +108,12 @@ int main() {
 // CHECK-NEXT: enum class enum_in_anonNS : short;
 // CHECK-NEXT: }
 // CHECK: template <enum_in_anonNS EnumType> class dummy_functor_4;
+// CHECK: enum class no_type_set : int;
+// CHECK: template <no_type_set EnumType> class dummy_functor_5;
 
 // CHECK: Specializations of KernelInfo for kernel function types:
-// CHECK: template <> struct KernelInfo<dummy_functor_1<(no_namespace_int)0>>
-// CHECK: template <> struct KernelInfo<dummy_functor_2<(no_namespace_short)1>>
-// CHECK: template <> struct KernelInfo<dummy_functor_3<(internal::namespace_short)1>>
-// CHECK: template <> struct KernelInfo<dummy_functor_4<(enum_in_anonNS)1>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_1<(no_namespace_int)0>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_2<(no_namespace_short)1>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_3<(internal::namespace_short)1>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_4<(enum_in_anonNS)1>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_5<(no_type_set)0>>

--- a/clang/test/CodeGenSYCL/kernelname-enum.cpp
+++ b/clang/test/CodeGenSYCL/kernelname-enum.cpp
@@ -8,11 +8,6 @@ enum unscoped_enum : int {
   val_2
 };
 
-enum unscoped_enum_no_type_set {
-  val_3,
-  val_4
-};
-
 enum class no_namespace_int : int {
   val_1,
   val_2
@@ -78,7 +73,7 @@ public:
   void operator()() {}
 };
 
-template <unscoped_enum_no_type_set EnumType>
+template <typename EnumType>
 class dummy_functor_7 {
 public:
   void operator()() {}
@@ -92,7 +87,8 @@ int main() {
   dummy_functor_4<enum_in_anonNS::val_2> f4;
   dummy_functor_5<no_type_set::val_1> f5;
   dummy_functor_6<unscoped_enum::val_1> f6;
-  dummy_functor_7<unscoped_enum_no_type_set::val_4> f7;
+  dummy_functor_7<no_namespace_int> f7;
+  dummy_functor_7<internal::namespace_short> f8;
 
   cl::sycl::queue q;
 
@@ -124,6 +120,10 @@ int main() {
     cgh.single_task(f7);
   });
 
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f8);
+  });
+
   return 0;
 }
 
@@ -144,8 +144,7 @@ int main() {
 // CHECK: template <no_type_set EnumType> class dummy_functor_5;
 // CHECK: enum unscoped_enum : int;
 // CHECK: template <unscoped_enum EnumType> class dummy_functor_6;
-// CHECK: enum unscoped_enum_no_type_set : unsigned int;
-// CHECK: template <unscoped_enum_no_type_set EnumType> class dummy_functor_7;
+// CHECK: template <typename EnumType> class dummy_functor_7;
 
 // CHECK: Specializations of KernelInfo for kernel function types:
 // CHECK: template <> struct KernelInfo<::dummy_functor_1<(no_namespace_int)0>>
@@ -154,4 +153,5 @@ int main() {
 // CHECK: template <> struct KernelInfo<::dummy_functor_4<(enum_in_anonNS)1>>
 // CHECK: template <> struct KernelInfo<::dummy_functor_5<(no_type_set)0>>
 // CHECK: template <> struct KernelInfo<::dummy_functor_6<(unscoped_enum)0>>
-// CHECK: template <> struct KernelInfo<::dummy_functor_7<(unscoped_enum_no_type_set)1>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_7<::no_namespace_int>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_7<::internal::namespace_short>>

--- a/clang/test/SemaSYCL/kernelname-enum.cpp
+++ b/clang/test/SemaSYCL/kernelname-enum.cpp
@@ -1,7 +1,5 @@
 // RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -verify %s
 
-//#include <sycl.hpp>
-
 #include "sycl.hpp"
 
 enum unscoped_enum_int : int {

--- a/clang/test/SemaSYCL/kernelname-enum.cpp
+++ b/clang/test/SemaSYCL/kernelname-enum.cpp
@@ -75,7 +75,5 @@ int main() {
     cgh.single_task(f4);
   });
 
-
   return 0;
 }
-

--- a/clang/test/SemaSYCL/kernelname-enum.cpp
+++ b/clang/test/SemaSYCL/kernelname-enum.cpp
@@ -1,0 +1,81 @@
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -verify %s
+
+//#include <sycl.hpp>
+
+#include "sycl.hpp"
+
+enum unscoped_enum_int : int {
+  val_1,
+  val_2
+};
+
+// expected-note@+1 {{'unscoped_enum_no_type_set' declared here}}
+enum unscoped_enum_no_type_set {
+  val_3,
+  val_4
+};
+
+enum class scoped_enum_int : int {
+  val_1,
+  val_2
+};
+
+enum class scoped_enum_no_type_set {
+  val_3,
+  val_4
+};
+
+template <unscoped_enum_int EnumType>
+class dummy_functor_1 {
+public:
+  void operator()() {}
+};
+
+// expected-error@+2 {{kernel name cannot be templated using unscoped enum without fixed underlying type}}
+template <unscoped_enum_no_type_set EnumType>
+class dummy_functor_2 {
+public:
+  void operator()() {}
+};
+
+template <scoped_enum_int EnumType>
+class dummy_functor_3 {
+public:
+  void operator()() {}
+};
+
+template <scoped_enum_no_type_set EnumType>
+class dummy_functor_4 {
+public:
+  void operator()() {}
+};
+
+int main() {
+
+  dummy_functor_1<val_1> f1;
+  dummy_functor_2<val_3> f2;
+  dummy_functor_3<scoped_enum_int::val_2> f3;
+  dummy_functor_4<scoped_enum_no_type_set::val_4> f4;
+
+  cl::sycl::queue q;
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f1);
+  });
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f2);
+  });
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f3);
+  });
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.single_task(f4);
+  });
+
+
+  return 0;
+}
+

--- a/clang/test/SemaSYCL/kernelname-enum.cpp
+++ b/clang/test/SemaSYCL/kernelname-enum.cpp
@@ -31,7 +31,7 @@ public:
   void operator()() {}
 };
 
-// expected-error@+2 {{kernel name cannot be templated using unscoped enum without fixed underlying type}}
+// expected-error@+2 {{kernel name is invalid. Unscoped enum requires fixed underlying type}}
 template <unscoped_enum_no_type_set EnumType>
 class dummy_functor_2 {
 public:


### PR DESCRIPTION
Forward declaration of enum used as template parameter for kernel name type is now emitted in integration header.

Enumerators in name type is also replaced with their underlying integer value since the enum definition is not visible in integration header..

E.g. For following application/user code:

     enum class device : int {
         cpu,
         gpu
     };

     template<device DeviceType>
     class dummy_functor { };

The following is generated in integration header:

    // Forward declaration of enum:
    enum class device : int;
    // Forward declaration of templated kernel function types: 
    template <device DeviceType> class dummy_functor;
    //Specializations of KernelInfo for kernel function types: 
    template <> struct KernelInfo<dummy_functor<(device)1>> {..} 

Signed-off-by: Elizabeth Andrews elizabeth.andrews@intel.com