### PR TITLE
[SYCL][NFCI] Split up 'stream' handling AccessorWrapperHelper

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -694,13 +694,12 @@ static void VisitAccessorWrapperHelper(CXXRecordDecl *Owner, RangeTy Range,
     if (Util::isSyclAccessorType(ItemTy))
       (void)std::initializer_list<int>{
           (handlers.handleSyclAccessorType(Item, ItemTy), 0)...};
-    else if (ItemTy->isStructureOrClassType()) {
+    else if (Util::isSyclStreamType(ItemTy))
+      (void)std::initializer_list<int>{
+          (handlers.handleSyclStreamType(Item, ItemTy), 0)...};
+    else if (ItemTy->isStructureOrClassType())
       VisitAccessorWrapper(Owner, Item, ItemTy->getAsCXXRecordDecl(),
                            handlers...);
-      if (Util::isSyclStreamType(ItemTy))
-        (void)std::initializer_list<int>{
-            (handlers.handleSyclStreamType(Item, ItemTy), 0)...};
-    }
   }
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -694,10 +694,12 @@ static void VisitAccessorWrapperHelper(CXXRecordDecl *Owner, RangeTy Range,
     if (Util::isSyclAccessorType(ItemTy))
       (void)std::initializer_list<int>{
           (handlers.handleSyclAccessorType(Item, ItemTy), 0)...};
-    else if (Util::isSyclStreamType(ItemTy))
+    else if (Util::isSyclStreamType(ItemTy)) {
+      VisitAccessorWrapper(Owner, Item, ItemTy->getAsCXXRecordDecl(),
+                           handlers...);
       (void)std::initializer_list<int>{
           (handlers.handleSyclStreamType(Item, ItemTy), 0)...};
-    else if (ItemTy->isStructureOrClassType())
+    } else if (ItemTy->isStructureOrClassType())
       VisitAccessorWrapper(Owner, Item, ItemTy->getAsCXXRecordDecl(),
                            handlers...);
   }


### PR DESCRIPTION
When reviewing the patch, I'd missed that this wasn't split separately
from the struct handling. This patch moves it to be top-level like
Accessor. The previous code also visits fields/bases of the sampler, but
I don't see how that was doing anything for a sampler.

Signed-off-by: Erich Keane <erich.keane@intel.com>