### PR TITLE
[SYCL] Fix building w/ disabled inline ns

### DIFF
--- a/sycl/source/detail/device_binary_image.cpp
+++ b/sycl/source/detail/device_binary_image.cpp
@@ -12,7 +12,9 @@
 
 #include <CL/sycl/detail/device_binary_image.hpp>
 
-using namespace sycl::detail;
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace detail {
 
 DynRTDeviceBinaryImage::DynRTDeviceBinaryImage(
     std::unique_ptr<char[]> &&DataPtr, size_t DataSize, OSModuleHandle M)
@@ -38,3 +40,7 @@ DynRTDeviceBinaryImage::~DynRTDeviceBinaryImage() {
   delete Bin;
   Bin = nullptr;
 }
+
+} // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/unittests/pi/cuda/test_interop_get_native.cpp
+++ b/sycl/unittests/pi/cuda/test_interop_get_native.cpp
@@ -74,9 +74,9 @@ TEST_F(DISABLED_CudaInteropGetNativeTests, getNativeQueue) {
 
 TEST_F(DISABLED_CudaInteropGetNativeTests, interopTaskGetMem) {
   buffer<int, 1> syclBuffer(range<1>{1});
-  syclQueue_.submit([&](cl::sycl::handler &cgh) {
+  syclQueue_.submit([&](handler &cgh) {
     auto syclAccessor = syclBuffer.get_access<access::mode::read>(cgh);
-    cgh.interop_task([=](sycl::interop_handler ih) {
+    cgh.interop_task([=](interop_handler ih) {
       CUdeviceptr cudaPtr = ih.get_mem<backend::cuda>(syclAccessor);
       CUdeviceptr cudaPtrBase;
       size_t cudaPtrSize = 0;
@@ -88,8 +88,8 @@ TEST_F(DISABLED_CudaInteropGetNativeTests, interopTaskGetMem) {
 
 TEST_F(DISABLED_CudaInteropGetNativeTests, interopTaskGetBufferMem) {
   CUstream cudaStream = get_native<backend::cuda>(syclQueue_);
-  syclQueue_.submit([&](cl::sycl::handler &cgh) {
-    cgh.interop_task([=](sycl::interop_handler ih) {
+  syclQueue_.submit([&](handler &cgh) {
+    cgh.interop_task([=](interop_handler ih) {
       CUstream cudaInteropStream = ih.get_queue<backend::cuda>();
       ASSERT_EQ(cudaInteropStream, cudaStream);
     });

--- a/sycl/unittests/scheduler/SchedulerTest.hpp
+++ b/sycl/unittests/scheduler/SchedulerTest.hpp
@@ -13,21 +13,22 @@
 
 class SchedulerTest : public ::testing::Test {
 protected:
-  sycl::queue MQueue;
-  sycl::async_handler MAsyncHandler = [](sycl::exception_list ExceptionList) {
-    for (sycl::exception_ptr_class ExceptionPtr : ExceptionList) {
-      try {
-        std::rethrow_exception(ExceptionPtr);
-      } catch (sycl::exception &E) {
-        std::cerr << E.what();
-      } catch (...) {
-        std::cerr << "Unknown async exception was caught." << std::endl;
-      }
-    }
-  };
+  cl::sycl::queue MQueue;
+  cl::sycl::async_handler MAsyncHandler =
+      [](cl::sycl::exception_list ExceptionList) {
+        for (cl::sycl::exception_ptr_class ExceptionPtr : ExceptionList) {
+          try {
+            std::rethrow_exception(ExceptionPtr);
+          } catch (cl::sycl::exception &E) {
+            std::cerr << E.what();
+          } catch (...) {
+            std::cerr << "Unknown async exception was caught." << std::endl;
+          }
+        }
+      };
 
 public:
   void SetUp() override {
-    MQueue = sycl::queue(sycl::host_selector(), MAsyncHandler);
+    MQueue = cl::sycl::queue(cl::sycl::host_selector(), MAsyncHandler);
   }
 };


### PR DESCRIPTION
Fix building the runtime with the CMake flag:
```sh
-DCMAKE_CXX_FLAGS="-D__SYCL_DISABLE_NAMESPACE_INLINE__=1"
```

The flag affects the macro `__SYCL_INLINE_NAMESPACE` in the defines.hpp
header.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>