### PR TITLE
[SYCL] Fix host-to-host copy during copyback

### DIFF
--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -365,7 +365,7 @@ static void copyH2H(SYCLMemObjI *SYCLMemObj, char *SrcMem,
     return;
 
   size_t BytesToCopy =
-       SrcAccessRange[0] * SrcElemSize * SrcAccessRange[1] * SrcAccessRange[2];
+      SrcAccessRange[0] * SrcElemSize * SrcAccessRange[1] * SrcAccessRange[2];
   std::memcpy(DstMem, SrcMem, BytesToCopy);
 }
 

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -358,13 +358,15 @@ static void copyH2H(SYCLMemObjI *SYCLMemObj, char *SrcMem,
                         PI_INVALID_OPERATION);
   }
 
-  DstOffset[0] *= DstElemSize;
-  SrcOffset[0] *= SrcElemSize;
+  SrcMem += SrcOffset[0] * SrcElemSize;
+  DstMem += DstOffset[0] * DstElemSize;
+
+  if (SrcMem == DstMem)
+    return;
 
   size_t BytesToCopy =
-      SrcAccessRange[0] * SrcElemSize * SrcAccessRange[1] * SrcAccessRange[2];
-
-  std::memcpy(DstMem + DstOffset[0], SrcMem + SrcOffset[0], BytesToCopy);
+       SrcAccessRange[0] * SrcElemSize * SrcAccessRange[1] * SrcAccessRange[2];
+  std::memcpy(DstMem, SrcMem, BytesToCopy);
 }
 
 // Copies memory between: host and device, host and host,


### PR DESCRIPTION
Copyback is performed unconditionally during buffer destruction, so
it's possible for it to perform a copy from and to the same host
pointer. This patch adds a check for this scenario so that we don't rely
on undefined behaviour of std::memcpy.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>