### PR TITLE
[SYCL][Doc] Fix tbb target path in Get Started Guide.

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -228,7 +228,7 @@ ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so.2
   /opt/intel/oclcpuexp_<cpu_version>/x64
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so.2
-  /opt/intel/oclcpuexp_<cpu_version>/
+  /opt/intel/oclcpuexp_<cpu_version>/x64
 ```
 
 5) Configure library paths

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -224,7 +224,7 @@ folder:
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so
   /opt/intel/oclcpuexp_<cpu_version>/x64
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so
-  /opt/intel/oclcpuexp_<cpu_version>/
+  /opt/intel/oclcpuexp_<cpu_version>/x64
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so.2
   /opt/intel/oclcpuexp_<cpu_version>/
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so.2

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -222,13 +222,13 @@ tar -zxvf tbb*lin.tgz
 folder:
 ```bash
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so
-  /opt/intel/oclcpuexp/x64/libtbb.so
+  /opt/intel/oclcpuexp_<cpu_version>/
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so
-  /opt/intel/oclcpuexp/x64/libtbbmalloc.so
+  /opt/intel/oclcpuexp_<cpu_version>/
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so.2
-  /opt/intel/oclcpuexp/x64/libtbb.so.2
+  /opt/intel/oclcpuexp_<cpu_version>/
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so.2
-  /opt/intel/oclcpuexp/x64/libtbbmalloc.so.2
+  /opt/intel/oclcpuexp_<cpu_version>/
 ```
 
 5) Configure library paths

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -222,7 +222,7 @@ tar -zxvf tbb*lin.tgz
 folder:
 ```bash
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so
-  /opt/intel/oclcpuexp_<cpu_version>/
+  /opt/intel/oclcpuexp_<cpu_version>/x64
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so
   /opt/intel/oclcpuexp_<cpu_version>/
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so.2

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -226,7 +226,7 @@ ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so
   /opt/intel/oclcpuexp_<cpu_version>/x64
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so.2
-  /opt/intel/oclcpuexp_<cpu_version>/
+  /opt/intel/oclcpuexp_<cpu_version>/x64
 ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so.2
   /opt/intel/oclcpuexp_<cpu_version>/
 ```


### PR DESCRIPTION
The previous guide suggests linking tbb to `/opt/intel/oclcpuexp/` which is not in the `LD_PATH`