### PR TITLE
[SYCL] Fix LIT if OpenCL GPU is missing

### DIFF
--- a/sycl/test/kernel_from_file/hw.cpp
+++ b/sycl/test/kernel_from_file/hw.cpp
@@ -4,7 +4,7 @@
 //-fsycl-targets=%sycl_triple
 // RUN: %clangxx -fsycl-device-only -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict
 // RUN: %clangxx -include %t.h -g %s -o %t.out -lsycl -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning
-// RUN: env SYCL_USE_KERNEL_SPV=%t.spv %t.out | FileCheck %s
+// RUN: env SYCL_BE=%sycl_be SYCL_USE_KERNEL_SPV=%t.spv %t.out | FileCheck %s
 // CHECK: Passed
 
 // TODO: InvalidTargetTriple: Expects spir-unknown-unknown or spir64-unknown-unknown. Actual target triple is x86_64-unknown-linux-gnu

--- a/sycl/test/separate-compile/test.cpp
+++ b/sycl/test/separate-compile/test.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: cuda
+// CUDA does not support SPIR-V.
+
 // >> ---- compile src1
 // >> device compilation...
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc -I %sycl_include -Wno-sycl-strict
@@ -34,10 +37,8 @@
 //
 // >> ---- link the full hetero app
 // RUN: %clangxx wrapper.o a.o b.o -o app.exe -lsycl
-// RUN: ./app.exe | FileCheck %s
+// RUN: env SYCL_BE=%sycl_be ./app.exe | FileCheck %s
 // CHECK: pass
-
-// UNSUPPORTED: cuda
 
 //==----------- test.cpp - Tests SYCL separate compilation -----------------==//
 //


### PR DESCRIPTION
Fix LIT tests to not run on PI_CUDA backend if only a CUDA GPU and
OpenCL CPU are available but no OpenCL GPU.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>