### PR TITLE
[SYCL] Detect AUX target built-in functions inside device code and emit a deferred diagnostic

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10878,4 +10878,6 @@ def err_ext_int_bad_size : Error<"%select{signed|unsigned}0 _ExtInt must "
                                  "have a bit size of at least %select{2|1}0">;
 def err_ext_int_max_size : Error<"%select{signed|unsigned}0 _ExtInt of bit "
                                  "sizes greater than %1 not supported">;
+def err_aux_target_builtin_in_device_code : Error<
+  "AUX target specific builtins should not be present in device code">;                                 
 } // end of sema component.

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1941,12 +1941,11 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
       if (CheckTSBuiltinFunctionCall(
               Context.getAuxTargetInfo()->getTriple().getArch(),
               Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall)) {
-                    
               return ExprError();
       }
       /*
-      Parameters of the AUX built-in function have been validated and have no errors.
-      Device code is not allowed to have the AUX built-ins in them.
+      At this point, parameters of the AUX built-in function have been validated and have no errors.
+      We must not allow Device code to have the AUX built-in functions inside them.
       To handle this we use SYCLDiagIfDeviceCode, which creates a DeviceDiagBuilder that emits 
       the diagnostic if the current context is "used as device code".
       We first detect if we are compiling for device. But we don't know that this function will be codegen'ed

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1941,19 +1941,21 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
       if (CheckTSBuiltinFunctionCall(
               Context.getAuxTargetInfo()->getTriple().getArch(),
               Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall)) {
-              return ExprError();
+        return ExprError();
       }
       /*
-      At this point, parameters of the AUX built-in function have been validated and have no errors.
-      We must not allow Device code to have the AUX built-in functions inside them.
-      To handle this we use SYCLDiagIfDeviceCode, which creates a DeviceDiagBuilder that emits 
-      the diagnostic if the current context is "used as device code".
-      We first detect if we are compiling for device. But we don't know that this function will be codegen'ed
-      for device yet.So we create a diagnostic which is emitted if and when we realize that the function 
-      will be codegen'ed
+      At this point, parameters of the AUX built-in function have been validated
+      and have no errors. We must not allow Device code to have the AUX built-in
+      functions inside them. To handle this we use SYCLDiagIfDeviceCode, which
+      creates a DeviceDiagBuilder that emits the diagnostic if the current
+      context is "used as device code". We first detect if we are compiling for
+      device. But we don't know that this function will be codegen'ed for device
+      yet.So we create a diagnostic which is emitted if and when we realize that
+      the function will be codegen'ed
       */
-      if(getLangOpts().SYCLIsDevice) {
-        SYCLDiagIfDeviceCode(TheCall->getBeginLoc(), diag::err_aux_target_builtin_in_device_code);
+      if (getLangOpts().SYCLIsDevice) {
+        SYCLDiagIfDeviceCode(TheCall->getBeginLoc(),
+                             diag::err_aux_target_builtin_in_device_code);
       }
     } else {
       if (CheckTSBuiltinFunctionCall(

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -1,0 +1,48 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -aux-triple x86_64-unknown-linux-gnu -verify -fsyntax-only  %s
+// 
+//
+/*
+ This test is to verify that deferred diagnostics are emitted whenever there is an AUX target builtin function inside device code.
+ x86_64 is the AUX target. Spir64 is the device target.
+ _mm_prefetch is the AUX target builtin.
+*/
+
+// Testing that the deferred diagnostics work in conjunction with the SYCL namespaces.
+inline namespace cl {
+namespace sycl {
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  // expected-note@+1 {{called by 'kernel_single_task<AName, (lambda}}
+  kernelFunc();
+}
+
+} // namespace sycl
+} // namespace cl
+
+int main(int argc, char **argv) {
+
+  //This is host code. This will not be compiled for the device.
+  /* 
+  _mm_prefetch is an x86-64 target architecture built-in function.
+  Its parameters are char const* p, int i
+  The valid values for "i" are 0 to 7 :
+  #define _MM_HINT_T0 1
+  #define _MM_HINT_T1 2
+  #define _MM_HINT_T2 3
+  #define _MM_HINT_NTA 0
+  #define _MM_HINT_ENTA 4
+  #define _MM_HINT_ET0 5
+  #define _MM_HINT_ET1 6
+  #define _MM_HINT_ET2 7
+  */
+  _mm_prefetch("test", 4); // no error thrown, since this is a valid invocation
+
+  _mm_prefetch("test", 8);// expected-error {{argument value 8 is outside the valid range [0, 7]}}
+  
+  cl::sycl::kernel_single_task<class AName>([]() {
+    //SYCL device compiler will compile this kernel for a device as well as any functions that the kernel calls
+    _mm_prefetch("test", 4); // expected-error {{AUX target specific builtins should not be present in device code}}
+  });
+  return 0;
+}

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -aux-triple x86_64-unknown-linux-gnu -verify -fsyntax-only  %s
-// 
 //
 /*
  This test is to verify that deferred diagnostics are emitted whenever there is an AUX target builtin function inside device code.
@@ -38,8 +37,8 @@ int main(int argc, char **argv) {
   */
   _mm_prefetch("test", 4); // no error thrown, since this is a valid invocation
 
-  _mm_prefetch("test", 8);// expected-error {{argument value 8 is outside the valid range [0, 7]}}
-  
+  _mm_prefetch("test", 8); // expected-error {{argument value 8 is outside the valid range [0, 7]}}
+
   cl::sycl::kernel_single_task<class AName>([]() {
     //SYCL device compiler will compile this kernel for a device as well as any functions that the kernel calls
     _mm_prefetch("test", 4); // expected-error {{AUX target specific builtins should not be present in device code}}


### PR DESCRIPTION
As a follow up to the previous issue that @erichkeane fixed in llvm community,
this patch adds the deferred diagnostic to diagnose when a host builtin is used
in device mode.

* Added a deferred diagnostic that will be emitted whenever an AUX target
  built-in function is found inside device code.
* Added a test to verify that the deferred diagnostic is emitted
  correctly.
