### PR TITLE
[SYCL] Detect host built-in functions inside device code and emit a deferred diagnostic

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10878,6 +10878,4 @@ def err_ext_int_bad_size : Error<"%select{signed|unsigned}0 _ExtInt must "
                                  "have a bit size of at least %select{2|1}0">;
 def err_ext_int_max_size : Error<"%select{signed|unsigned}0 _ExtInt of bit "
                                  "sizes greater than %1 not supported">;
-def err_aux_target_builtin_in_device_code : Error<
-  "Host specific builtin cannot be used in device functions">;                                 
 } // end of sema component.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10878,4 +10878,6 @@ def err_ext_int_bad_size : Error<"%select{signed|unsigned}0 _ExtInt must "
                                  "have a bit size of at least %select{2|1}0">;
 def err_ext_int_max_size : Error<"%select{signed|unsigned}0 _ExtInt of bit "
                                  "sizes greater than %1 not supported">;
+def err_aux_target_builtin_in_device_code : Error<
+  "Host specific builtin cannot be used in device functions">;                                 
 } // end of sema component.

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1942,7 +1942,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
               Context.getAuxTargetInfo()->getTriple().getArch(),
               Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall))
         return ExprError();
-      
+
       // Detect when host builtins are used in device code only
       if (getLangOpts().SYCLIsDevice)
         SYCLDiagIfDeviceCode(TheCall->getBeginLoc(),

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1943,7 +1943,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
               Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall)) {
         return ExprError();
       }
-      //Detect when host builtins are used in device code only 
+      // Detect when host builtins are used in device code only
       if (getLangOpts().SYCLIsDevice)
         SYCLDiagIfDeviceCode(TheCall->getBeginLoc(),
                              diag::err_aux_target_builtin_in_device_code);

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1938,7 +1938,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     if (Context.BuiltinInfo.isAuxBuiltinID(BuiltinID)) {
       assert(Context.getAuxTargetInfo() &&
              "Aux Target Builtin, but not an aux target?");
-             
+
       if (CheckTSBuiltinFunctionCall(
               Context.getAuxTargetInfo()->getTriple().getArch(),
               Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall))

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1940,9 +1940,9 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
              "Aux Target Builtin, but not an aux target?");
       if (CheckTSBuiltinFunctionCall(
               Context.getAuxTargetInfo()->getTriple().getArch(),
-              Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall)) {
+              Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall))
         return ExprError();
-      }
+      
       // Detect when host builtins are used in device code only
       if (getLangOpts().SYCLIsDevice)
         SYCLDiagIfDeviceCode(TheCall->getBeginLoc(),

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1938,11 +1938,15 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     if (Context.BuiltinInfo.isAuxBuiltinID(BuiltinID)) {
       assert(Context.getAuxTargetInfo() &&
              "Aux Target Builtin, but not an aux target?");
-
       if (CheckTSBuiltinFunctionCall(
               Context.getAuxTargetInfo()->getTriple().getArch(),
-              Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall))
+              Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall)) {
         return ExprError();
+      }
+      //Detect when host builtins are used in device code only 
+      if (getLangOpts().SYCLIsDevice)
+        SYCLDiagIfDeviceCode(TheCall->getBeginLoc(),
+                             diag::err_aux_target_builtin_in_device_code);
     } else {
       if (CheckTSBuiltinFunctionCall(
               Context.getTargetInfo().getTriple().getArch(), BuiltinID,

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1938,6 +1938,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     if (Context.BuiltinInfo.isAuxBuiltinID(BuiltinID)) {
       assert(Context.getAuxTargetInfo() &&
              "Aux Target Builtin, but not an aux target?");
+             
       if (CheckTSBuiltinFunctionCall(
               Context.getAuxTargetInfo()->getTriple().getArch(),
               Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall))

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1946,7 +1946,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
       // Detect when host builtins are used in device code only
       if (getLangOpts().SYCLIsDevice)
         SYCLDiagIfDeviceCode(TheCall->getBeginLoc(),
-                             diag::err_aux_target_builtin_in_device_code);
+                             diag::err_builtin_target_unsupported);
     } else {
       if (CheckTSBuiltinFunctionCall(
               Context.getTargetInfo().getTriple().getArch(), BuiltinID,

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -aux-triple x86_64-unknown-linux-gnu -verify -fsyntax-only  %s
+//
+
+inline namespace cl {
+namespace sycl {
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  // expected-note@+1 {{called by 'kernel_single_task<AName, (lambda}}
+  kernelFunc();
+}
+
+} // namespace sycl
+} // namespace cl
+
+int main(int argc, char **argv) {
+  //_mm_prefetch is an x86-64 specific builtin where the second integer parameter is required to be a constant 
+  //between 0 and 7.
+  _mm_prefetch("test", 4); // no error thrown, since this is a valid invocation
+
+  _mm_prefetch("test", 8); // expected-error {{argument value 8 is outside the valid range [0, 7]}}
+
+  cl::sycl::kernel_single_task<class AName>([]() {
+    
+    _mm_prefetch("test", 4); // expected-error {{Host specific builtin cannot be used in device functions}}
+    _mm_prefetch("test", 8); // expected-error {{argument value 8 is outside the valid range [0, 7]}} expected-error {{Host specific builtin cannot be used in device functions}}
+  });
+  return 0;
+}

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -aux-triple x86_64-unknown-linux-gnu -verify -fsyntax-only  %s
-//
 
 inline namespace cl {
 namespace sycl {
@@ -21,8 +20,8 @@ int main(int argc, char **argv) {
   _mm_prefetch("test", 8); // expected-error {{argument value 8 is outside the valid range [0, 7]}}
 
   cl::sycl::kernel_single_task<class AName>([]() {
-    _mm_prefetch("test", 4); // expected-error {{Host specific builtin cannot be used in device functions}}
-    _mm_prefetch("test", 8); // expected-error {{argument value 8 is outside the valid range [0, 7]}} expected-error {{Host specific builtin cannot be used in device functions}}
+    _mm_prefetch("test", 4); // expected-error {{builtin is not supported on this target}}
+    _mm_prefetch("test", 8); // expected-error {{argument value 8 is outside the valid range [0, 7]}} expected-error {{builtin is not supported on this target}}
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -14,14 +14,13 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 } // namespace cl
 
 int main(int argc, char **argv) {
-  //_mm_prefetch is an x86-64 specific builtin where the second integer parameter is required to be a constant 
+  //_mm_prefetch is an x86-64 specific builtin where the second integer parameter is required to be a constant
   //between 0 and 7.
   _mm_prefetch("test", 4); // no error thrown, since this is a valid invocation
 
   _mm_prefetch("test", 8); // expected-error {{argument value 8 is outside the valid range [0, 7]}}
 
   cl::sycl::kernel_single_task<class AName>([]() {
-    
     _mm_prefetch("test", 4); // expected-error {{Host specific builtin cannot be used in device functions}}
     _mm_prefetch("test", 8); // expected-error {{argument value 8 is outside the valid range [0, 7]}} expected-error {{Host specific builtin cannot be used in device functions}}
   });


### PR DESCRIPTION
As a follow up to the previous issue that @erichkeane fixed in llvm community,
this patch adds the deferred diagnostic to diagnose when a host builtin is used
in device mode.

- Added a deferred diagnostic that will be emitted whenever an host target built-in function is found inside device code.
- Added a test to verify that the deferred diagnostic is emitted correctly.