### PR TITLE
[SYCL][ESIMD] Intel "Explicit SIMD" extension documentation draft.

### DIFF
--- a/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
+++ b/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
@@ -14,7 +14,7 @@ additional features:
 Here are some future directions in which this API is intended to evolve:
 - enabling this extension for other architectures, such as x86, with extracting
   and clearly marking generic and target-dependent API portions
-- aligning with `std::simd` and maybe providing `std::simd` implemenation atop
+- aligning with `std::simd` and maybe providing `std::simd` implementation atop
   `sycl::intel::gpu`
 
 ## Explicit SIMD execution model
@@ -738,7 +738,7 @@ int main(void) {
 - Section covering 2D use cases
 - A bridge from `std::simd` to `sycl::intel::gpu::simd`
 - Describe `simd_view` class restrictions
-- Consider auto-inclusion of sycl_[[sycl_explicit_simd]].hpp under -fsycl-esimd option
+- Consider auto-inclusion of sycl_explicit_simd.hpp under -fsycl-esimd option
 - Add example showing the mapping between an ND-range and the number of
 thread-groups and EU threads, and showing the usage of explicit SIMD together
 with work-group barriers and SLM.

--- a/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
+++ b/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
@@ -105,98 +105,96 @@ namespace sycl {
 namespace intel {
 namespace gpu {
 
-// __vector_type, using clang vector type extension.
-template <typename __Ty, int __N> struct __vector_type {
-  static_assert(!std::is_const<__Ty>::value, "const element type not supported");
-  static_assert(__is_vectorizable_v<__Ty>::value, "element type not supported");
-  static_assert(__N > 0, "zero-element vector not supported");
+// vector_type, using clang vector type extension.
+template <typename Ty, int N> struct vector_type {
+  static_assert(!std::is_const<Ty>::value, "const element type not supported");
+  static_assert(is_vectorizable_v<Ty>::value, "element type not supported");
+  static_assert(N > 0, "zero-element vector not supported");
 
-  static constexpr int length = __N;
-  using type = __Ty __attribute__((ext_vector_type(__N)));
+  static constexpr int length = N;
+  using type = Ty attribute((ext_vector_type(N)));
 };
 
-template <int __N>
-using __mask_type_t = typename __vector_type<uint16_t, __N>::type;
+template <int N>
+using mask_type_t = typename vector_type<uint16_t, N>::type;
 
-template <typename __Ty, int __N> class simd {
+template <typename Ty, int N> class simd {
 public:
-  using value_type = simd<__Ty, __N, 0>;
-  using element_type = __Ty;
-  using vector_type = __vector_type_t<__Ty, __N>;
-  using type = simd<__Ty, __N>;
-  static constexpr int length = __N;
+  using value_type = simd<Ty, N, 0>;
+  using element_type = Ty;
+  using vector_type = vector_type_t<Ty, N>;
+  static constexpr int length = N;
 
   // Constructors.
   constexpr simd();
   constexpr simd(const simd &other);
   constexpr simd(simd &&other);
-  constexpr simd(const vector_type &__Val);
-  constexpr simd(std::initializer_list<__Ty> __Ilist) noexcept;
-  constexpr simd(__Ty __Val, __Ty __Step = __Ty()) noexcept;
+  constexpr simd(const vector_type &Val);
+  constexpr simd(std::initializer_list<Ty> Ilist) noexcept;
+  constexpr simd(Ty Val, Ty Step = Ty()) noexcept;
 
   // Assignment operators.
-  constexpr type &operator=(const type &) &;
-  constexpr type &operator=(type &&) &;
+  constexpr simd &operator=(const simd &) &;
+  constexpr simd &operator=(simd &&) &;
 
   // Subscript operators.
-  __Ty operator[](int __i);
-  __Ty operator[](int __i) const;
+  Ty operator[](int i) const;
 
   // Unary operators.
-  type &operator++();
-  type operator++(int);
-  type &operator--();
-  type operator--(int);
+  simd &operator++();
+  simd operator++(int);
+  simd &operator--();
+  simd operator--(int);
 
   // Binary operators.
-  auto operator +(const type &__RHS) const;
-  auto operator -(const type &__RHS) const;
-  auto operator *(const type &__RHS) const;
-  auto operator /(const type &__RHS) const;
-  type operator &(const type &__RHS) const;
-  type operator |(const type &__RHS) const;
-  type operator ^(const type &__RHS) const;
+  auto operator +(const simd &RHS) const;
+  auto operator -(const simd &RHS) const;
+  auto operator *(const simd &RHS) const;
+  auto operator /(const simd &RHS) const;
+  simd operator &(const simd &RHS) const;
+  simd operator |(const simd &RHS) const;
+  simd operator ^(const simd &RHS) const;
 
   // Compound assignment.
-  type &operator +=(const type &__RHS);
-  type &operator -=(const type &__RHS);
-  type &operator *=(const type &__RHS);
-  type &operator /=(const type &__RHS);
-  type &operator &=(const type &__RHS);
-  type &operator |=(const type &__RHS);
-  type &operator ^=(const type &__RHS);
+  simd &operator +=(const simd &RHS);
+  simd &operator -=(const simd &RHS);
+  simd &operator *=(const simd &RHS);
+  simd &operator /=(const simd &RHS);
+  simd &operator &=(const simd &RHS);
+  simd &operator |=(const simd &RHS);
+  simd &operator ^=(const simd &RHS);
 
   // Compare operators.
-  simd<uint16_t, __N> operator >(const type &__RHS) const;
-  simd<uint16_t, __N> operator >=(const type &__RHS) const;
-  simd<uint16_t, __N> operator <(const type &__RHS) const;
-  simd<uint16_t, __N> operator <=(const type &__RHS) const;
-  simd<uint16_t, __N> operator ==(const type &__RHS) const;
-  simd<uint16_t, __N> operator !=(const type &__RHS) const;
+  simd<uint16_t, N> operator >(const simd &RHS) const;
+  simd<uint16_t, N> operator >=(const simd &RHS) const;
+  simd<uint16_t, N> operator <(const simd &RHS) const;
+  simd<uint16_t, N> operator <=(const simd &RHS) const;
+  simd<uint16_t, N> operator ==(const simd &RHS) const;
+  simd<uint16_t, N> operator !=(const simd &RHS) const;
 
   // Select operations.
-  template <int __Size, int __Stride>
-  simd<__Ty, __Size> select(uint16_t __Offset = 0) &&;
-  template <int __Size, int __Stride>
-  simd_view<type, region1d_t<__Ty, __Size, __Stride>>
-  select(uint16_t __i = 0) &;
+  template <int Size, int Stride>
+  simd<Ty, Size> select(uint16_t Offset = 0) &&;
+  template <int Size, int Stride>
+  simd_view<simd, region1d_t<Ty, Size, Stride>>
+  select(uint16_t i = 0) &;
 
   // Replicate operations.
-  template <int Rep> simd<__Ty, Rep * __N> replicate();
-  template <int Rep, int W> simd<__Ty, Rep * W> replicate(uint16_t __i);
+  template <int Rep> simd<Ty, Rep * N> replicate();
+  template <int Rep, int W> simd<Ty, Rep * W> replicate(uint16_t i);
   template <int Rep, int VS, int W>
-  simd<__Ty, Rep * W> replicate(uint16_t __i);
+  simd<Ty, Rep * W> replicate(uint16_t i);
   template <int Rep, int VS, int W, int HS>
-  simd<__Ty, Rep * W> replicate(uint16_t __i);
+  simd<Ty, Rep * W> replicate(uint16_t i);
 
   // Format operations.
-  template <typename __EltTy> auto format() &;
-  template <typename __EltTy, int __Height, int __Width> auto format() &;
+  template <typename EltTy> auto format() &;
+  template <typename EltTy, int Height, int Width> auto format() &;
 
   // Merge operations.
-  void merge(const value_type &__Val, const __mask_type_t<__N> &__Mask);
-  void merge(const value_type &__Val1, value_type __Val2,
-             const __mask_type_t<__N> &__Mask);
+  void merge(const value_type &Val, const mask_type_t<N> &Mask);
+  void merge(const value_type &Val1, value_type Val2,
+             const mask_type_t<N> &Mask);
 } // namespace gpu
 } // namespace intel
 } // namespace sycl
@@ -221,8 +219,8 @@ unsequenced with respect to the others.
 To reference a subset of the elements in simd vector object, Explicit SIMD provides ```select```
 function, which returns a `simd` or `simd_view` object (*described below*) representing
 the selected sub-vector starting from the i-th element. The number of selected
-elements is specified by the template parameter **__Size**, while the distance
-between two adjacent elements is specified by the template parameter **__Stride**.
+elements is specified by the template parameter **Size**, while the distance
+between two adjacent elements is specified by the template parameter **Stride**.
 
 ```cpp
   simd<int, 8> a;
@@ -266,10 +264,10 @@ Selected blocks of **W** elements will overlap if **VS** < **W**.
 To avoid explicit type cast and the resulting move instructions for large vectors, Explicit SIMD allows
 programmer to reinterpret the fundamental data element type of a simd vector object and change
 its shape to 1D or 2D object through the ```format``` function:
-- ```format<__EltTy>( )```: returns a reference to the calling simd object interpreted as a new
-simd vector with the size determined by the template **__EltTy** parameter.
-- ```format<__EltTy, __Height, __Width>( )```: returns a reference to the calling simd object interpreted
-as a new 2D simd_view object with the shape determined by the template parameters **__Height** and**__Width**. The size of the new 2D block must not exceed the size of the original object.
+- ```format<EltTy>( )```: returns a reference to the calling simd object interpreted as a new
+simd vector with the size determined by the template **EltTy** parameter.
+- ```format<EltTy, Height, Width>( )```: returns a reference to the calling simd object interpreted
+as a new 2D simd_view object with the shape determined by the template parameters **Height** and**Width**. The size of the new 2D block must not exceed the size of the original object.
 
 ```cpp
   simd<int, 16> v1;
@@ -288,7 +286,7 @@ as a new 2D simd_view object with the shape determined by the template parameter
 ```
 
 To model predicated move, Explicit SIMD provides the following merge functions:
-- ```merge(value_type __Val, __mask_type __Mask)```: this merge operation takes one source operand **__Val** and a mask **__Mask** defined as unsigned short vector of the same length. The semantic is that if the LSB of an element of **__Mask** is set, then the corresponding data element of **__Val** is copied to the corresponding position in the calling simd object.
+- ```merge(value_type Val, mask_type Mask)```: this merge operation takes one source operand **Val** and a mask **Mask** defined as unsigned short vector of the same length. The semantic is that if the LSB of an element of **Mask** is set, then the corresponding data element of **Val** is copied to the corresponding position in the calling simd object.
 
 ```cpp
   simd<int, 4>   m, src;
@@ -299,7 +297,7 @@ To model predicated move, Explicit SIMD provides the following merge functions:
   // 2 2 2 2     4 4 4 4     1 1 0 1         4 4 2 4
 ```
 
-- ```merge(value_type __Val1, value_type __Val2, __mask_type __Mask)```: this merge operation takes two source operands **__Val1** and **__Val2** as well as a simd mask. The semantic is that if the LSB of an element of **__Mask** is set, then the corresponding data element of **__Val1** is copied to the corresponding position in the calling simd object. Otherwise the corresponding data element of **__Val2** is copied to the corresponding position in the calling simd object.
+- ```merge(value_type Val1, value_type Val2, mask_type Mask)```: this merge operation takes two source operands **Val1** and **Val2** as well as a simd mask. The semantic is that if the LSB of an element of **Mask** is set, then the corresponding data element of **Val1** is copied to the corresponding position in the calling simd object. Otherwise the corresponding data element of **Val2** is copied to the corresponding position in the calling simd object.
 
 ```cpp
   simd<int,4>   m, src1, src2;
@@ -314,8 +312,8 @@ To model predicated move, Explicit SIMD provides the following merge functions:
 The ```sycl::intel::gpu::simd_view``` represents a "window" into existing simd object,
 through which a part of the original object can be read or modified. This is a
 syntactic convenience feature to reduce verbosity when accessing sub-regions of
-simd objects. **__RegionTy** describes the window shape and can be 1D or 2D,
-**__BaseTy** is the original simd object type, which can be a ```simd_view```
+simd objects. **RegionTy** describes the window shape and can be 1D or 2D,
+**BaseTy** is the original simd object type, which can be a ```simd_view```
 itself.
 
 ```simd_view``` allows to model hierarchical "views" of the parent ```simd```
@@ -331,26 +329,24 @@ different shapes and dimensions as illustrated below (`auto` resolves to a
 namespace sycl {
 namespace intel {
 namespace gpu {
-template <typename __BaseTy, typename __RegionTy> class simd_view {
+template <typename BaseTy, typename RegionTy> class simd_view {
 public:
-  using __ShapeTy = typename __shape_type<__RegionTy>::type;
-  static constexpr int length = __ShapeTy::__Size_x * __ShapeTy::__Size_y;
-  using type = simd_view<__BaseTy, __RegionTy>;
-  using value_type = simd<typename __ShapeTy::element_type, length>;
-  using vector_type = __vector_type_t<typename __ShapeTy::element_type, length>;
-  using region_type = __RegionTy;
-  using base_type = typename __compute_base_type<__BaseTy, __RegionTy>::type;
-  using element_type = typename __ShapeTy::element_type;
+  using ShapeTy = typename shape_type<RegionTy>::type;
+  static constexpr int length = ShapeTy::Size_x * ShapeTy::Size_y;
+  using value_type = simd<typename ShapeTy::element_type, length>;
+  using vector_type = vector_type_t<typename ShapeTy::element_type, length>;
+  using region_type = RegionTy;
+  using element_type = typename ShapeTy::element_type;
 
   // Constructors.
-  simd_view(__BaseTy &__Base, __RegionTy __Region);
-  simd_view(__BaseTy &&__Base, __RegionTy __Region);
-  simd_view(type &__Other);
-  simd_view(type &&__Other);
+  simd_view(BaseTy &Base, RegionTy Region);
+  simd_view(BaseTy &&Base, RegionTy Region);
+  simd_view(simd_view &Other);
+  simd_view(simd_view &&Other);
 
   // Assignment operators.
-  type &operator=(const type &__Other);
-  type &operator=(const value_type &__Val);
+  simd_view &operator=(const simd_view &Other);
+  simd_view &operator=(const value_type &Val);
 
   // Region accessors.
   static constexpr bool is1D();
@@ -361,65 +357,64 @@ public:
   static constexpr int getStrideY();
   constexpr uint16_t getOffsetX();
   constexpr uint16_t getOffsetY();
-  template <int __Dim = 0> static constexpr int getSize();
-  template <int __Dim = 0> static constexpr int getStride();
-  template <int __Dim = 0> constexpr uint16_t getOffset() const;
+  template <int Dim = 0> static constexpr int getSize();
+  template <int Dim = 0> static constexpr int getStride();
+  template <int Dim = 0> constexpr uint16_t getOffset() const;
 
   // Subscript operators.
-  element_type operator[](int __i);
-  element_type operator[](int __i) const;
+  element_type operator[](int i) const;
 
   // Row/column operator.
-  template <typename __T = type, typename = std::enable_if_t<__T::is2D()>>
-  auto row(int __i);
-  template <typename __T = type, typename = std::enable_if_t<__T::is2D()>>
-  auto column(int __i);
+  template <typename T = simd_view, typename = std::enable_if_t<T::is2D()>>
+  auto row(int i);
+  template <typename T = simd_view, typename = std::enable_if_t<T::is2D()>>
+  auto column(int i);
 
   // Unary operators.
-  type &operator++();
-  type operator++(int);
-  type &operator--();
-  type operator--(int);
+  simd_view &operator++();
+  simd_view operator++(int);
+  simd_view &operator--();
+  simd_view operator--(int);
 
   // Binary operators.
-  auto operator +(const type &__RHS) const;
-  auto operator -(const type &__RHS) const;
-  auto operator *(const type &__RHS) const;
-  auto operator /(const type &__RHS) const;
-  type operator &(const type &__RHS) const;
-  type operator |(const type &__RHS) const;
-  type operator ^(const type &__RHS) const;
+  auto operator +(const simd_view &RHS) const;
+  auto operator -(const simd_view &RHS) const;
+  auto operator *(const simd_view &RHS) const;
+  auto operator /(const simd_view &RHS) const;
+  simd_view operator &(const simd_view &RHS) const;
+  simd_view operator |(const simd_view &RHS) const;
+  simd_view operator ^(const simd_view &RHS) const;
 
   // Compound assignment.
-  type &operator +=(const type &__RHS);
-  type &operator -=(const type &__RHS);
-  type &operator *=(const type &__RHS);
-  type &operator /=(const type &__RHS);
-  type &operator &=(const type &__RHS);
-  type &operator |=(const type &__RHS);
-  type &operator ^=(const type &__RHS);
+  simd_view &operator +=(const simd_view &RHS);
+  simd_view &operator -=(const simd_view &RHS);
+  simd_view &operator *=(const simd_view &RHS);
+  simd_view &operator /=(const simd_view &RHS);
+  simd_view &operator &=(const simd_view &RHS);
+  simd_view &operator |=(const simd_view &RHS);
+  simd_view &operator ^=(const simd_view &RHS);
 
   // Compare operators.
-  simd<uint16_t, __N> operator >(const type &__RHS) const;
-  simd<uint16_t, __N> operator >=(const type &__RHS) const;
-  simd<uint16_t, __N> operator <(const type &__RHS) const;
-  simd<uint16_t, __N> operator <=(const type &__RHS) const;
-  simd<uint16_t, __N> operator ==(const type &__RHS) const;
-  simd<uint16_t, __N> operator !=(const type &__RHS) const;
+  simd<uint16_t, N> operator >(const simd_view &RHS) const;
+  simd<uint16_t, N> operator >=(const simd_view &RHS) const;
+  simd<uint16_t, N> operator <(const simd_view &RHS) const;
+  simd<uint16_t, N> operator <=(const simd_view &RHS) const;
+  simd<uint16_t, N> operator ==(const simd_view &RHS) const;
+  simd<uint16_t, N> operator !=(const simd_view &RHS) const;
 
   // Select operations.
-  template <int __Size, int __Stride, typename __T = type,
-            typename = std::enable_if_t<__T::is1D()>>
-  auto select(uint16_t __Offset = 0) &;
-  template <int __Size, int __Stride, typename __T = type,
-            typename = std::enable_if_t<__T::is1D()>>
-  auto select(uint16_t __Offset = 0) &&;
-  template <int __SizeY, int __StrideY, int __SizeX, int __StrideX,
-            typename __T = type, typename = std::enable_if_t<__T::is2D()>>
-  auto select(uint16_t __OffsetY = 0, uint16_t __OffsetX = 0) &;
-  template <int __SizeY, int __StrideY, int __SizeX, int __StrideX,
-            typename __T = type, typename = std::enable_if_t<__T::is2D()>>
-  auto select(uint16_t __OffsetY = 0, uint16_t __OffsetX = 0) &&;
+  template <int Size, int Stride, typename T = simd_view,
+            typename = std::enable_if_t<T::is1D()>>
+  auto select(uint16_t Offset = 0) &;
+  template <int Size, int Stride, typename T = simd_view,
+            typename = std::enable_if_t<T::is1D()>>
+  auto select(uint16_t Offset = 0) &&;
+  template <int SizeY, int StrideY, int SizeX, int StrideX,
+            typename T = simd_view, typename = std::enable_if_t<T::is2D()>>
+  auto select(uint16_t OffsetY = 0, uint16_t OffsetX = 0) &;
+  template <int SizeY, int StrideY, int SizeX, int StrideX,
+            typename T = simd_view, typename = std::enable_if_t<T::is2D()>>
+  auto select(uint16_t OffsetY = 0, uint16_t OffsetX = 0) &&;
 
   // Replicate operations.
   template <int Rep> simd<element_type, Rep> replicate();
@@ -440,15 +435,15 @@ public:
                                         uint16_t OffsetX);
 
   // Format operations.
-  template <typename __EltTy> auto format();
-  template <typename __EltTy> auto format() &&;
-  template <typename __EltTy, int __Height, int __Width> auto format() &;
-  template <typename __EltTy, int __Height, int __Width> auto format() &&;
+  template <typename EltTy> auto format();
+  template <typename EltTy> auto format() &&;
+  template <typename EltTy, int Height, int Width> auto format() &;
+  template <typename EltTy, int Height, int Width> auto format() &&;
 
   // Merge operations.
-  void merge(const value_type &__Val, const __mask_type_t<length> &__Mask);
-  void merge(const value_type &__Val1, value_type __Val2,
-             const __mask_type_t<length> &__Mask);
+  void merge(const value_type &Val, const mask_type_t<length> &Mask);
+  void merge(const value_type &Val1, value_type Val2,
+             const mask_type_t<length> &Mask);
 } // namespace gpu
 } // namespace intel
 } // namespace sycl
@@ -575,14 +570,14 @@ template <typename T, int n, ChannelMaskType Mask,
           CacheHint L1H = CacheHint::Default,
           CacheHint L3H = CacheHint::Default>
     typename std::enable_if<(n == 16 || n == 32),
-                            simd<T, n * __NumChannels(Mask)>>::type
+                            simd<T, n * NumChannels(Mask)>>::type
     flat_load4(T *p, simd<uint32_t, n> offsets, simd<uint16_t, n> pred = 1);
 
 template <typename T, int n, ChannelMaskType Mask,
           CacheHint L1H = CacheHint::Default,
           CacheHint L3H = CacheHint::Default>
 typename std::enable_if<(n == 16 || n == 32), void>::type
-    flat_store4(T *p, simd<T, n * __NumChannels(Mask)> vals,
+    flat_store4(T *p, simd<T, n * NumChannels(Mask)> vals,
             simd<uint32_t, n> offsets, simd<uint16_t, n> pred = 1);
 ```
 
@@ -593,7 +588,7 @@ perform atomic memory access operation with zero source operand.
 template <CmAtomicOpType Op, typename T, int n,
           CacheHint L1H = CacheHint::Default,
           CacheHint L3H = CacheHint::Default>
-    typename std::enable_if<__check_atomic<Op, T, n, 0>(), simd<T, n>>::type
+    typename std::enable_if<check_atomic<Op, T, n, 0>(), simd<T, n>>::type
     flat_atomic(T *p, simd<unsigned, n> offset, simd<ushort, n> pred);
 ```
 
@@ -604,7 +599,7 @@ access operation with one source operand.
 template <CmAtomicOpType Op, typename T, int n,
           CacheHint L1H = CacheHint::Default,
           CacheHint L3H = CacheHint::Default>
-    typename std::enable_if<__check_atomic<Op, T, n, 1>(), simd<T, n>>::type
+    typename std::enable_if<check_atomic<Op, T, n, 1>(), simd<T, n>>::type
     flat_atomic(T *p, simd<unsigned, n> offset, simd<T, n> src0,
                 simd<ushort, n> pred);
 ```
@@ -617,7 +612,7 @@ with two source operands.
 template <CmAtomicOpType Op, typename T, int n,
           CacheHint L1H = CacheHint::Default,
           CacheHint L3H = CacheHint::Default>
-    typename std::enable_if<__check_atomic<Op, T, n, 2>(), simd<T, n>>::type
+    typename std::enable_if<check_atomic<Op, T, n, 2>(), simd<T, n>>::type
     flat_atomic(T *p, simd<unsigned, n> offset, simd<T, n> src0,
                 simd<T, n> src1, simd<ushort, n> pred);
 ```

--- a/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
+++ b/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
@@ -1,0 +1,731 @@
+# Explicit SIMD Programming Extension for DPC++
+
+## Introduction
+
+The main motivation for introducing the Explicit SIMD Programming (ESP) DPC++
+extension is enabling low-level efficient programming for Intel Gen
+architectures. More specifically, Explicit SIMD provides the following
+additional features:
+- Manual vectorization of device code using the `simd` class mapped to Gen's
+  general register file. This allows to write efficient code not relying on
+  further widening by the compiler, as with traditional SIMT programming.
+- Low-level APIs efficiently mapped to Gen architecture, such as block reads.
+
+One of the future directions is enabling this extension for other architectures,
+such as x86, with extracting and clearly marking generic and target-dependent
+API portions.
+
+## Explicit SIMD execution model
+
+Explicit SIMD execution model is a basically an equivalent of the base SYCL
+execution model with subgroup size restricted to 1. Which means in ESP
+it is guaranteed that there is a single work item in any workgroup, and it maps
+to a single hardware thread. All standard SYCL APIs continue to work,
+including `sycl::intel::sub_group` ones, which become either a no-op or
+trivial. E.g. a barrier becomes just a memory fence for a compiler, collectives
+just return the value in the single work-item. Another consequences of the unit
+subgroup size is guaranteed independent forward progress between work-items on
+some Gen architecture generations.
+
+## Explicit SIMD extension APIs
+
+Explicit SIMD APIs can be used only in code to be executed on Intel Gen
+architecture devices and the host device for now. Attempt to run such code on
+other devices will result in error. 
+
+Kernels and `SYCL_EXTERNAL` functions using ESP must be explicitly marked with
+the `EXPLICIT_SIMD` attribute macro. Subgroup size quiery within such
+functions will always return `1`.
+
+*Functor kernel*
+```cpp
+using AccTy = cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write,
+                                 cl::sycl::access::target::global_buffer>;
+class Functor {
+public:
+  Functor(int X, AccTy &Acc) : X(X), Acc(Acc) {}
+
+  EXPLICIT_SIMD void operator()() { Acc[0] += X; }
+
+private:
+  int X;
+  AccTy Acc;
+};
+```
+
+*Lambda kernel and function*
+```cpp
+EXPLICIT_SIMD SYCL_EXTERNAL
+void sycl_device_f(cl::sycl::global_ptr<int> ptr, sycl::intel::gpu::simd<float, 8> X) {
+  sycl::intel::gpu::flat_block_write(*ptr.get(), X);
+}
+...
+  Q.submit([&](cl::sycl::handler &Cgh) {
+    auto Acc1 = Buf1.get_access<cl::sycl::access::mode::read>(Cgh);
+    auto Acc2 = Buf2.get_access<cl::sycl::access::mode::read_write>(Cgh);
+
+    Cgh.single_task<class KernelID>([=] () EXPLICIT_SIMD {
+      sycl::intel::gpu::simd<float, 8> Val = sycl::intel::gpu::flat_block_read(Acc1.get_pointer());
+      sycl_device_f(Acc2, Val);
+    });
+  });
+}
+```
+
+## Implementation restrictions
+Current ESP implementation does not support using certain standard SYCL features
+inside explicit SIMD kernels and functions. Most of them will be eventually
+dropped. What's not supported today:
+- Mixing `EXPLICIT_SIMD` kernels with SYCL kernels in a single source
+- Local accessors. Local memory is allocated and accessed via explicit
+device-side API
+- 2D and 3D accessors
+- Constant accessors
+- `sycl::accessor::get_pointer()`. All memory accesses through an accessor are
+done via explicit APIs; e.g. `sycl::intel::gpu::block_store(acc, offset)`
+- Few others (to be documented)
+
+
+## Core Explicit SIMD programming APIs
+
+The DPC++ Explicit SIMD library defines the following classes to enhance the
+expressiveness for explicit SIMD data-parallel programming while enabling
+efficient mapping to SIMD vector operations on Intel GPU architectures.
+
+### SIMD vector class
+
+The ```sycl::intel::gpu::simd``` class is defined as a templated class for a vector
+of fundamental data elements. The fundamental data element type **__Ty** must be
+vectorizable, which can be any of the C++ character/integer/real floating-point types,
+or IEEE-754 half-precision floating-point type. The length of the vector
+is a constant expression, as determined by the template parameter **__N** in a
+given specialization.
+
+Each simd class object is mapped to a consecutive block of general register
+files (GRF).
+
+```cpp
+namespace cm {
+namespace gen {
+template <typename __Ty, int __N> class simd {
+public:
+  using value_type = simd<__Ty, __N, 0>;
+  using element_type = __Ty;
+  using vector_type = __vector_type_t<__Ty, __N>;
+  using type = simd<__Ty, __N>;
+  static constexpr int length = __N;
+
+  // Constructors.
+  constexpr simd();
+  constexpr simd(const simd &other);
+  constexpr simd(simd &&other);
+  constexpr simd(const vector_type &__Val);
+  constexpr simd(std::initializer_list<__Ty> __Ilist) noexcept;
+  constexpr simd(__Ty __Val, __Ty __Step = __Ty()) noexcept;
+
+  // Assignment operators.
+  constexpr type &operator=(const type &) &;
+  constexpr type &operator=(type &&) &;
+
+  // Subscript operators.
+  __Ty operator[](int __i);
+  __Ty operator[](int __i) const;
+
+  // Unary operators.
+  type &operator++();
+  type operator++(int);
+  type &operator--();
+  type operator--(int);
+
+  // Binary operators.
+  auto operator +(const type &__RHS) const;
+  auto operator -(const type &__RHS) const;
+  auto operator *(const type &__RHS) const;
+  auto operator /(const type &__RHS) const;
+  type operator &(const type &__RHS) const;
+  type operator |(const type &__RHS) const;
+  type operator ^(const type &__RHS) const;
+
+  // Compound assignment.
+  type &operator +=(const type &__RHS);
+  type &operator -=(const type &__RHS);
+  type &operator *=(const type &__RHS);
+  type &operator /=(const type &__RHS);
+  type &operator &=(const type &__RHS);
+  type &operator |=(const type &__RHS);
+  type &operator ^=(const type &__RHS);
+
+  // Compare operators.
+  simd<uint16_t, __N> operator >(const type &__RHS) const;
+  simd<uint16_t, __N> operator >=(const type &__RHS) const;
+  simd<uint16_t, __N> operator <(const type &__RHS) const;
+  simd<uint16_t, __N> operator <=(const type &__RHS) const;
+  simd<uint16_t, __N> operator ==(const type &__RHS) const;
+  simd<uint16_t, __N> operator !=(const type &__RHS) const;
+
+  // Select operations.
+  template <int __Size, int __Stride>
+  simd<__Ty, __Size> select(uint16_t __Offset = 0) &&;
+  template <int __Size, int __Stride>
+  simd_view<type, region1d_t<__Ty, __Size, __Stride>>
+  select(uint16_t __i = 0) &;
+
+  // Replicate operations.
+  template <int Rep> simd<__Ty, Rep * __N> replicate();
+  template <int Rep, int W> simd<__Ty, Rep * W> replicate(uint16_t __i);
+  template <int Rep, int VS, int W>
+  simd<__Ty, Rep * W> replicate(uint16_t __i);
+  template <int Rep, int VS, int W, int HS>
+  simd<__Ty, Rep * W> replicate(uint16_t __i);
+
+  // Format operations.
+  template <typename __EltTy> auto format() &;
+  template <typename __EltTy, int __Height, int __Width> auto format() &;
+
+  // Merge operations.
+  void merge(const value_type &__Val, const __mask_type_t<__N> &__Mask);
+  void merge(const value_type &__Val1, value_type __Val2,
+             const __mask_type_t<__N> &__Mask);
+} // namespace gen
+} // namespace cm
+```
+
+Every specialization of ```sycl::intel::gpu::simd``` shall be a complete type. The term
+simd type refers to all supported specialization of the simd class template.
+To access the i-th individual data element in a simd vector, Explicit SIMD supports the
+standard subscript operator ```[]```, which returns by value.
+
+For simd type object, Explicit SIMD supports the following simd vector operations:
+- Unary operators: ++ (*pre-/post-increment*), -- (*pre-/post-decrement*)
+- Binary operators: +, -, *, /, &, |, ^
+- Compound assignments: +=, -=, *=, /=, &=, |=, ^=
+- Compare operators: >, >=, <, <=, ==, !=
+
+These are all element-wise operations, which apply a specified operation to the
+elements of one or more simd objects and should follow the standard C++ rules for
+the corresponding scalar data element computation. Each such application is
+unsequenced with respect to the others.
+
+To reference a subset of the elements in simd vector object, Explicit SIMD provides ```select```
+function, which returns a simd or simd_view object (*described blow*) representing
+the selected sub-vector starting from the i-th element. The number of selected
+elements is specified by the template parameter **__Size**, while the distance
+between two adjacent elements is specified by the template parameter **__Stride**.
+
+```cpp
+  simd<int, 8> a;
+  simd<int, 4> b;
+  // ...
+  b = a.select<4, 2>(1);  // size=4, stride=2, offset=1 (elements a(1),
+                          // a(3), a(5) and a(7) are copied to b)
+```
+
+<p align="center">
+<img src="images/VectorOdd.svg" title="1D select example" width="600" height="60"/>
+</p>
+
+```cpp
+a.select<4, 2>(0) = b;  // selected elements of a are replaced
+                        // with elements of b (all elements of b are
+                        // copied to elements a(0), a(2), a(4), a(6))
+```
+
+<p align="center">
+<img src="images/VectorEven.svg" title="1D select example" width="600" height="60"/>
+</p>
+
+
+Gen ISA provides powerful register region addressing modes to facilitate cross-lane
+SIMD vector operation. To exploit this feature Explicit SIMD provides ```replicate``` function
+to allow programmer to implement any native Gen ISA region in the following forms:
+- ```replicate<REP>()```: replicate a simd vector object **REP** times and return a new simd
+vector of **REP** * Width, where Width specifies the original vector size.
+- ```replicate<REP, W>(uint16_t i)```: replicate **W** consecutive elements starting at the
+i-th element from the simd vector object **REP** times, and return a new simd vector of **REP** * **W** length.
+- ```replicate<REP, VS, W>(uint16_t i)```: replicate **REP** blocks of **W** consecutive
+elements starting at the i-th from the simd vector object with each block strided by **VS**
+elements, and return a new vector of **REP** * **W** length. Selected blocks of **W**
+elements will overlap if **VS** < **W**.
+- ```replicate<REP, VS, W, HS>(uint16_t i=0 )```: replicate **REP** blocks of **W** sequential
+elements with a stride of **HS** starting at the i-th element from the simd vector object with
+each block strided by **VS** elements, and return a new vector of **REP** * **W** length.
+Selected blocks of **W** elements will overlap if **VS** < **W**.
+
+To avoid explicit type cast and the resulting move instructions for large vectors, Explicit SIMD allows
+programmer to reinterpret the fundamental data element type of a simd vector object and change
+its shape to 1D or 2D object through the ```format``` function:
+- ```format<__EltTy>( )```: returns a reference to the calling simd object interpreted as a new
+simd vector with the size determined by the template **__EltTy** parameter.
+- ```format<__EltTy, __Height, __Width>( )```: returns a reference to the calling simd object interpreted
+as a new 2D simd_view object with the shape determined by the template parameters **__Height** and**__Width**. The size of the new 2D block must not exceed the size of the original object.
+
+```cpp
+  simd<int, 16> v1;
+   // ...
+  auto v2 = v1.format<short>;
+  // v2 is a reference to the location of v1
+  // interpreted as a vector of 32 shorts.
+  // ...
+  auto m1 = v1.format<int, 4, 4>;
+  // m1 is a reference to the location of v1
+  // interpreted as a matrix 4x4 of ints.
+  // ...
+  auto m2 = v1.format<char, 4, 16>( );
+  // m2 is a reference to the location of v1
+  // interpreted as a matrix 4x16 of chars.
+```
+
+To model predicated move, Explicit SIMD provides the following merge functions:
+- ```merge(value_type __Val, __mask_type __Mask)```: this merge operation takes one source operand **__Val** and a mask **__Mask** defined as unsigned short vector of the same length. The semantic is that if the LSB of an element of **__Mask** is set, then the corresponding data element of **__Val** is copied to the corresponding position in the calling simd object.
+
+```cpp
+  simd<int, 4>   m, src;
+  simd<unsigned short, 4> mask;
+  // ...
+  m.merge(src, mask);
+  // m           src         mask      --->  m
+  // 2 2 2 2     4 4 4 4     1 1 0 1         4 4 2 4
+```
+
+- ```merge(value_type __Val1, value_type __Val2, __mask_type __Mask)```: this merge operation takes two source operands **__Val1** and **__Val2** as well as a simd mask. The semantic is that if the LSB of an element of **__Mask** is set, then the corresponding data element of **__Val1** is copied to the corresponding position in the calling simd object. Otherwise the corresponding data element of **__Val2** is copied to the corresponding position in the calling simd object.
+
+```cpp
+  simd<int,4>   m, src1, src2;
+  simd<unsigned short, 4> mask;
+  // ...
+  m.merge(src1, src2, mask);
+  // m           src1        src2         mask        --->  m
+  // 2 2 2 2     4 4 4 4     3 3 3 3      1 1 0 1           4 4 3 4
+```
+### `simd_view` class
+
+The ```sycl::intel::gpu::simd_view``` represents a "window" into existing simd object,
+through which a part of the original object can be read or modified. This is a
+syntactic convenience feature to reduce verbosity when accessing sub-regions of
+simd objects. **__RegionTy** describes the window shape and can be 1D or 2D,
+**__BaseTy** is the original simd object type, which can be a ```simd_view```
+itself.
+
+```simd_view``` allows to model hierarchical “views” of the parent ```simd```
+object’s parts, read/modify its elements through the views. Views can be of
+different shapes and dimensions as illustrated below (`auto` resolves to a
+`simd_view` instantiation):
+
+<p align="center">
+<img src="images/simd_view.svg" title="1D select example" width="800" height="300"/>
+</p>
+
+```cpp
+namespace cm {
+namespace gen {
+template <typename __BaseTy, typename __RegionTy> class simd_view {
+public:
+  using __ShapeTy = typename __shape_type<__RegionTy>::type;
+  static constexpr int length = __ShapeTy::__Size_x * __ShapeTy::__Size_y;
+  using type = simd_view<__BaseTy, __RegionTy>;
+  using value_type = simd<typename __ShapeTy::element_type, length>;
+  using vector_type = __vector_type_t<typename __ShapeTy::element_type, length>;
+  using region_type = __RegionTy;
+  using base_type = typename __compute_base_type<__BaseTy, __RegionTy>::type;
+  using element_type = typename __ShapeTy::element_type;
+
+  // Constructors.
+  simd_view(__BaseTy &__Base, __RegionTy __Region);
+  simd_view(__BaseTy &&__Base, __RegionTy __Region);
+  simd_view(type &__Other);
+  simd_view(type &&__Other);
+
+  // Assignment operators.
+  type &operator=(const type &__Other);
+  type &operator=(const value_type &__Val);
+
+  // Region accessors.
+  static constexpr bool is1D();
+  static constexpr bool is2D();
+  static constexpr int getSizeX();
+  static constexpr int getStrideX();
+  static constexpr int getSizeY();
+  static constexpr int getStrideY();
+  constexpr uint16_t getOffsetX();
+  constexpr uint16_t getOffsetY();
+  template <int __Dim = 0> static constexpr int getSize();
+  template <int __Dim = 0> static constexpr int getStride();
+  template <int __Dim = 0> constexpr uint16_t getOffset() const;
+
+  // Subscript operators.
+  element_type operator[](int __i);
+  element_type operator[](int __i) const;
+
+  // Row/column operator.
+  template <typename __T = type, typename = std::enable_if_t<__T::is2D()>>
+  auto row(int __i);
+  template <typename __T = type, typename = std::enable_if_t<__T::is2D()>>
+  auto column(int __i);
+
+  // Unary operators.
+  type &operator++();
+  type operator++(int);
+  type &operator--();
+  type operator--(int);
+
+  // Binary operators.
+  auto operator +(const type &__RHS) const;
+  auto operator -(const type &__RHS) const;
+  auto operator *(const type &__RHS) const;
+  auto operator /(const type &__RHS) const;
+  type operator &(const type &__RHS) const;
+  type operator |(const type &__RHS) const;
+  type operator ^(const type &__RHS) const;
+
+  // Compound assignment.
+  type &operator +=(const type &__RHS);
+  type &operator -=(const type &__RHS);
+  type &operator *=(const type &__RHS);
+  type &operator /=(const type &__RHS);
+  type &operator &=(const type &__RHS);
+  type &operator |=(const type &__RHS);
+  type &operator ^=(const type &__RHS);
+
+  // Compare operators.
+  simd<uint16_t, __N> operator >(const type &__RHS) const;
+  simd<uint16_t, __N> operator >=(const type &__RHS) const;
+  simd<uint16_t, __N> operator <(const type &__RHS) const;
+  simd<uint16_t, __N> operator <=(const type &__RHS) const;
+  simd<uint16_t, __N> operator ==(const type &__RHS) const;
+  simd<uint16_t, __N> operator !=(const type &__RHS) const;
+
+  // Select operations.
+  template <int __Size, int __Stride, typename __T = type,
+            typename = std::enable_if_t<__T::is1D()>>
+  auto select(uint16_t __Offset = 0) &;
+  template <int __Size, int __Stride, typename __T = type,
+            typename = std::enable_if_t<__T::is1D()>>
+  auto select(uint16_t __Offset = 0) &&;
+  template <int __SizeY, int __StrideY, int __SizeX, int __StrideX,
+            typename __T = type, typename = std::enable_if_t<__T::is2D()>>
+  auto select(uint16_t __OffsetY = 0, uint16_t __OffsetX = 0) &;
+  template <int __SizeY, int __StrideY, int __SizeX, int __StrideX,
+            typename __T = type, typename = std::enable_if_t<__T::is2D()>>
+  auto select(uint16_t __OffsetY = 0, uint16_t __OffsetX = 0) &&;
+
+  // Replicate operations.
+  template <int Rep> simd<element_type, Rep> replicate();
+  template <int Rep, int W>
+  simd<element_type, Rep * W> replicate(uint16_t OffsetX);
+  template <int Rep, int W>
+  simd<element_type, Rep * W> replicate(uint16_t OffsetY,
+                                        uint16_t OffsetX);
+  template <int Rep, int VS, int W>
+  simd<element_type, Rep * W> replicate(uint16_t OffsetX);
+  template <int Rep, int VS, int W>
+  simd<element_type, Rep * W> replicate(uint16_t OffsetY,
+                                        uint16_t OffsetX);
+  template <int Rep, int VS, int W, int HS>
+  simd<element_type, Rep * W> replicate(uint16_t OffsetX);
+  template <int Rep, int VS, int W, int HS>
+  simd<element_type, Rep * W> replicate(uint16_t OffsetY,
+                                        uint16_t OffsetX);
+
+  // Format operations.
+  template <typename __EltTy> auto format();
+  template <typename __EltTy> auto format() &&;
+  template <typename __EltTy, int __Height, int __Width> auto format() &;
+  template <typename __EltTy, int __Height, int __Width> auto format() &&;
+
+  // Merge operations.
+  void merge(const value_type &__Val, const __mask_type_t<length> &__Mask);
+  void merge(const value_type &__Val1, value_type __Val2,
+             const __mask_type_t<length> &__Mask);
+} // namespace gen
+} // namespace cm
+```
+
+```sycl::intel::gpu::simd_view``` class supports all the element-wise operations and
+other utility functions defined for ```sycl::intel::gpu::simd``` class. It also
+provides region accessors and more generic operations tailored for 2D regions,
+such as row/column operators and 2D select/replicate/format/merge operations.
+
+```cpp
+  simd<float, 32> v1;
+  auto m1 = v1.format<float, 4, 8>();
+  simd<float, 4> v2;
+  auto m2 = v2.format<float, 2, 2>();
+
+  // ...
+  m2 = m1.select<2, 2, 2, 4>(1, 2);  // v_size = 2, v_stride = 2,
+                                     // h_size = 2, h_stride = 4,
+                                     // v_offset = 1, h_offset = 2.
+```
+<p align="center">
+<img src="images/Matrix_2_2_2_4__1_2.svg" title="2D select example" width="700" height="200"/>
+</p>
+
+```cpp
+  m1.select<4, 1, 4, 2>(0, 0) = 0.0f; // selected elements of m1
+                                      // are replaced with 0.0f
+```
+
+<p align="center">
+<img src="images/Matrix_4_1_4_2__0_0.svg" title="2D select example" width="700" height="200"/>
+</p>
+
+### Reduction functions
+
+Explicit SIMD provides the following reduction functions for simd objects.
+Compiler will produce optimal code sequence on the target device to apply the
+specified operation to all scalar elements in the input simd vector. Note that
+the order of element-wise operations is not guaranteed and the correctness of
+result should not depend on a particular computation order.
+- ```cm_sum(simd<T1, SZ> v)```: returns a scalar value of type **T0** that's
+equal to the sum of all data elements of type **T1** in simd vector **v** of
+length **SZ**.
+- ```cm_prod(simd<T1, SZ> v)```: returns a scalar value of type **T0** that's
+equal to the product of all data elements of type **T1** in simd vector **v** of
+length **SZ**.
+- ```cm_reduced_max(simd<T1, SZ> v)```: returns a scalar value of type **T0**
+that's equal to the maximum value of all data elements of type **T1** in simd
+vector **v** of length **SZ**.
+- ```cm_reduced_min(simd<T1, SZ> v)```: returns a scalar value of type **T0**
+that's equal to the minimum value of all data elements of type **T1** in simd
+vector **v** of length **SZ**.
+
+```cpp
+template <typename T0, typename T1, int SZ> T0 cm_sum(simd<T1, SZ> v);
+template <typename T0, typename T1, int SZ> T0 cm_prod(simd<T1, SZ> v);
+template <typename T0, typename T1, int SZ> T0 cm_reduced_max(simd<T1, SZ> v);
+template <typename T0, typename T1, int SZ> T0 cm_reduced_min(simd<T1, SZ> v);
+```
+
+### Memory access APIs
+
+Currently the variety of memory objects supported by the Explicit SIMD extension
+implementation is limited to the following:
+- USM pointers (aka 'flat address')
+- 1D global accessors
+- 2D image accessors
+
+The implementation further limits the set of memory access operations
+which a kernel can perform through those memory objects. Basically, all of them
+are special intrinsic APIs described below rather than standard SYCL accessor or
+pointer operations. Examples of unsupported features include
+`accessor::get_pointer()`, accessor's `operator []`, C/C++ dereference of an
+USM pointer, local accessors, 2D and 3D accessors.
+Those are temporary restrictions, to be dropped in future.
+
+See auto-generated documentation for the complete list of APIs here. (TBD)
+
+#### USM pointer-based memory access
+##### Flat-address gather/scatter
+perform scattered read/write for the given starting pointer **p** and
+**offsets**.
+
+```cpp
+template <typename T, int n, int ElemsPerAddr = 1,
+	  CacheHint L1H = CacheHint::Default,
+          CacheHint L3H = CacheHint::Default>
+typename std::enable_if<((n == 16 || n == 32) &&
+    (ElemsPerAddr == 1 || ElemsPerAddr == 2 || ElemsPerAddr == 4)),
+    simd<T, n*ElemsPerAddr>>::type
+flat_load(T *p, simd<uint32_t, n> offsets, simd<uint16_t, n> pred = 1);
+
+template <typename T, int n, int ElemsPerAddr = 1,
+	  CacheHint L1H = CacheHint::Default,
+          CacheHint L3H = CacheHint::Default>
+typename std::enable_if<((n == 16 || n == 32) &&
+    (ElemsPerAddr == 1 || ElemsPerAddr == 2 || ElemsPerAddr == 4)),
+    void>::type
+flat_store(T *p, simd<T, n*ElemsPerAddr> vals, simd<uint32_t, n> offsets,
+           simd<uint16_t, n> pred = 1);
+```
+##### Flat-address block load/store
+read or write a consecutive block of data for the memory location specified by
+**addr**.
+
+```cpp
+template <typename T, int n, CacheHint L1H = CacheHint::Default,
+          CacheHint L3H = CacheHint::Default>
+simd<T, n> flat_block_load(const T *const addr);
+
+template <typename T, int n, CacheHint L1H = CacheHint::Default,
+          CacheHint L3H = CacheHint::Default>
+void flat_block_store(T *p, simd<T, n> vals);
+```
+
+##### Flat-address load4/store4
+perform scattered read/write for the given starting pointer **p** and
+**offsets**. Up to 4 data elements may be accessed at each address depending on
+the enabled channel **Mask**.
+
+```cpp
+template <typename T, int n, ChannelMaskType Mask,
+          CacheHint L1H = CacheHint::Default,
+          CacheHint L3H = CacheHint::Default>
+    typename std::enable_if<(n == 16 || n == 32),
+                            simd<T, n * __NumChannels(Mask)>>::type
+    flat_load4(T *p, simd<uint32_t, n> offsets, simd<uint16_t, n> pred = 1);
+
+template <typename T, int n, ChannelMaskType Mask,
+          CacheHint L1H = CacheHint::Default,
+          CacheHint L3H = CacheHint::Default>
+typename std::enable_if<(n == 16 || n == 32), void>::type
+    flat_store4(T *p, simd<T, n * __NumChannels(Mask)> vals,
+            simd<uint32_t, n> offsets, simd<uint16_t, n> pred = 1);
+```
+
+##### Flat-address atomic inc/dec
+perform atomic memory access operation with zero source operand.
+
+```cpp
+template <CmAtomicOpType Op, typename T, int n,
+          CacheHint L1H = CacheHint::Default,
+          CacheHint L3H = CacheHint::Default>
+    typename std::enable_if<__check_atomic<Op, T, n, 0>(), simd<T, n>>::type
+    flat_atomic(T *p, simd<unsigned, n> offset, simd<ushort, n> pred);
+```
+
+- ```Flat-address atomic add/sub/min/max/etc.```: perform atomic memory
+access operation with one source operand.
+
+```cpp
+template <CmAtomicOpType Op, typename T, int n,
+          CacheHint L1H = CacheHint::Default,
+          CacheHint L3H = CacheHint::Default>
+    typename std::enable_if<__check_atomic<Op, T, n, 1>(), simd<T, n>>::type
+    flat_atomic(T *p, simd<unsigned, n> offset, simd<T, n> src0,
+                simd<ushort, n> pred);
+```
+
+- ```Flat-address atomic CMPXCHG```: perform atomic memory access operation
+with two source operands.
+
+```cpp
+
+template <CmAtomicOpType Op, typename T, int n,
+          CacheHint L1H = CacheHint::Default,
+          CacheHint L3H = CacheHint::Default>
+    typename std::enable_if<__check_atomic<Op, T, n, 2>(), simd<T, n>>::type
+    flat_atomic(T *p, simd<unsigned, n> offset, simd<T, n> src0,
+                simd<T, n> src1, simd<ushort, n> pred);
+```
+
+#### Accessor-based memory access
+
+Examples:
+##### 1D surface block store.
+T – element type, n – vector length, acc – SYCL global buffer accessor,
+offset – byte offset in the buffer, vals – vector value to store
+```cpp
+template <typename T, int n, typename AccessorTy>
+void block_store(AccessorTy acc, uint32_t offset, simd<T, n> vals);
+```
+##### 2D media block load.
+T – element type, m and n – block dimensions, acc – SYCL image2D accessor,
+x and y – image coordinates
+```cpp
+template <typename T, int m, int n, typename AccessorTy, unsigned plane = 0>
+simd<T, m * n> media_block_load(AccessorTy acc, unsigned x, unsigned y);
+```
+
+#### Local address space allocation and access
+Examples:
+
+##### SLM scatter.
+T – element type, n – vector length (16 or 32), vals – vector value to store,
+offsets – byte offsets in the local memory, pred – store mask
+```cpp
+template <typename T, int n>
+typename std::enable_if<(n == 16 || n == 32), void>::type
+slm_store(simd<T, n> vals, simd<uint32_t, n> offsets, simd<uint16_t, n> pred = 1);
+```
+<br>
+
+### Private Global Variables.
+
+Explicit SIMD extenstion supports "private global" variables - file scope
+variables in private address space (similar to thread-local variables on host).
+These variables have 1 copy per work-item (which maps to a single SIMD thread in
+ESP) and are visible to all functions in the translation unit. Conceptually they
+map to SPIRV variable with private storage class. Private globals can be bound
+to a specific byte offset within the GRF. To mark a file scope variable as
+private global, the `INTEL_GPU_PRIVATE` attribute macro is used,
+`INTEL_GPU_REGISTER` is used to bind it the register file:
+
+```cpp
+INTEL_GPU_PRIVATE INTEL_GPU_REGISTER(32) simd<int, 16> vc;
+```
+<br>
+
+## Examples
+### Vector addition (USM)
+```cpp
+#include <iostream>
+#include <CL/sycl.hpp>
+#include <sycl_explicit_simd.hpp>
+
+using namespace cl::sycl;
+
+int main(void) {
+  constexpr unsigned Size = 128;
+  constexpr unsigned VL = 32;
+  constexpr unsigned GroupSize = 2;
+
+  queue q;
+  auto dev = q.get_device();
+  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  auto ctxt = q.get_context();
+  float* A = static_cast<float*>(malloc_shared(Size*sizeof(float), dev, ctxt));
+  float* B = static_cast<float*>(malloc_shared(Size*sizeof(float), dev, ctxt));
+  float* C = static_cast<float*>(malloc_shared(Size*sizeof(float), dev, ctxt));
+
+  for (unsigned i = 0; i < Size; ++i) {
+    A[i] = B[i] = i;
+  }
+
+  // iteration space
+  nd_range<1> Range(range<1>(Size/VL), range<1>(GroupSize));
+
+  auto e = q.submit([&](handler &cgh) {
+    cgh.parallel_for<class Test>(
+      Range, [=](nd_item<1> i) EXPLICIT_SIMD {
+
+      auto offset = i.get_global_id(0) * VL;
+      sycl::intel::gpu<float, VL> va = sycl::intel::gpu::flat_block_load<float, VL>(A + offset);
+      sycl::intel::gpu<float, VL> vb = sycl::intel::gpu::flat_block_load<float, VL>(B + offset);
+      sycl::intel::gpu<float, VL> vc = va + vb;
+      sycl::intel::gpu::flat_block_store<float, VL>(C + offset, vc);
+    });
+  });
+  e.wait();
+  int err_cnt = 0;
+
+  for (unsigned i = 0; i < Size; ++i) {
+    if (A[i] + B[i] != C[i]) {
+      if (++err_cnt < 10) {
+        std::cout << "failed at index " << i << ", " << C[i] << " != " << A[i]
+          << " + " << B[i] << "\n";
+      }
+    }
+  }
+  if (err_cnt > 0) {
+    std::cout << "  pass rate: " << ((float)(Size - err_cnt) / (float)Size)*100.0f <<
+      "% (" << (Size - err_cnt) << "/" << Size << ")\n";
+  }
+
+  std::cout << (err_cnt > 0 ? "FAILED\n" : "Passed\n");
+  return err_cnt > 0 ? 1 : 0;
+}
+```
+
+### Open questions
+- Vectorization controls (e.g. enforcing vector length generated by the
+  compiler) for vector/matrix operations.
+- Enabling loop vectorizer on inner loops in a Explicit SIMD kernel or function.
+
+### TODOs
+
+- Design interoperability with SIMT context - via `subgroup::invoke()`
+- Generate sycl::intel::gpu API documentation from sources
+- Section covering 2D use cases
+- A bridge from `std::simd` to `sycl::intel::gpu::simd`
+- Describe `simd_view` class restrictions
+

--- a/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
+++ b/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
@@ -674,7 +674,7 @@ INTEL_GPU_PRIVATE INTEL_GPU_REGISTER(32) simd<int, 16> vc;
 ```cpp
 #include <iostream>
 #include <CL/sycl.hpp>
-#include <sycl_[[sycl_explicit_simd]].hpp>
+#include <sycl_esimd.hpp>
 
 using namespace cl::sycl;
 

--- a/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
+++ b/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
@@ -743,3 +743,6 @@ int main(void) {
 - A bridge from `std::simd` to `sycl::intel::gpu::simd`
 - Describe `simd_view` class restrictions
 - Consider auto-inclusion of sycl_[[sycl_explicit_simd]].hpp under -fsycl-esimd option
+- Add example showing the mapping between an ND-range and the number of
+thread-groups and EU threads, and showing the usage of explicit SIMD together
+with work-group barriers and SLM.

--- a/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
+++ b/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
@@ -485,24 +485,25 @@ Compiler will produce optimal code sequence on the target device to apply the
 specified operation to all scalar elements in the input simd vector. Note that
 the order of element-wise operations is not guaranteed and the correctness of
 result should not depend on a particular computation order.
-- ```cm_sum(simd<T1, SZ> v)```: returns a scalar value of type **T0** that's
-equal to the sum of all data elements of type **T1** in simd vector **v** of
-length **SZ**.
-- ```cm_prod(simd<T1, SZ> v)```: returns a scalar value of type **T0** that's
-equal to the product of all data elements of type **T1** in simd vector **v** of
-length **SZ**.
-- ```cm_reduced_max(simd<T1, SZ> v)```: returns a scalar value of type **T0**
+- ```reduce(simd<T1, SZ> v, std::plus<>())```: returns a scalar value of type
+**T0** that's equal to the sum of all data elements of type **T1** in simd vector
+**v** of length **SZ**.
+- ```reduce(simd<T1, SZ> v, std::multiplies<>())```: returns a scalar value of
+type **T0** that's equal to the product of all data elements of type **T1** in simd
+vector **v** of length **SZ**.
+- ```hmax(simd<T1, SZ> v)```: returns a scalar value of type **T0**
 that's equal to the maximum value of all data elements of type **T1** in simd
 vector **v** of length **SZ**.
-- ```cm_reduced_min(simd<T1, SZ> v)```: returns a scalar value of type **T0**
+- ```hmin(simd<T1, SZ> v)```: returns a scalar value of type **T0**
 that's equal to the minimum value of all data elements of type **T1** in simd
 vector **v** of length **SZ**.
 
 ```cpp
-template <typename T0, typename T1, int SZ> T0 cm_sum(simd<T1, SZ> v);
-template <typename T0, typename T1, int SZ> T0 cm_prod(simd<T1, SZ> v);
-template <typename T0, typename T1, int SZ> T0 cm_reduced_max(simd<T1, SZ> v);
-template <typename T0, typename T1, int SZ> T0 cm_reduced_min(simd<T1, SZ> v);
+template <typename T0, typename T1, int SZ, typename BinaryOperation>
+T0 reduce(simd<T1, SZ> v, BinaryOperation op);
+
+template <typename T0, typename T1, int SZ> T0 hmax(simd<T1, SZ> v);
+template <typename T0, typename T1, int SZ> T0 hmin(simd<T1, SZ> v);
 ```
 
 ### Memory access APIs

--- a/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
+++ b/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
@@ -19,7 +19,7 @@ Here are some future directions in which this API is intended to evolve:
 
 ## Explicit SIMD execution model
 
-Explicit SIMD execution model is a basically an equivalent of the base SYCL
+Explicit SIMD execution model is basically an equivalent of the base SYCL
 execution model with subgroup size restricted to 1. Which means each subgroup
 maps to a single hardware thread. All standard SYCL APIs continue to work,
 including `sycl::intel::sub_group` ones, which become either a no-op or
@@ -97,8 +97,8 @@ efficient mapping to SIMD vector operations on Intel GPU architectures.
 
 The `sycl::intel::gpu::simd` class is a vector templated on some element type. The element type must be vectorizable type. The set of vectorizable types is the set of fundamental SYCL arithmetic types (C++ arithmetic types or `half` type) excluding `bool`. The length of the vector is the second template parameter.
 
-Each simd class object is mapped to a consecutive block of general register
-files (GRF).
+ESIMD compiler back-end does the best it can to map each `simd` class object to a consecutive block
+of registers in the general register file (GRF).
 
 ```cpp
 namespace sycl {

--- a/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
+++ b/sycl/doc/extensions/ExplicitSIMD/dpcpp-explicit-simd.md
@@ -104,6 +104,20 @@ files (GRF).
 namespace sycl {
 namespace intel {
 namespace gpu {
+
+// __vector_type, using clang vector type extension.
+template <typename __Ty, int __N> struct __vector_type {
+  static_assert(!std::is_const<__Ty>::value, "const element type not supported");
+  static_assert(__is_vectorizable_v<__Ty>::value, "element type not supported");
+  static_assert(__N > 0, "zero-element vector not supported");
+
+  static constexpr int length = __N;
+  using type = __Ty __attribute__((ext_vector_type(__N)));
+};
+
+template <int __N>
+using __mask_type_t = typename __vector_type<uint16_t, __N>::type;
+
 template <typename __Ty, int __N> class simd {
 public:
   using value_type = simd<__Ty, __N, 0>;
@@ -728,3 +742,4 @@ int main(void) {
 - Section covering 2D use cases
 - A bridge from `std::simd` to `sycl::intel::gpu::simd`
 - Describe `simd_view` class restrictions
+- Consider auto-inclusion of sycl_explicit_simd.hpp under -fsycl-esimd option

--- a/sycl/doc/extensions/ExplicitSIMD/images/Matrix_2_2_2_4__1_2.svg
+++ b/sycl/doc/extensions/ExplicitSIMD/images/Matrix_2_2_2_4__1_2.svg
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="CMMatrix_2_2_2_4__1_2.svg"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 276.2329 71.202034"
+   height="71.202034mm"
+   width="276.23288mm">
+  <defs
+     id="defs2">
+    <rect
+       id="rect1123"
+       height="27.796032"
+       width="201.25395"
+       y="102.8446"
+       x="-47.093624" />
+    <rect
+       id="rect1117"
+       height="25.177505"
+       width="109.10014"
+       y="26.672779"
+       x="-99.74572" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="69"
+     inkscape:window-height="1411"
+     inkscape:window-width="2482"
+     lock-margins="true"
+     fit-margin-bottom="5"
+     fit-margin-right="5"
+     fit-margin-left="5"
+     fit-margin-top="5"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="242.02806"
+     inkscape:cx="875.92901"
+     inkscape:zoom="0.98994949"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(135.59491,-1.0149053)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <rect
+       id="rect833-4"
+       width="15.768902"
+       height="15.234363"
+       x="40.892223"
+       y="51.850288"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-6"
+       width="15.768902"
+       height="15.234363"
+       x="40.892246"
+       y="6.1471977"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="21.381563"
+       x="103.96786"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-9" />
+    <rect
+       id="rect833-3"
+       width="15.768902"
+       height="15.234363"
+       x="25.123344"
+       y="6.1471968"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="51.850288"
+       x="103.96786"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-3" />
+    <rect
+       id="rect833-5"
+       width="15.768902"
+       height="15.234363"
+       x="9.3544416"
+       y="6.1471968"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="21.381565"
+       x="40.892242"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-6" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="6.1471977"
+       x="56.661148"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-6-8" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="6.1472006"
+       x="103.96786"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-6-4" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="6.1471996"
+       x="88.198959"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3-2" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="6.1471996"
+       x="72.430054"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5-3" />
+    <rect
+       id="rect833-6-8-3"
+       width="15.768902"
+       height="15.234363"
+       x="119.73676"
+       y="6.1472006"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="21.381559"
+       x="25.123331"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3-4" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="21.381559"
+       x="9.3544283"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5-1" />
+    <rect
+       id="rect833-6-8-0"
+       width="15.768902"
+       height="15.234363"
+       x="56.661133"
+       y="21.381563"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-3-2-7"
+       width="15.768902"
+       height="15.234363"
+       x="88.198952"
+       y="21.381563"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-5-3-0"
+       width="15.768902"
+       height="15.234363"
+       x="72.430038"
+       y="21.381563"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="21.381563"
+       x="119.73676"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-6-8-3-6" />
+    <rect
+       id="rect833-6-9-4"
+       width="15.768902"
+       height="15.234363"
+       x="40.892242"
+       y="36.615925"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-3-4-7"
+       width="15.768902"
+       height="15.234363"
+       x="25.123337"
+       y="36.615921"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-5-1-3"
+       width="15.768902"
+       height="15.234363"
+       x="9.3544312"
+       y="36.615921"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="36.615925"
+       x="56.66114"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-6-8-0-8" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="36.615925"
+       x="103.96786"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-6-4-6-5" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="36.615925"
+       x="88.198967"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3-2-7-6" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="36.615925"
+       x="72.430046"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5-3-0-3" />
+    <rect
+       id="rect833-6-8-3-6-2"
+       width="15.768902"
+       height="15.234363"
+       x="119.73678"
+       y="36.615925"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="51.850285"
+       x="25.123322"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3-4-7-3" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="51.850285"
+       x="9.3544159"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5-1-3-3" />
+    <rect
+       id="rect833-6-8-0-8-3"
+       width="15.768902"
+       height="15.234363"
+       x="56.661125"
+       y="51.850288"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-3-2-7-6-9"
+       width="15.768902"
+       height="15.234363"
+       x="88.198952"
+       y="51.850288"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-5-3-0-3-4"
+       width="15.768902"
+       height="15.234363"
+       x="72.430031"
+       y="51.850288"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="51.850288"
+       x="119.73676"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-6-8-3-6-2-6" />
+    <text
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1117);fill:#000000;fill-opacity:1;stroke:none;"
+       id="text1115"
+       xml:space="preserve" />
+    <text
+       transform="translate(-84.457171,-72.430042)"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1123);fill:#000000;fill-opacity:1;stroke:none;"
+       id="text1121"
+       xml:space="preserve"><tspan
+         sodipodi:role="line"
+         x="-47.09375"
+         y="112.49922"><tspan>m1.select&lt;2,2,2,4&gt;(1, 2)</tspan></tspan></text>
+  </g>
+</svg>

--- a/sycl/doc/extensions/ExplicitSIMD/images/Matrix_4_1_4_2__0_0.svg
+++ b/sycl/doc/extensions/ExplicitSIMD/images/Matrix_4_1_4_2__0_0.svg
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="CMMatrix_4_1_4_2__0_0.svg"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 276.23287 71.202049"
+   height="71.202049mm"
+   width="276.23285mm">
+  <defs
+     id="defs2">
+    <rect
+       id="rect2415"
+       height="100.49334"
+       width="309.49811"
+       y="93.222893"
+       x="170.4287" />
+    <rect
+       id="rect1123"
+       height="27.796032"
+       width="201.25395"
+       y="102.8446"
+       x="-47.093624" />
+    <rect
+       id="rect1117"
+       height="25.177505"
+       width="109.10014"
+       y="26.672779"
+       x="-99.74572" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="69"
+     inkscape:window-height="1411"
+     inkscape:window-width="2482"
+     lock-margins="true"
+     fit-margin-bottom="5"
+     fit-margin-right="5"
+     fit-margin-left="5"
+     fit-margin-top="5"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="401.63215"
+     inkscape:cx="875.92901"
+     inkscape:zoom="0.98994949"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(135.59491,-1.5494455)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <rect
+       id="rect833-4"
+       width="15.768902"
+       height="15.234363"
+       x="40.892242"
+       y="6.6817369"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-3"
+       width="15.768902"
+       height="15.234363"
+       x="56.661144"
+       y="6.6817369"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-5"
+       width="15.768902"
+       height="15.234363"
+       x="25.123341"
+       y="6.6817446"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="6.6817446"
+       x="9.3544378"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-6" />
+    <text
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1117);fill:#000000;fill-opacity:1;stroke:none;"
+       id="text1115"
+       xml:space="preserve" />
+    <text
+       transform="translate(-84.457171,-72.430042)"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1123);fill:#000000;fill-opacity:1;stroke:none;"
+       id="text1121"
+       xml:space="preserve"><tspan
+         sodipodi:role="line"
+         x="-47.09375"
+         y="112.49922"><tspan>m1.select&lt;4,1,4,2&gt;(0, 0)</tspan></tspan></text>
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="6.6817369"
+       x="103.96785"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-5" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="6.6817369"
+       x="119.73675"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3-1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="6.6817369"
+       x="88.198944"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5-0" />
+    <rect
+       id="rect833-4-6-3"
+       width="15.768902"
+       height="15.234363"
+       x="72.430046"
+       y="6.6817369"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="21.916096"
+       x="40.892242"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-56" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="21.916096"
+       x="56.66114"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3-7" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="21.916103"
+       x="25.123339"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5-08" />
+    <rect
+       id="rect833-4-6-5"
+       width="15.768902"
+       height="15.234363"
+       x="9.3544407"
+       y="21.916103"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-4-5-0"
+       width="15.768902"
+       height="15.234363"
+       x="103.96784"
+       y="21.916096"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-3-1-1"
+       width="15.768902"
+       height="15.234363"
+       x="119.73675"
+       y="21.916096"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-5-0-2"
+       width="15.768902"
+       height="15.234363"
+       x="88.198944"
+       y="21.916096"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="21.916096"
+       x="72.430046"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-6-3-7" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="37.150455"
+       x="40.892242"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-7" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="37.150455"
+       x="56.66114"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3-11" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="37.150455"
+       x="25.123341"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5-6" />
+    <rect
+       id="rect833-4-6-37"
+       width="15.768902"
+       height="15.234363"
+       x="9.3544426"
+       y="37.150455"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-4-5-1"
+       width="15.768902"
+       height="15.234363"
+       x="103.96784"
+       y="37.150455"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-3-1-3"
+       width="15.768902"
+       height="15.234363"
+       x="119.73675"
+       y="37.150455"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-5-0-8"
+       width="15.768902"
+       height="15.234363"
+       x="88.198944"
+       y="37.150455"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="37.150455"
+       x="72.430046"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-6-3-8" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="52.384823"
+       x="40.892227"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-59" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="52.384823"
+       x="56.661133"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3-46" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="52.384838"
+       x="25.123322"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5-9" />
+    <rect
+       id="rect833-4-6-1"
+       width="15.768902"
+       height="15.234363"
+       x="9.3544235"
+       y="52.384838"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-4-5-12"
+       width="15.768902"
+       height="15.234363"
+       x="103.96783"
+       y="52.384823"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-3-1-6"
+       width="15.768902"
+       height="15.234363"
+       x="119.73674"
+       y="52.384823"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-5-0-80"
+       width="15.768902"
+       height="15.234363"
+       x="88.198929"
+       y="52.384823"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="52.384823"
+       x="72.430038"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4-6-3-9" />
+    <text
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2415);fill:#000000;fill-opacity:1;stroke:none;"
+       id="text2413"
+       xml:space="preserve" />
+  </g>
+</svg>

--- a/sycl/doc/extensions/ExplicitSIMD/images/VectorEven.svg
+++ b/sycl/doc/extensions/ExplicitSIMD/images/VectorEven.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="232.28477mm"
+   height="25.498947mm"
+   viewBox="0 0 232.28479 25.498947"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)"
+   sodipodi:docname="CMVectorOdd.svg">
+  <defs
+     id="defs2">
+    <rect
+       id="rect2309"
+       height="17.372519"
+       width="133.90202"
+       y="7.4293742"
+       x="-108.03106" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="685.47331"
+     inkscape:cy="441.36183"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     fit-margin-top="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5"
+     lock-margins="true"
+     inkscape:window-width="2482"
+     inkscape:window-height="1411"
+     inkscape:window-x="69"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(59.84172,-2.3512519)">
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="7.4835443"
+       x="41.159512"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="7.4835443"
+       x="120.00404"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-6" />
+    <rect
+       id="rect833-4-9"
+       width="15.768902"
+       height="15.234363"
+       x="135.77295"
+       y="7.4835443"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="7.4835443"
+       x="88.466225"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3" />
+    <rect
+       id="rect833-4-3"
+       width="15.768902"
+       height="15.234363"
+       x="104.23514"
+       y="7.4835443"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="7.4835443"
+       x="56.928417"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5" />
+    <rect
+       id="rect833-4-6"
+       width="15.768902"
+       height="15.234363"
+       x="72.697319"
+       y="7.4835443"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       id="rect833-6-8"
+       width="15.768902"
+       height="15.234363"
+       x="151.54185"
+       y="7.4835434"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <text
+       transform="translate(52.652097,0.53453906)"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2309);fill:#000000;fill-opacity:1;stroke:none;"
+       id="text2307"
+       xml:space="preserve"><tspan
+         sodipodi:role="line"
+         x="-108.03125"
+         y="17.085153"><tspan>a.select&lt;4,2&gt;(0)</tspan></tspan></text>
+  </g>
+</svg>

--- a/sycl/doc/extensions/ExplicitSIMD/images/VectorOdd.svg
+++ b/sycl/doc/extensions/ExplicitSIMD/images/VectorOdd.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="233.62173mm"
+   height="25.498945mm"
+   viewBox="0 0 233.62175 25.498945"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)"
+   sodipodi:docname="CMVectorEven.svg">
+  <defs
+     id="defs2">
+    <rect
+       id="rect1716"
+       height="15.234363"
+       width="140.3165"
+       y="8.7657213"
+       x="-108.56559" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="603.6151"
+     inkscape:cy="573.03849"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     fit-margin-top="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5"
+     lock-margins="true"
+     inkscape:window-width="2482"
+     inkscape:window-height="1411"
+     inkscape:window-x="69"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(61.178684,-2.6185225)">
+    <rect
+       id="rect833"
+       width="15.768902"
+       height="15.234363"
+       x="41.159512"
+       y="7.750814"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="7.750814"
+       x="56.928413"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-4" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="7.750814"
+       x="135.77295"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-6" />
+    <rect
+       id="rect833-4-9"
+       width="15.768902"
+       height="15.234363"
+       x="151.54185"
+       y="7.750814"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="7.750814"
+       x="104.23513"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-3" />
+    <rect
+       id="rect833-4-3"
+       width="15.768902"
+       height="15.234363"
+       x="120.00404"
+       y="7.750814"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       ry="1.1999595"
+       rx="1.6933334"
+       y="7.750814"
+       x="72.697319"
+       height="15.234363"
+       width="15.768902"
+       id="rect833-5" />
+    <rect
+       id="rect833-4-6"
+       width="15.768902"
+       height="15.234363"
+       x="88.466225"
+       y="7.750814"
+       rx="1.6933334"
+       ry="1.1999595"
+       style="fill:#c50000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" />
+    <text
+       transform="translate(51.850289,-0.53453906)"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1716);fill:#000000;fill-opacity:1;stroke:none;"
+       id="text1714"
+       xml:space="preserve"><tspan
+         sodipodi:role="line"
+         x="-108.56641"
+         y="18.42109"><tspan>a.select&lt;4,2&gt;(1)</tspan></tspan></text>
+  </g>
+</svg>

--- a/sycl/doc/extensions/ExplicitSIMD/images/simd_view.svg
+++ b/sycl/doc/extensions/ExplicitSIMD/images/simd_view.svg
@@ -1,0 +1,1856 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="simd_view.svg"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 262.13336 97.751869"
+   height="97.751869mm"
+   width="262.13336mm">
+  <defs
+     id="defs2">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath849">
+      <path
+         d="M 0,1.2207e-4 H 960 V 540.00012 H 0 Z"
+         clip-rule="evenodd"
+         id="path847"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath929">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path927"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath941">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path939"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath953">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path951"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath965">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path963"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath977">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path975"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath989">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path987"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1001">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path999"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1013">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1011"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1025">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1023"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1037">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1035"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1049">
+      <path
+         d="M 261.96,14.76 H 283.8 V 98.88 H 261.96 Z"
+         clip-rule="evenodd"
+         id="path1047"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1061">
+      <path
+         d="m 283.68,14.76 h 21.84 v 84.12 h -21.84 z"
+         clip-rule="evenodd"
+         id="path1059"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1073">
+      <path
+         d="m 305.4,14.76 h 21.96 V 98.88 H 305.4 Z"
+         clip-rule="evenodd"
+         id="path1071"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1085">
+      <path
+         d="m 327.24,14.76 h 21.84 v 84.12 h -21.84 z"
+         clip-rule="evenodd"
+         id="path1083"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1097">
+      <path
+         d="M 348.96,14.76 H 370.8 V 98.88 H 348.96 Z"
+         clip-rule="evenodd"
+         id="path1095"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1109">
+      <path
+         d="m 370.68,14.76 h 21.96 v 84.12 h -21.96 z"
+         clip-rule="evenodd"
+         id="path1107"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1125">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1123"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1141">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1139"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1157">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1155"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1173">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1171"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1189">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1187"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1205">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1203"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1221">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1219"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1237">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1235"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1269">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1267"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1285">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1283"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1301">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1299"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1317">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1315"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1337">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1335"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1349">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1347"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1361">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1359"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1373">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1371"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1385">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1383"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1397">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1395"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1409">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1407"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1421">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1419"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1437">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1435"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1453">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1451"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1469">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1467"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1485">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1483"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1501">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1499"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1517">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1515"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1533">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1531"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1549">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1547"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1561">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1559"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1573">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1571"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1585">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1583"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1603">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1601"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1619">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1617"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1635">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1633"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1651">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1649"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1663">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1661"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1677">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1675"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1689">
+      <path
+         d="M 1.4305e-5,0 H 960.00001 V 540 H 1.4305e-5 Z"
+         clip-rule="evenodd"
+         id="path1687"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="69"
+     inkscape:window-height="1411"
+     inkscape:window-width="2482"
+     fit-margin-bottom="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-top="5"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="84.459695"
+     inkscape:cx="662.07333"
+     inkscape:zoom="0.98994949"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(198.87728,14.097069)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       inkscape:connector-curvature="0"
+       id="path853"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -193.70089,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path855"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -186.02727,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path857"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -178.35365,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path859"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -170.68144,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path861"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -163.005,70.340591 h 7.67363 v -6.739113 h -7.67363 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path863"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -155.33208,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path865"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -147.65916,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path867"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -139.98625,70.340591 h 7.67363 v -6.739113 h -7.67363 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path869"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -132.31333,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path871"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -124.64041,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path873"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -116.96397,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path875"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -109.29105,70.340591 h 7.67362 v -6.739113 h -7.67362 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path877"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -101.61814,70.340591 h 7.673626 v -6.739113 h -7.673626 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path879"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -93.945219,70.340591 h 7.673622 v -6.739113 h -7.673622 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path881"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -86.272303,70.340591 h 7.673622 v -6.739113 h -7.673622 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path883"
+       style="fill:#d9d9d9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.352778"
+       d="m -78.599386,70.340591 h 7.673622 v -6.739113 h -7.673622 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path885"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -186.02727,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path887"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -178.35365,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path889"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -170.68144,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path891"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -163.005,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path893"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -155.33208,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path895"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -147.65916,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path897"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -139.98625,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path899"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -132.31333,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path901"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -124.64041,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path903"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -116.96397,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path905"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -109.29105,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path907"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -101.61814,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path909"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -93.945219,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path911"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -86.272303,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path913"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -78.599386,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path915"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -193.70089,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path917"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70.922942,63.425089 V 70.51698" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path919"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -193.87728,63.601478 H -70.746553" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path921"
+       style="fill:none;stroke:#000000;stroke-width:0.352778;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       d="M -193.87728,70.340591 H -70.746553" />
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g923">
+      <g
+         clip-path="url(#clipPath929)"
+         id="g925">
+        <text
+           id="text933"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,51.696,53.424)"><tspan
+             id="tspan931"
+             y="0"
+             x="0">0</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g935">
+      <g
+         clip-path="url(#clipPath941)"
+         id="g937">
+        <text
+           id="text945"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,73.464,53.424)"><tspan
+             id="tspan943"
+             y="0"
+             x="0">1</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g947">
+      <g
+         clip-path="url(#clipPath953)"
+         id="g949">
+        <text
+           id="text957"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,95.208,53.424)"><tspan
+             id="tspan955"
+             y="0"
+             x="0">2</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g959">
+      <g
+         clip-path="url(#clipPath965)"
+         id="g961">
+        <text
+           id="text969"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,116.98,53.424)"><tspan
+             id="tspan967"
+             y="0"
+             x="0">3</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g971">
+      <g
+         clip-path="url(#clipPath977)"
+         id="g973">
+        <text
+           id="text981"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,138.72,53.424)"><tspan
+             id="tspan979"
+             y="0"
+             x="0">4</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g983">
+      <g
+         clip-path="url(#clipPath989)"
+         id="g985">
+        <text
+           id="text993"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,160.49,53.424)"><tspan
+             id="tspan991"
+             y="0"
+             x="0">5</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g995">
+      <g
+         clip-path="url(#clipPath1001)"
+         id="g997">
+        <text
+           id="text1005"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,182.23,53.424)"><tspan
+             id="tspan1003"
+             y="0"
+             x="0">6</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1007">
+      <g
+         clip-path="url(#clipPath1013)"
+         id="g1009">
+        <text
+           id="text1017"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,204,53.424)"><tspan
+             id="tspan1015"
+             y="0"
+             x="0">7</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1019">
+      <g
+         clip-path="url(#clipPath1025)"
+         id="g1021">
+        <text
+           id="text1029"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,225.74,53.424)"><tspan
+             id="tspan1027"
+             y="0"
+             x="0">8</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1031">
+      <g
+         clip-path="url(#clipPath1037)"
+         id="g1033">
+        <text
+           id="text1041"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,247.49,53.424)"><tspan
+             id="tspan1039"
+             y="0"
+             x="0">9</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1043">
+      <g
+         clip-path="url(#clipPath1049)"
+         id="g1045">
+        <text
+           id="text1053"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,269.26,53.424)"><tspan
+             id="tspan1051"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.039988">10</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1055">
+      <g
+         clip-path="url(#clipPath1061)"
+         id="g1057">
+        <text
+           id="text1065"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,291,53.424)"><tspan
+             id="tspan1063"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.039988">11</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1067">
+      <g
+         clip-path="url(#clipPath1073)"
+         id="g1069">
+        <text
+           id="text1077"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,312.77,53.424)"><tspan
+             id="tspan1075"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.039988">12</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1079">
+      <g
+         clip-path="url(#clipPath1085)"
+         id="g1081">
+        <text
+           id="text1089"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,334.51,53.424)"><tspan
+             id="tspan1087"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.039988">13</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1091">
+      <g
+         clip-path="url(#clipPath1097)"
+         id="g1093">
+        <text
+           id="text1101"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,356.28,53.424)"><tspan
+             id="tspan1099"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.039988">14</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1103">
+      <g
+         clip-path="url(#clipPath1109)"
+         id="g1105">
+        <text
+           id="text1113"
+           style="font-variant:normal;font-weight:bold;font-size:9.984px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,378.02,53.424)"><tspan
+             id="tspan1111"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.039988">15</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1115">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1117"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 141,123.36 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1119">
+      <g
+         clip-path="url(#clipPath1125)"
+         id="g1121">
+        <text
+           id="text1129"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,147.17,128.26)"><tspan
+             id="tspan1127"
+             y="0"
+             x="0">0</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1131">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1133"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 159.96,123.36 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1135">
+      <g
+         clip-path="url(#clipPath1141)"
+         id="g1137">
+        <text
+           id="text1145"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,166.13,128.26)"><tspan
+             id="tspan1143"
+             y="0"
+             x="0">2</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1147">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1149"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 178.92,123.36 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1151">
+      <g
+         clip-path="url(#clipPath1157)"
+         id="g1153">
+        <text
+           id="text1161"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,185.09,128.26)"><tspan
+             id="tspan1159"
+             y="0"
+             x="0">4</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1163">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1165"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 197.88,123.36 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1167">
+      <g
+         clip-path="url(#clipPath1173)"
+         id="g1169">
+        <text
+           id="text1177"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,204.05,128.26)"><tspan
+             id="tspan1175"
+             y="0"
+             x="0">6</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1179">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1181"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 216.84,123.36 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1183">
+      <g
+         clip-path="url(#clipPath1189)"
+         id="g1185">
+        <text
+           id="text1193"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,223.01,128.26)"><tspan
+             id="tspan1191"
+             y="0"
+             x="0">8</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1195">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1197"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 235.8,123.36 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1199">
+      <g
+         clip-path="url(#clipPath1205)"
+         id="g1201">
+        <text
+           id="text1209"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,239.21,128.26)"><tspan
+             id="tspan1207"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.6399798">10</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1211">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1213"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 254.76,123.36 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1215">
+      <g
+         clip-path="url(#clipPath1221)"
+         id="g1217">
+        <text
+           id="text1225"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,258.17,128.26)"><tspan
+             id="tspan1223"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.6399798">12</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1227">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1229"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 273.72,123.36 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1231">
+      <g
+         clip-path="url(#clipPath1237)"
+         id="g1233">
+        <text
+           id="text1241"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,277.13,128.26)"><tspan
+             id="tspan1239"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.6399798">14</tspan></text>
+      </g>
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path1243"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -156.57033,43.264192 -33.98343,19.319169 0.17462,0.306917 33.9852,-19.322697 z m -34.11255,18.378311 -1.31692,1.96603 2.36326,-0.125942 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1245"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -149.91694,43.278303 -24.26406,19.438055 0.21873,0.275167 24.26758,-19.438055 z m -24.54028,18.528947 -0.99025,2.149475 2.31422,-0.497417 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1247"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -143.22827,43.302997 -15.44814,18.829867 0.27516,0.224014 15.44462,-18.828103 z m -15.90323,17.998017 -0.52563,2.307519 2.159,-0.9652 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1249"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -136.57136,43.352386 -7.48594,18.899364 0.32808,0.130175 7.48595,-18.902539 z m -8.17739,18.246725 0.20462,2.357614 1.76388,-1.577975 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1251"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -129.55108,43.401775 1.43228,18.434755 -0.35278,0.02716 -1.43228,-18.433697 z m 2.28247,18.014597 -0.889,2.192161 -1.22061,-2.028119 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1253"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -122.88005,43.334747 9.398,18.619611 -0.3175,0.159103 -9.398,-18.616436 z m 10.02594,17.907353 0.007,2.366433 -1.89795,-1.412522 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1255"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -116.22314,43.292414 18.196282,18.922647 -0.254,0.244475 -18.196282,-18.920177 z m 18.587865,18.05693 0.705556,2.259189 -2.229556,-0.791986 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1257"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -109.55916,43.271247 26.592385,18.842567 -0.204611,0.287866 -26.592384,-18.841155 z m 26.814635,17.918994 1.114778,2.087034 -2.338917,-0.360186 z" />
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1259">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1261"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 182.52,199.2 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1263">
+      <g
+         clip-path="url(#clipPath1269)"
+         id="g1265">
+        <text
+           id="text1273"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,188.66,204.12)"><tspan
+             id="tspan1271"
+             y="0"
+             x="0">0</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1275">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1277"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 201.48,199.2 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1279">
+      <g
+         clip-path="url(#clipPath1285)"
+         id="g1281">
+        <text
+           id="text1289"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,207.62,204.12)"><tspan
+             id="tspan1287"
+             y="0"
+             x="0">2</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1291">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1293"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 220.44,199.2 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1295">
+      <g
+         clip-path="url(#clipPath1301)"
+         id="g1297">
+        <text
+           id="text1305"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,226.58,204.12)"><tspan
+             id="tspan1303"
+             y="0"
+             x="0">4</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1307">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1309"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 239.4,199.2 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1311">
+      <g
+         clip-path="url(#clipPath1317)"
+         id="g1313">
+        <text
+           id="text1321"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,245.57,204.12)"><tspan
+             id="tspan1319"
+             y="0"
+             x="0">6</tspan></text>
+      </g>
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path1323"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -141.9865,16.558915 -13.61722,19.194638 0.28575,0.204611 13.62075,-19.194638 z m -14.13227,18.39736 -0.36336,2.338917 2.08844,-1.114778 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1325"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -135.29783,16.558915 -13.61722,19.194638 0.28575,0.204611 13.62075,-19.194638 z m -14.13228,18.39736 -0.36336,2.338917 2.08845,-1.114778 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1327"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -128.60916,16.558915 -13.61722,19.194638 0.28575,0.204611 13.62074,-19.194638 z m -14.13228,18.39736 -0.36336,2.338917 2.08844,-1.114778 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1329"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -121.9205,16.558915 -13.61722,19.194638 0.28575,0.204611 13.62075,-19.194638 z m -14.13227,18.39736 -0.36336,2.338917 2.08844,-1.114778 z" />
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1331">
+      <g
+         clip-path="url(#clipPath1337)"
+         id="g1333">
+        <text
+           id="text1341"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,94.488,231.07)"><tspan
+             id="tspan1339"
+             sodipodi:role="line"
+             y="0"
+             x="0 8.8920002 18.558001 24.714001 34.397999 38.268002 42.695999 52.380001 65.844002 69.804001 78.767998">auto low =</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1343">
+      <g
+         clip-path="url(#clipPath1349)"
+         id="g1345">
+        <text
+           id="text1353"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,177.41,231.07)"><tspan
+             id="tspan1351"
+             sodipodi:role="line"
+             y="0"
+             x="0 9 17.406 26.514 36.216 40.896 48.077999 57.132 61.416 70.416 77.940002">even.select</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1355">
+      <g
+         clip-path="url(#clipPath1361)"
+         id="g1357">
+        <text
+           id="text1365"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,261.67,231.07)"><tspan
+             id="tspan1363"
+             sodipodi:role="line"
+             y="0"
+             x="0 8.9639997 18.09 22.68 26.747999 35.874001 44.838001 50.507999 59.633999 65.25">&lt;4, 1&gt;(0);</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1367">
+      <g
+         clip-path="url(#clipPath1373)"
+         id="g1369">
+        <text
+           id="text1377"
+           style="font-variant:normal;font-weight:bold;font-size:18.024px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,43.392,26.04)"><tspan
+             id="tspan1375"
+             sodipodi:role="line"
+             y="0"
+             x="0 7.191576 11.62548 26.278992">simd</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1379">
+      <g
+         clip-path="url(#clipPath1385)"
+         id="g1381">
+        <text
+           id="text1389"
+           style="font-variant:normal;font-weight:bold;font-size:18.024px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,79.392,26.04)"><tspan
+             id="tspan1387"
+             sodipodi:role="line"
+             y="0"
+             x="0 8.9759521 13.409856 22.926529 29.180857 33.831047 37.562016 46.700184 55.838352 64.814301 68.977844 77.503197 81.576622 90.552574 94.625999 107.47711">&lt;int, 16&gt; v = …;</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1391">
+      <g
+         clip-path="url(#clipPath1397)"
+         id="g1393">
+        <text
+           id="text1401"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,91.848,158.33)"><tspan
+             id="tspan1399"
+             sodipodi:role="line"
+             y="0"
+             x="0 8.8920002 18.558001 24.714001 34.397999 38.268002 47.268002 55.674 64.781998 74.484001 78.318001 87.281998">auto even =</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1403">
+      <g
+         clip-path="url(#clipPath1409)"
+         id="g1405">
+        <text
+           id="text1413"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,183.29,158.33)"><tspan
+             id="tspan1411"
+             sodipodi:role="line"
+             y="0"
+             x="0 7.1999998 12.006 19.188 28.296 32.723999 41.832001 49.265999">v.select</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1415">
+      <g
+         clip-path="url(#clipPath1421)"
+         id="g1417">
+        <text
+           id="text1425"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,238.85,158.33)"><tspan
+             id="tspan1423"
+             sodipodi:role="line"
+             y="0"
+             x="0 8.9639997 18.09 22.788 26.514 35.639999 44.604 50.220001 59.346001 65.015999">&lt;8, 2&gt;(0);</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1427">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1429"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 382.68,134.28 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1431">
+      <g
+         clip-path="url(#clipPath1437)"
+         id="g1433">
+        <text
+           id="text1441"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,388.87,139.18)"><tspan
+             id="tspan1439"
+             y="0"
+             x="0">0</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1443">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1445"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 401.64,134.28 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1447">
+      <g
+         clip-path="url(#clipPath1453)"
+         id="g1449">
+        <text
+           id="text1457"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,407.86,139.18)"><tspan
+             id="tspan1455"
+             y="0"
+             x="0">2</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1459">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1461"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 420.6,134.28 h 18 v 17.4 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1463">
+      <g
+         clip-path="url(#clipPath1469)"
+         id="g1465">
+        <text
+           id="text1473"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,426.82,139.18)"><tspan
+             id="tspan1471"
+             y="0"
+             x="0">4</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1475">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1477"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 439.56,134.28 h 18.12 v 17.4 h -18.12 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1479">
+      <g
+         clip-path="url(#clipPath1485)"
+         id="g1481">
+        <text
+           id="text1489"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,445.78,139.18)"><tspan
+             id="tspan1487"
+             y="0"
+             x="0">6</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1491">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1493"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 382.68,116.64 h 18 v 17.28 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1495">
+      <g
+         clip-path="url(#clipPath1501)"
+         id="g1497">
+        <text
+           id="text1505"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,388.87,121.49)"><tspan
+             id="tspan1503"
+             y="0"
+             x="0">8</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1507">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1509"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 401.64,116.64 h 18 v 17.28 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1511">
+      <g
+         clip-path="url(#clipPath1517)"
+         id="g1513">
+        <text
+           id="text1521"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,405.07,121.49)"><tspan
+             id="tspan1519"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.6399798">10</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1523">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1525"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 420.6,116.64 h 18 v 17.28 h -18 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1527">
+      <g
+         clip-path="url(#clipPath1533)"
+         id="g1529">
+        <text
+           id="text1537"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,424.06,121.49)"><tspan
+             id="tspan1535"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.6399798">12</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1539">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1541"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 439.56,116.64 h 18.12 v 17.28 h -18.12 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1543">
+      <g
+         clip-path="url(#clipPath1549)"
+         id="g1545">
+        <text
+           id="text1553"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,443.02,121.49)"><tspan
+             id="tspan1551"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.6399798">14</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1555">
+      <g
+         clip-path="url(#clipPath1561)"
+         id="g1557">
+        <text
+           id="text1565"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,355.85,166.68)"><tspan
+             id="tspan1563"
+             sodipodi:role="line"
+             y="0"
+             x="0 8.8920002 18.558001 24.714001 34.397999 38.268002 47.268002 55.674 64.781998 74.484001 83.610001 94.949997 98.730003 107.694">auto even2D =</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1567">
+      <g
+         clip-path="url(#clipPath1573)"
+         id="g1569">
+        <text
+           id="text1577"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,467.81,166.68)"><tspan
+             id="tspan1575"
+             sodipodi:role="line"
+             y="0"
+             x="0 9 17.406 26.514 36.216 40.535999 45.936001 55.619999 62.009998 76.643997 85.410004">even.format</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1579">
+      <g
+         clip-path="url(#clipPath1585)"
+         id="g1581">
+        <text
+           id="text1589"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,559.51,166.68)"><tspan
+             id="tspan1587"
+             sodipodi:role="line"
+             y="0"
+             x="0 8.9639997 13.32 22.806 29.052 33.695999 37.439999 46.566002 51.209999 55.278 64.403999 73.421997 79.038002 84.653999">&lt;int, 2, 4&gt;();</tspan></text>
+      </g>
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path1591"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -76.70497,39.598831 -26.03147,0.529166 0.007,0.352778 26.031476,-0.529166 z m -25.69633,-0.359834 -2.0955,1.100667 2.13783,1.016 z" />
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1593">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1595"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 518.88,201.48 H 537 v 17.4 h -18.12 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1597">
+      <g
+         clip-path="url(#clipPath1603)"
+         id="g1599">
+        <text
+           id="text1607"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,525.12,206.4)"><tspan
+             id="tspan1605"
+             y="0"
+             x="0">8</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1609">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1611"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 537.84,201.48 h 18.12 v 17.4 h -18.12 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1613">
+      <g
+         clip-path="url(#clipPath1619)"
+         id="g1615">
+        <text
+           id="text1623"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,541.32,206.4)"><tspan
+             id="tspan1621"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.6399798">10</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1625">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1627"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 556.8,201.48 h 18.12 v 17.4 H 556.8 Z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1629">
+      <g
+         clip-path="url(#clipPath1635)"
+         id="g1631">
+        <text
+           id="text1639"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,560.28,206.4)"><tspan
+             id="tspan1637"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.6399798">12</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1641">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1643"
+         style="fill:none;stroke:#2f528f;stroke-width:0.96;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8;stroke-dasharray:3.84, 2.88;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 575.76,201.48 h 18.12 v 17.4 h -18.12 z" />
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1645">
+      <g
+         clip-path="url(#clipPath1651)"
+         id="g1647">
+        <text
+           id="text1655"
+           style="font-variant:normal;font-weight:normal;font-size:11.04px;font-family:Calibri;-inkscape-font-specification:Calibri;writing-mode:lr-tb;fill:#afabab;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,579.24,206.4)"><tspan
+             id="tspan1653"
+             sodipodi:role="line"
+             y="0"
+             x="0 5.6399798">14</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1657">
+      <g
+         clip-path="url(#clipPath1663)"
+         id="g1659">
+        <text
+           id="text1667"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,455.86,233.69)"><tspan
+             id="tspan1665"
+             sodipodi:role="line"
+             y="0"
+             x="0 8.8920002 18.558001 24.714001 34.397999 38.268002 47.970001 52.397999 60.93 70.632004 74.466003 83.43 87.641998 96.641998 105.048 114.156 123.858 132.98399 143.892 148.698 155.772 164.772 169.2 178.254 185.65199 191.89799 200.862 209.98801 214.668 223.79401 228.34801 237.474 242.118 251.244 255.924 264.888 270.54001 279.66599 284.22 293.34601 298.96201">auto high = even2D.select&lt;1,1,4,1,&gt;(1,0);</tspan></text>
+      </g>
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path1669"
+       style="fill:#4472c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.352778"
+       d="m -26.46236,15.747526 -20.510499,25.512888 0.275167,0.22225 20.510499,-25.516416 z m -20.976166,24.68386 -0.500944,2.314223 2.151944,-0.987778 z" />
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1671">
+      <g
+         clip-path="url(#clipPath1677)"
+         id="g1673">
+        <text
+           id="text1681"
+           style="font-variant:normal;font-weight:bold;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Bold;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,455.86,259.7)"><tspan
+             id="tspan1679"
+             sodipodi:role="line"
+             y="0"
+             x="0 8.8920002 18.558001 24.714001 34.397999 38.268002 47.970001 52.397999 60.93 70.632004 74.466003 83.43 87.641998 96.641998 105.048 114.156 123.858 132.98399 143.892 148.698 154.81799 164.412 177.82201 183.366 192.492 198.108 203.076">auto high = even2D.row(1);</tspan></text>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,-209.3988,86.934552)"
+       id="g1683">
+      <g
+         clip-path="url(#clipPath1689)"
+         id="g1685">
+        <text
+           id="text1693"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-size:18px;font-family:Calibri;-inkscape-font-specification:Calibri-Italic;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="matrix(1,0,0,-1,667.08,259.7)"><tspan
+             id="tspan1691"
+             sodipodi:role="line"
+             y="0"
+             x="0 9.2399998">or</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This PR starts a series of PRs to integrate DPC++ "Explicit SIMD" extension for efficient Intel GPU programming. This PR provides overall description of the extenstion.
   Contributors (alphabetic order):
    Konst Bobrovsky
    Peter Caday
    Gang Chen
    Kai Yu Chen
    Ken Lueh
    Wei Pan
    Xinmin Tian

The upcoming changes will be spread across a number of components:
- Driver
`-fsycl-explicit-simd` option option added to tweak FE behavior slightly compared to normal SYCL. In the future it is expected that no such distinction will be necessary, and the need in extra -fsycl-explicit-simd option will go away.
- Front-End
    - recognize and mark explicit SIMD kernels and functions
    - allow non-constant globals used in device code
    - `__SYCL_EXPLICIT_SIMD__` macro is set by (device FE only)
    - LLVM passes are run (-disable-llvm-passes is not added) (device FE only)
- LLVM
    - A number of ESIMD-specific LLVM-IR passes are added
- SYCL RT - ESIMD-specific tweaks in accessors (using image buffers), 2D images,...
- New SIMD API (~9000 lines)
This is the largest piece implementing the essence of the ESIMD extension. It provides APIs to write device code in close to metal manner.
- llvm-spirv translator
- (will be external github project) GenXIntrinsics llvm project. Provides APIs for low-level intrinsic generation.

More description of changes in each component will come with respective PR.