### PR TITLE
[SYCL] Enforce "construct from platform" mock test execution

### DIFF
--- a/sycl/unittests/pi/PiMock.cpp
+++ b/sycl/unittests/pi/PiMock.cpp
@@ -48,12 +48,12 @@ TEST(PiMockTest, ConstructFromQueue) {
 }
 
 TEST(PiMockTest, ConstructFromPlatform) {
-  platform NormalPlatform;
+  platform NormalPlatform(default_selector{});
   if (NormalPlatform.is_host()) {
     std::cerr << "Not run due to host-only environment\n";
     return;
   }
-  platform MockPlatform;
+  platform MockPlatform(default_selector{});
   unittest::PiMock Mock(MockPlatform);
 
   const auto &NormalPiPlugin =


### PR DESCRIPTION
The case was not being run due to platforms' default
construction as host platforms.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>