### PR TITLE
[SYCL][Test] Unify the code in AOT tests

### DIFF
--- a/sycl/test/aot/Inputs/aot.cpp
+++ b/sycl/test/aot/Inputs/aot.cpp
@@ -1,3 +1,11 @@
+//==----- aot.cpp - Simple vector addition (AOT compilation example)  --------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------------===//
+
 #include <CL/sycl.hpp>
 
 #include <array>

--- a/sycl/test/aot/accelerator.cpp
+++ b/sycl/test/aot/accelerator.cpp
@@ -9,5 +9,4 @@
 // REQUIRES: aoc, accelerator
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %S/Inputs/aot.cpp -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/aot/accelerator.cpp
+++ b/sycl/test/aot/accelerator.cpp
@@ -1,9 +1,3 @@
-// REQUIRES: aoc, accelerator
-
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %S/Inputs/aot.cpp -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
-
 //==----- accelerator.cpp - AOT compilation for fpga devices using aoc  ------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -12,71 +6,8 @@
 //
 //===------------------------------------------------------------------------===//
 
-#include <CL/sycl.hpp>
+// REQUIRES: aoc, accelerator
 
-#include <array>
-#include <iostream>
-
-constexpr cl::sycl::access::mode sycl_read = cl::sycl::access::mode::read;
-constexpr cl::sycl::access::mode sycl_write = cl::sycl::access::mode::write;
-
-template <typename T>
-class SimpleVadd;
-
-template <typename T, size_t N>
-void simple_vadd(const std::array<T, N>& VA, const std::array<T, N>& VB,
-                 std::array<T, N>& VC) {
-  cl::sycl::queue deviceQueue([](cl::sycl::exception_list ExceptionList) {
-      for (cl::sycl::exception_ptr_class ExceptionPtr : ExceptionList) {
-        try {
-          std::rethrow_exception(ExceptionPtr);
-        } catch (cl::sycl::exception &E) {
-          std::cerr << E.what();
-        } catch (...) {
-          std::cerr << "Unknown async exception was caught." << std::endl;
-        }
-      }
-    });
-
-  cl::sycl::range<1> numOfItems{N};
-  cl::sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferC(VC.data(), numOfItems);
-
-  deviceQueue.submit([&](cl::sycl::handler& cgh) {
-    auto accessorA = bufferA.template get_access<sycl_read>(cgh);
-    auto accessorB = bufferB.template get_access<sycl_read>(cgh);
-    auto accessorC = bufferC.template get_access<sycl_write>(cgh);
-
-    cgh.parallel_for<class SimpleVadd<T>>(numOfItems,
-    [=](cl::sycl::id<1> wiID) {
-        accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
-    });
-  });
-
-  deviceQueue.wait_and_throw();
-}
-
-int main() {
-  const size_t array_size = 4;
-  std::array<cl::sycl::cl_int, array_size> A = {{1, 2, 3, 4}},
-                                           B = {{1, 2, 3, 4}}, C;
-  std::array<cl::sycl::cl_float, array_size> D = {{1.f, 2.f, 3.f, 4.f}},
-                                             E = {{1.f, 2.f, 3.f, 4.f}}, F;
-  simple_vadd(A, B, C);
-  simple_vadd(D, E, F);
-  for (unsigned int i = 0; i < array_size; i++) {
-    if (C[i] != A[i] + B[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << C[i]
-                << "!\n";
-      return 1;
-    }
-    if (F[i] != D[i] + E[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << F[i]
-                << "!\n";
-      return 1;
-    }
-  }
-  std::cout << "The results are correct!\n";
-  return 0;
-}
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %S/Inputs/aot.cpp -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/aot/cpu.cpp
+++ b/sycl/test/aot/cpu.cpp
@@ -1,9 +1,3 @@
-// REQUIRES: opencl-aot, cpu
-
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/Inputs/aot.cpp -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-
 //==----- cpu.cpp - AOT compilation for cpu devices using opencl-aot  --------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -11,3 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===------------------------------------------------------------------------===//
+
+// REQUIRES: opencl-aot, cpu
+
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/Inputs/aot.cpp -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/aot/cpu.cpp
+++ b/sycl/test/aot/cpu.cpp
@@ -9,5 +9,4 @@
 // REQUIRES: opencl-aot, cpu
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/Inputs/aot.cpp -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/aot/cpu.cpp
+++ b/sycl/test/aot/cpu.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl-aot, cpu
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/Inputs/aot.cpp -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 
@@ -11,72 +11,3 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===------------------------------------------------------------------------===//
-
-#include <CL/sycl.hpp>
-
-#include <array>
-#include <iostream>
-
-constexpr cl::sycl::access::mode sycl_read = cl::sycl::access::mode::read;
-constexpr cl::sycl::access::mode sycl_write = cl::sycl::access::mode::write;
-
-template <typename T>
-class SimpleVadd;
-
-template <typename T, size_t N>
-void simple_vadd(const std::array<T, N>& VA, const std::array<T, N>& VB,
-                 std::array<T, N>& VC) {
-  cl::sycl::queue deviceQueue([](cl::sycl::exception_list ExceptionList) {
-      for (cl::sycl::exception_ptr_class ExceptionPtr : ExceptionList) {
-        try {
-          std::rethrow_exception(ExceptionPtr);
-        } catch (cl::sycl::exception &E) {
-          std::cerr << E.what();
-        } catch (...) {
-          std::cerr << "Unknown async exception was caught." << std::endl;
-        }
-      }
-    });
-
-  cl::sycl::range<1> numOfItems{N};
-  cl::sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferC(VC.data(), numOfItems);
-
-  deviceQueue.submit([&](cl::sycl::handler& cgh) {
-    auto accessorA = bufferA.template get_access<sycl_read>(cgh);
-    auto accessorB = bufferB.template get_access<sycl_read>(cgh);
-    auto accessorC = bufferC.template get_access<sycl_write>(cgh);
-
-    cgh.parallel_for<class SimpleVadd<T>>(numOfItems,
-    [=](cl::sycl::id<1> wiID) {
-        accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
-    });
-  });
-
-  deviceQueue.wait_and_throw();
-}
-
-int main() {
-  const size_t array_size = 4;
-  std::array<cl::sycl::cl_int, array_size> A = {{1, 2, 3, 4}},
-                                           B = {{1, 2, 3, 4}}, C;
-  std::array<cl::sycl::cl_float, array_size> D = {{1.f, 2.f, 3.f, 4.f}},
-                                             E = {{1.f, 2.f, 3.f, 4.f}}, F;
-  simple_vadd(A, B, C);
-  simple_vadd(D, E, F);
-  for (unsigned int i = 0; i < array_size; i++) {
-    if (C[i] != A[i] + B[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << C[i]
-                << "!\n";
-      return 1;
-    }
-    if (F[i] != D[i] + E[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << F[i]
-                << "!\n";
-      return 1;
-    }
-  }
-  std::cout << "The results are correct!\n";
-  return 0;
-}

--- a/sycl/test/aot/gpu.cpp
+++ b/sycl/test/aot/gpu.cpp
@@ -2,7 +2,7 @@
 // UNSUPPORTED: cuda
 // CUDA is not compatible with SPIR.
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" %S/Inputs/aot.cpp -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
@@ -13,72 +13,3 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===------------------------------------------------------------------------===//
-
-#include <CL/sycl.hpp>
-
-#include <array>
-#include <iostream>
-
-constexpr cl::sycl::access::mode sycl_read = cl::sycl::access::mode::read;
-constexpr cl::sycl::access::mode sycl_write = cl::sycl::access::mode::write;
-
-template <typename T>
-class SimpleVadd;
-
-template <typename T, size_t N>
-void simple_vadd(const std::array<T, N>& VA, const std::array<T, N>& VB,
-                 std::array<T, N>& VC) {
-  cl::sycl::queue deviceQueue([](cl::sycl::exception_list ExceptionList) {
-      for (cl::sycl::exception_ptr_class ExceptionPtr : ExceptionList) {
-        try {
-          std::rethrow_exception(ExceptionPtr);
-        } catch (cl::sycl::exception &E) {
-          std::cerr << E.what();
-        } catch (...) {
-          std::cerr << "Unknown async exception was caught." << std::endl;
-        }
-      }
-    });
-
-  cl::sycl::range<1> numOfItems{N};
-  cl::sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferC(VC.data(), numOfItems);
-
-  deviceQueue.submit([&](cl::sycl::handler& cgh) {
-    auto accessorA = bufferA.template get_access<sycl_read>(cgh);
-    auto accessorB = bufferB.template get_access<sycl_read>(cgh);
-    auto accessorC = bufferC.template get_access<sycl_write>(cgh);
-
-    cgh.parallel_for<class SimpleVadd<T>>(numOfItems,
-    [=](cl::sycl::id<1> wiID) {
-        accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
-    });
-  });
-
-  deviceQueue.wait_and_throw();
-}
-
-int main() {
-  const size_t array_size = 4;
-  std::array<cl::sycl::cl_int, array_size> A = {{1, 2, 3, 4}},
-                                           B = {{1, 2, 3, 4}}, C;
-  std::array<cl::sycl::cl_float, array_size> D = {{1.f, 2.f, 3.f, 4.f}},
-                                             E = {{1.f, 2.f, 3.f, 4.f}}, F;
-  simple_vadd(A, B, C);
-  simple_vadd(D, E, F);
-  for (unsigned int i = 0; i < array_size; i++) {
-    if (C[i] != A[i] + B[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << C[i]
-                << "!\n";
-      return 1;
-    }
-    if (F[i] != D[i] + E[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << F[i]
-                << "!\n";
-      return 1;
-    }
-  }
-  std::cout << "The results are correct!\n";
-  return 0;
-}

--- a/sycl/test/aot/gpu.cpp
+++ b/sycl/test/aot/gpu.cpp
@@ -11,5 +11,4 @@
 // CUDA is not compatible with SPIR.
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" %S/Inputs/aot.cpp -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/aot/gpu.cpp
+++ b/sycl/test/aot/gpu.cpp
@@ -1,11 +1,3 @@
-// REQUIRES: ocloc, gpu
-// UNSUPPORTED: cuda
-// CUDA is not compatible with SPIR.
-
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" %S/Inputs/aot.cpp -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
-
 //==----- gpu.cpp - AOT compilation for gen devices using GEN compiler  ------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -13,3 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===------------------------------------------------------------------------===//
+
+// REQUIRES: ocloc, gpu
+// UNSUPPORTED: cuda
+// CUDA is not compatible with SPIR.
+
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" %S/Inputs/aot.cpp -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/aot/multiple-devices.cpp
+++ b/sycl/test/aot/multiple-devices.cpp
@@ -12,7 +12,7 @@
 
 // 1-command compilation case
 // Targeting CPU, GPU, FPGA
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice,spir64_gen-unknown-unknown-sycldevice,spir64_fpga-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" %s -o %t_all.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice,spir64_gen-unknown-unknown-sycldevice,spir64_fpga-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl" %S/Inputs/aot.cpp -o %t_all.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t_all.out
 // RUN: %CPU_RUN_PLACEHOLDER %t_all.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_all.out
@@ -20,7 +20,7 @@
 
 // Produce object file, spirv, device images to combine these differently
 // at link-time, thus testing various AOT-compiled images configurations
-// RUN: %clangxx -fsycl %s -c -o %t.o
+// RUN: %clangxx -fsycl %S/Inputs/aot.cpp -c -o %t.o
 // RUN: %clangxx -fsycl -fsycl-link-targets=spir64-unknown-unknown-sycldevice %t.o -o %t.spv
 // AOT-compile device binary images
 // RUN: opencl-aot %t.spv -o=%t_cpu.ir --device=cpu
@@ -65,72 +65,3 @@
 // Check that execution on AOT-compatible devices is unaffected
 // RUN: %CPU_RUN_PLACEHOLDER %t_spv_cpu_gpu.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_spv_cpu_gpu.out
-
-#include <CL/sycl.hpp>
-
-#include <array>
-#include <iostream>
-
-constexpr cl::sycl::access::mode sycl_read = cl::sycl::access::mode::read;
-constexpr cl::sycl::access::mode sycl_write = cl::sycl::access::mode::write;
-
-template <typename T>
-class SimpleVadd;
-
-template <typename T, size_t N>
-void simple_vadd(const std::array<T, N>& VA, const std::array<T, N>& VB,
-                 std::array<T, N>& VC) {
-  cl::sycl::queue deviceQueue([](cl::sycl::exception_list ExceptionList) {
-      for (cl::sycl::exception_ptr_class ExceptionPtr : ExceptionList) {
-        try {
-          std::rethrow_exception(ExceptionPtr);
-        } catch (cl::sycl::exception &E) {
-          std::cerr << E.what();
-        } catch (...) {
-          std::cerr << "Unknown async exception was caught." << std::endl;
-        }
-      }
-    });
-
-  cl::sycl::range<1> numOfItems{N};
-  cl::sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferC(VC.data(), numOfItems);
-
-  deviceQueue.submit([&](cl::sycl::handler& cgh) {
-    auto accessorA = bufferA.template get_access<sycl_read>(cgh);
-    auto accessorB = bufferB.template get_access<sycl_read>(cgh);
-    auto accessorC = bufferC.template get_access<sycl_write>(cgh);
-
-    cgh.parallel_for<class SimpleVadd<T>>(numOfItems,
-    [=](cl::sycl::id<1> wiID) {
-        accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
-    });
-  });
-
-  deviceQueue.wait_and_throw();
-}
-
-int main() {
-  const size_t array_size = 4;
-  std::array<cl::sycl::cl_int, array_size> A = {{1, 2, 3, 4}},
-                                           B = {{1, 2, 3, 4}}, C;
-  std::array<cl::sycl::cl_float, array_size> D = {{1.f, 2.f, 3.f, 4.f}},
-                                             E = {{1.f, 2.f, 3.f, 4.f}}, F;
-  simple_vadd(A, B, C);
-  simple_vadd(D, E, F);
-  for (unsigned int i = 0; i < array_size; i++) {
-    if (C[i] != A[i] + B[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << C[i]
-                << "!\n";
-      return 1;
-    }
-    if (F[i] != D[i] + E[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << F[i]
-                << "!\n";
-      return 1;
-    }
-  }
-  std::cout << "The results are correct!\n";
-  return 0;
-}

--- a/sycl/test/aot/with-llvm-bc.cpp
+++ b/sycl/test/aot/with-llvm-bc.cpp
@@ -1,13 +1,3 @@
-// RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -c %S/Inputs/aot.cpp -o %t.o
-// RUN: %clangxx -fsycl -fsycl-link-targets=spir64-unknown-unknown-sycldevice %t.o -o %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.bc
-// RUN: %clangxx -fsycl -fsycl-add-targets=spir64:%t.bc %t.o -o %t.out
-//
-// Only CPU supports LLVM IR bitcode as a binary
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-
-// REQUIRES: cpu
-
 //==----- with-llvm-bc.cpp - SYCL kernel with LLVM IR bitcode as binary ----==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -15,3 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+// REQUIRES: cpu
+
+// RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -c %S/Inputs/aot.cpp -o %t.o
+// RUN: %clangxx -fsycl -fsycl-link-targets=spir64-unknown-unknown-sycldevice %t.o -o %t.spv
+// RUN: llvm-spirv -r %t.spv -o %t.bc
+// RUN: %clangxx -fsycl -fsycl-add-targets=spir64:%t.bc %t.o -o %t.out
+//
+// Only CPU supports LLVM IR bitcode as a binary
+// RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/aot/with-llvm-bc.cpp
+++ b/sycl/test/aot/with-llvm-bc.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -c %s -o %t.o
+// RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -c %S/Inputs/aot.cpp -o %t.o
 // RUN: %clangxx -fsycl -fsycl-link-targets=spir64-unknown-unknown-sycldevice %t.o -o %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.bc
 // RUN: %clangxx -fsycl -fsycl-add-targets=spir64:%t.bc %t.o -o %t.out
@@ -15,72 +15,3 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
-#include <CL/sycl.hpp>
-
-#include <array>
-#include <iostream>
-
-constexpr cl::sycl::access::mode sycl_read = cl::sycl::access::mode::read;
-constexpr cl::sycl::access::mode sycl_write = cl::sycl::access::mode::write;
-
-template <typename T>
-class SimpleVadd;
-
-template <typename T, size_t N>
-void simple_vadd(const std::array<T, N>& VA, const std::array<T, N>& VB,
-                 std::array<T, N>& VC) {
-  cl::sycl::queue deviceQueue([](cl::sycl::exception_list ExceptionList) {
-      for (cl::sycl::exception_ptr_class ExceptionPtr : ExceptionList) {
-        try {
-          std::rethrow_exception(ExceptionPtr);
-        } catch (cl::sycl::exception &E) {
-          std::cerr << E.what();
-        } catch (...) {
-          std::cerr << "Unknown async exception was caught." << std::endl;
-        }
-      }
-    });
-  
-  cl::sycl::range<1> numOfItems{N};
-  cl::sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferB(VB.data(), numOfItems);
-  cl::sycl::buffer<T, 1> bufferC(VC.data(), numOfItems);
-
-  deviceQueue.submit([&](cl::sycl::handler& cgh) {
-    auto accessorA = bufferA.template get_access<sycl_read>(cgh);
-    auto accessorB = bufferB.template get_access<sycl_read>(cgh);
-    auto accessorC = bufferC.template get_access<sycl_write>(cgh);
-
-    cgh.parallel_for<class SimpleVadd<T>>(numOfItems,
-    [=](cl::sycl::id<1> wiID) {
-        accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
-    });
-  });
-
-  deviceQueue.wait_and_throw();
-}
-
-int main() {
-  const size_t array_size = 4;
-  std::array<cl::sycl::cl_int, array_size> A = {{1, 2, 3, 4}},
-                                           B = {{1, 2, 3, 4}}, C;
-  std::array<cl::sycl::cl_float, array_size> D = {{1.f, 2.f, 3.f, 4.f}},
-                                             E = {{1.f, 2.f, 3.f, 4.f}}, F;
-  simple_vadd(A, B, C);
-  simple_vadd(D, E, F);
-  for (unsigned int i = 0; i < array_size; i++) {
-    if (C[i] != A[i] + B[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << C[i]
-                << "!\n";
-      return 1;
-    }
-    if (F[i] != D[i] + E[i]) {
-      std::cout << "The results are incorrect (element " << i << " is " << F[i]
-                << "!\n";
-      return 1;
-    }
-  }
-  std::cout << "The results are correct!\n";
-  return 0;
-}


### PR DESCRIPTION
All SYCL code is thus moved into a separate file,
which is shared by config-specific RUN lines of
the original LIT files.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>