### PR TITLE
[SYCL] Adding type checking to SYCL accessors.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10809,7 +10809,6 @@ def err_sycl_restrict : Error<
   "}0">;
 def err_sycl_virtual_types : Error<
   "No class with a vtable can be used in a SYCL kernel or any code included in the kernel">;
-def note_sycl_used_here : Note<"used here">;
 def note_sycl_recursive_function_declared_here: Note<"function implemented using recursion declared here">;
 def err_sycl_non_trivially_copy_ctor_dtor_type
     : Error<"kernel parameter has non-trivially %select{copy "

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -45,7 +45,7 @@ template <int dim>
 struct id {
 };
 
-template <typename dataT, int dim>
+template <int dim>
 struct _ImplT {
   range<dim> AccessRange;
   range<dim> MemRange;
@@ -78,13 +78,10 @@ class accessor {
 public:
   void use(void) const {}
   void use(void *) const {}
+  _ImplT<dimensions> impl;
 
 private:
   using PtrType = typename DeviceValueType<dataT, accessTarget>::type *;
-
-  _ImplT<dataT, dimensions> impl;
-  PtrType MData;
-
   void __init(PtrType Ptr, range<dimensions> AccessRange,
               range<dimensions> MemRange, id<dimensions> Offset) {}
 };

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -45,7 +45,7 @@ template <int dim>
 struct id {
 };
 
-template <int dim>
+template <typename dataT, int dim>
 struct _ImplT {
   range<dim> AccessRange;
   range<dim> MemRange;
@@ -78,10 +78,13 @@ class accessor {
 public:
   void use(void) const {}
   void use(void *) const {}
-  _ImplT<dimensions> impl;
 
 private:
   using PtrType = typename DeviceValueType<dataT, accessTarget>::type *;
+
+  _ImplT<dataT, dimensions> impl;
+  PtrType MData;
+
   void __init(PtrType Ptr, range<dimensions> AccessRange,
               range<dimensions> MemRange, id<dimensions> Offset) {}
 };

--- a/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
+++ b/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
@@ -22,33 +22,51 @@ T bar() { return T(); };
 //typedef
 typedef __float128 trickyFloatType;
 
+//struct
+struct Mesh {
+  __int128 prohib; //#struct_member
+};
+
 int main() {
-
   accessor<int, 1, access::mode::read_write> ok_acc;
-
+  // -- accessors using prohibited types
   accessor<__float128, 1, access::mode::read_write> f128_acc;
   accessor<__int128, 1, access::mode::read_write> i128_acc;
   accessor<long double, 1, access::mode::read_write> ld_acc;
+  // -- pointers, aliases, auto, typedef, decltype of prohibited type
+  accessor<__int128 *, 1, access::mode::read_write> i128Ptr_acc;
   accessor<int128alias_t<int>, 1, access::mode::read_write> aliased_acc;
   accessor<trickyFloatType, 1, access::mode::read_write> typedef_acc;
   auto V = bar<__int128>();
   accessor<decltype(V), 1, access::mode::read_write> declty_acc;
+  // -- Accessor of struct that contains a prohibited type.
+  accessor<Mesh, 1, access::mode::read_write> struct_acc;
 
   kernel<class use_local>(
       [=]() {
         ok_acc.use();
 
+        // -- accessors using prohibited types
         // expected-error@+1 {{'__float128' is not supported on this target}}
         f128_acc.use();
         // expected-error@+1 {{'__int128' is not supported on this target}}
         i128_acc.use();
         // expected-error@+1 {{'long double' is not supported on this target}}
         ld_acc.use();
+
+        // -- pointers, aliases, auto, typedef, decltype of prohibited type
+        // expected-error@+1 {{'__int128' is not supported on this target}}
+        i128Ptr_acc.use();
         // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
         aliased_acc.use();
         // expected-error@+1 {{'__float128' is not supported on this target}}
         typedef_acc.use();
         // expected-error@+1 {{'__int128' is not supported on this target}}
         declty_acc.use();
+
+        // -- Accessor of struct that contains a prohibited type.
+        // expected-error@#struct_member {{'__int128' is not supported on this target}}
+        // expected-note@+1 {{used here}}
+        struct_acc.use();
       });
 }

--- a/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
+++ b/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
@@ -1,0 +1,54 @@
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -triple spir64 -fsycl-is-device -verify -fsyntax-only  %s
+//
+// Ensure SYCL type restrictions are applied to accessors as well.
+
+#include <sycl.hpp>
+
+using namespace cl::sycl;
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+//alias template
+template <typename...>
+using int128alias_t = __uint128_t;
+
+//templated return type
+template <typename T>
+T bar() { return T(); };
+
+//typedef
+typedef __float128 trickyFloatType;
+
+int main() {
+
+  accessor<int, 1, access::mode::read_write> ok_acc;
+
+  accessor<__float128, 1, access::mode::read_write> f128_acc;
+  accessor<__int128, 1, access::mode::read_write> i128_acc;
+  accessor<long double, 1, access::mode::read_write> ld_acc;
+  accessor<int128alias_t<int>, 1, access::mode::read_write> aliased_acc;
+  accessor<trickyFloatType, 1, access::mode::read_write> typedef_acc;
+  auto V = bar<__int128>();
+  accessor<decltype(V), 1, access::mode::read_write> declty_acc;
+
+  kernel<class use_local>(
+      [=]() {
+        ok_acc.use();
+
+        // expected-error@+1 {{'__float128' is not supported on this target}}
+        f128_acc.use();
+        // expected-error@+1 {{'__int128' is not supported on this target}}
+        i128_acc.use();
+        // expected-error@+1 {{'long double' is not supported on this target}}
+        ld_acc.use();
+        // expected-error@+1 {{'unsigned __int128' is not supported on this target}}
+        aliased_acc.use();
+        // expected-error@+1 {{'__float128' is not supported on this target}}
+        typedef_acc.use();
+        // expected-error@+1 {{'__int128' is not supported on this target}}
+        declty_acc.use();
+      });
+}


### PR DESCRIPTION
Signed-off-by: Chris Perkins <chris.perkins@intel.com>

Some types (__float128, __int128, etc) are illegal in SYCL kernels and will cause the SPIR-V writer to fail.  Now we ensure that the type checking we use for device vars is also applied to the data type of any accessor used in the kernel. 