### PR TITLE
[SYCL][CUDA] Using Custom context by default

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -3340,6 +3340,7 @@ pi_result cuda_piEnqueueMemBufferMap(pi_queue command_queue, pi_mem buffer,
                                      pi_event *retEvent, void **ret_map) {
 
   assert(ret_map != nullptr);
+  assert(command_queue != nullptr);
 
   pi_result ret_err = PI_INVALID_OPERATION;
 
@@ -3361,9 +3362,15 @@ pi_result cuda_piEnqueueMemBufferMap(pi_queue command_queue, pi_mem buffer,
         num_events_in_wait_list, event_wait_list, retEvent);
   } else {
     if (retEvent) {
-      *retEvent =
-          _pi_event::make_native(PI_COMMAND_TYPE_MEM_BUFFER_MAP, command_queue);
-      (*retEvent)->record();
+      try {
+        ScopedContext active(command_queue->get_context());
+
+        *retEvent = _pi_event::make_native(PI_COMMAND_TYPE_MEM_BUFFER_MAP,
+                                           command_queue);
+        (*retEvent)->record();
+      } catch (pi_result error) {
+        ret_err = error;
+      }
     }
   }
 
@@ -3380,6 +3387,7 @@ pi_result cuda_piEnqueueMemUnmap(pi_queue command_queue, pi_mem memobj,
                                  pi_event *retEvent) {
   pi_result ret_err = PI_SUCCESS;
 
+  assert(command_queue != nullptr);
   assert(mapped_ptr != nullptr);
   assert(memobj != nullptr);
   assert(memobj->get_map_ptr() != nullptr);
@@ -3393,9 +3401,15 @@ pi_result cuda_piEnqueueMemUnmap(pi_queue command_queue, pi_mem memobj,
       retEvent);
   } else {
     if (retEvent) {
-      *retEvent = _pi_event::make_native(PI_COMMAND_TYPE_MEM_BUFFER_UNMAP,
-                                         command_queue);
-      (*retEvent)->record();
+      try {
+        ScopedContext active(command_queue->get_context());
+
+        *retEvent = _pi_event::make_native(PI_COMMAND_TYPE_MEM_BUFFER_UNMAP,
+                                           command_queue);
+        (*retEvent)->record();
+      } catch (pi_result error) {
+        ret_err = error;
+      }
     }
   }
 

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -43,8 +43,9 @@ context_impl::context_impl(const vector_class<cl::sycl::device> Devices,
 
   if (MPlatform->is_cuda()) {
 #if USE_PI_CUDA
-    const pi_context_properties props[] = {PI_CONTEXT_PROPERTIES_CUDA_PRIMARY,
-                                           UseCUDAPrimaryContext, 0};
+    const pi_context_properties props[] = {
+        static_cast<pi_context_properties>(PI_CONTEXT_PROPERTIES_CUDA_PRIMARY),
+        static_cast<pi_context_properties>(UseCUDAPrimaryContext), 0};
 
     getPlugin().call<PiApiKind::piContextCreate>(props, DeviceIds.size(), 
 	  	  DeviceIds.data(), nullptr, nullptr, &MContext);

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -33,6 +33,13 @@ using DeviceImplPtr = shared_ptr_class<detail::device_impl>;
 /// Sets max number of queues supported by FPGA RT.
 const size_t MaxNumQueues = 256;
 
+//// Possible CUDA context types supported by PI CUDA backend
+/// TODO: Implement this as a property once there is an extension document
+enum class cuda_context_type : char { primary, custom };
+
+/// Default context type created for CUDA backend
+constexpr cuda_context_type DefaultContextType = cuda_context_type::custom;
+
 enum QueueOrder { Ordered, OOO };
 
 class queue_impl {
@@ -50,7 +57,8 @@ public:
              const property_list &PropList)
       : queue_impl(Device,
                    detail::getSyclObjImpl(context(
-                       createSyclObjFromImpl<device>(Device), {}, true)),
+                       createSyclObjFromImpl<device>(Device), {},
+                       (DefaultContextType == cuda_context_type::primary))),
                    AsyncHandler, Order, PropList){};
 
   /// Constructs a SYCL queue with an async_handler and property_list provided


### PR DESCRIPTION
Performance analysis shows is better that the default behavior of
SYCL Queues on CUDA backend is to use the non-primary context.
Primary context will be exposed for interop with CUDA Runtime API
on a separate extension as a property.

Signed-off-by: Ruyman Reyes <ruyman@codeplay.com>