### PR TITLE
[SYCL][ESIMD] Add driver option to enable SYCL Explicit SIMD extension.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -327,6 +327,7 @@ def CUDA : LangOpt<"CUDA">;
 def SYCLIsDevice : LangOpt<"SYCLIsDevice">;
 def SYCL : LangOpt<"SYCLIsDevice">;
 def SYCLIsHost : LangOpt<"SYCLIsHost">;
+def SYCLExplicitSIMD : LangOpt<"SYCLExplicitSIMD">;
 def HIP : LangOpt<"HIP">;
 def COnly : LangOpt<"", "!LangOpts.CPlusPlus">;
 def CPlusPlus : LangOpt<"CPlusPlus">;

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -248,6 +248,7 @@ LANGOPT(SYCLStdLayoutKernelParams, 1, 0, "Enable standard layout requirement for
 LANGOPT(SYCLUnnamedLambda , 1, 0, "Allow unnamed lambda SYCL kernels")
 LANGOPT(SYCLVersion       , 32, 0, "Version of the SYCL standard used")
 LANGOPT(DeclareSPIRVBuiltins, 1, 0, "Declare SPIR-V builtin functions")
+LANGOPT(SYCLExplicitSIMD  , 1, 0, "SYCL compilation with explicit SIMD extension")
 
 LANGOPT(HIPUseNewLaunchAPI, 1, 0, "Use new kernel launching API for HIP")
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3550,6 +3550,10 @@ def fno_sycl : Flag<["-"], "fno-sycl">, Group<sycl_Group>, Flags<[CoreOption]>,
   HelpText<"Disable SYCL kernels compilation for device">;
 def sycl_std_EQ : Joined<["-"], "sycl-std=">, Group<sycl_Group>, Flags<[CC1Option, NoArgumentUnused, CoreOption]>,
   HelpText<"SYCL language standard to compile for.">, Values<"2017, 121, 1.2.1, sycl-1.2.1">;
+def fsycl_esimd : Flag<["-"], "fsycl-explicit-simd">, Group<sycl_Group>, Flags<[CC1Option, NoArgumentUnused, CoreOption]>,
+  HelpText<"Enable SYCL explicit SIMD extension">;
+def fno_sycl_esimd : Flag<["-"], "fno-sycl-explicit-simd">, Group<sycl_Group>,
+  HelpText<"Disable SYCL explicit SIMD extension">, Flags<[NoArgumentUnused, CoreOption]>;
 
 include "CC1Options.td"
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4124,6 +4124,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-fsycl");
     CmdArgs.push_back("-fsycl-is-device");
     CmdArgs.push_back("-fdeclare-spirv-builtins");
+
+    if (Args.hasFlag(options::OPT_fsycl_esimd, options::OPT_fno_sycl_esimd,
+                     false))
+      CmdArgs.push_back("-fsycl-explicit-simd");
     // Pass the triple of host when doing SYCL
     auto AuxT = llvm::Triple(llvm::sys::getProcessTriple());
     std::string NormalizedTriple = AuxT.normalize();
@@ -6145,6 +6149,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // doing the host pass.
       CmdArgs.push_back("-fsycl");
       CmdArgs.push_back("-fsycl-is-host");
+
+      // TODO add support to specify options shared between host and device
+      // compilation only once.
+      if (Args.hasFlag(options::OPT_fsycl_esimd, options::OPT_fno_sycl_esimd,
+                       false))
+        CmdArgs.push_back("-fsycl-explicit-simd");
     }
     if (IsSYCLOffloadDevice && JA.getType() == types::TY_SYCL_Header) {
       // Generating a SYCL Header

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6150,8 +6150,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-fsycl");
       CmdArgs.push_back("-fsycl-is-host");
 
-      // TODO add support to specify options shared between host and device
-      // compilation only once.
       if (Args.hasFlag(options::OPT_fsycl_esimd, options::OPT_fno_sycl_esimd,
                        false))
         CmdArgs.push_back("-fsycl-explicit-simd");

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2556,6 +2556,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
             << A->getAsString(Args) << A->getValue();
       }
     }
+    Opts.SYCLExplicitSIMD = Args.hasArg(options::OPT_fsycl_esimd);
   }
 
   Opts.IncludeDefaultHeader = Args.hasArg(OPT_finclude_default_header);

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1113,6 +1113,8 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
         Builder.defineMacro("__SYCL_NVPTX__", "1");
     }
   }
+  if (LangOpts.SYCLExplicitSIMD)
+    Builder.defineMacro("__SYCL_EXPLICIT_SIMD__", "1");
   if (LangOpts.SYCLUnnamedLambda)
     Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__", "1");
 

--- a/clang/test/Driver/sycl-esimd.cpp
+++ b/clang/test/Driver/sycl-esimd.cpp
@@ -1,0 +1,10 @@
+/// Check that explicit SIMD extension is disabled by default:
+// RUN: %clang -### %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHECK-DEFAULT %s
+// CHECK-DEFAULT-NOT: "-fsycl-explicit-simd"
+
+/// Check "-fsycl-explicit-simd" is passed when compiling for device and host:
+// RUN: %clang -### -fsycl -fsycl-explicit-simd %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHECK-SYCL-ESIMD %s
+// CHECK-SYCL-ESIMD: "-cc1"{{.*}} "-fsycl-explicit-simd"{{.*}}
+// CHECK-SYCL-ESIMD: "-cc1"{{.*}} "-fsycl-explicit-simd"{{.*}}


### PR DESCRIPTION
Options name: -fsycl-explicit-simd.
This option is temporary until ESIMD and normal SYCL kernels can
co-exist in the same source.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>