### PR TITLE
[SYCL] Do not select device with a negative score

### DIFF
--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -42,16 +42,15 @@ device device_selector::select_device() const {
       string_class DeviceName = dev.get_info<info::device::name>();
       std::cout << "SYCL_PI_TRACE[all]: "
                 << "select_device(): -> score = " << score
-                << ((score == REJECT_DEVICE_SCORE) ? "(REJECTED)" : " ")
-                << std::endl
+                << ((score < 0) ? "(REJECTED)" : " ") << std::endl
                 << "SYCL_PI_TRACE[all]: "
                 << "  platform: " << PlatformVersion << std::endl
                 << "SYCL_PI_TRACE[all]: "
                 << "  device: " << DeviceName << std::endl;
     }
 
-    // Device is discarded if is marked with REJECT_DEVICE_SCORE
-    if (dev_score == REJECT_DEVICE_SCORE)
+    // A negative score means that a device must not be selected.
+    if (dev_score < 0)
       continue;
 
     // SYCL spec says: "If more than one device receives the high score then

--- a/sycl/test/basic_tests/device_selector.cpp
+++ b/sycl/test/basic_tests/device_selector.cpp
@@ -1,0 +1,28 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_BE=%sycl_be %t.out
+//
+// Checks that no device is selected when no device of desired type is
+// available.
+
+#include <CL/sycl.hpp>
+
+#include <iostream>
+
+class RejectEverything : public sycl::device_selector {
+public:
+  int operator()(const sycl::device &Device) const final {
+    // Negative value means that a device must not be selected
+    return -1;
+  }
+};
+
+int main() {
+  RejectEverything Selector;
+  try {
+    sycl::device Device(Selector);
+  } catch (sycl::runtime_error &E) {
+    return 0;
+  }
+  std::cerr << "Error. A device is found." << std::endl;
+  return 1;
+}


### PR DESCRIPTION
According to the SYCL specification, if a device has a negative score
for a given selector it should not be selected.