### PR TITLE
[SYCL][ESIMD] Add "sycl_explicit_simd" attribute and metadata.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1135,6 +1135,17 @@ def SYCLKernel : InheritableAttr {
   let Documentation = [SYCLKernelDocs];
 }
 
+// Marks functions which must not be vectorized via horizontal SIMT widening,
+// e.g. because the function is already vectorized. Used to mark SYCL
+// explicit SIMD kernels and functions.
+def SYCLSimd : InheritableAttr {
+  let Spellings = [GNU<"sycl_explicit_simd">];
+  let Subjects = SubjectList<[Function]>;
+  let LangOpts = [SYCLExplicitSIMD];
+  let Documentation = [SYCLSimdDocs];
+  let PragmaAttributeSupport = 0;
+}
+
 // Available in SYCL explicit SIMD extension. Binds a file scope private
 // variable to a specific register.
 def SYCLRegisterNum : InheritableAttr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -338,7 +338,7 @@ def SYCLSimdDocs : Documentation {
     in the explicit SIMD mode. In this mode subgroup size is always 1 and
     explicit SIMD extensions - such as manual vectorization using wide vector
     data types and operations can be used. Compiler may decide to compile such
-    functions using different different optimization and code generation
+    functions using different optimization and code generation
     pipeline.
   }];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -330,6 +330,19 @@ The SYCL kernel in the previous code sample meets these expectations.
   }];
 }
 
+def SYCLSimdDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+    The ``__attribute__((sycl_explicit_simd))`` attribute is used by the device
+    compiler front end to mark kernels and functions to be compiled and executed
+    in the explicit SIMD mode. In this mode subgroup size is always 1 and
+    explicit SIMD extensions - such as manual vectorization using wide vector
+    data types and operations can be used. Compiler may decide to compile such
+    functions using different different optimization and code generation
+    pipeline.
+  }];
+}
+
 def SYCLRegisterNumDocs : Documentation {
   let Category = DocCatVariable;
   let Content = [{

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10828,6 +10828,9 @@ def err_conflicting_sycl_kernel_attributes : Error<
   "conflicting attributes applied to a SYCL kernel or SYCL_EXTERNAL function">;
 def err_conflicting_sycl_function_attributes : Error<
    "%0 attribute conflicts with '%1' attribute">;
+def err_sycl_function_attribute_mismatch : Error<
+  "SYCL kernel without %0 attribute can't call a function with this attribute">;
+def note_sycl_function_attribute_mismatch : Note<"function attribute is here">;
 def err_sycl_x_y_z_arguments_must_be_one : Error<
   "%0 X-, Y- and Z- sizes must be 1 when %1 attribute is used with value 0">;
 def err_intel_attribute_argument_is_not_in_range: Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10830,7 +10830,6 @@ def err_conflicting_sycl_function_attributes : Error<
    "%0 attribute conflicts with '%1' attribute">;
 def err_sycl_function_attribute_mismatch : Error<
   "SYCL kernel without %0 attribute can't call a function with this attribute">;
-def note_sycl_function_attribute_mismatch : Note<"function attribute is here">;
 def err_sycl_x_y_z_arguments_must_be_one : Error<
   "%0 X-, Y- and Z- sizes must be 1 when %1 attribute is used with value 0">;
 def err_intel_attribute_argument_is_not_in_range: Error<

--- a/clang/lib/CodeGen/CGSYCLRuntime.cpp
+++ b/clang/lib/CodeGen/CGSYCLRuntime.cpp
@@ -60,6 +60,10 @@ constexpr char ATTR_GENX_BYTE_OFFSET[] = "genx_byte_offset";
 
 bool CGSYCLRuntime::actOnFunctionStart(const FunctionDecl &FD,
                                        llvm::Function &F) {
+  // Populate "sycl_explicit_simd" attribute if any.
+  if (FD.hasAttr<SYCLSimdAttr>())
+    F.setMetadata("sycl_explicit_simd", llvm::MDNode::get(F.getContext(), {}));
+
   SYCLScopeAttr *Scope = FD.getAttr<SYCLScopeAttr>();
   if (!Scope)
     return false;

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -586,6 +586,14 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
                     llvm::MDNode::get(Context, AttrMDArgs));
   }
 
+  if (FD->hasAttr<SYCLSimdAttr>()) {
+    Fn->setMetadata("sycl_explicit_simd", llvm::MDNode::get(Context, {}));
+    llvm::Metadata *AttrMDArgs[] = {
+        llvm::ConstantAsMetadata::get(Builder.getInt32(1))};
+    Fn->setMetadata("intel_reqd_sub_group_size",
+                    llvm::MDNode::get(Context, AttrMDArgs));
+  }
+
   if (const SYCLIntelNumSimdWorkItemsAttr *A =
       FD->getAttr<SYCLIntelNumSimdWorkItemsAttr>()) {
     llvm::Metadata *AttrMDArgs[] = {

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -4427,12 +4427,8 @@ void CodeGenModule::EmitGlobalVarDefinition(const VarDecl *D,
     if (getCodeGenOpts().hasReducedDebugInfo())
       DI->EmitGlobalVariable(GV, D);
 
-  if (LangOpts.SYCLIsDevice) {
+  if (LangOpts.SYCLIsDevice)
     maybeEmitPipeStorageMetadata(D, GV, *this);
-    // Notify SYCL code generation infrastructure that a global variable is
-    // being generated.
-    getSYCLRuntime().actOnGlobalVarEmit(*this, *D, GV);
-  }
 }
 
 void CodeGenModule::EmitExternalVarDeclaration(const VarDecl *D) {

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -648,8 +648,16 @@ void CodeGenModule::Release() {
     SPIRVerMD->addOperand(llvm::MDNode::get(Ctx, SPIRVerElts));
     // We are trying to look like OpenCL C++ for SPIR-V translator.
     // 4 - OpenCL_CPP, 100000 - OpenCL C++ version 1.0
+    // 6 - CM, if any kernel or function is an explicit SIMD one
+    int Lang = 4;
+    for (auto &F : TheModule.functions())
+      if (F.getMetadata("sycl_explicit_simd") != nullptr) {
+        Lang = 6;
+        break;
+      }
+
     llvm::Metadata *SPIRVSourceElts[] = {
-        llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(Int32Ty, 4)),
+        llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(Int32Ty, Lang)),
         llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(Int32Ty, 100000))};
     llvm::NamedMDNode *SPIRVSourceMD =
         TheModule.getOrInsertNamedMetadata("spirv.Source");

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -648,7 +648,7 @@ void CodeGenModule::Release() {
     SPIRVerMD->addOperand(llvm::MDNode::get(Ctx, SPIRVerElts));
     // We are trying to look like OpenCL C++ for SPIR-V translator.
     // 4 - OpenCL_CPP, 100000 - OpenCL C++ version 1.0
-    // 6 - CM, if any kernel or function is an explicit SIMD one
+    // 6 - ESIMD, if any kernel or function is an explicit SIMD one
     int Lang = 4;
     for (auto &F : TheModule.functions())
       if (F.getMetadata("sycl_explicit_simd") != nullptr) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7560,6 +7560,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_SYCLKernel:
     handleSYCLKernelAttr(S, D, AL);
     break;
+  case ParsedAttr::AT_SYCLSimd:
+    handleSimpleAttribute<SYCLSimdAttr>(S, D, AL);
+    break;
   case ParsedAttr::AT_SYCLDevice:
     handleSYCLDeviceAttr(S, D, AL);
     break;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1700,7 +1700,8 @@ void Sema::MarkDevice(void) {
               Diag(Attr->getLocation(), diag::note_conflicting_attribute);
               SYCLKernel->setInvalidDecl();
             }
-          } else if (KBSimdAttr && (Attr->getSubGroupSize() != 1)) {
+          } else if ((KBSimdAttr != nullptr) &&
+                     (Attr->getSubGroupSize() != (unsigned)1)) {
             // ESIMD kernel can't call functions with reqd_subg_group_size != 1.
             reportConflictingAttrs(*this, KernelBody, KBSimdAttr, Attr);
           } else {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1045,7 +1045,7 @@ class SyclKernelDeclCreator
     FD->addAttr(AsmLabelAttr::CreateImplicit(Context, Name));
     FD->addAttr(ArtificialAttr::CreateImplicit(Context));
     if (IsSIMDKernel)
-      FD->addAttr(SYCLSimdAttr::CreateImplicit(Ctx));
+      FD->addAttr(SYCLSimdAttr::CreateImplicit(Context));
   }
 
   static FunctionDecl *createKernelDecl(ASTContext &Ctx, StringRef Name,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -434,12 +434,13 @@ public:
 
     while (!WorkList.empty()) {
       FunctionDecl *FD = WorkList.back().first;
-      if (isSYCLKernelBodyFunction(FD)) {
+      FunctionDecl *ParentFD = WorkList.back().second;
+
+      if ((ParentFD == SYCLKernel) && isSYCLKernelBodyFunction(FD)) {
         assert(!KernelBody && "inconsistent call graph - only one kernel body "
                               "function can be called");
         KernelBody = FD;
       }
-      FunctionDecl *ParentFD = WorkList.back().second;
       WorkList.pop_back();
       if (!Visited.insert(FD).second)
         continue; // We've already seen this Decl

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1740,7 +1740,7 @@ void Sema::MarkDevice(void) {
             Diag(KernelBody->getLocation(),
                  diag::err_sycl_function_attribute_mismatch)
                 << A;
-            Diag(A->getLocation(), diag::note_sycl_function_attribute_mismatch);
+            Diag(A->getLocation(), diag::note_attribute);
             KernelBody->setInvalidDecl();
           } else
             SYCLKernel->addAttr(A);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1039,11 +1039,13 @@ class SyclKernelDeclCreator
   }
 
   static void setKernelImplicitAttrs(ASTContext &Context, FunctionDecl *FD,
-                                     StringRef Name) {
+                                     StringRef Name, bool IsSIMDKernel) {
     // Set implicit attributes.
     FD->addAttr(OpenCLKernelAttr::CreateImplicit(Context));
     FD->addAttr(AsmLabelAttr::CreateImplicit(Context, Name));
     FD->addAttr(ArtificialAttr::CreateImplicit(Context));
+    if (IsSIMDKernel)
+      FD->addAttr(SYCLSimdAttr::CreateImplicit(Ctx));
   }
 
   static FunctionDecl *createKernelDecl(ASTContext &Ctx, StringRef Name,
@@ -1058,9 +1060,7 @@ class SyclKernelDeclCreator
         Ctx, Ctx.getTranslationUnitDecl(), Loc, Loc, &Ctx.Idents.get(Name),
         FuncType, Ctx.getTrivialTypeSourceInfo(Ctx.VoidTy), SC_None);
     FD->setImplicitlyInline(IsInline);
-    setKernelImplicitAttrs(Ctx, FD, Name);
-    if (IsSIMDKernel)
-      FD->addAttr(SYCLSimdAttr::CreateImplicit(Ctx));
+    setKernelImplicitAttrs(Ctx, FD, Name, IsSIMDKernel);
 
     // Add kernel to translation unit to see it in AST-dump.
     Ctx.getTranslationUnitDecl()->addDecl(FD);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -289,6 +289,31 @@ void Sema::checkSYCLDeviceVarDecl(VarDecl *Var) {
   checkSYCLType(*this, Ty, Loc, Visited);
 }
 
+// Tests whether given function is a lambda function or '()' operator used as
+// SYCL kernel body function (e.g. in parallel_for).
+//
+// TODO this test should involve checking the caller and matching function types
+// of the caller's parameter and the type of 'this' of this function. But the
+// information about the original caller (e.g. kernel_parallel_for) is
+// unavailable at this point - kernel creation infrastructure must be enhanced.
+// For now the check is only if FD is '()' operator. Works OK for today's
+// handler::kernel_parallel_for/... implementations as no other '()' operators
+// are invoked except the kernel body.
+static bool isSYCLKernelBodyFunction(FunctionDecl *FD) {
+  return FD->getOverloadedOperator() == OO_Call;
+}
+
+// Helper function to report conflicting function attributes.
+// F - the function, A1 - function attribute, A2 - the attribute it conflicts
+// with.
+static void reportConflictingAttrs(Sema &S, FunctionDecl *F, const Attr *A1,
+                                   const Attr *A2) {
+  S.Diag(F->getLocation(), diag::err_conflicting_sycl_kernel_attributes);
+  S.Diag(A1->getLocation(), diag::note_conflicting_attribute);
+  S.Diag(A2->getLocation(), diag::note_conflicting_attribute);
+  F->setInvalidDecl();
+}
+
 class MarkDeviceFunction : public RecursiveASTVisitor<MarkDeviceFunction> {
 public:
   MarkDeviceFunction(Sema &S)
@@ -397,15 +422,23 @@ public:
   // to be propagated down to callers and applied to SYCL kernels.
   // For example, reqd_work_group_size, vec_len_hint, reqd_sub_group_size
   // Attributes applied to SYCLKernel are also included
-  void CollectPossibleKernelAttributes(FunctionDecl *SYCLKernel,
-                                       llvm::SmallPtrSet<Attr *, 4> &Attrs) {
+  // Returns the kernel body function found during traversal.
+  FunctionDecl *
+  CollectPossibleKernelAttributes(FunctionDecl *SYCLKernel,
+                                  llvm::SmallPtrSet<Attr *, 4> &Attrs) {
     typedef std::pair<FunctionDecl *, FunctionDecl *> ChildParentPair;
     llvm::SmallPtrSet<FunctionDecl *, 16> Visited;
     llvm::SmallVector<ChildParentPair, 16> WorkList;
     WorkList.push_back({SYCLKernel, nullptr});
+    FunctionDecl *KernelBody = nullptr;
 
     while (!WorkList.empty()) {
       FunctionDecl *FD = WorkList.back().first;
+      if (isSYCLKernelBodyFunction(FD)) {
+        assert(!KernelBody && "inconsistent call graph - only one kernel body "
+                              "function can be called");
+        KernelBody = FD;
+      }
       FunctionDecl *ParentFD = WorkList.back().second;
       WorkList.pop_back();
       if (!Visited.insert(FD).second)
@@ -461,6 +494,11 @@ public:
       }
       if (auto *A = FD->getAttr<SYCLSimdAttr>())
         Attrs.insert(A);
+      // Propagate the explicit SIMD attribute through call graph - it is used
+      // to distinguish ESIMD code in ESIMD LLVM passes.
+      if (KernelBody && KernelBody->hasAttr<SYCLSimdAttr>() &&
+          (KernelBody != FD) && !FD->hasAttr<SYCLSimdAttr>())
+        FD->addAttr(SYCLSimdAttr::CreateImplicit(SemaRef.getASTContext()));
 
       // TODO: vec_len_hint should be handled here
 
@@ -476,6 +514,7 @@ public:
         }
       }
     }
+    return KernelBody;
   }
 
 private:
@@ -1643,11 +1682,14 @@ void Sema::MarkDevice(void) {
       // This function collects all kernel attributes which might be applied to
       // a device functions, but need to be propagated down to callers, i.e.
       // SYCL kernels
-      Marker.CollectPossibleKernelAttributes(SYCLKernel, Attrs);
+      FunctionDecl *KernelBody =
+          Marker.CollectPossibleKernelAttributes(SYCLKernel, Attrs);
+
       for (auto *A : Attrs) {
         switch (A->getKind()) {
         case attr::Kind::IntelReqdSubGroupSize: {
           auto *Attr = cast<IntelReqdSubGroupSizeAttr>(A);
+          const auto *KBSimdAttr = KernelBody->getAttr<SYCLSimdAttr>();
           if (auto *Existing =
                   SYCLKernel->getAttr<IntelReqdSubGroupSizeAttr>()) {
             if (Existing->getSubGroupSize() != Attr->getSubGroupSize()) {
@@ -1657,6 +1699,9 @@ void Sema::MarkDevice(void) {
               Diag(Attr->getLocation(), diag::note_conflicting_attribute);
               SYCLKernel->setInvalidDecl();
             }
+          } else if (KBSimdAttr && (Attr->getSubGroupSize() != 1)) {
+            // ESIMD kernel can't call functions with reqd_subg_group_size != 1.
+            reportConflictingAttrs(*this, KernelBody, KBSimdAttr, Attr);
           } else {
             SYCLKernel->addAttr(A);
           }
@@ -1685,7 +1730,16 @@ void Sema::MarkDevice(void) {
         case attr::Kind::SYCLIntelMaxWorkGroupSize:
         case attr::Kind::SYCLIntelNoGlobalWorkOffset:
         case attr::Kind::SYCLSimd: {
-          SYCLKernel->addAttr(A);
+          if ((A->getKind() == attr::Kind::SYCLSimd) &&
+              !KernelBody->getAttr<SYCLSimdAttr>()) {
+            // Usual kernel can't call ESIMD functions.
+            Diag(KernelBody->getLocation(),
+                 diag::err_sycl_function_attribute_mismatch)
+                << A;
+            Diag(A->getLocation(), diag::note_sycl_function_attribute_mismatch);
+            KernelBody->setInvalidDecl();
+          } else
+            SYCLKernel->addAttr(A);
           break;
         }
         // TODO: vec_len_hint should be handled here

--- a/clang/test/CodeGenSYCL/esimd_metadata1.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata1.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice \
+// RUN:   -fsycl -fsycl-is-device -fsycl-explicit-simd -I %S/Inputs -S -emit-llvm %s -o - | \
+// RUN:   FileCheck %s
+
+// The test checks that:
+// 1. !sycl_explicit_simd metadata is generated for functions
+// 2. !intel_reqd_sub_group_size !1 is added to explicit SIMD
+//    kernel
+// 3. Proper module !spirv.Source metadata is generated
+
+template <typename name, typename Func>
+void kernel(Func f) __attribute__((sycl_kernel)) __attribute__((sycl_explicit_simd)) {
+  f();
+}
+
+void bar() {
+  kernel<class MyKernel>([=]() {});
+  // CHECK: define spir_kernel void @_ZTSZ3barvE8MyKernel() {{.*}} !sycl_explicit_simd ![[EMPTY:[0-9]+]] !intel_reqd_sub_group_size ![[REQD_SIZE:[0-9]+]]
+}
+
+// CHECK: !spirv.Source = !{[[LANG:![0-9]+]]}
+// CHECK: [[LANG]] = !{i32 6, i32 100000}
+// CHECK: ![[EMPTY]] = !{}
+// CHECK: ![[REQD_SIZE]] = !{i32 1}

--- a/clang/test/CodeGenSYCL/esimd_metadata1.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata1.cpp
@@ -9,12 +9,12 @@
 // 3. Proper module !spirv.Source metadata is generated
 
 template <typename name, typename Func>
-void kernel(Func f) __attribute__((sycl_kernel)) __attribute__((sycl_explicit_simd)) {
+void kernel(Func f) __attribute__((sycl_kernel)) {
   f();
 }
 
 void bar() {
-  kernel<class MyKernel>([=]() {});
+  kernel<class MyKernel>([=]() __attribute__((sycl_explicit_simd)){});
   // CHECK: define spir_kernel void @_ZTSZ3barvE8MyKernel() {{.*}} !sycl_explicit_simd ![[EMPTY:[0-9]+]] !intel_reqd_sub_group_size ![[REQD_SIZE:[0-9]+]]
 }
 

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -1,0 +1,77 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify %s
+
+// ----------- Negative tests
+
+__attribute__((sycl_explicit_simd)) // expected-warning {{'sycl_explicit_simd' attribute only applies to functions}}
+int N;
+
+__attribute__((sycl_explicit_simd(3))) // expected-error {{'sycl_explicit_simd' attribute takes no arguments}}
+void
+bar() {}
+
+// -- ESIMD kernel can't call functions with required subgroup size != 1
+
+template <typename ID, typename F>
+void kernel0(F f) __attribute__((sycl_kernel)) {
+  f();
+}
+
+// expected-note@+1{{conflicting attribute is here}}
+[[cl::intel_reqd_sub_group_size(2)]] void g0() {}
+
+void test0() {
+  // expected-error@+2{{conflicting attributes applied to a SYCL kernel}}
+  // expected-note@+1{{conflicting attribute is here}}
+  kernel0<class Kernel0>([=]() __attribute__((sycl_explicit_simd)) { g0(); });
+}
+
+// -- Usual kernel can't call ESIMD function
+template <typename ID, typename F>
+void kernel1(F f) __attribute__((sycl_kernel)) {
+  f();
+}
+
+// expected-note@+1{{function attribute is here}}
+__attribute__((sycl_explicit_simd)) void g1() {}
+
+void test1() {
+  // expected-error@+1{{SYCL kernel without 'sycl_explicit_simd' attribute can't call a function with this attribute}}
+  kernel1<class Kernel1>([=]() { g1(); });
+}
+
+// ----------- Positive tests
+
+// -- Kernel-function call, both have the attribute, lambda kernel.
+template <typename ID, typename F>
+void kernel2(F f) __attribute__((sycl_kernel)) {
+  f();
+}
+
+void g2() __attribute__((sycl_explicit_simd)) {}
+
+void test2() {
+  kernel2<class Kernel2>([=]() __attribute__((sycl_explicit_simd)) { g2(); });
+}
+
+// --  Class members
+class A {
+  __attribute__((sycl_explicit_simd))
+  A() {}
+
+  __attribute__((sycl_explicit_simd)) void func3() {}
+};
+
+// --  Functor object kernel.
+
+template <typename F, typename ID = F>
+void kernel3(F f) __attribute__((sycl_kernel)) {
+  f();
+}
+
+struct Kernel3 {
+  void operator()() __attribute__((sycl_explicit_simd)) {}
+};
+
+void bar3() {
+  kernel3(Kernel3{});
+}

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -31,7 +31,7 @@ void kernel1(F f) __attribute__((sycl_kernel)) {
   f();
 }
 
-// expected-note@+1{{function attribute is here}}
+// expected-note@+1{{attribute is here}}
 __attribute__((sycl_explicit_simd)) void g1() {}
 
 void test1() {

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -verify %s
 
 // ----------- Negative tests
 

--- a/sycl/doc/extensions/ExplicitSIMD/ESIMD-TODO-list.md
+++ b/sycl/doc/extensions/ExplicitSIMD/ESIMD-TODO-list.md
@@ -8,3 +8,13 @@ github issues mechanism.
 1. Fix a generic (unrelated to ESIMD) issue [1811](https://github.com/intel/llvm/issues/1811) with lambda/functor function
    detection. Needed to improve diagnostics, fix attribute propagation.  
    ETA: ???
+2. Fix kernel body function detection. (unrelated to ESIMD)
+  clang/lib/Sema/SemaSYCL.cpp:296 function isSYCLKernelBodyFunction
+  The test in the function should involve checking the caller and matching function
+  types of the caller's parameter and the type of 'this' of this function. But the
+  information about the original caller (e.g. kernel_parallel_for) is
+  unavailable at this point - kernel creation infrastructure must be enhanced.
+  For now the check is only if FD is '()' operator. Works OK for today's
+  handler::kernel_parallel_for/... implementations as no other '()' operators
+  are invoked except the kernel body.
+


### PR DESCRIPTION
REVIEW SECOND COMMIT ONLY

This attribute is added by the FE to functions which must be
compiled in explicit SIMD mode. FE code generation then transforms
this attribute to specific metadata used by LLVM for further
compilation.

Authors:
Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>
Denis Bakhvalov <denis.bakhvalov@intel.com>

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>
