### PR TITLE
[SYCL][ESIMD] Support SYCL accessors in ESIMD mode in the FE.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -327,6 +327,7 @@ def CUDA : LangOpt<"CUDA">;
 def SYCLIsDevice : LangOpt<"SYCLIsDevice">;
 def SYCL : LangOpt<"SYCLIsDevice">;
 def SYCLIsHost : LangOpt<"SYCLIsHost">;
+def SYCLExplicitSIMD : LangOpt<"SYCLExplicitSIMD">;
 def HIP : LangOpt<"HIP">;
 def COnly : LangOpt<"", "!LangOpts.CPlusPlus">;
 def CPlusPlus : LangOpt<"CPlusPlus">;

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -248,6 +248,7 @@ LANGOPT(SYCLStdLayoutKernelParams, 1, 0, "Enable standard layout requirement for
 LANGOPT(SYCLUnnamedLambda , 1, 0, "Allow unnamed lambda SYCL kernels")
 LANGOPT(SYCLVersion       , 32, 0, "Version of the SYCL standard used")
 LANGOPT(DeclareSPIRVBuiltins, 1, 0, "Declare SPIR-V builtin functions")
+LANGOPT(SYCLExplicitSIMD  , 1, 0, "SYCL compilation with explicit SIMD extension")
 
 LANGOPT(HIPUseNewLaunchAPI, 1, 0, "Use new kernel launching API for HIP")
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3550,6 +3550,10 @@ def fno_sycl : Flag<["-"], "fno-sycl">, Group<sycl_Group>, Flags<[CoreOption]>,
   HelpText<"Disable SYCL kernels compilation for device">;
 def sycl_std_EQ : Joined<["-"], "sycl-std=">, Group<sycl_Group>, Flags<[CC1Option, NoArgumentUnused, CoreOption]>,
   HelpText<"SYCL language standard to compile for.">, Values<"2017, 121, 1.2.1, sycl-1.2.1">;
+def fsycl_esimd : Flag<["-"], "fsycl-explicit-simd">, Group<sycl_Group>, Flags<[CC1Option, NoArgumentUnused, CoreOption]>,
+  HelpText<"Enable SYCL explicit SIMD extension">;
+def fno_sycl_esimd : Flag<["-"], "fno-sycl-explicit-simd">, Group<sycl_Group>,
+  HelpText<"Disable SYCL explicit SIMD extension">, Flags<[NoArgumentUnused, CoreOption]>;
 
 include "CC1Options.td"
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -315,7 +315,8 @@ public:
     kind_std_layout,
     kind_sampler,
     kind_pointer,
-    kind_last = kind_pointer
+    kind_esimd_buffer_accessor,
+    kind_last = kind_esimd_buffer_accessor
   };
 
 public:

--- a/clang/lib/CodeGen/CGSYCLRuntime.cpp
+++ b/clang/lib/CodeGen/CGSYCLRuntime.cpp
@@ -20,6 +20,8 @@
 using namespace clang;
 using namespace CodeGen;
 
+namespace {
+
 /// Various utilities.
 /// TODO partially duplicates functionality from SemaSYCL.cpp, can be shared.
 class Util {
@@ -34,6 +36,8 @@ public:
   static bool matchQualifiedTypeName(const CXXRecordDecl *RecTy,
                                      ArrayRef<Util::DeclContextDesc> Scopes);
 };
+
+} // namespace
 
 static bool isPFWI(const FunctionDecl &FD) {
   const auto *MD = dyn_cast<CXXMethodDecl>(&FD);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4124,6 +4124,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-fsycl");
     CmdArgs.push_back("-fsycl-is-device");
     CmdArgs.push_back("-fdeclare-spirv-builtins");
+
+    if (Args.hasFlag(options::OPT_fsycl_esimd, options::OPT_fno_sycl_esimd,
+                     false))
+      CmdArgs.push_back("-fsycl-explicit-simd");
     // Pass the triple of host when doing SYCL
     auto AuxT = llvm::Triple(llvm::sys::getProcessTriple());
     std::string NormalizedTriple = AuxT.normalize();
@@ -6145,6 +6149,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // doing the host pass.
       CmdArgs.push_back("-fsycl");
       CmdArgs.push_back("-fsycl-is-host");
+
+      // TODO add support to specify options shared between host and device
+      // compilation only once.
+      if (Args.hasFlag(options::OPT_fsycl_esimd, options::OPT_fno_sycl_esimd,
+                       false))
+        CmdArgs.push_back("-fsycl-explicit-simd");
     }
     if (IsSYCLOffloadDevice && JA.getType() == types::TY_SYCL_Header) {
       // Generating a SYCL Header

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2556,6 +2556,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
             << A->getAsString(Args) << A->getValue();
       }
     }
+    Opts.SYCLExplicitSIMD = Args.hasArg(options::OPT_fsycl_esimd);
   }
 
   Opts.IncludeDefaultHeader = Args.hasArg(OPT_finclude_default_header);

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1113,6 +1113,8 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
         Builder.defineMacro("__SYCL_NVPTX__", "1");
     }
   }
+  if (LangOpts.SYCLExplicitSIMD)
+    Builder.defineMacro("__SYCL_EXPLICIT_SIMD__", "1");
   if (LangOpts.SYCLUnnamedLambda)
     Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__", "1");
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2041,9 +2041,7 @@ SYCLIntegrationHeader::SYCLIntegrationHeader(DiagnosticsEngine &_Diag,
 // -----------------------------------------------------------------------------
 
 bool Util::isSyclAccessorType(const QualType &Ty) {
-  if (const CXXRecordDecl *RecTy = Ty->getAsCXXRecordDecl())
-    return isSyclAccessorType(RecTy);
-  return false;
+  return isSyclType(Ty, "accessor", true /*Tmpl*/);
 }
 
 bool Util::isSyclAccessorType(const CXXRecordDecl *RecTy) {

--- a/clang/test/Driver/sycl-esimd.cpp
+++ b/clang/test/Driver/sycl-esimd.cpp
@@ -1,0 +1,10 @@
+/// Check that explicit SIMD extension is disabled by default:
+// RUN: %clang -### %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHECK-DEFAULT %s
+// CHECK-DEFAULT-NOT: "-fsycl-explicit-simd"
+
+/// Check "-fsycl-explicit-simd" is passed when compiling for device and host:
+// RUN: %clang -### -fsycl -fsycl-explicit-simd %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHECK-SYCL-ESIMD %s
+// CHECK-SYCL-ESIMD: "-cc1"{{.*}} "-fsycl-explicit-simd"{{.*}}
+// CHECK-SYCL-ESIMD: "-cc1"{{.*}} "-fsycl-explicit-simd"{{.*}}

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -80,6 +80,10 @@ public:
   void use(void *) const {}
   _ImplT<dimensions> impl;
 
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__SYCL_EXPLICIT_SIMD__)
+  void ESIMDBufferAccessorMarker() {}
+#endif // __SYCL_DEVICE_ONLY__ && __SYCL_EXPLICIT_SIMD__
+
 private:
   using PtrType = typename DeviceValueType<dataT, accessTarget>::type *;
   void __init(PtrType Ptr, range<dimensions> AccessRange,

--- a/clang/test/SemaSYCL/esimd-accessor-int-header.cpp
+++ b/clang/test/SemaSYCL/esimd-accessor-int-header.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang -I %S/Inputs -fsycl -fsycl-explicit-simd -fsycl-device-only \
+// RUN:  -Xclang -fsycl-int-header=%t.h %s -c
+// RUN: FileCheck -input-file=%t.h %s
+
+// This test checks that compiler generates correct integration header elements
+// for an accessor in ESIMD mode.
+
+#include <sycl.hpp>
+
+template <typename Acc>
+struct AccWrapper { Acc accessor; };
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write> acc;
+  kernel<class kernel_wrapper>(
+      [=]() {
+        acc.use();
+      });
+}
+// CHECK: static constexpr
+// CHECK: static constexpr
+// CHECK-NEXT: const kernel_param_desc_t kernel_signatures[] = {
+// CHECK-NEXT:  //--- {{[_a-zA-Z0-9]+}}kernel_wrapper
+// CHECK-NEXT:  { kernel_param_kind_t::kind_esimd_buffer_accessor, {{[0-9]+}}, {{[0-9]+}} },


### PR DESCRIPTION
REVIEW ONLY THE LAST COMMIT

FE detects whether an accessor kernel parameter is an accessor
passed to a ESIMD kernel), and marks the corrsponding integration
header parameter descriptor accordingly.
ESIMD accessors are handled differently at runtime (image1d_buffer_t is created).
Accompanying runtime changes are coming later.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>
