### PR TITLE
[SYCL] Deploy xmethod script to correct location

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -228,7 +228,8 @@ add_subdirectory( source )
 if (NOT WIN32)
   install(FILES
       "${CMAKE_CURRENT_SOURCE_DIR}/xmethods/libsycl.so-gdb.py"
-      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/$<TARGET_FILE_NAME:sycl>-gdb.py"
+      RENAME "libsycl.so.${SYCL_VERSION_STRING}-gdb.py"
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/"
       COMPONENT sycl-headers-extras)
 endif()
 


### PR DESCRIPTION
Place python script in the same folder as libsycl.so