### PR TITLE
[SYCL] Ensure utility methods are not exported from image_impl

### DIFF
--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -233,27 +233,6 @@ public:
 private:
   vector_class<device> getDevices(const ContextImplPtr Context);
 
-  template <info::device Param>
-  bool checkImageValueRange(const ContextImplPtr Context, const size_t Value) {
-    const auto &Devices = getDevices(Context);
-    return Value >= 1 && std::all_of(Devices.cbegin(), Devices.cend(),
-                                     [Value](const device &Dev) {
-                                       return Value <= Dev.get_info<Param>();
-                                     });
-  }
-
-  template <typename T, typename... Args> bool checkAnyImpl(T) { return false; }
-
-  template <typename ValT, typename VarT, typename... Args>
-  bool checkAnyImpl(ValT Value, VarT Variant, Args... Arguments) {
-    return (Value == Variant) ? true : checkAnyImpl(Value, Arguments...);
-  }
-
-  template <typename T, typename... Args>
-  bool checkAny(const T Value, Args... Arguments) {
-    return checkAnyImpl(Value, Arguments...);
-  }
-
   RT::PiMemObjectType getImageType() {
     if (Dimensions == 1)
       return (MIsArrayImage ? PI_MEM_TYPE_IMAGE1D_ARRAY : PI_MEM_TYPE_IMAGE1D);

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -11,6 +11,7 @@
 #include <CL/sycl/image.hpp>
 #include <detail/context_impl.hpp>
 
+#include <algorithm>
 #include <vector>
 
 __SYCL_INLINE_NAMESPACE(cl) {
@@ -20,7 +21,6 @@ namespace detail {
 template <info::device Param>
 static bool checkImageValueRange(const std::vector<device> &Devices,
                                  const size_t Value) {
-  // const auto &Devices = getDevices(Context);
   return Value >= 1 && std::all_of(Devices.cbegin(), Devices.cend(),
                                    [Value](const device &Dev) {
                                      return Value <= Dev.get_info<Param>();

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -10,10 +10,35 @@
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/image.hpp>
 #include <detail/context_impl.hpp>
+#include <vector>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+
+template <info::device Param>
+static bool checkImageValueRange(const std::vector<device> &Devices,
+                                 const size_t Value) {
+  // const auto &Devices = getDevices(Context);
+  return Value >= 1 && std::all_of(Devices.cbegin(), Devices.cend(),
+                                   [Value](const device &Dev) {
+                                     return Value <= Dev.get_info<Param>();
+                                   });
+}
+
+template <typename T, typename... Args> static bool checkAnyImpl(T) {
+  return false;
+}
+
+template <typename ValT, typename VarT, typename... Args>
+static bool checkAnyImpl(ValT Value, VarT Variant, Args... Arguments) {
+  return (Value == Variant) ? true : checkAnyImpl(Value, Arguments...);
+}
+
+template <typename T, typename... Args>
+static bool checkAny(const T Value, Args... Arguments) {
+  return checkAnyImpl(Value, Arguments...);
+}
 
 uint8_t getImageNumberChannels(image_channel_order Order) {
   switch (Order) {
@@ -308,16 +333,16 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
                                             void *UserPtr) {
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE1D, PI_MEM_TYPE_IMAGE1D_ARRAY,
                PI_MEM_TYPE_IMAGE2D_ARRAY, PI_MEM_TYPE_IMAGE2D) &&
-      !checkImageValueRange<info::device::image2d_max_width>(Context,
-                                                             Desc.image_width))
+      !checkImageValueRange<info::device::image2d_max_width>(
+          getDevices(Context), Desc.image_width))
     throw invalid_parameter_error(
         "For a 1D/2D image/image array, the width must be a Value >= 1 and "
         "<= CL_DEVICE_IMAGE2D_MAX_WIDTH.",
         PI_INVALID_VALUE);
 
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE3D) &&
-      !checkImageValueRange<info::device::image3d_max_width>(Context,
-                                                             Desc.image_width))
+      !checkImageValueRange<info::device::image3d_max_width>(
+          getDevices(Context), Desc.image_width))
     throw invalid_parameter_error(
         "For a 3D image, the width must be a Value >= 1 and <= "
         "CL_DEVICE_IMAGE3D_MAX_WIDTH",
@@ -326,7 +351,7 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE2D,
                PI_MEM_TYPE_IMAGE2D_ARRAY) &&
       !checkImageValueRange<info::device::image2d_max_height>(
-          Context, Desc.image_height))
+          getDevices(Context), Desc.image_height))
     throw invalid_parameter_error("For a 2D image or image array, the height "
                                   "must be a Value >= 1 and <= "
                                   "CL_DEVICE_IMAGE2D_MAX_HEIGHT",
@@ -334,15 +359,15 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
 
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE3D) &&
       !checkImageValueRange<info::device::image3d_max_height>(
-          Context, Desc.image_height))
+          getDevices(Context), Desc.image_height))
     throw invalid_parameter_error(
         "For a 3D image, the heightmust be a Value >= 1 and <= "
         "CL_DEVICE_IMAGE3D_MAX_HEIGHT",
         PI_INVALID_VALUE);
 
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE3D) &&
-      !checkImageValueRange<info::device::image3d_max_depth>(Context,
-                                                             Desc.image_depth))
+      !checkImageValueRange<info::device::image3d_max_depth>(
+          getDevices(Context), Desc.image_depth))
     throw invalid_parameter_error(
         "For a 3D image, the depth must be a Value >= 1 and <= "
         "CL_DEVICE_IMAGE3D_MAX_DEPTH",
@@ -351,7 +376,7 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE1D_ARRAY,
                PI_MEM_TYPE_IMAGE2D_ARRAY) &&
       !checkImageValueRange<info::device::image_max_array_size>(
-          Context, Desc.image_array_size))
+          getDevices(Context), Desc.image_array_size))
     throw invalid_parameter_error(
         "For a 1D and 2D image array, the array_size must be a "
         "Value >= 1 and <= CL_DEVICE_IMAGE_MAX_ARRAY_SIZE.",

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -10,6 +10,7 @@
 #include <CL/sycl/detail/memory_manager.hpp>
 #include <CL/sycl/image.hpp>
 #include <detail/context_impl.hpp>
+
 #include <vector>
 
 __SYCL_INLINE_NAMESPACE(cl) {


### PR DESCRIPTION
checkImageValueRange and checkAny are transformed to pure functions
with private linkage. This prevents linker to export these functions from
the library.