### PR TITLE
[SYCL][Doc] Fix default device selection rules doc

### DIFF
--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -87,9 +87,8 @@ device device_selector::select_device() const {
 
 /// Devices of different kinds are prioritized in the following order:
 /// 1. GPU
-/// 2. Accelerator
-/// 3. CPU
-/// 4. Host
+/// 2. CPU
+/// 3. Host
 int default_selector::operator()(const device &dev) const {
 
   int Score = REJECT_DEVICE_SCORE;


### PR DESCRIPTION
default_selector does not select accelerator devices anymore.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>