### PR TITLE
[SYCL] Fix KernelNameInfo generated for empty template paramter pack

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1864,20 +1864,16 @@ static void printArguments(ASTContext &Ctx, raw_ostream &ArgOS,
                            const PrintingPolicy &P);
 
 static void printArgument(ASTContext &Ctx, raw_ostream &ArgOS,
-                          TemplateArgument Arg, const PrintingPolicy &P,
-                          bool FirstArg) {
+                          TemplateArgument Arg, const PrintingPolicy &P) {
   switch (Arg.getKind()) {
   case TemplateArgument::ArgKind::Pack: {
-    if (Arg.pack_size() && !FirstArg)
-      ArgOS << ", ";
     printArguments(Ctx, ArgOS, Arg.getPackAsArray(), P);
     break;
   }
   case TemplateArgument::ArgKind::Integral: {
     QualType T = Arg.getIntegralType();
     const EnumType *ET = T->getAs<EnumType>();
-    if (!FirstArg)
-      ArgOS << ", ";
+
     if (ET) {
       const llvm::APSInt &Val = Arg.getAsIntegral();
       ArgOS << "(" << ET->getDecl()->getQualifiedNameAsString() << ")" << Val;
@@ -1893,14 +1889,10 @@ static void printArgument(ASTContext &Ctx, raw_ostream &ArgOS,
     TypePolicy.SuppressTagKeyword = true;
     QualType T = Arg.getAsType();
     QualType FullyQualifiedType = TypeName::getFullyQualifiedType(T, Ctx, true);
-    if (!FirstArg)
-      ArgOS << ", ";
     ArgOS << FullyQualifiedType.getAsString(TypePolicy);
     break;
   }
   default:
-    if (!FirstArg)
-      ArgOS << ", ";
     Arg.print(P, ArgOS);
   }
 }
@@ -1908,12 +1900,17 @@ static void printArgument(ASTContext &Ctx, raw_ostream &ArgOS,
 static void printArguments(ASTContext &Ctx, raw_ostream &ArgOS,
                            ArrayRef<TemplateArgument> Args,
                            const PrintingPolicy &P) {
-  bool FirstArg = true;
-
   for (unsigned I = 0; I < Args.size(); I++) {
     const TemplateArgument &Arg = Args[I];
-    printArgument(Ctx, ArgOS, Arg, P, FirstArg);
-    FirstArg = false;
+
+    // If argument is an empty pack argument, skip printing comma and argument.
+    if (Arg.getKind() == TemplateArgument::ArgKind::Pack && !Arg.pack_size())
+      continue;
+
+    if (I != 0)
+      ArgOS << ", ";
+
+    printArgument(Ctx, ArgOS, Arg, P);
   }
 }
 

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -12,6 +12,7 @@
 // CHECK:template <> struct KernelInfo<::nm1::KernelName4<KernelName7>> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName8<::nm1::nm2::C>> {
 // CHECK:template <> struct KernelInfo<::TmplClassInAnonNS<ClassInAnonNS>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName9<char>> {
 
 // This test checks if the SYCL device compiler is able to generate correct
 // integration header when the kernel name class is expressed in different
@@ -41,6 +42,9 @@ namespace nm1 {
 
   template <> class KernelName4<nm1::nm2::KernelName0> {};
   template <> class KernelName4<KernelName1> {};
+
+  template <typename T, typename...>
+  class KernelName9;
 
 } // namespace nm1
 
@@ -128,6 +132,10 @@ struct MyWrapper {
     kernel_single_task<TmplClassInAnonNS<class ClassInAnonNS>>(
       [=]() { acc.use(); });
 
+    // Kernel name type is a templated specialization class with empty template pack argument
+    kernel_single_task<nm1::KernelName9<char>>(
+        [=]() { acc.use(); });
+
     return 0;
   }
 };
@@ -151,5 +159,6 @@ int main() {
   KernelInfo<class nm1::KernelName4<class KernelName7>>::getName();
   KernelInfo<class nm1::KernelName8<nm1::nm2::C>>::getName();
   KernelInfo<class TmplClassInAnonNS<class ClassInAnonNS>>::getName();
+  KernelInfo<class nm1::KernelName9<char>>::getName();
 #endif //__SYCL_DEVICE_ONLY__
 }


### PR DESCRIPTION
Fix KernelNameInfo generated in integration header when kernelname type is a template specialization class with empty template pack argument.

This commit fixes a bug introduced by commit e7020a17439b322bfb where an extra comma was printed before empty pack arguments

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>