### PR TITLE
[SYCL] Fix FE attribute handling in SYCL_EXTERNAL functions.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10815,7 +10815,7 @@ def err_sycl_non_trivially_copy_ctor_dtor_type
 def err_sycl_non_std_layout_type : Error<
   "kernel parameter has non-standard layout class/struct type %0">;
 def err_conflicting_sycl_kernel_attributes : Error<
-  "conflicting attributes applied to a SYCL kernel">;
+  "conflicting attributes applied to a SYCL kernel or SYCL_EXTERNAL function">;
 def err_conflicting_sycl_function_attributes : Error<
    "%0 attribute conflicts with '%1' attribute">;
 def err_sycl_x_y_z_arguments_must_be_one : Error<

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12556,7 +12556,7 @@ public:
 private:
   // We store SYCL Kernels here and handle separately -- which is a hack.
   // FIXME: It would be best to refactor this.
-  SmallVector<Decl*, 4> SyclDeviceDecls;
+  llvm::SetVector<Decl *> SyclDeviceDecls;
   // SYCL integration header instance for current compilation unit this Sema
   // is associated with.
   std::unique_ptr<SYCLIntegrationHeader> SyclIntHeader;
@@ -12567,8 +12567,8 @@ private:
   bool ConstructingOpenCLKernel = false;
 
 public:
-  void addSyclDeviceDecl(Decl *d) { SyclDeviceDecls.push_back(d); }
-  SmallVectorImpl<Decl *> &syclDeviceDecls() { return SyclDeviceDecls; }
+  void addSyclDeviceDecl(Decl *d) { SyclDeviceDecls.insert(d); }
+  llvm::SetVector<Decl *> &syclDeviceDecls() { return SyclDeviceDecls; }
 
   /// Lazily creates and returns SYCL integration header instance.
   SYCLIntegrationHeader &getSyclIntegrationHeader() {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1460,6 +1460,15 @@ void Sema::MarkDevice(void) {
   // it is recursive.
   MarkDeviceFunction Marker(*this);
   Marker.SYCLCG.addToCallGraph(getASTContext().getTranslationUnitDecl());
+
+  // Iterate through SYCL_EXTERNAL functions and add them to the device decls.
+  for (const auto &entry : *Marker.SYCLCG.getRoot()) {
+    if (auto *FD = dyn_cast<FunctionDecl>(entry.Callee->getDecl())) {
+      if (FD->hasAttr<SYCLDeviceAttr>() && !FD->hasAttr<SYCLKernelAttr>())
+        addSyclDeviceDecl(FD);
+    }
+  }
+
   for (Decl *D : syclDeviceDecls()) {
     if (auto SYCLKernel = dyn_cast<FunctionDecl>(D)) {
       llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet;

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -48,6 +48,17 @@ void bar() {
   kernel<class kernel_name5>([]() [[cl::intel_reqd_sub_group_size(2)]] { });
 }
 
+#ifdef TRIGGER_ERROR
+// expected-note@+1 {{conflicting attribute is here}}
+[[cl::intel_reqd_sub_group_size(2)]] void sg_size2() {}
+
+// expected-note@+2 {{conflicting attribute is here}}
+// expected-error@+1 {{conflicting attributes applied to a SYCL kernel}}
+[[cl::intel_reqd_sub_group_size(4)]] __attribute__((sycl_device)) void sg_size4() {
+  sg_size2();
+}
+#endif
+
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name1
 // CHECK: IntelReqdSubGroupSizeAttr {{.*}} 16
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2


### PR DESCRIPTION
SYCL_EXTERNAL functions are not included into the device declarations
set which is iterated during SYCL attribute propagation and checking.

This leads e.g. to the following code getting silently accepted:
```
[[cl::intel_reqd_sub_group_size(2)]] void sg_size2() {}
[[cl::intel_reqd_sub_group_size(4)]] __attribute__((sycl_device)) void sg_size4() {
  sg_size2();
}
```
SYCL_EXTERNAL function with reqd_sub_group_size 4 calls a function with reqd_sub_group_size 2. This shoud be an error. Existing implementation detects it only when there is a kernel in place of SYCL_EXTERNAL function

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>