### PR TITLE
[SYCL] Add parallel_for interface simplification features

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -967,13 +967,6 @@ public:
   }
 
   template <int Dims = Dimensions,
-            typename = detail::enable_if_t<Dims == 1 && IsAccessAnyWrite>>
-  RefType operator[](size_t Index) const {
-    const size_t LinearIndex = getLinearIndex(id<Dimensions>(Index));
-    return getQualifiedPtr()[LinearIndex];
-  }
-
-  template <int Dims = Dimensions,
             typename = detail::enable_if_t<Dims == 0 && IsAccessReadOnly>>
   operator DataT() const {
     const size_t LinearIndex = getLinearIndex(id<AdjustedDim>());
@@ -984,13 +977,6 @@ public:
             typename = detail::enable_if_t<(Dims > 0) && IsAccessReadOnly>>
   DataT operator[](id<Dimensions> Index) const {
     const size_t LinearIndex = getLinearIndex(Index);
-    return getQualifiedPtr()[LinearIndex];
-  }
-
-  template <int Dims = Dimensions,
-            typename = detail::enable_if_t<Dims == 1 && IsAccessReadOnly>>
-  DataT operator[](size_t Index) const {
-    const size_t LinearIndex = getLinearIndex(id<Dimensions>(Index));
     return getQualifiedPtr()[LinearIndex];
   }
 

--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -30,6 +30,16 @@ template <int dimensions> class range;
 ///
 /// \ingroup sycl_api
 template <int dimensions = 1, bool with_offset = true> class item {
+#ifndef __SYCL_DISABLE_ITEM_TO_INT_CONV__
+  /* Helper class for conversion operator. Void type is not suitable. User
+   * cannot even try to get address of the operator __private_class(). User
+   * may try to get an address of operator void() and will get the
+   * compile-time error */
+  class __private_class;
+
+  template <bool B, typename T>
+  using EnableIfT = detail::conditional_t<B, T, __private_class>;
+#endif // __SYCL_DISABLE_ITEM_TO_INT_CONV__
 public:
   item() = delete;
 
@@ -54,7 +64,9 @@ public:
     __SYCL_ASSUME_INT(Id);
     return Id;
   }
-
+#ifndef __SYCL_DISABLE_ITEM_TO_INT_CONV__
+  operator EnableIfT<dimensions == 1, std::size_t>() const { return get_id(0); }
+#endif // __SYCL_DISABLE_ITEM_TO_INT_CONV__
   template <bool has_offset = with_offset>
   detail::enable_if_t<has_offset, id<dimensions>> get_offset() const {
     return MImpl.MOffset;

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -406,8 +406,8 @@ public:
 #endif
     return submit(
         [&](handler &CGH) {
-          CGH.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
-                                                                  KernelFunc);
+          CGH.template parallel_for<KernelName, KernelType>(NumWorkItems,
+                                                            KernelFunc);
         },
         CodeLoc);
   }
@@ -434,8 +434,8 @@ public:
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvent);
-          CGH.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
-                                                                  KernelFunc);
+          CGH.template parallel_for<KernelName, KernelType>(NumWorkItems,
+                                                            KernelFunc);
         },
         CodeLoc);
   }
@@ -464,8 +464,8 @@ public:
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvents);
-          CGH.template parallel_for<KernelName, KernelType, Dims>(NumWorkItems,
-                                                                  KernelFunc);
+          CGH.template parallel_for<KernelName, KernelType>(NumWorkItems,
+                                                            KernelFunc);
         },
         CodeLoc);
   }
@@ -491,7 +491,7 @@ public:
 #endif
     return submit(
         [&](handler &CGH) {
-          CGH.template parallel_for<KernelName, KernelType, Dims>(
+          CGH.template parallel_for<KernelName, KernelType>(
               NumWorkItems, WorkItemOffset, KernelFunc);
         },
         CodeLoc);
@@ -521,7 +521,7 @@ public:
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvent);
-          CGH.template parallel_for<KernelName, KernelType, Dims>(
+          CGH.template parallel_for<KernelName, KernelType>(
               NumWorkItems, WorkItemOffset, KernelFunc);
         },
         CodeLoc);
@@ -552,7 +552,7 @@ public:
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvents);
-          CGH.template parallel_for<KernelName, KernelType, Dims>(
+          CGH.template parallel_for<KernelName, KernelType>(
               NumWorkItems, WorkItemOffset, KernelFunc);
         },
         CodeLoc);
@@ -579,8 +579,8 @@ public:
 #endif
     return submit(
         [&](handler &CGH) {
-          CGH.template parallel_for<KernelName, KernelType, Dims>(
-              ExecutionRange, KernelFunc);
+          CGH.template parallel_for<KernelName, KernelType>(ExecutionRange,
+                                                            KernelFunc);
         },
         CodeLoc);
   }
@@ -608,8 +608,8 @@ public:
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvent);
-          CGH.template parallel_for<KernelName, KernelType, Dims>(
-              ExecutionRange, KernelFunc);
+          CGH.template parallel_for<KernelName, KernelType>(ExecutionRange,
+                                                            KernelFunc);
         },
         CodeLoc);
   }
@@ -639,8 +639,8 @@ public:
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvents);
-          CGH.template parallel_for<KernelName, KernelType, Dims>(
-              ExecutionRange, KernelFunc);
+          CGH.template parallel_for<KernelName, KernelType>(ExecutionRange,
+                                                            KernelFunc);
         },
         CodeLoc);
   }

--- a/sycl/test/basic_tests/accessor/accessor.cpp
+++ b/sycl/test/basic_tests/accessor/accessor.cpp
@@ -34,13 +34,6 @@ struct IdxID3 {
   operator sycl::id<3>() { return sycl::id<3>(x, y, z); }
 };
 
-struct IdxSzT {
-  int x;
-
-  IdxSzT(int x) : x(x) {}
-  operator size_t() { return x; }
-};
-
 template <typename Acc> struct AccWrapper { Acc accessor; };
 
 template <typename Acc1, typename Acc2> struct AccsWrapper {
@@ -85,10 +78,10 @@ int main() {
     // Make sure that operator[] is defined for both size_t and id<1>.
     // Implicit conversion from IdxSzT to size_t guarantees that no
     // implicit conversion from size_t to id<1> will happen.
-    assert(acc_src[IdxSzT(0)] + acc_src[IdxID1(1)] == 10);
+    assert(acc_src[0] + acc_src[IdxID1(1)] == 10);
 
     acc_dst[0] = acc_src[0] + acc_src[IdxID1(0)];
-    acc_dst[id1] = acc_src[1] + acc_src[IdxSzT(1)];
+    acc_dst[id1] = acc_src[1] + acc_src[1];
     assert(dst[0] == 6 && dst[1] == 14);
   }
 
@@ -130,7 +123,7 @@ int main() {
       assert(acc.get_count() == 1);
       assert(acc.get_range() == sycl::range<1>(1));
       cgh.single_task<class kernel>(
-          [=]() { acc[IdxSzT(0)] += acc[IdxID1(0)]; });
+          [=]() { acc[0] += acc[IdxID1(0)]; });
     });
     Queue.wait();
   }

--- a/sycl/test/basic_tests/handler/handler_generic_integral_lambda.cpp
+++ b/sycl/test/basic_tests/handler/handler_generic_integral_lambda.cpp
@@ -1,0 +1,77 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+//==-------------- handler_generic_integral_lambda.cpp ---------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+int main() {
+  constexpr std::size_t length = 10;
+
+  {
+    int data[length];
+    {
+      sycl::buffer<int> buf(data, sycl::range<1>(length));
+      sycl::queue q;
+      q.submit([&](cl::sycl::handler &cgh) {
+        sycl::accessor<int, 1, sycl::access::mode::write, sycl::access::target::global_buffer> acc(
+            buf.get_access<sycl::access::mode::write>(cgh));
+        cgh.parallel_for<class GenericLambda>(length, [=](auto item) {
+          acc[item.get_id()] = item;
+        });
+      });
+    }
+    for (int i = 0; i < length; i++) {
+      assert(data[i] == i);
+    }
+  }
+
+  {
+    int data[length];
+    {
+      sycl::buffer<int> buf(data, sycl::range<1>(length));
+      sycl::queue q;
+      q.submit([&](cl::sycl::handler &cgh) {
+        sycl::accessor<int, 1, sycl::access::mode::write, sycl::access::target::global_buffer> acc(
+            buf.get_access<sycl::access::mode::write>(cgh));
+        cgh.parallel_for<class SizeTLambda>(length, [=](std::size_t item) {
+          acc[item] = item;
+        });
+      });
+    }
+    for (int i = 0; i < length; i++) {
+      assert(data[i] == i);
+    }
+  }
+
+  {
+    int data[length];
+    {
+      sycl::buffer<int> buf(data, sycl::range<1>(length));
+      sycl::queue q;
+      q.submit([&](cl::sycl::handler &cgh) {
+        sycl::accessor<int, 1, sycl::access::mode::write, sycl::access::target::global_buffer> acc(
+            buf.get_access<sycl::access::mode::write>(cgh));
+        cgh.parallel_for<class IntLambda>(length, [=](int item) {
+          acc[item] = item;
+        });
+      });
+    }
+    for (int i = 0; i < length; i++) {
+      assert(data[i] == i);
+    }
+  }
+
+  return 0;
+}

--- a/sycl/test/basic_tests/handler/handler_generic_lambda_interface.cpp
+++ b/sycl/test/basic_tests/handler/handler_generic_lambda_interface.cpp
@@ -1,0 +1,56 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -I %sycl_include
+// expected-no-diagnostics
+//==--------------- handler_generic_lambda_interface.cpp -------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+template <typename KernelName, typename ExpectedType, typename Range>
+void test_parallel_for(Range r) {
+  sycl::queue q;
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelName>(r, [=](auto item) {
+      static_assert(std::is_same<decltype(item), ExpectedType>::value,
+                    "Argument type is unexpected");
+    });
+  });
+}
+
+template <typename KernelName, typename ExpectedType, typename Range>
+void test_parallel_for_work_group(Range r) {
+  sycl::queue q;
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.parallel_for_work_group<KernelName>(r, [=](auto item) {
+      static_assert(std::is_same<decltype(item), ExpectedType>::value,
+                    "Argument type is unexpected");
+    });
+  });
+}
+
+int main() {
+
+  test_parallel_for<class Item1Name, sycl::item<1>>(sycl::range<1>{1});
+  test_parallel_for<class Item2Name, sycl::item<2>>(sycl::range<2>{1, 1});
+  test_parallel_for<class Item3Name, sycl::item<3>>(sycl::range<3>{1, 1, 1});
+
+  test_parallel_for<class NdItem1Name, sycl::nd_item<1>>(sycl::nd_range<1>{
+      sycl::range<1>{1}, sycl::range<1>{1}});
+  test_parallel_for<class NdItem2Name, sycl::nd_item<2>>(sycl::nd_range<2>{
+      sycl::range<2>{1, 1}, sycl::range<2>{1, 1}});
+  test_parallel_for<class NdItem3Name, sycl::nd_item<3>>(sycl::nd_range<3>{
+      sycl::range<3>{1, 1, 1}, sycl::range<3>{1, 1, 1}});
+
+  test_parallel_for_work_group<class Group1Name, sycl::group<1>>(sycl::range<1>{1});
+  test_parallel_for_work_group<class Group2Name, sycl::group<2>>(sycl::range<2>{1, 1});
+  test_parallel_for_work_group<class Group3Name, sycl::group<3>>(sycl::range<3>{1, 1, 1});
+
+  return 0;
+}

--- a/sycl/test/basic_tests/handler/handler_one_dim_range_init_list.cpp
+++ b/sycl/test/basic_tests/handler/handler_one_dim_range_init_list.cpp
@@ -1,0 +1,21 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -I %sycl_include
+// expected-no-diagnostics
+//==---------------- handler_one_dim_range_init_list.cpp -------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+
+#include <utility>
+
+int main() {
+  auto l = [] {};
+
+  decltype(std::declval<sycl::handler>().parallel_for(1, l)) a1a();
+  decltype(std::declval<sycl::handler>().parallel_for({1}, l)) a1b();
+  decltype(std::declval<sycl::handler>().parallel_for({1, 2}, l)) a2();
+  decltype(std::declval<sycl::handler>().parallel_for({1, 2, 3}, l)) a3();
+}


### PR DESCRIPTION
[SYCL] Add parallel_for interface simplification features

This change implements "parallel_for simplification extension":
https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/ParallelForSimpification

Features list:
- Allow parallel_for call with number or braced-init-list as the first
argument, i.e.
- Allow C++14 Generic lambda expression as the kernel for parallel_for,
i.e `[](auto){}`
- Allow C++14 Generic lambda expression as the kernel for
parallel_for_work_group
- Allow integral type as the kernel argument for parallel_for called with
range<1>, e.g. `[](int i){}`
- Allow `item<1>` to `size_t` conversion

Changes:
 - Add overloads for parallel_for with range<1>, range<2> and range<3>
to allow implicit conversion either from number or from braced-init-list.
Extract the previously existing body to _impl function.
 - For generic lambda: Redesign the mechanism calculating lambda argument type.
If the address of the Callable object can be taken, mechanism deduces the
argument type, otherwise, uses the suggested type passed from the caller
side. Calculates the lambda argument type once and use it further on when
passing to kernel_parallel_for* function. Then the implementation of
kernel_parallel_for* uses the calculated lambda argument type to
determine the right overload of Builder::getElement by creating the
pseudo object of lambda argument type. That allows easier integration
of generic lambda support and allows to remove several overloads and
instances.
 - For lambda with integral argument: if calculated lambda argument
type is integral change it to item, otherwise, leave it as is.
 - Add conversion operator when item dimension is 1. accessor::operator[](size_t)
is removed though to make it possible to pass the item to the mentioned
operator. In that case we have accessor::operator[](id<>) left. Both
number and item can be used with that operator because both of them are
convertible to id. Otherwise, operator[] is ambiguous because item<1> is
convertible to id and is convertible to size_t.

Signed-off-by: Ruslan Arutyunyan <ruslan.arutyunyan@intel.com>