### PR TITLE
[SYCL] disallow mutable lambdas

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1127,7 +1127,9 @@ def OpenMP : DiagGroup<"openmp", [
   ]>;
 
 // SYCL warnings
-def SyclStrict : DiagGroup<"sycl-strict">;
+def Sycl2017Conform : DiagGroup<"sycl-2017-conform">;
+def Sycl2020Conform : DiagGroup<"sycl-2020-conform">;
+def SyclStrict : DiagGroup<"sycl-strict", [ Sycl2017Conform, Sycl2020Conform]>;
 def SyclTarget : DiagGroup<"sycl-target">;
 
 // Backend warnings.

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1127,9 +1127,9 @@ def OpenMP : DiagGroup<"openmp", [
   ]>;
 
 // SYCL warnings
-def Sycl2017Conform : DiagGroup<"sycl-2017-conform">;
-def Sycl2020Conform : DiagGroup<"sycl-2020-conform">;
-def SyclStrict : DiagGroup<"sycl-strict", [ Sycl2017Conform, Sycl2020Conform]>;
+def Sycl2017Compat : DiagGroup<"sycl-2017-compat">;
+def Sycl2020Compat : DiagGroup<"sycl-2020-compat">;
+def SyclStrict : DiagGroup<"sycl-strict", [ Sycl2017Compat, Sycl2020Compat]>;
 def SyclTarget : DiagGroup<"sycl-target">;
 
 // Backend warnings.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10971,7 +10971,10 @@ def err_sycl_attibute_cannot_be_applied_here
             "static function or function in an anonymous namespace">;
 def warn_sycl_pass_by_value_deprecated 
     : Warning<"Pass-by-value of kernel functions is deprecated in SYCL 2020.">,
-      InGroup<SyclStrict>;
+      InGroup<Sycl2020Conform>;
+def warn_sycl_pass_by_reference_future 
+    : Warning<"Pass-by-reference of kernel functions requires SYCL 2020, and does not conform to SYCL 1.2.1">,
+      InGroup<Sycl2017Conform>;
 def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
               "to a function with a raw pointer "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10970,10 +10970,10 @@ def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "static function or function in an anonymous namespace">;
 def warn_sycl_pass_by_value_deprecated 
-    : Warning<"Passing kernel functions by value is deprecated in SYCL 2020.">,
+    : Warning<"Passing kernel functions by value is deprecated in SYCL 2020">,
       InGroup<Sycl2020Compat>;
 def warn_sycl_pass_by_reference_future 
-    : Warning<"Passing of kernel functions by reference is a SYCL 2020 extension.">,
+    : Warning<"Passing of kernel functions by reference is a SYCL 2020 extension">,
       InGroup<Sycl2017Compat>;
 def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10969,8 +10969,8 @@ def warn_boolean_attribute_argument_is_not_valid: Warning<
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "static function or function in an anonymous namespace">;
-def warn_sycl_old_version 
-    : Warning<"Older version of SYCL headers encountered.">,
+def warn_sycl_pass_by_value_deprecated 
+    : Warning<"Pass-by-value of kernel functions is deprecated in SYCL 2020.">,
       InGroup<SyclStrict>;
 def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10969,6 +10969,9 @@ def warn_boolean_attribute_argument_is_not_valid: Warning<
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "static function or function in an anonymous namespace">;
+def warn_sycl_old_version 
+    : Warning<"Older version of SYCL headers encountered.">,
+      InGroup<SyclStrict>;
 def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
               "to a function with a raw pointer "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10970,11 +10970,11 @@ def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "static function or function in an anonymous namespace">;
 def warn_sycl_pass_by_value_deprecated 
-    : Warning<"Pass-by-value of kernel functions is deprecated in SYCL 2020.">,
-      InGroup<Sycl2020Conform>;
+    : Warning<"Passing kernel functions by value is deprecated in SYCL 2020.">,
+      InGroup<Sycl2020Compat>;
 def warn_sycl_pass_by_reference_future 
-    : Warning<"Pass-by-reference of kernel functions requires SYCL 2020, and does not conform to SYCL 1.2.1">,
-      InGroup<Sycl2017Conform>;
+    : Warning<"Passing of kernel functions by reference is a SYCL 2020 extension.">,
+      InGroup<Sycl2017Compat>;
 def warn_sycl_attibute_function_raw_ptr
     : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
               "to a function with a raw pointer "

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2582,6 +2582,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
     if (const Arg *A = Args.getLastArg(OPT_sycl_std_EQ)) {
       Opts.SYCLVersion = llvm::StringSwitch<unsigned>(A->getValue())
                              .Cases("2017", "1.2.1", "121", "sycl-1.2.1", 2017)
+                             .Case("2020", 2020)
                              .Default(0U);
 
       if (Opts.SYCLVersion == 0U) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -728,12 +728,11 @@ getKernelInvocationKind(FunctionDecl *KernelCallerFunc) {
       .Default(InvokeUnknown);
 }
 
-static CXXRecordDecl *getKernelObjectType(FunctionDecl *Caller) {
+static const CXXRecordDecl *getKernelObjectType(FunctionDecl *Caller) {
   auto KernelParamTy = (*Caller->param_begin())->getType();
   // In SYCL 2020 kernels are now passed by reference.
   if (KernelParamTy->isReferenceType())
-    return const_cast<CXXRecordDecl *>(
-        KernelParamTy->getPointeeCXXRecordDecl());
+    return KernelParamTy->getPointeeCXXRecordDecl();
   else
     return KernelParamTy->getAsCXXRecordDecl(); // SYCL 1.2
 }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -729,13 +729,13 @@ getKernelInvocationKind(FunctionDecl *KernelCallerFunc) {
 }
 
 static CXXRecordDecl *getKernelObjectType(FunctionDecl *Caller) {
-  auto KernelParam = (*Caller->param_begin());
+  auto KernelParamTy = (*Caller->param_begin())->getType();
   // In SYCL 2020 kernels are now passed by reference.
-  if (KernelParam->getType()->isReferenceType())
+  if (KernelParamTy->isReferenceType())
     return const_cast<CXXRecordDecl *>(
-        KernelParam->getType()->getPointeeCXXRecordDecl());
+        KernelParamTy->getPointeeCXXRecordDecl());
   else
-    return KernelParam->getType()->getAsCXXRecordDecl(); // SYCL 1.2
+    return KernelParamTy->getAsCXXRecordDecl(); // SYCL 1.2
 }
 
 /// Creates a kernel parameter descriptor

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -728,8 +728,14 @@ getKernelInvocationKind(FunctionDecl *KernelCallerFunc) {
       .Default(InvokeUnknown);
 }
 
-static const CXXRecordDecl *getKernelObjectType(FunctionDecl *Caller) {
-  return (*Caller->param_begin())->getType()->getAsCXXRecordDecl();
+static CXXRecordDecl *getKernelObjectType(FunctionDecl *Caller) {
+  auto KernelParam = (*Caller->param_begin());
+  // In SYCL 2020 kernels are now passed by reference.
+  if (KernelParam->getType()->isReferenceType())
+    return const_cast<CXXRecordDecl *>(
+        KernelParam->getType()->getPointeeCXXRecordDecl());
+  else
+    return KernelParam->getType()->getAsCXXRecordDecl(); // SYCL 1.2
 }
 
 /// Creates a kernel parameter descriptor

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -729,12 +729,12 @@ getKernelInvocationKind(FunctionDecl *KernelCallerFunc) {
 }
 
 static const CXXRecordDecl *getKernelObjectType(FunctionDecl *Caller) {
-  auto KernelParamTy = (*Caller->param_begin())->getType();
+  QualType KernelParamTy = (*Caller->param_begin())->getType();
   // In SYCL 2020 kernels are now passed by reference.
   if (KernelParamTy->isReferenceType())
     return KernelParamTy->getPointeeCXXRecordDecl();
-  else
-    return KernelParamTy->getAsCXXRecordDecl(); // SYCL 1.2
+
+  return KernelParamTy->getAsCXXRecordDecl(); // SYCL 1.2
 }
 
 /// Creates a kernel parameter descriptor

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -736,7 +736,10 @@ static const CXXRecordDecl *getKernelObjectType(Sema &SemaRef,
     return KernelParamTy->getPointeeCXXRecordDecl();
 
   // SYCL 1.2
-  SemaRef.Diag(Caller->getLocation(), diag::warn_sycl_old_version);
+  if (SemaRef.LangOpts.SYCLVersion > 2017)
+    SemaRef.Diag(Caller->getLocation(),
+                 diag::warn_sycl_pass_by_value_deprecated);
+
   return KernelParamTy->getAsCXXRecordDecl();
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -748,6 +748,7 @@ static void checkKernelAndCaller(Sema &SemaRef, FunctionDecl *Caller,
   }
 
   // check that calling kernel conforms to spec
+  assert(Caller->param_size() >= 1 && "missing kernel function argument.");
   QualType KernelParamTy = (*Caller->param_begin())->getType();
   if (KernelParamTy->isReferenceType()) {
     // passing by reference, so emit warning if not using SYCL 2020

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -260,26 +260,26 @@ public:
 
 #define ATTR_SYCL_KERNEL __attribute__((sycl_kernel))
 template <typename KernelName = auto_name, typename KernelType>
-ATTR_SYCL_KERNEL void kernel_single_task(KernelType kernelFunc) {
+ATTR_SYCL_KERNEL void kernel_single_task(const KernelType &kernelFunc) {
   kernelFunc();
 }
 
 template <typename KernelName, typename KernelType, int Dims>
 ATTR_SYCL_KERNEL void
-kernel_parallel_for(KernelType KernelFunc) {
+kernel_parallel_for(const KernelType &KernelFunc) {
   KernelFunc(id<Dims>());
 }
 
 template <typename KernelName, typename KernelType, int Dims>
 ATTR_SYCL_KERNEL void
-kernel_parallel_for_work_group(KernelType KernelFunc) {
+kernel_parallel_for_work_group(const KernelType &KernelFunc) {
   KernelFunc(group<Dims>());
 }
 
 class handler {
 public:
   template <typename KernelName = auto_name, typename KernelType, int Dims>
-  void parallel_for(range<Dims> numWorkItems, KernelType kernelFunc) {
+  void parallel_for(range<Dims> numWorkItems, const KernelType &kernelFunc) {
     using NameT = typename get_kernel_name_t<KernelName, KernelType>::name;
 #ifdef __SYCL_DEVICE_ONLY__
     kernel_parallel_for<NameT, KernelType, Dims>(kernelFunc);
@@ -289,7 +289,7 @@ public:
   }
 
   template <typename KernelName = auto_name, typename KernelType, int Dims>
-  void parallel_for_work_group(range<Dims> numWorkGroups, range<Dims> WorkGroupSize, KernelType kernelFunc) {
+  void parallel_for_work_group(range<Dims> numWorkGroups, range<Dims> WorkGroupSize, const KernelType &kernelFunc) {
     using NameT = typename get_kernel_name_t<KernelName, KernelType>::name;
 #ifdef __SYCL_DEVICE_ONLY__
     kernel_parallel_for_work_group<NameT, KernelType, Dims>(kernelFunc);
@@ -300,7 +300,7 @@ public:
   }
 
   template <typename KernelName = auto_name, typename KernelType>
-  void single_task(KernelType kernelFunc) {
+  void single_task(const KernelType &kernelFunc) {
     using NameT = typename get_kernel_name_t<KernelName, KernelType>::name;
 #ifdef __SYCL_DEVICE_ONLY__
     kernel_single_task<NameT>(kernelFunc);

--- a/clang/test/CodeGenSYCL/address-space-cond-op.cpp
+++ b/clang/test/CodeGenSYCL/address-space-cond-op.cpp
@@ -24,7 +24,7 @@ S foo(bool cond, S &lhs, S rhs) {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/address-space-new.cpp
+++ b/clang/test/CodeGenSYCL/address-space-new.cpp
@@ -110,12 +110,10 @@ void test() {
   // CHECK: call spir_func void @{{.*}}bar{{.*}}(%struct.{{.*}}.HasX addrspace(4)* align 4 dereferenceable(4) %[[SECOND]])
 }
 
-
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
-
 
 int main() {
   kernel_single_task<class fake_kernel>([]() { test(); });

--- a/clang/test/CodeGenSYCL/address-space-new.cpp
+++ b/clang/test/CodeGenSYCL/address-space-new.cpp
@@ -112,7 +112,7 @@ void test() {
 
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/address-space-of-returns.cpp
+++ b/clang/test/CodeGenSYCL/address-space-of-returns.cpp
@@ -29,7 +29,7 @@ A ret_agg() {
 // CHECK: define spir_func void @{{.*}}ret_agg{{.*}}(%struct.{{.*}}.A addrspace(4)* {{.*}} %agg.result)
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
@@ -195,7 +195,7 @@ void usages2() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 int main() {

--- a/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
@@ -6,7 +6,7 @@
 #include "sycl.hpp"
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/const-wg-init.cpp
+++ b/clang/test/CodeGenSYCL/const-wg-init.cpp
@@ -4,7 +4,7 @@
 
 template <typename KernelName, typename KernelType>
 __attribute__((sycl_kernel)) void
-kernel_parallel_for_work_group(KernelType KernelFunc) {
+kernel_parallel_for_work_group(const KernelType &KernelFunc) {
   cl::sycl::group<1> G;
   KernelFunc(G);
 }

--- a/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
@@ -11,7 +11,7 @@
 #include <sycl.hpp>
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/device-functions.cpp
+++ b/clang/test/CodeGenSYCL/device-functions.cpp
@@ -13,7 +13,7 @@ T bar(T arg) {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/device-variables.cpp
+++ b/clang/test/CodeGenSYCL/device-variables.cpp
@@ -11,7 +11,7 @@ static constexpr int my_array[1] = {42};
 void foo(const test_type &) {}
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
     kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
+++ b/clang/test/CodeGenSYCL/emit-kernel-in-virtual-func2.cpp
@@ -2,7 +2,7 @@
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
-    kernelFunc();
+  kernelFunc();
 }
 
 template <class TAR>

--- a/clang/test/CodeGenSYCL/esimd_metadata1.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata1.cpp
@@ -9,7 +9,7 @@
 // 3. Proper module !spirv.Source metadata is generated
 
 template <typename name, typename Func>
-void kernel(Func f) __attribute__((sycl_kernel)) {
+void kernel(const Func &f) __attribute__((sycl_kernel)) {
   f();
 }
 

--- a/clang/test/CodeGenSYCL/fpga_pipes.cpp
+++ b/clang/test/CodeGenSYCL/fpga_pipes.cpp
@@ -45,7 +45,7 @@ private:
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/inheritance.cpp
+++ b/clang/test/CodeGenSYCL/inheritance.cpp
@@ -24,7 +24,7 @@ public:
 struct derived : base, second_base {
   int a;
 
-  void operator()() {
+  void operator()() const {
   }
 };
 

--- a/clang/test/CodeGenSYCL/inline_asm.cpp
+++ b/clang/test/CodeGenSYCL/inline_asm.cpp
@@ -3,7 +3,7 @@
 class kernel;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [100 x i32], align 4
   // CHECK: %[[IDX:.*]] = getelementptr inbounds [100 x i32], [100 x i32]* %[[ARRAY_A]], i64 0, i64 0
   int a[100], i = 0;

--- a/clang/test/CodeGenSYCL/inlining.cpp
+++ b/clang/test/CodeGenSYCL/inlining.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice %s -S -emit-llvm -o - | FileCheck %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -22,7 +22,7 @@
 #include "sycl.hpp"
 
 template <typename KernelName, typename KernelType>
-__attribute__((sycl_kernel)) void kernel_single_task(KernelType kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const KernelType &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/int_header_inline_ns.cpp
+++ b/clang/test/CodeGenSYCL/int_header_inline_ns.cpp
@@ -8,7 +8,7 @@
 #include "sycl.hpp"
 
 template <typename KernelName, typename KernelType>
-__attribute__((sycl_kernel)) void kernel_single_task(KernelType kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const KernelType &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -68,7 +68,7 @@
 #include "sycl.hpp"
 
 template <typename KernelName, typename KernelType>
-__attribute__((sycl_kernel)) void kernel_single_task(KernelType kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const KernelType &kernelFunc) {
   kernelFunc();
 }
 struct x {};

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
@@ -178,7 +178,7 @@ void ivdep_struct() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
@@ -148,7 +148,7 @@ void ivdep_embedded_multiple_dimensions() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
@@ -80,7 +80,7 @@ void ivdep_conflicting_safelen() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -256,7 +256,7 @@ void field_addrspace_cast() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -95,7 +95,7 @@ void speculated_iterations() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-fpga-mem-builtin.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-mem-builtin.cpp
@@ -71,7 +71,7 @@ void foo(float *A, int *B, State *C, State &D) {
 // CHECK-DAG: attributes [[ATT]] = { readnone }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-no-global-work-offset.cpp
@@ -2,11 +2,11 @@
 
 class Foo {
 public:
-  [[intelfpga::no_global_work_offset(1)]] void operator()() {}
+  [[intelfpga::no_global_work_offset(1)]] void operator()() const {}
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-reg.cpp
@@ -143,7 +143,7 @@ void foo() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/CodeGenSYCL/intel-max-global-work-dim.cpp
@@ -2,11 +2,11 @@
 
 class Foo {
 public:
-  [[intelfpga::max_global_work_dim(1)]] void operator()() {}
+  [[intelfpga::max_global_work_dim(1)]] void operator()() const {}
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
@@ -2,11 +2,11 @@
 
 class Foo {
 public:
-  [[intelfpga::max_work_group_size(1, 1, 1)]] void operator()() {}
+  [[intelfpga::max_work_group_size(1, 1, 1)]] void operator()() const {}
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/intel-restrict.cpp
+++ b/clang/test/CodeGenSYCL/intel-restrict.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device %s -emit-llvm -triple spir64-unknown-unknown-sycldevice -o - | FileCheck %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/kernel-by-reference.cpp
+++ b/clang/test/CodeGenSYCL/kernel-by-reference.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only %s
+
+// SYCL 1.2 - kernel functions passed directly. (Also no const requirement, though mutable lambdas never supported)
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void sycl_12_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+// SYCL 2020 - kernel functions are passed by reference.
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void sycl_2020_single_task(const Func &kernelFunc) {
+  kernelFunc();
+}
+
+int do_nothing(int i) {
+  return i + 1;
+}
+
+// ensure both compile.
+int main() {
+  sycl_12_single_task<class sycl12>([]() {
+    do_nothing(10);
+  });
+
+  sycl_2020_single_task<class sycl2020>([]() {
+    do_nothing(11);
+  });
+
+  // expected-no-diagnostics
+  return 0;
+}

--- a/clang/test/CodeGenSYCL/kernel-by-reference.cpp
+++ b/clang/test/CodeGenSYCL/kernel-by-reference.cpp
@@ -6,7 +6,7 @@
 // SYCL 1.2/2017 - kernel functions passed directly. (Also no const requirement, though mutable lambdas never supported)
 template <typename name, typename Func>
 #if defined(SYCL2020)
-// expected-warning@+2 {{Pass-by-value of kernel functions is deprecated in SYCL 2020.}}
+// expected-warning@+2 {{Passing kernel functions by value is deprecated in SYCL 2020.}}
 #endif
 __attribute__((sycl_kernel)) void sycl_2017_single_task(Func kernelFunc) {
   kernelFunc();
@@ -15,7 +15,7 @@ __attribute__((sycl_kernel)) void sycl_2017_single_task(Func kernelFunc) {
 // SYCL 2020 - kernel functions are passed by reference.
 template <typename name, typename Func>
 #if defined(SYCL2017)
-// expected-warning@+2 {{Pass-by-reference of kernel functions requires SYCL 2020, and does not conform to SYCL 1.2.1}}
+// expected-warning@+2 {{Passing of kernel functions by reference is a SYCL 2020 extension.}}
 #endif
 __attribute__((sycl_kernel)) void sycl_2020_single_task(const Func &kernelFunc) {
   kernelFunc();

--- a/clang/test/CodeGenSYCL/kernel-by-reference.cpp
+++ b/clang/test/CodeGenSYCL/kernel-by-reference.cpp
@@ -6,7 +6,7 @@
 // SYCL 1.2/2017 - kernel functions passed directly. (Also no const requirement, though mutable lambdas never supported)
 template <typename name, typename Func>
 #if defined(SYCL2020)
-// expected-warning@+2 {{Passing kernel functions by value is deprecated in SYCL 2020.}}
+// expected-warning@+2 {{Passing kernel functions by value is deprecated in SYCL 2020}}
 #endif
 __attribute__((sycl_kernel)) void sycl_2017_single_task(Func kernelFunc) {
   kernelFunc();
@@ -15,7 +15,7 @@ __attribute__((sycl_kernel)) void sycl_2017_single_task(Func kernelFunc) {
 // SYCL 2020 - kernel functions are passed by reference.
 template <typename name, typename Func>
 #if defined(SYCL2017)
-// expected-warning@+2 {{Passing of kernel functions by reference is a SYCL 2020 extension.}}
+// expected-warning@+2 {{Passing of kernel functions by reference is a SYCL 2020 extension}}
 #endif
 __attribute__((sycl_kernel)) void sycl_2020_single_task(const Func &kernelFunc) {
   kernelFunc();

--- a/clang/test/CodeGenSYCL/kernel-by-reference.cpp
+++ b/clang/test/CodeGenSYCL/kernel-by-reference.cpp
@@ -1,9 +1,14 @@
-// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only -sycl-std=2017 -DNODIAG %s
+// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only -sycl-std=2020 -DSYCL2020 %s
+// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only -Wno-sycl-strict -DNODIAG %s
+// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only -sycl-std=2020 -Wno-sycl-strict -DNODIAG %s
 
-// SYCL 1.2 - kernel functions passed directly. (Also no const requirement, though mutable lambdas never supported)
+// SYCL 1.2/2017 - kernel functions passed directly. (Also no const requirement, though mutable lambdas never supported)
 template <typename name, typename Func>
-// expected-warning@+1 {{Older version of SYCL headers encountered.}}
-__attribute__((sycl_kernel)) void sycl_12_single_task(Func kernelFunc) {
+#if defined(SYCL2020)
+// expected-warning@+2 {{Pass-by-value of kernel functions is deprecated in SYCL 2020.}}
+#endif
+__attribute__((sycl_kernel)) void sycl_2017_single_task(Func kernelFunc) {
   kernelFunc();
 }
 
@@ -19,7 +24,7 @@ int do_nothing(int i) {
 
 // ensure both compile.
 int main() {
-  sycl_12_single_task<class sycl12>([]() {
+  sycl_2017_single_task<class sycl12>([]() {
     do_nothing(10);
   });
 
@@ -29,3 +34,6 @@ int main() {
 
   return 0;
 }
+#if defined(NODIAG)
+// expected-no-diagnostics
+#endif

--- a/clang/test/CodeGenSYCL/kernel-by-reference.cpp
+++ b/clang/test/CodeGenSYCL/kernel-by-reference.cpp
@@ -2,6 +2,7 @@
 
 // SYCL 1.2 - kernel functions passed directly. (Also no const requirement, though mutable lambdas never supported)
 template <typename name, typename Func>
+// expected-warning@+1 {{Older version of SYCL headers encountered.}}
 __attribute__((sycl_kernel)) void sycl_12_single_task(Func kernelFunc) {
   kernelFunc();
 }
@@ -26,6 +27,5 @@ int main() {
     do_nothing(11);
   });
 
-  // expected-no-diagnostics
   return 0;
 }

--- a/clang/test/CodeGenSYCL/kernel-by-reference.cpp
+++ b/clang/test/CodeGenSYCL/kernel-by-reference.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only -sycl-std=2017 -DNODIAG %s
+// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only -sycl-std=2017 -DSYCL2017 %s
 // RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only -sycl-std=2020 -DSYCL2020 %s
 // RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only -Wno-sycl-strict -DNODIAG %s
 // RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only -sycl-std=2020 -Wno-sycl-strict -DNODIAG %s
@@ -14,6 +14,9 @@ __attribute__((sycl_kernel)) void sycl_2017_single_task(Func kernelFunc) {
 
 // SYCL 2020 - kernel functions are passed by reference.
 template <typename name, typename Func>
+#if defined(SYCL2017)
+// expected-warning@+2 {{Pass-by-reference of kernel functions requires SYCL 2020, and does not conform to SYCL 1.2.1}}
+#endif
 __attribute__((sycl_kernel)) void sycl_2020_single_task(const Func &kernelFunc) {
   kernelFunc();
 }

--- a/clang/test/CodeGenSYCL/kernel-name.cpp
+++ b/clang/test/CodeGenSYCL/kernel-name.cpp
@@ -9,7 +9,7 @@ inline namespace cl {
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
@@ -37,7 +37,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void a_kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void a_kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/kernel-param-acc-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-acc-array.cpp
@@ -7,7 +7,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void a_kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void a_kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
@@ -37,7 +37,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void a_kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void a_kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/kernel-param-member-acc-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-member-acc-array.cpp
@@ -7,7 +7,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void a_kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void a_kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
@@ -39,7 +39,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void a_kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void a_kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/kernel-param-pod-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-pod-array.cpp
@@ -7,7 +7,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void a_kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void a_kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/kernel_functor.cpp
+++ b/clang/test/CodeGenSYCL/kernel_functor.cpp
@@ -9,32 +9,9 @@ constexpr auto sycl_read_write = cl::sycl::access::mode::read_write;
 constexpr auto sycl_global_buffer = cl::sycl::access::target::global_buffer;
 
 // Case 1:
-// - functor class is defined in an anonymous namespace
-// - the '()' operator:
-//   * does not have parameters (to be used in 'single_task').
-//   * has no 'const' qualifier
-namespace {
-  class Functor1 {
-  public:
-    Functor1(int X_, cl::sycl::accessor<int, 1, sycl_read_write, sycl_global_buffer> &Acc_) :
-      X(X_), Acc(Acc_)
-    {}
-
-    void operator()() {
-      Acc.use(X);
-    }
-
-  private:
-    int X;
-    cl::sycl::accessor<int, 1, sycl_read_write, sycl_global_buffer> Acc;
-  };
-}
-
-// Case 2:
 // - functor class is defined in a namespace
 // - the '()' operator:
 //   * does not have parameters (to be used in 'single_task').
-//   * has the 'const' qualifier
 namespace ns {
   class Functor2 {
   public:
@@ -52,31 +29,10 @@ namespace ns {
   };
 }
 
-// Case 3:
+// Case 2:
 // - functor class is templated and defined in the translation unit scope
 // - the '()' operator:
 //   * has a parameter of type cl::sycl::id<1> (to be used in 'parallel_for').
-//   * has no 'const' qualifier
-template <typename T> class TmplFunctor {
-public:
-  TmplFunctor(T X_, cl::sycl::accessor<T, 1, sycl_read_write, sycl_global_buffer> &Acc_) :
-    X(X_), Acc(Acc_)
-  {}
-
-  void operator()(cl::sycl::id<1> id) {
-    Acc.use(id, X);
-  }
-
-private:
-  T X;
-  cl::sycl::accessor<T, 1, sycl_read_write, sycl_global_buffer> Acc;
-};
-
-// Case 4:
-// - functor class is templated and defined in the translation unit scope
-// - the '()' operator:
-//   * has a parameter of type cl::sycl::id<1> (to be used in 'parallel_for').
-//   * has the 'const' qualifier
 template <typename T> class TmplConstFunctor {
 public:
   TmplConstFunctor(T X_, cl::sycl::accessor<T, 1, sycl_read_write, sycl_global_buffer> &Acc_) :
@@ -101,12 +57,6 @@ int foo(int X) {
 
     Q.submit([&](cl::sycl::handler& cgh) {
       auto Acc = Buf.get_access<sycl_read_write, sycl_global_buffer>(cgh);
-      Functor1 F(X, Acc);
-
-      cgh.single_task(F);
-    });
-    Q.submit([&](cl::sycl::handler& cgh) {
-      auto Acc = Buf.get_access<sycl_read_write, sycl_global_buffer>(cgh);
       ns::Functor2 F(X, Acc);
 
       cgh.single_task(F);
@@ -129,13 +79,6 @@ template <typename T> T bar(T X) {
   {
     cl::sycl::queue Q;
     cl::sycl::buffer<T, 1> Buf(A, ARR_LEN(A));
-
-    Q.submit([&](cl::sycl::handler& cgh) {
-      auto Acc = Buf.template get_access<sycl_read_write, sycl_global_buffer>(cgh);
-      TmplFunctor<T> F(X, Acc);
-
-      cgh.parallel_for(cl::sycl::range<1>(ARR_LEN(A)), F);
-    });
     // Spice with lambdas to make sure functors and lambdas work together.
     Q.submit([&](cl::sycl::handler& cgh) {
       auto Acc = Buf.template get_access<sycl_read_write, sycl_global_buffer>(cgh);
@@ -165,12 +108,8 @@ int main() {
   const int Gold2 = 80;
 
 #ifndef __SYCL_DEVICE_ONLY__
-  cl::sycl::detail::KernelInfo<Functor1>::getName();
-  // CHECK: Functor1
   cl::sycl::detail::KernelInfo<ns::Functor2>::getName();
   // CHECK: ns::Functor2
-  cl::sycl::detail::KernelInfo<TmplFunctor<int>>::getName();
-  // CHECK: TmplFunctor<int>
   cl::sycl::detail::KernelInfo<TmplConstFunctor<int>>::getName();
   // CHECK: TmplConstFunctor<int>
 #endif // __SYCL_DEVICE_ONLY__

--- a/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
+++ b/clang/test/CodeGenSYCL/kernel_name_with_typedefs.cpp
@@ -4,12 +4,12 @@
 #include "sycl.hpp"
 
 template <typename KernelName, typename KernelType>
-__attribute__((sycl_kernel)) void single_task(KernelType kernelFunc) {
+__attribute__((sycl_kernel)) void single_task(const KernelType &kernelFunc) {
   kernelFunc();
 }
 
 struct dummy_functor {
-  void operator()() {}
+  void operator()() const {}
 };
 
 typedef int int_t;

--- a/clang/test/CodeGenSYCL/kernelname-enum.cpp
+++ b/clang/test/CodeGenSYCL/kernelname-enum.cpp
@@ -40,43 +40,43 @@ enum class no_type_set {
 template <no_namespace_int EnumType>
 class dummy_functor_1 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <no_namespace_short EnumType>
 class dummy_functor_2 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <internal::namespace_short EnumType>
 class dummy_functor_3 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <enum_in_anonNS EnumType>
 class dummy_functor_4 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <no_type_set EnumType>
 class dummy_functor_5 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <unscoped_enum EnumType>
 class dummy_functor_6 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <typename EnumType>
 class dummy_functor_7 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 namespace type_argument_template_enum {
@@ -105,7 +105,7 @@ class Baz;
 template <typename EnumTypeOut, template <EnumValueIn EnumValue, typename EnumTypeIn> class T>
 class dummy_functor_8 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 int main() {

--- a/clang/test/CodeGenSYCL/loop_unroll.cpp
+++ b/clang/test/CodeGenSYCL/loop_unroll.cpp
@@ -30,7 +30,7 @@ void disable() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/module-id.cpp
+++ b/clang/test/CodeGenSYCL/module-id.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/noexcept.cpp
+++ b/clang/test/CodeGenSYCL/noexcept.cpp
@@ -48,7 +48,7 @@ void foo_cleanup() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/num-simd-work-items.cpp
+++ b/clang/test/CodeGenSYCL/num-simd-work-items.cpp
@@ -2,11 +2,11 @@
 
 class Foo {
 public:
-  [[intelfpga::num_simd_work_items(1)]] void operator()() {}
+  [[intelfpga::num_simd_work_items(1)]] void operator()() const {}
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/remove-ur-inst.cpp
+++ b/clang/test/CodeGenSYCL/remove-ur-inst.cpp
@@ -3,7 +3,7 @@
 SYCL_EXTERNAL void doesNotReturn() throw() __attribute__((__noreturn__));
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
@@ -2,14 +2,14 @@
 
 class Functor16 {
 public:
-  [[cl::intel_reqd_sub_group_size(16)]] void operator()() {}
+  [[cl::intel_reqd_sub_group_size(16)]] void operator()() const {}
 };
 
 [[cl::intel_reqd_sub_group_size(8)]] void foo() {}
 
 class Functor {
 public:
-  void operator()() {
+  void operator()() const {
     foo();
   }
 };
@@ -17,11 +17,11 @@ public:
 template <int SIZE>
 class Functor5 {
 public:
-  [[cl::intel_reqd_sub_group_size(SIZE)]] void operator()() {}
+  [[cl::intel_reqd_sub_group_size(SIZE)]] void operator()() const {}
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
@@ -2,20 +2,20 @@
 
 class Functor32x16x16 {
 public:
-  [[cl::reqd_work_group_size(32, 16, 16)]] void operator()() {}
+  [[cl::reqd_work_group_size(32, 16, 16)]] void operator()() const {}
 };
 
 [[cl::reqd_work_group_size(8, 1, 1)]] void f8x1x1() {}
 
 class Functor {
 public:
-  void operator()() {
+  void operator()() const {
     f8x1x1();
   }
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/sampler.cpp
+++ b/clang/test/CodeGenSYCL/sampler.cpp
@@ -43,7 +43,7 @@ struct sampler_wrapper {
 };
 
 template <typename KernelName, typename KernelType>
-__attribute__((sycl_kernel)) void kernel_single_task(KernelType kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const KernelType &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/spir-calling-conv.cpp
+++ b/clang/test/CodeGenSYCL/spir-calling-conv.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/spir-enum.cpp
+++ b/clang/test/CodeGenSYCL/spir-enum.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/spir-opencl-version.cpp
+++ b/clang/test/CodeGenSYCL/spir-opencl-version.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/sycl-device-static-init.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device-static-init.cpp
@@ -28,7 +28,7 @@ template <class T>
 const int BaseInit<T>::var = 9;
 template struct BaseInit<TestBaseType>;
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 int main() {

--- a/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
+++ b/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
@@ -5,7 +5,6 @@ public:
   [[cl::intel_reqd_sub_group_size(4), cl::reqd_work_group_size(32, 16, 16)]] void operator()() const {}
 };
 
-
 template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();

--- a/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
+++ b/clang/test/CodeGenSYCL/sycl-multi-kernel-attr.cpp
@@ -2,12 +2,12 @@
 
 class Functor {
 public:
-  [[cl::intel_reqd_sub_group_size(4), cl::reqd_work_group_size(32, 16, 16)]] void operator()() {}
+  [[cl::intel_reqd_sub_group_size(4), cl::reqd_work_group_size(32, 16, 16)]] void operator()() const {}
 };
 
 
 template <typename Name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/unique-stable-name.cpp
+++ b/clang/test/CodeGenSYCL/unique-stable-name.cpp
@@ -33,7 +33,7 @@ void lambda_in_dependent_function() {
   {DEF_IN_MACRO();}{DEF_IN_MACRO();}
 
 template <typename KernelName, typename KernelType>
-[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) {
+[[clang::sycl_kernel]] void kernel_single_task(const KernelType &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/usm-int-header.cpp
+++ b/clang/test/CodeGenSYCL/usm-int-header.cpp
@@ -17,7 +17,7 @@
 #include <sycl.hpp>
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/virtual-types.cpp
+++ b/clang/test/CodeGenSYCL/virtual-types.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-linux-sycldevice -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/CodeGenSYCL/wrapped-accessor.cpp
+++ b/clang/test/CodeGenSYCL/wrapped-accessor.cpp
@@ -34,7 +34,7 @@ template <typename Acc>
 struct AccWrapper { Acc accessor; };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -192,13 +192,13 @@ struct get_kernel_name_t<auto_name, Type> {
 };
 #define ATTR_SYCL_KERNEL __attribute__((sycl_kernel))
 template <typename KernelName = auto_name, typename KernelType>
-ATTR_SYCL_KERNEL void kernel_single_task(KernelType kernelFunc) {
+ATTR_SYCL_KERNEL void kernel_single_task(const KernelType &kernelFunc) {
   kernelFunc();
 }
 class handler {
 public:
   template <typename KernelName = auto_name, typename KernelType>
-  void single_task(KernelType kernelFunc) {
+  void single_task(const KernelType &kernelFunc) {
     using NameT = typename get_kernel_name_t<KernelName, KernelType>::name;
 #ifdef __SYCL_DEVICE_ONLY__
     kernel_single_task<NameT>(kernelFunc);

--- a/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
+++ b/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -triple spir64 -fsycl-is-device -verify -fsyntax-only  %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -triple spir64 -fsycl-is-device -verify -fsyntax-only -Wno-sycl-2017-conform  %s
 //
 // Ensure SYCL type restrictions are applied to accessors as well.
 

--- a/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
+++ b/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
@@ -7,7 +7,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
+++ b/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -triple spir64 -fsycl-is-device -verify -fsyntax-only -Wno-sycl-2017-conform  %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -triple spir64 -fsycl-is-device -verify -fsyntax-only -Wno-sycl-2017-compat  %s
 //
 // Ensure SYCL type restrictions are applied to accessors as well.
 

--- a/clang/test/SemaSYCL/accessors-targets-image.cpp
+++ b/clang/test/SemaSYCL/accessors-targets-image.cpp
@@ -8,7 +8,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/accessors-targets.cpp
+++ b/clang/test/SemaSYCL/accessors-targets.cpp
@@ -8,7 +8,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/allow-constexpr-recursion.cpp
+++ b/clang/test/SemaSYCL/allow-constexpr-recursion.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-conform -verify -fsyntax-only -std=c++20 -Werror=vla %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-compat -verify -fsyntax-only -std=c++20 -Werror=vla %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {

--- a/clang/test/SemaSYCL/allow-constexpr-recursion.cpp
+++ b/clang/test/SemaSYCL/allow-constexpr-recursion.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -fsyntax-only -std=c++20 -Werror=vla %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/allow-constexpr-recursion.cpp
+++ b/clang/test/SemaSYCL/allow-constexpr-recursion.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -fsyntax-only -std=c++20 -Werror=vla %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-conform -verify -fsyntax-only -std=c++20 -Werror=vla %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {

--- a/clang/test/SemaSYCL/array-kernel-param-neg.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param-neg.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-sycl-2017-conform -verify -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // an array of non-trivially copyable structs as SYCL kernel parameter or

--- a/clang/test/SemaSYCL/array-kernel-param-neg.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param-neg.cpp
@@ -20,11 +20,11 @@ class E {
   int i[];
 
 public:
-  int operator()() { return i[0]; }
+  int operator()() const { return i[0]; }
 };
 
 template <typename Name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/array-kernel-param-neg.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param-neg.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-sycl-2017-conform -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-sycl-2017-compat -verify -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // an array of non-trivially copyable structs as SYCL kernel parameter or

--- a/clang/test/SemaSYCL/array-kernel-param.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param.cpp
@@ -8,7 +8,7 @@
 using namespace cl::sycl;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void a_kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void a_kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
@@ -9,7 +9,7 @@ template <typename Acc>
 struct AccWrapper { Acc accessor; };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
@@ -6,7 +6,7 @@
 #include <sycl.hpp>
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/call-to-undefined-function.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function.cpp
@@ -9,7 +9,7 @@ void undefined();
 SYCL_EXTERNAL void undefinedExternal();
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/call-to-undefined-function.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-compat -verify -fsyntax-only %s
 
 void defined() {
 }

--- a/clang/test/SemaSYCL/call-to-undefined-function.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -verify -fsyntax-only %s
 
 void defined() {
 }

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -aux-triple x86_64-unknown-linux-gnu -verify -fsyntax-only  %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -aux-triple x86_64-unknown-linux-gnu -Wno-sycl-2017-conform -verify -fsyntax-only  %s
 
 inline namespace cl {
 namespace sycl {

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -aux-triple x86_64-unknown-linux-gnu -Wno-sycl-2017-conform -verify -fsyntax-only  %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -aux-triple x86_64-unknown-linux-gnu -Wno-sycl-2017-compat -verify -fsyntax-only  %s
 
 inline namespace cl {
 namespace sycl {

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -4,7 +4,7 @@ inline namespace cl {
 namespace sycl {
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-note@+1 {{called by 'kernel_single_task<AName, (lambda}}
   kernelFunc();
 }

--- a/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
@@ -12,7 +12,7 @@ inline namespace cl {
 namespace sycl {
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-note@+1 3{{called by 'kernel_single_task<AName, (lambda}}
   kernelFunc();
 }

--- a/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1  -fsycl -triple spir64 -fsycl-is-device -verify -fsyntax-only  %s
+// RUN: %clang_cc1  -fsycl -triple spir64 -fsycl-is-device -Wno-sycl-2017-conform -verify -fsyntax-only  %s
 //
 // Ensure that the SYCL diagnostics that are typically deferred are correctly emitted.
 

--- a/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1  -fsycl -triple spir64 -fsycl-is-device -Wno-sycl-2017-conform -verify -fsyntax-only  %s
+// RUN: %clang_cc1  -fsycl -triple spir64 -fsycl-is-device -Wno-sycl-2017-compat -verify -fsyntax-only  %s
 //
 // Ensure that the SYCL diagnostics that are typically deferred are correctly emitted.
 

--- a/clang/test/SemaSYCL/fake-accessors.cpp
+++ b/clang/test/SemaSYCL/fake-accessors.cpp
@@ -26,7 +26,7 @@ using MyAccessorA = cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_writ
                                        cl::sycl::access::target::global_buffer>;
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/float128.cpp
+++ b/clang/test/SemaSYCL/float128.cpp
@@ -63,7 +63,7 @@ void foo2(){};
 __float128 foo(__float128 P) { return P; }
 
 template <typename Name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   // expected-note@+1 6{{called by 'kernel}}
   kernelFunc();
 }

--- a/clang/test/SemaSYCL/float128.cpp
+++ b/clang/test/SemaSYCL/float128.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -verify -fsyntax-only %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl -fsycl-is-device -fsyntax-only %s
+// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -verify -fsyntax-only %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl -fsycl-is-device -Wno-sycl-2017-conform -fsyntax-only %s
 
 typedef __float128 BIGTY;
 

--- a/clang/test/SemaSYCL/float128.cpp
+++ b/clang/test/SemaSYCL/float128.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -verify -fsyntax-only %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl -fsycl-is-device -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -triple spir64 -fsycl -fsycl-is-device -Wno-sycl-2017-compat -verify -fsyntax-only %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl -fsycl-is-device -Wno-sycl-2017-compat -fsyntax-only %s
 
 typedef __float128 BIGTY;
 

--- a/clang/test/SemaSYCL/forward-decl.cpp
+++ b/clang/test/SemaSYCL/forward-decl.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -pedantic %s
 
 // expected-no-diagnostics
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/forward-decl.cpp
+++ b/clang/test/SemaSYCL/forward-decl.cpp
@@ -2,7 +2,7 @@
 
 // expected-no-diagnostics
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/forward-decl.cpp
+++ b/clang/test/SemaSYCL/forward-decl.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify -pedantic %s
 
 // expected-no-diagnostics
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/fpga_pipes.cpp
+++ b/clang/test/SemaSYCL/fpga_pipes.cpp
@@ -34,7 +34,7 @@ template <int N>
 pipe_storage Storage5 __attribute__((io_pipe_id(N)));
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/implicit_kernel_type.cpp
+++ b/clang/test/SemaSYCL/implicit_kernel_type.cpp
@@ -1,13 +1,43 @@
 // RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -verify %s -Werror=sycl-strict -DERROR
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -verify %s -Wsycl-strict -DWARN
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsycl-unnamed-lambda -fsyntax-only -verify %s -Werror=sycl-strict
-#include <sycl.hpp>
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -verify %s  -Wsycl-strict -DWARN
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsycl-unnamed-lambda -fsyntax-only -verify %s  -Werror=sycl-strict
+
+// SYCL 1.2 Definitions
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void sycl_121_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+class event {};
+class queue {
+public:
+  template <typename T>
+  event submit(T cgf) { return event{}; }
+};
+class auto_name {};
+template <typename Name, typename Type>
+struct get_kernel_name_t {
+  using name = Name;
+};
+class handler {
+public:
+  template <typename KernelName = auto_name, typename KernelType>
+  void single_task(KernelType kernelFunc) {
+    using NameT = typename get_kernel_name_t<KernelName, KernelType>::name;
+#ifdef __SYCL_DEVICE_ONLY__
+    sycl_121_single_task<NameT>(kernelFunc);
+#else
+    kernelFunc();
+#endif
+  }
+};
+// -- /Definitions
 
 #ifdef __SYCL_UNNAMED_LAMBDA__
 // expected-no-diagnostics
 #endif
 
-using namespace cl::sycl;
+//using namespace cl::sycl;
 
 void function() {
 }
@@ -20,11 +50,11 @@ struct myWrapper {
 class myWrapper2;
 
 int main() {
-  cl::sycl::queue q;
+  queue q;
 #ifndef __SYCL_UNNAMED_LAMBDA__
   // expected-note@+1 {{InvalidKernelName1 declared here}}
   class InvalidKernelName1 {};
-  q.submit([&](cl::sycl::handler &h) {
+  q.submit([&](handler &h) {
     // expected-error@+1 {{kernel needs to have a globally-visible name}}
     h.single_task<InvalidKernelName1>([]() {});
   });
@@ -36,7 +66,7 @@ int main() {
   // expected-error@+3 {{SYCL 1.2.1 specification requires an explicit forward declaration for a kernel type name; your program may not be portable}}
   // expected-note@+2 {{fake_kernel declared here}}
 #endif
-  cl::sycl::kernel_single_task<class fake_kernel>([]() { function(); });
+  sycl_121_single_task<class fake_kernel>([]() { function(); });
 #if defined(WARN)
   // expected-warning@+6 {{SYCL 1.2.1 specification requires an explicit forward declaration for a kernel type name; your program may not be portable}}
   // expected-note@+5 {{fake_kernel2 declared here}}
@@ -44,10 +74,10 @@ int main() {
   // expected-error@+3 {{SYCL 1.2.1 specification requires an explicit forward declaration for a kernel type name; your program may not be portable}}
   // expected-note@+2 {{fake_kernel2 declared here}}
 #endif
-  cl::sycl::kernel_single_task<class fake_kernel2>([]() {
+  sycl_121_single_task<class fake_kernel2>([]() {
     auto l = [](auto f) { f(); };
   });
-  cl::sycl::kernel_single_task<class myWrapper>([]() { function(); });
-  cl::sycl::kernel_single_task<class myWrapper2>([]() { function(); });
+  sycl_121_single_task<class myWrapper>([]() { function(); });
+  sycl_121_single_task<class myWrapper2>([]() { function(); });
   return 0;
 }

--- a/clang/test/SemaSYCL/inheritance.cpp
+++ b/clang/test/SemaSYCL/inheritance.cpp
@@ -24,7 +24,7 @@ public:
 struct derived : base, second_base {
   int a;
 
-  void operator()() {
+  void operator()() const {
   }
 };
 

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify %s -DLINUX_ASM
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify %s -DLINUX_ASM -DSPIR_CHECK -triple spir64-unknown-unknown-sycldevice
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -triple x86_64-windows -fasm-blocks %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s -DLINUX_ASM
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s -DLINUX_ASM -DSPIR_CHECK -triple spir64-unknown-unknown-sycldevice
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -triple x86_64-windows -fasm-blocks %s
 
 #ifndef SPIR_CHECK
 //expected-no-diagnostics

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s -DLINUX_ASM
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s -DLINUX_ASM -DSPIR_CHECK -triple spir64-unknown-unknown-sycldevice
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -triple x86_64-windows -fasm-blocks %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s -DLINUX_ASM
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s -DLINUX_ASM -DSPIR_CHECK -triple spir64-unknown-unknown-sycldevice
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify -triple x86_64-windows -fasm-blocks %s
 
 #ifndef SPIR_CHECK
 //expected-no-diagnostics

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -50,7 +50,7 @@ void bar() {
 }
 
 template <typename Name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 #ifdef LINUX_ASM
   __asm__("int3");

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -781,7 +781,7 @@ struct templ_st {
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -fcxx-exceptions -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -fcxx-exceptions -fsyntax-only -ast-dump -Wno-sycl-2017-conform -verify -pedantic %s | FileCheck %s
 
 //CHECK: FunctionDecl{{.*}}check_ast
 void check_ast()

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -fcxx-exceptions -fsyntax-only -ast-dump -Wno-sycl-2017-conform -verify -pedantic %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -fcxx-exceptions -fsyntax-only -ast-dump -Wno-sycl-2017-compat -verify -pedantic %s | FileCheck %s
 
 //CHECK: FunctionDecl{{.*}}check_ast
 void check_ast()

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -pedantic %s
 
 // Test for Intel FPGA loop attributes applied not to a loop
 void foo() {

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify -pedantic %s
 
 // Test for Intel FPGA loop attributes applied not to a loop
 void foo() {

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -371,7 +371,7 @@ void max_concurrency_dependent() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/intel-fpga-mem-builtin.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-mem-builtin.cpp
@@ -56,7 +56,7 @@ void foo(float *A, int *B, State *C) {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 int main() {

--- a/clang/test/SemaSYCL/intel-fpga-reg.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-reg.cpp
@@ -57,7 +57,7 @@ void foo() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 int main() {

--- a/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 -DTRIGGER_ERROR -verify
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 | FileCheck %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-host -Wno-sycl-2017-conform -fsyntax-only -verify %s
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -Wno-sycl-2017-compat -triple spir64 -DTRIGGER_ERROR -verify
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -Wno-sycl-2017-compat -triple spir64 | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-host -Wno-sycl-2017-compat -fsyntax-only -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {

--- a/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
@@ -5,7 +5,8 @@
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {
   [[intelfpga::max_global_work_dim(1)]] // expected-no-diagnostics
-  void operator()() const {}
+  void
+  operator()() const {}
 };
 
 template <typename name, typename Func>
@@ -24,22 +25,21 @@ void foo() {
 void func_ignore() {}
 
 struct FuncObj {
-  [[intelfpga::max_global_work_dim(1)]]
-  void operator()() const {}
+  [[intelfpga::max_global_work_dim(1)]] void operator()() const {}
 };
 
 struct TRIFuncObjGood1 {
   [[intelfpga::max_global_work_dim(0)]]
   [[intelfpga::max_work_group_size(1, 1, 1)]]
-  [[cl::reqd_work_group_size(1, 1, 1)]]
-  void operator()() const {}
+  [[cl::reqd_work_group_size(1, 1, 1)]] void
+  operator()() const {}
 };
 
 struct TRIFuncObjGood2 {
   [[intelfpga::max_global_work_dim(3)]]
   [[intelfpga::max_work_group_size(8, 1, 1)]]
-  [[cl::reqd_work_group_size(4, 1, 1)]]
-  void operator()() const {}
+  [[cl::reqd_work_group_size(4, 1, 1)]] void
+  operator()() const {}
 };
 
 #ifdef TRIGGER_ERROR
@@ -47,7 +47,8 @@ struct TRIFuncObjBad {
   [[intelfpga::max_global_work_dim(0)]]
   [[intelfpga::max_work_group_size(8, 8, 8)]] // expected-error{{'max_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
   [[cl::reqd_work_group_size(4, 4, 4)]] // expected-error{{'reqd_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
-  void operator()() const {}
+  void
+  operator()() const {}
 };
 #endif // TRIGGER_ERROR
 

--- a/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
@@ -46,7 +46,7 @@ struct TRIFuncObjGood2 {
 struct TRIFuncObjBad {
   [[intelfpga::max_global_work_dim(0)]]
   [[intelfpga::max_work_group_size(8, 8, 8)]] // expected-error{{'max_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
-  [[cl::reqd_work_group_size(4, 4, 4)]] // expected-error{{'reqd_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
+  [[cl::reqd_work_group_size(4, 4, 4)]]       // expected-error{{'reqd_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
   void
   operator()() const {}
 };

--- a/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
@@ -46,7 +46,7 @@ struct TRIFuncObjGood2 {
 struct TRIFuncObjBad {
   [[intelfpga::max_global_work_dim(0)]]
   [[intelfpga::max_work_group_size(8, 8, 8)]] // expected-error{{'max_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
-  [[cl::reqd_work_group_size(4, 4, 4)]]       // expected-error{{'reqd_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
+  [[cl::reqd_work_group_size(4, 4, 4)]] // expected-error{{'reqd_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
   void
   operator()() const {}
 };

--- a/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
@@ -5,11 +5,11 @@
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {
   [[intelfpga::max_global_work_dim(1)]] // expected-no-diagnostics
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <typename name, typename Func>
-void kernel(Func kernelFunc) {
+void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 
@@ -25,21 +25,21 @@ void func_ignore() {}
 
 struct FuncObj {
   [[intelfpga::max_global_work_dim(1)]]
-  void operator()() {}
+  void operator()() const {}
 };
 
 struct TRIFuncObjGood1 {
   [[intelfpga::max_global_work_dim(0)]]
   [[intelfpga::max_work_group_size(1, 1, 1)]]
   [[cl::reqd_work_group_size(1, 1, 1)]]
-  void operator()() {}
+  void operator()() const {}
 };
 
 struct TRIFuncObjGood2 {
   [[intelfpga::max_global_work_dim(3)]]
   [[intelfpga::max_work_group_size(8, 1, 1)]]
   [[cl::reqd_work_group_size(4, 1, 1)]]
-  void operator()() {}
+  void operator()() const {}
 };
 
 #ifdef TRIGGER_ERROR
@@ -47,12 +47,12 @@ struct TRIFuncObjBad {
   [[intelfpga::max_global_work_dim(0)]]
   [[intelfpga::max_work_group_size(8, 8, 8)]] // expected-error{{'max_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
   [[cl::reqd_work_group_size(4, 4, 4)]] // expected-error{{'reqd_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
-  void operator()() {}
+  void operator()() const {}
 };
 #endif // TRIGGER_ERROR
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -DTRIGGER_ERROR -verify
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 | FileCheck %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -verify %s
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 -DTRIGGER_ERROR -verify
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-host -Wno-sycl-2017-conform -fsyntax-only -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {

--- a/clang/test/SemaSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 -DTRIGGER_ERROR -verify
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 | FileCheck %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -Wno-sycl-2017-compat -triple spir64 -DTRIGGER_ERROR -verify
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -Wno-sycl-2017-compat -triple spir64 | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {

--- a/clang/test/SemaSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size.cpp
@@ -5,11 +5,11 @@
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {
   [[intelfpga::max_work_group_size(1, 1, 1)]] // expected-no-diagnostics
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <typename name, typename Func>
-void kernel(Func kernelFunc) {
+void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 
@@ -25,19 +25,19 @@ void func_ignore() {}
 
 struct FuncObj {
   [[intelfpga::max_work_group_size(4, 4, 4)]]
-  void operator()() {}
+  void operator()() const {}
 };
 
 #ifdef TRIGGER_ERROR
 struct DAFuncObj {
   [[intelfpga::max_work_group_size(4, 4, 4)]]
   [[cl::reqd_work_group_size(8, 8, 4)]] // expected-error{{'reqd_work_group_size' attribute conflicts with 'max_work_group_size' attribute}}
-  void operator()() {}
+  void operator()() const {}
 };
 #endif // TRIGGER_ERROR
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -DTRIGGER_ERROR -verify
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 | FileCheck %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -verify %s
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 -DTRIGGER_ERROR -verify
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -Wno-sycl-2017-conform -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {

--- a/clang/test/SemaSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size.cpp
@@ -5,7 +5,8 @@
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {
   [[intelfpga::max_work_group_size(1, 1, 1)]] // expected-no-diagnostics
-  void operator()() const {}
+  void
+  operator()() const {}
 };
 
 template <typename name, typename Func>
@@ -24,15 +25,15 @@ void foo() {
 void func_ignore() {}
 
 struct FuncObj {
-  [[intelfpga::max_work_group_size(4, 4, 4)]]
-  void operator()() const {}
+  [[intelfpga::max_work_group_size(4, 4, 4)]] void operator()() const {}
 };
 
 #ifdef TRIGGER_ERROR
 struct DAFuncObj {
   [[intelfpga::max_work_group_size(4, 4, 4)]]
   [[cl::reqd_work_group_size(8, 8, 4)]] // expected-error{{'reqd_work_group_size' attribute conflicts with 'max_work_group_size' attribute}}
-  void operator()() const {}
+  void
+  operator()() const {}
 };
 #endif // TRIGGER_ERROR
 

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -fsyntax-only -verify -DTRIGGER_ERROR %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -ast-dump %s | FileCheck %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-host -Wno-sycl-2017-conform -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-compat -fsyntax-only -verify -DTRIGGER_ERROR %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-host -Wno-sycl-2017-compat -fsyntax-only -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 // expected-no-diagnostics

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -DTRIGGER_ERROR %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -ast-dump %s | FileCheck %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -fsyntax-only -verify -DTRIGGER_ERROR %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-host -Wno-sycl-2017-conform -fsyntax-only -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 // expected-no-diagnostics

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size.cpp
@@ -6,11 +6,11 @@
 // expected-no-diagnostics
 class Functor {
 public:
-  [[intel::reqd_work_group_size(4)]] void operator()() {}
+  [[intel::reqd_work_group_size(4)]] void operator()() const {}
 };
 
 template <typename name, typename Func>
-void kernel(Func kernelFunc) {
+void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 
@@ -32,50 +32,50 @@ void bar() {
 #ifdef TRIGGER_ERROR
 class Functor32 {
 public:
-  [[cl::reqd_work_group_size(32)]] void operator()() {} // expected-error {{'reqd_work_group_size' attribute requires exactly 3 arguments}}
+  [[cl::reqd_work_group_size(32)]] void operator()() const {} // expected-error {{'reqd_work_group_size' attribute requires exactly 3 arguments}}
 };
 class Functor33 {
 public:
-  [[intel::reqd_work_group_size(32, -4)]] void operator()() {} // expected-error {{'reqd_work_group_size' attribute requires a non-negative integral compile time constant expression}}
+  [[intel::reqd_work_group_size(32, -4)]] void operator()() const {} // expected-error {{'reqd_work_group_size' attribute requires a non-negative integral compile time constant expression}}
 };
 #endif // TRIGGER_ERROR
 
 class Functor16 {
 public:
-  [[intel::reqd_work_group_size(16)]] void operator()() {}
+  [[intel::reqd_work_group_size(16)]] void operator()() const {}
 };
 
 class Functor64 {
 public:
-  [[intel::reqd_work_group_size(64, 64)]] void operator()() {}
+  [[intel::reqd_work_group_size(64, 64)]] void operator()() const {}
 };
 
 class Functor16x16x16 {
 public:
-  [[intel::reqd_work_group_size(16, 16, 16)]] void operator()() {}
+  [[intel::reqd_work_group_size(16, 16, 16)]] void operator()() const {}
 };
 
 class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
 public:
-  [[intel::reqd_work_group_size(8)]] void operator()() { // expected-note {{conflicting attribute is here}}
+  [[intel::reqd_work_group_size(8)]] void operator()() const { // expected-note {{conflicting attribute is here}}
     f4x1x1();
   }
 };
 
 class Functor {
 public:
-  void operator()() {
+  void operator()() const {
     f4x1x1();
   }
 };
 
 class FunctorAttr {
 public:
-  __attribute__((reqd_work_group_size(128, 128, 128))) void operator()() {}
+  __attribute__((reqd_work_group_size(128, 128, 128))) void operator()() const {}
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/intel-restrict.cpp
+++ b/clang/test/SemaSYCL/intel-restrict.cpp
@@ -5,8 +5,7 @@
 void func_ignore() {}
 
 struct FuncObj {
-  [[intel::kernel_args_restrict]]
-  void operator()() const {}
+  [[intel::kernel_args_restrict]] void operator()() const {}
 };
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/intel-restrict.cpp
+++ b/clang/test/SemaSYCL/intel-restrict.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 -DCHECKDIAG -verify
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 | FileCheck %s
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -Wno-sycl-2017-compat -triple spir64 -DCHECKDIAG -verify
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -Wno-sycl-2017-compat -triple spir64 | FileCheck %s
 
 [[intel::kernel_args_restrict]] // expected-warning{{'kernel_args_restrict' attribute ignored}}
 void func_ignore() {}

--- a/clang/test/SemaSYCL/intel-restrict.cpp
+++ b/clang/test/SemaSYCL/intel-restrict.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -DCHECKDIAG -verify
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 | FileCheck %s
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 -DCHECKDIAG -verify
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -Wno-sycl-2017-conform -triple spir64 | FileCheck %s
 
 [[intel::kernel_args_restrict]] // expected-warning{{'kernel_args_restrict' attribute ignored}}
 void func_ignore() {}

--- a/clang/test/SemaSYCL/intel-restrict.cpp
+++ b/clang/test/SemaSYCL/intel-restrict.cpp
@@ -6,11 +6,11 @@ void func_ignore() {}
 
 struct FuncObj {
   [[intel::kernel_args_restrict]]
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 #ifdef CHECKDIAG
   [[intel::kernel_args_restrict]] int invalid = 42; // expected-error{{'kernel_args_restrict' attribute only applies to functions}}

--- a/clang/test/SemaSYCL/kernel-function-type.cpp
+++ b/clang/test/SemaSYCL/kernel-function-type.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s
 // expected-no-diagnostics
 
 // The kernel_single_task call is emitted as an OpenCL kernel function. The call

--- a/clang/test/SemaSYCL/kernel-function-type.cpp
+++ b/clang/test/SemaSYCL/kernel-function-type.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s
 // expected-no-diagnostics
 
 // The kernel_single_task call is emitted as an OpenCL kernel function. The call

--- a/clang/test/SemaSYCL/kernel-function-type.cpp
+++ b/clang/test/SemaSYCL/kernel-function-type.cpp
@@ -29,7 +29,7 @@ void foo(j e, d k) {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/kernelname-enum.cpp
+++ b/clang/test/SemaSYCL/kernelname-enum.cpp
@@ -26,26 +26,26 @@ enum class scoped_enum_no_type_set {
 template <unscoped_enum_int EnumType>
 class dummy_functor_1 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 // expected-error@+2 {{kernel name is invalid. Unscoped enum requires fixed underlying type}}
 template <unscoped_enum_no_type_set EnumType>
 class dummy_functor_2 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <scoped_enum_int EnumType>
 class dummy_functor_3 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <scoped_enum_no_type_set EnumType>
 class dummy_functor_4 {
 public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 int main() {

--- a/clang/test/SemaSYCL/kernelname-enum.cpp
+++ b/clang/test/SemaSYCL/kernelname-enum.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
 #include "sycl.hpp"
 

--- a/clang/test/SemaSYCL/kernelname-enum.cpp
+++ b/clang/test/SemaSYCL/kernelname-enum.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -verify %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -Wno-sycl-2017-conform -verify %s
 
 #include "sycl.hpp"
 

--- a/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
+++ b/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsyntax-only -verify %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {

--- a/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
+++ b/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {

--- a/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
+++ b/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsyntax-only -verify %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/loop_unroll.cpp
+++ b/clang/test/SemaSYCL/loop_unroll.cpp
@@ -60,7 +60,7 @@ void foo() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/loop_unroll.cpp
+++ b/clang/test/SemaSYCL/loop_unroll.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -pedantic %s
 
 template <int A>
 void bar() {

--- a/clang/test/SemaSYCL/loop_unroll.cpp
+++ b/clang/test/SemaSYCL/loop_unroll.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify -pedantic %s
 
 template <int A>
 void bar() {

--- a/clang/test/SemaSYCL/mangle-kernel.cpp
+++ b/clang/test/SemaSYCL/mangle-kernel.cpp
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/markfunction-astconsumer.cpp
+++ b/clang/test/SemaSYCL/markfunction-astconsumer.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
 void bar();
 
 template <typename T>

--- a/clang/test/SemaSYCL/markfunction-astconsumer.cpp
+++ b/clang/test/SemaSYCL/markfunction-astconsumer.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
 void bar();
 
 template <typename T>

--- a/clang/test/SemaSYCL/markfunction-astconsumer.cpp
+++ b/clang/test/SemaSYCL/markfunction-astconsumer.cpp
@@ -7,7 +7,7 @@ void usage(T func) {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/no-vtables.cpp
+++ b/clang/test/SemaSYCL/no-vtables.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -verify -fsyntax-only -emit-llvm-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -verify -Wno-sycl-2017-conform -fsyntax-only -emit-llvm-only %s
 // expected-no-diagnostics
 // Should never fail, since the type is never used in kernel code.
 

--- a/clang/test/SemaSYCL/no-vtables.cpp
+++ b/clang/test/SemaSYCL/no-vtables.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -verify -Wno-sycl-2017-conform -fsyntax-only -emit-llvm-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -verify -Wno-sycl-2017-compat -fsyntax-only -emit-llvm-only %s
 // expected-no-diagnostics
 // Should never fail, since the type is never used in kernel code.
 

--- a/clang/test/SemaSYCL/no-vtables.cpp
+++ b/clang/test/SemaSYCL/no-vtables.cpp
@@ -17,7 +17,6 @@ void always_uses() {
 void usage() {
 }
 
-
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();

--- a/clang/test/SemaSYCL/no-vtables.cpp
+++ b/clang/test/SemaSYCL/no-vtables.cpp
@@ -19,7 +19,7 @@ void usage() {
 
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 int main() {

--- a/clang/test/SemaSYCL/no-vtables2.cpp
+++ b/clang/test/SemaSYCL/no-vtables2.cpp
@@ -28,7 +28,6 @@ Inherit usage() {
   usage_child();
 }
 
-
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();

--- a/clang/test/SemaSYCL/no-vtables2.cpp
+++ b/clang/test/SemaSYCL/no-vtables2.cpp
@@ -30,7 +30,7 @@ Inherit usage() {
 
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 int main() {

--- a/clang/test/SemaSYCL/no-vtables2.cpp
+++ b/clang/test/SemaSYCL/no-vtables2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only %s
 
 struct Base {
   virtual void f() const {}

--- a/clang/test/SemaSYCL/no-vtables2.cpp
+++ b/clang/test/SemaSYCL/no-vtables2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only %s
 
 struct Base {
   virtual void f() const {}

--- a/clang/test/SemaSYCL/non-std-layout-param.cpp
+++ b/clang/test/SemaSYCL/non-std-layout-param.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-std-layout-kernel-params -verify -fsyntax-only %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-std-layout-kernel-params -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // non-standard layout struct object as SYCL kernel parameter.

--- a/clang/test/SemaSYCL/non-std-layout-param.cpp
+++ b/clang/test/SemaSYCL/non-std-layout-param.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-std-layout-kernel-params -verify -Wno-sycl-2017-conform -fsyntax-only %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-std-layout-kernel-params -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-compat -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // non-standard layout struct object as SYCL kernel parameter.

--- a/clang/test/SemaSYCL/non-std-layout-param.cpp
+++ b/clang/test/SemaSYCL/non-std-layout-param.cpp
@@ -19,7 +19,6 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 
-
 void test() {
   C C0;
   C0.Y=0;

--- a/clang/test/SemaSYCL/non-std-layout-param.cpp
+++ b/clang/test/SemaSYCL/non-std-layout-param.cpp
@@ -15,7 +15,7 @@ struct C : public Base {
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 
@@ -30,7 +30,7 @@ void test() {
 }
 
 struct Kernel {
-  void operator()() {
+  void operator()() const {
     (void) c1;
     (void) c2;
     (void) p;

--- a/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
+++ b/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // a struct with non-trivially copyable type as SYCL kernel parameter.

--- a/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
+++ b/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // a struct with non-trivially copyable type as SYCL kernel parameter.

--- a/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
+++ b/clang/test/SemaSYCL/non-trivially-copyable-kernel-param.cpp
@@ -22,7 +22,7 @@ struct D {
 };
 
 template <typename Name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/num_simd_work_items.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items.cpp
@@ -5,11 +5,11 @@
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {
   [[intelfpga::num_simd_work_items(42)]] // expected-no-diagnostics
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <typename name, typename Func>
-void kernel(Func kernelFunc) {
+void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 
@@ -25,11 +25,11 @@ void func_ignore() {}
 
 struct FuncObj {
   [[intelfpga::num_simd_work_items(42)]]
-  void operator()() {}
+  void operator()() const {}
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/num_simd_work_items.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items.cpp
@@ -5,7 +5,8 @@
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {
   [[intelfpga::num_simd_work_items(42)]] // expected-no-diagnostics
-  void operator()() const {}
+  void
+  operator()() const {}
 };
 
 template <typename name, typename Func>
@@ -24,8 +25,7 @@ void foo() {
 void func_ignore() {}
 
 struct FuncObj {
-  [[intelfpga::num_simd_work_items(42)]]
-  void operator()() const {}
+  [[intelfpga::num_simd_work_items(42)]] void operator()() const {}
 };
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/num_simd_work_items.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -DTRIGGER_ERROR -verify
-// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -ast-dump | FileCheck %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -verify %s
+// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -Wno-sycl-2017-conform -DTRIGGER_ERROR -verify
+// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -Wno-sycl-2017-conform -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -Wno-sycl-2017-conform -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {

--- a/clang/test/SemaSYCL/num_simd_work_items.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -Wno-sycl-2017-conform -DTRIGGER_ERROR -verify
-// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -Wno-sycl-2017-conform -ast-dump | FileCheck %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -Wno-sycl-2017-compat -DTRIGGER_ERROR -verify
+// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -Wno-sycl-2017-compat -ast-dump | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {

--- a/clang/test/SemaSYCL/prohibit-thread-local.cpp
+++ b/clang/test/SemaSYCL/prohibit-thread-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -verify -Wno-sycl-2017-conform -fsyntax-only %s
 
 thread_local const int prohobit_ns_scope = 0;
 thread_local int prohobit_ns_scope2 = 0;

--- a/clang/test/SemaSYCL/prohibit-thread-local.cpp
+++ b/clang/test/SemaSYCL/prohibit-thread-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -verify -Wno-sycl-2017-compat -fsyntax-only %s
 
 thread_local const int prohobit_ns_scope = 0;
 thread_local int prohobit_ns_scope2 = 0;

--- a/clang/test/SemaSYCL/prohibit-thread-local.cpp
+++ b/clang/test/SemaSYCL/prohibit-thread-local.cpp
@@ -41,7 +41,7 @@ template <typename name, typename Func>
 __attribute__((sycl_kernel))
 // expected-note@+2 2{{called by}}
 void
-kernel_single_task(Func kernelFunc) { kernelFunc(); }
+kernel_single_task(const Func &kernelFunc) { kernelFunc(); }
 
 int main() {
   // expected-note@+1 2{{called by}}

--- a/clang/test/SemaSYCL/reference-kernel-param.cpp
+++ b/clang/test/SemaSYCL/reference-kernel-param.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // a reference as SYCL kernel parameter.

--- a/clang/test/SemaSYCL/reference-kernel-param.cpp
+++ b/clang/test/SemaSYCL/reference-kernel-param.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // a reference as SYCL kernel parameter.

--- a/clang/test/SemaSYCL/reference-kernel-param.cpp
+++ b/clang/test/SemaSYCL/reference-kernel-param.cpp
@@ -4,7 +4,7 @@
 // a reference as SYCL kernel parameter.
 
 template <typename Name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -DTRIGGER_ERROR %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -DTRIGGER_ERROR %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -ast-dump %s | FileCheck %s
 
 [[intel::reqd_sub_group_size(4)]] void foo() {} // expected-note {{conflicting attribute is here}}
 // expected-note@-1 {{conflicting attribute is here}}

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -DTRIGGER_ERROR %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify -DTRIGGER_ERROR %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
 
 [[intel::reqd_sub_group_size(4)]] void foo() {} // expected-note {{conflicting attribute is here}}
 // expected-note@-1 {{conflicting attribute is here}}

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -9,12 +9,12 @@ class Functor16 {
 public:
   // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
   // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-  [[cl::intel_reqd_sub_group_size(16)]] void operator()() {}
+  [[cl::intel_reqd_sub_group_size(16)]] void operator()() const {}
 };
 
 class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
 public:
-  [[intel::reqd_sub_group_size(8)]] void operator()() { // expected-note {{conflicting attribute is here}}
+  [[intel::reqd_sub_group_size(8)]] void operator()() const { // expected-note {{conflicting attribute is here}}
     foo();
   }
 };
@@ -26,13 +26,13 @@ public:
 
 class Functor {
 public:
-  void operator()() {
+  void operator()() const {
     foo();
   }
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -21,7 +21,7 @@ public:
 
 class Functor4 {
 public:
-  [[intel::reqd_sub_group_size(12)]] void operator()() {}
+  [[intel::reqd_sub_group_size(12)]] void operator()() const {}
 };
 
 class Functor {

--- a/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -DTRIGGER_ERROR %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify -DTRIGGER_ERROR %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
 
 [[cl::reqd_work_group_size(4, 1, 1)]] void f4x1x1() {} // expected-note {{conflicting attribute is here}}
 // expected-note@-1 {{conflicting attribute is here}}

--- a/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
@@ -13,7 +13,7 @@
 
 class Functor16 {
 public:
-  [[cl::reqd_work_group_size(16, 1, 1)]] [[cl::reqd_work_group_size(16, 1, 1)]] void operator()() {}
+  [[cl::reqd_work_group_size(16, 1, 1)]] [[cl::reqd_work_group_size(16, 1, 1)]] void operator()() const {}
 };
 
 #ifdef TRIGGER_ERROR
@@ -21,35 +21,35 @@ class Functor32 {
 public:
   //expected-warning@+2{{attribute 'reqd_work_group_size' is already applied with different parameters}}
   // expected-error@+1{{'reqd_work_group_size' attribute conflicts with 'reqd_work_group_size' attribute}}
-  [[cl::reqd_work_group_size(32, 1, 1)]] [[cl::reqd_work_group_size(1, 1, 32)]] void operator()() {}
+  [[cl::reqd_work_group_size(32, 1, 1)]] [[cl::reqd_work_group_size(1, 1, 32)]] void operator()() const {}
 };
 #endif
 class Functor16x16x16 {
 public:
-  [[cl::reqd_work_group_size(16, 16, 16)]] void operator()() {}
+  [[cl::reqd_work_group_size(16, 16, 16)]] void operator()() const {}
 };
 
 class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
 public:
-  [[cl::reqd_work_group_size(1, 1, 8)]] void operator()() { // expected-note {{conflicting attribute is here}}
+  [[cl::reqd_work_group_size(1, 1, 8)]] void operator()() const { // expected-note {{conflicting attribute is here}}
     f4x1x1();
   }
 };
 
 class Functor {
 public:
-  void operator()() {
+  void operator()() const {
     f4x1x1();
   }
 };
 
 class FunctorAttr {
 public:
-  __attribute__((reqd_work_group_size(128, 128, 128))) void operator()() {}
+  __attribute__((reqd_work_group_size(128, 128, 128))) void operator()() const {}
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -DTRIGGER_ERROR %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify -DTRIGGER_ERROR %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-sycl-2017-conform -ast-dump %s | FileCheck %s
 
 [[cl::reqd_work_group_size(4, 1, 1)]] void f4x1x1() {} // expected-note {{conflicting attribute is here}}
 // expected-note@-1 {{conflicting attribute is here}}

--- a/clang/test/SemaSYCL/restrict-recursion.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion.cpp
@@ -90,7 +90,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
 }
 
 template <typename name, typename Func>
-  // expected-note@+1 2{{function implemented using recursion declared here}}
+// expected-note@+1 2{{function implemented using recursion declared here}}
 __attribute__((sycl_kernel)) void kernel_single_task2(const Func &kernelFunc) {
   kernelFunc();
   // expected-error@+1 2{{SYCL kernel cannot call a recursive function}}

--- a/clang/test/SemaSYCL/restrict-recursion.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion.cpp
@@ -57,7 +57,7 @@ bool isa_B(void) {
 }
 
 template <typename N, typename L>
-__attribute__((sycl_kernel)) void kernel(L l) {
+__attribute__((sycl_kernel)) void kernel(const L &l) {
   l();
 }
 
@@ -85,13 +85,13 @@ int addInt(int n, int m) {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 
 template <typename name, typename Func>
   // expected-note@+1 2{{function implemented using recursion declared here}}
-__attribute__((sycl_kernel)) void kernel_single_task2(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task2(const Func &kernelFunc) {
   kernelFunc();
   // expected-error@+1 2{{SYCL kernel cannot call a recursive function}}
   kernel_single_task2<name, Func>(kernelFunc);

--- a/clang/test/SemaSYCL/restrict-recursion2.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion2.cpp
@@ -71,7 +71,7 @@ int addInt(int n, int m) {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/restrict-recursion2.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion2.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-conform -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -32,7 +32,7 @@ int addInt(int n, int m) {
 
 template <typename name, typename Func>
 // expected-note@+1 2{{function implemented using recursion declared here}}
-__attribute__((sycl_kernel)) void kernel_single_task2(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task2(const Func &kernelFunc) {
   // expected-note@+1 {{called by 'kernel_single_task2}}
   kernelFunc();
   // expected-warning@+1 2{{SYCL kernel cannot call a recursive function}}

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-conform -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-compat -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion4.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion4.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-conform -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion4.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion4.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-conform -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-compat -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion4.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion4.cpp
@@ -34,7 +34,7 @@ int addInt(int n, int m) {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-note@+1 {{called by 'kernel_single_task}}
   kernelFunc();
 }

--- a/clang/test/SemaSYCL/sampler.cpp
+++ b/clang/test/SemaSYCL/sampler.cpp
@@ -3,7 +3,7 @@
 #include <sycl.hpp>
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/spec_const_and_accesor_crash.cpp
+++ b/clang/test/SemaSYCL/spec_const_and_accesor_crash.cpp
@@ -5,7 +5,7 @@
 #include <sycl.hpp>
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/sycl-callstack.cpp
+++ b/clang/test/SemaSYCL/sycl-callstack.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {

--- a/clang/test/SemaSYCL/sycl-callstack.cpp
+++ b/clang/test/SemaSYCL/sycl-callstack.cpp
@@ -2,7 +2,7 @@
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel))
-void kernel_single_task(Func kernelFunc) {
+void kernel_single_task(const Func &kernelFunc) {
   // expected-note@+1 {{called by 'kernel_single_task}}
     kernelFunc();
 }

--- a/clang/test/SemaSYCL/sycl-callstack.cpp
+++ b/clang/test/SemaSYCL/sycl-callstack.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {

--- a/clang/test/SemaSYCL/sycl-callstack.cpp
+++ b/clang/test/SemaSYCL/sycl-callstack.cpp
@@ -1,10 +1,9 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -fsyntax-only -std=c++17 %s
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel))
-void kernel_single_task(const Func &kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-note@+1 {{called by 'kernel_single_task}}
-    kernelFunc();
+  kernelFunc();
 }
 
 void foo() {

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -13,7 +13,7 @@ void bar() {
 
 template <typename name, typename Func>
 // expected-no-warning@+1
-__cdecl __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__cdecl __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-error@+1{{SYCL kernel cannot call a variadic function}}
   printf("cannot call from here\n");
   // expected-no-error@+1

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-windows-sycldevice -aux-triple x86_64-pc-windows-msvc -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-windows-sycldevice -aux-triple x86_64-pc-windows-msvc -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
 // expected-no-warning@+1
 __inline __cdecl int printf(char const* const _Format, ...) { return 0; }

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-windows-sycldevice -aux-triple x86_64-pc-windows-msvc -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-windows-sycldevice -aux-triple x86_64-pc-windows-msvc -fsyntax-only -Wno-sycl-2017-conform -verify %s
 
 // expected-no-warning@+1
 __inline __cdecl int printf(char const* const _Format, ...) { return 0; }

--- a/clang/test/SemaSYCL/sycl-device-const-static.cpp
+++ b/clang/test/SemaSYCL/sycl-device-const-static.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
 
 struct Base {};
 struct S {

--- a/clang/test/SemaSYCL/sycl-device-const-static.cpp
+++ b/clang/test/SemaSYCL/sycl-device-const-static.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s
 
 struct Base {};
 struct S {

--- a/clang/test/SemaSYCL/sycl-device-const-static.cpp
+++ b/clang/test/SemaSYCL/sycl-device-const-static.cpp
@@ -37,7 +37,7 @@ void usage() {
 }
 
 template <typename Name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-error@+1{{SYCL kernel cannot use a non-const static data variable}}
   static int z;
   // expected-note-re@+3{{called by 'kernel_single_task<fake_kernel, (lambda at {{.*}})>}}

--- a/clang/test/SemaSYCL/sycl-device-static-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-device-static-restrict.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s
 const int glob1 = 1;
 int glob2 = 2;
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/sycl-device-static-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-device-static-restrict.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
 const int glob1 = 1;
 int glob2 = 2;
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/sycl-device-static-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-device-static-restrict.cpp
@@ -2,7 +2,7 @@
 const int glob1 = 1;
 int glob2 = 2;
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-note-re@+1{{called by 'kernel_single_task<fake_kernel, (lambda at {{.*}})>}}
   kernelFunc();
 }

--- a/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
+++ b/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
@@ -1,19 +1,19 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fms-extensions \
 // RUN: -aux-triple x86_64-unknown-linux-gnu -fsycl -fsycl-is-device \
-// RUN: -fsyntax-only -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: -fsyntax-only -Wno-sycl-2017-conform -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
 // check random triple aux-triple with sycl-device
 
-// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -fsyntax-only \
+// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -Wno-sycl-2017-conform -fsyntax-only \
 // RUN: -fms-extensions -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
 // check without -aux-triple but sycl-device
 
 // RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -fsycl \
 // RUN: -fsycl-is-device -aux-triple x86_64-pc-windows-msvc -fms-extensions \
-// RUN: -fsyntax-only -DWARNCHECK %s -o /dev/null 2>&1 | \
+// RUN: -fsyntax-only -Wno-sycl-2017-conform -DWARNCHECK %s -o /dev/null 2>&1 | \
 // RUN: FileCheck %s --check-prefixes CHECKALL
 // check -aux-tripe without sycl-device
 
-// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -fsyntax-only \
+// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -Wno-sycl-2017-conform -fsyntax-only \
 // RUN: -aux-triple x86_64-pc-windows-msvc -fsycl -fsycl-is-device \
 // RUN: -fms-extensions -verify  %s
 // check error message when dllimport function gets called in sycl-kernel code

--- a/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
+++ b/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
@@ -1,19 +1,19 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fms-extensions \
 // RUN: -aux-triple x86_64-unknown-linux-gnu -fsycl -fsycl-is-device \
-// RUN: -fsyntax-only -Wno-sycl-2017-conform -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: -fsyntax-only -Wno-sycl-2017-compat -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
 // check random triple aux-triple with sycl-device
 
-// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -Wno-sycl-2017-conform -fsyntax-only \
+// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -Wno-sycl-2017-compat -fsyntax-only \
 // RUN: -fms-extensions -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
 // check without -aux-triple but sycl-device
 
 // RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -fsycl \
 // RUN: -fsycl-is-device -aux-triple x86_64-pc-windows-msvc -fms-extensions \
-// RUN: -fsyntax-only -Wno-sycl-2017-conform -DWARNCHECK %s -o /dev/null 2>&1 | \
+// RUN: -fsyntax-only -Wno-sycl-2017-compat -DWARNCHECK %s -o /dev/null 2>&1 | \
 // RUN: FileCheck %s --check-prefixes CHECKALL
 // check -aux-tripe without sycl-device
 
-// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -Wno-sycl-2017-conform -fsyntax-only \
+// RUN: %clang_cc1 -triple spir64-unknown-windows-sycldevice -Wno-sycl-2017-compat -fsyntax-only \
 // RUN: -aux-triple x86_64-pc-windows-msvc -fsycl -fsycl-is-device \
 // RUN: -fms-extensions -verify  %s
 // check error message when dllimport function gets called in sycl-kernel code

--- a/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
+++ b/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
@@ -51,7 +51,7 @@ int foobar()  // expected-warning {{'foobar' redeclared without 'dllimport' attr
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
 // ----------- Negative tests
 

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -Wno-sycl-2017-conform -verify %s
 
 // ----------- Negative tests
 

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -12,7 +12,7 @@ bar() {}
 // -- ESIMD kernel can't call functions with required subgroup size != 1
 
 template <typename ID, typename F>
-void kernel0(F f) __attribute__((sycl_kernel)) {
+void kernel0(const F &f) __attribute__((sycl_kernel)) {
   f();
 }
 
@@ -27,7 +27,7 @@ void test0() {
 
 // -- Usual kernel can't call ESIMD function
 template <typename ID, typename F>
-void kernel1(F f) __attribute__((sycl_kernel)) {
+void kernel1(const F &f) __attribute__((sycl_kernel)) {
   f();
 }
 
@@ -43,7 +43,7 @@ void test1() {
 
 // -- Kernel-function call, both have the attribute, lambda kernel.
 template <typename ID, typename F>
-void kernel2(F f) __attribute__((sycl_kernel)) {
+void kernel2(const F &f) __attribute__((sycl_kernel)) {
   f();
 }
 
@@ -64,12 +64,12 @@ class A {
 // --  Functor object kernel.
 
 template <typename F, typename ID = F>
-void kernel3(F f) __attribute__((sycl_kernel)) {
+void kernel3(const F &f) __attribute__((sycl_kernel)) {
   f();
 }
 
 struct Kernel3 {
-  void operator()() __attribute__((sycl_explicit_simd)) {}
+  void operator()() const __attribute__((sycl_explicit_simd)) {}
 };
 
 void bar3() {

--- a/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
+++ b/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -std=c++14 -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -std=c++14 -verify -Wno-sycl-2017-compat -fsyntax-only %s
 // expected-no-diagnostics
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
+++ b/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
@@ -2,7 +2,7 @@
 // expected-no-diagnostics
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
+++ b/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -std=c++14 -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -std=c++14 -verify -Wno-sycl-2017-conform -fsyntax-only %s
 // expected-no-diagnostics
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
+++ b/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
@@ -13,7 +13,7 @@ struct S { virtual void foo(); };
 struct T { virtual ~T(); };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-no-note@+1
   using DATA_I = int;
   using DATA_S = S;

--- a/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
+++ b/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
 
 template <typename functor_t>
 struct functor_wrapper{

--- a/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
+++ b/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s
 
 template <typename functor_t>
 struct functor_wrapper{

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -fno-sycl-allow-func-ptr -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -DALLOW_FP=1 -fsycl-allow-func-ptr -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -fno-sycl-allow-func-ptr -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -DALLOW_FP=1 -fsycl-allow-func-ptr -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
 
 namespace std {
 class type_info;

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -Wno-return-type -verify -fsyntax-only -std=c++17 %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -fno-sycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -std=c++17 %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -DALLOW_FP=1 -fsycl-allow-func-ptr -Wno-return-type -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -fno-sycl-allow-func-ptr -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -triple spir64 -DALLOW_FP=1 -fsycl-allow-func-ptr -Wno-return-type -verify -Wno-sycl-2017-conform -fsyntax-only -std=c++17 %s
 
 namespace std {
 class type_info;

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -86,7 +86,7 @@ bool isa_B(A *a) {
 }
 
 template <typename N, typename L>
-__attribute__((sycl_kernel)) void kernel1(L l) {
+__attribute__((sycl_kernel)) void kernel1(const L &l) {
   l(); //#rtti_kernel  // expected-note 2{{called by 'kernel1<kernel_name, (lambda at }}
 }
 } // namespace Check_RTTI_Restriction
@@ -374,7 +374,7 @@ int use2(a_type ab, a_type *abp) {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc(); //#call_kernelFunc // expected-note 3{{called by 'kernel_single_task<fake_kernel, (lambda at}}
 }
 

--- a/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
@@ -43,7 +43,7 @@ void bar() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc(); //expected-note 2+ {{called by 'kernel_single_task}}
 }
 

--- a/clang/test/SemaSYCL/tls_error.cpp
+++ b/clang/test/SemaSYCL/tls_error.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -verify -Wno-sycl-2017-compat -fsyntax-only %s
 
 extern __thread void* __once_callable;  // expected-no-error
 extern __thread void (*__once_call)();  // expected-no-error

--- a/clang/test/SemaSYCL/tls_error.cpp
+++ b/clang/test/SemaSYCL/tls_error.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -verify -Wno-sycl-2017-conform -fsyntax-only %s
 
 extern __thread void* __once_callable;  // expected-no-error
 extern __thread void (*__once_call)();  // expected-no-error

--- a/clang/test/SemaSYCL/tls_error.cpp
+++ b/clang/test/SemaSYCL/tls_error.cpp
@@ -14,7 +14,7 @@ void usage() {
 }
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   //expected-note@+1{{called by}}
   kernelFunc();
 }

--- a/clang/test/SemaSYCL/unevaluated-function.cpp
+++ b/clang/test/SemaSYCL/unevaluated-function.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -Wno-sycl-2017-conform -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -Wno-sycl-2017-compat -fsyntax-only %s
 
 // Check that a function used in an unevaluated context is not subject
 // to delayed device diagnostics.

--- a/clang/test/SemaSYCL/unevaluated-function.cpp
+++ b/clang/test/SemaSYCL/unevaluated-function.cpp
@@ -24,7 +24,7 @@ bool foo3() {
 }
 
 template <typename Name, typename Func>
-__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-note@+1 1{{called by}}
   kernelFunc();
 }

--- a/clang/test/SemaSYCL/unevaluated-function.cpp
+++ b/clang/test/SemaSYCL/unevaluated-function.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -verify -Wno-sycl-2017-conform -fsyntax-only %s
 
 // Check that a function used in an unevaluated context is not subject
 // to delayed device diagnostics.

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -verify %s
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsycl-unnamed-lambda -fsyntax-only -verify %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsycl-unnamed-lambda -fsyntax-only -Wno-sycl-2017-conform -verify %s
 #include <sycl.hpp>
 
 #ifdef __SYCL_UNNAMED_LAMBDA__

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -Wno-sycl-2017-conform -verify %s
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsycl-unnamed-lambda -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsycl-unnamed-lambda -fsyntax-only -Wno-sycl-2017-compat -verify %s
 #include <sycl.hpp>
 
 #ifdef __SYCL_UNNAMED_LAMBDA__

--- a/clang/test/SemaSYCL/unsupported_math.cpp
+++ b/clang/test/SemaSYCL/unsupported_math.cpp
@@ -6,7 +6,7 @@ extern "C" double sin(double);
 extern "C" double cos(double);
 extern "C" double log(double);
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/test/SemaSYCL/unsupported_math.cpp
+++ b/clang/test/SemaSYCL/unsupported_math.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s
 extern "C" float  sinf(float);
 extern "C" float  cosf(float);
 extern "C" float  logf(float);

--- a/clang/test/SemaSYCL/unsupported_math.cpp
+++ b/clang/test/SemaSYCL/unsupported_math.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -Wno-sycl-2017-conform -verify %s
 extern "C" float  sinf(float);
 extern "C" float  cosf(float);
 extern "C" float  logf(float);

--- a/clang/test/SemaSYCL/variadic-func-call.cpp
+++ b/clang/test/SemaSYCL/variadic-func-call.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown -fsyntax-only -Wno-sycl-2017-conform -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
 void variadic(int, ...) {}
 namespace NS {

--- a/clang/test/SemaSYCL/variadic-func-call.cpp
+++ b/clang/test/SemaSYCL/variadic-func-call.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown -fsyntax-only -Wno-sycl-2017-conform -verify %s
 
 void variadic(int, ...) {}
 namespace NS {

--- a/clang/test/SemaSYCL/variadic-func-call.cpp
+++ b/clang/test/SemaSYCL/variadic-func-call.cpp
@@ -18,7 +18,7 @@ void foo() {
 void overloaded(int, int) {}
 void overloaded(int, ...) {}
 template <typename, typename Func>
-__attribute__((sycl_kernel)) void task(Func KF) {
+__attribute__((sycl_kernel)) void task(const Func &KF) {
   KF(); // expected-note 2 {{called by 'task}}
 }
 

--- a/clang/test/SemaSYCL/wrapped-accessor.cpp
+++ b/clang/test/SemaSYCL/wrapped-accessor.cpp
@@ -9,7 +9,7 @@ template <typename Acc>
 struct AccWrapper { Acc accessor; };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -733,14 +733,14 @@ private:
   // NOTE: the name of this function - "kernel_single_task" - is used by the
   // Front End to determine kernel invocation kind.
   template <typename KernelName, typename KernelType>
-  __attribute__((sycl_kernel)) void kernel_single_task(KernelType KernelFunc) {
+  __attribute__((sycl_kernel)) void kernel_single_task(const KernelType KernelFunc) {
     KernelFunc();
   }
 
   // NOTE: the name of these functions - "kernel_parallel_for" - are used by the
   // Front End to determine kernel invocation kind.
   template <typename KernelName, typename ElementType, typename KernelType>
-  __attribute__((sycl_kernel)) void kernel_parallel_for(KernelType KernelFunc) {
+  __attribute__((sycl_kernel)) void kernel_parallel_for(const KernelType KernelFunc) {
     KernelFunc(
         detail::Builder::getElement(static_cast<ElementType *>(nullptr)));
   }
@@ -749,7 +749,7 @@ private:
   // used by the Front End to determine kernel invocation kind.
   template <typename KernelName, typename ElementType, typename KernelType>
   __attribute__((sycl_kernel)) void
-  kernel_parallel_for_work_group(KernelType KernelFunc) {
+  kernel_parallel_for_work_group(const KernelType KernelFunc) {
     KernelFunc(
         detail::Builder::getElement(static_cast<ElementType *>(nullptr)));
   }
@@ -823,7 +823,7 @@ public:
   ///
   /// \param KernelFunc is a SYCL kernel function.
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void single_task(KernelType KernelFunc) {
+  void single_task(const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -913,7 +913,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
-                    KernelType KernelFunc) {
+                    const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -945,7 +945,7 @@ public:
   /// \param KernelFunc is a SYCL kernel function.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
-  void parallel_for(nd_range<Dims> ExecutionRange, KernelType KernelFunc) {
+  void parallel_for(nd_range<Dims> ExecutionRange, const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1004,7 +1004,7 @@ public:
             int Dims, typename Reduction>
   detail::enable_if_t<Reduction::accessor_mode == access::mode::discard_write &&
                       Reduction::has_fast_atomics>
-  parallel_for(nd_range<Dims> Range, Reduction Redu, KernelType KernelFunc) {
+  parallel_for(nd_range<Dims> Range, Reduction Redu, const KernelType KernelFunc) {
     shared_ptr_class<detail::queue_impl> QueueCopy = MQueue;
     auto RWAcc = Redu.getReadWriteScalarAcc(*this);
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
@@ -1115,7 +1115,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for_work_group(range<Dims> NumWorkGroups,
-                               KernelType KernelFunc) {
+                               const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1148,7 +1148,7 @@ public:
             int Dims>
   void parallel_for_work_group(range<Dims> NumWorkGroups,
                                range<Dims> WorkGroupSize,
-                               KernelType KernelFunc) {
+                               const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1247,7 +1247,7 @@ public:
   /// \param KernelFunc is a lambda that is used if device, queue is bound to,
   /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void single_task(kernel Kernel, KernelType KernelFunc) {
+  void single_task(kernel Kernel, const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1286,7 +1286,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
-                    KernelType KernelFunc) {
+                    const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1320,7 +1320,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
-                    id<Dims> WorkItemOffset, KernelType KernelFunc) {
+                    id<Dims> WorkItemOffset, const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1356,7 +1356,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(kernel Kernel, nd_range<Dims> NDRange,
-                    KernelType KernelFunc) {
+                    const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1397,7 +1397,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for_work_group(kernel Kernel, range<Dims> NumWorkGroups,
-                               KernelType KernelFunc) {
+                               const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1435,7 +1435,7 @@ public:
             int Dims>
   void parallel_for_work_group(kernel Kernel, range<Dims> NumWorkGroups,
                                range<Dims> WorkGroupSize,
-                               KernelType KernelFunc) {
+                               const KernelType KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1046,7 +1046,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims, typename Reduction>
   detail::enable_if_t<!Reduction::has_fast_atomics>
-  parallel_for(nd_range<Dims> Range, Reduction Redu, KernelType KernelFunc) {
+  parallel_for(nd_range<Dims> Range, Reduction Redu, const KernelType &KernelFunc) {
     // This parallel_for() is lowered to the following sequence:
     // 1) Call a kernel that a) call user's lambda function and b) performs
     //    one iteration of reduction, storing the partial reductions/sums

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -733,14 +733,15 @@ private:
   // NOTE: the name of this function - "kernel_single_task" - is used by the
   // Front End to determine kernel invocation kind.
   template <typename KernelName, typename KernelType>
-  __attribute__((sycl_kernel)) void kernel_single_task(const KernelType KernelFunc) {
+  __attribute__((sycl_kernel)) void
+  kernel_single_task(const KernelType &KernelFunc) {
     KernelFunc();
   }
 
   // NOTE: the name of these functions - "kernel_parallel_for" - are used by the
   // Front End to determine kernel invocation kind.
   template <typename KernelName, typename ElementType, typename KernelType>
-  __attribute__((sycl_kernel)) void kernel_parallel_for(const KernelType KernelFunc) {
+  __attribute__((sycl_kernel)) void kernel_parallel_for(const KernelType &KernelFunc) {
     KernelFunc(
         detail::Builder::getElement(static_cast<ElementType *>(nullptr)));
   }
@@ -749,7 +750,7 @@ private:
   // used by the Front End to determine kernel invocation kind.
   template <typename KernelName, typename ElementType, typename KernelType>
   __attribute__((sycl_kernel)) void
-  kernel_parallel_for_work_group(const KernelType KernelFunc) {
+  kernel_parallel_for_work_group(const KernelType &KernelFunc) {
     KernelFunc(
         detail::Builder::getElement(static_cast<ElementType *>(nullptr)));
   }
@@ -823,7 +824,7 @@ public:
   ///
   /// \param KernelFunc is a SYCL kernel function.
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void single_task(const KernelType KernelFunc) {
+  void single_task(const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -840,17 +841,17 @@ public:
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void parallel_for(range<1> NumWorkItems, KernelType KernelFunc) {
+  void parallel_for(range<1> NumWorkItems, const KernelType &KernelFunc) {
     parallel_for_lambda_impl<KernelName>(NumWorkItems, std::move(KernelFunc));
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void parallel_for(range<2> NumWorkItems, KernelType KernelFunc) {
+  void parallel_for(range<2> NumWorkItems, const KernelType &KernelFunc) {
     parallel_for_lambda_impl<KernelName>(NumWorkItems, std::move(KernelFunc));
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void parallel_for(range<3> NumWorkItems, KernelType KernelFunc) {
+  void parallel_for(range<3> NumWorkItems, const KernelType &KernelFunc) {
     parallel_for_lambda_impl<KernelName>(NumWorkItems, std::move(KernelFunc));
   }
 
@@ -913,7 +914,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
-                    const KernelType KernelFunc) {
+                    const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -945,7 +946,8 @@ public:
   /// \param KernelFunc is a SYCL kernel function.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
-  void parallel_for(nd_range<Dims> ExecutionRange, const KernelType KernelFunc) {
+  void parallel_for(nd_range<Dims> ExecutionRange,
+                    const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -972,7 +974,7 @@ public:
             int Dims, typename Reduction>
   detail::enable_if_t<Reduction::accessor_mode == access::mode::read_write &&
                       Reduction::has_fast_atomics && !Reduction::is_usm>
-  parallel_for(nd_range<Dims> Range, Reduction Redu, KernelType KernelFunc) {
+  parallel_for(nd_range<Dims> Range, Reduction Redu, const KernelType &KernelFunc) {
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
                                           Redu.getUserAccessor());
   }
@@ -985,7 +987,7 @@ public:
             int Dims, typename Reduction>
   detail::enable_if_t<Reduction::accessor_mode == access::mode::read_write &&
                       Reduction::has_fast_atomics && Reduction::is_usm>
-  parallel_for(nd_range<Dims> Range, Reduction Redu, KernelType KernelFunc) {
+  parallel_for(nd_range<Dims> Range, Reduction Redu, const KernelType &KernelFunc) {
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
                                           Redu.getUSMPointer());
   }
@@ -1004,7 +1006,8 @@ public:
             int Dims, typename Reduction>
   detail::enable_if_t<Reduction::accessor_mode == access::mode::discard_write &&
                       Reduction::has_fast_atomics>
-  parallel_for(nd_range<Dims> Range, Reduction Redu, const KernelType KernelFunc) {
+  parallel_for(nd_range<Dims> Range, Reduction Redu,
+               const KernelType &KernelFunc) {
     shared_ptr_class<detail::queue_impl> QueueCopy = MQueue;
     auto RWAcc = Redu.getReadWriteScalarAcc(*this);
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
@@ -1115,7 +1118,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for_work_group(range<Dims> NumWorkGroups,
-                               const KernelType KernelFunc) {
+                               const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1148,7 +1151,7 @@ public:
             int Dims>
   void parallel_for_work_group(range<Dims> NumWorkGroups,
                                range<Dims> WorkGroupSize,
-                               const KernelType KernelFunc) {
+                               const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1247,7 +1250,7 @@ public:
   /// \param KernelFunc is a lambda that is used if device, queue is bound to,
   /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void single_task(kernel Kernel, const KernelType KernelFunc) {
+  void single_task(kernel Kernel, const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1286,7 +1289,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
-                    const KernelType KernelFunc) {
+                    const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1320,7 +1323,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
-                    id<Dims> WorkItemOffset, const KernelType KernelFunc) {
+                    id<Dims> WorkItemOffset, const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1356,7 +1359,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(kernel Kernel, nd_range<Dims> NDRange,
-                    const KernelType KernelFunc) {
+                    const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1397,7 +1400,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for_work_group(kernel Kernel, range<Dims> NumWorkGroups,
-                               const KernelType KernelFunc) {
+                               const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1435,7 +1438,7 @@ public:
             int Dims>
   void parallel_for_work_group(kernel Kernel, range<Dims> NumWorkGroups,
                                range<Dims> WorkGroupSize,
-                               const KernelType KernelFunc) {
+                               const KernelType &KernelFunc) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1046,7 +1046,8 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims, typename Reduction>
   detail::enable_if_t<!Reduction::has_fast_atomics>
-  parallel_for(nd_range<Dims> Range, Reduction Redu, const KernelType &KernelFunc) {
+  parallel_for(nd_range<Dims> Range, Reduction Redu,
+               const KernelType &KernelFunc) {
     // This parallel_for() is lowered to the following sequence:
     // 1) Call a kernel that a) call user's lambda function and b) performs
     //    one iteration of reduction, storing the partial reductions/sums

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -741,7 +741,8 @@ private:
   // NOTE: the name of these functions - "kernel_parallel_for" - are used by the
   // Front End to determine kernel invocation kind.
   template <typename KernelName, typename ElementType, typename KernelType>
-  __attribute__((sycl_kernel)) void kernel_parallel_for(const KernelType &KernelFunc) {
+  __attribute__((sycl_kernel)) void
+  kernel_parallel_for(const KernelType &KernelFunc) {
     KernelFunc(
         detail::Builder::getElement(static_cast<ElementType *>(nullptr)));
   }
@@ -974,7 +975,8 @@ public:
             int Dims, typename Reduction>
   detail::enable_if_t<Reduction::accessor_mode == access::mode::read_write &&
                       Reduction::has_fast_atomics && !Reduction::is_usm>
-  parallel_for(nd_range<Dims> Range, Reduction Redu, const KernelType &KernelFunc) {
+  parallel_for(nd_range<Dims> Range, Reduction Redu,
+               const KernelType &KernelFunc) {
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
                                           Redu.getUserAccessor());
   }
@@ -987,7 +989,8 @@ public:
             int Dims, typename Reduction>
   detail::enable_if_t<Reduction::accessor_mode == access::mode::read_write &&
                       Reduction::has_fast_atomics && Reduction::is_usm>
-  parallel_for(nd_range<Dims> Range, Reduction Redu, const KernelType &KernelFunc) {
+  parallel_for(nd_range<Dims> Range, Reduction Redu,
+               const KernelType &KernelFunc) {
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
                                           Redu.getUSMPointer());
   }

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -454,7 +454,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<2> NumWorkItems, KernelType KernelFunc
+      range<2> NumWorkItems, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -474,7 +474,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<3> NumWorkItems, KernelType KernelFunc
+      range<3> NumWorkItems, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -517,7 +517,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<2> NumWorkItems, event DepEvent, KernelType KernelFunc
+      range<2> NumWorkItems, event DepEvent, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -539,7 +539,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<3> NumWorkItems, event DepEvent, KernelType KernelFunc
+      range<3> NumWorkItems, event DepEvent, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -587,7 +587,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
       range<2> NumWorkItems, const vector_class<event> &DepEvents,
-      KernelType KernelFunc
+      const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -611,7 +611,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
       range<3> NumWorkItems, const vector_class<event> &DepEvents,
-      KernelType KernelFunc
+      const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -751,7 +751,8 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(
-      nd_range<Dims> ExecutionRange, event DepEvent, const KernelType &KernelFunc
+      nd_range<Dims> ExecutionRange, event DepEvent,
+      const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -361,7 +361,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(
-      KernelType KernelFunc
+      const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -384,7 +384,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(
-      event DepEvent, KernelType KernelFunc
+      event DepEvent, const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -409,7 +409,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(
-      const vector_class<event> &DepEvents, KernelType KernelFunc
+      const vector_class<event> &DepEvents, const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -434,7 +434,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<1> NumWorkItems, KernelType KernelFunc
+      range<1> NumWorkItems, const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -495,7 +495,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<1> NumWorkItems, event DepEvent, KernelType KernelFunc
+      range<1> NumWorkItems, event DepEvent, const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -563,7 +563,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
       range<1> NumWorkItems, const vector_class<event> &DepEvents,
-      KernelType KernelFunc
+      const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -634,7 +634,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(
-      range<Dims> NumWorkItems, id<Dims> WorkItemOffset, KernelType KernelFunc
+      range<Dims> NumWorkItems, id<Dims> WorkItemOffset, const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -663,7 +663,7 @@ public:
             int Dims>
   event parallel_for(
       range<Dims> NumWorkItems, id<Dims> WorkItemOffset, event DepEvent,
-      KernelType KernelFunc
+      const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -694,7 +694,7 @@ public:
             int Dims>
   event parallel_for(
       range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
-      const vector_class<event> &DepEvents, KernelType KernelFunc
+      const vector_class<event> &DepEvents, const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -722,7 +722,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(
-      nd_range<Dims> ExecutionRange, KernelType KernelFunc
+      nd_range<Dims> ExecutionRange, const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -750,7 +750,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(
-      nd_range<Dims> ExecutionRange, event DepEvent, KernelType KernelFunc
+      nd_range<Dims> ExecutionRange, event DepEvent, const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -781,7 +781,7 @@ public:
             int Dims>
   event parallel_for(
       nd_range<Dims> ExecutionRange, const vector_class<event> &DepEvents,
-      KernelType KernelFunc
+      const KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -361,7 +361,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(
-      const KernelType KernelFunc
+      const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -384,7 +384,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(
-      event DepEvent, const KernelType KernelFunc
+      event DepEvent, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -409,7 +409,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(
-      const vector_class<event> &DepEvents, const KernelType KernelFunc
+      const vector_class<event> &DepEvents, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -434,7 +434,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<1> NumWorkItems, const KernelType KernelFunc
+      range<1> NumWorkItems, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -495,7 +495,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<1> NumWorkItems, event DepEvent, const KernelType KernelFunc
+      range<1> NumWorkItems, event DepEvent, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -563,7 +563,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
       range<1> NumWorkItems, const vector_class<event> &DepEvents,
-      const KernelType KernelFunc
+      const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -634,7 +634,8 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(
-      range<Dims> NumWorkItems, id<Dims> WorkItemOffset, const KernelType KernelFunc
+      range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
+      const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -663,7 +664,7 @@ public:
             int Dims>
   event parallel_for(
       range<Dims> NumWorkItems, id<Dims> WorkItemOffset, event DepEvent,
-      const KernelType KernelFunc
+      const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -694,7 +695,7 @@ public:
             int Dims>
   event parallel_for(
       range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
-      const vector_class<event> &DepEvents, const KernelType KernelFunc
+      const vector_class<event> &DepEvents, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -722,7 +723,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(
-      nd_range<Dims> ExecutionRange, const KernelType KernelFunc
+      nd_range<Dims> ExecutionRange, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -750,7 +751,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   event parallel_for(
-      nd_range<Dims> ExecutionRange, event DepEvent, const KernelType KernelFunc
+      nd_range<Dims> ExecutionRange, event DepEvent, const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -781,7 +782,7 @@ public:
             int Dims>
   event parallel_for(
       nd_range<Dims> ExecutionRange, const vector_class<event> &DepEvents,
-      const KernelType KernelFunc
+      const KernelType &KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()

--- a/sycl/test/functor/functor_inheritance.cpp
+++ b/sycl/test/functor/functor_inheritance.cpp
@@ -36,7 +36,7 @@ struct Derived : public Base, public SecondBase {
       int _A, int _B, int _C, int _D, int _E,
       cl::sycl::accessor<int, 1, sycl_read_write, sycl_global_buffer> &_Acc)
       : A(_A), Acc(_Acc), /*Out(_Out),*/ Base(_B, _C, _D), SecondBase(_E) {}
-  void operator()() {
+  void operator()() const {
     Acc[0] = this->A + this->B + this->InnerObj.C + this->InnerObj.D + this->E;
   }
 

--- a/sycl/test/functor/kernel_functor.cpp
+++ b/sycl/test/functor/kernel_functor.cpp
@@ -23,7 +23,7 @@ constexpr auto sycl_global_buffer = cl::sycl::access::target::global_buffer;
 // - functor class is defined in an anonymous namespace
 // - the '()' operator:
 //   * does not have parameters (to be used in 'single_task').
-//   * has no 'const' qualifier
+//   * has the 'const' qualifier
 namespace {
 class Functor1 {
 public:
@@ -32,7 +32,7 @@ public:
       cl::sycl::accessor<int, 1, sycl_read_write, sycl_global_buffer> &Acc_)
       : X(X_), Acc(Acc_) {}
 
-  void operator()() { Acc[0] += X; }
+  void operator()() const { Acc[0] += X; }
 
 private:
   int X;
@@ -66,14 +66,14 @@ private:
 // - functor class is templated and defined in the translation unit scope
 // - the '()' operator:
 //   * has a parameter of type cl::sycl::id<1> (to be used in 'parallel_for').
-//   * has no 'const' qualifier
+//   * has the 'const' qualifier
 template <typename T> class TmplFunctor {
 public:
   TmplFunctor(
       T X_, cl::sycl::accessor<T, 1, sycl_read_write, sycl_global_buffer> &Acc_)
       : X(X_), Acc(Acc_) {}
 
-  void operator()(cl::sycl::id<1> id) { Acc[id] += X; }
+  void operator()(cl::sycl::id<1> id) const { Acc[id] += X; }
 
 private:
   T X;

--- a/sycl/test/hier_par/hier_par_basic.cpp
+++ b/sycl/test/hier_par/hier_par_basic.cpp
@@ -65,7 +65,7 @@ struct PFWIFunctor {
     size_t ub = cl::sycl::min(wi_offset + wi_chunk, range_length);
 
     for (size_t ind = wi_offset; ind < ub; ind++)
-       dev_ptr[ind] += v;
+      dev_ptr[ind] += v;
   }
 
   size_t wg_chunk;

--- a/sycl/test/hier_par/hier_par_basic.cpp
+++ b/sycl/test/hier_par/hier_par_basic.cpp
@@ -55,7 +55,7 @@ struct PFWIFunctor {
       : wg_chunk(wg_chunk), wg_size(wg_size), wg_offset(wg_offset),
         range_length(range_length), v(v), dev_ptr(dev_ptr) {}
 
-  void operator()(h_item<1> i) {
+  void operator()(h_item<1> i) const {
     // number of buf elements per work item:
     size_t wi_chunk = (wg_chunk + wg_size - 1) / wg_size;
     auto id = i.get_physical_local_id().get(0);
@@ -65,7 +65,7 @@ struct PFWIFunctor {
     size_t ub = cl::sycl::min(wi_offset + wi_chunk, range_length);
 
     for (size_t ind = wi_offset; ind < ub; ind++)
-      dev_ptr[ind] += v;
+       dev_ptr[ind] += v;
   }
 
   size_t wg_chunk;
@@ -82,7 +82,7 @@ struct PFWGFunctor {
       : wg_chunk(wg_chunk), range_length(range_length), dev_ptr(dev_ptr),
         addend(addend), n_iter(n_iter) {}
 
-  void operator()(group<1> g) {
+  void operator()(group<1> g) const {
     int v = addend; // to check constant initializer works too
     size_t wg_offset = wg_chunk * g.get_id(0);
     size_t wg_size = g.get_local_range(0);
@@ -95,13 +95,13 @@ struct PFWGFunctor {
   }
   // Dummy operator '()' to make sure compiler can handle multiple '()'
   // operators/ and pick the right one for PFWG kernel code generation.
-  void operator()(int ind, int val) { dev_ptr[ind] += val; }
+  void operator()(int ind, int val) const { dev_ptr[ind] += val; }
 
   const size_t wg_chunk;
   const size_t range_length;
   const int n_iter;
   const int addend;
-  AccTy dev_ptr;
+  mutable AccTy dev_ptr;
 };
 
 int main() {

--- a/sycl/test/separate-compile/same-kernel.cpp
+++ b/sycl/test/separate-compile/same-kernel.cpp
@@ -26,7 +26,7 @@ public:
   TestFnObj(buffer<int> &buf, handler &cgh) :
     data(buf.get_access<access::mode::write>(cgh)) {}
   accessor<int, 1, access::mode::write, access::target::global_buffer> data;
-  void operator()(id<1> item) {
+  void operator()(id<1> item) const {
     data[item] = item[0];
   }
 };

--- a/sycl/test/separate-compile/same-kernel.cpp
+++ b/sycl/test/separate-compile/same-kernel.cpp
@@ -26,9 +26,7 @@ public:
   TestFnObj(buffer<int> &buf, handler &cgh) :
     data(buf.get_access<access::mode::write>(cgh)) {}
   accessor<int, 1, access::mode::write, access::target::global_buffer> data;
-  void operator()(id<1> item) const {
-    data[item] = item[0];
-  }
+  void operator()(id<1> item) const { data[item] = item[0]; }
 };
 
 void kernel2();

--- a/sycl/test/sub_group/attributes.cpp
+++ b/sycl/test/sub_group/attributes.cpp
@@ -22,7 +22,7 @@
   class KernelFunctor##SIZE {                                                  \
   public:                                                                      \
     [[cl::intel_reqd_sub_group_size(SIZE)]] void                               \
-    operator()(cl::sycl::nd_item<1> Item) {                                    \
+    operator()(cl::sycl::nd_item<1> Item) const {                              \
       const auto GID = Item.get_global_id();                                   \
     }                                                                          \
   };

--- a/sycl/test/sub_group/attributes.cpp
+++ b/sycl/test/sub_group/attributes.cpp
@@ -18,13 +18,13 @@
 
 #include <CL/sycl.hpp>
 
-#define KERNEL_FUNCTOR_WITH_SIZE(SIZE)            \
-  class KernelFunctor##SIZE {                     \
-  public:                                         \
-    [[cl::intel_reqd_sub_group_size(SIZE)]] void  \
-    operator()(cl::sycl::nd_item<1> Item) const { \
-      const auto GID = Item.get_global_id();      \
-    }                                             \
+#define KERNEL_FUNCTOR_WITH_SIZE(SIZE)                                         \
+  class KernelFunctor##SIZE {                                                  \
+  public:                                                                      \
+    [[cl::intel_reqd_sub_group_size(SIZE)]] void                               \
+    operator()(cl::sycl::nd_item<1> Item) const {                              \
+      const auto GID = Item.get_global_id();                                   \
+    }                                                                          \
   };
 
 KERNEL_FUNCTOR_WITH_SIZE(1);

--- a/sycl/test/sub_group/attributes.cpp
+++ b/sycl/test/sub_group/attributes.cpp
@@ -18,13 +18,13 @@
 
 #include <CL/sycl.hpp>
 
-#define KERNEL_FUNCTOR_WITH_SIZE(SIZE)                                         \
-  class KernelFunctor##SIZE {                                                  \
-  public:                                                                      \
-    [[cl::intel_reqd_sub_group_size(SIZE)]] void                               \
-    operator()(cl::sycl::nd_item<1> Item) const {                              \
-      const auto GID = Item.get_global_id();                                   \
-    }                                                                          \
+#define KERNEL_FUNCTOR_WITH_SIZE(SIZE)            \
+  class KernelFunctor##SIZE {                     \
+  public:                                         \
+    [[cl::intel_reqd_sub_group_size(SIZE)]] void  \
+    operator()(cl::sycl::nd_item<1> Item) const { \
+      const auto GID = Item.get_global_id();      \
+    }                                             \
   };
 
 KERNEL_FUNCTOR_WITH_SIZE(1);


### PR DESCRIPTION
With the latest changes in the SYCL spec kernel lambdas (and functors) must be const references. Have updated the SYCL headers and tests with this change.  Also had to make a minor adjustment to the kernel generation code in Clang and update many of the SemaSYCL tests, because their mock kernel defs needed to be updated as well. 





Signed-off-by: Chris Perkins <chris.perkins@intel.com>

