### PR TITLE
[SYCL] Matching sizeof long double of SYCL device with that of host

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -2065,7 +2065,9 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
       Align = Target->getDoubleAlign();
       break;
     case BuiltinType::LongDouble:
-      if (getLangOpts().OpenMP && getLangOpts().OpenMPIsDevice &&
+      if (((getLangOpts().SYCL && getLangOpts().SYCLIsDevice) ||
+           (getLangOpts().OpenMP && getLangOpts().OpenMPIsDevice)) &&
+          AuxTarget != nullptr &&
           (Target->getLongDoubleWidth() != AuxTarget->getLongDoubleWidth() ||
            Target->getLongDoubleAlign() != AuxTarget->getLongDoubleAlign())) {
         Width = AuxTarget->getLongDoubleWidth();

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -209,8 +209,6 @@ public:
   MicrosoftX86_32SPIRTargetInfo(const llvm::Triple &Triple,
                             const TargetOptions &Opts)
       : WindowsX86_32SPIRTargetInfo(Triple, Opts) {
-    LongDoubleWidth = LongDoubleAlign = 64;
-    LongDoubleFormat = &llvm::APFloat::IEEEdouble();
     assert(DataLayout->getPointerSizeInBits() == 32);
   }
 
@@ -261,8 +259,6 @@ public:
   MicrosoftX86_64_SPIR64TargetInfo(const llvm::Triple &Triple,
                             const TargetOptions &Opts)
       : WindowsX86_64_SPIR64TargetInfo(Triple, Opts) {
-    LongDoubleWidth = LongDoubleAlign = 64;
-    LongDoubleFormat = &llvm::APFloat::IEEEdouble();
     assert(DataLayout->getPointerSizeInBits() == 64);
   }
 

--- a/clang/test/SemaSYCL/check-long-double-size.cpp
+++ b/clang/test/SemaSYCL/check-long-double-size.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -aux-triple x86_64-unknown-linux-gnu -fsyntax-only -DLONG_DOUBLE_SIZE=16 -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir-unknown-unknown-sycldevice -aux-triple i386-pc-linux-gnu -fsyntax-only -DLONG_DOUBLE_SIZE=12 -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-windows-sycldevice -aux-triple x86_64-pc-windows-msvc -fsyntax-only -DLONG_DOUBLE_SIZE=8 -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir-unknown-windows-sycldevice -aux-triple i686-pc-windows-msvc -fsyntax-only -DLONG_DOUBLE_SIZE=8 -verify %s
+// expected-no-diagnostics
+
+static_assert(sizeof(long double) == LONG_DOUBLE_SIZE, "wrong sizeof long double");


### PR DESCRIPTION
static_assert of sizeof(long double)>8 fails to compile with -fsycl
switch because sizeof(long double) for SYCL device is 8 bytes whereas
the host is 16 bytes. This commit sets sizeof(long double) width to 16
bytes to match that of SYCL host for Linux gnu SYCLdevice x86_64 and x86