### PR TITLE
Remove "unreachable" instruction from LLVM IR for SYCL devices

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5017,8 +5017,9 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         EmitNounwindRuntimeCall(Fn);
       }
     }
-
-    EmitUnreachable(Loc);
+    //Do not emit unreachable instruction for Intel NEO driver and Gen "X" GPUs
+    if(getTarget().getTriple().getSubArch() != llvm::Triple::SPIRSubArch_gen)
+      EmitUnreachable(Loc);
     Builder.ClearInsertionPoint();
 
     // FIXME: For now, emit a dummy basic block because expr emitters in

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5018,7 +5018,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
       }
     }
     // Emit unreachable only for non-sycl devices
-    if (getTarget().getTriple().getSubArch() != getLangOpts().SYCLIsDevice)
+    if (!getLangOpts().SYCLIsDevice)
       EmitUnreachable(Loc);
     Builder.ClearInsertionPoint();
 

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5017,8 +5017,8 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         EmitNounwindRuntimeCall(Fn);
       }
     }
-    //Emit unreachable only for non-sycl devices
-    if(getTarget().getTriple().getSubArch() != getLangOpts().SYCLIsDevice)
+    // Emit unreachable only for non-sycl devices
+    if (getTarget().getTriple().getSubArch() != getLangOpts().SYCLIsDevice)
       EmitUnreachable(Loc);
     Builder.ClearInsertionPoint();
 

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -4988,10 +4988,10 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
 
   // 4. Finish the call.
 
-  // If the call doesn't return, finish the basic block and clear the
+  // If the call doesn't return for non-sycl devices, finish the basic block and clear the
   // insertion point; this allows the rest of IRGen to discard
   // unreachable code.
-  if (CI->doesNotReturn()) {
+  if (CI->doesNotReturn() && !getLangOpts().SYCLIsDevice) {
     if (UnusedReturnSizePtr)
       PopCleanupBlock();
 
@@ -5017,9 +5017,8 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         EmitNounwindRuntimeCall(Fn);
       }
     }
-    // Emit unreachable only for non-sycl devices
-    if (!getLangOpts().SYCLIsDevice)
-      EmitUnreachable(Loc);
+    
+    EmitUnreachable(Loc);
     Builder.ClearInsertionPoint();
 
     // FIXME: For now, emit a dummy basic block because expr emitters in

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5017,8 +5017,8 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         EmitNounwindRuntimeCall(Fn);
       }
     }
-    //Do not emit unreachable instruction for Intel NEO driver and Gen "X" GPUs
-    if(getTarget().getTriple().getSubArch() != llvm::Triple::SPIRSubArch_gen)
+    // Do not emit unreachable instruction for Intel NEO driver and Gen "X" GPUs
+    if (getTarget().getTriple().getSubArch() != llvm::Triple::SPIRSubArch_gen)
       EmitUnreachable(Loc);
     Builder.ClearInsertionPoint();
 

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5017,8 +5017,8 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         EmitNounwindRuntimeCall(Fn);
       }
     }
-    // Do not emit unreachable instruction for Intel NEO driver and Gen "X" GPUs
-    if (getTarget().getTriple().getSubArch() != llvm::Triple::SPIRSubArch_gen)
+    //Emit unreachable only for non-sycl devices
+    if(getTarget().getTriple().getSubArch() != getLangOpts().SYCLIsDevice)
       EmitUnreachable(Loc);
     Builder.ClearInsertionPoint();
 

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -4988,8 +4988,8 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
 
   // 4. Finish the call.
 
-  // If the call doesn't return for non-sycl devices, finish the basic block and clear the
-  // insertion point; this allows the rest of IRGen to discard
+  // If the call doesn't return for non-sycl devices, finish the basic block and
+  // clear the insertion point; this allows the rest of IRGen to discard
   // unreachable code.
   if (CI->doesNotReturn() && !getLangOpts().SYCLIsDevice) {
     if (UnusedReturnSizePtr)
@@ -5017,7 +5017,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         EmitNounwindRuntimeCall(Fn);
       }
     }
-    
+
     EmitUnreachable(Loc);
     Builder.ClearInsertionPoint();
 

--- a/clang/test/CodeGenSYCL/remove-ur-inst.cpp
+++ b/clang/test/CodeGenSYCL/remove-ur-inst.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
+
+
+SYCL_EXTERNAL void doesNotReturn ()
+     throw () __attribute__ ((__noreturn__));
+
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel<class test>([]() {
+    doesNotReturn();
+    // CHECK-NOT: unreachable
+  });
+  return 0;
+}

--- a/clang/test/CodeGenSYCL/remove-ur-inst.cpp
+++ b/clang/test/CodeGenSYCL/remove-ur-inst.cpp
@@ -1,9 +1,6 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
 
-
-SYCL_EXTERNAL void doesNotReturn ()
-     throw () __attribute__ ((__noreturn__));
-
+SYCL_EXTERNAL void doesNotReturn() throw() __attribute__((__noreturn__));
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {

--- a/sycl/test/devicelib/assert.cpp
+++ b/sycl/test/devicelib/assert.cpp
@@ -134,7 +134,7 @@ void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
   }
   if (unsupported && getenv("SKIP_IF_NO_EXT")) {
     fprintf(stderr, "Device has no support for cl_intel_devicelib_assert, "
-                    "skipping the test \n");
+                    "skipping the test\n");
     exit(EXIT_SKIP_TEST);
   }
 

--- a/sycl/test/devicelib/assert.cpp
+++ b/sycl/test/devicelib/assert.cpp
@@ -65,9 +65,6 @@
 // in SYCL Runtime, so it doesn't look into a device extensions list and always
 // link the fallback library.
 //
-// NOTE that Intel OpenCL CPU Vectorizer crashes when an `unreachable'
-// instruction is found in IR. Workaround it for now using
-// CL_CONFIG_USE_VECTORIZER=False environment variable.
 //
 // We also skip the native test entirely (see SKIP_IF_NO_EXT), since the assert
 // extension is a new feature and may not be supported by the runtime used with
@@ -75,12 +72,12 @@
 //
 // Overall this sounds stable enough. What could possibly go wrong?
 //
-// RUN: env SYCL_PI_TRACE=2 SHOULD_CRASH=1 CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGABRT SKIP_IF_NO_EXT=1 %t.out 2>%t.stderr.native >%t.stdout.native
+// RUN: env SYCL_PI_TRACE=2 SHOULD_CRASH=1 SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGABRT SKIP_IF_NO_EXT=1 %t.out 2>%t.stderr.native >%t.stdout.native
 // RUN: FileCheck %s --input-file %t.stdout.native --check-prefixes=CHECK-NATIVE || FileCheck %s --input-file %t.stderr.native --check-prefix CHECK-NOTSUPPORTED
 // RUN: FileCheck %s --input-file %t.stderr.native --check-prefixes=CHECK-MESSAGE || FileCheck %s --input-file %t.stderr.native --check-prefix CHECK-NOTSUPPORTED
 //
-// RUN: env SYCL_PI_TRACE=2 SYCL_DEVICELIB_INHIBIT_NATIVE=cl_intel_devicelib_assert CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGSEGV %t.out >%t.stdout.pi.fallback
-// RUN: env SHOULD_CRASH=1 SYCL_DEVICELIB_INHIBIT_NATIVE=cl_intel_devicelib_assert CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGSEGV %t.out >%t.stdout.msg.fallback
+// RUN: env SYCL_PI_TRACE=2 SYCL_DEVICELIB_INHIBIT_NATIVE=cl_intel_devicelib_assert SYCL_DEVICE_TYPE=CPU  %t.out >%t.stdout.pi.fallback
+// RUN: env SYCL_DEVICELIB_INHIBIT_NATIVE=cl_intel_devicelib_assert SYCL_DEVICE_TYPE=CPU  %t.out >%t.stdout.msg.fallback
 // RUN: FileCheck %s --input-file %t.stdout.pi.fallback --check-prefixes=CHECK-FALLBACK
 // RUN: FileCheck %s --input-file %t.stdout.msg.fallback --check-prefixes=CHECK-MESSAGE
 //
@@ -137,11 +134,10 @@ void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
   }
   if (unsupported && getenv("SKIP_IF_NO_EXT")) {
     fprintf(stderr, "Device has no support for cl_intel_devicelib_assert, "
-                    "skipping the test\n");
+                    "skipping the test \n");
     exit(EXIT_SKIP_TEST);
   }
 
-  int shouldCrash = getenv("SHOULD_CRASH") ? 1 : 0;
 
   cl::sycl::range<1> numOfItems{N};
   cl::sycl::buffer<T, 1> bufferA(VA.data(), numOfItems);
@@ -155,9 +151,7 @@ void simple_vadd(const std::array<T, N> &VA, const std::array<T, N> &VB,
 
     cgh.parallel_for<class SimpleVaddT>(numOfItems, [=](cl::sycl::id<1> wiID) {
       accessorC[wiID] = accessorA[wiID] + accessorB[wiID];
-      if (shouldCrash) {
         assert(accessorC[wiID] == 0 && "Invalid value");
-      }
     });
   });
   deviceQueue.wait_and_throw();


### PR DESCRIPTION
C/C++ standard functions with `__attribute__ ((__noreturn__))` in SYCL device code emit "unreachable" instruction in LLVM IR. This PR removes the "ur" instruction in LLVM IR for SYCL devices.