### PR TITLE
[SYCL] Fix FPGA devices selection on queue initialization

### DIFF
--- a/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
@@ -32,9 +32,9 @@ public:
   }
 };
 
-const char * EMULATION_PLATFORM_NAME =
+const char *EMULATION_PLATFORM_NAME =
     "Intel(R) FPGA Emulation Platform for OpenCL(TM)";
-const char * HARDWARE_PLATFORM_NAME = "Intel(R) FPGA SDK for OpenCL(TM)";
+const char *HARDWARE_PLATFORM_NAME = "Intel(R) FPGA SDK for OpenCL(TM)";
 
 class fpga_selector : public platform_selector {
 public:

--- a/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
@@ -32,9 +32,9 @@ public:
   }
 };
 
-static constexpr char const *EMULATION_PLATFORM_NAME =
+static constexpr auto EMULATION_PLATFORM_NAME =
     "Intel(R) FPGA Emulation Platform for OpenCL(TM)";
-static constexpr char const *HARDWARE_PLATFORM_NAME =
+static constexpr auto HARDWARE_PLATFORM_NAME =
     "Intel(R) FPGA SDK for OpenCL(TM)";
 
 class fpga_selector : public platform_selector {

--- a/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
@@ -32,9 +32,10 @@ public:
   }
 };
 
-const char *EMULATION_PLATFORM_NAME =
+static constexpr char const *EMULATION_PLATFORM_NAME =
     "Intel(R) FPGA Emulation Platform for OpenCL(TM)";
-const char *HARDWARE_PLATFORM_NAME = "Intel(R) FPGA SDK for OpenCL(TM)";
+static constexpr char const *HARDWARE_PLATFORM_NAME =
+    "Intel(R) FPGA SDK for OpenCL(TM)";
 
 class fpga_selector : public platform_selector {
 public:

--- a/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
+++ b/sycl/include/CL/sycl/intel/fpga_device_selector.hpp
@@ -22,7 +22,7 @@ public:
   platform_selector(const std::string &platform_name)
       : device_platform_name(platform_name){}
 
-  virtual int operator()(const device &device) const {
+  int operator()(const device &device) const override {
     const platform &pf = device.get_platform();
     const std::string &platform_name = pf.get_info<info::platform::name>();
     if (platform_name == device_platform_name) {
@@ -32,9 +32,9 @@ public:
   }
 };
 
-const std::string EMULATION_PLATFORM_NAME =
+const char * EMULATION_PLATFORM_NAME =
     "Intel(R) FPGA Emulation Platform for OpenCL(TM)";
-const std::string HARDWARE_PLATFORM_NAME = "Intel(R) FPGA SDK for OpenCL(TM)";
+const char * HARDWARE_PLATFORM_NAME = "Intel(R) FPGA SDK for OpenCL(TM)";
 
 class fpga_selector : public platform_selector {
 public:

--- a/sycl/test/fpga_tests/global_fpga_device_selector.cpp
+++ b/sycl/test/fpga_tests/global_fpga_device_selector.cpp
@@ -1,0 +1,26 @@
+//==--- global_fpga_device_selector.cpp - SYCL FPGA device selector test ---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: aoc, accelerator
+
+// RUN: %clangxx -fsycl -fintelfpga -std=c++17 %s -o %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/intel/fpga_extensions.hpp>
+
+// Check that FPGA emulator device is found if we try to initialize inline global
+// variable using fpga_emulator_selector parameter.
+
+inline cl::sycl::queue fpga_emu_queue_inlined{
+    cl::sycl::intel::fpga_emulator_selector{}};
+
+int main () {
+    return 0;
+}
+

--- a/sycl/test/fpga_tests/global_fpga_device_selector.cpp
+++ b/sycl/test/fpga_tests/global_fpga_device_selector.cpp
@@ -1,11 +1,3 @@
-//==--- global_fpga_device_selector.cpp - SYCL FPGA device selector test ---==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aoc, accelerator
 
 // RUN: %clangxx -fsycl -fintelfpga -std=c++17 %s -o %t.out
@@ -23,4 +15,3 @@ inline cl::sycl::queue fpga_emu_queue_inlined{
 int main() {
   return 0;
 }
-

--- a/sycl/test/fpga_tests/global_fpga_device_selector.cpp
+++ b/sycl/test/fpga_tests/global_fpga_device_selector.cpp
@@ -21,6 +21,6 @@ inline cl::sycl::queue fpga_emu_queue_inlined{
     cl::sycl::intel::fpga_emulator_selector{}};
 
 int main () {
-    return 0;
+  return 0;
 }
 

--- a/sycl/test/fpga_tests/global_fpga_device_selector.cpp
+++ b/sycl/test/fpga_tests/global_fpga_device_selector.cpp
@@ -20,7 +20,7 @@
 inline cl::sycl::queue fpga_emu_queue_inlined{
     cl::sycl::intel::fpga_emulator_selector{}};
 
-int main () {
+int main() {
   return 0;
 }
 


### PR DESCRIPTION
FPGA device selectors use global constants of std::string type as
parameters in constructor. If some other inline global variable uses
fpga_device_selector in its constructor then there may be a situation
when FPGA device selector is initialized before global std::string
objects that it is depending on. Then it cannot find FPGA hw or
emulator devices because it has uninitialized platform name member.
Change type of constant strings with platform names to constant
C-string to guarantee initialization of FPGA device selector with
proper platform name.