### PR TITLE
[SYCL][NFC] Handle a bunch of warnings coming from SYCL RT

### DIFF
--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -196,9 +196,6 @@ vec<T, 4> readPixel(T *Ptr, const image_channel_order ChannelOrder,
     Pixel.y() = Ptr[2]; // g
     Pixel.x() = Ptr[3]; // r
     break;
-  default:
-    throw cl::sycl::invalid_parameter_error("Unhandled image channel order",
-                                            PI_INVALID_VALUE);
   }
 
   return Pixel;
@@ -269,9 +266,6 @@ void writePixel(const vec<T, 4> Pixel, T *Ptr,
     Ptr[2] = Pixel.y(); // g
     Ptr[3] = Pixel.x(); // r
     break;
-  default:
-    throw cl::sycl::invalid_parameter_error("Unhandled image channel order",
-                                            PI_INVALID_VALUE);
   }
 }
 
@@ -413,8 +407,6 @@ void convertReadData(const vec<ChannelType, 4> PixelData,
   case image_channel_type::fp32:
     RetData = PixelData.template convert<cl_float>();
     break;
-  default:
-    break;
   }
 }
 
@@ -471,8 +463,6 @@ void convertReadData(const vec<ChannelType, 4> PixelData,
         "Datatype to read - cl_half4 is incompatible with the "
         "image_channel_type of the image.",
         PI_INVALID_VALUE);
-  default:
-    break;
   }
   RetData = RetDataFloat.template convert<cl_half>();
 }
@@ -634,8 +624,6 @@ convertWriteData(const vec<cl_float, 4> WriteData,
     return WriteData.convert<ChannelType>();
   case image_channel_type::fp32:
     return WriteData.convert<ChannelType>();
-  default:
-    break;
   }
 }
 
@@ -685,8 +673,6 @@ convertWriteData(const vec<cl_half, 4> WriteData,
         "Datatype of data to write - cl_float4 is incompatible with the "
         "image_channel_type of the image.",
         PI_INVALID_VALUE);
-  default:
-    break;
   }
 }
 
@@ -945,19 +931,19 @@ DataT ReadPixelDataLinearFiltMode(const cl_int8 CoordValues,
 
   // Get Color Values at each Coordinate.
   cl_float4 Ci0j0k0 = getColorInFloat(cl_int4{i0, j0, k0, 0});
-  
+
   cl_float4 Ci1j0k0 = getColorInFloat(cl_int4{i1, j0, k0, 0});
-  
+
   cl_float4 Ci0j1k0 = getColorInFloat(cl_int4{i0, j1, k0, 0});
-  
+
   cl_float4 Ci1j1k0 = getColorInFloat(cl_int4{i1, j1, k0, 0});
-  
+
   cl_float4 Ci0j0k1 = getColorInFloat(cl_int4{i0, j0, k1, 0});
-  
+
   cl_float4 Ci1j0k1 = getColorInFloat(cl_int4{i1, j0, k1, 0});
-  
+
   cl_float4 Ci0j1k1 = getColorInFloat(cl_int4{i0, j1, k1, 0});
-  
+
   cl_float4 Ci1j1k1 = getColorInFloat(cl_int4{i1, j1, k1, 0});
 
   cl_float a = abc.x();

--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -933,17 +933,17 @@ DataT ReadPixelDataLinearFiltMode(const cl_int8 CoordValues,
   cl_float4 Ci0j0k0 = getColorInFloat(cl_int4{i0, j0, k0, 0});
 
   cl_float4 Ci1j0k0 = getColorInFloat(cl_int4{i1, j0, k0, 0});
-
+ 
   cl_float4 Ci0j1k0 = getColorInFloat(cl_int4{i0, j1, k0, 0});
-
+ 
   cl_float4 Ci1j1k0 = getColorInFloat(cl_int4{i1, j1, k0, 0});
-
+ 
   cl_float4 Ci0j0k1 = getColorInFloat(cl_int4{i0, j0, k1, 0});
-
+ 
   cl_float4 Ci1j0k1 = getColorInFloat(cl_int4{i1, j0, k1, 0});
-
+ 
   cl_float4 Ci0j1k1 = getColorInFloat(cl_int4{i0, j1, k1, 0});
-
+ 
   cl_float4 Ci1j1k1 = getColorInFloat(cl_int4{i1, j1, k1, 0});
 
   cl_float a = abc.x();

--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -931,19 +931,19 @@ DataT ReadPixelDataLinearFiltMode(const cl_int8 CoordValues,
 
   // Get Color Values at each Coordinate.
   cl_float4 Ci0j0k0 = getColorInFloat(cl_int4{i0, j0, k0, 0});
-
+  
   cl_float4 Ci1j0k0 = getColorInFloat(cl_int4{i1, j0, k0, 0});
-
+  
   cl_float4 Ci0j1k0 = getColorInFloat(cl_int4{i0, j1, k0, 0});
-
+  
   cl_float4 Ci1j1k0 = getColorInFloat(cl_int4{i1, j1, k0, 0});
-
+  
   cl_float4 Ci0j0k1 = getColorInFloat(cl_int4{i0, j0, k1, 0});
-
+  
   cl_float4 Ci1j0k1 = getColorInFloat(cl_int4{i1, j0, k1, 0});
-
+  
   cl_float4 Ci0j1k1 = getColorInFloat(cl_int4{i0, j1, k1, 0});
-
+  
   cl_float4 Ci1j1k1 = getColorInFloat(cl_int4{i1, j1, k1, 0});
 
   cl_float a = abc.x();

--- a/sycl/include/CL/sycl/detail/image_accessor_util.hpp
+++ b/sycl/include/CL/sycl/detail/image_accessor_util.hpp
@@ -933,17 +933,17 @@ DataT ReadPixelDataLinearFiltMode(const cl_int8 CoordValues,
   cl_float4 Ci0j0k0 = getColorInFloat(cl_int4{i0, j0, k0, 0});
 
   cl_float4 Ci1j0k0 = getColorInFloat(cl_int4{i1, j0, k0, 0});
- 
+
   cl_float4 Ci0j1k0 = getColorInFloat(cl_int4{i0, j1, k0, 0});
- 
+
   cl_float4 Ci1j1k0 = getColorInFloat(cl_int4{i1, j1, k0, 0});
- 
+
   cl_float4 Ci0j0k1 = getColorInFloat(cl_int4{i0, j0, k1, 0});
- 
+
   cl_float4 Ci1j0k1 = getColorInFloat(cl_int4{i1, j0, k1, 0});
- 
+
   cl_float4 Ci0j1k1 = getColorInFloat(cl_int4{i0, j1, k1, 0});
- 
+
   cl_float4 Ci1j1k1 = getColorInFloat(cl_int4{i1, j1, k1, 0});
 
   cl_float a = abc.x();

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1537,8 +1537,8 @@ public:
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
 
     MRequirements.push_back(AccImpl.get());
-    MSrcPtr = (void *)Src;
-    MDstPtr = (void *)AccImpl.get();
+    MSrcPtr = const_cast<void *>(Src);
+    MDstPtr = static_cast<void *>(AccImpl.get());
     // Store copy of accessor to the local storage to make sure it is alive
     // until we finish
     MAccStorage.push_back(std::move(AccImpl));

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1537,7 +1537,7 @@ public:
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
 
     MRequirements.push_back(AccImpl.get());
-    MSrcPtr = const_cast<void *>(Src);
+    MSrcPtr = const_cast<T_Src *>(Src);
     MDstPtr = static_cast<void *>(AccImpl.get());
     // Store copy of accessor to the local storage to make sure it is alive
     // until we finish

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -85,7 +85,7 @@ get_kernel_work_group_info_host(const cl::sycl::device &Device);
 template <>
 inline cl::sycl::range<3>
 get_kernel_work_group_info_host<info::kernel_work_group::global_work_size>(
-    const cl::sycl::device &Dev) {
+    const cl::sycl::device &) {
   throw invalid_object_error("This instance of kernel is a host instance",
                              PI_INVALID_KERNEL);
 }
@@ -100,7 +100,7 @@ get_kernel_work_group_info_host<info::kernel_work_group::work_group_size>(
 template <>
 inline cl::sycl::range<3> get_kernel_work_group_info_host<
     info::kernel_work_group::compile_work_group_size>(
-    const cl::sycl::device &Dev) {
+    const cl::sycl::device &) {
   return {0, 0, 0};
 }
 
@@ -115,7 +115,7 @@ inline size_t get_kernel_work_group_info_host<
 template <>
 inline cl_ulong
 get_kernel_work_group_info_host<info::kernel_work_group::private_mem_size>(
-    const cl::sycl::device &Dev) {
+    const cl::sycl::device &) {
   return 0;
 }
 // The kernel sub-group methods

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -107,7 +107,7 @@ void *MemoryManager::allocateInteropMemObject(
     return UserPtr;
   }
   // Allocate new cl_mem and initialize from user provided one.
-  assert(!"Not implemented");
+  assert(false && "Not implemented");
   return nullptr;
 }
 
@@ -203,7 +203,7 @@ void *MemoryManager::allocateMemSubBuffer(ContextImplPtr TargetContext,
   return NewMem;
 }
 
-void copyH2D(SYCLMemObjI *SYCLMemObj, char *SrcMem, QueueImplPtr SrcQueue,
+void copyH2D(SYCLMemObjI *SYCLMemObj, char *SrcMem, QueueImplPtr ,
              unsigned int DimSrc, sycl::range<3> SrcSize,
              sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
              unsigned int SrcElemSize, RT::PiMem DstMem, QueueImplPtr TgtQueue,
@@ -255,7 +255,7 @@ void copyH2D(SYCLMemObjI *SYCLMemObj, char *SrcMem, QueueImplPtr SrcQueue,
 void copyD2H(SYCLMemObjI *SYCLMemObj, RT::PiMem SrcMem, QueueImplPtr SrcQueue,
              unsigned int DimSrc, sycl::range<3> SrcSize,
              sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
-             unsigned int SrcElemSize, char *DstMem, QueueImplPtr TgtQueue,
+             unsigned int SrcElemSize, char *DstMem, QueueImplPtr ,
              unsigned int DimDst, sycl::range<3> DstSize,
              sycl::range<3> DstAccessRange, sycl::id<3> DstOffset,
              unsigned int DstElemSize, std::vector<RT::PiEvent> DepEvents,
@@ -302,9 +302,9 @@ void copyD2H(SYCLMemObjI *SYCLMemObj, RT::PiMem SrcMem, QueueImplPtr SrcQueue,
 void copyD2D(SYCLMemObjI *SYCLMemObj, RT::PiMem SrcMem, QueueImplPtr SrcQueue,
              unsigned int DimSrc, sycl::range<3> SrcSize,
              sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
-             unsigned int SrcElemSize, RT::PiMem DstMem, QueueImplPtr TgtQueue,
+             unsigned int SrcElemSize, RT::PiMem DstMem, QueueImplPtr,
              unsigned int DimDst, sycl::range<3> DstSize,
-             sycl::range<3> DstAccessRange, sycl::id<3> DstOffset,
+             sycl::range<3>, sycl::id<3> DstOffset,
              unsigned int DstElemSize, std::vector<RT::PiEvent> DepEvents,
              RT::PiEvent &OutEvent) {
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
@@ -341,18 +341,17 @@ void copyD2D(SYCLMemObjI *SYCLMemObj, RT::PiMem SrcMem, QueueImplPtr SrcQueue,
   }
 }
 
-static void copyH2H(SYCLMemObjI *SYCLMemObj, char *SrcMem,
-                    QueueImplPtr SrcQueue, unsigned int DimSrc,
+static void copyH2H(SYCLMemObjI *, char *SrcMem,
+                    QueueImplPtr, unsigned int DimSrc,
                     sycl::range<3> SrcSize, sycl::range<3> SrcAccessRange,
                     sycl::id<3> SrcOffset, unsigned int SrcElemSize,
-                    char *DstMem, QueueImplPtr TgtQueue, unsigned int DimDst,
+                    char *DstMem, QueueImplPtr , unsigned int DimDst,
                     sycl::range<3> DstSize, sycl::range<3> DstAccessRange,
                     sycl::id<3> DstOffset, unsigned int DstElemSize,
-                    std::vector<RT::PiEvent> DepEvents, RT::PiEvent &OutEvent) {
+                    std::vector<RT::PiEvent> , RT::PiEvent &) {
   if ((DimSrc != 1 || DimDst != 1) &&
       (SrcOffset != id<3>{0, 0, 0} || DstOffset != id<3>{0, 0, 0} ||
        SrcSize != SrcAccessRange || DstSize != DstAccessRange)) {
-    assert(!"Not supported configuration of memcpy requested");
     throw runtime_error("Not supported configuration of memcpy requested",
                         PI_INVALID_OPERATION);
   }
@@ -412,7 +411,7 @@ void MemoryManager::copy(SYCLMemObjI *SYCLMemObj, void *SrcMem,
 
 void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
                          size_t PatternSize, const char *Pattern,
-                         unsigned int Dim, sycl::range<3> Size,
+                         unsigned int Dim, sycl::range<3> ,
                          sycl::range<3> Range, sycl::id<3> Offset,
                          unsigned int ElementSize,
                          std::vector<RT::PiEvent> DepEvents,
@@ -428,7 +427,6 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
           &DepEvents[0], &OutEvent);
       return;
     }
-    assert(!"Not supported configuration of fill requested");
     throw runtime_error("Not supported configuration of fill requested",
                         PI_INVALID_OPERATION);
   } else {
@@ -438,14 +436,13 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
   }
 }
 
-void *MemoryManager::map(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
-                         access::mode AccessMode, unsigned int Dim,
-                         sycl::range<3> Size, sycl::range<3> AccessRange,
+void *MemoryManager::map(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
+                         access::mode AccessMode, unsigned int ,
+                         sycl::range<3>, sycl::range<3> AccessRange,
                          sycl::id<3> AccessOffset, unsigned int ElementSize,
                          std::vector<RT::PiEvent> DepEvents,
                          RT::PiEvent &OutEvent) {
   if (Queue->is_host()) {
-    assert(!"Not supported configuration of map requested");
     throw runtime_error("Not supported configuration of map requested",
                         PI_INVALID_OPERATION);
   }
@@ -485,13 +482,13 @@ void *MemoryManager::map(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
   return MappedPtr;
 }
 
-void MemoryManager::unmap(SYCLMemObjI *SYCLMemObj, void *Mem,
+void MemoryManager::unmap(SYCLMemObjI *, void *Mem,
                           QueueImplPtr Queue, void *MappedPtr,
                           std::vector<RT::PiEvent> DepEvents,
                           RT::PiEvent &OutEvent) {
 
   // Host queue is not supported here.
-  // All DepEvents are to the same Context. 
+  // All DepEvents are to the same Context.
   // Using the plugin of the Queue.
 
   const detail::plugin &Plugin = Queue->getPlugin();

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -203,7 +203,7 @@ void *MemoryManager::allocateMemSubBuffer(ContextImplPtr TargetContext,
   return NewMem;
 }
 
-void copyH2D(SYCLMemObjI *SYCLMemObj, char *SrcMem, QueueImplPtr ,
+void copyH2D(SYCLMemObjI *SYCLMemObj, char *SrcMem, QueueImplPtr,
              unsigned int DimSrc, sycl::range<3> SrcSize,
              sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
              unsigned int SrcElemSize, RT::PiMem DstMem, QueueImplPtr TgtQueue,
@@ -255,11 +255,11 @@ void copyH2D(SYCLMemObjI *SYCLMemObj, char *SrcMem, QueueImplPtr ,
 void copyD2H(SYCLMemObjI *SYCLMemObj, RT::PiMem SrcMem, QueueImplPtr SrcQueue,
              unsigned int DimSrc, sycl::range<3> SrcSize,
              sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
-             unsigned int SrcElemSize, char *DstMem, QueueImplPtr ,
+             unsigned int SrcElemSize, char *DstMem, QueueImplPtr,
              unsigned int DimDst, sycl::range<3> DstSize,
              sycl::range<3> DstAccessRange, sycl::id<3> DstOffset,
              unsigned int DstElemSize, std::vector<RT::PiEvent> DepEvents,
-              RT::PiEvent &OutEvent) {
+             RT::PiEvent &OutEvent) {
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
 
   const RT::PiQueue Queue = SrcQueue->getHandleRef();
@@ -303,10 +303,9 @@ void copyD2D(SYCLMemObjI *SYCLMemObj, RT::PiMem SrcMem, QueueImplPtr SrcQueue,
              unsigned int DimSrc, sycl::range<3> SrcSize,
              sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
              unsigned int SrcElemSize, RT::PiMem DstMem, QueueImplPtr,
-             unsigned int DimDst, sycl::range<3> DstSize,
-             sycl::range<3>, sycl::id<3> DstOffset,
-             unsigned int DstElemSize, std::vector<RT::PiEvent> DepEvents,
-             RT::PiEvent &OutEvent) {
+             unsigned int DimDst, sycl::range<3> DstSize, sycl::range<3>,
+             sycl::id<3> DstOffset, unsigned int DstElemSize,
+             std::vector<RT::PiEvent> DepEvents, RT::PiEvent &OutEvent) {
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
 
   const RT::PiQueue Queue = SrcQueue->getHandleRef();
@@ -341,14 +340,14 @@ void copyD2D(SYCLMemObjI *SYCLMemObj, RT::PiMem SrcMem, QueueImplPtr SrcQueue,
   }
 }
 
-static void copyH2H(SYCLMemObjI *, char *SrcMem,
-                    QueueImplPtr, unsigned int DimSrc,
-                    sycl::range<3> SrcSize, sycl::range<3> SrcAccessRange,
-                    sycl::id<3> SrcOffset, unsigned int SrcElemSize,
-                    char *DstMem, QueueImplPtr , unsigned int DimDst,
-                    sycl::range<3> DstSize, sycl::range<3> DstAccessRange,
-                    sycl::id<3> DstOffset, unsigned int DstElemSize,
-                    std::vector<RT::PiEvent> , RT::PiEvent &) {
+static void copyH2H(SYCLMemObjI *, char *SrcMem, QueueImplPtr,
+                    unsigned int DimSrc, sycl::range<3> SrcSize,
+                    sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
+                    unsigned int SrcElemSize, char *DstMem, QueueImplPtr,
+                    unsigned int DimDst, sycl::range<3> DstSize,
+                    sycl::range<3> DstAccessRange, sycl::id<3> DstOffset,
+                    unsigned int DstElemSize, std::vector<RT::PiEvent>,
+                    RT::PiEvent &) {
   if ((DimSrc != 1 || DimDst != 1) &&
       (SrcOffset != id<3>{0, 0, 0} || DstOffset != id<3>{0, 0, 0} ||
        SrcSize != SrcAccessRange || DstSize != DstAccessRange)) {
@@ -411,9 +410,8 @@ void MemoryManager::copy(SYCLMemObjI *SYCLMemObj, void *SrcMem,
 
 void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
                          size_t PatternSize, const char *Pattern,
-                         unsigned int Dim, sycl::range<3> ,
-                         sycl::range<3> Range, sycl::id<3> Offset,
-                         unsigned int ElementSize,
+                         unsigned int Dim, sycl::range<3>, sycl::range<3> Range,
+                         sycl::id<3> Offset, unsigned int ElementSize,
                          std::vector<RT::PiEvent> DepEvents,
                          RT::PiEvent &OutEvent) {
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
@@ -437,9 +435,9 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
 }
 
 void *MemoryManager::map(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
-                         access::mode AccessMode, unsigned int ,
-                         sycl::range<3>, sycl::range<3> AccessRange,
-                         sycl::id<3> AccessOffset, unsigned int ElementSize,
+                         access::mode AccessMode, unsigned int, sycl::range<3>,
+                         sycl::range<3> AccessRange, sycl::id<3> AccessOffset,
+                         unsigned int ElementSize,
                          std::vector<RT::PiEvent> DepEvents,
                          RT::PiEvent &OutEvent) {
   if (Queue->is_host()) {
@@ -482,9 +480,8 @@ void *MemoryManager::map(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
   return MappedPtr;
 }
 
-void MemoryManager::unmap(SYCLMemObjI *, void *Mem,
-                          QueueImplPtr Queue, void *MappedPtr,
-                          std::vector<RT::PiEvent> DepEvents,
+void MemoryManager::unmap(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
+                          void *MappedPtr, std::vector<RT::PiEvent> DepEvents,
                           RT::PiEvent &OutEvent) {
 
   // Host queue is not supported here.

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1810,8 +1810,6 @@ cl_int ExecCGCommand::enqueueImp() {
                                                          Arg.MSize, Arg.MPtr);
         break;
       }
-      default:
-        assert(!"Unhandled");
       }
     }
 
@@ -1913,15 +1911,13 @@ cl_int ExecCGCommand::enqueueImp() {
       }
     }
 
-    MQueue->getThreadPool().submit<DispatchHostTask>(
-        std::move(DispatchHostTask(this)));
+    MQueue->getThreadPool().submit<DispatchHostTask>(DispatchHostTask(this));
 
     MShouldCompleteEventIfPossible = false;
 
     return CL_SUCCESS;
   }
   case CG::CGTYPE::NONE:
-  default:
     throw runtime_error("CG type not implemented.", PI_INVALID_OPERATION);
   }
 }

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1919,6 +1919,7 @@ cl_int ExecCGCommand::enqueueImp() {
   case CG::CGTYPE::NONE:
     throw runtime_error("CG type not implemented.", PI_INVALID_OPERATION);
   }
+  return PI_INVALID_OPERATION;
 }
 
 } // namespace detail

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1608,7 +1608,6 @@ cl_int ExecCGCommand::enqueueImp() {
   switch (MCommandGroup->getType()) {
 
   case CG::CGTYPE::UPDATE_HOST: {
-    assert(!"Update host should be handled by the Scheduler.");
     throw runtime_error("Update host should be handled by the Scheduler.",
                         PI_INVALID_OPERATION);
   }

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -422,8 +422,8 @@ public:
 
   void printDot(std::ostream &Stream) const final;
   const Requirement *getRequirement() const final { return &MDstReq; }
-  void emitInstrumentationData();
-  ContextImplPtr getContext() const override final;
+  void emitInstrumentationData() final;
+  ContextImplPtr getContext() const final;
 
 private:
   cl_int enqueueImp() final;
@@ -445,8 +445,8 @@ public:
 
   void printDot(std::ostream &Stream) const final;
   const Requirement *getRequirement() const final { return &MDstReq; }
-  void emitInstrumentationData() override final;
-  ContextImplPtr getContext() const override final;
+  void emitInstrumentationData() final;
+  ContextImplPtr getContext() const final;
 
 private:
   cl_int enqueueImp() final;
@@ -467,7 +467,7 @@ public:
   void flushStreams();
 
   void printDot(std::ostream &Stream) const final;
-  void emitInstrumentationData();
+  void emitInstrumentationData() final;
 
   detail::CG &getCG() const { return *MCommandGroup; }
 
@@ -494,7 +494,7 @@ public:
 
   void printDot(std::ostream &Stream) const final;
   const Requirement *getRequirement() const final { return &MDstReq; }
-  void emitInstrumentationData();
+  void emitInstrumentationData() final;
 
 private:
   cl_int enqueueImp() final;

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -165,7 +165,7 @@ public:
   virtual void printDot(std::ostream &Stream) const = 0;
 
   virtual const Requirement *getRequirement() const {
-    assert(!"Internal Error. The command has no stored requirement");
+    assert(false && "Internal Error. The command has no stored requirement");
     return nullptr;
   }
 
@@ -445,7 +445,7 @@ public:
 
   void printDot(std::ostream &Stream) const final;
   const Requirement *getRequirement() const final { return &MDstReq; }
-  void emitInstrumentationData();
+  void emitInstrumentationData() override final;
   ContextImplPtr getContext() const override final;
 
 private:

--- a/sycl/unittests/pi/PiMock.cpp
+++ b/sycl/unittests/pi/PiMock.cpp
@@ -13,15 +13,12 @@
 using namespace cl::sycl;
 
 pi_result
-piProgramBuildRedefine(pi_program program, pi_uint32 num_devices,
-                       const pi_device *device_list, const char *options,
-                       void (*pfn_notify)(pi_program program, void *user_data),
-                       void *user_data) {
+piProgramBuildRedefine(pi_program, pi_uint32,const pi_device *, const char *,
+                       void (*)(pi_program, void *), void *) {
   return PI_INVALID_BINARY;
 }
 
-pi_result piKernelCreateRedefine(pi_program program, const char *kernel_name,
-                                 pi_kernel *ret_kernel) {
+pi_result piKernelCreateRedefine(pi_program, const char *, pi_kernel *) {
   return PI_INVALID_DEVICE;
 }
 
@@ -91,7 +88,7 @@ TEST(PiMockTest, RedefineAPI) {
   // Pass a captureless lambda
   auto *OldFuncPtr = Table.piProgramRetain;
   Mock.redefine<detail::PiApiKind::piProgramRetain>(
-      [](pi_program program) -> pi_result { return PI_SUCCESS; });
+      [](pi_program) -> pi_result { return PI_SUCCESS; });
   EXPECT_FALSE(Table.piProgramRetain == OldFuncPtr)
       << "Passing a lambda didn't change the function table entry";
   ASSERT_FALSE(Table.piProgramRetain == nullptr)

--- a/sycl/unittests/pi/PiMock.cpp
+++ b/sycl/unittests/pi/PiMock.cpp
@@ -12,9 +12,9 @@
 
 using namespace cl::sycl;
 
-pi_result
-piProgramBuildRedefine(pi_program, pi_uint32,const pi_device *, const char *,
-                       void (*)(pi_program, void *), void *) {
+pi_result piProgramBuildRedefine(pi_program, pi_uint32, const pi_device *,
+                                 const char *, void (*)(pi_program, void *),
+                                 void *) {
   return PI_INVALID_BINARY;
 }
 

--- a/sycl/unittests/pi/PlatformTest.cpp
+++ b/sycl/unittests/pi/PlatformTest.cpp
@@ -24,7 +24,7 @@ protected:
 
   ~PlatformTest() override = default;
 
-  void SetUp() {
+  void SetUp() override {
 
     detail::plugin plugin = GetParam();
 

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -29,7 +29,7 @@ public:
       : Command{cl::sycl::detail::Command::EMPTY_TASK, Queue},
         MRequirement{std::move(getMockRequirement())} {}
 
-  void printDot(std::ostream &Stream) const override {}
+  void printDot(std::ostream &) const override {}
   void emitInstrumentationData() override {}
 
   const cl::sycl::detail::Requirement *getRequirement() const final {


### PR DESCRIPTION
- `-Wstring-conversion`: get rid of converting `const char*` to `bool` in `assert`
- `-Winconsistent-missing-override`: add missing `final` or `override`
- `-Wcovered-switch-default`: remove unreachable `default` clauses
- `-Wpessimizing-move`: allow temporary object copy elision by removing `std::move`
- `-Wcast-qual`: explicitly cast away `const` qualifier
- `-Wunused-parameter`: remove some unused parameters