### PR TITLE
[SYCL] Fixed assert on windows with GetModuleFileNameA failed

### DIFF
--- a/sycl/include/CL/sycl/detail/os_util.hpp
+++ b/sycl/include/CL/sycl/detail/os_util.hpp
@@ -59,7 +59,7 @@ public:
 
   /// Module handle for the executable module - it is assumed there is always
   /// single one at most.
-  static constexpr OSModuleHandle ExeModuleHandle = 0;
+  static constexpr OSModuleHandle ExeModuleHandle = -1;
 
   /// Dummy module handle to designate non-existing module for a device binary
   /// image loaded from file e.g. via SYCL_USE_KERNEL_SPV env var.

--- a/sycl/include/CL/sycl/detail/os_util.hpp
+++ b/sycl/include/CL/sycl/detail/os_util.hpp
@@ -59,7 +59,7 @@ public:
 
   /// Module handle for the executable module - it is assumed there is always
   /// single one at most.
-  static constexpr OSModuleHandle ExeModuleHandle = -1;
+  static constexpr OSModuleHandle ExeModuleHandle = 0;
 
   /// Dummy module handle to designate non-existing module for a device binary
   /// image loaded from file e.g. via SYCL_USE_KERNEL_SPV env var.

--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -191,7 +191,7 @@ OSModuleHandle OSUtil::getOSModuleHandle(const void *VirtAddr) {
     return 0;
   }
   if (PhModule == GetModuleHandleA(nullptr))
-    return OSUtil::ExeModuleHandle;
+    return 0;
   return reinterpret_cast<OSModuleHandle>(PhModule);
 }
 

--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -191,7 +191,7 @@ OSModuleHandle OSUtil::getOSModuleHandle(const void *VirtAddr) {
     return 0;
   }
   if (PhModule == GetModuleHandleA(nullptr))
-    return 0;
+    return OSUtil::ExeModuleHandle;
   return reinterpret_cast<OSModuleHandle>(PhModule);
 }
 
@@ -200,10 +200,10 @@ std::string OSUtil::getCurrentDSODir() {
   char Path[MAX_PATH];
   Path[0] = '\0';
   Path[sizeof(Path) - 1] = '\0';
+  auto Handle = getOSModuleHandle(&getCurrentDSODir);
   DWORD Ret = GetModuleFileNameA(
-    reinterpret_cast<HMODULE>(getOSModuleHandle(&getCurrentDSODir)),
-    reinterpret_cast<LPSTR>(&Path),
-    sizeof(Path));
+      reinterpret_cast<HMODULE>(OSUtil::ExeModuleHandle == Handle ? 0 : Handle),
+      reinterpret_cast<LPSTR>(&Path), sizeof(Path));
   assert(Ret < sizeof(Path) && "Path is longer than PATH_MAX?");
   assert(Ret > 0 && "GetModuleFileNameA failed");
   (void)Ret;


### PR DESCRIPTION
This patch fixes a problem on Windows, when any unit test with invocation kernel run:
`Assertion failed: Ret > 0 && "GetModuleFileNameA failed", file D:\sycl_workspace\llvm\sycl\source\detail\os_util.cpp, line 208`

GetModuleFileNameA() requires 0 as the first parameter for current executable module, but it is -1 (OSUtil::ExeModuleHandle), see return value in getOSModuleHandle().


About GetModuleFileNameA() from Windows API doc :
> A handle to the loaded module whose path is being requested. If this parameter is NULL, GetModuleFileName retrieves the path of the executable file of the current process.



Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>