### PR TITLE
[SYCL][ESIMD] TODO list started.

### DIFF
--- a/sycl/doc/extensions/ExplicitSIMD/ESIMD-TODO-list.md
+++ b/sycl/doc/extensions/ExplicitSIMD/ESIMD-TODO-list.md
@@ -1,0 +1,10 @@
+### TODO list for the SYCL Explicit SIMD extension.
+
+A place for TODO items/feedback regarding the extension in addition to the
+github issues mechanism.
+
+#### Front-End
+
+1. Fix a generic (unrelated to ESIMD) issue [1811](https://github.com/intel/llvm/issues/1811) with lambda/functor function
+   detection. Needed to improve diagnostics, fix attribute propagation.  
+   ETA: ???


### PR DESCRIPTION
This is a placeholder for various TODO items associated with the ESIMD extension.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>