### PR TITLE
[SYCL] Adjust Messaging for Invalid NDRange WorkGroup Sizes

### DIFF
--- a/sycl/source/detail/error_handling/enqueue_kernel.cpp
+++ b/sycl/source/detail/error_handling/enqueue_kernel.cpp
@@ -118,12 +118,9 @@ bool oclHandleInvalidWorkGroupSize(const device_impl &DeviceImpl,
     // Is the local size of the workgroup greater than the global range size in
     // any dimension? This is a sub-case of NonUniformWGs.
     const bool LocalExceedsGlobal =
-        (NDRDesc.LocalSize[0] != 0 &&
-         NDRDesc.LocalSize[0] > NDRDesc.GlobalSize[0]) ||
-        (NDRDesc.LocalSize[1] != 0 &&
-         NDRDesc.LocalSize[1] > NDRDesc.GlobalSize[1]) ||
-        (NDRDesc.LocalSize[2] != 0 &&
-         NDRDesc.LocalSize[2] > NDRDesc.GlobalSize[2]);
+        NonUniformWGs && (NDRDesc.LocalSize[0] > NDRDesc.GlobalSize[0] ||
+                          NDRDesc.LocalSize[1] > NDRDesc.GlobalSize[1] ||
+                          NDRDesc.LocalSize[2] > NDRDesc.GlobalSize[2]);
 
     if (NonUniformWGs) {
       if (Ver[0] == '1') {

--- a/sycl/source/detail/error_handling/enqueue_kernel.cpp
+++ b/sycl/source/detail/error_handling/enqueue_kernel.cpp
@@ -165,6 +165,7 @@ bool oclHandleInvalidWorkGroupSize(const device_impl &DeviceImpl,
               "OpenCL 2.x implementation supports this feature, but it is being "
               "disabled by -cl-uniform-work-group-size build flag"),
               PI_INVALID_WORK_GROUP_SIZE);
+        //else unknown.  fallback (below)
       }
     }
   }

--- a/sycl/source/detail/error_handling/enqueue_kernel.cpp
+++ b/sycl/source/detail/error_handling/enqueue_kernel.cpp
@@ -107,7 +107,7 @@ bool oclHandleInvalidWorkGroupSize(const device_impl &DeviceImpl,
   }
 
   if (HasLocalSize) {
-    // Is the global range size evenly divisible by the local workgroup size? 
+    // Is the global range size evenly divisible by the local workgroup size?
     const bool NonUniformWGs =
         (NDRDesc.LocalSize[0] != 0 &&
          NDRDesc.GlobalSize[0] % NDRDesc.LocalSize[0] != 0) ||
@@ -115,11 +115,16 @@ bool oclHandleInvalidWorkGroupSize(const device_impl &DeviceImpl,
          NDRDesc.GlobalSize[1] % NDRDesc.LocalSize[1] != 0) ||
         (NDRDesc.LocalSize[2] != 0 &&
          NDRDesc.GlobalSize[2] % NDRDesc.LocalSize[2] != 0);
-    // Is the local size of the workgroup greater than the global range size in any dimension? This is a sub-case of NonUniformWGs.
-    const bool LocalExceedsGlobal = (NDRDesc.LocalSize[0] != 0 && NDRDesc.LocalSize[0] > NDRDesc.GlobalSize[0]) ||
-                                    (NDRDesc.LocalSize[1] != 0 && NDRDesc.LocalSize[1] > NDRDesc.GlobalSize[1]) ||
-                                    (NDRDesc.LocalSize[2] != 0 && NDRDesc.LocalSize[2] > NDRDesc.GlobalSize[2]);
-    
+    // Is the local size of the workgroup greater than the global range size in
+    // any dimension? This is a sub-case of NonUniformWGs.
+    const bool LocalExceedsGlobal =
+        (NDRDesc.LocalSize[0] != 0 &&
+         NDRDesc.LocalSize[0] > NDRDesc.GlobalSize[0]) ||
+        (NDRDesc.LocalSize[1] != 0 &&
+         NDRDesc.LocalSize[1] > NDRDesc.GlobalSize[1]) ||
+        (NDRDesc.LocalSize[2] != 0 &&
+         NDRDesc.LocalSize[2] > NDRDesc.GlobalSize[2]);
+
     if (NonUniformWGs) {
       if (Ver[0] == '1') {
         // OpenCL 1.x:
@@ -127,9 +132,14 @@ bool oclHandleInvalidWorkGroupSize(const device_impl &DeviceImpl,
         // number of workitems specified by global_work_size is not evenly
         // divisible by size of work-group given by local_work_size
         if (LocalExceedsGlobal)
-          throw sycl::nd_range_error("Local workgroup size cannot be greater than global range in any dimension", PI_INVALID_WORK_GROUP_SIZE);
+          throw sycl::nd_range_error("Local workgroup size cannot be greater "
+                                     "than global range in any dimension",
+                                     PI_INVALID_WORK_GROUP_SIZE);
         else
-          throw sycl::nd_range_error("Global_work_size must be evenly divisible by local_work_size. Non-uniform work-groups are not supported by the target device",  PI_INVALID_WORK_GROUP_SIZE);
+          throw sycl::nd_range_error(
+              "Global_work_size must be evenly divisible by local_work_size. "
+              "Non-uniform work-groups are not supported by the target device",
+              PI_INVALID_WORK_GROUP_SIZE);
       } else {
         // OpenCL 2.x:
         // PI_INVALID_WORK_GROUP_SIZE if the program was compiled with
@@ -138,34 +148,42 @@ bool oclHandleInvalidWorkGroupSize(const device_impl &DeviceImpl,
         // given by local_work_size
 
         pi_program Program = nullptr;
-        Plugin.call<PiApiKind::piKernelGetInfo>(
-            Kernel, PI_KERNEL_INFO_PROGRAM, sizeof(pi_program), &Program, nullptr);
+        Plugin.call<PiApiKind::piKernelGetInfo>(Kernel, PI_KERNEL_INFO_PROGRAM,
+                                                sizeof(pi_program), &Program,
+                                                nullptr);
         size_t OptsSize = 0;
         Plugin.call<PiApiKind::piProgramGetBuildInfo>(
-            Program, Device, PI_PROGRAM_BUILD_INFO_OPTIONS, 0, nullptr, &OptsSize);
+            Program, Device, PI_PROGRAM_BUILD_INFO_OPTIONS, 0, nullptr,
+            &OptsSize);
         string_class Opts(OptsSize, '\0');
         Plugin.call<PiApiKind::piProgramGetBuildInfo>(
-            Program, Device, PI_PROGRAM_BUILD_INFO_OPTIONS, OptsSize, &Opts.front(),
-            nullptr);
+            Program, Device, PI_PROGRAM_BUILD_INFO_OPTIONS, OptsSize,
+            &Opts.front(), nullptr);
         const bool HasStd20 = Opts.find("-cl-std=CL2.0") != string_class::npos;
-        const bool RequiresUniformWGSize = Opts.find("-cl-uniform-work-group-size") != string_class::npos;
-        std::string message = LocalExceedsGlobal ? "Local workgroup size greater than global range size. "
-                                                 : "Global_work_size not evenly divisible by local_work_size. ";
+        const bool RequiresUniformWGSize =
+            Opts.find("-cl-uniform-work-group-size") != string_class::npos;
+        std::string message =
+            LocalExceedsGlobal
+                ? "Local workgroup size greater than global range size. "
+                : "Global_work_size not evenly divisible by local_work_size. ";
         if (!HasStd20)
           throw sycl::nd_range_error(
-              message.append(
-              "Non-uniform work-groups are not allowed by default. Underlying "
-              "OpenCL 2.x implementation supports this feature and to enable "
-              "it, build device program with -cl-std=CL2.0"),
+              message.append("Non-uniform work-groups are not allowed by "
+                             "default. Underlying "
+                             "OpenCL 2.x implementation supports this feature "
+                             "and to enable "
+                             "it, build device program with -cl-std=CL2.0"),
               PI_INVALID_WORK_GROUP_SIZE);
-        else if(RequiresUniformWGSize)
+        else if (RequiresUniformWGSize)
           throw sycl::nd_range_error(
               message.append(
-              "Non-uniform work-groups are not allowed by when -cl-uniform-work-group-size flag is used. Underlying "
-              "OpenCL 2.x implementation supports this feature, but it is being "
-              "disabled by -cl-uniform-work-group-size build flag"),
+                  "Non-uniform work-groups are not allowed by when "
+                  "-cl-uniform-work-group-size flag is used. Underlying "
+                  "OpenCL 2.x implementation supports this feature, but it is "
+                  "being "
+                  "disabled by -cl-uniform-work-group-size build flag"),
               PI_INVALID_WORK_GROUP_SIZE);
-        //else unknown.  fallback (below)
+        // else unknown.  fallback (below)
       }
     }
   }

--- a/sycl/source/detail/error_handling/enqueue_kernel.cpp
+++ b/sycl/source/detail/error_handling/enqueue_kernel.cpp
@@ -107,6 +107,7 @@ bool oclHandleInvalidWorkGroupSize(const device_impl &DeviceImpl,
   }
 
   if (HasLocalSize) {
+    // Is the global range size evenly divisible by the local workgroup size? 
     const bool NonUniformWGs =
         (NDRDesc.LocalSize[0] != 0 &&
          NDRDesc.GlobalSize[0] % NDRDesc.LocalSize[0] != 0) ||
@@ -114,44 +115,48 @@ bool oclHandleInvalidWorkGroupSize(const device_impl &DeviceImpl,
          NDRDesc.GlobalSize[1] % NDRDesc.LocalSize[1] != 0) ||
         (NDRDesc.LocalSize[2] != 0 &&
          NDRDesc.GlobalSize[2] % NDRDesc.LocalSize[2] != 0);
+    // Is the local size of the workgroup greater than the global range size in any dimension? This is a sub-case of NonUniformWGs.
+    const bool LocalExceedsGlobal = (NDRDesc.LocalSize[0] != 0 && NDRDesc.LocalSize[0] > NDRDesc.GlobalSize[0]) ||
+                                    (NDRDesc.LocalSize[1] != 0 && NDRDesc.LocalSize[1] > NDRDesc.GlobalSize[1]) ||
+                                    (NDRDesc.LocalSize[2] != 0 && NDRDesc.LocalSize[2] > NDRDesc.GlobalSize[2]);
+    if (LocalExceedsGlobal)
+        throw sycl::nd_range_error("Local workgroup size cannot be greater than global range in any dimension", PI_INVALID_WORK_GROUP_SIZE);
+    else if (NonUniformWGs) {
+      if (Ver[0] == '1') {
+        // OpenCL 1.x:
+        // PI_INVALID_WORK_GROUP_SIZE if local_work_size is specified and
+        // number of workitems specified by global_work_size is not evenly
+        // divisible by size of work-group given by local_work_size
+        
+        throw sycl::nd_range_error("Global_work_size must be evenly divisible by local_work_size. Non-uniform work-groups are not supported by the target device",  PI_INVALID_WORK_GROUP_SIZE);
+      } else {
+        // OpenCL 2.x:
+        // PI_INVALID_WORK_GROUP_SIZE if the program was compiled with
+        // –cl-uniform-work-group-size and the number of work-items specified
+        // by global_work_size is not evenly divisible by size of work-group
+        // given by local_work_size
 
-    if (Ver[0] == '1') {
-      // OpenCL 1.x:
-      // PI_INVALID_WORK_GROUP_SIZE if local_work_size is specified and
-      // number of workitems specified by global_work_size is not evenly
-      // divisible by size of work-group given by local_work_size
-
-      if (NonUniformWGs)
-        throw sycl::nd_range_error(
-            "Non-uniform work-groups are not supported by the target device",
-            PI_INVALID_WORK_GROUP_SIZE);
-    } else {
-      // OpenCL 2.x:
-      // PI_INVALID_WORK_GROUP_SIZE if the program was compiled with
-      // –cl-uniform-work-group-size and the number of work-items specified
-      // by global_work_size is not evenly divisible by size of work-group
-      // given by local_work_size
-
-      pi_program Program = nullptr;
-      Plugin.call<PiApiKind::piKernelGetInfo>(
-          Kernel, PI_KERNEL_INFO_PROGRAM, sizeof(pi_program), &Program, nullptr);
-      size_t OptsSize = 0;
-      Plugin.call<PiApiKind::piProgramGetBuildInfo>(
-          Program, Device, PI_PROGRAM_BUILD_INFO_OPTIONS, 0, nullptr, &OptsSize);
-      string_class Opts(OptsSize, '\0');
-      Plugin.call<PiApiKind::piProgramGetBuildInfo>(
-          Program, Device, PI_PROGRAM_BUILD_INFO_OPTIONS, OptsSize, &Opts.front(),
-          nullptr);
-      if (NonUniformWGs) {
+        pi_program Program = nullptr;
+        Plugin.call<PiApiKind::piKernelGetInfo>(
+            Kernel, PI_KERNEL_INFO_PROGRAM, sizeof(pi_program), &Program, nullptr);
+        size_t OptsSize = 0;
+        Plugin.call<PiApiKind::piProgramGetBuildInfo>(
+            Program, Device, PI_PROGRAM_BUILD_INFO_OPTIONS, 0, nullptr, &OptsSize);
+        string_class Opts(OptsSize, '\0');
+        Plugin.call<PiApiKind::piProgramGetBuildInfo>(
+            Program, Device, PI_PROGRAM_BUILD_INFO_OPTIONS, OptsSize, &Opts.front(),
+            nullptr);
         const bool HasStd20 = Opts.find("-cl-std=CL2.0") != string_class::npos;
         if (!HasStd20)
           throw sycl::nd_range_error(
+              "Global_work_size not evenly divisible by local_work_size. "
               "Non-uniform work-groups are not allowed by default. Underlying "
               "OpenCL 2.x implementation supports this feature and to enable "
               "it, build device program with -cl-std=CL2.0",
               PI_INVALID_WORK_GROUP_SIZE);
         else
           throw sycl::nd_range_error(
+              "Global_work_size not evenly divisible by local_work_size. "
               "Non-uniform work-groups are not allowed by default. Underlying "
               "OpenCL 2.x implementation supports this feature, but it is "
               "disabled by -cl-uniform-work-group-size build flag",

--- a/sycl/test/basic_tests/parallel_for_range.cpp
+++ b/sycl/test/basic_tests/parallel_for_range.cpp
@@ -209,7 +209,7 @@ int main() {
     // Local Size larger than Global.
     // CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified as larger
     // than the global size, then a different error string is used.
-    // This is a sub-case of the more general 'non-uniform work group' 
+    // This is a sub-case of the more general 'non-uniform work group'
     try {
       // parallel_for, 16 global, 17 local -> fail
       Q.submit([&](handler &CGH) {
@@ -245,10 +245,10 @@ int main() {
     }
 
     // Local Size larger than Global, multi-dimensional
-    // This is a sub-case of the more general 'non-uniform work group' 
+    // This is a sub-case of the more general 'non-uniform work group'
     try {
       // parallel_for, 6, 6, 6 global, 2, 2, 7 local -> fail
-     Q.submit([&](handler &CGH) {
+      Q.submit([&](handler &CGH) {
         CGH.parallel_for<class OpenCL1XNegativeB2>(
             nd_range<3>(range<3>(6, 6, 6), range<3>(2, 2, 7)),
             [=](nd_item<3>) {});
@@ -502,9 +502,9 @@ int main() {
       }
 
       // Local Size larger than Global, multi-dimensional
-      // This is a sub-case of the more general 'non-uniform work group' 
+      // This is a sub-case of the more general 'non-uniform work group'
       try {
-         // parallel_for, 6, 6, 6 global, 2, 2, 7 local -> fail
+        // parallel_for, 6, 6, 6 global, 2, 2, 7 local -> fail
         Q.submit([&](handler &CGH) {
           CGH.parallel_for<class OpenCL2XNegativeC2>(
               nd_range<3>(range<3>(6, 6, 6), range<3>(2, 2, 7)),
@@ -705,7 +705,7 @@ int main() {
         return 1;
       }
     }
-  
+
     // Local Size larger than Global, -cl-std=CL2.0 -cl-uniform-work-group-size flag used
     // CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified as larger
     // than the global size, then a different error string is used.
@@ -717,7 +717,7 @@ int main() {
 
       kernel K = P.get_kernel<class OpenCL2XNegativeD2>();
       try {
-         // parallel_for, 16 global, 17 local -> fail
+        // parallel_for, 16 global, 17 local -> fail
         Q.submit([&](handler &CGH) {
           CGH.parallel_for<class OpenCL2XNegativeD2>(
               K, nd_range<1>(range<1>(16), range<1>(17)), [=](nd_item<1>) {});

--- a/sycl/test/basic_tests/parallel_for_range.cpp
+++ b/sycl/test/basic_tests/parallel_for_range.cpp
@@ -206,6 +206,81 @@ int main() {
       return 1;
     }
 
+    // Local Size larger than Global.
+    // CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified as larger
+    // than the global size, then a different error string is used.
+    // This is a sub-case of the more general 'non-uniform work group' 
+    try {
+      // parallel_for, 16 global, 17 local -> fail
+      Q.submit([&](handler &CGH) {
+        CGH.parallel_for<class OpenCL1XNegativeA2>(
+            nd_range<1>(range<1>(16), range<1>(17)), [=](nd_item<1>) {});
+      });
+      Q.wait_and_throw();
+      // FIXME: some Intel runtimes contain bug and don't return expected
+      // error code
+      if (info::device_type::accelerator != DeviceType ||
+          DeviceVendorName.find("Intel") == string_class::npos) {
+        std::cerr
+            << "Test case OpenCL1XNegativeA2 failed: no exception has been "
+               "thrown\n";
+        return 1; // We shouldn't be here, exception is expected
+      }
+    } catch (nd_range_error &E) {
+      if (string_class(E.what()).find("Local workgroup size cannot be greater than global range in any dimension") == string_class::npos) {
+        std::cerr
+            << "Test case OpenCL1XNegativeA2 failed: unexpected exception: "
+            << E.what() << std::endl;
+        return 1;
+      }
+    } catch (runtime_error &E) {
+      std::cerr << "Test case OpenCL1XNegativeA2 failed: unexpected exception: "
+                << E.what() << std::endl;
+      return 1;
+    } catch (...) {
+      std::cerr << "Test case OpenCL1XNegativeA2 failed: something unexpected "
+                   "has been caught"
+                << std::endl;
+      return 1;
+    }
+
+    // Local Size larger than Global, multi-dimensional
+    // This is a sub-case of the more general 'non-uniform work group' 
+    try {
+      // parallel_for, 6, 6, 6 global, 2, 2, 7 local -> fail
+     Q.submit([&](handler &CGH) {
+        CGH.parallel_for<class OpenCL1XNegativeB2>(
+            nd_range<3>(range<3>(6, 6, 6), range<3>(2, 2, 7)),
+            [=](nd_item<3>) {});
+      });
+      Q.wait_and_throw();
+      // FIXME: some Intel runtimes contain bug and don't return expected
+      // error code
+      if (info::device_type::accelerator != DeviceType ||
+          DeviceVendorName.find("Intel") == string_class::npos) {
+        std::cerr
+            << "Test case OpenCL1XNegativeB2 failed: no exception has been "
+               "thrown\n";
+        return 1; // We shouldn't be here, exception is expected
+      }
+    } catch (nd_range_error &E) {
+      if (string_class(E.what()).find("Local workgroup size cannot be greater than global range in any dimension") == string_class::npos) {
+        std::cerr
+            << "Test case OpenCL1XNegativeB2 failed: unexpected exception: "
+            << E.what() << std::endl;
+        return 1;
+      }
+    } catch (runtime_error &E) {
+      std::cerr << "Test case OpenCL1XNegativeB2 failed: unexpected exception: "
+                << E.what() << std::endl;
+      return 1;
+    } catch (...) {
+      std::cerr << "Test case OpenCL1XNegativeB2 failed: something unexpected "
+                   "has been caught"
+                << std::endl;
+      return 1;
+    }
+
     // CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified and the
     // total number of work-items in the work-group computed as
     // local_work_size[0] * ... * local_work_size[work_dim – 1] is greater
@@ -382,6 +457,94 @@ int main() {
       }
     }
 
+    // Local Size larger than Global.
+    // CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified as larger
+    // than the global size, then a different error string is used.
+    // This is a sub-case of the more general 'non-uniform work group'
+    {
+      try {
+        // parallel_for, 16 global, 17 local -> fail
+        Q.submit([&](handler &CGH) {
+          CGH.parallel_for<class OpenCL2XNegativeB2>(
+              nd_range<1>(range<1>(16), range<1>(17)), [=](nd_item<1>) {});
+        });
+        Q.wait_and_throw();
+        // FIXME: some Intel runtimes contain bug and don't return expected
+        // error code
+        if (info::device_type::cpu != DeviceType ||
+            DeviceVendorName.find("Intel") == string_class::npos) {
+          std::cerr
+              << "Test case OpenCL2XNegativeB2 failed: no exception has been "
+                 "thrown\n";
+          return 1; // We shouldn't be here, exception is expected
+        }
+      } catch (nd_range_error &E) {
+        if (string_class(E.what()).find(
+                "Local workgroup size greater than global range size. "
+                "Non-uniform work-groups are not allowed by default. Underlying "
+                "OpenCL 2.x implementation supports this feature and to enable "
+                "it, build device program with -cl-std=CL2.0") == string_class::npos) {
+          std::cerr
+              << "Test case OpenCL2XNegativeB2 failed: unexpected exception: "
+              << E.what() << std::endl;
+          return 1;
+        }
+      } catch (runtime_error &E) {
+        std::cerr
+            << "Test case OpenCL2XNegativeB2 failed: unexpected exception: "
+            << E.what() << std::endl;
+        return 1;
+      } catch (...) {
+        std::cerr << "Test case OpenCL2XNegativeB2 failed: something unexpected "
+                     "has been caught"
+                  << std::endl;
+        return 1;
+      }
+
+      // Local Size larger than Global, multi-dimensional
+      // This is a sub-case of the more general 'non-uniform work group' 
+      try {
+         // parallel_for, 6, 6, 6 global, 2, 2, 7 local -> fail
+        Q.submit([&](handler &CGH) {
+          CGH.parallel_for<class OpenCL2XNegativeC2>(
+              nd_range<3>(range<3>(6, 6, 6), range<3>(2, 2, 7)),
+              [=](nd_item<3>) {});
+        });
+        Q.wait_and_throw();
+        // FIXME: some Intel runtimes contain bug and don't return expected
+        // error code
+        if (info::device_type::cpu != DeviceType ||
+            DeviceVendorName.find("Intel") == string_class::npos) {
+          std::cerr
+              << "Test case OpenCL2XNegativeC2 failed: no exception has been "
+                 "thrown\n";
+          return 1; // We shouldn't be here, exception is expected
+        }
+      } catch (nd_range_error &E) {
+        if (string_class(E.what()).find(
+                "Local workgroup size greater than global range size. "
+                "Non-uniform work-groups are not allowed by default. "
+                "Underlying OpenCL 2.x implementation supports this feature "
+                "and to enable it, build device program with -cl-std=CL2.0") ==
+            string_class::npos) {
+          std::cerr
+              << "Test case OpenCL2XNegativeC2 failed: unexpected exception: "
+              << E.what() << std::endl;
+          return 1;
+        }
+      } catch (runtime_error &E) {
+        std::cerr
+            << "Test case OpenCL2XNegativeC2 failed: unexpected exception: "
+            << E.what() << std::endl;
+        return 1;
+      } catch (...) {
+        std::cerr << "Test case OpenCL2XNegativeC2 failed: something unexpected "
+                     "has been caught"
+                  << std::endl;
+        return 1;
+      }
+    }
+
     // Enable non-uniform work-groups by passing -cl-std=CL2.0
     {
       program P(Q.get_context());
@@ -412,7 +575,7 @@ int main() {
         return 1;
       }
     }
-
+    // Multi-dimensional nd_range.
     {
       program P(Q.get_context());
       P.build_with_kernel_type<class OpenCL2XPositiveB>("-cl-std=CL2.0");
@@ -474,10 +637,10 @@ int main() {
         }
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
-                "Non-uniform work-groups are not allowed by default. "
-                "Underlying OpenCL 2.x implementation supports this feature, "
-                "but it is disabled by -cl-uniform-work-group-size build "
-                "flag") == string_class::npos) {
+                "Global_work_size not evenly divisible by local_work_size. "
+                "Non-uniform work-groups are not allowed by when -cl-uniform-work-group-size flag is used. Underlying "
+                "OpenCL 2.x implementation supports this feature, but it is being "
+                "disabled by -cl-uniform-work-group-size build flag") == string_class::npos) {
           std::cerr
               << "Test case OpenCL2XNegativeD failed: unexpected exception: "
               << E.what() << std::endl;
@@ -495,7 +658,7 @@ int main() {
         return 1;
       }
     }
-
+    // Multi-dimensional nd_range.
     {
       program P(Q.get_context());
       P.build_with_kernel_type<class OpenCL2XNegativeE>(
@@ -521,10 +684,10 @@ int main() {
         }
       } catch (nd_range_error &E) {
         if (string_class(E.what()).find(
-                "Non-uniform work-groups are not allowed by default. "
-                "Underlying OpenCL 2.x implementation supports this feature, "
-                "but it is disabled by -cl-uniform-work-group-size build "
-                "flag") == string_class::npos) {
+                "Global_work_size not evenly divisible by local_work_size. "
+                "Non-uniform work-groups are not allowed by when -cl-uniform-work-group-size flag is used. Underlying "
+                "OpenCL 2.x implementation supports this feature, but it is being "
+                "disabled by -cl-uniform-work-group-size build flag") == string_class::npos) {
           std::cerr
               << "Test case OpenCL2XNegativeE failed: unexpected exception: "
               << E.what() << std::endl;
@@ -537,6 +700,103 @@ int main() {
         return 1;
       } catch (...) {
         std::cerr << "Test case OpenCL2XNegativeE failed: something unexpected "
+                     "has been caught"
+                  << std::endl;
+        return 1;
+      }
+    }
+  
+    // Local Size larger than Global, -cl-std=CL2.0 -cl-uniform-work-group-size flag used
+    // CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified as larger
+    // than the global size, then a different error string is used.
+    // This is a sub-case of the more general 'non-uniform work group'
+    {
+      program P(Q.get_context());
+      P.build_with_kernel_type<class OpenCL2XNegativeD2>(
+          "-cl-std=CL2.0 -cl-uniform-work-group-size");
+
+      kernel K = P.get_kernel<class OpenCL2XNegativeD2>();
+      try {
+         // parallel_for, 16 global, 17 local -> fail
+        Q.submit([&](handler &CGH) {
+          CGH.parallel_for<class OpenCL2XNegativeD2>(
+              K, nd_range<1>(range<1>(16), range<1>(17)), [=](nd_item<1>) {});
+        });
+        Q.wait_and_throw();
+        // FIXME: some Intel runtimes contain bug and don't return expected
+        // error code
+        if (info::device_type::cpu != DeviceType ||
+            DeviceVendorName.find("Intel") == string_class::npos) {
+          std::cerr
+              << "Test case OpenCL2XNegativeD2 failed: no exception has been "
+                 "thrown\n";
+          return 1; // We shouldn't be here, exception is expected
+        }
+      } catch (nd_range_error &E) {
+        if (string_class(E.what()).find(
+                "Local workgroup size greater than global range size. "
+                "Non-uniform work-groups are not allowed by when -cl-uniform-work-group-size flag is used. Underlying "
+                "OpenCL 2.x implementation supports this feature, but it is being "
+                "disabled by -cl-uniform-work-group-size build flag") == string_class::npos) {
+          std::cerr
+              << "Test case OpenCL2XNegativeD2 failed: unexpected exception: "
+              << E.what() << std::endl;
+          return 1;
+        }
+      } catch (runtime_error &E) {
+        std::cerr
+            << "Test case OpenCL2XNegativeD2 failed: unexpected exception: "
+            << E.what() << std::endl;
+        return 1;
+      } catch (...) {
+        std::cerr << "Test case OpenCL2XNegativeD2 failed: something unexpected "
+                     "has been caught"
+                  << std::endl;
+        return 1;
+      }
+    }
+    // Multi-dimensional nd_range.
+    {
+      program P(Q.get_context());
+      P.build_with_kernel_type<class OpenCL2XNegativeE2>(
+          "-cl-std=CL2.0 -cl-uniform-work-group-size");
+
+      kernel K = P.get_kernel<class OpenCL2XNegativeE2>();
+      try {
+        // parallel_for, 6, 6, 6 global, 2, 2, 7 local -> fail
+        Q.submit([&](handler &CGH) {
+          CGH.parallel_for<class OpenCL2XNegativeE2>(
+              K, nd_range<3>(range<3>(6, 6, 6), range<3>(2, 2, 7)),
+              [=](nd_item<3>) {});
+        });
+        Q.wait_and_throw();
+        // FIXME: some Intel runtimes contain bug and don't return expected
+        // error code
+        if (info::device_type::cpu != DeviceType ||
+            DeviceVendorName.find("Intel") == string_class::npos) {
+          std::cerr
+              << "Test case OpenCL2XNegativeE2 failed: no exception has been "
+                 "thrown\n";
+          return 1; // We shouldn't be here, exception is expected
+        }
+      } catch (nd_range_error &E) {
+        if (string_class(E.what()).find(
+                "Local workgroup size greater than global range size. "
+                "Non-uniform work-groups are not allowed by when -cl-uniform-work-group-size flag is used. Underlying "
+                "OpenCL 2.x implementation supports this feature, but it is being "
+                "disabled by -cl-uniform-work-group-size build flag") == string_class::npos) {
+          std::cerr
+              << "Test case OpenCL2XNegativeE2 failed: unexpected exception: "
+              << E.what() << std::endl;
+          return 1;
+        }
+      } catch (runtime_error &E) {
+        std::cerr
+            << "Test case OpenCL2XNegativeE2 failed: unexpected exception: "
+            << E.what() << std::endl;
+        return 1;
+      } catch (...) {
+        std::cerr << "Test case OpenCL2XNegativeE2 failed: something unexpected "
                      "has been caught"
                   << std::endl;
         return 1;


### PR DESCRIPTION
This improves the error messages thrown when the workgroup sizes for a kernel invocation are invalid. It more accurately informs the user when the global workgroup size is not evenly divisible by the local work size, and when the local size is greater than the global.  Messaging in the more limited OpenCL 2.0 cases (where there are fewer size restrictions is likewise improved

Signed-off-by: Chris Perkins <chris.perkins@intel.com>