### PR TITLE
[WIP][Do not Review][SYCL] Decompose Kernel Parameters

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -690,11 +690,11 @@ static void VisitRecordHelper(CXXRecordDecl *Owner,
     QualType BaseTy = Base.getType();
     if (Util::isSyclAccessorType(BaseTy))
       (void)std::initializer_list<int>{
-	      (handlers.handleSyclAccessorType(Base, BaseTy), 0)...};
+          (handlers.handleSyclAccessorType(Base, BaseTy), 0)...};
     else if (Util::isSyclStreamType(BaseTy))
       (void)std::initializer_list<int>{
-	      (handlers.handleSyclStreamType(Base, BaseTy), 0)...};
-    else 
+          (handlers.handleSyclStreamType(Base, BaseTy), 0)...};
+    else
       VisitRecord(Owner, Base, BaseTy->getAsCXXRecordDecl(), handlers...);
   }
 }
@@ -1009,7 +1009,7 @@ public:
   }
 
   void handleStructType(FieldDecl *FD, QualType FieldTy) final {
-    //addParam(FD, FieldTy);
+    // addParam(FD, FieldTy);
   }
 
   void handleSyclStreamType(FieldDecl *FD, QualType FieldTy) final {
@@ -1260,7 +1260,7 @@ public:
   }
 
   void handleStructType(FieldDecl *FD, QualType FieldTy) final {
-    //createExprForStructOrScalar(FD);
+    // createExprForStructOrScalar(FD);
   }
 
   void handleScalarType(FieldDecl *FD, QualType FieldTy) final {
@@ -1408,7 +1408,7 @@ public:
     addParam(FD, FieldTy, SYCLIntegrationHeader::kind_pointer);
   }
   void handleStructType(FieldDecl *FD, QualType FieldTy) final {
-    //addParam(FD, FieldTy, SYCLIntegrationHeader::kind_std_layout);
+    // addParam(FD, FieldTy, SYCLIntegrationHeader::kind_std_layout);
   }
   void handleScalarType(FieldDecl *FD, QualType FieldTy) final {
     addParam(FD, FieldTy, SYCLIntegrationHeader::kind_std_layout);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -688,7 +688,14 @@ static void VisitRecordHelper(CXXRecordDecl *Owner,
                               Handlers &... handlers) {
   for (const auto &Base : Range) {
     QualType BaseTy = Base.getType();
-    VisitRecord(Owner, Base, BaseTy->getAsCXXRecordDecl(), handlers...);
+    if (Util::isSyclAccessorType(BaseTy))
+      (void)std::initializer_list<int>{
+	      (handlers.handleSyclAccessorType(Base, BaseTy), 0)...};
+    else if (Util::isSyclStreamType(BaseTy))
+      (void)std::initializer_list<int>{
+	      (handlers.handleSyclStreamType(Base, BaseTy), 0)...};
+    else 
+      VisitRecord(Owner, Base, BaseTy->getAsCXXRecordDecl(), handlers...);
   }
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -752,6 +752,8 @@ static void VisitRecordFields(CXXRecordDecl *Owner, Handlers &... handlers) {
       VisitRecord(nullptr, Field, RD, handlers...);
       KF_FOR_EACH(handleSyclStreamType);
     } else if (FieldTy->isStructureOrClassType()) {
+      // Handle diagnostics for non-standard layout
+      KF_FOR_EACH(handleStructType);
       CXXRecordDecl *RD = FieldTy->getAsCXXRecordDecl();
       VisitRecord(Owner, Field, RD, handlers...);
     } else if (FieldTy->isReferenceType())
@@ -1000,7 +1002,7 @@ public:
   }
 
   void handleStructType(FieldDecl *FD, QualType FieldTy) final {
-    addParam(FD, FieldTy);
+    //addParam(FD, FieldTy);
   }
 
   void handleSyclStreamType(FieldDecl *FD, QualType FieldTy) final {
@@ -1251,7 +1253,7 @@ public:
   }
 
   void handleStructType(FieldDecl *FD, QualType FieldTy) final {
-    createExprForStructOrScalar(FD);
+    //createExprForStructOrScalar(FD);
   }
 
   void handleScalarType(FieldDecl *FD, QualType FieldTy) final {
@@ -1399,7 +1401,7 @@ public:
     addParam(FD, FieldTy, SYCLIntegrationHeader::kind_pointer);
   }
   void handleStructType(FieldDecl *FD, QualType FieldTy) final {
-    addParam(FD, FieldTy, SYCLIntegrationHeader::kind_std_layout);
+    //addParam(FD, FieldTy, SYCLIntegrationHeader::kind_std_layout);
   }
   void handleScalarType(FieldDecl *FD, QualType FieldTy) final {
     addParam(FD, FieldTy, SYCLIntegrationHeader::kind_std_layout);


### PR DESCRIPTION
First (incomplete) patch decomposing base classes and structfields.

Currently, struct kernel parameters are passed as a whole, along with
individual parameters for special SYCL types resulting in special SYCL
paramters being passed twice. To avoid this, we now decompose structs,
passing all fields as top level parameters.

TO DO: in follow up commit: Add condition to decompose only if struct
contains special SYCL type

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>