### PR TITLE
[SYCL][NFC] Fix kernel release test when only host device is available

### DIFF
--- a/sycl/unittests/program/KernelRelease.cpp
+++ b/sycl/unittests/program/KernelRelease.cpp
@@ -71,7 +71,7 @@ pi_result redefinedKernelGetInfo(pi_kernel kernel, pi_kernel_info param_name,
 TEST(KernelReleaseTest, GetKernelRelease) {
   platform Plt{default_selector()};
   if (Plt.is_host()) {
-    std::cerr << "The program/kernel methods are mostly no-op on the host "
+    std::cout << "The program/kernel methods are mostly no-op on the host "
                  "device, the test is not run."
               << std::endl;
     return;

--- a/sycl/unittests/program/KernelRelease.cpp
+++ b/sycl/unittests/program/KernelRelease.cpp
@@ -69,8 +69,7 @@ pi_result redefinedKernelGetInfo(pi_kernel kernel, pi_kernel_info param_name,
 }
 
 TEST(KernelReleaseTest, GetKernelRelease) {
-  unittest::PiMock Mock;
-  platform Plt = Mock.getPlatform();
+  platform Plt{default_selector()};
   if (Plt.is_host()) {
     std::cerr << "The program/kernel methods are mostly no-op on the host "
                  "device, the test is not run."
@@ -78,6 +77,7 @@ TEST(KernelReleaseTest, GetKernelRelease) {
     return;
   }
 
+  unittest::PiMock Mock{Plt};
   Mock.redefine<detail::PiApiKind::piclProgramCreateWithSource>(
       redefinedProgramCreateWithSource);
   Mock.redefine<detail::PiApiKind::piProgramBuild>(redefinedProgramBuild);


### PR DESCRIPTION
PIMock should only be constructed from a non-host platform, make the
test check for a non-host platform prior to constructing PIMock.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>