### PR TITLE
[SYCL][CUDA] Re-enable LIT tests for CUDA

### DIFF
--- a/sycl/test/basic_tests/buffer/buffer_dev_to_dev.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_dev_to_dev.cpp
@@ -1,7 +1,3 @@
-// The test fails sporadically on cuda.
-// See https://github.com/intel/llvm/issues/1508 for more details.
-// UNSUPPORTED: cuda
-
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/basic_tests/handler/handler_mem_op.cpp
+++ b/sycl/test/basic_tests/handler/handler_mem_op.cpp
@@ -1,7 +1,3 @@
-// The test fails sporadically on cuda.
-// See https://github.com/intel/llvm/issues/1508 for more details.
-// UNSUPPORTED: cuda
-
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Re-enabling LIT tests marked as `UNSUPPORTED: cuda` that were previosuly
failing non-deterministically and should be fixed by commit
379702006effb7199019941f0c97ebbf70e6dc1d.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>