### PR TITLE
[SYCL][CUDA] LIT SPIR-V test unsupported

### DIFF
--- a/sycl/test/scheduler/ReleaseResourcesTest.cpp
+++ b/sycl/test/scheduler/ReleaseResourcesTest.cpp
@@ -1,12 +1,13 @@
+// UNSUPPORTED: cuda
+// CUDA does not support SPIR-V and the runtime therefore does not emit
+// `---> piProgramCreate` but `--->piclProgramCreateWithBinary` which fails
+// the otherwise passing test.
+//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
-
-// TODO: error: expected string not found in input
-// TODO: PI ---> pi::piProgramCreate(Context, Data, DataLen, &Program)
-// XFAIL: cuda
 
 //==------------------- ReleaseResourcesTests.cpp --------------------------==//
 //


### PR DESCRIPTION
Mark a LIT test that checks for SPIR-V specific trace output as
unsupported by CUDA as the CUDA plugin does not support SPIR-V.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>