### PR TITLE
[SYCL][ESIMD] Add basic headers for ESIMD runtime library.

### DIFF
--- a/sycl/include/CL/sycl/intel/esimd.hpp
+++ b/sycl/include/CL/sycl/intel/esimd.hpp
@@ -1,0 +1,19 @@
+//==------------ esimd.hpp - DPC++ Explicit SIMD API -----------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// The main header of the Explicit SIMD API.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#ifdef __SYCL_DEVICE_ONLY__
+#define SYCL_ESIMD_KERNEL __attribute__((sycl_explicit_simd))
+#define SYCL_ESIMD_FUNCTION __attribute__((sycl_explicit_simd))
+#else
+#define SYCL_ESIMD_KERNEL
+#define SYCL_ESIMD_FUNCTION
+#endif

--- a/sycl/include/CL/sycl/intel/esimd/detail/esimd_region.hpp
+++ b/sycl/include/CL/sycl/intel/esimd/detail/esimd_region.hpp
@@ -1,0 +1,119 @@
+//==-------------- esimd_region.hpp - DPC++ Explicit SIMD API --------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Region type to implement the Explicit SIMD APIs.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl/detail/defines.hpp>
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace intel {
+namespace gpu {
+
+// The common base type of region types.
+template <bool Is2D, typename T, int SizeY, int StrideY, int SizeX, int StrideX>
+struct region_base {
+  using element_type = T;
+  static constexpr int length = SizeX * SizeY;
+  static constexpr int Is_2D = Is2D;
+  static constexpr int Size_x = SizeX;
+  static constexpr int Stride_x = StrideX;
+  static constexpr int Size_y = SizeY;
+  static constexpr int Stride_y = StrideY;
+  static constexpr int Size_in_bytes = sizeof(T) * length;
+
+  static_assert(Size_x > 0 && Stride_x >= 0, "illegal region in x-dimension");
+  static_assert(Size_y > 0 && Stride_y >= 0, "illegal region in y-dimension");
+
+  uint16_t M_offset_y;
+  uint16_t M_offset_x;
+
+  explicit region_base() : M_offset_y(0), M_offset_x(0) {}
+
+  explicit region_base(uint16_t OffsetX) : M_offset_y(0), M_offset_x(OffsetX) {}
+
+  explicit region_base(uint16_t OffsetY, uint16_t OffsetX)
+      : M_offset_y(OffsetY), M_offset_x(OffsetX) {}
+};
+
+// A basic 1D region type.
+template <typename T, int Size, int Stride>
+using region1d_t = region_base<false, T, 1, 0, Size, Stride>;
+
+// A basic 2D region type.
+template <typename T, int SizeY, int StrideY, int SizeX, int StrideX>
+using region2d_t = region_base<true, T, SizeY, StrideY, SizeX, StrideX>;
+
+// simd_view forward declaration.
+template <typename BaseTy, typename RegionTy> class simd_view;
+
+// Compute the region type of a simd_view type.
+//
+// A region type could be either
+// - region1d_t
+// - region2d_t
+// - a pair (top_region_type, base_region_type)
+//
+// This is a recursive definition to capture the following rvalue region stack:
+//
+// simd<int 16> v;
+// v.format<int, 4, 4>().select<1, 0, 4, 1>(0, 0).format<short>() = 0;
+//
+// The LHS will be represented as a rvalue
+//
+// simd_view({v, { region1d_t<short, 8, 1>(0, 0),
+//              { region2d_t<int, 1, 1, 4, 1>(0, 0),
+//                region2d_t<int, 4, 1, 4, 1>(0, 0)
+//              }}})
+//
+template <typename Ty> struct shape_type {
+  using element_type = Ty;
+  using type = void;
+};
+
+template <typename Ty, int Size, int Stride>
+struct shape_type<region1d_t<Ty, Size, Stride>> {
+  using element_type = Ty;
+  using type = region1d_t<Ty, Size, Stride>;
+};
+
+template <typename Ty, int SizeY, int StrideY, int SizeX, int StrideX>
+struct shape_type<region2d_t<Ty, SizeY, StrideY, SizeX, StrideX>> {
+  using element_type = Ty;
+  using type = region2d_t<Ty, SizeY, StrideY, SizeX, StrideX>;
+};
+
+// Forward the shape computation on the top region type.
+template <typename TopRegionTy, typename BaseRegionTy>
+struct shape_type<std::pair<TopRegionTy, BaseRegionTy>>
+    : public shape_type<TopRegionTy> {};
+
+// Forward the shape computation on the region type.
+template <typename BaseTy, typename RegionTy>
+struct shape_type<simd_view<BaseTy, RegionTy>> : public shape_type<RegionTy> {};
+
+// Utility functions to access region components.
+template <typename T> T getTopRegion(T Reg) { return Reg; }
+template <typename T, typename U> T getTopRegion(std::pair<T, U> Reg) {
+  return Reg.first;
+}
+
+template <typename T> T getBaseRegion(T Reg) { return Reg; }
+template <typename T, typename U> T getBaseRegion(std::pair<T, U> Reg) {
+  return Reg.second;
+}
+
+} // namespace gpu
+} // namespace intel
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/intel/esimd/detail/esimd_types.hpp
+++ b/sycl/include/CL/sycl/intel/esimd/detail/esimd_types.hpp
@@ -1,0 +1,260 @@
+//==-------------- esimd_types.hpp - DPC++ Explicit SIMD API ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Types and type traits to implement Explicit SIMD APIs.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl/detail/stl_type_traits.hpp> // to define C++14,17 extensions
+#include <CL/sycl/half_type.hpp>
+#include <CL/sycl/intel/esimd/detail/esimd_region.hpp>
+#include <CL/sycl/intel/esimd/esimd_enum.hpp>
+#include <cstdint>
+#include <type_traits>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace intel {
+namespace gpu {
+
+namespace csd = cl::sycl::detail;
+
+using half = cl::sycl::detail::half_impl::StorageT;
+
+template <typename T>
+using remove_cvref_t = csd::remove_cv_t<csd::remove_reference_t<T>>;
+
+// is_esimd_arithmetic_type
+template <class...> struct make_esimd_void { using type = void; };
+template <class... Tys>
+using __esimd_void_t = typename make_esimd_void<Tys...>::type;
+
+template <class Ty, class = void>
+struct is_esimd_arithmetic_type : std::false_type {};
+
+template <class Ty>
+struct is_esimd_arithmetic_type<
+    Ty, __esimd_void_t<decltype(std::declval<Ty>() + std::declval<Ty>()),
+                       decltype(std::declval<Ty>() - std::declval<Ty>()),
+                       decltype(std::declval<Ty>() * std::declval<Ty>()),
+                       decltype(std::declval<Ty>() / std::declval<Ty>())>>
+    : std::true_type {};
+
+// is_vectorizable_type
+template <typename Ty>
+struct is_vectorizable : public is_esimd_arithmetic_type<Ty> {};
+
+template <> struct is_vectorizable<bool> : public std::false_type {};
+
+template <typename Ty>
+struct is_vectorizable_v
+    : std::integral_constant<bool, is_vectorizable<Ty>::value> {};
+
+// vector_type, using clang vector type extension.
+template <typename Ty, int N> struct vector_type {
+  static_assert(!std::is_const<Ty>::value, "const element type not supported");
+  static_assert(is_vectorizable_v<Ty>::value, "element type not supported");
+  static_assert(N > 0, "zero-element vector not supported");
+
+  static constexpr int length = N;
+  using type = Ty __attribute__((ext_vector_type(N)));
+};
+
+template <typename Ty, int N>
+using vector_type_t = typename vector_type<Ty, N>::type;
+
+// TODO @rolandschulz on May 21
+// {quote}
+// - The mask should also be a wrapper around the clang - vector type rather
+//   than the clang - vector type itself.
+// - The internal storage should be implementation defined.uint16_t is a bad
+//   choice for some HW.Nor is it how clang - vector types works(using the same
+//   size int as the corresponding vector type used for comparison(e.g. long for
+//   double and int for float)).
+template <int N> using mask_type_t = typename vector_type<uint16_t, N>::type;
+
+// simd and simd_view forward declarations
+template <typename Ty, int N> class simd;
+template <typename BaseTy, typename RegionTy> class simd_view;
+
+// Compute the simd_view type of a 1D format operation.
+template <typename BaseTy, typename EltTy> struct compute_format_type;
+
+template <typename Ty, int N, typename EltTy>
+struct compute_format_type<simd<Ty, N>, EltTy> {
+  static constexpr int Size = sizeof(Ty) * N / sizeof(EltTy);
+  static constexpr int Stride = 1;
+  using type = region1d_t<EltTy, Size, Stride>;
+};
+
+template <typename BaseTy, typename RegionTy, typename EltTy>
+struct compute_format_type<simd_view<BaseTy, RegionTy>, EltTy> {
+  using ShapeTy = typename shape_type<RegionTy>::type;
+  static constexpr int Size = ShapeTy::Size_in_bytes / sizeof(EltTy);
+  static constexpr int Stride = 1;
+  using type = region1d_t<EltTy, Size, Stride>;
+};
+
+template <typename Ty, typename EltTy>
+using compute_format_type_t = typename compute_format_type<Ty, EltTy>::type;
+
+// Compute the simd_view type of a 2D format operation.
+template <typename BaseTy, typename EltTy, int Height, int Width>
+struct compute_format_type_2d;
+
+template <typename Ty, int N, typename EltTy, int Height, int Width>
+struct compute_format_type_2d<simd<Ty, N>, EltTy, Height, Width> {
+  static constexpr int Prod = sizeof(Ty) * N / sizeof(EltTy);
+  static_assert(Prod == Width * Height, "size mismatch");
+
+  static constexpr int SizeX = Width;
+  static constexpr int StrideX = 1;
+  static constexpr int SizeY = Height;
+  static constexpr int StrideY = 1;
+  using type = region2d_t<EltTy, SizeY, StrideY, SizeX, StrideX>;
+};
+
+template <typename BaseTy, typename RegionTy, typename EltTy, int Height,
+          int Width>
+struct compute_format_type_2d<simd_view<BaseTy, RegionTy>, EltTy, Height,
+                              Width> {
+  using ShapeTy = typename shape_type<RegionTy>::type;
+  static constexpr int Prod = ShapeTy::Size_in_bytes / sizeof(EltTy);
+  static_assert(Prod == Width * Height, "size mismatch");
+
+  static constexpr int SizeX = Width;
+  static constexpr int StrideX = 1;
+  static constexpr int SizeY = Height;
+  static constexpr int StrideY = 1;
+  using type = region2d_t<EltTy, SizeY, StrideY, SizeX, StrideX>;
+};
+
+template <typename Ty, typename EltTy, int Height, int Width>
+using compute_format_type_2d_t =
+    typename compute_format_type_2d<Ty, EltTy, Height, Width>::type;
+
+// Check if a type is simd_view type
+template <typename Ty> struct is_simd_view_type : std::false_type {};
+
+template <typename BaseTy, typename RegionTy>
+struct is_simd_view_type<simd_view<BaseTy, RegionTy>> : std::true_type {};
+
+template <typename Ty>
+struct is_simd_view_v
+    : std::integral_constant<bool,
+                             is_simd_view_type<remove_cvref_t<Ty>>::value> {};
+
+// Check if a type is simd or simd_view type
+template <typename Ty> struct is_simd_type : std::false_type {};
+
+template <typename Ty, int N>
+struct is_simd_type<simd<Ty, N>> : std::true_type {};
+
+template <typename BaseTy, typename RegionTy>
+struct is_simd_type<simd_view<BaseTy, RegionTy>> : std::true_type {};
+
+template <typename Ty>
+struct is_simd_v
+    : std::integral_constant<bool, is_simd_type<remove_cvref_t<Ty>>::value> {};
+
+// Get the element type if it is a simd or simd_view type.
+template <typename Ty> struct element_type { using type = remove_cvref_t<Ty>; };
+template <typename Ty, int N> struct element_type<simd<Ty, N>> {
+  using type = Ty;
+};
+template <typename BaseTy, typename RegionTy>
+struct element_type<simd_view<BaseTy, RegionTy>> {
+  using type = typename RegionTy::element_type;
+};
+
+// Get the common type of a binary operator.
+template <typename T1, typename T2,
+          typename =
+              csd::enable_if_t<is_simd_v<T1>::value && is_simd_v<T2>::value>>
+struct common_type {
+private:
+  using Ty1 = typename element_type<T1>::type;
+  using Ty2 = typename element_type<T2>::type;
+  using EltTy = decltype(Ty1() + Ty2());
+  static constexpr int N1 = T1::length;
+  static constexpr int N2 = T2::length;
+  static_assert(N1 == N2, "size mismatch");
+
+public:
+  using type = simd<EltTy, N1>;
+};
+
+template <typename T1, typename T2 = T1>
+using compute_type_t =
+    typename common_type<remove_cvref_t<T1>, remove_cvref_t<T2>>::type;
+
+template <typename To, typename From> To convert(From Val) {
+  return __builtin_convertvector(Val, To);
+}
+
+/// Get the computation type.
+template <typename T1, typename T2> struct computation_type {
+  // Currently only arithmetic operations are needed.
+  typedef decltype(T1() + T2()) type;
+};
+
+/// Base case for checking if a type U is one of the types.
+template <typename U> constexpr bool is_type() { return false; }
+
+template <typename U, typename T, typename... Ts> constexpr bool is_type() {
+  using UU = typename std::remove_const<U>::type;
+  using TT = typename std::remove_const<T>::type;
+  return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
+}
+
+// calculates the number of elements in "To" type
+template <typename ToEltTy, typename FromEltTy, int FromN,
+          typename = csd::enable_if_t<is_vectorizable<ToEltTy>::value>>
+struct bitcast_helper {
+  static inline constexpr int nToElems() {
+    constexpr int R1 = sizeof(ToEltTy) / sizeof(FromEltTy);
+    constexpr int R2 = sizeof(FromEltTy) / sizeof(ToEltTy);
+    constexpr int ToN = (R2 > 0) ? (FromN * R2) : (FromN / R1);
+    return ToN;
+  }
+};
+
+// Change the element type of a simd vector.
+template <typename ToEltTy, typename FromEltTy, int FromN,
+          typename = csd::enable_if_t<is_vectorizable<ToEltTy>::value>>
+ESIMD_INLINE typename std::conditional<
+    std::is_same<FromEltTy, ToEltTy>::value, vector_type_t<FromEltTy, FromN>,
+    vector_type_t<ToEltTy,
+                  bitcast_helper<ToEltTy, FromEltTy, FromN>::nToElems()>>::type
+bitcast(vector_type_t<FromEltTy, FromN> Val) {
+  // Noop.
+  if constexpr (std::is_same<FromEltTy, ToEltTy>::value)
+    return Val;
+
+  // Bitcast
+  constexpr int ToN = bitcast_helper<ToEltTy, FromEltTy, FromN>::nToElems();
+  using VTy = vector_type_t<ToEltTy, ToN>;
+  return reinterpret_cast<VTy>(Val);
+}
+
+inline std::ostream &operator<<(std::ostream &O, half const &rhs) {
+  O << static_cast<float>(rhs);
+  return O;
+}
+
+inline std::istream &operator>>(std::istream &I, half &rhs) {
+  float ValFloat = 0.0f;
+  I >> ValFloat;
+  rhs = ValFloat;
+  return I;
+}
+
+} // namespace gpu
+} // namespace intel
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/intel/esimd/esimd_enum.hpp
+++ b/sycl/include/CL/sycl/intel/esimd/esimd_enum.hpp
@@ -1,0 +1,111 @@
+//==---------------- esimd_enum.hpp - DPC++ Explicit SIMD API   ------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// definitions used in Explicit SIMD APIs.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl/detail/defines.hpp>
+#include <cstdint> // for uint* types
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace intel {
+namespace gpu {
+
+using uchar = unsigned char;
+using ushort = unsigned short;
+using uint = unsigned int;
+
+#ifdef __SYCL_DEVICE_ONLY__
+// Mark a function being nodebug.
+#define ESIMD_NODEBUG __attribute__((nodebug))
+// Mark a "ESIMD global": accessible from all functions in current translation
+// unit, separate copy per subgroup (work-item), mapped to SPIRV private storage
+// class.
+#define ESIMD_PRIVATE __attribute__((opencl_private))
+// Bind a ESIMD global variable to a specific register.
+#define ESIMD_REGISTER(n) __attribute__((register(n)))
+#else
+// TODO ESIMD define what this means on Windows host
+#define ESIMD_NODEBUG
+// On host device ESIMD global is a thread local static var. This assumes that
+// each work-item is mapped to a separate OS thread on host device.
+#define ESIMD_PRIVATE thread_local
+#define ESIMD_REGISTER(n)
+#endif
+
+// Mark a function being noinline
+#define ESIMD_NOINLINE __attribute__((noinline))
+// Mark a function to be inlined
+#define ESIMD_INLINE __attribute__((always_inline))
+
+// Enums
+enum { GENX_NOSAT = 0, GENX_SAT };
+
+enum ChannelMaskType {
+  ESIMD_R_ENABLE = 1,
+  ESIMD_G_ENABLE = 2,
+  ESIMD_GR_ENABLE = 3,
+  ESIMD_B_ENABLE = 4,
+  ESIMD_BR_ENABLE = 5,
+  ESIMD_BG_ENABLE = 6,
+  ESIMD_BGR_ENABLE = 7,
+  ESIMD_A_ENABLE = 8,
+  ESIMD_AR_ENABLE = 9,
+  ESIMD_AG_ENABLE = 10,
+  ESIMD_AGR_ENABLE = 11,
+  ESIMD_AB_ENABLE = 12,
+  ESIMD_ABR_ENABLE = 13,
+  ESIMD_ABG_ENABLE = 14,
+  ESIMD_ABGR_ENABLE = 15
+};
+
+#define NumChannels(Mask)                                                      \
+  ((Mask & 1) + ((Mask & 2) >> 1) + ((Mask & 4) >> 2) + ((Mask & 8) >> 3))
+
+#define HasR(Mask) ((Mask & 1) == 1)
+#define HasG(Mask) ((Mask & 2) >> 1 == 1)
+#define HasB(Mask) ((Mask & 4) >> 2 == 1)
+#define HasA(Mask) ((Mask & 8) >> 3 == 1)
+
+enum class EsimdAtomicOpType : uint16_t {
+  ATOMIC_ADD = 0x0,
+  ATOMIC_SUB = 0x1,
+  ATOMIC_INC = 0x2,
+  ATOMIC_DEC = 0x3,
+  ATOMIC_MIN = 0x4,
+  ATOMIC_MAX = 0x5,
+  ATOMIC_XCHG = 0x6,
+  ATOMIC_CMPXCHG = 0x7,
+  ATOMIC_AND = 0x8,
+  ATOMIC_OR = 0x9,
+  ATOMIC_XOR = 0xa,
+  ATOMIC_MINSINT = 0xb,
+  ATOMIC_MAXSINT = 0xc,
+  ATOMIC_FMAX = 0x10,
+  ATOMIC_FMIN = 0x11,
+  ATOMIC_FCMPWR = 0x12,
+  ATOMIC_PREDEC = 0xff
+};
+
+// L1 or L3 cache hint kinds.
+enum class CacheHint : uint8_t {
+  None = 0,
+  Uncached = 1,
+  WriteBack = 2,
+  WriteThrough = 3,
+  Streaming = 4,
+  ReadInvalidate = 5
+};
+
+} // namespace gpu
+
+} // namespace intel
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)


### PR DESCRIPTION
This patch adds basic headers used to implement
Explicit SIMD APIs and integrates them into deployment.

Signed-off-by: Denis Bakhvalov <denis.bakhvalov@intel.com>
Author:         Wei Pan
Co-authored-by: Chen, Kai Yu <kai.yu.chen@intel.com>
Co-authored-by: Chen, Gang Y <gang.y.chen@intel.com>
Co-authored-by: Bobrovsky, Konstantin S <konstantin.s.bobrovsky@intel.com>
Signed-off-by: Denis Bakhvalov <denis.bakhvalov@intel.com>