### PR TITLE
[SYCL][NFC] Fix ABI tests in post-commit

### DIFF
--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -25,7 +25,7 @@ void foo() {
 // CHECK-NEXT: 16 |       struct std::_Vector_base<class std::vector<char, class std::allocator<char> >, class std::allocator<class std::vector<char, class std::allocator<char> > > >::_Vector_impl _M_impl
 // CHECK-NEXT: 16 |         class std::allocator<class std::vector<char, class std::allocator<char> > > (base) (empty)
 // CHECK-NEXT: 16 |           class __gnu_cxx::new_allocator<class std::vector<char, class std::allocator<char> > > (base) (empty)
-// CHECK-NEXT: 16 |         std::_Vector_base<class std::vector<char, class std::allocator<char> >, class std::allocator<class std::vector<char, class std::allocator<char> > > >::pointer _M_start
+// CHECK: 16 |         std::_Vector_base<class std::vector<char, class std::allocator<char> >, class std::allocator<class std::vector<char, class std::allocator<char> > > >::pointer _M_start
 // CHECK-NEXT: 24 |         std::_Vector_base<class std::vector<char, class std::allocator<char> >, class std::allocator<class std::vector<char, class std::allocator<char> > > >::pointer _M_finish
 // CHECK-NEXT: 32 |         std::_Vector_base<class std::vector<char, class std::allocator<char> >, class std::allocator<class std::vector<char, class std::allocator<char> > > >::pointer _M_end_of_storage
 // CHECK-NEXT: 40 |   class std::vector<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost> > > MAccStorage
@@ -33,7 +33,7 @@ void foo() {
 // CHECK-NEXT: 40 |       struct std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost> > >::_Vector_impl _M_impl
 // CHECK-NEXT: 40 |         class std::allocator<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost> > (base) (empty)
 // CHECK-NEXT: 40 |           class __gnu_cxx::new_allocator<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost> > (base) (empty)
-// CHECK-NEXT: 40 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost> > >::pointer _M_start
+// CHECK: 40 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost> > >::pointer _M_start
 // CHECK-NEXT: 48 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost> > >::pointer _M_finish
 // CHECK-NEXT: 56 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::AccessorImplHost> > >::pointer _M_end_of_storage
 // CHECK-NEXT: 64 |   class std::vector<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost> > > MLocalAccStorage
@@ -41,7 +41,7 @@ void foo() {
 // CHECK-NEXT: 64 |       struct std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost> > >::_Vector_impl _M_impl
 // CHECK-NEXT: 64 |         class std::allocator<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost> > (base) (empty)
 // CHECK-NEXT: 64 |           class __gnu_cxx::new_allocator<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost> > (base) (empty)
-// CHECK-NEXT: 64 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost> > >::pointer _M_start
+// CHECK: 64 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost> > >::pointer _M_start
 // CHECK-NEXT: 72 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost> > >::pointer _M_finish
 // CHECK-NEXT: 80 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::LocalAccessorImplHost> > >::pointer _M_end_of_storage
 // CHECK-NEXT: 88 |   class std::vector<class std::shared_ptr<class cl::sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::stream_impl> > > MStreamStorage
@@ -49,7 +49,7 @@ void foo() {
 // CHECK-NEXT: 88 |       struct std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::stream_impl> > >::_Vector_impl _M_impl
 // CHECK-NEXT: 88 |         class std::allocator<class std::shared_ptr<class cl::sycl::detail::stream_impl> > (base) (empty)
 // CHECK-NEXT: 88 |           class __gnu_cxx::new_allocator<class std::shared_ptr<class cl::sycl::detail::stream_impl> > (base) (empty)
-// CHECK-NEXT: 88 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::stream_impl> > >::pointer _M_start
+// CHECK: 88 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::stream_impl> > >::pointer _M_start
 // CHECK-NEXT: 96 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::stream_impl> > >::pointer _M_finish
 // CHECK-NEXT: 104 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::stream_impl> > >::pointer _M_end_of_storage
 // CHECK-NEXT: 112 |   class std::vector<class std::shared_ptr<const void>, class std::allocator<class std::shared_ptr<const void> > > MSharedPtrStorage
@@ -57,7 +57,7 @@ void foo() {
 // CHECK-NEXT: 112 |       struct std::_Vector_base<class std::shared_ptr<const void>, class std::allocator<class std::shared_ptr<const void> > >::_Vector_impl _M_impl
 // CHECK-NEXT: 112 |         class std::allocator<class std::shared_ptr<const void> > (base) (empty)
 // CHECK-NEXT: 112 |           class __gnu_cxx::new_allocator<class std::shared_ptr<const void> > (base) (empty)
-// CHECK-NEXT: 112 |         std::_Vector_base<class std::shared_ptr<const void>, class std::allocator<class std::shared_ptr<const void> > >::pointer _M_start
+// CHECK: 112 |         std::_Vector_base<class std::shared_ptr<const void>, class std::allocator<class std::shared_ptr<const void> > >::pointer _M_start
 // CHECK-NEXT: 120 |         std::_Vector_base<class std::shared_ptr<const void>, class std::allocator<class std::shared_ptr<const void> > >::pointer _M_finish
 // CHECK-NEXT: 128 |         std::_Vector_base<class std::shared_ptr<const void>, class std::allocator<class std::shared_ptr<const void> > >::pointer _M_end_of_storage
 // CHECK-NEXT: 136 |   class std::vector<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> > MArgs
@@ -65,7 +65,7 @@ void foo() {
 // CHECK-NEXT: 136 |       struct std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::_Vector_impl _M_impl
 // CHECK-NEXT: 136 |         class std::allocator<class cl::sycl::detail::ArgDesc> (base) (empty)
 // CHECK-NEXT: 136 |           class __gnu_cxx::new_allocator<class cl::sycl::detail::ArgDesc> (base) (empty)
-// CHECK-NEXT: 136 |         std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::pointer _M_start
+// CHECK: 136 |         std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::pointer _M_start
 // CHECK-NEXT: 144 |         std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::pointer _M_finish
 // CHECK-NEXT: 152 |         std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::pointer _M_end_of_storage
 // CHECK-NEXT: 160 |   class std::vector<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> > MAssociatedAccesors
@@ -73,7 +73,7 @@ void foo() {
 // CHECK-NEXT: 160 |       struct std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::_Vector_impl _M_impl
 // CHECK-NEXT: 160 |         class std::allocator<class cl::sycl::detail::ArgDesc> (base) (empty)
 // CHECK-NEXT: 160 |           class __gnu_cxx::new_allocator<class cl::sycl::detail::ArgDesc> (base) (empty)
-// CHECK-NEXT: 160 |         std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::pointer _M_start
+// CHECK: 160 |         std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::pointer _M_start
 // CHECK-NEXT: 168 |         std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::pointer _M_finish
 // CHECK-NEXT: 176 |         std::_Vector_base<class cl::sycl::detail::ArgDesc, class std::allocator<class cl::sycl::detail::ArgDesc> >::pointer _M_end_of_storage
 // CHECK-NEXT: 184 |   class std::vector<class cl::sycl::detail::AccessorImplHost *, class std::allocator<class cl::sycl::detail::AccessorImplHost *> > MRequirements
@@ -81,7 +81,7 @@ void foo() {
 // CHECK-NEXT: 184 |       struct std::_Vector_base<class cl::sycl::detail::AccessorImplHost *, class std::allocator<class cl::sycl::detail::AccessorImplHost *> >::_Vector_impl _M_impl
 // CHECK-NEXT: 184 |         class std::allocator<class cl::sycl::detail::AccessorImplHost *> (base) (empty)
 // CHECK-NEXT: 184 |           class __gnu_cxx::new_allocator<class cl::sycl::detail::AccessorImplHost *> (base) (empty)
-// CHECK-NEXT: 184 |         std::_Vector_base<class cl::sycl::detail::AccessorImplHost *, class std::allocator<class cl::sycl::detail::AccessorImplHost *> >::pointer _M_start
+// CHECK: 184 |         std::_Vector_base<class cl::sycl::detail::AccessorImplHost *, class std::allocator<class cl::sycl::detail::AccessorImplHost *> >::pointer _M_start
 // CHECK-NEXT: 192 |         std::_Vector_base<class cl::sycl::detail::AccessorImplHost *, class std::allocator<class cl::sycl::detail::AccessorImplHost *> >::pointer _M_finish
 // CHECK-NEXT: 200 |         std::_Vector_base<class cl::sycl::detail::AccessorImplHost *, class std::allocator<class cl::sycl::detail::AccessorImplHost *> >::pointer _M_end_of_storage
 // CHECK-NEXT: 208 |   class cl::sycl::detail::NDRDescT MNDRDesc
@@ -98,7 +98,7 @@ void foo() {
 // CHECK-NEXT: 280 |       class cl::sycl::detail::array<3> (base)
 // CHECK-NEXT: 280 |         size_t [3] common_array
 // CHECK-NEXT: 304 |     size_t Dims
-// CHECK-NEXT: 312 |   class std::__cxx11::basic_string<char, struct std::char_traits<char>, class std::allocator<char> > MKernelName
+// CHECK-NEXT: 312 |   class std::__cxx11::basic_string<char{{.*}}> MKernelName
 // CHECK-NEXT: 312 |     struct std::__cxx11::basic_string<char, struct std::char_traits<char>, class std::allocator<char> >::_Alloc_hider _M_dataplus
 // CHECK-NEXT: 312 |       class std::allocator<char> (base) (empty)
 // CHECK-NEXT: 312 |         class __gnu_cxx::new_allocator<char> (base) (empty)
@@ -122,11 +122,11 @@ void foo() {
 // CHECK-NEXT: 392 |       struct std::_Vector_base<char, class std::allocator<char> >::_Vector_impl _M_impl
 // CHECK-NEXT: 392 |         class std::allocator<char> (base) (empty)
 // CHECK-NEXT: 392 |           class __gnu_cxx::new_allocator<char> (base) (empty)
-// CHECK-NEXT: 392 |         std::_Vector_base<char, class std::allocator<char> >::pointer _M_start
+// CHECK: 392 |         std::_Vector_base<char, class std::allocator<char> >::pointer _M_start
 // CHECK-NEXT: 400 |         std::_Vector_base<char, class std::allocator<char> >::pointer _M_finish
 // CHECK-NEXT: 408 |         std::_Vector_base<char, class std::allocator<char> >::pointer _M_end_of_storage
 // CHECK-NEXT: 416 |   class std::unique_ptr<class cl::sycl::detail::HostKernelBase, struct std::default_delete<class cl::sycl::detail::HostKernelBase> > MHostKernel
-// CHECK-NEXT: 416 |     class std::__uniq_ptr_impl<class cl::sycl::detail::HostKernelBase, struct std::default_delete<class cl::sycl::detail::HostKernelBase> > _M_t
+// CHECK: 416 |     class std::__uniq_ptr_impl<class cl::sycl::detail::HostKernelBase, struct std::default_delete<class cl::sycl::detail::HostKernelBase> >
 // CHECK-NEXT: 416 |       class std::tuple<class cl::sycl::detail::HostKernelBase *, struct std::default_delete<class cl::sycl::detail::HostKernelBase> > _M_t
 // CHECK-NEXT: 416 |         struct std::_Tuple_impl<0, class cl::sycl::detail::HostKernelBase *, struct std::default_delete<class cl::sycl::detail::HostKernelBase> > (base)
 // CHECK-NEXT: 416 |           struct std::_Tuple_impl<1, struct std::default_delete<class cl::sycl::detail::HostKernelBase> > (base) (empty)
@@ -135,7 +135,7 @@ void foo() {
 // CHECK-NEXT: 416 |           struct std::_Head_base<0, class cl::sycl::detail::HostKernelBase *, false> (base)
 // CHECK-NEXT: 416 |             class cl::sycl::detail::HostKernelBase * _M_head_impl
 // CHECK-NEXT: 424 |   class std::unique_ptr<class cl::sycl::detail::HostTask, struct std::default_delete<class cl::sycl::detail::HostTask> > MHostTask
-// CHECK-NEXT: 424 |     class std::__uniq_ptr_impl<class cl::sycl::detail::HostTask, struct std::default_delete<class cl::sycl::detail::HostTask> > _M_t
+// CHECK: 424 |     class std::__uniq_ptr_impl<class cl::sycl::detail::HostTask, struct std::default_delete<class cl::sycl::detail::HostTask> >
 // CHECK-NEXT: 424 |       class std::tuple<class cl::sycl::detail::HostTask *, struct std::default_delete<class cl::sycl::detail::HostTask> > _M_t
 // CHECK-NEXT: 424 |         struct std::_Tuple_impl<0, class cl::sycl::detail::HostTask *, struct std::default_delete<class cl::sycl::detail::HostTask> > (base)
 // CHECK-NEXT: 424 |           struct std::_Tuple_impl<1, struct std::default_delete<class cl::sycl::detail::HostTask> > (base) (empty)
@@ -145,7 +145,7 @@ void foo() {
 // CHECK-NEXT: 424 |             class cl::sycl::detail::HostTask * _M_head_impl
 // CHECK-NEXT: 432 |   detail::OSModuleHandle MOSModuleHandle
 // CHECK-NEXT: 440 |   class std::unique_ptr<class cl::sycl::detail::InteropTask, struct std::default_delete<class cl::sycl::detail::InteropTask> > MInteropTask
-// CHECK-NEXT: 440 |     class std::__uniq_ptr_impl<class cl::sycl::detail::InteropTask, struct std::default_delete<class cl::sycl::detail::InteropTask> > _M_t
+// CHECK: 440 |     class std::__uniq_ptr_impl<class cl::sycl::detail::InteropTask, struct std::default_delete<class cl::sycl::detail::InteropTask> >
 // CHECK-NEXT: 440 |       class std::tuple<class cl::sycl::detail::InteropTask *, struct std::default_delete<class cl::sycl::detail::InteropTask> > _M_t
 // CHECK-NEXT: 440 |         struct std::_Tuple_impl<0, class cl::sycl::detail::InteropTask *, struct std::default_delete<class cl::sycl::detail::InteropTask> > (base)
 // CHECK-NEXT: 440 |           struct std::_Tuple_impl<1, struct std::default_delete<class cl::sycl::detail::InteropTask> > (base) (empty)
@@ -158,7 +158,7 @@ void foo() {
 // CHECK-NEXT: 448 |       struct std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::event_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::event_impl> > >::_Vector_impl _M_impl
 // CHECK-NEXT: 448 |         class std::allocator<class std::shared_ptr<class cl::sycl::detail::event_impl> > (base) (empty)
 // CHECK-NEXT: 448 |           class __gnu_cxx::new_allocator<class std::shared_ptr<class cl::sycl::detail::event_impl> > (base) (empty)
-// CHECK-NEXT: 448 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::event_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::event_impl> > >::pointer _M_start
+// CHECK: 448 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::event_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::event_impl> > >::pointer _M_start
 // CHECK-NEXT: 456 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::event_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::event_impl> > >::pointer _M_finish
 // CHECK-NEXT: 464 |         std::_Vector_base<class std::shared_ptr<class cl::sycl::detail::event_impl>, class std::allocator<class std::shared_ptr<class cl::sycl::detail::event_impl> > >::pointer _M_end_of_storage
 // CHECK-NEXT: 472 |   _Bool MIsHost


### PR DESCRIPTION
Post-commit machines have GCC 9 pre-installed. The newer libstdc++
changes field names while preserving data structure layout. Update tests
to be aware of these differences.