### PR TITLE
[SYCL][USM] fix clMemFreeIntel ptr argument

### DIFF
--- a/sycl/include/CL/cl_usm_ext.h
+++ b/sycl/include/CL/cl_usm_ext.h
@@ -119,11 +119,11 @@ typedef CL_API_ENTRY void *(CL_API_CALL *clSharedMemAllocINTEL_fn)(
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clMemFreeINTEL(cl_context context,
-               const void *ptr); // TBD: const?
+               void *ptr); // TBD: const?
 
 typedef CL_API_ENTRY
 cl_int(CL_API_CALL *clMemFreeINTEL_fn)(cl_context context,
-                                       const void *ptr); // TBD: const?
+                                       void *ptr); // TBD: const?
 
 extern CL_API_ENTRY cl_int CL_API_CALL clGetMemAllocInfoINTEL(
     cl_context context, const void *ptr, cl_mem_info_intel param_name,


### PR DESCRIPTION
Compiling llvm from 0 (using cmake to download opencl headers) fails with the following message:

```
In file included from ~/dev/gpu/llvm/sycl/include/CL/sycl/detail/pi.h:49,
                 from ~/dev/gpu/llvm/sycl/include/CL/sycl/exception.hpp:15,
                 from ~/dev/gpu/llvm/sycl/include/CL/sycl/detail/common.hpp:121,
                 from ~/dev/gpu/llvm/sycl/include/CL/sycl/aliases.hpp:11,
                 from ~/dev/gpu/llvm/sycl/include/CL/sycl/detail/generic_type_traits.hpp:12,
                 from ~/dev/gpu/llvm/sycl/source/detail/builtins_helper.hpp:10,
                 from ~/dev/gpu/llvm/sycl/source/detail/builtins_common.cpp:18:
~/dev/gpu/llvm/sycl/include/CL/cl_usm_ext.h:125:21: error: conflicting declaration 'typedef cl_int (* clMemFreeINTEL_fn)(cl_context, const void*)'
  125 | cl_int(CL_API_CALL *clMemFreeINTEL_fn)(cl_context context,
      |                     ^~~~~~~~~~~~~~~~~
In file included from ~/dev/gpu/llvm/sycl/include/CL/sycl/detail/common.hpp:11,
                 from ~/dev/gpu/llvm/sycl/include/CL/sycl/aliases.hpp:11,
                 from ~/dev/gpu/llvm/sycl/include/CL/sycl/detail/generic_type_traits.hpp:12,
                 from ~/dev/gpu/llvm/sycl/source/detail/builtins_helper.hpp:10,
                 from ~/dev/gpu/llvm/sycl/source/detail/builtins_common.cpp:18:
tools/sycl/OpenCL/inc/CL/cl_ext_intel.h:533:1: note: previous declaration as 'typedef cl_int (* clMemFreeINTEL_fn)(cl_context, void*)'
  533 | clMemFreeINTEL_fn)(
      | ^~~~~~~~~~~~~~~~~

```

It seems to relate to [a commit in OpenCL-Headers](https://github.com/KhronosGroup/OpenCL-Headers/commit/b04034a17e214322772c19e7ccd2adf0cd306920)
where clMemFreeIntel is defined as void* instead of const void*:
 https://github.com/KhronosGroup/OpenCL-Headers/blob/b04034a17e214322772c19e7ccd2adf0cd306920/CL/cl_ext_intel.h#L530

This PR changes the arguments from `const void* -> void*`
It is untested but compiles again.