### PR TITLE
[SYCL] Align TLS diagnosing with community code

### DIFF
--- a/clang/test/SemaSYCL/prohibit-thread-local.cpp
+++ b/clang/test/SemaSYCL/prohibit-thread-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -verify -fsyntax-only %s
 
 thread_local const int prohobit_ns_scope = 0;
 thread_local int prohobit_ns_scope2 = 0;


### PR DESCRIPTION
Move error reporting to the place where OpenMP and CUDA does it.

Signed-off-by: Mariya Podchishchaeva <mariya.podchishchaeva@intel.com>