### PR TITLE
[CERN] Crash occurs in a IR to SPIRV pass if source file has a custom class with separate constructor declaration and definition.

### DIFF
--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -36,6 +36,7 @@
 #include "llvm/IR/Value.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/IR/GlobalAlias.h"
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -1292,7 +1293,11 @@ public:
   /// Returns the function called, or null if this is an
   /// indirect function invocation.
   Function *getCalledFunction() const {
-    return dyn_cast_or_null<Function>(getCalledOperand());
+    if (auto Alias = dyn_cast_or_null<llvm::GlobalAlias>(getCalledOperand())) {
+      return dyn_cast_or_null<Function>(Alias->getAliasee());
+    } else {
+      return dyn_cast_or_null<Function>(getCalledOperand());
+    }
   }
 
   /// Return true if the callsite is an indirect call.


### PR DESCRIPTION
In case separate constructor declaration and definition the IR representation has GlobalAlias objects which didn't process properly in getCalledFunction method of CallInst class.

Signed-off-by: Aleksander Fadeev <aleksander.fadeev@intel.com>