### PR TITLE
[SYCL][LIT] Mark spec const LIT as pass

### DIFF
--- a/sycl/test/spec_const/spec_const_hw.cpp
+++ b/sycl/test/spec_const/spec_const_hw.cpp
@@ -1,12 +1,9 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// UNSUPPORTED: cuda || level0
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
-// TODO: re-enable after CI drivers are updated to newer which support spec
-// constants:
-// XFAIL: linux && opencl
-// UNSUPPORTED: cuda || level0
 //
 //==----------- spec_const_hw.cpp ------------------------------------------==//
 //

--- a/sycl/test/spec_const/spec_const_hw_accelerator.cpp
+++ b/sycl/test/spec_const/spec_const_hw_accelerator.cpp
@@ -1,0 +1,17 @@
+//==----------- spec_const_hw_accelerator.cpp ------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// The test checks that the specialization constant feature works correctly -
+// tool chain processes them correctly and runtime can correctly execute the
+// program.
+
+// TODO: re-enable after CI drivers are updated to newer which support spec
+// constants:
+// XFAIL: linux && opencl && accelerator
+// UNSUPPORTED: cuda || level0
+#include "spec_const_hw.cpp"
+// RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/spec_const/spec_const_redefine.cpp
+++ b/sycl/test/spec_const/spec_const_redefine.cpp
@@ -1,12 +1,9 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// UNSUPPORTED: cuda || level0
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
-// RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
-// TODO: re-enable after CI drivers are updated to newer which support spec
-// constants:
-// XFAIL: linux && opencl
-// UNSUPPORTED: cuda || level0
 //
 //==----------- spec_const_redefine.cpp ------------------------------------==//
 //

--- a/sycl/test/spec_const/spec_const_redefine_accelerator.cpp
+++ b/sycl/test/spec_const/spec_const_redefine_accelerator.cpp
@@ -1,0 +1,19 @@
+//==----------- spec_const_redefine.cpp ------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// The test checks that:
+// - a specialization constant can be redifined and correct new value is used
+//   after redefinition.
+// - the program is JITted only once per a unique set of specialization
+//   constants values.
+
+// TODO: re-enable after CI drivers are updated to newer which support spec
+// constants:
+// XFAIL: linux && opencl && accelerator
+// UNSUPPORTED: cuda || level0
+#include "spec_const_redefine_accelerator.cpp"
+// RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER


### PR DESCRIPTION
The spec_const LIT tests start to pass for Intel CPU and GPU devices
with the Intel OpenCL GPU driver 20.19.16754.

Fixes #1873

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>