### PR TITLE
Follow up fixes after enabling LIT for Level Zero

### DIFF
--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -46,7 +46,15 @@ if (NOT DEFINED L0_LIBRARY OR NOT DEFINED L0_INCLUDE_DIR)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS l0-loader)
 else()
   include_directories("${L0_INCLUDE_DIR}")
+  add_custom_target(l0-loader
+    DEPENDS ${L0_LIBRARY} COMMENT "Using provided L0 Loader")
 endif()
+
+add_library (L0Loader-Headers INTERFACE)
+add_library (L0Loader::Headers ALIAS L0Loader-Headers)
+target_include_directories(L0Loader-Headers
+  INTERFACE "${L0_INCLUDE_DIR}"
+)
 
 include_directories("${sycl_inc_dir}")
 include_directories(${OPENCL_INCLUDE})

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -90,7 +90,7 @@ def getDeviceCount(device_type):
     if exit_code != 0:
         lit_config.error("getDeviceCount {TYPE} {BACKEND}: Non-zero exit code {CODE}".format(
             TYPE=device_type, BACKEND=backend, CODE=exit_code))
-        return [0,False]
+        return [0,False,False]
 
     result = output.decode().replace('\n', '').split(':', 1)
     try:

--- a/sycl/tools/CMakeLists.txt
+++ b/sycl/tools/CMakeLists.txt
@@ -8,17 +8,20 @@ add_subdirectory(sycl-ls)
 add_executable(get_device_count_by_type get_device_count_by_type.cpp)
 add_dependencies(get_device_count_by_type ocl-headers ocl-icd l0-loader)
 
-if(MSVC)
-  set(L0_LIBRARY
+if (NOT DEFINED L0_LIBRARY)
+  if(MSVC)
+    set(L0_LIBRARY
       "${LLVM_LIBRARY_OUTPUT_INTDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}ze_loader${CMAKE_STATIC_LIBRARY_SUFFIX}")
-else()
-  set(L0_LIBRARY
+  else()
+    set(L0_LIBRARY
       "${LLVM_LIBRARY_OUTPUT_INTDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}ze_loader${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  endif()
 endif()
 
 target_link_libraries(get_device_count_by_type
   PRIVATE
     OpenCL::Headers
+    L0Loader::Headers
     ${OpenCL_LIBRARIES}
     ${L0_LIBRARY}
     $<$<BOOL:${SYCL_BUILD_PI_CUDA}>:cudadrv>


### PR DESCRIPTION
* Fix return values in lit.cfg.py
* Fix CMake file for get_device_count_by_type tool for the case when
local Level Zero lib and headers are provided.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>