### PR TITLE
[SYCL][ESIMD] Use vload/vstore for simd object getter/setter.

### DIFF
--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -415,6 +415,7 @@ void initializeStripSymbolsPass(PassRegistry&);
 void initializeStructurizeCFGPass(PassRegistry&);
 void initializeSYCLLowerWGScopeLegacyPassPass(PassRegistry &);
 void initializeSYCLLowerESIMDLegacyPassPass(PassRegistry &);
+void initializeESIMDLowerLoadStorePass(PassRegistry &);
 void initializeTailCallElimPass(PassRegistry&);
 void initializeTailDuplicatePass(PassRegistry&);
 void initializeTargetLibraryInfoWrapperPassPass(PassRegistry&);

--- a/llvm/include/llvm/LinkAllPasses.h
+++ b/llvm/include/llvm/LinkAllPasses.h
@@ -203,6 +203,7 @@ namespace {
       (void) llvm::createExpandMemCmpPass();
       (void)llvm::createSYCLLowerWGScopePass();
       (void)llvm::createSYCLLowerESIMDPass();
+      (void)llvm::createESIMDLowerLoadStorePass();
       std::string buf;
       llvm::raw_string_ostream os(buf);
       (void) llvm::createPrintModulePass(os);

--- a/llvm/include/llvm/SYCLLowerIR/LowerESIMD.h
+++ b/llvm/include/llvm/SYCLLowerIR/LowerESIMD.h
@@ -34,6 +34,11 @@ public:
 FunctionPass *createSYCLLowerESIMDPass();
 void initializeSYCLLowerESIMDLegacyPassPass(PassRegistry &);
 
+class ESIMDLowerLoadStorePass : public PassInfoMixin<ESIMDLowerLoadStorePass> {
+public:
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+};
+
 FunctionPass *createESIMDLowerLoadStorePass();
 void initializeESIMDLowerLoadStorePass(PassRegistry &);
 

--- a/llvm/include/llvm/SYCLLowerIR/LowerESIMD.h
+++ b/llvm/include/llvm/SYCLLowerIR/LowerESIMD.h
@@ -34,6 +34,9 @@ public:
 FunctionPass *createSYCLLowerESIMDPass();
 void initializeSYCLLowerESIMDLegacyPassPass(PassRegistry &);
 
+FunctionPass *createESIMDLowerLoadStorePass();
+void initializeESIMDLowerLoadStorePass(PassRegistry &);
+
 } // namespace llvm
 
 #endif // LLVM_SYCLLOWERIR_LOWERESIMD_H

--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 add_llvm_component_library(LLVMSYCLLowerIR
   LowerWGScope.cpp
   LowerESIMD.cpp
+  LowerESIMDVLoadVStore.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/SYCLLowerIR

--- a/llvm/lib/SYCLLowerIR/LowerESIMDVLoadVStore.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMDVLoadVStore.cpp
@@ -21,30 +21,29 @@
 
 #define DEBUG_TYPE "loweresimdvloadvstore"
 
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/GenXIntrinsics/GenXIntrinsics.h"
-#include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
-#include "llvm/InitializePasses.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Scalar.h"
+#include "llvm/SYCLLowerIR/LowerESIMD.h"
 
 #include "llvm/Pass.h"
 
 using namespace llvm;
 
 namespace llvm {
-void initializeESIMDLowerLoadStorePass(PassRegistry &);
+  void initializeESIMDLowerLoadStorePass(PassRegistry&);
 }
 
 namespace {
 
-struct ESIMDLowerLoadStore : public FunctionPass {
+class ESIMDLowerLoadStore : public FunctionPass {
+public:
   static char ID;
   ESIMDLowerLoadStore() : FunctionPass(ID) {
     initializeESIMDLowerLoadStorePass(*PassRegistry::getPassRegistry());
@@ -53,10 +52,14 @@ struct ESIMDLowerLoadStore : public FunctionPass {
     AU.setPreservesCFG();
   }
 
-  virtual bool runOnFunction(Function &F) override;
+  virtual bool runOnFunction(Function &F) override  {
+    FunctionAnalysisManager FAM;
+    auto PA = Impl.run(F, FAM);
+    return !PA.areAllPreserved();
+  }
 
 private:
-  bool lowerLoadStore(Function &F);
+  ESIMDLowerLoadStorePass Impl;
 };
 
 } // namespace
@@ -65,65 +68,61 @@ char ESIMDLowerLoadStore::ID = 0;
 INITIALIZE_PASS(ESIMDLowerLoadStore, "ESIMDLowerLoadStore",
                 "Lower ESIMD reference loads and stores", false, false)
 
-bool ESIMDLowerLoadStore::runOnFunction(Function &F) {
-  bool Changed = false;
-  Changed |= lowerLoadStore(F);
-  return Changed;
-}
-
 // Lower non-volatilE vload/vstore intrinsic calls into normal load/store
 // instructions.
-bool ESIMDLowerLoadStore::lowerLoadStore(Function &F) {
-  // lower all vload/vstore into normal load/store.
+PreservedAnalyses ESIMDLowerLoadStorePass::run(Function &F,
+                                FunctionAnalysisManager &FAM) {
   std::vector<Instruction *> ToErase;
   for (Instruction &Inst : instructions(F)) {
-    if (GenXIntrinsic::isVLoadStore(&Inst)) {
-      auto *Ptr = Inst.getOperand(0);
+    if (!GenXIntrinsic::isVLoadStore(&Inst))
+      continue;
+
+    auto *Ptr = Inst.getOperand(0);
+    if (GenXIntrinsic::isVStore(&Inst))
+      Ptr = Inst.getOperand(1);
+    auto AS0 = cast<PointerType>(Ptr->getType())->getAddressSpace();
+    Ptr = Ptr->stripPointerCasts();
+    auto GV = dyn_cast<GlobalVariable>(Ptr);
+    if (!GV || !GV->hasAttribute("genx_volatile")) {
+      // change to load/store
+      IRBuilder<> Builder(&Inst);
       if (GenXIntrinsic::isVStore(&Inst))
-        Ptr = Inst.getOperand(1);
-      auto AS0 = cast<PointerType>(Ptr->getType())->getAddressSpace();
-      Ptr = Ptr->stripPointerCasts();
-      auto GV = dyn_cast<GlobalVariable>(Ptr);
-      if (!GV || !GV->hasAttribute("genx_volatile")) {
-        // change to load/store
+        Builder.CreateStore(Inst.getOperand(0), Inst.getOperand(1));
+      else {
+        auto LI = Builder.CreateLoad(Inst.getOperand(0), Inst.getName());
+        LI->setDebugLoc(Inst.getDebugLoc());
+        Inst.replaceAllUsesWith(LI);
+      }
+      ToErase.push_back(&Inst);
+    }
+    else {
+      // change to vload/vstore that has the same address space as
+      // the global-var in order to clean up unnecessary addr-cast.
+      auto AS1 = GV->getType()->getAddressSpace();
+      if (AS0 != AS1) {
         IRBuilder<> Builder(&Inst);
-        if (GenXIntrinsic::isVStore(&Inst))
-          Builder.CreateStore(Inst.getOperand(0), Inst.getOperand(1));
+        if (GenXIntrinsic::isVStore(&Inst)) {
+          auto PtrTy = cast<PointerType>(Inst.getOperand(1)->getType());
+          PtrTy = PointerType::get(PtrTy->getElementType(), AS1);
+          auto PtrCast = Builder.CreateAddrSpaceCast(Inst.getOperand(1), PtrTy);
+          Type *Tys[] = {Inst.getOperand(0)->getType(),
+                          PtrCast->getType()};
+          Value *Args[] = {Inst.getOperand(0), PtrCast};
+          Function *Fn = GenXIntrinsic::getGenXDeclaration(
+                            F.getParent(), GenXIntrinsic::genx_vstore, Tys);
+          Builder.CreateCall(Fn, Args, Inst.getName());
+        }
         else {
-          auto LI = Builder.CreateLoad(Inst.getOperand(0), Inst.getName());
-          LI->setDebugLoc(Inst.getDebugLoc());
-          Inst.replaceAllUsesWith(LI);
+          auto PtrTy = cast<PointerType>(Inst.getOperand(0)->getType());
+          PtrTy = PointerType::get(PtrTy->getElementType(), AS1);
+          auto PtrCast = Builder.CreateAddrSpaceCast(Inst.getOperand(0), PtrTy);
+          Type *Tys[] = {Inst.getType(), PtrCast->getType()};
+          Function *Fn = GenXIntrinsic::getGenXDeclaration(
+                            F.getParent(), GenXIntrinsic::genx_vload, Tys);
+          Value *VLoad = Builder.CreateCall(Fn, PtrCast, Inst.getName());
+          Inst.replaceAllUsesWith(VLoad);
         }
         ToErase.push_back(&Inst);
-      } else {
-        // change to vload/vstore that has the same address space as
-        // the global-var in order to clean up unnecessary addr-cast.
-        auto AS1 = GV->getType()->getAddressSpace();
-        if (AS0 != AS1) {
-          IRBuilder<> Builder(&Inst);
-          if (GenXIntrinsic::isVStore(&Inst)) {
-            auto PtrTy = cast<PointerType>(Inst.getOperand(1)->getType());
-            PtrTy = PointerType::get(PtrTy->getElementType(), AS1);
-            auto PtrCast =
-                Builder.CreateAddrSpaceCast(Inst.getOperand(1), PtrTy);
-            Type *Tys[] = {Inst.getOperand(0)->getType(), PtrCast->getType()};
-            Value *Args[] = {Inst.getOperand(0), PtrCast};
-            Function *Fn = GenXIntrinsic::getGenXDeclaration(
-                F.getParent(), GenXIntrinsic::genx_vstore, Tys);
-            Builder.CreateCall(Fn, Args, Inst.getName());
-          } else {
-            auto PtrTy = cast<PointerType>(Inst.getOperand(0)->getType());
-            PtrTy = PointerType::get(PtrTy->getElementType(), AS1);
-            auto PtrCast =
-                Builder.CreateAddrSpaceCast(Inst.getOperand(0), PtrTy);
-            Type *Tys[] = {Inst.getType(), PtrCast->getType()};
-            Function *Fn = GenXIntrinsic::getGenXDeclaration(
-                F.getParent(), GenXIntrinsic::genx_vload, Tys);
-            Value *VLoad = Builder.CreateCall(Fn, PtrCast, Inst.getName());
-            Inst.replaceAllUsesWith(VLoad);
-          }
-          ToErase.push_back(&Inst);
-        }
       }
     }
   }
@@ -132,11 +131,12 @@ bool ESIMDLowerLoadStore::lowerLoadStore(Function &F) {
     Inst->eraseFromParent();
   }
 
-  return !ToErase.empty();
+  return !ToErase.empty() ? PreservedAnalyses::none()
+                           : PreservedAnalyses::all();
 }
 
 namespace llvm {
-FunctionPass *createESIMDLowerLoadStorePass() {
-  return new ESIMDLowerLoadStore;
+  FunctionPass* createESIMDLowerLoadStorePass() {
+    return new ESIMDLowerLoadStore;
+  }
 }
-} // namespace llvm

--- a/llvm/lib/SYCLLowerIR/LowerESIMDVLoadVStore.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMDVLoadVStore.cpp
@@ -1,0 +1,142 @@
+//===- LowerESIMDVLoadVStore.cpp - lower vload/vstore to load/store -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// convert vload/vstore to load/store if they are not for genx_volatile.
+//
+// File scope simd variables marked with genx_volatile attribute want
+// guarranteed allocation in register file, therefore we use vload/vstore
+// instead of load/store, so they won't be optimized away by llvm.
+//
+// For ordinary simd variables, we do not need to protect load/store. But
+// there is no good way to do this in clang. So we need this pass in the
+// end of module passes to separate the cases that we need vload/vstore vs.
+// the cases that we do not need vload/vstore
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "loweresimdvloadvstore"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/GenXIntrinsics/GenXIntrinsics.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Module.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Scalar.h"
+
+#include "llvm/Pass.h"
+
+using namespace llvm;
+
+namespace llvm {
+void initializeESIMDLowerLoadStorePass(PassRegistry &);
+}
+
+namespace {
+
+struct ESIMDLowerLoadStore : public FunctionPass {
+  static char ID;
+  ESIMDLowerLoadStore() : FunctionPass(ID) {
+    initializeESIMDLowerLoadStorePass(*PassRegistry::getPassRegistry());
+  }
+  virtual void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesCFG();
+  }
+
+  virtual bool runOnFunction(Function &F) override;
+
+private:
+  bool lowerLoadStore(Function &F);
+};
+
+} // namespace
+
+char ESIMDLowerLoadStore::ID = 0;
+INITIALIZE_PASS(ESIMDLowerLoadStore, "ESIMDLowerLoadStore",
+                "Lower ESIMD reference loads and stores", false, false)
+
+bool ESIMDLowerLoadStore::runOnFunction(Function &F) {
+  bool Changed = false;
+  Changed |= lowerLoadStore(F);
+  return Changed;
+}
+
+// Lower non-volatilE vload/vstore intrinsic calls into normal load/store
+// instructions.
+bool ESIMDLowerLoadStore::lowerLoadStore(Function &F) {
+  // lower all vload/vstore into normal load/store.
+  std::vector<Instruction *> ToErase;
+  for (Instruction &Inst : instructions(F)) {
+    if (GenXIntrinsic::isVLoadStore(&Inst)) {
+      auto *Ptr = Inst.getOperand(0);
+      if (GenXIntrinsic::isVStore(&Inst))
+        Ptr = Inst.getOperand(1);
+      auto AS0 = cast<PointerType>(Ptr->getType())->getAddressSpace();
+      Ptr = Ptr->stripPointerCasts();
+      auto GV = dyn_cast<GlobalVariable>(Ptr);
+      if (!GV || !GV->hasAttribute("genx_volatile")) {
+        // change to load/store
+        IRBuilder<> Builder(&Inst);
+        if (GenXIntrinsic::isVStore(&Inst))
+          Builder.CreateStore(Inst.getOperand(0), Inst.getOperand(1));
+        else {
+          auto LI = Builder.CreateLoad(Inst.getOperand(0), Inst.getName());
+          LI->setDebugLoc(Inst.getDebugLoc());
+          Inst.replaceAllUsesWith(LI);
+        }
+        ToErase.push_back(&Inst);
+      } else {
+        // change to vload/vstore that has the same address space as
+        // the global-var in order to clean up unnecessary addr-cast.
+        auto AS1 = GV->getType()->getAddressSpace();
+        if (AS0 != AS1) {
+          IRBuilder<> Builder(&Inst);
+          if (GenXIntrinsic::isVStore(&Inst)) {
+            auto PtrTy = cast<PointerType>(Inst.getOperand(1)->getType());
+            PtrTy = PointerType::get(PtrTy->getElementType(), AS1);
+            auto PtrCast =
+                Builder.CreateAddrSpaceCast(Inst.getOperand(1), PtrTy);
+            Type *Tys[] = {Inst.getOperand(0)->getType(), PtrCast->getType()};
+            Value *Args[] = {Inst.getOperand(0), PtrCast};
+            Function *Fn = GenXIntrinsic::getGenXDeclaration(
+                F.getParent(), GenXIntrinsic::genx_vstore, Tys);
+            Builder.CreateCall(Fn, Args, Inst.getName());
+          } else {
+            auto PtrTy = cast<PointerType>(Inst.getOperand(0)->getType());
+            PtrTy = PointerType::get(PtrTy->getElementType(), AS1);
+            auto PtrCast =
+                Builder.CreateAddrSpaceCast(Inst.getOperand(0), PtrTy);
+            Type *Tys[] = {Inst.getType(), PtrCast->getType()};
+            Function *Fn = GenXIntrinsic::getGenXDeclaration(
+                F.getParent(), GenXIntrinsic::genx_vload, Tys);
+            Value *VLoad = Builder.CreateCall(Fn, PtrCast, Inst.getName());
+            Inst.replaceAllUsesWith(VLoad);
+          }
+          ToErase.push_back(&Inst);
+        }
+      }
+    }
+  }
+
+  for (auto Inst : ToErase) {
+    Inst->eraseFromParent();
+  }
+
+  return !ToErase.empty();
+}
+
+namespace llvm {
+FunctionPass *createESIMDLowerLoadStorePass() {
+  return new ESIMDLowerLoadStore;
+}
+} // namespace llvm

--- a/llvm/test/SYCLLowerIR/esimd_lower_ldst.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_ldst.ll
@@ -1,0 +1,32 @@
+; RUN: opt -ESIMDLowerLoadStore -S < %s | FileCheck %s
+
+%"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd" = type { <16 x i32> }
+
+@vg = dso_local global %"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd" zeroinitializer, align 64 #0
+@vc = dso_local addrspace(1) global <16 x i32> zeroinitializer, align 64
+
+; Function Attrs: norecurse nounwind
+define dso_local spir_func void @_Z3foov() local_unnamed_addr #1 {
+; CHECK-LABEL: @_Z3foov(
+; CHECK-NEXT: [[TMP1:%.*]] = call <16 x i32> @llvm.genx.vload.v16i32.p0v16i32(<16 x i32>* getelementptr inbounds (%"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd", %"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd"* @vg, i64 0, i32 0))
+; CHECK-NEXT: store <16 x i32> [[TMP1]], <16 x i32> addrspace(4)* addrspacecast (<16 x i32> addrspace(1)* @vc to <16 x i32> addrspace(4)*), align 64
+
+  %call.esimd = call <16 x i32> @llvm.genx.vload.v16i32.p4v16i32(<16 x i32> addrspace(4)* addrspacecast (<16 x i32>* getelementptr inbounds (%"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd", %"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd"* @vg, i64 0, i32 0) to <16 x i32> addrspace(4)*))
+  call void @llvm.genx.vstore.v16i32.p4v16i32(<16 x i32> %call.esimd, <16 x i32> addrspace(4)* addrspacecast (<16 x i32> addrspace(1)* @vc to <16 x i32> addrspace(4)*))
+  ret void
+}
+
+; Function Attrs: nounwind
+declare !genx_intrinsic_id !1 <16 x i32> @llvm.genx.vload.v16i32.p4v16i32(<16 x i32> addrspace(4)*) #2
+
+; Function Attrs: nounwind
+declare !genx_intrinsic_id !2 void @llvm.genx.vstore.v16i32.p4v16i32(<16 x i32>, <16 x i32> addrspace(4)*) #2
+
+attributes #0 = { "genx_byte_offset"="192" "genx_volatile" }
+attributes #1 = { norecurse nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="512" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!0 = !{}
+!1 = !{i32 8269}
+!2 = !{i32 8270}
+

--- a/llvm/test/SYCLLowerIR/esimd_lower_ldst.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_ldst.ll
@@ -1,32 +1,34 @@
 ; RUN: opt -ESIMDLowerLoadStore -S < %s | FileCheck %s
 
-%"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd" = type { <16 x i32> }
+%"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd" = type { <16 x i32> }
 
-@vg = dso_local global %"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd" zeroinitializer, align 64 #0
+@vg = dso_local global %"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd" zeroinitializer, align 64 #0
 @vc = dso_local addrspace(1) global <16 x i32> zeroinitializer, align 64
 
 ; Function Attrs: norecurse nounwind
 define dso_local spir_func void @_Z3foov() local_unnamed_addr #1 {
 ; CHECK-LABEL: @_Z3foov(
-; CHECK-NEXT: [[TMP1:%.*]] = call <16 x i32> @llvm.genx.vload.v16i32.p0v16i32(<16 x i32>* getelementptr inbounds (%"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd", %"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd"* @vg, i64 0, i32 0))
+; CHECK-NEXT: [[TMP1:%.*]] = call <16 x i32> @llvm.genx.vload.v16i32.p0v16i32(<16 x i32>* getelementptr inbounds (%"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd", %"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd"* @vg, i64 0, i32 0))
 ; CHECK-NEXT: store <16 x i32> [[TMP1]], <16 x i32> addrspace(4)* addrspacecast (<16 x i32> addrspace(1)* @vc to <16 x i32> addrspace(4)*), align 64
+; CHECK-NEXT: [[TMP2:%.*]] = load <16 x i32>, <16 x i32> addrspace(4)* addrspacecast (<16 x i32> addrspace(1)* @vc to <16 x i32> addrspace(4)*), align 64
+; CHECK-NEXT: call void @llvm.genx.vstore.v16i32.p0v16i32(<16 x i32> [[TMP2]], <16 x i32>* getelementptr inbounds (%"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd", %"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd"* @vg, i64 0, i32 0))
 
-  %call.esimd = call <16 x i32> @llvm.genx.vload.v16i32.p4v16i32(<16 x i32> addrspace(4)* addrspacecast (<16 x i32>* getelementptr inbounds (%"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd", %"class._ZTSN4sycl5intel3gpu4simdIiLi16EEE.sycl::intel::gpu::simd"* @vg, i64 0, i32 0) to <16 x i32> addrspace(4)*))
-  call void @llvm.genx.vstore.v16i32.p4v16i32(<16 x i32> %call.esimd, <16 x i32> addrspace(4)* addrspacecast (<16 x i32> addrspace(1)* @vc to <16 x i32> addrspace(4)*))
+  %call.cm = call <16 x i32> @llvm.genx.vload.v16i32.p4v16i32(<16 x i32> addrspace(4)* addrspacecast (<16 x i32>* getelementptr inbounds (%"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd", %"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd"* @vg, i64 0, i32 0) to <16 x i32> addrspace(4)*))
+  call void @llvm.genx.vstore.v16i32.p4v16i32(<16 x i32> %call.cm, <16 x i32> addrspace(4)* addrspacecast (<16 x i32> addrspace(1)* @vc to <16 x i32> addrspace(4)*))
+  %call.cm2 = call <16 x i32> @llvm.genx.vload.v16i32.p4v16i32(<16 x i32> addrspace(4)* addrspacecast (<16 x i32> addrspace(1)* @vc to <16 x i32> addrspace(4)*))
+  call void @llvm.genx.vstore.v16i32.p4v16i32(<16 x i32> %call.cm2, <16 x i32> addrspace(4)* addrspacecast (<16 x i32>* getelementptr inbounds (%"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd", %"class._ZTSN2cm3gen4simdIiLi16EEE.cm::gen::simd"* @vg, i64 0, i32 0) to <16 x i32> addrspace(4)*))
   ret void
 }
 
 ; Function Attrs: nounwind
-declare !genx_intrinsic_id !1 <16 x i32> @llvm.genx.vload.v16i32.p4v16i32(<16 x i32> addrspace(4)*) #2
+declare <16 x i32> @llvm.genx.vload.v16i32.p4v16i32(<16 x i32> addrspace(4)*) #2
 
 ; Function Attrs: nounwind
-declare !genx_intrinsic_id !2 void @llvm.genx.vstore.v16i32.p4v16i32(<16 x i32>, <16 x i32> addrspace(4)*) #2
+declare void @llvm.genx.vstore.v16i32.p4v16i32(<16 x i32>, <16 x i32> addrspace(4)*) #2
 
 attributes #0 = { "genx_byte_offset"="192" "genx_volatile" }
 attributes #1 = { norecurse nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="512" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { nounwind }
 
 !0 = !{}
-!1 = !{i32 8269}
-!2 = !{i32 8270}
 

--- a/llvm/tools/opt/opt.cpp
+++ b/llvm/tools/opt/opt.cpp
@@ -595,6 +595,7 @@ int main(int argc, char **argv) {
   initializeTypePromotionPass(Registry);
   initializeSYCLLowerWGScopeLegacyPassPass(Registry);
   initializeSYCLLowerESIMDLegacyPassPass(Registry);
+  initializeESIMDLowerLoadStorePass(Registry);
 
 #ifdef BUILD_EXAMPLES
   initializeExampleIRTransforms(Registry);


### PR DESCRIPTION
DO NOT REVIEW FIRST TWO COMMITS (covered by https://github.com/intel/llvm/pull/1881)

Use special intrinsics to access simd objects in the private address space
to disable standard LLVM optimizations on them.

Author: Gang Chen <gang.y.chen@intel.com>

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>