### PR TITLE
[BuildBot] Uplift OpenCL runtime versions for Intel CPU and GPU

### DIFF
--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -15,14 +15,14 @@ tbb_ver=20200121_111047
 # https://github.com/oneapi-src/oneTBB/releases/download/v2020.2/tbb-2020.2-win.zip
 tbb_ver_win=20200124_000000
 # TODO: provide URL for Linux OpenCL emulator of FPGA device
-fpga_ver=20200520_000005
+fpga_ver=20200216_000000
 # TODO: provide URL for Windows OpenCL emulator of FPGA device
-fpga_ver_win=20200520_000005
+fpga_ver_win=20200216_000000
 
 [DRIVER VERSIONS]
 cpu_driver_lin=2020.10.6.0.04
 cpu_driver_win=2020.10.6.0.04
 gpu_driver_lin=20.19.16754
 gpu_driver_win=27.20.100.8280
-fpga_driver_lin=2020.9.5.0.08_110447.xmain
-fpga_driver_win=2020.9.5.0.08_110447.xmain
+fpga_driver_lin=2020.9.2.0
+fpga_driver_win=2020.9.2.0

--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -1,8 +1,8 @@
 [VERSIONS]
 # https://github.com/intel/llvm/releases/download/2020-03/oclcpuexp-2020.10.4.0.15_rel.tar.gz
-ocl_cpu_rt_ver=2020.10.4.0.15
+ocl_cpu_rt_ver=2020.10.6.0.04
 # https://github.com/intel/llvm/releases/download/2020-03/win-oclcpuexp-2020.10.4.0.15_rel.zip
-ocl_cpu_rt_ver_win=2020.10.4.0.15
+ocl_cpu_rt_ver_win=2020.10.6.0.04
 # Same GPU driver supports Level Zero and OpenCL:
 # https://github.com/intel/compute-runtime/releases/tag/20.19.16754
 ocl_gpu_rt_ver=20.19.16754
@@ -15,14 +15,14 @@ tbb_ver=20200121_111047
 # https://github.com/oneapi-src/oneTBB/releases/download/v2020.2/tbb-2020.2-win.zip
 tbb_ver_win=20200124_000000
 # TODO: provide URL for Linux OpenCL emulator of FPGA device
-fpga_ver=20200216_000000
+fpga_ver=20200520_000005
 # TODO: provide URL for Windows OpenCL emulator of FPGA device
-fpga_ver_win=20200216_000000
+fpga_ver_win=20200520_000005
 
 [DRIVER VERSIONS]
-cpu_driver_lin=2020.10.4.0.15
-cpu_driver_win=2020.10.4.0.15
+cpu_driver_lin=2020.10.6.0.04
+cpu_driver_win=2020.10.6.0.04
 gpu_driver_lin=20.19.16754
 gpu_driver_win=27.20.100.8280
-fpga_driver_lin=2020.9.2.0
-fpga_driver_win=2020.9.2.0
+fpga_driver_lin=2020.9.5.0.08_110447.xmain
+fpga_driver_win=2020.9.5.0.08_110447.xmain

--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -1,11 +1,11 @@
 [VERSIONS]
-# https://github.com/intel/llvm/releases/download/2020-03/oclcpuexp-2020.10.4.0.15_rel.tar.gz
+# https://github.com/intel/llvm/releases/download/2020-WW20/oclcpuexp-2020.10.6.0.4_rel.tar.gz
 ocl_cpu_rt_ver=2020.10.6.0.04
-# https://github.com/intel/llvm/releases/download/2020-03/win-oclcpuexp-2020.10.4.0.15_rel.zip
+# https://github.com/intel/llvm/releases/download/2020-WW20/win-oclcpuexp-2020.10.6.0.4_rel.zip
 ocl_cpu_rt_ver_win=2020.10.6.0.04
 # Same GPU driver supports Level Zero and OpenCL:
-# https://github.com/intel/compute-runtime/releases/tag/20.19.16754
-ocl_gpu_rt_ver=20.19.16754
+# https://github.com/intel/compute-runtime/releases/tag/20.21.16886
+ocl_gpu_rt_ver=20.21.16886
 # Same GPU driver supports Level Zero and OpenCL:
 # https://downloadmirror.intel.com/29616/a08/igfx_win10_100.8280.zip
 ocl_gpu_rt_ver_win=27.20.100.8280
@@ -22,7 +22,7 @@ fpga_ver_win=20200216_000000
 [DRIVER VERSIONS]
 cpu_driver_lin=2020.10.6.0.04
 cpu_driver_win=2020.10.6.0.04
-gpu_driver_lin=20.19.16754
+gpu_driver_lin=20.21.16886
 gpu_driver_win=27.20.100.8280
 fpga_driver_lin=2020.9.2.0
 fpga_driver_win=2020.9.2.0

--- a/sycl/test/hier_par/hier_par_basic.cpp
+++ b/sycl/test/hier_par/hier_par_basic.cpp
@@ -12,9 +12,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// The tests is failing on CPU RT 2020.10.4.0.15
-// XFAIL: cpu
-
 // This test checks hierarchical parallelism invocation APIs, but without any
 // data or code with side-effects between the work group and work item scopes.
 


### PR DESCRIPTION
 - uplift Opencl RT for Intel GPU and Intel CPU;
 - update links to binaries;
 - enable fixed tests.