### PR TITLE
[SYCL] Change event wait scope flag in Level Zero

### DIFF
--- a/sycl/plugins/level_zero/pi_level0.cpp
+++ b/sycl/plugins/level_zero/pi_level0.cpp
@@ -2177,7 +2177,7 @@ pi_result piEventCreate(pi_context Context, pi_event *RetEvent) {
   ze_event_handle_t ZeEvent;
   ze_event_desc_t ZeEventDesc = {};
   ZeEventDesc.signal = ZE_EVENT_SCOPE_FLAG_NONE;
-  ZeEventDesc.wait = ZE_EVENT_SCOPE_FLAG_NONE;
+  ZeEventDesc.wait = ZE_EVENT_SCOPE_FLAG_HOST;
   ZeEventDesc.version = ZE_EVENT_DESC_VERSION_CURRENT;
   ZeEventDesc.index = Index;
 


### PR DESCRIPTION
Set it to ZE_EVENT_SCOPE_FLAG_HOST, so cache hierarchies are
flushed in host scope.

This ensures that when host is waiting on a event with
zeEventHostSynchronize(), that changes in the event state
are correctly propagated and seen by the host.

Signed-off-by: Jaime Arteaga <jaime.a.arteaga.molina@intel.com>