### PR TITLE
[SYCL] Remove semantic check for conflicting pragma and unroll attribute

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -135,8 +135,6 @@ def illegal_type_declared_here : Note<
   "Field with illegal type declared here">;
 def err_sycl_loop_attr_duplication : Error<
   "duplicate %select{unroll|Intel FPGA}0 loop attribute '%1'">;
-def err_loop_unroll_compatibility : Error<
-  "incompatible loop unroll instructions: '%0' and '%1'">;
 def err_pipe_attribute_arg_not_allowed : Error<
   "'%0' mode for pipe attribute is not supported. Allowed modes: 'read_only', 'write_only'">;
 def err_bankbits_numbanks_conflicting : Error<

--- a/clang/test/SemaSYCL/loop_unroll.cpp
+++ b/clang/test/SemaSYCL/loop_unroll.cpp
@@ -32,11 +32,6 @@ void foo() {
   [[clang::loop_unroll(4)]]
   for (int i = 0; i < 10; ++i);
 
-  // expected-error@+2 {{incompatible loop unroll instructions: '#pragma unroll(4)' and '[[clang::loop_unroll(2)]]'}}
-#pragma unroll 4
-  [[clang::loop_unroll(2)]]
-  for (int i = 0; i < 10; ++i);
-
   // no error expected
   [[clang::loop_unroll(4)]]
   [[intelfpga::ii(2)]]


### PR DESCRIPTION
This commit resolves the issue: https://github.com/intel/llvm/issues/1893

With the changes from community for handling pragma unroll, compiler doesn't
allow to use pragma unroll and loop attributes together on the same loop.
Therefore, the redundant check for conflicting pragma unroll and unroll
attribute has been removed.

Signed-off-by: Viktoria Maksimova <viktoria.maksimova@intel.com>