### PR TITLE
[SYCL][L0] Fix memory leak in piDevicesGet()

### DIFF
--- a/sycl/plugins/level_zero/pi_level0.cpp
+++ b/sycl/plugins/level_zero/pi_level0.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include <level_zero/zet_api.h>
 
@@ -615,8 +616,8 @@ pi_result piDevicesGet(pi_platform Platform, pi_device_type DeviceType,
   }
 
   try {
-    ze_device_handle_t *ZeDevices = new ze_device_handle_t[ZeDeviceCount];
-    ZE_CALL(zeDeviceGet(ZeDriver, &ZeDeviceCount, ZeDevices));
+    std::vector<ze_device_handle_t> ZeDevices(ZeDeviceCount);
+    ZE_CALL(zeDeviceGet(ZeDriver, &ZeDeviceCount, ZeDevices.data()));
 
     for (uint32_t I = 0; I < ZeDeviceCount; ++I) {
       if (I < NumEntries) {
@@ -627,7 +628,6 @@ pi_result piDevicesGet(pi_platform Platform, pi_device_type DeviceType,
         }
       }
     }
-    delete[] ZeDevices;
   } catch (const std::bad_alloc &) {
     return PI_OUT_OF_HOST_MEMORY;
   } catch (...) {

--- a/sycl/plugins/level_zero/pi_level0.cpp
+++ b/sycl/plugins/level_zero/pi_level0.cpp
@@ -608,6 +608,12 @@ pi_result piDevicesGet(pi_platform Platform, pi_device_type DeviceType,
   if (NumDevices)
     *NumDevices = ZeDeviceCount;
 
+  if (Devices == nullptr) {
+    assert(NumEntries == 0 &&
+           "NumEntries should be zero when querying the number of devices");
+    return PI_SUCCESS;
+  }
+
   try {
     // TODO: Delete array at teardown
     ze_device_handle_t *ZeDevices = new ze_device_handle_t[ZeDeviceCount];

--- a/sycl/plugins/level_zero/pi_level0.cpp
+++ b/sycl/plugins/level_zero/pi_level0.cpp
@@ -615,7 +615,6 @@ pi_result piDevicesGet(pi_platform Platform, pi_device_type DeviceType,
   }
 
   try {
-    // TODO: Delete array at teardown
     ze_device_handle_t *ZeDevices = new ze_device_handle_t[ZeDeviceCount];
     ZE_CALL(zeDeviceGet(ZeDriver, &ZeDeviceCount, ZeDevices));
 
@@ -628,6 +627,7 @@ pi_result piDevicesGet(pi_platform Platform, pi_device_type DeviceType,
         }
       }
     }
+    delete[] ZeDevices;
   } catch (const std::bad_alloc &) {
     return PI_OUT_OF_HOST_MEMORY;
   } catch (...) {

--- a/sycl/plugins/level_zero/pi_level0.cpp
+++ b/sycl/plugins/level_zero/pi_level0.cpp
@@ -608,9 +608,9 @@ pi_result piDevicesGet(pi_platform Platform, pi_device_type DeviceType,
   if (NumDevices)
     *NumDevices = ZeDeviceCount;
 
-  if (Devices == nullptr) {
-    assert(NumEntries == 0 &&
-           "NumEntries should be zero when querying the number of devices");
+  if (NumEntries == 0) {
+    assert(Devices == nullptr &&
+           "Devices should be nullptr when querying the number of devices");
     return PI_SUCCESS;
   }
 


### PR DESCRIPTION
Exit early if 'Devices' parameter is nullptr.

Signed-off-by: Byoungro So <byoungro.so@intel.com>