### PR TITLE
[SYCL] Ensure Int-header prints CVR qualifiers for class template params

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2208,6 +2208,10 @@ static std::string getKernelNameTypeString(QualType T, ASTContext &Ctx,
     SmallString<64> Buf;
     llvm::raw_svector_ostream ArgOS(Buf);
 
+    // Print the qualifiers for the type.
+    FullyQualifiedType.getQualifiers().print(ArgOS, TypePolicy,
+                                             /*appendSpaceIfNotEmpty*/ true);
+
     // Print template class name
     TSD->printQualifiedName(ArgOS, TypePolicy, /*WithGlobalNsPrefix*/ true);
 

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -13,6 +13,7 @@
 // CHECK:template <> struct KernelInfo<::nm1::KernelName8<::nm1::nm2::C>> {
 // CHECK:template <> struct KernelInfo<::TmplClassInAnonNS<ClassInAnonNS>> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName9<char>> {
+// CHECK:template <> struct KernelInfo<::nm1::KernelName3<const volatile ::nm1::KernelName3<const volatile char>>> {
 
 // This test checks if the SYCL device compiler is able to generate correct
 // integration header when the kernel name class is expressed in different
@@ -134,6 +135,12 @@ struct MyWrapper {
 
     // Kernel name type is a templated specialization class with empty template pack argument
     kernel_single_task<nm1::KernelName9<char>>(
+        [=]() { acc.use(); });
+
+    // Ensure we print template arguments with CVR qualifiers
+    kernel_single_task<nm1::KernelName3<
+        const volatile nm1::KernelName3<
+            const volatile char>>>(
         [=]() { acc.use(); });
 
     return 0;


### PR DESCRIPTION
The integration header code seems to skip CVR qualifiers in at least
this one branch, so it makes the type unusable in the host build.  This
patch ensures that the qualifiers get printed.