### PR TITLE
[SYCL] Add global namespace specifier for Enum Values

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -295,7 +295,7 @@ public:
                                 bool WithGlobalNsPrefix = false) const;
 
   // FIXME: Remove string version.
-  std::string getQualifiedNameAsString() const;
+  std::string getQualifiedNameAsString(bool WithGlobalNsPrefix = false) const;
 
   /// Appends a human-readable name for this declaration into the given stream.
   ///

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1527,10 +1527,11 @@ void NamedDecl::printName(raw_ostream &os) const {
   os << Name;
 }
 
-std::string NamedDecl::getQualifiedNameAsString() const {
+std::string NamedDecl::getQualifiedNameAsString(bool WithGlobalNsPrefix) const {
   std::string QualName;
   llvm::raw_string_ostream OS(QualName);
-  printQualifiedName(OS, getASTContext().getPrintingPolicy());
+  printQualifiedName(OS, getASTContext().getPrintingPolicy(),
+                     WithGlobalNsPrefix);
   return OS.str();
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2138,7 +2138,9 @@ static void printArgument(ASTContext &Ctx, raw_ostream &ArgOS,
 
     if (ET) {
       const llvm::APSInt &Val = Arg.getAsIntegral();
-      ArgOS << "static_cast<" << ET->getDecl()->getQualifiedNameAsString(/*WithGlobalNsPrefix*/ true)
+      ArgOS << "static_cast<"
+            << ET->getDecl()->getQualifiedNameAsString(
+                   /*WithGlobalNsPrefix*/ true)
             << ">"
             << "(" << Val << ")";
     } else {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2138,7 +2138,7 @@ static void printArgument(ASTContext &Ctx, raw_ostream &ArgOS,
 
     if (ET) {
       const llvm::APSInt &Val = Arg.getAsIntegral();
-      ArgOS << "static_cast<" << ET->getDecl()->getQualifiedNameAsString()
+      ArgOS << "static_cast<" << ET->getDecl()->getQualifiedNameAsString(/*WithGlobalNsPrefix*/ true)
             << ">"
             << "(" << Val << ")";
     } else {

--- a/clang/test/CodeGenSYCL/kernelname-enum.cpp
+++ b/clang/test/CodeGenSYCL/kernelname-enum.cpp
@@ -197,14 +197,14 @@ int main() {
 // CHECK: template <EnumValueIn EnumValue, typename EnumTypeIn> class Baz;
 // CHECK: template <typename EnumTypeOut, template <EnumValueIn EnumValue, typename EnumTypeIn> class T> class dummy_functor_8;
 // CHECK: Specializations of KernelInfo for kernel function types:
-// CHECK: template <> struct KernelInfo<::dummy_functor_1<static_cast<no_namespace_int>(0)>>
-// CHECK: template <> struct KernelInfo<::dummy_functor_2<static_cast<no_namespace_short>(1)>>
-// CHECK: template <> struct KernelInfo<::dummy_functor_3<static_cast<internal::namespace_short>(1)>>
-// CHECK: template <> struct KernelInfo<::dummy_functor_4<static_cast<enum_in_anonNS>(1)>>
-// CHECK: template <> struct KernelInfo<::dummy_functor_5<static_cast<no_type_set>(0)>>
-// CHECK: template <> struct KernelInfo<::dummy_functor_6<static_cast<unscoped_enum>(0)>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_1<static_cast<::no_namespace_int>(0)>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_2<static_cast<::no_namespace_short>(1)>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_3<static_cast<::internal::namespace_short>(1)>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_4<static_cast<::enum_in_anonNS>(1)>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_5<static_cast<::no_type_set>(0)>>
+// CHECK: template <> struct KernelInfo<::dummy_functor_6<static_cast<::unscoped_enum>(0)>>
 // CHECK: template <> struct KernelInfo<::dummy_functor_7<::no_namespace_int>>
 // CHECK: template <> struct KernelInfo<::dummy_functor_7<::internal::namespace_short>>
-// CHECK: template <> struct KernelInfo<::T1<::T2<static_cast<type_argument_template_enum::E>(0)>>>
+// CHECK: template <> struct KernelInfo<::T1<::T2<static_cast<::type_argument_template_enum::E>(0)>>>
 // CHECK: template <> struct KernelInfo<::T1<::T3<::type_argument_template_enum::E>>>
 // CHECK: template <> struct KernelInfo<::dummy_functor_8<::EnumTypeOut, Baz>>


### PR DESCRIPTION
This patch is a follow up to commit e7020a17439. The prior commit
appends required scope resolution operator when kernel name is
templated with enum type but not enum value. This patch adds the
missing scope resolution operator when handling enum values.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>