### PR TITLE
[SYCL] Add handling for wrapped sampler

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1463,8 +1463,8 @@ public:
   }
 
   using SyclKernelFieldHandler::enterStruct;
-  using SyclKernelFieldHandler::leaveStruct;
   using SyclKernelFieldHandler::handleSyclSamplerType;
+  using SyclKernelFieldHandler::leaveStruct;
 };
 
 class SyclKernelIntHeaderCreator

--- a/sycl/test/basic_tests/sampler/sampler.cpp
+++ b/sycl/test/basic_tests/sampler/sampler.cpp
@@ -22,6 +22,15 @@ namespace sycl {
 using namespace cl::sycl;
 }
 
+struct SamplerWrapper {
+  SamplerWrapper(sycl::coordinate_normalization_mode Norm,
+                  sycl::addressing_mode Addr, sycl::filtering_mode Filter)
+      : Smpl(Norm, Addr, Filter), A(0) {}
+
+  sycl::sampler Smpl;
+  int A;
+};
+
 int main() {
   // Check constructor from enums
   sycl::sampler A(sycl::coordinate_normalization_mode::unnormalized,
@@ -88,6 +97,10 @@ int main() {
   assert(C == A);
   assert(Hasher(C) != Hasher(B));
 
+  SamplerWrapper WrappedSmplr(
+      sycl::coordinate_normalization_mode::normalized,
+      sycl::addressing_mode::repeat, sycl::filtering_mode::linear);
+
   // Device sampler.
   {
     sycl::queue Queue;
@@ -95,6 +108,7 @@ int main() {
       cgh.single_task<class kernel>([=]() {
         sycl::sampler C = A;
         sycl::sampler D(C);
+        sycl::sampler E(WrappedSmplr.Smpl);
       });
     });
   }

--- a/sycl/test/basic_tests/sampler/sampler.cpp
+++ b/sycl/test/basic_tests/sampler/sampler.cpp
@@ -24,7 +24,7 @@ using namespace cl::sycl;
 
 struct SamplerWrapper {
   SamplerWrapper(sycl::coordinate_normalization_mode Norm,
-                  sycl::addressing_mode Addr, sycl::filtering_mode Filter)
+                 sycl::addressing_mode Addr, sycl::filtering_mode Filter)
       : Smpl(Norm, Addr, Filter), A(0) {}
 
   sycl::sampler Smpl;


### PR DESCRIPTION
This adds proper initialization for sampler object that is wrapped by a
struct. This is temporary change because it contradicts the OpenCL and
SPIR-V spec, since the struct with sampler opaque type field appears as
kernel argument. We need it now to fix crashes in OpenCL backends.