### PR TITLE
[SYCL] get_access and get_host access enabling

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -1234,22 +1234,22 @@ accessor(buffer<DataT, Dimensions, AllocatorT>, Type1)
                detail::deduceAccessTarget<Type1, Type1>(target::global_buffer),
                access::placeholder::true_t>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          typename Type1, typename Type2>
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2>
 accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2)
     ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type2>(),
                detail::deduceAccessTarget<Type1, Type2>(target::global_buffer),
                access::placeholder::true_t>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          typename Type1, typename Type2, typename Type3>
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2, typename Type3>
 accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3)
     ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type2, Type3>(),
                detail::deduceAccessTarget<Type2, Type3>(target::global_buffer),
                access::placeholder::true_t>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          typename Type1, typename Type2, typename Type3, typename Type4>
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2, typename Type3, typename Type4>
 accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4)
     ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type3, Type4>(),
                detail::deduceAccessTarget<Type3, Type4>(target::global_buffer),
@@ -1266,22 +1266,22 @@ accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Type1)
                detail::deduceAccessTarget<Type1, Type1>(target::global_buffer),
                access::placeholder::false_t>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          typename Type1, typename Type2>
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2>
 accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Type1, Type2)
     ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type2>(),
                detail::deduceAccessTarget<Type1, Type2>(target::global_buffer),
                access::placeholder::false_t>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          typename Type1, typename Type2, typename Type3>
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2, typename Type3>
 accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Type1, Type2, Type3)
     ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type2, Type3>(),
                detail::deduceAccessTarget<Type2, Type3>(target::global_buffer),
                access::placeholder::false_t>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          typename Type1, typename Type2, typename Type3, typename Type4>
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2, typename Type3, typename Type4>
 accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Type1, Type2, Type3,
          Type4)
     ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type3, Type4>(),
@@ -1685,41 +1685,32 @@ public:
 
 #if __cplusplus > 201402L
 
-/*
-template <typename DataT, int Dimensions, typename AllocatorT, typename... Ts>
-host_accessor(buffer<DataT, Dimensions, AllocatorT>, Ts...)
-    ->host_accessor<DataT, Dimensions, access::mode::read_write>;
-
-template <typename DataT, int Dimensions, typename AllocatorT,
-          access_mode AccessMode, typename PropertyList = property_list,
-          typename... Ts>
-host_accessor(buffer<DataT, Dimensions, AllocatorT>, Ts...,
-              mode_tag_t<AccessMode>, PropertyList = {})
-    ->host_accessor<DataT, Dimensions, AccessMode>;
-*/
-
 template <typename DataT, int Dimensions, typename AllocatorT>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>)
     ->host_accessor<DataT, Dimensions, access::mode::read_write>;
 
 template <typename DataT, int Dimensions, typename AllocatorT, typename Type1>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1)
-    ->host_accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type1>()>;
+    ->host_accessor<DataT, Dimensions,
+                    detail::deduceAccessMode<Type1, Type1>()>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          typename Type1, typename Type2>
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2)
-    ->host_accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type2>()>;
+    ->host_accessor<DataT, Dimensions,
+                    detail::deduceAccessMode<Type1, Type2>()>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          typename Type1, typename Type2, typename Type3>
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2, typename Type3>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3)
-    ->host_accessor<DataT, Dimensions, detail::deduceAccessMode<Type2, Type3>()>;
+    ->host_accessor<DataT, Dimensions,
+                    detail::deduceAccessMode<Type2, Type3>()>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          typename Type1, typename Type2, typename Type3, typename Type4>
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2, typename Type3, typename Type4>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4)
-    ->host_accessor<DataT, Dimensions, detail::deduceAccessMode<Type3, Type4>()>;
+    ->host_accessor<DataT, Dimensions,
+                    detail::deduceAccessMode<Type3, Type4>()>;
 
 #endif
 

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -1223,42 +1223,69 @@ public:
 
 #if __cplusplus > 201402L
 
-template <typename DataT, int Dimensions, typename AllocatorT, typename... Ts>
-accessor(buffer<DataT, Dimensions, AllocatorT>, Ts...)
+template <typename DataT, int Dimensions, typename AllocatorT>
+accessor(buffer<DataT, Dimensions, AllocatorT>)
     ->accessor<DataT, Dimensions, access::mode::read_write,
                target::global_buffer, access::placeholder::true_t>;
 
-template <typename DataT, int Dimensions, typename AllocatorT, typename... Ts>
-accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Ts...)
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1>
+accessor(buffer<DataT, Dimensions, AllocatorT>, Type1)
+    ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type1>(),
+               detail::deduceAccessTarget<Type1, Type1>(target::global_buffer),
+               access::placeholder::true_t>;
+
+template <typename DataT, int Dimensions, typename AllocatorT,
+          typename Type1, typename Type2>
+accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2)
+    ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type2>(),
+               detail::deduceAccessTarget<Type1, Type2>(target::global_buffer),
+               access::placeholder::true_t>;
+
+template <typename DataT, int Dimensions, typename AllocatorT,
+          typename Type1, typename Type2, typename Type3>
+accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3)
+    ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type2, Type3>(),
+               detail::deduceAccessTarget<Type2, Type3>(target::global_buffer),
+               access::placeholder::true_t>;
+
+template <typename DataT, int Dimensions, typename AllocatorT,
+          typename Type1, typename Type2, typename Type3, typename Type4>
+accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4)
+    ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type3, Type4>(),
+               detail::deduceAccessTarget<Type3, Type4>(target::global_buffer),
+               access::placeholder::true_t>;
+
+template <typename DataT, int Dimensions, typename AllocatorT>
+accessor(buffer<DataT, Dimensions, AllocatorT>, handler)
     ->accessor<DataT, Dimensions, access::mode::read_write,
                target::global_buffer, access::placeholder::false_t>;
 
-template <typename DataT, int Dimensions, typename AllocatorT,
-          access_mode AccessMode, typename... Ts>
-accessor(buffer<DataT, Dimensions, AllocatorT>, Ts..., mode_tag_t<AccessMode>,
-         property_list = {})
-    ->accessor<DataT, Dimensions, AccessMode, target::global_buffer,
-               access::placeholder::true_t>;
-
-template <typename DataT, int Dimensions, typename AllocatorT,
-          access_mode AccessMode, typename... Ts>
-accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Ts...,
-         mode_tag_t<AccessMode>, property_list = {})
-    ->accessor<DataT, Dimensions, AccessMode, target::global_buffer,
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1>
+accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Type1)
+    ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type1>(),
+               detail::deduceAccessTarget<Type1, Type1>(target::global_buffer),
                access::placeholder::false_t>;
 
 template <typename DataT, int Dimensions, typename AllocatorT,
-          access_mode AccessMode, target AccessTarget, typename... Ts>
-accessor(buffer<DataT, Dimensions, AllocatorT>, Ts...,
-         mode_target_tag_t<AccessMode, AccessTarget>, property_list = {})
-    ->accessor<DataT, Dimensions, AccessMode, AccessTarget,
-               access::placeholder::true_t>;
+          typename Type1, typename Type2>
+accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Type1, Type2)
+    ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type2>(),
+               detail::deduceAccessTarget<Type1, Type2>(target::global_buffer),
+               access::placeholder::false_t>;
 
 template <typename DataT, int Dimensions, typename AllocatorT,
-          access_mode AccessMode, target AccessTarget, typename... Ts>
-accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Ts...,
-         mode_target_tag_t<AccessMode, AccessTarget>, property_list = {})
-    ->accessor<DataT, Dimensions, AccessMode, AccessTarget,
+          typename Type1, typename Type2, typename Type3>
+accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Type1, Type2, Type3)
+    ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type2, Type3>(),
+               detail::deduceAccessTarget<Type2, Type3>(target::global_buffer),
+               access::placeholder::false_t>;
+
+template <typename DataT, int Dimensions, typename AllocatorT,
+          typename Type1, typename Type2, typename Type3, typename Type4>
+accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Type1, Type2, Type3,
+         Type4)
+    ->accessor<DataT, Dimensions, detail::deduceAccessMode<Type3, Type4>(),
+               detail::deduceAccessTarget<Type3, Type4>(target::global_buffer),
                access::placeholder::false_t>;
 
 #endif
@@ -1658,15 +1685,41 @@ public:
 
 #if __cplusplus > 201402L
 
+/*
 template <typename DataT, int Dimensions, typename AllocatorT, typename... Ts>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>, Ts...)
     ->host_accessor<DataT, Dimensions, access::mode::read_write>;
 
 template <typename DataT, int Dimensions, typename AllocatorT,
-          access_mode AccessMode, typename... Ts>
+          access_mode AccessMode, typename PropertyList = property_list,
+          typename... Ts>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>, Ts...,
-              mode_tag_t<AccessMode>, property_list = {})
+              mode_tag_t<AccessMode>, PropertyList = {})
     ->host_accessor<DataT, Dimensions, AccessMode>;
+*/
+
+template <typename DataT, int Dimensions, typename AllocatorT>
+host_accessor(buffer<DataT, Dimensions, AllocatorT>)
+    ->host_accessor<DataT, Dimensions, access::mode::read_write>;
+
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1>
+host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1)
+    ->host_accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type1>()>;
+
+template <typename DataT, int Dimensions, typename AllocatorT,
+          typename Type1, typename Type2>
+host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2)
+    ->host_accessor<DataT, Dimensions, detail::deduceAccessMode<Type1, Type2>()>;
+
+template <typename DataT, int Dimensions, typename AllocatorT,
+          typename Type1, typename Type2, typename Type3>
+host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3)
+    ->host_accessor<DataT, Dimensions, detail::deduceAccessMode<Type2, Type3>()>;
+
+template <typename DataT, int Dimensions, typename AllocatorT,
+          typename Type1, typename Type2, typename Type3, typename Type4>
+host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4)
+    ->host_accessor<DataT, Dimensions, detail::deduceAccessMode<Type3, Type4>()>;
 
 #endif
 

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -277,6 +277,25 @@ public:
                                                   accessOffset);
   }
 
+#if __cplusplus > 201402L
+
+  template<typename... Ts>
+  auto get_access(Ts... args) {
+    return accessor{*this, args...};
+  }
+
+  template<typename... Ts>
+  auto get_access(handler &commandGroupHandler, Ts... args) {
+    return accessor{*this, commandGroupHandler, args...};
+  }
+
+  template<typename... Ts>
+  auto get_host_access(Ts... args) {
+    return host_accessor{*this, args...};
+  }
+
+#endif
+
   template <typename Destination = std::nullptr_t>
   void set_final_data(Destination finalData = nullptr) {
     impl->set_final_data(finalData);

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -279,18 +279,16 @@ public:
 
 #if __cplusplus > 201402L
 
-  template<typename... Ts>
-  auto get_access(Ts... args) {
+  template <typename... Ts> auto get_access(Ts... args) {
     return accessor{*this, args...};
   }
 
-  template<typename... Ts>
+  template <typename... Ts>
   auto get_access(handler &commandGroupHandler, Ts... args) {
     return accessor{*this, commandGroupHandler, args...};
   }
 
-  template<typename... Ts>
-  auto get_host_access(Ts... args) {
+  template <typename... Ts> auto get_host_access(Ts... args) {
     return host_accessor{*this, args...};
   }
 

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -223,8 +223,7 @@ constexpr access::target deduceAccessTarget(access::target defaultTarget) {
                    mode_target_tag_t<access::mode::read,
                                      access::target::constant_buffer>>::value) {
     return access::target::constant_buffer;
-  }
-  else {
+  } else {
     return defaultTarget;
   }
 }

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -195,12 +195,16 @@ constexpr access::mode deduceAccessMode() {
                 std::is_same<MayBeTag2,
                              mode_tag_t<access::mode::read>>::value) {
     return access::mode::read;
-  } else if constexpr (std::is_same<MayBeTag1,
-                                    mode_tag_t<access::mode::write>>::value ||
-                       std::is_same<MayBeTag2,
-                                    mode_tag_t<access::mode::write>>::value) {
+  }
+
+  if constexpr (std::is_same<MayBeTag1,
+                             mode_tag_t<access::mode::write>>::value ||
+                std::is_same<MayBeTag2,
+                             mode_tag_t<access::mode::write>>::value) {
     return access::mode::write;
-  } else if constexpr (
+  }
+
+  if constexpr (
       std::is_same<MayBeTag1,
                    mode_target_tag_t<access::mode::read,
                                      access::target::constant_buffer>>::value ||
@@ -208,9 +212,9 @@ constexpr access::mode deduceAccessMode() {
                    mode_target_tag_t<access::mode::read,
                                      access::target::constant_buffer>>::value) {
     return access::mode::read;
-  } else {
-    return access::mode::read_write;
   }
+
+  return access::mode::read_write;
 }
 
 template <typename MayBeTag1, typename MayBeTag2>
@@ -223,9 +227,9 @@ constexpr access::target deduceAccessTarget(access::target defaultTarget) {
                    mode_target_tag_t<access::mode::read,
                                      access::target::constant_buffer>>::value) {
     return access::target::constant_buffer;
-  } else {
-    return defaultTarget;
   }
+
+  return defaultTarget;
 }
 
 #endif

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -190,27 +190,38 @@ constexpr access::mode deduceAccessMode() {
   // property_list = {} is not properly detected by deduction guide,
   // when parameter is passed without curly braces: access(buffer, noinit)
   // thus simplest approach is to check 2 last arguments for being a tag
-  if constexpr ( std::is_same<MayBeTag1, mode_tag_t<access::mode::read>>::value ||
-                 std::is_same<MayBeTag2, mode_tag_t<access::mode::read>>::value ) {
+  if constexpr (std::is_same<MayBeTag1,
+                             mode_tag_t<access::mode::read>>::value ||
+                std::is_same<MayBeTag2,
+                             mode_tag_t<access::mode::read>>::value) {
     return access::mode::read;
-  }
-  else if constexpr ( std::is_same<MayBeTag1, mode_tag_t<access::mode::write>>::value ||
-                      std::is_same<MayBeTag2, mode_tag_t<access::mode::write>>::value ) {
+  } else if constexpr (std::is_same<MayBeTag1,
+                                    mode_tag_t<access::mode::write>>::value ||
+                       std::is_same<MayBeTag2,
+                                    mode_tag_t<access::mode::write>>::value) {
     return access::mode::write;
-  }
-  else if constexpr ( std::is_same<MayBeTag1, mode_target_tag_t<access::mode::read, access::target::constant_buffer>>::value ||
-                      std::is_same<MayBeTag2, mode_target_tag_t<access::mode::read, access::target::constant_buffer>>::value ) {
+  } else if constexpr (
+      std::is_same<MayBeTag1,
+                   mode_target_tag_t<access::mode::read,
+                                     access::target::constant_buffer>>::value ||
+      std::is_same<MayBeTag2,
+                   mode_target_tag_t<access::mode::read,
+                                     access::target::constant_buffer>>::value) {
     return access::mode::read;
-  }
-  else {
+  } else {
     return access::mode::read_write;
   }
 }
 
 template <typename MayBeTag1, typename MayBeTag2>
 constexpr access::target deduceAccessTarget(access::target defaultTarget) {
-  if constexpr ( std::is_same<MayBeTag1, mode_target_tag_t<access::mode::read, access::target::constant_buffer>>::value ||
-                 std::is_same<MayBeTag2, mode_target_tag_t<access::mode::read, access::target::constant_buffer>>::value) {
+  if constexpr (
+      std::is_same<MayBeTag1,
+                   mode_target_tag_t<access::mode::read,
+                                     access::target::constant_buffer>>::value ||
+      std::is_same<MayBeTag2,
+                   mode_target_tag_t<access::mode::read,
+                                     access::target::constant_buffer>>::value) {
     return access::target::constant_buffer;
   }
   else {

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -31,6 +31,8 @@ template <typename DataT, int Dimensions, access::mode AccessMode,
 class accessor;
 template <typename T, int Dimensions, typename AllocatorT, typename Enable>
 class buffer;
+template <typename DataT, int Dimensions, access::mode AccessMode>
+class host_accessor;
 
 using buffer_allocator = detail::sycl_memory_object_allocator;
 

--- a/sycl/test/basic_tests/accessor/Inputs/device_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/Inputs/device_accessor.cpp
@@ -8,10 +8,6 @@
 #include <CL/sycl.hpp>
 #include <cassert>
 
-namespace sycl {
-using namespace cl::sycl;
-}
-
 int main() {
   // Non-placeholder accessors.
   {

--- a/sycl/test/basic_tests/accessor/Inputs/device_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/Inputs/device_accessor.cpp
@@ -1,4 +1,4 @@
-//==----------------accessor.cpp - SYCL accessor basic test ----------------==//
+//==---------- device_accessor.cpp - SYCL accessor basic test --------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/test/basic_tests/accessor/Inputs/device_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/Inputs/device_accessor.cpp
@@ -1,0 +1,321 @@
+//==----------------accessor.cpp - SYCL accessor basic test ----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+#include <cassert>
+
+namespace sycl {
+using namespace cl::sycl;
+}
+
+int main() {
+  // Non-placeholder accessors.
+  {
+    int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
+                                 {cl::sycl::property::buffer::use_host_ptr()});
+
+    sycl::queue Queue;
+
+    Queue.submit([&](sycl::handler &cgh) {
+
+#if defined(accessor_new_api_test)
+      sycl::accessor acc_1(buf_data, cgh);
+      sycl::accessor acc_2(buf_data, cgh, sycl::range<1>(8));
+      sycl::accessor acc_3(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1));
+      sycl::accessor acc_4(buf_data, cgh, sycl::read_only);
+      sycl::accessor acc_5(buf_data, cgh, sycl::range<1>(8), sycl::read_only);
+      sycl::accessor acc_6(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
+                           sycl::read_only);
+      sycl::accessor acc_7(buf_data, cgh, sycl::write_only);
+      sycl::accessor acc_8(buf_data, cgh, sycl::range<1>(8), sycl::write_only);
+      sycl::accessor acc_9(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
+                           sycl::write_only);
+#elif defined(buffer_new_api_test)
+      auto acc_1 = buf_data.get_access(cgh);
+      auto acc_2 = buf_data.get_access(cgh, sycl::range<1>(8));
+      auto acc_3 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::id<1>(1));
+      auto acc_4 = buf_data.get_access(cgh, sycl::read_only);
+      auto acc_5 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::read_only);
+      auto acc_6 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                       sycl::read_only);
+      auto acc_7 = buf_data.get_access(cgh, sycl::write_only);
+      auto acc_8 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::write_only);
+      auto acc_9 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                       sycl::write_only);
+#endif
+
+      assert(!acc_1.is_placeholder());
+      assert(!acc_2.is_placeholder());
+      assert(!acc_3.is_placeholder());
+      assert(!acc_4.is_placeholder());
+      assert(!acc_5.is_placeholder());
+      assert(!acc_6.is_placeholder());
+      assert(!acc_7.is_placeholder());
+      assert(!acc_8.is_placeholder());
+      assert(!acc_9.is_placeholder());
+
+      cgh.single_task<class nonplaceholder_kernel>(
+          [=]() {
+        acc_7[6] = acc_1[0];
+        acc_8[7] = acc_2[1];
+        acc_9[7] = acc_3[1];
+        acc_1[0] = acc_4[3];
+        acc_2[1] = acc_5[4];
+        acc_3[1] = acc_6[4];
+      });
+    });
+    Queue.wait();
+
+#if defined(accessor_new_api_test)
+    sycl::host_accessor host_acc(buf_data, sycl::read_only);
+#elif defined(buffer_new_api_test)
+    auto host_acc = buf_data.get_host_access(sycl::read_only);
+#endif
+    assert(host_acc[0] == 4 && host_acc[1] == 5 && host_acc[2] == 6);
+    assert(host_acc[3] == 4 && host_acc[4] == 5 && host_acc[5] == 6);
+    assert(host_acc[6] == 1 && host_acc[7] == 2 && host_acc[8] == 3);
+  }
+
+  // Placeholder accessors.
+  {
+    int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
+                                 {cl::sycl::property::buffer::use_host_ptr()});
+
+#if defined(accessor_new_api_test)
+    sycl::accessor acc_1(buf_data);
+    sycl::accessor acc_2(buf_data, sycl::range<1>(8));
+    sycl::accessor acc_3(buf_data, sycl::range<1>(8), sycl::id<1>(1));
+    sycl::accessor acc_4(buf_data, sycl::read_only);
+    sycl::accessor acc_5(buf_data, sycl::range<1>(8), sycl::read_only);
+    sycl::accessor acc_6(buf_data, sycl::range<1>(8), sycl::id<1>(1),
+                         sycl::read_only);
+    sycl::accessor acc_7(buf_data, sycl::write_only);
+    sycl::accessor acc_8(buf_data, sycl::range<1>(8), sycl::write_only);
+    sycl::accessor acc_9(buf_data, sycl::range<1>(8), sycl::id<1>(1),
+                         sycl::write_only);
+#elif defined(buffer_new_api_test)
+    auto acc_1 = buf_data.get_access();
+    auto acc_2 = buf_data.get_access(sycl::range<1>(8));
+    auto acc_3 = buf_data.get_access(sycl::range<1>(8), sycl::id<1>(1));
+    auto acc_4 = buf_data.get_access(sycl::read_only);
+    auto acc_5 = buf_data.get_access(sycl::range<1>(8), sycl::read_only);
+    auto acc_6 = buf_data.get_access(sycl::range<1>(8), sycl::id<1>(1),
+                                     sycl::read_only);
+    auto acc_7 = buf_data.get_access(sycl::write_only);
+    auto acc_8 = buf_data.get_access(sycl::range<1>(8), sycl::write_only);
+    auto acc_9 = buf_data.get_access(sycl::range<1>(8), sycl::id<1>(1),
+                                     sycl::write_only);
+#endif
+
+    assert(acc_1.is_placeholder());
+    assert(acc_2.is_placeholder());
+    assert(acc_3.is_placeholder());
+    assert(acc_4.is_placeholder());
+    assert(acc_5.is_placeholder());
+    assert(acc_6.is_placeholder());
+    assert(acc_7.is_placeholder());
+    assert(acc_8.is_placeholder());
+    assert(acc_9.is_placeholder());
+
+    sycl::queue Queue;
+
+    Queue.submit([&](sycl::handler &cgh) {
+
+      cgh.require(acc_1);
+      cgh.require(acc_2);
+      cgh.require(acc_3);
+      cgh.require(acc_4);
+      cgh.require(acc_5);
+      cgh.require(acc_6);
+      cgh.require(acc_7);
+      cgh.require(acc_8);
+      cgh.require(acc_9);
+
+      cgh.single_task<class placeholder_kernel>(
+          [=]() {
+        acc_7[6] = acc_1[0];
+        acc_8[7] = acc_2[1];
+        acc_9[7] = acc_3[1];
+        acc_1[0] = acc_4[3];
+        acc_2[1] = acc_5[4];
+        acc_3[1] = acc_6[4];
+      });
+    });
+    Queue.wait();
+
+#if defined(accessor_new_api_test)
+    sycl::host_accessor host_acc(buf_data, sycl::read_only);
+#elif defined(buffer_new_api_test)
+    auto host_acc = buf_data.get_host_access(sycl::read_only);
+#endif
+    assert(host_acc[0] == 4 && host_acc[1] == 5 && host_acc[2] == 6);
+    assert(host_acc[3] == 4 && host_acc[4] == 5 && host_acc[5] == 6);
+    assert(host_acc[6] == 1 && host_acc[7] == 2 && host_acc[8] == 3);
+  }
+
+  // Non-placeholder noinit and constant_buffer accessors.
+  {
+    int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
+                                 {cl::sycl::property::buffer::use_host_ptr()});
+
+    sycl::queue Queue;
+
+    Queue.submit([&](sycl::handler &cgh) {
+
+#if defined(accessor_new_api_test)
+      sycl::accessor acc_1(buf_data, cgh, sycl::noinit);
+      sycl::accessor acc_2(buf_data, cgh, sycl::range<1>(8), sycl::noinit);
+      sycl::accessor acc_3(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
+                           sycl::noinit);
+      sycl::accessor acc_4(buf_data, cgh, sycl::read_constant);
+      sycl::accessor acc_5(buf_data, cgh, sycl::range<1>(8),
+                           sycl::read_constant);
+      sycl::accessor acc_6(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
+                           sycl::read_constant);
+      sycl::accessor acc_7(buf_data, cgh, sycl::write_only, sycl::noinit);
+      sycl::accessor acc_8(buf_data, cgh, sycl::range<1>(8), sycl::write_only,
+                           sycl::noinit);
+      sycl::accessor acc_9(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
+                           sycl::write_only, sycl::noinit);
+#elif defined(buffer_new_api_test)
+      auto acc_1 = buf_data.get_access(cgh, sycl::noinit);
+      auto acc_2 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::noinit);
+      auto acc_3 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                       sycl::noinit);
+      auto acc_4 = buf_data.get_access(cgh, sycl::read_constant);
+      auto acc_5 = buf_data.get_access(cgh, sycl::range<1>(8),
+                                       sycl::read_constant);
+      auto acc_6 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                       sycl::read_constant);
+      auto acc_7 = buf_data.get_access(cgh, sycl::write_only, sycl::noinit);
+      auto acc_8 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::write_only,
+                                       sycl::noinit);
+      auto acc_9 = buf_data.get_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                       sycl::write_only, sycl::noinit);
+#endif
+
+      assert(!acc_1.is_placeholder());
+      assert(!acc_2.is_placeholder());
+      assert(!acc_3.is_placeholder());
+      assert(!acc_4.is_placeholder());
+      assert(!acc_5.is_placeholder());
+      assert(!acc_6.is_placeholder());
+      assert(!acc_7.is_placeholder());
+      assert(!acc_8.is_placeholder());
+      assert(!acc_9.is_placeholder());
+
+      cgh.single_task<class nonplaceholder_noinit_kernel>(
+          [=]() {
+        acc_7[6] = 1;
+        acc_8[7] = 2;
+        acc_9[7] = 3;
+        acc_1[0] = acc_4[3];
+        acc_2[1] = acc_5[4];
+        acc_3[1] = acc_6[4];
+      });
+    });
+    Queue.wait();
+
+#if defined(accessor_new_api_test)
+    sycl::host_accessor host_acc(buf_data, sycl::read_only);
+#elif defined(buffer_new_api_test)
+    auto host_acc = buf_data.get_host_access(sycl::read_only);
+#endif
+    assert(host_acc[0] == 4 && host_acc[1] == 5 && host_acc[2] == 6);
+    assert(host_acc[3] == 4 && host_acc[4] == 5 && host_acc[5] == 6);
+    assert(host_acc[6] == 1 && host_acc[7] == 2 && host_acc[8] == 3);
+  }
+
+  // Placeholder noinit and constant_buffer accessors.
+  {
+    int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
+                                 {cl::sycl::property::buffer::use_host_ptr()});
+
+#if defined(accessor_new_api_test)
+    sycl::accessor acc_1(buf_data, sycl::noinit);
+    sycl::accessor acc_2(buf_data, sycl::range<1>(8), sycl::noinit);
+    sycl::accessor acc_3(buf_data, sycl::range<1>(8), sycl::id<1>(1),
+                         sycl::noinit);
+    sycl::accessor acc_4(buf_data, sycl::read_constant);
+    sycl::accessor acc_5(buf_data, sycl::range<1>(8), sycl::read_constant);
+    sycl::accessor acc_6(buf_data, sycl::range<1>(8), sycl::id<1>(1),
+                         sycl::read_constant);
+    sycl::accessor acc_7(buf_data, sycl::write_only, sycl::noinit);
+    sycl::accessor acc_8(buf_data, sycl::range<1>(8), sycl::write_only,
+                         sycl::noinit);
+    sycl::accessor acc_9(buf_data, sycl::range<1>(8), sycl::id<1>(1),
+                         sycl::write_only, sycl::noinit);
+#elif defined(buffer_new_api_test)
+    auto acc_1 = buf_data.get_access(sycl::noinit);
+    auto acc_2 = buf_data.get_access(sycl::range<1>(8), sycl::noinit);
+    auto acc_3 = buf_data.get_access(sycl::range<1>(8), sycl::id<1>(1),
+                                     sycl::noinit);
+    auto acc_4 = buf_data.get_access(sycl::read_constant);
+    auto acc_5 = buf_data.get_access(sycl::range<1>(8), sycl::read_constant);
+    auto acc_6 = buf_data.get_access(sycl::range<1>(8), sycl::id<1>(1),
+                                     sycl::read_constant);
+    auto acc_7 = buf_data.get_access(sycl::write_only, sycl::noinit);
+    auto acc_8 = buf_data.get_access(sycl::range<1>(8), sycl::write_only,
+                                     sycl::noinit);
+    auto acc_9 = buf_data.get_access(sycl::range<1>(8), sycl::id<1>(1),
+                                     sycl::write_only, sycl::noinit);
+#endif
+
+    assert(acc_1.is_placeholder());
+    assert(acc_2.is_placeholder());
+    assert(acc_3.is_placeholder());
+    assert(acc_4.is_placeholder());
+    assert(acc_5.is_placeholder());
+    assert(acc_6.is_placeholder());
+    assert(acc_7.is_placeholder());
+    assert(acc_8.is_placeholder());
+    assert(acc_9.is_placeholder());
+
+    sycl::queue Queue;
+
+    Queue.submit([&](sycl::handler &cgh) {
+
+      cgh.require(acc_1);
+      cgh.require(acc_2);
+      cgh.require(acc_3);
+      cgh.require(acc_4);
+      cgh.require(acc_5);
+      cgh.require(acc_6);
+      cgh.require(acc_7);
+      cgh.require(acc_8);
+      cgh.require(acc_9);
+
+      cgh.single_task<class placeholder_noinit_kernel>(
+          [=]() {
+        acc_7[6] = 1;
+        acc_8[7] = 2;
+        acc_9[7] = 3;
+        acc_1[0] = acc_4[3];
+        acc_2[1] = acc_5[4];
+        acc_3[1] = acc_6[4];
+      });
+    });
+    Queue.wait();
+
+#if defined(accessor_new_api_test)
+    sycl::host_accessor host_acc(buf_data, sycl::read_only);
+#elif defined(buffer_new_api_test)
+    auto host_acc = buf_data.get_host_access(sycl::read_only);
+#endif
+    assert(host_acc[0] == 4 && host_acc[1] == 5 && host_acc[2] == 6);
+    assert(host_acc[3] == 4 && host_acc[4] == 5 && host_acc[5] == 6);
+    assert(host_acc[6] == 1 && host_acc[7] == 2 && host_acc[8] == 3);
+  }
+}

--- a/sycl/test/basic_tests/accessor/Inputs/device_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/Inputs/device_accessor.cpp
@@ -18,7 +18,7 @@ int main() {
     int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
-                                 {cl::sycl::property::buffer::use_host_ptr()});
+                                  {cl::sycl::property::buffer::use_host_ptr()});
 
     sycl::queue Queue;
 
@@ -62,13 +62,13 @@ int main() {
 
       cgh.single_task<class nonplaceholder_kernel>(
           [=]() {
-        acc_7[6] = acc_1[0];
-        acc_8[7] = acc_2[1];
-        acc_9[7] = acc_3[1];
-        acc_1[0] = acc_4[3];
-        acc_2[1] = acc_5[4];
-        acc_3[1] = acc_6[4];
-      });
+            acc_7[6] = acc_1[0];
+            acc_8[7] = acc_2[1];
+            acc_9[7] = acc_3[1];
+            acc_1[0] = acc_4[3];
+            acc_2[1] = acc_5[4];
+            acc_3[1] = acc_6[4];
+          });
     });
     Queue.wait();
 
@@ -87,7 +87,7 @@ int main() {
     int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
-                                 {cl::sycl::property::buffer::use_host_ptr()});
+                                  {cl::sycl::property::buffer::use_host_ptr()});
 
 #if defined(accessor_new_api_test)
     sycl::accessor acc_1(buf_data);
@@ -128,7 +128,6 @@ int main() {
     sycl::queue Queue;
 
     Queue.submit([&](sycl::handler &cgh) {
-
       cgh.require(acc_1);
       cgh.require(acc_2);
       cgh.require(acc_3);
@@ -141,13 +140,13 @@ int main() {
 
       cgh.single_task<class placeholder_kernel>(
           [=]() {
-        acc_7[6] = acc_1[0];
-        acc_8[7] = acc_2[1];
-        acc_9[7] = acc_3[1];
-        acc_1[0] = acc_4[3];
-        acc_2[1] = acc_5[4];
-        acc_3[1] = acc_6[4];
-      });
+            acc_7[6] = acc_1[0];
+            acc_8[7] = acc_2[1];
+            acc_9[7] = acc_3[1];
+            acc_1[0] = acc_4[3];
+            acc_2[1] = acc_5[4];
+            acc_3[1] = acc_6[4];
+          });
     });
     Queue.wait();
 
@@ -166,7 +165,7 @@ int main() {
     int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
-                                 {cl::sycl::property::buffer::use_host_ptr()});
+                                  {cl::sycl::property::buffer::use_host_ptr()});
 
     sycl::queue Queue;
 
@@ -216,13 +215,13 @@ int main() {
 
       cgh.single_task<class nonplaceholder_noinit_kernel>(
           [=]() {
-        acc_7[6] = 1;
-        acc_8[7] = 2;
-        acc_9[7] = 3;
-        acc_1[0] = acc_4[3];
-        acc_2[1] = acc_5[4];
-        acc_3[1] = acc_6[4];
-      });
+            acc_7[6] = 1;
+            acc_8[7] = 2;
+            acc_9[7] = 3;
+            acc_1[0] = acc_4[3];
+            acc_2[1] = acc_5[4];
+            acc_3[1] = acc_6[4];
+          });
     });
     Queue.wait();
 
@@ -241,7 +240,7 @@ int main() {
     int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
-                                 {cl::sycl::property::buffer::use_host_ptr()});
+                                  {cl::sycl::property::buffer::use_host_ptr()});
 
 #if defined(accessor_new_api_test)
     sycl::accessor acc_1(buf_data, sycl::noinit);
@@ -286,7 +285,6 @@ int main() {
     sycl::queue Queue;
 
     Queue.submit([&](sycl::handler &cgh) {
-
       cgh.require(acc_1);
       cgh.require(acc_2);
       cgh.require(acc_3);
@@ -299,13 +297,13 @@ int main() {
 
       cgh.single_task<class placeholder_noinit_kernel>(
           [=]() {
-        acc_7[6] = 1;
-        acc_8[7] = 2;
-        acc_9[7] = 3;
-        acc_1[0] = acc_4[3];
-        acc_2[1] = acc_5[4];
-        acc_3[1] = acc_6[4];
-      });
+            acc_7[6] = 1;
+            acc_8[7] = 2;
+            acc_9[7] = 3;
+            acc_1[0] = acc_4[3];
+            acc_2[1] = acc_5[4];
+            acc_3[1] = acc_6[4];
+          });
     });
     Queue.wait();
 

--- a/sycl/test/basic_tests/accessor/Inputs/host_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/Inputs/host_accessor.cpp
@@ -1,0 +1,141 @@
+//==----------------host_accessor.cpp - SYCL accessor basic test -----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+#include <cassert>
+
+namespace sycl {
+using namespace cl::sycl;
+}
+
+int main() {
+  {
+    int data[3] = {3, 7, 9};
+
+    sycl::buffer<int, 1> buf_data(data, sycl::range<1>(3),
+                                 {cl::sycl::property::buffer::use_host_ptr()});
+
+    {
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc(buf_data);
+#elif defined(buffer_new_api_test)
+      auto acc = buf_data.get_host_access();
+#endif
+
+      assert(acc.get_count() == 3);
+      assert(acc.get_range() == sycl::range<1>(3));
+      assert(acc[0] == 3);
+
+      acc[0] = 2;
+
+      assert(data[0] == 2 && data[1] == 7 && data[2] == 9);
+    }
+    {
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc(buf_data, sycl::read_only);
+#elif defined(buffer_new_api_test)
+      auto acc = buf_data.get_host_access(sycl::read_only);
+#endif
+
+      assert(acc.get_count() == 3);
+      assert(acc.get_range() == sycl::range<1>(3));
+      assert(acc[0] == 2);
+    }
+    {
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc(buf_data, sycl::write_only);
+#elif defined(buffer_new_api_test)
+      auto acc = buf_data.get_host_access(sycl::write_only);
+#endif
+
+      assert(acc.get_count() == 3);
+      assert(acc.get_range() == sycl::range<1>(3));
+      acc[0] = 1;
+      assert(data[0] == 1 && data[1] == 7 && data[2] == 9);
+    }
+    {
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc(buf_data, sycl::range<1>(2));
+#elif defined(buffer_new_api_test)
+      auto acc = buf_data.get_host_access(sycl::range<1>(2));
+#endif
+
+      assert(acc.get_count() == 2);
+      assert(acc.get_range() == sycl::range<1>(2));
+      assert(acc[0] == 1);
+
+      acc[0] = 2;
+
+      assert(data[0] == 2 && data[1] == 7 && data[2] == 9);
+    }
+    {
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc(buf_data, sycl::range<1>(2), sycl::read_only);
+#elif defined(buffer_new_api_test)
+      auto acc = buf_data.get_host_access(sycl::range<1>(2), sycl::read_only);
+#endif
+
+      assert(acc.get_count() == 2);
+      assert(acc.get_range() == sycl::range<1>(2));
+      assert(acc[0] == 2);
+    }
+    {
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc(buf_data, sycl::range<1>(2), sycl::write_only);
+#elif defined(buffer_new_api_test)
+      auto acc = buf_data.get_host_access(sycl::range<1>(2), sycl::write_only);
+#endif
+
+      assert(acc.get_count() == 2);
+      assert(acc.get_range() == sycl::range<1>(2));
+      acc[0] = 1;
+      assert(data[0] == 1 && data[1] == 7 && data[2] == 9);
+    }
+    {
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc(buf_data, sycl::range<1>(2), sycl::id<1>(1));
+#elif defined(buffer_new_api_test)
+      auto acc = buf_data.get_host_access(sycl::range<1>(2), sycl::id<1>(1));
+#endif
+
+      assert(acc.get_count() == 2);
+      assert(acc.get_range() == sycl::range<1>(2));
+      assert(acc[0] == 7);
+
+      acc[0] = 6;
+
+      assert(data[0] == 1 && data[1] == 6 && data[2] == 9);
+    }
+    {
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc(buf_data, sycl::range<1>(2), sycl::id<1>(1),
+                              sycl::read_only);
+#elif defined(buffer_new_api_test)
+      auto acc = buf_data.get_host_access(sycl::range<1>(2), sycl::id<1>(1),
+                                          sycl::read_only);
+#endif
+
+      assert(acc.get_count() == 2);
+      assert(acc.get_range() == sycl::range<1>(2));
+      assert(acc[0] == 6);
+    }
+    {
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc(buf_data, sycl::range<1>(2), sycl::id<1>(1),
+                              sycl::write_only);
+#elif defined(buffer_new_api_test)
+      auto acc = buf_data.get_host_access(sycl::range<1>(2), sycl::id<1>(1),
+                                          sycl::write_only);
+#endif
+
+      assert(acc.get_count() == 2);
+      assert(acc.get_range() == sycl::range<1>(2));
+      acc[0] = 5;
+      assert(data[0] == 1 && data[1] == 5 && data[2] == 9);
+    }
+  }
+}

--- a/sycl/test/basic_tests/accessor/Inputs/host_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/Inputs/host_accessor.cpp
@@ -17,7 +17,7 @@ int main() {
     int data[3] = {3, 7, 9};
 
     sycl::buffer<int, 1> buf_data(data, sycl::range<1>(3),
-                                 {cl::sycl::property::buffer::use_host_ptr()});
+                                  {cl::sycl::property::buffer::use_host_ptr()});
 
     {
 #if defined(accessor_new_api_test)

--- a/sycl/test/basic_tests/accessor/Inputs/host_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/Inputs/host_accessor.cpp
@@ -8,10 +8,6 @@
 #include <CL/sycl.hpp>
 #include <cassert>
 
-namespace sycl {
-using namespace cl::sycl;
-}
-
 int main() {
   {
     int data[3] = {3, 7, 9};

--- a/sycl/test/basic_tests/accessor/accessor.cpp
+++ b/sycl/test/basic_tests/accessor/accessor.cpp
@@ -14,10 +14,6 @@
 #include <CL/sycl.hpp>
 #include <cassert>
 
-namespace sycl {
-using namespace cl::sycl;
-}
-
 struct IdxID1 {
   int x;
 

--- a/sycl/test/basic_tests/accessor/device_accessor_deduction.cpp
+++ b/sycl/test/basic_tests/accessor/device_accessor_deduction.cpp
@@ -1,0 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test -std=c++17 %S/Inputs/device_accessor.cpp -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/basic_tests/accessor/get_device_access_deduction.cpp
+++ b/sycl/test/basic_tests/accessor/get_device_access_deduction.cpp
@@ -1,0 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test -std=c++17 %S/Inputs/device_accessor.cpp -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/basic_tests/accessor/get_host_access_deduction.cpp
+++ b/sycl/test/basic_tests/accessor/get_host_access_deduction.cpp
@@ -1,0 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test -std=c++17 %S/Inputs/host_accessor.cpp -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/basic_tests/accessor/host_accessor_deduction.cpp
+++ b/sycl/test/basic_tests/accessor/host_accessor_deduction.cpp
@@ -1,0 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test -std=c++17 %S/Inputs/host_accessor.cpp -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
This second patch finishes the implementation of SYCL_INTEL_accessor_simplification extension.

It adds:

* `get_host_accessor`  to buffer
* adds overloads for `get_access` to enable deduction guide
* refactored test, as requested in this PR: https://github.com/intel/llvm/pull/1838
* updated deduction guides, based on limitations found via refactored tests
