### PR TITLE
[SYCL][CUDA] Cleanup of profiling events

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -369,6 +369,8 @@ public:
     return new _pi_event(type, queue->get_context(), queue);
   }
 
+  pi_result release();
+
   ~_pi_event();
 
 private:


### PR DESCRIPTION
Additional CUDA events created for profiling are now
released upon destruction of the PI Event.

Signed-off-by: Ruyman Reyes <ruyman@codeplay.com>