### PR TITLE
[SYCL] Added arbitrary integer SPIR-V spec as an extension

### DIFF
--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_arbitrary_precision_int.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_arbitrary_precision_int.asciidoc
@@ -1,0 +1,95 @@
+= SPV_INTEL_arbitrary_precision_integers
+
+== Name Strings
+
+SPV_INTEL_arbitrary_precision_integers
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/KhronosGroup/SPIRV-Headers
+
+== Contributors
+
+* Ajaykumar Kannan, Intel
+* Joe Garvey, Intel
+
+== Notice
+
+Copyright (c) 2020 Intel Corporation
+
+== Status
+
+Final draft
+
+=== Version
+
+[width="40%",cols="25,25"]
+|========================================
+| Last Modified Date | {docdate}
+| Revision           | 1
+|========================================
+
+== Dependencies
+
+This extension is written against the SPIR-V Specification Version 1.5, Revision 2.
+
+== Overview
+
+This extension relaxes the restriction that `OpTypeInt` must have a width of 32 bits.
+Ints of arbitrary bit widths can be beneficial on targets that can exploit narrower widths such as FPGAs.
+
+== Extension Name
+
+To use this extension within a SPIR-V module, the following *OpExtension* must be present in the module:
+
+----
+OpExtension "SPV_INTEL_arbitrary_precision_integers"
+----
+
+== New Capabilities
+
+This extension introduces a new capability:
+
+----
+ArbitraryPrecisionIntegersINTEL
+----
+
+== Token Number Assignments
+[width="40%"]
+[cols="70%,30%"]
+[grid="rows"]
+|====
+|`ArbitraryPrecisionIntegersINTEL`        | 5844
+|====
+
+== Modifications to the SPIR-V Specification Version 1.5
+
+=== Capability
+Modify Section 3.31, *Capability*, adding a row to the Capability table:
+[options="header"]
+|====
+2+^| Capability ^| Implicitly Declares
+| 5844 | *ArbitraryPrecisionIntegersINTEL* +
+
+Allows the use of the *OpTypeInt* to declare integers of any arbitrary width.
+The minimum requirement is that all bitwidths up to 32-bits must be supported, but implementations can extend the support beyond 32-bits.
+| Int8, Int16
+|====
+
+=== Validation Rules
+
+None.
+
+== Issues
+
+None.
+
+== Revision History
+
+[cols="^,<,<,<",options="header",]
+|================================================
+|Rev |Date |Author |Changes
+|1 |2020-03-27 |Ajaykumar Kannan |*Initial public release*
+|================================================


### PR DESCRIPTION
Create a new extension to enable SPIR-V to use arbitrary precision integers, with a default maximum bitwidth (with this extension) up to 32 bits, but implementers are allowed to go up to any arbitrary bitwidth.