### PR TITLE
Add more minor enhancements to ItaniumDemangle.h.

### DIFF
--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -1199,7 +1199,7 @@ public:
 
   template<typename Fn> void match(Fn F) const { F(Params); }
 
-  NodeArray getParams() { return Params; }
+  const NodeArray &getParams() const { return Params; }
 
   void printLeft(OutputStream &S) const override {
     S += "<";


### PR DESCRIPTION
- Add accessor method for the ObjCProtoName::Protocol field so that
  other Nodes such as PointerType can access it.
- Make TemplateArgs::getParams() const and return reference instead of
  a copy.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>