### PR TITLE
[SYCL] Change associated numbers for global_device/host addr spaces

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -30,8 +30,8 @@ static const unsigned SPIRAddrSpaceMap[] = {
     2,  // opencl_constant
     0,  // opencl_private
     4,  // opencl_generic
-    11, // opencl_global_device
-    12, // opencl_global_host
+    5, // opencl_global_device
+    6, // opencl_global_host
     0,  // cuda_device
     0,  // cuda_constant
     0,  // cuda_shared
@@ -47,8 +47,8 @@ static const unsigned SYCLAddrSpaceMap[] = {
     2,  // opencl_constant
     0,  // opencl_private
     4,  // opencl_generic
-    11, // opencl_global_device
-    12, // opencl_global_host
+    5, // opencl_global_device
+    6, // opencl_global_host
     0,  // cuda_device
     0,  // cuda_constant
     0,  // cuda_shared

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1382,9 +1382,9 @@ static unsigned ArgInfoAddressSpace(LangAS AS) {
   case LangAS::opencl_generic:
     return 4; // Not in SPIR 2.0 specs.
   case LangAS::opencl_global_device:
-    return 11;
+    return 5;
   case LangAS::opencl_global_host:
-    return 12;
+    return 6;
   default:
     return 0; // Assume private.
   }

--- a/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
@@ -23,9 +23,9 @@ void tmpl(T t){}
 void usages() {
   // CHECK-DAG: [[GLOB:%[a-zA-Z0-9]+]] = alloca i32 addrspace(1)*
   __attribute__((opencl_global)) int *GLOB;
-  // CHECK-DAG: [[GLOBDEV:%[a-zA-Z0-9]+]] = alloca i32 addrspace(11)*
+  // CHECK-DAG: [[GLOBDEV:%[a-zA-Z0-9]+]] = alloca i32 addrspace(5)*
   __attribute__((opencl_global_device)) int *GLOBDEV;
-  // CHECK-DAG: [[GLOBHOST:%[a-zA-Z0-9]+]] = alloca i32 addrspace(12)*
+  // CHECK-DAG: [[GLOBHOST:%[a-zA-Z0-9]+]] = alloca i32 addrspace(6)*
   __attribute__((opencl_global_host)) int *GLOBHOST;
   // CHECK-DAG: [[LOC:%[a-zA-Z0-9]+]] = alloca i32 addrspace(3)*
   __attribute__((opencl_local)) int *LOC;
@@ -44,29 +44,29 @@ void usages() {
   // CHECK-DAG: call spir_func void @[[RAW_REF2]](i32 addrspace(4)* align 4 dereferenceable(4) [[GLOB_CAST2]])
 
   bar(*GLOBDEV);
-  // CHECK-DAG: [[GLOBDEV_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(11)*, i32 addrspace(11)** [[GLOBDEV]]
-  // CHECK-DAG: [[GLOBDEV_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(11)* [[GLOBDEV_LOAD]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBDEV_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(5)*, i32 addrspace(5)** [[GLOBDEV]]
+  // CHECK-DAG: [[GLOBDEV_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(5)* [[GLOBDEV_LOAD]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* align 4 dereferenceable(4) [[GLOBDEV_CAST]])
   bar2(*GLOBDEV);
-  // CHECK-DAG: [[GLOBDEV_LOAD2:%[a-zA-Z0-9]+]] = load i32 addrspace(11)*, i32 addrspace(11)** [[GLOBDEV]]
-  // CHECK-DAG: [[GLOBDEV_CAST2:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(11)* [[GLOBDEV_LOAD2]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBDEV_LOAD2:%[a-zA-Z0-9]+]] = load i32 addrspace(5)*, i32 addrspace(5)** [[GLOBDEV]]
+  // CHECK-DAG: [[GLOBDEV_CAST2:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(5)* [[GLOBDEV_LOAD2]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_REF2]](i32 addrspace(4)* align 4 dereferenceable(4) [[GLOBDEV_CAST2]])
   bar3(*GLOBDEV);
-  // CHECK-DAG: [[GLOBDEV_LOAD3:%[a-zA-Z0-9]+]] = load i32 addrspace(11)*, i32 addrspace(11)** [[GLOBDEV]]
-  // CHECK-DAG: [[GLOBDEV_CAST3:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(11)* [[GLOBDEV_LOAD3]] to i32 addrspace(1)*
+  // CHECK-DAG: [[GLOBDEV_LOAD3:%[a-zA-Z0-9]+]] = load i32 addrspace(5)*, i32 addrspace(5)** [[GLOBDEV]]
+  // CHECK-DAG: [[GLOBDEV_CAST3:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(5)* [[GLOBDEV_LOAD3]] to i32 addrspace(1)*
   // CHECK-DAG: call spir_func void @[[GLOB_REF]](i32 addrspace(1)* align 4 dereferenceable(4) [[GLOBDEV_CAST3]])
 
   bar(*GLOBHOST);
-  // CHECK-DAG: [[GLOBHOST_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(12)*, i32 addrspace(12)** [[GLOBHOST]]
-  // CHECK-DAG: [[GLOBHOST_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(12)* [[GLOBHOST_LOAD]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBHOST_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(6)*, i32 addrspace(6)** [[GLOBHOST]]
+  // CHECK-DAG: [[GLOBHOST_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(6)* [[GLOBHOST_LOAD]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* align 4 dereferenceable(4) [[GLOBHOST_CAST]])
   bar2(*GLOBHOST);
-  // CHECK-DAG: [[GLOBHOST_LOAD2:%[a-zA-Z0-9]+]] = load i32 addrspace(12)*, i32 addrspace(12)** [[GLOBHOST]]
-  // CHECK-DAG: [[GLOBHOST_CAST2:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(12)* [[GLOBHOST_LOAD2]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBHOST_LOAD2:%[a-zA-Z0-9]+]] = load i32 addrspace(6)*, i32 addrspace(6)** [[GLOBHOST]]
+  // CHECK-DAG: [[GLOBHOST_CAST2:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(6)* [[GLOBHOST_LOAD2]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_REF2]](i32 addrspace(4)* align 4 dereferenceable(4) [[GLOBHOST_CAST2]])
   bar3(*GLOBHOST);
-  // CHECK-DAG: [[GLOBHOST_LOAD3:%[a-zA-Z0-9]+]] = load i32 addrspace(12)*, i32 addrspace(12)** [[GLOBHOST]]
-  // CHECK-DAG: [[GLOBHOST_CAST3:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(12)* [[GLOBHOST_LOAD3]] to i32 addrspace(1)*
+  // CHECK-DAG: [[GLOBHOST_LOAD3:%[a-zA-Z0-9]+]] = load i32 addrspace(6)*, i32 addrspace(6)** [[GLOBHOST]]
+  // CHECK-DAG: [[GLOBHOST_CAST3:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(6)* [[GLOBHOST_LOAD3]] to i32 addrspace(1)*
   // CHECK-DAG: call spir_func void @[[GLOB_REF]](i32 addrspace(1)* align 4 dereferenceable(4) [[GLOBHOST_CAST3]])
 
   bar(*LOC);
@@ -93,28 +93,28 @@ void usages() {
   // CHECK-DAG: [[GLOB_CAST4:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(1)* [[GLOB_LOAD4]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_PTR2]](i32 addrspace(4)* [[GLOB_CAST4]])
   foo(GLOBDEV);
-  // CHECK-DAG: [[GLOBDEV_LOAD4:%[a-zA-Z0-9]+]] = load i32 addrspace(11)*, i32 addrspace(11)** [[GLOBDEV]]
-  // CHECK-DAG: [[GLOBDEV_CAST4:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(11)* [[GLOBDEV_LOAD4]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBDEV_LOAD4:%[a-zA-Z0-9]+]] = load i32 addrspace(5)*, i32 addrspace(5)** [[GLOBDEV]]
+  // CHECK-DAG: [[GLOBDEV_CAST4:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(5)* [[GLOBDEV_LOAD4]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_PTR]](i32 addrspace(4)* [[GLOBDEV_CAST4]])
   foo2(GLOBDEV);
-  // CHECK-DAG: [[GLOBDEV_LOAD5:%[a-zA-Z0-9]+]] = load i32 addrspace(11)*, i32 addrspace(11)** [[GLOBDEV]]
-  // CHECK-DAG: [[GLOBDEV_CAST5:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(11)* [[GLOBDEV_LOAD5]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBDEV_LOAD5:%[a-zA-Z0-9]+]] = load i32 addrspace(5)*, i32 addrspace(5)** [[GLOBDEV]]
+  // CHECK-DAG: [[GLOBDEV_CAST5:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(5)* [[GLOBDEV_LOAD5]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_PTR2]](i32 addrspace(4)* [[GLOBDEV_CAST5]])
   foo3(GLOBDEV);
-  // CHECK-DAG: [[GLOBDEV_LOAD6:%[a-zA-Z0-9]+]] = load i32 addrspace(11)*, i32 addrspace(11)** [[GLOBDEV]]
-  // CHECK-DAG: [[GLOBDEV_CAST6:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(11)* [[GLOBDEV_LOAD6]] to i32 addrspace(1)*
+  // CHECK-DAG: [[GLOBDEV_LOAD6:%[a-zA-Z0-9]+]] = load i32 addrspace(5)*, i32 addrspace(5)** [[GLOBDEV]]
+  // CHECK-DAG: [[GLOBDEV_CAST6:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(5)* [[GLOBDEV_LOAD6]] to i32 addrspace(1)*
   // CHECK-DAG: call spir_func void @[[GLOB_PTR]](i32 addrspace(1)* [[GLOBDEV_CAST6]])
   foo(GLOBHOST);
-  // CHECK-DAG: [[GLOBHOST_LOAD4:%[a-zA-Z0-9]+]] = load i32 addrspace(12)*, i32 addrspace(12)** [[GLOBHOST]]
-  // CHECK-DAG: [[GLOBHOST_CAST4:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(12)* [[GLOBHOST_LOAD4]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBHOST_LOAD4:%[a-zA-Z0-9]+]] = load i32 addrspace(6)*, i32 addrspace(6)** [[GLOBHOST]]
+  // CHECK-DAG: [[GLOBHOST_CAST4:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(6)* [[GLOBHOST_LOAD4]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_PTR]](i32 addrspace(4)* [[GLOBHOST_CAST4]])
   foo2(GLOBHOST);
-  // CHECK-DAG: [[GLOBHOST_LOAD5:%[a-zA-Z0-9]+]] = load i32 addrspace(12)*, i32 addrspace(12)** [[GLOBHOST]]
-  // CHECK-DAG: [[GLOBHOST_CAST5:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(12)* [[GLOBHOST_LOAD5]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBHOST_LOAD5:%[a-zA-Z0-9]+]] = load i32 addrspace(6)*, i32 addrspace(6)** [[GLOBHOST]]
+  // CHECK-DAG: [[GLOBHOST_CAST5:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(6)* [[GLOBHOST_LOAD5]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_PTR2]](i32 addrspace(4)* [[GLOBHOST_CAST5]])
   foo3(GLOBHOST);
-  // CHECK-DAG: [[GLOBHOST_LOAD6:%[a-zA-Z0-9]+]] = load i32 addrspace(12)*, i32 addrspace(12)** [[GLOBHOST]]
-  // CHECK-DAG: [[GLOBHOST_CAST6:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(12)* [[GLOBHOST_LOAD6]] to i32 addrspace(1)*
+  // CHECK-DAG: [[GLOBHOST_LOAD6:%[a-zA-Z0-9]+]] = load i32 addrspace(6)*, i32 addrspace(6)** [[GLOBHOST]]
+  // CHECK-DAG: [[GLOBHOST_CAST6:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(6)* [[GLOBHOST_LOAD6]] to i32 addrspace(1)*
   // CHECK-DAG: call spir_func void @[[GLOB_PTR]](i32 addrspace(1)* [[GLOBHOST_CAST6]])
   foo(LOC);
   // CHECK-DAG: [[LOC_LOAD3:%[a-zA-Z0-9]+]] = load i32 addrspace(3)*, i32 addrspace(3)** [[LOC]]
@@ -135,11 +135,11 @@ void usages() {
   // CHECK-DAG: [[GLOB_LOAD4:%[a-zA-Z0-9]+]] = load i32 addrspace(1)*, i32 addrspace(1)** [[GLOB]]
   // CHECK-DAG: call spir_func void [[GLOB_TMPL:@[a-zA-Z0-9_]+]](i32 addrspace(1)* [[GLOB_LOAD4]])
   tmpl(GLOBDEV);
-  // CHECK-DAG: [[GLOBDEV_LOAD4:%[a-zA-Z0-9]+]] = load i32 addrspace(11)*, i32 addrspace(11)** [[GLOBDEV]]
-  // CHECK-DAG: call spir_func void [[GLOBDEV_TMPL:@[a-zA-Z0-9_]+]](i32 addrspace(11)* [[GLOBDEV_LOAD4]])
+  // CHECK-DAG: [[GLOBDEV_LOAD4:%[a-zA-Z0-9]+]] = load i32 addrspace(5)*, i32 addrspace(5)** [[GLOBDEV]]
+  // CHECK-DAG: call spir_func void [[GLOBDEV_TMPL:@[a-zA-Z0-9_]+]](i32 addrspace(5)* [[GLOBDEV_LOAD4]])
   tmpl(GLOBHOST);
-  // CHECK-DAG: [[GLOBHOST_LOAD4:%[a-zA-Z0-9]+]] = load i32 addrspace(12)*, i32 addrspace(12)** [[GLOBHOST]]
-  // CHECK-DAG: call spir_func void [[GLOBHOST_TMPL:@[a-zA-Z0-9_]+]](i32 addrspace(12)* [[GLOBHOST_LOAD4]])
+  // CHECK-DAG: [[GLOBHOST_LOAD4:%[a-zA-Z0-9]+]] = load i32 addrspace(6)*, i32 addrspace(6)** [[GLOBHOST]]
+  // CHECK-DAG: call spir_func void [[GLOBHOST_TMPL:@[a-zA-Z0-9_]+]](i32 addrspace(6)* [[GLOBHOST_LOAD4]])
   tmpl(LOC);
   // CHECK-DAG: [[LOC_LOAD5:%[a-zA-Z0-9]+]] = load i32 addrspace(3)*, i32 addrspace(3)** [[LOC]]
   // CHECK-DAG: call spir_func void [[LOC_TMPL:@[a-zA-Z0-9_]+]](i32 addrspace(3)* [[LOC_LOAD5]])
@@ -152,8 +152,8 @@ void usages() {
 }
 
 // CHECK-DAG: define linkonce_odr spir_func void [[GLOB_TMPL]](i32 addrspace(1)* %
-// CHECK-DAG: define linkonce_odr spir_func void [[GLOBDEV_TMPL]](i32 addrspace(11)* %
-// CHECK-DAG: define linkonce_odr spir_func void [[GLOBHOST_TMPL]](i32 addrspace(12)* %
+// CHECK-DAG: define linkonce_odr spir_func void [[GLOBDEV_TMPL]](i32 addrspace(5)* %
+// CHECK-DAG: define linkonce_odr spir_func void [[GLOBHOST_TMPL]](i32 addrspace(6)* %
 // CHECK-DAG: define linkonce_odr spir_func void [[LOC_TMPL]](i32 addrspace(3)* %
 // CHECK-DAG: define linkonce_odr spir_func void [[PRIV_TMPL]](i32* %
 // CHECK-DAG: define linkonce_odr spir_func void [[GEN_TMPL]](i32 addrspace(4)* %
@@ -164,9 +164,9 @@ void usages2() {
   __attribute__((opencl_global)) int *GLOB;
   // CHECK-DAG: [[GLOB:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(1)*
   __attribute__((opencl_global_device)) int *GLOBDEV;
-  // CHECK-DAG: [[GLOBDEV:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(11)*
+  // CHECK-DAG: [[GLOBDEV:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(5)*
   __attribute__((opencl_global_host)) int *GLOBHOST;
-  // CHECK-DAG: [[GLOBHOST:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(12)*
+  // CHECK-DAG: [[GLOBHOST:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(6)*
   __attribute__((opencl_constant)) int *CONST;
   // CHECK-DAG: [[CONST:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(2)*
   __attribute__((opencl_local)) int *LOCAL;
@@ -181,12 +181,12 @@ void usages2() {
   // CHECK-DAG: [[GLOB_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(1)* [[GLOB_LOAD]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* align 4 dereferenceable(4) [[GLOB_CAST]])
   bar(*GLOBDEV);
-  // CHECK-DAG: [[GLOBDEV_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(11)*, i32 addrspace(11)** [[GLOBDEV]]
-  // CHECK-DAG: [[GLOBDEV_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(11)* [[GLOBDEV_LOAD]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBDEV_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(5)*, i32 addrspace(5)** [[GLOBDEV]]
+  // CHECK-DAG: [[GLOBDEV_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(5)* [[GLOBDEV_LOAD]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* align 4 dereferenceable(4) [[GLOBDEV_CAST]])
   bar(*GLOBHOST);
-  // CHECK-DAG: [[GLOBHOST_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(12)*, i32 addrspace(12)** [[GLOBHOST]]
-  // CHECK-DAG: [[GLOBHOST_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(12)* [[GLOBHOST_LOAD]] to i32 addrspace(4)*
+  // CHECK-DAG: [[GLOBHOST_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(6)*, i32 addrspace(6)** [[GLOBHOST]]
+  // CHECK-DAG: [[GLOBHOST_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(6)* [[GLOBHOST_LOAD]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* align 4 dereferenceable(4) [[GLOBHOST_CAST]])
   bar2(*LOCAL);
   // CHECK-DAG: [[LOCAL_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(3)*, i32 addrspace(3)** [[LOCAL]]


### PR DESCRIPTION
Thus making SPIR AS map continuous.
This is a follow up from a discussion from here: https://reviews.llvm.org/D82174

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>