### PR TITLE
[SYCL][CUDA] Generalised Sampler Basic Test

### DIFF
--- a/sycl/test/basic_tests/sampler/sampler.cpp
+++ b/sycl/test/basic_tests/sampler/sampler.cpp
@@ -3,8 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// XFAIL: level0
-// "die: piextKernelSetArgSampler: not implemented"
 
 //==--------------- sampler.cpp - SYCL sampler basic test ------------------==//
 //

--- a/sycl/test/basic_tests/sampler/sampler.cpp
+++ b/sycl/test/basic_tests/sampler/sampler.cpp
@@ -3,6 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
+// XFAIL: level0
+// "die: piextKernelSetArgSampler: not implemented"
 
 //==--------------- sampler.cpp - SYCL sampler basic test ------------------==//
 //

--- a/sycl/test/basic_tests/sampler/sampler.cpp
+++ b/sycl/test/basic_tests/sampler/sampler.cpp
@@ -2,7 +2,6 @@
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
 
 //==--------------- sampler.cpp - SYCL sampler basic test ------------------==//
 //

--- a/sycl/test/basic_tests/sampler/sampler.cpp
+++ b/sycl/test/basic_tests/sampler/sampler.cpp
@@ -1,5 +1,3 @@
-// REQUIRES: opencl
-
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
@@ -50,37 +48,10 @@ int main() {
          A.get_filtering_mode() == B.get_filtering_mode());
 
   // Check assignment operator
-  if (!Queue.is_host()) {
-    // OpenCL sampler
-    cl_int Err = CL_SUCCESS;
-#ifdef CL_VERSION_2_0
-    const cl_sampler_properties sprops[] = {
-        CL_SAMPLER_NORMALIZED_COORDS,
-        static_cast<cl_sampler_properties>(true),
-        CL_SAMPLER_ADDRESSING_MODE,
-        static_cast<cl_sampler_properties>(CL_ADDRESS_REPEAT),
-        CL_SAMPLER_FILTER_MODE,
-        static_cast<cl_sampler_properties>(CL_FILTER_LINEAR),
-        0};
-    cl_sampler ClSampler =
-        clCreateSamplerWithProperties(Queue.get_context().get(), sprops, &Err);
-#else
-    cl_sampler ClSampler =
-        clCreateSampler(Queue.get_context().get(), true, CL_ADDRESS_REPEAT,
-                        CL_FILTER_LINEAR, &Err);
-#endif
-    // If device doesn't support sampler - skip it
-    if (Err == CL_INVALID_OPERATION)
-      return 0;
+  B = sycl::sampler(sycl::coordinate_normalization_mode::normalized,
+                    sycl::addressing_mode::repeat,
+                    sycl::filtering_mode::linear);
 
-    CHECK_OCL_CODE(Err);
-    B = sycl::sampler(ClSampler, Queue.get_context());
-  } else {
-    // Host sampler
-    B = sycl::sampler(sycl::coordinate_normalization_mode::normalized,
-                      sycl::addressing_mode::repeat,
-                      sycl::filtering_mode::linear);
-  }
   assert(B.get_addressing_mode() == sycl::addressing_mode::repeat);
   assert(B.get_coordinate_normalization_mode() ==
          sycl::coordinate_normalization_mode::normalized);

--- a/sycl/test/basic_tests/sampler/sampler_ocl.cpp
+++ b/sycl/test/basic_tests/sampler/sampler_ocl.cpp
@@ -1,0 +1,58 @@
+// REQUIRES: opencl
+
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+//==--------------- sampler.cpp - SYCL sampler basic test ------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/context.hpp>
+#include <cassert>
+
+namespace sycl {
+using namespace cl::sycl;
+}
+
+int main() {
+  sycl::queue Queue;
+  sycl::sampler B(sycl::coordinate_normalization_mode::unnormalized,
+                  sycl::addressing_mode::clamp, sycl::filtering_mode::nearest);
+
+  // OpenCL sampler
+  cl_int Err = CL_SUCCESS;
+#ifdef CL_VERSION_2_0
+  const cl_sampler_properties sprops[] = {
+      CL_SAMPLER_NORMALIZED_COORDS,
+      static_cast<cl_sampler_properties>(true),
+      CL_SAMPLER_ADDRESSING_MODE,
+      static_cast<cl_sampler_properties>(CL_ADDRESS_REPEAT),
+      CL_SAMPLER_FILTER_MODE,
+      static_cast<cl_sampler_properties>(CL_FILTER_LINEAR),
+      0};
+  cl_sampler ClSampler =
+      clCreateSamplerWithProperties(Queue.get_context().get(), sprops, &Err);
+#else
+  cl_sampler ClSampler =
+      clCreateSampler(Queue.get_context().get(), true, CL_ADDRESS_REPEAT,
+                      CL_FILTER_LINEAR, &Err);
+#endif
+  // If device doesn't support sampler - skip it
+  if (Err == CL_INVALID_OPERATION)
+    return 0;
+
+  CHECK_OCL_CODE(Err);
+  B = sycl::sampler(ClSampler, Queue.get_context());
+
+  assert(B.get_addressing_mode() == sycl::addressing_mode::repeat);
+  assert(B.get_coordinate_normalization_mode() ==
+         sycl::coordinate_normalization_mode::normalized);
+  assert(B.get_filtering_mode() == sycl::filtering_mode::linear);
+}


### PR DESCRIPTION
This PR introduces a generic test for `sycl::sampler`, and moves the existing testing to the OpenCL-specific `sampler_ocl.cpp`.