### PR TITLE
[SYCL][Driver] Address empty input issue for -foffload-static-lib opt…

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -400,6 +400,13 @@ DerivedArgList *Driver::TranslateInputArgs(const InputArgList &Args) const {
       continue;
     }
 
+    if (A->getOption().matches(options::OPT_offload_lib_Group)) {
+      if (!A->getNumValues()) {
+        Diag(clang::diag::warn_drv_unused_argument) << A->getSpelling();
+        continue;
+      }
+    }
+
     DAL->append(A);
   }
 
@@ -4788,7 +4795,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       }
     }
 
-    if (!UnbundlerInputs.empty()) {
+    if (!UnbundlerInputs.empty() && !PL.empty()) {
       Action *PartialLink =
           C.MakeAction<PartialLinkJobAction>(UnbundlerInputs, types::TY_Object);
       Action *Current = C.MakeAction<InputAction>(*LastArg, types::TY_Object);
@@ -4843,7 +4850,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
         UnbundlerInput = LI;
       }
     }
-    if (UnbundlerInput) {
+    if (UnbundlerInput && !PL.empty()) {
       if (auto *IA = dyn_cast<InputAction>(UnbundlerInput)) {
         std::string FileName = IA->getInputArg().getAsString(Args);
         Arg *InputArg = MakeInputArg(Args, Opts, FileName);

--- a/clang/test/Driver/sycl-offload-static-lib.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib.cpp
@@ -139,3 +139,10 @@
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 9: file-table-tform, {6, 8}, tempfiletable, (device-sycl)
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 10: clang-offload-wrapper, {9}, object, (device-sycl)
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 11: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64-unknown-unknown-sycldevice)" {10}, image
+
+/// ###########################################################################
+
+/// test behaviors of -foffload-static-lib with no value
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -foffload-static-lib= -c %s 2>&1 \
+// RUN:   | FileCheck %s -check-prefixes=FOFFLOAD_STATIC_LIB_NOVALUE
+// FOFFLOAD_STATIC_LIB_NOVALUE: warning: argument unused during compilation: '-foffload-static-lib='


### PR DESCRIPTION
Add some dealt for empty input for "-foffload-static-lib="  option, for example, the tests result in compiler crash because of empty input. 
`clang -fsycl -c hello.c -foffload-static-lib=`

Signed-off-by: haonanya <haonan.yang@intel.com>