### PR TITLE
[SYCL][CUDA] Enable cl_khr_3d_image_writes OpenCL extension for NVPTX targets

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -46,8 +46,8 @@ static const int NVPTXDWARFAddrSpaceMap[] = {
     -1, // Default, opencl_private or opencl_generic - not defined
     5,  // opencl_global
     -1,
-    8,  // opencl_local or cuda_shared
-    4,  // opencl_constant or cuda_constant
+    8, // opencl_local or cuda_shared
+    4, // opencl_constant or cuda_constant
 };
 
 class LLVM_LIBRARY_VISIBILITY NVPTXTargetInfo : public TargetInfo {
@@ -144,6 +144,7 @@ public:
     Opts.support("cl_khr_int64_base_atomics");
     Opts.support("cl_khr_int64_extended_atomics");
     Opts.support("cl_khr_fp16");
+    Opts.support("cl_khr_3d_image_writes");
   }
 
   /// \returns If a target requires an address within a target specific address

--- a/clang/test/Misc/nvptx.languageOptsOpenCL.cl
+++ b/clang/test/Misc/nvptx.languageOptsOpenCL.cl
@@ -20,7 +20,7 @@
 #ifndef cl_clang_storage_class_specifiers
 #error "Missing cl_clang_storage_class_specifiers define"
 #endif
-#pragma OPENCL EXTENSION cl_clang_storage_class_specifiers: enable
+#pragma OPENCL EXTENSION cl_clang_storage_class_specifiers : enable
 
 // TODO: Temporarily disabling the following test as a work around for the
 // SYCL codepath until the cl_khr_fp16 is restricted to only the sycldevice triple.
@@ -29,7 +29,7 @@
 // #ifdef cl_khr_fp16
 // #error "Incorrect cl_khr_fp16 define"
 // #endif
-#pragma OPENCL EXTENSION cl_khr_fp16: enable
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
 // expected warning@-1{{unsupported OpenCL extension 'cl_khr_fp16' - ignoring}}
 
 // TODO: Temporarily disabling the following two tests as a work around for the
@@ -39,31 +39,31 @@
 //#ifdef cl_khr_int64_base_atomics
 //#error "Incorrect cl_khr_int64_base_atomics define"
 //#endif
-#pragma OPENCL EXTENSION cl_khr_int64_base_atomics: enable
+#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
 // expectedwarning@-1{{unsupported OpenCL extension 'cl_khr_int64_base_atomics' - ignoring}}
 
 //#ifdef cl_khr_int64_extended_atomics
 //#error "Incorrect cl_khr_int64_extended_atomics define"
 //#endif
-#pragma OPENCL EXTENSION cl_khr_int64_extended_atomics: enable
+#pragma OPENCL EXTENSION cl_khr_int64_extended_atomics : enable
 // expectedwarning@-1{{unsupported OpenCL extension 'cl_khr_int64_extended_atomics' - ignoring}}
 
 #ifndef cl_khr_gl_sharing
 #error "Missing cl_khr_gl_sharing define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_gl_sharing: enable
+#pragma OPENCL EXTENSION cl_khr_gl_sharing : enable
 
 #ifndef cl_khr_icd
 #error "Missing cl_khr_icd define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_icd: enable
+#pragma OPENCL EXTENSION cl_khr_icd : enable
 
 // Core features in CL 1.1
 
 #ifndef cl_khr_byte_addressable_store
 #error "Missing cl_khr_byte_addressable_store define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_byte_addressable_store: enable
+#pragma OPENCL EXTENSION cl_khr_byte_addressable_store : enable
 #if (__OPENCL_C_VERSION__ >= 110) && defined TEST_CORE_FEATURES
 // expected-warning@-2{{OpenCL extension 'cl_khr_byte_addressable_store' is core feature or supported optional core feature - ignoring}}
 #endif
@@ -71,7 +71,7 @@
 #ifndef cl_khr_global_int32_base_atomics
 #error "Missing cl_khr_global_int32_base_atomics define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics: enable
+#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable
 #if (__OPENCL_C_VERSION__ >= 110) && defined TEST_CORE_FEATURES
 // expected-warning@-2{{OpenCL extension 'cl_khr_global_int32_base_atomics' is core feature or supported optional core feature - ignoring}}
 #endif
@@ -79,7 +79,7 @@
 #ifndef cl_khr_global_int32_extended_atomics
 #error "Missing cl_khr_global_int32_extended_atomics define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_global_int32_extended_atomics: enable
+#pragma OPENCL EXTENSION cl_khr_global_int32_extended_atomics : enable
 #if (__OPENCL_C_VERSION__ >= 110) && defined TEST_CORE_FEATURES
 // expected-warning@-2{{OpenCL extension 'cl_khr_global_int32_extended_atomics' is core feature or supported optional core feature - ignoring}}
 #endif
@@ -87,7 +87,7 @@
 #ifndef cl_khr_local_int32_base_atomics
 #error "Missing cl_khr_local_int32_base_atomics define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_local_int32_base_atomics: enable
+#pragma OPENCL EXTENSION cl_khr_local_int32_base_atomics : enable
 #if (__OPENCL_C_VERSION__ >= 110) && defined TEST_CORE_FEATURES
 // expected-warning@-2{{OpenCL extension 'cl_khr_local_int32_base_atomics' is core feature or supported optional core feature - ignoring}}
 #endif
@@ -95,7 +95,7 @@
 #ifndef cl_khr_local_int32_extended_atomics
 #error "Missing cl_khr_local_int32_extended_atomics define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_local_int32_extended_atomics: enable
+#pragma OPENCL EXTENSION cl_khr_local_int32_extended_atomics : enable
 #if (__OPENCL_C_VERSION__ >= 110) && defined TEST_CORE_FEATURES
 // expected-warning@-2{{OpenCL extension 'cl_khr_local_int32_extended_atomics' is core feature or supported optional core feature - ignoring}}
 #endif
@@ -105,115 +105,116 @@
 #ifdef cl_khr_select_fprounding_mode
 #error "Incorrect cl_khr_select_fprounding_mode define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_select_fprounding_mode: enable
+#pragma OPENCL EXTENSION cl_khr_select_fprounding_mode : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_select_fprounding_mode' - ignoring}}
 #endif
-
 
 // Core feature in CL 1.2
 #ifndef cl_khr_fp64
 #error "Missing cl_khr_fp64 define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_fp64: enable
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
 #if (__OPENCL_C_VERSION__ >= 120) && defined TEST_CORE_FEATURES
 // expected-warning@-2{{OpenCL extension 'cl_khr_fp64' is core feature or supported optional core feature - ignoring}}
 #endif
 
+// TODO: Temporarily disabling the following test as a work around for the
+// SYCL codepath until the cl_khr_3d_image_writes is restricted to
+// only the sycldevice triple.
+
 // Core feature in CL 2.0, but not supported on nvptx
-#ifdef cl_khr_3d_image_writes
-#error "Incorrect cl_khr_3d_image_writes define"
-#endif
-#pragma OPENCL EXTENSION cl_khr_3d_image_writes: enable
-// expected-warning@-1{{unsupported OpenCL extension 'cl_khr_3d_image_writes' - ignoring}}
-
-
+// #ifdef cl_khr_3d_image_writes
+// #error "Incorrect cl_khr_3d_image_writes define"
+// #endif
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+// expected warning@-1{{unsupported OpenCL extension 'cl_khr_3d_image_writes' - ignoring}}
 
 #ifdef cl_khr_gl_event
 #error "Incorrect cl_khr_gl_event define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_gl_event: enable
+#pragma OPENCL EXTENSION cl_khr_gl_event : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_gl_event' - ignoring}}
 
 #ifdef cl_khr_d3d10_sharing
 #error "Incorrect cl_khr_d3d10_sharing define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_d3d10_sharing: enable
+#pragma OPENCL EXTENSION cl_khr_d3d10_sharing : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_d3d10_sharing' - ignoring}}
 
 #ifdef cl_khr_context_abort
 #error "Incorrect cl_context_abort define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_context_abort: enable
+#pragma OPENCL EXTENSION cl_khr_context_abort : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_context_abort' - ignoring}}
 
 #ifdef cl_khr_d3d11_sharing
 #error "Incorrect cl_khr_d3d11_sharing define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_d3d11_sharing: enable
+#pragma OPENCL EXTENSION cl_khr_d3d11_sharing : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_d3d11_sharing' - ignoring}}
 
 #ifdef cl_khr_dx9_media_sharing
 #error "Incorrect cl_khr_dx9_media_sharing define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_dx9_media_sharing: enable
+#pragma OPENCL EXTENSION cl_khr_dx9_media_sharing : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_dx9_media_sharing' - ignoring}}
 
 #ifdef cl_khr_image2d_from_buffer
 #error "Incorrect cl_khr_image2d_from_buffer define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_image2d_from_buffer: enable
+#pragma OPENCL EXTENSION cl_khr_image2d_from_buffer : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_image2d_from_buffer' - ignoring}}
 
 #ifdef cl_khr_initialize_memory
 #error "Incorrect cl_khr_initialize_memory define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_initialize_memory: enable
+#pragma OPENCL EXTENSION cl_khr_initialize_memory : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_initialize_memory' - ignoring}}
 
 #ifdef cl_khr_gl_depth_images
 #error "Incorrect cl_khr_gl_depth_images define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_gl_depth_images: enable
+#pragma OPENCL EXTENSION cl_khr_gl_depth_images : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_gl_depth_images' - ignoring}}
 
 #ifdef cl_khr_gl_msaa_sharing
 #error "Incorrect cl_khr_gl_msaa_sharing define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_gl_msaa_sharing: enable
+#pragma OPENCL EXTENSION cl_khr_gl_msaa_sharing : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_gl_msaa_sharing' - ignoring}}
 
 #ifdef cl_khr_spir
 #error "Incorrect cl_khr_spir define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_spir: enable
+#pragma OPENCL EXTENSION cl_khr_spir : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_spir' - ignoring}}
 
 #ifdef cl_khr_egl_event
 #error "Incorrect cl_khr_egl_event define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_egl_event: enable
+#pragma OPENCL EXTENSION cl_khr_egl_event : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_egl_event' - ignoring}}
 
 #ifdef cl_khr_egl_image
 #error "Missing cl_khr_egl_image define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_egl_image: enable
+#pragma OPENCL EXTENSION cl_khr_egl_image : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_egl_image' - ignoring}}
 
 #ifdef cl_khr_srgb_image_writes
 #error "Incorrect cl_khr_srgb_image_writes define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_srgb_image_writes: enable
+#pragma OPENCL EXTENSION cl_khr_srgb_image_writes : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_srgb_image_writes' - ignoring}}
 
 #ifdef cl_khr_subgroups
 #error "Incorrect cl_khr_subgroups define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_subgroups: enable
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_subgroups' - ignoring}}
 
 #ifdef cl_khr_terminate_context
 #error "Incorrect cl_khr_terminate_context define"
 #endif
-#pragma OPENCL EXTENSION cl_khr_terminate_context: enable
+#pragma OPENCL EXTENSION cl_khr_terminate_context : enable
 // expected-warning@-1{{unsupported OpenCL extension 'cl_khr_terminate_context' - ignoring}}

--- a/clang/test/Misc/nvptx.languageOptsOpenCL.cl
+++ b/clang/test/Misc/nvptx.languageOptsOpenCL.cl
@@ -30,7 +30,6 @@
 // #error "Incorrect cl_khr_fp16 define"
 // #endif
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-// expected warning@-1{{unsupported OpenCL extension 'cl_khr_fp16' - ignoring}}
 
 // TODO: Temporarily disabling the following two tests as a work around for the
 // SYCL codepath until the cl_khr_int64_base_atomics and
@@ -127,7 +126,6 @@
 // #error "Incorrect cl_khr_3d_image_writes define"
 // #endif
 #pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
-// expected warning@-1{{unsupported OpenCL extension 'cl_khr_3d_image_writes' - ignoring}}
 
 #ifdef cl_khr_gl_event
 #error "Incorrect cl_khr_gl_event define"

--- a/clang/test/Misc/nvptx.languageOptsOpenCL.cl
+++ b/clang/test/Misc/nvptx.languageOptsOpenCL.cl
@@ -126,7 +126,7 @@
 // #error "Incorrect cl_khr_3d_image_writes define"
 // #endif
 #pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
-#if (__OPENCL_C_VERSION__ >= 120) && defined TEST_CORE_FEATURES
+#if (__OPENCL_C_VERSION__ >= 200) && defined TEST_CORE_FEATURES
 // expected-warning@-2{{OpenCL extension 'cl_khr_3d_image_writes' is core feature or supported optional core feature - ignoring}}
 #endif
 

--- a/clang/test/Misc/nvptx.languageOptsOpenCL.cl
+++ b/clang/test/Misc/nvptx.languageOptsOpenCL.cl
@@ -126,6 +126,9 @@
 // #error "Incorrect cl_khr_3d_image_writes define"
 // #endif
 #pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+#if (__OPENCL_C_VERSION__ >= 120) && defined TEST_CORE_FEATURES
+// expected-warning@-2{{OpenCL extension 'cl_khr_3d_image_writes' is core feature or supported optional core feature - ignoring}}
+#endif
 
 #ifdef cl_khr_gl_event
 #error "Incorrect cl_khr_gl_event define"


### PR DESCRIPTION
Enable cl_khr_3d_image_writes so that builtin for that image type can be implemented properly.

Note: due the issue https://github.com/intel/llvm/issues/1814, we can't enable this extension for the sycldevice context. This would blindly enable C++ and SYCL modes, making is unusable in libclc. This will be fixed once the issue is resolved.