### PR TITLE
[SYCL][CUDA][WIP] Lower OpenCL image type to CUDA image descriptors

### DIFF
--- a/clang/test/CodeGenOpenCL/sampled_image_cuda.cl
+++ b/clang/test/CodeGenOpenCL/sampled_image_cuda.cl
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 %s -triple nvptx64-nvidia-cuda -O0 -emit-llvm -o - | FileCheck %s
+
+__attribute__((overloadable)) void my_read_image(__ocl_sampled_image1d_ro_t img_ro);
+
+__attribute__((overloadable)) __ocl_sampled_image1d_ro_t __spirv_SampledImage(read_only image1d_t img_wo, sampler_t sampl);
+
+void test_read_image(__ocl_sampled_image1d_ro_t img_ro, read_only image1d_t img_wo, sampler_t sampl) {
+
+  // CHECK: call void @_Z13my_read_image32__spirv_SampledImage__image1d_ro(i64 %{{[a-zA-Z0-9]+}}, i32 %{{[a-zA-Z0-9]+}})
+  my_read_image(img_ro);
+  // CHECK: call { i64, i32 } @_Z20__spirv_SampledImage14ocl_image1d_ro11ocl_sampler(i64 %{{[a-zA-Z0-9]+}}, i32 %{{[a-zA-Z0-9]+}})
+  __ocl_sampled_image1d_ro_t s_imag = __spirv_SampledImage(img_wo, sampl);
+  // CHECK: call void @_Z13my_read_image32__spirv_SampledImage__image1d_ro(i64 %{{[a-zA-Z0-9]+}}, i32 %{{[a-zA-Z0-9]+}})
+  my_read_image(s_imag);
+}


### PR DESCRIPTION
Expands upon functionality introduced in #1945 and provides testing. Should be merged after #1945.

In CUDA images are descriptors represented as an 64 bits integer. The PR lowers the OpenCL image type to this descriptor so it can be processed properly by the NVPTX backend and allow image builtins implementation for this target.

Independent image/sampler are not supported by CUDA, they will be emulated in the libclc. To allow this emulation we need to lower the sampler type to i32. The sampled image type (return type of __spirv_SampledImage) is lowered into a struct containing the image descriptor (i64) and the sampler (i32).