### PR TITLE
[SYCL] Fix unreleased events returned by queue USM API

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -344,10 +344,12 @@ public:
   /// Provides additional information to the underlying runtime about how
   /// different allocations are used.
   ///
+  /// \param Impl is a shared_ptr to this queue.
   /// \param Ptr is a USM pointer to the allocation.
   /// \param Length is a number of bytes in the allocation.
   /// \param Advice is a device-defined advice for the specified allocation.
-  event mem_advise(const void *Ptr, size_t Length, pi_mem_advice Advice);
+  event mem_advise(shared_ptr_class<queue_impl> Impl, const void *Ptr,
+                   size_t Length, pi_mem_advice Advice);
 
   /// Puts exception to the list of asynchronous ecxeptions.
   ///

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -100,7 +100,7 @@ event queue::memcpy(void *dest, const void *src, size_t count) {
 }
 
 event queue::mem_advise(const void *ptr, size_t length, pi_mem_advice advice) {
-  return impl->mem_advise(ptr, length, advice);
+  return impl->mem_advise(impl, ptr, length, advice);
 }
 
 event queue::submit_impl(function_class<void(handler &)> CGH,


### PR DESCRIPTION
The events were created with the interoperability constructor that
performed an unneeded retain.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>