### PR TITLE
[SYCL] Workaround to support any kernel name for the L0 backend

### DIFF
--- a/sycl/plugins/level_zero/pi_level0.cpp
+++ b/sycl/plugins/level_zero/pi_level0.cpp
@@ -1895,7 +1895,7 @@ pi_result piKernelCreate(pi_program Program, const char *KernelName,
                          &ZeKernelDesc, &ZeKernel));
 
   try {
-    auto ZePiKernel = new _pi_kernel(ZeKernel, Program);
+    auto ZePiKernel = new _pi_kernel(ZeKernel, Program, KernelName);
     *RetKernel = pi_cast<pi_kernel>(ZePiKernel);
   } catch (const std::bad_alloc &) {
     return PI_OUT_OF_HOST_MEMORY;
@@ -1961,7 +1961,12 @@ pi_result piKernelGetInfo(pi_kernel Kernel, pi_kernel_info ParamName,
   case PI_KERNEL_INFO_PROGRAM:
     return ReturnValue(pi_program{Kernel->Program});
   case PI_KERNEL_INFO_FUNCTION_NAME:
-    return ReturnValue(ZeKernelProperties.name);
+    // TODO: Replace with the line in the comment once bug in the L0 driver will
+    // be fixed. Problem is that currently L0 driver truncates name of the
+    // returned kernel if it is longer than 256 symbols.
+    //
+    // return ReturnValue(ZeKernelProperties.name);
+    return ReturnValue(Kernel->KernelName.c_str());
   case PI_KERNEL_INFO_NUM_ARGS:
     return ReturnValue(pi_uint32{ZeKernelProperties.numKernelArgs});
   case PI_KERNEL_INFO_REFERENCE_COUNT:

--- a/sycl/plugins/level_zero/pi_level0.hpp
+++ b/sycl/plugins/level_zero/pi_level0.hpp
@@ -317,14 +317,18 @@ struct _pi_program : _pi_object {
 };
 
 struct _pi_kernel : _pi_object {
-  _pi_kernel(ze_kernel_handle_t Kernel, pi_program Program)
-      : ZeKernel{Kernel}, Program{Program} {}
+  _pi_kernel(ze_kernel_handle_t Kernel, pi_program Program,
+             const char *KernelName)
+      : ZeKernel{Kernel}, Program{Program}, KernelName(KernelName) {}
 
   // L0 function handle.
   ze_kernel_handle_t ZeKernel;
 
   // Keep the program of the kernel.
   pi_program Program;
+
+  // TODO: remove when bug in the L0 runtime will be fixed.
+  std::string KernelName;
 };
 
 struct _pi_sampler : _pi_object {


### PR DESCRIPTION
Problem is that currently the L0 driver truncates name of a kernel
when queried from the L0 driver. Problem comes from specification which
allows to accept any kernel name but limits a kernel name which can be
returned by the zeKernelGetProperties function.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>