### PR TITLE
[TESTING] Change clang-format rules for spirv.hpp

### DIFF
--- a/llvm-spirv/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/spirv.hpp
@@ -198,6 +198,8 @@ enum StorageClass {
     StorageClassPhysicalStorageBufferEXT = 5349,
     StorageClassDeviceOnlyINTEL = 5936,
     StorageClassHostOnlyINTEL = 5937,
+    //TODO to remove
+    StorageClangFormatTrigger = 9999,
     StorageClassMax = 0x7fffffff,
 };
 


### PR DESCRIPTION
This particular version shows clang-format firing for a change in spirv.hpp, since this header is unformatted in general. 

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>