### PR TITLE
[SYCL] Represent the half as __fp16 to follow OpenCL representation.

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2336,6 +2336,10 @@ void CompilerInvocation::setLangDefaults(LangOptions &Opts, InputKind IK,
       }
     }
   }
+  if (Opts.SYCL) {
+    Opts.NativeHalfType = 1;
+    Opts.NativeHalfArgsAndReturns = 1;
+  }
 
   Opts.HIP = IK.getLanguage() == Language::HIP;
   Opts.CUDA = IK.getLanguage() == Language::CUDA || Opts.HIP;

--- a/clang/lib/Sema/SPIRVBuiltins.td
+++ b/clang/lib/Sema/SPIRVBuiltins.td
@@ -298,7 +298,7 @@ def Long      : IntType<"long",      QualType<"getIntTypeForBitwidth(64, true)",
 def ULong     : UIntType<"ulong",     QualType<"getIntTypeForBitwidth(64, false)">, 64>;
 def Float     : FPType<"float",     QualType<"FloatTy">, 32>;
 def Double    : FPType<"double",    QualType<"DoubleTy">, 64>;
-def Half      : FPType<"half",      QualType<"Float16Ty">, 16>;
+def Half      : FPType<"half",      QualType<"HalfTy">, 16>;
 def Void      : Type<"void",      QualType<"VoidTy">>;
 // FIXME: ensure this is portable...
 def Size      : Type<"size_t",    QualType<"getSizeType()">>;

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -408,8 +408,8 @@ template <typename T>
 struct select_cl_vector_or_scalar<
     T, typename std::enable_if<is_vgentype<T>::value>::type> {
   using type =
-      // select_cl_scalar_t returns _Float16, so, we try to instantiate vec
-      // class with _Float16 DataType, which is not expected there
+      // select_cl_scalar_t returns __fp16, so, we try to instantiate vec
+      // class with __fp16 DataType, which is not expected there
       // So, leave vector<half, N> as-is
       vec<conditional_t<std::is_same<typename T::element_type, half>::value,
                         typename T::element_type,

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -21,7 +21,7 @@
 
 #ifdef __SYCL_DEVICE_ONLY__
 // `constexpr` could work because the implicit conversion from `float` to
-// `_Float16` can be `constexpr`.
+// `__fp16` can be `constexpr`.
 #define __SYCL_CONSTEXPR_ON_DEVICE constexpr
 #else
 #define __SYCL_CONSTEXPR_ON_DEVICE
@@ -103,8 +103,8 @@ class half;
 // - VecNStorageT - representation of N-element vector of halfs. Follows the
 //   same logic as StorageT
 #ifdef __SYCL_DEVICE_ONLY__
-  using StorageT = _Float16;
-  using BIsRepresentationT = _Float16;
+  using StorageT = __fp16;
+  using BIsRepresentationT = __fp16;
 
   using Vec2StorageT = StorageT __attribute__((ext_vector_type(2)));
   using Vec3StorageT = StorageT __attribute__((ext_vector_type(3)));


### PR DESCRIPTION
As per discussed in the upstreaming call, this is the changes identified to align the half type with the OpenCL one.

__fp16 is the type used to represent half type.
It lowers to the same type as would _Float16 if the target support native half
but doesn't requires that the target/backend support it to use it.

Signed-off-by: Victor Lomuller <victor@codeplay.com>