### PR TITLE
[SYCL-PTX] Enable half for CUDA target.

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -143,6 +143,7 @@ public:
     // FIXME: maybe we should have a way to control this ?
     Opts.support("cl_khr_int64_base_atomics");
     Opts.support("cl_khr_int64_extended_atomics");
+    Opts.support("cl_khr_fp16");
   }
 
   /// \returns If a target requires an address within a target specific address

--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -81,7 +81,6 @@ class QualType<string _Name, bit _IsAbstract=0> {
   // no corresponding AST QualType, e.g. a GenType or an `image2d_t` type
   // without access qualifiers.
   bit IsAbstract = _IsAbstract;
-  bit IsFunctionCall = 0;
 }
 
 // List of integers.

--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -81,6 +81,7 @@ class QualType<string _Name, bit _IsAbstract=0> {
   // no corresponding AST QualType, e.g. a GenType or an `image2d_t` type
   // without access qualifiers.
   bit IsAbstract = _IsAbstract;
+  bit IsFunctionCall = 0;
 }
 
 // List of integers.

--- a/clang/lib/Sema/SPIRVBuiltins.td
+++ b/clang/lib/Sema/SPIRVBuiltins.td
@@ -52,8 +52,9 @@ class FunctionExtension<string _Ext> : AbstractExtension<_Ext>;
 // FunctionExtension definitions.
 def FuncExtNone                          : FunctionExtension<"">;
 
-// Qualified Type.  These map to ASTContext::QualType.
-class QualType<string _Name, bit _IsAbstract=0, bit _IsSigned=0> {
+// Qualified Type.  These map to ASTContext::QualType or
+// a function taking an ASTContext.
+class QualType<string _Name, bit _IsAbstract=0, bit _IsSigned=0, bit _IsFunctionCall=0> {
   // Name of the field or function in a clang::ASTContext
   // E.g. Name="IntTy" for the int type, and "getIntPtrType()" for an intptr_t
   string Name = _Name;
@@ -62,6 +63,7 @@ class QualType<string _Name, bit _IsAbstract=0, bit _IsSigned=0> {
   // without access qualifiers.
   bit IsAbstract = _IsAbstract;
   bit IsSigned = _IsSigned;
+  bit IsFunctionCall = _IsFunctionCall;
 }
 
 // List of integers.
@@ -298,7 +300,7 @@ def Long      : IntType<"long",      QualType<"getIntTypeForBitwidth(64, true)",
 def ULong     : UIntType<"ulong",     QualType<"getIntTypeForBitwidth(64, false)">, 64>;
 def Float     : FPType<"float",     QualType<"FloatTy">, 32>;
 def Double    : FPType<"double",    QualType<"DoubleTy">, 64>;
-def Half      : FPType<"half",      QualType<"Float16Ty">, 16>;
+def Half      : FPType<"half",      QualType<"GetFloat16Type", 0, 0, 1>, 16>;
 def Void      : Type<"void",      QualType<"VoidTy">>;
 // FIXME: ensure this is portable...
 def Size      : Type<"size_t",    QualType<"getSizeType()">>;

--- a/clang/lib/Sema/SPIRVBuiltins.td
+++ b/clang/lib/Sema/SPIRVBuiltins.td
@@ -52,9 +52,11 @@ class FunctionExtension<string _Ext> : AbstractExtension<_Ext>;
 // FunctionExtension definitions.
 def FuncExtNone                          : FunctionExtension<"">;
 
-// Qualified Type.  These map to ASTContext::QualType or
-// a function taking an ASTContext.
-class QualType<string _Name, bit _IsAbstract=0, bit _IsSigned=0, bit _IsFunctionCall=0> {
+// Qualified Type.  These map to ASTContext::QualType.
+// TODO: Create a QualTypeFromASTContext.
+//       To fully make sense here, this class should represent
+//       the QualType only. How the QualType is accessed should be separated.
+class QualType<string _Name, bit _IsAbstract=0, bit _IsSigned=0> {
   // Name of the field or function in a clang::ASTContext
   // E.g. Name="IntTy" for the int type, and "getIntPtrType()" for an intptr_t
   string Name = _Name;
@@ -63,7 +65,20 @@ class QualType<string _Name, bit _IsAbstract=0, bit _IsSigned=0, bit _IsFunction
   // without access qualifiers.
   bit IsAbstract = _IsAbstract;
   bit IsSigned = _IsSigned;
-  bit IsFunctionCall = _IsFunctionCall;
+}
+
+// Qualified Type.  These map to a function taking an ASTContext
+// and returning a QualType.
+// Instead of direclty accessing ASTContext fields, the builtin lookup can
+// call a function to extract the correct type for the call.
+// The name will be interpreted as the function to call
+// rather than the field to access.
+class QualTypeFromFunction<string _Name, bit _IsAbstract=0, bit _IsSigned=0> :
+      QualType<_Name, _IsAbstract, _IsSigned> {
+// TODO: At the moment the user is expected to write the function outside this file.
+//       Although they could be generated in the .inc file and
+//       the user would only have to provide the body here
+//       (like it can be done for attributes for instance).
 }
 
 // List of integers.
@@ -300,7 +315,7 @@ def Long      : IntType<"long",      QualType<"getIntTypeForBitwidth(64, true)",
 def ULong     : UIntType<"ulong",     QualType<"getIntTypeForBitwidth(64, false)">, 64>;
 def Float     : FPType<"float",     QualType<"FloatTy">, 32>;
 def Double    : FPType<"double",    QualType<"DoubleTy">, 64>;
-def Half      : FPType<"half",      QualType<"GetFloat16Type", 0, 0, 1>, 16>;
+def Half      : FPType<"half",      QualTypeFromFunction<"GetFloat16Type">, 16>;
 def Void      : Type<"void",      QualType<"VoidTy">>;
 // FIXME: ensure this is portable...
 def Size      : Type<"size_t",    QualType<"getSizeType()">>;

--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -47,6 +47,8 @@
 #include <utility>
 #include <vector>
 
+static inline clang::QualType GetFloat16Type(clang::ASTContext &Context);
+
 #include "OpenCLBuiltins.inc"
 #include "SPIRVBuiltins.inc"
 
@@ -676,6 +678,10 @@ LLVM_DUMP_METHOD void LookupResult::dump() {
                << ":\n";
   for (NamedDecl *D : *this)
     D->dump();
+}
+
+static inline QualType GetFloat16Type(clang::ASTContext &Context) {
+  return Context.getLangOpts().OpenCL ? Context.HalfTy : Context.Float16Ty;
 }
 
 /// Get the QualType instances of the return type and arguments for a ProgModel

--- a/clang/test/Misc/nvptx.languageOptsOpenCL.cl
+++ b/clang/test/Misc/nvptx.languageOptsOpenCL.cl
@@ -22,11 +22,15 @@
 #endif
 #pragma OPENCL EXTENSION cl_clang_storage_class_specifiers: enable
 
-#ifdef cl_khr_fp16
-#error "Incorrect cl_khr_fp16 define"
-#endif
+// TODO: Temporarily disabling the following test as a work around for the
+// SYCL codepath until the cl_khr_fp16 is restricted to only the sycldevice triple.
+// link to issue https://github.com/intel/llvm/issues/1814
+
+// #ifdef cl_khr_fp16
+// #error "Incorrect cl_khr_fp16 define"
+// #endif
 #pragma OPENCL EXTENSION cl_khr_fp16: enable
-// expected-warning@-1{{unsupported OpenCL extension 'cl_khr_fp16' - ignoring}}
+// expected warning@-1{{unsupported OpenCL extension 'cl_khr_fp16' - ignoring}}
 
 // TODO: Temporarily disabling the following two tests as a work around for the
 // SYCL codepath until the cl_khr_int64_base_atomics and

--- a/clang/utils/TableGen/ClangProgModelBuiltinEmitter.cpp
+++ b/clang/utils/TableGen/ClangProgModelBuiltinEmitter.cpp
@@ -747,7 +747,7 @@ void BuiltinNameEmitter::EmitQualTypeFinder() {
          I++) {
       for (const auto *T :
            GenType->getValueAsDef("TypeList")->getValueAsListOfDefs("List")) {
-        if (T->getValueAsDef("QTName")->getValueAsBit("IsFunctionCall") == 1)
+        if (T->getValueAsDef("QTName")->isSubClassOf("QualTypeFromFunction"))
           OS << T->getValueAsDef("QTName")->getValueAsString("Name")
              << "(Context), ";
         else
@@ -791,7 +791,7 @@ void BuiltinNameEmitter::EmitQualTypeFinder() {
       continue;
     // Emit the cases for non generic, non image types.
     OS << "    case TID_" << T->getValueAsString("Name") << ":\n";
-    if (QT->getValueAsBit("IsFunctionCall") == 1)
+    if (QT->isSubClassOf("QualTypeFromFunction"))
       OS << "      QT.push_back(" << QT->getValueAsString("Name")
          << "(Context));\n";
     else

--- a/clang/utils/TableGen/ClangProgModelBuiltinEmitter.cpp
+++ b/clang/utils/TableGen/ClangProgModelBuiltinEmitter.cpp
@@ -747,8 +747,12 @@ void BuiltinNameEmitter::EmitQualTypeFinder() {
          I++) {
       for (const auto *T :
            GenType->getValueAsDef("TypeList")->getValueAsListOfDefs("List")) {
-        OS << "Context."
-           << T->getValueAsDef("QTName")->getValueAsString("Name") << ", ";
+        if (T->getValueAsDef("QTName")->getValueAsBit("IsFunctionCall") == 1)
+          OS << T->getValueAsDef("QTName")->getValueAsString("Name")
+             << "(Context), ";
+        else
+          OS << "Context."
+             << T->getValueAsDef("QTName")->getValueAsString("Name") << ", ";
       }
     }
     OS << "});\n";
@@ -787,8 +791,12 @@ void BuiltinNameEmitter::EmitQualTypeFinder() {
       continue;
     // Emit the cases for non generic, non image types.
     OS << "    case TID_" << T->getValueAsString("Name") << ":\n";
-    OS << "      QT.push_back(Context." << QT->getValueAsString("Name")
-       << ");\n";
+    if (QT->getValueAsBit("IsFunctionCall") == 1)
+      OS << "      QT.push_back(" << QT->getValueAsString("Name")
+         << "(Context));\n";
+    else
+      OS << "      QT.push_back(Context." << QT->getValueAsString("Name")
+         << ");\n";
     OS << "      break;\n";
   }
 

--- a/libclc/generic/include/clc/float/definitions.h
+++ b/libclc/generic/include/clc/float/definitions.h
@@ -71,8 +71,6 @@
 
 #ifdef cl_khr_fp16
 
-#if __OPENCL_VERSION__ >= 120
-
 #define HALF_DIG        3
 #define HALF_MANT_DIG   11
 #define HALF_MAX_10_EXP +4
@@ -84,7 +82,8 @@
 #define HALF_MAX        0x1.ffcp15h
 #define HALF_MIN        0x1.0p-14h
 #define HALF_EPSILON    0x1.0p-10h
+#define HALF_MAX_SQRT 0x1.0p+8h
+#define HALF_MIN_SQRT 0x1.0p-8h
 
-#endif
-
+#define M_PI_OVER_180_H 0x1.1ep-6h
 #endif

--- a/sycl/test/basic_tests/vec_convert_half.cpp
+++ b/sycl/test/basic_tests/vec_convert_half.cpp
@@ -1,4 +1,3 @@
-// XFAIL: cuda
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/built-ins/nan.cpp
+++ b/sycl/test/built-ins/nan.cpp
@@ -4,8 +4,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// XFAIL: cuda
-// CUDA fails with: ptxas fatal   : Unresolved extern function '_Z15__spirv_ocl_nanj'
+
 #include <CL/sycl.hpp>
 
 #include <cassert>


### PR DESCRIPTION
This patch enables 16 bits float in the libclc.

It also provides a better builtins binding (SPIRVBuiltins.td) for __fp16 (with native halfs) and _Float16.
It will now depends on the programing mode enabled.

Note: due to https://github.com/intel/llvm/issues/1814, we have to disable a test as a work around.

Signed-off-by: Victor Lomuller <victor@codeplay.com>