### PR TITLE
[Driver][SYCL] Add additional implied debug settings for AOT

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -476,7 +476,8 @@ static void addImpliedArgs(const llvm::Triple &Triple,
                            llvm::opt::ArgStringList &CmdArgs) {
   // Current implied args are for debug information and disabling of
   // optimizations.
-  auto addArgs = [&](llvm::opt::ArgStringList &CurArgList, bool IsGen = false) {
+  auto addOptDebugArgs = [&](llvm::opt::ArgStringList &CurArgList,
+                             bool IsGen = false) {
     if (Arg *A = Args.getLastArg(options::OPT_g_Group, options::OPT__SLASH_Z7))
       if (!A->getOption().matches(options::OPT_g0))
         CurArgList.push_back("-g");
@@ -486,14 +487,14 @@ static void addImpliedArgs(const llvm::Triple &Triple,
   // For FPGA and default device, pass along -g -cl-opt-disable
   if (Triple.getSubArch() == llvm::Triple::NoSubArch ||
       Triple.getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
-    addArgs(CmdArgs);
+    addOptDebugArgs(CmdArgs);
     return;
   }
   bool IsGen = Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
   // For CPU/Gen pass option list
   if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64 || IsGen) {
     llvm::opt::ArgStringList BeArgs;
-    addArgs(BeArgs, IsGen);
+    addOptDebugArgs(BeArgs, IsGen);
     if (!BeArgs.empty()) {
       SmallString<128> BeOpt;
       if (IsGen)

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -486,25 +486,25 @@ static void addImpliedArgs(const llvm::Triple &Triple,
       BeArgs.push_back("-g");
   if (Args.getLastArg(options::OPT_O0))
     BeArgs.push_back(IsGen ? "-O0" : "-cl-opt-disable");
+  if (BeArgs.empty())
+    return;
   if (Triple.getSubArch() == llvm::Triple::NoSubArch ||
       Triple.getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
     for (StringRef A : BeArgs)
       CmdArgs.push_back(Args.MakeArgString(A));
     return;
   }
-  if (!BeArgs.empty()) {
-    SmallString<128> BeOpt;
-    if (IsGen)
-      CmdArgs.push_back("-options");
-    else
-      BeOpt = "--bo=";
-    for (unsigned I = 0; I < BeArgs.size(); ++I) {
-      if (I)
-        BeOpt += ' ';
-      BeOpt += BeArgs[I];
-    }
-    CmdArgs.push_back(Args.MakeArgString(BeOpt));
+  SmallString<128> BeOpt;
+  if (IsGen)
+    CmdArgs.push_back("-options");
+  else
+    BeOpt = "--bo=";
+  for (unsigned I = 0; I < BeArgs.size(); ++I) {
+    if (I)
+      BeOpt += ' ';
+    BeOpt += BeArgs[I];
   }
+  CmdArgs.push_back(Args.MakeArgString(BeOpt));
 }
 
 void SYCLToolChain::TranslateBackendTargetArgs(const llvm::opt::ArgList &Args,

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -712,6 +712,24 @@
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS %s
 // CHK-TOOLS-IMPLIED-OPTS: clang-offload-wrapper{{.*}} "-compile-opts=-g -cl-opt-disable -DFOO1 -DFOO2"
 
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice -g -O0 -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-FPGA %s
+// RUN:   %clang_cl -### -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice -Zi -Od -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-FPGA %s
+// CHK-TOOLS-IMPLIED-OPTS-FPGA: aoc{{.*}} "-g" "-cl-opt-disable" "-DFOO1" "-DFOO2"
+
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -g -O0 -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-CPU %s
+// RUN:   %clang_cl -### -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -Zi -Od -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-CPU %s
+// CHK-TOOLS-IMPLIED-OPTS-CPU: opencl-aot{{.*}} "--bo=-g -cl-opt-disable" "-DFOO1" "-DFOO2"
+
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -g -O0 -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-GEN %s
+// RUN:   %clang_cl -### -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Zi -Od -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-GEN %s
+// CHK-TOOLS-IMPLIED-OPTS-GEN: ocloc{{.*}} "-options" "-g -O0" "-DFOO1" "-DFOO2"
+
 /// Check -Xsycl-target-linker option passing
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice -Xsycl-target-linker "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-FPGA-OPTS2 %s


### PR DESCRIPTION
The implied debug (-g) and optimization disabling (-O0) settings
being done for offload SYCL compilations were completed for default
device and FPGA targets.  This adds the implied options for GEN
and CPU targets.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>