### PR TITLE
[SYCL][CUDA] Add fsycl-targets to LIT

### DIFF
--- a/sycl/test/basic_tests/vec_op.cpp
+++ b/sycl/test/basic_tests/vec_op.cpp
@@ -1,9 +1,8 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// XFAIL: cuda
 //==------------ vec_op.cpp - SYCL vec operations basic test ---------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/built-ins/nan.cpp
+++ b/sycl/test/built-ins/nan.cpp
@@ -1,10 +1,11 @@
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %clangxx -fsycl -D HALF_IS_SUPPORTED %s -o %t_gpu.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -D HALF_IS_SUPPORTED %s -o %t_gpu.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 // XFAIL: cuda
+// CUDA fails with: ptxas fatal   : Unresolved extern function '_Z15__spirv_ocl_nanj'
 #include <CL/sycl.hpp>
 
 #include <cassert>


### PR DESCRIPTION
Add missing `-fsycl-targets=%sycl_triple` to more LIT tests.
This fixes one test for CUDA and prepares another to be looked into.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>