### PR TITLE
SPIRV patches

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVReader.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVReader.cpp
@@ -3470,6 +3470,18 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
                                       std::to_string(Kind));
       F->addAttribute(ArgNo + 1, Attr);
     }
+    if (BA->hasDecorate(DecorationFuncParamKindINTEL, 0, &Kind)) {
+      Attribute Attr = Attribute::get(*Context, kVCMetadata::VCArgumentKind,
+                                      std::to_string(Kind));
+      F->addAttribute(ArgNo + 1, Attr);
+    }
+    if (BA->hasDecorate(DecorationFuncParamDescINTEL)) {
+      auto Desc =
+          BA->getDecorationStringLiteral(DecorationFuncParamDescINTEL).front();
+      Attribute Attr =
+          Attribute::get(*Context, kVCMetadata::VCArgumentDesc, Desc);
+      F->addAttribute(ArgNo + 1, Attr);
+    }
   }
 
   // Do not add float control if there is no any

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -597,6 +597,19 @@ void LLVMToSPIRV::transVectorComputeMetadata(Function *F) {
           .getAsInteger(0, Kind);
       BA->addDecorate(DecorationFuncParamIOKind, Kind);
     }
+    if (Attrs.hasAttribute(ArgNo + 1, kVCMetadata::VCArgumentKind)) {
+      SPIRVWord Kind;
+      Attrs.getAttribute(ArgNo + 1, kVCMetadata::VCArgumentKind)
+          .getValueAsString()
+          .getAsInteger(0, Kind);
+      BA->addDecorate(DecorationFuncParamKindINTEL, Kind);
+    }
+    if (Attrs.hasAttribute(ArgNo + 1, kVCMetadata::VCArgumentDesc)) {
+      StringRef Desc =
+          Attrs.getAttribute(ArgNo + 1, kVCMetadata::VCArgumentDesc)
+              .getValueAsString();
+      BA->addDecorate(new SPIRVDecorateFuncParamDescAttr(BA, Desc.str()));
+    }
   }
 }
 

--- a/llvm-spirv/lib/SPIRV/VectorComputeUtil.h
+++ b/llvm-spirv/lib/SPIRV/VectorComputeUtil.h
@@ -116,6 +116,8 @@ const static char VCSLMSize[] = "VCSLMSize";
 const static char VCGlobalVariable[] = "VCGlobalVariable";
 const static char VCVolatile[] = "VCVolatile";
 const static char VCByteOffset[] = "VCByteOffset";
+const static char VCArgumentKind[] = "VCArgumentKind";
+const static char VCArgumentDesc[] = "VCArgumentDesc";
 } // namespace kVCMetadata
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
@@ -104,6 +104,9 @@ void SPIRVDecorate::encode(spv_ostream &O) const {
   case DecorationUserSemantic:
     SPIRVDecorateUserSemanticAttr::encodeLiterals(Encoder, Literals);
     break;
+  case DecorationFuncParamDescINTEL:
+    SPIRVDecorateFuncParamDescAttr::encodeLiterals(Encoder, Literals);
+    break;
   default:
     Encoder << Literals;
   }
@@ -130,6 +133,9 @@ void SPIRVDecorate::decode(std::istream &I) {
   case DecorationUserSemantic:
     SPIRVDecorateUserSemanticAttr::decodeLiterals(Decoder, Literals);
     break;
+  case DecorationFuncParamDescINTEL:
+    SPIRVDecorateFuncParamDescAttr::decodeLiterals(Decoder, Literals);
+    break;
   default:
     Decoder >> Literals;
   }
@@ -148,6 +154,9 @@ void SPIRVMemberDecorate::encode(spv_ostream &O) const {
     break;
   case DecorationUserSemantic:
     SPIRVDecorateUserSemanticAttr::encodeLiterals(Encoder, Literals);
+    break;
+  case DecorationFuncParamDescINTEL:
+    SPIRVDecorateFuncParamDescAttr::encodeLiterals(Encoder, Literals);
     break;
   default:
     Encoder << Literals;
@@ -171,6 +180,9 @@ void SPIRVMemberDecorate::decode(std::istream &I) {
     break;
   case DecorationUserSemantic:
     SPIRVDecorateUserSemanticAttr::decodeLiterals(Decoder, Literals);
+    break;
+  case DecorationFuncParamDescINTEL:
+    SPIRVDecorateFuncParamDescAttr::decodeLiterals(Decoder, Literals);
     break;
   default:
     Decoder >> Literals;

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -413,6 +413,15 @@ public:
       : SPIRVDecorateStrAttrBase(TheTarget, AnnotateString) {}
 };
 
+class SPIRVDecorateFuncParamDescAttr
+    : public SPIRVDecorateStrAttrBase<DecorationFuncParamDescINTEL> {
+public:
+  //  Complete constructor for UserSemantic decoration
+  SPIRVDecorateFuncParamDescAttr(SPIRVEntry *TheTarget,
+                                 const std::string &AnnotateString)
+      : SPIRVDecorateStrAttrBase(TheTarget, AnnotateString) {}
+};
+
 class SPIRVDecorateMergeINTELAttr : public SPIRVDecorate {
 public:
   // Complete constructor for MergeINTEL decoration

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -393,6 +393,8 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
                {CapabilityVectorComputeINTEL});
   ADD_VEC_INIT(DecorationFuncParamIOKind, {CapabilityVectorComputeINTEL});
   ADD_VEC_INIT(DecorationStackCallINTEL, {CapabilityVectorComputeINTEL});
+  ADD_VEC_INIT(DecorationFuncParamKindINTEL, {CapabilityVectorComputeINTEL});
+  ADD_VEC_INIT(DecorationFuncParamDescINTEL, {CapabilityVectorComputeINTEL});
 }
 
 template <> inline void SPIRVMap<BuiltIn, SPIRVCapVec>::init() {

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -426,6 +426,8 @@ inline bool isValid(spv::Decoration V) {
   case DecorationReferencedIndirectlyINTEL:
   case DecorationVectorComputeFunctionINTEL:
   case DecorationStackCallINTEL:
+  case DecorationFuncParamKindINTEL:
+  case DecorationFuncParamDescINTEL:
   case DecorationVectorComputeVariableINTEL:
   case DecorationGlobalVariableOffsetINTEL:
   case DecorationFuncParamIOKind:

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -366,6 +366,8 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationIOPipeStorageINTEL, "IOPipeStorageINTEL");
   add(DecorationVectorComputeFunctionINTEL, "VectorComputeFunctionINTEL");
   add(DecorationStackCallINTEL, "StackCallINTEL");
+  add(DecorationFuncParamKindINTEL, "FuncParamKindINTEL");
+  add(DecorationFuncParamDescINTEL, "FuncParamDescINTEL");
   add(DecorationVectorComputeVariableINTEL, "VectorComputeVariableINTEL");
   add(DecorationGlobalVariableOffsetINTEL, "GlobalVariableOffsetINTEL");
   add(DecorationFuncParamIOKind, "FuncParamIOKind");

--- a/llvm-spirv/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/spirv.hpp
@@ -477,6 +477,8 @@ enum Decoration {
   DecorationRestrictPointerEXT = 5355,
   DecorationAliasedPointer = 5356,
   DecorationAliasedPointerEXT = 5356,
+  DecorationFuncParamKindINTEL = 9624,
+  DecorationFuncParamDescINTEL = 9625,
   DecorationReferencedIndirectlyINTEL = 5602,
   DecorationSideEffectsINTEL = 5608,
   DecorationVectorComputeVariableINTEL = 5624,

--- a/llvm-spirv/test/transcoding/decoration_func_param_desc.ll
+++ b/llvm-spirv/test/transcoding/decoration_func_param_desc.ll
@@ -1,0 +1,32 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute
+; RUN: llvm-spirv %t.spv -o %t.spt --to-text
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck %s --input-file %t.spt -check-prefix=SPV
+; RUN: FileCheck %s --input-file %t.ll  -check-prefix=LLVM
+
+; ModuleID = 'slm.bc'
+source_filename = "slm.cpp"
+target datalayout = "e-p:64:64-i64:64-n8:16:32"
+target triple = "spir"
+
+; LLVM: @k_rte(i32 "VCArgumentDesc"="0" %ibuf, i32 "VCArgumentDesc"="1" %obuf)
+; SPV: Name [[IBUF:[0-9]+]] "ibuf"
+; SPV: Name [[OBUF:[0-9]+]] "obuf"
+; SPV: Decorate [[IBUF]] FuncParamDescINTEL "0"
+; SPV: Decorate [[OBUF]] FuncParamDescINTEL "1"
+; Function Attrs: noinline norecurse nounwind readnone
+define dso_local dllexport spir_kernel void @k_rte(i32 "VCArgumentDesc"="0" %ibuf, i32 "VCArgumentDesc"="1" %obuf) local_unnamed_addr #1 {
+entry:
+  ret void
+}
+
+attributes #1 = { noinline norecurse nounwind readnone "VCFunction" "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+; Note
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 8.0.1"}

--- a/llvm-spirv/test/transcoding/decoration_func_param_kind.ll
+++ b/llvm-spirv/test/transcoding/decoration_func_param_kind.ll
@@ -1,0 +1,32 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute
+; RUN: llvm-spirv %t.spv -o %t.spt --to-text
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck %s --input-file %t.spt -check-prefix=SPV
+; RUN: FileCheck %s --input-file %t.ll  -check-prefix=LLVM
+
+; ModuleID = 'slm.bc'
+source_filename = "slm.cpp"
+target datalayout = "e-p:64:64-i64:64-n8:16:32"
+target triple = "spir"
+
+; LLVM: @k_rte(i32 "VCArgumentKind"="0" %ibuf, i32 "VCArgumentKind"="1" %obuf)
+; SPV: Name [[IBUF:[0-9]+]] "ibuf"
+; SPV: Name [[OBUF:[0-9]+]] "obuf"
+; SPV: Decorate [[IBUF]] FuncParamKindINTEL 0
+; SPV: Decorate [[OBUF]] FuncParamKindINTEL 1
+; Function Attrs: noinline norecurse nounwind readnone
+define dso_local dllexport spir_kernel void @k_rte(i32 "VCArgumentKind"="0" %ibuf, i32 "VCArgumentKind"="1" %obuf) local_unnamed_addr #1 {
+entry:
+  ret void
+}
+
+attributes #1 = { noinline norecurse nounwind readnone "VCFunction" "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+; Note
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 8.0.1"}


### PR DESCRIPTION
This is a workaround patch for some of Vector Compute metadata. It will be removed in future