### PR TITLE
[SYCL] Extend shuffles to TriviallyCopyable types

### DIFF
--- a/sycl/include/CL/sycl/detail/spirv.hpp
+++ b/sycl/include/CL/sycl/detail/spirv.hpp
@@ -334,8 +334,7 @@ using EnableIfBitcastShuffle =
                         T>;
 
 template <typename T>
-using ConvertToNativeShuffleType_t =
-    select_apply_cl_scalar_t<T, uint8_t, uint16_t, uint32_t, uint64_t>;
+using ConvertToNativeShuffleType_t = select_cl_scalar_integral_unsigned_t<T>;
 
 template <typename T>
 EnableIfBitcastShuffle<T> SubgroupShuffle(T x, id<1> local_id) {

--- a/sycl/include/CL/sycl/detail/spirv.hpp
+++ b/sycl/include/CL/sycl/detail/spirv.hpp
@@ -387,7 +387,7 @@ using EnableIfGenericShuffle =
                         T>;
 
 template <typename T, typename ShuffleFunctor>
-void GenericShuffle(ShuffleFunctor ShuffleBytes) {
+void GenericShuffle(const ShuffleFunctor &ShuffleBytes) {
   if (sizeof(T) >= sizeof(uint64_t)) {
 #pragma unroll
     for (size_t Offset = 0; Offset < sizeof(T); Offset += sizeof(uint64_t)) {

--- a/sycl/include/CL/sycl/detail/spirv.hpp
+++ b/sycl/include/CL/sycl/detail/spirv.hpp
@@ -290,6 +290,38 @@ AtomicMax(multi_ptr<T, AddressSpace> MPtr, intel::memory_scope Scope,
   return __spirv_AtomicMax(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
+template <typename T>
+using EnableIfNativeShuffle =
+    detail::enable_if_t<detail::is_arithmetic<T>::value, T>;
+
+template <typename T>
+EnableIfNativeShuffle<T> SubgroupShuffle(T x, id<1> local_id) {
+  using OCLT = detail::ConvertToOpenCLType_t<T>;
+  return __spirv_SubgroupShuffleINTEL(OCLT(x),
+                                      static_cast<uint32_t>(local_id.get(0)));
+}
+
+template <typename T>
+EnableIfNativeShuffle<T> SubgroupShuffleXor(T x, id<1> local_id) {
+  using OCLT = detail::ConvertToOpenCLType_t<T>;
+  return __spirv_SubgroupShuffleXorINTEL(
+      OCLT(x), static_cast<uint32_t>(local_id.get(0)));
+}
+
+template <typename T>
+EnableIfNativeShuffle<T> SubgroupShuffleDown(T x, T y, id<1> local_id) {
+  using OCLT = detail::ConvertToOpenCLType_t<T>;
+  return __spirv_SubgroupShuffleDownINTEL(
+      OCLT(x), OCLT(y), static_cast<uint32_t>(local_id.get(0)));
+}
+
+template <typename T>
+EnableIfNativeShuffle<T> SubgroupShuffleUp(T x, T y, id<1> local_id) {
+  using OCLT = detail::ConvertToOpenCLType_t<T>;
+  return __spirv_SubgroupShuffleUpINTEL(OCLT(x), OCLT(y),
+                                        static_cast<uint32_t>(local_id.get(0)));
+}
+
 } // namespace spirv
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -202,7 +202,7 @@ struct sub_group {
 
   template <typename T> T shuffle(T x, id_type local_id) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    return sycl::detail::sub_group::shuffle(x, local_id);
+    return sycl::detail::spirv::SubgroupShuffle(x, local_id);
 #else
     (void)x;
     (void)local_id;
@@ -213,7 +213,7 @@ struct sub_group {
 
   template <typename T> T shuffle_down(T x, uint32_t delta) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    return sycl::detail::sub_group::shuffle_down(x, x, delta);
+    return sycl::detail::spirv::SubgroupShuffleDown(x, x, delta);
 #else
     (void)x;
     (void)delta;
@@ -224,7 +224,7 @@ struct sub_group {
 
   template <typename T> T shuffle_up(T x, uint32_t delta) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    return sycl::detail::sub_group::shuffle_up(x, x, delta);
+    return sycl::detail::spirv::SubgroupShuffleUp(x, x, delta);
 #else
     (void)x;
     (void)delta;
@@ -235,7 +235,7 @@ struct sub_group {
 
   template <typename T> T shuffle_xor(T x, id_type value) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    return sycl::detail::sub_group::shuffle_xor(x, value);
+    return sycl::detail::spirv::SubgroupShuffleXor(x, value);
 #else
     (void)x;
     (void)value;
@@ -251,7 +251,7 @@ struct sub_group {
   __SYCL_DEPRECATED("Two-input sub-group shuffles are deprecated.")
   T shuffle(T x, T y, id_type local_id) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    return sycl::detail::sub_group::shuffle_down(
+    return sycl::detail::spirv::SubgroupShuffleDown(
         x, y, (local_id - get_local_id()).get(0));
 #else
     (void)x;
@@ -266,7 +266,7 @@ struct sub_group {
   __SYCL_DEPRECATED("Two-input sub-group shuffles are deprecated.")
   T shuffle_down(T current, T next, uint32_t delta) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    return sycl::detail::sub_group::shuffle_down(current, next, delta);
+    return sycl::detail::spirv::SubgroupShuffleDown(current, next, delta);
 #else
     (void)current;
     (void)next;
@@ -280,7 +280,7 @@ struct sub_group {
   __SYCL_DEPRECATED("Two-input sub-group shuffles are deprecated.")
   T shuffle_up(T previous, T current, uint32_t delta) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    return sycl::detail::sub_group::shuffle_up(previous, current, delta);
+    return sycl::detail::spirv::SubgroupShuffleUp(previous, current, delta);
 #else
     (void)previous;
     (void)current;

--- a/sycl/include/CL/sycl/intel/sub_group.hpp
+++ b/sycl/include/CL/sycl/intel/sub_group.hpp
@@ -46,28 +46,6 @@ using AcceptableForLocalLoadStore =
                   Space == access::address_space::local_space>;
 
 #ifdef __SYCL_DEVICE_ONLY__
-#define __SYCL_SG_GENERATE_BODY_1ARG(name, SPIRVOperation)                     \
-  template <typename T> T name(T x, id<1> local_id) {                          \
-    using OCLT = sycl::detail::ConvertToOpenCLType_t<T>;                       \
-    return __spirv_##SPIRVOperation(OCLT(x), local_id.get(0));                 \
-  }
-
-__SYCL_SG_GENERATE_BODY_1ARG(shuffle, SubgroupShuffleINTEL)
-__SYCL_SG_GENERATE_BODY_1ARG(shuffle_xor, SubgroupShuffleXorINTEL)
-
-#undef __SYCL_SG_GENERATE_BODY_1ARG
-
-#define __SYCL_SG_GENERATE_BODY_2ARG(name, SPIRVOperation)                     \
-  template <typename T> T name(T A, T B, uint32_t Delta) {                     \
-    using OCLT = sycl::detail::ConvertToOpenCLType_t<T>;                       \
-    return __spirv_##SPIRVOperation(OCLT(A), OCLT(B), Delta);                  \
-  }
-
-__SYCL_SG_GENERATE_BODY_2ARG(shuffle_down, SubgroupShuffleDownINTEL)
-__SYCL_SG_GENERATE_BODY_2ARG(shuffle_up, SubgroupShuffleUpINTEL)
-
-#undef __SYCL_SG_GENERATE_BODY_2ARG
-
 template <typename T, access::address_space Space>
 T load(const multi_ptr<T, Space> src) {
   using BlockT = SelectBlockT<T>;

--- a/sycl/test/sub_group/generic-shuffle.cpp
+++ b/sycl/test/sub_group/generic-shuffle.cpp
@@ -15,9 +15,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "helper.hpp"
 #include <CL/sycl.hpp>
 #include <complex>
-#include <helper.hpp>
 template <typename T>
 class pointer_kernel;
 

--- a/sycl/test/sub_group/generic-shuffle.cpp
+++ b/sycl/test/sub_group/generic-shuffle.cpp
@@ -1,0 +1,209 @@
+// UNSUPPORTED: cuda
+// CUDA compilation and runtime do not yet support sub-groups.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUNx: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+//
+//==-- generic_shuffle.cpp - SYCL sub_group generic shuffle test *- C++ -*--==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+#include <complex>
+#include <helper.hpp>
+template <typename T>
+class pointer_kernel;
+
+using namespace cl::sycl;
+
+template <typename T>
+void check_pointer(queue &Queue, size_t G = 240, size_t L = 60) {
+  try {
+    nd_range<1> NdRange(G, L);
+    buffer<T *> buf(G);
+    buffer<T *> buf_up(G);
+    buffer<T *> buf_down(G);
+    buffer<T *> buf_xor(G);
+    buffer<size_t> sgsizebuf(1);
+    Queue.submit([&](handler &cgh) {
+      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      auto acc_up = buf_up.template get_access<access::mode::read_write>(cgh);
+      auto acc_down =
+          buf_down.template get_access<access::mode::read_write>(cgh);
+      auto acc_xor = buf_xor.template get_access<access::mode::read_write>(cgh);
+      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
+
+      cgh.parallel_for<pointer_kernel<T>>(NdRange, [=](nd_item<1> NdItem) {
+        intel::sub_group SG = NdItem.get_sub_group();
+        uint32_t wggid = NdItem.get_global_id(0);
+        uint32_t sgid = SG.get_group_id().get(0);
+        if (wggid == 0)
+          sgsizeacc[0] = SG.get_max_local_range()[0];
+
+        T *ptr = static_cast<T *>(0x0) + wggid;
+
+        /*GID of middle element in every subgroup*/
+        acc[NdItem.get_global_id()] =
+            SG.shuffle(ptr, SG.get_max_local_range()[0] / 2);
+
+        /* Save GID-SGID */
+        acc_up[NdItem.get_global_id()] = SG.shuffle_up(ptr, sgid);
+
+        /* Save GID+SGID */
+        acc_down[NdItem.get_global_id()] = SG.shuffle_down(ptr, sgid);
+
+        /* Save GID XOR SGID */
+        acc_xor[NdItem.get_global_id()] = SG.shuffle_xor(ptr, sgid);
+      });
+    });
+    auto acc = buf.template get_access<access::mode::read_write>();
+    auto acc_up = buf_up.template get_access<access::mode::read_write>();
+    auto acc_down = buf_down.template get_access<access::mode::read_write>();
+    auto acc_xor = buf_xor.template get_access<access::mode::read_write>();
+    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
+
+    size_t sg_size = sgsizeacc[0];
+    int SGid = 0;
+    for (int j = 0; j < G; j++) {
+      if (j % L % sg_size == 0) {
+        SGid++;
+      }
+      if (j % L == 0) {
+        SGid = 0;
+      }
+
+      /*GID of middle element in every subgroup*/
+      exit_if_not_equal(acc[j], static_cast<T *>(0x0) + (j / L * L + SGid * sg_size + sg_size / 2),
+                        "shuffle");
+
+      /* Value GID+SGID for all element except last SGID in SG*/
+      if (j % L % sg_size + SGid < sg_size && j % L + SGid < L) {
+        exit_if_not_equal(acc_down[j], static_cast<T *>(0x0) + (j + SGid), "shuffle_down");
+      }
+
+      /* Value GID-SGID for all element except first SGID in SG*/
+      if (j % L % sg_size >= SGid) {
+        exit_if_not_equal(acc_up[j], static_cast<T *>(0x0) + (j - SGid), "shuffle_up");
+      }
+
+      /* GID XOR SGID */
+      exit_if_not_equal(acc_xor[j], static_cast<T *>(0x0) + (j ^ SGid), "shuffle_xor");
+    }
+  } catch (exception e) {
+    std::cout << "SYCL exception caught: " << e.what();
+    exit(1);
+  }
+}
+
+template <typename T, typename Generator>
+void check_struct(queue &Queue, Generator& Gen, size_t G = 240, size_t L = 60) {
+
+  // Fill a vector with values that will be shuffled
+  std::vector<T> values(G);
+  std::generate(values.begin(), values.end(), Gen);
+
+  try {
+    nd_range<1> NdRange(G, L);
+    buffer<T> buf(G);
+    buffer<T> buf_up(G);
+    buffer<T> buf_down(G);
+    buffer<T> buf_xor(G);
+    buffer<size_t> sgsizebuf(1);
+    buffer<T> buf_in(values.data(), values.size());
+    Queue.submit([&](handler &cgh) {
+      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      auto acc_up = buf_up.template get_access<access::mode::read_write>(cgh);
+      auto acc_down =
+          buf_down.template get_access<access::mode::read_write>(cgh);
+      auto acc_xor = buf_xor.template get_access<access::mode::read_write>(cgh);
+      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
+      auto in = buf_in.template get_access<access::mode::read>(cgh);
+
+      cgh.parallel_for<pointer_kernel<T>>(NdRange, [=](nd_item<1> NdItem) {
+        intel::sub_group SG = NdItem.get_sub_group();
+        uint32_t wggid = NdItem.get_global_id(0);
+        uint32_t sgid = SG.get_group_id().get(0);
+        if (wggid == 0)
+          sgsizeacc[0] = SG.get_max_local_range()[0];
+
+        T val = in[wggid];
+
+        /*GID of middle element in every subgroup*/
+        acc[NdItem.get_global_id()] =
+            SG.shuffle(val, SG.get_max_local_range()[0] / 2);
+
+        /* Save GID-SGID */
+        acc_up[NdItem.get_global_id()] = SG.shuffle_up(val, sgid);
+
+        /* Save GID+SGID */
+        acc_down[NdItem.get_global_id()] = SG.shuffle_down(val, sgid);
+
+        /* Save GID XOR SGID */
+        acc_xor[NdItem.get_global_id()] = SG.shuffle_xor(val, sgid);
+      });
+    });
+    auto acc = buf.template get_access<access::mode::read_write>();
+    auto acc_up = buf_up.template get_access<access::mode::read_write>();
+    auto acc_down = buf_down.template get_access<access::mode::read_write>();
+    auto acc_xor = buf_xor.template get_access<access::mode::read_write>();
+    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
+
+    size_t sg_size = sgsizeacc[0];
+    int SGid = 0;
+    for (int j = 0; j < G; j++) {
+      if (j % L % sg_size == 0) {
+        SGid++;
+      }
+      if (j % L == 0) {
+        SGid = 0;
+      }
+
+      /*GID of middle element in every subgroup*/
+      exit_if_not_equal(acc[j], values[j / L * L + SGid * sg_size + sg_size / 2],
+                        "shuffle");
+
+      /* Value GID+SGID for all element except last SGID in SG*/
+      if (j % L % sg_size + SGid < sg_size && j % L + SGid < L) {
+        exit_if_not_equal(acc_down[j], values[j + SGid], "shuffle_down");
+      }
+
+      /* Value GID-SGID for all element except first SGID in SG*/
+      if (j % L % sg_size >= SGid) {
+        exit_if_not_equal(acc_up[j], values[j - SGid], "shuffle_up");
+      }
+
+      /* GID XOR SGID */
+      exit_if_not_equal(acc_xor[j], values[j ^ SGid], "shuffle_xor");
+    }
+  } catch (exception e) {
+    std::cout << "SYCL exception caught: " << e.what();
+    exit(1);
+  }
+}
+
+int main() {
+  queue Queue;
+  if (!Queue.get_device().has_extension("cl_intel_subgroups")) {
+    std::cout << "Skipping test\n";
+    return 0;
+  }
+
+  // Test shuffle of pointer types
+  check_pointer<int>(Queue);
+
+  // Test shuffle of non-native types
+  auto ComplexFloatGenerator = [state = std::complex<float>(0, 1)]() mutable {
+    return state += std::complex<float>(2, 2);
+  };
+  check_struct<std::complex<float>>(Queue, ComplexFloatGenerator);
+
+  std::cout << "Test passed." << std::endl;
+  return 0;
+}

--- a/sycl/test/sub_group/generic-shuffle.cpp
+++ b/sycl/test/sub_group/generic-shuffle.cpp
@@ -204,6 +204,11 @@ int main() {
   };
   check_struct<std::complex<float>>(Queue, ComplexFloatGenerator);
 
+  auto ComplexDoubleGenerator = [state = std::complex<double>(0, 1)]() mutable {
+    return state += std::complex<double>(2, 2);
+  };
+  check_struct<std::complex<double>>(Queue, ComplexDoubleGenerator);
+
   std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test/sub_group/generic-shuffle.cpp
+++ b/sycl/test/sub_group/generic-shuffle.cpp
@@ -103,7 +103,7 @@ void check_pointer(queue &Queue, size_t G = 240, size_t L = 60) {
 }
 
 template <typename T, typename Generator>
-void check_struct(queue &Queue, Generator& Gen, size_t G = 240, size_t L = 60) {
+void check_struct(queue &Queue, Generator &Gen, size_t G = 240, size_t L = 60) {
 
   // Fill a vector with values that will be shuffled
   std::vector<T> values(G);

--- a/sycl/test/sub_group/generic-shuffle.cpp
+++ b/sycl/test/sub_group/generic-shuffle.cpp
@@ -4,7 +4,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUNx: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
 //==-- generic_shuffle.cpp - SYCL sub_group generic shuffle test *- C++ -*--==//

--- a/sycl/test/sub_group/helper.hpp
+++ b/sycl/test/sub_group/helper.hpp
@@ -122,7 +122,7 @@ void exit_if_not_equal(std::complex<T> val, std::complex<T> ref, const char *nam
 }
 
 template <typename T>
-void exit_if_not_equal(T* val, T* ref, const char *name) {
+void exit_if_not_equal(T *val, T *ref, const char *name) {
   if ((val - ref) != 0) {
     std::cout << "Unexpected result for " << name << ": " << val
               << " expected value: " << ref << std::endl;

--- a/sycl/test/sub_group/helper.hpp
+++ b/sycl/test/sub_group/helper.hpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 #include <CL/sycl.hpp>
 #include <cmath>
+#include <complex>
 #include <iostream>
 
 using namespace cl::sycl;
@@ -108,6 +109,24 @@ template <typename T> void exit_if_not_equal(T val, T ref, const char *name) {
                 << " expected value: " << (long)ref << std::endl;
       exit(1);
     }
+  }
+}
+
+template <typename T>
+void exit_if_not_equal(std::complex<T> val, std::complex<T> ref, const char *name) {
+  if (std::fabs(val.real() - ref.real()) > 0.01 || std::fabs(val.imag() - ref.imag()) > 0.01) {
+    std::cout << "Unexpected result for " << name << ": " << val
+              << " expected value: " << ref << std::endl;
+    exit(1);
+  }
+}
+
+template <typename T>
+void exit_if_not_equal(T* val, T* ref, const char *name) {
+  if ((val - ref) != 0) {
+    std::cout << "Unexpected result for " << name << ": " << val
+              << " expected value: " << ref << std::endl;
+    exit(1);
   }
 }
 


### PR DESCRIPTION
Any 8-bit, 16-bit, 32-bit or 64-bit type that is TriviallyCopyable
can be implemented by existing shuffles and bit_cast.

Any TriviallyCopyable type can be shuffled by breaking it into smaller chunks
and shuffling each chunk in turn.  The current approach divides types into
64-bit chunks, then falls back to 32-, 16- or 8-bit chunks to handle the
remainder.

---

This PR is a step towards implementing the functionality requested by https://github.com/intel/llvm/issues/1885 and https://github.com/intel/llvm/issues/1947 for sub-groups.  Sub-group algorithms applied to generic types can be implemented on top of these generic shuffles.