### PR TITLE
[SYCL][NFC][SUBGROUPS] Separate half/double type tests from full type …

### DIFF
--- a/sycl/test/sub_group/broadcast.hpp
+++ b/sycl/test/sub_group/broadcast.hpp
@@ -1,0 +1,54 @@
+//==--------- broadcast.hpp - SYCL sub_group broadcast test ----*- C++ -*---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "helper.hpp"
+#include <CL/sycl.hpp>
+template <typename T>
+class sycl_subgr;
+using namespace cl::sycl;
+template <typename T>
+void check(queue &Queue) {
+  const int G = 240, L = 60;
+  try {
+    nd_range<1> NdRange(G, L);
+    buffer<T> syclbuf(G);
+    buffer<size_t> sgsizebuf(1);
+    Queue.submit([&](handler &cgh) {
+      auto syclacc = syclbuf.template get_access<access::mode::read_write>(cgh);
+      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<sycl_subgr<T>>(NdRange, [=](nd_item<1> NdItem) {
+        intel::sub_group SG = NdItem.get_sub_group();
+        /*Broadcast GID of element with SGLID == SGID */
+        syclacc[NdItem.get_global_id()] =
+            broadcast(SG, T(NdItem.get_global_id(0)), SG.get_group_id());
+        if (NdItem.get_global_id(0) == 0)
+          sgsizeacc[0] = SG.get_max_local_range()[0];
+      });
+    });
+    auto syclacc = syclbuf.template get_access<access::mode::read_write>();
+    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
+    size_t sg_size = sgsizeacc[0];
+    if (sg_size == 0)
+      sg_size = L;
+    int WGid = -1, SGid = 0;
+    for (int j = 0; j < G; j++) {
+      if (j % L % sg_size == 0) {
+        SGid++;
+      }
+      if (j % L == 0) {
+        WGid++;
+        SGid = 0;
+      }
+      exit_if_not_equal<T>(syclacc[j], L * WGid + SGid + SGid * sg_size,
+                           "broadcasted value");
+    }
+  } catch (exception e) {
+    std::cout << "SYCL exception caught: " << e.what();
+    exit(1);
+  }
+}

--- a/sycl/test/sub_group/broadcast_fp16.cpp
+++ b/sycl/test/sub_group/broadcast_fp16.cpp
@@ -1,21 +1,18 @@
 // UNSUPPORTED: cuda
 // CUDA compilation and runtime do not yet support sub-groups.
-//
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-//==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+//==--------- broadcast_fp16.cpp - SYCL sub_group broadcast test ----*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===---------------------------------------------------------------------------===//
 
-#include "scan.hpp"
+#include "broadcast.hpp"
 
 int main() {
   queue Queue;
@@ -23,11 +20,6 @@ int main() {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int>(Queue);
-  check<unsigned int>(Queue);
-  check<long>(Queue);
-  check<unsigned long>(Queue);
-  check<float>(Queue);
-  std::cout << "Test passed." << std::endl;
+  check<cl::sycl::half>(Queue);
   return 0;
 }

--- a/sycl/test/sub_group/broadcast_fp64.cpp
+++ b/sycl/test/sub_group/broadcast_fp64.cpp
@@ -1,21 +1,21 @@
 // UNSUPPORTED: cuda
 // CUDA compilation and runtime do not yet support sub-groups.
-//
+
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-//==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//
+//==--------- broadcast_fp64.cpp - SYCL sub_group broadcast test ----*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===---------------------------------------------------------------------------===//
 
-#include "scan.hpp"
+#include "broadcast.hpp"
 
 int main() {
   queue Queue;
@@ -23,11 +23,7 @@ int main() {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int>(Queue);
-  check<unsigned int>(Queue);
-  check<long>(Queue);
-  check<unsigned long>(Queue);
-  check<float>(Queue);
+  check<double>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test/sub_group/reduce.cpp
+++ b/sycl/test/sub_group/reduce.cpp
@@ -1,13 +1,11 @@
 // UNSUPPORTED: cuda
 // CUDA compilation and runtime do not yet support sub-groups.
 //
-// RUN: %clangxx -fsycl -std=c++14 %s -o %t.out
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -std=c++14 -D SG_GPU %s -o %t_gpu.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-
 //==--------------- reduce.cpp - SYCL sub_group reduce test ----*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -16,93 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "helper.hpp"
-#include <CL/sycl.hpp>
-
-template <typename T, class BinaryOperation>
-class sycl_subgr;
-
-using namespace cl::sycl;
-
-template <typename T, class BinaryOperation>
-void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
-              size_t G = 240, size_t L = 60) {
-  try {
-    nd_range<1> NdRange(G, L);
-    buffer<T> buf(G);
-    buffer<size_t> sgsizebuf(1);
-    Queue.submit([&](handler &cgh) {
-      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
-      auto acc = buf.template get_access<access::mode::read_write>(cgh);
-      cgh.parallel_for<sycl_subgr<T, BinaryOperation>>(
-          NdRange, [=](nd_item<1> NdItem) {
-            intel::sub_group sg = NdItem.get_sub_group();
-            if (skip_init) {
-              acc[NdItem.get_global_id(0)] =
-                  reduce(sg, T(NdItem.get_global_id(0)), op);
-            } else {
-              acc[NdItem.get_global_id(0)] =
-                  reduce(sg, T(NdItem.get_global_id(0)), init, op);
-            }
-            if (NdItem.get_global_id(0) == 0)
-              sgsizeacc[0] = sg.get_max_local_range()[0];
-          });
-    });
-    auto acc = buf.template get_access<access::mode::read_write>();
-    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
-    size_t sg_size = sgsizeacc[0];
-    int WGid = -1, SGid = 0;
-    T result = init;
-    for (int j = 0; j < G; j++) {
-      if (j % L % sg_size == 0) {
-        SGid++;
-        result = init;
-        for (int i = j; (i % L && i % L % sg_size) || (i == j); i++) {
-          result = op(result, T(i));
-        }
-      }
-      if (j % L == 0) {
-        WGid++;
-        SGid = 0;
-      }
-      std::string name =
-          std::string("reduce_") + typeid(BinaryOperation).name();
-      exit_if_not_equal<T>(acc[j], result, name.c_str());
-    }
-  } catch (exception e) {
-    std::cout << "SYCL exception caught: " << e.what();
-    exit(1);
-  }
-}
-
-template <typename T>
-void check(queue &Queue, size_t G = 240, size_t L = 60) {
-  // limit data range for half to avoid rounding issues
-  if (std::is_same<T, cl::sycl::half>::value) {
-    G = 64;
-    L = 32;
-  }
-
-  check_op<T>(Queue, T(L), intel::plus<T>(), false, G, L);
-  check_op<T>(Queue, T(0), intel::plus<T>(), true, G, L);
-
-  check_op<T>(Queue, T(0), intel::minimum<T>(), false, G, L);
-  check_op<T>(Queue, T(G), intel::minimum<T>(), true, G, L);
-
-  check_op<T>(Queue, T(G), intel::maximum<T>(), false, G, L);
-  check_op<T>(Queue, T(0), intel::maximum<T>(), true, G, L);
-
-#if __cplusplus >= 201402L
-  check_op<T>(Queue, T(L), intel::plus<>(), false, G, L);
-  check_op<T>(Queue, T(0), intel::plus<>(), true, G, L);
-
-  check_op<T>(Queue, T(0), intel::minimum<>(), false, G, L);
-  check_op<T>(Queue, T(G), intel::minimum<>(), true, G, L);
-
-  check_op<T>(Queue, T(G), intel::maximum<>(), false, G, L);
-  check_op<T>(Queue, T(0), intel::maximum<>(), true, G, L);
-#endif
-}
+#include "reduce.hpp"
 
 int main() {
   queue Queue;
@@ -110,21 +22,11 @@ int main() {
     std::cout << "Skipping test\n";
     return 0;
   }
-
   check<int>(Queue);
   check<unsigned int>(Queue);
   check<long>(Queue);
   check<unsigned long>(Queue);
   check<float>(Queue);
-  // reduce half type is not supported in OCL CPU RT
-#ifdef SG_GPU
-  if (Queue.get_device().has_extension("cl_khr_fp16")) {
-    check<cl::sycl::half>(Queue);
-  }
-#endif
-  if (Queue.get_device().has_extension("cl_khr_fp64")) {
-    check<double>(Queue);
-  }
   std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test/sub_group/reduce.hpp
+++ b/sycl/test/sub_group/reduce.hpp
@@ -1,0 +1,95 @@
+//==--------------- reduce.hpp - SYCL sub_group reduce test ----*- C++ -*---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "helper.hpp"
+#include <CL/sycl.hpp>
+
+template <typename T, class BinaryOperation>
+class sycl_subgr;
+
+using namespace cl::sycl;
+
+template <typename T, class BinaryOperation>
+void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
+              size_t G = 240, size_t L = 60) {
+  try {
+    nd_range<1> NdRange(G, L);
+    buffer<T> buf(G);
+    buffer<size_t> sgsizebuf(1);
+    Queue.submit([&](handler &cgh) {
+      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
+      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<sycl_subgr<T, BinaryOperation>>(
+          NdRange, [=](nd_item<1> NdItem) {
+            intel::sub_group sg = NdItem.get_sub_group();
+            if (skip_init) {
+              acc[NdItem.get_global_id(0)] =
+                  reduce(sg, T(NdItem.get_global_id(0)), op);
+            } else {
+              acc[NdItem.get_global_id(0)] =
+                  reduce(sg, T(NdItem.get_global_id(0)), init, op);
+            }
+            if (NdItem.get_global_id(0) == 0)
+              sgsizeacc[0] = sg.get_max_local_range()[0];
+          });
+    });
+    auto acc = buf.template get_access<access::mode::read_write>();
+    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
+    size_t sg_size = sgsizeacc[0];
+    int WGid = -1, SGid = 0;
+    T result = init;
+    for (int j = 0; j < G; j++) {
+      if (j % L % sg_size == 0) {
+        SGid++;
+        result = init;
+        for (int i = j; (i % L && i % L % sg_size) || (i == j); i++) {
+          result = op(result, T(i));
+        }
+      }
+      if (j % L == 0) {
+        WGid++;
+        SGid = 0;
+      }
+      std::string name =
+          std::string("reduce_") + typeid(BinaryOperation).name();
+      exit_if_not_equal<T>(acc[j], result, name.c_str());
+    }
+  } catch (exception e) {
+    std::cout << "SYCL exception caught: " << e.what();
+    exit(1);
+  }
+}
+
+template <typename T>
+void check(queue &Queue, size_t G = 240, size_t L = 60) {
+  // limit data range for half to avoid rounding issues
+  if (std::is_same<T, cl::sycl::half>::value) {
+    G = 64;
+    L = 32;
+  }
+
+  check_op<T>(Queue, T(L), intel::plus<T>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::plus<T>(), true, G, L);
+
+  check_op<T>(Queue, T(0), intel::minimum<T>(), false, G, L);
+  check_op<T>(Queue, T(G), intel::minimum<T>(), true, G, L);
+
+  check_op<T>(Queue, T(G), intel::maximum<T>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::maximum<T>(), true, G, L);
+
+#if __cplusplus >= 201402L
+  check_op<T>(Queue, T(L), intel::plus<>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::plus<>(), true, G, L);
+
+  check_op<T>(Queue, T(0), intel::minimum<>(), false, G, L);
+  check_op<T>(Queue, T(G), intel::minimum<>(), true, G, L);
+
+  check_op<T>(Queue, T(G), intel::maximum<>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::maximum<>(), true, G, L);
+#endif
+}

--- a/sycl/test/sub_group/reduce_fp16.cpp
+++ b/sycl/test/sub_group/reduce_fp16.cpp
@@ -2,20 +2,16 @@
 // CUDA compilation and runtime do not yet support sub-groups.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
-
-//==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//
+///==---------------- reduce_fp16.cpp - SYCL sub_group reduce test ----*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===-----------------------------------------------------------------------------===//
 
-#include "scan.hpp"
+#include "reduce.hpp"
 
 int main() {
   queue Queue;
@@ -23,11 +19,7 @@ int main() {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int>(Queue);
-  check<unsigned int>(Queue);
-  check<long>(Queue);
-  check<unsigned long>(Queue);
-  check<float>(Queue);
+  check<cl::sycl::half>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test/sub_group/reduce_fp64.cpp
+++ b/sycl/test/sub_group/reduce_fp64.cpp
@@ -6,16 +6,15 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-
-//==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//
+///==---------------- reduce_fp64.cpp - SYCL sub_group reduce test ----*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===-----------------------------------------------------------------------------===//
 
-#include "scan.hpp"
+#include "reduce.hpp"
 
 int main() {
   queue Queue;
@@ -23,11 +22,7 @@ int main() {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int>(Queue);
-  check<unsigned int>(Queue);
-  check<long>(Queue);
-  check<unsigned long>(Queue);
-  check<float>(Queue);
+  check<double>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test/sub_group/scan.hpp
+++ b/sycl/test/sub_group/scan.hpp
@@ -1,0 +1,131 @@
+//==--------------- scan.hpp - SYCL sub_group scan test --------*- C++ -*---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "helper.hpp"
+#include <CL/sycl.hpp>
+#include <limits>
+
+template <typename T, class BinaryOperation>
+class sycl_subgr;
+
+using namespace cl::sycl;
+
+template <typename T, class BinaryOperation>
+void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
+              size_t G = 120, size_t L = 60) {
+  try {
+    nd_range<1> NdRange(G, L);
+    buffer<T> exbuf(G), inbuf(G);
+    buffer<size_t> sgsizebuf(1);
+    Queue.submit([&](handler &cgh) {
+      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
+      auto exacc = exbuf.template get_access<access::mode::read_write>(cgh);
+      auto inacc = inbuf.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<sycl_subgr<T, BinaryOperation>>(
+          NdRange, [=](nd_item<1> NdItem) {
+            intel::sub_group sg = NdItem.get_sub_group();
+            if (skip_init) {
+              exacc[NdItem.get_global_id(0)] =
+                  exclusive_scan(sg, T(NdItem.get_global_id(0)), op);
+              inacc[NdItem.get_global_id(0)] =
+                  inclusive_scan(sg, T(NdItem.get_global_id(0)), op);
+            } else {
+              exacc[NdItem.get_global_id(0)] =
+                  exclusive_scan(sg, T(NdItem.get_global_id(0)), init, op);
+              inacc[NdItem.get_global_id(0)] =
+                  inclusive_scan(sg, T(NdItem.get_global_id(0)), op, init);
+            }
+            if (NdItem.get_global_id(0) == 0)
+              sgsizeacc[0] = sg.get_max_local_range()[0];
+          });
+    });
+    auto exacc = exbuf.template get_access<access::mode::read_write>();
+    auto inacc = inbuf.template get_access<access::mode::read_write>();
+    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
+    size_t sg_size = sgsizeacc[0];
+    int WGid = -1, SGid = 0;
+    T result = init;
+    for (int j = 0; j < G; j++) {
+      if (j % L % sg_size == 0) {
+        SGid++;
+        result = init;
+      }
+      if (j % L == 0) {
+        WGid++;
+        SGid = 0;
+      }
+      std::string exname =
+          std::string("scan_exc_") + typeid(BinaryOperation).name();
+      std::string inname =
+          std::string("scan_inc_") + typeid(BinaryOperation).name();
+      exit_if_not_equal<T>(exacc[j], result, exname.c_str());
+      result = op(result, T(j));
+      exit_if_not_equal<T>(inacc[j], result, inname.c_str());
+    }
+  } catch (exception e) {
+    std::cout << "SYCL exception caught: " << e.what();
+    exit(1);
+  }
+}
+
+template <typename T>
+void check(queue &Queue, size_t G = 120, size_t L = 60) {
+  // limit data range for half to avoid rounding issues
+  if (std::is_same<T, cl::sycl::half>::value) {
+    G = 64;
+    L = 32;
+  }
+
+  check_op<T>(Queue, T(L), intel::plus<T>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::plus<T>(), true, G, L);
+
+  check_op<T>(Queue, T(0), intel::minimum<T>(), false, G, L);
+  if (std::is_floating_point<T>::value ||
+      std::is_same<T, cl::sycl::half>::value) {
+    check_op<T>(Queue, std::numeric_limits<T>::infinity(), intel::minimum<T>(),
+                true, G, L);
+  } else {
+    check_op<T>(Queue, std::numeric_limits<T>::max(), intel::minimum<T>(), true,
+                G, L);
+  }
+
+  check_op<T>(Queue, T(G), intel::maximum<T>(), false, G, L);
+  if (std::is_floating_point<T>::value ||
+      std::is_same<T, cl::sycl::half>::value) {
+    check_op<T>(Queue, -std::numeric_limits<T>::infinity(), intel::maximum<T>(),
+                true, G, L);
+  } else {
+    check_op<T>(Queue, std::numeric_limits<T>::min(), intel::maximum<T>(), true,
+                G, L);
+  }
+
+#if __cplusplus >= 201402L
+  check_op<T>(Queue, T(L), intel::plus<>(), false, G, L);
+  check_op<T>(Queue, T(0), intel::plus<>(), true, G, L);
+
+  check_op<T>(Queue, T(0), intel::minimum<>(), false, G, L);
+  if (std::is_floating_point<T>::value ||
+      std::is_same<T, cl::sycl::half>::value) {
+    check_op<T>(Queue, std::numeric_limits<T>::infinity(), intel::minimum<>(),
+                true, G, L);
+  } else {
+    check_op<T>(Queue, std::numeric_limits<T>::max(), intel::minimum<>(), true,
+                G, L);
+  }
+
+  check_op<T>(Queue, T(G), intel::maximum<>(), false, G, L);
+  if (std::is_floating_point<T>::value ||
+      std::is_same<T, cl::sycl::half>::value) {
+    check_op<T>(Queue, -std::numeric_limits<T>::infinity(), intel::maximum<>(),
+                true, G, L);
+  } else {
+    check_op<T>(Queue, std::numeric_limits<T>::min(), intel::maximum<>(), true,
+                G, L);
+  }
+#endif
+}

--- a/sycl/test/sub_group/scan_fp16.cpp
+++ b/sycl/test/sub_group/scan_fp16.cpp
@@ -2,18 +2,15 @@
 // CUDA compilation and runtime do not yet support sub-groups.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-//==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//
+//==--------------- scan_fp16.cpp - SYCL sub_group scan test --------*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===---------------------------------------------------------------------------===//
 
 #include "scan.hpp"
 
@@ -23,11 +20,7 @@ int main() {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int>(Queue);
-  check<unsigned int>(Queue);
-  check<long>(Queue);
-  check<unsigned long>(Queue);
-  check<float>(Queue);
+  check<cl::sycl::half>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test/sub_group/scan_fp64.cpp
+++ b/sycl/test/sub_group/scan_fp64.cpp
@@ -7,13 +7,13 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-//==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//
+//==--------------- scan_fp64.cpp - SYCL sub_group scan test --------*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===---------------------------------------------------------------------------===//
 
 #include "scan.hpp"
 
@@ -23,11 +23,7 @@ int main() {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int>(Queue);
-  check<unsigned int>(Queue);
-  check<long>(Queue);
-  check<unsigned long>(Queue);
-  check<float>(Queue);
+  check<double>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test/sub_group/shuffle.cpp
+++ b/sycl/test/sub_group/shuffle.cpp
@@ -4,7 +4,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUNx: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
 //==------------ shuffle.cpp - SYCL sub_group shuffle test -----*- C++ -*---==//
@@ -15,228 +15,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "helper.hpp"
-#include <CL/sycl.hpp>
-template <typename T, int N> class sycl_subgr;
+#include "shuffle.hpp"
 
-using namespace cl::sycl;
-
-// TODO remove this workaround when clang will support correct generation of
-// half typename in integration header
-struct wa_half;
-
-template <typename T, int N>
-void check(queue &Queue, size_t G = 240, size_t L = 60) {
-  try {
-    nd_range<1> NdRange(G, L);
-    buffer<vec<T, N>> buf2(G);
-    buffer<vec<T, N>> buf2_up(G);
-    buffer<vec<T, N>> buf2_down(G);
-    buffer<vec<T, N>> buf(G);
-    buffer<vec<T, N>> buf_up(G);
-    buffer<vec<T, N>> buf_down(G);
-    buffer<vec<T, N>> buf_xor(G);
-    buffer<size_t> sgsizebuf(1);
-    Queue.submit([&](handler &cgh) {
-      auto acc2 = buf2.template get_access<access::mode::read_write>(cgh);
-      auto acc2_up = buf2_up.template get_access<access::mode::read_write>(cgh);
-      auto acc2_down =
-          buf2_down.template get_access<access::mode::read_write>(cgh);
-
-      auto acc = buf.template get_access<access::mode::read_write>(cgh);
-      auto acc_up = buf_up.template get_access<access::mode::read_write>(cgh);
-      auto acc_down =
-          buf_down.template get_access<access::mode::read_write>(cgh);
-      auto acc_xor = buf_xor.template get_access<access::mode::read_write>(cgh);
-      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
-
-      cgh.parallel_for<sycl_subgr<T, N>>(NdRange, [=](nd_item<1> NdItem) {
-        intel::sub_group SG = NdItem.get_sub_group();
-        uint32_t wggid = NdItem.get_global_id(0);
-        uint32_t sgid = SG.get_group_id().get(0);
-        vec<T, N> vwggid(wggid), vsgid(sgid);
-        if (wggid == 0)
-          sgsizeacc[0] = SG.get_max_local_range()[0];
-        /* 1 for odd subgroups and 2 for even*/
-        acc2[NdItem.get_global_id()] =
-            SG.shuffle(vec<T, N>(1), vec<T, N>(2),
-                       (sgid % 2) ? 1 : SG.get_max_local_range()[0]);
-        /* GID-SGID */
-        acc2_up[NdItem.get_global_id()] = SG.shuffle_up(vwggid, vwggid, sgid);
-        /* GID-SGID or SGLID if GID+SGID > SGsize*/
-        acc2_down[NdItem.get_global_id()] =
-            SG.shuffle_down(vwggid, vec<T, N>(SG.get_local_id().get(0)), sgid);
-
-        /*GID of middle element in every subgroup*/
-        acc[NdItem.get_global_id()] =
-            SG.shuffle(vwggid, SG.get_max_local_range()[0] / 2);
-        /* Save GID-SGID */
-        acc_up[NdItem.get_global_id()] = SG.shuffle_up(vwggid, sgid);
-        /* Save GID+SGID */
-        acc_down[NdItem.get_global_id()] = SG.shuffle_down(vwggid, sgid);
-        /* Save GID XOR SGID */
-        acc_xor[NdItem.get_global_id()] = SG.shuffle_xor(vwggid, sgid);
-      });
-    });
-    auto acc = buf.template get_access<access::mode::read_write>();
-    auto acc_up = buf_up.template get_access<access::mode::read_write>();
-    auto acc_down = buf_down.template get_access<access::mode::read_write>();
-    auto acc2 = buf2.template get_access<access::mode::read_write>();
-    auto acc2_up = buf2_up.template get_access<access::mode::read_write>();
-    auto acc2_down = buf2_down.template get_access<access::mode::read_write>();
-    auto acc_xor = buf_xor.template get_access<access::mode::read_write>();
-    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
-
-    size_t sg_size = sgsizeacc[0];
-    int SGid = 0;
-    for (int j = 0; j < G; j++) {
-      if (j % L % sg_size == 0) {
-        SGid++;
-      }
-      if (j % L == 0) {
-        SGid = 0;
-      }
-      /*GID of middle element in every subgroup*/
-      exit_if_not_equal_vec<T, N>(
-          acc[j], vec<T, N>(j / L * L + SGid * sg_size + sg_size / 2),
-          "shuffle");
-      /* 1 for odd subgroups and 2 for even*/
-      exit_if_not_equal_vec<T, N>(acc2[j], vec<T, N>((SGid % 2) ? 1 : 2),
-                                  "shuffle2");
-      /* Value GID+SGID for all element except last SGID in SG*/
-      if (j % L % sg_size + SGid < sg_size && j % L + SGid < L) {
-        exit_if_not_equal_vec(acc_down[j], vec<T, N>(j + SGid), "shuffle_down");
-        exit_if_not_equal_vec(acc2_down[j], vec<T, N>(j + SGid),
-                              "shuffle2_down");
-      } else {                /* SGLID for GID+SGid */
-        if (j % L + SGid < L) /* Do not go out  LG*/
-          exit_if_not_equal_vec<T, N>(acc2_down[j],
-                                      vec<T, N>((j + SGid) % L % sg_size),
-                                      "shuffle2_down");
-      }
-      /* Value GID-SGID for all element except first SGID in SG*/
-      if (j % L % sg_size >= SGid) {
-        exit_if_not_equal_vec(acc_up[j], vec<T, N>(j - SGid), "shuffle_up");
-        exit_if_not_equal_vec(acc2_up[j], vec<T, N>(j - SGid), "shuffle2_up");
-      } else {                          /* SGLID for GID-SGid */
-        if (j % L - SGid + sg_size < L) /* Do not go out  LG*/
-          exit_if_not_equal_vec(acc2_up[j], vec<T, N>(j - SGid + sg_size),
-                                "shuffle2_up");
-      }
-      /* GID XOR SGID */
-      exit_if_not_equal_vec(acc_xor[j], vec<T, N>(j ^ SGid), "shuffle_xor");
-    }
-  } catch (exception e) {
-    std::cout << "SYCL exception caught: " << e.what();
-    exit(1);
-  }
-}
-
-template <typename T> void check(queue &Queue, size_t G = 240, size_t L = 60) {
-  try {
-    nd_range<1> NdRange(G, L);
-    buffer<T> buf2(G);
-    buffer<T> buf2_up(G);
-    buffer<T> buf2_down(G);
-    buffer<T> buf(G);
-    buffer<T> buf_up(G);
-    buffer<T> buf_down(G);
-    buffer<T> buf_xor(G);
-    buffer<size_t> sgsizebuf(1);
-    Queue.submit([&](handler &cgh) {
-      auto acc2 = buf2.template get_access<access::mode::read_write>(cgh);
-      auto acc2_up = buf2_up.template get_access<access::mode::read_write>(cgh);
-      auto acc2_down =
-          buf2_down.template get_access<access::mode::read_write>(cgh);
-
-      auto acc = buf.template get_access<access::mode::read_write>(cgh);
-      auto acc_up = buf_up.template get_access<access::mode::read_write>(cgh);
-      auto acc_down =
-          buf_down.template get_access<access::mode::read_write>(cgh);
-      auto acc_xor = buf_xor.template get_access<access::mode::read_write>(cgh);
-      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
-
-      cgh.parallel_for<sycl_subgr<T, 0>>(NdRange, [=](nd_item<1> NdItem) {
-        intel::sub_group SG = NdItem.get_sub_group();
-        uint32_t wggid = NdItem.get_global_id(0);
-        uint32_t sgid = SG.get_group_id().get(0);
-        if (wggid == 0)
-          sgsizeacc[0] = SG.get_max_local_range()[0];
-        /* 1 for odd subgroups and 2 for even*/
-        acc2[NdItem.get_global_id()] =
-            SG.shuffle<T>(1, 2, (sgid % 2) ? 1 : SG.get_max_local_range()[0]);
-        /* GID-SGID */
-        acc2_up[NdItem.get_global_id()] = SG.shuffle_up<T>(wggid, wggid, sgid);
-        /* GID-SGID or SGLID if GID+SGID > SGsize*/
-        acc2_down[NdItem.get_global_id()] =
-            SG.shuffle_down<T>(wggid, SG.get_local_id().get(0), sgid);
-
-        /*GID of middle element in every subgroup*/
-        acc[NdItem.get_global_id()] =
-            SG.shuffle<T>(wggid, SG.get_max_local_range()[0] / 2);
-        /* Save GID-SGID */
-        acc_up[NdItem.get_global_id()] = SG.shuffle_up<T>(wggid, sgid);
-        /* Save GID+SGID */
-        acc_down[NdItem.get_global_id()] = SG.shuffle_down<T>(wggid, sgid);
-        /* Save GID XOR SGID */
-        acc_xor[NdItem.get_global_id()] = SG.shuffle_xor<T>(wggid, sgid);
-      });
-    });
-    auto acc = buf.template get_access<access::mode::read_write>();
-    auto acc_up = buf_up.template get_access<access::mode::read_write>();
-    auto acc_down = buf_down.template get_access<access::mode::read_write>();
-    auto acc2 = buf2.template get_access<access::mode::read_write>();
-    auto acc2_up = buf2_up.template get_access<access::mode::read_write>();
-    auto acc2_down = buf2_down.template get_access<access::mode::read_write>();
-    auto acc_xor = buf_xor.template get_access<access::mode::read_write>();
-    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
-
-    size_t sg_size = sgsizeacc[0];
-    int SGid = 0;
-    for (int j = 0; j < G; j++) {
-      if (j % L % sg_size == 0) {
-        SGid++;
-      }
-      if (j % L == 0) {
-        SGid = 0;
-      }
-      /*GID of middle element in every subgroup*/
-      exit_if_not_equal<T>(acc[j], j / L * L + SGid * sg_size + sg_size / 2,
-                           "shuffle");
-      /* 1 for odd subgroups and 2 for even*/
-      exit_if_not_equal<T>(acc2[j], (SGid % 2) ? 1 : 2, "shuffle2");
-      /* Value GID+SGID for all element except last SGID in SG*/
-      if (j % L % sg_size + SGid < sg_size && j % L + SGid < L) {
-        exit_if_not_equal<T>(acc_down[j], j + SGid, "shuffle_down");
-        exit_if_not_equal<T>(acc2_down[j], j + SGid, "shuffle2_down");
-      } else {                /* SGLID for GID+SGid */
-        if (j % L + SGid < L) /* Do not go out  LG*/
-          exit_if_not_equal<T>(acc2_down[j], (j + SGid) % L % sg_size,
-                               "shuffle2_down");
-      }
-      /* Value GID-SGID for all element except first SGID in SG*/
-      if (j % L % sg_size >= SGid) {
-        exit_if_not_equal<T>(acc_up[j], j - SGid, "shuffle_up");
-        exit_if_not_equal<T>(acc2_up[j], j - SGid, "shuffle2_up");
-      } else {                          /* SGLID for GID-SGid */
-        if (j % L - SGid + sg_size < L) /* Do not go out  LG*/
-          exit_if_not_equal<T>(acc2_up[j], j - SGid + sg_size, "shuffle2_up");
-      }
-      /* GID XOR SGID */
-      exit_if_not_equal<T>(acc_xor[j], j ^ SGid, "shuffle_xor");
-    }
-  } catch (exception e) {
-    std::cout << "SYCL exception caught: " << e.what();
-    exit(1);
-  }
-}
 int main() {
   queue Queue;
   if (!Queue.get_device().has_extension("cl_intel_subgroups")) {
     std::cout << "Skipping test\n";
     return 0;
   }
-
   if (Queue.get_device().has_extension("cl_intel_subgroups_short")) {
     check<short>(Queue);
     check<unsigned short>(Queue);
@@ -253,13 +39,7 @@ int main() {
   check<unsigned int, 16>(Queue);
   check<long>(Queue);
   check<unsigned long>(Queue);
-  if (Queue.get_device().has_extension("cl_khr_fp16")) {
-    check<half>(Queue);
-  }
   check<float>(Queue);
-  if (Queue.get_device().has_extension("cl_khr_fp64")) {
-    check<double>(Queue);
-  }
   std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test/sub_group/shuffle.hpp
+++ b/sycl/test/sub_group/shuffle.hpp
@@ -1,0 +1,225 @@
+//==------------ shuffle.hpp - SYCL sub_group shuffle test -----*- C++ -*---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "helper.hpp"
+#include <CL/sycl.hpp>
+template <typename T, int N>
+class sycl_subgr;
+
+using namespace cl::sycl;
+
+// TODO remove this workaround when clang will support correct generation of
+// half typename in integration header
+struct wa_half;
+
+template <typename T, int N>
+void check(queue &Queue, size_t G = 240, size_t L = 60) {
+  try {
+    nd_range<1> NdRange(G, L);
+    buffer<vec<T, N>> buf2(G);
+    buffer<vec<T, N>> buf2_up(G);
+    buffer<vec<T, N>> buf2_down(G);
+    buffer<vec<T, N>> buf(G);
+    buffer<vec<T, N>> buf_up(G);
+    buffer<vec<T, N>> buf_down(G);
+    buffer<vec<T, N>> buf_xor(G);
+    buffer<size_t> sgsizebuf(1);
+    Queue.submit([&](handler &cgh) {
+      auto acc2 = buf2.template get_access<access::mode::read_write>(cgh);
+      auto acc2_up = buf2_up.template get_access<access::mode::read_write>(cgh);
+      auto acc2_down =
+          buf2_down.template get_access<access::mode::read_write>(cgh);
+
+      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      auto acc_up = buf_up.template get_access<access::mode::read_write>(cgh);
+      auto acc_down =
+          buf_down.template get_access<access::mode::read_write>(cgh);
+      auto acc_xor = buf_xor.template get_access<access::mode::read_write>(cgh);
+      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
+
+      cgh.parallel_for<sycl_subgr<T, N>>(NdRange, [=](nd_item<1> NdItem) {
+        intel::sub_group SG = NdItem.get_sub_group();
+        uint32_t wggid = NdItem.get_global_id(0);
+        uint32_t sgid = SG.get_group_id().get(0);
+        vec<T, N> vwggid(wggid), vsgid(sgid);
+        if (wggid == 0)
+          sgsizeacc[0] = SG.get_max_local_range()[0];
+        /* 1 for odd subgroups and 2 for even*/
+        acc2[NdItem.get_global_id()] =
+            SG.shuffle(vec<T, N>(1), vec<T, N>(2),
+                       (sgid % 2) ? 1 : SG.get_max_local_range()[0]);
+        /* GID-SGID */
+        acc2_up[NdItem.get_global_id()] = SG.shuffle_up(vwggid, vwggid, sgid);
+        /* GID-SGID or SGLID if GID+SGID > SGsize*/
+        acc2_down[NdItem.get_global_id()] =
+            SG.shuffle_down(vwggid, vec<T, N>(SG.get_local_id().get(0)), sgid);
+
+        /*GID of middle element in every subgroup*/
+        acc[NdItem.get_global_id()] =
+            SG.shuffle(vwggid, SG.get_max_local_range()[0] / 2);
+        /* Save GID-SGID */
+        acc_up[NdItem.get_global_id()] = SG.shuffle_up(vwggid, sgid);
+        /* Save GID+SGID */
+        acc_down[NdItem.get_global_id()] = SG.shuffle_down(vwggid, sgid);
+        /* Save GID XOR SGID */
+        acc_xor[NdItem.get_global_id()] = SG.shuffle_xor(vwggid, sgid);
+      });
+    });
+    auto acc = buf.template get_access<access::mode::read_write>();
+    auto acc_up = buf_up.template get_access<access::mode::read_write>();
+    auto acc_down = buf_down.template get_access<access::mode::read_write>();
+    auto acc2 = buf2.template get_access<access::mode::read_write>();
+    auto acc2_up = buf2_up.template get_access<access::mode::read_write>();
+    auto acc2_down = buf2_down.template get_access<access::mode::read_write>();
+    auto acc_xor = buf_xor.template get_access<access::mode::read_write>();
+    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
+
+    size_t sg_size = sgsizeacc[0];
+    int SGid = 0;
+    for (int j = 0; j < G; j++) {
+      if (j % L % sg_size == 0) {
+        SGid++;
+      }
+      if (j % L == 0) {
+        SGid = 0;
+      }
+      /*GID of middle element in every subgroup*/
+      exit_if_not_equal_vec<T, N>(
+          acc[j], vec<T, N>(j / L * L + SGid * sg_size + sg_size / 2),
+          "shuffle");
+      /* 1 for odd subgroups and 2 for even*/
+      exit_if_not_equal_vec<T, N>(acc2[j], vec<T, N>((SGid % 2) ? 1 : 2),
+                                  "shuffle2");
+      /* Value GID+SGID for all element except last SGID in SG*/
+      if (j % L % sg_size + SGid < sg_size && j % L + SGid < L) {
+        exit_if_not_equal_vec(acc_down[j], vec<T, N>(j + SGid), "shuffle_down");
+        exit_if_not_equal_vec(acc2_down[j], vec<T, N>(j + SGid),
+                              "shuffle2_down");
+      } else {                /* SGLID for GID+SGid */
+        if (j % L + SGid < L) /* Do not go out  LG*/
+          exit_if_not_equal_vec<T, N>(acc2_down[j],
+                                      vec<T, N>((j + SGid) % L % sg_size),
+                                      "shuffle2_down");
+      }
+      /* Value GID-SGID for all element except first SGID in SG*/
+      if (j % L % sg_size >= SGid) {
+        exit_if_not_equal_vec(acc_up[j], vec<T, N>(j - SGid), "shuffle_up");
+        exit_if_not_equal_vec(acc2_up[j], vec<T, N>(j - SGid), "shuffle2_up");
+      } else {                          /* SGLID for GID-SGid */
+        if (j % L - SGid + sg_size < L) /* Do not go out  LG*/
+          exit_if_not_equal_vec(acc2_up[j], vec<T, N>(j - SGid + sg_size),
+                                "shuffle2_up");
+      }
+      /* GID XOR SGID */
+      exit_if_not_equal_vec(acc_xor[j], vec<T, N>(j ^ SGid), "shuffle_xor");
+    }
+  } catch (exception e) {
+    std::cout << "SYCL exception caught: " << e.what();
+    exit(1);
+  }
+}
+
+template <typename T>
+void check(queue &Queue, size_t G = 240, size_t L = 60) {
+  try {
+    nd_range<1> NdRange(G, L);
+    buffer<T> buf2(G);
+    buffer<T> buf2_up(G);
+    buffer<T> buf2_down(G);
+    buffer<T> buf(G);
+    buffer<T> buf_up(G);
+    buffer<T> buf_down(G);
+    buffer<T> buf_xor(G);
+    buffer<size_t> sgsizebuf(1);
+    Queue.submit([&](handler &cgh) {
+      auto acc2 = buf2.template get_access<access::mode::read_write>(cgh);
+      auto acc2_up = buf2_up.template get_access<access::mode::read_write>(cgh);
+      auto acc2_down =
+          buf2_down.template get_access<access::mode::read_write>(cgh);
+
+      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      auto acc_up = buf_up.template get_access<access::mode::read_write>(cgh);
+      auto acc_down =
+          buf_down.template get_access<access::mode::read_write>(cgh);
+      auto acc_xor = buf_xor.template get_access<access::mode::read_write>(cgh);
+      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
+
+      cgh.parallel_for<sycl_subgr<T, 0>>(NdRange, [=](nd_item<1> NdItem) {
+        intel::sub_group SG = NdItem.get_sub_group();
+        uint32_t wggid = NdItem.get_global_id(0);
+        uint32_t sgid = SG.get_group_id().get(0);
+        if (wggid == 0)
+          sgsizeacc[0] = SG.get_max_local_range()[0];
+        /* 1 for odd subgroups and 2 for even*/
+        acc2[NdItem.get_global_id()] =
+            SG.shuffle<T>(1, 2, (sgid % 2) ? 1 : SG.get_max_local_range()[0]);
+        /* GID-SGID */
+        acc2_up[NdItem.get_global_id()] = SG.shuffle_up<T>(wggid, wggid, sgid);
+        /* GID-SGID or SGLID if GID+SGID > SGsize*/
+        acc2_down[NdItem.get_global_id()] =
+            SG.shuffle_down<T>(wggid, SG.get_local_id().get(0), sgid);
+
+        /*GID of middle element in every subgroup*/
+        acc[NdItem.get_global_id()] =
+            SG.shuffle<T>(wggid, SG.get_max_local_range()[0] / 2);
+        /* Save GID-SGID */
+        acc_up[NdItem.get_global_id()] = SG.shuffle_up<T>(wggid, sgid);
+        /* Save GID+SGID */
+        acc_down[NdItem.get_global_id()] = SG.shuffle_down<T>(wggid, sgid);
+        /* Save GID XOR SGID */
+        acc_xor[NdItem.get_global_id()] = SG.shuffle_xor<T>(wggid, sgid);
+      });
+    });
+    auto acc = buf.template get_access<access::mode::read_write>();
+    auto acc_up = buf_up.template get_access<access::mode::read_write>();
+    auto acc_down = buf_down.template get_access<access::mode::read_write>();
+    auto acc2 = buf2.template get_access<access::mode::read_write>();
+    auto acc2_up = buf2_up.template get_access<access::mode::read_write>();
+    auto acc2_down = buf2_down.template get_access<access::mode::read_write>();
+    auto acc_xor = buf_xor.template get_access<access::mode::read_write>();
+    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
+
+    size_t sg_size = sgsizeacc[0];
+    int SGid = 0;
+    for (int j = 0; j < G; j++) {
+      if (j % L % sg_size == 0) {
+        SGid++;
+      }
+      if (j % L == 0) {
+        SGid = 0;
+      }
+      /*GID of middle element in every subgroup*/
+      exit_if_not_equal<T>(acc[j], j / L * L + SGid * sg_size + sg_size / 2,
+                           "shuffle");
+      /* 1 for odd subgroups and 2 for even*/
+      exit_if_not_equal<T>(acc2[j], (SGid % 2) ? 1 : 2, "shuffle2");
+      /* Value GID+SGID for all element except last SGID in SG*/
+      if (j % L % sg_size + SGid < sg_size && j % L + SGid < L) {
+        exit_if_not_equal<T>(acc_down[j], j + SGid, "shuffle_down");
+        exit_if_not_equal<T>(acc2_down[j], j + SGid, "shuffle2_down");
+      } else {                /* SGLID for GID+SGid */
+        if (j % L + SGid < L) /* Do not go out  LG*/
+          exit_if_not_equal<T>(acc2_down[j], (j + SGid) % L % sg_size,
+                               "shuffle2_down");
+      }
+      /* Value GID-SGID for all element except first SGID in SG*/
+      if (j % L % sg_size >= SGid) {
+        exit_if_not_equal<T>(acc_up[j], j - SGid, "shuffle_up");
+        exit_if_not_equal<T>(acc2_up[j], j - SGid, "shuffle2_up");
+      } else {                          /* SGLID for GID-SGid */
+        if (j % L - SGid + sg_size < L) /* Do not go out  LG*/
+          exit_if_not_equal<T>(acc2_up[j], j - SGid + sg_size, "shuffle2_up");
+      }
+      /* GID XOR SGID */
+      exit_if_not_equal<T>(acc_xor[j], j ^ SGid, "shuffle_xor");
+    }
+  } catch (exception e) {
+    std::cout << "SYCL exception caught: " << e.what();
+    exit(1);
+  }
+}

--- a/sycl/test/sub_group/shuffle_fp16.cpp
+++ b/sycl/test/sub_group/shuffle_fp16.cpp
@@ -2,32 +2,25 @@
 // CUDA compilation and runtime do not yet support sub-groups.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
-
-//==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//
+//
+//==------------ shuffle_fp16.cpp - SYCL sub_group shuffle test -----*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===--_____--------------------------------------------------------------------===//
 
-#include "scan.hpp"
+#include "shuffle.hpp"
 
 int main() {
   queue Queue;
-  if (!core_sg_supported(Queue.get_device())) {
+  if (!Queue.get_device().has_extension("cl_intel_subgroups")) {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int>(Queue);
-  check<unsigned int>(Queue);
-  check<long>(Queue);
-  check<unsigned long>(Queue);
-  check<float>(Queue);
+  check<half>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test/sub_group/shuffle_fp64.cpp
+++ b/sycl/test/sub_group/shuffle_fp64.cpp
@@ -6,28 +6,24 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-
-//==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//
+//
+//==------------ shuffle_fp64.cpp - SYCL sub_group shuffle test -----*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===---------------------------------------------------------------------------===//
 
-#include "scan.hpp"
+#include "shuffle.hpp"
 
 int main() {
   queue Queue;
-  if (!core_sg_supported(Queue.get_device())) {
+  if (!Queue.get_device().has_extension("cl_intel_subgroups")) {
     std::cout << "Skipping test\n";
     return 0;
   }
-  check<int>(Queue);
-  check<unsigned int>(Queue);
-  check<long>(Queue);
-  check<unsigned long>(Queue);
-  check<float>(Queue);
+  check<double>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;
 }


### PR DESCRIPTION
1. Separate half/double type tests from full type tests.
2. Fix error caused by half type shuffle.