### PR TITLE
Add workaround for MSVC++ 2017 bug to ItaniumDemangle.h.

### DIFF
--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -445,6 +445,14 @@ public:
   }
 };
 
+#ifdef _MSC_VER
+// Workaround for MSVC++ bug (Version 2017, 15.8.9) - w/o this forward
+// declaration, the friend declaration in ObjCProtoName below has no effect
+// and leads to compilation error when ObjCProtoName::Protocol private field
+// is accessed in PointerType::printLeft.
+class PointerType;
+#endif // _MSC_VER
+
 class ObjCProtoName : public Node {
   const Node *Ty;
   StringView Protocol;


### PR DESCRIPTION
This workaround is to avoid compilation error when building on Windows
with MSVC++ 2017.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>