### PR TITLE
[SYCL][NFC] Remove the w/a for hanging zeEventHostSynchronize

### DIFF
--- a/sycl/plugins/level_zero/pi_level0.cpp
+++ b/sycl/plugins/level_zero/pi_level0.cpp
@@ -2291,7 +2291,6 @@ pi_result piEventGetProfilingInfo(pi_event Event, pi_profiling_info ParamName,
 }
 
 pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
-  ze_result_t ZeResult;
 
   if (NumEvents && !EventList) {
     return PI_INVALID_EVENT;
@@ -2300,15 +2299,7 @@ pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
   for (uint32_t I = 0; I < NumEvents; I++) {
     ze_event_handle_t ZeEvent = EventList[I]->ZeEvent;
     zePrint("ZeEvent = %lx\n", pi_cast<std::uintptr_t>(ZeEvent));
-    // TODO: Using UINT32_MAX for timeout should have the desired
-    // effect of waiting until the event is trigerred, but it seems that
-    // it is causing an OS crash, so use an interruptable loop for now.
-    do {
-      ZeResult = ZE_CALL_NOCHECK(zeEventHostSynchronize(ZeEvent, 100000));
-    } while (ZeResult == ZE_RESULT_NOT_READY);
-
-    // Check the result to be success.
-    ZE_CALL(ZeResult);
+    ZE_CALL(zeEventHostSynchronize(ZeEvent, UINT32_MAX));
 
     // NOTE: we are destroying associated command lists here to free
     // resources sooner in case RT is not calling piEventRelease soon enough.


### PR DESCRIPTION
Avoid waiting for events in a loop. 
Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>