### PR TITLE
[SYCL][CUDA] Fix CUDA LIT w/-fsycl-targets

### DIFF
--- a/sycl/test/basic_tests/compare_exchange_strong.cpp
+++ b/sycl/test/basic_tests/compare_exchange_strong.cpp
@@ -1,8 +1,7 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// XFAIL: cuda
 
 #include <CL/sycl.hpp>
 using namespace cl::sycl;


### PR DESCRIPTION
Fix `XFAIL:: cuda` case by setting correct sycl targets parameter.

Signed-off-by: Bjoern Knafla <bjoern@codeplay.com>