### PR TITLE
[SYCL][CUDA] Fix 3D buffer D2D copy slice pitch

### DIFF
--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -353,10 +353,12 @@ void copyD2D(SYCLMemObjI *SYCLMemObj, RT::PiMem SrcMem, QueueImplPtr SrcQueue,
           DepEvents.size(), &DepEvents[0], &OutEvent);
     } else {
       size_t SrcRowPitch = (1 == DimSrc) ? 0 : SrcSize[0];
-      size_t SrcSlicePitch = (3 == DimSrc) ? SrcSize[0] * SrcSize[1] : 0;
+      size_t SrcSlicePitch =
+          (DimSrc > 1) ? SrcSize[0] * SrcSize[1] : SrcSize[0];
 
       size_t DstRowPitch = (1 == DimDst) ? 0 : DstSize[0];
-      size_t DstSlicePitch = (3 == DimDst) ? DstSize[0] * DstSize[1] : 0;
+      size_t DstSlicePitch =
+          (DimDst > 1) ? DstSize[0] * DstSize[1] : DstSize[0];
 
       Plugin.call<PiApiKind::piEnqueueMemBufferCopyRect>(
           Queue, SrcMem, DstMem, &SrcOffset[0], &DstOffset[0],

--- a/sycl/test/basic_tests/buffer/buffer_full_copy.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_full_copy.cpp
@@ -6,6 +6,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out
 // RUN: %ACC_RUN_PLACEHOLDER %t2.out
 
+// XFAIL: level0
+
 //==------------- buffer_full_copy.cpp - SYCL buffer basic test ------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -18,7 +20,7 @@
 #include <cassert>
 
 void check_copy_device_to_host(cl::sycl::queue &Queue) {
-  const int size = 6, offset = 2;
+  constexpr int size = 6, offset = 2;
 
   // Create 2d buffer
   cl::sycl::buffer<int, 2> simple_buffer(cl::sycl::range<2>(size, size));
@@ -56,11 +58,11 @@ void check_copy_device_to_host(cl::sycl::queue &Queue) {
 }
 
 void check_fill(cl::sycl::queue &Queue) {
-  const int size = 6, offset = 2;
+  constexpr int size = 6, offset = 2;
   cl::sycl::buffer<float, 1> buf_1(size);
   cl::sycl::buffer<float, 1> buf_2(size / 2);
-  std::vector<float> expected_res_1(size);
-  std::vector<float> expected_res_2(size / 2);
+  std::array<float, size> expected_res_1;
+  std::array<float, size / 2> expected_res_2;
 
   // fill with offset
   {
@@ -86,11 +88,11 @@ void check_fill(cl::sycl::queue &Queue) {
 }
 
 void check_copy_host_to_device(cl::sycl::queue &Queue) {
-  const int size = 6, offset = 2;
+  constexpr int size = 6, offset = 2;
   cl::sycl::buffer<float, 1> buf_1(size);
   cl::sycl::buffer<float, 1> buf_2(size / 2);
-  std::vector<float> expected_res_1(size);
-  std::vector<float> expected_res_2(size / 2);
+  std::array<float, size> expected_res_1;
+  std::array<float, size / 2> expected_res_2;
 
   // copy acc 2 acc with offset
   {
@@ -126,8 +128,8 @@ void check_copy_host_to_device(cl::sycl::queue &Queue) {
 
   cl::sycl::buffer<float, 2> buf_3({size, size});
   cl::sycl::buffer<float, 2> buf_4({size / 2, size / 2});
-  std::vector<float> expected_res_3(size * size);
-  std::vector<float> expected_res_4(size * size / 4);
+  std::array<std::array<float, size>, size> expected_res_3;
+  std::array<std::array<float, size / 2>, size / 2> expected_res_4;
 
   // copy acc 2 acc with offset for 2D buffers
   {
@@ -135,15 +137,14 @@ void check_copy_host_to_device(cl::sycl::queue &Queue) {
     for (int i = 0; i < size; ++i) {
       for (int j = 0; j < size; ++j) {
         acc[i][j] = i * size + j + 1;
-        expected_res_3[i * size + j] = i * size + j + 1;
+        expected_res_3[i][j] = acc[i][j];
       }
     }
   }
 
   for (int i = 0; i < size / 2; ++i)
     for (int j = 0; j < size / 2; ++j)
-      expected_res_4[i * size / 2 + j] =
-          expected_res_3[(i + offset) * size + j + offset];
+      expected_res_4[i][j] = expected_res_3[i + offset][j + offset];
 
   e = Queue.submit([&](cl::sycl::handler &cgh) {
     auto a = buf_3.get_access<cl::sycl::access::mode::read>(
@@ -161,12 +162,61 @@ void check_copy_host_to_device(cl::sycl::queue &Queue) {
     // check that there was no data corruption/loss
     for (int i = 0; i < size; ++i) {
       for (int j = 0; j < size; ++j)
-        assert(expected_res_3[i * size + j] == acc_1[i][j]);
+        assert(expected_res_3[i][j] == acc_1[i][j]);
     }
 
     for (int i = 0; i < size / 2; ++i)
       for (int j = 0; j < size / 2; ++j)
-        assert(expected_res_4[i * size / 2 + j] == acc_2[i][j]);
+        assert(expected_res_4[i][j] == acc_2[i][j]);
+  }
+
+  cl::sycl::buffer<float, 3> buf_5({size, size, size});
+  cl::sycl::buffer<float, 3> buf_6({size / 2, size / 2, size / 2});
+  std::array<std::array<std::array<float, size>, size>, size> expected_res_5;
+  std::array<std::array<std::array<float, size / 2>, size / 2>, size / 2> expected_res_6;
+
+  // copy acc 2 acc with offset for 3D buffers
+  {
+    auto acc = buf_5.get_access<cl::sycl::access::mode::write>();
+    for (int i = 0; i < size; ++i) {
+      for (int j = 0; j < size; ++j) {
+        for (int k = 0; k < size; ++k) {
+          acc[i][j][k] = (i * size * size) + (j * size) + k + 1;
+          expected_res_5[i][j][k] = (i * size * size) + (j * size) + k + 1;
+        }
+      }
+    }
+  }
+
+  for (int i = 0; i < size / 2; ++i)
+    for (int j = 0; j < size / 2; ++j)
+      for (int k = 0; k < size / 2; ++k)
+        expected_res_6[i][j][k] = expected_res_5[i + offset][j + offset][k + offset];
+
+  e = Queue.submit([&](cl::sycl::handler &cgh) {
+    auto a = buf_5.get_access<cl::sycl::access::mode::read>(
+        cgh, {size / 2, size / 2, size / 2}, {offset, offset, offset});
+    auto b = buf_6.get_access<cl::sycl::access::mode::write>(
+        cgh, {size / 2, size / 2, size / 2});
+    cgh.copy(a, b);
+  });
+  e.wait();
+
+  {
+    auto acc_1 = buf_5.get_access<cl::sycl::access::mode::read>();
+    auto acc_2 = buf_6.get_access<cl::sycl::access::mode::read>();
+
+    // check that there was no data corruption/loss
+    for (int i = 0; i < size; ++i)
+      for (int j = 0; j < size; ++j)
+        for (int k = 0; k < size; ++k)
+          assert(expected_res_5[i][j][k] == acc_1[i][j][k]);
+
+    for (int i = 0; i < size / 2; ++i) {
+      for (int j = 0; j < size / 2; ++j)
+        for (int k = 0; k < size / 2; ++k)
+          assert(expected_res_6[i][j][k] == acc_2[i][j][k]);
+    }
   }
 }
 
@@ -178,6 +228,7 @@ int main() {
     check_fill(Queue);
   } catch (cl::sycl::exception &ex) {
     std::cerr << ex.what() << std::endl;
+    return 1;
   }
 
   return 0;


### PR DESCRIPTION
This commit fixes the slice pitch parameters
for the 2D/3D buffer device to device
copy operation. This fixes a LIT test
(`buffer_full_copy`) that reported passing on
CUDA despite throwing a CUDA error. This LIT test
is also fixed so that it can no longer silently fail
upon thrown exceptions.

The CUDA error occured due to the `srcHeight`
member of the CUDA_MEMCPY3D struct not reflecting
the true extent of the source volume, but the copied
region instead.

Signed-off-by: Przemek Malon <przemek.malon@codeplay.com>