### PR TITLE
[SYCL] Fix test to not write into source directory after 0b2de9e

### DIFF
--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -fsycl-int-header=%t.h %s -emit-llvm
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -fsycl-int-header=%t.h %s -emit-llvm -o %t.ll
 // RUN: FileCheck -input-file=%t.h %s
 //
 // CHECK: #include <CL/sycl/detail/kernel_desc.hpp>


### PR DESCRIPTION
0b2de9e adds -emit-llvm to this test to make sure that llvm IR emission
for this test doesn't crash, but output filename wasn't added, so
it caused emission of integration-header.ll in source directory that is not
deleted after test execution and causes fail as test without run line on
attempt to run tests again.