### PR TITLE
[SYCL] Host task accessor deduction guides

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -1773,8 +1773,9 @@ host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4)
 template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
           typename Type2, typename Type3, typename Type4, typename Type5>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4,
-              Type5) -> host_accessor<DataT, Dimensions,
-                                      detail::deduceAccessMode<Type4, Type5>()>;
+              Type5)
+    ->host_accessor<DataT, Dimensions,
+                    detail::deduceAccessMode<Type4, Type5>()>;
 
 #endif
 

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -944,9 +944,9 @@ public:
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
-            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
-                                           IsValidTag<TagT>() && IsPlaceH &&
-                                           (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
+            typename = detail::enable_if_t<
+                IsSameAsBuffer<T, Dims>() && IsValidTag<TagT>() && IsPlaceH &&
+                (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, TagT,
            const property_list &PropertyList = {})
       : accessor(BufferRef, PropertyList) {}
@@ -980,9 +980,9 @@ public:
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
-            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
-                                           IsValidTag<TagT>() && !IsPlaceH &&
-                                           (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
+            typename = detail::enable_if_t<
+                IsSameAsBuffer<T, Dims>() && IsValidTag<TagT>() && !IsPlaceH &&
+                (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            TagT, const property_list &PropertyList = {})
       : accessor(BufferRef, CommandGroupHandler, PropertyList) {}
@@ -1014,9 +1014,9 @@ public:
 #endif
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
-            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
-                                           (!IsPlaceH &&
-                                            (IsGlobalBuf || IsConstantBuf || IsHostBuf))>>
+            typename = detail::enable_if_t<
+                IsSameAsBuffer<T, Dims>() &&
+                (!IsPlaceH && (IsGlobalBuf || IsConstantBuf || IsHostBuf))>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            range<Dimensions> AccessRange,
            const property_list &PropertyList = {})
@@ -1027,9 +1027,9 @@ public:
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
-            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
-                                           IsValidTag<TagT>() && !IsPlaceH &&
-                                           (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
+            typename = detail::enable_if_t<
+                IsSameAsBuffer<T, Dims>() && IsValidTag<TagT>() && !IsPlaceH &&
+                (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            range<Dimensions> AccessRange, TagT,
            const property_list &PropertyList = {})
@@ -1078,9 +1078,9 @@ public:
 #endif
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
-            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
-                                           (!IsPlaceH &&
-                                            (IsGlobalBuf || IsConstantBuf || IsHostBuf))>>
+            typename = detail::enable_if_t<
+                IsSameAsBuffer<T, Dims>() &&
+                (!IsPlaceH && (IsGlobalBuf || IsConstantBuf || IsHostBuf))>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            range<Dimensions> AccessRange, id<Dimensions> AccessOffset,
            const property_list &PropertyList = {})
@@ -1105,9 +1105,9 @@ public:
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
-            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
-                                           IsValidTag<TagT>() && !IsPlaceH &&
-                                           (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
+            typename = detail::enable_if_t<
+                IsSameAsBuffer<T, Dims>() && IsValidTag<TagT>() && !IsPlaceH &&
+                (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            range<Dimensions> AccessRange, id<Dimensions> AccessOffset, TagT,
            const property_list &PropertyList = {})
@@ -1685,8 +1685,8 @@ public:
   host_accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
                 handler &CommandGroupHandler, range<Dimensions> AccessRange,
                 const property_list &PropertyList = {})
-      : AccessorT(BufferRef, CommandGroupHandler, AccessRange, {}, PropertyList)
-      {}
+      : AccessorT(BufferRef, CommandGroupHandler, AccessRange, {},
+                  PropertyList) {}
 
 #if __cplusplus > 201402L
 
@@ -1773,9 +1773,8 @@ host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4)
 template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
           typename Type2, typename Type3, typename Type4, typename Type5>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4,
-              Type5)
-    ->host_accessor<DataT, Dimensions,
-                    detail::deduceAccessMode<Type4, Type5>()>;
+              Type5) -> host_accessor<DataT, Dimensions,
+                                      detail::deduceAccessMode<Type4, Type5>()>;
 
 #endif
 

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -946,7 +946,7 @@ public:
             typename TagT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
                                            IsValidTag<TagT>() && IsPlaceH &&
-                                           (IsGlobalBuf || IsConstantBuf)>>
+                                           (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, TagT,
            const property_list &PropertyList = {})
       : accessor(BufferRef, PropertyList) {}
@@ -982,7 +982,7 @@ public:
             typename TagT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
                                            IsValidTag<TagT>() && !IsPlaceH &&
-                                           (IsGlobalBuf || IsConstantBuf)>>
+                                           (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            TagT, const property_list &PropertyList = {})
       : accessor(BufferRef, CommandGroupHandler, PropertyList) {}
@@ -1016,7 +1016,7 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
                                            (!IsPlaceH &&
-                                            (IsGlobalBuf || IsConstantBuf))>>
+                                            (IsGlobalBuf || IsConstantBuf || IsHostBuf))>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            range<Dimensions> AccessRange,
            const property_list &PropertyList = {})
@@ -1029,7 +1029,7 @@ public:
             typename TagT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
                                            IsValidTag<TagT>() && !IsPlaceH &&
-                                           (IsGlobalBuf || IsConstantBuf)>>
+                                           (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            range<Dimensions> AccessRange, TagT,
            const property_list &PropertyList = {})
@@ -1080,7 +1080,7 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
                                            (!IsPlaceH &&
-                                            (IsGlobalBuf || IsConstantBuf))>>
+                                            (IsGlobalBuf || IsConstantBuf || IsHostBuf))>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            range<Dimensions> AccessRange, id<Dimensions> AccessOffset,
            const property_list &PropertyList = {})
@@ -1107,7 +1107,7 @@ public:
             typename TagT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>() &&
                                            IsValidTag<TagT>() && !IsPlaceH &&
-                                           (IsGlobalBuf || IsConstantBuf)>>
+                                           (IsGlobalBuf || IsConstantBuf || IsHostBuf)>>
   accessor(buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
            range<Dimensions> AccessRange, id<Dimensions> AccessOffset, TagT,
            const property_list &PropertyList = {})
@@ -1620,8 +1620,6 @@ public:
   // buffer | handler | range | id |          | property_list
   // buffer | handler | range | id | mode_tag | property_list
   // -------+---------+-------+----+----------+--------------
-  // host_accessor with handler argument will be added later
-  // to facilitate non-blocking accessor use case
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = typename detail::enable_if_t<
@@ -1648,6 +1646,24 @@ public:
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
+  host_accessor(buffer<T, Dims, AllocatorT> &BufferRef,
+                handler &CommandGroupHandler,
+                const property_list &PropertyList = {})
+      : AccessorT(BufferRef, CommandGroupHandler, PropertyList) {}
+
+#if __cplusplus > 201402L
+
+  template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
+            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
+  host_accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+                handler &CommandGroupHandler, mode_tag_t<AccessMode>,
+                const property_list &PropertyList = {})
+      : host_accessor(BufferRef, CommandGroupHandler, PropertyList) {}
+
+#endif
+
+  template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
+            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
   host_accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
                 range<Dimensions> AccessRange,
                 const property_list &PropertyList = {})
@@ -1667,6 +1683,26 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
   host_accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+                handler &CommandGroupHandler, range<Dimensions> AccessRange,
+                const property_list &PropertyList = {})
+      : AccessorT(BufferRef, CommandGroupHandler, AccessRange, {}, PropertyList)
+      {}
+
+#if __cplusplus > 201402L
+
+  template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
+            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
+  host_accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+                handler &CommandGroupHandler, range<Dimensions> AccessRange,
+                mode_tag_t<AccessMode>, const property_list &PropertyList = {})
+      : host_accessor(BufferRef, CommandGroupHandler, AccessRange, {},
+                      PropertyList) {}
+
+#endif
+
+  template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
+            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
+  host_accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
                 range<Dimensions> AccessRange, id<Dimensions> AccessOffset,
                 const property_list &PropertyList = {})
       : AccessorT(BufferRef, AccessRange, AccessOffset, PropertyList) {}
@@ -1679,6 +1715,28 @@ public:
                 range<Dimensions> AccessRange, id<Dimensions> AccessOffset,
                 mode_tag_t<AccessMode>, const property_list &PropertyList = {})
       : host_accessor(BufferRef, AccessRange, AccessOffset, PropertyList) {}
+
+#endif
+
+  template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
+            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
+  host_accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+                handler &CommandGroupHandler, range<Dimensions> AccessRange,
+                id<Dimensions> AccessOffset,
+                const property_list &PropertyList = {})
+      : AccessorT(BufferRef, CommandGroupHandler, AccessRange, AccessOffset,
+                  PropertyList) {}
+
+#if __cplusplus > 201402L
+
+  template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
+            typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
+  host_accessor(buffer<DataT, Dimensions, AllocatorT> &BufferRef,
+                handler &CommandGroupHandler, range<Dimensions> AccessRange,
+                id<Dimensions> AccessOffset, mode_tag_t<AccessMode>,
+                const property_list &PropertyList = {})
+      : host_accessor(BufferRef, CommandGroupHandler, AccessRange, AccessOffset,
+                      PropertyList) {}
 
 #endif
 };
@@ -1711,6 +1769,13 @@ template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
 host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4)
     ->host_accessor<DataT, Dimensions,
                     detail::deduceAccessMode<Type3, Type4>()>;
+
+template <typename DataT, int Dimensions, typename AllocatorT, typename Type1,
+          typename Type2, typename Type3, typename Type4, typename Type5>
+host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4,
+              Type5)
+    ->host_accessor<DataT, Dimensions,
+                    detail::deduceAccessMode<Type4, Type5>()>;
 
 #endif
 

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -292,6 +292,11 @@ public:
     return host_accessor{*this, args...};
   }
 
+  template <typename... Ts>
+  auto get_host_access(handler &commandGroupHandler, Ts... args) {
+    return host_accessor{*this, commandGroupHandler, args...};
+  }
+
 #endif
 
   template <typename Destination = std::nullptr_t>

--- a/sycl/test/basic_tests/accessor/Inputs/host_task_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/Inputs/host_task_accessor.cpp
@@ -39,11 +39,11 @@ int main() {
       auto acc_4 = buf_data.get_host_access(cgh, sycl::read_only);
       auto acc_5 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::read_only);
       auto acc_6 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
-                                       sycl::read_only);
+                                            sycl::read_only);
       auto acc_7 = buf_data.get_host_access(cgh, sycl::write_only);
       auto acc_8 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::write_only);
       auto acc_9 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
-                                       sycl::write_only);
+                                            sycl::write_only);
 #endif
 
       cgh.codeplay_host_task(
@@ -83,22 +83,22 @@ int main() {
       sycl::host_accessor acc_1(buf_data, cgh, sycl::noinit);
       sycl::host_accessor acc_2(buf_data, cgh, sycl::range<1>(8), sycl::noinit);
       sycl::host_accessor acc_3(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
-                           sycl::noinit);
+                                sycl::noinit);
       sycl::host_accessor acc_7(buf_data, cgh, sycl::write_only, sycl::noinit);
       sycl::host_accessor acc_8(buf_data, cgh, sycl::range<1>(8), sycl::write_only,
-                           sycl::noinit);
+                                sycl::noinit);
       sycl::host_accessor acc_9(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
-                           sycl::write_only, sycl::noinit);
+                                sycl::write_only, sycl::noinit);
 #elif defined(buffer_new_api_test)
       auto acc_1 = buf_data.get_host_access(cgh, sycl::noinit);
       auto acc_2 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::noinit);
       auto acc_3 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
-                                       sycl::noinit);
+                                            sycl::noinit);
       auto acc_7 = buf_data.get_host_access(cgh, sycl::write_only, sycl::noinit);
       auto acc_8 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::write_only,
-                                       sycl::noinit);
+                                            sycl::noinit);
       auto acc_9 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
-                                       sycl::write_only, sycl::noinit);
+                                            sycl::write_only, sycl::noinit);
 #endif
 
       cgh.codeplay_host_task(

--- a/sycl/test/basic_tests/accessor/Inputs/host_task_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/Inputs/host_task_accessor.cpp
@@ -1,0 +1,125 @@
+//==-------- host_task_accessor.cpp - SYCL accessor basic test -------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <CL/sycl.hpp>
+#include <cassert>
+
+int main() {
+  // Non-placeholder accessors.
+  {
+    int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
+                                  {cl::sycl::property::buffer::use_host_ptr()});
+
+    sycl::queue Queue;
+
+    Queue.submit([&](sycl::handler &cgh) {
+
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc_1(buf_data, cgh);
+      sycl::host_accessor acc_2(buf_data, cgh, sycl::range<1>(8));
+      sycl::host_accessor acc_3(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1));
+      sycl::host_accessor acc_4(buf_data, cgh, sycl::read_only);
+      sycl::host_accessor acc_5(buf_data, cgh, sycl::range<1>(8), sycl::read_only);
+      sycl::host_accessor acc_6(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                sycl::read_only);
+      sycl::host_accessor acc_7(buf_data, cgh, sycl::write_only);
+      sycl::host_accessor acc_8(buf_data, cgh, sycl::range<1>(8), sycl::write_only);
+      sycl::host_accessor acc_9(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                sycl::write_only);
+#elif defined(buffer_new_api_test)
+      auto acc_1 = buf_data.get_host_access(cgh);
+      auto acc_2 = buf_data.get_host_access(cgh, sycl::range<1>(8));
+      auto acc_3 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::id<1>(1));
+      auto acc_4 = buf_data.get_host_access(cgh, sycl::read_only);
+      auto acc_5 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::read_only);
+      auto acc_6 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                       sycl::read_only);
+      auto acc_7 = buf_data.get_host_access(cgh, sycl::write_only);
+      auto acc_8 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::write_only);
+      auto acc_9 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                       sycl::write_only);
+#endif
+
+      cgh.codeplay_host_task(
+          [=]() {
+            acc_7[6] = acc_1[0];
+            acc_8[7] = acc_2[1];
+            acc_9[7] = acc_3[1];
+            acc_1[0] = acc_4[3];
+            acc_2[1] = acc_5[4];
+            acc_3[1] = acc_6[4];
+          });
+    });
+    Queue.wait();
+
+#if defined(accessor_new_api_test)
+    sycl::host_accessor host_acc(buf_data, sycl::read_only);
+#elif defined(buffer_new_api_test)
+    auto host_acc = buf_data.get_host_access(sycl::read_only);
+#endif
+    assert(host_acc[0] == 4 && host_acc[1] == 5 && host_acc[2] == 6);
+    assert(host_acc[3] == 4 && host_acc[4] == 5 && host_acc[5] == 6);
+    assert(host_acc[6] == 1 && host_acc[7] == 2 && host_acc[8] == 3);
+  }
+
+  // noinit accessors.
+  {
+    int data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    sycl::buffer<int, 1> buf_data(data, sycl::range<1>(9),
+                                  {cl::sycl::property::buffer::use_host_ptr()});
+
+    sycl::queue Queue;
+
+    Queue.submit([&](sycl::handler &cgh) {
+
+#if defined(accessor_new_api_test)
+      sycl::host_accessor acc_1(buf_data, cgh, sycl::noinit);
+      sycl::host_accessor acc_2(buf_data, cgh, sycl::range<1>(8), sycl::noinit);
+      sycl::host_accessor acc_3(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
+                           sycl::noinit);
+      sycl::host_accessor acc_7(buf_data, cgh, sycl::write_only, sycl::noinit);
+      sycl::host_accessor acc_8(buf_data, cgh, sycl::range<1>(8), sycl::write_only,
+                           sycl::noinit);
+      sycl::host_accessor acc_9(buf_data, cgh, sycl::range<1>(8), sycl::id<1>(1),
+                           sycl::write_only, sycl::noinit);
+#elif defined(buffer_new_api_test)
+      auto acc_1 = buf_data.get_host_access(cgh, sycl::noinit);
+      auto acc_2 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::noinit);
+      auto acc_3 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                       sycl::noinit);
+      auto acc_7 = buf_data.get_host_access(cgh, sycl::write_only, sycl::noinit);
+      auto acc_8 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::write_only,
+                                       sycl::noinit);
+      auto acc_9 = buf_data.get_host_access(cgh, sycl::range<1>(8), sycl::id<1>(1),
+                                       sycl::write_only, sycl::noinit);
+#endif
+
+      cgh.codeplay_host_task(
+          [=]() {
+            acc_7[6] = acc_1[0];
+            acc_8[7] = acc_2[1];
+            acc_9[7] = acc_3[1];
+            acc_1[0] = 4;
+            acc_2[1] = 5;
+            acc_3[1] = 6;
+          });
+    });
+    Queue.wait();
+
+#if defined(accessor_new_api_test)
+    sycl::host_accessor host_acc(buf_data, sycl::read_only);
+#elif defined(buffer_new_api_test)
+    auto host_acc = buf_data.get_host_access(sycl::read_only);
+#endif
+    assert(host_acc[0] == 4 && host_acc[1] == 5 && host_acc[2] == 6);
+    assert(host_acc[3] == 4 && host_acc[4] == 5 && host_acc[5] == 6);
+    assert(host_acc[6] == 1 && host_acc[7] == 2 && host_acc[8] == 3);
+  }
+}

--- a/sycl/test/basic_tests/accessor/get_host_task_access_deduction.cpp
+++ b/sycl/test/basic_tests/accessor/get_host_task_access_deduction.cpp
@@ -1,0 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test -std=c++17 %S/Inputs/host_task_accessor.cpp -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/basic_tests/accessor/host_task_accessor_deduction.cpp
+++ b/sycl/test/basic_tests/accessor/host_task_accessor_deduction.cpp
@@ -1,0 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test -std=c++17 %S/Inputs/host_task_accessor.cpp -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
This patch adds host task functionality of [SYCL_INTEL_accessor_simplification](https://github.com/intel/llvm/pull/1498) extension.

`handler` type is now valid argument for `host_accessor` and `buffer.get_host_access()`, which enables non-blocking behavior, while accessing memory on the host.

Related PR: https://github.com/intel/llvm/pull/1943 and https://github.com/intel/llvm/pull/1471