### PR TITLE
[SYCL] Fix segmentation fault in program manager

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -288,7 +288,7 @@ static const char *getFormatStr(RT::PiDeviceBinaryType Format) {
 }
 
 RT::PiProgram ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
-                                              const context &Context) {
+                                              const context &Context) {                                          
   if (DbgProgMgr > 0)
     std::cerr << ">>> ProgramManager::createPIProgram(" << &Img << ")\n";
   const pi_device_binary_struct &RawImg = Img.getRawData();
@@ -329,8 +329,11 @@ RT::PiProgram ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
           ? createSpirvProgram(Ctx, RawImg.BinaryStart, ImgSize)
           : createBinaryProgram(Ctx, RawImg.BinaryStart, ImgSize);
 
-  // associate the PI program with the image it was created for
-  NativePrograms[Res] = &Img;
+  {
+    auto LockGuard = Ctx->getKernelProgramCache().acquireCachedPrograms();
+    // associate the PI program with the image it was created for
+    NativePrograms[Res] = &Img;
+  }
 
   if (DbgProgMgr > 1)
     std::cerr << "created program: " << Res

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -288,7 +288,7 @@ static const char *getFormatStr(RT::PiDeviceBinaryType Format) {
 }
 
 RT::PiProgram ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
-                                              const context &Context) {                                          
+                                              const context &Context) {
   if (DbgProgMgr > 0)
     std::cerr << ">>> ProgramManager::createPIProgram(" << &Img << ")\n";
   const pi_device_binary_struct &RawImg = Img.getRawData();


### PR DESCRIPTION
This patch fixes sporadic segmentation fault caused by data race in ```NativePrograms``` variable of ```ProgramManager``` class.  
According to documentation, an access to this variable should be synchronized via the same lock as program cache but there was a lack of lock guard for ```NativePrograms[Res] = &Img;``` in sycl/source/detail/program_manager/program_manager.cpp. Added missing lock guard.