### PR TITLE
[SYCL] Fix RUN-line in no-prototype-func.c test

### DIFF
--- a/clang/test/SemaSYCL/no-prototype-func.c
+++ b/clang/test/SemaSYCL/no-prototype-func.c
@@ -1,3 +1,3 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -verify -fsyntax-only %s
 // expected-no-diagnostics
 int foo();


### PR DESCRIPTION
Updated run line to avoid leaving no-prototype-func.ll file in source
directory after test run.