### PR TITLE
[SYCL] Propagate attributes from redeclarations to SYCL kernel

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3217,11 +3217,11 @@ static void adjustDeclContextForDeclaratorDecl(DeclaratorDecl *NewD,
     FixSemaDC(VD->getDescribedVarTemplate());
 }
 
-template <typename AttributeName>
+template <typename AttributeType>
 static void checkDimensionsAndSetDiagnostics(Sema &S, FunctionDecl *New,
                                              FunctionDecl *Old) {
-  auto *NewDeclAttr = New->getAttr<AttributeName>();
-  auto *OldDeclAttr = Old->getAttr<AttributeName>();
+  AttributeType *NewDeclAttr = New->getAttr<AttributeType>();
+  AttributeType *OldDeclAttr = Old->getAttr<AttributeType>();
   if ((NewDeclAttr->getXDim() != OldDeclAttr->getXDim()) ||
       (NewDeclAttr->getYDim() != OldDeclAttr->getYDim()) ||
       (NewDeclAttr->getZDim() != OldDeclAttr->getZDim())) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3306,6 +3306,21 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD,
     }
   }
 
+  if (New->hasAttr<SYCLIntelMaxWorkGroupSizeAttr>() &&
+      Old->hasAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
+    auto *NewDeclAttr = New->getAttr<SYCLIntelMaxWorkGroupSizeAttr>();
+    auto *OldDeclAttr = Old->getAttr<SYCLIntelMaxWorkGroupSizeAttr>();
+    if ((NewDeclAttr->getXDim() != OldDeclAttr->getXDim()) ||
+        (NewDeclAttr->getYDim() != OldDeclAttr->getYDim()) ||
+        (NewDeclAttr->getZDim() != OldDeclAttr->getZDim())) {
+      Diag(New->getLocation(), diag::err_conflicting_sycl_function_attributes)
+          << OldDeclAttr << NewDeclAttr;
+      Diag(New->getLocation(), diag::warn_duplicate_attribute) << OldDeclAttr;
+      Diag(OldDeclAttr->getLocation(), diag::note_conflicting_attribute);
+      Diag(NewDeclAttr->getLocation(), diag::note_conflicting_attribute);
+    }
+  }
+
   if (New->hasAttr<InternalLinkageAttr>() &&
       !Old->hasAttr<InternalLinkageAttr>()) {
     Diag(New->getLocation(), diag::err_internal_linkage_redeclaration)

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3291,6 +3291,21 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD,
     }
   }
 
+  if (New->hasAttr<ReqdWorkGroupSizeAttr>() &&
+      Old->hasAttr<ReqdWorkGroupSizeAttr>()) {
+    auto *NewDeclAttr = New->getAttr<ReqdWorkGroupSizeAttr>();
+    auto *OldDeclAttr = Old->getAttr<ReqdWorkGroupSizeAttr>();
+    if ((NewDeclAttr->getXDim() != OldDeclAttr->getXDim()) ||
+        (NewDeclAttr->getYDim() != OldDeclAttr->getYDim()) ||
+        (NewDeclAttr->getZDim() != OldDeclAttr->getZDim())) {
+      Diag(New->getLocation(), diag::err_conflicting_sycl_function_attributes)
+          << OldDeclAttr << NewDeclAttr;
+      Diag(New->getLocation(), diag::warn_duplicate_attribute) << OldDeclAttr;
+      Diag(OldDeclAttr->getLocation(), diag::note_conflicting_attribute);
+      Diag(NewDeclAttr->getLocation(), diag::note_conflicting_attribute);
+    }
+  }
+
   if (New->hasAttr<InternalLinkageAttr>() &&
       !Old->hasAttr<InternalLinkageAttr>()) {
     Diag(New->getLocation(), diag::err_internal_linkage_redeclaration)

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -554,7 +554,7 @@ public:
 
       for (const CallGraphNode *CI : *N) {
         if (auto *Callee = dyn_cast<FunctionDecl>(CI->getDecl())) {
-          Callee = Callee->getCanonicalDecl();
+          Callee = Callee->getMostRecentDecl();
           if (!Visited.count(Callee))
             WorkList.push_back({Callee, FD});
         }

--- a/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s -I %S/Inputs -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -verify
-// RUN: %clang_cc1 %s -I %S/Inputs -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -DTRIGGER_ERROR -verify
-// RUN: %clang_cc1 %s -I %S/Inputs -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 | FileCheck %s
+// RUN: %clang_cc1 %s -I %S/Inputs -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat -verify
+// RUN: %clang_cc1 %s -I %S/Inputs -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -DTRIGGER_ERROR -Wno-sycl-2017-compat -verify
+// RUN: %clang_cc1 %s -I %S/Inputs -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat | FileCheck %s
 
 #include <sycl.hpp>
 
@@ -16,7 +16,8 @@ func1();
 
 #else
 //second case - expect error
-[[intelfpga::max_work_group_size(4, 4, 4)]] void
+[[intelfpga::max_work_group_size(4, 4, 4)]] // expected-note {{conflicting attribute is here}}
+void
 func2();
 
 [[cl::reqd_work_group_size(8, 8, 8)]] // expected-note {{conflicting attribute is here}}
@@ -28,7 +29,7 @@ func2() {}
 void
 func3();
 
-[[cl::reqd_work_group_size(1, 1, 1)]] // expected-note 2 {{conflicting attribute is here}}
+[[cl::reqd_work_group_size(1, 1, 1)]] // expected-note {{conflicting attribute is here}}
 void
 // expected-warning@+1 {{attribute 'reqd_work_group_size' is already applied with different parameters}}
 func3() {} // expected-error {{'reqd_work_group_size' attribute conflicts with ''reqd_work_group_size'' attribute}}
@@ -44,32 +45,24 @@ void
 func4() {} // expected-error {{'max_work_group_size' attribute conflicts with ''max_work_group_size'' attribute}}
 #endif
 
-template <typename Name, typename Type>
-__attribute__((sycl_kernel)) void kernel(Type kernelFunc) {
-  kernelFunc();
+int main() {
 #ifndef TRIGGER_ERROR
-  func1();
-#else
-  func2();
-  func3();
-  func4();
-#endif
-}
-
-template <typename Name, typename Type>
-void parallel_for(Type kernelFunc) {
-  kernel<Name>(kernelFunc);
-}
-
-void use() {
-#ifndef TRIGGER_ERROR
-  // CHECK-LABEL:  FunctionDecl {{.*}} use 'void ()'
-  // CHECK:  `-FunctionDecl {{.*}}KernelName 'void ()'
+  // CHECK-LABEL:  FunctionDecl {{.*}} main 'int ()'
+  // CHECK:  `-FunctionDecl {{.*}}test_kernel1 'void ()'
   // CHECK:  -SYCLIntelMaxWorkGroupSizeAttr {{.*}} Inherited 4 4 4
   // CHECK:  -SYCLIntelNoGlobalWorkOffsetAttr {{.*}} Inherited Enabled
   // CHECK:  `-ReqdWorkGroupSizeAttr {{.*}} 2 2 2
-  parallel_for<class KernelName>([]() {});
+  cl::sycl::kernel_single_task<class test_kernel1>(
+      []() { func1(); });
+
 #else
-  parallel_for<class KernelName>([]() {}); // expected-error {{conflicting attributes applied to a SYCL kernel or SYCL_EXTERNAL function}}
+  cl::sycl::kernel_single_task<class test_kernel2>(
+      []() { func2(); }); // expected-error {{conflicting attributes applied to a SYCL kernel or SYCL_EXTERNAL function}}
+
+  cl::sycl::kernel_single_task<class test_kernel3>(
+      []() { func3(); });
+
+  cl::sycl::kernel_single_task<class test_kernel4>(
+      []() { func4(); });
 #endif
 }

--- a/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
@@ -1,0 +1,33 @@
+// RUN: %clang %s -fsyntax-only -Xclang -ast-dump -fsycl-device-only | FileCheck %s
+
+[[intelfpga::no_global_work_offset]] // expected-no-diagnostics
+void
+func();
+
+[[intelfpga::max_work_group_size(8, 8, 8)]] // expected-no-diagnostics
+void
+func();
+
+[[cl::reqd_work_group_size(4, 4, 4)]] // expected-no-diagnostics
+void
+func() {}
+
+template <typename Name, typename Type>
+[[clang::sycl_kernel]] void __my_kernel__(Type bar) {
+  bar();
+  func();
+}
+
+template <typename Name, typename Type>
+void parallel_for(Type func) {
+  __my_kernel__<Name>(func);
+}
+
+void invoke_foo2() {
+  // CHECK-LABEL:  FunctionDecl {{.*}} invoke_foo2 'void ()'
+  // CHECK:  `-FunctionDecl {{.*}} _ZTSZ11invoke_foo2vE10KernelName 'void ()'
+  // CHECK:  -SYCLIntelMaxWorkGroupSizeAttr {{.*}} Inherited 8 8 8
+  // CHECK:  -SYCLIntelNoGlobalWorkOffsetAttr {{.*}} Inherited Enabled
+  // CHECK:  `-ReqdWorkGroupSizeAttr {{.*}} 4 4 4
+  parallel_for<class KernelName>([]() {});
+}

--- a/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
@@ -24,11 +24,11 @@ void
 func2() {}
 
 //third case - expect error
-[[cl::reqd_work_group_size(1, 2, 3)]] // expected-note {{conflicting attribute is here}}
+[[cl::reqd_work_group_size(4, 4, 4)]] // expected-note {{conflicting attribute is here}}
 void
 func3();
 
-[[cl::reqd_work_group_size(4, 4, 4)]] // expected-note 2 {{conflicting attribute is here}}
+[[cl::reqd_work_group_size(1, 1, 1)]] // expected-note 2 {{conflicting attribute is here}}
 void
 // expected-warning@+1 {{attribute 'reqd_work_group_size' is already applied with different parameters}}
 func3() {} // expected-error {{'reqd_work_group_size' attribute conflicts with ''reqd_work_group_size'' attribute}}

--- a/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
@@ -3,6 +3,7 @@
 // RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 | FileCheck %s
 
 #ifndef TRIGGER_ERROR
+//first case - good case
 [[intelfpga::no_global_work_offset]] // expected-no-diagnostics
 void
 func1();
@@ -12,13 +13,24 @@ func1();
 [[cl::reqd_work_group_size(2, 2, 2)]] void func1() {}
 
 #else
-[[intelfpga::max_work_group_size(4, 4, 4)]] // expected-note {{conflicting attribute is here}}
-void
+//second case - expect error
+[[intelfpga::max_work_group_size(4, 4, 4)]] void
 func2();
 
 [[cl::reqd_work_group_size(8, 8, 8)]] // expected-note {{conflicting attribute is here}}
 void
 func2() {}
+
+//third case - expect error
+[[cl::reqd_work_group_size(4, 4, 4)]] // expected-note {{conflicting attribute is here}}
+void
+func3();
+
+[[cl::reqd_work_group_size(1, 1, 1)]] // expected-note 2 {{conflicting attribute is here}}
+void
+// expected-warning@+1 {{attribute 'reqd_work_group_size' is already applied with different parameters}}
+func3() {} // expected-error {{'reqd_work_group_size' attribute conflicts with ''reqd_work_group_size'' attribute}}
+
 #endif
 
 template <typename Name, typename Type>
@@ -28,6 +40,7 @@ template <typename Name, typename Type>
   func1();
 #else
   func2();
+  func3();
 #endif
 }
 

--- a/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
@@ -31,6 +31,15 @@ void
 // expected-warning@+1 {{attribute 'reqd_work_group_size' is already applied with different parameters}}
 func3() {} // expected-error {{'reqd_work_group_size' attribute conflicts with ''reqd_work_group_size'' attribute}}
 
+//fourth case - expect error
+[[intelfpga::max_work_group_size(4, 4, 4)]] // expected-note {{conflicting attribute is here}}
+void
+func4();
+
+[[intelfpga::max_work_group_size(8, 8, 8)]] // expected-note {{conflicting attribute is here}}
+void
+// expected-warning@+1 {{attribute 'max_work_group_size' is already applied with different parameters}}
+func4(); // expected-error {{'max_work_group_size' attribute conflicts with ''max_work_group_size'' attribute}}
 #endif
 
 template <typename Name, typename Type>

--- a/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
@@ -61,7 +61,7 @@ void parallel_for(Type func) {
 void invoke_foo2() {
 #ifndef TRIGGER_ERROR
   // CHECK-LABEL:  FunctionDecl {{.*}} invoke_foo2 'void ()'
-  // CHECK:  `-FunctionDecl {{.*}} _ZTSZ11invoke_foo2vE10KernelName 'void ()'
+  // CHECK:  `-FunctionDecl {{.*}}KernelName 'void ()'
   // CHECK:  -SYCLIntelMaxWorkGroupSizeAttr {{.*}} Inherited 4 4 4
   // CHECK:  -SYCLIntelNoGlobalWorkOffsetAttr {{.*}} Inherited Enabled
   // CHECK:  `-ReqdWorkGroupSizeAttr {{.*}} 2 2 2


### PR DESCRIPTION
- Fix bug that propagates attributes from only canoncial declaration
- Handle conflicting attributes
- Add a test