### PR TITLE
Fixed NVIDIA selector bug

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -517,7 +517,7 @@ class CUDASelector : public cl::sycl::device_selector {
       const std::string DeviceName = Device.get_info<device::name>();
       const std::string DeviceVendor = Device.get_info<device::vendor>();
 
-      if (Device.is_gpu() && (DeviceName.find("NVIDIA") != std::string::npos)) {
+      if (Device.is_gpu() && (DeviceVendor.find("NVIDIA") != std::string::npos)) {
         return 1;
       };
       return -1;


### PR DESCRIPTION
Hi,

I was following your guide but adding CUDA selector always returns -1, however, I actually have an NVIDIA GPU.

The error is caused by try finding "NVIDIA" in the DeviceName instead of the DeviceVendor.

I've used Ubuntu 20.04 and a GeForce GTX 1050 Ti.