### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1658,7 +1658,7 @@ public:
 
   bool nextElement(QualType ET) final {
     ArraySubscriptExpr *LastArrayRef =
-        dyn_cast<ArraySubscriptExpr>(MemberExprBases.back());
+        cast<ArraySubscriptExpr>(MemberExprBases.back());
     MemberExprBases.pop_back();
     Expr *LastIdx = LastArrayRef->getIdx();
     llvm::APSInt Result;


### PR DESCRIPTION
Found via a static-analysis tool, the line Expr *LastIdx = LastArrayRef->getIdx();
was highlighted as having dereferenced LastArrayRef without the value
being checked for null.

This patch fixes this by switching from a dyn_cast to a cast, which will assert/fail
in the event that the MemberBaseExpr is not an ArraySubscriptExpr, rather than
do an invalid dereference.
Signed-off-by: Soumi Manna <soumi.manna@intel.com>