### PR TITLE
[NFCI][SYCL] Remove some unnecessary string allocs during int-header …

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2458,7 +2458,7 @@ static void emitRecordType(raw_ostream &OS, QualType T, const CXXRecordDecl *RD,
   if (const auto *TSD = dyn_cast<ClassTemplateSpecializationDecl>(RD)) {
 
     // Print template class name
-    TSD->printQualifiedName(OS, TypePolicy, /*WithGlobalNsPrefix*/ true);
+    TSD->printQualifiedName(RecOS, TypePolicy, /*WithGlobalNsPrefix*/ true);
 
     // Print template arguments substituting enumerators
     ASTContext &Ctx = RD->getASTContext();
@@ -2476,7 +2476,7 @@ static void emitRecordType(raw_ostream &OS, QualType T, const CXXRecordDecl *RD,
   const NamespaceDecl *NS = dyn_cast<NamespaceDecl>(RD->getDeclContext());
   RD->printQualifiedName(RecOS, TypePolicy,
                          !(NS && NS->isAnonymousNamespace()));
-  return eraseAnonNamespace(OS, RecOS.str());
+  emitWithoutAnonNamespaces(OS, RecOS.str());
 }
 
 static void emitKernelNameType(QualType T, ASTContext &Ctx, raw_ostream &OS,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2457,9 +2457,8 @@ static void printTemplateArguments(ASTContext &Ctx, raw_ostream &ArgOS,
   ArgOS << ">";
 }
 
-static void emitKernelNameType(QualType T, ASTContext &Ctx,
-                                    raw_ostream &OS,
-                                    const PrintingPolicy &TypePolicy) {
+static void emitKernelNameType(QualType T, ASTContext &Ctx, raw_ostream &OS,
+                               const PrintingPolicy &TypePolicy) {
   QualType FullyQualifiedType = TypeName::getFullyQualifiedType(T, Ctx, true);
 
   const CXXRecordDecl *RD = T->getAsCXXRecordDecl();

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2472,13 +2472,12 @@ static void emitRecordType(raw_ostream &OS, QualType T, const CXXRecordDecl *RD,
     emitWithoutAnonNamespaces(OS, T.getCanonicalType().getAsString(TypePolicy));
     return;
   }
-  
+
   const NamespaceDecl *NS = dyn_cast<NamespaceDecl>(RD->getDeclContext());
   RD->printQualifiedName(RecOS, TypePolicy,
                          !(NS && NS->isAnonymousNamespace()));
   return eraseAnonNamespace(OS, RecOS.str());
 }
-
 
 static void emitKernelNameType(QualType T, ASTContext &Ctx, raw_ostream &OS,
                                const PrintingPolicy &TypePolicy) {
@@ -2486,7 +2485,7 @@ static void emitKernelNameType(QualType T, ASTContext &Ctx, raw_ostream &OS,
     emitRecordType(OS, T, T->getAsCXXRecordDecl(), TypePolicy);
     return;
   }
-  
+
   if (T->isEnumeralType())
     OS << "::";
   emitWithoutAnonNamespaces(OS, T.getCanonicalType().getAsString(TypePolicy));


### PR DESCRIPTION
…emit

These two have resulted in some awkwardly written code in order to
provide/return std::strings, so replace them with streams, which creates
a more natural interface.  Additionally, this should reduce the amount
of std::string allocations, so we should go a little faster.