### PR TITLE
Adding buffer_location SPIR-V spec as an extension

### DIFF
--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_fpga_buffer_location.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_fpga_buffer_location.asciidoc
@@ -1,0 +1,121 @@
+SPV_INTEL_fpga_buffer_location
+==============================
+
+== Name Strings
+
+SPV_INTEL_fpga_buffer_location
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/KhronosGroup/SPIRV-Headers
+
+== Contributors
+
+- Joe Garvey, Intel +
+
+== Notice
+
+Copyright (c) 2019-2020 Intel Corporation.  All rights reserved.
+
+== Status
+
+Draft
+
+== Version
+
+[width="40%",cols="25,25"]
+|========================================
+| Last Modified Date | {docdate}
+| Revision           | A
+|========================================
+
+== Dependencies
+
+This extension is written against the SPIR-V Specification,
+Version 1.5 Revision 2.
+
+This extension requires SPIR-V 1.0.
+
+== Overview
+
+This extension adds a function parameter decoration that is useful for FPGA targets.  This decoration indicates that a particular global memory pointer can only access a particular physical memory location.  Knowing this information at compile time can allow FPGA compilers to generate load store units of lower area for accesses done through such a pointer.  
+
+== Extension Name
+To use this extension within a SPIR-V module, the following *OpExtension* must be present in the module:
+
+----
+OpExtension "SPV_INTEL_fpga_buffer_location"
+----
+
+== New Capabilities
+This extension introduces a new capability:
+
+----
+FPGABufferLocationINTEL
+----
+
+== Token Number Assignments
+
+--
+[width="40%"]
+[cols="70%,30%"]
+[grid="rows"]
+|====
+|FPGABufferLocationINTEL |5920
+|BufferLocationINTEL     |5921
+|==== 
+--
+
+== Modifications to the SPIR-V Specification, Version 1.5
+
+=== Decoration
+
+Modify Section 3.20, Decoration, adding these rows to the Decoration table:
+
+--
+[options="header"]
+|====
+2+^| Decoration | Extra Operands | Enabling Capabilities
+| 5921 | *BufferLocationINTEL* + 
+Apply to a pointer *OpFunctionParameter*.  Indicates that the pointer may only point into the physical memory indentified by the subsequent literal number operand.  | Literal +
+_Buffer Location ID_ | *FPGABufferLocationINTEL*
+|====
+--
+
+=== Capability
+
+Modify Section 3.31, Capability, adding a row to the Capability table:
+--
+[options="header"]
+|====
+2+^| Capability ^| Implicitly Declares
+| 5920 | FPGABufferLocationINTEL |
+|====
+--
+
+=== Validation Rules
+
+None.
+
+== Issues
+
+None.
+
+//. Issue.
+//+
+//--
+//*RESOLVED*: Resolution.
+//--
+
+== Revision History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Rev|Date|Author|Changes
+|A|2019-11-21|Joe Garvey|*Initial internal draft*
+|B|2020-04-08|Joe Garvey|*Reworked to be a decoration instead of a function attribute and made the spec specific to buffer location*
+|======================================== 


### PR DESCRIPTION
This is used for heterogenous global memory in FPGA targets