### PR TITLE
[SYCL][CUDA] Enable multiple CUDA arch in the same SYCL build.

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4102,7 +4102,7 @@ class OffloadingActionBuilder final {
         ToolChains.push_back(TI->second);
 
       // No SYCL toolchain means nothing to offload.
-      if (!ToolChains.size()) {
+      if (ToolChains.empty()) {
         return false;
       }
 
@@ -4163,7 +4163,7 @@ class OffloadingActionBuilder final {
             //
             // Note: this odd, but the test assert that a integration header
             // is build no matter what. If only fsycl-add-targets is provided,
-            // the driver driscard the device compilation steps.
+            // the driver should discard the device compilation steps.
             SYCLTripleList.push_back(TT);
           }
         }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3562,7 +3562,7 @@ class OffloadingActionBuilder final {
       // The host depends on the generated integrated header from the device
       // compilation.
       if (CurPhase == phases::Compile) {
-        if (SYCLDeviceActions.size()) {
+        if (!SYCLDeviceActions.empty()) {
           // Pick the first target as the SYCL Header producer.
           Action *SYCLHeaderAction = C.MakeAction<CompileJobAction>(
               SYCLDeviceActions.back(), types::TY_SYCL_Header);
@@ -3580,7 +3580,7 @@ class OffloadingActionBuilder final {
       // The host only depends on device action in the linking phase, when all
       // the device images have to be embedded in the host image.
       if (CurPhase == phases::Link) {
-        if (SYCLDeviceActions.size()) {
+        if (!SYCLDeviceActions.empty()) {
           assert(SYCLDeviceActions.size() == DeviceLinkerInputs.size() &&
                  "Device action and device linker inputs sizes do not match.");
           for (auto TargetAction :
@@ -4188,7 +4188,7 @@ class OffloadingActionBuilder final {
           // Tests check that an integration header is created even if no kernel
           // is being built. This force compilation target to be added so that
           // the header is created until the CLI flags are cleaned up.
-          if (!SYCLTargetInfoList.size()) {
+          if (SYCLDeviceActions.empty()) {
             const ToolChain *TC = ToolChains.front();
             SYCLTargetInfoList.emplace_back(TC, nullptr);
           }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7224,7 +7224,8 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
     Triples += Action::GetOffloadKindName(CurKind);
     Triples += '-';
     Triples += CurTC->getTriple().normalize();
-    if (CurKind == Action::OFK_HIP && CurDep->getOffloadingArch()) {
+    if ((CurKind == Action::OFK_HIP || CurKind == Action::OFK_SYCL) &&
+        CurDep->getOffloadingArch()) {
       Triples += '-';
       Triples += CurDep->getOffloadingArch();
     }
@@ -7376,7 +7377,8 @@ void OffloadBundler::ConstructJobMultipleOutputs(
     Triples += Action::GetOffloadKindName(Dep.DependentOffloadKind);
     Triples += '-';
     Triples += Dep.DependentToolChain->getTriple().normalize();
-    if (Dep.DependentOffloadKind == Action::OFK_HIP &&
+    if ((Dep.DependentOffloadKind == Action::OFK_HIP ||
+         Dep.DependentOffloadKind == Action::OFK_SYCL) &&
         !Dep.DependentBoundArch.empty()) {
       Triples += '-';
       Triples += Dep.DependentBoundArch;

--- a/clang/test/Driver/sycl-offload-nvptx.cpp
+++ b/clang/test/Driver/sycl-offload-nvptx.cpp
@@ -30,8 +30,9 @@
 // CHK-PHASES-NO-CC: 11: linker, {10}, ir, (device-sycl, sm_50)
 // CHK-PHASES-NO-CC: 12: sycl-post-link, {11}, ir, (device-sycl, sm_50)
 // CHK-PHASES-NO-CC: 13: backend, {12}, assembler, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 14: clang-offload-wrapper, {13}, object, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 15: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (nvptx64-nvidia-nvcl-sycldevice:sm_50)" {14}, image
+// CHK-PHASES-NO-CC: 14: offload, "device-sycl (nvptx64-nvidia-nvcl-sycldevice:sm_50)" {13}, assembler
+// CHK-PHASES-NO-CC: 15: clang-offload-wrapper, {14}, object, (device-sycl)
+// CHK-PHASES-NO-CC: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (nvptx64-nvidia-nvcl-sycldevice)" {15}, image
 
 /// Check phases specifying a compute capability.
 // RUN: %clangxx -ccc-print-phases -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
@@ -52,5 +53,130 @@
 // CHK-PHASES: 11: linker, {10}, ir, (device-sycl, sm_35)
 // CHK-PHASES: 12: sycl-post-link, {11}, ir, (device-sycl, sm_35)
 // CHK-PHASES: 13: backend, {12}, assembler, (device-sycl, sm_35)
-// CHK-PHASES: 14: clang-offload-wrapper, {13}, object, (device-sycl, sm_35)
-// CHK-PHASES: 15: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (nvptx64-nvidia-nvcl-sycldevice:sm_35)" {14}, image
+// CHK-PHASES: 14: offload, "device-sycl (nvptx64-nvidia-nvcl-sycldevice:sm_35)" {13}, assembler
+// CHK-PHASES: 15: clang-offload-wrapper, {14}, object, (device-sycl)
+// CHK-PHASES: 16: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (nvptx64-nvidia-nvcl-sycldevice)" {15}, image
+
+/// Checks when requesting 2 CUDA gpu targets
+// RUN: %clangxx -ccc-print-phases -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: -fsycl-targets=nvptx64-nvidia-cuda-sycldevice \
+// RUN: -Xsycl-target-backend "--cuda-gpu-arch=sm_35" -Xsycl-target-backend "--cuda-gpu-arch=sm_70" %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-PHASES-SM35-70 %s
+// CHK-PHASES-SM35-70: 0: input, "[[INPUT:.*]]", c++, (host-sycl)
+// CHK-PHASES-SM35-70: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
+// CHK-PHASES-SM35-70: 2: input, "[[INPUT]]", c++, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70: 3: preprocessor, {2}, c++-cpp-output, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70: 4: compiler, {3}, sycl-header, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (nvptx64-nvidia-cuda-sycldevice:sm_70)" {4}, c++-cpp-output
+// CHK-PHASES-SM35-70: 6: compiler, {5}, ir, (host-sycl)
+// CHK-PHASES-SM35-70: 7: backend, {6}, assembler, (host-sycl)
+// CHK-PHASES-SM35-70: 8: assembler, {7}, object, (host-sycl)
+// CHK-PHASES-SM35-70: 9: linker, {8}, image, (host-sycl)
+// CHK-PHASES-SM35-70: 10: input, "[[INPUT]]", c++, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70: 11: preprocessor, {10}, c++-cpp-output, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70: 12: compiler, {11}, ir, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70: 13: linker, {12}, ir, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70: 14: sycl-post-link, {13}, ir, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70: 15: backend, {14}, assembler, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70: 16: assembler, {15}, object, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70: 17: offload, "device-sycl (nvptx64-nvidia-cuda-sycldevice:sm_35)" {16}, object
+// CHK-PHASES-SM35-70: 18: offload, "device-sycl (nvptx64-nvidia-cuda-sycldevice:sm_35)" {15}, assembler
+// CHK-PHASES-SM35-70: 19: compiler, {3}, ir, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70: 20: linker, {19}, ir, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70: 21: sycl-post-link, {20}, ir, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70: 22: backend, {21}, assembler, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70: 23: assembler, {22}, object, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70: 24: offload, "device-sycl (nvptx64-nvidia-cuda-sycldevice:sm_70)" {23}, object
+// CHK-PHASES-SM35-70: 25: offload, "device-sycl (nvptx64-nvidia-cuda-sycldevice:sm_70)" {22}, assembler
+// CHK-PHASES-SM35-70: 26: linker, {17, 18, 24, 25}, cuda-fatbin, (device-sycl)
+// CHK-PHASES-SM35-70: 27: clang-offload-wrapper, {26}, object, (device-sycl)
+// CHK-PHASES-SM35-70: 28: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (nvptx64-nvidia-cuda-sycldevice)" {27}, image
+
+/// Checks when requesting 2 CUDA gpu targets + SPIR
+// RUN: %clangxx -ccc-print-phases -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: -fsycl-targets=nvptx64-nvidia-cuda-sycldevice,spir64-unknown-unknown-sycldevice \
+// RUN: -Xsycl-target-backend "--cuda-gpu-arch=sm_35" -Xsycl-target-backend "--cuda-gpu-arch=sm_70" %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-PHASES-SM35-70-SPIR %s
+// CHK-PHASES-SM35-70-SPIR: 0: input, "[[INPUT:.*]]", c++, (host-sycl)
+// CHK-PHASES-SM35-70-SPIR: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
+// CHK-PHASES-SM35-70-SPIR: 2: input, "[[INPUT]]", c++, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 3: preprocessor, {2}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 4: compiler, {3}, sycl-header, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64-unknown-unknown-sycldevice)" {4}, c++-cpp-output
+// CHK-PHASES-SM35-70-SPIR: 6: compiler, {5}, ir, (host-sycl)
+// CHK-PHASES-SM35-70-SPIR: 7: backend, {6}, assembler, (host-sycl)
+// CHK-PHASES-SM35-70-SPIR: 8: assembler, {7}, object, (host-sycl)
+// CHK-PHASES-SM35-70-SPIR: 9: linker, {8}, image, (host-sycl)
+// CHK-PHASES-SM35-70-SPIR: 10: input, "[[INPUT]]", c++, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70-SPIR: 11: preprocessor, {10}, c++-cpp-output, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70-SPIR: 12: compiler, {11}, ir, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70-SPIR: 13: linker, {12}, ir, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70-SPIR: 14: sycl-post-link, {13}, ir, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70-SPIR: 15: backend, {14}, assembler, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70-SPIR: 16: assembler, {15}, object, (device-sycl, sm_35)
+// CHK-PHASES-SM35-70-SPIR: 17: offload, "device-sycl (nvptx64-nvidia-cuda-sycldevice:sm_35)" {16}, object
+// CHK-PHASES-SM35-70-SPIR: 18: offload, "device-sycl (nvptx64-nvidia-cuda-sycldevice:sm_35)" {15}, assembler
+// CHK-PHASES-SM35-70-SPIR: 19: input, "[[INPUT]]", c++, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70-SPIR: 20: preprocessor, {19}, c++-cpp-output, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70-SPIR: 21: compiler, {20}, ir, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70-SPIR: 22: linker, {21}, ir, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70-SPIR: 23: sycl-post-link, {22}, ir, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70-SPIR: 24: backend, {23}, assembler, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70-SPIR: 25: assembler, {24}, object, (device-sycl, sm_70)
+// CHK-PHASES-SM35-70-SPIR: 26: offload, "device-sycl (nvptx64-nvidia-cuda-sycldevice:sm_70)" {25}, object
+// CHK-PHASES-SM35-70-SPIR: 27: offload, "device-sycl (nvptx64-nvidia-cuda-sycldevice:sm_70)" {24}, assembler
+// CHK-PHASES-SM35-70-SPIR: 28: linker, {17, 18, 26, 27}, cuda-fatbin, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 29: clang-offload-wrapper, {28}, object, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 30: compiler, {3}, ir, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 31: linker, {30}, ir, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 32: sycl-post-link, {31}, tempfiletable, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 33: file-table-tform, {32}, tempfilelist, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 34: llvm-spirv, {33}, tempfilelist, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 35: file-table-tform, {32, 34}, tempfiletable, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 36: clang-offload-wrapper, {35}, object, (device-sycl)
+// CHK-PHASES-SM35-70-SPIR: 37: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (nvptx64-nvidia-cuda-sycldevice)" {29}, "device-sycl (spir64-unknown-unknown-sycldevice)" {36}, image
+
+/// Checks invocation when requesting 2 CUDA gpu targets
+// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: -fsycl-targets=nvptx64-nvidia-cuda-sycldevice \
+// RUN: -Xsycl-target-backend "--cuda-gpu-arch=sm_35" -Xsycl-target-backend "--cuda-gpu-arch=sm_70" %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-SM35-70 %s
+//      CPP -> BC for sm_35 step
+// CHK-INVOKE-SM35-70: "-cc1" "-triple" "nvptx64-nvidia-cuda-sycldevice" "-fsycl" "-fsycl-is-device" {{.*}} "-emit-llvm-bc" {{.*}} "-target-cpu" "sm_35" {{.*}}
+//      BC -> PTX for sm_35 step
+// CHK-INVOKE-SM35-70: "-cc1" "-triple" "nvptx64-nvidia-cuda-sycldevice" "-fsycl" "-fsycl-is-device" {{.*}} "-S" {{.*}} "-target-cpu" "sm_35" {{.*}} "-o" "[[SM_35_PTX:[^"]*]]"
+//      PTX -> CUBIN for sm_35 step
+// CHK-INVOKE-SM35-70: "{{.*}}ptxas" {{.*}} "--gpu-name" "sm_35" "--output-file" "[[SM_35_CUBIN:[^"]*]]" "[[SM_35_PTX]]"
+//      CPP -> BC for sm_70 step
+// CHK-INVOKE-SM35-70: "-cc1" "-triple" "nvptx64-nvidia-cuda-sycldevice" "-fsycl" "-fsycl-is-device" {{.*}} "-emit-llvm-bc" {{.*}} "-target-cpu" "sm_70" {{.*}}
+//      BC -> PTX for sm_70 step
+// CHK-INVOKE-SM35-70: "-cc1" "-triple" "nvptx64-nvidia-cuda-sycldevice" "-fsycl" "-fsycl-is-device" {{.*}} "-S" {{.*}} "-target-cpu" "sm_70" {{.*}} "-o" "[[SM_70_PTX:[^"]*]]"
+//      PTX -> CUBIN for sm_70 step
+// CHK-INVOKE-SM35-70: "{{.*}}ptxas" {{.*}} "--gpu-name" "sm_70" "--output-file" "[[SM_70_CUBIN:[^"]*]]" "[[SM_70_PTX]]"
+// CHK-INVOKE-SM35-70: "{{.*}}fatbinary" "-64" "--create" "[[FATBIN:[^"]*]]" "--image=profile=sm_35,file=[[SM_35_CUBIN]]" "--image=profile=compute_35,file=[[SM_35_PTX]]" "--image=profile=sm_70,file=[[SM_70_CUBIN]]" "--image=profile=compute_70,file=[[SM_70_PTX]]"
+// CHK-INVOKE-SM35-70: "{{.*}}clang-offload-wrapper" {{.*}} "[[FATBIN]]"
+
+/// Checks when requesting 2 CUDA gpu targets + SPIR
+// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: -fsycl-targets=nvptx64-nvidia-cuda-sycldevice,spir64-unknown-unknown-sycldevice \
+// RUN: -Xsycl-target-backend=nvptx64-nvidia-cuda-sycldevice "--cuda-gpu-arch=sm_35" -Xsycl-target-backend=nvptx64-nvidia-cuda-sycldevice "--cuda-gpu-arch=sm_70" %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-SM35-70-SPIR %s
+//      CPP -> BC for sm_35 step
+// CHK-INVOKE-SM35-70-SPIR: "-cc1" "-triple" "nvptx64-nvidia-cuda-sycldevice" "-fsycl" "-fsycl-is-device" {{.*}} "-emit-llvm-bc" {{.*}} "-target-cpu" "sm_35" {{.*}}
+//      BC -> PTX for sm_35 step
+// CHK-INVOKE-SM35-70-SPIR: "-cc1" "-triple" "nvptx64-nvidia-cuda-sycldevice" "-fsycl" "-fsycl-is-device" {{.*}} "-S" {{.*}} "-target-cpu" "sm_35" {{.*}} "-o" "[[SM_35_PTX:[^"]*]]"
+//      PTX -> CUBIN for sm_35 step
+// CHK-INVOKE-SM35-70-SPIR: "{{.*}}ptxas" {{.*}} "--gpu-name" "sm_35" "--output-file" "[[SM_35_CUBIN:[^"]*]]" "[[SM_35_PTX]]"
+//      CPP -> BC for sm_70 step
+// CHK-INVOKE-SM35-70-SPIR: "-cc1" "-triple" "nvptx64-nvidia-cuda-sycldevice" "-fsycl" "-fsycl-is-device" {{.*}} "-emit-llvm-bc" {{.*}} "-target-cpu" "sm_70" {{.*}}
+//      BC -> PTX for sm_70 step
+// CHK-INVOKE-SM35-70-SPIR: "-cc1" "-triple" "nvptx64-nvidia-cuda-sycldevice" "-fsycl" "-fsycl-is-device" {{.*}} "-S" {{.*}} "-target-cpu" "sm_70" {{.*}} "-o" "[[SM_70_PTX:[^"]*]]"
+//      PTX -> CUBIN for sm_70 step
+// CHK-INVOKE-SM35-70-SPIR: "{{.*}}ptxas" {{.*}} "--gpu-name" "sm_70" "--output-file" "[[SM_70_CUBIN:[^"]*]]" "[[SM_70_PTX]]"
+// CHK-INVOKE-SM35-70-SPIR: "{{.*}}fatbinary" "-64" "--create" "[[FATBIN:[^"]*]]" "--image=profile=sm_35,file=[[SM_35_CUBIN]]" "--image=profile=compute_35,file=[[SM_35_PTX]]" "--image=profile=sm_70,file=[[SM_70_CUBIN]]" "--image=profile=compute_70,file=[[SM_70_PTX]]"
+// CHK-INVOKE-SM35-70-SPIR: "{{.*}}clang-offload-wrapper" "-o=[[CUDA_WRAPPER_BC:[^"]*]]" {{.*}} "[[FATBIN]]"
+// CHK-INVOKE-SM35-70-SPIR: "{{.*}}llc" {{.*}} "-o" "[[CUDA_WRAPPER:[^"]*]]" "[[CUDA_WRAPPER_BC]]"
+//      SPIR step
+// CHK-INVOKE-SM35-70-SPIR: "-cc1" "-triple" "spir64-unknown-unknown-sycldevice" "-fsycl" "-fsycl-is-device"
+// CHK-INVOKE-SM35-70-SPIR: "{{.*}}llc" {{.*}} "-o" "[[SPIR_WRAPPER:[^"]*]]"
+// CHK-INVOKE-SM35-70-SPIR: "{{.*}}ld" {{.*}} "[[CUDA_WRAPPER]]" "[[SPIR_WRAPPER]]"

--- a/clang/test/Driver/sycl-offload-with-split.c
+++ b/clang/test/Driver/sycl-offload-with-split.c
@@ -234,7 +234,7 @@
 // CHK-PHASE-MULTI-TARG: 2: input, "[[INPUT]]", c, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 3: preprocessor, {2}, cpp-output, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 4: compiler, {3}, sycl-header, (device-sycl)
-// CHK-PHASE-MULTI-TARG: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64-unknown-unknown-sycldevice)" {4}, cpp-output
+// CHK-PHASE-MULTI-TARG: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_gen-unknown-unknown-sycldevice)" {4}, cpp-output
 // CHK-PHASE-MULTI-TARG: 6: compiler, {5}, ir, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 7: backend, {6}, assembler, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 8: assembler, {7}, object, (host-sycl)

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -546,22 +546,20 @@
 // CHK-ADD-TARGETS-REG-MUL: 7: backend, {6}, assembler, (host-sycl)
 // CHK-ADD-TARGETS-REG-MUL: 8: assembler, {7}, object, (host-sycl)
 // CHK-ADD-TARGETS-REG-MUL: 9: linker, {8}, image, (host-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 10: input, "[[INPUT]]", c, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 11: preprocessor, {10}, cpp-output, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 12: compiler, {11}, ir, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 13: linker, {12}, ir, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 14: sycl-post-link, {13}, tempfiletable, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 15: file-table-tform, {14}, tempfilelist, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 16: llvm-spirv, {15}, tempfilelist, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 17: file-table-tform, {14, 16}, tempfiletable, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 10: compiler, {3}, ir, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 11: linker, {10}, ir, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 12: sycl-post-link, {11}, tempfiletable, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 13: file-table-tform, {12}, tempfilelist, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 14: llvm-spirv, {13}, tempfilelist, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 15: file-table-tform, {12, 14}, tempfiletable, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 16: clang-offload-wrapper, {15}, object, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 17: input, "dummy.aocx", sycl-fatbin, (device-sycl)
 // CHK-ADD-TARGETS-REG-MUL: 18: clang-offload-wrapper, {17}, object, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 19: input, "dummy.aocx", sycl-fatbin, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 19: input, "dummy_Gen9core.bin", sycl-fatbin, (device-sycl)
 // CHK-ADD-TARGETS-REG-MUL: 20: clang-offload-wrapper, {19}, object, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 21: input, "dummy_Gen9core.bin", sycl-fatbin, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 21: input, "dummy.ir", sycl-fatbin, (device-sycl)
 // CHK-ADD-TARGETS-REG-MUL: 22: clang-offload-wrapper, {21}, object, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 23: input, "dummy.ir", sycl-fatbin, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 24: clang-offload-wrapper, {23}, object, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 25: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64-unknown-unknown-sycldevice)" {18}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {20}, "device-sycl (spir64_gen-unknown-unknown-sycldevice)" {22}, "device-sycl (spir64_x86_64-unknown-unknown-sycldevice)" {24}, image
+// CHK-ADD-TARGETS-REG-MUL: 23: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64-unknown-unknown-sycldevice)" {16}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {18}, "device-sycl (spir64_gen-unknown-unknown-sycldevice)" {20}, "device-sycl (spir64_x86_64-unknown-unknown-sycldevice)" {22}, image
 
 /// ###########################################################################
 
@@ -769,7 +767,7 @@
 // CHK-PHASE-MULTI-TARG: 2: input, "[[INPUT]]", c, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 3: preprocessor, {2}, cpp-output, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 4: compiler, {3}, sycl-header, (device-sycl)
-// CHK-PHASE-MULTI-TARG: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64-unknown-unknown-sycldevice)" {4}, cpp-output
+// CHK-PHASE-MULTI-TARG: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_gen-unknown-unknown-sycldevice)" {4}, cpp-output
 // CHK-PHASE-MULTI-TARG: 6: compiler, {5}, ir, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 7: backend, {6}, assembler, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 8: assembler, {7}, object, (host-sycl)

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -767,7 +767,7 @@
 // CHK-PHASE-MULTI-TARG: 2: input, "[[INPUT]]", c, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 3: preprocessor, {2}, cpp-output, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 4: compiler, {3}, sycl-header, (device-sycl)
-// CHK-PHASE-MULTI-TARG: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_gen-unknown-unknown-sycldevice)" {4}, cpp-output
+// CHK-PHASE-MULTI-TARG: 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64{{.*}}-unknown-unknown-sycldevice)" {4}, cpp-output
 // CHK-PHASE-MULTI-TARG: 6: compiler, {5}, ir, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 7: backend, {6}, assembler, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 8: assembler, {7}, object, (host-sycl)


### PR DESCRIPTION
The patch refactored the SYCL offloading to account for bound arch as well as toolchains.
Compilation target are represented as a pair of a toolchain (one toolchain per target triple) and a bound arch (which encodes the target arch).

The LTO step is now performed per toolchain/bound arch pair and
the produced binary are then bundled per toolchain.

The patch also makes the bundler/unbundler use the bound arch when SYCL offloading if enabled.

Signed-off-by: Victor Lomuller <victor@codeplay.com>
Co-authored-by: Alexander Johnston <alexander@codeplay.com>