### PR TITLE
[SYCL] Implement range simplification for other parallel_for queue API

### DIFF
--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -493,10 +493,9 @@ public:
   /// \param DepEvent is an event that specifies the kernel dependencies
   /// \param KernelFunc is the Kernel functor or lambda
   /// \param CodeLoc contains the code location of user code
-  template <typename KernelName = detail::auto_name, typename KernelType,
-            int Dims>
+  template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<Dims> NumWorkItems, event DepEvent, KernelType KernelFunc
+      range<1> NumWorkItems, event DepEvent, KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
       const detail::code_location &CodeLoc = detail::code_location::current()
@@ -505,13 +504,52 @@ public:
 #ifdef DISABLE_SYCL_INSTRUMENTATION_METADATA
     const detail::code_location &CodeLoc = {};
 #endif
-    return submit(
-        [&](handler &CGH) {
-          CGH.depends_on(DepEvent);
-          CGH.template parallel_for<KernelName, KernelType>(NumWorkItems,
-                                                            KernelFunc);
-        },
-        CodeLoc);
+    return parallel_for_impl<KernelName>(NumWorkItems, DepEvent, KernelFunc,
+                                         CodeLoc);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param NumWorkItems is a range that specifies the work space of the kernel
+  /// \param DepEvent is an event that specifies the kernel dependencies
+  /// \param KernelFunc is the Kernel functor or lambda
+  /// \param CodeLoc contains the code location of user code
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event parallel_for(
+      range<2> NumWorkItems, event DepEvent, KernelType KernelFunc
+#ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
+      ,
+      const detail::code_location &CodeLoc = detail::code_location::current()
+#endif
+  ) {
+#ifdef DISABLE_SYCL_INSTRUMENTATION_METADATA
+    const detail::code_location &CodeLoc = {};
+#endif
+    return parallel_for_impl<KernelName>(NumWorkItems, DepEvent, KernelFunc,
+                                         CodeLoc);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param NumWorkItems is a range that specifies the work space of the kernel
+  /// \param DepEvent is an event that specifies the kernel dependencies
+  /// \param KernelFunc is the Kernel functor or lambda
+  /// \param CodeLoc contains the code location of user code
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event parallel_for(
+      range<3> NumWorkItems, event DepEvent, KernelType KernelFunc
+#ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
+      ,
+      const detail::code_location &CodeLoc = detail::code_location::current()
+#endif
+  ) {
+#ifdef DISABLE_SYCL_INSTRUMENTATION_METADATA
+    const detail::code_location &CodeLoc = {};
+#endif
+    return parallel_for_impl<KernelName>(NumWorkItems, DepEvent, KernelFunc,
+                                         CodeLoc);
   }
 
   /// parallel_for version with a kernel represented as a lambda + range that
@@ -522,10 +560,9 @@ public:
   /// dependencies
   /// \param KernelFunc is the Kernel functor or lambda
   /// \param CodeLoc contains the code location of user code
-  template <typename KernelName = detail::auto_name, typename KernelType,
-            int Dims>
+  template <typename KernelName = detail::auto_name, typename KernelType>
   event parallel_for(
-      range<Dims> NumWorkItems, const vector_class<event> &DepEvents,
+      range<1> NumWorkItems, const vector_class<event> &DepEvents,
       KernelType KernelFunc
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
       ,
@@ -535,13 +572,56 @@ public:
 #ifdef DISABLE_SYCL_INSTRUMENTATION_METADATA
     const detail::code_location &CodeLoc = {};
 #endif
-    return submit(
-        [&](handler &CGH) {
-          CGH.depends_on(DepEvents);
-          CGH.template parallel_for<KernelName, KernelType>(NumWorkItems,
-                                                            KernelFunc);
-        },
-        CodeLoc);
+    return parallel_for_impl<KernelName>(NumWorkItems, DepEvents, KernelFunc,
+                                         CodeLoc);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param NumWorkItems is a range that specifies the work space of the kernel
+  /// \param DepEvents is a vector of events that specifies the kernel
+  /// dependencies
+  /// \param KernelFunc is the Kernel functor or lambda
+  /// \param CodeLoc contains the code location of user code
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event parallel_for(
+      range<2> NumWorkItems, const vector_class<event> &DepEvents,
+      KernelType KernelFunc
+#ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
+      ,
+      const detail::code_location &CodeLoc = detail::code_location::current()
+#endif
+  ) {
+#ifdef DISABLE_SYCL_INSTRUMENTATION_METADATA
+    const detail::code_location &CodeLoc = {};
+#endif
+    return parallel_for_impl<KernelName>(NumWorkItems, DepEvents, KernelFunc,
+                                         CodeLoc);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param NumWorkItems is a range that specifies the work space of the kernel
+  /// \param DepEvents is a vector of events that specifies the kernel
+  /// dependencies
+  /// \param KernelFunc is the Kernel functor or lambda
+  /// \param CodeLoc contains the code location of user code
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event parallel_for(
+      range<3> NumWorkItems, const vector_class<event> &DepEvents,
+      KernelType KernelFunc
+#ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
+      ,
+      const detail::code_location &CodeLoc = detail::code_location::current()
+#endif
+  ) {
+#ifdef DISABLE_SYCL_INSTRUMENTATION_METADATA
+    const detail::code_location &CodeLoc = {};
+#endif
+    return parallel_for_impl<KernelName>(NumWorkItems, DepEvents, KernelFunc,
+                                         CodeLoc);
   }
 
   /// parallel_for version with a kernel represented as a lambda + range and
@@ -764,6 +844,50 @@ private:
       const detail::code_location &CodeLoc = detail::code_location::current()) {
     return submit(
         [&](handler &CGH) {
+          CGH.template parallel_for<KernelName, KernelType>(NumWorkItems,
+                                                            KernelFunc);
+        },
+        CodeLoc);
+  }
+
+  /// parallel_for_impl with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param NumWorkItems is a range that specifies the work space of the kernel
+  /// \param DepEvent is an event that specifies the kernel dependencies
+  /// \param KernelFunc is the Kernel functor or lambda
+  /// \param CodeLoc contains the code location of user code
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for_impl(range<Dims> NumWorkItems, event DepEvent,
+                          KernelType KernelFunc,
+                          const detail::code_location &CodeLoc) {
+    return submit(
+        [&](handler &CGH) {
+          CGH.depends_on(DepEvent);
+          CGH.template parallel_for<KernelName, KernelType>(NumWorkItems,
+                                                            KernelFunc);
+        },
+        CodeLoc);
+  }
+
+  /// parallel_for_impl version with a kernel represented as a lambda + range
+  /// that specifies global size only.
+  ///
+  /// \param NumWorkItems is a range that specifies the work space of the kernel
+  /// \param DepEvents is a vector of events that specifies the kernel
+  /// dependencies
+  /// \param KernelFunc is the Kernel functor or lambda
+  /// \param CodeLoc contains the code location of user code
+  template <typename KernelName = detail::auto_name, typename KernelType,
+            int Dims>
+  event parallel_for_impl(range<Dims> NumWorkItems,
+                          const vector_class<event> &DepEvents,
+                          KernelType KernelFunc,
+                          const detail::code_location &CodeLoc) {
+    return submit(
+        [&](handler &CGH) {
+          CGH.depends_on(DepEvents);
           CGH.template parallel_for<KernelName, KernelType>(NumWorkItems,
                                                             KernelFunc);
         },

--- a/sycl/test/basic_tests/queue/queue_parallel_for_interface.cpp
+++ b/sycl/test/basic_tests/queue/queue_parallel_for_interface.cpp
@@ -109,11 +109,14 @@ int main() {
 
   test_number_braced_init_list(q);
 
+  // We need to get to event for further API testsing
+  // Getting them with two same calls
   auto e1 = q.parallel_for<class Event1>(1, [=](auto i) {
     static_assert(std::is_same<decltype(i), sycl::item<1>>::value,
                   "lambda arg type is unexpected");
   });
 
+  // Getting the second event for further API calling
   auto e2 = q.parallel_for<class Event2>(1, [=](auto i) {
     static_assert(std::is_same<decltype(i), sycl::item<1>>::value,
                   "lambda arg type is unexpected");

--- a/sycl/test/usm/pfor_flatten_range_shortcut.cpp
+++ b/sycl/test/usm/pfor_flatten_range_shortcut.cpp
@@ -1,0 +1,55 @@
+// UNSUPPORTED: cuda
+// CUDA does not support the unnamed lambda extension.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  -fsycl-unnamed-lambda %s -o %t1.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %CPU_RUN_PLACEHOLDER %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+
+//==-- pfor_flatten_range_shortcut.cpp - Kernel Launch Flattening test -----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+int main() {
+  int *array = nullptr;
+  const int N = 42;
+  const int MAGIC_NUM = 4;
+
+  sycl::queue q;
+  auto ctxt = q.get_context();
+
+  array = (int *)sycl::malloc_host(N * sizeof(int), q);
+  if (array == nullptr) {
+    return -1;
+  }
+
+  auto e1 = q.parallel_for(N, [=](auto item) {
+    array[item] = 1;
+  });
+
+  auto e2 = q.parallel_for({N}, e1, [=](auto item) {
+    array[item] += 2;
+  });
+
+  q.parallel_for(N, {e1, e2}, [=](auto item) {
+    array[item]++;
+  });
+
+  q.wait();
+
+  for (int i = 0; i < N; i++) {
+    if (array[i] != MAGIC_NUM) {
+      assert(array[i] == MAGIC_NUM);
+    }
+  }
+
+  free(array, ctxt);
+
+  return 0;
+}

--- a/sycl/test/usm/pfor_flatten_range_shortcut.cpp
+++ b/sycl/test/usm/pfor_flatten_range_shortcut.cpp
@@ -17,39 +17,39 @@
 #include <CL/sycl.hpp>
 
 int main() {
-  int *array = nullptr;
-  const int N = 42;
-  const int MAGIC_NUM = 4;
+  constexpr int n = 42;
+  constexpr int magic_num = 4;
 
   sycl::queue q;
   auto ctxt = q.get_context();
 
-  array = (int *)sycl::malloc_host(N * sizeof(int), q);
+  int *array = (int *)sycl::malloc_host(n * sizeof(int), q);
+
   if (array == nullptr) {
     return -1;
   }
 
-  auto e1 = q.parallel_for(N, [=](auto item) {
+  auto e1 = q.parallel_for(n, [=](auto item) {
     array[item] = 1;
   });
 
-  auto e2 = q.parallel_for({N}, e1, [=](auto item) {
+  auto e2 = q.parallel_for({n}, e1, [=](auto item) {
     array[item] += 2;
   });
 
-  q.parallel_for(N, {e1, e2}, [=](auto item) {
+  q.parallel_for(n, {e1, e2}, [=](auto item) {
     array[item]++;
   });
 
   q.wait();
 
-  for (int i = 0; i < N; i++) {
-    if (array[i] != MAGIC_NUM) {
-      assert(array[i] == MAGIC_NUM);
+  for (int i = 0; i < n; i++) {
+    if (array[i] != magic_num) {
+      assert(array[i] == magic_num);
     }
   }
 
-  free(array, ctxt);
+  sycl::free(array, ctxt);
 
   return 0;
 }


### PR DESCRIPTION
Modification:
    Add overloads with `range<1>`, `range<2>`, `range<3>` to allow implicit
    conversion from number or braced-init-list to range

Signed-off-by: Ruslan Arutyunyan <ruslan.arutyunyan@intel.com>