### PR TITLE
[SYCL][NFC] Make lit tests agnostic to compiler optimizations

### DIFF
--- a/sycl/test/check_device_code/kernel_arguments_as.cpp
+++ b/sycl/test/check_device_code/kernel_arguments_as.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll -I %sycl_include -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll -I %sycl_include -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning -Xclang -disable-llvm-passes
 // RUN: FileCheck %s --input-file %t.ll
 //
 // Check the address space of the pointer in accessor class.

--- a/sycl/test/check_device_code/usm_pointers.cpp
+++ b/sycl/test/check_device_code/usm_pointers.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll -I %sycl_include -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll -I %sycl_include -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning -Xclang -disable-llvm-passes
 // RUN: FileCheck %s --input-file %t.ll
 //
 // Check the address space of the pointer in multi_ptr class

--- a/sycl/test/fpga_tests/ap_fixed.cpp
+++ b/sycl/test/fpga_tests/ap_fixed.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -I %sycl_include -S -emit-llvm -fsycl-device-only %s -o - | FileCheck %s
+// RUN: %clangxx -I %sycl_include -S -emit-llvm -fsycl-device-only %s -o - -Xclang -disable-llvm-passes | FileCheck %s
 //
 //==---- ap_fixed.cpp - SYCL FPGA arbitrary precision fixed point test -----==//
 //


### PR DESCRIPTION
As of today SYCL device compiler do not apply any LLVM transformations
to emitted LLVM code, but SYCL tests shouldn't rely on this behavior, so
this patch explicitly set compiler option to disable any LLVM passes.