### PR TITLE
[WIP][SYCL] Implement sycl_special_class attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1135,6 +1135,20 @@ def SYCLKernel : InheritableAttr {
   let Documentation = [SYCLKernelDocs];
 }
 
+def SYCLSpecialClass: InheritableAttr {
+  let Spellings = [Clang<"sycl_special_class">];
+  let Subjects = SubjectList<[CXXRecord]>;
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  // TODO: Add doc
+  let Documentation = [Undocumented];
+  let Args = [
+    EnumArgument<"SpecialClassKind", "SpecialClassKind",
+                 [ "accessor", "sampler", "stream", "" ],
+                 [ "Accessor", "Sampler", "Stream", "Generic" ], 1>
+  ];
+  let PragmaAttributeSupport = 0;
+}
+
 // Marks functions which must not be vectorized via horizontal SIMT widening,
 // e.g. because the function is already vectorized. Used to mark SYCL
 // explicit SIMD kernels and functions.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2692,17 +2692,33 @@ SYCLIntegrationHeader::SYCLIntegrationHeader(DiagnosticsEngine &_Diag,
 // -----------------------------------------------------------------------------
 
 bool Util::isSyclAccessorType(const QualType &Ty) {
-  return isSyclType(Ty, "accessor", true /*Tmpl*/);
+  const CXXRecordDecl *RecTy = Ty->getAsCXXRecordDecl();
+  if (!RecTy)
+    return false; // only classes/structs supported
+  if (const auto *A = RecTy->getAttr<SYCLSpecialClassAttr>())
+    return A->getSpecialClassKind() == SYCLSpecialClassAttr::Accessor;
+  return false;
 }
 
 bool Util::isSyclSamplerType(const QualType &Ty) {
-  return isSyclType(Ty, "sampler");
+  const CXXRecordDecl *RecTy = Ty->getAsCXXRecordDecl();
+  if (!RecTy)
+    return false; // only classes/structs supported
+  if (const auto *A = RecTy->getAttr<SYCLSpecialClassAttr>())
+    return A->getSpecialClassKind() == SYCLSpecialClassAttr::Sampler;
+  return false;
 }
 
 bool Util::isSyclStreamType(const QualType &Ty) {
-  return isSyclType(Ty, "stream");
+  const CXXRecordDecl *RecTy = Ty->getAsCXXRecordDecl();
+  if (!RecTy)
+    return false; // only classes/structs supported
+  if (const auto *A = RecTy->getAttr<SYCLSpecialClassAttr>())
+    return A->getSpecialClassKind() == SYCLSpecialClassAttr::Stream;
+  return false;
 }
 
+// TODO: Remove this once structs decomposing is optimized
 bool Util::isSyclHalfType(const QualType &Ty) {
   const StringRef &Name = "half";
   std::array<DeclContextDesc, 5> Scopes = {
@@ -2714,6 +2730,7 @@ bool Util::isSyclHalfType(const QualType &Ty) {
   return matchQualifiedTypeName(Ty, Scopes);
 }
 
+// TODO: Do we need an attribute for this one as well?
 bool Util::isSyclSpecConstantType(const QualType &Ty) {
   const StringRef &Name = "spec_constant";
   std::array<DeclContextDesc, 4> Scopes = {

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -11,7 +11,7 @@ struct sampler_impl {
 #endif
 };
 
-class sampler {
+class __attribute__((sycl_special_class(sampler))) sampler {
   struct sampler_impl impl;
 #ifdef __SYCL_DEVICE_ONLY__
   void __init(__ocl_sampler_t Sampler) { impl.m_Sampler = Sampler; }
@@ -128,7 +128,7 @@ struct _ImplT {
 template <typename dataT, int dimensions, access::mode accessmode,
           access::target accessTarget = access::target::global_buffer,
           access::placeholder isPlaceholder = access::placeholder::false_t>
-class accessor {
+class __attribute__((sycl_special_class(accessor))) accessor {
 
 public:
   void use(void) const {}
@@ -189,7 +189,7 @@ struct _ImageImplT {
 };
 
 template <typename dataT, int dimensions, access::mode accessmode>
-class accessor<dataT, dimensions, accessmode, access::target::image, access::placeholder::false_t> {
+class __attribute__((sycl_special_class(accessor))) accessor<dataT, dimensions, accessmode, access::target::image, access::placeholder::false_t> {
 public:
   void use(void) const {}
   template <typename... T>
@@ -310,7 +310,7 @@ public:
   }
 };
 
-class stream {
+class __attribute__((sycl_special_class(stream))) stream {
 public:
   stream(unsigned long BufferSize, unsigned long MaxStatementSize,
          handler &CGH) {}

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -87,7 +87,7 @@ struct DeviceValueType<dataT, access::target::local> {
 template <typename dataT, int dimensions, access::mode accessmode,
           access::target accessTarget = access::target::global_buffer,
           access::placeholder isPlaceholder = access::placeholder::false_t>
-class accessor {
+class __attribute__((sycl_special_class(accessor))) accessor {
 
 public:
   void use(void) const {}
@@ -146,7 +146,7 @@ struct _ImageImplT {
 };
 
 template <typename dataT, int dimensions, access::mode accessmode>
-class accessor<dataT, dimensions, accessmode, access::target::image, access::placeholder::false_t> {
+class __attribute__((sycl_special_class(accessor))) accessor<dataT, dimensions, accessmode, access::target::image, access::placeholder::false_t> {
 public:
   void use(void) const {}
   template <typename... T>
@@ -165,7 +165,7 @@ struct sampler_impl {
 #endif
 };
 
-class sampler {
+class __attribute__((sycl_special_class(sampler))) sampler {
   struct sampler_impl impl;
 #ifdef __SYCL_DEVICE_ONLY__
   void __init(__ocl_sampler_t Sampler) { impl.m_Sampler = Sampler; }

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -730,7 +730,7 @@ private:
 /// \ingroup sycl_api_acc
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::target AccessTarget, access::placeholder IsPlaceholder>
-class accessor :
+class __SYCL_SPECIAL_CLASS(accessor) accessor :
 #ifndef __SYCL_DEVICE_ONLY__
     public detail::AccessorBaseHost,
 #endif
@@ -1350,8 +1350,8 @@ accessor(buffer<DataT, Dimensions, AllocatorT>, handler, Type1, Type2, Type3,
 /// \ingroup sycl_api_acc
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::placeholder IsPlaceholder>
-class accessor<DataT, Dimensions, AccessMode, access::target::local,
-               IsPlaceholder> :
+class __SYCL_SPECIAL_CLASS(accessor) accessor<
+    DataT, Dimensions, AccessMode, access::target::local, IsPlaceholder> :
 #ifndef __SYCL_DEVICE_ONLY__
     public detail::LocalAccessorBaseHost,
 #endif
@@ -1516,8 +1516,8 @@ public:
 /// \ingroup sycl_api_acc
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::placeholder IsPlaceholder>
-class accessor<DataT, Dimensions, AccessMode, access::target::image,
-               IsPlaceholder>
+class __SYCL_SPECIAL_CLASS(accessor) accessor<
+    DataT, Dimensions, AccessMode, access::target::image, IsPlaceholder>
     : public detail::image_accessor<DataT, Dimensions, AccessMode,
                                     access::target::image, IsPlaceholder> {
 public:
@@ -1580,8 +1580,8 @@ public:
 /// \ingroup sycl_api_acc
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::placeholder IsPlaceholder>
-class accessor<DataT, Dimensions, AccessMode, access::target::image_array,
-               IsPlaceholder>
+class __SYCL_SPECIAL_CLASS(accessor) accessor<
+    DataT, Dimensions, AccessMode, access::target::image_array, IsPlaceholder>
     : public detail::image_accessor<DataT, Dimensions + 1, AccessMode,
                                     access::target::image, IsPlaceholder> {
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/detail/defines.hpp
+++ b/sycl/include/CL/sycl/detail/defines.hpp
@@ -59,3 +59,9 @@
 #else
 #define __SYCL_INLINE_CONSTEXPR static constexpr
 #endif
+
+#if __has_attribute(sycl_special_class)
+#define __SYCL_SPECIAL_CLASS(kind) __attribute__((sycl_special_class(kind)))
+#else
+#define __SYCL_SPECIAL_CLASS(kind)
+#endif

--- a/sycl/include/CL/sycl/sampler.hpp
+++ b/sycl/include/CL/sycl/sampler.hpp
@@ -45,7 +45,7 @@ class image_accessor;
 /// \sa sycl_api_acc
 ///
 /// \ingroup sycl_api
-class __SYCL_EXPORT sampler {
+class __SYCL_EXPORT __SYCL_SPECIAL_CLASS(sampler) sampler {
 public:
   sampler(coordinate_normalization_mode normalizationMode,
           addressing_mode addressingMode, filtering_mode filteringMode);

--- a/sycl/include/CL/sycl/stream.hpp
+++ b/sycl/include/CL/sycl/stream.hpp
@@ -94,7 +94,7 @@ inline __width_manipulator__ setw(int Width) {
 /// vector and SYCL types to the console.
 ///
 /// \ingroup sycl_api
-class __SYCL_EXPORT stream {
+class __SYCL_EXPORT __SYCL_SPECIAL_CLASS(stream) stream {
 public:
   stream(size_t BufferSize, size_t MaxStatementSize, handler &CGH);
 


### PR DESCRIPTION
This attribute is used in SYCL headers to mark SYCL classes which need
additional compiler handling when passed from host to device.
Attribute can be applied to struct/class and can have optional argument
which indicates kind of SYCL special class, so it can be used to
implement handling of some generic case of SYCL special class as well as
implement different handling for each kind of SYCL special class.

Usage:
```
class __attribute__((sycl_special_class(accessor))) accessor {
...
}
```

The PR is created to gather early community feedback regarding the attribute form, since similar approach was discussed on upstreaming WG.

To finish this one, the following needs to be done:
-[ ] Add documentation
-[ ] Add a test for attribute
-[ ] Resolve TODO about spec constant class detection

Closes #2041