### PR TITLE
[SYCL]Emit an error if an array size exceeds SPIR-V intermediate format limitations

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10908,6 +10908,9 @@ def err_sycl_restrict : Error<
   "|use a const static or global variable that is neither zero-initialized "
   "nor constant-initialized"
   "}0">;
+def err_array_num_elements_exceeded
+    : Error<"Due to SPIR-V intermediate format limitations, constant arrays with number of elements more than 65532 cannot be used in SYCL."
+            "You can workaround this limitation by splitting the array into several ones">;
 def err_sycl_virtual_types : Error<
   "No class with a vtable can be used in a SYCL kernel or any code included in the kernel">;
 def note_sycl_recursive_function_declared_here: Note<"function implemented using recursion declared here">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -9969,6 +9969,7 @@ public:
   bool checkNSReturnsRetainedReturnType(SourceLocation loc, QualType type);
   bool checkAllowedSYCLInitializer(VarDecl *VD,
                                    bool CheckValueDependent = false);
+  bool isArrayZeroInitialized(VarDecl *VD, bool CheckValueDependent = false);
 
   // Adds an intel_reqd_sub_group_size attribute to a particular declaration.
   void addIntelReqdSubGroupSizeAttr(Decl *D, const AttributeCommonInfo &CI,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2087,9 +2087,8 @@ bool Sema::isArrayZeroInitialized(VarDecl *VD, bool CheckValueDependent) {
     Value = VD->evaluateValue();
   // zero-initialized arrays do not have any initialized elements.
   if (Value && Value->isArray() && Value->hasArrayFiller() &&
-      Value->getArrayInitializedElts() == 0) {
+      Value->getArrayInitializedElts() == 0)
     return true;
-  }
   return false;
 }
 

--- a/clang/test/SemaSYCL/array-num-elements-exceeded.cpp
+++ b/clang/test/SemaSYCL/array-num-elements-exceeded.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir-unknown -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown -verify -fsyntax-only %s
+
+const double big[67000] = {1.0, 2.0, 3.0};
+const int zero_init_array[67000] = {};
+
+template <typename Name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc(); // expected-note {{called by 'kernel_single_task<fake_kernel, (lambda}}
+}
+
+int main() {
+  double hostResult = big[0]; // no error thrown, since accessing global const arrays with size > 65532 is valid from host code.
+  kernel_single_task<class fake_kernel>([]() {
+    int a = zero_init_array[0]; // no error thrown, since accessing zero-initialized arrays with size > 65532 is valid.
+    double kernelGlobal = big[0]; // expected-error {{Due to SPIR-V intermediate format limitations, constant arrays with number of elements more than 65532 cannot be used in SYCL.You can workaround this limitation by splitting the array into several ones}}
+  });
+  return 0;
+}


### PR DESCRIPTION
- Some limitations in SPIR-V specification affect how SYCL code can be written.
- This PR addresses one such case where we cannot access a global variable which is a const array with more than ~65532 elements from within a SYCL kernel, because of the 65,535 wordcount limit on SPIR-V instruction. Refer : [Instruction-wordcount-limit](https://www.khronos.org/registry/spir-v/specs/1.0/SPIRV.html#_a_id_limits_a_universal_limits)
- The SPIRV-LLVM-Translator was updated to prevent crashing and instead emit a helpful message about this SPIR-V limitation. PR [here](https://github.com/intel/llvm/commit/d6140b06fe46afcef519a89acf7e9f1a6bba1a31#diff-2a050af60d1348a0a51cae5fb58b3df5)

According to SPIR-V specification Section [2.17.Universal-Limits](https://www.khronos.org/registry/spir-v/specs/1.0/SPIRV.html#_a_id_limits_a_universal_limits) :

> 2.17. Universal Limits
> These quantities are _minimum limits_ for all implementations and validators. Implementations are allowed to _support larger quantities_. Specific APIs may impose larger minimums.

While this means that a SPIR-V module can have quantities exceeding the minimum limits (65,535 WC), the device backend compiler does not handle such SPIR-V modules.

Hence, we detect quantities exceeding the limitations in device code (which is going to be translated to SPIR-V) and emit a warning.
This is not a bug, just a UX improvement in FE.

**The actual text of the warning message mentioned in this PR is open for wordsmithing.**