### PR TITLE
[SYCL] Fixed doOverlap function

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -32,9 +32,9 @@ namespace detail {
 /// This information can be used to prove that executing two kernels that
 /// work on different parts of the memory object in parallel is legal.
 static bool doOverlap(const Requirement *LHS, const Requirement *RHS) {
-  return (LHS->MOffsetInBytes + LHS->MAccessRange.size() * LHS->MElemSize >=
+  return (LHS->MOffsetInBytes + LHS->MAccessRange.size() * LHS->MElemSize >
           RHS->MOffsetInBytes) &&
-         (RHS->MOffsetInBytes + RHS->MAccessRange.size() * RHS->MElemSize >=
+         (RHS->MOffsetInBytes + RHS->MAccessRange.size() * RHS->MElemSize >
           LHS->MOffsetInBytes);
 }
 

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -33,7 +33,7 @@ namespace detail {
 /// work on different parts of the memory object in parallel is legal.
 static bool doOverlap(const Requirement *LHS, const Requirement *RHS) {
   return (LHS->MOffsetInBytes + LHS->MAccessRange.size() * LHS->MElemSize >=
-          RHS->MOffsetInBytes) ||
+          RHS->MOffsetInBytes) &&
          (RHS->MOffsetInBytes + RHS->MAccessRange.size() * RHS->MElemSize >=
           LHS->MOffsetInBytes);
 }


### PR DESCRIPTION
Fixed an error when two non-overlapping requirements considered as overlapping.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>