### PR TITLE
[SYCL][ESIMD] Mark ESIMD kernel callgraph with sycl_explicit_simd.

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12696,6 +12696,7 @@ public:
   void checkSYCLDeviceVarDecl(VarDecl *Var);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
   void MarkDevice();
+  void MarkSyclSimd();
 
   /// Creates a DeviceDiagBuilder that emits the diagnostic if the current
   /// context is "used as device code".

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -990,6 +990,8 @@ void Sema::ActOnEndOfTranslationUnitFragment(TUFragmentKind Kind) {
       SyclIntHeader->emit(getLangOpts().SYCLIntHeader);
     MarkDevice();
   }
+  if (getLangOpts().SYCLExplicitSIMD)
+    MarkSyclSimd();
 
   emitDeferredDiags();
 

--- a/clang/test/CodeGenSYCL/esimd_metadata2.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata2.cpp
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-ESIMD
+
+// In ESIMD mode:
+// 1. Attribute !intel_reqd_sub_group_size !1 is added
+//    for kernels with !sycl_explicit_simd
+// 2. Attribute !sycl_explicit_simd is propagated to all the
+//    callees of ESIMD kernel.
+
+__attribute__((sycl_device)) void shared_func_decl();
+__attribute__((sycl_device)) void shared_func() { shared_func_decl(); }
+
+__attribute__((sycl_device)) __attribute__((sycl_explicit_simd)) void esimd_func() { shared_func(); }
+
+// CHECK-ESIMD-DAG: define spir_kernel void @{{.*}}kernel_cm() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {{.*}} !intel_reqd_sub_group_size ![[SGSIZE1:[0-9]+]] {{.*}}{
+// CHECK-ESIMD-DAG: define spir_func void @{{.*}}esimd_funcv() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {
+// CHECK-ESIMD-DAG: define spir_func void @{{.*}}shared_funcv() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {
+// CHECK-ESIMD-DAG: define linkonce_odr spir_func void @_ZN12ESIMDFunctorclEv({{.*}}) #{{[0-9]+}} {{.*}} !sycl_explicit_simd !{{[0-9]+}} {
+// CHECK-ESIMD-DAG: declare spir_func void @{{.*}}shared_func_declv() #{{[0-9]+}}
+
+class ESIMDFunctor {
+public:
+  void operator()() __attribute__((sycl_explicit_simd)) {
+    esimd_func();
+  }
+};
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+void bar() {
+  ESIMDFunctor cmf;
+  kernel<class kernel_cm>(cmf);
+}
+
+// CHECK: !spirv.Source = !{[[LANG:![0-9]+]]}
+// CHECK: [[LANG]] = !{i32 6, i32 100000}
+// CHECK-ESIMD: ![[SGSIZE1]] = !{i32 1}

--- a/clang/test/CodeGenSYCL/esimd_metadata3.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata3.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-ESIMD
+
+__attribute__((sycl_device)) void funcWithSpirvIntrin() {}
+__attribute__((sycl_device)) __attribute__((sycl_explicit_simd)) void standaloneCmFunc() { funcWithSpirvIntrin(); }
+
+// CHECK-ESIMD-DAG: define spir_func void @{{.*}}funcWithSpirvIntrinv() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {
+// CHECK-ESIMD-DAG: define spir_func void @{{.*}}standaloneCmFuncv() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {


### PR DESCRIPTION
Traverse callgraph from ESIMD kernels and mark all functions
with sycl_explicit_simd along the way. ESIMD code generation depends
on presence of this attribute, which will be used to distinguish
normal from ESIMD code.

Author: Denis Bakhvalov <denis.bakhvalov@intel.com>.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>