### PR TITLE
[SYCL][CUDA] Map/unmap pinned host memory

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -3992,7 +3992,7 @@ pi_result cuda_piEnqueueMemBufferMap(pi_queue command_queue, pi_mem buffer,
   assert(buffer->mem_type_ == _pi_mem::mem_type::buffer);
 
   pi_result ret_err = PI_INVALID_OPERATION;
-  bool is_pinned = buffer->mem_.buffer_mem_.allocMode_ ==
+  const bool is_pinned = buffer->mem_.buffer_mem_.allocMode_ ==
                    _pi_mem::mem_::buffer_mem_::alloc_mode::alloc_host_ptr;
 
   // Currently no support for overlapping regions

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4052,7 +4052,7 @@ pi_result cuda_piEnqueueMemUnmap(pi_queue command_queue, pi_mem memobj,
   assert(memobj->mem_type_ == _pi_mem::mem_type::buffer);
   assert(memobj->mem_.buffer_mem_.get_map_ptr() != nullptr);
   assert(memobj->mem_.buffer_mem_.get_map_ptr() == mapped_ptr);
-  
+
   bool is_pinned = memobj->mem_.buffer_mem_.allocMode_ ==
                    _pi_mem::mem_::buffer_mem_::alloc_mode::alloc_host_ptr;
 

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -3993,7 +3993,7 @@ pi_result cuda_piEnqueueMemBufferMap(pi_queue command_queue, pi_mem buffer,
 
   pi_result ret_err = PI_INVALID_OPERATION;
   const bool is_pinned = buffer->mem_.buffer_mem_.allocMode_ ==
-                   _pi_mem::mem_::buffer_mem_::alloc_mode::alloc_host_ptr;
+                         _pi_mem::mem_::buffer_mem_::alloc_mode::alloc_host_ptr;
 
   // Currently no support for overlapping regions
   if (buffer->mem_.buffer_mem_.get_map_ptr() != nullptr) {
@@ -4053,8 +4053,8 @@ pi_result cuda_piEnqueueMemUnmap(pi_queue command_queue, pi_mem memobj,
   assert(memobj->mem_.buffer_mem_.get_map_ptr() != nullptr);
   assert(memobj->mem_.buffer_mem_.get_map_ptr() == mapped_ptr);
 
-  bool is_pinned = memobj->mem_.buffer_mem_.allocMode_ ==
-                   _pi_mem::mem_::buffer_mem_::alloc_mode::alloc_host_ptr;
+  const bool is_pinned = memobj->mem_.buffer_mem_.allocMode_ ==
+                         _pi_mem::mem_::buffer_mem_::alloc_mode::alloc_host_ptr;
 
   if (!is_pinned &&
       ((memobj->mem_.buffer_mem_.get_map_flags() & CL_MAP_WRITE) ||

--- a/sycl/unittests/pi/cuda/test_mem_obj.cpp
+++ b/sycl/unittests/pi/cuda/test_mem_obj.cpp
@@ -139,7 +139,7 @@ TEST_F(CudaTestMemObj, piMemBufferPinnedMappedRead) {
   int *host_ptr = nullptr;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
                 queue, memObj, true, CL_MAP_READ, 0, sizeof(int), 0, nullptr,
-                nullptr, (void**)&host_ptr)),
+                nullptr, (void **)&host_ptr)),
             PI_SUCCESS);
 
   ASSERT_EQ(*host_ptr, value);
@@ -173,7 +173,7 @@ TEST_F(CudaTestMemObj, piMemBufferPinnedMappedWrite) {
   int *host_ptr = nullptr;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
                 queue, memObj, true, CL_MAP_WRITE, 0, sizeof(int), 0, nullptr,
-                nullptr, (void**)&host_ptr)),
+                nullptr, (void **)&host_ptr)),
             PI_SUCCESS);
 
   *host_ptr = value;


### PR DESCRIPTION
This PRs changes map on pinned host memory to return a pointer to the pinned memory rather than copy to new memory. Likewise, unmap of pinned memory does no write operation.

Signed-off-by: Steffen Larsen <steffen.larsen@codeplay.com>