### PR TITLE
sycldevice-binding.bc Generation Fix, sycl branch (2020.07.13.)

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -213,6 +213,8 @@ function(add_libclc_sycl_binding OUT_LIST)
     if( EXISTS ${SYCLDEVICE_BINDING} )
       set( SYCLDEVICE_BINDING_OUT ${CMAKE_CURRENT_BINARY_DIR}/sycldevice-binding-${ARG_TRIPLE}/sycldevice-binding.bc )
       add_custom_command( OUTPUT ${SYCLDEVICE_BINDING_OUT}
+                         COMMAND ${CMAKE_COMMAND} -E make_directory
+                         ${CMAKE_CURRENT_BINARY_DIR}/sycldevice-binding-${ARG_TRIPLE}
                          COMMAND ${LLVM_CLANG}
                          -target ${ARG_TRIPLE}-sycldevice
                          -fsycl


### PR DESCRIPTION
While trying to build the tip of the sycl branch with

```
cmake -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=<FOO> \
   -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_EXTERNAL_PROJECTS="llvm-spirv;sycl;libdevice" \
   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;lld;openmp;llvm-spirv;sycl;libclc" \
   -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=<BAR> \
   -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=<FOO> \
   -DLLVM_EXTERNAL_LIBDEVICE_SOURCE_DIR=<BAR> \
   -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_PIC=ON -DLLVM_ENABLE_RTTI=ON \
   -DOpenCL_INCLUDE_DIRS= -DOpenCL_LIBRARIES= -DOpenCL_INSTALL_KHRONOS_ICD_LOADER=TRUE ../llvm/llvm/
```

, I ran into the following kind of failures:

```
[ 83%] Generating sycldevice-binding-nvptx64--/sycldevice-binding.bc
 Scanning dependencies of target builtins.link.clc-nvptx64--
 [ 83%] Building CLC object tools/libclc/CMakeFiles/builtins.link.clc-nvptx64--.dir/convert-clc.bc
 [ 83%] Building CLC object tools/libclc/CMakeFiles/builtins.link.clc-nvptx64--.dir/ptx/lib/math/nextafter.bc
 error: unable to open output file '/root/build/tools/libclc/sycldevice-binding-nvptx64--/sycldevice-binding.bc': 'No such file or directory'
 1 error generated.
 make[2]: *** [tools/libclc/sycldevice-binding-nvptx64--/sycldevice-binding.bc] Error 1
 make[1]: *** [tools/libclc/CMakeFiles/builtins.link.libspirv-nvptx64--.dir/all] Error 2
 make[1]: *** Waiting for unfinished jobs....
```

I traced them down to a shortcoming in the recently introduced `add_libclc_sycl_binding(...)` function. With this change added I was able to build the code successfully once again.