### PR TITLE
[SYCL] Move deferred emit check to after "Can be emitted" checks.

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2695,7 +2695,7 @@ void CodeGenModule::EmitGlobal(GlobalDecl GD) {
 
   // clang::ParseAST ensures that we emit the SYCL devices at the end, so
   // anything that is a device (or indirectly called) will be handled later.
-  if (LangOpts.SYCLIsDevice && Global->hasAttr<SYCLDeviceAttr>()) {
+  if (LangOpts.SYCLIsDevice && MustBeEmitted(Global)) {
     addDeferredDeclToEmit(GD);
     return;
   }

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2695,7 +2695,7 @@ void CodeGenModule::EmitGlobal(GlobalDecl GD) {
 
   // clang::ParseAST ensures that we emit the SYCL devices at the end, so
   // anything that is a device (or indirectly called will be handled later.
-  if (LangOpts.SYCLIsDevice && Global->hasAttr<SYCLDeviceAttr>()){
+  if (LangOpts.SYCLIsDevice && Global->hasAttr<SYCLDeviceAttr>()) {
     addDeferredDeclToEmit(GD);
     return;
   }

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2694,7 +2694,7 @@ void CodeGenModule::EmitGlobal(GlobalDecl GD) {
   }
 
   // clang::ParseAST ensures that we emit the SYCL devices at the end, so
-  // anything that is a device (or indirectly called will be handled later.
+  // anything that is a device (or indirectly called) will be handled later.
   if (LangOpts.SYCLIsDevice && Global->hasAttr<SYCLDeviceAttr>()) {
     addDeferredDeclToEmit(GD);
     return;

--- a/clang/test/CodeGenSYCL/emit-all-decls-crash.cpp
+++ b/clang/test/CodeGenSYCL/emit-all-decls-crash.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -emit-llvm %s -femit-all-decls -o - | FileCheck %s
+
+// This should not crash and we should not emit this declaration, even though
+// we have 'emit-all-decls'.
+// CHECK-NOT: define
+void foo(void);


### PR DESCRIPTION
The previous implementation caused function declarations to be attempted
to be emitted if they were required to be emitted (such as in the case
of -femit-all-decls), which caused a crash.

This patch moves the check until after the 'can be emitted' checks for
function/var decls, and limits it to only functions that are
sycl-devices (or, in the case of implicit attributes, called from a
sycl-device function).