### PR TITLE
[SYCL] Enable user-defined sub-group reductions

### DIFF
--- a/sycl/include/CL/sycl/intel/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/intel/group_algorithm.hpp
@@ -105,6 +105,17 @@ template <typename T, typename V> struct identity<T, intel::maximum<V>> {
   static constexpr T value = std::numeric_limits<T>::lowest();
 };
 
+template <typename T>
+using native_op_list =
+    type_list<intel::plus<T>, intel::bit_or<T>, intel::bit_xor<T>,
+              intel::bit_and<T>, intel::maximum<T>, intel::minimum<T>>;
+
+template <typename T, typename BinaryOperation> struct is_native_op {
+  static constexpr bool value =
+      is_contained<BinaryOperation, native_op_list<T>>::value ||
+      is_contained<BinaryOperation, native_op_list<void>>::value;
+};
+
 template <typename Group, typename Ptr, class Function>
 Function for_each(Group g, Ptr first, Ptr last, Function f) {
 #ifdef __SYCL_DEVICE_ONLY__
@@ -128,6 +139,7 @@ Function for_each(Group g, Ptr first, Ptr last, Function f) {
 
 namespace intel {
 
+// EnableIf shorthands for algorithms that depend only on type
 template <typename T>
 using EnableIfIsScalarArithmetic = cl::sycl::detail::enable_if_t<
     cl::sycl::detail::is_scalar_arithmetic<T>::value, T>;
@@ -139,6 +151,28 @@ using EnableIfIsVectorArithmetic = cl::sycl::detail::enable_if_t<
 template <typename Ptr, typename T>
 using EnableIfIsPointer =
     cl::sycl::detail::enable_if_t<cl::sycl::detail::is_pointer<Ptr>::value, T>;
+
+// EnableIf shorthands for algorithms that depend on type and an operator
+template <typename T, typename BinaryOperation>
+using EnableIfIsScalarArithmeticNativeOp = cl::sycl::detail::enable_if_t<
+    cl::sycl::detail::is_scalar_arithmetic<T>::value &&
+        cl::sycl::detail::is_native_op<T, BinaryOperation>::value,
+    T>;
+
+template <typename T, typename BinaryOperation>
+using EnableIfIsVectorArithmeticNativeOp = cl::sycl::detail::enable_if_t<
+    cl::sycl::detail::is_vector_arithmetic<T>::value &&
+        cl::sycl::detail::is_native_op<T, BinaryOperation>::value,
+    T>;
+
+// TODO: Lift TriviallyCopyable restriction eventually
+template <typename T, typename BinaryOperation>
+using EnableIfIsNonNativeOp = cl::sycl::detail::enable_if_t<
+    (!cl::sycl::detail::is_scalar_arithmetic<T>::value &&
+     !cl::sycl::detail::is_vector_arithmetic<T>::value &&
+     std::is_trivially_copyable<T>::value) ||
+        !cl::sycl::detail::is_native_op<T, BinaryOperation>::value,
+    T>;
 
 template <typename Group> bool all_of(Group, bool pred) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
@@ -377,7 +411,8 @@ EnableIfIsVectorArithmetic<T> broadcast(Group g, T x) {
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsScalarArithmetic<T> reduce(Group, T x, BinaryOperation binary_op) {
+EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
+reduce(Group, T x, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -398,7 +433,8 @@ EnableIfIsScalarArithmetic<T> reduce(Group, T x, BinaryOperation binary_op) {
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsVectorArithmetic<T> reduce(Group g, T x, BinaryOperation binary_op) {
+EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
+reduce(Group g, T x, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -416,9 +452,25 @@ EnableIfIsVectorArithmetic<T> reduce(Group g, T x, BinaryOperation binary_op) {
   return result;
 }
 
+template <typename Group, typename T, class BinaryOperation>
+EnableIfIsNonNativeOp<T, BinaryOperation> reduce(Group g, T x,
+                                                 BinaryOperation op) {
+  static_assert(sycl::detail::is_sub_group<Group>::value,
+                "reduce algorithm with user-defined types and operators"
+                "only supports intel::sub_group class.");
+  T result = x;
+  for (int mask = 1; mask < g.get_max_local_range()[0]; mask *= 2) {
+    T tmp = g.shuffle_xor(result, id<1>(mask));
+    if (g.get_local_id()[0] ^ mask < g.get_local_range()[0]) {
+      result = op(result, tmp);
+    }
+  }
+  return g.shuffle(result, 0);
+}
+
 template <typename Group, typename V, typename T, class BinaryOperation>
-EnableIfIsScalarArithmetic<T> reduce(Group g, V x, T init,
-                                     BinaryOperation binary_op) {
+EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
+reduce(Group g, V x, T init, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -438,8 +490,8 @@ EnableIfIsScalarArithmetic<T> reduce(Group g, V x, T init,
 }
 
 template <typename Group, typename V, typename T, class BinaryOperation>
-EnableIfIsVectorArithmetic<T> reduce(Group g, V x, T init,
-                                     BinaryOperation binary_op) {
+EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
+reduce(Group g, V x, T init, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -461,6 +513,22 @@ EnableIfIsVectorArithmetic<T> reduce(Group g, V x, T init,
   throw runtime_error("Group algorithms are not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
+}
+
+template <typename Group, typename V, typename T, class BinaryOperation>
+EnableIfIsNonNativeOp<T, BinaryOperation> reduce(Group g, V x, T init,
+                                                 BinaryOperation op) {
+  static_assert(sycl::detail::is_sub_group<Group>::value,
+                "reduce algorithm with user-defined types and operators"
+                "only supports intel::sub_group class.");
+  T result = x;
+  for (int mask = 1; mask < g.get_max_local_range()[0]; mask *= 2) {
+    T tmp = g.shuffle_xor(result, id<1>(mask));
+    if (g.get_local_id()[0] ^ mask < g.get_local_range()[0]) {
+      result = op(result, tmp);
+    }
+  }
+  return g.shuffle(op(init, result), 0);
 }
 
 template <typename Group, typename Ptr, class BinaryOperation>
@@ -523,8 +591,8 @@ EnableIfIsPointer<Ptr, T> reduce(Group g, Ptr first, Ptr last, T init,
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsScalarArithmetic<T> exclusive_scan(Group, T x,
-                                             BinaryOperation binary_op) {
+EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
+exclusive_scan(Group, T x, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -544,8 +612,8 @@ EnableIfIsScalarArithmetic<T> exclusive_scan(Group, T x,
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsVectorArithmetic<T> exclusive_scan(Group g, T x,
-                                             BinaryOperation binary_op) {
+EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
+exclusive_scan(Group g, T x, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -564,8 +632,8 @@ EnableIfIsVectorArithmetic<T> exclusive_scan(Group g, T x,
 }
 
 template <typename Group, typename V, typename T, class BinaryOperation>
-EnableIfIsVectorArithmetic<T> exclusive_scan(Group g, V x, T init,
-                                             BinaryOperation binary_op) {
+EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
+exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -584,8 +652,8 @@ EnableIfIsVectorArithmetic<T> exclusive_scan(Group g, V x, T init,
 }
 
 template <typename Group, typename V, typename T, class BinaryOperation>
-EnableIfIsScalarArithmetic<T> exclusive_scan(Group g, V x, T init,
-                                             BinaryOperation binary_op) {
+EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
+exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -677,8 +745,8 @@ EnableIfIsPointer<InPtr, OutPtr> exclusive_scan(Group g, InPtr first,
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsVectorArithmetic<T> inclusive_scan(Group g, T x,
-                                             BinaryOperation binary_op) {
+EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
+inclusive_scan(Group g, T x, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -697,8 +765,8 @@ EnableIfIsVectorArithmetic<T> inclusive_scan(Group g, T x,
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsScalarArithmetic<T> inclusive_scan(Group, T x,
-                                             BinaryOperation binary_op) {
+EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
+inclusive_scan(Group, T x, BinaryOperation binary_op) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
                 "intel::sub_group class.");
@@ -718,7 +786,7 @@ EnableIfIsScalarArithmetic<T> inclusive_scan(Group, T x,
 }
 
 template <typename Group, typename V, class BinaryOperation, typename T>
-EnableIfIsScalarArithmetic<T>
+EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
 inclusive_scan(Group g, V x, BinaryOperation binary_op, T init) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "
@@ -741,7 +809,7 @@ inclusive_scan(Group g, V x, BinaryOperation binary_op, T init) {
 }
 
 template <typename Group, typename V, class BinaryOperation, typename T>
-EnableIfIsVectorArithmetic<T>
+EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
 inclusive_scan(Group g, V x, BinaryOperation binary_op, T init) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "

--- a/sycl/include/CL/sycl/intel/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/intel/group_algorithm.hpp
@@ -461,7 +461,7 @@ EnableIfIsNonNativeOp<T, BinaryOperation> reduce(Group g, T x,
   T result = x;
   for (int mask = 1; mask < g.get_max_local_range()[0]; mask *= 2) {
     T tmp = g.shuffle_xor(result, id<1>(mask));
-    if (g.get_local_id()[0] ^ mask < g.get_local_range()[0]) {
+    if ((g.get_local_id()[0] ^ mask) < g.get_local_range()[0]) {
       result = op(result, tmp);
     }
   }
@@ -524,7 +524,7 @@ EnableIfIsNonNativeOp<T, BinaryOperation> reduce(Group g, V x, T init,
   T result = x;
   for (int mask = 1; mask < g.get_max_local_range()[0]; mask *= 2) {
     T tmp = g.shuffle_xor(result, id<1>(mask));
-    if (g.get_local_id()[0] ^ mask < g.get_local_range()[0]) {
+    if ((g.get_local_id()[0] ^ mask) < g.get_local_range()[0]) {
       result = op(result, tmp);
     }
   }

--- a/sycl/test/sub_group/generic_reduce.cpp
+++ b/sycl/test/sub_group/generic_reduce.cpp
@@ -1,0 +1,98 @@
+// UNSUPPORTED: cuda
+// CUDA compilation and runtime do not yet support sub-groups.
+//
+// RUN: %clangxx -fsycl -std=c++14 %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -std=c++14 -D SG_GPU %s -o %t_gpu.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+#include "helper.hpp"
+#include <CL/sycl.hpp>
+#include <complex>
+
+template <typename T, class BinaryOperation>
+class generic_reduce;
+
+using namespace cl::sycl;
+
+template <typename T, class BinaryOperation>
+void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
+              size_t G = 240, size_t L = 60) {
+  try {
+    nd_range<1> NdRange(G, L);
+    buffer<T> buf(G);
+    buffer<size_t> sgsizebuf(1);
+    Queue.submit([&](handler &cgh) {
+      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
+      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<generic_reduce<T, BinaryOperation>>(
+          NdRange, [=](nd_item<1> NdItem) {
+            intel::sub_group sg = NdItem.get_sub_group();
+            if (skip_init) {
+              acc[NdItem.get_global_id(0)] =
+                  reduce(sg, T(NdItem.get_global_id(0)), op);
+            } else {
+              acc[NdItem.get_global_id(0)] =
+                  reduce(sg, T(NdItem.get_global_id(0)), init, op);
+            }
+            if (NdItem.get_global_id(0) == 0)
+              sgsizeacc[0] = sg.get_max_local_range()[0];
+          });
+    });
+    auto acc = buf.template get_access<access::mode::read_write>();
+    auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>();
+    size_t sg_size = sgsizeacc[0];
+    int WGid = -1, SGid = 0;
+    T result = init;
+    for (int j = 0; j < G; j++) {
+      if (j % L % sg_size == 0) {
+        SGid++;
+        result = init;
+        for (int i = j; (i % L && i % L % sg_size) || (i == j); i++) {
+          result = op(result, T(i));
+        }
+      }
+      if (j % L == 0) {
+        WGid++;
+        SGid = 0;
+      }
+      std::string name =
+          std::string("reduce_") + typeid(BinaryOperation).name();
+      exit_if_not_equal(acc[j], result, name.c_str());
+    }
+  } catch (exception e) {
+    std::cout << "SYCL exception caught: " << e.what();
+    exit(1);
+  }
+}
+
+int main() {
+  queue Queue;
+  if (!core_sg_supported(Queue.get_device())) {
+    std::cout << "Skipping test\n";
+    return 0;
+  }
+
+  size_t G = 240;
+  size_t L = 60;
+
+  // Test user-defined type
+  // Use complex as a proxy for this
+  using UDT = std::complex<float>;
+  check_op<UDT>(Queue, UDT(L, L), intel::plus<UDT>(), false, G, L);
+  check_op<UDT>(Queue, UDT(0, 0), intel::plus<UDT>(), true, G, L);
+
+  // Test user-defined operator
+  auto UDOp = [=](const auto& lhs, const auto& rhs) { return lhs + rhs; };
+  check_op<int>(Queue, int(L), UDOp, false, G, L);
+  check_op<int>(Queue, int(0), UDOp, true, G, L);
+
+  // Test both user-defined type and operator
+  check_op<UDT>(Queue, UDT(L, L), UDOp, false, G, L);
+  check_op<UDT>(Queue, UDT(0, 0), UDOp, true, G, L);
+
+  std::cout << "Test passed." << std::endl;
+  return 0;
+}

--- a/sycl/test/sub_group/generic_reduce.cpp
+++ b/sycl/test/sub_group/generic_reduce.cpp
@@ -85,7 +85,7 @@ int main() {
   check_op<UDT>(Queue, UDT(0, 0), intel::plus<UDT>(), true, G, L);
 
   // Test user-defined operator
-  auto UDOp = [=](const auto& lhs, const auto& rhs) { return lhs + rhs; };
+  auto UDOp = [=](const auto &lhs, const auto &rhs) { return lhs + rhs; };
   check_op<int>(Queue, int(L), UDOp, false, G, L);
   check_op<int>(Queue, int(0), UDOp, true, G, L);
 

--- a/sycl/test/sub_group/generic_reduce.cpp
+++ b/sycl/test/sub_group/generic_reduce.cpp
@@ -1,8 +1,8 @@
 // UNSUPPORTED: cuda
 // CUDA compilation and runtime do not yet support sub-groups.
 //
-// RUN: %clangxx -fsycl -std=c++14 %s -o %t.out
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -std=c++14 -D SG_GPU %s -o %t_gpu.out
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -std=c++14 %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple -std=c++14 -D SG_GPU %s -o %t_gpu.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
@@ -11,9 +11,6 @@
 #include "helper.hpp"
 #include <CL/sycl.hpp>
 #include <complex>
-
-template <typename T, class BinaryOperation>
-class generic_reduce;
 
 using namespace cl::sycl;
 
@@ -27,7 +24,7 @@ void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
     Queue.submit([&](handler &cgh) {
       auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
       auto acc = buf.template get_access<access::mode::read_write>(cgh);
-      cgh.parallel_for<generic_reduce<T, BinaryOperation>>(
+      cgh.parallel_for(
           NdRange, [=](nd_item<1> NdItem) {
             intel::sub_group sg = NdItem.get_sub_group();
             if (skip_init) {

--- a/sycl/test/sub_group/generic_reduce.cpp
+++ b/sycl/test/sub_group/generic_reduce.cpp
@@ -67,7 +67,7 @@ void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
 
 int main() {
   queue Queue;
-  if (!core_sg_supported(Queue.get_device())) {
+  if (!Queue.get_device().has_extension("cl_intel_subgroups")) {
     std::cout << "Skipping test\n";
     return 0;
   }


### PR DESCRIPTION
Restricted to TriviallyCopyable types for now.

Signed-off-by: John Pennycook <john.pennycook@intel.com>

---

This is a partial implementation of the functionality proposed by @psteinbrecher in https://github.com/intel/llvm/issues/1947, enabling custom sub-group reductions for trivially copyable types.  I cannot see any good way to implement user-defined reductions using `group` instead of `sub_group` today, or to extend support for arbitrary types, but this is a step in the right direction.

Enabling the other algorithms for user-defined types and operators (with the same trivially copyable restriction) could follow the same approach.  Starting with reductions in this PR because they are the most common request.