### PR TITLE
[SYCL][ESIMD] Fix spelling of attribute to mark ESIMD register binding.

### DIFF
--- a/sycl/include/CL/sycl/intel/esimd/esimd_enum.hpp
+++ b/sycl/include/CL/sycl/intel/esimd/esimd_enum.hpp
@@ -30,7 +30,7 @@ using uint = unsigned int;
 // class.
 #define ESIMD_PRIVATE __attribute__((opencl_private))
 // Bind a ESIMD global variable to a specific register.
-#define ESIMD_REGISTER(n) __attribute__((register(n)))
+#define ESIMD_REGISTER(n) __attribute__((register_num(n)))
 #else
 // TODO ESIMD define what this means on Windows host
 #define ESIMD_NODEBUG

--- a/sycl/test/basic_tests/esimd/global_var.cpp
+++ b/sycl/test/basic_tests/esimd/global_var.cpp
@@ -1,0 +1,13 @@
+// RUN: %clangxx -fsycl -fsycl-explicit-simd -fsycl-device-only -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+
+#include <CL/sycl/intel/esimd.hpp>
+
+// This test checks that DPC++ compiler in ESIMD mode understands
+// the ESIMD_PRIVATE and ESIMD_REGISTER macros
+
+ESIMD_PRIVATE ESIMD_REGISTER(17) int vc;
+
+SYCL_EXTERNAL void init_vc(int x) {
+  vc = x;
+}


### PR DESCRIPTION
Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>