### PR TITLE
[SYCL] Release PI queue on queue_impl destruction

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -115,7 +115,7 @@ public:
 
   ~queue_impl() {
     throw_asynchronous();
-    if (MOpenCLInterop) {
+    if (!MHostQueue) {
       getPlugin().call<PiApiKind::piQueueRelease>(MCommandQueue);
     }
   }


### PR DESCRIPTION
The SYCL 1.2.1 specification requires queue to either encapsulate an
OpenCL interop object or be a host queue. The DPC++ implementation,
however, allows for different backends. Change queue_impl destructor to
release whatever native handle there is.