### PR TITLE
[SYCL][CUDA] Fix byte-offset issue in libclc Image Support for CUDA

### DIFF
--- a/libclc/ptx-nvidiacl/libspirv/images/image.cl
+++ b/libclc/ptx-nvidiacl/libspirv/images/image.cl
@@ -230,7 +230,7 @@ typedef float fp32;
                                                                   int x) {     \
     struct out_##pixelf_size res =                                             \
         __nvvm_suld_1d_v4i##pixelf_size##_##cuda_address_mode##_s(             \
-            image, x * pixelf_size * 4);                                       \
+            image, x * sizeof(struct out_##pixelf_size));                      \
     return out_pixelf##pixelf_size(res);                                       \
   }
 
@@ -239,7 +239,7 @@ typedef float fp32;
       long image, int x, int y) {                                              \
     struct out_##pixelf_size res =                                             \
         __nvvm_suld_2d_v4i##pixelf_size##_##cuda_address_mode##_s(             \
-            image, x * pixelf_size * 4, y);                                    \
+            image, x * sizeof(struct out_##pixelf_size), y);                   \
     return out_pixelf##pixelf_size(res);                                       \
   }
 
@@ -248,7 +248,7 @@ typedef float fp32;
       long image, int x, int y, int z) {                                       \
     struct out_##pixelf_size res =                                             \
         __nvvm_suld_3d_v4i##pixelf_size##_##cuda_address_mode##_s(             \
-            image, x * pixelf_size * 4, y, z);                                 \
+            image, x * sizeof(struct out_##pixelf_size), y, z);                \
     return out_pixelf##pixelf_size(res);                                       \
   }
 


### PR DESCRIPTION
This reverts commit 24af4d816ced3ed3cc1588a7c2ba088242d6c8ea.