### PR TITLE
[SYCL] Infer IdT in GroupBroadcast from group type

### DIFF
--- a/sycl/include/CL/sycl/detail/type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/type_traits.hpp
@@ -17,6 +17,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
+template <int Dimensions> class group;
+namespace intel {
+class sub_group;
+} // namespace intel
 namespace detail {
 namespace half_impl {
 class half;
@@ -301,6 +305,20 @@ using const_if_const_AS =
 template <access::address_space AS, class DataT>
 using const_if_const_AS = DataT;
 #endif
+
+template <typename T> struct is_group : std::false_type {};
+
+template <int Dimensions>
+struct is_group<group<Dimensions>> : std::true_type {};
+
+template <typename T> struct is_sub_group : std::false_type {};
+
+template <> struct is_sub_group<intel::sub_group> : std::true_type {};
+
+template <typename T>
+struct is_generic_group
+    : std::integral_constant<bool,
+                             is_group<T>::value || is_sub_group<T>::value> {};
 
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/detail/type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/type_traits.hpp
@@ -19,7 +19,7 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 template <int Dimensions> class group;
 namespace intel {
-class sub_group;
+struct sub_group;
 } // namespace intel
 namespace detail {
 namespace half_impl {

--- a/sycl/include/CL/sycl/intel/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/intel/group_algorithm.hpp
@@ -77,20 +77,6 @@ template <> inline id<3> linear_id_to_id(range<3> r, size_t linear_id) {
   return result;
 }
 
-template <typename T> struct is_group : std::false_type {};
-
-template <int Dimensions>
-struct is_group<group<Dimensions>> : std::true_type {};
-
-template <typename T> struct is_sub_group : std::false_type {};
-
-template <> struct is_sub_group<intel::sub_group> : std::true_type {};
-
-template <typename T>
-struct is_generic_group
-    : std::integral_constant<bool,
-                             is_group<T>::value || is_sub_group<T>::value> {};
-
 template <typename T, class BinaryOperation> struct identity {};
 
 template <typename T, typename V> struct identity<T, intel::plus<V>> {


### PR DESCRIPTION
- Work-group => any integral type
- Sub-group => unsigned 32-bit integer

Signed-off-by: John Pennycook <john.pennycook@intel.com>

---

Fixes failing broadcast test in https://github.com/intel/llvm/pull/2049.