### PR TITLE
[SYCL] Fix devices available when SYCL_BE is set.

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -12,7 +12,7 @@ subject to change. Do not rely on these variables in production code.
 | Environment variable | Values | Description |
 | -------------------- | ------ | ----------- |
 | SYCL_PI_TRACE | Described [below](#sycl_pi_trace-options)  | Enable specified level of tracing for PI. |
-| SYCL_BE | PI_OPENCL, PI_LEVEL0, PI_CUDA | Force SYCL RT to consider only devices of the specified backend during the device selection. |
+| SYCL_BE | PI_OPENCL, PI_LEVEL0, PI_CUDA | Set the preferred backend during the device selection. |
 | SYCL_DEVICE_TYPE | One of: CPU, GPU, ACC, HOST | Force SYCL to use the specified device type. If unset, default selection rules are applied. If set to any unlisted value, this control has no effect. If the requested device type is not found, a `cl::sycl::runtime_error` exception is thrown. If a non-default device selector is used, a device must satisfy both the selector and this control to be chosen. This control only has effect on devices created with a selector. |
 | SYCL_PROGRAM_COMPILE_OPTIONS | String of valid OpenCL compile options | Override compile options for all programs. |
 | SYCL_PROGRAM_LINK_OPTIONS | String of valid OpenCL link options | Override link options for all programs. |

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -10,7 +10,6 @@
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/device_selector.hpp>
 #include <CL/sycl/info/info_desc.hpp>
-#include <detail/config.hpp>
 #include <detail/device_impl.hpp>
 #include <detail/force_device.hpp>
 
@@ -51,14 +50,6 @@ vector_class<device> device::get_devices(info::device_type deviceType) {
   if (detail::match_types(deviceType, forced_type)) {
     detail::force_type(deviceType, forced_type);
     for (const auto &plt : platform::get_platforms()) {
-      // If SYCL_BE is set then skip platforms which doesn't have specified
-      // backend.
-      backend *ForcedBackend = detail::SYCLConfig<detail::SYCL_BE>::get();
-      if (ForcedBackend)
-        if (!plt.is_host() &&
-            (detail::getSyclObjImpl(plt)->getPlugin().getBackend() !=
-             *ForcedBackend))
-          continue;
       if (includeHost && plt.is_host()) {
         vector_class<device> host_device(
             plt.get_devices(info::device_type::host));

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -21,7 +21,7 @@ namespace sycl {
 
 // Utility function to check if device is of the preferred backend.
 // Currently preference is given to the level0 backend.
-static bool isDeviceOfPreferredSyclBe(const device &Device) {
+static bool isPreferredDevice(const device &Device) {
   if (!Device.is_gpu())
     return false;
 
@@ -29,7 +29,7 @@ static bool isDeviceOfPreferredSyclBe(const device &Device) {
   if (ForcedBackend) {
     return detail::getSyclObjImpl(Device)->getPlugin().getBackend() ==
            *ForcedBackend;
-
+  }
   return detail::getSyclObjImpl(Device)->getPlugin().getBackend() ==
          backend::level0;
 }
@@ -65,7 +65,7 @@ device device_selector::select_device() const {
     // preference to the device of the preferred BE.
     //
     if ((score < dev_score) ||
-        (score == dev_score && isDeviceOfPreferredSyclBe(dev))) {
+        (score == dev_score && isPreferredDevice(dev))) {
       res = &dev;
       score = dev_score;
     }
@@ -105,7 +105,7 @@ int default_selector::operator()(const device &dev) const {
   if (dev.is_gpu()) {
     Score += 500;
     // Give preference to device of SYCL BE.
-    if (isDeviceOfPreferredSyclBe(dev))
+    if (isPreferredDevice(dev))
       Score += 50;
   }
 
@@ -124,7 +124,7 @@ int gpu_selector::operator()(const device &dev) const {
   if (dev.is_gpu()) {
     Score = 1000;
     // Give preference to device of SYCL BE.
-    if (isDeviceOfPreferredSyclBe(dev))
+    if (isPreferredDevice(dev))
       Score += 50;
   }
   return Score;

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -29,10 +29,9 @@ static bool isDeviceOfPreferredSyclBe(const device &Device) {
   if (ForcedBackend) {
     return detail::getSyclObjImpl(Device)->getPlugin().getBackend() ==
            *ForcedBackend;
-  } else {
-    return detail::getSyclObjImpl(Device)->getPlugin().getBackend() ==
-           backend::level0;
-  }
+
+  return detail::getSyclObjImpl(Device)->getPlugin().getBackend() ==
+         backend::level0;
 }
 
 device device_selector::select_device() const {

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -64,8 +64,7 @@ device device_selector::select_device() const {
     // from the tied set is to be returned is not defined". Here we give a
     // preference to the device of the preferred BE.
     //
-    if ((score < dev_score) ||
-        (score == dev_score && isPreferredDevice(dev))) {
+    if ((score < dev_score) || (score == dev_score && isPreferredDevice(dev))) {
       res = &dev;
       score = dev_score;
     }

--- a/sycl/test/regression/device_avail.cpp
+++ b/sycl/test/regression/device_avail.cpp
@@ -1,0 +1,17 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %t.out
+// RUN: env SYCL_BE=PI_OPENCL %t.out
+// RUN: env SYCL_BE=PI_LEVEL0 %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+// This test checks if CPU device is not filtered out by setting SYCL_BE.
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main() {
+    auto devices = device::get_devices(info::device_type::cpu);
+    assert(devices.size() == 1 && "CPU device should be available even when SYCL_BE is set");
+   return 0;
+}

--- a/sycl/test/regression/device_avail.cpp
+++ b/sycl/test/regression/device_avail.cpp
@@ -11,7 +11,7 @@
 using namespace cl::sycl;
 
 int main() {
-    auto devices = device::get_devices(info::device_type::cpu);
-    assert(devices.size() == 1 && "CPU device should be available even when SYCL_BE is set");
-   return 0;
+  auto devices = device::get_devices(info::device_type::cpu);
+  assert(devices.size() == 1 && "CPU device should be available even when SYCL_BE is set");
+  return 0;
 }


### PR DESCRIPTION
Currently when SYCL_BE is set, other devices (such CPU) is filtered out from the available devices list.
This does not conform to the spec of device::get_devices().

static vector_class<device>get_devices(info::device_type deviceType =info::device_type::all) | Returns a vector_class containing all SYCL devices available in the system of the device type specified by the parameter deviceType. The returned vector_class must contain at least a SYCL device that is a host device if the deviceType is info::device_type::all, or a single host device if the deviceType is info::device_type::host.
-- | --

Basically, setting SYCL_BE should not limit the available devices (e.g., CPU) in the system.
The current implementation does not allow the usage of multiple devices when SYCL_BE is set because it filter out devices other than the only SYCL_BE setting device.

Signed-off-by: Byoungro So <byoungro.so@intel.com>