### PR TITLE
[SYCL] Default-instantiate ze_device_memory_properties_t in L0 plugin

### DIFF
--- a/sycl/plugins/level_zero/pi_level0.cpp
+++ b/sycl/plugins/level_zero/pi_level0.cpp
@@ -678,7 +678,7 @@ pi_result piDeviceGetInfo(pi_device Device, pi_device_info ParamName,
 
   std::vector<ze_device_memory_properties_t> ZeDeviceMemoryProperties;
   try {
-    ZeDeviceMemoryProperties.reserve(ZeAvailMemCount);
+    ZeDeviceMemoryProperties.resize(ZeAvailMemCount);
   } catch (const std::bad_alloc &) {
     return PI_OUT_OF_HOST_MEMORY;
   } catch (...) {


### PR DESCRIPTION
Fix post-commit review comment in https://github.com/intel/llvm/pull/2110

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>