### PR TITLE
[SYCL][PTX][CUDA] Fixes debug info cloning for implicit global offset

### DIFF
--- a/llvm/lib/Target/NVPTX/SYCL/GlobalOffset.cpp
+++ b/llvm/lib/Target/NVPTX/SYCL/GlobalOffset.cpp
@@ -259,6 +259,9 @@ public:
     Function *NewFunc = Function::Create(NewFuncTy, Func->getLinkage(),
                                          Func->getAddressSpace());
 
+    // Keep original function ordering.
+    M.getFunctionList().insertAfter(Func->getIterator(), NewFunc);
+
     if (KeepOriginal) {
       // TODO: Are there better naming alternatives that allow for unmangling?
       NewFunc->setName(Func->getName() + "_with_offset");
@@ -272,7 +275,7 @@ public:
       }
 
       SmallVector<ReturnInst *, 8> Returns;
-      CloneFunctionInto(NewFunc, Func, VMap, /*ModuleLevelChanges=*/false,
+      CloneFunctionInto(NewFunc, Func, VMap, /*ModuleLevelChanges=*/true,
                         Returns);
     } else {
       NewFunc->copyAttributesFrom(Func);
@@ -297,9 +300,6 @@ public:
       for (auto MD : MDs)
         NewFunc->addMetadata(MD.first, *MD.second);
     }
-
-    // Keep original function ordering.
-    M.getFunctionList().insertAfter(Func->getIterator(), NewFunc);
 
     Value *ImplicitOffset = NewFunc->arg_begin() + (NewFunc->arg_size() - 1);
     // Add bitcast to match the return type of the intrinsic if needed.

--- a/sycl/test/regression/implicit_offset_debug_info.cpp
+++ b/sycl/test/regression/implicit_offset_debug_info.cpp
@@ -1,0 +1,20 @@
+// RUN: %clangxx -g -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// REQUIRES: cuda
+
+// NOTE: Tests that the implicit global offset pass copies debug information
+
+#include <CL/sycl.hpp>
+using namespace cl::sycl;
+
+int main() {
+  queue q;
+  buffer<uint64_t, 1> t1(10);
+  q.submit([&](handler &cgh) {
+    auto table = t1.get_access<access::mode::write>(cgh);
+    cgh.parallel_for<class kernel>(10, [=](id<1> gtid) {
+      table[gtid] = gtid[0];
+    });
+  });
+  q.wait();
+}


### PR DESCRIPTION
The implicit global offset pass does not clone the debug information when cloning functions. This is fixed by inserting the new function before cloning so the parents of the clone and the original are the same, allowing the following call to `CloneFunctionInto` to also clone the debug information.