### PR TITLE
[SYCL][ESIMD] Don't add align attributes on sret arguments.

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -2135,7 +2135,10 @@ void CodeGenModule::ConstructAttributeList(
     hasUsedSRet = true;
     if (RetAI.getInReg())
       SRETAttrs.addAttribute(llvm::Attribute::InReg);
-    SRETAttrs.addAlignmentAttr(RetAI.getIndirectAlign().getQuantity());
+    // TODO: For ESIMD align attributes on sret arguments
+    // generate massively inefficient code.
+    if (!getLangOpts().SYCLExplicitSIMD || !getLangOpts().SYCLIsDevice)
+      SRETAttrs.addAlignmentAttr(RetAI.getIndirectAlign().getQuantity());
     ArgAttrs[IRFunctionArgs.getSRetArgNo()] =
         llvm::AttributeSet::get(getLLVMContext(), SRETAttrs);
   }


### PR DESCRIPTION
Adding align attributes leads to very inefficient code generation.

Author: Denis Bakhvalov <denis.bakhvalov@intel.com>

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>