### PR TITLE
[SYCL][ESIMD] Implement compile-time getNextPowerOf2 w/o recursion.

### DIFF
--- a/sycl/include/CL/sycl/intel/esimd/esimd_math.hpp
+++ b/sycl/include/CL/sycl/intel/esimd/esimd_math.hpp
@@ -1884,7 +1884,7 @@ T1 esimd_reduce(simd<T1, SZ> v) {
   if constexpr (isPowerOf2) {
     return esimd_reduce_single<T0, T1, SZ, OpType>(v);
   } else {
-    constexpr unsigned N1 = 1u << __esimd::log2(SZ);
+    constexpr unsigned N1 = 1u << __esimd::log2<SZ>();
     constexpr unsigned N2 = SZ - N1;
 
     simd<T1, N1> v1 = v.template select<N1, 1>(0);

--- a/sycl/include/CL/sycl/intel/esimd/esimd_memory.hpp
+++ b/sycl/include/CL/sycl/intel/esimd/esimd_memory.hpp
@@ -567,7 +567,7 @@ media_block_load(AccessorTy acc, unsigned x, unsigned y) {
   static_assert(plane <= 3u, "valid plane index is in range [0, 3]");
 #if defined(__SYCL_DEVICE_ONLY__) && defined(__SYCL_EXPLICIT_SIMD__)
   constexpr unsigned int RoundedWidth =
-      Width < 4 ? 4 : __esimd::getNextPowerOf2(Width);
+      Width < 4 ? 4 : __esimd::getNextPowerOf2<Width>();
 
   if constexpr (Width < RoundedWidth) {
     constexpr unsigned int n1 = RoundedWidth / sizeof(T);
@@ -617,7 +617,7 @@ media_block_store(AccessorTy acc, unsigned x, unsigned y, simd<T, m * n> vals) {
   static_assert(plane <= 3u, "valid plane index is in range [0, 3]");
 #if defined(__SYCL_DEVICE_ONLY__) && defined(__SYCL_EXPLICIT_SIMD__)
   constexpr unsigned int RoundedWidth =
-      Width < 4 ? 4 : __esimd::getNextPowerOf2(Width);
+      Width < 4 ? 4 : __esimd::getNextPowerOf2<Width>();
   constexpr unsigned int n1 = RoundedWidth / sizeof(T);
 
   if constexpr (Width < RoundedWidth) {


### PR DESCRIPTION
Device code is restricted not to allow recursion.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>