### PR TITLE
[SYCL][ESIMD] Setup compilation pipeline for ESIMD

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -581,6 +581,11 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
   if (CodeGenOpts.DisableLLVMPasses)
     return;
 
+  // Customize the head of the module passes list for the ESIMD extension.
+  if (LangOpts.SYCLIsDevice && LangOpts.SYCLExplicitSIMD) {
+    MPM.add(createSYCLLowerESIMDPass());
+  }
+
   // Figure out TargetLibraryInfo.  This needs to be added to MPM and FPM
   // manually (and not via PMBuilder), since some passes (eg. InstrProfiling)
   // are inserted before PMBuilder ones - they'd get the default-constructed
@@ -786,6 +791,25 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
 
   PMBuilder.populateFunctionPassManager(FPM);
   PMBuilder.populateModulePassManager(MPM);
+
+  // Customize the tail of the module passes list for the ESIMD extension.
+  if (LangOpts.SYCLIsDevice && LangOpts.SYCLExplicitSIMD &&
+    CodeGenOpts.OptimizationLevel != 0) {
+    MPM.add(createESIMDLowerVecArgPass());
+    MPM.add(createESIMDLowerLoadStorePass());
+    MPM.add(createSROAPass());
+    MPM.add(createEarlyCSEPass(true));
+    MPM.add(createInstructionCombiningPass());
+    MPM.add(createDeadCodeEliminationPass());
+    MPM.add(createFunctionInliningPass(
+      CodeGenOpts.OptimizationLevel, CodeGenOpts.OptimizeSize,
+      (!CodeGenOpts.SampleProfileFile.empty() &&
+        CodeGenOpts.PrepareForThinLTO)));
+    MPM.add(createSROAPass());
+    MPM.add(createEarlyCSEPass(true));
+    MPM.add(createInstructionCombiningPass());
+    MPM.add(createDeadCodeEliminationPass());
+  }
 }
 
 static void setCommandLineOpts(const CodeGenOptions &CodeGenOpts) {
@@ -880,29 +904,7 @@ void EmitAssemblyHelper::EmitAssembly(BackendAction Action,
   PerFunctionPasses.add(
       createTargetTransformInfoWrapperPass(getTargetIRAnalysis()));
 
-  if (LangOpts.SYCLIsDevice && LangOpts.SYCLExplicitSIMD) {
-    PerModulePasses.add(createSYCLLowerESIMDPass());
-  }
-
   CreatePasses(PerModulePasses, PerFunctionPasses);
-
-  if (LangOpts.SYCLIsDevice && LangOpts.SYCLExplicitSIMD &&
-      CodeGenOpts.OptimizationLevel != 0) {
-    PerModulePasses.add(createESIMDLowerVecArgPass());
-    PerModulePasses.add(createESIMDLowerLoadStorePass());
-    PerModulePasses.add(createSROAPass());
-    PerModulePasses.add(createEarlyCSEPass(true));
-    PerModulePasses.add(createInstructionCombiningPass());
-    PerModulePasses.add(createDeadCodeEliminationPass());
-    PerModulePasses.add(createFunctionInliningPass(
-        CodeGenOpts.OptimizationLevel, CodeGenOpts.OptimizeSize,
-        (!CodeGenOpts.SampleProfileFile.empty() &&
-         CodeGenOpts.PrepareForThinLTO)));
-    PerModulePasses.add(createSROAPass());
-    PerModulePasses.add(createEarlyCSEPass(true));
-    PerModulePasses.add(createInstructionCombiningPass());
-    PerModulePasses.add(createDeadCodeEliminationPass());
-  }
 
   legacy::PassManager CodeGenPasses;
   CodeGenPasses.add(

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -895,9 +895,9 @@ void EmitAssemblyHelper::EmitAssembly(BackendAction Action,
     PerModulePasses.add(createInstructionCombiningPass());
     PerModulePasses.add(createDeadCodeEliminationPass());
     PerModulePasses.add(createFunctionInliningPass(
-      CodeGenOpts.OptimizationLevel, CodeGenOpts.OptimizeSize,
-      (!CodeGenOpts.SampleProfileFile.empty() &&
-        CodeGenOpts.PrepareForThinLTO)));
+        CodeGenOpts.OptimizationLevel, CodeGenOpts.OptimizeSize,
+        (!CodeGenOpts.SampleProfileFile.empty() &&
+         CodeGenOpts.PrepareForThinLTO)));
     PerModulePasses.add(createSROAPass());
     PerModulePasses.add(createEarlyCSEPass(true));
     PerModulePasses.add(createInstructionCombiningPass());

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -794,7 +794,7 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
 
   // Customize the tail of the module passes list for the ESIMD extension.
   if (LangOpts.SYCLIsDevice && LangOpts.SYCLExplicitSIMD &&
-    CodeGenOpts.OptimizationLevel != 0) {
+      CodeGenOpts.OptimizationLevel != 0) {
     MPM.add(createESIMDLowerVecArgPass());
     MPM.add(createESIMDLowerLoadStorePass());
     MPM.add(createSROAPass());
@@ -802,9 +802,9 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
     MPM.add(createInstructionCombiningPass());
     MPM.add(createDeadCodeEliminationPass());
     MPM.add(createFunctionInliningPass(
-      CodeGenOpts.OptimizationLevel, CodeGenOpts.OptimizeSize,
-      (!CodeGenOpts.SampleProfileFile.empty() &&
-        CodeGenOpts.PrepareForThinLTO)));
+        CodeGenOpts.OptimizationLevel, CodeGenOpts.OptimizeSize,
+        (!CodeGenOpts.SampleProfileFile.empty() &&
+         CodeGenOpts.PrepareForThinLTO)));
     MPM.add(createSROAPass());
     MPM.add(createEarlyCSEPass(true));
     MPM.add(createInstructionCombiningPass());

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -582,9 +582,8 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
     return;
 
   // Customize the head of the module passes list for the ESIMD extension.
-  if (LangOpts.SYCLIsDevice && LangOpts.SYCLExplicitSIMD) {
+  if (LangOpts.SYCLIsDevice && LangOpts.SYCLExplicitSIMD)
     MPM.add(createSYCLLowerESIMDPass());
-  }
 
   // Figure out TargetLibraryInfo.  This needs to be added to MPM and FPM
   // manually (and not via PMBuilder), since some passes (eg. InstrProfiling)

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -816,10 +816,14 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
           Args.getLastArg(OPT_emit_llvm_uselists, OPT_no_emit_llvm_uselists))
     Opts.EmitLLVMUseLists = A->getOption().getID() == OPT_emit_llvm_uselists;
 
+  // ESIMD GPU Back-end requires optimized IR
+  bool IsSyclESIMD =
+    Args.hasFlag(options::OPT_fsycl_esimd, options::OPT_fno_sycl_esimd, false);
+
   Opts.DisableLLVMPasses =
       Args.hasArg(OPT_disable_llvm_passes) ||
       (Args.hasArg(OPT_fsycl_is_device) && Triple.isSPIR() &&
-       !Args.hasArg(OPT_fsycl_enable_optimizations));
+       !Args.hasArg(OPT_fsycl_enable_optimizations) && !IsSyclESIMD);
   Opts.DisableLifetimeMarkers = Args.hasArg(OPT_disable_lifetimemarkers);
 
   const llvm::Triple::ArchType DebugEntryValueArchs[] = {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -817,8 +817,8 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
     Opts.EmitLLVMUseLists = A->getOption().getID() == OPT_emit_llvm_uselists;
 
   // ESIMD GPU Back-end requires optimized IR
-  bool IsSyclESIMD =
-    Args.hasFlag(options::OPT_fsycl_esimd, options::OPT_fno_sycl_esimd, false);
+  bool IsSyclESIMD = Args.hasFlag(options::OPT_fsycl_esimd,
+                                  options::OPT_fno_sycl_esimd, false);
 
   Opts.DisableLLVMPasses =
       Args.hasArg(OPT_disable_llvm_passes) ||

--- a/clang/test/CodeGenSYCL/esimd-private-global.cpp
+++ b/clang/test/CodeGenSYCL/esimd-private-global.cpp
@@ -9,6 +9,6 @@ __attribute__((opencl_private)) __attribute__((register_num(17))) int vc;
 
 SYCL_EXTERNAL void init_vc(int x) {
   vc = x;
-  // CHECK: store i32 %0, i32* @vc
+  // CHECK: store i32 %{{[0-9a-zA-Z_]+}}, i32* @vc
 }
 // CHECK: attributes #0 = {{.*"VCByteOffset"="17".*"VCVolatile"}}

--- a/clang/test/CodeGenSYCL/esimd_metadata2.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-ESIMD
+// RUN: %clang_cc1 -O0 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-ESIMD
 
 // In ESIMD mode:
 // 1. Attribute !intel_reqd_sub_group_size !1 is added

--- a/clang/test/CodeGenSYCL/esimd_metadata2.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -O0 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-ESIMD
+// RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-ESIMD
 
 // In ESIMD mode:
 // 1. Attribute !intel_reqd_sub_group_size !1 is added

--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -820,7 +820,8 @@ translateSpirvIntrinsic(CallInst *CI, StringRef SpirvIntrName,
   auto translateSpirvIntr = [&SpirvIntrName, &ESIMDToErases,
                              CI](StringRef SpvIName, auto TranslateFunc) {
     if (SpirvIntrName.consume_front(SpvIName)) {
-      Value *TranslatedV = TranslateFunc(*CI, SpirvIntrName);
+      Value *TranslatedV =
+        TranslateFunc(*CI, SpirvIntrName.substr(1, 1));
       CI->replaceAllUsesWith(TranslatedV);
       ESIMDToErases.push_back(CI);
     }

--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -820,8 +820,7 @@ translateSpirvIntrinsic(CallInst *CI, StringRef SpirvIntrName,
   auto translateSpirvIntr = [&SpirvIntrName, &ESIMDToErases,
                              CI](StringRef SpvIName, auto TranslateFunc) {
     if (SpirvIntrName.consume_front(SpvIName)) {
-      Value *TranslatedV =
-        TranslateFunc(*CI, SpirvIntrName.substr(1, 1));
+      Value *TranslatedV = TranslateFunc(*CI, SpirvIntrName.substr(1, 1));
       CI->replaceAllUsesWith(TranslatedV);
       ESIMDToErases.push_back(CI);
     }

--- a/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
@@ -170,6 +170,17 @@ define dso_local spir_kernel void  @FUNC_30() !sycl_explicit_simd !1 {
 ; CHECK-NEXT: ret void
 }
 
+define dso_local spir_kernel void  @FUNC_31() !sycl_explicit_simd !1 {
+; CHECK: define dso_local spir_kernel void  @FUNC_31() !sycl_explicit_simd !1
+  %call = call spir_func i64 @_Z27__spirv_LocalInvocationId_xv()
+; CHECK-NEXT: %call.esimd = call <3 x i32> @llvm.genx.local.id.v3i32()
+; CHECK-NEXT: %local_id.x = extractelement <3 x i32> %call.esimd, i32 0
+; CHECK-NEXT: %local_id.x.cast.ty = zext i32 %local_id.x to i64
+  ret void
+; CHECK-NEXT: ret void
+}
+
+declare dso_local spir_func i64 @_Z27__spirv_LocalInvocationId_xv()
 declare dso_local spir_func <32 x i32> @_Z20__esimd_flat_atomic0ILN2cm3gen14CmAtomicOpTypeE2EjLi32ELNS1_9CacheHintE0ELS3_0EENS1_13__vector_typeIT0_XT1_EE4typeENS4_IyXT1_EE4typeENS4_ItXT1_EE4typeE(<32 x i64> %0, <32 x i16> %1)
 declare dso_local spir_func <32 x i32> @_Z20__esimd_flat_atomic1ILN2cm3gen14CmAtomicOpTypeE0EjLi32ELNS1_9CacheHintE0ELS3_0EENS1_13__vector_typeIT0_XT1_EE4typeENS4_IyXT1_EE4typeES7_NS4_ItXT1_EE4typeE(<32 x i64> %0, <32 x i32> %1, <32 x i16> %2)
 declare dso_local spir_func <32 x i32> @_Z20__esimd_flat_atomic2ILN2cm3gen14CmAtomicOpTypeE7EjLi32ELNS1_9CacheHintE0ELS3_0EENS1_13__vector_typeIT0_XT1_EE4typeENS4_IyXT1_EE4typeES7_S7_NS4_ItXT1_EE4typeE(<32 x i64> %0, <32 x i32> %1, <32 x i32> %2, <32 x i16> %3)

--- a/llvm/test/SYCLLowerIR/esimd_subroutine.ll
+++ b/llvm/test/SYCLLowerIR/esimd_subroutine.ll
@@ -49,7 +49,7 @@ entry:
 }
 
 ; Function Attrs: norecurse nounwind
-; CHECK: define linkonce_odr spir_func void @_ZN4simdIiLi16EEC1ERS0_(<16 x i32> addrspace(4)* [[OLDARG0:%[a-zA-Z0-9_]*]], <16 x i32> addrspace(4)* [[OLDARG1:%[a-zA-Z0-9_]*]]) unnamed_addr {{.+}}
+; CHECK: define linkonce_odr spir_func void @_ZN4simdIiLi16EEC1ERS0_(<16 x i32> addrspace(4)* [[OLDARG0:%[a-zA-Z0-9_]*]], <16 x i32> addrspace(4)*{{.*}} [[OLDARG1:%[a-zA-Z0-9_]*]]) unnamed_addr {{.+}}
 define linkonce_odr spir_func void @_ZN4simdIiLi16EEC1ERS0_(%class._ZTS4simdIiLi16EE.simd addrspace(4)* %this, %class._ZTS4simdIiLi16EE.simd addrspace(4)* align 64 dereferenceable(64) %other) unnamed_addr #0 comdat align 2 {
 entry:
 ; CHECK: [[NEWARG1:%[a-zA-Z0-9_]*]] = bitcast <16 x i32> addrspace(4)* [[OLDARG1]] to {{.+}}

--- a/sycl/test/basic_tests/esimd/vadd.cpp
+++ b/sycl/test/basic_tests/esimd/vadd.cpp
@@ -1,0 +1,103 @@
+// TODO ESIMD enable host device under -fsycl
+// RUN: %clangxx -I %sycl_include %s -o %t.out -lsycl
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+
+#include <iostream>
+#include <CL/sycl.hpp>
+#include <CL/sycl/intel/esimd.hpp>
+
+using namespace cl::sycl;
+
+class ESIMDSelector : public device_selector {
+  // Require GPU device unless HOST is requested in SYCL_DEVICE_TYPE env
+  virtual int operator()(const device &device) const {
+    if (const char *dev_type = getenv("SYCL_DEVICE_TYPE")) {
+      if (!strcmp(dev_type, "GPU"))
+        return device.is_gpu() ? 1000 : -1;
+      if (!strcmp(dev_type, "HOST"))
+        return device.is_host() ? 1000 : -1;
+      std::cerr << "Supported 'SYCL_DEVICE_TYPE' env var values are 'GPU' and 'HOST', '" << dev_type << "' is not.\n";
+      return -1;
+    }
+    // If "SYCL_DEVICE_TYPE" not defined, only allow gpu device
+    return device.is_gpu() ? 1000 : -1;
+  }
+};
+
+auto exception_handler = [](exception_list l) {
+  for (auto ep : l) {
+    try {
+      std::rethrow_exception(ep);
+    } catch (cl::sycl::exception &e0) {
+      std::cout << "sycl::exception: " << e0.what() << std::endl;
+    } catch (std::exception &e) {
+      std::cout << "std::exception: " << e.what() << std::endl;
+    } catch (...) {
+      std::cout << "generic exception\n";
+    }
+  }
+};
+
+int main(void) {
+  constexpr unsigned Size = 256;
+  constexpr unsigned VL = 32;
+  constexpr unsigned GroupSize = 2;
+
+  int A[Size];
+  int B[Size];
+  int C[Size] = {};
+
+  for (unsigned i = 0; i < Size; ++i) {
+    A[i] = B[i] = i;
+  }
+
+  {
+    cl::sycl::buffer<int, 1> bufA(A, Size);
+    cl::sycl::buffer<int, 1> bufB(B, Size);
+    cl::sycl::buffer<int, 1> bufC(C, Size);
+
+    // We need that many task groups
+    cl::sycl::range<1> GroupRange{Size / VL};
+
+    // We need that many tasks in each group
+    cl::sycl::range<1> TaskRange{GroupSize};
+
+    cl::sycl::nd_range<1> Range{GroupRange, TaskRange};
+
+    queue q(ESIMDSelector{}, exception_handler);
+    q.submit([&](cl::sycl::handler &cgh) {
+      auto accA = bufA.get_access<cl::sycl::access::mode::read>(cgh);
+      auto accB = bufB.get_access<cl::sycl::access::mode::read>(cgh);
+      auto accC = bufC.get_access<cl::sycl::access::mode::write>(cgh);
+
+      cgh.parallel_for<class Test>(
+          Range, [=](nd_item<1> ndi) SYCL_ESIMD_KERNEL {
+            using namespace sycl::intel::gpu;
+            auto pA = accA.get_pointer().get();
+            auto pB = accB.get_pointer().get();
+            auto pC = accC.get_pointer().get();
+
+            int i = ndi.get_global_id(0);
+            constexpr int ESIZE = sizeof(int);
+            simd<uint32_t, VL> offsets(0, ESIZE);
+
+            simd<int, VL> va = gather<int, VL>(pA + i * VL, offsets);
+            simd<int, VL> vb = block_load<int, VL>(pB + i * VL);
+            simd<int, VL> vc = va + vb;
+
+            block_store<int, VL>(pC + i * VL, vc);
+          });
+    });
+
+    for (unsigned i = 0; i < Size; ++i) {
+      if (A[i] + B[i] != C[i]) {
+        std::cout << "failed at index " << i << ", " << C[i] << " != " << A[i]
+                  << " + " << B[i] << "\n";
+        return 1;
+      }
+    }
+  }
+
+  std::cout << "Passed\n";
+  return 0;
+}

--- a/sycl/test/basic_tests/esimd/vadd.cpp
+++ b/sycl/test/basic_tests/esimd/vadd.cpp
@@ -16,7 +16,9 @@ class ESIMDSelector : public device_selector {
         return device.is_gpu() ? 1000 : -1;
       if (!strcmp(dev_type, "HOST"))
         return device.is_host() ? 1000 : -1;
-      std::cerr << "Supported 'SYCL_DEVICE_TYPE' env var values are 'GPU' and 'HOST', '" << dev_type << "' is not.\n";
+      std::cerr << "Supported 'SYCL_DEVICE_TYPE' env var values are 'GPU' and "
+                   "'HOST', '"
+                << dev_type << "' is not.\n";
       return -1;
     }
     // If "SYCL_DEVICE_TYPE" not defined, only allow gpu device

--- a/sycl/test/basic_tests/esimd/vadd.cpp
+++ b/sycl/test/basic_tests/esimd/vadd.cpp
@@ -2,9 +2,9 @@
 // RUN: %clangxx -I %sycl_include %s -o %t.out -lsycl
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 
-#include <iostream>
 #include <CL/sycl.hpp>
 #include <CL/sycl/intel/esimd.hpp>
+#include <iostream>
 
 using namespace cl::sycl;
 

--- a/sycl/test/esimd/glob.cpp
+++ b/sycl/test/esimd/glob.cpp
@@ -1,9 +1,9 @@
 // RUN: %clangxx -fsycl -fsycl-explicit-simd -c -fsycl-device-only -Xclang -emit-llvm %s -o - | \
 // RUN:  FileCheck %s
 
-// This test checks that globals with register attribute are allowed in ESIMD mode,
-// can be accessed in functions and correct LLVM IR is generated (including
-// translation of the register attribute)
+// This test checks that globals with register attribute are allowed in ESIMD
+// mode, can be accessed in functions and correct LLVM IR is generated
+// (including translation of the register attribute)
 
 #include <CL/sycl.hpp>
 #include <CL/sycl/intel/esimd.hpp>

--- a/sycl/test/esimd/glob.cpp
+++ b/sycl/test/esimd/glob.cpp
@@ -1,0 +1,28 @@
+// RUN: %clangxx -fsycl -fsycl-explicit-simd -c -fsycl-device-only -Xclang -emit-llvm %s -o - | \
+// RUN:  FileCheck %s
+
+// This test checks that globals with register attribute are allowed in ESIMD mode,
+// can be accessed in functions and correct LLVM IR is generated (including
+// translation of the register attribute)
+
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <CL/sycl/intel/esimd.hpp>
+
+using namespace cl::sycl;
+using namespace sycl::intel::gpu;
+
+#define VL 16
+
+ESIMD_PRIVATE ESIMD_REGISTER(17) simd<int, VL> vc;
+// CHECK-DAG: @vc = {{.+}} <16 x i32> zeroinitializer, align 64 #0
+// CHECK-DAG: attributes #0 = { "genx_byte_offset"="17" "genx_volatile" }
+
+ESIMD_PRIVATE ESIMD_REGISTER(17 + VL) simd<int, VL> vc1;
+// CHECK-DAG: @vc1 = {{.+}} <16 x i32> zeroinitializer, align 64 #1
+// CHECK-DAG: attributes #1 = { "genx_byte_offset"="33" "genx_volatile" }
+
+SYCL_EXTERNAL ESIMD_NOINLINE void init_vc(int x) {
+  vc1 = vc + 1;
+  vc = x;
+}

--- a/sycl/test/esimd/glob.cpp
+++ b/sycl/test/esimd/glob.cpp
@@ -6,8 +6,8 @@
 // translation of the register attribute)
 
 #include <CL/sycl.hpp>
-#include <iostream>
 #include <CL/sycl/intel/esimd.hpp>
+#include <iostream>
 
 using namespace cl::sycl;
 using namespace sycl::intel::gpu;

--- a/sycl/test/esimd/glob.cpp
+++ b/sycl/test/esimd/glob.cpp
@@ -16,11 +16,11 @@ constexpr unsigned VL = 16;
 
 ESIMD_PRIVATE ESIMD_REGISTER(17) simd<int, VL> vc;
 // CHECK-DAG: @vc = {{.+}} <16 x i32> zeroinitializer, align 64 #0
-// CHECK-DAG: attributes #0 = { "genx_byte_offset"="17" "genx_volatile" }
+// CHECK-DAG: attributes #0 = { {{.*}}"VCByteOffset"="17" "VCGlobalVariable" "VCVolatile"{{.*}} }
 
 ESIMD_PRIVATE ESIMD_REGISTER(17 + VL) simd<int, VL> vc1;
 // CHECK-DAG: @vc1 = {{.+}} <16 x i32> zeroinitializer, align 64 #1
-// CHECK-DAG: attributes #1 = { "genx_byte_offset"="33" "genx_volatile" }
+// CHECK-DAG: attributes #1 = { {{.*}}"VCByteOffset"="33" "VCGlobalVariable" "VCVolatile"{{.*}} }
 
 SYCL_EXTERNAL ESIMD_NOINLINE void init_vc(int x) {
   vc1 = vc + 1;

--- a/sycl/test/esimd/glob.cpp
+++ b/sycl/test/esimd/glob.cpp
@@ -12,7 +12,7 @@
 using namespace cl::sycl;
 using namespace sycl::intel::gpu;
 
-#define VL 16
+constexpr unsigned VL = 16;
 
 ESIMD_PRIVATE ESIMD_REGISTER(17) simd<int, VL> vc;
 // CHECK-DAG: @vc = {{.+}} <16 x i32> zeroinitializer, align 64 #0

--- a/sycl/test/esimd/hw_compile.cpp
+++ b/sycl/test/esimd/hw_compile.cpp
@@ -1,0 +1,38 @@
+// Basic ESIMD test which checks that ESIMD invocation syntax can get compiled.
+// RUN: %clangxx -fsycl -fsycl-explicit-simd -fsycl-device-only -c %s -o %t.bc
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/intel/esimd.hpp>
+#include <iostream>
+
+int main(void) {
+  constexpr unsigned Size = 4;
+  int A[Size] = {1, 2, 3, 4};
+  int B[Size] = {1, 2, 3, 4};
+  int C[Size];
+
+  {
+    cl::sycl::range<1> UnitRange{1};
+    cl::sycl::buffer<int, 1> bufA(A, UnitRange);
+    cl::sycl::buffer<int, 1> bufB(B, UnitRange);
+    cl::sycl::buffer<int, 1> bufC(C, UnitRange);
+
+    cl::sycl::queue().submit([&](cl::sycl::handler &cgh) {
+      auto accA = bufA.get_access<cl::sycl::access::mode::read>(cgh);
+      auto accB = bufB.get_access<cl::sycl::access::mode::read>(cgh);
+      auto accC = bufC.get_access<cl::sycl::access::mode::write>(cgh);
+
+      cgh.parallel_for<class Test>(
+          UnitRange * UnitRange, [=](sycl::id<1> i) SYCL_ESIMD_KERNEL {
+            // those operations below would normally be represented as a single
+            // vector operation through ESIMD vector
+            accC[i + 0] = accA[i + 0] + accB[i + 0];
+            accC[i + 1] = accA[i + 1] + accB[i + 1];
+            accC[i + 2] = accA[i + 2] + accB[i + 2];
+            accC[i + 3] = accA[i + 3] + accB[i + 3];
+          });
+    });
+  }
+
+  return 0;
+}

--- a/sycl/test/esimd/hw_compile.cpp
+++ b/sycl/test/esimd/hw_compile.cpp
@@ -22,15 +22,16 @@ int main(void) {
       auto accB = bufB.get_access<cl::sycl::access::mode::read>(cgh);
       auto accC = bufC.get_access<cl::sycl::access::mode::write>(cgh);
 
-      cgh.parallel_for<class Test>(
-          UnitRange * UnitRange, [=](sycl::id<1> i) SYCL_ESIMD_KERNEL {
-            // those operations below would normally be represented as a single
-            // vector operation through ESIMD vector
-            accC[i + 0] = accA[i + 0] + accB[i + 0];
-            accC[i + 1] = accA[i + 1] + accB[i + 1];
-            accC[i + 2] = accA[i + 2] + accB[i + 2];
-            accC[i + 3] = accA[i + 3] + accB[i + 3];
-          });
+      cgh.parallel_for<class Test>(UnitRange * UnitRange,
+                                   [=](sycl::id<1> i) SYCL_ESIMD_KERNEL {
+                                     // those operations below would normally be
+                                     // represented as a single vector operation
+                                     // through ESIMD vector
+                                     accC[i + 0] = accA[i + 0] + accB[i + 0];
+                                     accC[i + 1] = accA[i + 1] + accB[i + 1];
+                                     accC[i + 2] = accA[i + 2] + accB[i + 2];
+                                     accC[i + 3] = accA[i + 3] + accB[i + 3];
+                                   });
     });
   }
 

--- a/sycl/test/esimd/intrins_trans.cpp
+++ b/sycl/test/esimd/intrins_trans.cpp
@@ -17,9 +17,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo();
 
 class EsimdFunctor {
 public:
-  void operator()() __attribute__((sycl_explicit_simd)) {
-    foo();
-  }
+  void operator()() __attribute__((sycl_explicit_simd)) { foo(); }
 };
 
 template <typename name, typename Func>
@@ -45,21 +43,26 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
   simd<ushort, VL> pred;
   v_addr += offsets;
 
-  __esimd_flat_atomic0<EsimdAtomicOpType::ATOMIC_INC, uint32_t, VL>(v_addr.data(), pred.data());
+  __esimd_flat_atomic0<EsimdAtomicOpType::ATOMIC_INC, uint32_t, VL>(
+      v_addr.data(), pred.data());
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.inc.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
 
-  __esimd_flat_atomic1<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, VL>(v_addr.data(), v1, pred.data());
+  __esimd_flat_atomic1<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, VL>(
+      v_addr.data(), v1, pred.data());
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.add.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
-  __esimd_flat_atomic2<EsimdAtomicOpType::ATOMIC_CMPXCHG, uint32_t, VL>(v_addr.data(), v1, v1, pred.data());
+  __esimd_flat_atomic2<EsimdAtomicOpType::ATOMIC_CMPXCHG, uint32_t, VL>(
+      v_addr.data(), v1, v1, pred.data());
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.cmpxchg.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
 
   uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
-  simd<uint32_t, VL> v00 = __esimd_flat_block_read_unaligned<uint32_t, VL>(addr);
+  simd<uint32_t, VL> v00 =
+      __esimd_flat_block_read_unaligned<uint32_t, VL>(addr);
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.block.ld.unaligned.v32i32(i64 %{{[0-9a-zA-Z_.]+}})
   __esimd_flat_block_write<uint32_t, VL>(addr, v00.data());
   // CHECK: call void @llvm.genx.svm.block.st.v32i32(i64 %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}})
 
-  simd<uint32_t, VL> v01 = __esimd_flat_read<uint32_t, VL>(v_addr.data(), 0, pred.data());
+  simd<uint32_t, VL> v01 =
+      __esimd_flat_read<uint32_t, VL>(v_addr.data(), 0, pred.data());
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.gather.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
 
   __esimd_flat_write<uint32_t, VL>(v_addr.data(), v01.data(), 0, pred.data());
@@ -90,13 +93,9 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
                      cl::sycl::access::target::image, PH::false_t>
       pB;
 
-  auto d = __esimd_wrregion<
-      float,
-      16 /*ret size*/,
-      8 /*write size*/,
-      0 /*vstride*/,
-      8 /*row width*/,
-      1 /*hstride*/>(c.data() /*dst*/, b.data() /*src*/, 0 /*offset*/);
+  auto d = __esimd_wrregion<float, 16 /*ret size*/, 8 /*write size*/,
+                            0 /*vstride*/, 8 /*row width*/, 1 /*hstride*/>(
+      c.data() /*dst*/, b.data() /*src*/, 0 /*offset*/);
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x float> @llvm.genx.wrregionf.v16f32.v8f32.i16.v8i1(<16 x float> %{{[0-9a-zA-Z_.]+}}, <8 x float> %{{[0-9a-zA-Z_.]+}}, i32 0, i32 8, i32 1, i16 0, i32 0, <8 x i1> <i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true>)
 
   simd<int, 32> va;

--- a/sycl/test/esimd/intrins_trans.cpp
+++ b/sycl/test/esimd/intrins_trans.cpp
@@ -35,7 +35,7 @@ void bar() {
 SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
   // CHECK-LABEL: @_Z3foov
   constexpr int VL = 32;
-  uint32_t* ptr = 0;
+  uint32_t *ptr = 0;
 
   int x = 0, y = 0, z = 0;
 
@@ -91,12 +91,12 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
       pB;
 
   auto d = __esimd_wrregion<
-    float,
-    16/*ret size*/,
-    8/*write size*/,
-    0/*vstride*/,
-    8/*row width*/,
-    1/*hstride*/>(c.data()/*dst*/, b.data()/*src*/,0/*offset*/);
+      float,
+      16 /*ret size*/,
+      8 /*write size*/,
+      0 /*vstride*/,
+      8 /*row width*/,
+      1 /*hstride*/>(c.data() /*dst*/, b.data() /*src*/, 0 /*offset*/);
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x float> @llvm.genx.wrregionf.v16f32.v8f32.i16.v8i1(<16 x float> %{{[0-9a-zA-Z_.]+}}, <8 x float> %{{[0-9a-zA-Z_.]+}}, i32 0, i32 8, i32 1, i16 0, i32 0, <8 x i1> <i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true>)
 
   simd<int, 32> va;
@@ -109,7 +109,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
   // CHECK: %[[SI2:[0-9a-zA-Z_.]+]] = ptrtoint %opencl.image2d_wo_t addrspace(1)* %{{[0-9a-zA-Z_.]+}} to i32
   // CHECK: call void @llvm.genx.media.st.v32i32(i32 0, i32 %[[SI2]], i32 0, i32 32, i32 %{{[0-9a-zA-Z_.]+}}, i32 %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}})
 
-  auto ee = __esimd_vload<int, 16>((vector_type_t<int, 16>*)(&vg));
+  auto ee = __esimd_vload<int, 16>((vector_type_t<int, 16> *)(&vg));
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x i32> @llvm.genx.vload.v16i32.p4v16i32(<16 x i32> addrspace(4)* {{.*}})
   __esimd_vstore<int, 32>(&vc, va.data());
   // CHECK: store <32 x i32>  %{{[0-9a-zA-Z_.]+}}, <32 x i32> addrspace(4)* {{.*}}

--- a/sycl/test/esimd/intrins_trans.cpp
+++ b/sycl/test/esimd/intrins_trans.cpp
@@ -1,0 +1,118 @@
+// RUN: %clangxx -O0 -fsycl -fsycl-explicit-simd -fsycl-device-only -Xclang -emit-llvm %s -o - | \
+// RUN:   FileCheck %s
+
+// Checks ESIMD intrinsic translation.
+// NOTE: must be run in -O0, as optimizer optimizes away some of the code
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/detail/image_ocl_types.hpp>
+#include <CL/sycl/intel/esimd.hpp>
+
+using namespace sycl::intel::gpu;
+
+ESIMD_PRIVATE vector_type_t<int, 32> vc;
+ESIMD_PRIVATE ESIMD_REGISTER(192) simd<int, 16> vg;
+
+SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo();
+
+class EsimdFunctor {
+public:
+  void operator()() __attribute__((sycl_explicit_simd)) {
+    foo();
+  }
+};
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+void bar() {
+  EsimdFunctor esimdf;
+  kernel<class kernel_esimd>(esimdf);
+}
+
+SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
+  // CHECK-LABEL: @_Z3foov
+  constexpr int VL = 32;
+  uint32_t* ptr = 0;
+
+  int x = 0, y = 0, z = 0;
+
+  simd<uint32_t, VL> v1(0, x + z);
+  simd<uint64_t, VL> offsets(0, y);
+  simd<uintptr_t, VL> v_addr(reinterpret_cast<uintptr_t>(ptr));
+  simd<ushort, VL> pred;
+  v_addr += offsets;
+
+  __esimd_flat_atomic0<EsimdAtomicOpType::ATOMIC_INC, uint32_t, VL>(v_addr.data(), pred.data());
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.inc.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
+
+  __esimd_flat_atomic1<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, VL>(v_addr.data(), v1, pred.data());
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.add.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
+  __esimd_flat_atomic2<EsimdAtomicOpType::ATOMIC_CMPXCHG, uint32_t, VL>(v_addr.data(), v1, v1, pred.data());
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.cmpxchg.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
+
+  uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
+  simd<uint32_t, VL> v00 = __esimd_flat_block_read_unaligned<uint32_t, VL>(addr);
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.block.ld.unaligned.v32i32(i64 %{{[0-9a-zA-Z_.]+}})
+  __esimd_flat_block_write<uint32_t, VL>(addr, v00.data());
+  // CHECK: call void @llvm.genx.svm.block.st.v32i32(i64 %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}})
+
+  simd<uint32_t, VL> v01 = __esimd_flat_read<uint32_t, VL>(v_addr.data(), 0, pred.data());
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.gather.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
+
+  __esimd_flat_write<uint32_t, VL>(v_addr.data(), v01.data(), 0, pred.data());
+  // CHECK: call void @llvm.genx.svm.scatter.v32i1.v32i64.v32i32(<32 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}})
+
+  simd<short, 16> mina(0, 1);
+  simd<short, 16> minc(5);
+  minc = __esimd_smin<short, 16>(mina.data(), minc.data());
+  // CHECK:  %{{[0-9a-zA-Z_.]+}} = call <16 x i16> @llvm.genx.smin.v16i16.v16i16(<16 x i16> %{{[0-9a-zA-Z_.]+}}, <16 x i16> %{{[0-9a-zA-Z_.]+}})
+
+  simd<float, 1> diva(2.f);
+  simd<float, 1> divb(1.f);
+  diva = __esimd_div_ieee<1>(diva.data(), divb.data());
+  // CHECK:  %{{[0-9a-zA-Z_.]+}} = call <1 x float> @llvm.genx.ieee.div.v1f32(<1 x float>  %{{[0-9a-zA-Z_.]+}}, <1 x float>  %{{[0-9a-zA-Z_.]+}})
+
+  simd<float, 16> a(0.1f);
+  simd<float, 8> b = __esimd_rdregion<float, 16, 8, 0, 8, 1>(a.data(), 0);
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <8 x float> @llvm.genx.rdregionf.v8f32.v16f32.i16(<16 x float> %{{[0-9a-zA-Z_.]+}}, i32 0, i32 8, i32 1, i16 0, i32 0)
+
+  simd<float, 16> c(0.0f);
+
+  using PH = cl::sycl::access::placeholder;
+
+  cl::sycl::accessor<cl::sycl::cl_int4, 2, cl::sycl::access::mode::read,
+                     cl::sycl::access::target::image, PH::false_t>
+      pA;
+  cl::sycl::accessor<cl::sycl::cl_int4, 2, cl::sycl::access::mode::write,
+                     cl::sycl::access::target::image, PH::false_t>
+      pB;
+
+  auto d = __esimd_wrregion<
+    float,
+    16/*ret size*/,
+    8/*write size*/,
+    0/*vstride*/,
+    8/*row width*/,
+    1/*hstride*/>(c.data()/*dst*/, b.data()/*src*/,0/*offset*/);
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x float> @llvm.genx.wrregionf.v16f32.v8f32.i16.v8i1(<16 x float> %{{[0-9a-zA-Z_.]+}}, <8 x float> %{{[0-9a-zA-Z_.]+}}, i32 0, i32 8, i32 1, i16 0, i32 0, <8 x i1> <i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true>)
+
+  simd<int, 32> va;
+  va = media_block_load<int, 4, 8>(pA, x, y);
+  // CHECK: %[[SI0:[0-9a-zA-Z_.]+]] = ptrtoint %opencl.image2d_ro_t addrspace(1)* %{{[0-9a-zA-Z_.]+}} to i32
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.media.ld.v32i32(i32 0, i32 %[[SI0]], i32 0, i32 32, i32 %{{[0-9a-zA-Z_.]+}}, i32 %{{[0-9a-zA-Z_.]+}})
+
+  simd<int, 32> vb = va + 1;
+  media_block_store<int, 4, 8>(pB, x, y, vb);
+  // CHECK: %[[SI2:[0-9a-zA-Z_.]+]] = ptrtoint %opencl.image2d_wo_t addrspace(1)* %{{[0-9a-zA-Z_.]+}} to i32
+  // CHECK: call void @llvm.genx.media.st.v32i32(i32 0, i32 %[[SI2]], i32 0, i32 32, i32 %{{[0-9a-zA-Z_.]+}}, i32 %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}})
+
+  auto ee = __esimd_vload<int, 16>((vector_type_t<int, 16>*)(&vg));
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x i32> @llvm.genx.vload.v16i32.p4v16i32(<16 x i32> addrspace(4)* {{.*}})
+  __esimd_vstore<int, 32>(&vc, va.data());
+  // CHECK: store <32 x i32>  %{{[0-9a-zA-Z_.]+}}, <32 x i32> addrspace(4)* {{.*}}
+
+  return d;
+}

--- a/sycl/test/esimd/spirv_intrins_trans.cpp
+++ b/sycl/test/esimd/spirv_intrins_trans.cpp
@@ -1,0 +1,184 @@
+// RUN: %clangxx -fsycl -fsycl-explicit-simd -fsycl-device-only -O0 -S -emit-llvm -x c++ %s -o - | FileCheck %s
+// This test checks that all SPIRV intrinsics are correctly
+// translated into GenX counterparts (implemented in LowerCM.cpp)
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/intel/esimd.hpp>
+
+SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_x();
+SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_y();
+SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_z();
+
+SYCL_EXTERNAL size_t __spirv_GlobalSize_x();
+SYCL_EXTERNAL size_t __spirv_GlobalSize_y();
+SYCL_EXTERNAL size_t __spirv_GlobalSize_z();
+
+SYCL_EXTERNAL size_t __spirv_GlobalOffset_x();
+SYCL_EXTERNAL size_t __spirv_GlobalOffset_y();
+SYCL_EXTERNAL size_t __spirv_GlobalOffset_z();
+
+SYCL_EXTERNAL size_t __spirv_NumWorkgroups_x();
+SYCL_EXTERNAL size_t __spirv_NumWorkgroups_y();
+SYCL_EXTERNAL size_t __spirv_NumWorkgroups_z();
+
+SYCL_EXTERNAL size_t __spirv_WorkgroupSize_x();
+SYCL_EXTERNAL size_t __spirv_WorkgroupSize_y();
+SYCL_EXTERNAL size_t __spirv_WorkgroupSize_z();
+
+SYCL_EXTERNAL size_t __spirv_WorkgroupId_x();
+SYCL_EXTERNAL size_t __spirv_WorkgroupId_y();
+SYCL_EXTERNAL size_t __spirv_WorkgroupId_z();
+
+SYCL_EXTERNAL size_t __spirv_LocalInvocationId_x();
+SYCL_EXTERNAL size_t __spirv_LocalInvocationId_y();
+SYCL_EXTERNAL size_t __spirv_LocalInvocationId_z();
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+size_t caller() {
+
+  size_t DoNotOpt;
+  cl::sycl::buffer<size_t, 1> buf(&DoNotOpt, 1);
+  cl::sycl::queue().submit([&](cl::sycl::handler &cgh) {
+    auto DoNotOptimize = buf.get_access<cl::sycl::access::mode::write>(cgh);
+
+    kernel<class kernel_GlobalInvocationId_x>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalInvocationId_x(); });
+    // CHECK-LABEL: @{{.*}}kernel_GlobalInvocationId_x
+    // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 0
+    // CHECK: [[CALL_ESIMD2:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 0
+    // CHECK: {{.*}} call i32 @llvm.genx.group.id.x()
+
+    kernel<class kernel_GlobalInvocationId_y>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalInvocationId_y(); });
+    // CHECK-LABEL: @{{.*}}kernel_GlobalInvocationId_y
+    // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 1
+    // CHECK: [[CALL_ESIMD2:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 1
+    // CHECK: {{.*}} call i32 @llvm.genx.group.id.y()
+
+    kernel<class kernel_GlobalInvocationId_z>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalInvocationId_z(); });
+    // CHECK-LABEL: @{{.*}}kernel_GlobalInvocationId_z
+    // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 2
+    // CHECK: [[CALL_ESIMD2:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 2
+    // CHECK: {{.*}} call i32 @llvm.genx.group.id.z()
+
+    kernel<class kernel_GlobalSize_x>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalSize_x(); });
+    // CHECK-LABEL: @{{.*}}kernel_GlobalSize_x
+    // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 0
+    // CHECK: [[CALL_ESIMD2:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 0
+
+    kernel<class kernel_GlobalSize_y>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalSize_y(); });
+    // CHECK-LABEL: @{{.*}}kernel_GlobalSize_y
+    // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 1
+    // CHECK: [[CALL_ESIMD2:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 1
+
+    kernel<class kernel_GlobalSize_z>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalSize_z(); });
+    // CHECK-LABEL: @{{.*}}kernel_GlobalSize_z
+    // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 2
+    // CHECK: [[CALL_ESIMD2:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 2
+
+    kernel<class kernel_GlobalOffset_x>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalOffset_x(); });
+    // CHECK-LABEL: @{{.*}}kernel_GlobalOffset_x
+    // CHECK: store i64 0
+
+    kernel<class kernel_GlobalOffset_y>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalOffset_y(); });
+    // CHECK-LABEL: @{{.*}}kernel_GlobalOffset_y
+    // CHECK: store i64 0
+
+    kernel<class kernel_GlobalOffset_z>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalOffset_z(); });
+    // CHECK-LABEL: @{{.*}}kernel_GlobalOffset_z
+    // CHECK: store i64 0
+
+    kernel<class kernel_NumWorkgroups_x>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_NumWorkgroups_x(); });
+    // CHECK-LABEL: @{{.*}}kernel_NumWorkgroups_x
+    // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 0
+
+    kernel<class kernel_NumWorkgroups_y>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_NumWorkgroups_y(); });
+    // CHECK-LABEL: @{{.*}}kernel_NumWorkgroups_y
+    // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 1
+
+    kernel<class kernel_NumWorkgroups_z>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_NumWorkgroups_z(); });
+    // CHECK-LABEL: @{{.*}}kernel_NumWorkgroups_z
+    // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 2
+
+    kernel<class kernel_WorkgroupSize_x>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupSize_x(); });
+    // CHECK-LABEL: @{{.*}}kernel_WorkgroupSize_x
+    // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 0
+
+    kernel<class kernel_WorkgroupSize_y>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupSize_y(); });
+    // CHECK-LABEL: @{{.*}}kernel_WorkgroupSize_y
+    // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 1
+
+    kernel<class kernel_WorkgroupSize_z>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupSize_z(); });
+    // CHECK-LABEL: @{{.*}}kernel_WorkgroupSize_z
+    // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 2
+
+    kernel<class kernel_WorkgroupId_x>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupId_x(); });
+    // CHECK-LABEL: @{{.*}}kernel_WorkgroupId_x
+    // CHECK: {{.*}} call i32 @llvm.genx.group.id.x()
+
+    kernel<class kernel_WorkgroupId_y>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupId_y(); });
+    // CHECK-LABEL: @{{.*}}kernel_WorkgroupId_y
+    // CHECK: {{.*}} call i32 @llvm.genx.group.id.y()
+
+    kernel<class kernel_WorkgroupId_z>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupId_z(); });
+    // CHECK-LABEL: @{{.*}}kernel_WorkgroupId_z
+    // CHECK: {{.*}} call i32 @llvm.genx.group.id.z()
+
+    kernel<class kernel_LocalInvocationId_x>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_LocalInvocationId_x(); });
+    // CHECK-LABEL: @{{.*}}kernel_LocalInvocationId_x
+    // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 0
+
+    kernel<class kernel_LocalInvocationId_y>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_LocalInvocationId_y(); });
+    // CHECK-LABEL: @{{.*}}kernel_LocalInvocationId_y
+    // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 1
+
+    kernel<class kernel_LocalInvocationId_z>(
+        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_LocalInvocationId_z(); });
+    // CHECK-LABEL: @{{.*}}kernel_LocalInvocationId_z
+    // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
+    // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 2
+  });
+  return DoNotOpt;
+}

--- a/sycl/test/esimd/spirv_intrins_trans.cpp
+++ b/sycl/test/esimd/spirv_intrins_trans.cpp
@@ -45,8 +45,9 @@ size_t caller() {
   cl::sycl::queue().submit([&](cl::sycl::handler &cgh) {
     auto DoNotOptimize = buf.get_access<cl::sycl::access::mode::write>(cgh);
 
-    kernel<class kernel_GlobalInvocationId_x>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalInvocationId_x(); });
+    kernel<class kernel_GlobalInvocationId_x>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_GlobalInvocationId_x();
+    });
     // CHECK-LABEL: @{{.*}}kernel_GlobalInvocationId_x
     // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 0
@@ -54,8 +55,9 @@ size_t caller() {
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 0
     // CHECK: {{.*}} call i32 @llvm.genx.group.id.x()
 
-    kernel<class kernel_GlobalInvocationId_y>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalInvocationId_y(); });
+    kernel<class kernel_GlobalInvocationId_y>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_GlobalInvocationId_y();
+    });
     // CHECK-LABEL: @{{.*}}kernel_GlobalInvocationId_y
     // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 1
@@ -63,8 +65,9 @@ size_t caller() {
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 1
     // CHECK: {{.*}} call i32 @llvm.genx.group.id.y()
 
-    kernel<class kernel_GlobalInvocationId_z>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalInvocationId_z(); });
+    kernel<class kernel_GlobalInvocationId_z>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_GlobalInvocationId_z();
+    });
     // CHECK-LABEL: @{{.*}}kernel_GlobalInvocationId_z
     // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 2
@@ -72,110 +75,128 @@ size_t caller() {
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 2
     // CHECK: {{.*}} call i32 @llvm.genx.group.id.z()
 
-    kernel<class kernel_GlobalSize_x>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalSize_x(); });
+    kernel<class kernel_GlobalSize_x>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_GlobalSize_x();
+    });
     // CHECK-LABEL: @{{.*}}kernel_GlobalSize_x
     // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 0
     // CHECK: [[CALL_ESIMD2:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 0
 
-    kernel<class kernel_GlobalSize_y>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalSize_y(); });
+    kernel<class kernel_GlobalSize_y>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_GlobalSize_y();
+    });
     // CHECK-LABEL: @{{.*}}kernel_GlobalSize_y
     // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 1
     // CHECK: [[CALL_ESIMD2:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 1
 
-    kernel<class kernel_GlobalSize_z>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalSize_z(); });
+    kernel<class kernel_GlobalSize_z>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_GlobalSize_z();
+    });
     // CHECK-LABEL: @{{.*}}kernel_GlobalSize_z
     // CHECK: [[CALL_ESIMD1:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD1]], i32 2
     // CHECK: [[CALL_ESIMD2:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD2]], i32 2
 
-    kernel<class kernel_GlobalOffset_x>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalOffset_x(); });
+    kernel<class kernel_GlobalOffset_x>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_GlobalOffset_x();
+    });
     // CHECK-LABEL: @{{.*}}kernel_GlobalOffset_x
     // CHECK: store i64 0
 
-    kernel<class kernel_GlobalOffset_y>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalOffset_y(); });
+    kernel<class kernel_GlobalOffset_y>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_GlobalOffset_y();
+    });
     // CHECK-LABEL: @{{.*}}kernel_GlobalOffset_y
     // CHECK: store i64 0
 
-    kernel<class kernel_GlobalOffset_z>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_GlobalOffset_z(); });
+    kernel<class kernel_GlobalOffset_z>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_GlobalOffset_z();
+    });
     // CHECK-LABEL: @{{.*}}kernel_GlobalOffset_z
     // CHECK: store i64 0
 
-    kernel<class kernel_NumWorkgroups_x>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_NumWorkgroups_x(); });
+    kernel<class kernel_NumWorkgroups_x>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_NumWorkgroups_x();
+    });
     // CHECK-LABEL: @{{.*}}kernel_NumWorkgroups_x
     // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 0
 
-    kernel<class kernel_NumWorkgroups_y>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_NumWorkgroups_y(); });
+    kernel<class kernel_NumWorkgroups_y>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_NumWorkgroups_y();
+    });
     // CHECK-LABEL: @{{.*}}kernel_NumWorkgroups_y
     // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 1
 
-    kernel<class kernel_NumWorkgroups_z>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_NumWorkgroups_z(); });
+    kernel<class kernel_NumWorkgroups_z>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_NumWorkgroups_z();
+    });
     // CHECK-LABEL: @{{.*}}kernel_NumWorkgroups_z
     // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.group.count.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 2
 
-    kernel<class kernel_WorkgroupSize_x>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupSize_x(); });
+    kernel<class kernel_WorkgroupSize_x>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_WorkgroupSize_x();
+    });
     // CHECK-LABEL: @{{.*}}kernel_WorkgroupSize_x
     // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 0
 
-    kernel<class kernel_WorkgroupSize_y>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupSize_y(); });
+    kernel<class kernel_WorkgroupSize_y>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_WorkgroupSize_y();
+    });
     // CHECK-LABEL: @{{.*}}kernel_WorkgroupSize_y
     // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 1
 
-    kernel<class kernel_WorkgroupSize_z>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupSize_z(); });
+    kernel<class kernel_WorkgroupSize_z>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_WorkgroupSize_z();
+    });
     // CHECK-LABEL: @{{.*}}kernel_WorkgroupSize_z
     // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 2
 
-    kernel<class kernel_WorkgroupId_x>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupId_x(); });
+    kernel<class kernel_WorkgroupId_x>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_WorkgroupId_x();
+    });
     // CHECK-LABEL: @{{.*}}kernel_WorkgroupId_x
     // CHECK: {{.*}} call i32 @llvm.genx.group.id.x()
 
-    kernel<class kernel_WorkgroupId_y>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupId_y(); });
+    kernel<class kernel_WorkgroupId_y>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_WorkgroupId_y();
+    });
     // CHECK-LABEL: @{{.*}}kernel_WorkgroupId_y
     // CHECK: {{.*}} call i32 @llvm.genx.group.id.y()
 
-    kernel<class kernel_WorkgroupId_z>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_WorkgroupId_z(); });
+    kernel<class kernel_WorkgroupId_z>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_WorkgroupId_z();
+    });
     // CHECK-LABEL: @{{.*}}kernel_WorkgroupId_z
     // CHECK: {{.*}} call i32 @llvm.genx.group.id.z()
 
-    kernel<class kernel_LocalInvocationId_x>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_LocalInvocationId_x(); });
+    kernel<class kernel_LocalInvocationId_x>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_LocalInvocationId_x();
+    });
     // CHECK-LABEL: @{{.*}}kernel_LocalInvocationId_x
     // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 0
 
-    kernel<class kernel_LocalInvocationId_y>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_LocalInvocationId_y(); });
+    kernel<class kernel_LocalInvocationId_y>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_LocalInvocationId_y();
+    });
     // CHECK-LABEL: @{{.*}}kernel_LocalInvocationId_y
     // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 1
 
-    kernel<class kernel_LocalInvocationId_z>(
-        [=]() SYCL_ESIMD_KERNEL { *DoNotOptimize.get_pointer() = __spirv_LocalInvocationId_z(); });
+    kernel<class kernel_LocalInvocationId_z>([=]() SYCL_ESIMD_KERNEL {
+      *DoNotOptimize.get_pointer() = __spirv_LocalInvocationId_z();
+    });
     // CHECK-LABEL: @{{.*}}kernel_LocalInvocationId_z
     // CHECK: [[CALL_ESIMD:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
     // CHECK: {{.*}} extractelement <3 x i32> [[CALL_ESIMD]], i32 2


### PR DESCRIPTION
- Add passes in BackendUtil to enable ESIMD back-end code generation.
- Add more tests some of which are dependent on the new compilation pipeline for ESIMD
- on-device tests are to be added later once CI infrastructure is ready

Please review commits starting from
7f525d5 [SYCL][ESIMD] Enable LLVM passes for ESIMD.
Earlier commits are parts of other PRs.
