### PR TITLE
[SYCL] Add support for [[intel::reqd_sub_group_…

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1288,7 +1288,9 @@ def LoopUnrollHint : InheritableAttr {
 }
 
 def IntelReqdSubGroupSize: InheritableAttr {
-  let Spellings = [GNU<"intel_reqd_sub_group_size">, CXX11<"cl", "intel_reqd_sub_group_size">];
+  let Spellings = [GNU<"intel_reqd_sub_group_size">,
+                   CXX11<"cl", "intel_reqd_sub_group_size">,
+                   CXX11<"intel", "reqd_sub_group_size">];
   let Args = [ExprArgument<"SubGroupSize">];
   let Subjects = SubjectList<[Function, CXXMethod], ErrorDiag>;
   let Documentation = [IntelReqdSubGroupSizeDocs];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3498,7 +3498,7 @@ as in the examples below:
 
   class Functor
   {
-      void operator()(item<1> item) [[intel::reqd_sub_group_size(16)]]
+      [[intel::reqd_sub_group_size(16)]] void operator()(item<1> item)
       {
           /* kernel code */
       }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3472,9 +3472,10 @@ code. See `cl_intel_required_subgroup_size
 for details.
 
 SYCL documentation:
-The [[cl::intel_reqd_sub_group_size(n)]] attribute indicates that the kernel
-must be compiled and executed with a sub-group of size n. The value of n must be
-set to a sub-group size supported by the device, or device compilation will fail.
+The [[cl::intel_reqd_sub_group_size(n)]] and [[intel::reqd_sub_group_size(n)]]
+attribute indicates that the kernel must be compiled and executed with a
+sub-group of size n. The value of n must be set to a sub-group size supported
+by the device, or device compilation will fail.
 
 In addition to device functions, the required sub-group size attribute may also
 be specified in the definition of a named functor object and lambda functions,
@@ -3492,6 +3493,19 @@ as in the examples below:
 
   kernel<class kernel_name>(
   []() [[cl::intel_reqd_sub_group_size(n)]] {
+       /* kernel code */
+  });
+
+  class Functor
+  {
+      void operator()(item<1> item) [[intel::reqd_sub_group_size(16)]]
+      {
+          /* kernel code */
+      }
+  }
+
+  kernel<class kernel_name>(
+  []() [[intel::reqd_sub_group_size(n)]] {
        /* kernel code */
   });
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10970,8 +10970,10 @@ def warn_ivdep_redundant : Warning <"ignoring redundant Intel FPGA loop "
   "attribute 'ivdep': safelen %select{INF|%1}0 >= safelen %select{INF|%3}2">,
   InGroup<IgnoredAttributes>;
 def warn_attribute_spelling_deprecated : Warning<
-  "attribute %0 is deprecated, did you mean to use 'reqd_sub_group_size' instead?">,
+  "attribute %0 is deprecated">,
   InGroup<DeprecatedAttributes>;
+def note_spelling_suggestion : Note<
+  "did you mean to use 'intel::reqd_sub_group_size' instead?">;
 
 // errors of expect.with.probability
 def err_probability_not_constant_float : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10969,6 +10969,9 @@ def err_ivdep_declrefexpr_arg : Error<
 def warn_ivdep_redundant : Warning <"ignoring redundant Intel FPGA loop "
   "attribute 'ivdep': safelen %select{INF|%1}0 >= safelen %select{INF|%3}2">,
   InGroup<IgnoredAttributes>;
+def warn_attribute_spelling_deprecated : Warning<
+  "previous spelling of attribute %0 is deprecated">,
+  InGroup<DeprecatedAttributes>;
 
 // errors of expect.with.probability
 def err_probability_not_constant_float : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10973,7 +10973,7 @@ def warn_attribute_spelling_deprecated : Warning<
   "attribute %0 is deprecated">,
   InGroup<DeprecatedAttributes>;
 def note_spelling_suggestion : Note<
-  "did you mean to use 'intel::reqd_sub_group_size' instead?">;
+  "did you mean to use %0 instead?">;
 
 // errors of expect.with.probability
 def err_probability_not_constant_float : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10970,7 +10970,7 @@ def warn_ivdep_redundant : Warning <"ignoring redundant Intel FPGA loop "
   "attribute 'ivdep': safelen %select{INF|%1}0 >= safelen %select{INF|%3}2">,
   InGroup<IgnoredAttributes>;
 def warn_attribute_spelling_deprecated : Warning<
-  "previous spelling of attribute %0 is deprecated">,
+  "attribute %0 is deprecated, did you mean to use 'reqd_sub_group_size' instead?">,
   InGroup<DeprecatedAttributes>;
 
 // errors of expect.with.probability

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3018,7 +3018,7 @@ static void handleSubGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
       IntelReqdSubGroupSizeAttr::CXX11_cl_intel_reqd_sub_group_size) {
     S.Diag(AL.getLoc(), diag::warn_attribute_spelling_deprecated) << AL;
     S.Diag(AL.getLoc(), diag::note_spelling_suggestion)
-      << "'intel::reqd_sub_group_size'";
+        << "'intel::reqd_sub_group_size'";
   }
 
   S.addIntelReqdSubGroupSizeAttr(D, AL, E);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3014,6 +3014,10 @@ static void handleSubGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (D->getAttr<IntelReqdSubGroupSizeAttr>())
     S.Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL;
 
+  if (AL.getAttributeSpellingListIndex() ==
+          IntelReqdSubGroupSizeAttr::CXX11_cl_intel_reqd_sub_group_size)
+    S.Diag(AL.getLoc(), diag::warn_attribute_spelling_deprecated) << AL;
+
   S.addIntelReqdSubGroupSizeAttr(D, AL, E);
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3015,8 +3015,10 @@ static void handleSubGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
     S.Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL;
 
   if (AL.getAttributeSpellingListIndex() ==
-      IntelReqdSubGroupSizeAttr::CXX11_cl_intel_reqd_sub_group_size)
+      IntelReqdSubGroupSizeAttr::CXX11_cl_intel_reqd_sub_group_size) {
     S.Diag(AL.getLoc(), diag::warn_attribute_spelling_deprecated) << AL;
+    S.Diag(AL.getLoc(), diag::note_spelling_suggestion);
+  }
 
   S.addIntelReqdSubGroupSizeAttr(D, AL, E);
 }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3015,7 +3015,7 @@ static void handleSubGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
     S.Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL;
 
   if (AL.getAttributeSpellingListIndex() ==
-          IntelReqdSubGroupSizeAttr::CXX11_cl_intel_reqd_sub_group_size)
+      IntelReqdSubGroupSizeAttr::CXX11_cl_intel_reqd_sub_group_size)
     S.Diag(AL.getLoc(), diag::warn_attribute_spelling_deprecated) << AL;
 
   S.addIntelReqdSubGroupSizeAttr(D, AL, E);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3017,7 +3017,8 @@ static void handleSubGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (AL.getAttributeSpellingListIndex() ==
       IntelReqdSubGroupSizeAttr::CXX11_cl_intel_reqd_sub_group_size) {
     S.Diag(AL.getLoc(), diag::warn_attribute_spelling_deprecated) << AL;
-    S.Diag(AL.getLoc(), diag::note_spelling_suggestion);
+    S.Diag(AL.getLoc(), diag::note_spelling_suggestion)
+      << "'intel::reqd_sub_group_size'";
   }
 
   S.addIntelReqdSubGroupSizeAttr(D, AL, E);

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -53,7 +53,7 @@ void bar() {
   });
 #endif
 
-  kernel<class kernel_name5>([]() [[intel::reqd_sub_group_size(2)]] { });
+  kernel<class kernel_name5>([]() [[intel::reqd_sub_group_size(2)]]{});
   kernel<class kernel_name6>([]() [[intel::reqd_sub_group_size(4)]] { foo(); });
   // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
   // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -1,21 +1,21 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -DTRIGGER_ERROR %s
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -ast-dump %s | FileCheck %s
 
-// expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
 [[cl::intel_reqd_sub_group_size(4)]] void foo() {} // expected-note {{conflicting attribute is here}}
 // expected-note@-1 {{conflicting attribute is here}}
 [[cl::intel_reqd_sub_group_size(32)]] void baz() {} // expected-note {{conflicting attribute is here}}
-// expected-warning@-1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-warning@-1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
 
 class Functor16 {
 public:
-  // expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
   [[cl::intel_reqd_sub_group_size(16)]] void operator()() {}
 };
 
 class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
 public:
-  // expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
   [[cl::intel_reqd_sub_group_size(8)]] void operator()() { // expected-note {{conflicting attribute is here}}
     foo();
   }
@@ -55,9 +55,9 @@ void bar() {
   });
 #endif
 
-  // expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
   kernel<class kernel_name5>([]() [[cl::intel_reqd_sub_group_size(2)]] { });
-  // expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
   kernel<class kernel_name6>([]() [[cl::intel_reqd_sub_group_size(4)]] { foo(); });
   kernel<class kernel_name7>([]() [[intel::reqd_sub_group_size(6)]]{});
 
@@ -65,22 +65,22 @@ void bar() {
   kernel<class kernel_name8>(f4);
 }
 
-// expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
 [[cl::intel_reqd_sub_group_size(16)]] SYCL_EXTERNAL void B();
-// expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
 [[cl::intel_reqd_sub_group_size(16)]] void A() {
 }
-// expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
 [[cl::intel_reqd_sub_group_size(16)]] SYCL_EXTERNAL void B() {
   A();
 }
 
 #ifdef TRIGGER_ERROR
-// expected-warning@+2{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-warning@+2{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
 // expected-note@+1 {{conflicting attribute is here}}
 [[cl::intel_reqd_sub_group_size(2)]] void sg_size2() {}
 
-// expected-warning@+3{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-warning@+3{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
 // expected-note@+2 {{conflicting attribute is here}}
 // expected-error@+1 {{conflicting attributes applied to a SYCL kernel}}
 [[cl::intel_reqd_sub_group_size(4)]] __attribute__((sycl_device)) void sg_size4() {

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -1,26 +1,18 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -DTRIGGER_ERROR %s
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -ast-dump %s | FileCheck %s
 
-// expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-// expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-[[cl::intel_reqd_sub_group_size(4)]] void foo() {} // expected-note {{conflicting attribute is here}}
+[[intel::reqd_sub_group_size(4)]] void foo() {} // expected-note {{conflicting attribute is here}}
 // expected-note@-1 {{conflicting attribute is here}}
-[[cl::intel_reqd_sub_group_size(32)]] void baz() {} // expected-note {{conflicting attribute is here}}
-// expected-note@-1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-// expected-warning@-2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+[[intel::reqd_sub_group_size(32)]] void baz() {} // expected-note {{conflicting attribute is here}}
 
 class Functor16 {
 public:
-  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-  [[cl::intel_reqd_sub_group_size(16)]] void operator()() {}
+  [[intel::reqd_sub_group_size(16)]] void operator()() {}
 };
 
 class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
 public:
-  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-  [[cl::intel_reqd_sub_group_size(8)]] void operator()() { // expected-note {{conflicting attribute is here}}
+  [[intel::reqd_sub_group_size(8)]] void operator()() { // expected-note {{conflicting attribute is here}}
     foo();
   }
 };
@@ -59,43 +51,28 @@ void bar() {
   });
 #endif
 
-  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-  kernel<class kernel_name5>([]() [[cl::intel_reqd_sub_group_size(2)]] { });
-  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-  kernel<class kernel_name6>([]() [[cl::intel_reqd_sub_group_size(4)]] { foo(); });
-  kernel<class kernel_name7>([]() [[intel::reqd_sub_group_size(6)]]{});
+  kernel<class kernel_name5>([]() [[intel::reqd_sub_group_size(2)]] { });
+  kernel<class kernel_name6>([]() [[intel::reqd_sub_group_size(4)]] { foo(); });
 
   Functor4 f4;
-  kernel<class kernel_name8>(f4);
+  kernel<class kernel_name7>(f4);
 }
 
-// expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-// expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-[[cl::intel_reqd_sub_group_size(16)]] SYCL_EXTERNAL void B();
-// expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-// expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-[[cl::intel_reqd_sub_group_size(16)]] void A() {
+[[intel::reqd_sub_group_size(16)]] SYCL_EXTERNAL void B();
+[[intel::reqd_sub_group_size(16)]] void A() {
 }
 
-// expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-// expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-[[cl::intel_reqd_sub_group_size(16)]] SYCL_EXTERNAL void B() {
+[[intel::reqd_sub_group_size(16)]] SYCL_EXTERNAL void B() {
   A();
 }
 
 #ifdef TRIGGER_ERROR
-// expected-warning@+3 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-// expected-note@+2 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 // expected-note@+1 {{conflicting attribute is here}}
-[[cl::intel_reqd_sub_group_size(2)]] void sg_size2() {}
+[[intel::reqd_sub_group_size(2)]] void sg_size2() {}
 
-// expected-warning@+4 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
-// expected-note@+3 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 // expected-note@+2 {{conflicting attribute is here}}
 // expected-error@+1 {{conflicting attributes applied to a SYCL kernel}}
-[[cl::intel_reqd_sub_group_size(4)]] __attribute__((sycl_device)) void sg_size4() {
+[[intel::reqd_sub_group_size(4)]] __attribute__((sycl_device)) void sg_size4() {
   sg_size2();
 }
 #endif
@@ -110,8 +87,5 @@ void bar() {
 // CHECK: IntelReqdSubGroupSizeAttr {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name7
-// CHECK: IntelReqdSubGroupSizeAttr {{.*}}
-// CHECK-NEXT: IntegerLiteral{{.*}}6{{$}}
-// CHECK: FunctionDecl {{.*}} {{.*}}kernel_name8
 // CHECK: IntelReqdSubGroupSizeAttr {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}12{{$}}

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -1,20 +1,29 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -DTRIGGER_ERROR %s
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -ast-dump %s | FileCheck %s
 
+// expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
 [[cl::intel_reqd_sub_group_size(4)]] void foo() {} // expected-note {{conflicting attribute is here}}
 // expected-note@-1 {{conflicting attribute is here}}
 [[cl::intel_reqd_sub_group_size(32)]] void baz() {} // expected-note {{conflicting attribute is here}}
+// expected-warning@-1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
 
 class Functor16 {
 public:
+  // expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
   [[cl::intel_reqd_sub_group_size(16)]] void operator()() {}
 };
 
 class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
 public:
+  // expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
   [[cl::intel_reqd_sub_group_size(8)]] void operator()() { // expected-note {{conflicting attribute is here}}
     foo();
   }
+};
+
+class Functor4 {
+public:
+  [[intel::reqd_sub_group_size(12)]] void operator()() {}
 };
 
 class Functor {
@@ -46,21 +55,32 @@ void bar() {
   });
 #endif
 
+  // expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
   kernel<class kernel_name5>([]() [[cl::intel_reqd_sub_group_size(2)]] { });
+  // expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
   kernel<class kernel_name6>([]() [[cl::intel_reqd_sub_group_size(4)]] { foo(); });
+  kernel<class kernel_name7>([]() [[intel::reqd_sub_group_size(6)]] { });
+
+  Functor4 f4;
+  kernel<class kernel_name8>(f4);
 }
 
+// expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
 [[cl::intel_reqd_sub_group_size(16)]] SYCL_EXTERNAL void B();
+// expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
 [[cl::intel_reqd_sub_group_size(16)]] void A() {
 }
+// expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
 [[cl::intel_reqd_sub_group_size(16)]] SYCL_EXTERNAL void B() {
   A();
 }
 
 #ifdef TRIGGER_ERROR
+// expected-warning@+2{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
 // expected-note@+1 {{conflicting attribute is here}}
 [[cl::intel_reqd_sub_group_size(2)]] void sg_size2() {}
 
+// expected-warning@+3{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
 // expected-note@+2 {{conflicting attribute is here}}
 // expected-error@+1 {{conflicting attributes applied to a SYCL kernel}}
 [[cl::intel_reqd_sub_group_size(4)]] __attribute__((sycl_device)) void sg_size4() {
@@ -77,3 +97,9 @@ void bar() {
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name5
 // CHECK: IntelReqdSubGroupSizeAttr {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
+// CHECK: FunctionDecl {{.*}} {{.*}}kernel_name7
+// CHECK: IntelReqdSubGroupSizeAttr {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}6{{$}}
+// CHECK: FunctionDecl {{.*}} {{.*}}kernel_name8
+// CHECK: IntelReqdSubGroupSizeAttr {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}12{{$}}

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -1,21 +1,25 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -DTRIGGER_ERROR %s
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -ast-dump %s | FileCheck %s
 
-// expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+// expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 [[cl::intel_reqd_sub_group_size(4)]] void foo() {} // expected-note {{conflicting attribute is here}}
 // expected-note@-1 {{conflicting attribute is here}}
 [[cl::intel_reqd_sub_group_size(32)]] void baz() {} // expected-note {{conflicting attribute is here}}
-// expected-warning@-1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+// expected-note@-1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
+// expected-warning@-2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
 
 class Functor16 {
 public:
-  // expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
   [[cl::intel_reqd_sub_group_size(16)]] void operator()() {}
 };
 
 class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
 public:
-  // expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
   [[cl::intel_reqd_sub_group_size(8)]] void operator()() { // expected-note {{conflicting attribute is here}}
     foo();
   }
@@ -55,9 +59,11 @@ void bar() {
   });
 #endif
 
-  // expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
   kernel<class kernel_name5>([]() [[cl::intel_reqd_sub_group_size(2)]] { });
-  // expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
   kernel<class kernel_name6>([]() [[cl::intel_reqd_sub_group_size(4)]] { foo(); });
   kernel<class kernel_name7>([]() [[intel::reqd_sub_group_size(6)]]{});
 
@@ -65,22 +71,28 @@ void bar() {
   kernel<class kernel_name8>(f4);
 }
 
-// expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+// expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 [[cl::intel_reqd_sub_group_size(16)]] SYCL_EXTERNAL void B();
-// expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+// expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 [[cl::intel_reqd_sub_group_size(16)]] void A() {
 }
-// expected-warning@+1{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+
+// expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 [[cl::intel_reqd_sub_group_size(16)]] SYCL_EXTERNAL void B() {
   A();
 }
 
 #ifdef TRIGGER_ERROR
-// expected-warning@+2{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+// expected-warning@+3 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-note@+2 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 // expected-note@+1 {{conflicting attribute is here}}
 [[cl::intel_reqd_sub_group_size(2)]] void sg_size2() {}
 
-// expected-warning@+3{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+// expected-warning@+4 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-note@+3 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 // expected-note@+2 {{conflicting attribute is here}}
 // expected-error@+1 {{conflicting attributes applied to a SYCL kernel}}
 [[cl::intel_reqd_sub_group_size(4)]] __attribute__((sycl_device)) void sg_size4() {

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -59,7 +59,7 @@ void bar() {
   kernel<class kernel_name5>([]() [[cl::intel_reqd_sub_group_size(2)]] { });
   // expected-warning@+1{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
   kernel<class kernel_name6>([]() [[cl::intel_reqd_sub_group_size(4)]] { foo(); });
-  kernel<class kernel_name7>([]() [[intel::reqd_sub_group_size(6)]] { });
+  kernel<class kernel_name7>([]() [[intel::reqd_sub_group_size(6)]]{});
 
   Functor4 f4;
   kernel<class kernel_name8>(f4);

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -7,7 +7,9 @@
 
 class Functor16 {
 public:
-  [[intel::reqd_sub_group_size(16)]] void operator()() {}
+  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
+  [[cl::intel_reqd_sub_group_size(16)]] void operator()() {}
 };
 
 class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
@@ -53,9 +55,12 @@ void bar() {
 
   kernel<class kernel_name5>([]() [[intel::reqd_sub_group_size(2)]] { });
   kernel<class kernel_name6>([]() [[intel::reqd_sub_group_size(4)]] { foo(); });
+  // expected-warning@+2 {{attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-note@+1 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
+  kernel<class kernel_name7>([]() [[cl::intel_reqd_sub_group_size(6)]]{});
 
   Functor4 f4;
-  kernel<class kernel_name7>(f4);
+  kernel<class kernel_name8>(f4);
 }
 
 [[intel::reqd_sub_group_size(16)]] SYCL_EXTERNAL void B();
@@ -87,5 +92,8 @@ void bar() {
 // CHECK: IntelReqdSubGroupSizeAttr {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name7
+// CHECK: IntelReqdSubGroupSizeAttr {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}6{{$}}
+// CHECK: FunctionDecl {{.*}} {{.*}}kernel_name8
 // CHECK: IntelReqdSubGroupSizeAttr {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}12{{$}}

--- a/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
@@ -5,7 +5,8 @@
 template <int SIZE>
 class KernelFunctor {
 public:
-  //expected-error@+1{{'intel_reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
+  // expected-warning@+2{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-error@+1{{'intel_reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
   [[cl::intel_reqd_sub_group_size(SIZE)]] void operator()() {}
 };
 

--- a/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
@@ -5,7 +5,7 @@
 template <int SIZE>
 class KernelFunctor {
 public:
-  // expected-warning@+2{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-warning@+2{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
   // expected-error@+1{{'intel_reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
   [[cl::intel_reqd_sub_group_size(SIZE)]] void operator()() {}
 };

--- a/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
@@ -1,14 +1,12 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
 
-// Test that checkes template parameter support for 'intel_reqd_sub_group_size' attribute on sycl device.
+// Test that checkes template parameter support for 'reqd_sub_group_size' attribute on sycl device.
 
 template <int SIZE>
 class KernelFunctor {
 public:
-  // expected-warning@+3{{attribute 'intel_reqd_sub_group_size' is deprecated}}
-  // expected-note@+2 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
-  // expected-error@+1{{'intel_reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
-  [[cl::intel_reqd_sub_group_size(SIZE)]] void operator()() {}
+  // expected-error@+1{{'reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
+  [[intel::reqd_sub_group_size(SIZE)]] void operator()() {}
 };
 
 int main() {

--- a/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
@@ -5,7 +5,8 @@
 template <int SIZE>
 class KernelFunctor {
 public:
-  // expected-warning@+2{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+  // expected-warning@+3{{attribute 'intel_reqd_sub_group_size' is deprecated}}
+  // expected-note@+2 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
   // expected-error@+1{{'intel_reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
   [[cl::intel_reqd_sub_group_size(SIZE)]] void operator()() {}
 };

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -16,10 +16,8 @@ void kernel0(F f) __attribute__((sycl_kernel)) {
   f();
 }
 
-// expected-warning@+3{{attribute 'intel_reqd_sub_group_size' is deprecated}}
-// expected-note@+2 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 // expected-note@+1{{conflicting attribute is here}}
-[[cl::intel_reqd_sub_group_size(2)]] void g0() {}
+[[intel::reqd_sub_group_size(2)]] void g0() {}
 
 void test0() {
   // expected-error@+2{{conflicting attributes applied to a SYCL kernel}}

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -16,7 +16,8 @@ void kernel0(F f) __attribute__((sycl_kernel)) {
   f();
 }
 
-// expected-warning@+2{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
+// expected-warning@+3{{attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-note@+2 {{did you mean to use 'intel::reqd_sub_group_size' instead?}}
 // expected-note@+1{{conflicting attribute is here}}
 [[cl::intel_reqd_sub_group_size(2)]] void g0() {}
 

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -16,7 +16,7 @@ void kernel0(F f) __attribute__((sycl_kernel)) {
   f();
 }
 
-// expected-warning@+2{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
+// expected-warning@+2{{attribute 'intel_reqd_sub_group_size' is deprecated, did you mean to use 'reqd_sub_group_size' instead?}}
 // expected-note@+1{{conflicting attribute is here}}
 [[cl::intel_reqd_sub_group_size(2)]] void g0() {}
 

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -16,6 +16,7 @@ void kernel0(F f) __attribute__((sycl_kernel)) {
   f();
 }
 
+// expected-warning@+2{{previous spelling of attribute 'intel_reqd_sub_group_size' is deprecated}}
 // expected-note@+1{{conflicting attribute is here}}
 [[cl::intel_reqd_sub_group_size(2)]] void g0() {}
 


### PR DESCRIPTION
…size()]]

This patch adds new spelling of IntelReqdSubGroupSize attribute
and generates a diagnostic which will tell that previous spelling
of the attribute is deprecated.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>