### PR TITLE
[SYCL][NFC] Improve ABI testing for memory objects

### DIFF
--- a/sycl/test/abi/symbol_size.cpp
+++ b/sycl/test/abi/symbol_size.cpp
@@ -8,6 +8,8 @@
 #include <CL/sycl/detail/accessor_impl.hpp>
 #include <CL/sycl/detail/buffer_impl.hpp>
 #include <CL/sycl/detail/image_impl.hpp>
+#include <CL/sycl/detail/sampler_impl.hpp>
+#include <CL/sycl/detail/stream_impl.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/device_event.hpp>
 #include <CL/sycl/device_selector.hpp>
@@ -45,7 +47,6 @@ int main() {
   check_size<detail::AccessorBaseHost, 16>();
   check_size<detail::LocalAccessorImplHost, 56>();
   check_size<buffer<int>, 40>();
-  check_size<detail::buffer_impl, 256>();
   check_size<context, 16>();
   check_size<cpu_selector, 8>();
   check_size<device, 16>();
@@ -55,22 +56,28 @@ int main() {
   check_size<gpu_selector, 8>();
 #ifdef _MSC_VER
   check_size<handler, 552>();
+  check_size<detail::buffer_impl, 288>();
+  check_size<detail::image_impl<1>, 344>();
 #else
   check_size<handler, 560>();
+  check_size<detail::buffer_impl, 256>();
+  check_size<detail::image_impl<1>, 312>();
 #endif
   check_size<image<1>, 16>();
-  check_size<detail::image_impl<1>, 312>();
   check_size<kernel, 16>();
   check_size<platform, 16>();
 #ifdef __SYCL_DEVICE_ONLY__
   check_size<private_memory<int, 1>, 4>();
+  check_size<detail::sampler_impl, 8>();
 #else
   check_size<private_memory<int, 1>, 8>();
+  check_size<detail::sampler_impl, 72>();
 #endif
   check_size<program, 16>();
   check_size<range<1>, 8>();
   check_size<sampler, 16>();
   check_size<stream, 144>();
+  check_size<detail::stream_impl, 120>();
   check_size<queue, 16>();
 
   return 0;

--- a/sycl/test/abi/symbol_size.cpp
+++ b/sycl/test/abi/symbol_size.cpp
@@ -5,6 +5,9 @@
 
 #include <CL/sycl/accessor.hpp>
 #include <CL/sycl/buffer.hpp>
+#include <CL/sycl/detail/accessor_impl.hpp>
+#include <CL/sycl/detail/buffer_impl.hpp>
+#include <CL/sycl/detail/image_impl.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/device_event.hpp>
 #include <CL/sycl/device_selector.hpp>
@@ -33,9 +36,16 @@ void check_size() {
 
 int main() {
   using accessor_t = accessor<int, 1, access::mode::read,
-                              access::target::global_buffer, access::placeholder::true_t>;
+                              access::target::global_buffer,
+                              access::placeholder::true_t>;
   check_size<accessor_t, 32>();
+  check_size<detail::AccessorImplDevice<1>, 24>();
+  check_size<detail::LocalAccessorBaseDevice<1>, 24>();
+  check_size<detail::AccessorImplHost, 128>();
+  check_size<detail::AccessorBaseHost, 16>();
+  check_size<detail::LocalAccessorImplHost, 56>();
   check_size<buffer<int>, 40>();
+  check_size<detail::buffer_impl, 256>();
   check_size<context, 16>();
   check_size<cpu_selector, 8>();
   check_size<device, 16>();
@@ -49,6 +59,7 @@ int main() {
   check_size<handler, 560>();
 #endif
   check_size<image<1>, 16>();
+  check_size<detail::image_impl<1>, 312>();
   check_size<kernel, 16>();
   check_size<platform, 16>();
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/test/abi/symbol_size.cpp
+++ b/sycl/test/abi/symbol_size.cpp
@@ -71,7 +71,11 @@ int main() {
   check_size<detail::sampler_impl, 8>();
 #else
   check_size<private_memory<int, 1>, 8>();
+#ifdef _MSC_VER
+  check_size<detail::sampler_impl, 80>();
+#else
   check_size<detail::sampler_impl, 72>();
+#endif
 #endif
   check_size<program, 16>();
   check_size<range<1>, 8>();


### PR DESCRIPTION
https://github.com/intel/llvm/pull/1870 broke ABI by adding new field to
AccessorImplHost. This patch improves ABI testing to catch this type of
problems in future.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>