### PR TITLE
[SYCL] Fix handling of queue::in_order property

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -50,16 +50,14 @@ public:
   /// \param Device is a SYCL device that is used to dispatch tasks submitted
   /// to the queue.
   /// \param AsyncHandler is a SYCL asynchronous exception handler.
-  /// \param Order specifies whether the queue being constructed as in-order
-  /// or out-of-order.
   /// \param PropList is a list of properties to use for queue construction.
-  queue_impl(DeviceImplPtr Device, async_handler AsyncHandler, QueueOrder Order,
+  queue_impl(DeviceImplPtr Device, async_handler AsyncHandler,
              const property_list &PropList)
       : queue_impl(Device,
                    detail::getSyclObjImpl(context(
                        createSyclObjFromImpl<device>(Device), {},
                        (DefaultContextType == cuda_context_type::primary))),
-                   AsyncHandler, Order, PropList){};
+                   AsyncHandler, PropList){};
 
   /// Constructs a SYCL queue with an async_handler and property_list provided
   /// form a device and a context.
@@ -69,12 +67,9 @@ public:
   /// \param Context is a SYCL context to associate with the queue being
   /// constructed.
   /// \param AsyncHandler is a SYCL asynchronous exception handler.
-  /// \param Order specifies whether the queue being constructed as in-order
-  /// or out-of-order.
   /// \param PropList is a list of properties to use for queue construction.
   queue_impl(DeviceImplPtr Device, ContextImplPtr Context,
-             async_handler AsyncHandler, QueueOrder Order,
-             const property_list &PropList)
+             async_handler AsyncHandler, const property_list &PropList)
       : MDevice(Device), MContext(Context), MAsyncHandler(AsyncHandler),
         MPropList(PropList), MHostQueue(MDevice->is_host()),
         MOpenCLInterop(!MHostQueue) {
@@ -84,7 +79,11 @@ public:
           "as the context does not contain the given device.",
           PI_INVALID_DEVICE);
     if (!MHostQueue) {
-      MCommandQueue = createQueue(Order);
+      const QueueOrder qorder =
+          MPropList.has_property<property::queue::in_order>()
+              ? QueueOrder::Ordered
+              : QueueOrder::OOO;
+      MCommandQueue = createQueue(qorder);
     }
   }
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -231,7 +231,7 @@ Scheduler::Scheduler() {
   sycl::device HostDevice;
   DefaultHostQueue = QueueImplPtr(
       new queue_impl(detail::getSyclObjImpl(HostDevice), /*AsyncHandler=*/{},
-                     QueueOrder::Ordered, /*PropList=*/{}));
+                     /*PropList=*/{}));
 }
 
 void Scheduler::lockSharedTimedMutex(

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -18,17 +18,6 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
-namespace detail {
-
-QueueOrder getQueueOrder(const property_list &propList) {
-  if (propList.has_property<property::queue::in_order>()) {
-    return QueueOrder::Ordered;
-  }
-  return QueueOrder::OOO;
-}
-
-} // namespace detail
-
 queue::queue(const context &syclContext, const device_selector &deviceSelector,
              const async_handler &asyncHandler, const property_list &propList) {
 
@@ -42,7 +31,7 @@ queue::queue(const context &syclContext, const device_selector &deviceSelector,
 
   impl = std::make_shared<detail::queue_impl>(
       detail::getSyclObjImpl(syclDevice), detail::getSyclObjImpl(syclContext),
-      asyncHandler, detail::getQueueOrder(propList), propList);
+      asyncHandler, propList);
 }
 
 queue::queue(const context &syclContext,
@@ -51,14 +40,13 @@ queue::queue(const context &syclContext,
              const property_list &propList) {
   impl = std::make_shared<detail::queue_impl>(
       detail::getSyclObjImpl(syclDevice), detail::getSyclObjImpl(syclContext),
-      asyncHandler, cl::sycl::detail::QueueOrder::OOO, propList);
+      asyncHandler, propList);
 }
 
 queue::queue(const device &syclDevice, const async_handler &asyncHandler,
              const property_list &propList) {
   impl = std::make_shared<detail::queue_impl>(
-      detail::getSyclObjImpl(syclDevice), asyncHandler,
-      detail::getQueueOrder(propList), propList);
+      detail::getSyclObjImpl(syclDevice), asyncHandler, propList);
 }
 
 queue::queue(cl_command_queue clQueue, const context &syclContext,

--- a/sycl/test/inorder_queue/prop.cpp
+++ b/sycl/test/inorder_queue/prop.cpp
@@ -40,6 +40,8 @@ int CheckQueueOrder(const queue &q) {
   expected_result = dev.is_host() ? true : q.is_in_order();
   if (!expected_result)
     return -2;
+
+  return 0;
 }
 
 int main() {
@@ -57,7 +59,7 @@ int main() {
   queue q2{
       ctx, dev, exception_handler, {sycl::property::queue::in_order()}};
 
-  int res = CheckQueueOrder(q2);
+  res = CheckQueueOrder(q2);
   if (res != 0)
     return res;
 

--- a/sycl/test/inorder_queue/prop.cpp
+++ b/sycl/test/inorder_queue/prop.cpp
@@ -29,11 +29,10 @@ bool getQueueOrder(cl_command_queue cq) {
                                                                   : true;
 }
 
-int main() {
-  queue q{property::queue::in_order()};
+int CheckQueueOrder(const queue &q) {
   auto dev = q.get_device();
-  
-  cl_command_queue cq = q.get(); 
+
+  cl_command_queue cq = q.get();
   bool expected_result = dev.is_host() ? true : getQueueOrder(cq);
   if (!expected_result)
     return -1;
@@ -41,6 +40,26 @@ int main() {
   expected_result = dev.is_host() ? true : q.is_in_order();
   if (!expected_result)
     return -2;
+}
+
+int main() {
+  queue q1{property::queue::in_order()};
+  int res = CheckQueueOrder(q1);
+  if (res != 0)
+    return res;
+
+  device dev{cl::sycl::default_selector{}};
+  context ctx{dev};
+
+  auto exception_handler = [](cl::sycl::exception_list exceptions) {
+  };
+
+  queue q2{
+      ctx, dev, exception_handler, {sycl::property::queue::in_order()}};
+
+  int res = CheckQueueOrder(q2);
+  if (res != 0)
+    return res;
 
   return 0;
 }

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -97,7 +97,7 @@ TEST_F(SchedulerTest, CommandsWaitForEvents) {
   sycl::device HostDevice;
   std::shared_ptr<detail::queue_impl> DefaultHostQueue(new detail::queue_impl(
       detail::getSyclObjImpl(HostDevice), /*AsyncHandler=*/{},
-      detail::QueueOrder::Ordered, /*PropList=*/{}));
+      /*PropList=*/{}));
 
   MockCommand Cmd(DefaultHostQueue);
 


### PR DESCRIPTION
Fixed one of the sycl::queue constructor was ignoring the
queue::in_order property.
Also did some refactoring so now queue_impl checks properties to
undrestand if in-order queue is required rather than relying on
flag which is passed to constructor.