### PR TITLE
[SPIR][InstCombine] Work around SPIR-V translator limitation

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -873,7 +873,7 @@ Instruction *InstCombiner::visitTrunc(TruncInst &Trunc) {
   //   //   extractelement <8 x i32> (bitcast <4 x i64> %X to <8 x i32>), i32 0
   // ```
   // can't be lowered by SPIR-V translator to "standard" format.
-  if (Trunc.getModule()->getTargetTriple().substr(0, 4) == "spir")
+  if (StringRef(Trunc.getModule()->getTargetTriple()).startswith("spir"))
     return nullptr;
 
   // Whenever an element is extracted from a vector, and then truncated,

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -862,6 +862,17 @@ Instruction *InstCombiner::visitTrunc(TruncInst &Trunc) {
   if (Instruction *I = foldVecTruncToExtElt(Trunc, *this))
     return I;
 
+  // FIXME: This is temporary work-around for a problem reported here:
+  // https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/645
+  //
+  // InstCombine canonical form for this pattern
+  // ```
+  //   // Example (little endian):
+  //   //   trunc (extractelement <4 x i64> %X, 0) to i32
+  //   //   --->
+  //   //   extractelement <8 x i32> (bitcast <4 x i64> %X to <8 x i32>), i32 0
+  // ```
+  // can't be lowered by SPIR-V translator to "standard" format.
   if (Trunc.getModule()->getTargetTriple().substr(0, 4) == "spir")
     return nullptr;
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -862,6 +862,9 @@ Instruction *InstCombiner::visitTrunc(TruncInst &Trunc) {
   if (Instruction *I = foldVecTruncToExtElt(Trunc, *this))
     return I;
 
+  if (Trunc.getModule()->getTargetTriple().substr(0, 4) == "spir")
+    return nullptr;
+
   // Whenever an element is extracted from a vector, and then truncated,
   // canonicalize by converting it to a bitcast followed by an
   // extractelement.

--- a/llvm/test/Transforms/InstCombine/trunc-extractelement-spir.ll
+++ b/llvm/test/Transforms/InstCombine/trunc-extractelement-spir.ll
@@ -4,7 +4,7 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir"
 
 define i32 @shrinkExtractElt_i64_to_i32_0(<3 x i64> %x) {
-; LE-LABEL: @shrinkExtractElt_i64_to_i32_0(
+; CHECK-LABEL: @shrinkExtractElt_i64_to_i32_0(
 ; CHECK-NOT:    [[TMP1:%.*]] = bitcast <3 x i64> [[X:%.*]] to <6 x i32>
 ; CHECK-NOT:    [[T:%.*]] = extractelement <6 x i32> [[TMP1]], i32 0
 

--- a/llvm/test/Transforms/InstCombine/trunc-extractelement-spir.ll
+++ b/llvm/test/Transforms/InstCombine/trunc-extractelement-spir.ll
@@ -1,0 +1,14 @@
+; RUN: opt < %s -instcombine -S | FileCheck %s
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
+
+define i32 @shrinkExtractElt_i64_to_i32_0(<3 x i64> %x) {
+; LE-LABEL: @shrinkExtractElt_i64_to_i32_0(
+; CHECK-NOT:    [[TMP1:%.*]] = bitcast <3 x i64> [[X:%.*]] to <6 x i32>
+; CHECK-NOT:    [[T:%.*]] = extractelement <6 x i32> [[TMP1]], i32 0
+
+  %e = extractelement <3 x i64> %x, i32 0
+  %t = trunc i64 %e to i32
+  ret i32 %t
+}


### PR DESCRIPTION
This is temporary work-around for a problem reported here:
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/645

InstCombine canonical form for this pattern
```
  // Example (little endian):
  //   trunc (extractelement <4 x i64> %X, 0) to i32
  //   --->
  //   extractelement <8 x i32> (bitcast <4 x i64> %X to <8 x i32>), i32 0
```
can't be lowered by SPIR-V translator to "standard" format.