### PR TITLE
[SYCL] Return back 80 symbols limit for the SYCL LIT tests.

### DIFF
--- a/sycl/test/.clang-format
+++ b/sycl/test/.clang-format
@@ -1,2 +1,2 @@
 BasedOnStyle: LLVM
-ColumnLimit: 0
+CommentPragmas: "(RUN|FAIL|REQUIRES|UNSUPPORTED|CHECK) *:|expected-"

--- a/sycl/test/basic_tests/parallel_for_range.cpp
+++ b/sycl/test/basic_tests/parallel_for_range.cpp
@@ -1,7 +1,7 @@
 // XFAIL: cuda || level0
 // CUDA exposes broken hierarchical parallelism.
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out && echo "TEST. Makeing the line too long"
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/basic_tests/parallel_for_range.cpp
+++ b/sycl/test/basic_tests/parallel_for_range.cpp
@@ -1,7 +1,7 @@
 // XFAIL: cuda || level0
 // CUDA exposes broken hierarchical parallelism.
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out && echo "TEST. Makeing the line too long"
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
But disable the limit for comments containing specific keywords:
RUN, FAIL, REQUIRES, UNSUPPORTED, CHECK, expected-*