### PR TITLE
Bump minimum required cmake version to 3.14.

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1,6 +1,6 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.14)
 
 if ("${CMAKE_VERSION}" VERSION_LESS "3.13.4")
   message(FATAL_ERROR


### PR DESCRIPTION
llvm/lib/SYCLLowerIR/CMakeLists.txt uses FetchContent_MakeAvailable introduced
in cmake 3.14

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>