### PR TITLE
[SYCL] Fix undefined behaviour during graph cleanup

### DIFF
--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -219,8 +219,16 @@ public:
   bool MIsBlockable = false;
   /// Counts the number of memory objects this command is a leaf for.
   unsigned MLeafCounter = 0;
-  /// Used for marking the node as visited during graph traversal.
-  bool MVisited = false;
+
+  struct Marks {
+    /// Used for marking the node as visited during graph traversal.
+    bool MVisited = false;
+    /// Used for marking the node for deletion during cleanup.
+    bool MToBeDeleted = false;
+  };
+  /// Used for marking the node during graph traversal.
+  Marks MMarks;
+
 
   enum class BlockReason : int { HostAccessor = 0, HostTask };
 

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -229,7 +229,6 @@ public:
   /// Used for marking the node during graph traversal.
   Marks MMarks;
 
-
   enum class BlockReason : int { HostAccessor = 0, HostTask };
 
   // Only have reasonable value while MIsBlockable is true

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -911,6 +911,7 @@ void Scheduler::GraphBuilder::cleanupCommandsForRecord(MemObjRecord *Record) {
 
 void Scheduler::GraphBuilder::cleanupFinishedCommands(Command *FinishedCmd) {
   std::queue<Command *> CmdsToVisit({FinishedCmd});
+  std::vector<Command *> CmdsToDelete;
   std::vector<Command *> Visited;
 
   // Traverse the graph using BFS
@@ -948,12 +949,16 @@ void Scheduler::GraphBuilder::cleanupFinishedCommands(Command *FinishedCmd) {
       Command *DepCmd = Dep.MDepCommand;
       DepCmd->MUsers.erase(Cmd);
     }
-    Cmd->getEvent()->setCommand(nullptr);
 
+    CmdsToDelete.push_back(Cmd);
     Visited.pop_back();
-    delete Cmd;
   }
   unmarkVisitedNodes(Visited);
+
+  for (Command *Cmd : CmdsToDelete) {
+    Cmd->getEvent()->setCommand(nullptr);
+    delete Cmd;
+  }
 }
 
 void Scheduler::GraphBuilder::removeRecordForMemObj(SYCLMemObjI *MemObject) {

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -110,8 +110,8 @@ static void handleVisitedNodes(std::vector<Command *> &Visited) {
     if (Cmd->MMarks.MToBeDeleted) {
       Cmd->getEvent()->setCommand(nullptr);
       delete Cmd;
-    }
-    Cmd->MMarks.MVisited = false;
+    } else
+      Cmd->MMarks.MVisited = false;
   }
 }
 


### PR DESCRIPTION
With the switch to using the command member field to mark nodes as
visited during graph traversal, deleting nodes during the traversal
leads to invalid memory access whenever there's a node with multiple
indirect dependencies on another node. This patch fixes the issue by
moving the deletion of the nodes to take place post-traversal.