### PR TITLE
[SYCL] Allow recursive function calls on sycl device with a warning

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10979,6 +10979,9 @@ def warn_sycl_implicit_decl
               "declaration for a kernel type name; your program may not "
               "be portable">,
       InGroup<SyclStrict>, DefaultIgnore;
+def warn_sycl_restrict_recursion
+    : Warning<"SYCL kernel cannot call a recursive function">,
+      InGroup<SyclStrict>, DefaultError;
 def err_ivdep_duplicate_arg : Error<
   "duplicate argument to 'ivdep'. attribute requires one or both of a safelen "
   "and array">;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -354,8 +354,7 @@ public:
       // all functions used by kernel have already been parsed and have
       // definitions.
       if (RecursiveSet.count(Callee) && !ConstexprDepth) {
-        SemaRef.Diag(e->getExprLoc(), diag::err_sycl_restrict)
-            << Sema::KernelCallRecursiveFunction;
+        SemaRef.Diag(e->getExprLoc(), diag::warn_sycl_restrict_recursion);
         SemaRef.Diag(Callee->getSourceRange().getBegin(),
                      diag::note_sycl_recursive_function_declared_here)
             << Sema::KernelCallRecursiveFunction;

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-strict -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.
@@ -16,6 +16,7 @@ using myFuncDef = int(int, int);
 
 typedef __typeof__(sizeof(int)) size_t;
 
+// expected-warning@+1 {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
 SYCL_EXTERNAL
 void *operator new(size_t);
 
@@ -34,7 +35,7 @@ template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task2(Func kernelFunc) {
   // expected-note@+1 {{called by 'kernel_single_task2}}
   kernelFunc();
-  // expected-error@+1 2{{SYCL kernel cannot call a recursive function}}
+  // expected-warning@+1 2{{SYCL kernel cannot call a recursive function}}
   kernel_single_task2<name, Func>(kernelFunc);
 }
 

--- a/clang/test/SemaSYCL/restrict-recursion4.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion4.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-strict -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.
@@ -10,7 +10,7 @@ int fib(int n) {
 
 // expected-note@+1 2{{function implemented using recursion declared here}}
 void kernel2(void) {
-  // expected-error@+1 {{SYCL kernel cannot call a recursive function}}
+  // expected-warning@+1 {{SYCL kernel cannot call a recursive function}}
   kernel2();
 }
 
@@ -18,13 +18,14 @@ using myFuncDef = int(int, int);
 
 typedef __typeof__(sizeof(int)) size_t;
 
+// expected-warning@+1 {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
 SYCL_EXTERNAL
 void *operator new(size_t);
 
 void usage2(myFuncDef functionPtr) {
   // expected-error@+1 {{SYCL kernel cannot allocate storage}}
   int *ip = new int;
-  // expected-error@+1 {{SYCL kernel cannot call a recursive function}}
+  // expected-warning@+1 {{SYCL kernel cannot call a recursive function}}
   kernel2();
 }
 


### PR DESCRIPTION
Currently recursive function calls are not allowed on device.
A hard error is generated in the FE when recursive calls are detected
on device.  To permit enabling this functionality in the BE, this
diagnostic has been moved to the -Wsycl-strict group.  When
-Wsycl-strict is specified, this is still an error, but can be turned
into a warning with -Wno-error=sycl-strict.

TO DO: Once full support is available in the BE, this new diagnostic,
the existing enumerated diagnostic for recursive calls and the
mechanism for detecting the recursion can be removed.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>