### PR TITLE
[DO NOT MERGE] range/id term ordering issue. 

### DIFF
--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -52,7 +52,9 @@ void SYCLMemObjT::releaseMem(ContextImplPtr Context, void *MemAllocation) {
 
 void SYCLMemObjT::updateHostMemory(void *const Ptr) {
   const id<3> Offset{0, 0, 0};
-  const range<3> AccessRange{MSizeInBytes, 1, 1};
+  const range<3> AccessRange{
+      MSizeInBytes, 1, 1}; // <-- a proper range<3> is {z,y,x}.  This is more
+                           // like an OpenCL region [x-in-bytes, y, z]
   const range<3> MemoryRange{MSizeInBytes, 1, 1};
   const access::mode AccessMode = access::mode::read;
   SYCLMemObjI *SYCLMemObject = this;


### PR DESCRIPTION
demonstrates an issue. Not sure how to test. Not proposing this as solution.

Hi @romanovvlad ,  

So, when working on my sub-buffer PR ( https://github.com/intel/llvm/pull/2085 ), I encountered a problem with some tests failing on CUDA.  The tests were failing when sub-buffers of a 2D base buffer were copying back.   The problem is that the terms being passed to CUDA were reversed.  So `Height` and `WidthInBytes` would be wrong.  (They were really width and height in bytes).  When updating a full buffer, this doesn't really matter. Because h*Wb  is the same as w*Hb  and no trouble was encountered.  

But it matters for the partial updates the 2D buffers are trying to perform.   Fundamentally, the problem is  that an id<3> or a range<3> is supposed to be `[z, y, x]`   But the `size_t *` Region and Offset args expected by `piEnqueueMemBufferReadRect` are typically ` [x-in-bytes, y, z ]` , the reverse order and the x-term in bytes. 

Anyway, in this patch (which is for discussion, not submission) you can see that I reverse the terms.  For my sub-buffer PR, this patch fixes the faiilng CUDA test. However, to my mind, making this change only in copyD2H is likely wrong. This same exercise needs to be performed in copyH2D, copyD2D and others.   

Plus, were we to really do this right, we would add a new typedef for the Region/Offsets (instead of  generic `size_t *`) and provide a converter function to switch Range<> to Region and id<> to Offsets.   This would help avoid confusion. However, if we made such a change, that might also mean replacing the weird range<3>s we have in accessor_impl.hpp with Regions  and that's a pretty central class.  Not sure what the consequences would be.   

Question:  how can I make a lit test that guarantees the right order of the arguments being passed to the piEnqueueMemBufferReadRect ?  Do we have a way to inject assertions when testing? 

Anyway, to get my PR passing, I'll need some guidance.  Any advice welcome. 


Signed-off-by: Chris Perkins <chris.perkins@intel.com>