### PR TITLE
[SYCL] Fix copyback bug for container based buffers.

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -170,8 +170,8 @@ public:
          const property_list &propList = {})
       : Range(range<1>(container.size())) {
     impl = std::make_shared<detail::buffer_impl>(
-        container.data(), container.data() + container.size(),
-        get_count() * sizeof(T), detail::getNextPowerOfTwo(sizeof(T)), propList,
+        container.data(), get_count() * sizeof(T),
+        detail::getNextPowerOfTwo(sizeof(T)), propList,
         make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
             allocator));
   }

--- a/sycl/test/basic_tests/buffer/buffer.cpp
+++ b/sycl/test/basic_tests/buffer/buffer.cpp
@@ -420,6 +420,23 @@ int main() {
     }
   }
 
+  // buffer created from contiguous container copies back
+  {
+    constexpr int num = 10;
+    std::vector<int> out_data(num, -1);
+    {
+      buffer A(out_data);
+      queue Q;
+      Q.submit([&](handler &h) {
+        auto out = A.get_access<access::mode::write>(h);
+        h.parallel_for<class containerBuffer>(A.get_range(),
+                                              [out](id<1> i) { out[i] = 1; });
+      });
+    } //~buffer
+    for (int i = 0; i < num; i++)
+      assert(out_data[i] == 1);
+  }
+
   {
     std::vector<int> data1(10, -1);
     {

--- a/sycl/test/basic_tests/buffer/buffer.cpp
+++ b/sycl/test/basic_tests/buffer/buffer.cpp
@@ -420,23 +420,6 @@ int main() {
     }
   }
 
-  // buffer created from contiguous container copies back
-  {
-    constexpr int num = 10;
-    std::vector<int> out_data(num, -1);
-    {
-      buffer A(out_data);
-      queue Q;
-      Q.submit([&](handler &h) {
-        auto out = A.get_access<access::mode::write>(h);
-        h.parallel_for<class containerBuffer>(A.get_range(),
-                                              [out](id<1> i) { out[i] = 1; });
-      });
-    } //~buffer
-    for (int i = 0; i < num; i++)
-      assert(out_data[i] == 1);
-  }
-
   {
     std::vector<int> data1(10, -1);
     {

--- a/sycl/test/basic_tests/buffer/buffer_container.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_container.cpp
@@ -1,0 +1,30 @@
+// RUN: %clangxx %s -std=c++17 -o %t1.out -lsycl -I %sycl_include
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
+// RUN: %clangxx -std=c++17 -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t2.out
+// RUN: %CPU_RUN_PLACEHOLDER %t2.out
+// RUN: %GPU_RUN_PLACEHOLDER %t2.out
+// RUN: %ACC_RUN_PLACEHOLDER %t2.out
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main() {
+  // buffer created from contiguous container copies back
+  {
+    constexpr int num = 10;
+    std::vector<int> out_data(num, -1);
+    {
+      buffer A(out_data);
+      queue Q;
+      Q.submit([&](handler &h) {
+        auto out = A.get_access<access::mode::write>(h);
+        h.parallel_for<class containerBuffer>(A.get_range(),
+                                              [out](id<1> i) { out[i] = 1; });
+      });
+    } //~buffer
+    for (int i = 0; i < num; i++)
+      assert(out_data[i] == 1);
+  }
+}


### PR DESCRIPTION
The C++17 buffers from contiguous containers have a small bug where they don't copy back all the data correctly. This fixes this and adds a test. 