### PR TITLE
[SYCL][NFC] Suggest reading docs on ABI test fail

### DIFF
--- a/sycl/tools/abi_check.py
+++ b/sycl/tools/abi_check.py
@@ -91,11 +91,16 @@ def check_symbols(ref_path, target_path):
     correct_return = True
     if missing_symbols:
       correct_return = False
+      print(("There are missing symbols in the new library. It is a breaking "
+      "change. Refer to sycl/doc/ABIPolicyGuide.md for further instructions. "
+      "Do not forget to update ABI version according to the policy."))
       print('The following symbols are missing from the new object file:\n')
       print("\n".join(missing_symbols))
 
     if new_symbols:
       correct_return = False
+      print(("There are new symbols in the new library. It is a non-breaking "
+      "change. Refer to sycl/doc/ABIPolicyGuide.md for further instructions."))
       print('The following symbols are new to the object file:\n')
       print("\n".join(new_symbols))
 


### PR DESCRIPTION
If abi_check.py fails to match symbols, print a message that guides to
the ABI policy guide with instructions on how to fix the test.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>