### PR TITLE
[SYCL] Fix the dummy implementation of piProgramLink in the L0 plugin

### DIFF
--- a/sycl/plugins/level_zero/pi_level0.cpp
+++ b/sycl/plugins/level_zero/pi_level0.cpp
@@ -1796,9 +1796,13 @@ pi_result piProgramLink(pi_context Context, pi_uint32 NumDevices,
                         void (*PFnNotify)(pi_program Program, void *UserData),
                         void *UserData, pi_program *RetProgram) {
   // TODO: L0 does not [yet] support linking so dummy implementation here.
-  assert(NumInputPrograms == 1 && InputPrograms);
+  if (NumInputPrograms > 1)
+    die("piProgramLink: multiple program linking is not supported yet in "
+        "Level0");
+  assert(NumInputPrograms > 0 && InputPrograms);
   assert(RetProgram);
   *RetProgram = InputPrograms[0];
+  piProgramRetain(*RetProgram);
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
The only case supported so far is linking a single compiled program, add
a non-assertion check for other cases. The program returned by
piProgramLink is supposed to be a new program: since the dummy
implementation returns the same one, add a retain for it.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>