### PR TITLE
[SYCL][ESIMD] Fix ESIMD option propagation to piProgramBuild.

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -794,8 +794,8 @@ ProgramManager::build(ProgramPtr Program, const ContextImplPtr Context,
   // TODO: this is a temporary workaround for GPU tests for ESIMD compiler.
   // We do not link with other device libraries, because it may fail
   // due to unrecognized SPIRV format of those libraries.
-  if (std::string(LinkOpts).find(std::string("-cmc")) != std::string::npos ||
-      std::string(LinkOpts).find(std::string("-vc-codegen")) !=
+  if (std::string(CompileOpts).find(std::string("-cmc")) != std::string::npos ||
+      std::string(CompileOpts).find(std::string("-vc-codegen")) !=
           std::string::npos)
     LinkDeviceLibs = false;
 


### PR DESCRIPTION
With this fix and https://github.com/intel/llvm/pull/2134 ESIMD on-device tests (to be added after CI is ready) start to pass.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>