### PR TITLE
[SYCL][USM] Refactor indirect access calls to minimize invocations.

### DIFF
--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -416,6 +416,11 @@ RT::PiKernel program_impl::get_pi_kernel(const string_class &KernelName) const {
           Err);
     }
     Plugin.checkPiResult(Err);
+
+    // Some PI Plugins (like OpenCL) require this call to enable USM
+    // For others, PI will turn this into a NOP.
+    Plugin.call<PiApiKind::piKernelSetExecInfo>(Kernel, PI_USM_INDIRECT_ACCESS,
+                                                sizeof(pi_bool), &PI_TRUE);
   }
 
   return Kernel;

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -442,6 +442,11 @@ ProgramManager::getOrCreateKernel(OSModuleHandle M, const context &Context,
     Plugin.call<PiApiKind::piKernelCreate>(Program, KernelName.c_str(),
                                            &Result);
 
+    // Some PI Plugins (like OpenCL) require this call to enable USM
+    // For others, PI will turn this into a NOP.
+    Plugin.call<PiApiKind::piKernelSetExecInfo>(Result, PI_USM_INDIRECT_ACCESS,
+                                                sizeof(pi_bool), &PI_TRUE);
+
     return Result;
   };
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1691,11 +1691,6 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
   adjustNDRangePerKernel(NDRDesc, Kernel,
                          *(detail::getSyclObjImpl(MQueue->get_device())));
 
-  // Some PI Plugins (like OpenCL) require this call to enable USM
-  // For others, PI will turn this into a NOP.
-  Plugin.call<PiApiKind::piKernelSetExecInfo>(Kernel, PI_USM_INDIRECT_ACCESS,
-                                              sizeof(pi_bool), &PI_TRUE);
-
   // Remember this information before the range dimensions are reversed
   const bool HasLocalSize = (NDRDesc.LocalSize[0] != 0);
 

--- a/sycl/unittests/program/KernelRelease.cpp
+++ b/sycl/unittests/program/KernelRelease.cpp
@@ -68,6 +68,13 @@ pi_result redefinedKernelGetInfo(pi_kernel kernel, pi_kernel_info param_name,
   return PI_SUCCESS;
 }
 
+pi_result redefinedKernelSetExecInfo(pi_kernel kernel,
+                                     pi_kernel_exec_info param_name,
+                                     size_t param_value_size,
+                                     const void *param_value) {
+  return PI_SUCCESS;
+}
+
 TEST(KernelReleaseTest, GetKernelRelease) {
   platform Plt{default_selector()};
   if (Plt.is_host()) {
@@ -85,6 +92,8 @@ TEST(KernelReleaseTest, GetKernelRelease) {
   Mock.redefine<detail::PiApiKind::piKernelRetain>(redefinedKernelRetain);
   Mock.redefine<detail::PiApiKind::piKernelRelease>(redefinedKernelRelease);
   Mock.redefine<detail::PiApiKind::piKernelGetInfo>(redefinedKernelGetInfo);
+  Mock.redefine<detail::PiApiKind::piKernelSetExecInfo>(
+      redefinedKernelSetExecInfo);
 
   context Ctx{Plt};
   TestContext.reset(new TestCtx(Ctx));


### PR DESCRIPTION
We only need to set indirect access flags once after a kernel is created.  Previously we were doing it before every invocation, which is redundant and adds overhead.

Signed-off-by: James Brodman <james.brodman@intel.com>