### PR TITLE
[SYCL] Fixed check for set_arg

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -805,9 +805,9 @@ public:
 
   template <typename T> struct ShouldEnableSetArg {
     static constexpr bool value =
-        std::is_trivially_copyable<T>::value
+        std::is_trivially_copyable<remove_cv_ref_t<T>>::value
 #if CL_SYCL_LANGUAGE_VERSION && CL_SYCL_LANGUAGE_VERSION <= 121
-            && std::is_standard_layout<T>::value
+            && std::is_standard_layout<remove_cv_ref_t<T>>::value
 #endif
         || is_same_type<sampler, T>::value // Sampler
         || (!is_same_type<cl_mem, T>::value &&

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -805,9 +805,9 @@ public:
 
   template <typename T> struct ShouldEnableSetArg {
     static constexpr bool value =
-        std::is_trivially_copyable<remove_cv_ref_t<T>>::value
+        std::is_trivially_copyable<detail::remove_reference_t<T>>::value
 #if CL_SYCL_LANGUAGE_VERSION && CL_SYCL_LANGUAGE_VERSION <= 121
-            && std::is_standard_layout<remove_cv_ref_t<T>>::value
+            && std::is_standard_layout<detail::remove_reference_t<T>>::value
 #endif
         || is_same_type<sampler, T>::value // Sampler
         || (!is_same_type<cl_mem, T>::value &&

--- a/sycl/test/basic_tests/set_arg_error.cpp
+++ b/sycl/test/basic_tests/set_arg_error.cpp
@@ -33,15 +33,23 @@ int main() {
     cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write,
                        cl::sycl::access::target::local>
         local_acc({size}, h);
+    TriviallyCopyable tc{1, 2};
+    NonTriviallyCopyable ntc;
     h.set_arg(0, local_acc);
     h.set_arg(1, global_acc);
     h.set_arg(2, samp);
-    h.set_arg(3, TriviallyCopyable{});
+    h.set_arg(3, tc);
+    h.set_arg(4, TriviallyCopyable{});
+    h.set_arg( // expected-error {{no matching member function for call to 'set_arg'}}
+        5, ntc);
     h.set_arg( // expected-error {{no matching member function for call to 'set_arg'}}
         4, NonTriviallyCopyable{});
 #if CL_SYCL_LANGUAGE_VERSION && CL_SYCL_LANGUAGE_VERSION <= 121
+    NonStdLayout nstd;
     h.set_arg( // expected-error {{no matching member function for call to 'set_arg'}}
-        5, NonStdLayout{});
+        6, nstd);
+    h.set_arg( // expected-error {{no matching member function for call to 'set_arg'}}
+        7, NonStdLayout{});
 #endif
   });
 }


### PR DESCRIPTION
Need to get rid of references before checking for
is_trivially_copyable and is_standard_layout.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>