### PR TITLE
[SYCL] Add support for assuming SYCL queries fit in int

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -253,7 +253,7 @@ LANGOPT(DeclareSPIRVBuiltins, 1, 0, "Declare SPIR-V builtin functions")
 LANGOPT(SYCLExplicitSIMD  , 1, 0, "SYCL compilation with explicit SIMD extension")
 LANGOPT(EnableDAEInSpirKernels , 1, 0, "Enable Dead Argument Elimination in SPIR kernels")
 LANGOPT(
-    SYCLValueFitInMaxInt, 1, 1,
+    SYCLValueFitInMaxInt, 1, 0,
     "SYCL compiler assumes value fits within MAX_INT for member function of "
     "get/operator[], get_id/operator[] and get_global_id/get_global_linear_id "
     "in SYCL class id, iterm and nd_iterm")

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -252,6 +252,11 @@ LANGOPT(SYCLVersion       , 32, 0, "Version of the SYCL standard used")
 LANGOPT(DeclareSPIRVBuiltins, 1, 0, "Declare SPIR-V builtin functions")
 LANGOPT(SYCLExplicitSIMD  , 1, 0, "SYCL compilation with explicit SIMD extension")
 LANGOPT(EnableDAEInSpirKernels , 1, 0, "Enable Dead Argument Elimination in SPIR kernels")
+LANGOPT(
+    SYCLValueFitInMaxInt, 1, 1,
+    "SYCL compiler assume value fits within MAX_INT for member function of "
+    "get/operator[], get_id/operator[] and get_global_id/get_global_linear_id "
+    "in SYCL class id, iterm and nd_iterm")
 
 LANGOPT(HIPUseNewLaunchAPI, 1, 0, "Use new kernel launching API for HIP")
 

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -254,7 +254,7 @@ LANGOPT(SYCLExplicitSIMD  , 1, 0, "SYCL compilation with explicit SIMD extension
 LANGOPT(EnableDAEInSpirKernels , 1, 0, "Enable Dead Argument Elimination in SPIR kernels")
 LANGOPT(
     SYCLValueFitInMaxInt, 1, 1,
-    "SYCL compiler assume value fits within MAX_INT for member function of "
+    "SYCL compiler assumes value fits within MAX_INT for member function of "
     "get/operator[], get_id/operator[] and get_global_id/get_global_linear_id "
     "in SYCL class id, iterm and nd_iterm")
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1874,6 +1874,9 @@ def fsycl_device_code_split_EQ : Joined<["-"], "fsycl-device-code-split=">,
 def fsycl_device_code_split : Flag<["-"], "fsycl-device-code-split">, Alias<fsycl_device_code_split_EQ>,
   AliasArgs<["per_source"]>, Flags<[CC1Option, CoreOption]>,
   HelpText<"Perform SYCL device code split in the per_source mode i.e. create a device code module for each source (translation unit)">;
+defm sycl_id_queries_fit_in_int : OptOutFFlag<"sycl-id-queries-fit-in-int",
+  "Assume that SYCL ID queries fit within MAX_INT.", "Do not assume that SYCL "
+  "ID queries fit within MAX_INT.", "", [CoreOption]>;
 def fsycl_use_bitcode : Flag<["-"], "fsycl-use-bitcode">,
   Flags<[CC1Option, CoreOption]>, HelpText<"Use LLVM bitcode instead of SPIR-V in fat objects">;
 def fno_sycl_use_bitcode : Flag<["-"], "fno-sycl-use-bitcode">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1874,9 +1874,12 @@ def fsycl_device_code_split_EQ : Joined<["-"], "fsycl-device-code-split=">,
 def fsycl_device_code_split : Flag<["-"], "fsycl-device-code-split">, Alias<fsycl_device_code_split_EQ>,
   AliasArgs<["per_source"]>, Flags<[CC1Option, CoreOption]>,
   HelpText<"Perform SYCL device code split in the per_source mode i.e. create a device code module for each source (translation unit)">;
-defm sycl_id_queries_fit_in_int : OptOutFFlag<"sycl-id-queries-fit-in-int",
-  "Assume that SYCL ID queries fit within MAX_INT.", "Do not assume that SYCL "
-  "ID queries fit within MAX_INT.", "", [CoreOption]>;
+def fsycl_id_queries_fit_in_int : Flag<["-"], "fsycl-id-queries-fit-in-int">,
+  Flags<[CC1Option, CoreOption]>, HelpText<"Assume that SYCL ID queries fit "
+  "within MAX_INT.">;
+def fno_sycl_id_queries_fit_in_int : Flag<["-"], "fno-sycl-id-queries-fit-in-int">,
+  Flags<[CC1Option, CoreOption]>, HelpText<"Do not assume that SYCL ID queries "
+  "fit within MAX_INT.">;
 def fsycl_use_bitcode : Flag<["-"], "fsycl-use-bitcode">,
   Flags<[CC1Option, CoreOption]>, HelpText<"Use LLVM bitcode instead of SPIR-V in fat objects">;
 def fno_sycl_use_bitcode : Flag<["-"], "fno-sycl-use-bitcode">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4139,9 +4139,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                      options::OPT_fno_sycl_allow_func_ptr, false)) {
       CmdArgs.push_back("-fsycl-allow-func-ptr");
     }
-    if (Arg *A = Args.getLastArg(options::OPT_fsycl_id_queries_fit_in_int,
-                                 options::OPT_fno_sycl_id_queries_fit_in_int))
-      A->render(Args, CmdArgs);
 
     if (!SYCLStdArg) {
       // The user had not pass SYCL version, thus we'll employ no-sycl-strict
@@ -4149,6 +4146,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // along with marking the same function with explicit SYCL_EXTERNAL
       CmdArgs.push_back("-Wno-sycl-strict");
     }
+  }
+  if (IsSYCL || UseSYCLTriple) {
+    // Set options for both host and device
+    if (Arg *A = Args.getLastArg(options::OPT_fsycl_id_queries_fit_in_int,
+                                 options::OPT_fno_sycl_id_queries_fit_in_int))
+      A->render(Args, CmdArgs);
   }
 
   if (IsSYCL) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4139,10 +4139,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                      options::OPT_fno_sycl_allow_func_ptr, false)) {
       CmdArgs.push_back("-fsycl-allow-func-ptr");
     }
-    // -fsycl-id-queries-fit-in-int is the default
-    if (Args.hasFlag(options::OPT_fno_sycl_id_queries_fit_in_int,
-                     options::OPT_fsycl_id_queries_fit_in_int, false))
-      CmdArgs.push_back("-fno-sycl-id-queries-fit-in-int");
+    if (Arg *A = Args.getLastArg(options::OPT_fsycl_id_queries_fit_in_int,
+                                 options::OPT_fno_sycl_id_queries_fit_in_int))
+      A->render(Args, CmdArgs);
 
     if (!SYCLStdArg) {
       // The user had not pass SYCL version, thus we'll employ no-sycl-strict

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4139,6 +4139,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                      options::OPT_fno_sycl_allow_func_ptr, false)) {
       CmdArgs.push_back("-fsycl-allow-func-ptr");
     }
+    // -fsycl-id-queries-fit-in-int is the default
+    if (Args.hasFlag(options::OPT_fno_sycl_id_queries_fit_in_int,
+                     options::OPT_fsycl_id_queries_fit_in_int, false))
+      CmdArgs.push_back("-fno-sycl-id-queries-fit-in-int");
 
     if (!SYCLStdArg) {
       // The user had not pass SYCL version, thus we'll employ no-sycl-strict

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2596,8 +2596,9 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
     }
     Opts.SYCLExplicitSIMD = Args.hasArg(options::OPT_fsycl_esimd);
     Opts.EnableDAEInSpirKernels = Args.hasArg(options::OPT_fenable_sycl_dae);
-    if (Args.hasArg(options::OPT_fno_sycl_id_queries_fit_in_int))
-      Opts.SYCLValueFitInMaxInt = false;
+    Opts.SYCLValueFitInMaxInt =
+        Args.hasFlag(options::OPT_fsycl_id_queries_fit_in_int,
+                     options::OPT_fno_sycl_id_queries_fit_in_int, false);
   }
 
   Opts.IncludeDefaultHeader = Args.hasArg(OPT_finclude_default_header);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2596,6 +2596,8 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
     }
     Opts.SYCLExplicitSIMD = Args.hasArg(options::OPT_fsycl_esimd);
     Opts.EnableDAEInSpirKernels = Args.hasArg(options::OPT_fenable_sycl_dae);
+    if (Args.hasArg(options::OPT_fno_sycl_id_queries_fit_in_int))
+      Opts.SYCLValueFitInMaxInt = false;
   }
 
   Opts.IncludeDefaultHeader = Args.hasArg(OPT_finclude_default_header);

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -465,6 +465,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
     // SYCL Version is set to a value when building SYCL applications
     if (LangOpts.SYCLVersion == 2017)
       Builder.defineMacro("CL_SYCL_LANGUAGE_VERSION", "121");
+    if (LangOpts.SYCLValueFitInMaxInt)
+      Builder.defineMacro("__SYCL_ID_QUERIES_FIT_IN_INT__", "1");
   }
 
   if (LangOpts.DeclareSPIRVBuiltins) {

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -90,5 +90,5 @@
 // RUN: %clang_cl -### -fsycl -fno-sycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=NO_ID_QUERIES
 // RUN: %clang -### -fsycl-device-only -fno-sycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=NO_ID_QUERIES
 // RUN: %clang_cl -### -fsycl-device-only -fno-sycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=NO_ID_QUERIES
+// ID_QUERIES: "-fsycl-id-queries-fit-in-int"
 // NO_ID_QUERIES: "-fno-sycl-id-queries-fit-in-int"
-// ID_QUERIES-NOT: "-fno-sycl-id-queries-fit-in-int"

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -80,3 +80,15 @@
 // SYCL-HELP-FPGA: Use triple of 'spir64_fpga-unknown-unknown-sycldevice' to enable ahead of time compilation
 // SYCL-HELP-CPU: Emitting help information for opencl-aot
 // SYCL-HELP-CPU: Use triple of 'spir64_x86_64-unknown-unknown-sycldevice' to enable ahead of time compilation
+
+// -fsycl-id-queries-fit-in-int
+// RUN: %clang -### -fsycl -fsycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=ID_QUERIES
+// RUN: %clang_cl -### -fsycl -fsycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=ID_QUERIES
+// RUN: %clang -### -fsycl-device-only -fsycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=ID_QUERIES
+// RUN: %clang_cl -### -fsycl-device-only -fsycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=ID_QUERIES
+// RUN: %clang -### -fsycl -fno-sycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=NO_ID_QUERIES
+// RUN: %clang_cl -### -fsycl -fno-sycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=NO_ID_QUERIES
+// RUN: %clang -### -fsycl-device-only -fno-sycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=NO_ID_QUERIES
+// RUN: %clang_cl -### -fsycl-device-only -fno-sycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=NO_ID_QUERIES
+// NO_ID_QUERIES: "-fno-sycl-id-queries-fit-in-int"
+// ID_QUERIES-NOT: "-fno-sycl-id-queries-fit-in-int"

--- a/clang/test/Preprocessor/sycl-macro.cpp
+++ b/clang/test/Preprocessor/sycl-macro.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 %s -E -dM | FileCheck %s
-// RUN: %clang_cc1 %s -fsycl -fsycl-is-host -sycl-std=2017 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD %s
-// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -sycl-std=2017 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD %s
-// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -sycl-std=1.2.1 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD-DEVICE %s
-// RUNx: %clang_cc1 %s -fsycl -fsycl-is-device -E -dM -fms-compatibility | FileCheck --check-prefix=CHECK-MSVC %s
+// RUN: %clang_cc1 %s -fsycl -fsycl-id-queries-fit-in-int -fsycl-is-host -sycl-std=2017 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD %s
+// RUN: %clang_cc1 %s -fsycl -fsycl-id-queries-fit-in-int -fsycl-is-device -sycl-std=2017 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD %s
+// RUN: %clang_cc1 %s -fsycl -fsycl-id-queries-fit-in-int -fsycl-is-device -sycl-std=1.2.1 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD-DEVICE %s
+// RUNx: %clang_cc1 %s -fsycl -fsycl-id-queries-fit-in-int -fsycl-is-device -E -dM -fms-compatibility | FileCheck --check-prefix=CHECK-MSVC %s
 // RUN: %clang_cc1 -fno-sycl-id-queries-fit-in-int %s -E -dM | FileCheck \
 // RUN: --check-prefix=CHECK-NO-SYCL_FIT_IN_INT %s
 

--- a/clang/test/Preprocessor/sycl-macro.cpp
+++ b/clang/test/Preprocessor/sycl-macro.cpp
@@ -1,17 +1,24 @@
 // RUN: %clang_cc1 %s -E -dM | FileCheck %s
 // RUN: %clang_cc1 %s -fsycl -fsycl-is-host -sycl-std=2017 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD %s
 // RUN: %clang_cc1 %s -fsycl -fsycl-is-device -sycl-std=2017 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD %s
-// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -sycl-std=1.2.1 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD %s
+// RUN: %clang_cc1 %s -fsycl -fsycl-is-device -sycl-std=1.2.1 -E -dM | FileCheck --check-prefix=CHECK-SYCL-STD-DEVICE %s
 // RUNx: %clang_cc1 %s -fsycl -fsycl-is-device -E -dM -fms-compatibility | FileCheck --check-prefix=CHECK-MSVC %s
+// RUN: %clang_cc1 -fno-sycl-id-queries-fit-in-int %s -E -dM | FileCheck \
+// RUN: --check-prefix=CHECK-NO-SYCL_FIT_IN_INT %s
 
 // CHECK-NOT:#define __SYCL_DEVICE_ONLY__ 1
 // CHECK-NOT:#define SYCL_EXTERNAL
 // CHECK-NOT:#define CL_SYCL_LANGUAGE_VERSION 121
+// CHECK-NOT:#define __SYCL_ID_QUERIES_FIT_IN_INT__ 1
 
 // CHECK-SYCL-STD:#define CL_SYCL_LANGUAGE_VERSION 121
+// CHECK-SYCL-STD:#define __SYCL_ID_QUERIES_FIT_IN_INT__ 1
 
-// CHECK-SYCL:#define __SYCL_DEVICE_ONLY__ 1
-// CHECK-SYCL:#define SYCL_EXTERNAL __attribute__((sycl_device))
+// CHECK-SYCL-STD-DEVICE:#define __SYCL_DEVICE_ONLY__ 1
+// CHECK-SYCL-STD-DEVICE:#define __SYCL_ID_QUERIES_FIT_IN_INT__ 1
 
 // CHECK-MSVC-NOT: __GNUC__
 // CHECK-MSVC-NOT: __STDC__
+// CHECK-MSVC: #define __SYCL_ID_QUERIES_FIT_IN_INT__ 1
+
+// CHECK-NO-SYCL_FIT_IN_INT-NOT:#define __SYCL_ID_QUERIES_FIT_IN_INT__ 1

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -139,18 +139,16 @@ __SYCL_EXPORT device getDeviceFromHandler(handler &);
 #if defined(__SYCL_ID_QUERIES_FIT_IN_INT__)
 template <typename T> struct NotIntMsg;
 
-// TODO reword for "`fsycl-id-queries-fit-in-int' optimization flag." when
-// implemented
 template <int Dims> struct NotIntMsg<range<Dims>> {
-  constexpr static char *Msg = "Provided range is out of integer limits. "
-                               "Pass `-U__SYCL_ID_QUERIES_FIT_IN_INT__' to "
-                               "disable range check.";
+  constexpr static const char *Msg =
+      "Provided range is out of integer limits. Pass "
+      "`-fno-sycl-id-queries-fit-in-int' to disable range check.";
 };
 
 template <int Dims> struct NotIntMsg<id<Dims>> {
-  constexpr static char *Msg = "Provided offset is out of integer limits. "
-                               "Pass `-U__SYCL_ID_QUERIES_FIT_IN_INT__' to "
-                               "disable offset check.";
+  constexpr static const char *Msg =
+      "Provided offset is out of integer limits.  Pass "
+      "`-fno-sycl-id-queries-fit-in-int' to disable offset check.";
 };
 #endif
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -147,7 +147,7 @@ template <int Dims> struct NotIntMsg<range<Dims>> {
 
 template <int Dims> struct NotIntMsg<id<Dims>> {
   constexpr static const char *Msg =
-      "Provided offset is out of integer limits.  Pass "
+      "Provided offset is out of integer limits. Pass "
       "`-fno-sycl-id-queries-fit-in-int' to disable offset check.";
 };
 #endif

--- a/sycl/test/basic_tests/range_offset_fit_in_int.cpp
+++ b/sycl/test/basic_tests/range_offset_fit_in_int.cpp
@@ -8,7 +8,7 @@ namespace S = cl::sycl;
 
 void checkRangeException(S::runtime_error &E) {
   constexpr char Msg[] = "Provided range is out of integer limits. "
-                         "Pass `-U__SYCL_ID_QUERIES_FIT_IN_INT__' to "
+                         "Pass `-fno-sycl-id-queries-fit-in-int' to "
                          "disable range check.";
 
   std::cerr << E.what() << std::endl;
@@ -18,7 +18,7 @@ void checkRangeException(S::runtime_error &E) {
 
 void checkOffsetException(S::runtime_error &E) {
   constexpr char Msg[] = "Provided offset is out of integer limits. "
-                         "Pass `-U__SYCL_ID_QUERIES_FIT_IN_INT__' to "
+                         "Pass `-fno-sycl-id-queries-fit-in-int' to "
                          "disable offset check.";
 
   std::cerr << E.what() << std::endl;

--- a/sycl/test/basic_tests/range_offset_fit_in_int.cpp
+++ b/sycl/test/basic_tests/range_offset_fit_in_int.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -D__SYCL_ID_QUERIES_FIT_IN_INT__=1 %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-id-queries-fit-in-int %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 
 #include <CL/sycl.hpp>

--- a/sycl/test/check_device_code/id_queries_fit_int.cpp
+++ b/sycl/test/check_device_code/id_queries_fit_int.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -Xclang -fsycl-is-host -O1 -c -S -emit-llvm -o %t.ll -D__SYCL_ID_QUERIES_FIT_IN_INT__=1 %s
+// RUN: %clangxx -fsycl -Xclang -fsycl-is-host -fsycl-id-queries-fit-in-int -O1 -c -S -emit-llvm -o %t.ll %s
 // RUN: FileCheck %s --input-file %t.ll
 
 #include <CL/sycl.hpp>

--- a/sycl/test/check_device_code/id_queries_fit_int.cpp
+++ b/sycl/test/check_device_code/id_queries_fit_int.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -Xclang -fsycl-is-host -Xclang -fsycl-id-queries-fit-in-int -O1 -c -S -emit-llvm -o %t.ll %s
+// RUN: %clangxx -fsycl -Xclang -fsycl-is-host -fsycl-id-queries-fit-in-int -O1 -c -S -emit-llvm -o %t.ll %s
 // RUN: FileCheck %s --input-file %t.ll
 
 #include <CL/sycl.hpp>

--- a/sycl/test/check_device_code/id_queries_fit_int.cpp
+++ b/sycl/test/check_device_code/id_queries_fit_int.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -Xclang -fsycl-is-host -fsycl-id-queries-fit-in-int -O1 -c -S -emit-llvm -o %t.ll %s
+// RUN: %clangxx -fsycl -Xclang -fsycl-is-host -Xclang -fsycl-id-queries-fit-in-int -O1 -c -S -emit-llvm -o %t.ll %s
 // RUN: FileCheck %s --input-file %t.ll
 
 #include <CL/sycl.hpp>


### PR DESCRIPTION
For good default performance, compiler needs to set
-D_SYCL_ID_QUERIES_FIT_IN_INT_ by default. This will add
__builtin_assume() that says global_id/linear_id fits within
MAX_INT.  We also need to have an ability to override where
programmer needs 31+bit in global_id/linear_id.  This is
provided via -f[no-]sycl-id-queries-fit-in-int