### PR TITLE
[SYCL] Log output from ICD and Level Zero loader builds steps

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -107,6 +107,9 @@ if( NOT OpenCL_INCLUDE_DIRS )
     INSTALL_COMMAND   ""
     STEP_TARGETS      build
     COMMENT           "Downloading OpenCL headers."
+    LOG_DOWNLOAD 1
+    LOG_UPDATE 1
+    LOG_BUILD 1
   )
   add_definitions(-DCL_TARGET_OPENCL_VERSION=220)
 else()
@@ -154,6 +157,11 @@ if( NOT OpenCL_LIBRARIES )
     STEP_TARGETS      configure,build,install
     DEPENDS           ocl-headers
     BUILD_BYPRODUCTS ${OpenCL_LIBRARIES}
+    LOG_DOWNLOAD 1
+    LOG_UPDATE 1
+    LOG_CONFIGURE 1
+    LOG_BUILD 1
+    LOG_INSTALL 1
   )
   ExternalProject_Add_Step(ocl-icd llvminstall
     COMMAND ${CMAKE_COMMAND} -E copy_directory <INSTALL_DIR>/ ${LLVM_BINARY_DIR}

--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -33,6 +33,11 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
                -DOpenCL_INCLUDE_DIR=${OpenCL_INCLUDE_DIRS}
                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_INSTALL_LIBDIR:PATH=lib${LLVM_LIBDIR_SUFFIX}
+               LOG_DOWNLOAD 1
+               LOG_UPDATE 1
+               LOG_CONFIGURE 1
+               LOG_BUILD 1
+               LOG_INSTALL 1
                ${AUX_CMAKE_FLAGS}
     STEP_TARGETS      configure,build,install
     DEPENDS           ocl-headers


### PR DESCRIPTION
Currently build steps for ICD and Level Zero loader produce verbose
output. Log this output instead of spamming on the screen.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>