### PR TITLE
[SYCL] Build sycl/tools with same CXX STD settings as set for sycl

### DIFF
--- a/sycl/tools/CMakeLists.txt
+++ b/sycl/tools/CMakeLists.txt
@@ -1,7 +1,3 @@
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 add_subdirectory(sycl-ls)
 
 # TODO: move each tool in its own sub-directory


### PR DESCRIPTION
Having differnet CMAKE_CXX_STANDARD/CMAKE_CXX_STANDARD_REQUIRED/CMAKE_CXX_EXTENSIONS
may lead to errors during build of sycl/tools.
Removing explicit setting of those 3 parameters in sycl/tool/CMakeLists.txt
in this patch syncs the build settings of sycl/tools and sycl libraries.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>