### PR TITLE
[GitHub] Downgrade clang-format to version 9

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,16 +9,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Get clang-format first
+      run: sudo apt-get install -yqq clang-format-9
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
 
-    - name: Get clang-format first
-      run: sudo apt-get install -yqq clang-format-10
-
     - name: Run clang-format for the patch
       run: |
-        git diff -U0 --no-color ${GITHUB_SHA}^1 ${GITHUB_SHA} -- | ./clang/tools/clang-format/clang-format-diff.py -p1 -binary clang-format-10 > ./clang-format.patch
+        git diff -U0 --no-color ${GITHUB_SHA}^1 ${GITHUB_SHA} -- | ./clang/tools/clang-format/clang-format-diff.py -p1 -binary clang-format-9 > ./clang-format.patch
 
     # Add patch with formatting fixes to CI job artifacts
     - uses: actions/upload-artifact@v1


### PR DESCRIPTION
There issues with installing clang-format-10 in GitHub actions CI. 
Let's downgrade clang-format to version 9 to keep formatting check enabled.