### PR TITLE
[SYCL] Fix specialization constants struct members

### DIFF
--- a/clang/test/SemaSYCL/spec-const-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/spec-const-kernel-arg.cpp
@@ -21,7 +21,7 @@ int main() {
       });
 }
 
-// CHECK: FunctionDecl {{.*}}kernel_sc 'void ()'
+// CHECK: FunctionDecl {{.*}}kernel_sc{{.*}} 'void ()'
 // CHECK: VarDecl {{.*}}'(lambda at {{.*}}'
 // CHECK-NEXT: InitListExpr {{.*}}'(lambda at {{.*}}'
 // CHECK-NEXT: CXXConstructExpr {{.*}}'cl::sycl::experimental::spec_constant<char, class MyInt32Const>':'cl::sycl::experimental::spec_constant<char, MyInt32Const>'

--- a/clang/test/SemaSYCL/spec-const-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/spec-const-kernel-arg.cpp
@@ -5,11 +5,10 @@
 
 #include <sycl.hpp>
 
-struct SpecConstantsWrapper{
-    cl::sycl::experimental::spec_constant<int, class sc_name1> SC1;
-    cl::sycl::experimental::spec_constant<int, class sc_name2> SC2;
+struct SpecConstantsWrapper {
+  cl::sycl::experimental::spec_constant<int, class sc_name1> SC1;
+  cl::sycl::experimental::spec_constant<int, class sc_name2> SC2;
 };
-
 
 int main() {
   cl::sycl::experimental::spec_constant<char, class MyInt32Const> SC;

--- a/clang/test/SemaSYCL/spec-const-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/spec-const-kernel-arg.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -ast-dump %s | FileCheck %s
+
+// This test checks that compiler generates correct initialization for spec
+// constants
+
+#include <sycl.hpp>
+
+struct SpecConstantsWrapper{
+    cl::sycl::experimental::spec_constant<int, class sc_name1> SC1;
+    cl::sycl::experimental::spec_constant<int, class sc_name2> SC2;
+};
+
+
+int main() {
+  cl::sycl::experimental::spec_constant<char, class MyInt32Const> SC;
+  SpecConstantsWrapper W;
+  cl::sycl::kernel_single_task<class kernel_sc>(
+      [=]() {
+        (void)SC;
+        (void)W;
+      });
+}
+
+// CHECK: FunctionDecl {{.*}}kernel_sc 'void ()'
+// CHECK: VarDecl {{.*}}'(lambda at {{.*}}'
+// CHECK-NEXT: InitListExpr {{.*}}'(lambda at {{.*}}'
+// CHECK-NEXT: CXXConstructExpr {{.*}}'cl::sycl::experimental::spec_constant<char, class MyInt32Const>':'cl::sycl::experimental::spec_constant<char, MyInt32Const>'
+// CHECK-NEXT: InitListExpr {{.*}} 'SpecConstantsWrapper'
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::experimental::spec_constant<int, class sc_name1>':'cl::sycl::experimental::spec_constant<int, sc_name1>'
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::experimental::spec_constant<int, class sc_name2>':'cl::sycl::experimental::spec_constant<int, sc_name2>'

--- a/sycl/include/CL/sycl/experimental/spec_constant.hpp
+++ b/sycl/include/CL/sycl/experimental/spec_constant.hpp
@@ -32,7 +32,9 @@ template <typename T, typename ID = T> class spec_constant {
 private:
   // Implementation defined constructor.
 #ifdef __SYCL_DEVICE_ONLY__
+public:
   spec_constant() {}
+private:
 #else
   spec_constant(T Cst) : Val(Cst) {}
 #endif

--- a/sycl/include/CL/sycl/experimental/spec_constant.hpp
+++ b/sycl/include/CL/sycl/experimental/spec_constant.hpp
@@ -34,6 +34,7 @@ private:
 #ifdef __SYCL_DEVICE_ONLY__
 public:
   spec_constant() {}
+
 private:
 #else
   spec_constant(T Cst) : Val(Cst) {}

--- a/sycl/test/spec_const/spec_const_hw.cpp
+++ b/sycl/test/spec_const/spec_const_hw.cpp
@@ -39,6 +39,15 @@ float foo(
   return f32;
 }
 
+struct SCWrapper {
+    SCWrapper(cl::sycl::program &p)
+        : SC1(p.set_spec_constant<class sc_name1, int>(4)),
+          SC2(p.set_spec_constant<class sc_name2, int>(2)) {}
+
+    cl::sycl::experimental::spec_constant<int, class sc_name1> SC1;
+    cl::sycl::experimental::spec_constant<int, class sc_name2> SC2;
+};
+
 int main(int argc, char **argv) {
   val = argc + 16;
 
@@ -61,6 +70,7 @@ int main(int argc, char **argv) {
   std::cout << "val = " << val << "\n";
   cl::sycl::program program1(q.get_context());
   cl::sycl::program program2(q.get_context());
+  cl::sycl::program program3(q.get_context());
 
   int goldi = (int)get_value();
   // TODO make this floating point once supported by the compiler
@@ -77,11 +87,17 @@ int main(int argc, char **argv) {
   // SYCL RT execution path
   program2.build_with_kernel_type<KernelBBBf>("-cl-fast-relaxed-math");
 
+  SCWrapper W(program3);
+  program3.build_with_kernel_type<class KernelWrappedSC>();
+  int goldw = 6;
+
   std::vector<int> veci(1);
   std::vector<float> vecf(1);
+  std::vector<int> vecw(1);
   try {
     cl::sycl::buffer<int, 1> bufi(veci.data(), veci.size());
     cl::sycl::buffer<float, 1> buff(vecf.data(), vecf.size());
+    cl::sycl::buffer<int, 1> bufw(vecw.data(), vecw.size());
 
     q.submit([&](cl::sycl::handler &cgh) {
       auto acci = bufi.get_access<cl::sycl::access::mode::write>(cgh);
@@ -99,6 +115,15 @@ int main(int argc, char **argv) {
             accf[0] = foo(f32);
           });
     });
+
+    q.submit([&](cl::sycl::handler &cgh) {
+      auto accw = bufw.get_access<cl::sycl::access::mode::write>(cgh);
+      cgh.single_task<KernelWrappedSC>(
+          program3.get_kernel<KernelWrappedSC>(),
+          [=]() {
+            accw[0] = W.SC1.get() + W.SC2.get();
+          });
+    });
   } catch (cl::sycl::exception &e) {
     std::cout << "*** Exception caught: " << e.what() << "\n";
     return 1;
@@ -114,6 +139,12 @@ int main(int argc, char **argv) {
 
   if (valf != goldf) {
     std::cout << "*** ERROR: " << valf << " != " << goldf << "(gold)\n";
+    passed = false;
+  }
+  int valw = vecw[0];
+
+  if (valw != goldw) {
+    std::cout << "*** ERROR: " << valw << " != " << goldw << "(gold)\n";
     passed = false;
   }
   std::cout << (passed ? "passed\n" : "FAILED\n");

--- a/sycl/test/spec_const/spec_const_hw.cpp
+++ b/sycl/test/spec_const/spec_const_hw.cpp
@@ -40,12 +40,12 @@ float foo(
 }
 
 struct SCWrapper {
-    SCWrapper(cl::sycl::program &p)
-        : SC1(p.set_spec_constant<class sc_name1, int>(4)),
-          SC2(p.set_spec_constant<class sc_name2, int>(2)) {}
+  SCWrapper(cl::sycl::program &p)
+      : SC1(p.set_spec_constant<class sc_name1, int>(4)),
+        SC2(p.set_spec_constant<class sc_name2, int>(2)) {}
 
-    cl::sycl::experimental::spec_constant<int, class sc_name1> SC1;
-    cl::sycl::experimental::spec_constant<int, class sc_name2> SC2;
+  cl::sycl::experimental::spec_constant<int, class sc_name1> SC1;
+  cl::sycl::experimental::spec_constant<int, class sc_name2> SC2;
 };
 
 int main(int argc, char **argv) {
@@ -120,9 +120,7 @@ int main(int argc, char **argv) {
       auto accw = bufw.get_access<cl::sycl::access::mode::write>(cgh);
       cgh.single_task<KernelWrappedSC>(
           program3.get_kernel<KernelWrappedSC>(),
-          [=]() {
-            accw[0] = W.SC1.get() + W.SC2.get();
-          });
+          [=]() { accw[0] = W.SC1.get() + W.SC2.get(); });
     });
   } catch (cl::sycl::exception &e) {
     std::cout << "*** Exception caught: " << e.what() << "\n";


### PR DESCRIPTION
FE crashed on attempt to create initializer for struct with spec
constant members because there was no initializers for spec const
fields. Added default initialization for spec constants.