### PR TITLE
[SYCL] Fix opencl/sycl interoperability

### DIFF
--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -67,9 +67,9 @@ context::context(const vector_class<device> &DeviceList,
   }
 }
 context::context(cl_context ClContext, async_handler AsyncHandler) {
+  const auto &Plugin = RT::getPlugin<backend::opencl>();
   impl = std::make_shared<detail::context_impl>(
-      detail::pi::cast<detail::RT::PiContext>(ClContext), AsyncHandler,
-      *RT::GlobalPlugin);
+      detail::pi::cast<detail::RT::PiContext>(ClContext), AsyncHandler, Plugin);
 }
 
 #define PARAM_TRAITS_SPEC(param_type, param, ret_type)                         \

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -31,7 +31,8 @@ device::device() : impl(std::make_shared<detail::device_impl>()) {}
 
 device::device(cl_device_id deviceId)
     : impl(std::make_shared<detail::device_impl>(
-          detail::pi::cast<pi_native_handle>(deviceId), *RT::GlobalPlugin)) {
+          detail::pi::cast<pi_native_handle>(deviceId),
+          RT::getPlugin<backend::opencl>())) {
   // The implementation constructor takes ownership of the native handle so we
   // must retain it in order to adhere to SYCL 1.2.1 spec (Rev6, section 4.3.1.)
   clRetainDevice(deviceId);

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -21,7 +21,7 @@ platform::platform() : impl(std::make_shared<detail::platform_impl>()) {}
 platform::platform(cl_platform_id PlatformId)
     : impl(std::make_shared<detail::platform_impl>(
           detail::pi::cast<detail::RT::PiPlatform>(PlatformId),
-          RT::GlobalPlugin)) {}
+          RT::getPlugin<backend::opencl>())) {}
 
 platform::platform(const device_selector &dev_selector) {
   *this = dev_selector.select_device().get_platform();

--- a/sycl/test/basic_tests/opencl_interop.cpp
+++ b/sycl/test/basic_tests/opencl_interop.cpp
@@ -3,6 +3,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
 
 #include <CL/sycl.hpp>
 #include <cassert>
@@ -63,15 +64,15 @@ cl_context createOpenCLContext(cl_platform_id platform, cl_device_id device) {
 int main() {
   cl_platform_id ocl_platform = selectOpenCLPlatform();
   cl::sycl::platform syclPlt(ocl_platform);
-  assert(ocl_platform == syclPlt.get());
+  assert(ocl_platform == syclPlt.get() && "SYCL returns invalid OpenCL platform id");
 
   cl_device_id ocl_device = selectOpenCLDevice(ocl_platform);
   cl::sycl::device syclDev(ocl_device);
-  assert(ocl_device == syclDev.get());
+  assert(ocl_device == syclDev.get() && "SYCL returns invalid OpenCL device id");
 
   cl_context ocl_context = createOpenCLContext(ocl_platform, ocl_device);
   cl::sycl::context syclContext(ocl_context);
-  assert(ocl_context == syclContext.get());
+  assert(ocl_context == syclContext.get() && "SYCL returns invalid OpenCL context id");
 
   return 0;
 }

--- a/sycl/test/basic_tests/opencl_interop.cpp
+++ b/sycl/test/basic_tests/opencl_interop.cpp
@@ -64,15 +64,18 @@ cl_context createOpenCLContext(cl_platform_id platform, cl_device_id device) {
 int main() {
   cl_platform_id ocl_platform = selectOpenCLPlatform();
   cl::sycl::platform syclPlt(ocl_platform);
-  assert(ocl_platform == syclPlt.get() && "SYCL returns invalid OpenCL platform id");
+  assert(ocl_platform == syclPlt.get() &&
+         "SYCL returns invalid OpenCL platform id");
 
   cl_device_id ocl_device = selectOpenCLDevice(ocl_platform);
   cl::sycl::device syclDev(ocl_device);
-  assert(ocl_device == syclDev.get() && "SYCL returns invalid OpenCL device id");
+  assert(ocl_device == syclDev.get() &&
+         "SYCL returns invalid OpenCL device id");
 
   cl_context ocl_context = createOpenCLContext(ocl_platform, ocl_device);
   cl::sycl::context syclContext(ocl_context);
-  assert(ocl_context == syclContext.get() && "SYCL returns invalid OpenCL context id");
+  assert(ocl_context == syclContext.get() &&
+         "SYCL returns invalid OpenCL context id");
 
   return 0;
 }

--- a/sycl/test/basic_tests/opencl_interop.cpp
+++ b/sycl/test/basic_tests/opencl_interop.cpp
@@ -1,0 +1,77 @@
+// REQUIRES: opencl
+
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+#include <cassert>
+#include <exception>
+#include <vector>
+
+#define CL_CHECK_ERRORS(ERR)                                                   \
+  if (ERR != CL_SUCCESS) {                                                     \
+    throw std::runtime_error("Error in OpenCL object creation.");              \
+  }
+
+cl_platform_id selectOpenCLPlatform() {
+  cl_int err = 0;
+  cl_uint num_of_platforms = 0;
+
+  err = clGetPlatformIDs(0, NULL, &num_of_platforms);
+  CL_CHECK_ERRORS(err);
+
+  std::vector<cl_platform_id> platforms(num_of_platforms);
+
+  err = clGetPlatformIDs(num_of_platforms, &platforms[0], 0);
+  CL_CHECK_ERRORS(err);
+
+  return platforms[0];
+}
+
+cl_device_id selectOpenCLDevice(cl_platform_id platform) {
+  cl_int err = 0;
+  cl_uint num_of_devices = 0;
+
+  err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, 0, &num_of_devices);
+  CL_CHECK_ERRORS(err);
+
+  std::vector<cl_device_id> devices(num_of_devices);
+
+  err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, num_of_devices,
+                       &devices[0], 0);
+  CL_CHECK_ERRORS(err);
+
+  return devices[0];
+}
+
+cl_context createOpenCLContext(cl_platform_id platform, cl_device_id device) {
+  cl_int err = 0;
+  cl_context context;
+  std::vector<cl_context_properties> context_props(3);
+
+  context_props[0] = CL_CONTEXT_PLATFORM;
+  context_props[1] = cl_context_properties(platform);
+  context_props.back() = 0;
+
+  context = clCreateContext(&context_props[0], 1, &device, 0, 0, &err);
+  CL_CHECK_ERRORS(err);
+
+  return context;
+}
+
+int main() {
+  cl_platform_id ocl_platform = selectOpenCLPlatform();
+  cl::sycl::platform syclPlt(ocl_platform);
+  assert(ocl_platform == syclPlt.get());
+
+  cl_device_id ocl_device = selectOpenCLDevice(ocl_platform);
+  cl::sycl::device syclDev(ocl_device);
+  assert(ocl_device == syclDev.get());
+
+  cl_context ocl_context = createOpenCLContext(ocl_platform, ocl_device);
+  cl::sycl::context syclContext(ocl_context);
+  assert(ocl_context == syclContext.get());
+
+  return 0;
+}


### PR DESCRIPTION
Currently SYCL object creation from OpenCL object fails with
segmentation fault because of invalid GlobalPlugin. This patch fixes opencl/sycl
interop constructor by initializing GlobalPlugin before using it.

Signed-off-by: Nawrin Sultana <nawrin.sultana@intel.com>