### PR TITLE
[SYCL] Add online linking to Level Zero plugin

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -424,8 +424,30 @@ void _pi_event::deleteZeEventList(ze_event_handle_t *ZeEventList) {
 
 extern "C" {
 
-// Forward declararitons
+// Forward declarations
 decltype(piEventCreate) piEventCreate;
+
+static pi_result copyModule(ze_device_handle_t ZeDevice,
+                            ze_module_handle_t SrcMod,
+                            ze_module_handle_t *DestMod);
+
+// Forward declarations for mock implementations of Level Zero APIs that
+// are not yet available in the driver.
+// TODO: Remove these mock definitions when they are supported in the driver.
+enum ze_module_property_flag_t { ZE_MODULE_PROPERTY_FLAG_IMPORTS = ZE_BIT(0) };
+
+struct ze_module_properties_t {
+  ze_module_property_flag_t flags;
+};
+
+static ze_result_t zeModuleDynamicLink(uint32_t numModules,
+                                       ze_module_handle_t *phModules,
+                                       ze_module_build_log_handle_t *phLinkLog);
+
+static ze_result_t
+zeModuleGetProperties(ze_module_handle_t hModule,
+                      ze_module_properties_t *pModuleProperties);
+// End forward declarations for mock Level Zero APIs
 
 std::once_flag OnceFlag;
 
@@ -1655,8 +1677,8 @@ pi_result piextMemCreateWithNativeHandle(pi_native_handle NativeHandle,
   return PI_SUCCESS;
 }
 
-pi_result piProgramCreate(pi_context Context, const void *IL, size_t Length,
-                          pi_program *Program) {
+pi_result piProgramCreate(pi_context Context, const void *ILBytes,
+                          size_t Length, pi_program *Program) {
 
   assert(Context);
   assert(Program);
@@ -1664,16 +1686,9 @@ pi_result piProgramCreate(pi_context Context, const void *IL, size_t Length,
   // NOTE: the Level Zero module creation is also building the program, so we
   // are deferring it until the program is ready to be built in piProgramBuild
   // and piProgramCompile. Also it is only then we know the build options.
-  //
-  ze_module_desc_t ZeModuleDesc = {};
-  ZeModuleDesc.version = ZE_MODULE_DESC_VERSION_CURRENT;
-  ZeModuleDesc.format = ZE_MODULE_FORMAT_IL_SPIRV;
-  ZeModuleDesc.inputSize = Length;
-  ZeModuleDesc.pInputModule = new uint8_t[Length];
-  memcpy(const_cast<uint8_t *>(ZeModuleDesc.pInputModule), IL, Length);
 
   try {
-    *Program = new _pi_program(nullptr, ZeModuleDesc, Context);
+    *Program = new _pi_program(Context, ILBytes, Length);
   } catch (const std::bad_alloc &) {
     return PI_OUT_OF_HOST_MEMORY;
   } catch (...) {
@@ -1694,6 +1709,7 @@ pi_result piProgramCreateWithBinary(pi_context Context, pi_uint32 NumDevices,
   assert(Context);
   assert(RetProgram);
   assert(DeviceList && DeviceList[0] == Context->Device);
+  ze_device_handle_t ZeDevice = Context->Device->ZeDevice;
 
   // Check the binary too.
   assert(Lengths && Lengths[0] != 0);
@@ -1705,11 +1721,18 @@ pi_result piProgramCreateWithBinary(pi_context Context, pi_uint32 NumDevices,
   ZeModuleDesc.version = ZE_MODULE_DESC_VERSION_CURRENT;
   ZeModuleDesc.format = ZE_MODULE_FORMAT_NATIVE;
   ZeModuleDesc.inputSize = Length;
-  ZeModuleDesc.pInputModule = new uint8_t[Length];
-  memcpy(const_cast<uint8_t *>(ZeModuleDesc.pInputModule), Binary, Length);
+  ZeModuleDesc.pInputModule = Binary;
+  ZeModuleDesc.pBuildFlags = nullptr;
+  ZeModuleDesc.pConstants = nullptr;
+
+  ze_module_handle_t ZeModule;
+  ZE_CALL(zeModuleCreate(ZeDevice, &ZeModuleDesc, &ZeModule, 0));
 
   try {
-    *RetProgram = new _pi_program(nullptr, ZeModuleDesc, Context);
+    // TODO: It's not clear whether piProgramCreateWithBinary() can be
+    //  used also to create programs with state Object.  For now, assume
+    //  it's always a fully linked executable.
+    *RetProgram = new _pi_program(Context, ZeModule, _pi_program::Exe);
   } catch (const std::bad_alloc &) {
     return PI_OUT_OF_HOST_MEMORY;
   } catch (...) {
@@ -1746,37 +1769,108 @@ pi_result piProgramGetInfo(pi_program Program, pi_program_info ParamName,
   case PI_PROGRAM_INFO_DEVICES:
     return ReturnValue(Program->Context->Device);
   case PI_PROGRAM_INFO_BINARY_SIZES: {
-    size_t SzBinary = 0;
-    ZE_CALL(zeModuleGetNativeBinary(Program->ZeModule, &SzBinary, nullptr));
-    // This is an array of 1 element, initialize if it were scalar.
+    size_t SzBinary;
+    if (Program->State == _pi_program::IL) {
+      // The OpenCL spec indicates that PI_PROGRAM_INFO_BINARY_SIZES is not
+      // defined in this case, but it does not say what to do if it happens.
+      // Returning a zero size seems reasonable.
+      SzBinary = 0;
+    } else {
+      assert(Program->State == _pi_program::Object ||
+             Program->State == _pi_program::Exe ||
+             Program->State == _pi_program::LinkedExe);
+
+      // If the program is in LinkedExe state it may contain several modules.
+      // We cannot handle this case because each module's contents is in its
+      // own address range, discontiguous from the others.  The
+      // PI_PROGRAM_INFO_BINARY_SIZES API assume the entire linked program is
+      // one contiguous region, which is not the case for LinkedExe program
+      // in Level Zero.  Therefore, this API is unimplemented when the Program
+      // has more than one module.
+      _pi_program::ModuleIterator ModIt(Program);
+      assert(!ModIt.Done());
+      if (ModIt.Count() > 1) {
+        die("piProgramGetInfo: PI_PROGRAM_INFO_BINARY_SIZES not implemented "
+            "for linked programs");
+      }
+      ZE_CALL(zeModuleGetNativeBinary(*ModIt, &SzBinary, nullptr));
+    }
+    // This is an array of 1 element, initialized as if it were scalar.
     return ReturnValue(size_t{SzBinary});
   }
   case PI_PROGRAM_INFO_BINARIES: {
-    size_t SzBinary = 0;
+    // The caller sets "ParamValue" to an array of pointers, one for each
+    // device.  Since Level Zero supports only one device, there is only one
+    // pointer.  If the pointer is NULL, we don't do anything.  Otherwise, we
+    // copy the program's binary image to the buffer at that pointer.
     uint8_t **PBinary = pi_cast<uint8_t **>(ParamValue);
-    ZE_CALL(zeModuleGetNativeBinary(Program->ZeModule, &SzBinary, PBinary[0]));
+    if (!PBinary[0])
+      break;
+    if (Program->State == _pi_program::IL) {
+      // Nothing to do (see comments above for PI_PROGRAM_INFO_BINARY_SIZES).
+    } else {
+      assert(Program->State == _pi_program::Object ||
+             Program->State == _pi_program::Exe ||
+             Program->State == _pi_program::LinkedExe);
+
+      _pi_program::ModuleIterator ModIt(Program);
+      assert(!ModIt.Done());
+      if (ModIt.Count() > 1) {
+        die("piProgramGetInfo: PI_PROGRAM_INFO_BINARIES not implemented for "
+            "linked programs");
+      }
+      size_t SzBinary = 0;
+      ZE_CALL(zeModuleGetNativeBinary(*ModIt, &SzBinary, PBinary[0]));
+    }
     break;
   }
   case PI_PROGRAM_INFO_NUM_KERNELS: {
-    uint32_t NumKernels = 0;
-    ZE_CALL(zeModuleGetKernelNames(Program->ZeModule, &NumKernels, nullptr));
+    uint32_t NumKernels;
+    if (Program->State == _pi_program::IL ||
+        Program->State == _pi_program::Object) {
+      // The OpenCL spec says this case isn't supported, but it doesn't say
+      // what to do if it happens.  Returning zero seems reasonable.
+      NumKernels = 0;
+    } else {
+      assert(Program->State == _pi_program::Exe ||
+             Program->State == _pi_program::LinkedExe);
+
+      NumKernels = 0;
+      _pi_program::ModuleIterator ModIt(Program);
+      while (!ModIt.Done()) {
+        uint32_t Num;
+        ZE_CALL(zeModuleGetKernelNames(*ModIt, &Num, nullptr));
+        NumKernels += Num;
+        ModIt++;
+      }
+    }
     return ReturnValue(size_t{NumKernels});
   }
   case PI_PROGRAM_INFO_KERNEL_NAMES:
     try {
-      // There are extra allocations/copying here dictated by the difference
-      // in Level Zero and PI interfaces.
-      uint32_t Count = 0;
-      ZE_CALL(zeModuleGetKernelNames(Program->ZeModule, &Count, nullptr));
-      char **PNames = new char *[Count];
-      ZE_CALL(zeModuleGetKernelNames(Program->ZeModule, &Count,
-                                     const_cast<const char **>(PNames)));
       std::string PINames{""};
-      for (uint32_t I = 0; I < Count; ++I) {
-        PINames += (I > 0 ? ";" : "");
-        PINames += PNames[I];
+      if (Program->State == _pi_program::IL ||
+          Program->State == _pi_program::Object) {
+        // Nothing to do (see comment for PI_PROGRAM_INFO_NUM_KERNELS above).
+      } else {
+        assert(Program->State == _pi_program::Exe ||
+               Program->State == _pi_program::LinkedExe);
+
+        bool First = true;
+        _pi_program::ModuleIterator ModIt(Program);
+        while (!ModIt.Done()) {
+          uint32_t Count = 0;
+          ZE_CALL(zeModuleGetKernelNames(*ModIt, &Count, nullptr));
+          std::unique_ptr<const char *[]> PNames(new const char *[Count]);
+          ZE_CALL(zeModuleGetKernelNames(*ModIt, &Count, PNames.get()));
+          for (uint32_t I = 0; I < Count; ++I) {
+            PINames += (!First ? ";" : "");
+            PINames += PNames[I];
+            First = false;
+          }
+          ModIt++;
+        }
       }
-      delete[] PNames;
       return ReturnValue(PINames.c_str());
     } catch (const std::bad_alloc &) {
       return PI_OUT_OF_HOST_MEMORY;
@@ -1797,11 +1891,102 @@ pi_result piProgramLink(pi_context Context, pi_uint32 NumDevices,
                         void (*PFnNotify)(pi_program Program, void *UserData),
                         void *UserData, pi_program *RetProgram) {
 
-  // TODO: Level Zero does not [yet] support linking so dummy implementation
-  // here.
-  assert(NumInputPrograms == 1 && InputPrograms);
-  assert(RetProgram);
-  *RetProgram = InputPrograms[0];
+  // We only support one device with Level Zero.
+  assert(NumDevices == 1);
+  assert(DeviceList && DeviceList[0] == Context->Device);
+  assert(!PFnNotify && !UserData);
+
+  // Validate input parameters.
+  if (NumInputPrograms == 0 || InputPrograms == nullptr)
+    return PI_INVALID_VALUE;
+  for (pi_uint32 I = 0; I < NumInputPrograms; I++) {
+    if (InputPrograms[I]->State != _pi_program::Object) {
+      return PI_INVALID_OPERATION;
+    }
+    assert(InputPrograms[I]->ZeModule);
+  }
+
+  // Linking modules on Level Zero is different from OpenCL.  With Level Zero,
+  // each input object module already has native code loaded onto the device.
+  // Linking two modules together causes the importing module to be changed
+  // such that its native code points to an address in the exporting module.
+  // As a result, a module that imports symbols can only be linked into one
+  // executable at a time.  By contrast, modules that export symbols are not
+  // changed, so they can be safely linked into multiple executables
+  // simultaneously.
+  //
+  // Level Zero linking also differs from OpenCL because a link operation does
+  // not create a new module that represents the linked executable.  Instead,
+  // we must keep track of all the input modules and refer to the entire list
+  // whenever we want to know something about the executable.
+
+  // This vector hold the Level Zero modules that we will actually link
+  // together.  This may be different from "InputPrograms" because some of
+  // those modules may import symbols and already be linked into other
+  // executables.  In such a case, we must make a copy of the module before we
+  // can link it again.
+  std::vector<_pi_program::LinkedReleaser> Inputs;
+  try {
+    Inputs.reserve(NumInputPrograms);
+
+    // We do several things in this loop.
+    //
+    // 1. We identify any modules that need to be copied because they import
+    //    symbols and are already linked into some other program.
+    // 2. For any module that does not need to be copied, we bump its reference
+    //    count because we will hold a reference to it.
+    // 3. We create a vector of Level Zero modules, which we can pass to the
+    //    zeModuleDynamicLink() API.
+    std::vector<ze_module_handle_t> ZeHandles;
+    ZeHandles.reserve(NumInputPrograms);
+    for (pi_uint32 I = 0; I < NumInputPrograms; I++) {
+      pi_program Input = InputPrograms[I];
+      if (Input->HasImports) {
+        std::unique_lock<std::mutex> Guard(Input->MutexHasImportsAndIsLinked);
+        if (!Input->HasImportsAndIsLinked) {
+          // This module imports symbols, but it isn't currently linked with
+          // any other module.  Grab the flag to indicate that it is now
+          // linked.
+          piProgramRetain(Input);
+          Input->HasImportsAndIsLinked = true;
+        } else {
+          // This module imports symbols and is also linked with another module
+          // already, so it needs to be copied.  We expect this to be quite
+          // rare since linking is mostly used to link against libraries which
+          // only export symbols.
+          Guard.unlock();
+          ze_module_handle_t ZeModule;
+          pi_result res =
+              copyModule(Context->Device->ZeDevice, Input->ZeModule, &ZeModule);
+          if (res != PI_SUCCESS) {
+            return res;
+          }
+          Input = new _pi_program(Input->Context, ZeModule, _pi_program::Object,
+                                  Input->HasImports);
+          Input->HasImportsAndIsLinked = true;
+        }
+      } else {
+        piProgramRetain(Input);
+      }
+      Inputs.emplace_back(Input);
+      ZeHandles.push_back(Input->ZeModule);
+    }
+
+    // Link all the modules together.  If this fails (or if we catch an
+    // exception below), we need to release the reference counts on the input
+    // modules, delete any copies, etc.
+    ze_module_build_log_handle_t ZeBuildLog;
+    ZE_CALL(
+        zeModuleDynamicLink(ZeHandles.size(), ZeHandles.data(), &ZeBuildLog));
+
+    // Construct a new program object to represent the linked executable.  This
+    // new object holds a reference to all the input programs.
+    *RetProgram = new _pi_program(Context, std::move(Inputs), ZeBuildLog);
+  } catch (const std::bad_alloc &) {
+    return PI_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return PI_ERROR_UNKNOWN;
+  }
   return PI_SUCCESS;
 }
 
@@ -1811,36 +1996,26 @@ pi_result piProgramCompile(
     const pi_program *InputHeaders, const char **HeaderIncludeNames,
     void (*PFnNotify)(pi_program Program, void *UserData), void *UserData) {
 
-  // Assert on unsupported arguments.
-  assert(NumInputHeaders == 0);
-  assert(!InputHeaders);
-
-  // There is no support for linking yet in Level Zero so "compile" actually
-  // does the "build".
-  return piProgramBuild(Program, NumDevices, DeviceList, Options, PFnNotify,
-                        UserData);
-}
-
-pi_result piProgramBuild(pi_program Program, pi_uint32 NumDevices,
-                         const pi_device *DeviceList, const char *Options,
-                         void (*PFnNotify)(pi_program Program, void *UserData),
-                         void *UserData) {
+  // We only support one device with Level Zero, and we don't support input
+  // headers.
   assert(Program);
   assert(NumDevices == 1);
-  assert(DeviceList && DeviceList[0] == Program->Context->Device);
-  assert(!PFnNotify);
-  assert(!UserData);
+  assert(DeviceList);
+  assert(NumInputHeaders == 0);
+  assert(Program);
+  assert(!PFnNotify && !UserData);
 
-  // Check that the program wasn't already built.
-  assert(!Program->ZeModule);
+  // It is only valid to compile a program if it was loaded from IL.
+  if (Program->State != _pi_program::IL)
+    return PI_INVALID_OPERATION;
+  assert(Program->ILBytes);
 
   // Translate collected specialization constants.
   ze_module_constants_t ZeSpecConstants = {};
   std::vector<uint32_t> ZeSpecContantsIds(Program->ZeSpecConstants.size());
   std::vector<uint64_t> ZeSpecContantsValues(Program->ZeSpecConstants.size());
   {
-    std::lock_guard<std::mutex> ZeSpecConstantsMutexGuard(
-        Program->ZeSpecConstantsMutex);
+    std::lock_guard<std::mutex> Guard(Program->MutexZeSpecConstants);
     ZeSpecConstants.numConstants = Program->ZeSpecConstants.size();
     auto ZeSpecContantsIdsIt = ZeSpecContantsIds.begin();
     auto ZeSpecContantsValuesIt = ZeSpecContantsValues.begin();
@@ -1854,14 +2029,48 @@ pi_result piProgramBuild(pi_program Program, pi_uint32 NumDevices,
     ZeSpecConstants.pConstantValues = ZeSpecContantsValues.data();
   }
 
-  // Complete the module's descriptor
-  Program->ZeModuleDesc.pBuildFlags = Options;
-  Program->ZeModuleDesc.pConstants = &ZeSpecConstants;
+  // Ask Level Zero to build the IL and load the native code onto the device.
+  ze_module_desc_t ZeModuleDesc = {};
+  ZeModuleDesc.version = ZE_MODULE_DESC_VERSION_CURRENT;
+  ZeModuleDesc.format = ZE_MODULE_FORMAT_IL_SPIRV;
+  ZeModuleDesc.inputSize = Program->ILLength;
+  ZeModuleDesc.pInputModule = Program->ILBytes.get();
+  ZeModuleDesc.pBuildFlags = Options;
+  ZeModuleDesc.pConstants = &ZeSpecConstants;
 
-  ze_device_handle_t ZeDevice = Program->Context->Device->ZeDevice;
-  ZE_CALL(zeModuleCreate(ZeDevice, &Program->ZeModuleDesc, &Program->ZeModule,
-                         &Program->ZeBuildLog));
+  ze_device_handle_t ZeDevice = DeviceList[0]->ZeDevice;
+  ze_module_handle_t ZeModule;
+  ze_module_build_log_handle_t ZeBuildLog;
+  ZE_CALL(zeModuleCreate(ZeDevice, &ZeModuleDesc, &ZeModule, &ZeBuildLog));
 
+  // Check if this module imports any symbols, which we need to know if we
+  // end up linking this module later.  See comments in piProgramLink() for
+  // details.
+  ze_module_properties_t ZeModuleProps;
+  ZE_CALL(zeModuleGetProperties(ZeModule, &ZeModuleProps));
+  Program->HasImports = (ZeModuleProps.flags & ZE_MODULE_PROPERTY_FLAG_IMPORTS);
+
+  // The program is now in the Object state.  We no longer need the IL.
+  Program->State = _pi_program::Object;
+  Program->ILBytes.reset();
+  Program->ZeModule = ZeModule;
+  Program->ZeBuildLog = ZeBuildLog;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramBuild(pi_program Program, pi_uint32 NumDevices,
+                         const pi_device *DeviceList, const char *Options,
+                         void (*PFnNotify)(pi_program Program, void *UserData),
+                         void *UserData) {
+
+  // On Level Zero, there's no real difference between compiling and building.
+  // We just assume that the resulting program is an executable in the case of
+  // building.
+  pi_result res = piProgramCompile(Program, NumDevices, DeviceList, Options, 0,
+                                   nullptr, nullptr, PFnNotify, UserData);
+  if (res != PI_SUCCESS)
+    return res;
+  Program->State = _pi_program::Exe;
   return PI_SUCCESS;
 }
 
@@ -1872,11 +2081,14 @@ pi_result piProgramGetBuildInfo(pi_program Program, pi_device Device,
 
   ReturnHelper ReturnValue(ParamValueSize, ParamValue, ParamValueSizeRet);
   if (ParamName == CL_PROGRAM_BINARY_TYPE) {
-    // TODO: is this the only supported binary type in Level Zero?
-    // We should probably return CL_PROGRAM_BINARY_TYPE_NONE if asked
-    // before the program was compiled.
-    return ReturnValue(
-        cl_program_binary_type{CL_PROGRAM_BINARY_TYPE_EXECUTABLE});
+    cl_program_binary_type Type = CL_PROGRAM_BINARY_TYPE_NONE;
+    if (Program->State == _pi_program::Object) {
+      Type = CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT;
+    } else if (Program->State == _pi_program::Exe ||
+               Program->State == _pi_program::LinkedExe) {
+      Type = CL_PROGRAM_BINARY_TYPE_EXECUTABLE;
+    }
+    return ReturnValue(cl_program_binary_type{Type});
   }
   if (ParamName == CL_PROGRAM_BUILD_OPTIONS) {
     // TODO: how to get module build options out of Level Zero?
@@ -1886,7 +2098,10 @@ pi_result piProgramGetBuildInfo(pi_program Program, pi_device Device,
     // with piProgramRegister?
     return ReturnValue("");
   } else if (ParamName == CL_PROGRAM_BUILD_LOG) {
-    assert(Program->ZeBuildLog);
+    // The OpenCL spec says an empty string is returned if there was no
+    // previous Compile, Build, or Link.
+    if (!Program->ZeBuildLog)
+      return ReturnValue("");
     size_t LogSize = ParamValueSize;
     ZE_CALL(zeModuleBuildLogGetString(Program->ZeBuildLog, &LogSize,
                                       pi_cast<char *>(ParamValue)));
@@ -1910,10 +2125,6 @@ pi_result piProgramRelease(pi_program Program) {
   assert(Program);
   assert((Program->RefCount > 0) && "Program is already released.");
   if (--(Program->RefCount) == 0) {
-    delete[] Program->ZeModuleDesc.pInputModule;
-    if (Program->ZeBuildLog)
-      zeModuleBuildLogDestroy(Program->ZeBuildLog);
-    // TODO: call zeModuleDestroy for non-interop Level Zero modules
     delete Program;
   }
   return PI_SUCCESS;
@@ -1925,8 +2136,28 @@ pi_result piextProgramGetNativeHandle(pi_program Program,
   assert(NativeHandle);
 
   auto ZeModule = pi_cast<ze_module_handle_t *>(NativeHandle);
-  // Extract the Level Zero module handle from the given PI program
-  *ZeModule = Program->ZeModule;
+
+  switch (Program->State) {
+  case _pi_program::Object:
+  case _pi_program::Exe:
+  case _pi_program::LinkedExe: {
+    _pi_program::ModuleIterator ModIt(Program);
+    assert(!ModIt.Done());
+    if (ModIt.Count() > 1) {
+      // Programs in LinkedExe state could have several corresponding
+      // Level Zero modules, so there is no right answer in this case.
+      //
+      // TODO: Maybe we should return PI_INVALID_OPERATION instead here?
+      die("piextProgramGetNativeHandle: Not implemented for linked programs");
+    }
+    *ZeModule = *ModIt;
+    break;
+  }
+
+  default:
+    return PI_INVALID_OPERATION;
+  }
+
   return PI_SUCCESS;
 }
 
@@ -1939,20 +2170,12 @@ pi_result piextProgramCreateWithNativeHandle(pi_native_handle NativeHandle,
 
   auto ZeModule = pi_cast<ze_module_handle_t>(NativeHandle);
 
-  // Create PI program from the given Level Zero module handle.
-  //
-  // TODO: We don't have the real Level Zero module descriptor with
-  // which it was created, but that's only needed for zeModuleCreate,
-  // which we don't expect to be called on the interop program.
-  //
-  ze_module_desc_t ZeModuleDesc = {};
-  ZeModuleDesc.version = ZE_MODULE_DESC_VERSION_CURRENT;
-  ZeModuleDesc.format = ZE_MODULE_FORMAT_NATIVE;
-  ZeModuleDesc.inputSize = 0;
-  ZeModuleDesc.pInputModule = nullptr;
+  // We assume here that programs created from a native handle always
+  // represent a fully linked executable (state Exe) and not an unlinked
+  // executable (state Object).
 
   try {
-    *Program = new _pi_program(ZeModule, ZeModuleDesc, Context);
+    *Program = new _pi_program(Context, ZeModule, _pi_program::Exe);
   } catch (const std::bad_alloc &) {
     return PI_OUT_OF_HOST_MEMORY;
   } catch (...) {
@@ -1961,24 +2184,117 @@ pi_result piextProgramCreateWithNativeHandle(pi_native_handle NativeHandle,
   return PI_SUCCESS;
 }
 
+_pi_program::~_pi_program() {
+  if (ZeModule) {
+    ZE_CALL_NOCHECK(zeModuleDestroy(ZeModule));
+  }
+  if (ZeBuildLog) {
+    ZE_CALL_NOCHECK(zeModuleBuildLogDestroy(ZeBuildLog));
+  }
+}
+
+_pi_program::LinkedReleaser::~LinkedReleaser() {
+  if (Prog->HasImports) {
+    std::lock_guard<std::mutex> Guard(Prog->MutexHasImportsAndIsLinked);
+    if (Prog->HasImportsAndIsLinked)
+      Prog->HasImportsAndIsLinked = false;
+  }
+  piProgramRelease(Prog);
+}
+
+// Create a copy of a Level Zero module by extracting the native code and
+// creating a new module from that native code.
+static pi_result copyModule(ze_device_handle_t ZeDevice,
+                            ze_module_handle_t SrcMod,
+                            ze_module_handle_t *DestMod) {
+  size_t Length;
+  ZE_CALL(zeModuleGetNativeBinary(SrcMod, &Length, nullptr));
+
+  std::unique_ptr<uint8_t[]> Code(new uint8_t[Length]);
+  ZE_CALL(zeModuleGetNativeBinary(SrcMod, &Length, Code.get()));
+
+  ze_module_desc_t ZeModuleDesc = {};
+  ZeModuleDesc.version = ZE_MODULE_DESC_VERSION_CURRENT;
+  ZeModuleDesc.format = ZE_MODULE_FORMAT_NATIVE;
+  ZeModuleDesc.inputSize = Length;
+  ZeModuleDesc.pInputModule = Code.get();
+  ZeModuleDesc.pBuildFlags = nullptr;
+  ZeModuleDesc.pConstants = nullptr;
+
+  ze_module_handle_t ZeModule;
+  ZE_CALL(zeModuleCreate(ZeDevice, &ZeModuleDesc, &ZeModule, nullptr));
+  *DestMod = ZeModule;
+  return PI_SUCCESS;
+}
+
+// TODO: Remove this mock implementation once the Level Zero driver provides
+// the real implementation.
+static ze_result_t
+zeModuleDynamicLink(uint32_t numModules, ze_module_handle_t *phModules,
+                    ze_module_build_log_handle_t *phLinkLog) {
+
+  // The mock implementation can only handle the degenerate case where there
+  // is only a single module that is "linked" to itself.  There is nothing to
+  // do in this degenerate case.
+  if (numModules > 1) {
+    die("piProgramLink: Program Linking is not supported yet in Level0");
+  }
+
+  // The mock does not support the link log.
+  if (phLinkLog)
+    *phLinkLog = nullptr;
+  return ZE_RESULT_SUCCESS;
+}
+
+// TODO: Remove this mock implementation once the Level Zero driver provides
+// the real implementation.
+static ze_result_t
+zeModuleGetProperties(ze_module_handle_t hModule,
+                      ze_module_properties_t *pModuleProperties) {
+
+  // The mock implementation assumes that the module has imported symbols.
+  // This is a conservative guess which may result in unnecessary calls to
+  // copyModule(), but it is always correct.
+  pModuleProperties->flags = ZE_MODULE_PROPERTY_FLAG_IMPORTS;
+  return ZE_RESULT_SUCCESS;
+}
+
 pi_result piKernelCreate(pi_program Program, const char *KernelName,
                          pi_kernel *RetKernel) {
 
   assert(Program);
   assert(RetKernel);
   assert(KernelName);
+
+  // The OpenCL spec actually says this should return
+  // CL_INVALID_PROGRAM_EXECUTABLE, but there is no
+  // corresponding PI error code.
+  if (Program->State != _pi_program::Exe &&
+      Program->State != _pi_program::LinkedExe) {
+    return PI_INVALID_OPERATION;
+  }
+
   ze_kernel_desc_t ZeKernelDesc = {};
   ZeKernelDesc.version = ZE_KERNEL_DESC_VERSION_CURRENT;
   ZeKernelDesc.flags = ZE_KERNEL_FLAG_NONE;
   ZeKernelDesc.pKernelName = KernelName;
 
+  // Search for the kernel name in each module.
   ze_kernel_handle_t ZeKernel;
-  ZE_CALL(zeKernelCreate(pi_cast<ze_module_handle_t>(Program->ZeModule),
-                         &ZeKernelDesc, &ZeKernel));
+  ze_result_t ZeResult = ZE_RESULT_ERROR_INVALID_KERNEL_NAME;
+  _pi_program::ModuleIterator ModIt(Program);
+  while (!ModIt.Done()) {
+    ZeResult =
+        ZE_CALL_NOCHECK(zeKernelCreate(*ModIt, &ZeKernelDesc, &ZeKernel));
+    if (ZeResult != ZE_RESULT_ERROR_INVALID_KERNEL_NAME)
+      break;
+    ModIt++;
+  }
+  if (ZeResult != ZE_RESULT_SUCCESS)
+    return mapError(ZeResult);
 
   try {
-    auto ZePiKernel = new _pi_kernel(ZeKernel, Program, KernelName);
-    *RetKernel = pi_cast<pi_kernel>(ZePiKernel);
+    *RetKernel = new _pi_kernel(ZeKernel, Program, KernelName);
   } catch (const std::bad_alloc &) {
     return PI_OUT_OF_HOST_MEMORY;
   } catch (...) {
@@ -3394,10 +3710,24 @@ pi_result piextGetDeviceFunctionPointer(pi_device Device, pi_program Program,
                                         const char *FunctionName,
                                         pi_uint64 *FunctionPointerRet) {
   assert(Program != nullptr);
-  ZE_CALL(zeModuleGetFunctionPointer(
-      Program->ZeModule, FunctionName,
-      reinterpret_cast<void **>(FunctionPointerRet)));
-  return PI_SUCCESS;
+
+  if (Program->State != _pi_program::Exe &&
+      Program->State != _pi_program::LinkedExe) {
+    return PI_INVALID_OPERATION;
+  }
+
+  // Search for the function name in each module.
+  ze_result_t ZeResult = ZE_RESULT_ERROR_INVALID_FUNCTION_NAME;
+  _pi_program::ModuleIterator ModIt(Program);
+  while (!ModIt.Done()) {
+    ZeResult = ZE_CALL_NOCHECK(zeModuleGetFunctionPointer(
+        *ModIt, FunctionName, reinterpret_cast<void **>(FunctionPointerRet)));
+    if (ZeResult != ZE_RESULT_ERROR_INVALID_FUNCTION_NAME)
+      break;
+    ModIt++;
+  }
+
+  return mapError(ZeResult);
 }
 
 pi_result piextUSMHostAlloc(void **ResultPtr, pi_context Context,
@@ -3758,11 +4088,10 @@ pi_result piextProgramSetSpecializationConstant(pi_program Prog,
                                                 const void *SpecValue) {
   // Level Zero sets spec constants when creating modules,
   // so save them for when program is built.
-  std::lock_guard<std::mutex> ZeSpecConstantsMutexGuard(
-      Prog->ZeSpecConstantsMutex);
+  std::lock_guard<std::mutex> Guard(Prog->MutexZeSpecConstants);
 
   // Pass SpecValue pointer. Spec constant value is retrieved
-  // by Level-Zero when creating the modul
+  // by Level Zero when creating the module.
   //
   // NOTE: SpecSize is unused in Level Zero, the size is known from SPIR-V by
   // SpecID.

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -21,9 +21,12 @@
 #include <CL/sycl/detail/pi.h>
 #include <atomic>
 #include <cassert>
+#include <cstring>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <vector>
 
 #include <level_zero/ze_api.h>
 
@@ -307,25 +310,180 @@ struct _pi_event : _pi_object {
 };
 
 struct _pi_program : _pi_object {
-  _pi_program(ze_module_handle_t Module, ze_module_desc_t ModuleDesc,
-              pi_context Context)
-      : ZeModuleDesc(ModuleDesc), ZeModule{Module},
-        ZeBuildLog{nullptr}, Context{Context} {}
+  // Possible states of a program.
+  typedef enum {
+    // The program has been created from intermediate language (SPIR-v), but it
+    // is not yet compiled.
+    IL,
 
-  // Level Zero module descriptor.
-  ze_module_desc_t ZeModuleDesc;
+    // The program consists of native code (typically compiled from SPIR-v),
+    // but it has unresolved external dependencies which need to be resolved
+    // by linking with other Object state program(s).  Programs in this state
+    // have a single Level Zero module.
+    Object,
 
-  // Level Zero module handle.
-  ze_module_handle_t ZeModule;
-  // Level Zero module specialization constants
-  std::mutex ZeSpecConstantsMutex;
+    // The program consists of native code with no external dependencies.
+    // Programs in this state have a single Level Zero module, but no linking
+    // is needed in order to run kernels.
+    Exe,
+
+    // The program consists of several Level Zero modules, each of which
+    // contains native code.  Some modules may import external symbols and
+    // other modules may export definitions of those external symbols.  All of
+    // the modules have been linked together, so the imported references are
+    // resolved by the exported definitions.
+    //
+    // Module linking in Level Zero is quite different from program linking in
+    // OpenCL.  OpenCL statically links several program objects together to
+    // form a new program that contains the linked result.  Level Zero is more
+    // similar to shared libraries.  When several Level Zero modules are linked
+    // together, each module is modified "in place" such that external
+    // references from one are linked to external definitions in another.
+    // Linking in Level Zero does not produce a new Level Zero module that
+    // represents the linked result, therefore a program in LinkedExe state
+    // holds a list of all the pi_programs that were linked together.  Queries
+    // about the linked program need to query all the pi_programs in this list.
+    LinkedExe
+  } state;
+
+  // This is a wrapper class used for programs in LinkedExe state.  Such a
+  // program contains a list of pi_programs in Object state that have been
+  // linked together.  The program in LinkedExe state increments the reference
+  // counter for each of the Object state programs, thus "retaining" a
+  // reference to them, and it may also set the "HasImportsAndIsLinked" flag
+  // in these Object state programs.  The purpose of this wrapper is to
+  // decrement the reference count and clear the flag when the LinkedExe
+  // program is destroyed, so all the interesting code is in the wrapper's
+  // destructor.
+  //
+  // In order to ensure that the reference count is never decremented more
+  // than once, the wrapper has no copy constructor or copy assignment
+  // operator.  Instead, we only allow move semantics for the wrapper.
+  class LinkedReleaser {
+  public:
+    LinkedReleaser(pi_program Prog) : Prog(Prog) {}
+    LinkedReleaser(LinkedReleaser &&Other) {
+      Prog = Other.Prog;
+      Other.Prog = nullptr;
+    }
+    LinkedReleaser(const LinkedReleaser &Other) = delete;
+    LinkedReleaser &operator=(LinkedReleaser &&Other) {
+      std::swap(Prog, Other.Prog);
+      return *this;
+    }
+    LinkedReleaser &operator=(const LinkedReleaser &Other) = delete;
+    ~LinkedReleaser();
+
+    pi_program operator->() const { return Prog; }
+
+  private:
+    pi_program Prog;
+  };
+
+  // A utility class that iterates over the Level Zero modules contained by
+  // the program.  This helps hide the difference between programs in Object
+  // or Exe state (which have one module) and programs in LinkedExe state
+  // (which have several modules).
+  class ModuleIterator {
+  public:
+    ModuleIterator(pi_program Prog)
+        : Prog(Prog), It(Prog->LinkedPrograms.begin()) {
+      if (Prog->State == LinkedExe) {
+        NumMods = Prog->LinkedPrograms.size();
+        IsDone = (It == Prog->LinkedPrograms.end());
+        Mod = IsDone ? nullptr : (*It)->ZeModule;
+      } else if (Prog->State == IL) {
+        NumMods = 0;
+        IsDone = true;
+        Mod = nullptr;
+      } else {
+        NumMods = 1;
+        IsDone = false;
+        Mod = Prog->ZeModule;
+      }
+    }
+
+    bool Done() const { return IsDone; }
+    size_t Count() const { return NumMods; }
+    ze_module_handle_t operator*() const { return Mod; }
+
+    void operator++(int) {
+      if (!IsDone && (Prog->State == LinkedExe) &&
+          (++It != Prog->LinkedPrograms.end())) {
+        Mod = (*It)->ZeModule;
+      } else {
+        Mod = nullptr;
+        IsDone = true;
+      }
+    }
+
+  private:
+    pi_program Prog;
+    ze_module_handle_t Mod;
+    size_t NumMods;
+    bool IsDone;
+    std::vector<LinkedReleaser>::iterator It;
+  };
+
+  // Construct a program in IL state.
+  _pi_program(pi_context Context, const void *InputIL, size_t InputILLength)
+      : State(IL), Context(Context), ILBytes(new uint8_t[InputILLength]),
+        ILLength(InputILLength), ZeModule(nullptr), HasImports(false),
+        HasImportsAndIsLinked(false), ZeBuildLog(nullptr) {
+
+    std::memcpy(ILBytes.get(), InputIL, InputILLength);
+  }
+
+  // Construct a program in either Object or Exe state.
+  _pi_program(pi_context Context, ze_module_handle_t ZeModule, state St,
+              bool HasImports = false)
+      : State(St), Context(Context), ZeModule(ZeModule), HasImports(HasImports),
+        HasImportsAndIsLinked(false), ZeBuildLog(nullptr) {}
+
+  // Construct a program in LinkedExe state.
+  _pi_program(pi_context Context, std::vector<LinkedReleaser> &&Inputs,
+              ze_module_build_log_handle_t ZeLog)
+      : State(LinkedExe), Context(Context), ZeModule(nullptr),
+        HasImports(false), HasImportsAndIsLinked(false),
+        LinkedPrograms(std::move(Inputs)), ZeBuildLog(ZeLog) {}
+
+  ~_pi_program();
+
+  // Used for programs in all states.
+  state State;
+  pi_context Context; // Context of the program.
+
+  // Used for programs in IL state.
+  std::unique_ptr<uint8_t[]> ILBytes; // Array containing raw IL.
+  size_t ILLength;                    // Size (bytes) of the array.
+
+  // Level Zero specialization constants, used for programs in IL state.
+  // Access to this member is protected by Mutex.
   std::unordered_map<uint32_t, uint64_t> ZeSpecConstants;
+  std::mutex MutexZeSpecConstants; // Protects access to this field.
 
-  // Level Zero build log.
+  // Used for programs in Object or Exe state.
+  ze_module_handle_t ZeModule; // Level Zero module handle.
+  bool HasImports;             // Tells if module imports any symbols.
+
+  // Used for programs in Object state.  Tells if this module imports any
+  // symbols AND it is linked into some other program that has state LinkedExe.
+  // Such an Object is linked into exactly one other LinkedExe program.  Access
+  // to this field needs to be locked in case there are two threads that try to
+  // simultaneously link with this module.
+  bool HasImportsAndIsLinked;
+  std::mutex MutexHasImportsAndIsLinked; // Protects access to this field.
+
+  // Used for programs in LinkedExe state.  This is the set of Object programs
+  // that are linked together.
+  //
+  // Note that the Object programs in this vector might also be linked into
+  // other LinkedExe programs!
+  std::vector<LinkedReleaser> LinkedPrograms;
+
+  // Level Zero build or link log, used for programs in Obj, Exe, or LinkedExe
+  // state.
   ze_module_build_log_handle_t ZeBuildLog;
-
-  // Keep the context of the program.
-  pi_context Context;
 };
 
 struct _pi_kernel : _pi_object {

--- a/sycl/test/kernel-and-program/basic-program.cpp
+++ b/sycl/test/kernel-and-program/basic-program.cpp
@@ -1,3 +1,4 @@
+// XFAIL: cuda
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/kernel-and-program/basic-program.cpp
+++ b/sycl/test/kernel-and-program/basic-program.cpp
@@ -27,10 +27,12 @@ int main() {
       assert(prg.get_state() == cl::sycl::program_state::none);
       prg.build_with_kernel_type<class BuiltKernel>();
       assert(prg.get_state() == cl::sycl::program_state::linked);
-      cl::sycl::vector_class<cl::sycl::vector_class<char>> binaries = prg.get_binaries();
+      cl::sycl::vector_class<cl::sycl::vector_class<char>> binaries =
+          prg.get_binaries();
       assert(prg.has_kernel<class BuiltKernel>());
       cl::sycl::kernel krn = prg.get_kernel<class BuiltKernel>();
-      cl::sycl::string_class name = krn.get_info<cl::sycl::info::kernel::function_name>();
+      cl::sycl::string_class name =
+          krn.get_info<cl::sycl::info::kernel::function_name>();
       assert(prg.has_kernel(name));
 
       q.submit([&](cl::sycl::handler &cgh) {
@@ -53,15 +55,18 @@ int main() {
       assert(prg.get_state() == cl::sycl::program_state::compiled);
       prg.link();
       assert(prg.get_state() == cl::sycl::program_state::linked);
-      cl::sycl::vector_class<cl::sycl::vector_class<char>> binaries = prg.get_binaries();
+      cl::sycl::vector_class<cl::sycl::vector_class<char>> binaries =
+          prg.get_binaries();
       assert(prg.has_kernel<class CompiledKernel>());
       cl::sycl::kernel krn = prg.get_kernel<class CompiledKernel>();
-      cl::sycl::string_class name = krn.get_info<cl::sycl::info::kernel::function_name>();
+      cl::sycl::string_class name =
+          krn.get_info<cl::sycl::info::kernel::function_name>();
       assert(prg.has_kernel(name));
 
       q.submit([&](cl::sycl::handler &cgh) {
         auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-        cgh.single_task<class CompiledKernel>(krn, [=]() { acc[0] = acc[0] + 1; });
+        cgh.single_task<class CompiledKernel>(krn,
+                                              [=]() { acc[0] = acc[0] + 1; });
       });
     }
     assert(data == 1);

--- a/sycl/test/kernel-and-program/basic-program.cpp
+++ b/sycl/test/kernel-and-program/basic-program.cpp
@@ -1,0 +1,69 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+//==--- basic-program.cpp - Basic test of program and kernel APIs ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+#include <iostream>
+
+int main() {
+
+  // Test program and kernel APIs when building a kernel.
+  {
+    cl::sycl::queue q;
+    int data = 0;
+    {
+      cl::sycl::buffer<int, 1> buf(&data, cl::sycl::range<1>(1));
+      cl::sycl::program prg(q.get_context());
+      assert(prg.get_state() == cl::sycl::program_state::none);
+      prg.build_with_kernel_type<class BuiltKernel>();
+      assert(prg.get_state() == cl::sycl::program_state::linked);
+      cl::sycl::vector_class<cl::sycl::vector_class<char>> binaries = prg.get_binaries();
+      assert(prg.has_kernel<class BuiltKernel>());
+      cl::sycl::kernel krn = prg.get_kernel<class BuiltKernel>();
+      cl::sycl::string_class name = krn.get_info<cl::sycl::info::kernel::function_name>();
+      assert(prg.has_kernel(name));
+
+      q.submit([&](cl::sycl::handler &cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.single_task<class BuiltKernel>(krn, [=]() { acc[0] = acc[0] + 1; });
+      });
+    }
+    assert(data == 1);
+  }
+
+  // Test program and kernel APIs when compiling / linking a kernel.
+  {
+    cl::sycl::queue q;
+    int data = 0;
+    {
+      cl::sycl::buffer<int, 1> buf(&data, cl::sycl::range<1>(1));
+      cl::sycl::program prg(q.get_context());
+      assert(prg.get_state() == cl::sycl::program_state::none);
+      prg.compile_with_kernel_type<class CompiledKernel>();
+      assert(prg.get_state() == cl::sycl::program_state::compiled);
+      prg.link();
+      assert(prg.get_state() == cl::sycl::program_state::linked);
+      cl::sycl::vector_class<cl::sycl::vector_class<char>> binaries = prg.get_binaries();
+      assert(prg.has_kernel<class CompiledKernel>());
+      cl::sycl::kernel krn = prg.get_kernel<class CompiledKernel>();
+      cl::sycl::string_class name = krn.get_info<cl::sycl::info::kernel::function_name>();
+      assert(prg.has_kernel(name));
+
+      q.submit([&](cl::sycl::handler &cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.single_task<class CompiledKernel>(krn, [=]() { acc[0] = acc[0] + 1; });
+      });
+    }
+    assert(data == 1);
+  }
+}


### PR DESCRIPTION
This commit adds support to the Level Zero plugin for online linking,
but the underlying Level Zero driver APIs are still missing.  As a
short-term workaround, this commit includes mocked versions of those
APIs, which work only in the simple case when a single module is
"linked" to itself.