### PR TITLE
[WIP] Update Level-Zero plugin to v1.0

### DIFF
--- a/sycl/tools/sycl-ls/CMakeLists.txt
+++ b/sycl/tools/sycl-ls/CMakeLists.txt
@@ -6,3 +6,5 @@ target_link_libraries(sycl-ls
     sycl
     OpenCL::Headers
 )
+install(TARGETS sycl-ls
+  RUNTIME DESTINATION "bin" COMPONENT sycl-ls)


### PR DESCRIPTION
This patch adjusts to the [renamed] L0 fields. mostly querying various properties.
It also adds L0 contexts (yet to be completed), L0 command groups, etc
The intent of this preliminary patch is to make **L0 plugin buildable again**.

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>