### PR TITLE
[SYCL] Fix bug in piDeviceGetInfo for subgroup sizes property.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -114,6 +114,20 @@ pi_result getInfoArray(size_t array_length, size_t param_value_size,
                      array_length * sizeof(T), memcpy);
 }
 
+template <typename T, typename RetType>
+pi_result getInfoArray(size_t array_length, size_t param_value_size,
+                       void *param_value, size_t *param_value_size_ret,
+                       T *value) {
+  if (param_value) {
+    memset(param_value, 0, param_value_size);
+    for (uint32_t I = 0; I < array_length; I++)
+      ((RetType *)param_value)[I] = (RetType)value[I];
+  }
+  if (param_value_size_ret)
+    *param_value_size_ret = array_length * sizeof(RetType);
+  return PI_SUCCESS;
+}
+
 template <>
 pi_result getInfo<const char *>(size_t param_value_size, void *param_value,
                                 size_t *param_value_size_ret,
@@ -1061,9 +1075,10 @@ pi_result piDeviceGetInfo(pi_device Device, pi_device_info ParamName,
   case PI_DEVICE_INFO_SUB_GROUP_SIZES_INTEL: {
     // ze_device_compute_properties.subGroupSizes is in uint32_t whereas the
     // expected return is size_t datatype. size_t can be 8 bytes of data.
-    return getInfoArray(Device->ZeDeviceComputeProperties.numSubGroupSizes,
-                        ParamValueSize, ParamValue, ParamValueSizeRet,
-                        Device->ZeDeviceComputeProperties.subGroupSizes);
+    return getInfoArray<uint32_t, size_t>(
+        Device->ZeDeviceComputeProperties.numSubGroupSizes, ParamValueSize,
+        ParamValue, ParamValueSizeRet,
+        Device->ZeDeviceComputeProperties.subGroupSizes);
   }
   case PI_DEVICE_INFO_IL_VERSION: {
     // Set to a space separated list of IL version strings of the form

--- a/sycl/test/regression/get_subgroup_sizes.cpp
+++ b/sycl/test/regression/get_subgroup_sizes.cpp
@@ -1,0 +1,27 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+//==-- get_subgroup_sizes.cpp - Test for bug fix in subgroup sizes query --==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main() {
+  queue Q;
+  auto Dev = Q.get_device();
+  if (Dev.has_extension("cl_intel_required_subgroup_size")) {
+    cl::sycl::vector_class<size_t> SubGroupSizes =
+        Dev.get_info<cl::sycl::info::device::sub_group_sizes>();
+    cl::sycl::vector_class<size_t>::const_iterator MaxIter =
+        std::max_element(SubGroupSizes.begin(), SubGroupSizes.end());
+    int MaxSubGroup_size = *MaxIter;
+  }
+  return 0;
+}


### PR DESCRIPTION
Implement getInfoArray for return type which differs from the type
returned by Level Zero API. Otherwise incorrect data is copied to the
returned array.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>