### PR TITLE
[SYCL] Don't include level zero header explicitly to the interop header

### DIFF
--- a/sycl/include/CL/sycl/backend/level_zero.hpp
+++ b/sycl/include/CL/sycl/backend/level_zero.hpp
@@ -9,7 +9,8 @@
 #pragma once
 
 #include <CL/sycl.hpp>
-#include <level_zero/ze_api.h>
+// This header should be included by users.
+//#include <level_zero/ze_api.h>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {


### PR DESCRIPTION
Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>