### PR TITLE
[SPIR-V] Update SPV_INTEL_function_pointers extension

### DIFF
--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_function_pointers.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_function_pointers.asciidoc
@@ -17,6 +17,7 @@ https://github.com/intel/llvm/issues
 - Ben Ashbaugh, Intel
 - Pawel Jurek, Intel
 - Thomas Raoux, Intel
+- Alex Bezzubikov, Intel
 
 == Notice
 
@@ -37,7 +38,7 @@ If you are interested in using this feature in your software product, please let
 [width="40%",cols="25,25"]
 |==================================
 | Last Modified Date | {docdate}
-| Revision           | G
+| Revision           | H
 |==================================
 
 == Dependencies
@@ -86,7 +87,7 @@ IndirectReferencesINTEL
 Instructions added under the *FunctionPointersINTEL* capability:
 
 ----
-OpFunctionPointerINTEL
+OpConstFunctionPointerINTEL
 OpFunctionPointerCallINTEL
 ----
 
@@ -113,7 +114,7 @@ CodeSectionINTEL
 [cols="70%,30%"]
 [grid="rows"]
 |====
-|OpFunctionPointerINTEL     | 5600
+|OpConstFunctionPointerINTEL| 5600
 |OpFunctionPointerCallINTEL | 5601
 |ReferencedIndirectlyINTEL  | 5602
 |FunctionPointersINTEL      | 5603
@@ -133,23 +134,24 @@ Modify Section 2.2.2, Types, add the following at the end of the section: ::
 [[FunctionPointer]]'Function Pointer': A pointer that results from the following
 instruction:
 
-- *OpFunctionPointerINTEL*
+- *OpConstFunctionPointerINTEL*
 
 Additionally, any *OpSelect*, *OpPhi*, *OpFunctionCall*, *OpPtrAccessChain*,
 *OpLoad*, *OpAccessChain*, *OpInBoundAccessChain*, or *OpCopyObject* thas takes
 a function pointer as an operand also produces a function pointer. An
 *OpFunctionParameter* of pointer type is function pointer if any
 *OpFunctionCall* to the function statically passes a function pointer as the
-value of the parameter. *OpConstantNull* returns function pointer if 'Result
-type' is function pointer.
+value of the parameter. *OpCompositeExtract* and *OpConstantNull* return function pointer
+if 'Result type' is function pointer.
 
 Modify Section 2.9, Function Calling, add the following after the first sentence: ::
 
 Functions can be called indirectly using function pointers: to do so, use
 *OpFunctionPointerCallINTEL* with an operand that is the _<id>_ obtained using
-*OpFunctionPointerINTEL* of the *OpFunction* to call, and the _<id>s_ of the
-arguments to pass. All arguments are passed by value into the called function.
-This includes pointers, through which a callee object could be modified.
+*OpConstFunctionPointerINTEL* of the *OpFunction* to call,
+and the _<id>s_ of the arguments to pass. All arguments are passed by value
+into the called function. This includes pointers, through which a callee object
+could be modified.
 
 === Storage Classes
 
@@ -207,16 +209,17 @@ Modify Section 3.32.6, Type-Declaration Instructions, change the third sentence 
 pointer type. *OpFunction* and *OpTypePointer* are only valid uses of
 *OpTypeFunction*.
 
-Modify Section 3.32.9, Function Instructions, adding to the end of the list of instructions: ::
+Modify Section 3.32.7, Constant-Creation Instructions, adding to the end of the list of instructions: ::
 
 [cols="2*1,3*3",width="100%"]
 |=====
-4+|[[OpFunctionPointerINTEL]]*OpFunctionPointerINTEL* +
+4+|[[OpConstFunctionPointerINTEL]]*OpConstFunctionPointerINTEL* +
  +
-Obtains address of the specified function. +
+Obtains constant address of the specified function. +
  +
-Result value can be used immediately in *OpFunctionPointerCallINTEL* or stored
-somewhere for further usage in *OpFunctionPointerCallINTEL*. +
+Result value can be used in *OpFunctionPointerCallINTEL* or inserted into
+a composite constant or stored somewhere for further usage
+in *OpFunctionPointerCallINTEL*. +
  +
 _Result Type_ must be an *OpTypePointer*. Its _Type_ operand must be the same
 *OpTypeFunction* which was used as _Function Type_ operand of the _Function_
@@ -225,6 +228,8 @@ operand. Its _Storage Class_ operand must be *CodeSectionINTEL*
 *FunctionPointersINTEL*
 | 4 | 5600 | '<id>' 'Result Type' | '<id> Result ' | '<id>' 'Function'
 |=====
+
+Modify Section 3.32.9, Function Instructions, adding to the end of the list of instructions: ::
 
 [cols="2*1,4*3",width="100%"]
 |=====
@@ -252,13 +257,16 @@ argument types must match the formal parameter types.
 == Validation Rules
 
 It is legal to use <<FunctionPointer, Function Pointer>> as 'Result Type' of
-*OpFunctionArgument*, *OpUndef* and *OpConstantNULL*.
+*OpFunctionArgument*, *OpCompositeExtract*, *OpUndef* and *OpConstantNULL*.
 
 It is legal to use <<FunctionPointer, Function Pointer>> as 'Return Type' of
 *OpTypeFunction*.
 
 It is legal to use <<FunctionPointer, Function Pointer>> as 'Pointer'
 argument of *OpConvertPtrToU* and as 'Result Type' of *OpConvertUToPtr*.
+
+It is legal to use <<FunctionPointer, Function Pointer>> as 'Object'
+argument of *OpCompositeInsert*.
 
 It is illegal to use <<FunctionPointer, Function Pointer>> as 'Pointer'
 argument of *OpPtrCastToGeneric*.
@@ -308,6 +316,28 @@ be used for ones out of the box and we don't have much use-cases for it.
 *UNRESOLVED*
 --
 
+. Should we prohibit heterogenous composites with function pointers? Maybe we should
+distinct <<FunctionPointer, Function Pointer>> and Constant Function Pointer?
++
+--
+*RESOLVED*
+
+In general, we should not since this extension is aimed to support the whole C++ function
+pointers functionality in SPIR-V.
+--
+
+. Should we distinct const and non-const function pointers in rules for *OpCompositeInsert*?
+We can only use a result of *OpConstFunctionPointerINTEL* (which is a quite specific case of
+<<FunctionPointer, Function Pointer>>, so we can't use the whole term in the rule)
+in *OpConstantComposite*, but how should we specify that in this spec?
++
+--
+*RESOLVED*
+
+Removed *OpFunctionPointerINTEL* instruction.
+--
+
+
 //. Issue.
 //+
 //--
@@ -336,4 +366,6 @@ be used for ones out of the box and we don't have much use-cases for it.
 |F|2019-06-21|Alexey Sachkov|Added new storage class dedicated for function
 pointers. Updated validation rules. Misc updates.
 |G|2019-07-19|Ben Ashbaugh|Assigned SPIR-V enums, added preview extension disclaimer text.
+|H|2020-07-30|Alex Bezzubikov|Replaced *OpFunctionPointerINTEL* with
+*OpConstFunctionPointerINTEL*
 |========================================


### PR DESCRIPTION
Replace OpFunctionPointerINTEL with a constant one