### PR TITLE
[SYCL] Add copy functions to GroupAlgorithms

### DIFF
--- a/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
+++ b/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
@@ -70,6 +70,8 @@ The extension introduces the following functions:
 - +exclusive_scan+
 - +inclusive_scan+
 - +barrier+
+- +copy_n+
+- +async_copy_n+
 
 The definitions and behavior of the following functions are based on equivalents in the SYCL 2020 provisional specification:
 - +barrier+
@@ -258,6 +260,19 @@ The return types of the collective functions in {cpp}17 are not deduced from the
 |Perform an inclusive scan over the values in the range [_first_, _last_) using the operator _binary_op_, which must be one of the group algorithms library function objects.  The value written to +result + i+ is the inclusive scan of the first +i+ values in the range and an initial value specified by _init_. Returns a pointer to the end of the output range. _first_, _last_, _result_, _binary_op_ and _init_ must be the same for all work-items in the group. _binary_op(init, *first)_ must return a value of type _T_.
 |===
 
+==== Data Movement
+
+|===
+|Function|Description
+
+|+template <typename Group, typename InPtr, typename Size, typename OutPtr> void copy_n(Group g, InPtr first, Size n, OutputPtr result);+
+|Synchronously copies _n_ elements from the source pointer _first_ to the destination pointer _result_.  Returns _result + n_.  _first_, _n_ and _result_ must be the same for all work-items in the group.
+
+|+template <typename Group, typename InPtr, typename Size, typename OutPtr> device_event async_copy_n(Group g, InPtr first, Size n, OutputPtr result);+
+|Asynchronously copies _n_ elements from the source pointer _first_ to the destination pointer _result_.  Returns a +device_event+ which can be used to wait on completion of the copy.  _first_, _n_ and _result_ must be the same for all work-items in the group.
+
+|===
+
 ==== Synchronization
 
 The behavior of memory fences in this section is aligned with the single happens-before relationship defined by the +SYCL_INTEL_extended_atomics+ extension.
@@ -270,6 +285,9 @@ The behavior of memory fences in this section is aligned with the single happens
 
 |+template <typename Group> void barrier(Group g, memory_scope scope);+
 |Synchronize all work-items in the group, and ensure that all memory accesses to any address space prior to the barrier are visible to all work-items specified by _scope_ after the barrier.  The scope of the group memory fences implied by this barrier is controlled by _scope_ and must be broader than the narrowest scope including all work-items in the group.  If the specified _scope_ is narrower than the narrowest scope including all work-items in the group, the _scope_ argument is ignored.
+
+|+template <typename Group, typename... Events> void wait_for(Group g, Events... events);+
+|Waits for the asynchronous operations associated with each +device_event+ to complete.  Every argument in the _Events_ parameter pack must be of type +device_event+, and _events_ must be the same for all work-items in the group.
 
 |===
 
@@ -292,6 +310,7 @@ None.
 |Rev|Date|Author|Changes
 |1|2020-01-30|John Pennycook|*Initial public working draft*
 |2|2020-07-28|John Pennycook|*Add group barrier*
+|3|2020-08-04|John Pennycook|*Add copy_n and async_copy_n*
 |========================================
 
 //************************************************************************

--- a/sycl/doc/extensions/SubGroupAlgorithms/SYCL_INTEL_sub_group_algorithms.asciidoc
+++ b/sycl/doc/extensions/SubGroupAlgorithms/SYCL_INTEL_sub_group_algorithms.asciidoc
@@ -71,6 +71,8 @@ This extension adds sub-group support to all of the functions from +SYCL_INTEL_g
 - +exclusive_scan+
 - +inclusive_scan+
 - +barrier+
+- +copy_n+
+- +async_copy_n+
 
 It additionally introduces a number of functions that are currently specific to sub-groups:
 
@@ -167,6 +169,7 @@ None.
 |Rev|Date|Author|Changes
 |1|2020-03-16|John Pennycook|*Initial public working draft*
 |2|2020-07-28|John Pennycook|*Add group barrier*
+|3|2020-08-04|John Pennycook|*Add copy_n and async_copy_n*
 |========================================
 
 //************************************************************************

--- a/sycl/test/group-algorithm/copy.cpp
+++ b/sycl/test/group-algorithm/copy.cpp
@@ -1,0 +1,91 @@
+// UNSUPPORTED: cuda
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+#include <cassert>
+#include <tuple>
+using namespace sycl;
+using namespace sycl::intel;
+
+template <typename Group> class copy_kernel;
+
+// Returns a tuple of:
+// - The requested group
+// - The size of the requested group
+// - The global offset of the start of the group, for accessing global memory
+// - The local offset of the start of the group, for accessing local memory
+template <typename Group>
+std::tuple<Group, size_t, size_t, size_t> get_copy_args(nd_item<1> it);
+
+template <>
+std::tuple<group<1>, size_t, size_t, size_t>
+get_copy_args<group<1>>(nd_item<1> it) {
+  return {it.get_group(), it.get_local_range()[0],
+          it.get_group(0) * it.get_local_range()[0], 0};
+}
+
+template <>
+std::tuple<sub_group, size_t, size_t, size_t>
+get_copy_args<sub_group>(nd_item<1> it) {
+  sub_group sg = it.get_sub_group();
+  return {sg, sg.get_local_range()[0],
+          it.get_group(0) * it.get_local_range()[0] +
+              sg.get_group_id()[0] * sg.get_max_local_range()[0],
+          sg.get_group_id()[0] * sg.get_max_local_range()[0]};
+}
+
+template <typename Group> void test(queue q, bool async) {
+
+  constexpr size_t N = 32;
+  constexpr size_t L = 16;
+  std::array<int, N> in, out;
+  std::iota(in.begin(), in.end(), 0);
+  std::fill(out.begin(), out.end(), 0);
+  {
+    buffer<int> in_buf(in.data(), range<1>{N});
+    buffer<int> out_buf(out.data(), range<1>{N});
+    q.submit([&](handler &cgh) {
+      auto tmp =
+          accessor<int, 1, access::mode::read_write, access::target::local>(
+              L, cgh);
+      auto in = in_buf.get_access<access::mode::read_write>(cgh);
+      auto out = out_buf.get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<class copy_kernel<Group>>(
+          nd_range<1>(N, L), [=](nd_item<1> it) {
+        auto [g, size, goffset, loffset] = get_copy_args<Group>(it);
+        if (async) {
+          device_event e1 = async_copy_n(g, in.get_pointer() + goffset, size,
+                                         tmp.get_pointer() + loffset);
+          wait_for(g, e1);
+          tmp[it.get_local_linear_id()] += 1;
+          device_event e2 = async_copy_n(g, tmp.get_pointer() + loffset, size,
+                                         out.get_pointer() + goffset);
+          wait_for(g, e2);
+        } else {
+          copy_n(g, in.get_pointer() + goffset, size,
+                 tmp.get_pointer() + loffset);
+          tmp[it.get_local_linear_id()] += 1;
+          copy_n(g, tmp.get_pointer() + loffset, size,
+                 out.get_pointer() + goffset);
+        }
+          });
+    });
+  }
+
+  // Each result should be one greater than before
+  std::array<int, N> gold;
+  std::iota(gold.begin(), gold.end(), 1);
+  assert(std::equal(out.begin(), out.end(), gold.begin()));
+}
+
+int main() {
+  queue q;
+  test<group<1>>(q, true);
+  test<group<1>>(q, false);
+  test<sub_group>(q, true);
+  test<sub_group>(q, false);
+  std::cout << "Test passed." << std::endl;
+}


### PR DESCRIPTION
- copy_n is equivalent to std::copy_n
- async_copy_n replaces sycl::nd_item::async_work_group_copy
- wait_for replaces sycl::nd_item::wait_for