### PR TITLE
[SYCL] Visit explicit dependencies during finished command cleanup

### DIFF
--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -134,6 +134,14 @@ public:
 
   std::shared_ptr<event_impl> getEvent() const { return MEvent; }
 
+  const std::vector<EventImplPtr> &getPreparedDepsEvents() {
+    return MPreparedDepsEvents;
+  }
+
+  const std::vector<EventImplPtr> &getPreparedHostDepsEvents() {
+    return MPreparedHostDepsEvents;
+  }
+
   // Methods needed to support SYCL instrumentation
 
   /// Proxy method which calls emitInstrumentationData.

--- a/sycl/test/scheduler/ReleaseResourcesExplicitDep.cpp
+++ b/sycl/test/scheduler/ReleaseResourcesExplicitDep.cpp
@@ -1,0 +1,42 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out
+// RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
+//==------------------- ReleaseResourcesExplicitDep.cpp --------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+#include "../helpers.hpp"
+
+class KernelNameA;
+class KernelNameB;
+
+// Check that the resources are correctly released for command groups with only
+// explicit dependencies.
+int main() {
+  // CHECK:---> piContextCreate
+  // CHECK:---> piQueueCreate
+  // CHECK:---> piProgramCreate
+
+  // CHECK:---> piKernelCreate
+  // CHECK:---> piEnqueueKernelLaunch
+  sycl::queue Q{sycl::cpu_selector{}};
+  sycl::event EventA = Q.single_task<KernelNameA>([]() {});
+
+  // CHECK:---> piKernelCreate
+  // CHECK:---> piEnqueueKernelLaunch
+  sycl::event EventB = Q.single_task<KernelNameB>(EventA, []() {});
+  EventB.wait();
+}
+
+// CHECK:---> piEventRelease
+// CHECK:---> piEventRelease
+// CHECK:---> piQueueRelease
+// CHECK:---> piProgramRelease
+// CHECK:---> piContextRelease
+// CHECK:---> piKernelRelease
+// CHECK:---> piKernelRelease

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -58,6 +58,10 @@ public:
                           std::function<void()> Callback)
       : MockCommand(Queue, Req), MCallback(std::move(Callback)) {}
 
+  MockCommandWithCallback(cl::sycl::detail::QueueImplPtr Queue,
+                          std::function<void()> Callback)
+      : MockCommand(Queue), MCallback(std::move(Callback)) {}
+
   ~MockCommandWithCallback() override { MCallback(); }
 
 protected:


### PR DESCRIPTION
Previously, only implicit dependencies (represented by DepDesc) of each
command node were visited during finished command cleanup. That meant
that command nodes with no implicit dependencies were never cleaned up
unless waited for directly (via queue::wait or event::wait on that
event). This patch changes graph traversal during cleanup, so that all
command dependencies are visited, whether represented by DepDesc or not.

Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>