### PR TITLE
[SYCL] Check the kernel defined by a named function object  is trivially copyable.

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -690,6 +690,8 @@ private:
   template <typename KernelName, typename KernelType, int Dims>
   void parallel_for_lambda_impl(range<Dims> NumWorkItems,
                                 KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                                        "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -854,6 +856,8 @@ public:
   /// \param KernelFunc is a SYCL kernel function.
   template <typename KernelName = detail::auto_name, typename KernelType>
   void single_task(KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                                        "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -944,6 +948,8 @@ public:
             int Dims>
   void parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
                     KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                                   "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -976,6 +982,8 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   void parallel_for(nd_range<Dims> ExecutionRange, KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                                   "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1281,6 +1289,8 @@ public:
   /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType>
   void single_task(kernel Kernel, KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                                   "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1321,6 +1331,8 @@ public:
             int Dims>
   void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
                     KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                                   "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1356,6 +1368,8 @@ public:
             int Dims>
   void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
                     id<Dims> WorkItemOffset, KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                                   "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1393,6 +1407,8 @@ public:
             int Dims>
   void parallel_for(kernel Kernel, nd_range<Dims> NDRange,
                     KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                                   "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1473,6 +1489,8 @@ public:
   void parallel_for_work_group(kernel Kernel, range<Dims> NumWorkGroups,
                                range<Dims> WorkGroupSize,
                                KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                                   "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -691,7 +691,7 @@ private:
   void parallel_for_lambda_impl(range<Dims> NumWorkItems,
                                 KernelType KernelFunc) {
     static_assert(std::is_trivially_copyable<KernelType>::value,
-                                        "KernelType must be trivially copyable");
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -857,7 +857,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType>
   void single_task(KernelType KernelFunc) {
     static_assert(std::is_trivially_copyable<KernelType>::value,
-                                        "KernelType must be trivially copyable");
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -949,7 +949,7 @@ public:
   void parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
                     KernelType KernelFunc) {
     static_assert(std::is_trivially_copyable<KernelType>::value,
-                                   "KernelType must be trivially copyable");
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -983,7 +983,7 @@ public:
             int Dims>
   void parallel_for(nd_range<Dims> ExecutionRange, KernelType KernelFunc) {
     static_assert(std::is_trivially_copyable<KernelType>::value,
-                                   "KernelType must be trivially copyable");
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1290,7 +1290,7 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType>
   void single_task(kernel Kernel, KernelType KernelFunc) {
     static_assert(std::is_trivially_copyable<KernelType>::value,
-                                   "KernelType must be trivially copyable");
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1332,7 +1332,7 @@ public:
   void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
                     KernelType KernelFunc) {
     static_assert(std::is_trivially_copyable<KernelType>::value,
-                                   "KernelType must be trivially copyable");
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1369,7 +1369,7 @@ public:
   void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
                     id<Dims> WorkItemOffset, KernelType KernelFunc) {
     static_assert(std::is_trivially_copyable<KernelType>::value,
-                                   "KernelType must be trivially copyable");
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1408,7 +1408,7 @@ public:
   void parallel_for(kernel Kernel, nd_range<Dims> NDRange,
                     KernelType KernelFunc) {
     static_assert(std::is_trivially_copyable<KernelType>::value,
-                                   "KernelType must be trivially copyable");
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1490,7 +1490,7 @@ public:
                                range<Dims> WorkGroupSize,
                                KernelType KernelFunc) {
     static_assert(std::is_trivially_copyable<KernelType>::value,
-                                   "KernelType must be trivially copyable");
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1011,6 +1011,8 @@ public:
   detail::enable_if_t<Reduction::accessor_mode == access::mode::read_write &&
                       Reduction::has_fast_atomics && !Reduction::is_usm>
   parallel_for(nd_range<Dims> Range, Reduction Redu, KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                  "KernelType must be trivially copyable");
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
                                           Redu.getUserAccessor());
   }
@@ -1024,6 +1026,8 @@ public:
   detail::enable_if_t<Reduction::accessor_mode == access::mode::read_write &&
                       Reduction::has_fast_atomics && Reduction::is_usm>
   parallel_for(nd_range<Dims> Range, Reduction Redu, KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                  "KernelType must be trivially copyable");
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
                                           Redu.getUSMPointer());
   }
@@ -1043,6 +1047,8 @@ public:
   detail::enable_if_t<Reduction::accessor_mode == access::mode::discard_write &&
                       Reduction::has_fast_atomics>
   parallel_for(nd_range<Dims> Range, Reduction Redu, KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                  "KernelType must be trivially copyable");
     shared_ptr_class<detail::queue_impl> QueueCopy = MQueue;
     auto RWAcc = Redu.getReadWriteScalarAcc(*this);
     intel::detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Redu,
@@ -1100,6 +1106,8 @@ public:
     // the main kernel, but simply generate Range.get_global_range.size() number
     // of partial sums, leaving the reduction work to the additional/aux
     // kernels.
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                  "KernelType must be trivially copyable");
     constexpr bool HFR = Reduction::has_fast_reduce;
     size_t OneElemSize = HFR ? 0 : sizeof(typename Reduction::result_type);
     // TODO: currently the maximal work group size is determined for the given
@@ -1154,6 +1162,8 @@ public:
             int Dims>
   void parallel_for_work_group(range<Dims> NumWorkGroups,
                                KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1187,6 +1197,8 @@ public:
   void parallel_for_work_group(range<Dims> NumWorkGroups,
                                range<Dims> WorkGroupSize,
                                KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1451,6 +1463,8 @@ public:
             int Dims>
   void parallel_for_work_group(kernel Kernel, range<Dims> NumWorkGroups,
                                KernelType KernelFunc) {
+    static_assert(std::is_trivially_copyable<KernelType>::value,
+                  "KernelType must be trivially copyable");
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;


### PR DESCRIPTION
According to SYCL standard, SYCL-2020-provisional specification, the kernel defined by a named function object should be trivially copyable

Signed-off-by: sarathnandu <sarath.nandu.ramachandran.nair@intel.com>