### PR TITLE
[SYCL] Fix race that occurs when using sampler in parallel

### DIFF
--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -16,28 +16,32 @@ namespace detail {
 sampler_impl::sampler_impl(coordinate_normalization_mode normalizationMode,
                            addressing_mode addressingMode,
                            filtering_mode filteringMode)
-    : m_CoordNormMode(normalizationMode), m_AddrMode(addressingMode),
-      m_FiltMode(filteringMode) {}
+    : MCoordNormMode(normalizationMode), MAddrMode(addressingMode),
+      MFiltMode(filteringMode) {}
 
 sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
 
   RT::PiSampler Sampler = pi::cast<RT::PiSampler>(clSampler);
-  m_contextToSampler[syclContext] = Sampler;
+  {
+    std::lock_guard<mutex_class> Lock(MMutex);
+    MContextToSampler[syclContext] = Sampler;
+  }
   const detail::plugin &Plugin = getSyclObjImpl(syclContext)->getPlugin();
   Plugin.call<PiApiKind::piSamplerRetain>(Sampler);
   Plugin.call<PiApiKind::piSamplerGetInfo>(
       Sampler, PI_SAMPLER_INFO_NORMALIZED_COORDS, sizeof(pi_bool),
-      &m_CoordNormMode, nullptr);
+      &MCoordNormMode, nullptr);
   Plugin.call<PiApiKind::piSamplerGetInfo>(
       Sampler, PI_SAMPLER_INFO_ADDRESSING_MODE,
-      sizeof(pi_sampler_addressing_mode), &m_AddrMode, nullptr);
+      sizeof(pi_sampler_addressing_mode), &MAddrMode, nullptr);
   Plugin.call<PiApiKind::piSamplerGetInfo>(Sampler, PI_SAMPLER_INFO_FILTER_MODE,
                                            sizeof(pi_sampler_filter_mode),
-                                           &m_FiltMode, nullptr);
+                                           &MFiltMode, nullptr);
 }
 
 sampler_impl::~sampler_impl() {
-  for (auto &Iter : m_contextToSampler) {
+  std::lock_guard<mutex_class> Lock(MMutex);
+  for (auto &Iter : MContextToSampler) {
     // TODO catch an exception and add it to the list of asynchronous exceptions
     const detail::plugin &Plugin = getSyclObjImpl(Iter.first)->getPlugin();
     Plugin.call<PiApiKind::piSamplerRelease>(Iter.second);
@@ -45,20 +49,24 @@ sampler_impl::~sampler_impl() {
 }
 
 RT::PiSampler sampler_impl::getOrCreateSampler(const context &Context) {
-  if (m_contextToSampler[Context])
-    return m_contextToSampler[Context];
+  RT::PiSampler resultSampler = nullptr;
+  {
+    std::lock_guard<mutex_class> Lock(MMutex);
+    resultSampler = MContextToSampler[Context];
+  }
+  if (resultSampler)
+    return resultSampler;
 
   const pi_sampler_properties sprops[] = {
       PI_SAMPLER_INFO_NORMALIZED_COORDS,
-      static_cast<pi_sampler_properties>(m_CoordNormMode),
+      static_cast<pi_sampler_properties>(MCoordNormMode),
       PI_SAMPLER_INFO_ADDRESSING_MODE,
-      static_cast<pi_sampler_properties>(m_AddrMode),
+      static_cast<pi_sampler_properties>(MAddrMode),
       PI_SAMPLER_INFO_FILTER_MODE,
-      static_cast<pi_sampler_properties>(m_FiltMode),
+      static_cast<pi_sampler_properties>(MFiltMode),
       0};
 
   RT::PiResult errcode_ret = PI_SUCCESS;
-  RT::PiSampler resultSampler = nullptr;
   const detail::plugin &Plugin = getSyclObjImpl(Context)->getPlugin();
 
   errcode_ret = Plugin.call_nocheck<PiApiKind::piSamplerCreate>(
@@ -69,18 +77,19 @@ RT::PiSampler sampler_impl::getOrCreateSampler(const context &Context) {
                                 errcode_ret);
 
   Plugin.checkPiResult(errcode_ret);
-  m_contextToSampler[Context] = resultSampler;
+  std::lock_guard<mutex_class> Lock(MMutex);
+  MContextToSampler[Context] = resultSampler;
 
-  return m_contextToSampler[Context];
+  return resultSampler;
 }
 
-addressing_mode sampler_impl::get_addressing_mode() const { return m_AddrMode; }
+addressing_mode sampler_impl::get_addressing_mode() const { return MAddrMode; }
 
-filtering_mode sampler_impl::get_filtering_mode() const { return m_FiltMode; }
+filtering_mode sampler_impl::get_filtering_mode() const { return MFiltMode; }
 
 coordinate_normalization_mode
 sampler_impl::get_coordinate_normalization_mode() const {
-  return m_CoordNormMode;
+  return MCoordNormMode;
 }
 
 } // namespace detail

--- a/sycl/source/detail/sampler_impl.hpp
+++ b/sycl/source/detail/sampler_impl.hpp
@@ -24,14 +24,6 @@ enum class coordinate_normalization_mode : unsigned int;
 namespace detail {
 class __SYCL_EXPORT sampler_impl {
 public:
-  std::unordered_map<context, RT::PiSampler> m_contextToSampler;
-
-private:
-  coordinate_normalization_mode m_CoordNormMode;
-  addressing_mode m_AddrMode;
-  filtering_mode m_FiltMode;
-
-public:
   sampler_impl(coordinate_normalization_mode normalizationMode,
                addressing_mode addressingMode, filtering_mode filteringMode);
 
@@ -46,6 +38,16 @@ public:
   RT::PiSampler getOrCreateSampler(const context &Context);
 
   ~sampler_impl();
+
+private:
+  /// Protects all the fields that can be changed by class' methods.
+  mutex_class MMutex;
+
+  std::unordered_map<context, RT::PiSampler> MContextToSampler;
+
+  coordinate_normalization_mode MCoordNormMode;
+  addressing_mode MAddrMode;
+  filtering_mode MFiltMode;
 };
 
 } // namespace detail


### PR DESCRIPTION
This patch fixes sporadic hangs caused by data race in m_contextToSampler(MContextToSampler) variable of the sampler_impl class. Adding new elements into this shared map from different threads led to a race.

1. Added missing mutex and lock guards when accessing  m_contextToSampler(MContextToSampler) variable
1. Aligned variables names in the sampler_impl class

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>