### PR TITLE
[WIP][SYCL] Align stream handling with other classes

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -314,6 +314,7 @@ public:
     kind_accessor = kind_first,
     kind_std_layout,
     kind_sampler,
+    kind_stream,
     kind_pointer,
     kind_last = kind_pointer
   };

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -141,6 +141,7 @@ public:
 private:
   void __init(__attribute__((opencl_global)) dataT *Ptr, range<dimensions> AccessRange,
               range<dimensions> MemRange, id<dimensions> Offset) {}
+  friend class stream;
 };
 
 template <int dimensions, access::mode accessmode, access::target accesstarget>
@@ -314,10 +315,22 @@ class stream {
 public:
   stream(unsigned long BufferSize, unsigned long MaxStatementSize,
          handler &CGH) {}
+#ifdef __SYCL_DEVICE_ONLY__
+  // Default constructor for objects later initialized with __init member.
+  stream() = default;
+#endif
 
-  void __init() {}
+  void __init(__attribute((opencl_global)) char *Ptr, range<1> AccessRange,
+              range<1> MemRange, id<1> Offset, int _FlushBufferSize) {
+    Acc.__init(Ptr, AccessRange, MemRange, Offset);
+    FlushBufferSize = _FlushBufferSize;
+  }
 
   void __finalize() {}
+
+private:
+  cl::sycl::accessor<char, 1, cl::sycl::access::mode::read_write> Acc;
+  int FlushBufferSize;
 };
 
 template <typename T>

--- a/clang/test/CodeGenSYCL/stream.cpp
+++ b/clang/test/CodeGenSYCL/stream.cpp
@@ -1,8 +1,16 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -I %S/Inputs -disable-llvm-passes -emit-llvm %s -o %t.ll
 // RUN: FileCheck < %t.ll --enable-var-scope %s
 //
-// CHECK: define spir_kernel void @"{{.*}}StreamTester"(%"{{.*}}cl::sycl::stream"* byval(%"{{.*}}cl::sycl::stream") {{.*}}){{.*}}
-// CHECK: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}cl::sycl::stream{{.*}} addrspace(4)* %{{[0-9]+}})
+// CHECK: %[[RANGE_TYPE:"struct.*cl::sycl::range"]]
+// CHECK: %[[ID_TYPE:"struct.*cl::sycl::id"]]
+// CHECK: define spir_kernel void @{{.*}}StreamTester
+// CHECK-SAME: i8 addrspace(1)* [[ACC_DATA:%[a-zA-Z0-9_]+]],
+// CHECK-SAME: %[[RANGE_TYPE]]* byval(%[[RANGE_TYPE]]) align 4 [[ACC_RANGE1:%[a-zA-Z0-9_]+]],
+// CHECK-SAME: %[[RANGE_TYPE]]* byval(%[[RANGE_TYPE]]) align 4 [[ACC_RANGE2:%[a-zA-Z0-9_]+]],
+// CHECK-SAME: %[[ID_TYPE]]* byval(%[[ID_TYPE]]) align 4 [[ACC_ID:%[a-zA-Z0-9_]+]],
+// CHECK-SAME: i32 [[ARG_INT:%[a-zA-Z0-9_]+]])
+
+// CHECK: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}cl::sycl::stream{{.*}} addrspace(4)* %{{[0-9]+}}, i8 addrspace(1)* %5, %[[RANGE_TYPE]]* byval(%[[RANGE_TYPE]]) {{.*}} %{{.*}}
 // CHECK: call spir_func void @{{.*}}__finalize{{.*}}(%{{.*}}cl::sycl::stream{{.*}} addrspace(4)* %{{[0-9]+}})
 //
 

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -199,6 +199,7 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
+class stream;
 namespace intel {
 namespace gpu {
 // Forward declare a "back-door" access class to support ESIMD.
@@ -886,6 +887,7 @@ public:
 
 private:
   friend class sycl::intel::gpu::AccessorPrivateProxy;
+  friend class sycl::stream;
 
 public:
   using value_type = DataT;

--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -27,6 +27,7 @@ enum class kernel_param_kind_t {
   kind_accessor,
   kind_std_layout, // standard layout object parameters
   kind_sampler,
+  kind_stream,
   kind_pointer
 };
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1652,6 +1652,8 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
   const detail::plugin &Plugin = MQueue->getPlugin();
   for (ArgDesc &Arg : ExecKernel->MArgs) {
     switch (Arg.MType) {
+    case kernel_param_kind_t::kind_stream:
+      break;
     case kernel_param_kind_t::kind_accessor: {
       Requirement *Req = (Requirement *)(Arg.MPtr);
       AllocaCommandBase *AllocaCmd = getAllocaForReq(Req);

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -14,6 +14,7 @@
 #include <CL/sycl/event.hpp>
 #include <CL/sycl/handler.hpp>
 #include <CL/sycl/info/info_desc.hpp>
+#include <CL/sycl/stream.hpp>
 #include <detail/kernel_impl.hpp>
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/scheduler.hpp>
@@ -130,6 +131,41 @@ void handler::associateWithHandler(detail::AccessorBaseHost *AccBase,
                                    /*index*/ 0);
 }
 
+static void addArgsForGlobalAccessor(detail::Requirement *AccImpl,
+                                     const size_t Index, size_t &IndexShift,
+                                     const int Size,
+                                     bool IsKernelCreatedFromSource,
+                                     size_t GlobalSize,
+                                     vector_class<detail::ArgDesc> &Args) {
+  using detail::kernel_param_kind_t;
+  if (AccImpl->PerWI)
+    AccImpl->resize(GlobalSize);
+
+  Args.emplace_back(kernel_param_kind_t::kind_accessor, AccImpl, Size,
+                    Index + IndexShift);
+
+  // TODO ESIMD currently does not suport offset, memory and access ranges -
+  // accessor::init for ESIMD-mode accessor has a single field, translated
+  // to a single kernel argument set above.
+  if (!AccImpl->MIsESIMDAcc && !IsKernelCreatedFromSource) {
+    // Dimensionality of the buffer is 1 when dimensionality of the
+    // accessor is 0.
+    const size_t SizeAccField =
+        sizeof(size_t) * (AccImpl->MDims == 0 ? 1 : AccImpl->MDims);
+    ++IndexShift;
+    Args.emplace_back(kernel_param_kind_t::kind_std_layout,
+                      &AccImpl->MAccessRange[0], SizeAccField,
+                      Index + IndexShift);
+    ++IndexShift;
+    Args.emplace_back(kernel_param_kind_t::kind_std_layout,
+                      &AccImpl->MMemoryRange[0], SizeAccField,
+                      Index + IndexShift);
+    ++IndexShift;
+    Args.emplace_back(kernel_param_kind_t::kind_std_layout,
+                      &AccImpl->MOffset[0], SizeAccField, Index + IndexShift);
+  }
+}
+
 void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
                          const int Size, const size_t Index, size_t &IndexShift,
                          bool IsKernelCreatedFromSource) {
@@ -141,6 +177,40 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
     MArgs.emplace_back(Kind, Ptr, Size, Index + IndexShift);
     break;
   }
+  case kernel_param_kind_t::kind_stream: {
+    // Stream contains several accessors inside.
+    stream *S = static_cast<stream *>(Ptr);
+
+    detail::AccessorBaseHost *GBufBase =
+        (detail::AccessorBaseHost *)&S->GlobalBuf;
+    detail::AccessorImplPtr GBufImpl = detail::getSyclObjImpl(*GBufBase);
+    detail::Requirement *GBufReq = GBufImpl.get();
+    addArgsForGlobalAccessor(GBufReq, Index, IndexShift, Size,
+                             IsKernelCreatedFromSource,
+                             MNDRDesc.GlobalSize.size(), MArgs);
+    ++IndexShift;
+    detail::AccessorBaseHost *GOffsetBase =
+        (detail::AccessorBaseHost *)&S->GlobalOffset;
+    detail::AccessorImplPtr GOfssetImpl = detail::getSyclObjImpl(*GOffsetBase);
+    detail::Requirement *GOffsetReq = GOfssetImpl.get();
+    addArgsForGlobalAccessor(GOffsetReq, Index, IndexShift, Size,
+                             IsKernelCreatedFromSource,
+                             MNDRDesc.GlobalSize.size(), MArgs);
+    ++IndexShift;
+    detail::AccessorBaseHost *GFlushBase =
+        (detail::AccessorBaseHost *)&S->GlobalFlushBuf;
+    detail::AccessorImplPtr GFlushImpl = detail::getSyclObjImpl(*GFlushBase);
+    detail::Requirement *GFlushReq = GFlushImpl.get();
+    addArgsForGlobalAccessor(GFlushReq, Index, IndexShift, Size,
+                             IsKernelCreatedFromSource,
+                             MNDRDesc.GlobalSize.size(), MArgs);
+    ++IndexShift;
+    MArgs.emplace_back(kernel_param_kind_t::kind_std_layout,
+                       &S->FlushBufferSize, sizeof(S->FlushBufferSize),
+                       Index + IndexShift);
+
+    break;
+  }
   case kernel_param_kind_t::kind_accessor: {
     // For args kind of accessor Size is information about accessor.
     // The first 11 bits of Size encodes the accessor target.
@@ -149,37 +219,9 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
     case access::target::global_buffer:
     case access::target::constant_buffer: {
       detail::Requirement *AccImpl = static_cast<detail::Requirement *>(Ptr);
-
-      // Stream implementation creates an accessor with initial size for
-      // work item. Number of work items is not available during
-      // stream construction, that is why size of the accessor is updated here
-      // using information about number of work items.
-      if (AccImpl->PerWI) {
-        AccImpl->resize(MNDRDesc.GlobalSize.size());
-      }
-      MArgs.emplace_back(Kind, AccImpl, Size, Index + IndexShift);
-
-      // TODO ESIMD currently does not suport offset, memory and access ranges -
-      // accessor::init for ESIMD-mode accessor has a single field, translated
-      // to a single kernel argument set above.
-      if (!AccImpl->MIsESIMDAcc && !IsKernelCreatedFromSource) {
-        // Dimensionality of the buffer is 1 when dimensionality of the
-        // accessor is 0.
-        const size_t SizeAccField =
-            sizeof(size_t) * (AccImpl->MDims == 0 ? 1 : AccImpl->MDims);
-        ++IndexShift;
-        MArgs.emplace_back(kernel_param_kind_t::kind_std_layout,
-                           &AccImpl->MAccessRange[0], SizeAccField,
-                           Index + IndexShift);
-        ++IndexShift;
-        MArgs.emplace_back(kernel_param_kind_t::kind_std_layout,
-                           &AccImpl->MMemoryRange[0], SizeAccField,
-                           Index + IndexShift);
-        ++IndexShift;
-        MArgs.emplace_back(kernel_param_kind_t::kind_std_layout,
-                           &AccImpl->MOffset[0], SizeAccField,
-                           Index + IndexShift);
-      }
+      addArgsForGlobalAccessor(AccImpl, Index, IndexShift, Size,
+                               IsKernelCreatedFromSource,
+                               MNDRDesc.GlobalSize.size(), MArgs);
       break;
     }
     case access::target::local: {


### PR DESCRIPTION
This change simplifies FE handling of stream class and makes it
identical to handling of accessor and sampler classes. Stream class is not
handled as wrapper struct for several accessors anymore and initialized
within __init method instead.

This is part of job about adding an attribute to annotate special sycl types
and unifying handling of sycl classes by FE. See https://github.com/intel/llvm/pull/2091#discussion_r461743627
for the full idea.