### PR TITLE
[SYCL] Translating annotations for functions

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVReader.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVReader.cpp
@@ -3192,32 +3192,7 @@ bool SPIRVToLLVM::translate() {
   }
 
   for (unsigned I = 0, E = BM->getNumFunctions(); I != E; ++I) {
-    auto Fun = BM->getFunction(I);
-    auto transFun = transFunction(Fun);
-    for (auto UsSem : Fun->getDecorationStringLiteral(DecorationUserSemantic)) {
-      auto vFun = dyn_cast<Value>(transFun);
-      Constant *StrConstant =
-          ConstantDataArray::getString(*Context, StringRef(UsSem));
-      auto *GS = new GlobalVariable(
-          *transFun->getParent(), StrConstant->getType(),
-          /*IsConstant*/ true, GlobalValue::PrivateLinkage, StrConstant, "");
-
-      GS->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
-      GS->setSection("llvm.metadata");
-
-      Type *ResType = PointerType::getInt8PtrTy(
-          vFun->getContext(), vFun->getType()->getPointerAddressSpace());
-      Constant *C =
-          ConstantExpr::getPointerBitCastOrAddrSpaceCast(transFun, ResType);
-
-      Type *Int8PtrTyPrivate = Type::getInt8PtrTy(*Context, SPIRAS_Private);
-      IntegerType *Int32Ty = Type::getInt32Ty(*Context);
-
-      llvm::Constant *Fields[4] = {
-          C, ConstantExpr::getBitCast(GS, Int8PtrTyPrivate),
-          UndefValue::get(Int8PtrTyPrivate), UndefValue::get(Int32Ty)};
-      GlobalAnnotations.push_back(ConstantStruct::getAnon(Fields));
-    }
+    transUserSemantic(I);
   }
 
   transGlobalAnnotations();
@@ -3481,6 +3456,35 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
         C, ConstantExpr::getBitCast(GS, Int8PtrTyPrivate),
         UndefValue::get(Int8PtrTyPrivate), UndefValue::get(Int32Ty)};
 
+    GlobalAnnotations.push_back(ConstantStruct::getAnon(Fields));
+  }
+}
+
+void SPIRVToLLVM::transUserSemantic(unsigned FunNum) {
+  auto Fun = BM->getFunction(FunNum);
+  auto transFun = transFunction(Fun);
+  for (auto UsSem : Fun->getDecorationStringLiteral(DecorationUserSemantic)) {
+    auto vFun = dyn_cast<Value>(transFun);
+    Constant *StrConstant =
+        ConstantDataArray::getString(*Context, StringRef(UsSem));
+    auto *GS = new GlobalVariable(
+        *transFun->getParent(), StrConstant->getType(),
+        /*IsConstant*/ true, GlobalValue::PrivateLinkage, StrConstant, "");
+
+    GS->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+    GS->setSection("llvm.metadata");
+
+    Type *ResType = PointerType::getInt8PtrTy(
+        vFun->getContext(), vFun->getType()->getPointerAddressSpace());
+    Constant *C =
+        ConstantExpr::getPointerBitCastOrAddrSpaceCast(transFun, ResType);
+
+    Type *Int8PtrTyPrivate = Type::getInt8PtrTy(*Context, SPIRAS_Private);
+    IntegerType *Int32Ty = Type::getInt32Ty(*Context);
+
+    llvm::Constant *Fields[4] = {
+        C, ConstantExpr::getBitCast(GS, Int8PtrTyPrivate),
+        UndefValue::get(Int8PtrTyPrivate), UndefValue::get(Int32Ty)};
     GlobalAnnotations.push_back(ConstantStruct::getAnon(Fields));
   }
 }

--- a/llvm-spirv/lib/SPIRV/SPIRVReader.h
+++ b/llvm-spirv/lib/SPIRV/SPIRVReader.h
@@ -266,7 +266,7 @@ private:
   Instruction *transOCLAllAny(SPIRVInstruction *BI, BasicBlock *BB);
   Instruction *transOCLRelational(SPIRVInstruction *BI, BasicBlock *BB);
 
-  void transUserSemantic(SPIRV::SPIRVFunction* Fun);
+  void transUserSemantic(SPIRV::SPIRVFunction *Fun);
   void transGlobalAnnotations();
   void transIntelFPGADecorations(SPIRVValue *BV, Value *V);
 }; // class SPIRVToLLVM

--- a/llvm-spirv/lib/SPIRV/SPIRVReader.h
+++ b/llvm-spirv/lib/SPIRV/SPIRVReader.h
@@ -266,7 +266,7 @@ private:
   Instruction *transOCLAllAny(SPIRVInstruction *BI, BasicBlock *BB);
   Instruction *transOCLRelational(SPIRVInstruction *BI, BasicBlock *BB);
 
-  void transUserSemantic(unsigned FunNum);
+  void transUserSemantic(SPIRV::SPIRVFunction* Fun);
   void transGlobalAnnotations();
   void transIntelFPGADecorations(SPIRVValue *BV, Value *V);
 }; // class SPIRVToLLVM

--- a/llvm-spirv/lib/SPIRV/SPIRVReader.h
+++ b/llvm-spirv/lib/SPIRV/SPIRVReader.h
@@ -266,6 +266,7 @@ private:
   Instruction *transOCLAllAny(SPIRVInstruction *BI, BasicBlock *BB);
   Instruction *transOCLRelational(SPIRVInstruction *BI, BasicBlock *BB);
 
+  void transUserSemantic(unsigned FunNum);
   void transGlobalAnnotations();
   void transIntelFPGADecorations(SPIRVValue *BV, Value *V);
 }; // class SPIRVToLLVM

--- a/llvm-spirv/test/transcoding/GlobalFunAnnotate.ll
+++ b/llvm-spirv/test/transcoding/GlobalFunAnnotate.ll
@@ -1,0 +1,58 @@
+;RUN: llvm-as %s -o %t.bc
+;RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+;RUN: llvm-spirv %t.bc -o %t.spt
+;RUN: llvm-spirv -r %t.spt -o %t.rev.bc
+;RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+;CHECK-SPIRV: Decorate {{[0-9]+}} UserSemantic "annotation_on_variable"
+;CHECK-SPIRV: Decorate {{[0-9]+}} UserSemantic "annotation_on_function"
+
+;CHECK-LLVM: @llvm.global.annotations  = appending global [1 x { i8*, i8*, i8*, i32 }] [{ i8*, i8*, i8*, i32 } { i8* bitcast (void ()* @foo to i8*), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @1, i32 0, i32 0), i8* undef, i32 undef }], section "llvm.metadata"
+
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-linux-sycldevice"
+
+@.str = private unnamed_addr constant [23 x i8] c"annotation_on_variable\00", section "llvm.metadata"
+@.str.1 = private unnamed_addr constant [6 x i8] c"an.cl\00", section "llvm.metadata"
+@.str.2 = private unnamed_addr constant [23 x i8] c"annotation_on_function\00", section "llvm.metadata"
+@llvm.global.annotations = appending global [1 x { i8*, i8*, i8*, i32 }] [{ i8*, i8*, i8*, i32 } { i8* bitcast (void ()* @foo to i8*), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str.2, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str.1, i32 0, i32 0), i32 2 }], section "llvm.metadata"
+
+; Function Attrs: convergent norecurse nounwind
+define dso_local spir_func void @foo() #0 {
+entry:
+  %v = alloca i32, align 4
+  %0 = bitcast i32* %v to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #3
+  %v1 = bitcast i32* %v to i8*
+  call void @llvm.var.annotation(i8* %v1, i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str.1, i32 0, i32 0), i32 3)
+  %1 = bitcast i32* %v to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %1) #3
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: nounwind willreturn
+declare void @llvm.var.annotation(i8*, i8*, i8*, i32) #2
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+attributes #0 = { convergent norecurse nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { argmemonly nounwind willreturn }
+attributes #2 = { nounwind willreturn }
+attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!2, !2}
+!spirv.Source = !{!3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 0}
+!2 = !{i32 1, i32 2}
+!3 = !{i32 4, i32 100000}
+!4 = !{!"clang version 12.0.0 (https://github.com/c199914007/llvm.git 0b8947a9dbffb6911a5cd00b2cad98d885747c78)"}

--- a/llvm-spirv/test/transcoding/GlobalFunAnnotate.ll
+++ b/llvm-spirv/test/transcoding/GlobalFunAnnotate.ll
@@ -1,10 +1,10 @@
 ;RUN: llvm-as %s -o %t.bc
-;RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-;RUN: llvm-spirv %t.bc -o %t.spt
-;RUN: llvm-spirv -r %t.spt -o %t.rev.bc
+;RUN: llvm-spirv %t.bc -o %t.spv
+;RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+;RUN: llvm-spirv %t.bc -o %t.spv
+;RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ;RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
-;CHECK-SPIRV: Decorate {{[0-9]+}} UserSemantic "annotation_on_variable"
 ;CHECK-SPIRV: Decorate {{[0-9]+}} UserSemantic "annotation_on_function"
 
 ;CHECK-LLVM: @llvm.global.annotations  = appending global [1 x { i8*, i8*, i8*, i32 }] [{ i8*, i8*, i8*, i32 } { i8* bitcast (void ()* @foo to i8*), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @1, i32 0, i32 0), i8* undef, i32 undef }], section "llvm.metadata"

--- a/llvm-spirv/test/transcoding/GlobalFunAnnotate.ll
+++ b/llvm-spirv/test/transcoding/GlobalFunAnnotate.ll
@@ -1,49 +1,28 @@
 ;RUN: llvm-as %s -o %t.bc
 ;RUN: llvm-spirv %t.bc -o %t.spv
 ;RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-;RUN: llvm-spirv %t.bc -o %t.spv
 ;RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ;RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ;CHECK-SPIRV: Decorate {{[0-9]+}} UserSemantic "annotation_on_function"
 
-;CHECK-LLVM: @llvm.global.annotations  = appending global [1 x { i8*, i8*, i8*, i32 }] [{ i8*, i8*, i8*, i32 } { i8* bitcast (void ()* @foo to i8*), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @1, i32 0, i32 0), i8* undef, i32 undef }], section "llvm.metadata"
-
+;CHECK-LLVM: @0 = private unnamed_addr constant [23 x i8] c"annotation_on_function\00", section "llvm.metadata"
+;CHECK-LLVM: @llvm.global.annotations = appending global [1 x { i8*, i8*, i8*, i32 }] [{ i8*, i8*, i8*, i32 } { i8* bitcast (void ()* @foo to i8*), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @0, i32 0, i32 0), i8* undef, i32 undef }], section "llvm.metadata"
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-linux-sycldevice"
 
-@.str = private unnamed_addr constant [23 x i8] c"annotation_on_variable\00", section "llvm.metadata"
+@.str = private unnamed_addr constant [23 x i8] c"annotation_on_function\00", section "llvm.metadata"
 @.str.1 = private unnamed_addr constant [6 x i8] c"an.cl\00", section "llvm.metadata"
-@.str.2 = private unnamed_addr constant [23 x i8] c"annotation_on_function\00", section "llvm.metadata"
-@llvm.global.annotations = appending global [1 x { i8*, i8*, i8*, i32 }] [{ i8*, i8*, i8*, i32 } { i8* bitcast (void ()* @foo to i8*), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str.2, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str.1, i32 0, i32 0), i32 2 }], section "llvm.metadata"
+@llvm.global.annotations = appending global [1 x { i8*, i8*, i8*, i32 }] [{ i8*, i8*, i8*, i32 } { i8* bitcast (void ()* @foo to i8*), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str.1, i32 0, i32 0), i32 2 }], section "llvm.metadata"
 
 ; Function Attrs: convergent norecurse nounwind
 define dso_local spir_func void @foo() #0 {
 entry:
-  %v = alloca i32, align 4
-  %0 = bitcast i32* %v to i8*
-  call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #3
-  %v1 = bitcast i32* %v to i8*
-  call void @llvm.var.annotation(i8* %v1, i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str.1, i32 0, i32 0), i32 3)
-  %1 = bitcast i32* %v to i8*
-  call void @llvm.lifetime.end.p0i8(i64 4, i8* %1) #3
   ret void
 }
 
-; Function Attrs: argmemonly nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
-
-; Function Attrs: nounwind willreturn
-declare void @llvm.var.annotation(i8*, i8*, i8*, i32) #2
-
-; Function Attrs: argmemonly nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
-
 attributes #0 = { convergent norecurse nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { argmemonly nounwind willreturn }
-attributes #2 = { nounwind willreturn }
-attributes #3 = { nounwind }
 
 !llvm.module.flags = !{!0}
 !opencl.ocl.version = !{!1}
@@ -55,4 +34,4 @@ attributes #3 = { nounwind }
 !1 = !{i32 1, i32 0}
 !2 = !{i32 1, i32 2}
 !3 = !{i32 4, i32 100000}
-!4 = !{!"clang version 12.0.0 (https://github.com/c199914007/llvm.git 0b8947a9dbffb6911a5cd00b2cad98d885747c78)"}
+!4 = !{!"clang version 12.0.0 (https://github.com/c199914007/llvm.git 074e97d48896b959dfc832e2f1dd806796cde390)"}


### PR DESCRIPTION
Implementation of saving llvm.global.annotations for functions after SPIRV translation
Add test for this

Signed-off-by: amochalo anastasiya.mochalova@intel.com