### PR TITLE
[SYCL] Fix hang in ProgramManager class

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -982,7 +982,6 @@ void ProgramManager::flushSpecConstants(const program_impl &Prg,
   if (!Img) {
     // caller hasn't provided the image object - find it
     { // make sure NativePrograms map access is synchronized
-      ContextImplPtr Ctx = getSyclObjImpl(Prg.get_context());
       std::lock_guard<mutex_class> Lock(MMutex);
       auto It = NativePrograms.find(NativePrg);
       if (It == NativePrograms.end())

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -330,7 +330,7 @@ RT::PiProgram ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
           : createBinaryProgram(Ctx, RawImg.BinaryStart, ImgSize);
 
   {
-    auto LockGuard = Ctx->getKernelProgramCache().acquireCachedPrograms();
+    std::lock_guard<mutex_class> Lock(MMutex);
     // associate the PI program with the image it was created for
     NativePrograms[Res] = &Img;
   }
@@ -983,7 +983,7 @@ void ProgramManager::flushSpecConstants(const program_impl &Prg,
     // caller hasn't provided the image object - find it
     { // make sure NativePrograms map access is synchronized
       ContextImplPtr Ctx = getSyclObjImpl(Prg.get_context());
-      auto LockGuard = Ctx->getKernelProgramCache().acquireCachedPrograms();
+      std::lock_guard<mutex_class> Lock(MMutex);
       auto It = NativePrograms.find(NativePrg);
       if (It == NativePrograms.end())
         throw sycl::experimental::spec_const_error(

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -330,7 +330,7 @@ RT::PiProgram ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
           : createBinaryProgram(Ctx, RawImg.BinaryStart, ImgSize);
 
   {
-    std::lock_guard<mutex_class> Lock(MMutex);
+    std::lock_guard<mutex_class> Lock(MNativeProgramsMutex);
     // associate the PI program with the image it was created for
     NativePrograms[Res] = &Img;
   }
@@ -982,7 +982,7 @@ void ProgramManager::flushSpecConstants(const program_impl &Prg,
   if (!Img) {
     // caller hasn't provided the image object - find it
     { // make sure NativePrograms map access is synchronized
-      std::lock_guard<mutex_class> Lock(MMutex);
+      std::lock_guard<mutex_class> Lock(MNativeProgramsMutex);
       auto It = NativePrograms.find(NativePrg);
       if (It == NativePrograms.end())
         throw sycl::experimental::spec_const_error(

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -330,7 +330,7 @@ RT::PiProgram ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
           : createBinaryProgram(Ctx, RawImg.BinaryStart, ImgSize);
 
   {
-    std::lock_guard<mutex_class> Lock(MNativeProgramsMutex);
+    std::lock_guard<std::mutex> Lock(MNativeProgramsMutex);
     // associate the PI program with the image it was created for
     NativePrograms[Res] = &Img;
   }
@@ -982,7 +982,7 @@ void ProgramManager::flushSpecConstants(const program_impl &Prg,
   if (!Img) {
     // caller hasn't provided the image object - find it
     { // make sure NativePrograms map access is synchronized
-      std::lock_guard<mutex_class> Lock(MNativeProgramsMutex);
+      std::lock_guard<std::mutex> Lock(MNativeProgramsMutex);
       auto It = NativePrograms.find(NativePrg);
       if (It == NativePrograms.end())
         throw sycl::experimental::spec_const_error(

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -181,11 +181,11 @@ private:
   // NOTE: keys in the map can be invalid (reference count went to zero and
   // the underlying program disposed of), so the map can't be used in any way
   // other than binary image lookup with known live PiProgram as the key.
-  // NOTE: access is synchronized via the MMutex
+  // NOTE: access is synchronized via the MNativeProgramsMutex
   std::unordered_map<pi::PiProgram, const RTDeviceBinaryImage *> NativePrograms;
 
   /// Protects NativePrograms that can be changed by class' methods.
-  mutex_class MMutex;
+  mutex_class MNativeProgramsMutex;
   /// True iff a SPIRV file has been specified with an environment variable
   bool m_UseSpvFile = false;
 };

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -181,9 +181,11 @@ private:
   // NOTE: keys in the map can be invalid (reference count went to zero and
   // the underlying program disposed of), so the map can't be used in any way
   // other than binary image lookup with known live PiProgram as the key.
-  // NOTE: access is synchronized via the same lock as program cache
+  // NOTE: access is synchronized via the MMutex
   std::unordered_map<pi::PiProgram, const RTDeviceBinaryImage *> NativePrograms;
 
+  /// Protects NativePrograms that can be changed by class' methods.
+  mutex_class MMutex;
   /// True iff a SPIRV file has been specified with an environment variable
   bool m_UseSpvFile = false;
 };

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -185,7 +185,7 @@ private:
   std::unordered_map<pi::PiProgram, const RTDeviceBinaryImage *> NativePrograms;
 
   /// Protects NativePrograms that can be changed by class' methods.
-  mutex_class MNativeProgramsMutex;
+  std::mutex MNativeProgramsMutex;
   /// True iff a SPIRV file has been specified with an environment variable
   bool m_UseSpvFile = false;
 };


### PR DESCRIPTION
This patch fixes sporadic hangs caused by data race in NativePrograms variable of the ProgramManager class. 
The current mutex lock from the program cache is not thread-safe.
When multiple threads use their own queues then they use different contexts and then they use their own program caches.
And since multiple threads can queue own command of kernel execution in parallel, 
then each thread will lock its own program cache mutex but the access into NativePrograms variable remains with a race between the threads.

- Added separate mutex and lock guards when accessing NativePrograms variable



Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>