### PR TITLE
[SYCL] Unify usm memcpy/memset behavior for corner cases

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1733,7 +1733,7 @@ public:
   /// Copies data from one memory region to another, both pointed by
   /// USM pointers.
   /// No operations is done if \param Count is zero. An exception is thrown
-  /// if either \param Dest or \param Src is nullptr. The behavoir is undefined
+  /// if either \param Dest or \param Src is nullptr. The behavior is undefined
   /// if any of the pointer parameters is invalid.
   ///
   /// \param Dest is a USM pointer to the destination memory.
@@ -1743,7 +1743,7 @@ public:
 
   /// Fills the memory pointed by a USM pointer with the value specified.
   /// No operations is done if \param Count is zero. An exception is thrown
-  /// if \param Dest is nullptr. The behavoir is undefined if \param Dest
+  /// if \param Dest is nullptr. The behavior is undefined if \param Dest
   /// is invalid.
   ///
   /// \param Dest is a USM pointer to the memory to fill.

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1732,6 +1732,9 @@ public:
 
   /// Copies data from one memory region to another, both pointed by
   /// USM pointers.
+  /// No operations is done if \param Count is zero. An exception is thrown
+  /// if either \param Dest or \param Src is nullptr. The behavoir is undefined
+  /// if any of the pointer parameters is invalid.
   ///
   /// \param Dest is a USM pointer to the destination memory.
   /// \param Src is a USM pointer to the source memory.
@@ -1739,6 +1742,9 @@ public:
   void memcpy(void *Dest, const void *Src, size_t Count);
 
   /// Fills the memory pointed by a USM pointer with the value specified.
+  /// No operations is done if \param Count is zero. An exception is thrown
+  /// if \param Dest is nullptr. The behavoir is undefined if \param Dest
+  /// is invalid.
   ///
   /// \param Dest is a USM pointer to the memory to fill.
   /// \param Value is a value to be set. Value is cast as an unsigned char.

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -321,7 +321,7 @@ public:
 
   /// Fills the memory pointed by a USM pointer with the value specified.
   /// No operations is done if \param Count is zero. An exception is thrown
-  /// if \param Dest is nullptr. The behavoir is undefined if \param Ptr
+  /// if \param Dest is nullptr. The behavior is undefined if \param Ptr
   /// is invalid.
   ///
   /// \param Ptr is a USM pointer to the memory to fill.
@@ -333,7 +333,7 @@ public:
   /// Copies data from one memory region to another, both pointed by
   /// USM pointers.
   /// No operations is done if \param Count is zero. An exception is thrown
-  /// if either \param Dest or \param Src is nullptr. The behavoir is undefined
+  /// if either \param Dest or \param Src is nullptr. The behavior is undefined
   /// if any of the pointer parameters is invalid.
   ///
   /// \param Dest is a USM pointer to the destination memory.

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -320,6 +320,9 @@ public:
   template <typename PropertyT> PropertyT get_property() const;
 
   /// Fills the memory pointed by a USM pointer with the value specified.
+  /// No operations is done if \param Count is zero. An exception is thrown
+  /// if \param Dest is nullptr. The behavoir is undefined if \param Ptr
+  /// is invalid.
   ///
   /// \param Ptr is a USM pointer to the memory to fill.
   /// \param Value is a value to be set. Value is cast as an unsigned char.
@@ -329,6 +332,9 @@ public:
 
   /// Copies data from one memory region to another, both pointed by
   /// USM pointers.
+  /// No operations is done if \param Count is zero. An exception is thrown
+  /// if either \param Dest or \param Src is nullptr. The behavoir is undefined
+  /// if any of the pointer parameters is invalid.
   ///
   /// \param Dest is a USM pointer to the destination memory.
   /// \param Src is a USM pointer to the source memory.

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -541,6 +541,12 @@ void MemoryManager::copy_usm(const void *SrcMem, QueueImplPtr SrcQueue,
                              size_t Len, void *DstMem,
                              std::vector<RT::PiEvent> DepEvents,
                              RT::PiEvent &OutEvent) {
+  if (!Len)
+    return;
+  if (!SrcMem || !DstMem)
+    throw runtime_error("NULL pointer argument in memory copy operation.",
+                        PI_INVALID_VALUE);
+
   sycl::context Context = SrcQueue->get_context();
 
   if (Context.is_host()) {
@@ -557,6 +563,12 @@ void MemoryManager::copy_usm(const void *SrcMem, QueueImplPtr SrcQueue,
 void MemoryManager::fill_usm(void *Mem, QueueImplPtr Queue, size_t Length,
                              int Pattern, std::vector<RT::PiEvent> DepEvents,
                              RT::PiEvent &OutEvent) {
+  if (!Length)
+    return;
+  if (!Mem)
+    throw runtime_error("NULL pointer argument in memory fill operation.",
+                        PI_INVALID_VALUE);
+
   sycl::context Context = Queue->get_context();
 
   if (Context.is_host()) {

--- a/sycl/test/usm/memcpy.cpp
+++ b/sycl/test/usm/memcpy.cpp
@@ -11,6 +11,7 @@
 // https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t1.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 
@@ -58,6 +59,13 @@ int main() {
       assert(false && "Expected error from copying to nullptr");
     } catch (runtime_error e) {
     }
+
+    // Copying to nullptr is skipped if the number of bytes to copy is 0.
+    q.submit([&](handler &cgh) {
+      cgh.memcpy(nullptr, src, 0);
+    });
+    q.wait_and_throw();
   }
+  std::cout << "Passed\n";
   return 0;
 }

--- a/sycl/test/usm/memcpy.cpp
+++ b/sycl/test/usm/memcpy.cpp
@@ -61,9 +61,7 @@ int main() {
     }
 
     // Copying to nullptr is skipped if the number of bytes to copy is 0.
-    q.submit([&](handler &cgh) {
-      cgh.memcpy(nullptr, src, 0);
-    });
+    q.submit([&](handler &cgh) { cgh.memcpy(nullptr, src, 0); });
     q.wait_and_throw();
   }
   std::cout << "Passed\n";

--- a/sycl/test/usm/memset.cpp
+++ b/sycl/test/usm/memset.cpp
@@ -4,6 +4,7 @@
 // https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 
@@ -54,6 +55,13 @@ int main() {
       assert(false && "Expected error from writing to nullptr");
     } catch (runtime_error e) {
     }
+
+    // Filling to nullptr is skipped if the number of bytes to fill is 0.
+    q.submit([&](handler &cgh) {
+      cgh.memset(nullptr, 0, 0);
+    });
+    q.wait_and_throw();
   }
+  std::cout << "Passed\n";
   return 0;
 }

--- a/sycl/test/usm/memset.cpp
+++ b/sycl/test/usm/memset.cpp
@@ -57,9 +57,7 @@ int main() {
     }
 
     // Filling to nullptr is skipped if the number of bytes to fill is 0.
-    q.submit([&](handler &cgh) {
-      cgh.memset(nullptr, 0, 0);
-    });
+    q.submit([&](handler &cgh) { cgh.memset(nullptr, 0, 0); });
     q.wait_and_throw();
   }
   std::cout << "Passed\n";

--- a/sycl/test/usm/queue_wait.cpp
+++ b/sycl/test/usm/queue_wait.cpp
@@ -21,7 +21,6 @@ using namespace cl::sycl;
 int main() {
   const std::size_t Size = 32;
   queue Q;
-  std::cout << Q.is_host() << std::endl;
   device Dev = Q.get_device();
   context Ctx = Q.get_context();
   if (!(Dev.get_info<info::device::usm_device_allocations>() &&
@@ -38,11 +37,28 @@ int main() {
   Q.memcpy(HostArr, DevArr, Size);
   Q.wait();
 
+  try {
+    Q.memset(nullptr, 42, Size);
+    Q.wait_and_throw();
+  } catch (runtime_error e) {
+  }
+  try {
+    Q.memcpy(nullptr, DevArr, Size);
+    Q.wait_and_throw();
+  } catch (runtime_error e) {
+  }
+
+  Q.memset(nullptr, 42, 0);
+  Q.wait();
+  Q.memcpy(nullptr, DevArr, 0);
+  Q.wait();
+
   for (std::size_t i = 0; i < Size; ++i)
     assert(HostArr[i] == 42);
 
   free(DevArr, Ctx);
   free(HostArr, Ctx);
 
+  std::cout << "Passed\n";
   return 0;
 }

--- a/sycl/test/usm/queue_wait.cpp
+++ b/sycl/test/usm/queue_wait.cpp
@@ -40,11 +40,13 @@ int main() {
   try {
     Q.memset(nullptr, 42, Size);
     Q.wait_and_throw();
+    assert(false && "Expected to have an exception throw instead of assert");
   } catch (runtime_error e) {
   }
   try {
     Q.memcpy(nullptr, DevArr, Size);
     Q.wait_and_throw();
+    assert(false && "Expected to have an exception throw instead of assert");
   } catch (runtime_error e) {
   }
 


### PR DESCRIPTION
This patch handles queue::memcpy, queue::memset, handler::memcpy,
handler::memset.

Currently, queue::memcpy(nullptr, s, num_bytes) gives SegFault for HOST
and exception throw for CPU/GPU. With this patch an exception is thrown
ealier for all devices. Same for memset.

The call of queue::memcpy(nullptr, s, 0) is skipped before such call reaches device.
That is in sync with std::memcpy(nullptr, s, 0), which is deleted by clang/gcc
even with -O0 when num_of_bytes is statically known to be 0.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>