### PR TITLE
[SYCL] [NFC] Make instance variable in scheduler singleton

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -431,7 +431,9 @@ public:
 
 protected:
   Scheduler();
-  static Scheduler instance;
+  static std::atomic<Scheduler *> instance;
+
+  static void setInstance(Scheduler *);
 
   /// Provides exclusive access to std::shared_timed_mutex object with deadlock
   /// avoidance


### PR DESCRIPTION
This may be needed for testing purposes in unit-tests.