### PR TITLE
[SYCL]Move kernel diagnostics to the call, enable template trail on errors

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10937,6 +10937,8 @@ def err_sycl_kernel_incorrectly_named : Error<
   "|needs to have a globally-visible name"
   "|name is invalid. Unscoped enum requires fixed underlying type"
   "}0">;
+def err_sycl_kernel_not_function_object
+    : Error<"kernel parameter is required to be a lambda or function object">;
 def err_sycl_restrict : Error<
   "SYCL kernel cannot "
 "%select{use a non-const global variable"

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10938,7 +10938,7 @@ def err_sycl_kernel_incorrectly_named : Error<
   "|name is invalid. Unscoped enum requires fixed underlying type"
   "}0">;
 def err_sycl_kernel_not_function_object
-    : Error<"kernel parameter is required to be a lambda or function object">;
+    : Error<"kernel parameter must be a lambda or function object">;
 def err_sycl_restrict : Error<
   "SYCL kernel cannot "
 "%select{use a non-const global variable"

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12306,6 +12306,9 @@ private:
                  bool IsMemberFunction, SourceLocation Loc, SourceRange Range,
                  VariadicCallType CallType);
 
+  void CheckSYCLKernelCall(FunctionDecl *CallerFunc, SourceLocation CallLoc,
+                           ArrayRef<const Expr *> Args);
+
   bool CheckObjCString(Expr *Arg);
   ExprResult CheckOSLogFormatStringArg(Expr *Arg);
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12306,7 +12306,7 @@ private:
                  bool IsMemberFunction, SourceLocation Loc, SourceRange Range,
                  VariadicCallType CallType);
 
-  void CheckSYCLKernelCall(FunctionDecl *CallerFunc, SourceLocation CallLoc,
+  void CheckSYCLKernelCall(FunctionDecl *CallerFunc, SourceRange CallLoc,
                            ArrayRef<const Expr *> Args);
 
   bool CheckObjCString(Expr *Arg);
@@ -12730,7 +12730,7 @@ private:
   // Used to suppress diagnostics during kernel construction, since these were
   // already emitted earlier. Diagnosing during Kernel emissions also skips the
   // useful notes that shows where the kernel was called.
-  bool ConstructingOpenCLKernel = false;
+  bool DiagnosingSYCLKernel = false;
 
 public:
   void addSyclDeviceDecl(Decl *d) { SyclDeviceDecls.insert(d); }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4460,7 +4460,7 @@ void Sema::checkCall(NamedDecl *FDecl, const FunctionProtoType *Proto,
     diagnoseArgDependentDiagnoseIfAttrs(FD, ThisArg, Args, Loc);
 
   if (FD && FD->hasAttr<SYCLKernelAttr>())
-      CheckSYCLKernelCall(FD, Loc, Args);
+    CheckSYCLKernelCall(FD, Range, Args);
 
   // Diagnose variadic calls in SYCL.
   if (FD && FD ->isVariadic() && getLangOpts().SYCLIsDevice &&

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4459,6 +4459,9 @@ void Sema::checkCall(NamedDecl *FDecl, const FunctionProtoType *Proto,
   if (FD)
     diagnoseArgDependentDiagnoseIfAttrs(FD, ThisArg, Args, Loc);
 
+  if (FD && FD->hasAttr<SYCLKernelAttr>())
+      CheckSYCLKernelCall(FD, Loc, Args);
+
   // Diagnose variadic calls in SYCL.
   if (FD && FD ->isVariadic() && getLangOpts().SYCLIsDevice &&
       !isUnevaluatedContext() && !isKnownGoodSYCLDecl(FD))

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -706,7 +706,6 @@ getKernelInvocationKind(FunctionDecl *KernelCallerFunc) {
 }
 
 static const CXXRecordDecl *getKernelObjectType(QualType Ty) {
-  // TODO: Once Chris' work is committed again, this changes.
   return Ty->getAsCXXRecordDecl();
 }
 
@@ -2028,7 +2027,6 @@ public:
 
 void Sema::CheckSYCLKernelCall(FunctionDecl *KernelFunc, SourceRange CallLoc,
                                ArrayRef<const Expr *> Args) {
-  // TODO: Diagnose with 'CallLoc' to get a better diagnostic.
   const CXXRecordDecl *KernelObj = getKernelObjectType(Args);
   if (!KernelObj) {
     Diag(Args[0]->getExprLoc(), diag::err_sycl_kernel_not_function_object);
@@ -2045,9 +2043,7 @@ void Sema::CheckSYCLKernelCall(FunctionDecl *KernelFunc, SourceRange CallLoc,
       }
   }
 
-  // TODO: Teach SYCLKernelFieldChecker to better print the call location.
   SyclKernelFieldChecker checker(*this);
-  // TODO: Union checker likely needs to be here too.
 
   KernelObjVisitor Visitor{*this};
   DiagnosingSYCLKernel = true;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -705,18 +705,9 @@ getKernelInvocationKind(FunctionDecl *KernelCallerFunc) {
       .Default(InvokeUnknown);
 }
 
-static const CXXRecordDecl *getKernelObjectType(QualType Ty) {
-  return Ty->getAsCXXRecordDecl();
-}
-
 static const CXXRecordDecl *getKernelObjectType(FunctionDecl *Caller) {
   assert(Caller->getNumParams() > 0 && "Insufficient kernel parameters");
-  return getKernelObjectType(Caller->getParamDecl(0)->getType());
-}
-
-static const CXXRecordDecl *getKernelObjectType(ArrayRef<const Expr *> Args) {
-  assert(Args.size() > 0 && "Insufficient kernel arguments");
-  return getKernelObjectType(Args[0]->getType());
+  return Caller->getParamDecl(0)->getType()->getAsCXXRecordDecl();
 }
 
 /// Creates a kernel parameter descriptor
@@ -2027,7 +2018,7 @@ public:
 
 void Sema::CheckSYCLKernelCall(FunctionDecl *KernelFunc, SourceRange CallLoc,
                                ArrayRef<const Expr *> Args) {
-  const CXXRecordDecl *KernelObj = getKernelObjectType(Args);
+  const CXXRecordDecl *KernelObj = getKernelObjectType(KernelFunc);
   if (!KernelObj) {
     Diag(Args[0]->getExprLoc(), diag::err_sycl_kernel_not_function_object);
     KernelFunc->setInvalidDecl();

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2034,14 +2034,14 @@ void Sema::CheckSYCLKernelCall(FunctionDecl *KernelFunc, SourceRange CallLoc,
       }
   }
 
-  SyclKernelFieldChecker checker(*this);
+  SyclKernelFieldChecker Checker(*this);
 
   KernelObjVisitor Visitor{*this};
   DiagnosingSYCLKernel = true;
-  Visitor.VisitRecordBases(KernelObj, checker);
-  Visitor.VisitRecordFields(KernelObj, checker);
+  Visitor.VisitRecordBases(KernelObj, Checker);
+  Visitor.VisitRecordFields(KernelObj, Checker);
   DiagnosingSYCLKernel = false;
-  if (!checker.isValid())
+  if (!Checker.isValid())
     KernelFunc->setInvalidDecl();
 }
 

--- a/clang/test/SemaSYCL/kernel-not-functor.cpp
+++ b/clang/test/SemaSYCL/kernel-not-functor.cpp
@@ -7,7 +7,7 @@ __attribute__((sycl_kernel)) void kernel(F kernelFunc) {
 
 template <typename Name, typename F>
 void uses_kernel(F kernelFunc) {
-  // expected-error@+1{{kernel parameter is required to be a lambda or function object}}
+  // expected-error@+1{{kernel parameter must be a lambda or function object}}
   kernel<Name>(kernelFunc);
 }
 

--- a/clang/test/SemaSYCL/kernel-not-functor.cpp
+++ b/clang/test/SemaSYCL/kernel-not-functor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify %s
 
 template <typename Name, typename F>
 __attribute__((sycl_kernel)) void kernel(F kernelFunc) {

--- a/clang/test/SemaSYCL/kernel-not-functor.cpp
+++ b/clang/test/SemaSYCL/kernel-not-functor.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -I %S/Inputs -fsycl -fsycl-is-device -fsyntax-only -verify %s
+
+template <typename Name, typename F>
+__attribute__((sycl_kernel)) void kernel(F kernelFunc) {
+  kernelFunc();
+}
+
+template <typename Name, typename F>
+void uses_kernel(F kernelFunc) {
+  // expected-error@+1{{kernel parameter is required to be a lambda or function object}}
+  kernel<Name>(kernelFunc);
+}
+
+void func() {}
+
+template <typename Name>
+void kernel_wrapper() {
+  // expected-note@+1{{in instantiation of function template specialization}}
+  uses_kernel<Name>(func);
+}
+
+void use() {
+  // expected-note@+1{{in instantiation of function template specialization}}
+  kernel_wrapper<class Foo>();
+}

--- a/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
+++ b/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
@@ -13,6 +13,7 @@ public:
 };
 
 void Class::function() {
+  // expected-note@+1{{used here}}
   kernel<class kernel_wrapper>(
       [=]() {
         int acc[1] = {5};


### PR DESCRIPTION
This patch moves the diagnostics for the kernel to the point in which the 
kernel is called, rather than when generating the kernel.  This means that
the call location is available (so that the checkers can be taught how to print
better diagnostics in the future).  The biggest impact of this, is that it
causes us to print the template instantiation 'tree' since these are diagnosing
right away.

Currently, this uses the call location to better diagnose the lambda check (see
the additional note there!), and prints a kernel-parameter-must-be-lambda-or-functor
error.
