### PR TITLE
[SYCL] Adjust AUX target with lang options

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -955,8 +955,10 @@ bool CompilerInstance::ExecuteAction(FrontendAction &Act) {
   // Adjust target options based on codegen options.
   getTarget().adjustTargetOptions(getCodeGenOpts(), getTargetOpts());
 
-  if (auto *Aux = getAuxTarget())
+  if (auto *Aux = getAuxTarget()) {
+    Aux->adjust(getLangOpts());
     getTarget().setAuxTarget(Aux);
+  }
 
   // rewriter project will change target built-in bool type from its default.
   if (getFrontendOpts().ProgramAction == frontend::RewriteObjC)

--- a/clang/test/SemaSYCL/long-double.cpp
+++ b/clang/test/SemaSYCL/long-double.cpp
@@ -2,10 +2,9 @@
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl -fsycl-is-device -fsyntax-only %s
 // RUN: %clang_cc1 -triple spir64 -aux-triple x86_64-linux-gnu -fsycl -fsycl-is-device -fsyntax-only -mlong-double-64 %s
 
-
 template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
-// expected-note@+1 {{called by 'kernel<variables}}
+  // expected-note@+1 {{called by 'kernel<variables}}
   kernelFunc();
 }
 
@@ -13,11 +12,11 @@ __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
 void foo(long double A) {}
 
 int main() {
-//expected-note@+1 {{'CapturedToDevice' defined here}}
+  //expected-note@+1 {{'CapturedToDevice' defined here}}
   long double CapturedToDevice = 1;
   kernel<class variables>([=]() {
-// expected-error@+2 {{'foo' requires 128 bit size 'long double' type support, but device 'spir64' does not support it}}
-// expected-error@+1 {{'CapturedToDevice' requires 128 bit size 'long double' type support, but device 'spir64' does not support it}}
+    // expected-error@+2 {{'foo' requires 128 bit size 'long double' type support, but device 'spir64' does not support it}}
+    // expected-error@+1 {{'CapturedToDevice' requires 128 bit size 'long double' type support, but device 'spir64' does not support it}}
     foo(CapturedToDevice);
   });
 

--- a/clang/test/SemaSYCL/long-double.cpp
+++ b/clang/test/SemaSYCL/long-double.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple spir64 -aux-triple x86_64-linux-gnu -fsycl -fsycl-is-device -verify -fsyntax-only %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl -fsycl-is-device -fsyntax-only %s
+// RUN: %clang_cc1 -triple spir64 -aux-triple x86_64-linux-gnu -fsycl -fsycl-is-device -fsyntax-only -mlong-double-64 %s
+
+
+template <typename Name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+// expected-note@+1 {{called by 'kernel<variables}}
+  kernelFunc();
+}
+
+//expected-note@+1 {{'foo' defined here}}
+void foo(long double A) {}
+
+int main() {
+//expected-note@+1 {{'CapturedToDevice' defined here}}
+  long double CapturedToDevice = 1;
+  kernel<class variables>([=]() {
+// expected-error@+2 {{'foo' requires 128 bit size 'long double' type support, but device 'spir64' does not support it}}
+// expected-error@+1 {{'CapturedToDevice' requires 128 bit size 'long double' type support, but device 'spir64' does not support it}}
+    foo(CapturedToDevice);
+  });
+
+  return 0;
+}


### PR DESCRIPTION
Due to lack of this adjustment some options like -mlong-double-64 didn't
have an effect on AUX target and caused incorrect diagnostics.