### PR TITLE
cpp version mismatch diagnostics + tests

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -322,9 +322,6 @@ public:
   SYCLIntegrationHeader(DiagnosticsEngine &Diag, bool UnnamedLambdaSupport,
                         Sema &S);
 
-  /// Get c++ version to support version mismatch diagnostics
-  int getCppVersion();
-
   /// Emits contents of the header into given stream.
   void emit(raw_ostream &Out);
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -322,6 +322,9 @@ public:
   SYCLIntegrationHeader(DiagnosticsEngine &Diag, bool UnnamedLambdaSupport,
                         Sema &S);
 
+  /// Get c++ version to support version mismatch diagnostics
+  int getCppVersion();
+
   /// Emits contents of the header into given stream.
   void emit(raw_ostream &Out);
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -210,8 +210,7 @@ bool Sema::isKnownGoodSYCLDecl(const Decl *D) {
   if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
     const IdentifierInfo *II = FD->getIdentifier();
     const DeclContext *DC = FD->getDeclContext();
-    if (II && II->isStr("__spirv_ocl_printf") &&
-        !FD->isDefined() &&
+    if (II && II->isStr("__spirv_ocl_printf") && !FD->isDefined() &&
         FD->getLanguageLinkage() == CXXLanguageLinkage &&
         DC->getEnclosingNamespaceContext()->isTranslationUnit())
       return true;
@@ -2298,8 +2297,7 @@ void Sema::finalizeSYCLDelayedAnalysis(const FunctionDecl *Caller,
   bool NotDefinedNoAttr = !Callee->isDefined() && !HasAttr;
 
   if (NotDefinedNoAttr && !Callee->getBuiltinID()) {
-    Diag(Loc, diag::err_sycl_restrict)
-        << Sema::KernelCallUndefinedFunction;
+    Diag(Loc, diag::err_sycl_restrict) << Sema::KernelCallUndefinedFunction;
     Diag(Callee->getLocation(), diag::note_previous_decl) << Callee;
     Diag(Caller->getLocation(), diag::note_called_by) << Caller;
   }
@@ -2728,7 +2726,7 @@ static void emitKernelNameType(QualType T, ASTContext &Ctx, raw_ostream &OS,
   emitWithoutAnonNamespaces(OS, T.getCanonicalType().getAsString(TypePolicy));
 }
 
-static int getCppVersion(SemaRef& S) {
+static int getCppVersion(Sema &S) {
 
   // Get c++ version to support version mismatch diagnostics
   int CppVersion = -1;
@@ -2763,7 +2761,9 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   O << "#define STD_CPP_VERSION ";
   O << CppVersion << "\n";
   O << "#if (__cplusplus <= 201112L) && (STD_CPP_VERSION >= 201401L) \n";
-  O << "#error \"C++ version (std=c++11 or less) for host compilation cannot be matched with C++ version (std=c++14 or greater) for device compilation\"\n";
+  O << "#error \"C++ version (std=c++11 or less) for host compilation cannot "
+       "be matched with C++ version (std=c++14 or greater) for device "
+       "compilation\"\n";
   O << "#endif\n";
   O << "\n";
 

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
@@ -1,8 +1,10 @@
 // >> ---- device compilation
 // RUN: %clangxx -std=c++14 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -I %sycl_include
-//
+
 // >> ---- host compilation: cpp version mismatch
-// RUN: not %clangxx -std=c++11 -include sycl_ihdr_a.h -c %s -I %sycl_include 2>&1 | FileCheck %s 
+// RUN: not %clangxx -std=c++11 -include sycl_ihdr_a.h -c %s -I %sycl_include 2>&1 | FileCheck %s
+
+// >> ---- diagnostics correctness check
 // CHECK: C++ version for host compilation does not match C++ version used for device compilation
 
 //==----------- cpp_version_mismatch_test_1.cpp - SYCL separate compilation cpp version mismatch test -----------------==//
@@ -14,43 +16,21 @@
 //===----------------------------------------------------------------------===//
 // -----------------------------------------------------------------------------
 #include <CL/sycl.hpp>
-#include <iostream>
 
-using namespace std;
-
-const int VAL = 10;
-
-// This tests uses a simple example with kernel creation 
+// This tests uses a simple example with kernel creation
 // to help exercise integration header file generation
 // and c++ version mismatch diagnostics generation
 // In this case the compiler versions are different
-int run_test_a(int v) {
-  int arr[] = {v};
-  {
-    cl::sycl::queue deviceQueue;
-    cl::sycl::buffer<int, 1> buf(arr, 1);
-    deviceQueue.submit([&](cl::sycl::handler &cgh) {
-      auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-      cgh.single_task<class kernel_a>([=]() { acc[0] *= 2; });
-    });
-  }
-  return arr[0];
-}
+
+namespace sycl = cl::sycl;
 
 int main(int argc, char **argv) {
-  bool pass = true;
 
-  int test_a = run_test_a(VAL);
-  const int GOLD_A = 2 * VAL;
+  // Run empty kernel
+  sycl::queue deviceQueue;
+  deviceQueue.submit([&](sycl::handler& cgh) {
+    cgh.single_task<class kernel_a>([=]() { });
+  });
 
-  if (test_a != GOLD_A) {
-    std::cout << "FAILD test_a. Expected: " << GOLD_A << ", got: " << test_a
-              << "\n";
-    pass = false;
-  }
-
-  if (pass) {
-    std::cout << "pass\n";
-  }
-  return pass ? 0 : 1;
+  return 0;
 }

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
@@ -5,7 +5,7 @@
 // RUN: not %clangxx -std=c++11 -include sycl_ihdr_a.h -c %s -I %sycl_include 2>&1 | FileCheck %s
 
 // >> ---- diagnostics correctness check
-// CHECK: C++ version for host compilation does not match C++ version used for device compilation
+// CHECK: C++ version (std=c++11 or less) for host compilation cannot be matched with C++ version (std=c++14 or greater) for device compilation
 
 //==----------- cpp_version_mismatch_test_1.cpp - SYCL separate compilation cpp version mismatch test -----------------==//
 //

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
@@ -1,0 +1,56 @@
+// >> ---- device compilation
+// RUN: %clangxx -std=c++14 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -I %sycl_include
+//
+// >> ---- host compilation: cpp version mismatch
+// RUN: not %clangxx -std=c++11 -include sycl_ihdr_a.h -c %s -I %sycl_include 2>&1 | FileCheck %s 
+// CHECK: C++ version for host compilation does not match C++ version used for device compilation
+
+//==----------- cpp_version_mismatch_test_1.cpp - SYCL separate compilation cpp version mismatch test -----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// -----------------------------------------------------------------------------
+#include <CL/sycl.hpp>
+#include <iostream>
+
+using namespace std;
+
+const int VAL = 10;
+
+// This tests uses a simple example with kernel creation 
+// to help exercise integration header file generation
+// and c++ version mismatch diagnostics generation
+// In this case the compiler versions are different
+int run_test_a(int v) {
+  int arr[] = {v};
+  {
+    cl::sycl::queue deviceQueue;
+    cl::sycl::buffer<int, 1> buf(arr, 1);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+      cgh.single_task<class kernel_a>([=]() { acc[0] *= 2; });
+    });
+  }
+  return arr[0];
+}
+
+int main(int argc, char **argv) {
+  bool pass = true;
+
+  int test_a = run_test_a(VAL);
+  const int GOLD_A = 2 * VAL;
+
+  if (test_a != GOLD_A) {
+    std::cout << "FAILD test_a. Expected: " << GOLD_A << ", got: " << test_a
+              << "\n";
+    pass = false;
+  }
+
+  if (pass) {
+    std::cout << "pass\n";
+  }
+  return pass ? 0 : 1;
+}

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
@@ -8,7 +8,7 @@
 // CHECK: C++ version (std=c++11 or less) for host compilation cannot be matched with C++ version (std=c++14 or greater) for device compilation
 
 //==----------- cpp_version_mismatch_test_1.cpp - SYCL separate compilation cpp
-//version mismatch test -----------------==//
+// version mismatch test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_1.cpp
@@ -7,7 +7,8 @@
 // >> ---- diagnostics correctness check
 // CHECK: C++ version (std=c++11 or less) for host compilation cannot be matched with C++ version (std=c++14 or greater) for device compilation
 
-//==----------- cpp_version_mismatch_test_1.cpp - SYCL separate compilation cpp version mismatch test -----------------==//
+//==----------- cpp_version_mismatch_test_1.cpp - SYCL separate compilation cpp
+//version mismatch test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -28,9 +29,8 @@ int main(int argc, char **argv) {
 
   // Run empty kernel
   sycl::queue deviceQueue;
-  deviceQueue.submit([&](sycl::handler& cgh) {
-    cgh.single_task<class kernel_a>([=]() { });
-  });
+  deviceQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<class kernel_a>([=]() {}); });
 
   return 0;
 }

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
@@ -4,8 +4,8 @@
 // >> ---- code generation checks
 // RUN: FileCheck -input-file=sycl_ihdr_a.h %s
 // CHECK: #define STD_CPP_VERSION
-// CHECK-NEXT: #if __cplusplus != STD_CPP_VERSION
-// CHECK-NEXT: #error "C++ version for host compilation does not match C++ version used for device compilation"
+// CHECK-NEXT: #if (__cplusplus <= 201112L) && (STD_CPP_VERSION >= 201401L)
+// CHECK-NEXT: #error "C++ version (std=c++11 or less) for host compilation cannot be matched with C++ version (std=c++14 or greater) for device compilation"
 // CHECK-NEXT: #endif
 
 //==----------- cpp_version_mismatch_test_2.cpp - SYCL separate compilation cpp version mismatch test -----------------==//

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
@@ -1,12 +1,9 @@
 // >> ---- device compilation
-// RUN: %clangxx -std=c++14 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc -I %sycl_include
-//
-// >> ---- host compilation: no cpp version mismatch
-// RUN: %clangxx -std=c++14 -include sycl_ihdr_a.h -c %s -I %sycl_include
-//
+// RUN: %clangxx -std=c++14 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -I %sycl_include
+
 // >> ---- code generation checks
 // RUN: FileCheck -input-file=sycl_ihdr_a.h %s
-// CHECK: #define STD_CPP_VERSION 
+// CHECK: #define STD_CPP_VERSION
 // CHECK-NEXT: #if __cplusplus != STD_CPP_VERSION
 // CHECK-NEXT: #error "C++ version for host compilation does not match C++ version used for device compilation"
 // CHECK-NEXT: #endif
@@ -20,44 +17,21 @@
 //===----------------------------------------------------------------------===//
 // -----------------------------------------------------------------------------
 #include <CL/sycl.hpp>
-#include <iostream>
 
-using namespace std;
-
-const int VAL = 10;
-
-// This tests uses a simple example with kernel creation 
+// This tests uses a simple example with kernel creation
 // to help exercise integration header file generation
 // and c++ version mismatch diagnostics generation
 // In this case the compiler versions are the same
 
-int run_test_a(int v) {
-  int arr[] = {v};
-  {
-    cl::sycl::queue deviceQueue;
-    cl::sycl::buffer<int, 1> buf(arr, 1);
-    deviceQueue.submit([&](cl::sycl::handler &cgh) {
-      auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-      cgh.single_task<class kernel_a>([=]() { acc[0] *= 2; });
-    });
-  }
-  return arr[0];
-}
+namespace sycl = cl::sycl;
 
 int main(int argc, char **argv) {
-  bool pass = true;
 
-  int test_a = run_test_a(VAL);
-  const int GOLD_A = 2 * VAL;
+  // Run empty kernel
+  sycl::queue deviceQueue;
+  deviceQueue.submit([&](sycl::handler& cgh) {
+    cgh.single_task<class kernel_a>([=]() { });
+  });
 
-  if (test_a != GOLD_A) {
-    std::cout << "FAILD test_a. Expected: " << GOLD_A << ", got: " << test_a
-              << "\n";
-    pass = false;
-  }
-
-  if (pass) {
-    std::cout << "pass\n";
-  }
-  return pass ? 0 : 1;
+  return 0;
 }

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
@@ -1,0 +1,63 @@
+// >> ---- device compilation
+// RUN: %clangxx -std=c++14 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc -I %sycl_include
+//
+// >> ---- host compilation: no cpp version mismatch
+// RUN: %clangxx -std=c++14 -include sycl_ihdr_a.h -c %s -I %sycl_include
+//
+// >> ---- code generation checks
+// RUN: FileCheck -input-file=sycl_ihdr_a.h %s
+// CHECK: #define STD_CPP_VERSION 
+// CHECK-NEXT: #if __cplusplus != STD_CPP_VERSION
+// CHECK-NEXT: #error "C++ version for host compilation does not match C++ version used for device compilation"
+// CHECK-NEXT: #endif
+
+//==----------- cpp_version_mismatch_test_2.cpp - SYCL separate compilation cpp version mismatch test -----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// -----------------------------------------------------------------------------
+#include <CL/sycl.hpp>
+#include <iostream>
+
+using namespace std;
+
+const int VAL = 10;
+
+// This tests uses a simple example with kernel creation 
+// to help exercise integration header file generation
+// and c++ version mismatch diagnostics generation
+// In this case the compiler versions are the same
+
+int run_test_a(int v) {
+  int arr[] = {v};
+  {
+    cl::sycl::queue deviceQueue;
+    cl::sycl::buffer<int, 1> buf(arr, 1);
+    deviceQueue.submit([&](cl::sycl::handler &cgh) {
+      auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+      cgh.single_task<class kernel_a>([=]() { acc[0] *= 2; });
+    });
+  }
+  return arr[0];
+}
+
+int main(int argc, char **argv) {
+  bool pass = true;
+
+  int test_a = run_test_a(VAL);
+  const int GOLD_A = 2 * VAL;
+
+  if (test_a != GOLD_A) {
+    std::cout << "FAILD test_a. Expected: " << GOLD_A << ", got: " << test_a
+              << "\n";
+    pass = false;
+  }
+
+  if (pass) {
+    std::cout << "pass\n";
+  }
+  return pass ? 0 : 1;
+}

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
@@ -10,7 +10,7 @@
 // compilation" CHECK-NEXT: #endif
 
 //==----------- cpp_version_mismatch_test_2.cpp - SYCL separate compilation cpp
-//version mismatch test -----------------==//
+// version mismatch test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
+++ b/sycl/test/separate-compile/cpp_version_mismatch_test_2.cpp
@@ -5,10 +5,12 @@
 // RUN: FileCheck -input-file=sycl_ihdr_a.h %s
 // CHECK: #define STD_CPP_VERSION
 // CHECK-NEXT: #if (__cplusplus <= 201112L) && (STD_CPP_VERSION >= 201401L)
-// CHECK-NEXT: #error "C++ version (std=c++11 or less) for host compilation cannot be matched with C++ version (std=c++14 or greater) for device compilation"
-// CHECK-NEXT: #endif
+// CHECK-NEXT: #error "C++ version (std=c++11 or less) for host compilation
+// cannot be matched with C++ version (std=c++14 or greater) for device
+// compilation" CHECK-NEXT: #endif
 
-//==----------- cpp_version_mismatch_test_2.cpp - SYCL separate compilation cpp version mismatch test -----------------==//
+//==----------- cpp_version_mismatch_test_2.cpp - SYCL separate compilation cpp
+//version mismatch test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -29,9 +31,8 @@ int main(int argc, char **argv) {
 
   // Run empty kernel
   sycl::queue deviceQueue;
-  deviceQueue.submit([&](sycl::handler& cgh) {
-    cgh.single_task<class kernel_a>([=]() { });
-  });
+  deviceQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<class kernel_a>([=]() {}); });
 
   return 0;
 }


### PR DESCRIPTION
**Summary**
Adding auto-generated C++ version mismatch diagnostics to the integration header generation files to allow version mismatch detection for separate compilation flows.

**Detail**
An issue occurs when the C++ version used for the device compilation equals C++14 and the version used during the host compilation equals  C++11. For example, when the representation of an object in one C++ version by a compiler is different from that of another C++ version for the same object.
 
With this fix, the two versions (device C++ version and host C++ version) will be captured in the auto-generated integration header. When the integration header is run during the host compilation, the versions will be compared and a diagnostic can be reported.
 
This change set specifically covers cases where: C++ version (std=C++11 or less) for host compilation cannot be matched with C++ version (std=C++14 or greater) for device compilation.