### PR TITLE
[BuildBot] Add option to set (i.e. reduce) build parallelism

### DIFF
--- a/buildbot/compile.py
+++ b/buildbot/compile.py
@@ -13,6 +13,9 @@ def do_compile(args):
     except NotImplementedError:
         cpu_count = DEFAULT_CPU_COUNT
 
+    if args.build_parallelism:
+        cpu_count = int(args.build_parallelism)
+
     # Get absolute path to source directory
     if args.src_dir:
       abs_src_dir = os.path.abspath(args.src_dir)
@@ -51,6 +54,7 @@ def main():
                         help="builder directory, which is the directory contains source and build directories")
     parser.add_argument("-s", "--src-dir", metavar="SRC_DIR", help="source directory")
     parser.add_argument("-o", "--obj-dir", metavar="OBJ_DIR", help="build directory")
+    parser.add_argument("-j", "--build-parallelism", metavar="BUILD_PARALLELISM", help="build parallelism")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
the default option of "all the cores" or "4" is imprudent on some
systems, or when the user wants the system to be more responsive to
other applications.

this change was inspired by the thermal death (thankfully temporary)
of my Raspberry Pi, which has 4 cores but overheats when building LLVM
on all of them (a heatsink or fan would presumably resolve this).

Signed-off-by: Hammond, Jeff R <jeff.r.hammond@intel.com>