### PR TITLE
[SYCL][Driver] Specify target type for lit test.

### DIFF
--- a/clang/test/Driver/print-internal-defines-for-sycl.c
+++ b/clang/test/Driver/print-internal-defines-for-sycl.c
@@ -1,5 +1,6 @@
 // Test if clang is able to print internal defines in SYCL mode
+// REQUIRES: x86-registered-target
 //
-// RUN: %clangxx -fsycl -dM -E -x c++ %s 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -dM -E -x c++ %s 2>&1 \
 // RUN: | FileCheck --check-prefix CHECK-PRINT-INTERNAL-DEFINES %s
 // CHECK-PRINT-INTERNAL-DEFINES: #define


### PR DESCRIPTION
Update print-internal-defines-for-sycl.c to specify target type.
Signed-off-by: haonanya <haonan.yang@intel.com>