### PR TITLE
[SYCL][buildbot] add ARM target option to buildbot/configure.py

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -38,6 +38,10 @@ def do_configure(args):
         libclc_targets_to_build = 'nvptx64--;nvptx64--nvidiacl'
         sycl_build_pi_cuda = 'ON'
 
+    # replace not append, so ARM ^ X86
+    if args.arm:
+        llvm_targets_to_build = 'ARM;AArch64'
+
     if args.no_werror:
         sycl_werror = 'OFF'
 
@@ -128,6 +132,7 @@ def main():
     parser.add_argument("-t", "--build-type",
                         metavar="BUILD_TYPE", default="Release", help="build type: Debug, Release")
     parser.add_argument("--cuda", action='store_true', help="switch from OpenCL to CUDA")
+    parser.add_argument("--arm", action='store_true', help="build ARM support rather than x86")
     parser.add_argument("--no-assertions", action='store_true', help="build without assertions")
     parser.add_argument("--docs", action='store_true', help="build Doxygen documentation")
     parser.add_argument("--system-ocl", action='store_true', help="use OpenCL deps from system (no download)")


### PR DESCRIPTION
This has been tested on Raspberry Pi 4 and Cavium ThunderX2 running Ubuntu AArch64.  The build also depends on my fixes for #2304, but those are not ready.  Nonetheless, this fix is independent of that one and can be merged without side effects.

There is a clearly a more general solution here, but it seems imprudent to add architectures to the buildbot testing until they have actually been tested somewhere.  Once I have a chance to test on PowerPC, I'll see about adding that as an explicit target, or provide a more general solution (e.g. `--arch=..`).

Resolves #2313.

Signed-off-by: Jeff R. Hammond <jeff.r.hammond@intel.com>