### PR TITLE
[SYCL] Correction to handler::require API

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -757,8 +757,9 @@ public:
   /// \param Acc is a SYCL accessor describing required memory region.
   template <typename DataT, int Dims, access::mode AccMode,
             access::target AccTarget>
-  void require(accessor<DataT, Dims, AccMode, AccTarget,
-                        access::placeholder::true_t> &Acc) {
+  void
+  require(accessor<DataT, Dims, AccMode, AccTarget, access::placeholder::true_t>
+              Acc) {
 #ifndef __SYCL_DEVICE_ONLY__
     associateWithHandler(&Acc, AccTarget);
 #else


### PR DESCRIPTION
This fix corrects the definition of the handler::require API in our headers to match the SYCL specification.
The SYCL spec defines the accessor parameter of "require" to be passed by value. Our headers defined the API to take an accessor by reference.
This PR changes the accessor parameter from reference to value.

Signed-off-by: rdeodhar <rajiv.deodhar@intel.com>