### PR TITLE
[SYCL][Driver] Disable "early" optimizations for Intel FPGA by default

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4104,7 +4104,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-fsycl-explicit-simd");
 
     if (!Args.hasFlag(options::OPT_fsycl_early_optimizations,
-                      options::OPT_fno_sycl_early_optimizations, true))
+                      options::OPT_fno_sycl_early_optimizations, true) ||
+        Triple.getSubArch() == llvm::Triple::SPIRSubArch_fpga)
       CmdArgs.push_back("-fno-sycl-early-optimizations");
     else if (RawTriple.isSPIR()) {
       // Set `sycl-opt` option to configure LLVM passes for SPIR target

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4103,7 +4103,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                      false))
       CmdArgs.push_back("-fsycl-explicit-simd");
 
-    // Default value for FPGA is false and true for all other targets.
+    // Default value for FPGA is false, for all other targets is true.
     if (!Args.hasFlag(options::OPT_fsycl_early_optimizations,
                       options::OPT_fno_sycl_early_optimizations,
                       Triple.getSubArch() != llvm::Triple::SPIRSubArch_fpga))

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4103,9 +4103,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                      false))
       CmdArgs.push_back("-fsycl-explicit-simd");
 
+    // Default value for FPGA is false and true for all other targets.
     if (!Args.hasFlag(options::OPT_fsycl_early_optimizations,
-                      options::OPT_fno_sycl_early_optimizations, true) ||
-        Triple.getSubArch() == llvm::Triple::SPIRSubArch_fpga)
+                      options::OPT_fno_sycl_early_optimizations,
+                      Triple.getSubArch() != llvm::Triple::SPIRSubArch_fpga))
       CmdArgs.push_back("-fno-sycl-early-optimizations");
     else if (RawTriple.isSPIR()) {
       // Set `sycl-opt` option to configure LLVM passes for SPIR target

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -8,7 +8,9 @@
 
 /// Check "-fno-sycl-early-optimizations" is passed to the front-end:
 // RUN:   %clang -### -fsycl -fno-sycl-early-optimizations %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-STD-OPTS %s
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
 // RUN:   %clang -### -fsycl -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-STD-OPTS %s
-// CHECK-NO-SYCL-STD-OPTS: "-fno-sycl-early-optimizations"
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// RUN:   %clang -### -fsycl -fintelfpga %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// CHECK-NO-SYCL-EARLY-OPTS: "-fno-sycl-early-optimizations"

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -3,6 +3,8 @@
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
 // RUN:   %clang -### -fsycl -fsycl-device-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang -### -fsycl -fintelfpga -fsycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
 // CHECK-DEFAULT-NOT: "-fno-sycl-early-optimizations"
 // CHECK-DEFAULT-NOT: "-disable-llvm-passes"
 


### PR DESCRIPTION
Enabling standard LLVM passes for SPIR target by default might have
negative impact on the metadata added specifically for Intel FPGA
target. We might switch it back to "ON" by default after more though
validation.