### PR TITLE
[SYCL][NFC] Fix warnings in Base64, PropertySetIO tests

### DIFF
--- a/llvm/unittests/Support/Base64Test.cpp
+++ b/llvm/unittests/Support/Base64Test.cpp
@@ -78,7 +78,7 @@ TEST(Base64Test, RoundTrip) {
                {Arr6, sizeof(Arr6)}, {Arr7, sizeof(Arr7)}, {Arr8, sizeof(Arr8)},
                {Arr9, sizeof(Arr9)}};
 
-  for (auto I = 0; I < sizeof(Tests) / sizeof(Tests[0]); ++I) {
+  for (size_t I = 0; I < sizeof(Tests) / sizeof(Tests[0]); ++I) {
     std::string Encoded;
     size_t Len;
     {

--- a/llvm/unittests/Support/PropertySetIOTest.cpp
+++ b/llvm/unittests/Support/PropertySetIOTest.cpp
@@ -51,8 +51,8 @@ TEST(PropertySet, ByteArrayValuesIO) {
   // first 8 bytes are the size in bits (40) of what follows (5 bytes).
 
   auto Content = "[Opt/Param]\n"
-                 "kernel1=2|IAAAAAAAAAQA\n";
-  "kernel2=2|oAAAAAAAAAw///3/wB\n";
+                 "kernel1=2|IAAAAAAAAAQA\n"
+                 "kernel2=2|oAAAAAAAAAw///3/wB\n";
   auto MemBuf = MemoryBuffer::getMemBuffer(Content);
   // Parse a property set registry
   auto PropSetsPtr = PropertySetRegistry::read(MemBuf.get());


### PR DESCRIPTION
Signed-off-by: Sergey Semenov <sergey.semenov@intel.com>