### PR TITLE
[SYCL] Fix xmethod interaction with ptype command

### DIFF
--- a/sycl/gdb/libsycl.so-gdb.py
+++ b/sycl/gdb/libsycl.so-gdb.py
@@ -85,7 +85,7 @@ class AccessorOpIndex(gdb.xmethod.XMethodWorker):
     def get_arg_types(self):
         return gdb.lookup_type("cl::sycl::id<%s>" % self.depth)
 
-    def get_result_type(self):
+    def get_result_type(self, *args):
         return self.result_type
 
     def __call__(self, obj, arg):


### PR DESCRIPTION
Fixes the following error when `ptype accessor[0]` command is run in GDB:

> Python Exception <class 'TypeError'> get_result_type() takes 1 positional argument but 3 were given:
> Error while fetching result type of an xmethod worker defined in Python.

Regression test case will be added to the debugger.