### PR TITLE
[Driver][SYCL] Enable Dead Parameter Elimination Optimization

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4123,6 +4123,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-sycl-opt");
     }
+    // Turn on Dead Parameter Elimination Optimization with early optimizations
+    if (Args.hasFlag(options::OPT_fsycl_early_optimizations,
+                     options::OPT_fno_sycl_early_optimizations, true))
+      CmdArgs.push_back("-fenable-sycl-dae");
 
     // Pass the triple of host when doing SYCL
     auto AuxT = llvm::Triple(llvm::sys::getProcessTriple());
@@ -7807,6 +7811,10 @@ void SYCLPostLink::ConstructJob(Compilation &C, const JobAction &JA,
   // OPT_fsycl_device_code_split is not checked as it is an alias to
   // -fsycl-device-code-split=per_source
 
+  // Turn on Dead Parameter Elimination Optimization with early optimizations
+  if (TCArgs.hasFlag(options::OPT_fsycl_early_optimizations,
+                     options::OPT_fno_sycl_early_optimizations, true))
+    addArgs(CmdArgs, TCArgs, {"-emit-param-info"});
   if (JA.getType() == types::TY_LLVM_BC) {
     // single file output requested - this means only perform necessary IR
     // transformations (like specialization constant intrinsic lowering) and

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -16,3 +16,11 @@
 // RUN:   %clang -### -fsycl -fintelfpga %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
 // CHECK-NO-SYCL-EARLY-OPTS: "-fno-sycl-early-optimizations"
+
+/// Check that Dead Parameter Elimination Optimization is enabled
+// RUN:   %clang -### -fsycl %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DAE %s
+// RUN:   %clang -### -fsycl -fsycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DAE %s
+// CHECK-DAE: clang{{.*}} "-fenable-sycl-dae"
+// CHECK-DAE: sycl-post-link{{.*}} "-emit-param-info"


### PR DESCRIPTION
This is enabled by default for -fsycl, and can be disabled via the
-fno-sycl-early-optimizations switch.

Signed-off-by: Michael D Toguchi <michael.d.toguchi@intel.com>