### PR TITLE
[SYCL] Fix crash when kernel argument is a multi-dimensional array.

### DIFF
--- a/clang/test/CodeGenSYCL/kernel-param-pod-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-pod-array.cpp
@@ -25,6 +25,7 @@ struct foo {
 int main() {
 
   int a[2];
+  int array_2D[2][1];
   foo struct_array[2];
 
   a_kernel<class kernel_B>(
@@ -35,6 +36,11 @@ int main() {
   a_kernel<class kernel_C>(
       [=]() {
         foo local = struct_array[1];
+      });
+
+  a_kernel<class kernel_D>(
+      [=]() {
+        int local = array_2D[0][0];
       });
 }
 
@@ -151,3 +157,25 @@ int main() {
 // CHECK: [[GEP_FOO2_C:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct.{{.*}}foo.foo, %struct.{{.*}}foo.foo* [[FOO_ARRAY_1]], i32 0, i32 2
 // CHECK: [[LOAD_FOO2_C:%[a-zA-Z0-9_]+]] = load i32, i32* [[FOO2_C_LOCAL]], align 4
 // CHECK: store i32 [[LOAD_FOO2_C]], i32* [[GEP_FOO2_C]], align 4
+
+// Check kernel_D parameters
+// CHECK: define spir_kernel void @{{.*}}kernel_D
+// CHECK-SAME: i32 [[ARR_2D_1:%[a-zA-Z0-9_]+]], i32 [[ARR_2D_2:%[a-zA-Z0-9_]+]]
+
+// Check local lambda object alloca
+// CHECK: [[LAMBDA_OBJ:%[0-9]+]] = alloca %"class.{{.*}}.anon.1", align 4
+
+// Check local stores
+// CHECK: store i32 [[ARR_2D_1]], i32* [[ARR_2D_1_LOCAL:%[a-zA-Z_]+.addr[0-9]*]], align 4
+// CHECK: store i32 [[ARR_2D_2]], i32* [[ARR_2D_2_LOCAL:%[a-zA-Z_]+.addr[0-9]*]], align 4
+
+// Check initialization of local array
+// CHECK: [[GEP_ARR_2D:%[0-9]*]] = getelementptr inbounds %"class._ZTSZ4mainE3$_0.anon.1", %"class._ZTSZ4mainE3$_0.anon.1"* [[LAMBDA_OBJ]], i32 0, i32 0
+// CHECK: [[GEP_ARR_BEGIN1:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [2 x [1 x i32]], [2 x [1 x i32]]* [[GEP_ARR_2D]], i64 0, i64 0
+// CHECK: [[GEP_ARR_ELEM0:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [1 x i32], [1 x i32]* [[GEP_ARR_BEGIN1]], i64 0, i64 0
+// CHECK: [[ARR_2D_ELEM0:%[0-9]*]] = load i32, i32* [[ARR_2D_1_LOCAL]], align 4
+// CHECK: store i32 [[ARR_2D_ELEM0]], i32* [[GEP_ARR_ELEM0]], align 4
+// CHECK: [[GEP_ARR_BEGIN2:%[a-zA-Z_.]+]] = getelementptr inbounds [1 x i32], [1 x i32]* [[GEP_ARR_BEGIN1]], i64 1
+// CHECK: [[GEP_ARR_ELEM1:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [1 x i32], [1 x i32]* [[GEP_ARR_BEGIN2]], i64 0, i64 0
+// CHECK: [[ARR_2D_ELEM1:%[0-9]*]] = load i32, i32* [[ARR_2D_2_LOCAL]], align 4
+// CHECK: store i32 [[ARR_2D_ELEM1]], i32* [[GEP_ARR_ELEM1]], align 4

--- a/clang/test/SemaSYCL/array-kernel-param.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param.cpp
@@ -38,10 +38,13 @@ int main() {
   struct foo {
     int foo_a;
     foo_inner foo_b[2];
+    int foo_2D[2][1];
     int foo_c;
   };
 
   foo struct_array[2];
+
+  int array_2D[2][3];
 
   a_kernel<class kernel_A>(
       [=]() {
@@ -66,6 +69,11 @@ int main() {
   a_kernel<class kernel_E>(
       [=]() {
         int local = s.a[2];
+      });
+
+  a_kernel<class kernel_F>(
+      [=]() {
+        int local = array_2D[1][1];
       });
 }
 
@@ -111,8 +119,8 @@ int main() {
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'cl::sycl::id<1>'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} used '(lambda at {{.*}}array-kernel-param.cpp:57:7)' cinit
-// CHECK-NEXT: InitListExpr {{.*}} '(lambda at {{.*}}array-kernel-param.cpp:57:7)'
+// CHECK-NEXT: VarDecl {{.*}} used '(lambda at {{.*}}array-kernel-param.cpp{{.*}})' cinit
+// CHECK-NEXT: InitListExpr {{.*}} '(lambda at {{.*}}array-kernel-param.cpp{{.*}})'
 // CHECK-NEXT: InitListExpr {{.*}} 'struct_acc_t'
 // CHECK-NEXT: InitListExpr {{.*}} 'Accessor [2]'
 // CHECK-NEXT: CXXConstructExpr {{.*}} 'Accessor [2]'
@@ -125,7 +133,7 @@ int main() {
 // CHECK-NEXT: MemberExpr {{.*}}__init
 
 // Check kernel_D parameters
-// CHECK: FunctionDecl {{.*}}kernel_D{{.*}} 'void (int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int)'
+// CHECK: FunctionDecl {{.*}}kernel_D{{.*}} 'void (int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int)'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_a 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_inner_x 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_inner_y 'int'
@@ -135,6 +143,8 @@ int main() {
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_inner_y 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_inner_z 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_inner_z 'int'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_2D 'int'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_2D 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_c 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_a 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_inner_x 'int'
@@ -145,6 +155,8 @@ int main() {
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_inner_y 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_inner_z 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_inner_z 'int'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_2D 'int'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_2D 'int'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_foo_c 'int'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
@@ -182,6 +194,13 @@ int main() {
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_inner_z' 'int'
 // CHECK-NEXT: ImplicitCastExpr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_inner_z' 'int'
+// CHECK-NEXT: InitListExpr {{.*}} 'int [2][1]'
+// CHECK-NEXT: InitListExpr {{.*}} 'int [1]'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_2D' 'int'
+// CHECK-NEXT: InitListExpr {{.*}} 'int [1]'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_2D' 'int'
 // CHECK-NEXT: ImplicitCastExpr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_c' 'int'
 
@@ -210,6 +229,13 @@ int main() {
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_inner_z' 'int'
 // CHECK-NEXT: ImplicitCastExpr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_inner_z' 'int'
+// CHECK-NEXT: InitListExpr {{.*}} 'int [2][1]'
+// CHECK-NEXT: InitListExpr {{.*}} 'int [1]'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_2D' 'int'
+// CHECK-NEXT: InitListExpr {{.*}} 'int [1]'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_2D' 'int'
 // CHECK-NEXT: ImplicitCastExpr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_foo_c' 'int'
 
@@ -220,8 +246,8 @@ int main() {
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_a 'int':'int'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} used '(lambda at {{.*}}array-kernel-param.cpp:67:7)' cinit
-// CHECK-NEXT: InitListExpr {{.*}} '(lambda at {{.*}}array-kernel-param.cpp:67:7)'
+// CHECK-NEXT: VarDecl {{.*}} used '(lambda at {{.*}}array-kernel-param.cpp{{.*}})' cinit
+// CHECK-NEXT: InitListExpr {{.*}} '(lambda at {{.*}}array-kernel-param.cpp{{.*}})'
 // CHECK-NEXT: InitListExpr {{.*}} 'S<int>'
 // CHECK-NEXT: InitListExpr {{.*}} 'int [3]'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int':'int'
@@ -230,3 +256,32 @@ int main() {
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int':'int'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int':'int'
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int':'int'
+
+// Check kernel_F parameters
+// CHECK: FunctionDecl {{.*}}kernel_F{{.*}} 'void (int, int, int, int, int, int)'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'int'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'int'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'int'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'int'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'int'
+// CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ 'int'
+// Check kernel_F inits
+// CHECK-NEXT: CompoundStmt
+// CHECK-NEXT: DeclStmt
+// CHECK-NEXT: VarDecl {{.*}} cinit
+// CHECK-NEXT: InitListExpr
+// CHECK-NEXT: InitListExpr {{.*}} 'int [2][3]'
+// CHECK-NEXT: InitListExpr {{.*}} 'int [3]'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_' 'int'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_' 'int'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_' 'int'
+// CHECK-NEXT: InitListExpr {{.*}} 'int [3]'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_' 'int'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_' 'int'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_' 'int'


### PR DESCRIPTION
This patch fixes crash due to incorrect InitializedEntity for
multi-dimensional arrays. When generating the InitializedEntity
for an element, it is necessary to descend the array. For example,
the initialized entity for s.array[x][y][z] is constructed using
initialized entities for s.array[x][y], s.array[x] and s.array.
Prior to this patch, the 'descending' was not done.

Patch by: Rajiv Deodhar and Elizabeth Andrews

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>