### PR TITLE
[NFC][SYCL] Make Visitor functions private, other than the entry points

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -801,9 +801,6 @@ class KernelObjVisitor {
         (handlers.leaveUnion(Owner, Parent), 0)...};
   }
 
-public:
-  KernelObjVisitor(Sema &S) : SemaRef(S) {}
-
   // These enable handler execution only when previous handlers succeed.
   template <typename... Tn>
   bool handleField(FieldDecl *FD, QualType FDTy, Tn &&... tn) {
@@ -931,6 +928,9 @@ public:
     (void)std::initializer_list<int>{
         (handlers.leaveStruct(Owner, Parent), 0)...};
   }
+
+public:
+  KernelObjVisitor(Sema &S) : SemaRef(S) {}
 
   template <typename... Handlers>
   void VisitRecordBases(const CXXRecordDecl *KernelFunctor,


### PR DESCRIPTION
Just a cleanup task I saw that should happen.  None of this is really
necessary to be public, so make them all private.