### PR TITLE
[Driver][SYCL] Expand -fsycl-early-optimizations to Windows

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3550,7 +3550,7 @@ def fsycl_esimd : Flag<["-"], "fsycl-explicit-simd">, Group<sycl_Group>, Flags<[
   HelpText<"Enable SYCL explicit SIMD extension">;
 def fno_sycl_esimd : Flag<["-"], "fno-sycl-explicit-simd">, Group<sycl_Group>,
   HelpText<"Disable SYCL explicit SIMD extension">, Flags<[NoArgumentUnused, CoreOption]>;
-defm sycl_early_optimizations : OptOutFFlag<"sycl-early-optimizations", "Enable", "Disable", " standard optimization pipeline for SYCL device compiler">;
+defm sycl_early_optimizations : OptOutFFlag<"sycl-early-optimizations", "Enable", "Disable", " standard optimization pipeline for SYCL device compiler", [CoreOption]>;
 
 //===----------------------------------------------------------------------===//
 // CC1 Options

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -1,9 +1,15 @@
 /// Check that optimizations for sycl device are enabled by default:
 // RUN:   %clang -### -fsycl %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang_cl -### -fsycl %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
 // RUN:   %clang -### -fsycl -fsycl-device-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang_cl -### -fsycl -fsycl-device-only %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
 // RUN:   %clang -### -fsycl -fintelfpga -fsycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang_cl -### -fsycl -fintelfpga -fsycl-early-optimizations %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
 // CHECK-DEFAULT-NOT: "-fno-sycl-early-optimizations"
 // CHECK-DEFAULT-NOT: "-disable-llvm-passes"
@@ -11,8 +17,14 @@
 /// Check "-fno-sycl-early-optimizations" is passed to the front-end:
 // RUN:   %clang -### -fsycl -fno-sycl-early-optimizations %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// RUN:   %clang_cl -### -fsycl -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
 // RUN:   %clang -### -fsycl -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// RUN:   %clang_cl -### -fsycl -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
 // RUN:   %clang -### -fsycl -fintelfpga %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// RUN:   %clang_cl -### -fsycl -fintelfpga %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
 // CHECK-NO-SYCL-EARLY-OPTS: "-fno-sycl-early-optimizations"


### PR DESCRIPTION
Initial implementation was for Linux only, this is needed on the
Windows side too.