### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1227,7 +1227,7 @@ class SyclKernelFieldChecker : public SyclKernelFieldHandler {
 
   void checkBufferLocationType(QualType PropTy, SourceLocation Loc) {
     const auto *PropDecl =
-        dyn_cast<ClassTemplateSpecializationDecl>(PropTy->getAsRecordDecl());
+        cast<ClassTemplateSpecializationDecl>(PropTy->getAsRecordDecl());
     if (PropDecl->getTemplateArgs().size() != 1) {
       SemaRef.Diag(Loc, diag::err_sycl_invalid_property_list_param_number)
           << "buffer_location";


### PR DESCRIPTION
Found via a static-analysis tool check, 
Pointer 'PropDecl' returned from call to function 'dyn_cast<clang::ClassTemplateSpecializationDecl,clang::RecordDecl>'
may be NULL and will be dereferenced at line (PropDecl->getTemplateArgs().size() != 1).

This patch fixes this null pointer dereference issue in SemaSYCL.cpp by switching from a dyn_cast to a cast.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>