### PR TITLE
[SYCL] Add implementation for free function queries

### DIFF
--- a/sycl/include/CL/sycl/ONEAPI/sub_group.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/sub_group.hpp
@@ -570,8 +570,19 @@ struct sub_group {
 
 protected:
   template <int dimensions> friend class cl::sycl::nd_item;
+  friend sub_group this_sub_group();
   sub_group() = default;
 };
+
+inline sub_group this_sub_group() {
+#ifdef __SYCL_DEVICE_ONLY__
+  return sub_group();
+#else
+  throw runtime_error("Sub-groups are not supported on host device.",
+                      PI_INVALID_DEVICE);
+#endif
+}
+
 } // namespace ONEAPI
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/cg_types.hpp
+++ b/sycl/include/CL/sycl/detail/cg_types.hpp
@@ -213,8 +213,8 @@ public:
     detail::NDLoop<Dims>::iterate(Range, [&](const sycl::id<Dims> &ID) {
       sycl::item<Dims, /*Offset=*/true> Item =
           IDBuilder::createItem<Dims, true>(Range, ID, Offset);
-      store_id(&ID, true);
-      store_item(&Item, true);
+      store_id(&ID);
+      store_item(&Item);
       MKernel(ID);
     });
   }
@@ -232,8 +232,8 @@ public:
       sycl::item<Dims, /*Offset=*/false> Item =
           IDBuilder::createItem<Dims, false>(Range, ID);
       sycl::item<Dims, /*Offset=*/true> ItemWithOffset = Item;
-      store_id(&ID, true);
-      store_item(&ItemWithOffset, true);
+      store_id(&ID);
+      store_item(&ItemWithOffset);
       MKernel(Item);
     });
   }
@@ -253,8 +253,8 @@ public:
       sycl::id<Dims> OffsetID = ID + Offset;
       sycl::item<Dims, /*Offset=*/true> Item =
           IDBuilder::createItem<Dims, true>(Range, OffsetID, Offset);
-      store_id(&OffsetID, true);
-      store_item(&Item, true);
+      store_id(&OffsetID);
+      store_item(&Item);
       MKernel(Item);
     });
   }
@@ -294,11 +294,11 @@ public:
             IDBuilder::createItem<Dims, false>(LocalSize, LocalID);
         const sycl::nd_item<Dims> NDItem =
             IDBuilder::createNDItem<Dims>(GlobalItem, LocalItem, Group);
-        store_id(&GlobalID, true);
-        store_item(&GlobalItem, true);
-        store_nd_item(&NDItem, true);
+        store_id(&GlobalID);
+        store_item(&GlobalItem);
+        store_nd_item(&NDItem);
         auto g = NDItem.get_group();
-        store_group(&g, true);
+        store_group(&g);
         MKernel(NDItem);
       });
     });

--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -77,6 +77,16 @@ getOrWaitEvents(std::vector<cl::sycl::event> DepEvents,
 
 __SYCL_EXPORT void waitEvents(std::vector<cl::sycl::event> DepEvents);
 
+template <typename T> T *declptr() { return static_cast<T *>(nullptr); }
+
+template <typename T> T store(const T *obj, bool write) {
+  static thread_local auto stored = *obj;
+  if (write) {
+    stored = *obj;
+  }
+  return stored;
+}
+
 class Builder {
 public:
   Builder() = delete;
@@ -196,9 +206,8 @@ public:
   }
 
   template <int Dims>
-  static auto getNDItem()
-      -> decltype(getElement(static_cast<nd_item<Dims> *>(nullptr))) {
-    return getElement(static_cast<nd_item<Dims> *>(nullptr));
+  static auto getNDItem() -> decltype(getElement(declptr<nd_item<Dims>>())) {
+    return getElement(declptr<nd_item<Dims>>());
   }
 
 #endif // __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -79,9 +79,11 @@ __SYCL_EXPORT void waitEvents(std::vector<cl::sycl::event> DepEvents);
 
 template <typename T> T *declptr() { return static_cast<T *>(nullptr); }
 
-template <typename T> T store(const T *obj, bool write) {
+// Function to get of store id, item, nd_item, group for the host implementation
+// Pass nullptr to get stored object. Pass valid address to store object
+template <typename T> T get_or_store(const T *obj) {
   static thread_local auto stored = *obj;
-  if (write) {
+  if (obj != nullptr) {
     stored = *obj;
   }
   return stored;

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -377,8 +377,8 @@ protected:
 };
 
 namespace detail {
-template <int Dims> group<Dims> store_group(const group<Dims> *g, bool write) {
-  return store(g, write);
+template <int Dims> group<Dims> store_group(const group<Dims> *g) {
+  return get_or_store(g);
 }
 } // namespace detail
 
@@ -386,7 +386,7 @@ template <int Dims> group<Dims> this_group() {
 #ifdef __SYCL_DEVICE_ONLY__
   return detail::Builder::getElement(detail::declptr<group<Dims>>());
 #else
-  return detail::store_group<Dims>(nullptr, false);
+  return detail::store_group<Dims>(nullptr);
 #endif
 }
 

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -376,5 +376,19 @@ protected:
   }
 };
 
+namespace detail {
+template <int Dims> group<Dims> store_group(const group<Dims> *g, bool write) {
+  return store(g, write);
+}
+} // namespace detail
+
+template <int Dims> group<Dims> this_group() {
+#ifdef __SYCL_DEVICE_ONLY__
+  return detail::Builder::getElement(detail::declptr<group<Dims>>());
+#else
+  return detail::store_group<Dims>(nullptr, false);
+#endif
+}
+
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -744,8 +744,7 @@ private:
 #else
   kernel_parallel_for(const KernelType &KernelFunc) {
 #endif
-    KernelFunc(
-        detail::Builder::getElement(static_cast<ElementType *>(nullptr)));
+    KernelFunc(detail::Builder::getElement(detail::declptr<ElementType>()));
   }
 
   // NOTE: the name of this function - "kernel_parallel_for_work_group" - is
@@ -757,8 +756,7 @@ private:
 #else
   kernel_parallel_for_work_group(const KernelType &KernelFunc) {
 #endif
-    KernelFunc(
-        detail::Builder::getElement(static_cast<ElementType *>(nullptr)));
+    KernelFunc(detail::Builder::getElement(detail::declptr<ElementType>()));
   }
 
 #endif

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -261,8 +261,8 @@ id(size_t, size_t, size_t)->id<3>;
 #endif
 
 namespace detail {
-template <int Dims> id<Dims> store_id(const id<Dims> *i, bool write) {
-  return store(i, write);
+template <int Dims> id<Dims> store_id(const id<Dims> *i) {
+  return get_or_store(i);
 }
 } // namespace detail
 
@@ -270,7 +270,7 @@ template <int Dims> id<Dims> this_id() {
 #ifdef __SYCL_DEVICE_ONLY__
   return detail::Builder::getElement(detail::declptr<id<Dims>>());
 #else
-  return detail::store_id<Dims>(nullptr, false);
+  return detail::store_id<Dims>(nullptr);
 #endif
 }
 

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/detail/array.hpp>
 #include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/helpers.hpp>
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/range.hpp>
 
@@ -258,6 +259,20 @@ id(size_t)->id<1>;
 id(size_t, size_t)->id<2>;
 id(size_t, size_t, size_t)->id<3>;
 #endif
+
+namespace detail {
+template <int Dims> id<Dims> store_id(const id<Dims> *i, bool write) {
+  return store(i, write);
+}
+} // namespace detail
+
+template <int Dims> id<Dims> this_id() {
+#ifdef __SYCL_DEVICE_ONLY__
+  return detail::Builder::getElement(detail::declptr<id<Dims>>());
+#else
+  return detail::store_id<Dims>(nullptr, false);
+#endif
+}
 
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -122,8 +122,8 @@ private:
 };
 
 namespace detail {
-template <int Dims> item<Dims> store_item(const item<Dims> *i, bool write) {
-  return store(i, write);
+template <int Dims> item<Dims> store_item(const item<Dims> *i) {
+  return get_or_store(i);
 }
 } // namespace detail
 
@@ -131,7 +131,7 @@ template <int Dims> item<Dims> this_item() {
 #ifdef __SYCL_DEVICE_ONLY__
   return detail::Builder::getElement(detail::declptr<item<Dims>>());
 #else
-  return detail::store_item<Dims>(nullptr, false);
+  return detail::store_item<Dims>(nullptr);
 #endif
 }
 

--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -121,5 +121,19 @@ private:
   detail::ItemBase<dimensions, with_offset> MImpl;
 };
 
+namespace detail {
+template <int Dims> item<Dims> store_item(const item<Dims> *i, bool write) {
+  return store(i, write);
+}
+} // namespace detail
+
+template <int Dims> item<Dims> this_item() {
+#ifdef __SYCL_DEVICE_ONLY__
+  return detail::Builder::getElement(detail::declptr<item<Dims>>());
+#else
+  return detail::store_item<Dims>(nullptr, false);
+#endif
+}
+
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -194,9 +194,8 @@ private:
 };
 
 namespace detail {
-template <int Dims>
-nd_item<Dims> store_nd_item(const nd_item<Dims> *nd_i, bool write) {
-  return store(nd_i, write);
+template <int Dims> nd_item<Dims> store_nd_item(const nd_item<Dims> *nd_i) {
+  return get_or_store(nd_i);
 }
 } // namespace detail
 
@@ -204,7 +203,7 @@ template <int Dims> nd_item<Dims> this_nd_item() {
 #ifdef __SYCL_DEVICE_ONLY__
   return detail::Builder::getElement(detail::declptr<nd_item<Dims>>());
 #else
-  return detail::store_nd_item<Dims>(nullptr, false);
+  return detail::store_nd_item<Dims>(nullptr);
 #endif
 }
 

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -192,5 +192,21 @@ private:
   item<dimensions, false> localItem;
   group<dimensions> Group;
 };
+
+namespace detail {
+template <int Dims>
+nd_item<Dims> store_nd_item(const nd_item<Dims> *nd_i, bool write) {
+  return store(nd_i, write);
+}
+} // namespace detail
+
+template <int Dims> nd_item<Dims> this_nd_item() {
+#ifdef __SYCL_DEVICE_ONLY__
+  return detail::Builder::getElement(detail::declptr<nd_item<Dims>>());
+#else
+  return detail::store_nd_item<Dims>(nullptr, false);
+#endif
+}
+
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/test/basic_tests/free_function_queries/free_function_queries.cpp
+++ b/sycl/test/basic_tests/free_function_queries/free_function_queries.cpp
@@ -23,19 +23,28 @@ int main() {
 
   int data[n]{};
   int counter{0};
+
   {
+    constexpr int checks_number{3};
+    int results[checks_number]{};
     {
       sycl::buffer<int> buf(data, sycl::range<1>(n));
+      sycl::buffer<int> results_buf(results, sycl::range<1>(checks_number));
       sycl::queue q;
       q.submit([&](cl::sycl::handler &cgh) {
         sycl::accessor<int, 1, sycl::access::mode::write,
                        sycl::access::target::global_buffer>
             acc(buf.get_access<sycl::access::mode::write>(cgh));
+        sycl::accessor<int, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+            results_acc(results_buf.get_access<sycl::access::mode::write>(cgh));
         cgh.parallel_for<class IdTest>(n, [=](sycl::id<1> i) {
-          auto this_id = sycl::this_id<1>();
-          assert(this_id == i);
+          auto that_id = sycl::this_id<1>();
+          results_acc[0] = that_id == i;
+
           auto that_item = sycl::this_item<1>();
-          assert(that_item.get_id() == i);
+          results_acc[1] = that_item.get_id() == i;
+          results_acc[2] = that_item.get_range() == sycl::range<1>(n);
           acc[i]++;
         });
       });
@@ -44,23 +53,32 @@ int main() {
     for (int i = 0; i < n; i++) {
       assert(data[i] == counter);
     }
+    for (auto val : results) {
+      assert(val == 1);
+    }
   }
 
   {
+    constexpr int checks_number{2};
+    int results[checks_number]{};
     {
       sycl::buffer<int> buf(data, sycl::range<1>(n));
+      sycl::buffer<int> results_buf(results, sycl::range<1>(checks_number));
       sycl::queue q;
       q.submit([&](cl::sycl::handler &cgh) {
         sycl::accessor<int, 1, sycl::access::mode::write,
                        sycl::access::target::global_buffer>
             acc(buf.get_access<sycl::access::mode::write>(cgh));
+        sycl::accessor<int, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+            results_acc(results_buf.get_access<sycl::access::mode::write>(cgh));
         cgh.parallel_for<class ItemTest>(n, [=](auto i) {
           static_assert(std::is_same<decltype(i), sycl::item<1>>::value,
                         "lambda arg type is unexpected");
           auto that_id = sycl::this_id<1>();
-          assert(that_id == i.get_id());
+          results_acc[0] = i.get_id() == that_id;
           auto that_item = sycl::this_item<1>();
-          assert(that_item == i);
+          results_acc[1] = i == that_item;
           acc[i]++;
         });
       });
@@ -69,23 +87,32 @@ int main() {
     for (int i = 0; i < n; i++) {
       assert(data[i] == counter);
     }
+    for (auto val : results) {
+      assert(val == 1);
+    }
   }
 
   {
+    constexpr int checks_number{2};
+    int results[checks_number]{};
     {
       sycl::buffer<int> buf(data, sycl::range<1>(n));
+      sycl::buffer<int> results_buf(results, sycl::range<1>(checks_number));
       sycl::queue q;
       sycl::id<1> offset(1);
       q.submit([&](cl::sycl::handler &cgh) {
         sycl::accessor<int, 1, sycl::access::mode::write,
                        sycl::access::target::global_buffer>
             acc(buf.get_access<sycl::access::mode::write>(cgh));
+        sycl::accessor<int, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+            results_acc(results_buf.get_access<sycl::access::mode::write>(cgh));
         cgh.parallel_for<class ItemOffsetTest>(
             sycl::range<1>{n}, offset, [=](sycl::item<1, true> i) {
               auto that_id = sycl::this_id<1>();
-              assert(that_id == i.get_id());
+              results_acc[0] = i.get_id() == that_id;
               auto that_item = sycl::this_item<1>();
-              assert(that_item == i);
+              results_acc[1] = i == that_item;
               acc[that_item.get_linear_id()]++;
             });
       });
@@ -94,29 +121,39 @@ int main() {
     for (int i = 0; i < n; i++) {
       assert(data[i] == counter);
     }
+    for (auto val : results) {
+      assert(val == 1);
+    }
   }
 
   {
+    constexpr int checks_number{5};
+    int results[checks_number]{};
     {
       sycl::buffer<int> buf(data, sycl::range<1>(n));
+      sycl::buffer<int> results_buf(results, sycl::range<1>(checks_number));
       sycl::queue q;
       sycl::nd_range<1> NDR(sycl::range<1>{n}, sycl::range<1>{2});
       q.submit([&](cl::sycl::handler &cgh) {
         sycl::accessor<int, 1, sycl::access::mode::write,
                        sycl::access::target::global_buffer>
             acc(buf.get_access<sycl::access::mode::write>(cgh));
+        sycl::accessor<int, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+            results_acc(results_buf.get_access<sycl::access::mode::write>(cgh));
         cgh.parallel_for<class NdItemTest>(NDR, [=](auto nd_i) {
           static_assert(std::is_same<decltype(nd_i), sycl::nd_item<1>>::value,
                         "lambda arg type is unexpected");
           auto that_nd_item = sycl::this_nd_item<1>();
-          assert(that_nd_item == nd_i);
+          results_acc[0] = that_nd_item == nd_i;
           auto nd_item_group = that_nd_item.get_group();
-          assert(nd_item_group == sycl::this_group<1>());
+          results_acc[1] = nd_item_group == sycl::this_group<1>();
           auto nd_item_id = that_nd_item.get_global_id();
-          assert(nd_item_id == sycl::this_id<1>());
+          results_acc[2] = nd_item_id == sycl::this_id<1>();
           auto that_item = sycl::this_item<1>();
-          assert(nd_item_id == that_item.get_id());
-          assert(that_nd_item.get_global_range() == that_item.get_range());
+          results_acc[3] = nd_item_id == that_item.get_id();
+          results_acc[4] =
+              that_nd_item.get_global_range() == that_item.get_range();
 
           acc[that_nd_item.get_global_id(0)]++;
         });
@@ -125,6 +162,9 @@ int main() {
     ++counter;
     for (int i = 0; i < n; i++) {
       assert(data[i] == counter);
+    }
+    for (auto val : results) {
+      assert(val == 1);
     }
   }
 }

--- a/sycl/test/basic_tests/free_function_queries/free_function_queries.cpp
+++ b/sycl/test/basic_tests/free_function_queries/free_function_queries.cpp
@@ -1,0 +1,130 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+//==- free_function_queries.cpp - SYCL free function queries test -=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+#include <cassert>
+#include <iostream>
+#include <type_traits>
+
+int main() {
+  constexpr std::size_t n = 10;
+
+  int data[n]{};
+  int counter{0};
+  {
+    {
+      sycl::buffer<int> buf(data, sycl::range<1>(n));
+      sycl::queue q;
+      q.submit([&](cl::sycl::handler &cgh) {
+        sycl::accessor<int, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+            acc(buf.get_access<sycl::access::mode::write>(cgh));
+        cgh.parallel_for<class IdTest>(n, [=](sycl::id<1> i) {
+          auto this_id = sycl::this_id<1>();
+          assert(this_id == i);
+          auto that_item = sycl::this_item<1>();
+          assert(that_item.get_id() == i);
+          acc[i]++;
+        });
+      });
+    }
+    ++counter;
+    for (int i = 0; i < n; i++) {
+      assert(data[i] == counter);
+    }
+  }
+
+  {
+    {
+      sycl::buffer<int> buf(data, sycl::range<1>(n));
+      sycl::queue q;
+      q.submit([&](cl::sycl::handler &cgh) {
+        sycl::accessor<int, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+            acc(buf.get_access<sycl::access::mode::write>(cgh));
+        cgh.parallel_for<class ItemTest>(n, [=](auto i) {
+          static_assert(std::is_same<decltype(i), sycl::item<1>>::value,
+                        "lambda arg type is unexpected");
+          auto that_id = sycl::this_id<1>();
+          assert(that_id == i.get_id());
+          auto that_item = sycl::this_item<1>();
+          assert(that_item == i);
+          acc[i]++;
+        });
+      });
+    }
+    ++counter;
+    for (int i = 0; i < n; i++) {
+      assert(data[i] == counter);
+    }
+  }
+
+  {
+    {
+      sycl::buffer<int> buf(data, sycl::range<1>(n));
+      sycl::queue q;
+      sycl::id<1> offset(1);
+      q.submit([&](cl::sycl::handler &cgh) {
+        sycl::accessor<int, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+            acc(buf.get_access<sycl::access::mode::write>(cgh));
+        cgh.parallel_for<class ItemOffsetTest>(
+            sycl::range<1>{n}, offset, [=](sycl::item<1, true> i) {
+              auto that_id = sycl::this_id<1>();
+              assert(that_id == i.get_id());
+              auto that_item = sycl::this_item<1>();
+              assert(that_item == i);
+              acc[that_item.get_linear_id()]++;
+            });
+      });
+    }
+    ++counter;
+    for (int i = 0; i < n; i++) {
+      assert(data[i] == counter);
+    }
+  }
+
+  {
+    {
+      sycl::buffer<int> buf(data, sycl::range<1>(n));
+      sycl::queue q;
+      sycl::nd_range<1> NDR(sycl::range<1>{n}, sycl::range<1>{2});
+      q.submit([&](cl::sycl::handler &cgh) {
+        sycl::accessor<int, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+            acc(buf.get_access<sycl::access::mode::write>(cgh));
+        cgh.parallel_for<class NdItemTest>(NDR, [=](auto nd_i) {
+          static_assert(std::is_same<decltype(nd_i), sycl::nd_item<1>>::value,
+                        "lambda arg type is unexpected");
+          auto that_nd_item = sycl::this_nd_item<1>();
+          assert(that_nd_item == nd_i);
+          auto nd_item_group = that_nd_item.get_group();
+          assert(nd_item_group == sycl::this_group<1>());
+          auto nd_item_id = that_nd_item.get_global_id();
+          assert(nd_item_id == sycl::this_id<1>());
+          auto that_item = sycl::this_item<1>();
+          assert(nd_item_id == that_item.get_id());
+          assert(that_nd_item.get_global_range() == that_item.get_range());
+
+          acc[that_nd_item.get_global_id(0)]++;
+        });
+      });
+    }
+    ++counter;
+    for (int i = 0; i < n; i++) {
+      assert(data[i] == counter);
+    }
+  }
+}

--- a/sycl/test/basic_tests/free_function_queries/free_function_queries_interface.cpp
+++ b/sycl/test/basic_tests/free_function_queries/free_function_queries_interface.cpp
@@ -1,0 +1,72 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -I %sycl_include
+// expected-no-diagnostics
+//==- free_function_queries_interface.cpp - SYCL free queries interface -==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+#include <type_traits>
+
+template <int Dims> struct this_id_caller {
+  auto operator()() const -> decltype(sycl::this_id<Dims>()) {
+    return sycl::this_id<Dims>();
+  }
+};
+
+template <int Dims> struct this_item_caller {
+  auto operator()() const -> decltype(sycl::this_item<Dims>()) {
+    return sycl::this_item<Dims>();
+  }
+};
+
+template <int Dims> struct this_nd_item_caller {
+  auto operator()() const -> decltype(sycl::this_nd_item<Dims>()) {
+    return sycl::this_nd_item<Dims>();
+  }
+};
+
+template <int Dims> struct this_group_caller {
+  auto operator()() const -> decltype(sycl::this_group<Dims>()) {
+    return sycl::this_group<Dims>();
+  }
+};
+
+template <template <int> class IterationPoint, int Dims,
+          template <int> class Callable>
+void test(Callable<Dims> &&callable) {
+  static_assert(std::is_same<decltype(callable()), IterationPoint<Dims>>::value,
+                "Wrong return type of free function query");
+}
+
+template <template <int, bool = true> class Item, int Dims> void test() {
+  static_assert(
+      std::is_same<decltype(this_item_caller<Dims>{}()), Item<Dims>>::value,
+      "Wrong return type of free function query for Item");
+}
+
+int main() {
+  test<sycl::id>(this_id_caller<1>{});
+  test<sycl::id>(this_id_caller<2>{});
+  test<sycl::id>(this_id_caller<3>{});
+
+  test<sycl::item, 1>();
+  test<sycl::item, 2>();
+  test<sycl::item, 3>();
+
+  test<sycl::nd_item>(this_nd_item_caller<1>{});
+  test<sycl::nd_item>(this_nd_item_caller<2>{});
+  test<sycl::nd_item>(this_nd_item_caller<3>{});
+
+  test<sycl::group>(this_group_caller<1>{});
+  test<sycl::group>(this_group_caller<2>{});
+  test<sycl::group>(this_group_caller<3>{});
+
+  static_assert(std::is_same<decltype(sycl::ONEAPI::this_sub_group()),
+                             sycl::ONEAPI::sub_group>::value,
+                "Wrong return type of free function query for Sub Group");
+}

--- a/sycl/test/basic_tests/free_function_queries/free_function_queries_sub_group.cpp
+++ b/sycl/test/basic_tests/free_function_queries/free_function_queries_sub_group.cpp
@@ -1,0 +1,65 @@
+// UNSUPPORTED: cuda
+// CUDA compilation and runtime do not yet support sub-groups.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+//==- free_function_queries_sub_group.cpp - SYCL free queries for sub group -=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------------===//
+
+#include "../../sub_group/helper.hpp"
+#include <CL/sycl.hpp>
+
+#include <cassert>
+#include <iostream>
+#include <type_traits>
+
+int main() {
+  constexpr std::size_t n = 10;
+
+  int data[n]{};
+  int counter{0};
+  {
+    {
+      sycl::buffer<int> buf(data, sycl::range<1>(n));
+      sycl::queue q;
+      if (!core_sg_supported(q.get_device())) {
+        std::cout << "Skipping test" << std::endl;
+        return 0;
+      }
+      sycl::nd_range<1> NDR(sycl::range<1>{n}, sycl::range<1>{2});
+      q.submit([&](cl::sycl::handler &cgh) {
+        sycl::accessor<int, 1, sycl::access::mode::write,
+                       sycl::access::target::global_buffer>
+            acc(buf.get_access<sycl::access::mode::write>(cgh));
+        cgh.parallel_for<class NdItemTest>(NDR, [=](auto nd_i) {
+          static_assert(std::is_same<decltype(nd_i), sycl::nd_item<1>>::value,
+                        "lambda arg type is unexpected");
+          auto that_nd_item = sycl::this_nd_item<1>();
+          assert(that_nd_item == nd_i);
+          auto that_sub_group = sycl::ONEAPI::this_sub_group();
+          assert(that_sub_group.get_local_linear_id() ==
+                 that_nd_item.get_sub_group().get_local_linear_id());
+          assert(that_sub_group.get_local_id() ==
+                 that_nd_item.get_sub_group().get_local_id());
+          assert(that_sub_group.get_local_range() ==
+                 that_nd_item.get_sub_group().get_local_range());
+
+          acc[that_nd_item.get_global_id(0)]++;
+        });
+      });
+    }
+    ++counter;
+    for (int i = 0; i < n; i++) {
+      assert(data[i] == counter);
+    }
+  }
+}


### PR DESCRIPTION
Add the following functions: `this_id()`, `this_item()`, `this_nd_item()`, `this_group()`, `this_sub_group()`

Implementation of the following [extension](https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/FreeFunctionQueries)