### PR TITLE
[NFC] Revert tests that were modified for Dead Parameter Opts

### DIFF
--- a/sycl/test/kernel_from_file/hw.cpp
+++ b/sycl/test/kernel_from_file/hw.cpp
@@ -2,9 +2,7 @@
 // CUDA does not support SPIR-V.
 
 //-fsycl-targets=%sycl_triple
-// Runtime assumes that the image passed with SYCL_USE_KERNEL_SPV has no
-// eliminated arguments, compile without early optimizations.
-// RUN: %clangxx -fsycl-device-only -fno-sycl-early-optimizations -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict
+// RUN: %clangxx -fsycl-device-only -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict
 // RUN: %clangxx -include %t.h -g %s -o %t.out -lsycl -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning
 // RUN: env SYCL_BE=%sycl_be SYCL_USE_KERNEL_SPV=%t.spv %t.out | FileCheck %s
 // CHECK: Passed

--- a/sycl/test/separate-compile/test.cpp
+++ b/sycl/test/separate-compile/test.cpp
@@ -3,13 +3,13 @@
 //
 // >> ---- compile src1
 // >> device compilation...
-// RUN: %clangxx -fsycl-device-only -fno-sycl-early-optimizations -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc -I %sycl_include -Wno-sycl-strict
 // >> host compilation...
 // RUN: %clangxx -include sycl_ihdr_a.h -g -c %s -o a.o -I %sycl_include -Wno-sycl-strict
 //
 // >> ---- compile src2
 // >> device compilation...
-// RUN: %clangxx -DB_CPP=1 -fsycl-device-only -fno-sycl-early-optimizations -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -c -o b_kernel.bc -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -DB_CPP=1 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -c -o b_kernel.bc -I %sycl_include -Wno-sycl-strict
 // >> host compilation...
 // RUN: %clangxx -DB_CPP=1 -include sycl_ihdr_b.h -g -c %s -o b.o -I %sycl_include -Wno-sycl-strict
 //


### PR DESCRIPTION
A couple of tests were modified to restrict early-optimizations from a
prior implementation, but the final solution went a different direction.
Put these tests back to where they were.