### PR TITLE
[SYCL] Assume SYCL device functions are convergent

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2885,7 +2885,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.Coroutines = Opts.CPlusPlus20 || Args.hasArg(OPT_fcoroutines_ts);
 
   Opts.ConvergentFunctions = Opts.OpenCL || (Opts.CUDA && Opts.CUDAIsDevice) ||
-                             (Opts.SYCL && Opts.SYCLIsDevice) ||
+                             Opts.SYCLIsDevice ||
                              Args.hasArg(OPT_fconvergent_functions);
 
   Opts.DoubleSquareBracketAttributes =

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2885,7 +2885,8 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.Coroutines = Opts.CPlusPlus20 || Args.hasArg(OPT_fcoroutines_ts);
 
   Opts.ConvergentFunctions = Opts.OpenCL || (Opts.CUDA && Opts.CUDAIsDevice) ||
-    Args.hasArg(OPT_fconvergent_functions);
+                             (Opts.SYCL && Opts.SYCLIsDevice) ||
+                             Args.hasArg(OPT_fconvergent_functions);
 
   Opts.DoubleSquareBracketAttributes =
       Args.hasFlag(OPT_fdouble_square_bracket_attributes,

--- a/clang/test/CodeGenSYCL/convergent.cpp
+++ b/clang/test/CodeGenSYCL/convergent.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -emit-llvm -disable-llvm-passes \
+// RUN:  -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | \
+// RUN:   FileCheck %s
+
+// CHECK-DAG: Function Attrs:
+// CHECK-DAG-SAME: convergent
+// CHECK-DAG-NEXT: define void @_Z3foov
+void foo() {
+  int a = 1;
+}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class fake_kernel>([]() { foo(); });
+  return 0;
+}

--- a/clang/test/CodeGenSYCL/convergent.cpp
+++ b/clang/test/CodeGenSYCL/convergent.cpp
@@ -9,7 +9,7 @@ void foo() {
   int a = 1;
 }
 
-template <typename name, typename Func>
+template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }


### PR DESCRIPTION
SYCL device compiler (similar to other SPMD compilers) assumes that
functions are convergent by default to avoid invalid transformations.
This attribute can be removed if compiler can prove that function does
not have convergent operations.