### PR TITLE
[NFCI][SYCL] Rework of DeclBodyCreator/Array Handling in prep of non-Decomposition

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2027,7 +2027,8 @@ public:
     const auto *StreamDecl = Ty->getAsCXXRecordDecl();
     CollectionInitExprs.push_back(CreateInitListExpr(StreamDecl));
 
-    MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
+    if (!IsArrayElement(FD, Ty))
+      MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
     return true;
   }
 
@@ -2036,8 +2037,6 @@ public:
     // Stream requires that its 'init' calls happen after its accessors init
     // calls, so add them here instead.
     const auto *StreamDecl = Ty->getAsCXXRecordDecl();
-    if (!IsArrayElement(FD, Ty))
-      MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
 
     createSpecialMethodCall(StreamDecl, InitMethodName, BodyStmts);
     createSpecialMethodCall(StreamDecl, FinalizeMethodName, FinalizeStmts);
@@ -2046,7 +2045,6 @@ public:
       MemberExprBases.pop_back();
 
     CollectionInitExprs.pop_back();
-    MemberExprBases.pop_back();
     return true;
   }
 
@@ -2054,7 +2052,8 @@ public:
     ++ContainerDepth;
     addCollectionInitListExpr(Ty->getAsCXXRecordDecl());
 
-    MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
+    if (!IsArrayElement(FD, Ty))
+      MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
     return true;
   }
 
@@ -2062,7 +2061,8 @@ public:
     --ContainerDepth;
     CollectionInitExprs.pop_back();
 
-    MemberExprBases.pop_back();
+    if (!IsArrayElement(FD, Ty))
+      MemberExprBases.pop_back();
     return true;
   }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1916,11 +1916,14 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     addFieldInit(FD, Ty, None,
                  InitializationKind::CreateDefault(SourceLocation()));
 
-    // TODO ERICH: if this is in an array, we likely don't want this.
-    MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
+    if (!IsArrayElement(FD, Ty))
+      MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
+
     const auto *RecordDecl = Ty->getAsCXXRecordDecl();
     createSpecialMethodCall(RecordDecl, InitMethodName, BodyStmts);
-    MemberExprBases.pop_back();
+
+    if (!IsArrayElement(FD, Ty))
+      MemberExprBases.pop_back();
 
     return true;
   }
@@ -1986,11 +1989,14 @@ public:
     CollectionInitExprs.push_back(CreateInitListExpr(StreamDecl));
 
     // Add init/finalize method calls.
-    // TODO ERICH: if this is in an array, we likely don't want this.
-    MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
+    if (!IsArrayElement(FD, Ty))
+      MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
+
     createSpecialMethodCall(StreamDecl, InitMethodName, BodyStmts);
     createSpecialMethodCall(StreamDecl, FinalizeMethodName, FinalizeStmts);
-    MemberExprBases.pop_back();
+
+    if (!IsArrayElement(FD, Ty))
+      MemberExprBases.pop_back();
     return true;
   }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -901,7 +901,7 @@ class KernelObjVisitor {
                              Handlers &... handlers) {
     (void)std::initializer_list<int>{
         (handlers.nextElement(ElementTy, Index), 0)...};
-     VisitField(Owner, ArrayField, ElementTy, handlers...);
+    VisitField(Owner, ArrayField, ElementTy, handlers...);
   }
 
   template <typename... Handlers>
@@ -1128,8 +1128,7 @@ void KernelObjVisitor::VisitUnion(const CXXRecordDecl *Owner, ParentTy &Parent,
 template <typename... Handlers>
 void KernelObjVisitor::VisitNthArrayElement(const CXXRecordDecl *Owner,
                                             FieldDecl *ArrayField,
-                                            QualType ElementTy,
-                                            uint64_t Index,
+                                            QualType ElementTy, uint64_t Index,
                                             Handlers &... handlers) {
   // Don't continue descending if none of the handlers 'care'. This could be 'if
   // constexpr' starting in C++17.  Until then, we have to count on the
@@ -1718,7 +1717,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   }
 
   // Creates a DeclRefExpr to the ParmVar that represents the current field.
-  Expr* createParamReferenceExpr() {
+  Expr *createParamReferenceExpr() {
     ParmVarDecl *KernelParameter =
         DeclCreator.getParamVarDeclsForCurrentField()[0];
 
@@ -1730,7 +1729,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
   // Creates a DeclRefExpr to the ParmVar that represents the current pointer
   // field.
-  Expr* createPointerParamReferenceExpr(QualType PointerTy, bool Wrapped) {
+  Expr *createPointerParamReferenceExpr(QualType PointerTy, bool Wrapped) {
     ParmVarDecl *KernelParameter =
         DeclCreator.getParamVarDeclsForCurrentField()[0];
 
@@ -1742,11 +1741,11 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     // then wrapped inside a compiler generated struct. Therefore when
     // generating the initializers, we have to 'unwrap' the pointer.
     if (Wrapped) {
-       CXXRecordDecl *WrapperStruct = ParamType->getAsCXXRecordDecl();
-       // Pointer field wrapped inside __wrapper_class
-       FieldDecl *Pointer = *(WrapperStruct->field_begin());
-       DRE = BuildMemberExpr(DRE, Pointer);
-       ParamType = Pointer->getType();
+      CXXRecordDecl *WrapperStruct = ParamType->getAsCXXRecordDecl();
+      // Pointer field wrapped inside __wrapper_class
+      FieldDecl *Pointer = *(WrapperStruct->field_begin());
+      DRE = BuildMemberExpr(DRE, Pointer);
+      ParamType = Pointer->getType();
     }
 
     if (PointerTy->getPointeeType().getAddressSpace() !=
@@ -1792,8 +1791,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     InitializedEntity Entity = getFieldEntity(FD, Ty);
 
     InitializationSequence InitSeq(SemaRef, Entity, InitKind, ParamRef);
-    ExprResult Init =
-        InitSeq.Perform(SemaRef, Entity, InitKind, ParamRef);
+    ExprResult Init = InitSeq.Perform(SemaRef, Entity, InitKind, ParamRef);
 
     InitListExpr *ParentILE = CollectionInitExprs.back();
     ParentILE->updateInit(SemaRef.getASTContext(), ParentILE->getNumInits(),
@@ -1879,7 +1877,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
   InitListExpr *CreateInitListExpr(QualType InitTy, uint64_t NumChildInits) {
     InitListExpr *ILE = new (SemaRef.getASTContext()) InitListExpr(
-      SemaRef.getASTContext(), SourceLocation(), {}, SourceLocation());
+        SemaRef.getASTContext(), SourceLocation(), {}, SourceLocation());
     ILE->reserveInits(SemaRef.getASTContext(), NumChildInits);
     ILE->setType(InitTy);
 
@@ -1959,8 +1957,8 @@ public:
   }
 
   ~SyclKernelBodyCreator() {
-     CompoundStmt *KernelBody = createKernelBody();
-     DeclCreator.setBody(KernelBody);
+    CompoundStmt *KernelBody = createKernelBody();
+    DeclCreator.setBody(KernelBody);
   }
 
   bool handleSyclAccessorType(FieldDecl *FD, QualType Ty) final {
@@ -2050,13 +2048,14 @@ public:
     return true;
   }
 
-  bool enterStruct(const CXXRecordDecl *RD, const CXXBaseSpecifier &BS, QualType) final {
+  bool enterStruct(const CXXRecordDecl *RD, const CXXBaseSpecifier &BS,
+                   QualType) final {
     ++ContainerDepth;
 
     CXXCastPath BasePath;
     QualType DerivedTy(RD->getTypeForDecl(), 0);
     QualType BaseTy = BS.getType();
-//    // TODO: Why is this here? Do we think this check could fail?
+    //    // TODO: Why is this here? Do we think this check could fail?
     SemaRef.CheckDerivedToBaseConversion(DerivedTy, BaseTy, SourceLocation(),
                                          SourceRange(), &BasePath,
                                          /*IgnoreBaseAccess*/ true);
@@ -2069,7 +2068,8 @@ public:
     return true;
   }
 
-  bool leaveStruct(const CXXRecordDecl *RD, const CXXBaseSpecifier &BS, QualType) final {
+  bool leaveStruct(const CXXRecordDecl *RD, const CXXBaseSpecifier &BS,
+                   QualType) final {
     --ContainerDepth;
     MemberExprBases.pop_back();
     CollectionInitExprs.pop_back();
@@ -2096,7 +2096,8 @@ public:
     ArrayInfos.back().second = Index;
 
     // Pop off the last member expr base.
-    if (Index != 0) MemberExprBases.pop_back();
+    if (Index != 0)
+      MemberExprBases.pop_back();
 
     QualType SizeT = SemaRef.getASTContext().getSizeType();
 
@@ -2279,17 +2280,19 @@ public:
     return true;
   }
 
-  bool enterStruct(const CXXRecordDecl *RD, const CXXBaseSpecifier &BS, QualType) final {
+  bool enterStruct(const CXXRecordDecl *RD, const CXXBaseSpecifier &BS,
+                   QualType) final {
     CurOffset += offsetOf(RD, BS.getType()->getAsCXXRecordDecl());
     return true;
   }
 
-  bool leaveStruct(const CXXRecordDecl *RD, const CXXBaseSpecifier &BS, QualType) final {
+  bool leaveStruct(const CXXRecordDecl *RD, const CXXBaseSpecifier &BS,
+                   QualType) final {
     CurOffset -= offsetOf(RD, BS.getType()->getAsCXXRecordDecl());
     return true;
   }
 
-  bool enterArray(FieldDecl*, QualType, QualType) final {
+  bool enterArray(FieldDecl *, QualType, QualType) final {
     ArrayBaseOffsets.push_back(CurOffset);
     return true;
   }
@@ -2300,7 +2303,7 @@ public:
     return true;
   }
 
-  bool leaveArray(FieldDecl*, QualType, QualType) final {
+  bool leaveArray(FieldDecl *, QualType, QualType) final {
     CurOffset = ArrayBaseOffsets.pop_back_val();
     return true;
   }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1660,6 +1660,11 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   llvm::SmallVector<Stmt *, 16> BodyStmts;
   llvm::SmallVector<InitListExpr *, 16> CollectionInitExprs;
   llvm::SmallVector<Stmt *, 16> FinalizeStmts;
+  // This collection contains the information required to add/remove information
+  // about arrays as we enter them.  The InitializedEntity component is
+  // necessary for initializing child members.  uin64_t is the index of the
+  // current element being worked on, which is updated every time we visit
+  // nextElement.
   llvm::SmallVector<std::pair<InitializedEntity, uint64_t>, 8> ArrayInfos;
   VarDecl *KernelObjClone;
   InitializedEntity VarEntity;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1824,7 +1824,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     addFieldInit(FD, Ty, ParamRef);
   }
 
-  MemberExpr *BuildMemberExpr(Expr *Base, const ValueDecl *Member) {
+  MemberExpr *BuildMemberExpr(Expr *Base, ValueDecl *Member) {
     DeclAccessPair MemberDAP = DeclAccessPair::make(Member, AS_none);
     MemberExpr *Result = SemaRef.BuildMemberExpr(
         Base, /*IsArrow */ false, SourceLocation(), NestedNameSpecifierLoc(),
@@ -1835,13 +1835,13 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     return Result;
   }
 
-  void AddFieldMemberExpr(const FieldDecl *FD, QualType Ty) {
-    if (!IsArrayType(FD, Ty))
+  void AddFieldMemberExpr(FieldDecl *FD, QualType Ty) {
+    if (!IsArrayElement(FD, Ty))
       MemberExprBases.push_back(BuildMemberExpr(MemberExprBases.back(), FD));
   }
 
   void RemoveFieldMemberExpr(const FieldDecl *FD, QualType Ty) {
-    if (!IsArrayType(FD, Ty))
+    if (!IsArrayElement(FD, Ty))
       MemberExprBases.pop_back();
   }
 
@@ -2107,7 +2107,7 @@ public:
 
     // If this is the top-level array, we need to make a MemberExpr in addition
     // to an array subscript.
-    AddFieldMemberExpr(FD, Ty);
+    AddFieldMemberExpr(FD, ArrayType);
     return true;
   }
 
@@ -2149,7 +2149,7 @@ public:
     MemberExprBases.pop_back();
 
     // Remove the field access expr as well.
-    AddFieldMemberExpr(FD, Ty);
+    RemoveFieldMemberExpr(FD, ArrayType);
     return true;
   }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2199,7 +2199,6 @@ class SyclKernelIntHeaderCreator : public SyclKernelFieldHandler {
     return FD->getType() != Ty;
   }
 
-
 public:
   SyclKernelIntHeaderCreator(Sema &S, SYCLIntegrationHeader &H,
                              const CXXRecordDecl *KernelObj, QualType NameType,
@@ -2236,8 +2235,7 @@ public:
     uint64_t Offset = CurOffset;
     if (!IsArrayElement(FD, FieldTy))
       Offset += offsetOf(FD);
-    Header.addParamDesc(SYCLIntegrationHeader::kind_accessor, Info,
-                        Offset);
+    Header.addParamDesc(SYCLIntegrationHeader::kind_accessor, Info, Offset);
     return true;
   }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1845,7 +1845,6 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
       MemberExprBases.pop_back();
   }
 
-
   void createSpecialMethodCall(const CXXRecordDecl *RD, StringRef MethodName,
                                SmallVectorImpl<Stmt *> &AddTo) {
     CXXMethodDecl *Method = getMethodByName(RD, MethodName);

--- a/clang/test/CodeGenSYCL/kernel-param-acc-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-acc-array.cpp
@@ -52,27 +52,28 @@ int main() {
 // CHECK accessor array default inits
 // CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %"class.{{.*}}.anon", %"class.{{.*}}.anon"* [[LOCAL_OBJECT]], i32 0, i32 0
 // CHECK: [[BEGIN:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], [2 x [[ACCESSOR]]]* [[ACCESSOR_ARRAY1]], i64 0, i64 0
-// CHECK: [[END:%[a-zA-Z0-9._]*]] = getelementptr inbounds [[ACCESSOR:.*]], [[ACCESSOR]]* [[BEGIN]], i64 2
-// CHECK: [[NEXT0:%[a-zA-Z0-9._]*]] = getelementptr inbounds [[ACCESSOR]], [[ACCESSOR]]* {{.*}}, i64 1
-// CHECK: [[ELEMENT:%[a-zA-Z0-9._]*]] = getelementptr inbounds [[ACCESSOR]], [[ACCESSOR]]* {{.*}}, i64 1
-// CHECK: [[ELEMENT:%[a-zA-Z0-9._]*]] = getelementptr inbounds [[ACCESSOR]], [[ACCESSOR]]* {{.*}}, i64 2
-// CHECK: [[NEXT1:%[a-zA-Z0-9._]*]] = getelementptr inbounds [[ACCESSOR]], [[ACCESSOR]]* {{.*}}, i64 1
-
-// CHECK: [[ACCESSOR_ARRAY2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %"class.{{.*}}.anon", %"class.{{.*}}.anon"* [[LOCAL_OBJECT]], i32 0, i32 0
-// CHECK: [[INDEX:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR]]], [2 x [[ACCESSOR]]]* [[ACCESSOR_ARRAY2]], i64 0, i64 0
-
-// CHECK load from kernel pointer argument alloca
-// CHECK: [[MEM_LOAD1:%[a-zA-Z0-9_]+]] = load i32 addrspace(1)*, i32 addrspace(1)** [[MEM_ARG1]]
-
-// CHECK: [[ACC_CAST1:%[0-9]+]] = addrspacecast [[ACCESSOR]]* {{.*}} to [[ACCESSOR]] addrspace(4)*
+// Clang takes advantage of element 1 having the same address as the array, so it doesn't do a GEP.
+// CHECK: [[ELEM1_ASCAST:%[a-zA-Z0-9_.]+]] = addrspacecast [[ACCESSOR]]* [[BEGIN]] to [[ACCESSOR]] addrspace(4)*
+// CTOR Call #1
+// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* [[ELEM1_ASCAST]])
+// CHECK: [[ELEM2_GEP:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [[ACCESSOR]], [[ACCESSOR]]* [[BEGIN]], i64 1
+// CHECK: [[ELEM2_ASCAST:%[a-zA-Z0-9_.]+]] = addrspacecast [[ACCESSOR]]* [[ELEM2_GEP]] to [[ACCESSOR]] addrspace(4)*
+// CTOR Call #2
+// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* [[ELEM2_ASCAST]])
 
 // CHECK acc[0] __init method call
+// CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %"class.{{.*}}.anon", %"class.{{.*}}.anon"* [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[INDEX1:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR]]], [2 x [[ACCESSOR]]]* [[ACCESSOR_ARRAY1]], i64 0, i64 0
+// CHECK load from kernel pointer argument alloca
+// CHECK: [[MEM_LOAD1:%[a-zA-Z0-9_]+]] = load i32 addrspace(1)*, i32 addrspace(1)** [[MEM_ARG1]]
+// CHECK: [[ACC_CAST1:%[0-9]+]] = addrspacecast [[ACCESSOR]]* [[INDEX1]] to [[ACCESSOR]] addrspace(4)*
 // CHECK: call spir_func void @{{.*}}__init{{.*}}(%"class.{{.*}}.cl::sycl::accessor" addrspace(4)* [[ACC_CAST1]], i32 addrspace(1)* [[MEM_LOAD1]], %"struct.{{.*}}.cl::sycl::range"* byval({{.*}}) align 4 [[ACC_RANGE1]], %"struct.{{.*}}.cl::sycl::range"* byval({{.*}}) align 4 [[MEM_RANGE1]], %"struct.{{.*}}.cl::sycl::id"* byval({{.*}}) align 4 [[OFFSET1]])
 
-// CHECK load from kernel pointer argument alloca
-// CHECK: [[MEM_LOAD2:%[a-zA-Z0-9_]+]] = load i32 addrspace(1)*, i32 addrspace(1)** [[MEM_ARG2]]
-
-// CHECK: [[ACC_CAST2:%[0-9]+]] = addrspacecast [[ACCESSOR]]* {{.*}} to [[ACCESSOR]] addrspace(4)*
 
 // CHECK acc[1] __init method call
+// CHECK: [[ACCESSOR_ARRAY2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %"class.{{.*}}.anon", %"class.{{.*}}.anon"* [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[INDEX2:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR]]], [2 x [[ACCESSOR]]]* [[ACCESSOR_ARRAY2]], i64 0, i64 1
+// CHECK load from kernel pointer argument alloca
+// CHECK: [[MEM_LOAD2:%[a-zA-Z0-9_]+]] = load i32 addrspace(1)*, i32 addrspace(1)** [[MEM_ARG2]]
+// CHECK: [[ACC_CAST2:%[0-9]+]] = addrspacecast [[ACCESSOR]]* [[INDEX2]] to [[ACCESSOR]] addrspace(4)*
 // CHECK: call spir_func void @{{.*}}__init{{.*}}(%"class.{{.*}}.cl::sycl::accessor" addrspace(4)* [[ACC_CAST2]], i32 addrspace(1)* [[MEM_LOAD2]], %"struct.{{.*}}.cl::sycl::range"* byval({{.*}}) align 4 [[ACC_RANGE2]], %"struct.{{.*}}.cl::sycl::range"* byval({{.*}}) align 4 [[MEM_RANGE2]], %"struct.{{.*}}.cl::sycl::id"* byval({{.*}}) align 4 [[OFFSET2]])

--- a/clang/test/CodeGenSYCL/kernel-param-acc-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-acc-array.cpp
@@ -69,7 +69,6 @@ int main() {
 // CHECK: [[ACC_CAST1:%[0-9]+]] = addrspacecast [[ACCESSOR]]* [[INDEX1]] to [[ACCESSOR]] addrspace(4)*
 // CHECK: call spir_func void @{{.*}}__init{{.*}}(%"class.{{.*}}.cl::sycl::accessor" addrspace(4)* [[ACC_CAST1]], i32 addrspace(1)* [[MEM_LOAD1]], %"struct.{{.*}}.cl::sycl::range"* byval({{.*}}) align 4 [[ACC_RANGE1]], %"struct.{{.*}}.cl::sycl::range"* byval({{.*}}) align 4 [[MEM_RANGE1]], %"struct.{{.*}}.cl::sycl::id"* byval({{.*}}) align 4 [[OFFSET1]])
 
-
 // CHECK acc[1] __init method call
 // CHECK: [[ACCESSOR_ARRAY2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %"class.{{.*}}.anon", %"class.{{.*}}.anon"* [[LOCAL_OBJECT]], i32 0, i32 0
 // CHECK: [[INDEX2:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR]]], [2 x [[ACCESSOR]]]* [[ACCESSOR_ARRAY2]], i64 0, i64 1

--- a/clang/test/CodeGenSYCL/kernel-param-member-acc-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-member-acc-array.cpp
@@ -52,13 +52,18 @@ int main() {
 // CHECK: [[MEM_RANGE2:%[a-zA-Z0-9_.]+]] = alloca %"struct.{{.*}}.cl::sycl::range"
 // CHECK: [[OFFSET2:%[a-zA-Z0-9_.]+]] = alloca %"struct.{{.*}}.cl::sycl::id"
 
-// Check loop which calls the default constructor for each element of accessor array is emitted.
-// CHECK: [[GEP_LAMBDA:%[a-zA-Z0-9_]+]] = getelementptr inbounds %"class.{{.*}}.anon", %"class.{{.*}}.anon"* [[LOCAL_OBJECT]], i32 0, i32 0
-// CHECK: [[GEP_MEMBER_ACC:%[a-zA-Z_]+]] = getelementptr inbounds %struct.{{.*}}.struct_acc_t, %struct.{{.*}}.struct_acc_t* [[GEP_LAMBDA]], i32 0, i32 0
-// CHECK: [[ARRAY_BEGIN:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], [2 x [[ACCESSOR]]]* [[GEP_MEMBER_ACC]], i64 0, i64 0
-// CHECK: [[ARRAY_END:%[a-zA-Z0-9._]*]] = getelementptr inbounds [[ACCESSOR]], [[ACCESSOR]]* [[ARRAY_BEGIN]], i64 2
-// CHECK: br label %arrayctor.loop
-// CHECK: arrayctor.loop:
+// CHECK accessor array default inits
+// CHECK: [[ACCESSOR_WRAPPER:%[a-zA-Z0-9_]+]] = getelementptr inbounds %"class.{{.*}}.anon", %"class.{{.*}}.anon"* [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_.]+]] = getelementptr inbounds %struct.{{.*}}.struct_acc_t, %struct.{{.*}}.struct_acc_t* [[ACCESSOR_WRAPPER]], i32 0, i32 0
+// CHECK: [[BEGIN:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], [2 x [[ACCESSOR]]]* [[ACCESSOR_ARRAY1]], i64 0, i64 0
+// Clang takes advantage of element 1 having the same address as the array, so it doesn't do a GEP.
+// CHECK: [[ELEM1_ASCAST:%[a-zA-Z0-9_.]+]] = addrspacecast [[ACCESSOR]]* [[BEGIN]] to [[ACCESSOR]] addrspace(4)*
+// CTOR Call #1
+// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* [[ELEM1_ASCAST]])
+// CHECK: [[ELEM2_GEP:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [[ACCESSOR]], [[ACCESSOR]]* [[BEGIN]], i64 1
+// CHECK: [[ELEM2_ASCAST:%[a-zA-Z0-9_.]+]] = addrspacecast [[ACCESSOR]]* [[ELEM2_GEP]] to [[ACCESSOR]] addrspace(4)*
+// CTOR Call #2
+// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* [[ELEM2_ASCAST]])
 
 // Check acc[0] __init method call
 // CHECK: [[GEP_LAMBDA1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %"class.{{.*}}.anon", %"class.{{.*}}.anon"* [[LOCAL_OBJECT]], i32 0, i32 0

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -219,6 +219,7 @@ public:
 };
 
 class stream {
+  accessor<int, 1, access::mode::read> acc;
 public:
   stream(unsigned long BufferSize, unsigned long MaxStatementSize,
          handler &CGH) {}

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -229,7 +229,6 @@ public:
   void __finalize() {}
 };
 
-
 namespace ONEAPI {
 namespace experimental {
 template <typename T, typename ID = T>

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -218,6 +218,18 @@ public:
   }
 };
 
+class stream {
+public:
+  stream(unsigned long BufferSize, unsigned long MaxStatementSize,
+         handler &CGH) {}
+
+  void __init() {}
+  void use() const {}
+
+  void __finalize() {}
+};
+
+
 namespace ONEAPI {
 namespace experimental {
 template <typename T, typename ID = T>

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -220,6 +220,7 @@ public:
 
 class stream {
   accessor<int, 1, access::mode::read> acc;
+
 public:
   stream(unsigned long BufferSize, unsigned long MaxStatementSize,
          handler &CGH) {}

--- a/clang/test/SemaSYCL/array-kernel-param.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param.cpp
@@ -123,8 +123,8 @@ int main() {
 // CHECK-NEXT: InitListExpr {{.*}} '(lambda at {{.*}}array-kernel-param.cpp{{.*}})'
 // CHECK-NEXT: InitListExpr {{.*}} 'struct_acc_t'
 // CHECK-NEXT: InitListExpr {{.*}} 'Accessor [2]'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'Accessor [2]'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'Accessor [2]'
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'Accessor'
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'Accessor'
 
 // Check __init functions are called
 // CHECK: CXXMemberCallExpr {{.*}} 'void'

--- a/clang/test/SemaSYCL/streams.cpp
+++ b/clang/test/SemaSYCL/streams.cpp
@@ -12,7 +12,7 @@ using namespace cl::sycl;
 handler H;
 
 struct HasStreams {
-  stream s1{0,0,H};
+  stream s1{0, 0, H};
   stream s_array[2] = {{0, 0, H}, {0, 0, H}};
 };
 
@@ -22,9 +22,9 @@ struct HasArrayOfHasStreams {
 };
 
 void use() {
-  stream in_lambda {0,0,H};
+  stream in_lambda{0, 0, H};
   stream in_lambda_array[2] = {{0, 0, H}, {0, 0, H}};
-  stream in_lambda_mdarray[2][2] = {{{0, 0, H}, {0, 0, H}},{{0, 0, H}, {0, 0, H}}};
+  stream in_lambda_mdarray[2][2] = {{{0, 0, H}, {0, 0, H}}, {{0, 0, H}, {0, 0, H}}};
 
   HasStreams Struct;
   HasArrayOfHasStreams haohs;
@@ -40,7 +40,7 @@ void use() {
     haohs.hs[0].s1.use();
     haohs_array[0].hs[0].s1.use();
   });
-  }
+}
 
 // Function Declaration
 // CHECK: FunctionDecl {{.*}}stream_test{{.*}}
@@ -222,7 +222,6 @@ void use() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
 // CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
 
-
 // Calls to Init
 // in_lambda __init
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
@@ -319,7 +318,6 @@ void use() {
 // CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 
-
 // HasArrayOfHasStreams
 // First element
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
@@ -393,7 +391,6 @@ void use() {
 // CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-
 
 // HasArrayOfHasStreams array
 // First element
@@ -673,7 +670,6 @@ void use() {
 // CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 
-
 // HasArrayOfHasStreams
 // First element
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
@@ -747,7 +743,6 @@ void use() {
 // CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-
 
 // HasArrayOfHasStreams array
 // First element

--- a/clang/test/SemaSYCL/streams.cpp
+++ b/clang/test/SemaSYCL/streams.cpp
@@ -1,0 +1,932 @@
+// RUN: %clang_cc1 -S -I %S/Inputs -fsycl -fsycl-is-device -triple spir64 -ast-dump %s | FileCheck %s
+
+#include <sycl.hpp>
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
+  kernelFunc();
+}
+
+using namespace cl::sycl;
+
+handler H;
+
+struct HasStreams {
+  stream s1{0,0,H};
+  stream s_array[2] = {{0, 0, H}, {0, 0, H}};
+};
+
+struct HasArrayOfHasStreams {
+  int i;
+  HasStreams hs[2];
+};
+
+void use() {
+  stream in_lambda {0,0,H};
+  stream in_lambda_array[2] = {{0, 0, H}, {0, 0, H}};
+  stream in_lambda_mdarray[2][2] = {{{0, 0, H}, {0, 0, H}},{{0, 0, H}, {0, 0, H}}};
+
+  HasStreams Struct;
+  HasArrayOfHasStreams haohs;
+  HasArrayOfHasStreams haohs_array[2];
+
+  kernel<class stream_test>([=]() {
+    in_lambda.use();
+    in_lambda_array[1].use();
+    in_lambda_mdarray[1][1].use();
+
+    Struct.s1.use();
+
+    haohs.hs[0].s1.use();
+    haohs_array[0].hs[0].s1.use();
+  });
+  }
+
+// Function Declaration
+// CHECK: FunctionDecl {{.*}}stream_test{{.*}}
+
+// Initializers:
+// CHECK: InitListExpr {{.*}} '(lambda at
+// 'in_lambda'
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+
+// 'in_lambda_array'
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+
+// 'in_lambda_mdarray'
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2][2]'
+// sub-array 0
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// sub-array 1
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+
+// HasStreams struct
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
+// HasStreams::s1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams::s_array
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+
+// HasArrayOfHasStreams
+// CHECK-NEXT: InitListExpr {{.*}} 'HasArrayOfHasStreams'
+// HasArrayOfHasStreams::i
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar
+// HasArrayOfHasStreams::hs
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams [2]'
+// HasStreams struct
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
+// HasStreams::s1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams::s_array
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams struct
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
+// HasStreams::s1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams::s_array
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+
+// HasArrayOfHasStreams Array
+// CHECK-NEXT: InitListExpr {{.*}} 'HasArrayOfHasStreams [2]'
+// CHECK-NEXT: InitListExpr {{.*}} 'HasArrayOfHasStreams'
+// HasArrayOfHasStreams::i
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar
+// HasArrayOfHasStreams::hs
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams [2]'
+// HasStreams struct
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
+// HasStreams::s1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams::s_array
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams struct
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
+// HasStreams::s1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams::s_array
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// CHECK-NEXT: InitListExpr {{.*}} 'HasArrayOfHasStreams'
+// HasArrayOfHasStreams::i
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar
+// HasArrayOfHasStreams::hs
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams [2]'
+// HasStreams struct
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
+// HasStreams::s1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams::s_array
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams struct
+// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
+// HasStreams::s1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// HasStreams::s_array
+// CHECK-NEXT: InitListExpr {{.*}} 'cl::sycl::stream [2]'
+// element 0
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+// element 1
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'cl::sycl::stream' 'void (const cl::sycl::stream &) noexcept'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
+// CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
+
+
+// Calls to Init
+// in_lambda __init
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+
+// _in_lambda_array
+// element 0
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
+// _in_lambda_mdarray
+// [0][0]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// [0][1]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// [1][0]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// [1][1]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
+// HasStreams
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
+
+// HasArrayOfHasStreams
+// First element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// second element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
+
+// HasArrayOfHasStreams array
+// First element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// second element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// second element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// second element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
+// Finalize
+// in_lambda __finalize
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+
+// _in_lambda_array
+// element 0
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
+// _in_lambda_mdarray
+// [0][0]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// [0][1]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// [1][0]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// [1][1]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
+// HasStreams
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
+
+// HasArrayOfHasStreams
+// First element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// second element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
+
+// HasArrayOfHasStreams array
+// First element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// second element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// second element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// second element
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1

--- a/clang/test/SemaSYCL/streams.cpp
+++ b/clang/test/SemaSYCL/streams.cpp
@@ -222,8 +222,15 @@ void use() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const cl::sycl::stream' lvalue <NoOp>
 // CHECK-NEXT: DeclRefExpr {{.*}} 'cl::sycl::stream' lvalue ParmVar
 
-// Calls to Init
+// Calls to Init, note that the accessor in the stream comes first, since the
+// stream __init call depends on the accessor's call already having happened.
 // in_lambda __init
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .
@@ -232,13 +239,32 @@ void use() {
 // _in_lambda_array
 // element 0
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue
 // CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+
 // element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -249,6 +275,17 @@ void use() {
 
 // _in_lambda_mdarray
 // [0][0]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -261,6 +298,17 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // [0][1]
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
@@ -272,6 +320,17 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // [1][0]
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
@@ -282,6 +341,17 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // [1][1]
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream [2]' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream (*)[2]' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2][2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -295,11 +365,26 @@ void use() {
 
 // HasStreams
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
 // CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
 // CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
 // array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -309,6 +394,15 @@ void use() {
 // CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -321,6 +415,16 @@ void use() {
 // HasArrayOfHasStreams
 // First element
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
@@ -330,6 +434,19 @@ void use() {
 // CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -343,6 +460,19 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -357,6 +487,16 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // second element
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
@@ -366,6 +506,19 @@ void use() {
 // CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -379,6 +532,19 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -395,6 +561,19 @@ void use() {
 // HasArrayOfHasStreams array
 // First element
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
@@ -407,6 +586,22 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -423,6 +618,22 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -440,6 +651,19 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // second element
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
@@ -452,6 +676,22 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -468,6 +708,22 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -485,6 +741,19 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // second element
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
@@ -497,6 +766,22 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -513,6 +798,22 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -530,6 +831,19 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // second element
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream' lvalue .s1
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
@@ -542,6 +856,22 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // array:
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
@@ -558,6 +888,22 @@ void use() {
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
+// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (cl::sycl::accessor{{.*}})' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'accessor<{{.*}}' lvalue .acc
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'cl::sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'cl::sycl::stream [2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams [2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}} 'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams [2]' lvalue .
+// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'cl::sycl::stream' lvalue

--- a/clang/test/SemaSYCL/streams.cpp
+++ b/clang/test/SemaSYCL/streams.cpp
@@ -2,7 +2,7 @@
 
 #include <sycl.hpp>
 
-template <typename name, typename Func>
+template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }


### PR DESCRIPTION
The intent of this patch is simply to clean up how arrays work in the
SYCL visitors.  The patch unifies the handling of array elements and 
normal fields, such that they should be more maintainable.

This required a handful of changes to make integration headers work
a little better.

Work on this DID require quite a bit of a re-imagining of how the
DeclBodyCreator works. There are a number of small refactors to fix
things I found while working that I believe make it easier to maintain
this in the future.

However, the biggest change here is with the init-list-expr creation.
This patch creates them in advance, rather than waiting until we are
done with a struct/array/etc.  This allows us to generate them as we go.

The side effect of this is that the InitExprs array now ONLY contains
collection InitListExprs, since it no longer has to assemble them on the
other side.  However, now adding a field ends up being really easy,
since appending to the init-list is easier.

MemberExprBases also becomes easier to maintain, since they now only
get added when changing to/from a field or collection.