### PR TITLE
[SYCL][L0]: Fix Event Signal flags

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2722,7 +2722,9 @@ pi_result piEventCreate(pi_context Context, pi_event *RetEvent) {
   ZE_CALL(Context->getFreeSlotInExistingOrNewPool(ZeEventPool, Index));
   ze_event_handle_t ZeEvent;
   ze_event_desc_t ZeEventDesc = {};
-  ZeEventDesc.signal = ZE_EVENT_SCOPE_FLAG_NONE;
+  // We have to set the SIGNAL & WAIT flags as HOST scope because the
+  // L0 plugin implementation waits for the events to complete on the host.
+  ZeEventDesc.signal = ZE_EVENT_SCOPE_FLAG_HOST;
   ZeEventDesc.wait = ZE_EVENT_SCOPE_FLAG_HOST;
   ZeEventDesc.version = ZE_EVENT_DESC_VERSION_CURRENT;
   ZeEventDesc.index = Index;


### PR DESCRIPTION
- All events created in the plugin must have the event scope flag
ZE_EVENT_SCOPE_FLAG_HOST on the signal & wait otherwise the events are
not flushing changes to the host after completion causing a data race.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>