### PR TITLE
[SYCL] Eliminated events dependency on queue.

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -119,7 +119,7 @@ event_impl::event_impl(RT::PiEvent Event, const context &SyclContext)
   getPlugin().call<PiApiKind::piEventRetain>(MEvent);
 }
 
-event_impl::event_impl(QueueImplPtr Queue) : MQueue(Queue) {
+event_impl::event_impl(QueueImplPtr Queue) {
   if (Queue->is_host()) {
     MState.store(HES_NotComplete);
 
@@ -217,9 +217,9 @@ void event_impl::wait_and_throw(
     if (Cmd)
       Cmd->getQueue()->throw_asynchronous();
   }
-  QueueImplPtr Queue = MQueue.lock();
-  if (Queue)
-    Queue->throw_asynchronous();
+  Command *Cmd = (Command *)getCommand();
+  if (Cmd)
+    Cmd->getQueue()->throw_asynchronous();
 }
 
 template <>

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -26,7 +26,6 @@ class context_impl;
 using ContextImplPtr = std::shared_ptr<cl::sycl::detail::context_impl>;
 class queue_impl;
 using QueueImplPtr = std::shared_ptr<cl::sycl::detail::queue_impl>;
-using QueueImplWPtr = std::weak_ptr<cl::sycl::detail::queue_impl>;
 
 class event_impl {
 public:
@@ -166,7 +165,6 @@ private:
 
   RT::PiEvent MEvent = nullptr;
   ContextImplPtr MContext;
-  QueueImplWPtr MQueue;
   bool MOpenCLInterop = false;
   bool MHostEvent = true;
   std::unique_ptr<HostProfilingInfo> MHostProfilingInfo;


### PR DESCRIPTION
This patch removes events dependency on queue according to
suggestions from #1226.

Signed-off-by: Ivan Karachun <ivan.karachun@intel.com>