### PR TITLE
[SYCL] Fix get_backend() to work for host platform impls.

### DIFF
--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -106,7 +106,16 @@ public:
   static vector_class<platform> get_platforms();
 
   // \return the Backend associated with this platform.
-  backend get_backend() const noexcept { return getPlugin().getBackend(); }
+  backend get_backend() const noexcept {
+    backend Result;
+    if (is_host())
+      Result = backend::host;
+    else {
+      Result = getPlugin().getBackend();
+    }
+
+    return Result;
+  }
 
   // \return the Plugin associated with this platform.
   const plugin &getPlugin() const {


### PR DESCRIPTION
platform_impl's get_backend() method always tried to obtain a plugin first.
Host platforms don't have plugins, but do have a host backend.

Signed-off-by: James Brodman <james.brodman@intel.com>