### PR TITLE
[Driver][SYCL] Improve tool name specification for AOT tools on Windows

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -204,6 +204,13 @@ void SYCL::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                            SpirvInputs);
 }
 
+static const char *makeExeName(Compilation &C, StringRef Name) {
+  llvm::SmallString<8> ExeName(Name);
+  if (C.getDriver().IsCLMode())
+    ExeName.append(".exe");
+  return C.getArgs().MakeArgString(ExeName);
+}
+
 void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
                                          const JobAction &JA,
                                          const InputInfo &Output,
@@ -312,7 +319,8 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
     CmdArgs.push_back(Args.MakeArgString(A->getAsString(Args)));
   }
 
-  SmallString<128> ExecPath(getToolChain().GetProgramPath("aoc"));
+  SmallString<128> ExecPath(
+      getToolChain().GetProgramPath(makeExeName(C, "aoc")));
   const char *Exec = C.getArgs().MakeArgString(ExecPath);
   auto Cmd = std::make_unique<Command>(
       JA, *this, ResponseFileSupport::None(), Exec, CmdArgs, None);
@@ -349,7 +357,8 @@ void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
       static_cast<const toolchains::SYCLToolChain &>(getToolChain());
   TC.TranslateBackendTargetArgs(Args, CmdArgs);
   TC.TranslateLinkerTargetArgs(Args, CmdArgs);
-  SmallString<128> ExecPath(getToolChain().GetProgramPath("ocloc"));
+  SmallString<128> ExecPath(
+      getToolChain().GetProgramPath(makeExeName(C, "ocloc")));
   const char *Exec = C.getArgs().MakeArgString(ExecPath);
   auto Cmd = std::make_unique<Command>(
       JA, *this, ResponseFileSupport::None(), Exec, CmdArgs, None);
@@ -382,7 +391,8 @@ void SYCL::x86_64::BackendCompiler::ConstructJob(Compilation &C,
 
   TC.TranslateBackendTargetArgs(Args, CmdArgs);
   TC.TranslateLinkerTargetArgs(Args, CmdArgs);
-  SmallString<128> ExecPath(getToolChain().GetProgramPath("opencl-aot"));
+  SmallString<128> ExecPath(
+      getToolChain().GetProgramPath(makeExeName(C, "opencl-aot")));
   const char *Exec = C.getArgs().MakeArgString(ExecPath);
   auto Cmd = std::make_unique<Command>(
       JA, *this, ResponseFileSupport::None(), Exec, CmdArgs, None);

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -686,6 +686,17 @@
 // CHK-TOOLS-AOT: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-include" "[[INPUT1]]" {{.*}} "-o" "[[OUTPUT7:.+\.o]]"
 // CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT7]]" "[[OUTPUT6]]" {{.*}} "-lsycl"
 
+// Check to be sure that for windows, the 'exe' tools are called
+// RUN: %clang_cl -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-CPU-WIN
+// RUN: %clang_cl -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-GEN-WIN
+// RUN: %clang_cl -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-FPGA-WIN
+// CHK-TOOLS-GEN-WIN: ocloc.exe{{.*}}
+// CHK-TOOLS-CPU-WIN: opencl-aot.exe{{.*}}
+// CHK-TOOLS-FPGA-WIN: aoc.exe{{.*}}
+
 /// ###########################################################################
 
 /// Check -Xsycl-target-backend option passing


### PR DESCRIPTION
For Windows, we need to be sure to search for the full executable name
as opposed to just the case name for the AOT tools (aoc, ocloc, opencl-aot).
There can be instances of directory names of the same name, causing the
wrong 'binary' to be called.