### PR TITLE
[SYCL][FPGA] Add compute units library.

### DIFF
--- a/sycl/include/CL/sycl/INTEL/compute_units.hpp
+++ b/sycl/include/CL/sycl/INTEL/compute_units.hpp
@@ -1,0 +1,43 @@
+//==--------- compute_units.hpp - SYCL Compute Units -------*- C++ -*-------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl.hpp>
+#include <utility>
+
+namespace intelfpga {
+
+template <class Func, template <std::size_t> class Name, std::size_t index>
+class SubmitOneComputeUnit {
+public:
+  SubmitOneComputeUnit(Func &&f, sycl::queue &q) {
+
+    q.submit([&](sycl::handler &h) {
+      h.single_task<Name<index>>([=]() {
+        // verifies that f only takes a single argument
+        f(std::integral_constant<std::size_t, index>());
+      });
+    });
+  }
+};
+
+template <template <std::size_t> class Name, class Func, std::size_t... index>
+inline constexpr void Unroller(sycl::queue &q, Func &&f,
+                               std::index_sequence<index...>) {
+  (SubmitOneComputeUnit<Func, Name, index>(f, q), ...); // fold expression
+}
+
+// N is the number of compute units
+// Name is the kernel's name
+template <std::size_t N, template <std::size_t ID> class Name, class Func>
+constexpr void submit_compute_units(sycl::queue &q, Func &&f) {
+  std::make_index_sequence<N> indices;
+  Unroller<Name>(q, f, indices);
+}
+} // namespace intelfpga

--- a/sycl/include/CL/sycl/INTEL/compute_units.hpp
+++ b/sycl/include/CL/sycl/INTEL/compute_units.hpp
@@ -9,9 +9,12 @@
 #pragma once
 
 #include <CL/sycl.hpp>
+#include <CL/sycl/detail/defines.hpp>
 #include <utility>
 
-namespace intelfpga {
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace INTEL {
 
 template <class Func, template <std::size_t> class Name, std::size_t index>
 class SubmitOneComputeUnit {
@@ -28,7 +31,7 @@ public:
 };
 
 template <template <std::size_t> class Name, class Func, std::size_t... index>
-inline constexpr void Unroller(sycl::queue &q, Func &&f,
+inline constexpr void ComputeUnitUnroller(sycl::queue &q, Func &&f,
                                std::index_sequence<index...>) {
   (SubmitOneComputeUnit<Func, Name, index>(f, q), ...); // fold expression
 }
@@ -38,6 +41,9 @@ inline constexpr void Unroller(sycl::queue &q, Func &&f,
 template <std::size_t N, template <std::size_t ID> class Name, class Func>
 constexpr void submit_compute_units(sycl::queue &q, Func &&f) {
   std::make_index_sequence<N> indices;
-  Unroller<Name>(q, f, indices);
+  ComputeUnitUnroller<Name>(q, f, indices);
 }
-} // namespace intelfpga
+
+} // namespace INTEL
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/INTEL/compute_units.hpp
+++ b/sycl/include/CL/sycl/INTEL/compute_units.hpp
@@ -16,6 +16,7 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace INTEL {
 
+namespace {
 template <class Func, template <std::size_t> class Name, std::size_t index>
 class SubmitOneComputeUnit {
 public:
@@ -35,6 +36,7 @@ inline constexpr void ComputeUnitUnroller(sycl::queue &q, Func &&f,
                                           std::index_sequence<index...>) {
   (SubmitOneComputeUnit<Func, Name, index>(f, q), ...); // fold expression
 }
+} // namespace
 
 // N is the number of compute units
 // Name is the kernel's name

--- a/sycl/include/CL/sycl/INTEL/compute_units.hpp
+++ b/sycl/include/CL/sycl/INTEL/compute_units.hpp
@@ -32,7 +32,7 @@ public:
 
 template <template <std::size_t> class Name, class Func, std::size_t... index>
 inline constexpr void ComputeUnitUnroller(sycl::queue &q, Func &&f,
-                               std::index_sequence<index...>) {
+                                          std::index_sequence<index...>) {
   (SubmitOneComputeUnit<Func, Name, index>(f, q), ...); // fold expression
 }
 

--- a/sycl/include/CL/sycl/INTEL/fpga_extensions.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_extensions.hpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+#include <CL/sycl/INTEL/compute_units.hpp>
 #include <CL/sycl/INTEL/fpga_device_selector.hpp>
 #include <CL/sycl/INTEL/fpga_lsu.hpp>
 #include <CL/sycl/INTEL/fpga_reg.hpp>

--- a/sycl/include/CL/sycl/INTEL/fpga_extensions.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_extensions.hpp
@@ -11,5 +11,5 @@
 #include <CL/sycl/INTEL/fpga_device_selector.hpp>
 #include <CL/sycl/INTEL/fpga_lsu.hpp>
 #include <CL/sycl/INTEL/fpga_reg.hpp>
-#include <CL/sycl/INTEL/pipes.hpp>
 #include <CL/sycl/INTEL/pipe_array.hpp>
+#include <CL/sycl/INTEL/pipes.hpp>

--- a/sycl/include/CL/sycl/INTEL/fpga_extensions.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_extensions.hpp
@@ -12,3 +12,4 @@
 #include <CL/sycl/INTEL/fpga_lsu.hpp>
 #include <CL/sycl/INTEL/fpga_reg.hpp>
 #include <CL/sycl/INTEL/pipes.hpp>
+#include <CL/sycl/INTEL/pipe_array.hpp>

--- a/sycl/include/CL/sycl/INTEL/pipe_array.hpp
+++ b/sycl/include/CL/sycl/INTEL/pipe_array.hpp
@@ -1,0 +1,58 @@
+//==--------------- pipe_array.hpp - SYCL pipe array --------*- C++ -*------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===--------------------------------------------------------------------=== //
+
+#pragma once
+
+#include <CL/sycl/intel/pipes.hpp>
+#include <utility>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace INTEL {
+
+namespace {
+template <size_t dim1, size_t... dims> struct VerifierDimLayer {
+  template <size_t idx1, size_t... idxs> struct VerifierIdxLayer {
+    static constexpr bool IsValid() {
+      return idx1 < dim1 &&
+             (VerifierDimLayer<dims...>::template VerifierIdxLayer<
+                 idxs...>::IsValid());
+    }
+  };
+};
+template <size_t dim> struct VerifierDimLayer<dim> {
+  template <size_t idx> struct VerifierIdxLayer {
+    static constexpr bool IsValid() { return idx < dim; }
+  };
+};
+} // namespace
+
+template <class Id, typename BaseTy, size_t depth, size_t... dims>
+struct PipeArray {
+  PipeArray() = delete;
+
+  template <size_t... idxs> struct StructId;
+
+  template <size_t... idxs> struct VerifyIndices {
+    static_assert(sizeof...(idxs) == sizeof...(dims),
+                  "Indexing into a PipeArray requires as many indices as "
+                  "dimensions of the PipeArray.");
+    static_assert(VerifierDimLayer<dims...>::template VerifierIdxLayer<
+                      idxs...>::IsValid(),
+                  "Index out of bounds");
+    using VerifiedPipe =
+        cl::sycl::intel::pipe<StructId<idxs...>, BaseTy, depth>;
+  };
+
+  template <size_t... idxs>
+  using PipeAt = typename VerifyIndices<idxs...>::VerifiedPipe;
+};
+
+} // namespace INTEL
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/INTEL/pipe_array.hpp
+++ b/sycl/include/CL/sycl/INTEL/pipe_array.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <CL/sycl/intel/pipes.hpp>
+#include <CL/sycl/INTEL/pipes.hpp>
 #include <utility>
 
 __SYCL_INLINE_NAMESPACE(cl) {

--- a/sycl/include/CL/sycl/INTEL/pipe_array.hpp
+++ b/sycl/include/CL/sycl/INTEL/pipe_array.hpp
@@ -45,8 +45,7 @@ struct PipeArray {
     static_assert(VerifierDimLayer<dims...>::template VerifierIdxLayer<
                       idxs...>::IsValid(),
                   "Index out of bounds");
-    using VerifiedPipe =
-        cl::sycl::intel::pipe<StructId<idxs...>, BaseTy, depth>;
+    using VerifiedPipe = pipe<StructId<idxs...>, BaseTy, depth>;
   };
 
   template <size_t... idxs>

--- a/sycl/test/fpga_tests/compute_units.cpp
+++ b/sycl/test/fpga_tests/compute_units.cpp
@@ -1,0 +1,78 @@
+//==------------ compute_units.cpp - SYCL FPGA compute units test ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl/INTEL/fpga_extensions.hpp>
+
+using namespace sycl;
+
+constexpr float kTestData = 555;
+
+constexpr size_t kComputeUnits = 5;
+using Pipes = INTEL::PipeArray<class MyPipe, float, 4, kComputeUnits + 1>;
+
+class source_kernel;
+class sink_kernel;
+
+template <std::size_t ID> class chain_kernel;
+
+// Write the first piece of data to the pipeline
+void SourceKernel(queue &q, float data) {
+
+  q.submit([&](handler &h) {
+    h.single_task<source_kernel>([=]() { Pipes::PipeAt<0>::write(data); });
+  });
+}
+
+// Grab the data out of the pipeline and return to host in out_data array
+void SinkKernel(queue &q, std::array<float, 1> &out_data) {
+
+  buffer<float, 1> out_buf(out_data.data(), 1);
+
+  q.submit([&](handler &h) {
+    auto out_accessor = out_buf.get_access<access::mode::write>(h);
+    h.single_task<sink_kernel>(
+        [=]() { out_accessor[0] = Pipes::PipeAt<kEngines>::read(); });
+  });
+}
+
+template <int TestNumber> int test_compute_units(queue q) {
+
+  std::array<float, 1> out_data = {0};
+
+  SourceKernel(q, kTestData);
+
+  INTEL::submit_compute_units<kComputeUnits, chain_kernel>(q, [=](auto ID) {
+    // read from id, not id-1 because the index_sequence starts from 0
+    float f = Pipes::PipeAt<ID>::read();
+    Pipes::PipeAt<ID + 1>::write(f);
+  });
+
+  SinkKernel(q, out_data);
+
+  if (out_data[0] != kTestData) {
+    std::cout << "Test: " << TestNumber << "\nResult mismatches " << out_data[0]
+              << " Vs expected " << kTestData << std::endl;
+    return -1;
+  }
+
+  return 0;
+}
+
+int main() {
+  cl::sycl::queue Queue;
+
+  if (!Queue.get_device()
+           .get_info<cl::sycl::info::device::kernel_kernel_pipe_support>()) {
+    std::cout << "SYCL_INTEL_data_flow_pipes not supported, skipping"
+              << std::endl;
+    return 0;
+  }
+
+  int Result = test_compute_units</*test number*/ 1>(Queue);
+  return Result;
+}

--- a/sycl/test/fpga_tests/compute_units.cpp
+++ b/sycl/test/fpga_tests/compute_units.cpp
@@ -1,3 +1,6 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
 //==------------ compute_units.cpp - SYCL FPGA compute units test ----------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/fpga_tests/compute_units.cpp
+++ b/sycl/test/fpga_tests/compute_units.cpp
@@ -39,7 +39,7 @@ void SinkKernel(queue &q, std::array<float, 1> &out_data) {
   q.submit([&](handler &h) {
     auto out_accessor = out_buf.get_access<access::mode::write>(h);
     h.single_task<sink_kernel>(
-        [=]() { out_accessor[0] = Pipes::PipeAt<kEngines>::read(); });
+        [=]() { out_accessor[0] = Pipes::PipeAt<kComputeUnits>::read(); });
   });
 }
 


### PR DESCRIPTION
Add a header library that allows the user to duplicate a single-task kernel k times, for any k>=1.

For spatial architectures such as FPGA, users often wish to duplicate their kernels several times in order to fill the available area on the chip. Code duplication is easy to achieve using C++ template metaprogramming. We designed this API to improve the usability.

Usage:

```
// The name of the kernel is templated on the compute unit ID,
// so each compute unit receives a unique name, e.g., foo_kernel<0>
template <std::size_t ID> class foo_kernel;

// Create 5 compute units whose functionality is determined by the generic lambda
intelfpga::submit_compute_units<5, foo_kernel>(q, [=](auto ID) {
   // kernel function body
  // compute unit functionality can be specialized on ID
});
```
