### PR TITLE
[SYCL] Adjust devicelib install location

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -1,9 +1,9 @@
+set(obj_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 if (WIN32)
-  set(binary_dir "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+set(spv_binary_dir "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 else()
-  set(binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+set(spv_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 endif()
-
 set(clang $<TARGET_FILE:clang>)
 
 string(CONCAT sycl_targets_opt
@@ -27,7 +27,7 @@ set(compile_opts
 
 if (WIN32)
   set(lib-suffix obj)
-  set(devicelib-obj-file ${binary_dir}/libsycl-crt.${lib-suffix})
+  set(devicelib-obj-file ${obj_binary_dir}/libsycl-crt.${lib-suffix})
   add_custom_command(OUTPUT ${devicelib-obj-file}
                      COMMAND ${clang} -fsycl -c
                              ${compile_opts} ${sycl_targets_opt}
@@ -38,7 +38,7 @@ if (WIN32)
                      VERBATIM)
 else()
   set(lib-suffix o)
-  set(devicelib-obj-file ${binary_dir}/libsycl-crt.${lib-suffix})
+  set(devicelib-obj-file ${obj_binary_dir}/libsycl-crt.${lib-suffix})
   add_custom_command(OUTPUT ${devicelib-obj-file}
                      COMMAND ${clang} -fsycl -c
                              ${compile_opts} ${sycl_targets_opt}
@@ -49,7 +49,7 @@ else()
                      VERBATIM)
 endif()
 
-set(devicelib-obj-complex ${binary_dir}/libsycl-complex.${lib-suffix})
+set(devicelib-obj-complex ${obj_binary_dir}/libsycl-complex.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-complex}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
@@ -59,7 +59,7 @@ add_custom_command(OUTPUT ${devicelib-obj-complex}
                    DEPENDS device_complex.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-set(devicelib-obj-complex-fp64 ${binary_dir}/libsycl-complex-fp64.${lib-suffix})
+set(devicelib-obj-complex-fp64 ${obj_binary_dir}/libsycl-complex-fp64.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-complex-fp64}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
@@ -69,7 +69,7 @@ add_custom_command(OUTPUT ${devicelib-obj-complex-fp64}
                    DEPENDS device_complex.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-set(devicelib-obj-cmath ${binary_dir}/libsycl-cmath.${lib-suffix})
+set(devicelib-obj-cmath ${obj_binary_dir}/libsycl-cmath.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-cmath}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
@@ -79,7 +79,7 @@ add_custom_command(OUTPUT ${devicelib-obj-cmath}
                    DEPENDS device_math.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-set(devicelib-obj-cmath-fp64 ${binary_dir}/libsycl-cmath-fp64.${lib-suffix})
+set(devicelib-obj-cmath-fp64 ${obj_binary_dir}/libsycl-cmath-fp64.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-cmath-fp64}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
@@ -89,92 +89,92 @@ add_custom_command(OUTPUT ${devicelib-obj-cmath-fp64}
                    DEPENDS device_math.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cassert.spv
+add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cassert.spv
                    COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
                            ${compile_opts}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cassert.cpp
-                           -o ${binary_dir}/libsycl-fallback-cassert.spv
+                           -o ${spv_binary_dir}/libsycl-fallback-cassert.spv
                    MAIN_DEPENDENCY fallback-cassert.cpp
                    DEPENDS wrapper.h device.h clang spirv_vars.h llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cassert.${lib-suffix}
+add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cassert.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cassert.cpp
-                           -o ${binary_dir}/libsycl-fallback-cassert.${lib-suffix}
+                           -o ${obj_binary_dir}/libsycl-fallback-cassert.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cassert.cpp
                    DEPENDS wrapper.h device.h clang spirv_vars.h clang-offload-bundler
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex.spv
+add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-complex.spv
                    COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
                            ${compile_opts}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex.cpp
-                           -o ${binary_dir}/libsycl-fallback-complex.spv
+                           -o ${spv_binary_dir}/libsycl-fallback-complex.spv
                    MAIN_DEPENDENCY fallback-complex.cpp
                    DEPENDS device_math.h device_complex.h device.h clang llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex.${lib-suffix}
+add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-complex.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex.cpp
-                           -o ${binary_dir}/libsycl-fallback-complex.${lib-suffix}
+                           -o ${obj_binary_dir}/libsycl-fallback-complex.${lib-suffix}
                    MAIN_DEPENDENCY fallback-complex.cpp
                    DEPENDS device_math.h device_complex.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex-fp64.spv
+add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-complex-fp64.spv
                    COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
                            ${compile_opts}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex-fp64.cpp
-                           -o ${binary_dir}/libsycl-fallback-complex-fp64.spv
+                           -o ${spv_binary_dir}/libsycl-fallback-complex-fp64.spv
                    MAIN_DEPENDENCY fallback-complex-fp64.cpp
                    DEPENDS device_math.h device_complex.h device.h clang llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
+add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex-fp64.cpp
-                           -o ${binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
+                           -o ${obj_binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
                    MAIN_DEPENDENCY fallback-complex-fp64.cpp
                    DEPENDS device_math.h device_complex.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath.spv
+add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cmath.spv
                    COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
                            ${compile_opts}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath.cpp
-                           -o ${binary_dir}/libsycl-fallback-cmath.spv
+                           -o ${spv_binary_dir}/libsycl-fallback-cmath.spv
                    MAIN_DEPENDENCY fallback-cmath.cpp
                    DEPENDS device_math.h device.h clang llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath.${lib-suffix}
+add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cmath.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath.cpp
-                           -o ${binary_dir}/libsycl-fallback-cmath.${lib-suffix}
+                           -o ${obj_binary_dir}/libsycl-fallback-cmath.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cmath.cpp
                    DEPENDS device_math.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath-fp64.spv
+add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cmath-fp64.spv
                    COMMAND ${clang} -S -fsycl-device-only -fno-sycl-use-bitcode
                            ${compile_opts}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath-fp64.cpp
-                           -o ${binary_dir}/libsycl-fallback-cmath-fp64.spv
+                           -o ${spv_binary_dir}/libsycl-fallback-cmath-fp64.spv
                    MAIN_DEPENDENCY fallback-cmath-fp64.cpp
                    DEPENDS device_math.h device.h clang llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
+add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath-fp64.cpp
-                           -o ${binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
+                           -o ${obj_binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cmath-fp64.cpp
                    DEPENDS device_math.h device.h clang clang-offload-bundler
                    VERBATIM)
@@ -187,18 +187,18 @@ add_custom_target(libsycldevice-obj DEPENDS
   ${devicelib-obj-cmath-fp64}
 )
 add_custom_target(libsycldevice-spv DEPENDS
-  ${binary_dir}/libsycl-fallback-cassert.spv
-  ${binary_dir}/libsycl-fallback-complex.spv
-  ${binary_dir}/libsycl-fallback-complex-fp64.spv
-  ${binary_dir}/libsycl-fallback-cmath.spv
-  ${binary_dir}/libsycl-fallback-cmath-fp64.spv
+  ${spv_binary_dir}/libsycl-fallback-cassert.spv
+  ${spv_binary_dir}/libsycl-fallback-complex.spv
+  ${spv_binary_dir}/libsycl-fallback-complex-fp64.spv
+  ${spv_binary_dir}/libsycl-fallback-cmath.spv
+  ${spv_binary_dir}/libsycl-fallback-cmath-fp64.spv
   )
 add_custom_target(libsycldevice-fallback-obj DEPENDS
-  ${binary_dir}/libsycl-fallback-cassert.${lib-suffix}
-  ${binary_dir}/libsycl-fallback-complex.${lib-suffix}
-  ${binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
-  ${binary_dir}/libsycl-fallback-cmath.${lib-suffix}
-  ${binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
+  ${obj_binary_dir}/libsycl-fallback-cassert.${lib-suffix}
+  ${obj_binary_dir}/libsycl-fallback-complex.${lib-suffix}
+  ${obj_binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
+  ${obj_binary_dir}/libsycl-fallback-cmath.${lib-suffix}
+  ${obj_binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
 )
 add_custom_target(libsycldevice DEPENDS
   libsycldevice-obj
@@ -216,22 +216,22 @@ endif()
 set(install_dest_lib lib${LLVM_LIBDIR_SUFFIX})
 
 install(FILES ${devicelib-obj-file}
-	      ${binary_dir}/libsycl-fallback-cassert.${lib-suffix}
+	      ${obj_binary_dir}/libsycl-fallback-cassert.${lib-suffix}
               ${devicelib-obj-complex}
-	      ${binary_dir}/libsycl-fallback-complex.${lib-suffix}
+	      ${obj_binary_dir}/libsycl-fallback-complex.${lib-suffix}
               ${devicelib-obj-complex-fp64}
-	      ${binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
+	      ${obj_binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
               ${devicelib-obj-cmath}
-              ${binary_dir}/libsycl-fallback-cmath.${lib-suffix}
+              ${obj_binary_dir}/libsycl-fallback-cmath.${lib-suffix}
               ${devicelib-obj-cmath-fp64}
-	      ${binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
+	      ${obj_binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
         DESTINATION ${install_dest_lib}
         COMPONENT libsycldevice)
 
-install(FILES ${binary_dir}/libsycl-fallback-cassert.spv
-              ${binary_dir}/libsycl-fallback-complex.spv
-              ${binary_dir}/libsycl-fallback-complex-fp64.spv
-              ${binary_dir}/libsycl-fallback-cmath.spv
-              ${binary_dir}/libsycl-fallback-cmath-fp64.spv
+install(FILES ${spv_binary_dir}/libsycl-fallback-cassert.spv
+              ${spv_binary_dir}/libsycl-fallback-complex.spv
+              ${spv_binary_dir}/libsycl-fallback-complex-fp64.spv
+              ${spv_binary_dir}/libsycl-fallback-cmath.spv
+              ${spv_binary_dir}/libsycl-fallback-cmath-fp64.spv
         DESTINATION ${install_dest_spv}
         COMPONENT libsycldevice)

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -26,7 +26,8 @@ set(compile_opts
   )
 
 if (WIN32)
-  set(devicelib-obj-file ${binary_dir}/libsycl-msvc.o)
+  set(lib-suffix obj)
+  set(devicelib-obj-file ${binary_dir}/libsycl-crt.${lib-suffix})
   add_custom_command(OUTPUT ${devicelib-obj-file}
                      COMMAND ${clang} -fsycl -c
                              ${compile_opts} ${sycl_targets_opt}
@@ -36,7 +37,8 @@ if (WIN32)
                      DEPENDS wrapper.h device.h spirv_vars.h clang clang-offload-bundler
                      VERBATIM)
 else()
-  set(devicelib-obj-file ${binary_dir}/libsycl-glibc.o)
+  set(lib-suffix o)
+  set(devicelib-obj-file ${binary_dir}/libsycl-crt.${lib-suffix})
   add_custom_command(OUTPUT ${devicelib-obj-file}
                      COMMAND ${clang} -fsycl -c
                              ${compile_opts} ${sycl_targets_opt}
@@ -47,7 +49,7 @@ else()
                      VERBATIM)
 endif()
 
-set(devicelib-obj-complex ${binary_dir}/libsycl-complex.o)
+set(devicelib-obj-complex ${binary_dir}/libsycl-complex.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-complex}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
@@ -57,7 +59,7 @@ add_custom_command(OUTPUT ${devicelib-obj-complex}
                    DEPENDS device_complex.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-set(devicelib-obj-complex-fp64 ${binary_dir}/libsycl-complex-fp64.o)
+set(devicelib-obj-complex-fp64 ${binary_dir}/libsycl-complex-fp64.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-complex-fp64}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
@@ -67,7 +69,7 @@ add_custom_command(OUTPUT ${devicelib-obj-complex-fp64}
                    DEPENDS device_complex.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-set(devicelib-obj-cmath ${binary_dir}/libsycl-cmath.o)
+set(devicelib-obj-cmath ${binary_dir}/libsycl-cmath.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-cmath}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
@@ -77,7 +79,7 @@ add_custom_command(OUTPUT ${devicelib-obj-cmath}
                    DEPENDS device_math.h device.h clang clang-offload-bundler
                    VERBATIM)
 
-set(devicelib-obj-cmath-fp64 ${binary_dir}/libsycl-cmath-fp64.o)
+set(devicelib-obj-cmath-fp64 ${binary_dir}/libsycl-cmath-fp64.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-cmath-fp64}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
@@ -96,11 +98,11 @@ add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cassert.spv
                    DEPENDS wrapper.h device.h clang spirv_vars.h llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cassert.o
+add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cassert.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cassert.cpp
-                           -o ${binary_dir}/libsycl-fallback-cassert.o
+                           -o ${binary_dir}/libsycl-fallback-cassert.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cassert.cpp
                    DEPENDS wrapper.h device.h clang spirv_vars.h clang-offload-bundler
                    VERBATIM)
@@ -114,11 +116,11 @@ add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex.spv
                    DEPENDS device_math.h device_complex.h device.h clang llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex.o
+add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex.cpp
-                           -o ${binary_dir}/libsycl-fallback-complex.o
+                           -o ${binary_dir}/libsycl-fallback-complex.${lib-suffix}
                    MAIN_DEPENDENCY fallback-complex.cpp
                    DEPENDS device_math.h device_complex.h device.h clang clang-offload-bundler
                    VERBATIM)
@@ -132,11 +134,11 @@ add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex-fp64.spv
                    DEPENDS device_math.h device_complex.h device.h clang llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex-fp64.o
+add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex-fp64.cpp
-                           -o ${binary_dir}/libsycl-fallback-complex-fp64.o
+                           -o ${binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
                    MAIN_DEPENDENCY fallback-complex-fp64.cpp
                    DEPENDS device_math.h device_complex.h device.h clang clang-offload-bundler
                    VERBATIM)
@@ -150,11 +152,11 @@ add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath.spv
                    DEPENDS device_math.h device.h clang llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath.o
+add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath.cpp
-                           -o ${binary_dir}/libsycl-fallback-cmath.o
+                           -o ${binary_dir}/libsycl-fallback-cmath.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cmath.cpp
                    DEPENDS device_math.h device.h clang clang-offload-bundler
                    VERBATIM)
@@ -168,11 +170,11 @@ add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath-fp64.spv
                    DEPENDS device_math.h device.h clang llvm-spirv
                    VERBATIM)
 
-add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath-fp64.o
+add_custom_command(OUTPUT ${binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath-fp64.cpp
-                           -o ${binary_dir}/libsycl-fallback-cmath-fp64.o
+                           -o ${binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cmath-fp64.cpp
                    DEPENDS device_math.h device.h clang clang-offload-bundler
                    VERBATIM)
@@ -192,11 +194,11 @@ add_custom_target(libsycldevice-spv DEPENDS
   ${binary_dir}/libsycl-fallback-cmath-fp64.spv
   )
 add_custom_target(libsycldevice-fallback-obj DEPENDS
-  ${binary_dir}/libsycl-fallback-cassert.o
-  ${binary_dir}/libsycl-fallback-complex.o
-  ${binary_dir}/libsycl-fallback-complex-fp64.o
-  ${binary_dir}/libsycl-fallback-cmath.o
-  ${binary_dir}/libsycl-fallback-cmath-fp64.o
+  ${binary_dir}/libsycl-fallback-cassert.${lib-suffix}
+  ${binary_dir}/libsycl-fallback-complex.${lib-suffix}
+  ${binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
+  ${binary_dir}/libsycl-fallback-cmath.${lib-suffix}
+  ${binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
 )
 add_custom_target(libsycldevice DEPENDS
   libsycldevice-obj
@@ -206,25 +208,30 @@ add_custom_target(libsycldevice DEPENDS
 # Place device libraries near the libsycl.so library in an install
 # directory as well
 if (WIN32)
-  set(install_dest bin)
+  set(install_dest_spv bin)
 else()
-  set(install_dest lib${LLVM_LIBDIR_SUFFIX})
+  set(install_dest_spv lib${LLVM_LIBDIR_SUFFIX})
 endif()
 
+set(install_dest_lib lib${LLVM_LIBDIR_SUFFIX})
+
 install(FILES ${devicelib-obj-file}
-              ${binary_dir}/libsycl-fallback-cassert.spv
-              ${binary_dir}/libsycl-fallback-cassert.o
+	      ${binary_dir}/libsycl-fallback-cassert.${lib-suffix}
               ${devicelib-obj-complex}
-              ${binary_dir}/libsycl-fallback-complex.spv
-	      ${binary_dir}/libsycl-fallback-complex.o
+	      ${binary_dir}/libsycl-fallback-complex.${lib-suffix}
               ${devicelib-obj-complex-fp64}
-              ${binary_dir}/libsycl-fallback-complex-fp64.spv
-	      ${binary_dir}/libsycl-fallback-complex-fp64.o
+	      ${binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
               ${devicelib-obj-cmath}
-              ${binary_dir}/libsycl-fallback-cmath.spv
-              ${binary_dir}/libsycl-fallback-cmath.o
+              ${binary_dir}/libsycl-fallback-cmath.${lib-suffix}
               ${devicelib-obj-cmath-fp64}
+	      ${binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
+        DESTINATION ${install_dest_lib}
+        COMPONENT libsycldevice)
+
+install(FILES ${binary_dir}/libsycl-fallback-cassert.spv
+              ${binary_dir}/libsycl-fallback-complex.spv
+              ${binary_dir}/libsycl-fallback-complex-fp64.spv
+              ${binary_dir}/libsycl-fallback-cmath.spv
               ${binary_dir}/libsycl-fallback-cmath-fp64.spv
-	      ${binary_dir}/libsycl-fallback-cmath-fp64.o
-        DESTINATION ${install_dest}
+        DESTINATION ${install_dest_spv}
         COMPONENT libsycldevice)

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -1,8 +1,12 @@
 set(obj_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 if (WIN32)
-set(spv_binary_dir "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+  set(lib-suffix obj)
+  set(spv_binary_dir "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+  set(lib_crt_source msvc_wrapper.cpp)
 else()
-set(spv_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  set(lib-suffix o)
+  set(spv_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  set(lib_crt_source glibc_wrapper.cpp)
 endif()
 set(clang $<TARGET_FILE:clang>)
 
@@ -25,29 +29,15 @@ set(compile_opts
   -sycl-std=2017
   )
 
-if (WIN32)
-  set(lib-suffix obj)
-  set(devicelib-obj-file ${obj_binary_dir}/libsycl-crt.${lib-suffix})
-  add_custom_command(OUTPUT ${devicelib-obj-file}
-                     COMMAND ${clang} -fsycl -c
-                             ${compile_opts} ${sycl_targets_opt}
-                             ${CMAKE_CURRENT_SOURCE_DIR}/msvc_wrapper.cpp
-                             -o ${devicelib-obj-file}
-                     MAIN_DEPENDENCY msvc_wrapper.cpp
-                     DEPENDS wrapper.h device.h spirv_vars.h clang clang-offload-bundler
-                     VERBATIM)
-else()
-  set(lib-suffix o)
-  set(devicelib-obj-file ${obj_binary_dir}/libsycl-crt.${lib-suffix})
-  add_custom_command(OUTPUT ${devicelib-obj-file}
-                     COMMAND ${clang} -fsycl -c
-                             ${compile_opts} ${sycl_targets_opt}
-                             ${CMAKE_CURRENT_SOURCE_DIR}/glibc_wrapper.cpp
-                             -o ${devicelib-obj-file}
-                     MAIN_DEPENDENCY glibc_wrapper.cpp
-                     DEPENDS wrapper.h device.h spirv_vars.h clang clang-offload-bundler
-                     VERBATIM)
-endif()
+set(devicelib-obj-file ${obj_binary_dir}/libsycl-crt.${lib-suffix})
+add_custom_command(OUTPUT ${devicelib-obj-file}
+                   COMMAND ${clang} -fsycl -c
+                           ${compile_opts} ${sycl_targets_opt}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/${lib_crt_source}
+                           -o ${devicelib-obj-file}
+                   MAIN_DEPENDENCY ${lib_crt_source}
+                   DEPENDS wrapper.h device.h spirv_vars.h clang clang-offload-bundler
+                   VERBATIM)
 
 set(devicelib-obj-complex ${obj_binary_dir}/libsycl-complex.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-complex}

--- a/sycl/test/devicelib/assert-aot.cpp
+++ b/sycl/test/devicelib/assert-aot.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: opencl-aot, cpu, linux
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/assert.cpp %sycl_libs_dir/libsycl-glibc.o %sycl_libs_dir/libsycl-fallback-cassert.o -o %t.aot.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/assert.cpp %sycl_libs_dir/libsycl-crt.o %sycl_libs_dir/libsycl-fallback-cassert.o -o %t.aot.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.aot.out >%t.aot.msg
 // RUN: FileCheck %S/assert.cpp --input-file %t.aot.msg --check-prefixes=CHECK-MESSAGE

--- a/sycl/test/devicelib/assert-windows.cpp
+++ b/sycl/test/devicelib/assert-windows.cpp
@@ -5,7 +5,7 @@
 // XFAIL: *
 //
 // RUN: %clangxx -fsycl -c %s -o %t.o
-// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/../bin/libsycl-msvc.o -o %t.out
+// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/lib/libsycl-crt.obj -o %t.out
 //
 // MSVC implementation of assert does not call an unreachable built-in, so the
 // program doesn't terminate when fallback is used.

--- a/sycl/test/devicelib/assert-windows.cpp
+++ b/sycl/test/devicelib/assert-windows.cpp
@@ -5,7 +5,7 @@
 // XFAIL: *
 //
 // RUN: %clangxx -fsycl -c %s -o %t.o
-// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/lib/libsycl-crt.obj -o %t.out
+// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/libsycl-crt.obj -o %t.out
 //
 // MSVC implementation of assert does not call an unreachable built-in, so the
 // program doesn't terminate when fallback is used.

--- a/sycl/test/devicelib/assert.cpp
+++ b/sycl/test/devicelib/assert.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu,linux
 // RUN: %clangxx -fsycl -c %s -o %t.o
-// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/libsycl-glibc.o -o %t.out
+// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/libsycl-crt.o -o %t.out
 // (see the other RUN lines below; it is a bit complicated)
 //
 // assert() call in device code guarantees nothing: on some devices it behaves

--- a/sycl/test/devicelib/math_fp64_windows_test.cpp
+++ b/sycl/test/devicelib/math_fp64_windows_test.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu, windows
 // RUN: %clangxx -fsycl -c %s -o %t.o
-// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/../bin/libsycl-cmath-fp64.o -o %t.out
+// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/lib/libsycl-cmath-fp64.obj -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/devicelib/math_fp64_windows_test.cpp
+++ b/sycl/test/devicelib/math_fp64_windows_test.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu, windows
 // RUN: %clangxx -fsycl -c %s -o %t.o
-// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/lib/libsycl-cmath-fp64.obj -o %t.out
+// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/../bin/libsycl-cmath-fp64.obj -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/devicelib/math_fp64_windows_test.cpp
+++ b/sycl/test/devicelib/math_fp64_windows_test.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu, windows
 // RUN: %clangxx -fsycl -c %s -o %t.o
-// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/../bin/libsycl-cmath-fp64.obj -o %t.out
+// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/libsycl-cmath-fp64.obj -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/devicelib/math_windows_test.cpp
+++ b/sycl/test/devicelib/math_windows_test.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu, windows
 // RUN: %clangxx -fsycl -c %s -o %t.o
-// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/../bin/libsycl-cmath.o -o %t.out
+// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/libsycl-cmath.obj -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/devicelib/math_windows_test.cpp
+++ b/sycl/test/devicelib/math_windows_test.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu, windows
 // RUN: %clangxx -fsycl -c %s -o %t.o
-// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/libsycl-cmath.obj -o %t.out
+// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/../bin/libsycl-cmath.obj -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/devicelib/math_windows_test.cpp
+++ b/sycl/test/devicelib/math_windows_test.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu, windows
 // RUN: %clangxx -fsycl -c %s -o %t.o
-// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/../bin/libsycl-cmath.obj -o %t.out
+// RUN: %clangxx -fsycl %t.o %sycl_libs_dir/libsycl-cmath.obj -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
This patch will do following:
1. Rename all .o libraries to .obj on Windows
2. Install all .obj libraries in lib/ on Windows
3. Uniform the previous libsycl-glibc and libsycl-msvc to libsycl-crt.o/obj

Signed-off-by: gejin <ge.jin@intel.com>