### PR TITLE
[SYCL] Add is_native_function_object trait

### DIFF
--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -193,12 +193,12 @@ using EnableIfIsNonNativeOp = cl::sycl::detail::enable_if_t<
 template <typename T> struct is_native_function_object : std::false_type {};
 
 template <template <typename> class BinaryOperation, typename T>
-struct is_native_function_object<BinaryOperation<T>> {
-  static const bool value =
-      (sycl::detail::is_scalar_arithmetic<T>::value ||
-       sycl::detail::is_vector_arithmetic<T>::value ||
-       std::is_same<T, void>::value) &&
-      sycl::detail::is_native_op<T, BinaryOperation<T>>::value;
+struct is_native_function_object<BinaryOperation<T>>
+    : std::integral_constant<
+          bool, (sycl::detail::is_scalar_arithmetic<T>::value ||
+                 sycl::detail::is_vector_arithmetic<T>::value ||
+                 std::is_same<T, void>::value) &&
+                    sycl::detail::is_native_op<T, BinaryOperation<T>>::value> {
 };
 
 #if __cplusplus >= 201703L

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -190,6 +190,23 @@ using EnableIfIsNonNativeOp = cl::sycl::detail::enable_if_t<
         !cl::sycl::detail::is_native_op<T, BinaryOperation>::value,
     T>;
 
+template <typename T> struct is_native_function_object : std::false_type {};
+
+template <template <typename> class BinaryOperation, typename T>
+struct is_native_function_object<BinaryOperation<T>> {
+  static const bool value =
+      (sycl::detail::is_scalar_arithmetic<T>::value ||
+       sycl::detail::is_vector_arithmetic<T>::value ||
+       std::is_same<T, void>::value) &&
+      sycl::detail::is_native_op<T, BinaryOperation<T>>::value;
+};
+
+#if __cplusplus >= 201703L
+template <typename T>
+inline constexpr bool is_native_function_object_v =
+    is_native_function_object<T>::value;
+#endif
+
 template <typename Group> bool all_of(Group, bool pred) {
   static_assert(sycl::detail::is_generic_group<Group>::value,
                 "Group algorithms only support the sycl::group and "

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -204,7 +204,7 @@ struct is_native_function_object_impl<BinaryOperation<T>>
 
 template <typename T>
 struct is_native_function_object
-    : is_native_function_object_impl<std::decay_t<T>> {};
+    : is_native_function_object_impl<typename std::decay<T>::type> {};
 
 #if __cplusplus >= 201703L
 template <typename T>

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -190,16 +190,21 @@ using EnableIfIsNonNativeOp = cl::sycl::detail::enable_if_t<
         !cl::sycl::detail::is_native_op<T, BinaryOperation>::value,
     T>;
 
-template <typename T> struct is_native_function_object : std::false_type {};
+template <typename T>
+struct is_native_function_object_impl : std::false_type {};
 
 template <template <typename> class BinaryOperation, typename T>
-struct is_native_function_object<BinaryOperation<T>>
+struct is_native_function_object_impl<BinaryOperation<T>>
     : std::integral_constant<
           bool, (sycl::detail::is_scalar_arithmetic<T>::value ||
                  sycl::detail::is_vector_arithmetic<T>::value ||
                  std::is_same<T, void>::value) &&
                     sycl::detail::is_native_op<T, BinaryOperation<T>>::value> {
 };
+
+template <typename T>
+struct is_native_function_object
+    : is_native_function_object_impl<std::decay_t<T>> {};
 
 #if __cplusplus >= 201703L
 template <typename T>

--- a/sycl/test/group-algorithm/traits.cpp
+++ b/sycl/test/group-algorithm/traits.cpp
@@ -14,6 +14,7 @@ int main() {
   static_assert(is_native_function_object_v<bit_or<>>);
   static_assert(is_native_function_object_v<bit_xor<>>);
   static_assert(is_native_function_object_v<bit_and<>>);
+  static_assert(is_native_function_object_v<const plus<>>);
   static_assert(is_native_function_object_v<plus<float>>);
   static_assert(is_native_function_object_v<plus<sycl::vec<float, 4>>>);
   static_assert(!is_native_function_object_v<plus<CustomType>>);

--- a/sycl/test/group-algorithm/traits.cpp
+++ b/sycl/test/group-algorithm/traits.cpp
@@ -1,0 +1,21 @@
+// RUN: %clangxx -std=c++17 -fsyntax-only -Xclang -verify %s -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning
+// expected-no-diagnostics
+#include <CL/sycl.hpp>
+
+using namespace sycl::ONEAPI;
+
+struct CustomType {};
+
+template <typename T> struct CustomFunctor {};
+
+int main() {
+  static_assert(is_native_function_object_v<plus<>>);
+  static_assert(is_native_function_object_v<multiplies<>>);
+  static_assert(is_native_function_object_v<bit_or<>>);
+  static_assert(is_native_function_object_v<bit_xor<>>);
+  static_assert(is_native_function_object_v<bit_and<>>);
+  static_assert(is_native_function_object_v<plus<float>>);
+  static_assert(is_native_function_object_v<plus<sycl::vec<float, 4>>>);
+  static_assert(!is_native_function_object_v<plus<CustomType>>);
+  static_assert(!is_native_function_object_v<CustomFunctor<float>>);
+}


### PR DESCRIPTION
These traits were mentioned in the GroupAlgorithms extension and the SYCL 2020
provisional specification, but weren't implemented anywhere.

Signed-off-by: John Pennycook <john.pennycook@intel.com>