### PR TITLE
[SYCL] Fix crash on array of pointers

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2096,7 +2096,7 @@ public:
 
   bool handlePointerType(FieldDecl *FD, QualType FieldTy) final {
     Expr *PointerRef =
-        createPointerParamReferenceExpr(FD->getType(), StructDepth != 0);
+        createPointerParamReferenceExpr(FieldTy, StructDepth != 0);
     addFieldInit(FD, FieldTy, PointerRef);
     return true;
   }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1843,8 +1843,9 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
       ParamType = Pointer->getType();
     }
 
-    DRE = ImplicitCastExpr::Create(SemaRef.Context, ParamType,
-                                   CK_LValueToRValue, DRE, nullptr, VK_RValue);
+    DRE =
+        ImplicitCastExpr::Create(SemaRef.Context, ParamType, CK_LValueToRValue,
+                                 DRE, /*BasePath=*/nullptr, VK_RValue);
 
     if (PointerTy->getPointeeType().getAddressSpace() !=
         ParamType->getPointeeType().getAddressSpace())

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1843,6 +1843,9 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
       ParamType = Pointer->getType();
     }
 
+    DRE = ImplicitCastExpr::Create(SemaRef.Context, ParamType,
+                                   CK_LValueToRValue, DRE, nullptr, VK_RValue);
+
     if (PointerTy->getPointeeType().getAddressSpace() !=
         ParamType->getPointeeType().getAddressSpace())
       DRE = ImplicitCastExpr::Create(SemaRef.Context, PointerTy,

--- a/clang/test/CodeGenSYCL/pointers-in-structs.cpp
+++ b/clang/test/CodeGenSYCL/pointers-in-structs.cpp
@@ -13,6 +13,7 @@ struct B {
   int *F1;
   float *F2;
   A F3;
+  int *F4[2];
 };
 
 int main() {
@@ -35,9 +36,13 @@ int main() {
 // CHECK: %[[WRAPPER_F1:[a-zA-Z0-9_.]+]] = type { i32 addrspace(1)* }
 // CHECK: %[[WRAPPER_F2:[a-zA-Z0-9_.]+]] = type { float addrspace(1)* }
 // CHECK: %[[WRAPPER_F:[a-zA-Z0-9_.]+]] = type { float addrspace(1)* }
+// CHECK: %[[WRAPPER_F4_1:[a-zA-Z0-9_.]+]] = type { i32 addrspace(1)* }
+// CHECK: %[[WRAPPER_F4_2:[a-zA-Z0-9_.]+]] = type { i32 addrspace(1)* }
 // CHECK: %[[WRAPPER_LAMBDA_PTR:[a-zA-Z0-9_.]+]] = type { float addrspace(1)* }
 // CHECK: define spir_kernel void @{{.*}}structs
 // CHECK-SAME: %[[WRAPPER_F1]]* byval(%[[WRAPPER_F1]]) align 8 %_arg_F1,
 // CHECK-SAME: %[[WRAPPER_F2]]* byval(%[[WRAPPER_F2]]) align 8 %_arg_F2,
-// CHECK-SAME: %[[WRAPPER_F]]* byval(%[[WRAPPER_F]]) align 8 %_arg_F
+// CHECK-SAME: %[[WRAPPER_F]]* byval(%[[WRAPPER_F]]) align 8 %_arg_F,
+// CHECK-SAME: %[[WRAPPER_F4_1]]* byval(%[[WRAPPER_F4_1]]) align 8 %_arg_F4
+// CHECK-SAME: %[[WRAPPER_F4_2]]* byval(%[[WRAPPER_F4_2]]) align 8 %_arg_F41
 // CHECK: define spir_kernel void @{{.*}}lambdas{{.*}}(%[[WRAPPER_LAMBDA_PTR]]* byval(%[[WRAPPER_LAMBDA_PTR]]) align 8 %_arg_)

--- a/clang/test/CodeGenSYCL/pointers-int-header.cpp
+++ b/clang/test/CodeGenSYCL/pointers-int-header.cpp
@@ -10,6 +10,8 @@
 struct struct_with_pointer {
   int data_in_struct;
   int *ptr_in_struct;
+  int *ptr_array_in_struct1[2];
+  int *ptr_array_in_struct2[2][3];
 };
 
 int main() {
@@ -27,3 +29,11 @@ int main() {
 // CHECK:{ kernel_param_kind_t::kind_pointer, 8, 0 },
 // CHECK:{ kernel_param_kind_t::kind_std_layout, 4, 8 },
 // CHECK:{ kernel_param_kind_t::kind_std_layout, 8, 16 },
+// CHECK:{ kernel_param_kind_t::kind_std_layout, 8, 24 },
+// CHECK:{ kernel_param_kind_t::kind_std_layout, 8, 32 },
+// CHECK:{ kernel_param_kind_t::kind_std_layout, 8, 40 },
+// CHECK:{ kernel_param_kind_t::kind_std_layout, 8, 48 },
+// CHECK:{ kernel_param_kind_t::kind_std_layout, 8, 56 },
+// CHECK:{ kernel_param_kind_t::kind_std_layout, 8, 64 },
+// CHECK:{ kernel_param_kind_t::kind_std_layout, 8, 72 },
+// CHECK:{ kernel_param_kind_t::kind_std_layout, 8, 80 },

--- a/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
@@ -13,6 +13,8 @@ __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
 struct test_struct {
   int data;
   int *ptr; // Unused pointer in struct
+  int *ptr_array1[2];    // Unused array of pointers in struct
+  int *ptr_array2[2][3]; // Unused array of pointers in struct
 };
 
 void test(const int some_const) {
@@ -66,9 +68,18 @@ int main() {
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_' 'int'
 
 // Check kernel parameters
-// CHECK: {{.*}}kernel_struct{{.*}} 'void (int, __wrapper_class)'
+// CHECK: {{.*}}kernel_struct{{.*}} 'void (int, __wrapper_class, __wrapper_class, __wrapper_class
+// CHECK-SAME: __wrapper_class, __wrapper_class, __wrapper_class, __wrapper_class, __wrapper_class, __wrapper_class)'
 // CHECK: ParmVarDecl {{.*}} used _arg_data 'int'
 // CHECK: ParmVarDecl {{.*}} used _arg_ptr '__wrapper_class'
+// CHECK: ParmVarDecl {{.*}} used _arg_ptr_array1 '__wrapper_class'
+// CHECK: ParmVarDecl {{.*}} used _arg_ptr_array1 '__wrapper_class'
+// CHECK: ParmVarDecl {{.*}} used _arg_ptr_array2 '__wrapper_class'
+// CHECK: ParmVarDecl {{.*}} used _arg_ptr_array2 '__wrapper_class'
+// CHECK: ParmVarDecl {{.*}} used _arg_ptr_array2 '__wrapper_class'
+// CHECK: ParmVarDecl {{.*}} used _arg_ptr_array2 '__wrapper_class'
+// CHECK: ParmVarDecl {{.*}} used _arg_ptr_array2 '__wrapper_class'
+// CHECK: ParmVarDecl {{.*}} used _arg_ptr_array2 '__wrapper_class'
 
 // Check that lambda field of struct type is initialized
 // CHECK: VarDecl {{.*}}'(lambda at {{.*}}built-in-type-kernel-arg.cpp{{.*}})'
@@ -79,6 +90,34 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr' '__wrapper_class'
+// CHECK-NEXT: InitListExpr {{.*}} 'int *[2]'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
+// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array1' '__wrapper_class'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
+// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array1' '__wrapper_class'
+// CHECK-NEXT: InitListExpr {{.*}} 'int *[2][3]'
+// CHECK-NEXT: InitListExpr {{.*}} 'int *[3]'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
+// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
+// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
+// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
+// CHECK-NEXT: InitListExpr {{.*}} 'int *[3]'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
+// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
+// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
+// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
 
 // Check kernel parameters
 // CHECK: {{.*}}kernel_pointer{{.*}} 'void (__global int *, __global int *)'

--- a/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
@@ -12,9 +12,9 @@ __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
 
 struct test_struct {
   int data;
-  int *ptr; // Unused pointer in struct
-  int *ptr_array1[2];    // Unused array of pointers in struct
-  int *ptr_array2[2][3]; // Unused array of pointers in struct
+  int *ptr;
+  int *ptr_array1[2];
+  int *ptr_array2[2][3];
 };
 
 void test(const int some_const) {

--- a/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
@@ -28,6 +28,7 @@ int main() {
   int data = 5;
   int* data_addr = &data;
   int* new_data_addr = nullptr;
+  int *ptr_array[2];
   test_struct s;
   s.data = data;
   kernel<class kernel_int>(
@@ -42,7 +43,9 @@ int main() {
   kernel<class kernel_pointer>(
       [=]() {
         new_data_addr[0] = data_addr[0];
+        int *local = ptr_array[1];
       });
+
   const int some_const = 10;
   test(some_const);
   return 0;
@@ -88,39 +91,50 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_data' 'int'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr' '__wrapper_class'
 // CHECK-NEXT: InitListExpr {{.*}} 'int *[2]'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array1' '__wrapper_class'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array1' '__wrapper_class'
 // CHECK-NEXT: InitListExpr {{.*}} 'int *[2][3]'
 // CHECK-NEXT: InitListExpr {{.*}} 'int *[3]'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
 // CHECK-NEXT: InitListExpr {{.*}} 'int *[3]'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: MemberExpr {{.*}}  '__global int *' lvalue . {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array2' '__wrapper_class'
 
 // Check kernel parameters
-// CHECK: {{.*}}kernel_pointer{{.*}} 'void (__global int *, __global int *)'
+// CHECK: {{.*}}kernel_pointer{{.*}} 'void (__global int *, __global int *, __global int *, __global int *)'
+// CHECK: ParmVarDecl {{.*}} used _arg_ '__global int *'
+// CHECK: ParmVarDecl {{.*}} used _arg_ '__global int *'
 // CHECK: ParmVarDecl {{.*}} used _arg_ '__global int *'
 // CHECK: ParmVarDecl {{.*}} used _arg_ '__global int *'
 // CHECK: VarDecl {{.*}}'(lambda at {{.*}}built-in-type-kernel-arg.cpp{{.*}})'
@@ -128,8 +142,15 @@ int main() {
 // Check that lambda fields of pointer types are initialized
 // CHECK: InitListExpr
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_' '__global int *'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
 // CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_' '__global int *'
-
-// Check kernel parameters
+// CHECK: InitListExpr {{.*}} 'int *[2]'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
+// CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_' '__global int *'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
+// CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_' '__global int *'

--- a/sycl/test/basic_tests/unused_pointer.cpp
+++ b/sycl/test/basic_tests/unused_pointer.cpp
@@ -21,6 +21,8 @@ struct struct_with_pointer {
   int data;
   int *ptr1;   // Unused pointer
   float *ptr2; // Unused pointer
+  int *ptr_array1[2];    // Unused pointer array
+  int *ptr_array2[2][3]; // Unused pointer array
 };
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
The crash happens when address space of pointer element is
checked using array type. The type of 'array element' should
be checked, not the 'array type' itself. Also added a missing
LValueToRValue cast for pointers. 

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>