### PR TITLE
[SYCL][Driver] Respect the -target cross-compilation flag.

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4155,7 +4155,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-fenable-sycl-dae");
 
     // Pass the triple of host when doing SYCL
-    auto AuxT = llvm::Triple(llvm::sys::getProcessTriple());
+    llvm::Triple AuxT = C.getDefaultToolChain().getTriple();
+    if (Args.hasFlag(options::OPT_fsycl_device_only, OptSpecifier(), false))
+      AuxT = llvm::Triple(llvm::sys::getProcessTriple());
     std::string NormalizedTriple = AuxT.normalize();
     CmdArgs.push_back("-aux-triple");
     CmdArgs.push_back(Args.MakeArgString(NormalizedTriple));

--- a/clang/test/Driver/sycl-device.cpp
+++ b/clang/test/Driver/sycl-device.cpp
@@ -22,3 +22,9 @@
 // RUN:   %clang -### -fsycl %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-SYCL-STD_VERSION %s
 // CHECK-SYCL-STD_VERSION: clang{{.*}} "-sycl-std=2020"
+
+/// Check that -aux-triple is set correctly
+// RUN:   %clang -### -fsycl -target aarch64-linux-gnu %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-SYCL-AUX-TRIPLE %s
+// TODO: %clang -### -fsycl -fsycl-device-only -target aarch64-linux-gnu
+// CHECK-SYCL-AUX-TRIPLE: clang{{.*}} "-aux-triple" "aarch64-unknown-linux-gnu"


### PR DESCRIPTION
Currently when compiling with for sycl with a -target flag, clang will invoke the device compilation with an auxiliary triple of the machine performing the compilation instead of the host target completely ignoring the -target flag.
This patch fixes this.