### PR TITLE
[SYCL][LIT]Expect event_profiling_info.cpp test pass on host.

### DIFF
--- a/sycl/test/basic_tests/event_profiling_info.cpp
+++ b/sycl/test/basic_tests/event_profiling_info.cpp
@@ -1,4 +1,4 @@
-// XFAIL: *
+// XFAIL: !host
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 //
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out

--- a/sycl/test/basic_tests/event_profiling_info.cpp
+++ b/sycl/test/basic_tests/event_profiling_info.cpp
@@ -1,4 +1,4 @@
-// XFAIL: !host
+// XFAIL: cuda, opencl, level_zero
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 //
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out


### PR DESCRIPTION
The event_profiling_info.cpp failed on OpenCL/level_zero due to test
issue. 
Expect event_profiling_info.cpp test pass on host.