### PR TITLE
[SYCL] Source line info for kernel initialization code

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1752,7 +1752,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   const CXXRecordDecl *KernelObj;
   llvm::SmallVector<Expr *, 16> MemberExprBases;
   FunctionDecl *KernelCallerFunc;
-  SourceLocation KCFSL; // KernelCallerFunc source location.
+  SourceLocation KernelCallerSrcLoc; // KernelCallerFunc source location.
   // Contains a count of how many containers we're in.  This is used by the
   // pointer-struct-wrapping code to ensure that we don't try to wrap
   // non-top-level pointers.
@@ -1822,7 +1822,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
     QualType ParamType = KernelParameter->getOriginalType();
     Expr *DRE =
-        SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue, KCFSL);
+        SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue, KernelCallerSrcLoc);
     return DRE;
   }
 
@@ -1834,7 +1834,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
     QualType ParamType = KernelParameter->getOriginalType();
     Expr *DRE =
-        SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue, KCFSL);
+        SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue, KernelCallerSrcLoc);
 
     // Struct Type kernel arguments are decomposed. The pointer fields are
     // then wrapped inside a compiler generated struct. Therefore when
@@ -1876,7 +1876,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   }
 
   void addFieldInit(FieldDecl *FD, QualType Ty, MultiExprArg ParamRef) {
-    InitializationKind InitKind = InitializationKind::CreateCopy(KCFSL, KCFSL);
+    InitializationKind InitKind = InitializationKind::CreateCopy(KernelCallerSrcLoc, KernelCallerSrcLoc);
     addFieldInit(FD, Ty, ParamRef, InitKind);
   }
 
@@ -1913,10 +1913,10 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   MemberExpr *buildMemberExpr(Expr *Base, ValueDecl *Member) {
     DeclAccessPair MemberDAP = DeclAccessPair::make(Member, AS_none);
     MemberExpr *Result = SemaRef.BuildMemberExpr(
-        Base, /*IsArrow */ false, KCFSL, NestedNameSpecifierLoc(), KCFSL,
+        Base, /*IsArrow */ false, KernelCallerSrcLoc, NestedNameSpecifierLoc(), KernelCallerSrcLoc,
         Member, MemberDAP,
         /*HadMultipleCandidates*/ false,
-        DeclarationNameInfo(Member->getDeclName(), KCFSL), Member->getType(),
+        DeclarationNameInfo(Member->getDeclName(), KernelCallerSrcLoc), Member->getType(),
         VK_LValue, OK_Ordinary);
     return Result;
   }
@@ -1944,7 +1944,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     for (size_t I = 0; I < NumParams; ++I) {
       QualType ParamType = KernelParameters[I]->getOriginalType();
       ParamDREs[I] = SemaRef.BuildDeclRefExpr(KernelParameters[I], ParamType,
-                                              VK_LValue, KCFSL);
+                                              VK_LValue, KernelCallerSrcLoc);
     }
 
     MemberExpr *MethodME = buildMemberExpr(MemberExprBases.back(), Method);
@@ -1954,12 +1954,12 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     ResultTy = ResultTy.getNonLValueExprType(SemaRef.Context);
     llvm::SmallVector<Expr *, 4> ParamStmts;
     const auto *Proto = cast<FunctionProtoType>(Method->getType());
-    SemaRef.GatherArgumentsForCall(KCFSL, Method, Proto, 0, ParamDREs,
+    SemaRef.GatherArgumentsForCall(KernelCallerSrcLoc, Method, Proto, 0, ParamDREs,
                                    ParamStmts);
     // [kernel_obj or wrapper object].accessor.__init(_ValueType*,
     // range<int>, range<int>, id<int>)
     AddTo.push_back(CXXMemberCallExpr::Create(SemaRef.Context, MethodME,
-                                              ParamStmts, ResultTy, VK, KCFSL,
+                                              ParamStmts, ResultTy, VK, KernelCallerSrcLoc,
                                               FPOptionsOverride()));
   }
 
@@ -1981,7 +1981,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
   InitListExpr *createInitListExpr(QualType InitTy, uint64_t NumChildInits) {
     InitListExpr *ILE = new (SemaRef.getASTContext())
-        InitListExpr(SemaRef.getASTContext(), KCFSL, {}, KCFSL);
+        InitListExpr(SemaRef.getASTContext(), KernelCallerSrcLoc, {}, KernelCallerSrcLoc);
     ILE->reserveInits(SemaRef.getASTContext(), NumChildInits);
     ILE->setType(InitTy);
 
@@ -2016,7 +2016,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
   // Default inits the type, then calls the init-method in the body.
   bool handleSpecialType(FieldDecl *FD, QualType Ty) {
-    addFieldInit(FD, Ty, None, InitializationKind::CreateDefault(KCFSL));
+    addFieldInit(FD, Ty, None, InitializationKind::CreateDefault(KernelCallerSrcLoc));
 
     addFieldMemberExpr(FD, Ty);
 
@@ -2030,7 +2030,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
   bool handleSpecialType(const CXXBaseSpecifier &BS, QualType Ty) {
     const auto *RecordDecl = Ty->getAsCXXRecordDecl();
-    addBaseInit(BS, Ty, InitializationKind::CreateDefault(KCFSL));
+    addBaseInit(BS, Ty, InitializationKind::CreateDefault(KernelCallerSrcLoc));
     createSpecialMethodCall(RecordDecl, InitMethodName, BodyStmts);
     return true;
   }
@@ -2044,15 +2044,15 @@ public:
                                             DC.getKernelDecl(), KernelObj)),
         VarEntity(InitializedEntity::InitializeVariable(KernelObjClone)),
         KernelObj(KernelObj), KernelCallerFunc(KernelCallerFunc),
-        KCFSL(KernelCallerFunc->getLocation()) {
+        KernelCallerSrcLoc(KernelCallerFunc->getLocation()) {
     CollectionInitExprs.push_back(createInitListExpr(KernelObj));
     markParallelWorkItemCalls();
 
     Stmt *DS =
-        new (S.Context) DeclStmt(DeclGroupRef(KernelObjClone), KCFSL, KCFSL);
+        new (S.Context) DeclStmt(DeclGroupRef(KernelObjClone), KernelCallerSrcLoc, KernelCallerSrcLoc);
     BodyStmts.push_back(DS);
     DeclRefExpr *KernelObjCloneRef = DeclRefExpr::Create(
-        S.Context, NestedNameSpecifierLoc(), KCFSL, KernelObjClone, false,
+        S.Context, NestedNameSpecifierLoc(), KernelCallerSrcLoc, KernelObjClone, false,
         DeclarationNameInfo(), QualType(KernelObj->getTypeForDecl(), 0),
         VK_LValue);
     MemberExprBases.push_back(KernelObjCloneRef);
@@ -2163,7 +2163,7 @@ public:
     CXXCastPath BasePath;
     QualType DerivedTy(RD->getTypeForDecl(), 0);
     QualType BaseTy = BS.getType();
-    SemaRef.CheckDerivedToBaseConversion(DerivedTy, BaseTy, KCFSL,
+    SemaRef.CheckDerivedToBaseConversion(DerivedTy, BaseTy, KernelCallerSrcLoc,
                                          SourceRange(), &BasePath,
                                          /*IgnoreBaseAccess*/ true);
     auto Cast = ImplicitCastExpr::Create(
@@ -2212,10 +2212,10 @@ public:
         Index, SizeT->isSignedIntegerType()};
 
     auto IndexLiteral =
-        IntegerLiteral::Create(SemaRef.getASTContext(), IndexVal, SizeT, KCFSL);
+        IntegerLiteral::Create(SemaRef.getASTContext(), IndexVal, SizeT, KernelCallerSrcLoc);
 
     ExprResult IndexExpr = SemaRef.CreateBuiltinArraySubscriptExpr(
-        MemberExprBases.back(), KCFSL, IndexLiteral, KCFSL);
+        MemberExprBases.back(), KernelCallerSrcLoc, IndexLiteral, KernelCallerSrcLoc);
 
     assert(!IndexExpr.isInvalid());
     MemberExprBases.push_back(IndexExpr.get());

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1821,8 +1821,8 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
         DeclCreator.getParamVarDeclsForCurrentField()[0];
 
     QualType ParamType = KernelParameter->getOriginalType();
-    Expr *DRE =
-        SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue, KernelCallerSrcLoc);
+    Expr *DRE = SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue,
+                                         KernelCallerSrcLoc);
     return DRE;
   }
 
@@ -1833,8 +1833,8 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
         DeclCreator.getParamVarDeclsForCurrentField()[0];
 
     QualType ParamType = KernelParameter->getOriginalType();
-    Expr *DRE =
-        SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue, KernelCallerSrcLoc);
+    Expr *DRE = SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue,
+                                         KernelCallerSrcLoc);
 
     // Struct Type kernel arguments are decomposed. The pointer fields are
     // then wrapped inside a compiler generated struct. Therefore when
@@ -1876,7 +1876,8 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   }
 
   void addFieldInit(FieldDecl *FD, QualType Ty, MultiExprArg ParamRef) {
-    InitializationKind InitKind = InitializationKind::CreateCopy(KernelCallerSrcLoc, KernelCallerSrcLoc);
+    InitializationKind InitKind =
+        InitializationKind::CreateCopy(KernelCallerSrcLoc, KernelCallerSrcLoc);
     addFieldInit(FD, Ty, ParamRef, InitKind);
   }
 
@@ -1913,11 +1914,11 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   MemberExpr *buildMemberExpr(Expr *Base, ValueDecl *Member) {
     DeclAccessPair MemberDAP = DeclAccessPair::make(Member, AS_none);
     MemberExpr *Result = SemaRef.BuildMemberExpr(
-        Base, /*IsArrow */ false, KernelCallerSrcLoc, NestedNameSpecifierLoc(), KernelCallerSrcLoc,
-        Member, MemberDAP,
+        Base, /*IsArrow */ false, KernelCallerSrcLoc, NestedNameSpecifierLoc(),
+        KernelCallerSrcLoc, Member, MemberDAP,
         /*HadMultipleCandidates*/ false,
-        DeclarationNameInfo(Member->getDeclName(), KernelCallerSrcLoc), Member->getType(),
-        VK_LValue, OK_Ordinary);
+        DeclarationNameInfo(Member->getDeclName(), KernelCallerSrcLoc),
+        Member->getType(), VK_LValue, OK_Ordinary);
     return Result;
   }
 
@@ -1954,13 +1955,13 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     ResultTy = ResultTy.getNonLValueExprType(SemaRef.Context);
     llvm::SmallVector<Expr *, 4> ParamStmts;
     const auto *Proto = cast<FunctionProtoType>(Method->getType());
-    SemaRef.GatherArgumentsForCall(KernelCallerSrcLoc, Method, Proto, 0, ParamDREs,
-                                   ParamStmts);
+    SemaRef.GatherArgumentsForCall(KernelCallerSrcLoc, Method, Proto, 0,
+                                   ParamDREs, ParamStmts);
     // [kernel_obj or wrapper object].accessor.__init(_ValueType*,
     // range<int>, range<int>, id<int>)
-    AddTo.push_back(CXXMemberCallExpr::Create(SemaRef.Context, MethodME,
-                                              ParamStmts, ResultTy, VK, KernelCallerSrcLoc,
-                                              FPOptionsOverride()));
+    AddTo.push_back(CXXMemberCallExpr::Create(
+        SemaRef.Context, MethodME, ParamStmts, ResultTy, VK, KernelCallerSrcLoc,
+        FPOptionsOverride()));
   }
 
   // Creates an empty InitListExpr of the correct number of child-inits
@@ -1980,8 +1981,8 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   }
 
   InitListExpr *createInitListExpr(QualType InitTy, uint64_t NumChildInits) {
-    InitListExpr *ILE = new (SemaRef.getASTContext())
-        InitListExpr(SemaRef.getASTContext(), KernelCallerSrcLoc, {}, KernelCallerSrcLoc);
+    InitListExpr *ILE = new (SemaRef.getASTContext()) InitListExpr(
+        SemaRef.getASTContext(), KernelCallerSrcLoc, {}, KernelCallerSrcLoc);
     ILE->reserveInits(SemaRef.getASTContext(), NumChildInits);
     ILE->setType(InitTy);
 
@@ -2016,7 +2017,8 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
   // Default inits the type, then calls the init-method in the body.
   bool handleSpecialType(FieldDecl *FD, QualType Ty) {
-    addFieldInit(FD, Ty, None, InitializationKind::CreateDefault(KernelCallerSrcLoc));
+    addFieldInit(FD, Ty, None,
+                 InitializationKind::CreateDefault(KernelCallerSrcLoc));
 
     addFieldMemberExpr(FD, Ty);
 
@@ -2048,12 +2050,12 @@ public:
     CollectionInitExprs.push_back(createInitListExpr(KernelObj));
     markParallelWorkItemCalls();
 
-    Stmt *DS =
-        new (S.Context) DeclStmt(DeclGroupRef(KernelObjClone), KernelCallerSrcLoc, KernelCallerSrcLoc);
+    Stmt *DS = new (S.Context) DeclStmt(DeclGroupRef(KernelObjClone),
+                                        KernelCallerSrcLoc, KernelCallerSrcLoc);
     BodyStmts.push_back(DS);
     DeclRefExpr *KernelObjCloneRef = DeclRefExpr::Create(
-        S.Context, NestedNameSpecifierLoc(), KernelCallerSrcLoc, KernelObjClone, false,
-        DeclarationNameInfo(), QualType(KernelObj->getTypeForDecl(), 0),
+        S.Context, NestedNameSpecifierLoc(), KernelCallerSrcLoc, KernelObjClone,
+        false, DeclarationNameInfo(), QualType(KernelObj->getTypeForDecl(), 0),
         VK_LValue);
     MemberExprBases.push_back(KernelObjCloneRef);
   }
@@ -2211,11 +2213,12 @@ public:
         static_cast<unsigned>(SemaRef.getASTContext().getTypeSize(SizeT)),
         Index, SizeT->isSignedIntegerType()};
 
-    auto IndexLiteral =
-        IntegerLiteral::Create(SemaRef.getASTContext(), IndexVal, SizeT, KernelCallerSrcLoc);
+    auto IndexLiteral = IntegerLiteral::Create(
+        SemaRef.getASTContext(), IndexVal, SizeT, KernelCallerSrcLoc);
 
     ExprResult IndexExpr = SemaRef.CreateBuiltinArraySubscriptExpr(
-        MemberExprBases.back(), KernelCallerSrcLoc, IndexLiteral, KernelCallerSrcLoc);
+        MemberExprBases.back(), KernelCallerSrcLoc, IndexLiteral,
+        KernelCallerSrcLoc);
 
     assert(!IndexExpr.isInvalid());
     MemberExprBases.push_back(IndexExpr.get());

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1752,6 +1752,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   const CXXRecordDecl *KernelObj;
   llvm::SmallVector<Expr *, 16> MemberExprBases;
   FunctionDecl *KernelCallerFunc;
+  SourceLocation KCFSL; // KernelCallerFunc source location.
   // Contains a count of how many containers we're in.  This is used by the
   // pointer-struct-wrapping code to ensure that we don't try to wrap
   // non-top-level pointers.
@@ -1821,7 +1822,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
     QualType ParamType = KernelParameter->getOriginalType();
     Expr *DRE = SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue,
-                                         SourceLocation());
+                                         KCFSL);
     return DRE;
   }
 
@@ -1833,7 +1834,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
     QualType ParamType = KernelParameter->getOriginalType();
     Expr *DRE = SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue,
-                                         SourceLocation());
+                                         KCFSL);
 
     // Struct Type kernel arguments are decomposed. The pointer fields are
     // then wrapped inside a compiler generated struct. Therefore when
@@ -1876,7 +1877,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
   void addFieldInit(FieldDecl *FD, QualType Ty, MultiExprArg ParamRef) {
     InitializationKind InitKind =
-        InitializationKind::CreateCopy(SourceLocation(), SourceLocation());
+        InitializationKind::CreateCopy(KCFSL, KCFSL);
     addFieldInit(FD, Ty, ParamRef, InitKind);
   }
 
@@ -1913,10 +1914,10 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   MemberExpr *buildMemberExpr(Expr *Base, ValueDecl *Member) {
     DeclAccessPair MemberDAP = DeclAccessPair::make(Member, AS_none);
     MemberExpr *Result = SemaRef.BuildMemberExpr(
-        Base, /*IsArrow */ false, SourceLocation(), NestedNameSpecifierLoc(),
-        SourceLocation(), Member, MemberDAP,
+        Base, /*IsArrow */ false, KCFSL, NestedNameSpecifierLoc(),
+        KCFSL, Member, MemberDAP,
         /*HadMultipleCandidates*/ false,
-        DeclarationNameInfo(Member->getDeclName(), SourceLocation()),
+        DeclarationNameInfo(Member->getDeclName(), KCFSL),
         Member->getType(), VK_LValue, OK_Ordinary);
     return Result;
   }
@@ -1944,7 +1945,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     for (size_t I = 0; I < NumParams; ++I) {
       QualType ParamType = KernelParameters[I]->getOriginalType();
       ParamDREs[I] = SemaRef.BuildDeclRefExpr(KernelParameters[I], ParamType,
-                                              VK_LValue, SourceLocation());
+                                              VK_LValue, KCFSL);
     }
 
     MemberExpr *MethodME = buildMemberExpr(MemberExprBases.back(), Method);
@@ -1954,12 +1955,12 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     ResultTy = ResultTy.getNonLValueExprType(SemaRef.Context);
     llvm::SmallVector<Expr *, 4> ParamStmts;
     const auto *Proto = cast<FunctionProtoType>(Method->getType());
-    SemaRef.GatherArgumentsForCall(SourceLocation(), Method, Proto, 0,
+    SemaRef.GatherArgumentsForCall(KCFSL, Method, Proto, 0,
                                    ParamDREs, ParamStmts);
     // [kernel_obj or wrapper object].accessor.__init(_ValueType*,
     // range<int>, range<int>, id<int>)
     AddTo.push_back(CXXMemberCallExpr::Create(
-        SemaRef.Context, MethodME, ParamStmts, ResultTy, VK, SourceLocation(),
+        SemaRef.Context, MethodME, ParamStmts, ResultTy, VK, KCFSL,
         FPOptionsOverride()));
   }
 
@@ -1981,7 +1982,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
   InitListExpr *createInitListExpr(QualType InitTy, uint64_t NumChildInits) {
     InitListExpr *ILE = new (SemaRef.getASTContext()) InitListExpr(
-        SemaRef.getASTContext(), SourceLocation(), {}, SourceLocation());
+        SemaRef.getASTContext(), KCFSL, {}, KCFSL);
     ILE->reserveInits(SemaRef.getASTContext(), NumChildInits);
     ILE->setType(InitTy);
 
@@ -2007,7 +2008,8 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     TypeSourceInfo *TSInfo =
         KernelObj->isLambda() ? KernelObj->getLambdaTypeInfo() : nullptr;
     VarDecl *VD = VarDecl::Create(
-        Ctx, DC, SourceLocation(), SourceLocation(), KernelObj->getIdentifier(),
+        Ctx, DC, KernelObj->getLocation(), KernelObj->getLocation(),
+        KernelObj->getIdentifier(),
         QualType(KernelObj->getTypeForDecl(), 0), TSInfo, SC_None);
 
     return VD;
@@ -2016,7 +2018,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   // Default inits the type, then calls the init-method in the body.
   bool handleSpecialType(FieldDecl *FD, QualType Ty) {
     addFieldInit(FD, Ty, None,
-                 InitializationKind::CreateDefault(SourceLocation()));
+                 InitializationKind::CreateDefault(KCFSL));
 
     addFieldMemberExpr(FD, Ty);
 
@@ -2030,7 +2032,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
 
   bool handleSpecialType(const CXXBaseSpecifier &BS, QualType Ty) {
     const auto *RecordDecl = Ty->getAsCXXRecordDecl();
-    addBaseInit(BS, Ty, InitializationKind::CreateDefault(SourceLocation()));
+    addBaseInit(BS, Ty, InitializationKind::CreateDefault(KCFSL));
     createSpecialMethodCall(RecordDecl, InitMethodName, BodyStmts);
     return true;
   }
@@ -2043,15 +2045,16 @@ public:
         KernelObjClone(createKernelObjClone(S.getASTContext(),
                                             DC.getKernelDecl(), KernelObj)),
         VarEntity(InitializedEntity::InitializeVariable(KernelObjClone)),
-        KernelObj(KernelObj), KernelCallerFunc(KernelCallerFunc) {
+        KernelObj(KernelObj), KernelCallerFunc(KernelCallerFunc),
+        KCFSL(KernelCallerFunc->getLocation()) {
     CollectionInitExprs.push_back(createInitListExpr(KernelObj));
     markParallelWorkItemCalls();
 
     Stmt *DS = new (S.Context) DeclStmt(DeclGroupRef(KernelObjClone),
-                                        SourceLocation(), SourceLocation());
+                                        KCFSL, KCFSL);
     BodyStmts.push_back(DS);
     DeclRefExpr *KernelObjCloneRef = DeclRefExpr::Create(
-        S.Context, NestedNameSpecifierLoc(), SourceLocation(), KernelObjClone,
+        S.Context, NestedNameSpecifierLoc(), KCFSL, KernelObjClone,
         false, DeclarationNameInfo(), QualType(KernelObj->getTypeForDecl(), 0),
         VK_LValue);
     MemberExprBases.push_back(KernelObjCloneRef);
@@ -2162,7 +2165,7 @@ public:
     CXXCastPath BasePath;
     QualType DerivedTy(RD->getTypeForDecl(), 0);
     QualType BaseTy = BS.getType();
-    SemaRef.CheckDerivedToBaseConversion(DerivedTy, BaseTy, SourceLocation(),
+    SemaRef.CheckDerivedToBaseConversion(DerivedTy, BaseTy, KCFSL,
                                          SourceRange(), &BasePath,
                                          /*IgnoreBaseAccess*/ true);
     auto Cast = ImplicitCastExpr::Create(
@@ -2211,11 +2214,10 @@ public:
         Index, SizeT->isSignedIntegerType()};
 
     auto IndexLiteral = IntegerLiteral::Create(
-        SemaRef.getASTContext(), IndexVal, SizeT, SourceLocation());
+        SemaRef.getASTContext(), IndexVal, SizeT, KCFSL);
 
     ExprResult IndexExpr = SemaRef.CreateBuiltinArraySubscriptExpr(
-        MemberExprBases.back(), SourceLocation{}, IndexLiteral,
-        SourceLocation{});
+        MemberExprBases.back(), KCFSL, IndexLiteral, KCFSL);
 
     assert(!IndexExpr.isInvalid());
     MemberExprBases.push_back(IndexExpr.get());

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1821,8 +1821,8 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
         DeclCreator.getParamVarDeclsForCurrentField()[0];
 
     QualType ParamType = KernelParameter->getOriginalType();
-    Expr *DRE = SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue,
-                                         KCFSL);
+    Expr *DRE =
+        SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue, KCFSL);
     return DRE;
   }
 
@@ -1833,8 +1833,8 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
         DeclCreator.getParamVarDeclsForCurrentField()[0];
 
     QualType ParamType = KernelParameter->getOriginalType();
-    Expr *DRE = SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue,
-                                         KCFSL);
+    Expr *DRE =
+        SemaRef.BuildDeclRefExpr(KernelParameter, ParamType, VK_LValue, KCFSL);
 
     // Struct Type kernel arguments are decomposed. The pointer fields are
     // then wrapped inside a compiler generated struct. Therefore when
@@ -1876,8 +1876,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   }
 
   void addFieldInit(FieldDecl *FD, QualType Ty, MultiExprArg ParamRef) {
-    InitializationKind InitKind =
-        InitializationKind::CreateCopy(KCFSL, KCFSL);
+    InitializationKind InitKind = InitializationKind::CreateCopy(KCFSL, KCFSL);
     addFieldInit(FD, Ty, ParamRef, InitKind);
   }
 
@@ -1914,11 +1913,11 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   MemberExpr *buildMemberExpr(Expr *Base, ValueDecl *Member) {
     DeclAccessPair MemberDAP = DeclAccessPair::make(Member, AS_none);
     MemberExpr *Result = SemaRef.BuildMemberExpr(
-        Base, /*IsArrow */ false, KCFSL, NestedNameSpecifierLoc(),
-        KCFSL, Member, MemberDAP,
+        Base, /*IsArrow */ false, KCFSL, NestedNameSpecifierLoc(), KCFSL,
+        Member, MemberDAP,
         /*HadMultipleCandidates*/ false,
-        DeclarationNameInfo(Member->getDeclName(), KCFSL),
-        Member->getType(), VK_LValue, OK_Ordinary);
+        DeclarationNameInfo(Member->getDeclName(), KCFSL), Member->getType(),
+        VK_LValue, OK_Ordinary);
     return Result;
   }
 
@@ -1955,13 +1954,13 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     ResultTy = ResultTy.getNonLValueExprType(SemaRef.Context);
     llvm::SmallVector<Expr *, 4> ParamStmts;
     const auto *Proto = cast<FunctionProtoType>(Method->getType());
-    SemaRef.GatherArgumentsForCall(KCFSL, Method, Proto, 0,
-                                   ParamDREs, ParamStmts);
+    SemaRef.GatherArgumentsForCall(KCFSL, Method, Proto, 0, ParamDREs,
+                                   ParamStmts);
     // [kernel_obj or wrapper object].accessor.__init(_ValueType*,
     // range<int>, range<int>, id<int>)
-    AddTo.push_back(CXXMemberCallExpr::Create(
-        SemaRef.Context, MethodME, ParamStmts, ResultTy, VK, KCFSL,
-        FPOptionsOverride()));
+    AddTo.push_back(CXXMemberCallExpr::Create(SemaRef.Context, MethodME,
+                                              ParamStmts, ResultTy, VK, KCFSL,
+                                              FPOptionsOverride()));
   }
 
   // Creates an empty InitListExpr of the correct number of child-inits
@@ -1981,8 +1980,8 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
   }
 
   InitListExpr *createInitListExpr(QualType InitTy, uint64_t NumChildInits) {
-    InitListExpr *ILE = new (SemaRef.getASTContext()) InitListExpr(
-        SemaRef.getASTContext(), KCFSL, {}, KCFSL);
+    InitListExpr *ILE = new (SemaRef.getASTContext())
+        InitListExpr(SemaRef.getASTContext(), KCFSL, {}, KCFSL);
     ILE->reserveInits(SemaRef.getASTContext(), NumChildInits);
     ILE->setType(InitTy);
 
@@ -2009,16 +2008,15 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
         KernelObj->isLambda() ? KernelObj->getLambdaTypeInfo() : nullptr;
     VarDecl *VD = VarDecl::Create(
         Ctx, DC, KernelObj->getLocation(), KernelObj->getLocation(),
-        KernelObj->getIdentifier(),
-        QualType(KernelObj->getTypeForDecl(), 0), TSInfo, SC_None);
+        KernelObj->getIdentifier(), QualType(KernelObj->getTypeForDecl(), 0),
+        TSInfo, SC_None);
 
     return VD;
   }
 
   // Default inits the type, then calls the init-method in the body.
   bool handleSpecialType(FieldDecl *FD, QualType Ty) {
-    addFieldInit(FD, Ty, None,
-                 InitializationKind::CreateDefault(KCFSL));
+    addFieldInit(FD, Ty, None, InitializationKind::CreateDefault(KCFSL));
 
     addFieldMemberExpr(FD, Ty);
 
@@ -2050,12 +2048,12 @@ public:
     CollectionInitExprs.push_back(createInitListExpr(KernelObj));
     markParallelWorkItemCalls();
 
-    Stmt *DS = new (S.Context) DeclStmt(DeclGroupRef(KernelObjClone),
-                                        KCFSL, KCFSL);
+    Stmt *DS =
+        new (S.Context) DeclStmt(DeclGroupRef(KernelObjClone), KCFSL, KCFSL);
     BodyStmts.push_back(DS);
     DeclRefExpr *KernelObjCloneRef = DeclRefExpr::Create(
-        S.Context, NestedNameSpecifierLoc(), KCFSL, KernelObjClone,
-        false, DeclarationNameInfo(), QualType(KernelObj->getTypeForDecl(), 0),
+        S.Context, NestedNameSpecifierLoc(), KCFSL, KernelObjClone, false,
+        DeclarationNameInfo(), QualType(KernelObj->getTypeForDecl(), 0),
         VK_LValue);
     MemberExprBases.push_back(KernelObjCloneRef);
   }
@@ -2213,8 +2211,8 @@ public:
         static_cast<unsigned>(SemaRef.getASTContext().getTypeSize(SizeT)),
         Index, SizeT->isSignedIntegerType()};
 
-    auto IndexLiteral = IntegerLiteral::Create(
-        SemaRef.getASTContext(), IndexVal, SizeT, KCFSL);
+    auto IndexLiteral =
+        IntegerLiteral::Create(SemaRef.getASTContext(), IndexVal, SizeT, KCFSL);
 
     ExprResult IndexExpr = SemaRef.CreateBuiltinArraySubscriptExpr(
         MemberExprBases.back(), KCFSL, IndexLiteral, KCFSL);

--- a/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
@@ -3,9 +3,10 @@
 // Verify the SYCL kernel routine is marked artificial and has no source
 // correlation.
 //
-// The SYCL kernel should have no source correlation of its own, so it needs
-// to be marked artificial or it will inherit source correlation from the
-// surrounding code.
+// In order to placate the profiling tools, which can't cope with instructions
+// mapped to line 0, we've made the change so that the artificial code in a
+// SYCL kernel gets the source line info for the kernel caller function (the
+// 'kernel' template function on line 15 in this file).
 //
 
 #include <sycl.hpp>
@@ -33,8 +34,11 @@ int main() {
 // CHECK-SAME: scope: [[FILE]]
 // CHECK-SAME: file: [[FILE]]
 // CHECK-SAME: flags: DIFlagArtificial | DIFlagPrototyped
-// CHECK: [[LINE_A0]] = !DILocation(line: 0
+// CHECK: [[LINE_A0]] = !DILocation(line: 15,{{.*}}scope: [[KERNEL]]
 // CHECK: [[LINE_B0]] = !DILocation(line: 0
 
+// TODO: [[LINE_B0]] should be mapped to line 15 as well. That said,
+// this 'line 0' assignment is less problematic as the lambda function
+// call would be inlined in most cases.
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc


### PR DESCRIPTION
Assigning the source location of the kernel caller function to the
artificial initialization code generated in the kernel body.

This change is to enable the profiling tool to meaningfully
attribute the initialization code. Before this change, the code
was attributed to 'line 0' of the file where the kernel object
is at, which the tools consider meaningless.