### PR TITLE
Adding missing _CLC_OVERLOAD declarations to libclc OpenCL files, sycl branch (2020.09.04.)

### DIFF
--- a/libclc/generic/lib/workitem/get_global_offset.cl
+++ b/libclc/generic/lib/workitem/get_global_offset.cl
@@ -9,7 +9,7 @@
 #include <clc/clc.h>
 #include <spirv/spirv.h>
 
-_CLC_DEF size_t get_global_offset(uint dim) {
+_CLC_DEF _CLC_OVERLOAD size_t get_global_offset(uint dim) {
   switch (dim) {
     case 0:  return __spirv_GlobalOffset_x();
     case 1:  return __spirv_GlobalOffset_y();

--- a/libclc/generic/lib/workitem/get_group_id.cl
+++ b/libclc/generic/lib/workitem/get_group_id.cl
@@ -9,7 +9,7 @@
 #include <clc/clc.h>
 #include <spirv/spirv.h>
 
-_CLC_DEF size_t get_group_id(uint dim) {
+_CLC_DEF _CLC_OVERLOAD size_t get_group_id(uint dim) {
   switch (dim) {
     case 0:  return __spirv_WorkgroupId_x();
     case 1:  return __spirv_WorkgroupId_y();

--- a/libclc/generic/lib/workitem/get_local_id.cl
+++ b/libclc/generic/lib/workitem/get_local_id.cl
@@ -9,7 +9,7 @@
 #include <clc/clc.h>
 #include <spirv/spirv.h>
 
-_CLC_DEF size_t get_local_id(uint dim) {
+_CLC_DEF _CLC_OVERLOAD size_t get_local_id(uint dim) {
   switch (dim) {
     case 0:  return __spirv_LocalInvocationId_x();
     case 1:  return __spirv_LocalInvocationId_y();

--- a/libclc/generic/lib/workitem/get_local_size.cl
+++ b/libclc/generic/lib/workitem/get_local_size.cl
@@ -9,7 +9,7 @@
 #include <clc/clc.h>
 #include <spirv/spirv.h>
 
-_CLC_DEF size_t get_local_size(uint dim) {
+_CLC_DEF _CLC_OVERLOAD size_t get_local_size(uint dim) {
   switch (dim) {
     case 0:  return __spirv_WorkgroupSize_x();
     case 1:  return __spirv_WorkgroupSize_y();

--- a/libclc/generic/lib/workitem/get_num_groups.cl
+++ b/libclc/generic/lib/workitem/get_num_groups.cl
@@ -9,7 +9,7 @@
 #include <clc/clc.h>
 #include <spirv/spirv.h>
 
-_CLC_DEF size_t get_num_groups(uint dim) {
+_CLC_DEF _CLC_OVERLOAD size_t get_num_groups(uint dim) {
   switch (dim) {
     case 0:  return __spirv_NumWorkgroups_x();
     case 1:  return __spirv_NumWorkgroups_y();

--- a/libclc/generic/lib/workitem/get_work_dim.cl
+++ b/libclc/generic/lib/workitem/get_work_dim.cl
@@ -9,6 +9,4 @@
 #include <clc/clc.h>
 #include <spirv/spirv.h>
 
-_CLC_DEF _CLC_OVERLOAD uint get_work_dim(void) {
-  return __spirv_WorkDim();
-}
+_CLC_DEF _CLC_OVERLOAD uint get_work_dim(void) { return __spirv_WorkDim(); }

--- a/libclc/generic/lib/workitem/get_work_dim.cl
+++ b/libclc/generic/lib/workitem/get_work_dim.cl
@@ -9,6 +9,6 @@
 #include <clc/clc.h>
 #include <spirv/spirv.h>
 
-_CLC_DEF uint get_work_dim(void) {
+_CLC_DEF _CLC_OVERLOAD uint get_work_dim(void) {
   return __spirv_WorkDim();
 }


### PR DESCRIPTION
While trying to build the tip of the `sycl` branch, I ran into the following types of compilation failures:

```
[1/824] Building CLC object tools/libclc/CMakeFiles/builtins.link.clc-nvptx64--nvidiacl.dir/generic/lib/workitem/get_work_dim.bc
FAILED: tools/libclc/CMakeFiles/builtins.link.clc-nvptx64--nvidiacl.dir/generic/lib/workitem/get_work_dim.bc 
/data/projects/intel/build/./bin/clang -D_GNU_SOURCE -D__CLC_INTERNAL -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Itools/libclc -I/data/projects/intel/krasznaa-llvm/libclc -I/usr/include/libxml2 -Iinclude -I/data/projects/intel/krasznaa-llvm/llvm/include -I/data/projects/intel/krasznaa-llvm/libclc/generic/include -target nvptx64--nvidiacl -fno-builtin -nostdlib -I /data/projects/intel/krasznaa-llvm/libclc/generic/lib/workitem -o tools/libclc/CMakeFiles/builtins.link.clc-nvptx64--nvidiacl.dir/generic/lib/workitem/get_work_dim.bc -c /data/projects/intel/krasznaa-llvm/libclc/generic/lib/workitem/get_work_dim.cl -emit-llvm
/data/projects/intel/krasznaa-llvm/libclc/generic/lib/workitem/get_work_dim.cl:12:15: error: redeclaration of 'get_work_dim' must have the 'overloadable' attribute
_CLC_DEF uint get_work_dim(void) {
              ^
/data/projects/intel/krasznaa-llvm/libclc/generic/include/clc/workitem/get_work_dim.h:1:30: note: previous overload of function is here
_CLC_DECL _CLC_OVERLOAD uint get_work_dim(void);
```

These updates are here to fix them.