### PR TITLE
[Driver][SYCL][FPGA] Enable dependency file usage from static archive…

### DIFF
--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -111,4 +111,5 @@ TYPE("fpga_aocx",                FPGA_AOCX,    INVALID,         "aocx",   phases
 TYPE("fpga_aocr",                FPGA_AOCR,    INVALID,         "aocr",   phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("fpga_aoco",                FPGA_AOCO,    INVALID,         "aoco",   phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("fpga_dependencies",        FPGA_Dependencies, INVALID,    "d",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("fpga_dependencies_list",   FPGA_Dependencies_List, INVALID, "txt",  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("none",                     Nothing,      INVALID,         nullptr,  phases::Compile, phases::Backend, phases::Assemble, phases::Link)

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -150,7 +150,8 @@ bool Compilation::CleanupFileList(const TempFileList &Files,
     // Temporary file lists contain files that need to be cleaned. The
     // file containing the information is also removed
     if (File.second == types::TY_Tempfilelist ||
-        File.second == types::TY_Tempfiletable) {
+        File.second == types::TY_Tempfiletable ||
+        File.second == types::TY_FPGA_Dependencies_List) {
       // These are temporary files and need to be removed.
       bool IsTable = File.second == types::TY_Tempfiletable;
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7378,7 +7378,8 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   bool IsMSVCEnv =
       C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment();
   types::ID InputType(Input.getType());
-  bool IsFPGADepUnbundle = (JA.getType() == types::TY_FPGA_Dependencies);
+  bool IsFPGADepUnbundle = JA.getType() == types::TY_FPGA_Dependencies;
+  bool IsFPGADepLibUnbundle = JA.getType() == types::TY_FPGA_Dependencies_List;
   bool IsArchiveUnbundle =
       (!IsMSVCEnv && C.getDriver().getOffloadStaticLibSeen() &&
        (types::isArchive(InputType) || InputType == types::TY_Object));
@@ -7394,7 +7395,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
     else
       TypeArg = "aoo";
   }
-  if (InputType == types::TY_FPGA_AOCO ||
+  if (InputType == types::TY_FPGA_AOCO || IsFPGADepLibUnbundle ||
       (IsMSVCEnv && types::isArchive(InputType)))
     TypeArg = "aoo";
   if (IsFPGADepUnbundle)
@@ -7453,7 +7454,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
       Triples += Dep.DependentBoundArch;
     }
   }
-  if (IsFPGADepUnbundle) {
+  if (IsFPGADepUnbundle || IsFPGADepLibUnbundle) {
     // TODO - We are currently using the target triple inputs to slot a location
     // of the dependency information into the bundle.  It would be good to
     // separate this out to an explicit option in the bundler for the dependency
@@ -7474,7 +7475,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   // When dealing with -fintelfpga, there is an additional unbundle step
   // that occurs for the dependency file.  In that case, do not use the
   // dependent information, but just the output file.
-  if (IsFPGADepUnbundle)
+  if (IsFPGADepUnbundle || IsFPGADepLibUnbundle)
     UB += Outputs[0].getFilename();
   else {
     for (unsigned I = 0; I < Outputs.size(); ++I) {

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -278,13 +278,11 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
   if (!FPGADepFiles.empty()) {
     SmallString<128> DepOpt("-dep-files=");
     for (unsigned I = 0; I < FPGADepFiles.size(); ++I) {
-      SmallString<64> FileName;
-      if (FPGADepFiles[I].getType() == types::TY_FPGA_Dependencies_List)
-        FileName += "@";
-      FileName += FPGADepFiles[I].getFilename();
       if (I)
         DepOpt += ',';
-      DepOpt += FileName;
+      if (FPGADepFiles[I].getType() == types::TY_FPGA_Dependencies_List)
+        DepOpt += "@";
+      DepOpt += FPGADepFiles[I].getFilename();
     }
     CmdArgs.push_back(C.getArgs().MakeArgString(DepOpt));
   }

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -225,7 +225,8 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
       // Add any FPGA library lists.  These come in as special tempfile lists.
       CmdArgs.push_back(Args.MakeArgString(Twine("-library-list=") +
           Filename));
-    else if (II.getType() == types::TY_FPGA_Dependencies)
+    else if (II.getType() == types::TY_FPGA_Dependencies ||
+             II.getType() == types::TY_FPGA_Dependencies_List)
       FPGADepFiles.push_back(II);
     else
       CmdArgs.push_back(C.getArgs().MakeArgString(Filename));
@@ -277,9 +278,13 @@ void SYCL::fpga::BackendCompiler::ConstructJob(Compilation &C,
   if (!FPGADepFiles.empty()) {
     SmallString<128> DepOpt("-dep-files=");
     for (unsigned I = 0; I < FPGADepFiles.size(); ++I) {
+      SmallString<64> FileName;
+      if (FPGADepFiles[I].getType() == types::TY_FPGA_Dependencies_List)
+        FileName += "@";
+      FileName += FPGADepFiles[I].getFilename();
       if (I)
         DepOpt += ',';
-      DepOpt += FPGADepFiles[I].getFilename();
+      DepOpt += FileName;
     }
     CmdArgs.push_back(C.getArgs().MakeArgString(DepOpt));
   }

--- a/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
@@ -1,0 +1,33 @@
+///
+/// tests specific to -fintelfpga -fsycl w/ static libs
+///
+// REQUIRES: clang-driver
+// REQUIRES: system-windows
+
+// make dummy archive
+// Build a fat static lib that will be used for all tests
+// RUN: echo "void foo(void) {}" > %t1.cpp
+// RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fintelfpga %t1.cpp -c -o %t1_bundle.obj
+// RUN: lib -out:%t.lib %t1_bundle.obj
+
+/// Check phases with static lib
+// RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fintelfpga %t.lib -ccc-print-phases 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK_PHASES %s
+// CHECK_PHASES: 0: input, "[[INPUT:.+\.lib]]", object, (host-sycl)
+// CHECK_PHASES: 1: linker, {0}, image, (host-sycl)
+// CHECK_PHASES: 2: input, "[[INPUT]]", archive
+// CHECK_PHASES: 3: clang-offload-unbundler, {2}, archive
+// CHECK_PHASES: 4: linker, {3}, ir, (device-sycl)
+// CHECK_PHASES: 5: sycl-post-link, {4}, ir, (device-sycl)
+// CHECK_PHASES: 6: llvm-spirv, {5}, spirv, (device-sycl)
+// CHECK_PHASES: 7: input, "[[INPUT]]", archive
+// CHECK_PHASES: 8: clang-offload-unbundler, {7}, fpga_dependencies_list
+// CHECK_PHASES: 9: backend-compiler, {6, 8}, fpga_aocx, (device-sycl)
+// CHECK_PHASES: 10: clang-offload-wrapper, {9}, object, (device-sycl)
+// CHECK_PHASES: 11: offload, "host-sycl (x86_64-pc-windows-msvc)" {1}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {10}, image
+
+/// Check for unbundle and use of deps in static lib
+// RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fintelfpga %t.lib -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK_UNBUNDLE %s
+// CHECK_UNBUNDLE: clang-offload-bundler" "-type=aoo" "-targets=sycl-fpga_dep" "-inputs={{.*}}" "-outputs=[[DEPFILES:.+\.txt]]" "-unbundle"
+// CHECK_UNBUNDLE: aoc{{.*}} "-dep-files=@[[DEPFILES]]"

--- a/clang/test/Driver/sycl-intelfpga-static-lib.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib.cpp
@@ -1,0 +1,33 @@
+///
+/// tests specific to -fintelfpga -fsycl w/ static libs
+///
+// REQUIRES: clang-driver
+
+// make dummy archive
+// Build a fat static lib that will be used for all tests
+// RUN: echo "void foo(void) {}" > %t1.cpp
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fintelfpga -fsycl %t1.cpp -c -o %t1_bundle.o
+// RUN: llvm-ar cr %t.a %t1_bundle.o
+
+/// Check phases with static lib
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t.a -ccc-print-phases 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK_PHASES %s
+// CHECK_PHASES: 0: input, "[[INPUT:.+\.a]]", object, (host-sycl)
+// CHECK_PHASES: 1: linker, {0}, image, (host-sycl)
+// CHECK_PHASES: 2: input, "[[INPUT]]", archive
+// CHECK_PHASES: 3: partial-link, {2}, object
+// CHECK_PHASES: 4: clang-offload-unbundler, {3}, object
+// CHECK_PHASES: 5: linker, {4}, ir, (device-sycl)
+// CHECK_PHASES: 6: sycl-post-link, {5}, ir, (device-sycl)
+// CHECK_PHASES: 7: llvm-spirv, {6}, spirv, (device-sycl)
+// CHECK_PHASES: 8: input, "[[INPUT]]", archive
+// CHECK_PHASES: 9: clang-offload-unbundler, {8}, fpga_dependencies_list
+// CHECK_PHASES: 10: backend-compiler, {7, 9}, fpga_aocx, (device-sycl)
+// CHECK_PHASES: 11: clang-offload-wrapper, {10}, object, (device-sycl)
+// CHECK_PHASES: 12: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {11}, image
+
+/// Check for unbundle and use of deps in static lib
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t.a -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK_UNBUNDLE %s
+// CHECK_UNBUNDLE: clang-offload-bundler" "-type=aoo" "-targets=sycl-fpga_dep" "-inputs={{.*}}" "-outputs=[[DEPFILES:.+\.txt]]" "-unbundle"
+// CHECK_UNBUNDLE: aoc{{.*}} "-dep-files=@[[DEPFILES]]"

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -368,11 +368,13 @@
 // CHK-FPGA-AOCO-PHASES: 15: linker, {11, 14}, ir, (device-sycl)
 // CHK-FPGA-AOCO-PHASES: 16: sycl-post-link, {15}, ir, (device-sycl)
 // CHK-FPGA-AOCO-PHASES: 17: llvm-spirv, {16}, spirv, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 18: input, "[[INPUTA]]", fpga_aoco
-// CHK-FPGA-AOCO-PHASES: 19: clang-offload-unbundler, {18}, fpga_aoco
-// CHK-FPGA-AOCO-PHASES: 20: backend-compiler, {17, 19}, fpga_aocx, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 21: clang-offload-wrapper, {20}, object, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 22: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {21}, image
+// CHK-FPGA-AOCO-PHASES: 18: input, "[[INPUTA]]", archive
+// CHK-FPGA-AOCO-PHASES: 19: clang-offload-unbundler, {18}, fpga_dependencies_list
+// CHK-FPGA-AOCO-PHASES: 20: input, "[[INPUTA]]", fpga_aoco
+// CHK-FPGA-AOCO-PHASES: 21: clang-offload-unbundler, {20}, fpga_aoco
+// CHK-FPGA-AOCO-PHASES: 22: backend-compiler, {17, 19, 21}, fpga_aocx, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 23: clang-offload-wrapper, {22}, object, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 24: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {23}, image
 
 /// FPGA AOCO Windows phases check
 // RUN:  %clang_cl -fsycl -fintelfpga -foffload-static-lib=%t_aoco_cl.a %s -### -ccc-print-phases 2>&1 \
@@ -394,11 +396,13 @@
 // CHK-FPGA-AOCO-PHASES-WIN: 14: linker, {11, 13}, ir, (device-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 15: sycl-post-link, {14}, ir, (device-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 16: llvm-spirv, {15}, spirv, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 17: input, "[[INPUTA]]", fpga_aoco
-// CHK-FPGA-AOCO-PHASES-WIN: 18: clang-offload-unbundler, {17}, fpga_aoco
-// CHK-FPGA-AOCO-PHASES-WIN: 19: backend-compiler, {16, 18}, fpga_aocx, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 20: clang-offload-wrapper, {19}, object, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 21: offload, "host-sycl (x86_64-pc-windows-msvc)" {10}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {20}, image
+// CHK-FPGA-AOCO-PHASES-WIN: 17: input, "[[INPUTA]]", archive
+// CHK-FPGA-AOCO-PHASES-WIN: 18: clang-offload-unbundler, {17}, fpga_dependencies_list
+// CHK-FPGA-AOCO-PHASES-WIN: 19: input, "[[INPUTA]]", fpga_aoco
+// CHK-FPGA-AOCO-PHASES-WIN: 20: clang-offload-unbundler, {19}, fpga_aoco
+// CHK-FPGA-AOCO-PHASES-WIN: 21: backend-compiler, {16, 18, 20}, fpga_aocx, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 22: clang-offload-wrapper, {21}, object, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 23: offload, "host-sycl (x86_64-pc-windows-msvc)" {10}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {22}, image
 
 /// aoco test, checking tools
 // RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga -foffload-static-lib=%t_aoco.a -### %s 2>&1 \


### PR DESCRIPTION
…s for FPGA

When performing compilations for FPGA, we want to be sure to take advantage
of dependency information that could be part of the fat static archives.