### PR TITLE
[Driver][SYCL][FPGA] Improve help output for aoc with -fsycl-help

### DIFF
--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -75,7 +75,7 @@
 // SYCL-HELP-BADARG: unsupported argument 'foo' to option 'fsycl-help='
 // SYCL-HELP-GEN: Emitting help information for ocloc
 // SYCL-HELP-GEN: Use triple of 'spir64_gen-unknown-unknown-sycldevice' to enable ahead of time compilation
-// SYCL-HELP-FPGA-OUT: "[[DIR]]{{[/\\]+}}aoc" "-help"
+// SYCL-HELP-FPGA-OUT: "[[DIR]]{{[/\\]+}}aoc" "-help" "-sycl"
 // SYCL-HELP-FPGA: Emitting help information for aoc
 // SYCL-HELP-FPGA: Use triple of 'spir64_fpga-unknown-unknown-sycldevice' to enable ahead of time compilation
 // SYCL-HELP-CPU: Emitting help information for opencl-aot


### PR DESCRIPTION
aoc provides a way to emit SYCL FPGA specific options with the -help
via the -sycl option.  Augment the the help output behaviors to
allow for an additional option that can be used with the tools.