### PR TITLE
[SYCL] Unroll several loops in __init method accessor class

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -851,7 +851,7 @@ protected:
   void __init(ConcreteASPtrType Ptr, range<AdjustedDim> AccessRange,
               range<AdjustedDim> MemRange, id<AdjustedDim> Offset) {
     MData = Ptr;
-    [[clang::unroll]]
+    #pragma unroll
     for (int I = 0; I < AdjustedDim; ++I) {
       getOffset()[I] = Offset[I];
       getAccessRange()[I] = AccessRange[I];
@@ -1389,7 +1389,7 @@ protected:
   void __init(ConcreteASPtrType Ptr, range<AdjustedDim> AccessRange,
               range<AdjustedDim>, id<AdjustedDim>) {
     MData = Ptr;
-    [[clang::unroll]]
+    #pragma unroll
     for (int I = 0; I < AdjustedDim; ++I)
       getSize()[I] = AccessRange[I];
   }

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -851,7 +851,7 @@ protected:
   void __init(ConcreteASPtrType Ptr, range<AdjustedDim> AccessRange,
               range<AdjustedDim> MemRange, id<AdjustedDim> Offset) {
     MData = Ptr;
-    #pragma unroll
+#pragma unroll
     for (int I = 0; I < AdjustedDim; ++I) {
       getOffset()[I] = Offset[I];
       getAccessRange()[I] = AccessRange[I];
@@ -1389,7 +1389,7 @@ protected:
   void __init(ConcreteASPtrType Ptr, range<AdjustedDim> AccessRange,
               range<AdjustedDim>, id<AdjustedDim>) {
     MData = Ptr;
-    #pragma unroll
+#pragma unroll
     for (int I = 0; I < AdjustedDim; ++I)
       getSize()[I] = AccessRange[I];
   }

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -851,6 +851,7 @@ protected:
   void __init(ConcreteASPtrType Ptr, range<AdjustedDim> AccessRange,
               range<AdjustedDim> MemRange, id<AdjustedDim> Offset) {
     MData = Ptr;
+    [[clang::unroll]]
     for (int I = 0; I < AdjustedDim; ++I) {
       getOffset()[I] = Offset[I];
       getAccessRange()[I] = AccessRange[I];
@@ -1388,6 +1389,7 @@ protected:
   void __init(ConcreteASPtrType Ptr, range<AdjustedDim> AccessRange,
               range<AdjustedDim>, id<AdjustedDim>) {
     MData = Ptr;
+    [[clang::unroll]]
     for (int I = 0; I < AdjustedDim; ++I)
       getSize()[I] = AccessRange[I];
   }


### PR DESCRIPTION
It might improve performance on several platforms.

Co-author: Mark Mendell <mark.p.mendell@intel.com>
Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>