### PR TITLE
[SYCL] Add group algorithm constraints

### DIFF
--- a/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
+++ b/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
@@ -118,7 +118,7 @@ The following function objects alias objects in the +<functional>+ header from t
 - +cl::sycl::intel::bit_xor+
 - +cl::sycl::intel::logical_and+
 - +cl::sycl::intel::logical_or+
-
+/
 New function objects without {cpp} standard library equivalents are defined in the table below:
 
 |===
@@ -131,8 +131,6 @@ New function objects without {cpp} standard library equivalents are defined in t
 |+T operator(const T&, const T&) const+ applies +std::greater+ to its arguments, in the same order, then returns the greater argument unchanged.
 |===
 
-Function objects supported by the group algorithms library can be identified using the +cl::sycl::intel::is_native_function_object+ and +cl::sycl::intel::is_native_function_object_v+ traits classes.
-
 === Functions
 
 The group algorithms library is based on the algorithms library described in Section 28 of the {cpp}17 standard.  The syntax and restrictions are aligned, with two notable differences: the first argument to each function is a group of work-items, in place of an execution policy; and pointers are accepted in place of iterators in order to guarantee that address space information is visible to the compiler.
@@ -144,6 +142,8 @@ Many functions provide at least two overloads: one operating directly on data pr
 Using functions from the group algorithms library inside of a kernel may introduce additional limits on the resources available to user code inside the same kernel (e.g. private memory, work-group local memory).  The behavior of these limits is implementation-defined, but must be reflected by calls to kernel querying functions such as +kernel::get_work_group_info+.
 
 It is undefined behavior for any of these functions to be invoked within a +parallel_for_work_group+ or +parallel_for_work_item+ context, but this restriction may be lifted in a future version of the proposal.
+
+All restrictions on acceptable group types, input types and function objects must be implemented as constraints.
 
 ==== Vote
 
@@ -262,6 +262,11 @@ None.
 //*RESOLUTION*: Not resolved.
 //--
 
+. How should `is_native_function_object` work?  Does it represent what is minimally required by the specification, or what the implementation really supports?
+--
+*RESOLUTION*: The `is_native_function_object` trait has been removed.  It proved too difficult to implement something that returned sensible values for transparent function objects (e.g. `std::plus<void>`) that did not also require checking additional traits for each individual group algorithm.  Requiring the user to implement their own checks based on type requirements outlined in the specification would make it significantly harder for implementers to extend the algorithms to types and function objects beyond what is specified.  Using constrained forms of the algorithms instead allows a user to determine whether an implementation of a particular algorithm exists using the C++ detection idiom.
+--
+
 == Revision History
 
 [cols="5,15,15,70"]
@@ -270,6 +275,7 @@ None.
 |========================================
 |Rev|Date|Author|Changes
 |1|2020-01-30|John Pennycook|*Initial public working draft*
+|2|2020-09-10|John Pennycook|*Remove is_native_function_object and clarify which requirements are constraints*
 |========================================
 
 //************************************************************************

--- a/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
+++ b/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
@@ -143,7 +143,7 @@ Using functions from the group algorithms library inside of a kernel may introdu
 
 It is undefined behavior for any of these functions to be invoked within a +parallel_for_work_group+ or +parallel_for_work_item+ context, but this restriction may be lifted in a future version of the proposal.
 
-All restrictions on acceptable group types, input types and function objects must be implemented as constraints.
+A number of the restrictions regarding the types of parameters that are acceptable for each algorithm must implemented as constraints: group arguments must be of a supported group class type; binary operations must be one of the group algorithms function objects; pointer arguments must be pointers to fundamental data types; and value arguments must be scalar fundamental data types (or vectors of those types).
 
 ==== Vote
 

--- a/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
+++ b/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
@@ -118,7 +118,7 @@ The following function objects alias objects in the +<functional>+ header from t
 - +cl::sycl::intel::bit_xor+
 - +cl::sycl::intel::logical_and+
 - +cl::sycl::intel::logical_or+
-/
+
 New function objects without {cpp} standard library equivalents are defined in the table below:
 
 |===

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -203,18 +203,15 @@ all_of(Group, bool pred) {
 }
 
 template <typename Group, typename T, class Predicate>
-detail::enable_if_t<(detail::is_generic_group<Group>::value &&
-                     detail::is_arithmetic<T>::value),
-                    bool>
+detail::enable_if_t<detail::is_generic_group<Group>::value, bool>
 all_of(Group g, T x, Predicate pred) {
   return all_of(g, pred(x));
 }
 
 template <typename Group, typename Ptr, class Predicate>
-detail::enable_if_t<
-    (detail::is_generic_group<Group>::value && detail::is_pointer<Ptr>::value &&
-     detail::is_arithmetic<typename detail::remove_pointer<Ptr>::type>::value),
-    bool>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_pointer<Ptr>::value),
+                    bool>
 all_of(Group g, Ptr first, Ptr last, Predicate pred) {
 #ifdef __SYCL_DEVICE_ONLY__
   bool partial = true;
@@ -245,18 +242,15 @@ any_of(Group, bool pred) {
 }
 
 template <typename Group, typename T, class Predicate>
-detail::enable_if_t<(detail::is_generic_group<Group>::value &&
-                     detail::is_arithmetic<T>::value),
-                    bool>
+detail::enable_if_t<detail::is_generic_group<Group>::value, bool>
 any_of(Group g, T x, Predicate pred) {
   return any_of(g, pred(x));
 }
 
 template <typename Group, typename Ptr, class Predicate>
-detail::enable_if_t<
-    (detail::is_generic_group<Group>::value && detail::is_pointer<Ptr>::value &&
-     detail::is_arithmetic<typename detail::remove_pointer<Ptr>::type>::value),
-    bool>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_pointer<Ptr>::value),
+                    bool>
 any_of(Group g, Ptr first, Ptr last, Predicate pred) {
 #ifdef __SYCL_DEVICE_ONLY__
   bool partial = false;
@@ -287,18 +281,15 @@ none_of(Group, bool pred) {
 }
 
 template <typename Group, typename T, class Predicate>
-detail::enable_if_t<(detail::is_generic_group<Group>::value &&
-                     detail::is_arithmetic<T>::value),
-                    bool>
+detail::enable_if_t<detail::is_generic_group<Group>::value, bool>
 none_of(Group g, T x, Predicate pred) {
   return none_of(g, pred(x));
 }
 
 template <typename Group, typename Ptr, class Predicate>
-detail::enable_if_t<
-    (detail::is_generic_group<Group>::value && detail::is_pointer<Ptr>::value &&
-     detail::is_arithmetic<typename detail::remove_pointer<Ptr>::type>::value),
-    bool>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_pointer<Ptr>::value),
+                    bool>
 none_of(Group g, Ptr first, Ptr last, Predicate pred) {
 #ifdef __SYCL_DEVICE_ONLY__
   return !any_of(g, first, last, pred);

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -614,11 +614,11 @@ reduce(Group g, Ptr first, Ptr last, T init, BinaryOperation binary_op) {
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_scalar_arithmetic<T>::value &&
+                     detail::is_native_op<T, BinaryOperation>::value),
+                    T>
 exclusive_scan(Group, T x, BinaryOperation binary_op) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(std::is_same<decltype(binary_op(x, x)), T>::value ||
                     (std::is_same<T, half>::value &&
@@ -635,11 +635,11 @@ exclusive_scan(Group, T x, BinaryOperation binary_op) {
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_vector_arithmetic<T>::value &&
+                     detail::is_native_op<T, BinaryOperation>::value),
+                    T>
 exclusive_scan(Group g, T x, BinaryOperation binary_op) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(
       std::is_same<decltype(binary_op(x[0], x[0])),
@@ -655,11 +655,13 @@ exclusive_scan(Group g, T x, BinaryOperation binary_op) {
 }
 
 template <typename Group, typename V, typename T, class BinaryOperation>
-EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_vector_arithmetic<V>::value &&
+                     detail::is_vector_arithmetic<T>::value &&
+                     detail::is_native_op<V, BinaryOperation>::value &&
+                     detail::is_native_op<T, BinaryOperation>::value),
+                    T>
 exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(
       std::is_same<decltype(binary_op(init[0], x[0])),
@@ -675,11 +677,13 @@ exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
 }
 
 template <typename Group, typename V, typename T, class BinaryOperation>
-EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_scalar_arithmetic<V>::value &&
+                     detail::is_scalar_arithmetic<T>::value &&
+                     detail::is_native_op<V, BinaryOperation>::value &&
+                     detail::is_native_op<T, BinaryOperation>::value),
+                    T>
 exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(std::is_same<decltype(binary_op(init, x)), T>::value ||
                     (std::is_same<T, half>::value &&
@@ -705,12 +709,18 @@ exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
 
 template <typename Group, typename InPtr, typename OutPtr, typename T,
           class BinaryOperation>
-EnableIfIsPointer<InPtr, OutPtr>
+detail::enable_if_t<
+    (detail::is_generic_group<Group>::value &&
+     detail::is_pointer<InPtr>::value && detail::is_pointer<OutPtr>::value &&
+     detail::is_arithmetic<
+         typename detail::remove_pointer<InPtr>::type>::value &&
+     detail::is_arithmetic<T>::value &&
+     detail::is_native_op<typename detail::remove_pointer<InPtr>::type,
+                          BinaryOperation>::value &&
+     detail::is_native_op<T, BinaryOperation>::value),
+    OutPtr>
 exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init,
                BinaryOperation binary_op) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(
       std::is_same<decltype(binary_op(*first, *first)), T>::value ||
@@ -751,9 +761,16 @@ exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init,
 
 template <typename Group, typename InPtr, typename OutPtr,
           class BinaryOperation>
-EnableIfIsPointer<InPtr, OutPtr> exclusive_scan(Group g, InPtr first,
-                                                InPtr last, OutPtr result,
-                                                BinaryOperation binary_op) {
+detail::enable_if_t<
+    (detail::is_generic_group<Group>::value &&
+     detail::is_pointer<InPtr>::value && detail::is_pointer<OutPtr>::value &&
+     detail::is_arithmetic<
+         typename detail::remove_pointer<InPtr>::type>::value &&
+     detail::is_native_op<typename detail::remove_pointer<InPtr>::type,
+                          BinaryOperation>::value),
+    OutPtr>
+exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+               BinaryOperation binary_op) {
   // FIXME: Do not special-case for half precision
   static_assert(
       std::is_same<decltype(binary_op(*first, *first)),

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -536,8 +536,8 @@ template <typename Group, typename V, typename T, class BinaryOperation>
 detail::enable_if_t<(detail::is_sub_group<Group>::value &&
                      std::is_trivially_copyable<T>::value &&
                      std::is_trivially_copyable<V>::value &&
-                     (!std::is_arithmetic<T>::value ||
-                      !std::is_arithmetic<V>::value ||
+                     (!detail::is_arithmetic<T>::value ||
+                      !detail::is_arithmetic<V>::value ||
                       !detail::is_native_op<T, BinaryOperation>::value)),
                     T>
 reduce(Group g, V x, T init, BinaryOperation op) {

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -466,14 +466,11 @@ reduce(Group g, T x, BinaryOperation binary_op) {
 
 template <typename Group, typename T, class BinaryOperation>
 detail::enable_if_t<(detail::is_sub_group<Group>::value &&
-                     ((!detail::is_arithmetic<T>::value &&
-                       std::is_trivially_copyable<T>::value) ||
+                     std::is_trivially_copyable<T>::value &&
+                     (!detail::is_arithmetic<T>::value ||
                       !detail::is_native_op<T, BinaryOperation>::value)),
                     T>
 reduce(Group g, T x, BinaryOperation op) {
-  static_assert(sycl::detail::is_sub_group<Group>::value,
-                "reduce algorithm with user-defined types and operators"
-                "only supports ONEAPI::sub_group class.");
   T result = x;
   for (int mask = 1; mask < g.get_max_local_range()[0]; mask *= 2) {
     T tmp = g.shuffle_xor(result, id<1>(mask));
@@ -537,10 +534,10 @@ reduce(Group g, V x, T init, BinaryOperation binary_op) {
 
 template <typename Group, typename V, typename T, class BinaryOperation>
 detail::enable_if_t<(detail::is_sub_group<Group>::value &&
-                     ((!(detail::is_arithmetic<T>::value &&
-                         detail::is_arithmetic<V>::value) &&
-                       (std::is_trivially_copyable<T>::value &&
-                        std::is_trivially_copyable<V>::value)) ||
+                     std::is_trivially_copyable<T>::value &&
+                     std::is_trivially_copyable<V>::value &&
+                     (!std::is_arithmetic<T>::value ||
+                      !std::is_arithmetic<V>::value ||
                       !detail::is_native_op<T, BinaryOperation>::value)),
                     T>
 reduce(Group g, V x, T init, BinaryOperation op) {

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -190,10 +190,9 @@ using EnableIfIsNonNativeOp = cl::sycl::detail::enable_if_t<
         !cl::sycl::detail::is_native_op<T, BinaryOperation>::value,
     T>;
 
-template <typename Group> bool all_of(Group, bool pred) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+template <typename Group>
+detail::enable_if_t<detail::is_generic_group<Group>::value, bool>
+all_of(Group, bool pred) {
 #ifdef __SYCL_DEVICE_ONLY__
   return sycl::detail::spirv::GroupAll<Group>(pred);
 #else
@@ -204,19 +203,19 @@ template <typename Group> bool all_of(Group, bool pred) {
 }
 
 template <typename Group, typename T, class Predicate>
-bool all_of(Group g, T x, Predicate pred) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_arithmetic<T>::value),
+                    bool>
+all_of(Group g, T x, Predicate pred) {
   return all_of(g, pred(x));
 }
 
 template <typename Group, typename Ptr, class Predicate>
-EnableIfIsPointer<Ptr, bool> all_of(Group g, Ptr first, Ptr last,
-                                    Predicate pred) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+detail::enable_if_t<
+    (detail::is_generic_group<Group>::value && detail::is_pointer<Ptr>::value &&
+     detail::is_arithmetic<typename detail::remove_pointer<Ptr>::type>::value),
+    bool>
+all_of(Group g, Ptr first, Ptr last, Predicate pred) {
 #ifdef __SYCL_DEVICE_ONLY__
   bool partial = true;
   sycl::detail::for_each(
@@ -233,10 +232,9 @@ EnableIfIsPointer<Ptr, bool> all_of(Group g, Ptr first, Ptr last,
 #endif
 }
 
-template <typename Group> bool any_of(Group, bool pred) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+template <typename Group>
+detail::enable_if_t<detail::is_generic_group<Group>::value, bool>
+any_of(Group, bool pred) {
 #ifdef __SYCL_DEVICE_ONLY__
   return sycl::detail::spirv::GroupAny<Group>(pred);
 #else
@@ -247,20 +245,20 @@ template <typename Group> bool any_of(Group, bool pred) {
 }
 
 template <typename Group, typename T, class Predicate>
-bool any_of(Group g, T x, Predicate pred) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_arithmetic<T>::value),
+                    bool>
+any_of(Group g, T x, Predicate pred) {
   return any_of(g, pred(x));
 }
 
 template <typename Group, typename Ptr, class Predicate>
-EnableIfIsPointer<Ptr, bool> any_of(Group g, Ptr first, Ptr last,
-                                    Predicate pred) {
+detail::enable_if_t<
+    (detail::is_generic_group<Group>::value && detail::is_pointer<Ptr>::value &&
+     detail::is_arithmetic<typename detail::remove_pointer<Ptr>::type>::value),
+    bool>
+any_of(Group g, Ptr first, Ptr last, Predicate pred) {
 #ifdef __SYCL_DEVICE_ONLY__
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   bool partial = false;
   sycl::detail::for_each(
       g, first, last,
@@ -276,10 +274,9 @@ EnableIfIsPointer<Ptr, bool> any_of(Group g, Ptr first, Ptr last,
 #endif
 }
 
-template <typename Group> bool none_of(Group, bool pred) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+template <typename Group>
+detail::enable_if_t<detail::is_generic_group<Group>::value, bool>
+none_of(Group, bool pred) {
 #ifdef __SYCL_DEVICE_ONLY__
   return sycl::detail::spirv::GroupAll<Group>(!pred);
 #else
@@ -290,20 +287,20 @@ template <typename Group> bool none_of(Group, bool pred) {
 }
 
 template <typename Group, typename T, class Predicate>
-bool none_of(Group g, T x, Predicate pred) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_arithmetic<T>::value),
+                    bool>
+none_of(Group g, T x, Predicate pred) {
   return none_of(g, pred(x));
 }
 
 template <typename Group, typename Ptr, class Predicate>
-EnableIfIsPointer<Ptr, bool> none_of(Group g, Ptr first, Ptr last,
-                                     Predicate pred) {
+detail::enable_if_t<
+    (detail::is_generic_group<Group>::value && detail::is_pointer<Ptr>::value &&
+     detail::is_arithmetic<typename detail::remove_pointer<Ptr>::type>::value),
+    bool>
+none_of(Group g, Ptr first, Ptr last, Predicate pred) {
 #ifdef __SYCL_DEVICE_ONLY__
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   return !any_of(g, first, last, pred);
 #else
   (void)g;

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -785,11 +785,11 @@ exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_vector_arithmetic<T>::value &&
+                     detail::is_native_op<T, BinaryOperation>::value),
+                    T>
 inclusive_scan(Group g, T x, BinaryOperation binary_op) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(
       std::is_same<decltype(binary_op(x[0], x[0])),
@@ -805,11 +805,11 @@ inclusive_scan(Group g, T x, BinaryOperation binary_op) {
 }
 
 template <typename Group, typename T, class BinaryOperation>
-EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_scalar_arithmetic<T>::value &&
+                     detail::is_native_op<T, BinaryOperation>::value),
+                    T>
 inclusive_scan(Group, T x, BinaryOperation binary_op) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(std::is_same<decltype(binary_op(x, x)), T>::value ||
                     (std::is_same<T, half>::value &&
@@ -826,11 +826,13 @@ inclusive_scan(Group, T x, BinaryOperation binary_op) {
 }
 
 template <typename Group, typename V, class BinaryOperation, typename T>
-EnableIfIsScalarArithmeticNativeOp<T, BinaryOperation>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_scalar_arithmetic<V>::value &&
+                     detail::is_scalar_arithmetic<T>::value &&
+                     detail::is_native_op<V, BinaryOperation>::value &&
+                     detail::is_native_op<T, BinaryOperation>::value),
+                    T>
 inclusive_scan(Group g, V x, BinaryOperation binary_op, T init) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(std::is_same<decltype(binary_op(init, x)), T>::value ||
                     (std::is_same<T, half>::value &&
@@ -849,11 +851,13 @@ inclusive_scan(Group g, V x, BinaryOperation binary_op, T init) {
 }
 
 template <typename Group, typename V, class BinaryOperation, typename T>
-EnableIfIsVectorArithmeticNativeOp<T, BinaryOperation>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_vector_arithmetic<V>::value &&
+                     detail::is_vector_arithmetic<T>::value &&
+                     detail::is_native_op<V, BinaryOperation>::value &&
+                     detail::is_native_op<T, BinaryOperation>::value),
+                    T>
 inclusive_scan(Group g, V x, BinaryOperation binary_op, T init) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(
       std::is_same<decltype(binary_op(init[0], x[0])), T>::value ||
@@ -869,12 +873,18 @@ inclusive_scan(Group g, V x, BinaryOperation binary_op, T init) {
 
 template <typename Group, typename InPtr, typename OutPtr,
           class BinaryOperation, typename T>
-EnableIfIsPointer<InPtr, OutPtr>
+detail::enable_if_t<
+    (detail::is_generic_group<Group>::value &&
+     detail::is_pointer<InPtr>::value && detail::is_pointer<OutPtr>::value &&
+     detail::is_arithmetic<
+         typename detail::remove_pointer<InPtr>::type>::value &&
+     detail::is_arithmetic<T>::value &&
+     detail::is_native_op<typename detail::remove_pointer<InPtr>::type,
+                          BinaryOperation>::value &&
+     detail::is_native_op<T, BinaryOperation>::value),
+    OutPtr>
 inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
                BinaryOperation binary_op, T init) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
   // FIXME: Do not special-case for half precision
   static_assert(
       std::is_same<decltype(binary_op(init, *first)), T>::value ||
@@ -914,9 +924,16 @@ inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
 
 template <typename Group, typename InPtr, typename OutPtr,
           class BinaryOperation>
-EnableIfIsPointer<InPtr, OutPtr> inclusive_scan(Group g, InPtr first,
-                                                InPtr last, OutPtr result,
-                                                BinaryOperation binary_op) {
+detail::enable_if_t<
+    (detail::is_generic_group<Group>::value &&
+     detail::is_pointer<InPtr>::value && detail::is_pointer<OutPtr>::value &&
+     detail::is_arithmetic<
+         typename detail::remove_pointer<InPtr>::type>::value &&
+     detail::is_native_op<typename detail::remove_pointer<InPtr>::type,
+                          BinaryOperation>::value),
+    OutPtr>
+inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+               BinaryOperation binary_op) {
   // FIXME: Do not special-case for half precision
   static_assert(
       std::is_same<decltype(binary_op(*first, *first)),

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -313,11 +313,11 @@ none_of(Group g, Ptr first, Ptr last, Predicate pred) {
 }
 
 template <typename Group, typename T>
-EnableIfIsTriviallyCopyable<T> broadcast(Group, T x,
-                                         typename Group::id_type local_id) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     std::is_trivially_copyable<T>::value &&
+                     !detail::is_vector_arithmetic<T>::value),
+                    T>
+broadcast(Group, T x, typename Group::id_type local_id) {
 #ifdef __SYCL_DEVICE_ONLY__
   return sycl::detail::spirv::GroupBroadcast<Group>(x, local_id);
 #else
@@ -329,11 +329,10 @@ EnableIfIsTriviallyCopyable<T> broadcast(Group, T x,
 }
 
 template <typename Group, typename T>
-EnableIfIsVectorArithmetic<T> broadcast(Group g, T x,
-                                        typename Group::id_type local_id) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_vector_arithmetic<T>::value),
+                    T>
+broadcast(Group g, T x, typename Group::id_type local_id) {
 #ifdef __SYCL_DEVICE_ONLY__
   T result;
   for (int s = 0; s < x.get_size(); ++s) {
@@ -350,11 +349,11 @@ EnableIfIsVectorArithmetic<T> broadcast(Group g, T x,
 }
 
 template <typename Group, typename T>
-EnableIfIsTriviallyCopyable<T>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     std::is_trivially_copyable<T>::value &&
+                     !detail::is_vector_arithmetic<T>::value),
+                    T>
 broadcast(Group g, T x, typename Group::linear_id_type linear_local_id) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
 #ifdef __SYCL_DEVICE_ONLY__
   return broadcast(
       g, x,
@@ -369,11 +368,10 @@ broadcast(Group g, T x, typename Group::linear_id_type linear_local_id) {
 }
 
 template <typename Group, typename T>
-EnableIfIsVectorArithmetic<T>
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_vector_arithmetic<T>::value),
+                    T>
 broadcast(Group g, T x, typename Group::linear_id_type linear_local_id) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
 #ifdef __SYCL_DEVICE_ONLY__
   T result;
   for (int s = 0; s < x.get_size(); ++s) {
@@ -390,10 +388,11 @@ broadcast(Group g, T x, typename Group::linear_id_type linear_local_id) {
 }
 
 template <typename Group, typename T>
-EnableIfIsTriviallyCopyable<T> broadcast(Group g, T x) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     std::is_trivially_copyable<T>::value &&
+                     !detail::is_vector_arithmetic<T>::value),
+                    T>
+broadcast(Group g, T x) {
 #ifdef __SYCL_DEVICE_ONLY__
   return broadcast(g, x, 0);
 #else
@@ -405,10 +404,10 @@ EnableIfIsTriviallyCopyable<T> broadcast(Group g, T x) {
 }
 
 template <typename Group, typename T>
-EnableIfIsVectorArithmetic<T> broadcast(Group g, T x) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+detail::enable_if_t<(detail::is_generic_group<Group>::value &&
+                     detail::is_vector_arithmetic<T>::value),
+                    T>
+broadcast(Group g, T x) {
 #ifdef __SYCL_DEVICE_ONLY__
   T result;
   for (int s = 0; s < x.get_size(); ++s) {

--- a/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/group_algorithm.hpp
@@ -946,10 +946,9 @@ inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
                                                BinaryOperation>::value);
 }
 
-template <typename Group> bool leader(Group g) {
-  static_assert(sycl::detail::is_generic_group<Group>::value,
-                "Group algorithms only support the sycl::group and "
-                "ONEAPI::sub_group class.");
+template <typename Group>
+detail::enable_if_t<detail::is_generic_group<Group>::value, bool>
+leader(Group g) {
 #ifdef __SYCL_DEVICE_ONLY__
   typename Group::linear_id_type linear_id =
       sycl::detail::get_local_linear_id(g);


### PR DESCRIPTION
is_native_function_object proved too difficult to implement and use in a
practical way.  Replacing it with constraints makes the behavior of group
algorithms more predictable and enables users to detect which type combinations
are supported at compile-time.

Replacing several usages of static_assert with constraints will also be useful in
ensuring that group algorithms are not considered during overload resolution
if the first argument is an execution policy rather than a group or sub_group.

While updating the traits to use is_pointer I realized that several functions
would only support multi_ptr because they used Ptr::element_type.  This is now
fixed, by using remove_pointer instead.

Signed-off-by: John Pennycook <john.pennycook@intel.com>