### PR TITLE
[Driver][SYCL] Add defaultlib directive for sycl lib

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6816,6 +6816,16 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
     // users want.  The /Za flag to cl.exe turns this off, but it's not
     // implemented in clang.
     CmdArgs.push_back("--dependent-lib=oldnames");
+
+    // Add SYCL dependent library
+    if (Args.hasArg(options::OPT_fsycl) &&
+        !Args.hasArg(options::OPT_nolibsycl)) {
+      if (RTOptionID == options::OPT__SLASH_MDd ||
+          RTOptionID == options::OPT__SLASH_MTd)
+        CmdArgs.push_back("--dependent-lib=sycld");
+      else
+        CmdArgs.push_back("--dependent-lib=sycl");
+    }
   }
 
   if (Arg *ShowIncludes =

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -373,8 +373,8 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       !C.getDriver().IsCLMode())
     CmdArgs.push_back("-defaultlib:libcmt");
 
-  if (!Args.hasArg(options::OPT_nostdlib) && Args.hasArg(options::OPT_fsycl) &&
-      !Args.hasArg(options::OPT_nolibsycl)) {
+  if (!C.getDriver().IsCLMode() && !Args.hasArg(options::OPT_nostdlib) &&
+      Args.hasArg(options::OPT_fsycl) && !Args.hasArg(options::OPT_nolibsycl)) {
     if (Args.hasArg(options::OPT__SLASH_MDd) ||
         Args.hasArg(options::OPT__SLASH_MTd))
       CmdArgs.push_back("-defaultlib:sycld.lib");

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -577,21 +577,23 @@
 
 /// Check for default linking of sycl.lib with -fsycl usage
 // RUN: %clang -fsycl -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL %s
-// RUN: %clang_cl -fsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL %s
-// CHECK-LINK-SYCL: "{{.*}}link{{(.exe)?}}"
+// RUN: %clang_cl -fsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-CL %s
+// CHECK-LINK-SYCL-CL: "--dependent-lib=sycl"
+// CHECK-LINK-SYCL-CL-NOT: "-defaultlib:sycl.lib"
 // CHECK-LINK-SYCL: "-defaultlib:sycl.lib"
 
 /// Check no SYCL runtime is linked with -nolibsycl
 // RUN: %clang -fsycl -nolibsycl -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOLIBSYCL %s
 // RUN: %clang_cl -fsycl -nolibsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOLIBSYCL %s
+// CHECK-LINK-NOLIBSYCL-NOT: "--dependent-lib=sycl"
 // CHECK-LINK-NOLIBSYCL: "{{.*}}link{{(.exe)?}}"
 // CHECK-LINK-NOLIBSYCL-NOT: "-defaultlib:sycl.lib"
 
 /// Check sycld.lib is chosen with /MDd and /MTd
 // RUN:  %clang_cl -fsycl /MDd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
 // RUN:  %clang_cl -fsycl /MTd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
-// CHECK-LINK-SYCL-DEBUG: "{{.*}}link{{(.exe)?}}"
-// CHECK-LINK-SYCL-DEBUG: "-defaultlib:sycld.lib"
+// CHECK-LINK-SYCL-DEBUG: "--dependent-lib=sycld"
+// CHECK-LINK-SYCL-DEBUG-NOT: "-defaultlib:sycld.lib"
 
 /// Check "-spirv-allow-unknown-intrinsics" option is emitted for llvm-spirv tool for esimd mode
 // RUN: %clangxx %s -fsycl -fsycl-explicit-simd -### 2>&1 | FileCheck %s --check-prefix=CHK-FSYCL-ESIMD


### PR DESCRIPTION
When compiling for Windows, add the sycl dependent library to the
object.  If a person were to use /MTd to compile and not use /MTd
to link, the default sycl lib would be passed to the linker instead
of sycld.