### PR TITLE
[SYCL][L0]: Check Queue refcnt prior to using L0 members

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3018,16 +3018,18 @@ pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
       // Event has been signaled: If the fence for the associated command list
       // is signalled, then reset the fence and command list and add them to the
       // available list for reuse in PI calls.
-      EventList[I]->Queue->ZeCommandListFenceMapMutex.lock();
-      ze_result_t ZeResult = ZE_CALL_NOCHECK(zeFenceQueryStatus(
-          EventList[I]
-              ->Queue->ZeCommandListFenceMap[EventList[I]->ZeCommandList]));
-      if (ZeResult == ZE_RESULT_SUCCESS) {
-        EventList[I]->Queue->resetCommandListFenceEntry(
-            EventList[I]->ZeCommandList, true);
-        EventList[I]->ZeCommandList = nullptr;
+      if (EventList[I]->Queue->RefCount > 0) {
+        EventList[I]->Queue->ZeCommandListFenceMapMutex.lock();
+        ze_result_t ZeResult = ZE_CALL_NOCHECK(zeFenceQueryStatus(
+            EventList[I]
+                ->Queue->ZeCommandListFenceMap[EventList[I]->ZeCommandList]));
+        if (ZeResult == ZE_RESULT_SUCCESS) {
+          EventList[I]->Queue->resetCommandListFenceEntry(
+              EventList[I]->ZeCommandList, true);
+          EventList[I]->ZeCommandList = nullptr;
+        }
+        EventList[I]->Queue->ZeCommandListFenceMapMutex.unlock();
       }
-      EventList[I]->Queue->ZeCommandListFenceMapMutex.unlock();
     }
   }
   return PI_SUCCESS;
@@ -3059,7 +3061,7 @@ pi_result piEventRelease(pi_event Event) {
       // If the fence associated with this command list has signalled, then
       // Reset the Command List Used in this event and put it back on the
       // available list.
-      if (Event->Queue->ZeCommandQueue) {
+      if (Event->Queue->RefCount > 0) {
         Event->Queue->ZeCommandListFenceMapMutex.lock();
         ze_result_t ZeResult = ZE_CALL_NOCHECK(zeFenceQueryStatus(
             Event->Queue->ZeCommandListFenceMap[Event->ZeCommandList]));


### PR DESCRIPTION
- If the Queue was cleared of L0 data structures ie Refcnt == 0
  then all L0 data structures in the pi_queue can no longer be used.
- Prevent EventWait and EventRelease from using invalid data structures
  if the Queue has already been cleared.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>