### PR TITLE
[SYCL] Implement no-decomposition for kernel types that don't need it.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1198,6 +1198,14 @@ def SYCLIntelBufferLocation : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def SYCLRequiresDecomposition : InheritableAttr {
+  // No spellings, as this is for internal use.
+  let Spellings = [];
+  let Subjects = SubjectList<[Named]>;
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let Documentation = [Undocumented];
+}
+
 def SYCLIntelKernelArgsRestrict : InheritableAttr {
   let Spellings = [ CXX11<"intel", "kernel_args_restrict"> ];
   let Subjects = SubjectList<[Function], ErrorDiag>;


### PR DESCRIPTION
Kernel arguments don't need to be decomposed unless they contain a
pointer or a special type, so we don't want to decompose structs/arrays
containing these.  This patch accomplishes that.

First, we add a new attribute without a spelling that is added during the
'checking' stage, that the later vistiors can then check to see if
decomposition is necessary.

Next, we add a new checker to run during the checking stage that applies
the attribute based on logic. Basically, a container doesn't need to be
decomposed if all of its 'children' are acceptable, so we simply hold a
stack of the containers to tell which need to be decomposed.  This, of
course, works recursively.

Finally, we add some new calls to the visitor that handle the case of a
'simple array' and a 'simple struct', which are ones that don't require
decomposition.