### PR TITLE
[Driver][SYCL] Make /MD the default for -fsycl

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -132,6 +132,7 @@ def err_drv_invalid_Xsycl_frontend_with_args : Error<
   "invalid -Xsycl-target-frontend argument: '%0', options requiring arguments are unsupported">;
 def err_drv_bad_fpga_device_count : Error<
   "More than one FPGA specific device binary found in input objects">;
+def err_drv_unsupported_opt_dpcpp : Error<"option '%0' unsupported with DPC++">;
 def err_drv_argument_only_allowed_with : Error<
   "invalid argument '%0' only allowed with '%1'">;
 def err_drv_argument_not_allowed_with : Error<

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6769,7 +6769,8 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
                            bool *EmitCodeView) const {
   unsigned RTOptionID = options::OPT__SLASH_MT;
   bool isNVPTX = getToolChain().getTriple().isNVPTX();
-  bool isSYCL = Args.hasArg(options::OPT_fsycl) ||
+  bool isSYCL =
+      Args.hasArg(options::OPT_fsycl) ||
       getToolChain().getTriple().getEnvironment() == llvm::Triple::SYCLDevice;
   // For SYCL Windows, /MD is the default.
   if (isSYCL)

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6769,14 +6769,25 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
                            bool *EmitCodeView) const {
   unsigned RTOptionID = options::OPT__SLASH_MT;
   bool isNVPTX = getToolChain().getTriple().isNVPTX();
+  bool isSYCL = Args.hasArg(options::OPT_fsycl) ||
+      getToolChain().getTriple().getEnvironment() == llvm::Triple::SYCLDevice;
+  // For SYCL Windows, /MD is the default.
+  if (isSYCL)
+    RTOptionID = options::OPT__SLASH_MD;
 
   if (Args.hasArg(options::OPT__SLASH_LDd))
-    // The /LDd option implies /MTd. The dependent lib part can be overridden,
-    // but defining _DEBUG is sticky.
-    RTOptionID = options::OPT__SLASH_MTd;
+    // The /LDd option implies /MTd (/MDd for SYCL). The dependent lib part
+    // can be overridden but defining _DEBUG is sticky.
+    RTOptionID = isSYCL ? options::OPT__SLASH_MDd : options::OPT__SLASH_MTd;
 
-  if (Arg *A = Args.getLastArg(options::OPT__SLASH_M_Group))
+  if (Arg *A = Args.getLastArg(options::OPT__SLASH_M_Group)) {
     RTOptionID = A->getOption().getID();
+    if (isSYCL && (RTOptionID == options::OPT__SLASH_MT ||
+                   RTOptionID == options::OPT__SLASH_MTd))
+      // Use of /MT or /MTd is not supported for SYCL.
+      getToolChain().getDriver().Diag(diag::err_drv_unsupported_opt_dpcpp)
+          << A->getOption().getName();
+  }
 
   StringRef FlagForCRT;
   switch (RTOptionID) {

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -375,8 +375,7 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (!C.getDriver().IsCLMode() && !Args.hasArg(options::OPT_nostdlib) &&
       Args.hasArg(options::OPT_fsycl) && !Args.hasArg(options::OPT_nolibsycl)) {
-    if (Args.hasArg(options::OPT__SLASH_MDd) ||
-        Args.hasArg(options::OPT__SLASH_MTd))
+    if (Args.hasArg(options::OPT__SLASH_MDd))
       CmdArgs.push_back("-defaultlib:sycld.lib");
     else
       CmdArgs.push_back("-defaultlib:sycl.lib");

--- a/clang/test/Driver/sycl-MD-default.cpp
+++ b/clang/test/Driver/sycl-MD-default.cpp
@@ -1,0 +1,16 @@
+// REQUIRES: clang-driver
+
+// RUN: %clang_cl -### -fsycl -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
+// RUN: %clang_cl -### -MD -fsycl -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
+// RUN: %clang_cl -### -MDd -fsycl -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
+// CHK-DEFAULT: "-D_MT" "-D_DLL"
+// CHK-DEFAULT: "--dependent-lib=msvcrt{{d*}}"
+
+// RUN: %clang_cl -### -MT -fsycl -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-ERROR %s
+// RUN: %clang_cl -### -MTd -fsycl -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-ERROR %s
+// CHK-ERROR: option 'MT{{d*}}' unsupported with DPC++

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -589,9 +589,8 @@
 // CHECK-LINK-NOLIBSYCL: "{{.*}}link{{(.exe)?}}"
 // CHECK-LINK-NOLIBSYCL-NOT: "-defaultlib:sycl.lib"
 
-/// Check sycld.lib is chosen with /MDd and /MTd
+/// Check sycld.lib is chosen with /MDd
 // RUN:  %clang_cl -fsycl /MDd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
-// RUN:  %clang_cl -fsycl /MTd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
 // CHECK-LINK-SYCL-DEBUG: "--dependent-lib=sycld"
 // CHECK-LINK-SYCL-DEBUG-NOT: "-defaultlib:sycld.lib"
 

--- a/sycl/test/regression/msvc_crt.cpp
+++ b/sycl/test/regression/msvc_crt.cpp
@@ -2,8 +2,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t1.exe
 // RUN: %clang_cl -fsycl /MDd -o %t2.exe %s
 // RUN: %CPU_RUN_PLACEHOLDER %t2.exe
-// RUN: %clang_cl -fsycl /MT -o %t3.exe %s
-// RUN: %CPU_RUN_PLACEHOLDER %t3.exe
 // REQUIRES: system-windows
 //==-------------- msvc_crt.cpp - SYCL MSVC CRT test -----------------------==//
 //


### PR DESCRIPTION
When using -fsycl on Windows, make /MD the default behavior.  Any usage
of /MT will not be allowed and the driver will error upon usage.