### PR TITLE
[SYCL] Fix LIT regression after 9dd18ca8

### DIFF
--- a/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
@@ -11,7 +11,7 @@
 // RUN: lib -out:%t.lib %t1_bundle.obj
 
 /// Check phases with static lib
-// RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fintelfpga %t.lib -ccc-print-phases 2>&1 \
+// RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fno-sycl-device-lib=all -fintelfpga %t.lib -ccc-print-phases 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_PHASES %s
 // CHECK_PHASES: 0: input, "[[INPUT:.+\.lib]]", object, (host-sycl)
 // CHECK_PHASES: 1: linker, {0}, image, (host-sycl)
@@ -27,7 +27,7 @@
 // CHECK_PHASES: 11: offload, "host-sycl (x86_64-pc-windows-msvc)" {1}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {10}, image
 
 /// Check for unbundle and use of deps in static lib
-// RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fintelfpga %t.lib -### 2>&1 \
+// RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fno-sycl-device-lib=all -fintelfpga %t.lib -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_UNBUNDLE %s
 // CHECK_UNBUNDLE: clang-offload-bundler" "-type=aoo" "-targets=sycl-fpga_dep" "-inputs={{.*}}" "-outputs=[[DEPFILES:.+\.txt]]" "-unbundle"
 // CHECK_UNBUNDLE: aoc{{.*}} "-dep-files=@[[DEPFILES]]"

--- a/clang/test/Driver/sycl-intelfpga-static-lib.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib.cpp
@@ -10,7 +10,7 @@
 // RUN: llvm-ar cr %t.a %t1_bundle.o
 
 /// Check phases with static lib
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t.a -ccc-print-phases 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -fintelfpga %t.a -ccc-print-phases 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_PHASES %s
 // CHECK_PHASES: 0: input, "[[INPUT:.+\.a]]", object, (host-sycl)
 // CHECK_PHASES: 1: linker, {0}, image, (host-sycl)
@@ -27,7 +27,7 @@
 // CHECK_PHASES: 12: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {11}, image
 
 /// Check for unbundle and use of deps in static lib
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %t.a -### 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -fintelfpga %t.a -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_UNBUNDLE %s
 // CHECK_UNBUNDLE: clang-offload-bundler" "-type=aoo" "-targets=sycl-fpga_dep" "-inputs={{.*}}" "-outputs=[[DEPFILES:.+\.txt]]" "-unbundle"
 // CHECK_UNBUNDLE: aoc{{.*}} "-dep-files=@[[DEPFILES]]"


### PR DESCRIPTION
The test introduced by [f253851f7] was regressed by [9dd18ca8].

The [9dd18ca8] was tested before [f253851f7] submitted to sycl branch. So the regression was not detected in [pre-checkin](http://ci.llvm.intel.com:8010/#builders/2/builds/5057) testing but detected in [post-checkin](https://github.com/intel/llvm/runs/1116520039?check_suite_focus=true) . 