### PR TITLE
[SYCL] Fixed bugs regarding Platform Caching

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -644,7 +644,7 @@ static pi_result getOrCreatePlatform(ze_driver_handle_t ZeDriver,
     pi_uint32 CommandListCacheSizeValue;
     try {
       CommandListCacheSizeValue =
-          CommandListCacheSize ? std::atoi(CommandListCacheSize) : 20000;
+          CommandListCacheSize ? std::stoi(CommandListCacheSize) : 20000;
     } catch (std::exception const &) {
       zePrint("SYCL_PI_LEVEL0_MAX_COMMAND_LIST_CACHE: invalid value provided, "
               "default set.\n");
@@ -668,7 +668,7 @@ static pi_result getOrCreatePlatform(ze_driver_handle_t ZeDriver,
     static auto PiPlatformsCacheMutex = new std::mutex;
 
     std::lock_guard<std::mutex> Lock(*PiPlatformsCacheMutex);
-    for (const pi_platform CachedPlatform : *PiPlatformsCache) {
+    for (const pi_platform& CachedPlatform : *PiPlatformsCache) {
       if (CachedPlatform->ZeDriver == ZeDriver) {
         Platform[0] = CachedPlatform;
         return PI_SUCCESS;
@@ -775,10 +775,9 @@ pi_result piextPlatformCreateWithNativeHandle(pi_native_handle NativeHandle,
   assert(Platform);
 
   // Create PI platform from the given Level Zero driver handle or retrieve it
-  // from the cache..
+  // from the cache.
   auto ZeDriver = pi_cast<ze_driver_handle_t>(NativeHandle);
-  pi_result Res = getOrCreatePlatform(ZeDriver, Platform);
-  return Res;
+  return getOrCreatePlatform(ZeDriver, Platform);
 }
 
 // Get the cahched PI device created for the L0 device handle.

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -668,7 +668,7 @@ static pi_result getOrCreatePlatform(ze_driver_handle_t ZeDriver,
     static auto PiPlatformsCacheMutex = new std::mutex;
 
     std::lock_guard<std::mutex> Lock(*PiPlatformsCacheMutex);
-    for (const pi_platform& CachedPlatform : *PiPlatformsCache) {
+    for (const pi_platform &CachedPlatform : *PiPlatformsCache) {
       if (CachedPlatform->ZeDriver == ZeDriver) {
         Platform[0] = CachedPlatform;
         return PI_SUCCESS;


### PR DESCRIPTION
Added new Platforms that have been created and initialized to the
PiPlatformCache.

Created a new function, piCachePlatforms, so that the cached Platforms could be
shared accross both piPlatformsGet and piextPlatformCreateWithNativeHandle.

Handle platform initialization in piCachePlatforms, so that platforms created
with a native handle would also be initialized (Before initialization was not
occuring for platforms created in piextPlatformCreateWithNativeHandle).