### PR TITLE
[SYCL] Disable dead store elimination in early optimizations

### DIFF
--- a/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -472,7 +472,8 @@ void PassManagerBuilder::addFunctionSimplificationPasses(
   if (OptLevel > 1) {
     MPM.add(createJumpThreadingPass());         // Thread jumps
     MPM.add(createCorrelatedValuePropagationPass());
-    MPM.add(createDeadStoreEliminationPass());  // Delete dead stores
+    if (!SYCLOptimizationMode)
+      MPM.add(createDeadStoreEliminationPass()); // Delete dead stores
     MPM.add(createLICMPass(LicmMssaOptCap, LicmMssaNoAccForPromotionCap));
   }
 


### PR DESCRIPTION
Dead store elimination in early optimizations causes fail on GPU target
for some cases.