### PR TITLE
[SYCL] Fix hang in conditional variable pattern in program manager

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -196,7 +196,7 @@ getOrBuild(KernelProgramCache &KPCache, KeyT &&CacheKey, AcquireFT &&Acquire,
 #endif
 
     {
-      // Even if shared variable is atomic,it must be modified under the mutex
+      // Even if shared variable is atomic, it must be modified under the mutex
       // in order to correctly publish the modification to the waiting thread
       std::lock_guard<std::mutex> Lock(BuildResult->MBuildResultMutex);
       BuildResult->State.store(BS_Done);

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -195,7 +195,12 @@ getOrBuild(KernelProgramCache &KPCache, KeyT &&CacheKey, AcquireFT &&Acquire,
     BuildResult->Ptr.store(Desired);
 #endif
 
-    BuildResult->State.store(BS_Done);
+    {
+      // Even if shared variable is atomic,it must be modified under the mutex
+      // in order to correctly publish the modification to the waiting thread
+      std::lock_guard<std::mutex> Lock(BuildResult->MBuildResultMutex);
+      BuildResult->State.store(BS_Done);
+    }
 
     KPCache.notifyAllBuild(*BuildResult);
 
@@ -204,13 +209,19 @@ getOrBuild(KernelProgramCache &KPCache, KeyT &&CacheKey, AcquireFT &&Acquire,
     BuildResult->Error.Msg = Ex.what();
     BuildResult->Error.Code = Ex.get_cl_code();
 
-    BuildResult->State.store(BS_Failed);
+    {
+      std::lock_guard<std::mutex> Lock(BuildResult->MBuildResultMutex);
+      BuildResult->State.store(BS_Failed);
+    }
 
     KPCache.notifyAllBuild(*BuildResult);
 
     std::rethrow_exception(std::current_exception());
   } catch (...) {
-    BuildResult->State.store(BS_Failed);
+    {
+      std::lock_guard<std::mutex> Lock(BuildResult->MBuildResultMutex);
+      BuildResult->State.store(BS_Failed);
+    }
 
     KPCache.notifyAllBuild(*BuildResult);
 


### PR DESCRIPTION
The issue rarely occurs sporadically when we try to get a kernel instance by multiple threads:
`auto kernel = prog.get_kernel<some_kernel>();`

When debugging, all threads have finished except two threads, the main thread which is waiting for the last one to complete.
This last thread sleeps on condition_variable on the line:
`Cache.waitUntilBuilt() in sycl\source\detail\program_manager\program_manager.cpp`
It looks like the build has already been done, all other threads have already done their work and finished,  except for one thread that is waiting for notification in order to wake up.

Checked the condition variables pattern and found that `BuildResult->State` must be modified under the mutex.
Quote from doc:
> "Even if the shared variable is atomic, it must be modified under the mutex in order to correctly publish the modification to the waiting thread."



Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>