### PR TITLE
[Driver][SYCL] Adjust /MD settings for SYCL device compilations

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6797,8 +6797,9 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
 
   if (Arg *A = Args.getLastArg(options::OPT__SLASH_M_Group)) {
     RTOptionID = A->getOption().getID();
-    if (isSYCL && !isSYCLDevice && (RTOptionID == options::OPT__SLASH_MT ||
-                                    RTOptionID == options::OPT__SLASH_MTd))
+    if (isSYCL && !isSYCLDevice &&
+        (RTOptionID == options::OPT__SLASH_MT ||
+         RTOptionID == options::OPT__SLASH_MTd))
       // Use of /MT or /MTd is not supported for SYCL.
       getToolChain().getDriver().Diag(diag::err_drv_unsupported_opt_dpcpp)
           << A->getOption().getName();

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -83,8 +83,8 @@ private:
                                  llvm::opt::ArgStringList &cmdArgs,
                                  RewriteKind rewrite) const;
 
-  void AddClangCLArgs(const llvm::opt::ArgList &Args, types::ID InputType,
-                      llvm::opt::ArgStringList &CmdArgs,
+  void AddClangCLArgs(const JobAction &JA, const llvm::opt::ArgList &Args,
+                      types::ID InputType, llvm::opt::ArgStringList &CmdArgs,
                       codegenoptions::DebugInfoKind *DebugInfoKind,
                       bool *EmitCodeView) const;
 

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -83,8 +83,8 @@ private:
                                  llvm::opt::ArgStringList &cmdArgs,
                                  RewriteKind rewrite) const;
 
-  void AddClangCLArgs(const JobAction &JA, const llvm::opt::ArgList &Args,
-                      types::ID InputType, llvm::opt::ArgStringList &CmdArgs,
+  void AddClangCLArgs(const llvm::opt::ArgList &Args, types::ID InputType,
+                      llvm::opt::ArgStringList &CmdArgs,
                       codegenoptions::DebugInfoKind *DebugInfoKind,
                       bool *EmitCodeView) const;
 

--- a/clang/test/Driver/sycl-MD-default.cpp
+++ b/clang/test/Driver/sycl-MD-default.cpp
@@ -11,8 +11,7 @@
 // RUN: %clang_cl -### -MDd -fsycl -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
 // CHK-DEFAULT-NOT: "-fsycl-is-device" {{.*}} "-D_MT" "-D_DLL"
-// CHK-DEFAULT: "-D_MT" "-D_DLL"
-// CHK-DEFAULT: "--dependent-lib=msvcrt{{d*}}"
+// CHK-DEFAULT: "-D_MT" "-D_DLL" "--dependent-lib=msvcrt{{d*}}" {{.*}} "-fsycl-is-host"
 
 // RUN: %clang_cl -### -MT -fsycl -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-ERROR %s

--- a/clang/test/Driver/sycl-MD-default.cpp
+++ b/clang/test/Driver/sycl-MD-default.cpp
@@ -4,14 +4,17 @@
 // RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
 // RUN: %clangxx -### -fsycl -c -target x86_64-unknown-windows-msvc %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
-// RUN: %clang_cl -### -fsycl -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
-// RUN: %clang_cl -### -MD -fsycl -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
-// RUN: %clang_cl -### -MDd -fsycl -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
 // CHK-DEFAULT-NOT: "-fsycl-is-device" {{.*}} "-D_MT" "-D_DLL"
-// CHK-DEFAULT: "-D_MT" "-D_DLL" "--dependent-lib=msvcrt{{d*}}" {{.*}} "-fsycl-is-host"
+// CHK-DEFAULT: "-fsycl-is-host" "-D_MT" "-D_DLL" "--dependent-lib=msvcrt{{d*}}" {{.*}}
+
+// RUN: %clang_cl -### -fsycl -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DEFAULT-CL %s
+// RUN: %clang_cl -### -MD -fsycl -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DEFAULT-CL %s
+// RUN: %clang_cl -### -MDd -fsycl -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DEFAULT-CL %s
+// CHK-DEFAULT-CL-NOT: "-fsycl-is-device" {{.*}} "-D_MT" "-D_DLL"
+// CHK-DEFAULT-CL: "-D_MT" "-D_DLL" "--dependent-lib=msvcrt{{d*}}" {{.*}} "-fsycl-is-host"
 
 // RUN: %clang_cl -### -MT -fsycl -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-ERROR %s

--- a/clang/test/Driver/sycl-MD-default.cpp
+++ b/clang/test/Driver/sycl-MD-default.cpp
@@ -10,6 +10,7 @@
 // RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
 // RUN: %clang_cl -### -MDd -fsycl -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
+// CHK-DEFAULT-NOT: "-fsycl-is-device" {{.*}} "-D_MT" "-D_DLL"
 // CHK-DEFAULT: "-D_MT" "-D_DLL"
 // CHK-DEFAULT: "--dependent-lib=msvcrt{{d*}}"
 


### PR DESCRIPTION
When setting /MD (by default) we do not want to pass the _MT and _DLL
predefines to the device compilations, only the host for clang-cl