### PR TITLE
[SYCL] Emit a warning message for legacy env vars

### DIFF
--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -184,7 +184,7 @@ public:
       static device_filter_list DFL{ValStr};
       FilterList = &DFL;
     }
-    
+
     // TODO: remove the following code when we remove the support for legacy
     // env vars.
     // Emit the deprecation warning message if SYCL_BE or SYCL_DEVICE_TYPE is

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -184,6 +184,19 @@ public:
       static device_filter_list DFL{ValStr};
       FilterList = &DFL;
     }
+    
+    // TODO: remove the following code when we remove the support for legacy
+    // env vars.
+    // Emit the deprecation warning message if SYCL_BE or SYCL_DEVICE_TYPE is
+    // set.
+    if (SYCLConfig<SYCL_BE>::get() || getenv("SYCL_DEVICE_TYPE")) {
+      std::cerr << "\nWARNING: The legacy environment variables SYCL_BE and "
+                   "SYCL_DEVICE_TYPE are deprecated. Please use "
+                   "SYCL_DEVICE_FILTER instead. For details, please refer to "
+                   "https://github.com/intel/llvm/blob/sycl/sycl/doc/"
+                   "EnvironmentVariables.md\n\n";
+    }
+
     // As mentioned above, configuration parameters are processed only once.
     // If multiple threads are checking this env var at the same time,
     // they will end up setting the configration to the same value.

--- a/sycl/source/detail/filter_selector_impl.cpp
+++ b/sycl/source/detail/filter_selector_impl.cpp
@@ -131,11 +131,19 @@ int filter_selector_impl::operator()(const device &Dev) const {
       } else {
         BE = sycl::detail::getSyclObjImpl(Dev)->getPlugin().getBackend();
       }
-      BackendOK = (BE == Filter.Backend);
+      // Backend is okay if the filter BE is set 'all'.
+      if (Filter.Backend == backend::all)
+	BackendOK = true;
+      else
+	BackendOK = (BE == Filter.Backend);
     }
     if (Filter.HasDeviceType) {
       info::device_type DT = Dev.get_info<info::device::device_type>();
-      DeviceTypeOK = (DT == Filter.DeviceType);
+      // DeviceType is okay if the filter is set 'all'.
+      if (Filter.DeviceType == info::device_type::all)
+	DeviceTypeOK = true;
+      else
+	DeviceTypeOK = (DT == Filter.DeviceType);
     }
     if (Filter.HasDeviceNum) {
       // Only check device number if we're good on the previous matches

--- a/sycl/source/detail/filter_selector_impl.cpp
+++ b/sycl/source/detail/filter_selector_impl.cpp
@@ -133,17 +133,17 @@ int filter_selector_impl::operator()(const device &Dev) const {
       }
       // Backend is okay if the filter BE is set 'all'.
       if (Filter.Backend == backend::all)
-	BackendOK = true;
+        BackendOK = true;
       else
-	BackendOK = (BE == Filter.Backend);
+        BackendOK = (BE == Filter.Backend);
     }
     if (Filter.HasDeviceType) {
       info::device_type DT = Dev.get_info<info::device::device_type>();
       // DeviceType is okay if the filter is set 'all'.
       if (Filter.DeviceType == info::device_type::all)
-	DeviceTypeOK = true;
+        DeviceTypeOK = true;
       else
-	DeviceTypeOK = (DT == Filter.DeviceType);
+        DeviceTypeOK = (DT == Filter.DeviceType);
     }
     if (Filter.HasDeviceNum) {
       // Only check device number if we're good on the previous matches

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -292,17 +292,6 @@ const vector_class<plugin> &initialize() {
     // time when "Plugins" could be deleted.
     Plugins = new vector_class<plugin>;
     initializePlugins(Plugins);
-    // TODO: remove the following code when we remove the support for legacy
-    // env vars.
-    // Emit the deprecation warning message if SYCL_BE or SYCL_DEVICE_TYPE is
-    // set.
-    if (SYCLConfig<SYCL_BE>::get() || getenv("SYCL_DEVICE_TYPE")) {
-      std::cerr << "\nWARNING: The legacy environment variables SYCL_BE and "
-                   "SYCL_DEVICE_TYPE are deprecated. Please use "
-                   "SYCL_DEVICE_FILTER instead. For details, please refer to "
-                   "https://github.com/intel/llvm/blob/sycl/sycl/doc/"
-                   "EnvironmentVariables.md\n\n";
-    }
   });
 
   return *Plugins;

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -292,6 +292,17 @@ const vector_class<plugin> &initialize() {
     // time when "Plugins" could be deleted.
     Plugins = new vector_class<plugin>;
     initializePlugins(Plugins);
+    // TODO: remove the following code when we remove the support for legacy
+    // env vars.
+    // Emit the deprecation warning message if SYCL_BE or SYCL_DEVICE_TYPE is
+    // set.
+    if (SYCLConfig<SYCL_BE>::get() || getenv("SYCL_DEVICE_TYPE")) {
+      std::cerr << "\nWARNING: The legacy environment variables SYCL_BE and "
+                   "SYCL_DEVICE_TYPE are deprecated. Please use "
+                   "SYCL_DEVICE_FILTER instead. For details, please refer to "
+                   "https://github.com/intel/llvm/blob/sycl/sycl/doc/"
+                   "EnvironmentVariables.md\n\n";
+    }
   });
 
   return *Plugins;

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -154,6 +154,12 @@ int default_selector::operator()(const device &dev) const {
   if (dev.is_host())
     Score += 100;
 
+  // Since we deprecate SYCL_BE and SYCL_DEVICE_TYPE,
+  // we should not disallow accelerator to be chosen.
+  // But this device type gets the lowest heuristic point.
+  if (dev.is_accelerator())
+    Score += 75;
+
   return Score;
 }
 


### PR DESCRIPTION
We are deprecating legacy env vars SYCL_BE and SYCL_DEVICE_TYPE.
This PR is intended to inform users about this change during the grace period.

Signed-off-by: Byoungro So <byoungro.so@intel.com>