### PR TITLE
[SYCL] Add template parameter support for num_simd_work_items attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1209,7 +1209,7 @@ def SYCLIntelKernelArgsRestrict : InheritableAttr {
 
 def SYCLIntelNumSimdWorkItems : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","num_simd_work_items">];
-  let Args = [UnsignedArgument<"Number">];
+  let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelNumSimdWorkItemsAttrDocs];
@@ -1300,7 +1300,7 @@ def LoopUnrollHint : InheritableAttr {
 def IntelReqdSubGroupSize: InheritableAttr {
   let Spellings = [GNU<"intel_reqd_sub_group_size">,
                    CXX11<"intel", "reqd_sub_group_size">];
-  let Args = [ExprArgument<"SubGroupSize">];
+  let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[Function, CXXMethod], ErrorDiag>;
   let Documentation = [IntelReqdSubGroupSizeDocs];
   let LangOpts = [OpenCL, SYCLIsDevice, SYCLIsHost];

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12838,8 +12838,7 @@ template <typename AttrType>
 void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
                                              const AttributeCommonInfo &CI,
                                              Expr *E) {
-  if (!E)
-    return;
+  assert (!E);
 
   if (!E->isInstantiationDependent()) {
     Optional<llvm::APSInt> ArgVal = E->getIntegerConstantExpr(getASTContext());

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -9987,8 +9987,8 @@ public:
   void AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
                                 Expr **Exprs, unsigned Size);
   template <typename AttrType>
-  void addIntelSYCLFunctionAttr(Decl *D, const AttributeCommonInfo &CI,
-                                Expr *E);
+  void addIntelSYCLSingleArgFunctionAttr(Decl *D,
+                                         const AttributeCommonInfo &CI, Expr *E);
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,
                       bool IsPackExpansion);
@@ -12835,8 +12835,9 @@ public:
 };
 
 template <typename AttrType>
-void Sema::addIntelSYCLFunctionAttr(Decl *D, const AttributeCommonInfo &Attr,
-                                    Expr *E) {
+void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
+                                             const AttributeCommonInfo &CI,
+                                             Expr *E) {
   if (!E)
     return;
 
@@ -12844,19 +12845,19 @@ void Sema::addIntelSYCLFunctionAttr(Decl *D, const AttributeCommonInfo &Attr,
     Optional<llvm::APSInt> ArgVal = E->getIntegerConstantExpr(getASTContext());
     if (!ArgVal) {
       Diag(E->getExprLoc(), diag::err_attribute_argument_type)
-          << Attr.getAttrName() << AANT_ArgumentIntegerConstant
+          << CI.getAttrName() << AANT_ArgumentIntegerConstant
           << E->getSourceRange();
       return;
     }
     int32_t ArgInt = ArgVal->getSExtValue();
     if (ArgInt <= 0) {
       Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
-          << Attr.getAttrName() << /*positive*/ 0;
+          << CI.getAttrName() << /*positive*/ 0;
       return;
     }
   }
 
-  D->addAttr(::new (Context) AttrType(Context, Attr, E));
+  D->addAttr(::new (Context) AttrType(Context, CI, E));
 }
 
 template <typename AttrType>

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -9986,6 +9986,8 @@ public:
                                        Expr *E);
   void AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
                                 Expr **Exprs, unsigned Size);
+  template <typename AttrType>
+  void addIntelSYCLFunctionAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E);
 
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,
@@ -10040,10 +10042,6 @@ public:
   bool checkNSReturnsRetainedReturnType(SourceLocation loc, QualType type);
   bool checkAllowedSYCLInitializer(VarDecl *VD,
                                    bool CheckValueDependent = false);
-
-  // Adds an intel_reqd_sub_group_size attribute to a particular declaration.
-  void addIntelReqdSubGroupSizeAttr(Decl *D, const AttributeCommonInfo &CI,
-                                    Expr *E);
 
   //===--------------------------------------------------------------------===//
   // C++ Coroutines TS
@@ -12835,6 +12833,32 @@ public:
            (VDecl->getType().getAddressSpace() == LangAS::opencl_private);
   }
 };
+
+template <typename AttrType>
+void Sema::addIntelSYCLFunctionAttr(Decl *D,
+                                    const AttributeCommonInfo &Attr,
+                                    Expr *E) {
+  if (!E)
+    return;
+
+  if (!E->isInstantiationDependent()) {
+    Optional<llvm::APSInt> ArgVal = E->getIntegerConstantExpr(getASTContext());
+    if (!ArgVal) {
+      Diag(E->getExprLoc(), diag::err_attribute_argument_type)
+          << Attr.getAttrName() << AANT_ArgumentIntegerConstant
+          << E->getSourceRange();
+      return;
+    }
+    int32_t ArgInt = ArgVal->getSExtValue();
+    if (ArgInt <= 0) {
+      Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
+          << Attr.getAttrName() << /*positive*/ 0;
+      return;
+    }
+  }
+
+  D->addAttr(::new (Context) AttrType(Context, Attr, E));
+}
 
 template <typename AttrType>
 void Sema::AddOneConstantValueAttr(Decl *D, const AttributeCommonInfo &CI,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -9987,8 +9987,8 @@ public:
   void AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
                                 Expr **Exprs, unsigned Size);
   template <typename AttrType>
-  void addIntelSYCLFunctionAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E);
-
+  void addIntelSYCLFunctionAttr(Decl *D, const AttributeCommonInfo &CI,
+                                Expr *E);
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,
                       bool IsPackExpansion);
@@ -12835,8 +12835,7 @@ public:
 };
 
 template <typename AttrType>
-void Sema::addIntelSYCLFunctionAttr(Decl *D,
-                                    const AttributeCommonInfo &Attr,
+void Sema::addIntelSYCLFunctionAttr(Decl *D, const AttributeCommonInfo &Attr,
                                     Expr *E) {
   if (!E)
     return;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -9987,8 +9987,8 @@ public:
   void AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
                                 Expr **Exprs, unsigned Size);
   template <typename AttrType>
-  void addIntelSYCLSingleArgFunctionAttr(Decl *D,
-                                         const AttributeCommonInfo &CI, Expr *E);
+  void addIntelSYCLSingleArgFunctionAttr(Decl *D, const AttributeCommonInfo &CI,
+                                         Expr *E);
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,
                       bool IsPackExpansion);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12838,7 +12838,7 @@ template <typename AttrType>
 void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
                                              const AttributeCommonInfo &CI,
                                              Expr *E) {
-  assert(!E);
+  assert(E && "Attribute must have an argument.");
 
   if (!E->isInstantiationDependent()) {
     Optional<llvm::APSInt> ArgVal = E->getIntegerConstantExpr(getASTContext());

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12838,7 +12838,7 @@ template <typename AttrType>
 void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
                                              const AttributeCommonInfo &CI,
                                              Expr *E) {
-  assert (!E);
+  assert(!E);
 
   if (!E->isInstantiationDependent()) {
     Optional<llvm::APSInt> ArgVal = E->getIntegerConstantExpr(getASTContext());

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -611,7 +611,7 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
           FD->getAttr<IntelReqdSubGroupSizeAttr>()) {
     llvm::LLVMContext &Context = getLLVMContext();
     Optional<llvm::APSInt> ArgVal =
-        A->getSubGroupSize()->getIntegerConstantExpr(FD->getASTContext());
+        A->getValue()->getIntegerConstantExpr(FD->getASTContext());
     assert(ArgVal.hasValue() && "Not an integer constant expression");
     llvm::Metadata *AttrMDArgs[] = {llvm::ConstantAsMetadata::get(
         Builder.getInt32(ArgVal->getSExtValue()))};
@@ -629,8 +629,12 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
 
   if (const SYCLIntelNumSimdWorkItemsAttr *A =
       FD->getAttr<SYCLIntelNumSimdWorkItemsAttr>()) {
-    llvm::Metadata *AttrMDArgs[] = {
-        llvm::ConstantAsMetadata::get(Builder.getInt32(A->getNumber()))};
+    llvm::LLVMContext &Context = getLLVMContext();
+    Optional<llvm::APSInt> ArgVal =
+        A->getValue()->getIntegerConstantExpr(FD->getASTContext());
+    assert(ArgVal.hasValue() && "Not an integer constant expression");
+    llvm::Metadata *AttrMDArgs[] = {llvm::ConstantAsMetadata::get(
+        Builder.getInt32(ArgVal->getSExtValue()))};
     Fn->setMetadata("num_simd_work_items",
                     llvm::MDNode::get(Context, AttrMDArgs));
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3002,7 +3002,8 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
   if (D->getAttr<SYCLIntelNumSimdWorkItemsAttr>())
     S.Diag(Attr.getLoc(), diag::warn_duplicate_attribute) << Attr;
 
-  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(D, Attr, E);
+  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(D, Attr,
+                                                                     E);
 }
 
 // Handles max_global_work_dim.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3002,7 +3002,7 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
   if (D->getAttr<SYCLIntelNumSimdWorkItemsAttr>())
     S.Diag(Attr.getLoc(), diag::warn_duplicate_attribute) << Attr;
 
-   S.addIntelSYCLFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(D, Attr, E);
+  S.addIntelSYCLFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(D, Attr, E);
 }
 
 // Handles max_global_work_dim.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2988,7 +2988,7 @@ static void handleSubGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (D->getAttr<IntelReqdSubGroupSizeAttr>())
     S.Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL;
 
-  S.addIntelSYCLFunctionAttr<IntelReqdSubGroupSizeAttr>(D, AL, E);
+  S.addIntelSYCLSingleArgFunctionAttr<IntelReqdSubGroupSizeAttr>(D, AL, E);
 }
 
 // Handles num_simd_work_items.
@@ -3002,7 +3002,7 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
   if (D->getAttr<SYCLIntelNumSimdWorkItemsAttr>())
     S.Diag(Attr.getLoc(), diag::warn_duplicate_attribute) << Attr;
 
-  S.addIntelSYCLFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(D, Attr, E);
+  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(D, Attr, E);
 }
 
 // Handles max_global_work_dim.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2979,31 +2979,6 @@ static void handleWorkGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
 }
 
 // Handles intel_reqd_sub_group_size.
-void Sema::addIntelReqdSubGroupSizeAttr(Decl *D,
-                                        const AttributeCommonInfo &Attr,
-                                        Expr *E) {
-  if (!E)
-    return;
-
-  if (!E->isInstantiationDependent()) {
-    Optional<llvm::APSInt> ArgVal = E->getIntegerConstantExpr(getASTContext());
-    if (!ArgVal) {
-      Diag(E->getExprLoc(), diag::err_attribute_argument_type)
-          << Attr.getAttrName() << AANT_ArgumentIntegerConstant
-          << E->getSourceRange();
-      return;
-    }
-    int32_t ArgInt = ArgVal->getSExtValue();
-    if (ArgInt <= 0) {
-      Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
-          << Attr.getAttrName() << /*positive*/ 0;
-      return;
-    }
-  }
-
-  D->addAttr(::new (Context) IntelReqdSubGroupSizeAttr(Context, Attr, E));
-}
-
 static void handleSubGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (S.LangOpts.SYCLIsHost)
     return;
@@ -3013,7 +2988,7 @@ static void handleSubGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (D->getAttr<IntelReqdSubGroupSizeAttr>())
     S.Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL;
 
-  S.addIntelReqdSubGroupSizeAttr(D, AL, E);
+  S.addIntelSYCLFunctionAttr<IntelReqdSubGroupSizeAttr>(D, AL, E);
 }
 
 // Handles num_simd_work_items.
@@ -3022,23 +2997,12 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
   if (D->isInvalidDecl())
     return;
 
-  uint32_t NumSimdWorkItems = 0;
-  const Expr *E = Attr.getArgAsExpr(0);
-  if (!checkUInt32Argument(S, Attr, E, NumSimdWorkItems, 0,
-                           /*StrictlyUnsigned=*/true))
-    return;
-
-  if (NumSimdWorkItems == 0) {
-    S.Diag(Attr.getLoc(), diag::err_attribute_argument_is_zero)
-      << Attr << E->getSourceRange();
-    return;
-  }
+  Expr *E = Attr.getArgAsExpr(0);
 
   if (D->getAttr<SYCLIntelNumSimdWorkItemsAttr>())
     S.Diag(Attr.getLoc(), diag::warn_duplicate_attribute) << Attr;
 
-  D->addAttr(::new (S.Context) SYCLIntelNumSimdWorkItemsAttr(
-        S.Context, Attr, NumSimdWorkItems));
+   S.addIntelSYCLFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(D, Attr, E);
 }
 
 // Handles max_global_work_dim.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2740,15 +2740,15 @@ void Sema::MarkDevice(void) {
               KernelBody ? KernelBody->getAttr<SYCLSimdAttr>() : nullptr;
           if (auto *Existing =
                   SYCLKernel->getAttr<IntelReqdSubGroupSizeAttr>()) {
-            if (getIntExprValue(Existing->getSubGroupSize(), getASTContext()) !=
-                getIntExprValue(Attr->getSubGroupSize(), getASTContext())) {
+            if (getIntExprValue(Existing->getValue(), getASTContext()) !=
+                getIntExprValue(Attr->getValue(), getASTContext())) {
               Diag(SYCLKernel->getLocation(),
                    diag::err_conflicting_sycl_kernel_attributes);
               Diag(Existing->getLocation(), diag::note_conflicting_attribute);
               Diag(Attr->getLocation(), diag::note_conflicting_attribute);
               SYCLKernel->setInvalidDecl();
             }
-          } else if (KBSimdAttr && (getIntExprValue(Attr->getSubGroupSize(),
+          } else if (KBSimdAttr && (getIntExprValue(Attr->getValue(),
                                                     getASTContext()) != 1)) {
             reportConflictingAttrs(*this, KernelBody, KBSimdAttr, Attr);
           } else {

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -549,7 +549,8 @@ static void instantiateIntelSYCLFunctionAttr(
       S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
   ExprResult Result = S.SubstExpr(Attr->getValue(), TemplateArgs);
   if (!Result.isInvalid())
-    S.addIntelSYCLFunctionAttr<AttrName>(New, *Attr, Result.getAs<Expr>());
+    S.addIntelSYCLSingleArgFunctionAttr<AttrName>(New, *Attr,
+                                                  Result.getAs<Expr>());
 }
 
 void Sema::InstantiateAttrsForDecl(

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -541,15 +541,15 @@ static void instantiateSYCLIntelPipeIOAttr(
     S.addSYCLIntelPipeIOAttr(New, *Attr, Result.getAs<Expr>());
 }
 
-static void instantiateIntelReqdSubGroupSizeAttr(
+template <typename AttrName>
+static void instantiateIntelSYCLFunctionAttr(
     Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
-    const IntelReqdSubGroupSizeAttr *Attr, Decl *New) {
-  // The SubGroupSize expression is a constant expression.
+    const AttrName *Attr, Decl *New) {
   EnterExpressionEvaluationContext Unevaluated(
       S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
-  ExprResult Result = S.SubstExpr(Attr->getSubGroupSize(), TemplateArgs);
+  ExprResult Result = S.SubstExpr(Attr->getValue(), TemplateArgs);
   if (!Result.isInvalid())
-    S.addIntelReqdSubGroupSizeAttr(New, *Attr, Result.getAs<Expr>());
+    S.addIntelSYCLFunctionAttr<AttrName>(New, *Attr, Result.getAs<Expr>());
 }
 
 void Sema::InstantiateAttrsForDecl(
@@ -697,8 +697,14 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
     }
     if (const auto *IntelReqdSubGroupSize =
             dyn_cast<IntelReqdSubGroupSizeAttr>(TmplAttr)) {
-      instantiateIntelReqdSubGroupSizeAttr(*this, TemplateArgs,
-                                           IntelReqdSubGroupSize, New);
+      instantiateIntelSYCLFunctionAttr<IntelReqdSubGroupSizeAttr>(
+          *this, TemplateArgs, IntelReqdSubGroupSize, New);
+      continue;
+    }
+    if (const auto *SYCLIntelNumSimdWorkItems =
+            dyn_cast<SYCLIntelNumSimdWorkItemsAttr>(TmplAttr)) {
+      instantiateIntelSYCLFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(
+          *this, TemplateArgs, SYCLIntelNumSimdWorkItems, New);
       continue;
     }
     // Existing DLL attribute on the instantiation takes precedence.

--- a/clang/test/CodeGenSYCL/num-simd-work-items.cpp
+++ b/clang/test/CodeGenSYCL/num-simd-work-items.cpp
@@ -25,7 +25,6 @@ void bar() {
 
   Functor<2> f;
   kernel<class kernel_name3>(f);
-
 }
 
 // CHECK: define spir_kernel void @{{.*}}kernel_name1() {{.*}} !num_simd_work_items ![[NUM1:[0-9]+]]

--- a/clang/test/CodeGenSYCL/num-simd-work-items.cpp
+++ b/clang/test/CodeGenSYCL/num-simd-work-items.cpp
@@ -5,6 +5,12 @@ public:
   [[intelfpga::num_simd_work_items(1)]] void operator()() const {}
 };
 
+template <int SIZE>
+class Functor {
+public:
+  [[intelfpga::num_simd_work_items(SIZE)]] void operator()() const {}
+};
+
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
@@ -17,10 +23,14 @@ void bar() {
   kernel<class kernel_name2>(
   []() [[intelfpga::num_simd_work_items(42)]] {});
 
+  Functor<2> f;
+  kernel<class kernel_name3>(f);
+
 }
 
 // CHECK: define spir_kernel void @{{.*}}kernel_name1() {{.*}} !num_simd_work_items ![[NUM1:[0-9]+]]
 // CHECK: define spir_kernel void @{{.*}}kernel_name2() {{.*}} !num_simd_work_items ![[NUM42:[0-9]+]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name3() {{.*}} !num_simd_work_items ![[NUM2:[0-9]+]]
 // CHECK: ![[NUM1]] = !{i32 1}
 // CHECK: ![[NUM42]] = !{i32 42}
-
+// CHECK: ![[NUM2]] = !{i32 2}

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -53,10 +53,10 @@ int main() {
   [[intelfpga::num_simd_work_items(0)]] int Var = 0; // expected-error{{'num_simd_work_items' attribute only applies to functions}}
 
   kernel<class test_kernel4>(
-      []() [[intelfpga::num_simd_work_items(0)]] {}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
+      []() [[intelfpga::num_simd_work_items(0)]]{}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 
   kernel<class test_kernel5>(
-      []() [[intelfpga::num_simd_work_items(-42)]] {}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
+      []() [[intelfpga::num_simd_work_items(-42)]]{}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 
   kernel<class test_kernel6>(
       []() [[intelfpga::num_simd_work_items(1), intelfpga::num_simd_work_items(2)]] {}); // expected-warning{{attribute 'num_simd_work_items' is already applied with different parameters}}

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -Wno-sycl-2017-compat -DTRIGGER_ERROR -verify
 // RUN: %clang_cc1 %s -fsycl -fsycl-is-device -triple spir64 -fsyntax-only -Wno-sycl-2017-compat -ast-dump | FileCheck %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {
@@ -20,7 +19,6 @@ void foo() {
 }
 
 #else // __SYCL_DEVICE_ONLY__
-
 [[intelfpga::num_simd_work_items(2)]] void func_do_not_ignore() {}
 
 struct FuncObj {
@@ -34,17 +32,20 @@ __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
 
 int main() {
   // CHECK-LABEL: FunctionDecl {{.*}}test_kernel1
-  // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}} 42
+  // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
+  // CHECK-NEXT:  IntegerLiteral{{.*}}42{{$}}
   kernel<class test_kernel1>(
       FuncObj());
 
   // CHECK-LABEL: FunctionDecl {{.*}}test_kernel2
-  // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}} 8
+  // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
+  // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
   kernel<class test_kernel2>(
       []() [[intelfpga::num_simd_work_items(8)]] {});
 
   // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
-  // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}} 2
+  // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
+  // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
   kernel<class test_kernel3>(
       []() { func_do_not_ignore(); });
 
@@ -52,10 +53,10 @@ int main() {
   [[intelfpga::num_simd_work_items(0)]] int Var = 0; // expected-error{{'num_simd_work_items' attribute only applies to functions}}
 
   kernel<class test_kernel4>(
-      []() [[intelfpga::num_simd_work_items(0)]] {}); // expected-error{{'num_simd_work_items' attribute must be greater than 0}}
+      []() [[intelfpga::num_simd_work_items(0)]] {}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 
   kernel<class test_kernel5>(
-      []() [[intelfpga::num_simd_work_items(-42)]] {}); // expected-error{{'num_simd_work_items' attribute requires a non-negative integral compile time constant expression}}
+      []() [[intelfpga::num_simd_work_items(-42)]] {}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 
   kernel<class test_kernel6>(
       []() [[intelfpga::num_simd_work_items(1), intelfpga::num_simd_work_items(2)]] {}); // expected-warning{{attribute 'num_simd_work_items' is already applied with different parameters}}

--- a/clang/test/SemaSYCL/num_simd_work_items_host.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_host.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-host -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// expected-no-diagnostics
+
+[[intelfpga::num_simd_work_items(2)]] void func_do_not_ignore() {}
+
+struct FuncObj {
+  [[intelfpga::num_simd_work_items(42)]] void operator()() const {}
+};

--- a/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+
+// Test that checkes template parameter support for 'num_simd_work_items' attribute on sycl device.
+
+template <int SIZE>
+class KernelFunctor {
+public:
+  // expected-error@+1{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
+  [[intelfpga::num_simd_work_items(SIZE)]] void operator()() {}
+};
+
+int main() {
+  //expected-note@+1{{in instantiation of template class 'KernelFunctor<-1>' requested here}}
+  KernelFunctor<-1>();
+  // no error expected
+  KernelFunctor<10>();
+}
+
+// CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
+// CHECK: ClassTemplateSpecializationDecl {{.*}} {{.*}} class KernelFunctor definition
+// CHECK: CXXRecordDecl {{.*}} {{.*}} implicit class KernelFunctor
+// CHECK: SYCLIntelNumSimdWorkItemsAttr {{.*}}
+// CHECK: SubstNonTypeTemplateParmExpr {{.*}}
+// CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}10{{$}}


### PR DESCRIPTION
This patch

1. adds support for template parameter on [[intelfpga::num_simd_work_items()]] attribute

2. splits test/SemaSYCL/num_simd_work_items.cpp to separate files for
   host compilation (test/SemaSYCL/num_simd_work_items_host.cpp) and
   device compilation (test/SemaSYCL/num_simd_work_items_device.cpp)

3. makes changes to intel_reqd_sub_group_size attribute source codes
   to avoid duplication and reuse for the template parameter support.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>