### PR TITLE
[SYCL] Add clang support for FPGA kernel attribute scheduler_target_fmax_mhz

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1227,7 +1227,7 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
 
 def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","scheduler_target_fmax_mhz">];
-  let Args = [UnsignedArgument<"Number">];
+  let Args = [ExprArgument<"TargetFmaxMhz">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelSchedulerTargetFmaxMhzAttrDocs];

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1227,11 +1227,20 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
 
 def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","scheduler_target_fmax_mhz">];
-  let Args = [ExprArgument<"TargetFmaxMhz">];
+  let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelSchedulerTargetFmaxMhzAttrDocs];
   let PragmaAttributeSupport = 0;
+  let AdditionalMembers = [{
+    static unsigned getMinValue() {
+      return 0;
+    }
+    static unsigned getMaxValue() {
+      return 1048576;
+    }
+  }];
+
 }
 
 def SYCLIntelMaxWorkGroupSize : InheritableAttr {

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1225,6 +1225,15 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
   let PragmaAttributeSupport = 0;
 }
 
+def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
+  let Spellings = [CXX11<"intelfpga","scheduler_target_fmax_mhz">];
+  let Args = [UnsignedArgument<"Number">];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Documentation = [SYCLIntelSchedulerTargetFmaxMhzAttrDocs];
+  let PragmaAttributeSupport = 0;
+}
+
 def SYCLIntelMaxWorkGroupSize : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","max_work_group_size">];
   let Args = [UnsignedArgument<"XDim">,

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2197,6 +2197,17 @@ device kernel, the attribute is ignored and it is not propagated to a kernel.
   }];
 }
 
+def SYCLIntelSchedulerTargetFmaxMhzAttrDocs : Documentation {
+  let Category = DocCatFunction;
+  let Heading = "scheduler_target_fmax_mhz (IntelFPGA)";
+  let Content = [{
+Applies to a device function/lambda function. Indicates that the kernel should
+be pipelined so as to achieve the specified target clock frequency (Fmax) of N
+MHz. The argument N may be a template parameter. This attribute should be
+ignored for the FPGA emulator device.
+  }];
+}
+
 def SYCLIntelNoGlobalWorkOffsetAttrDocs : Documentation {
   let Category = DocCatFunction;
   let Heading = "no_global_work_offset (IntelFPGA)";

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2205,6 +2205,17 @@ Applies to a device function/lambda function. Indicates that the kernel should
 be pipelined so as to achieve the specified target clock frequency (Fmax) of N
 MHz. The argument N may be a template parameter. This attribute should be
 ignored for the FPGA emulator device.
+
+``[[intelfpga::scheduler_target_fmax_mhz(N)]]``
+Valid values of N are integers in the range [0, 1048576]. The upper limit,
+although too high to be a realistic value for frequency, is chosen to be future
+proof. The FPGA backend emits a diagnostic message if the passed value is
+unachievable by the device.
+
+This attribute enables communication of the desired maximum frequency of the
+device operation, guiding the FPGA backend to insert the appropriate number of
+registers to break-up the combinational logic circuit, and therby controlling
+the length of the longest combinational path.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2214,7 +2214,7 @@ unachievable by the device.
 
 This attribute enables communication of the desired maximum frequency of the
 device operation, guiding the FPGA backend to insert the appropriate number of
-registers to break-up the combinational logic circuit, and therby controlling
+registers to break-up the combinational logic circuit, and thereby controlling
 the length of the longest combinational path.
   }];
 }

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -162,6 +162,7 @@ public:
         (ParsedAttr == AT_ReqdWorkGroupSize && isCXX11Attribute()) ||
         (ParsedAttr == AT_IntelReqdSubGroupSize && isCXX11Attribute()) ||
         ParsedAttr == AT_SYCLIntelNumSimdWorkItems ||
+        ParsedAttr == AT_SYCLIntelSchedulerTargetFmaxMhz ||
         ParsedAttr == AT_SYCLIntelMaxWorkGroupSize ||
         ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim ||
         ParsedAttr == AT_SYCLIntelNoGlobalWorkOffset)

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10045,6 +10045,16 @@ public:
   bool checkAllowedSYCLInitializer(VarDecl *VD,
                                    bool CheckValueDependent = false);
 
+  // Adds an intel_reqd_sub_group_size attribute to a particular declaration.
+  void addIntelReqdSubGroupSizeAttr(Decl *D, const AttributeCommonInfo &CI,
+                                    Expr *E);
+
+  // Adds an scheduler_target_fmax_mhz intel_reqd_sub_group_size attribute to a
+  // particular declaration.
+  void addSYCLIntelSchedulerTargetFmaxMhzAttr(Decl *D,
+                                              const AttributeCommonInfo &CI,
+                                              Expr *E);
+
   //===--------------------------------------------------------------------===//
   // C++ Coroutines TS
   //

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10045,10 +10045,6 @@ public:
   bool checkAllowedSYCLInitializer(VarDecl *VD,
                                    bool CheckValueDependent = false);
 
-  // Adds an intel_reqd_sub_group_size attribute to a particular declaration.
-  void addIntelReqdSubGroupSizeAttr(Decl *D, const AttributeCommonInfo &CI,
-                                    Expr *E);
-
   // Adds an scheduler_target_fmax_mhz intel_reqd_sub_group_size attribute to a
   // particular declaration.
   void addSYCLIntelSchedulerTargetFmaxMhzAttr(Decl *D,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10045,8 +10045,7 @@ public:
   bool checkAllowedSYCLInitializer(VarDecl *VD,
                                    bool CheckValueDependent = false);
 
-  // Adds an scheduler_target_fmax_mhz intel_reqd_sub_group_size attribute to a
-  // particular declaration.
+  // Adds a scheduler_target_fmax_mhz attribute to a particular declaration.
   void addSYCLIntelSchedulerTargetFmaxMhzAttr(Decl *D,
                                               const AttributeCommonInfo &CI,
                                               Expr *E);

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -639,6 +639,14 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
                     llvm::MDNode::get(Context, AttrMDArgs));
   }
 
+  if (const SYCLIntelSchedulerTargetFmaxMhzAttr *A =
+      FD->getAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>()) {
+    llvm::Metadata *AttrMDArgs[] = {
+        llvm::ConstantAsMetadata::get(Builder.getInt32(A->getNumber()))};
+    Fn->setMetadata("scheduler_target_fmax_mhz",
+                    llvm::MDNode::get(Context, AttrMDArgs));
+  }
+
   if (const SYCLIntelMaxWorkGroupSizeAttr *A =
       FD->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
     llvm::Metadata *AttrMDArgs[] = {

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -641,8 +641,11 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
 
   if (const SYCLIntelSchedulerTargetFmaxMhzAttr *A =
           FD->getAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>()) {
+    Optional<llvm::APSInt> ArgVal =
+        A->getTargetFmaxMhz()->getIntegerConstantExpr(FD->getASTContext());
+    assert(ArgVal.hasValue() && "Not an integer constant expression");
     llvm::Metadata *AttrMDArgs[] = {
-        llvm::ConstantAsMetadata::get(Builder.getInt32(A->getNumber()))};
+        llvm::ConstantAsMetadata::get(Builder.getInt32(ArgVal->getZExtValue()))};
     Fn->setMetadata("scheduler_target_fmax_mhz",
                     llvm::MDNode::get(Context, AttrMDArgs));
   }

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -642,7 +642,7 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   if (const SYCLIntelSchedulerTargetFmaxMhzAttr *A =
           FD->getAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>()) {
     Optional<llvm::APSInt> ArgVal =
-        A->getTargetFmaxMhz()->getIntegerConstantExpr(FD->getASTContext());
+        A->getValue()->getIntegerConstantExpr(FD->getASTContext());
     assert(ArgVal.hasValue() && "Not an integer constant expression");
     llvm::Metadata *AttrMDArgs[] = {
         llvm::ConstantAsMetadata::get(Builder.getInt32(ArgVal->getZExtValue()))};

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -644,8 +644,8 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
     Optional<llvm::APSInt> ArgVal =
         A->getValue()->getIntegerConstantExpr(FD->getASTContext());
     assert(ArgVal.hasValue() && "Not an integer constant expression");
-    llvm::Metadata *AttrMDArgs[] = {
-        llvm::ConstantAsMetadata::get(Builder.getInt32(ArgVal->getZExtValue()))};
+    llvm::Metadata *AttrMDArgs[] = {llvm::ConstantAsMetadata::get(
+        Builder.getInt32(ArgVal->getSExtValue()))};
     Fn->setMetadata("scheduler_target_fmax_mhz",
                     llvm::MDNode::get(Context, AttrMDArgs));
   }

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -640,7 +640,7 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   }
 
   if (const SYCLIntelSchedulerTargetFmaxMhzAttr *A =
-      FD->getAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>()) {
+          FD->getAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>()) {
     llvm::Metadata *AttrMDArgs[] = {
         llvm::ConstantAsMetadata::get(Builder.getInt32(A->getNumber()))};
     Fn->setMetadata("scheduler_target_fmax_mhz",

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3017,9 +3017,12 @@ static void handleSchedulerTargetFmaxMhzAttr(Sema &S, Decl *D,
                            /*StrictlyUnsigned=*/true))
     return;
 
-  if (TargetFmaxMhz == 0) {
-    S.Diag(Attr.getLoc(), diag::err_attribute_argument_is_zero)
-        << Attr << E->getSourceRange();
+  uint32_t UpperLimit = 1048576;
+  if (TargetFmaxMhz > UpperLimit) {
+    // Allow frequency to be a "large enough" positive value, zero included
+    // Let FPGA backend handle unachievable frequency value
+    S.Diag(Attr.getLoc(), diag::err_attribute_argument_out_of_range)
+        << Attr << E->getSourceRange() << 0 << UpperLimit;
     return;
   }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3007,7 +3007,7 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
 }
 // Handles scheduler_target_fmax_mhz
 static void handleSchedulerTargetFmaxMhzAttr(Sema &S, Decl *D,
-                                       const ParsedAttr &Attr) {
+                                             const ParsedAttr &Attr) {
   if (D->isInvalidDecl())
     return;
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3009,8 +3009,7 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
 // Add scheduler_target_fmax_mhz
 void Sema::addSYCLIntelSchedulerTargetFmaxMhzAttr(
     Decl *D, const AttributeCommonInfo &Attr, Expr *E) {
-  if (!E)
-    return;
+  assert(E && "Attribute must have an argument.");
 
   SYCLIntelSchedulerTargetFmaxMhzAttr TmpAttr(Context, Attr, E);
   if (!E->isValueDependent()) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8350,10 +8350,6 @@ void Sema::ProcessDeclAttributeList(Scope *S, Decl *D,
         Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
         D->setInvalidDecl();
       }
-    } else if (const auto *A =
-                   D->getAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>()) {
-      Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
-      D->setInvalidDecl();
     } else if (!D->hasAttr<CUDAGlobalAttr>()) {
       if (const auto *A = D->getAttr<AMDGPUFlatWorkGroupSizeAttr>()) {
         Diag(D->getLocation(), diag::err_attribute_wrong_decl_type)

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -531,6 +531,9 @@ public:
       if (auto *A = FD->getAttr<SYCLIntelNumSimdWorkItemsAttr>())
         Attrs.insert(A);
 
+      if (auto *A = FD->getAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>())
+        Attrs.insert(A);
+
       if (auto *A = FD->getAttr<SYCLIntelMaxWorkGroupSizeAttr>())
         Attrs.insert(A);
 
@@ -3166,6 +3169,7 @@ void Sema::MarkDevice(void) {
         }
         case attr::Kind::SYCLIntelKernelArgsRestrict:
         case attr::Kind::SYCLIntelNumSimdWorkItems:
+        case attr::Kind::SYCLIntelSchedulerTargetFmaxMhz:
         case attr::Kind::SYCLIntelMaxGlobalWorkDim:
         case attr::Kind::SYCLIntelNoGlobalWorkOffset:
         case attr::Kind::SYCLSimd: {

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -582,17 +582,6 @@ static void instantiateIntelSYCLFunctionAttr(
                                                   Result.getAs<Expr>());
 }
 
-static void instantiateSYCLIntelSchedulerTargetFmaxMhzAttr(
-    Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
-    const SYCLIntelSchedulerTargetFmaxMhzAttr *Attr, Decl *New) {
-  // The TargetFmaxMhz expression is a constant expression.
-  EnterExpressionEvaluationContext Unevaluated(
-      S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
-  ExprResult Result = S.SubstExpr(Attr->getTargetFmaxMhz(), TemplateArgs);
-  if (!Result.isInvalid())
-    S.addSYCLIntelSchedulerTargetFmaxMhzAttr(New, *Attr, Result.getAs<Expr>());
-}
-
 void Sema::InstantiateAttrsForDecl(
     const MultiLevelTemplateArgumentList &TemplateArgs, const Decl *Tmpl,
     Decl *New, LateInstantiatedAttrVec *LateAttrs,
@@ -750,7 +739,7 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
     }
     if (const auto *SYCLIntelSchedulerTargetFmaxMhz =
             dyn_cast<SYCLIntelSchedulerTargetFmaxMhzAttr>(TmplAttr)) {
-      instantiateSYCLIntelSchedulerTargetFmaxMhzAttr(
+      instantiateIntelSYCLFunctionAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>(
           *this, TemplateArgs, SYCLIntelSchedulerTargetFmaxMhz, New);
       continue;
     }

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -582,6 +582,17 @@ static void instantiateIntelSYCLFunctionAttr(
                                                   Result.getAs<Expr>());
 }
 
+static void instantiateSYCLIntelSchedulerTargetFmaxMhzAttr(
+    Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
+    const SYCLIntelSchedulerTargetFmaxMhzAttr *Attr, Decl *New) {
+  // The TargetFmaxMhz expression is a constant expression.
+  EnterExpressionEvaluationContext Unevaluated(
+      S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
+  ExprResult Result = S.SubstExpr(Attr->getTargetFmaxMhz(), TemplateArgs);
+  if (!Result.isInvalid())
+    S.addSYCLIntelSchedulerTargetFmaxMhzAttr(New, *Attr, Result.getAs<Expr>());
+}
+
 void Sema::InstantiateAttrsForDecl(
     const MultiLevelTemplateArgumentList &TemplateArgs, const Decl *Tmpl,
     Decl *New, LateInstantiatedAttrVec *LateAttrs,
@@ -735,6 +746,12 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
             dyn_cast<SYCLIntelNumSimdWorkItemsAttr>(TmplAttr)) {
       instantiateIntelSYCLFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(
           *this, TemplateArgs, SYCLIntelNumSimdWorkItems, New);
+      continue;
+    }
+    if (const auto *SYCLIntelSchedulerTargetFmaxMhz =
+            dyn_cast<SYCLIntelSchedulerTargetFmaxMhzAttr>(TmplAttr)) {
+      instantiateSYCLIntelSchedulerTargetFmaxMhzAttr(
+          *this, TemplateArgs, SYCLIntelSchedulerTargetFmaxMhz, New);
       continue;
     }
     // Existing DLL attribute on the instantiation takes precedence.

--- a/clang/test/CodeGenSYCL/scheduler-target-fmax-mhz.cpp
+++ b/clang/test/CodeGenSYCL/scheduler-target-fmax-mhz.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -emit-llvm -o - %s | FileCheck %s
+
+#include "Inputs/sycl.hpp"
+[[intelfpga::scheduler_target_fmax_mhz(5)]] void
+func() {}
+
+template <int N>
+[[intelfpga::scheduler_target_fmax_mhz(N)]] void zoo() {}
+
+int main() {
+  cl::sycl::kernel_single_task<class test_kernel1>(
+      []() [[intelfpga::scheduler_target_fmax_mhz(2)]]{});
+
+  cl::sycl::kernel_single_task<class test_kernel2>(
+      []() { func(); });
+
+  cl::sycl::kernel_single_task<class test_kernel3>(
+      []() { zoo<75>(); });
+}
+// CHECK: define spir_kernel void @{{.*}}test_kernel1() {{.*}} !scheduler_target_fmax_mhz ![[PARAM1:[0-9]+]]
+// CHECK: define spir_kernel void @{{.*}}test_kernel2() {{.*}} !scheduler_target_fmax_mhz ![[PARAM2:[0-9]+]]
+// CHECK: define spir_kernel void @{{.*}}test_kernel3() {{.*}} !scheduler_target_fmax_mhz ![[PARAM3:[0-9]+]]
+// CHECK: ![[PARAM1]] = !{i32 2}
+// CHECK: ![[PARAM2]] = !{i32 5}
+// CHECK: ![[PARAM3]] = !{i32 75}

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -25,7 +25,7 @@ int main() {
   [[intelfpga::scheduler_target_fmax_mhz(0)]] int Var = 0; // expected-error{{'scheduler_target_fmax_mhz' attribute only applies to functions}}
 
   cl::sycl::kernel_single_task<class test_kernel3>(
-      []() [[intelfpga::scheduler_target_fmax_mhz(0)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute must be greater than 0}}
+      []() [[intelfpga::scheduler_target_fmax_mhz(1048577)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires integer constant between 0 and 1048576 inclusive}}
 
   cl::sycl::kernel_single_task<class test_kernel4>(
       []() [[intelfpga::scheduler_target_fmax_mhz(-4)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires a non-negative integral compile time constant expression}}

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -7,30 +7,42 @@
 [[intelfpga::scheduler_target_fmax_mhz(2)]] // expected-no-diagnostics
 void
 func() {}
+
+template <int N>
+[[intelfpga::scheduler_target_fmax_mhz(N)]] void zoo() {}
 #endif // TRIGGER_ERROR
 
 int main() {
 #ifndef TRIGGER_ERROR
-  // CHECK-LABEL:  -FunctionDecl {{.*}}test_kernel1 'void ()'
-  // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}} 5
+  // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel1 'void ()'
+  // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 5
   cl::sycl::kernel_single_task<class test_kernel1>(
       []() [[intelfpga::scheduler_target_fmax_mhz(5)]]{});
 
-  // CHECK-LABEL:  `-FunctionDecl {{.*}}test_kernel2 'void ()'
-  // CHECK:  -SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}} 2
+  // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel2 'void ()'
+  // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 2
   cl::sycl::kernel_single_task<class test_kernel2>(
       []() { func(); });
 
+  // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel3 'void ()'
+  // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
+  // CHECK-NEXT:   SubstNonTypeTemplateParmExpr {{.*}} 'int'
+  // CHECK-NEXT:   NonTypeTemplateParmDecl {{.*}} referenced 'int' depth 0 index 0 N
+  // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 75
+  cl::sycl::kernel_single_task<class test_kernel3>(
+      []() { zoo<75>(); });
 #else
   [[intelfpga::scheduler_target_fmax_mhz(0)]] int Var = 0; // expected-error{{'scheduler_target_fmax_mhz' attribute only applies to functions}}
 
-  cl::sycl::kernel_single_task<class test_kernel3>(
+  cl::sycl::kernel_single_task<class test_kernel4>(
       []() [[intelfpga::scheduler_target_fmax_mhz(1048577)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires integer constant between 0 and 1048576 inclusive}}
 
-  cl::sycl::kernel_single_task<class test_kernel4>(
-      []() [[intelfpga::scheduler_target_fmax_mhz(-4)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires a non-negative integral compile time constant expression}}
-
   cl::sycl::kernel_single_task<class test_kernel5>(
+      []() [[intelfpga::scheduler_target_fmax_mhz(-4)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires integer constant between 0 and 1048576 inclusive}}
+
+  cl::sycl::kernel_single_task<class test_kernel6>(
       []() [[intelfpga::scheduler_target_fmax_mhz(1), intelfpga::scheduler_target_fmax_mhz(2)]]{}); // expected-warning{{attribute 'scheduler_target_fmax_mhz' is already applied with different parameters}}
 #endif // TRIGGER_ERROR
 }

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -16,12 +16,16 @@ int main() {
 #ifndef TRIGGER_ERROR
   // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel1 'void ()'
   // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
+  // CHECK-NEXT:   ConstantExpr {{.*}} 'int'
+  // CHECK-NEXT:   value: Int 5
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 5
   cl::sycl::kernel_single_task<class test_kernel1>(
       []() [[intelfpga::scheduler_target_fmax_mhz(5)]]{});
 
   // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel2 'void ()'
   // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
+  // CHECK-NEXT:   ConstantExpr {{.*}} 'int'
+  // CHECK-NEXT:   value: Int 2
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 2
   cl::sycl::kernel_single_task<class test_kernel2>(
       []() { func(); });

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat -verify
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -DTRIGGER_ERROR -Wno-sycl-2017-compat -verify
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat | FileCheck %s
+
+#include "Inputs/sycl.hpp"
+#ifndef TRIGGER_ERROR
+[[intelfpga::scheduler_target_fmax_mhz(2)]] // expected-no-diagnostics
+void
+func() {}
+#endif // TRIGGER_ERROR
+
+int main() {
+#ifndef TRIGGER_ERROR
+  // CHECK-LABEL:  -FunctionDecl {{.*}}test_kernel1 'void ()'
+  // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}} 5
+  cl::sycl::kernel_single_task<class test_kernel1>(
+      []() [[intelfpga::scheduler_target_fmax_mhz(5)]]{});
+
+  // CHECK-LABEL:  `-FunctionDecl {{.*}}test_kernel2 'void ()'
+  // CHECK:  -SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}} 2
+  cl::sycl::kernel_single_task<class test_kernel2>(
+      []() { func(); });
+
+#else
+  [[intelfpga::scheduler_target_fmax_mhz(0)]] int Var = 0; // expected-error{{'scheduler_target_fmax_mhz' attribute only applies to functions}}
+
+  cl::sycl::kernel_single_task<class test_kernel3>(
+      []() [[intelfpga::scheduler_target_fmax_mhz(0)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute must be greater than 0}}
+
+  cl::sycl::kernel_single_task<class test_kernel4>(
+      []() [[intelfpga::scheduler_target_fmax_mhz(-4)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires a non-negative integral compile time constant expression}}
+
+  cl::sycl::kernel_single_task<class test_kernel5>(
+      []() [[intelfpga::scheduler_target_fmax_mhz(1), intelfpga::scheduler_target_fmax_mhz(2)]]{}); // expected-warning{{attribute 'scheduler_target_fmax_mhz' is already applied with different parameters}}
+#endif // TRIGGER_ERROR
+}

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -1,19 +1,13 @@
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat -verify
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -DTRIGGER_ERROR -Wno-sycl-2017-compat -verify
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat | FileCheck %s
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat -verify | FileCheck %s
 
 #include "Inputs/sycl.hpp"
-#ifndef TRIGGER_ERROR
-[[intelfpga::scheduler_target_fmax_mhz(2)]] // expected-no-diagnostics
-void
+[[intelfpga::scheduler_target_fmax_mhz(2)]] void
 func() {}
 
 template <int N>
 [[intelfpga::scheduler_target_fmax_mhz(N)]] void zoo() {}
-#endif // TRIGGER_ERROR
 
 int main() {
-#ifndef TRIGGER_ERROR
   // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel1 'void ()'
   // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
   // CHECK-NEXT:   ConstantExpr {{.*}} 'int'
@@ -37,7 +31,7 @@ int main() {
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 75
   cl::sycl::kernel_single_task<class test_kernel3>(
       []() { zoo<75>(); });
-#else
+
   [[intelfpga::scheduler_target_fmax_mhz(0)]] int Var = 0; // expected-error{{'scheduler_target_fmax_mhz' attribute only applies to functions}}
 
   cl::sycl::kernel_single_task<class test_kernel4>(
@@ -48,5 +42,4 @@ int main() {
 
   cl::sycl::kernel_single_task<class test_kernel6>(
       []() [[intelfpga::scheduler_target_fmax_mhz(1), intelfpga::scheduler_target_fmax_mhz(2)]]{}); // expected-warning{{attribute 'scheduler_target_fmax_mhz' is already applied with different parameters}}
-#endif // TRIGGER_ERROR
 }


### PR DESCRIPTION
[[intelfpga::scheduler_target_fmax_mhz(N)]] applies to a device function/lambda function. Indicates that the kernel should be pipelined so as to achieve the specified target clock frequency (Fmax) of N MHz. The argument N may be a template parameter. Limits of N are [0,1048576]; This attribute should be ignored for the FPGA emulator device.

This patch should
- Add clang support for attribute
- Add a code-gen test
- Add a sema/AST test