### PR TITLE
[SYCL][NFC] Remove redundant code in CMakeLists.txt

### DIFF
--- a/sycl/unittests/pi/CMakeLists.txt
+++ b/sycl/unittests/pi/CMakeLists.txt
@@ -9,7 +9,6 @@ add_sycl_unittest(PiTests OBJECT
 )
 
 add_dependencies(PiTests sycl)
-target_link_libraries(PiTests PRIVATE sycl LLVMTestingSupport OpenCL-Headers)
 target_include_directories(PiTests PRIVATE SYSTEM ${sycl_inc_dir})
 
 if(SYCL_BUILD_PI_CUDA)

--- a/sycl/unittests/pi/cuda/CMakeLists.txt
+++ b/sycl/unittests/pi/cuda/CMakeLists.txt
@@ -13,10 +13,6 @@ add_sycl_unittest(PiCudaTests OBJECT
 
 add_dependencies(PiCudaTests sycl)
 
-target_link_libraries(PiCudaTests PRIVATE
-  LLVMTestingSupport
-  OpenCL-Headers)
-
 target_compile_definitions(PiCudaTests PRIVATE
   GTEST_HAS_COMBINE=1)
 


### PR DESCRIPTION
add_sycl_unittest takes care of those dependencies.