### PR TITLE
[SYCL][Doc] Disable GitHub Pages job in forks

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'intel/llvm'
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This change prevents GitHub Pages documentation job from running in
forked repositories.