### PR TITLE
[SYCL] Set stype for event pool descriptor

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -214,6 +214,7 @@ _pi_context::getFreeSlotInExistingOrNewPool(ze_event_pool_handle_t &ZePool,
         NumEventsLiveInEventPoolMutex, std::adopt_lock);
 
     ze_event_pool_desc_t ZeEventPoolDesc = {};
+    ZeEventPoolDesc.stype = ZE_STRUCTURE_TYPE_EVENT_POOL_DESC;
     ZeEventPoolDesc.count = MaxNumEventsPerPool;
     ZeEventPoolDesc.flags = ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP;
 


### PR DESCRIPTION
See here, https://spec.oneapi.com/level-zero/latest/core/api.html?highlight=zeeventpoolcreate#ze-event-pool-desc-t. The "stype" is a new input field for the descriptors in Level-Zero v1.0.

Descriptors in v1.0 are now a linked list and have a "next" field, that allows you to pass extensions to any interface. So basically here we pass the basic descriptor (as we are doing) and then you could pass extensions through the next field if you want to instruct the Level-Zero driver to do something extra. The stype helps identifying which descriptor (if basic or extension) you are passing.

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>