### PR TITLE
[SYCL][DebugInfo] Reinstate source locations for some kernel instruct…

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -582,20 +582,10 @@ public:
       auto NewDecl = MappingPair.second;
       return DeclRefExpr::Create(
           SemaRef.getASTContext(), DRE->getQualifierLoc(),
-          DRE->getTemplateKeywordLoc(), NewDecl, false,
-          DeclarationNameInfo(DRE->getNameInfo().getName(), SourceLocation(),
-                              DRE->getNameInfo().getInfo()),
+          DRE->getTemplateKeywordLoc(), NewDecl, false, DRE->getNameInfo(),
           NewDecl->getType(), DRE->getValueKind());
     }
     return DRE;
-  }
-
-  StmtResult RebuildCompoundStmt(SourceLocation LBraceLoc,
-                                 MultiStmtArg Statements,
-                                 SourceLocation RBraceLoc, bool IsStmtExpr) {
-    // Build a new compound statement but clear the source locations.
-    return getSema().ActOnCompoundStmt(SourceLocation(), SourceLocation(),
-                                       Statements, IsStmtExpr);
   }
 
 private:

--- a/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang -fsycl-device-only %s -S -emit-llvm -O0 -g -o - | FileCheck %s
 //
-// Verify the SYCL kernel routine is marked artificial and has no source
-// correlation.
+// Verify the SYCL kernel routine is marked artificial and has the
+// expected source correlation.
 //
 // In order to placate the profiling tools, which can't cope with instructions
 // mapped to line 0, we've made the change so that the artificial code in a
@@ -28,17 +28,16 @@ int main() {
 // CHECK: getelementptr inbounds %"class.{{.*}}.anon"{{.*}} !dbg [[LINE_A0:![0-9]+]]
 // CHECK: call spir_func void {{.*}}6__init{{.*}} !dbg [[LINE_A0]]
 // CHECK: call spir_func void @"_ZZ4mainENK3$_0clEv"{{.*}} !dbg [[LINE_B0:![0-9]+]]
-// CHECK: ret void
+// CHECK: ret void, !dbg [[LINE_C0:![0-9]+]]
 // CHECK: [[FILE:![0-9]+]] = !DIFile(filename: "{{.*}}debug-info-srcpos-kernel.cpp"{{.*}})
 // CHECK: [[KERNEL]] = {{.*}}!DISubprogram(name: "{{.*}}19use_kernel_for_test"
 // CHECK-SAME: scope: [[FILE]]
 // CHECK-SAME: file: [[FILE]]
 // CHECK-SAME: flags: DIFlagArtificial | DIFlagPrototyped
 // CHECK: [[LINE_A0]] = !DILocation(line: 15,{{.*}}scope: [[KERNEL]]
-// CHECK: [[LINE_B0]] = !DILocation(line: 0
+// CHECK: [[LINE_B0]] = !DILocation(line: 16,{{.*}}scope: [[BLOCK:![0-9]+]]
+// CHECK: [[BLOCK]] = distinct !DILexicalBlock(scope: [[KERNEL]]
+// CHECK: [[LINE_C0]] = !DILocation(line: 17,{{.*}}scope: [[KERNEL]]
 
-// TODO: [[LINE_B0]] should be mapped to line 15 as well. That said,
-// this 'line 0' assignment is less problematic as the lambda function
-// call would be inlined in most cases.
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc

--- a/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
@@ -38,6 +38,3 @@ int main() {
 // CHECK: [[LINE_B0]] = !DILocation(line: 16,{{.*}}scope: [[BLOCK:![0-9]+]]
 // CHECK: [[BLOCK]] = distinct !DILexicalBlock(scope: [[KERNEL]]
 // CHECK: [[LINE_C0]] = !DILocation(line: 17,{{.*}}scope: [[KERNEL]]
-
-// TODO: SYCL specific fail - analyze and enable
-// XFAIL: windows-msvc


### PR DESCRIPTION
…ions

Now that the source location of the kernel caller function is being assigned to the initialization code in the kernel body, stop clearing the source locations for some other instructions (e.g. call to operator() and the return instruction).

Signed-off-by: Steve Merritt <steve.merritt@intel.com>