### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3215,8 +3215,8 @@ static void adjustDeclContextForDeclaratorDecl(DeclaratorDecl *NewD,
 template <typename AttributeType>
 static void checkDimensionsAndSetDiagnostics(Sema &S, FunctionDecl *New,
                                              FunctionDecl *Old) {
-  AttributeType *NewDeclAttr = New->getAttr<AttributeType>();
-  AttributeType *OldDeclAttr = Old->getAttr<AttributeType>();
+  const auto *NewDeclAttr = New->getAttr<AttributeType>();
+  const auto *OldDeclAttr = Old->getAttr<AttributeType>();
   if ((NewDeclAttr->getXDim() != OldDeclAttr->getXDim()) ||
       (NewDeclAttr->getYDim() != OldDeclAttr->getYDim()) ||
       (NewDeclAttr->getZDim() != OldDeclAttr->getZDim())) {


### PR DESCRIPTION
Found via a static-analysis tool:

Pointer 'NewDeclAttr' returned from call to function 'getAttr<clang::SYCLIntelMaxWorkGroupSizeAttr>'
at line 3218 may be NULL and will be dereferenced at line 3220.

Pointer 'NewDeclAttr' returned from call to function 'getAttr<clang::ReqdWorkGroupSizeAttr>'
at line 3218 may be NULL and will be dereferenced at line 3220.

Pointer 'OldDeclAttr' returned from call to function 'getAttr<clang::ReqdWorkGroupSizeAttr>'
at line 3219 may be NULL and will be dereferenced at line 3220.

Pointer 'OldDeclAttr' returned from call to function 'getAttr<clang::SYCLIntelMaxWorkGroupSizeAttr>'
at line 3219 may be NULL and will be dereferenced at line 3220.

This patch fixes null pointer dereference issues in SemaSYCL.cpp
by changing from AttributeType to const auto.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>