### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3215,8 +3215,8 @@ static void adjustDeclContextForDeclaratorDecl(DeclaratorDecl *NewD,
 template <typename AttributeType>
 static void checkDimensionsAndSetDiagnostics(Sema &S, FunctionDecl *New,
                                              FunctionDecl *Old) {
-  AttributeType *NewDeclAttr = New->getAttr<AttributeType>();
-  AttributeType *OldDeclAttr = Old->getAttr<AttributeType>();
+  const auto *NewDeclAttr = New->getAttr<AttributeType>();
+  const auto *OldDeclAttr = Old->getAttr<AttributeType>();
   if ((NewDeclAttr->getXDim() != OldDeclAttr->getXDim()) ||
       (NewDeclAttr->getYDim() != OldDeclAttr->getYDim()) ||
       (NewDeclAttr->getZDim() != OldDeclAttr->getZDim())) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3217,6 +3217,10 @@ static void checkDimensionsAndSetDiagnostics(Sema &S, FunctionDecl *New,
                                              FunctionDecl *Old) {
   const auto *NewDeclAttr = New->getAttr<AttributeType>();
   const auto *OldDeclAttr = Old->getAttr<AttributeType>();
+
+  if (!NewDeclAttr || !OldDeclAttr)
+    return;
+
   if ((NewDeclAttr->getXDim() != OldDeclAttr->getXDim()) ||
       (NewDeclAttr->getYDim() != OldDeclAttr->getYDim()) ||
       (NewDeclAttr->getZDim() != OldDeclAttr->getZDim())) {
@@ -3302,12 +3306,8 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD,
     }
   }
 
-  if (New->hasAttr<ReqdWorkGroupSizeAttr>() &&
-      Old->hasAttr<ReqdWorkGroupSizeAttr>())
     checkDimensionsAndSetDiagnostics<ReqdWorkGroupSizeAttr>(*this, New, Old);
 
-  if (New->hasAttr<SYCLIntelMaxWorkGroupSizeAttr>() &&
-      Old->hasAttr<SYCLIntelMaxWorkGroupSizeAttr>())
     checkDimensionsAndSetDiagnostics<SYCLIntelMaxWorkGroupSizeAttr>(*this, New,
                                                                     Old);
 


### PR DESCRIPTION
Found via a static-analysis tool:

    1. Pointer 'NewDeclAttr' returned from call to function 'getAttr<clang::SYCLIntelMaxWorkGroupSizeAttr>'
       at line 3218 may be NULL and will be dereferenced at line 3220.

    2. Pointer 'NewDeclAttr' returned from call to function 'getAttr<clang::ReqdWorkGroupSizeAttr>'
       at line 3218 may be NULL and will be dereferenced at line 3220.

    3. Pointer 'OldDeclAttr' returned from call to function 'getAttr<clang::ReqdWorkGroupSizeAttr>'
       at line 3219 may be NULL and will be dereferenced at line 3220.

    4. Pointer 'OldDeclAttr' returned from call to function 'getAttr<clang::SYCLIntelMaxWorkGroupSizeAttr>'
       at line 3219 may be NULL and will be dereferenced at line 3220.

This patch fixes null pointer dereference issues in SemaDecl.cpp file
by adding early return if (!NewDeclAttr || !OldDeclAttr)

Signed-off-by: Soumi Manna <soumi.manna@intel.com>