### PR TITLE
[SYCL][Deps]Uplift Windows GPU RT from 8673 to 8778

### DIFF
--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -7,8 +7,8 @@ ocl_cpu_rt_ver_win=2020.11.8.0.27
 # https://github.com/intel/compute-runtime/releases/tag/20.35.17767
 ocl_gpu_rt_ver=20.35.17767
 # Same GPU driver supports Level Zero and OpenCL:
-# https://downloadmirror.intel.com/29817/a08/igfx_win10_100.8673.zip
-ocl_gpu_rt_ver_win=27.20.100.8673
+# https://downloadmirror.intel.com/29879/a08/igfx_win10_100.8778.zip
+ocl_gpu_rt_ver_win=27.20.100.8778
 intel_sycl_ver=build
 # https://github.com/oneapi-src/oneTBB/releases/download/v2021.1-beta08/oneapi-tbb-2021.1-beta08-lin.tgz
 tbb_ver=2021.1.9.636
@@ -25,7 +25,7 @@ fpga_ver_win=20200811_000006
 cpu_driver_lin=2020.11.8.0.27
 cpu_driver_win=2020.11.8.0.27
 gpu_driver_lin=20.35.17767
-gpu_driver_win=27.20.100.8673
+gpu_driver_win=27.20.100.8778
 fpga_driver_lin=2020.11.8.0.27
 fpga_driver_win=2020.11.8.0.27
 # NVidia CUDA driver

--- a/sycl/test/basic_tests/buffer/buffer_full_copy.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_full_copy.cpp
@@ -1,4 +1,3 @@
-// XFAIL: windows && level_zero
 // RUN: %clangxx %s -o %t1.out -lsycl -I %sycl_include
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t2.out

--- a/sycl/test/hier_par/hier_par_wgscope.cpp
+++ b/sycl/test/hier_par/hier_par_wgscope.cpp
@@ -1,6 +1,6 @@
 // TODO: Enable compilation w/o -fno-sycl-early-optimizations option.
 // See https://github.com/intel/llvm/issues/2264 for more details.
-// XFAIL: gpu && (level_zero || opencl)
+// XFAIL: gpu && (level_zero || opencl) && linux
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out

--- a/sycl/test/sub_group/generic_reduce.cpp
+++ b/sycl/test/sub_group/generic_reduce.cpp
@@ -1,6 +1,6 @@
 // TODO: Enable compilation w/o -fno-sycl-early-optimizations option.
 // See https://github.com/intel/llvm/issues/2264 for more details.
-// XFAIL: gpu
+// XFAIL: gpu && linux
 
 // UNSUPPORTED: cuda
 // CUDA compilation and runtime do not yet support sub-groups.

--- a/sycl/test/sub_group/load_store.cpp
+++ b/sycl/test/sub_group/load_store.cpp
@@ -1,6 +1,6 @@
 // TODO: Enable compilation w/o -fno-sycl-early-optimizations option.
 // See https://github.com/intel/llvm/issues/2264 for more details.
-// XFAIL: gpu
+// XFAIL: gpu && linux
 
 // UNSUPPORTED: cuda || cpu
 // CUDA compilation and runtime do not yet support sub-groups.


### PR DESCRIPTION
Uplift Windows GPU RT from 27.20.100.8673 to 27.20.100.8778, with the new GPU RT, the following LIT test can pass on Windows L0GPU:
1. sycl/test/basic_tests/buffer/buffer_full_copy.cpp
2. sycl/test/hier_par/hier_par_wgscope.cpp
3. sycl/test/sub_group/generic_reduce.cpp 
4. sycl/test/sub_group/load_store.cpp
