### PR TITLE
[SYCL] Fix crash in piEventsWait in pi_level_zero

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3062,12 +3062,12 @@ pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
 
     // NOTE: we are destroying associated command lists here to free
     // resources sooner in case RT is not calling piEventRelease soon enough.
-    if (EventList[I]->ZeCommandList) {
-      // Event has been signaled: If the fence for the associated command list
-      // is signalled, then reset the fence and command list and add them to the
-      // available list for reuse in PI calls.
-      if (EventList[I]->Queue->RefCount > 0) {
-        EventList[I]->Queue->ZeCommandListFenceMapMutex.lock();
+    // Event has been signaled: If the fence for the associated command list
+    // is signalled, then reset the fence and command list and add them to the
+    // available list for reuse in PI calls.
+    if (EventList[I]->Queue->RefCount > 0) {
+      EventList[I]->Queue->ZeCommandListFenceMapMutex.lock();
+      if (EventList[I]->ZeCommandList) {
         ze_result_t ZeResult = ZE_CALL_NOCHECK(zeFenceQueryStatus(
             EventList[I]
                 ->Queue->ZeCommandListFenceMap[EventList[I]->ZeCommandList]));
@@ -3076,8 +3076,8 @@ pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
               EventList[I]->ZeCommandList, true);
           EventList[I]->ZeCommandList = nullptr;
         }
-        EventList[I]->Queue->ZeCommandListFenceMapMutex.unlock();
       }
+      EventList[I]->Queue->ZeCommandListFenceMapMutex.unlock();
     }
   }
   return PI_SUCCESS;


### PR DESCRIPTION
That fixes a sporadic thread-safety bug in `piEventsWait` when level0 plugin is used:
one thread changes `EventList[I]->ZeCommandList = nullptr;`
while another thread locks `ZeCommandListFenceMapMutex` and when it is time to use `EventList[I]->ZeCommandList` it already is nullptr.

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>