### PR TITLE
[SYCL] Remove kernel_signature_start from int header

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3747,30 +3747,8 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   }
   O << "};\n\n";
 
-  O << "// indices into the kernel_signatures array, each representing a "
-       "start"
-       " of\n";
-  O << "// kernel signature descriptor subarray of the kernel_signatures"
-       " array;\n";
-  O << "// the index order in this array corresponds to the kernel name order"
-       " in the\n";
-  O << "// kernel_names array\n";
-  O << "static constexpr\n";
-  O << "const unsigned kernel_signature_start[] = {\n";
-  unsigned CurStart = 0;
-
-  for (unsigned I = 0; I < KernelDescs.size(); I++) {
-    auto &K = KernelDescs[I];
-    O << "  " << CurStart;
-    if (I < KernelDescs.size() - 1)
-      O << ",";
-    O << " // " << K.Name << "\n";
-    CurStart += K.Params.size() + 1;
-  }
-  O << "};\n\n";
-
   O << "// Specializations of KernelInfo for kernel function types:\n";
-  CurStart = 0;
+  unsigned CurStart = 0;
 
   for (const KernelDesc &K : KernelDescs) {
     const size_t N = K.Params.size();

--- a/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
@@ -25,11 +25,6 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: };
 
-// CHECK: static constexpr
-// CHECK-NEXT: const unsigned kernel_signature_start[] = {
-// CHECK-NEXT:  0 // _ZTSZ4mainE8kernel_A
-// CHECK-NEXT: };
-
 // CHECK: template <> struct KernelInfo<class kernel_A> {
 
 #include "Inputs/sycl.hpp"

--- a/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
@@ -25,11 +25,6 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: };
 
-// CHECK: static constexpr
-// CHECK-NEXT: const unsigned kernel_signature_start[] = {
-// CHECK-NEXT:  0 // _ZTSZ4mainE8kernel_C
-// CHECK-NEXT: };
-
 // CHECK: template <> struct KernelInfo<class kernel_C> {
 
 #include "Inputs/sycl.hpp"

--- a/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
@@ -31,13 +31,6 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: };
 
-// CHECK: static constexpr
-// CHECK-NEXT: const unsigned kernel_signature_start[] = {
-// CHECK-NEXT:  0, // _ZTSZ4mainE8kernel_B
-// CHECK-NEXT:  2, // _ZTSZ4mainE8kernel_C
-// CHECK-NEXT:  4 // _ZTSZ4mainE8kernel_D
-// CHECK-NEXT: };
-
 // CHECK: template <> struct KernelInfo<class kernel_B> {
 // CHECK: template <> struct KernelInfo<class kernel_C> {
 // CHECK: template <> struct KernelInfo<class kernel_D> {

--- a/clang/test/CodeGenSYCL/stdtypes_kernel_type.cpp
+++ b/clang/test/CodeGenSYCL/stdtypes_kernel_type.cpp
@@ -18,12 +18,6 @@
 // CHECK-NEXT:   //--- _ZTSl
 // CHECK-EMPTY:
 // CHECK-NEXT: };
-//
-// CHECK: static constexpr
-// CHECK-NEXT: const unsigned kernel_signature_start[] = {
-// CHECK-NEXT:  0, // _ZTSm
-// CHECK-NEXT:  1 // _ZTSl
-// CHECK-NEXT: };
 
 // CHECK: template <> struct KernelInfo<unsigned long> {
 // CHECK: template <> struct KernelInfo<long> {

--- a/clang/test/CodeGenSYCL/union-kernel-param-ih.cpp
+++ b/clang/test/CodeGenSYCL/union-kernel-param-ih.cpp
@@ -24,11 +24,6 @@
 // CHECK-EMPTY:
 // CHECK-NEXT:};
 
-// CHECK: static constexpr
-// CHECK-NEXT: const unsigned kernel_signature_start[] = {
-// CHECK-NEXT:  0 // _ZTSZ4mainE8kernel_A
-// CHECK-NEXT: };
-
 // CHECK: template <> struct KernelInfo<class kernel_A> {
 
 union MyUnion {

--- a/clang/test/CodeGenSYCL/wrapped-accessor.cpp
+++ b/clang/test/CodeGenSYCL/wrapped-accessor.cpp
@@ -21,11 +21,6 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: };
 
-// CHECK: static constexpr
-// CHECK-NEXT: const unsigned kernel_signature_start[] = {
-// CHECK-NEXT:  0 // _ZTSZ4mainE14wrapped_access
-// CHECK-NEXT: };
-
 // CHECK: template <> struct KernelInfo<class wrapped_access> {
 
 #include "Inputs/sycl.hpp"


### PR DESCRIPTION
Some time ago, the `kernel_signatures` array used `kind_none` as a delimiter between signatures of different kernels. The `kernel_signature_start` array's values were computed with a `+ 1` to account for this. Then one day the delimiter was removed but the `+ 1` remained. It wasn't noticed that the values were off by 1 because `kernel_signature_start` isn't being used anymore anyway. Therefore in this change, we simply remove it.

GH issue #2490