### PR TITLE
[NFC][LIT] Temporary disable function pointers as they hang on L0

### DIFF
--- a/sycl/test/function-pointers/fp-as-kernel-arg.cpp
+++ b/sycl/test/function-pointers/fp-as-kernel-arg.cpp
@@ -1,6 +1,7 @@
 // UNSUPPORTED: windows
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || level_zero
 // CUDA does not support the function pointer as kernel argument extension.
+// Hangs on level zero
 
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out

--- a/sycl/test/function-pointers/pass-fp-through-buffer.cpp
+++ b/sycl/test/function-pointers/pass-fp-through-buffer.cpp
@@ -1,6 +1,7 @@
 // UNSUPPORTED: windows
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || level_zero
 // CUDA does not support the function pointer as kernel argument extension.
+// Hangs on level zero
 
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out


### PR DESCRIPTION
It seems LIT tests for function pointers hangs on L0. Root cause is not clear, I suggest disabling them to stabilize pre-commits.
Re-run pre-commit on linux ~5 times, all were successful.
