### PR TITLE
[SYCL] Fix warning caused by [[nodiscard]] attribute

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -269,8 +269,7 @@ void Scheduler::lockSharedTimedMutex(
   // access occurs after shared access.
   // TODO: after switching to C++17, change std::shared_timed_mutex to
   // std::shared_mutex and use std::lock_guard here both for Windows and Linux.
-  while (!Lock.owns_lock()) {
-    Lock.try_lock_for(std::chrono::milliseconds(10));
+  while (!Lock.try_lock_for(std::chrono::milliseconds(10))) {
     // Without yield while loop acts like endless while loop and occupies the
     // whole CPU when multiple command groups are created in multiple host
     // threads


### PR DESCRIPTION
try_lock_for method is marked with [[nodiscard]] attribute which means
that its result can't be discarded. Discarding the result causes warning
which turns into error in -Werror mode causing build failure.