### PR TITLE
[SYCL] Refix problem in 1291215b

### DIFF
--- a/buildbot/dependency.py
+++ b/buildbot/dependency.py
@@ -58,7 +58,7 @@ def do_dependency(args):
     # fetch and build OpenCL ICD loader
     icd_loader_dir = os.path.join(args.obj_dir, "OpenCL-ICD-Loader")
     if not os.path.isdir(icd_loader_dir):
-        clone_cmd = ["git", "clone", "https://github.com/KhronosGroup/OpenCL-ICD-Loader", "OpenCL-ICD-Loader", "-b", "98ca71fb9f8484f1cd1999f55224bf9e8d18693b"]
+        clone_cmd = ["git", "clone", "https://github.com/KhronosGroup/OpenCL-ICD-Loader", "OpenCL-ICD-Loader"]
 
         subprocess.check_call(clone_cmd, cwd=args.obj_dir)
     else:

--- a/buildbot/dependency.py
+++ b/buildbot/dependency.py
@@ -58,7 +58,8 @@ def do_dependency(args):
     # fetch and build OpenCL ICD loader
     icd_loader_dir = os.path.join(args.obj_dir, "OpenCL-ICD-Loader")
     if not os.path.isdir(icd_loader_dir):
-        clone_cmd = ["git", "clone", "https://github.com/KhronosGroup/OpenCL-ICD-Loader", "OpenCL-ICD-Loader"]
+        clone_cmd = ["git", "clone", "https://github.com/KhronosGroup/OpenCL-ICD-Loader", "OpenCL-ICD-Loader", "-b", "98ca71fb9f8484f1cd1999f55224bf9e8d18693b"]
+
         subprocess.check_call(clone_cmd, cwd=args.obj_dir)
     else:
         fetch_cmd = ["git", "pull", "--ff", "--ff-only", "origin"]
@@ -104,7 +105,8 @@ def main():
 
     print("args:{}".format(args))
 
-    return do_dependency(args)
+    # All dependencies are downloaded and configured as part of the build
+    return True
 
 if __name__ == "__main__":
     ret = main()

--- a/buildbot/dependency.py
+++ b/buildbot/dependency.py
@@ -58,7 +58,9 @@ def do_dependency(args):
     # fetch and build OpenCL ICD loader
     icd_loader_dir = os.path.join(args.obj_dir, "OpenCL-ICD-Loader")
     if not os.path.isdir(icd_loader_dir):
-        clone_cmd = ["git", "clone", "https://github.com/KhronosGroup/OpenCL-ICD-Loader", "OpenCL-ICD-Loader"]
+        clone_cmd = ["git", "clone",
+                     "https://github.com/KhronosGroup/OpenCL-ICD-Loader",
+                     "OpenCL-ICD-Loader", "-b", "v2020.06.16"]
 
         subprocess.check_call(clone_cmd, cwd=args.obj_dir)
     else:
@@ -105,8 +107,7 @@ def main():
 
     print("args:{}".format(args))
 
-    # All dependencies are downloaded and configured as part of the build
-    return True
+    return do_dependency(args)
 
 if __name__ == "__main__":
     ret = main()

--- a/opencl-aot/CMakeLists.txt
+++ b/opencl-aot/CMakeLists.txt
@@ -48,7 +48,7 @@ if (NOT OpenCL_LIBRARIES)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/icd_build)
     ExternalProject_Add(opencl-icd
             GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
-            GIT_TAG origin/master
+            GIT_TAG v2020.06.16
             SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL/icd"
             BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/icd_build"
             CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -100,7 +100,7 @@ if( NOT OpenCL_INCLUDE_DIRS )
   endif()
   ExternalProject_Add(ocl-headers
     GIT_REPOSITORY    https://github.com/KhronosGroup/OpenCL-Headers.git
-    GIT_TAG           98ca71fb9f8484f1cd1999f55224bf9e8d18693b
+    GIT_TAG           origin/master
     UPDATE_DISCONNECTED ${SYCL_EP_OCL_HEADERS_SKIP_AUTO_UPDATE}
     SOURCE_DIR        ${OpenCL_INCLUDE_DIRS}
     CONFIGURE_COMMAND ""
@@ -144,7 +144,7 @@ if( NOT OpenCL_LIBRARIES )
   endif()
   ExternalProject_Add(ocl-icd
     GIT_REPOSITORY    https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
-    GIT_TAG           origin/master
+    GIT_TAG           98ca71fb9f8484f1cd1999f55224bf9e8d18693b
     UPDATE_DISCONNECTED ${SYCL_EP_OCL_ICD_SKIP_AUTO_UPDATE}
     SOURCE_DIR        ${OpenCL_ICD_LOADER_SOURCE_DIR}
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/icd_build"

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -144,7 +144,7 @@ if( NOT OpenCL_LIBRARIES )
   endif()
   ExternalProject_Add(ocl-icd
     GIT_REPOSITORY    https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
-    GIT_TAG           98ca71fb9f8484f1cd1999f55224bf9e8d18693b
+    GIT_TAG           v2020.06.16
     UPDATE_DISCONNECTED ${SYCL_EP_OCL_ICD_SKIP_AUTO_UPDATE}
     SOURCE_DIR        ${OpenCL_ICD_LOADER_SOURCE_DIR}
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/icd_build"


### PR DESCRIPTION
Windows build failure is introduced in remote repository impacting our CI (KhronosGroup/OpenCL-ICD-Loader@97f0eb5).
Make our CI to use release version of OpenCL ICD loader.