### PR TITLE
[SYCL] Diagnose LLVM memset that can't convert to SPIR-V

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -2244,7 +2244,10 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
     }
     Value *Len = MSI->getLength();
     if (!isa<ConstantInt>(Len)) {
-      assert(!"Can't translate llvm.memset with non-const `length` argument");
+      BM->getErrorLog().checkError(
+          isa<ConstantInt>(Len), SPIRVEC_InvalidFunctionCall,
+          toString(II) +
+              "\nCan't translate llvm.memset with non-const `length` argument");
       return nullptr;
     }
     uint64_t NumElements = static_cast<ConstantInt *>(Len)->getZExtValue();

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -2247,7 +2247,7 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
       BM->getErrorLog().checkError(
           isa<ConstantInt>(Len), SPIRVEC_InvalidFunctionCall,
           toString(II) +
-              "\nCan't translate llvm.memset with non-const `length` argument");
+              "\nTranslation of llvm.memset requires a non-const `length` argument");
       return nullptr;
     }
     uint64_t NumElements = static_cast<ConstantInt *>(Len)->getZExtValue();

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -2246,8 +2246,8 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
     if (!isa<ConstantInt>(Len)) {
       BM->getErrorLog().checkError(
           isa<ConstantInt>(Len), SPIRVEC_InvalidFunctionCall,
-          toString(II) +
-              "\nTranslation of llvm.memset requires a non-const `length` argument");
+          toString(II) + "\nTranslation of llvm.memset requires a non-const "
+                         "`length` argument");
       return nullptr;
     }
     uint64_t NumElements = static_cast<ConstantInt *>(Len)->getZExtValue();

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -2246,7 +2246,7 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
     if (!isa<ConstantInt>(Len)) {
       BM->getErrorLog().checkError(
           isa<ConstantInt>(Len), SPIRVEC_InvalidFunctionCall,
-          toString(II) + "\nTranslation of llvm.memset requires a non-const "
+          toString(II) + "\nTranslation of llvm.memset requires a const "
                          "`length` argument");
       return nullptr;
     }

--- a/llvm-spirv/test/negative/llvm.memset.ll
+++ b/llvm-spirv/test/negative/llvm.memset.ll
@@ -2,7 +2,7 @@
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidFunctionCall: Unexpected llvm intrinsic:
-; CHECK: Translation of llvm.memset requires a non-const `length` argument
+; CHECK: Translation of llvm.memset requires a const `length` argument
 
 target triple = "spir"
 

--- a/llvm-spirv/test/negative/llvm.memset.ll
+++ b/llvm-spirv/test/negative/llvm.memset.ll
@@ -1,0 +1,14 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
+
+; CHECK: InvalidFunctionCall: Unexpected llvm intrinsic:
+; CHECK: Translation of llvm.memset requires a non-const `length` argument
+
+target triple = "spir"
+
+define void @spir_func(i8* %ptr, i32 %length) {
+  call void @llvm.memset.p0i8.i32(i8* %ptr, i8 42, i32 %length, i1 false)
+  ret void
+}
+
+declare void @llvm.memset.p0i8.i32(i8*, i8, i32, i1)


### PR DESCRIPTION
There is no direct mapping of @llvm.memset.* intrinsic to SPIR-V. Special cases such as compile-time constant value and length have been made to work, but outside those limitations, there's no conversion and it currently fails in an assertion. This PR merely changes the assertion failure into a diagnostic message that -- hopefully -- will give the user a better idea of what the issue is.

I debated whether to put this diagnostic in SPIRVWriter.cpp like I did, vs somewhere else such as SemaSYCL.cpp. SemaSYCL has more source context, but the LLVM IR it generates is technically fine and correct, and it's only when and if we convert that LLVM IR to SPIR-V IR that we encounter an issue. Thoughts, opinions welcome. I looked to surrounding code for the correct way to emit a diagnositic in SPIRVWriter.cpp.

Before this PR:

    $ cat test.cpp

        #include <CL/sycl.hpp>

        SYCL_EXTERNAL
            void fn(int* ptr, int size) {
                ::std::memset(ptr, 0, sizeof(int) * size);
            }

    $ clang++ -fsycl test.cpp

        Stack dump:
        0.  Program arguments: /home/ubuntu/workspace/build/bin/llvm-spirv -o /tmp/test-7b6a5e-0a2800.spv -spirv-max-version=1.1 -spirv-debug-info-version=legacy -spirv-ext=+all,-SPV_INTEL_usm_storage_classes /tmp/test-d527b3.bc 
        1.  Running pass 'LLVMToSPIRV' on module '/tmp/test-d527b3.bc'.
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x5ab6dc)[0x55a02c0166dc]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x5a95a4)[0x55a02c0145a4]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x5a96f3)[0x55a02c0146f3]
        /lib/x86_64-linux-gnu/libpthread.so.0(+0x128a0)[0x7fbda5f638a0]
        /lib/x86_64-linux-gnu/libc.so.6(gsignal+0xc7)[0x7fbda4e18f47]
        /lib/x86_64-linux-gnu/libc.so.6(abort+0x141)[0x7fbda4e1a8b1]
        /lib/x86_64-linux-gnu/libc.so.6(+0x3042a)[0x7fbda4e0a42a]
        /lib/x86_64-linux-gnu/libc.so.6(+0x304a2)[0x7fbda4e0a4a2]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x1886b2)[0x55a02bbf36b2]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x188b27)[0x55a02bbf3b27]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x18b492)[0x55a02bbf6492]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x190966)[0x55a02bbfb966]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x193270)[0x55a02bbfe270]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x1933f3)[0x55a02bbfe3f3]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x4e0b86)[0x55a02bf4bb86]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0x1937e2)[0x55a02bbfe7e2]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0xda8da)[0x55a02bb458da]
        /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xe7)[0x7fbda4dfbb97]
        /home/ubuntu/workspace/build/bin/llvm-spirv(+0xec03a)[0x55a02bb5703a]
        llvm-foreach: Aborted (core dumped)
        clang-12: error: llvm-spirv command failed with exit code 1 (use -v to see invocation)

After this PR:

    $ clang++ -fsycl test.cpp

        InvalidFunctionCall: Unexpected llvm intrinsic:
           call void @llvm.memset.p4i8.i64(i8 addrspace(4)* align 4 %0, i8 42, i64 %mul, i1 false)
        Translation of llvm.memset requires a const `length` argument
        llvm-foreach: 
        clang-12: error: llvm-spirv command failed with exit code 1 (use -v to see invocation)

Alexey Sachkov mentioned the separate PR https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/696 that adds LLVM memset conversion support to SPIR-V. That PR would make this one redundant. However, it's gone a month without activity and I can't predict how long before that PR gets merged, so in the meantime, still submitting this PR.