### PR TITLE
[SYCL] Emit kernel args size warning for real sycl headers

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11005,7 +11005,7 @@ def err_sycl_restrict : Error<
   "}0">;
 def warn_sycl_kernel_too_big_args : Warning<
   "size of kernel arguments (%0 bytes) may exceed the supported maximum "
-  "of %1 bytes on some devices">, InGroup<SyclStrict>;
+  "of %1 bytes on some devices">, InGroup<SyclStrict>, ShowInSystemHeader;
 def err_sycl_virtual_types : Error<
   "No class with a vtable can be used in a SYCL kernel or any code included in the kernel">;
 def note_sycl_recursive_function_declared_here: Note<"function implemented using recursion declared here">;

--- a/sycl/test/basic_tests/args-size-overflow.cpp
+++ b/sycl/test/basic_tests/args-size-overflow.cpp
@@ -1,0 +1,22 @@
+// RUN: %clangxx -fsycl -fsycl-device-only -Xclang -verify -Wsycl-strict %s -fsyntax-only
+
+#include <CL/sycl.hpp>
+class Foo;
+
+using namespace cl::sycl;
+
+// expected-warning@../../include/sycl/CL/sycl/handler.hpp:919 {{size of kernel arguments (8068 bytes) may exceed the supported maximum of 2048 bytes on some devices}}
+
+int main() {
+  struct S {
+    int A;
+    int B;
+    int Array[2015];
+  } Args;
+  queue myQueue;
+  myQueue.submit([&](handler &cgh) {
+    // expected-note@+1 {{in instantiation of function template specialization 'cl::sycl::handler::single_task}}
+    cgh.single_task<class kernel>([=]() { (void)Args; });
+  });
+  return 0;
+}

--- a/sycl/test/basic_tests/args-size-overflow.cpp
+++ b/sycl/test/basic_tests/args-size-overflow.cpp
@@ -1,7 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -Xclang -verify -Wsycl-strict %s -fsyntax-only
 
 #include <CL/sycl.hpp>
-class Foo;
 
 using namespace cl::sycl;
 


### PR DESCRIPTION
It turned out that real sycl headers are included as "system" headers
and the actual warning points to function defined there, so the warning
about kernel arguments size wasn't emitted.