### PR TITLE
[SYCL][CUDA] Eliminate incorrect assertions and enable cuda usm tests

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4133,7 +4133,7 @@ pi_result cuda_piextUSMHostAlloc(void **result_ptr, pi_context context,
   } catch (pi_result error) {
     result = error;
   }
-  assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0);
+
   return result;
 }
 
@@ -4154,7 +4154,7 @@ pi_result cuda_piextUSMDeviceAlloc(void **result_ptr, pi_context context,
   } catch (pi_result error) {
     result = error;
   }
-  assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0);
+
   return result;
 }
 
@@ -4176,7 +4176,7 @@ pi_result cuda_piextUSMSharedAlloc(void **result_ptr, pi_context context,
   } catch (pi_result error) {
     result = error;
   }
-  assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0);
+
   return result;
 }
 

--- a/sycl/test/basic_tests/queue/queue_parallel_for_generic.cpp
+++ b/sycl/test/basic_tests/queue/queue_parallel_for_generic.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/inorder_queue/in_order_dmemll.cpp
+++ b/sycl/test/inorder_queue/in_order_dmemll.cpp
@@ -2,7 +2,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 //
-// XFAIL: cuda
 //==----------- ordered_dmemll.cpp - Device Memory Linked List test --------==//
 // It uses an ordered queue where explicit waiting is not necessary between
 // kernels

--- a/sycl/test/usm/allocator_equal.cpp
+++ b/sycl/test/usm/allocator_equal.cpp
@@ -1,7 +1,3 @@
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/badmalloc.cpp
+++ b/sycl/test/usm/badmalloc.cpp
@@ -1,8 +1,4 @@
 // UNSUPPORTED: windows
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out

--- a/sycl/test/usm/depends_on.cpp
+++ b/sycl/test/usm/depends_on.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/dmemll.cpp
+++ b/sycl/test/usm/dmemll.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/fill.cpp
+++ b/sycl/test/usm/fill.cpp
@@ -5,8 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out

--- a/sycl/test/usm/hmemll.cpp
+++ b/sycl/test/usm/hmemll.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/memadvise.cpp
+++ b/sycl/test/usm/memadvise.cpp
@@ -1,7 +1,3 @@
-// XFAIL: cuda
-// SYCL runtime and piextUSM*Alloc functions for CUDA not behaving as described
-// in: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/memcpy.cpp
+++ b/sycl/test/usm/memcpy.cpp
@@ -5,10 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out

--- a/sycl/test/usm/memset.cpp
+++ b/sycl/test/usm/memset.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/mixed.cpp
+++ b/sycl/test/usm/mixed.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/mixed2.cpp
+++ b/sycl/test/usm/mixed2.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/mixed2template.cpp
+++ b/sycl/test/usm/mixed2template.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/mixed_queue.cpp
+++ b/sycl/test/usm/mixed_queue.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/pfor_flatten.cpp
+++ b/sycl/test/usm/pfor_flatten.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// CUDA does not support the unnamed lambda extension.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-unnamed-lambda -fsycl-dead-args-optimization %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/pfor_flatten_range_shortcut.cpp
+++ b/sycl/test/usm/pfor_flatten_range_shortcut.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// CUDA does not support the unnamed lambda extension.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  -fsycl-unnamed-lambda %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/sycl/test/usm/queue_wait.cpp
+++ b/sycl/test/usm/queue_wait.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/usm/smemll.cpp
+++ b/sycl/test/usm/smemll.cpp
@@ -1,8 +1,3 @@
-// XFAIL: cuda
-// piextUSM*Alloc functions for CUDA are not behaving as described in
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/USM.adoc
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out


### PR DESCRIPTION
Cuda plugin basically had divide by 0 assertions that weren't necessary.

Signed-off-by: James Brodman <james.brodman@intel.com>