### PR TITLE
[SYCL] Make ESIMD on-device tests require linux,gpu,opencl.

### DIFF
--- a/sycl/test/esimd/on-device/BitonicSortK.cpp
+++ b/sycl/test/esimd/on-device/BitonicSortK.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out
 

--- a/sycl/test/esimd/on-device/BitonicSortKv2.cpp
+++ b/sycl/test/esimd/on-device/BitonicSortKv2.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out

--- a/sycl/test/esimd/on-device/accessor.cpp
+++ b/sycl/test/esimd/on-device/accessor.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl -D_CRT_SECURE_NO_WARNINGS=1 %s -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out
 

--- a/sycl/test/esimd/on-device/histogram.cpp
+++ b/sycl/test/esimd/on-device/histogram.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out

--- a/sycl/test/esimd/on-device/histogram_256_slm.cpp
+++ b/sycl/test/esimd/on-device/histogram_256_slm.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out
 

--- a/sycl/test/esimd/on-device/histogram_2d.cpp
+++ b/sycl/test/esimd/on-device/histogram_2d.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out

--- a/sycl/test/esimd/on-device/kmeans/kmeans.cpp
+++ b/sycl/test/esimd/on-device/kmeans/kmeans.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -I%S/.. -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out %S/points.big.json
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out %S/points.big.json

--- a/sycl/test/esimd/on-device/linear/linear.cpp
+++ b/sycl/test/esimd/on-device/linear/linear.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -I%S/.. -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out %S/linear_in.bmp %S/linear_gold_hw.bmp
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out %S/linear_in.bmp %S/linear_gold_hw.bmp

--- a/sycl/test/esimd/on-device/mandelbrot/mandelbrot.cpp
+++ b/sycl/test/esimd/on-device/mandelbrot/mandelbrot.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -I%S/.. -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out %S/output.ppm %S/golden_hw.ppm
 

--- a/sycl/test/esimd/on-device/matrix_transpose.cpp
+++ b/sycl/test/esimd/on-device/matrix_transpose.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out
 

--- a/sycl/test/esimd/on-device/matrix_transpose_glb.cpp
+++ b/sycl/test/esimd/on-device/matrix_transpose_glb.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out
 // XFAIL: linux

--- a/sycl/test/esimd/on-device/matrix_transpose_usm.cpp
+++ b/sycl/test/esimd/on-device/matrix_transpose_usm.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out

--- a/sycl/test/esimd/on-device/slm_barrier.cpp
+++ b/sycl/test/esimd/on-device/slm_barrier.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out
 

--- a/sycl/test/esimd/on-device/test_id_3d.cpp
+++ b/sycl/test/esimd/on-device/test_id_3d.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out

--- a/sycl/test/esimd/on-device/vadd_1d.cpp
+++ b/sycl/test/esimd/on-device/vadd_1d.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out
 

--- a/sycl/test/esimd/on-device/vadd_2d.cpp
+++ b/sycl/test/esimd/on-device/vadd_2d.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out

--- a/sycl/test/esimd/on-device/vadd_usm.cpp
+++ b/sycl/test/esimd/on-device/vadd_usm.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO enable on Windows
-// REQUIRES: linux
-// REQUIRES: gpu
+// TODO enable on Windows and Level Zero
+// REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
This is the only SW/HW combination ESIMD is supported on for now.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>