### PR TITLE
[SYCL][DOC] Fix path to FPGA device selector in doc

### DIFF
--- a/sycl/doc/extensions/IntelFPGA/FPGASelector.md
+++ b/sycl/doc/extensions/IntelFPGA/FPGASelector.md
@@ -1,6 +1,6 @@
 # FPGA selector
 
-Intel FPGA users can use header file: `#include<CL/sycl/intel/fpga_device_selector.hpp>` to simplify their code
+Intel FPGA users can use header file: `#include<CL/sycl/INTEL/fpga_device_selector.hpp>` to simplify their code
 when they want to specify FPGA hardware device or FPGA emulation device.
 
 ## Implementation
@@ -10,18 +10,18 @@ one FPGA board installed in their system (one device per platform).
 
 ## Usage: select FPGA hardware device
 ```c++
-#include <CL/sycl/intel/fpga_device_selector.hpp>
+#include <CL/sycl/INTEL/fpga_device_selector.hpp>
 ...
 // force FPGA hardware device
-cl::sycl::queue deviceQueue{cl::sycl::intel::fpga_selector{}};
+cl::sycl::queue deviceQueue{cl::sycl::INTEL::fpga_selector{}};
 ...
 ```
 
 ## Usage: select FPGA emulator device
 ```c++
-#include <CL/sycl/intel/fpga_device_selector.hpp>
+#include <CL/sycl/INTEL/fpga_device_selector.hpp>
 ...
 // force FPGA emulation device
-cl::sycl::queue deviceQueue{cl::sycl::intel::fpga_emulator_selector{}};
+cl::sycl::queue deviceQueue{cl::sycl::INTEL::fpga_emulator_selector{}};
 ...
 ```


### PR DESCRIPTION
The documentation for the FPGA Selector points now to the uppercase INTEL directory instead of lowercase.