### PR TITLE
[SYCL] handle wrap around in HW timestamp

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3111,7 +3111,7 @@ pi_result piEventGetProfilingInfo(pi_event Event, pi_profiling_info ParamName,
     if (ContextEndTime <= ContextStartTime) {
       pi_device Device = Event->Context->Devices[0];
       const uint64_t TimestampMaxValue =
-          ~(-1LL << Device->ZeDeviceProperties.kernelTimestampValidBits);
+          (1LL << Device->ZeDeviceProperties.kernelTimestampValidBits) - 1;
       ContextEndTime += TimestampMaxValue - ContextStartTime;
     }
     ContextEndTime *= ZeTimerResolution;


### PR DESCRIPTION
More details here: https://one-api.gitlab-pages.devtools.intel.com/level_zero/core/PROG.html#kernel-timestamp-events:
~~~
Since these counters are only 32bits, the application must detect and handle counter wrapping when calculating execution time
~~~
Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>