### PR TITLE
[SYCL] Relax test to work in Win32 environment.

### DIFF
--- a/clang/test/SemaSYCL/array-kernel-param.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param.cpp
@@ -337,7 +337,7 @@ int main() {
 // CHECK-NEXT: OpaqueValueExpr {{.*}} 'int [2][3]' lvalue
 // CHECK-NEXT: MemberExpr {{.*}} 'int [2][3]' lvalue .
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_' '__wrapper_class'
-// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned long
+// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'int' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <ArrayToPointerDecay>
@@ -347,8 +347,8 @@ int main() {
 // CHECK-NEXT: OpaqueValueExpr {{.*}} 'int [2][3]' lvalue
 // CHECK-NEXT: MemberExpr {{.*}} 'int [2][3]' lvalue .
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_' '__wrapper_class'
-// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned long
-// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned long
+// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned
+// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned
 
 // Check kernel_G parameters.
 // CHECK: FunctionDecl {{.*}}kernel_G{{.*}} 'void (__wrapper_class)'
@@ -369,4 +369,4 @@ int main() {
 // CHECK-NEXT: OpaqueValueExpr {{.*}} 'foo2 [2]' lvalue
 // CHECK-NEXT: MemberExpr {{.*}} 'foo2 [2]' lvalue .
 // CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_' '__wrapper_class'
-// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned long
+// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned


### PR DESCRIPTION
Our downstream runs this test on a 32 bit windwos machine, so relax the
test slightly to allow it to pass there.

The problem is that the type of 'size_t' (the array index type) is
different (it is unsigned int instead of unsigned long/unsigned long
long), so this changes the test to allow all 3.