### PR TITLE
[WIP][SYCL] update lit test with the target

### DIFF
--- a/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -fsycl-device-only %s -S -emit-llvm -O0 -g -o - | FileCheck %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -fsycl-device-only %s -Xclang -S -emit-llvm -O0 -g -o - | FileCheck %s
 //
 // Verify the SYCL kernel routine is marked artificial and has the
 // expected source correlation.


### PR DESCRIPTION
The lit test runs on a 32 bit windwos machine in downstream and causes
qssertion failed: HT.getArch() == llvm::Triple::x86_64 && "Unsupported host architecture"
inside Targets.cpp file.

The patch updates this test to specify a target to fix the issue.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>