### PR TITLE
[SYCL] Expand release lit test to CPU and ACC

### DIFF
--- a/sycl/test/basic_tests/queue/release.cpp
+++ b/sycl/test/basic_tests/queue/release.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// REQUIRES: gpu
+// RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
 
 #include <CL/sycl.hpp>
 int main() {


### PR DESCRIPTION
memory release lit test should be run on CPU as well as ACC

Signed-off-by: Chris Perkins <chris.perkins@intel.com>