### PR TITLE
[SYCL] [L0 PI] Added an assert when GlobalWorkOffset!=0

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2942,6 +2942,11 @@ piEnqueueKernelLaunch(pi_queue Queue, pi_kernel Kernel, pi_uint32 WorkDim,
   assert(Kernel);
   assert(Queue);
   assert((WorkDim > 0) && (WorkDim < 4));
+  if (GlobalWorkOffset != NULL) {
+    for (pi_uint32 i = 0; i < WorkDim; i++) {
+      assert(GlobalWorkOffset[i] == 0);
+    }
+  }
 
   ze_group_count_t ZeThreadGroupDimensions{1, 1, 1};
   uint32_t WG[3];

--- a/sycl/test/basic_tests/free_function_queries/free_function_queries.cpp
+++ b/sycl/test/basic_tests/free_function_queries/free_function_queries.cpp
@@ -4,6 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// TODO: Support global work offset on Level Zero.
+// XFAIL: level_zero
+
 //==- free_function_queries.cpp - SYCL free function queries test -=//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
GlobalWorkOffset is not currently supported in Level Zero.
Now the function will assert if someone tries to use it.

Signed-off-by: Gail Lyons <gail.lyons@intel.com>