### PR TITLE
[SYCL] Fix test failure due to size discrepancy in 32 and 64 bit environment

### DIFF
--- a/clang/test/SemaSYCL/args-size-overflow.cpp
+++ b/clang/test/SemaSYCL/args-size-overflow.cpp
@@ -10,7 +10,7 @@ queue q;
 using Accessor =
     accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer>;
 
-// expected-warning@Inputs/sycl.hpp:220 {{size of kernel arguments (7994 bytes) may exceed the supported maximum of 2048 bytes on some devices}}
+// expected-warning-re@Inputs/sycl.hpp:220 {{size of kernel arguments ({{.*}} bytes) may exceed the supported maximum of 2048 bytes on some devices}}
 
 void use() {
   struct S {

--- a/clang/test/SemaSYCL/args-size-overflow.cpp
+++ b/clang/test/SemaSYCL/args-size-overflow.cpp
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -Wsycl-strict -sycl-std=2020 -verify %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64 -internal-isystem %S/Inputs -fsyntax-only -Wsycl-strict -sycl-std=2020 -verify %s -DSPIR64
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir -internal-isystem %S/Inputs -fsyntax-only -Wsycl-strict -sycl-std=2020 -verify %s -DSPIR32
 
 #include "sycl.hpp"
 class Foo;
@@ -9,8 +10,11 @@ queue q;
 
 using Accessor =
     accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer>;
-
-// expected-warning-re@Inputs/sycl.hpp:220 {{size of kernel arguments ({{.*}} bytes) may exceed the supported maximum of 2048 bytes on some devices}}
+#ifdef SPIR64
+// expected-warning@Inputs/sycl.hpp:220 {{size of kernel arguments (7994 bytes) may exceed the supported maximum of 2048 bytes on some devices}}
+#elif SPIR32
+// expected-warning@Inputs/sycl.hpp:220 {{size of kernel arguments (7986 bytes) may exceed the supported maximum of 2048 bytes on some devices}}
+#endif
 
 void use() {
   struct S {


### PR DESCRIPTION
Fix test failure due to size discrepancy of pointers in 32 and 64 bit environment. 


Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>