### PR TITLE
[SYCL] Add KernelNameTypeVisitor validation check

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2912,8 +2912,8 @@ public:
     QualType T = TA.getAsType();
     if (const auto *ET = T->getAs<EnumType>())
       VisitEnumType(ET);
-  else
-    Visit(T);
+    else
+      Visit(T);
   }
 
   void VisitIntegralTemplateArgument(const TemplateArgument &TA) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2845,11 +2845,9 @@ public:
   bool isValid() { return !IsInvalid; }
 
   bool Visit(QualType T) {
-    if (T.isNull())
-      return false;
+    assert(!T.isNull() && "KernelNameType cannot be null");
     const CXXRecordDecl *RD = T->getAsCXXRecordDecl();
-    if (!RD)
-      return false;
+    assert(RD && "KernelNameType is not a record");
     // If KernelNameType has template args visit each template arg via
     // ConstTemplateArgumentVisitor
     if (const auto *TSD = dyn_cast<ClassTemplateSpecializationDecl>(RD)) {
@@ -2864,8 +2862,7 @@ public:
   }
 
   bool Visit(const TemplateArgument &TA) {
-    if (TA.isNull())
-      return false;
+    assert(!TA.isNull() && "TemplateArgument cannot be null");
     return InnerTAVisitor::Visit(TA);
   }
 
@@ -2917,8 +2914,7 @@ public:
     QualType T = TA.getAsType();
     if (const auto *ET = T->getAs<EnumType>())
       return VisitEnumType(ET);
-    else
-      return Visit(T);
+    return Visit(T);
   }
 
   bool VisitIntegralTemplateArgument(const TemplateArgument &TA) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2912,6 +2912,7 @@ public:
     QualType T = TA.getAsType();
     if (const auto *ET = T->getAs<EnumType>())
       VisitEnumType(ET);
+  else
     Visit(T);
   }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2984,10 +2984,12 @@ void Sema::CheckSYCLKernelCall(FunctionDecl *KernelFunc, SourceRange CallLoc,
 
   KernelObjVisitor Visitor{*this};
   SYCLKernelNameTypeVisitor KernelNameTypeVisitor(*this, Args[0]->getExprLoc());
+
+  DiagnosingSYCLKernel = true;
+
   // Emit diagnostics for SYCL device kernels only
   if (LangOpts.SYCLIsDevice)
     KernelNameTypeVisitor.Visit(KernelNameType);
-  DiagnosingSYCLKernel = true;
   Visitor.VisitRecordBases(KernelObj, FieldChecker, UnionChecker, DecompMarker);
   Visitor.VisitRecordFields(KernelObj, FieldChecker, UnionChecker,
                             DecompMarker);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2845,9 +2845,11 @@ public:
   bool isValid() { return !IsInvalid; }
 
   bool Visit(QualType T) {
-    assert(!T.isNull() && "KernelNameType cannot be null");
+    if (T.isNull())
+      return false;
     const CXXRecordDecl *RD = T->getAsCXXRecordDecl();
-    assert(RD && "KernelNameType is not a record");
+    if (!RD)
+      return false;
     // If KernelNameType has template args visit each template arg via
     // ConstTemplateArgumentVisitor
     if (const auto *TSD = dyn_cast<ClassTemplateSpecializationDecl>(RD)) {
@@ -2862,7 +2864,8 @@ public:
   }
 
   bool Visit(const TemplateArgument &TA) {
-    assert(!TA.isNull() && "TemplateArgument cannot be null");
+    if (TA.isNull())
+      return false;
     return InnerTAVisitor::Visit(TA);
   }
 


### PR DESCRIPTION
This patch is a follow-up to this [PR](https://github.com/intel/llvm/pull/2474)
It sets the kernel invocation function invalid, if the KernelNameTypeVisitor fails validating the kernel name type.