### PR TITLE
[SYCL] Align image class constructors with the SYCL spec

### DIFF
--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -155,7 +155,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range,
-        typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Pitch,
@@ -167,7 +167,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range,
-        typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Pitch,

--- a/sycl/test/basic_tests/image.cpp
+++ b/sycl/test/basic_tests/image.cpp
@@ -83,7 +83,7 @@ int main() {
     TestQueue Q{sycl::default_selector()};
     Q.submit([&](sycl::handler &CGH) {
       auto ImgAcc = Img.get_access<sycl::float4, SYCLRead>(CGH);
-      CGH.single_task<class ConstTestPitch>([=]() { ImgAcc.get_range(); });
+      CGH.single_task<class ConstTestPitch>([=] { ImgAcc.get_range(); });
     });
   }
 

--- a/sycl/test/basic_tests/image.cpp
+++ b/sycl/test/basic_tests/image.cpp
@@ -76,6 +76,17 @@ int main() {
     });
   }
 
+  {
+    const sycl::range<1> ImgPitch(4 * 4 * 4 * 2);
+    sycl::image<2> Img(Img1HostData.data(), ChanOrder, ChanType, Img1Size,
+                       ImgPitch);
+    TestQueue Q{sycl::default_selector()};
+    Q.submit([&](sycl::handler &CGH) {
+      auto ImgAcc = Img.get_access<sycl::float4, SYCLRead>(CGH);
+      CGH.single_task<class ConstTestPitch>([=]() { ImgAcc.get_range(); });
+    });
+  }
+
   // image with write accessor to it in kernel
   {
     int NX = 32;


### PR DESCRIPTION
Enable image construction with initialization data and const pitch
parameters.

Fixes #2598.