### PR TITLE
[SYCL] Fix dependency for SYCL add_sycl_executable macro

### DIFF
--- a/sycl/cmake/modules/AddSYCLExecutable.cmake
+++ b/sycl/cmake/modules/AddSYCLExecutable.cmake
@@ -34,7 +34,7 @@ macro(add_sycl_executable ARG_TARGET_NAME)
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_TARGET_NAME}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND_EXPAND_LISTS)
-  add_dependencies(${ARG_TARGET_NAME}_exec sycl clang)
+  add_dependencies(${ARG_TARGET_NAME}_exec sycl-toolchain)
   foreach(_lib in ${ARG_LIBRARIES})
     if (TARGET _lib)
       add_dependencies(${ARG_TARGET_NAME}_exec _lib)


### PR DESCRIPTION
Compiler toolchain includes more tools in addition to clang and sycl
library.