### PR TITLE
[SYCL] Change in buffer management for integrated GPUs

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1861,34 +1861,50 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
   assert(RetMem);
 
   void *Ptr;
+  ze_device_handle_t ZeDevice = Context->Devices[0]->ZeDevice;
 
-  ze_device_mem_alloc_desc_t ZeDeviceMemDesc = {};
-  ZeDeviceMemDesc.flags = 0;
-  ZeDeviceMemDesc.ordinal = 0;
+  // We treat integrated devices (physical memory shared with the CPU)
+  // differently from discrete devices (those with distinct memories).
+  // For integrated devices, allocating the buffer in host shared memory
+  // enables automatic access from the device, and makes copying
+  // unnecessary in the map/unmap operations. This improves performance.
+  bool DeviceIsIntegrated = Context->Devices.size() == 1 &&
+                            Context->Devices[0]->ZeDeviceProperties.flags &
+                                ZE_DEVICE_PROPERTY_FLAG_INTEGRATED;
 
-  if (Context->Devices.size() == 1) {
-    ZE_CALL(zeMemAllocDevice(Context->ZeContext, &ZeDeviceMemDesc, Size,
-                             1, // TODO: alignment
-                             Context->Devices[0]->ZeDevice, &Ptr));
+  if (DeviceIsIntegrated) {
+    ze_host_mem_alloc_desc_t ZeDesc = {};
+    ZeDesc.flags = 0;
+
+    ZE_CALL(zeMemAllocHost(Context->ZeContext, &ZeDesc, Size, 4096, &Ptr));
+
   } else {
-    ze_host_mem_alloc_desc_t ZeHostMemDesc = {};
-    ZeHostMemDesc.flags = 0;
-    ZE_CALL(zeMemAllocShared(Context->ZeContext, &ZeDeviceMemDesc,
-                             &ZeHostMemDesc, Size,
-                             1,       // TODO: alignment
-                             nullptr, // not bound to any device
+    ze_device_mem_alloc_desc_t ZeDesc = {};
+    ZeDesc.flags = 0;
+    ZeDesc.ordinal = 0;
+
+    ZE_CALL(zeMemAllocDevice(Context->ZeContext, &ZeDesc, Size, 4096, ZeDevice,
                              &Ptr));
   }
+  if (HostPtr) {
+    if ((Flags & PI_MEM_FLAGS_HOST_PTR_USE) != 0 ||
+        (Flags & PI_MEM_FLAGS_HOST_PTR_COPY) != 0) {
+      // Initialize the buffer with user data
+      if (DeviceIsIntegrated) {
+        // Do a host to host copy
+        memcpy(Ptr, HostPtr, Size);
+      } else {
 
-  if ((Flags & PI_MEM_FLAGS_HOST_PTR_USE) != 0 ||
-      (Flags & PI_MEM_FLAGS_HOST_PTR_COPY) != 0) {
-    // Initialize the buffer synchronously with immediate offload
-    ZE_CALL(zeCommandListAppendMemoryCopy(Context->ZeCommandListInit, Ptr,
-                                          HostPtr, Size, nullptr, 0, nullptr));
-  } else if (Flags == 0 || (Flags == PI_MEM_FLAGS_ACCESS_RW)) {
-    // Nothing more to do.
-  } else {
-    die("piMemBufferCreate: not implemented");
+        // Initialize the buffer synchronously with immediate offload
+        ZE_CALL(zeCommandListAppendMemoryCopy(Context->ZeCommandListInit, Ptr,
+                                              HostPtr, Size, nullptr, 0,
+                                              nullptr));
+      }
+    } else if (Flags == 0 || (Flags == PI_MEM_FLAGS_ACCESS_RW)) {
+      // Nothing more to do.
+    } else {
+      die("piMemBufferCreate: not implemented");
+    }
   }
 
   auto HostPtrOrNull =
@@ -3304,7 +3320,18 @@ pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
   for (uint32_t I = 0; I < NumEvents; I++) {
     ze_event_handle_t ZeEvent = EventList[I]->ZeEvent;
     zePrint("ZeEvent = %lx\n", pi_cast<std::uintptr_t>(ZeEvent));
-    ZE_CALL(zeEventHostSynchronize(ZeEvent, UINT32_MAX));
+
+    // If event comes from a Map operation in integrated device, then do
+    // sync and signaling on host
+    if (EventList[I]->CommandType == PI_COMMAND_TYPE_MEM_BUFFER_MAP) {
+      for (auto ZeWaitEvent : EventList[I]->waitEvents) {
+        if (ZeWaitEvent)
+          ZE_CALL(zeEventHostSynchronize(ZeWaitEvent, UINT32_MAX));
+      }
+      ZE_CALL(zeEventHostSignal(ZeEvent));
+    } else {
+      ZE_CALL(zeEventHostSynchronize(ZeEvent, UINT32_MAX));
+    }
 
     // NOTE: we are destroying associated command lists here to free
     // resources sooner in case RT is not calling piEventRelease soon enough.
@@ -3982,12 +4009,19 @@ piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer, pi_bool BlockingMap,
   // Lock automatically releases when this goes out of scope.
   std::lock_guard<std::mutex> lock(Queue->PiQueueMutex);
 
+  bool DeviceIsIntegrated = Queue->Device->ZeDeviceProperties.flags &
+                            ZE_DEVICE_PROPERTY_FLAG_INTEGRATED;
+
   // Get a new command list to be used on this call
   ze_command_list_handle_t ZeCommandList = nullptr;
   ze_fence_handle_t ZeFence = nullptr;
-  if (auto Res = Queue->Device->getAvailableCommandList(Queue, &ZeCommandList,
-                                                        &ZeFence))
-    return Res;
+  // We will be executing a copy on GPU for discrete devices only,
+  // so for integrated no command list is needed.
+  if (!DeviceIsIntegrated) {
+    if (auto Res = Queue->Device->getAvailableCommandList(Queue, &ZeCommandList,
+                                                          &ZeFence))
+      return Res;
+  }
 
   ze_event_handle_t ZeEvent = nullptr;
   if (Event) {
@@ -3999,40 +4033,38 @@ piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer, pi_bool BlockingMap,
     (*Event)->CommandType = PI_COMMAND_TYPE_MEM_BUFFER_MAP;
     (*Event)->ZeCommandList = ZeCommandList;
 
+    for (uint32_t i = 0; i < NumEventsInWaitList; i++) {
+      (*Event)->waitEvents.push_back(EventWaitList[i]->ZeEvent);
+    }
+
     ZeEvent = (*Event)->ZeEvent;
+  }
+
+  if (DeviceIsIntegrated) {
+    if (Buffer->MapHostPtr) {
+      *RetMap = Buffer->MapHostPtr + Offset;
+    } else {
+      *RetMap = pi_cast<char *>(Buffer->getZeHandle()) + Offset;
+    }
+
+    return Buffer->addMapping(*RetMap, Offset, Size);
   }
 
   ze_event_handle_t *ZeEventWaitList =
       _pi_event::createZeEventList(NumEventsInWaitList, EventWaitList);
 
-  ZE_CALL(zeCommandListAppendWaitOnEvents(ZeCommandList, NumEventsInWaitList,
-                                          ZeEventWaitList));
-
-  // TODO: Level Zero is missing the memory "mapping" capabilities, so we are
-  // left to doing new memory allocation and a copy (read).
-  //
-  // TODO: check if the input buffer is already allocated in shared
-  // memory and thus is accessible from the host as is. Can we get SYCL RT
-  // to predict/allocate in shared memory from the beginning?
   if (Buffer->MapHostPtr) {
-    // NOTE: borrowing below semantics from OpenCL as SYCL RT relies on it.
-    // It is also better for performance.
-    //
-    // "If the buffer object is created with CL_MEM_USE_HOST_PTR set in
-    // mem_flags, the following will be true:
-    // - The host_ptr specified in clCreateBuffer is guaranteed to contain the
-    //   latest bits in the region being mapped when the clEnqueueMapBuffer
-    //   command has completed.
-    // - The pointer value returned by clEnqueueMapBuffer will be derived from
-    //   the host_ptr specified when the buffer object is created."
     *RetMap = Buffer->MapHostPtr + Offset;
   } else {
     ze_host_mem_alloc_desc_t ZeDesc = {};
     ZeDesc.flags = 0;
-    ZE_CALL(zeMemAllocHost(Queue->Context->ZeContext, &ZeDesc, Size,
-                           1, // TODO: alignment
-                           RetMap));
+
+    ZE_CALL(
+        zeMemAllocHost(Queue->Context->ZeContext, &ZeDesc, Size, 4096, RetMap));
   }
+
+  ZE_CALL(zeCommandListAppendWaitOnEvents(ZeCommandList, NumEventsInWaitList,
+                                          ZeEventWaitList));
 
   ZE_CALL(zeCommandListAppendMemoryCopy(
       ZeCommandList, *RetMap, pi_cast<char *>(Buffer->getZeHandle()) + Offset,
@@ -4093,16 +4125,32 @@ pi_result piEnqueueMemUnmap(pi_queue Queue, pi_mem MemObj, void *MappedPtr,
   if (pi_result Res = MemObj->removeMapping(MappedPtr, MapInfo))
     return Res;
 
-  ZE_CALL(zeCommandListAppendMemoryCopy(
-      ZeCommandList, pi_cast<char *>(MemObj->getZeHandle()) + MapInfo.Offset,
-      MappedPtr, MapInfo.Size, ZeEvent, 0, nullptr));
+  bool DeviceIsIntegrated = Queue->Device->ZeDeviceProperties.flags &
+                            ZE_DEVICE_PROPERTY_FLAG_INTEGRATED;
+  // For an integrated device the buffer is allocated in host shared memory
+  // therefore no copying is needed here.
+  // We add an operation so that the returned event is valid at the SYCL level.
+  if (DeviceIsIntegrated) {
+
+    ZE_CALL(zeCommandListAppendSignalEvent(ZeCommandList, ZeEvent));
+
+  } else {
+
+    ZE_CALL(zeCommandListAppendMemoryCopy(
+        ZeCommandList, pi_cast<char *>(MemObj->getZeHandle()) + MapInfo.Offset,
+        MappedPtr, MapInfo.Size, ZeEvent, 0, nullptr));
+  }
 
   // NOTE: we still have to free the host memory allocated/returned by
   // piEnqueueMemBufferMap, but can only do so after the above copy
   // is completed. Instead of waiting for It here (blocking), we shall
   // do so in piEventRelease called for the pi_event tracking the unmap.
+  // In the case of an integrated device, the map operation does not allocate
+  // any memory, so there is nothing to free. This is indicated by a nullptr.
   if (Event)
-    (*Event)->CommandData = MemObj->MapHostPtr ? nullptr : MappedPtr;
+    (*Event)->CommandData =
+        (DeviceIsIntegrated ? nullptr
+                            : (MemObj->MapHostPtr ? nullptr : MappedPtr));
 
   // Execute command list asynchronously, as the event will be used
   // to track down its completion.

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -467,6 +467,9 @@ struct _pi_event : _pi_object {
 
   // Opaque data to hold any data needed for CommandType.
   void *CommandData;
+  // A list of events that need to be waited upon on host
+  // used in bufferMap operation.
+  std::vector<ze_event_handle_t> waitEvents;
 
   // Methods for translating PI events list into Level Zero events list
   static ze_event_handle_t *createZeEventList(pi_uint32, const pi_event *);

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -451,6 +451,14 @@ struct _pi_event : _pi_object {
   // Level Zero event pool handle.
   ze_event_pool_handle_t ZeEventPool;
 
+  // The following are used by MemBufferMap/UnMap on integrated devices
+  bool HostSyncforMap = false;
+  std::vector<ze_event_handle_t> waitEvents;
+  void *DstBuffer = nullptr;
+  void *SrcBuffer = nullptr;
+  size_t RetMapSize = 0;
+  bool CopyPending = false;
+
   // Level Zero command list where the command signaling this event was appended
   // to. This is currently used to remember/destroy the command list after all
   // commands in it are completed, i.e. this event signaled.
@@ -467,9 +475,6 @@ struct _pi_event : _pi_object {
 
   // Opaque data to hold any data needed for CommandType.
   void *CommandData;
-  // A list of events that need to be waited upon on host
-  // used in bufferMap operation.
-  std::vector<ze_event_handle_t> waitEvents;
 
   // Methods for translating PI events list into Level Zero events list
   static ze_event_handle_t *createZeEventList(pi_uint32, const pi_event *);


### PR DESCRIPTION
This change make a distinction between integrated devices (physical memory shared with the CPU) and discrete devices (distinct physical memories). Buffer management for integrated devices takes advantage of the physically shared memory to increase perceived data transfer performance between CPU and device.
 
Signed-off-by: rdeodhar <rajiv.deodhar@intel.com>