### PR TITLE
[SYCL] Add support for new spelling of FPGA kernel attribute scheduler_target_fmax_mhz

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1227,7 +1227,8 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
 }
 
 def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","scheduler_target_fmax_mhz">];
+  let Spellings = [CXX11<"intelfpga","scheduler_target_fmax_mhz">,
+                   CXX11<"intel","scheduler_target_fmax_mhz">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2225,14 +2225,14 @@ device kernel, the attribute is ignored and it is not propagated to a kernel.
 
 def SYCLIntelSchedulerTargetFmaxMhzAttrDocs : Documentation {
   let Category = DocCatFunction;
-  let Heading = "scheduler_target_fmax_mhz (IntelFPGA)";
+  let Heading = "intel::scheduler_target_fmax_mhz";
   let Content = [{
 Applies to a device function/lambda function. Indicates that the kernel should
 be pipelined so as to achieve the specified target clock frequency (Fmax) of N
 MHz. The argument N may be a template parameter. This attribute should be
 ignored for the FPGA emulator device.
 
-``[[intelfpga::scheduler_target_fmax_mhz(N)]]``
+``[[intel::scheduler_target_fmax_mhz(N)]]``
 Valid values of N are integers in the range [0, 1048576]. The upper limit,
 although too high to be a realistic value for frequency, is chosen to be future
 proof. The FPGA backend emits a diagnostic message if the passed value is

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3053,6 +3053,10 @@ static void handleSchedulerTargetFmaxMhzAttr(Sema &S, Decl *D,
   if (D->getAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>())
     S.Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL;
 
+  if (checkDeprecatedSYCLAttributeSpelling(S, AL))
+    S.Diag(AL.getLoc(), diag::note_spelling_suggestion)
+        << "'intel::scheduler_target_fmax_mhz'";
+
   S.addSYCLIntelSchedulerTargetFmaxMhzAttr(D, AL, E);
 }
 

--- a/clang/test/CodeGenSYCL/scheduler-target-fmax-mhz.cpp
+++ b/clang/test/CodeGenSYCL/scheduler-target-fmax-mhz.cpp
@@ -1,15 +1,15 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -emit-llvm -o - %s | FileCheck %s
 
 #include "Inputs/sycl.hpp"
-[[intelfpga::scheduler_target_fmax_mhz(5)]] void
+[[intel::scheduler_target_fmax_mhz(5)]] void
 func() {}
 
 template <int N>
-[[intelfpga::scheduler_target_fmax_mhz(N)]] void zoo() {}
+[[intel::scheduler_target_fmax_mhz(N)]] void zoo() {}
 
 int main() {
   cl::sycl::kernel_single_task<class test_kernel1>(
-      []() [[intelfpga::scheduler_target_fmax_mhz(2)]]{});
+      []() [[intel::scheduler_target_fmax_mhz(2)]]{});
 
   cl::sycl::kernel_single_task<class test_kernel2>(
       []() { func(); });

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -1,11 +1,13 @@
 // RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat -verify | FileCheck %s
 
 #include "Inputs/sycl.hpp"
+// expected-warning@+2 {{attribute 'intelfpga::scheduler_target_fmax_mhz' is deprecated}}
+// expected-note@+1 {{did you mean to use 'intel::scheduler_target_fmax_mhz' instead?}}
 [[intelfpga::scheduler_target_fmax_mhz(2)]] void
 func() {}
 
 template <int N>
-[[intelfpga::scheduler_target_fmax_mhz(N)]] void zoo() {}
+[[intel::scheduler_target_fmax_mhz(N)]] void zoo() {}
 
 int main() {
   // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel1 'void ()'
@@ -14,7 +16,7 @@ int main() {
   // CHECK-NEXT:   value: Int 5
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 5
   cl::sycl::kernel_single_task<class test_kernel1>(
-      []() [[intelfpga::scheduler_target_fmax_mhz(5)]]{});
+      []() [[intel::scheduler_target_fmax_mhz(5)]]{});
 
   // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel2 'void ()'
   // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
@@ -32,14 +34,14 @@ int main() {
   cl::sycl::kernel_single_task<class test_kernel3>(
       []() { zoo<75>(); });
 
-  [[intelfpga::scheduler_target_fmax_mhz(0)]] int Var = 0; // expected-error{{'scheduler_target_fmax_mhz' attribute only applies to functions}}
+  [[intel::scheduler_target_fmax_mhz(0)]] int Var = 0; // expected-error{{'scheduler_target_fmax_mhz' attribute only applies to functions}}
 
   cl::sycl::kernel_single_task<class test_kernel4>(
-      []() [[intelfpga::scheduler_target_fmax_mhz(1048577)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires integer constant between 0 and 1048576 inclusive}}
+      []() [[intel::scheduler_target_fmax_mhz(1048577)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires integer constant between 0 and 1048576 inclusive}}
 
   cl::sycl::kernel_single_task<class test_kernel5>(
-      []() [[intelfpga::scheduler_target_fmax_mhz(-4)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires integer constant between 0 and 1048576 inclusive}}
+      []() [[intel::scheduler_target_fmax_mhz(-4)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires integer constant between 0 and 1048576 inclusive}}
 
   cl::sycl::kernel_single_task<class test_kernel6>(
-      []() [[intelfpga::scheduler_target_fmax_mhz(1), intelfpga::scheduler_target_fmax_mhz(2)]]{}); // expected-warning{{attribute 'scheduler_target_fmax_mhz' is already applied with different parameters}}
+      []() [[intel::scheduler_target_fmax_mhz(1), intel::scheduler_target_fmax_mhz(2)]]{}); // expected-warning{{attribute 'scheduler_target_fmax_mhz' is already applied with different parameters}}
 }

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -15,8 +15,8 @@ int main() {
   // CHECK-NEXT:   ConstantExpr {{.*}} 'int'
   // CHECK-NEXT:   value: Int 5
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 5
-  // expected-warning@+2 {{attribute 'intelfpga::scheduler_target_fmax_mhz' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::scheduler_target_fmax_mhz' instead?}}
+  // expected-warning@+3 {{attribute 'intelfpga::scheduler_target_fmax_mhz' is deprecated}}
+  // expected-note@+2 {{did you mean to use 'intel::scheduler_target_fmax_mhz' instead?}}
   cl::sycl::kernel_single_task<class test_kernel1>(
       []() [[intelfpga::scheduler_target_fmax_mhz(5)]]{});
 

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -15,8 +15,10 @@ int main() {
   // CHECK-NEXT:   ConstantExpr {{.*}} 'int'
   // CHECK-NEXT:   value: Int 5
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 5
+  // expected-warning@+2 {{attribute 'intelfpga::scheduler_target_fmax_mhz' is deprecated}}
+  // expected-note@+1 {{did you mean to use 'intel::scheduler_target_fmax_mhz' instead?}}
   cl::sycl::kernel_single_task<class test_kernel1>(
-      []() [[intel::scheduler_target_fmax_mhz(5)]]{});
+      []() [[intelfpga::scheduler_target_fmax_mhz(5)]]{});
 
   // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel2 'void ()'
   // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}


### PR DESCRIPTION
Clang support for FPGA kernel attribute
[[intelfpga::scheduler_target_fmax_mhz()]] was added on commit 20013e2.

commit 5949228 updated all FPGA attribute spellings that currently used
intelfpga:: prefixes to intel:: in all lowercase to avoid mismatch
between our namespace in SYCL (which use intel::) and the prefixes
we used for FPGA attributes in LLVM.

This patches

1. Enable attribute spelling with intel:: prefix, without disabling the previous one.
2. Provide a deprecation warning for the previous attribute spelling.
3. Modify the tests and documentation.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>