### PR TITLE
[SYCL][L0] Fixed SYCL_PI_TRACE printing problem

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -216,7 +216,7 @@ template <> inline void print<>(PiResult val) {
 
 // cout does not resolve a nullptr.
 template <> inline void print<>(std::nullptr_t val) {
-  std::cout << "<nullptr> : 0x0" << std::endl;
+  std::cout << "<nullptr> : " << static_cast<void *>(val) << std::endl;
 }
 
 template <> inline void print(char *val) {

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -215,12 +215,16 @@ template <> inline void print<>(PiResult val) {
 }
 
 // cout does not resolve a nullptr.
-template <> inline void print<>(std::nullptr_t val) {
-  std::cout << "<nullptr> : " << static_cast<void *>(val) << std::endl;
+template <> inline void print<>(std::nullptr_t) {
+  std::cout << "<nullptr> :" << std::endl;
 }
 
-template <> inline void print(char *val) {
+template <> inline void print<>(char *val) {
   std::cout << "<char * > : " << static_cast<void *>(val) << std::endl;
+}
+
+template <> inline void print<>(const char *val) {
+  std::cout << "<const char *>: " << val << std::endl;
 }
 
 inline void printArgs(void) {}

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -215,7 +215,13 @@ template <> inline void print<>(PiResult val) {
 }
 
 // cout does not resolve a nullptr.
-template <> inline void print<>(std::nullptr_t val) { print<void *>(val); }
+template <> inline void print<>(std::nullptr_t val) {
+  std::cout << "<nullptr> : 0x0" << std::endl;
+}
+
+template <> inline void print(char *val) {
+  std::cout << "<char * > : " << static_cast<void *>(val) << std::endl;
+}
 
 inline void printArgs(void) {}
 template <typename Arg0, typename... Args>

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -216,7 +216,7 @@ template <> inline void print<>(PiResult val) {
 
 // cout does not resolve a nullptr.
 template <> inline void print<>(std::nullptr_t) {
-  std::cout << "<nullptr> :" << std::endl;
+  std::cout << "<nullptr>" << std::endl;
 }
 
 template <> inline void print<>(char *val) {


### PR DESCRIPTION
SYCL_PI_TRACE is used for internal debugging. It displays
the PI function that is being called and its arguments.

When piGetDeviceInfo() was called, the printing of the
pointer used for a variable sized string was incorrect.
Added a print() specialization.

The nullptr print() specialization was also updated because
specializations should be special.

Signed-off-by: Gail Lyons <gail.lyons@intel.com>