### PR TITLE
[SYCL] Fix initialization issue on Windows

### DIFF
--- a/sycl/include/CL/sycl/detail/spinlock.hpp
+++ b/sycl/include/CL/sycl/detail/spinlock.hpp
@@ -33,7 +33,7 @@ public:
   void unlock() { MLock.clear(std::memory_order_release); }
 
 private:
-  std::atomic_flag MLock{ATOMIC_FLAG_INIT};
+  std::atomic_flag MLock = ATOMIC_FLAG_INIT;
 };
 } // namespace detail
 } // namespace sycl


### PR DESCRIPTION
Using initializer list causes compilation issue on Windows when using
compile.py script.