### PR TITLE
[SYCL][L0] Add support for pinned host memory.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2103,8 +2103,8 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
         zeMemAllocDevice(Context->ZeContext, &ZeDesc, Size, 1, ZeDevice, &Ptr));
   }
   if (HostPtr) {
-    // As of now, zeMemAllocHost() does not support allocation of pinned
-    // host memory. So even if PI_MEM_FLAGS_HOST_PTR_ALLOC set, it allocates
+    // Currently zeMemAllocHost() does not support allocation of pinned
+    // host memory. So for PI_MEM_FLAGS_HOST_PTR_ALLOC flag, it allocates
     // pageable host memory.
     if ((Flags & PI_MEM_FLAGS_HOST_PTR_ALLOC) != 0) {
       ze_host_mem_alloc_desc_t ZeHostDesc = {};
@@ -2136,7 +2136,7 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
     }
   }
 
-  auto HostPtrOrNull =
+  auto HostPtrOrNull = (Flags & PI_MEM_FLAGS_HOST_PTR_ALLOC) ||
       (Flags & PI_MEM_FLAGS_HOST_PTR_USE) ? pi_cast<char *>(HostPtr) : nullptr;
   try {
     *RetMem = new _pi_buffer(

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2105,21 +2105,12 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
   if (HostPtr) {
 
     if ((Flags & PI_MEM_FLAGS_HOST_PTR_ALLOC) != 0) {
-      void *PinnedHostPtr;
-
       ze_host_mem_alloc_desc_t ZeHostDesc = {};
       ZeHostDesc.flags = 0;
     
       ZE_CALL(zeMemAllocHost(Context->ZeContext, &ZeHostDesc, Size,
                              1, // TODO: alignment
-                             &PinnedHostPtr));
-      ZE_CALL(zeCommandListAppendMemoryCopy(Context->ZeCommandListInit,
-                                            PinnedHostPtr, HostPtr, Size,
-                                            nullptr, 0, nullptr));
-      ZE_CALL(zeCommandListAppendMemoryCopy(Context->ZeCommandListInit, Ptr,
-                                            PinnedHostPtr, Size, nullptr, 0,
-                                            nullptr));
-      HostPtr = PinnedHostPtr;
+                             &HostPtr));
     } else if ((Flags & PI_MEM_FLAGS_HOST_PTR_USE) != 0 ||
                (Flags & PI_MEM_FLAGS_HOST_PTR_COPY) != 0) {
       // Initialize the buffer with user data

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2106,7 +2106,6 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
     // As of now, zeMemAllocHost() does not support allocation of pinned
     // host memory. So even if PI_MEM_FLAGS_HOST_PTR_ALLOC set, it allocates
     // pageable host memory.
-    // TODO: 
     if ((Flags & PI_MEM_FLAGS_HOST_PTR_ALLOC) != 0) {
       ze_host_mem_alloc_desc_t ZeHostDesc = {};
       ZeHostDesc.flags = 0;

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2109,12 +2109,12 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
     ZE_CALL(zeMemAllocHost(Context->ZeContext, &ZeDesc, Size, 1, &Ptr));
 
   } else {
-    ze_device_mem_alloc_desc_t ZeDeviceMemDesc = {};
-    ZeDeviceMemDesc.flags = 0;
-    ZeDeviceMemDesc.ordinal = 0;
-
-    ZE_CALL(zeMemAllocDevice(Context->ZeContext, &ZeDeviceMemDesc, Size, 1,
-                             ZeDevice, &Ptr));
+    ze_device_mem_alloc_desc_t ZeDesc = {};
+    ZeDesc.flags = 0;
+    ZeDesc.ordinal = 0;
+    
+    ZE_CALL(
+        zeMemAllocDevice(Context->ZeContext, &ZeDesc, Size, 1, ZeDevice, &Ptr));
   }
 
   if (HostPtr) {

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2120,9 +2120,8 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
                                             PinnedHostPtr, Size, nullptr, 0,
                                             nullptr));
       HostPtr = PinnedHostPtr;
-    }
-    if ((Flags & PI_MEM_FLAGS_HOST_PTR_USE) != 0 ||
-        (Flags & PI_MEM_FLAGS_HOST_PTR_COPY) != 0) {
+    } else if ((Flags & PI_MEM_FLAGS_HOST_PTR_USE) != 0 ||
+               (Flags & PI_MEM_FLAGS_HOST_PTR_COPY) != 0) {
       // Initialize the buffer with user data
       if (DeviceIsIntegrated) {
         // Do a host to host copy

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2106,7 +2106,6 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
     ZE_CALL(zeMemAllocHost(Context->ZeContext, &ZeDesc, Size, 1, &Ptr));
 
   } else if (DeviceIsIntegrated) {
-
     ze_host_mem_alloc_desc_t ZeDesc = {};
     ZeDesc.flags = 0;
 

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2100,7 +2100,7 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
 
     ZE_CALL(zeMemAllocHost(Context->ZeContext, &ZeDesc, Size, 1, &Ptr));
 
-  } else if (AllocHostPtr){
+  } else if (AllocHostPtr) {
     // Currently L0 does not support allocation of pinned
     // host memory. So for PI_MEM_FLAGS_HOST_PTR_ALLOC flag, it allocates
     // from host accessible memory.
@@ -2108,15 +2108,14 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
     ZeHostMemDesc.flags = 0;
 
     ZE_CALL(zeMemAllocShared(Context->ZeContext, &ZeDeviceMemDesc,
-                           &ZeHostMemDesc, Size,
-                           1,       // TODO: alignment
-                           nullptr, // not bound to any device
-                           &Ptr));
+                             &ZeHostMemDesc, Size,
+                             1,       // TODO: alignment
+                             nullptr, // not bound to any device
+                             &Ptr));
 
   } else {
-    ZE_CALL(
-        zeMemAllocDevice(Context->ZeContext, &ZeDeviceMemDesc, Size, 1,
-                         ZeDevice, &Ptr));
+    ZE_CALL(zeMemAllocDevice(Context->ZeContext, &ZeDeviceMemDesc, Size, 1,
+                             ZeDevice, &Ptr));
   }
 
   if (HostPtr) {

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2112,7 +2112,7 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
     ze_device_mem_alloc_desc_t ZeDesc = {};
     ZeDesc.flags = 0;
     ZeDesc.ordinal = 0;
-    
+
     ZE_CALL(
         zeMemAllocDevice(Context->ZeContext, &ZeDesc, Size, 1, ZeDevice, &Ptr));
   }

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2071,6 +2071,7 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
   }
   PI_ASSERT(Context, PI_INVALID_CONTEXT);
   PI_ASSERT(RetMem, PI_INVALID_VALUE);
+  PI_ASSERT(HostPtr && PI_MEM_FLAGS_HOST_PTR_ALLOC, PI_INVALID_VALUE);
 
   if (properties != nullptr) {
     die("piMemBufferCreate: no mem properties goes to Level-Zero RT yet");
@@ -2132,8 +2133,6 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
                                               HostPtr, Size, nullptr, 0,
                                               nullptr));
       }
-    } else if ((Flags & PI_MEM_FLAGS_HOST_PTR_ALLOC) != 0) {
-      // Nothing more to do.
     } else if (Flags == 0 || (Flags == PI_MEM_FLAGS_ACCESS_RW)) {
       // Nothing more to do.
     } else {

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2103,6 +2103,24 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
         zeMemAllocDevice(Context->ZeContext, &ZeDesc, Size, 1, ZeDevice, &Ptr));
   }
   if (HostPtr) {
+
+    if ((Flags & PI_MEM_FLAGS_HOST_PTR_ALLOC) != 0) {
+      void *PinnedHostPtr;
+
+      ze_host_mem_alloc_desc_t ZeHostDesc = {};
+      ZeHostDesc.flags = 0;
+    
+      ZE_CALL(zeMemAllocHost(Context->ZeContext, &ZeHostDesc, Size,
+                             1, // TODO: alignment
+                             &PinnedHostPtr));
+      ZE_CALL(zeCommandListAppendMemoryCopy(Context->ZeCommandListInit,
+                                            PinnedHostPtr, HostPtr, Size,
+                                            nullptr, 0, nullptr));
+      ZE_CALL(zeCommandListAppendMemoryCopy(Context->ZeCommandListInit, Ptr,
+                                            PinnedHostPtr, Size, nullptr, 0,
+                                            nullptr));
+      HostPtr = PinnedHostPtr;
+    }
     if ((Flags & PI_MEM_FLAGS_HOST_PTR_USE) != 0 ||
         (Flags & PI_MEM_FLAGS_HOST_PTR_COPY) != 0) {
       // Initialize the buffer with user data

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2099,13 +2099,9 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
 
   if (AllocHostPtr) {
     PI_ASSERT(HostPtr == nullptr, PI_INVALID_VALUE);
+  }
 
-    ze_host_mem_alloc_desc_t ZeDesc = {};
-    ZeDesc.flags = 0;
-
-    ZE_CALL(zeMemAllocHost(Context->ZeContext, &ZeDesc, Size, 1, &Ptr));
-
-  } else if (DeviceIsIntegrated) {
+  if (AllocHostPtr || DeviceIsIntegrated) {
     ze_host_mem_alloc_desc_t ZeDesc = {};
     ZeDesc.flags = 0;
 

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -390,7 +390,6 @@ struct _pi_mem : _pi_object {
   char *MapHostPtr;
 
   // Flag to indicate that this memory is allocated in host memory
-  // if created with PI_MEM_FLAGS_HOST_PTR_ALLOC and/or integrated devices.
   bool OnHost;
 
   // Supplementary data to keep track of the mappings of this memory

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -390,6 +390,7 @@ struct _pi_mem : _pi_object {
   char *MapHostPtr;
 
   // Flag to indicate that this memory is allocated in host memory
+  // if created with PI_MEM_FLAGS_HOST_PTR_ALLOC and/or integrated devices.
   bool OnHost;
 
   // Supplementary data to keep track of the mappings of this memory


### PR DESCRIPTION
This change implements the support for pinned host memory in level_zero plugin. It allocates pinned host memory when PI_MEM_FLAGS_HOST_PTR_ALLOC is set. Pinned host memories are automatically accessible from the device through PCI. This property also ensures that the memory map/unmap operations are free of cost and the buffer is optimized for frequent accesses from the host.
A test is added for this change in a separate PR for the intel/llvm-test-suite: https://github.com/intel/llvm-test-suite/pull/83

Signed-off-by: rbegam <rehana.begam@intel.com>