### PR TITLE
[SYCL] Fix bug with introp buffer

### DIFF
--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
@@ -61,6 +61,11 @@ public:
   // Returns size of object in bytes
   virtual size_t getSize() const = 0;
 
+  // TODO: Fix the comment
+  // Returns true if a memory object has been created using interoperability
+  // constructor
+  virtual ContextImplPtr interopContext() const = 0;
+
 protected:
   // Pointer to the record that contains the memory commands. This is managed
   // by the scheduler.

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_i.hpp
@@ -61,10 +61,9 @@ public:
   // Returns size of object in bytes
   virtual size_t getSize() const = 0;
 
-  // TODO: Fix the comment
-  // Returns true if a memory object has been created using interoperability
-  // constructor
-  virtual ContextImplPtr interopContext() const = 0;
+  // Returns the context which is passed if a memory object is created using
+  // interoperability constructor, nullptr otherwise.
+  virtual ContextImplPtr getInteropContext() const = 0;
 
 protected:
   // Pointer to the record that contains the memory commands. This is managed

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -287,7 +287,7 @@ public:
 
   DLL_LOCAL MemObjType getType() const override { return UNDEFINED; }
 
-  ContextImplPtr interopContext() const override { return MInteropContext; }
+  ContextImplPtr getInteropContext() const override { return MInteropContext; }
 
 protected:
   // Allocator used for allocation memory on host.

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -287,6 +287,8 @@ public:
 
   DLL_LOCAL MemObjType getType() const override { return UNDEFINED; }
 
+  ContextImplPtr interopContext() const override { return MInteropContext; }
+
 protected:
   // Allocator used for allocation memory on host.
   unique_ptr_class<SYCLMemObjAllocator> MAllocator;

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -125,21 +125,16 @@ void *MemoryManager::allocateInteropMemObject(
     ContextImplPtr TargetContext, void *UserPtr,
     const EventImplPtr &InteropEvent, const ContextImplPtr &InteropContext,
     const sycl::property_list &, RT::PiEvent &OutEventToWait) {
-  // If memory object is created with interop c'tor.
-  // Return cl_mem as is if contexts match.
-  if (TargetContext == InteropContext) {
-    OutEventToWait = InteropEvent->getHandleRef();
-    // Retain the event since it will be released during alloca command
-    // destruction
-    if (nullptr != OutEventToWait) {
-      const detail::plugin &Plugin = InteropEvent->getPlugin();
-      Plugin.call<PiApiKind::piEventRetain>(OutEventToWait);
-    }
-    return UserPtr;
+  // If memory object is created with interop c'tor return cl_mem as is.
+  assert(TargetContext == InteropContext && "Expected matching contexts");
+  OutEventToWait = InteropEvent->getHandleRef();
+  // Retain the event since it will be released during alloca command
+  // destruction
+  if (nullptr != OutEventToWait) {
+    const detail::plugin &Plugin = InteropEvent->getPlugin();
+    Plugin.call<PiApiKind::piEventRetain>(OutEventToWait);
   }
-  // Allocate new cl_mem and initialize from user provided one.
-  assert(false && "Not implemented");
-  return nullptr;
+  return UserPtr;
 }
 
 void *MemoryManager::allocateImageObject(ContextImplPtr TargetContext,

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -142,7 +142,7 @@ public:
 
   const plugin &getPlugin() const { return MContext->getPlugin(); }
 
-  ContextImplPtr getContextImplPtr() const { return MContext; }
+  const ContextImplPtr &getContextImplPtr() const { return MContext; }
 
   /// \return an associated SYCL device.
   device get_device() const { return createSyclObjFromImpl<device>(MDevice); }

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -176,11 +176,11 @@ Scheduler::GraphBuilder::getOrInsertMemObjRecord(const QueueImplPtr &Queue,
         --(Dependency->MLeafCounter);
       };
 
-  const ContextImplPtr &InteropCtxPtr = Req->MSYCLMemObj->interopContext();
+  const ContextImplPtr &InteropCtxPtr = Req->MSYCLMemObj->getInteropContext();
   if (InteropCtxPtr) {
     // The memory object has been constructed using interoperability constructor
     // which means that there is already an allocation(cl_mem) in some context.
-    // Regestering this allocation in the SYCL graph.
+    // Registering this allocation in the SYCL graph.
 
     sycl::vector_class<sycl::device> Devices =
         InteropCtxPtr->get_info<info::context::devices>();
@@ -193,11 +193,10 @@ Scheduler::GraphBuilder::getOrInsertMemObjRecord(const QueueImplPtr &Queue,
     QueueImplPtr InteropQueuePtr{new detail::queue_impl{
         Dev, InteropCtxPtr, /*AsyncHandler=*/{}, /*PropertyList=*/{}}};
 
-    MemObject->MRecord.reset(new MemObjRecord{InteropCtxPtr,
-                                            LeafLimit, AllocateDependency});
+    MemObject->MRecord.reset(
+        new MemObjRecord{InteropCtxPtr, LeafLimit, AllocateDependency});
     getOrCreateAllocaForReq(MemObject->MRecord.get(), Req, InteropQueuePtr);
-  }
-  else
+  } else
     MemObject->MRecord.reset(new MemObjRecord{Queue->getContextImplPtr(),
                                               LeafLimit, AllocateDependency});
 

--- a/sycl/test/basic_tests/buffer/buffer_interop.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_interop.cpp
@@ -33,6 +33,8 @@ int main() {
     Error = clReleaseContext(OCLCtx);
     CHECK_OCL_CODE(Error);
 
+    sycl::buffer<int, 1> Buf{OCLBuf, Ctx};
+
     sycl::queue Q;
 
     if (Ctx == Q.get_context()) {

--- a/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
+++ b/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
@@ -33,7 +33,7 @@ public:
   void releaseMem(ContextImplPtr, void *) {}
   void releaseHostMem(void *) {}
   size_t getSize() const override { return 10; }
-  detail::ContextImplPtr interopContext() const override { return nullptr; }
+  detail::ContextImplPtr getInteropContext() const override { return nullptr; }
 };
 
 TEST_F(SchedulerTest, LinkedAllocaDependencies) {

--- a/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
+++ b/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
@@ -33,6 +33,7 @@ public:
   void releaseMem(ContextImplPtr, void *) {}
   void releaseHostMem(void *) {}
   size_t getSize() const override { return 10; }
+  detail::ContextImplPtr interopContext() const override { return nullptr; }
 };
 
 TEST_F(SchedulerTest, LinkedAllocaDependencies) {


### PR DESCRIPTION
Fixed a problem which happened when a buffer constructed using
interaperablity constructor with sycl::context A is used in a different
context.