### PR TITLE
[SYCL] Wait before deleting a stream buffer

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -276,6 +276,8 @@ void Scheduler::allocateStreamBuffers(stream_impl *Impl,
 
 void Scheduler::deallocateStreamBuffers(stream_impl *Impl) {
   std::lock_guard<std::mutex> lock(StreamBuffersPoolMutex);
+  assert(Impl->FlushEvent != nullptr);
+  Impl->FlushEvent->wait(Impl->FlushEvent);
   delete StreamBuffersPool[Impl];
   StreamBuffersPool.erase(Impl);
 }

--- a/sycl/source/detail/stream_impl.cpp
+++ b/sycl/source/detail/stream_impl.cpp
@@ -67,7 +67,7 @@ void stream_impl::flush() {
   // finishes execution.
   auto Q = detail::createSyclObjFromImpl<queue>(
       cl::sycl::detail::Scheduler::getInstance().getDefaultHostQueue());
-  Q.submit([&](handler &cgh) {
+  auto Event = Q.submit([&](handler &cgh) {
     auto BufHostAcc =
         detail::Scheduler::getInstance()
             .StreamBuffersPool.find(this)
@@ -89,6 +89,7 @@ void stream_impl::flush() {
       fflush(stdout);
     });
   });
+  FlushEvent = detail::getSyclObjImpl(Event);
 }
 } // namespace detail
 } // namespace sycl

--- a/sycl/source/detail/stream_impl.hpp
+++ b/sycl/source/detail/stream_impl.hpp
@@ -11,6 +11,7 @@
 #include <CL/sycl/accessor.hpp>
 #include <CL/sycl/buffer.hpp>
 #include <CL/sycl/detail/export.hpp>
+#include <CL/sycl/event.hpp>
 #include <CL/sycl/handler.hpp>
 #include <CL/sycl/range.hpp>
 #include <CL/sycl/stream.hpp>
@@ -41,6 +42,8 @@ public:
   size_t get_size() const;
 
   size_t get_max_statement_size() const;
+
+  EventImplPtr FlushEvent;
 
 private:
   // Size of the stream buffer

--- a/sycl/test/basic_tests/stream/flush_with_throw_on_block.cpp
+++ b/sycl/test/basic_tests/stream/flush_with_throw_on_block.cpp
@@ -1,0 +1,27 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_THROW_ON_BLOCK=1 SYCL_DEVICE_TYPE=HOST %t.out | FileCheck %s
+// RUN: env SYCL_THROW_ON_BLOCK=1 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_THROW_ON_BLOCK=1 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_THROW_ON_BLOCK=1 %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
+
+// Simple test to check that asynchronous stream flushing works when flag is
+// enabled to throw an exception on attempt to enqueue a blocked command.
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main() {
+  queue Queue;
+
+  Queue.submit([&](handler &CGH) {
+    stream Out(1024, 80, CGH);
+    CGH.parallel_for<class auto_flush1>(
+        range<1>(2), [=](id<1> i) { Out << "Hello World!" << endl; });
+  });
+  Queue.wait();
+  // CHECK: Hello World!
+  // CHECK-NEXT: Hello World!
+
+  return 0;
+}


### PR DESCRIPTION
Currently streamed data is printed in a host task. Host task has a corresponding empty task which is a leaf command for a stream buffer. Since stream buffer is not a leaf for a kernel it doesn't block the kernel from being cleaned up after completion. During this cleanup process stream buffer is deleted, as a result scheduler does a blocking enqueue of the empty task. Problem is that this empty task has a blocked status (blocked by host task). This results in exception saying that we try to wait for a blocked command. It is not clear if this use case is invalid or there is a bug in the scheduler.

Explicitly waiting for a host task before stream buffer deletion is correct for sure and resolves this problem.