### PR TITLE
[SYCL][CUDA] Add group algorithms

### DIFF
--- a/libclc/generic/include/spirv/spirv_types.h
+++ b/libclc/generic/include/spirv/spirv_types.h
@@ -40,4 +40,10 @@ enum FPRoundingMode {
   SPV_RTN = 3,
 };
 
+enum GroupOperation {
+  Reduce = 0,
+  InclusiveScan = 1,
+  ExclusiveScan = 2,
+};
+
 #endif // CLC_SPIRV_TYPES

--- a/libclc/ptx-nvidiacl/libspirv/SOURCES
+++ b/libclc/ptx-nvidiacl/libspirv/SOURCES
@@ -83,3 +83,5 @@ workitem/get_sub_group_local_id.cl
 workitem/get_sub_group_size.cl
 images/image_helpers.ll
 images/image.cl
+group/collectives_helpers.ll
+group/collectives.cl

--- a/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
+++ b/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
@@ -60,11 +60,10 @@ __CLC_SUBGROUP_SHUFFLE_I32(uint);
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT ulong __clc__SubgroupShuffle(ulong x,
                                                                     uint idx) {
-  uint lo = (uint)x;
-  uint hi = (uint)(x >> 32);
-  lo = __nvvm_shfl_sync_idx_i32(__clc__membermask(), lo, idx, 0x1f);
-  hi = __nvvm_shfl_sync_idx_i32(__clc__membermask(), hi, idx, 0x1f);
-  return (((ulong)hi) << 32ul) | lo;
+  uint2 y = as_uint2(x);
+  y.lo = __nvvm_shfl_sync_idx_i32(__clc__membermask(), y.lo, idx, 0x1f);
+  y.hi = __nvvm_shfl_sync_idx_i32(__clc__membermask(), y.hi, idx, 0x1f);
+  return as_ulong(y);
 }
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT long __clc__SubgroupShuffle(long x,
@@ -102,11 +101,10 @@ __CLC_SUBGROUP_SHUFFLEUP_I32(uint);
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT ulong
 __clc__SubgroupShuffleUp(ulong x, uint delta) {
-  uint lo = (uint)x;
-  uint hi = (uint)(x >> 32);
-  lo = __nvvm_shfl_sync_up_i32(__clc__membermask(), lo, delta, 0);
-  hi = __nvvm_shfl_sync_up_i32(__clc__membermask(), hi, delta, 0);
-  return (((ulong)hi) << 32ul) | lo;
+  uint2 y = as_uint2(x);
+  y.lo = __nvvm_shfl_sync_up_i32(__clc__membermask(), y.lo, delta, 0);
+  y.hi = __nvvm_shfl_sync_up_i32(__clc__membermask(), y.hi, delta, 0);
+  return as_ulong(y);
 }
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT long

--- a/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
+++ b/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
@@ -1,0 +1,371 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <spirv/spirv.h>
+#include <spirv/spirv_types.h>
+
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+
+// CLC helpers
+__local bool *
+__clc__get_group_scratch_bool() __asm("__clc__get_group_scratch_bool");
+__local char *
+__clc__get_group_scratch_char() __asm("__clc__get_group_scratch_char");
+__local uchar *
+__clc__get_group_scratch_uchar() __asm("__clc__get_group_scratch_char");
+__local short *
+__clc__get_group_scratch_short() __asm("__clc__get_group_scratch_short");
+__local ushort *
+__clc__get_group_scratch_ushort() __asm("__clc__get_group_scratch_short");
+__local int *
+__clc__get_group_scratch_int() __asm("__clc__get_group_scratch_int");
+__local uint *
+__clc__get_group_scratch_uint() __asm("__clc__get_group_scratch_int");
+__local long *
+__clc__get_group_scratch_long() __asm("__clc__get_group_scratch_long");
+__local ulong *
+__clc__get_group_scratch_ulong() __asm("__clc__get_group_scratch_long");
+__local float *
+__clc__get_group_scratch_float() __asm("__clc__get_group_scratch_float");
+__local double *
+__clc__get_group_scratch_double() __asm("__clc__get_group_scratch_double");
+
+_CLC_DEF _CLC_CONVERGENT uint __clc__membermask() {
+  uint FULL_MASK = 0xFFFFFFFF;
+  uint max_size = __spirv_SubgroupMaxSize();
+  uint sg_size = __spirv_SubgroupSize();
+  return FULL_MASK >> (max_size - sg_size);
+}
+
+#define __CLC_SUBGROUP_SHUFFLE_I32(TYPE)                                       \
+  _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT TYPE __clc__SubgroupShuffle(          \
+      TYPE x, uint idx) {                                                      \
+    return __nvvm_shfl_sync_idx_i32(__clc__membermask(), x, idx, 0x1f);        \
+  }
+__CLC_SUBGROUP_SHUFFLE_I32(char);
+__CLC_SUBGROUP_SHUFFLE_I32(uchar);
+__CLC_SUBGROUP_SHUFFLE_I32(short);
+__CLC_SUBGROUP_SHUFFLE_I32(ushort);
+__CLC_SUBGROUP_SHUFFLE_I32(int);
+__CLC_SUBGROUP_SHUFFLE_I32(uint);
+#undef __CLC_SUBGROUP_SHUFFLE_I32
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT ulong __clc__SubgroupShuffle(ulong x,
+                                                                    uint idx) {
+  uint lo = (uint)x;
+  uint hi = (uint)(x >> 32);
+  lo = __nvvm_shfl_sync_idx_i32(__clc__membermask(), lo, idx, 0x1f);
+  hi = __nvvm_shfl_sync_idx_i32(__clc__membermask(), hi, idx, 0x1f);
+  return (((ulong)hi) << 32ul) | lo;
+}
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT long __clc__SubgroupShuffle(long x,
+                                                                   uint idx) {
+  return as_long(__clc__SubgroupShuffle(as_ulong(x), idx));
+}
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT float __clc__SubgroupShuffle(float x,
+                                                                    uint idx) {
+  return __nvvm_shfl_sync_idx_f32(__clc__membermask(), x, idx, 0x1f);
+}
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT double __clc__SubgroupShuffle(double x,
+                                                                     uint idx) {
+  return as_double(__clc__SubgroupShuffle(as_ulong(x), idx));
+}
+
+#define __CLC_SUBGROUP_SHUFFLEUP_I32(TYPE)                                     \
+  _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT TYPE __clc__SubgroupShuffleUp(        \
+      TYPE x, uint delta) {                                                    \
+    return __nvvm_shfl_sync_up_i32(__clc__membermask(), x, delta, 0);          \
+  }
+__CLC_SUBGROUP_SHUFFLEUP_I32(char);
+__CLC_SUBGROUP_SHUFFLEUP_I32(uchar);
+__CLC_SUBGROUP_SHUFFLEUP_I32(short);
+__CLC_SUBGROUP_SHUFFLEUP_I32(ushort);
+__CLC_SUBGROUP_SHUFFLEUP_I32(int);
+__CLC_SUBGROUP_SHUFFLEUP_I32(uint);
+#undef __CLC_SUBGROUP_SHUFFLEUP_I32
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT ulong
+__clc__SubgroupShuffleUp(ulong x, uint delta) {
+  uint lo = (uint)x;
+  uint hi = (uint)(x >> 32);
+  lo = __nvvm_shfl_sync_up_i32(__clc__membermask(), lo, delta, 0);
+  hi = __nvvm_shfl_sync_up_i32(__clc__membermask(), hi, delta, 0);
+  return (((ulong)hi) << 32ul) | lo;
+}
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT long
+__clc__SubgroupShuffleUp(long x, uint delta) {
+  return as_long(__clc__SubgroupShuffleUp(as_ulong(x), delta));
+}
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT float
+__clc__SubgroupShuffleUp(float x, uint delta) {
+  return __nvvm_shfl_sync_up_f32(__clc__membermask(), x, delta, 0);
+}
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT double
+__clc__SubgroupShuffleUp(double x, uint delta) {
+  return as_double(__clc__SubgroupShuffleUp(as_ulong(x), delta));
+}
+
+// TODO: Implement InclusiveScan/ExclusiveScan
+//       Currently only Reduce is required (for GroupAny and GroupAll)
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT bool
+__clc__SubgroupBitwiseOr(uint op, bool predicate, bool *carry) {
+  bool result = __nvvm_vote_any_sync(__clc__membermask(), predicate);
+  *carry = result;
+  return result;
+}
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT bool
+__clc__SubgroupBitwiseAny(uint op, bool predicate, bool *carry) {
+  bool result = __nvvm_vote_all_sync(__clc__membermask(), predicate);
+  *carry = result;
+  return result;
+}
+
+#define __CLC_APPEND(NAME, SUFFIX) NAME##SUFFIX
+
+#define __CLC_ADD(x, y) (x + y)
+#define __CLC_MIN(x, y) ((x < y) ? (x) : (y))
+#define __CLC_MAX(x, y) ((x > y) ? (x) : (y))
+#define __CLC_OR(x, y) (x | y)
+#define __CLC_AND(x, y) (x & y)
+
+#define __CLC_SUBGROUP_COLLECTIVE(NAME, OP, TYPE, IDENTITY)                    \
+  _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT TYPE __CLC_APPEND(                    \
+      __clc__Subgroup, NAME)(uint op, TYPE x, TYPE * carry) {                  \
+    uint sg_lid = __spirv_SubgroupLocalInvocationId();                         \
+    /* Can't use XOR/butterfly shuffles; some lanes may be inactive */         \
+    for (int o = 1; o < __spirv_SubgroupMaxSize(); o *= 2) {                   \
+      TYPE contribution = __clc__SubgroupShuffleUp(x, o);                      \
+      bool inactive = (sg_lid < o);                                            \
+      contribution = (inactive) ? IDENTITY : contribution;                     \
+      x = OP(x, contribution);                                                 \
+    }                                                                          \
+    /* For Reduce, broadcast result from highest active lane */                \
+    TYPE result;                                                               \
+    if (op == Reduce) {                                                        \
+      result = __clc__SubgroupShuffle(x, __spirv_SubgroupSize() - 1);          \
+      *carry = result;                                                         \
+    } /* For InclusiveScan, use results as computed */                         \
+    else if (op == InclusiveScan) {                                            \
+      result = x;                                                              \
+      *carry = result;                                                         \
+    } /* For ExclusiveScan, shift and prepend identity */                      \
+    else if (op == ExclusiveScan) {                                            \
+      *carry = x;                                                              \
+      result = __clc__SubgroupShuffleUp(x, 1);                                 \
+      if (sg_lid == 0) {                                                       \
+        result = IDENTITY;                                                     \
+      }                                                                        \
+    }                                                                          \
+    return result;                                                             \
+  }
+
+__CLC_SUBGROUP_COLLECTIVE(IAdd, __CLC_ADD, char, 0)
+__CLC_SUBGROUP_COLLECTIVE(IAdd, __CLC_ADD, uchar, 0)
+__CLC_SUBGROUP_COLLECTIVE(IAdd, __CLC_ADD, short, 0)
+__CLC_SUBGROUP_COLLECTIVE(IAdd, __CLC_ADD, ushort, 0)
+__CLC_SUBGROUP_COLLECTIVE(IAdd, __CLC_ADD, int, 0)
+__CLC_SUBGROUP_COLLECTIVE(IAdd, __CLC_ADD, uint, 0)
+__CLC_SUBGROUP_COLLECTIVE(IAdd, __CLC_ADD, long, 0)
+__CLC_SUBGROUP_COLLECTIVE(IAdd, __CLC_ADD, ulong, 0)
+__CLC_SUBGROUP_COLLECTIVE(FAdd, __CLC_ADD, float, 0)
+__CLC_SUBGROUP_COLLECTIVE(FAdd, __CLC_ADD, double, 0)
+
+__CLC_SUBGROUP_COLLECTIVE(SMin, __CLC_MIN, char, CHAR_MAX)
+__CLC_SUBGROUP_COLLECTIVE(UMin, __CLC_MIN, uchar, UCHAR_MAX)
+__CLC_SUBGROUP_COLLECTIVE(SMin, __CLC_MIN, short, SHRT_MAX)
+__CLC_SUBGROUP_COLLECTIVE(UMin, __CLC_MIN, ushort, USHRT_MAX)
+__CLC_SUBGROUP_COLLECTIVE(SMin, __CLC_MIN, int, INT_MAX)
+__CLC_SUBGROUP_COLLECTIVE(UMin, __CLC_MIN, uint, UINT_MAX)
+__CLC_SUBGROUP_COLLECTIVE(SMin, __CLC_MIN, long, LONG_MAX)
+__CLC_SUBGROUP_COLLECTIVE(UMin, __CLC_MIN, ulong, ULONG_MAX)
+__CLC_SUBGROUP_COLLECTIVE(FMin, __CLC_MIN, float, FLT_MAX)
+__CLC_SUBGROUP_COLLECTIVE(FMin, __CLC_MIN, double, DBL_MAX)
+
+__CLC_SUBGROUP_COLLECTIVE(SMax, __CLC_MAX, char, CHAR_MIN)
+__CLC_SUBGROUP_COLLECTIVE(UMax, __CLC_MAX, uchar, 0)
+__CLC_SUBGROUP_COLLECTIVE(SMax, __CLC_MAX, short, SHRT_MIN)
+__CLC_SUBGROUP_COLLECTIVE(UMax, __CLC_MAX, ushort, 0)
+__CLC_SUBGROUP_COLLECTIVE(SMax, __CLC_MAX, int, INT_MIN)
+__CLC_SUBGROUP_COLLECTIVE(UMax, __CLC_MAX, uint, 0)
+__CLC_SUBGROUP_COLLECTIVE(SMax, __CLC_MAX, long, LONG_MIN)
+__CLC_SUBGROUP_COLLECTIVE(UMax, __CLC_MAX, ulong, 0)
+__CLC_SUBGROUP_COLLECTIVE(FMax, __CLC_MAX, float, -FLT_MAX)
+__CLC_SUBGROUP_COLLECTIVE(FMax, __CLC_MAX, double, -DBL_MAX)
+
+#undef __CLC_SUBGROUP_COLLECTIVE
+
+#define __CLC_GROUP_COLLECTIVE(NAME, OP, TYPE, IDENTITY)                       \
+  _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT TYPE __CLC_APPEND(                    \
+      __spirv_Group, NAME)(uint scope, uint op, TYPE x) {                      \
+    TYPE carry = IDENTITY;                                                     \
+    /* Perform GroupOperation within sub-group */                              \
+    TYPE sg_x = __CLC_APPEND(__clc__Subgroup, NAME)(op, x, &carry);            \
+    if (scope == Subgroup) {                                                   \
+      return sg_x;                                                             \
+    }                                                                          \
+    __local TYPE *scratch = __CLC_APPEND(__clc__get_group_scratch_, TYPE)();   \
+    uint sg_id = __spirv_SubgroupId();                                         \
+    uint num_sg = __spirv_NumSubgroups();                                      \
+    uint sg_lid = __spirv_SubgroupLocalInvocationId();                         \
+    uint sg_size = __spirv_SubgroupSize();                                     \
+    /* Share carry values across sub-groups */                                 \
+    if (sg_lid == sg_size - 1) {                                               \
+      scratch[sg_id] = carry;                                                  \
+    }                                                                          \
+    __spirv_ControlBarrier(Workgroup, 0, 0);                                   \
+    /* Perform InclusiveScan over sub-group results */                         \
+    /* FIXME: Ideally, use an alternative algorithm that doesn't require two   \
+     * calls to __syncthreads() */                                             \
+    for (int o = 1; o < num_sg; o *= 2) {                                      \
+      TYPE contribution = IDENTITY;                                            \
+      if (sg_id >= o && sg_lid == 0) {                                         \
+        contribution = scratch[sg_id - o];                                     \
+      }                                                                        \
+      __spirv_ControlBarrier(Workgroup, 0, 0);                                 \
+      if (sg_id >= o && sg_lid == 0) {                                         \
+        scratch[sg_id] = OP(scratch[sg_id], contribution);                     \
+      }                                                                        \
+      __spirv_ControlBarrier(Workgroup, 0, 0);                                 \
+    }                                                                          \
+    /* For Reduce, broadcast result from final sub-group */                    \
+    /* For Scan, combine results from previous sub-groups */                   \
+    TYPE result;                                                               \
+    if (op == Reduce) {                                                        \
+      result = scratch[num_sg - 1];                                            \
+    } else if (op == InclusiveScan || op == ExclusiveScan) {                   \
+      if (sg_id == 0) {                                                        \
+        result = sg_x;                                                         \
+      } else {                                                                 \
+        result = OP(sg_x, scratch[sg_id - 1]);                                 \
+      }                                                                        \
+    }                                                                          \
+    return result;                                                             \
+  }
+
+__CLC_GROUP_COLLECTIVE(BitwiseOr, __CLC_OR, bool, false);
+__CLC_GROUP_COLLECTIVE(BitwiseAny, __CLC_AND, bool, true);
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT bool __spirv_GroupAny(uint scope,
+                                                             bool predicate) {
+  return __spirv_GroupBitwiseOr(scope, Reduce, predicate);
+}
+_CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT bool __spirv_GroupAll(uint scope,
+                                                             bool predicate) {
+  return __spirv_GroupBitwiseAny(scope, Reduce, predicate);
+}
+
+__CLC_GROUP_COLLECTIVE(IAdd, __CLC_ADD, char, 0)
+__CLC_GROUP_COLLECTIVE(IAdd, __CLC_ADD, uchar, 0)
+__CLC_GROUP_COLLECTIVE(IAdd, __CLC_ADD, short, 0)
+__CLC_GROUP_COLLECTIVE(IAdd, __CLC_ADD, ushort, 0)
+__CLC_GROUP_COLLECTIVE(IAdd, __CLC_ADD, int, 0)
+__CLC_GROUP_COLLECTIVE(IAdd, __CLC_ADD, uint, 0)
+__CLC_GROUP_COLLECTIVE(IAdd, __CLC_ADD, long, 0)
+__CLC_GROUP_COLLECTIVE(IAdd, __CLC_ADD, ulong, 0)
+__CLC_GROUP_COLLECTIVE(FAdd, __CLC_ADD, float, 0)
+__CLC_GROUP_COLLECTIVE(FAdd, __CLC_ADD, double, 0)
+
+__CLC_GROUP_COLLECTIVE(SMin, __CLC_MIN, char, CHAR_MAX)
+__CLC_GROUP_COLLECTIVE(UMin, __CLC_MIN, uchar, UCHAR_MAX)
+__CLC_GROUP_COLLECTIVE(SMin, __CLC_MIN, short, SHRT_MAX)
+__CLC_GROUP_COLLECTIVE(UMin, __CLC_MIN, ushort, USHRT_MAX)
+__CLC_GROUP_COLLECTIVE(SMin, __CLC_MIN, int, INT_MAX)
+__CLC_GROUP_COLLECTIVE(UMin, __CLC_MIN, uint, UINT_MAX)
+__CLC_GROUP_COLLECTIVE(SMin, __CLC_MIN, long, LONG_MAX)
+__CLC_GROUP_COLLECTIVE(UMin, __CLC_MIN, ulong, ULONG_MAX)
+__CLC_GROUP_COLLECTIVE(FMin, __CLC_MIN, float, FLT_MAX)
+__CLC_GROUP_COLLECTIVE(FMin, __CLC_MIN, double, DBL_MAX)
+
+__CLC_GROUP_COLLECTIVE(SMax, __CLC_MAX, char, CHAR_MIN)
+__CLC_GROUP_COLLECTIVE(UMax, __CLC_MAX, uchar, 0)
+__CLC_GROUP_COLLECTIVE(SMax, __CLC_MAX, short, SHRT_MIN)
+__CLC_GROUP_COLLECTIVE(UMax, __CLC_MAX, ushort, 0)
+__CLC_GROUP_COLLECTIVE(SMax, __CLC_MAX, int, INT_MIN)
+__CLC_GROUP_COLLECTIVE(UMax, __CLC_MAX, uint, 0)
+__CLC_GROUP_COLLECTIVE(SMax, __CLC_MAX, long, LONG_MIN)
+__CLC_GROUP_COLLECTIVE(UMax, __CLC_MAX, ulong, 0)
+__CLC_GROUP_COLLECTIVE(FMax, __CLC_MAX, float, -FLT_MAX)
+__CLC_GROUP_COLLECTIVE(FMax, __CLC_MAX, double, -DBL_MAX)
+
+#undef __CLC_GROUP_COLLECTIVE
+
+#undef __CLC_AND
+#undef __CLC_OR
+#undef __CLC_MAX
+#undef __CLC_MIN
+#undef __CLC_ADD
+
+long __clc__get_linear_local_id() {
+  size_t id_x = __spirv_LocalInvocationId_x();
+  size_t id_y = __spirv_LocalInvocationId_y();
+  size_t id_z = __spirv_LocalInvocationId_z();
+  size_t size_x = __spirv_WorkgroupSize_x();
+  size_t size_y = __spirv_WorkgroupSize_y();
+  size_t size_z = __spirv_WorkgroupSize_z();
+  uint sg_size = __spirv_SubgroupMaxSize();
+  return (id_z * size_y * size_x + id_y * size_x + id_x);
+}
+
+long __clc__2d_to_linear_local_id(ulong2 id) {
+  size_t size_x = __spirv_WorkgroupSize_x();
+  size_t size_y = __spirv_WorkgroupSize_y();
+  return (id.y * size_x + id.x);
+}
+
+long __clc__3d_to_linear_local_id(ulong3 id) {
+  size_t size_x = __spirv_WorkgroupSize_x();
+  size_t size_y = __spirv_WorkgroupSize_y();
+  size_t size_z = __spirv_WorkgroupSize_z();
+  return (id.z * size_y * size_x + id.y * size_x + id.x);
+}
+
+#define __CLC_GROUP_BROADCAST(TYPE)                                            \
+  _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT TYPE __spirv_GroupBroadcast(          \
+      uint scope, TYPE x, ulong local_id) {                                    \
+    if (scope == Subgroup) {                                                   \
+      return __clc__SubgroupShuffle(x, local_id);                              \
+    }                                                                          \
+    bool source = (__clc__get_linear_local_id() == local_id);                  \
+    __local TYPE *scratch = __CLC_APPEND(__clc__get_group_scratch_, TYPE)();   \
+    if (source) {                                                              \
+      *scratch = x;                                                            \
+    }                                                                          \
+    __spirv_ControlBarrier(Workgroup, 0, 0);                                   \
+    TYPE result = *scratch;                                                    \
+    __spirv_ControlBarrier(Workgroup, 0, 0);                                   \
+    return result;                                                             \
+  }                                                                            \
+  _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT TYPE __spirv_GroupBroadcast(          \
+      uint scope, TYPE x, ulong2 local_id) {                                   \
+    ulong linear_local_id = __clc__2d_to_linear_local_id(local_id);            \
+    return __spirv_GroupBroadcast(scope, x, linear_local_id);                  \
+  }                                                                            \
+  _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT TYPE __spirv_GroupBroadcast(          \
+      uint scope, TYPE x, ulong3 local_id) {                                   \
+    ulong linear_local_id = __clc__3d_to_linear_local_id(local_id);            \
+    return __spirv_GroupBroadcast(scope, x, linear_local_id);                  \
+  }
+__CLC_GROUP_BROADCAST(char);
+__CLC_GROUP_BROADCAST(uchar);
+__CLC_GROUP_BROADCAST(short);
+__CLC_GROUP_BROADCAST(ushort);
+__CLC_GROUP_BROADCAST(int)
+__CLC_GROUP_BROADCAST(uint)
+__CLC_GROUP_BROADCAST(long)
+__CLC_GROUP_BROADCAST(ulong)
+__CLC_GROUP_BROADCAST(float)
+__CLC_GROUP_BROADCAST(double)
+
+#undef __CLC_GROUP_BROADCAST
+
+#undef __CLC_APPEND

--- a/libclc/ptx-nvidiacl/libspirv/group/collectives_helpers.ll
+++ b/libclc/ptx-nvidiacl/libspirv/group/collectives_helpers.ll
@@ -1,0 +1,54 @@
+; 64 storage locations is sufficient for all current-generation NVIDIA GPUs
+; 64 bits per warp is sufficient for all fundamental data types
+; Reducing storage for small data types or increasing it for user-defined types
+; will likely require an additional pass to track group algorithm usage
+@__clc__group_scratch = internal addrspace(3) global [64 x i64] undef, align 1
+
+define i8 addrspace(3)* @__clc__get_group_scratch_bool() nounwind alwaysinline {
+entry:
+  %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
+  ret i8 addrspace(3)* %cast
+}
+
+define i8 addrspace(3)* @__clc__get_group_scratch_char() nounwind alwaysinline {
+entry:
+  %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
+  ret i8 addrspace(3)* %cast
+}
+
+define i8 addrspace(3)* @__clc__get_group_scratch_short() nounwind alwaysinline {
+entry:
+  %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
+  ret i8 addrspace(3)* %cast
+}
+
+define i32 addrspace(3)* @__clc__get_group_scratch_int() nounwind alwaysinline {
+entry:
+  %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %cast = bitcast i64 addrspace(3)* %ptr to i32 addrspace(3)*
+  ret i32 addrspace(3)* %cast
+}
+
+define i64 addrspace(3)* @__clc__get_group_scratch_long() nounwind alwaysinline {
+entry:
+  %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %cast = bitcast i64 addrspace(3)* %ptr to i64 addrspace(3)*
+  ret i64 addrspace(3)* %cast
+}
+
+define float addrspace(3)* @__clc__get_group_scratch_float() nounwind alwaysinline {
+entry:
+  %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %cast = bitcast i64 addrspace(3)* %ptr to float addrspace(3)*
+  ret float addrspace(3)* %cast
+}
+
+define double addrspace(3)* @__clc__get_group_scratch_double() nounwind alwaysinline {
+entry:
+  %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %cast = bitcast i64 addrspace(3)* %ptr to double addrspace(3)*
+  ret double addrspace(3)* %cast
+}

--- a/libclc/ptx-nvidiacl/libspirv/group/collectives_helpers.ll
+++ b/libclc/ptx-nvidiacl/libspirv/group/collectives_helpers.ll
@@ -18,11 +18,11 @@ entry:
   ret i8 addrspace(3)* %cast
 }
 
-define i8 addrspace(3)* @__clc__get_group_scratch_short() nounwind alwaysinline {
+define i16 addrspace(3)* @__clc__get_group_scratch_short() nounwind alwaysinline {
 entry:
   %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
-  ret i8 addrspace(3)* %cast
+  %cast = bitcast i64 addrspace(3)* %ptr to i16 addrspace(3)*
+  ret i16 addrspace(3)* %cast
 }
 
 define i32 addrspace(3)* @__clc__get_group_scratch_int() nounwind alwaysinline {

--- a/libclc/ptx-nvidiacl/libspirv/group/collectives_helpers.ll
+++ b/libclc/ptx-nvidiacl/libspirv/group/collectives_helpers.ll
@@ -39,6 +39,13 @@ entry:
   ret i64 addrspace(3)* %cast
 }
 
+define half addrspace(3)* @__clc__get_group_scratch_half() nounwind alwaysinline {
+entry:
+  %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %cast = bitcast i64 addrspace(3)* %ptr to half addrspace(3)*
+  ret half addrspace(3)* %cast
+}
+
 define float addrspace(3)* @__clc__get_group_scratch_float() nounwind alwaysinline {
 entry:
   %ptr = getelementptr inbounds [64 x i64], [64 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0

--- a/sycl/doc/extensions/README.md
+++ b/sycl/doc/extensions/README.md
@@ -14,7 +14,7 @@ DPC++ extensions status:
 | [SYCL_INTEL_device_specific_kernel_queries](DeviceSpecificKernelQueries/SYCL_INTEL_device_specific_kernel_queries.asciidoc) | Proposal                                  | |
 | [SYCL_INTEL_enqueue_barrier](EnqueueBarrier/enqueue_barrier.asciidoc)                                                       | Supported(OpenCL, Level Zero)             | |
 | [SYCL_INTEL_extended_atomics](ExtendedAtomics/SYCL_INTEL_extended_atomics.asciidoc)                                         | Supported(OpenCL: CPU, GPU)               | |
-| [SYCL_INTEL_group_algorithms](GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc)                                         | Supported(OpenCL)                         | |
+| [SYCL_INTEL_group_algorithms](GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc)                                         | Supported(OpenCL; CUDA)                   | |
 | [SYCL_INTEL_group_mask](./GroupMask/SYCL_INTEL_group_mask.asciidoc)                                                         | Proposal                                  | |
 | [FPGA selector](IntelFPGA/FPGASelector.md)                                                                                  | Supported                                 | |
 | [FPGA reg](IntelFPGA/FPGAReg.md)                                                                                            | Supported(OpenCL: ACCELERATOR)            | |
@@ -22,7 +22,7 @@ DPC++ extensions status:
 | [SYCL_INTEL_attribute_style](KernelRHSAttributes/SYCL_INTEL_attribute_style.asciidoc)                                       | Proposal                                  | |
 | [Queue Order Properties](OrderedQueue/OrderedQueue_v2.adoc)                                                                 | Supported                                 | |
 | [Queue Shortcuts](QueueShortcuts/QueueShortcuts.adoc)                                                                       | Supported                                 | |
-| [Reductions for ND-Range Parallelism](Reduction/Reduction.md)                                                               | Partially supported(OpenCL: CPU, GPU)     | Not supported: multiple reduction vars, multi-dimensional reduction vars |
+| [Reductions for ND-Range Parallelism](Reduction/Reduction.md)                                                               | Partially supported(OpenCL: CPU, GPU; CUDA) | Not supported: multiple reduction vars, multi-dimensional reduction vars |
 | [SYCL_INTEL_relax_standard_layout](RelaxStdLayout/SYCL_INTEL_relax_standard_layout.asciidoc)                                | Supported                                 | |
 | [SYCL_INTEL_reqd_work_group_size](ReqdWorkGroupSize/SYCL_INTEL_reqd_work_group_size.asciidoc)                               | Supported(OpenCL: CPU, GPU)               | |
 | [SPV_INTEL_function_pointers](SPIRV/SPV_INTEL_function_pointers.asciidoc)                                                   | Supported(OpenCL: CPU, GPU; HOST)         | |

--- a/sycl/test/group-algorithm/all_of.cpp
+++ b/sycl/test/group-algorithm/all_of.cpp
@@ -1,12 +1,10 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -I . -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+#include "support.h"
 #include <CL/sycl.hpp>
 #include <algorithm>
 #include <cassert>
@@ -32,7 +30,7 @@ void test(queue q, InputContainer input, OutputContainer output,
           Predicate pred) {
   typedef class all_of_kernel<Predicate> kernel_name;
   size_t N = input.size();
-  size_t G = 16;
+  size_t G = 64;
   {
     buffer<int> in_buf(input.data(), input.size());
     buffer<bool> out_buf(output.data(), output.size());
@@ -57,13 +55,12 @@ void test(queue q, InputContainer input, OutputContainer output,
 
 int main() {
   queue q;
-  std::string version = q.get_device().get_info<info::device::version>();
-  if (version < std::string("2.0")) {
+  if (!isSupportedDevice(q.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
 
-  constexpr int N = 32;
+  constexpr int N = 128;
   std::array<int, N> input;
   std::array<bool, 3> output;
   std::iota(input.begin(), input.end(), 0);

--- a/sycl/test/group-algorithm/any_of.cpp
+++ b/sycl/test/group-algorithm/any_of.cpp
@@ -1,12 +1,10 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -I . -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+#include "support.h"
 #include <CL/sycl.hpp>
 #include <algorithm>
 #include <cassert>
@@ -34,7 +32,7 @@ void test(queue q, InputContainer input, OutputContainer output,
   typedef typename OutputContainer::value_type OutputT;
   typedef class any_of_kernel<Predicate> kernel_name;
   size_t N = input.size();
-  size_t G = 16;
+  size_t G = 64;
   {
     buffer<InputT> in_buf(input.data(), input.size());
     buffer<OutputT> out_buf(output.data(), output.size());
@@ -59,13 +57,12 @@ void test(queue q, InputContainer input, OutputContainer output,
 
 int main() {
   queue q;
-  std::string version = q.get_device().get_info<info::device::version>();
-  if (version < std::string("2.0")) {
+  if (!isSupportedDevice(q.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
 
-  constexpr int N = 32;
+  constexpr int N = 128;
   std::array<int, N> input;
   std::array<bool, 3> output;
   std::iota(input.begin(), input.end(), 0);

--- a/sycl/test/group-algorithm/broadcast.cpp
+++ b/sycl/test/group-algorithm/broadcast.cpp
@@ -1,12 +1,10 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+#include "support.h"
 #include <CL/sycl.hpp>
 #include <algorithm>
 #include <cassert>
@@ -46,8 +44,7 @@ void test(queue q, InputContainer input, OutputContainer output) {
 
 int main() {
   queue q;
-  std::string version = q.get_device().get_info<info::device::version>();
-  if (version < std::string("2.0")) {
+  if (!isSupportedDevice(q.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }

--- a/sycl/test/group-algorithm/exclusive_scan.cpp
+++ b/sycl/test/group-algorithm/exclusive_scan.cpp
@@ -1,7 +1,4 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -I . -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -13,8 +10,10 @@
 // unconditionally. Using operators specific for spirv 1.3 and higher with
 // -spirv-max-version=1.1 being set by default causes assert/check fails
 // in spirv translator.
-// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -o %t13.out
+// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o
+// %t13.out
 
+#include "support.h"
 #include <CL/sycl.hpp>
 #include <algorithm>
 #include <cassert>
@@ -57,7 +56,7 @@ void test(queue q, InputContainer input, OutputContainer output,
   typedef class exclusive_scan_kernel<SpecializationKernelName, 3> kernel_name3;
   OutputT init = 42;
   size_t N = input.size();
-  size_t G = 16;
+  size_t G = 64;
   std::vector<OutputT> expected(N);
   {
     buffer<InputT> in_buf(input.data(), input.size());
@@ -128,24 +127,6 @@ void test(queue q, InputContainer input, OutputContainer output,
   assert(std::equal(output.begin(), output.begin() + N, expected.begin()));
 }
 
-bool isSupportedDevice(device D) {
-  std::string PlatformName = D.get_platform().get_info<info::platform::name>();
-  if (PlatformName.find("Level-Zero") != std::string::npos)
-    return true;
-
-  if (PlatformName.find("OpenCL") != std::string::npos) {
-    std::string Version = D.get_info<info::device::version>();
-    size_t Offset = Version.find("OpenCL");
-    if (Offset == std::string::npos)
-      return false;
-    Version = Version.substr(Offset + 7, 3);
-    if (Version >= std::string("2.0"))
-      return true;
-  }
-
-  return false;
-}
-
 int main() {
   queue q;
   if (!isSupportedDevice(q.get_device())) {
@@ -153,7 +134,7 @@ int main() {
     return 0;
   }
 
-  constexpr int N = 32;
+  constexpr int N = 128;
   std::array<int, N> input;
   std::array<int, N> output;
   std::iota(input.begin(), input.end(), 0);

--- a/sycl/test/group-algorithm/exclusive_scan.cpp
+++ b/sycl/test/group-algorithm/exclusive_scan.cpp
@@ -10,8 +10,8 @@
 // unconditionally. Using operators specific for spirv 1.3 and higher with
 // -spirv-max-version=1.1 being set by default causes assert/check fails
 // in spirv translator.
-// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o
-// %t13.out
+// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o \
+   %t13.out
 
 #include "support.h"
 #include <CL/sycl.hpp>

--- a/sycl/test/group-algorithm/inclusive_scan.cpp
+++ b/sycl/test/group-algorithm/inclusive_scan.cpp
@@ -10,8 +10,8 @@
 // unconditionally. Using operators specific for spirv 1.3 and higher with
 // -spirv-max-version=1.1 being set by default causes assert/check fails
 // in spirv translator.
-// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o
-// %t13.out
+// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o \
+   %t13.out
 
 #include "support.h"
 #include <CL/sycl.hpp>

--- a/sycl/test/group-algorithm/inclusive_scan.cpp
+++ b/sycl/test/group-algorithm/inclusive_scan.cpp
@@ -1,7 +1,4 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -I . -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -13,8 +10,10 @@
 // unconditionally. Using operators specific for spirv 1.3 and higher with
 // -spirv-max-version=1.1 being set by default causes assert/check fails
 // in spirv translator.
-// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -o %t13.out
+// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o
+// %t13.out
 
+#include "support.h"
 #include <CL/sycl.hpp>
 #include <algorithm>
 #include <cassert>
@@ -57,7 +56,7 @@ void test(queue q, InputContainer input, OutputContainer output,
   typedef class inclusive_scan_kernel<SpecializationKernelName, 3> kernel_name3;
   OutputT init = 42;
   size_t N = input.size();
-  size_t G = 16;
+  size_t G = 64;
   std::vector<OutputT> expected(N);
   {
     buffer<InputT> in_buf(input.data(), input.size());
@@ -128,24 +127,6 @@ void test(queue q, InputContainer input, OutputContainer output,
   assert(std::equal(output.begin(), output.begin() + N, expected.begin()));
 }
 
-bool isSupportedDevice(device D) {
-  std::string PlatformName = D.get_platform().get_info<info::platform::name>();
-  if (PlatformName.find("Level-Zero") != std::string::npos)
-    return true;
-
-  if (PlatformName.find("OpenCL") != std::string::npos) {
-    std::string Version = D.get_info<info::device::version>();
-    size_t Offset = Version.find("OpenCL");
-    if (Offset == std::string::npos)
-      return false;
-    Version = Version.substr(Offset + 7, 3);
-    if (Version >= std::string("2.0"))
-      return true;
-  }
-
-  return false;
-}
-
 int main() {
   queue q;
   if (!isSupportedDevice(q.get_device())) {
@@ -153,7 +134,7 @@ int main() {
     return 0;
   }
 
-  constexpr int N = 32;
+  constexpr int N = 128;
   std::array<int, N> input;
   std::array<int, N> output;
   std::iota(input.begin(), input.end(), 0);

--- a/sycl/test/group-algorithm/none_of.cpp
+++ b/sycl/test/group-algorithm/none_of.cpp
@@ -1,12 +1,10 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -I . -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+#include "support.h"
 #include <CL/sycl.hpp>
 #include <algorithm>
 #include <cassert>
@@ -32,7 +30,7 @@ void test(queue q, InputContainer input, OutputContainer output,
           Predicate pred) {
   typedef class none_of_kernel<Predicate> kernel_name;
   size_t N = input.size();
-  size_t G = 16;
+  size_t G = 64;
   {
     buffer<int> in_buf(input.data(), input.size());
     buffer<bool> out_buf(output.data(), output.size());
@@ -57,13 +55,12 @@ void test(queue q, InputContainer input, OutputContainer output,
 
 int main() {
   queue q;
-  std::string version = q.get_device().get_info<info::device::version>();
-  if (version < std::string("2.0")) {
+  if (!isSupportedDevice(q.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
 
-  constexpr int N = 32;
+  constexpr int N = 128;
   std::array<int, N> input;
   std::array<bool, 3> output;
   std::iota(input.begin(), input.end(), 0);

--- a/sycl/test/group-algorithm/reduce.cpp
+++ b/sycl/test/group-algorithm/reduce.cpp
@@ -10,8 +10,8 @@
 // unconditionally. Using operators specific for spirv 1.3 and higher with
 // -spirv-max-version=1.1 being set by default causes assert/check fails
 // in spirv translator.
-// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o
-// %t13.out
+// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o \
+   %t13.out
 
 #include "support.h"
 #include <CL/sycl.hpp>

--- a/sycl/test/group-algorithm/reduce.cpp
+++ b/sycl/test/group-algorithm/reduce.cpp
@@ -1,7 +1,4 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -I . -o %t.out
 // RUN: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -13,8 +10,10 @@
 // unconditionally. Using operators specific for spirv 1.3 and higher with
 // -spirv-max-version=1.1 being set by default causes assert/check fails
 // in spirv translator.
-// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -o %t13.out
+// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o
+// %t13.out
 
+#include "support.h"
 #include <CL/sycl.hpp>
 #include <algorithm>
 #include <cassert>
@@ -32,7 +31,7 @@ void test(queue q, InputContainer input, OutputContainer output,
   typedef typename OutputContainer::value_type OutputT;
   OutputT init = 42;
   size_t N = input.size();
-  size_t G = 16;
+  size_t G = 64;
   {
     buffer<InputT> in_buf(input.data(), input.size());
     buffer<OutputT> out_buf(output.data(), output.size());
@@ -64,24 +63,6 @@ void test(queue q, InputContainer input, OutputContainer output,
          std::accumulate(input.begin(), input.end(), init, binary_op));
 }
 
-bool isSupportedDevice(device D) {
-  std::string PlatformName = D.get_platform().get_info<info::platform::name>();
-  if (PlatformName.find("Level-Zero") != std::string::npos)
-    return true;
-
-  if (PlatformName.find("OpenCL") != std::string::npos) {
-    std::string Version = D.get_info<info::device::version>();
-    size_t Offset = Version.find("OpenCL");
-    if (Offset == std::string::npos)
-      return false;
-    Version = Version.substr(Offset + 7, 3);
-    if (Version >= std::string("2.0"))
-      return true;
-  }
-
-  return false;
-}
-
 int main() {
   queue q;
   if (!isSupportedDevice(q.get_device())) {
@@ -89,7 +70,7 @@ int main() {
     return 0;
   }
 
-  constexpr int N = 32;
+  constexpr int N = 128;
   std::array<int, N> input;
   std::array<int, 4> output;
   std::iota(input.begin(), input.end(), 0);

--- a/sycl/test/group-algorithm/support.h
+++ b/sycl/test/group-algorithm/support.h
@@ -1,0 +1,24 @@
+#include <CL/sycl.hpp>
+using namespace sycl;
+using namespace sycl::ONEAPI;
+
+bool isSupportedDevice(device D) {
+  std::string PlatformName = D.get_platform().get_info<info::platform::name>();
+  if (PlatformName.find("CUDA") != std::string::npos)
+    return true;
+
+  if (PlatformName.find("Level-Zero") != std::string::npos)
+    return true;
+
+  if (PlatformName.find("OpenCL") != std::string::npos) {
+    std::string Version = D.get_info<info::device::version>();
+    size_t Offset = Version.find("OpenCL");
+    if (Offset == std::string::npos)
+      return false;
+    Version = Version.substr(Offset + 7, 3);
+    if (Version >= std::string("2.0"))
+      return true;
+  }
+
+  return false;
+}

--- a/sycl/test/reduction/reduction_nd_conditional.cpp
+++ b/sycl/test/reduction/reduction_nd_conditional.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// Reductions use work-group builtins not yet supported by CUDA.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_ext_double.cpp
+++ b/sycl/test/reduction/reduction_nd_ext_double.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_ext_half.cpp
+++ b/sycl/test/reduction/reduction_nd_ext_half.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/sycl/test/reduction/reduction_nd_lambda.cpp
+++ b/sycl/test/reduction/reduction_nd_lambda.cpp
@@ -1,7 +1,3 @@
-// UNSUPPORTED: cuda
-// Reductions use work-group builtins (e.g. ONEAPI::reduce()) not yet supported
-// by CUDA.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_s0_dw.cpp
+++ b/sycl/test/reduction/reduction_nd_s0_dw.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// Reductions use work-group builtins not yet supported by CUDA.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_s0_rw.cpp
+++ b/sycl/test/reduction/reduction_nd_s0_rw.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// Reductions use work-group builtins not yet supported by CUDA.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_s1_dw.cpp
+++ b/sycl/test/reduction/reduction_nd_s1_dw.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// Reductions use work-group builtins not yet supported by CUDA.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_nd_s1_rw.cpp
+++ b/sycl/test/reduction/reduction_nd_s1_rw.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// OpenCL C 2.x alike work-group functions not yet supported by CUDA.
-//
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: env SYCL_DEVICE_TYPE=HOST %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_placeholder.cpp
+++ b/sycl/test/reduction/reduction_placeholder.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// Reductions use work-group builtins not yet supported by CUDA.
-
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_transparent.cpp
+++ b/sycl/test/reduction/reduction_transparent.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// Reductions use work-group builtins not yet supported by CUDA.
-
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/sycl/test/reduction/reduction_usm.cpp
+++ b/sycl/test/reduction/reduction_usm.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: cuda
-// Reductions use work-group builtins not yet supported by CUDA.
-
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Adds support for the following SPIR-V instructions to libclc:
- OpGroupAll, OpGroupAny
- OpGroupBroadcast
- OpGroupIAdd, OpGroupFAdd
- OpGroupFMin, OpGroupUMin, OpGroupSMin
- OpGroupFMax, OpGroupUMax, OpGroupSMax

At sub-group scope, these operations employ shuffles and other warp
instructions.

At work-group scope, partial results from each sub-group are combined
via shared memory.

The current implementation reserves 512 bytes of shared memory for any kernel
using a group algorithm, which is sufficient to cover the worst case.
Determining the correct amount of shared memory to reserve for a specific
kernel will likely require a dedicated compiler pass.

Signed-off-by: John Pennycook <john.pennycook@intel.com>