### PR TITLE
[SYCL] Reinitialize moved containers

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -217,6 +217,11 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
     std::lock_guard<mutex_class> Lock(MMutex);
     Events = std::move(MEventsWeak);
     USMEvents = std::move(MEventsShared);
+
+    // moved objects are in "valid but unspecified state". It's okay to only
+    // clear the vector. Though, we'll recostruct it hust to be sure.
+    MEventsWeak = vector_class<std::weak_ptr<event_impl>>{};
+    MEventsShared = vector_class<event>{};
   }
 
   for (std::weak_ptr<event_impl> &EventImplWeakPtr : Events)

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -215,13 +215,8 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
   vector_class<event> USMEvents;
   {
     std::lock_guard<mutex_class> Lock(MMutex);
-    Events = std::move(MEventsWeak);
-    USMEvents = std::move(MEventsShared);
-
-    // moved objects are in "valid but unspecified state". It's okay to only
-    // clear the vector. Though, we'll recostruct it hust to be sure.
-    MEventsWeak = vector_class<std::weak_ptr<event_impl>>{};
-    MEventsShared = vector_class<event>{};
+    Events.swap(MEventsWeak);
+    USMEvents.swap(MEventsShared);
   }
 
   for (std::weak_ptr<event_impl> &EventImplWeakPtr : Events)

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -227,6 +227,8 @@ public:
     {
       std::lock_guard<mutex_class> Lock(MMutex);
       Exceptions = std::move(MExceptions);
+
+      MExceptions = exception_list{};
     }
     // Unlock the mutex before calling user-provided handler to avoid
     // potential deadlock if the same queue is somehow referenced in the

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -226,9 +226,7 @@ public:
     exception_list Exceptions;
     {
       std::lock_guard<mutex_class> Lock(MMutex);
-      Exceptions = std::move(MExceptions);
-
-      MExceptions = exception_list{};
+      std::swap(Exceptions, MExceptions);
     }
     // Unlock the mutex before calling user-provided handler to avoid
     // potential deadlock if the same queue is somehow referenced in the


### PR DESCRIPTION
Moved objects are in "valid but unspecified state". Using moved objects leads to undefined behaviour. It's okay to only clear moved containers if `clear` method doesn't imply any preconditions. Hence we will reinitialize the containers just to be sure.