### PR TITLE
[SYCL][RT] do not assume Linux always has aligned_alloc

### DIFF
--- a/sycl/include/CL/sycl/detail/os_util.hpp
+++ b/sycl/include/CL/sycl/detail/os_util.hpp
@@ -14,7 +14,7 @@
 #include <CL/sycl/detail/export.hpp>
 
 #include <cstdint>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 
 #ifdef _WIN32

--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -11,10 +11,6 @@
 
 #include <cassert>
 
-#ifdef SYCL_RT_OS_POSIX_SUPPORT
-#include <cstdlib>
-#endif
-
 #if defined(SYCL_RT_OS_LINUX)
 
 #ifndef _GNU_SOURCE
@@ -242,7 +238,8 @@ size_t OSUtil::getOSMemSize() {
 }
 
 void *OSUtil::alignedAlloc(size_t Alignment, size_t NumBytes) {
-#if defined(SYCL_RT_OS_LINUX)
+#if defined(SYCL_RT_OS_LINUX) && (defined(_GLIBCXX_HAVE_ALIGNED_ALLOC) ||      \
+                                  defined(_LIBCPP_HAS_C11_FEATURES))
   return aligned_alloc(Alignment, NumBytes);
 #elif defined(SYCL_RT_OS_POSIX_SUPPORT)
   void *Addr = nullptr;


### PR DESCRIPTION
Older glibc lacks aligned_alloc (C11 and C++17).
Dropping through to the POSIX option (`posix_memalign`) is necessary
on such systems.

The lazy way to detect if aligned_alloc is supported is:
```c++
defined(_GLIBCXX_HAVE_ALIGNED_ALLOC) || defined(_LIBCPP_HAS_C11_FEATURES)
```
This does not work for C++ libraries besides GCC and LLVM (e.g. MUSL)
but unless those are explicitly supported and tested, we should not
need to include them here anyways.

The inclusion of stdlib.h was changed to cstdlib, as appropriate for C++
code.  The conditional inclusion of cstdlib in the cpp file was removed
since it was included unconditionally in the header.

Signed-off-by: Jeff Hammond <jeff.r.hammond@intel.com>