### PR TITLE
Add `private_memory::operator()` support to xmethods

### DIFF
--- a/sycl/test/gdb/private-memory-device.cpp
+++ b/sycl/test/gdb/private-memory-device.cpp
@@ -1,0 +1,12 @@
+// RUN: %clangxx -fsycl-device-only -c -fno-color-diagnostics -Xclang -ast-dump %s -I %sycl_include -Wno-sycl-strict | FileCheck %s
+// UNSUPPORTED: windows
+#include <CL/sycl/group.hpp>
+#include <CL/sycl/id.hpp>
+
+typedef cl::sycl::private_memory<cl::sycl::id<1>, 1> dummy;
+
+// private_memory must have Val field of T type
+
+// CHECK: CXXRecordDecl {{.*}} class private_memory definition
+// CHECK-NOT: CXXRecordDecl {{.*}} definition
+// CHECK: FieldDecl {{.*}} referenced Val 'T'

--- a/sycl/test/gdb/private-memory.cpp
+++ b/sycl/test/gdb/private-memory.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx -c -fsycl -fno-color-diagnostics -Xclang -ast-dump %s | FileCheck %s
+// UNSUPPORTED: windows
+#include <CL/sycl/group.hpp>
+#include <CL/sycl/id.hpp>
+
+typedef cl::sycl::private_memory<cl::sycl::id<1>, 1> dummy;
+
+// private_memory must have Val field of unique_ptr<T [], ...> type
+
+// CHECK: CXXRecordDecl {{.*}} class private_memory definition
+// CHECK: FieldDecl {{.*}} referenced Val {{.*}}:'unique_ptr<T []>'


### PR DESCRIPTION
Enables evaluating `pgid.operator()(wi)` in GDB when using a GPU device.

NB: this is an important fix for upcoming release, please make sure it propagates.