### PR TITLE
[BuildBot] Reorder ARM and CUDA arg parsing

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -32,15 +32,15 @@ def do_configure(args):
 
     icd_loader_lib = os.path.join(icd_loader_lib, "libOpenCL.so" if platform.system() == 'Linux' else "OpenCL.lib")
 
+    # replace not append, so ARM ^ X86
+    if args.arm:
+        llvm_targets_to_build = 'ARM;AArch64'
+
     if args.cuda:
         llvm_targets_to_build += ';NVPTX'
         llvm_enable_projects += ';libclc'
         libclc_targets_to_build = 'nvptx64--;nvptx64--nvidiacl'
         sycl_build_pi_cuda = 'ON'
-
-    # replace not append, so ARM ^ X86
-    if args.arm:
-        llvm_targets_to_build = 'ARM;AArch64'
 
     if args.no_werror:
         sycl_werror = 'OFF'


### PR DESCRIPTION
ARM replaces x86 whereas CUDA appends, so the ARM part needs to come first for `llvm_targets_to_build` to be populated correctly.

This fixes the trivial bug I introduced when adding ARM support, which wasn't relevant until now because I didn't have an ARM+NVIDIA platform on which to test.

Signed-off-by: Hammond, Jeff R <jeff.r.hammond@intel.com>