### PR TITLE
[NFC][SYCL] Use visitors to print kernel name type

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3772,12 +3772,8 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
       P.SuppressTypedefs = true;
       P.SuppressUnwrittenScope = true;
       O << "template <> struct KernelInfo<";
-      {
-        // SYCLKernelNameTypePrinter flushes internal buffer during destruction,
-        // so make sure that it is destructed before we print the next '>'.
-        SYCLKernelNameTypePrinter Printer(O, P);
-        Printer.Visit(K.NameType);
-      }
+      SYCLKernelNameTypePrinter Printer(O, P);
+      Printer.Visit(K.NameType);
       O << "> {\n";
     }
     O << "  DLL_LOCAL\n";

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3588,13 +3588,15 @@ class SYCLKernelNameTypePrinter
     }
   }
 
+  void VisitQualifiers(Qualifiers Quals) {
+    Quals.print(O, P, /*appendSpaceIfNotEmpty*/ true);
+  }
+
 public:
   SYCLKernelNameTypePrinter(raw_ostream &Out, PrintingPolicy &P)
       : Out(Out), P(P), O(Buf) {}
 
-  ~SYCLKernelNameTypePrinter() {
-    emitWithoutAnonNamespaces(Out, O.str());
-  }
+  ~SYCLKernelNameTypePrinter() { emitWithoutAnonNamespaces(Out, O.str()); }
 
   void Visit(QualType T) {
     if (T.isNull())
@@ -3604,10 +3606,6 @@ public:
     VisitQualifiers(CT.getQualifiers());
 
     InnerTypeVisitor::Visit(CT.getTypePtr());
-  }
-
-  void VisitQualifiers(Qualifiers Quals) {
-    Quals.print(O, P, /*appendSpaceIfNotEmpty*/ true);
   }
 
   void VisitType(const Type *T) {


### PR DESCRIPTION
This is the part of integration header generator refactoring to make
it use clang visitors and simplify the code.