### PR TITLE
[SYCL] Add properties argument to piMemBufferCreate

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -494,6 +494,12 @@ constexpr pi_mem_flags PI_MEM_FLAGS_HOST_PTR_USE = CL_MEM_USE_HOST_PTR;
 constexpr pi_mem_flags PI_MEM_FLAGS_HOST_PTR_COPY = CL_MEM_COPY_HOST_PTR;
 constexpr pi_mem_flags PI_MEM_FLAGS_HOST_PTR_ALLOC = CL_MEM_ALLOC_HOST_PTR;
 
+// NOTE: this is made 64-bit to match the size of cl_mem_properties_intel to
+// make the translation to OpenCL transparent.
+// TODO: populate
+//
+using pi_mem_properties = pi_bitfield;
+
 // NOTE: queue properties are implemented this way to better support bit
 // manipulations
 using pi_queue_properties = pi_bitfield;
@@ -981,7 +987,7 @@ __SYCL_EXPORT pi_result piextQueueCreateWithNativeHandle(
 //
 __SYCL_EXPORT pi_result piMemBufferCreate(
     pi_context context, pi_mem_flags flags, size_t size, void *host_ptr,
-    pi_mem *ret_mem, const cl_mem_properties_intel *properties = nullptr);
+    pi_mem *ret_mem, const pi_mem_properties *properties = nullptr);
 
 __SYCL_EXPORT pi_result piMemImageCreate(pi_context context, pi_mem_flags flags,
                                          const pi_image_format *image_format,

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -979,9 +979,9 @@ __SYCL_EXPORT pi_result piextQueueCreateWithNativeHandle(
 //
 // Memory
 //
-__SYCL_EXPORT pi_result piMemBufferCreate(pi_context context,
-                                          pi_mem_flags flags, size_t size,
-                                          void *host_ptr, pi_mem *ret_mem);
+__SYCL_EXPORT pi_result piMemBufferCreate(
+    pi_context context, pi_mem_flags flags, size_t size, void *host_ptr,
+    pi_mem *ret_mem, const cl_mem_properties_intel *properties = nullptr);
 
 __SYCL_EXPORT pi_result piMemImageCreate(pi_context context, pi_mem_flags flags,
                                          const pi_image_format *image_format,

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1627,7 +1627,8 @@ pi_result cuda_piextContextCreateWithNativeHandle(pi_native_handle nativeHandle,
 /// \TODO Implement USE_HOST_PTR using cuHostRegister
 ///
 pi_result cuda_piMemBufferCreate(pi_context context, pi_mem_flags flags,
-                                 size_t size, void *host_ptr, pi_mem *ret_mem) {
+                                 size_t size, void *host_ptr, pi_mem *ret_mem,
+                                 const cl_mem_properties_intel *properties) {
   // Need input memory object
   assert(ret_mem != nullptr);
   // Currently, USE_HOST_PTR is not implemented using host register

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1628,7 +1628,7 @@ pi_result cuda_piextContextCreateWithNativeHandle(pi_native_handle nativeHandle,
 ///
 pi_result cuda_piMemBufferCreate(pi_context context, pi_mem_flags flags,
                                  size_t size, void *host_ptr, pi_mem *ret_mem,
-                                 const cl_mem_properties_intel *properties) {
+                                 const cl_mem_properties_intel *) {
   // Need input memory object
   assert(ret_mem != nullptr);
   // Currently, USE_HOST_PTR is not implemented using host register

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1628,9 +1628,10 @@ pi_result cuda_piextContextCreateWithNativeHandle(pi_native_handle nativeHandle,
 ///
 pi_result cuda_piMemBufferCreate(pi_context context, pi_mem_flags flags,
                                  size_t size, void *host_ptr, pi_mem *ret_mem,
-                                 const cl_mem_properties_intel *) {
+                                 const pi_mem_properties *properties) {
   // Need input memory object
   assert(ret_mem != nullptr);
+  assert(properties == nullptr && "no mem properties goes to cuda RT yet");
   // Currently, USE_HOST_PTR is not implemented using host register
   // since this triggers a weird segfault after program ends.
   // Setting this constant to true enables testing that behavior.

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1909,7 +1909,7 @@ pi_result piextQueueCreateWithNativeHandle(pi_native_handle NativeHandle,
 
 pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
                             void *HostPtr, pi_mem *RetMem,
-                            const cl_mem_properties_intel *properties) {
+                            const cl_mem_properties_intel *) {
 
   // TODO: implement read-only, write-only
   assert((Flags & PI_MEM_FLAGS_ACCESS_RW) != 0);

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1909,12 +1909,13 @@ pi_result piextQueueCreateWithNativeHandle(pi_native_handle NativeHandle,
 
 pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
                             void *HostPtr, pi_mem *RetMem,
-                            const cl_mem_properties_intel *) {
+                            const pi_mem_properties *properties) {
 
   // TODO: implement read-only, write-only
   assert((Flags & PI_MEM_FLAGS_ACCESS_RW) != 0);
   assert(Context);
   assert(RetMem);
+  assert(properties == nullptr && "no mem properties goes to l0 RT yet");
 
   void *Ptr;
   ze_device_handle_t ZeDevice = Context->Devices[0]->ZeDevice;

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1915,7 +1915,8 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
   assert((Flags & PI_MEM_FLAGS_ACCESS_RW) != 0);
   assert(Context);
   assert(RetMem);
-  assert(properties == nullptr && "no mem properties goes to l0 RT yet");
+  assert(properties == nullptr &&
+         "no mem properties goes to Level-Zero RT yet");
 
   void *Ptr;
   ze_device_handle_t ZeDevice = Context->Devices[0]->ZeDevice;

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1908,7 +1908,8 @@ pi_result piextQueueCreateWithNativeHandle(pi_native_handle NativeHandle,
 }
 
 pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
-                            void *HostPtr, pi_mem *RetMem) {
+                            void *HostPtr, pi_mem *RetMem,
+                            const cl_mem_properties_intel *properties) {
 
   // TODO: implement read-only, write-only
   assert((Flags & PI_MEM_FLAGS_ACCESS_RW) != 0);

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -519,7 +519,7 @@ pi_result piextContextCreateWithNativeHandle(pi_native_handle nativeHandle,
 
 pi_result piMemBufferCreate(pi_context context, pi_mem_flags flags, size_t size,
                             void *host_ptr, pi_mem *ret_mem,
-                            const cl_mem_properties_intel *properties) {
+                            const pi_mem_properties *properties) {
   pi_result ret_err = PI_INVALID_OPERATION;
   clCreateBufferWithPropertiesINTEL_fn FuncPtr = nullptr;
 

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -53,6 +53,8 @@ CONSTFIX char clHostMemAllocName[] = "clHostMemAllocINTEL";
 CONSTFIX char clDeviceMemAllocName[] = "clDeviceMemAllocINTEL";
 CONSTFIX char clSharedMemAllocName[] = "clSharedMemAllocINTEL";
 CONSTFIX char clMemFreeName[] = "clMemFreeINTEL";
+CONSTFIX char clCreateBufferWithPropertiesName[] =
+    "clCreateBufferWithPropertiesINTEL";
 CONSTFIX char clSetKernelArgMemPointerName[] = "clSetKernelArgMemPointerINTEL";
 CONSTFIX char clEnqueueMemsetName[] = "clEnqueueMemsetINTEL";
 CONSTFIX char clEnqueueMemcpyName[] = "clEnqueueMemcpyINTEL";
@@ -516,12 +518,25 @@ pi_result piextContextCreateWithNativeHandle(pi_native_handle nativeHandle,
 }
 
 pi_result piMemBufferCreate(pi_context context, pi_mem_flags flags, size_t size,
-                            void *host_ptr, pi_mem *ret_mem) {
+                            void *host_ptr, pi_mem *ret_mem,
+                            const cl_mem_properties_intel *properties) {
   pi_result ret_err = PI_INVALID_OPERATION;
-  *ret_mem = cast<pi_mem>(clCreateBuffer(cast<cl_context>(context),
-                                         cast<cl_mem_flags>(flags), size,
-                                         host_ptr, cast<cl_int *>(&ret_err)));
+  clCreateBufferWithPropertiesINTEL_fn FuncPtr = nullptr;
 
+  if (properties)
+    // First we need to look up the function pointer
+    ret_err = getExtFuncFromContext<clCreateBufferWithPropertiesName,
+                                    clCreateBufferWithPropertiesINTEL_fn>(
+        context, &FuncPtr);
+
+  if (FuncPtr)
+    *ret_mem = cast<pi_mem>(FuncPtr(cast<cl_context>(context), properties,
+                                    cast<cl_mem_flags>(flags), size, host_ptr,
+                                    cast<cl_int *>(&ret_err)));
+  else
+    *ret_mem = cast<pi_mem>(clCreateBuffer(cast<cl_context>(context),
+                                           cast<cl_mem_flags>(flags), size,
+                                           host_ptr, cast<cl_int *>(&ret_err)));
   return ret_err;
 }
 

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -171,8 +171,9 @@ MemoryManager::allocateBufferObject(ContextImplPtr TargetContext, void *UserPtr,
 
   RT::PiMem NewMem = nullptr;
   const detail::plugin &Plugin = TargetContext->getPlugin();
-  Plugin.call<PiApiKind::piMemBufferCreate>(
-      TargetContext->getHandleRef(), CreationFlags, Size, UserPtr, &NewMem);
+  Plugin.call<PiApiKind::piMemBufferCreate>(TargetContext->getHandleRef(),
+                                            CreationFlags, Size, UserPtr,
+                                            &NewMem, nullptr);
   return NewMem;
 }
 

--- a/sycl/unittests/pi/EnqueueMemTest.cpp
+++ b/sycl/unittests/pi/EnqueueMemTest.cpp
@@ -50,11 +50,11 @@ protected:
                   _context, _device, 0, &_queue)),
               PI_SUCCESS);
 
-    ASSERT_EQ(
-        (plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-            _context, PI_MEM_FLAGS_ACCESS_RW,
-            _numElementsX * _numElementsY * sizeof(pi_int32), nullptr, &_mem)),
-        PI_SUCCESS);
+    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+                  _context, PI_MEM_FLAGS_ACCESS_RW,
+                  _numElementsX * _numElementsY * sizeof(pi_int32), nullptr,
+                  &_mem, nullptr)),
+              PI_SUCCESS);
   }
 
   void TearDown() override {

--- a/sycl/unittests/pi/cuda/test_commands.cpp
+++ b/sycl/unittests/pi/cuda/test_commands.cpp
@@ -77,7 +77,8 @@ TEST_F(CudaCommandsTest, PIEnqueueReadBufferBlocking) {
 
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj)),
+                context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj,
+                nullptr)),
             PI_SUCCESS);
 
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
@@ -106,7 +107,8 @@ TEST_F(CudaCommandsTest, PIEnqueueReadBufferNonBlocking) {
 
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj)),
+                context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj,
+                nullptr)),
             PI_SUCCESS);
 
   pi_event cpIn, cpOut;

--- a/sycl/unittests/pi/cuda/test_commands.cpp
+++ b/sycl/unittests/pi/cuda/test_commands.cpp
@@ -76,10 +76,10 @@ TEST_F(CudaCommandsTest, PIEnqueueReadBufferBlocking) {
   int output[memSize] = {};
 
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj,
-                nullptr)),
-            PI_SUCCESS);
+  ASSERT_EQ(
+      (plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+          context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj, nullptr)),
+      PI_SUCCESS);
 
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
                 queue_, memObj, true, 0, bytes, data, 0, nullptr, nullptr)),
@@ -106,10 +106,10 @@ TEST_F(CudaCommandsTest, PIEnqueueReadBufferNonBlocking) {
   int output[memSize] = {};
 
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj,
-                nullptr)),
-            PI_SUCCESS);
+  ASSERT_EQ(
+      (plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+          context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj, nullptr)),
+      PI_SUCCESS);
 
   pi_event cpIn, cpOut;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(

--- a/sycl/unittests/pi/cuda/test_kernels.cpp
+++ b/sycl/unittests/pi/cuda/test_kernels.cpp
@@ -240,7 +240,8 @@ TEST_F(CudaKernelsTest, PIKernelSetMemObj) {
   size_t memSize = 1024u;
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj)),
+                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
+                nullptr)),
             PI_SUCCESS);
 
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelSetArg>(

--- a/sycl/unittests/pi/cuda/test_kernels.cpp
+++ b/sycl/unittests/pi/cuda/test_kernels.cpp
@@ -275,7 +275,8 @@ TEST_F(CudaKernelsTest, PIkerneldispatch) {
   size_t memSize = 1024u;
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj)),
+                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
+                nullptr)),
             PI_SUCCESS);
 
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piextKernelSetArgMemObj>(
@@ -317,12 +318,14 @@ TEST_F(CudaKernelsTest, PIkerneldispatchTwo) {
   size_t memSize = 1024u;
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj)),
+                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
+                nullptr)),
             PI_SUCCESS);
 
   pi_mem memObj2;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj2)),
+                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj2,
+                nullptr)),
             PI_SUCCESS);
 
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piextKernelSetArgMemObj>(

--- a/sycl/unittests/pi/cuda/test_mem_obj.cpp
+++ b/sycl/unittests/pi/cuda/test_mem_obj.cpp
@@ -66,7 +66,8 @@ TEST_F(CudaTestMemObj, piMemBufferCreateSimple) {
   const size_t memSize = 1024u;
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj)),
+                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
+                nullptr)),
             PI_SUCCESS);
 
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
@@ -78,7 +79,7 @@ TEST_F(CudaTestMemObj, piMemBufferAllocHost) {
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW | PI_MEM_FLAGS_HOST_PTR_ALLOC,
-                memSize, nullptr, &memObj)),
+                memSize, nullptr, &memObj, nullptr)),
             PI_SUCCESS);
 
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
@@ -106,7 +107,8 @@ TEST_F(CudaTestMemObj, piMemBufferCreateNoActiveContext) {
   // to allocate the memory object
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
-                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj)),
+                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
+                nullptr)),
             PI_SUCCESS);
   ASSERT_NE(memObj, nullptr);
 
@@ -128,7 +130,7 @@ TEST_F(CudaTestMemObj, piMemBufferPinnedMappedRead) {
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW | PI_MEM_FLAGS_HOST_PTR_ALLOC,
-                memSize, nullptr, &memObj)),
+                memSize, nullptr, &memObj, nullptr)),
             PI_SUCCESS);
 
   ASSERT_EQ(
@@ -167,7 +169,7 @@ TEST_F(CudaTestMemObj, piMemBufferPinnedMappedWrite) {
   pi_mem memObj;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW | PI_MEM_FLAGS_HOST_PTR_ALLOC,
-                memSize, nullptr, &memObj)),
+                memSize, nullptr, &memObj, nullptr)),
             PI_SUCCESS);
 
   int *host_ptr = nullptr;


### PR DESCRIPTION
This will allow to pass property list to lower APIs.
This patch adds support for cl_intel_create_buffer_with_properties
extension, that adds clCreateBufferWithPropertiesINTEL API function
for OpenCL 1.0 with itself is ported from OpenCL 3.0.
https://www.khronos.org/registry/OpenCL/extensions/intel/cl_intel_create_buffer_with_properties.html

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>