### PR TITLE
[SYCL] piDeviceRelease resource leak fix

### DIFF
--- a/sycl/test/basic_tests/queue/release.cpp
+++ b/sycl/test/basic_tests/queue/release.cpp
@@ -19,3 +19,4 @@ int main() {
 //CHECK: ---> piContextRelease(
 //CHECK: ---> piKernelRelease(
 //CHECK: ---> piProgramRelease(
+//CHECK: ---> piDeviceRelease(


### PR DESCRIPTION
piDeviceRetain/piDeviceRelease fix.  
There is a dependency loop between device_impl and platform_impl, each holding a shared pointer to the other, preventing their destruction.  Here device_impl is modified to use a weak_ptr to the platform_impl, but this means the device must track the plugin as well, as it needs it during its destruction (when the weak_ptr<platform> will be dangling).
Once device_impl destructor runs, piDeviceRelease is called.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>