### PR TITLE
POD Specialization constants design update

### DIFF
--- a/sycl/doc/CompilerAndRuntimeDesign.md
+++ b/sycl/doc/CompilerAndRuntimeDesign.md
@@ -498,7 +498,9 @@ unit)
 TBD
 
 ##### Specialization constants lowering
-TBD
+
+See [corresponding documentation](SpecializationConstants.md)
+
 
 #### CUDA support
 

--- a/sycl/doc/SpecializationConstants.md
+++ b/sycl/doc/SpecializationConstants.md
@@ -8,10 +8,10 @@ with some restrictions. See this [document](https://github.com/intel/llvm/blob/s
 - must work with separate compilation and linking
 - must support AOT compilation
 
-Implementaion is based on SPIR-V specialization constants. But there is one
-important difference between SYCL and SPIR-V: in SYCL speciazation constants are
-identified by a type ID which is mapped to a symbolic name, in SPIR-V - by an
-ordinal number. This complicates the design, as the compiler
+Implementation is based on SPIR-V specialization constants. But there is one
+important difference between SYCL and SPIR-V: in SYCL specialization constants
+are identified by a type ID which is mapped to a symbolic name, in SPIR-V - by
+an ordinal number. This complicates the design, as the compiler
 1) needs to propagate symbolic =\> numeric ID correspondence to the runtime
 2) can assign numeric IDs only when linking due to the separate compilation
 
@@ -66,7 +66,7 @@ recognized by a special LLVM pass later.
 
 Compilation and subsequent linkage of device code results in a number of
 `__sycl_getSpecConstantValue` calls whose arguments are symbolic spec constant
-IDs. Before generating the a device binary, each linked device code LLVMIR
+IDs. Before generating a device binary, each linked device code LLVMIR
 module undergoes processing by the sycl-post-link tool which can run LLVMIR
 passes before passing the module onto the llvm-spirv translator.
 

--- a/sycl/doc/SpecializationConstants.md
+++ b/sycl/doc/SpecializationConstants.md
@@ -239,7 +239,7 @@ spec constants, because its defined by its members instead.
 ##### The post-link tool changes
 
 For composite specialization constants the post link tool will additionally
-generate linearized list of \<leaf spec ID,type,offset,size\> tuples (descriptors),
+generate linearized list of \<leaf spec ID,offset,size\> tuples (descriptors),
 where each tuple describes a leaf field, and store it together with the
 existing meta-information associated with the specialization constants and
 passed to the runtime. Also, for a composite specialization constant there is
@@ -247,7 +247,7 @@ no ID map entry within the meta information, and the composite constant is
 referenced by its symbolic ID. For example:
 
 ```
-MyConst_mangled [10,int,0,4],[11,float,4,4],[12,int,8,4],[13,float,12,4],[14,int,16,4]
+MyConst_mangled [10,0,4],[11,4,4],[12,8,4],[13,12,4],[14,16,4]
 ```
 
 #### SYCL runtime

--- a/sycl/doc/SpecializationConstants.md
+++ b/sycl/doc/SpecializationConstants.md
@@ -17,9 +17,9 @@ ordinal number. This complicates the design, as the compiler
 
 Simple source code example:
 
-```
+```c++
 class MyInt32Const;
-...
+// ...
   sycl::program p(q.get_context());
   sycl::ONEAPI::experimental::spec_constant<int32_t, MyInt32Const> i32 =
       p.set_spec_constant<MyInt32Const>(rt_val);
@@ -34,7 +34,7 @@ class MyInt32Const;
           acc[0] = i32.get();
         });
   });
-...
+// ...
 ```
 
 ## Design
@@ -46,9 +46,9 @@ primitive numeric types. POD types support is described further in the document.
 
 Key `spec_constant::get()` function implementation for the device code:
 
-```
+```c++
 template <typename T, typename ID = T> class spec_constant {
-...
+// ...
 public:
   T get() const { // explicit access.
 #ifdef __SYCL_DEVICE_ONLY__
@@ -87,9 +87,9 @@ After this pass the sycl-post-link tool will output the
 attaching this info to the device binary image via the offload wrapper tool as
 a property set:
 
-```
+```c++
 struct pi_device_binary_struct {
-...
+  // ...
   // Array of preperty sets; e.g. specialization constants symbol-int ID map is
   // propagated to runtime with this mechanism.
   pi_device_binary_property_set PropertySetsBegin;
@@ -152,7 +152,7 @@ unaware of the clang-specific built-ins.
 Before JIT-ing a program, the runtime "flushes" the spec constants: it iterates
 through the value map and invokes the
 
-```
+```c++
 pi_result piextProgramSetSpecializationConstant(pi_program prog,
                                                 pi_uint32 spec_id,
                                                 size_t spec_size,
@@ -167,7 +167,7 @@ Plugin Interface function for each entry, taking the `spec_id` from the ID map.
 
 Say, the POD type is
 
-```
+```c++
 struct A {
   int x;
   float y;
@@ -181,7 +181,7 @@ struct POD {
 
 and the user says
 
-```
+```c++
   POD gold{
     {
       { goldi, goldf },

--- a/sycl/doc/SpecializationConstants.md
+++ b/sycl/doc/SpecializationConstants.md
@@ -17,9 +17,9 @@ an ordinal number. This complicates the design, as the compiler
 
 Simple source code example:
 
-```c++
+```
 class MyInt32Const;
-// ...
+...
   sycl::program p(q.get_context());
   sycl::ONEAPI::experimental::spec_constant<int32_t, MyInt32Const> i32 =
       p.set_spec_constant<MyInt32Const>(rt_val);
@@ -34,7 +34,7 @@ class MyInt32Const;
           acc[0] = i32.get();
         });
   });
-// ...
+...
 ```
 
 ## Design
@@ -46,9 +46,9 @@ primitive numeric types. POD types support is described further in the document.
 
 Key `spec_constant::get()` function implementation for the device code:
 
-```c++
+```
 template <typename T, typename ID = T> class spec_constant {
-// ...
+...
 public:
   T get() const { // explicit access.
 #ifdef __SYCL_DEVICE_ONLY__
@@ -87,9 +87,9 @@ After this pass the sycl-post-link tool will output the
 attaching this info to the device binary image via the offload wrapper tool as
 a property set:
 
-```c++
+```
 struct pi_device_binary_struct {
-  // ...
+...
   // Array of preperty sets; e.g. specialization constants symbol-int ID map is
   // propagated to runtime with this mechanism.
   pi_device_binary_property_set PropertySetsBegin;
@@ -152,7 +152,7 @@ unaware of the clang-specific built-ins.
 Before JIT-ing a program, the runtime "flushes" the spec constants: it iterates
 through the value map and invokes the
 
-```c++
+```
 pi_result piextProgramSetSpecializationConstant(pi_program prog,
                                                 pi_uint32 spec_id,
                                                 size_t spec_size,
@@ -167,7 +167,7 @@ Plugin Interface function for each entry, taking the `spec_id` from the ID map.
 
 Say, the POD type is
 
-```c++
+```
 struct A {
   int x;
   float y;
@@ -181,7 +181,7 @@ struct POD {
 
 and the user says
 
-```c++
+```
   POD gold{
     {
       { goldi, goldf },

--- a/sycl/doc/SpecializationConstants.md
+++ b/sycl/doc/SpecializationConstants.md
@@ -208,8 +208,8 @@ The SpecConstants pass in the post-link will have the following IR as input
 ```
 
 `__sycl_getCompositeSpecConstantValue` is a new "intrinsic" (in addition to
-`__sycl_getSpecConstantValue`) recognized by `SpecConstants` pass, which creates
-a value of a composite (of non-primitive type) specialization constant.
+`__sycl_getSpecConstantValue`) recognized by the `SpecConstants` pass, which
+creates a value of a composite (of non-primitive type) specialization constant.
 It does not need a default value, because its default value consists of default
 values of its leaf specialization constants (see below).
 
@@ -217,7 +217,7 @@ values of its leaf specialization constants (see below).
 `__spirv_SpecConstant` calls for each member of its return type plus one
 `__spirv_SpecConstantComposite` to gather members back into a single composite.
 If any composite member is another composite, then it will be also represented
-by number of `__spirv_SpecConstant` plus one `__spirv_SpecConstantComposite`:
+by number of `__spirv_SpecConstant` plus one `__spirv_SpecConstantComposite`.
 
 ```
 %gold_POD_A0_x = call i32 __spirv_SpecConstant(i32 10, i32 0)
@@ -241,13 +241,15 @@ by number of `__spirv_SpecConstant` plus one `__spirv_SpecConstantComposite`:
 ```
 
 Spec ID for the composite spec constant is not needed, as runtime will never use
-it - it will use IDs of the leaves instead.
-Yet, the SPIR-V specification does not allow `SpecID` decoration for composite
-spec constants, because its defined by its members instead.
+it - it will use IDs of the leaves instead, which are being assigned by the
+`SpecConstants` pass during replacement of SYCL intrinsics with SPIR-V
+intrinsics.
+Besides, the SPIR-V specification does not allow `SpecID` decoration for
+composite spec constants, because its defined by its members instead.
 
-`__spirv_SpecConstantComposite` is a new "intrinsic", which represents composite
-specialization constant. Its arguments are LLVM IR valures corresponding to
-elements of composite type of the constant.
+`__spirv_SpecConstantComposite` is a new SPIR-V intrinsic, which represents
+composite specialization constant. Its arguments are LLVM IR valures
+corresponding to elements of composite type of the constant.
 
 ##### LLVM -> SPIR-V translation
 

--- a/sycl/doc/SpecializationConstants.md
+++ b/sycl/doc/SpecializationConstants.md
@@ -302,13 +302,14 @@ MyConst_mangled [10,0,4],[11,4,4],[12,8,4],[13,12,4],[14,16,4]
 ```
 
 This tuple is needed, because at SYCL runtime level, composite constants are set
-by user as a single entity and we have to break it down to its members and set a
-value for each leaf as for a separate specialization constant. It contains the
-following data:
-- ID of composite constants leaf, i.e. ID of scalar spec constant
+by user as a byte array and we have to break it down to the leaf members of the
+composite and set a value for each leaf as for a separate scalar specialization
+constant. Each tuple contains the following data:
+- ID of composite constant leaf, i.e. ID of a scalar specialization constant
 - Offset from the beginning of composite, which points to the location of a
-  scalar value within the composite
-- Size of the scalar value
+  scalar value within the composite, i.e. the position where scalar
+  specialization constant resides within the byte array supplied by the user
+- Size of the scalar specialization constant
 
 #### SYCL runtime
 


### PR DESCRIPTION
Besides some tiny markup & typo fixes this PR changes interfaces for defining specialization constants between `sycl-post-link` and SPIRV-LLVM-Translator, in particular:

Renamed `__spirvCompositeSpecConstant` to `__spirv_SpecConstantComposite` to better match SPIR-V friendly IR representaiton, which is aligned with opcode names from SPIR-V spec.

Changed logic of generating `__spirv_SpecConstantComposite`: instead of getting list of `SpecID` for each composite member it now accepts vector of actual members, which might be another composits, undefs or regular constants. This change was done to align this intrinsic with corresponding opcode prototype to make its handling more universal and useful for the upstream translator project.