### PR TITLE
[SYCL] Second approach to piDeviceRelease resource leak fix.

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -300,9 +300,11 @@ std::shared_ptr<device_impl> platform_impl::getOrMakeDeviceImpl(
   const std::lock_guard<std::mutex> Guard(MDeviceMapMutex);
 
   // If we've already seen this device, return the impl
-  for (const std::shared_ptr<device_impl> &Device : MDeviceCache) {
-    if (Device->getHandleRef() == PiDevice)
-      return Device;
+  for (const std::weak_ptr<device_impl> &DeviceWP : MDeviceCache) {
+    if (std::shared_ptr<device_impl> Device = DeviceWP.lock()) {
+      if (Device->getHandleRef() == PiDevice)
+        return Device;
+    }
   }
 
   // Otherwise make the impl

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -195,7 +195,7 @@ private:
   bool MHostPlatform = false;
   RT::PiPlatform MPlatform = 0;
   std::shared_ptr<plugin> MPlugin;
-  std::vector<std::shared_ptr<device_impl>> MDeviceCache;
+  std::vector<std::weak_ptr<device_impl>> MDeviceCache;
   std::mutex MDeviceMapMutex;
 };
 

--- a/sycl/test/basic_tests/queue/release.cpp
+++ b/sycl/test/basic_tests/queue/release.cpp
@@ -19,3 +19,4 @@ int main() {
 //CHECK: ---> piContextRelease(
 //CHECK: ---> piKernelRelease(
 //CHECK: ---> piProgramRelease(
+//CHECK: ---> piDeviceRelease(


### PR DESCRIPTION
piDeviceRelease resource leak fix - second attempt.  There is a circular dependency between the device_impl and the platform_impl, each holding a shared pointer to the other, which prevents their destruction.  In this second approach, I've replaced the vector of shared pointers in the platform_impl with a vector of weak_ptr.  It seems to work well. The destructors are getting called, and piDeviceRetain/Release calls are balanced.
Original draft is here:  https://github.com/intel/llvm/pull/2668    

Signed-off-by: Chris Perkins <chris.perkins@intel.com>