### PR TITLE
[NFC][SYCL] Clean up FPGA archive files after test runs

### DIFF
--- a/sycl/test/fpga_tests/fpga_aocx.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx.cpp
@@ -9,8 +9,8 @@
 // REQUIRES: aoc, accelerator
 
 /// E2E test for AOCX creation/use/run for FPGA
-// Produce an archive with device (AOCX) image. Pre-create a file to avoid
-// appending objects to leftover archives.
+// Produce an archive with device (AOCX) image. Avoid appending objects to
+// leftover archives.
 // RUN: if [ -f %t_image.a ]; then rm %t_image.a; fi
 // RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
 // Produce a host object

--- a/sycl/test/fpga_tests/fpga_aocx.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx.cpp
@@ -9,7 +9,9 @@
 // REQUIRES: aoc, accelerator
 
 /// E2E test for AOCX creation/use/run for FPGA
-// Produce an archive with device (AOCX) image
+// Produce an archive with device (AOCX) image. Pre-create a file to avoid appending objects to
+// leftover archives.
+// RUN: touch %t_image.a
 // RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
 // Produce a host object
 // RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp -c -o %t.o

--- a/sycl/test/fpga_tests/fpga_aocx.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx.cpp
@@ -9,8 +9,8 @@
 // REQUIRES: aoc, accelerator
 
 /// E2E test for AOCX creation/use/run for FPGA
-// Produce an archive with device (AOCX) image. Pre-create a file to avoid appending objects to
-// leftover archives.
+// Produce an archive with device (AOCX) image. Pre-create a file to avoid
+// appending objects to leftover archives.
 // RUN: touch %t_image.a
 // RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
 // Produce a host object

--- a/sycl/test/fpga_tests/fpga_aocx.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx.cpp
@@ -9,9 +9,9 @@
 // REQUIRES: aoc, accelerator
 
 /// E2E test for AOCX creation/use/run for FPGA
-// Produce an archive with device (AOCX) image. Avoid appending objects to
-// leftover archives.
-// RUN: if [ -f %t_image.a ]; then rm %t_image.a; fi
+// Produce an archive with device (AOCX) image. To avoid appending objects to
+// leftover archives, remove one if exists.
+// RUN: rm %t_image.a || true
 // RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
 // Produce a host object
 // RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp -c -o %t.o

--- a/sycl/test/fpga_tests/fpga_aocx.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx.cpp
@@ -11,7 +11,7 @@
 /// E2E test for AOCX creation/use/run for FPGA
 // Produce an archive with device (AOCX) image. Pre-create a file to avoid
 // appending objects to leftover archives.
-// RUN: touch %t_image.a
+// RUN: if [ -f %t_image.a ]; then rm %t_image.a; fi
 // RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
 // Produce a host object
 // RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp -c -o %t.o

--- a/sycl/test/fpga_tests/fpga_aocx_win.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx_win.cpp
@@ -10,8 +10,8 @@
 // REQUIRES: system-windows
 
 /// E2E test for AOCX creation/use/run for FPGA
-// Produce an archive with device (AOCX) image. Pre-create a file to avoid appending objects to
-// leftover archives.
+// Produce an archive with device (AOCX) image. Pre-create a file to avoid
+// appending objects to leftover archives.
 // RUN: touch %t_image.lib
 // RUN: %clang_cl -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
 // Produce a host object

--- a/sycl/test/fpga_tests/fpga_aocx_win.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx_win.cpp
@@ -10,8 +10,8 @@
 // REQUIRES: system-windows
 
 /// E2E test for AOCX creation/use/run for FPGA
-// Produce an archive with device (AOCX) image. Pre-create a file to avoid
-// appending objects to leftover archives.
+// Produce an archive with device (AOCX) image. Avoid appending objects to
+// leftover archives.
 // RUN: if [ -f %t_image.a ]; then rm %t_image.a; fi
 // RUN: %clang_cl -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
 // Produce a host object

--- a/sycl/test/fpga_tests/fpga_aocx_win.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx_win.cpp
@@ -12,7 +12,7 @@
 /// E2E test for AOCX creation/use/run for FPGA
 // Produce an archive with device (AOCX) image. Pre-create a file to avoid
 // appending objects to leftover archives.
-// RUN: touch %t_image.lib
+// RUN: if [ -f %t_image.a ]; then rm %t_image.a; fi
 // RUN: %clang_cl -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
 // Produce a host object
 // RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj

--- a/sycl/test/fpga_tests/fpga_aocx_win.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx_win.cpp
@@ -10,7 +10,9 @@
 // REQUIRES: system-windows
 
 /// E2E test for AOCX creation/use/run for FPGA
-// Produce an archive with device (AOCX) image
+// Produce an archive with device (AOCX) image. Pre-create a file to avoid appending objects to
+// leftover archives.
+// RUN: touch %t_image.lib
 // RUN: %clang_cl -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
 // Produce a host object
 // RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj

--- a/sycl/test/fpga_tests/fpga_aocx_win.cpp
+++ b/sycl/test/fpga_tests/fpga_aocx_win.cpp
@@ -10,9 +10,9 @@
 // REQUIRES: system-windows
 
 /// E2E test for AOCX creation/use/run for FPGA
-// Produce an archive with device (AOCX) image. Avoid appending objects to
-// leftover archives.
-// RUN: if [ -f %t_image.a ]; then rm %t_image.a; fi
+// Produce an archive with device (AOCX) image. To avoid appending objects to
+// leftover archives, remove one if exists.
+// RUN: rm %t_image.a || true
 // RUN: %clang_cl -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
 // Produce a host object
 // RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj


### PR DESCRIPTION
In some local configurations, re-launching fpga_aocx*.cpp tests
appends new objects to the archive created during preceding test
runs. Overwrite the archive files in a separate `RUN` line to avoid
misleading failures in local development environments.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>