### PR TITLE
[SYCL][Driver] Propagate floating point optimizations flag

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -511,6 +511,13 @@ static void addImpliedArgs(const llvm::Triple &Triple,
       BeArgs.push_back("-g");
   if (Args.getLastArg(options::OPT_O0))
     BeArgs.push_back("-cl-opt-disable");
+  // Check if -ffast-math or -funsafe-math.
+  Arg *A = Args.getLastArg(options::OPT_ffast_math, options::OPT_fno_fast_math,
+                           options::OPT_funsafe_math_optimizations,
+                           options::OPT_fno_unsafe_math_optimizations);
+  if (A && (A->getOption().getID() == options::OPT_ffast_math ||
+      A->getOption().getID() == options::OPT_funsafe_math_optimizations))
+    BeArgs.push_back("-cl-fast-relaxed-math");
   if (BeArgs.empty())
     return;
   if (Triple.getSubArch() == llvm::Triple::NoSubArch ||

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -511,12 +511,18 @@ static void addImpliedArgs(const llvm::Triple &Triple,
       BeArgs.push_back("-g");
   if (Args.getLastArg(options::OPT_O0))
     BeArgs.push_back("-cl-opt-disable");
-  // Check if -ffast-math or -funsafe-math.
+  // Check if floating pointing optimizations are allowed.
+  bool isFastMath = isOptimizationLevelFast(Args);
   Arg *A = Args.getLastArg(options::OPT_ffast_math, options::OPT_fno_fast_math,
                            options::OPT_funsafe_math_optimizations,
                            options::OPT_fno_unsafe_math_optimizations);
-  if (A && (A->getOption().getID() == options::OPT_ffast_math ||
-            A->getOption().getID() == options::OPT_funsafe_math_optimizations))
+  isFastMath =
+      isFastMath || (A && (A->getOption().getID() == options::OPT_ffast_math ||
+                           A->getOption().getID() ==
+                               options::OPT_funsafe_math_optimizations));
+  A = Args.getLastArg(options::OPT_ffp_model_EQ);
+  isFastMath = isFastMath || (A && StringRef(A->getValue()).equals("fast"));
+  if (isFastMath)
     BeArgs.push_back("-cl-fast-relaxed-math");
   if (BeArgs.empty())
     return;

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -516,7 +516,7 @@ static void addImpliedArgs(const llvm::Triple &Triple,
                            options::OPT_funsafe_math_optimizations,
                            options::OPT_fno_unsafe_math_optimizations);
   if (A && (A->getOption().getID() == options::OPT_ffast_math ||
-      A->getOption().getID() == options::OPT_funsafe_math_optimizations))
+            A->getOption().getID() == options::OPT_funsafe_math_optimizations))
     BeArgs.push_back("-cl-fast-relaxed-math");
   if (BeArgs.empty())
     return;

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -904,5 +904,11 @@
 // CHECK-STD-OVR: clang{{.*}} "-emit-obj" {{.*}} "-std=c++14"
 // CHECK-STD-OVR-NOT: clang{{.*}} "-std=c++17"
 
+// Bypass -cl-fast-relaxed-math to SPIR-V compiler.
+// RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -ffast-math %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
+// RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -funsafe-math-optimizations %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
+// RUN: %clang_cl -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice /fp:fast %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
+// CHECK-FAST-MATH-OPT: clang-offload-wrapper{{.*}} "-compile-opts=-cl-fast-relaxed-math"
+
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -907,6 +907,8 @@
 // Bypass -cl-fast-relaxed-math to SPIR-V compiler.
 // RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -ffast-math %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
 // RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -funsafe-math-optimizations %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
+// RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -Ofast %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
+// RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -ffp-model=fast %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
 // RUN: %clang_cl -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice /fp:fast %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
 // CHECK-FAST-MATH-OPT: clang-offload-wrapper{{.*}} "-compile-opts=-cl-fast-relaxed-math"
 


### PR DESCRIPTION
SPIR-V compiler(s) support `-cl-fast-relaxed-math` option enabling a set
of optimizations over floating point values. This change maps Clang's
`-ffast-math` and `-funsafe-math-optimizations` to this SPIR-V compiler
option.