### PR TITLE
[Driver][SYCL] Remove real_path workaround for integration header

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6289,24 +6289,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     // Host-side SYCL compilation receives the integration header file as
     // Inputs[1].  Include the header with -include
     if (!IsSYCLOffloadDevice && SYCLDeviceInput) {
-      SmallString<128> RealPath;
-#if defined(_WIN32)
-      // Fixup the header path name in case there are discrepancies in the
-      // string used for the temporary directory environment variable and
-      // actual path expectations.
-      //
-      // While generating the driver commands, we're most often working
-      // with non-existing files. The Unix implementation of LLVM's real_path
-      // returns an empty path for a non-existing file if it's expected to be
-      // placed in the current directory. This becomes a problem when we're
-      // saving intermediate compilation results via -save-temps.
-      // Since the header file path fix-up is Windows-specific, the real_path
-      // call is not necessary for a Unix-based OS (case-sensitive filesystem).
-      llvm::sys::fs::real_path(SYCLDeviceInput->getFilename(), RealPath);
-#else  // _WIN32
-      RealPath.assign(StringRef(SYCLDeviceInput->getFilename()));
-#endif // _WIN32
-      const char *IntHeaderPath = Args.MakeArgString(RealPath);
+      const char *IntHeaderPath =
+          Args.MakeArgString(SYCLDeviceInput->getFilename());
       CmdArgs.push_back("-include");
       CmdArgs.push_back(IntHeaderPath);
       // When creating dependency information, filter out the generated

--- a/clang/test/Driver/sycl-offload-header-check.cpp
+++ b/clang/test/Driver/sycl-offload-header-check.cpp
@@ -9,7 +9,8 @@
 // RUN: env TMP=%t_dirname  \
 // RUN: %clang -### -fsycl %s 2>&1 | \
 // RUN: FileCheck --check-prefix=CHECK-HEADER %s
+// CHECK-HEADER-NOT: non-portable path
 // CHECK-HEADER: clang{{.*}} "-fsycl-int-header=[[HEADER:.+\.h]]"
 // CHECK-HEADER: {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"
 // CHECK-HEADER-NOT: clang{{.*}} "-include" "[[HEADER]]"
-// CHECK-HEADER: clang{{.*}} "-include" "{{.*}}_DiRnAmE{{.+}}.h"
+// CHECK-HEADER: clang{{.*}} "-include" "{{.*}}_dirname{{.+}}.h"

--- a/clang/test/Driver/sycl-offload-header-check.cpp
+++ b/clang/test/Driver/sycl-offload-header-check.cpp
@@ -9,7 +9,6 @@
 // RUN: env TMP=%t_dirname  \
 // RUN: %clang -### -fsycl %s 2>&1 | \
 // RUN: FileCheck --check-prefix=CHECK-HEADER %s
-// CHECK-HEADER-NOT: non-portable path
 // CHECK-HEADER: clang{{.*}} "-fsycl-int-header=[[HEADER:.+\.h]]"
 // CHECK-HEADER: {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"
 // CHECK-HEADER-NOT: clang{{.*}} "-include" "[[HEADER]]"

--- a/clang/test/Driver/sycl-offload-with-split.c
+++ b/clang/test/Driver/sycl-offload-with-split.c
@@ -284,6 +284,3 @@
 // RUN:   %clang_cl -### -fsycl -fsycl-device-code-split -fsycl-device-code-split=off %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefixes=CHK-NO-SPLIT
 // CHK-NO-SPLIT-NOT: sycl-post-link{{.*}} -split{{.*}}
-
-// TODO: SYCL specific fail - analyze and enable
-// XFAIL: windows-msvc

--- a/sycl/test/regression/fsycl-save-temps.cpp
+++ b/sycl/test/regression/fsycl-save-temps.cpp
@@ -20,8 +20,3 @@ int main() {
   });
   return 0;
 }
-
-// TODO: Address a Windows-specific issue with integration header filenames
-// XFAIL: system-windows && !level_zero
-// TODO: fail is flaky on Windows for Level Zero. Enable when fixed.
-// UNSUPPORTED: system-windows && level_zero


### PR DESCRIPTION
We applied a workaround for integration header usage on Windows that
corrected the directory name in case it did not match expectations
of the file system (lowercase/uppercase like things).  The workaround
is not needed anymore as community has addressed the non-portable
path warning directly for Windows.