### PR TITLE
[SYCL][NFC] Add -fno-sycl-id-queries-fit-in-int to the parallel_for_range.cpp test

### DIFF
--- a/sycl/test/basic_tests/parallel_for_range.cpp
+++ b/sycl/test/basic_tests/parallel_for_range.cpp
@@ -2,7 +2,7 @@
 // UNSUPPORTED: windows
 // Level0 testing times out on Windows.
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
+// RUN: %clangxx -fsycl -fno-sycl-id-queries-fit-in-int -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
This LIT test assumes that compiler doesn't check ranges to fit integer
that is why explicitly disable these checks for this test.