### PR TITLE
[SYCL][ESIMD] Fix LowerESIMD crash on a scalar fptoui.

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -1239,10 +1239,11 @@ PreservedAnalyses SYCLLowerESIMDPass::run(Function &F,
     if (auto CastOp = dyn_cast<llvm::CastInst>(&I)) {
       llvm::Type *DstTy = CastOp->getDestTy();
       auto CastOpcode = CastOp->getOpcode();
-      if ((CastOpcode == llvm::Instruction::FPToUI &&
-           DstTy->getScalarType()->getPrimitiveSizeInBits() <= 32) ||
-          (CastOpcode == llvm::Instruction::FPToSI &&
-           DstTy->getScalarType()->getPrimitiveSizeInBits() < 32)) {
+      if (isa<FixedVectorType>(DstTy) &&
+          ((CastOpcode == llvm::Instruction::FPToUI &&
+            DstTy->getScalarType()->getPrimitiveSizeInBits() <= 32) ||
+           (CastOpcode == llvm::Instruction::FPToSI &&
+            DstTy->getScalarType()->getPrimitiveSizeInBits() < 32))) {
         IRBuilder<> Builder(&I);
         llvm::Value *Src = CastOp->getOperand(0);
         auto TmpTy = llvm::FixedVectorType::get(

--- a/llvm/test/SYCLLowerIR/scalar_fptoui.ll
+++ b/llvm/test/SYCLLowerIR/scalar_fptoui.ll
@@ -1,0 +1,17 @@
+; This is a regression test for LowerESIMD crashing on a scalar fptoui
+; instruction.
+;
+; RUN: opt < %s -LowerESIMD -S | FileCheck %s
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown-sycldevice"
+
+; Function Attrs: convergent norecurse
+define dso_local spir_func i32 @foo(float %x) !sycl_explicit_simd !1 {
+  %y = fptoui float %x to i32
+; check that the scalar float to unsigned int conversion is left intact
+; CHECK: %y = fptoui float %x to i32
+  ret i32 %y
+}
+
+!1 = !{i32 0, i32 0}


### PR DESCRIPTION
Fix small bug in LowerESIMD.cpp

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>