### PR TITLE
[SYCL] Fix compilation with --std=c++20

### DIFF
--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -16,8 +16,10 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/detail/type_traits.hpp>
 
+#if __cpp_lib_bit_cast
+#include <bit>
+#endif
 #include <memory>
-#include <numeric> // std::bit_cast
 #include <stdexcept>
 #include <type_traits>
 #include <vector>

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -150,7 +150,7 @@ public:
 
   __SYCL_DLL_LOCAL void set_final_data_from_storage() {
     MUploadDataFunctor = [this]() {
-      if (MSharedPtrStorage.use_count() == 1) {
+      if (MSharedPtrStorage.use_count() > 1) {
         void *FinalData = const_cast<void *>(MSharedPtrStorage.get());
         updateHostMemory(FinalData);
       }

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -150,7 +150,7 @@ public:
 
   __SYCL_DLL_LOCAL void set_final_data_from_storage() {
     MUploadDataFunctor = [this]() {
-      if (!MSharedPtrStorage.unique()) {
+      if (MSharedPtrStorage.use_count()==1) {
         void *FinalData = const_cast<void *>(MSharedPtrStorage.get());
         updateHostMemory(FinalData);
       }

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -150,7 +150,7 @@ public:
 
   __SYCL_DLL_LOCAL void set_final_data_from_storage() {
     MUploadDataFunctor = [this]() {
-      if (MSharedPtrStorage.use_count()==1) {
+      if (MSharedPtrStorage.use_count() == 1) {
         void *FinalData = const_cast<void *>(MSharedPtrStorage.get());
         updateHostMemory(FinalData);
       }

--- a/sycl/test/basic_tests/stdcpp_compat.cpp
+++ b/sycl/test/basic_tests/stdcpp_compat.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s -c -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s -c -o %t.out
 // RUN: %clangxx -std=c++14 -fsyntax-only -Xclang -verify -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning %s -o -c %t.out
 // RUN: %clangxx -std=c++17 -fsyntax-only -Xclang -verify -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning %s -o -c %t.out
 // RUN: %clangxx -std=c++20 -fsyntax-only -Xclang -verify -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning %s -o -c %t.out

--- a/sycl/test/basic_tests/stdcpp_compat.cpp
+++ b/sycl/test/basic_tests/stdcpp_compat.cpp
@@ -1,0 +1,7 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s -c -o %t.out
+// RUN: %clangxx -std=c++14 -fsyntax-only -Xclang -verify -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning %s -o -c %t.out
+// RUN: %clangxx -std=c++17 -fsyntax-only -Xclang -verify -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning %s -o -c %t.out
+// RUN: %clangxx -std=c++20 -fsyntax-only -Xclang -verify -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning %s -o -c %t.out
+// expected-no-diagnostics
+
+#include <CL/sycl.hpp>


### PR DESCRIPTION
 - add include containing definition of std::bit_cast
 - replace usage of share_pointer::unique() deprecated in C++20
 - add test to verify compilation with different C++ standards