### PR TITLE
[SYCL][Driver] Revert -cl-fast-relaxed-math propagation

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -511,19 +511,6 @@ static void addImpliedArgs(const llvm::Triple &Triple,
       BeArgs.push_back("-g");
   if (Args.getLastArg(options::OPT_O0))
     BeArgs.push_back("-cl-opt-disable");
-  // Check if floating pointing optimizations are allowed.
-  bool isFastMath = isOptimizationLevelFast(Args);
-  Arg *A = Args.getLastArg(options::OPT_ffast_math, options::OPT_fno_fast_math,
-                           options::OPT_funsafe_math_optimizations,
-                           options::OPT_fno_unsafe_math_optimizations);
-  isFastMath =
-      isFastMath || (A && (A->getOption().getID() == options::OPT_ffast_math ||
-                           A->getOption().getID() ==
-                               options::OPT_funsafe_math_optimizations));
-  A = Args.getLastArg(options::OPT_ffp_model_EQ);
-  isFastMath = isFastMath || (A && StringRef(A->getValue()).equals("fast"));
-  if (isFastMath)
-    BeArgs.push_back("-cl-fast-relaxed-math");
   if (BeArgs.empty())
     return;
   if (Triple.getSubArch() == llvm::Triple::NoSubArch ||

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -904,13 +904,5 @@
 // CHECK-STD-OVR: clang{{.*}} "-emit-obj" {{.*}} "-std=c++14"
 // CHECK-STD-OVR-NOT: clang{{.*}} "-std=c++17"
 
-// Bypass -cl-fast-relaxed-math to SPIR-V compiler.
-// RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -ffast-math %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
-// RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -funsafe-math-optimizations %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
-// RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -Ofast %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
-// RUN: %clang -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice -ffp-model=fast %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
-// RUN: %clang_cl -### -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice /fp:fast %s 2>&1 | FileCheck -check-prefix=CHECK-FAST-MATH-OPT %s
-// CHECK-FAST-MATH-OPT: clang-offload-wrapper{{.*}} "-compile-opts=-cl-fast-relaxed-math"
-
 // TODO: SYCL specific fail - analyze and enable
 // XFAIL: windows-msvc


### PR DESCRIPTION
This reverts commit ce0888998126e62a97b21c576aaffd0c81db6cb5.

Reason: the issue with this implementation is that we can't preserve
correct correlation between the option and the source impacted by this
option. `-ffast-math` is applied to C++ translation unit, whereas single
SPIR-V module might include code sections from multiple translation
units and some of them might be compiled with `-fno-fast-math`.