### PR TITLE
[SYCL] float atomic_ref performance fix

### DIFF
--- a/sycl/include/CL/sycl/ONEAPI/atomic_ref.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/atomic_ref.hpp
@@ -457,7 +457,8 @@ public:
     T expected;
     T desired;
     do {
-      expected = load(load_order, scope);
+      expected =
+          load(load_order, scope); // performs better with load in CAS loop.
       desired = expected + operand;
     } while (!compare_exchange_weak(expected, desired, order, scope));
     return expected;

--- a/sycl/include/CL/sycl/ONEAPI/atomic_ref.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/atomic_ref.hpp
@@ -454,9 +454,10 @@ public:
   T fetch_add(T operand, memory_order order = default_read_modify_write_order,
               memory_scope scope = default_scope) const noexcept {
     auto load_order = detail::getLoadOrder(order);
-    T expected = load(load_order, scope);
+    T expected;
     T desired;
     do {
+      expected = load(load_order, scope);
       desired = expected + operand;
     } while (!compare_exchange_weak(expected, desired, order, scope));
     return expected;
@@ -563,9 +564,10 @@ public:
                memory_scope scope = default_scope) const noexcept {
     // TODO: Find a way to avoid compare_exchange here
     auto load_order = detail::getLoadOrder(order);
-    T *expected = load(load_order, scope);
+    T *expected;
     T *desired;
     do {
+      expected = load(load_order, scope);
       desired = expected + operand;
     } while (!compare_exchange_weak(expected, desired, order, scope));
     return expected;

--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -237,8 +237,7 @@ public:
             Ptr);
     cl_int TmpVal = __spirv_AtomicLoad(
         TmpPtr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order));
-    cl_float ResVal;
-    detail::memcpy(&ResVal, &TmpVal, sizeof(TmpVal));
+    cl_float ResVal = *reinterpret_cast<const cl_float *>(&TmpVal);
     return ResVal;
   }
 #else

--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -237,7 +237,7 @@ public:
             Ptr);
     cl_int TmpVal = __spirv_AtomicLoad(
         TmpPtr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order));
-    cl_float ResVal = *reinterpret_cast<const cl_float *>(&TmpVal);
+    cl_float ResVal = detail::bit_cast<cl_float>(TmpVal);
     return ResVal;
   }
 #else

--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -61,8 +61,7 @@ constexpr To bit_cast(const From &from) noexcept {
   static_assert(std::is_trivially_default_constructible<To>::value,
                 "To must be trivially default constructible");
   To to;
-  using F = typename std::remove_const<From>::type;
-  to = *(reinterpret_cast<To *>((const_cast<F *>(&from))));
+  sycl::detail::memcpy(&to, &from, sizeof(To));
   return to;
 #endif // __has_builtin(__builtin_bit_cast)
 

--- a/sycl/include/CL/sycl/detail/helpers.hpp
+++ b/sycl/include/CL/sycl/detail/helpers.hpp
@@ -61,7 +61,8 @@ constexpr To bit_cast(const From &from) noexcept {
   static_assert(std::is_trivially_default_constructible<To>::value,
                 "To must be trivially default constructible");
   To to;
-  sycl::detail::memcpy(&to, &from, sizeof(To));
+  using F = typename std::remove_const<From>::type;
+  to = *(reinterpret_cast<To *>((const_cast<F *>(&from))));
   return to;
 #endif // __has_builtin(__builtin_bit_cast)
 


### PR DESCRIPTION
Moving the load into the CAS loop greatly improves performance, especially on GPU. It isn't entirely clear to me why this should produce such a dramatic improvement.  

Signed-off-by: Chris Perkins <chris.perkins@intel.com>