### PR TITLE
[SYCL]Remove warning about SYCL_EXTERNAL with pointers

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11131,11 +11131,6 @@ def warn_sycl_pass_by_value_deprecated
 def warn_sycl_pass_by_reference_future 
     : Warning<"Passing of kernel functions by reference is a SYCL 2020 extension">,
       InGroup<Sycl2017Compat>, ShowInSystemHeader;
-def warn_sycl_attibute_function_raw_ptr
-    : Warning<"SYCL 1.2.1 specification does not allow %0 attribute applied "
-              "to a function with a raw pointer "
-              "%select{return type|parameter type}1">,
-      InGroup<SyclStrict>, DefaultError;
 def warn_sycl_implicit_decl
     : Warning<"SYCL 1.2.1 specification requires an explicit forward "
               "declaration for a kernel type name; your program may not "

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4539,15 +4539,6 @@ static void handleSYCLDeviceAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     S.Diag(AL.getLoc(), diag::err_sycl_attibute_cannot_be_applied_here) << AL;
     return;
   }
-  if (FD->getReturnType()->isPointerType()) {
-    S.Diag(AL.getLoc(), diag::warn_sycl_attibute_function_raw_ptr)
-        << AL << 0 /* function with a raw pointer return type */;
-  }
-  for (const ParmVarDecl *Param : FD->parameters())
-    if (Param->getType()->isPointerType()) {
-      S.Diag(AL.getLoc(), diag::warn_sycl_attibute_function_raw_ptr)
-          << AL << 1 /* function with a raw pointer parameter type */;
-    }
 
   handleSimpleAttribute<SYCLDeviceAttr>(S, D, AL);
 }

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -16,7 +16,6 @@ using myFuncDef = int(int, int);
 
 typedef __typeof__(sizeof(int)) size_t;
 
-// expected-warning@+1 {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
 SYCL_EXTERNAL
 void *operator new(size_t);
 

--- a/clang/test/SemaSYCL/restrict-recursion4.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion4.cpp
@@ -18,7 +18,6 @@ using myFuncDef = int(int, int);
 
 typedef __typeof__(sizeof(int)) size_t;
 
-// expected-warning@+1 {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
 SYCL_EXTERNAL
 void *operator new(size_t);
 

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -1,9 +1,6 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify %s
 // RUN: %clang_cc1 -verify -DNO_SYCL %s
 
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -DNOT_STRICT -Wno-error=sycl-strict -Wno-sycl-strict %s
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -verify -DWARN_STRICT -Wno-error=sycl-strict %s
-
 #ifndef NO_SYCL
 
 __attribute__((sycl_device)) // expected-warning {{'sycl_device' attribute only applies to functions}}
@@ -34,21 +31,17 @@ public:
   __attribute__((sycl_device)) virtual void bar() = 0;
 };
 
-#if defined(NOT_STRICT)
-__attribute__((sycl_device))
-int* func3() { return nullptr; }
+__attribute__((sycl_device)) int *func0() { return nullptr; }
 
-__attribute__((sycl_device))
-void func3(int *) {}
-#elif defined(WARN_STRICT)
+__attribute__((sycl_device)) void func2(int *) {}
+
 __attribute__((sycl_device)) int *func3() { return nullptr; }
 
-__attribute__((sycl_device)) void func3(int *) {}
-#else
-__attribute__((sycl_device)) int *func3() { return nullptr; }
+__attribute__((sycl_device)) void func4(int *) {}
 
-__attribute__((sycl_device)) void func3(int *) {}
-#endif
+__attribute__((sycl_device)) int *func5() { return nullptr; }
+
+__attribute__((sycl_device)) void func6(int *) {}
 
 #else // NO_SYCL
 __attribute__((sycl_device)) // expected-warning {{'sycl_device' attribute ignored}}

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -41,17 +41,13 @@ int* func3() { return nullptr; }
 __attribute__((sycl_device))
 void func3(int *) {}
 #elif defined(WARN_STRICT)
-__attribute__((sycl_device)) // expected-warning {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
-int* func3() { return nullptr; }
+__attribute__((sycl_device)) int *func3() { return nullptr; }
 
-__attribute__((sycl_device)) // expected-warning {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer parameter type}}
-void func3(int *) {}
+__attribute__((sycl_device)) void func3(int *) {}
 #else
-__attribute__((sycl_device)) // expected-error {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer return type}}
-int* func3() { return nullptr; }
+__attribute__((sycl_device)) int *func3() { return nullptr; }
 
-__attribute__((sycl_device)) // expected-error {{SYCL 1.2.1 specification does not allow 'sycl_device' attribute applied to a function with a raw pointer parameter type}}
-void func3(int *) {}
+__attribute__((sycl_device)) void func3(int *) {}
 #endif
 
 #else // NO_SYCL

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -35,14 +35,6 @@ __attribute__((sycl_device)) int *func0() { return nullptr; }
 
 __attribute__((sycl_device)) void func2(int *) {}
 
-__attribute__((sycl_device)) int *func3() { return nullptr; }
-
-__attribute__((sycl_device)) void func4(int *) {}
-
-__attribute__((sycl_device)) int *func5() { return nullptr; }
-
-__attribute__((sycl_device)) void func6(int *) {}
-
 #else // NO_SYCL
 __attribute__((sycl_device)) // expected-warning {{'sycl_device' attribute ignored}}
 void baz() {}


### PR DESCRIPTION
Raw pointers for SYCL_EXTERNAL are prohibited without generic address space. Generic address space doesn't exist in 1.2.1 and is optional in 2020. Our implementation isn't spec compliant to 1.2.1 because we use generic address space (among other).
This diagnostic has no practical value to users. We aren't warning about something which has any impact for our implementation based on generic address space.