### PR TITLE
[SYCL]Enable Dead Function Elimination in sycl-post-link

### DIFF
--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -687,8 +687,13 @@ public:
 
   bool getRTSetsSpecConstants() const { return RTSetsSpecConsts; }
 
+  void setDeadFunctionElimination(bool Val) { DeadFunctionElimination = Val; }
+
+  bool getDeadFunctionElimination() const { return DeadFunctionElimination; }
+
 private:
   bool RTSetsSpecConsts = true;
+  bool DeadFunctionElimination = false;
 };
 
 class PartialLinkJobAction : public JobAction {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3962,7 +3962,7 @@ class OffloadingActionBuilder final {
         StringRef devicelib_option;
       };
 
-      bool NumOfDeviceLibLinked = 0;
+      int NumOfDeviceLibLinked = 0;
       bool NoDeviceLibs = false;
       // Currently, libc, libm-fp32 will be linked in by default. In order
       // to use libm-fp64, -fsycl-device-lib=libm-fp64/all should be used.


### PR DESCRIPTION
Signed-off-by: gejin <ge.jin@intel.com>
We have decided to split https://github.com/intel/llvm/pull/2277 into 2 parts:
1. device libraries link by default
2. optimization in sycl-post-link to eliminate "dead"(unused) functions in device image which are introduced by device library default link feature.

Currently, part1 has been finished, we have linked all NON-fp64 device libraries with user's device code in offline compilation phase. However, this will lead to code redundancy in final device image since we will pull everything from device libraries into device image regardless of whether those device libraries functions are really used or not.
We expect the related perf impact will be obvious to some application with "small" kernel. To address this problem, we added "DeadFunctionElimination" in offline compilation, the procedure is:
// normal device compilation
........
// llvm-link link user's device image and sycl device libraries by default.
llvm-link user-device-image.bc libsycl-cmath.bc libsycl-complex.bc libsycl-crt.bc...  -o final-device-image.bc
// Use sycl-post-link to eliminate "dead" functions in final-device-image.bc
sycl-post-link final-device-image.bc --dead-function-eliminate .... -o reduced-device-image.o
//other build steps including sycl-post-link(code-split, spec-const...),  llvm-spirv translation....