### PR TITLE
[SYCL] Improve diagnostics for invalid SYCL kernel names.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11066,12 +11066,15 @@ def err_ext_int_max_size : Error<"%select{signed|unsigned}0 _ExtInt of bit "
 def err_esimd_glob_cant_init : Error<
   "SYCL explicit SIMD does not permit private global variable to have an initializer">;
 
+def err_sycl_kernel_name_missing : Error<"kernel name is missing">;
 def err_sycl_kernel_incorrectly_named : Error<
-  "kernel %select{name is missing"
-  "|needs to have a globally-visible name"
-  "|name is invalid. Unscoped enum requires fixed underlying type"
-  "|name cannot be a type in the \"std\" namespace"
-  "}0">;
+  "invalid type %0 used in kernel name. "
+  "%select{Kernel name should be globally-visible"
+  "|Unscoped enum requires fixed underlying type"
+  "|Type cannot be in the \"std\" namespace"
+  "}1">;
+def note_kernel_name: Note<"Invalid kernel name is %0">;
+
 def err_sycl_kernel_not_function_object
     : Error<"kernel parameter must be a lambda or function object">;
 def err_sycl_restrict : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11066,14 +11066,13 @@ def err_ext_int_max_size : Error<"%select{signed|unsigned}0 _ExtInt of bit "
 def err_esimd_glob_cant_init : Error<
   "SYCL explicit SIMD does not permit private global variable to have an initializer">;
 
-def err_sycl_kernel_name_missing : Error<"kernel name is missing">;
-def err_sycl_kernel_incorrectly_named : Error<
-  "invalid type %0 used in kernel name. "
-  "%select{Kernel name should be globally-visible"
-  "|Unscoped enum requires fixed underlying type"
-  "|Type cannot be in the \"std\" namespace"
-  "}1">;
-def note_kernel_name: Note<"Invalid kernel name is %0">;
+def err_sycl_kernel_incorrectly_named : Error<"%0 is an invalid kernel name type">;
+def note_invalid_type_in_sycl_kernel : Note<
+  "%select{%1 should be globally-visible"
+  "|unscoped enum %1 requires fixed underlying type"
+  "|type %1 cannot be in the \"std\" namespace"
+  "|kernel name is missing"
+  "}0">;
 
 def err_sycl_kernel_not_function_object
     : Error<"kernel parameter must be a lambda or function object">;

--- a/clang/test/SemaSYCL/implicit_kernel_type.cpp
+++ b/clang/test/SemaSYCL/implicit_kernel_type.cpp
@@ -25,14 +25,12 @@ int main() {
   queue q;
 
 #if defined(WARN)
-  // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName1' used in kernel name. Kernel name should be globally-visible}}
-  // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'InvalidKernelName1'}}
-  // expected-note@+8 {{InvalidKernelName1 declared here}}
-  // expected-note@+9 {{in instantiation of function template specialization}}
+  // expected-error@Inputs/sycl.hpp:220 {{'InvalidKernelName1' is an invalid kernel name type}}
+  // expected-note@Inputs/sycl.hpp:220 {{'InvalidKernelName1' should be globally-visible}}
+  // expected-note@+8 {{in instantiation of function template specialization}}
 #elif defined(ERROR)
-  // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName1' used in kernel name. Kernel name should be globally-visible}}
-  // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'InvalidKernelName1'}}
-  // expected-note@+3 {{InvalidKernelName1 declared here}}
+  // expected-error@Inputs/sycl.hpp:220 {{'InvalidKernelName1' is an invalid kernel name type}}
+  // expected-note@Inputs/sycl.hpp:220 {{'InvalidKernelName1' should be globally-visible}}
   // expected-note@+4 {{in instantiation of function template specialization}}
 #endif
   class InvalidKernelName1 {};

--- a/clang/test/SemaSYCL/implicit_kernel_type.cpp
+++ b/clang/test/SemaSYCL/implicit_kernel_type.cpp
@@ -25,11 +25,13 @@ int main() {
   queue q;
 
 #if defined(WARN)
-  // expected-error@Inputs/sycl.hpp:220 {{kernel needs to have a globally-visible name}}
-  // expected-note@+7 {{InvalidKernelName1 declared here}}
-  // expected-note@+8 {{in instantiation of function template specialization}}
+  // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName1' used in kernel name. Kernel name should be globally-visible}}
+  // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'InvalidKernelName1'}}
+  // expected-note@+8 {{InvalidKernelName1 declared here}}
+  // expected-note@+9 {{in instantiation of function template specialization}}
 #elif defined(ERROR)
-  // expected-error@Inputs/sycl.hpp:220 {{kernel needs to have a globally-visible name}}
+  // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName1' used in kernel name. Kernel name should be globally-visible}}
+  // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'InvalidKernelName1'}}
   // expected-note@+3 {{InvalidKernelName1 declared here}}
   // expected-note@+4 {{in instantiation of function template specialization}}
 #endif

--- a/clang/test/SemaSYCL/kernelname-enum.cpp
+++ b/clang/test/SemaSYCL/kernelname-enum.cpp
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
-// expected-error@Inputs/sycl.hpp:220 2{{invalid type 'unscoped_enum_no_type_set' used in kernel name. Unscoped enum requires fixed underlying type}}
 #include "Inputs/sycl.hpp"
 
 enum unscoped_enum_int : int {
@@ -8,7 +7,6 @@ enum unscoped_enum_int : int {
   val_2
 };
 
-// expected-note@+1 2 {{'unscoped_enum_no_type_set' declared here}}
 enum unscoped_enum_no_type_set {
   val_3,
   val_4
@@ -69,13 +67,15 @@ int main() {
   });
 
   q.submit([&](cl::sycl::handler &cgh) {
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'dummy_functor_2<val_3>'}}
+    // expected-error@Inputs/sycl.hpp:220 {{'dummy_functor_2<val_3>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{unscoped enum 'unscoped_enum_no_type_set' requires fixed underlying type}}
     // expected-note@+1{{in instantiation of function template specialization}}
     cgh.single_task(f2);
   });
 
   q.submit([&](cl::sycl::handler &cgh) {
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'templated_functor<dummy_functor_2>'}}
+    // expected-error@Inputs/sycl.hpp:220 {{'templated_functor<dummy_functor_2>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{unscoped enum 'unscoped_enum_no_type_set' requires fixed underlying type}}
     // expected-note@+1{{in instantiation of function template specialization}}
     cgh.single_task(f5);
   });

--- a/clang/test/SemaSYCL/kernelname-enum.cpp
+++ b/clang/test/SemaSYCL/kernelname-enum.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
-// expected-error@Inputs/sycl.hpp:220 2{{kernel name is invalid. Unscoped enum requires fixed underlying type}}
+// expected-error@Inputs/sycl.hpp:220 2{{invalid type 'unscoped_enum_no_type_set' used in kernel name. Unscoped enum requires fixed underlying type}}
 #include "Inputs/sycl.hpp"
 
 enum unscoped_enum_int : int {
@@ -69,11 +69,13 @@ int main() {
   });
 
   q.submit([&](cl::sycl::handler &cgh) {
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'dummy_functor_2<val_3>'}}
     // expected-note@+1{{in instantiation of function template specialization}}
     cgh.single_task(f2);
   });
 
   q.submit([&](cl::sycl::handler &cgh) {
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'templated_functor<dummy_functor_2>'}}
     // expected-note@+1{{in instantiation of function template specialization}}
     cgh.single_task(f5);
   });

--- a/clang/test/SemaSYCL/stdtypes_kernel_type.cpp
+++ b/clang/test/SemaSYCL/stdtypes_kernel_type.cpp
@@ -8,10 +8,14 @@ typedef long int ptrdiff_t;
 typedef decltype(nullptr) nullptr_t;
 class T;
 class U;
+class Foo;
 } // namespace std
 
 template <typename T>
 struct Templated_kernel_name;
+
+template <typename T>
+struct Templated_kernel_name2;
 
 template <typename T, typename... Args> class TemplParamPack;
 
@@ -20,24 +24,39 @@ queue q;
 
 int main() {
 #ifdef CHECK_ERROR
-  // expected-error@Inputs/sycl.hpp:220 5 {{kernel name cannot be a type in the "std" namespace}}
   q.submit([&](handler &h) {
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'nullptr_t' used in kernel name. Type cannot be in the "std" namespace}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'nullptr_t'}}
     // expected-note@+1{{in instantiation of function template specialization}}
     h.single_task<std::nullptr_t>([=] {});
   });
   q.submit([&](handler &h) {
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'std::T' used in kernel name. Type cannot be in the "std" namespace}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'std::T'}}
     // expected-note@+1{{in instantiation of function template specialization}}
     h.single_task<std::T>([=] {});
   });
   q.submit([&](handler &h) {
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'nullptr_t' used in kernel name. Type cannot be in the "std" namespace}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'Templated_kernel_name<nullptr_t>'}}
     // expected-note@+1{{in instantiation of function template specialization}}
     h.single_task<Templated_kernel_name<std::nullptr_t>>([=] {});
   });
   q.submit([&](handler &h) {
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'std::U' used in kernel name. Type cannot be in the "std" namespace}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'Templated_kernel_name<std::U>'}}
     // expected-note@+1{{in instantiation of function template specialization}}
     h.single_task<Templated_kernel_name<std::U>>([=] {});
   });
   q.submit([&](handler &cgh) {
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'std::Foo' used in kernel name. Type cannot be in the "std" namespace}}
+    // expected-note@Inputs/sycl.hpp:220{{Invalid kernel name is 'Templated_kernel_name2<Templated_kernel_name<std::Foo>>'}}
+    // expected-note@+1{{in instantiation of function template specialization}}
+    cgh.single_task<Templated_kernel_name2<Templated_kernel_name<std::Foo>>>([]() {});
+  });
+  q.submit([&](handler &cgh) {
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'nullptr_t' used in kernel name. Type cannot be in the "std" namespace}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'TemplParamPack<int, float, nullptr_t, double>'}}
     // expected-note@+1{{in instantiation of function template specialization}}
     cgh.single_task<TemplParamPack<int, float, std::nullptr_t, double>>([]() {});
   });

--- a/clang/test/SemaSYCL/stdtypes_kernel_type.cpp
+++ b/clang/test/SemaSYCL/stdtypes_kernel_type.cpp
@@ -25,38 +25,38 @@ queue q;
 int main() {
 #ifdef CHECK_ERROR
   q.submit([&](handler &h) {
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'nullptr_t' used in kernel name. Type cannot be in the "std" namespace}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'nullptr_t'}}
+    // expected-error@Inputs/sycl.hpp:220 {{'nullptr_t' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{type 'nullptr_t' cannot be in the "std" namespace}}
     // expected-note@+1{{in instantiation of function template specialization}}
     h.single_task<std::nullptr_t>([=] {});
   });
   q.submit([&](handler &h) {
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'std::T' used in kernel name. Type cannot be in the "std" namespace}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'std::T'}}
+    // expected-error@Inputs/sycl.hpp:220 {{'std::T' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{type 'std::T' cannot be in the "std" namespace}}
     // expected-note@+1{{in instantiation of function template specialization}}
     h.single_task<std::T>([=] {});
   });
   q.submit([&](handler &h) {
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'nullptr_t' used in kernel name. Type cannot be in the "std" namespace}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'Templated_kernel_name<nullptr_t>'}}
+    // expected-error@Inputs/sycl.hpp:220 {{'Templated_kernel_name<nullptr_t>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{type 'nullptr_t' cannot be in the "std" namespace}}
     // expected-note@+1{{in instantiation of function template specialization}}
     h.single_task<Templated_kernel_name<std::nullptr_t>>([=] {});
   });
   q.submit([&](handler &h) {
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'std::U' used in kernel name. Type cannot be in the "std" namespace}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'Templated_kernel_name<std::U>'}}
+    // expected-error@Inputs/sycl.hpp:220 {{'Templated_kernel_name<std::U>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{type 'std::U' cannot be in the "std" namespace}}
     // expected-note@+1{{in instantiation of function template specialization}}
     h.single_task<Templated_kernel_name<std::U>>([=] {});
   });
   q.submit([&](handler &cgh) {
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'std::Foo' used in kernel name. Type cannot be in the "std" namespace}}
-    // expected-note@Inputs/sycl.hpp:220{{Invalid kernel name is 'Templated_kernel_name2<Templated_kernel_name<std::Foo>>'}}
+    // expected-error@Inputs/sycl.hpp:220 {{'Templated_kernel_name2<Templated_kernel_name<std::Foo>>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220{{type 'std::Foo' cannot be in the "std" namespace}}
     // expected-note@+1{{in instantiation of function template specialization}}
     cgh.single_task<Templated_kernel_name2<Templated_kernel_name<std::Foo>>>([]() {});
   });
   q.submit([&](handler &cgh) {
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'nullptr_t' used in kernel name. Type cannot be in the "std" namespace}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'TemplParamPack<int, float, nullptr_t, double>'}}
+    // expected-error@Inputs/sycl.hpp:220 {{'TemplParamPack<int, float, nullptr_t, double>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{type 'nullptr_t' cannot be in the "std" namespace}}
     // expected-note@+1{{in instantiation of function template specialization}}
     cgh.single_task<TemplParamPack<int, float, std::nullptr_t, double>>([]() {});
   });

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -16,6 +16,12 @@ typedef struct {
 } max_align_t;
 } // namespace std
 
+template <typename T>
+struct Templated_kernel_name;
+
+template <typename T>
+struct Templated_kernel_name2;
+
 struct MyWrapper {
 private:
   class InvalidKernelName0 {};
@@ -27,7 +33,8 @@ public:
   void test() {
     cl::sycl::queue q;
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{kernel needs to have a globally-visible name}}
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName1' used in kernel name. Kernel name should be globally-visible}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'InvalidKernelName1'}}
     // expected-note@+3 {{InvalidKernelName1 declared here}}
     // expected-note@+4{{in instantiation of function template specialization}}
 #endif
@@ -37,7 +44,8 @@ public:
     });
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{kernel needs to have a globally-visible name}}
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName2' used in kernel name. Kernel name should be globally-visible}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'namespace1::KernelName<InvalidKernelName2>'}}
     // expected-note@+3 {{InvalidKernelName2 declared here}}
     // expected-note@+4{{in instantiation of function template specialization}}
 #endif
@@ -47,8 +55,9 @@ public:
     });
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{kernel needs to have a globally-visible name}}
-    // expected-note@21 {{InvalidKernelName0 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'MyWrapper::InvalidKernelName0' used in kernel name. Kernel name should be globally-visible}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'MyWrapper::InvalidKernelName0'}}
+    // expected-note@27 {{InvalidKernelName0 declared here}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
@@ -56,8 +65,9 @@ public:
     });
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{kernel needs to have a globally-visible name}}
-    // expected-note@22 {{InvalidKernelName3 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'MyWrapper::InvalidKernelName3' used in kernel name. Kernel name should be globally-visible}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'namespace1::KernelName<MyWrapper::InvalidKernelName3>'}}
+    // expected-note@28 {{InvalidKernelName3 declared here}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
@@ -70,7 +80,8 @@ public:
     });
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{kernel name cannot be a type in the "std" namespace}}
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'std::max_align_t' used in kernel name. Type cannot be in the "std" namespace}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'std::max_align_t'}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
@@ -79,8 +90,9 @@ public:
 
     using InvalidAlias = InvalidKernelName4;
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{kernel needs to have a globally-visible name}}
-    // expected-note@23 {{InvalidKernelName4 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'MyWrapper::InvalidKernelName4' used in kernel name. Kernel name should be globally-visible}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'MyWrapper::InvalidKernelName4'}}
+    // expected-note@29 {{InvalidKernelName4 declared here}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
@@ -89,12 +101,22 @@ public:
 
     using InvalidAlias1 = InvalidKernelName5;
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{kernel needs to have a globally-visible name}}
-    // expected-note@24 {{InvalidKernelName5 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'MyWrapper::InvalidKernelName5' used in kernel name. Kernel name should be globally-visible}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'namespace1::KernelName<MyWrapper::InvalidKernelName5>'}}
+    // expected-note@30 {{InvalidKernelName5 declared here}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidAlias1>>([] {});
+    });
+#ifndef __SYCL_UNNAMED_LAMBDA__
+    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName1' used in kernel name. Kernel name should be globally-visible}}
+    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>'}}
+    // expected-note@41 {{InvalidKernelName1 declared here}}
+    // expected-note@+3{{in instantiation of function template specialization}}
+#endif
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>>([] {});
     });
   }
 };
@@ -103,6 +125,7 @@ int main() {
   cl::sycl::queue q;
 #ifndef __SYCL_UNNAMED_LAMBDA__
   // expected-error@Inputs/sycl.hpp:220 {{kernel name is missing}}
+  // expected-note-re@Inputs/sycl.hpp:220 {{Invalid kernel name is '(lambda at {{.*}}unnamed-kernel.cpp{{.*}}'}}
   // expected-note@+2{{in instantiation of function template specialization}}
 #endif
   q.submit([&](cl::sycl::handler &h) { h.single_task([] {}); });

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -33,9 +33,8 @@ public:
   void test() {
     cl::sycl::queue q;
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName1' used in kernel name. Kernel name should be globally-visible}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'InvalidKernelName1'}}
-    // expected-note@+3 {{InvalidKernelName1 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{'InvalidKernelName1' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{'InvalidKernelName1' should be globally-visible}}
     // expected-note@+4{{in instantiation of function template specialization}}
 #endif
     class InvalidKernelName1 {};
@@ -44,9 +43,8 @@ public:
     });
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName2' used in kernel name. Kernel name should be globally-visible}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'namespace1::KernelName<InvalidKernelName2>'}}
-    // expected-note@+3 {{InvalidKernelName2 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{'namespace1::KernelName<InvalidKernelName2>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{'InvalidKernelName2' should be globally-visible}}
     // expected-note@+4{{in instantiation of function template specialization}}
 #endif
     class InvalidKernelName2 {};
@@ -55,9 +53,8 @@ public:
     });
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'MyWrapper::InvalidKernelName0' used in kernel name. Kernel name should be globally-visible}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'MyWrapper::InvalidKernelName0'}}
-    // expected-note@27 {{InvalidKernelName0 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName0' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName0' should be globally-visible}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
@@ -65,9 +62,8 @@ public:
     });
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'MyWrapper::InvalidKernelName3' used in kernel name. Kernel name should be globally-visible}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'namespace1::KernelName<MyWrapper::InvalidKernelName3>'}}
-    // expected-note@28 {{InvalidKernelName3 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{'namespace1::KernelName<MyWrapper::InvalidKernelName3>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName3' should be globally-visible}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
@@ -80,8 +76,8 @@ public:
     });
 
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'std::max_align_t' used in kernel name. Type cannot be in the "std" namespace}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'std::max_align_t'}}
+    // expected-error@Inputs/sycl.hpp:220 {{'std::max_align_t' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{type 'std::max_align_t' cannot be in the "std" namespace}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
@@ -90,9 +86,8 @@ public:
 
     using InvalidAlias = InvalidKernelName4;
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'MyWrapper::InvalidKernelName4' used in kernel name. Kernel name should be globally-visible}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'MyWrapper::InvalidKernelName4'}}
-    // expected-note@29 {{InvalidKernelName4 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName4' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName4' should be globally-visible}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
@@ -101,18 +96,16 @@ public:
 
     using InvalidAlias1 = InvalidKernelName5;
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'MyWrapper::InvalidKernelName5' used in kernel name. Kernel name should be globally-visible}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'namespace1::KernelName<MyWrapper::InvalidKernelName5>'}}
-    // expected-note@30 {{InvalidKernelName5 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{'namespace1::KernelName<MyWrapper::InvalidKernelName5>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName5' should be globally-visible}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidAlias1>>([] {});
     });
 #ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{invalid type 'InvalidKernelName1' used in kernel name. Kernel name should be globally-visible}}
-    // expected-note@Inputs/sycl.hpp:220 {{Invalid kernel name is 'Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>'}}
-    // expected-note@41 {{InvalidKernelName1 declared here}}
+    // expected-error@Inputs/sycl.hpp:220 {{'Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{'InvalidKernelName1' should be globally-visible}}
     // expected-note@+3{{in instantiation of function template specialization}}
 #endif
     q.submit([&](cl::sycl::handler &h) {
@@ -124,8 +117,8 @@ public:
 int main() {
   cl::sycl::queue q;
 #ifndef __SYCL_UNNAMED_LAMBDA__
-  // expected-error@Inputs/sycl.hpp:220 {{kernel name is missing}}
-  // expected-note-re@Inputs/sycl.hpp:220 {{Invalid kernel name is '(lambda at {{.*}}unnamed-kernel.cpp{{.*}}'}}
+  // expected-error-re@Inputs/sycl.hpp:220 {{'(lambda at {{.*}}unnamed-kernel.cpp{{.*}}' is an invalid kernel name type}}
+  // expected-note@Inputs/sycl.hpp:220 {{kernel name is missing}}
   // expected-note@+2{{in instantiation of function template specialization}}
 #endif
   q.submit([&](cl::sycl::handler &h) { h.single_task([] {}); });


### PR DESCRIPTION
This patch modifies the error diagnostic to print the fully instantiated
kernel name to easily identify problematic types in kernel name. A note
diagnostic with the problematic type was also added.