### PR TITLE
[SYCL] Add support for new FPGA function attribute stall_enable

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1226,6 +1226,19 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
   let PragmaAttributeSupport = 0;
 }
 
+def SYCLIntelStallEnable : InheritableAttr {
+  let Spellings = [CXX11<"intel","stall_enable">];
+  let LangOpts = [OpenCL, SYCLIsDevice, SYCLIsHost];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let AdditionalMembers = [{
+    static const char *getName() {
+      return "stall_enable";
+    }
+  }];
+  let Documentation = [SYCLIntelStallEnableAttrDocs];
+  let PragmaAttributeSupport = 0;
+}
+
 def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","scheduler_target_fmax_mhz">,
                    CXX11<"intel","scheduler_target_fmax_mhz">];

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1228,7 +1228,7 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
 
 def SYCLIntelStallEnable : InheritableAttr {
   let Spellings = [CXX11<"intel","stall_enable">];
-  let LangOpts = [SYCLIsDevice];
+  let LangOpts = [SYCLIsHost, SYCLIsDevice];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let AdditionalMembers = [{
     static const char *getName() {

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1228,7 +1228,7 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
 
 def SYCLIntelStallEnable : InheritableAttr {
   let Spellings = [CXX11<"intel","stall_enable">];
-  let LangOpts = [OpenCL, SYCLIsDevice, SYCLIsHost];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let AdditionalMembers = [{
     static const char *getName() {

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1228,7 +1228,7 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
 
 def SYCLIntelStallEnable : InheritableAttr {
   let Spellings = [CXX11<"intel","stall_enable">];
-  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let LangOpts = [SYCLIsDevice];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let AdditionalMembers = [{
     static const char *getName() {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2229,13 +2229,6 @@ LLVM IR function metadata should simply be i32 1.
 
 .. code-block:: c++
 
-  [[intel::stall_enable]] void foo1() {}
-
-  class f
-  {
-      [[intel::stall_enable]] void foo2() {}
-  };
-
   class Functor
   {
       [[intel::stall_enable]] void operator()(item<1> item)

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2212,6 +2212,36 @@ device kernel, the attribute is ignored and it is not propagated to a kernel.
   }];
 }
 
+def SYCLIntelStallEnableAttrDocs : Documentation {
+  let Category = DocCatFunction;
+  let Heading = "intel::stall_enable";
+  let Content = [{
+Applies to a lambda function, or function definition. Requests, to the extent
+possible, that statically-scheduled clusters handle stalls using a stall-enable
+signal to freeze computation within the cluster. This attribute can be applied
+to any lambda or function definition, it does not have to be a device
+function/kernel.
+
+.. code-block:: c++
+
+  [[intel::stall_enable]] void foo1() {}
+
+  class Functor
+  {
+      [[intel::stall_enable]] void operator()(item<1> item)
+      {
+          /* kernel code */
+      }
+  }
+
+  kernel<class kernel_name>(
+  []() [[intel::stall_enable]] {
+       /* kernel code */
+  });
+
+  }];
+}
+
 def ReqdWorkGroupSizeAttrDocs : Documentation {
   let Category = DocCatFunction;
   let Heading = "reqd_work_group_size";

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2219,7 +2219,7 @@ def SYCLIntelStallEnableAttrDocs : Documentation {
 When applied to a lambda or function call operator (of a function object)
 on device, this requests, to the extent possible, that statically-scheduled
 clusters handle stalls using a stall-enable signal to freeze computation
-within the cluster.
+within the cluster. This attribute is ignored on the host.
 
 If ``intel::stall_enable`` is applied to a function called from a device
 kernel, the attribute is ignored and it is not propagated to a kernel.

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2216,11 +2216,16 @@ def SYCLIntelStallEnableAttrDocs : Documentation {
   let Category = DocCatFunction;
   let Heading = "intel::stall_enable";
   let Content = [{
-Applies to a lambda function, or function definition. Requests, to the extent
-possible, that statically-scheduled clusters handle stalls using a stall-enable
-signal to freeze computation within the cluster. This attribute can be applied
-to device function/kernel and not to arbitrary device functions. This takes no
-argument and LLVM IR function metadata should simply be i32 1.
+Applies to a device function/lambda function. Requests, to the extent
+possible, that statically-scheduled clusters handle stalls using a
+stall-enable signal to freeze computation within the cluster.
+
+If ``intel::stall_enable`` is applied to a function called from a device
+kernel, the attribute is ignored and it is not propagated to a kernel.
+
+The ``intel::stall_enable`` attribute has an effect when applied to a
+function, and no effect otherwise. This attribute takes no argument and
+LLVM IR function metadata should simply be i32 1.
 
 .. code-block:: c++
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2219,12 +2219,17 @@ def SYCLIntelStallEnableAttrDocs : Documentation {
 Applies to a lambda function, or function definition. Requests, to the extent
 possible, that statically-scheduled clusters handle stalls using a stall-enable
 signal to freeze computation within the cluster. This attribute can be applied
-to any lambda or function definition, it does not have to be a device
-function/kernel.
+to device function/kernel and not to arbitrary device functions. This takes no
+argument and LLVM IR function metadata should simply be i32 1.
 
 .. code-block:: c++
 
   [[intel::stall_enable]] void foo1() {}
+
+  class f
+  {
+      [[intel::stall_enable]] void foo2() {}
+  };
 
   class Functor
   {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2216,9 +2216,10 @@ def SYCLIntelStallEnableAttrDocs : Documentation {
   let Category = DocCatFunction;
   let Heading = "intel::stall_enable";
   let Content = [{
-Applies to a device function/lambda function. Requests, to the extent
-possible, that statically-scheduled clusters handle stalls using a
-stall-enable signal to freeze computation within the cluster.
+When applied to a lambda or function call operator (of a function object)
+on device, this requests, to the extent possible, that statically-scheduled
+clusters handle stalls using a stall-enable signal to freeze computation
+within the cluster.
 
 If ``intel::stall_enable`` is applied to a function called from a device
 kernel, the attribute is ignored and it is not propagated to a kernel.

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2224,9 +2224,8 @@ within the cluster.
 If ``intel::stall_enable`` is applied to a function called from a device
 kernel, the attribute is ignored and it is not propagated to a kernel.
 
-The ``intel::stall_enable`` attribute has an effect when applied to a
-function, and no effect otherwise. This attribute takes no argument and
-LLVM IR function metadata should simply be i32 1.
+The ``intel::stall_enable`` attribute takes no argument and has an effect
+when applied to a function, and no effect otherwise.
 
 .. code-block:: c++
 

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -165,7 +165,8 @@ public:
         ParsedAttr == AT_SYCLIntelSchedulerTargetFmaxMhz ||
         ParsedAttr == AT_SYCLIntelMaxWorkGroupSize ||
         ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim ||
-        ParsedAttr == AT_SYCLIntelNoGlobalWorkOffset)
+        ParsedAttr == AT_SYCLIntelNoGlobalWorkOffset ||
+	ParsedAttr == AT_SYCLIntelStallEnable)
       return true;
 
     return false;

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -166,7 +166,7 @@ public:
         ParsedAttr == AT_SYCLIntelMaxWorkGroupSize ||
         ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim ||
         ParsedAttr == AT_SYCLIntelNoGlobalWorkOffset ||
-	ParsedAttr == AT_SYCLIntelStallEnable)
+        ParsedAttr == AT_SYCLIntelStallEnable)
       return true;
 
     return false;

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -676,6 +676,13 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
     if (A->getEnabled())
       Fn->setMetadata("no_global_work_offset", llvm::MDNode::get(Context, {}));
   }
+
+  if (FD->hasAttr<SYCLIntelStallEnableAttr>()) {
+    llvm::Metadata *AttrMDArgs[] = {
+        llvm::ConstantAsMetadata::get(Builder.getInt32(1))};
+    Fn->setMetadata("stall_enable",
+                   llvm::MDNode::get(Context, AttrMDArgs));
+  }
 }
 
 /// Determine whether the function F ends with a return stmt.

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -680,8 +680,7 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   if (FD->hasAttr<SYCLIntelStallEnableAttr>()) {
     llvm::Metadata *AttrMDArgs[] = {
         llvm::ConstantAsMetadata::get(Builder.getInt32(1))};
-    Fn->setMetadata("stall_enable",
-                   llvm::MDNode::get(Context, AttrMDArgs));
+    Fn->setMetadata("stall_enable", llvm::MDNode::get(Context, AttrMDArgs));
   }
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3029,6 +3029,23 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
                                                                      E);
 }
 
+//Handles stall_enable
+static void handleStallEnableAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
+  if (D->isInvalidDecl())
+    return;
+
+  if (S.LangOpts.SYCLIsHost)
+    return;
+
+  unsigned NumArgs = Attr.getNumArgs();
+  if (NumArgs > 0) {
+    S.Diag(Attr.getLoc(), diag::warn_attribute_too_many_arguments) << Attr << 0;
+    return;
+  }
+
+  handleSimpleAttribute<SYCLIntelStallEnableAttr>(S, D, Attr);
+}
+
 // Add scheduler_target_fmax_mhz
 void Sema::addSYCLIntelSchedulerTargetFmaxMhzAttr(
     Decl *D, const AttributeCommonInfo &Attr, Expr *E) {
@@ -8397,6 +8414,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset:
     handleNoGlobalWorkOffsetAttr(S, D, AL);
     break;
+  case ParsedAttr::AT_SYCLIntelStallEnable:
+    handleStallEnableAttr(S, D, AL);
+    break;
   case ParsedAttr::AT_VecTypeHint:
     handleVecTypeHint(S, D, AL);
     break;
@@ -8820,6 +8840,9 @@ void Sema::ProcessDeclAttributeList(Scope *S, Decl *D,
       Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
       D->setInvalidDecl();
     } else if (const auto *A = D->getAttr<IntelReqdSubGroupSizeAttr>()) {
+      Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
+      D->setInvalidDecl();
+    } else if (const auto *A = D->getAttr<SYCLIntelStallEnableAttr>()) {
       Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
       D->setInvalidDecl();
     } else if (!D->hasAttr<CUDAGlobalAttr>()) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8842,9 +8842,6 @@ void Sema::ProcessDeclAttributeList(Scope *S, Decl *D,
     } else if (const auto *A = D->getAttr<IntelReqdSubGroupSizeAttr>()) {
       Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
       D->setInvalidDecl();
-    } else if (const auto *A = D->getAttr<SYCLIntelStallEnableAttr>()) {
-      Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
-      D->setInvalidDecl();
     } else if (!D->hasAttr<CUDAGlobalAttr>()) {
       if (const auto *A = D->getAttr<AMDGPUFlatWorkGroupSizeAttr>()) {
         Diag(D->getLocation(), diag::err_attribute_wrong_decl_type)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3034,9 +3034,6 @@ static void handleStallEnableAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
   if (D->isInvalidDecl())
     return;
 
-  if (S.LangOpts.SYCLIsHost)
-    return;
-
   unsigned NumArgs = Attr.getNumArgs();
   if (NumArgs > 0) {
     S.Diag(Attr.getLoc(), diag::warn_attribute_too_many_arguments) << Attr << 0;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3029,7 +3029,7 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
                                                                      E);
 }
 
-//Handles stall_enable
+// Handles stall_enable
 static void handleStallEnableAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
   if (D->isInvalidDecl())
     return;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -543,6 +543,9 @@ public:
       if (auto *A = FD->getAttr<SYCLIntelNoGlobalWorkOffsetAttr>())
         Attrs.insert(A);
 
+      if (auto *A = FD->getAttr<SYCLIntelStallEnableAttr>())
+        Attrs.insert(A);
+
       if (auto *A = FD->getAttr<SYCLSimdAttr>())
         Attrs.insert(A);
       // Propagate the explicit SIMD attribute through call graph - it is used
@@ -3204,6 +3207,7 @@ void Sema::MarkDevice(void) {
         case attr::Kind::SYCLIntelSchedulerTargetFmaxMhz:
         case attr::Kind::SYCLIntelMaxGlobalWorkDim:
         case attr::Kind::SYCLIntelNoGlobalWorkOffset:
+        case attr::Kind::SYCLIntelStallEnable:
         case attr::Kind::SYCLSimd: {
           if ((A->getKind() == attr::Kind::SYCLSimd) && KernelBody &&
               !KernelBody->getAttr<SYCLSimdAttr>()) {

--- a/clang/test/CodeGenSYCL/stall_enable.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable.cpp
@@ -5,8 +5,6 @@
 using namespace cl::sycl;
 queue q;
 
-[[intel::stall_enable]] void test() {}
-
 class Foo {
 public:
   [[intel::stall_enable]] void operator()() const {}
@@ -18,9 +16,6 @@ int main() {
     h.single_task<class test_kernel1>(f);
 
     h.single_task<class test_kernel2>(
-        []() { test(); });
-
-    h.single_task<class test_kernel3>(
         []() [[intel::stall_enable]]{});
   });
   return 0;
@@ -28,5 +23,4 @@ int main() {
 
 // CHECK: define spir_kernel void @"{{.*}}test_kernel1"() #0 {{.*}} !stall_enable ![[NUM5:[0-9]+]]
 // CHECK: define spir_kernel void @"{{.*}}test_kernel2"() #0 {{.*}} !stall_enable ![[NUM5]]
-// CHECK: define spir_kernel void @"{{.*}}test_kernel3"() #0 {{.*}} !stall_enable ![[NUM5]]
 // CHECK: ![[NUM5]] = !{i32 1}

--- a/clang/test/CodeGenSYCL/stall_enable.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
+
+[[intel::stall_enable]] void test() {}
+
+class Foo {
+public:
+  [[intel::stall_enable]] void operator()() const {}
+};
+
+int main() {
+  q.submit([&](handler &h) {
+
+  Foo boo;
+  h.single_task<class test_kernel1>(boo);
+
+  h.single_task<class test_kernel2>(
+    []() [[intel::stall_enable]]{});
+ });
+  return 0;
+}
+
+// CHECK: define spir_kernel void @"{{.*}}test_kernel1"() #0 {{.*}} !stall_enable [[FOO:![0-9]+]]
+// CHECK: define spir_kernel void @"{{.*}}test_kernel2"() #0 {{.*}} !stall_enable [[FOO:![0-9]+]]
+// CHECK: [[FOO]] = !{i32 1}

--- a/clang/test/CodeGenSYCL/stall_enable.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable.cpp
@@ -14,13 +14,12 @@ public:
 
 int main() {
   q.submit([&](handler &h) {
+    Foo boo;
+    h.single_task<class test_kernel1>(boo);
 
-  Foo boo;
-  h.single_task<class test_kernel1>(boo);
-
-  h.single_task<class test_kernel2>(
-    []() [[intel::stall_enable]]{});
- });
+    h.single_task<class test_kernel2>(
+        []() [[intel::stall_enable]]{});
+    });
   return 0;
 }
 

--- a/clang/test/CodeGenSYCL/stall_enable.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable.cpp
@@ -26,7 +26,7 @@ int main() {
   return 0;
 }
 
-// CHECK: define spir_kernel void @"{{.*}}test_kernel1"() #0 {{.*}} !stall_enable [[FOO:![0-9]+]]
-// CHECK: define spir_kernel void @"{{.*}}test_kernel2"() #0 {{.*}} !stall_enable [[FOO:![0-9]+]]
-// CHECK: define spir_kernel void @"{{.*}}test_kernel3"() #0 {{.*}} !stall_enable [[FOO:![0-9]+]]
-// CHECK: [[FOO]] = !{i32 1}
+// CHECK: define spir_kernel void @"{{.*}}test_kernel1"() #0 {{.*}} !stall_enable ![[NUM5:[0-9]+]]
+// CHECK: define spir_kernel void @"{{.*}}test_kernel2"() #0 {{.*}} !stall_enable ![[NUM5]]
+// CHECK: define spir_kernel void @"{{.*}}test_kernel3"() #0 {{.*}} !stall_enable ![[NUM5]]
+// CHECK: ![[NUM5]] = !{i32 1}

--- a/clang/test/CodeGenSYCL/stall_enable.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable.cpp
@@ -14,10 +14,13 @@ public:
 
 int main() {
   q.submit([&](handler &h) {
-    Foo boo;
-    h.single_task<class test_kernel1>(boo);
+    Foo f;
+    h.single_task<class test_kernel1>(f);
 
     h.single_task<class test_kernel2>(
+        []() { test(); });
+
+    h.single_task<class test_kernel3>(
         []() [[intel::stall_enable]]{});
   });
   return 0;
@@ -25,4 +28,5 @@ int main() {
 
 // CHECK: define spir_kernel void @"{{.*}}test_kernel1"() #0 {{.*}} !stall_enable [[FOO:![0-9]+]]
 // CHECK: define spir_kernel void @"{{.*}}test_kernel2"() #0 {{.*}} !stall_enable [[FOO:![0-9]+]]
+// CHECK: define spir_kernel void @"{{.*}}test_kernel3"() #0 {{.*}} !stall_enable [[FOO:![0-9]+]]
 // CHECK: [[FOO]] = !{i32 1}

--- a/clang/test/CodeGenSYCL/stall_enable.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable.cpp
@@ -19,7 +19,7 @@ int main() {
 
     h.single_task<class test_kernel2>(
         []() [[intel::stall_enable]]{});
-    });
+  });
   return 0;
 }
 

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -11,11 +11,11 @@ queue q;
 // CHECK: SYCLIntelStallEnableAttr
 
 #ifdef TRIGGER_ERROR
-[[intel::stall_enable(1)]]void bar1() {} // expected-error{{'stall_enable' attribute takes no arguments}}
-#endif // TRIGGER_ERROR
+[[intel::stall_enable(1)]] void bar1() {} // expected-error{{'stall_enable' attribute takes no arguments}}
+#endif
 
 void foo2() {
-  auto lambda = []() [[intel::stall_enable]] {};
+  auto lambda = []() [[intel::stall_enable]]{};
   lambda();
   // CHECK: FunctionDecl{{.*}}foo2
   // CHECK: LambdaExpr
@@ -30,20 +30,20 @@ struct FuncObj {
 
 int main() {
   q.submit([&](handler &h) {
-  // CHECK-LABEL: FunctionDecl {{.*}}test_kernel1
-  // CHECK:       SYCLIntelStallEnableAttr {{.*}}
-  h.single_task<class test_kernel1>(
-      FuncObj());
+    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel1
+    // CHECK:       SYCLIntelStallEnableAttr {{.*}}
+    h.single_task<class test_kernel1>(
+        FuncObj());
 
-  // CHECK-LABEL: FunctionDecl {{.*}}test_kernel2
-  // CHECK:       SYCLIntelStallEnableAttr {{.*}}
-   h.single_task<class test_kernel2>(
-      []() [[intel::stall_enable]]{});
+    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel2
+    // CHECK:       SYCLIntelStallEnableAttr {{.*}}
+    h.single_task<class test_kernel2>(
+        []() [[intel::stall_enable]]{});
 
-  // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
-  // CHECK:       SYCLIntelStallEnableAttr {{.*}}
-  h.single_task<class test_kernel3>(
-      []() { func_do_not_ignore(); });
- });
+    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
+    // CHECK:       SYCLIntelStallEnableAttr {{.*}}
+    h.single_task<class test_kernel3>(
+        []() { func_do_not_ignore(); });
+    });
   return 0;
 }

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -6,7 +6,7 @@
 using namespace cl::sycl;
 queue q;
 
-[[intel::stall_enable]] void test() {}    //expected-warning{{'stall_enable' attribute ignored}}
+[[intel::stall_enable]] void test() {} //expected-warning{{'stall_enable' attribute ignored}}
 
 #ifdef TRIGGER_ERROR
 [[intel::stall_enable(1)]] void bar1() {} // expected-error{{'stall_enable' attribute takes no arguments}}
@@ -43,7 +43,6 @@ int main() {
     // CHECK-NOT:   SYCLIntelStallEnableAttr {{.*}}
     h.single_task<class test_kernel4>(
         []() { test(); });
-
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -15,8 +15,6 @@ struct FuncObj {
   [[intel::stall_enable]] void operator()() const {}
 };
 
-[[intel::stall_enable]] void func_do_not_ignore() {}
-
 class Functor16 {
 public:
   [[intel::stall_enable]] void operator()() const {}
@@ -34,15 +32,10 @@ int main() {
     h.single_task<class test_kernel2>(
         []() [[intel::stall_enable]]{});
 
+    Functor16 f16;
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
     // CHECK:       SYCLIntelStallEnableAttr {{.*}}
-    h.single_task<class test_kernel3>(
-        []() { func_do_not_ignore(); });
-
-    Functor16 f16;
-    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel4
-    // CHECK:       SYCLIntelStallEnableAttr {{.*}}
-    h.single_task<class test_kernel4>(f16);
+    h.single_task<class test_kernel3>(f16);
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -6,6 +6,8 @@
 using namespace cl::sycl;
 queue q;
 
+[[intel::stall_enable]] void test() {}    //expected-warning{{'stall_enable' attribute ignored}}
+
 #ifdef TRIGGER_ERROR
 [[intel::stall_enable(1)]] void bar1() {} // expected-error{{'stall_enable' attribute takes no arguments}}
 [[intel::stall_enable]] int N;            // expected-error{{'stall_enable' attribute only applies to functions}}
@@ -36,6 +38,12 @@ int main() {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
     // CHECK:       SYCLIntelStallEnableAttr {{.*}}
     h.single_task<class test_kernel3>(f16);
+
+    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel4
+    // CHECK-NOT:   SYCLIntelStallEnableAttr {{.*}}
+    h.single_task<class test_kernel4>(
+        []() { test(); });
+
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -44,6 +44,6 @@ int main() {
     // CHECK:       SYCLIntelStallEnableAttr {{.*}}
     h.single_task<class test_kernel3>(
         []() { func_do_not_ignore(); });
-    });
+  });
   return 0;
 }

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -16,7 +16,7 @@ queue q;
 
 #ifdef TRIGGER_ERROR
 [[intel::stall_enable(1)]] void bar1() {} // expected-error{{'stall_enable' attribute takes no arguments}}
-[[intel::stall_enable]] int N; // expected-error{{'stall_enable' attribute only applies to functions}}
+[[intel::stall_enable]] int N;            // expected-error{{'stall_enable' attribute only applies to functions}}
 #endif
 
 void foo3() {

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -17,11 +17,6 @@ struct FuncObj {
   [[intel::stall_enable]] void operator()() const {}
 };
 
-class Functor16 {
-public:
-  [[intel::stall_enable]] void operator()() const {}
-};
-
 int main() {
   q.submit([&](handler &h) {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel1
@@ -34,14 +29,9 @@ int main() {
     h.single_task<class test_kernel2>(
         []() [[intel::stall_enable]]{});
 
-    Functor16 f16;
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
-    // CHECK:       SYCLIntelStallEnableAttr {{.*}}
-    h.single_task<class test_kernel3>(f16);
-
-    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel4
     // CHECK-NOT:   SYCLIntelStallEnableAttr {{.*}}
-    h.single_task<class test_kernel4>(
+    h.single_task<class test_kernel3>(
         []() { test(); });
   });
   return 0;

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -internal-isystem %S/Inputs -fsycl-is-device -Wno-sycl-2017-compat -DTRIGGER_ERROR -verify
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -ast-dump -Wno-sycl-2017-compat %s | FileCheck %s
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
+
+[[intel::stall_enable]] void foo1() {}
+// CHECK: FunctionDecl{{.*}}foo1
+// CHECK: SYCLIntelStallEnableAttr
+
+#ifdef TRIGGER_ERROR
+[[intel::stall_enable(1)]]void bar1() {} // expected-error{{'stall_enable' attribute takes no arguments}}
+#endif // TRIGGER_ERROR
+
+void foo2() {
+  auto lambda = []() [[intel::stall_enable]] {};
+  lambda();
+  // CHECK: FunctionDecl{{.*}}foo2
+  // CHECK: LambdaExpr
+  // CHECK: SYCLIntelStallEnableAttr
+}
+
+struct FuncObj {
+  [[intel::stall_enable]] void operator()() const {}
+};
+
+[[intel::stall_enable]] void func_do_not_ignore() {}
+
+int main() {
+  q.submit([&](handler &h) {
+  // CHECK-LABEL: FunctionDecl {{.*}}test_kernel1
+  // CHECK:       SYCLIntelStallEnableAttr {{.*}}
+  h.single_task<class test_kernel1>(
+      FuncObj());
+
+  // CHECK-LABEL: FunctionDecl {{.*}}test_kernel2
+  // CHECK:       SYCLIntelStallEnableAttr {{.*}}
+   h.single_task<class test_kernel2>(
+      []() [[intel::stall_enable]]{});
+
+  // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
+  // CHECK:       SYCLIntelStallEnableAttr {{.*}}
+  h.single_task<class test_kernel3>(
+      []() { func_do_not_ignore(); });
+ });
+  return 0;
+}

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -6,26 +6,10 @@
 using namespace cl::sycl;
 queue q;
 
-[[intel::stall_enable]] void foo1() {}
-// CHECK: FunctionDecl{{.*}}foo1
-// CHECK: SYCLIntelStallEnableAttr
-
-[[intel::stall_enable]] void foo2(int x) {}
-// CHECK: FunctionDecl{{.*}}foo2
-// CHECK: SYCLIntelStallEnableAttr
-
 #ifdef TRIGGER_ERROR
 [[intel::stall_enable(1)]] void bar1() {} // expected-error{{'stall_enable' attribute takes no arguments}}
 [[intel::stall_enable]] int N;            // expected-error{{'stall_enable' attribute only applies to functions}}
 #endif
-
-void foo3() {
-  auto lambda = []() [[intel::stall_enable]]{};
-  lambda();
-  // CHECK: FunctionDecl{{.*}}foo3
-  // CHECK: LambdaExpr
-  // CHECK: SYCLIntelStallEnableAttr
-}
 
 struct FuncObj {
   [[intel::stall_enable]] void operator()() const {}
@@ -36,20 +20,6 @@ struct FuncObj {
 class Functor16 {
 public:
   [[intel::stall_enable]] void operator()() const {}
-};
-
-class Functor8 {
-public:
-  [[intel::stall_enable]] void operator()() const {
-    foo1();
-  }
-};
-
-class test {
-  [[intel::stall_enable]] void bar() {}
-  // CHECK: CXXRecordDecl{{.*}}implicit class test
-  // CHECK: CXXMethodDecl{{.*}}bar 'void ()'
-  // CHECK: SYCLIntelStallEnableAttr
 };
 
 int main() {
@@ -73,11 +43,6 @@ int main() {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel4
     // CHECK:       SYCLIntelStallEnableAttr {{.*}}
     h.single_task<class test_kernel4>(f16);
-
-    Functor8 f8;
-    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel5
-    // CHECK:       SYCLIntelStallEnableAttr {{.*}}
-    h.single_task<class test_kernel5>(f8);
   });
   return 0;
 }


### PR DESCRIPTION
This patch adds support a new FPGA function attribute, stall_enable,
to be sent through to the backend (and ignored by the emulator).

Syntax:
[[intel::stall_enable]]

This function attribute applies to a lambda function, or function definition.
Requests, to the extent possible, that statically-scheduled clusters handle
stalls using a stall-enable signal to freeze computation within the cluster.

Stall_enable attribute can be applied to device function/kernel 
and it takes no arguments.  

LLVM IR function metadata should simply be i32 1.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>