### PR TITLE
[SYCL] Fix wrong except. raising for ALLOWLIST

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -211,7 +211,7 @@ static std::vector<DevDescT> getAllowListDesc() {
   return DecDescs;
 }
 
-enum MatchState { UNKNOWN, MATCH, NOMATCH };
+enum class FilterState { DENIED, ALLOWED };
 
 static void filterAllowList(vector_class<RT::PiDevice> &PiDevices,
                             RT::PiPlatform PiPlatform, const plugin &Plugin) {
@@ -219,10 +219,10 @@ static void filterAllowList(vector_class<RT::PiDevice> &PiDevices,
   if (AllowList.empty())
     return;
 
-  MatchState DevNameState = UNKNOWN;
-  MatchState DevVerState = UNKNOWN;
-  MatchState PlatNameState = UNKNOWN;
-  MatchState PlatVerState = UNKNOWN;
+  FilterState DevNameState = FilterState::ALLOWED;
+  FilterState DevVerState = FilterState::ALLOWED;
+  FilterState PlatNameState = FilterState::ALLOWED;
+  FilterState PlatVerState = FilterState::ALLOWED;
 
   const string_class PlatformName =
       sycl::detail::get_platform_info<string_class, info::platform::name>::get(
@@ -245,52 +245,39 @@ static void filterAllowList(vector_class<RT::PiDevice> &PiDevices,
     for (const DevDescT &Desc : AllowList) {
       if (!Desc.PlatName.empty()) {
         if (!std::regex_match(PlatformName, std::regex(Desc.PlatName))) {
-          PlatNameState = MatchState::NOMATCH;
+          PlatNameState = FilterState::DENIED;
           continue;
-        } else {
-          PlatNameState = MatchState::MATCH;
         }
       }
 
       if (!Desc.PlatVer.empty()) {
         if (!std::regex_match(PlatformVer, std::regex(Desc.PlatVer))) {
-          PlatVerState = MatchState::NOMATCH;
+          PlatVerState = FilterState::DENIED;
           continue;
-        } else {
-          PlatVerState = MatchState::MATCH;
         }
       }
 
       if (!Desc.DevName.empty()) {
         if (!std::regex_match(DeviceName, std::regex(Desc.DevName))) {
-          DevNameState = MatchState::NOMATCH;
+          DevNameState = FilterState::DENIED;
           continue;
-        } else {
-          DevNameState = MatchState::MATCH;
         }
       }
 
       if (!Desc.DevDriverVer.empty()) {
         if (!std::regex_match(DeviceDriverVer, std::regex(Desc.DevDriverVer))) {
-          DevVerState = MatchState::NOMATCH;
+          DevVerState = FilterState::DENIED;
           continue;
-        } else {
-          DevVerState = MatchState::MATCH;
         }
       }
 
-      PiDevices[InsertIDx++] = Device;
+      if (DevNameState == FilterState::ALLOWED &&
+          DevVerState == FilterState::ALLOWED &&
+          PlatNameState == FilterState::ALLOWED &&
+          PlatVerState == FilterState::ALLOWED)
+        PiDevices[InsertIDx++] = Device;
       break;
     }
-  }
-  if (DevNameState == MatchState::MATCH && DevVerState == MatchState::NOMATCH) {
-    throw sycl::runtime_error("Requested SYCL device not found",
-                              PI_DEVICE_NOT_FOUND);
-  }
-  if (PlatNameState == MatchState::MATCH &&
-      PlatVerState == MatchState::NOMATCH) {
-    throw sycl::runtime_error("Requested SYCL platform not found",
-                              PI_DEVICE_NOT_FOUND);
   }
   PiDevices.resize(InsertIDx);
 }

--- a/sycl/test/on-device/config/select_device.cpp
+++ b/sycl/test/on-device/config/select_device.cpp
@@ -337,7 +337,8 @@ int main() {
           device dev = deviceQueue.get_device();
           const auto &plt = dev.get_platform();
         } catch (sycl::runtime_error &E) {
-          const std::string expectedMsg("Requested SYCL device not found");
+          const std::string expectedMsg(
+              "No device of requested type available");
           const std::string gotMessage(E.what());
           if (gotMessage.find(expectedMsg) != std::string::npos) {
             passed = true;
@@ -394,7 +395,8 @@ int main() {
           device dev = deviceQueue.get_device();
           const auto &plt = dev.get_platform();
         } catch (sycl::runtime_error &E) {
-          const std::string expectedMsg("Requested SYCL platform not found");
+          const std::string expectedMsg(
+              "No device of requested type available");
           const std::string gotMessage(E.what());
           if (gotMessage.find(expectedMsg) != std::string::npos) {
             passed = true;


### PR DESCRIPTION
This patch fixes the following situation:

1. User set

* SYCL_DEVICE_ALLOWLIST=DeviceName:{{DEV_NAME}},DriverVersion:{{X.Y.Z}}
* SYCL_DEVICE_TYPE=GPU
* SYCL_BE=PI_OPENCL  // no effect

2. Machine has

* OpenCL GPU device with name DEV_NAME and driver version
X.Y.Z
* Level Zero device with name DEV_NAME and driver version A.B.C

User expects that OpenCL GPU device will be selected but instead got
cl::sycl::runtime_error Requested SYCL device not found -1
(CL_DEVICE_NOT_FOUND).

Since GPU driver 20.43.18277, OpenCL GPU and Level Zero device names are
the same. So, DPC++ RT checks OpenCL GPU device first - everything is
ok, then checks Level Zero device, and throws the exception above.

This patch changes behavior - instead of raising exception in case of
device name == device name in SYCL_DEVICE_ALLOWLIST and driver version
!= driver version in SYCL_DEVICE_ALLOWLIST - now DPC++ raise an
exception
in case none devices were selected based on a value from
SYCL_DEVICE_ALLOWLIST.

Regression test: LIT test config/select_device.cpp with GPU driver
20.43.18277.