### PR TITLE
[SYCL][ESIMD] Refactor ESIMD kernel support in FE.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1162,6 +1162,19 @@ def SYCLRegisterNum : InheritableAttr {
   let PragmaAttributeSupport = 0;
 }
 
+// Used to mark kernel pointer parameters which correspond to the original
+// lambda's captured accessor. FE turns it to some metadata required by the
+// ESIMD Back-End.
+// Not supposed to be used directly in the source - SYCL device compiler FE
+// automatically adds it for ESIMD kernels.
+def SYCLSimdAccessorPtr : InheritableAttr {
+  let Spellings = [GNU<"esimd_acc_ptr">, Declspec<"esimd_acc_ptr">];
+  let Subjects = SubjectList<[ParmVar]>;
+  let LangOpts = [SYCLExplicitSIMD];
+  let Documentation = [SYCLSimdAccessorPtrDocs];
+  let PragmaAttributeSupport = 0;
+}
+
 def SYCLScope : Attr {
   // No spelling, as this attribute can't be created in the source code.
   let Spellings = [];

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1162,13 +1162,10 @@ def SYCLRegisterNum : InheritableAttr {
   let PragmaAttributeSupport = 0;
 }
 
-// Used to mark kernel pointer parameters which correspond to the original
-// lambda's captured accessor. FE turns it to some metadata required by the
-// ESIMD Back-End.
-// Not supposed to be used directly in the source - SYCL device compiler FE
-// automatically adds it for ESIMD kernels.
+// Used to mark ESIMD kernel pointer parameters originating from accessors.
 def SYCLSimdAccessorPtr : InheritableAttr {
-  let Spellings = [GNU<"esimd_acc_ptr">, Declspec<"esimd_acc_ptr">];
+  // No spelling, as this attribute can't be created in the source code.
+  let Spellings = [];
   let Subjects = SubjectList<[ParmVar]>;
   let LangOpts = [SYCLExplicitSIMD];
   let Documentation = [SYCLSimdAccessorPtrDocs];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -380,6 +380,18 @@ def SYCLRegisterNumDocs : Documentation {
   }];
 }
 
+def SYCLSimdAccessorPtrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Content = [{
+    The ``__attribute__((esimd_acc_ptr))`` attribute must be used to mark ESIMD
+    kernel pointer parameters which correspond to the original
+    lambda's captured accessors. FE turns the attribute to some metadata
+    required by the ESIMD Back-End.
+    Not supposed to be used directly in the source - SYCL device compiler FE
+    automatically adds it for ESIMD kernels.
+  }];
+}
+
 def C11NoReturnDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -332,7 +332,7 @@ public:
   ///  Signals that subsequent parameter descriptor additions will go to
   ///  the kernel with given name. Starts new kernel invocation descriptor.
   void startKernel(StringRef KernelName, QualType KernelNameType,
-                   StringRef KernelStableName, SourceLocation Loc);
+                   StringRef KernelStableName, SourceLocation Loc, bool IsESIMD);
 
   /// Adds a kernel parameter descriptor to current kernel invocation
   /// descriptor.
@@ -374,6 +374,9 @@ private:
     std::string StableName;
 
     SourceLocation KernelLocation;
+
+    /// Whether this kernel is an ESIMD one.
+    bool IsESIMD;
 
     /// Descriptor of kernel actual parameters.
     SmallVector<KernelParamDesc, 8> Params;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -376,7 +376,7 @@ private:
     SourceLocation KernelLocation;
 
     /// Whether this kernel is an ESIMD one.
-    bool IsESIMD;
+    bool IsESIMDKernel;
 
     /// Descriptor of kernel actual parameters.
     SmallVector<KernelParamDesc, 8> Params;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -332,7 +332,8 @@ public:
   ///  Signals that subsequent parameter descriptor additions will go to
   ///  the kernel with given name. Starts new kernel invocation descriptor.
   void startKernel(StringRef KernelName, QualType KernelNameType,
-                   StringRef KernelStableName, SourceLocation Loc, bool IsESIMD);
+                   StringRef KernelStableName, SourceLocation Loc,
+                   bool IsESIMD);
 
   /// Adds a kernel parameter descriptor to current kernel invocation
   /// descriptor.

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1575,9 +1575,10 @@ void CodeGenModule::GenOpenCLArgMetadata(llvm::Function *Fn,
                     SYCLBufferLocationAttr->getLocationID()))
               : llvm::ConstantAsMetadata::get(CGF->Builder.getInt32(-1)));
 
-      argESIMDAccPtrs.push_back(
-          llvm::ConstantAsMetadata::get(CGF->Builder.getInt1(
-              parm->getAttr<SYCLSimdAccessorPtrAttr>() != nullptr)));
+      if (FD->hasAttr<SYCLSimdAttr>())
+        argESIMDAccPtrs.push_back(
+            llvm::ConstantAsMetadata::get(CGF->Builder.getInt1(
+                parm->getAttr<SYCLSimdAccessorPtrAttr>() != nullptr)));
     }
 
   if (LangOpts.SYCLIsDevice && !LangOpts.SYCLExplicitSIMD)
@@ -1594,8 +1595,9 @@ void CodeGenModule::GenOpenCLArgMetadata(llvm::Function *Fn,
                     llvm::MDNode::get(VMContext, argBaseTypeNames));
     Fn->setMetadata("kernel_arg_type_qual",
                     llvm::MDNode::get(VMContext, argTypeQuals));
-    Fn->setMetadata("kernel_arg_accessor_ptr",
-                    llvm::MDNode::get(VMContext, argESIMDAccPtrs));
+    if (FD->hasAttr<SYCLSimdAttr>())
+      Fn->setMetadata("kernel_arg_accessor_ptr",
+                      llvm::MDNode::get(VMContext, argESIMDAccPtrs));
     if (getCodeGenOpts().EmitOpenCLArgMetadata)
       Fn->setMetadata("kernel_arg_name",
                       llvm::MDNode::get(VMContext, argNames));

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1594,7 +1594,7 @@ void CodeGenModule::GenOpenCLArgMetadata(llvm::Function *Fn,
                     llvm::MDNode::get(VMContext, argBaseTypeNames));
     Fn->setMetadata("kernel_arg_type_qual",
                     llvm::MDNode::get(VMContext, argTypeQuals));
-    if (FD->hasAttr<SYCLSimdAttr>())
+    if (FD && FD->hasAttr<SYCLSimdAttr>())
       Fn->setMetadata("kernel_arg_accessor_ptr",
                       llvm::MDNode::get(VMContext, argESIMDAccPtrs));
     if (getCodeGenOpts().EmitOpenCLArgMetadata)

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1576,9 +1576,8 @@ void CodeGenModule::GenOpenCLArgMetadata(llvm::Function *Fn,
               : llvm::ConstantAsMetadata::get(CGF->Builder.getInt32(-1)));
 
       if (FD->hasAttr<SYCLSimdAttr>())
-        argESIMDAccPtrs.push_back(
-            llvm::ConstantAsMetadata::get(CGF->Builder.getInt1(
-                parm->getAttr<SYCLSimdAccessorPtrAttr>() != nullptr)));
+        argESIMDAccPtrs.push_back(llvm::ConstantAsMetadata::get(
+            CGF->Builder.getInt1(parm->hasAttr<SYCLSimdAccessorPtrAttr>())));
     }
 
   if (LangOpts.SYCLIsDevice && !LangOpts.SYCLExplicitSIMD)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8209,6 +8209,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_SYCLRegisterNum:
     handleSYCLRegisterNumAttr(S, D, AL);
     break;
+  case ParsedAttr::AT_SYCLSimdAccessorPtr:
+    handleSimpleAttribute<SYCLSimdAccessorPtrAttr>(S, D, AL);
+    break;
   case ParsedAttr::AT_Format:
     handleFormatAttr(S, D, AL);
     break;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8209,9 +8209,6 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_SYCLRegisterNum:
     handleSYCLRegisterNumAttr(S, D, AL);
     break;
-  case ParsedAttr::AT_SYCLSimdAccessorPtr:
-    handleSimpleAttribute<SYCLSimdAccessorPtrAttr>(S, D, AL);
-    break;
   case ParsedAttr::AT_Format:
     handleFormatAttr(S, D, AL);
     break;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2041,8 +2041,7 @@ public:
 };
 
 static const CXXMethodDecl *getOperatorParens(const CXXRecordDecl *Rec) {
-  for (const auto *D : Rec->decls()) {
-    if (const CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(D))
+  for (const auto *MD : Rec->methods()) {
       if (MD->getOverloadedOperator() == OO_Call)
         return MD;
   }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1815,7 +1815,9 @@ public:
                               QualType FieldTy) final {
     const auto *RecordDecl = FieldTy->getAsCXXRecordDecl();
     assert(RecordDecl && "The accessor/sampler must be a RecordDecl");
-    const std::string MethodName = KernelDecl->hasAttr<SYCLSimdAttr>() ? InitESIMDMethodName : InitMethodName;
+    const std::string MethodName = KernelDecl->hasAttr<SYCLSimdAttr>()
+                                       ? InitESIMDMethodName
+                                       : InitMethodName;
     CXXMethodDecl *InitMethod = getMethodByName(RecordDecl, MethodName);
     assert(InitMethod && "The accessor/sampler must have the __init method");
 
@@ -1958,7 +1960,8 @@ class SyclKernelArgsSizeChecker : public SyclKernelFieldHandler {
   bool handleSpecialType(QualType FieldTy) {
     const CXXRecordDecl *RecordDecl = FieldTy->getAsCXXRecordDecl();
     assert(RecordDecl && "The accessor/sampler must be a RecordDecl");
-    const std::string &MethodName = IsSIMD ? InitESIMDMethodName : InitMethodName;
+    const std::string &MethodName =
+        IsSIMD ? InitESIMDMethodName : InitMethodName;
     CXXMethodDecl *InitMethod = getMethodByName(RecordDecl, MethodName);
     assert(InitMethod && "The accessor/sampler must have the __init method");
     for (const ParmVarDecl *Param : InitMethod->parameters())
@@ -2045,8 +2048,8 @@ public:
 
 static const CXXMethodDecl *getOperatorParens(const CXXRecordDecl *Rec) {
   for (const auto *MD : Rec->methods()) {
-      if (MD->getOverloadedOperator() == OO_Call)
-        return MD;
+    if (MD->getOverloadedOperator() == OO_Call)
+      return MD;
   }
   return nullptr;
 }
@@ -2371,7 +2374,7 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     return VD;
   }
 
-  const std::string& getInitMethodName() const {
+  const std::string &getInitMethodName() const {
     bool IsSIMDKernel = isESIMDKernelType(KernelObj);
     return IsSIMDKernel ? InitESIMDMethodName : InitMethodName;
   }


### PR DESCRIPTION
This patch adds necessary support in FE to get rid of buffer object wrapping into image1d_buffer -
workaround for ESIMD BE gaps.

- Add 'esimd_acc_ptr' parameter attribute to FE.
This attribute is to be used by the FE to mark ESIMD kernel arguments
originating from buffer accessors, which is then translated to BE-specific
metadata needed for correct code generation.
- Use 'esimd_acc_ptr' attribute to mark ESIMD kernel pointer
  arguments originating from accessors
- Use '__init_esimd' initializer in FE for ESIMD kernel accessors.
- Add 'isESIMD()' function to the integration header for the RT to
  be able to distinguish ESIMD kernels from normal ones for the
  purpose of proper accessor arg setting.

TODO add tests for the new attrs

The other two PRs needed for this one to work are:
- https://github.com/intel/llvm/pull/2746
- https://github.com/intel/llvm/pull/2748