### PR TITLE
[SYCL][ESIMD] LowerESIMD: add 'buffer_t' MD for accessor kernel args.

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -1148,11 +1148,15 @@ void SYCLLowerESIMDLegacyPass::generateKernelMetadata(Module &M) {
 
         if (Arg.getType()->isPointerTy()) {
           const auto *IsAccMD =
-              cast<ConstantAsMetadata>(KernelArgAccPtrs->getOperand(Idx));
+              KernelArgAccPtrs
+                  ? cast<ConstantAsMetadata>(KernelArgAccPtrs->getOperand(Idx))
+                  : nullptr;
           unsigned IsAcc =
-              static_cast<unsigned>(cast<ConstantInt>(IsAccMD->getValue())
-                                        ->getValue()
-                                        .getZExtValue());
+              IsAccMD
+                  ? static_cast<unsigned>(cast<ConstantInt>(IsAccMD->getValue())
+                                              ->getValue()
+                                              .getZExtValue())
+                  : 0;
           if (IsAcc) {
             ArgDesc = "buffer_t";
             Kind = AK_SURFACE;


### PR DESCRIPTION
LowerESIMD will now use the 'kernel_arg_accessor_ptr' to detect pointers originating from accessors (rather then svm pointers) and mark them appropriately for the BE.

The other two PRs needed for this one to work are:
- https://github.com/intel/llvm/pull/2746
- https://github.com/intel/llvm/pull/2747

The patches also require at least this Gen driver:
https://github.com/intel/compute-runtime/releases/tag/20.43.18277

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>