### PR TITLE
[SYCL]Improve diagnostic for invalid kernel name

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11071,7 +11071,7 @@ def note_invalid_type_in_sycl_kernel : Note<
   "%select{%1 should be globally-visible"
   "|unscoped enum %1 requires fixed underlying type"
   "|type %1 cannot be in the \"std\" namespace"
-  "|Unnamed type used in a SYCL kernel name"
+  "|unnamed type used in a SYCL kernel name"
   "}0">;
 
 def err_sycl_kernel_not_function_object

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11071,7 +11071,7 @@ def note_invalid_type_in_sycl_kernel : Note<
   "%select{%1 should be globally-visible"
   "|unscoped enum %1 requires fixed underlying type"
   "|type %1 cannot be in the \"std\" namespace"
-  "|kernel name is missing"
+  "|Unnamed type used in a SYCL kernel name"
   "}0">;
 
 def err_sycl_kernel_not_function_object

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2921,7 +2921,7 @@ public:
               << KernelNameType;
           S.Diag(KernelInvocationFuncLoc,
                  diag::note_invalid_type_in_sycl_kernel)
-              << /* kernel name is missing */ 3;
+              << /* Unnamed type used in a SYCL kernel name */ 3;
           IsInvalid = true;
           return;
         }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2921,7 +2921,7 @@ public:
               << KernelNameType;
           S.Diag(KernelInvocationFuncLoc,
                  diag::note_invalid_type_in_sycl_kernel)
-              << /* Unnamed type used in a SYCL kernel name */ 3;
+              << /* unnamed type used in a SYCL kernel name */ 3;
           IsInvalid = true;
           return;
         }

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -118,7 +118,7 @@ int main() {
   cl::sycl::queue q;
 #ifndef __SYCL_UNNAMED_LAMBDA__
   // expected-error-re@Inputs/sycl.hpp:220 {{'(lambda at {{.*}}unnamed-kernel.cpp{{.*}}' is an invalid kernel name type}}
-  // expected-note@Inputs/sycl.hpp:220 {{kernel name is missing}}
+  // expected-note@Inputs/sycl.hpp:220 {{Unnamed type used in a SYCL kernel name}}
   // expected-note@+2{{in instantiation of function template specialization}}
 #endif
   q.submit([&](cl::sycl::handler &h) { h.single_task([] {}); });

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -118,7 +118,7 @@ int main() {
   cl::sycl::queue q;
 #ifndef __SYCL_UNNAMED_LAMBDA__
   // expected-error-re@Inputs/sycl.hpp:220 {{'(lambda at {{.*}}unnamed-kernel.cpp{{.*}}' is an invalid kernel name type}}
-  // expected-note@Inputs/sycl.hpp:220 {{Unnamed type used in a SYCL kernel name}}
+  // expected-note@Inputs/sycl.hpp:220 {{unnamed type used in a SYCL kernel name}}
   // expected-note@+2{{in instantiation of function template specialization}}
 #endif
   q.submit([&](cl::sycl::handler &h) { h.single_task([] {}); });


### PR DESCRIPTION
This patch updates the error message from `kernel name is missing` to `Unnamed type used in a SYCL kernel name` , when an unnamed lambda is set as the kernel name.