### PR TITLE
[NFC][SYCL] Update -help output for -fsycl-help

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1934,7 +1934,9 @@ def fsycl_link : Flag<["-"], "fsycl-link">, Alias<fsycl_link_EQ>,
 def fsycl_unnamed_lambda : Flag<["-"], "fsycl-unnamed-lambda">,
   Flags<[CC1Option, CoreOption]>, HelpText<"Allow unnamed SYCL lambda kernels">;
 def fsycl_help_EQ : Joined<["-"], "fsycl-help=">,
-  Flags<[DriverOption, CoreOption]>, HelpText<"Emit help information from the related offline compilation tool">, Values<"all,fpga,gen,x86_64">;
+  Flags<[DriverOption, CoreOption]>, HelpText<"Emit help information from the "
+  "related offline compilation tool. Valid values: all, fpga, gen, x86_64.">,
+  Values<"all,fpga,gen,x86_64">;
 def fsycl_help : Flag<["-"], "fsycl-help">, Alias<fsycl_help_EQ>,
   Flags<[DriverOption, CoreOption]>, AliasArgs<["all"]>, HelpText<"Emit help information "
   "from all of the offline compilation tools">;


### PR DESCRIPTION
-fsycl-help allows for arguments that can be used to specify what
target you want to display.  Update the help description to include
these values.