### PR TITLE
[SYCL] Add code examples for all SYCL FPGA loop attributes

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2380,6 +2380,17 @@ is unspecified and is therefore considered infinite.
 In case of ivdep being applied both w/o an array variable and for a particular
 array, the array variables that were not designated a separate ivdep will receive
 the no-array ivdep's safelen, with the correspondent treatment by the backend.
+
+.. code-block:: c++
+
+  void foo() {
+    int a[10];
+    [[intel::ivdep]] for (int i = 0; i != 10; ++i) { }
+    [[intel::ivdep(2)]] for (int i = 0; i != 10; ++i) { }
+    [[intel::ivdep(a)]] for (int i = 0; i != 10; ++i) { }
+    [[intel::ivdep(a, 2)]] for (int i = 0; i != 10; ++i) { }
+  }
+
   }];
 }
 
@@ -2390,6 +2401,14 @@ def SYCLIntelFPGAIIAttrDocs : Documentation {
 This attribute applies to a loop. Indicates that the loop should be pipelined
 with an initiation interval of N. N must be a positive integer. Cannot be
 applied multiple times to the same loop.
+
+.. code-block:: c++
+
+  void foo() {
+    int var = 0;
+    [[intel::ii(4)]] for (int i = 0; i < 10; ++i) var++;
+  }
+
   }];
 }
 
@@ -2401,6 +2420,14 @@ This attribute applies to a loop. Indicates that the loop should allow no more
 than N threads or iterations to execute it simultaneously. N must be a non
 negative integer. '0' indicates the max_concurrency case to be unbounded. Cannot
 be applied multiple times to the same loop.
+
+.. code-block:: c++
+
+  void foo() {
+    int a[10];
+    [[intel::max_concurrency(2)]] for (int i = 0; i != 10; ++i) a[i] = 0;
+  }
+
   }];
 }
 
@@ -2412,6 +2439,14 @@ This attribute applies to a loop. Indicates that the loop nest should be
 coalesced into a single loop without affecting functionality. Parameter N is
 optional. If specified, it shall be a positive integer, and indicates how many
 of the nested loop levels should be coalesced.
+
+.. code-block:: c++
+
+  void foo() {
+    int a[10];
+    [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i) a[i] = 0;
+  }
+
   }];
 }
 
@@ -2423,6 +2458,14 @@ This attribute applies to a loop. Disables pipelining of the loop data path,
 causing the loop to be executed serially. Cannot be used on the same loop in
 conjunction with max_interleaving, speculated_iterations, max_concurrency, ii
 or ivdep.
+
+.. code-block:: c++
+
+  void foo() {
+    int var = 0;
+    [[intel::disable_loop_pipelining] for (int i = 0; i < 10; ++i) var++;
+  }
+
   }];
 }
 
@@ -2436,6 +2479,14 @@ mean that this attribute can only be applied to inner loops in user code - outer
 loops in user code may still be contained in an implicit loop due to NDRange).
 Parameter N is mandatory, and shall be non-negative integer. Cannot be
 used on the same loop in conjunction with disable_loop_pipelining.
+
+.. code-block:: c++
+
+  void foo() {
+    int a[10];
+    [[intel::max_interleaving(4)]] for (int i = 0; i != 10; ++i) a[i] = 0;
+  }
+
   }];
 }
 
@@ -2448,6 +2499,15 @@ iterations that will be in flight for a loop invocation (i.e. the exit
 condition for these iterations will not have been evaluated yet).
 Parameter N is mandatory, and may either be 0, or a positive integer. Cannot be
 used on the same loop in conjunction with disable_loop_pipelining.
+
+.. code-block:: c++
+
+  void foo() {
+    int var = 0;
+    [[intel::speculated_iterations(4)]]
+    for (int i = 0; i < 10; ++i) var++;
+  }
+
   }];
 }
 
@@ -2457,6 +2517,13 @@ def SYCLIntelFPGANofusionAttrDocs : Documentation {
   let Content = [{
 This attribute applies to a loop. Indicates that the annotated
 loop should not be fused with any adjacent loop.
+
+.. code-block:: c++
+
+  void foo() {
+    [[intel::nofusion]] for (int i=0; i<10;++i) { }
+  }
+
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2391,6 +2391,11 @@ the no-array ivdep's safelen, with the correspondent treatment by the backend.
     [[intel::ivdep(a, 2)]] for (int i = 0; i != 10; ++i) { }
   }
 
+  template<int N>
+  void bar() {
+    [[intel::ivdep(N)]] for(;;) { }
+  }
+
   }];
 }
 
@@ -2407,6 +2412,11 @@ applied multiple times to the same loop.
   void foo() {
     int var = 0;
     [[intel::ii(4)]] for (int i = 0; i < 10; ++i) var++;
+  }
+
+  template<int N>
+  void bar() {
+    [[intel::ii(N)]] for(;;) { }
   }
 
   }];
@@ -2428,6 +2438,11 @@ be applied multiple times to the same loop.
     [[intel::max_concurrency(2)]] for (int i = 0; i != 10; ++i) a[i] = 0;
   }
 
+  template<int N>
+  void bar() {
+    [[intel::max_concurrency(N)]] for(;;) { }
+  }
+
   }];
 }
 
@@ -2445,6 +2460,11 @@ of the nested loop levels should be coalesced.
   void foo() {
     int a[10];
     [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i) a[i] = 0;
+  }
+
+  template<int N>
+  void bar() {
+    [[intel::loop_coalesce(N)]] for(;;) { }
   }
 
   }];
@@ -2487,6 +2507,11 @@ used on the same loop in conjunction with disable_loop_pipelining.
     [[intel::max_interleaving(4)]] for (int i = 0; i != 10; ++i) a[i] = 0;
   }
 
+  template<int N>
+  void bar() {
+    [[intel::max_interleaving(N)]] for(;;) { }
+  }
+
   }];
 }
 
@@ -2505,6 +2530,11 @@ used on the same loop in conjunction with disable_loop_pipelining.
   void foo() {
     int var = 0;
     [[intel::speculated_iterations(4)]] for (int i = 0; i < 10; ++i) var++;
+  }
+
+  template<int N>
+  void bar() {
+    [[intel::speculated_iterations(N)]] for(;;) { }
   }
 
   }];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2504,8 +2504,7 @@ used on the same loop in conjunction with disable_loop_pipelining.
 
   void foo() {
     int var = 0;
-    [[intel::speculated_iterations(4)]]
-    for (int i = 0; i < 10; ++i) var++;
+    [[intel::speculated_iterations(4)]] for (int i = 0; i < 10; ++i) var++;
   }
 
   }];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2463,8 +2463,23 @@ of the nested loop levels should be coalesced.
   }
 
   template<int N>
-  void bar() {
-    [[intel::loop_coalesce(N)]] for(;;) { }
+  void loop_coalesce() {
+    int j = 0, n = 48;
+    [[intel::loop_coalesce(N)]]
+    while (j < n) {
+      if (j % 4) {
+        ++j;
+        continue;
+      }
+    }
+    j = 0;
+    [[intel::loop_coalesce]]
+    while (j < n) {
+      if (j % 6) {
+        ++j;
+        continue;
+      }
+    }
   }
 
   }];
@@ -2551,6 +2566,14 @@ loop should not be fused with any adjacent loop.
 
   void foo() {
     [[intel::nofusion]] for (int i=0; i<10;++i) { }
+  }
+
+  void nofusion() {
+    int a1[10];
+    for (int i = 0; i < 10; ++i) {
+    [[intel::nofusion]] for (int j = 0; j < 10; ++j) {
+      a1[i] += a1[j];
+    }
   }
 
   }];


### PR DESCRIPTION
This is a follow-up in https://github.com/intel/llvm/pull/2715#discussion_r516637843

This patch improves the documentation by adding code examples for all FPGA loop 
attributes that we did not have before.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>