### PR TITLE
[SYCL] Remove idle assert from releaseCG function

### DIFF
--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -509,8 +509,6 @@ public:
   // memory in DispatchNativeKernel.
   // TODO remove when native kernel support is terminated.
   void releaseCG() {
-    assert(MCommandGroup->getType() == CG::RUN_ON_HOST_INTEL &&
-           "Only 'native kernel' is allowed to release command group");
     MCommandGroup.release();
   }
 


### PR DESCRIPTION
The removed assert contains access to invalid memory, which is read-after-free. The free'd memory is native kernel CG. We don't control execution of this CG, hence we shouldn't assume on memory allocation status here.