### PR TITLE
[SYCL][NFC] Improve type traits' usage in headers & runtime

### DIFF
--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_types.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_types.hpp
@@ -16,7 +16,6 @@
 #include <CL/sycl/detail/stl_type_traits.hpp> // to define C++14,17 extensions
 #include <CL/sycl/half_type.hpp>
 #include <cstdint>
-#include <type_traits>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -208,8 +207,8 @@ template <typename T1, typename T2> struct computation_type {
 template <typename U> constexpr bool is_type() { return false; }
 
 template <typename U, typename T, typename... Ts> constexpr bool is_type() {
-  using UU = typename std::remove_const<U>::type;
-  using TT = typename std::remove_const<T>::type;
+  using UU = typename detail::remove_const_t<U>;
+  using TT = typename detail::remove_const_t<T>;
   return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
 }
 
@@ -228,10 +227,10 @@ struct bitcast_helper {
 // Change the element type of a simd vector.
 template <typename ToEltTy, typename FromEltTy, int FromN,
           typename = csd::enable_if_t<is_vectorizable<ToEltTy>::value>>
-ESIMD_INLINE typename std::conditional<
+ESIMD_INLINE typename detail::conditional_t<
     std::is_same<FromEltTy, ToEltTy>::value, vector_type_t<FromEltTy, FromN>,
     vector_type_t<ToEltTy,
-                  bitcast_helper<ToEltTy, FromEltTy, FromN>::nToElems()>>::type
+                  bitcast_helper<ToEltTy, FromEltTy, FromN>::nToElems()>>
 bitcast(vector_type_t<FromEltTy, FromN> Val) {
   // Noop.
   if constexpr (std::is_same<FromEltTy, ToEltTy>::value)

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_util.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_util.hpp
@@ -100,10 +100,10 @@ struct is_esimd_scalar
 template <typename T>
 struct is_dword_type
     : std::integral_constant<
-          bool, std::is_same<int, typename std::remove_const<T>::type>::value ||
-                    std::is_same<unsigned int,
-                                 typename std::remove_const<T>::type>::value> {
-};
+          bool,
+          std::is_same<int, typename sycl::detail::remove_const_t<T>>::value ||
+              std::is_same<unsigned int,
+                           typename sycl::detail::remove_const_t<T>>::value> {};
 
 template <typename T, int N>
 struct is_dword_type<sycl::INTEL::gpu::vector_type<T, N>> {
@@ -119,9 +119,10 @@ template <typename T>
 struct is_word_type
     : std::integral_constant<
           bool,
-          std::is_same<short, typename std::remove_const<T>::type>::value ||
+          std::is_same<short,
+                       typename sycl::detail::remove_const_t<T>>::value ||
               std::is_same<unsigned short,
-                           typename std::remove_const<T>::type>::value> {};
+                           typename sycl::detail::remove_const_t<T>>::value> {};
 
 template <typename T, int N>
 struct is_word_type<sycl::INTEL::gpu::vector_type<T, N>> {
@@ -136,9 +137,9 @@ template <typename T>
 struct is_byte_type
     : std::integral_constant<
           bool,
-          std::is_same<char, typename std::remove_const<T>::type>::value ||
+          std::is_same<char, typename sycl::detail::remove_const_t<T>>::value ||
               std::is_same<unsigned char,
-                           typename std::remove_const<T>::type>::value> {};
+                           typename sycl::detail::remove_const_t<T>>::value> {};
 
 template <typename T, int N>
 struct is_byte_type<sycl::INTEL::gpu::vector_type<T, N>> {
@@ -152,31 +153,36 @@ template <typename T, int N> struct is_byte_type<sycl::INTEL::gpu::simd<T, N>> {
 template <typename T>
 struct is_fp_type
     : std::integral_constant<
-          bool,
-          std::is_same<float, typename std::remove_const<T>::type>::value> {};
+          bool, std::is_same<float,
+                             typename sycl::detail::remove_const_t<T>>::value> {
+};
 
 template <typename T>
 struct is_df_type
     : std::integral_constant<
-          bool,
-          std::is_same<double, typename std::remove_const<T>::type>::value> {};
+          bool, std::is_same<double,
+                             typename sycl::detail::remove_const_t<T>>::value> {
+};
 
 template <typename T>
 struct is_fp_or_dword_type
     : std::integral_constant<
           bool,
-          std::is_same<float, typename std::remove_const<T>::type>::value ||
-              std::is_same<int, typename std::remove_const<T>::type>::value ||
+          std::is_same<float,
+                       typename sycl::detail::remove_const_t<T>>::value ||
+              std::is_same<int,
+                           typename sycl::detail::remove_const_t<T>>::value ||
               std::is_same<unsigned int,
-                           typename std::remove_const<T>::type>::value> {};
+                           typename sycl::detail::remove_const_t<T>>::value> {};
 
 template <typename T>
 struct is_qword_type
     : std::integral_constant<
           bool,
-          std::is_same<long long, typename std::remove_const<T>::type>::value ||
+          std::is_same<long long,
+                       typename sycl::detail::remove_const_t<T>>::value ||
               std::is_same<unsigned long long,
-                           typename std::remove_const<T>::type>::value> {};
+                           typename sycl::detail::remove_const_t<T>>::value> {};
 
 template <typename T, int N>
 struct is_qword_type<sycl::INTEL::gpu::vector_type<T, N>> {

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd.hpp
@@ -328,8 +328,9 @@ public:
   //
   // @return 1 if any element is set, 0 otherwise
 
-  template <typename T1 = element_type, typename T2 = Ty,
-            typename = std::enable_if_t<std::is_integral<T1>::value, T2>>
+  template <
+      typename T1 = element_type, typename T2 = Ty,
+      typename = sycl::detail::enable_if_t<std::is_integral<T1>::value, T2>>
   uint16_t any() {
     return __esimd_any<Ty, N>(data());
   }
@@ -338,8 +339,9 @@ public:
   //
   // @return 1 if all elements are set, 0 otherwise
 
-  template <typename T1 = element_type, typename T2 = Ty,
-            typename = std::enable_if_t<std::is_integral<T1>::value, T2>>
+  template <
+      typename T1 = element_type, typename T2 = Ty,
+      typename = sycl::detail::enable_if_t<std::is_integral<T1>::value, T2>>
   uint16_t all() {
     return __esimd_all<Ty, N>(data());
   }

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_math.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_math.hpp
@@ -58,13 +58,12 @@ __esimd_abs_common_internal(simd<T1, SZ> src0, int flag = GENX_NOSAT) {
 }
 
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T0>::value &&
-                                detail::is_esimd_scalar<T1>::value,
-                            typename std::remove_const<T0>::type>::type
-    __esimd_abs_common_internal(T1 src0, int flag = GENX_NOSAT) {
-  typedef typename std::remove_const<T0>::type TT0;
-  typedef typename std::remove_const<T1>::type TT1;
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value,
+    typename sycl::detail::remove_const_t<T0>>
+__esimd_abs_common_internal(T1 src0, int flag = GENX_NOSAT) {
+  typedef typename sycl::detail::remove_const_t<T0> TT0;
+  typedef typename sycl::detail::remove_const_t<T1> TT1;
 
   simd<TT1, 1> Src0 = src0;
   simd<TT0, 1> Result = __esimd_abs_common_internal<TT0>(Src0, flag);
@@ -73,21 +72,21 @@ ESIMD_NODEBUG ESIMD_INLINE
 } // namespace detail
 
 template <typename T0, typename T1, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
-    !std::is_same<typename std::remove_const<T0>::type,
-                  typename std::remove_const<T1>::type>::value,
-    simd<T0, SZ>>::type
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    !std::is_same<typename sycl::detail::remove_const_t<T0>,
+                  typename sycl::detail::remove_const_t<T1>>::value,
+    simd<T0, SZ>>
 esimd_abs(simd<T1, SZ> src0, int flag = GENX_NOSAT) {
   return detail::__esimd_abs_common_internal<T0, T1, SZ>(src0, flag);
 }
 
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
-    !std::is_same<typename std::remove_const<T0>::type,
-                  typename std::remove_const<T1>::type>::value &&
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    !std::is_same<typename sycl::detail::remove_const_t<T0>,
+                  typename sycl::detail::remove_const_t<T1>>::value &&
         detail::is_esimd_scalar<T0>::value &&
         detail::is_esimd_scalar<T1>::value,
-    typename std::remove_const<T0>::type>::type
+    typename sycl::detail::remove_const_t<T0>>
 esimd_abs(T1 src0, int flag = GENX_NOSAT) {
   return detail::__esimd_abs_common_internal<T0, T1>(src0, flag);
 }
@@ -99,20 +98,20 @@ ESIMD_NODEBUG ESIMD_INLINE simd<T1, SZ> esimd_abs(simd<T1, SZ> src0,
 }
 
 template <typename T1>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T1>::value,
-                            typename std::remove_const<T1>::type>::type
-    esimd_abs(T1 src0, int flag = GENX_NOSAT) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_esimd_scalar<T1>::value,
+    typename sycl::detail::remove_const_t<T1>>
+esimd_abs(T1 src0, int flag = GENX_NOSAT) {
   return detail::__esimd_abs_common_internal<T1, T1>(src0, flag);
 }
 
 // esimd_shl
 template <typename T0, typename T1, int SZ, typename U>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T0>::value &&
-                                std::is_integral<T1>::value &&
-                                std::is_integral<U>::value,
-                            simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
+                                           std::is_integral<T1>::value &&
+                                           std::is_integral<U>::value,
+                                       simd<T0, SZ>>
     esimd_shl(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
   typedef typename computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -146,11 +145,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename std::remove_const<T0>::type>::type
+    typename sycl::detail::remove_const_t<T0>>
 esimd_shl(T1 src0, T2 src1, int flag = GENX_NOSAT) {
   typedef typename computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -162,10 +161,10 @@ esimd_shl(T1 src0, T2 src1, int flag = GENX_NOSAT) {
 // esimd_shr
 template <typename T0, typename T1, int SZ, typename U>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T0>::value &&
-                                std::is_integral<T1>::value &&
-                                std::is_integral<U>::value,
-                            simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
+                                           std::is_integral<T1>::value &&
+                                           std::is_integral<U>::value,
+                                       simd<T0, SZ>>
     esimd_shr(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
   typedef typename computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -180,11 +179,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename std::remove_const<T0>::type>::type
+    typename sycl::detail::remove_const_t<T0>>
 esimd_shr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
   typedef typename computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -195,20 +194,18 @@ esimd_shr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
 
 // esimd_rol
 template <typename T0, typename T1, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T0>::value &&
-                                std::is_integral<T1>::value,
-                            simd<T0, SZ>>::type
-    esimd_rol(simd<T1, SZ> src0, simd<T1, SZ> src1) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    std::is_integral<T0>::value && std::is_integral<T1>::value, simd<T0, SZ>>
+esimd_rol(simd<T1, SZ> src0, simd<T1, SZ> src1) {
   return __esimd_rol<T0, T1, SZ>(src0, src1);
 }
 
 template <typename T0, typename T1, int SZ, typename U>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T0>::value &&
-                                std::is_integral<T1>::value &&
-                                std::is_integral<U>::value,
-                            simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
+                                           std::is_integral<T1>::value &&
+                                           std::is_integral<U>::value,
+                                       simd<T0, SZ>>
     esimd_rol(simd<T1, SZ> src0, U src1) {
   typedef typename computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -217,11 +214,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename std::remove_const<T0>::type>::type
+    typename sycl::detail::remove_const_t<T0>>
 esimd_rol(T1 src0, T2 src1) {
   typedef typename computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -232,20 +229,18 @@ esimd_rol(T1 src0, T2 src1) {
 
 // esimd_ror
 template <typename T0, typename T1, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T0>::value &&
-                                std::is_integral<T1>::value,
-                            simd<T0, SZ>>::type
-    esimd_ror(simd<T1, SZ> src0, simd<T1, SZ> src1) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    std::is_integral<T0>::value && std::is_integral<T1>::value, simd<T0, SZ>>
+esimd_ror(simd<T1, SZ> src0, simd<T1, SZ> src1) {
   return __esimd_ror<T0, T1, SZ>(src0, src1);
 }
 
 template <typename T0, typename T1, int SZ, typename U>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T0>::value &&
-                                std::is_integral<T1>::value &&
-                                std::is_integral<U>::value,
-                            simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
+                                           std::is_integral<T1>::value &&
+                                           std::is_integral<U>::value,
+                                       simd<T0, SZ>>
     esimd_ror(simd<T1, SZ> src0, U src1) {
   typedef typename computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -254,11 +249,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename std::remove_const<T0>::type>::type
+    typename sycl::detail::remove_const_t<T0>>
 esimd_ror(T1 src0, T2 src1) {
   typedef typename computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -270,10 +265,10 @@ esimd_ror(T1 src0, T2 src1) {
 // esimd_lsr
 template <typename T0, typename T1, int SZ, typename U>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T0>::value &&
-                                std::is_integral<T1>::value &&
-                                std::is_integral<U>::value,
-                            simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
+                                           std::is_integral<T1>::value &&
+                                           std::is_integral<U>::value,
+                                       simd<T0, SZ>>
     esimd_lsr(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
   typedef typename computation_type<T1, T1>::type IntermedTy;
   typedef typename std::make_unsigned<IntermedTy>::type ComputationTy;
@@ -287,11 +282,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename std::remove_const<T0>::type>::type
+    typename sycl::detail::remove_const_t<T0>>
 esimd_lsr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
   typedef typename computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -301,11 +296,11 @@ esimd_lsr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
 }
 
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T1>::value && detail::is_esimd_vector<T2>::value &&
         std::is_integral<T0>::value && std::is_integral<T1>::value &&
         std::is_integral<T2>::value,
-    decltype(esimd_lsr<T0>(T2(), T1()))>::type
+    decltype(esimd_lsr<T0>(T2(), T1()))>
 esimd_lsr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
   return esimd_lsr<T0>(src1, src0, flag);
 }
@@ -313,10 +308,10 @@ esimd_lsr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
 // esimd_asr
 template <typename T0, typename T1, int SZ, typename U>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T0>::value &&
-                                std::is_integral<T1>::value &&
-                                std::is_integral<U>::value,
-                            simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
+                                           std::is_integral<T1>::value &&
+                                           std::is_integral<U>::value,
+                                       simd<T0, SZ>>
     esimd_asr(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
   typedef typename computation_type<T1, T1>::type IntermedTy;
   typedef typename std::make_signed<IntermedTy>::type ComputationTy;
@@ -330,11 +325,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename std::remove_const<T0>::type>::type
+    typename sycl::detail::remove_const_t<T0>>
 esimd_asr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
   typedef typename computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -344,11 +339,11 @@ esimd_asr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
 }
 
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T1>::value && detail::is_esimd_vector<T2>::value &&
         std::is_integral<T0>::value && std::is_integral<T1>::value &&
         std::is_integral<T2>::value,
-    decltype(esimd_asr<T0>(T2(), T1()))>::type
+    decltype(esimd_asr<T0>(T2(), T1()))>
 esimd_asr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
   return esimd_asr<T0>(src1, src0, flag);
 }
@@ -358,10 +353,10 @@ esimd_asr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
 // use mulh instruction for high half
 template <typename T0, typename T1, typename U, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_dword_type<T0>::value &&
-                                detail::is_dword_type<T1>::value &&
-                                detail::is_dword_type<U>::value,
-                            simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<detail::is_dword_type<T0>::value &&
+                                           detail::is_dword_type<T1>::value &&
+                                           detail::is_dword_type<U>::value,
+                                       simd<T0, SZ>>
     esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
   typedef typename computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -378,12 +373,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 // We need to special case SZ==1 to avoid "error: when select size is 1, the
 // stride must also be 1" on the selects.
 template <typename T0, typename T1, typename U, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_dword_type<T0>::value &&
-                                detail::is_dword_type<T1>::value &&
-                                detail::is_dword_type<U>::value && SZ == 1,
-                            simd<T0, SZ>>::type
-    esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_dword_type<T0>::value && detail::is_dword_type<T1>::value &&
+        detail::is_dword_type<U>::value && SZ == 1,
+    simd<T0, SZ>>
+esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
   typedef
       typename computation_type<decltype(rmd), long long>::type ComputationTy;
   ComputationTy Product = convert<long long>(src0);
@@ -393,12 +387,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename U, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_dword_type<T0>::value &&
-                                detail::is_dword_type<T1>::value &&
-                                detail::is_dword_type<U>::value && SZ != 1,
-                            simd<T0, SZ>>::type
-    esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_dword_type<T0>::value && detail::is_dword_type<T1>::value &&
+        detail::is_dword_type<U>::value && SZ != 1,
+    simd<T0, SZ>>
+esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
   typedef
       typename computation_type<decltype(rmd), long long>::type ComputationTy;
   ComputationTy Product = convert<long long>(src0);
@@ -412,18 +405,18 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T0, typename T1, typename U, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<U>::value,
-                            simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<U>::value,
+                                       simd<T0, SZ>>
     esimd_imul(simd<T0, SZ> &rmd, U src0, simd<T1, SZ> src1) {
   return esimd_imul(rmd, src1, src0);
 }
 
 template <typename T0, typename T, typename U>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T>::value &&
-                                detail::is_esimd_scalar<U>::value &&
-                                detail::is_esimd_scalar<T0>::value,
-                            T0>::type
+    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value &&
+                                           detail::is_esimd_scalar<U>::value &&
+                                           detail::is_esimd_scalar<T0>::value,
+                                       T0>
     esimd_imul(simd<T0, 1> &rmd, T src0, U src1) {
   simd<T, 1> src_0 = src0;
   simd<U, 1> src_1 = src1;
@@ -433,42 +426,42 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 // esimd_quot
 template <typename T, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
-    std::is_integral<T>::value && std::is_integral<U>::value, simd<T, SZ>>::type
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    std::is_integral<T>::value && std::is_integral<U>::value, simd<T, SZ>>
 esimd_quot(simd<T, SZ> src0, U src1) {
   return src0 / src1;
 }
 
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         std::is_integral<T0>::value && std::is_integral<T1>::value,
-    typename std::remove_const<T0>::type>::type
+    typename sycl::detail::remove_const_t<T0>>
 esimd_quot(T0 src0, T1 src1) {
   return src0 / src1;
 }
 
 // esimd_mod
 template <typename T, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
-    std::is_integral<T>::value && std::is_integral<U>::value, simd<T, SZ>>::type
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    std::is_integral<T>::value && std::is_integral<U>::value, simd<T, SZ>>
 esimd_mod(simd<T, SZ> src0, U src1) {
   return src0 % src1;
 }
 
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         std::is_integral<T0>::value && std::is_integral<T1>::value,
-    typename std::remove_const<T0>::type>::type
+    typename sycl::detail::remove_const_t<T0>>
 esimd_mod(T0 src0, T1 src1) {
   return src0 % src1;
 }
 
 // esimd_div, compute quotient and remainder of division.
 template <typename T, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
-    std::is_integral<T>::value && std::is_integral<U>::value, simd<T, SZ>>::type
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    std::is_integral<T>::value && std::is_integral<U>::value, simd<T, SZ>>
 esimd_div(simd<T, SZ> &remainder, simd<T, SZ> src0, U src1) {
   remainder = src0 % src1;
   return src0 / src1;
@@ -476,23 +469,22 @@ esimd_div(simd<T, SZ> &remainder, simd<T, SZ> src0, U src1) {
 
 template <typename T, int SZ, typename U>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T>::value &&
-                                std::is_integral<U>::value &&
-                                detail::is_esimd_scalar<U>::value,
-                            simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T>::value &&
+                                           std::is_integral<U>::value &&
+                                           detail::is_esimd_scalar<U>::value,
+                                       simd<T, SZ>>
     esimd_div(simd<T, SZ> &remainder, U src0, simd<T, SZ> src1) {
   remainder = src0 % src1;
   return src0 / src1;
 }
 
 template <typename RT, typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<RT>::value &&
-                                detail::is_esimd_scalar<T0>::value &&
-                                detail::is_esimd_scalar<T1>::value,
-                            typename std::remove_const<RT>::type>::type
-    esimd_div(simd<typename std::remove_const<RT>::type, 1> &remainder, T0 src0,
-              T1 src1) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_esimd_scalar<RT>::value && detail::is_esimd_scalar<T0>::value &&
+        detail::is_esimd_scalar<T1>::value,
+    typename sycl::detail::remove_const_t<RT>>
+esimd_div(simd<typename std::remove_const<RT>, 1> &remainder, T0 src0,
+          T1 src1) {
   remainder[0] = src0 % src1;
   return src0 / src1;
 }
@@ -522,8 +514,8 @@ esimd_max(simd<T, SZ> src0, simd<T, SZ> src1, int flag = GENX_NOSAT) {
 
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T>::value,
-                            simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value,
+                                       simd<T, SZ>>
     esimd_max(simd<T, SZ> src0, T src1, int flag = GENX_NOSAT) {
   simd<T, SZ> Src1 = src1;
   simd<T, SZ> Result = esimd_max<T>(src0, Src1, flag);
@@ -532,8 +524,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T>::value,
-                            simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value,
+                                       simd<T, SZ>>
     esimd_max(T src0, simd<T, SZ> src1, int flag = GENX_NOSAT) {
   simd<T, SZ> Src0 = src0;
   simd<T, SZ> Result = esimd_max<T>(Src0, src1, flag);
@@ -542,7 +534,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T>::value, T>::type
+    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value, T>
     esimd_max(T src0, T src1, int flag = GENX_NOSAT) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Src1 = src1;
@@ -569,8 +561,8 @@ esimd_min(simd<T, SZ> src0, simd<T, SZ> src1, int flag = GENX_NOSAT) {
 
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T>::value,
-                            simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value,
+                                       simd<T, SZ>>
     esimd_min(simd<T, SZ> src0, T src1, int flag = GENX_NOSAT) {
   simd<T, SZ> Src1 = src1;
   simd<T, SZ> Result = esimd_min<T>(src0, Src1, flag);
@@ -579,8 +571,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T>::value,
-                            simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value,
+                                       simd<T, SZ>>
     esimd_min(T src0, simd<T, SZ> src1, int flag = GENX_NOSAT) {
   simd<T, SZ> Src0 = src0;
   simd<T, SZ> Result = esimd_min<T>(Src0, src1, flag);
@@ -588,7 +580,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 template <typename T>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T>::value, T>::type
+    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value, T>
     esimd_min(T src0, T src1, int flag = GENX_NOSAT) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Src1 = src1;
@@ -689,13 +681,13 @@ esimd_line(float P, float Q, simd<T, SZ> src1, int flag = GENX_NOSAT) {
 // If the gen is not specified we warn the programmer that they are potentially
 // using a less efficient implementation if not on GEN10 or above.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_fp_or_dword_type<T1>::value &&
-                                std::is_floating_point<T1>::value &&
-                                detail::is_fp_or_dword_type<U>::value &&
-                                std::is_floating_point<U>::value,
-                            simd<T0, SZ>>::type
-    esimd_dp2(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_fp_or_dword_type<T1>::value &&
+        std::is_floating_point<T1>::value &&
+        detail::is_fp_or_dword_type<U>::value &&
+        std::is_floating_point<U>::value,
+    simd<T0, SZ>>
+esimd_dp2(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
   simd<float, SZ> Src1 = src1;
@@ -711,13 +703,13 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_fp_or_dword_type<T1>::value &&
-                                std::is_floating_point<T1>::value &&
-                                detail::is_fp_or_dword_type<U>::value &&
-                                std::is_floating_point<U>::value,
-                            simd<T0, SZ>>::type
-    esimd_dp3(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_fp_or_dword_type<T1>::value &&
+        std::is_floating_point<T1>::value &&
+        detail::is_fp_or_dword_type<U>::value &&
+        std::is_floating_point<U>::value,
+    simd<T0, SZ>>
+esimd_dp3(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
   simd<float, SZ> Src1 = src1;
@@ -734,13 +726,13 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_fp_or_dword_type<T1>::value &&
-                                std::is_floating_point<T1>::value &&
-                                detail::is_fp_or_dword_type<U>::value &&
-                                std::is_floating_point<U>::value,
-                            simd<T0, SZ>>::type
-    esimd_dp4(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_fp_or_dword_type<T1>::value &&
+        std::is_floating_point<T1>::value &&
+        detail::is_fp_or_dword_type<U>::value &&
+        std::is_floating_point<U>::value,
+    simd<T0, SZ>>
+esimd_dp4(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
   simd<T1, SZ> Src1 = src1;
@@ -758,13 +750,12 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T, typename U, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_fp_or_dword_type<T>::value &&
-                                std::is_floating_point<T>::value &&
-                                detail::is_fp_or_dword_type<U>::value &&
-                                std::is_floating_point<U>::value,
-                            simd<T, SZ>>::type
-    esimd_dph(simd<T, SZ> src0, U src1, int flag = GENX_NOSAT) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_fp_or_dword_type<T>::value && std::is_floating_point<T>::value &&
+        detail::is_fp_or_dword_type<U>::value &&
+        std::is_floating_point<U>::value,
+    simd<T, SZ>>
+esimd_dph(simd<T, SZ> src0, U src1, int flag = GENX_NOSAT) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
   simd<float, SZ> Src1 = src1;
@@ -782,9 +773,9 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_fp_or_dword_type<T>::value &&
-                                std::is_floating_point<T>::value,
-                            simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<detail::is_fp_or_dword_type<T>::value &&
+                                           std::is_floating_point<T>::value,
+                                       simd<T, SZ>>
     esimd_line(simd<T, 4> src0, simd<T, SZ> src1, int flag = GENX_NOSAT) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
@@ -803,9 +794,9 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_fp_or_dword_type<T>::value &&
-                                std::is_floating_point<T>::value,
-                            simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<detail::is_fp_or_dword_type<T>::value &&
+                                           std::is_floating_point<T>::value,
+                                       simd<T, SZ>>
     esimd_line(float P, float Q, simd<T, SZ> src1, int flag = GENX_NOSAT) {
   simd<T, 4> Src0 = P;
   Src0(3) = Q;
@@ -836,11 +827,10 @@ ESIMD_NODEBUG ESIMD_INLINE simd<RT, SZ> esimd_lzd(simd<T0, SZ> src0,
 }
 
 template <typename RT, typename T0>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<RT>::value &&
-                                detail::is_esimd_scalar<T0>::value,
-                            typename std::remove_const<RT>::type>::type
-    esimd_lzd(T0 src0, int flag = GENX_NOSAT) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_esimd_scalar<RT>::value && detail::is_esimd_scalar<T0>::value,
+    typename sycl::detail::remove_const_t<RT>>
+esimd_lzd(T0 src0, int flag = GENX_NOSAT) {
   simd<T0, 1> Src0 = src0;
   simd<RT, 1> Result = esimd_lzd<RT>(Src0);
   return Result[0];
@@ -877,13 +867,12 @@ esimd_lrp(simd<float, SZ> src0, U src1, V src2, int flag = GENX_NOSAT) {
 // If the gen is not specified we warn the programmer that they are potentially
 // using less efficient implementation.
 template <typename T, int SZ, typename U, typename V>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_fp_or_dword_type<T>::value &&
-                                std::is_floating_point<T>::value &&
-                                detail::is_fp_or_dword_type<U>::value &&
-                                std::is_floating_point<U>::value,
-                            simd<T, SZ>>::type
-    esimd_lrp(simd<T, SZ> src0, U src1, V src2, int flag = GENX_NOSAT) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_fp_or_dword_type<T>::value && std::is_floating_point<T>::value &&
+        detail::is_fp_or_dword_type<U>::value &&
+        std::is_floating_point<U>::value,
+    simd<T, SZ>>
+esimd_lrp(simd<T, SZ> src0, U src1, V src2, int flag = GENX_NOSAT) {
 
   simd<float, SZ> Src1 = src1;
   simd<float, SZ> Src2 = src2;
@@ -932,11 +921,10 @@ ESIMD_NODEBUG ESIMD_INLINE simd<T0, SZ> esimd_bf_reverse(simd<T1, SZ> src0) {
 }
 
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T0>::value &&
-                                detail::is_esimd_scalar<T1>::value,
-                            typename std::remove_const<T0>::type>::type
-    esimd_bf_reverse(T1 src0) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value,
+    typename sycl::detail::remove_const_t<T0>>
+esimd_bf_reverse(T1 src0) {
   simd<T1, 1> Src0 = src0;
   simd<T0, 1> Result = esimd_bf_reverse<T0>(Src0);
   return Result[0];
@@ -945,9 +933,10 @@ ESIMD_NODEBUG ESIMD_INLINE
 // esimd_bf_insert
 template <typename T0, typename T1, int SZ, typename U, typename V, typename W>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T1>::value, simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T1>::value,
+                                       simd<T0, SZ>>
     esimd_bf_insert(U src0, V src1, W src2, simd<T1, SZ> src3) {
-  typedef typename detail::dword_type<T1>::type DT1;
+  typedef typename detail::dword_type<T1> DT1;
   static_assert(std::is_integral<DT1>::value && sizeof(DT1) == sizeof(int),
                 "operand conversion failed");
   simd<DT1, SZ> Src0 = src0;
@@ -959,11 +948,10 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2, typename T3, typename T4>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T0>::value &&
-                                detail::is_esimd_scalar<T4>::value,
-                            typename std::remove_const<T0>::type>::type
-    esimd_bf_insert(T1 src0, T2 src1, T3 src2, T4 src3) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T4>::value,
+    typename sycl::detail::remove_const_t<T0>>
+esimd_bf_insert(T1 src0, T2 src1, T3 src2, T4 src3) {
   simd<T4, 1> Src3 = src3;
   simd<T0, 1> Result = esimd_bf_insert<T0>(src0, src1, src2, Src3);
   return Result[0];
@@ -972,9 +960,10 @@ ESIMD_NODEBUG ESIMD_INLINE
 // esimd_bf_extract
 template <typename T0, typename T1, int SZ, typename U, typename V>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T1>::value, simd<T0, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T1>::value,
+                                       simd<T0, SZ>>
     esimd_bf_extract(U src0, V src1, simd<T1, SZ> src2) {
-  typedef typename detail::dword_type<T1>::type DT1;
+  typedef typename detail::dword_type<T1> DT1;
   static_assert(std::is_integral<DT1>::value && sizeof(DT1) == sizeof(int),
                 "operand conversion failed");
   simd<DT1, SZ> Src0 = src0;
@@ -985,11 +974,10 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2, typename T3>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_esimd_scalar<T0>::value &&
-                                detail::is_esimd_scalar<T3>::value,
-                            typename std::remove_const<T0>::type>::type
-    esimd_bf_extract(T1 src0, T2 src1, T3 src2) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T3>::value,
+    typename sycl::detail::remove_const_t<T0>>
+esimd_bf_extract(T1 src0, T2 src1, T3 src2) {
   simd<T3, 1> Src2 = src2;
   simd<T0, 1> Result = esimd_bf_extract<T0>(src0, src1, Src2);
   return Result[0];
@@ -1072,8 +1060,8 @@ ESIMD_INTRINSIC_DEF(double, sqrt_ieee)
   }                                                                            \
   template <int SZ, typename U>                                                \
   ESIMD_NODEBUG ESIMD_INLINE                                                   \
-      typename std::enable_if<detail::is_esimd_scalar<U>::value,               \
-                              simd<ftype, SZ>>::type                           \
+      typename sycl::detail::enable_if_t<detail::is_esimd_scalar<U>::value,    \
+                                         simd<ftype, SZ>>                      \
           esimd_##name(U src0, simd<ftype, SZ> src1, int flag = GENX_NOSAT) {  \
     simd<ftype, SZ> Src0 = src0;                                               \
     return esimd_##name(Src0, src1, flag);                                     \
@@ -1107,7 +1095,8 @@ esimd_sincos(simd<float, SZ> &dstcos, U src0, int flag = GENX_NOSAT) {
 
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_floating_point<T>::value, simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value,
+                                       simd<T, SZ>>
     esimd_atan(simd<T, SZ> src0, int flag = GENX_NOSAT) {
   simd<T, SZ> Src0 = esimd_abs(src0);
 
@@ -1138,7 +1127,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_floating_point<T>::value, T>::type
+    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value, T>
     esimd_atan(T src0, int flag = GENX_NOSAT) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Result = esimd_atan(Src0, flag);
@@ -1149,7 +1138,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_floating_point<T>::value, simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value,
+                                       simd<T, SZ>>
     esimd_acos(simd<T, SZ> src0, int flag = GENX_NOSAT) {
   simd<T, SZ> Src0 = esimd_abs(src0);
 
@@ -1182,7 +1172,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_floating_point<T>::value, T>::type
+    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value, T>
     esimd_acos(T src0, int flag = GENX_NOSAT) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Result = esimd_acos(Src0, flag);
@@ -1193,7 +1183,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_floating_point<T>::value, simd<T, SZ>>::type
+    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value,
+                                       simd<T, SZ>>
     esimd_asin(simd<T, SZ> src0, int flag = GENX_NOSAT) {
   simd<ushort, SZ> Neg = src0 < T(0.0);
 
@@ -1210,7 +1201,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 
 template <typename T>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_floating_point<T>::value, T>::type
+    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value, T>
     esimd_asin(T src0, int flag = GENX_NOSAT) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Result = esimd_asin(Src0, flag);
@@ -1247,22 +1238,22 @@ ESIMD_INTRINSIC_DEF(rndz)
 
 template <int N>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<(N == 8 || N == 16 || N == 32), uint>::type
+    typename sycl::detail::enable_if_t<(N == 8 || N == 16 || N == 32), uint>
     esimd_pack_mask(simd<ushort, N> src0) {
   return __esimd_pack_mask<N>(src0.data());
 }
 
 template <int N>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<(N == 8 || N == 16 || N == 32),
-                            simd<ushort, N>>::type
+    typename sycl::detail::enable_if_t<(N == 8 || N == 16 || N == 32),
+                                       simd<ushort, N>>
     esimd_unpack_mask(uint src0) {
   return __esimd_unpack_mask<N>(src0);
 }
 
 template <int N>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<(N != 8 && N != 16 && N < 32), uint>::type
+    typename sycl::detail::enable_if_t<(N != 8 && N != 16 && N < 32), uint>
     esimd_pack_mask(simd<ushort, N> src0) {
   simd<ushort, (N < 8 ? 8 : N < 16 ? 16 : 32)> src_0 = 0;
   src_0.template select<N, 1>() = src0.template format<ushort>();
@@ -1272,14 +1263,15 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// Count component-wise the total bits set in source operand.
 template <typename T, int N>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<std::is_integral<T>::value, simd<uint, N>>::type
+    typename sycl::detail::enable_if_t<std::is_integral<T>::value,
+                                       simd<uint, N>>
     esimd_cbit(simd<T, N> src0) {
   return __esimd_cbit(src0.data());
 }
 
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
-    std::is_integral<T>::value && detail::is_esimd_scalar<T>::value, uint>::type
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    std::is_integral<T>::value && detail::is_esimd_scalar<T>::value, uint>
 esimd_cbit(T src) {
   simd<T, 1> Src = src;
   simd<uint, 1> Result = esimd_cbit(Src);
@@ -1312,11 +1304,9 @@ esimd_fbh(simd<unsigned int, N> src) {
 }
 
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if<detail::is_dword_type<T>::value &&
-                                detail::is_esimd_scalar<T>::value,
-                            T>::type
-    esimd_fbh(T src) {
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+    detail::is_dword_type<T>::value && detail::is_esimd_scalar<T>::value, T>
+esimd_fbh(T src) {
   simd<T, 1> Src = src;
   simd<T, 1> Result = esimd_fbh(Src);
   return Result[0];
@@ -1325,10 +1315,10 @@ ESIMD_NODEBUG ESIMD_INLINE
 template <typename T = void> simd<uint, 4> esimd_rdtsc();
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-ESIMD_NODEBUG ESIMD_INLINE typename std::enable_if<
+ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
     detail::is_dword_type<T1>::value && detail::is_dword_type<T2>::value &&
         detail::is_dword_type<T3>::value && detail::is_dword_type<T4>::value,
-    simd<T1, N>>::type
+    simd<T1, N>>
 esimd_dp4a(simd<T2, N> src0, simd<T3, N> src1, simd<T4, N> src2,
            int flag = GENX_NOSAT) {
   simd<T2, N> Src0 = src0;

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_view.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_view.hpp
@@ -143,7 +143,7 @@ public:
   // @return the representing region object.
   //
   template <int Size, int Stride, typename T = simd_view,
-            typename = std::enable_if_t<T::is1D()>>
+            typename = sycl::detail::enable_if_t<T::is1D()>>
   auto select(uint16_t Offset = 0) {
     using TopRegionTy = region1d_t<element_type, Size, Stride>;
     using NewRegionTy = std::pair<TopRegionTy, RegionTy>;
@@ -171,7 +171,8 @@ public:
   // @return the representing region object.
   //
   template <int SizeY, int StrideY, int SizeX, int StrideX,
-            typename T = simd_view, typename = std::enable_if_t<T::is2D()>>
+            typename T = simd_view,
+            typename = sycl::detail::enable_if_t<T::is2D()>>
   auto select(uint16_t OffsetY = 0, uint16_t OffsetX = 0) {
     using TopRegionTy =
         region2d_t<element_type, SizeY, StrideY, SizeX, StrideX>;
@@ -263,19 +264,22 @@ public:
   }
 
   // Reference a row from a 2D region. This returns a 1D region.
-  template <typename T = simd_view, typename = std::enable_if_t<T::is2D()>>
+  template <typename T = simd_view,
+            typename = sycl::detail::enable_if_t<T::is2D()>>
   auto row(int i) {
     return select<1, 0, getSizeX(), 1>(i, 0).template format<element_type>();
   }
 
   // Reference a column from a 2D region. This returns a 2D region.
-  template <typename T = simd_view, typename = std::enable_if_t<T::is2D()>>
+  template <typename T = simd_view,
+            typename = sycl::detail::enable_if_t<T::is2D()>>
   auto column(int i) {
     return select<getSizeY(), 1, 1, 0>(0, i);
   }
 
   // Read a single element from a 1D region, by value only.
-  template <typename T = simd_view, typename = std::enable_if_t<T::is1D()>>
+  template <typename T = simd_view,
+            typename = sycl::detail::enable_if_t<T::is1D()>>
   element_type operator[](int i) const {
     return read()[i];
   }
@@ -336,8 +340,9 @@ public:
   //
   // @return 1 if any element is set, 0 otherwise
 
-  template <typename T1 = element_type, typename T2 = BaseTy,
-            typename = std::enable_if_t<std::is_integral<T1>::value, T2>>
+  template <
+      typename T1 = element_type, typename T2 = BaseTy,
+      typename = sycl::detail::enable_if_t<std::is_integral<T1>::value, T2>>
   uint16_t any() {
     return read().any();
   }
@@ -346,8 +351,9 @@ public:
   //
   // @return 1 if all elements are set, 0 otherwise
 
-  template <typename T1 = element_type, typename T2 = BaseTy,
-            typename = std::enable_if_t<std::is_integral<T1>::value, T2>>
+  template <
+      typename T1 = element_type, typename T2 = BaseTy,
+      typename = sycl::detail::enable_if_t<std::is_integral<T1>::value, T2>>
   uint16_t all() {
     return read().all();
   }

--- a/sycl/include/CL/sycl/INTEL/fpga_utils.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_utils.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/detail/defines.hpp>
+#include <CL/sycl/detail/stl_type_traits.hpp>
 #include <CL/sycl/stl.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
@@ -25,8 +26,8 @@ template <template <int32_t> class _Type, class... _T> struct _GetValue {
 template <template <int32_t> class _Type, class _T1, class... _T>
 struct _GetValue<_Type, _T1, _T...> {
   static constexpr auto value =
-      std::conditional<_MatchType<_Type, _T1>::value, _T1,
-                       _GetValue<_Type, _T...>>::type::value;
+      detail::conditional_t<_MatchType<_Type, _T1>::value, _T1,
+                            _GetValue<_Type, _T...>>::value;
 };
 } // namespace INTEL
 } // namespace sycl

--- a/sycl/include/CL/sycl/ONEAPI/function_pointer.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/function_pointer.hpp
@@ -9,11 +9,10 @@
 #pragma once
 
 #include <CL/sycl/detail/export.hpp>
+#include <CL/sycl/detail/stl_type_traits.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/program.hpp>
 #include <CL/sycl/stl.hpp>
-
-#include <type_traits>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -37,17 +36,17 @@ using device_func_ptr_holder_t = cl_ulong;
 /// to the provided function pointer type.
 template <
     class FuncType,
-    typename FuncPtrType = typename std::add_pointer<FuncType>::type,
-    typename std::enable_if<std::is_function<FuncType>::value, int>::type = 0>
+    typename FuncPtrType = typename detail::add_pointer_t<FuncType>,
+    typename detail::enable_if_t<std::is_function<FuncType>::value, int> = 0>
 inline FuncPtrType to_device_func_ptr(device_func_ptr_holder_t FptrHolder) {
   return reinterpret_cast<FuncPtrType>(FptrHolder);
 }
 
 template <class FuncType>
-using enable_if_is_function_pointer_t = typename std::enable_if<
+using enable_if_is_function_pointer_t = typename detail::enable_if_t<
     std::is_pointer<FuncType>::value &&
         std::is_function<typename std::remove_pointer<FuncType>::type>::value,
-    int>::type;
+    int>;
 
 /// \brief this function can be used only on host side to obtain device
 /// function pointer for the specified function.

--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -201,17 +201,17 @@ public:
 #ifdef __ENABLE_USM_ADDR_SPACE__
   // Create atomic in global_space with one from global_device_space
   template <access::address_space _Space = addressSpace,
-            typename = typename std::enable_if<
+            typename = typename detail::enable_if_t<
                 _Space == addressSpace &&
-                addressSpace == access::address_space::global_space>::type>
+                addressSpace == access::address_space::global_space>>
   atomic(const atomic<T, access::address_space::global_device_space> &RHS) {
     Ptr = RHS.Ptr;
   }
 
   template <access::address_space _Space = addressSpace,
-            typename = typename std::enable_if<
+            typename = typename detail::enable_if_t<
                 _Space == addressSpace &&
-                addressSpace == access::address_space::global_space>::type>
+                addressSpace == access::address_space::global_space>>
   atomic(atomic<T, access::address_space::global_device_space> &&RHS) {
     Ptr = RHS.Ptr;
   }

--- a/sycl/include/CL/sycl/backend/level_zero.hpp
+++ b/sycl/include/CL/sycl/backend/level_zero.hpp
@@ -58,31 +58,31 @@ program make_program(const context &Context, pi_native_handle NativeHandle);
 queue make_queue(const context &Context, pi_native_handle InteropHandle);
 
 // Construction of SYCL platform.
-template <typename T, typename std::enable_if<
-                          std::is_same<T, platform>::value>::type * = nullptr>
+template <typename T, typename detail::enable_if_t<
+                          std::is_same<T, platform>::value> * = nullptr>
 T make(typename interop<backend::level_zero, T>::type Interop) {
   return make_platform(reinterpret_cast<pi_native_handle>(Interop));
 }
 
 // Construction of SYCL device.
-template <typename T, typename std::enable_if<
-                          std::is_same<T, device>::value>::type * = nullptr>
+template <typename T, typename detail::enable_if_t<
+                          std::is_same<T, device>::value> * = nullptr>
 T make(const platform &Platform,
        typename interop<backend::level_zero, T>::type Interop) {
   return make_device(Platform, reinterpret_cast<pi_native_handle>(Interop));
 }
 
 // Construction of SYCL program.
-template <typename T, typename std::enable_if<
-                          std::is_same<T, program>::value>::type * = nullptr>
+template <typename T, typename detail::enable_if_t<
+                          std::is_same<T, program>::value> * = nullptr>
 T make(const context &Context,
        typename interop<backend::level_zero, T>::type Interop) {
   return make_program(Context, reinterpret_cast<pi_native_handle>(Interop));
 }
 
 // Construction of SYCL queue.
-template <typename T, typename std::enable_if<
-                          std::is_same<T, queue>::value>::type * = nullptr>
+template <typename T, typename detail::enable_if_t<
+                          std::is_same<T, queue>::value> * = nullptr>
 T make(const context &Context,
        typename interop<backend::level_zero, T>::type Interop) {
   return make_queue(Context, reinterpret_cast<pi_native_handle>(Interop));

--- a/sycl/include/CL/sycl/backend/opencl.hpp
+++ b/sycl/include/CL/sycl/backend/opencl.hpp
@@ -66,37 +66,37 @@ __SYCL_EXPORT queue make_queue(const context &Context,
                                pi_native_handle InteropHandle);
 
 // Construction of SYCL platform.
-template <typename T, typename std::enable_if<
-                          std::is_same<T, platform>::value>::type * = nullptr>
+template <typename T, typename detail::enable_if_t<
+                          std::is_same<T, platform>::value> * = nullptr>
 T make(typename interop<backend::opencl, T>::type Interop) {
   return make_platform(detail::pi::cast<pi_native_handle>(Interop));
 }
 
 // Construction of SYCL device.
-template <typename T, typename std::enable_if<
-                          std::is_same<T, device>::value>::type * = nullptr>
+template <typename T, typename detail::enable_if_t<
+                          std::is_same<T, device>::value> * = nullptr>
 T make(typename interop<backend::opencl, T>::type Interop) {
   return make_device(detail::pi::cast<pi_native_handle>(Interop));
 }
 
 // Construction of SYCL context.
-template <typename T, typename std::enable_if<
-                          std::is_same<T, context>::value>::type * = nullptr>
+template <typename T, typename detail::enable_if_t<
+                          std::is_same<T, context>::value> * = nullptr>
 T make(typename interop<backend::opencl, T>::type Interop) {
   return make_context(detail::pi::cast<pi_native_handle>(Interop));
 }
 
 // Construction of SYCL program.
-template <typename T, typename std::enable_if<
-                          std::is_same<T, program>::value>::type * = nullptr>
+template <typename T, typename detail::enable_if_t<
+                          std::is_same<T, program>::value> * = nullptr>
 T make(const context &Context,
        typename interop<backend::opencl, T>::type Interop) {
   return make_program(Context, detail::pi::cast<pi_native_handle>(Interop));
 }
 
 // Construction of SYCL queue.
-template <typename T, typename std::enable_if<
-                          std::is_same<T, queue>::value>::type * = nullptr>
+template <typename T, typename detail::enable_if_t<
+                          std::is_same<T, queue>::value> * = nullptr>
 T make(const context &Context,
        typename interop<backend::opencl, T>::type Interop) {
   return make_queue(Context, detail::pi::cast<pi_native_handle>(Interop));

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -33,8 +33,8 @@ template <int dimensions> class range;
 /// \ingroup sycl_api
 template <typename T, int dimensions = 1,
           typename AllocatorT = cl::sycl::buffer_allocator,
-          typename = typename std::enable_if<(dimensions > 0) &&
-                                             (dimensions <= 3)>::type>
+          typename = typename detail::enable_if_t<(dimensions > 0) &&
+                                                  (dimensions <= 3)>>
 class buffer {
 public:
   using value_type = T;
@@ -42,7 +42,7 @@ public:
   using const_reference = const value_type &;
   using allocator_type = AllocatorT;
   template <int dims>
-  using EnableIfOneDimension = typename std::enable_if<1 == dims>::type;
+  using EnableIfOneDimension = typename detail::enable_if_t<1 == dims>;
   // using same requirement for contiguous container as std::span
   template <class Container>
   using EnableIfContiguous =
@@ -56,9 +56,8 @@ public:
       std::is_convertible<typename std::iterator_traits<It>::iterator_category,
                           std::input_iterator_tag>::value>;
   template <typename ItA, typename ItB>
-  using EnableIfSameNonConstIterators =
-      typename std::enable_if<std::is_same<ItA, ItB>::value &&
-                              !std::is_const<ItA>::value, ItA>::type;
+  using EnableIfSameNonConstIterators = typename detail::enable_if_t<
+      std::is_same<ItA, ItB>::value && !std::is_const<ItA>::value, ItA>;
 
   buffer(const range<dimensions> &bufferRange,
          const property_list &propList = {})

--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -11,12 +11,12 @@
 #include <CL/sycl/backend_types.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/export.hpp>
+#include <CL/sycl/detail/stl_type_traits.hpp>
 #include <CL/sycl/exception_list.hpp>
 #include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/property_list.hpp>
 #include <CL/sycl/stl.hpp>
 
-#include <type_traits>
 // 4.6.2 Context class
 
 __SYCL_INLINE_NAMESPACE(cl) {
@@ -225,7 +225,7 @@ private:
 
   template <class T>
   friend
-      typename std::add_pointer<typename decltype(T::impl)::element_type>::type
+      typename detail::add_pointer_t<typename decltype(T::impl)::element_type>
       detail::getRawSyclObjImpl(const T &SyclObject);
 
   template <class T>

--- a/sycl/include/CL/sycl/detail/array.hpp
+++ b/sycl/include/CL/sycl/detail/array.hpp
@@ -25,13 +25,13 @@ public:
   /* The following constructor is only available in the array struct
    * specialization where: dimensions==1 */
   template <int N = dimensions>
-  array(typename std::enable_if<(N == 1), size_t>::type dim0 = 0)
+  array(typename detail::enable_if_t<(N == 1), size_t> dim0 = 0)
       : common_array{dim0} {}
 
   /* The following constructors are only available in the array struct
    * specialization where: dimensions==2 */
   template <int N = dimensions>
-  array(typename std::enable_if<(N == 2), size_t>::type dim0, size_t dim1)
+  array(typename detail::enable_if_t<(N == 2), size_t> dim0, size_t dim1)
       : common_array{dim0, dim1} {}
 
   template <int N = dimensions, detail::enable_if_t<(N == 2), size_t> = 0>
@@ -40,7 +40,7 @@ public:
   /* The following constructors are only available in the array struct
    * specialization where: dimensions==3 */
   template <int N = dimensions>
-  array(typename std::enable_if<(N == 3), size_t>::type dim0, size_t dim1,
+  array(typename detail::enable_if_t<(N == 3), size_t> dim0, size_t dim1,
         size_t dim2)
       : common_array{dim0, dim1, dim2} {}
 

--- a/sycl/include/CL/sycl/detail/cg_types.hpp
+++ b/sycl/include/CL/sycl/detail/cg_types.hpp
@@ -195,13 +195,13 @@ public:
   char *getPtr() override { return reinterpret_cast<char *>(&MKernel); }
 
   template <class ArgT = KernelArgType>
-  typename std::enable_if<std::is_same<ArgT, void>::value>::type
+  typename detail::enable_if_t<std::is_same<ArgT, void>::value>
   runOnHost(const NDRDescT &) {
     MKernel();
   }
 
   template <class ArgT = KernelArgType>
-  typename std::enable_if<std::is_same<ArgT, sycl::id<Dims>>::value>::type
+  typename detail::enable_if_t<std::is_same<ArgT, sycl::id<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
     sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
     sycl::id<Dims> Offset;
@@ -220,8 +220,8 @@ public:
   }
 
   template <class ArgT = KernelArgType>
-  typename std::enable_if<
-      std::is_same<ArgT, item<Dims, /*Offset=*/false>>::value>::type
+  typename detail::enable_if_t<
+      std::is_same<ArgT, item<Dims, /*Offset=*/false>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
     sycl::id<Dims> ID;
     sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
@@ -239,8 +239,8 @@ public:
   }
 
   template <class ArgT = KernelArgType>
-  typename std::enable_if<
-      std::is_same<ArgT, item<Dims, /*Offset=*/true>>::value>::type
+  typename detail::enable_if_t<
+      std::is_same<ArgT, item<Dims, /*Offset=*/true>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
     sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
     sycl::id<Dims> Offset;
@@ -260,7 +260,7 @@ public:
   }
 
   template <class ArgT = KernelArgType>
-  typename std::enable_if<std::is_same<ArgT, nd_item<Dims>>::value>::type
+  typename detail::enable_if_t<std::is_same<ArgT, nd_item<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
     sycl::range<Dims> GroupSize(InitializedVal<Dims, range>::template get<0>());
     for (int I = 0; I < Dims; ++I) {

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -12,10 +12,10 @@
 #include <CL/sycl/detail/cl.h>
 #include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/detail/export.hpp>
+#include <CL/sycl/detail/stl_type_traits.hpp>
 
 #include <cstdint>
 #include <string>
-#include <type_traits>
 
 #define __SYCL_STRINGIFY_LINE_HELP(s) #s
 #define __SYCL_STRINGIFY_LINE(s) __SYCL_STRINGIFY_LINE_HELP(s)
@@ -173,7 +173,7 @@ template <class Obj> decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject) {
 // must make sure the returned pointer is not captured in a field or otherwise
 // stored - i.e. must live only as on-stack value.
 template <class T>
-typename std::add_pointer<typename decltype(T::impl)::element_type>::type
+typename detail::add_pointer_t<typename decltype(T::impl)::element_type>
 getRawSyclObjImpl(const T &SyclObject) {
   return SyclObject.impl.get();
 }

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -64,7 +64,7 @@ using is_validImageDataT = typename detail::is_contained<
 
 template <typename DataT>
 using EnableIfImgAccDataT =
-    typename std::enable_if<is_validImageDataT<DataT>::value, DataT>::type;
+    typename detail::enable_if_t<is_validImageDataT<DataT>::value, DataT>;
 
 template <int Dimensions>
 class __SYCL_EXPORT image_impl final : public SYCLMemObjT {
@@ -73,8 +73,7 @@ class __SYCL_EXPORT image_impl final : public SYCLMemObjT {
 
 private:
   template <bool B>
-  using EnableIfPitchT =
-      typename std::enable_if<B, range<Dimensions - 1>>::type;
+  using EnableIfPitchT = typename detail::enable_if_t<B, range<Dimensions - 1>>;
   static_assert(Dimensions >= 1 || Dimensions <= 3,
                 "Dimensions of cl::sycl::image can be 1, 2 or 3");
 
@@ -192,7 +191,7 @@ public:
   // Return a range object representing the pitch of the image in bytes.
   // Available only when: Dimensions == 2.
   template <bool B = (Dimensions == 2)>
-  typename std::enable_if<B, range<1>>::type get_pitch() const {
+  typename detail::enable_if_t<B, range<1>> get_pitch() const {
     range<1> Temp = range<1>(MRowPitch);
     return Temp;
   }
@@ -200,7 +199,7 @@ public:
   // Return a range object representing the pitch of the image in bytes.
   // Available only when: Dimensions == 3.
   template <bool B = (Dimensions == 3)>
-  typename std::enable_if<B, range<2>>::type get_pitch() const {
+  typename detail::enable_if_t<B, range<2>> get_pitch() const {
     range<2> Temp = range<2>(MRowPitch, MSlicePitch);
     return Temp;
   }

--- a/sycl/include/CL/sycl/detail/property_list_base.hpp
+++ b/sycl/include/CL/sycl/detail/property_list_base.hpp
@@ -10,10 +10,10 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/property_helper.hpp>
+#include <CL/sycl/detail/stl_type_traits.hpp>
 
 #include <bitset>
 #include <memory>
-#include <type_traits>
 #include <vector>
 
 __SYCL_INLINE_NAMESPACE(cl) {
@@ -32,8 +32,8 @@ protected:
   void ctorHelper() {}
 
   template <typename... PropsT, class PropT>
-  typename std::enable_if<
-      std::is_base_of<DataLessPropertyBase, PropT>::value>::type
+  typename detail::enable_if_t<
+      std::is_base_of<DataLessPropertyBase, PropT>::value>
   ctorHelper(PropT &, PropsT... Props) {
     const int PropKind = static_cast<int>(PropT::getKind());
     MDataLessProps[PropKind] = true;
@@ -41,8 +41,8 @@ protected:
   }
 
   template <typename... PropsT, class PropT>
-  typename std::enable_if<
-      std::is_base_of<PropertyWithDataBase, PropT>::value>::type
+  typename detail::enable_if_t<
+      std::is_base_of<PropertyWithDataBase, PropT>::value>
   ctorHelper(PropT &Prop, PropsT... Props) {
     MPropsWithData.emplace_back(new PropT(Prop));
     ctorHelper(Props...);
@@ -50,16 +50,16 @@ protected:
 
   // Compile-time-constant properties are simply skipped
   template <typename... PropsT, class PropT>
-  typename std::enable_if<
+  typename detail::enable_if_t<
       !std::is_base_of<PropertyWithDataBase, PropT>::value &&
-      !std::is_base_of<DataLessPropertyBase, PropT>::value>::type
+      !std::is_base_of<DataLessPropertyBase, PropT>::value>
   ctorHelper(PropT &, PropsT... Props) {
     ctorHelper(Props...);
   }
 
   template <typename PropT>
-  typename std::enable_if<std::is_base_of<DataLessPropertyBase, PropT>::value,
-                          bool>::type
+  typename detail::enable_if_t<
+      std::is_base_of<DataLessPropertyBase, PropT>::value, bool>
   has_property_helper() const {
     const int PropKind = static_cast<int>(PropT::getKind());
     if (PropKind >= detail::DataLessPropKind::DataLessPropKindSize)
@@ -68,8 +68,8 @@ protected:
   }
 
   template <typename PropT>
-  typename std::enable_if<std::is_base_of<PropertyWithDataBase, PropT>::value,
-                          bool>::type
+  typename detail::enable_if_t<
+      std::is_base_of<PropertyWithDataBase, PropT>::value, bool>
   has_property_helper() const {
     const int PropKind = static_cast<int>(PropT::getKind());
     for (const std::shared_ptr<PropertyWithDataBase> &Prop : MPropsWithData)
@@ -79,16 +79,16 @@ protected:
   }
 
   template <typename PropT>
-  typename std::enable_if<std::is_base_of<DataLessPropertyBase, PropT>::value,
-                          PropT>::type
+  typename detail::enable_if_t<
+      std::is_base_of<DataLessPropertyBase, PropT>::value, PropT>
   get_property_helper() const {
     // In case of simple property we can just construct it
     return PropT{};
   }
 
   template <typename PropT>
-  typename std::enable_if<std::is_base_of<PropertyWithDataBase, PropT>::value,
-                          PropT>::type
+  typename detail::enable_if_t<
+      std::is_base_of<PropertyWithDataBase, PropT>::value, PropT>
   get_property_helper() const {
     const int PropKind = static_cast<int>(PropT::getKind());
     if (PropKind >= PropWithDataKind::PropWithDataKindSize)

--- a/sycl/include/CL/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/stl_type_traits.hpp
@@ -36,11 +36,6 @@ using remove_reference_t = typename std::remove_reference<T>::type;
 
 template <typename T> using add_pointer_t = typename std::add_pointer<T>::type;
 
-template <typename T> using remove_cv_t = typename std::remove_cv<T>::type;
-
-template <typename T>
-using remove_reference_t = typename std::remove_reference<T>::type;
-
 // C++17
 template <bool V> using bool_constant = std::integral_constant<bool, V>;
 

--- a/sycl/include/CL/sycl/detail/type_list.hpp
+++ b/sycl/include/CL/sycl/detail/type_list.hpp
@@ -11,8 +11,6 @@
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/detail/stl_type_traits.hpp>
 
-#include <type_traits>
-
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {

--- a/sycl/include/CL/sycl/device.hpp
+++ b/sycl/include/CL/sycl/device.hpp
@@ -199,7 +199,7 @@ private:
 
   template <class T>
   friend
-      typename std::add_pointer<typename decltype(T::impl)::element_type>::type
+      typename detail::add_pointer_t<typename decltype(T::impl)::element_type>
       detail::getRawSyclObjImpl(const T &SyclObject);
 
   template <class T>

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -122,12 +122,12 @@ public:
   size_t operator[](int dimension) const { return index[dimension]; }
 
   template <int dims = Dimensions>
-  typename std::enable_if<(dims == 1), size_t>::type get_linear_id() const {
+  typename detail::enable_if_t<(dims == 1), size_t> get_linear_id() const {
     return index[0];
   }
 
   template <int dims = Dimensions>
-  typename std::enable_if<(dims == 2), size_t>::type get_linear_id() const {
+  typename detail::enable_if_t<(dims == 2), size_t> get_linear_id() const {
     return index[0] * groupRange[1] + index[1];
   }
 
@@ -142,7 +142,7 @@ public:
   //    Get a linearized version of the work-group id. Calculating a linear
   //    work-group id from a multi-dimensional index follows the equation 4.3.
   template <int dims = Dimensions>
-  typename std::enable_if<(dims == 3), size_t>::type get_linear_id() const {
+  typename detail::enable_if_t<(dims == 3), size_t> get_linear_id() const {
     return (index[0] * groupRange[1] * groupRange[2]) +
            (index[1] * groupRange[2]) + index[2];
   }
@@ -256,12 +256,12 @@ public:
   /// Executes a work-group mem-fence with memory ordering on the local address
   /// space, global address space or both based on the value of \p accessSpace.
   template <access::mode accessMode = access::mode::read_write>
-  void mem_fence(typename std::enable_if<
-                     accessMode == access::mode::read ||
-                     accessMode == access::mode::write ||
-                     accessMode == access::mode::read_write,
-                     access::fence_space>::type accessSpace =
-                     access::fence_space::global_and_local) const {
+  void mem_fence(
+      typename detail::enable_if_t<accessMode == access::mode::read ||
+                                       accessMode == access::mode::write ||
+                                       accessMode == access::mode::read_write,
+                                   access::fence_space>
+          accessSpace = access::fence_space::global_and_local) const {
     uint32_t flags = detail::getSPIRVMemorySemanticsMask(accessSpace);
     // TODO: currently, there is no good way in SPIR-V to set the memory
     // barrier only for load operations or only for store operations.

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -161,8 +161,8 @@ template <int Dims> struct NotIntMsg<id<Dims>> {
 
 #if __SYCL_ID_QUERIES_FIT_IN_INT__
 template <typename T, typename ValT>
-typename std::enable_if<std::is_same<ValT, size_t>::value ||
-                        std::is_same<ValT, unsigned long long>::value>::type
+typename detail::enable_if_t<std::is_same<ValT, size_t>::value ||
+                             std::is_same<ValT, unsigned long long>::value>
 checkValueRangeImpl(ValT V) {
   static constexpr size_t Limit =
       static_cast<size_t>((std::numeric_limits<int>::max)());
@@ -172,8 +172,8 @@ checkValueRangeImpl(ValT V) {
 #endif
 
 template <int Dims, typename T>
-typename std::enable_if<std::is_same<T, range<Dims>>::value ||
-                        std::is_same<T, id<Dims>>::value>::type
+typename detail::enable_if_t<std::is_same<T, range<Dims>>::value ||
+                             std::is_same<T, id<Dims>>::value>
 checkValueRange(const T &V) {
 #if __SYCL_ID_QUERIES_FIT_IN_INT__
   for (size_t Dim = 0; Dim < Dims; ++Dim)
@@ -210,7 +210,7 @@ void checkValueRange(const range<Dims> &R, const id<Dims> &O) {
 }
 
 template <int Dims, typename T>
-typename std::enable_if<std::is_same<T, nd_range<Dims>>::value>::type
+typename detail::enable_if_t<std::is_same<T, nd_range<Dims>>::value>
 checkValueRange(const T &V) {
 #if __SYCL_ID_QUERIES_FIT_IN_INT__
   checkValueRange<Dims>(V.get_global_range());
@@ -299,8 +299,8 @@ private:
       : MQueue(std::move(Queue)), MIsHost(IsHost) {}
 
   /// Stores copy of Arg passed to the MArgsStorage.
-  template <typename T, typename F = typename std::remove_const<
-                            typename std::remove_reference<T>::type>::type>
+  template <typename T, typename F = typename detail::remove_const_t<
+                            typename detail::remove_reference_t<T>>>
   F *storePlainArg(T &&Arg) {
     MArgsStorage.emplace_back(sizeof(T));
     auto Storage = reinterpret_cast<F *>(MArgsStorage.back().data());
@@ -411,7 +411,7 @@ private:
   // setArgHelper for non local accessor argument.
   template <typename DataT, int Dims, access::mode AccessMode,
             access::target AccessTarget, access::placeholder IsPlaceholder>
-  typename std::enable_if<AccessTarget != access::target::local, void>::type
+  typename detail::enable_if_t<AccessTarget != access::target::local, void>
   setArgHelper(
       int ArgIndex,
       accessor<DataT, Dims, AccessMode, AccessTarget, IsPlaceholder> &&Arg) {
@@ -642,7 +642,7 @@ private:
     parallel_for<class __copyAcc2Ptr<TSrc, TDst, Dim, AccMode, AccTarget, IsPH>>
         (Range, [=](id<Dim> Index) {
       const size_t LinearIndex = detail::getLinearIndex(Index, Range);
-      using TSrcNonConst = typename std::remove_const<TSrc>::type;
+      using TSrcNonConst = typename detail::remove_const_t<TSrc>;
       (reinterpret_cast<TSrcNonConst *>(Dst))[LinearIndex] = Src[Index];
     });
   }
@@ -659,7 +659,7 @@ private:
                    TDst *Dst) {
     single_task<class __copyAcc2Ptr<TSrc, TDst, Dim, AccMode, AccTarget, IsPH>>
         ([=]() {
-      using TSrcNonConst = typename std::remove_const<TSrc>::type;
+      using TSrcNonConst = typename detail::remove_const_t<TSrc>;
       *(reinterpret_cast<TSrcNonConst *>(Dst)) = readFromFirstAccElement(Src);
     });
   }
@@ -732,9 +732,9 @@ private:
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     using LambdaArgType = sycl::detail::lambda_arg_type<KernelType, item<Dims>>;
     using TransformedArgType =
-        typename std::conditional<std::is_integral<LambdaArgType>::value &&
-                                      Dims == 1,
-                                  item<Dims>, LambdaArgType>::type;
+        typename detail::conditional_t<std::is_integral<LambdaArgType>::value &&
+                                           Dims == 1,
+                                       item<Dims>, LambdaArgType>;
 #ifdef __SYCL_DEVICE_ONLY__
     (void)NumWorkItems;
     kernel_parallel_for<NameT, TransformedArgType>(KernelFunc);
@@ -849,7 +849,7 @@ public:
 
   template <typename T>
   using remove_cv_ref_t =
-      typename std::remove_cv<detail::remove_reference_t<T>>::type;
+      typename detail::remove_cv_t<detail::remove_reference_t<T>>;
 
   template <typename U, typename T>
   using is_same_type = std::is_same<remove_cv_ref_t<U>, remove_cv_ref_t<T>>;
@@ -873,7 +873,7 @@ public:
   /// \param ArgIndex is a positional number of argument to be set.
   /// \param Arg is an argument value to be set.
   template <typename T>
-  typename std::enable_if<ShouldEnableSetArg<T>::value, void>::type
+  typename detail::enable_if_t<ShouldEnableSetArg<T>::value, void>
   set_arg(int ArgIndex, T &&Arg) {
     setArgHelper(ArgIndex, std::move(Arg));
   }

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -93,7 +93,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image(image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range,
-        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const typename detail::enable_if_t<B, range<Dimensions - 1>> &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
         Order, Type, Range, Pitch,
@@ -105,7 +105,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image(image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range,
-        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const typename detail::enable_if_t<B, range<Dimensions - 1>> &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
         Order, Type, Range, Pitch,
@@ -155,7 +155,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range,
-        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const typename detail::enable_if_t<B, range<Dimensions - 1>> &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Pitch,
@@ -167,7 +167,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image(void *HostPointer, image_channel_order Order, image_channel_type Type,
         const range<Dimensions> &Range,
-        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const typename detail::enable_if_t<B, range<Dimensions - 1>> &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Pitch,
@@ -199,7 +199,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
-        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const typename detail::enable_if_t<B, range<Dimensions - 1>> &Pitch,
         const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Pitch,
@@ -211,7 +211,7 @@ public:
   template <bool B = (Dimensions > 1)>
   image(shared_ptr_class<void> &HostPointer, image_channel_order Order,
         image_channel_type Type, const range<Dimensions> &Range,
-        const typename std::enable_if<B, range<Dimensions - 1>>::type &Pitch,
+        const typename detail::enable_if_t<B, range<Dimensions - 1>> &Pitch,
         AllocatorT Allocator, const property_list &PropList = {}) {
     impl = std::make_shared<detail::image_impl<Dimensions>>(
         HostPointer, Order, Type, Range, Pitch,
@@ -256,7 +256,7 @@ public:
 
   /* Available only when: dimensions >1 */
   template <bool B = (Dimensions > 1)>
-  typename std::enable_if<B, range<Dimensions - 1>>::type get_pitch() const {
+  typename detail::enable_if_t<B, range<Dimensions - 1>> get_pitch() const {
     return impl->get_pitch();
   }
 

--- a/sycl/include/CL/sycl/interop_handle.hpp
+++ b/sycl/include/CL/sycl/interop_handle.hpp
@@ -44,11 +44,11 @@ public:
   /// asynchronously.
   template <backend BackendName = backend::opencl, typename DataT, int Dims,
             access::mode Mode, access::target Target, access::placeholder IsPlh>
-  typename std::enable_if<
+  typename detail::enable_if_t<
       Target == access::target::global_buffer ||
           Target == access::target::constant_buffer,
       typename interop<BackendName,
-                       accessor<DataT, Dims, Mode, Target, IsPlh>>::type>::type
+                       accessor<DataT, Dims, Mode, Target, IsPlh>>::type>
   get_native_mem(const accessor<DataT, Dims, Mode, Target, IsPlh> &Acc) const {
 #ifndef __SYCL_DEVICE_ONLY__
     const auto *AccBase = static_cast<const detail::AccessorBaseHost *>(&Acc);
@@ -63,12 +63,12 @@ public:
 
   template <backend BackendName = backend::opencl, typename DataT, int Dims,
             access::mode Mode, access::target Target, access::placeholder IsPlh>
-  typename std::enable_if<
+  typename detail::enable_if_t<
       !(Target == access::target::global_buffer ||
         Target == access::target::constant_buffer),
-      typename interop<BackendName, accessor<DataT, Dims, Mode,
-                                             access::target::global_buffer,
-                                             IsPlh>>::type>::type
+      typename interop<BackendName,
+                       accessor<DataT, Dims, Mode,
+                                access::target::global_buffer, IsPlh>>::type>
   get_native_mem(const accessor<DataT, Dims, Mode, Target, IsPlh> &) const {
     throw invalid_object_error("Getting memory object out of accessor for "
                                "specified target is not allowed",

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -121,12 +121,12 @@ public:
   /// Executes a work-group mem-fence with memory ordering on the local address
   /// space, global address space or both based on the value of \p accessSpace.
   template <access::mode accessMode = access::mode::read_write>
-  void
-  mem_fence(typename std::enable_if<accessMode == access::mode::read ||
-                                        accessMode == access::mode::write ||
-                                        accessMode == access::mode::read_write,
-                                    access::fence_space>::type accessSpace =
-                access::fence_space::global_and_local) const {
+  void mem_fence(
+      typename detail::enable_if_t<accessMode == access::mode::read ||
+                                       accessMode == access::mode::write ||
+                                       accessMode == access::mode::read_write,
+                                   access::fence_space>
+          accessSpace = access::fence_space::global_and_local) const {
     (void)accessSpace;
     Group.mem_fence();
   }

--- a/sycl/include/CL/sycl/property_list.hpp
+++ b/sycl/include/CL/sycl/property_list.hpp
@@ -26,14 +26,14 @@ class property_list : protected detail::PropertyListBase {
   template <typename... Tail> struct AllProperties : std::true_type {};
   template <typename T, typename... Tail>
   struct AllProperties<T, Tail...>
-      : std::conditional<
+      : detail::conditional_t<
             std::is_base_of<detail::DataLessPropertyBase, T>::value ||
                 std::is_base_of<detail::PropertyWithDataBase, T>::value,
-            AllProperties<Tail...>, std::false_type>::type {};
+            AllProperties<Tail...>, std::false_type> {};
 
 public:
-  template <typename... PropsT, typename = typename std::enable_if<
-                                    AllProperties<PropsT...>::value>::type>
+  template <typename... PropsT, typename = typename detail::enable_if_t<
+                                    AllProperties<PropsT...>::value>>
   property_list(PropsT... Props) : detail::PropertyListBase(false) {
     ctorHelper(Props...);
   }

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -31,18 +31,18 @@ public:
   /* The following constructor is only available in the range class
   specialization where: dimensions==1 */
   template <int N = dimensions>
-  range(typename std::enable_if<(N == 1), size_t>::type dim0) : base(dim0) {}
+  range(typename detail::enable_if_t<(N == 1), size_t> dim0) : base(dim0) {}
 
   /* The following constructor is only available in the range class
   specialization where: dimensions==2 */
   template <int N = dimensions>
-  range(typename std::enable_if<(N == 2), size_t>::type dim0, size_t dim1)
+  range(typename detail::enable_if_t<(N == 2), size_t> dim0, size_t dim1)
       : base(dim0, dim1) {}
 
   /* The following constructor is only available in the range class
   specialization where: dimensions==3 */
   template <int N = dimensions>
-  range(typename std::enable_if<(N == 3), size_t>::type dim0, size_t dim1,
+  range(typename detail::enable_if_t<(N == 3), size_t> dim0, size_t dim1,
         size_t dim2)
       : base(dim0, dim1, dim2) {}
 

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -105,14 +105,14 @@ template <typename T, int N> class BaseCLTypeConverter;
 
 // Element type for relational operator return value.
 template <typename DataT>
-using rel_t = typename std::conditional<
+using rel_t = typename detail::conditional_t<
     sizeof(DataT) == sizeof(cl_char), cl_char,
-    typename std::conditional<
+    typename detail::conditional_t<
         sizeof(DataT) == sizeof(cl_short), cl_short,
-        typename std::conditional<
+        typename detail::conditional_t<
             sizeof(DataT) == sizeof(cl_int), cl_int,
-            typename std::conditional<sizeof(DataT) == sizeof(cl_long), cl_long,
-                                      bool>::type>::type>::type>::type;
+            typename detail::conditional_t<sizeof(DataT) == sizeof(cl_long),
+                                           cl_long, bool>>>>;
 
 // Special type indicating that SwizzleOp should just read value from vector -
 // not trying to perform any operations. Should not be called.
@@ -630,12 +630,12 @@ template <typename Type, int NumElements> class vec {
 
   // Shortcuts for args validation in vec(const argTN &... args) ctor.
   template <typename... argTN>
-  using EnableIfSuitableTypes = typename std::enable_if<
-      conjunction<TypeChecker<argTN, DataT>...>::value>::type;
+  using EnableIfSuitableTypes = typename detail::enable_if_t<
+      conjunction<TypeChecker<argTN, DataT>...>::value>;
 
   template <typename... argTN>
-  using EnableIfSuitableNumElements = typename std::enable_if<
-      SizeChecker<0, NumElements, argTN...>::value>::type;
+  using EnableIfSuitableNumElements = typename detail::enable_if_t<
+      SizeChecker<0, NumElements, argTN...>::value>;
 
 public:
   using element_type = DataT;
@@ -661,9 +661,9 @@ public:
 
   // W/o this, things like "vec<char,*> = vec<signed char, *>" doesn't work.
   template <typename Ty = DataT>
-  typename std::enable_if<!std::is_same<Ty, rel_t>::value &&
-                              std::is_convertible<Ty, rel_t>::value,
-                          vec &>::type
+  typename detail::enable_if_t<!std::is_same<Ty, rel_t>::value &&
+                                   std::is_convertible<Ty, rel_t>::value,
+                               vec &>
   operator=(const vec<rel_t, NumElements> &Rhs) {
     *this = Rhs.template as<vec>();
     return *this;
@@ -671,17 +671,17 @@ public:
 
 #ifdef __SYCL_USE_EXT_VECTOR_TYPE__
   template <typename T = void>
-  using EnableIfNotHostHalf = typename std::enable_if<
+  using EnableIfNotHostHalf = typename detail::enable_if_t<
       !std::is_same<DataT, cl::sycl::detail::half_impl::half>::value ||
           !std::is_same<cl::sycl::detail::half_impl::StorageT,
-                            cl::sycl::detail::host_half_impl::half>::value,
-      T>::type;
+                        cl::sycl::detail::host_half_impl::half>::value,
+      T>;
   template <typename T = void>
-  using EnableIfHostHalf = typename std::enable_if<
+  using EnableIfHostHalf = typename detail::enable_if_t<
       std::is_same<DataT, cl::sycl::detail::half_impl::half>::value &&
           std::is_same<cl::sycl::detail::half_impl::StorageT,
                        cl::sycl::detail::host_half_impl::half>::value,
-      T>::type;
+      T>;
 
   template <typename Ty = DataT>
   explicit vec(const EnableIfNotHostHalf<Ty> &arg) {
@@ -689,10 +689,10 @@ public:
   }
 
   template <typename Ty = DataT>
-  typename std::enable_if<
+  typename detail::enable_if_t<
       std::is_fundamental<Ty>::value ||
-          std::is_same<typename std::remove_const<Ty>::type, half>::value,
-      vec &>::type
+          std::is_same<typename detail::remove_const_t<Ty>, half>::value,
+      vec &>
   operator=(const EnableIfNotHostHalf<Ty> &Rhs) {
     m_Data = (DataType)Rhs;
     return *this;
@@ -705,10 +705,10 @@ public:
   }
 
   template <typename Ty = DataT>
-  typename std::enable_if<
+  typename detail::enable_if_t<
       std::is_fundamental<Ty>::value ||
-          std::is_same<typename std::remove_const<Ty>::type, half>::value,
-      vec &>::type
+          std::is_same<typename detail::remove_const_t<Ty>, half>::value,
+      vec &>
   operator=(const EnableIfHostHalf<Ty> &Rhs) {
     for (int i = 0; i < NumElements; ++i) {
       setValue(i, Rhs);
@@ -723,10 +723,10 @@ public:
   }
 
   template <typename Ty = DataT>
-  typename std::enable_if<
+  typename detail::enable_if_t<
       std::is_fundamental<Ty>::value ||
-          std::is_same<typename std::remove_const<Ty>::type, half>::value,
-      vec &>::type
+          std::is_same<typename detail::remove_const_t<Ty>, half>::value,
+      vec &>
   operator=(const DataT &Rhs) {
     for (int i = 0; i < NumElements; ++i) {
       setValue(i, Rhs);
@@ -742,9 +742,8 @@ public:
   // Helper type to make specific constructors available only for specific
   // number of elements.
   template <int IdxNum, typename T = void>
-  using EnableIfMultipleElems = typename std::enable_if<
-      std::is_convertible<T, DataT>::value && NumElements == IdxNum,
-      DataT>::type;
+  using EnableIfMultipleElems = typename detail::enable_if_t<
+      std::is_convertible<T, DataT>::value && NumElements == IdxNum, DataT>;
   template <typename Ty = DataT>
   vec(const EnableIfMultipleElems<2, Ty> Arg0,
       const EnableIfNotHostHalf<Ty> Arg1)
@@ -792,16 +791,16 @@ public:
 
 #ifdef __SYCL_DEVICE_ONLY__
   template <typename vector_t_ = vector_t,
-            typename = typename std::enable_if<
+            typename = typename detail::enable_if_t<
                 std::is_same<vector_t_, vector_t>::value &&
-                !std::is_same<vector_t_, DataT>::value>::type>
+                !std::is_same<vector_t_, DataT>::value>>
   vec(vector_t openclVector) : m_Data(openclVector) {}
   operator vector_t() const { return m_Data; }
 #endif
 
   // Available only when: NumElements == 1
   template <int N = NumElements>
-  operator typename std::enable_if<N == 1, DataT>::type() const {
+  operator typename detail::enable_if_t<N == 1, DataT>() const {
     return m_Data;
   }
   static constexpr size_t get_count() { return NumElements; }
@@ -946,11 +945,11 @@ public:
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
-  typename std::enable_if<                                                     \
+  typename detail::enable_if_t<                                                \
       std::is_convertible<DataT, T>::value &&                                  \
           (std::is_fundamental<T>::value ||                                    \
-           std::is_same<typename std::remove_const<T>::type, half>::value),    \
-      vec>::type                                                               \
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+      vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
   }                                                                            \
@@ -959,8 +958,8 @@ public:
     return *this;                                                              \
   }                                                                            \
   template <int Num = NumElements>                                             \
-  typename std::enable_if<Num != 1, vec &>::type                               \
-  operator OPASSIGN(const DataT &Rhs) {                                        \
+  typename detail::enable_if_t<Num != 1, vec &> operator OPASSIGN(             \
+      const DataT &Rhs) {                                                      \
     *this = *this BINOP vec(Rhs);                                              \
     return *this;                                                              \
   }
@@ -974,11 +973,11 @@ public:
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
-  typename std::enable_if<                                                     \
+  typename detail::enable_if_t<                                                \
       std::is_convertible<DataT, T>::value &&                                  \
           (std::is_fundamental<T>::value ||                                    \
-           std::is_same<typename std::remove_const<T>::type, half>::value),    \
-      vec>::type                                                               \
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+      vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
   }                                                                            \
@@ -987,7 +986,7 @@ public:
     return *this;                                                              \
   }                                                                            \
   template <int Num = NumElements>                                             \
-  typename std::enable_if<Num != 1, vec &>::type operator OPASSIGN(            \
+  typename detail::enable_if_t<Num != 1, vec &> operator OPASSIGN(             \
       const DataT &Rhs) {                                                      \
     *this = *this BINOP vec(Rhs);                                              \
     return *this;                                                              \
@@ -1033,10 +1032,10 @@ public:
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
-  typename std::enable_if<std::is_convertible<T, DataT>::value &&              \
-                              (std::is_fundamental<T>::value ||                \
-                               std::is_same<T, half>::value),                  \
-                          vec<rel_t, NumElements>>::type                       \
+  typename detail::enable_if_t<std::is_convertible<T, DataT>::value &&         \
+                                   (std::is_fundamental<T>::value ||           \
+                                    std::is_same<T, half>::value),             \
+                               vec<rel_t, NumElements>>                        \
   operator RELLOGOP(const T &Rhs) const {                                      \
     return *this RELLOGOP vec(static_cast<const DataT &>(Rhs));                \
   }
@@ -1050,10 +1049,10 @@ public:
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
-  typename std::enable_if<std::is_convertible<T, DataT>::value &&              \
-                              (std::is_fundamental<T>::value ||                \
-                               std::is_same<T, half>::value),                  \
-                          vec<rel_t, NumElements>>::type                       \
+  typename detail::enable_if_t<std::is_convertible<T, DataT>::value &&         \
+                                   (std::is_fundamental<T>::value ||           \
+                                    std::is_same<T, half>::value),             \
+                               vec<rel_t, NumElements>>                        \
   operator RELLOGOP(const T &Rhs) const {                                      \
     return *this RELLOGOP vec(static_cast<const DataT &>(Rhs));                \
   }
@@ -1091,7 +1090,7 @@ public:
   // Available only when: dataT != cl_float && dataT != cl_double
   // && dataT != cl_half
   template <typename T = DataT>
-  typename std::enable_if<std::is_integral<T>::value, vec>::type
+  typename detail::enable_if_t<std::is_integral<T>::value, vec>
   operator~() const {
 // Use __SYCL_DEVICE_ONLY__ macro because cast to OpenCL vector type is defined
 // by SYCL device compiler only.
@@ -1196,50 +1195,50 @@ private:
 // types: enum cl_float#N , builtin vector float#N, builtin type float.
 #ifdef __SYCL_USE_EXT_VECTOR_TYPE__
   template <int Num = NumElements, typename Ty = int,
-            typename = typename std::enable_if<1 != Num>::type>
+            typename = typename detail::enable_if_t<1 != Num>>
   void setValue(EnableIfNotHostHalf<Ty> Index, const DataT &Value, int) {
     m_Data[Index] = Value;
   }
 
   template <int Num = NumElements, typename Ty = int,
-            typename = typename std::enable_if<1 != Num>::type>
+            typename = typename detail::enable_if_t<1 != Num>>
   DataT getValue(EnableIfNotHostHalf<Ty> Index, int) const {
     return m_Data[Index];
   }
 
   template <int Num = NumElements, typename Ty = int,
-            typename = typename std::enable_if<1 != Num>::type>
+            typename = typename detail::enable_if_t<1 != Num>>
   void setValue(EnableIfHostHalf<Ty> Index, const DataT &Value, int) {
     m_Data.s[Index] = Value;
   }
 
   template <int Num = NumElements, typename Ty = int,
-            typename = typename std::enable_if<1 != Num>::type>
+            typename = typename detail::enable_if_t<1 != Num>>
   DataT getValue(EnableIfHostHalf<Ty> Index, int) const {
     return m_Data.s[Index];
   }
 #else  // __SYCL_USE_EXT_VECTOR_TYPE__
   template <int Num = NumElements,
-            typename = typename std::enable_if<1 != Num>::type>
+            typename = typename detail::enable_if_t<1 != Num>>
   void setValue(int Index, const DataT &Value, int) {
     m_Data.s[Index] = Value;
   }
 
   template <int Num = NumElements,
-            typename = typename std::enable_if<1 != Num>::type>
+            typename = typename detail::enable_if_t<1 != Num>>
   DataT getValue(int Index, int) const {
     return m_Data.s[Index];
   }
 #endif // __SYCL_USE_EXT_VECTOR_TYPE__
 
   template <int Num = NumElements,
-            typename = typename std::enable_if<1 == Num>::type>
+            typename = typename detail::enable_if_t<1 == Num>>
   void setValue(int, const DataT &Value, float) {
     m_Data = Value;
   }
 
   template <int Num = NumElements,
-            typename = typename std::enable_if<1 == Num>::type>
+            typename = typename detail::enable_if_t<1 == Num>>
   DataT getValue(int, float) const {
     return m_Data;
   }
@@ -1369,24 +1368,24 @@ class SwizzleOp {
                             OperationCurrentT_, Idx_...>;
 
   template <int IdxNum, typename T = void>
-  using EnableIfOneIndex = typename std::enable_if<
-      1 == IdxNum && SwizzleOp::getNumElements() == IdxNum, T>::type;
+  using EnableIfOneIndex = typename detail::enable_if_t<
+      1 == IdxNum && SwizzleOp::getNumElements() == IdxNum, T>;
 
   template <int IdxNum, typename T = void>
-  using EnableIfMultipleIndexes = typename std::enable_if<
-      1 != IdxNum && SwizzleOp::getNumElements() == IdxNum, T>::type;
+  using EnableIfMultipleIndexes = typename detail::enable_if_t<
+      1 != IdxNum && SwizzleOp::getNumElements() == IdxNum, T>;
 
   template <typename T>
-  using EnableIfScalarType = typename std::enable_if<
+  using EnableIfScalarType = typename detail::enable_if_t<
       std::is_convertible<DataT, T>::value &&
       (std::is_fundamental<T>::value ||
-       std::is_same<typename std::remove_const<T>::type, half>::value)>::type;
+       std::is_same<typename detail::remove_const_t<T>, half>::value)>;
 
   template <typename T>
-  using EnableIfNoScalarType = typename std::enable_if<
+  using EnableIfNoScalarType = typename detail::enable_if_t<
       !std::is_convertible<DataT, T>::value ||
       !(std::is_fundamental<T>::value ||
-        std::is_same<typename std::remove_const<T>::type, half>::value)>::type;
+        std::is_same<typename detail::remove_const_t<T>, half>::value)>;
 
   template <int... Indices>
   using Swizzle =
@@ -1476,8 +1475,7 @@ public:
 #undef __SYCL_UOP
 
   template <typename T = DataT>
-  typename std::enable_if<std::is_integral<T>::value, vec_t>::type
-  operator~() {
+  typename detail::enable_if_t<std::is_integral<T>::value, vec_t> operator~() {
     vec_t Tmp = *this;
     return ~Tmp;
   }
@@ -1650,8 +1648,8 @@ public:
 
   template <typename T1, typename T2, typename T3, template <typename> class T4,
             int... T5,
-            typename = typename std::enable_if<sizeof...(T5) ==
-                                               getNumElements()>::type>
+            typename =
+                typename detail::enable_if_t<sizeof...(T5) == getNumElements()>>
   SwizzleOp &operator=(const SwizzleOp<T1, T2, T3, T4, T5...> &Rhs) {
     std::array<int, getNumElements()> Idxs{Indexes...};
     for (size_t I = 0; I < Idxs.size(); ++I) {
@@ -1662,8 +1660,8 @@ public:
 
   template <typename T1, typename T2, typename T3, template <typename> class T4,
             int... T5,
-            typename = typename std::enable_if<sizeof...(T5) ==
-                                               getNumElements()>::type>
+            typename =
+                typename detail::enable_if_t<sizeof...(T5) == getNumElements()>>
   SwizzleOp &operator=(SwizzleOp<T1, T2, T3, T4, T5...> &&Rhs) {
     std::array<int, getNumElements()> Idxs{Indexes...};
     for (size_t I = 0; I < Idxs.size(); ++I) {
@@ -1821,7 +1819,7 @@ public:
   }
 
   template <typename asT>
-  typename std::enable_if<asT::getNumElements() == getNumElements(), asT>::type
+  typename detail::enable_if_t<asT::getNumElements() == getNumElements(), asT>
   as() const {
     // First materialize the swizzle to vec_t and then apply as() to it.
     vec_t Tmp = *this;
@@ -1903,10 +1901,10 @@ private:
 #endif
 #define __SYCL_BINOP(BINOP)                                                    \
   template <typename T, int Num>                                               \
-  typename std::enable_if<                                                     \
+  typename detail::enable_if_t<                                                \
       std::is_fundamental<T>::value ||                                         \
-          std::is_same<typename std::remove_const<T>::type, half>::value,      \
-      vec<T, Num>>::type                                                       \
+          std::is_same<typename detail::remove_const_t<T>, half>::value,       \
+      vec<T, Num>>                                                             \
   operator BINOP(const T &Lhs, const vec<T, Num> &Rhs) {                       \
     return vec<T, Num>(Lhs) BINOP Rhs;                                         \
   }                                                                            \
@@ -1914,14 +1912,15 @@ private:
             template <typename> class OperationCurrentT, int... Indexes,       \
             typename T, typename T1 = typename VecT::element_type,             \
             int Num = sizeof...(Indexes)>                                      \
-  typename std::enable_if<                                                     \
+  typename detail::enable_if_t<                                                \
       std::is_convertible<T, T1>::value &&                                     \
           (std::is_fundamental<T>::value ||                                    \
-           std::is_same<typename std::remove_const<T>::type, half>::value),    \
-      vec<T1, Num>>::type                                                      \
-  operator BINOP(const T &Lhs,                                                 \
-                 const detail::SwizzleOp<VecT, OperationLeftT, OperationRightT,\
-                                         OperationCurrentT, Indexes...> &Rhs) {\
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+      vec<T1, Num>>                                                            \
+  operator BINOP(                                                              \
+      const T &Lhs,                                                            \
+      const detail::SwizzleOp<VecT, OperationLeftT, OperationRightT,           \
+                              OperationCurrentT, Indexes...> &Rhs) {           \
     vec<T1, Num> Tmp = Rhs;                                                    \
     return Lhs BINOP Tmp;                                                      \
   }                                                                            \
@@ -1956,11 +1955,11 @@ __SYCL_BINOP(<<)
 #endif
 #define __SYCL_RELLOGOP(RELLOGOP)                                              \
   template <typename T, typename DataT, int Num>                               \
-  typename std::enable_if<                                                     \
+  typename detail::enable_if_t<                                                \
       std::is_convertible<T, DataT>::value &&                                  \
           (std::is_fundamental<T>::value ||                                    \
-           std::is_same<typename std::remove_const<T>::type, half>::value),    \
-      vec<detail::rel_t<DataT>, Num>>::type                                    \
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+      vec<detail::rel_t<DataT>, Num>>                                          \
   operator RELLOGOP(const T &Lhs, const vec<DataT, Num> &Rhs) {                \
     return vec<T, Num>(static_cast<T>(Lhs)) RELLOGOP Rhs;                      \
   }                                                                            \
@@ -1968,11 +1967,11 @@ __SYCL_BINOP(<<)
             template <typename> class OperationCurrentT, int... Indexes,       \
             typename T, typename T1 = typename VecT::element_type,             \
             int Num = sizeof...(Indexes)>                                      \
-  typename std::enable_if<                                                     \
+  typename detail::enable_if_t<                                                \
       std::is_convertible<T, T1>::value &&                                     \
           (std::is_fundamental<T>::value ||                                    \
-           std::is_same<typename std::remove_const<T>::type, half>::value),    \
-      vec<detail::rel_t<T1>, Num>>::type                                       \
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+      vec<detail::rel_t<T1>, Num>>                                             \
   operator RELLOGOP(                                                           \
       const T &Lhs,                                                            \
       const detail::SwizzleOp<VecT, OperationLeftT, OperationRightT,           \

--- a/sycl/source/detail/builtins_geometric.cpp
+++ b/sycl/source/detail/builtins_geometric.cpp
@@ -10,6 +10,7 @@
 // in SYCL SPEC section - 4.13.6 Geometric functions.
 
 #include "builtins_helper.hpp"
+#include <CL/sycl/detail/stl_type_traits.hpp>
 
 #include <cmath>
 
@@ -58,46 +59,47 @@ template <typename T> inline T __FMul(T p0, T p1) {
 }
 
 template <typename T>
-inline typename std::enable_if<d::is_sgengeo<T>::value, T>::type __length(T t) {
+inline typename sycl::detail::enable_if_t<d::is_sgengeo<T>::value, T>
+__length(T t) {
   return std::sqrt(__FMul(t, t));
 }
 
 template <typename T>
-inline typename std::enable_if<d::is_vgengeo<T>::value,
-                               typename T::element_type>::type
+inline typename sycl::detail::enable_if_t<d::is_vgengeo<T>::value,
+                                          typename T::element_type>
 __length(T t) {
   return std::sqrt(Dot(t, t));
 }
 
 template <typename T>
-inline typename std::enable_if<d::is_sgengeo<T>::value, T>::type
+inline typename sycl::detail::enable_if_t<d::is_sgengeo<T>::value, T>
 __normalize(T t) {
   T r = __length(t);
   return t / T(r);
 }
 
 template <typename T>
-inline typename std::enable_if<d::is_vgengeo<T>::value, T>::type
+inline typename sycl::detail::enable_if_t<d::is_vgengeo<T>::value, T>
 __normalize(T t) {
   typename T::element_type r = __length(t);
   return t / T(r);
 }
 
 template <typename T>
-inline typename std::enable_if<d::is_sgengeo<T>::value, T>::type
+inline typename sycl::detail::enable_if_t<d::is_sgengeo<T>::value, T>
 __fast_length(T t) {
   return std::sqrt(__FMul(t, t));
 }
 
 template <typename T>
-inline typename std::enable_if<d::is_vgengeo<T>::value,
-                               typename T::element_type>::type
+inline typename sycl::detail::enable_if_t<d::is_vgengeo<T>::value,
+                                          typename T::element_type>
 __fast_length(T t) {
   return std::sqrt(Dot(t, t));
 }
 
 template <typename T>
-inline typename std::enable_if<d::is_vgengeo<T>::value, T>::type
+inline typename sycl::detail::enable_if_t<d::is_vgengeo<T>::value, T>
 __fast_normalize(T t) {
   if (All(t == T(0.0f)))
     return t;

--- a/sycl/source/detail/builtins_relational.cpp
+++ b/sycl/source/detail/builtins_relational.cpp
@@ -10,6 +10,7 @@
 // in SYCL SPEC section - 4.13.7 Relational functions.
 
 #include "builtins_helper.hpp"
+#include <CL/sycl/detail/stl_type_traits.hpp>
 
 #include <cmath>
 
@@ -76,7 +77,7 @@ template <typename T> inline T __sUnordered(T x, T y) {
 }
 
 template <typename T>
-inline typename std::enable_if<d::is_sgeninteger<T>::value, T>::type
+inline typename sycl::detail::enable_if_t<d::is_sgeninteger<T>::value, T>
 __bitselect(T a, T b, T c) {
   return (a & ~c) | (b & c);
 }
@@ -107,8 +108,8 @@ template <> union databitset<s::cl_half> {
 };
 
 template <typename T>
-typename std::enable_if<d::is_sgenfloat<T>::value, T>::type inline __bitselect(
-    T a, T b, T c) {
+typename sycl::detail::enable_if_t<d::is_sgenfloat<T>::value,
+                                   T> inline __bitselect(T a, T b, T c) {
   databitset<T> ba;
   ba.f = a;
   databitset<T> bb;

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -16,6 +16,7 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/device_filter.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/stl_type_traits.hpp>
 #include <detail/config.hpp>
 #include <detail/global_handler.hpp>
 #include <detail/plugin.hpp>
@@ -566,7 +567,7 @@ RT::PiDeviceBinaryType getBinaryImageFormat(const unsigned char *ImgData,
               {PI_DEVICE_BINARY_TYPE_LLVMIR_BITCODE, 0xDEC04342}};
 
   if (ImgSize >= sizeof(Fmts[0].Magic)) {
-    std::remove_const<decltype(Fmts[0].Magic)>::type Hdr = 0;
+    detail::remove_const_t<decltype(Fmts[0].Magic)> Hdr = 0;
     std::copy(ImgData, ImgData + sizeof(Hdr), reinterpret_cast<char *>(&Hdr));
 
     for (const auto &Fmt : Fmts) {

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -687,9 +687,9 @@ void Scheduler::GraphBuilder::markModifiedIfWrite(MemObjRecord *Record,
 }
 
 template <typename T>
-typename std::enable_if<
-    std::is_same<typename std::remove_cv<T>::type, Requirement>::value,
-    EmptyCommand *>::type
+typename detail::enable_if_t<
+    std::is_same<typename std::remove_cv_t<T>, Requirement>::value,
+    EmptyCommand *>
 Scheduler::GraphBuilder::addEmptyCmd(Command *Cmd, const std::vector<T *> &Reqs,
                                      const QueueImplPtr &Queue,
                                      Command::BlockReason Reason) {

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -582,9 +582,9 @@ protected:
                                        const ContextImplPtr &Context);
 
     template <typename T>
-    typename std::enable_if<
-        std::is_same<typename std::remove_cv<T>::type, Requirement>::value,
-        EmptyCommand *>::type
+    typename detail::enable_if_t<
+        std::is_same<typename std::remove_cv_t<T>, Requirement>::value,
+        EmptyCommand *>
     addEmptyCmd(Command *Cmd, const std::vector<T *> &Req,
                 const QueueImplPtr &Queue, Command::BlockReason Reason);
 


### PR DESCRIPTION
The patch aims to:
1. Facilitate consistent usage of type traits accross the SYCL library.
2. Make a potential switch to C++14 STL type traits easier to perform.

The following traits were affected:
- `enable_if`
- `remove_const`
- `remove_reference`
- `conditional`
- `remove_pointer`
- `remove_cv`

An overview of the changes:
1. Wherever possible, `std::[trait]<>::type` usages were replaced with `detail::[trait]_t<>`.
2. The corresponding `std::[trait]_t<>` usages were also replaced, as we're still supposed to comply with C++11.
3. The type traits-related `#include` directives were slightly re-organized with some removal of obsolete ones.
4. Some duplicating code was removed from `detail/stl_type_traits.hpp`.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>