### PR TITLE
[SYCL[DOC] Add AOT compilation info to GSG

### DIFF
--- a/sycl/doc/CompilerAndRuntimeDesign.md
+++ b/sycl/doc/CompilerAndRuntimeDesign.md
@@ -305,7 +305,7 @@ used:
 `-fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend "-device skl"`
 
 The driver passes the `-device skl` parameter directly to the Gen device backend
-compiler without parsing it.
+compiler `ocloc` without parsing it.
 
 **TBD:** Having multiple code forms for the same target in the fat binary might
 mean invoking device compiler multiple times. Multiple invocations are not

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -280,8 +280,7 @@ command:
 
 [Ahead of time compilation](CompilerAndRuntimeDesign.md#ahead-of-time-aot-compilation)
 requires OpenCL ahead of time compiler available in `PATH`. There is
-AOT compiler for each OpenCL device type (`GPU`, `CPU` and `ACC`
-(accelerator)).
+AOT compiler for each OpenCL device type (`GPU`, `CPU` and `Accelerator`).
 
 #### GPU
 
@@ -310,9 +309,9 @@ AOT compiler for each OpenCL device type (`GPU`, `CPU` and `ACC`
 * AOT CPU compiler `opencl-aot` is enabled by default. For more, see
 [opencl-aot documentation](../../opencl-aot/README.md).
 
-#### ACC
+#### Accelerator
 
-* AOT ACC compiler `aoc` is a part of
+* AOT Accelerator compiler `aoc` is a part of
 [Intel&reg; oneAPI Base Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html)
 (Intel&reg; oneAPI DPC++/C++ Compiler component).  
 Make sure that these binaries are available in `PATH` environment variable:
@@ -486,7 +485,7 @@ the target architecture:
 
 ```-fsycl-targets=spir64_gen-unknown-unknown-sycldevice``` for GPU,  
 ```-fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice``` for CPU,  
-```-fsycl-targets=spir64_fpga-unknown-unknown-sycldevice``` for ACC.
+```-fsycl-targets=spir64_fpga-unknown-unknown-sycldevice``` for Accelerator.
 
 Multiple target architectures are supported.
 

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -279,24 +279,25 @@ command:
 ### Obtain prerequisites for ahead of time (AOT) compilation
 
 [Ahead of time compilation](CompilerAndRuntimeDesign.md#ahead-of-time-aot-compilation)
-requires OpenCL ahead of time compiler available in `PATH`. There is
-AOT compiler for each OpenCL device type (`GPU`, `CPU` and `Accelerator`).
+requires ahead of time compiler available in `PATH`. There is
+AOT compiler for each device type (`GPU`, `CPU` and `Accelerator` (FPGA or
+FPGA emulation)).
 
 #### GPU
 
 * Linux
 
-  There are two ways how to obtain AOT GPU compiler `ocloc`:
+  There are two ways how to obtain GPU AOT compiler `ocloc`:
   * (Ubuntu) Download and install intel-ocloc_***.deb package from
     [intel/compute-runtime releases](https://github.com/intel/compute-runtime/releases).
-    This package should have the same version as OpenCL GPU runtime installed
-    on the system.
+    This package should have the same version as Level Zero / OpenCL GPU
+    runtimes installed on the system.
   * (other distros) `ocloc` is a part of
     [Intel&reg; software packages for general purpose GPU capabilities](https://dgpu-docs.intel.com/index.html).
 
 * Windows
 
-  * AOT GPU compiler `ocloc` is a part of
+  * GPU AOT compiler `ocloc` is a part of
     [Intel&reg; oneAPI Base Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html)
     (Intel&reg; oneAPI DPC++/C++ Compiler component).  
     Make sure that the following path to `ocloc` binary is available in `PATH`
@@ -306,12 +307,12 @@ AOT compiler for each OpenCL device type (`GPU`, `CPU` and `Accelerator`).
 
 #### CPU
 
-* AOT CPU compiler `opencl-aot` is enabled by default. For more, see
+* CPU AOT compiler `opencl-aot` is enabled by default. For more, see
 [opencl-aot documentation](../../opencl-aot/README.md).
 
 #### Accelerator
 
-* AOT Accelerator compiler `aoc` is a part of
+* Accelerator AOT compiler `aoc` is a part of
 [Intel&reg; oneAPI Base Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html)
 (Intel&reg; oneAPI DPC++/C++ Compiler component).  
 Make sure that these binaries are available in `PATH` environment variable:
@@ -480,8 +481,8 @@ clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice \
   simple-sycl-app.cpp -o simple-sycl-app-cuda.exe
 ```
 
-To build simple-sycl-app ahead of time for GPU, CPU or ACC devices, specify
-the target architecture:
+To build simple-sycl-app ahead of time for GPU, CPU or Accelerator devices,
+specify the target architecture:
 
 ```-fsycl-targets=spir64_gen-unknown-unknown-sycldevice``` for GPU,  
 ```-fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice``` for CPU,  
@@ -501,9 +502,9 @@ the DPC++ compiler using ```-Xsycl-target-backend``` option, see
 [Device code formats](CompilerAndRuntimeDesign.md#device-code-formats) for
 more. To find available options, execute:
 
-```bash
-clang++ -fsycl-help
-```
+```ocloc compile --help``` for GPU,
+```opencl-aot --help``` for CPU,
+```aoc -help -sycl``` for Accelerator.
 
 The `simple-sycl-app.exe` application doesn't specify SYCL device for
 execution, so SYCL runtime will use `default_selector` logic to select one

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -280,8 +280,11 @@ command:
 
 [Ahead of time compilation](CompilerAndRuntimeDesign.md#ahead-of-time-aot-compilation)
 requires ahead of time compiler available in `PATH`. There is
-AOT compiler for each device type (`GPU`, `CPU` and `Accelerator` (FPGA or
-FPGA emulation)).
+AOT compiler for each device type:
+
+* `GPU`, Level Zero and OpenCL runtimes are supported,
+* `CPU`, OpenCL runtime is supported,
+* `Accelerator` (FPGA or FPGA emulation), OpenCL runtime is supported.
 
 #### GPU
 


### PR DESCRIPTION
This patch improves DPC++ compiler's Get Started Guide by including
information about obtaining OpenCL AOT compilers and by including
simple example of ahead of time compilation for various devices.