### PR TITLE
[SYCL][NFC] Fix write after free in the CommandsWaitForEvents unit test

### DIFF
--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -71,21 +71,19 @@ TEST_F(SchedulerTest, CommandsWaitForEvents) {
     return;
   }
 
-  queue Q1;
-  queue Q2;
 
-  unittest::PiMock Mock1(Q1);
-  unittest::PiMock Mock2(Q2);
+  platform Plt{Selector};
+  unittest::PiMock Mock{Plt};
 
-  Mock1.redefine<detail::PiApiKind::piEventsWait>(waitFunc);
-  Mock1.redefine<detail::PiApiKind::piEventRetain>(retainReleaseFunc);
-  Mock1.redefine<detail::PiApiKind::piEventRelease>(retainReleaseFunc);
-  Mock1.redefine<detail::PiApiKind::piEventGetInfo>(getEventInfoFunc);
+  Mock.redefine<detail::PiApiKind::piEventsWait>(waitFunc);
+  Mock.redefine<detail::PiApiKind::piEventRetain>(retainReleaseFunc);
+  Mock.redefine<detail::PiApiKind::piEventRelease>(retainReleaseFunc);
+  Mock.redefine<detail::PiApiKind::piEventGetInfo>(getEventInfoFunc);
 
-  Mock2.redefine<detail::PiApiKind::piEventsWait>(waitFunc);
-  Mock2.redefine<detail::PiApiKind::piEventRetain>(retainReleaseFunc);
-  Mock2.redefine<detail::PiApiKind::piEventRelease>(retainReleaseFunc);
-  Mock2.redefine<detail::PiApiKind::piEventGetInfo>(getEventInfoFunc);
+  context Ctx1{Plt};
+  queue Q1{Ctx1, Selector};
+  context Ctx2{Plt};
+  queue Q2{Ctx2, Selector};
 
   TestContext.reset(new TestCtx(Q1, Q2));
 

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -71,7 +71,6 @@ TEST_F(SchedulerTest, CommandsWaitForEvents) {
     return;
   }
 
-
   platform Plt{Selector};
   unittest::PiMock Mock{Plt};
 


### PR DESCRIPTION
The test used to pass two queues with the same platform to two different
PiMock objects. Since it's the platform object that PiMock modifies, the
changes made by the first PiMock were overwritten by the second one.