### PR TITLE
[SYCL] Rename FPGA kernel attribute stall_enable

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1236,8 +1236,8 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
   let PragmaAttributeSupport = 0;
 }
 
-def SYCLIntelStallEnable : InheritableAttr {
-  let Spellings = [CXX11<"intel","stall_enable">];
+def SYCLIntelUseStallEnableClusters : InheritableAttr {
+  let Spellings = [CXX11<"intel","use_stall_enable_clusters">];
   let LangOpts = [SYCLIsHost, SYCLIsDevice];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let AdditionalMembers = [{
@@ -1245,7 +1245,7 @@ def SYCLIntelStallEnable : InheritableAttr {
       return "stall_enable";
     }
   }];
-  let Documentation = [SYCLIntelStallEnableAttrDocs];
+  let Documentation = [SYCLIntelUseStallEnableClustersAttrDocs];
   let PragmaAttributeSupport = 0;
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2241,33 +2241,33 @@ device kernel, the attribute is ignored and it is not propagated to a kernel.
   }];
 }
 
-def SYCLIntelStallEnableAttrDocs : Documentation {
+def SYCLIntelUseStallEnableClustersAttrDocs : Documentation {
   let Category = DocCatFunction;
-  let Heading = "intel::stall_enable";
+  let Heading = "intel::use_stall_enable_clusters";
   let Content = [{
 When applied to a lambda or function call operator (of a function object)
 on device, this requests, to the extent possible, that statically-scheduled
 clusters handle stalls using a stall-enable signal to freeze computation
 within the cluster. This attribute is ignored on the host.
 
-If ``intel::stall_enable`` is applied to a function called from a device
+If ``intel::use_stall_enable_clusters`` is applied to a function called from a device
 kernel, the attribute is ignored and it is not propagated to a kernel.
 
-The ``intel::stall_enable`` attribute takes no argument and has an effect
+The ``intel::use_stall_enable_clusters`` attribute takes no argument and has an effect
 when applied to a function, and no effect otherwise.
 
 .. code-block:: c++
 
   class Functor
   {
-      [[intel::stall_enable]] void operator()(item<1> item)
+      [[intel::use_stall_enable_clusters]] void operator()(item<1> item)
       {
           /* kernel code */
       }
   }
 
   kernel<class kernel_name>(
-  []() [[intel::stall_enable]] {
+  []() [[intel::use_stall_enable_clusters]] {
        /* kernel code */
   });
 

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -166,7 +166,7 @@ public:
         ParsedAttr == AT_SYCLIntelMaxWorkGroupSize ||
         ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim ||
         ParsedAttr == AT_SYCLIntelNoGlobalWorkOffset ||
-        ParsedAttr == AT_SYCLIntelStallEnable)
+        ParsedAttr == AT_SYCLIntelUseStallEnableClusters)
       return true;
 
     return false;

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -677,7 +677,7 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
       Fn->setMetadata("no_global_work_offset", llvm::MDNode::get(Context, {}));
   }
 
-  if (FD->hasAttr<SYCLIntelStallEnableAttr>()) {
+  if (FD->hasAttr<SYCLIntelUseStallEnableClustersAttr>()) {
     llvm::Metadata *AttrMDArgs[] = {
         llvm::ConstantAsMetadata::get(Builder.getInt32(1))};
     Fn->setMetadata("stall_enable", llvm::MDNode::get(Context, AttrMDArgs));

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3029,8 +3029,9 @@ static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
                                                                      E);
 }
 
-// Handles stall_enable
-static void handleStallEnableAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
+// Handles use_stall_enable_clusters
+static void handleUseStallEnableClustersAttr(Sema &S, Decl *D,
+                                             const ParsedAttr &Attr) {
   if (D->isInvalidDecl())
     return;
 
@@ -3040,7 +3041,7 @@ static void handleStallEnableAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
     return;
   }
 
-  handleSimpleAttribute<SYCLIntelStallEnableAttr>(S, D, Attr);
+  handleSimpleAttribute<SYCLIntelUseStallEnableClustersAttr>(S, D, Attr);
 }
 
 // Add scheduler_target_fmax_mhz
@@ -8415,8 +8416,8 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset:
     handleNoGlobalWorkOffsetAttr(S, D, AL);
     break;
-  case ParsedAttr::AT_SYCLIntelStallEnable:
-    handleStallEnableAttr(S, D, AL);
+  case ParsedAttr::AT_SYCLIntelUseStallEnableClusters:
+    handleUseStallEnableClustersAttr(S, D, AL);
     break;
   case ParsedAttr::AT_VecTypeHint:
     handleVecTypeHint(S, D, AL);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -547,8 +547,8 @@ public:
       if (auto *A = FD->getAttr<SYCLSimdAttr>())
         Attrs.insert(A);
 
-      // Allow the kernel attribute "use_stall_enable_clusters" only on lambda functions
-      // and function objects that are called directly from a kernel
+      // Allow the kernel attribute "use_stall_enable_clusters" only on lambda
+      // functions and function objects that are called directly from a kernel
       // (i.e. the one passed to the single_task or parallel_for functions).
       // For all other cases, emit a warning and ignore.
       if (auto *A = FD->getAttr<SYCLIntelUseStallEnableClustersAttr>()) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -547,16 +547,16 @@ public:
       if (auto *A = FD->getAttr<SYCLSimdAttr>())
         Attrs.insert(A);
 
-      // Allow the kernel attribute "stall_enable" only on lambda functions
+      // Allow the kernel attribute "use_stall_enable_clusters" only on lambda functions
       // and function objects that are called directly from a kernel
       // (i.e. the one passed to the single_task or parallel_for functions).
       // For all other cases, emit a warning and ignore.
-      if (auto *A = FD->getAttr<SYCLIntelStallEnableAttr>()) {
+      if (auto *A = FD->getAttr<SYCLIntelUseStallEnableClustersAttr>()) {
         if (ParentFD == SYCLKernel) {
           Attrs.insert(A);
         } else {
           SemaRef.Diag(A->getLocation(), diag::warn_attribute_ignored) << A;
-          FD->dropAttr<SYCLIntelStallEnableAttr>();
+          FD->dropAttr<SYCLIntelUseStallEnableClustersAttr>();
         }
       }
 
@@ -3277,7 +3277,7 @@ void Sema::MarkDevice(void) {
         case attr::Kind::SYCLIntelSchedulerTargetFmaxMhz:
         case attr::Kind::SYCLIntelMaxGlobalWorkDim:
         case attr::Kind::SYCLIntelNoGlobalWorkOffset:
-        case attr::Kind::SYCLIntelStallEnable:
+        case attr::Kind::SYCLIntelUseStallEnableClusters:
         case attr::Kind::SYCLSimd: {
           if ((A->getKind() == attr::Kind::SYCLSimd) && KernelBody &&
               !KernelBody->getAttr<SYCLSimdAttr>()) {

--- a/clang/test/CodeGenSYCL/stall_enable.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable.cpp
@@ -7,7 +7,7 @@ queue q;
 
 class Foo {
 public:
-  [[intel::stall_enable]] void operator()() const {}
+  [[intel::use_stall_enable_clusters]] void operator()() const {}
 };
 
 int main() {
@@ -16,7 +16,7 @@ int main() {
     h.single_task<class test_kernel1>(f);
 
     h.single_task<class test_kernel2>(
-        []() [[intel::stall_enable]]{});
+        []() [[intel::use_stall_enable_clusters]]{});
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/stall_enable.cpp
+++ b/clang/test/SemaSYCL/stall_enable.cpp
@@ -6,31 +6,31 @@
 using namespace cl::sycl;
 queue q;
 
-[[intel::stall_enable]] void test() {} //expected-warning{{'stall_enable' attribute ignored}}
+[[intel::use_stall_enable_clusters]] void test() {} //expected-warning{{'use_stall_enable_clusters' attribute ignored}}
 
 #ifdef TRIGGER_ERROR
-[[intel::stall_enable(1)]] void bar1() {} // expected-error{{'stall_enable' attribute takes no arguments}}
-[[intel::stall_enable]] int N;            // expected-error{{'stall_enable' attribute only applies to functions}}
+[[intel::use_stall_enable_clusters(1)]] void bar1() {} // expected-error{{'use_stall_enable_clusters' attribute takes no arguments}}
+[[intel::use_stall_enable_clusters]] int N;            // expected-error{{'use_stall_enable_clusters' attribute only applies to functions}}
 #endif
 
 struct FuncObj {
-  [[intel::stall_enable]] void operator()() const {}
+  [[intel::use_stall_enable_clusters]] void operator()() const {}
 };
 
 int main() {
   q.submit([&](handler &h) {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel1
-    // CHECK:       SYCLIntelStallEnableAttr {{.*}}
+    // CHECK:       SYCLIntelUseStallEnableClustersAttr {{.*}}
     h.single_task<class test_kernel1>(
         FuncObj());
 
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel2
-    // CHECK:       SYCLIntelStallEnableAttr {{.*}}
+    // CHECK:       SYCLIntelUseStallEnableClustersAttr {{.*}}
     h.single_task<class test_kernel2>(
-        []() [[intel::stall_enable]]{});
+        []() [[intel::use_stall_enable_clusters]]{});
 
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
-    // CHECK-NOT:   SYCLIntelStallEnableAttr {{.*}}
+    // CHECK-NOT:   SYCLIntelUseStallEnableClustersAttr {{.*}}
     h.single_task<class test_kernel3>(
         []() { test(); });
   });


### PR DESCRIPTION
The FPGA kernel attribute [[intel::stall_enable]] should be
renamed to [[intel::use_stall_enable_clusters]] for SYCL to
be consistent with the name used in OpenCL and HLS.

There is no need to formally deprecate the old name, because
users have not had a chance to use the old name yet.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>