### PR TITLE
[SYCL] Fix hang in deallocateStreams function

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -189,8 +189,8 @@ void Scheduler::cleanupFinishedCommands(EventImplPtr FinishedEvent) {
       if (FinishedCmd)
         MGraphBuilder.cleanupFinishedCommands(FinishedCmd, StreamsToDeallocate);
     }
-    deallocateStreams(StreamsToDeallocate);
   }
+  deallocateStreams(StreamsToDeallocate);
 }
 
 void Scheduler::removeMemoryObject(detail::SYCLMemObjI *MemObj) {
@@ -226,9 +226,9 @@ void Scheduler::removeMemoryObject(detail::SYCLMemObjI *MemObj) {
       MGraphBuilder.decrementLeafCountersForRecord(Record);
       MGraphBuilder.cleanupCommandsForRecord(Record, StreamsToDeallocate);
       MGraphBuilder.removeRecordForMemObj(MemObj);
-      deallocateStreams(StreamsToDeallocate);
     }
   }
+  deallocateStreams(StreamsToDeallocate);
 }
 
 EventImplPtr Scheduler::addHostAccessor(Requirement *Req) {
@@ -276,13 +276,13 @@ void Scheduler::enqueueLeavesOfReqUnlocked(const Requirement *const Req) {
 void Scheduler::allocateStreamBuffers(stream_impl *Impl,
                                       size_t StreamBufferSize,
                                       size_t FlushBufferSize) {
-  std::lock_guard<std::mutex> lock(StreamBuffersPoolMutex);
+  std::lock_guard<std::recursive_mutex> lock(StreamBuffersPoolMutex);
   StreamBuffersPool.insert(
       {Impl, new StreamBuffers(StreamBufferSize, FlushBufferSize)});
 }
 
 void Scheduler::deallocateStreamBuffers(stream_impl *Impl) {
-  std::lock_guard<std::mutex> lock(StreamBuffersPoolMutex);
+  std::lock_guard<std::recursive_mutex> lock(StreamBuffersPoolMutex);
   delete StreamBuffersPool[Impl];
   StreamBuffersPool.erase(Impl);
 }
@@ -302,7 +302,7 @@ Scheduler::~Scheduler() {
   // the kernel. Otherwise resources for stream will not be released, issue a
   // warning in this case.
   if (pi::trace(pi::TraceLevel::PI_TRACE_BASIC)) {
-    std::lock_guard<std::mutex> lock(StreamBuffersPoolMutex);
+    std::lock_guard<std::recursive_mutex> lock(StreamBuffersPoolMutex);
     if (!StreamBuffersPool.empty())
       fprintf(
           stderr,

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -189,8 +189,8 @@ void Scheduler::cleanupFinishedCommands(EventImplPtr FinishedEvent) {
       if (FinishedCmd)
         MGraphBuilder.cleanupFinishedCommands(FinishedCmd, StreamsToDeallocate);
     }
+    deallocateStreams(StreamsToDeallocate);
   }
-  deallocateStreams(StreamsToDeallocate);
 }
 
 void Scheduler::removeMemoryObject(detail::SYCLMemObjI *MemObj) {
@@ -226,9 +226,9 @@ void Scheduler::removeMemoryObject(detail::SYCLMemObjI *MemObj) {
       MGraphBuilder.decrementLeafCountersForRecord(Record);
       MGraphBuilder.cleanupCommandsForRecord(Record, StreamsToDeallocate);
       MGraphBuilder.removeRecordForMemObj(MemObj);
+      deallocateStreams(StreamsToDeallocate);
     }
   }
-  deallocateStreams(StreamsToDeallocate);
 }
 
 EventImplPtr Scheduler::addHostAccessor(Requirement *Req) {

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -766,7 +766,7 @@ protected:
   friend class stream_impl;
 
   // Protects stream buffers pool
-  std::mutex StreamBuffersPoolMutex;
+  std::recursive_mutex StreamBuffersPoolMutex;
 
   // We need to store a pointer to the structure with stream buffers because we
   // want to avoid a situation when buffers are destructed during destruction of


### PR DESCRIPTION
This patch fixes hang caused by deadlock in 
`Scheduler::deallocateStreamBuffers` function. Deadlock was
happened when `StreamBuffersPool[Impl]` had been being
deleted.
`StreamBuffersPool[Impl]` is a pointer to `StreamBuffers` struct
object which has `buffer` object as a field, so the dtor of `buffer`
class was called. After that the call stack is the following: 
`~buffer_impl()` -> `SYCLMemObjT::updateHostMemory()` -> 
`Scheduler::removeMemoryObject` ->`deallocateStreams` -> 
`Scheduler::deallocateStreamBuffers` -> deadlock in 
`lock_guard`, mutex was already locked by the same thread.

Changed `std::mutex` to `std::recursive_mutex`, so now 
the same thread can enter the critical section, locked by 
itself before.