### PR TITLE
[SYCL][L0] Proposal for new device descriptors for Intel GPU devices

### DIFF
--- a/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
+++ b/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
@@ -1,0 +1,113 @@
+# SYCL(TM) Proposal: New device descriptors for Intel GPUs
+
+**IMPORTANT**: This specification is a draft.
+
+**NOTE**: Khronos(R) is a registered trademark and SYCL(TM) is a trademark of the Khronos Group, Inc.
+
+An internal team at Intel has requested a new device descriptors to provide access to low-level hardware details about Intel GPU devices.  This information will be useful to developers tuning specifically for those devices.
+
+This proposal details what is required to provide this information as a SYCL extensions.
+
+## Feature Test Macro ##
+
+The same Feature Test Macro will be used for the new device descriptor support.  It will be defined as:
+
+    #define SYCL_EXT_INTEL_GPU_DEVICE_INFO 1
+
+
+
+# Intel GPU PCI Address #
+
+A new device descriptor will be added which will provide the PCI address of an Intel GPU in BDF format.  BDF format contains the address as: `domain:bus:device.function`.
+
+This support can only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.  The OpenCL BE does not provide the PCI address at this time.
+
+
+## Device Information Descriptors ##
+
+| Device Descriptors | Return Type | Description |
+| ------------------ | ----------- | ----------- |
+| info\:\:device\:\:ext\_intel\_gpu\_pci\_address | std\:\:string | For Level Zero BE, returns the PCI address in BDF format: `domain:bus:device.function`.|
+
+
+## Aspects ##
+
+A new aspect, ext\_intel\_gpu\_pci\_address, will be added.
+
+## Error Condition ##
+
+The function device\:\:get_info\(\) will return an empty string if the device does not support aspect\:\:ext\_intel\_gpu\_pci\_address.
+
+
+## Example Usage ##
+
+The PCI address can be obtained using the standard get\_info() interface.
+
+    if (dev.has(aspect::ext_intel_gpu_pci_address) {
+      auto BDF = dev.get_info<info::device::ext_intel_gpu_pci_address>();
+    }
+
+
+
+# Intel GPU Execution Unit SIMD Width #
+
+A new device descriptor will be added which will provide the physical SIMD width of an execution unit on an Intel GPU.  This data will be used to calculate the computational capabilities of the device.
+
+This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.  The OpenCL BE does not provide the physical SIMD width at this time.
+
+## Device Information Descriptors ##
+
+| Device Descriptors | Return Type | Description |
+| ------------------ | ----------- | ----------- |
+| info\:\:device\:\:ext\_intel\_gpu\_eu\_simd\_width | uint32\_t| Returns the physical SIMD width of the  execution unit (EU).|
+
+
+## Aspects ##
+
+A new aspect, ext\_intel\_gpu\_eu\_simd\_width, will be added.
+
+
+## Error Condition ##
+
+The function device\:\:get_info\(\) will return PI\_INVALID\_VALUE if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_simd\_width.
+
+## Example Usage ##
+
+The physical EU SIMD width can be obtained using the standard get\_info() interface.
+
+    if (dev.has(aspect::ext_intel_gpu_eu_simd_width) {
+        auto euSimdWidth = dev.get_info<info::device::ext_intel_gpu_eu_simd_width>();
+    }
+
+
+# Intel GPU Execution Unit Count #
+
+A new device descriptor will be added which will provide the number of execution units on an Intel GPU.  If the device is a subdevice, then the number of EUs in the subdevice is returned.
+
+This new device descriptor will provide the same information as "max\_compute\_units" does today.  We would like to have an API which is specific for Intel GPUs.
+
+This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+
+## Device Information Descriptors ##
+
+| Device Descriptors | Return Type | Description |
+| ------------------ | ----------- | ----------- |
+| info\:\:device\:\:ext\_intel\_gpu\__eu\_count | uint32\_t| Returns the number of execution units (EUs) associated with the Intel GPU.|
+
+
+## Aspects ##
+
+A new aspect, ext\_intel\_gpu\_eu\_count, will be added.
+
+
+## Error Condition ##
+
+The function device\:\:get_info\(\) will return PI\_INVALID\_VALUE if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_count.
+
+## Example Usage ##
+
+Then the number of EUs can be obtained using the standard get\_info() interface.
+
+    if (dev.has(aspect::ext_intel_gpu_eu_count) {
+      auto euCount = dev.get_info<info::device::ext_intel_gpu_eu_count>();
+    }

--- a/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
+++ b/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
@@ -36,14 +36,14 @@ A new aspect, ext\_intel\_gpu\_pci\_address, will be added.
 
 ## Error Condition ##
 
-The function device\:\:get_info\(\) will return an empty string if the device does not support aspect\:\:ext\_intel\_gpu\_pci\_address.
+An exception will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_pci\_address.
 
 
 ## Example Usage ##
 
 The PCI address can be obtained using the standard get\_info() interface.
 
-    if (dev.has(aspect::ext_intel_gpu_pci_address) {
+    if (dev.has(aspect::ext_intel_gpu_pci_address)) {
       auto BDF = dev.get_info<info::device::ext_intel_gpu_pci_address>();
     }
 
@@ -69,13 +69,13 @@ A new aspect, ext\_intel\_gpu\_eu\_simd\_width, will be added.
 
 ## Error Condition ##
 
-The function device\:\:get_info\(\) will return PI\_INVALID\_VALUE if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_simd\_width.
+An exception will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_simd\_width.
 
 ## Example Usage ##
 
 The physical EU SIMD width can be obtained using the standard get\_info() interface.
 
-    if (dev.has(aspect::ext_intel_gpu_eu_simd_width) {
+    if (dev.has(aspect::ext_intel_gpu_eu_simd_width)) {
         auto euSimdWidth = dev.get_info<info::device::ext_intel_gpu_eu_simd_width>();
     }
 
@@ -102,12 +102,12 @@ A new aspect, ext\_intel\_gpu\_eu\_count, will be added.
 
 ## Error Condition ##
 
-The function device\:\:get_info\(\) will return PI\_INVALID\_VALUE if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_count.
+An exception will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_count.
 
 ## Example Usage ##
 
 Then the number of EUs can be obtained using the standard get\_info() interface.
 
-    if (dev.has(aspect::ext_intel_gpu_eu_count) {
+    if (dev.has(aspect::ext_intel_gpu_eu_count)) {
       auto euCount = dev.get_info<info::device::ext_intel_gpu_eu_count>();
     }

--- a/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
+++ b/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
@@ -218,7 +218,7 @@ This support will only be provided when using the Level Zero backend \(BE\).  Th
 
 | Device Descriptors | Return Type | Description |
 | ------------------ | ----------- | ----------- |
-| info\:\:device\:\:ext\_intel\_max\_mem\_bandwidth | uint64\_t| Returns the maximum memory bandwidth.|
+| info\:\:device\:\:ext\_intel\_max\_mem\_bandwidth | uint64\_t| Returns the maximum memory bandwidth in units of bytes\/second.|
 
 
 ## Aspects ##

--- a/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
+++ b/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
@@ -1,4 +1,4 @@
-# SYCL(TM) Proposal: New device descriptors for Intel GPUs
+# SYCL(TM) Proposal: Intel's Extensions for Device Information
 
 **IMPORTANT**: This specification is a draft.
 

--- a/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
+++ b/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
@@ -8,6 +8,12 @@ New device descriptors will be added to provide access to low-level hardware det
 
 This proposal details what is required to provide this information as a SYCL extensions.
 
+## Feature Test Macro ##
+
+The Feature Test Macro will be defined as:
+
+    #define SYCL_EXT_INTEL_DEVICE_INFO 1
+
 
 
 # Intel GPU PCI Address #
@@ -41,12 +47,6 @@ The PCI address can be obtained using the standard get\_info() interface.
       auto BDF = dev.get_info<info::device::ext_intel_pci_address>();
     }
 
-## Feature Test Macro ##
-
-The Feature Test Macro will be defined as:
-
-    #define SYCL_EXT_INTEL_DEVICE_INFO 1
-
 
 
 # Intel GPU Execution Unit SIMD Width #
@@ -79,11 +79,6 @@ The physical EU SIMD width can be obtained using the standard get\_info() interf
         auto euSimdWidth = dev.get_info<info::device::ext_intel_gpu_eu_simd_width>();
     }
 
-## Feature Test Macro ##
-
-The Feature Test Macro will be defined as:
-
-    #define SYCL_EXT_INTEL_GPU_DEVICE_INFO 1
 
 
 # Intel GPU Execution Unit Count #
@@ -118,8 +113,127 @@ Then the number of EUs can be obtained using the standard get\_info() interface.
       auto euCount = dev.get_info<info::device::ext_intel_gpu_eu_count>();
     }
 
-## Feature Test Macro ##
 
-The Feature Test Macro will be defined as:
 
-    #define SYCL_EXT_INTEL_GPU_DEVICE_INFO 1
+# Intel GPU Number of Slices #
+
+A new device descriptor will be added which will provide the number of slices on an Intel GPU.  If the device is a subdevice, then the number of slices in the subdevice is returned.
+
+This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+
+## Device Information Descriptors ##
+
+| Device Descriptors | Return Type | Description |
+| ------------------ | ----------- | ----------- |
+| info\:\:device\:\:ext\_intel\_gpu\_slices | uint32\_t| Returns the number of slices.|
+
+
+## Aspects ##
+
+A new aspect, ext\_intel\_gpu\_slices, will be added.
+
+
+## Error Condition ##
+
+An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_slices.
+
+## Example Usage ##
+
+Then the number of slices can be obtained using the standard get\_info() interface.
+
+    if (dev.has(aspect::ext_intel_gpu_slices)) {
+      auto slices = dev.get_info<info::device::ext_intel_gpu_slices>();
+    }
+
+
+# Intel GPU Number of Subslices per Slice #
+
+A new device descriptor will be added which will provide the number of subslices per slice on an Intel GPU.  If the device is a subdevice, then the number of subslices per slice in the subdevice is returned.
+
+This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+
+## Device Information Descriptors ##
+
+| Device Descriptors | Return Type | Description |
+| ------------------ | ----------- | ----------- |
+| info\:\:device\:\:ext\_intel\_gpu\_subslices\_per\_slice | uint32\_t| Returns the number of subslices per slice.|
+
+
+## Aspects ##
+
+A new aspect, ext\_intel\_gpu\_subslices\_per\_slice, will be added.
+
+
+## Error Condition ##
+
+An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_subslices\_per\_slice.
+
+## Example Usage ##
+
+Then the number of subslices per slice can be obtained using the standard get\_info() interface.
+
+    if (dev.has(aspect::ext_intel_gpu_subslices_per_slice)) {
+      auto subslices = dev.get_info<info::device::ext_intel_gpu_subslices_per_slice>();
+    }
+
+
+# Intel GPU Number of Execution Units (EUs) per Subslice #
+
+A new device descriptor will be added which will provide the number of EUs per subslice on an Intel GPU.  If the device is a subdevice, then the number of EUs per subslice in the subdevice is returned.
+
+This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+
+## Device Information Descriptors ##
+
+| Device Descriptors | Return Type | Description |
+| ------------------ | ----------- | ----------- |
+| info\:\:device\:\:ext\_intel\_gpu\_eu\_count\_per\_subslice | uint32\_t| Returns the number of EUs in a subslice.|
+
+
+## Aspects ##
+
+A new aspect, ext\_intel\_gpu\_eu\_count\_per\_subslice, will be added.
+
+
+## Error Condition ##
+
+An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_count\_per\_subslice.
+
+## Example Usage ##
+
+Then the number of EUs per subslice can be obtained using the standard get\_info() interface.
+
+    if (dev.has(aspect::ext_intel_gpu_eu_count_per_subslice)) {
+      auto euCount = dev.get_info<info::device::ext_intel_gpu_eu_count_per_subslice>();
+    }
+
+
+# Intel GPU Maximum Memory Bandwidth #
+
+A new device descriptor will be added which will provide the maximum memory bandwidth of an Intel GPU.  If the device is a subdevice, then the maximum bandwidth of the subdevice is returned.
+
+This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+
+## Device Information Descriptors ##
+
+| Device Descriptors | Return Type | Description |
+| ------------------ | ----------- | ----------- |
+| info\:\:device\:\:ext\_intel\_max\_mem\_bandwidth | uint64\_t| Returns the maximum memory bandwidth.|
+
+
+## Aspects ##
+
+A new aspect, ext\_intel\_max\_mem\_bandwidth, will be added.
+
+
+## Error Condition ##
+
+An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_max\_mem\_bandwidth.
+
+## Example Usage ##
+
+Then the maximum memory bandwidth can be obtained using the standard get\_info() interface.
+
+    if (dev.has(aspect::ext_intel_max_mem_bandwidth)) {
+      auto maxBW = dev.get_info<info::device::ext_intel_max_mem_bandwidth>();
+    }

--- a/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
+++ b/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
@@ -36,7 +36,7 @@ A new aspect, ext\_intel\_gpu\_pci\_address, will be added.
 
 ## Error Condition ##
 
-An exception will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_pci\_address.
+An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_pci\_address.
 
 
 ## Example Usage ##
@@ -69,7 +69,7 @@ A new aspect, ext\_intel\_gpu\_eu\_simd\_width, will be added.
 
 ## Error Condition ##
 
-An exception will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_simd\_width.
+An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_simd\_width.
 
 ## Example Usage ##
 
@@ -102,7 +102,7 @@ A new aspect, ext\_intel\_gpu\_eu\_count, will be added.
 
 ## Error Condition ##
 
-An exception will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_count.
+An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_eu\_count.
 
 ## Example Usage ##
 

--- a/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
+++ b/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
@@ -4,7 +4,7 @@
 
 **NOTE**: Khronos(R) is a registered trademark and SYCL(TM) is a trademark of the Khronos Group, Inc.
 
-An internal team at Intel has requested a new device descriptors to provide access to low-level hardware details about Intel GPU devices.  This information will be useful to developers tuning specifically for those devices.
+New device descriptors will be added to provide access to low-level hardware details about Intel GPU devices.  This information will be useful to developers tuning specifically for those devices.
 
 This proposal details what is required to provide this information as a SYCL extensions.
 

--- a/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
+++ b/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
@@ -16,11 +16,11 @@ The Feature Test Macro will be defined as:
 
 
 
-# Intel GPU PCI Address #
+# PCI Address #
 
-A new device descriptor will be added which will provide the PCI address of an Intel GPU in BDF format.  BDF format contains the address as: `domain:bus:device.function`.
+A new device descriptor will be added which will provide the PCI address in BDF format.  BDF format contains the address as: `domain:bus:device.function`.
 
-This support can only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.  The OpenCL BE does not provide the PCI address at this time.
+This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform.
 
 
 ## Device Information Descriptors ##
@@ -53,7 +53,8 @@ The PCI address can be obtained using the standard get\_info() interface.
 
 A new device descriptor will be added which will provide the physical SIMD width of an execution unit on an Intel GPU.  This data will be used to calculate the computational capabilities of the device.
 
-This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.  The OpenCL BE does not provide the physical SIMD width at this time.
+This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform.
+
 
 ## Device Information Descriptors ##
 
@@ -87,7 +88,8 @@ A new device descriptor will be added which will provide the number of execution
 
 This new device descriptor will provide the same information as "max\_compute\_units" does today.  We would like to have an API which is specific for Intel GPUs.
 
-This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform.
+
 
 ## Device Information Descriptors ##
 
@@ -119,7 +121,8 @@ Then the number of EUs can be obtained using the standard get\_info() interface.
 
 A new device descriptor will be added which will provide the number of slices on an Intel GPU.  If the device is a subdevice, then the number of slices in the subdevice is returned.
 
-This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform.
+
 
 ## Device Information Descriptors ##
 
@@ -150,7 +153,8 @@ Then the number of slices can be obtained using the standard get\_info() interfa
 
 A new device descriptor will be added which will provide the number of subslices per slice on an Intel GPU.  If the device is a subdevice, then the number of subslices per slice in the subdevice is returned.
 
-This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform.
+
 
 ## Device Information Descriptors ##
 
@@ -181,7 +185,8 @@ Then the number of subslices per slice can be obtained using the standard get\_i
 
 A new device descriptor will be added which will provide the number of EUs per subslice on an Intel GPU.  If the device is a subdevice, then the number of EUs per subslice in the subdevice is returned.
 
-This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform.
+
 
 ## Device Information Descriptors ##
 
@@ -208,11 +213,12 @@ Then the number of EUs per subslice can be obtained using the standard get\_info
     }
 
 
-# Intel GPU Maximum Memory Bandwidth #
+# Maximum Memory Bandwidth #
 
-A new device descriptor will be added which will provide the maximum memory bandwidth of an Intel GPU.  If the device is a subdevice, then the maximum bandwidth of the subdevice is returned.
+A new device descriptor will be added which will provide the maximum memory bandwidth.  If the device is a subdevice, then the maximum bandwidth of the subdevice is returned.
 
-This support will only be provided when using the Level Zero backend \(BE\).  This is the default for Intel GPUs.
+This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform.
+
 
 ## Device Information Descriptors ##
 
@@ -229,6 +235,7 @@ A new aspect, ext\_intel\_max\_mem\_bandwidth, will be added.
 ## Error Condition ##
 
 An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_max\_mem\_bandwidth.
+
 
 ## Example Usage ##
 

--- a/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
+++ b/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
@@ -8,12 +8,6 @@ New device descriptors will be added to provide access to low-level hardware det
 
 This proposal details what is required to provide this information as a SYCL extensions.
 
-## Feature Test Macro ##
-
-The same Feature Test Macro will be used for the new device descriptor support.  It will be defined as:
-
-    #define SYCL_EXT_INTEL_GPU_DEVICE_INFO 1
-
 
 
 # Intel GPU PCI Address #
@@ -27,25 +21,31 @@ This support can only be provided when using the Level Zero backend \(BE\).  Thi
 
 | Device Descriptors | Return Type | Description |
 | ------------------ | ----------- | ----------- |
-| info\:\:device\:\:ext\_intel\_gpu\_pci\_address | std\:\:string | For Level Zero BE, returns the PCI address in BDF format: `domain:bus:device.function`.|
+| info\:\:device\:\:ext\_intel\_pci\_address | std\:\:string | For Level Zero BE, returns the PCI address in BDF format: `domain:bus:device.function`.|
 
 
 ## Aspects ##
 
-A new aspect, ext\_intel\_gpu\_pci\_address, will be added.
+A new aspect, ext\_intel\_pci\_address, will be added.
 
 ## Error Condition ##
 
-An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_gpu\_pci\_address.
+An invalid object runtime error will be thrown if the device does not support aspect\:\:ext\_intel\_pci\_address.
 
 
 ## Example Usage ##
 
 The PCI address can be obtained using the standard get\_info() interface.
 
-    if (dev.has(aspect::ext_intel_gpu_pci_address)) {
-      auto BDF = dev.get_info<info::device::ext_intel_gpu_pci_address>();
+    if (dev.has(aspect::ext_intel_pci_address)) {
+      auto BDF = dev.get_info<info::device::ext_intel_pci_address>();
     }
+
+## Feature Test Macro ##
+
+The Feature Test Macro will be defined as:
+
+    #define SYCL_EXT_INTEL_DEVICE_INFO 1
 
 
 
@@ -79,6 +79,12 @@ The physical EU SIMD width can be obtained using the standard get\_info() interf
         auto euSimdWidth = dev.get_info<info::device::ext_intel_gpu_eu_simd_width>();
     }
 
+## Feature Test Macro ##
+
+The Feature Test Macro will be defined as:
+
+    #define SYCL_EXT_INTEL_GPU_DEVICE_INFO 1
+
 
 # Intel GPU Execution Unit Count #
 
@@ -111,3 +117,9 @@ Then the number of EUs can be obtained using the standard get\_info() interface.
     if (dev.has(aspect::ext_intel_gpu_eu_count)) {
       auto euCount = dev.get_info<info::device::ext_intel_gpu_eu_count>();
     }
+
+## Feature Test Macro ##
+
+The Feature Test Macro will be defined as:
+
+    #define SYCL_EXT_INTEL_GPU_DEVICE_INFO 1


### PR DESCRIPTION
This proposal details what is required to expose some low-level details of hardware devices as a SYCL extension.

Signed-off-by: Gail Lyons <gail.lyons@intel.com>