### PR TITLE
[SYCL] Fix build with --shared-libs flag enabled

### DIFF
--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -52,6 +52,10 @@ add_llvm_component_library(LLVMSYCLLowerIR
   LLVMGenXIntrinsics
   LLVMDemangle
   LLVMTransformUtils
+  
+  LINK_COMPONENTS
+  Core
+  Support
   )
 
 target_include_directories(LLVMSYCLLowerIR


### PR DESCRIPTION
The patch fixes regression introduced by 9218ff50.