### PR TITLE
simple discard_write optimization for LevelZero .

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -4126,7 +4126,8 @@ piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer, pi_bool BlockingMap,
     piEventsWait(NumEventsInWaitList, EventWaitList);
     if (Buffer->MapHostPtr) {
       *RetMap = Buffer->MapHostPtr + Offset;
-      memcpy(*RetMap, pi_cast<char *>(Buffer->getZeHandle()) + Offset, Size);
+      if (!(MapFlags & CL_MAP_WRITE_INVALIDATE_REGION))
+        memcpy(*RetMap, pi_cast<char *>(Buffer->getZeHandle()) + Offset, Size);
     } else {
       *RetMap = pi_cast<char *>(Buffer->getZeHandle()) + Offset;
     }

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -357,8 +357,8 @@ Command *Scheduler::GraphBuilder::insertMemoryMove(MemObjRecord *Record,
     // by copying specific range from host to device and backwards.
     NewCmd =
         new MemCpyCommand(*AllocaCmdSrc->getRequirement(), AllocaCmdSrc,
-                          *Req, AllocaCmdDst,
-                          AllocaCmdSrc->getQueue(), AllocaCmdDst->getQueue());
+                          *Req, AllocaCmdDst, AllocaCmdSrc->getQueue(),
+                          AllocaCmdDst->getQueue());
   }
 
   for (Command *Dep : Deps) {

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -355,10 +355,9 @@ Command *Scheduler::GraphBuilder::insertMemoryMove(MemObjRecord *Record,
 
     // Full copy of buffer is needed to avoid loss of data that may be caused
     // by copying specific range from host to device and backwards.
-    NewCmd =
-        new MemCpyCommand(*AllocaCmdSrc->getRequirement(), AllocaCmdSrc,
-                          *Req, AllocaCmdDst, AllocaCmdSrc->getQueue(),
-                          AllocaCmdDst->getQueue());
+    NewCmd = new MemCpyCommand(*AllocaCmdSrc->getRequirement(), AllocaCmdSrc,
+                               *Req, AllocaCmdDst, AllocaCmdSrc->getQueue(),
+                               AllocaCmdDst->getQueue());
   }
 
   for (Command *Dep : Deps) {

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -357,7 +357,7 @@ Command *Scheduler::GraphBuilder::insertMemoryMove(MemObjRecord *Record,
     // by copying specific range from host to device and backwards.
     NewCmd =
         new MemCpyCommand(*AllocaCmdSrc->getRequirement(), AllocaCmdSrc,
-                          *AllocaCmdDst->getRequirement(), AllocaCmdDst,
+                          *Req, AllocaCmdDst,
                           AllocaCmdSrc->getQueue(), AllocaCmdDst->getQueue());
   }
 


### PR DESCRIPTION
When discard_write (ie CL_MAP_WRITE_INVALIDATE_REGION) flag is being used, we do not need to perform a memcpy. Can result in significant peformance improvement when using discard_write access mode flag and LevelZero

Signed-off-by: Chris Perkins <chris.perkins@intel.com>