### PR TITLE
[SYCL] Fix instantiation after specialization warning

### DIFF
--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -6,12 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl/detail/common.hpp>
-#include <CL/sycl/info/info_desc.hpp>
-#include <CL/sycl/program.hpp>
 #include <detail/context_impl.hpp>
 #include <detail/kernel_impl.hpp>
-#include <detail/kernel_info.hpp>
 #include <detail/program_impl.hpp>
 
 #include <memory>
@@ -63,121 +59,6 @@ kernel_impl::~kernel_impl() {
   }
 }
 
-template <info::kernel param>
-typename info::param_traits<info::kernel, param>::return_type
-kernel_impl::get_info() const {
-  if (is_host()) {
-    // TODO implement
-    assert(0 && "Not implemented");
-  }
-  return get_kernel_info<
-      typename info::param_traits<info::kernel, param>::return_type,
-      param>::get(this->getHandleRef(), getPlugin());
-}
-
-template <> context kernel_impl::get_info<info::kernel::context>() const {
-  return createSyclObjFromImpl<context>(MContext);
-}
-
-template <> program kernel_impl::get_info<info::kernel::program>() const {
-  return createSyclObjFromImpl<program>(MProgramImpl);
-}
-
-template <info::kernel_device_specific param>
-typename info::param_traits<info::kernel_device_specific, param>::return_type
-kernel_impl::get_info(const device &Device) const {
-  if (is_host()) {
-    return get_kernel_device_specific_info_host<param>(Device);
-  }
-  return get_kernel_device_specific_info<
-      typename info::param_traits<info::kernel_device_specific,
-                                  param>::return_type,
-      param>::get(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(),
-                  getPlugin());
-}
-
-template <info::kernel_device_specific param>
-typename info::param_traits<info::kernel_device_specific, param>::return_type
-kernel_impl::get_info(
-    const device &Device,
-    typename info::param_traits<info::kernel_device_specific, param>::input_type
-        Value) const {
-  if (is_host()) {
-    throw runtime_error("Sub-group feature is not supported on HOST device.",
-                        PI_INVALID_DEVICE);
-  }
-  return get_kernel_device_specific_info_with_input<param>::get(
-      this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(), Value,
-      getPlugin());
-}
-
-template <info::kernel_work_group param>
-typename info::param_traits<info::kernel_work_group, param>::return_type
-kernel_impl::get_work_group_info(const device &Device) const {
-  return get_info<
-      info::compatibility_param_traits<info::kernel_work_group, param>::value>(
-      Device);
-}
-
-template <info::kernel_sub_group param>
-typename info::param_traits<info::kernel_sub_group, param>::return_type
-kernel_impl::get_sub_group_info(const device &Device) const {
-  return get_info<
-      info::compatibility_param_traits<info::kernel_sub_group, param>::value>(
-      Device);
-}
-
-template <info::kernel_sub_group param>
-typename info::param_traits<info::kernel_sub_group, param>::return_type
-kernel_impl::get_sub_group_info(
-    const device &Device,
-    typename info::param_traits<info::kernel_sub_group, param>::input_type
-        Value) const {
-  return get_info<
-      info::compatibility_param_traits<info::kernel_sub_group, param>::value>(
-      Device, Value);
-}
-
-#define __SYCL_PARAM_TRAITS_SPEC(param_type, param, ret_type)                  \
-  template ret_type kernel_impl::get_info<info::param_type::param>() const;
-
-#include <CL/sycl/info/kernel_traits.def>
-
-#undef __SYCL_PARAM_TRAITS_SPEC
-
-#define __SYCL_PARAM_TRAITS_SPEC(param_type, param, ret_type)                  \
-  template ret_type kernel_impl::get_info<info::param_type::param>(            \
-      const device &) const;
-#define __SYCL_PARAM_TRAITS_SPEC_WITH_INPUT(param_type, param, ret_type,       \
-                                            in_type)                           \
-  template ret_type kernel_impl::get_info<info::param_type::param>(            \
-      const device &, in_type) const;
-
-#include <CL/sycl/info/kernel_device_specific_traits.def>
-
-#undef __SYCL_PARAM_TRAITS_SPEC
-#undef __SYCL_PARAM_TRAITS_SPEC_WITH_INPUT
-
-#define __SYCL_PARAM_TRAITS_SPEC(param_type, param, ret_type)                  \
-  template ret_type kernel_impl::get_work_group_info<info::param_type::param>( \
-      const device &) const;
-
-#include <CL/sycl/info/kernel_work_group_traits.def>
-
-#undef __SYCL_PARAM_TRAITS_SPEC
-
-#define __SYCL_PARAM_TRAITS_SPEC(param_type, param, ret_type)                  \
-  template ret_type kernel_impl::get_sub_group_info<info::param_type::param>(  \
-      const device &) const;
-#define __SYCL_PARAM_TRAITS_SPEC_WITH_INPUT(param_type, param, ret_type,       \
-                                            in_type)                           \
-  template ret_type kernel_impl::get_sub_group_info<info::param_type::param>(  \
-      const device &, in_type) const;
-
-#include <CL/sycl/info/kernel_sub_group_traits.def>
-
-#undef __SYCL_PARAM_TRAITS_SPEC
-#undef __SYCL_PARAM_TRAITS_SPEC_WITH_INPUT
 
 bool kernel_impl::isCreatedFromSource() const {
   // TODO it is not clear how to understand whether the SYCL kernel is created

--- a/sycl/source/detail/kernel_impl.hpp
+++ b/sycl/source/detail/kernel_impl.hpp
@@ -12,21 +12,21 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/info/info_desc.hpp>
+#include <CL/sycl/program.hpp>
 #include <detail/context_impl.hpp>
 #include <detail/device_impl.hpp>
+#include <detail/kernel_info.hpp>
 
 #include <cassert>
 #include <memory>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-// Forward declaration
-class program;
-
 namespace detail {
+// Forward declaration
 class program_impl;
 
-using ContextImplPtr = std::shared_ptr<detail::context_impl>;
+using ContextImplPtr = std::shared_ptr<context_impl>;
 using ProgramImplPtr = std::shared_ptr<program_impl>;
 class kernel_impl {
 public:
@@ -175,6 +175,85 @@ private:
   const ProgramImplPtr MProgramImpl;
   bool MCreatedFromSource = true;
 };
+
+template <info::kernel param>
+inline typename info::param_traits<info::kernel, param>::return_type
+kernel_impl::get_info() const {
+  if (is_host()) {
+    // TODO implement
+    assert(0 && "Not implemented");
+  }
+  return get_kernel_info<
+      typename info::param_traits<info::kernel, param>::return_type,
+      param>::get(this->getHandleRef(), getPlugin());
+}
+
+template <>
+inline context kernel_impl::get_info<info::kernel::context>() const {
+  return createSyclObjFromImpl<context>(MContext);
+}
+
+template <>
+inline program kernel_impl::get_info<info::kernel::program>() const {
+  return createSyclObjFromImpl<program>(MProgramImpl);
+}
+
+template <info::kernel_device_specific param>
+inline typename info::param_traits<info::kernel_device_specific,
+                                   param>::return_type
+kernel_impl::get_info(const device &Device) const {
+  if (is_host()) {
+    return get_kernel_device_specific_info_host<param>(Device);
+  }
+  return get_kernel_device_specific_info<
+      typename info::param_traits<info::kernel_device_specific,
+                                  param>::return_type,
+      param>::get(this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(),
+                  getPlugin());
+}
+
+template <info::kernel_device_specific param>
+inline typename info::param_traits<info::kernel_device_specific,
+                                   param>::return_type
+kernel_impl::get_info(
+    const device &Device,
+    typename info::param_traits<info::kernel_device_specific, param>::input_type
+        Value) const {
+  if (is_host()) {
+    throw runtime_error("Sub-group feature is not supported on HOST device.",
+                        PI_INVALID_DEVICE);
+  }
+  return get_kernel_device_specific_info_with_input<param>::get(
+      this->getHandleRef(), getSyclObjImpl(Device)->getHandleRef(), Value,
+      getPlugin());
+}
+
+template <info::kernel_work_group param>
+inline typename info::param_traits<info::kernel_work_group, param>::return_type
+kernel_impl::get_work_group_info(const device &Device) const {
+  return get_info<
+      info::compatibility_param_traits<info::kernel_work_group, param>::value>(
+      Device);
+}
+
+template <info::kernel_sub_group param>
+inline typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel_impl::get_sub_group_info(const device &Device) const {
+  return get_info<
+      info::compatibility_param_traits<info::kernel_sub_group, param>::value>(
+      Device);
+}
+
+template <info::kernel_sub_group param>
+inline typename info::param_traits<info::kernel_sub_group, param>::return_type
+kernel_impl::get_sub_group_info(
+    const device &Device,
+    typename info::param_traits<info::kernel_sub_group, param>::input_type
+        Value) const {
+  return get_info<
+      info::compatibility_param_traits<info::kernel_sub_group, param>::value>(
+      Device, Value);
+}
 
 } // namespace detail
 } // namespace sycl

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -13,7 +13,6 @@
 #include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/info/info_desc.hpp>
-#include <detail/kernel_impl.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {


### PR DESCRIPTION
Explicit instantiation of template that occurs after an explicit specialization
has no effect. Move template specializations to header to avoid this kind
of warnings.