### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3013,6 +3013,7 @@ public:
 
   void VisitTemplateTemplateArgument(const TemplateArgument &TA) {
     TemplateDecl *TD = TA.getAsTemplate().getAsTemplateDecl();
+    assert(TD && "template declaration must be available");
     TemplateParameterList *TemplateParams = TD->getTemplateParameters();
     for (NamedDecl *P : *TemplateParams) {
       if (NonTypeTemplateParmDecl *TemplateParam =
@@ -3594,6 +3595,7 @@ public:
     // template class Foo specialized by class Baz<Bar>, not a template
     // class template <template <typename> class> class T as it should.
     TemplateDecl *TD = TA.getAsTemplate().getAsTemplateDecl();
+    assert(TD && "template declaration must be available");
     TemplateParameterList *TemplateParams = TD->getTemplateParameters();
     for (NamedDecl *P : *TemplateParams) {
       // If template template parameter type has an enum value template


### PR DESCRIPTION
Found via a static-analysis tool:

Inside VisitTemplateTemplateArgument() function:
 
TemplateDecl *TD = TA.getAsTemplate.getAsTemplateDecl(); ----> Pointer 'TD' may be NULL
TemplateParameterList *TemplateParams = TD->getTemplateParameters(); ---> will be dereferenced here

This patch fixes null pointer dereference issues in SemaSYCL.cpp file by adding assert().

Signed-off-by: Soumi Manna <soumi.manna@intel.com>