### PR TITLE
[SYCL] Add new auto device code split mode

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1987,11 +1987,11 @@ def fsycl_link_targets_EQ : CommaJoined<["-"], "fsycl-link-targets=">, Flags<[No
   HelpText<"Specify comma-separated list of triples SYCL offloading targets to produce linked device images">;
 def fsycl_device_code_split_EQ : Joined<["-"], "fsycl-device-code-split=">,
    Flags<[CC1Option, CoreOption]>, HelpText<"Perform SYCL device code split: per_kernel (device code module is "
-  "created for each SYCL kernel) | per_source (device code module is created for each source (translation unit)) | off (no device code split). "
-  "Default is 'off' - all kernels go into a single module`">, Values<"per_source, per_kernel, off">;
+  "created for each SYCL kernel) | per_source (device code module is created for each source (translation unit)) | off (no device code split). | auto (use heuristic to select the best way of splitting device code)"
+  "Default is 'auto' - automatically select how to split device code into modules">, Values<"per_source, per_kernel, off, auto">;
 def fsycl_device_code_split : Flag<["-"], "fsycl-device-code-split">, Alias<fsycl_device_code_split_EQ>,
-  AliasArgs<["per_source"]>, Flags<[CC1Option, CoreOption]>,
-  HelpText<"Perform SYCL device code split in the per_source mode i.e. create a device code module for each source (translation unit)">;
+  AliasArgs<["auto"]>, Flags<[CC1Option, CoreOption]>,
+  HelpText<"Perform SYCL device code split in the 'auto' mode i.e. use heuristic to distribute device code across modules">;
 def fsycl_id_queries_fit_in_int : Flag<["-"], "fsycl-id-queries-fit-in-int">,
   Flags<[CC1Option, CoreOption]>, HelpText<"Assume that SYCL ID queries fit "
   "within MAX_INT.">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1988,10 +1988,10 @@ def fsycl_link_targets_EQ : CommaJoined<["-"], "fsycl-link-targets=">, Flags<[No
 def fsycl_device_code_split_EQ : Joined<["-"], "fsycl-device-code-split=">,
    Flags<[CC1Option, CoreOption]>, HelpText<"Perform SYCL device code split: per_kernel (device code module is "
   "created for each SYCL kernel) | per_source (device code module is created for each source (translation unit)) | off (no device code split). | auto (use heuristic to select the best way of splitting device code)"
-  "Default is 'auto' - automatically select how to split device code into modules">, Values<"per_source, per_kernel, off, auto">;
+  "Default is 'auto' - use heuristic to distribute device code across modules">, Values<"per_source, per_kernel, off, auto">;
 def fsycl_device_code_split : Flag<["-"], "fsycl-device-code-split">, Alias<fsycl_device_code_split_EQ>,
   AliasArgs<["auto"]>, Flags<[CC1Option, CoreOption]>,
-  HelpText<"Perform SYCL device code split in the 'auto' mode i.e. use heuristic to distribute device code across modules">;
+  HelpText<"Perform SYCL device code split in the 'auto' mode, i.e. use heuristic to distribute device code across modules">;
 def fsycl_id_queries_fit_in_int : Flag<["-"], "fsycl-id-queries-fit-in-int">,
   Flags<[CC1Option, CoreOption]>, HelpText<"Assume that SYCL ID queries fit "
   "within MAX_INT.">;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8142,12 +8142,17 @@ void SYCLPostLink::ConstructJob(Compilation &C, const JobAction &JA,
       addArgs(CmdArgs, TCArgs, {"-split=kernel"});
     else if (StringRef(A->getValue()) == "per_source")
       addArgs(CmdArgs, TCArgs, {"-split=source"});
+    else if (StringRef(A->getValue()) == "auto")
+      addArgs(CmdArgs, TCArgs, {"-split=auto"});
     else
       // split must be off
       assert(StringRef(A->getValue()) == "off");
+  } else {
+    // auto is the default split mode
+    addArgs(CmdArgs, TCArgs, {"-split=auto"});
   }
   // OPT_fsycl_device_code_split is not checked as it is an alias to
-  // -fsycl-device-code-split=per_source
+  // -fsycl-device-code-split=auto
 
   // Turn on Dead Parameter Elimination Optimization with early optimizations
   if (!getToolChain().getTriple().isNVPTX() &&

--- a/clang/test/Driver/sycl-offload-with-split.c
+++ b/clang/test/Driver/sycl-offload-with-split.c
@@ -206,7 +206,7 @@
 // RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-CPU
 // CHK-TOOLS-AOT: clang{{.*}} "-fsycl-is-device" {{.*}} "-o" "[[OUTPUT1:.+\.bc]]"
 // CHK-TOOLS-AOT: llvm-link{{.*}} "[[OUTPUT1]]" "-o" "[[OUTPUT2:.+\.bc]]"
-// CHK-TOOLS-AOT: sycl-post-link{{.*}} "-spec-const=default" "-o" "[[OUTPUT3:.+\.table]]" "[[OUTPUT2]]"
+// CHK-TOOLS-AOT: sycl-post-link{{.*}} "-split=auto" {{.*}} "-spec-const=default" "-o" "[[OUTPUT3:.+\.table]]" "[[OUTPUT2]]"
 // CHK-TOOLS-AOT: file-table-tform{{.*}} "-o" "[[OUTPUT4:.+\.txt]]" "[[OUTPUT3]]"
 // CHK-TOOLS-AOT: llvm-foreach{{.*}} "--in-file-list=[[OUTPUT4]]" "--in-replace=[[OUTPUT4]]" "--out-ext=spv" "--out-file-list=[[OUTPUT5:.+\.txt]]" "--out-replace=[[OUTPUT5]]" "--" "{{.*}}llvm-spirv{{.*}}" "-o" "[[OUTPUT5]]" {{.*}} "[[OUTPUT4]]"
 // CHK-TOOLS-FPGA: llvm-foreach{{.*}} "--out-file-list=[[OUTPUT6:.+\.txt]]{{.*}} "--" "{{.*}}aoc{{.*}} "-o" "[[OUTPUT6]]" "[[OUTPUT5]]"
@@ -271,12 +271,32 @@
 // CHK-PHASE-MULTI-TARG: 36: clang-offload-wrapper, {35}, object, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 37: offload, "host-sycl (x86_64-unknown-linux-gnu)" {9}, "device-sycl (spir64-unknown-unknown-sycldevice)" {18}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {28}, "device-sycl (spir64_gen-unknown-unknown-sycldevice)" {36}, image
 
-// Check -fsycl-one-kernel-per-module option passing.
+// Check -fsycl-device-code-split=per_kernel option passing.
 // RUN:   %clang -### -fsycl -fsycl-device-code-split=per_kernel %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefixes=CHK-ONE-KERNEL
 // RUN:   %clang_cl -### -fsycl -fsycl-device-code-split=per_kernel %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefixes=CHK-ONE-KERNEL
 // CHK-ONE-KERNEL: sycl-post-link{{.*}} "-split=kernel"{{.*}} "-o"{{.*}}
+
+// Check -fsycl-device-code-split=per_source option passing.
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_source %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-PER-SOURCE
+// RUN:   %clang_cl -### -fsycl -fsycl-device-code-split=per_source %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-PER-SOURCE
+// CHK-PER-SOURCE: sycl-post-link{{.*}} "-split=source"{{.*}} "-o"{{.*}}
+
+// Check -fsycl-device-code-split option passing.
+// RUN:   %clang -### -fsycl -fsycl-device-code-split %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang_cl -### -fsycl -fsycl-device-code-split %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=auto %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang_cl -### -fsycl -fsycl-device-code-split=auto %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang -### -fsycl %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang_cl -### -fsycl %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
+// CHK-AUTO: sycl-post-link{{.*}} "-split=auto"{{.*}} "-o"{{.*}}
 
 // Check no device code split mode.
 // RUN:   %clang -### -fsycl -fsycl-device-code-split -fsycl-device-code-split=off %s 2>&1 \

--- a/llvm/test/tools/sycl-post-link/auto-module-split-1.ll
+++ b/llvm/test/tools/sycl-post-link/auto-module-split-1.ll
@@ -1,0 +1,121 @@
+; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; By default auto mode is equal to source mode
+; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-TU0,CHECK
+; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-TU1,CHECK
+; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-TU0-TXT
+; RUN: FileCheck %s -input-file=%t_1.sym --check-prefixes CHECK-TU1-TXT
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-linux-sycldevice"
+
+$_Z3barIiET_S0_ = comdat any
+
+; CHECK-TU0-NOT: @{{.*}}GV{{.*}}
+; CHECK-TU1: @{{.*}}GV{{.*}} = internal addrspace(1) constant [1 x i32] [i32 42], align 4
+@_ZL2GV = internal addrspace(1) constant [1 x i32] [i32 42], align 4
+
+; CHECK-TU0: define dso_local spir_kernel void @{{.*}}TU0_kernel0{{.*}}
+; CHECK-TU0-TXT: {{.*}}TU0_kernel0{{.*}}
+; CHECK-TU1-NOT: define dso_local spir_kernel void @{{.*}}TU0_kernel0{{.*}}
+; CHECK-TU1-TXT-NOT: {{.*}}TU0_kernel0{{.*}}
+
+; CHECK-TU0: call spir_func void @{{.*}}foo{{.*}}()
+
+define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel0() #0 {
+entry:
+  call spir_func void @_Z3foov()
+  ret void
+}
+
+; CHECK-TU0: define dso_local spir_func void @{{.*}}foo{{.*}}()
+; CHECK-TU1-NOT: define dso_local spir_func void @{{.*}}foo{{.*}}()
+
+; CHECK-TU0: call spir_func i32 @{{.*}}bar{{.*}}(i32 1)
+
+define dso_local spir_func void @_Z3foov() {
+entry:
+  %a = alloca i32, align 4
+  %call = call spir_func i32 @_Z3barIiET_S0_(i32 1)
+  %add = add nsw i32 2, %call
+  store i32 %add, i32* %a, align 4
+  ret void
+}
+
+; CHECK-TU0: define {{.*}} spir_func i32 @{{.*}}bar{{.*}}(i32 %arg)
+; CHECK-TU1-NOT: define {{.*}} spir_func i32 @{{.*}}bar{{.*}}(i32 %arg)
+
+; Function Attrs: nounwind
+define linkonce_odr dso_local spir_func i32 @_Z3barIiET_S0_(i32 %arg) comdat {
+entry:
+  %arg.addr = alloca i32, align 4
+  store i32 %arg, i32* %arg.addr, align 4
+  %0 = load i32, i32* %arg.addr, align 4
+  ret i32 %0
+}
+
+; CHECK-TU0: define dso_local spir_kernel void @{{.*}}TU0_kernel1{{.*}}()
+; CHECK-TU0-TXT: {{.*}}TU0_kernel1{{.*}}
+; CHECK-TU1-NOT: define dso_local spir_kernel void @{{.*}}TU0_kernel1{{.*}}()
+; CHECK-TU1-TXT-NOT: {{.*}}TU0_kernel1{{.*}}
+
+; CHECK-TU0: call spir_func void @{{.*}}foo1{{.*}}()
+
+define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel1() #0 {
+entry:
+  call spir_func void @_Z4foo1v()
+  ret void
+}
+
+; CHECK-TU0: define dso_local spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-TU1-NOT: define dso_local spir_func void @{{.*}}foo1{{.*}}()
+
+; Function Attrs: nounwind
+define dso_local spir_func void @_Z4foo1v() {
+entry:
+  %a = alloca i32, align 4
+  store i32 2, i32* %a, align 4
+  ret void
+}
+
+; CHECK-TU0-NOT: define dso_local spir_kernel void @{{.*}}TU1_kernel{{.*}}()
+; CHECK-TU0-TXT-NOT: {{.*}}TU1_kernel{{.*}}
+; CHECK-TU1: define dso_local spir_kernel void @{{.*}}TU1_kernel{{.*}}()
+; CHECK-TU1-TXT: {{.*}}TU1_kernel{{.*}}
+
+; CHECK-TU1: call spir_func void @{{.*}}foo2{{.*}}()
+
+define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
+entry:
+  call spir_func void @_Z4foo2v()
+  ret void
+}
+
+; CHECK-TU0-NOT: define dso_local spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-TU1: define dso_local spir_func void @{{.*}}foo2{{.*}}()
+
+; Function Attrs: nounwind
+define dso_local spir_func void @_Z4foo2v() {
+entry:
+  %a = alloca i32, align 4
+; CHECK-TU1: %0 = load i32, i32 addrspace(4)* getelementptr inbounds ([1 x i32], [1 x i32] addrspace(4)* addrspacecast ([1 x i32] addrspace(1)* @{{.*}}GV{{.*}} to [1 x i32] addrspace(4)*), i64 0, i64 0), align 4
+  %0 = load i32, i32 addrspace(4)* getelementptr inbounds ([1 x i32], [1 x i32] addrspace(4)* addrspacecast ([1 x i32] addrspace(1)* @_ZL2GV to [1 x i32] addrspace(4)*), i64 0, i64 0), align 4
+  %add = add nsw i32 4, %0
+  store i32 %add, i32* %a, align 4
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="TU1.cpp" }
+attributes #1 = { "sycl-module-id"="TU2.cpp" }
+
+; Metadata is saved in both modules.
+; CHECK: !opencl.spir.version = !{!0, !0}
+; CHECK: !spirv.Source = !{!1, !1}
+
+!opencl.spir.version = !{!0, !0}
+!spirv.Source = !{!1, !1}
+
+; CHECK: !0 = !{i32 1, i32 2}
+; CHECK: !1 = !{i32 4, i32 100000}
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 4, i32 100000}

--- a/llvm/test/tools/sycl-post-link/auto-module-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/auto-module-split-2.ll
@@ -1,0 +1,81 @@
+; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; In precense of indirectly callable function auto mode is equal to no split,
+; which means that separate LLVM IR file for device is not generated and we only
+; need to check generated symbol table
+; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-linux-sycldevice"
+
+$_Z3barIiET_S0_ = comdat any
+
+@_ZL2GV = internal addrspace(1) constant [1 x i32] [i32 42], align 4
+
+; CHECK: {{.*}}TU0_kernel0{{.*}}
+
+define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel0() #0 {
+entry:
+  call spir_func void @_Z3foov()
+  ret void
+}
+
+define dso_local spir_func void @_Z3foov() #2 {
+entry:
+  %a = alloca i32, align 4
+  %call = call spir_func i32 @_Z3barIiET_S0_(i32 1)
+  %add = add nsw i32 2, %call
+  store i32 %add, i32* %a, align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+define linkonce_odr dso_local spir_func i32 @_Z3barIiET_S0_(i32 %arg) comdat {
+entry:
+  %arg.addr = alloca i32, align 4
+  store i32 %arg, i32* %arg.addr, align 4
+  %0 = load i32, i32* %arg.addr, align 4
+  ret i32 %0
+}
+
+; CHECK: {{.*}}TU0_kernel1{{.*}}
+
+define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel1() #0 {
+entry:
+  call spir_func void @_Z4foo1v()
+  ret void
+}
+
+; Function Attrs: nounwind
+define dso_local spir_func void @_Z4foo1v() {
+entry:
+  %a = alloca i32, align 4
+  store i32 2, i32* %a, align 4
+  ret void
+}
+; CHECK: {{.*}}TU1_kernel{{.*}}
+
+define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
+entry:
+  call spir_func void @_Z4foo2v()
+  ret void
+}
+
+; Function Attrs: nounwind
+define dso_local spir_func void @_Z4foo2v() {
+entry:
+  %a = alloca i32, align 4
+  %0 = load i32, i32 addrspace(4)* getelementptr inbounds ([1 x i32], [1 x i32] addrspace(4)* addrspacecast ([1 x i32] addrspace(1)* @_ZL2GV to [1 x i32] addrspace(4)*), i64 0, i64 0), align 4
+  %add = add nsw i32 4, %0
+  store i32 %add, i32* %a, align 4
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="TU1.cpp" }
+attributes #1 = { "sycl-module-id"="TU2.cpp" }
+attributes #2 = { "referenced-indirectly" }
+
+!opencl.spir.version = !{!0, !0}
+!spirv.Source = !{!1, !1}
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 4, i32 100000}

--- a/llvm/test/tools/sycl-post-link/auto-module-split-3.ll
+++ b/llvm/test/tools/sycl-post-link/auto-module-split-3.ll
@@ -1,0 +1,81 @@
+; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; In precense of indirect calls auto mode is equal to no split,
+; which means that separate LLVM IR file for device is not generated and we only
+; need to check generated symbol table
+; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-linux-sycldevice"
+
+$_Z3barIiET_S0_ = comdat any
+
+@_ZL2GV = internal addrspace(1) constant [1 x i32] [i32 42], align 4
+
+; CHECK: {{.*}}TU0_kernel0{{.*}}
+
+define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel0() #0 {
+entry:
+  call spir_func void @_Z3foov()
+  ret void
+}
+
+define dso_local spir_func void @_Z3foov() {
+entry:
+  %a = alloca i32, align 4
+  %ptr = bitcast i32* %a to i32 (i32)*
+  %call = call spir_func i32 %ptr(i32 1)
+  %add = add nsw i32 2, %call
+  store i32 %add, i32* %a, align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+define linkonce_odr dso_local spir_func i32 @_Z3barIiET_S0_(i32 %arg) comdat {
+entry:
+  %arg.addr = alloca i32, align 4
+  store i32 %arg, i32* %arg.addr, align 4
+  %0 = load i32, i32* %arg.addr, align 4
+  ret i32 %0
+}
+
+; CHECK: {{.*}}TU0_kernel1{{.*}}
+
+define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel1() #0 {
+entry:
+  call spir_func void @_Z4foo1v()
+  ret void
+}
+
+; Function Attrs: nounwind
+define dso_local spir_func void @_Z4foo1v() {
+entry:
+  %a = alloca i32, align 4
+  store i32 2, i32* %a, align 4
+  ret void
+}
+; CHECK: {{.*}}TU1_kernel{{.*}}
+
+define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
+entry:
+  call spir_func void @_Z4foo2v()
+  ret void
+}
+
+; Function Attrs: nounwind
+define dso_local spir_func void @_Z4foo2v() {
+entry:
+  %a = alloca i32, align 4
+  %0 = load i32, i32 addrspace(4)* getelementptr inbounds ([1 x i32], [1 x i32] addrspace(4)* addrspacecast ([1 x i32] addrspace(1)* @_ZL2GV to [1 x i32] addrspace(4)*), i64 0, i64 0), align 4
+  %add = add nsw i32 4, %0
+  store i32 %add, i32* %a, align 4
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="TU1.cpp" }
+attributes #1 = { "sycl-module-id"="TU2.cpp" }
+
+!opencl.spir.version = !{!0, !0}
+!spirv.Source = !{!1, !1}
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 4, i32 100000}

--- a/llvm/test/tools/sycl-post-link/help.test
+++ b/llvm/test/tools/sycl-post-link/help.test
@@ -52,4 +52,5 @@ CHECK:   =default           -   set spec constants to C++ defaults
 CHECK: --split=<value>      - split input module
 CHECK:   =source            -   1 output module per source (translation unit)
 CHECK:   =kernel            -   1 output module per kernel
+CHECK:   =auto              -   Choose split mode automatically
 CHECK: --symbols            - generate exported symbol files

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -89,14 +89,14 @@ static cl::opt<bool> OutputAssembly{"S",
                                     cl::Hidden, cl::cat(PostLinkCat)};
 
 enum IRSplitMode {
-  SPLIT_PER_TU,    // one module per translation unit
+  SPLIT_PER_TU,     // one module per translation unit
   SPLIT_PER_KERNEL, // one module per kernel
-  SPLIT_AUTO // automatically select split mode
+  SPLIT_AUTO        // automatically select split mode
 };
 
 static cl::opt<IRSplitMode> SplitMode(
     "split", cl::desc("split input module"), cl::Optional,
-    cl::init(SPLIT_PER_TU),
+    cl::init(SPLIT_AUTO),
     cl::values(
         clEnumValN(SPLIT_PER_TU, "source",
                    "1 output module per source (translation unit)"),
@@ -292,16 +292,6 @@ enum KernelMapEntryScope {
 };
 
 static KernelMapEntryScope selectDeviceCodeSplitScopeAutomatically(Module &M) {
-  // Here we can employ various heuristics to decide which way to split kernels
-  // is the best in each particular situation.
-  // At the moment, we assume that per-kernel split is the best way of splitting
-  // device code and it can be always selected unless:
-  // - there are functions marked with [[intel::device_indirectly_callable]]
-  //   attribute, because it instructs us to make this function available to the
-  //   whole program as it was compiled as a single module.
-  // - there are indirect calls in the module, which means that we don't know
-  //   how to group functions so both caller and callee of indirect call are in
-  //   the same module.
   if (IROutputOnly) {
     // We allow enabling auto split mode even in presence of -ir-output-only
     // flag, but in this case we are limited by it so we can't do any split at
@@ -310,11 +300,17 @@ static KernelMapEntryScope selectDeviceCodeSplitScopeAutomatically(Module &M) {
   }
 
   for (const auto &F : M.functions()) {
+    // There are functions marked with [[intel::device_indirectly_callable]]
+    // attribute, because it instructs us to make this function available to the
+    // whole program as it was compiled as a single module.
     if (F.hasFnAttribute("referenced-indirectly"))
       return Scope_Global;
     if (F.isDeclaration())
       continue;
-    for (const auto &BB: F) {
+    // There are indirect calls in the module, which means that we don't know
+    // how to group functions so both caller and callee of indirect call are in
+    // the same module.
+    for (const auto &BB : F) {
       for (const auto &I : BB) {
         if (auto *CI = dyn_cast<CallInst>(&I)) {
           if (!CI->getCalledFunction())
@@ -324,6 +320,8 @@ static KernelMapEntryScope selectDeviceCodeSplitScopeAutomatically(Module &M) {
     }
   }
 
+  // At the moment, we assume that per-source split is the best way of splitting
+  // device code and can always be used execpt for cases handled above.
   return Scope_PerModule;
 }
 
@@ -633,6 +631,8 @@ int main(int argc, char **argv) {
       "  kernels with the same values of the 'sycl-module-id' attribute will\n"
       "  be put into the same module. If -split=kernel option is specified,\n"
       "  one module per kernel will be emitted.\n"
+      "  '-split=auto' mode automatically selects the best way of splitting\n"
+      "  kernels into modules based on some heuristic.\n"
       "- If -symbols options is also specified, then for each produced module\n"
       "  a text file containing names of all spir kernels in it is generated.\n"
       "- Specialization constant intrinsic transformer. Replaces symbolic\n"
@@ -652,7 +652,9 @@ int main(int argc, char **argv) {
       "  $ sycl-post-link --ir-output-only --spec-const=default \\\n"
       "    -o example_p.bc example.bc\n"
       "will produce single output file example_p.bc suitable for SPIRV\n"
-      "translation.\n");
+      "translation.\n"
+      "--ir-output-only option is not not compatible with split modes other\n"
+      "than 'auto'.\n");
 
   bool DoSplit = SplitMode.getNumOccurrences() > 0;
   bool DoSpecConst = SpecConstLower.getNumOccurrences() > 0;

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -95,8 +95,7 @@ enum IRSplitMode {
 };
 
 static cl::opt<IRSplitMode> SplitMode(
-    "split", cl::desc("split input module"), cl::Optional,
-    cl::init(SPLIT_AUTO),
+    "split", cl::desc("split input module"), cl::Optional, cl::init(SPLIT_AUTO),
     cl::values(
         clEnumValN(SPLIT_PER_TU, "source",
                    "1 output module per source (translation unit)"),


### PR DESCRIPTION
This patch introduces new device code split mode `auto`, which is
intended to automatically select the best device code split mode and
apply it.

At the moment, `auto` is equivalent to `per_source` for most cases and
it is equivalent to `off` in case of precense of function pointers.