### PR TITLE
[SYCL] Allow multiple build options for opencl-aot

### DIFF
--- a/opencl-aot/source/main.cpp
+++ b/opencl-aot/source/main.cpp
@@ -416,9 +416,8 @@ int main(int Argc, char *Argv[]) {
   // step 7: set OpenCL build options
   std::string BuildOptions;
   if (!OptBuildOptions.empty()) {
-    BuildOptions = *OptBuildOptions.begin();
-    std::for_each(OptBuildOptions.begin() + 1, OptBuildOptions.end(),
-                  [&](const std::string &s) { BuildOptions += ' ' + s; });
+    for (const auto &BO : OptBuildOptions)
+      BuildOptions += BO + ' ';
   }
 
   auto ParentDir = sys::path::parent_path(OptInputBinary);

--- a/opencl-aot/source/main.cpp
+++ b/opencl-aot/source/main.cpp
@@ -414,14 +414,13 @@ int main(int Argc, char *Argv[]) {
   CLProgramUPtr ProgramUPtr(std::move(Progs[0]));
 
   // step 7: set OpenCL build options
-  std::string BuildOptsStr;
+  std::string BuildOptions;
   if (!OptBuildOptions.empty()) {
-    BuildOptsStr = *OptBuildOptions.begin();
-    for_each(OptBuildOptions.begin() + 1, OptBuildOptions.end(),
-             [&](const std::string &s) { BuildOptsStr += ' ' + s; });
+    BuildOptions = *OptBuildOptions.begin();
+    std::for_each(OptBuildOptions.begin() + 1, OptBuildOptions.end(),
+                  [&](const std::string &s) { BuildOptions += ' ' + s; });
   }
 
-  std::string BuildOptions = BuildOptsStr;
   auto ParentDir = sys::path::parent_path(OptInputBinary);
   if (!ParentDir.empty()) {
     BuildOptions += " -I \"" + std::string(ParentDir) + '\"';
@@ -429,7 +428,7 @@ int main(int Argc, char *Argv[]) {
   std::cout << "Using build options: " << BuildOptions << '\n';
 
   // step 8: build OpenCL program
-  CLErr = clBuildProgram(ProgramUPtr.get(), 1, &DeviceId, BuildOptsStr.c_str(),
+  CLErr = clBuildProgram(ProgramUPtr.get(), 1, &DeviceId, BuildOptions.c_str(),
                          nullptr, nullptr);
 
   std::string CompilerBuildLog;

--- a/opencl-aot/source/main.cpp
+++ b/opencl-aot/source/main.cpp
@@ -299,9 +299,9 @@ int main(int Argc, char *Argv[]) {
       "o", cl::init("output.bin"),
       cl::desc("Specify the output OpenCL program binary filename"),
       cl::value_desc("filename"));
-  cl::opt<std::string> OptBuildOptions("bo",
-                                       cl::desc("Set OpenCL build options"),
-                                       cl::value_desc("build options"));
+  cl::list<std::string> OptBuildOptions("bo", cl::ZeroOrMore,
+                                        cl::desc("Set OpenCL build options"),
+                                        cl::value_desc("build options"));
 
   cl::ParseCommandLineOptions(Argc, Argv,
                               "OpenCL ahead-of-time (AOT) compilation tool");
@@ -414,7 +414,14 @@ int main(int Argc, char *Argv[]) {
   CLProgramUPtr ProgramUPtr(std::move(Progs[0]));
 
   // step 7: set OpenCL build options
-  std::string BuildOptions = OptBuildOptions;
+  std::string BuildOptsStr;
+  if (!OptBuildOptions.empty()) {
+    BuildOptsStr = *OptBuildOptions.begin();
+    for_each(OptBuildOptions.begin() + 1, OptBuildOptions.end(),
+             [&](const std::string &s) { BuildOptsStr += ' ' + s; });
+  }
+
+  std::string BuildOptions = BuildOptsStr;
   auto ParentDir = sys::path::parent_path(OptInputBinary);
   if (!ParentDir.empty()) {
     BuildOptions += " -I \"" + std::string(ParentDir) + '\"';
@@ -422,8 +429,8 @@ int main(int Argc, char *Argv[]) {
   std::cout << "Using build options: " << BuildOptions << '\n';
 
   // step 8: build OpenCL program
-  CLErr = clBuildProgram(ProgramUPtr.get(), 1, &DeviceId,
-                         OptBuildOptions.c_str(), nullptr, nullptr);
+  CLErr = clBuildProgram(ProgramUPtr.get(), 1, &DeviceId, BuildOptsStr.c_str(),
+                         nullptr, nullptr);
 
   std::string CompilerBuildLog;
   std::tie(CompilerBuildLog, ErrorMessage, std::ignore) =


### PR DESCRIPTION
This patch adds handling of multiple build options if they were set separately.
Covered by test https://github.com/intel/llvm-test-suite/pull/58/files

Signed-off-by: Viktoria Maksimova <viktoria.maksimova@intel.com>