### PR TITLE
[SYCL][Test] Add IR checks into atomic tests

### DIFF
--- a/sycl/test/atomic_ref/add.cpp
+++ b/sycl/test/atomic_ref/add.cpp
@@ -1,3 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-device-only -S %s -o - \
+// RUN: | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %RUN_ON_HOST %t.out
 
@@ -165,10 +167,22 @@ void add_test(queue q, size_t N) {
 // Floating-point types do not support pre- or post-increment
 template <> void add_test<float>(queue q, size_t N) {
   add_fetch_test<float>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32)
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32, i32, i32)
   add_plus_equal_test<float>(q, N);
 }
 template <> void add_test<double>(queue q, size_t N) {
   add_fetch_test<double>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
   add_plus_equal_test<double>(q, N);
 }
 
@@ -181,12 +195,31 @@ int main() {
   }
 
   constexpr int N = 32;
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
+  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
   add_test<int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
+  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
   add_test<unsigned int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   add_test<long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   add_test<unsigned long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   add_test<long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   add_test<unsigned long long>(q, N);
+  // The remaining functions have been instantiated earlier
   add_test<float>(q, N);
   add_test<double>(q, N);
   add_test<char *, ptrdiff_t>(q, N);

--- a/sycl/test/atomic_ref/add.cpp
+++ b/sycl/test/atomic_ref/add.cpp
@@ -197,27 +197,27 @@ int main() {
   constexpr int N = 32;
   // CHECK-LLVM: declare dso_local spir_func i32
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
-  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   add_test<int>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i32
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
-  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   add_test<unsigned int>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
-  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   add_test<long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
-  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   add_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   add_test<long long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   add_test<unsigned long long>(q, N);
   // The remaining functions have been instantiated earlier
   add_test<float>(q, N);

--- a/sycl/test/atomic_ref/add.cpp
+++ b/sycl/test/atomic_ref/add.cpp
@@ -203,13 +203,13 @@ int main() {
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
   // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
   add_test<unsigned int>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
   add_test<long>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
   add_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicIAdd

--- a/sycl/test/atomic_ref/compare_exchange.cpp
+++ b/sycl/test/atomic_ref/compare_exchange.cpp
@@ -70,13 +70,15 @@ int main() {
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
   // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32, i32, i32)
   compare_exchange_test<unsigned int>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i32,
+  // CHECK-LLVM-SAME: i[[long]], i[[long]])
   compare_exchange_test<long>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i32,
+  // CHECK-LLVM-SAME: i[[long]], i[[long]])
   compare_exchange_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange

--- a/sycl/test/atomic_ref/compare_exchange.cpp
+++ b/sycl/test/atomic_ref/compare_exchange.cpp
@@ -1,3 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-device-only -S %s -o - \
+// RUN: | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %RUN_ON_HOST %t.out
 
@@ -60,12 +62,31 @@ int main() {
   }
 
   constexpr int N = 32;
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32, i32, i32)
   compare_exchange_test<int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32, i32, i32)
   compare_exchange_test<unsigned int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
   compare_exchange_test<long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
   compare_exchange_test<unsigned long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
   compare_exchange_test<long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
   compare_exchange_test<unsigned long long>(q, N);
+  // The remaining functions use the already-declared ones on the IR level
   compare_exchange_test<float>(q, N);
   compare_exchange_test<double>(q, N);
   compare_exchange_test<char *>(q, N);

--- a/sycl/test/atomic_ref/exchange.cpp
+++ b/sycl/test/atomic_ref/exchange.cpp
@@ -1,3 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-device-only -S %s -o - \
+// RUN: | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %RUN_ON_HOST %t.out
 
@@ -52,12 +54,31 @@ int main() {
   }
 
   constexpr int N = 32;
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   exchange_test<int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   exchange_test<unsigned int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   exchange_test<long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   exchange_test<unsigned long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   exchange_test<long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   exchange_test<unsigned long long>(q, N);
+  // The remaining functions use the already-declared ones on the IR level
   exchange_test<float>(q, N);
   exchange_test<double>(q, N);
   exchange_test<char *>(q, N);

--- a/sycl/test/atomic_ref/exchange.cpp
+++ b/sycl/test/atomic_ref/exchange.cpp
@@ -62,13 +62,13 @@ int main() {
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange
   // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   exchange_test<unsigned int>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   exchange_test<long>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   exchange_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicExchange

--- a/sycl/test/atomic_ref/load.cpp
+++ b/sycl/test/atomic_ref/load.cpp
@@ -1,3 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-device-only -S %s -o - \
+// RUN: | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %RUN_ON_HOST %t.out
 
@@ -49,12 +51,31 @@ int main() {
   }
 
   constexpr int N = 32;
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32)
   load_test<int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32)
   load_test<unsigned int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
   load_test<long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
   load_test<unsigned long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
   load_test<long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
   load_test<unsigned long long>(q, N);
+  // The remaining functions use the already-declared ones on the IR level
   load_test<float>(q, N);
   load_test<double>(q, N);
   load_test<char *>(q, N);

--- a/sycl/test/atomic_ref/load.cpp
+++ b/sycl/test/atomic_ref/load.cpp
@@ -59,13 +59,13 @@ int main() {
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
   // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32)
   load_test<unsigned int>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32)
   load_test<long>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32)
   load_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad

--- a/sycl/test/atomic_ref/max.cpp
+++ b/sycl/test/atomic_ref/max.cpp
@@ -67,13 +67,13 @@ int main() {
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMax
   // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
   max_test<unsigned int>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMax
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
   max_test<long>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMax
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
   max_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMax

--- a/sycl/test/atomic_ref/max.cpp
+++ b/sycl/test/atomic_ref/max.cpp
@@ -61,27 +61,27 @@ int main() {
   constexpr int N = 32;
   // CHECK-LLVM: declare dso_local spir_func i32
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMax
-  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   max_test<int>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i32
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMax
-  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   max_test<unsigned int>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMax
-  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   max_test<long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMax
-  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   max_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMax
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   max_test<long long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMax
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   max_test<unsigned long long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i32
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad

--- a/sycl/test/atomic_ref/max.cpp
+++ b/sycl/test/atomic_ref/max.cpp
@@ -1,3 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-device-only -S %s -o - \
+// RUN: | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %RUN_ON_HOST %t.out
 
@@ -57,13 +59,43 @@ int main() {
   }
 
   constexpr int N = 32;
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMax
+  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
   max_test<int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMax
+  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
   max_test<unsigned int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMax
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   max_test<long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMax
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   max_test<unsigned long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMax
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   max_test<long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMax
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   max_test<unsigned long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32)
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32, i32, i32)
   max_test<float>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
   max_test<double>(q, N);
 
   std::cout << "Test passed." << std::endl;

--- a/sycl/test/atomic_ref/min.cpp
+++ b/sycl/test/atomic_ref/min.cpp
@@ -65,13 +65,13 @@ int main() {
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMin
   // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
   min_test<unsigned int>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMin
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
   min_test<long>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMin
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
   min_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMin

--- a/sycl/test/atomic_ref/min.cpp
+++ b/sycl/test/atomic_ref/min.cpp
@@ -59,27 +59,27 @@ int main() {
   constexpr int N = 32;
   // CHECK-LLVM: declare dso_local spir_func i32
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMin
-  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   min_test<int>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i32
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMin
-  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   min_test<unsigned int>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMin
-  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   min_test<long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMin
-  // CHECK-LLVM-SAME: i[[long]] addrspace(1)*, i32, i32, i[[long]])
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   min_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMin
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   min_test<long long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMin
-  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   min_test<unsigned long long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i32
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad

--- a/sycl/test/atomic_ref/min.cpp
+++ b/sycl/test/atomic_ref/min.cpp
@@ -1,3 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-device-only -S %s -o - \
+// RUN: | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %RUN_ON_HOST %t.out
 
@@ -55,13 +57,43 @@ int main() {
   }
 
   constexpr int N = 32;
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMin
+  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
   min_test<int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMin
+  // CHECK-LLVM-SAME: i32 addrspace(1)*, i32, i32, i32)
   min_test<unsigned int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMin
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   min_test<long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMin
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   min_test<unsigned long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicSMin
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   min_test<long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicUMin
+  // CHECK-LLVM-SAME: i64 addrspace(1)*, i32, i32, i64)
   min_test<unsigned long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32)
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32, i32, i32)
   min_test<float>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
   min_test<double>(q, N);
 
   std::cout << "Test passed." << std::endl;

--- a/sycl/test/atomic_ref/store.cpp
+++ b/sycl/test/atomic_ref/store.cpp
@@ -56,12 +56,12 @@ int main() {
   // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   store_test<unsigned int>(q, N);
   // CHECK-LLVM: declare dso_local spir_func void
-  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore{{.*}}(i[[long:(32)|(64)]]
+  // CHECK-LLVM-SAME:  addrspace(1)*, i32, i32, i[[long]])
   store_test<long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func void
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   store_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func void
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore

--- a/sycl/test/atomic_ref/store.cpp
+++ b/sycl/test/atomic_ref/store.cpp
@@ -1,3 +1,5 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-device-only -S %s -o - \
+// RUN: | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %RUN_ON_HOST %t.out
 
@@ -45,12 +47,31 @@ int main() {
   }
 
   constexpr int N = 32;
+  // CHECK-LLVM: declare dso_local spir_func void
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   store_test<int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func void
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   store_test<unsigned int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func void
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   store_test<long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func void
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   store_test<unsigned long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func void
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   store_test<long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func void
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicStore
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   store_test<unsigned long long>(q, N);
+  // The remaining functions use the already-declared ones on the IR level
   store_test<float>(q, N);
   store_test<double>(q, N);
   store_test<char *>(q, N);

--- a/sycl/test/atomic_ref/sub.cpp
+++ b/sycl/test/atomic_ref/sub.cpp
@@ -201,13 +201,13 @@ int main() {
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub
   // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   sub_test<unsigned int>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long:(32)|(64)]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   sub_test<long>(q, N);
-  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM: declare dso_local spir_func i[[long]]
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub
-  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
+  // CHECK-LLVM-SAME: (i[[long]] addrspace(1)*, i32, i32, i[[long]])
   sub_test<unsigned long>(q, N);
   // CHECK-LLVM: declare dso_local spir_func i64
   // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub

--- a/sycl/test/atomic_ref/sub.cpp
+++ b/sycl/test/atomic_ref/sub.cpp
@@ -165,10 +165,22 @@ void sub_test(queue q, size_t N) {
 // Floating-point types do not support pre- or post-decrement
 template <> void sub_test<float>(queue q, size_t N) {
   sub_fetch_test<float>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32)
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32, i32, i32)
   sub_plus_equal_test<float>(q, N);
 }
 template <> void sub_test<double>(queue q, size_t N) {
   sub_fetch_test<double>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicLoad
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32)
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicCompareExchange
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i32, i64, i64)
   sub_plus_equal_test<double>(q, N);
 }
 
@@ -181,12 +193,31 @@ int main() {
   }
 
   constexpr int N = 32;
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   sub_test<int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i32
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub
+  // CHECK-LLVM-SAME: (i32 addrspace(1)*, i32, i32, i32)
   sub_test<unsigned int>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   sub_test<long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   sub_test<unsigned long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   sub_test<long long>(q, N);
+  // CHECK-LLVM: declare dso_local spir_func i64
+  // CHECK-LLVM-SAME: @_Z{{[0-9]+}}__spirv_AtomicISub
+  // CHECK-LLVM-SAME: (i64 addrspace(1)*, i32, i32, i64)
   sub_test<unsigned long long>(q, N);
+  // The remaining functions have been instantiated earlier
   sub_test<float>(q, N);
   sub_test<double>(q, N);
   sub_test<char *, ptrdiff_t>(q, N);


### PR DESCRIPTION
Check that correct `__spirv_Atomic*` external calls are emitted
by the compiler FE, and thus ensure that the headers provide a
proper implementation for each function.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>