### PR TITLE
[SYCL][L0] Fix memory leak in event pool.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3566,10 +3566,11 @@ pi_result piEventRelease(pi_event Event) {
     }
     ZE_CALL(zeEventDestroy(Event->ZeEvent));
 
+    auto Context = Event->Context;
+    ZE_CALL(Context->decrementAliveEventsInPool(Event->ZeEventPool));
+
     delete Event;
   }
-  auto Context = Event->Context;
-  ZE_CALL(Context->decrementAliveEventsInPool(Event->ZeEventPool));
 
   return PI_SUCCESS;
 }

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -250,12 +250,15 @@ _pi_context::getFreeSlotInExistingOrNewPool(ze_event_pool_handle_t &ZePool,
                               &ZeDevices[0], &ZeEventPool))
       return ZeRes;
     NumEventsAvailableInEventPool[ZeEventPool] = MaxNumEventsPerPool - 1;
-    NumEventsLiveInEventPool[ZeEventPool] = MaxNumEventsPerPool;
+    NumEventsLiveInEventPool[ZeEventPool] = 1;
   } else {
     std::lock_guard<std::mutex> NumEventsAvailableInEventPoolGuard(
         NumEventsAvailableInEventPoolMutex);
     Index = MaxNumEventsPerPool - NumEventsAvailableInEventPool[ZeEventPool];
     --NumEventsAvailableInEventPool[ZeEventPool];
+    std::lock_guard<std::mutex> NumEventsLiveInEventPoolGuard(
+        NumEventsLiveInEventPoolMutex, std::adopt_lock);
+    NumEventsLiveInEventPool[ZeEventPool]++;
   }
   ZePool = ZeEventPool;
   return ZE_RESULT_SUCCESS;

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1831,8 +1831,9 @@ pi_result piContextRelease(pi_context Context) {
   assert(Context);
   if (--(Context->RefCount) == 0) {
     // Clean up any live memory associated with Context
-    Context->finalize();
+    pi_result Result = Context->finalize();
     delete Context;
+    return Result;
   }
   return PI_SUCCESS;
 }

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -217,7 +217,7 @@ struct _pi_context : _pi_object {
   pi_result initialize();
 
   // Finalize the PI context
-  void finalize();
+  pi_result finalize();
 
   // A L0 context handle is primarily used during creation and management of
   // resources that may be used by multiple devices.

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -216,6 +216,9 @@ struct _pi_context : _pi_object {
   // Initialize the PI context.
   pi_result initialize();
 
+  // Finalize the PI context
+  void finalize();
+
   // A L0 context handle is primarily used during creation and management of
   // resources that may be used by multiple devices.
   ze_context_handle_t ZeContext;


### PR DESCRIPTION
Memory leak in event pool was caused because we failed to invoke zeEventPoolDestroy() because we set the live events of the newly created pool with max number of events. And then we only destroy the pool if the live events count drops to zero.
The number of live events drops to zero only we really used all 256 events available in the pool.
Therefore, it became a memory leak when only a few events are used in the pool.
The fix is to introduce a new method finalize() in pi_context class.
This method is invoked from the pi_context destructor.
It checks if there is any pool that has non-zero live events and then calls zeEventPoolDestroy for it to deallocate event pool associated with the context. 

Signed-off-by: Byoungro So <byoungro.so@intel.com>