### PR TITLE
[SYCL] Add template parameter support for no_global_work_offset attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1303,7 +1303,7 @@ def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
 def SYCLIntelNoGlobalWorkOffset : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","no_global_work_offset">,
                    CXX11<"intel","no_global_work_offset">];
-  let Args = [ExprArgument<"Value">, BoolArgument<"Enabled", 1>];
+  let Args = [ExprArgument<"Value", /*default*/1>];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelNoGlobalWorkOffsetAttrDocs];

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1303,7 +1303,7 @@ def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
 def SYCLIntelNoGlobalWorkOffset : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","no_global_work_offset">,
                    CXX11<"intel","no_global_work_offset">];
-  let Args = [BoolArgument<"Enabled", 1>];
+  let Args = [ExprArgument<"Value">, BoolArgument<"Enabled", 1>];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelNoGlobalWorkOffsetAttrDocs];

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1303,7 +1303,7 @@ def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
 def SYCLIntelNoGlobalWorkOffset : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","no_global_work_offset">,
                    CXX11<"intel","no_global_work_offset">];
-  let Args = [ExprArgument<"Value", /*default*/1>];
+  let Args = [ExprArgument<"Value", /*optional*/1>];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelNoGlobalWorkOffsetAttrDocs];

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -667,10 +667,8 @@ def NSReturnsMismatch : DiagGroup<"nsreturns-mismatch">;
 def IndependentClassAttribute : DiagGroup<"IndependentClass-attribute">;
 def UnknownAttributes : DiagGroup<"unknown-attributes">;
 def IgnoredAttributes : DiagGroup<"ignored-attributes">;
-def AdjustedAttributes : DiagGroup<"adjusted-attributes">;
 def Attributes : DiagGroup<"attributes", [UnknownAttributes,
-                                          IgnoredAttributes,
-                                          AdjustedAttributes]>;
+                                          IgnoredAttributes]>;
 def UnknownSanitizers : DiagGroup<"unknown-sanitizers">;
 def UnnamedTypeTemplateArgs : DiagGroup<"unnamed-type-template-args",
                                         [CXX98CompatUnnamedTypeTemplateArgs]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11134,9 +11134,6 @@ def err_sycl_function_attribute_mismatch : Error<
   "SYCL kernel without %0 attribute can't call a function with this attribute">;
 def err_sycl_x_y_z_arguments_must_be_one : Error<
   "%0 X-, Y- and Z- sizes must be 1 when %1 attribute is used with value 0">;
-def warn_boolean_attribute_argument_is_not_valid: Warning<
-   "The value of %0 attribute should be 0 or 1. Adjusted to 1">,
-   InGroup<AdjustedAttributes>;
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "static function or function in an anonymous namespace">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12973,13 +12973,14 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
     }
     if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
       if (ArgInt > 1) {
-        Diag(E->getExprLoc(), diag::warn_boolean_attribute_argument_is_not_valid)
+        Diag(E->getExprLoc(),
+	     diag::warn_boolean_attribute_argument_is_not_valid)
             << CI.getAttrName();
         return;
       }
     }
     if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim ||
-	CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
+        CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
       if (ArgInt < 0) {
         Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
             << CI.getAttrName() << /*non-negative*/ 1;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12973,8 +12973,9 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
     }
     if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
       if (ArgInt > 1) {
-        Diag(E->getExprLoc(),
-             diag::warn_boolean_attribute_argument_is_not_valid) << CI;
+	Diag(E->getExprLoc(),
+             diag::warn_boolean_attribute_argument_is_not_valid)
+            << CI;
         return;
       }
     }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12971,14 +12971,6 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
         return;
       }
     }
-    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
-      if (ArgInt > 1) {
-        Diag(E->getExprLoc(),
-             diag::warn_boolean_attribute_argument_is_not_valid)
-            << CI;
-        return;
-      }
-    }
     if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim ||
         CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
       if (ArgInt < 0) {
@@ -12986,6 +12978,8 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
             << CI.getAttrName() << /*non-negative*/ 1;
         return;
       }
+    }
+    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim) {
       if (ArgInt > 3) {
         Diag(E->getBeginLoc(), diag::err_attribute_argument_out_of_range)
             << CI.getAttrName() << 0 << 3 << E->getSourceRange();

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12974,8 +12974,7 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
     if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
       if (ArgInt > 1) {
         Diag(E->getExprLoc(),
-             diag::warn_boolean_attribute_argument_is_not_valid)
-            << CI.getAttrName();
+             diag::warn_boolean_attribute_argument_is_not_valid) << CI;
         return;
       }
     }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12971,15 +12971,12 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
         return;
       }
     }
-    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim ||
-        CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
+    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim) {
       if (ArgInt < 0) {
         Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
             << CI.getAttrName() << /*non-negative*/ 1;
         return;
       }
-    }
-    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim) {
       if (ArgInt > 3) {
         Diag(E->getBeginLoc(), diag::err_attribute_argument_out_of_range)
             << CI.getAttrName() << 0 << 3 << E->getSourceRange();

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12973,7 +12973,7 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
     }
     if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
       if (ArgInt > 1) {
-	Diag(E->getExprLoc(),
+        Diag(E->getExprLoc(),
              diag::warn_boolean_attribute_argument_is_not_valid)
             << CI;
         return;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12974,7 +12974,7 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
     if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
       if (ArgInt > 1) {
         Diag(E->getExprLoc(),
-	     diag::warn_boolean_attribute_argument_is_not_valid)
+             diag::warn_boolean_attribute_argument_is_not_valid)
             << CI.getAttrName();
         return;
       }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12971,7 +12971,15 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
         return;
       }
     }
-    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim) {
+    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
+      if (ArgInt > 1) {
+        Diag(E->getExprLoc(), diag::warn_boolean_attribute_argument_is_not_valid)
+            << CI.getAttrName();
+        return;
+      }
+    }
+    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim ||
+	CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset) {
       if (ArgInt < 0) {
         Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
             << CI.getAttrName() << /*non-negative*/ 1;

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -693,15 +693,9 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   }
 
   if (const SYCLIntelNoGlobalWorkOffsetAttr *A =
-          FD->getAttr<SYCLIntelNoGlobalWorkOffsetAttr>()) {
-    llvm::LLVMContext &Context = getLLVMContext();
-    Optional<llvm::APSInt> ArgVal =
-        A->getValue()->getIntegerConstantExpr(FD->getASTContext());
-    assert(ArgVal.hasValue() && "Not an integer constant expression");
-    llvm::Metadata *AttrMDArgs[] = {llvm::ConstantAsMetadata::get(
-        Builder.getInt32(ArgVal->getSExtValue()))};
-    Fn->setMetadata("no_global_work_offset",
-                    llvm::MDNode::get(Context, AttrMDArgs));
+      FD->getAttr<SYCLIntelNoGlobalWorkOffsetAttr>()) {
+    if (A->getValue())
+      Fn->setMetadata("no_global_work_offset", llvm::MDNode::get(Context, {}));
   }
 
   if (FD->hasAttr<SYCLIntelUseStallEnableClustersAttr>()) {

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -693,8 +693,13 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   }
 
   if (const SYCLIntelNoGlobalWorkOffsetAttr *A =
-          FD->getAttr<SYCLIntelNoGlobalWorkOffsetAttr>()) {
-    if (A->getValue())
+      FD->getAttr<SYCLIntelNoGlobalWorkOffsetAttr>()) {
+    const Expr *Arg = A->getValue();
+    assert(Arg && "Got an unexpected null argument");
+    Optional<llvm::APSInt> ArgVal =
+	Arg->getIntegerConstantExpr(FD->getASTContext());
+    assert(ArgVal.hasValue() && "Not an integer constant expression");
+    if (ArgVal)
       Fn->setMetadata("no_global_work_offset", llvm::MDNode::get(Context, {}));
   }
 

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -699,7 +699,7 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
     Optional<llvm::APSInt> ArgVal =
         Arg->getIntegerConstantExpr(FD->getASTContext());
     assert(ArgVal.hasValue() && "Not an integer constant expression");
-    if (ArgVal)
+    if (ArgVal->getBoolValue())
       Fn->setMetadata("no_global_work_offset", llvm::MDNode::get(Context, {}));
   }
 

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -693,11 +693,11 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   }
 
   if (const SYCLIntelNoGlobalWorkOffsetAttr *A =
-      FD->getAttr<SYCLIntelNoGlobalWorkOffsetAttr>()) {
+          FD->getAttr<SYCLIntelNoGlobalWorkOffsetAttr>()) {
     const Expr *Arg = A->getValue();
     assert(Arg && "Got an unexpected null argument");
     Optional<llvm::APSInt> ArgVal =
-	Arg->getIntegerConstantExpr(FD->getASTContext());
+        Arg->getIntegerConstantExpr(FD->getASTContext());
     assert(ArgVal.hasValue() && "Not an integer constant expression");
     if (ArgVal)
       Fn->setMetadata("no_global_work_offset", llvm::MDNode::get(Context, {}));

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -701,7 +701,7 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
     llvm::Metadata *AttrMDArgs[] = {llvm::ConstantAsMetadata::get(
         Builder.getInt32(ArgVal->getSExtValue()))};
     Fn->setMetadata("no_global_work_offset",
-		    llvm::MDNode::get(Context, AttrMDArgs));
+                    llvm::MDNode::get(Context, AttrMDArgs));
   }
 
   if (FD->hasAttr<SYCLIntelUseStallEnableClustersAttr>()) {

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -693,7 +693,7 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   }
 
   if (const SYCLIntelNoGlobalWorkOffsetAttr *A =
-      FD->getAttr<SYCLIntelNoGlobalWorkOffsetAttr>()) {
+          FD->getAttr<SYCLIntelNoGlobalWorkOffsetAttr>()) {
     if (A->getValue())
       Fn->setMetadata("no_global_work_offset", llvm::MDNode::get(Context, {}));
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5294,15 +5294,22 @@ static void handleNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
 
   checkForDuplicateAttribute<SYCLIntelNoGlobalWorkOffsetAttr>(S, D, Attr);
 
-  Expr *E = Attr.getArgAsExpr(0);
-
   if (Attr.getKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset &&
       checkDeprecatedSYCLAttributeSpelling(S, Attr))
     S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::no_global_work_offset'";
+	<< "'intel::no_global_work_offset'";
 
-  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, Attr,
-                                                                       E);
+  // If no attribute argument is specified, set to default value '1'.
+  if (!Attr.isArgExpr(0)) {
+    Expr *E = IntegerLiteral::Create(S.Context, llvm::APInt(32, 1),
+                                     S.Context.IntTy, Attr.getLoc());
+    D->addAttr(::new (S.Context) SYCLIntelNoGlobalWorkOffsetAttr(S.Context,
+			                                         Attr, E));
+  } else {
+    Expr *E = Attr.getArgAsExpr(0);
+    S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, Attr,
+		                                                         E);
+  }
 }
 
 /// Handle the [[intelfpga::doublepump]] and [[intelfpga::singlepump]] attributes.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5297,18 +5297,18 @@ static void handleNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
   if (Attr.getKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset &&
       checkDeprecatedSYCLAttributeSpelling(S, Attr))
     S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-	<< "'intel::no_global_work_offset'";
+        << "'intel::no_global_work_offset'";
 
   // If no attribute argument is specified, set to default value '1'.
   if (!Attr.isArgExpr(0)) {
     Expr *E = IntegerLiteral::Create(S.Context, llvm::APInt(32, 1),
                                      S.Context.IntTy, Attr.getLoc());
-    D->addAttr(::new (S.Context) SYCLIntelNoGlobalWorkOffsetAttr(S.Context,
-			                                         Attr, E));
+    D->addAttr(::new (S.Context)
+                   SYCLIntelNoGlobalWorkOffsetAttr(S.Context, Attr, E));
   } else {
     Expr *E = Attr.getArgAsExpr(0);
-    S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, Attr,
-		                                                         E);
+    S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(
+        D, Attr, E);
   }
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5294,24 +5294,15 @@ static void handleNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
 
   checkForDuplicateAttribute<SYCLIntelNoGlobalWorkOffsetAttr>(S, D, Attr);
 
-  uint32_t Enabled = 1;
-  if (Attr.getNumArgs()) {
-    const Expr *E = Attr.getArgAsExpr(0);
-    if (!checkUInt32Argument(S, Attr, E, Enabled, 0,
-                             /*StrictlyUnsigned=*/true))
-      return;
-  }
-  if (Enabled > 1)
-    S.Diag(Attr.getLoc(), diag::warn_boolean_attribute_argument_is_not_valid)
-        << Attr;
+  Expr *E = Attr.getArgAsExpr(0);
 
   if (Attr.getKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset &&
       checkDeprecatedSYCLAttributeSpelling(S, Attr))
     S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
         << "'intel::no_global_work_offset'";
 
-  D->addAttr(::new (S.Context)
-                 SYCLIntelNoGlobalWorkOffsetAttr(S.Context, Attr, Enabled));
+  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, Attr,
+                                                                       E);
 }
 
 /// Handle the [[intelfpga::doublepump]] and [[intelfpga::singlepump]] attributes.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5300,16 +5300,11 @@ static void handleNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
         << "'intel::no_global_work_offset'";
 
   // If no attribute argument is specified, set to default value '1'.
-  if (!Attr.isArgExpr(0)) {
-    Expr *E = IntegerLiteral::Create(S.Context, llvm::APInt(32, 1),
-                                     S.Context.IntTy, Attr.getLoc());
-    D->addAttr(::new (S.Context)
-                   SYCLIntelNoGlobalWorkOffsetAttr(S.Context, Attr, E));
-  } else {
-    Expr *E = Attr.getArgAsExpr(0);
-    S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(
-        D, Attr, E);
-  }
+  Expr *E = Attr.isArgExpr(0) ? Attr.getArgAsExpr(0)
+	                      : IntegerLiteral::Create(S.Context,
+			        llvm::APInt(32, 1), S.Context.IntTy, Attr.getLoc());
+  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, Attr,
+                                                                       E);
 }
 
 /// Handle the [[intelfpga::doublepump]] and [[intelfpga::singlepump]] attributes.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5300,9 +5300,10 @@ static void handleNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
         << "'intel::no_global_work_offset'";
 
   // If no attribute argument is specified, set to default value '1'.
-  Expr *E = Attr.isArgExpr(0) ? Attr.getArgAsExpr(0)
-	                      : IntegerLiteral::Create(S.Context,
-			        llvm::APInt(32, 1), S.Context.IntTy, Attr.getLoc());
+  Expr *E = Attr.isArgExpr(0)
+                ? Attr.getArgAsExpr(0)
+                : IntegerLiteral::Create(S.Context, llvm::APInt(32, 1),
+                                         S.Context.IntTy, Attr.getLoc());
   S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, Attr,
                                                                        E);
 }

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -775,6 +775,12 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
           *this, TemplateArgs, SYCLIntelMaxGlobalWorkDim, New);
       continue;
     }
+    if (const auto *SYCLIntelNoGlobalWorkOffset =
+            dyn_cast<SYCLIntelNoGlobalWorkOffsetAttr>(TmplAttr)) {
+      instantiateIntelSYCLFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(
+          *this, TemplateArgs, SYCLIntelNoGlobalWorkOffset, New);
+      continue;
+    }
     // Existing DLL attribute on the instantiation takes precedence.
     if (TmplAttr->getKind() == attr::DLLExport ||
         TmplAttr->getKind() == attr::DLLImport) {

--- a/clang/test/CodeGenSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-no-global-work-offset.cpp
@@ -16,6 +16,9 @@ public:
   [[intel::no_global_work_offset(SIZE)]] void operator()() const {}
 };
 
+template <int N>
+[[intel::no_global_work_offset(N)]] void func() {}
+
 int main() {
   q.submit([&](handler &h) {
     Foo boo;
@@ -29,6 +32,10 @@ int main() {
 
     Functor<1> f;
     h.single_task<class kernel_name4>(f);
+
+    h.single_task<class kernel_name5>([]() {
+      func<1>();
+    });
   });
   return 0;
 }
@@ -37,5 +44,6 @@ int main() {
 // CHECK: define spir_kernel void @{{.*}}kernel_name2"() #0 {{.*}} !no_global_work_offset ![[NUM5]]
 // CHECK: define spir_kernel void @{{.*}}kernel_name3"() #0 {{.*}} ![[NUM4:[0-9]+]]
 // CHECK: define spir_kernel void @{{.*}}kernel_name4"() #0 {{.*}} !no_global_work_offset ![[NUM5]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name5"() #0 {{.*}} !no_global_work_offset ![[NUM5]]
 // CHECK-NOT: ![[NUM4]]  = !{i32 0}
 // CHECK: ![[NUM5]] = !{}

--- a/clang/test/CodeGenSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-no-global-work-offset.cpp
@@ -22,7 +22,7 @@ int main() {
     h.single_task<class kernel_name1>(boo);
 
     h.single_task<class kernel_name2>(
-        []() [[intel::no_global_work_offset(1)]]{});
+        []() [[intel::no_global_work_offset]]{});
 
     h.single_task<class kernel_name3>(
         []() [[intel::no_global_work_offset(0)]]{});
@@ -38,4 +38,4 @@ int main() {
 // CHECK: define spir_kernel void @{{.*}}kernel_name3"() #0 {{.*}} ![[NUM4:[0-9]+]]
 // CHECK: define spir_kernel void @{{.*}}kernel_name4"() #0 {{.*}} !no_global_work_offset ![[NUM5]]
 // CHECK-NOT: ![[NUM4]]  = !{i32 0}
-// CHECK: ![[NUM5]] = !{i32 1}
+// CHECK: ![[NUM5]] = !{}

--- a/clang/test/CodeGenSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-no-global-work-offset.cpp
@@ -1,28 +1,41 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
 
 class Foo {
 public:
   [[intel::no_global_work_offset(1)]] void operator()() const {}
 };
 
-template <typename name, typename Func>
-__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
-  kernelFunc();
+template <int SIZE>
+class Functor {
+public:
+  [[intel::no_global_work_offset(SIZE)]] void operator()() const {}
+};
+
+int main() {
+  q.submit([&](handler &h) {
+    Foo boo;
+    h.single_task<class kernel_name1>(boo);
+
+    h.single_task<class kernel_name2>(
+        []() [[intel::no_global_work_offset(1)]]{});
+
+    h.single_task<class kernel_name3>(
+        []() [[intel::no_global_work_offset(0)]]{});
+
+    Functor<1> f;
+    h.single_task<class kernel_name4>(f);
+  });
+  return 0;
 }
 
-void bar() {
-  Foo boo;
-  kernel<class kernel_name1>(boo);
-
-  kernel<class kernel_name2>(
-      []() [[intel::no_global_work_offset]]{});
-
-  kernel<class kernel_name3>(
-      []() [[intel::no_global_work_offset(0)]]{});
-}
-
-// CHECK: define spir_kernel void @{{.*}}kernel_name1() {{.*}} !no_global_work_offset ![[NUM5:[0-9]+]]
-// CHECK: define spir_kernel void @{{.*}}kernel_name2() {{.*}} !no_global_work_offset ![[NUM5]]
-// CHECK: define spir_kernel void @{{.*}}kernel_name3() {{.*}} ![[NUM4:[0-9]+]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name1"() #0 {{.*}} !no_global_work_offset ![[NUM5:[0-9]+]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name2"() #0 {{.*}} !no_global_work_offset ![[NUM5]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name3"() #0 {{.*}} ![[NUM4:[0-9]+]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name4"() #0 {{.*}} !no_global_work_offset ![[NUM5]]
 // CHECK-NOT: ![[NUM4]]  = !{i32 0}
-// CHECK: ![[NUM5]] = !{}
+// CHECK: ![[NUM5]] = !{i32 1}

--- a/clang/test/SemaSYCL/check-notdirect-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/check-notdirect-attribute-propagation.cpp
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 | FileCheck %s
 
 #ifndef TRIGGER_ERROR
-[[intel::no_global_work_offset]] void not_direct_one() {} // expected-no-diagnostics
+[[intel::no_global_work_offset(1)]] void not_direct_one() {} // expected-no-diagnostics
 
 [[intel::reqd_sub_group_size(1)]] void func_one() {
   not_direct_one();
@@ -46,7 +46,7 @@ void invoke_foo2() {
   // CHECK-LABEL:  FunctionDecl {{.*}} invoke_foo2 'void ()'
   // CHECK:        `-FunctionDecl {{.*}}KernelName 'void ()'
   // CHECK:        -IntelReqdSubGroupSizeAttr {{.*}}
-  // CHECK:        `-SYCLIntelNoGlobalWorkOffsetAttr {{.*}} Enabled
+  // CHECK:        `-SYCLIntelNoGlobalWorkOffsetAttr {{.*}}
   parallel_for<class KernelName>([]() {});
 #else
   parallel_for<class KernelName>([]() {}); // expected-error 2 {{conflicting attributes applied to a SYCL kernel or SYCL_EXTERNAL function}}

--- a/clang/test/SemaSYCL/check-notdirect-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/check-notdirect-attribute-propagation.cpp
@@ -5,7 +5,7 @@
 #ifndef TRIGGER_ERROR
 [[intel::no_global_work_offset]] void not_direct_one() {} // expected-no-diagnostics
 
-[[intel::reqd_sub_group_size(2)]] void func_one() {
+[[intel::reqd_sub_group_size(1)]] void func_one() {
   not_direct_one();
 }
 

--- a/clang/test/SemaSYCL/check-notdirect-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/check-notdirect-attribute-propagation.cpp
@@ -3,9 +3,9 @@
 // RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 | FileCheck %s
 
 #ifndef TRIGGER_ERROR
-[[intel::no_global_work_offset(1)]] void not_direct_one() {} // expected-no-diagnostics
+[[intel::no_global_work_offset]] void not_direct_one() {} // expected-no-diagnostics
 
-[[intel::reqd_sub_group_size(1)]] void func_one() {
+[[intel::reqd_sub_group_size(2)]] void func_one() {
   not_direct_one();
 }
 

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
@@ -23,7 +23,6 @@ int main() {
         []() [[intel::no_global_work_offset(0)]]{});
 
     // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
-    // expected-warning@+2{{'no_global_work_offset' attribute should be 0 or 1. Adjusted to 1}}
     h.single_task<class test_kernel3>(
         []() [[intel::no_global_work_offset(42)]]{});
 
@@ -40,10 +39,6 @@ int main() {
       [[intel::no_global_work_offset(1)]] int a;
     });
 
-    // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
-    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 1
-    // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
-    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 0
     // expected-warning@+2{{attribute 'no_global_work_offset' is already applied}}
     h.single_task<class test_kernel7>(
         []() [[intel::no_global_work_offset(0), intel::no_global_work_offset(1)]]{});

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
@@ -42,6 +42,8 @@ int main() {
 
     // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
     // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 1
+    // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
+    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 0
     // expected-warning@+2{{attribute 'no_global_work_offset' is already applied}}
     h.single_task<class test_kernel7>(
         []() [[intel::no_global_work_offset(0), intel::no_global_work_offset(1)]]{});

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
@@ -1,51 +1,50 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -Wno-return-type -fcxx-exceptions -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -internal-isystem %S/Inputs -Wno-return-type -Wno-sycl-2017-compat -fcxx-exceptions -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
 
 struct FuncObj {
   //expected-warning@+2 {{attribute 'intelfpga::no_global_work_offset' is deprecated}}
   //expected-note@+1 {{did you mean to use 'intel::no_global_work_offset' instead?}}
-  [[intelfpga::no_global_work_offset]] void operator()() {}
+  [[intelfpga::no_global_work_offset(1)]] void operator()() const {}
 };
 
-template <typename name, typename Func>
-void kernel(Func kernelFunc) {
-  kernelFunc();
-}
-
 int main() {
-  // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}Enabled
-  kernel<class test_kernel1>([]() {
-    FuncObj();
-  });
+  q.submit([&](handler &h) {
+    // CHECK:       SYCLIntelNoGlobalWorkOffsetAttr {{.*}}
+    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
+    h.single_task<class test_kernel1>(FuncObj());
 
-  // CHECK: SYCLIntelNoGlobalWorkOffsetAttr
-  // CHECK-NOT: Enabled
-  kernel<class test_kernel2>(
-      []() [[intel::no_global_work_offset(0)]]{});
+    // CHECK: SYCLIntelNoGlobalWorkOffsetAttr {{.*}}
+    // CHECK-NEXT:  IntegerLiteral{{.*}}0{{$}}
+    h.single_task<class test_kernel2>(
+        []() [[intel::no_global_work_offset(0)]]{});
 
-  // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}Enabled
-  // expected-warning@+2{{'no_global_work_offset' attribute should be 0 or 1. Adjusted to 1}}
-  kernel<class test_kernel3>(
-      []() [[intel::no_global_work_offset(42)]]{});
+    // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
+    // expected-warning@+2{{'no_global_work_offset' attribute should be 0 or 1. Adjusted to 1}}
+    h.single_task<class test_kernel3>(
+        []() [[intel::no_global_work_offset(42)]]{});
 
-  // expected-error@+2{{'no_global_work_offset' attribute requires a non-negative integral compile time constant expression}}
-  kernel<class test_kernel4>(
-      []() [[intel::no_global_work_offset(-1)]]{});
+    // expected-error@+2{{'no_global_work_offset' attribute requires a non-negative integral compile time constant expression}}
+    h.single_task<class test_kernel4>(
+        []() [[intel::no_global_work_offset(-1)]]{});
 
-  // expected-error@+2{{'no_global_work_offset' attribute requires parameter 0 to be an integer constant}}
-  kernel<class test_kernel5>(
-      []() [[intel::no_global_work_offset("foo")]]{});
+    // expected-error@+2{{'no_global_work_offset' attribute requires an integer constant}}
+    h.single_task<class test_kernel5>(
+        []() [[intel::no_global_work_offset("foo")]]{});
 
-  kernel<class test_kernel6>([]() {
-    // expected-error@+1{{'no_global_work_offset' attribute only applies to functions}}
-    [[intel::no_global_work_offset(1)]] int a;
-  });
+    h.single_task<class test_kernel6>([]() {
+        // expected-error@+1{{'no_global_work_offset' attribute only applies to functions}}
+        [[intel::no_global_work_offset(1)]] int a;
 
-  // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
-  // CHECK-NOT: Enabled
-  // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}Enabled
-  // expected-warning@+2{{attribute 'no_global_work_offset' is already applied}}
-  kernel<class test_kernel7>(
-      []() [[intel::no_global_work_offset(0), intel::no_global_work_offset(1)]]{});
-
+    });
+    // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
+    // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 1
+    // expected-warning@+2{{attribute 'no_global_work_offset' is already applied}}
+    h.single_task<class test_kernel7>(
+        []() [[intel::no_global_work_offset(0), intel::no_global_work_offset(1)]]{});
+    });
   return 0;
 }

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
@@ -36,15 +36,15 @@ int main() {
         []() [[intel::no_global_work_offset("foo")]]{});
 
     h.single_task<class test_kernel6>([]() {
-        // expected-error@+1{{'no_global_work_offset' attribute only applies to functions}}
-        [[intel::no_global_work_offset(1)]] int a;
+      // expected-error@+1{{'no_global_work_offset' attribute only applies to functions}}
+      [[intel::no_global_work_offset(1)]] int a;
+     });
 
-    });
     // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
     // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 1
     // expected-warning@+2{{attribute 'no_global_work_offset' is already applied}}
     h.single_task<class test_kernel7>(
         []() [[intel::no_global_work_offset(0), intel::no_global_work_offset(1)]]{});
-    });
+  });
   return 0;
 }

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
@@ -38,7 +38,7 @@ int main() {
     h.single_task<class test_kernel6>([]() {
       // expected-error@+1{{'no_global_work_offset' attribute only applies to functions}}
       [[intel::no_global_work_offset(1)]] int a;
-     });
+    });
 
     // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
     // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 1

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
@@ -26,7 +26,7 @@ int main() {
     h.single_task<class test_kernel3>(
         []() [[intel::no_global_work_offset(42)]]{});
 
-    // expected-error@+2{{'no_global_work_offset' attribute requires a non-negative integral compile time constant expression}}
+    // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
     h.single_task<class test_kernel4>(
         []() [[intel::no_global_work_offset(-1)]]{});
 

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
@@ -23,10 +23,13 @@ int main() {
         []() [[intel::no_global_work_offset(0)]]{});
 
     // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
+    // CHECK-NEXT:  IntegerLiteral{{.*}}42{{$}}
     h.single_task<class test_kernel3>(
         []() [[intel::no_global_work_offset(42)]]{});
 
     // CHECK: SYCLIntelNoGlobalWorkOffsetAttr{{.*}}
+    // CHECK-NEXT: UnaryOperator{{.*}} 'int' prefix '-'
+    // CHECK-NEXT-NEXT: IntegerLiteral{{.*}}1{{$}}
     h.single_task<class test_kernel4>(
         []() [[intel::no_global_work_offset(-1)]]{});
 

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
@@ -8,7 +8,7 @@ queue q;
 struct FuncObj {
   //expected-warning@+2 {{attribute 'intelfpga::no_global_work_offset' is deprecated}}
   //expected-note@+1 {{did you mean to use 'intel::no_global_work_offset' instead?}}
-  [[intelfpga::no_global_work_offset(1)]] void operator()() const {}
+  [[intelfpga::no_global_work_offset]] void operator()() const {}
 };
 
 int main() {

--- a/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
@@ -9,7 +9,7 @@ queue q;
 
 #ifndef TRIGGER_ERROR
 //first case - good case
-[[intel::no_global_work_offset(1)]] // expected-no-diagnostics
+[[intel::no_global_work_offset]] // expected-no-diagnostics
 void
 func1();
 

--- a/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
@@ -51,23 +51,23 @@ func4() {} // expected-error {{'max_work_group_size' attribute conflicts with ''
 int main() {
   q.submit([&](handler &h) {
 #ifndef TRIGGER_ERROR
-  // CHECK-LABEL:  FunctionDecl {{.*}} main 'int ()'
-  // CHECK:  `-FunctionDecl {{.*}}test_kernel1 'void ()'
-  // CHECK:  -SYCLIntelMaxWorkGroupSizeAttr {{.*}} Inherited 4 4 4
-  // CHECK:  -SYCLIntelNoGlobalWorkOffsetAttr {{.*}}
-  // CHECK:  `-ReqdWorkGroupSizeAttr {{.*}} 2 2 2
-  h.single_task<class test_kernel1>(
-      []() { func1(); });
+    // CHECK-LABEL:  FunctionDecl {{.*}} main 'int ()'
+    // CHECK:  `-FunctionDecl {{.*}}test_kernel1 'void ()'
+    // CHECK:  -SYCLIntelMaxWorkGroupSizeAttr {{.*}} Inherited 4 4 4
+    // CHECK:  -SYCLIntelNoGlobalWorkOffsetAttr {{.*}}
+    // CHECK:  `-ReqdWorkGroupSizeAttr {{.*}} 2 2 2
+    h.single_task<class test_kernel1>(
+        []() { func1(); });
 
 #else
-  h.single_task<class test_kernel2>(
-      []() { func2(); }); // expected-error {{conflicting attributes applied to a SYCL kernel or SYCL_EXTERNAL function}}
+    h.single_task<class test_kernel2>(
+        []() { func2(); }); // expected-error {{conflicting attributes applied to a SYCL kernel or SYCL_EXTERNAL function}}
 
-  h.single_task<class test_kernel3>(
-      []() { func3(); });
+    h.single_task<class test_kernel3>(
+        []() { func3(); });
 
-  h.single_task<class test_kernel4>(
-      []() { func4(); });
+    h.single_task<class test_kernel4>(
+        []() { func4(); });
 #endif
   });
   return 0;

--- a/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/redeclaration-attribute-propagation.cpp
@@ -1,12 +1,15 @@
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat -verify
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -triple spir64 -DTRIGGER_ERROR -Wno-sycl-2017-compat -verify
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -triple spir64 -Wno-sycl-2017-compat | FileCheck %s
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -internal-isystem %S/Inputs -triple spir64 -Wno-sycl-2017-compat -verify
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl -fsycl-is-device -internal-isystem %S/Inputs -triple spir64 -DTRIGGER_ERROR -Wno-sycl-2017-compat -verify
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl -fsycl-is-device -internal-isystem %S/Inputs -triple spir64 -Wno-sycl-2017-compat | FileCheck %s
 
-#include "Inputs/sycl.hpp"
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
 
 #ifndef TRIGGER_ERROR
 //first case - good case
-[[intel::no_global_work_offset]] // expected-no-diagnostics
+[[intel::no_global_work_offset(1)]] // expected-no-diagnostics
 void
 func1();
 
@@ -46,23 +49,26 @@ func4() {} // expected-error {{'max_work_group_size' attribute conflicts with ''
 #endif
 
 int main() {
+  q.submit([&](handler &h) {
 #ifndef TRIGGER_ERROR
   // CHECK-LABEL:  FunctionDecl {{.*}} main 'int ()'
   // CHECK:  `-FunctionDecl {{.*}}test_kernel1 'void ()'
   // CHECK:  -SYCLIntelMaxWorkGroupSizeAttr {{.*}} Inherited 4 4 4
-  // CHECK:  -SYCLIntelNoGlobalWorkOffsetAttr {{.*}} Inherited Enabled
+  // CHECK:  -SYCLIntelNoGlobalWorkOffsetAttr {{.*}}
   // CHECK:  `-ReqdWorkGroupSizeAttr {{.*}} 2 2 2
-  cl::sycl::kernel_single_task<class test_kernel1>(
+  h.single_task<class test_kernel1>(
       []() { func1(); });
 
 #else
-  cl::sycl::kernel_single_task<class test_kernel2>(
+  h.single_task<class test_kernel2>(
       []() { func2(); }); // expected-error {{conflicting attributes applied to a SYCL kernel or SYCL_EXTERNAL function}}
 
-  cl::sycl::kernel_single_task<class test_kernel3>(
+  h.single_task<class test_kernel3>(
       []() { func3(); });
 
-  cl::sycl::kernel_single_task<class test_kernel4>(
+  h.single_task<class test_kernel4>(
       []() { func4(); });
 #endif
+  });
+  return 0;
 }

--- a/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
@@ -7,9 +7,9 @@ template <typename Ty>
 [[intel::no_global_work_offset(Ty{})]] void func() {}
 
 struct S {};
-  // expected-error@+2{{template specialization requires 'template<>'}}
-  // expected-error@+1{{C++ requires a type specifier for all declarations}}
-  func<S>();
+// expected-error@+2{{template specialization requires 'template<>'}}
+// expected-error@+1{{C++ requires a type specifier for all declarations}}
+func<S>();
 
 // Test that checks expression is not a constant expression.
 int foo();

--- a/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
 
-// Test that checkes template parameter support for 'no_global_work_offset' attribute on sycl device.
+// Test that checks template parameter support for 'no_global_work_offset' attribute on sycl device.
 
 template <int SIZE>
 class KernelFunctor {

--- a/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+
+// Test that checkes template parameter support for 'no_global_work_offset' attribute on sycl device.
+
+template <int SIZE>
+class KernelFunctor {
+public:
+  // expected-error@+1{{'no_global_work_offset' attribute requires a non-negative integral compile time constant expression}}
+  [[intel::no_global_work_offset(SIZE)]] void operator()() {}
+};
+
+int main() {
+  //expected-note@+1{{in instantiation of template class 'KernelFunctor<-1>' requested here}}
+  KernelFunctor<-1>();
+  // no error expected
+  KernelFunctor<1>();
+}
+
+// CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
+// CHECK: ClassTemplateSpecializationDecl {{.*}} {{.*}} class KernelFunctor definition
+// CHECK: CXXRecordDecl {{.*}} {{.*}} implicit class KernelFunctor
+// CHECK: SYCLIntelNoGlobalWorkOffsetAttr {{.*}}
+// CHECK: SubstNonTypeTemplateParmExpr {{.*}}
+// CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}

--- a/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
@@ -2,14 +2,17 @@
 
 // Test that checks template parameter support for 'no_global_work_offset' attribute on sycl device.
 
-// Test that checks wrong template instantiation.
+// Test that checks wrong function template instantiation and ensures that the type
+// is checked properly when instantiating from the template definition.
 template <typename Ty>
+// expected-error@+1{{'no_global_work_offset' attribute requires an integer constant}}
 [[intel::no_global_work_offset(Ty{})]] void func() {}
 
 struct S {};
-// expected-error@+2{{template specialization requires 'template<>'}}
-// expected-error@+1{{C++ requires a type specifier for all declarations}}
-func<S>();
+void var() {
+  //expected-note@+1{{in instantiation of function template specialization 'func<S>' requested here}}
+  func<S>();
+}
 
 // Test that checks expression is not a constant expression.
 int foo();
@@ -24,14 +27,10 @@ constexpr int bar() { return 0; }
 template <int SIZE>
 class KernelFunctor {
 public:
-  // expected-error@+1{{'no_global_work_offset' attribute requires a non-negative integral compile time constant expression}}
   [[intel::no_global_work_offset(SIZE)]] void operator()() {}
 };
 
 int main() {
-  //expected-note@+1{{in instantiation of template class 'KernelFunctor<-1>' requested here}}
-  KernelFunctor<-1>();
-  // no error expected
   KernelFunctor<1>();
 }
 

--- a/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-fpga-no-global-work-offset.cpp
@@ -2,6 +2,25 @@
 
 // Test that checks template parameter support for 'no_global_work_offset' attribute on sycl device.
 
+// Test that checks wrong template instantiation.
+template <typename Ty>
+[[intel::no_global_work_offset(Ty{})]] void func() {}
+
+struct S {};
+  // expected-error@+2{{template specialization requires 'template<>'}}
+  // expected-error@+1{{C++ requires a type specifier for all declarations}}
+  func<S>();
+
+// Test that checks expression is not a constant expression.
+int foo();
+// expected-error@+1{{'no_global_work_offset' attribute requires an integer constant}}
+[[intel::no_global_work_offset(foo() + 12)]] void func1();
+
+// Test that checks expression is a constant expression.
+constexpr int bar() { return 0; }
+[[intel::no_global_work_offset(bar() + 12)]] void func2(); // OK
+
+// Test that checks template parameter suppport on member function of class template.
 template <int SIZE>
 class KernelFunctor {
 public:
@@ -19,6 +38,23 @@ int main() {
 // CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
 // CHECK: ClassTemplateSpecializationDecl {{.*}} {{.*}} class KernelFunctor definition
 // CHECK: CXXRecordDecl {{.*}} {{.*}} implicit class KernelFunctor
+// CHECK: SYCLIntelNoGlobalWorkOffsetAttr {{.*}}
+// CHECK: SubstNonTypeTemplateParmExpr {{.*}}
+// CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
+
+// Test that checks template parameter suppport on function.
+template <int N>
+[[intel::no_global_work_offset(N)]] void func3() {}
+
+int check() {
+  func3<1>();
+  return 0;
+}
+
+// CHECK: FunctionTemplateDecl {{.*}} {{.*}} func3
+// CHECK: NonTypeTemplateParmDecl {{.*}} {{.*}} referenced 'int' depth 0 index 0 N
+// CHECK: FunctionDecl {{.*}} {{.*}} func3 'void ()'
 // CHECK: SYCLIntelNoGlobalWorkOffsetAttr {{.*}}
 // CHECK: SubstNonTypeTemplateParmExpr {{.*}}
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}


### PR DESCRIPTION
This patch

adds support for template parameter on
[[intel:: no_global_work_offset())]] attribute where
valid values are 0 and 1. If 1, compiler doesn't 
use the global work offset values for the device function. 
If used without argument, value of 1 is set implicitly.
Attribute parameter is optional,
so [[intelfpga::no_global_work_offset]] means 
the same as [[intelfpga::no_global_work_offset(1)]].

updates sema/codegen tests with mock headers on device.

uses existing function "sema::addIntelSYCLSingleArgFunctionAttr" from
other single argument function attributes such as num_simd_work_items,
max_global_work_dim, and intel_reqd_sub_group_size to avoid source
codes duplication and reuse the codes for the template parameter support.

Removes Bool argument "Enabled" from test and attr.td file since template 
parameter covers functionality of "Enabled" parameter.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>