### PR TITLE
[SYCL] Add code owner for sycl-post-link

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,3 +86,5 @@ sycl/doc/extensions/ @intel/dpcpp-specification-reviewers
 
 xpti/ @tovinkere @andykaylor
 xptifw/ @tovinkere  @andykaylor
+
+llvm/tools/sycl-post-link/ @AlexeySachkov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,4 +87,4 @@ sycl/doc/extensions/ @intel/dpcpp-specification-reviewers
 xpti/ @tovinkere @andykaylor
 xptifw/ @tovinkere  @andykaylor
 
-llvm/tools/sycl-post-link/ @AlexeySachkov
+llvm/tools/sycl-post-link/ @kbobrovs @AlexeySachkov


### PR DESCRIPTION
We don't have a particular code owner for this tool and at the moment it is covered by @bader as a generic code owner for the whole project.

If there are no objections, I would like to nominate myself for this role