### PR TITLE
Add codeowners for bundler and wrapper tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,3 +86,6 @@ sycl/doc/extensions/ @intel/dpcpp-specification-reviewers
 
 xpti/ @tovinkere @andykaylor
 xptifw/ @tovinkere  @andykaylor
+
+clang/tools/clang-offload-bundler/ @kbobrovs @sndmitriev
+clang/tools/clang-offload-wrapper/ @kbobrovs @sndmitriev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,4 +90,4 @@ xptifw/ @tovinkere  @andykaylor
 llvm/tools/sycl-post-link/ @kbobrovs @AlexeySachkov
 
 clang/tools/clang-offload-bundler/ @kbobrovs @sndmitriev
-clang/tools/clang-offload-wrapper/ @kbobrovs @sndmitriev
+clang/tools/clang-offload-wrapper/ @sndmitriev @kbobrovs


### PR DESCRIPTION
Since these tools are placed in clang/ directory, the automation
requests review from clang frontend codeowners, this is not correct. Add
proper codeowners for these tools.