### PR TITLE
[SYCL] Enable instantiation after specialization warning where possible

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -90,6 +90,12 @@ function(add_sycl_rt_library LIB_NAME)
                         VERSION ${SYCL_VERSION_STRING}
                         SOVERSION ${SYCL_MAJOR_VERSION})
 
+  check_cxx_compiler_flag(-Winstantiation-after-specialization
+    HAS_INST_AFTER_SPEC)
+  if (HAS_INST_AFTER_SPEC)
+    target_compile_options(${LIB_OBJ_NAME} PRIVATE
+      -Winstantiation-after-specialization)
+  endif()
 endfunction(add_sycl_rt_library)
 
 set(SYCL_SOURCES


### PR DESCRIPTION
This is a followup for https://github.com/intel/llvm/pull/2818