### PR TITLE
[SYCL] discard_write optimization

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -4126,7 +4126,8 @@ piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer, pi_bool BlockingMap,
     piEventsWait(NumEventsInWaitList, EventWaitList);
     if (Buffer->MapHostPtr) {
       *RetMap = Buffer->MapHostPtr + Offset;
-      memcpy(*RetMap, pi_cast<char *>(Buffer->getZeHandle()) + Offset, Size);
+      if (!(MapFlags & CL_MAP_WRITE_INVALIDATE_REGION))
+        memcpy(*RetMap, pi_cast<char *>(Buffer->getZeHandle()) + Offset, Size);
     } else {
       *RetMap = pi_cast<char *>(Buffer->getZeHandle()) + Offset;
     }

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1141,21 +1141,12 @@ cl_int MemCpyCommand::enqueueImp() {
 
   auto RawEvents = getPiEvents(EventImpls);
 
-  // Omit copying if mode is discard one.
-  // TODO: Handle this at the graph building time by, for example, creating
-  // empty node instead of memcpy.
-  if (MDstReq.MAccessMode == access::mode::discard_read_write ||
-      MDstReq.MAccessMode == access::mode::discard_write ||
-      MSrcAllocaCmd->getMemAllocation() == MDstAllocaCmd->getMemAllocation()) {
-    Command::waitForEvents(Queue, EventImpls, Event);
-  } else {
-    MemoryManager::copy(
-        MSrcAllocaCmd->getSYCLMemObj(), MSrcAllocaCmd->getMemAllocation(),
-        MSrcQueue, MSrcReq.MDims, MSrcReq.MMemoryRange, MSrcReq.MAccessRange,
-        MSrcReq.MOffset, MSrcReq.MElemSize, MDstAllocaCmd->getMemAllocation(),
-        MQueue, MDstReq.MDims, MDstReq.MMemoryRange, MDstReq.MAccessRange,
-        MDstReq.MOffset, MDstReq.MElemSize, std::move(RawEvents), Event);
-  }
+  MemoryManager::copy(
+      MSrcAllocaCmd->getSYCLMemObj(), MSrcAllocaCmd->getMemAllocation(),
+      MSrcQueue, MSrcReq.MDims, MSrcReq.MMemoryRange, MSrcReq.MAccessRange,
+      MSrcReq.MOffset, MSrcReq.MElemSize, MDstAllocaCmd->getMemAllocation(),
+      MQueue, MDstReq.MDims, MDstReq.MMemoryRange, MDstReq.MAccessRange,
+      MDstReq.MOffset, MDstReq.MElemSize, std::move(RawEvents), Event);
 
   return CL_SUCCESS;
 }

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -353,12 +353,20 @@ Command *Scheduler::GraphBuilder::insertMemoryMove(MemObjRecord *Record,
     Record->MHostAccess = MapMode;
   } else {
 
-    // Full copy of buffer is needed to avoid loss of data that may be caused
-    // by copying specific range from host to device and backwards.
-    NewCmd =
-        new MemCpyCommand(*AllocaCmdSrc->getRequirement(), AllocaCmdSrc,
-                          *AllocaCmdDst->getRequirement(), AllocaCmdDst,
-                          AllocaCmdSrc->getQueue(), AllocaCmdDst->getQueue());
+    if (Req->MAccessMode == access::mode::discard_write) {
+      EmptyCommand *Cmd = new EmptyCommand(AllocaCmdDst->getQueue());
+      Cmd->addRequirement(/* DepCmd = */ nullptr, /* AllocaCmd = */ nullptr,
+                          Req);
+      Cmd->MBlockReason = Command::BlockReason::HostAccessor;
+      NewCmd = Cmd;
+    } else {
+      // Full copy of buffer is needed to avoid loss of data that may be caused
+      // by copying specific range from host to device and backwards.
+      NewCmd =
+          new MemCpyCommand(*AllocaCmdSrc->getRequirement(), AllocaCmdSrc,
+                            *AllocaCmdDst->getRequirement(), AllocaCmdDst,
+                            AllocaCmdSrc->getQueue(), AllocaCmdDst->getQueue());
+    }
   }
 
   for (Command *Dep : Deps) {
@@ -1058,7 +1066,8 @@ void Scheduler::GraphBuilder::cleanupFinishedCommands(
     // Update dependency users
     for (DepDesc &Dep : Cmd->MDeps) {
       Command *DepCmd = Dep.MDepCommand;
-      DepCmd->MUsers.erase(Cmd);
+      if (DepCmd)
+        DepCmd->MUsers.erase(Cmd);
     }
 
     Cmd->MMarks.MToBeDeleted = true;


### PR DESCRIPTION
When using `discard_write`  with a host accessor, we do not need to keep the buffer updated with the latest changes on the device. Skipping that operation results in a significant speed-up.

When we have host unified memory, then Map/Unmap operations are enqueued. As these must always match, it is up to the backend (or its plugin) to take advantage of any optimization. In the case of Level Zero, this can be be done in the SYCL plugin interface code.   This PR includes a fix for LevelZero.
CUDA requires no change. OpenCL will need to be changed in the library itself.

When we are not using host unified memory, instead of Map/Unmap operations, we enqueue basic Read/Write ops. When using discard_write on the host, the Read op is unnecessary.   This PR schedules an empty operation instead.  

