### PR TITLE
[SYCL] Handle non-function declaration context

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -1931,8 +1931,13 @@ Sema::SemaDiagnosticBuilder Sema::diagIfOpenMPHostCode(SourceLocation Loc,
                                                        unsigned DiagID) {
   assert(LangOpts.OpenMP && !LangOpts.OpenMPIsDevice &&
          "Expected OpenMP host compilation.");
-  FunctionEmissionStatus FES = getEmissionStatus(getCurFunctionDecl());
+
+  FunctionDecl *FD = getCurFunctionDecl();
   SemaDiagnosticBuilder::Kind Kind = SemaDiagnosticBuilder::K_Nop;
+  if (!FD)
+    return SemaDiagnosticBuilder(Kind, Loc, DiagID, FD, *this);
+
+  FunctionEmissionStatus FES = getEmissionStatus(FD);
   switch (FES) {
   case FunctionEmissionStatus::Emitted:
     Kind = SemaDiagnosticBuilder::K_Immediate;
@@ -1947,7 +1952,7 @@ Sema::SemaDiagnosticBuilder Sema::diagIfOpenMPHostCode(SourceLocation Loc,
     break;
   }
 
-  return SemaDiagnosticBuilder(Kind, Loc, DiagID, getCurFunctionDecl(), *this);
+  return SemaDiagnosticBuilder(Kind, Loc, DiagID, FD, *this);
 }
 
 static OpenMPDefaultmapClauseKind

--- a/clang/test/SemaSYCL/sycl-null-funcdecl.cpp
+++ b/clang/test/SemaSYCL/sycl-null-funcdecl.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -fopenmp-simd -fsycl -fsycl-is-device -triple spir64 -verify -fsyntax-only %s
+
+// Test that in the presence of the OpenMP SIMD option, null function
+// declarations are accounted for when checking to emit diagnostics.
+
+// expected-no-diagnostics
+
+void *x;


### PR DESCRIPTION
With OpenMP SIMD enabled, ensure that it is a function declaration
context before checking the emission status of the function.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>