### PR TITLE
[Driver][SYCL] Remove partial-link path when dealing with fat static …

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4605,41 +4605,27 @@ public:
         !InputArg->getOption().hasFlag(options::LinkerInput) &&
         !types::isSrcFile(HostAction->getType())) {
       std::string InputName = InputArg->getAsString(Args);
-      // Do not create an unbundling action for an object when we know a fat
-      // static library is being used.  A separate unbundling action is created
-      // for all objects and the fat static library.
-      // But in MSVC environment static offload archives are handled differently
-      // due to absence of partial linking support in the linker. Instead of
-      // partially linking input objects and static archives and then unbundling
-      // result we are unbundling all objects and offload archives to extract
-      // device parts. Therefore, in case on MSVC environment unbundling action
-      // for objects is still needed.
-      if (C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment() ||
+      ActionList HostActionList;
+      Action *A(HostAction);
+      // Only check for FPGA device information when using fpga SubArch.
+      if (Args.hasArg(options::OPT_fintelfpga) &&
           !(HostAction->getType() == types::TY_Object &&
-            isObjectFile(InputName) &&
-            C.getDriver().getOffloadStaticLibSeen())) {
-        ActionList HostActionList;
-        Action *A(HostAction);
-        // Only check for FPGA device information when using fpga SubArch.
-        if (Args.hasArg(options::OPT_fintelfpga) &&
-            !(HostAction->getType() == types::TY_Object &&
-              isObjectFile(InputName))) {
-          // Type FPGA aoco is a special case for -foffload-static-lib.
-          if (HostAction->getType() == types::TY_FPGA_AOCO) {
-            if (!hasFPGABinary(C, InputName, types::TY_FPGA_AOCO))
-              return false;
-            A = C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCO);
-          } else if (hasFPGABinary(C, InputName, types::TY_FPGA_AOCX))
-            A = C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCX);
-          else if (hasFPGABinary(C, InputName, types::TY_FPGA_AOCR))
-            A = C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCR);
-        }
-        auto UnbundlingHostAction = C.MakeAction<OffloadUnbundlingJobAction>(A);
-        UnbundlingHostAction->registerDependentActionInfo(
-            C.getSingleOffloadToolChain<Action::OFK_Host>(),
-            /*BoundArch=*/StringRef(), Action::OFK_Host);
-        HostAction = UnbundlingHostAction;
+            isObjectFile(InputName))) {
+        // Type FPGA aoco is a special case for -foffload-static-lib.
+        if (HostAction->getType() == types::TY_FPGA_AOCO) {
+          if (!hasFPGABinary(C, InputName, types::TY_FPGA_AOCO))
+            return false;
+          A = C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCO);
+        } else if (hasFPGABinary(C, InputName, types::TY_FPGA_AOCX))
+          A = C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCX);
+        else if (hasFPGABinary(C, InputName, types::TY_FPGA_AOCR))
+          A = C.MakeAction<InputAction>(*InputArg, types::TY_FPGA_AOCR);
       }
+      auto UnbundlingHostAction = C.MakeAction<OffloadUnbundlingJobAction>(A);
+      UnbundlingHostAction->registerDependentActionInfo(
+          C.getSingleOffloadToolChain<Action::OFK_Host>(),
+          /*BoundArch=*/StringRef(), Action::OFK_Host);
+      HostAction = UnbundlingHostAction;
     }
 
     assert(HostAction && "Invalid host action!");
@@ -5096,84 +5082,9 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
   OffloadBuilder.appendTopLevelLinkAction(Actions);
 
   // Go through all of the args, and create a Linker specific argument list.
-  // When dealing with fat static archives, this is fed into the partial link
-  // step on Linux or each archive is individually addressed on Windows.
+  // When dealing with fat static archives each archive is individually
+  // unbundled.
   SmallVector<const char *, 16> LinkArgs(getLinkerArgs(C, Args));
-  // When a static fat archive is provided, create a new unbundling step
-  // for all of the objects.
-  if (!C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment() &&
-      C.getDriver().getOffloadStaticLibSeen()) {
-    ActionList UnbundlerInputs;
-    for (const auto &LI : LinkerInputs) {
-      // Unbundler only handles objects.
-      if (auto *IA = dyn_cast<InputAction>(LI)) {
-        std::string FileName = IA->getInputArg().getAsString(Args);
-        if ((IA->getType() == types::TY_Object && !isObjectFile(FileName)) ||
-            IA->getInputArg().getOption().hasFlag(options::LinkerInput))
-          // Pass the Input along to linker only.
-          continue;
-      }
-      UnbundlerInputs.push_back(LI);
-    }
-    const Arg *LastArg = nullptr;
-    auto addUnbundlerInput = [&](types::ID T, const StringRef &A) {
-      const llvm::opt::OptTable &Opts = getOpts();
-      Arg *InputArg = MakeInputArg(Args, Opts, C.getArgs().MakeArgString(A));
-      LastArg = InputArg;
-      Action *Current = C.MakeAction<InputAction>(*InputArg, T);
-      UnbundlerInputs.push_back(Current);
-    };
-    bool IsWholeArchive = false;
-    for (StringRef LA : LinkArgs) {
-      if (isStaticArchiveFile(LA)) {
-        addUnbundlerInput(
-            IsWholeArchive ? types::TY_WholeArchive : types::TY_Archive, LA);
-        continue;
-      }
-      if (optionMatches("-no-whole-archive", LA.str())) {
-        IsWholeArchive = false;
-        continue;
-      }
-      if (optionMatches("-whole-archive", LA.str())) {
-        IsWholeArchive = true;
-        continue;
-      }
-      if (isObjectFile(LA.str())) {
-        // Add any objects to the unbundler step.  These objects are passed
-        // directly to the linker, so the driver does not know about them.
-        // FIXME - Better process objects passed to the linker.  We are only
-        // adding these objects to the unbundler step, but these objects can
-        // potentially be fat objects that should be processed by the driver.
-        addUnbundlerInput(types::TY_Object, LA);
-        continue;
-      }
-    }
-
-    if (!UnbundlerInputs.empty() && !PL.empty()) {
-      Action *PartialLink =
-          C.MakeAction<PartialLinkJobAction>(UnbundlerInputs, types::TY_Object);
-      if (!LastArg) {
-        auto *TA = dyn_cast<Action>(UnbundlerInputs.back());
-        assert(TA->getKind() == Action::InputClass ||
-               TA->getKind() == Action::OffloadClass);
-
-        // If the Action is of OffloadAction type, use the HostAction of the
-        // specific Offload Action to set LastArg
-        if (auto *OA = dyn_cast<OffloadAction>(UnbundlerInputs.back()))
-          LastArg =
-              &(dyn_cast<InputAction>(OA->getHostDependence())->getInputArg());
-        else if (auto *IA = dyn_cast<InputAction>(UnbundlerInputs.back()))
-          // else set the LastArg based on Last InputAction
-          LastArg = &(IA->getInputArg());
-      }
-      Action *Current = C.MakeAction<InputAction>(*LastArg, types::TY_Object);
-      ActionList AL;
-      AL.push_back(PartialLink);
-      OffloadBuilder.addHostDependenceToUnbundlingAction(Current, AL, LastArg);
-      Current = OffloadBuilder.addDeviceDependencesToHostAction(Current,
-          LastArg, phases::Link, PL.back(), PL);
-    }
-  }
   const llvm::opt::OptTable &Opts = getOpts();
   auto unbundleStaticLib = [&](types::ID T, const StringRef &A) {
     Arg *InputArg = MakeInputArg(Args, Opts, Args.MakeArgString(A));
@@ -5191,14 +5102,12 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     // as they have already been unbundled and processed for linking.
     if (hasFPGABinary(C, LA.str(), types::TY_FPGA_AOCX))
       continue;
-    // In MSVC environment offload-static-libs are handled slightly different
-    // because of missing support for partial linking in the linker. We add an
-    // unbundling action for each static archive which produces list files with
-    // extracted objects. Device lists are then added to the appropriate device
-    // link actions and host list is ignored since we are adding
-    // offload-static-libs as normal libraries to the host link command.
-    if (C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment() &&
-        hasOffloadSections(C, LA, Args))
+    // For offload-static-libs we add an unbundling action for each static
+    // archive which produces list files with extracted objects. Device lists
+    // are then added to the appropriate device link actions and host list is
+    // ignored since we are adding offload-static-libs as normal libraries to
+    // the host link command.
+    if (hasOffloadSections(C, LA, Args))
       unbundleStaticLib(types::TY_Archive, LA);
     // Pass along the static libraries to check if we need to add them for
     // unbundling for FPGA AOT static lib usage.  Uses FPGA aoco type to
@@ -6160,14 +6069,11 @@ InputInfo Driver::BuildJobsForActionNoCache(
       // unbundling action does not change the type of the output which can
       // cause a overwrite.
       InputInfo CurI;
-      bool IsMSVCEnv =
-          C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment();
       bool IsFPGAObjLink = (JA->getType() == types::TY_Object &&
           C.getInputArgs().hasArg(options::OPT_fintelfpga) &&
           C.getInputArgs().hasArg(options::OPT_fsycl_link_EQ));
       if (C.getDriver().getOffloadStaticLibSeen() &&
-          (JA->getType() == types::TY_Archive ||
-           (JA->getType() == types::TY_Object && !IsMSVCEnv))) {
+          JA->getType() == types::TY_Archive) {
         // Host part of the unbundled static archive is not used.
         if (UI.DependentOffloadKind == Action::OFK_Host)
           continue;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7657,8 +7657,6 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   InputInfo Input = Inputs.front();
   const char *TypeArg = types::getTypeTempSuffix(Input.getType());
   const char *InputFileName = Input.getFilename();
-  bool IsMSVCEnv =
-      C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment();
   types::ID InputType(Input.getType());
   bool IsFPGADepUnbundle = JA.getType() == types::TY_FPGA_Dependencies;
   bool IsFPGADepLibUnbundle = JA.getType() == types::TY_FPGA_Dependencies_List;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7662,14 +7662,8 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   types::ID InputType(Input.getType());
   bool IsFPGADepUnbundle = JA.getType() == types::TY_FPGA_Dependencies;
   bool IsFPGADepLibUnbundle = JA.getType() == types::TY_FPGA_Dependencies_List;
-  bool IsArchiveUnbundle =
-      (!IsMSVCEnv && C.getDriver().getOffloadStaticLibSeen() &&
-       (types::isArchive(InputType) || InputType == types::TY_Object));
 
-  if (IsArchiveUnbundle)
-    TypeArg = "oo";
-  else if (InputType == types::TY_FPGA_AOCX ||
-           InputType == types::TY_FPGA_AOCR) {
+  if (InputType == types::TY_FPGA_AOCX || InputType == types::TY_FPGA_AOCR) {
     // Override type with archive object
     if (getToolChain().getTriple().getSubArch() ==
         llvm::Triple::SPIRSubArch_fpga)
@@ -7678,7 +7672,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
       TypeArg = "aoo";
   }
   if (InputType == types::TY_FPGA_AOCO || IsFPGADepLibUnbundle ||
-      (IsMSVCEnv && types::isArchive(InputType)))
+      types::isArchive(InputType))
     TypeArg = "aoo";
   if (IsFPGADepUnbundle)
     TypeArg = "o";
@@ -7714,7 +7708,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
         Triples += Dep.DependentToolChain->getTriple().normalize();
       }
       continue;
-    } else if (InputType == types::TY_Archive || IsArchiveUnbundle ||
+    } else if (InputType == types::TY_Archive ||
                (TCArgs.hasArg(options::OPT_fintelfpga) &&
                 TCArgs.hasArg(options::OPT_fsycl_link_EQ))) {
       // Do not extract host part if we are unbundling archive on Windows

--- a/clang/test/Driver/openmp-offload.c
+++ b/clang/test/Driver/openmp-offload.c
@@ -661,12 +661,13 @@
 /// ###########################################################################
 
 /// test behaviors of -foffload-static-lib=<lib>
-// RUN: touch %t.a
+// RUN: echo "void foo(void) {}" > %t1.cpp
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fopenmp -fopenmp-targets=x86_64-pc-linux-gnu  %t1.cpp -c -o %t1_bundle.o
+// RUN: llvm-ar cr %t.a %t1_bundle.o
 // RUN: touch %t.o
 // RUN: %clang -fopenmp -fopenmp-targets=x86_64-pc-linux-gnu -foffload-static-lib=%t.a -### %t.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB
-// FOFFLOAD_STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.o]]"
-// FOFFLOAD_STATIC_LIB: clang-offload-bundler{{.*}} "-type=oo"
+// FOFFLOAD_STATIC_LIB: clang-offload-bundler{{.*}} "-type=aoo"
 // FOFFLOAD_STATIC_LIB: ld{{.*}} "@{{.*}}"
 
 // TODO: SYCL specific fail - analyze and enable

--- a/clang/test/Driver/sycl-intelfpga-aoco.cpp
+++ b/clang/test/Driver/sycl-intelfpga-aoco.cpp
@@ -28,18 +28,17 @@
 // CHK-FPGA-AOCO-PHASES: 10: linker, {0, 9}, image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 11: compiler, {4}, ir, (device-sycl)
 // CHK-FPGA-AOCO-PHASES: 12: input, "[[INPUTA]]", archive
-// CHK-FPGA-AOCO-PHASES: 13: partial-link, {9, 12}, object
-// CHK-FPGA-AOCO-PHASES: 14: clang-offload-unbundler, {13}, object
-// CHK-FPGA-AOCO-PHASES: 15: linker, {11, 14}, ir, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 16: sycl-post-link, {15}, ir, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 17: llvm-spirv, {16}, spirv, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 18: input, "[[INPUTA]]", archive
-// CHK-FPGA-AOCO-PHASES: 19: clang-offload-unbundler, {18}, fpga_dependencies_list
-// CHK-FPGA-AOCO-PHASES: 20: input, "[[INPUTA]]", fpga_aoco
-// CHK-FPGA-AOCO-PHASES: 21: clang-offload-unbundler, {20}, fpga_aoco
-// CHK-FPGA-AOCO-PHASES: 22: backend-compiler, {17, 19, 21}, fpga_aocx, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 23: clang-offload-wrapper, {22}, object, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 24: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {23}, image
+// CHK-FPGA-AOCO-PHASES: 13: clang-offload-unbundler, {12}, archive
+// CHK-FPGA-AOCO-PHASES: 14: linker, {11, 13}, ir, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 15: sycl-post-link, {14}, ir, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 16: llvm-spirv, {15}, spirv, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 17: input, "[[INPUTA]]", archive
+// CHK-FPGA-AOCO-PHASES: 18: clang-offload-unbundler, {17}, fpga_dependencies_list
+// CHK-FPGA-AOCO-PHASES: 19: input, "[[INPUTA]]", fpga_aoco
+// CHK-FPGA-AOCO-PHASES: 20: clang-offload-unbundler, {19}, fpga_aoco
+// CHK-FPGA-AOCO-PHASES: 21: backend-compiler, {16, 18, 20}, fpga_aocx, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 22: clang-offload-wrapper, {21}, object, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 23: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {22}, image
 
 /// FPGA AOCO Windows phases check
 // RUN:  %clang_cl -fsycl -fno-sycl-device-lib=all -fintelfpga -foffload-static-lib=%t_aoco_cl.a %s -### -ccc-print-phases 2>&1 \
@@ -78,11 +77,7 @@
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCO,CHK-FPGA-AOCO-WIN %s
 // RUN:  %clang_cl -fsycl -fno-sycl-device-lib=all -fintelfpga %t_aoco_cl.a -### %s 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCO,CHK-FPGA-AOCO-WIN %s
-// CHK-FPGA-AOCO-LIN: clang-offload-bundler{{.*}} "-type=ao" "-targets=sycl-fpga_aoco-intel-unknown-sycldevice" "-inputs=[[INPUTLIB:.+\.a]]" "-check-section"
-// CHK-FPGA-AOCO-LIN: clang{{.*}} "-emit-obj" {{.*}} "-o" "[[HOSTOBJ:.+\.o]]"
-// CHK-FPGA-AOCO-LIN: ld{{.*}} "-r" "-o" "[[PARTLINKOBJ:.+\.o]]" "{{.*}}crt1.o" "{{.*}}crti.o" {{.*}} "[[HOSTOBJ]]" "[[INPUTLIB]]" "{{.*}}crtn.o"
-// CHK-FPGA-AOCO-LIN: clang-offload-bundler{{.*}} "-type=oo" "-targets=sycl-spir64_fpga-unknown-unknown-sycldevice" "-inputs=[[PARTLINKOBJ]]" "-outputs={{.*}}" "-unbundle"
-// CHK-FPGA-AOCO-WIN: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-spir64_fpga-unknown-unknown-sycldevice" "-inputs=[[INPUTLIB:.+\.a]]" "-outputs={{.*}}" "-unbundle"
+// CHK-FPGA-AOCO: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-spir64_fpga-unknown-unknown-sycldevice" "-inputs=[[INPUTLIB:.+\.a]]" "-outputs={{.*}}" "-unbundle"
 // CHK-FPGA-AOCO: llvm-link{{.*}} "@{{.*}}" "-o" "[[LINKEDBC:.+\.bc]]"
 // CHK-FPGA-AOCO: sycl-post-link{{.*}} "-ir-output-only" "-spec-const=default" "-o" "[[PLINKEDBC:.+\.bc]]" "[[LINKEDBC]]"
 // CHK-FPGA-AOCO: llvm-spirv{{.*}} "-o" "[[TARGSPV:.+\.spv]]" {{.*}} "[[PLINKEDBC]]"

--- a/clang/test/Driver/sycl-intelfpga-static-lib.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib.cpp
@@ -15,16 +15,15 @@
 // CHECK_PHASES: 0: input, "[[INPUT:.+\.a]]", object, (host-sycl)
 // CHECK_PHASES: 1: linker, {0}, image, (host-sycl)
 // CHECK_PHASES: 2: input, "[[INPUT]]", archive
-// CHECK_PHASES: 3: partial-link, {2}, object
-// CHECK_PHASES: 4: clang-offload-unbundler, {3}, object
-// CHECK_PHASES: 5: linker, {4}, ir, (device-sycl)
-// CHECK_PHASES: 6: sycl-post-link, {5}, ir, (device-sycl)
-// CHECK_PHASES: 7: llvm-spirv, {6}, spirv, (device-sycl)
-// CHECK_PHASES: 8: input, "[[INPUT]]", archive
-// CHECK_PHASES: 9: clang-offload-unbundler, {8}, fpga_dependencies_list
-// CHECK_PHASES: 10: backend-compiler, {7, 9}, fpga_aocx, (device-sycl)
-// CHECK_PHASES: 11: clang-offload-wrapper, {10}, object, (device-sycl)
-// CHECK_PHASES: 12: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {11}, image
+// CHECK_PHASES: 3: clang-offload-unbundler, {2}, archive
+// CHECK_PHASES: 4: linker, {3}, ir, (device-sycl)
+// CHECK_PHASES: 5: sycl-post-link, {4}, ir, (device-sycl)
+// CHECK_PHASES: 6: llvm-spirv, {5}, spirv, (device-sycl)
+// CHECK_PHASES: 7: input, "[[INPUT]]", archive
+// CHECK_PHASES: 8: clang-offload-unbundler, {7}, fpga_dependencies_list
+// CHECK_PHASES: 9: backend-compiler, {6, 8}, fpga_aocx, (device-sycl)
+// CHECK_PHASES: 10: clang-offload-wrapper, {9}, object, (device-sycl)
+// CHECK_PHASES: 11: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64_fpga-unknown-unknown-sycldevice)" {10}, image
 
 /// Check for unbundle and use of deps in static lib
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -fintelfpga %t.a -### 2>&1 \

--- a/clang/test/Driver/sycl-offload-static-lib-2.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib-2.cpp
@@ -21,10 +21,10 @@
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t_lib.lo -### %t_obj.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB
-// STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" "[[INPUTLD:[^ ]+\.o]]" {{.*}} "-L/dummy/dir"{{.*}} "{{.*}}_obj.o" "{{.*}}_lib.{{(a|lo)}}"
-// STATIC_LIB: clang-offload-bundler{{.*}} "-type=oo" {{.*}} "-inputs=[[INPUTLD]]" "-outputs=[[LISTFILE:.+\.txt]]"
+// STATIC_LIB: clang-offload-bundler{{.*}} "-type=o" {{.*}} "-inputs=[[INPUTO:.+\.o]]" "-outputs=[[HOSTOBJ:.+\.o]],{{.+\.o}}"
+// STATIC_LIB: clang-offload-bundler{{.*}} "-type=aoo" {{.*}} "-inputs={{.*}}" "-outputs=[[LISTFILE:.+\.txt]]"
 // STATIC_LIB: llvm-link{{.*}} "@[[LISTFILE]]"
-// STATIC_LIB: ld{{.*}} "{{.*}}_lib.{{(a|lo)}}" "{{.*}}_obj.o"
+// STATIC_LIB: ld{{.*}} "{{.*}}_lib.{{(a|lo)}}" "[[HOSTOBJ]]"
 
 /// ###########################################################################
 
@@ -35,37 +35,56 @@
 // RUN: touch %t-3.o
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t_lib.a -### %t-1.o %t-2.o %t-3.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_MULTI_O
-// STATIC_LIB_MULTI_O: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\-1.o]]" "[[INPUT:.+\-2.o]]" "[[INPUT:.+\-3.o]]" "[[INPUT:.+\.a]]"
-// STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=oo"
+// STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=o" {{.*}} "-inputs={{.+}}-1.o"
+// STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=o" {{.*}} "-inputs={{.+}}-2.o"
+// STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=o" {{.*}} "-inputs={{.+}}-3.o"
+// STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=aoo"
 // STATIC_LIB_MULTI_O: llvm-link{{.*}} "@{{.*}}"
 
 /// ###########################################################################
 
 /// test behaviors of fat static lib from source
 // RUN: touch %t_lib.a
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t_lib.a -### %s 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t_lib.a -ccc-print-phases -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_SRC
-// STATIC_LIB_SRC: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.a]]"
-// STATIC_LIB_SRC: clang-offload-bundler{{.*}} "-type=oo"
-// STATIC_LIB_SRC: llvm-link{{.*}} "@{{.*}}"
+// STATIC_LIB_SRC: 0: input, "[[INPUTA:.+\.a]]", object, (host-sycl)
+// STATIC_LIB_SRC: 1: input, "[[INPUTC:.+\.cpp]]", c++, (host-sycl)
+// STATIC_LIB_SRC: 2: preprocessor, {1}, c++-cpp-output, (host-sycl)
+// STATIC_LIB_SRC: 3: input, "[[INPUTC]]", c++, (device-sycl)
+// STATIC_LIB_SRC: 4: preprocessor, {3}, c++-cpp-output, (device-sycl)
+// STATIC_LIB_SRC: 5: compiler, {4}, sycl-header, (device-sycl)
+// STATIC_LIB_SRC: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (spir64-unknown-unknown-sycldevice)" {5}, c++-cpp-output
+// STATIC_LIB_SRC: 7: compiler, {6}, ir, (host-sycl)
+// STATIC_LIB_SRC: 8: backend, {7}, assembler, (host-sycl)
+// STATIC_LIB_SRC: 9: assembler, {8}, object, (host-sycl)
+// STATIC_LIB_SRC: 10: linker, {0, 9}, image, (host-sycl)
+// STATIC_LIB_SRC: 11: compiler, {4}, ir, (device-sycl)
+// STATIC_LIB_SRC: 12: input, "[[INPUTA]]", archive
+// STATIC_LIB_SRC: 13: clang-offload-unbundler, {12}, archive
+// STATIC_LIB_SRC: 14: linker, {11, 13}, ir, (device-sycl)
+// STATIC_LIB_SRC: 15: sycl-post-link, {14}, tempfiletable, (device-sycl)
+// STATIC_LIB_SRC: 16: file-table-tform, {15}, tempfilelist, (device-sycl)
+// STATIC_LIB_SRC: 17: llvm-spirv, {16}, tempfilelist, (device-sycl)
+// STATIC_LIB_SRC: 18: file-table-tform, {15, 17}, tempfiletable, (device-sycl)
+// STATIC_LIB_SRC: 19: clang-offload-wrapper, {18}, object, (device-sycl)
+// STATIC_LIB_SRC: 20: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown-sycldevice)" {19}, image
 
 /// ###########################################################################
 
 // RUN: touch %t_lib.a
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t_lib.a -o output_name -lOpenCL -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_SRC2
-// STATIC_LIB_SRC2: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.a]]"
-// STATIC_LIB_SRC2: clang-offload-bundler{{.*}} "-type=oo"
+// STATIC_LIB_SRC2: clang-offload-bundler{{.*}} "-type=aoo"
 // STATIC_LIB_SRC2: llvm-link{{.*}} "@{{.*}}"
-// STATIC_LIB_SRC2: ld{{(.exe)?}}" {{.*}} "-o" "output_name" {{.*}} "-lOpenCL"
+// STATIC_LIB_SRC2: clang{{.*}} "-emit-obj" {{.*}} "-o" "[[HOSTOBJ:.+\.o]]"
+// STATIC_LIB_SRC2: ld{{(.exe)?}}" {{.*}} "[[HOSTOBJ]]"
 
 /// ###########################################################################
 
 // RUN: touch %t_lib.a
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t_lib.a -o output_name -lstdc++ -z relro -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_SRC3
-// STATIC_LIB_SRC3: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.a]]"
-// STATIC_LIB_SRC3: clang-offload-bundler{{.*}} "-type=oo"
+// STATIC_LIB_SRC3: clang-offload-bundler{{.*}} "-type=aoo"
 // STATIC_LIB_SRC3: llvm-link{{.*}} "@{{.*}}"
 // STATIC_LIB_SRC3: ld{{(.exe)?}}" {{.*}} "-o" "output_name" {{.*}} "-lstdc++" "-z" "relro"
 
@@ -80,20 +99,21 @@
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t_obj.o -Wl,--whole-archive %t_lib.a %t_lib_2.a -Wl,--no-whole-archive -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=WHOLE_STATIC_LIB,WHOLE_STATIC_LIB_1
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir %t_obj.o -Wl,@%/t_arg.arg -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefixes=WHOLE_STATIC_LIB,WHOLE_STATIC_LIB_2
-// WHOLE_STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" "[[INPUT:.+\.o]]" "{{.*}}crt1.o" "{{.*}}crti.o" "-L/dummy/dir" {{.*}} "[[INPUTO:.+\.o]]" "--whole-archive" "[[INPUTA:.+\.a]]" "[[INPUTB:.+\.a]]" "--no-whole-archive" "{{.*}}crtn.o"
-// WHOLE_STATIC_LIB: clang-offload-bundler{{.*}} "-type=oo" {{.*}} "-inputs=[[INPUT]]"
+// RUN:   | FileCheck %s -check-prefix=WHOLE_STATIC_LIB
+// WHOLE_STATIC_LIB: clang-offload-bundler{{.*}} "-type=o" {{.*}}
+// WHOLE_STATIC_LIB: clang-offload-bundler{{.*}} "-type=aoo" {{.*}} "-inputs=[[INPUTA:.+\.a]]"
+// WHOLE_STATIC_LIB: clang-offload-bundler{{.*}} "-type=aoo" {{.*}} "-inputs=[[INPUTB:.+\.a]]"
 // WHOLE_STATIC_LIB: llvm-link{{.*}} "@{{.*}}"
 // WHOLE_STATIC_LIB: llvm-spirv{{.*}}
 // WHOLE_STATIC_LIB: clang-offload-wrapper{{.*}}
 // WHOLE_STATIC_LIB: llc{{.*}}
-// WHOLE_STATIC_LIB_1: ld{{.*}} "[[INPUTO]]" "--whole-archive" "[[INPUTA]]" "[[INPUTB]]" "--no-whole-archive"
-// WHOLE_STATIC_LIB_2: ld{{.*}} "[[INPUTO]]" "@{{.*}}_arg.arg"
+// WHOLE_STATIC_LIB_1: ld{{.*}} "--whole-archive" "[[INPUTA]]" "[[INPUTB]]" "--no-whole-archive"
 
 /// test behaviors for special case handling of -z and -rpath
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -z anystring -L/dummy/dir %t_obj.o -Wl,-rpath,nopass -Wl,-z,nopass %t_lib.a %t_lib_2.a -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=WL_CHECK
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -z anystring -L/dummy/dir %t_obj.o -Wl,-rpath -Wl,nopass -Xlinker -z -Xlinker nopass %t_lib.a %t_lib_2.a -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefixes=WL_CHECK
 // WL_CHECK-NOT: ld{{.*}} "-r" {{.*}} "anystring" {{.*}} "nopass"
 // WL_CHECK: ld{{.*}} "-z" "anystring" {{.*}} "-rpath" "nopass" "-z" "nopass"
 
@@ -104,9 +124,7 @@
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_NOSRC
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -L/dummy/dir %t_lib.lo -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_NOSRC
-// STATIC_LIB_NOSRC: clang-offload-bundler{{.*}} "-type=ao" "-targets=host-x86_64-unknown-linux-gnu" "-inputs={{.*}}_lib.{{(a|lo)}}" "-check-section"
-// STATIC_LIB_NOSRC: ld{{.*}} "-r" "-o" "[[PARTIALOBJ:.+\.o]]" "{{.*}}crt1.o" {{.*}} "-L/dummy/dir" {{.*}} "{{.*}}_lib.{{(a|lo)}}"
-// STATIC_LIB_NOSRC: clang-offload-bundler{{.*}} "-type=oo" "-targets=sycl-spir64-unknown-unknown-sycldevice" "-inputs=[[PARTIALOBJ]]" "-outputs=[[DEVICELIST:.+\.txt]]" "-unbundle"
+// STATIC_LIB_NOSRC: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-spir64-unknown-unknown-sycldevice" "-inputs={{.*}}_lib.{{(a|lo)}}" "-outputs=[[DEVICELIST:.+\.txt]]" "-unbundle"
 // STATIC_LIB_NOSRC: llvm-link{{.*}} "@[[DEVICELIST]]" "-o" "[[BCFILE:.+\.bc]]"
 // STATIC_LIB_NOSRC: sycl-post-link{{.*}} "-o" "[[TABLE:.+\.table]]" "[[BCFILE]]"
 // STATIC_LIB_NOSRC: file-table-tform{{.*}} "-o" "[[LIST:.+\.txt]]" "[[TABLE]]"

--- a/clang/test/Driver/sycl-offload-static-lib-2.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib-2.cpp
@@ -45,7 +45,7 @@
 
 /// test behaviors of fat static lib from source
 // RUN: touch %t_lib.a
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t_lib.a -ccc-print-phases -### %s 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fno-sycl-device-lib=all -fsycl %t_lib.a -ccc-print-phases -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_SRC
 // STATIC_LIB_SRC: 0: input, "[[INPUTA:.+\.a]]", object, (host-sycl)
 // STATIC_LIB_SRC: 1: input, "[[INPUTC:.+\.cpp]]", c++, (host-sycl)

--- a/clang/test/Driver/sycl-offload-static-lib.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib.cpp
@@ -18,8 +18,7 @@
 // RUN: touch %t.o
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir -foffload-static-lib=%t.a -### %t.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB
-// FOFFLOAD_STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.o]]" "-L/dummy/dir" "[[INPUT:.+\.a]]"
-// FOFFLOAD_STATIC_LIB: clang-offload-bundler{{.*}} "-type=oo"
+// FOFFLOAD_STATIC_LIB: clang-offload-bundler{{.*}} "-type=aoo"
 // FOFFLOAD_STATIC_LIB: llvm-link{{.*}} "@{{.*}}"
 
 /// Use of -foffload-static-lib and -foffload-whole-static-lib are deprecated
@@ -39,8 +38,10 @@
 // RUN: touch %t-3.o
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -foffload-static-lib=%t.a -### %t-1.o %t-2.o %t-3.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB_MULTI_O
-// FOFFLOAD_STATIC_LIB_MULTI_O: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\-1.o]]" "[[INPUT:.+\-2.o]]" "[[INPUT:.+\-3.o]]" "[[INPUT:.+\.a]]"
-// FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=oo"
+// FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=o" {{.*}} "-inputs={{.+}}-1.o"
+// FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=o" {{.*}} "-inputs={{.+}}-2.o"
+// FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=o" {{.*}} "-inputs={{.+}}-3.o"
+// FOFFLOAD_STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=aoo"
 // FOFFLOAD_STATIC_LIB_MULTI_O: llvm-link{{.*}} "@{{.*}}"
 
 /// ###########################################################################
@@ -63,33 +64,31 @@
 // FOFFLOAD_STATIC_LIB_SRC: 10: linker, {0, 9}, image, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 11: compiler, {4}, ir, (device-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 12: input, "[[INPUTA]]", archive
-// FOFFLOAD_STATIC_LIB_SRC: 13: partial-link, {9, 12}, object
-// FOFFLOAD_STATIC_LIB_SRC: 14: clang-offload-unbundler, {13}, object
-// FOFFLOAD_STATIC_LIB_SRC: 15: linker, {11, 14}, ir, (device-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 16: sycl-post-link, {15}, tempfiletable, (device-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 17: file-table-tform, {16}, tempfilelist, (device-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 18: llvm-spirv, {17}, tempfilelist, (device-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 19: file-table-tform, {16, 18}, tempfiletable, (device-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 20: clang-offload-wrapper, {19}, object, (device-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 21: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown-sycldevice)" {20}, image
+// FOFFLOAD_STATIC_LIB_SRC: 13: clang-offload-unbundler, {12}, archive
+// FOFFLOAD_STATIC_LIB_SRC: 14: linker, {11, 13}, ir, (device-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 15: sycl-post-link, {14}, tempfiletable, (device-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 16: file-table-tform, {15}, tempfilelist, (device-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 17: llvm-spirv, {16}, tempfilelist, (device-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 18: file-table-tform, {15, 17}, tempfiletable, (device-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 19: clang-offload-wrapper, {18}, object, (device-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 20: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown-sycldevice)" {19}, image
 
 /// ###########################################################################
 
 // RUN: touch %t.a
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -foffload-static-lib=%t.a -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB_SRC2
-// FOFFLOAD_STATIC_LIB_SRC2: clang{{.*}} "-emit-obj" {{.*}} "-o" "[[HOSTOBJ:.+\.o]]"
-// FOFFLOAD_STATIC_LIB_SRC2: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[HOSTOBJ]]" "[[INPUT:.+\.a]]"
-// FOFFLOAD_STATIC_LIB_SRC2: clang-offload-bundler{{.*}} "-type=oo"
+// FOFFLOAD_STATIC_LIB_SRC2: clang-offload-bundler{{.*}} "-type=aoo"
 // FOFFLOAD_STATIC_LIB_SRC2: llvm-link{{.*}} "@{{.*}}"
+// FOFFLOAD_STATIC_LIB_SRC2: clang{{.*}} "-emit-obj" {{.*}} "-o" "[[HOSTOBJ:.+\.o]]"
+// FOFFLOAD_STATIC_LIB_SRC2: ld{{(.exe)?}}" {{.*}} "[[HOSTOBJ]]"
 
 /// ###########################################################################
 
 // RUN: touch %t.a
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -foffload-static-lib=%t.a -o output_name -lOpenCL -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB_SRC3
-// FOFFLOAD_STATIC_LIB_SRC3: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.a]]"
-// FOFFLOAD_STATIC_LIB_SRC3: clang-offload-bundler{{.*}} "-type=oo"
+// FOFFLOAD_STATIC_LIB_SRC3: clang-offload-bundler{{.*}} "-type=aoo"
 // FOFFLOAD_STATIC_LIB_SRC3: llvm-link{{.*}} "@{{.*}}"
 // FOFFLOAD_STATIC_LIB_SRC3: ld{{(.exe)?}}" {{.*}} "-o" "output_name" {{.*}} "-lOpenCL"
 
@@ -98,8 +97,7 @@
 // RUN: touch %t.a
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -foffload-static-lib=%t.a -o output_name -lstdc++ -z relro -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB_SRC4
-// FOFFLOAD_STATIC_LIB_SRC4: ld{{(.exe)?}}" "-r" "-o" {{.*}} "[[INPUT:.+\.a]]"
-// FOFFLOAD_STATIC_LIB_SRC4: clang-offload-bundler{{.*}} "-type=oo"
+// FOFFLOAD_STATIC_LIB_SRC4: clang-offload-bundler{{.*}} "-type=aoo"
 // FOFFLOAD_STATIC_LIB_SRC4: llvm-link{{.*}} "@{{.*}}"
 // FOFFLOAD_STATIC_LIB_SRC4: ld{{(.exe)?}}" {{.*}} "-o" "output_name" {{.*}} "-lstdc++" "-z" "relro"
 
@@ -111,34 +109,33 @@
 // RUN: touch %t.o
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -L/dummy/dir -foffload-whole-static-lib=%t.a -foffload-whole-static-lib=%t_2.a -### %t.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_WHOLE_STATIC_LIB
-// FOFFLOAD_WHOLE_STATIC_LIB: ld{{(.exe)?}}" "-r" "-o" "[[INPUT:.+\.o]]" "{{.*}}crt1.o" "{{.*}}crti.o" "-L/dummy/dir" {{.*}} "[[INPUTO:.+\.o]]" "--whole-archive" "[[INPUTA:.+\.a]]" "[[INPUTB:.+\.a]]" "--no-whole-archive" "{{.*}}crtn.o"
-// FOFFLOAD_WHOLE_STATIC_LIB: clang-offload-bundler{{.*}} "-type=oo" {{.*}} "-inputs=[[INPUT]]"
+// FOFFLOAD_WHOLE_STATIC_LIB: clang-offload-bundler{{.*}} "-type=o" {{.*}}
+// FOFFLOAD_WHOLE_STATIC_LIB: clang-offload-bundler{{.*}} "-type=aoo" {{.*}} "-inputs=[[INPUTA:.+\.a]]"
+// FOFFLOAD_WHOLE_STATIC_LIB: clang-offload-bundler{{.*}} "-type=aoo" {{.*}} "-inputs=[[INPUTB:.+\.a]]"
 // FOFFLOAD_WHOLE_STATIC_LIB: llvm-link{{.*}} "@{{.*}}"
 // FOFFLOAD_WHOLE_STATIC_LIB: llvm-spirv{{.*}}
 // FOFFLOAD_WHOLE_STATIC_LIB: clang-offload-wrapper{{.*}}
 // FOFFLOAD_WHOLE_STATIC_LIB: llc{{.*}}
-// FOFFLOAD_WHOLE_STATIC_LIB: ld{{.*}} "[[INPUTA]]" "[[INPUTB]]" "[[INPUTO]]"
+// FOFFLOAD_WHOLE_STATIC_LIB: ld{{.*}} "[[INPUTA]]" "[[INPUTB]]"
 
 /// ###########################################################################
 
 /// test behaviors of -foffload-static-lib with no source/object
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -L/dummy/dir -foffload-static-lib=%t.a -### -ccc-print-phases 2>&1 \
-// RUN:   | FileCheck %s -check-prefixes=FOFFLOAD_STATIC_LIB_NOSRC_PHASES,FOFFLOAD_STATIC_LIB_NOSRC_PHASES_1
+// RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB_NOSRC_PHASES
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -L/dummy/dir -foffload-whole-static-lib=%t.a -### -ccc-print-phases 2>&1 \
-// RUN:   | FileCheck %s -check-prefixes=FOFFLOAD_STATIC_LIB_NOSRC_PHASES,FOFFLOAD_STATIC_LIB_NOSRC_PHASES_2
+// RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB_NOSRC_PHASES
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 0: input, "[[INPUTA:.+\.a]]", object, (host-sycl)
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 1: linker, {0}, image, (host-sycl)
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES_1: 2: input, "[[INPUTA]]", archive
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES_2: 2: input, "[[INPUTA]]", wholearchive
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 3: partial-link, {2}, object
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 4: clang-offload-unbundler, {3}, object
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 5: linker, {4}, ir, (device-sycl)
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 6: sycl-post-link, {5}, tempfiletable, (device-sycl)
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 7: file-table-tform, {6}, tempfilelist, (device-sycl)
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 8: llvm-spirv, {7}, tempfilelist, (device-sycl)
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 9: file-table-tform, {6, 8}, tempfiletable, (device-sycl)
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 10: clang-offload-wrapper, {9}, object, (device-sycl)
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 11: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64-unknown-unknown-sycldevice)" {10}, image
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 2: input, "[[INPUTA]]", archive
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 3: clang-offload-unbundler, {2}, archive
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 4: linker, {3}, ir, (device-sycl)
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 5: sycl-post-link, {4}, tempfiletable, (device-sycl)
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 6: file-table-tform, {5}, tempfilelist, (device-sycl)
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 7: llvm-spirv, {6}, tempfilelist, (device-sycl)
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 8: file-table-tform, {5, 7}, tempfiletable, (device-sycl)
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 9: clang-offload-wrapper, {8}, object, (device-sycl)
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 10: offload, "host-sycl (x86_64-unknown-linux-gnu)" {1}, "device-sycl (spir64-unknown-unknown-sycldevice)" {9}, image
 
 /// ###########################################################################
 

--- a/clang/test/Driver/sycl-offload-tempfile.cpp
+++ b/clang/test/Driver/sycl-offload-tempfile.cpp
@@ -1,14 +1,19 @@
 // UNSUPPORTED: system-windows
 // Test temp file cleanup
+/// test behaviors of passing a fat static lib
+
+// Build a fat static lib that will be used for all tests
+// RUN: echo "void foo(void) {}" > %t1.cpp
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t1.cpp -c -o %t1_bundle.o
+// RUN: llvm-ar cr %t_lib.a %t1_bundle.o
 // RUN: touch %t_obj.o
-// RUN: touch %t_lib.a
 // RUN: mkdir -p %t_dir
 // invoke the compiler overriding output temp location
 // RUN: env TMPDIR=%t_dir TEMP=%t_dir TMP=%t_dir                           \
 // RUN: %clang -target x86_64-unknown-linux-gnu -### -fsycl %t_obj.o -foffload-static-lib=%t_lib.a 2>&1 | \
 // RUN:       FileCheck -DDIRNAME=%t_dir --check-prefix=CHECK-TEMPFILE %s
 // RUN: not ls %t_dir/*
-// CHECK-TEMPFILE: clang-offload-bundler{{.*}} "-type=oo" "-targets=sycl-spir64-unknown-unknown-sycldevice" "-inputs=[[DIRNAME]]{{.*}}" "-outputs=[[DIRNAME]]{{\/|\\}}[[OUTPUT3:.+\.txt]]" "-unbundle"
+// CHECK-TEMPFILE: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-spir64-unknown-unknown-sycldevice" "-inputs={{.*}}" "-outputs=[[DIRNAME]]{{\/|\\}}[[OUTPUT3:.+\.txt]]" "-unbundle"
 // CHECK-TEMPFILE: llvm-link{{.*}} "@[[DIRNAME]]{{\/|\\}}[[OUTPUT3]]"
 
 // RUN: mkdir -p %t_dir


### PR DESCRIPTION
…archives

For Linux, we would use partial linking to generate the object that contained
the device binaries from a fat static archive.  We are moving away from
using partial linking to provide a better overall solution that is the
same in regards to link behaviors for both Linux and Windows.

The change here will allow for the extraction of device binaries from
archives occur in the same manner as it does for Windows.  We do full
extraction from the archives, and do a full llvm-link with those extracted
device binaries.