### PR TITLE
Link clang-offload-bundler with LLVM Core library to fix build breakage

### DIFF
--- a/clang/tools/clang-offload-bundler/CMakeLists.txt
+++ b/clang/tools/clang-offload-bundler/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LLVM_LINK_COMPONENTS Object Support)
+set(LLVM_LINK_COMPONENTS Core Object Support)
 
 add_clang_tool(clang-offload-bundler
   ClangOffloadBundler.cpp


### PR DESCRIPTION
Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>