### PR TITLE
[SYCL] untie from cl_map_flags

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -494,7 +494,7 @@ constexpr pi_mem_flags PI_MEM_FLAGS_HOST_PTR_USE = CL_MEM_USE_HOST_PTR;
 constexpr pi_mem_flags PI_MEM_FLAGS_HOST_PTR_COPY = CL_MEM_COPY_HOST_PTR;
 constexpr pi_mem_flags PI_MEM_FLAGS_HOST_PTR_ALLOC = CL_MEM_ALLOC_HOST_PTR;
 
-// CP
+// flags passed to Map operations
 using pi_map_flags = pi_bitfield;
 constexpr pi_map_flags PI_MAP_READ = CL_MAP_READ;
 constexpr pi_map_flags PI_MAP_WRITE = CL_MAP_WRITE;
@@ -1385,7 +1385,7 @@ piEnqueueMemImageFill(pi_queue command_queue, pi_mem image,
 
 __SYCL_EXPORT pi_result piEnqueueMemBufferMap(
     pi_queue command_queue, pi_mem buffer, pi_bool blocking_map,
-    pi_mem_flags map_flags, size_t offset, size_t size,
+    pi_map_flags map_flags, size_t offset, size_t size,
     pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
     pi_event *event, void **ret_map);
 

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -494,6 +494,13 @@ constexpr pi_mem_flags PI_MEM_FLAGS_HOST_PTR_USE = CL_MEM_USE_HOST_PTR;
 constexpr pi_mem_flags PI_MEM_FLAGS_HOST_PTR_COPY = CL_MEM_COPY_HOST_PTR;
 constexpr pi_mem_flags PI_MEM_FLAGS_HOST_PTR_ALLOC = CL_MEM_ALLOC_HOST_PTR;
 
+// CP
+using pi_map_flags = pi_bitfield;
+constexpr pi_map_flags PI_MAP_READ = CL_MAP_READ;
+constexpr pi_map_flags PI_MAP_WRITE = CL_MAP_WRITE;
+constexpr pi_map_flags PI_MAP_WRITE_INVALIDATE_REGION =
+    CL_MAP_WRITE_INVALIDATE_REGION;
+
 // NOTE: this is made 64-bit to match the size of cl_mem_properties_intel to
 // make the translation to OpenCL transparent.
 // TODO: populate
@@ -1378,9 +1385,9 @@ piEnqueueMemImageFill(pi_queue command_queue, pi_mem image,
 
 __SYCL_EXPORT pi_result piEnqueueMemBufferMap(
     pi_queue command_queue, pi_mem buffer, pi_bool blocking_map,
-    cl_map_flags map_flags, // TODO: untie from OpenCL
-    size_t offset, size_t size, pi_uint32 num_events_in_wait_list,
-    const pi_event *event_wait_list, pi_event *event, void **ret_map);
+    pi_mem_flags map_flags, size_t offset, size_t size,
+    pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
+    pi_event *event, void **ret_map);
 
 __SYCL_EXPORT pi_result piEnqueueMemUnmap(pi_queue command_queue, pi_mem memobj,
                                           void *mapped_ptr,

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4039,7 +4039,7 @@ pi_result cuda_piEnqueueMemImageFill(pi_queue command_queue, pi_mem image,
 ///
 pi_result cuda_piEnqueueMemBufferMap(pi_queue command_queue, pi_mem buffer,
                                      pi_bool blocking_map,
-                                     cl_map_flags map_flags, size_t offset,
+                                     pi_mem_flags map_flags, size_t offset,
                                      size_t size,
                                      pi_uint32 num_events_in_wait_list,
                                      const pi_event *event_wait_list,
@@ -4065,7 +4065,7 @@ pi_result cuda_piEnqueueMemBufferMap(pi_queue command_queue, pi_mem buffer,
     ret_err = PI_SUCCESS;
   }
 
-  if (!is_pinned && ((map_flags & CL_MAP_READ) || (map_flags & CL_MAP_WRITE))) {
+  if (!is_pinned && ((map_flags & PI_MAP_READ) || (map_flags & PI_MAP_WRITE))) {
     // Pinned host memory is already on host so it doesn't need to be read.
     ret_err = cuda_piEnqueueMemBufferRead(
         command_queue, buffer, blocking_map, offset, size, hostPtr,
@@ -4115,9 +4115,9 @@ pi_result cuda_piEnqueueMemUnmap(pi_queue command_queue, pi_mem memobj,
                          _pi_mem::mem_::buffer_mem_::alloc_mode::alloc_host_ptr;
 
   if (!is_pinned &&
-      ((memobj->mem_.buffer_mem_.get_map_flags() & CL_MAP_WRITE) ||
+      ((memobj->mem_.buffer_mem_.get_map_flags() & PI_MAP_WRITE) ||
        (memobj->mem_.buffer_mem_.get_map_flags() &
-        CL_MAP_WRITE_INVALIDATE_REGION))) {
+        PI_MAP_WRITE_INVALIDATE_REGION))) {
     // Pinned host memory is only on host so it doesn't need to be written to.
     ret_err = cuda_piEnqueueMemBufferWrite(
         command_queue, memobj, true,

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4039,7 +4039,7 @@ pi_result cuda_piEnqueueMemImageFill(pi_queue command_queue, pi_mem image,
 ///
 pi_result cuda_piEnqueueMemBufferMap(pi_queue command_queue, pi_mem buffer,
                                      pi_bool blocking_map,
-                                     pi_mem_flags map_flags, size_t offset,
+                                     pi_map_flags map_flags, size_t offset,
                                      size_t size,
                                      pi_uint32 num_events_in_wait_list,
                                      const pi_event *event_wait_list,

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -217,7 +217,7 @@ struct _pi_mem {
       /// Pointer to the active mapped region, if any
       void *mapPtr_;
       /// Original flags for the mapped region
-      pi_mem_flags mapFlags_;
+      pi_map_flags mapFlags_;
 
       /** alloc_mode
        * classic: Just a normal buffer allocated on the device via cuda malloc
@@ -245,7 +245,7 @@ struct _pi_mem {
       /// the data on the device associated with this allocation.
       /// The offset is used to index into the CUDA allocation.
       ///
-      void *map_to_ptr(size_t offset, pi_mem_flags flags) noexcept {
+      void *map_to_ptr(size_t offset, pi_map_flags flags) noexcept {
         assert(mapPtr_ == nullptr);
         mapOffset_ = offset;
         mapFlags_ = flags;
@@ -269,7 +269,7 @@ struct _pi_mem {
         mapOffset_ = 0;
       }
 
-      pi_mem_flags get_map_flags() const noexcept {
+      pi_map_flags get_map_flags() const noexcept {
         assert(mapPtr_ != nullptr);
         return mapFlags_;
       }

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -217,7 +217,7 @@ struct _pi_mem {
       /// Pointer to the active mapped region, if any
       void *mapPtr_;
       /// Original flags for the mapped region
-      cl_map_flags mapFlags_;
+      pi_mem_flags mapFlags_;
 
       /** alloc_mode
        * classic: Just a normal buffer allocated on the device via cuda malloc
@@ -245,7 +245,7 @@ struct _pi_mem {
       /// the data on the device associated with this allocation.
       /// The offset is used to index into the CUDA allocation.
       ///
-      void *map_to_ptr(size_t offset, cl_map_flags flags) noexcept {
+      void *map_to_ptr(size_t offset, pi_mem_flags flags) noexcept {
         assert(mapPtr_ == nullptr);
         mapOffset_ = offset;
         mapFlags_ = flags;
@@ -269,7 +269,7 @@ struct _pi_mem {
         mapOffset_ = 0;
       }
 
-      cl_map_flags get_map_flags() const noexcept {
+      pi_mem_flags get_map_flags() const noexcept {
         assert(mapPtr_ != nullptr);
         return mapFlags_;
       }
@@ -299,7 +299,7 @@ struct _pi_mem {
     mem_.buffer_mem_.size_ = size;
     mem_.buffer_mem_.mapOffset_ = 0;
     mem_.buffer_mem_.mapPtr_ = nullptr;
-    mem_.buffer_mem_.mapFlags_ = CL_MAP_WRITE;
+    mem_.buffer_mem_.mapFlags_ = PI_MAP_WRITE;
     mem_.buffer_mem_.allocMode_ = mode;
     if (is_sub_buffer()) {
       cuda_piMemRetain(mem_.buffer_mem_.parent_);

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -4170,7 +4170,7 @@ pi_result piEnqueueMemBufferFill(pi_queue Queue, pi_mem Buffer,
 }
 
 pi_result piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer,
-                                pi_bool BlockingMap, pi_mem_flags MapFlags,
+                                pi_bool BlockingMap, pi_map_flags MapFlags,
                                 size_t Offset, size_t Size,
                                 pi_uint32 NumEventsInWaitList,
                                 const pi_event *EventWaitList, pi_event *Event,

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -4169,16 +4169,16 @@ pi_result piEnqueueMemBufferFill(pi_queue Queue, pi_mem Buffer,
                               EventWaitList, Event);
 }
 
-pi_result
-piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer, pi_bool BlockingMap,
-                      cl_map_flags MapFlags, // TODO: untie from OpenCL
-                      size_t Offset, size_t Size, pi_uint32 NumEventsInWaitList,
-                      const pi_event *EventWaitList, pi_event *Event,
-                      void **RetMap) {
+pi_result piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer,
+                                pi_bool BlockingMap, pi_mem_flags MapFlags,
+                                size_t Offset, size_t Size,
+                                pi_uint32 NumEventsInWaitList,
+                                const pi_event *EventWaitList, pi_event *Event,
+                                void **RetMap) {
 
   // TODO: we don't implement read-only or write-only, always read-write.
-  // assert((map_flags & CL_MAP_READ) != 0);
-  // assert((map_flags & CL_MAP_WRITE) != 0);
+  // assert((map_flags & PI_MAP_READ) != 0);
+  // assert((map_flags & PI_MAP_WRITE) != 0);
   assert(Buffer);
   assert(Queue);
 
@@ -4217,7 +4217,7 @@ piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer, pi_bool BlockingMap,
     piEventsWait(NumEventsInWaitList, EventWaitList);
     if (Buffer->MapHostPtr) {
       *RetMap = Buffer->MapHostPtr + Offset;
-      if (!(MapFlags & CL_MAP_WRITE_INVALIDATE_REGION))
+      if (!(MapFlags & PI_MAP_WRITE_INVALIDATE_REGION))
         memcpy(*RetMap, pi_cast<char *>(Buffer->getZeHandle()) + Offset, Size);
     } else {
       *RetMap = pi_cast<char *>(Buffer->getZeHandle()) + Offset;

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -666,11 +666,12 @@ pi_result piextEventCreateWithNativeHandle(pi_native_handle nativeHandle,
   return PI_SUCCESS;
 }
 
-pi_result piEnqueueMemBufferMap(
-    pi_queue command_queue, pi_mem buffer, pi_bool blocking_map,
-    cl_map_flags map_flags, // TODO: untie from OpenCL
-    size_t offset, size_t size, pi_uint32 num_events_in_wait_list,
-    const pi_event *event_wait_list, pi_event *event, void **ret_map) {
+pi_result piEnqueueMemBufferMap(pi_queue command_queue, pi_mem buffer,
+                                pi_bool blocking_map, pi_mem_flags map_flags,
+                                size_t offset, size_t size,
+                                pi_uint32 num_events_in_wait_list,
+                                const pi_event *event_wait_list,
+                                pi_event *event, void **ret_map) {
 
   pi_result ret_err = PI_INVALID_OPERATION;
   *ret_map = cast<void *>(clEnqueueMapBuffer(

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -667,7 +667,7 @@ pi_result piextEventCreateWithNativeHandle(pi_native_handle nativeHandle,
 }
 
 pi_result piEnqueueMemBufferMap(pi_queue command_queue, pi_mem buffer,
-                                pi_bool blocking_map, pi_mem_flags map_flags,
+                                pi_bool blocking_map, pi_map_flags map_flags,
                                 size_t offset, size_t size,
                                 pi_uint32 num_events_in_wait_list,
                                 const pi_event *event_wait_list,

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -595,7 +595,7 @@ void *MemoryManager::map(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
                         PI_INVALID_OPERATION);
   }
 
-  pi_mem_flags Flags = 0;
+  pi_map_flags Flags = 0;
 
   switch (AccessMode) {
   case access::mode::read:

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -595,22 +595,22 @@ void *MemoryManager::map(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
                         PI_INVALID_OPERATION);
   }
 
-  cl_map_flags Flags = 0;
+  pi_mem_flags Flags = 0;
 
   switch (AccessMode) {
   case access::mode::read:
-    Flags |= CL_MAP_READ;
+    Flags |= PI_MAP_READ;
     break;
   case access::mode::write:
-    Flags |= CL_MAP_WRITE;
+    Flags |= PI_MAP_WRITE;
     break;
   case access::mode::read_write:
   case access::mode::atomic:
-    Flags = CL_MAP_WRITE | CL_MAP_READ;
+    Flags = PI_MAP_WRITE | PI_MAP_READ;
     break;
   case access::mode::discard_write:
   case access::mode::discard_read_write:
-    Flags |= CL_MAP_WRITE_INVALIDATE_REGION;
+    Flags |= PI_MAP_WRITE_INVALIDATE_REGION;
     break;
   }
 

--- a/sycl/unittests/pi/cuda/test_mem_obj.cpp
+++ b/sycl/unittests/pi/cuda/test_mem_obj.cpp
@@ -140,7 +140,7 @@ TEST_F(CudaTestMemObj, piMemBufferPinnedMappedRead) {
 
   int *host_ptr = nullptr;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
-                queue, memObj, true, CL_MAP_READ, 0, sizeof(int), 0, nullptr,
+                queue, memObj, true, PI_MAP_READ, 0, sizeof(int), 0, nullptr,
                 nullptr, (void **)&host_ptr)),
             PI_SUCCESS);
 
@@ -174,7 +174,7 @@ TEST_F(CudaTestMemObj, piMemBufferPinnedMappedWrite) {
 
   int *host_ptr = nullptr;
   ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
-                queue, memObj, true, CL_MAP_WRITE, 0, sizeof(int), 0, nullptr,
+                queue, memObj, true, PI_MAP_WRITE, 0, sizeof(int), 0, nullptr,
                 nullptr, (void **)&host_ptr)),
             PI_SUCCESS);
 


### PR DESCRIPTION
Define new pi_map_flags to use in lieu of cl_map_flags. 

Signed-off-by: Chris Perkins <chris.perkins@intel.com>