### PR TITLE
[SYCL][L0] Fix the Pi Platform Cache memory leak

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -119,10 +119,9 @@ public:
 
   ~queue_impl() {
     throw_asynchronous();
-    //if (!MHostQueue) {
-    if (!MQueues.empty())
+    if (!MHostQueue) {
       getPlugin().call<PiApiKind::piQueueRelease>(MQueues[0]);
-      //}
+    }
   }
 
   /// \return an OpenCL interoperability queue handle.

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -119,9 +119,10 @@ public:
 
   ~queue_impl() {
     throw_asynchronous();
-    if (!MHostQueue) {
+    //if (!MHostQueue) {
+    if (!MQueues.empty())
       getPlugin().call<PiApiKind::piQueueRelease>(MQueues[0]);
-    }
+      //}
   }
 
   /// \return an OpenCL interoperability queue handle.


### PR DESCRIPTION
Previously we created piPlatformCache from the heap and never deallocated it because this cache should persist until the program ends.
This caused memory leak.
This PR fix this memory leak by turning it into a static vector which will be automatically deallocated when the user program finishes execution.