### PR TITLE
[SYCL][ESIMD] Fix build errors: "no member named 'cl_int2'"

### DIFF
--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_intrin.hpp
@@ -15,6 +15,7 @@
 #include <CL/sycl/INTEL/esimd/detail/esimd_util.hpp>
 #include <CL/sycl/INTEL/esimd/esimd_enum.hpp>
 #include <CL/sycl/detail/accessor_impl.hpp>
+
 #include <assert.h>
 #include <cstdint>
 

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_intrin.hpp
@@ -14,6 +14,8 @@
 #include <CL/sycl/INTEL/esimd/detail/esimd_types.hpp>
 #include <CL/sycl/INTEL/esimd/detail/esimd_util.hpp>
 #include <CL/sycl/INTEL/esimd/esimd_enum.hpp>
+#include <CL/sycl/detail/accessor_impl.hpp>
+#include <assert.h>
 #include <cstdint>
 
 // \brief __esimd_rdregion: region access intrinsic.

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_memory_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_memory_intrin.hpp
@@ -14,6 +14,7 @@
 #include <CL/sycl/INTEL/esimd/detail/esimd_types.hpp>
 #include <CL/sycl/INTEL/esimd/detail/esimd_util.hpp>
 #include <CL/sycl/INTEL/esimd/esimd_enum.hpp>
+#include <CL/sycl/types.hpp>
 #include <cstdint>
 
 // flat_read does flat-address gather


### PR DESCRIPTION
After pull from github I'm seeing build errors like below.
Added missing includes.

```
$ clang++ -fsycl -fsycl-explicit-simd struct_arg_esimd.cpp
In file included from struct_arg_esimd.cpp:1:
In file included from .../include/sycl/CL/sycl/INTEL/esimd.hpp:17:
In file included from .../include/sycl/CL/sycl/INTEL/esimd/esimd_memory.hpp:13:
.../include/sycl/CL/sycl/INTEL/esimd/detail/esimd_memory_intrin.hpp:662:31: error: no member named 'cl_int2' in namespace 'sycl'
      auto coords = cl::sycl::cl_int2(xoff, yoff);
                    ~~~~~~~~~~^
```

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>