### PR TITLE
[Driver] Let all offload builders add inputs to host link job action

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4780,7 +4780,7 @@ public:
     return false;
   }
 
-  Action* makeHostLinkAction() {
+  void makeHostLinkAction(ActionList &LinkerInputs) {
     // Build a list of device linking actions.
     ActionList DeviceAL;
     for (DeviceActionBuilder *SB : SpecializedBuilders) {
@@ -4790,16 +4790,15 @@ public:
     }
 
     if (DeviceAL.empty())
-      return nullptr;
+      return;
 
     // Let builders add host linking actions.
-    Action* HA;
     for (DeviceActionBuilder *SB : SpecializedBuilders) {
       if (!SB->isValid())
         continue;
-      HA = SB->appendLinkHostActions(DeviceAL);
+      if (Action *HA = SB->appendLinkHostActions(DeviceAL))
+        LinkerInputs.push_back(HA);
     }
-    return HA;
   }
 
   /// Processes the host linker action. This currently consists of replacing it
@@ -5184,8 +5183,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
 
   // Add a link action if necessary.
   if (!LinkerInputs.empty()) {
-    if (Action *Wrapper = OffloadBuilder.makeHostLinkAction())
-      LinkerInputs.push_back(Wrapper);
+    OffloadBuilder.makeHostLinkAction(LinkerInputs);
     types::ID LinkType(types::TY_Image);
     if (Args.hasArg(options::OPT_fsycl_link_EQ))
       LinkType = types::TY_Archive;

--- a/clang/test/Driver/openmp-sycl-interop.c
+++ b/clang/test/Driver/openmp-sycl-interop.c
@@ -7,5 +7,8 @@
 // RUN: touch %t.o
 // RUN: %clang --target=x86_64-host-linux-gnu -fsycl -fopenmp -fopenmp-targets=x86_64-device-linux-gnu -### %t.o 2>&1 \
 // RUN:   | FileCheck %s
-// CHECK: clang-offload-wrapper{{(.exe)?}}" {{.*}} "-target=spir64" "-kind=sycl"
-// CHECK: clang-offload-wrapper{{(.exe)?}}" {{.*}} "-kind=openmp" "-target=x86_64-device-linux-gnu"
+// CHECK: clang-offload-wrapper{{(.exe)?}}" {{.*}}"-o=[[SYCLBC:.+\.bc]]" {{.*}}"-target=spir64" "-kind=sycl"
+// CHECK: llc{{.*}}" {{.*}}"-o" "[[SYCLOBJ:.+]]" "[[SYCLBC]]"
+// CHECK: clang-offload-wrapper{{(.exe)?}}" {{.*}}"-o" "[[OMPBC:.*\.bc]]" {{.*}}"-kind=openmp" "-target=x86_64-device-linux-gnu"
+// CHECK: clang{{.*}}" {{.*}}"-o" "[[OMPOBJ:.+]]" "-x" "ir" "[[OMPBC]]"
+// CHECK: ld{{.*}}" "[[OMPOBJ]]" "[[SYCLOBJ]]"

--- a/clang/test/Driver/openmp-sycl-interop.c
+++ b/clang/test/Driver/openmp-sycl-interop.c
@@ -1,0 +1,11 @@
+/// Check that OpenMP and SYCL device binaries are wrapped and linked to the host
+/// image when program uses both OpenMP and SYCL offloading models.
+
+// REQUIRES: clang-driver
+// REQUIRES: x86-registered-target
+
+// RUN: touch %t.o
+// RUN: %clang --target=x86_64-host-linux-gnu -fsycl -fopenmp -fopenmp-targets=x86_64-device-linux-gnu -### %t.o 2>&1 \
+// RUN:   | FileCheck %s
+// CHECK: clang-offload-wrapper{{(.exe)?}}" {{.*}} "-target=spir64" "-kind=sycl"
+// CHECK: clang-offload-wrapper{{(.exe)?}}" {{.*}} "-kind=openmp" "-target=x86_64-device-linux-gnu"


### PR DESCRIPTION
This patch fixes a problem with loosing OpenMP device binary when
program uses both OpenMP and SYCL offloading models.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>