### PR TITLE
[SYCL] Reword some diagnostics to be more consistent.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -130,15 +130,17 @@ def err_intel_fpga_memory_arg_invalid : Error<
 def err_intel_fpga_merge_dir_invalid : Error<
   "merge direction must be 'depth' or 'width'">;
 def err_intel_fpga_reg_limitations : Error <
-  "Illegal %select{argument of type %1 |field in argument}0 to __builtin_intel_fpga_reg.">;
+  "illegal %select{argument of type %1 |field in argument}0 to "
+  "__builtin_intel_fpga_reg">;
 def illegal_type_declared_here : Note<
-  "Field with illegal type declared here">;
+  "field with illegal type declared here">;
 def err_sycl_loop_attr_duplication : Error<
   "duplicate %select{unroll|Intel FPGA}0 loop attribute '%1'">;
 def err_loop_unroll_compatibility : Error<
   "incompatible loop unroll instructions: '%0' and '%1'">;
 def err_pipe_attribute_arg_not_allowed : Error<
-  "'%0' mode for pipe attribute is not supported. Allowed modes: 'read_only', 'write_only'">;
+  "'%0' mode for pipe attribute is not supported; allowed modes are "
+  "'read_only' and 'write_only'">;
 def err_bankbits_numbanks_conflicting : Error<
   "the number of bank_bits must be equal to ceil(log2(numbanks))">;
 def err_bankbits_non_consecutive : Error<
@@ -146,7 +148,7 @@ def err_bankbits_non_consecutive : Error<
 def err_intel_fpga_mem_limitations
     : Error<
           "illegal %select{pointer argument of type %1 |field in type pointed "
-          "to by pointer argument}0 to __builtin_intel_fpga_mem. Only pointers "
+          "to by pointer argument}0 to __builtin_intel_fpga_mem; only pointers "
           "to a first class lvalue or to an rvalue are allowed">;
 def err_intel_fpga_mem_arg_mismatch
     : Error<"builtin parameter must be %select{"
@@ -2844,12 +2846,12 @@ def err_attribute_wrong_number_arguments : Error<
 def err_attribute_too_many_arguments : Error<
   "%0 attribute takes no more than %1 argument%s1">;
 def warn_attribute_too_many_arguments : Warning<
-  "%0 attribute takes no more than %1 argument%s1 - attribute ignored">,
+  "%0 attribute takes no more than %1 argument%s1; attribute ignored">,
  InGroup<IgnoredAttributes>;
 def err_attribute_too_few_arguments : Error<
   "%0 attribute takes at least %1 argument%s1">;
 def warn_attribute_too_few_arguments : Warning<
-  "%0 attribute takes at least %1 argument%s1 - attribute ignored">,
+  "%0 attribute takes at least %1 argument%s1; attribute ignored">,
  InGroup<IgnoredAttributes>;
 def err_attribute_invalid_vector_type : Error<"invalid vector element type %0">;
 def err_attribute_invalid_matrix_type : Error<"invalid matrix element type %0">;
@@ -2866,10 +2868,6 @@ def err_attribute_arm_feature_sve_bits_unsupported : Error<
 def err_attribute_requires_positive_integer : Error<
   "%0 attribute requires a %select{positive|non-negative}1 "
   "integral compile time constant expression">;
-def warn_attribute_requires_positive_integer : Warning<
-  "%0 attribute requires a %select{positive|non-negative}1 "
-  "integral compile time constant expression - attribute ignored">,
- InGroup<IgnoredAttributes>;
 def err_attribute_requires_opencl_version : Error<
   "%0 attribute requires OpenCL version %1%select{| or above}2">;
 def err_invalid_branch_protection_spec : Error<
@@ -11172,12 +11170,12 @@ def warn_sycl_restrict_recursion
     : Warning<"SYCL kernel cannot call a recursive function">,
       InGroup<SyclStrict>, DefaultError;
 def err_ivdep_duplicate_arg : Error<
-  "duplicate argument to 'ivdep'. attribute requires one or both of a safelen "
+  "duplicate argument to 'ivdep'; attribute requires one or both of a safelen "
   "and array">;
 def err_ivdep_unknown_arg : Error<
-  "unknown argument to 'ivdep'. Expected integer or array variable">;
+  "unknown argument to 'ivdep'; expected integer or array variable">;
 def err_ivdep_declrefexpr_arg : Error<
-  "invalid declaration reference argument to 'ivdep'. Expected integer or array"
+  "invalid declaration reference argument to 'ivdep'; expected integer or array"
   " variable">;
 def warn_ivdep_redundant : Warning <"ignoring redundant Intel FPGA loop "
   "attribute 'ivdep': safelen %select{INF|%1}0 >= safelen %select{INF|%3}2">,

--- a/clang/test/SemaSYCL/fpga_pipes.cpp
+++ b/clang/test/SemaSYCL/fpga_pipes.cpp
@@ -6,7 +6,7 @@ using type1 = __attribute__((pipe("read_only"))) const int;
 // no error expected
 using type2 = __attribute__((pipe("write_only"))) const int;
 
-// expected-error@+1 {{'42' mode for pipe attribute is not supported. Allowed modes: 'read_only', 'write_only'}}
+// expected-error@+1 {{'42' mode for pipe attribute is not supported; allowed modes are 'read_only' and 'write_only'}}
 using type3 = __attribute__((pipe("42"))) const int;
 
 // expected-error@+1{{'pipe' attribute requires a string}}

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -72,51 +72,51 @@ void foo_deprecated() {
 void boo() {
   int a[10];
   int b[10];
-  // expected-error@+1 {{duplicate argument to 'ivdep'. attribute requires one or both of a safelen and array}}
+  // expected-error@+1 {{duplicate argument to 'ivdep'; attribute requires one or both of a safelen and array}}
   [[intel::ivdep(2, 2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'ii' attribute takes at least 1 argument - attribute ignored}}
+  // expected-warning@+1 {{'ii' attribute takes at least 1 argument; attribute ignored}}
   [[intel::ii]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'ii' attribute takes no more than 1 argument - attribute ignored}}
+  // expected-warning@+1 {{'ii' attribute takes no more than 1 argument; attribute ignored}}
   [[intel::ii(2, 2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'max_concurrency' attribute takes at least 1 argument - attribute ignored}}
+  // expected-warning@+1 {{'max_concurrency' attribute takes at least 1 argument; attribute ignored}}
   [[intel::max_concurrency]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'max_concurrency' attribute takes no more than 1 argument - attribute ignored}}
+  // expected-warning@+1 {{'max_concurrency' attribute takes no more than 1 argument; attribute ignored}}
   [[intel::max_concurrency(2, 2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-error@+1 {{duplicate argument to 'ivdep'. attribute requires one or both of a safelen and array}}
+  // expected-error@+1 {{duplicate argument to 'ivdep'; attribute requires one or both of a safelen and array}}
   [[intel::ivdep(2, 3)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{duplicate argument to 'ivdep'. attribute requires one or both of a safelen and array}}
+  // expected-error@+1 {{duplicate argument to 'ivdep'; attribute requires one or both of a safelen and array}}
   [[intel::ivdep(a, b)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
+  // expected-error@+1 {{unknown argument to 'ivdep'; expected integer or array variable}}
   [[intel::ivdep(2, 3.0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-warning@+1 {{'disable_loop_pipelining' attribute takes no more than 0 arguments - attribute ignored}}
+  // expected-warning@+1 {{'disable_loop_pipelining' attribute takes no more than 0 arguments; attribute ignored}}
   [[intel::disable_loop_pipelining(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'loop_coalesce' attribute takes no more than 1 argument - attribute ignored}}
+  // expected-warning@+1 {{'loop_coalesce' attribute takes no more than 1 argument; attribute ignored}}
   [[intel::loop_coalesce(2, 3)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'max_interleaving' attribute takes at least 1 argument - attribute ignored}}
+  // expected-warning@+1 {{'max_interleaving' attribute takes at least 1 argument; attribute ignored}}
   [[intel::max_interleaving]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'max_interleaving' attribute takes no more than 1 argument - attribute ignored}}
+  // expected-warning@+1 {{'max_interleaving' attribute takes no more than 1 argument; attribute ignored}}
   [[intel::max_interleaving(2, 4)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'speculated_iterations' attribute takes at least 1 argument - attribute ignored}}
+  // expected-warning@+1 {{'speculated_iterations' attribute takes at least 1 argument; attribute ignored}}
   [[intel::speculated_iterations]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'speculated_iterations' attribute takes no more than 1 argument - attribute ignored}}
+  // expected-warning@+1 {{'speculated_iterations' attribute takes no more than 1 argument; attribute ignored}}
   [[intel::speculated_iterations(1, 2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'nofusion' attribute takes no more than 0 arguments - attribute ignored}}
+  // expected-warning@+1 {{'nofusion' attribute takes no more than 0 arguments; attribute ignored}}
   [[intel::nofusion(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
@@ -148,7 +148,7 @@ void goo() {
   // expected-error@+1 {{'speculated_iterations' attribute requires a non-negative integral compile time constant expression}}
   [[intel::speculated_iterations(-1)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
+  // expected-error@+1 {{unknown argument to 'ivdep'; expected integer or array variable}}
   [[intel::ivdep("test123")]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+1 {{'ii' attribute requires an integer constant}}
@@ -166,7 +166,7 @@ void goo() {
   // expected-error@+1 {{'speculated_iterations' attribute requires an integer constant}}
   [[intel::speculated_iterations("test123")]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{unknown argument to 'ivdep'. Expected integer or array variable}}
+  // expected-error@+1 {{unknown argument to 'ivdep'; expected integer or array variable}}
   [[intel::ivdep("test123")]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // no diagnostics are expected

--- a/clang/test/SemaSYCL/intel-fpga-mem-builtin.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-mem-builtin.cpp
@@ -12,7 +12,7 @@ struct State {
 };
 
 struct inner {
-  void (*fp)(); // expected-note {{Field with illegal type declared here}}
+  void (*fp)(); // expected-note {{field with illegal type declared here}}
 };
 
 struct outer {
@@ -37,22 +37,22 @@ void foo(float *A, int *B, State *C) {
   z = __builtin_intel_fpga_mem(C, i, 0);
   // expected-error@-1{{argument to '__builtin_intel_fpga_mem' must be a constant integer}}
   z = __builtin_intel_fpga_mem(U, 0, 0);
-  // expected-error@-1{{illegal pointer argument of type 'void *'  to __builtin_intel_fpga_mem. Only pointers to a first class lvalue or to an rvalue are allowed}}
+  // expected-error@-1{{illegal pointer argument of type 'void *'  to __builtin_intel_fpga_mem; only pointers to a first class lvalue or to an rvalue are allowed}}
 
   int intArr[10] = {0};
   int *k1 = __builtin_intel_fpga_mem(intArr, 0, 0);
   // expected-error@-1{{builtin parameter must be a pointer}}
 
   int **k2 = __builtin_intel_fpga_mem(&intArr, 0, 0);
-  // expected-error@-1{{illegal pointer argument of type 'int (*)[10]'  to __builtin_intel_fpga_mem. Only pointers to a first class lvalue or to an rvalue are allowed}}
+  // expected-error@-1{{illegal pointer argument of type 'int (*)[10]'  to __builtin_intel_fpga_mem; only pointers to a first class lvalue or to an rvalue are allowed}}
 
   void (*fp1)();
   void (*fp2)() = __builtin_intel_fpga_mem(fp1, 0, 0);
-  // expected-error@-1{{illegal pointer argument of type 'void (*)()'  to __builtin_intel_fpga_mem. Only pointers to a first class lvalue or to an rvalue are allowed}}
+  // expected-error@-1{{illegal pointer argument of type 'void (*)()'  to __builtin_intel_fpga_mem; only pointers to a first class lvalue or to an rvalue are allowed}}
 
   struct outer *iii;
   struct outer *iv = __builtin_intel_fpga_mem(iii, 0, 0);
-  // expected-error@-1{{illegal field in type pointed to by pointer argument to __builtin_intel_fpga_mem. Only pointers to a first class lvalue or to an rvalue are allowed}}
+  // expected-error@-1{{illegal field in type pointed to by pointer argument to __builtin_intel_fpga_mem; only pointers to a first class lvalue or to an rvalue are allowed}}
 }
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/intel-fpga-reg.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-reg.cpp
@@ -19,7 +19,7 @@ struct st {
 static_assert(__has_builtin(__builtin_intel_fpga_reg), "");
 
 struct inner {
-  void (*fp)(); // expected-note {{Field with illegal type declared here}}
+  void (*fp)(); // expected-note {{field with illegal type declared here}}
 };
 
 struct outer {
@@ -42,14 +42,14 @@ void foo() {
   int *bp = __builtin_intel_fpga_reg(ap);
   int intArr[10] = {0};
   int *k = __builtin_intel_fpga_reg(intArr);
-  // expected-error@-1{{Illegal argument of type 'int [10]'  to __builtin_intel_fpga_reg}}
+  // expected-error@-1{{illegal argument of type 'int [10]'  to __builtin_intel_fpga_reg}}
 
   void (*fp1)();
   void (*fp2)() = __builtin_intel_fpga_reg(fp1);
-  //expected-error@-1{{Illegal argument of type 'void (*)()'  to __builtin_intel_fpga_reg.}}
+  //expected-error@-1{{illegal argument of type 'void (*)()'  to __builtin_intel_fpga_reg}}
   struct outer iii;
   struct outer iv = __builtin_intel_fpga_reg(iii);
-  //expected-error@-1{{Illegal field in argument to __builtin_intel_fpga_reg}}
+  //expected-error@-1{{illegal field in argument to __builtin_intel_fpga_reg}}
   void *vp = __builtin_intel_fpga_reg();
   // expected-error@-1{{too few arguments to function call, expected 1, have 0}}
   int tmp = __builtin_intel_fpga_reg(1, 2);


### PR DESCRIPTION
Diagnostics in Clang do not start with a capital letter or contain
terminating punctuation. Aside from rewording, this is an NFC change.