### PR TITLE
[SYCL][L0] Fix memory leak for piCommandListFenceMap.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -525,8 +525,10 @@ pi_result _pi_device::getAvailableCommandList(
 
     if (Queue->Device->ZeCommandListCache.size() > 0) {
       *ZeCommandList = Queue->Device->ZeCommandListCache.front();
-      *ZeFence = Queue->ZeCommandListFenceMap[*ZeCommandList];
-      if (*ZeFence == nullptr) {
+      auto it = Queue->ZeCommandListFenceMap.find(*ZeCommandList);
+      if (it != Queue->ZeCommandListFenceMap.end()) {
+        *ZeFence = it->second;
+      } else {
         // If there is a command list available on this device, but no
         // fence yet associated, then we must create a fence/list
         // reference for this Queue. This can happen if two Queues reuse


### PR DESCRIPTION
std::map::[]operator should not be used to lookup the existence of the map entry because it creates a place-holder entry if the entry does not exist.
This leads to a memory leak because the place-holder won't be explictly deallocated.
Instead, we should use std::map::find() to check if a map entry exists or not.

Signed-off-by: Byoungro So <byoungro.so@intel.com>