### PR TITLE
[llvm-link] fix linker behavior when linking archives with --only-needed option

### DIFF
--- a/llvm/test/tools/llvm-link/Inputs/i.ll
+++ b/llvm/test/tools/llvm-link/Inputs/i.ll
@@ -1,0 +1,8 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @i() {
+  call void @f()
+  ret void
+}
+
+declare void @f()

--- a/llvm/test/tools/llvm-link/archive-only-needed.ll
+++ b/llvm/test/tools/llvm-link/archive-only-needed.ll
@@ -1,0 +1,15 @@
+; RUN: llvm-as %S/Inputs/f.ll -o %t.f.bc
+; RUN: llvm-as %S/Inputs/g.ll -o %t.g.bc
+; RUN: llvm-as %S/Inputs/i.ll -o %t.i.bc
+; RUN: rm -f %t.lib
+; RUN: llvm-ar cr %t.lib %t.f.bc %t.g.bc %t.i.bc
+; RUN: llvm-link %s %t.lib -o %t.linked.bc --only-needed
+; RUN: llvm-nm %t.linked.bc | FileCheck %s
+
+; CHECK: -------- T f
+; CHECK: -------- T i
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+@i = external global i8*
+@llvm.used = appending global [1 x i8*] [i8* bitcast (i8** @i to i8*)], section "llvm.metadata"

--- a/llvm/tools/llvm-link/llvm-link.cpp
+++ b/llvm/tools/llvm-link/llvm-link.cpp
@@ -142,9 +142,9 @@ static std::unique_ptr<Module> loadFile(const char *argv0,
   return Result;
 }
 
-static std::unique_ptr<Module>
-loadArFile(const char *Argv0, std::unique_ptr<MemoryBuffer> Buffer,
-           LLVMContext &Context, unsigned OrigFlags, unsigned ApplicableFlags) {
+static std::unique_ptr<Module> loadArFile(const char *Argv0,
+                                          std::unique_ptr<MemoryBuffer> Buffer,
+                                          LLVMContext &Context) {
   std::unique_ptr<Module> Result(new Module("ArchiveModule", Context));
   StringRef ArchiveName = Buffer->getBufferIdentifier();
   if (Verbose)
@@ -197,9 +197,8 @@ loadArFile(const char *Argv0, std::unique_ptr<MemoryBuffer> Buffer,
     }
     if (Verbose)
       errs() << "Linking member '" << ChildName << "' of archive library.\n";
-    if (Linker::linkModules(*Result, std::move(M), ApplicableFlags))
+    if (Linker::linkModules(*Result, std::move(M)))
       return nullptr;
-    ApplicableFlags = OrigFlags;
   } // end for each child
   ExitOnErr(std::move(Err));
   return Result;
@@ -354,8 +353,7 @@ static bool linkFiles(const char *argv0, LLVMContext &Context, Linker &L,
 
     std::unique_ptr<Module> M =
         identify_magic(Buffer->getBuffer()) == file_magic::archive
-            ? loadArFile(argv0, std::move(Buffer), Context, Flags,
-                         ApplicableFlags)
+            ? loadArFile(argv0, std::move(Buffer), Context)
             : loadFile(argv0, std::move(Buffer), Context);
     if (!M.get()) {
       errs() << argv0 << ": ";


### PR DESCRIPTION
This patch fixes linker behavior when archive is linked with other inputs as
a library (i.e. when --only-needed option is specified). In this case library is
expected to be normally linked first into a separate module and only after
that linker should import required symbols from the linked library module.

This is the same change as https://reviews.llvm.org/D92535

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>