### PR TITLE
[SYCL][ESIMD] Software-emulation of ESIMD using CM library

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -24,6 +24,8 @@ def do_configure(args):
     llvm_enable_projects = 'clang;llvm-spirv;sycl;opencl-aot;xpti;libdevice'
     libclc_targets_to_build = ''
     sycl_build_pi_cuda = 'OFF'
+    sycl_build_pi_esimd_cpu = 'ON'
+    sycl_build_pi_esimd_cpu_deprecated = 'OFF'
     sycl_werror = 'ON'
     llvm_enable_assertions = 'ON'
     llvm_enable_doxygen = 'OFF'
@@ -41,6 +43,11 @@ def do_configure(args):
         llvm_enable_projects += ';libclc'
         libclc_targets_to_build = 'nvptx64--;nvptx64--nvidiacl'
         sycl_build_pi_cuda = 'ON'
+
+    if args.disable_esimd_cpu:
+        sycl_build_pi_esimd_cpu = 'OFF'
+    elif args.esimd_cpu_deprecated:
+        sycl_build_pi_esimd_cpu_deprecated = 'ON'
 
     if args.no_werror:
         sycl_werror = 'OFF'
@@ -78,6 +85,8 @@ def do_configure(args):
         "-DLLVM_ENABLE_DOXYGEN={}".format(llvm_enable_doxygen),
         "-DLLVM_ENABLE_SPHINX={}".format(llvm_enable_sphinx),
         "-DBUILD_SHARED_LIBS={}".format(llvm_build_shared_libs),
+        "-DSYCL_BUILD_PI_ESIMD_CPU={}".format(sycl_build_pi_esimd_cpu),
+        "-DSYCL_BUILD_PI_ESIMD_CPU_DEPRECATED={}".format(sycl_build_pi_esimd_cpu_deprecated),
         "-DSYCL_ENABLE_XPTI_TRACING=ON" # Explicitly turn on XPTI tracing
     ]
 
@@ -133,6 +142,8 @@ def main():
                         metavar="BUILD_TYPE", default="Release", help="build type: Debug, Release")
     parser.add_argument("--cuda", action='store_true', help="switch from OpenCL to CUDA")
     parser.add_argument("--arm", action='store_true', help="build ARM support rather than x86")
+    parser.add_argument("--disable-esimd-cpu", action='store_true', help="build without ESIMD_CPU support")
+    parser.add_argument("--esimd-cpu-deprecated", action='store_true', help="build with deprecated ESIMD_CPU support")
     parser.add_argument("--no-assertions", action='store_true', help="build without assertions")
     parser.add_argument("--docs", action='store_true', help="build Doxygen documentation")
     parser.add_argument("--system-ocl", action='store_true', help="use OpenCL deps from system (no download)")

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -351,6 +351,7 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      pi_opencl
      pi_level_zero
      libsycldevice
+     pi_esimd_cpu
 )
 if(OpenCL_INSTALL_KHRONOS_ICD_LOADER AND TARGET ocl-icd)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS opencl-icd)
@@ -366,6 +367,15 @@ if(SYCL_BUILD_PI_CUDA)
 
   add_dependencies(sycl-toolchain libspirv-builtins pi_cuda)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins pi_cuda)
+endif()
+
+if (SYCL_BUILD_PI_ESIMD_CPU)
+  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libcmrt-headers)
+  if (MSVC)
+    list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libcmrt-libs libcmrt-dlls)
+  else()
+    list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libcmrt-sos)
+  endif()
 endif()
 
 # Use it as fake dependency in order to force another command(s) to execute.

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/cmrt_if_defs.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/cmrt_if_defs.hpp
@@ -1,0 +1,147 @@
+//==----------------- CM Runtime Interface Definitions ---------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef _CMRT_IF_DEFS_HPP_
+#define _CMRT_IF_DEFS_HPP_
+
+/// CMRT Inteface Defines
+
+#include <unordered_map>
+
+// Base class to store common data
+struct _pi_object {
+  _pi_object() : RefCount{1} {}
+
+  std::atomic<pi_uint32> RefCount;
+};
+struct _pi_platform {
+  _pi_platform() {}
+
+  // Keep Version information.
+  std::string CmEmuVersion;
+};
+
+struct _pi_device : _pi_object {
+  _pi_device(pi_platform plt) : Platform{plt} {}
+
+  pi_platform Platform;
+};
+
+struct _pi_context : _pi_object {
+  _pi_context(pi_device DeviceArg, cm_support::CmDevice *CmDeviceArg)
+      : Device{DeviceArg}, CmDevicePtr{CmDeviceArg} {}
+
+  /// One-to-one mapping between Context and Device
+  pi_device Device;
+
+  cm_support::CmDevice *CmDevicePtr = nullptr;
+
+  /// Map SVM memory starting address to corresponding
+  /// CmBufferSVM object. CmBufferSVM object is needed to release memory.
+  std::unordered_map<void *, cm_support::CmBufferSVM *> Addr2CmBufferSVM;
+};
+
+struct _pi_queue : _pi_object {
+  _pi_queue(pi_context ContextArg, cm_support::CmQueue *CmQueueArg)
+      : Context{ContextArg}, CmQueuePtr{CmQueueArg} {}
+
+  // Keeps the PI context to which this queue belongs.
+  pi_context Context = nullptr;
+  cm_support::CmQueue *CmQueuePtr = nullptr;
+};
+
+struct _pi_mem : _pi_object {
+  _pi_mem() {}
+
+  pi_context Context;
+
+  char *MapHostPtr = nullptr;
+
+  // Supplementary data to keep track of the mappings of this memory
+  // created with piEnqueueMemBufferMap and piEnqueueMemImageMap.
+  struct Mapping {
+    // The offset in the buffer giving the start of the mapped region.
+    size_t Offset;
+    // The size of the mapped region.
+    size_t Size;
+  };
+
+  /*
+  // Method to get type of the derived object (image or buffer)
+  virtual bool isImage() const = 0;
+  */
+
+  virtual ~_pi_mem() = default;
+
+  _pi_mem_type getMemType() const { return MemType; };
+
+  /*
+  // Thread-safe methods to work with memory mappings
+  pi_result addMapping(void *MappedTo, size_t Size, size_t Offset);
+  pi_result removeMapping(void *MappedTo, Mapping &MapInfo);
+  */
+
+protected:
+  _pi_mem(pi_context ctxt, char *HostPtr, _pi_mem_type MemTypeArg)
+      : Context{ctxt}, MapHostPtr{HostPtr}, Mappings{}, MemType{MemTypeArg} {}
+
+private:
+  // The key is the host pointer representing an active mapping.
+  // The value is the information needed to maintain/undo the mapping.
+  std::unordered_map<void *, Mapping> Mappings;
+
+  // TODO: we'd like to create a thread safe map class instead of mutex + map,
+  // that must be carefully used together.
+  // The mutex that is used for thread-safe work with Mappings.
+  std::mutex MappingsMutex;
+
+  _pi_mem_type MemType;
+};
+
+struct _pi_buffer final : _pi_mem {
+  // Buffer/Sub-buffer constructor
+  _pi_buffer(pi_context ctxt, char *HostPtr, cm_support::CmBuffer *CmBufArg,
+             cm_support::SurfaceIndex *CmIdxArg)
+      : _pi_mem(ctxt, HostPtr, PI_MEM_TYPE_BUFFER), CmBufferPtr{CmBufArg},
+        CmBufferIdx{CmIdxArg} {}
+
+  cm_support::CmBuffer *CmBufferPtr;
+  cm_support::SurfaceIndex *CmBufferIdx;
+};
+
+struct _pi_image final : _pi_mem {
+  // Image constructor
+  _pi_image(pi_context ctxt, char *HostPtr, cm_support::CmSurface2D *CmSurfArg,
+            cm_support::SurfaceIndex *CmIdxArg)
+      : _pi_mem(ctxt, HostPtr, PI_MEM_TYPE_IMAGE2D), CmSurfacePtr{CmSurfArg},
+        CmSurfaceIdx{CmIdxArg} {}
+
+  cm_support::CmSurface2D *CmSurfacePtr;
+  cm_support::SurfaceIndex *CmSurfaceIdx;
+};
+
+struct _pi_event : _pi_object {
+  _pi_event() {}
+
+  cm_support::CmEvent *CmEventPtr = nullptr;
+  cm_support::CmQueue *OwnerQueue = nullptr;
+  pi_context Context = nullptr;
+  bool IsDummyEvent = false;
+};
+
+struct _pi_program : _pi_object {
+  _pi_program() {}
+
+  // Keep the context of the program.
+  pi_context Context;
+};
+
+struct _pi_kernel : _pi_object {
+  _pi_kernel() {}
+};
+
+#endif // _CMRT_IF_DEFS_HPP_

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_libcm.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_libcm.hpp
@@ -1,0 +1,349 @@
+//==------------ esimd_libcm.hpp libcm interface definitions --------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _ESIMD_LIBCM_HPP_
+#define _ESIMD_LIBCM_HPP_
+
+#ifndef __SYCL_DEVICE_ONLY__
+
+#include <CL/sycl/backend_types.hpp>
+#include <CL/sycl/detail/accessor_impl.hpp>
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/export.hpp>
+#include <CL/sycl/detail/helpers.hpp>
+#include <CL/sycl/detail/host_profiling_info.hpp>
+#include <CL/sycl/detail/kernel_desc.hpp>
+#include <CL/sycl/detail/type_traits.hpp>
+#include <CL/sycl/group.hpp>
+#include <CL/sycl/id.hpp>
+#include <CL/sycl/kernel.hpp>
+#include <CL/sycl/nd_item.hpp>
+#include <CL/sycl/range.hpp>
+
+#include <thread>
+
+#include "esimdcpu_runtime.h" // TODO : From CM library
+
+#include "esimd_libcm_lambda_wrapper.hpp"
+
+#define _COMMA_ ,
+
+LAMBDA_WRAPPER_TMPL(sycl::id<3>, ID_3DIM)
+LAMBDA_WRAPPER_TMPL(sycl::id<2>, ID_2DIM)
+LAMBDA_WRAPPER_TMPL(sycl::id<1>, ID_1DIM)
+LAMBDA_WRAPPER_TMPL(sycl::item<3 _COMMA_ false>, ITEM_3DIM)
+LAMBDA_WRAPPER_TMPL(sycl::item<2 _COMMA_ false>, ITEM_2DIM)
+LAMBDA_WRAPPER_TMPL(sycl::item<1 _COMMA_ false>, ITEM_1DIM)
+LAMBDA_WRAPPER_TMPL(sycl::item<3 _COMMA_ true>, ITEM_OFFSET_3DIM)
+LAMBDA_WRAPPER_TMPL(sycl::item<2 _COMMA_ true>, ITEM_OFFSET_2DIM)
+LAMBDA_WRAPPER_TMPL(sycl::item<1 _COMMA_ true>, ITEM_OFFSET_1DIM)
+LAMBDA_WRAPPER_TMPL(sycl::nd_item<3>, NDITEM_3DIM)
+LAMBDA_WRAPPER_TMPL(sycl::nd_item<2>, NDITEM_2DIM)
+LAMBDA_WRAPPER_TMPL(sycl::nd_item<1>, NDITEM_1DIM)
+
+template <class KernelType, class KernelArgType, typename IteratorType,
+          int __Dims__>
+class libCMBatch {
+private:
+  KernelType MKernel;
+  std::vector<IteratorType> argVector;
+  std::vector<uint32_t> spaceDim;
+  const std::vector<uint32_t> singleGrpDim = {1, 1, 1};
+  const uint32_t hwThreads = (uint32_t)std::thread::hardware_concurrency();
+
+  using IDBuilder = sycl::detail::Builder;
+
+public:
+  libCMBatch(KernelType Kernel) : MKernel(Kernel), spaceDim{1, 1, 1} {}
+
+  // ID
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::id<__Dims__>>::value>::type
+  runIterationSpace(const sycl::range<__Dims__> Range) {
+    sycl::detail::NDLoop<__Dims__>::iterate(
+        Range, [&](const sycl::id<__Dims__> &ID) { argVector.push_back(ID); });
+    for (int I = 0; I < __Dims__; ++I) {
+      spaceDim[I] = (uint32_t)Range[I];
+    }
+    run();
+  }
+
+  // Item w/o offset
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<
+      std::is_same<ArgT, sycl::item<__Dims__, /*Offset=*/false>>::value>::type
+  runIterationSpace(const sycl::range<__Dims__> Range) {
+    sycl::detail::NDLoop<__Dims__>::iterate(
+        Range, [&](const sycl::id<__Dims__> ID) {
+          sycl::item<__Dims__, /*Offset=*/false> Item =
+              IDBuilder::createItem<__Dims__, false>(Range, ID);
+          argVector.push_back(Item);
+        });
+    for (int I = 0; I < __Dims__; ++I) {
+      spaceDim[I] = (uint32_t)Range[I];
+    }
+    run();
+  }
+
+  // Item w/ offset
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<
+      std::is_same<ArgT, sycl::item<__Dims__, /*Offset=*/true>>::value>::type
+  runIterationSpace(const sycl::range<__Dims__> Range,
+                    const sycl::id<__Dims__> Offset) {
+    sycl::detail::NDLoop<__Dims__>::iterate(
+        Range, [&](const sycl::id<__Dims__> &ID) {
+          sycl::id<__Dims__> OffsetID = ID + Offset;
+          sycl::item<__Dims__, /*Offset=*/true> Item =
+              IDBuilder::createItem<__Dims__, true>(Range, OffsetID, Offset);
+          argVector.push_back(Item);
+        });
+    for (int I = 0; I < __Dims__; ++I) {
+      spaceDim[I] = (uint32_t)Range[I];
+    }
+    run();
+  }
+
+  // NDItem
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<
+      std::is_same<ArgT, sycl::nd_item<__Dims__>>::value>::type
+  runIterationSpace(const sycl::id<__Dims__> &GroupID,
+                    const sycl::group<__Dims__> Group,
+                    const sycl::range<__Dims__> LocalSize,
+                    const sycl::range<__Dims__> GlobalSize,
+                    const sycl::id<__Dims__> GlobalOffset) {
+    sycl::detail::NDLoop<__Dims__>::iterate(
+        LocalSize, [&](const sycl::id<__Dims__> &LocalID) {
+          sycl::id<__Dims__> GlobalID =
+              GroupID * LocalSize + LocalID + GlobalOffset;
+          const sycl::item<__Dims__, /*Offset=*/true> GlobalItem =
+              IDBuilder::createItem<__Dims__, true>(GlobalSize, GlobalID,
+                                                    GlobalOffset);
+          const sycl::item<__Dims__, /*Offset=*/false> LocalItem =
+              IDBuilder::createItem<__Dims__, false>(LocalSize, LocalID);
+          const sycl::nd_item<__Dims__> NDItem =
+              IDBuilder::createNDItem<__Dims__>(GlobalItem, LocalItem, Group);
+          argVector.push_back(NDItem);
+        });
+    for (int I = 0; I < __Dims__; ++I) {
+      spaceDim[I] = (uint32_t)LocalSize[I];
+    }
+    run();
+  }
+
+private:
+  /*
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::id<__Dims__>>::value>::type
+  run()
+  {
+    throw cl::sycl::feature_not_supported();
+  }
+  */
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::id<1>>::value>::type run() {
+    struct LambdaWrapper_ID_1DIM *wrappedLambda_ID_1DIM =
+        makeWrapper_ID_1DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_ID_1DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_ID_1DIM),
+                      wrappedLambda_ID_1DIM);
+
+    argVector.clear();
+  }
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::id<2>>::value>::type run() {
+    struct LambdaWrapper_ID_2DIM *wrappedLambda_ID_2DIM =
+        makeWrapper_ID_2DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_ID_2DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_ID_2DIM),
+                      wrappedLambda_ID_2DIM);
+
+    argVector.clear();
+  }
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::id<3>>::value>::type run() {
+    struct LambdaWrapper_ID_3DIM *wrappedLambda_ID_3DIM =
+        makeWrapper_ID_3DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_ID_3DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_ID_3DIM),
+                      wrappedLambda_ID_3DIM);
+
+    argVector.clear();
+  }
+
+  /*
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<
+      std::is_same<ArgT, sycl::item<__Dims__, false>>::value>::type
+  run()
+  {
+    throw cl::sycl::feature_not_supported();
+  }
+  */
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::item<1, false>>::value>::type
+  run() {
+    struct LambdaWrapper_ITEM_1DIM *wrappedLambda_ITEM_1DIM =
+        makeWrapper_ITEM_1DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_ITEM_1DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_ITEM_1DIM),
+                      wrappedLambda_ITEM_1DIM);
+
+    argVector.clear();
+  }
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::item<2, false>>::value>::type
+  run() {
+    struct LambdaWrapper_ITEM_2DIM *wrappedLambda_ITEM_2DIM =
+        makeWrapper_ITEM_2DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_ITEM_2DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_ITEM_2DIM),
+                      wrappedLambda_ITEM_2DIM);
+
+    argVector.clear();
+  }
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::item<3, false>>::value>::type
+  run() {
+    struct LambdaWrapper_ITEM_3DIM *wrappedLambda_ITEM_3DIM =
+        makeWrapper_ITEM_3DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_ITEM_3DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_ITEM_3DIM),
+                      wrappedLambda_ITEM_3DIM);
+
+    argVector.clear();
+  }
+
+  /*
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<
+      std::is_same<ArgT, sycl::item<__Dims__, true>>::value>::type
+  run()
+  {
+    throw cl::sycl::feature_not_supported();
+  }
+  */
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::item<1, true>>::value>::type
+  run() {
+    struct LambdaWrapper_ITEM_OFFSET_1DIM *wrappedLambda_ITEM_OFFSET_1DIM =
+        makeWrapper_ITEM_OFFSET_1DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_ITEM_OFFSET_1DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_ITEM_OFFSET_1DIM),
+                      wrappedLambda_ITEM_OFFSET_1DIM);
+    argVector.clear();
+  }
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::item<2, true>>::value>::type
+  run() {
+    struct LambdaWrapper_ITEM_OFFSET_2DIM *wrappedLambda_ITEM_OFFSET_2DIM =
+        makeWrapper_ITEM_OFFSET_2DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_ITEM_OFFSET_2DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_ITEM_OFFSET_2DIM),
+                      wrappedLambda_ITEM_OFFSET_2DIM);
+    argVector.clear();
+  }
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::item<3, true>>::value>::type
+  run() {
+    struct LambdaWrapper_ITEM_OFFSET_3DIM *wrappedLambda_ITEM_OFFSET_3DIM =
+        makeWrapper_ITEM_OFFSET_3DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_ITEM_OFFSET_3DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_ITEM_OFFSET_3DIM),
+                      wrappedLambda_ITEM_OFFSET_3DIM);
+    argVector.clear();
+  }
+
+  /*
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT,
+  sycl::nd_item<__Dims__>>::value>::type run()
+  {
+    throw cl::sycl::feature_not_supported();
+  }
+  */
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::nd_item<1>>::value>::type
+  run() {
+    struct LambdaWrapper_NDITEM_1DIM *wrappedLambda_NDITEM_1DIM =
+        makeWrapper_NDITEM_1DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_NDITEM_1DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_NDITEM_1DIM),
+                      wrappedLambda_NDITEM_1DIM);
+    argVector.clear();
+  }
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::nd_item<2>>::value>::type
+  run() {
+    struct LambdaWrapper_NDITEM_2DIM *wrappedLambda_NDITEM_2DIM =
+        makeWrapper_NDITEM_2DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_NDITEM_2DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_NDITEM_2DIM),
+                      wrappedLambda_NDITEM_2DIM);
+    argVector.clear();
+  }
+
+  template <class ArgT = KernelArgType>
+  typename std::enable_if<std::is_same<ArgT, sycl::nd_item<3>>::value>::type
+  run() {
+    struct LambdaWrapper_NDITEM_3DIM *wrappedLambda_NDITEM_3DIM =
+        makeWrapper_NDITEM_3DIM(argVector, MKernel);
+
+    ESimdCPUKernel eSimdCPU((fptrVoid)invokeLambda_NDITEM_3DIM, spaceDim);
+
+    eSimdCPU.launchMT(sizeof(struct LambdaWrapper_NDITEM_3DIM),
+                      wrappedLambda_NDITEM_3DIM);
+    argVector.clear();
+  }
+};
+
+inline void __cm_mt_barrier() { cm_support::mt_barrier(); }
+
+inline void __cm_set_slm_size(size_t size) { cm_support::set_slm_size(size); }
+
+inline size_t __cm_get_slm_size() { return cm_support::get_slm_size(); }
+
+inline char *__cm_get_slm() { return cm_support::get_slm(); }
+
+#endif // __SYCL_DEVICE_ONLY__
+
+#endif // _ESIMD_LIBCM_HPP_

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_libcm_lambda_wrapper.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_libcm_lambda_wrapper.hpp
@@ -1,0 +1,33 @@
+//==- esimd_libcm_lambda_wrapper.hpp Wrapper for calling lambda function from C
+//-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef _CM_LIBCM_LAMBDA_WRAPPER_HPP_
+#define _CM_LIBCM_LAMBDA_WRAPPER_HPP_
+
+#define LAMBDA_WRAPPER_TMPL(ARGTYPE, TAG)                                      \
+  typedef std::function<void(const ARGTYPE &)> LambdaFunction_##TAG;           \
+  extern "C" struct LambdaWrapper_##TAG {                                      \
+    LambdaFunction_##TAG f;                                                    \
+    std::vector<ARGTYPE> argVector;                                            \
+  };                                                                           \
+                                                                               \
+  template <typename LambdaTy>                                                 \
+  LambdaWrapper_##TAG *makeWrapper_##TAG(std::vector<ARGTYPE> &vec,            \
+                                         LambdaTy f) {                         \
+    LambdaWrapper_##TAG *w = new LambdaWrapper_##TAG;                          \
+    w->f = LambdaFunction_##TAG(f);                                            \
+    w->argVector = vec;                                                        \
+    return w;                                                                  \
+  }                                                                            \
+                                                                               \
+  extern "C" inline void invokeLambda_##TAG(void *p) {                         \
+    auto *w = reinterpret_cast<LambdaWrapper_##TAG *>(p);                      \
+    w->f(w->argVector[cm_support::thread_local_idx()]);                        \
+  }
+
+#endif // _CM_LIBCM_LAMBDA_WRAPPER_HPP_

--- a/sycl/include/CL/sycl/INTEL/esimd/esimdcpu_runtime.h
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimdcpu_runtime.h
@@ -1,0 +1,66 @@
+//===--- esimdcpu_runtime.h -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _ESIMDCPU_RUNTIME_H_INCLUDED_
+#define _ESIMDCPU_RUNTIME_H_INCLUDED_
+
+#include <vector>
+
+#ifndef __GNUC__
+#define ESIMD_API __declspec(dllexport)
+#else // __GNUC__
+#define ESIMD_API
+#endif // __GNUC__
+
+using fptrVoid = void (*)();
+
+/// Imported from rt.h : Begin
+
+/// Imported from rt.h : End
+
+class ESimdCPUKernel {
+private:
+  const std::vector<uint32_t> m_singleGrpDim = {1, 1, 1};
+  const std::vector<uint32_t> &m_spaceDim;
+  uint32_t m_parallel;
+  fptrVoid m_entryPoint;
+
+public:
+  ESIMD_API
+  ESimdCPUKernel(fptrVoid entryPoint, const std::vector<uint32_t> &spaceDim);
+
+  ESIMD_API
+  void launchMT(const uint32_t argSize, const void *rawArg);
+};
+
+namespace cm_support {
+
+ESIMD_API
+int32_t thread_local_idx();
+
+ESIMD_API
+void mt_barrier();
+
+ESIMD_API
+void split_barrier(int flag);
+
+ESIMD_API
+void set_slm_size(size_t sz);
+
+ESIMD_API
+size_t get_slm_size();
+
+ESIMD_API
+char *get_slm();
+
+ESIMD_API
+void aux_barrier();
+
+} // namespace cm_support
+
+#endif // _ESIMDCPU_RUNTIME_H_INCLUDED_

--- a/sycl/include/CL/sycl/backend_types.hpp
+++ b/sycl/include/CL/sycl/backend_types.hpp
@@ -18,7 +18,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
-enum class backend : char { host, opencl, level_zero, cuda, all };
+enum class backend : char { host, opencl, level_zero, cuda, esimd_cpu, all };
 
 template <backend name, typename SYCLObjectT> struct interop;
 
@@ -35,6 +35,9 @@ inline std::ostream &operator<<(std::ostream &Out, backend be) {
     break;
   case backend::cuda:
     Out << "cuda";
+    break;
+  case backend::esimd_cpu:
+    Out << "esimd_cpu";
     break;
   case backend::all:
     Out << "all";

--- a/sycl/include/CL/sycl/detail/pi.def
+++ b/sycl/include/CL/sycl/detail/pi.def
@@ -97,6 +97,7 @@ _PI_API(piSamplerRetain)
 _PI_API(piSamplerRelease)
 // Queue commands
 _PI_API(piEnqueueKernelLaunch)
+_PI_API(piEnqueueHostKernelLaunch)
 _PI_API(piEnqueueNativeKernel)
 _PI_API(piEnqueueEventsWait)
 _PI_API(piEnqueueEventsWaitWithBarrier)

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -1304,6 +1304,35 @@ __SYCL_EXPORT pi_result piSamplerRelease(pi_sampler sampler);
 //
 // Queue Commands
 //
+
+// pi_host_kernel_arg_type specifies the prototype of lambda function,
+// i.e. std::function(void(const argtype&)) in calls to
+// piEnqueueHostKernelLaunch. The argument can be id, item w/o offset, item w/
+// offset or nd_item.
+//
+typedef enum {
+  PI_HOST_KERNEL_ARG_TYPE_INVALID,
+  PI_HOST_KERNEL_ARG_TYPE_ID,
+  PI_HOST_KERNEL_ARG_TYPE_ITEM,
+  PI_HOST_KERNEL_ARG_TYPE_ITEM_OFFSET,
+  PI_HOST_KERNEL_ARG_TYPE_ND_ITEM
+} pi_host_kernel_arg_type;
+
+// Executes a kernel on host.
+//
+// \param kernel is the lambda to call.
+// \param argtype specifies the prototype, i.e. std::function(void(const
+// argtype&))
+//
+// All other arguments have the same semantics as piEnqueueKernelLaunch.
+
+__SYCL_EXPORT pi_result piEnqueueHostKernelLaunch(
+    pi_queue queue, void *kernel, pi_host_kernel_arg_type argtype,
+    pi_uint32 work_dim, const size_t *global_work_offset,
+    const size_t *global_work_size, const size_t *local_work_size,
+    pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
+    pi_event *event);
+
 __SYCL_EXPORT pi_result piEnqueueKernelLaunch(
     pi_queue queue, pi_kernel kernel, pi_uint32 work_dim,
     const size_t *global_work_offset, const size_t *global_work_size,

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -61,10 +61,12 @@ bool trace(TraceLevel level);
 #define __SYCL_OPENCL_PLUGIN_NAME "pi_opencl.dll"
 #define __SYCL_LEVEL_ZERO_PLUGIN_NAME "pi_level_zero.dll"
 #define __SYCL_CUDA_PLUGIN_NAME "pi_cuda.dll"
+#define __SYCL_ESIMD_CPU_PLUGIN_NAME "pi_esimd_cpu.dll"
 #else
 #define __SYCL_OPENCL_PLUGIN_NAME "libpi_opencl.so"
 #define __SYCL_LEVEL_ZERO_PLUGIN_NAME "libpi_level_zero.so"
 #define __SYCL_CUDA_PLUGIN_NAME "libpi_cuda.so"
+#define __SYCL_ESIMD_CPU_PLUGIN_NAME "libpi_esimd_cpu.so"
 #endif
 
 // Report error and no return (keeps compiler happy about no return statements).

--- a/sycl/plugins/CMakeLists.txt
+++ b/sycl/plugins/CMakeLists.txt
@@ -6,3 +6,4 @@ endif()
 
 add_subdirectory(opencl)
 add_subdirectory(level_zero)
+add_subdirectory(esimd_cpu)

--- a/sycl/plugins/esimd_cpu/CMakeLists.txt
+++ b/sycl/plugins/esimd_cpu/CMakeLists.txt
@@ -1,0 +1,120 @@
+
+# PI Esimd CPU  library
+# Create Shared library for libpi_esimd_cpu.so.
+
+include_directories("${sycl_inc_dir}")
+include_directories(${OPENCL_INCLUDE})
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/libva_build)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/libva_install)
+ExternalProject_Add(libva
+  GIT_REPOSITORY    https://github.com/intel/libva.git
+  BINARY_DIR        ${CMAKE_CURRENT_BINARY_DIR}/libva_build
+  INSTALL_DIR       ${CMAKE_CURRENT_BINARY_DIR}/libva_install
+  CONFIGURE_COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/libva-prefix/src/libva && ./autogen.sh --prefix=${CMAKE_CURRENT_BINARY_DIR}/libva_install
+  BUILD_COMMAND     cd ${CMAKE_CURRENT_BINARY_DIR}/libva-prefix/src/libva && make -j
+  INSTALL_COMMAND   cd ${CMAKE_CURRENT_BINARY_DIR}/libva-prefix/src/libva && make install
+)
+ExternalProject_Add_Step(libva llvminstall
+  COMMAND mkdir -p ${LLVM_BINARY_DIR}/pi_esimd_cpu_deps && ${CMAKE_COMMAND} -E copy_directory <INSTALL_DIR>/ ${LLVM_BINARY_DIR}/pi_esimd_cpu_deps
+  COMMENT "Installing libva into the LLVM binary directory"
+  DEPENDEES install
+)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/level-zero-loader_build)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/level-zero-loader_install)
+ExternalProject_Add(level-zero-loader_esimd_cpu
+  GIT_REPOSITORY    https://github.com/oneapi-src/level-zero.git
+  GIT_TAG           v1.0.22
+  BINARY_DIR        ${CMAKE_CURRENT_BINARY_DIR}/level-zero-loader_build
+  INSTALL_DIR       ${CMAKE_CURRENT_BINARY_DIR}/level-zero-loader_install
+  CMAKE_ARGS        -DOpenCL_INCLUDE_DIR=${OpenCL_INCLUDE_DIRS}
+                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                    -DCMAKE_INSTALL_LIBDIR:PATH=lib${LLVM_LIBDIR_SUFFIX}
+                    ${AUX_CMAKE_FLAGS}
+  STEP_TARGETS      configure,build,install
+  DEPENDS           ocl-headers
+)
+ExternalProject_Add_Step(level-zero-loader_esimd_cpu llvminstall
+  COMMAND mkdir -p ${LLVM_BINARY_DIR}/pi_esimd_cpu_deps && ${CMAKE_COMMAND} -E copy_directory <INSTALL_DIR>/ ${LLVM_BINARY_DIR}/pi_esimd_cpu_deps
+  COMMENT "Installing level-zero-loader into the LLVM binary directory"
+  DEPENDEES install
+)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_build)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_install)
+set(LIBCM ${LLVM_BINARY_DIR}/pi_esimd_cpu_deps/lib/libcm.so)
+set(LIBIGFXCMRT_EMU ${LLVM_BINARY_DIR}/pi_esimd_cpu_deps/lib/libigfxcmrt_emu.so)
+if (NOT DEFINED CM_LOCAL_SOURCE_DIR)
+  ExternalProject_Add(cm-emu
+    GIT_REPOSITORY    https://github.com/intel/cm-cpu-emulation.git
+    BINARY_DIR        ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_build
+    INSTALL_DIR       ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_install
+    CMAKE_ARGS        -DLIBVA_INSTALL_PATH=${CMAKE_CURRENT_BINARY_DIR}/libva_install
+                      -DLevelZero_INCLUDE_DIR=${CMAKE_CURRENT_BINARY_DIR}/level-zero-loader_install/include
+                      -DLevelZero_LIBRARY=${CMAKE_CURRENT_BINARY_DIR}/level-zero-loader_install/lib
+                      -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    DEPENDS           level-zero-loader_esimd_cpu libva
+    BUILD_BYPRODUCTS  ${LIBCM} ${LIBIGFXCMRT_EMU}
+  )
+else ()
+  ExternalProject_Add(cm-emu
+    URL               ${CM_LOCAL_SOURCE_DIR}
+    BINARY_DIR        ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_build
+    INSTALL_DIR       ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_install
+    CMAKE_ARGS        -DLIBVA_INSTALL_PATH=${CMAKE_CURRENT_BINARY_DIR}/libva_install
+                      -DLevelZero_INCLUDE_DIR=${CMAKE_CURRENT_BINARY_DIR}/level-zero-loader_install/include
+                      -DLevelZero_LIBRARY=${CMAKE_CURRENT_BINARY_DIR}/level-zero-loader_install/lib
+                      -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    DEPENDS           level-zero-loader_esimd_cpu libva
+    BUILD_BYPRODUCTS  ${LIBCM} ${LIBIGFXCMRT_EMU}
+  )
+endif ()
+ExternalProject_Add_Step(cm-emu llvminstall
+  COMMAND mkdir -p ${LLVM_BINARY_DIR}/pi_esimd_cpu_deps && ${CMAKE_COMMAND} -E copy_directory <INSTALL_DIR>/ ${LLVM_BINARY_DIR}/pi_esimd_cpu_deps
+  COMMENT "Installing cm-emu into the LLVM binary directory"
+  DEPENDEES install
+)
+
+include_directories(${LLVM_BINARY_DIR}/pi_esimd_cpu_deps/include/igfxcmrt_emu)
+
+# Compilation flag to exclude lines in header files imported from CM
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__SYCL_EXPLICIT_SIMD_PLUGIN__")
+
+# Compilation option modification to prevent build termination caused by
+# warnings from CM-imported files
+string(REPLACE "-std=c++14" "-std=c++1z" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REPLACE "-Werror=date\-time" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REPLACE "-Werror" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+add_library(pi_esimd_cpu SHARED
+  "${sycl_inc_dir}/CL/sycl/detail/pi.h"
+  "pi_esimd_cpu.cpp"
+)
+
+add_dependencies(pi_esimd_cpu ocl-headers)
+add_dependencies(pi_esimd_cpu cm-emu)
+add_dependencies(sycl-toolchain pi_esimd_cpu)
+
+target_link_libraries(pi_esimd_cpu PRIVATE sycl ${LIBCM} ${LIBIGFXCMRT_EMU})
+set_target_properties(pi_esimd_cpu PROPERTIES LINKER_LANGUAGE CXX)
+
+add_common_options(pi_esimd_cpu)
+
+install(TARGETS pi_esimd_cpu
+        LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT pi_esimd_cpu
+        RUNTIME DESTINATION "bin" COMPONENT pi_esimd_cpu)
+
+# Copy CM Header files to $(INSTALL)/include/sycl/CL/
+install(DIRECTORY    ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_install/include/libcm/cm/
+        DESTINATION  ${SYCL_INCLUDE_DEPLOY_DIR}/CL
+        COMPONENT    libcmrt-headers
+        FILES_MATCHING PATTERN "*.h"
+)
+
+# Copy '.so' files to '$(INSTALL)/lib'
+install(DIRECTORY   ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_install/lib/
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+        COMPONENT   libcmrt-sos
+        FILES_MATCHING PATTERN "*.so"
+)

--- a/sycl/plugins/esimd_cpu/pi_esimd_cpu.cpp
+++ b/sycl/plugins/esimd_cpu/pi_esimd_cpu.cpp
@@ -1,0 +1,1445 @@
+//===---------- pi_esimd_cpu.cpp - CM Emulation Plugin --------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+/// \defgroup sycl_pi_esimd_cpu CM Emulation Plugin
+/// \ingroup sycl_pi
+
+/// \file pi_esimd_cpu.cpp
+/// Declarations for CM Emulation Plugin. It is the interface between the
+/// device-agnostic SYCL runtime layer and underlying CM Emulation
+///
+/// \ingroup sycl_pi_esimd_cpu
+
+#include <stdint.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "pi_esimd_cpu.hpp"
+
+namespace {
+
+template <typename T, typename Assign>
+pi_result getInfoImpl(size_t param_value_size, void *param_value,
+                      size_t *param_value_size_ret, T value, size_t value_size,
+                      Assign &&assign_func) {
+
+  if (param_value != nullptr) {
+
+    if (param_value_size < value_size) {
+      return PI_INVALID_VALUE;
+    }
+
+    assign_func(param_value, value, value_size);
+  }
+
+  if (param_value_size_ret != nullptr) {
+    *param_value_size_ret = value_size;
+  }
+
+  return PI_SUCCESS;
+}
+
+template <typename T>
+pi_result getInfo(size_t param_value_size, void *param_value,
+                  size_t *param_value_size_ret, T value) {
+
+  auto assignment = [](void *param_value, T value, size_t value_size) {
+    *static_cast<T *>(param_value) = value;
+  };
+
+  return getInfoImpl(param_value_size, param_value, param_value_size_ret, value,
+                     sizeof(T), assignment);
+}
+
+template <typename T>
+pi_result getInfoArray(size_t array_length, size_t param_value_size,
+                       void *param_value, size_t *param_value_size_ret,
+                       T *value) {
+  return getInfoImpl(param_value_size, param_value, param_value_size_ret, value,
+                     array_length * sizeof(T), memcpy);
+}
+
+template <>
+pi_result getInfo<const char *>(size_t param_value_size, void *param_value,
+                                size_t *param_value_size_ret,
+                                const char *value) {
+  return getInfoArray(strlen(value) + 1, param_value_size, param_value,
+                      param_value_size_ret, value);
+}
+
+class ReturnHelper {
+public:
+  ReturnHelper(size_t param_value_size, void *param_value,
+               size_t *param_value_size_ret)
+      : param_value_size(param_value_size), param_value(param_value),
+        param_value_size_ret(param_value_size_ret) {}
+
+  template <class T> pi_result operator()(const T &t) {
+    return getInfo(param_value_size, param_value, param_value_size_ret, t);
+  }
+
+private:
+  size_t param_value_size;
+  void *param_value;
+  size_t *param_value_size_ret;
+};
+
+} // anonymous namespace
+
+extern "C" {
+
+#define DIE_NO_IMPLEMENTATION                                                  \
+  std::cerr << "Not Implemented : " << __FUNCTION__                            \
+            << " - File : " << __FILE__;                                       \
+  std::cerr << " / Line : " << __LINE__ << std::endl;                          \
+  die("Terminated")
+
+#define DIE_NO_SUPPORT                                                         \
+  std::cerr << "Not Supported : " << __FUNCTION__ << " - File : " << __FILE__; \
+  std::cerr << " / Line : " << __LINE__ << std::endl;                          \
+  die("Terminated")
+
+#define CONTINUE_NO_IMPLEMENTATION                                             \
+  std::cerr << "Warning : Not Implemented : " << __FUNCTION__                  \
+            << " - File : " << __FILE__;                                       \
+  std::cerr << " / Line : " << __LINE__ << std::endl;
+
+pi_result piPlatformsGet(pi_uint32 NumEntries, pi_platform *Platforms,
+                         pi_uint32 *NumPlatforms) {
+  if (NumEntries == 0 && Platforms != nullptr) {
+    return PI_INVALID_VALUE;
+  }
+  if (Platforms == nullptr && NumPlatforms == nullptr) {
+    return PI_INVALID_VALUE;
+  }
+
+  if (Platforms && NumEntries > 0) {
+    *Platforms = new _pi_platform();
+    Platforms[0]->CmEmuVersion = std::string("0.0.1");
+  }
+
+  if (NumPlatforms) {
+    *NumPlatforms = 1;
+  }
+
+  return PI_SUCCESS;
+}
+
+pi_result piPlatformGetInfo(pi_platform Platform, pi_platform_info ParamName,
+                            size_t ParamValueSize, void *ParamValue,
+                            size_t *ParamValueSizeRet) {
+  assert(Platform);
+  ReturnHelper ReturnValue(ParamValueSize, ParamValue, ParamValueSizeRet);
+
+  switch (ParamName) {
+  case PI_PLATFORM_INFO_NAME:
+    return ReturnValue("Intel(R) ESIMD_CPU/GPU");
+
+  case PI_PLATFORM_INFO_VENDOR:
+    return ReturnValue("Intel(R) Corporation");
+
+  case PI_PLATFORM_INFO_VERSION:
+    return ReturnValue(Platform->CmEmuVersion);
+
+  case PI_PLATFORM_INFO_PROFILE:
+    return ReturnValue("CM_FULL_PROFILE");
+
+  case PI_PLATFORM_INFO_EXTENSIONS:
+    return ReturnValue("");
+
+  default:
+    // TODO: implement other parameters
+    die("Unsupported ParamName in piPlatformGetInfo");
+  }
+
+  return PI_SUCCESS;
+}
+
+pi_result piextPlatformGetNativeHandle(pi_platform Platform,
+                                       pi_native_handle *NativeHandle) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextPlatformCreateWithNativeHandle(pi_native_handle NativeHandle,
+                                              pi_platform *Platform) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piDevicesGet(pi_platform Platform, pi_device_type DeviceType,
+                       pi_uint32 NumEntries, pi_device *Devices,
+                       pi_uint32 *NumDevices) {
+
+  if (NumEntries == 0) {
+    if (NumDevices) {
+      *NumDevices = 1;
+    } else {
+      return PI_INVALID_VALUE;
+    }
+  }
+
+  if (NumDevices) {
+    *NumDevices = 1;
+  } else {
+    // assert(NumEntries == 1);
+    Devices[0] = new _pi_device(Platform);
+  }
+
+  return PI_SUCCESS;
+}
+
+pi_result piDeviceRetain(pi_device Device) {
+  assert(Device);
+
+  ++(Device->RefCount);
+
+  return PI_SUCCESS;
+}
+
+pi_result piDeviceRelease(pi_device Device) {
+  CONTINUE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piDeviceGetInfo(pi_device Device, pi_device_info ParamName,
+                          size_t ParamValueSize, void *ParamValue,
+                          size_t *ParamValueSizeRet) {
+  ReturnHelper ReturnValue(ParamValueSize, ParamValue, ParamValueSizeRet);
+
+  switch (ParamName) {
+  case PI_DEVICE_INFO_TYPE:
+    return ReturnValue(PI_DEVICE_TYPE_GPU);
+  case PI_DEVICE_INFO_PARENT_DEVICE:
+    return ReturnValue(pi_device{0});
+  case PI_DEVICE_INFO_PLATFORM:
+    return ReturnValue(Device->Platform);
+  case PI_DEVICE_INFO_NAME:
+    return ReturnValue("ESIMD_CPU");
+  case PI_DEVICE_INFO_IMAGE_SUPPORT:
+    return ReturnValue(pi_bool{true});
+  case PI_DEVICE_INFO_DRIVER_VERSION:
+    return ReturnValue("0.0.1");
+  case PI_DEVICE_INFO_VENDOR:
+    return ReturnValue("Intel(R) Corporation");
+  case PI_DEVICE_INFO_IMAGE2D_MAX_WIDTH:
+    return ReturnValue(size_t{8192});
+  case PI_DEVICE_INFO_IMAGE2D_MAX_HEIGHT:
+    return ReturnValue(size_t{8192});
+  case PI_DEVICE_INFO_COMPILER_AVAILABLE:
+    return ReturnValue(pi_bool{0});
+  case PI_DEVICE_INFO_EXTENSIONS: {
+    return ReturnValue("(No Extension)");
+  }
+  case PI_DEVICE_INFO_HOST_UNIFIED_MEMORY:
+    return ReturnValue(pi_bool{1});
+
+#define UNSUPPORTED_INFO(info)                                                 \
+  case info:                                                                   \
+    std::cerr << std::endl                                                     \
+              << "Unsupported device info = " << #info << std::endl;           \
+    DIE_NO_IMPLEMENTATION;                                                     \
+    break;
+
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_VENDOR_ID)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_LINKER_AVAILABLE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_COMPUTE_UNITS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_WORK_GROUP_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_WORK_ITEM_SIZES)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_CLOCK_FREQUENCY)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_ADDRESS_BITS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_MEM_ALLOC_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_GLOBAL_MEM_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_LOCAL_MEM_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_AVAILABLE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_VERSION)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_REFERENCE_COUNT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PARTITION_PROPERTIES)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PARTITION_TYPE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_OPENCL_C_VERSION)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PRINTF_BUFFER_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PROFILE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_BUILT_IN_KERNELS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_QUEUE_PROPERTIES)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_EXECUTION_CAPABILITIES)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_ENDIAN_LITTLE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_ERROR_CORRECTION_SUPPORT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PROFILING_TIMER_RESOLUTION)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_LOCAL_MEM_TYPE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_CONSTANT_ARGS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_PARAMETER_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MEM_BASE_ADDR_ALIGN)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_SAMPLERS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_READ_IMAGE_ARGS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_SINGLE_FP_CONFIG)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_HALF_FP_CONFIG)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_DOUBLE_FP_CONFIG)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_IMAGE3D_MAX_WIDTH)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_IMAGE3D_MAX_HEIGHT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_IMAGE3D_MAX_DEPTH)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_MAX_NUM_SUB_GROUPS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_SUB_GROUP_SIZES_INTEL)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_IL_VERSION)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_USM_HOST_SUPPORT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_USM_DEVICE_SUPPORT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT)
+    UNSUPPORTED_INFO(PI_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT)
+
+#undef UNSUPPORTED_INFO
+  default:
+    DIE_NO_IMPLEMENTATION;
+  }
+  return PI_SUCCESS;
+}
+
+pi_result piDevicePartition(pi_device Device,
+                            const pi_device_partition_property *Properties,
+                            pi_uint32 NumDevices, pi_device *OutDevices,
+                            pi_uint32 *OutNumDevices) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextDeviceGetNativeHandle(pi_device Device,
+                                     pi_native_handle *NativeHandle) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextDeviceCreateWithNativeHandle(pi_native_handle nativeHandle,
+                                            pi_platform platform,
+                                            pi_device *device) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piContextCreate(const pi_context_properties *Properties,
+                          pi_uint32 NumDevices, const pi_device *Devices,
+                          void (*PFnNotify)(const char *ErrInfo,
+                                            const void *PrivateInfo, size_t CB,
+                                            void *UserData),
+                          void *UserData, pi_context *RetContext) {
+  if (NumDevices != 1) {
+    return PI_INVALID_VALUE;
+  }
+  assert(Devices);
+  assert(RetContext);
+
+  cm_support::CmDevice *device = nullptr;
+  unsigned int version = 0;
+
+  int result = cm_support::CreateCmDevice(device, version);
+
+  if (result != cm_support::CM_SUCCESS) {
+    return PI_INVALID_VALUE;
+  }
+
+  try {
+    *RetContext = new _pi_context(*Devices, device);
+  } catch (const std::bad_alloc &) {
+    return PI_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return PI_ERROR_UNKNOWN;
+  }
+
+  return PI_SUCCESS;
+}
+
+pi_result piContextGetInfo(pi_context Context, pi_context_info ParamName,
+                           size_t ParamValueSize, void *ParamValue,
+                           size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextContextSetExtendedDeleter(pi_context Context,
+                                         pi_context_extended_deleter Function,
+                                         void *UserData) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextContextGetNativeHandle(pi_context Context,
+                                      pi_native_handle *NativeHandle) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextContextCreateWithNativeHandle(pi_native_handle NativeHandle,
+                                             pi_uint32 NumDevices,
+                                             const pi_device *Devices,
+                                             pi_context *RetContext) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piContextRetain(pi_context Context) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piContextRelease(pi_context Context) {
+  if ((Context == nullptr) || (Context->CmDevicePtr == nullptr)) {
+    return PI_INVALID_CONTEXT;
+  }
+
+  int result = cm_support::DestroyCmDevice(Context->CmDevicePtr);
+  if (result != cm_support::CM_SUCCESS) {
+    return PI_INVALID_CONTEXT;
+  }
+
+  delete Context;
+  return PI_SUCCESS;
+}
+
+pi_result piQueueCreate(pi_context Context, pi_device Device,
+                        pi_queue_properties Properties, pi_queue *Queue) {
+  cm_support::CmQueue *cmQueue;
+
+  int result = Context->CmDevicePtr->CreateQueue(cmQueue);
+  if (result != cm_support::CM_SUCCESS) {
+    return PI_INVALID_CONTEXT;
+  }
+
+  try {
+    *Queue = new _pi_queue(Context, cmQueue);
+  } catch (const std::bad_alloc &) {
+    return PI_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return PI_ERROR_UNKNOWN;
+  }
+
+  return PI_SUCCESS;
+}
+
+pi_result piQueueGetInfo(pi_queue Queue, pi_queue_info ParamName,
+                         size_t ParamValueSize, void *ParamValue,
+                         size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piQueueRetain(pi_queue Queue) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piQueueRelease(pi_queue Queue) {
+  if ((Queue == nullptr) || (Queue->CmQueuePtr == nullptr)) {
+    return PI_INVALID_QUEUE;
+  }
+
+  // TODO : Destory 'Queue->CmQueuePtr'?
+  delete Queue;
+
+  return PI_SUCCESS;
+}
+
+pi_result piQueueFinish(pi_queue Queue) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextQueueGetNativeHandle(pi_queue Queue,
+                                    pi_native_handle *NativeHandle) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextQueueCreateWithNativeHandle(pi_native_handle nativeHandle,
+                                           pi_context context,
+                                           pi_queue *queue) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
+                            void *HostPtr, pi_mem *RetMem,
+                            const pi_mem_properties *properties) {
+  assert((Flags & PI_MEM_FLAGS_ACCESS_RW) != 0);
+  assert(Context);
+  assert(RetMem);
+
+  cm_support::CmBuffer *CmBuf = nullptr;
+  cm_support::SurfaceIndex *CmIndex;
+
+  int status = Context->CmDevicePtr->CreateBuffer(
+      static_cast<unsigned int>(Size), CmBuf);
+
+  if (status != cm_support::CM_SUCCESS) {
+    // TODO : Convert "CM_" return value to "PI_" return value
+    return PI_OUT_OF_HOST_MEMORY;
+  }
+
+  status = CmBuf->GetIndex(CmIndex);
+
+  if ((Flags & PI_MEM_FLAGS_HOST_PTR_USE) != 0 ||
+      (Flags & PI_MEM_FLAGS_HOST_PTR_COPY) != 0) {
+    status =
+        CmBuf->WriteSurface(reinterpret_cast<const unsigned char *>(HostPtr),
+                            nullptr, static_cast<unsigned int>(Size));
+  }
+
+  auto HostPtrOrNull =
+      (Flags & PI_MEM_FLAGS_HOST_PTR_USE) ? pi_cast<char *>(HostPtr) : nullptr;
+
+  try {
+    *RetMem = new _pi_buffer(Context, HostPtrOrNull, CmBuf, CmIndex);
+  } catch (const std::bad_alloc &) {
+    return PI_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return PI_ERROR_UNKNOWN;
+  }
+
+  return PI_SUCCESS;
+}
+
+pi_result piMemGetInfo(pi_mem Mem,
+                       cl_mem_info ParamName, // TODO: untie from OpenCL
+                       size_t ParamValueSize, void *ParamValue,
+                       size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piMemRetain(pi_mem Mem) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piMemRelease(pi_mem Mem) {
+  if (Mem->getMemType() == PI_MEM_TYPE_BUFFER) {
+    _pi_buffer *pi_buf = static_cast<_pi_buffer *>(Mem);
+    int result = Mem->Context->CmDevicePtr->DestroySurface(pi_buf->CmBufferPtr);
+
+    if (result != cm_support::CM_SUCCESS) {
+      return PI_INVALID_MEM_OBJECT;
+    }
+  } else if (Mem->getMemType() == PI_MEM_TYPE_IMAGE2D) {
+    _pi_image *pi_image = static_cast<_pi_image *>(Mem);
+    int result =
+        Mem->Context->CmDevicePtr->DestroySurface(pi_image->CmSurfacePtr);
+
+    if (result != cm_support::CM_SUCCESS) {
+      return PI_INVALID_MEM_OBJECT;
+    }
+  } else if (Mem->getMemType() == PI_MEM_TYPE_IMAGE2D) {
+    _pi_image *pi_img = static_cast<_pi_image *>(Mem);
+    int result =
+        Mem->Context->CmDevicePtr->DestroySurface(pi_img->CmSurfacePtr);
+    if (result != cm_support::CM_SUCCESS) {
+      return PI_INVALID_MEM_OBJECT;
+    }
+  } else {
+    return PI_INVALID_MEM_OBJECT;
+  }
+
+  return PI_SUCCESS;
+}
+
+cm_support::CM_SURFACE_FORMAT
+piImageFormatToCmFormat(const pi_image_format *piFormat) {
+  using ULongPair = std::pair<unsigned long, unsigned long>;
+  using FmtMap = std::map<ULongPair, cm_support::CM_SURFACE_FORMAT>;
+  static const FmtMap pi2cm = {
+      {{PI_IMAGE_CHANNEL_TYPE_UNORM_INT8, PI_IMAGE_CHANNEL_ORDER_RGBA},
+       cm_support::CM_SURFACE_FORMAT_A8R8G8B8},
+
+      {{PI_IMAGE_CHANNEL_TYPE_UNORM_INT8, PI_IMAGE_CHANNEL_ORDER_ARGB},
+       cm_support::CM_SURFACE_FORMAT_A8R8G8B8},
+
+      {{PI_IMAGE_CHANNEL_TYPE_UNSIGNED_INT8, PI_IMAGE_CHANNEL_ORDER_RGBA},
+       cm_support::CM_SURFACE_FORMAT_A8R8G8B8},
+
+      {{PI_IMAGE_CHANNEL_TYPE_UNSIGNED_INT32, PI_IMAGE_CHANNEL_ORDER_RGBA},
+       cm_support::CM_SURFACE_FORMAT_R32G32B32A32F},
+  };
+  auto result = pi2cm.find(
+      {piFormat->image_channel_data_type, piFormat->image_channel_order});
+  if (result != pi2cm.end()) {
+    return result->second;
+  }
+  DIE_NO_IMPLEMENTATION;
+  return cm_support::CM_SURFACE_FORMAT_A8R8G8B8;
+}
+
+pi_result piMemImageCreate(pi_context Context, pi_mem_flags Flags,
+                           const pi_image_format *ImageFormat,
+                           const pi_image_desc *ImageDesc, void *HostPtr,
+                           pi_mem *RetImage) {
+  if (ImageFormat == nullptr || ImageDesc == nullptr)
+    return PI_INVALID_VALUE;
+
+  switch (ImageDesc->image_type) {
+  case PI_MEM_TYPE_IMAGE2D:
+    break;
+  default:
+    return PI_INVALID_MEM_OBJECT;
+  }
+
+  auto bytesPerPixel = 4;
+  switch (ImageFormat->image_channel_data_type) {
+  case PI_IMAGE_CHANNEL_TYPE_UNSIGNED_INT32:
+    bytesPerPixel = 16;
+    break;
+  case PI_IMAGE_CHANNEL_TYPE_UNSIGNED_INT8:
+  case PI_IMAGE_CHANNEL_TYPE_UNORM_INT8:
+    bytesPerPixel = 4;
+    break;
+  default:
+    return PI_INVALID_VALUE;
+  }
+
+  cm_support::CmSurface2D *CmSurface = nullptr;
+  cm_support::SurfaceIndex *CmIndex;
+
+  int status = Context->CmDevicePtr->CreateSurface2D(
+      static_cast<unsigned int>(ImageDesc->image_width),
+      static_cast<unsigned int>(ImageDesc->image_height),
+      piImageFormatToCmFormat(ImageFormat), CmSurface);
+
+  if (status != cm_support::CM_SUCCESS) {
+    // TODO : Convert "CM_" return value to "PI_" return value
+    return PI_OUT_OF_HOST_MEMORY;
+  }
+
+  status = CmSurface->GetIndex(CmIndex);
+
+  if ((Flags & PI_MEM_FLAGS_HOST_PTR_USE) != 0 ||
+      (Flags & PI_MEM_FLAGS_HOST_PTR_COPY) != 0) {
+
+    if (HostPtr != nullptr) {
+
+      status = CmSurface->WriteSurface(
+          reinterpret_cast<const unsigned char *>(HostPtr), nullptr,
+          static_cast<unsigned int>(ImageDesc->image_width *
+                                    ImageDesc->image_height * bytesPerPixel));
+    }
+  }
+
+  auto HostPtrOrNull =
+      (Flags & PI_MEM_FLAGS_HOST_PTR_USE) ? pi_cast<char *>(HostPtr) : nullptr;
+
+  try {
+    *RetImage = new _pi_image(Context, HostPtrOrNull, CmSurface, CmIndex);
+  } catch (const std::bad_alloc &) {
+    return PI_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return PI_ERROR_UNKNOWN;
+  }
+
+  return PI_SUCCESS;
+}
+
+pi_result piextMemGetNativeHandle(pi_mem Mem, pi_native_handle *NativeHandle) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextMemCreateWithNativeHandle(pi_native_handle NativeHandle,
+                                         pi_mem *Mem) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramCreate(pi_context Context, const void *IL, size_t Length,
+                          pi_program *Program) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramCreateWithBinary(pi_context Context, pi_uint32 NumDevices,
+                                    const pi_device *DeviceList,
+                                    const size_t *Lengths,
+                                    const unsigned char **Binaries,
+                                    pi_int32 *BinaryStatus,
+                                    pi_program *Program) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piclProgramCreateWithBinary(pi_context Context, pi_uint32 NumDevices,
+                                      const pi_device *DeviceList,
+                                      const size_t *Lengths,
+                                      const unsigned char **Binaries,
+                                      pi_int32 *BinaryStatus,
+                                      pi_program *RetProgram) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piclProgramCreateWithSource(pi_context Context, pi_uint32 Count,
+                                      const char **Strings,
+                                      const size_t *Lengths,
+                                      pi_program *RetProgram) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramGetInfo(pi_program Program, pi_program_info ParamName,
+                           size_t ParamValueSize, void *ParamValue,
+                           size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramLink(pi_context Context, pi_uint32 NumDevices,
+                        const pi_device *DeviceList, const char *Options,
+                        pi_uint32 NumInputPrograms,
+                        const pi_program *InputPrograms,
+                        void (*PFnNotify)(pi_program Program, void *UserData),
+                        void *UserData, pi_program *RetProgram) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramCompile(
+    pi_program Program, pi_uint32 NumDevices, const pi_device *DeviceList,
+    const char *Options, pi_uint32 NumInputHeaders,
+    const pi_program *InputHeaders, const char **HeaderIncludeNames,
+    void (*PFnNotify)(pi_program Program, void *UserData), void *UserData) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramBuild(pi_program Program, pi_uint32 NumDevices,
+                         const pi_device *DeviceList, const char *Options,
+                         void (*PFnNotify)(pi_program Program, void *UserData),
+                         void *UserData) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramGetBuildInfo(pi_program Program, pi_device Device,
+                                cl_program_build_info ParamName,
+                                size_t ParamValueSize, void *ParamValue,
+                                size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramRetain(pi_program Program) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piProgramRelease(pi_program Program) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextProgramGetNativeHandle(pi_program Program,
+                                      pi_native_handle *NativeHandle) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextProgramCreateWithNativeHandle(pi_native_handle nativeHandle,
+                                             pi_context context,
+                                             pi_program *program) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piKernelCreate(pi_program Program, const char *KernelName,
+                         pi_kernel *RetKernel) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piKernelSetArg(pi_kernel Kernel, pi_uint32 ArgIndex, size_t ArgSize,
+                         const void *ArgValue) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextKernelSetArgMemObj(pi_kernel Kernel, pi_uint32 ArgIndex,
+                                  const pi_mem *ArgValue) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+// Special version of piKernelSetArg to accept pi_sampler.
+pi_result piextKernelSetArgSampler(pi_kernel Kernel, pi_uint32 ArgIndex,
+                                   const pi_sampler *ArgValue) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piKernelGetInfo(pi_kernel Kernel, pi_kernel_info ParamName,
+                          size_t ParamValueSize, void *ParamValue,
+                          size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piKernelGetGroupInfo(pi_kernel Kernel, pi_device Device,
+                               pi_kernel_group_info ParamName,
+                               size_t ParamValueSize, void *ParamValue,
+                               size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piKernelGetSubGroupInfo(
+    pi_kernel Kernel, pi_device Device,
+    pi_kernel_sub_group_info ParamName, // TODO: untie from OpenCL
+    size_t InputValueSize, const void *InputValue, size_t ParamValueSize,
+    void *ParamValue, size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piKernelRetain(pi_kernel Kernel) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piKernelRelease(pi_kernel Kernel) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result
+piEnqueueKernelLaunch(pi_queue Queue, pi_kernel Kernel, pi_uint32 WorkDim,
+                      const size_t *GlobalWorkOffset,
+                      const size_t *GlobalWorkSize, const size_t *LocalWorkSize,
+                      pi_uint32 NumEventsInWaitList,
+                      const pi_event *EventWaitList, pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEventCreate(pi_context Context, pi_event *RetEvent) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEventGetInfo(pi_event Event, pi_event_info ParamName,
+                         size_t ParamValueSize, void *ParamValue,
+                         size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEventGetProfilingInfo(pi_event Event, pi_profiling_info ParamName,
+                                  size_t ParamValueSize, void *ParamValue,
+                                  size_t *ParamValueSizeRet) {
+  std::cerr << "Warning : Profiling Not supported under PI_ESIMD_CPU"
+            << std::endl;
+  return PI_SUCCESS;
+}
+
+pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
+  for (int i = 0; i < (int)NumEvents; i++) {
+    if (EventList[i]->IsDummyEvent) {
+      continue;
+    }
+    int result = EventList[i]->CmEventPtr->WaitForTaskFinished();
+    if (result != cm_support::CM_SUCCESS) {
+      return PI_OUT_OF_RESOURCES;
+    }
+  }
+  return PI_SUCCESS;
+}
+
+pi_result piEventSetCallback(pi_event Event, pi_int32 CommandExecCallbackType,
+                             void (*PFnNotify)(pi_event Event,
+                                               pi_int32 EventCommandStatus,
+                                               void *UserData),
+                             void *UserData) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEventSetStatus(pi_event Event, pi_int32 ExecutionStatus) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEventRetain(pi_event Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEventRelease(pi_event Event) {
+  if (!Event->IsDummyEvent) {
+    if ((Event->CmEventPtr == nullptr) || (Event->OwnerQueue == nullptr)) {
+      return PI_INVALID_EVENT;
+    }
+    int result = Event->OwnerQueue->DestroyEvent(Event->CmEventPtr);
+    if (result != cm_support::CM_SUCCESS) {
+      return PI_INVALID_EVENT;
+    }
+  }
+  delete Event;
+
+  return PI_SUCCESS;
+}
+
+pi_result piextEventGetNativeHandle(pi_event Event,
+                                    pi_native_handle *NativeHandle) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextEventCreateWithNativeHandle(pi_native_handle NativeHandle,
+                                           pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+pi_result piSamplerCreate(pi_context Context,
+                          const pi_sampler_properties *SamplerProperties,
+                          pi_sampler *RetSampler) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piSamplerGetInfo(pi_sampler Sampler, pi_sampler_info ParamName,
+                           size_t ParamValueSize, void *ParamValue,
+                           size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piSamplerRetain(pi_sampler Sampler) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piSamplerRelease(pi_sampler Sampler) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueEventsWait(pi_queue Queue, pi_uint32 NumEventsInWaitList,
+                              const pi_event *EventWaitList, pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueEventsWaitWithBarrier(pi_queue Queue,
+                                         pi_uint32 NumEventsInWaitList,
+                                         const pi_event *EventWaitList,
+                                         pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemBufferRead(pi_queue Queue, pi_mem Src,
+                                 pi_bool BlockingRead, size_t Offset,
+                                 size_t Size, void *Dst,
+                                 pi_uint32 NumEventsInWaitList,
+                                 const pi_event *EventWaitList,
+                                 pi_event *Event) {
+  /// TODO : Support Blocked read, 'Queue' handling
+  assert(BlockingRead == false);
+  assert(NumEventsInWaitList == 0);
+
+  _pi_buffer *buf = static_cast<_pi_buffer *>(Src);
+
+  int status =
+      buf->CmBufferPtr->ReadSurface(reinterpret_cast<unsigned char *>(Dst),
+                                    nullptr, // event
+                                    static_cast<uint64_t>(Size));
+
+  if (status != cm_support::CM_SUCCESS) {
+    return PI_INVALID_MEM_OBJECT;
+  }
+
+  if (Event) {
+    try {
+      *Event = new _pi_event();
+    } catch (const std::bad_alloc &) {
+      return PI_OUT_OF_HOST_MEMORY;
+    } catch (...) {
+      return PI_ERROR_UNKNOWN;
+    }
+    (*Event)->IsDummyEvent = true;
+  }
+
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemBufferReadRect(
+    pi_queue command_queue, pi_mem buffer, pi_bool blocking_read,
+    pi_buff_rect_offset buffer_offset, pi_buff_rect_offset host_offset,
+    pi_buff_rect_region region, size_t buffer_row_pitch,
+    size_t buffer_slice_pitch, size_t host_row_pitch, size_t host_slice_pitch,
+    void *ptr, pi_uint32 num_events_in_wait_list,
+    const pi_event *event_wait_list, pi_event *event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemBufferWrite(pi_queue Queue, pi_mem Buffer,
+                                  pi_bool BlockingWrite, size_t Offset,
+                                  size_t Size, const void *Ptr,
+                                  pi_uint32 NumEventsInWaitList,
+                                  const pi_event *EventWaitList,
+                                  pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemBufferWriteRect(
+    pi_queue command_queue, pi_mem buffer, pi_bool blocking_write,
+    pi_buff_rect_offset buffer_offset, pi_buff_rect_offset host_offset,
+    pi_buff_rect_region region, size_t buffer_row_pitch,
+    size_t buffer_slice_pitch, size_t host_row_pitch, size_t host_slice_pitch,
+    const void *ptr, pi_uint32 num_events_in_wait_list,
+    const pi_event *event_wait_list, pi_event *event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemBufferCopy(pi_queue Queue, pi_mem SrcBuffer,
+                                 pi_mem DstBuffer, size_t SrcOffset,
+                                 size_t DstOffset, size_t Size,
+                                 pi_uint32 NumEventsInWaitList,
+                                 const pi_event *EventWaitList,
+                                 pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemBufferCopyRect(
+    pi_queue command_queue, pi_mem src_buffer, pi_mem dst_buffer,
+    pi_buff_rect_offset src_origin, pi_buff_rect_offset dst_origin,
+    pi_buff_rect_region region, size_t src_row_pitch, size_t src_slice_pitch,
+    size_t dst_row_pitch, size_t dst_slice_pitch,
+    pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
+    pi_event *event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemBufferFill(pi_queue Queue, pi_mem Buffer,
+                                 const void *Pattern, size_t PatternSize,
+                                 size_t Offset, size_t Size,
+                                 pi_uint32 NumEventsInWaitList,
+                                 const pi_event *EventWaitList,
+                                 pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result
+piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer, pi_bool BlockingMap,
+                      cl_map_flags MapFlags, // TODO: untie from OpenCL
+                      size_t Offset, size_t Size, pi_uint32 NumEventsInWaitList,
+                      const pi_event *EventWaitList, pi_event *Event,
+                      void **RetMap) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemUnmap(pi_queue Queue, pi_mem MemObj, void *MappedPtr,
+                            pi_uint32 NumEventsInWaitList,
+                            const pi_event *EventWaitList, pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piMemImageGetInfo(pi_mem Image, pi_image_info ParamName,
+                            size_t ParamValueSize, void *ParamValue,
+                            size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemImageRead(pi_queue command_queue, pi_mem image,
+                                pi_bool blocking_read, pi_image_offset origin,
+                                pi_image_region region, size_t row_pitch,
+                                size_t slice_pitch, void *ptr,
+                                pi_uint32 num_events_in_wait_list,
+                                const pi_event *event_wait_list,
+                                pi_event *event) {
+  _pi_image *img = static_cast<_pi_image *>(image);
+  int status =
+      img->CmSurfacePtr->ReadSurface(reinterpret_cast<unsigned char *>(ptr),
+                                     nullptr, // event
+                                     row_pitch * (region->height));
+  if (status != cm_support::CM_SUCCESS) {
+    return PI_INVALID_MEM_OBJECT;
+  }
+
+  if (event) {
+    try {
+      *event = new _pi_event();
+    } catch (const std::bad_alloc &) {
+      return PI_OUT_OF_HOST_MEMORY;
+    } catch (...) {
+      return PI_ERROR_UNKNOWN;
+    }
+    (*event)->IsDummyEvent = true;
+  }
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemImageWrite(pi_queue command_queue, pi_mem image,
+                                 pi_bool blocking_write, pi_image_offset origin,
+                                 pi_image_region region, size_t input_row_pitch,
+                                 size_t input_slice_pitch, const void *ptr,
+                                 pi_uint32 num_events_in_wait_list,
+                                 const pi_event *event_wait_list,
+                                 pi_event *event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemImageCopy(pi_queue command_queue, pi_mem src_image,
+                                pi_mem dst_image, pi_image_offset src_origin,
+                                pi_image_offset dst_origin,
+                                pi_image_region region,
+                                pi_uint32 num_events_in_wait_list,
+                                const pi_event *event_wait_list,
+                                pi_event *event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueMemImageFill(pi_queue Queue, pi_mem Image,
+                                const void *FillColor, const size_t *Origin,
+                                const size_t *Region,
+                                pi_uint32 NumEventsInWaitList,
+                                const pi_event *EventWaitList,
+                                pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piMemBufferPartition(pi_mem Buffer, pi_mem_flags Flags,
+                               pi_buffer_create_type BufferCreateType,
+                               void *BufferCreateInfo, pi_mem *RetMem) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piEnqueueNativeKernel(pi_queue Queue, void (*UserFunc)(void *),
+                                void *Args, size_t CbArgs,
+                                pi_uint32 NumMemObjects, const pi_mem *MemList,
+                                const void **ArgsMemLoc,
+                                pi_uint32 NumEventsInWaitList,
+                                const pi_event *EventWaitList,
+                                pi_event *Event) {
+
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextGetDeviceFunctionPointer(pi_device Device, pi_program Program,
+                                        const char *FunctionName,
+                                        pi_uint64 *FunctionPointerRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextUSMHostAlloc(void **ResultPtr, pi_context Context,
+                            pi_usm_mem_properties *Properties, size_t Size,
+                            pi_uint32 Alignment) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextUSMDeviceAlloc(void **ResultPtr, pi_context Context,
+                              pi_device Device,
+                              pi_usm_mem_properties *Properties, size_t Size,
+                              pi_uint32 Alignment) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextUSMSharedAlloc(void **ResultPtr, pi_context Context,
+                              pi_device Device,
+                              pi_usm_mem_properties *Properties, size_t Size,
+                              pi_uint32 Alignment) {
+  assert(Context);
+  assert(ResultPtr);
+
+  cm_support::CmBufferSVM *buf = nullptr;
+  void *pSystemMem = nullptr;
+  int32_t ret = Context->CmDevicePtr->CreateBufferSVM(
+      Size, pSystemMem, CM_SVM_ACCESS_FLAG_DEFAULT, buf);
+  assert(cm_support::CM_SUCCESS == ret);
+  *ResultPtr = pSystemMem;
+  auto it = Context->Addr2CmBufferSVM.find(pSystemMem);
+  assert(Context->Addr2CmBufferSVM.end() == it);
+  Context->Addr2CmBufferSVM[pSystemMem] = buf;
+  return PI_SUCCESS;
+}
+
+pi_result piextUSMFree(pi_context Context, void *Ptr) {
+  assert(Context);
+  assert(Ptr);
+
+  cm_support::CmBufferSVM *buf = Context->Addr2CmBufferSVM[Ptr];
+  assert(buf);
+  auto count = Context->Addr2CmBufferSVM.erase(Ptr);
+  assert(1 == count);
+  int32_t ret = Context->CmDevicePtr->DestroyBufferSVM(buf);
+  assert(cm_support::CM_SUCCESS == ret);
+  return PI_SUCCESS;
+}
+
+pi_result piextKernelSetArgPointer(pi_kernel Kernel, pi_uint32 ArgIndex,
+                                   size_t ArgSize, const void *ArgValue) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextUSMEnqueueMemset(pi_queue Queue, void *Ptr, pi_int32 Value,
+                                size_t Count, pi_uint32 NumEventsInWaitlist,
+                                const pi_event *EventsWaitlist,
+                                pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextUSMEnqueueMemcpy(pi_queue Queue, pi_bool Blocking, void *DstPtr,
+                                const void *SrcPtr, size_t Size,
+                                pi_uint32 NumEventsInWaitlist,
+                                const pi_event *EventsWaitlist,
+                                pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextUSMEnqueueMemAdvise(pi_queue Queue, const void *Ptr,
+                                   size_t Length, pi_mem_advice Advice,
+                                   pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextUSMGetMemAllocInfo(pi_context Context, const void *Ptr,
+                                  pi_mem_info ParamName, size_t ParamValueSize,
+                                  void *ParamValue, size_t *ParamValueSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piKernelSetExecInfo(pi_kernel Kernel, pi_kernel_exec_info ParamName,
+                              size_t ParamValueSize, const void *ParamValue) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextProgramSetSpecializationConstant(pi_program Prog,
+                                                pi_uint32 SpecID,
+                                                size_t SpecSize,
+                                                const void *SpecValue) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result
+piextDeviceSelectBinary(pi_device Device, // TODO: does this need to be context?
+                        pi_device_binary *Binaries, pi_uint32 NumBinaries,
+                        pi_uint32 *SelectedBinaryInd) {
+  CONTINUE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piextUSMEnqueuePrefetch(pi_queue Queue, const void *Ptr, size_t Size,
+                                  pi_usm_migration_flags Flags,
+                                  pi_uint32 NumEventsInWaitlist,
+                                  const pi_event *EventsWaitlist,
+                                  pi_event *Event) {
+  DIE_NO_IMPLEMENTATION;
+  return PI_SUCCESS;
+}
+
+pi_result piPluginInit(pi_plugin *PluginInit) {
+  assert(PluginInit);
+  size_t PluginVersionSize = sizeof(PluginInit->PluginVersion);
+  assert(strlen(_PI_H_VERSION_STRING) < PluginVersionSize);
+  strncpy(PluginInit->PluginVersion, _PI_H_VERSION_STRING, PluginVersionSize);
+
+#define _PI_API(api)                                                           \
+  (PluginInit->PiFunctionTable).api = (decltype(&::api))(&api);
+#include <CL/sycl/detail/pi.def>
+
+  return PI_SUCCESS;
+}
+}
+
+template <typename T> using KernelFunc = std::function<void(T)>;
+
+template <int NDims> struct InvokeBaseImpl {
+  static sycl::range<NDims> get_range(const size_t *GlobalWorkSize);
+};
+
+template <int NDims, typename ArgTy> struct InvokeImpl {
+
+  template <int _NDims = NDims>
+  static typename std::enable_if<_NDims == 1, sycl::range<1>>::type
+  get_range(const size_t *a) {
+    return sycl::range<1>(a[0]);
+  }
+
+  template <int _NDims = NDims>
+  static typename std::enable_if<_NDims == 2, sycl::range<2>>::type
+  get_range(const size_t *a) {
+    return sycl::range<2>(a[0], a[1]);
+  }
+
+  template <int _NDims = NDims>
+  static typename std::enable_if<_NDims == 3, sycl::range<3>>::type
+  get_range(const size_t *a) {
+    return sycl::range<3>(a[0], a[1], a[2]);
+  }
+
+  static void invoke(void *fptr, const sycl::range<NDims> &range) {
+    auto f = reinterpret_cast<std::function<void(const ArgTy &)> *>(fptr);
+    libCMBatch<KernelFunc<const ArgTy &>, ArgTy, ArgTy, NDims> cmThreading(*f);
+    cmThreading.runIterationSpace(range);
+  }
+
+  static void invoke(void *fptr, const size_t *GlobalWorkSize) {
+    sycl::range<NDims> range = get_range(GlobalWorkSize);
+    invoke(fptr, range);
+  }
+
+  static void invoke(void *fptr, const size_t *GlobalWorkOffset,
+                     const size_t *GlobalWorkSize) {
+    auto GlobalSize = get_range(GlobalWorkSize);
+    sycl::id<NDims> GlobalOffset = get_range(GlobalWorkOffset);
+
+    auto f = reinterpret_cast<std::function<void(const ArgTy &)> *>(fptr);
+    libCMBatch<KernelFunc<const ArgTy &>, ArgTy, ArgTy, NDims> cmThreading(*f);
+    cmThreading.runIterationSpace(GlobalSize, GlobalOffset);
+  }
+
+  static void invoke(void *fptr, const size_t *GlobalWorkOffset,
+                     const size_t *GlobalWorkSize,
+                     const size_t *LocalWorkSize) {
+    auto GlobalSize = get_range(GlobalWorkSize);
+    auto LocalSize = get_range(LocalWorkSize);
+    auto NumGroups = GlobalSize / LocalSize;
+    sycl::id<NDims> GlobalOffset = get_range(GlobalWorkOffset);
+
+    // TODO: cmThreading should be 'CmThreading'. Not a descriptive name.
+    // Keeping as is for for now, to maintain consistency with cg_types.hpp.
+    // Will rename when
+    // __SYCL_EXPLICIT_SIMD_PLUGIN_DEPRECATED__ is removed.
+    auto f = reinterpret_cast<std::function<void(const ArgTy &)> *>(fptr);
+    libCMBatch<KernelFunc<const ArgTy &>, ArgTy, ArgTy, NDims> cmThreading(*f);
+
+    // TODO: This is inefficient - groups are run sequentially one
+    // after another. Change the loop to run groups in parallel.
+    using IDBuilder = sycl::detail::Builder;
+    sycl::detail::NDLoop<NDims>::iterate(
+        NumGroups, [&](const sycl::id<NDims> &GroupID) {
+          sycl::group<NDims> Group = IDBuilder::createGroup<NDims>(
+              GlobalSize, LocalSize, NumGroups, GroupID);
+          cmThreading.runIterationSpace(GroupID, Group, LocalSize, GlobalSize,
+                                        GlobalOffset);
+        });
+  }
+};
+
+template <int NDims>
+static pi_result enqueueHostKernelLaunch(void *Kernel,
+                                         pi_host_kernel_arg_type ArgType,
+                                         const size_t *GlobalWorkOffset,
+                                         const size_t *GlobalWorkSize,
+                                         const size_t *LocalWorkSize) {
+#define IS_NULL(NDims, R)                                                      \
+  ((0 == R[0]) && (1 >= NDims || 0 == R[1]) && (2 >= NDims || 0 == R[2]))
+
+  switch (ArgType) {
+  case PI_HOST_KERNEL_ARG_TYPE_ID: {
+    assert(IS_NULL(NDims, GlobalWorkOffset));
+    assert(IS_NULL(NDims, LocalWorkSize));
+    InvokeImpl<NDims, sycl::id<NDims>>::invoke(Kernel, GlobalWorkSize);
+    break;
+  }
+
+  case PI_HOST_KERNEL_ARG_TYPE_ITEM: {
+    assert(IS_NULL(NDims, GlobalWorkOffset));
+    assert(IS_NULL(NDims, LocalWorkSize));
+    InvokeImpl<NDims, sycl::item<NDims, /*Offset=*/false>>::invoke(
+        Kernel, GlobalWorkSize);
+    break;
+  }
+
+  case PI_HOST_KERNEL_ARG_TYPE_ITEM_OFFSET: {
+    assert(IS_NULL(NDims, LocalWorkSize));
+    InvokeImpl<NDims, sycl::item<NDims, /*Offset=*/true>>::invoke(
+        Kernel, GlobalWorkOffset, GlobalWorkSize);
+    break;
+  }
+
+  case PI_HOST_KERNEL_ARG_TYPE_ND_ITEM: {
+    InvokeImpl<NDims, sycl::nd_item<NDims>>::invoke(
+        Kernel, GlobalWorkOffset, GlobalWorkSize, LocalWorkSize);
+    break;
+  }
+
+  default:
+    std::cerr << "Error: Invalid kernel argument type." << std::endl;
+    return PI_ERROR_UNKNOWN;
+  }
+
+  return PI_SUCCESS;
+}
+
+// TODO: Support waitlist.
+extern "C" {
+pi_result piEnqueueHostKernelLaunch(
+    pi_queue Queue, void *Kernel, pi_host_kernel_arg_type ArgType,
+    pi_uint32 WorkDim, const size_t *GlobalWorkOffset,
+    const size_t *GlobalWorkSize, const size_t *LocalWorkSize,
+    pi_uint32 NumEventsInWaitList, const pi_event *EventWaitList,
+    pi_event *Event) {
+  switch (WorkDim) {
+  case 1:
+    return enqueueHostKernelLaunch<1>(Kernel, ArgType, GlobalWorkOffset,
+                                      GlobalWorkSize, LocalWorkSize);
+  case 2:
+    return enqueueHostKernelLaunch<2>(Kernel, ArgType, GlobalWorkOffset,
+                                      GlobalWorkSize, LocalWorkSize);
+  case 3:
+    return enqueueHostKernelLaunch<3>(Kernel, ArgType, GlobalWorkOffset,
+                                      GlobalWorkSize, LocalWorkSize);
+  }
+}
+
+} // extern C

--- a/sycl/plugins/esimd_cpu/pi_esimd_cpu.hpp
+++ b/sycl/plugins/esimd_cpu/pi_esimd_cpu.hpp
@@ -1,0 +1,55 @@
+//===---------- pi_esimd_cpu.hpp - CM Emulation Plugin
+//-------------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+/// \defgroup sycl_pi_esimd_cpu CM Emulation Plugin
+/// \ingroup sycl_pi
+
+/// \file pi_esimd_cpu.hpp
+/// Declarations for CM Emulation Plugin. It is the interface between the
+/// device-agnostic SYCL runtime layer and underlying CM Emulation
+///
+/// \ingroup sycl_pi_esimd_cpu
+
+#ifndef PI_ESIMD_CPU_HPP
+#define PI_ESIMD_CPU_HPP
+
+#include <CL/sycl/INTEL/esimd/esimd_libcm.hpp>
+#include <CL/sycl/detail/pi.h>
+#include <atomic>
+#include <cassert>
+#include <iostream>
+#include <mutex>
+#include <unordered_map>
+
+#include <malloc.h>
+
+namespace cm_support {
+#include <cm_rt.h>
+} // namespace cm_support
+
+template <class To, class From> To pi_cast(From Value) {
+  // TODO: see if more sanity checks are possible.
+  assert(sizeof(From) == sizeof(To));
+  return (To)(Value);
+}
+
+template <> uint32_t pi_cast(uint64_t Value) {
+  // Cast value and check that we don't lose any information.
+  uint32_t CastedValue = (uint32_t)(Value);
+  assert((uint64_t)CastedValue == Value);
+  return CastedValue;
+}
+
+// TODO: Currently die is defined in each plugin. Probably some
+// common header file with utilities should be created.
+[[noreturn]] void die(const char *Message) {
+  std::cerr << "die: " << Message << std::endl;
+  std::terminate();
+}
+
+#include <CL/sycl/INTEL/esimd/detail/cmrt_if_defs.hpp>
+
+#endif // PI_ESIMD_CPU_HPP

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3297,6 +3297,16 @@ pi_result piKernelRelease(pi_kernel Kernel) {
   return PI_SUCCESS;
 }
 
+pi_result piEnqueueHostKernelLaunch(
+    pi_queue Queue, void *Kernel, pi_host_kernel_arg_type ArgType,
+    pi_uint32 WorkDim, const size_t *GlobalWorkOffset,
+    const size_t *GlobalWorkSize, const size_t *LocalWorkSize,
+    pi_uint32 NumEventsInWaitList, const pi_event *EventWaitList,
+    pi_event *Event) {
+  die("piEnqueueHostKernel: not implemented");
+  return {};
+}
+
 pi_result
 piEnqueueKernelLaunch(pi_queue Queue, pi_kernel Kernel, pi_uint32 WorkDim,
                       const size_t *GlobalWorkOffset,

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -135,8 +135,9 @@ public:
             return element.first == ValStr;
           });
       if (It == SyclBeMap.end())
-        pi::die("Invalid backend. "
-                "Valid values are PI_OPENCL/PI_LEVEL_ZERO/PI_CUDA/PI_ESIMD_CPU");
+        pi::die(
+            "Invalid backend. "
+            "Valid values are PI_OPENCL/PI_LEVEL_ZERO/PI_CUDA/PI_ESIMD_CPU");
       static backend Backend = It->second;
       BackendPtr = &Backend;
     }

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -122,11 +122,12 @@ public:
       return BackendPtr;
 
     const char *ValStr = BaseT::getRawValue();
-    const std::array<std::pair<std::string, backend>, 4> SyclBeMap = {
+    const std::array<std::pair<std::string, backend>, 5> SyclBeMap = {
         {{"PI_OPENCL", backend::opencl},
          {"PI_LEVEL_ZERO", backend::level_zero},
          {"PI_LEVEL0", backend::level_zero}, // for backward compatibility
-         {"PI_CUDA", backend::cuda}}};
+         {"PI_CUDA", backend::cuda},
+         {"PI_ESIMD_CPU", backend::esimd_cpu}}};
     if (ValStr) {
       auto It = std::find_if(
           std::begin(SyclBeMap), std::end(SyclBeMap),
@@ -135,7 +136,7 @@ public:
           });
       if (It == SyclBeMap.end())
         pi::die("Invalid backend. "
-                "Valid values are PI_OPENCL/PI_LEVEL_ZERO/PI_CUDA");
+                "Valid values are PI_OPENCL/PI_LEVEL_ZERO/PI_CUDA/PI_ESIMD_CPU");
       static backend Backend = It->second;
       BackendPtr = &Backend;
     }

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -24,11 +24,12 @@ device_filter::device_filter(const std::string &FilterString) {
                             {"gpu", info::device_type::gpu},
                             {"acc", info::device_type::accelerator},
                             {"*", info::device_type::all}}};
-  const std::array<std::pair<std::string, backend>, 5> SyclBeMap = {
+  const std::array<std::pair<std::string, backend>, 6> SyclBeMap = {
       {{"host", backend::host},
        {"opencl", backend::opencl},
        {"level_zero", backend::level_zero},
        {"cuda", backend::cuda},
+       {"esimd_cpu", backend::esimd_cpu},
        {"*", backend::all}}};
 
   size_t Cursor = 0;
@@ -88,7 +89,8 @@ device_filter::device_filter(const std::string &FilterString) {
     } catch (...) {
       std::string Message =
           std::string("Invalid device filter: ") + FilterString +
-          "\nPossible backend values are {host,opencl,level_zero,cuda,*}.\n"
+          "\nPossible backend values are "
+          "{host,opencl,level_zero,cuda,esimd_cpu,*}.\n"
           "Possible device types are {host,cpu,gpu,acc,*}.\n"
           "Device number should be an non-negative integer.\n";
       throw cl::sycl::invalid_parameter_error(Message, PI_INVALID_VALUE);

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -223,11 +223,13 @@ bool findPlugins(vector_class<std::pair<std::string, backend>> &PluginNames) {
     PluginNames.emplace_back(__SYCL_LEVEL_ZERO_PLUGIN_NAME,
                              backend::level_zero);
     PluginNames.emplace_back(__SYCL_CUDA_PLUGIN_NAME, backend::cuda);
+    PluginNames.emplace_back(__SYCL_ESIMD_CPU_PLUGIN_NAME, backend::esimd_cpu);
   } else {
     std::vector<device_filter> Filters = FilterList->get();
     bool OpenCLFound = false;
     bool LevelZeroFound = false;
     bool CudaFound = false;
+    bool ESimdCPUFound = false;
     for (const device_filter &Filter : Filters) {
       backend Backend = Filter.Backend;
       if (!OpenCLFound &&
@@ -244,6 +246,12 @@ bool findPlugins(vector_class<std::pair<std::string, backend>> &PluginNames) {
       if (!CudaFound && (Backend == backend::cuda || Backend == backend::all)) {
         PluginNames.emplace_back(__SYCL_CUDA_PLUGIN_NAME, backend::cuda);
         CudaFound = true;
+      }
+      if (!ESimdCPUFound &&
+          (Backend == backend::esimd_cpu || Backend == backend::all)) {
+        PluginNames.emplace_back(__SYCL_ESIMD_CPU_PLUGIN_NAME,
+                                 backend::esimd_cpu);
+        ESimdCPUFound = true;
       }
     }
   }

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1891,10 +1891,10 @@ cl_int ExecCGCommand::enqueueImp() {
       } else {
         assert(MQueue->getPlugin().getBackend() == backend::esimd_cpu);
         MQueue->getPlugin().call<PiApiKind::piEnqueueHostKernelLaunch>(
-          MQueue->getHandleRef(), ExecKernel->MHostKernel->getKernel(),
-          ExecKernel->MHostKernel->getArgType(), NDRDesc.Dims,
-          &NDRDesc.GlobalOffset[0], &NDRDesc.GlobalSize[0],
-          &NDRDesc.LocalSize[0], 0, nullptr, nullptr);
+            MQueue->getHandleRef(), ExecKernel->MHostKernel->getKernel(),
+            ExecKernel->MHostKernel->getArgType(), NDRDesc.Dims,
+            &NDRDesc.GlobalOffset[0], &NDRDesc.GlobalSize[0],
+            &NDRDesc.LocalSize[0], 0, nullptr, nullptr);
       }
 #endif
       return CL_SUCCESS;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1885,12 +1885,12 @@ cl_int ExecCGCommand::enqueueImp() {
 #ifndef __SYCL_EXPLICIT_SIMD_PLUGIN_DEPRECATED__
       if (MQueue->is_host()) {
 #endif
-	ExecKernel->MHostKernel->call(NDRDesc,
-				      getEvent()->getHostProfilingInfo());
+        ExecKernel->MHostKernel->call(NDRDesc,
+                                      getEvent()->getHostProfilingInfo());
 #ifndef __SYCL_EXPLICIT_SIMD_PLUGIN_DEPRECATED__
       } else {
-	assert(MQueue->getPlugin().getBackend() == backend::esimd_cpu);
-	MQueue->getPlugin().call<PiApiKind::piEnqueueHostKernelLaunch>(
+        assert(MQueue->getPlugin().getBackend() == backend::esimd_cpu);
+        MQueue->getPlugin().call<PiApiKind::piEnqueueHostKernelLaunch>(
           MQueue->getHandleRef(), ExecKernel->MHostKernel->getKernel(),
           ExecKernel->MHostKernel->getArgType(), NDRDesc.Dims,
           &NDRDesc.GlobalOffset[0], &NDRDesc.GlobalSize[0],


### PR DESCRIPTION
- This PR enables software-emulation of ESIMD with a new Plug-In
module - ESIMD_CPU
- CM library is used for runtime and ESIMD intrinsic such as multi-threaded
kernel launching
- With 'SYCL_DEVICE_FILTER=esimd_cpu:gpu' environment variable, ESIMD
kernels are executed as Linux64 application (Win64 support to come)
- CM_RT_PLATFORM environment variable is required for CM. 'skl' is
recommended.