### PR TITLE
[SYCL][NFC] Minor update of upper limit attribute value

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1278,7 +1278,7 @@ def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
       return 0;
     }
     static unsigned getMaxValue() {
-      return 1048576;
+      return 1024*1024;
     }
   }];
 


### PR DESCRIPTION
This patch updates MaxValue of SYCLIntelSchedulerTargetFmaxMhz
attribute to be consistent with other FPGA attributes.

Before:
static unsigned getMaxValue() {
      return 1048576;

After:
static unsigned getMaxValue() {
      return 1024*1024;

The MaxValue(upper limit) is just an arbitrary high value.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>