### PR TITLE
LLVM and SPIRV-LLVM-Translator pulldown (WW53)

### DIFF
--- a/llvm-spirv/test/AtomicCompareExchange.ll
+++ b/llvm-spirv/test/AtomicCompareExchange.ll
@@ -7,6 +7,11 @@
 ; CHECK-SPIRV: Constant [[Int]] [[MemScope_Device:[0-9]+]] 1
 ; CHECK-SPIRV: Constant [[Int]] [[MemSemEqual_SeqCst:[0-9]+]] 16
 ; CHECK-SPIRV: Constant [[Int]] [[MemSemUnequal_Acquire:[0-9]+]] 2
+; CHECK-SPIRV: Constant [[Int]] [[Constant_456:[0-9]+]] 456
+; CHECK-SPIRV: Constant [[Int]] [[Constant_128:[0-9]+]] 128
+; CHECK-SPIRV: TypeBool [[Bool:[0-9]+]]
+; CHECK-SPIRV: TypeStruct [[Struct:[0-9]+]] [[Int]] [[Bool]]
+; CHECK-SPIRV: Undef [[Struct]] [[UndefStruct:[0-9]+]]
 
 ; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[Pointer:[0-9]+]]
 ; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[Value_ptr:[0-9]+]]
@@ -37,6 +42,24 @@ cmpxchg.store_expected:                           ; preds = %entry
   br label %cmpxchg.continue
 
 cmpxchg.continue:                                 ; preds = %cmpxchg.store_expected, %entry
+  ret void
+}
+
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[Ptr:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[Store_ptr:[0-9]+]]
+
+; CHECK-SPIRV: AtomicCompareExchange [[Int]] [[Res_1:[0-9]+]] [[Ptr]] [[MemScope_Device]]
+; CHECK-SPIRV-SAME:                  [[MemSemEqual_SeqCst]] [[MemSemUnequal_Acquire]] [[Constant_456]] [[Constant_128]]
+; CHECK-SPIRV: IEqual {{[0-9]+}} [[Success_1:[0-9]+]] [[Res_1]] [[Constant_128]]
+; CHECK-SPIRV: CompositeInsert [[Struct]] [[Composite:[0-9]+]] [[Res_1]] [[UndefStruct]] 0
+; CHECK-SPIRV: CompositeInsert [[Struct]] [[Composite_1:[0-9]+]] [[Success_1]] [[Composite]] 1
+; CHECK-SPIRV: Store [[Store_ptr]] [[Composite_1]]
+
+; Function Attrs: nounwind
+define dso_local spir_func void @test2(i32* %ptr, {i32, i1}* %store_ptr) local_unnamed_addr #0 {
+entry:
+  %0 = cmpxchg i32* %ptr, i32 128, i32 456 seq_cst acquire
+  store { i32, i1 } %0, { i32, i1 }* %store_ptr, align 4
   ret void
 }
 


### PR DESCRIPTION
SPIRV-LLVM-Translator: KhronosGroup/SPIRV-LLVM-Translator@f57e6c9