### PR TITLE
[SYCL] Fix argument printing in PI trace

### DIFF
--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -76,16 +76,19 @@ public:
     std::string PIFnName = PiCallInfo.getFuncName();
     uint64_t CorrelationID = pi::emitFunctionBeginTrace(PIFnName.c_str());
 #endif
-    RT::PiResult R = PiCallInfo.getFuncPtr(MPlugin)(Args...);
+    RT::PiResult R;
     if (pi::trace(pi::TraceLevel::PI_TRACE_CALLS)) {
       std::lock_guard<std::mutex> Guard(*TracingMutex);
       std::string FnName = PiCallInfo.getFuncName();
       std::cout << "---> " << FnName << "(" << std::endl;
       RT::printArgs(Args...);
+      R = PiCallInfo.getFuncPtr(MPlugin)(Args...);
       std::cout << ") ---> ";
       RT::printArgs(R);
       RT::printOuts(Args...);
       std::cout << std::endl;
+    } else {
+      R = PiCallInfo.getFuncPtr(MPlugin)(Args...);
     }
 #ifdef XPTI_ENABLE_INSTRUMENTATION
     // Close the function begin with a call to function end


### PR DESCRIPTION
Fix an issue where PI call arguments were printed after the call has
been made, which led to incorrect values reported for out pointer
arguments.

Fixes SYCL/Tracing/pi_tracing_test.cpp from llvm-test-suite.