### PR TITLE
[SYCL] Enable host optimization of work-item free functions

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -346,8 +346,17 @@ public:
   /// Registers a specialization constant to emit info for it into the header.
   void addSpecConstant(StringRef IDName, QualType IDType);
 
+  // CP
   /// Notes that this_item is called within the kernel.
+  // void setCallsThisItem(bool B);
+
+  // CP
+  /// Note which free functions (this_id, this_item, etc) are called within the
+  /// kernel
+  void setCallsThisId(bool B);
   void setCallsThisItem(bool B);
+  void setCallsThisNDItem(bool B);
+  void setCallsThisGroup(bool B);
 
 private:
   // Kernel actual parameter descriptor.
@@ -364,6 +373,15 @@ private:
     unsigned Offset = 0;
 
     KernelParamDesc() = default;
+  };
+
+  // there are four free function the kernel may call (this_id, this_item,
+  // this_nd_item, this_group)
+  struct KernelCallsSYCLFreeFunction {
+    bool CallsThisId;
+    bool CallsThisItem;
+    bool CallsThisNDItem;
+    bool CallsThisGroup;
   };
 
   // Kernel invocation descriptor
@@ -386,7 +404,8 @@ private:
     SmallVector<KernelParamDesc, 8> Params;
 
     // Whether kernel calls this_item()
-    bool CallsThisItem;
+    // bool CallsThisItem;
+    KernelCallsSYCLFreeFunction FreeFunctionCalls;
 
     KernelDesc() = default;
   };

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -370,7 +370,7 @@ private:
     KernelParamDesc() = default;
   };
 
-  // there are four free function the kernel may call (this_id, this_item,
+  // there are four free functions the kernel may call (this_id, this_item,
   // this_nd_item, this_group)
   struct KernelCallsSYCLFreeFunction {
     bool CallsThisId;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -346,11 +346,6 @@ public:
   /// Registers a specialization constant to emit info for it into the header.
   void addSpecConstant(StringRef IDName, QualType IDType);
 
-  // CP
-  /// Notes that this_item is called within the kernel.
-  // void setCallsThisItem(bool B);
-
-  // CP
   /// Note which free functions (this_id, this_item, etc) are called within the
   /// kernel
   void setCallsThisId(bool B);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -398,8 +398,7 @@ private:
     /// Descriptor of kernel actual parameters.
     SmallVector<KernelParamDesc, 8> Params;
 
-    // Whether kernel calls this_item()
-    // bool CallsThisItem;
+    // Whether kernel calls any of the SYCL free functions (this_item(), this_id(), etc)
     KernelCallsSYCLFreeFunction FreeFunctionCalls;
 
     KernelDesc() = default;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -398,7 +398,8 @@ private:
     /// Descriptor of kernel actual parameters.
     SmallVector<KernelParamDesc, 8> Params;
 
-    // Whether kernel calls any of the SYCL free functions (this_item(), this_id(), etc)
+    // Whether kernel calls any of the SYCL free functions (this_item(),
+    // this_id(), etc)
     KernelCallsSYCLFreeFunction FreeFunctionCalls;
 
     KernelDesc() = default;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2721,7 +2721,7 @@ class SyclKernelIntHeaderCreator : public SyclKernelFieldHandler {
       if (!Visited.insert(FD).second)
         continue; // We've already seen this Decl
 
-      // Check whether this call is to free functions (  sycl::this_item(),
+      // Check whether this call is to free functions (sycl::this_item(),
       // this_id, etc.).
       if (Util::isSyclFunction(FD, "this_id")) {
         Header.setCallsThisId(true);
@@ -4001,25 +4001,25 @@ void SYCLIntegrationHeader::addSpecConstant(StringRef IDName, QualType IDType) {
 
 void SYCLIntegrationHeader::setCallsThisId(bool B) {
   KernelDesc *K = getCurKernelDesc();
-  assert(K && "no kernels");
+  assert(K && "no kernel");
   K->FreeFunctionCalls.CallsThisId = B;
 }
 
 void SYCLIntegrationHeader::setCallsThisItem(bool B) {
   KernelDesc *K = getCurKernelDesc();
-  assert(K && "no kernels");
+  assert(K && "no kernel");
   K->FreeFunctionCalls.CallsThisItem = B;
 }
 
 void SYCLIntegrationHeader::setCallsThisNDItem(bool B) {
   KernelDesc *K = getCurKernelDesc();
-  assert(K && "no kernels");
+  assert(K && "no kernel");
   K->FreeFunctionCalls.CallsThisNDItem = B;
 }
 
 void SYCLIntegrationHeader::setCallsThisGroup(bool B) {
   KernelDesc *K = getCurKernelDesc();
-  assert(K && "no kernels");
+  assert(K && "no kernel");
   K->FreeFunctionCalls.CallsThisGroup = B;
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2721,9 +2721,22 @@ class SyclKernelIntHeaderCreator : public SyclKernelFieldHandler {
       if (!Visited.insert(FD).second)
         continue; // We've already seen this Decl
 
-      // Check whether this call is to sycl::this_item().
+      // Check whether this call is to free functions (  sycl::this_item(),
+      // this_id, etc.).
+      if (Util::isSyclFunction(FD, "this_id")) {
+        Header.setCallsThisId(true);
+        return;
+      }
       if (Util::isSyclFunction(FD, "this_item")) {
         Header.setCallsThisItem(true);
+        return;
+      }
+      if (Util::isSyclFunction(FD, "this_nd_item")) {
+        Header.setCallsThisNDItem(true);
+        return;
+      }
+      if (Util::isSyclFunction(FD, "this_group")) {
+        Header.setCallsThisGroup(true);
         return;
       }
 
@@ -3920,7 +3933,14 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
       << "; }\n";
     O << "  __SYCL_DLL_LOCAL\n";
     O << "  static constexpr bool callsThisItem() { return ";
-    O << K.CallsThisItem << "; }\n";
+    O << K.FreeFunctionCalls.CallsThisItem << "; }\n";
+    O << "  __SYCL_DLL_LOCAL\n";
+    O << "  static constexpr bool callsAnyThisFreeFunction() { return ";
+    O << (K.FreeFunctionCalls.CallsThisId ||
+          K.FreeFunctionCalls.CallsThisItem ||
+          K.FreeFunctionCalls.CallsThisNDItem ||
+          K.FreeFunctionCalls.CallsThisGroup)
+      << "; }\n";
     O << "};\n";
     CurStart += N;
   }
@@ -3979,10 +3999,28 @@ void SYCLIntegrationHeader::addSpecConstant(StringRef IDName, QualType IDType) {
   SpecConsts.emplace_back(std::make_pair(IDType, IDName.str()));
 }
 
+void SYCLIntegrationHeader::setCallsThisId(bool B) {
+  KernelDesc *K = getCurKernelDesc();
+  assert(K && "no kernels");
+  K->FreeFunctionCalls.CallsThisId = B;
+}
+
 void SYCLIntegrationHeader::setCallsThisItem(bool B) {
   KernelDesc *K = getCurKernelDesc();
   assert(K && "no kernels");
-  K->CallsThisItem = B;
+  K->FreeFunctionCalls.CallsThisItem = B;
+}
+
+void SYCLIntegrationHeader::setCallsThisNDItem(bool B) {
+  KernelDesc *K = getCurKernelDesc();
+  assert(K && "no kernels");
+  K->FreeFunctionCalls.CallsThisNDItem = B;
+}
+
+void SYCLIntegrationHeader::setCallsThisGroup(bool B) {
+  KernelDesc *K = getCurKernelDesc();
+  assert(K && "no kernels");
+  K->FreeFunctionCalls.CallsThisGroup = B;
 }
 
 SYCLIntegrationHeader::SYCLIntegrationHeader(DiagnosticsEngine &_Diag,

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -130,6 +130,9 @@ private:
 template <int Dims> item<Dims>
 this_item() { return item<Dims>{}; }
 
+template <int Dims> id<Dims>
+this_id() { return id<Dims>{}; }
+
 template <int dim>
 struct range {
   template <typename... T>

--- a/clang/test/CodeGenSYCL/kernel-by-reference.cpp
+++ b/clang/test/CodeGenSYCL/kernel-by-reference.cpp
@@ -15,7 +15,7 @@ int simple_add(int i) {
 int main() {
   queue q;
 #if defined(SYCL2020)
-  // expected-warning@Inputs/sycl.hpp:298 {{Passing kernel functions by value is deprecated in SYCL 2020}}
+  // expected-warning@Inputs/sycl.hpp:301 {{Passing kernel functions by value is deprecated in SYCL 2020}}
   // expected-note@+3 {{in instantiation of function template specialization}}
 #endif
   q.submit([&](handler &h) {
@@ -23,7 +23,7 @@ int main() {
   });
 
 #if defined(SYCL2017)
-  // expected-warning@Inputs/sycl.hpp:293 {{Passing of kernel functions by reference is a SYCL 2020 extension}}
+  // expected-warning@Inputs/sycl.hpp:296 {{Passing of kernel functions by reference is a SYCL 2020 extension}}
   // expected-note@+3 {{in instantiation of function template specialization}}
 #endif
   q.submit([&](handler &h) {

--- a/clang/test/CodeGenSYCL/parallel_for_this_item.cpp
+++ b/clang/test/CodeGenSYCL/parallel_for_this_item.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -sycl-std=2020 -internal-isystem %S/Inputs -triple spir64-unknown-unknown-sycldevice -fsycl-int-header=%t.h %s -fsyntax-only
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown-sycldevice -fsycl-int-header=%t.h %s -fsyntax-only
 // RUN: FileCheck -input-file=%t.h %s
 
 // This test checks that compiler generates correct kernel description

--- a/clang/test/CodeGenSYCL/parallel_for_this_item.cpp
+++ b/clang/test/CodeGenSYCL/parallel_for_this_item.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown-sycldevice -fsycl-int-header=%t.h %s -fsyntax-only
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -sycl-std=2020 -internal-isystem %S/Inputs -triple spir64-unknown-unknown-sycldevice -fsycl-int-header=%t.h %s -fsyntax-only
 // RUN: FileCheck -input-file=%t.h %s
 
 // This test checks that compiler generates correct kernel description
@@ -13,7 +13,8 @@
 // CHECK-NEXT:   "_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE3GNU",
 // CHECK-NEXT:   "_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE3EMU",
 // CHECK-NEXT:   "_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE3OWL",
-// CHECK-NEXT:   "_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE3RAT"
+// CHECK-NEXT:   "_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE3RAT",
+// CHECK-NEXT:   "_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE3FOX"
 // CHECK-NEXT: };
 
 // CHECK:template <> struct KernelInfo<class GNU> {
@@ -29,6 +30,8 @@
 // CHECK-NEXT:  static constexpr bool isESIMD() { return 0; }
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
 // CHECK-NEXT:  static constexpr bool callsThisItem() { return 0; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:  static constexpr bool callsAnyThisFreeFunction() { return 0; }
 // CHECK-NEXT:};
 // CHECK-NEXT:template <> struct KernelInfo<class EMU> {
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
@@ -43,6 +46,8 @@
 // CHECK-NEXT:  static constexpr bool isESIMD() { return 0; }
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
 // CHECK-NEXT:    static constexpr bool callsThisItem() { return 1; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 1; }
 // CHECK-NEXT:};
 // CHECK-NEXT:template <> struct KernelInfo<class OWL> {
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
@@ -57,6 +62,8 @@
 // CHECK-NEXT:  static constexpr bool isESIMD() { return 0; }
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
 // CHECK-NEXT:    static constexpr bool callsThisItem() { return 0; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 0; }
 // CHECK-NEXT:};
 // CHECK-NEXT:template <> struct KernelInfo<class RAT> {
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
@@ -71,6 +78,24 @@
 // CHECK-NEXT:  static constexpr bool isESIMD() { return 0; }
 // CHECK-NEXT: __SYCL_DLL_LOCAL
 // CHECK-NEXT:    static constexpr bool callsThisItem() { return 1; }
+// CHECK-NEXT: __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 1; }
+// CHECK-NEXT:};
+// CHECK-NEXT:template <> struct KernelInfo<class FOX> {
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const char* getName() { return "_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE3FOX"; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr unsigned getNumParams() { return 0; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const kernel_param_desc_t& getParamDesc(unsigned i) {
+// CHECK-NEXT:    return kernel_signatures[i+0];
+// CHECK-NEXT: }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:  static constexpr bool isESIMD() { return 0; }
+// CHECK-NEXT: __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsThisItem() { return 0; }
+// CHECK-NEXT: __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 1; }
 // CHECK-NEXT:};
 
 #include "sycl.hpp"
@@ -108,6 +133,10 @@ int main() {
 
     // This kernel calls sycl::this_item
     cgh.parallel_for<class RAT>(range<1>(1), [=](id<1> I) { f(); });
+
+    // This kernel does not call sycl::this_item, but does call this_id
+    cgh.parallel_for<class FOX>(range<1>(1),
+                                [=](id<1> I) { this_id<1>(); });
   });
 
   return 0;

--- a/sycl/include/CL/sycl/ONEAPI/reduction.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/reduction.hpp
@@ -12,6 +12,7 @@
 #include <CL/sycl/ONEAPI/group_algorithm.hpp>
 #include <CL/sycl/accessor.hpp>
 #include <CL/sycl/handler.hpp>
+#include <CL/sycl/kernel.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {

--- a/sycl/include/CL/sycl/detail/cg_types.hpp
+++ b/sycl/include/CL/sycl/detail/cg_types.hpp
@@ -203,9 +203,6 @@ public:
   template <class ArgT = KernelArgType>
   typename detail::enable_if_t<std::is_same<ArgT, sycl::id<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using NameT =
-        typename detail::get_kernel_name_t<KernelName, KernelType>::name;
-    std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
     constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
 
@@ -232,9 +229,6 @@ public:
   typename detail::enable_if_t<
       std::is_same<ArgT, item<Dims, /*Offset=*/false>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using NameT =
-        typename detail::get_kernel_name_t<KernelName, KernelType>::name;
-    std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
     constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
 
@@ -260,9 +254,6 @@ public:
   typename detail::enable_if_t<
       std::is_same<ArgT, item<Dims, /*Offset=*/true>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using NameT =
-        typename detail::get_kernel_name_t<KernelName, KernelType>::name;
-    std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
     constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
 
@@ -289,9 +280,6 @@ public:
   template <class ArgT = KernelArgType>
   typename detail::enable_if_t<std::is_same<ArgT, nd_item<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using NameT =
-        typename detail::get_kernel_name_t<KernelName, KernelType>::name;
-    std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
     constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
 

--- a/sycl/include/CL/sycl/detail/cg_types.hpp
+++ b/sycl/include/CL/sycl/detail/cg_types.hpp
@@ -11,7 +11,6 @@
 #include <CL/sycl/detail/host_profiling_info.hpp>
 #include <CL/sycl/detail/kernel_desc.hpp>
 #include <CL/sycl/group.hpp>
-//#include <CL/sycl/handler.hpp>
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/interop_handle.hpp>
 #include <CL/sycl/interop_handler.hpp>

--- a/sycl/include/CL/sycl/detail/cg_types.hpp
+++ b/sycl/include/CL/sycl/detail/cg_types.hpp
@@ -204,7 +204,8 @@ public:
   template <class ArgT = KernelArgType>
   typename detail::enable_if_t<std::is_same<ArgT, sycl::id<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using NameT = typename detail::get_kernel_name_t<KernelName, KernelType>::name;
+    using NameT =
+        typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
     constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
@@ -219,9 +220,9 @@ public:
     detail::NDLoop<Dims>::iterate(Range, [&](const sycl::id<Dims> &ID) {
       sycl::item<Dims, /*Offset=*/true> Item =
           IDBuilder::createItem<Dims, true>(Range, ID, Offset);
-          
-      if(StoreLocation){
-        store_id(&ID);  // <--
+
+      if (StoreLocation) {
+        store_id(&ID);
         store_item(&Item);
       }
       MKernel(ID);
@@ -232,7 +233,8 @@ public:
   typename detail::enable_if_t<
       std::is_same<ArgT, item<Dims, /*Offset=*/false>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using NameT = typename detail::get_kernel_name_t<KernelName, KernelType>::name;
+    using NameT =
+        typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
     constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
@@ -247,7 +249,7 @@ public:
           IDBuilder::createItem<Dims, false>(Range, ID);
       sycl::item<Dims, /*Offset=*/true> ItemWithOffset = Item;
 
-      if(StoreLocation){
+      if (StoreLocation) {
         store_id(&ID);
         store_item(&ItemWithOffset);
       }
@@ -259,7 +261,8 @@ public:
   typename detail::enable_if_t<
       std::is_same<ArgT, item<Dims, /*Offset=*/true>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using NameT = typename detail::get_kernel_name_t<KernelName, KernelType>::name;
+    using NameT =
+        typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
     constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
@@ -276,7 +279,7 @@ public:
       sycl::item<Dims, /*Offset=*/true> Item =
           IDBuilder::createItem<Dims, true>(Range, OffsetID, Offset);
 
-      if(StoreLocation){
+      if (StoreLocation) {
         store_id(&OffsetID);
         store_item(&Item);
       }
@@ -287,7 +290,8 @@ public:
   template <class ArgT = KernelArgType>
   typename detail::enable_if_t<std::is_same<ArgT, nd_item<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using NameT = typename detail::get_kernel_name_t<KernelName, KernelType>::name;
+    using NameT =
+        typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
     constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
@@ -325,7 +329,7 @@ public:
         const sycl::nd_item<Dims> NDItem =
             IDBuilder::createNDItem<Dims>(GlobalItem, LocalItem, Group);
 
-        if(StoreLocation){
+        if (StoreLocation) {
           store_id(&GlobalID);
           store_item(&GlobalItem);
           store_nd_item(&NDItem);

--- a/sycl/include/CL/sycl/detail/cg_types.hpp
+++ b/sycl/include/CL/sycl/detail/cg_types.hpp
@@ -204,11 +204,10 @@ public:
   template <class ArgT = KernelArgType>
   typename detail::enable_if_t<std::is_same<ArgT, sycl::id<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    //CP
     using NameT = typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
-    constexpr bool StoreLocation = KI::callsThisItem(); //TO callsThisID or ThisItem?
+    constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
 
     sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
     sycl::id<Dims> Offset;
@@ -220,7 +219,7 @@ public:
     detail::NDLoop<Dims>::iterate(Range, [&](const sycl::id<Dims> &ID) {
       sycl::item<Dims, /*Offset=*/true> Item =
           IDBuilder::createItem<Dims, true>(Range, ID, Offset);
-      //CP
+          
       if(StoreLocation){
         store_id(&ID);  // <--
         store_item(&Item);
@@ -233,11 +232,10 @@ public:
   typename detail::enable_if_t<
       std::is_same<ArgT, item<Dims, /*Offset=*/false>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    //CP
     using NameT = typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
-    constexpr bool StoreLocation = KI::callsThisItem(); //TO callsThisID or ThisItem?
+    constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
 
     sycl::id<Dims> ID;
     sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
@@ -248,7 +246,7 @@ public:
       sycl::item<Dims, /*Offset=*/false> Item =
           IDBuilder::createItem<Dims, false>(Range, ID);
       sycl::item<Dims, /*Offset=*/true> ItemWithOffset = Item;
-      //CP
+
       if(StoreLocation){
         store_id(&ID);
         store_item(&ItemWithOffset);
@@ -261,11 +259,10 @@ public:
   typename detail::enable_if_t<
       std::is_same<ArgT, item<Dims, /*Offset=*/true>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    //CP
     using NameT = typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
-    constexpr bool StoreLocation = KI::callsThisItem(); //TO callsThisID or ThisItem?
+    constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
 
     sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
     sycl::id<Dims> Offset;
@@ -278,7 +275,7 @@ public:
       sycl::id<Dims> OffsetID = ID + Offset;
       sycl::item<Dims, /*Offset=*/true> Item =
           IDBuilder::createItem<Dims, true>(Range, OffsetID, Offset);
-      //CP
+
       if(StoreLocation){
         store_id(&OffsetID);
         store_item(&Item);
@@ -290,11 +287,10 @@ public:
   template <class ArgT = KernelArgType>
   typename detail::enable_if_t<std::is_same<ArgT, nd_item<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    //CP
     using NameT = typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     std::string KName = typeid(NameT *).name();
     using KI = detail::KernelInfo<KernelName>;
-    constexpr bool StoreLocation = KI::callsThisItem(); //TO callsThisID or ThisItem?
+    constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
 
     sycl::range<Dims> GroupSize(InitializedVal<Dims, range>::template get<0>());
     for (int I = 0; I < Dims; ++I) {
@@ -328,7 +324,7 @@ public:
             IDBuilder::createItem<Dims, false>(LocalSize, LocalID);
         const sycl::nd_item<Dims> NDItem =
             IDBuilder::createNDItem<Dims>(GlobalItem, LocalItem, Group);
-        //CP    
+
         if(StoreLocation){
           store_id(&GlobalID);
           store_item(&GlobalItem);

--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -58,6 +58,7 @@ template <class KernelNameType> struct KernelInfo {
   static constexpr const char *getName() { return ""; }
   static constexpr bool isESIMD() { return 0; }
   static constexpr bool callsThisItem() { return false; }
+  static constexpr bool callsAnyThisFreeFunction() { return false; }
 };
 #else
 template <char...> struct KernelInfoData {
@@ -69,6 +70,7 @@ template <char...> struct KernelInfoData {
   static constexpr const char *getName() { return ""; }
   static constexpr bool isESIMD() { return 0; }
   static constexpr bool callsThisItem() { return false; }
+  static constexpr bool callsAnyThisFreeFunction() { return false; }
 };
 
 // C++14 like index_sequence and make_index_sequence

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -107,11 +107,6 @@ SuggestedArgType argument_helper(...);
 template <typename F, typename SuggestedArgType>
 using lambda_arg_type = decltype(argument_helper<F, SuggestedArgType>(0));
 
-/// Specialization for the case when \c Name is undefined.
-template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {
-  using name = Type;
-};
-
 // Used when parallel_for range is rounded-up.
 template <typename Type> class __pf_kernel_wrapper;
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -78,7 +78,6 @@ template <typename T, int Dimensions, typename AllocatorT, typename Enable>
 class buffer;
 namespace detail {
 
-
 class kernel_impl;
 class queue_impl;
 class stream_impl;
@@ -107,7 +106,6 @@ SuggestedArgType argument_helper(...);
 
 template <typename F, typename SuggestedArgType>
 using lambda_arg_type = decltype(argument_helper<F, SuggestedArgType>(0));
-
 
 /// Specialization for the case when \c Name is undefined.
 template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {
@@ -400,7 +398,7 @@ private:
   // Recursively calls itself until arguments pack is fully processed.
   // The version for regular(standard layout) argument.
   template <typename T, typename... Ts>
-  void setArgsHelper(int ArgIndex, T &&Arg, Ts &&... Args) {
+  void setArgsHelper(int ArgIndex, T &&Arg, Ts &&...Args) {
     set_arg(ArgIndex, std::move(Arg));
     setArgsHelper(++ArgIndex, std::move(Args)...);
   }
@@ -499,7 +497,8 @@ private:
             typename LambdaArgType>
   void StoreLambda(KernelType KernelFunc) {
     MHostKernel.reset(
-        new detail::HostKernel<KernelType, LambdaArgType, Dims, KernelName>(KernelFunc));
+        new detail::HostKernel<KernelType, LambdaArgType, Dims, KernelName>(
+            KernelFunc));
 
     using KI = sycl::detail::KernelInfo<KernelName>;
     // Empty name indicates that the compilation happens without integration
@@ -976,7 +975,7 @@ public:
   /// Registers pack of arguments(Args) with indexes starting from 0.
   ///
   /// \param Args are argument values to be set.
-  template <typename... Ts> void set_args(Ts &&... Args) {
+  template <typename... Ts> void set_args(Ts &&...Args) {
     setArgsHelper(0, std::move(Args)...);
   }
 
@@ -1046,7 +1045,8 @@ public:
     MNDRDesc.set(range<1>{1});
 
     MArgs = std::move(MAssociatedAccesors);
-    MHostKernel.reset(new detail::HostKernel<FuncT, void, 1, void>(std::move(Func)));
+    MHostKernel.reset(
+        new detail::HostKernel<FuncT, void, 1, void>(std::move(Func)));
     MCGType = detail::CG::RUN_ON_HOST_INTEL;
   }
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -78,9 +78,10 @@ template <typename T, int Dimensions, typename AllocatorT, typename Enable>
 class buffer;
 namespace detail {
 
+//CP
 /// This class is the default KernelName template parameter type for kernel
 /// invocation APIs such as single_task.
-class auto_name {};
+//class auto_name {};
 
 class kernel_impl;
 class queue_impl;
@@ -111,12 +112,13 @@ SuggestedArgType argument_helper(...);
 template <typename F, typename SuggestedArgType>
 using lambda_arg_type = decltype(argument_helper<F, SuggestedArgType>(0));
 
+//CP
 /// Helper struct to get a kernel name type based on given \c Name and \c Type
 /// types: if \c Name is undefined (is a \c auto_name) then \c Type becomes
 /// the \c Name.
-template <typename Name, typename Type> struct get_kernel_name_t {
-  using name = Name;
-};
+// template <typename Name, typename Type> struct get_kernel_name_t {
+//   using name = Name;
+// };
 
 /// Specialization for the case when \c Name is undefined.
 template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {
@@ -508,7 +510,7 @@ private:
             typename LambdaArgType>
   void StoreLambda(KernelType KernelFunc) {
     MHostKernel.reset(
-        new detail::HostKernel<KernelType, LambdaArgType, Dims>(KernelFunc));
+        new detail::HostKernel<KernelType, LambdaArgType, Dims, KernelName>(KernelFunc));
 
     using KI = sycl::detail::KernelInfo<KernelName>;
     // Empty name indicates that the compilation happens without integration
@@ -1055,7 +1057,7 @@ public:
     MNDRDesc.set(range<1>{1});
 
     MArgs = std::move(MAssociatedAccesors);
-    MHostKernel.reset(new detail::HostKernel<FuncT, void, 1>(std::move(Func)));
+    MHostKernel.reset(new detail::HostKernel<FuncT, void, 1, void>(std::move(Func)));
     MCGType = detail::CG::RUN_ON_HOST_INTEL;
   }
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -78,10 +78,6 @@ template <typename T, int Dimensions, typename AllocatorT, typename Enable>
 class buffer;
 namespace detail {
 
-//CP
-/// This class is the default KernelName template parameter type for kernel
-/// invocation APIs such as single_task.
-//class auto_name {};
 
 class kernel_impl;
 class queue_impl;
@@ -112,13 +108,6 @@ SuggestedArgType argument_helper(...);
 template <typename F, typename SuggestedArgType>
 using lambda_arg_type = decltype(argument_helper<F, SuggestedArgType>(0));
 
-//CP
-/// Helper struct to get a kernel name type based on given \c Name and \c Type
-/// types: if \c Name is undefined (is a \c auto_name) then \c Type becomes
-/// the \c Name.
-// template <typename Name, typename Type> struct get_kernel_name_t {
-//   using name = Name;
-// };
 
 /// Specialization for the case when \c Name is undefined.
 template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -398,7 +398,7 @@ private:
   // Recursively calls itself until arguments pack is fully processed.
   // The version for regular(standard layout) argument.
   template <typename T, typename... Ts>
-  void setArgsHelper(int ArgIndex, T &&Arg, Ts &&...Args) {
+  void setArgsHelper(int ArgIndex, T &&Arg, Ts &&... Args) {
     set_arg(ArgIndex, std::move(Arg));
     setArgsHelper(++ArgIndex, std::move(Args)...);
   }
@@ -975,7 +975,7 @@ public:
   /// Registers pack of arguments(Args) with indexes starting from 0.
   ///
   /// \param Args are argument values to be set.
-  template <typename... Ts> void set_args(Ts &&...Args) {
+  template <typename... Ts> void set_args(Ts &&... Args) {
     setArgsHelper(0, std::move(Args)...);
   }
 

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -34,6 +34,11 @@ template <typename Name, typename Type> struct get_kernel_name_t {
   using name = Name;
 };
 
+/// Specialization for the case when \c Name is undefined.
+template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {
+  using name = Type;
+};
+
 } // namespace detail
 
 /// Provides an abstraction of a SYCL kernel.

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -22,7 +22,21 @@ class program;
 class context;
 namespace detail {
 class kernel_impl;
-}
+
+
+//CP
+/// This class is the default KernelName template parameter type for kernel
+/// invocation APIs such as single_task.
+class auto_name {};
+
+/// Helper struct to get a kernel name type based on given \c Name and \c Type
+/// types: if \c Name is undefined (is a \c auto_name) then \c Type becomes
+/// the \c Name.
+template <typename Name, typename Type> struct get_kernel_name_t {
+  using name = Name;
+};
+
+} //detail namespace
 
 /// Provides an abstraction of a SYCL kernel.
 ///

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -23,7 +23,6 @@ class context;
 namespace detail {
 class kernel_impl;
 
-
 /// This class is the default KernelName template parameter type for kernel
 /// invocation APIs such as single_task.
 class auto_name {};
@@ -35,7 +34,7 @@ template <typename Name, typename Type> struct get_kernel_name_t {
   using name = Name;
 };
 
-} //detail namespace
+} // namespace detail
 
 /// Provides an abstraction of a SYCL kernel.
 ///

--- a/sycl/include/CL/sycl/kernel.hpp
+++ b/sycl/include/CL/sycl/kernel.hpp
@@ -24,7 +24,6 @@ namespace detail {
 class kernel_impl;
 
 
-//CP
 /// This class is the default KernelName template parameter type for kernel
 /// invocation APIs such as single_task.
 class auto_name {};


### PR DESCRIPTION
The SYCL free functions ( `this_item`, `this_id`, etc) are expensive to support on host devices. They cause performance delays because every iteration through one of the `parallel_for` routines the various indexing values have to be updated in case the users code might call `this_item` or `this_id` (or the others).   But with the new `callsThisItem`  method added to the Kernel Information (thanks @rdeodhar !), the host device can avoid paying the performance penalty if the users code doesn't actually call `this_item`..   We can detect at compile time whether or not any of the `this_xxx` free functions are used by the users code, and if not, don't bother storing the indexing data in each loop iteration. 

In this PR we add further expand the Kernel Information to support a `callsAnyThisFreeFunction` method, and we use it to avoid the sundry `store_item` etc. calls on the host. 