### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -6297,6 +6297,7 @@ static void processSYCLKernel(Sema &S, FunctionDecl *FD, MangleContext &MC) {
     const CXXRecordDecl *CRD = (KernelParamTy->isReferenceType()
                                     ? KernelParamTy->getPointeeCXXRecordDecl()
                                     : KernelParamTy->getAsCXXRecordDecl());
+    assert(CRD && "invalid kernel caller");
     for (auto *Method : CRD->methods())
       if (Method->getOverloadedOperator() == OO_Call &&
           !Method->hasAttr<AlwaysInlineAttr>())


### PR DESCRIPTION
Found via a static-analysis tool Inside processSYCLKernel():

const CXXRecordDecl *CRD = (KernelParamTy->isReferenceType()
                                    ? KernelParamTy->getPointeeCXXRecordDecl()  Pointer 'CRD' returned from call to function 'getPointeeCXXRecordDecl' may be NULL here
                                    : KernelParamTy->getAsCXXRecordDecl());

for (auto *Method : CRD->methods()) -- will be dereferenced here

This patch fixes null pointer dereference issue inside SemaTemplateInstantiateDecl.cpp file.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>