### PR TITLE
[SYCL][NFC] Diagnostic message improvement for negative arguments values of work_group_size attributes

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11207,10 +11207,8 @@ def warn_attribute_spelling_deprecated : Warning<
   InGroup<DeprecatedAttributes>;
 def note_spelling_suggestion : Note<
   "did you mean to use %0 instead?">;
-def warn_attribute_requires_non_negative_integer_argument : Warning<
-  "the resulting value of the %0 attribute %select{first|second|third}1"
-  " parameter is always non-negative after implicit conversion">,
- InGroup<AcceptedAttributes>;
+def warn_attribute_requires_non_negative_integer_argument :
+  Warning<warn_impcast_integer_sign.Text>, InGroup<AcceptedAttributes>;
 
 // errors of expect.with.probability
 def err_probability_not_constant_float : Error<

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12982,7 +12982,7 @@ static bool handleMaxWorkSizeAttrExpr(Sema &S, const AttrInfo &AI,
       S.Diag(Expr->getExprLoc(),
              diag::warn_attribute_requires_non_negative_integer_argument)
           << S.Context.IntTy << S.Context.UnsignedIntTy
-	  << Expr->getSourceRange();
+          << Expr->getSourceRange();
       return true;
     }
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12981,7 +12981,8 @@ static bool handleMaxWorkSizeAttrExpr(Sema &S, const AttrInfo &AI,
     if (ArgVal->isNegative()) {
       S.Diag(Expr->getExprLoc(),
              diag::warn_attribute_requires_non_negative_integer_argument)
-          << &AI << Idx << Expr->getSourceRange();
+          << S.Context.IntTy << S.Context.UnsignedIntTy
+	  << Expr->getSourceRange();
       return true;
     }
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12964,32 +12964,32 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
 
 template <typename AttrInfo>
 static bool handleMaxWorkSizeAttrExpr(Sema &S, const AttrInfo &AI,
-                                      const Expr *Expr, unsigned &Val,
+                                      const Expr *E, unsigned &Val,
                                       unsigned Idx) {
-  assert(Expr && "Attribute must have an argument.");
+  assert(E && "Attribute must have an argument.");
 
-  if (!Expr->isInstantiationDependent()) {
+  if (!E->isInstantiationDependent()) {
     Optional<llvm::APSInt> ArgVal =
-        Expr->getIntegerConstantExpr(S.getASTContext());
+        E->getIntegerConstantExpr(S.getASTContext());
 
     if (!ArgVal) {
       S.Diag(AI.getLocation(), diag::err_attribute_argument_type)
-          << &AI << AANT_ArgumentIntegerConstant << Expr->getSourceRange();
+          << &AI << AANT_ArgumentIntegerConstant << E->getSourceRange();
       return false;
     }
 
     if (ArgVal->isNegative()) {
-      S.Diag(Expr->getExprLoc(),
+      S.Diag(E->getExprLoc(),
              diag::warn_attribute_requires_non_negative_integer_argument)
-          << S.Context.IntTy << S.Context.UnsignedIntTy
-          << Expr->getSourceRange();
+          << E->getType() << S.Context.UnsignedLongLongTy
+          << E->getSourceRange();
       return true;
     }
 
     Val = ArgVal->getZExtValue();
     if (Val == 0) {
-      S.Diag(Expr->getExprLoc(), diag::err_attribute_argument_is_zero)
-          << &AI << Expr->getSourceRange();
+      S.Diag(E->getExprLoc(), diag::err_attribute_argument_is_zero)
+          << &AI << E->getSourceRange();
       return false;
     }
   }

--- a/clang/test/SemaOpenCL/invalid-kernel-attrs.cl
+++ b/clang/test/SemaOpenCL/invalid-kernel-attrs.cl
@@ -42,7 +42,7 @@ kernel __attribute__((intel_reqd_sub_group_size(-1))) void kernel16() {} // expe
 kernel __attribute__((intel_reqd_sub_group_size(8))) __attribute__((intel_reqd_sub_group_size(16))) void kernel17() {} //expected-warning{{attribute 'intel_reqd_sub_group_size' is already applied with different parameters}}
 
 __kernel __attribute__((work_group_size_hint(8,-16,32))) void neg1() {} //expected-error{{'work_group_size_hint' attribute requires a non-negative integral compile time constant expression}}
-__kernel __attribute__((reqd_work_group_size(8, 16, -32))) void neg2() {} //expected-warning{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
+__kernel __attribute__((reqd_work_group_size(8, 16, -32))) void neg2() {} //expected-warning{{implicit conversion changes signedness: 'int' to 'unsigned long long'}}
 
 // 4294967294 is a negative integer if treated as signed.
 // Should compile successfully, since we expect an unsigned.

--- a/clang/test/SemaOpenCL/invalid-kernel-attrs.cl
+++ b/clang/test/SemaOpenCL/invalid-kernel-attrs.cl
@@ -42,7 +42,7 @@ kernel __attribute__((intel_reqd_sub_group_size(-1))) void kernel16() {} // expe
 kernel __attribute__((intel_reqd_sub_group_size(8))) __attribute__((intel_reqd_sub_group_size(16))) void kernel17() {} //expected-warning{{attribute 'intel_reqd_sub_group_size' is already applied with different parameters}}
 
 __kernel __attribute__((work_group_size_hint(8,-16,32))) void neg1() {} //expected-error{{'work_group_size_hint' attribute requires a non-negative integral compile time constant expression}}
-__kernel __attribute__((reqd_work_group_size(8, 16, -32))) void neg2() {} //expected-warning{{the resulting value of the 'reqd_work_group_size' attribute third parameter is always non-negative after implicit conversion}}
+__kernel __attribute__((reqd_work_group_size(8, 16, -32))) void neg2() {} //expected-warning{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
 
 // 4294967294 is a negative integer if treated as signed.
 // Should compile successfully, since we expect an unsigned.

--- a/clang/test/SemaSYCL/intel-max-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size-device.cpp
@@ -75,7 +75,7 @@ int main() {
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
     // CHECK-NEXT:  UnaryOperator{{.*}} 'int' prefix '-'
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
-    // expected-warning@+2{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
+    // expected-warning@+2{{implicit conversion changes signedness: 'int' to 'unsigned long long'}}
     h.single_task<class test_kernel4>(
         []() [[intel::max_work_group_size(8, 8, -8)]]{});
 
@@ -86,7 +86,7 @@ int main() {
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
     // CHECK-NEXT:  UnaryOperator{{.*}} 'int' prefix '-'
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
-    // expected-warning@+2 2{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
+    // expected-warning@+2 2{{implicit conversion changes signedness: 'int' to 'unsigned long long'}}
     h.single_task<class test_kernel5>(
         []() [[intel::max_work_group_size(-8, 8, -8)]]{});
 #ifdef TRIGGER_ERROR

--- a/clang/test/SemaSYCL/intel-max-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size-device.cpp
@@ -75,24 +75,34 @@ int main() {
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
     // CHECK-NEXT:  UnaryOperator{{.*}} 'int' prefix '-'
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
-    // expected-warning@+2{{the resulting value of the 'max_work_group_size' attribute third parameter is always non-negative after implicit conversion}}
+    // expected-warning@+2{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
     h.single_task<class test_kernel4>(
         []() [[intel::max_work_group_size(8, 8, -8)]]{});
 
+    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel5
+    // CHECK:       SYCLIntelMaxWorkGroupSizeAttr {{.*}}
+    // CHECK-NEXT:  UnaryOperator{{.*}} 'int' prefix '-'
+    // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
+    // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
+    // CHECK-NEXT:  UnaryOperator{{.*}} 'int' prefix '-'
+    // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
+    // expected-warning@+2 2{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
+    h.single_task<class test_kernel5>(
+        []() [[intel::max_work_group_size(-8, 8, -8)]]{});
 #ifdef TRIGGER_ERROR
     [[intel::max_work_group_size(1, 1, 1)]] int Var = 0; // expected-error{{'max_work_group_size' attribute only applies to functions}}
 
-    h.single_task<class test_kernel5>(
+    h.single_task<class test_kernel6>(
         []() [[intel::max_work_group_size(0, 1, 3)]]{}); // expected-error{{'max_work_group_size' attribute must be greater than 0}}
 
-    h.single_task<class test_kernel6>(
+    h.single_task<class test_kernel7>(
         []() [[intel::max_work_group_size(1.2f, 1, 3)]]{}); // expected-error{{'max_work_group_size' attribute requires an integer constant}}
 
-    h.single_task<class test_kernel7>(
+    h.single_task<class test_kernel8>(
         []() [[intel::max_work_group_size(16, 16, 16),   // expected-note{{conflicting attribute is here}}
                intel::max_work_group_size(2, 2, 2)]]{}); // expected-warning{{attribute 'max_work_group_size' is already applied with different parameters}}
 
-    h.single_task<class test_kernel8>(
+    h.single_task<class test_kernel9>(
         DAFuncObj());
 
 #endif // TRIGGER_ERROR

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
@@ -40,8 +40,14 @@ public:
 
 class Functor33 {
 public:
-  // expected-warning@+1{{the resulting value of the 'reqd_work_group_size' attribute second parameter is always non-negative after implicit conversion}}
+  // expected-warning@+1{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
   [[intel::reqd_work_group_size(32, -4)]] void operator()() const {}
+};
+
+class Functor30 {
+public:
+  // expected-warning@+1 2{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
+  [[intel::reqd_work_group_size(30, -30, -30)]] void operator()() const {}
 };
 
 class Functor16 {
@@ -95,30 +101,33 @@ int main() {
     Functor33 f33;
     h.single_task<class kernel_name5>(f33);
 
-    h.single_task<class kernel_name6>([]() [[intel::reqd_work_group_size(32, 32, 32)]] {
+    Functor30 f30;
+    h.single_task<class kernel_name6>(f30);
+
+    h.single_task<class kernel_name7>([]() [[intel::reqd_work_group_size(32, 32, 32)]] {
       f32x32x32();
     });
 #ifdef TRIGGER_ERROR
     Functor8 f8;
-    h.single_task<class kernel_name7>(f8);
+    h.single_task<class kernel_name8>(f8);
 
-    h.single_task<class kernel_name8>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name9>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
       f4x1x1();
       f32x1x1();
     });
 
-    h.single_task<class kernel_name9>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name10>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
       f16x1x1();
       f16x16x1();
     });
 
-    h.single_task<class kernel_name10>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name11>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
       f32x32x32();
       f32x32x1();
     });
 
     // expected-error@+1 {{expected variable name or 'this' in lambda capture list}}
-    h.single_task<class kernel_name11>([[intel::reqd_work_group_size(32, 32, 32)]][]() {
+    h.single_task<class kernel_name12>([[intel::reqd_work_group_size(32, 32, 32)]][]() {
       f32x32x32();
     });
 
@@ -154,6 +163,13 @@ int main() {
 // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
 // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name6
+// CHECK: ReqdWorkGroupSizeAttr {{.*}}
+// CHECK-NEXT:  IntegerLiteral{{.*}}30{{$}}
+// CHECK-NEXT:  UnaryOperator{{.*}} 'int' prefix '-'
+// CHECK-NEXT:  IntegerLiteral{{.*}}30{{$}}
+// CHECK-NEXT:  UnaryOperator{{.*}} 'int' prefix '-'
+// CHECK-NEXT:  IntegerLiteral{{.*}}30{{$}}
+// CHECK: FunctionDecl {{.*}} {{.*}}kernel_name7
 // CHECK: ReqdWorkGroupSizeAttr {{.*}}
 // CHECK-NEXT:  IntegerLiteral{{.*}}32{{$}}
 // CHECK-NEXT:  IntegerLiteral{{.*}}32{{$}}

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
@@ -40,13 +40,13 @@ public:
 
 class Functor33 {
 public:
-  // expected-warning@+1{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
+  // expected-warning@+1{{implicit conversion changes signedness: 'int' to 'unsigned long long'}}
   [[intel::reqd_work_group_size(32, -4)]] void operator()() const {}
 };
 
 class Functor30 {
 public:
-  // expected-warning@+1 2{{implicit conversion changes signedness: 'int' to 'unsigned int'}}
+  // expected-warning@+1 2{{implicit conversion changes signedness: 'int' to 'unsigned long long'}}
   [[intel::reqd_work_group_size(30, -30, -30)]] void operator()() const {}
 };
 


### PR DESCRIPTION
Template parameter support for work_group_size attributes was added on
https://github.com/intel/llvm/pull/2906/

This is a follow-up comments in https://github.com/intel/llvm/pull/2906#discussion_r551314371

This patch improves the diagnostic message for
"warn_attribute_requires_non_negative_integer_argument" and updates tests
related to this diagnostic.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>