### PR TITLE
[SYCL] Do not emit "llvm.used" to output module(s) in the post link tool

### DIFF
--- a/llvm/test/tools/sycl-post-link/erase_used.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used.ll
@@ -1,0 +1,20 @@
+; This test checks that the post-link tool does not add "llvm.used" global to
+; the output modules when splitting kernels.
+;
+; RUN: sycl-post-link -split=kernel -S %s -o %T/files.table
+; RUN: FileCheck %s -input-file=%T/files_0.ll
+; RUN: FileCheck %s -input-file=%T/files_1.ll
+
+target triple = "spir64-unknown-unknown-sycldevice"
+
+; CHECK-NOT: llvm.used
+@llvm.used = appending global [2 x i8*] [i8* bitcast (void ()* @foo to i8*), i8* bitcast (void ()* @bar to i8*)], section "llvm.metadata"
+
+define weak_odr spir_kernel void @foo() {
+  ret void
+}
+
+define weak_odr spir_kernel void @bar() {
+  ret void
+}
+

--- a/llvm/test/tools/sycl-post-link/erase_used.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used.ll
@@ -17,4 +17,3 @@ define weak_odr spir_kernel void @foo() {
 define weak_odr spir_kernel void @bar() {
   ret void
 }
-

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -693,7 +693,7 @@ int main(int argc, char **argv) {
   // module is known to cause problems for tools which run later in pipeline, so
   // remove it from the module before perfroming any other actions.
   if (GlobalVariable *GV = MPtr->getGlobalVariable("llvm.used")) {
-    assert(GV->user_empty() && "unexpected ");
+    assert(GV->user_empty() && "unexpected llvm.used users");
     GV->eraseFromParent();
   }
 

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -688,6 +688,15 @@ int main(int argc, char **argv) {
     Err.print(argv[0], errs());
     return 1;
   }
+
+  // Special "llvm.used" variable which holds references to global values in the
+  // module is known to cause problems for tools which run later in pipeline, so
+  // remove it from the module before perfroming any other actions.
+  if (GlobalVariable *GV = MPtr->getGlobalVariable("llvm.used")) {
+    assert(GV->user_empty() && "unexpected ");
+    GV->eraseFromParent();
+  }
+
   if (OutputFilename.getNumOccurrences() == 0)
     OutputFilename = (Twine(sys::path::stem(InputFilename)) + ".files").str();
 


### PR DESCRIPTION
This special global variable may cause problems for tools runing later in pipeline.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>