### PR TITLE
[SYCL] Add identification macro for DPCPP compiler

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -475,6 +475,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
   }
 
   if (LangOpts.SYCL) {
+    // DPCPP compiler identification macro
+    Builder.defineMacro("__DPCPP_COMPILER", "1");
     // SYCL Version is set to a value when building SYCL applications
     if (LangOpts.getSYCLVersion() == LangOptions::SYCL_2017) {
       Builder.defineMacro("CL_SYCL_LANGUAGE_VERSION", "121");

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -476,7 +476,7 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
 
   if (LangOpts.SYCL) {
     // DPCPP compiler identification macro
-    Builder.defineMacro("__DPCPP_COMPILER", "1");
+    Builder.defineMacro("__DPCPP_COMPILER__", "1");
     // SYCL Version is set to a value when building SYCL applications
     if (LangOpts.getSYCLVersion() == LangOptions::SYCL_2017) {
       Builder.defineMacro("CL_SYCL_LANGUAGE_VERSION", "121");

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -215,10 +215,10 @@
 // CHECK-HIP-DEV: #define __HIP_DEVICE_COMPILE__ 1
 // CHECK-HIP-DEV: #define __HIP__ 1
 
-// RUN: %clang_cc1 %s -E -dM -fsycl -o - -triple spir64\
+// RUN: %clang_cc1 %s -E -dM -fsycl -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-FSYCL
-// CHECK-FSYCL: #define __DPCPP_COMPILER 1
+// CHECK-FSYCL: #define __DPCPP_COMPILER__ 1
 
-// RUN: %clang_cc1 %s -E -dM -o - -triple spir64\
+// RUN: %clang_cc1 %s -E -dM -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-FSYCL
-// CHECK-NO-FSYCL-NOT: #define DPCPP_COMPILER 1
+// CHECK-NO-FSYCL-NOT: #define DPCPP_COMPILER__ 1

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -221,4 +221,4 @@
 
 // RUN: %clang_cc1 %s -E -dM -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-FSYCL
-// CHECK-NO-FSYCL-NOT: #define DPCPP_COMPILER__ 1
+// CHECK-NO-FSYCL-NOT: #define __DPCPP_COMPILER__ 1

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -214,3 +214,11 @@
 // CHECK-HIP-DEV: #define __HIPCC__ 1
 // CHECK-HIP-DEV: #define __HIP_DEVICE_COMPILE__ 1
 // CHECK-HIP-DEV: #define __HIP__ 1
+
+// RUN: %clang_cc1 %s -E -dM -fsycl -o - -triple spir64\
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-FSYCL
+// CHECK-FSYCL: #define __DPCPP_COMPILER 1
+
+// RUN: %clang_cc1 %s -E -dM -o - -triple spir64\
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-FSYCL
+// CHECK-NO-FSYCL-NOT: #define DPCPP_COMPILER 1


### PR DESCRIPTION
Add predefined macro __DPCPP_COMPILER = 1, to uniquely identify DPCPP compiler.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>