### PR TITLE
[SYCL] Fix -fno-sycl-early-optimizations behavior broken in pulldown.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4463,8 +4463,7 @@ def disable_llvm_verifier : Flag<["-"], "disable-llvm-verifier">,
   MarshallingInfoNegativeFlag<"CodeGenOpts.VerifyModule">;
 def disable_llvm_passes : Flag<["-"], "disable-llvm-passes">,
   HelpText<"Use together with -emit-llvm to get pristine LLVM IR from the "
-           "frontend by not running any LLVM passes at all">,
-  MarshallingInfoFlag<"CodeGenOpts.DisableLLVMPasses">;
+           "frontend by not running any LLVM passes at all">;
 def disable_llvm_optzns : Flag<["-"], "disable-llvm-optzns">,
   Alias<disable_llvm_passes>;
 def disable_lifetimemarkers : Flag<["-"], "disable-lifetime-markers">,

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -923,6 +923,11 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
         {std::string(Split.first), std::string(Split.second)});
   }
 
+  Opts.DisableLLVMPasses =
+      Args.hasArg(OPT_disable_llvm_passes) ||
+      (Args.hasArg(OPT_fsycl_is_device) && Triple.isSPIR() &&
+       Args.hasArg(OPT_fno_sycl_early_optimizations));
+
   const llvm::Triple::ArchType DebugEntryValueArchs[] = {
       llvm::Triple::x86, llvm::Triple::x86_64, llvm::Triple::aarch64,
       llvm::Triple::arm, llvm::Triple::armeb, llvm::Triple::mips,

--- a/clang/test/CodeGenSYCL/kernel-early-optimization-pipeline.cpp
+++ b/clang/test/CodeGenSYCL/kernel-early-optimization-pipeline.cpp
@@ -1,0 +1,10 @@
+// Check LLVM optimization pipeline is run by default for SPIR-V compiled for
+// SYCL device target, and can be disabled with -fno-sycl-early-optimizations.
+//
+// RUN: %clang_cc1 -O2 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice %s -mllvm -debug-pass=Structure -emit-llvm -o - 2>&1 | FileCheck %s --check-prefix=CHECK-EARLYOPT
+// CHECK-EARLYOPT: Lower Work Group Scope Code
+// CHECK-EARLYOPT: Combine redundant instructions
+//
+// RUN: %clang_cc1 -O2 -fsycl -fsycl-is-device -fno-sycl-early-optimizations -triple spir64-unknown-unknown-sycldevice %s -mllvm -debug-pass=Structure -emit-llvm -o - 2>&1 | FileCheck %s --check-prefix=CHECK-NOEARLYOPT
+// CHECK-NOEARLYOPT: Lower Work Group Scope Code
+// CHECK-NOEARLYOPT-NOT: Combine redundant instructions


### PR DESCRIPTION
D83892 simplifies Clang option parsing, including that of
"-disable-llvm-passes", but inadvertently removes SYCL custom logic for it.
This patch reverts to the old way of handling "-disable-llvm-passes" and
restores the original behavior.