### PR TITLE
[SYCL] Fix acquiring a mutex in _pi_context::finalize

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -459,7 +459,7 @@ pi_result _pi_context::finalize() {
   // There could be some memory that may have not been deallocated.
   // For example, zeEventPool could be still alive.
   std::lock_guard<std::mutex> NumEventsLiveInEventPoolGuard(
-      NumEventsLiveInEventPoolMutex, std::adopt_lock);
+      NumEventsLiveInEventPoolMutex);
   if (ZeEventPool && NumEventsLiveInEventPool[ZeEventPool])
     zeEventPoolDestroy(ZeEventPool);
 


### PR DESCRIPTION
I observed crashes in ESIMD tests at the exit of _pi_context::finalize
function. Unlocking not owned mutex is Undefined Behavior.
Crashes occured only on Debug builds on Windows platforms when using
LevelZero. I saw the following error: "unlock of unowned mutex".