### PR TITLE
Fix the clang-tidy build after work_group_size attr changes.

### DIFF
--- a/clang-tools-extra/clang-tidy/altera/SingleWorkItemBarrierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/altera/SingleWorkItemBarrierCheck.cpp
@@ -57,8 +57,9 @@ void SingleWorkItemBarrierCheck::check(const MatchFinder::MatchResult &Result) {
     bool IsNDRange = false;
     if (MatchedDecl->hasAttr<ReqdWorkGroupSizeAttr>()) {
       const auto *Attribute = MatchedDecl->getAttr<ReqdWorkGroupSizeAttr>();
-      if (Attribute->getXDim() > 1 || Attribute->getYDim() > 1 ||
-          Attribute->getZDim() > 1)
+      if (*Attribute->getXDimVal(*Result.Context) > 1 ||
+          *Attribute->getYDimVal(*Result.Context) > 1 ||
+          *Attribute->getZDimVal(*Result.Context) > 1)
         IsNDRange = true;
     }
     if (IsNDRange) // No warning if kernel is treated as an NDRange.

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1303,14 +1303,14 @@ def SYCLIntelMaxWorkGroupSize : InheritableAttr {
       return {getXDim(), getYDim(), getZDim()};
     }
     Optional<llvm::APSInt> getXDimVal(ASTContext &Ctx) const {
-	  return getXDim()->getIntegerConstantExpr(Ctx);
-	}
+      return getXDim()->getIntegerConstantExpr(Ctx);
+    }
     Optional<llvm::APSInt> getYDimVal(ASTContext &Ctx) const {
-	  return getYDim()->getIntegerConstantExpr(Ctx);
-	}
+      return getYDim()->getIntegerConstantExpr(Ctx);
+    }
     Optional<llvm::APSInt> getZDimVal(ASTContext &Ctx) const {
-	  return getZDim()->getIntegerConstantExpr(Ctx);
-	}
+      return getZDim()->getIntegerConstantExpr(Ctx);
+    }
   }];
   let Documentation = [SYCLIntelMaxWorkGroupSizeAttrDocs];
 }
@@ -2863,14 +2863,14 @@ def ReqdWorkGroupSize : InheritableAttr {
       return {getXDim(), getYDim(), getZDim()};
     }
     Optional<llvm::APSInt> getXDimVal(ASTContext &Ctx) const {
-	  return getXDim()->getIntegerConstantExpr(Ctx);
-	}
+      return getXDim()->getIntegerConstantExpr(Ctx);
+    }
     Optional<llvm::APSInt> getYDimVal(ASTContext &Ctx) const {
-	  return getYDim()->getIntegerConstantExpr(Ctx);
-	}
+      return getYDim()->getIntegerConstantExpr(Ctx);
+    }
     Optional<llvm::APSInt> getZDimVal(ASTContext &Ctx) const {
-	  return getZDim()->getIntegerConstantExpr(Ctx);
-	}
+      return getZDim()->getIntegerConstantExpr(Ctx);
+    }
   }];
   let Documentation = [ReqdWorkGroupSizeAttrDocs];
 }

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1302,6 +1302,15 @@ def SYCLIntelMaxWorkGroupSize : InheritableAttr {
     ArrayRef<const Expr *> dimensions() const {
       return {getXDim(), getYDim(), getZDim()};
     }
+    Optional<llvm::APSInt> getXDimVal(ASTContext &Ctx) const {
+	  return getXDim()->getIntegerConstantExpr(Ctx);
+	}
+    Optional<llvm::APSInt> getYDimVal(ASTContext &Ctx) const {
+	  return getYDim()->getIntegerConstantExpr(Ctx);
+	}
+    Optional<llvm::APSInt> getZDimVal(ASTContext &Ctx) const {
+	  return getZDim()->getIntegerConstantExpr(Ctx);
+	}
   }];
   let Documentation = [SYCLIntelMaxWorkGroupSizeAttrDocs];
 }
@@ -2853,6 +2862,15 @@ def ReqdWorkGroupSize : InheritableAttr {
     ArrayRef<const Expr *> dimensions() const {
       return {getXDim(), getYDim(), getZDim()};
     }
+    Optional<llvm::APSInt> getXDimVal(ASTContext &Ctx) const {
+	  return getXDim()->getIntegerConstantExpr(Ctx);
+	}
+    Optional<llvm::APSInt> getYDimVal(ASTContext &Ctx) const {
+	  return getYDim()->getIntegerConstantExpr(Ctx);
+	}
+    Optional<llvm::APSInt> getZDimVal(ASTContext &Ctx) const {
+	  return getZDim()->getIntegerConstantExpr(Ctx);
+	}
   }];
   let Documentation = [ReqdWorkGroupSizeAttrDocs];
 }

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -621,12 +621,10 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
 
   if (const ReqdWorkGroupSizeAttr *A = FD->getAttr<ReqdWorkGroupSizeAttr>()) {
     llvm::LLVMContext &Context = getLLVMContext();
-    Optional<llvm::APSInt> XDimVal =
-        A->getXDim()->getIntegerConstantExpr(FD->getASTContext());
-    Optional<llvm::APSInt> YDimVal =
-        A->getYDim()->getIntegerConstantExpr(FD->getASTContext());
-    Optional<llvm::APSInt> ZDimVal =
-        A->getZDim()->getIntegerConstantExpr(FD->getASTContext());
+    ASTContext &ClangCtx = FD->getASTContext();
+    Optional<llvm::APSInt> XDimVal = A->getXDimVal(ClangCtx);
+    Optional<llvm::APSInt> YDimVal = A->getYDimVal(ClangCtx);
+    Optional<llvm::APSInt> ZDimVal = A->getZDimVal(ClangCtx);
 
     // For a SYCLDevice ReqdWorkGroupSizeAttr arguments are reversed.
     if (getLangOpts().SYCLIsDevice)
@@ -701,12 +699,10 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
   if (const SYCLIntelMaxWorkGroupSizeAttr *A =
           FD->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
     llvm::LLVMContext &Context = getLLVMContext();
-    Optional<llvm::APSInt> XDimVal =
-        A->getXDim()->getIntegerConstantExpr(FD->getASTContext());
-    Optional<llvm::APSInt> YDimVal =
-        A->getYDim()->getIntegerConstantExpr(FD->getASTContext());
-    Optional<llvm::APSInt> ZDimVal =
-        A->getZDim()->getIntegerConstantExpr(FD->getASTContext());
+    ASTContext &ClangCtx = FD->getASTContext();
+    Optional<llvm::APSInt> XDimVal = A->getXDimVal(ClangCtx);
+    Optional<llvm::APSInt> YDimVal = A->getYDimVal(ClangCtx);
+    Optional<llvm::APSInt> ZDimVal = A->getZDimVal(ClangCtx);
 
     // For a SYCLDevice SYCLIntelMaxWorkGroupSizeAttr arguments are reversed.
     if (getLangOpts().SYCLIsDevice)

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -9003,12 +9003,8 @@ void AMDGPUTargetCodeGenInfo::setTargetAttributes(
     unsigned ZDim = 0;
     ASTContext &Ctx = M.getContext();
     if (FlatWGS) {
-      Min = FlatWGS->getMin()
-                ->EvaluateKnownConstInt(Ctx)
-                .getExtValue();
-      Max = FlatWGS->getMax()
-                ->EvaluateKnownConstInt(Ctx)
-                .getExtValue();
+      Min = FlatWGS->getMin()->EvaluateKnownConstInt(Ctx).getExtValue();
+      Max = FlatWGS->getMax()->EvaluateKnownConstInt(Ctx).getExtValue();
     }
     if (ReqdWGS) {
       XDim = ReqdWGS->getXDimVal(Ctx)->getZExtValue();

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -8108,15 +8108,10 @@ void TCETargetCodeGenInfo::setTargetAttributes(
 
         SmallVector<llvm::Metadata *, 5> Operands;
         Operands.push_back(llvm::ConstantAsMetadata::get(F));
-        unsigned XDim = Attr->getXDim()
-                            ->EvaluateKnownConstInt(M.getContext())
-                            .getZExtValue();
-        unsigned YDim = Attr->getYDim()
-                            ->EvaluateKnownConstInt(M.getContext())
-                            .getZExtValue();
-        unsigned ZDim = Attr->getZDim()
-                            ->EvaluateKnownConstInt(M.getContext())
-                            .getZExtValue();
+        ASTContext &Ctx = M.getContext();
+        unsigned XDim = Attr->getXDimVal(Ctx)->getZExtValue();
+        unsigned YDim = Attr->getYDimVal(Ctx)->getZExtValue();
+        unsigned ZDim = Attr->getZDimVal(Ctx)->getZExtValue();
 
         Operands.push_back(llvm::ConstantAsMetadata::get(
             llvm::Constant::getIntegerValue(M.Int32Ty, llvm::APInt(32, XDim))));
@@ -9006,24 +9001,19 @@ void AMDGPUTargetCodeGenInfo::setTargetAttributes(
     unsigned XDim = 0;
     unsigned YDim = 0;
     unsigned ZDim = 0;
+    ASTContext &Ctx = M.getContext();
     if (FlatWGS) {
       Min = FlatWGS->getMin()
-                ->EvaluateKnownConstInt(M.getContext())
+                ->EvaluateKnownConstInt(Ctx)
                 .getExtValue();
       Max = FlatWGS->getMax()
-                ->EvaluateKnownConstInt(M.getContext())
+                ->EvaluateKnownConstInt(Ctx)
                 .getExtValue();
     }
     if (ReqdWGS) {
-      XDim = ReqdWGS->getXDim()
-                 ->EvaluateKnownConstInt(M.getContext())
-                 .getZExtValue();
-      YDim = ReqdWGS->getYDim()
-                 ->EvaluateKnownConstInt(M.getContext())
-                 .getZExtValue();
-      ZDim = ReqdWGS->getZDim()
-                 ->EvaluateKnownConstInt(M.getContext())
-                 .getZExtValue();
+      XDim = ReqdWGS->getXDimVal(Ctx)->getZExtValue();
+      YDim = ReqdWGS->getYDimVal(Ctx)->getZExtValue();
+      ZDim = ReqdWGS->getZDimVal(Ctx)->getZExtValue();
     }
     if (ReqdWGS && Min == 0 && Max == 0)
       Min = Max = XDim * YDim * ZDim;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3209,18 +3209,10 @@ static void checkDimensionsAndSetDiagnostics(Sema &S, FunctionDecl *New,
   if (!NewDeclAttr || !OldDeclAttr)
     return;
 
-  /// Returns the usigned constant integer value represented by
-  /// given expression.
-  auto getExprValue = [](const Expr *E, ASTContext &Ctx) {
-    return E->getIntegerConstantExpr(Ctx)->getZExtValue();
-  };
-
-  if ((getExprValue(NewDeclAttr->getXDim(), S.getASTContext()) !=
-       getExprValue(OldDeclAttr->getXDim(), S.getASTContext())) ||
-      (getExprValue(NewDeclAttr->getYDim(), S.getASTContext()) !=
-       getExprValue(OldDeclAttr->getYDim(), S.getASTContext())) ||
-      (getExprValue(NewDeclAttr->getZDim(), S.getASTContext()) !=
-       getExprValue(OldDeclAttr->getZDim(), S.getASTContext()))) {
+  ASTContext &Ctx = S.getASTContext();
+  if (NewDeclAttr->getXDimVal(Ctx) != OldDeclAttr->getXDimVal(Ctx) ||
+      NewDeclAttr->getYDimVal(Ctx) != OldDeclAttr->getYDimVal(Ctx) ||
+      NewDeclAttr->getZDimVal(Ctx) != OldDeclAttr->getZDimVal(Ctx)) {
     S.Diag(New->getLocation(), diag::err_conflicting_sycl_function_attributes)
         << OldDeclAttr << NewDeclAttr;
     S.Diag(New->getLocation(), diag::warn_duplicate_attribute) << OldDeclAttr;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3096,23 +3096,17 @@ static void handleWorkGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
   }
 
   if (WorkGroupAttr *ExistingAttr = D->getAttr<WorkGroupAttr>()) {
-    Optional<llvm::APSInt> XDimVal =
-        XDimExpr->getIntegerConstantExpr(S.getASTContext());
-    Optional<llvm::APSInt> YDimVal =
-        YDimExpr->getIntegerConstantExpr(S.getASTContext());
-    Optional<llvm::APSInt> ZDimVal =
-        ZDimExpr->getIntegerConstantExpr(S.getASTContext());
-    Optional<llvm::APSInt> ExistingXDimVal =
-        ExistingAttr->getXDim()->getIntegerConstantExpr(S.getASTContext());
-    Optional<llvm::APSInt> ExistingYDimVal =
-        ExistingAttr->getYDim()->getIntegerConstantExpr(S.getASTContext());
-    Optional<llvm::APSInt> ExistingZDimVal =
-        ExistingAttr->getZDim()->getIntegerConstantExpr(S.getASTContext());
+    ASTContext &Ctx = S.getASTContext();
+    Optional<llvm::APSInt> XDimVal = XDimExpr->getIntegerConstantExpr(Ctx);
+    Optional<llvm::APSInt> YDimVal = YDimExpr->getIntegerConstantExpr(Ctx);
+    Optional<llvm::APSInt> ZDimVal = ZDimExpr->getIntegerConstantExpr(Ctx);
+    Optional<llvm::APSInt> ExistingXDimVal = ExistingAttr->getXDimVal(Ctx);
+    Optional<llvm::APSInt> ExistingYDimVal = ExistingAttr->getYDimVal(Ctx);
+    Optional<llvm::APSInt> ExistingZDimVal = ExistingAttr->getZDimVal(Ctx);
 
     // Compare attribute arguments value and warn for a mismatch.
-    if (!((ExistingXDimVal->getZExtValue() == XDimVal->getZExtValue()) &&
-          (ExistingYDimVal->getZExtValue() == YDimVal->getZExtValue()) &&
-          (ExistingZDimVal->getZExtValue() == ZDimVal->getZExtValue()))) {
+    if (ExistingXDimVal != XDimVal || ExistingYDimVal != YDimVal ||
+        ExistingZDimVal != ZDimVal) {
       S.Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL;
       S.Diag(ExistingAttr->getLocation(), diag::note_conflicting_attribute);
     }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3302,32 +3302,28 @@ void Sema::MarkDevice(void) {
           break;
         }
         case attr::Kind::ReqdWorkGroupSize: {
-          auto *Attr = cast<ReqdWorkGroupSizeAttr>(A);
+          auto *RWGSA = cast<ReqdWorkGroupSizeAttr>(A);
           if (auto *Existing = SYCLKernel->getAttr<ReqdWorkGroupSizeAttr>()) {
-            if ((getIntExprValue(Existing->getXDim(), getASTContext()) !=
-                 getIntExprValue(Attr->getXDim(), getASTContext())) ||
-                (getIntExprValue(Existing->getYDim(), getASTContext()) !=
-                 getIntExprValue(Attr->getYDim(), getASTContext())) ||
-                (getIntExprValue(Existing->getZDim(), getASTContext()) !=
-                 getIntExprValue(Attr->getZDim(), getASTContext()))) {
+            ASTContext &Ctx = getASTContext();
+            if (Existing->getXDimVal(Ctx) != RWGSA->getXDimVal(Ctx) ||
+                Existing->getYDimVal(Ctx) != RWGSA->getYDimVal(Ctx) ||
+                Existing->getZDimVal(Ctx) != RWGSA->getZDimVal(Ctx)) {
               Diag(SYCLKernel->getLocation(),
                    diag::err_conflicting_sycl_kernel_attributes);
               Diag(Existing->getLocation(), diag::note_conflicting_attribute);
-              Diag(Attr->getLocation(), diag::note_conflicting_attribute);
+              Diag(RWGSA->getLocation(), diag::note_conflicting_attribute);
               SYCLKernel->setInvalidDecl();
             }
           } else if (auto *Existing =
                          SYCLKernel->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
-            if ((getIntExprValue(Existing->getXDim(), getASTContext()) <
-                 getIntExprValue(Attr->getXDim(), getASTContext())) ||
-                (getIntExprValue(Existing->getYDim(), getASTContext()) <
-                 getIntExprValue(Attr->getYDim(), getASTContext())) ||
-                (getIntExprValue(Existing->getZDim(), getASTContext()) <
-                 getIntExprValue(Attr->getZDim(), getASTContext()))) {
+            ASTContext &Ctx = getASTContext();
+            if (Existing->getXDimVal(Ctx) < RWGSA->getXDimVal(Ctx) ||
+                Existing->getYDimVal(Ctx) < RWGSA->getYDimVal(Ctx) ||
+                Existing->getZDimVal(Ctx) < RWGSA->getZDimVal(Ctx)) {
               Diag(SYCLKernel->getLocation(),
                    diag::err_conflicting_sycl_kernel_attributes);
               Diag(Existing->getLocation(), diag::note_conflicting_attribute);
-              Diag(Attr->getLocation(), diag::note_conflicting_attribute);
+              Diag(RWGSA->getLocation(), diag::note_conflicting_attribute);
               SYCLKernel->setInvalidDecl();
             } else {
               SYCLKernel->addAttr(A);
@@ -3338,18 +3334,16 @@ void Sema::MarkDevice(void) {
           break;
         }
         case attr::Kind::SYCLIntelMaxWorkGroupSize: {
-          auto *Attr = cast<SYCLIntelMaxWorkGroupSizeAttr>(A);
+          auto *SIMWGSA = cast<SYCLIntelMaxWorkGroupSizeAttr>(A);
           if (auto *Existing = SYCLKernel->getAttr<ReqdWorkGroupSizeAttr>()) {
-            if ((getIntExprValue(Existing->getXDim(), getASTContext()) >
-                 getIntExprValue(Attr->getXDim(), getASTContext())) ||
-                (getIntExprValue(Existing->getYDim(), getASTContext()) >
-                 getIntExprValue(Attr->getYDim(), getASTContext())) ||
-                (getIntExprValue(Existing->getZDim(), getASTContext()) >
-                 getIntExprValue(Attr->getZDim(), getASTContext()))) {
+            ASTContext &Ctx = getASTContext();
+            if (Existing->getXDimVal(Ctx) > SIMWGSA->getXDimVal(Ctx) ||
+                Existing->getYDimVal(Ctx) > SIMWGSA->getYDimVal(Ctx) ||
+                Existing->getZDimVal(Ctx) > SIMWGSA->getZDimVal(Ctx)) {
               Diag(SYCLKernel->getLocation(),
                    diag::err_conflicting_sycl_kernel_attributes);
               Diag(Existing->getLocation(), diag::note_conflicting_attribute);
-              Diag(Attr->getLocation(), diag::note_conflicting_attribute);
+              Diag(SIMWGSA->getLocation(), diag::note_conflicting_attribute);
               SYCLKernel->setInvalidDecl();
             } else {
               SYCLKernel->addAttr(A);


### PR DESCRIPTION
SingleWorkItemBarrierCheck.cpp from upstream does not work with our
recent changes in ca9d816234c6a0a73d300085e90dd3d2d5e5ccef. This
addresses the issue by adding some helper methods to the work group
size attributes and using them where appropriate.