### PR TITLE
[NFC] Remove redundant call to getMainExecutable()

### DIFF
--- a/clang/tools/clang-offload-deps/ClangOffloadDeps.cpp
+++ b/clang/tools/clang-offload-deps/ClangOffloadDeps.cpp
@@ -73,7 +73,7 @@ static void reportError(Error E) {
 
 int main(int argc, const char **argv) {
   sys::PrintStackTraceOnErrorSignal(argv[0]);
-  ToolPath = sys::fs::getMainExecutable(argv[0], &ToolPath);
+  ToolPath = argv[0];
 
   cl::HideUnrelatedOptions(ClangOffloadDepsCategory);
   cl::SetVersionPrinter([](raw_ostream &OS) {


### PR DESCRIPTION
The call to getMainExecutable() function can be eliminated because the
path returned by that call is used only for error reporting, so the tool
can use argv[0] for this purpose as is without any additional processing.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>