### PR TITLE
[SYCL] Clean up the builder_dir argument description

### DIFF
--- a/buildbot/check.py
+++ b/buildbot/check.py
@@ -49,7 +49,7 @@ def main():
     parser.add_argument("-d", "--base-branch", metavar="BASE_BRANCH", help="pull request base branch")
     parser.add_argument("-r", "--pr-number", metavar="PR_NUM", help="pull request number")
     parser.add_argument("-w", "--builder-dir", metavar="BUILDER_DIR",
-                        help="builder directory, which is the directory contains source and build directories")
+                        help="builder directory, which is the directory containing source and build directories")
     parser.add_argument("-s", "--src-dir", metavar="SRC_DIR", help="source directory")
     parser.add_argument("-o", "--obj-dir", metavar="OBJ_DIR", help="build directory")
     parser.add_argument("-t", "--test-suite", metavar="TEST_SUITE", default="check-all", help="check-xxx target")

--- a/buildbot/clang_tidy.py
+++ b/buildbot/clang_tidy.py
@@ -51,7 +51,7 @@ def main():
                         help="pull request base branch")
     parser.add_argument("-r", "--pr-number", metavar="PR_NUM", help="pull request number")
     parser.add_argument("-w", "--builder-dir", metavar="BUILDER_DIR", required=True,
-                        help="builder directory, which is the directory contains source and build directories")
+                        help="builder directory, which is the directory containing source and build directories")
     parser.add_argument("-s", "--src-dir", metavar="SRC_DIR", required=True, help="source directory")
     parser.add_argument("-o", "--obj-dir", metavar="OBJ_DIR", required=True, help="build directory")
 

--- a/buildbot/compile.py
+++ b/buildbot/compile.py
@@ -51,7 +51,7 @@ def main():
     parser.add_argument("-d", "--base-branch", metavar="BASE_BRANCH", help="pull request base branch")
     parser.add_argument("-r", "--pr-number", metavar="PR_NUM", help="pull request number")
     parser.add_argument("-w", "--builder-dir", metavar="BUILDER_DIR",
-                        help="builder directory, which is the directory contains source and build directories")
+                        help="builder directory, which is the directory containing source and build directories")
     parser.add_argument("-s", "--src-dir", metavar="SRC_DIR", help="source directory")
     parser.add_argument("-o", "--obj-dir", metavar="OBJ_DIR", help="build directory")
     parser.add_argument("-j", "--build-parallelism", metavar="BUILD_PARALLELISM", help="build parallelism")

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -123,7 +123,7 @@ def main():
     parser.add_argument("-d", "--base-branch", metavar="BASE_BRANCH", help="pull request base branch")
     parser.add_argument("-r", "--pr-number", metavar="PR_NUM", help="pull request number")
     parser.add_argument("-w", "--builder-dir", metavar="BUILDER_DIR",
-                        help="builder directory, which is the directory contains source and build directories")
+                        help="builder directory, which is the directory containing source and build directories")
     # User options
     parser.add_argument("-s", "--src-dir", metavar="SRC_DIR", help="source directory (autodetected by default)")
     parser.add_argument("-o", "--obj-dir", metavar="OBJ_DIR", help="build directory. (<src>/build by default)")

--- a/buildbot/dependency.py
+++ b/buildbot/dependency.py
@@ -97,7 +97,7 @@ def main():
     parser.add_argument("-d", "--base-branch", metavar="BASE_BRANCH", help="pull request base branch")
     parser.add_argument("-r", "--pr-number", metavar="PR_NUM", help="pull request number")
     parser.add_argument("-w", "--builder-dir", metavar="BUILDER_DIR",
-                        help="builder directory, which is the directory contains source and build directories")
+                        help="builder directory, which is the directory containing source and build directories")
     parser.add_argument("-s", "--src-dir", metavar="SRC_DIR", help="source directory")
     parser.add_argument("-o", "--obj-dir", metavar="OBJ_DIR", required=True, help="build directory")
     parser.add_argument("-c", "--clean-build", action="store_true", default=False,


### PR DESCRIPTION
Correct the description in the clang-tidy script where the argument
is actually used, remove the parameter from the rest of the scripts.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>