### PR TITLE
[SYCL][NFC] Fix warning in self-build

### DIFF
--- a/sycl/source/detail/plugin_printers.hpp
+++ b/sycl/source/detail/plugin_printers.hpp
@@ -18,7 +18,8 @@ namespace detail {
 namespace pi {
 
 template <typename T> inline void print(T val) {
-  std::cout << "<unknown> : " << val << std::endl;
+  std::cout << "<unknown> : " << reinterpret_cast<const void *>(val)
+            << std::endl;
 }
 
 template <> inline void print<>(PiPlatform val) {

--- a/sycl/source/detail/plugin_printers.hpp
+++ b/sycl/source/detail/plugin_printers.hpp
@@ -12,12 +12,22 @@
 
 #include <CL/sycl/detail/pi.hpp>
 
+#include <type_traits>
+
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 namespace pi {
 
-template <typename T> inline void print(T val) {
+template <typename T>
+inline typename std::enable_if<!std::is_pointer<T>::value, void>::type
+print(T val) {
+  std::cout << "<unknown> : " << val << std::endl;
+}
+
+template <typename T>
+inline typename std::enable_if<std::is_pointer<T>::value, void>::type
+print(T val) {
   std::cout << "<unknown> : " << reinterpret_cast<const void *>(val)
             << std::endl;
 }


### PR DESCRIPTION
Implicit conversion between pointer-to-function and pointer-to-object is a Microsoft extension.