### PR TITLE
[SYCL] Fix plugin deinit order

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -98,7 +98,7 @@ std::vector<plugin> &GlobalHandler::getPlugins() {
 
   const std::lock_guard<SpinLock> Lock{MFieldsLock};
   if (!MPlugins)
-    MPlugins = std::make_shared<std::vector<plugin>>();
+    MPlugins = std::make_unique<std::vector<plugin>>();
 
   return *MPlugins;
 }

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -114,7 +114,9 @@ GlobalHandler::getDeviceFilterList(const std::string &InitValue) {
   return *MDeviceFilterList;
 }
 
-std::shared_ptr<std::vector<plugin>> GlobalHandler::acquirePlugins() { return MPlugins; }
+std::shared_ptr<std::vector<plugin>> GlobalHandler::acquirePlugins() {
+  return MPlugins;
+}
 
 void shutdown() {
   auto plugins = GlobalHandler::instance().acquirePlugins();
@@ -122,14 +124,14 @@ void shutdown() {
   delete &GlobalHandler::instance();
 
   if (plugins)
-  for (plugin &Plugin : *plugins) {
-    // PluginParameter is reserved for future use that can control
-    // some parameters in the plugin tear-down process.
-    // Currently, it is not used.
-    void *PluginParameter = nullptr;
-    Plugin.call_nocheck<PiApiKind::piTearDown>(PluginParameter);
-    Plugin.unload();
-  }
+    for (plugin &Plugin : *plugins) {
+      // PluginParameter is reserved for future use that can control
+      // some parameters in the plugin tear-down process.
+      // Currently, it is not used.
+      void *PluginParameter = nullptr;
+      Plugin.call_nocheck<PiApiKind::piTearDown>(PluginParameter);
+      Plugin.unload();
+    }
 }
 
 #ifdef _WIN32

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -60,8 +60,6 @@ public:
 private:
   friend void shutdown();
 
-  std::shared_ptr<std::vector<plugin>> acquirePlugins();
-
   // Constructor and destructor are declared out-of-line to allow incomplete
   // types as template arguments to unique_ptr.
   GlobalHandler();
@@ -69,13 +67,14 @@ private:
 
   SpinLock MFieldsLock;
 
+  // Do not forget to update shutdown() function if needed.
   std::unique_ptr<Scheduler> MScheduler;
   std::unique_ptr<ProgramManager> MProgramManager;
   std::unique_ptr<Sync> MSync;
   std::unique_ptr<std::vector<PlatformImplPtr>> MPlatformCache;
   std::unique_ptr<std::mutex> MPlatformMapMutex;
   std::unique_ptr<std::mutex> MFilterMutex;
-  std::shared_ptr<std::vector<plugin>> MPlugins;
+  std::unique_ptr<std::vector<plugin>> MPlugins;
   std::unique_ptr<device_filter_list> MDeviceFilterList;
 };
 } // namespace detail

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -59,6 +59,9 @@ public:
 
 private:
   friend void shutdown();
+
+  std::shared_ptr<std::vector<plugin>> acquirePlugins();
+
   // Constructor and destructor are declared out-of-line to allow incomplete
   // types as template arguments to unique_ptr.
   GlobalHandler();
@@ -72,7 +75,7 @@ private:
   std::unique_ptr<std::vector<PlatformImplPtr>> MPlatformCache;
   std::unique_ptr<std::mutex> MPlatformMapMutex;
   std::unique_ptr<std::mutex> MFilterMutex;
-  std::unique_ptr<std::vector<plugin>> MPlugins;
+  std::shared_ptr<std::vector<plugin>> MPlugins;
   std::unique_ptr<device_filter_list> MDeviceFilterList;
 };
 } // namespace detail


### PR DESCRIPTION
Scheduler may hold references to active queues, which upon destruction
may call PI APIs. To avoid potential clashes, acquire a reference on plugins
and only perform tear down after scheduler is gone.