### PR TITLE
[SYCL][Driver] Provide a CLI option for atomic float emulation

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4168,6 +4168,7 @@ def fsycl_esimd : Flag<["-"], "fsycl-explicit-simd">, Group<sycl_Group>, Flags<[
 def fno_sycl_esimd : Flag<["-"], "fno-sycl-explicit-simd">, Group<sycl_Group>,
   HelpText<"Disable SYCL explicit SIMD extension">, Flags<[NoArgumentUnused, CoreOption]>;
 defm sycl_early_optimizations : OptOutFFlag<"sycl-early-optimizations", "Enable", "Disable", " standard optimization pipeline for SYCL device compiler", [CoreOption]>;
+defm sycl_emulate_float_atomics : OptOutFFlag<"sycl-emulate-float-atomics", "Enable", "Disable", " lockspin emulation for FP-typed SYCL atomic functions", [CoreOption]>;
 def fsycl_dead_args_optimization : Flag<["-"], "fsycl-dead-args-optimization">,
   Group<sycl_Group>, Flags<[NoArgumentUnused, CoreOption]>, HelpText<"Enables "
   "elimination of DPC++ dead kernel arguments">;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4252,6 +4252,16 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-sycl-opt");
     }
+
+    // If SYCL float atomics' emulation is requested, define the needed macro
+    // that will be recognized by DPC++ headers.
+    // TODO: Once all targets support SPIR-V resulting from "native"
+    // implementation, the macro support will be dropped - at that moment, drop
+    // this option's support as well.
+    if (Args.hasFlag(options::OPT_fsycl_emulate_float_atomics,
+                     options::OPT_fno_sycl_emulate_float_atomics, false))
+      CmdArgs.push_back("-D__SYCL_EMULATE_FLOAT_ATOMICS__=1");
+
     // Turn on Dead Parameter Elimination Optimization with early optimizations
     if (!RawTriple.isNVPTX() &&
         Args.hasFlag(options::OPT_fsycl_dead_args_optimization,

--- a/clang/test/Driver/sycl-float-atomics.cpp
+++ b/clang/test/Driver/sycl-float-atomics.cpp
@@ -1,0 +1,21 @@
+/// Check that float atomics are NOT "emulated" by default:
+// RUN:   %clang -### -fsycl %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang_cl -### -fsycl %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang -### -fsycl -fsycl-device-only %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang_cl -### -fsycl -fsycl-device-only %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// CHECK-DEFAULT-NOT: "-D__SYCL_EMULATE_FLOAT_ATOMICS__"
+
+/// Check that "-fsycl-emulate-float-atomics" passes the macro to the device FE:
+// RUN:   %clang -### -fsycl -fsycl-emulate-float-atomics %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-SYCL-EMULATE-ATOMICS %s
+// RUN:   %clang_cl -### -fsycl -fsycl-emulate-float-atomics %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-SYCL-EMULATE-ATOMICS %s
+// RUN:   %clang -### -fsycl -fsycl-device-only -fsycl-emulate-float-atomics %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-SYCL-EMULATE-ATOMICS %s
+// RUN:   %clang_cl -### -fsycl -fsycl-device-only -fsycl-emulate-float-atomics %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-SYCL-EMULATE-ATOMICS %s
+// CHECK-SYCL-EMULATE-ATOMICS: clang{{.*}} "-fsycl-is-device"{{.*}} "-D__SYCL_EMULATE_FLOAT_ATOMICS__=1"


### PR DESCRIPTION
Since the functionality is temporary, it is implemented via directly
passing a macro that is detected by SYCL headers without a "proper"
intermediate step of a similar Clang FE option.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>