### PR TITLE
[NFC] Fix sycl-post-link tests to avoid potential race

### DIFF
--- a/llvm/test/tools/sycl-post-link/erase_used.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used.ll
@@ -1,9 +1,9 @@
 ; This test checks that the post-link tool does not add "llvm.used" global to
 ; the output modules when splitting kernels.
 ;
-; RUN: sycl-post-link -split=kernel -S %s -o %T/files.table
-; RUN: FileCheck %s -input-file=%T/files_0.ll
-; RUN: FileCheck %s -input-file=%T/files_1.ll
+; RUN: sycl-post-link -split=kernel -S %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.ll
+; RUN: FileCheck %s -input-file=%t.files_1.ll
 
 target triple = "spir64-unknown-unknown-sycldevice"
 

--- a/llvm/test/tools/sycl-post-link/one-kernel-per-module.ll
+++ b/llvm/test/tools/sycl-post-link/one-kernel-per-module.ll
@@ -1,10 +1,10 @@
-; RUN: sycl-post-link -split=kernel -symbols -S %s -o %T/files.table
-; RUN: FileCheck %s -input-file=%T/files_0.ll --check-prefixes CHECK-MODULE0,CHECK
-; RUN: FileCheck %s -input-file=%T/files_1.ll --check-prefixes CHECK-MODULE1,CHECK
-; RUN: FileCheck %s -input-file=%T/files_2.ll --check-prefixes CHECK-MODULE2,CHECK
-; RUN: FileCheck %s -input-file=%T/files_0.sym --check-prefixes CHECK-MODULE0-TXT
-; RUN: FileCheck %s -input-file=%T/files_1.sym --check-prefixes CHECK-MODULE1-TXT
-; RUN: FileCheck %s -input-file=%T/files_2.sym --check-prefixes CHECK-MODULE2-TXT
+; RUN: sycl-post-link -split=kernel -symbols -S %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefixes CHECK-MODULE0,CHECK
+; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefixes CHECK-MODULE1,CHECK
+; RUN: FileCheck %s -input-file=%t.files_2.ll --check-prefixes CHECK-MODULE2,CHECK
+; RUN: FileCheck %s -input-file=%t.files_0.sym --check-prefixes CHECK-MODULE0-TXT
+; RUN: FileCheck %s -input-file=%t.files_1.sym --check-prefixes CHECK-MODULE1-TXT
+; RUN: FileCheck %s -input-file=%t.files_2.sym --check-prefixes CHECK-MODULE2-TXT
 ; ModuleID = 'one-kernel-per-module.ll'
 source_filename = "one-kernel-per-module.ll"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"


### PR DESCRIPTION
Change test to not use %T which may cause race conditions with other
tests from the same directory.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>