### PR TITLE
[SYCL][NFC] Revise Cmake config for LIT

### DIFF
--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -55,7 +55,8 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
     COMPONENT level-zero-loader
   )
 
-  set(LEVEL_ZERO_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/level_zero_loader_install/include/)
+  set(LEVEL_ZERO_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/level_zero_loader_install/include/
+	  CACHE INTERNAL "Path containing Level_Zero header files.")
 else()
   file(GLOB LEVEL_ZERO_LIBRARY_SRC "${LEVEL_ZERO_LIBRARY}*")
   get_filename_component(LEVEL_ZERO_LIB_NAME ${LEVEL_ZERO_LIBRARY} NAME)

--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -51,18 +51,6 @@ add_lit_testsuite(check-sycl-deploy "Running the SYCL regression tests"
   )
 set_target_properties(check-sycl-deploy PROPERTIES FOLDER "SYCL tests")
 
-add_lit_testsuites(SYCL ${CMAKE_CURRENT_SOURCE_DIR}
-  DEPENDS ${SYCL_TEST_DEPS}
-  EXCLUDE_FROM_CHECK_ALL
-  )
-
-add_lit_testsuites(SYCL-DEPLOY ${CMAKE_CURRENT_SOURCE_DIR}
-  ARGS ${DEPLOY_RT_TEST_ARGS}
-  PARAMS "SYCL_PLUGIN=opencl"
-  DEPENDS ${SYCL_DEPLOY_TEST_DEPS}
-  EXCLUDE_FROM_CHECK_ALL
-  )
-
 add_lit_testsuite(check-sycl-spirv "Running device-agnostic SYCL regression tests for SPIR-V"
   ${CMAKE_CURRENT_BINARY_DIR}
   ARGS ${RT_TEST_ARGS}

--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -21,13 +21,6 @@ configure_lit_site_cfg(
   )
 
 configure_lit_site_cfg(
-  ${CMAKE_CURRENT_SOURCE_DIR}/on-device/lit.site.cfg.py.in
-  ${CMAKE_CURRENT_BINARY_DIR}/on-device/lit.site.cfg.py
-  MAIN_CONFIG
-  ${CMAKE_CURRENT_SOURCE_DIR}/on-device/lit.cfg.py
-  )
-
-configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg.py
   MAIN_CONFIG
@@ -70,23 +63,6 @@ add_lit_testsuites(SYCL-DEPLOY ${CMAKE_CURRENT_SOURCE_DIR}
   EXCLUDE_FROM_CHECK_ALL
   )
 
-add_lit_testsuite(check-sycl-opencl "Running the SYCL regression tests for OpenCL"
-  ${CMAKE_CURRENT_BINARY_DIR}/on-device
-  ARGS ${RT_TEST_ARGS}
-  PARAMS "SYCL_PLUGIN=opencl"
-  DEPENDS ${SYCL_TEST_DEPS}
-  EXCLUDE_FROM_CHECK_ALL
-  )
-set_target_properties(check-sycl-opencl PROPERTIES FOLDER "SYCL tests")
-
-add_lit_testsuite(check-sycl-level-zero "Running the SYCL regression tests for Level Zero"
-  ${CMAKE_CURRENT_BINARY_DIR}/on-device
-  ARGS ${RT_TEST_ARGS}
-  PARAMS "SYCL_PLUGIN=level_zero"
-  DEPENDS ${SYCL_TEST_DEPS}
-  EXCLUDE_FROM_CHECK_ALL
-  )
-
 add_lit_testsuite(check-sycl-spirv "Running device-agnostic SYCL regression tests for SPIR-V"
   ${CMAKE_CURRENT_BINARY_DIR}
   ARGS ${RT_TEST_ARGS}
@@ -94,22 +70,12 @@ add_lit_testsuite(check-sycl-spirv "Running device-agnostic SYCL regression test
   DEPENDS ${SYCL_TEST_DEPS}
   EXCLUDE_FROM_CHECK_ALL
   )
-set_target_properties(check-sycl-level-zero PROPERTIES FOLDER "SYCL tests")
 
 add_custom_target(check-sycl)
-add_dependencies(check-sycl check-sycl-opencl check-sycl-level-zero check-sycl-spirv)
+add_dependencies(check-sycl check-sycl-spirv)
 set_target_properties(check-sycl PROPERTIES FOLDER "SYCL tests")
 
 if(SYCL_BUILD_PI_CUDA)
-  add_lit_testsuite(check-sycl-cuda "Running the SYCL regression tests for CUDA"
-    ${CMAKE_CURRENT_BINARY_DIR}/on-device
-    ARGS ${RT_TEST_ARGS}
-    PARAMS "SYCL_PLUGIN=cuda"
-    DEPENDS ${SYCL_TEST_DEPS}
-    EXCLUDE_FROM_CHECK_ALL
-  )
-  set_target_properties(check-sycl-cuda PROPERTIES FOLDER "SYCL CUDA tests")
-
   add_lit_testsuite(check-sycl-ptx "Running device-agnostic SYCL regression tests for NVidia PTX"
     ${CMAKE_CURRENT_BINARY_DIR}
     ARGS ${RT_TEST_ARGS}
@@ -118,13 +84,9 @@ if(SYCL_BUILD_PI_CUDA)
     EXCLUDE_FROM_CHECK_ALL
   )
 
+  add_custom_target(check-sycl-cuda)
   add_dependencies(check-sycl-cuda check-sycl-ptx)
-
   add_dependencies(check-sycl check-sycl-cuda)
 
-  add_lit_testsuites(SYCL-CUDA ${CMAKE_CURRENT_SOURCE_DIR}/on-device
-    PARAMS "SYCL_PLUGIN=cuda"
-    DEPENDS ${SYCL_TEST_DEPS}
-    EXCLUDE_FROM_CHECK_ALL
-  )
 endif()
+add_subdirectory(on-device)

--- a/sycl/test/on-device/CMakeLists.txt
+++ b/sycl/test/on-device/CMakeLists.txt
@@ -1,0 +1,42 @@
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+  )
+
+add_lit_testsuite(check-sycl-opencl "Running the SYCL regression tests for OpenCL"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ARGS ${RT_TEST_ARGS}
+  PARAMS "SYCL_PLUGIN=opencl"
+  DEPENDS ${SYCL_TEST_DEPS}
+  EXCLUDE_FROM_CHECK_ALL
+  )
+set_target_properties(check-sycl-opencl PROPERTIES FOLDER "SYCL OpenCL device tests")
+
+add_lit_testsuite(check-sycl-level-zero "Running the SYCL regression tests for Level Zero"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ARGS ${RT_TEST_ARGS}
+  PARAMS "SYCL_PLUGIN=level_zero"
+  DEPENDS ${SYCL_TEST_DEPS}
+  EXCLUDE_FROM_CHECK_ALL
+  )
+set_target_properties(check-sycl-level-zero PROPERTIES FOLDER "SYCL Level_Zero device tests")
+
+if( TARGET check-sycl)
+  add_dependencies(check-sycl check-sycl-opencl check-sycl-level-zero)
+endif()
+
+if(SYCL_BUILD_PI_CUDA)
+  add_lit_testsuite(check-sycl-cuda-on-device "Running the SYCL regression tests for CUDA"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ARGS ${RT_TEST_ARGS}
+    PARAMS "SYCL_PLUGIN=cuda"
+    DEPENDS ${SYCL_TEST_DEPS}
+    EXCLUDE_FROM_CHECK_ALL
+  )
+  set_target_properties(check-sycl-cuda-on-device PROPERTIES FOLDER "SYCL CUDA device tests")
+  if(TARGET check-sycl-cuda)
+    add_dependencies(check-sycl-cuda check-sycl-cuda-on-device)
+  endif()
+endif()

--- a/sycl/test/on-device/README.md
+++ b/sycl/test/on-device/README.md
@@ -28,8 +28,9 @@ cd build
 
 # set extra environment
 export EXTCMPLRROOT=# path to deployed SYCL compiler and runtime
-export GET_DEVICE_TOOL=# Path to get full path to utility detecting available devices ([source](../../tools/get_device_count_by_type.cpp))
-
+export GET_DEVICE_TOOL=# Path to the get_device_count_by_type tool
+# The get_device_count_by_type tool should be built from sources [under](../../tools/get_device_count_by_type.cpp)
+export LEVEL_ZERO_INCLUDE_DIR=# Path to Level_Zero headers (optional)
 
 # Configure project
 cmake -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_EXTERNAL_PROJECTS=sycl-test \
@@ -38,32 +39,32 @@ cmake -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_EXTERNAL_PROJECTS=sycl-test \
       $ROOT/llvm
 
 # Build LIT tools
-make FileCheck not llvm-config
+make FileCheck
 
 # Run tests for OpenCL BE
-/usr/bin/python3.6 $ROOT/llvm/utils/lit/lit.py -v \
-                        --param SYCL_PLUGIN=opencl \
+python3 $ROOT/llvm/utils/lit/lit.py -v --param SYCL_PLUGIN=opencl \
                         --param SYCL_TOOLS_DIR="$EXTCMPLRROOT/bin" \
                         --param SYCL_INCLUDE="$EXTCMPLRROOT/include/sycl" \
                         --param SYCL_LIBS_DIR="$EXTCMPLRROOT/lib" \
                         --param GET_DEVICE_TOOL=$GET_DEVICE_TOOL \
+                        --param LEVEL_ZERO_INCLUDE_DIR=$L0_HEADER_PATH \
                         tools/sycl-test/
 
 # Run tests for Level_Zero BE
-/usr/bin/python3.6 $ROOT/llvm/utils/lit/lit.py -v \
-                        --param SYCL_PLUGIN=level_zero \
+python3 $ROOT/llvm/utils/lit/lit.py -v --param SYCL_PLUGIN=level_zero \
                         --param SYCL_TOOLS_DIR="$EXTCMPLRROOT/bin" \
                         --param SYCL_INCLUDE="$EXTCMPLRROOT/include/sycl" \
                         --param SYCL_LIBS_DIR="$EXTCMPLRROOT/lib" \
                         --param GET_DEVICE_TOOL=$GET_DEVICE_TOOL \
+                        --param LEVEL_ZERO_INCLUDE_DIR=$L0_HEADER_PATH \
                         tools/sycl-test/
 
 # Run tests for CUDA BE (if compiler build supports it)
-/usr/bin/python3.6 $ROOT/llvm/utils/lit/lit.py -v \
-                        --param SYCL_PLUGIN=cuda \
+python3 $ROOT/llvm/utils/lit/lit.py -v --param SYCL_PLUGIN=cuda \
                         --param SYCL_TOOLS_DIR="$EXTCMPLRROOT/bin" \
                         --param SYCL_INCLUDE="$EXTCMPLRROOT/include/sycl" \
                         --param SYCL_LIBS_DIR="$EXTCMPLRROOT/lib" \
                         --param GET_DEVICE_TOOL=$GET_DEVICE_TOOL \
+                        --param LEVEL_ZERO_INCLUDE_DIR=$L0_HEADER_PATH \
                         tools/sycl-test
 ```

--- a/sycl/test/on-device/README.md
+++ b/sycl/test/on-device/README.md
@@ -11,3 +11,59 @@ It is developer responsibility to move the tests from this directory to
 [DPC++ E2E test suite](https://github.com/intel/llvm-test-suite/tree/intel/SYCL)
 or [KhronosGroup/SYCL-CTS](https://github.com/KhronosGroup/SYCL-CTS) once the
 feature is stabilized.
+
+# Running tests on deployed DPC++ compiler and runtime
+The tests in this directory can be run on deployed DPC++ compiler and runtime.
+It is expected that get_device_count_by_type tool is prebuilt by the developer
+and tools with full path os provided as value for GET_DEVICE_TOOL LIT
+parameter. 
+
+```bash
+# clone llvm_project repo
+git clone https://github.com/intel/llvm sycl_lit
+cd sycl_lit
+export ROOT=`pwd`
+mkdir build
+cd build
+
+# set extra environment
+export EXTCMPLRROOT=# path to deployed SYCL compiler and runtime
+export GET_DEVICE_TOOL=# Path to get full path to utility detecting available devices ([source](../../tools/get_device_count_by_type.cpp))
+
+
+# Configure project
+cmake -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_EXTERNAL_PROJECTS=sycl-test \
+      -DLLVM_EXTERNAL_SYCL_TEST_SOURCE_DIR=$ROOT/sycl/test/on-device \
+      -DSYCL_SOURCE_DIR=$ROOT/sycl -DOpenCL_LIBRARIES=$EXTCMPLRROOT/lib \
+      $ROOT/llvm
+
+# Build LIT tools
+make FileCheck not llvm-config
+
+# Run tests for OpenCL BE
+/usr/bin/python3.6 $ROOT/llvm/utils/lit/lit.py -v \
+                        --param SYCL_PLUGIN=opencl \
+                        --param SYCL_TOOLS_DIR="$EXTCMPLRROOT/bin" \
+                        --param SYCL_INCLUDE="$EXTCMPLRROOT/include/sycl" \
+                        --param SYCL_LIBS_DIR="$EXTCMPLRROOT/lib" \
+                        --param GET_DEVICE_TOOL=$GET_DEVICE_TOOL \
+                        tools/sycl-test/
+
+# Run tests for Level_Zero BE
+/usr/bin/python3.6 $ROOT/llvm/utils/lit/lit.py -v \
+                        --param SYCL_PLUGIN=level_zero \
+                        --param SYCL_TOOLS_DIR="$EXTCMPLRROOT/bin" \
+                        --param SYCL_INCLUDE="$EXTCMPLRROOT/include/sycl" \
+                        --param SYCL_LIBS_DIR="$EXTCMPLRROOT/lib" \
+                        --param GET_DEVICE_TOOL=$GET_DEVICE_TOOL \
+                        tools/sycl-test/
+
+# Run tests for CUDA BE (if compiler build supports it)
+/usr/bin/python3.6 $ROOT/llvm/utils/lit/lit.py -v \
+                        --param SYCL_PLUGIN=cuda \
+                        --param SYCL_TOOLS_DIR="$EXTCMPLRROOT/bin" \
+                        --param SYCL_INCLUDE="$EXTCMPLRROOT/include/sycl" \
+                        --param SYCL_LIBS_DIR="$EXTCMPLRROOT/lib" \
+                        --param GET_DEVICE_TOOL=$GET_DEVICE_TOOL \
+                        tools/sycl-test
+```

--- a/sycl/test/on-device/lit.cfg.py
+++ b/sycl/test/on-device/lit.cfg.py
@@ -66,10 +66,17 @@ config.substitutions.append( ('%sycl_include',  config.sycl_include ) )
 config.substitutions.append( ('%sycl_source_dir', config.sycl_source_dir) )
 config.substitutions.append( ('%opencl_libs_dir',  config.opencl_libs_dir) )
 config.substitutions.append( ('%opencl_include_dir',  config.opencl_include_dir) )
+config.substitutions.append( ('%level_zero_include_dir',  config.level_zero_include_dir) )
 config.substitutions.append( ('%cuda_toolkit_include',  config.cuda_toolkit_include) )
 config.substitutions.append( ('%sycl_tools_src_dir',  config.sycl_tools_src_dir ) )
 config.substitutions.append( ('%llvm_build_lib_dir',  config.llvm_build_lib_dir ) )
 config.substitutions.append( ('%llvm_build_bin_dir',  config.llvm_build_bin_dir ) )
+
+if config.level_zero_include_dir:
+    config.available_features.add("level_zero_headers")
+else:
+    lit_config.warning("Level_Zero headers path is not configured. Dependent tests are skipped.")
+
 
 llvm_config.use_clang()
 
@@ -82,6 +89,8 @@ config.substitutions.append( ('%BE_RUN_PLACEHOLDER', "env SYCL_DEVICE_FILTER={SY
 config.substitutions.append( ('%RUN_ON_HOST', "env SYCL_DEVICE_FILTER=host ") )
 
 get_device_count_by_type_path = lit_config.params.get('GET_DEVICE_TOOL', os.path.join(config.llvm_tools_dir, "get_device_count_by_type"))
+if 'GET_DEVICE_TOOL' in lit_config.params.keys():
+    lit_config.warning("The tool from none-default path is used: "+get_device_count_by_type_path)
 
 def getDeviceCount(device_type):
     is_cuda = False;

--- a/sycl/test/on-device/lit.cfg.py
+++ b/sycl/test/on-device/lit.cfg.py
@@ -81,7 +81,7 @@ config.substitutions.append( ('%sycl_be', { 'opencl': 'PI_OPENCL',  'cuda': 'PI_
 config.substitutions.append( ('%BE_RUN_PLACEHOLDER', "env SYCL_DEVICE_FILTER={SYCL_PLUGIN} ".format(SYCL_PLUGIN=backend)) )
 config.substitutions.append( ('%RUN_ON_HOST', "env SYCL_DEVICE_FILTER=host ") )
 
-get_device_count_by_type_path = os.path.join(config.llvm_tools_dir, "get_device_count_by_type")
+get_device_count_by_type_path = lit_config.params.get('GET_DEVICE_TOOL', os.path.join(config.llvm_tools_dir, "get_device_count_by_type"))
 
 def getDeviceCount(device_type):
     is_cuda = False;

--- a/sycl/test/on-device/lit.site.cfg.py.in
+++ b/sycl/test/on-device/lit.site.cfg.py.in
@@ -18,6 +18,7 @@ config.sycl_tools_src_dir = "@SYCL_TOOLS_SRC_DIR@"
 config.llvm_build_lib_dir = "@LLVM_BUILD_LIBRARY_DIRS@"
 config.llvm_build_bin_dir = "@LLVM_BUILD_BINARY_DIRS@"
 config.sycl_clang_extra_flags = "@SYCL_CLANG_EXTRA_FLAGS@"
+config.level_zero_include_dir = lit_config.params.get('LEVEL_ZERO_INCLUDE_DIR', "@LEVEL_ZERO_INCLUDE_DIR@")
 
 config.llvm_enable_projects = "@LLVM_ENABLE_PROJECTS@"
 

--- a/sycl/test/on-device/online_compiler/online_compiler_L0.cpp
+++ b/sycl/test/on-device/online_compiler/online_compiler_L0.cpp
@@ -1,9 +1,9 @@
-// REQUIRES: level_zero
+// REQUIRES: level_zero, level_zero_headers
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir -DRUN_KERNELS -lze_loader %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %level_zero_include_dir -DRUN_KERNELS -lze_loader %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir -lze_loader %s -o %th.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %level_zero_include_dir -lze_loader %s -o %th.out
 // RUN: %RUN_ON_HOST %th.out
 
 // This test checks INTEL feature class online_compiler for Level-Zero.


### PR DESCRIPTION
CMake target configuration is aligned with LIT test location.

That also alows to run on-device LIT tests for prebuilt SYCL compiler
and runtime binaries following the
[instructions](https://github.com/intel/llvm/blob/sycl/sycl/test/on-device/README.md).