### PR TITLE
[SYCL] Cleanup the deprecated Intel attribute logic

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12884,6 +12884,11 @@ public:
   void MarkDevice();
   void MarkSyclSimd();
 
+  /// Diagnoses an attribute in the 'intelfpga' namespace and suggests using
+  /// the attribute in the 'intel' namespace instead.
+  void CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &Attr,
+                                            StringRef NewName = "");
+
   /// Creates a SemaDiagnosticBuilder that emits the diagnostic if the current
   /// context is "used as device code".
   ///

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12886,7 +12886,7 @@ public:
 
   /// Diagnoses an attribute in the 'intelfpga' namespace and suggests using
   /// the attribute in the 'intel' namespace instead.
-  void CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &Attr,
+  void CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,
                                             StringRef NewName = "");
 
   /// Creates a SemaDiagnosticBuilder that emits the diagnostic if the current

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -330,7 +330,7 @@ void Sema::CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,
     Diag(A.getLoc(), diag::warn_attribute_spelling_deprecated)
         << "'" + A.getNormalizedFullName() + "'";
 
-	FixItHint Fix = NewName.empty()
+    FixItHint Fix = NewName.empty()
                         ? FixItHint::CreateReplacement(A.getScopeLoc(), "intel")
                         : FixItHint::CreateReplacement(
                               A.getRange(), ("intel::" + NewName).str());
@@ -5521,8 +5521,7 @@ static void handleNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
                 ? A.getArgAsExpr(0)
                 : IntegerLiteral::Create(S.Context, llvm::APInt(32, 1),
                                          S.Context.IntTy, A.getLoc());
-  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, A,
-                                                                       E);
+  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, A, E);
 }
 
 /// Handle the [[intelfpga::doublepump]] and [[intelfpga::singlepump]] attributes.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -320,12 +320,27 @@ static bool checkAttrMutualExclusion(Sema &S, Decl *D, const Attr &AL) {
   return false;
 }
 
-static bool checkDeprecatedSYCLAttributeSpelling(Sema &S,
-                                                 const ParsedAttr &Attr) {
-  if (Attr.getScopeName()->isStr("intelfpga"))
-    return S.Diag(Attr.getLoc(), diag::warn_attribute_spelling_deprecated)
-           << "'" + Attr.getNormalizedFullName() + "'";
-  return false;
+void Sema::CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,
+                                                StringRef NewName) {
+  // All attributes in the intelfpga vendor namespace are deprecated in favor
+  // of a name in the intel vendor namespace. By default, assume the attribute
+  // retains its original name but changes the namespace. However, some
+  // attributes were renamed, so we support supplying a new name as well.
+  if (A.getScopeName()->isStr("intelfpga")) {
+    Diag(A.getLoc(), diag::warn_attribute_spelling_deprecated)
+        << "'" + A.getNormalizedFullName() + "'";
+
+	FixItHint Fix = NewName.empty()
+                        ? FixItHint::CreateReplacement(A.getScopeLoc(), "intel")
+                        : FixItHint::CreateReplacement(
+                              A.getRange(), ("intel::" + NewName).str());
+
+    Diag(A.getLoc(), diag::note_spelling_suggestion)
+        << (llvm::Twine("'intel::") +
+            (NewName.empty() ? A.getAttrName()->getName() : NewName) + "'")
+               .str()
+        << Fix;
+  }
 }
 
 /// Check if IdxExpr is a valid parameter index for a function or
@@ -3012,10 +3027,8 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
     return Result;
   }
 
-  if (AL.getKind() == ParsedAttr::AT_SYCLIntelMaxWorkGroupSize &&
-      checkDeprecatedSYCLAttributeSpelling(S, AL))
-    S.Diag(AL.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::max_work_group_size'";
+  if (AL.getKind() == ParsedAttr::AT_SYCLIntelMaxWorkGroupSize)
+    S.CheckDeprecatedSYCLAttributeSpelling(AL);
 
   // For a SYCLDevice, WorkGroupAttr arguments are reversed.
   // "XDim" gets the third argument to the attribute and
@@ -3162,22 +3175,18 @@ static void handleSubGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
 }
 
 // Handles num_simd_work_items.
-static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D,
-                                       const ParsedAttr &Attr) {
+static void handleNumSimdWorkItemsAttr(Sema &S, Decl *D, const ParsedAttr &A) {
   if (D->isInvalidDecl())
     return;
 
-  Expr *E = Attr.getArgAsExpr(0);
+  Expr *E = A.getArgAsExpr(0);
 
   if (D->getAttr<SYCLIntelNumSimdWorkItemsAttr>())
-    S.Diag(Attr.getLoc(), diag::warn_duplicate_attribute) << Attr;
+    S.Diag(A.getLoc(), diag::warn_duplicate_attribute) << A;
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::num_simd_work_items'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
-  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(D, Attr,
-                                                                     E);
+  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(D, A, E);
 }
 
 // Handles use_stall_enable_clusters
@@ -3206,35 +3215,29 @@ static void handleSchedulerTargetFmaxMhzAttr(Sema &S, Decl *D,
   if (D->getAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>())
     S.Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL;
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, AL))
-    S.Diag(AL.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::scheduler_target_fmax_mhz'";
+  S.CheckDeprecatedSYCLAttributeSpelling(AL);
 
   S.AddOneConstantValueAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>(D, AL, E);
 }
 
 // Handles max_global_work_dim.
-static void handleMaxGlobalWorkDimAttr(Sema &S, Decl *D,
-                                       const ParsedAttr &Attr) {
+static void handleMaxGlobalWorkDimAttr(Sema &S, Decl *D, const ParsedAttr &A) {
   if (D->isInvalidDecl())
     return;
 
-  Expr *E = Attr.getArgAsExpr(0);
+  Expr *E = A.getArgAsExpr(0);
 
-  if (!checkWorkGroupSizeValues(S, D, Attr)) {
+  if (!checkWorkGroupSizeValues(S, D, A)) {
     D->setInvalidDecl();
     return;
   }
 
   if (D->getAttr<SYCLIntelMaxGlobalWorkDimAttr>())
-    S.Diag(Attr.getLoc(), diag::warn_duplicate_attribute) << Attr;
+    S.Diag(A.getLoc(), diag::warn_duplicate_attribute) << A;
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::max_global_work_dim'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
-  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelMaxGlobalWorkDimAttr>(D, Attr,
-                                                                     E);
+  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelMaxGlobalWorkDimAttr>(D, A, E);
 }
 
 SYCLIntelLoopFuseAttr *
@@ -5506,23 +5509,19 @@ static bool checkForDuplicateAttribute(Sema &S, Decl *D,
 }
 
 static void handleNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
-                                         const ParsedAttr &Attr) {
+                                         const ParsedAttr &A) {
   if (S.LangOpts.SYCLIsHost)
     return;
 
-  checkForDuplicateAttribute<SYCLIntelNoGlobalWorkOffsetAttr>(S, D, Attr);
-
-  if (Attr.getKind() == ParsedAttr::AT_SYCLIntelNoGlobalWorkOffset &&
-      checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::no_global_work_offset'";
+  checkForDuplicateAttribute<SYCLIntelNoGlobalWorkOffsetAttr>(S, D, A);
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
   // If no attribute argument is specified, set to default value '1'.
-  Expr *E = Attr.isArgExpr(0)
-                ? Attr.getArgAsExpr(0)
+  Expr *E = A.isArgExpr(0)
+                ? A.getArgAsExpr(0)
                 : IntegerLiteral::Create(S.Context, llvm::APInt(32, 1),
-                                         S.Context.IntTy, Attr.getLoc());
-  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, Attr,
+                                         S.Context.IntTy, A.getLoc());
+  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelNoGlobalWorkOffsetAttr>(D, A,
                                                                        E);
 }
 
@@ -5530,32 +5529,24 @@ static void handleNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
 /// One but not both can be specified
 /// Both are incompatible with the __register__ attribute.
 template <typename AttrType, typename IncompatAttrType>
-static void handleIntelFPGAPumpAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
-
+static void handleIntelFPGAPumpAttr(Sema &S, Decl *D, const ParsedAttr &A) {
   if (S.LangOpts.SYCLIsHost)
     return;
 
-  checkForDuplicateAttribute<AttrType>(S, D, Attr);
-  if (checkAttrMutualExclusion<IncompatAttrType>(S, D, Attr))
+  checkForDuplicateAttribute<AttrType>(S, D, A);
+  if (checkAttrMutualExclusion<IncompatAttrType>(S, D, A))
     return;
 
-  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, A))
     return;
 
   if (!D->hasAttr<IntelFPGAMemoryAttr>())
     D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
         S.Context, IntelFPGAMemoryAttr::Default));
 
-  if (Attr.getKind() == ParsedAttr::AT_IntelFPGADoublePump &&
-      checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::doublepump'";
-  else if (Attr.getKind() == ParsedAttr::AT_IntelFPGASinglePump &&
-           checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::singlepump'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
-  handleSimpleAttribute<AttrType>(S, D, Attr);
+  handleSimpleAttribute<AttrType>(S, D, A);
 }
 
 /// Handle the [[intelfpga::memory]] attribute.
@@ -5592,9 +5583,7 @@ static void handleIntelFPGAMemoryAttr(Sema &S, Decl *D,
     if (MA->isImplicit())
       D->dropAttr<IntelFPGAMemoryAttr>();
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, AL))
-    S.Diag(AL.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::fpga_memory'";
+  S.CheckDeprecatedSYCLAttributeSpelling(AL, "fpga_memory");
 
   D->addAttr(::new (S.Context) IntelFPGAMemoryAttr(S.Context, AL, Kind));
 }
@@ -5636,21 +5625,18 @@ static bool checkIntelFPGARegisterAttrCompatibility(Sema &S, Decl *D,
 
 /// Handle the [[intelfpga::register]] attribute.
 /// This is incompatible with most of the other memory attributes.
-static void handleIntelFPGARegisterAttr(Sema &S, Decl *D,
-                                        const ParsedAttr &Attr) {
+static void handleIntelFPGARegisterAttr(Sema &S, Decl *D, const ParsedAttr &A) {
 
   if (S.LangOpts.SYCLIsHost)
     return;
 
-  checkForDuplicateAttribute<IntelFPGARegisterAttr>(S, D, Attr);
-  if (checkIntelFPGARegisterAttrCompatibility(S, D, Attr))
+  checkForDuplicateAttribute<IntelFPGARegisterAttr>(S, D, A);
+  if (checkIntelFPGARegisterAttrCompatibility(S, D, A))
     return;
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::fpga_register'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A, "fpga_register");
 
-  handleSimpleAttribute<IntelFPGARegisterAttr>(S, D, Attr);
+  handleSimpleAttribute<IntelFPGARegisterAttr>(S, D, A);
 }
 
 /// Handle the [[intelfpga::bankwidth]] and [[intelfpga::numbanks]] attributes.
@@ -5660,25 +5646,20 @@ static void handleIntelFPGARegisterAttr(Sema &S, Decl *D,
 /// when handling numbanks they are checked for consistency.
 template <typename AttrType>
 static void handleOneConstantPowerTwoValueAttr(Sema &S, Decl *D,
-                                               const ParsedAttr &Attr) {
+                                               const ParsedAttr &A) {
 
   if (S.LangOpts.SYCLIsHost)
     return;
 
-  checkForDuplicateAttribute<AttrType>(S, D, Attr);
-  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
+  checkForDuplicateAttribute<AttrType>(S, D, A);
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, A))
     return;
 
-  if (Attr.getKind() == ParsedAttr::AT_IntelFPGABankWidth &&
-      checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::bankwidth'";
-  else if (Attr.getKind() == ParsedAttr::AT_IntelFPGANumBanks &&
-           checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::numbanks'";
+  if (A.getKind() == ParsedAttr::AT_IntelFPGABankWidth ||
+      A.getKind() == ParsedAttr::AT_IntelFPGANumBanks)
+    S.CheckDeprecatedSYCLAttributeSpelling(A);
 
-  S.AddOneConstantPowerTwoValueAttr<AttrType>(D, Attr, Attr.getArgAsExpr(0));
+  S.AddOneConstantPowerTwoValueAttr<AttrType>(D, A, A.getArgAsExpr(0));
 }
 
 static void handleIntelFPGASimpleDualPortAttr(Sema &S, Decl *D,
@@ -5695,30 +5676,26 @@ static void handleIntelFPGASimpleDualPortAttr(Sema &S, Decl *D,
     D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
         S.Context, IntelFPGAMemoryAttr::Default));
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, AL))
-    S.Diag(AL.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::simple_dual_port'";
+  S.CheckDeprecatedSYCLAttributeSpelling(AL);
 
   D->addAttr(::new (S.Context)
                  IntelFPGASimpleDualPortAttr(S.Context, AL));
 }
 
 static void handleIntelFPGAMaxReplicatesAttr(Sema &S, Decl *D,
-                                             const ParsedAttr &Attr) {
+                                             const ParsedAttr &A) {
   if (S.LangOpts.SYCLIsHost)
     return;
 
-  checkForDuplicateAttribute<IntelFPGAMaxReplicatesAttr>(S, D, Attr);
+  checkForDuplicateAttribute<IntelFPGAMaxReplicatesAttr>(S, D, A);
 
-  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, A))
     return;
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::max_replicates'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
-  S.AddOneConstantValueAttr<IntelFPGAMaxReplicatesAttr>(D, Attr,
-                                                        Attr.getArgAsExpr(0));
+  S.AddOneConstantValueAttr<IntelFPGAMaxReplicatesAttr>(D, A,
+                                                        A.getArgAsExpr(0));
 }
 
 /// Handle the merge attribute.
@@ -5751,8 +5728,7 @@ static void handleIntelFPGAMergeAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
         S.Context, IntelFPGAMemoryAttr::Default));
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, AL))
-    S.Diag(AL.getLoc(), diag::note_spelling_suggestion) << "'intel::merge'";
+  S.CheckDeprecatedSYCLAttributeSpelling(AL);
 
   D->addAttr(::new (S.Context)
                  IntelFPGAMergeAttr(S.Context, AL, Results[0], Results[1]));
@@ -5766,26 +5742,23 @@ static void handleIntelFPGAMergeAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 /// hasn't been added yet an implicit one is added with the correct value.
 /// If the user later adds a numbanks attribute the implicit one is removed.
 /// The values must be consecutive values (i.e. 3,4,5 or 2,1).
-static void handleIntelFPGABankBitsAttr(Sema &S, Decl *D,
-                                        const ParsedAttr &Attr) {
-  checkForDuplicateAttribute<IntelFPGABankBitsAttr>(S, D, Attr);
+static void handleIntelFPGABankBitsAttr(Sema &S, Decl *D, const ParsedAttr &A) {
+  checkForDuplicateAttribute<IntelFPGABankBitsAttr>(S, D, A);
 
-  if (!checkAttributeAtLeastNumArgs(S, Attr, 1))
+  if (!checkAttributeAtLeastNumArgs(S, A, 1))
     return;
 
-  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, A))
     return;
 
   SmallVector<Expr *, 8> Args;
-  for (unsigned I = 0; I < Attr.getNumArgs(); ++I) {
-    Args.push_back(Attr.getArgAsExpr(I));
+  for (unsigned I = 0; I < A.getNumArgs(); ++I) {
+    Args.push_back(A.getArgAsExpr(I));
   }
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::bank_bits'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
-  S.AddIntelFPGABankBitsAttr(D, Attr, Args.data(), Args.size());
+  S.AddIntelFPGABankBitsAttr(D, A, Args.data(), Args.size());
 }
 
 void Sema::AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
@@ -5849,43 +5822,38 @@ void Sema::AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
 }
 
 static void handleIntelFPGAPrivateCopiesAttr(Sema &S, Decl *D,
-                                             const ParsedAttr &Attr) {
-
+                                             const ParsedAttr &A) {
   if (S.LangOpts.SYCLIsHost)
     return;
 
-  checkForDuplicateAttribute<IntelFPGAPrivateCopiesAttr>(S, D, Attr);
-  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
+  checkForDuplicateAttribute<IntelFPGAPrivateCopiesAttr>(S, D, A);
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, A))
     return;
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::private_copies'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
-  S.AddOneConstantValueAttr<IntelFPGAPrivateCopiesAttr>(
-      D, Attr, Attr.getArgAsExpr(0));
+  S.AddOneConstantValueAttr<IntelFPGAPrivateCopiesAttr>(D, A,
+                                                        A.getArgAsExpr(0));
 }
 
 static void handleIntelFPGAForcePow2DepthAttr(Sema &S, Decl *D,
-                                              const ParsedAttr &Attr) {
+                                              const ParsedAttr &A) {
   if (S.LangOpts.SYCLIsHost)
     return;
 
-  checkForDuplicateAttribute<IntelFPGAForcePow2DepthAttr>(S, D, Attr);
+  checkForDuplicateAttribute<IntelFPGAForcePow2DepthAttr>(S, D, A);
 
-  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, Attr))
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, A))
     return;
 
   if (!D->hasAttr<IntelFPGAMemoryAttr>())
     D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
         S.Context, IntelFPGAMemoryAttr::Default));
 
-  if (checkDeprecatedSYCLAttributeSpelling(S, Attr))
-    S.Diag(Attr.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::force_pow2_depth'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
-  S.AddOneConstantValueAttr<IntelFPGAForcePow2DepthAttr>(D, Attr,
-                                                         Attr.getArgAsExpr(0));
+  S.AddOneConstantValueAttr<IntelFPGAForcePow2DepthAttr>(D, A,
+                                                         A.getArgAsExpr(0));
 }
 
 static void handleXRayLogArgsAttr(Sema &S, Decl *D, const ParsedAttr &AL) {

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -74,14 +74,6 @@ static Attr *handleSuppressAttr(Sema &S, Stmt *St, const ParsedAttr &A,
       S.Context, A, DiagnosticIdentifiers.data(), DiagnosticIdentifiers.size());
 }
 
-static bool checkDeprecatedSYCLLoopAttributeSpelling(Sema &S,
-                                                     const ParsedAttr &A) {
-  if (A.getScopeName()->isStr("intelfpga"))
-    return S.Diag(A.getLoc(), diag::warn_attribute_spelling_deprecated)
-           << "'" + A.getNormalizedFullName() + "'";
-  return false;
-}
-
 template <typename FPGALoopAttrT>
 static Attr *handleIntelFPGALoopAttr(Sema &S, const ParsedAttr &A) {
   if(S.LangOpts.SYCLIsHost)
@@ -103,30 +95,7 @@ static Attr *handleIntelFPGALoopAttr(Sema &S, const ParsedAttr &A) {
     }
   }
 
-  if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAII &&
-      checkDeprecatedSYCLLoopAttributeSpelling(S, A)) {
-    S.Diag(A.getLoc(), diag::note_spelling_suggestion) << "'intel::ii'";
-  } else if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency &&
-             checkDeprecatedSYCLLoopAttributeSpelling(S, A)) {
-    S.Diag(A.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::max_concurrency'";
-  } else if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency &&
-             checkDeprecatedSYCLLoopAttributeSpelling(S, A)) {
-    S.Diag(A.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::max_concurrency'";
-  } else if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxInterleaving &&
-             checkDeprecatedSYCLLoopAttributeSpelling(S, A)) {
-    S.Diag(A.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::max_interleaving'";
-  } else if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGASpeculatedIterations &&
-             checkDeprecatedSYCLLoopAttributeSpelling(S, A)) {
-    S.Diag(A.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::speculated_iterations'";
-  } else if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGALoopCoalesce &&
-             checkDeprecatedSYCLLoopAttributeSpelling(S, A)) {
-    S.Diag(A.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::loop_coalesce'";
-  }
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
   return S.BuildSYCLIntelFPGALoopAttr<FPGALoopAttrT>(
       A, A.getNumArgs() ? A.getArgAsExpr(0) : nullptr);
@@ -144,9 +113,7 @@ Attr *handleIntelFPGALoopAttr<SYCLIntelFPGADisableLoopPipeliningAttr>(
     return nullptr;
   }
 
-  if (checkDeprecatedSYCLLoopAttributeSpelling(S, A))
-    S.Diag(A.getLoc(), diag::note_spelling_suggestion)
-        << "'intel::disable_loop_pipelining'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
   return new (S.Context) SYCLIntelFPGADisableLoopPipeliningAttr(S.Context, A);
 }
@@ -309,8 +276,7 @@ static Attr *handleIntelFPGAIVDepAttr(Sema &S, const ParsedAttr &A) {
     return nullptr;
   }
 
-  if (checkDeprecatedSYCLLoopAttributeSpelling(S, A))
-    S.Diag(A.getLoc(), diag::note_spelling_suggestion) << "'intel::ivdep'";
+  S.CheckDeprecatedSYCLAttributeSpelling(A);
 
   return S.BuildSYCLIntelFPGAIVDepAttr(
       A, NumArgs >= 1 ? A.getArgAsExpr(0) : nullptr,


### PR DESCRIPTION
We previously sprinkled deprecated attribute logic around to a few places
when we could instead use a single helper function to do the work for us.

This also adds a fix-it hint when we find a deprecated attribute to help
the user convert to the new spelling.

As a drive-by, this fixes functions that were using `Attr` as a variable name.