### PR TITLE
[SYCL][L0] Fix the leak in event pool

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -508,7 +508,7 @@ pi_result _pi_context::finalize() {
   // For example, zeEventPool could be still alive.
   std::lock_guard<std::mutex> NumEventsLiveInEventPoolGuard(
       NumEventsLiveInEventPoolMutex, std::adopt_lock);
-  if (ZeEventPool && NumEventsLiveInEventPool[ZeEventPool])
+  if (ZeEventPool)
     zeEventPoolDestroy(ZeEventPool);
 
   // Destroy the command list used for initializations


### PR DESCRIPTION
When tearing down context, we should deallocate memory regardless of its live events count.

Signed-off-by: Byoungro So <byoungro.so@intel.com>