### PR TITLE
[SYCL] submit barrier command to execution (see issue #3000)

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -4102,7 +4102,9 @@ pi_result piEnqueueEventsWaitWithBarrier(pi_queue Queue,
                                      (*Event)->WaitList.Length,
                                      (*Event)->WaitList.ZeEventList));
 
-  return PI_SUCCESS;
+  // Execute command list asynchronously as the event will be used
+  // to track down its completion.
+  return Queue->executeCommandList(ZeCommandList, ZeFence);
 }
 
 pi_result piEnqueueMemBufferRead(pi_queue Queue, pi_mem Src,


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/issues/3000
A submission of the barrier was missing.
Test: https://github.com/intel/llvm-test-suite/pull/98

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>