### PR TITLE
[CODEOWNERS] Fix ownership of DPC++ tools tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,10 +95,10 @@ xpti/ @tovinkere @andykaylor
 xptifw/ @tovinkere  @andykaylor
 
 # DPC++ tools
-llvm/tools/file-table-tform/ @kbobrovs @AlexeySachkov
-llvm/tools/llvm-foreach/ @AlexeySachkov  @Fznamznon
-llvm/tools/llvm-no-spir-kernel/ @AGindinson @AlexeySachkov
-llvm/tools/sycl-post-link/ @kbobrovs @AlexeySachkov
+llvm/**/file-table-tform/ @kbobrovs @AlexeySachkov
+llvm/**/llvm-foreach/ @AlexeySachkov  @Fznamznon
+llvm/**/llvm-no-spir-kernel/ @AGindinson @AlexeySachkov
+llvm/**/sycl-post-link/ @kbobrovs @AlexeySachkov
 
 # Clang offload tools
 clang/tools/clang-offload-bundler/ @kbobrovs @sndmitriev


### PR DESCRIPTION
New pattern matches both source (llvm/tools/*) and test
(llvm/test/tools/*) directories.