### PR TITLE
[clang-offload-bundler] Initialize member names in unbundled archive

### DIFF
--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -1056,7 +1056,7 @@ public:
               return Err;
           } else if (Mode == OutputType::Archive) {
             // Extract the bundle to a buffer.
-            SmallVector<char, 0u> Data;
+            SmallVector<char> Data;
             raw_svector_ostream ChildOS{Data};
             if (Error Err = OFH.ReadBundle(ChildOS, *Buf))
               return Err;


### PR DESCRIPTION
Member names in the unbundled archive were not properly initialized
which could lead to random problems for tools working with these
archives later. This patch fixes this problem.

There is no LIT test in this patch because it is impossible to create
stable test which shows the problem.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>