### PR TITLE
[SYCL][Doc] Update for get started guide

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -661,7 +661,7 @@ class CUDASelector : public cl::sycl::device_selector {
 
 ## C++ standard
 
-* DPC++ runtime is built as C++14 library.
+* DPC++ runtime and headers require C++14 at least.
 * DPC++ compiler is building apps as C++17 apps by default.
 
 ## Known Issues and Limitations
@@ -669,6 +669,7 @@ class CUDASelector : public cl::sycl::device_selector {
 * DPC++ device compiler fails if the same kernel was used in different
   translation units.
 * SYCL host device is not fully supported.
+* SYCL 2020 support work is in progress.
 * 32-bit host/target is not supported.
 * DPC++ works only with OpenCL low level runtimes which support out-of-order
   queues.


### PR DESCRIPTION
* Add note that SYCL 2020 implementation is in progress (see issue #2971)
* Add note that DPC++ runtime and headers require C++14 (see PR #2528)

Signed-off-by: Pavel V Chupin <pavel.v.chupin@intel.com>