### PR TITLE
[ESIMD] Remove documentation for SYCLSimdAccessorPtr attr w/o spelling.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1180,13 +1180,17 @@ def SYCLRegisterNum : InheritableAttr {
   let Documentation = [SYCLRegisterNumDocs];
 }
 
-// Used to mark ESIMD kernel pointer parameters originating from accessors.
+// Used by FE to mark ESIMD kernel pointer parameters which correspond to the
+// original lambda's captured accessors. FE turns the attribute to some metadata
+// required by the ESIMD Back-End.
+// Not supposed to be used directly in the source - SYCL device compiler FE
+// automatically adds it for ESIMD kernels, hence undocumented.
 def SYCLSimdAccessorPtr : InheritableAttr {
   // No spelling, as this attribute can't be created in the source code.
   let Spellings = [];
   let Subjects = SubjectList<[ParmVar]>;
   let LangOpts = [SYCLExplicitSIMD];
-  let Documentation = [SYCLSimdAccessorPtrDocs];
+  let Documentation = [Undocumented];
 }
 
 def SYCLScope : Attr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -380,18 +380,6 @@ def SYCLRegisterNumDocs : Documentation {
   }];
 }
 
-def SYCLSimdAccessorPtrDocs : Documentation {
-  let Category = DocCatVariable;
-  let Content = [{
-    The ``__attribute__((esimd_acc_ptr))`` attribute is used by FE to mark ESIMD
-    kernel pointer parameters which correspond to the original
-    lambda's captured accessors. FE turns the attribute to some metadata
-    required by the ESIMD Back-End.
-    Not supposed to be used directly in the source - SYCL device compiler FE
-    automatically adds it for ESIMD kernels.
-  }];
-}
-
 def C11NoReturnDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/issues/3046

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>