### PR TITLE
[Driver][SYCL] Improve output file handling for -fsycl-device-only

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6367,7 +6367,8 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
   llvm::PrettyStackTraceString CrashInfo("Computing output path");
   // Output to a user requested destination?
   if (AtTopLevel && !isa<DsymutilJobAction>(JA) && !isa<VerifyJobAction>(JA)) {
-    if (Arg *FinalOutput = C.getArgs().getLastArg(options::OPT_o))
+    if (Arg *FinalOutput =
+            C.getArgs().getLastArg(options::OPT_o, options::OPT__SLASH_o))
       return C.addResultFile(FinalOutput->getValue(), &JA);
   }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6367,9 +6367,12 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
   llvm::PrettyStackTraceString CrashInfo("Computing output path");
   // Output to a user requested destination?
   if (AtTopLevel && !isa<DsymutilJobAction>(JA) && !isa<VerifyJobAction>(JA)) {
-    if (Arg *FinalOutput =
-            C.getArgs().getLastArg(options::OPT_o, options::OPT__SLASH_o))
+    if (Arg *FinalOutput = C.getArgs().getLastArg(options::OPT_o))
       return C.addResultFile(FinalOutput->getValue(), &JA);
+    // Output to destination for -fsycl-device-only and Windows -o
+    if (C.getArgs().hasArg(options::OPT_fsycl_device_only))
+      if (Arg *FinalOutput = C.getArgs().getLastArg(options::OPT__SLASH_o))
+        return C.addResultFile(FinalOutput->getValue(), &JA);
   }
 
   // For /P, preprocess to file named after BaseInput.

--- a/clang/test/Driver/sycl-device.cpp
+++ b/clang/test/Driver/sycl-device.cpp
@@ -28,3 +28,10 @@
 // RUN:   | FileCheck -check-prefix=CHECK-SYCL-AUX-TRIPLE %s
 // TODO: %clang -### -fsycl -fsycl-device-only -target aarch64-linux-gnu
 // CHECK-SYCL-AUX-TRIPLE: clang{{.*}} "-aux-triple" "aarch64-unknown-linux-gnu"
+
+/// Verify output files are properly specified given -o
+// RUN: %clang -### -fsycl -fsycl-device-only -o dummy.out %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK-OUTPUT-FILE %s
+// RUN: %clang_cl -### -fsycl -fsycl-device-only -o dummy.out %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK-OUTPUT-FILE %s
+// CHECK-OUTPUT-FILE: clang{{.*}} "-o" "dummy.out"


### PR DESCRIPTION
When using -fsycl-device-only, specifying -o file would not output to file
when used on Windows (clang-cl).  Update to allow for the Windows /o to
interpret this as expected.