### PR TITLE
[SYCL] Update kernel name diagnostics logic

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3036,6 +3036,10 @@ public:
         return;
       }
       if (!DeclCtx->isTranslationUnit() && !isa<NamespaceDecl>(DeclCtx)) {
+        // Allow Structs since they are public by default
+        if (Tag->isStruct()) {
+          return;
+        }
         const bool KernelNameIsMissing = Tag->getName().empty();
         if (KernelNameIsMissing) {
           S.Diag(KernelInvocationFuncLoc,

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h %s -o %t.out
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -sycl-std=2020 -fsycl-int-header=%t.h %s -o %t.out
 // RUN: FileCheck -input-file=%t.h %s
 
 // CHECK:template <> struct KernelInfo<class KernelName> {
@@ -11,7 +11,6 @@
 // CHECK:template <> struct KernelInfo<::nm1::KernelName3<KernelName5>> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName4<KernelName7>> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName8<::nm1::nm2::C>> {
-// CHECK:template <> struct KernelInfo<::TmplClassInAnonNS<ClassInAnonNS>> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName9<char>> {
 // CHECK:template <> struct KernelInfo<::nm1::KernelName3<const volatile ::nm1::KernelName3<const volatile char>>> {
 
@@ -48,11 +47,6 @@ namespace nm1 {
   class KernelName9;
 
 } // namespace nm1
-
-namespace {
-  class ClassInAnonNS;
-  template <typename T> class TmplClassInAnonNS;
-}
 
 struct MyWrapper {
   class KN101 {};
@@ -130,8 +124,6 @@ struct MyWrapper {
 
     // kernel name type is a templated class, both the top-level class and the
     // template argument are declared in the anonymous namespace
-    kernel_single_task<TmplClassInAnonNS<class ClassInAnonNS>>(
-      [=]() { acc.use(); });
 
     // Kernel name type is a templated specialization class with empty template pack argument
     kernel_single_task<nm1::KernelName9<char>>(
@@ -165,7 +157,7 @@ int main() {
   KernelInfo<class nm1::KernelName3<class KernelName5>>::getName();
   KernelInfo<class nm1::KernelName4<class KernelName7>>::getName();
   KernelInfo<class nm1::KernelName8<nm1::nm2::C>>::getName();
-  KernelInfo<class TmplClassInAnonNS<class ClassInAnonNS>>::getName();
+
   KernelInfo<class nm1::KernelName9<char>>::getName();
 #endif //__SYCL_DEVICE_ONLY__
 }

--- a/clang/test/SemaSYCL/allow-nested-structs.cpp
+++ b/clang/test/SemaSYCL/allow-nested-structs.cpp
@@ -1,0 +1,69 @@
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -sycl-std=2020 -verify %s
+
+#include "sycl.hpp"
+
+struct NestedStruct1 {
+  struct NestedStruct2 {
+    struct NestedStruct3 {};
+  };
+};
+
+namespace {
+struct StructInAnonymousNS {};
+} // namespace
+
+namespace ValidNS {
+struct StructinValidNS {};
+} // namespace ValidNS
+
+struct Parent {
+  using A = struct {
+    struct Child1 {
+      struct Child2 {};
+    };
+  };
+};
+
+struct MyWrapper {
+
+public:
+  void test() {
+    cl::sycl::queue q;
+    struct StructInsideFunc {};
+
+    // no error
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<NestedStruct1::NestedStruct2::NestedStruct3>([] {});
+    });
+
+    // no error
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<ValidNS::StructinValidNS>([] {});
+    });
+
+    // no error
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<Parent::A::Child1::Child2>([] {});
+    });
+
+    // expected-error@Inputs/sycl.hpp:220 {{'(anonymous namespace)::StructInAnonymousNS' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{'(anonymous namespace)::StructInAnonymousNS' should be globally-visible}}
+    // expected-note@+2{{in instantiation of function template specialization}}
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<StructInAnonymousNS>([] {});
+    });
+
+    // expected-error@Inputs/sycl.hpp:220 {{'StructInsideFunc' is an invalid kernel name type}}
+    // expected-note@Inputs/sycl.hpp:220 {{'StructInsideFunc' should be globally-visible}}
+    // expected-note@+2{{in instantiation of function template specialization}}
+    q.submit([&](cl::sycl::handler &h) {
+      h.single_task<StructInsideFunc>([] {});
+    });
+  }
+};
+
+int main() {
+  cl::sycl::queue q;
+
+  return 0;
+}

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -52,20 +52,12 @@ public:
       h.single_task<namespace1::KernelName<InvalidKernelName2>>([] {});
     });
 
-#ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName0' is an invalid kernel name type}}
-    // expected-note@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName0' should be globally-visible}}
-    // expected-note@+3{{in instantiation of function template specialization}}
-#endif
+    // no error
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidKernelName0>([] {});
     });
 
-#ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{'namespace1::KernelName<MyWrapper::InvalidKernelName3>' is an invalid kernel name type}}
-    // expected-note@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName3' should be globally-visible}}
-    // expected-note@+3{{in instantiation of function template specialization}}
-#endif
+    //no error
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidKernelName3>>([] {});
     });
@@ -85,21 +77,13 @@ public:
     });
 
     using InvalidAlias = InvalidKernelName4;
-#ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName4' is an invalid kernel name type}}
-    // expected-note@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName4' should be globally-visible}}
-    // expected-note@+3{{in instantiation of function template specialization}}
-#endif
+    // no error
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidAlias>([] {});
     });
 
     using InvalidAlias1 = InvalidKernelName5;
-#ifndef __SYCL_UNNAMED_LAMBDA__
-    // expected-error@Inputs/sycl.hpp:220 {{'namespace1::KernelName<MyWrapper::InvalidKernelName5>' is an invalid kernel name type}}
-    // expected-note@Inputs/sycl.hpp:220 {{'MyWrapper::InvalidKernelName5' should be globally-visible}}
-    // expected-note@+3{{in instantiation of function template specialization}}
-#endif
+    // no error
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidAlias1>>([] {});
     });

--- a/sycl/test/functor/kernel_functor.cpp
+++ b/sycl/test/functor/kernel_functor.cpp
@@ -81,7 +81,7 @@ int foo(int X) {
   {
     cl::sycl::queue Q;
     cl::sycl::buffer<int, 1> Buf(A, 1);
-    
+
     Q.submit([&](cl::sycl::handler &cgh) {
       auto Acc = Buf.get_access<sycl_read_write, sycl_global_buffer>(cgh);
       ns::Functor2 F(X, Acc);

--- a/sycl/test/functor/kernel_functor.cpp
+++ b/sycl/test/functor/kernel_functor.cpp
@@ -18,27 +18,6 @@ constexpr auto sycl_read_write = cl::sycl::access::mode::read_write;
 constexpr auto sycl_global_buffer = cl::sycl::access::target::global_buffer;
 
 // Case 1:
-// - functor class is defined in an anonymous namespace
-// - the '()' operator:
-//   * does not have parameters (to be used in 'single_task').
-//   * has the 'const' qualifier
-namespace {
-class Functor1 {
-public:
-  Functor1(
-      int X_,
-      cl::sycl::accessor<int, 1, sycl_read_write, sycl_global_buffer> &Acc_)
-      : X(X_), Acc(Acc_) {}
-
-  void operator()() const { Acc[0] += X; }
-
-private:
-  int X;
-  cl::sycl::accessor<int, 1, sycl_read_write, sycl_global_buffer> Acc;
-};
-}
-
-// Case 2:
 // - functor class is defined in a namespace
 // - the '()' operator:
 //   * does not have parameters (to be used in 'single_task').
@@ -60,7 +39,7 @@ private:
 };
 }
 
-// Case 3:
+// Case 2:
 // - functor class is templated and defined in the translation unit scope
 // - the '()' operator:
 //   * has a parameter of type cl::sycl::id<1> (to be used in 'parallel_for').
@@ -78,7 +57,7 @@ private:
   cl::sycl::accessor<T, 1, sycl_read_write, sycl_global_buffer> Acc;
 };
 
-// Case 4:
+// Case 3:
 // - functor class is templated and defined in the translation unit scope
 // - the '()' operator:
 //   * has a parameter of type cl::sycl::id<1> (to be used in 'parallel_for').
@@ -102,13 +81,7 @@ int foo(int X) {
   {
     cl::sycl::queue Q;
     cl::sycl::buffer<int, 1> Buf(A, 1);
-
-    Q.submit([&](cl::sycl::handler &cgh) {
-      auto Acc = Buf.get_access<sycl_read_write, sycl_global_buffer>(cgh);
-      Functor1 F(X, Acc);
-
-      cgh.single_task(F);
-    });
+    
     Q.submit([&](cl::sycl::handler &cgh) {
       auto Acc = Buf.get_access<sycl_read_write, sycl_global_buffer>(cgh);
       ns::Functor2 F(X, Acc);
@@ -167,7 +140,7 @@ template <typename T> T bar(T X) {
 int main() {
   const int Res1 = foo(10);
   const int Res2 = bar(10);
-  const int Gold1 = 40;
+  const int Gold1 = 30;
   const int Gold2 = 80;
 
   assert(Res1 == Gold1);


### PR DESCRIPTION
This patch makes the following changes:

- Allows nested named types to be used as valid kernel names.
- Allows kernel names inside named namespaces.
- Disallows kernel names inside anonymous namespaces.

It does the above by recursively checking if the declaration contexts in the parent-chain of the kernel name are valid or not.

PS: The standards quote (in C++20 as [class.access]p5), clarifies that **visibility isn't controlled by access specifiers (public/private/etc).** 
Before this patch, the compiler would throw an error if any of the InvalidKernelName* was used as kernel name :

```
struct MyWrapper {
private:
  class InvalidKernelName0 {};
  class InvalidKernelName3 {};
  class InvalidKernelName4 {};
  class InvalidKernelName5 {};
}
```

But based on standards quote, access specifiers do not matter and we should allow nested  named types.
