### PR TITLE
[SYCL] Added a new category for device binary properties

### DIFF
--- a/llvm/include/llvm/Support/PropertySetIO.h
+++ b/llvm/include/llvm/Support/PropertySetIO.h
@@ -187,7 +187,7 @@ public:
       "SYCL/composite specialization constants";
   static constexpr char SYCL_DEVICELIB_REQ_MASK[] = "SYCL/devicelib req mask";
   static constexpr char SYCL_KERNEL_PARAM_OPT_INFO[] = "SYCL/kernel param opt";
-  static constexpr char SYCL_IS_ESIMD_IMAGE[] = "SYCL/is ESIMD image";
+  static constexpr char SYCL_MISC_PROP[] = "SYCL/misc properties";
 
   // Function for bulk addition of an entire property set under given category
   // (property set name).

--- a/llvm/include/llvm/Support/PropertySetIO.h
+++ b/llvm/include/llvm/Support/PropertySetIO.h
@@ -187,6 +187,7 @@ public:
       "SYCL/composite specialization constants";
   static constexpr char SYCL_DEVICELIB_REQ_MASK[] = "SYCL/devicelib req mask";
   static constexpr char SYCL_KERNEL_PARAM_OPT_INFO[] = "SYCL/kernel param opt";
+  static constexpr char SYCL_IS_ESIMD_IMAGE[] = "SYCL/is ESIMD image";
 
   // Function for bulk addition of an entire property set under given category
   // (property set name).

--- a/llvm/lib/Support/PropertySetIO.cpp
+++ b/llvm/lib/Support/PropertySetIO.cpp
@@ -197,7 +197,7 @@ constexpr char PropertySetRegistry::SYCL_SPECIALIZATION_CONSTANTS[];
 constexpr char PropertySetRegistry::SYCL_DEVICELIB_REQ_MASK[];
 constexpr char PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO[];
 constexpr char PropertySetRegistry::SYCL_COMPOSITE_SPECIALIZATION_CONSTANTS[];
-constexpr char PropertySetRegistry::SYCL_IS_ESIMD_IMAGE[];
+constexpr char PropertySetRegistry::SYCL_MISC_PROP[];
 
 } // namespace util
 } // namespace llvm

--- a/llvm/lib/Support/PropertySetIO.cpp
+++ b/llvm/lib/Support/PropertySetIO.cpp
@@ -197,6 +197,7 @@ constexpr char PropertySetRegistry::SYCL_SPECIALIZATION_CONSTANTS[];
 constexpr char PropertySetRegistry::SYCL_DEVICELIB_REQ_MASK[];
 constexpr char PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO[];
 constexpr char PropertySetRegistry::SYCL_COMPOSITE_SPECIALIZATION_CONSTANTS[];
+constexpr char PropertySetRegistry::SYCL_IS_ESIMD_IMAGE[];
 
 } // namespace util
 } // namespace llvm

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -670,6 +670,8 @@ static const uint8_t PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL = 4;
 #define __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK "SYCL/devicelib req mask"
 /// PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO defined in PropertySetIO.h
 #define __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO "SYCL/kernel param opt"
+/// PropertySetRegistry::SYCL_IS_ESIMD_IMAGE defined in PropertySetIO.h
+#define __SYCL_PI_PROPERTY_SET_SYCL_IS_ESIMD_IMAGE "SYCL/is ESIMD image"
 
 /// This struct is a record of the device binary information. If the Kind field
 /// denotes a portable binary type (SPIR-V or LLVM IR), the DeviceTargetSpec

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -670,8 +670,8 @@ static const uint8_t PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL = 4;
 #define __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK "SYCL/devicelib req mask"
 /// PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO defined in PropertySetIO.h
 #define __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO "SYCL/kernel param opt"
-/// PropertySetRegistry::SYCL_IS_ESIMD_IMAGE defined in PropertySetIO.h
-#define __SYCL_PI_PROPERTY_SET_SYCL_IS_ESIMD_IMAGE "SYCL/is ESIMD image"
+/// PropertySetRegistry::SYCL_MISC_PROP defined in PropertySetIO.h
+#define __SYCL_PI_PROPERTY_SET_SYCL_MISC_PROP "SYCL/misc properties"
 
 /// This struct is a record of the device binary information. If the Kind field
 /// denotes a portable binary type (SPIR-V or LLVM IR), the DeviceTargetSpec

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -320,6 +320,7 @@ public:
   const PropertyRange &getKernelParamOptInfo() const {
     return KernelParamOptInfo;
   }
+  const PropertyRange &getSyclIsEsimdImage() const { return SyclIsEsimdImage; }
   virtual ~DeviceBinaryImage() {}
 
 protected:
@@ -332,6 +333,7 @@ protected:
   DeviceBinaryImage::PropertyRange CompositeSpecConstIDMap;
   DeviceBinaryImage::PropertyRange DeviceLibReqMask;
   DeviceBinaryImage::PropertyRange KernelParamOptInfo;
+  DeviceBinaryImage::PropertyRange SyclIsEsimdImage;
 };
 
 /// Tries to determine the device binary image foramat. Returns

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -290,8 +290,8 @@ public:
     return Format;
   }
 
-  /// Returns the value of a single property
-  bool isBoolPropertyTrue(const char *PropName) const;
+  /// Returns a single property from SYCL_MISC_PROP category.
+  pi_device_binary_property getProperty(const char *PropName) const;
 
   /// Gets the iterator range over scalar specialization constants in this
   /// binary image. For each property pointed to by an iterator within the

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -290,6 +290,9 @@ public:
     return Format;
   }
 
+  /// Returns the value of a single property
+  bool isBoolPropertyTrue(const char *PropName) const;
+
   /// Gets the iterator range over scalar specialization constants in this
   /// binary image. For each property pointed to by an iterator within the
   /// range, the name of the property is the specialization constant symbolic ID
@@ -320,7 +323,6 @@ public:
   const PropertyRange &getKernelParamOptInfo() const {
     return KernelParamOptInfo;
   }
-  const PropertyRange &getSyclIsEsimdImage() const { return SyclIsEsimdImage; }
   virtual ~DeviceBinaryImage() {}
 
 protected:
@@ -333,7 +335,6 @@ protected:
   DeviceBinaryImage::PropertyRange CompositeSpecConstIDMap;
   DeviceBinaryImage::PropertyRange DeviceLibReqMask;
   DeviceBinaryImage::PropertyRange KernelParamOptInfo;
-  DeviceBinaryImage::PropertyRange SyclIsEsimdImage;
 };
 
 /// Tries to determine the device binary image foramat. Returns

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -603,6 +603,7 @@ void DeviceBinaryImage::init(pi_device_binary Bin) {
                                __SYCL_PI_PROPERTY_SET_COMPOSITE_SPEC_CONST_MAP);
   DeviceLibReqMask.init(Bin, __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK);
   KernelParamOptInfo.init(Bin, __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
+  SyclIsEsimdImage.init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_IS_ESIMD_IMAGE);
 }
 
 } // namespace pi

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -565,6 +565,13 @@ void DeviceBinaryImage::PropertyRange::init(pi_device_binary Bin,
   End = Begin ? PS->PropertiesEnd : nullptr;
 }
 
+bool DeviceBinaryImage::isBoolPropertyTrue(const char *PropName) const {
+  DeviceBinaryImage::PropertyRange BoolProp;
+  BoolProp.init(Bin, PropName);
+  return BoolProp.isAvailable() &&
+         pi::DeviceBinaryProperty(*(BoolProp.begin())).asUint32();
+}
+
 RT::PiDeviceBinaryType getBinaryImageFormat(const unsigned char *ImgData,
                                             size_t ImgSize) {
   struct {
@@ -603,7 +610,6 @@ void DeviceBinaryImage::init(pi_device_binary Bin) {
                                __SYCL_PI_PROPERTY_SET_COMPOSITE_SPEC_CONST_MAP);
   DeviceLibReqMask.init(Bin, __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK);
   KernelParamOptInfo.init(Bin, __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
-  SyclIsEsimdImage.init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_IS_ESIMD_IMAGE);
 }
 
 } // namespace pi

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -565,11 +565,20 @@ void DeviceBinaryImage::PropertyRange::init(pi_device_binary Bin,
   End = Begin ? PS->PropertiesEnd : nullptr;
 }
 
-bool DeviceBinaryImage::isBoolPropertyTrue(const char *PropName) const {
+pi_device_binary_property
+DeviceBinaryImage::getProperty(const char *PropName) const {
   DeviceBinaryImage::PropertyRange BoolProp;
-  BoolProp.init(Bin, PropName);
-  return BoolProp.isAvailable() &&
-         pi::DeviceBinaryProperty(*(BoolProp.begin())).asUint32();
+  BoolProp.init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_MISC_PROP);
+  if (!BoolProp.isAvailable())
+    return nullptr;
+  auto It = std::find_if(BoolProp.begin(), BoolProp.end(),
+                         [=](pi_device_binary_property Prop) {
+                           return !strcmp(PropName, Prop->Name);
+                         });
+  if (It == BoolProp.end())
+    return nullptr;
+
+  return *It;
 }
 
 RT::PiDeviceBinaryType getBinaryImageFormat(const unsigned char *ImgData,


### PR DESCRIPTION
This PR introduces a new category for general properties of device binary images. And it adds an API to retrieve properties from that common category.