### PR TITLE
[SYCL] Add -vc-codegen compile option for ESIMD images

### DIFF
--- a/llvm/include/llvm/Support/PropertySetIO.h
+++ b/llvm/include/llvm/Support/PropertySetIO.h
@@ -187,6 +187,7 @@ public:
       "SYCL/composite specialization constants";
   static constexpr char SYCL_DEVICELIB_REQ_MASK[] = "SYCL/devicelib req mask";
   static constexpr char SYCL_KERNEL_PARAM_OPT_INFO[] = "SYCL/kernel param opt";
+  static constexpr char SYCL_IS_ESIMD_IMAGE[] = "SYCL/is ESIMD image";
 
   // Function for bulk addition of an entire property set under given category
   // (property set name).

--- a/llvm/lib/Support/PropertySetIO.cpp
+++ b/llvm/lib/Support/PropertySetIO.cpp
@@ -197,6 +197,7 @@ constexpr char PropertySetRegistry::SYCL_SPECIALIZATION_CONSTANTS[];
 constexpr char PropertySetRegistry::SYCL_DEVICELIB_REQ_MASK[];
 constexpr char PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO[];
 constexpr char PropertySetRegistry::SYCL_COMPOSITE_SPECIALIZATION_CONSTANTS[];
+constexpr char PropertySetRegistry::SYCL_IS_ESIMD_IMAGE[];
 
 } // namespace util
 } // namespace llvm

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/basic-sycl-esimd-split.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/basic-sycl-esimd-split.ll
@@ -2,9 +2,11 @@
 ; RUN: FileCheck %s -input-file=%t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-SYCL-IR
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-ESIMD-IR
+; RUN: FileCheck %s -input-file=%t_0.prop --check-prefixes CHECK-SYCL-PROP
+; RUN: FileCheck %s -input-file=%t_esimd_0.prop --check-prefixes CHECK-ESIMD-PROP
 
-; This is basic test of splitting SYCL and ESIMD kernels into separate
-; modules.
+; This is basic test of splitting SYCL and ESIMD kernels into separate modules.
+; ESIMD module should have isEsimdImage=1 property set after splitting.
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux-sycldevice"
@@ -41,5 +43,11 @@ attributes #0 = { "sycl-module-id"="a.cpp" }
 ; CHECK-SYCL-IR-DAG: define dso_local spir_kernel void @SYCL_kernel()
 ; CHECK-SYCL-IR-DAG: declare dso_local spir_func i64 @_Z28__spirv_GlobalInvocationId_xv()
 
+; CHECK-SYCL-PROP-NOT: [SYCL/is ESIMD image]
+; CHECK-SYCL-PROP-NOT: isEsimdImage=1|1
+
 ; CHECK-ESIMD-IR-DAG: define dso_local spir_kernel void @ESIMD_kernel()
 ; CHECK-ESIMD-IR-DAG: declare dso_local spir_func i64 @_Z28__spirv_GlobalInvocationId_xv()
+
+; CHECK-ESIMD-PROP: [SYCL/is ESIMD image]
+; CHECK-ESIMD-PROP: isEsimdImage=1|1

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -586,6 +586,13 @@ static string_vector saveDeviceImageProperty(
             NameInfoPair.first, llvm::util::PropertyValue(Data, DataBitSize)));
       }
     }
+
+    if (ImgPSInfo.IsEsimdKernel) {
+      std::map<StringRef, bool> RMEntry = {{"isEsimdImage", true}};
+      PropSet.add(llvm::util::PropertySetRegistry::SYCL_IS_ESIMD_IMAGE,
+                  RMEntry);
+    }
+
     std::error_code EC;
     std::string SCFile =
         makeResultFileName(".prop", I, ImgPSInfo.IsEsimdKernel ? "esimd_" : "");

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -670,6 +670,8 @@ static const uint8_t PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL = 4;
 #define __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK "SYCL/devicelib req mask"
 /// PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO defined in PropertySetIO.h
 #define __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO "SYCL/kernel param opt"
+/// PropertySetRegistry::SYCL_IS_ESIMD_IMAGE defined in PropertySetIO.h
+#define __SYCL_PI_PROPERTY_SET_SYCL_IS_ESIMD_IMAGE "SYCL/is ESIMD image"
 
 /// This struct is a record of the device binary information. If the Kind field
 /// denotes a portable binary type (SPIR-V or LLVM IR), the DeviceTargetSpec

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -320,6 +320,7 @@ public:
   const PropertyRange &getKernelParamOptInfo() const {
     return KernelParamOptInfo;
   }
+  const PropertyRange &getSyclIsEsimdImage() const { return SyclIsEsimdImage; }
   virtual ~DeviceBinaryImage() {}
 
 protected:
@@ -332,6 +333,7 @@ protected:
   DeviceBinaryImage::PropertyRange CompositeSpecConstIDMap;
   DeviceBinaryImage::PropertyRange DeviceLibReqMask;
   DeviceBinaryImage::PropertyRange KernelParamOptInfo;
+  DeviceBinaryImage::PropertyRange SyclIsEsimdImage;
 };
 
 /// Tries to determine the device binary image foramat. Returns

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -603,6 +603,7 @@ void DeviceBinaryImage::init(pi_device_binary Bin) {
                                __SYCL_PI_PROPERTY_SET_COMPOSITE_SPEC_CONST_MAP);
   DeviceLibReqMask.init(Bin, __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK);
   KernelParamOptInfo.init(Bin, __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
+  SyclIsEsimdImage.init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_IS_ESIMD_IMAGE);
 }
 
 } // namespace pi

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -391,15 +391,10 @@ RT::PiProgram ProgramManager::getBuiltPIProgram(OSModuleHandle M,
       DeviceLibReqMask = getDeviceLibReqMask(Img);
 
     std::string CompileOpts = Img.getCompileOptions();
-    if (Img.getSyclIsEsimdImage().isAvailable()) {
-      bool IsEsimdImage =
-          pi::DeviceBinaryProperty(*(Img.getSyclIsEsimdImage().begin()))
-              .asUint32();
-      if (IsEsimdImage) {
-        if (!CompileOpts.empty())
-          CompileOpts += " ";
-        CompileOpts += "-vc-codegen";
-      }
+    if (Img.isBoolPropertyTrue(__SYCL_PI_PROPERTY_SET_SYCL_IS_ESIMD_IMAGE)) {
+      if (!CompileOpts.empty())
+        CompileOpts += " ";
+      CompileOpts += "-vc-codegen";
     }
 
     ProgramPtr BuiltProgram =

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -390,8 +390,20 @@ RT::PiProgram ProgramManager::getBuiltPIProgram(OSModuleHandle M,
         !SYCLConfig<SYCL_DEVICELIB_NO_FALLBACK>::get())
       DeviceLibReqMask = getDeviceLibReqMask(Img);
 
+    std::string CompileOpts = Img.getCompileOptions();
+    if (Img.getSyclIsEsimdImage().isAvailable()) {
+      bool IsEsimdImage =
+          pi::DeviceBinaryProperty(*(Img.getSyclIsEsimdImage().begin()))
+              .asUint32();
+      if (IsEsimdImage) {
+        if (!CompileOpts.empty())
+          CompileOpts += " ";
+        CompileOpts += "-vc-codegen";
+      }
+    }
+
     ProgramPtr BuiltProgram =
-        build(std::move(ProgramManaged), ContextImpl, Img.getCompileOptions(),
+        build(std::move(ProgramManaged), ContextImpl, CompileOpts,
               Img.getLinkOptions(), getRawSyclObjImpl(Device)->getHandleRef(),
               ContextImpl->getCachedLibPrograms(), DeviceLibReqMask);
 


### PR DESCRIPTION
This change is a part of 3 patches:
Patch (1/3): [new property] https://github.com/intel/llvm/pull/3072
Patch (2/3): [sycl-post-link] https://github.com/intel/llvm/pull/3073
Patch (3/3): [DPCPP RT] this PR

Please review only patch f8fdd3ce1d28701e9b2c8e05339161f1129c3adb