### PR TITLE
[SYCL] [WIP][FPGA] Improve mutual diagnostic of different work_group_size attributes

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1288,9 +1288,6 @@ def SYCLIntelMaxWorkGroupSize : InheritableAttr {
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let AdditionalMembers = [{
-    ArrayRef<const Expr *> dimensions() const {
-      return {getXDim(), getYDim(), getZDim()};
-    }
     Optional<llvm::APSInt> getXDimVal(ASTContext &Ctx) const {
       return getXDim()->getIntegerConstantExpr(Ctx);
     }
@@ -2844,9 +2841,6 @@ def ReqdWorkGroupSize : InheritableAttr {
               ExprArgument<"ZDim", /*optional*/1>];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let AdditionalMembers = [{
-    ArrayRef<const Expr *> dimensions() const {
-      return {getXDim(), getYDim(), getZDim()};
-    }
     Optional<llvm::APSInt> getXDimVal(ASTContext &Ctx) const {
       return getXDim()->getIntegerConstantExpr(Ctx);
     }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2993,7 +2993,7 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
   };
 
   if (AL.getKind() == ParsedAttr::AT_SYCLIntelMaxWorkGroupSize)
-     S.CheckDeprecatedSYCLAttributeSpelling(AL);
+    S.CheckDeprecatedSYCLAttributeSpelling(AL);
 
   if (AL.getKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim) {
     // in case of 'max_global_work_dim' attribute equals to 0 we should be sure
@@ -3021,17 +3021,16 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
     // <= max_work_group_size attribute value
     if (const auto *A = D->getAttr<SYCLIntelMaxGlobalWorkDimAttr>()) {
       int64_t AttrValue =
-      A->getValue()->getIntegerConstantExpr(S.Context)->getSExtValue();
+          A->getValue()->getIntegerConstantExpr(S.Context)->getSExtValue();
       if (AttrValue == 0) {
         if (!((getExprValue(AL.getArgAsExpr(0), S.getASTContext()) == 1) &&
-             (getExprValue(AL.getArgAsExpr(1), S.getASTContext()) == 1) &&
-             (getExprValue(AL.getArgAsExpr(2), S.getASTContext()) == 1))) {
+              (getExprValue(AL.getArgAsExpr(1), S.getASTContext()) == 1) &&
+              (getExprValue(AL.getArgAsExpr(2), S.getASTContext()) == 1))) {
           S.Diag(AL.getLoc(), diag::err_sycl_x_y_z_arguments_must_be_one)
-               << AL << A;
+              << AL << A;
         }
       }
-    } else if (const auto *A =
-               D->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
+    } else if (const auto *A = D->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
       if (!((getExprValue(AL.getArgAsExpr(0), S.getASTContext()) <=
              getExprValue(A->getXDim(), S.getASTContext())) &&
             (getExprValue(AL.getArgAsExpr(1), S.getASTContext()) <=
@@ -3040,7 +3039,7 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
              getExprValue(A->getZDim(), S.getASTContext())))) {
         S.Diag(AL.getLoc(), diag::err_conflicting_sycl_function_attributes)
             << AL << A->getSpelling();
-	D->setInvalidDecl();
+        D->setInvalidDecl();
         return false;
       }
     }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2996,9 +2996,9 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
     S.CheckDeprecatedSYCLAttributeSpelling(AL);
 
   if (AL.getKind() == ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim) {
-    // in case of 'max_global_work_dim' attribute equals to 0 we should be sure
-    // that if max_work_group_size and reqd_work_group_size attributes exist,
-    // then they are equal (1, 1, 1)
+    // In case the value of 'max_global_work_dim' attribute equals to 0
+    // we shall ensure that if max_work_group_size and reqd_work_group_size
+    // attributes exist, they hold equal values (1, 1, 1).
     if (const auto *A = D->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
       if (getExprValue(A->getXDim(), S.getASTContext()) != 1 ||
           getExprValue(A->getYDim(), S.getASTContext()) != 1 ||

--- a/clang/test/SemaSYCL/intel-max-global-work-dim-device.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim-device.cpp
@@ -55,6 +55,14 @@ struct TRIFuncObjBad {
   void
   operator()() const {}
 };
+struct TRIFuncObjBad1 {
+  [[intel::max_work_group_size(8, 8, 8)]] // expected-error{{'max_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
+  [[cl::reqd_work_group_size(4, 4, 4)]]   // expected-error{{'reqd_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
+  [[intel::max_global_work_dim(0)]]
+  void
+  operator()() const {}
+};
+
 #endif // TRIGGER_ERROR
 
 int main() {
@@ -115,7 +123,9 @@ int main() {
 
     h.single_task<class test_kernel8>(TRIFuncObjBad());
 
-    h.single_task<class test_kernel9>(
+    h.single_task<class test_kernel9>(TRIFuncObjBad1());
+
+    h.single_task<class test_kernel10>(
         []() [[intel::max_global_work_dim(4)]]{}); // expected-error{{'max_global_work_dim' attribute requires integer constant between 0 and 3 inclusive}}
 #endif // TRIGGER_ERROR
   });

--- a/clang/test/SemaSYCL/intel-max-global-work-dim-device.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim-device.cpp
@@ -58,8 +58,7 @@ struct TRIFuncObjBad {
 struct TRIFuncObjBad1 {
   [[intel::max_work_group_size(8, 8, 8)]] // expected-error{{'max_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
   [[cl::reqd_work_group_size(4, 4, 4)]]   // expected-error{{'reqd_work_group_size' X-, Y- and Z- sizes must be 1 when 'max_global_work_dim' attribute is used with value 0}}
-  [[intel::max_global_work_dim(0)]]
-  void
+  [[intel::max_global_work_dim(0)]] void
   operator()() const {}
 };
 


### PR DESCRIPTION
This patch modifies function "checkWorkGroupSizeValues()" that is used to check
correctness of mutual usage of different work_group_size attributes to handle
new test case where the value of 'max_global_work_dim' attribute
equals to 0, we shall ensure that if max_work_group_size and
reqd_work_group_size attributes exist, they hold equal values (1, 1, 1).

Before the current patch, we silently accepeted this test case:

struct TRIFuncObjBad1 {
  [[intel::max_work_group_size(8, 8, 8)]]
  [[cl::reqd_work_group_size(4, 4, 4)]]
  [[intel::max_global_work_dim(0)]]
  void
  operator()() const {}
};

I noticed this problem while working on unifying OpenCL/SYCL attribute
spelling for work_group_size attributes.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>