### PR TITLE
[NFC][SYCL][Doc] Fix dependencies installation documentation

### DIFF
--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -18,8 +18,8 @@ intel_sycl_ver=build
 tbb_ver=2021.1.053
 # https://github.com/oneapi-src/oneTBB/releases/download/v2021.1.1/oneapi-tbb-2021.1.1-win.zip
 tbb_ver_win=2021.1.049
-# https://github.com/intel/llvm/releases/download/2020-WW45/fpgaemu-2020.11.11.0.04_rel.tar.gz
 
+# https://github.com/intel/llvm/releases/download/2020-WW45/fpgaemu-2020.11.11.0.04_rel.tar.gz
 ocl_fpga_emu_ver=2020.11.11.0.04
 # https://github.com/intel/llvm/releases/download/2020-WW45/win-fpgaemu-2020.11.11.0.04_rel.zip
 ocl_fpga_emu_ver_win=2020.11.11.0.04

--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -10,12 +10,16 @@ ocl_gpu_rt_ver=21.02.18820
 # https://downloadmirror.intel.com/30066/a08/igfx_win10_100.9030.zip
 ocl_gpu_rt_ver_win=27.20.100.9030
 intel_sycl_ver=build
-# https://github.com/oneapi-src/oneTBB/releases/download/v2021.1-beta10/oneapi-tbb-2021.1-beta10-lin.tgz
-tbb_ver=2021.1.053
-# Binaries can be built from sources following instructions under:
+
+# TBB binaries can be built from sources following instructions under
 # https://github.com/oneapi-src/oneTBB/blob/master/cmake/README.md
+# or downloaded using links below:
+# https://github.com/oneapi-src/oneTBB/releases/download/v2021.1.1/oneapi-tbb-2021.1.1-lin.tgz
+tbb_ver=2021.1.053
+# https://github.com/oneapi-src/oneTBB/releases/download/v2021.1.1/oneapi-tbb-2021.1.1-win.zip
 tbb_ver_win=2021.1.049
 # https://github.com/intel/llvm/releases/download/2020-WW45/fpgaemu-2020.11.11.0.04_rel.tar.gz
+
 ocl_fpga_emu_ver=2020.11.11.0.04
 # https://github.com/intel/llvm/releases/download/2020-WW45/win-fpgaemu-2020.11.11.0.04_rel.zip
 ocl_fpga_emu_ver_win=2020.11.11.0.04

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -207,12 +207,14 @@ run the following commands
       /etc/OpenCL/vendors/intel_expcpu.icd
     ```
 
-3) Extract TBB libraries. For example, for the archive tbb-<tbb_version>-lin.tgz
+3) Extract or build TBB libraries using links in
+[the dependency configuration file](../../buildbot/dependency.conf). For example,
+for the archive oneapi-tbb-<tbb_version>-lin.tgz:
 
     ```bash
-    mkdir -p /opt/intel/tbb_<tbb_version>
-    cd /opt/intel/tbb_<tbb_version>
-    tar -zxvf tbb*lin.tgz
+    mkdir -p /opt/intel
+    cd /opt/intel
+    tar -zxvf oneapi-tbb*lin.tgz
     ```
 
 4) Copy files from or create symbolic links to TBB libraries in OpenCL RT
@@ -220,22 +222,22 @@ folder:
 
     ```bash
     # OpenCL FPGA emulation RT
-    ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so
+    ln -s /opt/intel/oneapi-tbb-<tbb_version>/lib/intel64/gcc4.8/libtbb.so
       /opt/intel/oclfpgaemu_<fpga_version>/x64
-    ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so
+    ln -s /opt/intel/oneapi-tbb-<tbb_version>/lib/intel64/gcc4.8/libtbbmalloc.so
       /opt/intel/oclfpgaemu_<fpga_version>/x64
-    ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so.12
+    ln -s /opt/intel/oneapi-tbb-<tbb_version>/lib/intel64/gcc4.8/libtbb.so.12
       /opt/intel/oclfpgaemu_<fpga_version>/x64
-    ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so.2
+    ln -s /opt/intel/oneapi-tbb-<tbb_version>/lib/intel64/gcc4.8/libtbbmalloc.so.2
       /opt/intel/oclfpgaemu_<fpga_version>/x64
     # OpenCL CPU RT
-    ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so
+    ln -s /opt/intel/oneapi-tbb-<tbb_version>/lib/intel64/gcc4.8/libtbb.so
       /opt/intel/oclcpuexp_<cpu_version>/x64
-    ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so
+    ln -s /opt/intel/oneapi-tbb-<tbb_version>/lib/intel64/gcc4.8/libtbbmalloc.so
       /opt/intel/oclcpuexp_<cpu_version>/x64
-    ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbb.so.12
+    ln -s /opt/intel/oneapi-tbb-<tbb_version>/lib/intel64/gcc4.8/libtbb.so.12
       /opt/intel/oclcpuexp_<cpu_version>/x64
-    ln -s /opt/intel/tbb_<tbb_version>/tbb/lib/intel64/gcc4.8/libtbbmalloc.so.2
+    ln -s /opt/intel/oneapi-tbb-<tbb_version>/lib/intel64/gcc4.8/libtbbmalloc.so.2
       /opt/intel/oclcpuexp_<cpu_version>/x64
     ```
 
@@ -262,9 +264,9 @@ not working properly.
 [the dependency configuration file](../../buildbot/dependency.conf).  For
 example, to `c:\oclcpu_rt_<cpu_version>`.
 
-3) Extract the archive with TBB runtime using links in
-[the dependency configuration file](../../buildbot/dependency.conf).  For
-example, to `c:\tbb_<tbb_version>`.
+3) Extract the archive with TBB runtime or build it from sources using links
+in [the dependency configuration file](../../buildbot/dependency.conf).  For
+example, to `c:\oneapi-tbb-<tbb_version>`.
 
 4) Run `Command Prompt` as `Administrator`. To do that click `Start` button,
 type `Command Prompt`, click the Right mouse button on it, then click
@@ -278,10 +280,10 @@ command:
     ```bash
     # Install OpenCL FPGA emulation RT
     # Answer N to clean previous OCL_ICD_FILENAMES configuration
-    c:\oclfpga_rt_<fpga_version>\install.bat c:\tbb_<tbb_version>\tbb\bin\intel64\vc14
+    c:\oclfpga_rt_<fpga_version>\install.bat c:\oneapi-tbb-<tbb_version>\redist\intel64\vc14
     # Install OpenCL CPU RT
     # Answer Y to setup CPU RT side-bi-side with FPGA RT
-    c:\oclcpu_rt_<cpu_version>\install.bat c:\tbb_<tbb_version>\tbb\bin\intel64\vc14
+    c:\oclcpu_rt_<cpu_version>\install.bat c:\oneapi-tbb-<tbb_version>\redist\intel64\vc14
     ```
 
 ### Obtain prerequisites for ahead of time (AOT) compilation


### PR DESCRIPTION
 - Fix TBB links to point to Gold Release binaries;
 - Align with Gold release by fixing directory structure and
   directory/archive naming scheme;
 - Mention possibility to build TBB RT from sources in GetStartedGuide.md

That change also fixes #3077.