### PR TITLE
[SYCL] Update tests with new test cases for FPGA function attributes 

### DIFF
--- a/clang/test/CodeGenSYCL/intel-max-global-work-dim.cpp
+++ b/clang/test/CodeGenSYCL/intel-max-global-work-dim.cpp
@@ -16,6 +16,9 @@ public:
   [[intel::max_global_work_dim(SIZE)]] void operator()() const {}
 };
 
+template <int N>
+[[intel::max_global_work_dim(N)]] void func() {}
+
 int main() {
   q.submit([&](handler &h) {
     Foo boo;
@@ -26,6 +29,10 @@ int main() {
 
     Functor<2> f;
     h.single_task<class kernel_name3>(f);
+
+    h.single_task<class kernel_name4>([]() {
+      func<2>();
+    });
   });
   return 0;
 }
@@ -33,5 +40,6 @@ int main() {
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name1"() #0 {{.*}} !max_global_work_dim ![[NUM1:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name2"() #0 {{.*}} !max_global_work_dim ![[NUM2:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name3"() #0 {{.*}} !max_global_work_dim ![[NUM2]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4"() #0 {{.*}} !max_global_work_dim ![[NUM2]]
 // CHECK: ![[NUM1]] = !{i32 1}
 // CHECK: ![[NUM2]] = !{i32 2}

--- a/clang/test/CodeGenSYCL/num-simd-work-items.cpp
+++ b/clang/test/CodeGenSYCL/num-simd-work-items.cpp
@@ -16,6 +16,9 @@ public:
   [[intel::num_simd_work_items(SIZE)]] void operator()() const {}
 };
 
+template <int N>
+[[intel::num_simd_work_items(N)]] void func() {}
+
 int main() {
   q.submit([&](handler &h) {
     Foo boo;
@@ -26,6 +29,10 @@ int main() {
 
     Functor<2> f;
     h.single_task<class kernel_name3>(f);
+
+    h.single_task<class kernel_name4>([]() {
+      func<4>();
+    });
   });
   return 0;
 }
@@ -33,6 +40,8 @@ int main() {
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name1"() #0 {{.*}} !num_simd_work_items ![[NUM1:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name2"() #0 {{.*}} !num_simd_work_items ![[NUM42:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name3"() #0 {{.*}} !num_simd_work_items ![[NUM2:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4"() #0 {{.*}} !num_simd_work_items ![[NUM4:[0-9]+]]
 // CHECK: ![[NUM1]] = !{i32 1}
 // CHECK: ![[NUM42]] = !{i32 42}
 // CHECK: ![[NUM2]] = !{i32 2}
+// CHECK: ![[NUM4]] = !{i32 4}

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
@@ -25,6 +25,9 @@ public:
   [[intel::reqd_sub_group_size(SIZE)]] void operator()() const {}
 };
 
+template <int N>
+[[intel::reqd_sub_group_size(N)]] void func() {}
+
 int main() {
   q.submit([&](handler &h) {
     Functor16 f16;
@@ -38,6 +41,10 @@ int main() {
 
     Functor2<2> f2;
     h.single_task<class kernel_name4>(f2);
+
+    h.single_task<class kernel_name5>([]() {
+      func<2>();
+    });
   });
   return 0;
 }
@@ -46,6 +53,7 @@ int main() {
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name2"() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE8:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name3"() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE4:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4"() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE2:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name5"() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE2]]
 // CHECK: ![[SGSIZE16]] = !{i32 16}
 // CHECK: ![[SGSIZE8]] = !{i32 8}
 // CHECK: ![[SGSIZE4]] = !{i32 4}

--- a/clang/test/SemaSYCL/sycl-device-intel-max-global-work-dim-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-max-global-work-dim-template.cpp
@@ -5,13 +5,17 @@
 // Test that checks wrong function template instantiation and ensures that the type
 // is checked properly when instantiating from the template definition.
 template <typename Ty>
-// expected-error@+1{{'max_global_work_dim' attribute requires an integer constant}}
+// expected-error@+1 2{{'max_global_work_dim' attribute requires an integer constant}}
 [[intel::max_global_work_dim(Ty{})]] void func() {}
 
 struct S {};
-void var() {
+void test() {
   //expected-note@+1{{in instantiation of function template specialization 'func<S>' requested here}}
   func<S>();
+  //expected-note@+1{{in instantiation of function template specialization 'func<float>' requested here}}
+  func<float>();
+  // no error expected
+  func<int>(); // OK
 }
 
 // Test that checks expression is not a constant expression.
@@ -48,10 +52,14 @@ int main() {
 
 // Test that checks template parameter support on function.
 template <int N>
+// expected-error@+1{{'max_global_work_dim' attribute requires a non-negative integral compile time constant expression}}
 [[intel::max_global_work_dim(N)]] void func3() {}
 
 int check() {
+  // no error expected
   func3<2>();
+  //expected-note@+1{{in instantiation of function template specialization 'func3<-1>' requested here}}
+  func3<-1>();
   return 0;
 }
 

--- a/clang/test/SemaSYCL/sycl-device-intel-max-global-work-dim-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-max-global-work-dim-template.cpp
@@ -23,7 +23,7 @@ int foo();
 constexpr int bar() { return 0; }
 [[intel::max_global_work_dim(bar() + 2)]] void func2(); // OK
 
-// Test that checks template parameter suppport on member function of class template.
+// Test that checks template parameter support on member function of class template.
 template <int SIZE>
 class KernelFunctor {
 public:

--- a/clang/test/SemaSYCL/sycl-device-intel-max-work-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-max-work-group-size-template.cpp
@@ -24,7 +24,7 @@ int foo();
 constexpr int bar() { return 0; }
 [[intel::max_work_group_size(bar() + 12, bar() + 12, bar() + 12)]] void func2(); // OK
 
-// Test that checks template parameter suppport on member function of class template.
+// Test that checks template parameter support on member function of class template.
 template <int SIZE, int SIZE1, int SIZE2>
 class KernelFunctor {
 public:

--- a/clang/test/SemaSYCL/sycl-device-intel-reqd-work-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-reqd-work-group-size-template.cpp
@@ -24,7 +24,7 @@ int foo();
 constexpr int bar() { return 0; }
 [[intel::reqd_work_group_size(bar() + 12, bar() + 12, bar() + 12)]] void func2(); // OK
 
-// Test that checks template parameter suppport on member function of class template.
+// Test that checks template parameter support on member function of class template.
 template <int SIZE, int SIZE1, int SIZE2>
 class KernelFunctor {
 public:

--- a/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
@@ -2,6 +2,28 @@
 
 // Test that checkes template parameter support for 'num_simd_work_items' attribute on sycl device.
 
+// Test that checks wrong function template instantiation and ensures that the type
+// is checked properly when instantiating from the template definition.
+template <typename Ty>
+// expected-error@+1{{'num_simd_work_items' attribute requires an integer constant}}
+[[intel::num_simd_work_items(Ty{})]] void func() {}
+
+struct S {};
+void var() {
+  //expected-note@+1{{in instantiation of function template specialization 'func<S>' requested here}}
+  func<S>();
+}
+
+// Test that checks expression is not a constant expression.
+int foo();
+// expected-error@+1{{'num_simd_work_items' attribute requires an integer constant}}
+[[intel::num_simd_work_items(foo() + 12)]] void func1();
+
+// Test that checks expression is a constant expression.
+constexpr int bar() { return 0; }
+[[intel::num_simd_work_items(bar() + 12)]] void func2(); // OK
+
+// Test that checks template parameter suppport on member function of class template.
 template <int SIZE>
 class KernelFunctor {
 public:
@@ -23,3 +45,20 @@ int main() {
 // CHECK: SubstNonTypeTemplateParmExpr {{.*}}
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}10{{$}}
+
+// Test that checks template parameter support on function.
+template <int N>
+[[intel::num_simd_work_items(N)]] void func3() {}
+
+int check() {
+  func3<8>();
+  return 0;
+}
+
+// CHECK: FunctionTemplateDecl {{.*}} {{.*}} func3
+// CHECK: NonTypeTemplateParmDecl {{.*}} {{.*}} referenced 'int' depth 0 index 0 N
+// CHECK: FunctionDecl {{.*}} {{.*}} func3 'void ()'
+// CHECK: SYCLIntelNumSimdWorkItemsAttr {{.*}}
+// CHECK: SubstNonTypeTemplateParmExpr {{.*}}
+// CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}

--- a/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
@@ -23,7 +23,7 @@ int foo();
 constexpr int bar() { return 0; }
 [[intel::num_simd_work_items(bar() + 12)]] void func2(); // OK
 
-// Test that checks template parameter suppport on member function of class template.
+// Test that checks template parameter support on member function of class template.
 template <int SIZE>
 class KernelFunctor {
 public:

--- a/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
@@ -5,13 +5,18 @@
 // Test that checks wrong function template instantiation and ensures that the type
 // is checked properly when instantiating from the template definition.
 template <typename Ty>
-// expected-error@+1{{'num_simd_work_items' attribute requires an integer constant}}
+// expected-error@+2{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
+// expected-error@+1 2{{'num_simd_work_items' attribute requires an integer constant}}
 [[intel::num_simd_work_items(Ty{})]] void func() {}
 
 struct S {};
-void var() {
+void test() {
   //expected-note@+1{{in instantiation of function template specialization 'func<S>' requested here}}
   func<S>();
+  //expected-note@+1{{in instantiation of function template specialization 'func<float>' requested here}}
+  func<float>();
+  //expected-note@+1{{in instantiation of function template specialization 'func<int>' requested here}}
+  func<int>();
 }
 
 // Test that checks expression is not a constant expression.
@@ -36,6 +41,7 @@ int main() {
   KernelFunctor<-1>();
   // no error expected
   KernelFunctor<10>();
+  return 0;
 }
 
 // CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
@@ -48,10 +54,14 @@ int main() {
 
 // Test that checks template parameter support on function.
 template <int N>
+// expected-error@+1{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 [[intel::num_simd_work_items(N)]] void func3() {}
 
 int check() {
+  // no error expected
   func3<8>();
+  //expected-note@+1{{in instantiation of function template specialization 'func3<-1>' requested here}}
+  func3<-1>();
   return 0;
 }
 

--- a/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
@@ -23,7 +23,7 @@ int foo();
 constexpr int bar() { return 0; }
 [[intel::reqd_sub_group_size(bar() + 12)]] void func2(); // OK
 
-// Test that checks template parameter suppport on member function of class template.
+// Test that checks template parameter support on member function of class template.
 template <int SIZE>
 class KernelFunctor {
 public:

--- a/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
@@ -5,13 +5,18 @@
 // Test that checks wrong function template instantiation and ensures that the type
 // is checked properly when instantiating from the template definition.
 template <typename Ty>
-// expected-error@+1{{'reqd_sub_group_size' attribute requires an integer constant}}
+// expected-error@+2{{'reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
+// expected-error@+1 2{{'reqd_sub_group_size' attribute requires an integer constant}}
 [[intel::reqd_sub_group_size(Ty{})]] void func() {}
 
 struct S {};
-void var() {
+void test() {
   //expected-note@+1{{in instantiation of function template specialization 'func<S>' requested here}}
   func<S>();
+  //expected-note@+1{{in instantiation of function template specialization 'func<float>' requested here}}
+  func<float>();
+  //expected-note@+1{{in instantiation of function template specialization 'func<int>' requested here}}
+  func<int>();
 }
 
 // Test that checks expression is not a constant expression.
@@ -36,6 +41,7 @@ int main() {
   KernelFunctor<-1>();
   // no error expected
   KernelFunctor<10>();
+  return 0;
 }
 
 // CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
@@ -48,10 +54,14 @@ int main() {
 
 // Test that checks template parameter support on function.
 template <int N>
+// expected-error@+1{{'reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
 [[intel::reqd_sub_group_size(N)]] void func3() {}
 
 int check() {
+  // no error expected
   func3<12>();
+  //expected-note@+1{{in instantiation of function template specialization 'func3<-1>' requested here}}
+  func3<-1>();
   return 0;
 }
 

--- a/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
@@ -2,6 +2,28 @@
 
 // Test that checkes template parameter support for 'reqd_sub_group_size' attribute on sycl device.
 
+// Test that checks wrong function template instantiation and ensures that the type
+// is checked properly when instantiating from the template definition.
+template <typename Ty>
+// expected-error@+1{{'reqd_sub_group_size' attribute requires an integer constant}}
+[[intel::reqd_sub_group_size(Ty{})]] void func() {}
+
+struct S {};
+void var() {
+  //expected-note@+1{{in instantiation of function template specialization 'func<S>' requested here}}
+  func<S>();
+}
+
+// Test that checks expression is not a constant expression.
+int foo();
+// expected-error@+1{{'reqd_sub_group_size' attribute requires an integer constant}}
+[[intel::reqd_sub_group_size(foo() + 12)]] void func1();
+
+// Test that checks expression is a constant expression.
+constexpr int bar() { return 0; }
+[[intel::reqd_sub_group_size(bar() + 12)]] void func2(); // OK
+
+// Test that checks template parameter suppport on member function of class template.
 template <int SIZE>
 class KernelFunctor {
 public:
@@ -23,3 +45,20 @@ int main() {
 // CHECK: SubstNonTypeTemplateParmExpr {{.*}}
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}10{{$}}
+
+// Test that checks template parameter support on function.
+template <int N>
+[[intel::reqd_sub_group_size(N)]] void func3() {}
+
+int check() {
+  func3<12>();
+  return 0;
+}
+
+// CHECK: FunctionTemplateDecl {{.*}} {{.*}} func3
+// CHECK: NonTypeTemplateParmDecl {{.*}} {{.*}} referenced 'int' depth 0 index 0 N
+// CHECK: FunctionDecl {{.*}} {{.*}} func3 'void ()'
+// CHECK: IntelReqdSubGroupSizeAttr {{.*}}
+// CHECK: SubstNonTypeTemplateParmExpr {{.*}}
+// CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}12{{$}}

--- a/clang/test/SemaSYCL/sycl-device-reqd-work-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-work-group-size-template.cpp
@@ -24,7 +24,7 @@ int foo();
 constexpr int bar() { return 0; }
 [[cl::reqd_work_group_size(bar() + 12, bar() + 12, bar() + 12)]] void func2(); // OK
 
-// Test that checks template parameter suppport on member function of class template.
+// Test that checks template parameter support on member function of class template.
 template <int SIZE, int SIZE1, int SIZE2>
 class KernelFunctor {
 public:


### PR DESCRIPTION
Template parameter support was added for

 1. [[intel::max_global_work_dim)]] attribute on https://github.com/intel/llvm/pull/2816
 2. [[intel::num_simd_work_items()]] attribute on https://github.com/intel/llvm/pull/2510
 3. [[intel::reqd_sub_group_size()]] attribute on https://github.com/intel/llvm/pull/1807

This patch adds the following new test cases that were not there before to verify/improve the template support:

 1. Test that checks wrong function template instantiation and ensures that the type
    is checked properly when instantiating from the template definition.
 2. Test that checks expression is not a constant expression.
 3. Test that checks expression is a constant expression.
 4. Test that checks template parameter support on function.

NOTE: No change in compiler. All new test cases have already been supported.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>