### PR TITLE
[SYCL] Join thread pool threads on Scheduler destruction

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -366,6 +366,12 @@ public:
     return *MHostTaskThreadPool;
   }
 
+  void stopThreadPool() {
+    if (MHostTaskThreadPool) {
+      MHostTaskThreadPool->finishAndWait();
+    }
+  }
+
   /// Gets the native handle of the SYCL queue.
   ///
   /// \return a native handle.

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -306,6 +306,7 @@ Scheduler::Scheduler() {
 }
 
 Scheduler::~Scheduler() {
+  DefaultHostQueue->stopThreadPool();
   // By specification there are several possible sync points: buffer
   // destruction, wait() method of a queue or event. Stream doesn't introduce
   // any synchronization point. It is guaranteed that stream is flushed and


### PR DESCRIPTION
Threads from default queue thread pool can access scheduler after its destruction has begun.
To avoid such illegal access, wait for all threads to join in scheduler destructor.