### PR TITLE
[SYCL][NFC] Fix typos in test code comments

### DIFF
--- a/clang/test/SemaSYCL/sycl-device-intel-max-work-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-max-work-group-size-template.cpp
@@ -38,7 +38,7 @@ int main() {
 // CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
 // CHECK: ClassTemplateSpecializationDecl {{.*}} {{.*}} class KernelFunctor definition
 // CHECK: CXXRecordDecl {{.*}} {{.*}} implicit class KernelFunctor
-// SYCLIntelMaxWorkGroupSizeAttr {{.*}}
+// CHECK: SYCLIntelMaxWorkGroupSizeAttr {{.*}}
 // CHECK: SubstNonTypeTemplateParmExpr {{.*}}
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
@@ -49,7 +49,7 @@ int main() {
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
 
-// Test that checks template parameter suppport on function.
+// Test that checks template parameter support on function.
 template <int N, int N1, int N2>
 [[intel::max_work_group_size(N, N1, N2)]] void func3() {}
 
@@ -61,7 +61,7 @@ int check() {
 // CHECK: FunctionTemplateDecl {{.*}} {{.*}} func3
 // CHECK: NonTypeTemplateParmDecl {{.*}} {{.*}} referenced 'int' depth 0 index 0 N
 // CHECK: FunctionDecl {{.*}} {{.*}} func3 'void ()'
-// SYCLIntelMaxWorkGroupSizeAttr {{.*}}
+// CHECK: SYCLIntelMaxWorkGroupSizeAttr {{.*}}
 // CHECK: SubstNonTypeTemplateParmExpr {{.*}}
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}

--- a/clang/test/SemaSYCL/sycl-device-intel-reqd-work-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-reqd-work-group-size-template.cpp
@@ -49,7 +49,7 @@ int main() {
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
 
-// Test that checks template parameter suppport on function.
+// Test that checks template parameter support on function.
 template <int N, int N1, int N2>
 [[intel::reqd_work_group_size(N, N1, N2)]] void func3() {}
 

--- a/clang/test/SemaSYCL/sycl-device-reqd-work-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-work-group-size-template.cpp
@@ -49,7 +49,7 @@ int main() {
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
 
-// Test that checks template parameter suppport on function.
+// Test that checks template parameter support on function.
 template <int N, int N1, int N2>
 [[cl::reqd_work_group_size(N, N1, N2)]] void func3() {}
 


### PR DESCRIPTION
This patch updates tests related to work_group_size attributes by fixing
typos and adding CHECK that happened on commit https://github.com/intel/llvm/pull/2906/

Signed-off-by: Soumi Manna <soumi.manna@intel.com>