### PR TITLE
[SYCL] Support accessors to array types

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -1512,9 +1512,17 @@ public:
     return detail::convertToArrayOfN<Dimensions, 0>(getOffset());
   }
 
-  template <int Dims = Dimensions,
-            typename = detail::enable_if_t<Dims == 0 && IsAccessAnyWrite>>
+  template <int Dims = Dimensions, typename RefT = RefType,
+            typename = detail::enable_if_t<Dims == 0 && IsAccessAnyWrite &&
+                                           !std::is_const<RefT>::value>>
   operator RefType() const {
+    const size_t LinearIndex = getLinearIndex(id<AdjustedDim>());
+    return *(getQualifiedPtr() + LinearIndex);
+  }
+
+  template <int Dims = Dimensions,
+            typename = detail::enable_if_t<Dims == 0 && IsAccessReadOnly>>
+  operator ConstRefType() const {
     const size_t LinearIndex = getLinearIndex(id<AdjustedDim>());
     return *(getQualifiedPtr() + LinearIndex);
   }
@@ -1524,13 +1532,6 @@ public:
   RefType operator[](id<Dimensions> Index) const {
     const size_t LinearIndex = getLinearIndex(Index);
     return getQualifiedPtr()[LinearIndex];
-  }
-
-  template <int Dims = Dimensions,
-            typename = detail::enable_if_t<Dims == 0 && IsAccessReadOnly>>
-  operator DataT() const {
-    const size_t LinearIndex = getLinearIndex(id<AdjustedDim>());
-    return *(getQualifiedPtr() + LinearIndex);
   }
 
   template <int Dims = Dimensions>


### PR DESCRIPTION
The patch does not break functionality guaranteed by SYCL 1.2.1.
The fix also is in accordance with SYCL 2020, which replaces 'operator DataT()'
with 'operator reference() const' and allows using accessors
to trivially_copyable arrays such as int[N].

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>