### PR TITLE
[SYCL] Fix long long support in vec::convert on Windows

### DIFF
--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -242,9 +242,8 @@ using is_float_to_float =
     std::integral_constant<bool, detail::is_floating_point<T>::value &&
                                      detail::is_floating_point<R>::value>;
 template <typename T>
-using is_standard_type = std::integral_constant<
-    bool, detail::is_sgentype<T>::value && !std::is_same<T, long long>::value &&
-              !std::is_same<T, unsigned long long>::value>;
+using is_standard_type =
+    std::integral_constant<bool, detail::is_sgentype<T>::value>;
 
 template <typename T, typename R, rounding_mode roundingMode, typename OpenCLT,
           typename OpenCLR>
@@ -330,7 +329,7 @@ convertImpl(T Value) {
             typename OpenCLT, typename OpenCLR>                                \
   detail::enable_if_t<is_sint_to_sint<T, R>::value &&                          \
                           !std::is_same<OpenCLT, OpenCLR>::value &&            \
-                          (std::is_same<OpenCLR, DestType>::value ||           \
+                          (std::is_same<OpenCLR, cl_##DestType>::value ||      \
                            (std::is_same<OpenCLR, signed char>::value &&       \
                             std::is_same<DestType, char>::value)),             \
                       R>                                                       \
@@ -352,7 +351,7 @@ __SYCL_GENERATE_CONVERT_IMPL(long)
             typename OpenCLT, typename OpenCLR>                                \
   detail::enable_if_t<is_uint_to_uint<T, R>::value &&                          \
                           !std::is_same<OpenCLT, OpenCLR>::value &&            \
-                          std::is_same<OpenCLR, DestType>::value,              \
+                          std::is_same<OpenCLR, cl_##DestType>::value,         \
                       R>                                                       \
   convertImpl(T Value) {                                                       \
     OpenCLT OpValue = cl::sycl::detail::convertDataToType<T, OpenCLT>(Value);  \
@@ -454,7 +453,7 @@ __SYCL_GENERATE_CONVERT_IMPL_FOR_ROUNDING_MODE(rtn, Rtn)
   template <typename T, typename R, rounding_mode roundingMode,                \
             typename OpenCLT, typename OpenCLR>                                \
   detail::enable_if_t<is_float_to_int<T, R>::value &&                          \
-                          (std::is_same<OpenCLR, DestType>::value ||           \
+                          (std::is_same<OpenCLR, cl_##DestType>::value ||      \
                            std::is_same<OpenCLR, signed char>::value &&        \
                                std::is_same<DestType, char>::value) &&         \
                           RoundingModeCondition<roundingMode>::value,          \

--- a/sycl/test/basic_tests/vectors/vectors.cpp
+++ b/sycl/test/basic_tests/vectors/vectors.cpp
@@ -11,9 +11,8 @@
 #define SYCL_SIMPLE_SWIZZLES
 #include <CL/sycl.hpp>
 
-void check_vectors(cl::sycl::int4 a, cl::sycl::int4 b, cl::sycl::int4 c,
-                   cl::sycl::int4 gold) {
-  cl::sycl::int4 result = a * (cl::sycl::int4)b.y() + c;
+void check_vectors(sycl::int4 a, sycl::int4 b, sycl::int4 c, sycl::int4 gold) {
+  sycl::int4 result = a * (sycl::int4)b.y() + c;
   assert((int)result.x() == (int)gold.x());
   assert((int)result.y() == (int)gold.y());
   assert((int)result.z() == (int)gold.z());
@@ -21,8 +20,8 @@ void check_vectors(cl::sycl::int4 a, cl::sycl::int4 b, cl::sycl::int4 c,
 }
 
 template <typename From, typename To> void check_convert() {
-  cl::sycl::vec<From, 4> vec{1, 2, 3, 4};
-  cl::sycl::vec<To, 4> result = vec.template convert<To>();
+  sycl::vec<From, 4> vec{1, 2, 3, 4};
+  sycl::vec<To, 4> result = vec.template convert<To>();
   assert((int)result.x() == (int)vec.x());
   assert((int)result.y() == (int)vec.y());
   assert((int)result.z() == (int)vec.z());
@@ -31,10 +30,10 @@ template <typename From, typename To> void check_convert() {
 
 template <typename From, typename To> void check_signed_unsigned_convert_to() {
   check_convert<From, To>();
-  check_convert<From, cl::sycl::detail::make_unsigned_t<To>>();
-  check_convert<cl::sycl::detail::make_unsigned_t<From>, To>();
-  check_convert<cl::sycl::detail::make_unsigned_t<From>,
-                cl::sycl::detail::make_unsigned_t<To>>();
+  check_convert<From, sycl::detail::make_unsigned_t<To>>();
+  check_convert<sycl::detail::make_unsigned_t<From>, To>();
+  check_convert<sycl::detail::make_unsigned_t<From>,
+                sycl::detail::make_unsigned_t<To>>();
 }
 
 template <typename From> void check_convert_from() {
@@ -42,16 +41,21 @@ template <typename From> void check_convert_from() {
   check_signed_unsigned_convert_to<From, int16_t>();
   check_signed_unsigned_convert_to<From, int32_t>();
   check_signed_unsigned_convert_to<From, int64_t>();
+  check_signed_unsigned_convert_to<From, char>();
+  check_signed_unsigned_convert_to<From, short>();
+  check_signed_unsigned_convert_to<From, int>();
+  check_signed_unsigned_convert_to<From, long>();
+  check_signed_unsigned_convert_to<From, long long>();
   check_signed_unsigned_convert_to<From, half>();
   check_signed_unsigned_convert_to<From, float>();
   check_signed_unsigned_convert_to<From, double>();
 }
 
 int main() {
-  cl::sycl::int4 a = {1, 2, 3, 4};
-  const cl::sycl::int4 b = {10, 20, 30, 40};
-  const cl::sycl::int4 gold = {21, 42, 90, 120};
-  const cl::sycl::int2 a_xy = a.xy();
+  sycl::int4 a = {1, 2, 3, 4};
+  const sycl::int4 b = {10, 20, 30, 40};
+  const sycl::int4 gold = {21, 42, 90, 120};
+  const sycl::int2 a_xy = a.xy();
   check_vectors(a, b, {1, 2, 30, 40}, gold);
   check_vectors(a, b, {a.x(), a.y(), b.z(), b.w()}, gold);
   check_vectors(a, b, {a.x(), 2, b.z(), 40}, gold);
@@ -60,11 +64,11 @@ int main() {
   check_vectors(a, b, {a.xy(), b.zw()}, gold);
 
   // Constructing vector from a scalar
-  cl::sycl::vec<int, 1> vec_from_one_elem(1);
+  sycl::vec<int, 1> vec_from_one_elem(1);
 
   // implicit conversion
-  cl::sycl::vec<unsigned char, 2> vec_2(1, 2);
-  cl::sycl::vec<unsigned char, 4> vec_4(0, vec_2, 3);
+  sycl::vec<unsigned char, 2> vec_2(1, 2);
+  sycl::vec<unsigned char, 4> vec_4(0, vec_2, 3);
 
   assert(vec_4.get_count() == 4);
   assert(static_cast<unsigned char>(vec_4.x()) == static_cast<unsigned char>(0));
@@ -74,10 +78,10 @@ int main() {
 
   // explicit conversion
   int64_t(vec_2.x());
-  cl::sycl::int4(vec_2.x());
+  sycl::int4(vec_2.x());
 
   // Check broadcasting operator=
-  cl::sycl::vec<float, 4> b_vec(1.0);
+  sycl::vec<float, 4> b_vec(1.0);
   b_vec = 0.5;
   assert(static_cast<float>(b_vec.x()) == static_cast<float>(0.5));
   assert(static_cast<float>(b_vec.y()) == static_cast<float>(0.5));
@@ -87,33 +91,37 @@ int main() {
   // Check that vector with 'unsigned long long' elements has enough bits to
   // store value.
   unsigned long long ull_ref = 1ull - 2ull;
-  auto ull_vec = cl::sycl::vec<unsigned long long, 1>(ull_ref);
-  unsigned long long ull_val = ull_vec.template swizzle<cl::sycl::elem::s0>();
+  auto ull_vec = sycl::vec<unsigned long long, 1>(ull_ref);
+  unsigned long long ull_val = ull_vec.template swizzle<sycl::elem::s0>();
   assert(ull_val == ull_ref);
 
   // Check that the function as() in swizzle vec class is working correctly
-  cl::sycl::vec<int8_t, 2> inputVec = cl::sycl::vec<int8_t, 2>(0, 1);
-  auto asVec =
-      inputVec.template swizzle<cl::sycl::elem::s0, cl::sycl::elem::s1>()
-          .template as<cl::sycl::vec<int16_t, 1>>();
+  sycl::vec<int8_t, 2> inputVec = sycl::vec<int8_t, 2>(0, 1);
+  auto asVec = inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1>()
+                   .template as<sycl::vec<int16_t, 1>>();
 
   // Check that [u]long[n] type aliases match vec<[unsigned] long, n> types.
-  assert((std::is_same<cl::sycl::vec<long, 2>, cl::sycl::long2>::value));
-  assert((std::is_same<cl::sycl::vec<long, 3>, cl::sycl::long3>::value));
-  assert((std::is_same<cl::sycl::vec<long, 4>, cl::sycl::long4>::value));
-  assert((std::is_same<cl::sycl::vec<long, 8>, cl::sycl::long8>::value));
-  assert((std::is_same<cl::sycl::vec<long, 16>, cl::sycl::long16>::value));
-  assert((std::is_same<cl::sycl::vec<unsigned long, 2>, cl::sycl::ulong2>::value));
-  assert((std::is_same<cl::sycl::vec<unsigned long, 3>, cl::sycl::ulong3>::value));
-  assert((std::is_same<cl::sycl::vec<unsigned long, 4>, cl::sycl::ulong4>::value));
-  assert((std::is_same<cl::sycl::vec<unsigned long, 8>, cl::sycl::ulong8>::value));
-  assert((std::is_same<cl::sycl::vec<unsigned long, 16>, cl::sycl::ulong16>::value));
+  assert((std::is_same<sycl::vec<long, 2>, sycl::long2>::value));
+  assert((std::is_same<sycl::vec<long, 3>, sycl::long3>::value));
+  assert((std::is_same<sycl::vec<long, 4>, sycl::long4>::value));
+  assert((std::is_same<sycl::vec<long, 8>, sycl::long8>::value));
+  assert((std::is_same<sycl::vec<long, 16>, sycl::long16>::value));
+  assert((std::is_same<sycl::vec<unsigned long, 2>, sycl::ulong2>::value));
+  assert((std::is_same<sycl::vec<unsigned long, 3>, sycl::ulong3>::value));
+  assert((std::is_same<sycl::vec<unsigned long, 4>, sycl::ulong4>::value));
+  assert((std::is_same<sycl::vec<unsigned long, 8>, sycl::ulong8>::value));
+  assert((std::is_same<sycl::vec<unsigned long, 16>, sycl::ulong16>::value));
 
   // Check convert() from and to various types.
   check_convert_from<int8_t>();
   check_convert_from<int16_t>();
   check_convert_from<int32_t>();
   check_convert_from<int64_t>();
+  check_convert_from<char>();
+  check_convert_from<short>();
+  check_convert_from<int>();
+  check_convert_from<long>();
+  check_convert_from<long long>();
   check_convert_from<half>();
   check_convert_from<float>();
   check_convert_from<double>();


### PR DESCRIPTION
- Keep `long long` and `unsigned long long` in `is_standard_type`.
  Excluding them resulted in duplicate `convertImpl` definitions on
  Windows when converting from `long long` or `unsigned long long`:
  SPIR-V-based and the non-standard type version.
- For to-int SPIR-V-based `convertImpl` overload resolution, compare
  the OpenCL return type with cl_DestType instead of simply DestType
  ((u)char, (u)short, (u)int, (u)long). When converting to `long long`
  or `unsigned long long` on Windows, the non-standard type version
  was used instead of these functions, because `cl_long == long long
  != long` there.