### PR TITLE
[SYCL][AOT] Enhance opencl-aot to compile or link program

### DIFF
--- a/opencl-aot/include/utils.h
+++ b/opencl-aot/include/utils.h
@@ -28,7 +28,7 @@ enum Errors : int8_t {
   OPENCL_AOT_FAILED_TO_CREATE_OPENCL_PROGRAM,
   OPENCL_AOT_FAILED_TO_CREATE_ELF,
   OPENCL_AOT_DEVICE_INFO_PARAMETER_IS_EMPTY,
-  OPENCL_AOT_LIST_OF_INPUT_BINARIES_IS_EMPTY,
+  OPENCL_AOT_LIST_OF_INPUT_FILES_IS_EMPTY,
   OPENCL_AOT_FAILED_TO_OPEN_FILE,
   OPENCL_AOT_FILE_IS_EMPTY,
   OPENCL_AOT_DEVICE_DOESNT_SUPPORT_SPIRV,
@@ -93,8 +93,12 @@ createProgramWithIL(std::vector<char> IL, cl_context Context,
 std::tuple<std::vector<char>, std::string, cl_int>
 readBinaryFile(std::string FileName);
 
+bool isFileOCLSource(const std::string &FileName);
+
 bool isFileELF(const std::vector<char> &BinaryData);
 
 bool isFileSPIRV(const std::vector<char> &BinaryData);
+
+bool isFileLLVMIR(const std::vector<char> &BinaryData);
 
 #endif /* AOT_COMP_TOOL_UTILS */

--- a/opencl-aot/source/utils.cpp
+++ b/opencl-aot/source/utils.cpp
@@ -403,6 +403,11 @@ readBinaryFile(std::string FileName) {
   return std::make_tuple(FileContent, "", CL_SUCCESS);
 }
 
+bool isFileEndsWithGivenExtentionName(const std::string &FileName,
+                                      const char *Ext) {
+  return FileName.substr(FileName.find_last_of('.')) == Ext;
+}
+
 bool isFileStartsWithGivenMagicNumber(const std::vector<char> &BinaryData,
                                       const uint32_t ExpectedMagicNumber) {
   if (BinaryData.size() < sizeof(ExpectedMagicNumber))
@@ -410,6 +415,10 @@ bool isFileStartsWithGivenMagicNumber(const std::vector<char> &BinaryData,
   const auto &BinaryDataAsIntBuffer =
       reinterpret_cast<decltype(ExpectedMagicNumber) *>(BinaryData.data());
   return BinaryDataAsIntBuffer[0] == ExpectedMagicNumber;
+}
+
+bool isFileOCLSource(const std::string &FileName) {
+  return isFileEndsWithGivenExtentionName(FileName, ".cl");
 }
 
 bool isFileELF(const std::vector<char> &BinaryData) {
@@ -420,4 +429,9 @@ bool isFileELF(const std::vector<char> &BinaryData) {
 bool isFileSPIRV(const std::vector<char> &BinaryData) {
   const uint32_t SPIRVMagicNumber = 0x07230203;
   return isFileStartsWithGivenMagicNumber(BinaryData, SPIRVMagicNumber);
+}
+
+bool isFileLLVMIR(const std::vector<char> &BinaryData) {
+  const uint32_t LLVMIRMagicNumber = 0xdec04342;
+  return isFileStartsWithGivenMagicNumber(BinaryData, LLVMIRMagicNumber);
 }


### PR DESCRIPTION
This patch implements 3 invocation types:

* opencl-aot -device=<value> -cmd=link -spv=<spirv_input>
             -ir=<output_aocx>
  This compiles a SPIR-V program to an aocx (i.e. the standard ELF file
  from opencl_rt compiles)

* opencl-aot -device=<value> -cmd=link
             -binary=<comma_separated_list_of_binary_filename>
             -ir=<output_aocx>
  This links LLVM IR and object files to generate an aocx

* opencl-aot -device=<value> -cmd=compile -input=<opencl_input_file>
             -ir=<output_aocx>
  This compiles OpenCL source to an aocx