### PR TITLE
[SYCL] Add code examples for all SYCL Function Attributes

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2219,6 +2219,15 @@ program is ill-formed and no diagnostic is required.
 
 The ``intel::kernel_args_restrict`` attribute has an effect when applied to a
 function, and no effect otherwise.
+
+.. code-block:: c++
+
+  [[intel::kernel_args_restrict]] void func() {}
+
+  struct Bar {
+    [[intel::kernel_args_restrict]] void operator()() const {}
+  };
+
   }];
 }
 
@@ -2230,6 +2239,25 @@ Applies to a device function/lambda function. Indicates the number of work
 items that should be processed in parallel. Valid values are positive integers.
 If ``intel::num_simd_work_items`` is applied to a function called from a
 device kernel, the attribute is ignored and it is not propagated to a kernel.
+
+.. code-block:: c++
+
+  [[intel::num_simd_work_items(4)]] int foo() {}
+
+  template<int N>
+  [[intel::num_simd_work_items(N)]] int bar() {}
+
+  class Foo {
+  public:
+    [[intel::num_simd_work_items(6)]] void operator()() const {}
+  };
+
+  template <int SIZE>
+  class Functor {
+  public:
+    [[intel::num_simd_work_items(SIZE)]] void operator()() const {}
+  };
+
   }];
 }
 
@@ -2293,6 +2321,33 @@ defaults to ``1``.
 In OpenCL C, this attribute is available in GNU spelling
 (``__attribute__((reqd_work_group_size(X, Y, Z)))``), see section
 6.7.2 Optional Attribute Qualifiers of OpenCL 1.2 specification for details.
+
+.. code-block:: c++
+
+  __kernel __attribute__((reqd_work_group_size(8, 16, 32))) void test() {}
+
+  [[cl::reqd_work_group_size(4, 4, 4)]] int foo() {}
+
+  class Foo {
+  public:
+    [[cl::reqd_work_group_size(2, 2, 2)]] void operator()() const {}
+  };
+
+  template <int SIZE, int SIZE1, int SIZE2>
+  class Functor {
+  public:
+    [[cl::reqd_work_group_size(SIZE, SIZE1, SIZE2)]] void operator()() const {}
+  };
+
+  template <int N, int N1, int N2>
+  [[cl::reqd_work_group_size(N, N1, N2)]] void func() {}
+
+  [[intel::reqd_work_group_size(N, N1, N2)]] void bar() {}
+
+  ``[[intel::reqd_work_group_size(N, N1, N2)]]`` takes two optional
+  arguments `N1` and `N2`that are constant unsigned integer expressions.
+  The parameter N, N1, N2 may be a template parameters.
+
   }];
 }
 
@@ -2306,6 +2361,25 @@ reqd_work_group_size, but allows work groups that are smaller or equal to the
 specified sizes.
 If ``intel::max_work_group_size`` is applied to a function called from a
 device kernel, the attribute is ignored and it is not propagated to a kernel.
+
+.. code-block:: c++
+
+  [[intel::max_work_group_size(4, 4, 4)]] int foo() {}
+
+  class Foo {
+  public:
+    [[intel::max_work_group_size(2, 2, 2)]] void operator()() const {}
+  };
+
+  template <int SIZE, int SIZE1, int SIZE2>
+  class Functor {
+  public:
+    [[intel::max_work_group_size(SIZE, SIZE1, SIZE2)]] void operator()() const {}
+  };
+
+  template <int N, int N1, int N2>
+  [[intel::max_work_group_size(N, N1, N2)]] void func() {}
+
   }];
 }
 
@@ -2322,6 +2396,32 @@ range of [0, 3]. A kernel with max_global_work_dim(0) must be invoked with a
 have arguments of (1, 1, 1).
 If ``intel::max_global_work_dim`` is applied to a function called from a
 device kernel, the attribute is ignored and it is not propagated to a kernel.
+
+.. code-block:: c++
+
+  [[intel::max_global_work_dim(1)]] int foo() {}
+
+  template<int N>
+  [[intel::max_global_work_dim(N)]] int bar() {}
+
+  class Foo {
+  public:
+    [[intel::max_global_work_dim(1)]] void operator()() const {}
+  };
+
+  template <int SIZE>
+  class Functor {
+  public:
+    [[intel::max_global_work_dim(SIZE)]] void operator()() const {}
+  };
+
+  struct TRIFuncObjGood {
+    [[intel::max_global_work_dim(0)]]
+    [[intel::max_work_group_size(1, 1, 1)]]
+    [[cl::reqd_work_group_size(1, 1, 1)]]
+    void operator()() const {}
+  };
+
   }];
 }
 
@@ -2344,6 +2444,25 @@ This attribute enables communication of the desired maximum frequency of the
 device operation, guiding the FPGA backend to insert the appropriate number of
 registers to break-up the combinational logic circuit, and thereby controlling
 the length of the longest combinational path.
+
+.. code-block:: c++
+
+  [[intel::scheduler_target_fmax_mhz(4)]] int foo() {}
+
+  template<int N>
+  [[intel::scheduler_target_fmax_mhz(N)]] int bar() {}
+
+  class Foo {
+  public:
+    [[intel::scheduler_target_fmax_mhz(6)]] void operator()() const {}
+  };
+
+  template <int SIZE>
+  class Functor {
+  public:
+    [[intel::scheduler_target_fmax_mhz(SIZE)]] void operator()() const {}
+  };
+
   }];
 }
 
@@ -2355,6 +2474,15 @@ Applies to a device function/lambda function or function call operator (of a
 function object). If 1, compiler doesn't use the global work offset values for
 the device function. Valid values are 0 and 1. If used without argument, value
 of 1 is set implicitly.
+
+.. code-block:: c++
+
+  [[intel::no_global_work_offset(N)]] int foo() {}
+
+``[[intel::no_global_work_offset(N)]]`` takes one optional parameter that is a
+constant unsigned integer expression. The parameter N may be a template
+parameter.
+
   }];
 }
 
@@ -2645,6 +2773,15 @@ optimization.
 This attribute allows to pass name and address of the function to a special
 ``cl::sycl::intel::get_device_func_ptr`` API call which extracts the device
 function pointer for the specified function.
+
+.. code-block:: c++
+
+  [[intel::device_indirectly_callable]] int func3() {}
+
+  class A {
+    [[intel::device_indirectly_callable]] A() {}
+  };
+
   }];
 }
 


### PR DESCRIPTION
We have added code examples for some of the function attributes.

This patch adds code examples for remaining SYCL function attributes
that we did not have before to improve the documentation about
attributes.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>