### PR TITLE
[SYCL] Add code examples for all SYCL Function Attributes

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2331,12 +2331,21 @@ See section 6.7 Attributes for more details.
   template <int N, int N1, int N2>
   [[cl::reqd_work_group_size(N, N1, N2)]] void func() {}
 
-As Intel extension, ``[[intel::reqd_work_group_size(X, Y, Z)]]`` spelling is
-allowed which features optional arguments `Y` and `Z`, those simplifies its
-usage if only 1- or 2-dimensional ND-range is assumed by a programmer. These
-arguments defaults to ``1``.
+As an Intel extension, the ``[[intel::reqd_work_group_size(X, Y, Z)]]``
+spelling is supported. This spelling allows the Y and Z arguments to be
+optional. If not provided by the user, the value of Y and Z defaults to 1.
+This simplifies usage of the attribute when a 1- or 2-dimensional ND-range
+is assumed.
 
 .. code-block:: c++
+
+  [[intel::reqd_work_group_size(5)]]
+  // identical to [[intel::reqd_work_group_size(5, 1, 1)]]
+  void quux() {}
+
+  [[intel::reqd_work_group_size(5, 5)]]
+  // identical to [[intel::reqd_work_group_size(5, 5, 1)]]
+  void qux() {}
 
   [[intel::reqd_work_group_size(4, 4, 4)]] void foo() {}
 
@@ -2426,7 +2435,7 @@ device kernel, the attribute is not ignored and it is propagated to the kernel.
     [[intel::max_global_work_dim(N)]] void operator()() const {}
   };
 
-A kernel with max_global_work_dim(0) must be invoked with a
+A kernel with ``intel::max_global_work_dim(0)`` must be invoked with a
 'single_task' and if ``intel::max_work_group_size`` or
 ``cl::reqd_work_group_size`` are applied to the kernel as well - they shall
 have arguments of (1, 1, 1).
@@ -2495,11 +2504,25 @@ of 1 is set implicitly.
 
 .. code-block:: c++
 
-  [[intel::no_global_work_offset(N)]] int foo() {}
+  [[intel::no_global_work_offset]]
+  // identical to [[intel::no_global_work_offset(1)]]
+  void quux() {}
 
-``[[intel::no_global_work_offset(N)]]`` takes one optional parameter that is a
-constant unsigned integer expression. The parameter N may be a template
-parameter.
+  [[intel::no_global_work_offset(0)]] void foo() {}
+
+  class Foo {
+  public:
+    [[intel::no_global_work_offset(1)]] void operator()() const {}
+  };
+
+  template <int N>
+  class Functor {
+  public:
+    [[intel::no_global_work_offset(N)]] void operator()() const {}
+  };
+
+  template <int N>
+  [[intel::no_global_work_offset(N)]] void func() {}
 
   }];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2313,18 +2313,7 @@ those device functions, such that the kernel attributes are the sum of all
 attributes of all device functions called in this kernel.
 See section 6.7 Attributes for more details.
 
-As Intel extension, ``[[intel::reqd_work_group_size(X, Y, Z)]]`` spelling is allowed
-which features optional arguments `Y` and `Z`, those simplifies its usage if
-only 1- or 2-dimensional ND-range is assumed by a programmer. These arguments
-defaults to ``1``.
-
-In OpenCL C, this attribute is available in GNU spelling
-(``__attribute__((reqd_work_group_size(X, Y, Z)))``), see section
-6.7.2 Optional Attribute Qualifiers of OpenCL 1.2 specification for details.
-
 .. code-block:: c++
-
-  __kernel __attribute__((reqd_work_group_size(8, 16, 32))) void test() {}
 
   [[cl::reqd_work_group_size(4, 4, 4)]] void foo() {}
 
@@ -2342,11 +2331,36 @@ In OpenCL C, this attribute is available in GNU spelling
   template <int N, int N1, int N2>
   [[cl::reqd_work_group_size(N, N1, N2)]] void func() {}
 
-  [[intel::reqd_work_group_size(N, N1, N2)]] void bar() {}
+As Intel extension, ``[[intel::reqd_work_group_size(X, Y, Z)]]`` spelling is
+allowed which features optional arguments `Y` and `Z`, those simplifies its
+usage if only 1- or 2-dimensional ND-range is assumed by a programmer. These
+arguments defaults to ``1``.
 
-  ``[[intel::reqd_work_group_size(N, N1, N2)]]`` takes two optional
-  arguments `N1` and `N2`that are constant unsigned integer expressions.
-  The parameter N, N1, N2 may be a template parameters.
+.. code-block:: c++
+
+  [[intel::reqd_work_group_size(4, 4, 4)]] void foo() {}
+
+  class Foo {
+  public:
+    [[intel::reqd_work_group_size(2, 2, 2)]] void operator()() const {}
+  };
+
+  template <int X, int Y, int Z>
+  class Functor {
+  public:
+    [[intel::reqd_work_group_size(X, Y, Z)]] void operator()() const {}
+  };
+
+  template <int X, int Y, int Z>
+  [[intel::reqd_work_group_size(X, Y, Z)]] void func() {}
+
+In OpenCL C, this attribute is available in GNU spelling
+(``__attribute__((reqd_work_group_size(X, Y, Z)))``), see section
+6.7.2 Optional Attribute Qualifiers of OpenCL 1.2 specification for details.
+
+.. code-block:: c++
+
+  __kernel __attribute__((reqd_work_group_size(8, 16, 32))) void test() {}
 
   }];
 }
@@ -2390,10 +2404,7 @@ def SYCLIntelMaxGlobalWorkDimAttrDocs : Documentation {
 Applies to a device function/lambda function or function call operator (of a
 function object). Indicates the largest valid global work dimension that will be
 accepted when running the kernel on a device. Valid values are integers in a
-range of [0, 3]. A kernel with max_global_work_dim(0) must be invoked with a
-'single_task' and if ``intel::max_work_group_size`` or
-``cl::reqd_work_group_size`` are applied to the kernel as well - they shall
-have arguments of (1, 1, 1).
+range of [0, 3].
 If ``intel::max_global_work_dim`` is applied to a function called from a
 device kernel, the attribute is not ignored and it is propagated to the kernel.
 
@@ -2414,6 +2425,13 @@ device kernel, the attribute is not ignored and it is propagated to the kernel.
   public:
     [[intel::max_global_work_dim(N)]] void operator()() const {}
   };
+
+A kernel with max_global_work_dim(0) must be invoked with a
+'single_task' and if ``intel::max_work_group_size`` or
+``cl::reqd_work_group_size`` are applied to the kernel as well - they shall
+have arguments of (1, 1, 1).
+
+.. code-block:: c++
 
   struct TRIFuncObjGood {
     [[intel::max_global_work_dim(0)]]

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2219,6 +2219,15 @@ program is ill-formed and no diagnostic is required.
 
 The ``intel::kernel_args_restrict`` attribute has an effect when applied to a
 function, and no effect otherwise.
+
+.. code-block:: c++
+
+  [[intel::kernel_args_restrict]] void func() {}
+
+  struct bar {
+    [[intel::kernel_args_restrict]] void operator()() const {}
+  };
+
   }];
 }
 
@@ -2230,6 +2239,25 @@ Applies to a device function/lambda function. Indicates the number of work
 items that should be processed in parallel. Valid values are positive integers.
 If ``intel::num_simd_work_items`` is applied to a function called from a
 device kernel, the attribute is not ignored and it is propagated to the kernel.
+
+.. code-block:: c++
+
+  [[intel::num_simd_work_items(4)]] void foo() {}
+
+  template<int N>
+  [[intel::num_simd_work_items(N)]] void bar() {}
+
+  class Foo {
+  public:
+    [[intel::num_simd_work_items(6)]] void operator()() const {}
+  };
+
+  template <int N>
+  class Functor {
+  public:
+    [[intel::num_simd_work_items(N)]] void operator()() const {}
+  };
+
   }];
 }
 
@@ -2293,6 +2321,33 @@ defaults to ``1``.
 In OpenCL C, this attribute is available in GNU spelling
 (``__attribute__((reqd_work_group_size(X, Y, Z)))``), see section
 6.7.2 Optional Attribute Qualifiers of OpenCL 1.2 specification for details.
+
+.. code-block:: c++
+
+  __kernel __attribute__((reqd_work_group_size(8, 16, 32))) void test() {}
+
+  [[cl::reqd_work_group_size(4, 4, 4)]] void foo() {}
+
+  class Foo {
+  public:
+    [[cl::reqd_work_group_size(2, 2, 2)]] void operator()() const {}
+  };
+
+  template <int N, int N1, int N2>
+  class Functor {
+  public:
+    [[cl::reqd_work_group_size(N, N1, N2)]] void operator()() const {}
+  };
+
+  template <int N, int N1, int N2>
+  [[cl::reqd_work_group_size(N, N1, N2)]] void func() {}
+
+  [[intel::reqd_work_group_size(N, N1, N2)]] void bar() {}
+
+  ``[[intel::reqd_work_group_size(N, N1, N2)]]`` takes two optional
+  arguments `N1` and `N2`that are constant unsigned integer expressions.
+  The parameter N, N1, N2 may be a template parameters.
+
   }];
 }
 
@@ -2306,6 +2361,25 @@ reqd_work_group_size, but allows work groups that are smaller or equal to the
 specified sizes.
 If ``intel::max_work_group_size`` is applied to a function called from a
 device kernel, the attribute is not ignored and it is propagated to the kernel.
+
+.. code-block:: c++
+
+  [[intel::max_work_group_size(4, 4, 4)]] void foo() {}
+
+  class Foo {
+  public:
+    [[intel::max_work_group_size(2, 2, 2)]] void operator()() const {}
+  };
+
+  template <int N, int N1, int N2>
+  class Functor {
+  public:
+    [[intel::max_work_group_size(N, N1, N2)]] void operator()() const {}
+  };
+
+  template <int N, int N1, int N2>
+  [[intel::max_work_group_size(N, N1, N2)]] void func() {}
+
   }];
 }
 
@@ -2322,6 +2396,32 @@ range of [0, 3]. A kernel with max_global_work_dim(0) must be invoked with a
 have arguments of (1, 1, 1).
 If ``intel::max_global_work_dim`` is applied to a function called from a
 device kernel, the attribute is not ignored and it is propagated to the kernel.
+
+.. code-block:: c++
+
+  [[intel::max_global_work_dim(1)]] void foo() {}
+
+  template<int N>
+  [[intel::max_global_work_dim(N)]] void bar() {}
+
+  class Foo {
+  public:
+    [[intel::max_global_work_dim(1)]] void operator()() const {}
+  };
+
+  template <int N>
+  class Functor {
+  public:
+    [[intel::max_global_work_dim(N)]] void operator()() const {}
+  };
+
+  struct TRIFuncObjGood {
+    [[intel::max_global_work_dim(0)]]
+    [[intel::max_work_group_size(1, 1, 1)]]
+    [[cl::reqd_work_group_size(1, 1, 1)]]
+    void operator()() const {}
+  };
+
   }];
 }
 
@@ -2344,6 +2444,25 @@ This attribute enables communication of the desired maximum frequency of the
 device operation, guiding the FPGA backend to insert the appropriate number of
 registers to break-up the combinational logic circuit, and thereby controlling
 the length of the longest combinational path.
+
+.. code-block:: c++
+
+  [[intel::scheduler_target_fmax_mhz(4)]] void foo() {}
+
+  template<int N>
+  [[intel::scheduler_target_fmax_mhz(N)]] void bar() {}
+
+  class Foo {
+  public:
+    [[intel::scheduler_target_fmax_mhz(6)]] void operator()() const {}
+  };
+
+  template <int N>
+  class Functor {
+  public:
+    [[intel::scheduler_target_fmax_mhz(N)]] void operator()() const {}
+  };
+
   }];
 }
 
@@ -2355,6 +2474,15 @@ Applies to a device function/lambda function or function call operator (of a
 function object). If 1, compiler doesn't use the global work offset values for
 the device function. Valid values are 0 and 1. If used without argument, value
 of 1 is set implicitly.
+
+.. code-block:: c++
+
+  [[intel::no_global_work_offset(N)]] int foo() {}
+
+``[[intel::no_global_work_offset(N)]]`` takes one optional parameter that is a
+constant unsigned integer expression. The parameter N may be a template
+parameter.
+
   }];
 }
 
@@ -2645,6 +2773,15 @@ optimization.
 This attribute allows to pass name and address of the function to a special
 ``cl::sycl::intel::get_device_func_ptr`` API call which extracts the device
 function pointer for the specified function.
+
+.. code-block:: c++
+
+  [[intel::device_indirectly_callable]] int func3() {}
+
+  class A {
+    [[intel::device_indirectly_callable]] A() {}
+  };
+
   }];
 }
 


### PR DESCRIPTION
We have added code examples for some of the function attributes.

This patch adds code examples for remaining SYCL function attributes
that we did not have before to improve the documentation about
attributes.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>