### PR TITLE
[SYCL][NFC] Minor update for mutual diagnostic function of different work_group_size attributes

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3022,9 +3022,9 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
     else if (const auto *B = D->getAttr<ReqdWorkGroupSizeAttr>())
       Dims = B->dimensions();
     if (B) {
-      Result &= checkZeroDim(B, getExprValue(Dims[0], Ctx),
-                             getExprValue(Dims[1], Ctx),
-                             getExprValue(Dims[2], Ctx));
+      Result &=
+          checkZeroDim(B, getExprValue(Dims[0], Ctx),
+                       getExprValue(Dims[1], Ctx), getExprValue(Dims[2], Ctx));
     }
     return Result;
   }
@@ -3034,11 +3034,10 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
 
   if (const auto *A = D->getAttr<SYCLIntelMaxGlobalWorkDimAttr>()) {
     if ((A->getValue()->getIntegerConstantExpr(Ctx)->getSExtValue()) == 0) {
-      Result &=
-          checkZeroDim(A, getExprValue(AL.getArgAsExpr(0), Ctx),
-                       getExprValue(AL.getArgAsExpr(1), Ctx),
-                       getExprValue(AL.getArgAsExpr(2), Ctx),
-                       /*ReverseAttrs=*/true);
+       Result &= checkZeroDim(A, getExprValue(AL.getArgAsExpr(0), Ctx),
+                              getExprValue(AL.getArgAsExpr(1), Ctx),
+                              getExprValue(AL.getArgAsExpr(2), Ctx),
+                              /*ReverseAttrs=*/true);
     }
   }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3044,7 +3044,7 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
 
   if (const auto *A = D->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
     if (!((getExprValue(AL.getArgAsExpr(0), Ctx) <=
-	   getExprValue(A->getXDim(), Ctx)) &&
+           getExprValue(A->getXDim(), Ctx)) &&
           (getExprValue(AL.getArgAsExpr(1), Ctx) <=
            getExprValue(A->getYDim(), Ctx)) &&
           (getExprValue(AL.getArgAsExpr(2), Ctx) <=

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3006,8 +3006,8 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
     return true;
   };
 
-  /// Returns the usigned constant integer value represented by
-  /// given expression.
+  // Returns the unsigned constant integer value represented by
+  // given expression.
   auto getExprValue = [](const Expr *E, ASTContext &Ctx) {
     return E->getIntegerConstantExpr(Ctx)->getZExtValue();
   };
@@ -3030,13 +3030,8 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (AL.getKind() == ParsedAttr::AT_SYCLIntelMaxWorkGroupSize)
     S.CheckDeprecatedSYCLAttributeSpelling(AL);
 
-  // For a SYCLDevice, WorkGroupAttr arguments are reversed.
-  // "XDim" gets the third argument to the attribute and
-  // "ZDim" gets the first argument of the attribute.
   if (const auto *A = D->getAttr<SYCLIntelMaxGlobalWorkDimAttr>()) {
-    int64_t AttrValue =
-        A->getValue()->getIntegerConstantExpr(S.Context)->getSExtValue();
-    if (AttrValue == 0) {
+    if (getExprValue(A->getValue(), S.getASTContext()) == 0) {
       Result &=
           checkZeroDim(A, getExprValue(AL.getArgAsExpr(0), S.getASTContext()),
                        getExprValue(AL.getArgAsExpr(1), S.getASTContext()),

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3034,10 +3034,10 @@ static bool checkWorkGroupSizeValues(Sema &S, Decl *D, const ParsedAttr &AL) {
 
   if (const auto *A = D->getAttr<SYCLIntelMaxGlobalWorkDimAttr>()) {
     if ((A->getValue()->getIntegerConstantExpr(Ctx)->getSExtValue()) == 0) {
-       Result &= checkZeroDim(A, getExprValue(AL.getArgAsExpr(0), Ctx),
-                              getExprValue(AL.getArgAsExpr(1), Ctx),
-                              getExprValue(AL.getArgAsExpr(2), Ctx),
-                              /*ReverseAttrs=*/true);
+      Result &= checkZeroDim(A, getExprValue(AL.getArgAsExpr(0), Ctx),
+                             getExprValue(AL.getArgAsExpr(1), Ctx),
+                             getExprValue(AL.getArgAsExpr(2), Ctx),
+                             /*ReverseAttrs=*/true);
     }
   }
 


### PR DESCRIPTION
This patch
  1. fixes typo
  2. removes redundant comments (we have disabled swapping dimension values of WorkGroupAttr
     arguments for semantic checks on  https://github.com/intel/llvm/pull/2962)
  3. hoists the logic from the second if into the above if (AttrValue == 0)

Signed-off-by: Soumi Manna <soumi.manna@intel.com>