### PR TITLE
[SYCL][NFC] Fix build errors revealed by self build.

### DIFF
--- a/clang/lib/CodeGen/CGSYCLRuntime.cpp
+++ b/clang/lib/CodeGen/CGSYCLRuntime.cpp
@@ -70,18 +70,16 @@ bool CGSYCLRuntime::actOnFunctionStart(const FunctionDecl &FD,
   switch (Scope->getLevel()) {
   case SYCLScopeAttr::Level::WorkGroup:
     F.setMetadata(WG_SCOPE_MD_ID, llvm::MDNode::get(F.getContext(), {}));
-    break;
+    return true;
   case SYCLScopeAttr::Level::WorkItem:
     F.setMetadata(WI_SCOPE_MD_ID, llvm::MDNode::get(F.getContext(), {}));
     if (isPFWI(FD))
       // also emit specific marker for parallel_for_work_item, as it needs to
       // be handled specially in the SYCL lowering pass
       F.setMetadata(PFWI_MD_ID, llvm::MDNode::get(F.getContext(), {}));
-    break;
-  default:
-    llvm_unreachable("unknown sycl scope");
+    return true;
   }
-  return true;
+  llvm_unreachable("unknown sycl scope");
 }
 
 void CGSYCLRuntime::emitWorkGroupLocalVarDecl(CodeGenFunction &CGF,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8353,8 +8353,6 @@ void FileTableTform::ConstructJob(Compilation &C, const JobAction &JA,
       addArgs(CmdArgs, TCArgs, {Arg});
       break;
     }
-    default:
-      llvm_unreachable("unknown file table transformation kind");
     }
   }
   // 2) add output option

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1466,12 +1466,12 @@ public:
     return isValid();
   }
 
-  bool enterUnion(const CXXRecordDecl *RD, FieldDecl *FD) {
+  bool enterUnion(const CXXRecordDecl *RD, FieldDecl *FD) override {
     ++UnionCount;
     return true;
   }
 
-  bool leaveUnion(const CXXRecordDecl *RD, FieldDecl *FD) {
+  bool leaveUnion(const CXXRecordDecl *RD, FieldDecl *FD) override {
     --UnionCount;
     return true;
   }
@@ -3477,9 +3477,9 @@ static const char *paramKind2Str(KernelParamKind K) {
     CASE(std_layout);
     CASE(sampler);
     CASE(pointer);
-  default:
-    return "<ERROR>";
   }
+  return "<ERROR>";
+
 #undef CASE
 }
 

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -218,9 +218,9 @@ static StringRef offloadKindToString(OffloadKind Kind) {
     return "hip";
   case OffloadKind::SYCL:
     return "sycl";
-  default:
-    llvm_unreachable("bad offload kind");
   }
+  llvm_unreachable("bad offload kind");
+
   return "<ERROR>";
 }
 
@@ -234,9 +234,9 @@ static StringRef formatToString(BinaryImageFormat Fmt) {
     return "llvmbc";
   case BinaryImageFormat::native:
     return "native";
-  default:
-    llvm_unreachable("bad format");
   }
+  llvm_unreachable("bad format");
+
   return "<ERROR>";
 }
 


### PR DESCRIPTION
Clang warns about using default in a switch statement where all enumerated cases are covered. This is a patch to avoid the warning.
 