### PR TITLE
[SYCL] Remove arbitrary range Part 1

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1269,14 +1269,6 @@ def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelSchedulerTargetFmaxMhzAttrDocs];
-  let AdditionalMembers = [{
-    static unsigned getMinValue() {
-      return 0;
-    }
-    static unsigned getMaxValue() {
-      return 1024*1024;
-    }
-  }];
 }
 
 def SYCLIntelMaxWorkGroupSize : InheritableAttr {
@@ -1331,14 +1323,6 @@ def SYCLIntelLoopFuse : InheritableAttr {
   let Accessors = [Accessor<"isIndependent",
                   [CXX11<"intel", "loop_fuse_independent">]>];
   let Documentation = [SYCLIntelLoopFuseDocs];
-  let AdditionalMembers = [{
-    static unsigned getMinValue() {
-      return 0;
-    }
-    static unsigned getMaxValue() {
-      return 1024*1024;
-    }
-  }];
 }
 
 def C11NoReturn : InheritableAttr {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12970,6 +12970,13 @@ void Sema::addIntelSYCLSingleArgFunctionAttr(Decl *D,
         return;
       }
     }
+    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelSchedulerTargetFmaxMhz) {
+      if (ArgInt < 0) {
+        Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
+            << CI.getAttrName() << /*non-negative*/ 1;
+        return;
+      }
+    }
   }
 
   D->addAttr(::new (Context) AttrType(Context, CI, E));

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3210,7 +3210,8 @@ static void handleSchedulerTargetFmaxMhzAttr(Sema &S, Decl *D,
     S.Diag(AL.getLoc(), diag::note_spelling_suggestion)
         << "'intel::scheduler_target_fmax_mhz'";
 
-  S.AddOneConstantValueAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>(D, AL, E);
+  S.addIntelSYCLSingleArgFunctionAttr<SYCLIntelSchedulerTargetFmaxMhzAttr>(
+      D, AL, E);
 }
 
 // Handles max_global_work_dim.
@@ -3287,10 +3288,13 @@ static bool checkSYCLIntelLoopFuseArgument(Sema &S,
     return true;
   }
 
-  SYCLIntelLoopFuseAttr TmpAttr(S.Context, CI, E);
-  ExprResult ICE;
+  if (!ArgVal->isNonNegative()) {
+    S.Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
+        << CI << /*non-negative*/ 1;
+    return true;
+  }
 
-  return S.checkRangedIntegralArgument<SYCLIntelLoopFuseAttr>(E, &TmpAttr, ICE);
+  return false;
 }
 
 void Sema::addSYCLIntelLoopFuseAttr(Decl *D, const AttributeCommonInfo &CI,

--- a/clang/test/SemaSYCL/loop_fusion.cpp
+++ b/clang/test/SemaSYCL/loop_fusion.cpp
@@ -4,8 +4,8 @@
 
 [[intel::loop_fuse("foo")]] void func() {} // expected-error{{'loop_fuse' attribute requires an integer constant}}
 
-[[intel::loop_fuse(1048577)]] void func1() {}        // expected-error{{'loop_fuse' attribute requires integer constant between 0 and 1048576 inclusive}}
-[[intel::loop_fuse_independent(-1)]] void func2() {} // expected-error{{'loop_fuse_independent' attribute requires integer constant between 0 and 1048576 inclusive}}
+[[intel::loop_fuse(1048577)]] void func1() {}        // OK
+[[intel::loop_fuse_independent(-1)]] void func2() {} // expected-error{{'loop_fuse_independent' attribute requires a non-negative integral compile time constant expression}}
 
 [[intel::loop_fuse(0, 1)]] void func3() {}             // expected-error{{'loop_fuse' attribute takes no more than 1 argument}}
 [[intel::loop_fuse_independent(2, 3)]] void func4() {} // expected-error{{'loop_fuse_independent' attribute takes no more than 1 argument}}
@@ -48,13 +48,14 @@
 [[intel::loop_fuse]] void func16();
 
 template <int N>
-[[intel::loop_fuse(N)]] void func17(); // expected-error{{'loop_fuse' attribute requires integer constant between 0 and 1048576 inclusive}}
+[[intel::loop_fuse(N)]] void func17(); // expected-error{{'loop_fuse' attribute requires a non-negative integral compile time constant expression}}
 
 template <typename Ty>
 [[intel::loop_fuse(Ty{})]] void func18() {} // expected-error{{'loop_fuse' attribute requires an integer constant}}
 
 void checkTemplates() {
   func17<-1>();    // expected-note{{in instantiation of}}
+  func17<0>();     // OK
   func18<float>(); // expected-note{{in instantiation of}}
 }
 

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -10,20 +10,16 @@ template <int N>
 [[intel::scheduler_target_fmax_mhz(N)]] void zoo() {}
 
 int main() {
-  // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel1 'void ()'
+  // CHECK:  FunctionDecl {{.*}}test_kernel1 'void ()'
   // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
-  // CHECK-NEXT:   ConstantExpr {{.*}} 'int'
-  // CHECK-NEXT:   value: Int 5
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 5
   // expected-warning@+3 {{attribute 'intelfpga::scheduler_target_fmax_mhz' is deprecated}}
   // expected-note@+2 {{did you mean to use 'intel::scheduler_target_fmax_mhz' instead?}}
   cl::sycl::kernel_single_task<class test_kernel1>(
       []() [[intelfpga::scheduler_target_fmax_mhz(5)]]{});
 
-  // CHECK-LABEL:  FunctionDecl {{.*}}test_kernel2 'void ()'
+  // CHECK:  FunctionDecl {{.*}}test_kernel2 'void ()'
   // CHECK:        SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
-  // CHECK-NEXT:   ConstantExpr {{.*}} 'int'
-  // CHECK-NEXT:   value: Int 2
   // CHECK-NEXT:   IntegerLiteral {{.*}} 'int' 2
   cl::sycl::kernel_single_task<class test_kernel2>(
       []() { func(); });
@@ -39,10 +35,10 @@ int main() {
   [[intel::scheduler_target_fmax_mhz(0)]] int Var = 0; // expected-error{{'scheduler_target_fmax_mhz' attribute only applies to functions}}
 
   cl::sycl::kernel_single_task<class test_kernel4>(
-      []() [[intel::scheduler_target_fmax_mhz(1048577)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires integer constant between 0 and 1048576 inclusive}}
+      []() [[intel::scheduler_target_fmax_mhz(1048577)]]{}); // OK
 
   cl::sycl::kernel_single_task<class test_kernel5>(
-      []() [[intel::scheduler_target_fmax_mhz(-4)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires integer constant between 0 and 1048576 inclusive}}
+      []() [[intel::scheduler_target_fmax_mhz(-4)]]{}); // expected-error{{'scheduler_target_fmax_mhz' attribute requires a non-negative integral compile time constant expression}}
 
   cl::sycl::kernel_single_task<class test_kernel6>(
       []() [[intel::scheduler_target_fmax_mhz(1), intel::scheduler_target_fmax_mhz(2)]]{}); // expected-warning{{attribute 'scheduler_target_fmax_mhz' is already applied with different parameters}}


### PR DESCRIPTION
Remove arbitrary range for SYCLIntelSchedulerTargetFmaxMhz and
SYCLIntelLoopFuse attributes.

This patch partially addresses https://github.com/intel/llvm/issues/2911

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>