### PR TITLE
[CI] Update ToT version of clang to 13 for post-commit job

### DIFF
--- a/.github/workflows/linux_post_commit.yml
+++ b/.github/workflows/linux_post_commit.yml
@@ -29,10 +29,10 @@ jobs:
                  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
                  sudo add-apt-repository "deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic main"
                  sudo apt-get update
-                 sudo apt-get install -y clang-12
+                 sudo apt-get install -y clang-13
                  export ARGS="--shared-libs"
-                 export CC="clang-12"
-                 export CXX="clang++-12"
+                 export CC="clang-13"
+                 export CXX="clang++-13"
                  ;;
              NoAssertions)
                  export ARGS="--no-assertions"


### PR DESCRIPTION
Nightly builds in Ubutntu repository now have version 13. Update post-commit CI job to reflect those changes.