### PR TITLE
[SYCL] Refactor the way we diagnose some SYCL attributes; mostly NFC

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1272,11 +1272,6 @@ def SYCLIntelUseStallEnableClusters : InheritableAttr {
   let Spellings = [CXX11<"intel","use_stall_enable_clusters">];
   let LangOpts = [SYCLIsHost, SYCLIsDevice];
   let Subjects = SubjectList<[Function], ErrorDiag>;
-  let AdditionalMembers = [{
-    static const char *getName() {
-      return "stall_enable";
-    }
-  }];
   let Documentation = [SYCLIntelUseStallEnableClustersAttrDocs];
 }
 
@@ -1394,9 +1389,6 @@ def LoopUnrollHint : InheritableAttr {
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
   let AdditionalMembers = [{
-    static const char *getName() {
-      return "loop_unroll";
-    }
     std::string getDiagnosticName(const PrintingPolicy &Policy) const {
       std::string ValueName;
       llvm::raw_string_ostream OS(ValueName);
@@ -1820,9 +1812,6 @@ def SYCLIntelFPGAIVDep : Attr {
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
   let AdditionalMembers = [{
-    static const char *getName() {
-      return "ivdep";
-    }
     bool isDependent() const {
       return (getSafelenExpr() &&
               getSafelenExpr()->isInstantiationDependent()) ||
@@ -1863,11 +1852,6 @@ def SYCLIntelFPGAII : Attr {
   let Args = [ExprArgument<"IntervalExpr">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
-  let AdditionalMembers = [{
-    static const char *getName() {
-      return "ii";
-    }
-  }];
   let Documentation = [SYCLIntelFPGAIIAttrDocs];
 }
 
@@ -1877,11 +1861,6 @@ def SYCLIntelFPGAMaxConcurrency : Attr {
   let Args = [ExprArgument<"NThreadsExpr">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
-  let AdditionalMembers = [{
-    static const char *getName() {
-      return "max_concurrency";
-    }
-  }];
   let Documentation = [SYCLIntelFPGAMaxConcurrencyAttrDocs];
 }
 
@@ -1891,11 +1870,6 @@ def SYCLIntelFPGALoopCoalesce : Attr {
   let Args = [ExprArgument<"NExpr">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
-  let AdditionalMembers = [{
-    static const char *getName() {
-      return "loop_coalesce";
-    }
-  }];
   let Documentation = [SYCLIntelFPGALoopCoalesceAttrDocs];
 }
 
@@ -1904,11 +1878,6 @@ def SYCLIntelFPGADisableLoopPipelining : Attr {
                    CXX11<"intel","disable_loop_pipelining">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
-  let AdditionalMembers = [{
-    static const char *getName() {
-      return "disable_loop_pipelining";
-    }
-  }];
   let Documentation = [SYCLIntelFPGADisableLoopPipeliningAttrDocs];
 }
 
@@ -1918,11 +1887,6 @@ def SYCLIntelFPGAMaxInterleaving : Attr {
   let Args = [ExprArgument<"NExpr">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
-  let AdditionalMembers = [{
-    static const char *getName() {
-      return "max_interleaving";
-    }
-  }];
   let Documentation = [SYCLIntelFPGAMaxInterleavingAttrDocs];
 }
 
@@ -1932,11 +1896,6 @@ def SYCLIntelFPGASpeculatedIterations : Attr {
   let Args = [ExprArgument<"NExpr">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
-  let AdditionalMembers = [{
-    static const char *getName() {
-      return "speculated_iterations";
-    }
-  }];
   let Documentation = [SYCLIntelFPGASpeculatedIterationsAttrDocs];
 }
 
@@ -1944,11 +1903,6 @@ def SYCLIntelFPGANofusion : Attr {
   let Spellings = [CXX11<"intel","nofusion">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
-  let AdditionalMembers = [{
-    static const char *getName() {
-      return "nofusion";
-    }
-  }];
   let Documentation = [SYCLIntelFPGANofusionAttrDocs];
 }
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -135,7 +135,7 @@ def err_intel_fpga_reg_limitations : Error <
 def illegal_type_declared_here : Note<
   "field with illegal type declared here">;
 def err_sycl_loop_attr_duplication : Error<
-  "duplicate %select{unroll|Intel FPGA}0 loop attribute '%1'">;
+  "duplicate %select{unroll|Intel FPGA}0 loop attribute %1">;
 def err_loop_unroll_compatibility : Error<
   "incompatible loop unroll instructions: '%0' and '%1'">;
 def err_pipe_attribute_arg_not_allowed : Error<

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -593,19 +593,17 @@ CheckForIncompatibleAttributes(Sema &S,
 }
 
 template <typename LoopAttrT>
-static void CheckForDuplicationSYCLLoopAttribute(
-    Sema &S, const SmallVectorImpl<const Attr *> &Attrs, SourceRange Range,
-    bool isIntelFPGAAttr = true) {
+static void
+CheckForDuplicationSYCLLoopAttribute(Sema &S,
+                                     const SmallVectorImpl<const Attr *> &Attrs,
+                                     bool isIntelFPGAAttr = true) {
   const LoopAttrT *LoopAttr = nullptr;
 
   for (const auto *I : Attrs) {
-    if (LoopAttr) {
-      if (isa<LoopAttrT>(I)) {
-        SourceLocation Loc = Range.getBegin();
-        // Cannot specify same type of attribute twice.
-        S.Diag(Loc, diag::err_sycl_loop_attr_duplication)
-            << isIntelFPGAAttr << LoopAttr->getName();
-      }
+    if (LoopAttr && isa<LoopAttrT>(I)) {
+      // Cannot specify same type of attribute twice.
+      S.Diag(I->getLocation(), diag::err_sycl_loop_attr_duplication)
+          << isIntelFPGAAttr << LoopAttr;
     }
     if (isa<LoopAttrT>(I))
       LoopAttr = cast<LoopAttrT>(I);
@@ -616,7 +614,7 @@ static void CheckForDuplicationSYCLLoopAttribute(
 /// declaration. Returns true if diagnosed.
 template <typename LoopAttrT, typename LoopAttrT2>
 static void CheckMutualExclusionSYCLLoopAttribute(
-    Sema &S, const SmallVectorImpl<const Attr *> &Attrs, SourceRange Range) {
+    Sema &S, const SmallVectorImpl<const Attr *> &Attrs) {
   const LoopAttrT *LoopAttr = nullptr;
   const LoopAttrT2 *LoopAttr2 = nullptr;
 
@@ -625,46 +623,41 @@ static void CheckMutualExclusionSYCLLoopAttribute(
       LoopAttr = cast<LoopAttrT>(I);
     if (isa<LoopAttrT2>(I))
       LoopAttr2 = cast<LoopAttrT2>(I);
-    if (LoopAttr && LoopAttr2) {
-      S.Diag(Range.getBegin(), diag::err_attributes_are_not_compatible)
-          << LoopAttr->getSpelling() << LoopAttr2->getSpelling();
-    }
+    if (LoopAttr && LoopAttr2)
+      S.Diag(LoopAttr2->getLocation(), diag::err_attributes_are_not_compatible)
+          << LoopAttr << LoopAttr2;
   }
 }
 
 static void CheckForIncompatibleSYCLLoopAttributes(
-    Sema &S, const SmallVectorImpl<const Attr *> &Attrs, SourceRange Range) {
-  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAIIAttr>(S, Attrs, Range);
-  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAMaxConcurrencyAttr>(
-      S, Attrs, Range);
-  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGALoopCoalesceAttr>(S, Attrs,
-                                                                      Range);
+    Sema &S, const SmallVectorImpl<const Attr *> &Attrs) {
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAIIAttr>(S, Attrs);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAMaxConcurrencyAttr>(S,
+                                                                        Attrs);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGALoopCoalesceAttr>(S, Attrs);
   CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr>(
-      S, Attrs, Range);
-  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAMaxInterleavingAttr>(
-      S, Attrs, Range);
+      S, Attrs);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAMaxInterleavingAttr>(S,
+                                                                         Attrs);
   CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGASpeculatedIterationsAttr>(
-      S, Attrs, Range);
-  CheckForDuplicationSYCLLoopAttribute<LoopUnrollHintAttr>(S, Attrs, Range,
-                                                           false);
+      S, Attrs);
+  CheckForDuplicationSYCLLoopAttribute<LoopUnrollHintAttr>(S, Attrs, false);
   CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
                                         SYCLIntelFPGAMaxInterleavingAttr>(
-      S, Attrs, Range);
+      S, Attrs);
   CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
                                         SYCLIntelFPGASpeculatedIterationsAttr>(
-      S, Attrs, Range);
+      S, Attrs);
   CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
-                                        SYCLIntelFPGAIIAttr>(S, Attrs, Range);
+                                        SYCLIntelFPGAIIAttr>(S, Attrs);
   CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
-                                        SYCLIntelFPGAIVDepAttr>(S, Attrs,
-                                                                Range);
+                                        SYCLIntelFPGAIVDepAttr>(S, Attrs);
   CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
-                                        SYCLIntelFPGAMaxConcurrencyAttr>(
-      S, Attrs, Range);
+                                        SYCLIntelFPGAMaxConcurrencyAttr>(S,
+                                                                         Attrs);
 
   CheckRedundantSYCLIntelFPGAIVDepAttrs(S, Attrs);
-  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGANofusionAttr>(S, Attrs,
-                                                                  Range);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGANofusionAttr>(S, Attrs);
 }
 
 void CheckForIncompatibleUnrollHintAttributes(
@@ -814,7 +807,7 @@ StmtResult Sema::ProcessStmtAttributes(Stmt *S,
   }
 
   CheckForIncompatibleAttributes(*this, Attrs);
-  CheckForIncompatibleSYCLLoopAttributes(*this, Attrs, Range);
+  CheckForIncompatibleSYCLLoopAttributes(*this, Attrs);
   CheckForIncompatibleUnrollHintAttributes(*this, Attrs, Range);
 
   if (Attrs.empty())

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -317,7 +317,7 @@ void loop_attrs_compatibility() {
   [[intel::disable_loop_pipelining]]
   [[intel::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
+  // expected-error@+2 {{'speculated_iterations' and 'disable_loop_pipelining' attributes are not compatible}}
   [[intel::speculated_iterations(0)]]
   [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
@@ -325,7 +325,7 @@ void loop_attrs_compatibility() {
   [[intel::disable_loop_pipelining]]
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'disable_loop_pipelining' and 'ii' attributes are not compatible}}
+  // expected-error@+2 {{'ii' and 'disable_loop_pipelining' attributes are not compatible}}
   [[intel::ii(10)]]
   [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -221,34 +221,34 @@ void zoo() {
   [[intel::ivdep(4)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::max_concurrency(2)]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'max_concurrency'}}
+  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'max_concurrency'}}
   [[intel::max_concurrency(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::ii(2)]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ii'}}
+  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'ii'}}
   [[intel::ii(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::ii(2)]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'ii'}}
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'ii'}}
   [[intel::max_concurrency(2)]]
   [[intel::ii(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::disable_loop_pipelining]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'disable_loop_pipelining'}}
+  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'disable_loop_pipelining'}}
   [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::loop_coalesce(2)]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'loop_coalesce'}}
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'loop_coalesce'}}
   [[intel::max_interleaving(1)]]
   [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::max_interleaving(1)]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'max_interleaving'}}
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'max_interleaving'}}
   [[intel::speculated_iterations(1)]]
   [[intel::max_interleaving(4)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::speculated_iterations(1)]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'speculated_iterations'}}
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'speculated_iterations'}}
   [[intel::loop_coalesce]]
   [[intel::speculated_iterations(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
@@ -301,7 +301,7 @@ void zoo() {
       a[i] = 0;
 
   [[intel::nofusion]]
-  // expected-error@-1 {{duplicate Intel FPGA loop attribute 'nofusion'}}
+  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'nofusion'}}
   [[intel::nofusion]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
@@ -313,23 +313,23 @@ void loop_attrs_compatibility() {
   [[intel::disable_loop_pipelining]]
   [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{disable_loop_pipelining and max_interleaving attributes are not compatible}}
+  // expected-error@+2 {{'disable_loop_pipelining' and 'max_interleaving' attributes are not compatible}}
   [[intel::disable_loop_pipelining]]
   [[intel::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{disable_loop_pipelining and speculated_iterations attributes are not compatible}}
+  // expected-error@+1 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
   [[intel::speculated_iterations(0)]]
   [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{disable_loop_pipelining and max_concurrency attributes are not compatible}}
+  // expected-error@+2 {{'disable_loop_pipelining' and 'max_concurrency' attributes are not compatible}}
   [[intel::disable_loop_pipelining]]
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{disable_loop_pipelining and ii attributes are not compatible}}
+  // expected-error@+1 {{'disable_loop_pipelining' and 'ii' attributes are not compatible}}
   [[intel::ii(10)]]
   [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{disable_loop_pipelining and ivdep attributes are not compatible}}
+  // expected-error@+2 {{'disable_loop_pipelining' and 'ivdep' attributes are not compatible}}
   [[intel::disable_loop_pipelining]]
   [[intel::ivdep]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
@@ -378,7 +378,7 @@ void ii_dependent() {
   [[intel::ii(C)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'ii'}}
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'ii'}}
   [[intel::ii(A)]]
   [[intel::ii(B)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
@@ -391,7 +391,7 @@ void max_concurrency_dependent() {
   [[intel::max_concurrency(C)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'max_concurrency'}}
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'max_concurrency'}}
   [[intel::max_concurrency(A)]]
   [[intel::max_concurrency(B)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;

--- a/clang/test/SemaSYCL/loop_unroll.cpp
+++ b/clang/test/SemaSYCL/loop_unroll.cpp
@@ -27,7 +27,7 @@ void foo() {
   [[clang::loop_unroll("str123")]]
   for (int i = 0; i < 10; ++i);
 
-  // expected-error@+1 {{duplicate unroll loop attribute 'loop_unroll'}}
+  // expected-error@+2 {{duplicate unroll loop attribute 'loop_unroll'}}
   [[clang::loop_unroll(2)]]
   [[clang::loop_unroll(4)]]
   for (int i = 0; i < 10; ++i);


### PR DESCRIPTION
This removes a helper method from some SYCL attributes which would
provide the name of the attribute. This code wasn't needed because the
diagnostics engine already knows how to print attributes by name.

While making this change, some diagnostics are now properly quoted when
they weren't previously. As a drive-by, I also noticed that the location
of the diagnostics was wrong (it was diagnosing the start of the
attribute range rather than the problematic attribute). This means that
duplicate or conflicting attributes should be warning about the second
attribute (the one causing the conflict) rather than the first
attribute.