### PR TITLE
[Driver][SYCL] Fix SYCL option passing for preprocessing

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6473,17 +6473,21 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   if (IsSYCL) {
-    // Host-side SYCL compilation receives the integration header file as
-    // Inputs[1].  Include the header with -include
-    if (!IsSYCLOffloadDevice && SYCLDeviceInput) {
-      const char *IntHeaderPath =
-          Args.MakeArgString(SYCLDeviceInput->getFilename());
-      CmdArgs.push_back("-include");
-      CmdArgs.push_back(IntHeaderPath);
-      // When creating dependency information, filter out the generated
-      // header file.
-      CmdArgs.push_back("-dependency-filter");
-      CmdArgs.push_back(IntHeaderPath);
+    // Add any options that are needed specific to SYCL offload while
+    // performing the host side compilation.
+    if (!IsSYCLOffloadDevice) {
+      // Host-side SYCL compilation receives the integration header file as
+      // Inputs[1].  Include the header with -include
+      if (SYCLDeviceInput) {
+        const char *IntHeaderPath =
+            Args.MakeArgString(SYCLDeviceInput->getFilename());
+        CmdArgs.push_back("-include");
+        CmdArgs.push_back(IntHeaderPath);
+        // When creating dependency information, filter out the generated
+        // header file.
+        CmdArgs.push_back("-dependency-filter");
+        CmdArgs.push_back(IntHeaderPath);
+      }
       // Let the FE know we are doing a SYCL offload compilation, but we are
       // doing the host pass.
       CmdArgs.push_back("-fsycl");

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -16,8 +16,11 @@
 //  OFFLOAD-AVX-NEXT-SAME: "-target-cpu" "[[HOST_CPU_NAME]]" "-target-feature" "+avx"
 
 /// Check that the needed -fsycl -fsycl-is-device and -fsycl-is-host options
-/// are passed to all of the needed steps with and without preprocessing
+/// are passed to all of the needed compilation steps regardless of final
+/// phase.
 // RUN:  %clang -### -fsycl -c %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
 // RUN:  %clang -### -fsycl -E %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
+// RUN:  %clang -### -fsycl -S %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
+// RUN:  %clang -### -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
 // CHECK-OPTS: clang{{.*}} "-cc1" {{.*}} "-fsycl" "-fsycl-is-device"
 // CHECK-OPTS: clang{{.*}} "-cc1" {{.*}} "-fsycl" "-fsycl-is-host"

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -14,3 +14,10 @@
 //  OFFLOAD-AVX-NEXT: clang{{.*}} "-cc1" {{.*}}
 //  OFFLOAD-AVX-NEXT-SAME: "-fsycl-is-host"
 //  OFFLOAD-AVX-NEXT-SAME: "-target-cpu" "[[HOST_CPU_NAME]]" "-target-feature" "+avx"
+
+/// Check that the needed -fsycl -fsycl-is-device and -fsycl-is-host options
+/// are passed to all of the needed steps with and without preprocessing
+// RUN:  %clang -### -fsycl -c %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
+// RUN:  %clang -### -fsycl -E %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
+// CHECK-OPTS: clang{{.*}} "-cc1" {{.*}} "-fsycl" "-fsycl-is-device"
+// CHECK-OPTS: clang{{.*}} "-cc1" {{.*}} "-fsycl" "-fsycl-is-host"


### PR DESCRIPTION
When performing SYCL offload, various -fsycl -fsycl-is* options are passed
to the host and target compilations respectively.  When performing
preprocessing, a few of these options were not properly passed causing
problems with the generated preprocessed file for the host compilation
side.