### PR TITLE
[SYCL] Rename [[intel::ii]] to [[intel::initiation_interval]]

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1846,13 +1846,14 @@ def SYCLIntelFPGAIVDep : Attr {
   let Documentation = [SYCLIntelFPGAIVDepAttrDocs];
 }
 
-def SYCLIntelFPGAII : Attr {
+def SYCLIntelFPGAInitiationInterval : StmtAttr {
   let Spellings = [CXX11<"intelfpga","ii">,
-                   CXX11<"intel","ii">];
+                   CXX11<"intel","ii">,
+                   CXX11<"intel", "initiation_interval">];
   let Args = [ExprArgument<"IntervalExpr">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let HasCustomTypeTransform = 1;
-  let Documentation = [SYCLIntelFPGAIIAttrDocs];
+  let Documentation = [SYCLIntelFPGAInitiationIntervalAttrDocs];
 }
 
 def SYCLIntelFPGAMaxConcurrency : Attr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2749,24 +2749,27 @@ the no-array ivdep's safelen, with the correspondent treatment by the backend.
   }];
 }
 
-def SYCLIntelFPGAIIAttrDocs : Documentation {
+def SYCLIntelFPGAInitiationIntervalAttrDocs : Documentation {
   let Category = DocCatVariable;
-  let Heading = "intel::ii";
+  let Heading = "intel::initiation_interval";
   let Content = [{
 This attribute applies to a loop. Indicates that the loop should be pipelined
 with an initiation interval of N. N must be a positive integer. Cannot be
 applied multiple times to the same loop.
 
+The ``[[intel::ii]]`` attribute spelling is a deprecated synonym for
+``[[intel::initiation_interval]]`` and will be removed in the future.
+
 .. code-block:: c++
 
   void foo() {
     int var = 0;
-    [[intel::ii(4)]] for (int i = 0; i < 10; ++i) var++;
+    [[intel::initiation_interval(4)]] for (int i = 0; i < 10; ++i) var++;
   }
 
   template<int N>
   void bar() {
-    [[intel::ii(N)]] for(;;) { }
+    [[intel::initiation_interval(N)]] for(;;) { }
   }
 
   }];

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12998,6 +12998,11 @@ public:
   void MarkDevice();
   void MarkSyclSimd();
 
+  /// Emit a diagnostic about the given attribute having a deprecated name, and
+  // also emit a fixit hint to generate the new attribute name.
+  void DiagnoseDeprecatedAttribute(const ParsedAttr &A, StringRef NewScope,
+                                   StringRef NewName);
+
   /// Diagnoses an attribute in the 'intelfpga' namespace and suggests using
   /// the attribute in the 'intel' namespace instead.
   void CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,
@@ -13252,7 +13257,7 @@ FPGALoopAttrT *Sema::BuildSYCLIntelFPGALoopAttr(const AttributeCommonInfo &A,
 
     int Val = ArgVal->getSExtValue();
 
-    if (A.getParsedKind() == ParsedAttr::AT_SYCLIntelFPGAII ||
+    if (A.getParsedKind() == ParsedAttr::AT_SYCLIntelFPGAInitiationInterval ||
         A.getParsedKind() == ParsedAttr::AT_SYCLIntelFPGALoopCoalesce) {
       if (Val <= 0) {
         Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12999,7 +12999,7 @@ public:
   void MarkSyclSimd();
 
   /// Emit a diagnostic about the given attribute having a deprecated name, and
-  // also emit a fixit hint to generate the new attribute name.
+  /// also emit a fixit hint to generate the new attribute name.
   void DiagnoseDeprecatedAttribute(const ParsedAttr &A, StringRef NewScope,
                                    StringRef NewName);
 

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -1017,7 +1017,8 @@ void LoopInfoStack::push(BasicBlock *Header, clang::ASTContext &Ctx,
       addSYCLIVDepInfo(Header->getContext(), IntelFPGAIVDep->getSafelenValue(),
                        IntelFPGAIVDep->getArrayDecl());
 
-    if (const auto *IntelFPGAII = dyn_cast<SYCLIntelFPGAIIAttr>(A))
+    if (const auto *IntelFPGAII =
+            dyn_cast<SYCLIntelFPGAInitiationIntervalAttr>(A))
       setSYCLIInterval(IntelFPGAII->getIntervalExpr()
                            ->getIntegerConstantExpr(Ctx)
                            ->getSExtValue());

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2573,7 +2573,8 @@ bool Parser::ParseSYCLLoopAttributes(ParsedAttributes &Attrs) {
     return true;
 
   if (Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAIVDep &&
-      Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAII &&
+      Attrs.begin()->getKind() !=
+          ParsedAttr::AT_SYCLIntelFPGAInitiationInterval &&
       Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency &&
       Attrs.begin()->getKind() != ParsedAttr::AT_SYCLIntelFPGALoopCoalesce &&
       Attrs.begin()->getKind() !=

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -320,26 +320,53 @@ static bool checkAttrMutualExclusion(Sema &S, Decl *D, const Attr &AL) {
   return false;
 }
 
+void Sema::DiagnoseDeprecatedAttribute(const ParsedAttr &A, StringRef NewScope,
+                                       StringRef NewName) {
+  assert((!NewName.empty() || !NewScope.empty()) &&
+         "Deprecated attribute with no new scope or name?");
+  Diag(A.getLoc(), diag::warn_attribute_spelling_deprecated)
+      << "'" + A.getNormalizedFullName() + "'";
+
+  FixItHint Fix;
+  std::string NewFullName;
+  if (NewScope.empty() && !NewName.empty()) {
+    // Only have a new name.
+    Fix = FixItHint::CreateReplacement(A.getLoc(), NewName);
+    NewFullName =
+        ((A.hasScope() ? A.getScopeName()->getName() : StringRef("")) +
+         "::" + NewName)
+            .str();
+  } else if (NewName.empty() && !NewScope.empty()) {
+    // Only have a new scope.
+    Fix = FixItHint::CreateReplacement(A.getScopeLoc(), NewScope);
+    NewFullName = (NewScope + "::" + A.getAttrName()->getName()).str();
+  } else {
+    // Have both a new name and a new scope.
+    NewFullName = (NewScope + "::" + NewName).str();
+    Fix = FixItHint::CreateReplacement(A.getRange(), NewFullName);
+  }
+
+  Diag(A.getLoc(), diag::note_spelling_suggestion)
+      << "'" + NewFullName + "'"
+      << Fix;
+}
+
 void Sema::CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,
                                                 StringRef NewName) {
+  // Additionally, diagnose the old [[intel::ii]] spelling.
+  if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAInitiationInterval &&
+      A.getAttrName()->isStr("ii")) {
+    DiagnoseDeprecatedAttribute(A, "intel", "initiation_interval");
+    return;
+  }
+
   // All attributes in the intelfpga vendor namespace are deprecated in favor
   // of a name in the intel vendor namespace. By default, assume the attribute
   // retains its original name but changes the namespace. However, some
   // attributes were renamed, so we support supplying a new name as well.
   if (A.hasScope() && A.getScopeName()->isStr("intelfpga")) {
-    Diag(A.getLoc(), diag::warn_attribute_spelling_deprecated)
-        << "'" + A.getNormalizedFullName() + "'";
-
-    FixItHint Fix = NewName.empty()
-                        ? FixItHint::CreateReplacement(A.getScopeLoc(), "intel")
-                        : FixItHint::CreateReplacement(
-                              A.getRange(), ("intel::" + NewName).str());
-
-    Diag(A.getLoc(), diag::note_spelling_suggestion)
-        << (llvm::Twine("'intel::") +
-            (NewName.empty() ? A.getAttrName()->getName() : NewName) + "'")
-               .str()
-        << Fix;
+    DiagnoseDeprecatedAttribute(A, "intel", NewName);
+    return;
   }
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -347,8 +347,7 @@ void Sema::DiagnoseDeprecatedAttribute(const ParsedAttr &A, StringRef NewScope,
   }
 
   Diag(A.getLoc(), diag::note_spelling_suggestion)
-      << "'" + NewFullName + "'"
-      << Fix;
+      << "'" + NewFullName + "'" << Fix;
 }
 
 void Sema::CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -87,7 +87,7 @@ static Attr *handleIntelFPGALoopAttr(Sema &S, const ParsedAttr &A) {
   }
 
   if (NumArgs == 0) {
-    if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAII ||
+    if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGAInitiationInterval ||
         A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency ||
         A.getKind() == ParsedAttr::AT_SYCLIntelFPGAMaxInterleaving ||
         A.getKind() == ParsedAttr::AT_SYCLIntelFPGASpeculatedIterations) {
@@ -639,7 +639,8 @@ static void CheckMutualExclusionSYCLLoopAttribute(
 
 static void CheckForIncompatibleSYCLLoopAttributes(
     Sema &S, const SmallVectorImpl<const Attr *> &Attrs) {
-  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAIIAttr>(S, Attrs);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAInitiationIntervalAttr>(
+      S, Attrs);
   CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGAMaxConcurrencyAttr>(S,
                                                                         Attrs);
   CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGALoopCoalesceAttr>(S, Attrs);
@@ -657,7 +658,8 @@ static void CheckForIncompatibleSYCLLoopAttributes(
                                         SYCLIntelFPGASpeculatedIterationsAttr>(
       S, Attrs);
   CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
-                                        SYCLIntelFPGAIIAttr>(S, Attrs);
+                                        SYCLIntelFPGAInitiationIntervalAttr>(
+      S, Attrs);
   CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
                                         SYCLIntelFPGAIVDepAttr>(S, Attrs);
   CheckMutualExclusionSYCLLoopAttribute<SYCLIntelFPGADisableLoopPipeliningAttr,
@@ -770,8 +772,8 @@ static Attr *ProcessStmtAttribute(Sema &S, Stmt *St, const ParsedAttr &A,
     return handleLoopHintAttr(S, St, A, Range);
   case ParsedAttr::AT_SYCLIntelFPGAIVDep:
     return handleIntelFPGAIVDepAttr(S, A);
-  case ParsedAttr::AT_SYCLIntelFPGAII:
-    return handleIntelFPGALoopAttr<SYCLIntelFPGAIIAttr>(S, A);
+  case ParsedAttr::AT_SYCLIntelFPGAInitiationInterval:
+    return handleIntelFPGALoopAttr<SYCLIntelFPGAInitiationIntervalAttr>(S, A);
   case ParsedAttr::AT_SYCLIntelFPGAMaxConcurrency:
     return handleIntelFPGALoopAttr<SYCLIntelFPGAMaxConcurrencyAttr>(S, A);
   case ParsedAttr::AT_SYCLIntelFPGALoopCoalesce:

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1576,7 +1576,7 @@ TemplateInstantiator::TransformSYCLIntelFPGAInitiationIntervalAttr(
       getDerived().TransformExpr(II->getIntervalExpr()).get();
   return getSema()
       .BuildSYCLIntelFPGALoopAttr<SYCLIntelFPGAInitiationIntervalAttr>(
-      *II, TransformedExpr);
+          *II, TransformedExpr);
 }
 
 const SYCLIntelFPGAMaxConcurrencyAttr *

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1077,8 +1077,9 @@ namespace {
     const LoopHintAttr *TransformLoopHintAttr(const LoopHintAttr *LH);
     const SYCLIntelFPGAIVDepAttr *
     TransformSYCLIntelFPGAIVDepAttr(const SYCLIntelFPGAIVDepAttr *IV);
-    const SYCLIntelFPGAIIAttr *
-    TransformSYCLIntelFPGAIIAttr(const SYCLIntelFPGAIIAttr *II);
+    const SYCLIntelFPGAInitiationIntervalAttr *
+    TransformSYCLIntelFPGAInitiationIntervalAttr(
+        const SYCLIntelFPGAInitiationIntervalAttr *II);
     const SYCLIntelFPGAMaxConcurrencyAttr *
     TransformSYCLIntelFPGAMaxConcurrencyAttr(
         const SYCLIntelFPGAMaxConcurrencyAttr *MC);
@@ -1568,11 +1569,13 @@ TemplateInstantiator::TransformSYCLIntelFPGAIVDepAttr(
   return getSema().BuildSYCLIntelFPGAIVDepAttr(*IVDep, Expr1, Expr2);
 }
 
-const SYCLIntelFPGAIIAttr *TemplateInstantiator::TransformSYCLIntelFPGAIIAttr(
-    const SYCLIntelFPGAIIAttr *II) {
+const SYCLIntelFPGAInitiationIntervalAttr *
+TemplateInstantiator::TransformSYCLIntelFPGAInitiationIntervalAttr(
+    const SYCLIntelFPGAInitiationIntervalAttr *II) {
   Expr *TransformedExpr =
       getDerived().TransformExpr(II->getIntervalExpr()).get();
-  return getSema().BuildSYCLIntelFPGALoopAttr<SYCLIntelFPGAIIAttr>(
+  return getSema()
+      .BuildSYCLIntelFPGALoopAttr<SYCLIntelFPGAInitiationIntervalAttr>(
       *II, TransformedExpr);
 }
 

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -4,10 +4,10 @@
 void foo() {
   // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
   [[intel::ivdep]] int a[10];
-  // expected-error@+1 {{ loop attributes must be applied to for, while, or do statements}}
+  // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
   [[intel::ivdep(2)]] int b[10];
   // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
-  [[intel::ii(2)]] int c[10];
+  [[intel::initiation_interval(2)]] int c[10];
   // expected-error@+1 {{intelfpga loop attributes must be applied to for, while, or do statements}}
   [[intel::max_concurrency(2)]] int d[10];
 
@@ -38,8 +38,13 @@ void foo_deprecated() {
       a[i] = 0;
 
   // expected-warning@+2 {{attribute 'intelfpga::ii' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::ii' instead?}}
+  // expected-note@+1 {{did you mean to use 'intel::initiation_interval' instead?}}
   [[intelfpga::ii(2)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // expected-warning@+2 {{attribute 'intel::ii' is deprecated}}
+  // expected-note@+1 {{did you mean to use 'intel::initiation_interval' instead?}}
+  [[intel::ii(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
   // expected-warning@+2 {{attribute 'intelfpga::max_concurrency' is deprecated}}
@@ -75,11 +80,11 @@ void boo() {
   // expected-error@+1 {{duplicate argument to 'ivdep'; attribute requires one or both of a safelen and array}}
   [[intel::ivdep(2, 2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'ii' attribute takes at least 1 argument; attribute ignored}}
-  [[intel::ii]] for (int i = 0; i != 10; ++i)
+  // expected-warning@+1 {{'initiation_interval' attribute takes at least 1 argument; attribute ignored}}
+  [[intel::initiation_interval]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-warning@+1 {{'ii' attribute takes no more than 1 argument; attribute ignored}}
-  [[intel::ii(2, 2)]] for (int i = 0; i != 10; ++i)
+  // expected-warning@+1 {{'initiation_interval' attribute takes no more than 1 argument; attribute ignored}}
+  [[intel::initiation_interval(2, 2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-warning@+1 {{'max_concurrency' attribute takes at least 1 argument; attribute ignored}}
   [[intel::max_concurrency]] for (int i = 0; i != 10; ++i)
@@ -133,8 +138,8 @@ void goo() {
   // expected-error@+1 {{'ivdep' attribute requires a positive integral compile time constant expression}}
   [[intel::ivdep(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'ii' attribute requires a positive integral compile time constant expression}}
-  [[intel::ii(0)]] for (int i = 0; i != 10; ++i)
+  // expected-error@+1 {{'initiation_interval' attribute requires a positive integral compile time constant expression}}
+  [[intel::initiation_interval(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+1 {{'max_concurrency' attribute requires a non-negative integral compile time constant expression}}
   [[intel::max_concurrency(-1)]] for (int i = 0; i != 10; ++i)
@@ -151,8 +156,8 @@ void goo() {
   // expected-error@+1 {{unknown argument to 'ivdep'; expected integer or array variable}}
   [[intel::ivdep("test123")]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'ii' attribute requires an integer constant}}
-  [[intel::ii("test123")]] for (int i = 0; i != 10; ++i)
+  // expected-error@+1 {{'initiation_interval' attribute requires an integer constant}}
+  [[intel::initiation_interval("test123")]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+1 {{'max_concurrency' attribute requires an integer constant}}
   [[intel::max_concurrency("test123")]] for (int i = 0; i != 10; ++i)
@@ -224,14 +229,14 @@ void zoo() {
   // expected-error@+1 {{duplicate Intel FPGA loop attribute 'max_concurrency'}}
   [[intel::max_concurrency(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  [[intel::ii(2)]]
-  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'ii'}}
-  [[intel::ii(2)]] for (int i = 0; i != 10; ++i)
+  [[intel::initiation_interval(2)]]
+  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'initiation_interval'}}
+  [[intel::initiation_interval(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  [[intel::ii(2)]]
-  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'ii'}}
+  [[intel::initiation_interval(2)]]
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'initiation_interval'}}
   [[intel::max_concurrency(2)]]
-  [[intel::ii(2)]] for (int i = 0; i != 10; ++i)
+  [[intel::initiation_interval(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::disable_loop_pipelining]]
   // expected-error@+1 {{duplicate Intel FPGA loop attribute 'disable_loop_pipelining'}}
@@ -325,8 +330,8 @@ void loop_attrs_compatibility() {
   [[intel::disable_loop_pipelining]]
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+2 {{'ii' and 'disable_loop_pipelining' attributes are not compatible}}
-  [[intel::ii(10)]]
+  // expected-error@+2 {{'initiation_interval' and 'disable_loop_pipelining' attributes are not compatible}}
+  [[intel::initiation_interval(10)]]
   [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+2 {{'disable_loop_pipelining' and 'ivdep' attributes are not compatible}}
@@ -374,13 +379,13 @@ void ivdep_dependent() {
 template <int A, int B, int C>
 void ii_dependent() {
   int a[10];
-  // expected-error@+1 {{'ii' attribute requires a positive integral compile time constant expression}}
-  [[intel::ii(C)]] for (int i = 0; i != 10; ++i)
+  // expected-error@+1 {{'initiation_interval' attribute requires a positive integral compile time constant expression}}
+  [[intel::initiation_interval(C)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'ii'}}
-  [[intel::ii(A)]]
-  [[intel::ii(B)]] for (int i = 0; i != 10; ++i)
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'initiation_interval'}}
+  [[intel::initiation_interval(A)]]
+  [[intel::initiation_interval(B)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
 

--- a/clang/test/SemaSYCL/loop_unroll.cpp
+++ b/clang/test/SemaSYCL/loop_unroll.cpp
@@ -39,7 +39,7 @@ void foo() {
 
   // no error expected
   [[clang::loop_unroll(4)]]
-  [[intel::ii(2)]] for (int i = 0; i < 10; ++i);
+  [[intel::initiation_interval(2)]] for (int i = 0; i < 10; ++i);
 
   // expected-error@+2 {{'loop_unroll' attribute requires an integer constant}}
   int b = 4;


### PR DESCRIPTION
"ii" is a low-quality name that is difficult for users to discover the
meaning of, so rename to a more descriptive name. We also warn that the
old name is deprecated and provide a fix-it to migrate to the new name.

Fixes #3035