### PR TITLE
[ESIMD] Remove propagation of sycl_explicit_simd to the callees

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12996,7 +12996,6 @@ public:
   void checkSYCLDeviceVarDecl(VarDecl *Var);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
   void MarkDevice();
-  void MarkSyclSimd();
 
   /// Diagnoses an attribute in the 'intelfpga' namespace and suggests using
   /// the attribute in the 'intel' namespace instead.

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1014,8 +1014,6 @@ void Sema::ActOnEndOfTranslationUnitFragment(TUFragmentKind Kind) {
       SyclIntHeader->emit(getLangOpts().SYCLIntHeader);
     MarkDevice();
   }
-  if (getLangOpts().SYCLExplicitSIMD)
-    MarkSyclSimd();
 
   emitDeferredDiags();
 

--- a/clang/test/CodeGenSYCL/esimd_metadata2.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata2.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-ESIMD
 
-// This test checks that attribute !intel_reqd_sub_group_size !1 
+// This test checks that attribute !intel_reqd_sub_group_size !1
 // is added for kernels with !sycl_explicit_simd
 
 __attribute__((sycl_device)) void shared_func_decl();

--- a/clang/test/CodeGenSYCL/esimd_metadata2.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata2.cpp
@@ -1,10 +1,7 @@
 // RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-ESIMD
 
-// In ESIMD mode:
-// 1. Attribute !intel_reqd_sub_group_size !1 is added
-//    for kernels with !sycl_explicit_simd
-// 2. Attribute !sycl_explicit_simd is propagated to all the
-//    callees of ESIMD kernel.
+// This test checks that attribute !intel_reqd_sub_group_size !1 
+// is added for kernels with !sycl_explicit_simd
 
 __attribute__((sycl_device)) void shared_func_decl();
 __attribute__((sycl_device)) void shared_func() { shared_func_decl(); }
@@ -13,7 +10,7 @@ __attribute__((sycl_device)) __attribute__((sycl_explicit_simd)) void esimd_func
 
 // CHECK-ESIMD-DAG: define {{.*}}spir_kernel void @{{.*}}kernel_cm() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {{.*}} !intel_reqd_sub_group_size ![[SGSIZE1:[0-9]+]] {{.*}}{
 // CHECK-ESIMD-DAG: define {{.*}}spir_func void @{{.*}}esimd_funcv() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {
-// CHECK-ESIMD-DAG: define {{.*}}spir_func void @{{.*}}shared_funcv() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {
+// CHECK-ESIMD-DAG: define {{.*}}spir_func void @{{.*}}shared_funcv() #{{[0-9]+}} {
 // CHECK-ESIMD-DAG: define linkonce_odr spir_func void @_ZN12ESIMDFunctorclEv({{.*}}) #{{[0-9]+}} {{.*}} !sycl_explicit_simd !{{[0-9]+}} {
 // CHECK-ESIMD-DAG: declare spir_func void @{{.*}}shared_func_declv() #{{[0-9]+}}
 

--- a/clang/test/CodeGenSYCL/esimd_metadata3.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata3.cpp
@@ -1,7 +1,0 @@
-// RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-ESIMD
-
-__attribute__((sycl_device)) void funcWithSpirvIntrin() {}
-__attribute__((sycl_device)) __attribute__((sycl_explicit_simd)) void standaloneCmFunc() { funcWithSpirvIntrin(); }
-
-// CHECK-ESIMD-DAG: define {{.*}}spir_func void @{{.*}}funcWithSpirvIntrinv() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {
-// CHECK-ESIMD-DAG: define {{.*}}spir_func void @{{.*}}standaloneCmFuncv() #{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} {


### PR DESCRIPTION
We don't need to mark the ESIMD CFG since all ESIMD-specific passes will work exclusively on the ESIMD code. So, in ESIMD passes we don't have to worry about breaking other SYCL code.