### PR TITLE
[SYCL][NFC] Code cleanup revealed by self-build.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1126,12 +1126,8 @@ public:
                            QualType) {
     return true;
   }
-  virtual bool enterUnion(const CXXRecordDecl *, FieldDecl *) override {
-    return true;
-  }
-  virtual bool leaveUnion(const CXXRecordDecl *, FieldDecl *) override {
-    return true;
-  }
+  virtual bool enterUnion(const CXXRecordDecl *, FieldDecl *) { return true; }
+  virtual bool leaveUnion(const CXXRecordDecl *, FieldDecl *) { return true; }
 
   // The following are used for stepping through array elements.
   virtual bool enterArray(FieldDecl *, QualType ArrayTy, QualType ElementTy) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3482,7 +3482,7 @@ static const char *paramKind2Str(KernelParamKind K) {
     CASE(sampler);
     CASE(pointer);
   }
-    return "<ERROR>";
+  return "<ERROR>";
 #undef CASE
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1126,8 +1126,12 @@ public:
                            QualType) {
     return true;
   }
-  virtual bool enterUnion(const CXXRecordDecl *, FieldDecl *) { return true; }
-  virtual bool leaveUnion(const CXXRecordDecl *, FieldDecl *) { return true; }
+  virtual bool enterUnion(const CXXRecordDecl *, FieldDecl *) override {
+    return true;
+  }
+  virtual bool leaveUnion(const CXXRecordDecl *, FieldDecl *) override {
+    return true;
+  }
 
   // The following are used for stepping through array elements.
   virtual bool enterArray(FieldDecl *, QualType ArrayTy, QualType ElementTy) {
@@ -3477,7 +3481,6 @@ static const char *paramKind2Str(KernelParamKind K) {
     CASE(std_layout);
     CASE(sampler);
     CASE(pointer);
-  default:
     return "<ERROR>";
   }
 #undef CASE

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3481,8 +3481,8 @@ static const char *paramKind2Str(KernelParamKind K) {
     CASE(std_layout);
     CASE(sampler);
     CASE(pointer);
-    return "<ERROR>";
   }
+    return "<ERROR>";
 #undef CASE
 }
 

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -364,8 +364,6 @@ static void collectKernelModuleMap(
         // the map key is not significant here
         ResKernelModuleMap["<GLOBAL>"].push_back(&F);
         break;
-      default:
-        llvm_unreachable("unknown scope");
       }
     }
   }


### PR DESCRIPTION
Remove redundant false case in switch statement following:
https://llvm.org/docs/CodingStandards.html#don-t-use-default-labels-in-fully-covered-switches-over-enumerations