### PR TITLE
[SYCL] Test memory allocated by buffer creation API.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2246,10 +2246,6 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
   bool DeviceIsIntegrated = Context->Devices.size() == 1 &&
                             Context->Devices[0]->ZeDeviceProperties.flags &
                                 ZE_DEVICE_PROPERTY_FLAG_INTEGRATED;
-  if (DeviceIsIntegrated)
-    zePrint("Buffer Create: Integrated GPU will use zeMemAllocHost\n");
-  else
-    zePrint("Buffer Create: Discrete GPU will use zeMemAllocDevice\n");
 
   // Having PI_MEM_FLAGS_HOST_PTR_ALLOC for buffer requires allocation of
   // pinned host memory which then becomes automatically accessible from

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2246,6 +2246,10 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
   bool DeviceIsIntegrated = Context->Devices.size() == 1 &&
                             Context->Devices[0]->ZeDeviceProperties.flags &
                                 ZE_DEVICE_PROPERTY_FLAG_INTEGRATED;
+  if (DeviceIsIntegrated)
+    zePrint("Buffer Create: Integrated GPU will use zeMemAllocHost\n");
+  else
+    zePrint("Buffer Create: Discrete GPU will use zeMemAllocDevice\n");
 
   // Having PI_MEM_FLAGS_HOST_PTR_ALLOC for buffer requires allocation of
   // pinned host memory which then becomes automatically accessible from

--- a/sycl/test/on-device/basic_tests/buffer/buffer_create.cpp
+++ b/sycl/test/on-device/basic_tests/buffer/buffer_create.cpp
@@ -1,0 +1,26 @@
+// REQUIRES: gpu,level_zero
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env ZE_DEBUG=1 %GPU_RUN_PLACEHOLDER %t.out 2> %t1.out; cat %t1.out %GPU_CHECK_PLACEHOLDER
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main() {
+  constexpr int Size = 100;
+  {
+    queue Queue;
+    buffer<::cl_int, 1> Buffer(Size);
+
+    Queue.submit([&](handler &cgh) {
+      accessor Accessor{Buffer, cgh, read_write};
+      cgh.parallel_for<class CreateBuffer>(range<1>(Size), [=](id<1> ID) {});
+    });
+    Queue.wait();
+  }
+
+  return 0;
+}
+
+// CHECK: Buffer Create: {{Integrated|Discrete}} GPU will use [[API:zeMemAllocHost|zeMemAllocDevice]]
+// CHECK-NEXT: ZE ---> [[API]](


### PR DESCRIPTION
This change enables testing whether buffers on integrated / discrete devices are created in host / device memory as expected.
Signed-off-by: rdeodhar <rajiv.deodhar@intel.com>