### PR TITLE
[SYCL] Allow using interop program constructor with multi-device context

### DIFF
--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -123,14 +123,6 @@ program_impl::program_impl(ContextImplPtr Context,
                            pi_native_handle InteropProgram,
                            RT::PiProgram Program)
     : MProgram(Program), MContext(Context), MLinkable(true) {
-
-  if (Context->getDevices().size() > 1) {
-    throw feature_not_supported(
-        "multiple devices within a context are not supported with "
-        "sycl::program and sycl::kernel",
-        PI_INVALID_OPERATION);
-  }
-
   const detail::plugin &Plugin = getPlugin();
   if (MProgram == nullptr) {
     assert(InteropProgram &&
@@ -172,6 +164,12 @@ program_impl::program_impl(ContextImplPtr Context,
   Plugin.call<PiApiKind::piProgramGetBuildInfo>(
       MProgram, Device, CL_PROGRAM_BINARY_TYPE, sizeof(cl_program_binary_type),
       &BinaryType, nullptr);
+  if (BinaryType == CL_PROGRAM_BINARY_TYPE_NONE) {
+    throw invalid_object_error(
+        "The native program passed to the program constructor has to be either "
+        "compiled or linked",
+        PI_INVALID_PROGRAM);
+  }
   size_t Size = 0;
   Plugin.call<PiApiKind::piProgramGetBuildInfo>(
       MProgram, Device, CL_PROGRAM_BUILD_OPTIONS, 0, nullptr, &Size);
@@ -182,7 +180,7 @@ program_impl::program_impl(ContextImplPtr Context,
   string_class Options(OptionsVector.begin(), OptionsVector.end());
   switch (BinaryType) {
   case CL_PROGRAM_BINARY_TYPE_NONE:
-    MState = program_state::none;
+    assert(false);
     break;
   case CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT:
     MState = program_state::compiled;


### PR DESCRIPTION
Since programs created with the interoperability constructor have to be
already compiled or linked, they don't run into the same limitations as
those created internally by the runtime.

In addition, enforce this state requirement by throwing an
invalid_object_error if the native program is neither compiled nor linked
as required by SYCL 1.2.1 specification.