### PR TITLE
Configure issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Please describe the steps to reproduce the behavior:
+
+1. Include code snippet as short as possible
+2. Specify the command which should be used to compile the program
+3. Specify the comment which should be used to launch the program
+4. Indicate what is wrong and what was expected
+
+**Environment (please complete the following information):**
+
+- OS: [e.g Windows/Linux]
+- Target device and vendor: [e.g. Intel GPU]
+- DPC++ version: [e.g. commit hash or output of `clang++ --version`]
+- Dependencies version: [e.g. low-level runtime versions (like NEO 20.04)]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Ask community a question
+    url: https://github.com/intel/llvm/discussions/categories/q-a
+    about: Please use Q&A Discussions category instead of Issues to ask questions

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea/improvement for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe**
+A clear and concise description of what the problem is.
+Include reproducer or code/pseudo-code example.
+Include specific environment details where problem occurs.
+
+**Describe the solution you would like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you have considered**
+A clear and concise description of any alternative solutions or features you
+have considered.
+
+**Additional context**
+Add any other context about the feature request here.


### PR DESCRIPTION
Added templates for bug and feature issue types. Added a link to
Discussions tab which will be displayed when creating an issue.

With this PR "New issue page" will look like: 
![image](https://user-images.githubusercontent.com/6417047/107055508-6c2b9f00-67e2-11eb-8485-a532352ba23b.png)
