### PR TITLE
[SYCL][NFC] Remove some work-arounds for C++11

### DIFF
--- a/sycl/include/CL/sycl/ONEAPI/atomic_enums.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/atomic_enums.hpp
@@ -60,9 +60,7 @@ __SYCL_INLINE_CONSTEXPR memory_scope memory_scope_system = memory_scope::system;
 
 #ifndef __SYCL_DEVICE_ONLY__
 namespace detail {
-// Cannot use switch statement in constexpr before C++14
-// Nested ternary conditions in else branch required for C++11
-#if __cplusplus >= 201402L
+
 static inline constexpr std::memory_order
 getStdMemoryOrder(::cl::sycl::ONEAPI::memory_order order) {
   switch (order) {
@@ -80,22 +78,7 @@ getStdMemoryOrder(::cl::sycl::ONEAPI::memory_order order) {
     return std::memory_order_seq_cst;
   }
 }
-#else
-static inline constexpr std::memory_order
-getStdMemoryOrder(::cl::sycl::ONEAPI::memory_order order) {
-  return (order == memory_order::relaxed)
-             ? std::memory_order_relaxed
-             : (order == memory_order::__consume_unsupported)
-                   ? std::memory_order_consume
-                   : (order == memory_order::acquire)
-                         ? std::memory_order_acquire
-                         : (order == memory_order::release)
-                               ? std::memory_order_release
-                               : (order == memory_order::acq_rel)
-                                     ? std::memory_order_acq_rel
-                                     : std::memory_order_seq_cst;
-}
-#endif // __cplusplus
+
 } // namespace detail
 #endif // __SYCL_DEVICE_ONLY__
 

--- a/sycl/include/CL/sycl/ONEAPI/atomic_ref.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/atomic_ref.hpp
@@ -69,9 +69,6 @@ template <> struct memory_order_traits<memory_order::seq_cst> {
   static constexpr memory_order write_order = memory_order::seq_cst;
 };
 
-// Cannot use switch statement in constexpr before C++14
-// Nested ternary conditions in else branch required for C++11
-#if __cplusplus >= 201402L
 inline constexpr memory_order getLoadOrder(memory_order order) {
   switch (order) {
   case memory_order_relaxed:
@@ -87,14 +84,6 @@ inline constexpr memory_order getLoadOrder(memory_order order) {
     return memory_order_seq_cst;
   }
 }
-#else
-inline constexpr memory_order getLoadOrder(memory_order order) {
-  return (order == memory_order_relaxed)
-             ? memory_order_relaxed
-             : (order == memory_order_seq_cst) ? memory_order_seq_cst
-                                               : memory_order_acquire;
-}
-#endif
 
 template <typename T, typename = void> struct bit_equal;
 

--- a/sycl/include/CL/sycl/ONEAPI/functional.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/functional.hpp
@@ -19,7 +19,6 @@ template <typename T = void> struct minimum {
   }
 };
 
-#if __cplusplus >= 201402L
 template <> struct minimum<void> {
   struct is_transparent {};
   template <typename T, typename U>
@@ -30,7 +29,6 @@ template <> struct minimum<void> {
                : std::forward<U>(rhs);
   }
 };
-#endif
 
 template <typename T = void> struct maximum {
   T operator()(const T &lhs, const T &rhs) const {
@@ -38,7 +36,6 @@ template <typename T = void> struct maximum {
   }
 };
 
-#if __cplusplus >= 201402L
 template <> struct maximum<void> {
   struct is_transparent {};
   template <typename T, typename U>
@@ -50,7 +47,6 @@ template <> struct maximum<void> {
                : std::forward<U>(rhs);
   }
 };
-#endif
 
 template <typename T = void> using plus = std::plus<T>;
 template <typename T = void> using multiplies = std::multiplies<T>;

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -26,11 +26,6 @@
 #else
 #define __SYCL_CONSTEXPR_ON_DEVICE
 #endif
-#if __cplusplus >= 201402L
-#define _CPP14_CONSTEXPR constexpr
-#else
-#define _CPP14_CONSTEXPR
-#endif
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -80,7 +75,7 @@ public:
   }
 
   // Operator neg
-  _CPP14_CONSTEXPR half &operator-() {
+  constexpr half &operator-() {
     Buf ^= 0x8000;
     return *this;
   }
@@ -207,11 +202,11 @@ public:
     operator--();
     return ret;
   }
-  _CPP14_CONSTEXPR half &operator-() {
+  constexpr half &operator-() {
     Data = -Data;
     return *this;
   }
-  _CPP14_CONSTEXPR half operator-() const {
+  constexpr half operator-() const {
     half r = *this;
     return -r;
   }


### PR DESCRIPTION
C++14 is required after https://github.com/intel/llvm/pull/3053
Thus some of C++11 workarounds in the code became unnecessary.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>