### PR TITLE
[SYCL] Temporarily restore event deps in in-order queues for Level Zero

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -499,7 +499,8 @@ void Command::processDepEvent(EventImplPtr DepEvent, const DepDesc &Dep) {
   // TODO temporarily disabled with Level Zero since the enqueued operations
   // that are implemented directly in the plugin (e.g. map/unmap) do not satisfy
   // in-order queue requirements.
-  if (WorkerQueue->getPlugin().getBackend() != backend::level_zero)
+  if (WorkerQueue->is_host() ||
+      WorkerQueue->getPlugin().getBackend() != backend::level_zero)
     if (Dep.MDepCommand && Dep.MDepCommand->getWorkerQueue() == WorkerQueue &&
         WorkerQueue->has_property<property::queue::in_order>())
       return;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -496,9 +496,13 @@ void Command::processDepEvent(EventImplPtr DepEvent, const DepDesc &Dep) {
   }
 
   // Do not add redundant event dependencies for in-order queues.
-  if (Dep.MDepCommand && Dep.MDepCommand->getWorkerQueue() == WorkerQueue &&
-      WorkerQueue->has_property<property::queue::in_order>())
-    return;
+  // TODO temporarily disabled with Level Zero since the enqueued operations
+  // that are implemented directly in the plugin (e.g. map/unmap) do not satisfy
+  // in-order queue requirements.
+  if (WorkerQueue->getPlugin().getBackend() != backend::level_zero)
+    if (Dep.MDepCommand && Dep.MDepCommand->getWorkerQueue() == WorkerQueue &&
+        WorkerQueue->has_property<property::queue::in_order>())
+      return;
 
   ContextImplPtr DepEventContext = DepEvent->getContextImpl();
   // If contexts don't match we'll connect them using host task

--- a/sycl/unittests/scheduler/InOrderQueueDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueDeps.cpp
@@ -83,6 +83,13 @@ TEST_F(SchedulerTest, InOrderQueueDeps) {
     std::cout << "Not run due to host-only environment\n";
     return;
   }
+  if (detail::getSyclObjImpl(Plt)->getPlugin().getBackend() ==
+      backend::level_zero) {
+    std::cout << "Removal of redundant dependencies in in-order queues is "
+                 "disabled for Level Zero until it is supported by the plugin"
+              << std::endl;
+    return;
+  }
 
   unittest::PiMock Mock{Plt};
   Mock.redefine<detail::PiApiKind::piMemBufferCreate>(redefinedMemBufferCreate);


### PR DESCRIPTION
Some of the enqueued operations are implemented directly in the Level
Zero plugin (e.g. map/unmap) and their implementation does not satisfy
in-order queue requirements, leading to incorrect behaviour if the event
dependencies that should be redundant are dropped.

Restore these event dependencies until this is fixed in the Level Zero
plugin.