### PR TITLE
[sycl-post-link] Enable ESIMD-specific lowering

### DIFF
--- a/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
@@ -1,0 +1,66 @@
+; This is a basic test for Lowering ESIMD constructs after splitting.
+; This test also implicitly checks that input module is not reused
+; for ESIMD kernels in any case.
+
+; No lowering
+; RUN: sycl-post-link -split-esimd -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-NO-LOWERING
+
+; Default lowering
+; RUN: sycl-post-link -split-esimd -lower-esimd -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O2
+
+; -O2 lowering
+; RUN: sycl-post-link -split-esimd -lower-esimd -O2 -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O2
+
+; -O0 lowering
+; RUN: sycl-post-link -split-esimd -lower-esimd -O0 -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O0
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-linux-sycldevice"
+
+declare dso_local spir_func i64 @_Z28__spirv_GlobalInvocationId_xv()
+
+define dso_local spir_kernel void @ESIMD_kernel() #0 !sycl_explicit_simd !3 {
+entry:
+  %call = tail call spir_func i64 @_Z28__spirv_GlobalInvocationId_xv()
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="a.cpp" }
+
+!llvm.module.flags = !{!0}
+!opencl.spir.version = !{!1}
+!spirv.Source = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{i32 0, i32 100000}
+!3 = !{}
+
+; By default, no lowering is performed
+; CHECK-NO-LOWERING: declare dso_local spir_func i64 @_Z28__spirv_GlobalInvocationId_xv()
+; CHECK-NO-LOWERING: define dso_local spir_kernel void @ESIMD_kernel()
+; CHECK-NO-LOWERING: entry:
+; CHECK-NO-LOWERING:   %call = tail call spir_func i64 @_Z28__spirv_GlobalInvocationId_xv()
+; CHECK-NO-LOWERING:   ret void
+; CHECK-NO-LOWERING: }
+
+; With -O0, we only lower ESIMD code, but no other optimizations
+; CHECK-O0: declare dso_local spir_func i64 @_Z28__spirv_GlobalInvocationId_xv()
+; CHECK-O0: define dso_local spir_kernel void @ESIMD_kernel() #1 !sycl_explicit_simd !3 !intel_reqd_sub_group_size !4 {
+; CHECK-O0: entry:
+; CHECK-O0:   call <3 x i32> @llvm.genx.local.id.v3i32()
+; CHECK-O0:   call <3 x i32> @llvm.genx.local.size.v3i32()
+; CHECK-O0:   call i32 @llvm.genx.group.id.x()
+; CHECK-O0:   ret void
+; CHECK-O0: }
+
+; With -O2, unused call was optimized away
+; CHECK-O2: declare dso_local spir_func i64 @_Z28__spirv_GlobalInvocationId_xv()
+; CHECK-O2: define dso_local spir_kernel void @ESIMD_kernel()
+; CHECK-O2: entry:
+; CHECK-O2:   ret void
+; CHECK-O2: }

--- a/llvm/tools/sycl-post-link/CMakeLists.txt
+++ b/llvm/tools/sycl-post-link/CMakeLists.txt
@@ -5,13 +5,26 @@ set(LLVM_LINK_COMPONENTS
   IRReader
   Support
   TransformUtils
+  SYCLLowerIR
   )
+
+get_property(LLVMGenXIntrinsics_SOURCE_DIR GLOBAL PROPERTY LLVMGenXIntrinsics_SOURCE_PROP)
+get_property(LLVMGenXIntrinsics_BINARY_DIR GLOBAL PROPERTY LLVMGenXIntrinsics_BINARY_PROP)
+
+include_directories(
+  ${LLVMGenXIntrinsics_SOURCE_DIR}/GenXIntrinsics/include
+  ${LLVMGenXIntrinsics_BINARY_DIR}/GenXIntrinsics/include)
 
 add_llvm_tool(sycl-post-link
   sycl-post-link.cpp
   SPIRKernelParamOptInfo.cpp
   SpecConstants.cpp
 
+  ADDITIONAL_HEADER_DIRS
+  ${LLVMGenXIntrinsics_SOURCE_DIR}/GenXIntrinsics/include
+  ${LLVMGenXIntrinsics_BINARY_DIR}/GenXIntrinsics/include
+
   DEPENDS
   intrinsics_gen
+  LLVMGenXIntrinsics
   )

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -96,13 +96,14 @@ static cl::opt<bool> SplitEsimd{"split-esimd",
                                 cl::desc("Split SYCL and ESIMD kernels"),
                                 cl::cat(PostLinkCat)};
 
-// TODO Design note: sycl-post-link should probably separate different kinds of its
-// functionality on  logical and source level:
+// TODO Design note: sycl-post-link should probably separate different kinds of
+// its functionality on  logical and source level:
 //  - LLVM IR module splitting
 //  - Running LLVM IR passes on resulting modules
 //  - Generating additional files (like spec constants, dead arg info,...)
-// The tool itself could be just a "driver" creating needed pipelines from the above actions.
-// This could help make the tool structure clearer and more maintainable.
+// The tool itself could be just a "driver" creating needed pipelines from the
+// above actions. This could help make the tool structure clearer and more
+// maintainable.
 
 static cl::opt<bool> LowerEsimd{
     "lower-esimd", cl::desc("Lower ESIMD constructs"), cl::cat(PostLinkCat)};
@@ -704,8 +705,10 @@ static void LowerEsimdConstructs(Module &M) {
     // ESIMD/accessor_gather_scatter.cpp test work.
     MPM.add(createFunctionInliningPassHelper());
     MPM.add(createSROAPass());
-    MPM.add(createESIMDLowerVecArgPass());
-    MPM.add(createESIMDLowerLoadStorePass());
+  }
+  MPM.add(createESIMDLowerVecArgPass());
+  MPM.add(createESIMDLowerLoadStorePass());
+  if (!OptLevelO0) {
     MPM.add(createSROAPass());
     MPM.add(createEarlyCSEPass(true));
     MPM.add(createInstructionCombiningPass());

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -96,6 +96,14 @@ static cl::opt<bool> SplitEsimd{"split-esimd",
                                 cl::desc("Split SYCL and ESIMD kernels"),
                                 cl::cat(PostLinkCat)};
 
+// TODO Design note: sycl-post-link should probably separate different kinds of its
+// functionality on  logical and source level:
+//  - LLVM IR module splitting
+//  - Running LLVM IR passes on resulting modules
+//  - Generating additional files (like spec constants, dead arg info,...)
+// The tool itself could be just a "driver" creating needed pipelines from the above actions.
+// This could help make the tool structure clearer and more maintainable.
+
 static cl::opt<bool> LowerEsimd{
     "lower-esimd", cl::desc("Lower ESIMD constructs"), cl::cat(PostLinkCat)};
 


### PR DESCRIPTION
This is the first patch in the effort of moving ESIMD-specific
lowering passes from clang FE (BackendUtils.cpp) to the
sycl-post-link tool after SYCL-ESIMD splitting.