### PR TITLE
[SYCL] Ignore file-scope asm during device-side SYCL compilation.

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -6037,6 +6037,9 @@ void CodeGenModule::EmitTopLevelDecl(Decl *D) {
     // File-scope asm is ignored during device-side OpenMP compilation.
     if (LangOpts.OpenMPIsDevice)
       break;
+    // File-scope asm is ignored during device-side SYCL compilation.
+    if (LangOpts.SYCLIsDevice)
+      break;
     auto *AD = cast<FileScopeAsmDecl>(D);
     getModule().appendModuleInlineAsm(AD->getAsmString()->getString());
     break;

--- a/clang/test/CodeGenSYCL/filescope_asm.c
+++ b/clang/test/CodeGenSYCL/filescope_asm.c
@@ -1,0 +1,8 @@
+// RUN:  %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
+//
+// 
+// Check that file-scope asm is ignored during device-side SYCL compilation. 
+//
+//
+// CHECK-NOT: module asm "foo"
+__asm__ ("foo");

--- a/clang/test/CodeGenSYCL/filescope_asm.c
+++ b/clang/test/CodeGenSYCL/filescope_asm.c
@@ -1,8 +1,6 @@
 // RUN:  %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
 //
-//
 // Check that file-scope asm is ignored during device-side SYCL compilation.
-//
 //
 // CHECK-NOT: module asm "foo"
 __asm__("foo");

--- a/clang/test/CodeGenSYCL/filescope_asm.c
+++ b/clang/test/CodeGenSYCL/filescope_asm.c
@@ -1,8 +1,8 @@
 // RUN:  %clang_cc1 -fsycl -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -emit-llvm %s -o - | FileCheck %s
 //
-// 
-// Check that file-scope asm is ignored during device-side SYCL compilation. 
+//
+// Check that file-scope asm is ignored during device-side SYCL compilation.
 //
 //
 // CHECK-NOT: module asm "foo"
-__asm__ ("foo");
+__asm__("foo");

--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -22,10 +22,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Triple.h"
-#include "llvm/Bitcode/BitcodeReader.h"
-#include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/LLVMContext.h"
-#include "llvm/IRReader/IRReader.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/ArchiveWriter.h"
 #include "llvm/Object/Binary.h"
@@ -41,7 +38,6 @@
 #include "llvm/Support/Program.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/StringSaver.h"
-#include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
@@ -589,36 +585,8 @@ class ObjectFileHandler final : public FileHandler {
       if (!BufOrErr)
         return createFileError(InputFileNames[I], BufOrErr.getError());
 
-      std::unique_ptr<MemoryBuffer> Buf = std::move(*BufOrErr);
-
-      // Workaround for the absence of assembly parser for spir target. If this
-      // input is a bitcode for spir target we need to remove module-level
-      // inline asm from it, if there is one, and recreate the buffer with new
-      // contents.
-      // TODO: remove this workaround once spir target gets asm parser.
-      if (isBitcode((const unsigned char *)Buf->getBufferStart(),
-                    (const unsigned char *)Buf->getBufferEnd()))
-        if (getTargetTriple(TargetNames[I]).isSPIR()) {
-          SMDiagnostic Err;
-          std::unique_ptr<Module> Mod = parseIR(*Buf, Err, Context);
-          if (!Mod)
-            return createStringError(inconvertibleErrorCode(),
-                                     Err.getMessage());
-
-          if (!Mod->getModuleInlineAsm().empty()) {
-            Mod->setModuleInlineAsm("");
-
-            SmallVector<char, 0> ModuleBuf;
-            raw_svector_ostream ModuleOS(ModuleBuf);
-            WriteBitcodeToFile(*Mod, ModuleOS);
-
-            Buf = MemoryBuffer::getMemBufferCopy(ModuleOS.str(),
-                                                 Buf->getBufferIdentifier());
-          }
-        }
-
       Expected<std::unique_ptr<Binary>> BinOrErr =
-          createBinary(Buf->getMemBufferRef(), &Context);
+          createBinary(BufOrErr.get()->getMemBufferRef(), &Context);
 
       // If it is not a symbolic file just ignore it since we cannot do anything
       // with it.
@@ -1502,11 +1470,6 @@ int main(int argc, const char **argv) {
     cl::PrintHelpMessage();
     return 0;
   }
-
-  // These calls are needed so that we can read bitcode correctly.
-  InitializeAllTargetInfos();
-  InitializeAllTargetMCs();
-  InitializeAllAsmParsers();
 
   auto reportError = [argv](Error E) {
     logAllUnhandledErrors(std::move(E), WithColor::error(errs(), argv[0]));


### PR DESCRIPTION
Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>