### PR TITLE
[SYCL] Store the constant expression value into the ConstantExpr object.

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -16227,7 +16227,8 @@ Sema::VerifyIntegerConstantExpression(Expr *E, llvm::APSInt *Result,
     if (Result)
       *Result = E->EvaluateKnownConstIntCheckOverflow(Context);
     if (!isa<ConstantExpr>(E))
-      E = ConstantExpr::Create(Context, E);
+      E = Result ? ConstantExpr::Create(Context, E, APValue(*Result))
+                 : ConstantExpr::Create(Context, E);
     return E;
   }
 

--- a/clang/test/AST/ast-dump-c-attr.c
+++ b/clang/test/AST/ast-dump-c-attr.c
@@ -34,8 +34,9 @@ struct [[deprecated]] Test4 {
 // CHECK-NEXT:   FieldDecl{{.*}}Test6
 // CHECK-NEXT:     DeprecatedAttr 0x{{[^ ]*}} <col:5, col:25> "Frobble" ""
 // CHECK-NEXT:   FieldDecl{{.*}}Test7
-// CHECK-NEXT:     Constant{{.*}}'int'
-// CHECK-NEXT:       IntegerLiteral{{.*}}'int' 12
+// CHECK-NEXT:     ConstantExpr{{.*}}'int'
+// CHECK-NEXT:       value: Int 12
+// CHECK-NEXT:         IntegerLiteral{{.*}}'int' 12
 // CHECK-NEXT:     DeprecatedAttr 0x{{[^ ]*}} <col:15> "" ""
 
 struct [[deprecated]] Test8;

--- a/clang/test/AST/ast-dump-decl-json.c
+++ b/clang/test/AST/ast-dump-decl-json.c
@@ -948,6 +948,7 @@ void testParmVarDecl(int TestParmVarDecl);
 // CHECK-NEXT:     "qualType": "int"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "valueCategory": "rvalue",
+// CHECK-NEXT:    "value": "1",
 // CHECK-NEXT:    "inner": [
 // CHECK-NEXT:     {
 // CHECK-NEXT:      "id": "0x{{.*}}",
@@ -1668,6 +1669,7 @@ void testParmVarDecl(int TestParmVarDecl);
 // CHECK-NEXT:     "qualType": "int"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "valueCategory": "rvalue",
+// CHECK-NEXT:    "value": "1",
 // CHECK-NEXT:    "inner": [
 // CHECK-NEXT:     {
 // CHECK-NEXT:      "id": "0x{{.*}}",

--- a/clang/test/AST/ast-dump-decl.c
+++ b/clang/test/AST/ast-dump-decl.c
@@ -112,7 +112,8 @@ enum testEnumConstantDecl {
 // CHECK:      EnumConstantDecl{{.*}} TestEnumConstantDecl 'int'
 // CHECK:      EnumConstantDecl{{.*}} TestEnumConstantDeclInit 'int'
 // CHECK-NEXT:   ConstantExpr
-// CHECK-NEXT:     IntegerLiteral
+// CHECK-NEXT:     value: Int 1
+// CHECK-NEXT:       IntegerLiteral
 
 struct testIndirectFieldDecl {
   struct {
@@ -160,7 +161,8 @@ struct testFieldDecl {
 // CHECK:      FieldDecl{{.*}} TestFieldDecl 'int'
 // CHECK:      FieldDecl{{.*}} TestFieldDeclWidth 'int'
 // CHECK-NEXT:   ConstantExpr
-// CHECK-NEXT:     IntegerLiteral
+// CHECK-NEXT:     value: Int 1
+// CHECK-NEXT:       IntegerLiteral
 // CHECK-MODULE:      FieldDecl{{.*}} TestFieldDeclPrivate 'int' __module_private__
 
 int TestVarDecl;

--- a/clang/test/AST/ast-dump-openmp-distribute-parallel-for-simd.c
+++ b/clang/test/AST/ast-dump-openmp-distribute-parallel-for-simd.c
@@ -113,6 +113,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPDistributeParallelForSimdDirective {{.*}} <line:17:1, col:53>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:42, col:52>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:51> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:51> 'int' 1
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:18:3, line:20:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -159,6 +160,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPDistributeParallelForSimdDirective {{.*}} <line:24:1, col:53>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:42, col:52>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:51> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:51> 'int' 2
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:25:3, line:27:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -206,6 +208,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPDistributeParallelForSimdDirective {{.*}} <line:31:1, col:53>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:42, col:52>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:51> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:51> 'int' 2
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:32:3, line:35:9>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow

--- a/clang/test/AST/ast-dump-openmp-distribute-parallel-for.c
+++ b/clang/test/AST/ast-dump-openmp-distribute-parallel-for.c
@@ -113,6 +113,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPDistributeParallelForDirective {{.*}} <line:17:1, col:48>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:37, col:47>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:46> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:46> 'int' 1
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:18:3, line:20:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -159,6 +160,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPDistributeParallelForDirective {{.*}} <line:24:1, col:48>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:37, col:47>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:46> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:46> 'int' 2
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:25:3, line:27:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -206,6 +208,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPDistributeParallelForDirective {{.*}} <line:31:1, col:48>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:37, col:47>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:46> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:46> 'int' 2
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:32:3, line:35:9>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow

--- a/clang/test/AST/ast-dump-openmp-distribute-simd.c
+++ b/clang/test/AST/ast-dump-openmp-distribute-simd.c
@@ -105,6 +105,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPDistributeSimdDirective {{.*}} <line:17:1, col:40>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:29, col:39>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:38> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:38> 'int' 1
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:18:3, line:20:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -147,6 +148,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPDistributeSimdDirective {{.*}} <line:24:1, col:40>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:29, col:39>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:38> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:38> 'int' 2
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:25:3, line:27:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -190,6 +192,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPDistributeSimdDirective {{.*}} <line:31:1, col:40>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:29, col:39>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:38> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:38> 'int' 2
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:32:3, line:35:9>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow

--- a/clang/test/AST/ast-dump-openmp-distribute.c
+++ b/clang/test/AST/ast-dump-openmp-distribute.c
@@ -105,6 +105,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPDistributeDirective {{.*}} <line:17:1, col:35>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:24, col:34>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:33> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:33> 'int' 1
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:18:3, line:20:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>
@@ -147,6 +148,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPDistributeDirective {{.*}} <line:24:1, col:35>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:24, col:34>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:33> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:33> 'int' 2
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:25:3, line:27:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>
@@ -190,6 +192,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPDistributeDirective {{.*}} <line:31:1, col:35>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:24, col:34>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:33> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:33> 'int' 2
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:32:3, line:35:9>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>

--- a/clang/test/AST/ast-dump-openmp-for-simd.c
+++ b/clang/test/AST/ast-dump-openmp-for-simd.c
@@ -105,6 +105,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPForSimdDirective {{.*}} <line:17:1, col:33>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:22, col:32>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:31> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:31> 'int' 1
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:18:3, line:20:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>
@@ -147,6 +148,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPForSimdDirective {{.*}} <line:24:1, col:33>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:22, col:32>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:31> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:31> 'int' 2
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:25:3, line:27:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>
@@ -190,6 +192,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPForSimdDirective {{.*}} <line:31:1, col:33>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:22, col:32>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:31> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:31> 'int' 2
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:32:3, line:35:9>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>

--- a/clang/test/AST/ast-dump-openmp-for.c
+++ b/clang/test/AST/ast-dump-openmp-for.c
@@ -105,6 +105,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPForDirective {{.*}} <line:17:1, col:28>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:17, col:27>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:26> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:26> 'int' 1
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:18:3, line:20:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>
@@ -147,6 +148,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPForDirective {{.*}} <line:24:1, col:28>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:17, col:27>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:26> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:26> 'int' 2
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:25:3, line:27:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>
@@ -190,6 +192,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPForDirective {{.*}} <line:31:1, col:28>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:17, col:27>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:26> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:26> 'int' 2
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:32:3, line:35:9>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>

--- a/clang/test/AST/ast-dump-openmp-ordered.c
+++ b/clang/test/AST/ast-dump-openmp-ordered.c
@@ -57,6 +57,7 @@ void test_three(int x) {
 // CHECK-NEXT:     `-OMPForDirective {{.*}} <line:15:1, col:27>
 // CHECK-NEXT:       |-OMPOrderedClause {{.*}} <col:17, col:26>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:25> 'int'
+// CHECK-NEXT:       | |-value: Int 1
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:25> 'int' 1
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:16:3, line:18:3>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>

--- a/clang/test/AST/ast-dump-openmp-parallel-for-simd.c
+++ b/clang/test/AST/ast-dump-openmp-parallel-for-simd.c
@@ -109,6 +109,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPParallelForSimdDirective {{.*}} <line:17:1, col:42>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:31, col:41>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:40> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:40> 'int' 1
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:18:3, line:20:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -153,6 +154,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPParallelForSimdDirective {{.*}} <line:24:1, col:42>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:31, col:41>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:40> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:40> 'int' 2
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:25:3, line:27:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -198,6 +200,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPParallelForSimdDirective {{.*}} <line:31:1, col:42>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:31, col:41>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:40> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:40> 'int' 2
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:32:3, line:35:9>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow

--- a/clang/test/AST/ast-dump-openmp-parallel-for.c
+++ b/clang/test/AST/ast-dump-openmp-parallel-for.c
@@ -109,6 +109,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPParallelForDirective {{.*}} <line:17:1, col:37>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:26, col:36>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:35> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:35> 'int' 1
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:18:3, line:20:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -153,6 +154,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPParallelForDirective {{.*}} <line:24:1, col:37>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:26, col:36>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:35> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:35> 'int' 2
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:25:3, line:27:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -198,6 +200,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPParallelForDirective {{.*}} <line:31:1, col:37>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:26, col:36>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:35> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:35> 'int' 2
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:32:3, line:35:9>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow

--- a/clang/test/AST/ast-dump-openmp-simd.c
+++ b/clang/test/AST/ast-dump-openmp-simd.c
@@ -105,6 +105,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPSimdDirective {{.*}} <line:17:1, col:29>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:18, col:28>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:27> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:27> 'int' 1
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:18:3, line:20:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>
@@ -147,6 +148,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPSimdDirective {{.*}} <line:24:1, col:29>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:18, col:28>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:27> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:27> 'int' 2
 // CHECK-NEXT: |     `-CapturedStmt {{.*}} <line:25:3, line:27:7>
 // CHECK-NEXT: |       |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>
@@ -190,6 +192,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPSimdDirective {{.*}} <line:31:1, col:29>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:18, col:28>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:27> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:27> 'int' 2
 // CHECK-NEXT:       `-CapturedStmt {{.*}} <line:32:3, line:35:9>
 // CHECK-NEXT:         |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc>

--- a/clang/test/AST/ast-dump-openmp-target-parallel-for-simd.c
+++ b/clang/test/AST/ast-dump-openmp-target-parallel-for-simd.c
@@ -339,6 +339,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetParallelForSimdDirective {{.*}} <line:17:1, col:49>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:38, col:48>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:47> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:47> 'int' 1
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:18:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -524,6 +525,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetParallelForSimdDirective {{.*}} <line:24:1, col:49>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:38, col:48>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:47> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:47> 'int' 2
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:25:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -710,6 +712,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPTargetParallelForSimdDirective {{.*}} <line:31:1, col:49>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:38, col:48>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:47> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:47> 'int' 2
 // CHECK-NEXT:       |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT:       | |-DeclRefExpr {{.*}} <line:32:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'

--- a/clang/test/AST/ast-dump-openmp-target-parallel-for.c
+++ b/clang/test/AST/ast-dump-openmp-target-parallel-for.c
@@ -339,6 +339,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetParallelForDirective {{.*}} <line:17:1, col:44>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:33, col:43>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:42> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:42> 'int' 1
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:18:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -524,6 +525,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetParallelForDirective {{.*}} <line:24:1, col:44>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:33, col:43>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:42> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:42> 'int' 2
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:25:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -710,6 +712,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPTargetParallelForDirective {{.*}} <line:31:1, col:44>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:33, col:43>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:42> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:42> 'int' 2
 // CHECK-NEXT:       |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT:       | |-DeclRefExpr {{.*}} <line:32:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'

--- a/clang/test/AST/ast-dump-openmp-target-simd.c
+++ b/clang/test/AST/ast-dump-openmp-target-simd.c
@@ -189,6 +189,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetSimdDirective {{.*}} <line:17:1, col:36>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:25, col:35>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:34> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:34> 'int' 1
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:18:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -282,6 +283,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetSimdDirective {{.*}} <line:24:1, col:36>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:25, col:35>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:34> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:34> 'int' 2
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:25:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -376,6 +378,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPTargetSimdDirective {{.*}} <line:31:1, col:36>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:25, col:35>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:34> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:34> 'int' 2
 // CHECK-NEXT:       |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT:       | |-DeclRefExpr {{.*}} <line:32:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'

--- a/clang/test/AST/ast-dump-openmp-target-teams-distribute-parallel-for-simd.c
+++ b/clang/test/AST/ast-dump-openmp-target-teams-distribute-parallel-for-simd.c
@@ -671,6 +671,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetTeamsDistributeParallelForSimdDirective {{.*}} <line:17:1, col:66>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:55, col:65>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:64> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:64> 'int' 1
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:18:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -1056,6 +1057,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetTeamsDistributeParallelForSimdDirective {{.*}} <line:24:1, col:66>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:55, col:65>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:64> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:64> 'int' 2
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:25:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -1442,6 +1444,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPTargetTeamsDistributeParallelForSimdDirective {{.*}} <line:31:1, col:66>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:55, col:65>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:64> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:64> 'int' 2
 // CHECK-NEXT:       |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT:       | |-DeclRefExpr {{.*}} <line:32:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'

--- a/clang/test/AST/ast-dump-openmp-target-teams-distribute-parallel-for.c
+++ b/clang/test/AST/ast-dump-openmp-target-teams-distribute-parallel-for.c
@@ -671,6 +671,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetTeamsDistributeParallelForDirective {{.*}} <line:17:1, col:61>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:50, col:60>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:59> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:59> 'int' 1
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:18:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -1056,6 +1057,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetTeamsDistributeParallelForDirective {{.*}} <line:24:1, col:61>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:50, col:60>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:59> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:59> 'int' 2
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:25:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -1442,6 +1444,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPTargetTeamsDistributeParallelForDirective {{.*}} <line:31:1, col:61>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:50, col:60>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:59> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:59> 'int' 2
 // CHECK-NEXT:       |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT:       | |-DeclRefExpr {{.*}} <line:32:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'

--- a/clang/test/AST/ast-dump-openmp-target-teams-distribute-simd.c
+++ b/clang/test/AST/ast-dump-openmp-target-teams-distribute-simd.c
@@ -339,6 +339,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetTeamsDistributeSimdDirective {{.*}} <line:17:1, col:53>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:42, col:52>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:51> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:51> 'int' 1
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:18:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -524,6 +525,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetTeamsDistributeSimdDirective {{.*}} <line:24:1, col:53>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:42, col:52>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:51> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:51> 'int' 2
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:25:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -710,6 +712,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPTargetTeamsDistributeSimdDirective {{.*}} <line:31:1, col:53>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:42, col:52>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:51> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:51> 'int' 2
 // CHECK-NEXT:       |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT:       | |-DeclRefExpr {{.*}} <line:32:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'

--- a/clang/test/AST/ast-dump-openmp-target-teams-distribute.c
+++ b/clang/test/AST/ast-dump-openmp-target-teams-distribute.c
@@ -339,6 +339,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetTeamsDistributeDirective {{.*}} <line:17:1, col:48>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:37, col:47>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:46> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:46> 'int' 1
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:18:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -524,6 +525,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTargetTeamsDistributeDirective {{.*}} <line:24:1, col:48>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:37, col:47>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:46> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:46> 'int' 2
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:25:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -710,6 +712,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPTargetTeamsDistributeDirective {{.*}} <line:31:1, col:48>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:37, col:47>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:46> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:46> 'int' 2
 // CHECK-NEXT:       |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT:       | |-DeclRefExpr {{.*}} <line:32:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'

--- a/clang/test/AST/ast-dump-openmp-taskloop-simd.c
+++ b/clang/test/AST/ast-dump-openmp-taskloop-simd.c
@@ -129,6 +129,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTaskLoopSimdDirective {{.*}} <line:17:1, col:38>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:27, col:37>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:36> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:36> 'int' 1
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:18:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -183,6 +184,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTaskLoopSimdDirective {{.*}} <line:24:1, col:38>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:27, col:37>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:36> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:36> 'int' 2
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:25:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -238,6 +240,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPTaskLoopSimdDirective {{.*}} <line:31:1, col:38>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:27, col:37>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:36> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:36> 'int' 2
 // CHECK-NEXT:       |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT:       | |-DeclRefExpr {{.*}} <line:32:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'

--- a/clang/test/AST/ast-dump-openmp-taskloop.c
+++ b/clang/test/AST/ast-dump-openmp-taskloop.c
@@ -129,6 +129,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTaskLoopDirective {{.*}} <line:17:1, col:33>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:22, col:32>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:31> 'int'
+// CHECK-NEXT: |     | |-value: Int 1
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:31> 'int' 1
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:18:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -183,6 +184,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |   `-OMPTaskLoopDirective {{.*}} <line:24:1, col:33>
 // CHECK-NEXT: |     |-OMPCollapseClause {{.*}} <col:22, col:32>
 // CHECK-NEXT: |     | `-ConstantExpr {{.*}} <col:31> 'int'
+// CHECK-NEXT: |     | |-value: Int 2
 // CHECK-NEXT: |     |   `-IntegerLiteral {{.*}} <col:31> 'int' 2
 // CHECK-NEXT: |     |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT: |     | |-DeclRefExpr {{.*}} <line:25:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'
@@ -238,6 +240,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:     `-OMPTaskLoopDirective {{.*}} <line:31:1, col:33>
 // CHECK-NEXT:       |-OMPCollapseClause {{.*}} <col:22, col:32>
 // CHECK-NEXT:       | `-ConstantExpr {{.*}} <col:31> 'int'
+// CHECK-NEXT:       | |-value: Int 2
 // CHECK-NEXT:       |   `-IntegerLiteral {{.*}} <col:31> 'int' 2
 // CHECK-NEXT:       |-OMPFirstprivateClause {{.*}} <<invalid sloc>> <implicit>
 // CHECK-NEXT:       | |-DeclRefExpr {{.*}} <line:32:23> 'int' lvalue ParmVar {{.*}} 'x' 'int'

--- a/clang/test/AST/ast-dump-openmp-teams-distribute-parallel-for-simd.c
+++ b/clang/test/AST/ast-dump-openmp-teams-distribute-parallel-for-simd.c
@@ -742,6 +742,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       | | | |-OMPTeamsDistributeParallelForSimdDirective {{.*}} <col:1, col:59>
 // CHECK-NEXT: |       | | | | |-OMPCollapseClause {{.*}} <col:48, col:58>
 // CHECK-NEXT: |       | | | | | `-ConstantExpr {{.*}} <col:57> 'int'
+// CHECK-NEXT: |       | | | | | |-value: Int 1
 // CHECK-NEXT: |       | | | | |   `-IntegerLiteral {{.*}} <col:57> 'int' 1
 // CHECK-NEXT: |       | | | | `-CapturedStmt {{.*}} <line:21:3, line:23:7>
 // CHECK-NEXT: |       | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -950,6 +951,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       |   |-OMPTeamsDistributeParallelForSimdDirective {{.*}} <line:20:1, col:59>
 // CHECK-NEXT: |       |   | |-OMPCollapseClause {{.*}} <col:48, col:58>
 // CHECK-NEXT: |       |   | | `-ConstantExpr {{.*}} <col:57> 'int'
+// CHECK-NEXT: |       |   | | |-value: Int 1
 // CHECK-NEXT: |       |   | |   `-IntegerLiteral {{.*}} <col:57> 'int' 1
 // CHECK-NEXT: |       |   | `-CapturedStmt {{.*}} <line:21:3, line:23:7>
 // CHECK-NEXT: |       |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1156,6 +1158,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       | | | |-OMPTeamsDistributeParallelForSimdDirective {{.*}} <col:1, col:59>
 // CHECK-NEXT: |       | | | | |-OMPCollapseClause {{.*}} <col:48, col:58>
 // CHECK-NEXT: |       | | | | | `-ConstantExpr {{.*}} <col:57> 'int'
+// CHECK-NEXT: |       | | | | | |-value: Int 2
 // CHECK-NEXT: |       | | | | |   `-IntegerLiteral {{.*}} <col:57> 'int' 2
 // CHECK-NEXT: |       | | | | `-CapturedStmt {{.*}} <line:29:3, line:31:7>
 // CHECK-NEXT: |       | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1383,6 +1386,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       |   |-OMPTeamsDistributeParallelForSimdDirective {{.*}} <line:28:1, col:59>
 // CHECK-NEXT: |       |   | |-OMPCollapseClause {{.*}} <col:48, col:58>
 // CHECK-NEXT: |       |   | | `-ConstantExpr {{.*}} <col:57> 'int'
+// CHECK-NEXT: |       |   | | |-value: Int 2
 // CHECK-NEXT: |       |   | |   `-IntegerLiteral {{.*}} <col:57> 'int' 2
 // CHECK-NEXT: |       |   | `-CapturedStmt {{.*}} <line:29:3, line:31:7>
 // CHECK-NEXT: |       |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1610,6 +1614,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:         | | | |-OMPTeamsDistributeParallelForSimdDirective {{.*}} <col:1, col:59>
 // CHECK-NEXT:         | | | | |-OMPCollapseClause {{.*}} <col:48, col:58>
 // CHECK-NEXT:         | | | | | `-ConstantExpr {{.*}} <col:57> 'int'
+// CHECK-NEXT:         | | | | | |-value: Int 2
 // CHECK-NEXT:         | | | | |   `-IntegerLiteral {{.*}} <col:57> 'int' 2
 // CHECK-NEXT:         | | | | `-CapturedStmt {{.*}} <line:37:3, line:40:9>
 // CHECK-NEXT:         | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1902,6 +1907,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:         |   |-OMPTeamsDistributeParallelForSimdDirective {{.*}} <line:36:1, col:59>
 // CHECK-NEXT:         |   | |-OMPCollapseClause {{.*}} <col:48, col:58>
 // CHECK-NEXT:         |   | | `-ConstantExpr {{.*}} <col:57> 'int'
+// CHECK-NEXT:         |   | | |-value: Int 2
 // CHECK-NEXT:         |   | |   `-IntegerLiteral {{.*}} <col:57> 'int' 2
 // CHECK-NEXT:         |   | `-CapturedStmt {{.*}} <line:37:3, line:40:9>
 // CHECK-NEXT:         |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow

--- a/clang/test/AST/ast-dump-openmp-teams-distribute-parallel-for.c
+++ b/clang/test/AST/ast-dump-openmp-teams-distribute-parallel-for.c
@@ -742,6 +742,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       | | | |-OMPTeamsDistributeParallelForDirective {{.*}} <col:1, col:54>
 // CHECK-NEXT: |       | | | | |-OMPCollapseClause {{.*}} <col:43, col:53>
 // CHECK-NEXT: |       | | | | | `-ConstantExpr {{.*}} <col:52> 'int'
+// CHECK-NEXT: |       | | | | | |-value: Int 1
 // CHECK-NEXT: |       | | | | |   `-IntegerLiteral {{.*}} <col:52> 'int' 1
 // CHECK-NEXT: |       | | | | `-CapturedStmt {{.*}} <line:21:3, line:23:7>
 // CHECK-NEXT: |       | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -950,6 +951,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       |   |-OMPTeamsDistributeParallelForDirective {{.*}} <line:20:1, col:54>
 // CHECK-NEXT: |       |   | |-OMPCollapseClause {{.*}} <col:43, col:53>
 // CHECK-NEXT: |       |   | | `-ConstantExpr {{.*}} <col:52> 'int'
+// CHECK-NEXT: |       |   | | |-value: Int 1
 // CHECK-NEXT: |       |   | |   `-IntegerLiteral {{.*}} <col:52> 'int' 1
 // CHECK-NEXT: |       |   | `-CapturedStmt {{.*}} <line:21:3, line:23:7>
 // CHECK-NEXT: |       |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1156,6 +1158,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       | | | |-OMPTeamsDistributeParallelForDirective {{.*}} <col:1, col:54>
 // CHECK-NEXT: |       | | | | |-OMPCollapseClause {{.*}} <col:43, col:53>
 // CHECK-NEXT: |       | | | | | `-ConstantExpr {{.*}} <col:52> 'int'
+// CHECK-NEXT: |       | | | | | |-value: Int 2
 // CHECK-NEXT: |       | | | | |   `-IntegerLiteral {{.*}} <col:52> 'int' 2
 // CHECK-NEXT: |       | | | | `-CapturedStmt {{.*}} <line:29:3, line:31:7>
 // CHECK-NEXT: |       | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1383,6 +1386,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       |   |-OMPTeamsDistributeParallelForDirective {{.*}} <line:28:1, col:54>
 // CHECK-NEXT: |       |   | |-OMPCollapseClause {{.*}} <col:43, col:53>
 // CHECK-NEXT: |       |   | | `-ConstantExpr {{.*}} <col:52> 'int'
+// CHECK-NEXT: |       |   | | |-value: Int 2
 // CHECK-NEXT: |       |   | |   `-IntegerLiteral {{.*}} <col:52> 'int' 2
 // CHECK-NEXT: |       |   | `-CapturedStmt {{.*}} <line:29:3, line:31:7>
 // CHECK-NEXT: |       |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1610,6 +1614,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:         | | | |-OMPTeamsDistributeParallelForDirective {{.*}} <col:1, col:54>
 // CHECK-NEXT:         | | | | |-OMPCollapseClause {{.*}} <col:43, col:53>
 // CHECK-NEXT:         | | | | | `-ConstantExpr {{.*}} <col:52> 'int'
+// CHECK-NEXT:         | | | | | |-value: Int 2
 // CHECK-NEXT:         | | | | |   `-IntegerLiteral {{.*}} <col:52> 'int' 2
 // CHECK-NEXT:         | | | | `-CapturedStmt {{.*}} <line:37:3, line:40:9>
 // CHECK-NEXT:         | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1902,6 +1907,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:         |   |-OMPTeamsDistributeParallelForDirective {{.*}} <line:36:1, col:54>
 // CHECK-NEXT:         |   | |-OMPCollapseClause {{.*}} <col:43, col:53>
 // CHECK-NEXT:         |   | | `-ConstantExpr {{.*}} <col:52> 'int'
+// CHECK-NEXT:         |   | | |-value: Int 2
 // CHECK-NEXT:         |   | |   `-IntegerLiteral {{.*}} <col:52> 'int' 2
 // CHECK-NEXT:         |   | `-CapturedStmt {{.*}} <line:37:3, line:40:9>
 // CHECK-NEXT:         |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow

--- a/clang/test/AST/ast-dump-openmp-teams-distribute-simd.c
+++ b/clang/test/AST/ast-dump-openmp-teams-distribute-simd.c
@@ -422,6 +422,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       | | | |-OMPTeamsDistributeSimdDirective {{.*}} <col:1, col:46>
 // CHECK-NEXT: |       | | | | |-OMPCollapseClause {{.*}} <col:35, col:45>
 // CHECK-NEXT: |       | | | | | `-ConstantExpr {{.*}} <col:44> 'int'
+// CHECK-NEXT: |       | | | | | |-value: Int 1
 // CHECK-NEXT: |       | | | | |   `-IntegerLiteral {{.*}} <col:44> 'int' 1
 // CHECK-NEXT: |       | | | | `-CapturedStmt {{.*}} <line:21:3, line:23:7>
 // CHECK-NEXT: |       | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -534,6 +535,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       |   |-OMPTeamsDistributeSimdDirective {{.*}} <line:20:1, col:46>
 // CHECK-NEXT: |       |   | |-OMPCollapseClause {{.*}} <col:35, col:45>
 // CHECK-NEXT: |       |   | | `-ConstantExpr {{.*}} <col:44> 'int'
+// CHECK-NEXT: |       |   | | |-value: Int 1
 // CHECK-NEXT: |       |   | |   `-IntegerLiteral {{.*}} <col:44> 'int' 1
 // CHECK-NEXT: |       |   | `-CapturedStmt {{.*}} <line:21:3, line:23:7>
 // CHECK-NEXT: |       |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -644,6 +646,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       | | | |-OMPTeamsDistributeSimdDirective {{.*}} <col:1, col:46>
 // CHECK-NEXT: |       | | | | |-OMPCollapseClause {{.*}} <col:35, col:45>
 // CHECK-NEXT: |       | | | | | `-ConstantExpr {{.*}} <col:44> 'int'
+// CHECK-NEXT: |       | | | | | |-value: Int 2
 // CHECK-NEXT: |       | | | | |   `-IntegerLiteral {{.*}} <col:44> 'int' 2
 // CHECK-NEXT: |       | | | | `-CapturedStmt {{.*}} <line:29:3, line:31:7>
 // CHECK-NEXT: |       | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -775,6 +778,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       |   |-OMPTeamsDistributeSimdDirective {{.*}} <line:28:1, col:46>
 // CHECK-NEXT: |       |   | |-OMPCollapseClause {{.*}} <col:35, col:45>
 // CHECK-NEXT: |       |   | | `-ConstantExpr {{.*}} <col:44> 'int'
+// CHECK-NEXT: |       |   | | |-value: Int 2
 // CHECK-NEXT: |       |   | |   `-IntegerLiteral {{.*}} <col:44> 'int' 2
 // CHECK-NEXT: |       |   | `-CapturedStmt {{.*}} <line:29:3, line:31:7>
 // CHECK-NEXT: |       |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -906,6 +910,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:         | | | |-OMPTeamsDistributeSimdDirective {{.*}} <col:1, col:46>
 // CHECK-NEXT:         | | | | |-OMPCollapseClause {{.*}} <col:35, col:45>
 // CHECK-NEXT:         | | | | | `-ConstantExpr {{.*}} <col:44> 'int'
+// CHECK-NEXT:         | | | | | |-value: Int 2
 // CHECK-NEXT:         | | | | |   `-IntegerLiteral {{.*}} <col:44> 'int' 2
 // CHECK-NEXT:         | | | | `-CapturedStmt {{.*}} <line:37:3, line:40:9>
 // CHECK-NEXT:         | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1070,6 +1075,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:         |   |-OMPTeamsDistributeSimdDirective {{.*}} <line:36:1, col:46>
 // CHECK-NEXT:         |   | |-OMPCollapseClause {{.*}} <col:35, col:45>
 // CHECK-NEXT:         |   | | `-ConstantExpr {{.*}} <col:44> 'int'
+// CHECK-NEXT:         |   | | |-value: Int 2
 // CHECK-NEXT:         |   | |   `-IntegerLiteral {{.*}} <col:44> 'int' 2
 // CHECK-NEXT:         |   | `-CapturedStmt {{.*}} <line:37:3, line:40:9>
 // CHECK-NEXT:         |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow

--- a/clang/test/AST/ast-dump-openmp-teams-distribute.c
+++ b/clang/test/AST/ast-dump-openmp-teams-distribute.c
@@ -422,6 +422,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       | | | |-OMPTeamsDistributeDirective {{.*}} <col:1, col:41>
 // CHECK-NEXT: |       | | | | |-OMPCollapseClause {{.*}} <col:30, col:40>
 // CHECK-NEXT: |       | | | | | `-ConstantExpr {{.*}} <col:39> 'int'
+// CHECK-NEXT: |       | | | | | |-value: Int 1
 // CHECK-NEXT: |       | | | | |   `-IntegerLiteral {{.*}} <col:39> 'int' 1
 // CHECK-NEXT: |       | | | | `-CapturedStmt {{.*}} <line:21:3, line:23:7>
 // CHECK-NEXT: |       | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -534,6 +535,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       |   |-OMPTeamsDistributeDirective {{.*}} <line:20:1, col:41>
 // CHECK-NEXT: |       |   | |-OMPCollapseClause {{.*}} <col:30, col:40>
 // CHECK-NEXT: |       |   | | `-ConstantExpr {{.*}} <col:39> 'int'
+// CHECK-NEXT: |       |   | | |-value: Int 1
 // CHECK-NEXT: |       |   | |   `-IntegerLiteral {{.*}} <col:39> 'int' 1
 // CHECK-NEXT: |       |   | `-CapturedStmt {{.*}} <line:21:3, line:23:7>
 // CHECK-NEXT: |       |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -644,6 +646,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       | | | |-OMPTeamsDistributeDirective {{.*}} <col:1, col:41>
 // CHECK-NEXT: |       | | | | |-OMPCollapseClause {{.*}} <col:30, col:40>
 // CHECK-NEXT: |       | | | | | `-ConstantExpr {{.*}} <col:39> 'int'
+// CHECK-NEXT: |       | | | | | |-value: Int 2
 // CHECK-NEXT: |       | | | | |   `-IntegerLiteral {{.*}} <col:39> 'int' 2
 // CHECK-NEXT: |       | | | | `-CapturedStmt {{.*}} <line:29:3, line:31:7>
 // CHECK-NEXT: |       | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -775,6 +778,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT: |       |   |-OMPTeamsDistributeDirective {{.*}} <line:28:1, col:41>
 // CHECK-NEXT: |       |   | |-OMPCollapseClause {{.*}} <col:30, col:40>
 // CHECK-NEXT: |       |   | | `-ConstantExpr {{.*}} <col:39> 'int'
+// CHECK-NEXT: |       |   | | |-value: Int 2
 // CHECK-NEXT: |       |   | |   `-IntegerLiteral {{.*}} <col:39> 'int' 2
 // CHECK-NEXT: |       |   | `-CapturedStmt {{.*}} <line:29:3, line:31:7>
 // CHECK-NEXT: |       |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -906,6 +910,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:         | | | |-OMPTeamsDistributeDirective {{.*}} <col:1, col:41>
 // CHECK-NEXT:         | | | | |-OMPCollapseClause {{.*}} <col:30, col:40>
 // CHECK-NEXT:         | | | | | `-ConstantExpr {{.*}} <col:39> 'int'
+// CHECK-NEXT:         | | | | | |-value: Int 2
 // CHECK-NEXT:         | | | | |   `-IntegerLiteral {{.*}} <col:39> 'int' 2
 // CHECK-NEXT:         | | | | `-CapturedStmt {{.*}} <line:37:3, line:40:9>
 // CHECK-NEXT:         | | | |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow
@@ -1070,6 +1075,7 @@ void test_five(int x, int y, int z) {
 // CHECK-NEXT:         |   |-OMPTeamsDistributeDirective {{.*}} <line:36:1, col:41>
 // CHECK-NEXT:         |   | |-OMPCollapseClause {{.*}} <col:30, col:40>
 // CHECK-NEXT:         |   | | `-ConstantExpr {{.*}} <col:39> 'int'
+// CHECK-NEXT:         |   | | |-value: Int 2
 // CHECK-NEXT:         |   | |   `-IntegerLiteral {{.*}} <col:39> 'int' 2
 // CHECK-NEXT:         |   | `-CapturedStmt {{.*}} <line:37:3, line:40:9>
 // CHECK-NEXT:         |   |   |-CapturedDecl {{.*}} <<invalid sloc>> <invalid sloc> nothrow

--- a/clang/test/AST/ast-dump-records.c
+++ b/clang/test/AST/ast-dump-records.c
@@ -15,7 +15,7 @@ struct B;
 // CHECK: RecordDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:1, col:8> col:8 struct B
 
 struct A {
-  // CHECK: RecordDecl 0x{{[^ ]*}} prev 0x{{[^ ]*}} <line:[[@LINE-1]]:1, line:[[@LINE+20]]:1> line:[[@LINE-1]]:8 struct A definition
+  // CHECK: RecordDecl 0x{{[^ ]*}} prev 0x{{[^ ]*}} <line:[[@LINE-1]]:1, line:[[@LINE+23]]:1> line:[[@LINE-1]]:8 struct A definition
   int a;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:7> col:7 a 'int'
   int b, c;
@@ -24,14 +24,17 @@ struct A {
   int d : 12;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:11> col:7 d 'int'
   // CHECK-NEXT: ConstantExpr 0x{{[^ ]*}} <col:11> 'int'
+  // CHECK-NEXT: value: Int 12
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:11> 'int' 12
   int : 0;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:9> col:3 'int'
   // CHECK-NEXT: ConstantExpr 0x{{[^ ]*}} <col:9> 'int'
+  // CHECK-NEXT: value: Int 0
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:9> 'int' 0
   int e : 10;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:11> col:7 e 'int'
   // CHECK-NEXT: ConstantExpr 0x{{[^ ]*}} <col:11> 'int'
+  // CHECK-NEXT: value: Int 10
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:11> 'int' 10
   struct B *f;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:13> col:13 f 'struct B *'
@@ -93,7 +96,7 @@ union F;
 // CHECK: RecordDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:1, col:7> col:7 union F
 
 union E {
-  // CHECK: RecordDecl 0x{{[^ ]*}} prev 0x{{[^ ]*}} <line:[[@LINE-1]]:1, line:[[@LINE+20]]:1> line:[[@LINE-1]]:7 union E definition
+  // CHECK: RecordDecl 0x{{[^ ]*}} prev 0x{{[^ ]*}} <line:[[@LINE-1]]:1, line:[[@LINE+23]]:1> line:[[@LINE-1]]:7 union E definition
   int a;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:7> col:7 a 'int'
   int b, c;
@@ -102,14 +105,17 @@ union E {
   int d : 12;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:11> col:7 d 'int'
   // CHECK-NEXT: ConstantExpr 0x{{[^ ]*}} <col:11> 'int'
+  // CHECK-NEXT: value: Int 12
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:11> 'int' 12
   int : 0;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:9> col:3 'int'
   // CHECK-NEXT: ConstantExpr 0x{{[^ ]*}} <col:9> 'int'
+  // CHECK-NEXT: value: Int 0
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:9> 'int' 0
   int e : 10;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:11> col:7 e 'int'
   // CHECK-NEXT: ConstantExpr 0x{{[^ ]*}} <col:11> 'int'
+  // CHECK-NEXT: value: Int 10
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:11> 'int' 10
   struct B *f;
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:13> col:13 f 'struct B *'


### PR DESCRIPTION
This appears to be an oversight from the community changes made in
https://reviews.llvm.org/D63376, where we would calculate the constant
expression value but failed to store it into the ConstantExpr object.

I am also making similar changes upstream, but this functionality is needed
by https://github.com/intel/llvm/pull/3169.