### PR TITLE
[SYCL][GDB] Fix xmethod script for local accessors on Host

### DIFF
--- a/sycl/gdb/libsycl.so-gdb.py
+++ b/sycl/gdb/libsycl.so-gdb.py
@@ -56,6 +56,23 @@ class HostAccessor(Accessor):
     def data(self):
         return self.payload()['MData']
 
+class HostAccessorLocal(HostAccessor):
+    """For Host device memory layout"""
+
+    def index(self, arg):
+        if arg.type.code == gdb.TYPE_CODE_INT:
+            return int(arg)
+        # https://github.com/intel/llvm/blob/97272b7ebd569bfa13811913a31e30f926559217/sycl/include/CL/sycl/accessor.hpp#L1049-L1053
+        result = 0;
+        for dim in range(self.depth):
+            result = result * \
+                self.payload()['MSize']['common_array'][dim] + \
+                arg['common_array'][dim];
+        return result;
+
+    def data(self):
+        return self.payload()['MMem']
+
 class DeviceAccessor(Accessor):
     """For CPU/GPU memory layout"""
 
@@ -88,7 +105,8 @@ class AccessorOpIndex(gdb.xmethod.XMethodWorker):
         # try all accessor implementations until one of them works:
         accessors = [
             DeviceAccessor(obj, self.result_type, self.depth),
-            HostAccessor(obj, self.result_type, self.depth)
+            HostAccessor(obj, self.result_type, self.depth),
+            HostAccessorLocal(obj, self.result_type, self.depth)
         ]
         for accessor in accessors:
             try:

--- a/sycl/test/gdb/accessors.cpp
+++ b/sycl/test/gdb/accessors.cpp
@@ -19,7 +19,15 @@ typedef cl::sycl::accessor<int, 1, cl::sycl::access::mode::read> dummy;
 // CHECK: CXXRecordDecl {{.*}} class AccessorBaseHost definition
 // CHECK-NOT: CXXRecordDecl {{.*}} definition
 // CHECK: FieldDecl {{.*}} referenced impl {{.*}}:'std::shared_ptr<sycl::detail::AccessorImplHost>'
+
+// LocalAccessorImplHost must have MSize and MMem fields
+
+// CHECK: CXXRecordDecl {{.*}} class LocalAccessorImplHost definition
+// CHECK-NOT: CXXRecordDecl {{.*}} definition
+// CHECK: FieldDecl {{.*}} referenced MSize
+// CHECK-NOT: CXXRecordDecl {{.*}} definition
+// CHECK: FieldDecl {{.*}} referenced MMem
+
 // CHECK: CXXRecordDecl {{.*}} class accessor definition
 // CHECK-NOT: CXXRecordDecl {{.*}} definition
 // CHECK: public {{.*}}:'sycl::detail::AccessorBaseHost'
-


### PR DESCRIPTION
Previous version of script didn't take into account that local accessors
have a slightly different index calculation logic on Host and need to be
treated specially.

For Device the same script should still be applicable.