### PR TITLE
[CodeGen] Fix ICE caused by invalid cast

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5100,8 +5100,8 @@ void CodeGenModule::EmitAliasDefinition(GlobalDecl GD) {
     LT = getFunctionLinkage(GD);
     AS = Aliasee->getType()->getPointerAddressSpace();
   } else {
-    const auto *VarD = cast<VarDecl>(GD.getDecl());
-    AS = ArgInfoAddressSpace(GetGlobalVarAddressSpace(VarD));
+    AS = ArgInfoAddressSpace(
+        GetGlobalVarAddressSpace(dyn_cast<VarDecl>(GD.getDecl())));
     Aliasee = GetOrCreateLLVMGlobal(AA->getAliasee(), DeclTy->getPointerTo(AS),
                                     /*D=*/nullptr);
     if (const auto *VD = dyn_cast<VarDecl>(GD.getDecl()))


### PR DESCRIPTION
CodeGen wrongly casts function declaration to a variable declaration
assuming that alias attribute can be applied to variable declarations
only.