### PR TITLE
[SYCL] Report an error message when "sycl::program::create_program_with_source" is used with Level-Zero

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -289,6 +289,11 @@ namespace pi {
   std::terminate();
 }
 
+// Reports error messages
+void cuPrint(const char *Message) {
+  std::cerr << "pi_print: " << Message << std::endl;
+}
+
 void assertion(bool Condition, const char *Message) {
   if (!Condition)
     die(Message);
@@ -2649,7 +2654,7 @@ pi_result cuda_piclProgramCreateWithSource(pi_context context, pi_uint32 count,
                                            const char **strings,
                                            const size_t *lengths,
                                            pi_program *program) {
-  cl::sycl::detail::pi::die("cuda_piclProgramCreateWithSource not implemented");
+  cl::sycl::detail::pi::cuPrint("cuda_piclProgramCreateWithSource not implemented");
   return PI_INVALID_OPERATION;
 }
 

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2650,7 +2650,7 @@ pi_result cuda_piclProgramCreateWithSource(pi_context context, pi_uint32 count,
                                            const size_t *lengths,
                                            pi_program *program) {
   cl::sycl::detail::pi::die("cuda_piclProgramCreateWithSource not implemented");
-  return {};
+  return PI_INVALID_OPERATION;
 }
 
 /// Loads the images from a PI program into a CUmodule that can be

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2654,7 +2654,8 @@ pi_result cuda_piclProgramCreateWithSource(pi_context context, pi_uint32 count,
                                            const char **strings,
                                            const size_t *lengths,
                                            pi_program *program) {
-  cl::sycl::detail::pi::cuPrint("cuda_piclProgramCreateWithSource not implemented");
+  cl::sycl::detail::pi::cuPrint(
+      "cuda_piclProgramCreateWithSource not implemented");
   return PI_INVALID_OPERATION;
 }
 

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -358,13 +358,14 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
   const char *Src = Source.c_str();
   size_t Size = Source.size();
   const detail::plugin &Plugin = getPlugin();
-  RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piclProgramCreateWithSource>(
-      MContext->getHandleRef(), 1, &Src, &Size, &MProgram);
+  RT::PiResult Err =
+      Plugin.call_nocheck<PiApiKind::piclProgramCreateWithSource>(
+          MContext->getHandleRef(), 1, &Src, &Size, &MProgram);
 
-  if (getPlugin().getBackend() == cl::sycl::backend::level_zero &&
+  if (Plugin.getBackend() == cl::sycl::backend::level_zero &&
       Err == PI_INVALID_OPERATION) {
     throw feature_not_supported(
-        "piclProgramCreateWithSource: not supported in Level Zero",
+        "piclProgramCreateWithSource is not supported in Level Zero",
         PI_INVALID_OPERATION);
   }
 }

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -358,8 +358,15 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
   const char *Src = Source.c_str();
   size_t Size = Source.size();
   const detail::plugin &Plugin = getPlugin();
-  Plugin.call<PiApiKind::piclProgramCreateWithSource>(
+  RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piclProgramCreateWithSource>(
       MContext->getHandleRef(), 1, &Src, &Size, &MProgram);
+
+  if (getPlugin().getBackend() == cl::sycl::backend::level_zero &&
+      Err == PI_INVALID_OPERATION) {
+    throw feature_not_supported(
+        "piclProgramCreateWithSource: not supported in Level Zero",
+        PI_INVALID_OPERATION);
+  }
 }
 
 void program_impl::compile(const string_class &Options) {

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -363,9 +363,8 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
           MContext->getHandleRef(), 1, &Src, &Size, &MProgram);
 
   if (Err == PI_INVALID_OPERATION) {
-    throw feature_not_supported(
-        "program::compile_with_source is not supported",
-        PI_INVALID_OPERATION);
+    throw feature_not_supported("program::compile_with_source is not supported",
+                                PI_INVALID_OPERATION);
   }
 }
 

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -17,7 +17,6 @@
 #include <detail/spec_constant_impl.hpp>
 
 #include <algorithm>
-#include <string>
 #include <fstream>
 #include <list>
 #include <memory>
@@ -26,21 +25,6 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
-
-inline const std::string GetBackendString(cl::sycl::backend backend) {
-  switch (backend) {
-#define PI_BACKEND_STR(backend_name)                                           \
-  case cl::sycl::backend::backend_name:                                        \
-    return #backend_name
-    PI_BACKEND_STR(cuda);
-    PI_BACKEND_STR(host);
-    PI_BACKEND_STR(opencl);
-    PI_BACKEND_STR(level_zero);
-#undef PI_BACKEND_STR
-  default:
-    return "Unknown Plugin";
-  }
-}
 
 program_impl::program_impl(ContextImplPtr Context,
                            const property_list &PropList)
@@ -380,8 +364,7 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
 
   if (Err == PI_INVALID_OPERATION) {
     throw feature_not_supported(
-        "program::compile_with_source is not supported in" +
-            GetBackendString(Plugin.getBackend()),
+        "program::compile_with_source is not supported",
         PI_INVALID_OPERATION);
   }
 }

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -363,8 +363,9 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
           MContext->getHandleRef(), 1, &Src, &Size, &MProgram);
 
   if (Err == PI_INVALID_OPERATION) {
-    throw feature_not_supported("program::compile_with_source is not supported",
-                                PI_INVALID_OPERATION);
+    throw feature_not_supported(
+      "program::compile_with_source is not supported by the selected backend",
+          PI_INVALID_OPERATION);
   }
 }
 

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -364,8 +364,8 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
 
   if (Err == PI_INVALID_OPERATION) {
     throw feature_not_supported(
-      "program::compile_with_source is not supported by the selected backend",
-          PI_INVALID_OPERATION);
+        "program::compile_with_source is not supported by the selected backend",
+        PI_INVALID_OPERATION);
   }
 }
 

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -17,6 +17,7 @@
 #include <detail/spec_constant_impl.hpp>
 
 #include <algorithm>
+#include <string>
 #include <fstream>
 #include <list>
 #include <memory>
@@ -25,6 +26,21 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+
+inline const std::string GetBackendString(cl::sycl::backend backend) {
+  switch (backend) {
+#define PI_BACKEND_STR(backend_name)                                           \
+  case cl::sycl::backend::backend_name:                                        \
+    return #backend_name
+    PI_BACKEND_STR(cuda);
+    PI_BACKEND_STR(host);
+    PI_BACKEND_STR(opencl);
+    PI_BACKEND_STR(level_zero);
+#undef PI_BACKEND_STR
+  default:
+    return "Unknown Plugin";
+  }
+}
 
 program_impl::program_impl(ContextImplPtr Context,
                            const property_list &PropList)
@@ -362,11 +378,10 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
       Plugin.call_nocheck<PiApiKind::piclProgramCreateWithSource>(
           MContext->getHandleRef(), 1, &Src, &Size, &MProgram);
 
-  if (Plugin.getBackend() == cl::sycl::backend::level_zero &&
-      Err == PI_INVALID_OPERATION) {
+  if (Err == PI_INVALID_OPERATION) {
     throw feature_not_supported(
-        "piclProgramCreateWithSource is not supported in Level Zero",
-        PI_INVALID_OPERATION);
+        "program::compile_with_source is not supported in" +
+         GetBackendString(Plugin.getBackend()), PI_INVALID_OPERATION);
   }
 }
 

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -381,7 +381,8 @@ void program_impl::create_cl_program_with_source(const string_class &Source) {
   if (Err == PI_INVALID_OPERATION) {
     throw feature_not_supported(
         "program::compile_with_source is not supported in" +
-         GetBackendString(Plugin.getBackend()), PI_INVALID_OPERATION);
+            GetBackendString(Plugin.getBackend()),
+        PI_INVALID_OPERATION);
   }
 }
 


### PR DESCRIPTION
Level-Zero backend does not support create_program_with_source. This is to report an error message from SYCL RT if that is requested.

Signed-off-by: rbegam <rehana.begam@intel.com>