### PR TITLE
[SYCL] Create an empty integration header file with -fsycl-int-header

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2894,9 +2894,17 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
   if (LangOpts.OpenMPIsDevice)
     Res.getTargetOpts().HostTriple = Res.getFrontendOpts().AuxTriple;
 
-  // Set the triple of the host for SYCL device compile.
-  if (LangOpts.SYCLIsDevice)
+  if (LangOpts.SYCLIsDevice) {
+    // Set the triple of the host for SYCL device compile.
     Res.getTargetOpts().HostTriple = Res.getFrontendOpts().AuxTriple;
+    // If specified, create an empty integration header file for now.
+    const StringRef &HeaderName = LangOpts.SYCLIntHeader;
+    if (!HeaderName.empty()) {
+      int ResultFD = 0;
+      // Ignore the return value; compilation will fail if this file is absent.
+      (void)llvm::sys::fs::openFileForWrite(HeaderName, ResultFD);
+    }
+  }
 
   Success &= ParseCodeGenArgs(Res.getCodeGenOpts(), Args, DashX, Diags, T,
                               Res.getFrontendOpts().OutputFile, LangOpts);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2900,15 +2900,16 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
     // If specified, create an empty integration header file for now.
     const StringRef &HeaderName = LangOpts.SYCLIntHeader;
     if (!HeaderName.empty()) {
-      // Ignore the return value; compilation will fail if this file is absent.
       Expected<llvm::sys::fs::file_t> ft =
-          llvm::sys::fs::openNativeFileForWrite(HeaderName,
-              llvm::sys::fs::CD_OpenAlways, llvm::sys::fs::OF_None);
+          llvm::sys::fs::openNativeFileForWrite(
+              HeaderName, llvm::sys::fs::CD_OpenAlways, llvm::sys::fs::OF_None);
       if (ft)
         llvm::sys::fs::closeFile(*ft);
       else {
-        llvm::errs() << "Error: " << llvm::toString(ft.takeError()) <<
-            " when opening " << HeaderName << "\n";
+        // Emit a message but don't terminate; compilation will fail
+        // later if this file is absent.
+        llvm::errs() << "Error: " << llvm::toString(ft.takeError())
+                     << " when opening " << HeaderName << "\n";
       }
     }
   }

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -305,6 +305,12 @@ void Sema::Initialize() {
                      Context.SingletonId);
 #include "clang/Basic/OpenCLImageTypes.def"
 #undef SEMA_STRINGIZE
+    const StringRef &HeaderName = getLangOpts().SYCLIntHeader;
+    if (!HeaderName.empty()) {
+      int ResultFD = 0;
+      // Ignore the return value; compilation will fail if file is absent
+      (void)llvm::sys::fs::openFileForWrite(HeaderName, ResultFD);
+    }
   }
 
   if (getLangOpts().SYCLIsDevice || getLangOpts().OpenCL) {

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -305,12 +305,6 @@ void Sema::Initialize() {
                      Context.SingletonId);
 #include "clang/Basic/OpenCLImageTypes.def"
 #undef SEMA_STRINGIZE
-    const StringRef &HeaderName = getLangOpts().SYCLIntHeader;
-    if (!HeaderName.empty()) {
-      int ResultFD = 0;
-      // Ignore the return value; compilation will fail if file is absent
-      (void)llvm::sys::fs::openFileForWrite(HeaderName, ResultFD);
-    }
   }
 
   if (getLangOpts().SYCLIsDevice || getLangOpts().OpenCL) {

--- a/clang/test/SemaSYCL/sycl-empty-header.cpp
+++ b/clang/test/SemaSYCL/sycl-empty-header.cpp
@@ -5,12 +5,8 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h -save-temps=cwd %s
 // RUN: ls %t.h
 // RUN: rm -f %t.h
-// RUN: cp %s %t_dir/foo.cpp
-// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h -save-temps=cwd %t_dir/foo.cpp
-// RUN: ls %t.h
-// RUN: rm -rf %t.h %t_dir
 // RUN: touch %t.fail.h
 // RUN: chmod 400 %t.fail.h
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.fail.h %s 2>&1 | FileCheck %s --check-prefix=SYCL-BADFILE
-// RUN: rm %t.fail.h
+// RUN: rm -f %t.fail.h
 // SYCL-BADFILE: Error: {{[Pp]ermission}} denied when opening {{.*.fail.h}}

--- a/clang/test/SemaSYCL/sycl-empty-header.cpp
+++ b/clang/test/SemaSYCL/sycl-empty-header.cpp
@@ -4,7 +4,8 @@
 // RUN: mkdir -p %t_dir
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h -save-temps=cwd %s
 // RUN: ls %t.h
-// RUN: rm %t.h
+// RUN: rm -f %t.h
 // RUN: cp %s %t_dir/foo.cpp
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h -save-temps=cwd %t_dir/foo.cpp
 // RUN: ls %t.h
+// RUN: rm -rf %t.h %t_dir

--- a/clang/test/SemaSYCL/sycl-empty-header.cpp
+++ b/clang/test/SemaSYCL/sycl-empty-header.cpp
@@ -9,3 +9,8 @@
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h -save-temps=cwd %t_dir/foo.cpp
 // RUN: ls %t.h
 // RUN: rm -rf %t.h %t_dir
+// RUN: touch %t.fail.h
+// RUN: chmod 400 %t.fail.h
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.fail.h %s 2>&1 | FileCheck %s --check-prefix=SYCL-BADFILE
+// RUN: rm %t.fail.h
+// SYCL-BADFILE: Error: Permission denied when opening {{.*.fail.h}}

--- a/clang/test/SemaSYCL/sycl-empty-header.cpp
+++ b/clang/test/SemaSYCL/sycl-empty-header.cpp
@@ -13,4 +13,4 @@
 // RUN: chmod 400 %t.fail.h
 // RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.fail.h %s 2>&1 | FileCheck %s --check-prefix=SYCL-BADFILE
 // RUN: rm %t.fail.h
-// SYCL-BADFILE: Error: Permission denied when opening {{.*.fail.h}}
+// SYCL-BADFILE: Error: {{[Pp]ermission}} denied when opening {{.*.fail.h}}

--- a/clang/test/SemaSYCL/sycl-empty-header.cpp
+++ b/clang/test/SemaSYCL/sycl-empty-header.cpp
@@ -1,0 +1,10 @@
+// Test that at least an empty integration header file is created when
+// compiling source files with no device sycl construct.
+
+// RUN: mkdir -p %t_dir
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h -save-temps=cwd %s
+// RUN: ls %t.h
+// RUN: rm %t.h
+// RUN: cp %s %t_dir/foo.cpp
+// RUN: %clang_cc1 -fsycl -fsycl-is-device -fsycl-int-header=%t.h -save-temps=cwd %t_dir/foo.cpp
+// RUN: ls %t.h


### PR DESCRIPTION
When in the integration header generation phase of compilation,
and the source file being compiled is not in the current working directory,
the Driver assumes that an integration header file will get generated by the
front-end and includes the file for consumption by subsequent phases.
(In other cases, the Driver inadvertently creates an empty temporary file.)
However, currently the file only gets created by the front-end when there is 
something to emit inside it.  This causes missing include file failures when a
later compilation phase expects this integration header file.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>