### PR TITLE
[SYCL] Refactor the way we handle duplicate attribute logic

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1393,7 +1393,7 @@ def IntelReqdSubGroupSize: InheritableAttr {
   let Spellings = [GNU<"intel_reqd_sub_group_size">,
                    CXX11<"intel", "reqd_sub_group_size">];
   let Args = [ExprArgument<"Value">];
-  let Subjects = SubjectList<[Function, CXXMethod], ErrorDiag>;
+  let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [IntelReqdSubGroupSizeDocs];
   let LangOpts = [OpenCL, SYCLIsDevice, SYCLIsHost];
 }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10210,6 +10210,16 @@ public:
   template <typename AttrType>
   void addIntelTripleArgAttr(Decl *D, const AttributeCommonInfo &CI,
                              Expr *XDimExpr, Expr *YDimExpr, Expr *ZDimExpr);
+  void AddIntelReqdSubGroupSize(Decl *D, const AttributeCommonInfo &CI,
+                                Expr *E);
+  IntelReqdSubGroupSizeAttr *
+  MergeIntelReqdSubGroupSizeAttr(Decl *D, const IntelReqdSubGroupSizeAttr &A);
+  void AddSYCLIntelNumSimdWorkItemsAttr(Decl *D, const AttributeCommonInfo &CI,
+                                        Expr *E);
+  SYCLIntelNumSimdWorkItemsAttr *
+  MergeSYCLIntelNumSimdWorkItemsAttr(Decl *D,
+                                     const SYCLIntelNumSimdWorkItemsAttr &A);
+
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,
                       bool IsPackExpansion);
@@ -13068,9 +13078,7 @@ void Sema::addIntelSingleArgAttr(Decl *D, const AttributeCommonInfo &CI,
       return;
     E = ICE.get();
     int32_t ArgInt = ArgVal.getSExtValue();
-    if (CI.getParsedKind() == ParsedAttr::AT_SYCLIntelNumSimdWorkItems ||
-        CI.getParsedKind() == ParsedAttr::AT_IntelReqdSubGroupSize ||
-        CI.getParsedKind() == ParsedAttr::AT_IntelFPGAMaxReplicates) {
+    if (CI.getParsedKind() == ParsedAttr::AT_IntelFPGAMaxReplicates) {
       if (ArgInt <= 0) {
         Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
             << CI << /*positive*/ 0;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2618,6 +2618,10 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
     NewAttr = S.mergeEnforceTCBAttr(D, *TCBA);
   else if (const auto *TCBLA = dyn_cast<EnforceTCBLeafAttr>(Attr))
     NewAttr = S.mergeEnforceTCBLeafAttr(D, *TCBLA);
+  else if (const auto *A = dyn_cast<IntelReqdSubGroupSizeAttr>(Attr))
+    NewAttr = S.MergeIntelReqdSubGroupSizeAttr(D, *A);
+  else if (const auto *A = dyn_cast<SYCLIntelNumSimdWorkItemsAttr>(Attr))
+    NewAttr = S.MergeSYCLIntelNumSimdWorkItemsAttr(D, *A);
   else if (Attr->shouldInheritEvenIfAlreadyPresent() || !DeclHasAttr(D, Attr))
     NewAttr = cast<InheritableAttr>(Attr->clone(S.Context));
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3314,8 +3314,8 @@ void Sema::AddSYCLIntelNumSimdWorkItemsAttr(Decl *D,
       Optional<llvm::APSInt> YDimVal = DeclAttr->getYDimVal(Context);
       Optional<llvm::APSInt> ZDimVal = DeclAttr->getZDimVal(Context);
 
-      if (*XDimVal % ArgVal != 0 || *YDimVal % ArgVal != 0 ||
-          *ZDimVal % ArgVal != 0) {
+      if (!(*XDimVal % ArgVal == 0 || *YDimVal % ArgVal == 0 ||
+            *ZDimVal % ArgVal == 0)) {
         Diag(CI.getLoc(), diag::err_sycl_num_kernel_wrong_reqd_wg_size)
             << CI << DeclAttr;
         Diag(DeclAttr->getLocation(), diag::note_conflicting_attribute);

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -643,6 +643,26 @@ static void instantiateSYCLIntelLoopFuseAttr(
     S.addSYCLIntelLoopFuseAttr(New, *Attr, Result.getAs<Expr>());
 }
 
+static void instantiateIntelReqdSubGroupSize(
+    Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
+    const IntelReqdSubGroupSizeAttr *A, Decl *New) {
+  EnterExpressionEvaluationContext Unevaluated(
+      S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
+  ExprResult Result = S.SubstExpr(A->getValue(), TemplateArgs);
+  if (!Result.isInvalid())
+    S.AddIntelReqdSubGroupSize(New, *A, Result.getAs<Expr>());
+}
+
+static void instantiateSYCLIntelNumSimdWorkItemsAttr(
+    Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
+    const SYCLIntelNumSimdWorkItemsAttr *A, Decl *New) {
+  EnterExpressionEvaluationContext Unevaluated(
+      S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
+  ExprResult Result = S.SubstExpr(A->getValue(), TemplateArgs);
+  if (!Result.isInvalid())
+    S.AddSYCLIntelNumSimdWorkItemsAttr(New, *A, Result.getAs<Expr>());
+}
+
 template <typename AttrName>
 static void instantiateIntelSYCLFunctionAttr(
     Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
@@ -834,14 +854,14 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
     }
     if (const auto *IntelReqdSubGroupSize =
             dyn_cast<IntelReqdSubGroupSizeAttr>(TmplAttr)) {
-      instantiateIntelSYCLFunctionAttr<IntelReqdSubGroupSizeAttr>(
-          *this, TemplateArgs, IntelReqdSubGroupSize, New);
+      instantiateIntelReqdSubGroupSize(*this, TemplateArgs,
+                                       IntelReqdSubGroupSize, New);
       continue;
     }
     if (const auto *SYCLIntelNumSimdWorkItems =
             dyn_cast<SYCLIntelNumSimdWorkItemsAttr>(TmplAttr)) {
-      instantiateIntelSYCLFunctionAttr<SYCLIntelNumSimdWorkItemsAttr>(
-          *this, TemplateArgs, SYCLIntelNumSimdWorkItems, New);
+      instantiateSYCLIntelNumSimdWorkItemsAttr(*this, TemplateArgs,
+                                               SYCLIntelNumSimdWorkItems, New);
       continue;
     }
     if (const auto *SYCLIntelSchedulerTargetFmaxMhz =

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -71,7 +71,7 @@
 // CHECK-NEXT: IBAction (SubjectMatchRule_objc_method_is_instance)
 // CHECK-NEXT: IFunc (SubjectMatchRule_function)
 // CHECK-NEXT: InitPriority (SubjectMatchRule_variable)
-// CHECK-NEXT: IntelReqdSubGroupSize (SubjectMatchRule_function, SubjectMatchRule_function_is_member)
+// CHECK-NEXT: IntelReqdSubGroupSize (SubjectMatchRule_function)
 // CHECK-NEXT: InternalLinkage (SubjectMatchRule_variable, SubjectMatchRule_function, SubjectMatchRule_record)
 // CHECK-NEXT: LTOVisibilityPublic (SubjectMatchRule_record)
 // CHECK-NEXT: Leaf (SubjectMatchRule_function)

--- a/clang/test/SemaOpenCL/invalid-kernel-attrs.cl
+++ b/clang/test/SemaOpenCL/invalid-kernel-attrs.cl
@@ -39,7 +39,8 @@ kernel __attribute__((intel_reqd_sub_group_size(0))) void kernel15() {} // expec
 
 kernel __attribute__((intel_reqd_sub_group_size(-1))) void kernel16() {} // expected-error {{'intel_reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
 
-kernel __attribute__((intel_reqd_sub_group_size(8))) __attribute__((intel_reqd_sub_group_size(16))) void kernel17() {} //expected-warning{{attribute 'intel_reqd_sub_group_size' is already applied with different parameters}}
+kernel __attribute__((intel_reqd_sub_group_size(8))) __attribute__((intel_reqd_sub_group_size(16))) void kernel17() {} //expected-warning{{attribute 'intel_reqd_sub_group_size' is already applied with different parameters}} \
+                                                                                                                       // expected-note {{previous attribute is here}}
 
 __kernel __attribute__((work_group_size_hint(8,-16,32))) void neg1() {} //expected-error{{'work_group_size_hint' attribute requires a non-negative integral compile time constant expression}}
 __kernel __attribute__((reqd_work_group_size(8, 16, -32))) void neg2() {} //expected-warning{{implicit conversion changes signedness: 'int' to 'unsigned long long'}}

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -69,7 +69,7 @@ struct TRIFuncObjBad4 {
 };
 
 struct TRIFuncObjBad5 {
-  [[intel::num_simd_work_items(0)]] // expected-error{{'num_simd_work_items' attribute must be greater than 0}}
+  [[intel::num_simd_work_items(0)]] // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
   [[intel::reqd_work_group_size(5, 5, 5)]] void
   operator()() const {}
 };
@@ -104,7 +104,7 @@ struct TRIFuncObjBad9 {
 
 struct TRIFuncObjBad10 {
   [[intel::reqd_work_group_size(5, 5, 5)]]
-  [[intel::num_simd_work_items(0)]] // expected-error{{'num_simd_work_items' attribute must be greater than 0}}
+  [[intel::num_simd_work_items(0)]] // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
   void operator()() const {}
 };
 
@@ -122,12 +122,12 @@ struct TRIFuncObjBad12 {
 
 struct TRIFuncObjBad13 {
   [[intel::reqd_work_group_size(0)]] // expected-error{{'reqd_work_group_size' attribute must be greater than 0}}
-  [[intel::num_simd_work_items(0)]]  // expected-error{{'num_simd_work_items' attribute must be greater than 0}}
+  [[intel::num_simd_work_items(0)]]  // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
   void operator()() const {}
 };
 
 struct TRIFuncObjBad14 {
-  [[intel::num_simd_work_items(0)]]  // expected-error{{'num_simd_work_items' attribute must be greater than 0}}
+  [[intel::num_simd_work_items(0)]]  // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
   [[intel::reqd_work_group_size(0)]] // expected-error{{'reqd_work_group_size' attribute must be greater than 0}}
   void operator()() const {}
 };
@@ -151,7 +151,7 @@ struct TRIFuncObjBad17 {
 };
 
 struct TRIFuncObjBad18 {
-  [[intel::num_simd_work_items(-1)]]  // expected-error{{'num_simd_work_items' attribute requires a non-negative integral compile time constant expression}}
+  [[intel::num_simd_work_items(-1)]]  // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
   [[intel::reqd_work_group_size(-1)]] // expected-warning{{implicit conversion changes signedness: 'int' to 'unsigned long long'}}
   void operator()() const {}
 };
@@ -372,10 +372,10 @@ int main() {
     [[intel::num_simd_work_items(0)]] int Var = 0; // expected-error{{'num_simd_work_items' attribute only applies to functions}}
 
     h.single_task<class test_kernel12>(
-        []() [[intel::num_simd_work_items(0)]]{}); // expected-error{{'num_simd_work_items' attribute must be greater than 0}}
+        []() [[intel::num_simd_work_items(0)]]{}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 
     h.single_task<class test_kernel13>(
-        []() [[intel::num_simd_work_items(-42)]]{}); // expected-error{{'num_simd_work_items' attribute requires a non-negative integral compile time constant expression}}
+        []() [[intel::num_simd_work_items(-42)]]{}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 
     h.single_task<class test_kernel14>(TRIFuncObjBad1());
 

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -8,7 +8,7 @@ queue q;
 
 #ifndef __SYCL_DEVICE_ONLY__
 struct FuncObj {
-  [[intel::num_simd_work_items(42)]] // expected-no-diagnostics
+  [[intel::num_simd_work_items(42)]]
   void
   operator()() const {}
 };
@@ -25,6 +25,12 @@ void foo() {
     h.single_task<class test_kernel1>(FuncObj());
   });
 }
+
+[[intel::num_simd_work_items(12)]] void bar();
+[[intel::num_simd_work_items(12)]] void bar() {} // OK
+
+[[intel::num_simd_work_items(12)]] void baz();  // expected-note {{previous attribute is here}}
+[[intel::num_simd_work_items(100)]] void baz(); // expected-warning {{attribute 'num_simd_work_items' is already applied with different parameters}}
 
 #else // __SYCL_DEVICE_ONLY__
 [[intel::num_simd_work_items(2)]] void func_do_not_ignore() {}
@@ -70,7 +76,8 @@ int main() {
         []() [[intel::num_simd_work_items(-42)]]{}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 
     h.single_task<class test_kernel6>(
-        []() [[intel::num_simd_work_items(1), intel::num_simd_work_items(2)]]{}); // expected-warning{{attribute 'num_simd_work_items' is already applied with different parameters}}
+        []() [[intel::num_simd_work_items(1), intel::num_simd_work_items(2)]]{}); // expected-warning{{attribute 'num_simd_work_items' is already applied with different parameters}} \
+                                                                                  // expected-note {{previous attribute is here}}
 #endif // TRIGGER_ERROR
   });
   return 0;

--- a/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-device.cpp
@@ -10,6 +10,12 @@ queue q;
 // expected-note@-1 {{conflicting attribute is here}}
 [[intel::reqd_sub_group_size(32)]] void baz() {} // expected-note {{conflicting attribute is here}}
 
+[[intel::reqd_sub_group_size(12)]] void bar();
+[[intel::reqd_sub_group_size(12)]] void bar() {} // OK
+
+[[intel::reqd_sub_group_size(12)]] void quux(); // expected-note {{previous attribute is here}}
+[[intel::reqd_sub_group_size(100)]] void quux(); // expected-warning {{attribute 'reqd_sub_group_size' is already applied with different parameters}}
+
 class Functor16 {
 public:
   [[intel::reqd_sub_group_size(16)]] void operator()() const {}

--- a/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
@@ -60,11 +60,20 @@ template <int N>
 // expected-error@+1{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 [[intel::num_simd_work_items(N)]] void func3() {}
 
+template <int N>
+[[intel::num_simd_work_items(4)]] void func4(); // expected-note {{previous attribute is here}}
+
+template <int N>
+[[intel::num_simd_work_items(N)]] void func4() {} // expected-warning {{attribute 'num_simd_work_items' is already applied with different parameters}}
+
 int check() {
   // no error expected
   func3<8>();
   //expected-note@+1{{in instantiation of function template specialization 'func3<-1>' requested here}}
   func3<-1>();
+
+  func4<6>(); //expected-note {{in instantiation of function template specialization 'func4<6>' requested here}}
+
   return 0;
 }
 

--- a/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
@@ -5,8 +5,9 @@
 // Test that checks wrong function template instantiation and ensures that the type
 // is checked properly when instantiating from the template definition.
 template <typename Ty>
-// expected-error@+2{{integral constant expression must have integral or unscoped enumeration type, not 'S'}}
-// expected-error@+1{{integral constant expression must have integral or unscoped enumeration type, not 'float'}}
+// expected-error@+3{{integral constant expression must have integral or unscoped enumeration type, not 'S'}}
+// expected-error@+2{{integral constant expression must have integral or unscoped enumeration type, not 'float'}}
+// expected-error@+1{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 [[intel::num_simd_work_items(Ty{})]] void func() {}
 
 struct S {};
@@ -15,6 +16,7 @@ void test() {
   func<S>();
   //expected-note@+1{{in instantiation of function template specialization 'func<float>' requested here}}
   func<float>();
+  //expected-note@+1{{in instantiation of function template specialization 'func<int>' requested here}}
   func<int>();
 }
 
@@ -33,7 +35,7 @@ constexpr int bar() { return 0; }
 template <int SIZE>
 class KernelFunctor {
 public:
-  // expected-error@+1{{'num_simd_work_items' attribute requires a non-negative integral compile time constant expression}}
+  // expected-error@+1{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
   [[intel::num_simd_work_items(SIZE)]] void operator()() {}
 };
 
@@ -55,7 +57,7 @@ int main() {
 
 // Test that checks template parameter support on function.
 template <int N>
-// expected-error@+1{{'num_simd_work_items' attribute requires a non-negative integral compile time constant expression}}
+// expected-error@+1{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 [[intel::num_simd_work_items(N)]] void func3() {}
 
 template <int N>

--- a/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-reqd-sub-group-size-template.cpp
@@ -60,11 +60,20 @@ template <int N>
 // expected-error@+1{{'reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}
 [[intel::reqd_sub_group_size(N)]] void func3() {}
 
+template <int N>
+[[intel::reqd_sub_group_size(4)]] void func4(); // expected-note {{previous attribute is here}}
+
+template <int N>
+[[intel::reqd_sub_group_size(N)]] void func4() {} // expected-warning {{attribute 'reqd_sub_group_size' is already applied with different parameters}}
+
 int check() {
   // no error expected
   func3<12>();
   //expected-note@+1{{in instantiation of function template specialization 'func3<-1>' requested here}}
   func3<-1>();
+
+  func4<6>(); //expected-note {{in instantiation of function template specialization 'func4<6>' requested here}}
+
   return 0;
 }
 


### PR DESCRIPTION
The existing code does not handle things like redeclarations or
template instantiations properly. This refactoring changes things to
be a bit more like they would be upstream for other attributes. Namely,
it splits out an Add method that can be used for template instantiation
as well as regular attribute handling, and a Merge method to handle
redeclarations.

This patch only handles [[intel::reqd_sub_group_size]] and
[[intel::num_simd_work_items]] currently. Other attributes will be
handled in follow-up work.