### PR TITLE
[SYCL] Fix the type trait 'known_identity'

### DIFF
--- a/sycl/include/CL/sycl/ONEAPI/reduction.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/reduction.hpp
@@ -22,121 +22,100 @@ namespace ONEAPI {
 
 namespace detail {
 
+using cl::sycl::detail::bool_constant;
+using cl::sycl::detail::enable_if_t;
+using cl::sycl::detail::is_sgenfloat;
+using cl::sycl::detail::is_sgeninteger;
 using cl::sycl::detail::queue_impl;
+using cl::sycl::detail::remove_AS;
 
 __SYCL_EXPORT size_t reduGetMaxWGSize(shared_ptr_class<queue_impl> Queue,
                                       size_t LocalMemBytesPerWorkItem);
 __SYCL_EXPORT size_t reduComputeWGSize(size_t NWorkItems, size_t MaxWGSize,
                                        size_t &NWorkGroups);
 
-using cl::sycl::detail::bool_constant;
-using cl::sycl::detail::enable_if_t;
-using cl::sycl::detail::is_geninteger16bit;
-using cl::sycl::detail::is_geninteger32bit;
-using cl::sycl::detail::is_geninteger64bit;
-using cl::sycl::detail::is_geninteger8bit;
-using cl::sycl::detail::remove_AS;
+template <typename T, class BinaryOperation>
+using IsReduPlus =
+    bool_constant<std::is_same<BinaryOperation, ONEAPI::plus<T>>::value ||
+                  std::is_same<BinaryOperation, ONEAPI::plus<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsReduPlus = detail::bool_constant<
-    std::is_same<BinaryOperation, ONEAPI::plus<T>>::value ||
-    std::is_same<BinaryOperation, ONEAPI::plus<void>>::value>;
+using IsReduMultiplies =
+    bool_constant<std::is_same<BinaryOperation, std::multiplies<T>>::value ||
+                  std::is_same<BinaryOperation, std::multiplies<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsReduMultiplies = detail::bool_constant<
-    std::is_same<BinaryOperation, std::multiplies<T>>::value ||
-    std::is_same<BinaryOperation, std::multiplies<void>>::value>;
+using IsReduMinimum =
+    bool_constant<std::is_same<BinaryOperation, ONEAPI::minimum<T>>::value ||
+                  std::is_same<BinaryOperation, ONEAPI::minimum<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsReduMinimum = detail::bool_constant<
-    std::is_same<BinaryOperation, ONEAPI::minimum<T>>::value ||
-    std::is_same<BinaryOperation, ONEAPI::minimum<void>>::value>;
+using IsReduMaximum =
+    bool_constant<std::is_same<BinaryOperation, ONEAPI::maximum<T>>::value ||
+                  std::is_same<BinaryOperation, ONEAPI::maximum<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsReduMaximum = detail::bool_constant<
-    std::is_same<BinaryOperation, ONEAPI::maximum<T>>::value ||
-    std::is_same<BinaryOperation, ONEAPI::maximum<void>>::value>;
+using IsReduBitOR =
+    bool_constant<std::is_same<BinaryOperation, ONEAPI::bit_or<T>>::value ||
+                  std::is_same<BinaryOperation, ONEAPI::bit_or<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsReduBitOR = detail::bool_constant<
-    std::is_same<BinaryOperation, ONEAPI::bit_or<T>>::value ||
-    std::is_same<BinaryOperation, ONEAPI::bit_or<void>>::value>;
+using IsReduBitXOR =
+    bool_constant<std::is_same<BinaryOperation, ONEAPI::bit_xor<T>>::value ||
+                  std::is_same<BinaryOperation, ONEAPI::bit_xor<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsReduBitXOR = detail::bool_constant<
-    std::is_same<BinaryOperation, ONEAPI::bit_xor<T>>::value ||
-    std::is_same<BinaryOperation, ONEAPI::bit_xor<void>>::value>;
-
-template <typename T, class BinaryOperation>
-using IsReduBitAND = detail::bool_constant<
-    std::is_same<BinaryOperation, ONEAPI::bit_and<T>>::value ||
-    std::is_same<BinaryOperation, ONEAPI::bit_and<void>>::value>;
+using IsReduBitAND =
+    bool_constant<std::is_same<BinaryOperation, ONEAPI::bit_and<T>>::value ||
+                  std::is_same<BinaryOperation, ONEAPI::bit_and<void>>::value>;
 
 template <typename T, class BinaryOperation>
 using IsReduOptForFastAtomicFetch =
-    detail::bool_constant<(is_geninteger32bit<T>::value ||
-                           is_geninteger64bit<T>::value) &&
-                          (IsReduPlus<T, BinaryOperation>::value ||
-                           IsReduMinimum<T, BinaryOperation>::value ||
-                           IsReduMaximum<T, BinaryOperation>::value ||
-                           IsReduBitOR<T, BinaryOperation>::value ||
-                           IsReduBitXOR<T, BinaryOperation>::value ||
-                           IsReduBitAND<T, BinaryOperation>::value)>;
+    bool_constant<is_sgeninteger<T>::value && IsValidAtomicType<T>::value &&
+                  (IsReduPlus<T, BinaryOperation>::value ||
+                   IsReduMinimum<T, BinaryOperation>::value ||
+                   IsReduMaximum<T, BinaryOperation>::value ||
+                   IsReduBitOR<T, BinaryOperation>::value ||
+                   IsReduBitXOR<T, BinaryOperation>::value ||
+                   IsReduBitAND<T, BinaryOperation>::value)>;
 
 template <typename T, class BinaryOperation>
-using IsReduOptForFastReduce = detail::bool_constant<
-    (is_geninteger32bit<T>::value || is_geninteger64bit<T>::value ||
-     std::is_same<T, half>::value || std::is_same<T, float>::value ||
-     std::is_same<T, double>::value) &&
-    (IsReduPlus<T, BinaryOperation>::value ||
-     IsReduMinimum<T, BinaryOperation>::value ||
-     IsReduMaximum<T, BinaryOperation>::value)>;
+using IsReduOptForFastReduce =
+    bool_constant<(is_sgeninteger<T>::value || is_sgenfloat<T>::value) &&
+                  (IsReduPlus<T, BinaryOperation>::value ||
+                   IsReduMinimum<T, BinaryOperation>::value ||
+                   IsReduMaximum<T, BinaryOperation>::value)>;
 
 // Identity = 0
 template <typename T, class BinaryOperation>
 using IsZeroIdentityOp = bool_constant<
-    ((is_geninteger8bit<T>::value || is_geninteger16bit<T>::value ||
-      is_geninteger32bit<T>::value || is_geninteger64bit<T>::value) &&
-     (IsReduPlus<T, BinaryOperation>::value ||
-      IsReduBitOR<T, BinaryOperation>::value ||
-      IsReduBitXOR<T, BinaryOperation>::value)) ||
-    ((std::is_same<T, half>::value || std::is_same<T, float>::value ||
-      std::is_same<T, double>::value) &&
-     IsReduPlus<T, BinaryOperation>::value)>;
+    (is_sgeninteger<T>::value && (IsReduPlus<T, BinaryOperation>::value ||
+                                  IsReduBitOR<T, BinaryOperation>::value ||
+                                  IsReduBitXOR<T, BinaryOperation>::value)) ||
+    (is_sgenfloat<T>::value && IsReduPlus<T, BinaryOperation>::value)>;
 
 // Identity = 1
 template <typename T, class BinaryOperation>
-using IsOneIdentityOp = bool_constant<
-    (is_geninteger8bit<T>::value || is_geninteger16bit<T>::value ||
-     is_geninteger32bit<T>::value || is_geninteger64bit<T>::value ||
-     std::is_same<T, half>::value || std::is_same<T, float>::value ||
-     std::is_same<T, double>::value) &&
-    IsReduMultiplies<T, BinaryOperation>::value>;
+using IsOneIdentityOp =
+    bool_constant<(is_sgeninteger<T>::value || is_sgenfloat<T>::value) &&
+                  IsReduMultiplies<T, BinaryOperation>::value>;
 
 // Identity = ~0
 template <typename T, class BinaryOperation>
-using IsOnesIdentityOp = bool_constant<
-    (is_geninteger8bit<T>::value || is_geninteger16bit<T>::value ||
-     is_geninteger32bit<T>::value || is_geninteger64bit<T>::value) &&
-    IsReduBitAND<T, BinaryOperation>::value>;
+using IsOnesIdentityOp = bool_constant<is_sgeninteger<T>::value &&
+                                       IsReduBitAND<T, BinaryOperation>::value>;
 
 // Identity = <max possible value>
 template <typename T, class BinaryOperation>
-using IsMinimumIdentityOp = bool_constant<
-    (is_geninteger8bit<T>::value || is_geninteger16bit<T>::value ||
-     is_geninteger32bit<T>::value || is_geninteger64bit<T>::value ||
-     std::is_same<T, half>::value || std::is_same<T, float>::value ||
-     std::is_same<T, double>::value) &&
-    IsReduMinimum<T, BinaryOperation>::value>;
+using IsMinimumIdentityOp =
+    bool_constant<(is_sgeninteger<T>::value || is_sgenfloat<T>::value) &&
+                  IsReduMinimum<T, BinaryOperation>::value>;
 
 // Identity = <min possible value>
 template <typename T, class BinaryOperation>
-using IsMaximumIdentityOp = bool_constant<
-    (is_geninteger8bit<T>::value || is_geninteger16bit<T>::value ||
-     is_geninteger32bit<T>::value || is_geninteger64bit<T>::value ||
-     std::is_same<T, half>::value || std::is_same<T, float>::value ||
-     std::is_same<T, double>::value) &&
-    IsReduMaximum<T, BinaryOperation>::value>;
+using IsMaximumIdentityOp =
+    bool_constant<(is_sgeninteger<T>::value || is_sgenfloat<T>::value) &&
+                  IsReduMaximum<T, BinaryOperation>::value>;
 
 template <typename T, class BinaryOperation>
 using IsKnownIdentityOp =
@@ -1604,7 +1583,7 @@ reduction(accessor<T, Dims, AccMode, access::target::global_buffer, IsPH> &Acc,
 /// The identity value is not passed to this version as it is statically known.
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
           access::placeholder IsPH>
-detail::enable_if_t<
+std::enable_if_t<
     detail::IsKnownIdentityOp<T, BinaryOperation>::value,
     detail::reduction_impl<T, BinaryOperation, Dims, false, AccMode, IsPH>>
 reduction(accessor<T, Dims, AccMode, access::target::global_buffer, IsPH> &Acc,
@@ -1632,16 +1611,18 @@ reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
 /// operation used in the reduction.
 /// The identity value is not passed to this version as it is statically known.
 template <typename T, class BinaryOperation>
-detail::enable_if_t<detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-                    detail::reduction_impl<T, BinaryOperation, 0, true,
-                                           access::mode::read_write>>
+std::enable_if_t<detail::IsKnownIdentityOp<T, BinaryOperation>::value,
+                 detail::reduction_impl<T, BinaryOperation, 0, true,
+                                        access::mode::read_write>>
 reduction(T *VarPtr, BinaryOperation) {
   return detail::reduction_impl<T, BinaryOperation, 0, true,
                                 access::mode::read_write>(VarPtr);
 }
 
+} // namespace ONEAPI
+
 template <typename BinaryOperation, typename AccumulatorT>
-struct has_known_identity : detail::has_known_identity_impl<
+struct has_known_identity : ONEAPI::detail::has_known_identity_impl<
                                 typename std::decay<BinaryOperation>::type,
                                 typename std::decay<AccumulatorT>::type> {};
 #if __cplusplus >= 201703L
@@ -1651,15 +1632,14 @@ inline constexpr bool has_known_identity_v =
 #endif
 
 template <typename BinaryOperation, typename AccumulatorT>
-struct known_identity
-    : detail::known_identity_impl<typename std::decay<BinaryOperation>::type,
-                                  typename std::decay<AccumulatorT>::type> {};
+struct known_identity : ONEAPI::detail::known_identity_impl<
+                            typename std::decay<BinaryOperation>::type,
+                            typename std::decay<AccumulatorT>::type> {};
 #if __cplusplus >= 201703L
 template <typename BinaryOperation, typename AccumulatorT>
 inline constexpr AccumulatorT known_identity_v =
     known_identity<BinaryOperation, AccumulatorT>::value;
 #endif
 
-} // namespace ONEAPI
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/ONEAPI/reduction.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/reduction.hpp
@@ -1647,23 +1647,25 @@ inline constexpr AccumulatorT known_identity_v =
 // Currently, the type traits defined below correspond to SYCL 1.2.1 ONEAPI
 // reduction extension. That may be changed later when SYCL 2020 reductions
 // are implemented.
-#if SYCL_LANGUAGE_VERSION >= 202001
 template <typename BinaryOperation, typename AccumulatorT>
 struct has_known_identity
     : ONEAPI::has_known_identity<BinaryOperation, AccumulatorT> {};
 
+#if __cplusplus >= 201703L
 template <typename BinaryOperation, typename AccumulatorT>
 inline constexpr bool has_known_identity_v =
     has_known_identity<BinaryOperation, AccumulatorT>::value;
+#endif
 
 template <typename BinaryOperation, typename AccumulatorT>
 struct known_identity : ONEAPI::known_identity<BinaryOperation, AccumulatorT> {
 };
 
+#if __cplusplus >= 201703L
 template <typename BinaryOperation, typename AccumulatorT>
 inline constexpr AccumulatorT known_identity_v =
     known_identity<BinaryOperation, AccumulatorT>::value;
-#endif // SYCL_LANGUAGE_VERSION >= 202001
+#endif
 
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/test/basic_tests/reduction_known_identity.cpp
+++ b/sycl/test/basic_tests/reduction_known_identity.cpp
@@ -1,0 +1,106 @@
+// RUN: %clangxx -fsyntax-only -Xclang -verify %s -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning
+// expected-no-diagnostics
+
+// This test performs basic checks of has_known_identity and known_identity
+// type traits.
+
+#include <CL/sycl.hpp>
+#include <cassert>
+
+using namespace cl::sycl;
+
+template <typename T> void checkCommonBasicKnownIdentity() {
+  static_assert(has_known_identity<ONEAPI::maximum<>, T>::value);
+  static_assert(has_known_identity<ONEAPI::maximum<T>, T>::value);
+  static_assert(has_known_identity<ONEAPI::minimum<>, T>::value);
+  static_assert(has_known_identity<ONEAPI::minimum<T>, T>::value);
+}
+
+template <typename T> void checkCommonKnownIdentity() {
+  checkCommonBasicKnownIdentity<T>();
+
+  static_assert(has_known_identity<std::plus<>, T>::value);
+  static_assert(has_known_identity<std::plus<T>, T>::value);
+  static_assert(known_identity<std::plus<>, T>::value == 0);
+  static_assert(known_identity<std::plus<T>, T>::value == 0);
+
+  static_assert(has_known_identity<std::multiplies<>, T>::value);
+  static_assert(has_known_identity<std::multiplies<T>, T>::value);
+  static_assert(known_identity<std::multiplies<>, T>::value == 1);
+  static_assert(known_identity<std::multiplies<T>, T>::value == 1);
+}
+
+template <typename T> void checkIntKnownIdentity() {
+  checkCommonKnownIdentity<T>();
+
+  constexpr T Ones = ~static_cast<T>(0);
+  static_assert(has_known_identity<std::bit_and<>, T>::value);
+  static_assert(has_known_identity<std::bit_and<T>, T>::value);
+  static_assert(known_identity<std::bit_and<>, T>::value == Ones);
+  static_assert(known_identity<std::bit_and<T>, T>::value == Ones);
+
+  static_assert(has_known_identity<std::bit_or<>, T>::value);
+  static_assert(has_known_identity<std::bit_or<T>, T>::value);
+  static_assert(known_identity<std::bit_or<>, T>::value == 0);
+  static_assert(known_identity<std::bit_or<T>, T>::value == 0);
+
+  static_assert(has_known_identity<std::bit_xor<>, T>::value);
+  static_assert(has_known_identity<std::bit_xor<T>, T>::value);
+  static_assert(known_identity<std::bit_xor<>, T>::value == 0);
+  static_assert(known_identity<std::bit_xor<T>, T>::value == 0);
+}
+
+int main() {
+  checkIntKnownIdentity<int8_t>();
+  checkIntKnownIdentity<char>();
+  checkIntKnownIdentity<cl_char>();
+
+  checkIntKnownIdentity<int16_t>();
+  checkIntKnownIdentity<short>();
+  checkIntKnownIdentity<cl_short>();
+
+  checkIntKnownIdentity<int32_t>();
+  checkIntKnownIdentity<int>();
+  checkIntKnownIdentity<cl_int>();
+
+  checkIntKnownIdentity<long>();
+
+  checkIntKnownIdentity<int64_t>();
+  checkIntKnownIdentity<long long>();
+  checkIntKnownIdentity<cl_long>();
+
+  checkIntKnownIdentity<uint8_t>();
+  checkIntKnownIdentity<unsigned char>();
+  checkIntKnownIdentity<cl_uchar>();
+
+  checkIntKnownIdentity<uint16_t>();
+  checkIntKnownIdentity<unsigned short>();
+  checkIntKnownIdentity<cl_ushort>();
+
+  checkIntKnownIdentity<uint32_t>();
+  checkIntKnownIdentity<unsigned int>();
+  checkIntKnownIdentity<unsigned>();
+  checkIntKnownIdentity<cl_uint>();
+
+  checkIntKnownIdentity<unsigned long>();
+
+  checkIntKnownIdentity<uint64_t>();
+  checkIntKnownIdentity<unsigned long long>();
+  checkIntKnownIdentity<cl_ulong>();
+  checkIntKnownIdentity<std::size_t>();
+
+  checkCommonKnownIdentity<float>();
+  checkCommonKnownIdentity<cl_float>();
+  checkCommonKnownIdentity<double>();
+  checkCommonKnownIdentity<cl_double>();
+
+  checkCommonBasicKnownIdentity<half>();
+  checkCommonBasicKnownIdentity<sycl::cl_half>();
+  checkCommonBasicKnownIdentity<::cl_half>();
+
+  // Few negative tests just to check that it does not always return true.
+  static_assert(!has_known_identity<std::minus<>, int>::value);
+  static_assert(!has_known_identity<ONEAPI::bit_or<>, float>::value);
+
+  return 0;
+}


### PR DESCRIPTION
- Copy 'known_identity' and 'has_known_identity' from sycl::ONEAPI to sycl
- Fix the compilation errors reported on attempts to use vector types
  like sycl::int4 as a reduction variable.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>