### PR TITLE
[ESIMD] Run DAE pass but skip ESIMD kernels in it

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -968,12 +968,9 @@ void EmitAssemblyHelper::EmitAssembly(BackendAction Action,
   std::unique_ptr<llvm::ToolOutputFile> ThinLinkOS, DwoOS;
 
   // Eliminate dead arguments from SPIR kernels in SYCL environment.
-  // 1. Run DAE when LLVM optimizations are applied as well.
-  // 2. We cannot run DAE for ESIMD since the pointers to SPIR kernel
-  //    functions are saved in !genx.kernels metadata.
-  // 3. DAE pass temporary guarded under option.
+  // Run DAE when LLVM optimizations are applied as well.
   if (LangOpts.SYCLIsDevice && !CodeGenOpts.DisableLLVMPasses &&
-      !LangOpts.SYCLExplicitSIMD && LangOpts.EnableDAEInSpirKernels)
+      LangOpts.EnableDAEInSpirKernels)
     PerModulePasses.add(createDeadArgEliminationSYCLPass());
 
   if (LangOpts.SYCLIsDevice && LangOpts.SYCLExplicitSIMD)

--- a/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
+++ b/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
@@ -1,3 +1,4 @@
+//===- DeadArgumentElimination.cpp - Eliminate dead arguments -------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -570,12 +571,12 @@ void DeadArgumentEliminationPass::SurveyFunction(const Function &F) {
   // We can't modify arguments if the function is not local
   // but we can do so for SPIR kernel function in SYCL environment.
   // DAE is not currently supported for ESIMD kernels.
-  bool FuncIsNonEsimdSpirKernel =
+  bool FuncIsSpirNonEsimdKernel =
       CheckSpirKernels &&
       StringRef(F.getParent()->getTargetTriple()).contains("sycldevice") &&
       F.getCallingConv() == CallingConv::SPIR_KERNEL &&
       !F.getMetadata("sycl_explicit_simd");
-  bool FuncIsLive = !F.hasLocalLinkage() && !FuncIsNonEsimdSpirKernel;
+  bool FuncIsLive = !F.hasLocalLinkage() && !FuncIsSpirNonEsimdKernel;
   if (FuncIsLive && (!ShouldHackArguments || F.isIntrinsic())) {
     MarkLive(F);
     return;


### PR DESCRIPTION
This patch is a part of the efforts for allowing
ESIMD and regular SYCL kernels to coexist in the same
translation unit and in the same program.

This patch helps to eliminate one of the dependencies
on -fsycl-explicit-simd, which we want to remove in
the future.