### PR TITLE
[NFC][ESIMD] Remove dependencies on -fsycl-explicit-simd flag

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1656,7 +1656,9 @@ void CodeGenModule::GenOpenCLArgMetadata(llvm::Function *Fn,
             CGF->Builder.getInt1(parm->hasAttr<SYCLSimdAccessorPtrAttr>())));
     }
 
-  if (LangOpts.SYCLIsDevice && !LangOpts.SYCLExplicitSIMD)
+  bool IsEsimdFunction = FD && FD->hasAttr<SYCLSimdAttr>();
+
+  if (LangOpts.SYCLIsDevice && !IsEsimdFunction)
     Fn->setMetadata("kernel_arg_buffer_location",
                     llvm::MDNode::get(VMContext, argSYCLBufferLocationAttr));
   else {
@@ -1670,7 +1672,7 @@ void CodeGenModule::GenOpenCLArgMetadata(llvm::Function *Fn,
                     llvm::MDNode::get(VMContext, argBaseTypeNames));
     Fn->setMetadata("kernel_arg_type_qual",
                     llvm::MDNode::get(VMContext, argTypeQuals));
-    if (FD && FD->hasAttr<SYCLSimdAttr>())
+    if (IsEsimdFunction)
       Fn->setMetadata("kernel_arg_accessor_ptr",
                       llvm::MDNode::get(VMContext, argESIMDAccPtrs));
     if (getCodeGenOpts().EmitOpenCLArgMetadata)


### PR DESCRIPTION
This patch is a part of the efforts for allowing ESIMD and
regular SYCL kernels to coexist in the same translation unit and
in the same program.

Set the `kernel_arg*` metadata based on the sycl_explicit_simd 
attribute, not depending on `-fsycl-explicit-esimd` flag, which
soon will be removed.