### PR TITLE
[NFC][ESIMD] Remove one of the uses of __SYCL_EXPLICIT_SIMD__

### DIFF
--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -15,7 +15,7 @@
 
 #define __SPIRV_VAR_QUALIFIERS extern "C" const
 
-#if defined(__SYCL_NVPTX__) || defined(__SYCL_EXPLICIT_SIMD__)
+#if defined(__SYCL_NVPTX__)
 
 SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_x();
 SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_y();


### PR DESCRIPTION
This patch is a part of the efforts for allowing ESIMD and
regular SYCL kernels to coexist in the same translation unit and
in the same program.

In ESIMD kernels, calls to __spirv_ functions are lowered into GenX intrinsic.
Because of that, it's OK to have definitions instead of declarations for those functions.
Unused definitions of __spirv_ functions will be DCE'ed anyway, so no impact on functionality.