### PR TITLE
[Driver][SYCL] Only preprocess for device when using -fsycl-device-only

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3728,6 +3728,20 @@ class OffloadingActionBuilder final {
     getDeviceDependences(OffloadAction::DeviceDependences &DA,
                          phases::ID CurPhase, phases::ID FinalPhase,
                          PhasesTy &Phases) override {
+      if (CurPhase == phases::Preprocess) {
+        // Do not perform the host compilation when doing preprocessing only
+        // with -fsycl-device-only.
+        bool IsPreprocessOnly =
+            Args.getLastArg(options::OPT_E) ||
+            Args.getLastArg(options::OPT__SLASH_EP, options::OPT__SLASH_P) ||
+            Args.getLastArg(options::OPT_M, options::OPT_MM);
+        if (Args.hasArg(options::OPT_fsycl_device_only) && IsPreprocessOnly) {
+          for (Action *&A : SYCLDeviceActions)
+            A = C.getDriver().ConstructPhaseAction(C, Args, CurPhase, A,
+                                                   AssociatedOffloadKind);
+          return ABRT_Ignore_Host;
+        }
+      }
 
       // FIXME: This adds the integration header generation pass before the
       // Host compilation pass so the Host can use the header generated.  This
@@ -3764,20 +3778,6 @@ class OffloadingActionBuilder final {
         // action.
         DeviceCompilerInput = nullptr;
         return SYCLDeviceOnly ? ABRT_Ignore_Host : ABRT_Success;
-      }
-
-      if (CurPhase == phases::Preprocess) {
-        // Do not perform the host compilation when doing preprocessing only
-        // with -fsycl-device-only.
-        if (Args.hasArg(options::OPT_fsycl_device_only) &&
-            (Args.getLastArg(options::OPT__SLASH_EP, options::OPT__SLASH_P) ||
-             Args.getLastArg(options::OPT_E) ||
-             Args.getLastArg(options::OPT_M, options::OPT_MM))) {
-          for (Action *&A : SYCLDeviceActions)
-            A = C.getDriver().ConstructPhaseAction(C, Args, CurPhase, A,
-                                                   AssociatedOffloadKind);
-          return ABRT_Ignore_Host;
-        }
       }
 
       // Backend/Assemble actions are obsolete for the SYCL device side

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3766,6 +3766,20 @@ class OffloadingActionBuilder final {
         return SYCLDeviceOnly ? ABRT_Ignore_Host : ABRT_Success;
       }
 
+      if (CurPhase == phases::Preprocess) {
+        // Do not perform the host compilation when doing preprocessing only
+        // with -fsycl-device-only.
+        if (Args.hasArg(options::OPT_fsycl_device_only) &&
+            (Args.getLastArg(options::OPT__SLASH_EP, options::OPT__SLASH_P) ||
+             Args.getLastArg(options::OPT_E) ||
+             Args.getLastArg(options::OPT_M, options::OPT_MM))) {
+          for (Action *&A : SYCLDeviceActions)
+            A = C.getDriver().ConstructPhaseAction(C, Args, CurPhase, A,
+                                                   AssociatedOffloadKind);
+          return ABRT_Ignore_Host;
+        }
+      }
+
       // Backend/Assemble actions are obsolete for the SYCL device side
       if (CurPhase == phases::Backend || CurPhase == phases::Assemble)
         return ABRT_Inactive;

--- a/clang/test/Driver/sycl-device.cpp
+++ b/clang/test/Driver/sycl-device.cpp
@@ -35,3 +35,24 @@
 // RUN: %clang_cl -### -fsycl -fsycl-device-only -o dummy.out %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK-OUTPUT-FILE %s
 // CHECK-OUTPUT-FILE: clang{{.*}} "-o" "dummy.out"
+
+/// -fsycl-device-only with preprocessing should only do the device compile
+// RUN: %clang -ccc-print-phases -E -fsycl -fsycl-device-only %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=PHASES-PREPROCESS %s
+// RUN: %clang_cl -ccc-print-phases -E -fsycl -fsycl-device-only %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=PHASES-PREPROCESS %s
+// RUN: %clang_cl -ccc-print-phases -P -fsycl -fsycl-device-only %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=PHASES-PREPROCESS %s
+// RUN: %clang_cl -ccc-print-phases -EP -fsycl -fsycl-device-only %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=PHASES-PREPROCESS %s
+// PHASES-PREPROCESS: 0: input, {{.*}}, c++, (device-sycl)
+// PHASES-PREPROCESS: 1: preprocessor, {0}, c++-cpp-output, (device-sycl)
+// PHASES-PREPROCESS: 2: offload, "device-sycl (spir64-unknown-unknown-sycldevice)" {1}, c++-cpp-output
+
+// RUN: %clang -ccc-print-phases -MM -fsycl -fsycl-device-only %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=PHASES-PREPROC-DEPS %s
+// RUN: %clang -ccc-print-phases -M -fsycl -fsycl-device-only %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=PHASES-PREPROC-DEPS %s
+// PHASES-PREPROC-DEPS: 0: input, {{.*}}, c++, (device-sycl)
+// PHASES-PROPROC-DEPS: 1: preprocessor, {0}, dependencies, (device-sycl)
+// PHASES-PREPROC-DEPS: 2: offload, "device-sycl (spir64-unknown-unknown-sycldevice)" {1}, dependencies


### PR DESCRIPTION
When performing -fsycl-device-only with preprocessing output, make sure
we only output for the device compilation.  The compilation was also doing
host compiles causing incorrect output for 'device only'