### PR TITLE
[ESIMD] Add CXX11-style [[intel::sycl_explicit_simd]] attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1176,7 +1176,8 @@ def SYCLKernel : InheritableAttr {
 // e.g. because the function is already vectorized. Used to mark SYCL
 // explicit SIMD kernels and functions.
 def SYCLSimd : InheritableAttr {
-  let Spellings = [GNU<"sycl_explicit_simd">];
+  let Spellings = [GNU<"sycl_explicit_simd">,
+                   CXX11<"intel", "sycl_explicit_simd">];
   let Subjects = SubjectList<[Function]>;
   let LangOpts = [SYCLExplicitSIMD];
   let Documentation = [SYCLSimdDocs];

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -167,7 +167,7 @@ public:
         ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim ||
         ParsedAttr == AT_SYCLIntelNoGlobalWorkOffset ||
         ParsedAttr == AT_SYCLIntelUseStallEnableClusters ||
-        ParsedAttr == AT_SYCLIntelLoopFuse)
+        ParsedAttr == AT_SYCLIntelLoopFuse || ParsedAttr == AT_SYCLSimd)
       return true;
 
     return false;

--- a/clang/test/CodeGenSYCL/esimd_metadata1.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata1.cpp
@@ -16,6 +16,9 @@ void kernel(const Func &f) __attribute__((sycl_kernel)) {
 void bar() {
   kernel<class MyKernel>([=]() __attribute__((sycl_explicit_simd)){});
   // CHECK: define {{.*}}spir_kernel void @_ZTSZ3barvE8MyKernel() {{.*}} !sycl_explicit_simd ![[EMPTY:[0-9]+]] !intel_reqd_sub_group_size ![[REQD_SIZE:[0-9]+]]
+
+  kernel<class MyEsimdKernel>([=]() [[intel::sycl_explicit_simd]]{});
+  // CHECK: define {{.*}}spir_kernel void @_ZTSZ3barvE13MyEsimdKernel() {{.*}} !sycl_explicit_simd ![[EMPTY:[0-9]+]] !intel_reqd_sub_group_size ![[REQD_SIZE]]
 }
 
 // CHECK: !spirv.Source = !{[[LANG:![0-9]+]]}

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -75,3 +75,31 @@ struct Kernel3 {
 void bar3() {
   kernel3(Kernel3{});
 }
+
+// -- Clang-style [[sycl_explicit_simd]] attribute for functor object kernel.
+
+template <typename F, typename ID = F>
+[[clang::sycl_kernel]] void kernel4(const F &f) {
+  f();
+}
+
+struct Kernel4 {
+  [[intel::sycl_explicit_simd]] void operator()() const {}
+};
+
+void bar4() {
+  kernel4(Kernel4{});
+}
+
+// -- Clang-style [[sycl_explicit_simd]] attribute for lambda and free function.
+
+template <typename ID, typename F>
+[[clang::sycl_kernel]] void kernel5(const F &f) {
+  f();
+}
+
+[[intel::sycl_explicit_simd]] void g5() {}
+
+void test5() {
+  kernel5<class Kernel5>([=]() [[intel::sycl_explicit_simd]] { g5(); });
+}


### PR DESCRIPTION
This patch enables CXX11-style sycl_explicit_simd attribute
to conform to the ESIMD specification.

This fixes https://github.com/intel/llvm/issues/3229.