### PR TITLE
Revert "[NFC][ESIMD] Remove one of the uses of __SYCL_EXPLICIT_SIMD__"

### DIFF
--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -15,7 +15,7 @@
 
 #define __SPIRV_VAR_QUALIFIERS extern "C" const
 
-#if defined(__SYCL_NVPTX__)
+#if defined(__SYCL_NVPTX__) || defined(__SYCL_EXPLICIT_SIMD__)
 
 SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_x();
 SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_y();


### PR DESCRIPTION
Reverts intel/llvm#3242