### PR TITLE
[CUDA] Fix SYCL NVPTX passes if function operand is null-ref

### DIFF
--- a/llvm/lib/Target/NVPTX/SYCL/GlobalOffset.cpp
+++ b/llvm/lib/Target/NVPTX/SYCL/GlobalOffset.cpp
@@ -342,8 +342,10 @@ public:
         continue;
 
       // Get a pointer to the entry point function from the metadata.
-      auto FuncConstant =
-          dyn_cast<ConstantAsMetadata>(MetadataNode->getOperand(0));
+      const auto &FuncOperand = MetadataNode->getOperand(0);
+      if (!FuncOperand)
+        continue;
+      auto FuncConstant = dyn_cast<ConstantAsMetadata>(FuncOperand);
       if (!FuncConstant)
         continue;
       auto Func = dyn_cast<Function>(FuncConstant->getValue());

--- a/llvm/lib/Target/NVPTX/SYCL/LocalAccessorToSharedMemory.cpp
+++ b/llvm/lib/Target/NVPTX/SYCL/LocalAccessorToSharedMemory.cpp
@@ -65,6 +65,8 @@ public:
 
       // Get a pointer to the entry point function from the metadata.
       const MDOperand &FuncOperand = MetadataNode->getOperand(0);
+      if (!FuncOperand)
+        continue;
       auto FuncConstant = dyn_cast<ConstantAsMetadata>(FuncOperand);
       if (!FuncConstant)
         continue;


### PR DESCRIPTION
Fixes #3271