### PR TITLE
[SYCL] Add implementation of kernel_bundle support. Part 1.

### DIFF
--- a/sycl/include/CL/sycl.hpp
+++ b/sycl/include/CL/sycl.hpp
@@ -33,6 +33,7 @@
 #include <CL/sycl/image.hpp>
 #include <CL/sycl/item.hpp>
 #include <CL/sycl/kernel.hpp>
+#include <CL/sycl/kernel_bundle.hpp>
 #include <CL/sycl/marray.hpp>
 #include <CL/sycl/multi_ptr.hpp>
 #include <CL/sycl/nd_item.hpp>

--- a/sycl/include/CL/sycl/kernel_bundle.hpp
+++ b/sycl/include/CL/sycl/kernel_bundle.hpp
@@ -1,0 +1,572 @@
+//==------- kernel_bundle.hpp - SYCL kernel_bundle and free functions ------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <CL/sycl/context.hpp>
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/device.hpp>
+#include <CL/sycl/kernel.hpp>
+
+#include <cassert>
+#include <memory>
+#include <vector>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+
+enum class bundle_state : char { input = 0, object = 1, executable = 2 };
+
+namespace detail {
+class kernel_id_impl;
+}
+
+/// Objects of the class identify kernel is some kernel_bundle related APIs
+///
+/// \ingroup sycl_api
+class __SYCL_EXPORT kernel_id {
+public:
+  /// Returns a null-terminated string which contains the kernel name
+  const char *get_name() const;
+
+private:
+  kernel_id(const char *Name);
+
+  kernel_id(const std::shared_ptr<detail::kernel_id_impl> &Impl);
+
+  std::shared_ptr<detail::kernel_id_impl> impl;
+
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
+
+  template <class T>
+  friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
+
+  template <typename KernelName> friend kernel_id get_kernel_id();
+};
+
+
+namespace detail {
+class device_image_impl;
+using DeviceImageImplPtr = std::shared_ptr<device_image_impl>;
+
+// The class is used as a base for device_image for "untemplating" public
+// methods.
+class __SYCL_EXPORT device_image_plain {
+public:
+  device_image_plain(const detail::DeviceImageImplPtr &Impl)
+      : impl(std::move(Impl)) {}
+
+  bool operator==(const device_image_plain &RHS) const {
+    return impl == RHS.impl;
+  }
+
+  bool operator!=(const device_image_plain &RHS) const {
+    return !(*this == RHS);
+  }
+
+  // Returns true if the device_image contains the kernel identified by the
+  // KernelID
+  bool has_kernel(const kernel_id &KernelID) const noexcept;
+
+  // Returns true if the device_image contains the kernel identified by the
+  // KernelID and is compatible with the passed Dev
+  bool has_kernel(const kernel_id &KernelID, const device &Dev) const noexcept;
+
+protected:
+  detail::DeviceImageImplPtr impl;
+};
+} // namespace detail
+
+
+// Objects of the class represents an instance of an image in a specific state.
+template <sycl::bundle_state State>
+class device_image : public detail::device_image_plain {
+public:
+  device_image() = delete;
+
+  // required methods come from the base class
+
+private:
+  device_image(detail::DeviceImageImplPtr Impl)
+      : device_image_plain(std::move(Impl)) {}
+
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
+
+  template <class T>
+  friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
+};
+
+namespace detail {
+class kernel_bundle_impl;
+using KernelBundleImplPtr = std::shared_ptr<detail::kernel_bundle_impl>;
+
+// The class is used as a base for kernel_bundle to "untemplate" it's methods
+class __SYCL_EXPORT kernel_bundle_plain {
+public:
+  kernel_bundle_plain(const detail::KernelBundleImplPtr &Impl)
+      : impl(std::move(Impl)) {}
+
+  bool operator==(const kernel_bundle_plain &RHS) const {
+    return impl == RHS.impl;
+  }
+
+  bool operator!=(const kernel_bundle_plain &RHS) const {
+    return !(*this == RHS);
+  }
+
+  /// Returns true if the kernel_bundles contains no device images
+  bool empty() const noexcept;
+
+  /// Returns the backend associated with the kernel bundle
+  backend get_backend() const noexcept;
+
+  /// Returns the context associated with the kernel_bundle
+  context get_context() const noexcept;
+
+  /// Returns devices associated with the kernel_bundle
+  std::vector<device> get_devices() const noexcept;
+
+  /// Returns true if the kernel_bundle contains the kernel identified by
+  /// kernel_id passed
+  bool has_kernel(const kernel_id &KernelID) const noexcept;
+
+  /// Returns true if the kernel_bundle contains the kernel identified by
+  /// kernel_id passed and if this kernel is compatible with the device
+  /// specified
+  bool has_kernel(const kernel_id &KernelID, const device &Dev) const noexcept;
+
+  /// Returns a vector of kernel_id's that contained in the kernel_bundle
+  std::vector<kernel_id> get_kernel_ids() const;
+
+  /// Returns true if the kernel_bundle contains at least one device image which
+  /// uses specialization constants
+  bool contains_specialization_constants() const noexcept;
+
+  /// Returns true if all specialization constants which are used in the
+  /// kernel_bundle are "native specialization constants in all device images
+  bool native_specialization_constant() const noexcept;
+
+protected:
+  // Returns true if the kernel_bundle has the specialization constant with
+  // specified ID
+  bool has_specialization_constant(unsigned int SpecID) const noexcept;
+
+  // Sets the specialization constant with specified ID to the value pointed by
+  // Value + ValueSize
+  void set_specialization_constant(unsigned int SpecID, void *Value,
+                                   size_t ValueSize);
+
+  // Returns pointer to the value of the specialization constant with specified
+  // ID
+  void *get_specialization_constant(unsigned int SpecID) const;
+
+  // Returns a kernel object which represents the kernel identified by
+  // kernel_id passed
+  kernel get_kernel(const kernel_id &KernelID) const;
+
+  // Returns an iterator to the first device image kernel_bundle contains
+  kernel_bundle_plain *begin() const;
+
+  // Returns an iterator to the last device image kernel_bundle contains
+  kernel_bundle_plain *end() const;
+
+  detail::KernelBundleImplPtr impl;
+};
+
+} // namespace detail
+
+/// The kernel_bundle class represents collection of device images in a
+/// particular state
+///
+/// \ingroup sycl_api
+template <bundle_state State>
+class kernel_bundle : public detail::kernel_bundle_plain {
+public:
+  using device_image_iterator = device_image<State> *;
+
+  kernel_bundle() = delete;
+
+  // some required methods come from the base class
+
+  /// Returns a kernel object which represents the kernel identified by
+  /// kernel_id passed
+  template <bundle_state _State = State,
+            typename = detail::enable_if_t<_State == bundle_state::executable>>
+  kernel get_kernel(const kernel_id &KernelID) const {
+    return detail::kernel_bundle_plain::get_kernel(KernelID);
+  }
+
+#if __cplusplus > 201402L
+  /// Returns true if any device image in the kernel_bundle uses specialization
+  /// constant whose address is SpecName
+  template <auto &SpecName> bool has_specialization_constant() const noexcept {
+    assert(false && "has_specialization_constant is not implemented yet");
+    unsigned int SpecID = 0; // TODO: Convert SpecName to a numeric ID
+    return kernel_bundle_plain::has_specialization_constant(SpecID);
+  }
+
+  /// Sets the value of the specialization constant whose address is SpecName
+  /// for this bundle. If the specialization constant’s value was previously set
+  /// in this bundle, the value is overwritten.
+  template <auto &SpecName, bundle_state _State = State,
+            typename = detail::enable_if_t<_State == bundle_state::input>>
+  void set_specialization_constant(
+      typename std::remove_reference_t<decltype(SpecName)>::type Value) {
+    assert(false && "set_specialization_constant is not implemented yet");
+    unsigned int SpecID = 0; // TODO: Convert SpecName to a numeric ID
+    return kernel_bundle_plain::set_specialization_constant(SpecID, &Value,
+                                                            sizeof(Value));
+  }
+
+  /// The value of the specialization constant whose address is SpecName for
+  /// this kernel bundle.
+  template <auto &SpecName>
+  typename std::remove_reference_t<decltype(SpecName)>::type
+  get_specialization_constant() const {
+    assert(false && "get_specialization_constant is not implemented yet");
+    unsigned int SpecID = 0; // TODO: Convert SpecName to a numeric ID
+    typename std::remove_reference_t<decltype(SpecName)>::type *ValuePtr =
+        kernel_bundle_plain::get_specialization_constant(SpecID);
+    return *ValuePtr;
+  }
+#endif
+
+  /// Returns an iterator to the first device image kernel_bundle contains
+  device_image_iterator begin() const {
+    return reinterpret_cast<device_image_iterator>(
+        kernel_bundle_plain::begin());
+  }
+
+  /// Returns an iterator to the last device image kernel_bundle contains
+  device_image_iterator end() const {
+    return reinterpret_cast<device_image_iterator>(kernel_bundle_plain::end());
+  }
+
+private:
+  kernel_bundle(detail::KernelBundleImplPtr Impl)
+      : kernel_bundle_plain(std::move(Impl)) {}
+
+  template <class Obj>
+  friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
+
+  template <class T>
+  friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
+};
+
+
+/////////////////////////
+// get_kernel_id API
+/////////////////////////
+
+/// Returns the kernel_id associated with the KernelName
+template <typename KernelName> kernel_id get_kernel_id() {
+  using KI = sycl::detail::KernelInfo<KernelName>;
+  return sycl::kernel_id(KI::getName());
+}
+
+/// Returns a vector with all kernel_id's defined in the application
+std::vector<kernel_id> get_kernel_ids();
+
+/////////////////////////
+// get_kernel_bundle API
+/////////////////////////
+
+namespace detail {
+
+// Internal non-template versions of get_kernel_bundle API which is used by
+// public onces
+detail::KernelBundleImplPtr
+get_kernel_bundle_impl(const context &Ctx, const std::vector<device> &Devs,
+                       bundle_state State);
+} // namespace detail
+
+/// A kernel bundle in state State which contains all of the kernels in the
+/// application which are compatible with at least one of the devices in Devs.
+/// This does not include any device built-in kernels. The bundle’s set of
+/// associated devices is Devs.
+template <bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context &Ctx,
+                                       const std::vector<device> &Devs) {
+  detail::KernelBundleImplPtr Impl =
+      detail::get_kernel_bundle_impl(Ctx, Devs, State);
+  return detail::createSyclObjFromImpl<kernel_bundle<State>>(Impl);
+}
+
+template <bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context &Ctx) {
+  return get_kernel_bundle<State>(Ctx, Ctx.get_devices());
+}
+
+namespace detail {
+
+// Internal non-template versions of get_kernel_bundle API which is used by
+// public onces
+detail::KernelBundleImplPtr
+get_kernel_bundle_impl(const context &Ctx, const std::vector<device> &Devs,
+                       const std::vector<kernel_id> &KernelIDs,
+                       bundle_state State);
+} // namespace detail
+
+/// Returns a kernel bundle in state State which contains all of the device
+/// images that are compatible with at least one of the devices in Devs, further
+/// filtered to contain only those device images that contain kernels with the
+/// given identifiers. These identifiers may represent kernels that are defined
+/// in the application, device built-in kernels, or a mixture of the two. Since
+/// the device images may group many kernels together, the returned bundle may
+/// contain additional kernels beyond those that are requested in KernelIDs. The
+/// bundle’s set of associated devices is Devs.
+template <bundle_state State>
+kernel_bundle<State>
+get_kernel_bundle(const context &Ctx, const std::vector<device> &Devs,
+                  const std::vector<kernel_id> &KernelIDs) {
+  detail::KernelBundleImplPtr Impl =
+      detail::get_kernel_bundle_impl(Ctx, Devs, KernelIDs, State);
+  return detail::createSyclObjFromImpl<kernel_bundle<State>>(Impl);
+}
+
+template <bundle_state State>
+kernel_bundle<State>
+get_kernel_bundle(const context &Ctx, const std::vector<kernel_id> &KernelIDs) {
+  return get_kernel_bundle<State>(Ctx, Ctx.get_devices(), KernelIDs);
+}
+
+template <typename KernelName, bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context &Ctx) {
+  return get_kernel_bundle<State>(Ctx, Ctx.get_devices(),
+                                  {get_kernel_id<KernelName>()});
+}
+
+template <typename KernelName, bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context &Ctx,
+                                       const std::vector<device> &Devs) {
+  return get_kernel_bundle<State>(Ctx, Devs, {get_kernel_id<KernelName>()});
+}
+
+namespace detail {
+
+// Stable selector function type for passing thru library boundaries
+using DevImgSelectorImpl =
+    std::function<bool(const detail::DeviceImageImplPtr &DevImgImpl)>;
+
+// Internal non-template versions of get_kernel_bundle API which is used by
+// public onces
+detail::KernelBundleImplPtr
+get_kernel_bundle_impl(const context &Ctx, const std::vector<device> &Devs,
+                       bundle_state State, const DevImgSelectorImpl &Selector);
+} // namespace detail
+
+/// A kernel bundle in state State which contains all of the device images for
+/// which the selector returns true.
+template <bundle_state State, typename SelectorT>
+kernel_bundle<State> get_kernel_bundle(const context &Ctx,
+                                       const std::vector<device> &Devs,
+                                       SelectorT Selector) {
+  detail::DevImgSelectorImpl SelectorWrapper =
+      [Selector](const detail::DeviceImageImplPtr &DevImg) {
+        return Selector(
+            detail::createSyclObjFromImpl<sycl::device_image<State>>(DevImg));
+      };
+
+  std::vector<kernel_id> EmptyKernelIDs;
+  detail::KernelBundleImplPtr Impl =
+      detail::get_kernel_bundle_impl(Ctx, Devs, State, SelectorWrapper);
+
+  return detail::createSyclObjFromImpl<sycl::kernel_bundle<State>>(Impl);
+}
+
+template <bundle_state State, typename SelectorT>
+kernel_bundle<State> get_kernel_bundle(const context &Ctx, SelectorT Selector) {
+  return get_kernel_bundle<State>(Ctx, Ctx.get_devices(), Selector);
+}
+
+/////////////////////////
+// has_kernel_bundle API
+/////////////////////////
+
+namespace detail {
+
+bool has_kernel_bundle_impl(const context &Ctx, const std::vector<device> &Devs,
+                            bundle_state State);
+
+bool has_kernel_bundle_impl(const context &Ctx, const std::vector<device> &Devs,
+                            const std::vector<kernel_id> &kernelIds,
+                            bundle_state State);
+} // namespace detail
+
+/// Returns true if the following is true:
+/// The application defines at least one kernel that is compatible with at
+/// least one of the devices in Devs, and that kernel can be represented in a
+/// device image of state State.
+///
+/// If State is bundle_state::input, all devices in Devs have
+/// aspect::online_compiler.
+///
+/// If State is bundle_state::object, all devices in Devs have
+/// aspect::online_linker.
+template <bundle_state State>
+bool has_kernel_bundle(const context &Ctx, const std::vector<device> &Devs) {
+  return detail::has_kernel_bundle_impl(Ctx, Devs, State);
+}
+
+template <bundle_state State>
+bool has_kernel_bundle(const context &Ctx, const std::vector<device> &Devs,
+                       const std::vector<kernel_id> &KernelIDs) {
+  return detail::has_kernel_bundle_impl(Ctx, Devs, KernelIDs, State);
+}
+
+template <bundle_state State> bool has_kernel_bundle(const context &Ctx) {
+  return has_kernel_bundle<State>(Ctx, Ctx.get_devices());
+}
+
+template <bundle_state State>
+bool has_kernel_bundle(const context &Ctx,
+                       const std::vector<kernel_id> &KernelIDs) {
+  return has_kernel_bundle<State>(Ctx, Ctx.get_devices(), KernelIDs);
+}
+
+template <typename KernelName, bundle_state State>
+bool has_kernel_bundle(const context &Ctx) {
+  return has_kernel_bundle<State>(Ctx, {get_kernel_id<KernelName>()});
+}
+
+template <typename KernelName, bundle_state State>
+bool has_kernel_bundle(const context &Ctx, const std::vector<device> &Devs) {
+  return has_kernel_bundle<State>(Ctx, Devs, {get_kernel_id<KernelName>()});
+}
+
+/////////////////////////
+// is_compatible API
+/////////////////////////
+
+/// Returns true if all of the kernels identified by KernelIDs are compatible
+/// with the device Dev.
+bool is_compatible(const std::vector<kernel_id> &KernelIDs, const device &Dev);
+
+template <typename KernelName> bool is_compatible(const device &Dev) {
+  return is_compatible({get_kernel_id<KernelName>()}, Dev);
+}
+
+/////////////////////////
+// join API
+/////////////////////////
+
+namespace detail {
+
+std::shared_ptr<detail::kernel_bundle_impl>
+join_impl(const std::vector<detail::KernelBundleImplPtr> &Bundles);
+
+}
+
+/// Returns a new kernel bundle that represents the union of all the device
+/// images in the input bundles with duplicates removed.
+template <sycl::bundle_state State>
+sycl::kernel_bundle<State>
+join(const std::vector<sycl::kernel_bundle<State>> &Bundles) {
+  std::vector<detail::KernelBundleImplPtr> KernelBundleImpls;
+  // TODO: Can we just reinterpret?
+  KernelBundleImpls.reserve(Bundles.size());
+  for (sycl::kernel_bundle<State> &Bundle : Bundles)
+    KernelBundleImpls.push_back(detail::getSyclObjImpl(Bundle));
+
+  std::shared_ptr<detail::kernel_bundle_impl> Impl =
+      detail::join_impl(KernelBundleImpls);
+  return detail::createSyclObjFromImpl<kernel_bundle<State>>(Impl);
+}
+
+/////////////////////////
+// compile API
+/////////////////////////
+
+namespace detail {
+
+std::shared_ptr<detail::kernel_bundle_impl>
+compile_impl(const kernel_bundle<bundle_state::input> &InputBundle,
+             const std::vector<device> &Devs, const property_list &PropList);
+}
+
+/// Returns a new kernel_bundle which contains the device images from
+/// InputBundle that are translated into one or more new device images of state
+/// bundle_state::object. The new bundle represents all of the kernels in
+/// InputBundles that are compatible with at least one of the devices in Devs.
+inline kernel_bundle<bundle_state::object>
+compile(const kernel_bundle<bundle_state::input> &InputBundle,
+        const std::vector<device> &Devs, const property_list &PropList = {}) {
+  detail::KernelBundleImplPtr Impl =
+      detail::compile_impl(InputBundle, Devs, PropList);
+  return detail::createSyclObjFromImpl<
+      kernel_bundle<sycl::bundle_state::object>>(Impl);
+}
+
+inline kernel_bundle<bundle_state::object>
+compile(const kernel_bundle<bundle_state::input> &InputBundle,
+        const property_list &PropList = {}) {
+  return compile(InputBundle, InputBundle.get_devices(), PropList);
+}
+
+/////////////////////////
+// link API
+/////////////////////////
+
+namespace detail {
+std::vector<sycl::device> find_device_intersection(
+    const std::vector<kernel_bundle<bundle_state::object>> &ObjectBundles);
+}
+
+/// Returns a new kernel_bundle which contains the device images from the
+/// ObjectBundles that are translated into one or more new device images of
+/// state bundle_state::executable The new bundle represents all of the kernels
+/// in ObjectBundles that are compatible with at least one of the devices in
+/// Devs.
+kernel_bundle<bundle_state::executable>
+link(const std::vector<kernel_bundle<bundle_state::object>> &ObjectBundles,
+     const std::vector<device> &Devs, const property_list &PropList = {});
+
+inline kernel_bundle<bundle_state::executable>
+link(const kernel_bundle<bundle_state::object> &ObjectBundle,
+     const property_list &PropList = {}) {
+  return link(std::vector<kernel_bundle<bundle_state::object>>{ObjectBundle},
+              ObjectBundle.get_devices(), PropList);
+}
+
+inline kernel_bundle<bundle_state::executable>
+link(const std::vector<kernel_bundle<bundle_state::object>> &ObjectBundles,
+     const property_list &PropList = {}) {
+  std::vector<sycl::device> IntersectDevices =
+      find_device_intersection(ObjectBundles);
+  return link(ObjectBundles, IntersectDevices, PropList);
+}
+
+inline kernel_bundle<bundle_state::executable>
+link(const kernel_bundle<bundle_state::object> &ObjectBundle,
+     const std::vector<device> &Devs, const property_list &PropList = {}) {
+  return link(std::vector<kernel_bundle<bundle_state::object>>{ObjectBundle},
+              Devs, PropList);
+}
+
+/////////////////////////
+// build API
+/////////////////////////
+
+/// Returns a new kernel_bundle which contains device images that are translated
+/// into one ore more new device images of state bundle_state::executable.
+/// The new bundle represents all of the kernels in InputBundle that are
+/// compatible with at least one of the devices in Devs.
+kernel_bundle<bundle_state::executable>
+build(const kernel_bundle<bundle_state::input> &InputBundle,
+      const std::vector<device> &Devs, const property_list &PropList = {});
+
+inline kernel_bundle<bundle_state::executable>
+build(const kernel_bundle<bundle_state::input> &InputBundle,
+      const property_list &PropList = {}) {
+  return build(InputBundle, InputBundle.get_devices(), PropList);
+}
+
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/kernel_bundle.hpp
+++ b/sycl/include/CL/sycl/kernel_bundle.hpp
@@ -50,7 +50,6 @@ private:
   template <typename KernelName> friend kernel_id get_kernel_id();
 };
 
-
 namespace detail {
 class device_image_impl;
 using DeviceImageImplPtr = std::shared_ptr<device_image_impl>;
@@ -82,7 +81,6 @@ protected:
   detail::DeviceImageImplPtr impl;
 };
 } // namespace detail
-
 
 // Objects of the class represents an instance of an image in a specific state.
 template <sycl::bundle_state State>
@@ -259,7 +257,6 @@ private:
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 };
-
 
 /////////////////////////
 // get_kernel_id API


### PR DESCRIPTION
This patch adds most of declarations of kernel_bundle related APIs.
Most of the logic of this patch is in making so APIs that have
template parameters call corresponding library APIs that have no
template parameters.