### PR TITLE
[SYCL] Fix a crash with __bulitin_unique_stable_name

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1465,7 +1465,6 @@ static ExprResult TransformUniqueStableName(TemplateInstantiator &TI,
     if (SubExpr.isInvalid())
       return ExprError();
 
-
     if (!TI.getDerived().AlwaysRebuild() && SubExpr.get() == E->getExpr())
       return E;
 

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1460,6 +1460,12 @@ static ExprResult TransformUniqueStableName(TemplateInstantiator &TI,
     if (SubExpr.isInvalid())
       return ExprError();
 
+    SubExpr = TI.getSema().CheckPlaceholderExpr(SubExpr.get());
+
+    if (SubExpr.isInvalid())
+      return ExprError();
+
+
     if (!TI.getDerived().AlwaysRebuild() && SubExpr.get() == E->getExpr())
       return E;
 

--- a/clang/test/CodeGenSYCL/unique-stable-name-placeholder-crash.cpp
+++ b/clang/test/CodeGenSYCL/unique-stable-name-placeholder-crash.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -std=c++17 -sycl-std=2020 -fsycl -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+
+template <typename KernelName, typename KernelType>
+[[clang::sycl_kernel]] void kernel_single_task(const KernelType &kernelFunc) {
+  kernelFunc();
+}
+
+struct A {
+  int a = 0;
+  A() = default;
+};
+constexpr A THE_NAME;
+
+template <auto &R> void temp() {}
+template <auto &R> void foo(const char *out) {
+  out = __builtin_unique_stable_name(temp<R>);
+}
+
+int main() {
+  kernel_single_task<class kernel>(
+      []() {
+        const char *c;
+        foo<THE_NAME>(c);
+      });
+}
+
+// Note: the mangling here is actually the 'typeinfo name for void ()'.  That is
+// because the type of temp<R> is actually the function type (which is void()).
+// CHECK: @__builtin_unique_stable_name._Z3fooIL_ZL8THE_NAMEEEvPKc = private unnamed_addr addrspace(1) constant [9 x i8] c"_ZTSFvvE\00", align 1

--- a/clang/test/CodeGenSYCL/unique-stable-name-placeholder-crash.cpp
+++ b/clang/test/CodeGenSYCL/unique-stable-name-placeholder-crash.cpp
@@ -1,9 +1,8 @@
-// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -std=c++17 -sycl-std=2020 -fsycl -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -internal-isystem %S/Inputs -std=c++17 -sycl-std=2020 -fsycl -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
-template <typename KernelName, typename KernelType>
-[[clang::sycl_kernel]] void kernel_single_task(const KernelType &kernelFunc) {
-  kernelFunc();
-}
+#include <sycl.hpp>
+
+using namespace cl::sycl;
 
 struct A {
   int a = 0;


### PR DESCRIPTION
A placeholder expression inside a unique-stable-name(at this point, an
unresolved lookup expression) was not properly being transformed during
template instantation.  This patch ensures that it gets instantiated.