### PR TITLE
[SYCL] Fix a typo in test regression/device_num.cpp

### DIFF
--- a/sycl/test/regression/device_num.cpp
+++ b/sycl/test/regression/device_num.cpp
@@ -44,7 +44,7 @@ int main() {
   deviceNum = std::atoi(envVal);
 
   auto devices = device::get_devices();
-  if (devices.size() >= deviceNum) {
+  if (devices.size() > deviceNum) {
     device targetDevice = devices[deviceNum];
     std::cout << "Target Device: ";
     printDeviceType(targetDevice);


### PR DESCRIPTION
The change is simple.
">=" ==> ">"
The original code was written assuming the device_num starts at 1.
As I changed the code to start device_num at 0, the condition of test
should have been changed to NOT run when the test is going over the total
number of devices found in the system.

Signed-off-by: Byoungro So <byoungro.so@intel.com>