### PR TITLE
[SYCL] Fix device_num LIT test

### DIFF
--- a/sycl/test/regression/device_num.cpp
+++ b/sycl/test/regression/device_num.cpp
@@ -44,7 +44,7 @@ int main() {
   deviceNum = std::atoi(envVal);
 
   auto devices = device::get_devices();
-  if (devices.size() >= deviceNum) {
+  if (devices.size() > deviceNum) {
     device targetDevice = devices[deviceNum];
     std::cout << "Target Device: ";
     printDeviceType(targetDevice);


### PR DESCRIPTION
Fixed the check which caused out-of-boundaries access if the number of
device found is equal to the device id requested thru
SYCL_DEVICE_FILTER.