### PR TITLE
[SYCL] Fix link dependencies when building shared libraries

### DIFF
--- a/llvm/lib/Passes/CMakeLists.txt
+++ b/llvm/lib/Passes/CMakeLists.txt
@@ -20,6 +20,7 @@ add_llvm_component_library(LLVMPasses
   ObjCARC
   Scalar
   Support
+  SYCLLowerIR
   Target
   TransformUtils
   Vectorize


### PR DESCRIPTION
Otherwise, the linker is not able to find SYCL/ESIMD symbols
when linking the Passes.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>