### PR TITLE
[SYCL][L0] Add SubDevices into the device cache

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1914,13 +1914,13 @@ pi_result piextDeviceCreateWithNativeHandle(pi_native_handle NativeHandle,
   PI_ASSERT(Device, PI_INVALID_DEVICE);
   PI_ASSERT(NativeHandle, PI_INVALID_VALUE);
   PI_ASSERT(Platform, PI_INVALID_PLATFORM);
-
-  std::lock_guard<std::mutex> Lock(Platform->PiDevicesCacheMutex);
-  pi_result Res = populateDeviceCacheIfNeeded(Platform);
-  if (Res != PI_SUCCESS) {
-    return Res;
+  {
+    std::lock_guard<std::mutex> Lock(Platform->PiDevicesCacheMutex);
+    pi_result Res = populateDeviceCacheIfNeeded(Platform);
+    if (Res != PI_SUCCESS) {
+      return Res;
+    }
   }
-
   auto ZeDevice = pi_cast<ze_device_handle_t>(NativeHandle);
 
   // The SYCL spec requires that the set of devices must remain fixed for the

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1841,6 +1841,8 @@ pi_result piDevicePartition(pi_device Device,
       pi_device Dev = Platform->getDeviceFromNativeHandle(ZeSubdevices[I]);
       if (Dev) {
         OutDevices[I] = Dev;
+        // reusing the same pi_device needs to increment the reference count
+        piDeviceRetain(OutDevices[I]);
       } else {
         std::unique_ptr<_pi_device> PiSubDevice(
             new _pi_device(ZeSubdevices[I], Platform));

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1804,7 +1804,7 @@ pi_result piDevicePartition(pi_device Device,
 
   // Check if Device was already partitioned into the same or bigger size
   // before. If so, we can return immediately without searching the global
-  // device cache. Note that L0 driver always return the same handles in the
+  // device cache. Note that L0 driver always returns the same handles in the
   // same order for the given number of sub-devices.
   if (OutDevices && NumDevices <= Device->SubDevices.size()) {
     for (uint32_t I = 0; I < NumDevices; I++) {

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1809,6 +1809,8 @@ pi_result piDevicePartition(pi_device Device,
   if (OutDevices && NumDevices <= Device->SubDevices.size()) {
     for (uint32_t I = 0; I < NumDevices; I++) {
       OutDevices[I] = Device->SubDevices[I];
+      // reusing the same pi_device needs to increment the reference count
+      piDeviceRetain(OutDevices[I]);
     }
     if (OutNumDevices)
       *OutNumDevices = NumDevices;

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -156,6 +156,9 @@ struct _pi_device : _pi_object {
   // Level Zero device handle.
   ze_device_handle_t ZeDevice;
 
+  // Keep the subdevices that are partitioned from this pi_device for reuse
+  std::vector<pi_device> SubDevices;
+
   // PI platform to which this device belongs.
   pi_platform Platform;
 

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -157,6 +157,9 @@ struct _pi_device : _pi_object {
   ze_device_handle_t ZeDevice;
 
   // Keep the subdevices that are partitioned from this pi_device for reuse
+  // The order of sub-devices in this vector is repeated from the
+  // ze_device_handle_t array that are returned from zeDeviceGetSubDevices()
+  // call, which will always return sub-devices in the fixed same order.
   std::vector<pi_device> SubDevices;
 
   // PI platform to which this device belongs.


### PR DESCRIPTION
This PR adds the missing sub-devices in the device cache.
This fixes the missing cache loopup for sub-devices.

Signed-off-by: Byoungro So <byoungro.so@intel.com>