### PR TITLE
[SYCL] Allow non-evaluated globals to be used in a kernel.

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -215,8 +215,9 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
   if (getLangOpts().SYCLIsDevice) {
     if (auto VD = dyn_cast<VarDecl>(D)) {
       bool IsConst = VD->getType().isConstant(Context);
-      bool IsRuntimeEvaluated = ExprEvalContexts.empty() ||
-                                isUnevaluatedContext() || isConstantEvaluated();
+      bool IsRuntimeEvaluated =
+          ExprEvalContexts.empty() ||
+          (!isUnevaluatedContext() && !isConstantEvaluated());
       if (IsRuntimeEvaluated && !IsConst && VD->getStorageClass() == SC_Static)
         SYCLDiagIfDeviceCode(*Locs.begin(), diag::err_sycl_restrict)
             << Sema::KernelNonConstStaticDataVariable;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -215,10 +215,8 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
   if (getLangOpts().SYCLIsDevice) {
     if (auto VD = dyn_cast<VarDecl>(D)) {
       bool IsConst = VD->getType().isConstant(Context);
-      bool IsRuntimeEvaluated =
-          ExprEvalContexts.empty() ||
-          (!ExprEvalContexts.back().isUnevaluated() &&
-           !ExprEvalContexts.back().isConstantEvaluated());
+      bool IsRuntimeEvaluated = ExprEvalContexts.empty() ||
+                                isUnevaluatedContext() || isConstantEvaluated();
       if (IsRuntimeEvaluated && !IsConst && VD->getStorageClass() == SC_Static)
         SYCLDiagIfDeviceCode(*Locs.begin(), diag::err_sycl_restrict)
             << Sema::KernelNonConstStaticDataVariable;

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -384,6 +384,10 @@ int moar_globals = 5;
 }
 }
 
+template<const auto &T>
+int uses_global(){}
+
+
 int addInt(int n, int m) {
   return n + m;
 }
@@ -400,6 +404,9 @@ int use2(a_type ab, a_type *abp) {
     return 0;
   if (ab.fm()) // expected-note {{called by 'use2'}}
     return 0;
+
+  // No error, as this is not in an evaluated context.
+  (void)(uses_global<another_global>() + uses_global<ns::glob>());
 
   return another_global; // expected-error {{SYCL kernel cannot use a non-const global variable}}
 


### PR DESCRIPTION
As requested to support SYCL-2020 specialization constants, this makes
our global variable diagnostics not happen unless it is in a runtime
evaluated context.

This is OK, because the SYCL standard prohibits ODR uses, of which
non-runtime-evaluated uses are not.