### PR TITLE
[SYCL] zero argument version of buffer::reinterpret() for SYCL 2020.

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -351,17 +351,7 @@ public:
         impl, reinterpretRange, OffsetInBytes, IsSubBuffer);
   }
 
-  // reinterpret() with no arguments. Can be specialized with one or two
-  // template arguments. four possible combinations two template specializers:
-  // R is same size as T. RD is same as dimensions.
-  // RD is one. To avoid ambiguity, R size is different or previous dimension is
-  // not same.
-
-  // single template specializers
-  // R is same size as T.  RD is assumed to be same as previous.
-  // R is not same as T  previous dimensions were 1.
-
-  template <typename ReinterpretT, int ReinterpretDim>
+  template <typename ReinterpretT, int ReinterpretDim = dimensions>
   typename std::enable_if<
       (sizeof(ReinterpretT) == sizeof(T)) && (dimensions == ReinterpretDim),
       buffer<ReinterpretT, ReinterpretDim, AllocatorT>>::type
@@ -370,32 +360,20 @@ public:
         impl, get_range(), OffsetInBytes, IsSubBuffer);
   }
 
-  template <typename ReinterpretT, int ReinterpretDim>
+  template <typename ReinterpretT, int ReinterpretDim = dimensions>
   typename std::enable_if<
       (ReinterpretDim == 1) && ((dimensions != ReinterpretDim) ||
                                 (sizeof(ReinterpretT) != sizeof(T))),
       buffer<ReinterpretT, ReinterpretDim, AllocatorT>>::type
   reinterpret() const {
     long sz = get_size(); // TODO: switch to byte_size() once implemented
+    if (sz % sizeof(ReinterpretT) != 0)
+      throw cl::sycl::invalid_object_error(
+          "Total byte size of buffer is not evenly divisible by the size of "
+          "the reinterpreted type",
+          PI_INVALID_VALUE);
+
     return buffer<ReinterpretT, ReinterpretDim, AllocatorT>(
-        impl, range<1>{sz / sizeof(ReinterpretT)}, OffsetInBytes, IsSubBuffer);
-  }
-
-  template <typename ReinterpretT>
-  typename std::enable_if<sizeof(ReinterpretT) == sizeof(T),
-                          buffer<ReinterpretT, dimensions, AllocatorT>>::type
-  reinterpret() const {
-    return buffer<ReinterpretT, dimensions, AllocatorT>(
-        impl, get_range(), OffsetInBytes, IsSubBuffer);
-  }
-
-  template <typename ReinterpretT>
-  typename std::enable_if<(sizeof(ReinterpretT) != sizeof(T)) &&
-                              (dimensions == 1),
-                          buffer<ReinterpretT, 1, AllocatorT>>::type
-  reinterpret() const {
-    long sz = get_size(); // TODO: switch to byte_size() once implemented
-    return buffer<ReinterpretT, dimensions, AllocatorT>(
         impl, range<1>{sz / sizeof(ReinterpretT)}, OffsetInBytes, IsSubBuffer);
   }
 


### PR DESCRIPTION
SYCL 2020 adds a new override of buffer::reinterpret() that takes zero arguments. Four specializations to fulfill spec.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>