### PR TITLE
[SYCL] Remove redundant build options processing

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -353,6 +353,8 @@ RT::PiProgram ProgramManager::getBuiltPIProgram(OSModuleHandle M,
                                                 const string_class &KernelName,
                                                 const program_impl *Prg,
                                                 bool JITCompilationIsRequired) {
+  // TODO: Make sure that KSIds will be different for the case when the same
+  // kernel built with different options is present in the fat binary.
   KernelSetId KSId = getKernelSetId(M, KernelName);
 
   const ContextImplPtr Ctx = getSyclObjImpl(Context);


### PR DESCRIPTION
After 86b0e8d5 patch extra operations with device images happen before
check if it is present in in-memory cache. For applications with small
kernels which are executed multiple times noticeable performance
degradation is seen for host code. That was done to get build options
stored in the kernel image and use them as in-memory cache key. At the
same time kernel image (where these options are taken from) is used in
cache key so it is reasonable to use only build options which are
specified in SYCL API and/or environment variables as separate cache
key.

Getting build options from kernel image is moved back to build
operation which happens only if built program is missed in in-memory
cache.