### PR TITLE
[SYCL][NVPTX] Fix CUDA lit tests after pulldown from llorg

### DIFF
--- a/llvm/lib/Target/NVPTX/SYCL/GlobalOffset.cpp
+++ b/llvm/lib/Target/NVPTX/SYCL/GlobalOffset.cpp
@@ -276,7 +276,7 @@ public:
 
       SmallVector<ReturnInst *, 8> Returns;
       CloneFunctionInto(NewFunc, Func, VMap,
-                        CloneFunctionChangeType::DifferentModule, Returns);
+                        CloneFunctionChangeType::GlobalChanges, Returns);
     } else {
       NewFunc->copyAttributesFrom(Func);
       NewFunc->setComdat(Func->getComdat());


### PR DESCRIPTION
20 lit tests for CUDA are failed with the following assert:
"clang-13: llvm/lib/Transforms/Utils/CloneFunction.cpp:152:
 void llvm::CloneFunctionInto(llvm::Function*, const llvm::Function*,
                              llvm::ValueToValueMapTy&,
                              llvm::CloneFunctionChangeType,
                              llvm::SmallVectorImpl<llvm::ReturnInst*>&,
                              const char*, llvm::ClonedCodeInfo*,
                              llvm::ValueMapTypeRemapper*,
                              llvm::ValueMaterializer*)
   : Assertion `(NewFunc->getParent() == nullptr ||
                 NewFunc->getParent() != OldFunc->getParent()) &&
                "Set SameModule to true if the new function is in the same module"' failed."

Change CloneFunctionChangeType to pass those lit tests.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>