### PR TITLE
[ESIMD] Mark ESIMD globals with sycl_explicit_simd attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1183,7 +1183,7 @@ def SYCLKernel : InheritableAttr {
 def SYCLSimd : InheritableAttr {
   let Spellings = [GNU<"sycl_explicit_simd">,
                    CXX11<"intel", "sycl_explicit_simd">];
-  let Subjects = SubjectList<[Function]>;
+  let Subjects = SubjectList<[Function, GlobalVar]>;
   let LangOpts = [SYCLExplicitSIMD];
   let Documentation = [SYCLSimdDocs];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -363,7 +363,7 @@ def SYCLSimdDocs : Documentation {
     compiler front end to mark ESIMD kernels and functions. In this mode,
     subgroup size is always equal to 1 and explicit SIMD extensions, such as
     manual vectorization using wide vector data types and operations can be used.
-    Compiler may decide to compile such functions using different optimization
+    The compiler may decide to compile such functions using different optimization
     and code generation pipeline. Also, this attribute is used to distinguish
     ESIMD private globals from regular SYCL global variables.
   }];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -361,7 +361,7 @@ def SYCLSimdDocs : Documentation {
   let Content = [{
     The ``__attribute__((sycl_explicit_simd))`` attribute is used by the device
     compiler front end to mark ESIMD kernels and functions. In this mode,
-    subgroup size is always equals to 1 and explicit SIMD extensions, such as
+    subgroup size is always equal to 1 and explicit SIMD extensions, such as
     manual vectorization using wide vector data types and operations can be used.
     Compiler may decide to compile such functions using different optimization
     and code generation pipeline. Also, this attribute is used to distinguish

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -360,12 +360,12 @@ def SYCLSimdDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{
     The ``__attribute__((sycl_explicit_simd))`` attribute is used by the device
-    compiler front end to mark kernels and functions to be compiled and executed
-    in the explicit SIMD mode. In this mode subgroup size is always 1 and
-    explicit SIMD extensions - such as manual vectorization using wide vector
-    data types and operations can be used. Compiler may decide to compile such
-    functions using different optimization and code generation
-    pipeline.
+    compiler front end to mark ESIMD kernels and functions. In this mode,
+    subgroup size is always equals to 1 and explicit SIMD extensions, such as
+    manual vectorization using wide vector data types and operations can be used.
+    Compiler may decide to compile such functions using different optimization
+    and code generation pipeline. Also, this attribute is used to distinguish
+    ESIMD private globals from regular SYCL global variables.
   }];
 }
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -13081,7 +13081,7 @@ public:
   /// Tells whether given variable is a SYCL explicit SIMD extension's "private
   /// global" variable - global variable in the private address space.
   bool isSYCLEsimdPrivateGlobal(VarDecl *VDecl) {
-    return getLangOpts().SYCLIsDevice && getLangOpts().SYCLExplicitSIMD &&
+    return getLangOpts().SYCLIsDevice && VDecl->hasAttr<SYCLSimdAttr>() &&
            VDecl->hasGlobalStorage() &&
            (VDecl->getType().getAddressSpace() == LangAS::opencl_private);
   }

--- a/clang/test/CodeGenSYCL/esimd-private-global.cpp
+++ b/clang/test/CodeGenSYCL/esimd-private-global.cpp
@@ -10,7 +10,7 @@
 
 // This test checks that FE allows globals with register_num attribute in ESIMD mode.
 
-__attribute__((opencl_private)) __attribute__((register_num(17))) int vc;
+__attribute__((opencl_private)) __attribute__((sycl_explicit_simd)) __attribute__((register_num(17))) int vc;
 // CHECK: @vc = {{.+}} i32 0, align 4 #0
 
 template <typename name, typename Func>

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -162,7 +162,7 @@
 // CHECK-NEXT: SYCLIntelSchedulerTargetFmaxMhz (SubjectMatchRule_function)
 // CHECK-NEXT: SYCLIntelUseStallEnableClusters (SubjectMatchRule_function)
 // CHECK-NEXT: SYCLRegisterNum (SubjectMatchRule_variable_is_global)
-// CHECK-NEXT: SYCLSimd (SubjectMatchRule_function)
+// CHECK-NEXT: SYCLSimd (SubjectMatchRule_function, SubjectMatchRule_variable_is_global)
 // CHECK-NEXT: ScopedLockable (SubjectMatchRule_record)
 // CHECK-NEXT: Section (SubjectMatchRule_function, SubjectMatchRule_variable_is_global, SubjectMatchRule_objc_method, SubjectMatchRule_objc_property)
 // CHECK-NEXT: SetTypestate (SubjectMatchRule_function_is_member)

--- a/clang/test/SemaSYCL/esimd-private-global.cpp
+++ b/clang/test/SemaSYCL/esimd-private-global.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -verify -pedantic %s
 
+// This test checks specifics of semantic analysis of ESIMD private globals
+
 // No error expected. SYCL private globals are allowed to have initializers
 __attribute__((opencl_private)) int syclPrivGlob;
 __attribute__((opencl_private)) int syclPrivGlobInit = 10;

--- a/clang/test/SemaSYCL/esimd-private-global.cpp
+++ b/clang/test/SemaSYCL/esimd-private-global.cpp
@@ -1,5 +1,15 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -verify -pedantic %s
 
+// No error expected. SYCL private globals are allowed to have initializers
+__attribute__((opencl_private)) int syclPrivGlob;
+__attribute__((opencl_private)) int syclPrivGlobInit = 10;
+
+// expected-error@+1{{SYCL explicit SIMD does not permit private global variable to have an initializer}}
+__attribute__((opencl_private)) __attribute__((sycl_explicit_simd)) int esimdPrivGlobInit = 10;
+
+// No error expected. ESIMD private globals without initializers are OK
+__attribute__((opencl_private)) __attribute__((sycl_explicit_simd)) int esimdPrivGlob;
+
 // no error expected
 __attribute__((opencl_private)) __attribute__((register_num(17))) int privGlob;
 
@@ -8,9 +18,6 @@ __attribute__((opencl_private)) __attribute__((register_num())) int privGlob1;
 
 // expected-error@+1{{'register_num' attribute takes one argument}}
 __attribute__((opencl_private)) __attribute__((register_num(10, 11))) int privGlob2;
-
-// expected-error@+1{{SYCL explicit SIMD does not permit private global variable to have an initializer}}
-__attribute__((opencl_private)) int privGlob3 = 10;
 
 void foo() {
   // expected-warning@+1{{'register_num' attribute only applies to global variables}}

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -2,8 +2,9 @@
 
 // ----------- Negative tests
 
-__attribute__((sycl_explicit_simd)) // expected-warning {{'sycl_explicit_simd' attribute only applies to functions}}
-int N;
+void foo(
+__attribute__((sycl_explicit_simd)) // expected-warning {{'sycl_explicit_simd' attribute only applies to functions and global variables}}
+int N);
 
 __attribute__((sycl_explicit_simd(3))) // expected-error {{'sycl_explicit_simd' attribute takes no arguments}}
 void
@@ -103,3 +104,7 @@ template <typename ID, typename F>
 void test5() {
   kernel5<class Kernel5>([=]() [[intel::sycl_explicit_simd]] { g5(); });
 }
+
+// -- Globals.
+
+__attribute__((sycl_explicit_simd)) int N;

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
+// This test checks specifics of semantic analysis of ESIMD kernels.
+
 // ----------- Negative tests
 
 void foo(
@@ -104,7 +106,3 @@ template <typename ID, typename F>
 void test5() {
   kernel5<class Kernel5>([=]() [[intel::sycl_explicit_simd]] { g5(); });
 }
-
-// -- Globals.
-
-__attribute__((sycl_explicit_simd)) int N;

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -3,8 +3,8 @@
 // ----------- Negative tests
 
 void foo(
-__attribute__((sycl_explicit_simd)) // expected-warning {{'sycl_explicit_simd' attribute only applies to functions and global variables}}
-int N);
+    __attribute__((sycl_explicit_simd)) // expected-warning {{'sycl_explicit_simd' attribute only applies to functions and global variables}}
+    int N);
 
 __attribute__((sycl_explicit_simd(3))) // expected-error {{'sycl_explicit_simd' attribute takes no arguments}}
 void

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_enum.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_enum.hpp
@@ -28,7 +28,8 @@ using uint = unsigned int;
 // Mark a "ESIMD global": accessible from all functions in current translation
 // unit, separate copy per subgroup (work-item), mapped to SPIR-V private
 // storage class.
-#define ESIMD_PRIVATE __attribute__((opencl_private)) __attribute__((sycl_explicit_simd))
+#define ESIMD_PRIVATE                                                          \
+  __attribute__((opencl_private)) __attribute__((sycl_explicit_simd))
 // Bind a ESIMD global variable to a specific register.
 #define ESIMD_REGISTER(n) __attribute__((register_num(n)))
 #else

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_enum.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_enum.hpp
@@ -28,7 +28,7 @@ using uint = unsigned int;
 // Mark a "ESIMD global": accessible from all functions in current translation
 // unit, separate copy per subgroup (work-item), mapped to SPIR-V private
 // storage class.
-#define ESIMD_PRIVATE __attribute__((opencl_private))
+#define ESIMD_PRIVATE __attribute__((opencl_private)) __attribute__((sycl_explicit_simd))
 // Bind a ESIMD global variable to a specific register.
 #define ESIMD_REGISTER(n) __attribute__((register_num(n)))
 #else


### PR DESCRIPTION
This patch is a part of the efforts for allowing ESIMD and
regular SYCL kernels to coexist in the same translation unit and
in the same program.

There are differences in semantic analysis of global variables
used in ESIMD and regular SYCL kernels. One such difference is that
ESIMD does not permit private global variable to have an initializer.

Before this patch we used -fsycl-explicit-simd compiler flag to
differentiate globals used in ESIMD and regular kernels. With this
change we mark ESIMD globals with sycl_explicit_simd attribute. So,
the goal of this change is to remove dependency on compiler option,
while preserving the same behavior in semantic analysis.