### PR TITLE
[SYCL] Retain PI events until they have signaled

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -584,6 +584,12 @@ struct _pi_event : _pi_object {
   // enqueued, and must then be released when this event has signalled.
   // This list must be destroyed once the event has signalled.
   _pi_ze_event_list_t WaitList;
+
+  // Tracks if the needed cleanupAfterEvent was already performed for
+  // a completed event. This allows to control that some cleanup
+  // actions are performed only once.
+  //
+  bool CleanedUp = {false};
 };
 
 struct _pi_program : _pi_object {


### PR DESCRIPTION
It is illegal to destroy an event until it is completed in the GPU.
This change prevents sporadic failures due to Level-Zero RT crashes because we released event too early.
I am adding E2E test: https://github.com/intel/llvm-test-suite/pull/180

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>