### PR TITLE
[SYCL][NFC] Factor out GenXIntrinsics git repo tag.

### DIFF
--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -4,10 +4,12 @@ if (NOT TARGET LLVMGenXIntrinsics)
   if (NOT DEFINED LLVMGenXIntrinsics_SOURCE_DIR)
     message(STATUS "vc-intrinsics are missing. Will try to download them from github.com")
 
+    set(LLVMGenXIntrinsics_GIT_TAG b831d10e49e1fb8fcd92b5b50e2cdc8f9cb6277b)
+
     include(FetchContent)
     FetchContent_Declare(vc-intrinsics
       GIT_REPOSITORY https://github.com/intel/vc-intrinsics.git
-      GIT_TAG        b831d10e49e1fb8fcd92b5b50e2cdc8f9cb6277b
+      GIT_TAG        ${LLVMGenXIntrinsics_GIT_TAG}
     )
     FetchContent_MakeAvailable(vc-intrinsics)
     FetchContent_GetProperties(vc-intrinsics)


### PR DESCRIPTION
This is needed for more flexible vc-intrinsics repo management during custom internal builds which may use different commit hash.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>