### PR TITLE
[SYCL] logical revert of the patch: "Fix get() method for non-opencl backends"

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -107,7 +107,7 @@ context_impl::context_impl(RT::PiContext PiContext, async_handler AsyncHandler,
 }
 
 cl_context context_impl::get() const {
-  if (MHostContext || getPlugin().getBackend() != cl::sycl::backend::opencl) {
+  if (MHostContext) {
     throw invalid_object_error(
         "This instance of context doesn't support OpenCL interoperability.",
         PI_INVALID_CONTEXT);

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -89,7 +89,7 @@ bool device_impl::is_affinity_supported(
 }
 
 cl_device_id device_impl::get() const {
-  if (MIsHostDevice || getPlugin().getBackend() != cl::sycl::backend::opencl) {
+  if (MIsHostDevice) {
     throw invalid_object_error(
         "This instance of device doesn't support OpenCL interoperability.",
         PI_INVALID_DEVICE);

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -35,8 +35,7 @@ extern xpti::trace_event_data_t *GSYCLGraphEvent;
 bool event_impl::is_host() const { return MHostEvent || !MOpenCLInterop; }
 
 cl_event event_impl::get() const {
-  if (!MOpenCLInterop ||
-      getPlugin().getBackend() != cl::sycl::backend::opencl) {
+  if (!MOpenCLInterop) {
     throw invalid_object_error(
         "This instance of event doesn't support OpenCL interoperability.",
         PI_INVALID_EVENT);

--- a/sycl/source/detail/kernel_impl.hpp
+++ b/sycl/source/detail/kernel_impl.hpp
@@ -80,7 +80,7 @@ public:
   ///
   /// \return a valid cl_kernel instance
   cl_kernel get() const {
-    if (is_host() || getPlugin().getBackend() != cl::sycl::backend::opencl) {
+    if (is_host()) {
       throw invalid_object_error(
           "This instance of kernel doesn't support OpenCL interoperability.",
           PI_INVALID_KERNEL);

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -76,7 +76,7 @@ public:
 
   /// \return an instance of OpenCL cl_platform_id.
   cl_platform_id get() const {
-    if (is_host() || getPlugin().getBackend() != cl::sycl::backend::opencl) {
+    if (is_host()) {
       throw invalid_object_error(
           "This instance of platform doesn't support OpenCL interoperability.",
           PI_INVALID_PLATFORM);

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -210,7 +210,7 @@ program_impl::~program_impl() {
 
 cl_program program_impl::get() const {
   throw_if_state_is(program_state::none);
-  if (is_host() || getPlugin().getBackend() != cl::sycl::backend::opencl) {
+  if (is_host()) {
     throw invalid_object_error(
         "This instance of program doesn't support OpenCL interoperability.",
         PI_INVALID_PROGRAM);

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -126,7 +126,7 @@ public:
 
   /// \return an OpenCL interoperability queue handle.
   cl_command_queue get() {
-    if (MHostQueue || getPlugin().getBackend() != cl::sycl::backend::opencl) {
+    if (MHostQueue) {
       throw invalid_object_error(
           "This instance of queue doesn't support OpenCL interoperability",
           PI_INVALID_QUEUE);


### PR DESCRIPTION

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>