### PR TITLE
[NFC][ESIMD] Separate functions called from SYCL and ESIMD kernels

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -449,7 +449,7 @@ public:
   }
 
   // This is an interface function for collecting sets of
-  // functions called from a regular SYCL kernel.
+  // functions in an ESIMD call graph.
   void collectEsimdCallGraphNodes(FunctionDecl *RootNode) {
     llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet;
     collectCallGraphNodes(RootNode, RootNode, VisitedSet, EsimdCallGraphNodes);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -441,14 +441,14 @@ public:
   // kernel set, this is used for error diagnostics.
   llvm::SmallPtrSet<FunctionDecl *, 10> RecursiveSet;
 
-  // This is an interface function for collecting sets of 
+  // This is an interface function for collecting sets of
   // functions called from an ESIMD kernel.
   void CollectSyclKernelSet(FunctionDecl *RootNode) {
     llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet;
     CollectKernelSet(RootNode, RootNode, VisitedSet, SYCLKernelSet);
   }
 
-  // This is an interface function for collecting sets of 
+  // This is an interface function for collecting sets of
   // functions called from a regular SYCL kernel.
   void CollectEsimdKernelSet(FunctionDecl *RootNode) {
     llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet;
@@ -462,7 +462,7 @@ private:
   // diagnostic notes on each function as the callstack is unwound.
   void CollectKernelSet(FunctionDecl *CalleeNode, FunctionDecl *FD,
                         llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet,
-                        llvm::SmallPtrSet<FunctionDecl *, 10>& KernelSet) {
+                        llvm::SmallPtrSet<FunctionDecl *, 10> &KernelSet) {
     // We're currently checking CalleeNode on a different
     // trace through the CallGraph, we avoid infinite recursion
     // by using KernelSet to keep track of this.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -434,25 +434,25 @@ public:
   // The call graph for this translation unit.
   CallGraph SYCLCG;
   // The set of functions called by a regular SYCL kernel.
-  llvm::SmallPtrSet<FunctionDecl *, 10> SYCLKernelSet;
+  llvm::SmallPtrSet<FunctionDecl *, 10> SyclCallGraphNodes;
   // The set of functions called by an ESIMD kernel.
-  llvm::SmallPtrSet<FunctionDecl *, 10> ESIMDKernelSet;
+  llvm::SmallPtrSet<FunctionDecl *, 10> EsimdCallGraphNodes;
   // The set of recursive functions identified while building the
   // kernel set, this is used for error diagnostics.
   llvm::SmallPtrSet<FunctionDecl *, 10> RecursiveSet;
 
   // This is an interface function for collecting sets of
   // functions called from an ESIMD kernel.
-  void CollectSyclKernelSet(FunctionDecl *RootNode) {
+  void collectSyclCallGraphNodes(FunctionDecl *RootNode) {
     llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet;
-    CollectKernelSet(RootNode, RootNode, VisitedSet, SYCLKernelSet);
+    collectCallGraphNodes(RootNode, RootNode, VisitedSet, SyclCallGraphNodes);
   }
 
   // This is an interface function for collecting sets of
   // functions called from a regular SYCL kernel.
-  void CollectEsimdKernelSet(FunctionDecl *RootNode) {
+  void collectEsimdCallGraphNodes(FunctionDecl *RootNode) {
     llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet;
-    CollectKernelSet(RootNode, RootNode, VisitedSet, ESIMDKernelSet);
+    collectCallGraphNodes(RootNode, RootNode, VisitedSet, EsimdCallGraphNodes);
   }
 
 private:
@@ -460,9 +460,9 @@ private:
   // CalleeNode is a function which is called either directly
   // or indirectly from FD.  If recursion is detected then create
   // diagnostic notes on each function as the callstack is unwound.
-  void CollectKernelSet(FunctionDecl *CalleeNode, FunctionDecl *FD,
-                        llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet,
-                        llvm::SmallPtrSet<FunctionDecl *, 10> &KernelSet) {
+  void collectCallGraphNodes(FunctionDecl *CalleeNode, FunctionDecl *FD,
+                             llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet,
+                             llvm::SmallPtrSet<FunctionDecl *, 10> &KernelSet) {
     // We're currently checking CalleeNode on a different
     // trace through the CallGraph, we avoid infinite recursion
     // by using KernelSet to keep track of this.
@@ -480,7 +480,7 @@ private:
             RecursiveSet.insert(CalleeNode);
           } else {
             VisitedSet.insert(Callee);
-            CollectKernelSet(Callee, FD, VisitedSet, KernelSet);
+            collectCallGraphNodes(Callee, FD, VisitedSet, KernelSet);
             VisitedSet.erase(Callee);
           }
         }
@@ -3244,9 +3244,9 @@ void Sema::MarkDevice(void) {
     if (auto SYCLKernel = dyn_cast<FunctionDecl>(D)) {
 
       if (SYCLKernel->hasAttr<SYCLSimdAttr>())
-        Marker.CollectEsimdKernelSet(SYCLKernel);
+        Marker.collectEsimdCallGraphNodes(SYCLKernel);
       else
-        Marker.CollectSyclKernelSet(SYCLKernel);
+        Marker.collectSyclCallGraphNodes(SYCLKernel);
 
       // Let's propagate attributes from device functions to a SYCL kernels
       llvm::SmallPtrSet<Attr *, 4> Attrs;
@@ -3362,11 +3362,11 @@ void Sema::MarkDevice(void) {
       }
     }
   }
-  for (const auto &elt : Marker.SYCLKernelSet) {
+  for (const auto &elt : Marker.SyclCallGraphNodes) {
     if (FunctionDecl *Def = elt->getDefinition())
       Marker.TraverseStmt(Def->getBody());
   }
-  for (const auto &elt : Marker.ESIMDKernelSet) {
+  for (const auto &elt : Marker.EsimdCallGraphNodes) {
     if (FunctionDecl *Def = elt->getDefinition())
       Marker.TraverseStmt(Def->getBody());
   }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -442,7 +442,7 @@ public:
   llvm::SmallPtrSet<FunctionDecl *, 10> RecursiveSet;
 
   // This is an interface function for collecting sets of
-  // functions called from an ESIMD kernel.
+  // functions in a SYCL call graph.
   void collectSyclCallGraphNodes(FunctionDecl *RootNode) {
     llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet;
     collectCallGraphNodes(RootNode, RootNode, VisitedSet, SyclCallGraphNodes);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -459,11 +459,11 @@ private:
   // diagnostic notes on each function as the callstack is unwound.
   void collectCallGraphNodes(FunctionDecl *CalleeNode, FunctionDecl *FD,
                              llvm::SmallPtrSet<FunctionDecl *, 10> VisitedSet,
-                             llvm::SmallPtrSet<FunctionDecl *, 10> &KernelSet) {
+                             llvm::SmallPtrSet<FunctionDecl *, 10> &CFGNodes) {
     // We're currently checking CalleeNode on a different
     // trace through the CallGraph, we avoid infinite recursion
-    // by using KernelSet to keep track of this.
-    if (!KernelSet.insert(CalleeNode).second)
+    // by using CFGNodes to keep track of this.
+    if (!CFGNodes.insert(CalleeNode).second)
       // Previously seen, stop recursion.
       return;
     if (CallGraphNode *N = SYCLCG.getNode(CalleeNode)) {
@@ -477,7 +477,7 @@ private:
             RecursiveSet.insert(CalleeNode);
           } else {
             VisitedSet.insert(Callee);
-            collectCallGraphNodes(Callee, FD, VisitedSet, KernelSet);
+            collectCallGraphNodes(Callee, FD, VisitedSet, CFGNodes);
             VisitedSet.erase(Callee);
           }
         }


### PR DESCRIPTION
This is just an NFC patch to collect functions reachable from
SYCL and ESIMD kernels. In later patch I will add reachability
analysis for every function, i.e. whether a function is reachable
from regular SYCL context, or ESIMD, or both.

Such reachabilty analysis will be used for semantic analysis and
later be stored in IR as metadata.