### PR TITLE
[sycl-post-link] Improve spec constants pattern recognition

### DIFF
--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -57,6 +57,23 @@ StringRef getStringLiteralArg(const CallInst *CI, unsigned ArgNo,
     // @.str = private unnamed_addr constant[10 x i8] c"SpecConst\00", align 1
     // ...
     // %TName = alloca i8 addrspace(4)*, align 8
+    // %TName.ascast = addrspacecast i8 addrspace(4)** %TName to 
+    //                               i8 addrspace(4)* addrspace(4)*
+    // ...
+    // store i8 addrspace(4)* getelementptr inbounds ([19 x i8], [19 x i8]
+    //    addrspace(4)* addrspacecast ([19 x i8] addrspace(1)* @str to [19 x i8]
+    //    addrspace(4)*), i64 0, i64 0), i8 addrspace(4)* addrspace(4)*
+    //    %TName.ascast, align 8
+    // %0 = load i8 addrspace(4)*, i8 addrspace(4)* addrspace(4)* %TName.ascast,
+    //    align 8
+    // %call = call spir_func zeroext
+    //   i1 @_Z27__sycl_getSpecConstantValueIbET_PKc(i8 addrspace(4)* %0)
+    // ^^^^^^^^^^^^^^^^^^^^
+    // or (optimized version)
+    // vvvvvvvvvvvvvvvvvvvv
+    // @.str = private unnamed_addr constant[10 x i8] c"SpecConst\00", align 1
+    // ...
+    // %TName = alloca i8 addrspace(4)*, align 8
     // ...
     // store i8 addrspace(4)* addrspacecast(
     //    i8* getelementptr inbounds([10 x i8], [10 x i8] * @.str, i32 0, i32 0)
@@ -68,8 +85,14 @@ StringRef getStringLiteralArg(const CallInst *CI, unsigned ArgNo,
     // sequence, w/o any intervening stores and calls between the store and load
     // so that %1 is trivially known to be the address of the @.str literal.
 
-    AllocaInst *TmpPtr =
-        cast<AllocaInst>(L->getPointerOperand()->stripPointerCasts());
+    Value *TmpPtr = L->getPointerOperand();
+    AssertRelease((isa<AddrSpaceCastInst>(TmpPtr) &&
+                   isa<AllocaInst>(cast<AddrSpaceCastInst>(TmpPtr)
+                                       ->getPointerOperand()
+                                       ->stripPointerCasts())) ||
+                      isa<AllocaInst>(TmpPtr),
+                  "unexpected instruction type");
+
     // find the store of the literal address into TmpPtr
     StoreInst *Store = nullptr;
 

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -57,7 +57,7 @@ StringRef getStringLiteralArg(const CallInst *CI, unsigned ArgNo,
     // @.str = private unnamed_addr constant[10 x i8] c"SpecConst\00", align 1
     // ...
     // %TName = alloca i8 addrspace(4)*, align 8
-    // %TName.ascast = addrspacecast i8 addrspace(4)** %TName to 
+    // %TName.ascast = addrspacecast i8 addrspace(4)** %TName to
     //                               i8 addrspace(4)* addrspace(4)*
     // ...
     // store i8 addrspace(4)* getelementptr inbounds ([19 x i8], [19 x i8]


### PR DESCRIPTION
1113d0a5e9f3a9ee471311603d3874f54bf1595b changes addrspacecast
instruction generation. This impacts the pattern recognition if LLVM IR
is not optimized before SpecConstantsPass. Now both load and store
instructions accepting cast pointer instead of a pointer produced by
alloca instruction.
This change make pattern recognition to support both versions of LLVM
IR.