### PR TITLE
[SYCL][FPGA] Allowing max-concurrency attribute on functions.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1854,11 +1854,14 @@ def SYCLIntelFPGAInitiationInterval : StmtAttr {
   let Documentation = [SYCLIntelFPGAInitiationIntervalAttrDocs];
 }
 
-def SYCLIntelFPGAMaxConcurrency : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","max_concurrency">,
-                   CXX11<"intel","max_concurrency">];
-  let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
-                             ErrorDiag, "'for', 'while', and 'do' statements">;
+def SYCLIntelFPGAMaxConcurrency : DeclOrStmtAttr {
+  let Spellings = [
+    CXX11<"intelfpga", "max_concurrency">, CXX11<"intel", "max_concurrency">
+  ];
+  let Subjects =
+      SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
+                  ErrorDiag,
+                  "'for', 'while', 'do' statements, and (device) functions">;
   let Args = [ExprArgument<"NThreadsExpr">];
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let HasCustomTypeTransform = 1;

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1854,10 +1854,10 @@ def SYCLIntelFPGAInitiationInterval : StmtAttr {
   let Documentation = [SYCLIntelFPGAInitiationIntervalAttrDocs];
 }
 
-def SYCLIntelFPGAMaxConcurrency : StmtAttr {
+def SYCLIntelFPGAMaxConcurrency : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","max_concurrency">,
                    CXX11<"intel","max_concurrency">];
-  let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
+  let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Args = [ExprArgument<"NThreadsExpr">];
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2799,10 +2799,10 @@ def SYCLIntelFPGAMaxConcurrencyAttrDocs : Documentation {
   let Category = DocCatVariable;
   let Heading = "intel::max_concurrency";
   let Content = [{
-This attribute applies to a loop. Indicates that the loop should allow no more
-than N threads or iterations to execute it simultaneously. N must be a non
-negative integer. '0' indicates the max_concurrency case to be unbounded. Cannot
-be applied multiple times to the same loop.
+This attribute applies to a loop or a function. Indicates that the loop/function
+should allow no more than N threads or iterations to execute it simultaneously.
+N must be a non negative integer. '0' indicates the max_concurrency case to be
+unbounded. Cannot be applied multiple times to the same loop.
 
 .. code-block:: c++
 
@@ -2811,10 +2811,13 @@ be applied multiple times to the same loop.
     [[intel::max_concurrency(2)]] for (int i = 0; i != 10; ++i) a[i] = 0;
   }
 
+  [[intel::component_max_concurrency(2)]] void foo1 { }
+
   template<int N>
   void bar() {
     [[intel::max_concurrency(N)]] for(;;) { }
   }
+  [[intel::component_max_concurrency(N)]] void bar1() { }
 
   }];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2811,13 +2811,13 @@ unbounded. Cannot be applied multiple times to the same loop.
     [[intel::max_concurrency(2)]] for (int i = 0; i != 10; ++i) a[i] = 0;
   }
 
-  [[intel::component_max_concurrency(2)]] void foo1 { }
+  [[intel::max_concurrency(2)]] void foo1 { }
 
   template<int N>
   void bar() {
     [[intel::max_concurrency(N)]] for(;;) { }
   }
-  [[intel::component_max_concurrency(N)]] void bar1() { }
+  [[intel::max_concurrency(N)]] void bar1() { }
 
   }];
 }

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -167,7 +167,9 @@ public:
         ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim ||
         ParsedAttr == AT_SYCLIntelNoGlobalWorkOffset ||
         ParsedAttr == AT_SYCLIntelUseStallEnableClusters ||
-        ParsedAttr == AT_SYCLIntelLoopFuse || ParsedAttr == AT_SYCLSimd)
+        ParsedAttr == AT_SYCLIntelLoopFuse ||
+        ParsedAttr == AT_SYCLSimd ||
+        ParsedAttr == AT_SYCLIntelFPGAMaxConcurrency)
       return true;
 
     return false;

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -167,8 +167,7 @@ public:
         ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim ||
         ParsedAttr == AT_SYCLIntelNoGlobalWorkOffset ||
         ParsedAttr == AT_SYCLIntelUseStallEnableClusters ||
-        ParsedAttr == AT_SYCLIntelLoopFuse ||
-        ParsedAttr == AT_SYCLSimd ||
+        ParsedAttr == AT_SYCLIntelLoopFuse || ParsedAttr == AT_SYCLSimd ||
         ParsedAttr == AT_SYCLIntelFPGAMaxConcurrency)
       return true;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -134,8 +134,8 @@ def err_intel_fpga_reg_limitations : Error <
   "__builtin_intel_fpga_reg">;
 def illegal_type_declared_here : Note<
   "field with illegal type declared here">;
-def err_sycl_loop_attr_duplication : Error<
-  "duplicate %select{unroll|Intel FPGA}0 loop attribute %1">;
+def err_sycl_attr_duplication : Error<
+  "duplicate %select{unroll|Intel FPGA}0 %select{loop|function}1 attribute %2">;
 def err_loop_unroll_compatibility : Error<
   "incompatible loop unroll instructions: '%0' and '%1'">;
 def err_pipe_attribute_arg_not_allowed : Error<

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10295,7 +10295,7 @@ public:
   /// declaration.
   void addSYCLIntelPipeIOAttr(Decl *D, const AttributeCommonInfo &CI, Expr *ID);
 
-  /// AddSYCLIntelFPGAMaxConcurrencyAttr - Adds a max_component attribute to a
+  /// AddSYCLIntelFPGAMaxConcurrencyAttr - Adds a max_concurrency attribute to a
   /// particular declaration.
   void AddSYCLIntelFPGAMaxConcurrencyAttr(Decl *D,
                                           const AttributeCommonInfo &CI,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10241,6 +10241,9 @@ public:
   IntelFPGAMaxReplicatesAttr *
   MergeIntelFPGAMaxReplicatesAttr(Decl *D, const IntelFPGAMaxReplicatesAttr &A);
 
+  SYCLIntelFPGAMaxConcurrencyAttr *MergeSYCLIntelFPGAMaxConcurrencyAttr(
+      Decl *D, const SYCLIntelFPGAMaxConcurrencyAttr &A);
+
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,
                       bool IsPackExpansion);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10295,6 +10295,11 @@ public:
   /// declaration.
   void addSYCLIntelPipeIOAttr(Decl *D, const AttributeCommonInfo &CI, Expr *ID);
 
+  /// AddSYCLIntelFPGAMaxConcurrencyAttr - Adds a max_component attribute to a
+  /// particular declaration.
+  void AddSYCLIntelFPGAMaxConcurrencyAttr(Decl *D,
+                                          const AttributeCommonInfo &CI,
+                                          Expr *E);
   bool checkNSReturnsRetainedReturnType(SourceLocation loc, QualType type);
   bool checkAllowedSYCLInitializer(VarDecl *VD,
                                    bool CheckValueDependent = false);

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -731,12 +731,11 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
     Fn->setMetadata("stall_enable", llvm::MDNode::get(Context, AttrMDArgs));
   }
 
-  if (const SYCLIntelFPGAMaxConcurrencyAttr *A =
-          FD->getAttr<SYCLIntelFPGAMaxConcurrencyAttr>()) {
-    const auto *CE = dyn_cast<ConstantExpr>(A->getNThreadsExpr());
-    Optional<llvm::APSInt> ArgVal = CE->getResultAsAPSInt();
-    llvm::Metadata *AttrMDArgs[] = {llvm::ConstantAsMetadata::get(
-        Builder.getInt32(ArgVal->getSExtValue()))};
+  if (const auto *A = FD->getAttr<SYCLIntelFPGAMaxConcurrencyAttr>()) {
+    const auto *CE = cast<ConstantExpr>(A->getNThreadsExpr());
+    llvm::APSInt ArgVal = CE->getResultAsAPSInt();
+    llvm::Metadata *AttrMDArgs[] = {
+        llvm::ConstantAsMetadata::get(Builder.getInt32(ArgVal.getSExtValue()))};
     Fn->setMetadata("max_concurrency", llvm::MDNode::get(Context, AttrMDArgs));
   }
 }

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -730,6 +730,15 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
         llvm::ConstantAsMetadata::get(Builder.getInt32(1))};
     Fn->setMetadata("stall_enable", llvm::MDNode::get(Context, AttrMDArgs));
   }
+
+  if (const SYCLIntelFPGAMaxConcurrencyAttr *A =
+          FD->getAttr<SYCLIntelFPGAMaxConcurrencyAttr>()) {
+    const auto *CE = dyn_cast<ConstantExpr>(A->getNThreadsExpr());
+    Optional<llvm::APSInt> ArgVal = CE->getResultAsAPSInt();
+    llvm::Metadata *AttrMDArgs[] = {llvm::ConstantAsMetadata::get(
+        Builder.getInt32(ArgVal->getSExtValue()))};
+    Fn->setMetadata("max_concurrency", llvm::MDNode::get(Context, AttrMDArgs));
+  }
 }
 
 /// Determine whether the function F ends with a return stmt.

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2628,6 +2628,8 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
     NewAttr = S.MergeSYCLIntelNoGlobalWorkOffsetAttr(D, *A);
   else if (const auto *A = dyn_cast<IntelFPGAMaxReplicatesAttr>(Attr))
     NewAttr = S.MergeIntelFPGAMaxReplicatesAttr(D, *A);
+  else if (const auto *A = dyn_cast<SYCLIntelFPGAMaxConcurrencyAttr>(Attr))
+    NewAttr = S.MergeSYCLIntelFPGAMaxConcurrencyAttr(D, *A);
   else if (Attr->shouldInheritEvenIfAlreadyPresent() || !DeclHasAttr(D, Attr))
     NewAttr = cast<InheritableAttr>(Attr->clone(S.Context));
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -559,6 +559,8 @@ public:
           Attrs.insert(A);
         }
       }
+      if (auto *A = FD->getAttr<SYCLIntelFPGAMaxConcurrencyAttr>())
+        Attrs.insert(A);
 
       // TODO: vec_len_hint should be handled here
 
@@ -3316,7 +3318,8 @@ void Sema::MarkDevice(void) {
         case attr::Kind::SYCLIntelNoGlobalWorkOffset:
         case attr::Kind::SYCLIntelUseStallEnableClusters:
         case attr::Kind::SYCLIntelLoopFuse:
-        case attr::Kind::SYCLSimd: {
+        case attr::Kind::SYCLSimd:
+        case attr::Kind::SYCLIntelFPGAMaxConcurrency:  {
           if ((A->getKind() == attr::Kind::SYCLSimd) && KernelBody &&
               !KernelBody->getAttr<SYCLSimdAttr>()) {
             // Usual kernel can't call ESIMD functions.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3316,25 +3316,6 @@ void Sema::MarkDevice(void) {
           }
           break;
         }
-        case attr::Kind::SYCLIntelFPGAMaxConcurrency: {
-          auto *SIMCA = cast<SYCLIntelFPGAMaxConcurrencyAttr>(A);
-          if (auto *Existing =
-                  SYCLKernel->getAttr<SYCLIntelFPGAMaxConcurrencyAttr>()) {
-            ASTContext &Ctx = getASTContext();
-            if (Existing->getNThreadsExpr() > SIMCA->getNThreadsExpr()) {
-              Diag(SYCLKernel->getLocation(),
-                   diag::err_conflicting_sycl_kernel_attributes);
-              Diag(Existing->getLocation(), diag::note_conflicting_attribute);
-              Diag(SIMCA->getLocation(), diag::note_conflicting_attribute);
-              SYCLKernel->setInvalidDecl();
-            } else {
-              SYCLKernel->addAttr(A);
-            }
-          } else {
-            SYCLKernel->addAttr(A);
-          }
-          break;
-        }
         case attr::Kind::SYCLIntelKernelArgsRestrict:
         case attr::Kind::SYCLIntelNumSimdWorkItems:
         case attr::Kind::SYCLIntelSchedulerTargetFmaxMhz:
@@ -3342,7 +3323,8 @@ void Sema::MarkDevice(void) {
         case attr::Kind::SYCLIntelNoGlobalWorkOffset:
         case attr::Kind::SYCLIntelUseStallEnableClusters:
         case attr::Kind::SYCLIntelLoopFuse:
-        case attr::Kind::SYCLSimd: {
+        case attr::Kind::SYCLSimd:
+        case attr::Kind::SYCLIntelFPGAMaxConcurrency: {
           if ((A->getKind() == attr::Kind::SYCLSimd) && KernelBody &&
               !KernelBody->getAttr<SYCLSimdAttr>()) {
             // Usual kernel can't call ESIMD functions.

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -627,8 +627,8 @@ CheckForDuplicationSYCLLoopAttribute(Sema &S,
   for (const auto *I : Attrs) {
     if (LoopAttr && isa<LoopAttrT>(I)) {
       // Cannot specify same type of attribute twice.
-      S.Diag(I->getLocation(), diag::err_sycl_loop_attr_duplication)
-          << isIntelFPGAAttr << LoopAttr;
+      S.Diag(I->getLocation(), diag::err_sycl_attr_duplication)
+          << isIntelFPGAAttr << 0 << LoopAttr;
     }
     if (isa<LoopAttrT>(I))
       LoopAttr = cast<LoopAttrT>(I);

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -953,8 +953,9 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
     }
     if (const auto *SYCLIntelMaxConcurrency =
             dyn_cast<SYCLIntelFPGAMaxConcurrencyAttr>(TmplAttr)) {
-      instantiateSYCLIntelFPGAMaxConcurrencyAttr<SYCLIntelFPGAMaxConcurrencyAttr>(
-          *this, TemplateArgs, SYCLIntelMaxConcurrency, New);
+      instantiateSYCLIntelFPGAMaxConcurrencyAttr<
+          SYCLIntelFPGAMaxConcurrencyAttr>(*this, TemplateArgs,
+                                           SYCLIntelMaxConcurrency, New);
       continue;
     }
     // Existing DLL attribute on the instantiation takes precedence.

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -694,6 +694,17 @@ static void instantiateIntelSYCLFunctionAttr(
     S.addIntelSingleArgAttr<AttrName>(New, *Attr, Result.getAs<Expr>());
 }
 
+template <typename AttrName>
+static void instantiateSYCLIntelFPGAMaxConcurrencyAttr(
+    Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
+    const SYCLIntelFPGAMaxConcurrencyAttr *A, Decl *New) {
+  EnterExpressionEvaluationContext Unevaluated(
+      S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
+  ExprResult Result = S.SubstExpr(A->getNThreadsExpr(), TemplateArgs);
+  if (!Result.isInvalid())
+    S.AddSYCLIntelFPGAMaxConcurrencyAttr(New, *A, Result.getAs<Expr>());
+}
+
 static void instantiateIntelFPGAPrivateCopiesAttr(
     Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
     const IntelFPGAPrivateCopiesAttr *A, Decl *New) {
@@ -938,6 +949,12 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
             dyn_cast<SYCLIntelMaxWorkGroupSizeAttr>(TmplAttr)) {
       instantiateIntelSYCTripleLFunctionAttr<SYCLIntelMaxWorkGroupSizeAttr>(
           *this, TemplateArgs, SYCLIntelMaxWorkGroupSize, New);
+      continue;
+    }
+    if (const auto *SYCLIntelMaxConcurrency =
+            dyn_cast<SYCLIntelFPGAMaxConcurrencyAttr>(TmplAttr)) {
+      instantiateSYCLIntelFPGAMaxConcurrencyAttr<SYCLIntelFPGAMaxConcurrencyAttr>(
+          *this, TemplateArgs, SYCLIntelMaxConcurrency, New);
       continue;
     }
     // Existing DLL attribute on the instantiation takes precedence.

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -3,8 +3,6 @@
 // CHECK: br label %for.cond,   !llvm.loop ![[MD_DLP:[0-9]+]]
 // CHECK: br label %for.cond,   !llvm.loop ![[MD_II:[0-9]+]]
 // CHECK: br label %for.cond2,  !llvm.loop ![[MD_II_2:[0-9]+]]
-// CHECK: br label %for.cond,   !llvm.loop ![[MD_MC:[0-9]+]]
-// CHECK: br label %for.cond2,  !llvm.loop ![[MD_MC_2:[0-9]+]]
 // CHECK: br label %for.cond,   !llvm.loop ![[MD_LC:[0-9]+]]
 // CHECK: br label %for.cond2,  !llvm.loop ![[MD_LC_2:[0-9]+]]
 // CHECK: br label %for.cond13, !llvm.loop ![[MD_LC_3:[0-9]+]]
@@ -32,19 +30,6 @@ void ii() {
   // CHECK: ![[MD_II_2]] = distinct !{![[MD_II_2]], ![[MP]], ![[MD_ii_count_2:[0-9]+]]}
   // CHECK-NEXT: ![[MD_ii_count_2]] = !{!"llvm.loop.ii.count", i32 8}
   [[intel::ii(8)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
-}
-
-template <int A>
-void max_concurrency() {
-  int a[10];
-  // CHECK: ![[MD_MC]] = distinct !{![[MD_MC]], ![[MP]], ![[MD_max_concurrency:[0-9]+]]}
-  // CHECK-NEXT: ![[MD_max_concurrency]] = !{!"llvm.loop.max_concurrency.count", i32 0}
-  [[intel::max_concurrency(A)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
-  // CHECK: ![[MD_MC_2]] = distinct !{![[MD_MC_2]], ![[MP]], ![[MD_max_concurrency_2:[0-9]+]]}
-  // CHECK-NEXT: ![[MD_max_concurrency_2]] = !{!"llvm.loop.max_concurrency.count", i32 4}
-  [[intel::max_concurrency(4)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
 
@@ -100,7 +85,6 @@ int main() {
   kernel_single_task<class kernel_function>([]() {
     disable_loop_pipelining();
     ii<4>();
-    max_concurrency<0>();
     loop_coalesce<2>();
     max_interleaving<3>();
     speculated_iterations<4>();

--- a/clang/test/CodeGenSYCL/max-concurrency.cpp
+++ b/clang/test/CodeGenSYCL/max-concurrency.cpp
@@ -1,0 +1,91 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -Wno-sycl-2017-compat -emit-llvm -o - %s | FileCheck %s
+
+#include "sycl.hpp"
+
+// CHECK: br label %for.cond,   !llvm.loop ![[MD_MC:[0-9]+]]
+// CHECK: br label %for.cond2,  !llvm.loop ![[MD_MC_1:[0-9]+]]
+
+// CHECK: define {{.*}}spir_kernel void @"{{.*}}kernel_name1"() #0 {{.*}} !max_concurrency !16
+// CHECK: define {{.*}}spir_kernel void @"{{.*}}kernel_name2"() #0 {{.*}} !max_concurrency ![[NUM2:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @"{{.*}}kernel_name3"() #0 {{.*}} !max_concurrency ![[NUM3:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @"{{.*}}kernel_name4"() #0 {{.*}} !max_concurrency ![[NUM1:[0-9]+]]
+
+template <int A>
+void max_concurrency() {
+  int a[10];
+  // CHECK: ![[MD_MC]] = distinct !{![[MD_MC]], ![[MP:[0-9]+]], ![[MD_max_concurrency:[0-9]+]]}
+  // CHECK-NEXT: ![[MP]] = !{!"llvm.loop.mustprogress"}
+  // CHECK-NEXT: ![[MD_max_concurrency]] = !{!"llvm.loop.max_concurrency.count", i32 5}
+  [[intel::max_concurrency(A)]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  // CHECK: ![[MD_MC_1]] = distinct !{![[MD_MC_1]], ![[MP]], ![[MD_max_concurrency_1:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_max_concurrency_1]] = !{!"llvm.loop.max_concurrency.count", i32 4}
+  [[intel::max_concurrency(4)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+}
+
+// CHECK: !16 = !{i32 4}
+// CHECK: !17 = !{i32 2}
+// CHECK: !18 = !{i32 3}
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task_1(const Func &kernelFunc) {
+  kernelFunc();
+}
+
+using namespace cl::sycl;
+queue q;
+
+class Functor1 {
+public:
+  [[intel::max_concurrency(4)]] void operator()() const {}
+};
+
+[[intel::max_concurrency(2)]] void foo() {}
+
+class Functor2 {
+public:
+  void operator()() const {
+    foo();
+  }
+};
+
+template <int NT>
+class Functor3 {
+public:
+  [[intel::max_concurrency(NT)]] void operator()() const {}
+};
+
+template <int NT>
+[[intel::reqd_sub_group_size(NT)]] void func() {}
+
+int main() {
+  kernel_single_task_1<class kernel_function>([]() {
+     max_concurrency<5>();
+   });
+
+  q.submit([&](handler &h) {
+    Functor1 f1;
+    h.single_task<class kernel_name1>(f1);
+
+    Functor2 f2;
+    h.single_task<class kernel_name2>(f2);
+
+
+    h.single_task<class kernel_name3>(
+        []() [[intel::max_concurrency(3)]]{});
+
+    Functor3<4> f3;
+    h.single_task<class kernel_name4>(f3);
+
+    h.single_task<class kernel_name5>([]() {
+      func<2>();
+    });
+
+  });
+
+
+  return 0;
+}
+
+

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -10,7 +10,7 @@ void foo() {
   [[intel::ivdep]] int a[10];
   // expected-error@+1 {{'initiation_interval' attribute only applies to 'for', 'while', and 'do' statements}}
   [[intel::initiation_interval(2)]] int c[10];
-  // expected-error@+1 {{'max_concurrency' attribute only applies to 'for', 'while', and 'do' statements}}
+  // expected-error@+1 {{'max_concurrency' attribute only applies to 'for', 'while', 'do' statements, and (device) functions}}
   [[intel::max_concurrency(2)]] int d[10];
   // expected-error@+1 {{'disable_loop_pipelining' attribute only applies to 'for', 'while', and 'do' statements}}
   [[intel::disable_loop_pipelining]] int g[10];

--- a/clang/test/SemaSYCL/max-concurrency.cpp
+++ b/clang/test/SemaSYCL/max-concurrency.cpp
@@ -48,15 +48,12 @@ public:
 
 // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'const char [16]'}}
 [[intel::max_concurrency("numberofthreads")]] void zoo() {}
-class Functor6 {
-public:
-  void operator() () const {
-    zoo();
-  }
-};
 
 template <int NT>
 [[intel::max_concurrency(NT)]] void func() {}
+
+[[intel::max_concurrency(8)]] void dup();
+[[intel::max_concurrency(9)]] void dup() {} // expected-error {{duplicate Intel FPGA function attribute 'max_concurrency'}}
 
 int main() {
   queue q;
@@ -81,6 +78,36 @@ int main() {
   });
 }
 
+// CHECK: CXXMethodDecl {{.*}}used operator() {{.*}}
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: ConstantExpr {{.*}} 'int'
+// CHECK: value: Int 4
+// CHECK: IntegerLiteral {{.*}}4{{$}}
+// CHECK: CXXMethodDecl {{.*}}operator() {{.*}}
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'NT' 'int'
+// CHECK: CXXMethodDecl {{.*}}{{.*}}used operator() {{.*}}
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: ConstantExpr {{.*}} 'int'
+// CHECK: value: Int 4
+// CHECK: IntegerLiteral {{.*}}4{{$}}
+// CHECK: FunctionDecl {{.*}}{{.*}}func {{.*}}
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: FunctionDecl {{.*}}{{.*}}used func 'void ()'
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: ConstantExpr {{.*}} 'int'
+// CHECK: value: Int 5
+// CHECK: IntegerLiteral {{.*}}5{{$}}
+// CHECK: FunctionDecl {{.*}}{{.*}}dup {{.*}}
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: ConstantExpr {{.*}} 'int'
+// CHECK: value: Int 8
+// CHECK: IntegerLiteral {{.*}}8{{$}}
+// CHECK: FunctionDecl {{.*}}{{.*}}dup {{.*}}
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: ConstantExpr {{.*}} 'int'
+// CHECK: value: Int 9
+// CHECK: IntegerLiteral {{.*}}9{{$}}
 // CHECK: FunctionDecl {{.*}}{{.*}}kernel_name1{{.*}}
 // CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
 // CHECK: ConstantExpr {{.*}} 'int'

--- a/clang/test/SemaSYCL/max-concurrency.cpp
+++ b/clang/test/SemaSYCL/max-concurrency.cpp
@@ -1,0 +1,98 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020  -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
+
+class Functor1 {
+public:
+  [[intel::max_concurrency(4)]] void operator()() const {}
+};
+
+[[intel::max_concurrency]] void foo() {} // expected-error {{'max_concurrency' attribute takes one argument}}
+
+class Functor2 {
+public:
+  void operator()() const {
+    foo();
+  }
+};
+
+template <int NT>
+class Functor3 {
+public:
+  [[intel::max_concurrency(NT)]] void operator()() const {}
+  // expected-error@+1 {{'max_concurrency' attribute only applies to 'for', 'while', 'do' statements, and (device) functions}}
+  [[intel::max_concurrency(2)]] int a[10];
+};
+
+// expected-error@+1 {{'max_concurrency' attribute takes one argument}}
+[[intel::max_concurrency(3, 3)]] void goo() {}
+
+class Functor4 {
+public:
+  void operator() () const {
+    goo();
+  }
+};
+
+// expected-error@+1 {{'max_concurrency' attribute requires a positive integral compile time constant expression}}
+[[intel::max_concurrency(-1)]] void bar() {}
+class Functor5 {
+public:
+  void operator() () const {
+    bar();
+  }
+};
+
+// expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'const char [16]'}}
+[[intel::max_concurrency("numberofthreads")]] void zoo() {}
+class Functor6 {
+public:
+  void operator() () const {
+    zoo();
+  }
+};
+
+template <int NT>
+[[intel::max_concurrency(NT)]] void func() {}
+
+int main() {
+  queue q;
+
+  q.submit([&](handler &h) {
+    Functor1 f1;
+    h.single_task<class kernel_name1>(f1);
+
+    Functor2 f2;
+    h.single_task<class kernel_name2>(f2);
+
+    h.single_task<class kernel_name3>(
+        []() [[intel::max_concurrency(3)]]{});
+
+    Functor3<4> f3;
+    h.single_task<class kernel_name4>(f3);
+
+    h.single_task<class kernel_name5>([]() {
+      func<5>();
+    });
+
+  });
+}
+
+// CHECK: FunctionDecl {{.*}}{{.*}}kernel_name1{{.*}}
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: ConstantExpr {{.*}} 'int'
+// CHECK: value: Int 4
+// CHECK: IntegerLiteral{{.*}}4{{$}}
+// CHECK: FunctionDecl {{.*}}{{.*}}kernel_name3{{.*}}
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: ConstantExpr {{.*}} 'int'
+// CHECK: value: Int 3
+// CHECK: IntegerLiteral{{.*}}3{{$}}
+// CHECK: FunctionDecl {{.*}}{{.*}}kernel_name4{{.*}}
+// CHECK: SYCLIntelFPGAMaxConcurrencyAttr {{.*}}
+// CHECK: ConstantExpr {{.*}} 'int'
+// CHECK: value: Int 4
+// CHECK: IntegerLiteral{{.*}}4{{$}}


### PR DESCRIPTION
This patch implements the support of a new FPGA function attribute ‘max_concurrency”. The attribute exists already for loops. It takes a single unsigned integer argument and has the following syntax:
[[intel::component_max_concurrency(n)]]

An example of it use:
[[intel::component_max_concurrency(n)]]
void foo() {
}
The LLVM IR representation will be function metadata:
!component_max_concurrency !0
!0 = !{!i32 n}

Max_concurrency applies to functions in device code. It is not be propagated to the caller.
