### PR TITLE
[Driver][SYCL] Address issue when unbundling for non-FPGA archive

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6193,7 +6193,8 @@ InputInfo Driver::BuildJobsForActionNoCache(
             TI = types::TY_Tempfilelist;
         } else if (EffectiveTriple.getSubArch() !=
                    llvm::Triple::SPIRSubArch_fpga) {
-          if (UI.DependentOffloadKind == Action::OFK_SYCL) {
+          if (UI.DependentOffloadKind == Action::OFK_SYCL &&
+              JA->getType() != types::TY_FPGA_AOCO) {
             // Do not add the current info for device with FPGA device.  The
             // device side isn't used
             continue;

--- a/clang/test/Driver/sycl-offload-static-lib.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib.cpp
@@ -150,3 +150,15 @@
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -foffload-static-lib= -c %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=FOFFLOAD_STATIC_LIB_NOVALUE
 // FOFFLOAD_STATIC_LIB_NOVALUE: warning: argument unused during compilation: '-foffload-static-lib='
+
+/// Use of a static archive with various targets should compile and unbundle
+// RUN: touch %t.a
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t.a -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_NO_UNBUNDLE
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice %t.a -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_NO_UNBUNDLE
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %t.a -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_NO_UNBUNDLE
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %t.a -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_NO_UNBUNDLE
+// STATIC_ARCHIVE_NO_UNBUNDLE: clang-offload-bundler{{.*}}

--- a/clang/test/Driver/sycl-offload-static-lib.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib.cpp
@@ -154,11 +154,11 @@
 /// Use of a static archive with various targets should compile and unbundle
 // RUN: touch %t.a
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl %t.a -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_NO_UNBUNDLE
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_UNBUNDLE
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice %t.a -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_NO_UNBUNDLE
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_UNBUNDLE
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %t.a -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_NO_UNBUNDLE
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_UNBUNDLE
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %t.a -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_NO_UNBUNDLE
-// STATIC_ARCHIVE_NO_UNBUNDLE: clang-offload-bundler{{.*}}
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_UNBUNDLE
+// STATIC_ARCHIVE_UNBUNDLE: clang-offload-bundler{{.*}}


### PR DESCRIPTION
When unbundling a fat static archive and not targeting FPGA, the driver
would assert due to a mismatch of expected unbundled files within the
generated toolchain.  This was due to the generic nature in which we
were searching for AOCO type archives.