### PR TITLE
[SYCL] minor spelling fix for pragma

### DIFF
--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
@@ -14,7 +14,7 @@
 // SYCL runtime later.
 //===----------------------------------------------------------------------===//
 
-#pragma onece
+#pragma once
 
 #include "llvm/Pass.h"
 #include <unordered_map>


### PR DESCRIPTION
Encountered when testing building intel/llvm with clang libc++. 
Signed-off-by: Chris Perkins <chris.perkins@intel.com>