### PR TITLE
[SYCL] Move the lambda attribute hack logic into tablegen; NFC

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -566,6 +566,14 @@ class Attr {
   // attribute may be documented under multiple categories, more than one
   // Documentation entry may be listed.
   list<Documentation> Documentation;
+  // The SYCL specification allows attributes on lambdas as a nonconforming
+  // extension to C++. The attributes are written in the type position but will
+  // be applied to the generated function declaration rather than type. Setting
+  // this bit to 1 opts an attribute into this nonconforming extension. New
+  // attributes should not set this bit unless the attribute is required by the
+  // SYCL specification. This bit only applies to the [[]] spelling of an
+  // attribute and has no effect on any other spellings.
+  bit SupportsNonconformingLambdaSyntax = 0;
 }
 
 /// A type attribute is not processed on a declaration or a statement.
@@ -1186,6 +1194,7 @@ def SYCLSimd : InheritableAttr {
   let Subjects = SubjectList<[Function]>;
   let LangOpts = [SYCLExplicitSIMD];
   let Documentation = [SYCLSimdDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 // Available in SYCL explicit SIMD extension. Binds a file scope private
@@ -1258,11 +1267,12 @@ def SYCLRequiresDecomposition : InheritableAttr {
 }
 
 def SYCLIntelKernelArgsRestrict : InheritableAttr {
-  let Spellings = [ CXX11<"intel", "kernel_args_restrict"> ];
+  let Spellings = [CXX11<"intel", "kernel_args_restrict">];
   let Subjects = SubjectList<[Function], ErrorDiag>;
-  let LangOpts = [ SYCLIsDevice, SYCLIsHost ];
-  let Documentation = [ SYCLIntelKernelArgsRestrictDocs ];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let Documentation = [SYCLIntelKernelArgsRestrictDocs];
   let SimpleHandler = 1;
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def SYCLIntelNumSimdWorkItems : InheritableAttr {
@@ -1272,6 +1282,7 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelNumSimdWorkItemsAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def SYCLIntelUseStallEnableClusters : InheritableAttr {
@@ -1279,6 +1290,7 @@ def SYCLIntelUseStallEnableClusters : InheritableAttr {
   let LangOpts = [SYCLIsHost, SYCLIsDevice];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelUseStallEnableClustersAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
@@ -1288,6 +1300,7 @@ def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelSchedulerTargetFmaxMhzAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def SYCLIntelMaxWorkGroupSize : InheritableAttr {
@@ -1313,6 +1326,7 @@ def SYCLIntelMaxWorkGroupSize : InheritableAttr {
     }
   }];
   let Documentation = [SYCLIntelMaxWorkGroupSizeAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
@@ -1322,6 +1336,7 @@ def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelMaxGlobalWorkDimAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def SYCLIntelNoGlobalWorkOffset : InheritableAttr {
@@ -1331,6 +1346,7 @@ def SYCLIntelNoGlobalWorkOffset : InheritableAttr {
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelNoGlobalWorkOffsetAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def SYCLIntelLoopFuse : InheritableAttr {
@@ -1342,6 +1358,7 @@ def SYCLIntelLoopFuse : InheritableAttr {
   let Accessors = [Accessor<"isIndependent",
                   [CXX11<"intel", "loop_fuse_independent">]>];
   let Documentation = [SYCLIntelLoopFuseDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def C11NoReturn : InheritableAttr {
@@ -1404,6 +1421,7 @@ def IntelReqdSubGroupSize: InheritableAttr {
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [IntelReqdSubGroupSizeDocs];
   let LangOpts = [OpenCL, SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 // This attribute is both a type attribute, and a declaration attribute (for
@@ -2808,6 +2826,7 @@ def ReqdWorkGroupSize : InheritableAttr {
     }
   }];
   let Documentation = [ReqdWorkGroupSizeAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def WorkGroupSizeHint :  InheritableAttr {

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -153,26 +153,6 @@ public:
     return SyntaxUsed == AS_CXX11 || isAlignasAttribute();
   }
 
-  bool isAllowedOnLambdas() const {
-    // FIXME: Eventually we want to do a list here populated via tablegen.  But
-    // we want C++ attributes to be permissible on Lambdas, and get propagated
-    // to the call operator declaration.
-    auto ParsedAttr = getParsedKind();
-    if (ParsedAttr == AT_SYCLIntelKernelArgsRestrict ||
-        (ParsedAttr == AT_ReqdWorkGroupSize && isCXX11Attribute()) ||
-        (ParsedAttr == AT_IntelReqdSubGroupSize && isCXX11Attribute()) ||
-        ParsedAttr == AT_SYCLIntelNumSimdWorkItems ||
-        ParsedAttr == AT_SYCLIntelSchedulerTargetFmaxMhz ||
-        ParsedAttr == AT_SYCLIntelMaxWorkGroupSize ||
-        ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim ||
-        ParsedAttr == AT_SYCLIntelNoGlobalWorkOffset ||
-        ParsedAttr == AT_SYCLIntelUseStallEnableClusters ||
-        ParsedAttr == AT_SYCLIntelLoopFuse || ParsedAttr == AT_SYCLSimd)
-      return true;
-
-    return false;
-  }
-
   bool isC2xAttribute() const { return SyntaxUsed == AS_C2x; }
 
   bool isKeywordAttribute() const {

--- a/clang/include/clang/Sema/ParsedAttr.h
+++ b/clang/include/clang/Sema/ParsedAttr.h
@@ -60,6 +60,9 @@ struct ParsedAttrInfo {
   unsigned IsKnownToGCC : 1;
   /// True if this attribute is supported by #pragma clang attribute.
   unsigned IsSupportedByPragmaAttribute : 1;
+  /// True if this attribute supports a nonconforming behavior when applied to
+  /// a lambda in the type position.
+  unsigned SupportsNonconformingLambdaSyntax : 1;
   /// The syntaxes supported by this attribute and how they're spelled.
   struct Spelling {
     AttributeCommonInfo::Syntax Syntax;
@@ -590,6 +593,7 @@ public:
   bool existsInTarget(const TargetInfo &Target) const;
   bool isKnownToGCC() const;
   bool isSupportedByPragmaAttribute() const;
+  bool supportsNonconformingLambdaSyntax() const;
 
   /// If the parsed attribute has a semantic equivalent, and it would
   /// have a semantic Spelling enumeration (due to having semantically-distinct

--- a/clang/lib/Sema/ParsedAttr.cpp
+++ b/clang/lib/Sema/ParsedAttr.cpp
@@ -193,6 +193,10 @@ bool ParsedAttr::isSupportedByPragmaAttribute() const {
   return getInfo().IsSupportedByPragmaAttribute;
 }
 
+bool ParsedAttr::supportsNonconformingLambdaSyntax() const {
+  return getInfo().SupportsNonconformingLambdaSyntax && isCXX11Attribute();
+}
+
 unsigned ParsedAttr::getSemanticSpelling() const {
   return getInfo().spellingIndexToSemanticSpelling(*this);
 }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8859,7 +8859,7 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   // Ignore C++11 attributes on declarator chunks: they appertain to the type
   // instead.
   if (AL.isCXX11Attribute() && !IncludeCXX11Attributes &&
-      (!IsDeclLambdaCallOperator(D) || !AL.isAllowedOnLambdas()))
+      (!IsDeclLambdaCallOperator(D) || !AL.supportsNonconformingLambdaSyntax()))
     return;
 
   // Unknown attributes are automatically warned on. Target-specific attributes

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8123,7 +8123,8 @@ static void processTypeAttrs(TypeProcessingState &state, QualType &type,
     default:
       // A C++11 attribute on a declarator chunk must appertain to a type.
       if (attr.isCXX11Attribute() && TAL == TAL_DeclChunk &&
-          (!state.isProcessingLambdaExpr() || !attr.isAllowedOnLambdas())) {
+          (!state.isProcessingLambdaExpr() ||
+           !attr.supportsNonconformingLambdaSyntax())) {
         state.getSema().Diag(attr.getLoc(), diag::err_attribute_not_type_attr)
             << attr;
         attr.setUsedAsTypeAttr();

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3796,6 +3796,8 @@ void EmitClangAttrParsedAttrImpl(RecordKeeper &Records, raw_ostream &OS) {
     OS << IsKnownToGCC(Attr) << ";\n";
     OS << "    IsSupportedByPragmaAttribute = ";
     OS << PragmaAttributeSupport.isAttributedSupported(*I->second) << ";\n";
+    OS << "    SupportsNonconformingLambdaSyntax = ";
+    OS << Attr.getValueAsBit("SupportsNonconformingLambdaSyntax") << ";\n";
     if (!Spellings.empty())
       OS << "    Spellings = " << I->first << "Spellings;\n";
     OS << "  }\n";


### PR DESCRIPTION
We have a hack in place that lets an attribute written in the type
position of a lambda to slide into the declaration position. Instead
of specifying that in a header file, each attribute can opt into the
behavior within Attr.td.