### PR TITLE
[Driver][SYCL] Update unbundling behaviors for AOCO type archives

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4699,8 +4699,13 @@ public:
       for (auto TI = SYCLTCRange.first, TE = SYCLTCRange.second; TI != TE; ++TI)
         HasFPGATarget |= TI->second->getTriple().getSubArch() ==
                          llvm::Triple::SPIRSubArch_fpga;
-      if (HasFPGATarget && !(HostAction->getType() == types::TY_Object &&
-                             isObjectFile(InputName))) {
+      bool isArchive = !(HostAction->getType() == types::TY_Object &&
+                         isObjectFile(InputName));
+      if (!HasFPGATarget && isArchive &&
+          HostAction->getType() == types::TY_FPGA_AOCO)
+        // Archive with Non-FPGA target with AOCO type should not be unbundled.
+        return false;
+      if (HasFPGATarget && isArchive) {
         // Type FPGA aoco is a special case for -foffload-static-lib.
         if (HostAction->getType() == types::TY_FPGA_AOCO) {
           if (!hasFPGABinary(C, InputName, types::TY_FPGA_AOCO))
@@ -6193,8 +6198,7 @@ InputInfo Driver::BuildJobsForActionNoCache(
             TI = types::TY_Tempfilelist;
         } else if (EffectiveTriple.getSubArch() !=
                    llvm::Triple::SPIRSubArch_fpga) {
-          if (UI.DependentOffloadKind == Action::OFK_SYCL &&
-              JA->getType() != types::TY_FPGA_AOCO) {
+          if (UI.DependentOffloadKind == Action::OFK_SYCL) {
             // Do not add the current info for device with FPGA device.  The
             // device side isn't used
             continue;

--- a/clang/test/Driver/sycl-offload-static-lib.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib.cpp
@@ -162,3 +162,14 @@
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %t.a -### 2>&1 \
 // RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_UNBUNDLE
 // STATIC_ARCHIVE_UNBUNDLE: clang-offload-bundler{{.*}}
+
+/// Use of static archives with AOT should not split or use llvm-foreach
+// RUN: touch %t.a
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice %t.a -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_SPLIT_CHECK
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %t.a -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_SPLIT_CHECK
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %t.a -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=STATIC_ARCHIVE_SPLIT_CHECK
+// STATIC_ARCHIVE_SPLIT_CHECK-NOT: file-table-tform{{.*}}
+// STATIC_ARCHIVE_SPLIT_CHECK-NOT: llvm-foreach{{.*}}


### PR DESCRIPTION
When unbundling archives for non-FPGA targets, we were going through
an additional unbundle step for AOCO.  Update the logic here so we do
not attempt to unbundle for AOCO when we know we are not doing AOT for
FPGA.  The additional unbundling step was causing havoc with the
expected binaries to be unbundled as well as causing unwanted usage
of split/llvm-foreach