### PR TITLE
[Driver][SYCL] Disable code coverage for device compilations

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -531,8 +531,17 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
 
   if (!DAL) {
     DAL = new DerivedArgList(Args.getBaseArgs());
-    for (Arg *A : Args)
-      DAL->append(A);
+    for (Arg *A : Args) {
+      // Filter out any options we do not want to pass along to the device
+      // compilation.
+      switch ((options::ID)A->getOption().getID()) {
+      default:
+        DAL->append(A);
+        break;
+      case options::OPT_fcoverage_mapping:
+        break;
+      }
+    }
   }
 
   const OptTable &Opts = getDriver().getOpts();

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -28,7 +28,7 @@
 /// Check that -fcoverage-mapping is disabled for device
 // RUN: %clang -### -fsycl -fprofile-instr-generate -fcoverage-mapping -target x86_64-unknown-linux-gnu -c %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_COVERAGE_MAPPING %s
-// CHECK_COVERAGE_MAPPING: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown-sycldevice"{{.*}} "-fprofile-instrument=clang"
+// CHECK_COVERAGE_MAPPING: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown-sycldevice" "-fsycl-is-device"{{.*}} "-fprofile-instrument=clang"
 // CHECK_COVERAGE_MAPPING-NOT: "-fcoverage-mapping"
 // CHECK_COVERAGE_MAPPING: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-fprofile-instrument=clang"
-// CHECK_COVERAGE_MAPPING: "-fcoverage-mapping"
+// CHECK_COVERAGE_MAPPING: "-fcoverage-mapping"{{.*}} "-fsycl-is-host"

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -24,3 +24,11 @@
 // RUN:  %clang -### -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
 // CHECK-OPTS: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-device"
 // CHECK-OPTS: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-host"
+
+/// Check that -fcoverage-mapping is disabled for device
+// RUN: %clang -### -fsycl -fprofile-instr-generate -fcoverage-mapping -target x86_64-unknown-linux-gnu -c %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK_COVERAGE_MAPPING %s
+// CHECK_COVERAGE_MAPPING: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown-sycldevice"{{.*}} "-fprofile-instrument=clang"
+// CHECK_COVERAGE_MAPPING-NOT: "-fcoverage-mapping"
+// CHECK_COVERAGE_MAPPING: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-fprofile-instrument=clang"
+// CHECK_COVERAGE_MAPPING: "-fcoverage-mapping"


### PR DESCRIPTION
Code coverage for SYCL device compilation is currently not supported.
If used with -fsycl, do not enable for the device compile.