### PR TITLE
[SYCL][FPGA] Refactor of [[intel::force_pow2_depth()]] attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2083,7 +2083,7 @@ def IntelFPGABankBits : Attr {
   let Documentation = [IntelFPGABankBitsDocs];
 }
 
-def IntelFPGAForcePow2Depth : Attr {
+def IntelFPGAForcePow2Depth : InheritableAttr {
   let Spellings = [CXX11<"intelfpga","force_pow2_depth">,
                    CXX11<"intel","force_pow2_depth">];
   let Args = [ExprArgument<"Value">];
@@ -2091,14 +2091,6 @@ def IntelFPGAForcePow2Depth : Attr {
                               Field], ErrorDiag>;
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Documentation = [IntelFPGAForcePow2DepthAttrDocs];
-  let AdditionalMembers = [{
-    static unsigned getMinValue() {
-      return 0;
-    }
-    static unsigned getMaxValue() {
-      return 1;
-    }
-  }];
 }
 
 def Naked : InheritableAttr {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10200,8 +10200,6 @@ public:
   bool checkRangedIntegralArgument(Expr *E, const AttrType *TmpAttr,
                                    ExprResult &Result);
   template <typename AttrType>
-  void AddOneConstantValueAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E);
-  template <typename AttrType>
   void AddOneConstantPowerTwoValueAttr(Decl *D, const AttributeCommonInfo &CI,
                                        Expr *E);
   void AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
@@ -10240,6 +10238,10 @@ public:
                                      Expr *E);
   IntelFPGAMaxReplicatesAttr *
   MergeIntelFPGAMaxReplicatesAttr(Decl *D, const IntelFPGAMaxReplicatesAttr &A);
+  void AddIntelFPGAForcePow2DepthAttr(Decl *D, const AttributeCommonInfo &CI,
+                                      Expr *E);
+  IntelFPGAForcePow2DepthAttr *MergeIntelFPGAForcePow2DepthAttr(
+       Decl *D, const IntelFPGAForcePow2DepthAttr &A);
 
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,
@@ -13173,20 +13175,6 @@ void Sema::addIntelTripleArgAttr(Decl *D, const AttributeCommonInfo &CI,
   }
   D->addAttr(::new (Context)
                  WorkGroupAttrType(Context, CI, XDimExpr, YDimExpr, ZDimExpr));
-}
-
-template <typename AttrType>
-void Sema::AddOneConstantValueAttr(Decl *D, const AttributeCommonInfo &CI,
-                                   Expr *E) {
-  AttrType TmpAttr(Context, CI, E);
-
-  if (!E->isValueDependent()) {
-    ExprResult ICE;
-    if (checkRangedIntegralArgument<AttrType>(E, &TmpAttr, ICE))
-      return;
-    E = ICE.get();
-  }
-  D->addAttr(::new (Context) AttrType(Context, CI, E));
 }
 
 template <typename AttrType>

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10197,9 +10197,6 @@ public:
   void AddOptnoneAttributeIfNoConflicts(FunctionDecl *FD, SourceLocation Loc);
 
   template <typename AttrType>
-  bool checkRangedIntegralArgument(Expr *E, const AttrType *TmpAttr,
-                                   ExprResult &Result);
-  template <typename AttrType>
   void AddOneConstantPowerTwoValueAttr(Decl *D, const AttributeCommonInfo &CI,
                                        Expr *E);
   void AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10240,8 +10240,9 @@ public:
   MergeIntelFPGAMaxReplicatesAttr(Decl *D, const IntelFPGAMaxReplicatesAttr &A);
   void AddIntelFPGAForcePow2DepthAttr(Decl *D, const AttributeCommonInfo &CI,
                                       Expr *E);
-  IntelFPGAForcePow2DepthAttr *MergeIntelFPGAForcePow2DepthAttr(
-       Decl *D, const IntelFPGAForcePow2DepthAttr &A);
+  IntelFPGAForcePow2DepthAttr *
+  MergeIntelFPGAForcePow2DepthAttr(Decl *D,
+                                   const IntelFPGAForcePow2DepthAttr &A);
 
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2628,6 +2628,8 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
     NewAttr = S.MergeSYCLIntelNoGlobalWorkOffsetAttr(D, *A);
   else if (const auto *A = dyn_cast<IntelFPGAMaxReplicatesAttr>(Attr))
     NewAttr = S.MergeIntelFPGAMaxReplicatesAttr(D, *A);
+  else if (const auto *A = dyn_cast<IntelFPGAForcePow2DepthAttr>(Attr))
+    NewAttr = S.MergeIntelFPGAForcePow2DepthAttr(D, *A);
   else if (Attr->shouldInheritEvenIfAlreadyPresent() || !DeclHasAttr(D, Attr))
     NewAttr = cast<InheritableAttr>(Attr->clone(S.Context));
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6205,21 +6205,92 @@ static void handleIntelFPGAPrivateCopiesAttr(Sema &S, Decl *D,
   S.AddIntelFPGAPrivateCopiesAttr(D, A, A.getArgAsExpr(0));
 }
 
+void Sema::AddIntelFPGAForcePow2DepthAttr(Decl *D, const AttributeCommonInfo &CI,
+                                          Expr *E) {
+  if (!E->isValueDependent()) {
+    // Validate that we have an integer constant expression and then store the
+    // converted constant expression into the semantic attribute so that we
+    // don't have to evaluate it again later.
+    llvm::APSInt ArgVal;
+    ExprResult Res = VerifyIntegerConstantExpression(E, &ArgVal);
+    if (Res.isInvalid())
+      return;
+    E = Res.get();
+    // This attribute requires a non-negative value.
+    if (ArgVal < 0) {
+      Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
+          << CI << /*non-negative*/ 1;
+      return;
+    }
+    if (ArgVal > 1) {
+      Diag(E->getBeginLoc(), diag::err_attribute_argument_out_of_range)
+          << CI << 0 << 1 << E->getSourceRange();
+      return;
+    }
+
+    // Check to see if there's a duplicate attribute with different values
+    // already applied to the declaration.
+    if (const auto *DeclAttr = D->getAttr<IntelFPGAForcePow2DepthAttr>()) {
+      // If the other attribute argument is instantiation dependent, we won't
+      // have converted it to a constant expression yet and thus we test
+      // whether this is a null pointer.
+      if (const auto *DeclExpr = dyn_cast<ConstantExpr>(DeclAttr->getValue())) {
+        if (DeclExpr && ArgVal != DeclExpr->getResultAsAPSInt()) {
+          Diag(CI.getLoc(), diag::warn_duplicate_attribute) << CI;
+          Diag(DeclAttr->getLoc(), diag::note_previous_attribute);
+	  return;
+	}
+	// If there is no mismatch, drop any duplicate attributes.
+        D->dropAttr<IntelFPGAForcePow2DepthAttr>();
+      }
+    }
+    // [[intel::fpga_register]] and [[intel::force_pow2_depth()]]
+    // attributes are incompatible.
+    if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(*this, D, CI))
+      return;
+
+    // If the declaration does not have [[intel::memory]]
+    // attribute, this creates default implicit memory.
+    if (!D->hasAttr<IntelFPGAMemoryAttr>())
+      D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
+          Context, IntelFPGAMemoryAttr::Default));
+  }
+
+  D->addAttr(::new (Context) IntelFPGAForcePow2DepthAttr(Context, CI, E));
+}
+
+IntelFPGAForcePow2DepthAttr *
+Sema::MergeIntelFPGAForcePow2DepthAttr(Decl *D,
+                                       const IntelFPGAForcePow2DepthAttr &A) {
+  // Check to see if there's a duplicate attribute with different values
+  // already applied to the declaration.
+  if (const auto *DeclAttr = D->getAttr<IntelFPGAForcePow2DepthAttr>()) {
+    if (const auto *DeclExpr = dyn_cast<ConstantExpr>(DeclAttr->getValue())) {
+      if (const auto *MergeExpr = dyn_cast<ConstantExpr>(A.getValue())) {
+        if (DeclExpr->getResultAsAPSInt() != MergeExpr->getResultAsAPSInt()) {
+          Diag(DeclAttr->getLoc(), diag::warn_duplicate_attribute) << &A;
+          Diag(A.getLoc(), diag::note_previous_attribute);
+	  return nullptr;
+	}
+	// If there is no mismatch, drop any duplicate attributes.
+	D->dropAttr<IntelFPGAForcePow2DepthAttr>();
+      }
+    }
+  }
+
+  // [[intel::fpga_register]] and [[intel::force_pow2_depth()]]
+  // attributes are incompatible.
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(*this, D, A))
+    return nullptr;
+
+  return ::new (Context) IntelFPGAForcePow2DepthAttr(Context, A, A.getValue());
+}
+
 static void handleIntelFPGAForcePow2DepthAttr(Sema &S, Decl *D,
                                               const ParsedAttr &A) {
-  checkForDuplicateAttribute<IntelFPGAForcePow2DepthAttr>(S, D, A);
-
-  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(S, D, A))
-    return;
-
-  if (!D->hasAttr<IntelFPGAMemoryAttr>())
-    D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
-        S.Context, IntelFPGAMemoryAttr::Default));
-
   S.CheckDeprecatedSYCLAttributeSpelling(A);
 
-  S.AddOneConstantValueAttr<IntelFPGAForcePow2DepthAttr>(D, A,
-                                                         A.getArgAsExpr(0));
+  S.AddIntelFPGAForcePow2DepthAttr(D, A, A.getArgAsExpr(0));
 }
 
 static void handleXRayLogArgsAttr(Sema &S, Decl *D, const ParsedAttr &AL) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6274,7 +6274,7 @@ Sema::MergeIntelFPGAForcePow2DepthAttr(Decl *D,
           return nullptr;
         }
         // If there is no mismatch, drop any duplicate attributes.
-        D->dropAttr<IntelFPGAForcePow2DepthAttr>()
+        D->dropAttr<IntelFPGAForcePow2DepthAttr>();
       }
     }
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6239,10 +6239,9 @@ void Sema::AddIntelFPGAForcePow2DepthAttr(Decl *D,
         if (ArgVal != DeclExpr->getResultAsAPSInt()) {
           Diag(CI.getLoc(), diag::warn_duplicate_attribute) << CI;
           Diag(DeclAttr->getLoc(), diag::note_previous_attribute);
-          return;
         }
         // If there is no mismatch, drop any duplicate attributes.
-        D->dropAttr<IntelFPGAForcePow2DepthAttr>();
+        return;
       }
     }
     // [[intel::fpga_register]] and [[intel::force_pow2_depth()]]
@@ -6250,8 +6249,8 @@ void Sema::AddIntelFPGAForcePow2DepthAttr(Decl *D,
     if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(*this, D, CI))
       return;
 
-    // If the declaration does not have [[intel::memory]]
-    // attribute, this creates default implicit memory.
+    // If the declaration does not have an [[intel::fpga_memory]]
+    // attribute, this creates one as an implicit attribute.
     if (!D->hasAttr<IntelFPGAMemoryAttr>())
       D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
           Context, IntelFPGAMemoryAttr::Default));
@@ -6271,10 +6270,9 @@ Sema::MergeIntelFPGAForcePow2DepthAttr(Decl *D,
         if (DeclExpr->getResultAsAPSInt() != MergeExpr->getResultAsAPSInt()) {
           Diag(DeclAttr->getLoc(), diag::warn_duplicate_attribute) << &A;
           Diag(A.getLoc(), diag::note_previous_attribute);
-          return nullptr;
         }
         // If there is no mismatch, drop any duplicate attributes.
-        D->dropAttr<IntelFPGAForcePow2DepthAttr>();
+        return nullptr;
       }
     }
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6205,7 +6205,8 @@ static void handleIntelFPGAPrivateCopiesAttr(Sema &S, Decl *D,
   S.AddIntelFPGAPrivateCopiesAttr(D, A, A.getArgAsExpr(0));
 }
 
-void Sema::AddIntelFPGAForcePow2DepthAttr(Decl *D, const AttributeCommonInfo &CI,
+void Sema::AddIntelFPGAForcePow2DepthAttr(Decl *D,
+                                          const AttributeCommonInfo &CI,
                                           Expr *E) {
   if (!E->isValueDependent()) {
     // Validate that we have an integer constant expression and then store the
@@ -6235,12 +6236,12 @@ void Sema::AddIntelFPGAForcePow2DepthAttr(Decl *D, const AttributeCommonInfo &CI
       // have converted it to a constant expression yet and thus we test
       // whether this is a null pointer.
       if (const auto *DeclExpr = dyn_cast<ConstantExpr>(DeclAttr->getValue())) {
-        if (DeclExpr && ArgVal != DeclExpr->getResultAsAPSInt()) {
+        if (ArgVal != DeclExpr->getResultAsAPSInt()) {
           Diag(CI.getLoc(), diag::warn_duplicate_attribute) << CI;
           Diag(DeclAttr->getLoc(), diag::note_previous_attribute);
-	  return;
-	}
-	// If there is no mismatch, drop any duplicate attributes.
+          return;
+        }
+        // If there is no mismatch, drop any duplicate attributes.
         D->dropAttr<IntelFPGAForcePow2DepthAttr>();
       }
     }
@@ -6270,10 +6271,10 @@ Sema::MergeIntelFPGAForcePow2DepthAttr(Decl *D,
         if (DeclExpr->getResultAsAPSInt() != MergeExpr->getResultAsAPSInt()) {
           Diag(DeclAttr->getLoc(), diag::warn_duplicate_attribute) << &A;
           Diag(A.getLoc(), diag::note_previous_attribute);
-	  return nullptr;
-	}
-	// If there is no mismatch, drop any duplicate attributes.
-	D->dropAttr<IntelFPGAForcePow2DepthAttr>();
+          return nullptr;
+        }
+        // If there is no mismatch, drop any duplicate attributes.
+        D->dropAttr<IntelFPGAForcePow2DepthAttr>()
       }
     }
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6222,17 +6222,18 @@ void Sema::AddIntelFPGAForcePow2DepthAttr(Decl *D,
         return;
       }
     }
-    // [[intel::fpga_register]] and [[intel::force_pow2_depth()]]
-    // attributes are incompatible.
-    if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(*this, D, CI))
-      return;
-
-    // If the declaration does not have an [[intel::fpga_memory]]
-    // attribute, this creates one as an implicit attribute.
-    if (!D->hasAttr<IntelFPGAMemoryAttr>())
-      D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
-          Context, IntelFPGAMemoryAttr::Default));
   }
+
+  // [[intel::fpga_register]] and [[intel::force_pow2_depth()]]
+  // attributes are incompatible.
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(*this, D, CI))
+    return;
+
+  // If the declaration does not have an [[intel::fpga_memory]]
+  // attribute, this creates one as an implicit attribute.
+  if (!D->hasAttr<IntelFPGAMemoryAttr>())
+    D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
+        Context, IntelFPGAMemoryAttr::Default));
 
   D->addAttr(::new (Context) IntelFPGAForcePow2DepthAttr(Context, CI, E));
 }

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -581,8 +581,7 @@ static void instantiateIntelFPGAForcePow2DepthAttr(
       S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
   ExprResult Result = S.SubstExpr(Attr->getValue(), TemplateArgs);
   if (!Result.isInvalid())
-    return S.AddOneConstantValueAttr<IntelFPGAForcePow2DepthAttr>(
-        New, *Attr, Result.getAs<Expr>());
+    return S.AddIntelFPGAForcePow2DepthAttr(New, *Attr, Result.getAs<Expr>());
 }
 
 static void instantiateIntelFPGABankWidthAttr(

--- a/clang/test/SemaSYCL/intel-fpga-global-const.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-global-const.cpp
@@ -31,3 +31,32 @@
 //expected-note@+2{{conflicting attribute is here}}
 [[intel::max_replicates(12)]] extern const int var_max_replicates_2;
 [[intel::fpga_register]] const int var_max_replicates_2 =0;
+
+// Test that checks global constant variable (which allows the redeclaration) since
+// IntelFPGAConstVar is one of the subjects listed for [[intel::force_pow2_depth()]] attribute.
+
+// Checking of duplicate argument values.
+//CHECK: VarDecl{{.*}}force_pow2_depth
+//CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
+//CHECK: IntelFPGAForcePow2DepthAttr
+//CHECK-NEXT: ConstantExpr
+//CHECK-NEXT: value:{{.*}}1
+//CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
+[[intel::force_pow2_depth(1)]] extern const int var_force_pow2_depth;
+[[intel::force_pow2_depth(1)]] const int var_force_pow2_depth = 0; // OK
+
+// Merging of different arg values.
+//expected-warning@+2{{attribute 'force_pow2_depth' is already applied with different arguments}}
+[[intel::force_pow2_depth(1)]] extern const int var_force_pow2_depth_1;
+[[intel::force_pow2_depth(0)]] const int var_force_pow2_depth_1 = 0;
+//expected-note@-2{{previous attribute is here}}
+
+// Merging of incompatible attributes.
+// FIXME: Diagnostic order isn't correct, this isn't what we'd want here but
+// this is an upstream issue. Merge function is calling here
+// checkAttrMutualExclusion() function that has backwards diagnostic behavior.
+// This should be fixed into upstream.
+//expected-error@+2{{'force_pow2_depth' and 'fpga_register' attributes are not compatible}}
+//expected-note@+2{{conflicting attribute is here}}
+[[intel::force_pow2_depth(1)]] extern const int var_force_pow2_depth_2;
+[[intel::fpga_register]] const int var_force_pow2_depth_2 =0;

--- a/clang/test/SemaSYCL/intel-fpga-global-const.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-global-const.cpp
@@ -42,6 +42,10 @@
 //CHECK-NEXT: ConstantExpr
 //CHECK-NEXT: value:{{.*}}1
 //CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
+//CHECK: IntelFPGAForcePow2DepthAttr
+//CHECK-NEXT: ConstantExpr
+//CHECK-NEXT: value:{{.*}}1
+//CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
 [[intel::force_pow2_depth(1)]] extern const int var_force_pow2_depth;
 [[intel::force_pow2_depth(1)]] const int var_force_pow2_depth = 0; // OK
 

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -608,7 +608,7 @@ void diagnostics()
   //expected-note@+1 {{did you mean to use 'intel::force_pow2_depth' instead?}}
   [[intelfpga::force_pow2_depth(0)]] unsigned int arr_force_p2d_0[64];
 
-  //expected-error@+1{{'force_pow2_depth' attribute requires a non-negative integral compile time constant expression}}
+  //expected-error@+1{{'force_pow2_depth' attribute requires integer constant between 0 and 1 inclusive}}
   [[intel::force_pow2_depth(-1)]] unsigned int force_p2d_below_min[64];
   //expected-error@+1{{'force_pow2_depth' attribute requires integer constant between 0 and 1 inclusive}}
   [[intel::force_pow2_depth(2)]] unsigned int force_p2d_above_max[64];

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -172,6 +172,16 @@ void check_ast()
   //CHECK-NEXT: IntegerLiteral{{.*}}12{{$}}
   [[intel::private_copies(12)]]
   [[intel::private_copies(12)]] int var_private_copies; // OK
+
+  // Checking of duplicate argument values.
+  //CHECK: VarDecl{{.*}}var_forcep2d
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK: IntelFPGAForcePow2DepthAttr
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: value:{{.*}}1
+  //CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
+  [[intel::force_pow2_depth(1)]]
+  [[intel::force_pow2_depth(1)]] int var_forcep2d; // OK
 }
 
 //CHECK: FunctionDecl{{.*}}diagnostics
@@ -598,7 +608,7 @@ void diagnostics()
   //expected-note@+1 {{did you mean to use 'intel::force_pow2_depth' instead?}}
   [[intelfpga::force_pow2_depth(0)]] unsigned int arr_force_p2d_0[64];
 
-  //expected-error@+1{{'force_pow2_depth' attribute requires integer constant between 0 and 1 inclusive}}
+  //expected-error@+1{{'force_pow2_depth' attribute requires a non-negative integral compile time constant expression}}
   [[intel::force_pow2_depth(-1)]] unsigned int force_p2d_below_min[64];
   //expected-error@+1{{'force_pow2_depth' attribute requires integer constant between 0 and 1 inclusive}}
   [[intel::force_pow2_depth(2)]] unsigned int force_p2d_above_max[64];
@@ -608,17 +618,15 @@ void diagnostics()
   //expected-error@+1{{'force_pow2_depth' attribute takes one argument}}
   [[intel::force_pow2_depth(0, 1)]] unsigned int force_p2d_2_args[64];
 
+  // Checking of different argument values.
   //CHECK: VarDecl{{.*}}force_p2d_dup
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAForcePow2DepthAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: value:{{.*}}1
   //CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
-  //CHECK: IntelFPGAForcePow2DepthAttr
-  //CHECK-NEXT: ConstantExpr
-  //CHECK-NEXT: value:{{.*}}0
-  //CHECK-NEXT: IntegerLiteral{{.*}}0{{$}}
-  //expected-warning@+1{{attribute 'force_pow2_depth' is already applied}}
+  //expected-note@+2{{previous attribute is here}}
+  //expected-warning@+1{{attribute 'force_pow2_depth' is already applied with different arguments}}
   [[intel::force_pow2_depth(1), intel::force_pow2_depth(0)]] unsigned int force_p2d_dup[64];
 }
 
@@ -857,6 +865,7 @@ void check_template_parameters() {
   //expected-note@-1{{conflicting attribute is here}}
   [[intel::force_pow2_depth(E)]] unsigned int reg_force_p2d[64];
 
+  // Test that checks template instantiations for different arg values.
   //CHECK: VarDecl{{.*}}force_p2d_dup
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAForcePow2DepthAttr
@@ -865,11 +874,8 @@ void check_template_parameters() {
   //CHECK-NEXT: SubstNonTypeTemplateParmExpr
   //CHECK-NEXT: NonTypeTemplateParmDecl
   //CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
-  //CHECK: IntelFPGAForcePow2DepthAttr
-  //CHECK: ConstantExpr
-  //CHECK-NEXT: value:{{.*}}0
-  //CHECK-NEXT: IntegerLiteral{{.*}}0{{$}}
-  //expected-warning@+1{{attribute 'force_pow2_depth' is already applied}}
+  //expected-note@+2{{previous attribute is here}}
+  //expected-warning@+1{{attribute 'force_pow2_depth' is already applied with different arguments}}
   [[intel::force_pow2_depth(E), intel::force_pow2_depth(0)]] unsigned int force_p2d_dup[64];
 }
 


### PR DESCRIPTION
This patch

1. refactors FPGA Decl attribute [[intel::force_pow2_depth()]]
   to better fit for community standards.

2. refactors the way we handle duplicate attributes with same and
   different argument values and mutually exclusive attributes logic
   when present on a given declaration.

3. handles redeclarations or template instantiations properly.

4. adds tests

5. removes AddOneConstantValueAttr() function.

6. adds tests to check for global constant variable (which allows the redeclaration)
   since IntelFPGAConstVar is one of the subjects listed for [[intel::force_pow2_depth()]] attribute.

7. removes arbitrary upper bound check for attribute argument.

Signed-off-by: soumi.manna <smanna@scsel-cfl-02.sc.intel.com>