### PR TITLE
[SYCL] Enable build with llvm libcxx for xpti

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -13,9 +13,7 @@ def do_configure(args):
     if not os.path.isdir(abs_obj_dir):
       os.makedirs(abs_obj_dir)
 
-    llvm_external_projects = 'sycl;llvm-spirv;opencl-aot;libdevice'
-    if not args.use_libcxx:
-        llvm_external_projects += ';xpti;xptifw'
+    llvm_external_projects = 'sycl;llvm-spirv;opencl-aot;libdevice;xpti;xptifw'
 
     llvm_dir = os.path.join(abs_src_dir, "llvm")
     sycl_dir = os.path.join(abs_src_dir, "sycl")
@@ -34,8 +32,8 @@ def do_configure(args):
     llvm_enable_doxygen = 'OFF'
     llvm_enable_sphinx = 'OFF'
     llvm_build_shared_libs = 'OFF'
-    sycl_enable_xpti_tracing = 'OFF' if args.use_libcxx else 'ON'
 
+    sycl_enable_xpti_tracing = 'ON'
     icd_loader_lib = os.path.join(icd_loader_lib, "libOpenCL.so" if platform.system() == 'Linux' else "OpenCL.lib")
 
     # replace not append, so ARM ^ X86

--- a/xpti/CMakeLists.txt
+++ b/xpti/CMakeLists.txt
@@ -47,6 +47,18 @@ if (MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG "")
 endif()
 
+if (SYCL_USE_LIBCXX)
+  if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
+    (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+    if ((NOT (DEFINED SYCL_LIBCXX_INCLUDE_PATH)) OR (NOT (DEFINED SYCL_LIBCXX_LIBRARY_PATH)))
+      message(FATAL_ERROR "When building with libc++ SYCL_LIBCXX_INCLUDE_PATHS and"
+                          "SYCL_LIBCXX_LIBRARY_PATH should be set")
+    endif()
+    set(CMAKE_CXX_FLAGS "-nostdinc++ -I ${SYCL_LIBCXX_INCLUDE_PATH} ${CMAKE_CXX_FLAGS}")
+  else()
+    message(FATAL_ERROR "Build with libc++ is not yet supported for this compiler")
+  endif()
+endif()
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/lib/${CMAKE_BUILD_TYPE})
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})

--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -21,6 +21,19 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 endif()
 
+if (SYCL_USE_LIBCXX)
+  if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
+    (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+    if ((NOT (DEFINED SYCL_LIBCXX_INCLUDE_PATH)) OR (NOT (DEFINED SYCL_LIBCXX_LIBRARY_PATH)))
+      message(FATAL_ERROR "When building with libc++ SYCL_LIBCXX_INCLUDE_PATHS and"
+                          "SYCL_LIBCXX_LIBRARY_PATH should be set")
+    endif()
+    set(CMAKE_CXX_FLAGS "-nostdinc++ -I ${SYCL_LIBCXX_INCLUDE_PATH} ${CMAKE_CXX_FLAGS}")
+  else()
+    message(FATAL_ERROR "Build with libc++ is not yet supported for this compiler")
+  endif()
+endif()
+
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/lib/${CMAKE_BUILD_TYPE})
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
@@ -36,6 +49,7 @@ add_subdirectory(unit_test)
 add_subdirectory(samples/basic_collector)
 add_subdirectory(samples/syclpi_collector)
 endif()
+
 # The tests in basic_test are written using TBB, so these tests are enabled
 # only if TBB has been enabled.
 if (XPTI_ENABLE_TBB)

--- a/xptifw/src/CMakeLists.txt
+++ b/xptifw/src/CMakeLists.txt
@@ -15,5 +15,8 @@ if (XPTI_ENABLE_TBB)
   target_link_libraries(xptifw PRIVATE tbb)
 endif()
 
+if (SYCL_USE_LIBCXX)
+    target_link_libraries(xptifw PRIVATE "-L${SYCL_LIBCXX_LIBRARY_PATH}" -Wl,-rpath,${SYCL_LIBCXX_LIBRARY_PATH} -nodefaultlibs -lc++ -lc++abi -lm -lc -lgcc_s -lgcc)
+endif()
 # Set the location of the library installation
 install(TARGETS xptifw DESTINATION ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Signed-off-by: gejin <ge.jin@intel.com>
Currently, we support building SYCL runtime with llvm libcxx instead of GNU libstdc++ as an experiment feature.
Previously, xpti is disabled when the experiment feature is enabled, the reason is we need to update the CMakeFile to involve llvm libcxx for xpti, the PR aims to enable building xpti project with llvm libcxx.