### PR TITLE
Revert "Enable cfg-printer LLVM lit tests only if LLVM linked statica…

### DIFF
--- a/llvm/test/Other/cfg-printer-branch-weights.ll
+++ b/llvm/test/Other/cfg-printer-branch-weights.ll
@@ -1,9 +1,6 @@
 ;RUN: opt < %s -dot-cfg -cfg-weights -cfg-raw-weights -cfg-dot-filename-prefix=%t 2>/dev/null
 ;RUN: FileCheck %s -input-file=%t.f.dot
 
-;TODO: Investigate why this test doesn't work with dynamically linked libraries
-;REQUIRES: static-libs
-
 define void @f(i32) {
 entry:
   %check = icmp sgt i32 %0, 0

--- a/llvm/test/Other/cfg_deopt_unreach.ll
+++ b/llvm/test/Other/cfg_deopt_unreach.ll
@@ -9,9 +9,6 @@
 ; RUN: opt < %s -dot-cfg -cfg-hide-unreachable-paths -cfg-hide-deoptimize-paths -cfg-dot-filename-prefix=%t/both-flags 2>/dev/null
 ; RUN: FileCheck %s -input-file=%t/both-flags.callee.dot -check-prefix=BOTH-FLAGS
 
-; TODO: Investigate why this test doesn't work with dynamically linked libraries
-; REQUIRES: static-libs
-
 declare i8 @llvm.experimental.deoptimize.i8(...)
 
 define i8 @callee(i1* %c) alwaysinline {


### PR DESCRIPTION
…lly (#1479)"

This reverts commit ff0b066b884cabbf34bafbd5b2a0da1ead9123e7.

Closes #1478.