### PR TITLE
[SYCL][FPGA] Add implicit memory attribute with [[intel::max_replicates()]]

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5992,17 +5992,18 @@ void Sema::AddIntelFPGAMaxReplicatesAttr(Decl *D, const AttributeCommonInfo &CI,
         return;
       }
     }
-    // [[intel::fpga_register]] and [[intel::max_replicates()]]
-    // attributes are incompatible.
-    if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(*this, D, CI))
-      return;
-
-    // If the declaration does not have an [[intel::fpga_memory]]
-    // attribute, this creates one as an implicit attribute.
-    if (!D->hasAttr<IntelFPGAMemoryAttr>())
-      D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
-          Context, IntelFPGAMemoryAttr::Default));
   }
+
+  // [[intel::fpga_register]] and [[intel::max_replicates()]]
+  // attributes are incompatible.
+  if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(*this, D, CI))
+    return;
+
+  // If the declaration does not have an [[intel::fpga_memory]]
+  // attribute, this creates one as an implicit attribute.
+  if (!D->hasAttr<IntelFPGAMemoryAttr>())
+    D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
+        Context, IntelFPGAMemoryAttr::Default));
 
   D->addAttr(::new (Context) IntelFPGAMaxReplicatesAttr(Context, CI, E));
 }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5996,6 +5996,12 @@ void Sema::AddIntelFPGAMaxReplicatesAttr(Decl *D, const AttributeCommonInfo &CI,
     // attributes are incompatible.
     if (checkAttrMutualExclusion<IntelFPGARegisterAttr>(*this, D, CI))
       return;
+
+    // If the declaration does not have an [[intel::fpga_memory]]
+    // attribute, this creates one as an implicit attribute.
+    if (!D->hasAttr<IntelFPGAMemoryAttr>())
+      D->addAttr(IntelFPGAMemoryAttr::CreateImplicit(
+          Context, IntelFPGAMemoryAttr::Default));
   }
 
   D->addAttr(::new (Context) IntelFPGAMaxReplicatesAttr(Context, CI, E));

--- a/clang/test/SemaSYCL/intel-fpga-global-const.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-global-const.cpp
@@ -5,6 +5,7 @@
 
 // Checking of duplicate argument values.
 //CHECK: VarDecl{{.*}}var_max_replicates
+//CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
 //CHECK: IntelFPGAMaxReplicatesAttr
 //CHECK-NEXT: ConstantExpr
 //CHECK-NEXT: value:{{.*}}12

--- a/clang/test/SemaSYCL/intel-fpga-global-const.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-global-const.cpp
@@ -3,7 +3,7 @@
 // Test that checks global constant variable (which allows the redeclaration) since
 // IntelFPGAConstVar is one of the subjects listed for [[intel::max_replicates()]] attribute.
 
-// Checking of duplicate argument values.
+// Check duplicate argument values with implicit memory attribute.
 //CHECK: VarDecl{{.*}}var_max_replicates
 //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
 //CHECK: IntelFPGAMaxReplicatesAttr

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -110,6 +110,7 @@ void check_ast()
   [[intel::fpga_memory("MLAB")]] unsigned int doublepump_mlab[64];
 
   //CHECK: VarDecl{{.*}}max_replicates
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxReplicatesAttr
   //CHECK: ConstantExpr
   //CHECK-NEXT: value:{{.*}}2
@@ -148,6 +149,7 @@ void check_ast()
 
   // Checking of duplicate argument values.
   //CHECK: VarDecl{{.*}}var_max_replicates
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxReplicatesAttr
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: value:{{.*}}12
@@ -337,6 +339,7 @@ void diagnostics()
 
   // **max_replicates
   //CHECK: VarDecl{{.*}}max_replicates
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxReplicatesAttr
   //CHECK: ConstantExpr
   //CHECK-NEXT: value:{{.*}}2
@@ -814,6 +817,7 @@ void check_template_parameters() {
   [[intel::bank_bits(A, 3), intel::bankwidth(C)]] unsigned int bank_bits_width;
 
   //CHECK: VarDecl{{.*}}max_replicates
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxReplicatesAttr
   //CHECK: ConstantExpr
   //CHECK-NEXT: value:{{.*}}2

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -109,6 +109,7 @@ void check_ast()
   [[intel::doublepump]]
   [[intel::fpga_memory("MLAB")]] unsigned int doublepump_mlab[64];
 
+  // Add implicit memory attribute.
   //CHECK: VarDecl{{.*}}max_replicates
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxReplicatesAttr
@@ -147,7 +148,7 @@ void check_ast()
   [[intel::force_pow2_depth(1)]] int var_force_p2d;
   [[intel::force_pow2_depth(1)]] const int const_force_p2d[64] = {0, 1};
 
-  // Checking of duplicate argument values.
+  // Check duplicate argument values with implicit memory attribute.
   //CHECK: VarDecl{{.*}}var_max_replicates
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxReplicatesAttr
@@ -338,6 +339,7 @@ void diagnostics()
   unsigned int bankwidth_reg[64];
 
   // **max_replicates
+  // Add implicit memory attribute.
   //CHECK: VarDecl{{.*}}max_replicates
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxReplicatesAttr
@@ -816,6 +818,7 @@ void check_template_parameters() {
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
   [[intel::bank_bits(A, 3), intel::bankwidth(C)]] unsigned int bank_bits_width;
 
+  // Add implicit memory attribute.
   //CHECK: VarDecl{{.*}}max_replicates
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMaxReplicatesAttr


### PR DESCRIPTION
If the declaration does not have an [[intel::fpga_memory]] attribute,
we create one as an implicit attribute.

During refactoring work with [[intel::max_replicates()]] attribute, we somehow
dropped the implicit memory attribute.

This patch fixes the problem.

Signed-off-by: soumi.manna <smanna@scsel-cfl-02.sc.intel.com>