### PR TITLE
[SYCL] Avoid HOST .wait scope; .signal=HOST is expected to be enough

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3695,11 +3695,11 @@ pi_result piEventCreate(pi_context Context, pi_event *RetEvent) {
 
   ze_event_handle_t ZeEvent;
   ze_event_desc_t ZeEventDesc = {};
-  // We have to set the SIGNAL & WAIT flags as HOST scope because the
+  // We have to set the SIGNAL flag as HOST scope because the
   // Level-Zero plugin implementation waits for the events to complete
   // on the host.
   ZeEventDesc.signal = ZE_EVENT_SCOPE_FLAG_HOST;
-  ZeEventDesc.wait = ZE_EVENT_SCOPE_FLAG_HOST;
+  ZeEventDesc.wait = 0;
   ZeEventDesc.index = Index;
 
   ZE_CALL(zeEventCreate, (ZeEventPool, &ZeEventDesc, &ZeEvent));


### PR DESCRIPTION
The expectation is that this might improve performance since no redundant cache flushes occur on the wait-side.
Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>