### PR TITLE
Enable async Map/Unmap and factor copying in/out of buffers into one routine.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -352,7 +352,7 @@ constexpr char ZE_SUPPORTED_EXTENSIONS[] =
 static pi_result
 enqueueMemCopyHelper(pi_command_type CommandType, pi_queue Queue, void *Dst,
                      pi_bool BlockingWrite, size_t Size, const void *Src,
-                     pi_uint32 NumEventsInWaitList,
+                     bool HostCopy, pi_uint32 NumEventsInWaitList,
                      const pi_event *EventWaitList, pi_event *Event);
 
 static pi_result enqueueMemCopyRectHelper(
@@ -3915,7 +3915,24 @@ pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
   for (uint32_t I = 0; I < NumEvents; I++) {
     ze_event_handle_t ZeEvent = EventList[I]->ZeEvent;
     zePrint("ZeEvent = %#lx\n", pi_cast<std::uintptr_t>(ZeEvent));
-    ZE_CALL(zeEventHostSynchronize, (ZeEvent, UINT32_MAX));
+
+    // If event comes from a Map operation in integrated device, then do
+    // sync, memcpy, and signaling on the host
+    if (EventList[I]->DeferredHostCopy) {
+      for (auto ZeWaitEvent : EventList[I]->waitEvents) {
+        zePrint("ZeWaitEvent = %lx\n", pi_cast<std::uintptr_t>(ZeWaitEvent));
+        if (ZeWaitEvent)
+          ZE_CALL(zeEventHostSynchronize, (ZeWaitEvent, UINT32_MAX));
+      }
+      if (EventList[I]->CopyPending) {
+        memcpy(EventList[I]->DstBuffer, EventList[I]->SrcBuffer,
+               EventList[I]->RetMapSize);
+        EventList[I]->CopyPending = false;
+      }
+      ZE_CALL(zeEventHostSignal, (ZeEvent));
+    } else {
+      ZE_CALL(zeEventHostSynchronize, (ZeEvent, UINT32_MAX));
+    }
 
     // NOTE: we are cleaning up after the event here to free resources
     // sooner in case run-time is not calling piEventRelease soon enough.
@@ -4245,6 +4262,21 @@ pi_result piEnqueueEventsWaitWithBarrier(pi_queue Queue,
   return Queue->executeCommandList(ZeCommandList, ZeFence);
 }
 
+static bool piHostCopyablePtr(pi_queue Queue, const void *Ptr) {
+  ze_device_handle_t ZeDeviceHandle;
+  ze_memory_allocation_properties_t ZeMemoryAllocationProperties = {};
+
+  ZE_CALL(zeMemGetAllocProperties, (Queue->Context->ZeContext, Ptr,
+                                  &ZeMemoryAllocationProperties,
+                                  &ZeDeviceHandle));
+
+  return ZeMemoryAllocationProperties.type != ZE_MEMORY_TYPE_DEVICE;
+}
+
+static bool piHostCopyableMem(pi_queue Queue, pi_mem Mem) {
+  return piHostCopyablePtr(Queue, pi_cast<const void *>(Mem->getZeHandle()));
+}
+
 pi_result piEnqueueMemBufferRead(pi_queue Queue, pi_mem Src,
                                  pi_bool BlockingRead, size_t Offset,
                                  size_t Size, void *Dst,
@@ -4254,10 +4286,12 @@ pi_result piEnqueueMemBufferRead(pi_queue Queue, pi_mem Src,
   PI_ASSERT(Src, PI_INVALID_MEM_OBJECT);
   PI_ASSERT(Queue, PI_INVALID_QUEUE);
 
-  return enqueueMemCopyHelper(PI_COMMAND_TYPE_MEM_BUFFER_READ, Queue, Dst,
-                              BlockingRead, Size,
-                              pi_cast<char *>(Src->getZeHandle()) + Offset,
-                              NumEventsInWaitList, EventWaitList, Event);
+  return enqueueMemCopyHelper(
+      PI_COMMAND_TYPE_MEM_BUFFER_READ, Queue, Dst, BlockingRead, Size,
+      pi_cast<char *>(Src->getZeHandle()) + Offset,
+      piHostCopyableMem(Queue, Src) &&
+          piHostCopyablePtr(Queue, Dst), // Whether memcpy on host can be used
+      NumEventsInWaitList, EventWaitList, Event);
 }
 
 pi_result piEnqueueMemBufferReadRect(
@@ -4285,10 +4319,29 @@ pi_result piEnqueueMemBufferReadRect(
 static pi_result
 enqueueMemCopyHelper(pi_command_type CommandType, pi_queue Queue, void *Dst,
                      pi_bool BlockingWrite, size_t Size, const void *Src,
-                     pi_uint32 NumEventsInWaitList,
+                     bool HostCopy, pi_uint32 NumEventsInWaitList,
                      const pi_event *EventWaitList, pi_event *Event) {
   PI_ASSERT(Queue, PI_INVALID_QUEUE);
   PI_ASSERT(Event, PI_INVALID_EVENT);
+
+  if (HostCopy) {
+    assert(Event);
+    if (*Event) {
+      (*Event)->DeferredHostCopy = true;
+      for (uint32_t i = 0; i < NumEventsInWaitList; i++) {
+        zePrint("enqueueMemCopyHelper added ZeWaitEvent = %lx\n",
+          pi_cast<std::uintptr_t>(EventWaitList[i]->ZeEvent));
+        (*Event)->waitEvents.push_back(EventWaitList[i]->ZeEvent);
+      }
+      (*Event)->SrcBuffer = Src;
+      (*Event)->DstBuffer = Dst;
+      (*Event)->RetMapSize = Size;
+      (*Event)->CopyPending = true;
+    } else {
+      memcpy(Dst, Src, Size);
+    }
+    return PI_SUCCESS;
+  }
 
   _pi_ze_event_list_t TmpWaitList;
   if (auto Res = TmpWaitList.createAndRetainPiZeEventList(NumEventsInWaitList,
@@ -4441,12 +4494,14 @@ pi_result piEnqueueMemBufferWrite(pi_queue Queue, pi_mem Buffer,
   PI_ASSERT(Buffer, PI_INVALID_MEM_OBJECT);
   PI_ASSERT(Queue, PI_INVALID_QUEUE);
 
-  return enqueueMemCopyHelper(PI_COMMAND_TYPE_MEM_BUFFER_WRITE, Queue,
-                              pi_cast<char *>(Buffer->getZeHandle()) +
-                                  Offset, // dst
-                              BlockingWrite, Size,
-                              Ptr, // src
-                              NumEventsInWaitList, EventWaitList, Event);
+  return enqueueMemCopyHelper(
+      PI_COMMAND_TYPE_MEM_BUFFER_WRITE, Queue,
+      pi_cast<char *>(Buffer->getZeHandle()) + Offset, // dst
+      BlockingWrite, Size,
+      Ptr, // src
+      piHostCopyableMem(Queue, Buffer) &&
+          piHostCopyablePtr(Queue, Ptr), // Whether memcpy on host can be used
+      NumEventsInWaitList, EventWaitList, Event);
 }
 
 pi_result piEnqueueMemBufferWriteRect(
@@ -4482,6 +4537,9 @@ pi_result piEnqueueMemBufferCopy(pi_queue Queue, pi_mem SrcBuffer,
       pi_cast<char *>(DstBuffer->getZeHandle()) + DstOffset,
       false, // blocking
       Size, pi_cast<char *>(SrcBuffer->getZeHandle()) + SrcOffset,
+      piHostCopyableMem(Queue, SrcBuffer) &&
+          piHostCopyableMem(Queue,
+                            DstBuffer), // Whether memcpy on host can be used
       NumEventsInWaitList, EventWaitList, Event);
 }
 
@@ -4603,8 +4661,6 @@ pi_result piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer,
 
   // For discrete devices we don't need a commandlist
   ze_command_list_handle_t ZeCommandList = nullptr;
-  ze_fence_handle_t ZeFence = nullptr;
-  ze_event_handle_t ZeEvent = nullptr;
 
   {
     // Lock automatically releases when this goes out of scope.
@@ -4614,7 +4670,6 @@ pi_result piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer,
         Queue, Event, PI_COMMAND_TYPE_MEM_BUFFER_MAP, ZeCommandList);
     if (Res != PI_SUCCESS)
       return Res;
-    ZeEvent = (*Event)->ZeEvent;
     (*Event)->WaitList = TmpWaitList;
   }
 
@@ -4630,6 +4685,7 @@ pi_result piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer,
   // Can we get SYCL RT to predict/allocate in shared memory
   // from the beginning?
 
+#if 0
   // For integrated devices the buffer has been allocated in host memory.
   if (Buffer->OnHost) {
     // Wait on incoming events before doing the copy
@@ -4685,6 +4741,32 @@ pi_result piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer,
     return Res;
 
   return Buffer->addMapping(*RetMap, Offset, Size);
+#else
+  if (Buffer->MapHostPtr)
+    *RetMap = Buffer->MapHostPtr + Offset;
+
+  // For integrated devices the buffer has been allocated in host memory.
+  if (Buffer->OnHost) {
+    if (!Buffer->MapHostPtr) {
+      *RetMap = pi_cast<char *>(Buffer->getZeHandle()) + Offset;
+    }
+  } else {
+    if (!Buffer->MapHostPtr) {
+      ze_host_mem_alloc_desc_t ZeDesc = {};
+      ZeDesc.flags = 0;
+
+      ZE_CALL(zeMemAllocHost,
+              (Queue->Context->ZeContext, &ZeDesc, Size, 1, RetMap));
+    }
+  }
+  if (auto Res = enqueueMemCopyHelper(
+          PI_COMMAND_TYPE_MEM_BUFFER_COPY, Queue, *RetMap, BlockingMap, Size,
+          pi_cast<char *>(Buffer->getZeHandle()) + Offset, Buffer->OnHost,
+          NumEventsInWaitList, EventWaitList, Event))
+    return Res;
+
+  return Buffer->addMapping(*RetMap, Offset, Size);
+#endif
 }
 
 pi_result piEnqueueMemUnmap(pi_queue Queue, pi_mem MemObj, void *MappedPtr,
@@ -4701,13 +4783,10 @@ pi_result piEnqueueMemUnmap(pi_queue Queue, pi_mem MemObj, void *MappedPtr,
   // Integrated devices don't need a command list.
   // If discrete we will get a commandlist later.
   ze_command_list_handle_t ZeCommandList = nullptr;
-  ze_fence_handle_t ZeFence = nullptr;
 
   // TODO: handle the case when user does not care to follow the event
   // of unmap completion.
   PI_ASSERT(Event, PI_INVALID_EVENT);
-
-  ze_event_handle_t ZeEvent = nullptr;
 
   {
     // Lock automatically releases when this goes out of scope.
@@ -4717,7 +4796,6 @@ pi_result piEnqueueMemUnmap(pi_queue Queue, pi_mem MemObj, void *MappedPtr,
         Queue, Event, PI_COMMAND_TYPE_MEM_BUFFER_UNMAP, ZeCommandList);
     if (Res != PI_SUCCESS)
       return Res;
-    ZeEvent = (*Event)->ZeEvent;
     (*Event)->WaitList = TmpWaitList;
   }
 
@@ -4725,6 +4803,7 @@ pi_result piEnqueueMemUnmap(pi_queue Queue, pi_mem MemObj, void *MappedPtr,
   if (pi_result Res = MemObj->removeMapping(MappedPtr, MapInfo))
     return Res;
 
+#if 0
   // NOTE: we still have to free the host memory allocated/returned by
   // piEnqueueMemBufferMap, but can only do so after the above copy
   // is completed. Instead of waiting for It here (blocking), we shall
@@ -4781,6 +4860,16 @@ pi_result piEnqueueMemUnmap(pi_queue Queue, pi_mem MemObj, void *MappedPtr,
     return Res;
 
   return PI_SUCCESS;
+#else
+  if (auto Res = enqueueMemCopyHelper(
+          PI_COMMAND_TYPE_MEM_BUFFER_COPY, Queue,
+          pi_cast<char *>(MemObj->getZeHandle()) + MapInfo.Offset, true,
+          MapInfo.Size, MappedPtr, MemObj->OnHost, NumEventsInWaitList,
+          EventWaitList, Event))
+    return Res;
+
+  return PI_SUCCESS;
+#endif
 }
 
 pi_result piMemImageGetInfo(pi_mem Image, pi_image_info ParamName,
@@ -5445,6 +5534,9 @@ pi_result piextUSMEnqueueMemcpy(pi_queue Queue, pi_bool Blocking, void *DstPtr,
   return enqueueMemCopyHelper(
       // TODO: do we need a new command type for this?
       PI_COMMAND_TYPE_MEM_BUFFER_COPY, Queue, DstPtr, Blocking, Size, SrcPtr,
+      piHostCopyablePtr(Queue, DstPtr) &&
+          piHostCopyablePtr(Queue,
+                            SrcPtr), // Use host mempcy
       NumEventsInWaitlist, EventsWaitlist, Event);
 }
 

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -407,7 +407,7 @@ inline void zeParseError(ze_result_t ZeError, std::string &ErrorString) {
 
 #undef ZE_ERRCASE
   default:
-    assert("Unexpected Error code");
+    assert(false && "Unexpected Error code");
   } // switch
 }
 

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -4266,9 +4266,9 @@ static bool piHostCopyablePtr(pi_queue Queue, const void *Ptr) {
   ze_device_handle_t ZeDeviceHandle;
   ze_memory_allocation_properties_t ZeMemoryAllocationProperties = {};
 
-  ZE_CALL(zeMemGetAllocProperties, (Queue->Context->ZeContext, Ptr,
-                                  &ZeMemoryAllocationProperties,
-                                  &ZeDeviceHandle));
+  ZE_CALL(zeMemGetAllocProperties,
+          (Queue->Context->ZeContext, Ptr, &ZeMemoryAllocationProperties,
+           &ZeDeviceHandle));
 
   return ZeMemoryAllocationProperties.type != ZE_MEMORY_TYPE_DEVICE;
 }
@@ -4330,7 +4330,7 @@ enqueueMemCopyHelper(pi_command_type CommandType, pi_queue Queue, void *Dst,
       (*Event)->DeferredHostCopy = true;
       for (uint32_t i = 0; i < NumEventsInWaitList; i++) {
         zePrint("enqueueMemCopyHelper added ZeWaitEvent = %lx\n",
-          pi_cast<std::uintptr_t>(EventWaitList[i]->ZeEvent));
+                pi_cast<std::uintptr_t>(EventWaitList[i]->ZeEvent));
         (*Event)->waitEvents.push_back(EventWaitList[i]->ZeEvent);
       }
       (*Event)->SrcBuffer = Src;

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -565,8 +565,8 @@ struct _pi_event : _pi_object {
   // For deferred copy from Map/Unmap operations
   bool DeferredHostCopy = false;
   std::vector<ze_event_handle_t> waitEvents;
-  void* DstBuffer = nullptr;
-  const void* SrcBuffer = nullptr;
+  void *DstBuffer = nullptr;
+  const void *SrcBuffer = nullptr;
   size_t RetMapSize = 0;
   bool CopyPending = false;
 

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -562,6 +562,14 @@ struct _pi_event : _pi_object {
   // Level Zero event pool handle.
   ze_event_pool_handle_t ZeEventPool;
 
+  // For deferred copy from Map/Unmap operations
+  bool DeferredHostCopy = false;
+  std::vector<ze_event_handle_t> waitEvents;
+  void* DstBuffer = nullptr;
+  const void* SrcBuffer = nullptr;
+  size_t RetMapSize = 0;
+  bool CopyPending = false;
+
   // Level Zero command list where the command signaling this event was appended
   // to. This is currently used to remember/destroy the command list after all
   // commands in it are completed, i.e. this event signaled.

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -453,7 +453,7 @@ std::ostream &operator<<(std::ostream &Out, const DeviceBinaryProperty &P) {
     Out << "[String] ";
     break;
   default:
-    assert("unsupported property");
+    assert(false && "unsupported property");
     return Out;
   }
   Out << P.Prop->Name << "=";


### PR DESCRIPTION
This change allows bufferMap and unMap operations to be non-blocking if requested, and also places all copying in/out of buffers in one routine.