### PR TITLE
[SYCL] Fix event info queries for dummy non-host events

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -226,8 +226,14 @@ template <>
 cl_ulong
 event_impl::get_profiling_info<info::event_profiling::command_submit>() const {
   if (!MHostEvent) {
-    return get_event_profiling_info<info::event_profiling::command_submit>::get(
-        this->getHandleRef(), this->getPlugin());
+    if (MEvent)
+      return get_event_profiling_info<
+          info::event_profiling::command_submit>::get(this->getHandleRef(),
+                                                      this->getPlugin());
+    else
+      // TODO this should throw an exception if the queue the dummy event is
+      // bound to does not support profiling info.
+      return 0;
   }
   if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.",
@@ -239,8 +245,14 @@ template <>
 cl_ulong
 event_impl::get_profiling_info<info::event_profiling::command_start>() const {
   if (!MHostEvent) {
-    return get_event_profiling_info<info::event_profiling::command_start>::get(
-        this->getHandleRef(), this->getPlugin());
+    if (MEvent)
+      return get_event_profiling_info<
+          info::event_profiling::command_start>::get(this->getHandleRef(),
+                                                     this->getPlugin());
+    else
+      // TODO this should throw an exception if the queue the dummy event is
+      // bound to does not support profiling info.
+      return 0;
   }
   if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.",
@@ -252,8 +264,13 @@ template <>
 cl_ulong
 event_impl::get_profiling_info<info::event_profiling::command_end>() const {
   if (!MHostEvent) {
-    return get_event_profiling_info<info::event_profiling::command_end>::get(
-        this->getHandleRef(), this->getPlugin());
+    if (MEvent)
+      return get_event_profiling_info<info::event_profiling::command_end>::get(
+          this->getHandleRef(), this->getPlugin());
+    else
+      // TODO this should throw an exception if the queue the dummy event is
+      // bound to does not support profiling info.
+      return 0;
   }
   if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.",
@@ -262,7 +279,7 @@ event_impl::get_profiling_info<info::event_profiling::command_end>() const {
 }
 
 template <> cl_uint event_impl::get_info<info::event::reference_count>() const {
-  if (!MHostEvent) {
+  if (!MHostEvent && MEvent) {
     return get_event_info<info::event::reference_count>::get(
         this->getHandleRef(), this->getPlugin());
   }
@@ -272,7 +289,7 @@ template <> cl_uint event_impl::get_info<info::event::reference_count>() const {
 template <>
 info::event_command_status
 event_impl::get_info<info::event::command_execution_status>() const {
-  if (!MHostEvent) {
+  if (!MHostEvent && MEvent) {
     return get_event_info<info::event::command_execution_status>::get(
         this->getHandleRef(), this->getPlugin());
   }

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -230,10 +230,9 @@ event_impl::get_profiling_info<info::event_profiling::command_submit>() const {
       return get_event_profiling_info<
           info::event_profiling::command_submit>::get(this->getHandleRef(),
                                                       this->getPlugin());
-    else
-      // TODO this should throw an exception if the queue the dummy event is
-      // bound to does not support profiling info.
-      return 0;
+    // TODO this should throw an exception if the queue the dummy event is
+    // bound to does not support profiling info.
+    return 0;
   }
   if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.",
@@ -249,10 +248,9 @@ event_impl::get_profiling_info<info::event_profiling::command_start>() const {
       return get_event_profiling_info<
           info::event_profiling::command_start>::get(this->getHandleRef(),
                                                      this->getPlugin());
-    else
-      // TODO this should throw an exception if the queue the dummy event is
-      // bound to does not support profiling info.
-      return 0;
+    // TODO this should throw an exception if the queue the dummy event is
+    // bound to does not support profiling info.
+    return 0;
   }
   if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.",
@@ -267,10 +265,9 @@ event_impl::get_profiling_info<info::event_profiling::command_end>() const {
     if (MEvent)
       return get_event_profiling_info<info::event_profiling::command_end>::get(
           this->getHandleRef(), this->getPlugin());
-    else
-      // TODO this should throw an exception if the queue the dummy event is
-      // bound to does not support profiling info.
-      return 0;
+    // TODO this should throw an exception if the queue the dummy event is
+    // bound to does not support profiling info.
+    return 0;
   }
   if (!MHostProfilingInfo)
     throw invalid_object_error("Profiling info is not available.",


### PR DESCRIPTION
It's possible to obtain a non-host event without an encapsulated
pi_event, e.g. as a result of a USM operation on 0 bytes. Handle this
case in event information queries.