### PR TITLE
[SYCL] Add macro to disable range rounding for FPGA compilations

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1132,7 +1132,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     // Enable SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING macro for
     // all FPGA compilations.
     if (TI.getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
-      Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");
+      Builder.defineMacro("SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING", "1");
     }
 
     if (TI.getTriple().isNVPTX()) {

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1138,6 +1138,14 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
   if (LangOpts.SYCLUnnamedLambda)
     Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__", "1");
 
+  if (LangOpts.SYCLIsDevice) {
+    // Enable SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING macro for
+    // all FPGA compilations.
+    if (TI.getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
+      Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");
+    }
+  }
+
   // OpenCL definitions.
   if (LangOpts.OpenCL) {
     TI.getOpenCLFeatureDefines(LangOpts, Builder);

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1129,6 +1129,12 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     Builder.defineMacro("__SYCL_DEVICE_ONLY__", "1");
     Builder.defineMacro("SYCL_EXTERNAL", "__attribute__((sycl_device))");
 
+    // Enable SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING macro for
+    // all FPGA compilations.
+    if (TI.getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
+      Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");
+    }
+
     if (TI.getTriple().isNVPTX()) {
         Builder.defineMacro("__SYCL_NVPTX__", "1");
     }
@@ -1137,14 +1143,6 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     Builder.defineMacro("__SYCL_EXPLICIT_SIMD__", "1");
   if (LangOpts.SYCLUnnamedLambda)
     Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__", "1");
-
-  if (LangOpts.SYCLIsDevice) {
-    // Enable SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING macro for
-    // all FPGA compilations.
-    if (TI.getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
-      Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");
-    }
-  }
 
   // OpenCL definitions.
   if (LangOpts.OpenCL) {

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1129,7 +1129,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     Builder.defineMacro("__SYCL_DEVICE_ONLY__", "1");
     Builder.defineMacro("SYCL_EXTERNAL", "__attribute__((sycl_device))");
 
-    // Enable SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING macro for
+    // Enable __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
     // all FPGA compilations.
     if (TI.getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
       Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1132,7 +1132,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     // Enable SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING macro for
     // all FPGA compilations.
     if (TI.getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
-      Builder.defineMacro("SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING", "1");
+      Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");
     }
 
     if (TI.getTriple().isNVPTX()) {

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -220,6 +220,10 @@
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
 // CHECK-RANGE: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
 
+// RUN: %clang_cc1 %s -E -dM -fsycl-is-device -o - \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
+// CHECK-NO-RANGE-NOT: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
+
 // RUN: %clang_cc1 %s -E -dM -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
 // CHECK-NO-RANGE-NOT: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -214,3 +214,13 @@
 // CHECK-HIP-DEV: #define __HIPCC__ 1
 // CHECK-HIP-DEV: #define __HIP_DEVICE_COMPILE__ 1
 // CHECK-HIP-DEV: #define __HIP__ 1
+
+// RUN: %clang_cc1 %s -E -dM -triple spir64_fpga-unknown-unknown-sycldevice \
+// RUN: -o - \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
+// CHECK-RANGE: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
+
+// RUN: %clang_cc1 %s -E -dM -triple spir64_fpga-unknown-unknown-sycldevice \
+// RUN: -o - \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
+// CHECK-NO-RANGE-NOT: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -215,12 +215,11 @@
 // CHECK-HIP-DEV: #define __HIP_DEVICE_COMPILE__ 1
 // CHECK-HIP-DEV: #define __HIP__ 1
 
-// RUN: %clang_cc1 %s -E -dM -triple spir64_fpga-unknown-unknown-sycldevice \
-// RUN: -o - \
+// RUN: %clang_cc1 %s -E -dM -fsycl-is-device \
+// RUN:   -triple spir64_fpga-unknown-unknown-sycldevice -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
 // CHECK-RANGE: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
 
-// RUN: %clang_cc1 %s -E -dM -triple spir64_fpga-unknown-unknown-sycldevice \
-// RUN: -o - \
+// RUN: %clang_cc1 %s -E -dM -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
 // CHECK-NO-RANGE-NOT: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -218,7 +218,7 @@
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device \
 // RUN:   -triple spir64_fpga-unknown-unknown-sycldevice -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
-// CHECK-RANGE: #define SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING 1
+// CHECK-RANGE: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
 
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
@@ -226,4 +226,4 @@
 // RUN: %clang_cc1 %s -E -dM -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
 
-// CHECK-NO-RANGE-NOT: #define SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING 1
+// CHECK-NO-RANGE-NOT: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -218,7 +218,7 @@
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device \
 // RUN:   -triple spir64_fpga-unknown-unknown-sycldevice -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
-// CHECK-RANGE: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
+// CHECK-RANGE: #define SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING 1
 
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
@@ -226,4 +226,4 @@
 // RUN: %clang_cc1 %s -E -dM -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
 
-// CHECK-NO-RANGE-NOT: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
+// CHECK-NO-RANGE-NOT: #define SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING 1

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -222,8 +222,8 @@
 
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
-// CHECK-NO-RANGE-NOT: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
 
 // RUN: %clang_cc1 %s -E -dM -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
+
 // CHECK-NO-RANGE-NOT: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1


### PR DESCRIPTION
Set macro SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING for all FPGA compilations
to avoid emitting two versions of the kernel - one by default and another for parallel_for.

Signed-off-by: Soumi Manna soumi.manna@intel.com