### PR TITLE
[SYCL] Replace spec constants 2020 with RT-provided values in sycl-post-link

### DIFF
--- a/llvm/test/tools/sycl-post-link/composite-spec-constant-default-value.ll
+++ b/llvm/test/tools/sycl-post-link/composite-spec-constant-default-value.ll
@@ -1,5 +1,5 @@
 ; RUN: sycl-post-link -spec-const=default --ir-output-only %s -S -o - \
-; RUN: | FileCheck %s --implicit-check-not __sycl_getCompositeSpecConstantValue
+; RUN: | FileCheck %s --implicit-check-not __sycl_getCompositeSpecConstantValue --implicit-check-not __sycl_getComposite2020SpecConstantValue
 ;
 ; This test checks that composite specialization constants can be correctly
 ; initialized by sycl-post-link tool for AOT use-case (default initialization
@@ -24,8 +24,10 @@ target triple = "spir64-unknown-unknown-sycldevice"
 %"class._ZTSN2cl4sycl2idILi1EEE.cl::sycl::id" = type { %"class._ZTSN2cl4sycl6detail5arrayILi1EEE.cl::sycl::detail::array" }
 
 $_ZTS4Test = comdat any
+$_ZTS17SpecializedKernel = comdat any
 
 @__builtin_unique_stable_name._ZNK2cl4sycl6ONEAPI12experimental13spec_constantI3PODS4_E3getIS4_EENSt9enable_ifIXsr3std6is_podIT_EE5valueES8_E4typeEv = private unnamed_addr addrspace(1) constant [9 x i8] c"_ZTS3POD\00", align 1
+@__builtin_unique_stable_name._ZNK2cl4sycl6ONEAPI12experimental13spec_constantI13MyComposConstE3getIS4_EENSt9enable_ifIXaasr3std8is_classIT_EE5valuesr3std6is_podIS9_EE5valueES9_E4typeEv = private unnamed_addr addrspace(1) constant [20 x i8] c"_ZTS13MyComposConst\00", align 1
 
 ; Function Attrs: convergent norecurse uwtable
 define weak_odr dso_local spir_kernel void @_ZTS4Test(%struct._ZTS3POD.POD addrspace(1)* %_arg_, %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range"* byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_1, %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range"* byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_2, %"class._ZTSN2cl4sycl2idILi1EEE.cl::sycl::id"* byval(%"class._ZTSN2cl4sycl2idILi1EEE.cl::sycl::id") align 8 %_arg_3) local_unnamed_addr #0 comdat !kernel_arg_buffer_location !4 {
@@ -45,6 +47,35 @@ entry:
   ret void
 }
 
+; Function Attrs: convergent norecurse
+define weak_odr dso_local spir_kernel void @_ZTS17SpecializedKernel(float addrspace(1)* %_arg_, %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range"* byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_1, %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range"* byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_2, %"class._ZTSN2cl4sycl2idILi1EEE.cl::sycl::id"* byval(%"class._ZTSN2cl4sycl2idILi1EEE.cl::sycl::id") align 8 %_arg_3) local_unnamed_addr #0 comdat !kernel_arg_buffer_location !4 {
+entry:
+  %c.i = alloca %struct._ZTS1A.A, align 4
+  %0 = getelementptr inbounds %"class._ZTSN2cl4sycl2idILi1EEE.cl::sycl::id", %"class._ZTSN2cl4sycl2idILi1EEE.cl::sycl::id"* %_arg_3, i64 0, i32 0, i32 0, i64 0
+  %1 = addrspacecast i64* %0 to i64 addrspace(4)*
+  %2 = load i64, i64 addrspace(4)* %1, align 8
+  %add.ptr.i = getelementptr inbounds float, float addrspace(1)* %_arg_, i64 %2
+; CHECK: %[[CAST1:[0-9a-z.]+]] = addrspacecast %struct._ZTS1A.A* %c.i
+  %c.ascast.i = addrspacecast %struct._ZTS1A.A* %c.i to %struct._ZTS1A.A addrspace(4)*
+  %3 = bitcast %struct._ZTS1A.A* %c.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %3) #3
+  call spir_func void @_Z40__sycl_getComposite2020SpecConstantValueI13MyComposConstET_PKcPvS4_(%struct._ZTS1A.A addrspace(4)* sret(%struct._ZTS1A.A) align 4 %c.ascast.i, i8 addrspace(4)* getelementptr inbounds ([20 x i8], [20 x i8] addrspace(4)* addrspacecast ([20 x i8] addrspace(1)* @__builtin_unique_stable_name._ZNK2cl4sycl6ONEAPI12experimental13spec_constantI13MyComposConstE3getIS4_EENSt9enable_ifIXaasr3std8is_classIT_EE5valuesr3std6is_podIS9_EE5valueES9_E4typeEv to [20 x i8] addrspace(4)*), i64 0, i64 0), i8 addrspace(4)* null, i8 addrspace(4)* null) #4
+; CHECK: %[[GEP:[0-9a-z]+]] = getelementptr i8, i8 addrspace(4)* null, i32 0
+; CHECK: %[[BITCAST:[0-9a-z]+]] = bitcast i8 addrspace(4)* %[[GEP]] to %struct._ZTS1A.A addrspace(4)*
+; CHECK: %[[LOAD:[0-9a-z]+]] = load %struct._ZTS1A.A, %struct._ZTS1A.A addrspace(4)* %[[BITCAST]], align 4
+; CHECK: store %struct._ZTS1A.A %[[LOAD]], %struct._ZTS1A.A {{.*}}* %[[CAST1]]
+  %a.i = getelementptr inbounds %struct._ZTS1A.A, %struct._ZTS1A.A addrspace(4)* %c.ascast.i, i64 0, i32 0
+  %4 = load i32, i32 addrspace(4)* %a.i, align 4
+  %conv.i = sitofp i32 %4 to float
+  %b.i = getelementptr inbounds %struct._ZTS1A.A, %struct._ZTS1A.A addrspace(4)* %c.ascast.i, i64 0, i32 1
+  %5 = load float, float addrspace(4)* %b.i, align 4
+  %add.i = fadd float %5, %conv.i
+  %ptridx.ascast.i.i = addrspacecast float addrspace(1)* %add.ptr.i to float addrspace(4)*
+  store float %add.i, float addrspace(4)* %ptridx.ascast.i.i, align 4, !tbaa !11
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %3) #3
+  ret void
+}
+
 ; Function Attrs: argmemonly nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
 
@@ -56,6 +87,9 @@ declare void @llvm.memcpy.p4i8.p0i8.i64(i8 addrspace(4)* noalias nocapture write
 
 ; Function Attrs: convergent
 declare dso_local spir_func void @_Z36__sycl_getCompositeSpecConstantValueI3PODET_PKc(%struct._ZTS3POD.POD addrspace(4)* sret(%struct._ZTS3POD.POD) align 8, i8 addrspace(4)*) local_unnamed_addr #2
+
+; Function Attrs: convergent
+declare dso_local spir_func void @_Z40__sycl_getComposite2020SpecConstantValueI13MyComposConstET_PKcPvS4_(%struct._ZTS1A.A addrspace(4)* sret(%struct._ZTS1A.A) align 4, i8 addrspace(4)*, i8 addrspace(4)*, i8 addrspace(4)*) local_unnamed_addr #2
 
 attributes #0 = { convergent norecurse uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="../sycl/test/spec_const/composite.cpp" "tune-cpu"="generic" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { argmemonly nounwind willreturn }
@@ -77,3 +111,6 @@ attributes #4 = { convergent }
 !6 = !{!7, !7, i64 0}
 !7 = !{!"omnipotent char", !8, i64 0}
 !8 = !{!"Simple C++ TBAA"}
+!9 = !{!"int", !7, i64 0}
+!10 = !{!"float", !7, i64 0}
+!11 = !{!10, !10, i64 0}

--- a/llvm/test/tools/sycl-post-link/composite-spec-constant-default-value.ll
+++ b/llvm/test/tools/sycl-post-link/composite-spec-constant-default-value.ll
@@ -59,8 +59,11 @@ entry:
   %c.ascast.i = addrspacecast %struct._ZTS1A.A* %c.i to %struct._ZTS1A.A addrspace(4)*
   %3 = bitcast %struct._ZTS1A.A* %c.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %3) #3
-  call spir_func void @_Z40__sycl_getComposite2020SpecConstantValueI13MyComposConstET_PKcPvS4_(%struct._ZTS1A.A addrspace(4)* sret(%struct._ZTS1A.A) align 4 %c.ascast.i, i8 addrspace(4)* getelementptr inbounds ([20 x i8], [20 x i8] addrspace(4)* addrspacecast ([20 x i8] addrspace(1)* @__builtin_unique_stable_name._ZNK2cl4sycl6ONEAPI12experimental13spec_constantI13MyComposConstE3getIS4_EENSt9enable_ifIXaasr3std8is_classIT_EE5valuesr3std6is_podIS9_EE5valueES9_E4typeEv to [20 x i8] addrspace(4)*), i64 0, i64 0), i8 addrspace(4)* null, i8 addrspace(4)* null) #4
-; CHECK: %[[GEP:[0-9a-z]+]] = getelementptr i8, i8 addrspace(4)* null, i32 0
+  %a.i.i = alloca i32, align 4
+  %bc = bitcast i32* %a.i.i to i8*
+  %tmp = addrspacecast i8* %bc to i8 addrspace(4)*
+  call spir_func void @_Z40__sycl_getComposite2020SpecConstantValueI13MyComposConstET_PKcPvS4_(%struct._ZTS1A.A addrspace(4)* sret(%struct._ZTS1A.A) align 4 %c.ascast.i, i8 addrspace(4)* getelementptr inbounds ([20 x i8], [20 x i8] addrspace(4)* addrspacecast ([20 x i8] addrspace(1)* @__builtin_unique_stable_name._ZNK2cl4sycl6ONEAPI12experimental13spec_constantI13MyComposConstE3getIS4_EENSt9enable_ifIXaasr3std8is_classIT_EE5valuesr3std6is_podIS9_EE5valueES9_E4typeEv to [20 x i8] addrspace(4)*), i64 0, i64 0), i8 addrspace(4)* null, i8 addrspace(4)* %tmp) #4
+; CHECK: %[[GEP:[0-9a-z]+]] = getelementptr i8, i8 addrspace(4)* %tmp, i32 0
 ; CHECK: %[[BITCAST:[0-9a-z]+]] = bitcast i8 addrspace(4)* %[[GEP]] to %struct._ZTS1A.A addrspace(4)*
 ; CHECK: %[[LOAD:[0-9a-z]+]] = load %struct._ZTS1A.A, %struct._ZTS1A.A addrspace(4)* %[[BITCAST]], align 4
 ; CHECK: store %struct._ZTS1A.A %[[LOAD]], %struct._ZTS1A.A {{.*}}* %[[CAST1]]

--- a/llvm/test/tools/sycl-post-link/spec_const_2020.ll
+++ b/llvm/test/tools/sycl-post-link/spec_const_2020.ll
@@ -1,0 +1,41 @@
+; RUN: sycl-post-link --ir-output-only -spec-const=default %s -S -o - | \
+; RUN:   FileCheck %s -check-prefixes=CHECK,CHECK-DEF
+
+; This test checks that the post link tool is able to correctly transform
+; specialization constant intrinsics for different types in a device code
+; compiled for AOT.
+
+%class.specialization_id = type { double }
+%class.specialization_id.0 = type { i32 }
+
+@id_double = dso_local global %class.specialization_id { double 3.140000e+00 }, align 8
+@id_int = dso_local global %class.specialization_id.0 { i32 42 }, align 4
+; check that no longer used globals are removed:
+@__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_doubleE17specialization_idIdEdET1_v = private unnamed_addr constant [37 x i8] c"_ZTS14name_generatorIL_Z9id_doubleEE\00", align 1
+; CHECK-NOT: @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_doubleE17specialization_idIdEdET1_v
+@__builtin_unique_stable_name._Z27get_specialization_constantIL_Z6id_intE17specialization_idIiEiET1_v = private unnamed_addr constant [34 x i8] c"_ZTS14name_generatorIL_Z6id_intEE\00", align 1
+; CHECK-NOT: @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z6id_intE17specialization_idIiEiET1_v
+
+define dso_local void @_Z5test2v() local_unnamed_addr #0 {
+entry:
+  %call.i = tail call fast double @_Z37__sycl_getScalar2020SpecConstantValueIdET_PKcPvS3_(i8* getelementptr inbounds ([37 x i8], [37 x i8]* @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_doubleE17specialization_idIdEdET1_v, i64 0, i64 0), i8* bitcast (%class.specialization_id* @id_double to i8*), i8* null)
+; CHECK-DEF: %[[GEP:[0-9a-z]+]] = getelementptr i8, i8* null, i32 0
+; CHECK-DEF: %[[BITCAST:[0-9a-z]+]] = bitcast i8* %[[GEP]] to double*
+; CHECK-DEF: %[[LOAD:[0-9a-z]+]] = load double, double* %[[BITCAST]], align 8
+  %call.i3 = tail call i32 @_Z37__sycl_getScalar2020SpecConstantValueIiET_PKcPvS3_(i8* getelementptr inbounds ([34 x i8], [34 x i8]* @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z6id_intE17specialization_idIiEiET1_v, i64 0, i64 0), i8* bitcast (%class.specialization_id.0* @id_int to i8*), i8* null)
+; CHECK-DEF: %[[GEP1:[0-9a-z]+]] = getelementptr i8, i8* null, i32 8
+; CHECK-DEF: %[[BITCAST1:[0-9a-z]+]] = bitcast i8* %[[GEP1]] to i32*
+; CHECK-DEF: %[[LOAD1:[0-9a-z]+]] = load i32, i32* %[[BITCAST1]], align 4
+  %call.i4 = tail call fast double @_Z37__sycl_getScalar2020SpecConstantValueIdET_PKcPvS3_(i8* getelementptr inbounds ([37 x i8], [37 x i8]* @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_doubleE17specialization_idIdEdET1_v, i64 0, i64 0), i8* bitcast (%class.specialization_id* @id_double to i8*), i8* null)
+; CHECK-DEF: %[[GEP2:[0-9a-z]+]] = getelementptr i8, i8* null, i32 0
+; CHECK-DEF: %[[BITCAST2:[0-9a-z]+]] = bitcast i8* %[[GEP2]] to double*
+; CHECK-DEF: %[[LOAD2:[0-9a-z]+]] = load double, double* %[[BITCAST2]], align 8
+  ret void
+}
+
+declare dso_local double @_Z37__sycl_getScalar2020SpecConstantValueIdET_PKcPvS3_(i8*, i8*, i8*) local_unnamed_addr #1
+
+declare dso_local i32 @_Z37__sycl_getScalar2020SpecConstantValueIiET_PKcPvS3_(i8*, i8*, i8*) local_unnamed_addr #1
+
+attributes #0 = { uwtable mustprogress "denormal-fp-math"="preserve-sign,preserve-sign" "denormal-fp-math-f32"="ieee,ieee" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="true" "no-jump-tables"="false" "no-nans-fp-math"="true" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="true" "use-soft-float"="false" }
+attributes #1 = { "denormal-fp-math"="preserve-sign,preserve-sign" "denormal-fp-math-f32"="ieee,ieee" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="true" "no-nans-fp-math"="true" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="true" "use-soft-float"="false" }

--- a/llvm/test/tools/sycl-post-link/spec_const_2020.ll
+++ b/llvm/test/tools/sycl-post-link/spec_const_2020.ll
@@ -7,16 +7,28 @@
 
 %class.specialization_id = type { double }
 %class.specialization_id.0 = type { i32 }
+%class.specialization_id.1 = type { %struct.ComposConst }
+%struct.ComposConst = type { i32, double, %struct.myConst }
+%struct.myConst = type { i32, float }
+%class.specialization_id.2 = type { %struct.ComposConst2 }
+%struct.ComposConst2 = type { i8, %struct.myConst, double }
 
 @id_double = dso_local global %class.specialization_id { double 3.140000e+00 }, align 8
 @id_int = dso_local global %class.specialization_id.0 { i32 42 }, align 4
+@id_compos = dso_local global %class.specialization_id.1 { %struct.ComposConst { i32 1, double 2.000000e+00, %struct.myConst { i32 13, float 0x4020666660000000 } } }, align 8
+@id_compos2 = dso_local global %class.specialization_id.2 { %struct.ComposConst2 { i8 1, %struct.myConst { i32 52, float 0x40479999A0000000 }, double 2.000000e+00 } }, align 8
+
 ; check that no longer used globals are removed:
 @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_doubleE17specialization_idIdEdET1_v = private unnamed_addr constant [37 x i8] c"_ZTS14name_generatorIL_Z9id_doubleEE\00", align 1
 ; CHECK-NOT: @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_doubleE17specialization_idIdEdET1_v
 @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z6id_intE17specialization_idIiEiET1_v = private unnamed_addr constant [34 x i8] c"_ZTS14name_generatorIL_Z6id_intEE\00", align 1
 ; CHECK-NOT: @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z6id_intE17specialization_idIiEiET1_v
+@__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_composE17specialization_idI11ComposConstES1_ET1_v = private unnamed_addr constant [37 x i8] c"_ZTS14name_generatorIL_Z9id_composEE\00", align 1
+; CHECK-NOT: @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_composE17specialization_idI11ComposConstES1_ET1_v
+@__builtin_unique_stable_name._Z27get_specialization_constantIL_Z10id_compos2E17specialization_idI12ComposConst2ES1_ET1_v = private unnamed_addr constant [39 x i8] c"_ZTS14name_generatorIL_Z10id_compos2EE\00", align 1
+; CHECK-NOT: @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z10id_compos2E17specialization_idI12ComposConst2ES1_ET1_v
 
-define dso_local void @_Z5test2v() local_unnamed_addr #0 {
+define dso_local void @_Z4testv() local_unnamed_addr #0 {
 entry:
   %call.i = tail call fast double @_Z37__sycl_getScalar2020SpecConstantValueIdET_PKcPvS3_(i8* getelementptr inbounds ([37 x i8], [37 x i8]* @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_doubleE17specialization_idIdEdET1_v, i64 0, i64 0), i8* bitcast (%class.specialization_id* @id_double to i8*), i8* null)
 ; CHECK-DEF: %[[GEP:[0-9a-z]+]] = getelementptr i8, i8* null, i32 0
@@ -33,9 +45,49 @@ entry:
   ret void
 }
 
+define dso_local void @_Z5test2v() local_unnamed_addr #0 {
+entry:
+  %tmp = alloca %struct.ComposConst, align 8
+  %tmp1 = alloca %struct.ComposConst2, align 8
+  %tmp2 = alloca %struct.ComposConst, align 8
+  %0 = bitcast %struct.ComposConst* %tmp to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %0) #3
+  call void @_Z40__sycl_getComposite2020SpecConstantValueI11ComposConstET_PKcPvS4_(%struct.ComposConst* nonnull sret(%struct.ComposConst) align 8 %tmp, i8* getelementptr inbounds ([37 x i8], [37 x i8]* @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_composE17specialization_idI11ComposConstES1_ET1_v, i64 0, i64 0), i8* bitcast (%class.specialization_id.1* @id_compos to i8*), i8* null)
+; CHECK: %[[GEP:[0-9a-z]+]] = getelementptr i8, i8* null, i32 12
+; CHECK: %[[BITCAST:[0-9a-z]+]] = bitcast i8* %[[GEP]] to %struct.ComposConst*
+; CHECK: %[[LOAD:[0-9a-z]+]] = load %struct.ComposConst, %struct.ComposConst* %[[BITCAST]], align 8
+; CHECK: store %struct.ComposConst %[[LOAD]], %struct.ComposConst*
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %0) #3
+  %1 = getelementptr inbounds %struct.ComposConst2, %struct.ComposConst2* %tmp1, i64 0, i32 0
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %1) #3
+  call void @_Z40__sycl_getComposite2020SpecConstantValueI12ComposConst2ET_PKcPvS4_(%struct.ComposConst2* nonnull sret(%struct.ComposConst2) align 8 %tmp1, i8* getelementptr inbounds ([39 x i8], [39 x i8]* @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z10id_compos2E17specialization_idI12ComposConst2ES1_ET1_v, i64 0, i64 0), i8* getelementptr inbounds (%class.specialization_id.2, %class.specialization_id.2* @id_compos2, i64 0, i32 0, i32 0), i8* null)  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %1) #3
+; CHECK: %[[GEP1:[0-9a-z]+]] = getelementptr i8, i8* null, i32 36
+; CHECK: %[[BITCAST1:[0-9a-z]+]] = bitcast i8* %[[GEP1]] to %struct.ComposConst2*
+; CHECK: %[[LOAD1:[0-9a-z]+]] = load %struct.ComposConst2, %struct.ComposConst2* %[[BITCAST1]], align 8
+; CHECK: store %struct.ComposConst2 %[[LOAD1]], %struct.ComposConst2*
+  %2 = bitcast %struct.ComposConst* %tmp2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %2) #3
+  call void @_Z40__sycl_getComposite2020SpecConstantValueI11ComposConstET_PKcPvS4_(%struct.ComposConst* nonnull sret(%struct.ComposConst) align 8 %tmp2, i8* getelementptr inbounds ([37 x i8], [37 x i8]* @__builtin_unique_stable_name._Z27get_specialization_constantIL_Z9id_composE17specialization_idI11ComposConstES1_ET1_v, i64 0, i64 0), i8* bitcast (%class.specialization_id.1* @id_compos to i8*), i8* null)
+; CHECK: %[[GEP2:[0-9a-z]+]] = getelementptr i8, i8* null, i32 12
+; CHECK: %[[BITCAST2:[0-9a-z]+]] = bitcast i8* %[[GEP2]] to %struct.ComposConst*
+; CHECK: %[[LOAD2:[0-9a-z]+]] = load %struct.ComposConst, %struct.ComposConst* %[[BITCAST2]], align 8
+; CHECK: store %struct.ComposConst %[[LOAD2]], %struct.ComposConst*
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %2) #3
+  ret void
+}
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
 declare dso_local double @_Z37__sycl_getScalar2020SpecConstantValueIdET_PKcPvS3_(i8*, i8*, i8*) local_unnamed_addr #1
 
 declare dso_local i32 @_Z37__sycl_getScalar2020SpecConstantValueIiET_PKcPvS3_(i8*, i8*, i8*) local_unnamed_addr #1
 
+declare dso_local void @_Z40__sycl_getComposite2020SpecConstantValueI11ComposConstET_PKcPvS4_(%struct.ComposConst* sret(%struct.ComposConst) align 8, i8*, i8*, i8*) local_unnamed_addr #2
+
+declare dso_local void @_Z40__sycl_getComposite2020SpecConstantValueI12ComposConst2ET_PKcPvS4_(%struct.ComposConst2* sret(%struct.ComposConst2) align 8, i8*, i8*, i8*) local_unnamed_addr #2
+
 attributes #0 = { uwtable mustprogress "denormal-fp-math"="preserve-sign,preserve-sign" "denormal-fp-math-f32"="ieee,ieee" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="true" "no-jump-tables"="false" "no-nans-fp-math"="true" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="true" "use-soft-float"="false" }
-attributes #1 = { "denormal-fp-math"="preserve-sign,preserve-sign" "denormal-fp-math-f32"="ieee,ieee" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="true" "no-nans-fp-math"="true" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="true" "use-soft-float"="false" }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { "denormal-fp-math"="preserve-sign,preserve-sign" "denormal-fp-math-f32"="ieee,ieee" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="true" "no-nans-fp-math"="true" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="true" "use-soft-float"="false" }
+attributes #3 = { nounwind }

--- a/llvm/test/tools/sycl-post-link/spec_const_O2.ll
+++ b/llvm/test/tools/sycl-post-link/spec_const_O2.ll
@@ -116,7 +116,10 @@ define weak_odr dso_local spir_kernel void @_ZTS17SpecializedKernel(float addrsp
   %37 = tail call spir_func double @_Z37__sycl_getScalar2020SpecConstantValueIdET_PKcPvS3_(i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([21 x i8], [21 x i8]* @__unique_stable_name.SC_Id14MyDoubleConst2E3getEv, i64 0, i64 0) to i8 addrspace(4)*), i8 addrspace(4)* null, i8 addrspace(4)* null)
 ; CHECK-RT: %{{[0-9]+}} = call double @_Z20__spirv_SpecConstantid(i32 11, double 0.000000e+00), !SYCL_SPEC_CONST_SYM_ID ![[ID11:[0-9]+]]
   %38 = fadd double %37, %36
-; CHECK-DEF: %[[SUM10:[0-9]+]] = fadd double 0.000000e+00, %[[SUM9]]
+; CHECK-DEF: %[[GEP:[0-9a-z]+]] = getelementptr i8, i8 addrspace(4)* null, i32 0
+; CHECK-DEF: %[[BITCAST:[0-9a-z]+]] = bitcast i8 addrspace(4)* %[[GEP]] to double addrspace(4)*
+; CHECK-DEF: %[[LOAD:[0-9a-z]+]] = load double, double addrspace(4)* %[[BITCAST]], align 8
+; CHECK-DEF: %[[SUM10:[0-9]+]] = fadd double %[[LOAD]], %[[SUM9]]
   %39 = fptrunc double %38 to float
 ; CHECK-DEF: %[[VAL8:[0-9]+]] = fptrunc double %[[SUM10]] to float
   %40 = addrspacecast float addrspace(1)* %7 to float addrspace(4)*

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -426,7 +426,7 @@ Instruction *emitSpecConstantRecursive(Type *Ty, Instruction *InsertBefore,
 PreservedAnalyses SpecConstantsPass::run(Module &M,
                                          ModuleAnalysisManager &MAM) {
   unsigned NextID = 0;
-  unsigned Offset = 0;
+  unsigned NextOffset = 0;
   StringMap<SmallVector<unsigned, 1>> IDMap;
   StringMap<unsigned> OffsetMap;
 
@@ -525,7 +525,7 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
       } else {
         // 2a. Spec constant must be resolved at compile time - replace the
         // intrinsic with the actual value for spec constant.
-
+        Value *Val = nullptr;
         bool Is2020Intrinsic =
             F.getName().startswith(SYCL_GET_SCALAR_2020_SPEC_CONST_VAL) ||
             F.getName().startswith(SYCL_GET_COMPOSITE_2020_SPEC_CONST_VAL);
@@ -541,7 +541,7 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
           // Add the string literal to a "spec const string literal ID" ->
           // "offset" map, uniquing the integer offsets if this is new
           // literal.
-          auto Ins = OffsetMap.insert(std::make_pair(SymID, Offset));
+          auto Ins = OffsetMap.insert(std::make_pair(SymID, NextOffset));
           bool IsNewSpecConstant = Ins.second;
           auto CurrentOffset = Ins.first->second;
           if (IsNewSpecConstant) {
@@ -555,46 +555,35 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
                   CI->getArgOperand(0)->getType()->getPointerElementType());
               const StructLayout *SL =
                   M.getDataLayout().getStructLayout(StructTy);
-              Offset += SL->getSizeInBytes();
+              NextOffset += SL->getSizeInBytes();
             } else
-              Offset += SCTy->getScalarSizeInBits() / __CHAR_BIT__;
+              NextOffset += SCTy->getScalarSizeInBits() / CHAR_BIT;
           }
 
           Type *Int8Ty = Type::getInt8Ty(CI->getContext());
           Type *Int32Ty = Type::getInt32Ty(CI->getContext());
           GetElementPtrInst *GEP = GetElementPtrInst::Create(
               Int8Ty, RTBuffer,
-              {ConstantInt::get(Int32Ty, CurrentOffset, false)}, "gep",
-              CI->getNextNode());
+              {ConstantInt::get(Int32Ty, CurrentOffset, false)}, "gep", CI);
 
           BitCastInst *BitCast = new BitCastInst(
-              GEP, PointerType::get(SCTy, GEP->getAddressSpace()), "bc",
-              GEP->getNextNode());
+              GEP, PointerType::get(SCTy, GEP->getAddressSpace()), "bc", CI);
 
-          LoadInst *Load =
-              new LoadInst(SCTy, BitCast, "load", BitCast->getNextNode());
-
-          if (IsComposite) {
-            // __sycl_getCompositeSpecConstant returns through argument, so, the
-            // only thing we need to do here is to store into a memory pointed
-            // by that argument
-            new StoreInst(Load, CI->getArgOperand(0), Load->getNextNode());
-          } else {
-            CI->replaceAllUsesWith(Load);
-          }
+          LoadInst *Load = new LoadInst(SCTy, BitCast, "load", CI);
+          Val = Load;
         } else {
           // Replace the intrinsic with default C++ value for the spec constant
           // type.
-          Value *Default = getDefaultCPPValue(SCTy);
+          Val = getDefaultCPPValue(SCTy);
+        }
           if (IsComposite) {
             // __sycl_getCompositeSpecConstant returns through argument, so, the
             // only thing we need to do here is to store into a memory pointed
             // by that argument
-            new StoreInst(Default, CI->getArgOperand(0), CI);
+            new StoreInst(Val, CI->getArgOperand(0), CI);
           } else {
-            CI->replaceAllUsesWith(Default);
+            CI->replaceAllUsesWith(Val);
           }
-        }
       }
 
       for (auto *I : DelInsts) {

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -426,7 +426,9 @@ Instruction *emitSpecConstantRecursive(Type *Ty, Instruction *InsertBefore,
 PreservedAnalyses SpecConstantsPass::run(Module &M,
                                          ModuleAnalysisManager &MAM) {
   unsigned NextID = 0;
+  unsigned Offset = 0;
   StringMap<SmallVector<unsigned, 1>> IDMap;
+  StringMap<unsigned> OffsetMap;
 
   // Iterate through all declarations of instances of function template
   // template <typename T> T __sycl_getSpecConstantValue(const char *ID)
@@ -521,16 +523,61 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
         //          %1, i32 %2), !SYCL_SPEC_CONST_SYM_ID !23
         // !23 = {!"string-id-2", i32 3, i32 4}
       } else {
-        // 2a. Spec constant must be resolved at compile time - just replace
-        // the intrinsic with default C++ value for the spec constant type.
-        Value *Default = getDefaultCPPValue(SCTy);
-        if (IsComposite) {
-          // __sycl_getCompositeSpecConstant returns through argument, so, the
-          // only thing we need to do here is to store into a memory pointed by
-          // that argument
-          new StoreInst(Default, CI->getArgOperand(0), CI);
+        // 2a. Spec constant must be resolved at compile time - replace the
+        // intrinsic with the actual value for spec constant.
+
+        bool Is2020Intrinsic =
+            F.getName().startswith(SYCL_GET_SCALAR_2020_SPEC_CONST_VAL) ||
+            F.getName().startswith(SYCL_GET_COMPOSITE_2020_SPEC_CONST_VAL);
+
+        if (Is2020Intrinsic) {
+          // Handle SYCL2020 version of intrinsic - replace it with a pointer to
+          // specialization constant value.
+          // A pointer to a single RT-buffer with all the values of
+          // specialization constants is passed as a 3rd argument of intrinsic.
+          if (IsComposite) {
+
+          } else {
+            Type *Int8Ty = Type::getInt8Ty(CI->getContext());
+            Type *Int32Ty = Type::getInt32Ty(CI->getContext());
+            Value *RTBuffer = CI->getArgOperand(2);
+
+            // Add the string literal to a "spec const string literal ID" ->
+            // "offset" map, uniquing the integer offsets if this is new
+            // literal.
+            auto Ins = OffsetMap.insert(std::make_pair(SymID, Offset));
+            bool IsNewSpecConstant = Ins.second;
+            auto CurrentOffset = Ins.first->second;
+            if (IsNewSpecConstant) {
+              Offset += SCTy->getScalarSizeInBits() / __CHAR_BIT__;
+            }
+
+            GetElementPtrInst *GEP = GetElementPtrInst::Create(
+                Int8Ty, RTBuffer,
+                {ConstantInt::get(Int32Ty, CurrentOffset, false)}, "gep",
+                CI->getNextNode());
+
+            BitCastInst *BitCast = new BitCastInst(
+                GEP, PointerType::get(SCTy, GEP->getAddressSpace()), "bc",
+                GEP->getNextNode());
+
+            LoadInst *Load =
+                new LoadInst(SCTy, BitCast, "load", BitCast->getNextNode());
+
+            CI->replaceAllUsesWith(Load);
+          }
         } else {
-          CI->replaceAllUsesWith(Default);
+          // Replace the intrinsic with default C++ value for the spec constant
+          // type.
+          Value *Default = getDefaultCPPValue(SCTy);
+          if (IsComposite) {
+            // __sycl_getCompositeSpecConstant returns through argument, so, the
+            // only thing we need to do here is to store into a memory pointed
+            // by that argument
+            new StoreInst(Default, CI->getArgOperand(0), CI);
+          } else {
+            CI->replaceAllUsesWith(Default);
+          }
         }
       }
 

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -576,14 +576,15 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
           // type.
           Val = getDefaultCPPValue(SCTy);
         }
-          if (IsComposite) {
-            // __sycl_getCompositeSpecConstant returns through argument, so, the
-            // only thing we need to do here is to store into a memory pointed
-            // by that argument
-            new StoreInst(Val, CI->getArgOperand(0), CI);
-          } else {
-            CI->replaceAllUsesWith(Val);
-          }
+
+        if (IsComposite) {
+          // __sycl_getCompositeSpecConstant returns through argument, so, the
+          // only thing we need to do here is to store into a memory pointed
+          // by that argument
+          new StoreInst(Val, CI->getArgOperand(0), CI);
+        } else {
+          CI->replaceAllUsesWith(Val);
+        }
       }
 
       for (auto *I : DelInsts) {

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -531,8 +531,8 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
             F.getName().startswith(SYCL_GET_COMPOSITE_2020_SPEC_CONST_VAL);
 
         if (Is2020Intrinsic) {
-          // Handle SYCL2020 version of intrinsic - replace it with a pointer to
-          // specialization constant value.
+          // Handle SYCL2020 version of intrinsic - replace it with a load from
+          // the pointer to the specialization constant value.
           // A pointer to a single RT-buffer with all the values of
           // specialization constants is passed as a 3rd argument of intrinsic.
           Value *RTBuffer =
@@ -553,6 +553,8 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
               // padded in order to ensure particular alignment of its elements.
               auto *StructTy = cast<StructType>(
                   CI->getArgOperand(0)->getType()->getPointerElementType());
+              // We rely on the fact that the StructLayout of spec constant RT
+              // values is the same for the host and the device.
               const StructLayout *SL =
                   M.getDataLayout().getStructLayout(StructTy);
               NextOffset += SL->getSizeInBytes();


### PR DESCRIPTION
By doing this change, SpecConstantsPass starts to replace scalar specialization
constants with a user-provided value from RT (instead of using C++ default
initialization value) for AOT mode.

This is done with the new intrinsic __sycl_getScalar2020SpecConstantValue:
the 3rd argument `RTBuffer` is a pointer to a runtime buffer, which holds
values of all specialization constants.