### PR TITLE
[SYCL] Fix build error on Windows caused by wrong usage of std::uniqu…

### DIFF
--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -93,7 +93,8 @@ public:
                 return detail::getSyclObjImpl(LHS) <
                        detail::getSyclObjImpl(RHS);
               });
-    std::unique(Result.begin(), Result.end());
+    auto LastIt = std::unique(Result.begin(), Result.end());
+    Result.erase(LastIt, Result.end());
 
     return Result;
   }


### PR DESCRIPTION
…eue()

Discarding the return of std::uniqueue causes warning (treated as an error)
during the build process. Also, not removing the tail after calling
std::uniqueue() may cause runtime errors as the values in the tail
are undefined.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>