### PR TITLE
[ESIMD] Honor noinline attribute in LowerESIMD pass

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -1263,6 +1263,7 @@ size_t SYCLLowerESIMDPass::runOnFunction(Function &F,
   // limitation, mark every function called from ESIMD kernel with
   // 'alwaysinline' attribute.
   if ((F.getCallingConv() != CallingConv::SPIR_KERNEL) &&
+      !F.hasFnAttribute(Attribute::NoInline) &&
       !F.hasFnAttribute(Attribute::AlwaysInline))
     F.addFnAttr(Attribute::AlwaysInline);
 

--- a/llvm/test/SYCLLowerIR/esimd_lower_inline_hint.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_inline_hint.ll
@@ -2,6 +2,7 @@
 
 ; This test checks that LowerESIMD pass sets the 'alwaysinline'
 ; attribute for all non-kernel functions.
+; If the function already has noinline attribute -- honor that.
 
 define spir_kernel void @EsimdKernel1() {
 ; CHECK: @EsimdKernel1(
@@ -15,25 +16,36 @@ define spir_kernel void @EsimdKernel1() {
 define spir_kernel void @EsimdKernel2() {
 ; CHECK: @EsimdKernel2(
 ; CHECK-NEXT:    call void @foobar()
+; CHECK-NEXT:    call void @noinline_func()
   call void @foobar()
+  call void @noinline_func()
   ret void
 }
 
 define spir_func void @foo() {
-; CHECK: @foo() #[[ATTR:[0-9]+]]
+; CHECK: @foo() #[[ATTR_INL:[0-9]+]]
   ret void
 }
 
 define spir_func void @bar() {
-; CHECK: @bar() #[[ATTR]]
+; CHECK: @bar() #[[ATTR_INL]]
 ; CHECK-NEXT:    call void @foobar
+; CHECK-NEXT:    call void @noinline_func()
   call void @foobar()
+  call void @noinline_func()
   ret void
 }
 
 define spir_func void @foobar() {
-; CHECK: @foobar() #[[ATTR]]
+; CHECK: @foobar() #[[ATTR_INL]]
   ret void
 }
 
-; CHECK: attributes #[[ATTR]] = { alwaysinline }
+define spir_func void @noinline_func() #0 {
+; CHECK: @noinline_func() #[[ATTR_NOINL:[0-9]+]] {
+  ret void
+}
+
+attributes #0 = { noinline }
+; CHECK-DAG: attributes #[[ATTR_INL]] = { alwaysinline }
+; CHECK-DAG: attributes #[[ATTR_NOINL]] = { noinline }

--- a/sycl/test/esimd/vadd.cpp
+++ b/sycl/test/esimd/vadd.cpp
@@ -2,6 +2,10 @@
 // RUN: %clangxx -I %sycl_include %s -o %t.out -lsycl
 // RUN: %RUN_ON_HOST %t.out
 
+// Check that the code compiles with -O0 and -g
+// RUN: %clangxx -I %sycl_include %s -o %t.out -fsycl -fsycl-explicit-simd -O0
+// RUN: %clangxx -I %sycl_include %s -o %t.out -fsycl -fsycl-explicit-simd -O0 -g
+
 #include <CL/sycl.hpp>
 #include <CL/sycl/INTEL/esimd.hpp>
 #include <iostream>


### PR DESCRIPTION
This patch supports both `-O0` mode, when `noinline` attribute is added automatically by the compiler, as well as the case when a user manually added `__attribute__((noinline))` attribute to a function.