### PR TITLE
[ESIMD] Let ESIMD attributes not depend on -fsycl-explicit-simd

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -337,7 +337,6 @@ def SYCL : LangOpt<"SYCL">;
 def SYCLIsDevice : LangOpt<"SYCLIsDevice">;
 def SYCLIsHost : LangOpt<"SYCLIsHost">;
 def SilentlyIgnoreSYCLIsHost : LangOpt<"SYCLIsHost", "", 1>;
-def SYCLExplicitSIMD : LangOpt<"SYCLExplicitSIMD">;
 def COnly : LangOpt<"", "!LangOpts.CPlusPlus">;
 def CPlusPlus : LangOpt<"CPlusPlus">;
 def OpenCL : LangOpt<"OpenCL">;
@@ -1192,7 +1191,6 @@ def SYCLSimd : InheritableAttr {
   let Spellings = [GNU<"sycl_explicit_simd">,
                    CXX11<"intel", "sycl_explicit_simd">];
   let Subjects = SubjectList<[Function, GlobalVar]>;
-  let LangOpts = [SYCLExplicitSIMD];
   let Documentation = [SYCLSimdDocs];
   let SupportsNonconformingLambdaSyntax = 1;
 }
@@ -1205,7 +1203,6 @@ def SYCLRegisterNum : InheritableAttr {
   let Subjects = SubjectList<[GlobalVar]>;
   // This attribute is applied to file-scope variables and must be compilable
   // for the host device as well
-  let LangOpts = [SYCLExplicitSIMD];
   let Documentation = [SYCLRegisterNumDocs];
 }
 
@@ -1218,7 +1215,6 @@ def SYCLSimdAccessorPtr : InheritableAttr {
   // No spelling, as this attribute can't be created in the source code.
   let Spellings = [];
   let Subjects = SubjectList<[ParmVar]>;
-  let LangOpts = [SYCLExplicitSIMD];
   let Documentation = [Undocumented];
 }
 

--- a/clang/test/CodeGenSYCL/esimd-accessor-ptr-md.cpp
+++ b/clang/test/CodeGenSYCL/esimd-accessor-ptr-md.cpp
@@ -3,7 +3,7 @@
 // separate. So, we can split this test into 2, where one
 // will be testing code generation and the second ESIMD lowering.
 //
-// RUN: %clang_cc1 -fsycl-explicit-simd -fsycl-is-device \
+// RUN: %clang_cc1 -fsycl-is-device \
 // RUN:   -internal-isystem %S/Inputs -triple spir64-unknown-unknown-sycldevice \
 // RUN:   -disable-llvm-passes -emit-llvm %s -o %t
 // RUN: sycl-post-link -split-esimd -lower-esimd -O0 -S %t -o %t.table

--- a/clang/test/CodeGenSYCL/esimd-private-global.cpp
+++ b/clang/test/CodeGenSYCL/esimd-private-global.cpp
@@ -4,7 +4,7 @@
 // will be testing code generation and the second ESIMD lowering.
 //
 // RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice \
-// RUN:   -fsycl-is-device -fsycl-explicit-simd -emit-llvm %s -o %t
+// RUN:   -fsycl-is-device -emit-llvm %s -o %t
 // RUN: sycl-post-link -split-esimd -lower-esimd -O0 -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll
 

--- a/clang/test/CodeGenSYCL/esimd_metadata1.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata1.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice \
-// RUN:   -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | \
+// RUN:   -fsycl-is-device -S -emit-llvm %s -o - | \
 // RUN:   FileCheck %s
 
 // The test checks that:

--- a/clang/test/CodeGenSYCL/esimd_metadata2.cpp
+++ b/clang/test/CodeGenSYCL/esimd_metadata2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -fsycl-explicit-simd -S -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-ESIMD
+// RUN: %clang_cc1 -disable-llvm-passes -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -S -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-ESIMD
 
 // This test checks that attribute !intel_reqd_sub_group_size !1
 // is added for kernels with !sycl_explicit_simd

--- a/clang/test/CodeGenSYCL/int_header_esimd.cpp
+++ b/clang/test/CodeGenSYCL/int_header_esimd.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-explicit-simd -fsycl-is-device -internal-isystem %S/Inputs -fsycl-int-header=%t.h %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsycl-int-header=%t.h %s
 // RUN: FileCheck -input-file=%t.h %s
 
 // This test checks that

--- a/clang/test/SemaSYCL/esimd-private-glob.cpp
+++ b/clang/test/SemaSYCL/esimd-private-glob.cpp
@@ -1,3 +1,3 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 // expected-no-diagnostics
 int x = 0;

--- a/clang/test/SemaSYCL/esimd-private-global.cpp
+++ b/clang/test/SemaSYCL/esimd-private-global.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 // This test checks specifics of semantic analysis of ESIMD private globals
 

--- a/clang/test/SemaSYCL/sycl-esimd.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsycl-explicit-simd -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s
 
 // This test checks specifics of semantic analysis of ESIMD kernels.
 


### PR DESCRIPTION
This is one of the final patches to support mixing SYCL and ESIMD kernels.
In the end, we want to get rid of `-fsycl-explicit-simd` option and unify the two modes: regular SYCL and ESIMD.
This patch eliminates one of the dependencies on the `-fsycl-explicit-simd` flag, allowing to use ESIMD attributes without it.