### PR TITLE
[CI] Temporarily switch back to Clang 12 for post-commit

### DIFF
--- a/.github/workflows/linux_post_commit.yml
+++ b/.github/workflows/linux_post_commit.yml
@@ -27,12 +27,12 @@ jobs:
                  ;;
              SharedLibs)
                  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-                 sudo add-apt-repository "deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic main"
+                 sudo add-apt-repository "deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic-12 main"
                  sudo apt-get update
-                 sudo apt-get install -y clang-13
+                 sudo apt-get install -y clang-12
                  export ARGS="--shared-libs"
-                 export CC="clang-13"
-                 export CXX="clang++-13"
+                 export CC="clang-12"
+                 export CXX="clang++-12"
                  ;;
              NoAssertions)
                  export ARGS="--no-assertions"


### PR DESCRIPTION
Latest clang-13 builds have trouble with self-build. See https://github.com/intel/llvm/issues/3453