### PR TITLE
[ESIMD] Fixed in-tree vadd test

### DIFF
--- a/sycl/test/esimd/vadd.cpp
+++ b/sycl/test/esimd/vadd.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-explicit-simd %s -o %t.out
 // RUN: %RUN_ON_HOST %t.out
 
 // Check that the code compiles with -O0 and -g


### PR DESCRIPTION
This patch fixes a regression introduced in #2501.
Currently, we still require `-fsycl-explicit-simd` option to compile ESIMD tests.