### PR TITLE
[SYCL][NFC] Set max number of data-less properties to 32

### DIFF
--- a/sycl/include/CL/sycl/detail/property_helper.hpp
+++ b/sycl/include/CL/sycl/detail/property_helper.hpp
@@ -32,7 +32,8 @@ enum DataLessPropKind {
   BufferUsePinnedHostMemory = 5,
   UsePrimaryContext = 6,
   InitializeToIdentity = 7,
-  DataLessPropKindSize = 8
+  // Exceeding 32 may cause ABI breaking change on some of OSes.
+  DataLessPropKindSize = 32
 };
 
 // List of all properties with data IDs

--- a/sycl/include/CL/sycl/detail/property_helper.hpp
+++ b/sycl/include/CL/sycl/detail/property_helper.hpp
@@ -32,6 +32,8 @@ enum DataLessPropKind {
   BufferUsePinnedHostMemory = 5,
   UsePrimaryContext = 6,
   InitializeToIdentity = 7,
+  // Indicates the last known dataless property.
+  LastKnownDataLessPropKind = 7,
   // Exceeding 32 may cause ABI breaking change on some of OSes.
   DataLessPropKindSize = 32
 };

--- a/sycl/include/CL/sycl/detail/property_list_base.hpp
+++ b/sycl/include/CL/sycl/detail/property_list_base.hpp
@@ -62,7 +62,7 @@ protected:
       std::is_base_of<DataLessPropertyBase, PropT>::value, bool>
   has_property_helper() const {
     const int PropKind = static_cast<int>(PropT::getKind());
-    if (PropKind >= detail::DataLessPropKind::DataLessPropKindSize)
+    if (PropKind > detail::DataLessPropKind::LastKnownDataLessPropKind)
       return false;
     return MDataLessProps[PropKind];
   }

--- a/sycl/test/abi/layout_buffer.cpp
+++ b/sycl/test/abi/layout_buffer.cpp
@@ -28,7 +28,7 @@ void foo(sycl::buffer<int, 2>) {}
 // CHECK-NEXT:  24 |                 class sycl::detail::SYCLMemObjAllocator * _M_head_impl
 // CHECK-NEXT:  32 |     class sycl::property_list MProps
 // CHECK-NEXT:  32 |       class sycl::detail::PropertyListBase (base)
-// CHECK-NEXT:  32 |         class std::bitset<8> MDataLessProps
+// CHECK-NEXT:  32 |         class std::bitset<32> MDataLessProps
 // CHECK-NEXT:  32 |           struct std::_Base_bitset<1> (base)
 // CHECK-NEXT:  32 |             std::_Base_bitset<1>::_WordT _M_w
 // CHECK-NEXT:  40 |         class std::vector<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > MPropsWithData

--- a/sycl/test/abi/layout_image.cpp
+++ b/sycl/test/abi/layout_image.cpp
@@ -29,7 +29,7 @@ sycl::image<2> Img{sycl::image_channel_order::rgba, sycl::image_channel_type::fp
 // CHECK-NEXT: 24 |                 class sycl::detail::SYCLMemObjAllocator * _M_head_impl
 // CHECK-NEXT: 32 |     class sycl::property_list MProps
 // CHECK-NEXT: 32 |       class sycl::detail::PropertyListBase (base)
-// CHECK-NEXT: 32 |         class std::bitset<8> MDataLessProps
+// CHECK-NEXT: 32 |         class std::bitset<32> MDataLessProps
 // CHECK-NEXT: 32 |           struct std::_Base_bitset<1> (base)
 // CHECK-NEXT: 32 |             std::_Base_bitset<1>::_WordT _M_w
 // CHECK-NEXT: 40 |         class std::vector<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > MPropsWithData


### PR DESCRIPTION
Linux reserves 8 bytes and Windows reserves 4 bytes as a minimum to
hold std::bitset. Thus, having more than 32 data-less properties,
i.e. exceeding 32-bits on Windows, will cause ABI breaking change.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>