### PR TITLE
[SYCL][ESIMD] Temp w/a for ESIMD BE: filter out @llvm.assume.

### DIFF
--- a/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
@@ -308,6 +308,18 @@ define dso_local spir_func <16 x i32>  @FUNC_44() {
   ret <16 x i32>  %ret_val
 }
 
+; TODO LowerESIMD.cpp temporarily removes @llvm.assume, this test checks this.
+; Remove once @llvm.assume is allowed in the ESIMD BE.
+define dso_local spir_func void  @FUNC_45() {
+; CHECK-LABEL: FUNC_45
+  call void @llvm.assume(i1 1)
+; CHECK-NOT: @llvm.assume
+  ret void
+}
+; CHECK-LABEL: }
+
+declare void @llvm.assume(i1 noundef)
+
 declare dso_local spir_func <32 x i32> @_Z20__esimd_flat_atomic0ILN2cm3gen14CmAtomicOpTypeE2EjLi32ELNS1_9CacheHintE0ELS3_0EENS1_13__vector_typeIT0_XT1_EE4typeENS4_IyXT1_EE4typeENS4_ItXT1_EE4typeE(<32 x i64> %0, <32 x i16> %1)
 declare dso_local spir_func <32 x i32> @_Z20__esimd_flat_atomic1ILN2cm3gen14CmAtomicOpTypeE0EjLi32ELNS1_9CacheHintE0ELS3_0EENS1_13__vector_typeIT0_XT1_EE4typeENS4_IyXT1_EE4typeES7_NS4_ItXT1_EE4typeE(<32 x i64> %0, <32 x i32> %1, <32 x i16> %2)
 declare dso_local spir_func <32 x i32> @_Z20__esimd_flat_atomic2ILN2cm3gen14CmAtomicOpTypeE7EjLi32ELNS1_9CacheHintE0ELS3_0EENS1_13__vector_typeIT0_XT1_EE4typeENS4_IyXT1_EE4typeES7_S7_NS4_ItXT1_EE4typeE(<32 x i64> %0, <32 x i32> %1, <32 x i32> %2, <32 x i16> %3)


### PR DESCRIPTION
ESIMD BE does not support `@llvm.assume`, which is generated when `-fsycl-id-queries-fit-in-int` is in effect.
This problem blocks https://github.com/intel/llvm/pull/3427.
This patch works around this problem until ESIMD BE supports `@llvm.assume`.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>