### PR TITLE
[SYCL][ESIMD] -fsycl-explicit-simd is still required - revert vadd.cpp

### DIFF
--- a/sycl/test/esimd/vadd.cpp
+++ b/sycl/test/esimd/vadd.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-explicit-simd %s -o %t.out
 // RUN: %RUN_ON_HOST %t.out
 
 // Check that the code compiles with -O0 and -g


### PR DESCRIPTION
Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>