### PR TITLE
Fix kernel_lambda_with_kernel_handler_arg.cpp test

### DIFF
--- a/sycl/test/on-device/basic_tests/specialization_constants/kernel_lambda_with_kernel_handler_arg.cpp
+++ b/sycl/test/on-device/basic_tests/specialization_constants/kernel_lambda_with_kernel_handler_arg.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
 
 // This test checks all possible scenarios of running single_task, parallel_for
 // and parallel_for_work_group to verify that this code compiles and runs


### PR DESCRIPTION
This patch avoids running this test on the host device as spec constants
for host device are not implemented yet. Instead, it runs with OpenCL CPU
because low-level runtime and devices are not important here - the impl
is backend-agnostic.