### PR TITLE
[SYCL][NFC] Fix esimg/vadd.cpp: Data need to bring back

### DIFF
--- a/sycl/test/esimd/vadd.cpp
+++ b/sycl/test/esimd/vadd.cpp
@@ -98,13 +98,13 @@ int main(void) {
     });
   }
   for (unsigned i = 0; i < Size; ++i) {
-     if (A[i] + B[i] != C[i]) {
+    if (A[i] + B[i] != C[i]) {
       std::cout << "failed at index " << i << ", " << C[i] << " != " << A[i]
-                << " + " << B[i] << "\n";
+                 << " + " << B[i] << "\n";
       return 1;
-     }
+    }
   }
-
+ 
   std::cout << "Passed\n";
   return 0;
 }

--- a/sycl/test/esimd/vadd.cpp
+++ b/sycl/test/esimd/vadd.cpp
@@ -100,11 +100,11 @@ int main(void) {
   for (unsigned i = 0; i < Size; ++i) {
     if (A[i] + B[i] != C[i]) {
       std::cout << "failed at index " << i << ", " << C[i] << " != " << A[i]
-                 << " + " << B[i] << "\n";
+                << " + " << B[i] << "\n";
       return 1;
     }
   }
- 
+
   std::cout << "Passed\n";
   return 0;
 }

--- a/sycl/test/esimd/vadd.cpp
+++ b/sycl/test/esimd/vadd.cpp
@@ -96,14 +96,13 @@ int main(void) {
             block_store<int, VL>(pC + i * VL, vc);
           });
     });
-
-    for (unsigned i = 0; i < Size; ++i) {
-      if (A[i] + B[i] != C[i]) {
-        std::cout << "failed at index " << i << ", " << C[i] << " != " << A[i]
-                  << " + " << B[i] << "\n";
-        return 1;
-      }
-    }
+  }
+  for (unsigned i = 0; i < Size; ++i) {
+     if (A[i] + B[i] != C[i]) {
+      std::cout << "failed at index " << i << ", " << C[i] << " != " << A[i]
+                << " + " << B[i] << "\n";
+      return 1;
+     }
   }
 
   std::cout << "Passed\n";


### PR DESCRIPTION
The buffer destructor should be called to synchronize and bring back the data to the device.
The simplest is to exit the scope. 