### PR TITLE
[SYCL] Add support multidimensional subscript for atomic accessor

### DIFF
--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -324,6 +324,14 @@ protected:
       MIDs[Dims - CurDims] = Index;
       return MAccessor[MIDs];
     }
+    
+    template <int CurDims = SubDims>
+    typename detail::enable_if_t<CurDims == 1 && AccessMode == access::mode::atomic,
+                              atomic<DataT, AS>> 
+    operator[](size_t Index) const {
+      MIDs[Dims - CurDims] = Index;
+      return MAccessor[MIDs];
+    }
 
     template <int CurDims = SubDims,
               typename = detail::enable_if_t<CurDims == 1 && IsAccessReadOnly>>

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -286,6 +286,8 @@ protected:
   constexpr static bool IsAccessReadWrite =
       AccessMode == access::mode::read_write;
 
+  constexpr static bool IsAccessAtomic = AccessMode == access::mode::atomic;
+
   using RefType = detail::const_if_const_AS<AS, DataT> &;
   using ConstRefType = const DataT &;
   using PtrType = detail::const_if_const_AS<AS, DataT> *;
@@ -327,7 +329,7 @@ protected:
 
     template <int CurDims = SubDims>
     typename detail::enable_if_t<
-        CurDims == 1 && AccessMode == access::mode::atomic, atomic<DataT, AS>>
+        CurDims == 1 && IsAccessAtomic, atomic<DataT, AS>>
     operator[](size_t Index) const {
       MIDs[Dims - CurDims] = Index;
       return MAccessor[MIDs];

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -324,10 +324,10 @@ protected:
       MIDs[Dims - CurDims] = Index;
       return MAccessor[MIDs];
     }
-    
+
     template <int CurDims = SubDims>
-    typename detail::enable_if_t<CurDims == 1 && AccessMode == access::mode::atomic,
-                              atomic<DataT, AS>> 
+    typename detail::enable_if_t<
+        CurDims == 1 && AccessMode == access::mode::atomic, atomic<DataT, AS>>
     operator[](size_t Index) const {
       MIDs[Dims - CurDims] = Index;
       return MAccessor[MIDs];

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -328,8 +328,8 @@ protected:
     }
 
     template <int CurDims = SubDims>
-    typename detail::enable_if_t<
-        CurDims == 1 && IsAccessAtomic, atomic<DataT, AS>>
+    typename detail::enable_if_t<CurDims == 1 && IsAccessAtomic,
+                                 atomic<DataT, AS>>
     operator[](size_t Index) const {
       MIDs[Dims - CurDims] = Index;
       return MAccessor[MIDs];


### PR DESCRIPTION
Add support for multidimensional subscript operations for atomic accessor
The test : https://github.com/intel/llvm-test-suite/pull/218
Signed-off-by: mdimakov <maxim.dimakov@intel.com>