### PR TITLE
[SYCL][Doc] Update C++ standard support in GSG

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -639,8 +639,10 @@ which contains all the symbols required.
 
 ## C++ standard
 
-* DPC++ runtime and headers require C++14 at least.
-* DPC++ compiler is building apps as C++17 apps by default.
+* DPC++ headers require C++17 at least.
+* DPC++ runtime requires C++14 at least.
+* DPC++ compiler supports building apps as C++17 apps and higher.
+* DPC++ compiler builds apps as C++17 apps by default.
 
 ## Known Issues and Limitations
 

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -639,9 +639,9 @@ which contains all the symbols required.
 
 ## C++ standard
 
-* DPC++ headers require C++17 at least.
-* DPC++ runtime requires C++14 at least.
-* DPC++ compiler builds apps as C++17 apps by default. Higher versions of standard are supported as well.
+* DPC++ runtime and headers require C++14 at least.
+* DPC++ compiler builds apps as C++17 apps by default. Higher versions of
+  standard are supported as well.
 
 ## Known Issues and Limitations
 

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -641,8 +641,7 @@ which contains all the symbols required.
 
 * DPC++ headers require C++17 at least.
 * DPC++ runtime requires C++14 at least.
-* DPC++ compiler supports building apps as C++17 apps and higher.
-* DPC++ compiler builds apps as C++17 apps by default.
+* DPC++ compiler builds apps as C++17 apps by default. Higher versions of standard are supported as well.
 
 ## Known Issues and Limitations
 


### PR DESCRIPTION
This patch updates C++ standard support in sycl/doc/GetStartedGuide.md:

* DPC++ compiler builds applications as C++17 apps and higher due to C++17
  features added to DPC++ headers