### PR TITLE
[SYCL][ESIMD][NFC] Fix namespace of ESIMD implementation details.

### DIFF
--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_host_util.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_host_util.hpp
@@ -14,19 +14,19 @@
 
 #define SIMDCF_ELEMENT_SKIP(i)
 
-namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
+
 namespace detail {
 namespace half_impl {
 class half;
 } // namespace half_impl
 } // namespace detail
-} // namespace sycl
-} // namespace cl
 
-using half = cl::sycl::detail::half_impl::half;
-
-namespace EsimdEmulSys {
+namespace INTEL {
+namespace gpu {
+namespace emu {
+namespace detail {
 
 constexpr int sat_is_on = 1;
 
@@ -44,14 +44,10 @@ template <typename RT> struct satur {
       return (RT)val;
     }
 
-#ifdef max
-#undef max
-#endif
-#ifdef min
-#undef min
-#endif
-    const RT t_max = std::numeric_limits<RT>::max();
-    const RT t_min = std::numeric_limits<RT>::min();
+    // min/max can be macros on Windows, so wrap them into parens to avoid their
+    // expansion
+    const RT t_max = (std::numeric_limits<RT>::max)();
+    const RT t_min = (std::numeric_limits<RT>::min)();
 
     if (val > t_max) {
       return t_max;
@@ -111,8 +107,6 @@ template <> struct SetSatur<float, true> {
 template <> struct SetSatur<double, true> {
   static unsigned int set() { return sat_is_on; }
 };
-
-} // namespace EsimdEmulSys
 
 // used for intermediate type in dp4a emulation
 template <typename T1, typename T2> struct restype_ex {
@@ -470,10 +464,11 @@ template <typename T> struct dwordtype;
 template <> struct dwordtype<int> { static const bool value = true; };
 template <> struct dwordtype<unsigned int> { static const bool value = true; };
 
-template <unsigned int N1, unsigned int N2> struct ressize {
-  static const unsigned int size = (N1 > N2) ? N1 : N2;
-  static const bool conformable =
-      check_true < N1 % size == 0 && N2 % size == 0 > ::value;
-};
+} // namespace detail
+} // namespace emu
+} // namespace gpu
+} // namespace INTEL
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
-#endif
+#endif // #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_intrin.hpp
@@ -14,10 +14,11 @@
 #include <CL/sycl/INTEL/esimd/detail/esimd_types.hpp>
 #include <CL/sycl/INTEL/esimd/detail/esimd_util.hpp>
 #include <CL/sycl/INTEL/esimd/esimd_enum.hpp>
-#include <CL/sycl/detail/accessor_impl.hpp>
 
 #include <assert.h>
 #include <cstdint>
+
+#define __SIGD sycl::INTEL::gpu::detail
 
 // \brief __esimd_rdregion: region access intrinsic.
 //
@@ -63,13 +64,13 @@
 //
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth = 0>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<T, M>
-__esimd_rdregion(sycl::INTEL::gpu::vector_type_t<T, N> Input, uint16_t Offset);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, M>
+__esimd_rdregion(__SIGD::vector_type_t<T, N> Input, uint16_t Offset);
 
 template <typename T, int N, int M, int ParentWidth = 0>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<T, M>
-__esimd_rdindirect(sycl::INTEL::gpu::vector_type_t<T, N> Input,
-                   sycl::INTEL::gpu::vector_type_t<uint16_t, M> Offset);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, M>
+__esimd_rdindirect(__SIGD::vector_type_t<T, N> Input,
+                   __SIGD::vector_type_t<uint16_t, M> Offset);
 
 // __esimd_wrregion returns the updated vector with the region updated.
 //
@@ -120,46 +121,28 @@ __esimd_rdindirect(sycl::INTEL::gpu::vector_type_t<T, N> Input,
 //
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth = 0>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<T, N>
-__esimd_wrregion(sycl::INTEL::gpu::vector_type_t<T, N> OldVal,
-                 sycl::INTEL::gpu::vector_type_t<T, M> NewVal, uint16_t Offset,
+SYCL_EXTERNAL __SIGD::vector_type_t<T, N>
+__esimd_wrregion(__SIGD::vector_type_t<T, N> OldVal,
+                 __SIGD::vector_type_t<T, M> NewVal, uint16_t Offset,
                  sycl::INTEL::gpu::mask_type_t<M> Mask = 1);
 
 template <typename T, int N, int M, int ParentWidth = 0>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<T, N>
-__esimd_wrindirect(sycl::INTEL::gpu::vector_type_t<T, N> OldVal,
-                   sycl::INTEL::gpu::vector_type_t<T, M> NewVal,
-                   sycl::INTEL::gpu::vector_type_t<uint16_t, M> Offset,
+SYCL_EXTERNAL __SIGD::vector_type_t<T, N>
+__esimd_wrindirect(__SIGD::vector_type_t<T, N> OldVal,
+                   __SIGD::vector_type_t<T, M> NewVal,
+                   __SIGD::vector_type_t<uint16_t, M> Offset,
                    sycl::INTEL::gpu::mask_type_t<M> Mask = 1);
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace INTEL {
 namespace gpu {
-// TODO dependencies on the std SYCL concepts like images
-// should be refactored in a separate header
-class AccessorPrivateProxy {
-public:
-#ifdef __SYCL_DEVICE_ONLY__
-  template <typename AccessorTy>
-  static auto getNativeImageObj(const AccessorTy &Acc) {
-    return Acc.getNativeImageObj();
-  }
-#else
-  template <typename AccessorTy>
-  static auto getImageRange(const AccessorTy &Acc) {
-    return Acc.getAccessRange();
-  }
-  static auto getElemSize(const sycl::detail::AccessorBaseHost &Acc) {
-    return Acc.getElemSize();
-  }
-#endif
-};
+namespace detail {
 
 /// read from a basic region of a vector, return a vector
 template <typename BT, int BN, typename RTy>
-vector_type_t<typename RTy::element_type, RTy::length>
-    ESIMD_INLINE readRegion(const vector_type_t<BT, BN> &Base, RTy Region) {
+__SIGD::vector_type_t<typename RTy::element_type, RTy::length> ESIMD_INLINE
+readRegion(const __SIGD::vector_type_t<BT, BN> &Base, RTy Region) {
   using ElemTy = typename RTy::element_type;
   auto Base1 = bitcast<ElemTy, BT, BN>(Base);
   constexpr int Bytes = BN * sizeof(BT);
@@ -180,8 +163,8 @@ vector_type_t<typename RTy::element_type, RTy::length>
 
 /// read from a nested region of a vector, return a vector
 template <typename BT, int BN, typename T, typename U>
-ESIMD_INLINE vector_type_t<typename T::element_type, T::length>
-readRegion(const vector_type_t<BT, BN> &Base, std::pair<T, U> Region) {
+ESIMD_INLINE __SIGD::vector_type_t<typename T::element_type, T::length>
+readRegion(const __SIGD::vector_type_t<BT, BN> &Base, std::pair<T, U> Region) {
   // parent-region type
   using PaTy = typename shape_type<U>::type;
   constexpr int BN1 = PaTy::length;
@@ -222,6 +205,7 @@ readRegion(const vector_type_t<BT, BN> &Base, std::pair<T, U> Region) {
   }
 }
 
+} // namespace detail
 } // namespace gpu
 } // namespace INTEL
 } // namespace sycl
@@ -233,37 +217,37 @@ readRegion(const vector_type_t<BT, BN> &Base, std::pair<T, U> Region) {
 // optimization on simd object
 //
 template <typename T, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<T, N>
-__esimd_vload(const sycl::INTEL::gpu::vector_type_t<T, N> *ptr);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, N>
+__esimd_vload(const __SIGD::vector_type_t<T, N> *ptr);
 
 // vstore
 //
 // map to the backend vstore intrinsic, used by compiler to control
 // optimization on simd object
 template <typename T, int N>
-SYCL_EXTERNAL void __esimd_vstore(sycl::INTEL::gpu::vector_type_t<T, N> *ptr,
-                                  sycl::INTEL::gpu::vector_type_t<T, N> vals);
+SYCL_EXTERNAL void __esimd_vstore(__SIGD::vector_type_t<T, N> *ptr,
+                                  __SIGD::vector_type_t<T, N> vals);
 
 template <typename T, int N>
-SYCL_EXTERNAL uint16_t __esimd_any(sycl::INTEL::gpu::vector_type_t<T, N> src);
+SYCL_EXTERNAL uint16_t __esimd_any(__SIGD::vector_type_t<T, N> src);
 
 template <typename T, int N>
-SYCL_EXTERNAL uint16_t __esimd_all(sycl::INTEL::gpu::vector_type_t<T, N> src);
+SYCL_EXTERNAL uint16_t __esimd_all(__SIGD::vector_type_t<T, N> src);
 
 #ifndef __SYCL_DEVICE_ONLY__
 
 // Implementations of ESIMD intrinsics for the SYCL host device
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<T, M>
-__esimd_rdregion(sycl::INTEL::gpu::vector_type_t<T, N> Input, uint16_t Offset) {
+SYCL_EXTERNAL __SIGD::vector_type_t<T, M>
+__esimd_rdregion(__SIGD::vector_type_t<T, N> Input, uint16_t Offset) {
   uint16_t EltOffset = Offset / sizeof(T);
   assert(Offset % sizeof(T) == 0);
 
   int NumRows = M / Width;
   assert(M % Width == 0);
 
-  sycl::INTEL::gpu::vector_type_t<T, M> Result;
+  __SIGD::vector_type_t<T, M> Result;
   int Index = 0;
   for (int i = 0; i < NumRows; ++i) {
     for (int j = 0; j < Width; ++j) {
@@ -274,10 +258,10 @@ __esimd_rdregion(sycl::INTEL::gpu::vector_type_t<T, N> Input, uint16_t Offset) {
 }
 
 template <typename T, int N, int M, int ParentWidth>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<T, M>
-__esimd_rdindirect(sycl::INTEL::gpu::vector_type_t<T, N> Input,
-                   sycl::INTEL::gpu::vector_type_t<uint16_t, M> Offset) {
-  sycl::INTEL::gpu::vector_type_t<T, M> Result;
+SYCL_EXTERNAL __SIGD::vector_type_t<T, M>
+__esimd_rdindirect(__SIGD::vector_type_t<T, N> Input,
+                   __SIGD::vector_type_t<uint16_t, M> Offset) {
+  __SIGD::vector_type_t<T, M> Result;
   for (int i = 0; i < M; ++i) {
     uint16_t EltOffset = Offset[i] / sizeof(T);
     assert(Offset[i] % sizeof(T) == 0);
@@ -289,9 +273,9 @@ __esimd_rdindirect(sycl::INTEL::gpu::vector_type_t<T, N> Input,
 
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<T, N>
-__esimd_wrregion(sycl::INTEL::gpu::vector_type_t<T, N> OldVal,
-                 sycl::INTEL::gpu::vector_type_t<T, M> NewVal, uint16_t Offset,
+SYCL_EXTERNAL __SIGD::vector_type_t<T, N>
+__esimd_wrregion(__SIGD::vector_type_t<T, N> OldVal,
+                 __SIGD::vector_type_t<T, M> NewVal, uint16_t Offset,
                  sycl::INTEL::gpu::mask_type_t<M> Mask) {
   uint16_t EltOffset = Offset / sizeof(T);
   assert(Offset % sizeof(T) == 0);
@@ -299,7 +283,7 @@ __esimd_wrregion(sycl::INTEL::gpu::vector_type_t<T, N> OldVal,
   int NumRows = M / Width;
   assert(M % Width == 0);
 
-  sycl::INTEL::gpu::vector_type_t<T, N> Result = OldVal;
+  __SIGD::vector_type_t<T, N> Result = OldVal;
   int Index = 0;
   for (int i = 0; i < NumRows; ++i) {
     for (int j = 0; j < Width; ++j) {
@@ -312,12 +296,12 @@ __esimd_wrregion(sycl::INTEL::gpu::vector_type_t<T, N> OldVal,
 }
 
 template <typename T, int N, int M, int ParentWidth>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<T, N>
-__esimd_wrindirect(sycl::INTEL::gpu::vector_type_t<T, N> OldVal,
-                   sycl::INTEL::gpu::vector_type_t<T, M> NewVal,
-                   sycl::INTEL::gpu::vector_type_t<uint16_t, M> Offset,
+SYCL_EXTERNAL __SIGD::vector_type_t<T, N>
+__esimd_wrindirect(__SIGD::vector_type_t<T, N> OldVal,
+                   __SIGD::vector_type_t<T, M> NewVal,
+                   __SIGD::vector_type_t<uint16_t, M> Offset,
                    sycl::INTEL::gpu::mask_type_t<M> Mask) {
-  sycl::INTEL::gpu::vector_type_t<T, N> Result = OldVal;
+  __SIGD::vector_type_t<T, N> Result = OldVal;
   for (int i = 0; i < M; ++i) {
     if (Mask[i]) {
       uint16_t EltOffset = Offset[i] / sizeof(T);
@@ -330,3 +314,5 @@ __esimd_wrindirect(sycl::INTEL::gpu::vector_type_t<T, N> OldVal,
 }
 
 #endif // __SYCL_DEVICE_ONLY__
+
+#undef __SIGD

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
@@ -1173,9 +1173,10 @@ __esimd_dp4a(__SIGD::vector_type_t<T2, N> src0,
 
   int src1_a, src1_b, src1_c, src1_d, src2_a, src2_b, src2_c, src2_d, ret;
 
-  uint32_t sat1 = __SIGED::SetSatur<T2, __SIGED::is_inttype<T1>::value>::set() ||
-                  __SIGED::SetSatur<T3, __SIGED::is_inttype<T1>::value>::set() ||
-                  __SIGED::SetSatur<T4, __SIGED::is_inttype<T1>::value>::set();
+  uint32_t sat1 =
+      __SIGED::SetSatur<T2, __SIGED::is_inttype<T1>::value>::set() ||
+      __SIGED::SetSatur<T3, __SIGED::is_inttype<T1>::value>::set() ||
+      __SIGED::SetSatur<T4, __SIGED::is_inttype<T1>::value>::set();
 
   for (uint32_t i = 0; i < N; i++) {
 

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
@@ -16,268 +16,303 @@
 #include <CL/sycl/INTEL/esimd/esimd_enum.hpp>
 #include <cstdint>
 
-using sycl::INTEL::gpu::vector_type_t;
+#define __SIGD sycl::INTEL::gpu::detail
 
 // saturation intrinsics
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ> __esimd_satf(vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_satf(__SIGD::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_fptoui_sat(vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_fptoui_sat(__SIGD::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_fptosi_sat(vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_fptosi_sat(__SIGD::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_uutrunc_sat(vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_uutrunc_sat(__SIGD::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_ustrunc_sat(vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_ustrunc_sat(__SIGD::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_sutrunc_sat(vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_sutrunc_sat(__SIGD::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_sstrunc_sat(vector_type_t<T1, SZ> src);
-
-template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_abs(vector_type_t<T, SZ> src0);
-
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ> __esimd_ssshl(vector_type_t<T1, SZ> src0,
-                                                  vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ> __esimd_sushl(vector_type_t<T1, SZ> src0,
-                                                  vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ> __esimd_usshl(vector_type_t<T1, SZ> src0,
-                                                  vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ> __esimd_uushl(vector_type_t<T1, SZ> src0,
-                                                  vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_ssshl_sat(vector_type_t<T1, SZ> src0, vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_sushl_sat(vector_type_t<T1, SZ> src0, vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_usshl_sat(vector_type_t<T1, SZ> src0, vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_uushl_sat(vector_type_t<T1, SZ> src0, vector_type_t<T1, SZ> src1);
-
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ> __esimd_rol(vector_type_t<T1, SZ> src0,
-                                                vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ> __esimd_ror(vector_type_t<T1, SZ> src0,
-                                                vector_type_t<T1, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_sstrunc_sat(__SIGD::vector_type_t<T1, SZ> src);
 
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_umulh(vector_type_t<T, SZ> src0,
-                                                 vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_abs(__SIGD::vector_type_t<T, SZ> src0);
+
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_ssshl(__SIGD::vector_type_t<T1, SZ> src0,
+              __SIGD::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_sushl(__SIGD::vector_type_t<T1, SZ> src0,
+              __SIGD::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_usshl(__SIGD::vector_type_t<T1, SZ> src0,
+              __SIGD::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_uushl(__SIGD::vector_type_t<T1, SZ> src0,
+              __SIGD::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_ssshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
+                  __SIGD::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_sushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
+                  __SIGD::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_usshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
+                  __SIGD::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_uushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
+                  __SIGD::vector_type_t<T1, SZ> src1);
+
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_rol(__SIGD::vector_type_t<T1, SZ> src0,
+            __SIGD::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_ror(__SIGD::vector_type_t<T1, SZ> src0,
+            __SIGD::vector_type_t<T1, SZ> src1);
+
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_smulh(vector_type_t<T, SZ> src0,
-                                                 vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_umulh(__SIGD::vector_type_t<T, SZ> src0,
+              __SIGD::vector_type_t<T, SZ> src1);
+template <typename T, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_smulh(__SIGD::vector_type_t<T, SZ> src0,
+              __SIGD::vector_type_t<T, SZ> src1);
 
 template <int SZ>
-SYCL_EXTERNAL SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_frc(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_frc(__SIGD::vector_type_t<float, SZ> src0);
 
 /// 3 kinds of max
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_fmax(vector_type_t<T, SZ> src0,
-                                                vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_fmax(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1);
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_umax(vector_type_t<T, SZ> src0,
-                                                vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_umax(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1);
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_smax(vector_type_t<T, SZ> src0,
-                                                vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_smax(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1);
 
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_lzd(vector_type_t<T, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_lzd(__SIGD::vector_type_t<T, SZ> src0);
 
 /// 3 kinds of min
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_fmin(vector_type_t<T, SZ> src0,
-                                                vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_fmin(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1);
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_umin(vector_type_t<T, SZ> src0,
-                                                vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_umin(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1);
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<T, SZ> __esimd_smin(vector_type_t<T, SZ> src0,
-                                                vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<T, SZ>
+__esimd_smin(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ> __esimd_bfrev(vector_type_t<T1, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_bfrev(__SIGD::vector_type_t<T1, SZ> src0);
 
 template <typename T, int SZ>
-SYCL_EXTERNAL vector_type_t<unsigned int, SZ>
-__esimd_cbit(vector_type_t<T, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<unsigned int, SZ>
+__esimd_cbit(__SIGD::vector_type_t<T, SZ> src0);
 
 template <typename T0, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ>
-__esimd_bfins(vector_type_t<T0, SZ> src0, vector_type_t<T0, SZ> src1,
-              vector_type_t<T0, SZ> src2, vector_type_t<T0, SZ> src3);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ> __esimd_bfins(
+    __SIGD::vector_type_t<T0, SZ> src0, __SIGD::vector_type_t<T0, SZ> src1,
+    __SIGD::vector_type_t<T0, SZ> src2, __SIGD::vector_type_t<T0, SZ> src3);
 
 template <typename T0, int SZ>
-SYCL_EXTERNAL vector_type_t<T0, SZ> __esimd_bfext(vector_type_t<T0, SZ> src0,
-                                                  vector_type_t<T0, SZ> src1,
-                                                  vector_type_t<T0, SZ> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<T0, SZ>
+__esimd_bfext(__SIGD::vector_type_t<T0, SZ> src0,
+              __SIGD::vector_type_t<T0, SZ> src1,
+              __SIGD::vector_type_t<T0, SZ> src2);
 
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<uint32_t, SZ>
-__esimd_fbl(vector_type_t<uint32_t, SZ> src0);
-
-template <typename T0, int SZ>
-SYCL_EXTERNAL vector_type_t<int, SZ> __esimd_sfbh(vector_type_t<T0, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<uint32_t, SZ>
+__esimd_fbl(__SIGD::vector_type_t<uint32_t, SZ> src0);
 
 template <typename T0, int SZ>
-SYCL_EXTERNAL vector_type_t<uint32_t, SZ>
-__esimd_ufbh(vector_type_t<T0, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<int, SZ>
+__esimd_sfbh(__SIGD::vector_type_t<T0, SZ> src0);
+
+template <typename T0, int SZ>
+SYCL_EXTERNAL __SIGD::vector_type_t<uint32_t, SZ>
+__esimd_ufbh(__SIGD::vector_type_t<T0, SZ> src0);
 
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_inv(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_inv(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_log(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_log(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_exp(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_exp(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_sqrt(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_sqrt(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_sqrt_ieee(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_sqrt_ieee(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_rsqrt(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_rsqrt(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_sin(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_sin(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_cos(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_cos(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_pow(vector_type_t<float, SZ> src0, vector_type_t<float, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_pow(__SIGD::vector_type_t<float, SZ> src0,
+            __SIGD::vector_type_t<float, SZ> src1);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_div_ieee(vector_type_t<float, SZ> src0, vector_type_t<float, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_div_ieee(__SIGD::vector_type_t<float, SZ> src0,
+                 __SIGD::vector_type_t<float, SZ> src1);
 
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_rndd(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_rndd(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_rndu(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_rndu(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_rnde(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_rnde(__SIGD::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<float, SZ>
-__esimd_rndz(vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<float, SZ>
+__esimd_rndz(__SIGD::vector_type_t<float, SZ> src0);
 
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<double, SZ>
-__esimd_sqrt_ieee(vector_type_t<double, SZ> src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<double, SZ>
+__esimd_sqrt_ieee(__SIGD::vector_type_t<double, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL vector_type_t<double, SZ>
-__esimd_div_ieee(vector_type_t<double, SZ> src0,
-                 vector_type_t<double, SZ> src1);
+SYCL_EXTERNAL __SIGD::vector_type_t<double, SZ>
+__esimd_div_ieee(__SIGD::vector_type_t<double, SZ> src0,
+                 __SIGD::vector_type_t<double, SZ> src1);
 
 template <int N>
-SYCL_EXTERNAL uint32_t __esimd_pack_mask(vector_type_t<uint16_t, N> src0);
+SYCL_EXTERNAL uint32_t
+__esimd_pack_mask(__SIGD::vector_type_t<uint16_t, N> src0);
 
 template <int N>
-SYCL_EXTERNAL vector_type_t<uint16_t, N> __esimd_unpack_mask(uint32_t src0);
+SYCL_EXTERNAL __SIGD::vector_type_t<uint16_t, N>
+__esimd_unpack_mask(uint32_t src0);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL vector_type_t<T1, N> __esimd_uudp4a(vector_type_t<T2, N> src0,
-                                                  vector_type_t<T3, N> src1,
-                                                  vector_type_t<T4, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<T1, N>
+__esimd_uudp4a(__SIGD::vector_type_t<T2, N> src0,
+               __SIGD::vector_type_t<T3, N> src1,
+               __SIGD::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL vector_type_t<T1, N> __esimd_usdp4a(vector_type_t<T2, N> src0,
-                                                  vector_type_t<T3, N> src1,
-                                                  vector_type_t<T4, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<T1, N>
+__esimd_usdp4a(__SIGD::vector_type_t<T2, N> src0,
+               __SIGD::vector_type_t<T3, N> src1,
+               __SIGD::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL vector_type_t<T1, N> __esimd_sudp4a(vector_type_t<T2, N> src0,
-                                                  vector_type_t<T3, N> src1,
-                                                  vector_type_t<T4, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<T1, N>
+__esimd_sudp4a(__SIGD::vector_type_t<T2, N> src0,
+               __SIGD::vector_type_t<T3, N> src1,
+               __SIGD::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL vector_type_t<T1, N> __esimd_ssdp4a(vector_type_t<T2, N> src0,
-                                                  vector_type_t<T3, N> src1,
-                                                  vector_type_t<T4, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<T1, N>
+__esimd_ssdp4a(__SIGD::vector_type_t<T2, N> src0,
+               __SIGD::vector_type_t<T3, N> src1,
+               __SIGD::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL vector_type_t<T1, N>
-__esimd_uudp4a_sat(vector_type_t<T2, N> src0, vector_type_t<T3, N> src1,
-                   vector_type_t<T4, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<T1, N>
+__esimd_uudp4a_sat(__SIGD::vector_type_t<T2, N> src0,
+                   __SIGD::vector_type_t<T3, N> src1,
+                   __SIGD::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL vector_type_t<T1, N>
-__esimd_usdp4a_sat(vector_type_t<T2, N> src0, vector_type_t<T3, N> src1,
-                   vector_type_t<T4, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<T1, N>
+__esimd_usdp4a_sat(__SIGD::vector_type_t<T2, N> src0,
+                   __SIGD::vector_type_t<T3, N> src1,
+                   __SIGD::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL vector_type_t<T1, N>
-__esimd_sudp4a_sat(vector_type_t<T2, N> src0, vector_type_t<T3, N> src1,
-                   vector_type_t<T4, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<T1, N>
+__esimd_sudp4a_sat(__SIGD::vector_type_t<T2, N> src0,
+                   __SIGD::vector_type_t<T3, N> src1,
+                   __SIGD::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL vector_type_t<T1, N>
-__esimd_ssdp4a_sat(vector_type_t<T2, N> src0, vector_type_t<T3, N> src1,
-                   vector_type_t<T4, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<T1, N>
+__esimd_ssdp4a_sat(__SIGD::vector_type_t<T2, N> src0,
+                   __SIGD::vector_type_t<T3, N> src1,
+                   __SIGD::vector_type_t<T4, N> src2);
 
 // Reduction functions
 template <typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_fmax(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_fmax(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_umax(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_umax(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_smax(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_smax(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_fmin(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_fmin(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_umin(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_umin(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-sycl::INTEL::gpu::vector_type_t<Ty, N> SYCL_EXTERNAL
-__esimd_reduced_smin(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2);
+__SIGD::vector_type_t<Ty, N>
+    SYCL_EXTERNAL __esimd_reduced_smin(__SIGD::vector_type_t<Ty, N> src1,
+                                       __SIGD::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_dp4(sycl::INTEL::gpu::vector_type_t<Ty, N> v1,
-            sycl::INTEL::gpu::vector_type_t<Ty, N> v2);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_dp4(__SIGD::vector_type_t<Ty, N> v1, __SIGD::vector_type_t<Ty, N> v2);
 
 #ifndef __SYCL_DEVICE_ONLY__
 
@@ -296,81 +331,91 @@ inline T extract(const uint32_t &width, const uint32_t &offset, uint32_t src,
   return ret;
 }
 
+#define __SIGED sycl::INTEL::gpu::emu::detail
+
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_satf(vector_type_t<T1, SZ> src) {
-  vector_type_t<T0, SZ> retv;
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_satf(__SIGD::vector_type_t<T1, SZ> src) {
+  __SIGD::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_fptoui_sat(vector_type_t<T1, SZ> src) {
-  vector_type_t<T0, SZ> retv;
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_fptoui_sat(__SIGD::vector_type_t<T1, SZ> src) {
+  __SIGD::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_fptosi_sat(vector_type_t<T1, SZ> src) {
-  vector_type_t<T0, SZ> retv;
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_fptosi_sat(__SIGD::vector_type_t<T1, SZ> src) {
+  __SIGD::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_uutrunc_sat(vector_type_t<T1, SZ> src) {
-  vector_type_t<T0, SZ> retv;
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_uutrunc_sat(__SIGD::vector_type_t<T1, SZ> src) {
+  __SIGD::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_ustrunc_sat(vector_type_t<T1, SZ> src) {
-  vector_type_t<T0, SZ> retv;
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_ustrunc_sat(__SIGD::vector_type_t<T1, SZ> src) {
+  __SIGD::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_sutrunc_sat(vector_type_t<T1, SZ> src) {
-  vector_type_t<T0, SZ> retv;
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_sutrunc_sat(__SIGD::vector_type_t<T1, SZ> src) {
+  __SIGD::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_sstrunc_sat(vector_type_t<T1, SZ> src) {
-  vector_type_t<T0, SZ> retv;
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_sstrunc_sat(__SIGD::vector_type_t<T1, SZ> src) {
+  __SIGD::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_abs(vector_type_t<T, SZ> src0) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_abs(__SIGD::vector_type_t<T, SZ> src0) {
   int i;
-  typename abstype<T>::type ret;
-  vector_type_t<T, SZ> retv;
+  typename __SIGED::abstype<T>::type ret;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -385,11 +430,12 @@ inline vector_type_t<T, SZ> __esimd_abs(vector_type_t<T, SZ> src0) {
 };
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_ssshl(vector_type_t<T1, SZ> src0,
-                                           vector_type_t<T1, SZ> src1) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_ssshl(__SIGD::vector_type_t<T1, SZ> src0,
+              __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
   typename maxtype<T1>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -399,11 +445,12 @@ inline vector_type_t<T0, SZ> __esimd_ssshl(vector_type_t<T1, SZ> src0,
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_sushl(vector_type_t<T1, SZ> src0,
-                                           vector_type_t<T1, SZ> src1) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_sushl(__SIGD::vector_type_t<T1, SZ> src0,
+              __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
   typename maxtype<T1>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -413,11 +460,12 @@ inline vector_type_t<T0, SZ> __esimd_sushl(vector_type_t<T1, SZ> src0,
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_usshl(vector_type_t<T1, SZ> src0,
-                                           vector_type_t<T1, SZ> src1) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_usshl(__SIGD::vector_type_t<T1, SZ> src0,
+              __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
   typename maxtype<T1>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -427,11 +475,12 @@ inline vector_type_t<T0, SZ> __esimd_usshl(vector_type_t<T1, SZ> src0,
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_uushl(vector_type_t<T1, SZ> src0,
-                                           vector_type_t<T1, SZ> src1) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_uushl(__SIGD::vector_type_t<T1, SZ> src0,
+              __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
   typename maxtype<T1>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -441,75 +490,82 @@ inline vector_type_t<T0, SZ> __esimd_uushl(vector_type_t<T1, SZ> src0,
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_ssshl_sat(vector_type_t<T1, SZ> src0,
-                                               vector_type_t<T1, SZ> src1) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_ssshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
+                  __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
   typename maxtype<T1>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     ret = src0.get(i) << src1.get(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(ret, 1);
+    retv[i] = __SIGED::satur<T0>::saturate(ret, 1);
   }
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_sushl_sat(vector_type_t<T1, SZ> src0,
-                                               vector_type_t<T1, SZ> src1) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_sushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
+                  __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
   typename maxtype<T1>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     ret = src0.get(i) << src1.get(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(ret, 1);
+    retv[i] = __SIGED::satur<T0>::saturate(ret, 1);
   }
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_usshl_sat(vector_type_t<T1, SZ> src0,
-                                               vector_type_t<T1, SZ> src1) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_usshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
+                  __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
   typename maxtype<T1>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     ret = src0.get(i) << src1.get(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(ret, 1);
+    retv[i] = __SIGED::satur<T0>::saturate(ret, 1);
   }
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_uushl_sat(vector_type_t<T1, SZ> src0,
-                                               vector_type_t<T1, SZ> src1) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_uushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
+                  __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
   typename maxtype<T1>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     ret = src0.get(i) << src1.get(i);
-    retv[i] = EsimdEmulSys::satur<T0>::saturate(ret, 1);
+    retv[i] = __SIGED::satur<T0>::saturate(ret, 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_rol(vector_type_t<T1, SZ> src0,
-                                         vector_type_t<T1, SZ> src1){};
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_rol(__SIGD::vector_type_t<T1, SZ> src0,
+            __SIGD::vector_type_t<T1, SZ> src1){};
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_ror(vector_type_t<T1, SZ> src0,
-                                         vector_type_t<T1, SZ> src1){};
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_ror(__SIGD::vector_type_t<T1, SZ> src0,
+            __SIGD::vector_type_t<T1, SZ> src1){};
 
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_umulh(vector_type_t<T, SZ> src0,
-                                          vector_type_t<T, SZ> src1) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_umulh(__SIGD::vector_type_t<T, SZ> src0,
+              __SIGD::vector_type_t<T, SZ> src1) {
   int i;
-  vector_type_t<T, SZ> retv;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     unsigned long long temp;
@@ -521,10 +577,11 @@ inline vector_type_t<T, SZ> __esimd_umulh(vector_type_t<T, SZ> src0,
 }
 
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_smulh(vector_type_t<T, SZ> src0,
-                                          vector_type_t<T, SZ> src1) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_smulh(__SIGD::vector_type_t<T, SZ> src0,
+              __SIGD::vector_type_t<T, SZ> src1) {
   int i;
-  vector_type_t<T, SZ> retv;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     long long temp;
@@ -536,8 +593,9 @@ inline vector_type_t<T, SZ> __esimd_smulh(vector_type_t<T, SZ> src0,
 };
 
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_frc(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_frc(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     retv[i] = src0[i] - floor(src0[i]);
@@ -547,10 +605,11 @@ inline vector_type_t<float, SZ> __esimd_frc(vector_type_t<float, SZ> src0) {
 
 /// 3 kinds of max
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_fmax(vector_type_t<T, SZ> src0,
-                                         vector_type_t<T, SZ> src1) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_fmax(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1) {
   int i;
-  vector_type_t<T, SZ> retv;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -564,10 +623,11 @@ inline vector_type_t<T, SZ> __esimd_fmax(vector_type_t<T, SZ> src0,
   return retv;
 };
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_umax(vector_type_t<T, SZ> src0,
-                                         vector_type_t<T, SZ> src1) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_umax(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1) {
   int i;
-  vector_type_t<T, SZ> retv;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -581,10 +641,11 @@ inline vector_type_t<T, SZ> __esimd_umax(vector_type_t<T, SZ> src0,
   return retv;
 };
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_smax(vector_type_t<T, SZ> src0,
-                                         vector_type_t<T, SZ> src1) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_smax(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1) {
   int i;
-  vector_type_t<T, SZ> retv;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -599,10 +660,11 @@ inline vector_type_t<T, SZ> __esimd_smax(vector_type_t<T, SZ> src0,
 };
 
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_lzd(vector_type_t<T, SZ> src0) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_lzd(__SIGD::vector_type_t<T, SZ> src0) {
   int i;
   T ret;
-  vector_type_t<T, SZ> retv;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -620,10 +682,11 @@ inline vector_type_t<T, SZ> __esimd_lzd(vector_type_t<T, SZ> src0) {
 
 /// 3 kinds of min
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_fmin(vector_type_t<T, SZ> src0,
-                                         vector_type_t<T, SZ> src1) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_fmin(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1) {
   int i;
-  vector_type_t<T, SZ> retv;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -638,10 +701,11 @@ inline vector_type_t<T, SZ> __esimd_fmin(vector_type_t<T, SZ> src0,
 };
 
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_umin(vector_type_t<T, SZ> src0,
-                                         vector_type_t<T, SZ> src1) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_umin(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1) {
   int i;
-  vector_type_t<T, SZ> retv;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -656,10 +720,11 @@ inline vector_type_t<T, SZ> __esimd_umin(vector_type_t<T, SZ> src0,
 };
 
 template <typename T, int SZ>
-inline vector_type_t<T, SZ> __esimd_smin(vector_type_t<T, SZ> src0,
-                                         vector_type_t<T, SZ> src1) {
+inline __SIGD::vector_type_t<T, SZ>
+__esimd_smin(__SIGD::vector_type_t<T, SZ> src0,
+             __SIGD::vector_type_t<T, SZ> src1) {
   int i;
-  vector_type_t<T, SZ> retv;
+  __SIGD::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -674,9 +739,10 @@ inline vector_type_t<T, SZ> __esimd_smin(vector_type_t<T, SZ> src0,
 };
 
 template <typename T0, typename T1, int SZ>
-inline vector_type_t<T0, SZ> __esimd_bfrev(vector_type_t<T1, SZ> src0) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_bfrev(__SIGD::vector_type_t<T1, SZ> src0) {
   int i, j;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -698,10 +764,11 @@ inline vector_type_t<T0, SZ> __esimd_bfrev(vector_type_t<T1, SZ> src0) {
 };
 
 template <typename T, int SZ>
-inline vector_type_t<unsigned int, SZ> __esimd_cbit(vector_type_t<T, SZ> src0) {
+inline __SIGD::vector_type_t<unsigned int, SZ>
+__esimd_cbit(__SIGD::vector_type_t<T, SZ> src0) {
   int i;
   uint32_t ret;
-  vector_type_t<uint32_t, SZ> retv;
+  __SIGD::vector_type_t<uint32_t, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -720,12 +787,12 @@ inline vector_type_t<unsigned int, SZ> __esimd_cbit(vector_type_t<T, SZ> src0) {
 };
 
 template <typename T0, int SZ>
-inline vector_type_t<T0, SZ>
-__esimd_bfins(vector_type_t<T0, SZ> width, vector_type_t<T0, SZ> offset,
-              vector_type_t<T0, SZ> val, vector_type_t<T0, SZ> src) {
+inline __SIGD::vector_type_t<T0, SZ> __esimd_bfins(
+    __SIGD::vector_type_t<T0, SZ> width, __SIGD::vector_type_t<T0, SZ> offset,
+    __SIGD::vector_type_t<T0, SZ> val, __SIGD::vector_type_t<T0, SZ> src) {
   int i;
   typename maxtype<T0>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -744,12 +811,13 @@ __esimd_bfins(vector_type_t<T0, SZ> width, vector_type_t<T0, SZ> offset,
 };
 
 template <typename T0, int SZ>
-inline vector_type_t<T0, SZ> __esimd_bfext(vector_type_t<T0, SZ> width,
-                                           vector_type_t<T0, SZ> offset,
-                                           vector_type_t<T0, SZ> src) {
+inline __SIGD::vector_type_t<T0, SZ>
+__esimd_bfext(__SIGD::vector_type_t<T0, SZ> width,
+              __SIGD::vector_type_t<T0, SZ> offset,
+              __SIGD::vector_type_t<T0, SZ> src) {
   int i;
   typename maxtype<T0>::type ret;
-  vector_type_t<T0, SZ> retv;
+  __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -762,11 +830,11 @@ inline vector_type_t<T0, SZ> __esimd_bfext(vector_type_t<T0, SZ> width,
 };
 
 template <int SZ>
-inline vector_type_t<uint32_t, SZ>
-__esimd_fbl(vector_type_t<uint32_t, SZ> src0) {
+inline __SIGD::vector_type_t<uint32_t, SZ>
+__esimd_fbl(__SIGD::vector_type_t<uint32_t, SZ> src0) {
   int i;
   uint32_t ret;
-  vector_type_t<uint32_t, SZ> retv;
+  __SIGD::vector_type_t<uint32_t, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -787,11 +855,12 @@ __esimd_fbl(vector_type_t<uint32_t, SZ> src0) {
 };
 
 template <typename T0, int SZ>
-inline vector_type_t<int, SZ> __esimd_sfbh(vector_type_t<T0, SZ> src0) {
+inline __SIGD::vector_type_t<int, SZ>
+__esimd_sfbh(__SIGD::vector_type_t<T0, SZ> src0) {
 
   int i, cval;
   int ret;
-  vector_type_t<int, SZ> retv;
+  __SIGD::vector_type_t<int, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -818,9 +887,10 @@ inline vector_type_t<int, SZ> __esimd_sfbh(vector_type_t<T0, SZ> src0) {
 };
 
 template <typename T0, int SZ>
-inline vector_type_t<uint32_t, SZ> __esimd_ufbh(vector_type_t<T0, SZ> src0) {
+inline __SIGD::vector_type_t<uint32_t, SZ>
+__esimd_ufbh(__SIGD::vector_type_t<T0, SZ> src0) {
   uint32_t ret;
-  vector_type_t<uint32_t, SZ> retv;
+  __SIGD::vector_type_t<uint32_t, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -841,8 +911,9 @@ inline vector_type_t<uint32_t, SZ> __esimd_ufbh(vector_type_t<T0, SZ> src0) {
 };
 
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_inv(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_inv(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -852,8 +923,9 @@ inline vector_type_t<float, SZ> __esimd_inv(vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_log(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_log(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -862,8 +934,9 @@ inline vector_type_t<float, SZ> __esimd_log(vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_exp(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_exp(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -872,8 +945,9 @@ inline vector_type_t<float, SZ> __esimd_exp(vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_sqrt(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_sqrt(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -882,9 +956,9 @@ inline vector_type_t<float, SZ> __esimd_sqrt(vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline vector_type_t<float, SZ>
-__esimd_sqrt_ieee(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_sqrt_ieee(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -893,8 +967,9 @@ __esimd_sqrt_ieee(vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_rsqrt(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_rsqrt(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -903,8 +978,9 @@ inline vector_type_t<float, SZ> __esimd_rsqrt(vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_sin(vector_type_t<float, SZ> src) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_sin(__SIGD::vector_type_t<float, SZ> src) {
+  __SIGD::vector_type_t<float, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     retv[i] = sin(src[i]);
@@ -912,8 +988,9 @@ inline vector_type_t<float, SZ> __esimd_sin(vector_type_t<float, SZ> src) {
   return retv;
 };
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_cos(vector_type_t<float, SZ> src) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_cos(__SIGD::vector_type_t<float, SZ> src) {
+  __SIGD::vector_type_t<float, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     retv[i] = cos(src[i]);
@@ -921,9 +998,10 @@ inline vector_type_t<float, SZ> __esimd_cos(vector_type_t<float, SZ> src) {
   return retv;
 };
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_pow(vector_type_t<float, SZ> src0,
-                                            vector_type_t<float, SZ> src1) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_pow(__SIGD::vector_type_t<float, SZ> src0,
+            __SIGD::vector_type_t<float, SZ> src1) {
+  __SIGD::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -933,10 +1011,11 @@ inline vector_type_t<float, SZ> __esimd_pow(vector_type_t<float, SZ> src0,
 };
 
 template <int SZ>
-inline vector_type_t<float, SZ>
-__esimd_div_ieee(vector_type_t<float, SZ> src0, vector_type_t<float, SZ> src1) {
-  vector_type_t<float, SZ> divinv;
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_div_ieee(__SIGD::vector_type_t<float, SZ> src0,
+                 __SIGD::vector_type_t<float, SZ> src1) {
+  __SIGD::vector_type_t<float, SZ> divinv;
+  __SIGD::vector_type_t<float, SZ> retv;
 
   for (int idx = 0; idx < SZ; idx += 1) {
     SIMDCF_ELEMENT_SKIP(idx);
@@ -952,8 +1031,9 @@ __esimd_div_ieee(vector_type_t<float, SZ> src0, vector_type_t<float, SZ> src1) {
 };
 
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_rndd(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_rndd(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -963,8 +1043,9 @@ inline vector_type_t<float, SZ> __esimd_rndd(vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_rndu(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_rndu(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
   int increment;
 
   for (int i = 0; i < SZ; i++) {
@@ -982,8 +1063,9 @@ inline vector_type_t<float, SZ> __esimd_rndu(vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_rnde(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_rnde(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
   int increment;
 
   for (int i = 0; i < SZ; i++) {
@@ -1003,8 +1085,9 @@ inline vector_type_t<float, SZ> __esimd_rnde(vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline vector_type_t<float, SZ> __esimd_rndz(vector_type_t<float, SZ> src0) {
-  vector_type_t<float, SZ> retv;
+inline __SIGD::vector_type_t<float, SZ>
+__esimd_rndz(__SIGD::vector_type_t<float, SZ> src0) {
+  __SIGD::vector_type_t<float, SZ> retv;
   int increment;
 
   for (int i = 0; i < SZ; i++) {
@@ -1021,9 +1104,9 @@ inline vector_type_t<float, SZ> __esimd_rndz(vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline vector_type_t<double, SZ>
-__esimd_sqrt_ieee(vector_type_t<double, SZ> src0) {
-  vector_type_t<double, SZ> retv;
+inline __SIGD::vector_type_t<double, SZ>
+__esimd_sqrt_ieee(__SIGD::vector_type_t<double, SZ> src0) {
+  __SIGD::vector_type_t<double, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -1033,11 +1116,11 @@ __esimd_sqrt_ieee(vector_type_t<double, SZ> src0) {
 };
 
 template <int SZ>
-inline vector_type_t<double, SZ>
-__esimd_div_ieee(vector_type_t<double, SZ> src0,
-                 vector_type_t<double, SZ> src1) {
-  vector_type_t<double, SZ> divinv;
-  vector_type_t<double, SZ> retv;
+inline __SIGD::vector_type_t<double, SZ>
+__esimd_div_ieee(__SIGD::vector_type_t<double, SZ> src0,
+                 __SIGD::vector_type_t<double, SZ> src1) {
+  __SIGD::vector_type_t<double, SZ> divinv;
+  __SIGD::vector_type_t<double, SZ> retv;
 
   for (int idx = 0; idx < SZ; idx += 1) {
     SIMDCF_ELEMENT_SKIP(idx);
@@ -1053,7 +1136,7 @@ __esimd_div_ieee(vector_type_t<double, SZ> src0,
 };
 
 template <int N>
-inline uint32_t __esimd_pack_mask(vector_type_t<uint16_t, N> src0) {
+inline uint32_t __esimd_pack_mask(__SIGD::vector_type_t<uint16_t, N> src0) {
   // We don't check the arguments here as this function is only invoked by
   // wrapper code (which does the checks already)
   uint32_t retv = 0;
@@ -1067,8 +1150,8 @@ inline uint32_t __esimd_pack_mask(vector_type_t<uint16_t, N> src0) {
 };
 
 template <int N>
-inline vector_type_t<uint16_t, N> __esimd_unpack_mask(uint32_t src0) {
-  vector_type_t<uint16_t, N> retv;
+inline __SIGD::vector_type_t<uint16_t, N> __esimd_unpack_mask(uint32_t src0) {
+  __SIGD::vector_type_t<uint16_t, N> retv;
   for (int i = 0; i < N; i++) {
     if ((src0 >> i) & 0x1) {
       retv[i] = 1;
@@ -1080,17 +1163,19 @@ inline vector_type_t<uint16_t, N> __esimd_unpack_mask(uint32_t src0) {
 };
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-inline vector_type_t<T1, N> __esimd_dp4a(vector_type_t<T2, N> src0,
-                                         vector_type_t<T3, N> src1,
-                                         vector_type_t<T4, N> src2) {
+inline __SIGD::vector_type_t<T1, N>
+__esimd_dp4a(__SIGD::vector_type_t<T2, N> src0,
+             __SIGD::vector_type_t<T3, N> src1,
+             __SIGD::vector_type_t<T4, N> src2) {
+  using sycl::INTEL::gpu::emu::detail::restype_ex;
   typename restype_ex<T2, typename restype_ex<T3, T4>::type>::type reta;
-  vector_type_t<T1, N> retv;
+  __SIGD::vector_type_t<T1, N> retv;
 
   int src1_a, src1_b, src1_c, src1_d, src2_a, src2_b, src2_c, src2_d, ret;
 
-  uint32_t sat1 = EsimdEmulSys::SetSatur<T2, is_inttype<T1>::value>::set() ||
-                  EsimdEmulSys::SetSatur<T3, is_inttype<T1>::value>::set() ||
-                  EsimdEmulSys::SetSatur<T4, is_inttype<T1>::value>::set();
+  uint32_t sat1 = __SIGED::SetSatur<T2, is_inttype<T1>::value>::set() ||
+                  __SIGED::SetSatur<T3, is_inttype<T1>::value>::set() ||
+                  __SIGED::SetSatur<T4, is_inttype<T1>::value>::set();
 
   for (uint32_t i = 0; i < N; i++) {
 
@@ -1107,17 +1192,17 @@ inline vector_type_t<T1, N> __esimd_dp4a(vector_type_t<T2, N> src0,
 
     ret = src1_a * src2_a + src1_b * src2_b + src1_c * src2_c + src1_d * src2_d;
     reta = ret + src0[i];
-    retv[i] = EsimdEmulSys::satur<T1>::saturate(reta, sat1);
+    retv[i] = __SIGED::satur<T1>::saturate(reta, sat1);
   }
 
   return retv;
 };
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_max(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                    sycl::INTEL::gpu::vector_type_t<Ty, N> src2) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_max(__SIGD::vector_type_t<Ty, N> src1,
+                    __SIGD::vector_type_t<Ty, N> src2) {
+  __SIGD::vector_type_t<Ty, N> retv;
   for (int I = 0; I < N; I++) {
     if (src1[I] >= src2[I]) {
       retv[I] = src1[I];
@@ -1129,31 +1214,31 @@ __esimd_reduced_max(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
 }
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_fmax(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2) {
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_fmax(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_max<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_umax(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2) {
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_umax(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_max<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_smax(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2) {
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_smax(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_max<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_min(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                    sycl::INTEL::gpu::vector_type_t<Ty, N> src2) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_min(__SIGD::vector_type_t<Ty, N> src1,
+                    __SIGD::vector_type_t<Ty, N> src2) {
+  __SIGD::vector_type_t<Ty, N> retv;
   for (int I = 0; I < N; I++) {
     if (src1[I] <= src2[I]) {
       retv[I] = src1[I];
@@ -1165,24 +1250,28 @@ __esimd_reduced_min(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
 }
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_fmin(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2) {
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_fmin(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_min<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_umin(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2) {
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_umin(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_min<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_reduced_smin(sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src2) {
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_reduced_smin(__SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_min<Ty, N>(src1, src2);
 }
 
-#endif
+#undef __SIGED
+
+#endif // #ifndef __SYCL_DEVICE_ONLY__
+
+#undef __SIGD

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
@@ -434,7 +434,7 @@ inline __SIGD::vector_type_t<T0, SZ>
 __esimd_ssshl(__SIGD::vector_type_t<T1, SZ> src0,
               __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
-  typename maxtype<T1>::type ret;
+  typename __SIGED::maxtype<T1>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -449,7 +449,7 @@ inline __SIGD::vector_type_t<T0, SZ>
 __esimd_sushl(__SIGD::vector_type_t<T1, SZ> src0,
               __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
-  typename maxtype<T1>::type ret;
+  typename __SIGED::maxtype<T1>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -464,7 +464,7 @@ inline __SIGD::vector_type_t<T0, SZ>
 __esimd_usshl(__SIGD::vector_type_t<T1, SZ> src0,
               __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
-  typename maxtype<T1>::type ret;
+  typename __SIGED::maxtype<T1>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -479,7 +479,7 @@ inline __SIGD::vector_type_t<T0, SZ>
 __esimd_uushl(__SIGD::vector_type_t<T1, SZ> src0,
               __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
-  typename maxtype<T1>::type ret;
+  typename __SIGED::maxtype<T1>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -494,7 +494,7 @@ inline __SIGD::vector_type_t<T0, SZ>
 __esimd_ssshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
                   __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
-  typename maxtype<T1>::type ret;
+  typename __SIGED::maxtype<T1>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -509,7 +509,7 @@ inline __SIGD::vector_type_t<T0, SZ>
 __esimd_sushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
                   __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
-  typename maxtype<T1>::type ret;
+  typename __SIGED::maxtype<T1>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -524,7 +524,7 @@ inline __SIGD::vector_type_t<T0, SZ>
 __esimd_usshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
                   __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
-  typename maxtype<T1>::type ret;
+  typename __SIGED::maxtype<T1>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -539,7 +539,7 @@ inline __SIGD::vector_type_t<T0, SZ>
 __esimd_uushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
                   __SIGD::vector_type_t<T1, SZ> src1) {
   int i;
-  typename maxtype<T1>::type ret;
+  typename __SIGED::maxtype<T1>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -791,7 +791,7 @@ inline __SIGD::vector_type_t<T0, SZ> __esimd_bfins(
     __SIGD::vector_type_t<T0, SZ> width, __SIGD::vector_type_t<T0, SZ> offset,
     __SIGD::vector_type_t<T0, SZ> val, __SIGD::vector_type_t<T0, SZ> src) {
   int i;
-  typename maxtype<T0>::type ret;
+  typename __SIGED::maxtype<T0>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -816,7 +816,7 @@ __esimd_bfext(__SIGD::vector_type_t<T0, SZ> width,
               __SIGD::vector_type_t<T0, SZ> offset,
               __SIGD::vector_type_t<T0, SZ> src) {
   int i;
-  typename maxtype<T0>::type ret;
+  typename __SIGED::maxtype<T0>::type ret;
   __SIGD::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
@@ -1173,9 +1173,9 @@ __esimd_dp4a(__SIGD::vector_type_t<T2, N> src0,
 
   int src1_a, src1_b, src1_c, src1_d, src2_a, src2_b, src2_c, src2_d, ret;
 
-  uint32_t sat1 = __SIGED::SetSatur<T2, is_inttype<T1>::value>::set() ||
-                  __SIGED::SetSatur<T3, is_inttype<T1>::value>::set() ||
-                  __SIGED::SetSatur<T4, is_inttype<T1>::value>::set();
+  uint32_t sat1 = __SIGED::SetSatur<T2, __SIGED::is_inttype<T1>::value>::set() ||
+                  __SIGED::SetSatur<T3, __SIGED::is_inttype<T1>::value>::set() ||
+                  __SIGED::SetSatur<T4, __SIGED::is_inttype<T1>::value>::set();
 
   for (uint32_t i = 0; i < N; i++) {
 

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_memory_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_memory_intrin.hpp
@@ -676,10 +676,8 @@ __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
   // On host the input surface is modeled as sycl image 2d object,
   // and the read/write access is done through accessor,
   // which is passed in as the handle argument.
-  auto range =
-      sycl::INTEL::gpu::detail::AccessorPrivateProxy::getImageRange(handle);
-  unsigned bpp =
-      sycl::INTEL::gpu::detail::AccessorPrivateProxy::getElemSize(handle);
+  auto range = __SIGD::AccessorPrivateProxy::getImageRange(handle);
+  unsigned bpp = __SIGD::AccessorPrivateProxy::getElemSize(handle);
   unsigned vpp = bpp / sizeof(Ty);
   unsigned int i = x / bpp;
   unsigned int j = y;
@@ -727,11 +725,9 @@ inline void __esimd_media_block_store(unsigned modififer, TACC handle,
                                       unsigned plane, unsigned width,
                                       unsigned x, unsigned y,
                                       __SIGD::vector_type_t<Ty, M * N> vals) {
-  unsigned bpp =
-      sycl::INTEL::gpu::detail::AccessorPrivateProxy::getElemSize(handle);
+  unsigned bpp = __SIGD::AccessorPrivateProxy::getElemSize(handle);
   unsigned vpp = bpp / sizeof(Ty);
-  auto range =
-      sycl::INTEL::gpu::detail::AccessorPrivateProxy::getImageRange(handle);
+  auto range = __SIGD::AccessorPrivateProxy::getImageRange(handle);
   unsigned int i = x / bpp;
   unsigned int j = y;
 

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_memory_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_memory_intrin.hpp
@@ -14,73 +14,121 @@
 #include <CL/sycl/INTEL/esimd/detail/esimd_types.hpp>
 #include <CL/sycl/INTEL/esimd/detail/esimd_util.hpp>
 #include <CL/sycl/INTEL/esimd/esimd_enum.hpp>
+#include <CL/sycl/detail/accessor_impl.hpp>
 #include <CL/sycl/types.hpp>
 #include <cstdint>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace INTEL {
+namespace gpu {
+namespace detail {
+// Provides access to sycl accessor class' private members.
+class AccessorPrivateProxy {
+public:
+#ifdef __SYCL_DEVICE_ONLY__
+  template <typename AccessorTy>
+  static auto getNativeImageObj(const AccessorTy &Acc) {
+    return Acc.getNativeImageObj();
+  }
+#else
+  template <typename AccessorTy>
+  static auto getImageRange(const AccessorTy &Acc) {
+    return Acc.getAccessRange();
+  }
+  static auto getElemSize(const sycl::detail::AccessorBaseHost &Acc) {
+    return Acc.getElemSize();
+  }
+#endif
+};
+
+template <int ElemsPerAddr,
+          typename = sycl::detail::enable_if_t<
+              (ElemsPerAddr == 1 || ElemsPerAddr == 2 || ElemsPerAddr == 4)>>
+constexpr unsigned int ElemsPerAddrEncoding() {
+  // encoding requires log2 of ElemsPerAddr
+  if constexpr (ElemsPerAddr == 1)
+    return 0;
+  else if constexpr (ElemsPerAddr == 2)
+    return 1;
+  else if constexpr (ElemsPerAddr == 4)
+    return 2;
+
+  // other cases not needed since enable_if disallows other values
+}
+
+constexpr unsigned int ElemsPerAddrDecoding(unsigned int ElemsPerAddrEncoded) {
+  // encoding requires 2^ElemsPerAddrEncoded
+  return (1 << ElemsPerAddrEncoded);
+}
+
+} // namespace detail
+} // namespace gpu
+} // namespace INTEL
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)
+
+#define __SIGD sycl::INTEL::gpu::detail
 
 // flat_read does flat-address gather
 template <typename Ty, int N, int NumBlk = 0,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<
-    Ty, N * sycl::INTEL::gpu::ElemsPerAddrDecoding(NumBlk)>
-__esimd_flat_read(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                  int ElemsPerAddr = NumBlk,
-                  sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred = 1);
+SYCL_EXTERNAL
+    __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)>
+    __esimd_flat_read(__SIGD::vector_type_t<uint64_t, N> addrs,
+                      int ElemsPerAddr = NumBlk,
+                      __SIGD::vector_type_t<uint16_t, N> pred = 1);
 
 // flat_write does flat-address scatter
 template <typename Ty, int N, int NumBlk = 0,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL void
-__esimd_flat_write(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                   sycl::INTEL::gpu::vector_type_t<
-                       Ty, N * sycl::INTEL::gpu::ElemsPerAddrDecoding(NumBlk)>
-                       vals,
-                   int ElemsPerAddr = NumBlk,
-                   sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred = 1);
+SYCL_EXTERNAL void __esimd_flat_write(
+    __SIGD::vector_type_t<uint64_t, N> addrs,
+    __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)> vals,
+    int ElemsPerAddr = NumBlk, __SIGD::vector_type_t<uint16_t, N> pred = 1);
 
 // flat_block_read reads a block of data from one flat address
 template <typename Ty, int N,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
 __esimd_flat_block_read_unaligned(uint64_t addr);
 
 // flat_block_write writes a block of data using one flat address
 template <typename Ty, int N,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL void
-__esimd_flat_block_write(uint64_t addr,
-                         sycl::INTEL::gpu::vector_type_t<Ty, N> vals);
+SYCL_EXTERNAL void __esimd_flat_block_write(uint64_t addr,
+                                            __SIGD::vector_type_t<Ty, N> vals);
 
 // Reads a block of data from given surface at given offset.
 template <typename Ty, int N, typename SurfIndAliasTy>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
 __esimd_block_read(SurfIndAliasTy surf_ind, uint32_t offset);
 
 // Writes given block of data to a surface with given index at given offset.
 template <typename Ty, int N, typename SurfIndAliasTy>
-SYCL_EXTERNAL void
-__esimd_block_write(SurfIndAliasTy surf_ind, uint32_t offset,
-                    sycl::INTEL::gpu::vector_type_t<Ty, N> vals);
+SYCL_EXTERNAL void __esimd_block_write(SurfIndAliasTy surf_ind, uint32_t offset,
+                                       __SIGD::vector_type_t<Ty, N> vals);
 
 // flat_read4 does flat-address gather4
 template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)> SYCL_EXTERNAL
-__esimd_flat_read4(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                   sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred = 1);
+__SIGD::vector_type_t<Ty, N * NumChannels(Mask)> SYCL_EXTERNAL
+__esimd_flat_read4(__SIGD::vector_type_t<uint64_t, N> addrs,
+                   __SIGD::vector_type_t<uint16_t, N> pred = 1);
 
 // flat_write does flat-address scatter
 template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL void __esimd_flat_write4(
-    sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-    sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)> vals,
-    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred = 1);
+SYCL_EXTERNAL void
+__esimd_flat_write4(__SIGD::vector_type_t<uint64_t, N> addrs,
+                    __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> vals,
+                    __SIGD::vector_type_t<uint16_t, N> pred = 1);
 
 // Low-level surface-based gather. Collects elements located at given offsets in
 // a surface and returns them as a single \ref simd object. Element can be
@@ -106,10 +154,10 @@ SYCL_EXTERNAL void __esimd_flat_write4(
 template <typename Ty, int N, typename SurfIndAliasTy, int TySizeLog2,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
 __esimd_surf_read(int16_t scale, SurfIndAliasTy surf_ind,
                   uint32_t global_offset,
-                  sycl::INTEL::gpu::vector_type_t<uint32_t, N> elem_offsets)
+                  __SIGD::vector_type_t<uint32_t, N> elem_offsets)
 #ifdef __SYCL_DEVICE_ONLY__
     ;
 #else
@@ -149,11 +197,10 @@ template <typename Ty, int N, typename SurfIndAliasTy, int TySizeLog2,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
 SYCL_EXTERNAL void
-__esimd_surf_write(sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
-                   int16_t scale, SurfIndAliasTy surf_ind,
-                   uint32_t global_offset,
-                   sycl::INTEL::gpu::vector_type_t<uint32_t, N> elem_offsets,
-                   sycl::INTEL::gpu::vector_type_t<Ty, N> vals)
+__esimd_surf_write(__SIGD::vector_type_t<uint16_t, N> pred, int16_t scale,
+                   SurfIndAliasTy surf_ind, uint32_t global_offset,
+                   __SIGD::vector_type_t<uint32_t, N> elem_offsets,
+                   __SIGD::vector_type_t<Ty, N> vals)
 #ifdef __SYCL_DEVICE_ONLY__
     ;
 #else
@@ -172,26 +219,24 @@ __esimd_surf_write(sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_flat_atomic0(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                     sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_flat_atomic0(__SIGD::vector_type_t<uint64_t, N> addrs,
+                     __SIGD::vector_type_t<uint16_t, N> pred);
 
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_flat_atomic1(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src0,
-                     sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_flat_atomic1(__SIGD::vector_type_t<uint64_t, N> addrs,
+                     __SIGD::vector_type_t<Ty, N> src0,
+                     __SIGD::vector_type_t<uint16_t, N> pred);
 
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
           sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
           sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_flat_atomic2(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src0,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N> __esimd_flat_atomic2(
+    __SIGD::vector_type_t<uint64_t, N> addrs, __SIGD::vector_type_t<Ty, N> src0,
+    __SIGD::vector_type_t<Ty, N> src1, __SIGD::vector_type_t<uint16_t, N> pred);
 
 // esimd_barrier, generic group barrier
 SYCL_EXTERNAL void __esimd_barrier();
@@ -204,59 +249,56 @@ SYCL_EXTERNAL void __esimd_slm_fence(uint8_t cntl);
 
 // slm_read does SLM gather
 template <typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_slm_read(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                 sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred = 1);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_slm_read(__SIGD::vector_type_t<uint32_t, N> addrs,
+                 __SIGD::vector_type_t<uint16_t, N> pred = 1);
 
 // slm_write does SLM scatter
 template <typename Ty, int N>
 SYCL_EXTERNAL void
-__esimd_slm_write(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                  sycl::INTEL::gpu::vector_type_t<Ty, N> vals,
-                  sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred = 1);
+__esimd_slm_write(__SIGD::vector_type_t<uint32_t, N> addrs,
+                  __SIGD::vector_type_t<Ty, N> vals,
+                  __SIGD::vector_type_t<uint16_t, N> pred = 1);
 
 // slm_block_read reads a block of data from SLM
 template <typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
 __esimd_slm_block_read(uint32_t addr);
 
 // slm_block_write writes a block of data to SLM
 template <typename Ty, int N>
-SYCL_EXTERNAL void
-__esimd_slm_block_write(uint32_t addr,
-                        sycl::INTEL::gpu::vector_type_t<Ty, N> vals);
+SYCL_EXTERNAL void __esimd_slm_block_write(uint32_t addr,
+                                           __SIGD::vector_type_t<Ty, N> vals);
 
 // slm_read4 does SLM gather4
 template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)>
-__esimd_slm_read4(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                  sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred = 1);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N * NumChannels(Mask)>
+__esimd_slm_read4(__SIGD::vector_type_t<uint32_t, N> addrs,
+                  __SIGD::vector_type_t<uint16_t, N> pred = 1);
 
 // slm_write4 does SLM scatter4
 template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask>
-SYCL_EXTERNAL void __esimd_slm_write4(
-    sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-    sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)> vals,
-    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred = 1);
+SYCL_EXTERNAL void
+__esimd_slm_write4(__SIGD::vector_type_t<uint32_t, N> addrs,
+                   __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> vals,
+                   __SIGD::vector_type_t<uint16_t, N> pred = 1);
 
 // slm_atomic: SLM atomic
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_slm_atomic0(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_slm_atomic0(__SIGD::vector_type_t<uint32_t, N> addrs,
+                    __SIGD::vector_type_t<uint16_t, N> pred);
 
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_slm_atomic1(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                    sycl::INTEL::gpu::vector_type_t<Ty, N> src0,
-                    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N>
+__esimd_slm_atomic1(__SIGD::vector_type_t<uint32_t, N> addrs,
+                    __SIGD::vector_type_t<Ty, N> src0,
+                    __SIGD::vector_type_t<uint16_t, N> pred);
 
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_slm_atomic2(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                    sycl::INTEL::gpu::vector_type_t<Ty, N> src0,
-                    sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, N> __esimd_slm_atomic2(
+    __SIGD::vector_type_t<uint32_t, N> addrs, __SIGD::vector_type_t<Ty, N> src0,
+    __SIGD::vector_type_t<Ty, N> src1, __SIGD::vector_type_t<uint16_t, N> pred);
 
 // Media block load
 //
@@ -283,7 +325,7 @@ __esimd_slm_atomic2(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
 // @return the linearized 2D block data read from surface.
 //
 template <typename Ty, int M, int N, typename TACC>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty, M * N>
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty, M * N>
 __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
                          unsigned width, unsigned x, unsigned y);
 
@@ -315,7 +357,7 @@ template <typename Ty, int M, int N, typename TACC>
 SYCL_EXTERNAL void
 __esimd_media_block_store(unsigned modififer, TACC handle, unsigned plane,
                           unsigned width, unsigned x, unsigned y,
-                          sycl::INTEL::gpu::vector_type_t<Ty, M * N> vals);
+                          __SIGD::vector_type_t<Ty, M * N> vals);
 
 /// \brief esimd_get_value
 ///
@@ -359,14 +401,12 @@ SYCL_EXTERNAL uint32_t __esimd_get_value(SurfIndAliasTy sid);
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, typename Ty3, int N3,
           int N = 16>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty1, N1>
-__esimd_raw_sends_load(uint8_t modifier, uint8_t execSize,
-                       sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
-                       uint8_t numSrc0, uint8_t numSrc1, uint8_t numDst,
-                       uint8_t sfid, uint32_t exDesc, uint32_t msgDesc,
-                       sycl::INTEL::gpu::vector_type_t<Ty2, N2> msgSrc0,
-                       sycl::INTEL::gpu::vector_type_t<Ty3, N3> msgSrc1,
-                       sycl::INTEL::gpu::vector_type_t<Ty1, N1> msgDst);
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty1, N1> __esimd_raw_sends_load(
+    uint8_t modifier, uint8_t execSize, __SIGD::vector_type_t<uint16_t, N> pred,
+    uint8_t numSrc0, uint8_t numSrc1, uint8_t numDst, uint8_t sfid,
+    uint32_t exDesc, uint32_t msgDesc, __SIGD::vector_type_t<Ty2, N2> msgSrc0,
+    __SIGD::vector_type_t<Ty3, N3> msgSrc1,
+    __SIGD::vector_type_t<Ty1, N1> msgDst);
 
 /// \brief Raw send load.
 ///
@@ -395,13 +435,12 @@ __esimd_raw_sends_load(uint8_t modifier, uint8_t execSize,
 /// Returns a simd vector of type Ty1 and size N1.
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, int N = 16>
-SYCL_EXTERNAL sycl::INTEL::gpu::vector_type_t<Ty1, N1>
+SYCL_EXTERNAL __SIGD::vector_type_t<Ty1, N1>
 __esimd_raw_send_load(uint8_t modifier, uint8_t execSize,
-                      sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
-                      uint8_t numSrc0, uint8_t numDst, uint8_t sfid,
-                      uint32_t exDesc, uint32_t msgDesc,
-                      sycl::INTEL::gpu::vector_type_t<Ty2, N2> msgSrc0,
-                      sycl::INTEL::gpu::vector_type_t<Ty1, N1> msgDst);
+                      __SIGD::vector_type_t<uint16_t, N> pred, uint8_t numSrc0,
+                      uint8_t numDst, uint8_t sfid, uint32_t exDesc,
+                      uint32_t msgDesc, __SIGD::vector_type_t<Ty2, N2> msgSrc0,
+                      __SIGD::vector_type_t<Ty1, N1> msgDst);
 
 /// \brief Raw sends store.
 ///
@@ -428,13 +467,11 @@ __esimd_raw_send_load(uint8_t modifier, uint8_t execSize,
 /// @param msgSrc1 the second source operand of send message.
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, int N = 16>
-SYCL_EXTERNAL void
-__esimd_raw_sends_store(uint8_t modifier, uint8_t execSize,
-                        sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
-                        uint8_t numSrc0, uint8_t numSrc1, uint8_t sfid,
-                        uint32_t exDesc, uint32_t msgDesc,
-                        sycl::INTEL::gpu::vector_type_t<Ty1, N1> msgSrc0,
-                        sycl::INTEL::gpu::vector_type_t<Ty2, N2> msgSrc1);
+SYCL_EXTERNAL void __esimd_raw_sends_store(
+    uint8_t modifier, uint8_t execSize, __SIGD::vector_type_t<uint16_t, N> pred,
+    uint8_t numSrc0, uint8_t numSrc1, uint8_t sfid, uint32_t exDesc,
+    uint32_t msgDesc, __SIGD::vector_type_t<Ty1, N1> msgSrc0,
+    __SIGD::vector_type_t<Ty2, N2> msgSrc1);
 
 /// \brief Raw send store.
 ///
@@ -458,24 +495,19 @@ __esimd_raw_sends_store(uint8_t modifier, uint8_t execSize,
 template <typename Ty1, int N1, int N = 16>
 SYCL_EXTERNAL void
 __esimd_raw_send_store(uint8_t modifier, uint8_t execSize,
-                       sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
-                       uint8_t numSrc0, uint8_t sfid, uint32_t exDesc,
-                       uint32_t msgDesc,
-                       sycl::INTEL::gpu::vector_type_t<Ty1, N1> msgSrc0);
+                       __SIGD::vector_type_t<uint16_t, N> pred, uint8_t numSrc0,
+                       uint8_t sfid, uint32_t exDesc, uint32_t msgDesc,
+                       __SIGD::vector_type_t<Ty1, N1> msgSrc0);
 #ifndef __SYCL_DEVICE_ONLY__
 
 template <typename Ty, int N, int NumBlk, sycl::INTEL::gpu::CacheHint L1H,
           sycl::INTEL::gpu::CacheHint L3H>
-inline sycl::INTEL::gpu::vector_type_t<
-    Ty, N * sycl::INTEL::gpu::ElemsPerAddrDecoding(NumBlk)>
-__esimd_flat_read(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                  int ElemsPerAddr,
-                  sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  auto NumBlkDecoded = sycl::INTEL::gpu::ElemsPerAddrDecoding(NumBlk);
-  sycl::INTEL::gpu::vector_type_t<
-      Ty, N * sycl::INTEL::gpu::ElemsPerAddrDecoding(NumBlk)>
-      V;
-  ElemsPerAddr = sycl::INTEL::gpu::ElemsPerAddrDecoding(ElemsPerAddr);
+inline __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)>
+__esimd_flat_read(__SIGD::vector_type_t<uint64_t, N> addrs, int ElemsPerAddr,
+                  __SIGD::vector_type_t<uint16_t, N> pred) {
+  auto NumBlkDecoded = __SIGD::ElemsPerAddrDecoding(NumBlk);
+  __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)> V;
+  ElemsPerAddr = __SIGD::ElemsPerAddrDecoding(ElemsPerAddr);
 
   for (int I = 0; I < N; I++) {
     if (pred[I]) {
@@ -496,10 +528,10 @@ __esimd_flat_read(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
 
 template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask,
           sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)>
-__esimd_flat_read4(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                   sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)> V;
+inline __SIGD::vector_type_t<Ty, N * NumChannels(Mask)>
+__esimd_flat_read4(__SIGD::vector_type_t<uint64_t, N> addrs,
+                   __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> V;
   unsigned int Next = 0;
 
   if constexpr (HasR(Mask)) {
@@ -544,15 +576,12 @@ __esimd_flat_read4(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
 
 template <typename Ty, int N, int NumBlk, sycl::INTEL::gpu::CacheHint L1H,
           sycl::INTEL::gpu::CacheHint L3H>
-inline void
-__esimd_flat_write(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                   sycl::INTEL::gpu::vector_type_t<
-                       Ty, N * sycl::INTEL::gpu::ElemsPerAddrDecoding(NumBlk)>
-                       vals,
-                   int ElemsPerAddr,
-                   sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  auto NumBlkDecoded = sycl::INTEL::gpu::ElemsPerAddrDecoding(NumBlk);
-  ElemsPerAddr = sycl::INTEL::gpu::ElemsPerAddrDecoding(ElemsPerAddr);
+inline void __esimd_flat_write(
+    __SIGD::vector_type_t<uint64_t, N> addrs,
+    __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)> vals,
+    int ElemsPerAddr, __SIGD::vector_type_t<uint16_t, N> pred) {
+  auto NumBlkDecoded = __SIGD::ElemsPerAddrDecoding(NumBlk);
+  ElemsPerAddr = __SIGD::ElemsPerAddrDecoding(ElemsPerAddr);
 
   for (int I = 0; I < N; I++) {
     if (pred[I]) {
@@ -572,11 +601,11 @@ __esimd_flat_write(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
 
 template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask,
           sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
-inline void __esimd_flat_write4(
-    sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-    sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)> vals,
-    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)> V;
+inline void
+__esimd_flat_write4(__SIGD::vector_type_t<uint64_t, N> addrs,
+                    __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> vals,
+                    __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> V;
   unsigned int Next = 0;
 
   if constexpr (HasR(Mask)) {
@@ -619,9 +648,9 @@ inline void __esimd_flat_write4(
 
 template <typename Ty, int N, sycl::INTEL::gpu::CacheHint L1H,
           sycl::INTEL::gpu::CacheHint L3H>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
+inline __SIGD::vector_type_t<Ty, N>
 __esimd_flat_block_read_unaligned(uint64_t addr) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> V;
+  __SIGD::vector_type_t<Ty, N> V;
 
   for (int I = 0; I < N; I++) {
     Ty *Addr = reinterpret_cast<Ty *>(addr + I * sizeof(Ty));
@@ -632,9 +661,8 @@ __esimd_flat_block_read_unaligned(uint64_t addr) {
 
 template <typename Ty, int N, sycl::INTEL::gpu::CacheHint L1H,
           sycl::INTEL::gpu::CacheHint L3H>
-inline void
-__esimd_flat_block_write(uint64_t addr,
-                         sycl::INTEL::gpu::vector_type_t<Ty, N> vals) {
+inline void __esimd_flat_block_write(uint64_t addr,
+                                     __SIGD::vector_type_t<Ty, N> vals) {
   for (int I = 0; I < N; I++) {
     Ty *Addr = reinterpret_cast<Ty *>(addr + I * sizeof(Ty));
     *Addr = vals[I];
@@ -642,14 +670,16 @@ __esimd_flat_block_write(uint64_t addr,
 }
 
 template <typename Ty, int M, int N, typename TACC>
-inline sycl::INTEL::gpu::vector_type_t<Ty, M * N>
+inline __SIGD::vector_type_t<Ty, M * N>
 __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
                          unsigned width, unsigned x, unsigned y) {
   // On host the input surface is modeled as sycl image 2d object,
   // and the read/write access is done through accessor,
   // which is passed in as the handle argument.
-  auto range = sycl::INTEL::gpu::AccessorPrivateProxy::getImageRange(handle);
-  unsigned bpp = sycl::INTEL::gpu::AccessorPrivateProxy::getElemSize(handle);
+  auto range =
+      sycl::INTEL::gpu::detail::AccessorPrivateProxy::getImageRange(handle);
+  unsigned bpp =
+      sycl::INTEL::gpu::detail::AccessorPrivateProxy::getElemSize(handle);
   unsigned vpp = bpp / sizeof(Ty);
   unsigned int i = x / bpp;
   unsigned int j = y;
@@ -658,7 +688,7 @@ __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
   unsigned int xbound = range[0] - 1;
   unsigned int ybound = range[1] - 1;
 
-  sycl::INTEL::gpu::vector_type_t<Ty, M * N> vals;
+  __SIGD::vector_type_t<Ty, M * N> vals;
   for (int row = 0; row < M; row++) {
     for (int col = 0; col < N; col += vpp) {
       unsigned int xoff = (i > xbound) ? xbound : i;
@@ -666,14 +696,14 @@ __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
       auto coords = cl::sycl::cl_int2(xoff, yoff);
       cl::sycl::cl_uint4 data = handle.read(coords);
 
-      sycl::INTEL::gpu::vector_type_t<unsigned int, 4> res;
+      __SIGD::vector_type_t<unsigned int, 4> res;
       for (int idx = 0; idx < 4; idx++) {
         res[idx] = data[idx];
       }
 
       constexpr int refN = sizeof(cl::sycl::cl_uint4) / sizeof(Ty);
       unsigned int stride = sizeof(cl::sycl::cl_uint4) / bpp;
-      using refTy = sycl::INTEL::gpu::vector_type_t<Ty, refN>;
+      using refTy = __SIGD::vector_type_t<Ty, refN>;
       auto ref = reinterpret_cast<refTy>(res);
 
       unsigned int offset1 = col + row * N;
@@ -693,13 +723,15 @@ __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
 }
 
 template <typename Ty, int M, int N, typename TACC>
-inline void
-__esimd_media_block_store(unsigned modififer, TACC handle, unsigned plane,
-                          unsigned width, unsigned x, unsigned y,
-                          sycl::INTEL::gpu::vector_type_t<Ty, M * N> vals) {
-  unsigned bpp = sycl::INTEL::gpu::AccessorPrivateProxy::getElemSize(handle);
+inline void __esimd_media_block_store(unsigned modififer, TACC handle,
+                                      unsigned plane, unsigned width,
+                                      unsigned x, unsigned y,
+                                      __SIGD::vector_type_t<Ty, M * N> vals) {
+  unsigned bpp =
+      sycl::INTEL::gpu::detail::AccessorPrivateProxy::getElemSize(handle);
   unsigned vpp = bpp / sizeof(Ty);
-  auto range = sycl::INTEL::gpu::AccessorPrivateProxy::getImageRange(handle);
+  auto range =
+      sycl::INTEL::gpu::detail::AccessorPrivateProxy::getImageRange(handle);
   unsigned int i = x / bpp;
   unsigned int j = y;
 
@@ -708,7 +740,7 @@ __esimd_media_block_store(unsigned modififer, TACC handle, unsigned plane,
   for (int row = 0; row < M; row++) {
     for (int col = 0; col < N; col += vpp) {
       constexpr int Sz = sizeof(cl::sycl::cl_uint4) / sizeof(Ty);
-      sycl::INTEL::gpu::vector_type_t<Ty, Sz> res = 0;
+      __SIGD::vector_type_t<Ty, Sz> res = 0;
 
       unsigned int offset1 = col + row * N;
       unsigned int offset2 = 0;
@@ -719,7 +751,7 @@ __esimd_media_block_store(unsigned modififer, TACC handle, unsigned plane,
         offset2 += stride;
       }
 
-      using refTy = sycl::INTEL::gpu::vector_type_t<unsigned int, 4>;
+      using refTy = __SIGD::vector_type_t<unsigned int, 4>;
       auto ref = reinterpret_cast<refTy>(res);
 
       cl::sycl::cl_uint4 data;
@@ -739,7 +771,7 @@ __esimd_media_block_store(unsigned modififer, TACC handle, unsigned plane,
 }
 
 template <typename Ty, int N>
-inline uint16_t __esimd_any(sycl::INTEL::gpu::vector_type_t<Ty, N> src) {
+inline uint16_t __esimd_any(__SIGD::vector_type_t<Ty, N> src) {
   for (unsigned int i = 0; i != N; i++) {
     if (src[i] != 0)
       return 1;
@@ -748,7 +780,7 @@ inline uint16_t __esimd_any(sycl::INTEL::gpu::vector_type_t<Ty, N> src) {
 }
 
 template <typename Ty, int N>
-inline uint16_t __esimd_all(sycl::INTEL::gpu::vector_type_t<Ty, N> src) {
+inline uint16_t __esimd_all(__SIGD::vector_type_t<Ty, N> src) {
   for (unsigned int i = 0; i != N; i++) {
     if (src[i] == 0)
       return 0;
@@ -757,10 +789,9 @@ inline uint16_t __esimd_all(sycl::INTEL::gpu::vector_type_t<Ty, N> src) {
 }
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_dp4(sycl::INTEL::gpu::vector_type_t<Ty, N> v1,
-            sycl::INTEL::gpu::vector_type_t<Ty, N> v2) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_dp4(__SIGD::vector_type_t<Ty, N> v1, __SIGD::vector_type_t<Ty, N> v2) {
+  __SIGD::vector_type_t<Ty, N> retv;
   for (auto i = 0; i != N; i += 4) {
     Ty dp = (v1[i] * v2[i]) + (v1[i + 1] * v2[i + 1]) +
             (v1[i + 2] * v2[i + 2]) + (v1[i + 3] * v2[i + 3]);
@@ -780,118 +811,115 @@ inline void __esimd_sbarrier(sycl::INTEL::gpu::EsimdSbarrierType flag) {}
 inline void __esimd_slm_fence(uint8_t cntl) {}
 
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_slm_read(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                 sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_slm_read(__SIGD::vector_type_t<uint32_t, N> addrs,
+                 __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 // slm_write does SLM scatter
 template <typename Ty, int N>
-inline void
-__esimd_slm_write(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                  sycl::INTEL::gpu::vector_type_t<Ty, N> vals,
-                  sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {}
+inline void __esimd_slm_write(__SIGD::vector_type_t<uint32_t, N> addrs,
+                              __SIGD::vector_type_t<Ty, N> vals,
+                              __SIGD::vector_type_t<uint16_t, N> pred) {}
 
 // slm_block_read reads a block of data from SLM
 template <typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_slm_block_read(uint32_t addr) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N> __esimd_slm_block_read(uint32_t addr) {
+  __SIGD::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 // slm_block_write writes a block of data to SLM
 template <typename Ty, int N>
-inline void
-__esimd_slm_block_write(uint32_t addr,
-                        sycl::INTEL::gpu::vector_type_t<Ty, N> vals) {}
+inline void __esimd_slm_block_write(uint32_t addr,
+                                    __SIGD::vector_type_t<Ty, N> vals) {}
 
 // slm_read4 does SLM gather4
 template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)>
-__esimd_slm_read4(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                  sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)> retv;
+inline __SIGD::vector_type_t<Ty, N * NumChannels(Mask)>
+__esimd_slm_read4(__SIGD::vector_type_t<uint32_t, N> addrs,
+                  __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> retv;
   return retv;
 }
 
 // slm_write4 does SLM scatter4
 template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask>
-inline void __esimd_slm_write4(
-    sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-    sycl::INTEL::gpu::vector_type_t<Ty, N * NumChannels(Mask)> vals,
-    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {}
+inline void
+__esimd_slm_write4(__SIGD::vector_type_t<uint32_t, N> addrs,
+                   __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> vals,
+                   __SIGD::vector_type_t<uint16_t, N> pred) {}
 
 // slm_atomic: SLM atomic
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_slm_atomic0(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_slm_atomic0(__SIGD::vector_type_t<uint32_t, N> addrs,
+                    __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_slm_atomic1(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                    sycl::INTEL::gpu::vector_type_t<Ty, N> src0,
-                    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_slm_atomic1(__SIGD::vector_type_t<uint32_t, N> addrs,
+                    __SIGD::vector_type_t<Ty, N> src0,
+                    __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_slm_atomic2(sycl::INTEL::gpu::vector_type_t<uint32_t, N> addrs,
-                    sycl::INTEL::gpu::vector_type_t<Ty, N> src0,
-                    sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                    sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_slm_atomic2(__SIGD::vector_type_t<uint32_t, N> addrs,
+                    __SIGD::vector_type_t<Ty, N> src0,
+                    __SIGD::vector_type_t<Ty, N> src1,
+                    __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
           sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_flat_atomic0(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                     sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_flat_atomic0(__SIGD::vector_type_t<uint64_t, N> addrs,
+                     __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
           sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_flat_atomic1(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src0,
-                     sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_flat_atomic1(__SIGD::vector_type_t<uint64_t, N> addrs,
+                     __SIGD::vector_type_t<Ty, N> src0,
+                     __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
           sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_flat_atomic2(sycl::INTEL::gpu::vector_type_t<uint64_t, N> addrs,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src0,
-                     sycl::INTEL::gpu::vector_type_t<Ty, N> src1,
-                     sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred) {
-  sycl::INTEL::gpu::vector_type_t<Ty, N> retv;
+inline __SIGD::vector_type_t<Ty, N>
+__esimd_flat_atomic2(__SIGD::vector_type_t<uint64_t, N> addrs,
+                     __SIGD::vector_type_t<Ty, N> src0,
+                     __SIGD::vector_type_t<Ty, N> src1,
+                     __SIGD::vector_type_t<uint16_t, N> pred) {
+  __SIGD::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 template <typename Ty, int N, typename SurfIndAliasTy>
-inline sycl::INTEL::gpu::vector_type_t<Ty, N>
-__esimd_block_read(SurfIndAliasTy surf_ind, uint32_t offset) {
+inline __SIGD::vector_type_t<Ty, N> __esimd_block_read(SurfIndAliasTy surf_ind,
+                                                       uint32_t offset) {
   throw cl::sycl::feature_not_supported();
-  return sycl::INTEL::gpu::vector_type_t<Ty, N>();
+  return __SIGD::vector_type_t<Ty, N>();
 }
 
 template <typename Ty, int N, typename SurfIndAliasTy>
 inline void __esimd_block_write(SurfIndAliasTy surf_ind, uint32_t offset,
-                                sycl::INTEL::gpu::vector_type_t<Ty, N> vals) {
+                                __SIGD::vector_type_t<Ty, N> vals) {
 
   throw cl::sycl::feature_not_supported();
 }
@@ -941,14 +969,12 @@ inline uint32_t __esimd_get_value(AccessorTy acc) {
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, typename Ty3, int N3,
           int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty1, N1>
-__esimd_raw_sends_load(uint8_t modifier, uint8_t execSize,
-                       sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
-                       uint8_t numSrc0, uint8_t numSrc1, uint8_t numDst,
-                       uint8_t sfid, uint32_t exDesc, uint32_t msgDesc,
-                       sycl::INTEL::gpu::vector_type_t<Ty2, N2> msgSrc0,
-                       sycl::INTEL::gpu::vector_type_t<Ty3, N3> msgSrc1,
-                       sycl::INTEL::gpu::vector_type_t<Ty1, N1> msgDst) {
+inline __SIGD::vector_type_t<Ty1, N1> __esimd_raw_sends_load(
+    uint8_t modifier, uint8_t execSize, __SIGD::vector_type_t<uint16_t, N> pred,
+    uint8_t numSrc0, uint8_t numSrc1, uint8_t numDst, uint8_t sfid,
+    uint32_t exDesc, uint32_t msgDesc, __SIGD::vector_type_t<Ty2, N2> msgSrc0,
+    __SIGD::vector_type_t<Ty3, N3> msgSrc1,
+    __SIGD::vector_type_t<Ty1, N1> msgDst) {
   throw cl::sycl::feature_not_supported();
   return 0;
 }
@@ -980,13 +1006,12 @@ __esimd_raw_sends_load(uint8_t modifier, uint8_t execSize,
 /// Returns a simd vector of type Ty1 and size N1.
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, int N>
-inline sycl::INTEL::gpu::vector_type_t<Ty1, N1>
+inline __SIGD::vector_type_t<Ty1, N1>
 __esimd_raw_send_load(uint8_t modifier, uint8_t execSize,
-                      sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
-                      uint8_t numSrc0, uint8_t numDst, uint8_t sfid,
-                      uint32_t exDesc, uint32_t msgDesc,
-                      sycl::INTEL::gpu::vector_type_t<Ty2, N2> msgSrc0,
-                      sycl::INTEL::gpu::vector_type_t<Ty1, N1> msgDst) {
+                      __SIGD::vector_type_t<uint16_t, N> pred, uint8_t numSrc0,
+                      uint8_t numDst, uint8_t sfid, uint32_t exDesc,
+                      uint32_t msgDesc, __SIGD::vector_type_t<Ty2, N2> msgSrc0,
+                      __SIGD::vector_type_t<Ty1, N1> msgDst) {
   throw cl::sycl::feature_not_supported();
   return 0;
 }
@@ -1016,13 +1041,13 @@ __esimd_raw_send_load(uint8_t modifier, uint8_t execSize,
 /// @param msgSrc1 the second source operand of send message.
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, int N>
-inline void
-__esimd_raw_sends_store(uint8_t modifier, uint8_t execSize,
-                        sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
-                        uint8_t numSrc0, uint8_t numSrc1, uint8_t sfid,
-                        uint32_t exDesc, uint32_t msgDesc,
-                        sycl::INTEL::gpu::vector_type_t<Ty1, N1> msgSrc0,
-                        sycl::INTEL::gpu::vector_type_t<Ty2, N2> msgSrc1) {
+inline void __esimd_raw_sends_store(uint8_t modifier, uint8_t execSize,
+                                    __SIGD::vector_type_t<uint16_t, N> pred,
+                                    uint8_t numSrc0, uint8_t numSrc1,
+                                    uint8_t sfid, uint32_t exDesc,
+                                    uint32_t msgDesc,
+                                    __SIGD::vector_type_t<Ty1, N1> msgSrc0,
+                                    __SIGD::vector_type_t<Ty2, N2> msgSrc1) {
   throw cl::sycl::feature_not_supported();
 }
 
@@ -1046,13 +1071,14 @@ __esimd_raw_sends_store(uint8_t modifier, uint8_t execSize,
 /// @param msgSrc0 the first source operand of send message.
 ///
 template <typename Ty1, int N1, int N>
-inline void
-__esimd_raw_send_store(uint8_t modifier, uint8_t execSize,
-                       sycl::INTEL::gpu::vector_type_t<uint16_t, N> pred,
-                       uint8_t numSrc0, uint8_t sfid, uint32_t exDesc,
-                       uint32_t msgDesc,
-                       sycl::INTEL::gpu::vector_type_t<Ty1, N1> msgSrc0) {
+inline void __esimd_raw_send_store(uint8_t modifier, uint8_t execSize,
+                                   __SIGD::vector_type_t<uint16_t, N> pred,
+                                   uint8_t numSrc0, uint8_t sfid,
+                                   uint32_t exDesc, uint32_t msgDesc,
+                                   __SIGD::vector_type_t<Ty1, N1> msgSrc0) {
   throw cl::sycl::feature_not_supported();
 }
 
 #endif // __SYCL_DEVICE_ONLY__
+
+#undef __SIGD

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_types.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_types.hpp
@@ -22,9 +22,16 @@ namespace sycl {
 namespace INTEL {
 namespace gpu {
 
+// simd and simd_view forward declarations
+template <typename Ty, int N> class simd;
+template <typename BaseTy, typename RegionTy> class simd_view;
+
+namespace detail {
+
 namespace csd = cl::sycl::detail;
 
 using half = cl::sycl::detail::half_impl::StorageT;
+using namespace sycl::INTEL::gpu;
 
 template <typename T>
 using remove_cvref_t = csd::remove_cv_t<csd::remove_reference_t<T>>;
@@ -67,20 +74,6 @@ template <typename Ty, int N> struct vector_type {
 
 template <typename Ty, int N>
 using vector_type_t = typename vector_type<Ty, N>::type;
-
-// TODO @rolandschulz on May 21
-// {quote}
-// - The mask should also be a wrapper around the clang - vector type rather
-//   than the clang - vector type itself.
-// - The internal storage should be implementation defined.uint16_t is a bad
-//   choice for some HW.Nor is it how clang - vector types works(using the same
-//   size int as the corresponding vector type used for comparison(e.g. long for
-//   double and int for float)).
-template <int N> using mask_type_t = typename vector_type<uint16_t, N>::type;
-
-// simd and simd_view forward declarations
-template <typename Ty, int N> class simd;
-template <typename BaseTy, typename RegionTy> class simd_view;
 
 // Compute the simd_view type of a 1D format operation.
 template <typename BaseTy, typename EltTy> struct compute_format_type;
@@ -207,8 +200,8 @@ template <typename T1, typename T2> struct computation_type {
 template <typename U> constexpr bool is_type() { return false; }
 
 template <typename U, typename T, typename... Ts> constexpr bool is_type() {
-  using UU = typename detail::remove_const_t<U>;
-  using TT = typename detail::remove_const_t<T>;
+  using UU = typename csd::remove_const_t<U>;
+  using TT = typename csd::remove_const_t<T>;
   return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
 }
 
@@ -227,7 +220,7 @@ struct bitcast_helper {
 // Change the element type of a simd vector.
 template <typename ToEltTy, typename FromEltTy, int FromN,
           typename = csd::enable_if_t<is_vectorizable<ToEltTy>::value>>
-ESIMD_INLINE typename detail::conditional_t<
+ESIMD_INLINE typename csd::conditional_t<
     std::is_same<FromEltTy, ToEltTy>::value, vector_type_t<FromEltTy, FromN>,
     vector_type_t<ToEltTy,
                   bitcast_helper<ToEltTy, FromEltTy, FromN>::nToElems()>>
@@ -253,6 +246,18 @@ inline std::istream &operator>>(std::istream &I, half &rhs) {
   rhs = ValFloat;
   return I;
 }
+} // namespace detail
+
+// TODO @rolandschulz on May 21
+// {quote}
+// - The mask should also be a wrapper around the clang - vector type rather
+//   than the clang - vector type itself.
+// - The internal storage should be implementation defined.uint16_t is a bad
+//   choice for some HW.Nor is it how clang - vector types works(using the same
+//   size int as the corresponding vector type used for comparison(e.g. long for
+//   double and int for float)).
+template <int N>
+using mask_type_t = typename detail::vector_type<uint16_t, N>::type;
 
 } // namespace gpu
 } // namespace INTEL

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_util.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_util.hpp
@@ -10,12 +10,19 @@
 
 #pragma once
 
+#include <CL/sycl/INTEL/esimd/detail/esimd_types.hpp>
 #include <CL/sycl/detail/type_traits.hpp>
 
-namespace __esimd {
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace INTEL {
+namespace gpu {
+namespace detail {
 
-/// Constant in number of bytes.
-enum { BYTE = 1, WORD = 2, DWORD = 4, QWORD = 8, OWORD = 16, GRF = 32 };
+/// ESIMD intrinsic operand size in bytes.
+struct OperandSize {
+  enum { BYTE = 1, WORD = 2, DWORD = 4, QWORD = 8, OWORD = 16, GRF = 32 };
+};
 
 /// Compute next power of 2 of a constexpr with guaranteed compile-time
 /// evaluation.
@@ -65,20 +72,6 @@ static ESIMD_INLINE constexpr bool isPowerOf2(unsigned int n,
   return (n & (n - 1)) == 0 && n <= limit;
 }
 
-} // namespace __esimd
-
-__SYCL_INLINE_NAMESPACE(cl) {
-namespace sycl {
-namespace INTEL {
-namespace gpu {
-
-constexpr unsigned int ElemsPerAddrDecoding(unsigned int ElemsPerAddrEncoded) {
-  // encoding requires 2^ElemsPerAddrEncoded
-  return (1 << ElemsPerAddrEncoded);
-}
-
-namespace detail {
-
 /// type traits
 template <typename T> struct is_esimd_vector {
   static const bool value = false;
@@ -88,7 +81,7 @@ struct is_esimd_vector<sycl::INTEL::gpu::simd<T, N>> {
   static const bool value = true;
 };
 template <typename T, int N>
-struct is_esimd_vector<sycl::INTEL::gpu::vector_type<T, N>> {
+struct is_esimd_vector<sycl::INTEL::gpu::detail::vector_type<T, N>> {
   static const bool value = true;
 };
 
@@ -106,7 +99,7 @@ struct is_dword_type
                            typename sycl::detail::remove_const_t<T>>::value> {};
 
 template <typename T, int N>
-struct is_dword_type<sycl::INTEL::gpu::vector_type<T, N>> {
+struct is_dword_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
   static const bool value = is_dword_type<T>::value;
 };
 
@@ -125,7 +118,7 @@ struct is_word_type
                            typename sycl::detail::remove_const_t<T>>::value> {};
 
 template <typename T, int N>
-struct is_word_type<sycl::INTEL::gpu::vector_type<T, N>> {
+struct is_word_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
   static const bool value = is_word_type<T>::value;
 };
 
@@ -142,7 +135,7 @@ struct is_byte_type
                            typename sycl::detail::remove_const_t<T>>::value> {};
 
 template <typename T, int N>
-struct is_byte_type<sycl::INTEL::gpu::vector_type<T, N>> {
+struct is_byte_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
   static const bool value = is_byte_type<T>::value;
 };
 
@@ -185,7 +178,7 @@ struct is_qword_type
                            typename sycl::detail::remove_const_t<T>>::value> {};
 
 template <typename T, int N>
-struct is_qword_type<sycl::INTEL::gpu::vector_type<T, N>> {
+struct is_qword_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
   static const bool value = is_qword_type<T>::value;
 };
 
@@ -196,7 +189,7 @@ struct is_qword_type<sycl::INTEL::gpu::simd<T, N>> {
 
 // Extends to ESIMD vector types.
 template <typename T, int N>
-struct is_fp_or_dword_type<sycl::INTEL::gpu::vector_type<T, N>> {
+struct is_fp_or_dword_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
   static const bool value = is_fp_or_dword_type<T>::value;
 };
 
@@ -210,7 +203,7 @@ template <typename T> struct simd_type {
   using type = sycl::INTEL::gpu::simd<T, 1>;
 };
 template <typename T, int N>
-struct simd_type<sycl::INTEL::gpu::vector_type<T, N>> {
+struct simd_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
   using type = sycl::INTEL::gpu::simd<T, N>;
 };
 

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd.hpp
@@ -18,6 +18,8 @@ namespace sycl {
 namespace INTEL {
 namespace gpu {
 
+using namespace sycl::INTEL::gpu::detail;
+
 /// The simd vector class.
 ///
 /// This is a wrapper class for llvm vector values. Additionally this class
@@ -29,7 +31,7 @@ namespace gpu {
 template <typename Ty, int N> class simd {
 public:
   /// The underlying builtin data type.
-  using vector_type = vector_type_t<Ty, N>;
+  using vector_type = detail::vector_type_t<Ty, N>;
 
   /// The element type of this simd object.
   using element_type = Ty;

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_enum.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_enum.hpp
@@ -48,6 +48,8 @@ using uint = unsigned int;
 #define ESIMD_INLINE inline __attribute__((always_inline))
 
 // Enums
+// TODO FIXME convert the two enums below to nested enum or class enum to
+// remove enum values from the global namespace
 enum { GENX_NOSAT = 0, GENX_SAT };
 
 enum ChannelMaskType {

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_math.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_math.hpp
@@ -1879,7 +1879,7 @@ T0 esimd_reduce_single(simd<T1, SZ> v) {
   if constexpr (SZ == 1) {
     return v[0];
   } else {
-    static_assert(__esimd::isPowerOf2(SZ),
+    static_assert(detail::isPowerOf2(SZ),
                   "Invaid input for esimd_reduce_single - the vector size must "
                   "be power of two.");
     constexpr int N = SZ / 2;
@@ -1903,7 +1903,7 @@ T0 esimd_reduce_pair(simd<T1, N1> v1, simd<T1, N2> v2) {
     return esimd_reduce_pair<T0, T0, N1, N, OpType>(tmp1, tmp2);
   } else {
     static_assert(
-        __esimd::isPowerOf2(N1),
+        detail::isPowerOf2(N1),
         "Invaid input for esimd_reduce_pair - N1 must be power of two.");
     constexpr int N = N1 / 2;
     simd<T0, N> tmp = OpType<T0, T1, N>()(v1.template select<N, 1>(0),
@@ -1917,11 +1917,11 @@ T0 esimd_reduce_pair(simd<T1, N1> v1, simd<T1, N2> v2) {
 template <typename T0, typename T1, int SZ,
           template <typename RT, typename T, int N> class OpType>
 T0 esimd_reduce(simd<T1, SZ> v) {
-  constexpr bool isPowerOf2 = __esimd::isPowerOf2(SZ);
+  constexpr bool isPowerOf2 = detail::isPowerOf2(SZ);
   if constexpr (isPowerOf2) {
     return esimd_reduce_single<T0, T1, SZ, OpType>(v);
   } else {
-    constexpr unsigned N1 = 1u << __esimd::log2<SZ>();
+    constexpr unsigned N1 = 1u << detail::log2<SZ>();
     constexpr unsigned N2 = SZ - N1;
 
     simd<T1, N1> v1 = v.template select<N1, 1>(0);

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_memory.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_memory.hpp
@@ -23,21 +23,6 @@ namespace sycl {
 namespace INTEL {
 namespace gpu {
 
-template <int ElemsPerAddr,
-          typename = sycl::detail::enable_if_t<
-              (ElemsPerAddr == 1 || ElemsPerAddr == 2 || ElemsPerAddr == 4)>>
-constexpr unsigned int ElemsPerAddrEncoding() {
-  // encoding requires log2 of ElemsPerAddr
-  if constexpr (ElemsPerAddr == 1)
-    return 0;
-  else if constexpr (ElemsPerAddr == 2)
-    return 1;
-  else if constexpr (ElemsPerAddr == 4)
-    return 2;
-
-  // other cases not needed since enable_if disallows other values
-}
-
 // TODO @Pennycook
 // {quote}
 // ...I'd like us to think more about what we can do to make these interfaces
@@ -95,25 +80,32 @@ gather(T *p, simd<uint32_t, n> offsets, simd<uint16_t, n> pred = 1) {
   addrs = addrs + offsets_i;
 
   if constexpr (sizeof(T) == 1 && ElemsPerAddr == 2) {
-    auto Ret = __esimd_flat_read<T, n, ElemsPerAddrEncoding<4>(), L1H, L3H>(
-        addrs.data(), ElemsPerAddrEncoding<ElemsPerAddr>(), pred.data());
+    auto Ret =
+        __esimd_flat_read<T, n, detail::ElemsPerAddrEncoding<4>(), L1H, L3H>(
+            addrs.data(), detail::ElemsPerAddrEncoding<ElemsPerAddr>(),
+            pred.data());
     return __esimd_rdregion<T, n * 4, n * ElemsPerAddr, /*VS*/ 4, 2, 1>(Ret, 0);
   } else if constexpr (sizeof(T) == 1 && ElemsPerAddr == 1) {
-    auto Ret = __esimd_flat_read<T, n, ElemsPerAddrEncoding<4>(), L1H, L3H>(
-        addrs.data(), ElemsPerAddrEncoding<ElemsPerAddr>(), pred.data());
+    auto Ret =
+        __esimd_flat_read<T, n, detail::ElemsPerAddrEncoding<4>(), L1H, L3H>(
+            addrs.data(), detail::ElemsPerAddrEncoding<ElemsPerAddr>(),
+            pred.data());
     return __esimd_rdregion<T, n * 4, n * ElemsPerAddr, /*VS*/ 0, n, 4>(Ret, 0);
   } else if constexpr (sizeof(T) == 2 && ElemsPerAddr == 1) {
-    auto Ret = __esimd_flat_read<T, n, ElemsPerAddrEncoding<2>(), L1H, L3H>(
-        addrs.data(), ElemsPerAddrEncoding<2>(), pred.data());
+    auto Ret =
+        __esimd_flat_read<T, n, detail::ElemsPerAddrEncoding<2>(), L1H, L3H>(
+            addrs.data(), detail::ElemsPerAddrEncoding<2>(), pred.data());
     return __esimd_rdregion<T, n * 2, n, /*VS*/ 0, n, 2>(Ret, 0);
   } else if constexpr (sizeof(T) == 2)
-    return __esimd_flat_read<T, n, ElemsPerAddrEncoding<ElemsPerAddr>(), L1H,
-                             L3H>(
-        addrs.data(), ElemsPerAddrEncoding<2 * ElemsPerAddr>(), pred.data());
+    return __esimd_flat_read<T, n, detail::ElemsPerAddrEncoding<ElemsPerAddr>(),
+                             L1H, L3H>(
+        addrs.data(), detail::ElemsPerAddrEncoding<2 * ElemsPerAddr>(),
+        pred.data());
   else
-    return __esimd_flat_read<T, n, ElemsPerAddrEncoding<ElemsPerAddr>(), L1H,
-                             L3H>(
-        addrs.data(), ElemsPerAddrEncoding<ElemsPerAddr>(), pred.data());
+    return __esimd_flat_read<T, n, detail::ElemsPerAddrEncoding<ElemsPerAddr>(),
+                             L1H, L3H>(
+        addrs.data(), detail::ElemsPerAddrEncoding<ElemsPerAddr>(),
+        pred.data());
 }
 
 // TODO bring this SVM-based scatter/gather interface in accordance with
@@ -139,29 +131,31 @@ scatter(T *p, simd<T, n * ElemsPerAddr> vals, simd<uint32_t, n> offsets,
     simd<T, n * 4> D;
     D = __esimd_wrregion<T, n * 4, n * ElemsPerAddr, /*VS*/ 4, 2, 1>(
         D.data(), vals.data(), 0);
-    __esimd_flat_write<T, n, ElemsPerAddrEncoding<4>(), L1H, L3H>(
-        addrs.data(), D.data(), ElemsPerAddrEncoding<ElemsPerAddr>(),
+    __esimd_flat_write<T, n, detail::ElemsPerAddrEncoding<4>(), L1H, L3H>(
+        addrs.data(), D.data(), detail::ElemsPerAddrEncoding<ElemsPerAddr>(),
         pred.data());
   } else if constexpr (sizeof(T) == 1 && ElemsPerAddr == 1) {
     simd<T, n * 4> D;
     D = __esimd_wrregion<T, n * 4, n * ElemsPerAddr, /*VS*/ 0, n, 4>(
         D.data(), vals.data(), 0);
-    __esimd_flat_write<T, n, ElemsPerAddrEncoding<4>(), L1H, L3H>(
-        addrs.data(), D.data(), ElemsPerAddrEncoding<ElemsPerAddr>(),
+    __esimd_flat_write<T, n, detail::ElemsPerAddrEncoding<4>(), L1H, L3H>(
+        addrs.data(), D.data(), detail::ElemsPerAddrEncoding<ElemsPerAddr>(),
         pred.data());
   } else if constexpr (sizeof(T) == 2 && ElemsPerAddr == 1) {
     simd<T, n * 2> D;
     D = __esimd_wrregion<T, n * 2, n, /*VS*/ 0, n, 2>(D.data(), vals.data(), 0);
-    __esimd_flat_write<T, n, ElemsPerAddrEncoding<2>(), L1H, L3H>(
-        addrs.data(), D.data(), ElemsPerAddrEncoding<2>(), pred.data());
+    __esimd_flat_write<T, n, detail::ElemsPerAddrEncoding<2>(), L1H, L3H>(
+        addrs.data(), D.data(), detail::ElemsPerAddrEncoding<2>(), pred.data());
   } else if constexpr (sizeof(T) == 2)
-    __esimd_flat_write<T, n, ElemsPerAddrEncoding<ElemsPerAddr>(), L1H, L3H>(
-        addrs.data(), vals.data(), ElemsPerAddrEncoding<2 * ElemsPerAddr>(),
-        pred.data());
+    __esimd_flat_write<T, n, detail::ElemsPerAddrEncoding<ElemsPerAddr>(), L1H,
+                       L3H>(addrs.data(), vals.data(),
+                            detail::ElemsPerAddrEncoding<2 * ElemsPerAddr>(),
+                            pred.data());
   else
-    __esimd_flat_write<T, n, ElemsPerAddrEncoding<ElemsPerAddr>(), L1H, L3H>(
-        addrs.data(), vals.data(), ElemsPerAddrEncoding<ElemsPerAddr>(),
-        pred.data());
+    __esimd_flat_write<T, n, detail::ElemsPerAddrEncoding<ElemsPerAddr>(), L1H,
+                       L3H>(addrs.data(), vals.data(),
+                            detail::ElemsPerAddrEncoding<ElemsPerAddr>(),
+                            pred.data());
 }
 
 // TODO @rolandschulz
@@ -174,12 +168,13 @@ template <typename T, int n, CacheHint L1H = CacheHint::None,
           CacheHint L3H = CacheHint::None>
 ESIMD_INLINE ESIMD_NODEBUG simd<T, n> block_load(const T *const addr) {
   constexpr unsigned Sz = sizeof(T) * n;
-  static_assert(Sz >= __esimd::OWORD, "block size must be at least 1 oword");
-  static_assert(Sz % __esimd::OWORD == 0,
+  static_assert(Sz >= detail::OperandSize::OWORD,
+                "block size must be at least 1 oword");
+  static_assert(Sz % detail::OperandSize::OWORD == 0,
                 "block size must be whole number of owords");
-  static_assert(__esimd::isPowerOf2(Sz / __esimd::OWORD),
+  static_assert(detail::isPowerOf2(Sz / detail::OperandSize::OWORD),
                 "block must be 1, 2, 4 or 8 owords long");
-  static_assert(Sz <= 8 * __esimd::OWORD,
+  static_assert(Sz <= 8 * detail::OperandSize::OWORD,
                 "block size must be at most 8 owords");
 
   uintptr_t Addr = reinterpret_cast<uintptr_t>(addr);
@@ -192,16 +187,17 @@ template <typename T, int n, typename AccessorTy>
 ESIMD_INLINE ESIMD_NODEBUG simd<T, n> block_load(AccessorTy acc,
                                                  uint32_t offset) {
   constexpr unsigned Sz = sizeof(T) * n;
-  static_assert(Sz >= __esimd::OWORD, "block size must be at least 1 oword");
-  static_assert(Sz % __esimd::OWORD == 0,
+  static_assert(Sz >= detail::OperandSize::OWORD,
+                "block size must be at least 1 oword");
+  static_assert(Sz % detail::OperandSize::OWORD == 0,
                 "block size must be whole number of owords");
-  static_assert(__esimd::isPowerOf2(Sz / __esimd::OWORD),
+  static_assert(detail::isPowerOf2(Sz / detail::OperandSize::OWORD),
                 "block must be 1, 2, 4 or 8 owords long");
-  static_assert(Sz <= 8 * __esimd::OWORD,
+  static_assert(Sz <= 8 * detail::OperandSize::OWORD,
                 "block size must be at most 8 owords");
 
 #if defined(__SYCL_DEVICE_ONLY__)
-  auto surf_ind = AccessorPrivateProxy::getNativeImageObj(acc);
+  auto surf_ind = detail::AccessorPrivateProxy::getNativeImageObj(acc);
   return __esimd_block_read<T, n>(surf_ind, offset);
 #else
   return __esimd_block_read<T, n>(acc, offset);
@@ -214,12 +210,13 @@ template <typename T, int n, CacheHint L1H = CacheHint::None,
           CacheHint L3H = CacheHint::None>
 ESIMD_INLINE ESIMD_NODEBUG void block_store(T *p, simd<T, n> vals) {
   constexpr unsigned Sz = sizeof(T) * n;
-  static_assert(Sz >= __esimd::OWORD, "block size must be at least 1 oword");
-  static_assert(Sz % __esimd::OWORD == 0,
+  static_assert(Sz >= detail::OperandSize::OWORD,
+                "block size must be at least 1 oword");
+  static_assert(Sz % detail::OperandSize::OWORD == 0,
                 "block size must be whole number of owords");
-  static_assert(__esimd::isPowerOf2(Sz / __esimd::OWORD),
+  static_assert(detail::isPowerOf2(Sz / detail::OperandSize::OWORD),
                 "block must be 1, 2, 4 or 8 owords long");
-  static_assert(Sz <= 8 * __esimd::OWORD,
+  static_assert(Sz <= 8 * detail::OperandSize::OWORD,
                 "block size must be at most 8 owords");
 
   uintptr_t Addr = reinterpret_cast<uintptr_t>(p);
@@ -232,16 +229,17 @@ template <typename T, int n, typename AccessorTy>
 ESIMD_INLINE ESIMD_NODEBUG void block_store(AccessorTy acc, uint32_t offset,
                                             simd<T, n> vals) {
   constexpr unsigned Sz = sizeof(T) * n;
-  static_assert(Sz >= __esimd::OWORD, "block size must be at least 1 oword");
-  static_assert(Sz % __esimd::OWORD == 0,
+  static_assert(Sz >= detail::OperandSize::OWORD,
+                "block size must be at least 1 oword");
+  static_assert(Sz % detail::OperandSize::OWORD == 0,
                 "block size must be whole number of owords");
-  static_assert(__esimd::isPowerOf2(Sz / __esimd::OWORD),
+  static_assert(detail::isPowerOf2(Sz / detail::OperandSize::OWORD),
                 "block must be 1, 2, 4 or 8 owords long");
-  static_assert(Sz <= 8 * __esimd::OWORD,
+  static_assert(Sz <= 8 * detail::OperandSize::OWORD,
                 "block size must be at most 8 owords");
 
 #if defined(__SYCL_DEVICE_ONLY__)
-  auto surf_ind = AccessorPrivateProxy::getNativeImageObj(acc);
+  auto surf_ind = detail::AccessorPrivateProxy::getNativeImageObj(acc);
   __esimd_block_write<T, n>(surf_ind, offset >> 4, vals.data());
 #else
   __esimd_block_write<T, n>(acc, offset >> 4, vals.data());
@@ -275,7 +273,7 @@ ESIMD_INLINE ESIMD_NODEBUG
            uint32_t glob_offset = 0) {
 
   constexpr int TypeSizeLog2 =
-      sycl::INTEL::gpu::ElemsPerAddrEncoding<sizeof(T)>();
+      sycl::INTEL::gpu::detail::ElemsPerAddrEncoding<sizeof(T)>();
   // TODO (performance) use hardware-supported scale once BE supports it
   constexpr uint32_t scale = 0;
   constexpr uint32_t t_scale = sizeof(T);
@@ -291,7 +289,7 @@ ESIMD_INLINE ESIMD_NODEBUG
         typename sycl::detail::conditional_t<std::is_signed<T>::value, int32_t,
                                              uint32_t>;
 #if defined(__SYCL_DEVICE_ONLY__)
-    const auto surf_ind = AccessorPrivateProxy::getNativeImageObj(acc);
+    const auto surf_ind = detail::AccessorPrivateProxy::getNativeImageObj(acc);
     const simd<PromoT, N> promo_vals =
         __esimd_surf_read<PromoT, N, decltype(surf_ind), TypeSizeLog2, L1H,
                           L3H>(scale, surf_ind, glob_offset, offsets);
@@ -303,7 +301,7 @@ ESIMD_INLINE ESIMD_NODEBUG
     return sycl::INTEL::gpu::convert<T>(promo_vals);
   } else {
 #if defined(__SYCL_DEVICE_ONLY__)
-    const auto surf_ind = AccessorPrivateProxy::getNativeImageObj(acc);
+    const auto surf_ind = detail::AccessorPrivateProxy::getNativeImageObj(acc);
     return __esimd_surf_read<T, N, decltype(surf_ind), TypeSizeLog2, L1H, L3H>(
         scale, surf_ind, glob_offset, offsets);
 #else
@@ -343,7 +341,7 @@ ESIMD_INLINE ESIMD_NODEBUG
             uint32_t glob_offset = 0, simd<uint16_t, N> pred = 1) {
 
   constexpr int TypeSizeLog2 =
-      sycl::INTEL::gpu::ElemsPerAddrEncoding<sizeof(T)>();
+      sycl::INTEL::gpu::detail::ElemsPerAddrEncoding<sizeof(T)>();
   // TODO (performance) use hardware-supported scale once BE supports it
   constexpr uint32_t scale = 0;
   constexpr uint32_t t_scale = sizeof(T);
@@ -360,7 +358,7 @@ ESIMD_INLINE ESIMD_NODEBUG
                                              uint32_t>;
     const simd<PromoT, N> promo_vals = sycl::INTEL::gpu::convert<PromoT>(vals);
 #if defined(__SYCL_DEVICE_ONLY__)
-    const auto surf_ind = AccessorPrivateProxy::getNativeImageObj(acc);
+    const auto surf_ind = detail::AccessorPrivateProxy::getNativeImageObj(acc);
     __esimd_surf_write<PromoT, N, decltype(surf_ind), TypeSizeLog2, L1H, L3H>(
         pred, scale, surf_ind, glob_offset, offsets, promo_vals);
 #else
@@ -369,7 +367,7 @@ ESIMD_INLINE ESIMD_NODEBUG
 #endif
   } else {
 #if defined(__SYCL_DEVICE_ONLY__)
-    const auto surf_ind = AccessorPrivateProxy::getNativeImageObj(acc);
+    const auto surf_ind = detail::AccessorPrivateProxy::getNativeImageObj(acc);
     __esimd_surf_write<T, N, decltype(surf_ind), TypeSizeLog2, L1H, L3H>(
         pred, scale, surf_ind, glob_offset, offsets, vals);
 #else
@@ -433,12 +431,13 @@ ESIMD_INLINE ESIMD_NODEBUG
                                             pred.data());
 }
 
+namespace detail {
 /// Check the legality of an atomic call in terms of size and type.
 /// \ingroup sycl_esimd
 template <EsimdAtomicOpType Op, typename T, int N, unsigned NumSrc>
 constexpr bool check_atomic() {
-  if constexpr (!__esimd::isPowerOf2(N, 32)) {
-    static_assert((__esimd::isPowerOf2(N, 32)),
+  if constexpr (!detail::isPowerOf2(N, 32)) {
+    static_assert((detail::isPowerOf2(N, 32)),
                   "Execution size 1, 2, 4, 8, 16, 32 are supported");
     return false;
   }
@@ -531,6 +530,7 @@ constexpr bool check_atomic() {
   // Unsupported svm atomic Op.
   return false;
 }
+} // namespace detail
 
 // TODO @Pennycook
 // {quote}
@@ -545,7 +545,8 @@ constexpr bool check_atomic() {
 template <EsimdAtomicOpType Op, typename T, int n,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<check_atomic<Op, T, n, 0>(), simd<T, n>>
+    typename sycl::detail::enable_if_t<detail::check_atomic<Op, T, n, 0>(),
+                                       simd<T, n>>
     flat_atomic(T *p, simd<unsigned, n> offset, simd<ushort, n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
   simd<uintptr_t, n> offset_i1 = convert<uintptr_t>(offset);
@@ -558,7 +559,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 template <EsimdAtomicOpType Op, typename T, int n,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<check_atomic<Op, T, n, 1>(), simd<T, n>>
+    typename sycl::detail::enable_if_t<detail::check_atomic<Op, T, n, 1>(),
+                                       simd<T, n>>
     flat_atomic(T *p, simd<unsigned, n> offset, simd<T, n> src0,
                 simd<ushort, n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
@@ -573,7 +575,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 template <EsimdAtomicOpType Op, typename T, int n,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<check_atomic<Op, T, n, 2>(), simd<T, n>>
+    typename sycl::detail::enable_if_t<detail::check_atomic<Op, T, n, 2>(),
+                                       simd<T, n>>
     flat_atomic(T *p, simd<unsigned, n> offset, simd<T, n> src0,
                 simd<T, n> src1, simd<ushort, n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
@@ -682,12 +685,13 @@ slm_store4(simd<T, n * NumChannels(Mask)> vals, simd<uint32_t, n> offsets,
 template <typename T, int n>
 ESIMD_INLINE ESIMD_NODEBUG simd<T, n> slm_block_load(uint32_t offset) {
   constexpr unsigned Sz = sizeof(T) * n;
-  static_assert(Sz >= __esimd::OWORD, "block size must be at least 1 oword");
-  static_assert(Sz % __esimd::OWORD == 0,
+  static_assert(Sz >= detail::OperandSize::OWORD,
+                "block size must be at least 1 oword");
+  static_assert(Sz % detail::OperandSize::OWORD == 0,
                 "block size must be whole number of owords");
-  static_assert(__esimd::isPowerOf2(Sz / __esimd::OWORD),
+  static_assert(detail::isPowerOf2(Sz / detail::OperandSize::OWORD),
                 "block must be 1, 2, 4 or 8 owords long");
-  static_assert(Sz <= 16 * __esimd::OWORD,
+  static_assert(Sz <= 16 * detail::OperandSize::OWORD,
                 "block size must be at most 16 owords");
 
   return __esimd_slm_block_read<T, n>(offset >> 4);
@@ -698,12 +702,13 @@ template <typename T, int n>
 ESIMD_INLINE ESIMD_NODEBUG void slm_block_store(uint32_t offset,
                                                 simd<T, n> vals) {
   constexpr unsigned Sz = sizeof(T) * n;
-  static_assert(Sz >= __esimd::OWORD, "block size must be at least 1 oword");
-  static_assert(Sz % __esimd::OWORD == 0,
+  static_assert(Sz >= detail::OperandSize::OWORD,
+                "block size must be at least 1 oword");
+  static_assert(Sz % detail::OperandSize::OWORD == 0,
                 "block size must be whole number of owords");
-  static_assert(__esimd::isPowerOf2(Sz / __esimd::OWORD),
+  static_assert(detail::isPowerOf2(Sz / detail::OperandSize::OWORD),
                 "block must be 1, 2, 4 or 8 owords long");
-  static_assert(Sz <= 8 * __esimd::OWORD,
+  static_assert(Sz <= 8 * detail::OperandSize::OWORD,
                 "block size must be at most 8 owords");
 
   // offset in genx.oword.st is in owords
@@ -713,7 +718,8 @@ ESIMD_INLINE ESIMD_NODEBUG void slm_block_store(uint32_t offset,
 /// SLM atomic, zero source operand: inc and dec.
 template <EsimdAtomicOpType Op, typename T, int n>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<check_atomic<Op, T, n, 0>(), simd<T, n>>
+    typename sycl::detail::enable_if_t<detail::check_atomic<Op, T, n, 0>(),
+                                       simd<T, n>>
     slm_atomic(simd<uint32_t, n> offsets, simd<ushort, n> pred) {
   return __esimd_slm_atomic0<Op, T, n>(offsets.data(), pred.data());
 }
@@ -721,7 +727,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// SLM atomic, one source operand, add/sub/min/max etc.
 template <EsimdAtomicOpType Op, typename T, int n>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<check_atomic<Op, T, n, 1>(), simd<T, n>>
+    typename sycl::detail::enable_if_t<detail::check_atomic<Op, T, n, 1>(),
+                                       simd<T, n>>
     slm_atomic(simd<uint32_t, n> offsets, simd<T, n> src0,
                simd<ushort, n> pred) {
   return __esimd_slm_atomic1<Op, T, n>(offsets.data(), src0.data(),
@@ -731,7 +738,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// SLM atomic, two source operands.
 template <EsimdAtomicOpType Op, typename T, int n>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<check_atomic<Op, T, n, 2>(), simd<T, n>>
+    typename sycl::detail::enable_if_t<detail::check_atomic<Op, T, n, 2>(),
+                                       simd<T, n>>
     slm_atomic(simd<uint32_t, n> offsets, simd<T, n> src0, simd<T, n> src1,
                simd<ushort, n> pred) {
   return __esimd_slm_atomic2<Op, T, n>(offsets.data(), src0.data(), src1.data(),
@@ -763,18 +771,18 @@ media_block_load(AccessorTy acc, unsigned x, unsigned y) {
   static_assert(plane <= 3u, "valid plane index is in range [0, 3]");
 #if defined(__SYCL_DEVICE_ONLY__)
   constexpr unsigned int RoundedWidth =
-      Width < 4 ? 4 : __esimd::getNextPowerOf2<Width>();
+      Width < 4 ? 4 : detail::getNextPowerOf2<Width>();
 
   if constexpr (Width < RoundedWidth) {
     constexpr unsigned int n1 = RoundedWidth / sizeof(T);
     simd<T, m *n1> temp = __esimd_media_block_load<T, m, n1>(
-        0, AccessorPrivateProxy::getNativeImageObj(acc), plane, sizeof(T) * n,
-        x, y);
+        0, detail::AccessorPrivateProxy::getNativeImageObj(acc), plane,
+        sizeof(T) * n, x, y);
     return temp.template select<m, 1, n, 1>(0, 0);
   } else {
     return __esimd_media_block_load<T, m, n>(
-        0, AccessorPrivateProxy::getNativeImageObj(acc), plane, sizeof(T) * n,
-        x, y);
+        0, detail::AccessorPrivateProxy::getNativeImageObj(acc), plane,
+        sizeof(T) * n, x, y);
   }
 #else
   return __esimd_media_block_load<T, m, n>(0, acc, plane, sizeof(T) * n, x, y);
@@ -805,7 +813,7 @@ media_block_store(AccessorTy acc, unsigned x, unsigned y, simd<T, m * n> vals) {
   static_assert(plane <= 3u, "valid plane index is in range [0, 3]");
 #if defined(__SYCL_DEVICE_ONLY__)
   constexpr unsigned int RoundedWidth =
-      Width < 4 ? 4 : __esimd::getNextPowerOf2<Width>();
+      Width < 4 ? 4 : detail::getNextPowerOf2<Width>();
   constexpr unsigned int n1 = RoundedWidth / sizeof(T);
 
   if constexpr (Width < RoundedWidth) {
@@ -814,12 +822,12 @@ media_block_store(AccessorTy acc, unsigned x, unsigned y, simd<T, m * n> vals) {
     auto vals_ref = vals.template format<T, m, n>();
     temp_ref.template select<m, 1, n, 1>() = vals_ref;
     __esimd_media_block_store<T, m, n1>(
-        0, AccessorPrivateProxy::getNativeImageObj(acc), plane, sizeof(T) * n,
-        x, y, temp);
+        0, detail::AccessorPrivateProxy::getNativeImageObj(acc), plane,
+        sizeof(T) * n, x, y, temp);
   } else {
     __esimd_media_block_store<T, m, n>(
-        0, AccessorPrivateProxy::getNativeImageObj(acc), plane, sizeof(T) * n,
-        x, y, vals);
+        0, detail::AccessorPrivateProxy::getNativeImageObj(acc), plane,
+        sizeof(T) * n, x, y, vals);
   }
 #else
   __esimd_media_block_store<T, m, n>(0, acc, plane, sizeof(T) * n, x, y, vals);
@@ -841,7 +849,8 @@ inline void slm_init(uint32_t size) {}
 template <typename AccessorTy>
 ESIMD_INLINE ESIMD_NODEBUG uint32_t esimd_get_value(AccessorTy acc) {
 #if defined(__SYCL_DEVICE_ONLY__)
-  return __esimd_get_value(AccessorPrivateProxy::getNativeImageObj(acc));
+  return __esimd_get_value(
+      detail::AccessorPrivateProxy::getNativeImageObj(acc));
 #else
   return __esimd_get_value(acc);
 #endif // __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_view.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_view.hpp
@@ -34,7 +34,8 @@ public:
   using value_type = simd<typename ShapeTy::element_type, length>;
 
   /// The underlying builtin value type
-  using vector_type = vector_type_t<typename ShapeTy::element_type, length>;
+  using vector_type =
+      detail::vector_type_t<typename ShapeTy::element_type, length>;
 
   /// The region type of this class.
   using region_type = RegionTy;

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -205,8 +205,10 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace INTEL {
 namespace gpu {
+namespace detail {
 // Forward declare a "back-door" access class to support ESIMD.
 class AccessorPrivateProxy;
+} // namespace detail
 } // namespace gpu
 } // namespace INTEL
 } // namespace sycl
@@ -459,7 +461,7 @@ private:
 #endif
 
 private:
-  friend class sycl::INTEL::gpu::AccessorPrivateProxy;
+  friend class sycl::INTEL::gpu::detail::AccessorPrivateProxy;
 
 #ifdef __SYCL_DEVICE_ONLY__
   const OCLImageTy getNativeImageObj() const { return MImageObj; }
@@ -916,7 +918,7 @@ public:
 #endif // __SYCL_DEVICE_ONLY__
 
 private:
-  friend class sycl::INTEL::gpu::AccessorPrivateProxy;
+  friend class sycl::INTEL::gpu::detail::AccessorPrivateProxy;
 
 public:
   using value_type = DataT;

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -19,8 +19,10 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace INTEL {
 namespace gpu {
+namespace detail {
 // Forward declare a "back-door" access class to support ESIMD.
 class AccessorPrivateProxy;
+} // namespace detail
 } // namespace gpu
 } // namespace INTEL
 } // namespace sycl
@@ -161,7 +163,7 @@ protected:
   AccessorImplPtr impl;
 
 private:
-  friend class sycl::INTEL::gpu::AccessorPrivateProxy;
+  friend class sycl::INTEL::gpu::detail::AccessorPrivateProxy;
 };
 
 class __SYCL_EXPORT LocalAccessorImplHost {

--- a/sycl/test/esimd/esimd-util-compiler-eval.cpp
+++ b/sycl/test/esimd/esimd-util-compiler-eval.cpp
@@ -4,12 +4,12 @@
 #include "CL/sycl.hpp"
 #include "CL/sycl/INTEL/esimd/esimd.hpp"
 
-static_assert(__esimd::getNextPowerOf2<0>() == 0, "");
-static_assert(__esimd::getNextPowerOf2<1>() == 1, "");
-static_assert(__esimd::getNextPowerOf2<7>() == 8, "");
-static_assert(__esimd::getNextPowerOf2<1024>() == 1024, "");
+static_assert(sycl::INTEL::gpu::detail::getNextPowerOf2<0>() == 0, "");
+static_assert(sycl::INTEL::gpu::detail::getNextPowerOf2<1>() == 1, "");
+static_assert(sycl::INTEL::gpu::detail::getNextPowerOf2<7>() == 8, "");
+static_assert(sycl::INTEL::gpu::detail::getNextPowerOf2<1024>() == 1024, "");
 
-static_assert(__esimd::log2<0>() == 0, "");
-static_assert(__esimd::log2<1>() == 0, "");
-static_assert(__esimd::log2<7>() == 2, "");
-static_assert(__esimd::log2<1024 * 1024>() == 20, "");
+static_assert(sycl::INTEL::gpu::detail::log2<0>() == 0, "");
+static_assert(sycl::INTEL::gpu::detail::log2<1>() == 0, "");
+static_assert(sycl::INTEL::gpu::detail::log2<7>() == 2, "");
+static_assert(sycl::INTEL::gpu::detail::log2<1024 * 1024>() == 20, "");


### PR DESCRIPTION
- Move ESIMD API declarations that are implementaion details into
sycl::INTEL::gpu::detail and sycl::INTEL::gpu::emu::detail
namespaces.

- Make enum { BYTE = 1, WORD = 2, ..., GRF = 32 } local to a struct
to avoid global namespace pollution.

- Relocate AccessorPrivateProxy to memory intrinsics header(s) where
it is only supposed to be used.

- get rid of extra __esimd namespace

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>