### PR TITLE
[SYCL] Fix DeclareSYCLBuiltins for round-trip setting.

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3496,6 +3496,9 @@ void CompilerInvocation::GenerateLangArgs(const LangOptions &Opts,
   if (Opts.getSignReturnAddressKey() ==
       LangOptions::SignReturnAddressKeyKind::BKey)
     GenerateArg(Args, OPT_msign_return_address_key_EQ, "b_key", SA);
+
+  if (Opts.DeclareSPIRVBuiltins)
+    GenerateArg(Args, OPT_fdeclare_spirv_builtins, SA);
 }
 
 bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,


### PR DESCRIPTION
Upstream LLVMadded a round-trip functionality to the command line args so
that we can generate a full set of command line arguments from our
existing state.  At the moment, this is 'assert' build only, but it
seems the intent is to make this perminent for future functionality.

We will have to analyze the full set of our command line args to make
sure we do this right (that is, that it gets set right the 2nd time),
but this one fixes the DeclareSYCLBuiltins to unblock the pulldown's
build.