### PR TITLE
[SYCL] Allow pointers to const and volatile in sub-group load

### DIFF
--- a/sycl/include/CL/sycl/ONEAPI/sub_group.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/sub_group.hpp
@@ -226,20 +226,22 @@ struct sub_group {
   /* these can map to SIMD or block read/write hardware where available */
 #ifdef __SYCL_DEVICE_ONLY__
   // Method for decorated pointer
-  template <typename T>
+  template <typename CVT, typename T = std::remove_cv_t<CVT>>
   detail::enable_if_t<
       !std::is_same<typename detail::remove_AS<T>::type, T>::value, T>
-  load(T *src) const {
+  load(CVT *cv_src) const {
+    T *src = const_cast<T *>(cv_src);
     return load(sycl::multi_ptr<typename detail::remove_AS<T>::type,
                                 sycl::detail::deduce_AS<T>::value>(
         (typename detail::remove_AS<T>::type *)src));
   }
 
   // Method for raw pointer
-  template <typename T>
+  template <typename CVT, typename T = std::remove_cv_t<CVT>>
   detail::enable_if_t<
       std::is_same<typename detail::remove_AS<T>::type, T>::value, T>
-  load(T *src) const {
+  load(CVT *cv_src) const {
+    T *src = const_cast<T *>(cv_src);
 
 #ifdef __NVPTX__
     return src[get_local_id()[0]];
@@ -257,17 +259,20 @@ struct sub_group {
 #endif // __NVPTX__
   }
 #else  //__SYCL_DEVICE_ONLY__
-  template <typename T> T load(T *src) const {
+  template <typename CVT, typename T = std::remove_cv_t<CVT>>
+  T load(CVT *src) const {
     (void)src;
     throw runtime_error("Sub-groups are not supported on host device.",
                         PI_INVALID_DEVICE);
   }
 #endif //__SYCL_DEVICE_ONLY__
 
-  template <typename T, access::address_space Space>
+  template <typename CVT, access::address_space Space,
+            typename T = std::remove_cv_t<CVT>>
   sycl::detail::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value, T>
-  load(const multi_ptr<T, Space> src) const {
+  load(const multi_ptr<CVT, Space> cv_src) const {
+    multi_ptr<T, Space> src = const_cast<T *>(static_cast<CVT *>(cv_src));
 #ifdef __SYCL_DEVICE_ONLY__
 #ifdef __NVPTX__
     return src.get()[get_local_id()[0]];
@@ -281,10 +286,12 @@ struct sub_group {
 #endif
   }
 
-  template <typename T, access::address_space Space>
+  template <typename CVT, access::address_space Space,
+            typename T = std::remove_cv_t<CVT>>
   sycl::detail::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value, T>
-  load(const multi_ptr<T, Space> src) const {
+  load(const multi_ptr<CVT, Space> cv_src) const {
+    multi_ptr<T, Space> src = const_cast<T *>(static_cast<CVT *>(cv_src));
 #ifdef __SYCL_DEVICE_ONLY__
     return src.get()[get_local_id()[0]];
 #else
@@ -295,11 +302,13 @@ struct sub_group {
   }
 #ifdef __SYCL_DEVICE_ONLY__
 #ifdef __NVPTX__
-  template <int N, typename T, access::address_space Space>
+  template <int N, typename CVT, access::address_space Space,
+            typename T = std::remove_cv_t<CVT>>
   sycl::detail::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value,
       vec<T, N>>
-  load(const multi_ptr<T, Space> src) const {
+  load(const multi_ptr<CVT, Space> cv_src) const {
+    multi_ptr<T, Space> src = const_cast<T *>(static_cast<CVT *>(cv_src));
     vec<T, N> res;
     for (int i = 0; i < N; ++i) {
       res[i] = *(src.get() + i * get_max_local_range()[0] + get_local_id()[0]);
@@ -307,63 +316,74 @@ struct sub_group {
     return res;
   }
 #else  // __NVPTX__
-  template <int N, typename T, access::address_space Space>
+  template <int N, typename CVT, access::address_space Space,
+            typename T = std::remove_cv_t<CVT>>
   sycl::detail::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N != 1 && N != 3 && N != 16,
       vec<T, N>>
-  load(const multi_ptr<T, Space> src) const {
+  load(const multi_ptr<CVT, Space> cv_src) const {
+    multi_ptr<T, Space> src = const_cast<T *>(static_cast<CVT *>(cv_src));
     return sycl::detail::sub_group::load<N, T>(src);
   }
 
-  template <int N, typename T, access::address_space Space>
+  template <int N, typename CVT, access::address_space Space,
+            typename T = std::remove_cv_t<CVT>>
   sycl::detail::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N == 16,
       vec<T, 16>>
-  load(const multi_ptr<T, Space> src) const {
+  load(const multi_ptr<CVT, Space> cv_src) const {
+    multi_ptr<T, Space> src = const_cast<T *>(static_cast<CVT *>(cv_src));
     return {sycl::detail::sub_group::load<8, T>(src),
             sycl::detail::sub_group::load<8, T>(src +
                                                 8 * get_max_local_range()[0])};
   }
 
-  template <int N, typename T, access::address_space Space>
+  template <int N, typename CVT, access::address_space Space,
+            typename T = std::remove_cv_t<CVT>>
   sycl::detail::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N == 3,
       vec<T, 3>>
-  load(const multi_ptr<T, Space> src) const {
+  load(const multi_ptr<CVT, Space> cv_src) const {
+    multi_ptr<T, Space> src = const_cast<T *>(static_cast<CVT *>(cv_src));
     return {
         sycl::detail::sub_group::load<1, T>(src),
         sycl::detail::sub_group::load<2, T>(src + get_max_local_range()[0])};
   }
 
-  template <int N, typename T, access::address_space Space>
+  template <int N, typename CVT, access::address_space Space,
+            typename T = std::remove_cv_t<CVT>>
   sycl::detail::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N == 1,
       vec<T, 1>>
-  load(const multi_ptr<T, Space> src) const {
+  load(const multi_ptr<CVT, Space> cv_src) const {
+    multi_ptr<T, Space> src = const_cast<T *>(static_cast<CVT *>(cv_src));
     return sycl::detail::sub_group::load(src);
   }
 #endif // ___NVPTX___
 #else  // __SYCL_DEVICE_ONLY__
-  template <int N, typename T, access::address_space Space>
+  template <int N, typename CVT, access::address_space Space,
+            typename T = std::remove_cv_t<CVT>>
   sycl::detail::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value,
       vec<T, N>>
-  load(const multi_ptr<T, Space> src) const {
+  load(const multi_ptr<CVT, Space> src) const {
     (void)src;
     throw runtime_error("Sub-groups are not supported on host device.",
                         PI_INVALID_DEVICE);
   }
 #endif // __SYCL_DEVICE_ONLY__
 
-  template <int N, typename T, access::address_space Space>
+  template <int N, typename CVT, access::address_space Space,
+            typename T = std::remove_cv_t<CVT>>
   sycl::detail::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value,
       vec<T, N>>
-  load(const multi_ptr<T, Space> src) const {
+  load(const multi_ptr<CVT, Space> cv_src) const {
+    multi_ptr<T, Space> src = const_cast<T *>(static_cast<CVT *>(cv_src));
 #ifdef __SYCL_DEVICE_ONLY__
     vec<T, N> res;
     for (int i = 0; i < N; ++i) {


### PR DESCRIPTION
In every `load()` overload, use `T` with `const` and `volatile` removed.