### PR TITLE
[SYCL] Allow max-concurrency attribute on lambdas.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1898,6 +1898,7 @@ def SYCLIntelFPGAMaxConcurrency : DeclOrStmtAttr {
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let HasCustomTypeTransform = 1;
   let Documentation = [SYCLIntelFPGAMaxConcurrencyAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def SYCLIntelFPGALoopCoalesce : StmtAttr {

--- a/clang/test/SemaSYCL/max-concurrency.cpp
+++ b/clang/test/SemaSYCL/max-concurrency.cpp
@@ -80,10 +80,6 @@ int main() {
     Functor2 f2;
     h.single_task<class kernel_name2>(f2);
 
-    // Applying attributes to lambdas is a nonconforming extension. This will
-    // remain an an error until the SYCL specifications allow it or until
-    // users require it. Refer to comments about
-    // SupportsNonconformingLambdaSyntax bit in Attr.td.
     h.single_task<class kernel_name3>(
       []() [[intel::max_concurrency(3)]]{});
 

--- a/clang/test/SemaSYCL/max-concurrency.cpp
+++ b/clang/test/SemaSYCL/max-concurrency.cpp
@@ -85,7 +85,7 @@ int main() {
     // users require it. Refer to comments about
     // SupportsNonconformingLambdaSyntax bit in Attr.td.
     h.single_task<class kernel_name3>(
-      []() [[intel::max_concurrency(3)]]{}); // expected-error{{'max_concurrency' attribute cannot be applied to types}}
+      []() [[intel::max_concurrency(3)]]{});
 
     Functor3<4> f3;
     h.single_task<class kernel_name4>(f3);


### PR DESCRIPTION
Signed-off-by: Zahira Ammarguellat <zahira.ammarguellat@intel.com>