### PR TITLE
[SYCL] Fix StringLiteral Ctor issue from #3504.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -73,7 +73,7 @@ public:
   template <size_t N>
   static constexpr DeclContextDesc MakeDeclContextDesc(Decl::Kind K,
                                                        const char (&Str)[N]) {
-    return DeclContextDesc{K, llvm::StringLiteral{Str}};
+    return DeclContextDesc{K, llvm::StringRef{Str, N}};
   }
 
   static constexpr DeclContextDesc MakeDeclContextDesc(Decl::Kind K,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -73,7 +73,12 @@ public:
   template <size_t N>
   static constexpr DeclContextDesc MakeDeclContextDesc(Decl::Kind K,
                                                        const char (&Str)[N]) {
-    return DeclContextDesc{K, llvm::StringRef{Str, N}};
+    // FIXME: This SHOULD be able to use the StringLiteral constructor here
+    // instead, however this seems to fail with an 'invalid string literal' note
+    // on the correct constructor in some build configurations.  We need to
+    // figure that out before reverting this to use the StringLiteral
+    // constructor.
+    return DeclContextDesc{K, StringRef{Str, N}};
   }
 
   static constexpr DeclContextDesc MakeDeclContextDesc(Decl::Kind K,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -78,7 +78,7 @@ public:
     // on the correct constructor in some build configurations.  We need to
     // figure that out before reverting this to use the StringLiteral
     // constructor.
-    return DeclContextDesc{K, StringRef{Str, N}};
+    return DeclContextDesc{K, StringRef{Str, N - 1}};
   }
 
   static constexpr DeclContextDesc MakeDeclContextDesc(Decl::Kind K,


### PR DESCRIPTION
I'm not sure what causes this to not like this conversion, the error
message seems incorrect and only on certain configs of the build, but we
should fix the build anyway.  This calls the StringRef pointer-size
directly, rather than having the StringLiteral type do it.