### PR TITLE
[SYCL] Move sycl.hpp in install directory and adjust driver to match

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -705,10 +705,14 @@ SYCLToolChain::GetCXXStdlibType(const ArgList &Args) const {
 void SYCLToolChain::AddSYCLIncludeArgs(const clang::driver::Driver &Driver,
                                        const ArgList &DriverArgs,
                                        ArgStringList &CC1Args) {
+  // Add ../include/sycl and ../include (in that order)
   SmallString<128> P(Driver.getInstalledDir());
   llvm::sys::path::append(P, "..");
   llvm::sys::path::append(P, "include");
-  llvm::sys::path::append(P, "sycl");
+  SmallString<128> SYCLP(P);
+  llvm::sys::path::append(SYCLP, "sycl");
+  CC1Args.push_back("-internal-isystem");
+  CC1Args.push_back(DriverArgs.MakeArgString(SYCLP));
   CC1Args.push_back("-internal-isystem");
   CC1Args.push_back(DriverArgs.MakeArgString(P));
 }

--- a/clang/test/Driver/sycl-device.cpp
+++ b/clang/test/Driver/sycl-device.cpp
@@ -6,7 +6,7 @@
 /// Check "-fsycl-is-device" is passed when compiling for device:
 // RUN:   %clang -### -fsycl-device-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-SYCL-DEV %s
-// CHECK-SYCL-DEV: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"
+// CHECK-SYCL-DEV: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl" "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
 
 /// Check that "-Wno-sycl-strict" is set on compiler invocation with "-fsycl"
 /// or "-fsycl-device-only" or both:

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -922,3 +922,9 @@
 // CHK-POST-LINK-OPT-LEVEL-O3: sycl-post-link{{.*}} "-O3"
 // CHK-POST-LINK-OPT-LEVEL-Os: sycl-post-link{{.*}} "-Os"
 // CHK-POST-LINK-OPT-LEVEL-Oz: sycl-post-link{{.*}} "-Oz"
+
+// Verify header search dirs are added with -fsycl
+// RUN: %clang -### -fsycl %s 2>&1 | FileCheck %s -check-prefixes=CHECK-HEADER-DIR
+// RUN: %clang_cl -### -fsycl %s 2>&1 | FileCheck %s -check-prefixes=CHECK-HEADER-DIR
+// CHECK-HEADER-DIR: clang{{.*}} "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl" "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
+// CHECK-HEADER-DIR: clang{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl" "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"{{.*}} "-fsycl-is-host"

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 # Unlike PACKAGE_VERSION, CLANG_VERSION does not include LLVM_VERSION_SUFFIX.
 set(CLANG_VERSION "${CLANG_VERSION_MAJOR}.${CLANG_VERSION_MINOR}.${CLANG_VERSION_PATCHLEVEL}")
 
-set(SYCL_INCLUDE_DIR "include/sycl")
+set(SYCL_INCLUDE_DIR "include")
 set(SYCL_INCLUDE_BUILD_DIR ${LLVM_BINARY_DIR}/${SYCL_INCLUDE_DIR})
 set(SYCL_INCLUDE_DEPLOY_DIR ${CMAKE_INSTALL_PREFIX}/${SYCL_INCLUDE_DIR})
 
@@ -104,7 +104,7 @@ if( NOT OpenCL_INCLUDE_DIRS )
     UPDATE_DISCONNECTED ${SYCL_EP_OCL_HEADERS_SKIP_AUTO_UPDATE}
     SOURCE_DIR        ${OpenCL_INCLUDE_DIRS}
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND     ${CMAKE_COMMAND} -E copy_directory ${OpenCL_INCLUDE_DIRS}/CL ${SYCL_INCLUDE_BUILD_DIR}/CL
+    BUILD_COMMAND     ${CMAKE_COMMAND} -E copy_directory ${OpenCL_INCLUDE_DIRS}/CL ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL
     INSTALL_COMMAND   ""
     STEP_TARGETS      build
     COMMENT           "Downloading OpenCL headers."
@@ -116,7 +116,7 @@ if( NOT OpenCL_INCLUDE_DIRS )
 else()
   add_custom_target( ocl-headers ALL
     DEPENDS ${OpenCL_INCLUDE_DIRS}
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${OpenCL_INCLUDE_DIRS}/CL ${SYCL_INCLUDE_BUILD_DIR}/CL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${OpenCL_INCLUDE_DIRS}/CL ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL
     COMMENT "Copying OpenCL headers ..."
   )
 endif()
@@ -192,7 +192,7 @@ target_include_directories(OpenCL-Headers
   INTERFACE ${OPENCL_INCLUDE}
 )
 install(DIRECTORY ${OPENCL_INCLUDE}/CL
-  DESTINATION ${SYCL_INCLUDE_DEPLOY_DIR}
+  DESTINATION ${SYCL_INCLUDE_DEPLOY_DIR}/sycl
   COMPONENT opencl-headers
 )
 
@@ -209,11 +209,13 @@ configure_file("${version_header}.in" "${version_header}")
 
 # Copy SYCL headers
 add_custom_target(sycl-headers ALL
-COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir} ${SYCL_INCLUDE_BUILD_DIR}
+COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir}/sycl ${SYCL_INCLUDE_BUILD_DIR}/sycl
+COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir}/CL ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL
 COMMENT "Copying SYCL headers ...")
 
 # Configure SYCL headers
-install(DIRECTORY "${sycl_inc_dir}/." DESTINATION ${SYCL_INCLUDE_DEPLOY_DIR} COMPONENT sycl-headers)
+install(DIRECTORY "${sycl_inc_dir}/sycl" DESTINATION ${SYCL_INCLUDE_DEPLOY_DIR} COMPONENT sycl-headers)
+install(DIRECTORY "${sycl_inc_dir}/CL" DESTINATION ${SYCL_INCLUDE_DEPLOY_DIR}/sycl COMPONENT sycl-headers)
 
 set(SYCL_RT_LIBS sycl)
 if (MSVC)

--- a/sycl/test/basic_tests/image_accessor_types.cpp
+++ b/sycl/test/basic_tests/image_accessor_types.cpp
@@ -1,4 +1,4 @@
-// RUN: not %clangxx -fsyntax-only %s -I %sycl_include 2>&1 | FileCheck %s
+// RUN: not %clangxx -fsyntax-only %s -I %sycl_include/sycl 2>&1 | FileCheck %s
 #include <CL/sycl.hpp>
 #include <iostream>
 

--- a/sycl/test/basic_tests/vectors/ctad_fail.cpp
+++ b/sycl/test/basic_tests/vectors/ctad_fail.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -std=c++17 -fsyntax-only -Xclang -verify %s -I %sycl_include -Xclang -verify-ignore-unexpected
+// RUN: %clangxx -std=c++17 -fsyntax-only -Xclang -verify %s -I %sycl_include/sycl -Xclang -verify-ignore-unexpected
 //==--------------- ctad.cpp - SYCL vector CTAD fail test ------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/gdb/accessors.cpp
+++ b/sycl/test/gdb/accessors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -c -fno-color-diagnostics -I %sycl_include -Xclang -ast-dump %s | FileCheck %s
+// RUN: %clangxx -c -fno-color-diagnostics -I %sycl_include/sycl -Xclang -ast-dump %s | FileCheck %s
 // UNSUPPORTED: windows
 #include <CL/sycl/accessor.hpp>
 

--- a/sycl/test/gdb/printers.cpp
+++ b/sycl/test/gdb/printers.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -c -fno-color-diagnostics -I %sycl_include -Xclang -ast-dump %s | FileCheck %s
+// RUN: %clangxx -c -fno-color-diagnostics -I %sycl_include/sycl -Xclang -ast-dump %s | FileCheck %s
 // UNSUPPORTED: windows
 #include <CL/sycl/buffer.hpp>
 #include <CL/sycl/detail/array.hpp>

--- a/sycl/test/separate-compile/test.cpp
+++ b/sycl/test/separate-compile/test.cpp
@@ -7,13 +7,13 @@
 // >> host compilation...
 // Driver automatically adds -D_DLL and -D_MT on Windows with -fsycl.
 // Add those defines required for Windows and harmless for Linux.
-// RUN: %clangxx -D_DLL -D_MT -include sycl_ihdr_a.h -g -c %s -o a.o -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -D_DLL -D_MT -include sycl_ihdr_a.h -g -c %s -o a.o -I %sycl_include/sycl -Wno-sycl-strict
 //
 // >> ---- compile src2
 // >> device compilation...
 // RUN: %clangxx -DB_CPP=1 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -c -o b_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -DB_CPP=1 -D_DLL -D_MT -include sycl_ihdr_b.h -g -c %s -o b.o -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -DB_CPP=1 -D_DLL -D_MT -include sycl_ihdr_b.h -g -c %s -o b.o -I %sycl_include/sycl -Wno-sycl-strict
 //
 // >> ---- bundle .o with .spv
 // >> run bundler


### PR DESCRIPTION
Default location in which the driver adds the header searches for sycl
headers is 'include/sycl'.  With the change to the location of sycl.hpp
we also need to adjust (add) the 'include' location for default searches

Also update tests to reflect being able to find the 'CL' dir with new
%sycl_include setting