### PR TITLE
[SYCL][PI][L0][NFC] - Refactor setting of LastCommandEvent

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -841,8 +841,10 @@ void _pi_queue::adjustBatchSizeForPartialBatch(pi_uint32 PartialBatchSize) {
 
 pi_result _pi_queue::executeCommandList(ze_command_list_handle_t ZeCommandList,
                                         ze_fence_handle_t ZeFence,
-                                        bool IsBlocking,
+                                        pi_event Event, bool IsBlocking,
                                         bool OKToBatchCommand) {
+  this->LastCommandEvent = Event;
+
   if (OKToBatchCommand && this->isBatchingAllowed()) {
     if (this->ZeOpenCommandList != nullptr &&
         this->ZeOpenCommandList != ZeCommandList)
@@ -906,7 +908,7 @@ pi_result _pi_queue::executeOpenCommandList() {
     this->ZeOpenCommandListFence = nullptr;
     this->ZeOpenCommandListSize = 0;
 
-    return executeCommandList(OpenList, OpenListFence);
+    return executeCommandList(OpenList, OpenListFence, this->LastCommandEvent);
   }
 
   return PI_SUCCESS;
@@ -969,9 +971,9 @@ pi_result _pi_ze_event_list_t::createAndRetainPiZeEventList(
       }
     }
 
-    // For in-order queues, every command should be executed once after the
+    // For in-order queues, every command should be executed only after the
     // previous command has finished. The event associated with the last
-    // enqued command is added into the waitlist to ensure in-order semantics.
+    // enqueued command is added into the waitlist to ensure in-order semantics.
     if (CurQueue->isInOrderQueue() && CurQueue->LastCommandEvent != nullptr) {
       this->ZeEventList[TmpListLength] = CurQueue->LastCommandEvent->ZeEvent;
       this->PiEventList[TmpListLength] = CurQueue->LastCommandEvent;
@@ -3847,11 +3849,10 @@ piEnqueueKernelLaunch(pi_queue Queue, pi_kernel Kernel, pi_uint32 WorkDim,
           pi_cast<std::uintptr_t>(ZeEvent));
   printZeEventList((*Event)->WaitList);
 
-  Queue->LastCommandEvent = *Event;
-
   // Execute command list asynchronously, as the event will be used
   // to track down its completion.
-  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, false, true))
+  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, *Event,
+                                           false, true))
     return Res;
 
   return PI_SUCCESS;
@@ -4370,11 +4371,9 @@ pi_result piEnqueueEventsWait(pi_queue Queue, pi_uint32 NumEventsInWaitList,
 
     ZE_CALL(zeCommandListAppendSignalEvent, (ZeCommandList, ZeEvent));
 
-    Queue->LastCommandEvent = *Event;
-
     // Execute command list asynchronously as the event will be used
     // to track down its completion.
-    return Queue->executeCommandList(ZeCommandList, ZeFence);
+    return Queue->executeCommandList(ZeCommandList, ZeFence, *Event);
   }
 
   // If wait-list is empty, then this particular command should wait until
@@ -4434,11 +4433,9 @@ pi_result piEnqueueEventsWaitWithBarrier(pi_queue Queue,
           (ZeCommandList, ZeEvent, (*Event)->WaitList.Length,
            (*Event)->WaitList.ZeEventList));
 
-  Queue->LastCommandEvent = *Event;
-
   // Execute command list asynchronously as the event will be used
   // to track down its completion.
-  return Queue->executeCommandList(ZeCommandList, ZeFence);
+  return Queue->executeCommandList(ZeCommandList, ZeFence, *Event);
 }
 
 pi_result piEnqueueMemBufferRead(pi_queue Queue, pi_mem Src,
@@ -4526,10 +4523,8 @@ static pi_result enqueueMemCopyHelper(pi_command_type CommandType,
           pi_cast<std::uintptr_t>(ZeEvent));
   printZeEventList(WaitList);
 
-  Queue->LastCommandEvent = *Event;
-
-  if (auto Res =
-          Queue->executeCommandList(ZeCommandList, ZeFence, BlockingWrite))
+  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, *Event,
+                                           BlockingWrite))
     return Res;
 
   return PI_SUCCESS;
@@ -4625,9 +4620,8 @@ static pi_result enqueueMemCopyRectHelper(
   zePrint("calling zeCommandListAppendBarrier() with Event %#lx\n",
           pi_cast<std::uintptr_t>(ZeEvent));
 
-  Queue->LastCommandEvent = *Event;
-
-  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, Blocking))
+  if (auto Res =
+          Queue->executeCommandList(ZeCommandList, ZeFence, *Event, Blocking))
     return Res;
 
   return PI_SUCCESS;
@@ -4767,11 +4761,9 @@ enqueueMemFillHelper(pi_command_type CommandType, pi_queue Queue, void *Ptr,
           pi_cast<pi_uint64>(ZeEvent));
   printZeEventList(WaitList);
 
-  Queue->LastCommandEvent = *Event;
-
   // Execute command list asynchronously, as the event will be used
   // to track down its completion.
-  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence))
+  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, *Event))
     return Res;
 
   return PI_SUCCESS;
@@ -4911,9 +4903,8 @@ pi_result piEnqueueMemBufferMap(pi_queue Queue, pi_mem Buffer,
            pi_cast<char *>(Buffer->getZeHandle()) + Offset, Size, ZeEvent, 0,
            nullptr));
 
-  Queue->LastCommandEvent = *Event;
-
-  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, BlockingMap))
+  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, *Event,
+                                           BlockingMap))
     return Res;
 
   return Buffer->addMapping(*RetMap, Offset, Size);
@@ -5023,11 +5014,9 @@ pi_result piEnqueueMemUnmap(pi_queue Queue, pi_mem MemObj, void *MappedPtr,
            pi_cast<char *>(MemObj->getZeHandle()) + MapInfo.Offset, MappedPtr,
            MapInfo.Size, ZeEvent, 0, nullptr));
 
-  Queue->LastCommandEvent = *Event;
-
   // Execute command list asynchronously, as the event will be used
   // to track down its completion.
-  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence))
+  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, *Event))
     return Res;
 
   return PI_SUCCESS;
@@ -5221,9 +5210,8 @@ static pi_result enqueueMemImageCommandHelper(
     return PI_INVALID_OPERATION;
   }
 
-  Queue->LastCommandEvent = *Event;
-
-  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, IsBlocking))
+  if (auto Res =
+          Queue->executeCommandList(ZeCommandList, ZeFence, *Event, IsBlocking))
     return Res;
 
   return PI_SUCCESS;
@@ -5762,9 +5750,8 @@ pi_result piextUSMEnqueuePrefetch(pi_queue Queue, const void *Ptr, size_t Size,
   // so manually add command to signal our event.
   ZE_CALL(zeCommandListAppendSignalEvent, (ZeCommandList, ZeEvent));
 
-  Queue->LastCommandEvent = *Event;
-
-  if (auto Res = Queue->executeCommandList(ZeCommandList, ZeFence, false))
+  if (auto Res =
+          Queue->executeCommandList(ZeCommandList, ZeFence, *Event, false))
     return Res;
 
   return PI_SUCCESS;
@@ -5821,13 +5808,11 @@ pi_result piextUSMEnqueueMemAdvise(pi_queue Queue, const void *Ptr,
   ZE_CALL(zeCommandListAppendMemAdvise,
           (ZeCommandList, Queue->Device->ZeDevice, Ptr, Length, ZeAdvice));
 
-  Queue->LastCommandEvent = *Event;
-
   // TODO: Level Zero does not have a completion "event" with the advise API,
   // so manually add command to signal our event.
   ZE_CALL(zeCommandListAppendSignalEvent, (ZeCommandList, ZeEvent));
 
-  Queue->executeCommandList(ZeCommandList, ZeFence, false);
+  Queue->executeCommandList(ZeCommandList, ZeFence, *Event, false);
   return PI_SUCCESS;
 }
 

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -416,13 +416,15 @@ struct _pi_queue : _pi_object {
   // The "IsBlocking" tells if the wait for completion is required.
   // The "ZeFence" passed is used to track when the command list passed
   // has completed execution on the device and can be reused.
+  // The Event parameter is the pi_event that the last command in the command
+  // list will signal upon its completion.
   // If OKToBatchCommand is true, then this command list may be executed
   // immediately, or it may be left open for other future command to be
   // batched into.
   // If IsBlocking is true, then batching will not be allowed regardless
   // of the value of OKToBatchCommand
   pi_result executeCommandList(ze_command_list_handle_t ZeCommandList,
-                               ze_fence_handle_t ZeFence,
+                               ze_fence_handle_t ZeFence, pi_event Event,
                                bool IsBlocking = false,
                                bool OKToBatchCommand = false);
 


### PR DESCRIPTION
This change moves the setting of LastCommandEvent into
executeCommandList.  This cleans up the code a bit.

It also makes it possible for future changes to executeCommandList
to use the state or information about Queue's current LastCommandList
and the future/next LastCommandList to guide batch submission
decisions.