### PR TITLE
[Driver][SYCL] Provide ability to use an external host compiler

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -106,6 +106,8 @@ def err_drv_use_of_Z_option : Error<
   "unsupported use of internal gcc -Z option '%0'">;
 def err_drv_output_argument_with_multiple_files : Error<
   "cannot specify -o when generating multiple output files">;
+def err_drv_output_type_with_host_compiler : Error<
+  "unsupported output type when using external host compiler">;
 def err_drv_out_file_argument_with_multiple_sources : Error<
   "cannot specify '%0%1' when compiling multiple source files">;
 def err_no_external_assembler : Error<

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2519,8 +2519,8 @@ def fsycl_libspirv_path_EQ : Joined<["-"], "fsycl-libspirv-path=">,
   Flags<[CC1Option, CoreOption]>, HelpText<"Path to libspirv library">;
 def fno_sycl_libspirv : Flag<["-"], "fno-sycl-libspirv">, HelpText<"Disable check for libspirv">;
 def fsycl_host_compiler_EQ : Joined<["-"], "fsycl-host-compiler=">,
-  Flags<[CoreOption]>, HelpText<"Specify the compiler binary to use during "
-  "host compilation during SYCL offload compiles.">;
+  Flags<[CoreOption]>, HelpText<"Specify C++ compiler binary to perform host "
+  "compilation with during SYCL offload compiles.">;
 def fsycl_host_compiler_options_EQ : Joined<["-"], "fsycl-host-compiler-options=">,
   Flags<[CoreOption]>, HelpText<"When performing the host compilation with "
   "-fsycl-host-compiler specified, us the given options during that compile. "

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2523,7 +2523,7 @@ def fsycl_host_compiler_EQ : Joined<["-"], "fsycl-host-compiler=">,
   "compilation with during SYCL offload compiles.">;
 def fsycl_host_compiler_options_EQ : Joined<["-"], "fsycl-host-compiler-options=">,
   Flags<[CoreOption]>, HelpText<"When performing the host compilation with "
-  "-fsycl-host-compiler specified, us the given options during that compile. "
+  "-fsycl-host-compiler specified, use the given options during that compile. "
   "Options are expected to be a quoted list of space separated options.">;
 def fsyntax_only : Flag<["-"], "fsyntax-only">,
   Flags<[NoXarchOption,CoreOption,CC1Option,FC1Option]>, Group<Action_Group>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2518,6 +2518,13 @@ def fsycl_help : Flag<["-"], "fsycl-help">, Alias<fsycl_help_EQ>,
 def fsycl_libspirv_path_EQ : Joined<["-"], "fsycl-libspirv-path=">,
   Flags<[CC1Option, CoreOption]>, HelpText<"Path to libspirv library">;
 def fno_sycl_libspirv : Flag<["-"], "fno-sycl-libspirv">, HelpText<"Disable check for libspirv">;
+def fsycl_host_compiler_EQ : Joined<["-"], "fsycl-host-compiler=">,
+  Flags<[CoreOption]>, HelpText<"Specify the compiler binary to use during "
+  "host compilation during SYCL offload compiles.">;
+def fsycl_host_compiler_options_EQ : Joined<["-"], "fsycl-host-compiler-options=">,
+  Flags<[CoreOption]>, HelpText<"When performing the host compilation with "
+  "-fsycl-host-compiler specified, us the given options during that compile. "
+  "Options are expected to be a quoted list of space separated options.">;
 def fsyntax_only : Flag<["-"], "fsyntax-only">,
   Flags<[NoXarchOption,CoreOption,CC1Option,FC1Option]>, Group<Action_Group>;
 def ftabstop_EQ : Joined<["-"], "ftabstop=">, Group<f_Group>;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4241,6 +4241,9 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
   bool OutputAdded = false;
   StringRef CompilerName =
       llvm::sys::path::stem(HostCompilerDefArg->getValue());
+  if (CompilerName.empty())
+    TC.getDriver().Diag(diag::err_drv_missing_arg_mtp)
+        << HostCompilerDefArg->getAsString(TCArgs);
   // FIXME: Consider requiring user input to specify a compatibility class
   // to determine the type of host compiler being used.
   SmallVector<StringRef, 4> MSVCCompilers = {"cl", "clang-cl", "icl"};
@@ -4327,7 +4330,7 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
   SmallString<128> ExecPath;
   if (HostCompilerDefArg) {
     ExecPath = HostCompilerDefArg->getValue();
-    if (ExecPath == llvm::sys::path::stem(ExecPath))
+    if (!ExecPath.empty() && ExecPath == llvm::sys::path::stem(ExecPath))
       ExecPath = TC.GetProgramPath(ExecPath.c_str());
   }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4239,13 +4239,15 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
       TCArgs.getLastArg(options::OPT_fsycl_host_compiler_EQ);
   assert(HostCompilerDefArg && "Expected host compiler designation.");
 
-  bool IsMSVCHostCompiler = false;
   bool OutputAdded = false;
   StringRef CompilerName =
       llvm::sys::path::stem(HostCompilerDefArg->getValue());
   // FIXME: Consider requiring user input to specify a compatibility class
   // to determine the type of host compiler being used.
-  IsMSVCHostCompiler = CompilerName.endswith("cl");
+  SmallVector<StringRef, 4> MSVCCompilers = {"cl", "clang-cl", "icl"};
+  bool IsMSVCHostCompiler =
+      std::find(MSVCCompilers.begin(), MSVCCompilers.end(), CompilerName) !=
+      MSVCCompilers.end();
 
   auto addMSVCOutputFile = [&](StringRef Opt) {
     SmallString<128> OutOpt(Opt);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4196,8 +4196,10 @@ static bool ContainsWrapperAction(const Action *A) {
 // Put together an external compiler compilation call which is used instead
 // of the clang invocation for the host compile of an offload compilation.
 void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
-    const InputInfo &Output, const InputInfoList &Inputs,
-    const llvm::opt::ArgList &TCArgs, const Tool *T) const {
+                                     const InputInfo &Output,
+                                     const InputInfoList &Inputs,
+                                     const llvm::opt::ArgList &TCArgs,
+                                     const Tool *T) const {
 
   // The Host compilation step that occurs here is constructed based on the
   // input from the user.  This consists of the compiler to call and the
@@ -4294,7 +4296,8 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
   }
 
   // Add the integration header.
-  StringRef Header = TC.getDriver().getIntegrationHeader(InputFile.getBaseInput());
+  StringRef Header =
+      TC.getDriver().getIntegrationHeader(InputFile.getBaseInput());
   if (types::getPreprocessedType(InputFile.getType()) != types::TY_INVALID &&
       !Header.empty()) {
     HostCompileArgs.push_back(IsMSVCHostCompiler ? "-FI" : "-include");
@@ -4320,7 +4323,8 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
       HostCompileArgs.push_back(TCArgs.MakeArgString(A));
   }
   auto Cmd = std::make_unique<Command>(JA, *T, ResponseFileSupport::None(),
-      TCArgs.MakeArgString(ExecPath), HostCompileArgs, None);
+                                       TCArgs.MakeArgString(ExecPath),
+                                       HostCompileArgs, None);
 
   C.addCommand(std::move(Cmd));
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -40,6 +40,7 @@
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/FileSystem.h"
@@ -4192,6 +4193,138 @@ static bool ContainsWrapperAction(const Action *A) {
   return false;
 }
 
+// Put together an external compiler compilation call which is used instead
+// of the clang invocation for the host compile of an offload compilation.
+void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
+    const InputInfo &Output, const InputInfoList &Inputs,
+    const llvm::opt::ArgList &TCArgs, const Tool *T) const {
+
+  // The Host compilation step that occurs here is constructed based on the
+  // input from the user.  This consists of the compiler to call and the
+  // options that will be used during the compilation.
+  ArgStringList HostCompileArgs;
+  const InputInfo &InputFile = Inputs.front();
+  const auto &TC = getToolChain();
+
+  // Input file.
+  HostCompileArgs.push_back(InputFile.getFilename());
+
+  // When performing the host compilation, we are expecting to only be
+  // creating intermediate files.  These being preprocessed, assembly or
+  // object files.
+  // We are making assumptions in regards to what options are used to
+  // generate these intermediate files.
+  //                gcc/g++/clang/clang++/default | cl
+  //  Object:                   -c                | -c
+  //  Preprocessed:             -E                | -P -Fi<file>
+  //  Assembly:                 -S                | -c -Fa<file>
+  //  Header Input:        -include <file>        | -FI <file>
+  //
+  // The options used are determined by the compiler name and target triple.
+  auto *HostArg = TCArgs.getLastArg(options::OPT_fsycl_host_compiler_EQ);
+  assert(HostArg && "Expected host compiler designation.");
+
+  bool IsMSVCHostCompiler = false;
+  bool OutputAdded = false;
+  StringRef CompilerName = llvm::sys::path::stem(HostArg->getValue());
+  IsMSVCHostCompiler = CompilerName.contains("cl");
+
+  auto addMSVCOutputFile = [&](StringRef Opt) {
+    SmallString<128> OutOpt(Opt);
+    OutOpt += Output.getFilename();
+    HostCompileArgs.push_back(TCArgs.MakeArgString(OutOpt));
+    OutputAdded = true;
+  };
+  if (isa<PreprocessJobAction>(JA)) {
+    if (IsMSVCHostCompiler) {
+      // Check the output file, if it is 'stdout' we want to use -E.
+      llvm::errs() << "output string is " << Output.getAsString() << '\n';
+      if (StringRef(Output.getFilename()).equals("-")) {
+        HostCompileArgs.push_back("-E");
+        OutputAdded = true;
+      } else {
+        HostCompileArgs.push_back("-P");
+        addMSVCOutputFile("-Fi");
+      }
+    } else
+      HostCompileArgs.push_back("-E");
+  } else if (isa<AssembleJobAction>(JA)) {
+    HostCompileArgs.push_back("-c");
+    if (IsMSVCHostCompiler)
+      addMSVCOutputFile("-Fo");
+  } else {
+    assert((isa<CompileJobAction>(JA) || isa<BackendJobAction>(JA)) &&
+           "Invalid action for external host compilation tool.");
+    if (JA.getType() == types::TY_PP_Asm) {
+      if (IsMSVCHostCompiler) {
+        HostCompileArgs.push_back("-c");
+        addMSVCOutputFile("-Fa");
+        // The MSVC Compiler does not have a way to just create the assembly
+        // file so we create the assembly file and object file, and redirect
+        // the object file to a temporary.
+        std::string ObjTmpName = C.getDriver().GetTemporaryPath("host", "obj");
+        StringRef WrapperFileName =
+            C.addTempFile(C.getArgs().MakeArgString(ObjTmpName));
+        SmallString<128> ObjOutOpt("-Fo");
+        ObjOutOpt += WrapperFileName;
+        HostCompileArgs.push_back(C.getArgs().MakeArgString(ObjOutOpt));
+      } else
+        HostCompileArgs.push_back("-S");
+    } else {
+      TC.getDriver().Diag(diag::err_drv_output_type_with_host_compiler);
+    }
+  }
+
+  // Add default header search directories.
+  SmallString<128> BaseDir(C.getDriver().Dir);
+  llvm::sys::path::append(BaseDir, "..");
+  llvm::sys::path::append(BaseDir, "include");
+  SmallString<128> SYCLDir(BaseDir);
+  llvm::sys::path::append(SYCLDir, "sycl");
+  HostCompileArgs.push_back("-I");
+  HostCompileArgs.push_back(TCArgs.MakeArgString(SYCLDir));
+  HostCompileArgs.push_back("-I");
+  HostCompileArgs.push_back(TCArgs.MakeArgString(BaseDir));
+
+  if (!OutputAdded) {
+    // Add output file to the command line.  This is assumed to be prefaced
+    // with the '-o' option that is used to designate the output file.
+    HostCompileArgs.push_back("-o");
+    HostCompileArgs.push_back(Output.getFilename());
+  }
+
+  // Add the integration header.
+  StringRef Header = TC.getDriver().getIntegrationHeader(InputFile.getBaseInput());
+  if (types::getPreprocessedType(InputFile.getType()) != types::TY_INVALID &&
+      !Header.empty()) {
+    HostCompileArgs.push_back(IsMSVCHostCompiler ? "-FI" : "-include");
+    HostCompileArgs.push_back(TCArgs.MakeArgString(Header));
+  }
+
+  SmallString<128> ExecPath;
+  if (HostArg) {
+    ExecPath = HostArg->getValue();
+    if (ExecPath == llvm::sys::path::stem(ExecPath))
+      ExecPath = TC.GetProgramPath(ExecPath.c_str());
+  }
+
+  // Add any user specified arguments
+  if (auto *Arg =
+          TCArgs.getLastArg(options::OPT_fsycl_host_compiler_options_EQ)) {
+    SmallVector<const char *, 8> TargetArgs;
+    llvm::BumpPtrAllocator BPA;
+    llvm::StringSaver S(BPA);
+    // Tokenize the string.
+    llvm::cl::TokenizeGNUCommandLine(Arg->getValue(), S, TargetArgs);
+    for (auto A : TargetArgs)
+      HostCompileArgs.push_back(TCArgs.MakeArgString(A));
+  }
+  auto Cmd = std::make_unique<Command>(JA, *T, ResponseFileSupport::None(),
+      TCArgs.MakeArgString(ExecPath), HostCompileArgs, None);
+
+  C.addCommand(std::move(Cmd));
+}
+
 void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                          const InputInfo &Output, const InputInfoList &Inputs,
                          const ArgList &Args, const char *LinkingOutput) const {
@@ -4224,6 +4357,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   assert((IsCuda || IsHIP || (IsOpenMPDevice && Inputs.size() == 2) || IsSYCL ||
           IsHeaderModulePrecompile || Inputs.size() == 1) &&
          "Unable to handle multiple inputs.");
+
+  // Perform the host compilation using an external compiler if the user
+  // requested.
+  if (Args.hasArg(options::OPT_fsycl_host_compiler_EQ) && IsSYCL &&
+      !IsSYCLOffloadDevice) {
+    ConstructHostCompilerJob(C, JA, Output, Inputs, Args, this);
+    return;
+  }
 
   // A header module compilation doesn't have a main input file, so invent a
   // fake one as a placeholder.

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -88,6 +88,10 @@ private:
                       codegenoptions::DebugInfoKind *DebugInfoKind,
                       bool *EmitCodeView) const;
 
+  void ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
+      const InputInfo &Output, const InputInfoList &Inputs,
+      const llvm::opt::ArgList &TCArgs, const Tool *T) const;
+
   mutable std::unique_ptr<llvm::raw_fd_ostream> CompilationDatabase = nullptr;
   void DumpCompilationDatabase(Compilation &C, StringRef Filename,
                                StringRef Target,

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -89,8 +89,10 @@ private:
                       bool *EmitCodeView) const;
 
   void ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
-      const InputInfo &Output, const InputInfoList &Inputs,
-      const llvm::opt::ArgList &TCArgs, const Tool *T) const;
+                                const InputInfo &Output,
+                                const InputInfoList &Inputs,
+                                const llvm::opt::ArgList &TCArgs,
+                                const Tool *T) const;
 
   mutable std::unique_ptr<llvm::raw_fd_ostream> CompilationDatabase = nullptr;
   void DumpCompilationDatabase(Compilation &C, StringRef Filename,

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -91,8 +91,7 @@ private:
   void ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
                                 const InputInfo &Output,
                                 const InputInfoList &Inputs,
-                                const llvm::opt::ArgList &TCArgs,
-                                const Tool *T) const;
+                                const llvm::opt::ArgList &TCArgs) const;
 
   mutable std::unique_ptr<llvm::raw_fd_ostream> CompilationDatabase = nullptr;
   void DumpCompilationDatabase(Compilation &C, StringRef Filename,

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -433,8 +433,10 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-defaultlib:oldnames");
   }
 
-  if (!C.getDriver().IsCLMode() && !Args.hasArg(options::OPT_nostdlib) &&
-      Args.hasArg(options::OPT_fsycl) && !Args.hasArg(options::OPT_nolibsycl)) {
+  if ((!C.getDriver().IsCLMode() && !Args.hasArg(options::OPT_nostdlib) &&
+       Args.hasArg(options::OPT_fsycl) &&
+       !Args.hasArg(options::OPT_nolibsycl)) ||
+      Args.hasArg(options::OPT_fsycl_host_compiler_EQ)) {
     if (Args.hasArg(options::OPT__SLASH_MDd))
       CmdArgs.push_back("-defaultlib:sycld.lib");
     else

--- a/clang/test/Driver/sycl-host-compiler.cpp
+++ b/clang/test/Driver/sycl-host-compiler.cpp
@@ -1,0 +1,55 @@
+// Tests the abilities involved with using an external host compiler
+// REQUIRES: clang-driver
+
+/// enabling with -fsycl-host-compiler
+// RUN: %clangxx -fsycl -fsycl-host-compiler=/some/dir/g++ %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_COMPILER %s
+// HOST_COMPILER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]"
+// HOST_COMPILER: g++{{.*}} "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"{{.*}} "-o" "[[HOSTOBJ:.+\.o]]"{{.*}} "-include" "[[INTHEADER]]"
+// HOST_COMPILER: ld{{.*}} "[[HOSTOBJ]]"
+
+// RUN: %clang_cl -fsycl -fsycl-host-compiler=/some/dir/cl %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_COMPILER_CL %s
+// HOST_COMPILER_CL: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]"
+// HOST_COMPILER_CL: cl{{.*}} "-Fo[[HOSTOBJ:.+\.obj]]"{{.*}} "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"{{.*}} "-FI" "[[INTHEADER]]"
+// HOST_COMPILER_CL: link{{.*}} "[[HOSTOBJ]]"
+
+/// check for additional host options
+// RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -fsycl-host-compiler-options="-DFOO -DBAR" %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_OPTIONS %s
+// HOST_OPTIONS: g++{{.*}} "-o" "[[HOSTOBJ:.+\.o]]"{{.*}} "-DFOO" "-DBAR"
+
+/// preprocessing
+// RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -E %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_PREPROCESS %s
+// HOST_PREPROCESS: g++{{.*}} "-E"{{.*}} "-o" "[[PPOUT:.+\.ii]]"
+// HOST_PREPROCESS: g++{{.*}} "-E"{{.*}} "-o" "-"
+// HOST_PREPROCESS: clang-offload-bundler{{.*}} "-inputs={{.*}}.ii,[[PPOUT]]"
+
+// RUN: %clang_cl -fsycl -fsycl-host-compiler=cl -E %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_PREPROCESS_CL %s
+// HOST_PREPROCESS_CL: cl{{.*}} "-P"{{.*}} "-Fi[[PPOUT:.+\.ii]]"
+// HOST_PREPROCESS_CL: cl{{.*}} "-E"
+// HOST_PREPROCESS_CL: clang-offload-bundler{{.*}} "-inputs={{.*}}.ii,[[PPOUT]]"
+
+/// obj output
+// RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -c %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_OBJECT %s
+// HOST_OBJECT: g++{{.*}} "-c"{{.*}} "-o" "[[OBJOUT:.+\.o]]"
+// HOST_OBJECT: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,[[OBJOUT]]"
+
+// RUN: %clang_cl -fsycl -fsycl-host-compiler=cl -c %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_OBJECT_CL %s
+// HOST_OBJECT_CL: cl{{.*}} "-c"{{.*}} "-Fo[[OBJOUT:.+\.obj]]"
+// HOST_OBJECT_CL: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,[[OBJOUT]]"
+
+/// assembly output
+// RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -S %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_ASSEMBLY %s
+// HOST_ASSEMBLY: g++{{.*}} "-S"{{.*}} "-o" "[[ASMOUT:.+\.s]]"
+// HOST_ASSEMBLY: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,[[ASMOUT]]"
+
+// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -S %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_ASSEMBLY_CL %s
+// HOST_ASSEMBLY_CL: cl{{.*}} "-c"{{.*}} "-Fa[[ASMOUT:.+\.s]]" "-Fo{{.*}}.obj"
+// HOST_ASSEMBLY_CL: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,[[ASMOUT]]"

--- a/clang/test/Driver/sycl-host-compiler.cpp
+++ b/clang/test/Driver/sycl-host-compiler.cpp
@@ -57,3 +57,8 @@
 // RUN:  | FileCheck -check-prefix=HOST_ASSEMBLY_CL %s
 // HOST_ASSEMBLY_CL: cl{{.*}} "-c"{{.*}} "-Fa[[ASMOUT:.+\.s]]" "-Fo{{.*}}.obj"
 // HOST_ASSEMBLY_CL: clang-offload-bundler{{.*}} "-inputs={{.*}}.bc,[[ASMOUT]]"
+
+/// missing argument error -fsycl-host-compiler=
+// RUN: %clangxx -fsycl -fsycl-host-compiler= -c -### %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_COMPILER_NOARG %s
+// HOST_COMPILER_NOARG: missing argument to '-fsycl-host-compiler='

--- a/clang/test/Driver/sycl-host-compiler.cpp
+++ b/clang/test/Driver/sycl-host-compiler.cpp
@@ -19,6 +19,10 @@
 // RUN:  | FileCheck -check-prefix=HOST_OPTIONS %s
 // HOST_OPTIONS: g++{{.*}} "-o" "[[HOSTOBJ:.+\.o]]"{{.*}} "-DFOO" "-DBAR"
 
+// RUN: %clang_cl -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options="/DFOO /DBAR /O2" %s -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_OPTIONS_CL %s
+// HOST_OPTIONS_CL: cl{{.*}} "-Fo[[HOSTOBJ:.+\.obj]]"{{.*}} "/DFOO" "/DBAR" "/O2"
+
 /// preprocessing
 // RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -E %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_PREPROCESS %s

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -238,6 +238,10 @@ and not recommended to use in production environment.
     expected that the options used here are compatible with the compiler
     specified via -fsycl-host-compiler=<arg>.
 
+    NOTE: Using -fsycl-host-compiler-options to pass any kind of phase limiting
+    options (e.g. -c, -E, -S) may interfere with the expected output set during
+    the host compilation.  Doing so is considered undefined behavior.
+
 # Example: SYCL device code compilation
 
 To invoke SYCL device compiler set `-fsycl-device-only` flag.

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -222,6 +222,22 @@ and not recommended to use in production environment.
     same as specifying -fsycl-help with no argument and emits help for all
     backends.
 
+**`-fsycl-host-compiler=<arg>`**
+
+    Informs the compiler driver that the host compilation step that is performed
+    as part of the greater compilation flow will be performed by the compiler
+    <arg>.  It is expected that <arg> is the compiler to be called, either by
+    name (in which the PATH will be used to discover it) or a fully qualified
+    directory with compiler to invoke.  This option is only useful when -fsycl
+    is provided on the command line.
+
+**`-fsycl-host-compiler-options="opts"`**
+
+    Passes along the space separated quoted "opts" string as option arguments
+    to the compiler specified with the -fsycl-host-compiler=<arg> option.  It is
+    expected that the options used here are compatible with the compiler
+    specified via -fsycl-host-compiler=<arg>.
+
 # Example: SYCL device code compilation
 
 To invoke SYCL device compiler set `-fsycl-device-only` flag.

--- a/sycl/test/regression/fsycl-host-compiler-win.cpp
+++ b/sycl/test/regression/fsycl-host-compiler-win.cpp
@@ -1,0 +1,46 @@
+// RUN: %clang_cl -fsycl -fsycl-host-compiler=cl -DDEFINE_CHECK -fsycl-host-compiler-options="-DDEFINE_CHECK" /Fe%t1.exe %s
+// RUN: %RUN_ON_HOST %t1.exe
+// REQUIRES: system-windows
+//
+//==------- fsycl-host-compiler-win.cpp - external host compiler test ------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Uses -fsycl-host-compiler=<compiler> on a simple test, requires 'cl'
+
+#include <CL/sycl.hpp>
+
+#ifndef DEFINE_CHECK
+#error predefined macro not set
+#endif // DEFINE_CHECK
+
+using namespace cl::sycl;
+
+int main() {
+  int data[] = {0, 0, 0};
+
+  {
+    buffer<int, 1> b(data, range<1>(3), {property::buffer::use_host_ptr()});
+    queue q;
+    q.submit([&](handler &cgh) {
+      auto B = b.get_access<access::mode::write>(cgh);
+      cgh.parallel_for<class test>(range<1>(3), [=](id<1> idx) {
+        B[idx] = 1;
+      });
+    });
+  }
+
+  bool isSuccess = true;
+
+  for (int i = 0; i < 3; i++)
+    if (data[i] != 1) isSuccess = false;
+
+  if (!isSuccess)
+    return -1;
+
+  return 0;
+}

--- a/sycl/test/regression/fsycl-host-compiler.cpp
+++ b/sycl/test/regression/fsycl-host-compiler.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang++ -fsycl -fsycl-host-compiler=g++ -o %t1.exe %s
+// RUN: %clang++ -fsycl -fsycl-host-compiler=g++ -DDEFINE_CHECK -fsycl-host-compiler-options="-DDEFINE_CHECK" -o %t1.exe %s
 // RUN: %RUN_ON_HOST %t1.exe
 // REQUIRES: system-linux
 //==------- fsycl-host-compiler.cpp - external host compiler test ----------==//
@@ -12,6 +12,10 @@
 // Uses -fsycl-host-compiler=<compiler> on a simple test, requires 'g++'
 
 #include <CL/sycl.hpp>
+
+#ifndef DEFINE_CHECK
+#error predefined macro not set
+#endif // DEFINE_CHECK
 
 using namespace cl::sycl;
 

--- a/sycl/test/regression/fsycl-host-compiler.cpp
+++ b/sycl/test/regression/fsycl-host-compiler.cpp
@@ -1,0 +1,41 @@
+// RUN: %clang++ -fsycl -fsycl-host-compiler=g++ -o %t1.exe %s
+// RUN: %RUN_ON_HOST %t1.exe
+// REQUIRES: system-linux
+//==------- fsycl-host-compiler.cpp - external host compiler test ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Uses -fsycl-host-compiler=<compiler> on a simple test, requires 'g++'
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main() {
+  int data[] = {0, 0, 0};
+
+  {
+    buffer<int, 1> b(data, range<1>(3), {property::buffer::use_host_ptr()});
+    queue q;
+    q.submit([&](handler &cgh) {
+      auto B = b.get_access<access::mode::write>(cgh);
+      cgh.parallel_for<class test>(range<1>(3), [=](id<1> idx) {
+        B[idx] = 1;
+      });
+    });
+  }
+
+  bool isSuccess = true;
+
+  for (int i = 0; i < 3; i++)
+    if (data[i] != 1) isSuccess = false;
+
+  if (!isSuccess)
+    return -1;
+
+  return 0;
+}


### PR DESCRIPTION
The default toolchain when performing -fsycl compilations is to use the
clang compiler for the device and host compilations.  Enable the ability
to use an external host compiler (e.g. gcc/g++) to be used when creating
the host objects.  This introduces 2 options:

-fsycl-host-compiler=<arg>
  When specified, this option informs the compiler driver that the host
  compilation step that is performed as part of the greater compilation
  flow will be performed by the compiler <arg>.  It is expected that
  <arg> is the compiler to be called, either by name (in which the PATH
  will be used to discover it) or a fully qualified directory with
  compiler to invoke.  This option is only useful when used with when
  '-fsycl' is provided on the command line.

-fsycl-host-compiler-options="opts"
  Passes along the space separated quoted "opts" string as option
  arguments to the compiler specified with the -fsycl-host-compiler=<arg>
  option.  It is expected that the options used here are compatible with
  the compiler specified via -fsycl-host-compiler=<arg>.  This option
  does not have any affect without -fsycl-host-compiler=<arg>.