### PR TITLE
[SYCL][NVPTX][NFC] Refactor NVPTX target configuration

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.cpp
+++ b/clang/lib/Basic/Targets/NVPTX.cpp
@@ -62,8 +62,7 @@ NVPTXTargetInfo::NVPTXTargetInfo(const llvm::Triple &Triple,
                      .Default(32);
   }
 
-  // FIXME: Needed for compiling SYCL to PTX.
-  TLSSupported = Triple.getEnvironment() == llvm::Triple::SYCLDevice;
+  TLSSupported = false;
   VLASupported = false;
   AddrSpaceMap = &NVPTXAddrSpaceMap;
   GridValues = llvm::omp::NVPTXGpuGridValues;

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -171,6 +171,11 @@ public:
     return CCCR_Warning;
   }
 
+  void adjust(LangOptions &Opts) override {
+    TargetInfo::adjust(Opts);
+    TLSSupported = TLSSupported || Opts.SYCLIsDevice;
+  }
+
   bool hasExtIntType() const override { return true; }
 };
 } // namespace targets

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -173,6 +173,7 @@ public:
 
   void adjust(LangOptions &Opts) override {
     TargetInfo::adjust(Opts);
+    // FIXME: Needed for compiling SYCL to PTX.
     TLSSupported = TLSSupported || Opts.SYCLIsDevice;
   }
 

--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -304,8 +304,10 @@ void NVPTXPassConfig::addIRPasses() {
   const NVPTXSubtarget &ST = *getTM<NVPTXTargetMachine>().getSubtargetImpl();
   addPass(createNVVMReflectPass(ST.getSmVersion()));
 
-  addPass(createGlobalOffsetPass());
+  // FIXME: should the target triple check be done by the pass itself?
+  // See createNVPTXLowerArgsPass as an example
   if (getTM<NVPTXTargetMachine>().getTargetTriple().getOS() == Triple::CUDA) {
+    addPass(createGlobalOffsetPass());
     addPass(createLocalAccessorToSharedMemoryPass());
   }
 

--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -304,9 +304,8 @@ void NVPTXPassConfig::addIRPasses() {
   const NVPTXSubtarget &ST = *getTM<NVPTXTargetMachine>().getSubtargetImpl();
   addPass(createNVVMReflectPass(ST.getSmVersion()));
 
-  if (getTM<NVPTXTargetMachine>().getTargetTriple().getOS() == Triple::CUDA &&
-      getTM<NVPTXTargetMachine>().getTargetTriple().getEnvironment() == Triple::SYCLDevice) {
-    addPass(createGlobalOffsetPass());
+  addPass(createGlobalOffsetPass());
+  if (getTM<NVPTXTargetMachine>().getTargetTriple().getOS() == Triple::CUDA) {
     addPass(createLocalAccessorToSharedMemoryPass());
   }
 

--- a/llvm/lib/Target/NVPTX/SYCL/LocalAccessorToSharedMemory.cpp
+++ b/llvm/lib/Target/NVPTX/SYCL/LocalAccessorToSharedMemory.cpp
@@ -48,7 +48,9 @@ public:
     // Access `nvvm.annotations` to determine which functions are kernel entry
     // points.
     auto NvvmMetadata = M.getNamedMetadata("nvvm.annotations");
-    assert(NvvmMetadata && "IR compiled to PTX must have nvvm.annotations");
+    if (!NvvmMetadata)
+      return false;
+
     for (auto MetadataNode : NvvmMetadata->operands()) {
       if (MetadataNode->getNumOperands() != 3)
         continue;

--- a/llvm/lib/Target/NVPTX/SYCL/LocalAccessorToSharedMemory.cpp
+++ b/llvm/lib/Target/NVPTX/SYCL/LocalAccessorToSharedMemory.cpp
@@ -38,7 +38,8 @@ public:
 
   bool runOnModule(Module &M) override {
     // Invariant: This pass is only intended to operate on SYCL kernels being
-    // compiled to the `nvptx{,64}-nvidia-cuda-sycldevice` triple.
+    // compiled to the `nvptx{,64}-nvidia-cuda` triple.
+    // TODO: make sure that non-SYCL kernels are not impacted.
     if (skipModule(M))
       return false;
 


### PR DESCRIPTION
Avoid using `-sycldevice` for configuring NVPTX target.