### PR TITLE
[CI] Switch to default clang-format version.

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Get clang-format first
-      run: sudo apt-get install -yqq clang-format-9
+      run: sudo apt-get install -yqq clang-format
 
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
GitHub actions CI system uses Ubuntu 20 as "ubuntu-latest" and default
clang-format version is more recent than clang-format-9 we use today.