### PR TITLE
[SYCL][CUDA] Removed PI_COMMAND_TYPE_USER assert from _pi_event::_pi_event

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -326,8 +326,6 @@ _pi_event::_pi_event(pi_command_type type, pi_context context, pi_queue queue)
       isStarted_{false}, evEnd_{nullptr}, evStart_{nullptr}, evQueued_{nullptr},
       queue_{queue}, context_{context} {
 
-  assert(type != PI_COMMAND_TYPE_USER);
-
   bool profilingEnabled = queue_->properties_ & PI_QUEUE_PROFILING_ENABLE;
 
   PI_CHECK_ERROR(cuEventCreate(


### PR DESCRIPTION
Addresses [memadvice](https://github.com/intel/llvm-test-suite/blob/intel/SYCL/USM/memadvise.cpp) test failure [identified](https://github.com/intel/llvm/commit/2b56ac92ac0539a1113adc3d7beed40e6471f757#commitcomment-49493148) after merging #3365
