### PR TITLE
Fix warnings in SYCLLowerIR to facilitate -Werror builds

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -730,7 +730,8 @@ static bool translateVLoad(CallInst &CI, SmallPtrSet<Type *, 4> &GVTS) {
   if (GVTS.find(CI.getType()) != GVTS.end())
     return false;
   IRBuilder<> Builder(&CI);
-  auto LI = Builder.CreateLoad(CI.getArgOperand(0), CI.getName());
+  auto *PtrTy = CI.getArgOperand(0)->getType()->getPointerElementType();
+  auto LI = Builder.CreateLoad(PtrTy, CI.getArgOperand(0), CI.getName());
   LI->setDebugLoc(CI.getDebugLoc());
   CI.replaceAllUsesWith(LI);
   return true;

--- a/llvm/lib/SYCLLowerIR/LowerESIMDVLoadVStore.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMDVLoadVStore.cpp
@@ -89,7 +89,8 @@ PreservedAnalyses ESIMDLowerLoadStorePass::run(Function &F,
       if (GenXIntrinsic::isVStore(&Inst))
         Builder.CreateStore(Inst.getOperand(0), Inst.getOperand(1));
       else {
-        auto LI = Builder.CreateLoad(Inst.getOperand(0), Inst.getName());
+        auto *PtrTy = Inst.getOperand(0)->getType()->getPointerElementType();
+        auto LI = Builder.CreateLoad(PtrTy, Inst.getOperand(0), Inst.getName());
         LI->setDebugLoc(Inst.getDebugLoc());
         Inst.replaceAllUsesWith(LI);
       }

--- a/llvm/lib/SYCLLowerIR/LowerWGScope.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerWGScope.cpp
@@ -303,7 +303,9 @@ shareOutputViaLocalMem(Instruction &I, BasicBlock &BBa, BasicBlock &BBb,
   Bld.CreateStore(&I, WGLocal);
   // 3) Generate a load in the "worker" BB of the value stored by the leader
   Bld.SetInsertPoint(&BBb.front());
-  auto *WGVal = Bld.CreateLoad(WGLocal, "wg_val_" + Twine(I.getName()));
+  auto *WGLocalTy = WGLocal->getType()->getPointerElementType();
+  auto *WGVal =
+      Bld.CreateLoad(WGLocalTy, WGLocal, "wg_val_" + Twine(I.getName()));
   // 4) Finally, replace usages of I outside the scope
   for (auto *U : Users)
     U->replaceUsesOfWith(&I, WGVal);
@@ -416,7 +418,8 @@ static void copyBetweenPrivateAndShadow(Value *L, GlobalVariable *Shadow,
 
     if (!Loc2Shadow)
       std::swap(Src, Dst);
-    Value *LocalVal = Builder.CreateLoad(Src, "mat_ld");
+    auto *SrcTy = Src->getType()->getPointerElementType();
+    Value *LocalVal = Builder.CreateLoad(SrcTy, Src, "mat_ld");
     Builder.CreateStore(LocalVal, Dst);
   }
 }


### PR DESCRIPTION
Use a non-deprecated version of IRBuilder::CreateLoad

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>
Co-authored-by: Arvind Sudarsanam <arvind.sudarsanam@intel.com>