### PR TITLE
[SYCL][NFC] Replace cl_ext_intel.h with cl_ext.h

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <CL/cl_ext_intel.h>
 #include <CL/sycl/detail/cl.h>
 #include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/detail/export.hpp>

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -47,7 +47,7 @@
 // TODO: we need a mapping of PI to OpenCL somewhere, and this can be done
 // elsewhere, e.g. in the pi_opencl, but constants/enums mapping is now
 // done here, for efficiency and simplicity.
-#include <CL/cl_ext_intel.h>
+#include <CL/cl_ext.h>
 #include <CL/sycl/detail/cl.h>
 #include <CL/sycl/detail/export.hpp>
 #include <cstdint>


### PR DESCRIPTION
Fixes the annoying warning about deprecated include.