### PR TITLE
[SYCL][CUDA] Add default to image format switch

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -3833,9 +3833,10 @@ static size_t imageElementByteSize(CUDA_ARRAY_DESCRIPTOR array_desc) {
   case CU_AD_FORMAT_SIGNED_INT32:
   case CU_AD_FORMAT_FLOAT:
     return 4;
+  default:
+    cl::sycl::detail::pi::die("Invalid image format.");
+    return 0;
   }
-  cl::sycl::detail::pi::die("Invalid iamge format.");
-  return 0;
 }
 
 /// General ND memory copy operation for images (where N > 1).


### PR DESCRIPTION
Enables imageElementByteSize to compile when there are values of the
CUDA_ARRAY_DESCRIPTOR enum not explicitly covered by the switch statement,
such as when compiling with CUDA 11 (which adds CU_AD_FORMAT_NV12).

Closes #3550.

Signed-off-by: John Pennycook <john.pennycook@intel.com>