### PR TITLE
[SYCL] Fix warnings on clang-based build

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -521,9 +521,10 @@ static bool FixupInvocation(CompilerInvocation &Invocation,
 static unsigned getOptimizationLevel(ArgList &Args, InputKind IK,
                                      DiagnosticsEngine &Diags) {
   unsigned DefaultOpt = llvm::CodeGenOpt::None;
-  if ((IK.getLanguage() == Language::OpenCL ||
-       IK.getLanguage() == Language::OpenCLCXX) &&
-      !Args.hasArg(OPT_cl_opt_disable) || Args.hasArg(OPT_fsycl_is_device))
+  if (((IK.getLanguage() == Language::OpenCL ||
+        IK.getLanguage() == Language::OpenCLCXX) &&
+       !Args.hasArg(OPT_cl_opt_disable)) ||
+      Args.hasArg(OPT_fsycl_is_device))
     DefaultOpt = llvm::CodeGenOpt::Default;
 
   if (Arg *A = Args.getLastArg(options::OPT_O_Group)) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3192,7 +3192,9 @@ class SyclKernelIntFooterCreator : public SyclKernelFieldHandler {
 
 public:
   SyclKernelIntFooterCreator(Sema &S, SYCLIntegrationFooter &F)
-      : SyclKernelFieldHandler(S), Footer(F) {(void)Footer;}
+      : SyclKernelFieldHandler(S), Footer(F) {
+    (void)Footer; // workaround for unused field warning
+  }
 };
 
 } // namespace

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3188,11 +3188,11 @@ public:
 };
 
 class SyclKernelIntFooterCreator : public SyclKernelFieldHandler {
-  LLVM_ATTRIBUTE_UNUSED SYCLIntegrationFooter &Footer;
+  SYCLIntegrationFooter &Footer;
 
 public:
   SyclKernelIntFooterCreator(Sema &S, SYCLIntegrationFooter &F)
-      : SyclKernelFieldHandler(S), Footer(F) {}
+      : SyclKernelFieldHandler(S), Footer(F) {(void)Footer;}
 };
 
 } // namespace

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3188,10 +3188,7 @@ public:
 };
 
 class SyclKernelIntFooterCreator : public SyclKernelFieldHandler {
-#ifdef __clang__
-  [[maybe_unused]]
-#endif
-  SYCLIntegrationFooter &Footer;
+  LLVM_ATTRIBUTE_UNUSED SYCLIntegrationFooter &Footer;
 
 public:
   SyclKernelIntFooterCreator(Sema &S, SYCLIntegrationFooter &F)

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3188,6 +3188,9 @@ public:
 };
 
 class SyclKernelIntFooterCreator : public SyclKernelFieldHandler {
+#ifdef __clang__
+  [[maybe_unused]]
+#endif
   SYCLIntegrationFooter &Footer;
 
 public:

--- a/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
@@ -1720,10 +1720,7 @@ public:
 private:
   OCLExtOpKind ExtOpId;
   ArrayRef<Type *> ArgTys;
-#ifdef __clang__
-  [[maybe_unused]]
-#endif
-  Type *RetTy;
+  LLVM_MAYBE_UNUSED Type *RetTy;
 };
 } // namespace
 

--- a/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
@@ -1720,7 +1720,7 @@ public:
 private:
   OCLExtOpKind ExtOpId;
   ArrayRef<Type *> ArgTys;
-  LLVM_MAYBE_UNUSED Type *RetTy;
+  LLVM_ATTRIBUTE_UNUSED Type *RetTy;
 };
 } // namespace
 

--- a/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
@@ -1720,7 +1720,7 @@ public:
 private:
   OCLExtOpKind ExtOpId;
   ArrayRef<Type *> ArgTys;
-  LLVM_ATTRIBUTE_UNUSED Type *RetTy;
+  Type *RetTy;
 };
 } // namespace
 

--- a/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVUtil.cpp
@@ -1720,6 +1720,9 @@ public:
 private:
   OCLExtOpKind ExtOpId;
   ArrayRef<Type *> ArgTys;
+#ifdef __clang__
+  [[maybe_unused]]
+#endif
   Type *RetTy;
 };
 } // namespace

--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -218,7 +218,7 @@ std::string OSUtil::getDirName(const char *Path) {
   // Remove trailing directory separators
   Tmp.erase(Tmp.find_last_not_of("/\\") + 1, std::string::npos);
 
-  int pos = Tmp.find_last_of("/\\");
+  size_t pos = Tmp.find_last_of("/\\");
   if (pos != std::string::npos)
     return Tmp.substr(0, pos);
 


### PR DESCRIPTION
* CompilerInvocation.cpp: error: '&&' within '||'
  [-Werror,-Wlogical-op-parentheses]
* clang/lib/Sema/SemaSYCL.cpp: error: private field 'Footer' is not used
  [-Werror,-Wunused-private-field]
* os_util.cpp: comparison of integers of different signs: 'int' and
  'const unsigned long long' [-Werror,-Wsign-compare]

Signed-off-by: Pavel V Chupin <pavel.v.chupin@intel.com>