### PR TITLE
[SYCL][CUDA] Fix USM pointer device query

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4584,7 +4584,7 @@ pi_result cuda_piextUSMGetMemAllocInfo(pi_context context, const void *ptr,
       result = PI_CHECK_ERROR(cuPointerGetAttribute(
           &value, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, (CUdeviceptr)ptr));
       pi_platform platform;
-      result = cuda_piPlatformsGet(0, &platform, nullptr);
+      result = cuda_piPlatformsGet(1, &platform, nullptr);
       pi_device device = platform->devices_[value].get();
       return getInfo(param_value_size, param_value, param_value_size_ret,
                      device);


### PR DESCRIPTION
Querying the device corresponding to a USM pointer would cause fail due
to an invalid parameter when requesting the underlying platform. This
changes the invalid parameter to a valid one.

This fixes https://github.com/intel/llvm-test-suite/blob/intel/SYCL/USM/pointer_query.cpp for CUDA.