### PR TITLE
[SYCL] Implement anonymous namespace spec-id functionality.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4549,7 +4549,8 @@ void SYCLIntegrationFooter::emitSpecIDName(raw_ostream &O, const VarDecl *VD) {
 }
 
 template <typename Before, typename After>
-static void PrintNSHelper(Before B, After A, raw_ostream &O, const DeclContext *DC) {
+static void PrintNSHelper(Before B, After A, raw_ostream &O,
+                          const DeclContext *DC) {
   if (DC->isTranslationUnit())
     return;
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4491,10 +4491,22 @@ SYCLIntegrationHeader::SYCLIntegrationHeader(bool _UnnamedLambdaSupport,
     : UnnamedLambdaSupport(_UnnamedLambdaSupport), S(_S) {}
 
 void SYCLIntegrationFooter::addVarDecl(const VarDecl *VD) {
+  // Skip the dependent version of these variables, we only care about them
+  // after instantiation.
+  if (VD->getDeclContext()->isDependentContext())
+    return;
   // Step 1: ensure that this is of the correct type-spec-constant template
   // specialization).
-  if (!Util::isSyclSpecIdType(VD->getType()))
-    return;
+  if (!Util::isSyclSpecIdType(VD->getType())) {
+    // handle the case where this could be a deduced type, such as a deduction
+    // guide. We have to do this here since this function, unlike most of the
+    // rest of this file, is called during Sema instead of after it. We will
+    // also have to filter out after deduction later.
+    QualType Ty = VD->getType().getCanonicalType();
+
+    if (!Ty->isUndeducedType())
+      return;
+  }
   // Step 2: ensure that this is a static member, or a namespace-scope.
   // Note that isLocalVarDeclorParm excludes thread-local and static-local
   // intentionally, as there is no way to 'spell' one of those in the
@@ -4536,23 +4548,161 @@ void SYCLIntegrationFooter::emitSpecIDName(raw_ostream &O, const VarDecl *VD) {
   O << "";
 }
 
+template <typename Before, typename After>
+static void PrintNSHelper(Before B, After A, raw_ostream &O, const DeclContext *DC) {
+  if (DC->isTranslationUnit())
+    return;
+
+  const auto *CurDecl = cast<Decl>(DC);
+  // Ensure we are in the canonical version, so that we know we have the 'full'
+  // name of the thing.
+  CurDecl = CurDecl->getCanonicalDecl();
+
+  // We are intentionally skipping linkage decls and record decls.  Namespaces
+  // can appear in a linkage decl, but not a record decl, so we don't have to
+  // worry about the names getting messed up from that.  We handle record-decls
+  // later when printing the name of the thing.
+  if (const auto *NS = dyn_cast<NamespaceDecl>(CurDecl))
+    B(O, NS);
+
+  if (CurDecl->getDeclContext())
+    PrintNSHelper(B, A, O, CurDecl->getDeclContext());
+
+  if (const auto *NS = dyn_cast<NamespaceDecl>(CurDecl))
+    A(O, NS);
+}
+
+static void PrintNamespaces(raw_ostream &O, const DeclContext *DC) {
+  PrintNSHelper([](raw_ostream &O, const NamespaceDecl *NS) {},
+                [](raw_ostream &O, const NamespaceDecl *NS) {
+                  if (NS->isInline())
+                    O << "inline ";
+                  O << "namespace ";
+                  if (!NS->isAnonymousNamespace())
+                    O << NS->getName() << " ";
+                  O << "{\n";
+                },
+                O, DC);
+}
+
+static void PrintNSClosingBraces(raw_ostream &O, const DeclContext *DC) {
+  PrintNSHelper(
+      [](raw_ostream &O, const NamespaceDecl *NS) {
+        O << "} // ";
+        if (NS->isInline())
+          O << "inline ";
+
+        O << "namespace ";
+        if (!NS->isAnonymousNamespace())
+          O << NS->getName();
+
+        O << '\n';
+      },
+      [](raw_ostream &O, const NamespaceDecl *NS) {}, O, DC);
+}
+
+static std::string EmitSpecIdShim(raw_ostream &O, unsigned &ShimCounter,
+                                  const std::string &LastShim,
+                                  const NamespaceDecl *AnonNS) {
+  std::string NewShimName =
+      "__sycl_detail::__spec_id_shim_" + std::to_string(ShimCounter) + "()";
+  // Print opening-namespace
+  PrintNamespaces(O, Decl::castToDeclContext(AnonNS));
+  O << "namespace __sycl_detail {\n";
+  O << "static constexpr decltype(" << LastShim << ") &__spec_id_shim_"
+    << ShimCounter << "() {\n";
+  O << "  return " << LastShim << ";\n";
+  O << "}\n";
+  O << "} // namespace __sycl_detail \n";
+  PrintNSClosingBraces(O, Decl::castToDeclContext(AnonNS));
+
+  ++ShimCounter;
+  return std::move(NewShimName);
+}
+
+// Emit the list of shims required for a DeclContext, calls itself recursively.
+static std::string EmitSpecIdShims(raw_ostream &O, unsigned &ShimCounter,
+                                   const DeclContext *DC,
+                                   std::string NameForLastShim) {
+  if (DC->isTranslationUnit()) {
+    NameForLastShim = "::" + NameForLastShim;
+    return std::move(NameForLastShim);
+  }
+
+  const auto *CurDecl = cast<Decl>(DC)->getCanonicalDecl();
+
+  // We skip linkage decls, since they don't modify the Qualified name.
+  if (const auto *RD = dyn_cast<RecordDecl>(CurDecl)) {
+    NameForLastShim = RD->getNameAsString() + "::" + NameForLastShim;
+  } else if (const auto *ND = dyn_cast<NamespaceDecl>(CurDecl)) {
+    if (ND->isAnonymousNamespace()) {
+      // Print current shim, reset 'name for last shim'.
+      NameForLastShim = EmitSpecIdShim(O, ShimCounter, NameForLastShim, ND);
+    } else {
+      NameForLastShim = ND->getNameAsString() + "::" + NameForLastShim;
+    }
+  } else {
+    // FIXME: I don't believe there are other declarations that these variables
+    // could possibly find themselves in. LinkageDecls don't change the
+    // qualified name, so there is nothing to do here. At one point we should
+    // probably convince ourselves that this is entire list and remove this
+    // comment.
+    assert(
+        (isa<LinkageSpecDecl>(CurDecl) || isa<ExternCContextDecl>(CurDecl)) &&
+        "Unhandled decl type");
+  }
+
+  return EmitSpecIdShims(O, ShimCounter, CurDecl->getDeclContext(),
+                         NameForLastShim);
+}
+
+// Emit the list of shims required for a variable declaration.
+// Returns a string containing the FQN of the 'top most' shim, including its
+// function call parameters.
+static std::string EmitSpecIdShims(raw_ostream &O, unsigned &ShimCounter,
+                                   const VarDecl *VD) {
+  assert(VD->isInAnonymousNamespace() &&
+         "Function assumes this is in an anonymous namespace");
+  std::string RelativeName = VD->getNameAsString();
+  return EmitSpecIdShims(O, ShimCounter, VD->getDeclContext(), RelativeName);
+}
+
 bool SYCLIntegrationFooter::emit(raw_ostream &O) {
   PrintingPolicy Policy{S.getLangOpts()};
   Policy.adjustForCPlusPlusFwdDecl();
   Policy.SuppressTypedefs = true;
   Policy.SuppressUnwrittenScope = true;
 
-  for (const VarDecl *D : SpecConstants) {
-    O << "template<>\n";
-    O << "inline const char *get_spec_constant_symbolic_ID<";
-    // Emit the FQN for this, but we probably need to do some funny-business for
-    // anonymous namespaces.
-    D->printQualifiedName(O, Policy);
-    O << ">() {\n";
-    O << "  return \"";
-    emitSpecIDName(O, D);
-    O << "\";\n";
-    O << "}\n";
+  // Used to uniquely name the 'shim's as we generate the names in each
+  // anonymous namespace.
+  unsigned ShimCounter = 0;
+  for (const VarDecl *VD : SpecConstants) {
+    VD = VD->getCanonicalDecl();
+    if (VD->isInAnonymousNamespace()) {
+      std::string TopShim = EmitSpecIdShims(O, ShimCounter, VD);
+      O << "namespace sycl {\n";
+      O << "namespace detail {\n";
+      O << "template<>\n";
+      O << "inline const char *get_spec_constant_symbolic_ID<" << TopShim
+        << ">() {\n";
+      O << "  return " << TopShim << ";\n";
+      O << "}\n";
+      O << "} // namespace detail\n";
+      O << "} // namespace sycl\n";
+    } else {
+      O << "namespace sycl {\n";
+      O << "namespace detail {\n";
+      O << "template<>\n";
+      O << "inline const char *get_spec_constant_symbolic_ID<::";
+      VD->printQualifiedName(O, Policy);
+      O << ">() {\n";
+      O << "  return \"";
+      emitSpecIDName(O, VD);
+      O << "\";\n";
+      O << "}\n";
+      O << "} // namespace detail\n";
+      O << "} // namespace sycl\n";
+    }
   }
 
   O << "#include <CL/sycl/detail/spec_const_integration.hpp>\n";

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -321,6 +321,10 @@ private:
   T MDefaultValue;
 };
 
+#if __cplusplus >= 201703L
+template<typename T> specialization_id(T) -> specialization_id<T>;
+#endif // C++17.
+
 #define ATTR_SYCL_KERNEL __attribute__((sycl_kernel))
 template <typename KernelName = auto_name, typename KernelType>
 ATTR_SYCL_KERNEL void kernel_single_task(const KernelType &kernelFunc) { // #KernelSingleTask

--- a/clang/test/CodeGenSYCL/anonymous_integration_footer.cpp
+++ b/clang/test/CodeGenSYCL/anonymous_integration_footer.cpp
@@ -1,0 +1,363 @@
+// RUN: %clang_cc1 -fsycl-is-device -std=c++17 -triple spir64-unknown-unknown-sycldevice -fsycl-int-footer=%t.h %s -emit-llvm -o %t.ll
+// RUN: FileCheck -input-file=%t.h %s
+// A test that validates the more complex cases of the specialization-constant
+// integration footer details, basically any situation we can come up with that
+// has an anonymous namespace.
+
+#include "Inputs/sycl.hpp"
+int main() {
+  cl::sycl::kernel_single_task<class first_kernel>([]() {});
+}
+
+using namespace cl;
+// Example ways in which the application can declare a "specialization_id"
+// variable.
+struct S1 {
+  static constexpr sycl::specialization_id a{1};
+  // CHECK: namespace sycl {
+  // CHECK-NEXT: namespace detail {
+  // CHECK-NEXT: template<>
+  // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::S1::a>() {
+  // CHECK-NEXT: return "";
+  // CHECK-NEXT: }
+  // CHECK-NEXT: } // namespace detail
+  // CHECK-NEXT: } // namespace sycl
+};
+constexpr sycl::specialization_id b{2};
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::b>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+inline constexpr sycl::specialization_id c{3};
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::c>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+static constexpr sycl::specialization_id d{4};
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::d>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+
+namespace {
+struct S2 {
+  static constexpr sycl::specialization_id a{18};
+  // CHECK-NEXT: namespace {
+  // CHECK-NEXT: namespace __sycl_detail {
+  // CHECK-NEXT: static constexpr decltype(S2::a) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+  // CHECK-NEXT: return S2::a;
+  // CHECK-NEXT: }
+  // CHECK-NEXT: } // namespace __sycl_detail
+  // CHECK-NEXT: } // namespace
+  // CHECK-NEXT: namespace sycl {
+  // CHECK-NEXT: namespace detail {
+  // CHECK-NEXT: template<>
+  // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+  // CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+  // CHECK-NEXT: }
+  // CHECK-NEXT: // namespace detail
+  // CHECK-NEXT: // namespace sycl
+};
+} // namespace
+
+template <int Val>
+struct S3 {
+  static constexpr sycl::specialization_id a{Val};
+};
+template class S3<1>;
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::S3<1>::a>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+template class S3<2>;
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::S3<2>::a>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+
+namespace inner {
+constexpr sycl::specialization_id same_name{5};
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::inner::same_name>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+}
+constexpr sycl::specialization_id same_name{6};
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::same_name>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+namespace {
+constexpr sycl::specialization_id same_name{7};
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+}
+namespace {
+namespace inner {
+constexpr sycl::specialization_id same_name{8};
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(inner::same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return inner::same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+}
+} // namespace
+namespace inner {
+namespace {
+constexpr sycl::specialization_id same_name{9};
+// CHECK-NEXT: namespace inner {
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // namespace inner
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+// CHECK-NEXT: return ::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+}
+} // namespace inner
+
+namespace outer {
+constexpr sycl::specialization_id same_name{10};
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::same_name>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+namespace {
+constexpr sycl::specialization_id same_name{11};
+// CHECK-NEXT: namespace outer {
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+// CHECK-NEXT: return ::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+
+namespace inner {
+constexpr sycl::specialization_id same_name{12};
+// CHECK-NEXT: namespace outer {
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(inner::same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return inner::same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+// CHECK-NEXT: return ::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+
+namespace {
+// This has multiple anonymous namespaces in its declaration context, we need to
+// make sure we emit a shim for each.
+constexpr sycl::specialization_id same_name{13};
+// CHECK-NEXT: namespace outer {
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace inner {
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // namespace inner
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // namespace outer
+
+// CHECK-NEXT: namespace outer {
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()) &__spec_id_shim_[[SHIM_ID_2:[0-9]+]]() {
+// CHECK-NEXT: return inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID_2]]()>() {
+// CHECK-NEXT: return ::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID_2]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+}
+} // namespace inner
+} // namespace
+} // namespace outer
+
+namespace {
+namespace outer {
+constexpr sycl::specialization_id same_name{14};
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(outer::same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return outer::same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+namespace {
+constexpr sycl::specialization_id same_name{15};
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace outer {
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()) &__spec_id_shim_[[SHIM_ID2:[0-9]+]]() {
+// CHECK-NEXT: return outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]()>() {
+// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+namespace inner {
+constexpr sycl::specialization_id same_name{16};
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace outer {
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(inner::same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return inner::same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()) &__spec_id_shim_[[SHIM_ID2:[0-9]+]]() {
+// CHECK-NEXT: return outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]()>() {
+// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+}
+} // namespace
+} // namespace outer
+} // namespace
+
+namespace outer {
+namespace inner {
+constexpr sycl::specialization_id same_name{17};
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::inner::same_name>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+}
+} // namespace outer
+
+// CHECK: #include <CL/sycl/detail/spec_const_integration.hpp>

--- a/clang/test/CodeGenSYCL/anonymous_integration_footer2.cpp
+++ b/clang/test/CodeGenSYCL/anonymous_integration_footer2.cpp
@@ -109,4 +109,29 @@ constexpr sycl::specialization_id same_name{208};
 }
 } // namespace
 
+namespace outer::inline inner {
+namespace {
+constexpr sycl::specialization_id same_name{209};
+// CHECK: namespace outer {
+// CHECK-NEXT: namespace inner {
+// CHECK-NEXT: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // inline namespace inner
+// CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+// CHECK-NEXT: return ::outer::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+}
+}
+
 // CHECK: #include <CL/sycl/detail/spec_const_integration.hpp>

--- a/clang/test/CodeGenSYCL/anonymous_integration_footer2.cpp
+++ b/clang/test/CodeGenSYCL/anonymous_integration_footer2.cpp
@@ -1,0 +1,112 @@
+// RUN: %clang_cc1 -fsycl-is-device -std=c++17 -triple spir64-unknown-unknown-sycldevice -fsycl-int-footer=%t.h %s -emit-llvm -o %t.ll
+// RUN: FileCheck -input-file=%t.h %s
+// A test that validates the more complex cases of the specialization-constant
+// integration footer details, basically any situation we can come up with that
+// has an anonymous namespace.
+
+#include "Inputs/sycl.hpp"
+int main() {
+  cl::sycl::kernel_single_task<class first_kernel>([]() {});
+}
+using namespace cl;
+
+struct S1 {
+  static constexpr sycl::specialization_id a{1};
+};
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::S1::a>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+
+constexpr sycl::specialization_id b{202};
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::b>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+inline constexpr sycl::specialization_id c{3};
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::c>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+static constexpr sycl::specialization_id d{205};
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::d>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+
+namespace inner {
+constexpr sycl::specialization_id same_name{5};
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::inner::same_name>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+}
+constexpr sycl::specialization_id same_name{6};
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::same_name>() {
+// CHECK-NEXT: return "";
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+namespace {
+constexpr sycl::specialization_id same_name{207};
+// CHECK: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+}
+namespace {
+namespace inner {
+constexpr sycl::specialization_id same_name{208};
+// CHECK: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(inner::same_name) &__spec_id_shim_[[SHIM_ID:[0-9]+]]() {
+// CHECK-NEXT: return inner::same_name;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
+// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: // namespace detail
+// CHECK-NEXT: // namespace sycl
+}
+} // namespace
+
+// CHECK: #include <CL/sycl/detail/spec_const_integration.hpp>

--- a/clang/test/CodeGenSYCL/integration_footer.cpp
+++ b/clang/test/CodeGenSYCL/integration_footer.cpp
@@ -10,17 +10,25 @@ int main() {
 using namespace cl::sycl;
 
 cl::sycl::specialization_id<int> GlobalSpecID;
-// CHECK: template<>
-// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<GlobalSpecID>() {
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::GlobalSpecID>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
 
 struct Wrapper {
   static specialization_id<int> WrapperSpecID;
-  // CHECK: template<>
-  // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<Wrapper::WrapperSpecID>() {
+  // CHECK: namespace sycl {
+  // CHECK-NEXT: namespace detail {
+  // CHECK-NEXT: template<>
+  // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::Wrapper::WrapperSpecID>() {
   // CHECK-NEXT: return "";
   // CHECK-NEXT: }
+  // CHECK-NEXT: } // namespace detail
+  // CHECK-NEXT: } // namespace sycl
 };
 
 template <typename T>
@@ -28,40 +36,64 @@ struct WrapperTemplate {
   static specialization_id<T> WrapperSpecID;
 };
 template class WrapperTemplate<int>;
-// CHECK: template<>
-// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<WrapperTemplate<int>::WrapperSpecID>() {
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::WrapperTemplate<int>::WrapperSpecID>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
 template class WrapperTemplate<double>;
-// CHECK: template<>
-// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<WrapperTemplate<double>::WrapperSpecID>() {
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::WrapperTemplate<double>::WrapperSpecID>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
 
 namespace Foo {
 specialization_id<int> NSSpecID;
-// CHECK: template<>
-// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<Foo::NSSpecID>() {
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::Foo::NSSpecID>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
 inline namespace Bar {
 specialization_id<int> InlineNSSpecID;
-// CHECK: template<>
-// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<Foo::InlineNSSpecID>() {
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::Foo::InlineNSSpecID>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
 specialization_id<int> NSSpecID;
-// CHECK: template<>
-// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<Foo::Bar::NSSpecID>() {
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::Foo::Bar::NSSpecID>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
 
 struct Wrapper {
   static specialization_id<int> WrapperSpecID;
-  // CHECK: template<>
-  // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<Foo::Wrapper::WrapperSpecID>() {
+  // CHECK: namespace sycl {
+  // CHECK-NEXT: namespace detail {
+  // CHECK-NEXT: template<>
+  // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::Foo::Wrapper::WrapperSpecID>() {
   // CHECK-NEXT: return "";
   // CHECK-NEXT: }
+  // CHECK-NEXT: } // namespace detail
+  // CHECK-NEXT: } // namespace sycl
 };
 
 template <typename T>
@@ -69,22 +101,45 @@ struct WrapperTemplate {
   static specialization_id<T> WrapperSpecID;
 };
 template class WrapperTemplate<int>;
-// CHECK: template<>
-// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<Foo::WrapperTemplate<int>::WrapperSpecID>() {
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::Foo::WrapperTemplate<int>::WrapperSpecID>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
 template class WrapperTemplate<double>;
-// CHECK: template<>
-// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<Foo::WrapperTemplate<double>::WrapperSpecID>() {
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::Foo::WrapperTemplate<double>::WrapperSpecID>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
 } // namespace Bar
 namespace {
 specialization_id<int> AnonNSSpecID;
-// CHECK: template<>
-// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<Foo::AnonNSSpecID>() {
-// CHECK-NEXT: return "";
+
+// CHECK: namespace Foo {
+// CHECK: namespace {
+// CHECK-NEXT: namespace __sycl_detail {
+// CHECK-NEXT: static constexpr decltype(AnonNSSpecID) &__spec_id_shim_[[SHIM0:[0-9]+]]() {
+// CHECK-NEXT: return AnonNSSpecID;
 // CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: } // namespace Foo
+
+// CHECK: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::Foo::__sycl_detail::__spec_id_shim_[[SHIM0]]()>() {
+// CHECK-NEXT: return ::Foo::__sycl_detail::__spec_id_shim_[[SHIM0]]();
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
 } // namespace
 
 } // namespace Foo


### PR DESCRIPTION
In order to get the specialization_id metadata to be usable in the
integration footer, we need to insert a 'shim' function at each
anonymous namespace so that we can do a lookup at the 'right' location,
then look it up again later by the type.

This implements all that functionality based on my latest understanding
of the design.