### PR TITLE
[SYCL] Fix for cached subdevices.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2015,7 +2015,7 @@ pi_result piDevicePartition(pi_device Device,
         OutDevices[I] = PiSubDevice.get();
         Platform->PiDevicesCache.push_back(std::move(PiSubDevice));
         // save pointers to sub-devices for quick retrieval in the future.
-        Device->SubDevices.push_back(Dev);
+        Device->SubDevices.push_back(OutDevices[I]);
       }
     }
     delete[] ZeSubdevices;

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2013,9 +2013,9 @@ pi_result piDevicePartition(pi_device Device,
           return Result;
         }
         OutDevices[I] = PiSubDevice.get();
-        Platform->PiDevicesCache.push_back(std::move(PiSubDevice));
         // save pointers to sub-devices for quick retrieval in the future.
-        Device->SubDevices.push_back(OutDevices[I]);
+        Device->SubDevices.push_back(PiSubDevice.get());
+        Platform->PiDevicesCache.push_back(std::move(PiSubDevice));
       }
     }
     delete[] ZeSubdevices;


### PR DESCRIPTION
This change corrects an error in the caching of subdevices.

Signed-off-by: rdeodhar <rajiv.deodhar@intel.com>