### PR TITLE
[SYCL][NFC] Refactor CG type versioning

### DIFF
--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -164,8 +164,6 @@ public:
     PREFETCH_USM = 12,
     CODEPLAY_INTEROP_TASK = 13,
     CODEPLAY_HOST_TASK = 14,
-    KERNEL_V1 =
-        getVersionedCGType(KERNEL, static_cast<unsigned int>(CG_VERSION::V1)),
   };
 
   CG(CGTYPE Type, vector_class<vector_class<char>> ArgsStorage,
@@ -191,6 +189,10 @@ public:
   CG(CG &&CommandGroup) = default;
 
   CGTYPE getType() { return static_cast<CGTYPE>(getUnversionedCGType(MType)); }
+
+  CG_VERSION getVersion() {
+    return static_cast<CG_VERSION>(getCGTypeVersion(MType));
+  }
 
   std::shared_ptr<std::vector<ExtendedMemberT>> getExtendedMembers() {
     if (getCGTypeVersion(MType) == static_cast<unsigned int>(CG_VERSION::V0) ||
@@ -259,8 +261,7 @@ public:
         MSyclKernel(std::move(SyclKernel)), MArgs(std::move(Args)),
         MKernelName(std::move(KernelName)), MOSModuleHandle(OSModuleHandle),
         MStreams(std::move(Streams)) {
-    assert((getType() == RUN_ON_HOST_INTEL || getType() == KERNEL ||
-            getType() == KERNEL_V1) &&
+    assert((getType() == RUN_ON_HOST_INTEL || getType() == KERNEL) &&
            "Wrong type of exec kernel CG.");
   }
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -2224,7 +2224,7 @@ private:
   shared_ptr_class<detail::kernel_impl> MKernel;
   /// Type of the command group, e.g. kernel, fill. Can also encode version.
   /// Use getType and setType methods to access this variable unless
-  /// manupulations with version are required
+  /// manipulations with version are required
   detail::CG::CGTYPE MCGType = detail::CG::NONE;
   /// Pointer to the source host memory or accessor(depending on command type).
   void *MSrcPtr = nullptr;

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -325,8 +325,18 @@ private:
     return Storage;
   }
 
+  void setType(detail::CG::CGTYPE Type) {
+    constexpr detail::CG::CG_VERSION Version = detail::CG::CG_VERSION::V1;
+    MCGType = static_cast<detail::CG::CGTYPE>(
+        getVersionedCGType(Type, static_cast<int>(Version)));
+  }
+
+  detail::CG::CGTYPE getType() {
+    return static_cast<detail::CG::CGTYPE>(getUnversionedCGType(MCGType));
+  }
+
   void throwIfActionIsCreated() {
-    if (detail::CG::NONE != MCGType)
+    if (detail::CG::NONE != getType())
       throw sycl::runtime_error("Attempt to set multiple actions for the "
                                 "command group. Command group must consist of "
                                 "a single kernel or explicit memory operation.",
@@ -822,7 +832,7 @@ private:
       MNDRDesc.set(std::move(AdjustedRange));
       StoreLambda<NameWT, decltype(Wrapper), Dims, TransformedArgType>(
           std::move(Wrapper));
-      MCGType = detail::CG::KERNEL_V1;
+      setType(detail::CG::KERNEL);
 #endif
     } else
 #endif // !__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ &&                     \
@@ -837,7 +847,7 @@ private:
       MNDRDesc.set(std::move(NumWorkItems));
       StoreLambda<NameT, KernelType, Dims, TransformedArgType>(
           std::move(KernelFunc));
-      MCGType = detail::CG::KERNEL_V1;
+      setType(detail::CG::KERNEL);
 #endif
     }
   }
@@ -856,7 +866,7 @@ private:
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NumWorkItems);
     MNDRDesc.set(std::move(NumWorkItems));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
     extractArgsAndReqs();
     MKernelName = getKernelName();
   }
@@ -1173,7 +1183,7 @@ public:
     MNDRDesc.set(range<1>{1});
 
     StoreLambda<NameT, KernelType, /*Dims*/ 0, void>(KernelFunc);
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
 #endif
   }
 
@@ -1217,7 +1227,7 @@ public:
     MArgs = std::move(MAssociatedAccesors);
     MHostKernel.reset(
         new detail::HostKernel<FuncT, void, 1, void>(std::move(Func)));
-    MCGType = detail::CG::RUN_ON_HOST_INTEL;
+    setType(detail::CG::RUN_ON_HOST_INTEL);
   }
 
   template <typename FuncT>
@@ -1231,7 +1241,7 @@ public:
 
     MHostTask.reset(new detail::HostTask(std::move(Func)));
 
-    MCGType = detail::CG::CODEPLAY_HOST_TASK;
+    setType(detail::CG::CODEPLAY_HOST_TASK);
   }
 
   template <typename FuncT>
@@ -1245,7 +1255,7 @@ public:
 
     MHostTask.reset(new detail::HostTask(std::move(Func)));
 
-    MCGType = detail::CG::CODEPLAY_HOST_TASK;
+    setType(detail::CG::CODEPLAY_HOST_TASK);
   }
 
 // replace _KERNELFUNCPARAM(KernelFunc) with   KernelType KernelFunc
@@ -1285,7 +1295,7 @@ public:
     detail::checkValueRange<Dims>(NumWorkItems, WorkItemOffset);
     MNDRDesc.set(std::move(NumWorkItems), std::move(WorkItemOffset));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
 #endif
   }
 
@@ -1317,7 +1327,7 @@ public:
     detail::checkValueRange<Dims>(ExecutionRange);
     MNDRDesc.set(std::move(ExecutionRange));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
 #endif
   }
 
@@ -1550,7 +1560,7 @@ public:
     detail::checkValueRange<Dims>(NumWorkGroups);
     MNDRDesc.setNumWorkGroups(NumWorkGroups);
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -1586,7 +1596,7 @@ public:
     detail::checkValueRange<Dims>(ExecRange);
     MNDRDesc.set(std::move(ExecRange));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -1603,7 +1613,7 @@ public:
     // known constant
     MNDRDesc.set(range<1>{1});
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
     extractArgsAndReqs();
     MKernelName = getKernelName();
   }
@@ -1636,7 +1646,7 @@ public:
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NumWorkItems, WorkItemOffset);
     MNDRDesc.set(std::move(NumWorkItems), std::move(WorkItemOffset));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
     extractArgsAndReqs();
     MKernelName = getKernelName();
   }
@@ -1655,7 +1665,7 @@ public:
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NDRange);
     MNDRDesc.set(std::move(NDRange));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
     extractArgsAndReqs();
     MKernelName = getKernelName();
   }
@@ -1679,7 +1689,7 @@ public:
     // known constant
     MNDRDesc.set(range<1>{1});
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
@@ -1694,7 +1704,7 @@ public:
   template <typename FuncT> void interop_task(FuncT Func) {
 
     MInteropTask.reset(new detail::InteropTask(std::move(Func)));
-    MCGType = detail::CG::CODEPLAY_INTEROP_TASK;
+    setType(detail::CG::CODEPLAY_INTEROP_TASK);
   }
 
   /// Defines and invokes a SYCL kernel function for the specified range.
@@ -1720,7 +1730,7 @@ public:
     detail::checkValueRange<Dims>(NumWorkItems);
     MNDRDesc.set(std::move(NumWorkItems));
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
@@ -1756,7 +1766,7 @@ public:
     detail::checkValueRange<Dims>(NumWorkItems, WorkItemOffset);
     MNDRDesc.set(std::move(NumWorkItems), std::move(WorkItemOffset));
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
@@ -1792,7 +1802,7 @@ public:
     detail::checkValueRange<Dims>(NDRange);
     MNDRDesc.set(std::move(NDRange));
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
@@ -1833,7 +1843,7 @@ public:
     MNDRDesc.setNumWorkGroups(NumWorkGroups);
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -1874,7 +1884,7 @@ public:
     MNDRDesc.set(std::move(ExecRange));
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    MCGType = detail::CG::KERNEL_V1;
+    setType(detail::CG::KERNEL);
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -1957,7 +1967,7 @@ public:
       return;
     }
 #endif
-    MCGType = detail::CG::COPY_ACC_TO_PTR;
+    setType(detail::CG::COPY_ACC_TO_PTR);
 
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Src;
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
@@ -1996,7 +2006,7 @@ public:
       return;
     }
 #endif
-    MCGType = detail::CG::COPY_PTR_TO_ACC;
+    setType(detail::CG::COPY_PTR_TO_ACC);
 
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Dst;
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
@@ -2041,7 +2051,7 @@ public:
            "The destination accessor does not fit the copied memory.");
     if (copyAccToAccHelper(Src, Dst))
       return;
-    MCGType = detail::CG::COPY_ACC_TO_ACC;
+    setType(detail::CG::COPY_ACC_TO_ACC);
 
     detail::AccessorBaseHost *AccBaseSrc = (detail::AccessorBaseHost *)&Src;
     detail::AccessorImplPtr AccImplSrc = detail::getSyclObjImpl(*AccBaseSrc);
@@ -2071,7 +2081,7 @@ public:
     throwIfActionIsCreated();
     static_assert(isValidTargetForExplicitOp(AccessTarget),
                   "Invalid accessor target for the update_host method.");
-    MCGType = detail::CG::UPDATE_HOST;
+    setType(detail::CG::UPDATE_HOST);
 
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Acc;
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
@@ -2103,7 +2113,7 @@ public:
                   "Invalid accessor target for the fill method.");
     if (!MIsHost && (((Dims == 1) && isConstOrGlobal(AccessTarget)) ||
                      isImageOrImageArray(AccessTarget))) {
-      MCGType = detail::CG::FILL;
+      setType(detail::CG::FILL);
 
       detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Dst;
       detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
@@ -2148,7 +2158,7 @@ public:
   /// complete state.
   void barrier() {
     throwIfActionIsCreated();
-    MCGType = detail::CG::BARRIER;
+    setType(detail::CG::BARRIER);
   }
 
   /// Prevents any commands submitted afterward to this queue from executing
@@ -2212,7 +2222,9 @@ private:
   string_class MKernelName;
   /// Storage for a sycl::kernel object.
   shared_ptr_class<detail::kernel_impl> MKernel;
-  /// Type of the command group, e.g. kernel, fill.
+  /// Type of the command group, e.g. kernel, fill. Can also encode version.
+  /// Use getType and setType methods to access this variable unless
+  /// manupulations with version are required
   detail::CG::CGTYPE MCGType = detail::CG::NONE;
   /// Pointer to the source host memory or accessor(depending on command type).
   void *MSrcPtr = nullptr;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1882,8 +1882,7 @@ cl_int ExecCGCommand::enqueueImp() {
           "Enqueueing run_on_host_intel task has failed.", Error);
     }
   }
-  case CG::CGTYPE::KERNEL:
-  case CG::CGTYPE::KERNEL_V1: {
+  case CG::CGTYPE::KERNEL: {
     CGExecKernel *ExecKernel = (CGExecKernel *)MCommandGroup.get();
 
     NDRDescT &NDRDesc = ExecKernel->MNDRDesc;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -127,7 +127,7 @@ event handler::finalize() {
   }
 
   unique_ptr_class<detail::CG> CommandGroup;
-  switch (static_cast<detail::CG::CGTYPE>(getType())) {
+  switch (getType()) {
   case detail::CG::KERNEL:
   case detail::CG::RUN_ON_HOST_INTEL: {
     CommandGroup.reset(new detail::CGExecKernel(
@@ -204,8 +204,9 @@ event handler::finalize() {
   }
 
   if (!CommandGroup)
-    throw runtime_error("Internal Error. Command group cannot be constructed.",
-                        PI_INVALID_OPERATION);
+    throw sycl::runtime_error(
+        "Internal Error. Command group cannot be constructed.",
+        PI_INVALID_OPERATION);
 
   detail::EventImplPtr Event = detail::Scheduler::getInstance().addCG(
       std::move(CommandGroup), std::move(MQueue));

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -127,9 +127,8 @@ event handler::finalize() {
   }
 
   unique_ptr_class<detail::CG> CommandGroup;
-  switch (MCGType) {
+  switch (static_cast<detail::CG::CGTYPE>(getType())) {
   case detail::CG::KERNEL:
-  case detail::CG::KERNEL_V1:
   case detail::CG::RUN_ON_HOST_INTEL: {
     CommandGroup.reset(new detail::CGExecKernel(
         std::move(MNDRDesc), std::move(MHostKernel), std::move(MKernel),
@@ -203,6 +202,10 @@ event handler::finalize() {
                         "explicit memory operation.",
                         PI_INVALID_OPERATION);
   }
+
+  if (!CommandGroup)
+    throw runtime_error("Internal Error. Command group cannot be constructed.",
+                        PI_INVALID_OPERATION);
 
   detail::EventImplPtr Event = detail::Scheduler::getInstance().addCG(
       std::move(CommandGroup), std::move(MQueue));


### PR DESCRIPTION
Removed dedicated `KERNEL_V1` value, start using setType and getType
which hide manipulations with the version.