### PR TITLE
[SYCL] Fix SYCLLowerWGLocalMemoryPass crash

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerWGLocalMemory.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerWGLocalMemory.cpp
@@ -98,8 +98,8 @@ static bool allocaWGLocalMemory(Module &M) {
 
   assert(ALMFunc->isDeclaration() && "should have declaration only");
 
-  for (User *U : ALMFunc->users()) {
-    auto *CI = cast<CallInst>(U);
+  for (auto U = ALMFunc->user_begin(), UE = ALMFunc->user_end(); U != UE;) {
+    auto *CI = cast<CallInst>(*U++);
     lowerAllocaLocalMemCall(CI, M);
   }
 


### PR DESCRIPTION
When call of __sycl_allocateLocalMemory is lowered and erased from parent
function block then iterator on this call instruction may be invalidated.
Modify iterating through __sycl_allocateLocalMemory function users.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>