### PR TITLE
[SYCL] Add string header include required for std::stoi

### DIFF
--- a/sycl/plugins/level_zero/usm_allocator.cpp
+++ b/sycl/plugins/level_zero/usm_allocator.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
The build with some versions of MS VS fails without the include.