### PR TITLE
[SYCL] Define interop type for images in Level-Zero and OpenCL backends

### DIFF
--- a/sycl/include/CL/sycl/backend/level_zero.hpp
+++ b/sycl/include/CL/sycl/backend/level_zero.hpp
@@ -50,9 +50,9 @@ struct interop<backend::level_zero, accessor<DataT, Dimensions, AccessMode,
 };
 
 template <typename DataT, int Dimensions, access::mode AccessMode>
-struct interop<backend::level_zero, accessor<DataT, Dimensions, AccessMode,
-                                             access::target::image,
-                                             access::placeholder::false_t>> {
+struct interop<backend::level_zero,
+               accessor<DataT, Dimensions, AccessMode, access::target::image,
+                        access::placeholder::false_t>> {
   using type = ze_image_handle_t;
 };
 

--- a/sycl/include/CL/sycl/backend/level_zero.hpp
+++ b/sycl/include/CL/sycl/backend/level_zero.hpp
@@ -49,6 +49,13 @@ struct interop<backend::level_zero, accessor<DataT, Dimensions, AccessMode,
   using type = char *;
 };
 
+template <typename DataT, int Dimensions, access::mode AccessMode>
+struct interop<backend::level_zero, accessor<DataT, Dimensions, AccessMode,
+                                             access::target::image,
+                                             access::placeholder::false_t>> {
+  using type = ze_image_handle_t;
+};
+
 namespace detail {
 template <> struct InteropFeatureSupportMap<backend::level_zero> {
   static constexpr bool MakePlatform = true;

--- a/sycl/include/CL/sycl/backend/opencl.hpp
+++ b/sycl/include/CL/sycl/backend/opencl.hpp
@@ -53,6 +53,13 @@ struct interop<backend::opencl, accessor<DataT, Dimensions, AccessMode,
   using type = cl_mem;
 };
 
+template <typename DataT, int Dimensions, access::mode AccessMode>
+struct interop<backend::opencl, accessor<DataT, Dimensions, AccessMode,
+                                         access::target::image,
+                                         access::placeholder::false_t>> {
+  using type = cl_mem;
+};
+
 template <typename DataT, int Dimensions, typename AllocatorT>
 struct interop<backend::opencl, buffer<DataT, Dimensions, AllocatorT>> {
   using type = cl_mem;

--- a/sycl/include/CL/sycl/backend/opencl.hpp
+++ b/sycl/include/CL/sycl/backend/opencl.hpp
@@ -54,9 +54,9 @@ struct interop<backend::opencl, accessor<DataT, Dimensions, AccessMode,
 };
 
 template <typename DataT, int Dimensions, access::mode AccessMode>
-struct interop<backend::opencl, accessor<DataT, Dimensions, AccessMode,
-                                         access::target::image,
-                                         access::placeholder::false_t>> {
+struct interop<backend::opencl,
+               accessor<DataT, Dimensions, AccessMode, access::target::image,
+                        access::placeholder::false_t>> {
   using type = cl_mem;
 };
 


### PR DESCRIPTION
Currently interop type defined for buffers only.
Tests: [llvm-test-suite#252](https://github.com/intel/llvm-test-suite/pull/252)