### PR TITLE
Pass RewriteTypes=true to the GenXSPIRVWriterAdaptor pass

### DIFF
--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -702,7 +702,7 @@ static void LowerEsimdConstructs(Module &M) {
     MPM.add(createInstructionCombiningPass());
     MPM.add(createDeadCodeEliminationPass());
   }
-  MPM.add(createGenXSPIRVWriterAdaptorPass());
+  MPM.add(createGenXSPIRVWriterAdaptorPass(/*RewriteTypes=*/true));
   MPM.run(M);
 }
 


### PR DESCRIPTION
This parameter enables encoding different VC attributes as
OpenCL types, which can be naturally translated from LLVM IR to SPIRV
and vice-versa.
Previously these attributes were transcoded using non-standard
spirv decorations, which are now deprecated and not supported.