### PR TITLE
[NFC][SYCL] Avoid -Wreorder warning about order of initialization

### DIFF
--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -1037,7 +1037,7 @@ struct OptRecordFileRAII {
 
   OptRecordFileRAII(CodeGenAction &CGA, llvm::LLVMContext &Ctx,
                     BackendConsumer &BC)
-      : Ctx(Ctx), OldDiagnosticHandler(Ctx.getDiagnosticHandler()) {
+      : OldDiagnosticHandler(Ctx.getDiagnosticHandler()), Ctx(Ctx) {
 
     CompilerInstance &CI = CGA.getCompilerInstance();
     CodeGenOptions &CodeGenOpts = CI.getCodeGenOpts();


### PR DESCRIPTION
In the OptRecordFileRAII constructor, Ctx is initialized before OldDiagnosticHandler.
Change the order of declaration of these data members to avoid a -Wreorder warning.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>