### PR TITLE
[SYCL-PTX] Fix libclc dependencies

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -91,7 +91,7 @@ macro(add_libclc_builtin_set arch_suffix)
     COMMAND prepare_builtins -o
     "${builtins_obj_path}"
     "$<TARGET_PROPERTY:opt.${obj_suffix},TARGET_FILE>"
-    DEPENDS ${builtins_opt_path}
+    DEPENDS "opt.${obj_suffix}"
             prepare_builtins )
   add_custom_target( "prepare-${obj_suffix}" ALL
     DEPENDS "${builtins_obj_path}" )


### PR DESCRIPTION
Changes the file-level dependency in the prepare step to a target-level dependency, ensuring the custom opt command has been run before the prepare step.