### PR TITLE
[SYCL] Implement SYCL-2020 queue::parallel_for

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1534,6 +1534,17 @@ public:
       MLastEvent = *CopyEvent;
   }
 
+  // TODO: make it private!!!!!!!!
+  template <typename KernelName, typename RangeT, typename... Ts, size_t... Is>
+  inline void parallel_for(RangeT &Range, std::tuple<Ts...> Args, std::index_sequence<Is...>) {
+    parallel_for<KernelName>(Range, std::get<Is>(Args)...);
+  }
+  template <typename KernelName, typename RangeT, typename... Ts>
+  inline void parallel_for(RangeT &Range, std::tuple<Ts...> Args) {
+    constexpr auto Indices = std::make_index_sequence<sizeof...(Ts)>();
+    parallel_for<KernelName>(Range, Args, Indices);
+  }
+
   /// Hierarchical kernel invocation method of a kernel defined as a lambda
   /// encoding the body of each work-group to launch.
   ///

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1534,17 +1534,6 @@ public:
       MLastEvent = *CopyEvent;
   }
 
-  // TODO: make it private!!!!!!!!
-  template <typename KernelName, typename RangeT, typename... Ts, size_t... Is>
-  inline void parallel_for(RangeT &Range, std::tuple<Ts...> Args, std::index_sequence<Is...>) {
-    parallel_for<KernelName>(Range, std::get<Is>(Args)...);
-  }
-  template <typename KernelName, typename RangeT, typename... Ts>
-  inline void parallel_for(RangeT &Range, std::tuple<Ts...> Args) {
-    constexpr auto Indices = std::make_index_sequence<sizeof...(Ts)>();
-    parallel_for<KernelName>(Range, Args, Indices);
-  }
-
   /// Hierarchical kernel invocation method of a kernel defined as a lambda
   /// encoding the body of each work-group to launch.
   ///


### PR DESCRIPTION
DRAFT NOW: the implementation is incomplete.
It is a prototype that is uploaded to get initial testing results and check if the implementation is legit. 

Any implementation that tries to preserve the existing XPTI instrumentation
implemented for queue::parallel_for() methods via the last argument 'code_location' having the default value, conflicts with SYCL-2020. 
The experimental proposal suggests having XPTI instrumentation for queue::parallel_for() accepting up to some fixed N number of reductions (e.g. 8, but in the current changes it is 2 for simplitity). More than N reductions would not support XPTI instrumentation.