### PR TITLE
[SYCL] Allow fpga_reg only for PODs and Trivially-copyable structs

### DIFF
--- a/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
@@ -18,8 +18,8 @@ namespace INTEL {
 // This function is intended for FPGA users to instruct the compiler to insert
 // at least one register stage between the input and the return value.
 template <typename _T>
-typename std::enable_if<std::is_trivially_copyable<T>::value, T>::type
-fpga_reg(T t) {
+typename std::enable_if<std::is_trivially_copyable<_T>::value, _T>::type
+fpga_reg(_T t) {
 #if __has_builtin(__builtin_intel_fpga_reg)
   return __builtin_intel_fpga_reg(t);
 #else

--- a/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
@@ -14,7 +14,12 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace INTEL {
 
-template <typename _T> _T fpga_reg(const _T &t) {
+// Returns a registered copy of the input
+// This function is intended for FPGA users to instruct the compiler to insert
+// at least one register stage between the input and the return value.
+template <typename _T>
+typename std::enable_if<std::is_trivially_copyable<T>::value, T>::type
+fpga_reg(T t) {
 #if __has_builtin(__builtin_intel_fpga_reg)
   return __builtin_intel_fpga_reg(t);
 #else
@@ -25,11 +30,3 @@ template <typename _T> _T fpga_reg(const _T &t) {
 } // namespace INTEL
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
-
-// Keep it consistent with FPGA attributes like intelfpga::memory()
-// Currently clang does not support nested namespace for attributes
-namespace intelfpga {
-template <typename _T> _T fpga_reg(const _T &t) {
-  return cl::sycl::INTEL::fpga_reg(t);
-}
-} // namespace intelfpga

--- a/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
@@ -30,3 +30,4 @@ fpga_reg(T t) {
 } // namespace INTEL
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
+

--- a/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
@@ -18,9 +18,9 @@ namespace INTEL {
 // Returns a registered copy of the input
 // This function is intended for FPGA users to instruct the compiler to insert
 // at least one register stage between the input and the return value.
-template <typename _T>
-typename std::enable_if<std::is_trivially_copyable<_T>::value, _T>::type
-fpga_reg(_T t) {
+template <typename _T> _T fpga_reg(_T t) {
+  static_assert(std::is_trivially_copyable<_T>::value,
+                "Type is not trivially_copyable.");
 #if __has_builtin(__builtin_intel_fpga_reg)
   return __builtin_intel_fpga_reg(t);
 #else
@@ -31,4 +31,3 @@ fpga_reg(_T t) {
 } // namespace INTEL
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
-

--- a/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
@@ -18,9 +18,22 @@ namespace INTEL {
 // Returns a registered copy of the input
 // This function is intended for FPGA users to instruct the compiler to insert
 // at least one register stage between the input and the return value.
-template <typename _T> _T fpga_reg(_T t) {
-  static_assert(std::is_trivially_copyable<_T>::value,
-                "Type is not trivially_copyable.");
+template <typename _T>
+typename std::enable_if<std::is_trivially_copyable<_T>::value, _T>::type
+fpga_reg(_T t) {
+#if __has_builtin(__builtin_intel_fpga_reg)
+  return __builtin_intel_fpga_reg(t);
+#else
+  return t;
+#endif
+}
+
+template <typename _T>
+[[deprecated("INTEL::fpga_reg will only support trivially_copyable types in a "
+             "future release. The type used here will be disallowed.")]]
+typename std::enable_if<std::is_trivially_copyable<_T>::value == false,
+                        _T>::type
+fpga_reg(_T t) {
 #if __has_builtin(__builtin_intel_fpga_reg)
   return __builtin_intel_fpga_reg(t);
 #else
@@ -31,3 +44,13 @@ template <typename _T> _T fpga_reg(_T t) {
 } // namespace INTEL
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
+
+// Keep it consistent with FPGA attributes like intelfpga::memory()
+// Currently clang does not support nested namespace for attributes
+namespace intelfpga {
+template <typename _T>
+[[deprecated("intelfpga::fpga_reg will be removed in a future release.")]] _T
+fpga_reg(const _T &t) {
+  return cl::sycl::INTEL::fpga_reg(t);
+}
+} // namespace intelfpga

--- a/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
+++ b/sycl/include/CL/sycl/INTEL/fpga_reg.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/detail/defines.hpp>
+#include <type_traits>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {


### PR DESCRIPTION
This change restricts the INTEL::fpga_reg function to only take in trivially copyable structs, and models the hardware better but created a registered copy, rather than just passing through as a reference. 

The intention of this function was initially built for PODs and later extended to structs in OpenCL. It literally is used to force a register stage in hardware between the input and output (i.e. in the software model, it is an exact copy of the data in memory). It doesn't translate directly to C++ objects because classes with complex copy constructors cannot be modelled to do what is described above, and building out this builtin in hardware as per the software model reduces its use case. As such, restricting the function to only types that have a usable and correct implementation of this function is the ideal thing to do here

Note that I also removed the old mapping to intelfpga::fpga_reg as part of this changelist. 

Testing:
- Ran this new header file with a variety of SYCL examples in the FPGA design suite to ensure that it was still behaving in its intended behavior