### PR TITLE
[SYCL][CUDA] Quick fix for CUDA function to make it match the PI.

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2492,8 +2492,8 @@ pi_result cuda_piEnqueueNativeKernel(
   return {};
 }
 
-pi_result cuda_piextKernelCreateWithNativeHandle(pi_native_handle, pi_context, bool,
-                                                 pi_kernel *) {
+pi_result cuda_piextKernelCreateWithNativeHandle(pi_native_handle, pi_context,
+                                                 bool, pi_kernel *) {
   sycl::detail::pi::die("Unsupported operation");
   return PI_SUCCESS;
 }

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2492,7 +2492,7 @@ pi_result cuda_piEnqueueNativeKernel(
   return {};
 }
 
-pi_result cuda_piextKernelCreateWithNativeHandle(pi_native_handle, pi_context,
+pi_result cuda_piextKernelCreateWithNativeHandle(pi_native_handle, pi_context, bool,
                                                  pi_kernel *) {
   sycl::detail::pi::die("Unsupported operation");
   return PI_SUCCESS;


### PR DESCRIPTION
Quick fix for CUDA function to make it match the PI. Was missing a bool. Without this cuda builds fail.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>