### PR TITLE
[SYCL] Fix -Wrange-loop-construct warning

### DIFF
--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -270,7 +270,7 @@ public:
             &SpecConsts = ImgImpl->get_spec_const_data_ref();
         const std::vector<unsigned char> &Blob =
             ImgImpl->get_spec_const_blob_ref();
-        for (const std::pair<std::string,
+        for (const std::pair<const std::string,
                              std::vector<device_image_impl::SpecConstDescT>>
                  &SpecConst : SpecConsts) {
           if (SpecConst.second.front().IsSet)


### PR DESCRIPTION
This warning is unique to clang compiler