### PR TITLE
[SYCL] Fix persistent cache keys comparison

### DIFF
--- a/sycl/source/detail/persistent_device_code_cache.cpp
+++ b/sycl/source/detail/persistent_device_code_cache.cpp
@@ -272,7 +272,7 @@ bool PersistentDeviceCodeCache::isCacheItemSrcEqual(
   FileStream.read((char *)&Size, sizeof(Size));
   res.resize(Size);
   FileStream.read(&res[0], Size);
-  if (BuildOptionsString.compare(0, Size, res.data()))
+  if (BuildOptionsString.compare(res))
     return false;
 
   FileStream.read((char *)&Size, sizeof(Size));


### PR DESCRIPTION
`int compare (const string& str)` method compares strings containing '\0' characters
accurately.