### PR TITLE
[ESIMD] Lower __esimd_lane_id intrinsics

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -383,6 +383,7 @@ public:
         {"ssdp4a_sat", {"ssdp4a.sat", {a(0), a(1), a(2)}}},
         {"any", {"any", {ai1(0)}}},
         {"all", {"all", {ai1(0)}}},
+        {"lane_id", {"lane.id", {}}}
     };
   }
 

--- a/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
@@ -320,6 +320,15 @@ define dso_local spir_func void  @FUNC_45() {
 
 declare void @llvm.assume(i1 noundef)
 
+define dso_local i32 @FUNC_46() {
+; CHECK-LABEL: FUNC_46
+; CHECK: %{{[0-9a-zA-Z_.]+}} = call i32 @llvm.genx.lane.id()
+  %call = call i32 @_Z15__esimd_lane_idv()
+  ret i32 %call
+}
+
+declare dso_local i32 @_Z15__esimd_lane_idv()
+
 declare dso_local spir_func <32 x i32> @_Z20__esimd_flat_atomic0ILN2cm3gen14CmAtomicOpTypeE2EjLi32ELNS1_9CacheHintE0ELS3_0EENS1_13__vector_typeIT0_XT1_EE4typeENS4_IyXT1_EE4typeENS4_ItXT1_EE4typeE(<32 x i64> %0, <32 x i16> %1)
 declare dso_local spir_func <32 x i32> @_Z20__esimd_flat_atomic1ILN2cm3gen14CmAtomicOpTypeE0EjLi32ELNS1_9CacheHintE0ELS3_0EENS1_13__vector_typeIT0_XT1_EE4typeENS4_IyXT1_EE4typeES7_NS4_ItXT1_EE4typeE(<32 x i64> %0, <32 x i32> %1, <32 x i16> %2)
 declare dso_local spir_func <32 x i32> @_Z20__esimd_flat_atomic2ILN2cm3gen14CmAtomicOpTypeE7EjLi32ELNS1_9CacheHintE0ELS3_0EENS1_13__vector_typeIT0_XT1_EE4typeENS4_IyXT1_EE4typeES7_S7_NS4_ItXT1_EE4typeE(<32 x i64> %0, <32 x i32> %1, <32 x i32> %2, <32 x i16> %3)


### PR DESCRIPTION
This patch is one of the few patches to provide a functionality to reuse
existing scalar function implementations in a vector context.