### PR TITLE
[SYCL] Rename helper functions to avoid collision

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -199,18 +199,18 @@ __spirv_GenericCastToPtrExplicit_ToLocal(const void *Ptr,
 
 template <typename dataT>
 extern __attribute__((opencl_global)) dataT *
-__SYCL_GenericCastToPtrExplicit_ToGlobal(
-    const void *Ptr, __spv::StorageClass::Flag S) noexcept {
-  return (__attribute__((opencl_global))
-          dataT *)__spirv_GenericCastToPtrExplicit_ToGlobal(Ptr, S);
+__SYCL_GenericCastToPtrExplicit_ToGlobal(const void *Ptr) noexcept {
+  return (__attribute__((opencl_global)) dataT *)
+      __spirv_GenericCastToPtrExplicit_ToGlobal(
+          Ptr, __spv::StorageClass::CrossWorkgroup);
 }
 
 template <typename dataT>
 extern __attribute__((opencl_local)) dataT *
-__SYCL_GenericCastToPtrExplicit_ToLocal(const void *Ptr,
-                                        __spv::StorageClass::Flag S) noexcept {
-  return (__attribute__((opencl_local))
-          dataT *)__spirv_GenericCastToPtrExplicit_ToLocal(Ptr, S);
+__SYCL_GenericCastToPtrExplicit_ToLocal(const void *Ptr) noexcept {
+  return (__attribute__((opencl_local)) dataT *)
+      __spirv_GenericCastToPtrExplicit_ToLocal(Ptr,
+                                               __spv::StorageClass::Workgroup);
 }
 
 template <typename dataT>

--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -199,7 +199,7 @@ __spirv_GenericCastToPtrExplicit_ToLocal(const void *Ptr,
 
 template <typename dataT>
 extern __attribute__((opencl_global)) dataT *
-__spirv_GenericCastToPtrExplicit_ToGlobal(
+__SYCL_GenericCastToPtrExplicit_ToGlobal(
     const void *Ptr, __spv::StorageClass::Flag S) noexcept {
   return (__attribute__((opencl_global))
           dataT *)__spirv_GenericCastToPtrExplicit_ToGlobal(Ptr, S);
@@ -207,8 +207,8 @@ __spirv_GenericCastToPtrExplicit_ToGlobal(
 
 template <typename dataT>
 extern __attribute__((opencl_local)) dataT *
-__spirv_GenericCastToPtrExplicit_ToLocal(const void *Ptr,
-                                         __spv::StorageClass::Flag S) noexcept {
+__SYCL_GenericCastToPtrExplicit_ToLocal(const void *Ptr,
+                                        __spv::StorageClass::Flag S) noexcept {
   return (__attribute__((opencl_local))
           dataT *)__spirv_GenericCastToPtrExplicit_ToLocal(Ptr, S);
 }

--- a/sycl/include/CL/sycl/ONEAPI/sub_group.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/sub_group.hpp
@@ -244,13 +244,11 @@ struct sub_group {
 #ifdef __NVPTX__
     return src[get_local_id()[0]];
 #else  // __NVPTX__
-    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<T>(
-        src, __spv::StorageClass::Workgroup);
+    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<T>(src);
     if (l)
       return load(l);
 
-    auto g = __SYCL_GenericCastToPtrExplicit_ToGlobal<T>(
-        src, __spv::StorageClass::CrossWorkgroup);
+    auto g = __SYCL_GenericCastToPtrExplicit_ToGlobal<T>(src);
     if (g)
       return load(g);
 
@@ -400,15 +398,13 @@ struct sub_group {
 #ifdef __NVPTX__
     dst[get_local_id()[0]] = x;
 #else  // __NVPTX__
-    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<T>(
-        dst, __spv::StorageClass::Workgroup);
+    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<T>(dst);
     if (l) {
       store(l, x);
       return;
     }
 
-    auto g = __SYCL_GenericCastToPtrExplicit_ToGlobal<T>(
-        dst, __spv::StorageClass::CrossWorkgroup);
+    auto g = __SYCL_GenericCastToPtrExplicit_ToGlobal<T>(dst);
     if (g) {
       store(g, x);
       return;

--- a/sycl/include/CL/sycl/ONEAPI/sub_group.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/sub_group.hpp
@@ -244,12 +244,12 @@ struct sub_group {
 #ifdef __NVPTX__
     return src[get_local_id()[0]];
 #else  // __NVPTX__
-    auto l = __spirv_GenericCastToPtrExplicit_ToLocal<T>(
+    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<T>(
         src, __spv::StorageClass::Workgroup);
     if (l)
       return load(l);
 
-    auto g = __spirv_GenericCastToPtrExplicit_ToGlobal<T>(
+    auto g = __SYCL_GenericCastToPtrExplicit_ToGlobal<T>(
         src, __spv::StorageClass::CrossWorkgroup);
     if (g)
       return load(g);
@@ -400,14 +400,14 @@ struct sub_group {
 #ifdef __NVPTX__
     dst[get_local_id()[0]] = x;
 #else  // __NVPTX__
-    auto l = __spirv_GenericCastToPtrExplicit_ToLocal<T>(
+    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<T>(
         dst, __spv::StorageClass::Workgroup);
     if (l) {
       store(l, x);
       return;
     }
 
-    auto g = __spirv_GenericCastToPtrExplicit_ToGlobal<T>(
+    auto g = __SYCL_GenericCastToPtrExplicit_ToGlobal<T>(
         dst, __spv::StorageClass::CrossWorkgroup);
     if (g) {
       store(g, x);

--- a/sycl/test/extensions/sub_group_as.cpp
+++ b/sycl/test/extensions/sub_group_as.cpp
@@ -1,5 +1,7 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -O3 -S -emit-llvm -x c++ %s -o - | FileCheck %s
-
+// RUN: %clangxx -fsycl -fsycl-device-only -O3 -S -emit-llvm -x c++ %s -o - | FileCheck %s --check-prefix CHECK-O3
+// RUN: %clangxx -fsycl -fsycl-device-only -O0 -S -emit-llvm -x c++ %s -o - | FileCheck %s --check-prefix CHECK-O0
+// Test compilation with -O3 when all methods are inlined in kernel function
+// and -O0 when helper methods are preserved.
 #include <CL/sycl.hpp>
 #include <cassert>
 #include <cstdint>
@@ -43,46 +45,66 @@ int main(int argc, char *argv[]) {
                 local[i] = i;
               }
             }
-            // CHECK:  call spir_func void {{.*}}spirv_ControlBarrierjjj
+            // CHECK-O3:  call spir_func void {{.*}}spirv_ControlBarrierjjj
             it.barrier();
 
             int i = (it.get_global_id(0) / sg.get_max_local_range()[0]) *
                     sg.get_max_local_range()[0];
 
-            // load for global address space
-            // CHECK: call spir_func i8 addrspace(3)* {{.*}}spirv_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
-            // CHECK: {{.*}}SubgroupLocalInvocationId
-            // CHECK: call spir_func i8 addrspace(1)* {{.*}}spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
-            // CHECK: call spir_func i32 {{.*}}spirv_SubgroupBlockRead{{.*}}(i32 addrspace(1)*
-            // CHECK: call spir_func void {{.*}}assert
+            // load() for global address space
+            // CHECK-O3: call spir_func i8 addrspace(3)* {{.*}}spirv_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
+            // CHECK-O3: {{.*}}SubgroupLocalInvocationId
+            // CHECK-O3: call spir_func i8 addrspace(1)* {{.*}}spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
+            // CHECK-O3: call spir_func i32 {{.*}}spirv_SubgroupBlockRead{{.*}}(i32 addrspace(1)*
+            // CHECK-O3: call spir_func void {{.*}}assert
+
             auto x = sg.load(&global[i]);
 
             // load() for local address space
-            // CHECK: call spir_func i8 addrspace(3)* {{.*}}spirv_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
-            // CHECK: {{.*}}SubgroupLocalInvocationId
-            // CHECK: call spir_func i8 addrspace(1)* {{.*}}spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
-            // CHECK: call spir_func i32 {{.*}}spirv_SubgroupBlockRead{{.*}}(i32 addrspace(1)*
-            // CHECK: call spir_func void {{.*}}assert
+            // CHECK-O3: call spir_func i8 addrspace(3)* {{.*}}spirv_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
+            // CHECK-O3: {{.*}}SubgroupLocalInvocationId
+            // CHECK-O3: call spir_func i8 addrspace(1)* {{.*}}spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
+            // CHECK-O3: call spir_func i32 {{.*}}spirv_SubgroupBlockRead{{.*}}(i32 addrspace(1)*
+            // CHECK-O3: call spir_func void {{.*}}assert
             auto y = sg.load(&local[i]);
 
             // load() for private address space
-            // CHECK: call spir_func i8 addrspace(3)* {{.*}}spirv_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
-            // CHECK: {{.*}}SubgroupLocalInvocationId
-            // CHECK: call spir_func i8 addrspace(1)* {{.*}}spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
-            // CHECK: call spir_func i32 {{.*}}spirv_SubgroupBlockRead{{.*}}(i32 addrspace(1)*
-            // CHECK: call spir_func void {{.*}}assert
+            // CHECK-O3: call spir_func i8 addrspace(3)* {{.*}}spirv_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
+            // CHECK-O3: {{.*}}SubgroupLocalInvocationId
+            // CHECK-O3: call spir_func i8 addrspace(1)* {{.*}}spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
+            // CHECK-O3: call spir_func i32 {{.*}}spirv_SubgroupBlockRead{{.*}}(i32 addrspace(1)*
+            // CHECK-O3: call spir_func void {{.*}}assert
             auto z = sg.load(v + i);
 
             // store() for global address space
-            // CHECK: call spir_func i8 addrspace(3)* {{.*}}spirv_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
-            // CHECK: {{.*}}SubgroupLocalInvocationId
-            // CHECK: call spir_func i8 addrspace(1)* {{.*}}spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
-            // CHECK: call spir_func void {{.*}}spirv_SubgroupBlockWriteINTEL{{.*}}(i32 addrspace(1)*
-            // CHECK: call spir_func void {{.*}}assert
+            // CHECK-O3: call spir_func i8 addrspace(3)* {{.*}}spirv_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
+            // CHECK-O3: {{.*}}SubgroupLocalInvocationId
+            // CHECK-O3: call spir_func i8 addrspace(1)* {{.*}}spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
+            // CHECK-O3: call spir_func void {{.*}}spirv_SubgroupBlockWriteINTEL{{.*}}(i32 addrspace(1)*
+            // CHECK-O3: call spir_func void {{.*}}assert
             sg.store(&global[i], x + y + z);
           });
     });
   }
+  // load() accepting raw pointers method
+  // CHECK-O0: define{{.*}}spir_func i32 {{.*}}cl4sycl6ONEAPI9sub_group4load{{.*}}addrspace(4)* %src)
+  // CHECK-O0: call spir_func i32 addrspace(3)* {{.*}}SYCL_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
+  // CHECK-O0: call spir_func i32 {{.*}}sycl6ONEAPI9sub_group4load{{.*}}i32 addrspace(3)* %
+  // CHECK-O0: call spir_func i32 addrspace(1)* {{.*}}SYCL_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
+  // CHECK-O0: call spir_func i32 {{.*}}sycl6ONEAPI9sub_group4load{{.*}}i32 addrspace(1)* %
+  // CHECK-O0: call spir_func void {{.*}}assert
+
+  // store() accepting raw pointers method
+  // CHECK-O0: define{{.*}}spir_func void {{.*}}cl4sycl6ONEAPI9sub_group5store{{.*}}i32 addrspace(4)* %dst
+  // CHECK-O0: call spir_func i32 addrspace(3)* {{.*}}SYCL_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
+  // CHECK-O0: call spir_func void {{.*}}cl4sycl6ONEAPI9sub_group5store{{.*}}, i32 addrspace(3)* %
+  // CHECK-O0: call spir_func i32 addrspace(1)* {{.*}}SYCL_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
+  // CHECK-O0: call spir_func void {{.*}}cl4sycl6ONEAPI9sub_group5store{{.*}}, i32 addrspace(1)* %
+  // CHECK-O0: call spir_func void {{.*}}assert
+  // CHECK-O0: define {{.*}}spir_func i32 addrspace(3)* {{.*}}SYCL_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)* %
+  // CHECK-O0: call spir_func i8 addrspace(3)* {{.*}}spirv_GenericCastToPtrExplicit_ToLocal{{.*}}(i8 addrspace(4)*
+  // CHECK-O0: define {{.*}}spir_func i32 addrspace(1)* {{.*}}SYCL_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)* %
+  // CHECK-O0: call spir_func i8 addrspace(1)* {{.*}}spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}(i8 addrspace(4)*
 
   return 0;
 }


### PR DESCRIPTION
Helper functions have the same names but different signatures to the
ones to be mapped to SPIR-V operations. That makes some backends
generate external calls for them which causes undefined reference
on JIT compilation. The problem is seen only when compiling with
-O0 or -O1 optimization options because when -O3 or -O2 are used
helper functions are inlined and definitions are removed from final
code eliminating the issue.