### PR TITLE
[SYCL][build scripts] Minor update in build scripts

### DIFF
--- a/buildbot/compile.py
+++ b/buildbot/compile.py
@@ -35,6 +35,9 @@ def do_compile(args):
         "deploy-opencl-aot",
         "-j", str(cpu_count)]
 
+    if args.verbose:
+      cmake_cmd.append("--verbose")
+
     print("[Cmake Command]: {}".format(" ".join(cmake_cmd)))
 
     subprocess.check_call(cmake_cmd, cwd=abs_obj_dir)
@@ -55,6 +58,7 @@ def main():
     parser.add_argument("-s", "--src-dir", metavar="SRC_DIR", help="source directory")
     parser.add_argument("-o", "--obj-dir", metavar="OBJ_DIR", help="build directory")
     parser.add_argument("-j", "--build-parallelism", metavar="BUILD_PARALLELISM", help="build parallelism")
+    parser.add_argument("-v", "--verbose", action='store_true', help="verbose build output")
 
     args = parser.parse_args()
 

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -115,8 +115,10 @@ def do_configure(args):
     except subprocess.CalledProcessError:
         cmake_cache = os.path.join(abs_obj_dir, "CMakeCache.txt")
         if os.path.isfile(cmake_cache):
-            os.remove(cmake_cache)
-        subprocess.check_call(cmake_cmd, cwd=abs_obj_dir)
+           print("There is CMakeCache.txt at " + cmake_cache +
+             " ... you can try to remove it and rerun.")
+           print("Configure failed!")
+        return False
 
     return True
 


### PR DESCRIPTION
* Removed automatic retry in configure.py if it failed. It's quite
  annoying when modifying CMakeLists.txt
* Added verbose option to compile.py to print out commands during build

Signed-off-by: Pavel V Chupin <pavel.v.chupin@intel.com>