### PR TITLE
[SYCL] Fix integration-footer anon-NS handling to return right value

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4691,7 +4691,9 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
       OS << "template<>\n";
       OS << "inline const char *get_spec_constant_symbolic_ID<" << TopShim
          << ">() {\n";
-      OS << "  return " << TopShim << ";\n";
+      OS << "  return \"";
+      emitSpecIDName(OS, VD);
+      OS << "\";\n";
     } else {
       OS << "namespace sycl {\n";
       OS << "namespace detail {\n";

--- a/clang/test/CodeGenSYCL/anonymous_integration_footer.cpp
+++ b/clang/test/CodeGenSYCL/anonymous_integration_footer.cpp
@@ -65,7 +65,7 @@ struct S2 {
   // CHECK-NEXT: namespace detail {
   // CHECK-NEXT: template<>
   // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-  // CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
   // CHECK-NEXT: }
   // CHECK-NEXT: // namespace detail
   // CHECK-NEXT: // namespace sycl
@@ -128,7 +128,7 @@ constexpr sycl::specialization_id same_name{7};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -147,7 +147,7 @@ constexpr sycl::specialization_id same_name{8};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -169,7 +169,7 @@ constexpr sycl::specialization_id same_name{9};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-// CHECK-NEXT: return ::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -201,7 +201,7 @@ constexpr sycl::specialization_id same_name{11};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-// CHECK-NEXT: return ::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -221,7 +221,7 @@ constexpr sycl::specialization_id same_name{12};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-// CHECK-NEXT: return ::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -257,7 +257,7 @@ constexpr sycl::specialization_id same_name{13};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID_2]]()>() {
-// CHECK-NEXT: return ::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID_2]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -280,7 +280,7 @@ constexpr sycl::specialization_id same_name{14};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -309,7 +309,7 @@ constexpr sycl::specialization_id same_name{15};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]()>() {
-// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -337,7 +337,7 @@ constexpr sycl::specialization_id same_name{16};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]()>() {
-// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl

--- a/clang/test/CodeGenSYCL/anonymous_integration_footer2.cpp
+++ b/clang/test/CodeGenSYCL/anonymous_integration_footer2.cpp
@@ -83,7 +83,7 @@ constexpr sycl::specialization_id same_name{207};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -102,7 +102,7 @@ constexpr sycl::specialization_id same_name{208};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-// CHECK-NEXT: return ::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl
@@ -127,7 +127,7 @@ constexpr sycl::specialization_id same_name{209};
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
-// CHECK-NEXT: return ::outer::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: // namespace detail
 // CHECK-NEXT: // namespace sycl

--- a/clang/test/CodeGenSYCL/integration_footer.cpp
+++ b/clang/test/CodeGenSYCL/integration_footer.cpp
@@ -136,7 +136,7 @@ specialization_id<int> AnonNSSpecID;
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::Foo::__sycl_detail::__spec_id_shim_[[SHIM0]]()>() {
-// CHECK-NEXT: return ::Foo::__sycl_detail::__spec_id_shim_[[SHIM0]]();
+// CHECK-NEXT: return "";
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace detail
 // CHECK-NEXT: } // namespace sycl


### PR DESCRIPTION
Looks like I got carried away with the implementation and we didn't
catch that I was returning the wrong things from the 'end call function'
when generating anonymous function shims.  This was brought up here:
https://github.com/intel/llvm/pull/3576#pullrequestreview-649401972

This should fix that problem.