### PR TITLE
[SYCL] small fix to alignment assertion

### DIFF
--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -754,9 +754,10 @@ pi_result piextUSMHostAlloc(void **result_ptr, pi_context context,
 
   *result_ptr = Ptr;
 
-  assert(alignment == 0 ||
-         (RetVal == PI_SUCCESS &&
-          reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0));
+  //ensure we aligned the allocation correctly
+  if(RetVal == PI_SUCCESS && alignment != 0)
+    assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0 && "allocation not aligned correctly");
+
   return RetVal;
 }
 
@@ -790,9 +791,10 @@ pi_result piextUSMDeviceAlloc(void **result_ptr, pi_context context,
 
   *result_ptr = Ptr;
 
-  assert(alignment == 0 ||
-         (RetVal == PI_SUCCESS &&
-          reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0));
+  //ensure we aligned the allocation correctly
+  if(RetVal == PI_SUCCESS && alignment != 0)
+    assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0 && "allocation not aligned correctly");
+
   return RetVal;
 }
 

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -754,9 +754,10 @@ pi_result piextUSMHostAlloc(void **result_ptr, pi_context context,
 
   *result_ptr = Ptr;
 
-  //ensure we aligned the allocation correctly
-  if(RetVal == PI_SUCCESS && alignment != 0)
-    assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0 && "allocation not aligned correctly");
+  // ensure we aligned the allocation correctly
+  if (RetVal == PI_SUCCESS && alignment != 0)
+    assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0 &&
+           "allocation not aligned correctly");
 
   return RetVal;
 }
@@ -791,9 +792,10 @@ pi_result piextUSMDeviceAlloc(void **result_ptr, pi_context context,
 
   *result_ptr = Ptr;
 
-  //ensure we aligned the allocation correctly
-  if(RetVal == PI_SUCCESS && alignment != 0)
-    assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0 && "allocation not aligned correctly");
+  // ensure we aligned the allocation correctly
+  if (RetVal == PI_SUCCESS && alignment != 0)
+    assert(reinterpret_cast<std::uintptr_t>(*result_ptr) % alignment == 0 &&
+           "allocation not aligned correctly");
 
   return RetVal;
 }


### PR DESCRIPTION
There are several reasons `sycl::aligned_alloc_host` might fail, for example if there is not enough memory. The present assertion seems to want to ensure that if the alignment is used that the memory is, ultimately, properly aligned. But it is too open and could instead assert if an alignment was specified and any failure occurred (even one not associated with alignment).  This fix tightens that. 

Signed-off-by: Chris Perkins <chris.perkins@intel.com>