### PR TITLE
[ESIMD] Fix leakage of detail namespace

### DIFF
--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_math.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_math.hpp
@@ -113,7 +113,8 @@ ESIMD_NODEBUG ESIMD_INLINE
                                            std::is_integral<U>::value,
                                        simd<T0, SZ>>
     esimd_shl(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
-  typedef typename computation_type<decltype(src0), U>::type ComputationTy;
+  typedef
+      typename detail::computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
 
@@ -151,7 +152,7 @@ ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
         std::is_integral<T1>::value && std::is_integral<T2>::value,
     typename sycl::detail::remove_const_t<T0>>
 esimd_shl(T1 src0, T2 src1, int flag = GENX_NOSAT) {
-  typedef typename computation_type<T1, T2>::type ComputationTy;
+  typedef typename detail::computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   simd<T0, 1> Result = esimd_shl<T0>(Src0, Src1, flag);
@@ -166,7 +167,8 @@ ESIMD_NODEBUG ESIMD_INLINE
                                            std::is_integral<U>::value,
                                        simd<T0, SZ>>
     esimd_shr(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
-  typedef typename computation_type<decltype(src0), U>::type ComputationTy;
+  typedef
+      typename detail::computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   typename detail::simd_type<ComputationTy>::type Result =
@@ -185,7 +187,7 @@ ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
         std::is_integral<T1>::value && std::is_integral<T2>::value,
     typename sycl::detail::remove_const_t<T0>>
 esimd_shr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
-  typedef typename computation_type<T1, T2>::type ComputationTy;
+  typedef typename detail::computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   simd<T0, 1> Result = esimd_shr<T0>(Src0, Src1, flag);
@@ -207,7 +209,8 @@ ESIMD_NODEBUG ESIMD_INLINE
                                            std::is_integral<U>::value,
                                        simd<T0, SZ>>
     esimd_rol(simd<T1, SZ> src0, U src1) {
-  typedef typename computation_type<decltype(src0), U>::type ComputationTy;
+  typedef
+      typename detail::computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   return __esimd_rol<T0>(Src0.data(), Src1.data());
@@ -220,7 +223,7 @@ ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
         std::is_integral<T1>::value && std::is_integral<T2>::value,
     typename sycl::detail::remove_const_t<T0>>
 esimd_rol(T1 src0, T2 src1) {
-  typedef typename computation_type<T1, T2>::type ComputationTy;
+  typedef typename detail::computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   simd<T0, 1> Result = esimd_rol<T0>(Src0, Src1);
@@ -242,7 +245,8 @@ ESIMD_NODEBUG ESIMD_INLINE
                                            std::is_integral<U>::value,
                                        simd<T0, SZ>>
     esimd_ror(simd<T1, SZ> src0, U src1) {
-  typedef typename computation_type<decltype(src0), U>::type ComputationTy;
+  typedef
+      typename detail::computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   return __esimd_ror<T0>(Src0.data(), Src1.data());
@@ -255,7 +259,7 @@ ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
         std::is_integral<T1>::value && std::is_integral<T2>::value,
     typename sycl::detail::remove_const_t<T0>>
 esimd_ror(T1 src0, T2 src1) {
-  typedef typename computation_type<T1, T2>::type ComputationTy;
+  typedef typename detail::computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   simd<T0, 1> Result = esimd_ror<T0>(Src0, Src1);
@@ -270,7 +274,7 @@ ESIMD_NODEBUG ESIMD_INLINE
                                            std::is_integral<U>::value,
                                        simd<T0, SZ>>
     esimd_lsr(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
-  typedef typename computation_type<T1, T1>::type IntermedTy;
+  typedef typename detail::computation_type<T1, T1>::type IntermedTy;
   typedef typename std::make_unsigned<IntermedTy>::type ComputationTy;
   simd<ComputationTy, SZ> Src0 = src0;
   simd<ComputationTy, SZ> Result = Src0.data() >> src1.data();
@@ -288,7 +292,7 @@ ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
         std::is_integral<T1>::value && std::is_integral<T2>::value,
     typename sycl::detail::remove_const_t<T0>>
 esimd_lsr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
-  typedef typename computation_type<T1, T2>::type ComputationTy;
+  typedef typename detail::computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   simd<T0, 1> Result = esimd_lsr<T0>(Src0, Src1, flag);
@@ -313,7 +317,7 @@ ESIMD_NODEBUG ESIMD_INLINE
                                            std::is_integral<U>::value,
                                        simd<T0, SZ>>
     esimd_asr(simd<T1, SZ> src0, U src1, int flag = GENX_NOSAT) {
-  typedef typename computation_type<T1, T1>::type IntermedTy;
+  typedef typename detail::computation_type<T1, T1>::type IntermedTy;
   typedef typename std::make_signed<IntermedTy>::type ComputationTy;
   simd<ComputationTy, SZ> Src0 = src0;
   simd<ComputationTy, SZ> Result = Src0 >> src1;
@@ -331,7 +335,7 @@ ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
         std::is_integral<T1>::value && std::is_integral<T2>::value,
     typename sycl::detail::remove_const_t<T0>>
 esimd_asr(T1 src0, T2 src1, int flag = GENX_NOSAT) {
-  typedef typename computation_type<T1, T2>::type ComputationTy;
+  typedef typename detail::computation_type<T1, T2>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   simd<T0, 1> Result = esimd_asr<T0>(Src0, Src1, flag);
@@ -358,7 +362,8 @@ ESIMD_NODEBUG ESIMD_INLINE
                                            detail::is_dword_type<U>::value,
                                        simd<T0, SZ>>
     esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
-  typedef typename computation_type<decltype(src0), U>::type ComputationTy;
+  typedef
+      typename detail::computation_type<decltype(src0), U>::type ComputationTy;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
   rmd = Src0 * Src1;
@@ -378,8 +383,8 @@ ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
         detail::is_dword_type<U>::value && SZ == 1,
     simd<T0, SZ>>
 esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
-  typedef
-      typename computation_type<decltype(rmd), long long>::type ComputationTy;
+  typedef typename detail::computation_type<decltype(rmd), long long>::type
+      ComputationTy;
   ComputationTy Product = convert<long long>(src0);
   Product *= src1;
   rmd = Product.format<T0>().select<1, 1>[0];
@@ -392,8 +397,8 @@ ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
         detail::is_dword_type<U>::value && SZ != 1,
     simd<T0, SZ>>
 esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
-  typedef
-      typename computation_type<decltype(rmd), long long>::type ComputationTy;
+  typedef typename detail::computation_type<decltype(rmd), long long>::type
+      ComputationTy;
   ComputationTy Product = convert<long long>(src0);
   Product *= src1;
   rmd = Product.format<T0>().select<SZ, 2>(0);
@@ -1964,11 +1969,11 @@ ESIMD_INLINE ESIMD_NODEBUG T0 hmin(simd<T1, SZ> v) {
 
 template <typename T0, typename T1, int SZ, typename BinaryOperation>
 ESIMD_INLINE ESIMD_NODEBUG T0 reduce(simd<T1, SZ> v, BinaryOperation op) {
-  if constexpr (std::is_same<remove_cvref_t<BinaryOperation>,
+  if constexpr (std::is_same<detail::remove_cvref_t<BinaryOperation>,
                              std::plus<>>::value) {
     T0 retv = detail::esimd_sum<T0>(v);
     return retv;
-  } else if constexpr (std::is_same<remove_cvref_t<BinaryOperation>,
+  } else if constexpr (std::is_same<detail::remove_cvref_t<BinaryOperation>,
                                     std::multiplies<>>::value) {
     T0 retv = detail::esimd_prod<T0>(v);
     return retv;

--- a/sycl/test/esimd/intrins_trans.cpp
+++ b/sycl/test/esimd/intrins_trans.cpp
@@ -11,7 +11,7 @@
 
 using namespace sycl::INTEL::gpu;
 
-ESIMD_PRIVATE vector_type_t<int, 32> vc;
+ESIMD_PRIVATE sycl::INTEL::gpu::detail::vector_type_t<int, 32> vc;
 ESIMD_PRIVATE ESIMD_REGISTER(192) simd<int, 16> vg;
 
 SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo();
@@ -109,7 +109,8 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
   // CHECK: %[[SI2:[0-9a-zA-Z_.]+]] = ptrtoint %opencl.image2d_wo_t addrspace(1)* %{{[0-9a-zA-Z_.]+}} to i32
   // CHECK: call void @llvm.genx.media.st.v32i32(i32 0, i32 %[[SI2]], i32 0, i32 32, i32 %{{[0-9a-zA-Z_.]+}}, i32 %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}})
 
-  auto ee = __esimd_vload<int, 16>((vector_type_t<int, 16> *)(&vg));
+  auto ee = __esimd_vload<int, 16>(
+      (sycl::INTEL::gpu::detail::vector_type_t<int, 16> *)(&vg));
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x i32> @llvm.genx.vload.v16i32.p0v16i32(<16 x i32>* {{.*}})
   __esimd_vstore<int, 32>(&vc, va.data());
   // CHECK: store <32 x i32>  %{{[0-9a-zA-Z_.]+}}, <32 x i32> addrspace(4)* {{.*}}


### PR DESCRIPTION
This patch removes `using namespace sycl::INTEL::gpu::detail;` from `esimd.hpp` header file, which leaks names into the global namespace.