### PR TITLE
Fix warning on build with clang based compiler

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4624,7 +4624,7 @@ static std::string EmitSpecIdShim(raw_ostream &OS, unsigned &ShimCounter,
   PrintNSClosingBraces(OS, Decl::castToDeclContext(AnonNS));
 
   ++ShimCounter;
-  return std::move(NewShimName);
+  return NewShimName;
 }
 
 // Emit the list of shims required for a DeclContext, calls itself recursively.
@@ -4670,7 +4670,7 @@ static std::string EmitSpecIdShims(raw_ostream &OS, unsigned &ShimCounter,
          "Function assumes this is in an anonymous namespace");
   std::string RelativeName = VD->getNameAsString();
   EmitSpecIdShims(OS, ShimCounter, VD->getDeclContext(), RelativeName);
-  return std::move(RelativeName);
+  return RelativeName;
 }
 
 bool SYCLIntegrationFooter::emit(raw_ostream &OS) {


### PR DESCRIPTION
.../llvm/clang/lib/Sema/SemaSYCL.cpp(4662,10):
error: moving a local object in a return statement prevents copy elision
[-Werror,-Wpessimizing-move]
  return std::move(NewShimName);
         ^
.../llvm/clang/lib/Sema/SemaSYCL.cpp(4662,10):
note: remove std::move call here
  return std::move(NewShimName);
         ^~~~~~~~~~           ~

Signed-off-by: Pavel V Chupin <pavel.v.chupin@intel.com>