### PR TITLE
[SYCL][ESIMD] Move ESIMD APIs to sycl::ext::intel::experimental::esimd.

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -1243,7 +1243,9 @@ SmallPtrSet<Type *, 4> collectGenXVolatileTypes(Module &M) {
     if (!PTy)
       continue;
     auto GTy = dyn_cast<StructType>(PTy->getPointerElementType());
-    if (!GTy || !GTy->getName().endswith("cl::sycl::INTEL::gpu::simd"))
+    // TODO FIXME relying on type name in LLVM IR is fragile, needs rework
+    if (!GTy || !GTy->getName().endswith(
+                    "cl::sycl::ext::intel::experimental::esimd::simd"))
       continue;
     assert(GTy->getNumContainedTypes() == 1);
     auto VTy = GTy->getContainedType(0);
@@ -1326,7 +1328,8 @@ size_t SYCLLowerESIMDPass::runOnFunction(Function &F,
 
       // process ESIMD builtins that go through special handling instead of
       // the translation procedure
-      if (Name.startswith("N2cl4sycl5INTEL3gpu8slm_init")) {
+      // TODO FIXME slm_init should be made top-level __esimd_slm_init
+      if (Name.startswith("N2cl4sycl3ext5intel12experimental5esimd8slm_init")) {
         // tag the kernel with meta-data SLMSize, and remove this builtin
         translateSLMInit(*CI);
         ESIMDToErases.push_back(CI);

--- a/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
@@ -167,7 +167,7 @@ define dso_local spir_func void  @FUNC_29() {
 
 define dso_local spir_kernel void  @FUNC_30() {
 ; CHECK: define dso_local spir_kernel void  @FUNC_30()
-  call spir_func void @_ZN2cl4sycl5INTEL3gpu8slm_initEj(i32 1023)
+  call spir_func void @_ZN2cl4sycl3ext5intel12experimental5esimd8slm_initEj(i32 1023)
   ret void
 ; CHECK-NEXT: ret void
 }
@@ -358,7 +358,7 @@ declare dso_local spir_func <32 x i32> @_Z24__esimd_media_block_loadIiLi4ELi8E14
 declare dso_local spir_func void @_Z25__esimd_media_block_storeIiLi4ELi8E14ocl_image2d_woEvjT2_jjjjN2cm3gen13__vector_typeIT_XmlT0_T1_EE4typeE(i32 %0, %opencl.image2d_wo_t addrspace(1)* %1, i32 %2, i32 %3, i32 %4, i32 %5, <32 x i32> %6)
 declare dso_local spir_func <32 x i32> @_Z13__esimd_vloadIiLi32EEN2cm3gen13__vector_typeIT_XT0_EE4typeEPKS5_(<32 x i32> addrspace(4)* %0)
 declare dso_local spir_func void @_Z14__esimd_vstoreIfLi16EEvPN2cm3gen13__vector_typeIT_XT0_EE4typeES5_(<16 x float> addrspace(4)* %0, <16 x float> %1)
-declare dso_local spir_func void @_ZN2cl4sycl5INTEL3gpu8slm_initEj(i32)
+declare dso_local spir_func void @_ZN2cl4sycl3ext5intel12experimental5esimd8slm_initEj(i32)
 declare dso_local spir_func <16 x i32> @_Z14__esimd_uudp4aIjjjjLi16EEN2cl4sycl5INTEL3gpu11vector_typeIT_XT3_EE4typeENS4_IT0_XT3_EE4typeENS4_IT1_XT3_EE4typeENS4_IT2_XT3_EE4typeE(<16 x i32> %0, <16 x i32> %1, <16 x i32> %2)
 declare dso_local spir_func <16 x i32> @_Z14__esimd_usdp4aIjiiiLi16EEN2cl4sycl5INTEL3gpu11vector_typeIT_XT3_EE4typeENS4_IT0_XT3_EE4typeENS4_IT1_XT3_EE4typeENS4_IT2_XT3_EE4typeE(<16 x i32> %0, <16 x i32> %1, <16 x i32> %2)
 declare dso_local spir_func <16 x i32> @_Z14__esimd_sudp4aIijjjLi16EEN2cl4sycl5INTEL3gpu11vector_typeIT_XT3_EE4typeENS4_IT0_XT3_EE4typeENS4_IT1_XT3_EE4typeENS4_IT2_XT3_EE4typeE(<16 x i32> %0, <16 x i32> %1, <16 x i32> %2)

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_host_util.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_host_util.hpp
@@ -16,15 +16,20 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-
 namespace detail {
 namespace half_impl {
 class half;
 } // namespace half_impl
 } // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
-namespace INTEL {
-namespace gpu {
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 namespace emu {
 namespace detail {
 
@@ -466,8 +471,10 @@ template <> struct dwordtype<unsigned int> { static const bool value = true; };
 
 } // namespace detail
 } // namespace emu
-} // namespace gpu
-} // namespace INTEL
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
 

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_intrin.hpp
@@ -18,7 +18,8 @@
 #include <assert.h>
 #include <cstdint>
 
-#define __SIGD sycl::INTEL::gpu::detail
+#define __SEIEED sycl::ext::intel::experimental::esimd::detail
+#define __SEIEE sycl::ext::intel::experimental::esimd
 
 // \brief __esimd_rdregion: region access intrinsic.
 //
@@ -64,13 +65,13 @@
 //
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth = 0>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, M>
-__esimd_rdregion(__SIGD::vector_type_t<T, N> Input, uint16_t Offset);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, M>
+__esimd_rdregion(__SEIEED::vector_type_t<T, N> Input, uint16_t Offset);
 
 template <typename T, int N, int M, int ParentWidth = 0>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, M>
-__esimd_rdindirect(__SIGD::vector_type_t<T, N> Input,
-                   __SIGD::vector_type_t<uint16_t, M> Offset);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, M>
+__esimd_rdindirect(__SEIEED::vector_type_t<T, N> Input,
+                   __SEIEED::vector_type_t<uint16_t, M> Offset);
 
 // __esimd_wrregion returns the updated vector with the region updated.
 //
@@ -121,28 +122,30 @@ __esimd_rdindirect(__SIGD::vector_type_t<T, N> Input,
 //
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth = 0>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, N>
-__esimd_wrregion(__SIGD::vector_type_t<T, N> OldVal,
-                 __SIGD::vector_type_t<T, M> NewVal, uint16_t Offset,
-                 sycl::INTEL::gpu::mask_type_t<M> Mask = 1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, N>
+__esimd_wrregion(__SEIEED::vector_type_t<T, N> OldVal,
+                 __SEIEED::vector_type_t<T, M> NewVal, uint16_t Offset,
+                 __SEIEE::mask_type_t<M> Mask = 1);
 
 template <typename T, int N, int M, int ParentWidth = 0>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, N>
-__esimd_wrindirect(__SIGD::vector_type_t<T, N> OldVal,
-                   __SIGD::vector_type_t<T, M> NewVal,
-                   __SIGD::vector_type_t<uint16_t, M> Offset,
-                   sycl::INTEL::gpu::mask_type_t<M> Mask = 1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, N>
+__esimd_wrindirect(__SEIEED::vector_type_t<T, N> OldVal,
+                   __SEIEED::vector_type_t<T, M> NewVal,
+                   __SEIEED::vector_type_t<uint16_t, M> Offset,
+                   __SEIEE::mask_type_t<M> Mask = 1);
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 namespace detail {
 
 /// read from a basic region of a vector, return a vector
 template <typename BT, int BN, typename RTy>
-__SIGD::vector_type_t<typename RTy::element_type, RTy::length> ESIMD_INLINE
-readRegion(const __SIGD::vector_type_t<BT, BN> &Base, RTy Region) {
+__SEIEED::vector_type_t<typename RTy::element_type, RTy::length> ESIMD_INLINE
+readRegion(const __SEIEED::vector_type_t<BT, BN> &Base, RTy Region) {
   using ElemTy = typename RTy::element_type;
   auto Base1 = bitcast<ElemTy, BT, BN>(Base);
   constexpr int Bytes = BN * sizeof(BT);
@@ -163,8 +166,9 @@ readRegion(const __SIGD::vector_type_t<BT, BN> &Base, RTy Region) {
 
 /// read from a nested region of a vector, return a vector
 template <typename BT, int BN, typename T, typename U>
-ESIMD_INLINE __SIGD::vector_type_t<typename T::element_type, T::length>
-readRegion(const __SIGD::vector_type_t<BT, BN> &Base, std::pair<T, U> Region) {
+ESIMD_INLINE __SEIEED::vector_type_t<typename T::element_type, T::length>
+readRegion(const __SEIEED::vector_type_t<BT, BN> &Base,
+           std::pair<T, U> Region) {
   // parent-region type
   using PaTy = typename shape_type<U>::type;
   constexpr int BN1 = PaTy::length;
@@ -206,8 +210,11 @@ readRegion(const __SIGD::vector_type_t<BT, BN> &Base, std::pair<T, U> Region) {
 }
 
 } // namespace detail
-} // namespace gpu
-} // namespace INTEL
+
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
 
@@ -217,8 +224,8 @@ readRegion(const __SIGD::vector_type_t<BT, BN> &Base, std::pair<T, U> Region) {
 // optimization on simd object
 //
 template <typename T, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, N>
-__esimd_vload(const __SIGD::vector_type_t<T, N> *ptr);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, N>
+__esimd_vload(const __SEIEED::vector_type_t<T, N> *ptr);
 
 // vstore
 //
@@ -226,31 +233,31 @@ __esimd_vload(const __SIGD::vector_type_t<T, N> *ptr);
 // optimization on simd object
 template <typename T, int N>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
-__esimd_vstore(__SIGD::vector_type_t<T, N> *ptr,
-               __SIGD::vector_type_t<T, N> vals);
+__esimd_vstore(__SEIEED::vector_type_t<T, N> *ptr,
+               __SEIEED::vector_type_t<T, N> vals);
 
 template <typename T, int N>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION uint16_t
-__esimd_any(__SIGD::vector_type_t<T, N> src);
+__esimd_any(__SEIEED::vector_type_t<T, N> src);
 
 template <typename T, int N>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION uint16_t
-__esimd_all(__SIGD::vector_type_t<T, N> src);
+__esimd_all(__SEIEED::vector_type_t<T, N> src);
 
 #ifndef __SYCL_DEVICE_ONLY__
 
 // Implementations of ESIMD intrinsics for the SYCL host device
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, M>
-__esimd_rdregion(__SIGD::vector_type_t<T, N> Input, uint16_t Offset) {
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, M>
+__esimd_rdregion(__SEIEED::vector_type_t<T, N> Input, uint16_t Offset) {
   uint16_t EltOffset = Offset / sizeof(T);
   assert(Offset % sizeof(T) == 0);
 
   int NumRows = M / Width;
   assert(M % Width == 0);
 
-  __SIGD::vector_type_t<T, M> Result;
+  __SEIEED::vector_type_t<T, M> Result;
   int Index = 0;
   for (int i = 0; i < NumRows; ++i) {
     for (int j = 0; j < Width; ++j) {
@@ -261,10 +268,10 @@ __esimd_rdregion(__SIGD::vector_type_t<T, N> Input, uint16_t Offset) {
 }
 
 template <typename T, int N, int M, int ParentWidth>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, M>
-__esimd_rdindirect(__SIGD::vector_type_t<T, N> Input,
-                   __SIGD::vector_type_t<uint16_t, M> Offset) {
-  __SIGD::vector_type_t<T, M> Result;
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, M>
+__esimd_rdindirect(__SEIEED::vector_type_t<T, N> Input,
+                   __SEIEED::vector_type_t<uint16_t, M> Offset) {
+  __SEIEED::vector_type_t<T, M> Result;
   for (int i = 0; i < M; ++i) {
     uint16_t EltOffset = Offset[i] / sizeof(T);
     assert(Offset[i] % sizeof(T) == 0);
@@ -276,17 +283,17 @@ __esimd_rdindirect(__SIGD::vector_type_t<T, N> Input,
 
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, N>
-__esimd_wrregion(__SIGD::vector_type_t<T, N> OldVal,
-                 __SIGD::vector_type_t<T, M> NewVal, uint16_t Offset,
-                 sycl::INTEL::gpu::mask_type_t<M> Mask) {
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, N>
+__esimd_wrregion(__SEIEED::vector_type_t<T, N> OldVal,
+                 __SEIEED::vector_type_t<T, M> NewVal, uint16_t Offset,
+                 __SEIEE::mask_type_t<M> Mask) {
   uint16_t EltOffset = Offset / sizeof(T);
   assert(Offset % sizeof(T) == 0);
 
   int NumRows = M / Width;
   assert(M % Width == 0);
 
-  __SIGD::vector_type_t<T, N> Result = OldVal;
+  __SEIEED::vector_type_t<T, N> Result = OldVal;
   int Index = 0;
   for (int i = 0; i < NumRows; ++i) {
     for (int j = 0; j < Width; ++j) {
@@ -299,12 +306,12 @@ __esimd_wrregion(__SIGD::vector_type_t<T, N> OldVal,
 }
 
 template <typename T, int N, int M, int ParentWidth>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, N>
-__esimd_wrindirect(__SIGD::vector_type_t<T, N> OldVal,
-                   __SIGD::vector_type_t<T, M> NewVal,
-                   __SIGD::vector_type_t<uint16_t, M> Offset,
-                   sycl::INTEL::gpu::mask_type_t<M> Mask) {
-  __SIGD::vector_type_t<T, N> Result = OldVal;
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, N>
+__esimd_wrindirect(__SEIEED::vector_type_t<T, N> OldVal,
+                   __SEIEED::vector_type_t<T, M> NewVal,
+                   __SEIEED::vector_type_t<uint16_t, M> Offset,
+                   __SEIEE::mask_type_t<M> Mask) {
+  __SEIEED::vector_type_t<T, N> Result = OldVal;
   for (int i = 0; i < M; ++i) {
     if (Mask[i]) {
       uint16_t EltOffset = Offset[i] / sizeof(T);
@@ -318,4 +325,5 @@ __esimd_wrindirect(__SIGD::vector_type_t<T, N> OldVal,
 
 #endif // __SYCL_DEVICE_ONLY__
 
-#undef __SIGD
+#undef __SEIEE
+#undef __SEIEED

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
@@ -1170,7 +1170,7 @@ inline __SEIEED::vector_type_t<T1, N>
 __esimd_dp4a(__SEIEED::vector_type_t<T2, N> src0,
              __SEIEED::vector_type_t<T3, N> src1,
              __SEIEED::vector_type_t<T4, N> src2) {
-  using __SEIEE::emu::detail::restype_ex;
+  using __SEIEEED::restype_ex;
   typename restype_ex<T2, typename restype_ex<T3, T4>::type>::type reta;
   __SEIEED::vector_type_t<T1, N> retv;
 

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_math_intrin.hpp
@@ -16,303 +16,304 @@
 #include <CL/sycl/INTEL/esimd/esimd_enum.hpp>
 #include <cstdint>
 
-#define __SIGD sycl::INTEL::gpu::detail
+#define __SEIEED sycl::ext::intel::experimental::esimd::detail
 
 // saturation intrinsics
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_satf(__SIGD::vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_satf(__SEIEED::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_fptoui_sat(__SIGD::vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_fptoui_sat(__SEIEED::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_fptosi_sat(__SIGD::vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_fptosi_sat(__SEIEED::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_uutrunc_sat(__SIGD::vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_uutrunc_sat(__SEIEED::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_ustrunc_sat(__SIGD::vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_ustrunc_sat(__SEIEED::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_sutrunc_sat(__SIGD::vector_type_t<T1, SZ> src);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_sutrunc_sat(__SEIEED::vector_type_t<T1, SZ> src);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_sstrunc_sat(__SIGD::vector_type_t<T1, SZ> src);
-
-template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_abs(__SIGD::vector_type_t<T, SZ> src0);
-
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_ssshl(__SIGD::vector_type_t<T1, SZ> src0,
-              __SIGD::vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_sushl(__SIGD::vector_type_t<T1, SZ> src0,
-              __SIGD::vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_usshl(__SIGD::vector_type_t<T1, SZ> src0,
-              __SIGD::vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_uushl(__SIGD::vector_type_t<T1, SZ> src0,
-              __SIGD::vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_ssshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
-                  __SIGD::vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_sushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
-                  __SIGD::vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_usshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
-                  __SIGD::vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_uushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
-                  __SIGD::vector_type_t<T1, SZ> src1);
-
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_rol(__SIGD::vector_type_t<T1, SZ> src0,
-            __SIGD::vector_type_t<T1, SZ> src1);
-template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_ror(__SIGD::vector_type_t<T1, SZ> src0,
-            __SIGD::vector_type_t<T1, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_sstrunc_sat(__SEIEED::vector_type_t<T1, SZ> src);
 
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_umulh(__SIGD::vector_type_t<T, SZ> src0,
-              __SIGD::vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_abs(__SEIEED::vector_type_t<T, SZ> src0);
+
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_ssshl(__SEIEED::vector_type_t<T1, SZ> src0,
+              __SEIEED::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_sushl(__SEIEED::vector_type_t<T1, SZ> src0,
+              __SEIEED::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_usshl(__SEIEED::vector_type_t<T1, SZ> src0,
+              __SEIEED::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_uushl(__SEIEED::vector_type_t<T1, SZ> src0,
+              __SEIEED::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_ssshl_sat(__SEIEED::vector_type_t<T1, SZ> src0,
+                  __SEIEED::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_sushl_sat(__SEIEED::vector_type_t<T1, SZ> src0,
+                  __SEIEED::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_usshl_sat(__SEIEED::vector_type_t<T1, SZ> src0,
+                  __SEIEED::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_uushl_sat(__SEIEED::vector_type_t<T1, SZ> src0,
+                  __SEIEED::vector_type_t<T1, SZ> src1);
+
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_rol(__SEIEED::vector_type_t<T1, SZ> src0,
+            __SEIEED::vector_type_t<T1, SZ> src1);
+template <typename T0, typename T1, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_ror(__SEIEED::vector_type_t<T1, SZ> src0,
+            __SEIEED::vector_type_t<T1, SZ> src1);
+
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_smulh(__SIGD::vector_type_t<T, SZ> src0,
-              __SIGD::vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_umulh(__SEIEED::vector_type_t<T, SZ> src0,
+              __SEIEED::vector_type_t<T, SZ> src1);
+template <typename T, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_smulh(__SEIEED::vector_type_t<T, SZ> src0,
+              __SEIEED::vector_type_t<T, SZ> src1);
 
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_frc(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_frc(__SEIEED::vector_type_t<float, SZ> src0);
 
 /// 3 kinds of max
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_fmax(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_fmax(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1);
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_umax(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_umax(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1);
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_smax(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_smax(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1);
 
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_lzd(__SIGD::vector_type_t<T, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_lzd(__SEIEED::vector_type_t<T, SZ> src0);
 
 /// 3 kinds of min
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_fmin(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_fmin(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1);
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_umin(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_umin(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1);
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T, SZ>
-__esimd_smin(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T, SZ>
+__esimd_smin(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1);
 
 template <typename T0, typename T1, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_bfrev(__SIGD::vector_type_t<T1, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_bfrev(__SEIEED::vector_type_t<T1, SZ> src0);
 
 template <typename T, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<unsigned int, SZ>
-__esimd_cbit(__SIGD::vector_type_t<T, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<unsigned int, SZ>
+__esimd_cbit(__SEIEED::vector_type_t<T, SZ> src0);
 
 template <typename T0, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ> __esimd_bfins(
-    __SIGD::vector_type_t<T0, SZ> src0, __SIGD::vector_type_t<T0, SZ> src1,
-    __SIGD::vector_type_t<T0, SZ> src2, __SIGD::vector_type_t<T0, SZ> src3);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ> __esimd_bfins(
+    __SEIEED::vector_type_t<T0, SZ> src0, __SEIEED::vector_type_t<T0, SZ> src1,
+    __SEIEED::vector_type_t<T0, SZ> src2, __SEIEED::vector_type_t<T0, SZ> src3);
 
 template <typename T0, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T0, SZ>
-__esimd_bfext(__SIGD::vector_type_t<T0, SZ> src0,
-              __SIGD::vector_type_t<T0, SZ> src1,
-              __SIGD::vector_type_t<T0, SZ> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T0, SZ>
+__esimd_bfext(__SEIEED::vector_type_t<T0, SZ> src0,
+              __SEIEED::vector_type_t<T0, SZ> src1,
+              __SEIEED::vector_type_t<T0, SZ> src2);
 
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<uint32_t, SZ>
-__esimd_fbl(__SIGD::vector_type_t<uint32_t, SZ> src0);
-
-template <typename T0, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<int, SZ>
-__esimd_sfbh(__SIGD::vector_type_t<T0, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<uint32_t, SZ>
+__esimd_fbl(__SEIEED::vector_type_t<uint32_t, SZ> src0);
 
 template <typename T0, int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<uint32_t, SZ>
-__esimd_ufbh(__SIGD::vector_type_t<T0, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<int, SZ>
+__esimd_sfbh(__SEIEED::vector_type_t<T0, SZ> src0);
+
+template <typename T0, int SZ>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<uint32_t, SZ>
+__esimd_ufbh(__SEIEED::vector_type_t<T0, SZ> src0);
 
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_inv(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_inv(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_log(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_log(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_exp(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_exp(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_sqrt(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_sqrt(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_sqrt_ieee(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_sqrt_ieee(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_rsqrt(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_rsqrt(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_sin(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_sin(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_cos(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_cos(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_pow(__SIGD::vector_type_t<float, SZ> src0,
-            __SIGD::vector_type_t<float, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_pow(__SEIEED::vector_type_t<float, SZ> src0,
+            __SEIEED::vector_type_t<float, SZ> src1);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_div_ieee(__SIGD::vector_type_t<float, SZ> src0,
-                 __SIGD::vector_type_t<float, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_div_ieee(__SEIEED::vector_type_t<float, SZ> src0,
+                 __SEIEED::vector_type_t<float, SZ> src1);
 
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_rndd(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_rndd(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_rndu(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_rndu(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_rnde(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_rnde(__SEIEED::vector_type_t<float, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<float, SZ>
-__esimd_rndz(__SIGD::vector_type_t<float, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<float, SZ>
+__esimd_rndz(__SEIEED::vector_type_t<float, SZ> src0);
 
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<double, SZ>
-__esimd_sqrt_ieee(__SIGD::vector_type_t<double, SZ> src0);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<double, SZ>
+__esimd_sqrt_ieee(__SEIEED::vector_type_t<double, SZ> src0);
 template <int SZ>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<double, SZ>
-__esimd_div_ieee(__SIGD::vector_type_t<double, SZ> src0,
-                 __SIGD::vector_type_t<double, SZ> src1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<double, SZ>
+__esimd_div_ieee(__SEIEED::vector_type_t<double, SZ> src0,
+                 __SEIEED::vector_type_t<double, SZ> src1);
 
 template <int N>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION uint32_t
-__esimd_pack_mask(__SIGD::vector_type_t<uint16_t, N> src0);
+__esimd_pack_mask(__SEIEED::vector_type_t<uint16_t, N> src0);
 
 template <int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<uint16_t, N>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<uint16_t, N>
 __esimd_unpack_mask(uint32_t src0);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T1, N>
-__esimd_uudp4a(__SIGD::vector_type_t<T2, N> src0,
-               __SIGD::vector_type_t<T3, N> src1,
-               __SIGD::vector_type_t<T4, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T1, N>
+__esimd_uudp4a(__SEIEED::vector_type_t<T2, N> src0,
+               __SEIEED::vector_type_t<T3, N> src1,
+               __SEIEED::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T1, N>
-__esimd_usdp4a(__SIGD::vector_type_t<T2, N> src0,
-               __SIGD::vector_type_t<T3, N> src1,
-               __SIGD::vector_type_t<T4, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T1, N>
+__esimd_usdp4a(__SEIEED::vector_type_t<T2, N> src0,
+               __SEIEED::vector_type_t<T3, N> src1,
+               __SEIEED::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T1, N>
-__esimd_sudp4a(__SIGD::vector_type_t<T2, N> src0,
-               __SIGD::vector_type_t<T3, N> src1,
-               __SIGD::vector_type_t<T4, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T1, N>
+__esimd_sudp4a(__SEIEED::vector_type_t<T2, N> src0,
+               __SEIEED::vector_type_t<T3, N> src1,
+               __SEIEED::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T1, N>
-__esimd_ssdp4a(__SIGD::vector_type_t<T2, N> src0,
-               __SIGD::vector_type_t<T3, N> src1,
-               __SIGD::vector_type_t<T4, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T1, N>
+__esimd_ssdp4a(__SEIEED::vector_type_t<T2, N> src0,
+               __SEIEED::vector_type_t<T3, N> src1,
+               __SEIEED::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T1, N>
-__esimd_uudp4a_sat(__SIGD::vector_type_t<T2, N> src0,
-                   __SIGD::vector_type_t<T3, N> src1,
-                   __SIGD::vector_type_t<T4, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T1, N>
+__esimd_uudp4a_sat(__SEIEED::vector_type_t<T2, N> src0,
+                   __SEIEED::vector_type_t<T3, N> src1,
+                   __SEIEED::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T1, N>
-__esimd_usdp4a_sat(__SIGD::vector_type_t<T2, N> src0,
-                   __SIGD::vector_type_t<T3, N> src1,
-                   __SIGD::vector_type_t<T4, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T1, N>
+__esimd_usdp4a_sat(__SEIEED::vector_type_t<T2, N> src0,
+                   __SEIEED::vector_type_t<T3, N> src1,
+                   __SEIEED::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T1, N>
-__esimd_sudp4a_sat(__SIGD::vector_type_t<T2, N> src0,
-                   __SIGD::vector_type_t<T3, N> src1,
-                   __SIGD::vector_type_t<T4, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T1, N>
+__esimd_sudp4a_sat(__SEIEED::vector_type_t<T2, N> src0,
+                   __SEIEED::vector_type_t<T3, N> src1,
+                   __SEIEED::vector_type_t<T4, N> src2);
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<T1, N>
-__esimd_ssdp4a_sat(__SIGD::vector_type_t<T2, N> src0,
-                   __SIGD::vector_type_t<T3, N> src1,
-                   __SIGD::vector_type_t<T4, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<T1, N>
+__esimd_ssdp4a_sat(__SEIEED::vector_type_t<T2, N> src0,
+                   __SEIEED::vector_type_t<T3, N> src1,
+                   __SEIEED::vector_type_t<T4, N> src2);
 
 // Reduction functions
 template <typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_fmax(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_fmax(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_umax(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_umax(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_smax(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_smax(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_fmin(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_fmin(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_umin(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_umin(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-__SIGD::vector_type_t<Ty, N> SYCL_EXTERNAL SYCL_ESIMD_FUNCTION
-__esimd_reduced_smin(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2);
+__SEIEED::vector_type_t<Ty, N> SYCL_EXTERNAL SYCL_ESIMD_FUNCTION
+__esimd_reduced_smin(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2);
 
 template <typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_dp4(__SIGD::vector_type_t<Ty, N> v1, __SIGD::vector_type_t<Ty, N> v2);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_dp4(__SEIEED::vector_type_t<Ty, N> v1,
+            __SEIEED::vector_type_t<Ty, N> v2);
 
 #ifndef __SYCL_DEVICE_ONLY__
 
@@ -331,91 +332,91 @@ inline T extract(const uint32_t &width, const uint32_t &offset, uint32_t src,
   return ret;
 }
 
-#define __SIGED sycl::INTEL::gpu::emu::detail
+#define __SEIEEED sycl::ext::intel::experimental::esimd::emu::detail
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_satf(__SIGD::vector_type_t<T1, SZ> src) {
-  __SIGD::vector_type_t<T0, SZ> retv;
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_satf(__SEIEED::vector_type_t<T1, SZ> src) {
+  __SEIEED::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_fptoui_sat(__SIGD::vector_type_t<T1, SZ> src) {
-  __SIGD::vector_type_t<T0, SZ> retv;
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_fptoui_sat(__SEIEED::vector_type_t<T1, SZ> src) {
+  __SEIEED::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_fptosi_sat(__SIGD::vector_type_t<T1, SZ> src) {
-  __SIGD::vector_type_t<T0, SZ> retv;
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_fptosi_sat(__SEIEED::vector_type_t<T1, SZ> src) {
+  __SEIEED::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_uutrunc_sat(__SIGD::vector_type_t<T1, SZ> src) {
-  __SIGD::vector_type_t<T0, SZ> retv;
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_uutrunc_sat(__SEIEED::vector_type_t<T1, SZ> src) {
+  __SEIEED::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_ustrunc_sat(__SIGD::vector_type_t<T1, SZ> src) {
-  __SIGD::vector_type_t<T0, SZ> retv;
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_ustrunc_sat(__SEIEED::vector_type_t<T1, SZ> src) {
+  __SEIEED::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_sutrunc_sat(__SIGD::vector_type_t<T1, SZ> src) {
-  __SIGD::vector_type_t<T0, SZ> retv;
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_sutrunc_sat(__SEIEED::vector_type_t<T1, SZ> src) {
+  __SEIEED::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_sstrunc_sat(__SIGD::vector_type_t<T1, SZ> src) {
-  __SIGD::vector_type_t<T0, SZ> retv;
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_sstrunc_sat(__SEIEED::vector_type_t<T1, SZ> src) {
+  __SEIEED::vector_type_t<T0, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
-    retv[i] = __SIGED::satur<T0>::saturate(src[i], 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(src[i], 1);
   }
   return retv;
 };
 
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_abs(__SIGD::vector_type_t<T, SZ> src0) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_abs(__SEIEED::vector_type_t<T, SZ> src0) {
   int i;
-  typename __SIGED::abstype<T>::type ret;
-  __SIGD::vector_type_t<T, SZ> retv;
+  typename __SEIEEED::abstype<T>::type ret;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -430,12 +431,12 @@ __esimd_abs(__SIGD::vector_type_t<T, SZ> src0) {
 };
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_ssshl(__SIGD::vector_type_t<T1, SZ> src0,
-              __SIGD::vector_type_t<T1, SZ> src1) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_ssshl(__SEIEED::vector_type_t<T1, SZ> src0,
+              __SEIEED::vector_type_t<T1, SZ> src1) {
   int i;
-  typename __SIGED::maxtype<T1>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T1>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -445,12 +446,12 @@ __esimd_ssshl(__SIGD::vector_type_t<T1, SZ> src0,
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_sushl(__SIGD::vector_type_t<T1, SZ> src0,
-              __SIGD::vector_type_t<T1, SZ> src1) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_sushl(__SEIEED::vector_type_t<T1, SZ> src0,
+              __SEIEED::vector_type_t<T1, SZ> src1) {
   int i;
-  typename __SIGED::maxtype<T1>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T1>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -460,12 +461,12 @@ __esimd_sushl(__SIGD::vector_type_t<T1, SZ> src0,
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_usshl(__SIGD::vector_type_t<T1, SZ> src0,
-              __SIGD::vector_type_t<T1, SZ> src1) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_usshl(__SEIEED::vector_type_t<T1, SZ> src0,
+              __SEIEED::vector_type_t<T1, SZ> src1) {
   int i;
-  typename __SIGED::maxtype<T1>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T1>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -475,12 +476,12 @@ __esimd_usshl(__SIGD::vector_type_t<T1, SZ> src0,
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_uushl(__SIGD::vector_type_t<T1, SZ> src0,
-              __SIGD::vector_type_t<T1, SZ> src1) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_uushl(__SEIEED::vector_type_t<T1, SZ> src0,
+              __SEIEED::vector_type_t<T1, SZ> src1) {
   int i;
-  typename __SIGED::maxtype<T1>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T1>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -490,82 +491,82 @@ __esimd_uushl(__SIGD::vector_type_t<T1, SZ> src0,
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_ssshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
-                  __SIGD::vector_type_t<T1, SZ> src1) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_ssshl_sat(__SEIEED::vector_type_t<T1, SZ> src0,
+                  __SEIEED::vector_type_t<T1, SZ> src1) {
   int i;
-  typename __SIGED::maxtype<T1>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T1>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     ret = src0.get(i) << src1.get(i);
-    retv[i] = __SIGED::satur<T0>::saturate(ret, 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(ret, 1);
   }
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_sushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
-                  __SIGD::vector_type_t<T1, SZ> src1) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_sushl_sat(__SEIEED::vector_type_t<T1, SZ> src0,
+                  __SEIEED::vector_type_t<T1, SZ> src1) {
   int i;
-  typename __SIGED::maxtype<T1>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T1>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     ret = src0.get(i) << src1.get(i);
-    retv[i] = __SIGED::satur<T0>::saturate(ret, 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(ret, 1);
   }
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_usshl_sat(__SIGD::vector_type_t<T1, SZ> src0,
-                  __SIGD::vector_type_t<T1, SZ> src1) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_usshl_sat(__SEIEED::vector_type_t<T1, SZ> src0,
+                  __SEIEED::vector_type_t<T1, SZ> src1) {
   int i;
-  typename __SIGED::maxtype<T1>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T1>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     ret = src0.get(i) << src1.get(i);
-    retv[i] = __SIGED::satur<T0>::saturate(ret, 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(ret, 1);
   }
   return retv;
 };
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_uushl_sat(__SIGD::vector_type_t<T1, SZ> src0,
-                  __SIGD::vector_type_t<T1, SZ> src1) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_uushl_sat(__SEIEED::vector_type_t<T1, SZ> src0,
+                  __SEIEED::vector_type_t<T1, SZ> src1) {
   int i;
-  typename __SIGED::maxtype<T1>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T1>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     ret = src0.get(i) << src1.get(i);
-    retv[i] = __SIGED::satur<T0>::saturate(ret, 1);
+    retv[i] = __SEIEEED::satur<T0>::saturate(ret, 1);
   }
   return retv;
 };
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_rol(__SIGD::vector_type_t<T1, SZ> src0,
-            __SIGD::vector_type_t<T1, SZ> src1){};
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_rol(__SEIEED::vector_type_t<T1, SZ> src0,
+            __SEIEED::vector_type_t<T1, SZ> src1){};
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_ror(__SIGD::vector_type_t<T1, SZ> src0,
-            __SIGD::vector_type_t<T1, SZ> src1){};
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_ror(__SEIEED::vector_type_t<T1, SZ> src0,
+            __SEIEED::vector_type_t<T1, SZ> src1){};
 
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_umulh(__SIGD::vector_type_t<T, SZ> src0,
-              __SIGD::vector_type_t<T, SZ> src1) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_umulh(__SEIEED::vector_type_t<T, SZ> src0,
+              __SEIEED::vector_type_t<T, SZ> src1) {
   int i;
-  __SIGD::vector_type_t<T, SZ> retv;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     unsigned long long temp;
@@ -577,11 +578,11 @@ __esimd_umulh(__SIGD::vector_type_t<T, SZ> src0,
 }
 
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_smulh(__SIGD::vector_type_t<T, SZ> src0,
-              __SIGD::vector_type_t<T, SZ> src1) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_smulh(__SEIEED::vector_type_t<T, SZ> src0,
+              __SEIEED::vector_type_t<T, SZ> src1) {
   int i;
-  __SIGD::vector_type_t<T, SZ> retv;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     long long temp;
@@ -593,9 +594,9 @@ __esimd_smulh(__SIGD::vector_type_t<T, SZ> src0,
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_frc(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_frc(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     retv[i] = src0[i] - floor(src0[i]);
@@ -605,11 +606,11 @@ __esimd_frc(__SIGD::vector_type_t<float, SZ> src0) {
 
 /// 3 kinds of max
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_fmax(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_fmax(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1) {
   int i;
-  __SIGD::vector_type_t<T, SZ> retv;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -623,11 +624,11 @@ __esimd_fmax(__SIGD::vector_type_t<T, SZ> src0,
   return retv;
 };
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_umax(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_umax(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1) {
   int i;
-  __SIGD::vector_type_t<T, SZ> retv;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -641,11 +642,11 @@ __esimd_umax(__SIGD::vector_type_t<T, SZ> src0,
   return retv;
 };
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_smax(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_smax(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1) {
   int i;
-  __SIGD::vector_type_t<T, SZ> retv;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -660,11 +661,11 @@ __esimd_smax(__SIGD::vector_type_t<T, SZ> src0,
 };
 
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_lzd(__SIGD::vector_type_t<T, SZ> src0) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_lzd(__SEIEED::vector_type_t<T, SZ> src0) {
   int i;
   T ret;
-  __SIGD::vector_type_t<T, SZ> retv;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -682,11 +683,11 @@ __esimd_lzd(__SIGD::vector_type_t<T, SZ> src0) {
 
 /// 3 kinds of min
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_fmin(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_fmin(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1) {
   int i;
-  __SIGD::vector_type_t<T, SZ> retv;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -701,11 +702,11 @@ __esimd_fmin(__SIGD::vector_type_t<T, SZ> src0,
 };
 
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_umin(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_umin(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1) {
   int i;
-  __SIGD::vector_type_t<T, SZ> retv;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -720,11 +721,11 @@ __esimd_umin(__SIGD::vector_type_t<T, SZ> src0,
 };
 
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<T, SZ>
-__esimd_smin(__SIGD::vector_type_t<T, SZ> src0,
-             __SIGD::vector_type_t<T, SZ> src1) {
+inline __SEIEED::vector_type_t<T, SZ>
+__esimd_smin(__SEIEED::vector_type_t<T, SZ> src0,
+             __SEIEED::vector_type_t<T, SZ> src1) {
   int i;
-  __SIGD::vector_type_t<T, SZ> retv;
+  __SEIEED::vector_type_t<T, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -739,10 +740,10 @@ __esimd_smin(__SIGD::vector_type_t<T, SZ> src0,
 };
 
 template <typename T0, typename T1, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_bfrev(__SIGD::vector_type_t<T1, SZ> src0) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_bfrev(__SEIEED::vector_type_t<T1, SZ> src0) {
   int i, j;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -764,11 +765,11 @@ __esimd_bfrev(__SIGD::vector_type_t<T1, SZ> src0) {
 };
 
 template <typename T, int SZ>
-inline __SIGD::vector_type_t<unsigned int, SZ>
-__esimd_cbit(__SIGD::vector_type_t<T, SZ> src0) {
+inline __SEIEED::vector_type_t<unsigned int, SZ>
+__esimd_cbit(__SEIEED::vector_type_t<T, SZ> src0) {
   int i;
   uint32_t ret;
-  __SIGD::vector_type_t<uint32_t, SZ> retv;
+  __SEIEED::vector_type_t<uint32_t, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -787,12 +788,14 @@ __esimd_cbit(__SIGD::vector_type_t<T, SZ> src0) {
 };
 
 template <typename T0, int SZ>
-inline __SIGD::vector_type_t<T0, SZ> __esimd_bfins(
-    __SIGD::vector_type_t<T0, SZ> width, __SIGD::vector_type_t<T0, SZ> offset,
-    __SIGD::vector_type_t<T0, SZ> val, __SIGD::vector_type_t<T0, SZ> src) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_bfins(__SEIEED::vector_type_t<T0, SZ> width,
+              __SEIEED::vector_type_t<T0, SZ> offset,
+              __SEIEED::vector_type_t<T0, SZ> val,
+              __SEIEED::vector_type_t<T0, SZ> src) {
   int i;
-  typename __SIGED::maxtype<T0>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T0>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -811,13 +814,13 @@ inline __SIGD::vector_type_t<T0, SZ> __esimd_bfins(
 };
 
 template <typename T0, int SZ>
-inline __SIGD::vector_type_t<T0, SZ>
-__esimd_bfext(__SIGD::vector_type_t<T0, SZ> width,
-              __SIGD::vector_type_t<T0, SZ> offset,
-              __SIGD::vector_type_t<T0, SZ> src) {
+inline __SEIEED::vector_type_t<T0, SZ>
+__esimd_bfext(__SEIEED::vector_type_t<T0, SZ> width,
+              __SEIEED::vector_type_t<T0, SZ> offset,
+              __SEIEED::vector_type_t<T0, SZ> src) {
   int i;
-  typename __SIGED::maxtype<T0>::type ret;
-  __SIGD::vector_type_t<T0, SZ> retv;
+  typename __SEIEEED::maxtype<T0>::type ret;
+  __SEIEED::vector_type_t<T0, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -830,11 +833,11 @@ __esimd_bfext(__SIGD::vector_type_t<T0, SZ> width,
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<uint32_t, SZ>
-__esimd_fbl(__SIGD::vector_type_t<uint32_t, SZ> src0) {
+inline __SEIEED::vector_type_t<uint32_t, SZ>
+__esimd_fbl(__SEIEED::vector_type_t<uint32_t, SZ> src0) {
   int i;
   uint32_t ret;
-  __SIGD::vector_type_t<uint32_t, SZ> retv;
+  __SEIEED::vector_type_t<uint32_t, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -855,12 +858,12 @@ __esimd_fbl(__SIGD::vector_type_t<uint32_t, SZ> src0) {
 };
 
 template <typename T0, int SZ>
-inline __SIGD::vector_type_t<int, SZ>
-__esimd_sfbh(__SIGD::vector_type_t<T0, SZ> src0) {
+inline __SEIEED::vector_type_t<int, SZ>
+__esimd_sfbh(__SEIEED::vector_type_t<T0, SZ> src0) {
 
   int i, cval;
   int ret;
-  __SIGD::vector_type_t<int, SZ> retv;
+  __SEIEED::vector_type_t<int, SZ> retv;
 
   for (i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -887,10 +890,10 @@ __esimd_sfbh(__SIGD::vector_type_t<T0, SZ> src0) {
 };
 
 template <typename T0, int SZ>
-inline __SIGD::vector_type_t<uint32_t, SZ>
-__esimd_ufbh(__SIGD::vector_type_t<T0, SZ> src0) {
+inline __SEIEED::vector_type_t<uint32_t, SZ>
+__esimd_ufbh(__SEIEED::vector_type_t<T0, SZ> src0) {
   uint32_t ret;
-  __SIGD::vector_type_t<uint32_t, SZ> retv;
+  __SEIEED::vector_type_t<uint32_t, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -911,9 +914,9 @@ __esimd_ufbh(__SIGD::vector_type_t<T0, SZ> src0) {
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_inv(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_inv(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -923,9 +926,9 @@ __esimd_inv(__SIGD::vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_log(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_log(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -934,9 +937,9 @@ __esimd_log(__SIGD::vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_exp(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_exp(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -945,9 +948,9 @@ __esimd_exp(__SIGD::vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_sqrt(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_sqrt(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -956,9 +959,9 @@ __esimd_sqrt(__SIGD::vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_sqrt_ieee(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_sqrt_ieee(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -967,9 +970,9 @@ __esimd_sqrt_ieee(__SIGD::vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_rsqrt(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_rsqrt(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -978,9 +981,9 @@ __esimd_rsqrt(__SIGD::vector_type_t<float, SZ> src0) {
   return retv;
 };
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_sin(__SIGD::vector_type_t<float, SZ> src) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_sin(__SEIEED::vector_type_t<float, SZ> src) {
+  __SEIEED::vector_type_t<float, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     retv[i] = sin(src[i]);
@@ -988,9 +991,9 @@ __esimd_sin(__SIGD::vector_type_t<float, SZ> src) {
   return retv;
 };
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_cos(__SIGD::vector_type_t<float, SZ> src) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_cos(__SEIEED::vector_type_t<float, SZ> src) {
+  __SEIEED::vector_type_t<float, SZ> retv;
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
     retv[i] = cos(src[i]);
@@ -998,10 +1001,10 @@ __esimd_cos(__SIGD::vector_type_t<float, SZ> src) {
   return retv;
 };
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_pow(__SIGD::vector_type_t<float, SZ> src0,
-            __SIGD::vector_type_t<float, SZ> src1) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_pow(__SEIEED::vector_type_t<float, SZ> src0,
+            __SEIEED::vector_type_t<float, SZ> src1) {
+  __SEIEED::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -1011,11 +1014,11 @@ __esimd_pow(__SIGD::vector_type_t<float, SZ> src0,
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_div_ieee(__SIGD::vector_type_t<float, SZ> src0,
-                 __SIGD::vector_type_t<float, SZ> src1) {
-  __SIGD::vector_type_t<float, SZ> divinv;
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_div_ieee(__SEIEED::vector_type_t<float, SZ> src0,
+                 __SEIEED::vector_type_t<float, SZ> src1) {
+  __SEIEED::vector_type_t<float, SZ> divinv;
+  __SEIEED::vector_type_t<float, SZ> retv;
 
   for (int idx = 0; idx < SZ; idx += 1) {
     SIMDCF_ELEMENT_SKIP(idx);
@@ -1031,9 +1034,9 @@ __esimd_div_ieee(__SIGD::vector_type_t<float, SZ> src0,
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_rndd(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_rndd(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -1043,9 +1046,9 @@ __esimd_rndd(__SIGD::vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_rndu(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_rndu(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
   int increment;
 
   for (int i = 0; i < SZ; i++) {
@@ -1063,9 +1066,9 @@ __esimd_rndu(__SIGD::vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_rnde(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_rnde(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
   int increment;
 
   for (int i = 0; i < SZ; i++) {
@@ -1085,9 +1088,9 @@ __esimd_rnde(__SIGD::vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<float, SZ>
-__esimd_rndz(__SIGD::vector_type_t<float, SZ> src0) {
-  __SIGD::vector_type_t<float, SZ> retv;
+inline __SEIEED::vector_type_t<float, SZ>
+__esimd_rndz(__SEIEED::vector_type_t<float, SZ> src0) {
+  __SEIEED::vector_type_t<float, SZ> retv;
   int increment;
 
   for (int i = 0; i < SZ; i++) {
@@ -1104,9 +1107,9 @@ __esimd_rndz(__SIGD::vector_type_t<float, SZ> src0) {
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<double, SZ>
-__esimd_sqrt_ieee(__SIGD::vector_type_t<double, SZ> src0) {
-  __SIGD::vector_type_t<double, SZ> retv;
+inline __SEIEED::vector_type_t<double, SZ>
+__esimd_sqrt_ieee(__SEIEED::vector_type_t<double, SZ> src0) {
+  __SEIEED::vector_type_t<double, SZ> retv;
 
   for (int i = 0; i < SZ; i++) {
     SIMDCF_ELEMENT_SKIP(i);
@@ -1116,11 +1119,11 @@ __esimd_sqrt_ieee(__SIGD::vector_type_t<double, SZ> src0) {
 };
 
 template <int SZ>
-inline __SIGD::vector_type_t<double, SZ>
-__esimd_div_ieee(__SIGD::vector_type_t<double, SZ> src0,
-                 __SIGD::vector_type_t<double, SZ> src1) {
-  __SIGD::vector_type_t<double, SZ> divinv;
-  __SIGD::vector_type_t<double, SZ> retv;
+inline __SEIEED::vector_type_t<double, SZ>
+__esimd_div_ieee(__SEIEED::vector_type_t<double, SZ> src0,
+                 __SEIEED::vector_type_t<double, SZ> src1) {
+  __SEIEED::vector_type_t<double, SZ> divinv;
+  __SEIEED::vector_type_t<double, SZ> retv;
 
   for (int idx = 0; idx < SZ; idx += 1) {
     SIMDCF_ELEMENT_SKIP(idx);
@@ -1136,7 +1139,7 @@ __esimd_div_ieee(__SIGD::vector_type_t<double, SZ> src0,
 };
 
 template <int N>
-inline uint32_t __esimd_pack_mask(__SIGD::vector_type_t<uint16_t, N> src0) {
+inline uint32_t __esimd_pack_mask(__SEIEED::vector_type_t<uint16_t, N> src0) {
   // We don't check the arguments here as this function is only invoked by
   // wrapper code (which does the checks already)
   uint32_t retv = 0;
@@ -1150,8 +1153,8 @@ inline uint32_t __esimd_pack_mask(__SIGD::vector_type_t<uint16_t, N> src0) {
 };
 
 template <int N>
-inline __SIGD::vector_type_t<uint16_t, N> __esimd_unpack_mask(uint32_t src0) {
-  __SIGD::vector_type_t<uint16_t, N> retv;
+inline __SEIEED::vector_type_t<uint16_t, N> __esimd_unpack_mask(uint32_t src0) {
+  __SEIEED::vector_type_t<uint16_t, N> retv;
   for (int i = 0; i < N; i++) {
     if ((src0 >> i) & 0x1) {
       retv[i] = 1;
@@ -1163,20 +1166,20 @@ inline __SIGD::vector_type_t<uint16_t, N> __esimd_unpack_mask(uint32_t src0) {
 };
 
 template <typename T1, typename T2, typename T3, typename T4, int N>
-inline __SIGD::vector_type_t<T1, N>
-__esimd_dp4a(__SIGD::vector_type_t<T2, N> src0,
-             __SIGD::vector_type_t<T3, N> src1,
-             __SIGD::vector_type_t<T4, N> src2) {
-  using sycl::INTEL::gpu::emu::detail::restype_ex;
+inline __SEIEED::vector_type_t<T1, N>
+__esimd_dp4a(__SEIEED::vector_type_t<T2, N> src0,
+             __SEIEED::vector_type_t<T3, N> src1,
+             __SEIEED::vector_type_t<T4, N> src2) {
+  using __SEIEE::emu::detail::restype_ex;
   typename restype_ex<T2, typename restype_ex<T3, T4>::type>::type reta;
-  __SIGD::vector_type_t<T1, N> retv;
+  __SEIEED::vector_type_t<T1, N> retv;
 
   int src1_a, src1_b, src1_c, src1_d, src2_a, src2_b, src2_c, src2_d, ret;
 
   uint32_t sat1 =
-      __SIGED::SetSatur<T2, __SIGED::is_inttype<T1>::value>::set() ||
-      __SIGED::SetSatur<T3, __SIGED::is_inttype<T1>::value>::set() ||
-      __SIGED::SetSatur<T4, __SIGED::is_inttype<T1>::value>::set();
+      __SEIEEED::SetSatur<T2, __SEIEEED::is_inttype<T1>::value>::set() ||
+      __SEIEEED::SetSatur<T3, __SEIEEED::is_inttype<T1>::value>::set() ||
+      __SEIEEED::SetSatur<T4, __SEIEEED::is_inttype<T1>::value>::set();
 
   for (uint32_t i = 0; i < N; i++) {
 
@@ -1193,17 +1196,17 @@ __esimd_dp4a(__SIGD::vector_type_t<T2, N> src0,
 
     ret = src1_a * src2_a + src1_b * src2_b + src1_c * src2_c + src1_d * src2_d;
     reta = ret + src0[i];
-    retv[i] = __SIGED::satur<T1>::saturate(reta, sat1);
+    retv[i] = __SEIEEED::satur<T1>::saturate(reta, sat1);
   }
 
   return retv;
 };
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_max(__SIGD::vector_type_t<Ty, N> src1,
-                    __SIGD::vector_type_t<Ty, N> src2) {
-  __SIGD::vector_type_t<Ty, N> retv;
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_max(__SEIEED::vector_type_t<Ty, N> src1,
+                    __SEIEED::vector_type_t<Ty, N> src2) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   for (int I = 0; I < N; I++) {
     if (src1[I] >= src2[I]) {
       retv[I] = src1[I];
@@ -1215,31 +1218,31 @@ __esimd_reduced_max(__SIGD::vector_type_t<Ty, N> src1,
 }
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_fmax(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2) {
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_fmax(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_max<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_umax(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2) {
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_umax(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_max<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_smax(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2) {
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_smax(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_max<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_min(__SIGD::vector_type_t<Ty, N> src1,
-                    __SIGD::vector_type_t<Ty, N> src2) {
-  __SIGD::vector_type_t<Ty, N> retv;
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_min(__SEIEED::vector_type_t<Ty, N> src1,
+                    __SEIEED::vector_type_t<Ty, N> src2) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   for (int I = 0; I < N; I++) {
     if (src1[I] <= src2[I]) {
       retv[I] = src1[I];
@@ -1251,28 +1254,28 @@ __esimd_reduced_min(__SIGD::vector_type_t<Ty, N> src1,
 }
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_fmin(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2) {
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_fmin(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_min<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_umin(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2) {
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_umin(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_min<Ty, N>(src1, src2);
 }
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_reduced_smin(__SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<Ty, N> src2) {
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_reduced_smin(__SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<Ty, N> src2) {
   return __esimd_reduced_min<Ty, N>(src1, src2);
 }
 
-#undef __SIGED
+#undef __SEIEEED
 
 #endif // #ifndef __SYCL_DEVICE_ONLY__
 
-#undef __SIGD
+#undef __SEIEED

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_memory_intrin.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_memory_intrin.hpp
@@ -20,8 +20,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 namespace detail {
 // Provides access to sycl accessor class' private members.
 class AccessorPrivateProxy {
@@ -63,74 +65,77 @@ constexpr unsigned int ElemsPerAddrDecoding(unsigned int ElemsPerAddrEncoded) {
 }
 
 } // namespace detail
-} // namespace gpu
-} // namespace INTEL
+
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
 
-#define __SIGD sycl::INTEL::gpu::detail
+#define __SEIEE sycl::ext::intel::experimental::esimd
+#define __SEIEED sycl::ext::intel::experimental::esimd::detail
 
 // flat_read does flat-address gather
 template <typename Ty, int N, int NumBlk = 0,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
+          __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION
-    __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)>
-    __esimd_flat_read(__SIGD::vector_type_t<uint64_t, N> addrs,
+    __SEIEED::vector_type_t<Ty, N * __SEIEED::ElemsPerAddrDecoding(NumBlk)>
+    __esimd_flat_read(__SEIEED::vector_type_t<uint64_t, N> addrs,
                       int ElemsPerAddr = NumBlk,
-                      __SIGD::vector_type_t<uint16_t, N> pred = 1);
+                      __SEIEED::vector_type_t<uint16_t, N> pred = 1);
 
 // flat_write does flat-address scatter
 template <typename Ty, int N, int NumBlk = 0,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
+          __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void __esimd_flat_write(
-    __SIGD::vector_type_t<uint64_t, N> addrs,
-    __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)> vals,
-    int ElemsPerAddr = NumBlk, __SIGD::vector_type_t<uint16_t, N> pred = 1);
+    __SEIEED::vector_type_t<uint64_t, N> addrs,
+    __SEIEED::vector_type_t<Ty, N * __SEIEED::ElemsPerAddrDecoding(NumBlk)>
+        vals,
+    int ElemsPerAddr = NumBlk, __SEIEED::vector_type_t<uint16_t, N> pred = 1);
 
 // flat_block_read reads a block of data from one flat address
-template <typename Ty, int N,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
+template <typename Ty, int N, __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
 __esimd_flat_block_read_unaligned(uint64_t addr);
 
 // flat_block_write writes a block of data using one flat address
-template <typename Ty, int N,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
+template <typename Ty, int N, __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
-__esimd_flat_block_write(uint64_t addr, __SIGD::vector_type_t<Ty, N> vals);
+__esimd_flat_block_write(uint64_t addr, __SEIEED::vector_type_t<Ty, N> vals);
 
 // Reads a block of data from given surface at given offset.
 template <typename Ty, int N, typename SurfIndAliasTy>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
 __esimd_block_read(SurfIndAliasTy surf_ind, uint32_t offset);
 
 // Writes given block of data to a surface with given index at given offset.
 template <typename Ty, int N, typename SurfIndAliasTy>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
 __esimd_block_write(SurfIndAliasTy surf_ind, uint32_t offset,
-                    __SIGD::vector_type_t<Ty, N> vals);
+                    __SEIEED::vector_type_t<Ty, N> vals);
 
 // flat_read4 does flat-address gather4
-template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-__SIGD::vector_type_t<Ty, N * NumChannels(Mask)>
+template <typename Ty, int N, __SEIEE::ChannelMaskType Mask,
+          __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
+__SEIEED::vector_type_t<Ty, N * NumChannels(Mask)>
     SYCL_EXTERNAL SYCL_ESIMD_FUNCTION
-    __esimd_flat_read4(__SIGD::vector_type_t<uint64_t, N> addrs,
-                       __SIGD::vector_type_t<uint16_t, N> pred = 1);
+    __esimd_flat_read4(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                       __SEIEED::vector_type_t<uint16_t, N> pred = 1);
 
 // flat_write does flat-address scatter
-template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
+template <typename Ty, int N, __SEIEE::ChannelMaskType Mask,
+          __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
-__esimd_flat_write4(__SIGD::vector_type_t<uint64_t, N> addrs,
-                    __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> vals,
-                    __SIGD::vector_type_t<uint16_t, N> pred = 1);
+__esimd_flat_write4(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                    __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)> vals,
+                    __SEIEED::vector_type_t<uint16_t, N> pred = 1);
 
 // Low-level surface-based gather. Collects elements located at given offsets in
 // a surface and returns them as a single \ref simd object. Element can be
@@ -154,12 +159,12 @@ __esimd_flat_write4(__SIGD::vector_type_t<uint64_t, N> addrs,
 // @param elem_offsets - per-element offsets
 //
 template <typename Ty, int N, typename SurfIndAliasTy, int TySizeLog2,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
+          __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
 __esimd_surf_read(int16_t scale, SurfIndAliasTy surf_ind,
                   uint32_t global_offset,
-                  __SIGD::vector_type_t<uint32_t, N> elem_offsets)
+                  __SEIEED::vector_type_t<uint32_t, N> elem_offsets)
 #ifdef __SYCL_DEVICE_ONLY__
     ;
 #else
@@ -196,13 +201,13 @@ __esimd_surf_read(int16_t scale, SurfIndAliasTy surf_ind,
 // @param vals - values to write
 //
 template <typename Ty, int N, typename SurfIndAliasTy, int TySizeLog2,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
+          __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
-__esimd_surf_write(__SIGD::vector_type_t<uint16_t, N> pred, int16_t scale,
+__esimd_surf_write(__SEIEED::vector_type_t<uint16_t, N> pred, int16_t scale,
                    SurfIndAliasTy surf_ind, uint32_t global_offset,
-                   __SIGD::vector_type_t<uint32_t, N> elem_offsets,
-                   __SIGD::vector_type_t<Ty, N> vals)
+                   __SEIEED::vector_type_t<uint32_t, N> elem_offsets,
+                   __SEIEED::vector_type_t<Ty, N> vals)
 #ifdef __SYCL_DEVICE_ONLY__
     ;
 #else
@@ -218,95 +223,95 @@ __esimd_surf_write(__SIGD::vector_type_t<uint16_t, N> pred, int16_t scale,
 // correponsing BE intrinsicics parameter order.
 
 // flat_atomic: flat-address atomic
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_flat_atomic0(__SIGD::vector_type_t<uint64_t, N> addrs,
-                     __SIGD::vector_type_t<uint16_t, N> pred);
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N,
+          __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_flat_atomic0(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                     __SEIEED::vector_type_t<uint16_t, N> pred);
 
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_flat_atomic1(__SIGD::vector_type_t<uint64_t, N> addrs,
-                     __SIGD::vector_type_t<Ty, N> src0,
-                     __SIGD::vector_type_t<uint16_t, N> pred);
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N,
+          __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_flat_atomic1(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                     __SEIEED::vector_type_t<Ty, N> src0,
+                     __SEIEED::vector_type_t<uint16_t, N> pred);
 
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
-          sycl::INTEL::gpu::CacheHint L1H = sycl::INTEL::gpu::CacheHint::None,
-          sycl::INTEL::gpu::CacheHint L3H = sycl::INTEL::gpu::CacheHint::None>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_flat_atomic2(__SIGD::vector_type_t<uint64_t, N> addrs,
-                     __SIGD::vector_type_t<Ty, N> src0,
-                     __SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<uint16_t, N> pred);
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N,
+          __SEIEE::CacheHint L1H = __SEIEE::CacheHint::None,
+          __SEIEE::CacheHint L3H = __SEIEE::CacheHint::None>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_flat_atomic2(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                     __SEIEED::vector_type_t<Ty, N> src0,
+                     __SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<uint16_t, N> pred);
 
 // esimd_barrier, generic group barrier
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void __esimd_barrier();
 
 // generic work-group split barrier
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
-__esimd_sbarrier(sycl::INTEL::gpu::EsimdSbarrierType flag);
+__esimd_sbarrier(__SEIEE::EsimdSbarrierType flag);
 
 // slm_fence sets the SLM read/write order
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void __esimd_slm_fence(uint8_t cntl);
 
 // slm_read does SLM gather
 template <typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_slm_read(__SIGD::vector_type_t<uint32_t, N> addrs,
-                 __SIGD::vector_type_t<uint16_t, N> pred = 1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_slm_read(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                 __SEIEED::vector_type_t<uint16_t, N> pred = 1);
 
 // slm_write does SLM scatter
 template <typename Ty, int N>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
-__esimd_slm_write(__SIGD::vector_type_t<uint32_t, N> addrs,
-                  __SIGD::vector_type_t<Ty, N> vals,
-                  __SIGD::vector_type_t<uint16_t, N> pred = 1);
+__esimd_slm_write(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                  __SEIEED::vector_type_t<Ty, N> vals,
+                  __SEIEED::vector_type_t<uint16_t, N> pred = 1);
 
 // slm_block_read reads a block of data from SLM
 template <typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
 __esimd_slm_block_read(uint32_t addr);
 
 // slm_block_write writes a block of data to SLM
 template <typename Ty, int N>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
-__esimd_slm_block_write(uint32_t addr, __SIGD::vector_type_t<Ty, N> vals);
+__esimd_slm_block_write(uint32_t addr, __SEIEED::vector_type_t<Ty, N> vals);
 
 // slm_read4 does SLM gather4
-template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask>
+template <typename Ty, int N, __SEIEE::ChannelMaskType Mask>
 SYCL_EXTERNAL
-    SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N * NumChannels(Mask)>
-    __esimd_slm_read4(__SIGD::vector_type_t<uint32_t, N> addrs,
-                      __SIGD::vector_type_t<uint16_t, N> pred = 1);
+    SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)>
+    __esimd_slm_read4(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                      __SEIEED::vector_type_t<uint16_t, N> pred = 1);
 
 // slm_write4 does SLM scatter4
-template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask>
+template <typename Ty, int N, __SEIEE::ChannelMaskType Mask>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
-__esimd_slm_write4(__SIGD::vector_type_t<uint32_t, N> addrs,
-                   __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> vals,
-                   __SIGD::vector_type_t<uint16_t, N> pred = 1);
+__esimd_slm_write4(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                   __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)> vals,
+                   __SEIEED::vector_type_t<uint16_t, N> pred = 1);
 
 // slm_atomic: SLM atomic
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_slm_atomic0(__SIGD::vector_type_t<uint32_t, N> addrs,
-                    __SIGD::vector_type_t<uint16_t, N> pred);
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_slm_atomic0(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                    __SEIEED::vector_type_t<uint16_t, N> pred);
 
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_slm_atomic1(__SIGD::vector_type_t<uint32_t, N> addrs,
-                    __SIGD::vector_type_t<Ty, N> src0,
-                    __SIGD::vector_type_t<uint16_t, N> pred);
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_slm_atomic1(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                    __SEIEED::vector_type_t<Ty, N> src0,
+                    __SEIEED::vector_type_t<uint16_t, N> pred);
 
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, N>
-__esimd_slm_atomic2(__SIGD::vector_type_t<uint32_t, N> addrs,
-                    __SIGD::vector_type_t<Ty, N> src0,
-                    __SIGD::vector_type_t<Ty, N> src1,
-                    __SIGD::vector_type_t<uint16_t, N> pred);
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, N>
+__esimd_slm_atomic2(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                    __SEIEED::vector_type_t<Ty, N> src0,
+                    __SEIEED::vector_type_t<Ty, N> src1,
+                    __SEIEED::vector_type_t<uint16_t, N> pred);
 
 // Media block load
 //
@@ -333,7 +338,7 @@ __esimd_slm_atomic2(__SIGD::vector_type_t<uint32_t, N> addrs,
 // @return the linearized 2D block data read from surface.
 //
 template <typename Ty, int M, int N, typename TACC>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty, M * N>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty, M * N>
 __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
                          unsigned width, unsigned x, unsigned y);
 
@@ -365,7 +370,7 @@ template <typename Ty, int M, int N, typename TACC>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
 __esimd_media_block_store(unsigned modififer, TACC handle, unsigned plane,
                           unsigned width, unsigned x, unsigned y,
-                          __SIGD::vector_type_t<Ty, M * N> vals);
+                          __SEIEED::vector_type_t<Ty, M * N> vals);
 
 /// \brief esimd_get_value
 ///
@@ -410,14 +415,14 @@ __esimd_get_value(SurfIndAliasTy sid);
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, typename Ty3, int N3,
           int N = 16>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty1, N1>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty1, N1>
 __esimd_raw_sends_load(uint8_t modifier, uint8_t execSize,
-                       __SIGD::vector_type_t<uint16_t, N> pred, uint8_t numSrc0,
-                       uint8_t numSrc1, uint8_t numDst, uint8_t sfid,
-                       uint32_t exDesc, uint32_t msgDesc,
-                       __SIGD::vector_type_t<Ty2, N2> msgSrc0,
-                       __SIGD::vector_type_t<Ty3, N3> msgSrc1,
-                       __SIGD::vector_type_t<Ty1, N1> msgDst);
+                       __SEIEED::vector_type_t<uint16_t, N> pred,
+                       uint8_t numSrc0, uint8_t numSrc1, uint8_t numDst,
+                       uint8_t sfid, uint32_t exDesc, uint32_t msgDesc,
+                       __SEIEED::vector_type_t<Ty2, N2> msgSrc0,
+                       __SEIEED::vector_type_t<Ty3, N3> msgSrc1,
+                       __SEIEED::vector_type_t<Ty1, N1> msgDst);
 
 /// \brief Raw send load.
 ///
@@ -446,12 +451,13 @@ __esimd_raw_sends_load(uint8_t modifier, uint8_t execSize,
 /// Returns a simd vector of type Ty1 and size N1.
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, int N = 16>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SIGD::vector_type_t<Ty1, N1>
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION __SEIEED::vector_type_t<Ty1, N1>
 __esimd_raw_send_load(uint8_t modifier, uint8_t execSize,
-                      __SIGD::vector_type_t<uint16_t, N> pred, uint8_t numSrc0,
-                      uint8_t numDst, uint8_t sfid, uint32_t exDesc,
-                      uint32_t msgDesc, __SIGD::vector_type_t<Ty2, N2> msgSrc0,
-                      __SIGD::vector_type_t<Ty1, N1> msgDst);
+                      __SEIEED::vector_type_t<uint16_t, N> pred,
+                      uint8_t numSrc0, uint8_t numDst, uint8_t sfid,
+                      uint32_t exDesc, uint32_t msgDesc,
+                      __SEIEED::vector_type_t<Ty2, N2> msgSrc0,
+                      __SEIEED::vector_type_t<Ty1, N1> msgDst);
 
 /// \brief Raw sends store.
 ///
@@ -478,11 +484,13 @@ __esimd_raw_send_load(uint8_t modifier, uint8_t execSize,
 /// @param msgSrc1 the second source operand of send message.
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, int N = 16>
-SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void __esimd_raw_sends_store(
-    uint8_t modifier, uint8_t execSize, __SIGD::vector_type_t<uint16_t, N> pred,
-    uint8_t numSrc0, uint8_t numSrc1, uint8_t sfid, uint32_t exDesc,
-    uint32_t msgDesc, __SIGD::vector_type_t<Ty1, N1> msgSrc0,
-    __SIGD::vector_type_t<Ty2, N2> msgSrc1);
+SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
+__esimd_raw_sends_store(uint8_t modifier, uint8_t execSize,
+                        __SEIEED::vector_type_t<uint16_t, N> pred,
+                        uint8_t numSrc0, uint8_t numSrc1, uint8_t sfid,
+                        uint32_t exDesc, uint32_t msgDesc,
+                        __SEIEED::vector_type_t<Ty1, N1> msgSrc0,
+                        __SEIEED::vector_type_t<Ty2, N2> msgSrc1);
 
 /// \brief Raw send store.
 ///
@@ -506,19 +514,20 @@ SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void __esimd_raw_sends_store(
 template <typename Ty1, int N1, int N = 16>
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION void
 __esimd_raw_send_store(uint8_t modifier, uint8_t execSize,
-                       __SIGD::vector_type_t<uint16_t, N> pred, uint8_t numSrc0,
-                       uint8_t sfid, uint32_t exDesc, uint32_t msgDesc,
-                       __SIGD::vector_type_t<Ty1, N1> msgSrc0);
+                       __SEIEED::vector_type_t<uint16_t, N> pred,
+                       uint8_t numSrc0, uint8_t sfid, uint32_t exDesc,
+                       uint32_t msgDesc,
+                       __SEIEED::vector_type_t<Ty1, N1> msgSrc0);
 #ifndef __SYCL_DEVICE_ONLY__
 
-template <typename Ty, int N, int NumBlk, sycl::INTEL::gpu::CacheHint L1H,
-          sycl::INTEL::gpu::CacheHint L3H>
-inline __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)>
-__esimd_flat_read(__SIGD::vector_type_t<uint64_t, N> addrs, int ElemsPerAddr,
-                  __SIGD::vector_type_t<uint16_t, N> pred) {
-  auto NumBlkDecoded = __SIGD::ElemsPerAddrDecoding(NumBlk);
-  __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)> V;
-  ElemsPerAddr = __SIGD::ElemsPerAddrDecoding(ElemsPerAddr);
+template <typename Ty, int N, int NumBlk, __SEIEE::CacheHint L1H,
+          __SEIEE::CacheHint L3H>
+inline __SEIEED::vector_type_t<Ty, N * __SEIEED::ElemsPerAddrDecoding(NumBlk)>
+__esimd_flat_read(__SEIEED::vector_type_t<uint64_t, N> addrs, int ElemsPerAddr,
+                  __SEIEED::vector_type_t<uint16_t, N> pred) {
+  auto NumBlkDecoded = __SEIEED::ElemsPerAddrDecoding(NumBlk);
+  __SEIEED::vector_type_t<Ty, N * __SEIEED::ElemsPerAddrDecoding(NumBlk)> V;
+  ElemsPerAddr = __SEIEED::ElemsPerAddrDecoding(ElemsPerAddr);
 
   for (int I = 0; I < N; I++) {
     if (pred[I]) {
@@ -537,12 +546,12 @@ __esimd_flat_read(__SIGD::vector_type_t<uint64_t, N> addrs, int ElemsPerAddr,
   return V;
 }
 
-template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask,
-          sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
-inline __SIGD::vector_type_t<Ty, N * NumChannels(Mask)>
-__esimd_flat_read4(__SIGD::vector_type_t<uint64_t, N> addrs,
-                   __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> V;
+template <typename Ty, int N, __SEIEE::ChannelMaskType Mask,
+          __SEIEE::CacheHint L1H, __SEIEE::CacheHint L3H>
+inline __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)>
+__esimd_flat_read4(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                   __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)> V;
   unsigned int Next = 0;
 
   if constexpr (HasR(Mask)) {
@@ -585,14 +594,15 @@ __esimd_flat_read4(__SIGD::vector_type_t<uint64_t, N> addrs,
   return V;
 }
 
-template <typename Ty, int N, int NumBlk, sycl::INTEL::gpu::CacheHint L1H,
-          sycl::INTEL::gpu::CacheHint L3H>
+template <typename Ty, int N, int NumBlk, __SEIEE::CacheHint L1H,
+          __SEIEE::CacheHint L3H>
 inline void __esimd_flat_write(
-    __SIGD::vector_type_t<uint64_t, N> addrs,
-    __SIGD::vector_type_t<Ty, N * __SIGD::ElemsPerAddrDecoding(NumBlk)> vals,
-    int ElemsPerAddr, __SIGD::vector_type_t<uint16_t, N> pred) {
-  auto NumBlkDecoded = __SIGD::ElemsPerAddrDecoding(NumBlk);
-  ElemsPerAddr = __SIGD::ElemsPerAddrDecoding(ElemsPerAddr);
+    __SEIEED::vector_type_t<uint64_t, N> addrs,
+    __SEIEED::vector_type_t<Ty, N * __SEIEED::ElemsPerAddrDecoding(NumBlk)>
+        vals,
+    int ElemsPerAddr, __SEIEED::vector_type_t<uint16_t, N> pred) {
+  auto NumBlkDecoded = __SEIEED::ElemsPerAddrDecoding(NumBlk);
+  ElemsPerAddr = __SEIEED::ElemsPerAddrDecoding(ElemsPerAddr);
 
   for (int I = 0; I < N; I++) {
     if (pred[I]) {
@@ -610,13 +620,13 @@ inline void __esimd_flat_write(
   }
 }
 
-template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask,
-          sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
+template <typename Ty, int N, __SEIEE::ChannelMaskType Mask,
+          __SEIEE::CacheHint L1H, __SEIEE::CacheHint L3H>
 inline void
-__esimd_flat_write4(__SIGD::vector_type_t<uint64_t, N> addrs,
-                    __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> vals,
-                    __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> V;
+__esimd_flat_write4(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                    __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)> vals,
+                    __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)> V;
   unsigned int Next = 0;
 
   if constexpr (HasR(Mask)) {
@@ -657,11 +667,10 @@ __esimd_flat_write4(__SIGD::vector_type_t<uint64_t, N> addrs,
   }
 }
 
-template <typename Ty, int N, sycl::INTEL::gpu::CacheHint L1H,
-          sycl::INTEL::gpu::CacheHint L3H>
-inline __SIGD::vector_type_t<Ty, N>
+template <typename Ty, int N, __SEIEE::CacheHint L1H, __SEIEE::CacheHint L3H>
+inline __SEIEED::vector_type_t<Ty, N>
 __esimd_flat_block_read_unaligned(uint64_t addr) {
-  __SIGD::vector_type_t<Ty, N> V;
+  __SEIEED::vector_type_t<Ty, N> V;
 
   for (int I = 0; I < N; I++) {
     Ty *Addr = reinterpret_cast<Ty *>(addr + I * sizeof(Ty));
@@ -670,10 +679,9 @@ __esimd_flat_block_read_unaligned(uint64_t addr) {
   return V;
 }
 
-template <typename Ty, int N, sycl::INTEL::gpu::CacheHint L1H,
-          sycl::INTEL::gpu::CacheHint L3H>
+template <typename Ty, int N, __SEIEE::CacheHint L1H, __SEIEE::CacheHint L3H>
 inline void __esimd_flat_block_write(uint64_t addr,
-                                     __SIGD::vector_type_t<Ty, N> vals) {
+                                     __SEIEED::vector_type_t<Ty, N> vals) {
   for (int I = 0; I < N; I++) {
     Ty *Addr = reinterpret_cast<Ty *>(addr + I * sizeof(Ty));
     *Addr = vals[I];
@@ -681,14 +689,14 @@ inline void __esimd_flat_block_write(uint64_t addr,
 }
 
 template <typename Ty, int M, int N, typename TACC>
-inline __SIGD::vector_type_t<Ty, M * N>
+inline __SEIEED::vector_type_t<Ty, M * N>
 __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
                          unsigned width, unsigned x, unsigned y) {
   // On host the input surface is modeled as sycl image 2d object,
   // and the read/write access is done through accessor,
   // which is passed in as the handle argument.
-  auto range = __SIGD::AccessorPrivateProxy::getImageRange(handle);
-  unsigned bpp = __SIGD::AccessorPrivateProxy::getElemSize(handle);
+  auto range = __SEIEED::AccessorPrivateProxy::getImageRange(handle);
+  unsigned bpp = __SEIEED::AccessorPrivateProxy::getElemSize(handle);
   unsigned vpp = bpp / sizeof(Ty);
   unsigned int i = x / bpp;
   unsigned int j = y;
@@ -697,7 +705,7 @@ __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
   unsigned int xbound = range[0] - 1;
   unsigned int ybound = range[1] - 1;
 
-  __SIGD::vector_type_t<Ty, M * N> vals;
+  __SEIEED::vector_type_t<Ty, M * N> vals;
   for (int row = 0; row < M; row++) {
     for (int col = 0; col < N; col += vpp) {
       unsigned int xoff = (i > xbound) ? xbound : i;
@@ -705,14 +713,14 @@ __esimd_media_block_load(unsigned modififer, TACC handle, unsigned plane,
       auto coords = cl::sycl::cl_int2(xoff, yoff);
       cl::sycl::cl_uint4 data = handle.read(coords);
 
-      __SIGD::vector_type_t<unsigned int, 4> res;
+      __SEIEED::vector_type_t<unsigned int, 4> res;
       for (int idx = 0; idx < 4; idx++) {
         res[idx] = data[idx];
       }
 
       constexpr int refN = sizeof(cl::sycl::cl_uint4) / sizeof(Ty);
       unsigned int stride = sizeof(cl::sycl::cl_uint4) / bpp;
-      using refTy = __SIGD::vector_type_t<Ty, refN>;
+      using refTy = __SEIEED::vector_type_t<Ty, refN>;
       auto ref = reinterpret_cast<refTy>(res);
 
       unsigned int offset1 = col + row * N;
@@ -735,10 +743,10 @@ template <typename Ty, int M, int N, typename TACC>
 inline void __esimd_media_block_store(unsigned modififer, TACC handle,
                                       unsigned plane, unsigned width,
                                       unsigned x, unsigned y,
-                                      __SIGD::vector_type_t<Ty, M * N> vals) {
-  unsigned bpp = __SIGD::AccessorPrivateProxy::getElemSize(handle);
+                                      __SEIEED::vector_type_t<Ty, M * N> vals) {
+  unsigned bpp = __SEIEED::AccessorPrivateProxy::getElemSize(handle);
   unsigned vpp = bpp / sizeof(Ty);
-  auto range = __SIGD::AccessorPrivateProxy::getImageRange(handle);
+  auto range = __SEIEED::AccessorPrivateProxy::getImageRange(handle);
   unsigned int i = x / bpp;
   unsigned int j = y;
 
@@ -747,7 +755,7 @@ inline void __esimd_media_block_store(unsigned modififer, TACC handle,
   for (int row = 0; row < M; row++) {
     for (int col = 0; col < N; col += vpp) {
       constexpr int Sz = sizeof(cl::sycl::cl_uint4) / sizeof(Ty);
-      __SIGD::vector_type_t<Ty, Sz> res = 0;
+      __SEIEED::vector_type_t<Ty, Sz> res = 0;
 
       unsigned int offset1 = col + row * N;
       unsigned int offset2 = 0;
@@ -758,7 +766,7 @@ inline void __esimd_media_block_store(unsigned modififer, TACC handle,
         offset2 += stride;
       }
 
-      using refTy = __SIGD::vector_type_t<unsigned int, 4>;
+      using refTy = __SEIEED::vector_type_t<unsigned int, 4>;
       auto ref = reinterpret_cast<refTy>(res);
 
       cl::sycl::cl_uint4 data;
@@ -778,7 +786,7 @@ inline void __esimd_media_block_store(unsigned modififer, TACC handle,
 }
 
 template <typename Ty, int N>
-inline uint16_t __esimd_any(__SIGD::vector_type_t<Ty, N> src) {
+inline uint16_t __esimd_any(__SEIEED::vector_type_t<Ty, N> src) {
   for (unsigned int i = 0; i != N; i++) {
     if (src[i] != 0)
       return 1;
@@ -787,7 +795,7 @@ inline uint16_t __esimd_any(__SIGD::vector_type_t<Ty, N> src) {
 }
 
 template <typename Ty, int N>
-inline uint16_t __esimd_all(__SIGD::vector_type_t<Ty, N> src) {
+inline uint16_t __esimd_all(__SEIEED::vector_type_t<Ty, N> src) {
   for (unsigned int i = 0; i != N; i++) {
     if (src[i] == 0)
       return 0;
@@ -796,9 +804,10 @@ inline uint16_t __esimd_all(__SIGD::vector_type_t<Ty, N> src) {
 }
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_dp4(__SIGD::vector_type_t<Ty, N> v1, __SIGD::vector_type_t<Ty, N> v2) {
-  __SIGD::vector_type_t<Ty, N> retv;
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_dp4(__SEIEED::vector_type_t<Ty, N> v1,
+            __SEIEED::vector_type_t<Ty, N> v2) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   for (auto i = 0; i != N; i += 4) {
     Ty dp = (v1[i] * v2[i]) + (v1[i + 1] * v2[i + 1]) +
             (v1[i + 2] * v2[i + 2]) + (v1[i + 3] * v2[i + 3]);
@@ -813,120 +822,120 @@ __esimd_dp4(__SIGD::vector_type_t<Ty, N> v1, __SIGD::vector_type_t<Ty, N> v2) {
 /// TODO
 inline void __esimd_barrier() {}
 
-inline void __esimd_sbarrier(sycl::INTEL::gpu::EsimdSbarrierType flag) {}
+inline void __esimd_sbarrier(__SEIEE::EsimdSbarrierType flag) {}
 
 inline void __esimd_slm_fence(uint8_t cntl) {}
 
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_slm_read(__SIGD::vector_type_t<uint32_t, N> addrs,
-                 __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N> retv;
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_slm_read(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                 __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 // slm_write does SLM scatter
 template <typename Ty, int N>
-inline void __esimd_slm_write(__SIGD::vector_type_t<uint32_t, N> addrs,
-                              __SIGD::vector_type_t<Ty, N> vals,
-                              __SIGD::vector_type_t<uint16_t, N> pred) {}
+inline void __esimd_slm_write(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                              __SEIEED::vector_type_t<Ty, N> vals,
+                              __SEIEED::vector_type_t<uint16_t, N> pred) {}
 
 // slm_block_read reads a block of data from SLM
 template <typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N> __esimd_slm_block_read(uint32_t addr) {
-  __SIGD::vector_type_t<Ty, N> retv;
+inline __SEIEED::vector_type_t<Ty, N> __esimd_slm_block_read(uint32_t addr) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 // slm_block_write writes a block of data to SLM
 template <typename Ty, int N>
 inline void __esimd_slm_block_write(uint32_t addr,
-                                    __SIGD::vector_type_t<Ty, N> vals) {}
+                                    __SEIEED::vector_type_t<Ty, N> vals) {}
 
 // slm_read4 does SLM gather4
-template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask>
-inline __SIGD::vector_type_t<Ty, N * NumChannels(Mask)>
-__esimd_slm_read4(__SIGD::vector_type_t<uint32_t, N> addrs,
-                  __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> retv;
+template <typename Ty, int N, __SEIEE::ChannelMaskType Mask>
+inline __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)>
+__esimd_slm_read4(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                  __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)> retv;
   return retv;
 }
 
 // slm_write4 does SLM scatter4
-template <typename Ty, int N, sycl::INTEL::gpu::ChannelMaskType Mask>
+template <typename Ty, int N, __SEIEE::ChannelMaskType Mask>
 inline void
-__esimd_slm_write4(__SIGD::vector_type_t<uint32_t, N> addrs,
-                   __SIGD::vector_type_t<Ty, N * NumChannels(Mask)> vals,
-                   __SIGD::vector_type_t<uint16_t, N> pred) {}
+__esimd_slm_write4(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                   __SEIEED::vector_type_t<Ty, N * NumChannels(Mask)> vals,
+                   __SEIEED::vector_type_t<uint16_t, N> pred) {}
 
 // slm_atomic: SLM atomic
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_slm_atomic0(__SIGD::vector_type_t<uint32_t, N> addrs,
-                    __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N> retv;
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N>
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_slm_atomic0(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                    __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   return retv;
 }
 
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_slm_atomic1(__SIGD::vector_type_t<uint32_t, N> addrs,
-                    __SIGD::vector_type_t<Ty, N> src0,
-                    __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N> retv;
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N>
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_slm_atomic1(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                    __SEIEED::vector_type_t<Ty, N> src0,
+                    __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   return retv;
 }
 
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_slm_atomic2(__SIGD::vector_type_t<uint32_t, N> addrs,
-                    __SIGD::vector_type_t<Ty, N> src0,
-                    __SIGD::vector_type_t<Ty, N> src1,
-                    __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N> retv;
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N>
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_slm_atomic2(__SEIEED::vector_type_t<uint32_t, N> addrs,
+                    __SEIEED::vector_type_t<Ty, N> src0,
+                    __SEIEED::vector_type_t<Ty, N> src1,
+                    __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   return retv;
 }
 
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
-          sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_flat_atomic0(__SIGD::vector_type_t<uint64_t, N> addrs,
-                     __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N> retv;
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N,
+          __SEIEE::CacheHint L1H, __SEIEE::CacheHint L3H>
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_flat_atomic0(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                     __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   return retv;
 }
 
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
-          sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_flat_atomic1(__SIGD::vector_type_t<uint64_t, N> addrs,
-                     __SIGD::vector_type_t<Ty, N> src0,
-                     __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N> retv;
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N,
+          __SEIEE::CacheHint L1H, __SEIEE::CacheHint L3H>
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_flat_atomic1(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                     __SEIEED::vector_type_t<Ty, N> src0,
+                     __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   return retv;
 }
 
-template <sycl::INTEL::gpu::EsimdAtomicOpType Op, typename Ty, int N,
-          sycl::INTEL::gpu::CacheHint L1H, sycl::INTEL::gpu::CacheHint L3H>
-inline __SIGD::vector_type_t<Ty, N>
-__esimd_flat_atomic2(__SIGD::vector_type_t<uint64_t, N> addrs,
-                     __SIGD::vector_type_t<Ty, N> src0,
-                     __SIGD::vector_type_t<Ty, N> src1,
-                     __SIGD::vector_type_t<uint16_t, N> pred) {
-  __SIGD::vector_type_t<Ty, N> retv;
+template <__SEIEE::EsimdAtomicOpType Op, typename Ty, int N,
+          __SEIEE::CacheHint L1H, __SEIEE::CacheHint L3H>
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_flat_atomic2(__SEIEED::vector_type_t<uint64_t, N> addrs,
+                     __SEIEED::vector_type_t<Ty, N> src0,
+                     __SEIEED::vector_type_t<Ty, N> src1,
+                     __SEIEED::vector_type_t<uint16_t, N> pred) {
+  __SEIEED::vector_type_t<Ty, N> retv;
   return retv;
 }
 
 template <typename Ty, int N, typename SurfIndAliasTy>
-inline __SIGD::vector_type_t<Ty, N> __esimd_block_read(SurfIndAliasTy surf_ind,
-                                                       uint32_t offset) {
+inline __SEIEED::vector_type_t<Ty, N>
+__esimd_block_read(SurfIndAliasTy surf_ind, uint32_t offset) {
   throw cl::sycl::feature_not_supported();
-  return __SIGD::vector_type_t<Ty, N>();
+  return __SEIEED::vector_type_t<Ty, N>();
 }
 
 template <typename Ty, int N, typename SurfIndAliasTy>
 inline void __esimd_block_write(SurfIndAliasTy surf_ind, uint32_t offset,
-                                __SIGD::vector_type_t<Ty, N> vals) {
+                                __SEIEED::vector_type_t<Ty, N> vals) {
 
   throw cl::sycl::feature_not_supported();
 }
@@ -976,12 +985,14 @@ inline uint32_t __esimd_get_value(AccessorTy acc) {
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, typename Ty3, int N3,
           int N>
-inline __SIGD::vector_type_t<Ty1, N1> __esimd_raw_sends_load(
-    uint8_t modifier, uint8_t execSize, __SIGD::vector_type_t<uint16_t, N> pred,
-    uint8_t numSrc0, uint8_t numSrc1, uint8_t numDst, uint8_t sfid,
-    uint32_t exDesc, uint32_t msgDesc, __SIGD::vector_type_t<Ty2, N2> msgSrc0,
-    __SIGD::vector_type_t<Ty3, N3> msgSrc1,
-    __SIGD::vector_type_t<Ty1, N1> msgDst) {
+inline __SEIEED::vector_type_t<Ty1, N1>
+__esimd_raw_sends_load(uint8_t modifier, uint8_t execSize,
+                       __SEIEED::vector_type_t<uint16_t, N> pred,
+                       uint8_t numSrc0, uint8_t numSrc1, uint8_t numDst,
+                       uint8_t sfid, uint32_t exDesc, uint32_t msgDesc,
+                       __SEIEED::vector_type_t<Ty2, N2> msgSrc0,
+                       __SEIEED::vector_type_t<Ty3, N3> msgSrc1,
+                       __SEIEED::vector_type_t<Ty1, N1> msgDst) {
   throw cl::sycl::feature_not_supported();
   return 0;
 }
@@ -1013,12 +1024,13 @@ inline __SIGD::vector_type_t<Ty1, N1> __esimd_raw_sends_load(
 /// Returns a simd vector of type Ty1 and size N1.
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, int N>
-inline __SIGD::vector_type_t<Ty1, N1>
+inline __SEIEED::vector_type_t<Ty1, N1>
 __esimd_raw_send_load(uint8_t modifier, uint8_t execSize,
-                      __SIGD::vector_type_t<uint16_t, N> pred, uint8_t numSrc0,
-                      uint8_t numDst, uint8_t sfid, uint32_t exDesc,
-                      uint32_t msgDesc, __SIGD::vector_type_t<Ty2, N2> msgSrc0,
-                      __SIGD::vector_type_t<Ty1, N1> msgDst) {
+                      __SEIEED::vector_type_t<uint16_t, N> pred,
+                      uint8_t numSrc0, uint8_t numDst, uint8_t sfid,
+                      uint32_t exDesc, uint32_t msgDesc,
+                      __SEIEED::vector_type_t<Ty2, N2> msgSrc0,
+                      __SEIEED::vector_type_t<Ty1, N1> msgDst) {
   throw cl::sycl::feature_not_supported();
   return 0;
 }
@@ -1049,12 +1061,12 @@ __esimd_raw_send_load(uint8_t modifier, uint8_t execSize,
 ///
 template <typename Ty1, int N1, typename Ty2, int N2, int N>
 inline void __esimd_raw_sends_store(uint8_t modifier, uint8_t execSize,
-                                    __SIGD::vector_type_t<uint16_t, N> pred,
+                                    __SEIEED::vector_type_t<uint16_t, N> pred,
                                     uint8_t numSrc0, uint8_t numSrc1,
                                     uint8_t sfid, uint32_t exDesc,
                                     uint32_t msgDesc,
-                                    __SIGD::vector_type_t<Ty1, N1> msgSrc0,
-                                    __SIGD::vector_type_t<Ty2, N2> msgSrc1) {
+                                    __SEIEED::vector_type_t<Ty1, N1> msgSrc0,
+                                    __SEIEED::vector_type_t<Ty2, N2> msgSrc1) {
   throw cl::sycl::feature_not_supported();
 }
 
@@ -1079,13 +1091,14 @@ inline void __esimd_raw_sends_store(uint8_t modifier, uint8_t execSize,
 ///
 template <typename Ty1, int N1, int N>
 inline void __esimd_raw_send_store(uint8_t modifier, uint8_t execSize,
-                                   __SIGD::vector_type_t<uint16_t, N> pred,
+                                   __SEIEED::vector_type_t<uint16_t, N> pred,
                                    uint8_t numSrc0, uint8_t sfid,
                                    uint32_t exDesc, uint32_t msgDesc,
-                                   __SIGD::vector_type_t<Ty1, N1> msgSrc0) {
+                                   __SEIEED::vector_type_t<Ty1, N1> msgSrc0) {
   throw cl::sycl::feature_not_supported();
 }
 
 #endif // __SYCL_DEVICE_ONLY__
 
-#undef __SIGD
+#undef __SEIEED
+#undef __SEIEE

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_region.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_region.hpp
@@ -17,8 +17,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 
 // The common base type of region types.
 template <bool Is2D, typename T, int SizeY, int StrideY, int SizeX, int StrideX>
@@ -113,7 +115,9 @@ template <typename T, typename U> T getBaseRegion(std::pair<T, U> Reg) {
   return Reg.second;
 }
 
-} // namespace gpu
-} // namespace INTEL
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_sycl_util.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_sycl_util.hpp
@@ -15,8 +15,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 namespace detail {
 
 // Checks that given type is a SYCL accessor type. Sets its static field
@@ -80,7 +82,9 @@ using EnableIfAccessor = sycl::detail::enable_if_t<
     detail::is_sycl_accessor_with<T, Capability, AccessTarget>::value, RetT>;
 
 } // namespace detail
-} // namespace gpu
-} // namespace INTEL
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_types.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_types.hpp
@@ -19,8 +19,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 
 // simd and simd_view forward declarations
 template <typename Ty, int N> class simd;
@@ -31,7 +33,6 @@ namespace detail {
 namespace csd = cl::sycl::detail;
 
 using half = cl::sycl::detail::half_impl::StorageT;
-using namespace sycl::INTEL::gpu;
 
 template <typename T>
 using remove_cvref_t = csd::remove_cv_t<csd::remove_reference_t<T>>;
@@ -259,7 +260,9 @@ inline std::istream &operator>>(std::istream &I, half &rhs) {
 template <int N>
 using mask_type_t = typename detail::vector_type<uint16_t, N>::type;
 
-} // namespace gpu
-} // namespace INTEL
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_util.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/detail/esimd_util.hpp
@@ -15,8 +15,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 namespace detail {
 
 /// ESIMD intrinsic operand size in bytes.
@@ -76,12 +78,10 @@ static ESIMD_INLINE constexpr bool isPowerOf2(unsigned int n,
 template <typename T> struct is_esimd_vector {
   static const bool value = false;
 };
-template <typename T, int N>
-struct is_esimd_vector<sycl::INTEL::gpu::simd<T, N>> {
+template <typename T, int N> struct is_esimd_vector<simd<T, N>> {
   static const bool value = true;
 };
-template <typename T, int N>
-struct is_esimd_vector<sycl::INTEL::gpu::detail::vector_type<T, N>> {
+template <typename T, int N> struct is_esimd_vector<vector_type<T, N>> {
   static const bool value = true;
 };
 
@@ -98,13 +98,11 @@ struct is_dword_type
               std::is_same<unsigned int,
                            typename sycl::detail::remove_const_t<T>>::value> {};
 
-template <typename T, int N>
-struct is_dword_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
+template <typename T, int N> struct is_dword_type<vector_type<T, N>> {
   static const bool value = is_dword_type<T>::value;
 };
 
-template <typename T, int N>
-struct is_dword_type<sycl::INTEL::gpu::simd<T, N>> {
+template <typename T, int N> struct is_dword_type<simd<T, N>> {
   static const bool value = is_dword_type<T>::value;
 };
 
@@ -117,12 +115,11 @@ struct is_word_type
               std::is_same<unsigned short,
                            typename sycl::detail::remove_const_t<T>>::value> {};
 
-template <typename T, int N>
-struct is_word_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
+template <typename T, int N> struct is_word_type<vector_type<T, N>> {
   static const bool value = is_word_type<T>::value;
 };
 
-template <typename T, int N> struct is_word_type<sycl::INTEL::gpu::simd<T, N>> {
+template <typename T, int N> struct is_word_type<simd<T, N>> {
   static const bool value = is_word_type<T>::value;
 };
 
@@ -134,12 +131,11 @@ struct is_byte_type
               std::is_same<unsigned char,
                            typename sycl::detail::remove_const_t<T>>::value> {};
 
-template <typename T, int N>
-struct is_byte_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
+template <typename T, int N> struct is_byte_type<vector_type<T, N>> {
   static const bool value = is_byte_type<T>::value;
 };
 
-template <typename T, int N> struct is_byte_type<sycl::INTEL::gpu::simd<T, N>> {
+template <typename T, int N> struct is_byte_type<simd<T, N>> {
   static const bool value = is_byte_type<T>::value;
 };
 
@@ -177,34 +173,27 @@ struct is_qword_type
               std::is_same<unsigned long long,
                            typename sycl::detail::remove_const_t<T>>::value> {};
 
-template <typename T, int N>
-struct is_qword_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
+template <typename T, int N> struct is_qword_type<vector_type<T, N>> {
   static const bool value = is_qword_type<T>::value;
 };
 
-template <typename T, int N>
-struct is_qword_type<sycl::INTEL::gpu::simd<T, N>> {
+template <typename T, int N> struct is_qword_type<simd<T, N>> {
   static const bool value = is_qword_type<T>::value;
 };
 
 // Extends to ESIMD vector types.
-template <typename T, int N>
-struct is_fp_or_dword_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
+template <typename T, int N> struct is_fp_or_dword_type<vector_type<T, N>> {
   static const bool value = is_fp_or_dword_type<T>::value;
 };
 
-template <typename T, int N>
-struct is_fp_or_dword_type<sycl::INTEL::gpu::simd<T, N>> {
+template <typename T, int N> struct is_fp_or_dword_type<simd<T, N>> {
   static const bool value = is_fp_or_dword_type<T>::value;
 };
 
 /// Convert types into vector types
-template <typename T> struct simd_type {
-  using type = sycl::INTEL::gpu::simd<T, 1>;
-};
-template <typename T, int N>
-struct simd_type<sycl::INTEL::gpu::detail::vector_type<T, N>> {
-  using type = sycl::INTEL::gpu::simd<T, N>;
+template <typename T> struct simd_type { using type = simd<T, 1>; };
+template <typename T, int N> struct simd_type<vector_type<T, N>> {
+  using type = simd<T, N>;
 };
 
 template <typename T> struct simd_type<T &> {
@@ -236,7 +225,10 @@ template <> struct word_type<uchar> { using type = ushort; };
 template <> struct word_type<uint> { using type = ushort; };
 
 } // namespace detail
-} // namespace gpu
-} // namespace INTEL
+
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd.hpp
@@ -17,8 +17,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 
 /// The simd vector class.
 ///
@@ -625,15 +627,18 @@ ESIMD_INLINE
 #endif // __SYCL_DEVICE_ONLY__
 }
 
-} // namespace gpu
-} // namespace INTEL
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
 
 #ifndef __SYCL_DEVICE_ONLY__
 template <typename Ty, int N>
-std::ostream &operator<<(std::ostream &OS,
-                         const sycl::INTEL::gpu::simd<Ty, N> &V) {
+std::ostream &
+operator<<(std::ostream &OS,
+           const sycl::ext::intel::experimental::esimd::simd<Ty, N> &V) {
   OS << "{";
   for (int I = 0; I < N; I++) {
     OS << V[I];

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_enum.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_enum.hpp
@@ -15,8 +15,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 
 using uchar = unsigned char;
 using ushort = unsigned short;
@@ -116,8 +118,9 @@ enum class EsimdSbarrierType : uint8_t {
 #define ESIMD_SBARRIER_WAIT EsimdSbarrierType::WAIT
 #define ESIMD_SBARRIER_SIGNAL EsimdSbarrierType::SIGNAL
 
-} // namespace gpu
-
-} // namespace INTEL
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_math.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_math.hpp
@@ -19,8 +19,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 
 template <typename T0, typename T1, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE simd<T0, SZ> esimd_sat(simd<T1, SZ> src) {
@@ -1986,7 +1988,9 @@ simd<T, N> esimd_dp4(simd<T, N> v1, simd<T, N> v2) {
   return retv;
 }
 
-} // namespace gpu
-} // namespace INTEL
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_memory.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_memory.hpp
@@ -20,8 +20,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 
 // TODO @Pennycook
 // {quote}
@@ -249,8 +251,7 @@ ESIMD_INLINE ESIMD_NODEBUG
     gather(AccessorTy acc, simd<uint32_t, N> offsets,
            uint32_t glob_offset = 0) {
 
-  constexpr int TypeSizeLog2 =
-      sycl::INTEL::gpu::detail::ElemsPerAddrEncoding<sizeof(T)>();
+  constexpr int TypeSizeLog2 = detail::ElemsPerAddrEncoding<sizeof(T)>();
   // TODO (performance) use hardware-supported scale once BE supports it
   constexpr uint32_t scale = 0;
   constexpr uint32_t t_scale = sizeof(T);
@@ -275,7 +276,7 @@ ESIMD_INLINE ESIMD_NODEBUG
         __esimd_surf_read<PromoT, N, AccessorTy, TypeSizeLog2, L1H, L3H>(
             scale, acc, glob_offset, offsets);
 #endif
-    return sycl::INTEL::gpu::convert<T>(promo_vals);
+    return convert<T>(promo_vals);
   } else {
 #if defined(__SYCL_DEVICE_ONLY__)
     const auto surf_ind = detail::AccessorPrivateProxy::getNativeImageObj(acc);
@@ -317,8 +318,7 @@ ESIMD_INLINE ESIMD_NODEBUG
     scatter(AccessorTy acc, simd<T, N> vals, simd<uint32_t, N> offsets,
             uint32_t glob_offset = 0, simd<uint16_t, N> pred = 1) {
 
-  constexpr int TypeSizeLog2 =
-      sycl::INTEL::gpu::detail::ElemsPerAddrEncoding<sizeof(T)>();
+  constexpr int TypeSizeLog2 = detail::ElemsPerAddrEncoding<sizeof(T)>();
   // TODO (performance) use hardware-supported scale once BE supports it
   constexpr uint32_t scale = 0;
   constexpr uint32_t t_scale = sizeof(T);
@@ -333,7 +333,7 @@ ESIMD_INLINE ESIMD_NODEBUG
     using PromoT =
         typename sycl::detail::conditional_t<std::is_signed<T>::value, int32_t,
                                              uint32_t>;
-    const simd<PromoT, N> promo_vals = sycl::INTEL::gpu::convert<PromoT>(vals);
+    const simd<PromoT, N> promo_vals = convert<PromoT>(vals);
 #if defined(__SYCL_DEVICE_ONLY__)
     const auto surf_ind = detail::AccessorPrivateProxy::getNativeImageObj(acc);
     __esimd_surf_write<PromoT, N, decltype(surf_ind), TypeSizeLog2, L1H, L3H>(
@@ -994,7 +994,9 @@ esimd_raw_send_store(simd<T1, n1> msgSrc0, uint32_t exDesc, uint32_t msgDesc,
 }
 /// @}
 
-} // namespace gpu
-} // namespace INTEL
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/INTEL/esimd/esimd_view.hpp
+++ b/sycl/include/CL/sycl/INTEL/esimd/esimd_view.hpp
@@ -14,8 +14,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 
 /// The reference class.
 ///
@@ -443,7 +445,9 @@ private:
   RegionTy M_region;
 };
 
-} // namespace gpu
-} // namespace INTEL
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -203,19 +203,19 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 namespace detail {
 // Forward declare a "back-door" access class to support ESIMD.
 class AccessorPrivateProxy;
 } // namespace detail
-} // namespace gpu
-} // namespace INTEL
-} // namespace sycl
-} // __SYCL_INLINE_NAMESPACE(cl)
-
-__SYCL_INLINE_NAMESPACE(cl) {
-namespace sycl {
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 
 template <typename DataT, int Dimensions = 1,
           access::mode AccessMode = access::mode::read_write,
@@ -471,7 +471,8 @@ private:
 #endif
 
 private:
-  friend class sycl::INTEL::gpu::detail::AccessorPrivateProxy;
+  friend class sycl::ext::intel::experimental::esimd::detail::
+      AccessorPrivateProxy;
 
 #ifdef __SYCL_DEVICE_ONLY__
   const OCLImageTy getNativeImageObj() const { return MImageObj; }
@@ -928,7 +929,8 @@ public:
 #endif // __SYCL_DEVICE_ONLY__
 
 private:
-  friend class sycl::INTEL::gpu::detail::AccessorPrivateProxy;
+  friend class sycl::ext::intel::experimental::esimd::detail::
+      AccessorPrivateProxy;
 
 public:
   using value_type = DataT;

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -17,19 +17,20 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace INTEL {
-namespace gpu {
+
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 namespace detail {
 // Forward declare a "back-door" access class to support ESIMD.
 class AccessorPrivateProxy;
 } // namespace detail
-} // namespace gpu
-} // namespace INTEL
-} // namespace sycl
-} // __SYCL_INLINE_NAMESPACE(cl)
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 
-__SYCL_INLINE_NAMESPACE(cl) {
-namespace sycl {
 namespace detail {
 
 class Command;
@@ -163,7 +164,8 @@ protected:
   AccessorImplPtr impl;
 
 private:
-  friend class sycl::INTEL::gpu::detail::AccessorPrivateProxy;
+  friend class sycl::ext::intel::experimental::esimd::detail::
+      AccessorPrivateProxy;
 };
 
 class __SYCL_EXPORT LocalAccessorImplHost {

--- a/sycl/test/esimd/block_load_store.cpp
+++ b/sycl/test/esimd/block_load_store.cpp
@@ -13,21 +13,21 @@ SYCL_EXTERNAL void kernel1(
         &buf) SYCL_ESIMD_FUNCTION {
   simd<int, 32> v1(0, 1);
   // expected-warning@+2 {{deprecated}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd_memory.hpp:188 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd_memory.hpp:190 {{}}
   auto v0 = block_load<int, 32>(buf, 0);
   v0 = v0 + v1;
   // expected-warning@+2 {{deprecated}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd_memory.hpp:220 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd_memory.hpp:222 {{}}
   block_store<int, 32>(buf, 0, v0);
 }
 
 SYCL_EXTERNAL void kernel2(int *ptr) SYCL_ESIMD_FUNCTION {
   simd<int, 32> v1(0, 1);
   // expected-warning@+2 {{deprecated}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd_memory.hpp:169 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd_memory.hpp:171 {{}}
   auto v0 = block_load<int, 32>(ptr);
   v0 = v0 + v1;
   // expected-warning@+2 {{deprecated}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd_memory.hpp:201 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd_memory.hpp:203 {{}}
   block_store<int, 32>(ptr, v0);
 }

--- a/sycl/test/esimd/block_load_store.cpp
+++ b/sycl/test/esimd/block_load_store.cpp
@@ -5,7 +5,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace cl::sycl;
 
 SYCL_EXTERNAL void kernel1(

--- a/sycl/test/esimd/esimd-util-compiler-eval.cpp
+++ b/sycl/test/esimd/esimd-util-compiler-eval.cpp
@@ -4,12 +4,14 @@
 #include "CL/sycl.hpp"
 #include "CL/sycl/INTEL/esimd.hpp"
 
-static_assert(sycl::INTEL::gpu::detail::getNextPowerOf2<0>() == 0, "");
-static_assert(sycl::INTEL::gpu::detail::getNextPowerOf2<1>() == 1, "");
-static_assert(sycl::INTEL::gpu::detail::getNextPowerOf2<7>() == 8, "");
-static_assert(sycl::INTEL::gpu::detail::getNextPowerOf2<1024>() == 1024, "");
+using namespace sycl::ext::intel::experimental::esimd::detail;
 
-static_assert(sycl::INTEL::gpu::detail::log2<0>() == 0, "");
-static_assert(sycl::INTEL::gpu::detail::log2<1>() == 0, "");
-static_assert(sycl::INTEL::gpu::detail::log2<7>() == 2, "");
-static_assert(sycl::INTEL::gpu::detail::log2<1024 * 1024>() == 20, "");
+static_assert(getNextPowerOf2<0>() == 0, "");
+static_assert(getNextPowerOf2<1>() == 1, "");
+static_assert(getNextPowerOf2<7>() == 8, "");
+static_assert(getNextPowerOf2<1024>() == 1024, "");
+
+static_assert(log2<0>() == 0, "");
+static_assert(log2<1>() == 0, "");
+static_assert(log2<7>() == 2, "");
+static_assert(log2<1024 * 1024>() == 20, "");

--- a/sycl/test/esimd/esimd_math.cpp
+++ b/sycl/test/esimd/esimd_math.cpp
@@ -5,7 +5,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 
 bool test_esimd_mask() __attribute__((sycl_device)) {
   simd<ushort, 16> a(0);

--- a/sycl/test/esimd/flat_atomic.cpp
+++ b/sycl/test/esimd/flat_atomic.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace cl::sycl;
 
 void kernel0(accessor<uint32_t, 1, access::mode::read_write, access::target::global_buffer> &buf) __attribute__((sycl_device)) {

--- a/sycl/test/esimd/gather4_scatter4.cpp
+++ b/sycl/test/esimd/gather4_scatter4.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace cl::sycl;
 
 void kernel(accessor<int, 1, access::mode::read_write,

--- a/sycl/test/esimd/gather_scatter.cpp
+++ b/sycl/test/esimd/gather_scatter.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace cl::sycl;
 
 void kernel(accessor<int, 1, access::mode::read_write, access::target::global_buffer> &buf) __attribute__((sycl_device)) {

--- a/sycl/test/esimd/glob.cpp
+++ b/sycl/test/esimd/glob.cpp
@@ -10,7 +10,7 @@
 #include <CL/sycl/INTEL/esimd.hpp>
 #include <iostream>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 
 constexpr unsigned VL = 16;
 

--- a/sycl/test/esimd/intrins_trans.cpp
+++ b/sycl/test/esimd/intrins_trans.cpp
@@ -9,9 +9,10 @@
 #include <CL/sycl/INTEL/esimd.hpp>
 #include <CL/sycl/detail/image_ocl_types.hpp>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 
-ESIMD_PRIVATE sycl::INTEL::gpu::detail::vector_type_t<int, 32> vc;
+ESIMD_PRIVATE
+detail::vector_type_t<int, 32> vc;
 ESIMD_PRIVATE ESIMD_REGISTER(192) simd<int, 16> vg;
 
 SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo();
@@ -109,8 +110,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
   // CHECK: %[[SI2:[0-9a-zA-Z_.]+]] = ptrtoint %opencl.image2d_wo_t addrspace(1)* %{{[0-9a-zA-Z_.]+}} to i32
   // CHECK: call void @llvm.genx.media.st.v32i32(i32 0, i32 %[[SI2]], i32 0, i32 32, i32 %{{[0-9a-zA-Z_.]+}}, i32 %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}})
 
-  auto ee = __esimd_vload<int, 16>(
-      (sycl::INTEL::gpu::detail::vector_type_t<int, 16> *)(&vg));
+  auto ee = __esimd_vload<int, 16>((detail::vector_type_t<int, 16> *)(&vg));
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x i32> @llvm.genx.vload.v16i32.p0v16i32(<16 x i32>* {{.*}})
   __esimd_vstore<int, 32>(&vc, va.data());
   // CHECK: store <32 x i32>  %{{[0-9a-zA-Z_.]+}}, <32 x i32> addrspace(4)* {{.*}}

--- a/sycl/test/esimd/odr.cpp
+++ b/sycl/test/esimd/odr.cpp
@@ -16,7 +16,7 @@
 #include <iostream>
 
 using namespace cl::sycl;
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 
 #define VLEN 8
 

--- a/sycl/test/esimd/simd.cpp
+++ b/sycl/test/esimd/simd.cpp
@@ -5,7 +5,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 
 bool test_simd_ctors() __attribute__((sycl_device)) {
   simd<int, 16> v0 = 1;

--- a/sycl/test/esimd/simd_copy_to_copy_from.cpp
+++ b/sycl/test/esimd/simd_copy_to_copy_from.cpp
@@ -10,7 +10,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace cl::sycl;
 
 // --- Postive tests.
@@ -42,13 +42,13 @@ kernel3(accessor<int, 1, access::mode::read_write, access::target::local> &buf)
   simd<int, 32> v1(0, 1);
   simd<int, 32> v0;
   // expected-error@+3 {{no matching member function for call to 'copy_from'}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:514 {{}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:509 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:499 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:511 {{}}
   v0.copy_from(buf, 0);
   v0 = v0 + v1;
   // expected-error@+3 {{no matching member function for call to 'copy_to'}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:497 {{}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:525 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:516 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:527 {{}}
   v0.copy_to(buf, 0);
 }
 
@@ -58,8 +58,8 @@ SYCL_EXTERNAL void kernel4(
     SYCL_ESIMD_FUNCTION {
   simd<int, 32> v;
   // expected-error@+3 {{no matching member function for call to 'copy_from'}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:514 {{}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:509 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:499 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:511 {{}}
   v.copy_from(buf, 0);
 }
 
@@ -69,7 +69,7 @@ SYCL_EXTERNAL void kernel5(
     SYCL_ESIMD_FUNCTION {
   simd<int, 32> v(0, 1);
   // expected-error@+3 {{no matching member function for call to 'copy_to'}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:497 {{}}
-  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:525 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:516 {{}}
+  // expected-note@CL/sycl/INTEL/esimd/esimd.hpp:527 {{}}
   v.copy_to(buf, 0);
 }

--- a/sycl/test/esimd/simd_merge.cpp
+++ b/sycl/test/esimd/simd_merge.cpp
@@ -5,7 +5,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 
 bool test_simd_merge1() __attribute__((sycl_device)) {
   simd<int, 16> v0 = 1;

--- a/sycl/test/esimd/simd_view.cpp
+++ b/sycl/test/esimd/simd_view.cpp
@@ -5,7 +5,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 
 bool test_simd_view_bin_ops() __attribute__((sycl_device)) {
   simd<int, 16> v0 = 1;

--- a/sycl/test/esimd/slm_atomic.cpp
+++ b/sycl/test/esimd/slm_atomic.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace cl::sycl;
 
 void kernel0() __attribute__((sycl_device)) {

--- a/sycl/test/esimd/slm_block.cpp
+++ b/sycl/test/esimd/slm_block.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace cl::sycl;
 
 void kernel() __attribute__((sycl_device)) {

--- a/sycl/test/esimd/slm_load.cpp
+++ b/sycl/test/esimd/slm_load.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace cl::sycl;
 
 void kernel() __attribute__((sycl_device)) {

--- a/sycl/test/esimd/slm_load4.cpp
+++ b/sycl/test/esimd/slm_load4.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 #include <utility>
 
-using namespace sycl::INTEL::gpu;
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace cl::sycl;
 
 template <typename name, typename Func>

--- a/sycl/test/esimd/vadd.cpp
+++ b/sycl/test/esimd/vadd.cpp
@@ -80,7 +80,7 @@ int main(void) {
 
       cgh.parallel_for<class Test>(
           Range, [=](nd_item<1> ndi) SYCL_ESIMD_KERNEL {
-            using namespace sycl::INTEL::gpu;
+            using namespace sycl::ext::intel::experimental::esimd;
             auto pA = accA.get_pointer().get();
             auto pB = accB.get_pointer().get();
             auto pC = accC.get_pointer().get();


### PR DESCRIPTION
This makes the ESIMD extension namespace conforming to the SYCL2020 spec.
Necessary file renames will be done as a separate commit.

Changes to the llvm-test-suite are underway

Signed-off-by: kbobrovs <Konstantin.S.Bobrovsky@intel.com>