### PR TITLE
[SYCL][Matrix] Delete aliases for local convenience in joint_matrix API

### DIFF
--- a/sycl/include/CL/sycl/ONEAPI/matrix/matrix-amx.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/matrix/matrix-amx.hpp
@@ -64,9 +64,6 @@ ELEMS_PER_DWORD(unsigned short, 2)
 } // namespace detail
 
 namespace experimental::matrix {
-using namespace cl::sycl;
-using namespace cl::sycl::ONEAPI;
-
 #ifdef __SYCL_DEVICE_ONLY__
 SYCL_EXTERNAL extern "C" _tile1024i
 _tileloadd64_internal(short row, short col, char *buf, size_t stride);

--- a/sycl/test/matrix/matrix-amx-bf16-test.cpp
+++ b/sycl/test/matrix/matrix-amx-bf16-test.cpp
@@ -3,6 +3,7 @@
 #if (SYCL_EXT_ONEAPI_MATRIX == 1)
 #include <iostream>
 
+using namespace sycl;
 using namespace sycl::intel;
 using namespace sycl::ext::intel::experimental::matrix;
 

--- a/sycl/test/matrix/matrix-amx-int8-test.cpp
+++ b/sycl/test/matrix/matrix-amx-int8-test.cpp
@@ -3,6 +3,7 @@
 #if (SYCL_EXT_ONEAPI_MATRIX == 1)
 #include <iostream>
 
+using namespace sycl;
 using namespace sycl::intel;
 using namespace sycl::ext::intel::experimental::matrix;
 


### PR DESCRIPTION
https://google.github.io/styleguide/cppguide.html#Aliases said "Don't put an alias in your public API just to save typing in the implementation; do so only if you intend it to be used by your clients." So I delete aliases for local convenience in joint_matrix API.