### PR TITLE
[SYCL] Add the notion of a "default" -cc1 SYCL mode.

### DIFF
--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -131,6 +131,9 @@ public:
     SYCL_None,
     SYCL_2017,
     SYCL_2020,
+    // The "default" SYCL version to be used when none is specified on the
+    // frontend command line.
+    SYCL_Default = SYCL_2020
   };
 
   enum class SYCLVersionList {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3618,25 +3618,6 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
       LangStd = OpenCLLangStd;
   }
 
-  if (Args.hasArg(OPT_fsycl_is_device) || Args.hasArg(OPT_fsycl_is_host)) {
-    // -sycl-std applies to any SYCL source, not only those containing kernels,
-    // but also those using the SYCL API
-    if (const Arg *A = Args.getLastArg(OPT_sycl_std_EQ)) {
-      Opts.setSYCLVersion(
-          llvm::StringSwitch<LangOptions::SYCLMajorVersion>(A->getValue())
-              .Cases("2017", "1.2.1", "121", "sycl-1.2.1",
-                     LangOptions::SYCL_2017)
-              .Case("2020", LangOptions::SYCL_2020)
-              .Default(LangOptions::SYCL_None));
-
-      if (Opts.getSYCLVersion() == LangOptions::SYCL_None) {
-        // User has passed an invalid value to the flag, this is an error
-        Diags.Report(diag::err_drv_invalid_value)
-            << A->getAsString(Args) << A->getValue();
-      }
-    }
-  }
-
   // Parse SYCL Default Sub group size.
   if (const Arg *A = Args.getLastArg(OPT_fsycl_default_sub_group_size)) {
     StringRef Value = A->getValue();
@@ -3685,6 +3666,16 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
     if (Name == "full" || Name == "branch") {
       Opts.CFProtectionBranch = 1;
     }
+  }
+
+  if ((Args.hasArg(OPT_fsycl_is_device) || Args.hasArg(OPT_fsycl_is_host)) &&
+      !Args.hasArg(OPT_sycl_std_EQ)) {
+    // If the user supplied -fsycl-is-device or -fsycl-is-host, but failed to
+    // provide -sycl-std=, we want to default it to whatever the default SYCL
+    // version is. I could not find a way to express this with the options
+    // tablegen because we still want this value to be SYCL_None when the user
+    // is not in device or host mode.
+    Opts.setSYCLVersion(LangOptions::SYCL_Default);
   }
 
   if (Opts.ObjC) {

--- a/clang/test/SemaSYCL/check-notdirect-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/check-notdirect-attribute-propagation.cpp
@@ -26,7 +26,7 @@ func_three() {
 #endif
 
 template <typename Name, typename Type>
-[[clang::sycl_kernel]] void __my_kernel__(Type bar) {
+[[clang::sycl_kernel]] void __my_kernel__(Type &&bar) {
   bar();
 #ifndef TRIGGER_ERROR
   func_one();

--- a/clang/test/SemaSYCL/kernel-attribute.cpp
+++ b/clang/test/SemaSYCL/kernel-attribute.cpp
@@ -50,13 +50,13 @@ template <typename T, typename A, int I>
 // No diagnostics
 template <typename Func>
 void __attribute__((sycl_kernel))
-KernelImpl4(Func f, int i, double d) {
+KernelImpl4(Func &&f, int i, double d) {
   f(i, d);
 }
 
 template <typename Name, typename Func>
 void __attribute__((sycl_kernel))
-Kernel(Func f) {
+Kernel(Func &&f) {
   KernelImpl4(f, 1, 2.0);
 }
 

--- a/clang/test/SemaSYCL/long-double.cpp
+++ b/clang/test/SemaSYCL/long-double.cpp
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -triple spir64 -aux-triple x86_64-linux-gnu -fsycl-is-device -fsyntax-only -mlong-double-64 %s
 
 template <typename Name, typename Func>
-__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void kernel(Func &&kernelFunc) {
   // expected-note@+1 {{called by 'kernel<variables}}
   kernelFunc();
 }

--- a/clang/test/SemaSYCL/union-kernel-param-neg.cpp
+++ b/clang/test/SemaSYCL/union-kernel-param-neg.cpp
@@ -12,7 +12,7 @@ union union_with_sampler {
 };
 
 template <typename name, typename Func>
-__attribute__((sycl_kernel)) void a_kernel(Func kernelFunc) {
+__attribute__((sycl_kernel)) void a_kernel(Func &&kernelFunc) {
   kernelFunc();
 }
 

--- a/clang/unittests/Frontend/CompilerInvocationTest.cpp
+++ b/clang/unittests/Frontend/CompilerInvocationTest.cpp
@@ -566,18 +566,34 @@ TEST_F(CommandLineTest, ConditionalParsingIfFalseFlagPresent) {
   ASSERT_THAT(GeneratedArgs, Not(Contains(HasSubstr("-sycl-std="))));
 }
 
-TEST_F(CommandLineTest, ConditionalParsingIfTrueFlagNotPresent) {
+TEST_F(CommandLineTest, ConditionalParsingIfTrueFlagNotPresentHost) {
   const char *Args[] = {"-fsycl-is-host"};
 
   CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags);
 
   ASSERT_FALSE(Diags->hasErrorOccurred());
-  ASSERT_EQ(Invocation.getLangOpts()->getSYCLVersion(), LangOptions::SYCL_None);
+  ASSERT_EQ(Invocation.getLangOpts()->getSYCLVersion(),
+            LangOptions::SYCL_Default);
 
   Invocation.generateCC1CommandLine(GeneratedArgs, *this);
 
   ASSERT_THAT(GeneratedArgs, Contains(StrEq("-fsycl-is-host")));
-  ASSERT_THAT(GeneratedArgs, Not(Contains(HasSubstr("-sycl-std="))));
+  ASSERT_THAT(GeneratedArgs, Contains(HasSubstr("-sycl-std=")));
+}
+
+TEST_F(CommandLineTest, ConditionalParsingIfTrueFlagNotPresentDevice) {
+  const char *Args[] = {"-fsycl-is-device"};
+
+  CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags);
+
+  ASSERT_FALSE(Diags->hasErrorOccurred());
+  ASSERT_EQ(Invocation.getLangOpts()->getSYCLVersion(),
+            LangOptions::SYCL_Default);
+
+  Invocation.generateCC1CommandLine(GeneratedArgs, *this);
+
+  ASSERT_THAT(GeneratedArgs, Contains(StrEq("-fsycl-is-device")));
+  ASSERT_THAT(GeneratedArgs, Contains(HasSubstr("-sycl-std=")));
 }
 
 TEST_F(CommandLineTest, ConditionalParsingIfTrueFlagPresent) {


### PR DESCRIPTION
This defaults to SYCL 2020 currently, but makes it easier to change to
a new default later. This default kicks in only in -cc1 mode when the
user specifies -fsycl-is-device or -fsycl-is-host but does not pass
-sycl-std= to the invocation. This does not impact the driver behavior.