### PR TITLE
[Driver][SYCL] Imply -fPIC compilation for wrapped object when using …

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8294,7 +8294,7 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     bool IsPIE;
     std::tie(RelocationModel, PICLevel, IsPIE) =
         ParsePICArgs(getToolChain(), TCArgs);
-    if (PICLevel > 0) {
+    if (PICLevel > 0 || TCArgs.hasArg(options::OPT_shared)) {
       LlcArgs.push_back("-relocation-model=pic");
     }
     if (IsPIE) {

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -31,3 +31,10 @@
 // CHECK_COVERAGE_MAPPING: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-fprofile-instrument=clang"
 // CHECK_COVERAGE_MAPPING-NOT: "-fcoverage-mapping"
 // CHECK_COVERAGE_MAPPING: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu"{{.*}} "-fsycl-is-host"{{.*}} "-fprofile-instrument=clang"{{.*}} "-fcoverage-mapping"{{.*}}
+
+/// check for PIC for device wrap compilation when using -shared or -fPIC
+// RUN: %clangxx -### -fsycl -target x86_64-unknown-linux-gnu -shared %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK_SHARED %s
+// RUN: %clangxx -### -fsycl -target x86_64-unknown-linux-gnu -fPIC %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK_SHARED %s
+// CHECK_SHARED: llc{{.*}} "-relocation-model=pic"


### PR DESCRIPTION
…-shared

Imply -fPIC when generating the wrapped object when using -shared.  This
reduces confusion if -fPIC is not used when performing the 'link' step
using -fsycl as the additional object is created by us, and not by
a previous compilation done by the user with -fPIC.