### PR TITLE
[SYCL][opencl-aot] Workaround for build with clang

### DIFF
--- a/opencl/opencl-aot/CMakeLists.txt
+++ b/opencl/opencl-aot/CMakeLists.txt
@@ -12,6 +12,11 @@ set(OPENCL_AOT_PROJECT_NAME opencl-aot)
 
 add_llvm_tool(${OPENCL_AOT_PROJECT_NAME} ${TARGET_SOURCES})
 
+if(NOT MSVC)
+  # FIXME: when built with clang it produces a warning.
+  target_compile_options(${OPENCL_AOT_PROJECT_NAME} PRIVATE "-Wno-unused-parameter")
+endif()
+
 target_link_libraries(${OPENCL_AOT_PROJECT_NAME}
   PRIVATE
     OpenCL-Headers


### PR DESCRIPTION
Issue has been introduced in PR#3670.
This is hot fix to resolve post-commit issue. When opencl-aot is included from
sycl project, warnings enforcements got propagated to this.
g++ works clean, but clang produces -Wunused-parameter in llvm headers.

Signed-off-by: Pavel V Chupin <pavel.v.chupin@intel.com>