### PR TITLE
[SYCL] Ensure the deferred diagnostics correctly handles discarded stmts

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -2080,7 +2080,7 @@ public:
   /// If this is an 'if constexpr', determine which substatement will be taken.
   /// Otherwise, or if the condition is value-dependent, returns None.
   Optional<const Stmt*> getNondiscardedCase(const ASTContext &Ctx) const;
-  Optional<Stmt*> getNondiscardedCase(const ASTContext &Ctx);
+  Optional<Stmt *> getNondiscardedCase(const ASTContext &Ctx);
 
   bool isObjCAvailabilityCheck() const;
 

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -2080,6 +2080,7 @@ public:
   /// If this is an 'if constexpr', determine which substatement will be taken.
   /// Otherwise, or if the condition is value-dependent, returns None.
   Optional<const Stmt*> getNondiscardedCase(const ASTContext &Ctx) const;
+  Optional<Stmt*> getNondiscardedCase(const ASTContext &Ctx);
 
   bool isObjCAvailabilityCheck() const;
 

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -990,9 +990,11 @@ bool IfStmt::isObjCAvailabilityCheck() const {
 }
 
 Optional<const Stmt*> IfStmt::getNondiscardedCase(const ASTContext &Ctx) const {
-  if (!isConstexpr() || getCond()->isValueDependent())
-    return None;
-  return !getCond()->EvaluateKnownConstInt(Ctx) ? getElse() : getThen();
+  Optional<Stmt *> Result =
+      const_cast<IfStmt *>(this)->getNondiscardedCase(Ctx);
+  if (Result.hasValue())
+    return {*Result};
+  return None;
 }
 
 Optional<Stmt *> IfStmt::getNondiscardedCase(const ASTContext &Ctx) {

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -994,7 +994,8 @@ Optional<const Stmt*> IfStmt::getNondiscardedCase(const ASTContext &Ctx) const {
     return None;
   return !getCond()->EvaluateKnownConstInt(Ctx) ? getElse() : getThen();
 }
-Optional<Stmt*> IfStmt::getNondiscardedCase(const ASTContext &Ctx) {
+
+Optional<Stmt *> IfStmt::getNondiscardedCase(const ASTContext &Ctx) {
   if (!isConstexpr() || getCond()->isValueDependent())
     return None;
   return !getCond()->EvaluateKnownConstInt(Ctx) ? getElse() : getThen();

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -990,10 +990,9 @@ bool IfStmt::isObjCAvailabilityCheck() const {
 }
 
 Optional<const Stmt*> IfStmt::getNondiscardedCase(const ASTContext &Ctx) const {
-  Optional<Stmt *> Result =
-      const_cast<IfStmt *>(this)->getNondiscardedCase(Ctx);
-  if (Result.hasValue())
-    return {*Result};
+  if (Optional<Stmt *> Result =
+          const_cast<IfStmt *>(this)->getNondiscardedCase(Ctx))
+    return *Result;
   return None;
 }
 

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -994,6 +994,11 @@ Optional<const Stmt*> IfStmt::getNondiscardedCase(const ASTContext &Ctx) const {
     return None;
   return !getCond()->EvaluateKnownConstInt(Ctx) ? getElse() : getThen();
 }
+Optional<Stmt*> IfStmt::getNondiscardedCase(const ASTContext &Ctx) {
+  if (!isConstexpr() || getCond()->isValueDependent())
+    return None;
+  return !getCond()->EvaluateKnownConstInt(Ctx) ? getElse() : getThen();
+}
 
 ForStmt::ForStmt(const ASTContext &C, Stmt *Init, Expr *Cond, VarDecl *condVar,
                  Expr *Inc, Stmt *Body, SourceLocation FL, SourceLocation LP,

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1687,7 +1687,7 @@ public:
   }
 
   void VisitIfStmt(IfStmt *If) {
-    if (Optional<Stmt*> SubStmt = If->getNondiscardedCase(S.Context)) {
+    if (Optional<Stmt *> SubStmt = If->getNondiscardedCase(S.Context)) {
       if (*SubStmt)
         this->Visit(*SubStmt);
     } else {

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1686,6 +1686,15 @@ public:
     InUsePath.erase(FD);
   }
 
+  void VisitIfStmt(IfStmt *If) {
+    if (Optional<Stmt*> SubStmt = If->getNondiscardedCase(S.Context)) {
+      if (*SubStmt)
+        this->Visit(*SubStmt);
+    } else {
+      this->VisitStmt(If);
+    }
+  }
+
   void checkRecordedDecl(Decl *D) {
     if (auto *FD = dyn_cast<FunctionDecl>(D)) {
       ShouldEmitRootNode = S.getEmissionStatus(FD, /*Final=*/true) ==

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1691,7 +1691,7 @@ public:
       if (*SubStmt)
         this->Visit(*SubStmt);
     } else {
-      this->VisitStmt(If);
+      Inherited::VisitStmt(If);
     }
   }
 

--- a/clang/test/SemaSYCL/call-to-undefined-function.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function.cpp
@@ -7,8 +7,7 @@ sycl::queue deviceQueue;
 void defined() {
 }
 
-void undefined();
-// expected-note@-1 {{'undefined' declared here}}
+void undefined(); // #UNDEFINED
 
 SYCL_EXTERNAL void undefinedExternal();
 
@@ -98,21 +97,22 @@ int main() {
   undefined();
 
   deviceQueue.submit([&](sycl::handler &h) {
-    h.single_task<class CallToUndefinedFnTester>([]() {
-      // expected-note@-1 {{called by 'operator()'}}
-      // expected-note@-2 {{called by 'operator()'}}
+    h.single_task<class CallToUndefinedFnTester>([]() { // #CALLOP
 
       // simple functions
       defined();
       undefinedExternal();
       undefined();
       // expected-error@-1 {{SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute}}
+      // expected-note@#UNDEFINED {{'undefined' declared here}}
+      // expected-note@#CALLOP {{called by 'operator()'}}
 
       // templated functions
       definedTpl<int>();
       undefinedExternalTpl<int>();
       undefinedTpl<int>();
       // expected-error@-1 {{SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute}}
+      // expected-note@#CALLOP {{called by 'operator()'}}
 
       // partially specialized template function
       definedPartialTpl<int, false>();
@@ -169,8 +169,11 @@ int main() {
       forwardDeclFn();
       forwardDeclFn2();
 
+      // expected-warning@+1 {{constexpr if is a C++17 extension}}
       if constexpr (true) {
-        // expected-error@+1 {{SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute}}
+        // expected-error@+3 {{SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute}}
+        // expected-note@#CALLOP {{called by 'operator()'}}
+        // expected-note@#UNDEFINED {{'undefined' declared here}}
         undefined();
       } else {
         // Should not diagnose.
@@ -178,6 +181,7 @@ int main() {
       }
 
       // Similar to the one above, just make sure the active branch being empty changes nothing.
+      // expected-warning@+1 {{constexpr if is a C++17 extension}}
       if constexpr (true) {
       } else {
         // Should not diagnose.
@@ -185,6 +189,7 @@ int main() {
       }
 
       // Tests that an active 'else'  where 'else' doesn't exist won't crash.
+      // expected-warning@+1 {{constexpr if is a C++17 extension}}
       if constexpr (false) {
         // Should not diagnose.
         undefined();

--- a/clang/test/SemaSYCL/call-to-undefined-function.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function.cpp
@@ -188,7 +188,7 @@ int main() {
         undefined();
       }
 
-      // Tests that an active 'else'  where 'else' doesn't exist won't crash.
+      // Tests that an active 'else' where 'else' doesn't exist won't crash.
       // expected-warning@+1 {{constexpr if is a C++17 extension}}
       if constexpr (false) {
         // Should not diagnose.

--- a/clang/test/SemaSYCL/call-to-undefined-function.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function.cpp
@@ -79,6 +79,9 @@ struct TplWithTplMethod2<T, true> {
   }
 };
 
+template <typename T>
+void defined_only_in_discarded_stmt(){}
+
 void forwardDeclFn();
 void forwardDeclFn2();
 
@@ -165,6 +168,28 @@ int main() {
       useFwDeclFn();
       forwardDeclFn();
       forwardDeclFn2();
+
+      if constexpr (true) {
+        // expected-error@+1 {{SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute}}
+        undefined();
+      } else {
+        // Should not diagnose.
+        undefined();
+      }
+
+      // Similar to the one above, just make sure the active branch being empty changes nothing.
+      if constexpr (true) {
+      } else {
+        // Should not diagnose.
+        undefined();
+      }
+
+      // Tests that an active 'else'  where 'else' doesn't exist won't crash.
+      if constexpr (false) {
+        // Should not diagnose.
+        undefined();
+        defined_only_in_discarded_stmt<int>();
+      }
     });
   });
 }


### PR DESCRIPTION
The deferred diagnostic 'checkFunc' handling uses the StmtVisitor to
check through all the calls. This inadvertently ends up diagnosing
discarded statements (that is, the inactive branch of the constexpr-if).
This patch adds a handler to only visit the active side.

We don't have to worry about visiting the conditional(that is, the
'rest' of the children) because we don't care about actions that happen
in the constant-expression, things that happen in a constexpr context
are typically allowed.