### PR TITLE
[SYCL] Don't diagnose checks in a discarded statement.

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -2080,6 +2080,7 @@ public:
   /// If this is an 'if constexpr', determine which substatement will be taken.
   /// Otherwise, or if the condition is value-dependent, returns None.
   Optional<const Stmt*> getNondiscardedCase(const ASTContext &Ctx) const;
+  Optional<Stmt *> getNondiscardedCase(const ASTContext &Ctx);
 
   bool isObjCAvailabilityCheck() const;
 

--- a/clang/include/clang/Analysis/CallGraph.h
+++ b/clang/include/clang/Analysis/CallGraph.h
@@ -29,6 +29,7 @@
 
 namespace clang {
 
+class ASTContext;
 class CallGraphNode;
 class Decl;
 class DeclContext;
@@ -51,6 +52,12 @@ class CallGraph : public RecursiveASTVisitor<CallGraph> {
   /// This is a virtual root node that has edges to all the functions.
   CallGraphNode *Root;
 
+  /// A setting to determine whether this should include calls that are done in
+  /// a constant expression's context. This DOES require the ASTContext object
+  /// for constexpr-if, so setting it requires a valid ASTContext.
+  bool shouldSkipConstexpr = false;
+  ASTContext *Ctx;
+
 public:
   CallGraph();
   ~CallGraph();
@@ -66,7 +73,7 @@ public:
   /// Determine if a declaration should be included in the graph.
   static bool includeInGraph(const Decl *D);
 
-  /// Determine if a declaration should be included in the graph for the 
+  /// Determine if a declaration should be included in the graph for the
   /// purposes of being a callee. This is similar to includeInGraph except
   /// it permits declarations, not just definitions.
   static bool includeCalleeInGraph(const Decl *D);
@@ -138,6 +145,16 @@ public:
   bool shouldWalkTypesOfTypeLocs() const { return false; }
   bool shouldVisitTemplateInstantiations() const { return true; }
   bool shouldVisitImplicitCode() const { return true; }
+  bool shouldVisitConstantExpressions() const { return false; }
+  bool shouldSkipConstantExpressions() const { return shouldSkipConstexpr; }
+  void setSkipConstantExpressions(ASTContext &Context) {
+    Ctx = &Context;
+    shouldSkipConstexpr = true;
+  }
+  ASTContext &getASTContext() {
+    assert(Ctx);
+    return *Ctx;
+  }
 
 private:
   /// Add the given declaration to the call graph.

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -995,6 +995,12 @@ Optional<const Stmt*> IfStmt::getNondiscardedCase(const ASTContext &Ctx) const {
   return !getCond()->EvaluateKnownConstInt(Ctx) ? getElse() : getThen();
 }
 
+Optional<Stmt *> IfStmt::getNondiscardedCase(const ASTContext &Ctx) {
+  if (!isConstexpr() || getCond()->isValueDependent())
+    return None;
+  return !getCond()->EvaluateKnownConstInt(Ctx) ? getElse() : getThen();
+}
+
 ForStmt::ForStmt(const ASTContext &C, Stmt *Init, Expr *Cond, VarDecl *condVar,
                  Expr *Inc, Stmt *Body, SourceLocation FL, SourceLocation LP,
                  SourceLocation RP)

--- a/clang/lib/Analysis/CallGraph.cpp
+++ b/clang/lib/Analysis/CallGraph.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Analysis/CallGraph.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclObjC.h"
@@ -134,6 +135,19 @@ public:
         NumObjCCallEdges++;
       }
     }
+  }
+
+  void VisitIfStmt(IfStmt *If) {
+    if (G->shouldSkipConstantExpressions()) {
+      if (llvm::Optional<Stmt *> ActiveStmt =
+              If->getNondiscardedCase(G->getASTContext())) {
+        if (*ActiveStmt)
+          this->Visit(*ActiveStmt);
+        return;
+      }
+    }
+
+    VisitChildren(If);
   }
 
   void VisitChildren(Stmt *S) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -548,6 +548,7 @@ class DeviceFunctionTracker {
 
 public:
   DeviceFunctionTracker(Sema &S) : SemaRef(S) {
+    CG.setSkipConstantExpressions(S.Context);
     CG.addToCallGraph(S.getASTContext().getTranslationUnitDecl());
     CollectSyclExternalFuncs();
   }


### PR DESCRIPTION
For the checks we do in SemaSYCL via the callgraph, we don't want to
diagnose when it is in a discarded statement. This adds the
infrastructure for another bug, where we visit constexpr during this
too.

Note this is a 'draft' since I don't find myself with the time to implement the "rest" of this (tests + all the rest of the constexpr stuff).  I believe @elizabethandrews was assigned the constexpr-call bug after @mibintc  gave up on it  ( :D), so this might be of interest to her!

The change to the CallGraph.cpp (CGBuilder) should be all that is necessary, we simply have to implement the 'visit' functions for every situation we can come up with for constant-evaluation.  I believe the ill-planned ConstexprRAII (which likely needs removing once we fix this?) has at least most of the list implemented, so that should be at least a head start.