### PR TITLE
[SYCL] Fix check-clang dependencies

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -73,6 +73,8 @@ list(APPEND CLANG_TEST_DEPS
   clang-scan-deps
   diagtool
   hmaptool
+  libsycldevice
+  sycl-post-link
   )
   
 if(CLANG_ENABLE_STATIC_ANALYZER)


### PR DESCRIPTION
 - sycl-post-link is required by:
     Clang :: CodeGenSYCL/esimd-accessor-ptr-md.cpp
     Clang :: CodeGenSYCL/esimd-private-global.cpp
 - libdevicelib is needed by:
     Clang :: Driver/sycl-device-lib.cpp