### PR TITLE
[SYCL] [FPGA] Fix num_simd_work_items and reqd_work_group_size argument check 

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2944,6 +2944,9 @@ def ReqdWorkGroupSize : InheritableAttr {
               ExprArgument<"YDim", /*optional*/1>,
               ExprArgument<"ZDim", /*optional*/1>];
   let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Accessors = [Accessor<"usesOpenCLArgOrdering",
+                   [GNU<"reqd_work_group_size">,
+                    CXX11<"cl","reqd_work_group_size">]>];
   let AdditionalMembers = [{
     ArrayRef<const Expr *> dimensions() const {
       return {getXDim(), getYDim(), getZDim()};

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2944,7 +2944,7 @@ def ReqdWorkGroupSize : InheritableAttr {
               ExprArgument<"YDim", /*optional*/1>,
               ExprArgument<"ZDim", /*optional*/1>];
   let Subjects = SubjectList<[Function], ErrorDiag>;
-  let Accessors = [Accessor<"usesOpenCLArgOrdering",
+  let Accessors = [Accessor<"usesOpenCLSemantics",
                    [GNU<"reqd_work_group_size">]>];
   let AdditionalMembers = [{
     ArrayRef<const Expr *> dimensions() const {

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2944,8 +2944,6 @@ def ReqdWorkGroupSize : InheritableAttr {
               ExprArgument<"YDim", /*optional*/1>,
               ExprArgument<"ZDim", /*optional*/1>];
   let Subjects = SubjectList<[Function], ErrorDiag>;
-  let Accessors = [Accessor<"usesOpenCLSemantics",
-                   [GNU<"reqd_work_group_size">]>];
   let AdditionalMembers = [{
     ArrayRef<const Expr *> dimensions() const {
       return {getXDim(), getYDim(), getZDim()};

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2945,8 +2945,7 @@ def ReqdWorkGroupSize : InheritableAttr {
               ExprArgument<"ZDim", /*optional*/1>];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Accessors = [Accessor<"usesOpenCLArgOrdering",
-                   [GNU<"reqd_work_group_size">,
-                    CXX11<"cl","reqd_work_group_size">]>];
+                   [GNU<"reqd_work_group_size">]>];
   let AdditionalMembers = [{
     ArrayRef<const Expr *> dimensions() const {
       return {getXDim(), getYDim(), getZDim()};

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2503,6 +2503,69 @@ device kernel, the attribute is not ignored and it is propagated to the kernel.
     [[intel::num_simd_work_items(N)]] void operator()() const {}
   };
 
+The arguments to reqd_work_group_size are ordered based on which index
+increments the fastest. In OpenCL, the first argument is the index that
+increments the fastest, and in SYCL, the last argument is the index that
+increments the fastest.
+
+In OpenCL, all three arguments are required.
+
+In SYCL, the attribute accepts either one, two, or three arguments; in each
+form, the last (or only) argument is the index that increments fastest.
+The number of arguments passed to the attribute must match the dimensionality
+of the kernel the attribute is applied to.
+
+If the reqd_work_group_size attribute is specified on a declaration along
+with ``intel::num_simd_work_items``, the required work group size specified
+by ``intel::num_simd_work_items`` attribute must evenly divide the index that
+increments fastest in the reqd_work_group_size attribute.
+
+.. code-block:: c++
+
+  struct func {
+    [[intel::num_simd_work_items(4)]]
+    [[intel::reqd_work_group_size(3, 4, 64)]]
+    void operator()() const {}
+  };
+
+  struct bar {
+    [[intel::reqd_work_group_size(3, 4, 64)]]
+    [[intel::num_simd_work_items(4)]]
+    void operator()() const {}
+  };
+
+  [[intel::reqd_work_group_size(5)]]
+  // identical to [[intel::reqd_work_group_size(5, 1, 1)]]
+  [[intel::num_simd_work_items(5)]] void fun() {}
+
+  [[intel::reqd_work_group_size(5, 10)]]
+  // identical to [[intel::reqd_work_group_size(5, 10, 1)]]
+  [[intel::num_simd_work_items(5)]] void fun1() {}
+
+  [[cl::reqd_work_group_size(7, 10, 20)]]
+  [[intel::num_simd_work_items(5)]] void fun2() {}
+
+  [[intel::num_simd_work_items(4)]]
+  [[cl::reqd_work_group_size(5, 4, 8)]] void fun3() {}
+
+  struct func1 {
+    [[intel::num_simd_work_items(4)]]
+    [[cl::reqd_work_group_size(5, 4, 64)]]
+    void operator()() const {}
+  };
+
+  struct bar1 {
+    [[cl::reqd_work_group_size(3, 4, 64)]]
+    [[intel::num_simd_work_items(4)]]
+    void operator()() const {}
+  };
+
+  [[intel::num_simd_work_items(2)]]
+  __attribute__((reqd_work_group_size(4, 2, 3))) void test();
+
+  __attribute__((reqd_work_group_size(4, 2, 3)))
+  [[intel::num_simd_work_items(2)]] void test1();
+
   }];
 }
 
@@ -2616,28 +2679,22 @@ In OpenCL C, this attribute is available in GNU spelling
 
   __kernel __attribute__((reqd_work_group_size(8, 16, 32))) void test() {}
 
-The order of the arguments to reqd_work_group_size in SYCL and OpenCL are
-reversed. In the OpenCL syntax,
-(``__attribute__((reqd_work_group_size(X, Y, Z)))``), X is the index that
-increments the fastest, followed by Y, then Z. If we preserve that definition
-of X, Y, and Z, then in SYCL the attribute is specified as
-``[[intel::reqd_work_group_size(Z, Y, X)]]`` or
-``[[cl::reqd_work_group_size(Z, Y, X)]]``. This gets more complicated in the
--case where fewer than three arguments are provided since
-``[[intel::reqd_work_group_size(Z, Y, X)]]`` attribute spelling allows
-the Y and Z arguments to be optional. In such a case it's not the ``X`` argument
-that is omitted (by the definitions of X, Y, and Z above) it's the ``Z``
-dimension that's omitted. So the two argument version has the syntax
-``[[intel::reqd_work_group_size(Y, X)]]``. Similarly, the one argument variant
-has syntax ``[[intel::reqd_work_group_size(X)]]``.
-In summary, in SYCL if the ``intel::reqd_work_group_size`` or
-``cl::reqd_work_group_size`` attribute is specified on a declaration along with
-a ``intel::num_simd_work_items`` attribute, the required work-group size
-(``X`` dimention, which is the last dimension in the reqd_work_group_size) must
-be evenly divisible by the argument specified in the
-``intel::num_simd_work_items``.
-Fore more information, see the documentation about required work-group size.
-..`Specify a Work-Group Size`: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/optimize-your-design/resource-use/specify-a-work-group-size.html
+The arguments to reqd_work_group_size are ordered based on which index
+increments the fastest. In OpenCL, the first argument is the index that
+increments the fastest, and in SYCL, the last argument is the index that
+increments the fastest.
+
+In OpenCL, all three arguments are required.
+
+In SYCL, the attribute accepts either one, two, or three arguments; in each
+form, the last (or only) argument is the index that increments fastest. The
+number of arguments passed to the attribute must match the dimensionality of
+the kernel the attribute is applied to.
+
+If the reqd_work_group_size attribute is specified on a declaration along with
+num_simd_work_items, the required work group size specified by num_simd_work_items
+must evenly divide the index that increments fastest in the reqd_work_group_size
+attribute.
 
 .. code-block:: c++
 
@@ -2653,9 +2710,23 @@ Fore more information, see the documentation about required work-group size.
     void operator()() const {}
   };
 
+  [[intel::reqd_work_group_size(5)]]
+  // identical to [[intel::reqd_work_group_size(5, 1, 1)]]
+  [[intel::num_simd_work_items(5)]] void fun() {}
+
+  [[intel::reqd_work_group_size(5, 10)]]
+  // identical to [[intel::reqd_work_group_size(5, 10, 1)]]
+  [[intel::num_simd_work_items(5)]] void fun1() {}
+
+  [[cl::reqd_work_group_size(7, 10, 20)]]
+  [[intel::num_simd_work_items(5)]] void fun2() {}
+
+  [[intel::num_simd_work_items(4)]]
+  [[cl::reqd_work_group_size(5, 4, 8)]] void fun3() {}
+
   struct func1 {
     [[intel::num_simd_work_items(4)]]
-    [[cl::reqd_work_group_size(3, 4, 64)]]
+    [[cl::reqd_work_group_size(5, 4, 64)]]
     void operator()() const {}
   };
   
@@ -2664,17 +2735,6 @@ Fore more information, see the documentation about required work-group size.
     [[intel::num_simd_work_items(4)]]
     void operator()() const {}
   };
-
-If the ``__attribute__((reqd_work_group_size()))`` attribute is specified on
-a declaration along with a ``intel::num_simd_work_items``
-attribute, the required work-group size (``X`` dimention, which is the first
-dimension in the reqd_work_group_size by the definitions of X, Y, and Z above)
-must be evenly divisible by the argument specified in the
-``intel::num_simd_work_items`` attribute. GNU spelling of ReqdWorkGroupSizeAttr
-maps to the OpenCL semantic. The first and last dimension are only swapped for
-the attributes in SYCL and not the OpenCL ones.
-
-.. code-block:: c++
 
   [[intel::num_simd_work_items(2)]]
   __attribute__((reqd_work_group_size(4, 2, 3))) void test();

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2617,22 +2617,27 @@ In OpenCL C, this attribute is available in GNU spelling
   __kernel __attribute__((reqd_work_group_size(8, 16, 32))) void test() {}
 
 The order of the arguments to reqd_work_group_size in SYCL and OpenCL are
-reversed. In the OpenCL syntax, ``[[cl::reqd_work_group_size(X, Y, Z)]]`` or
+reversed. In the OpenCL syntax,
 (``__attribute__((reqd_work_group_size(X, Y, Z)))``), X is the index that
 increments the fastest, followed by Y, then Z. If we preserve that definition
 of X, Y, and Z, then in SYCL the attribute is specified as
-``[[intel::reqd_work_group_size(Z, Y, X)]]``. This gets more complicated in the
-case where fewer than three arguments are provided since this spelling allows
+``[[intel::reqd_work_group_size(Z, Y, X)]]`` or
+``[[cl::reqd_work_group_size(Z, Y, X)]]``. This gets more complicated in the
+case where fewer than three arguments are provided since
+``[[intel::reqd_work_group_size(Z, Y, X)]]`` attribute spelling allows
 the Y and Z arguments to be optional. In such a case it's not the ``X`` argument
 that is omitted (by the definitions of X, Y, and Z above) it's the ``Z``
 dimension that's omitted. So the two argument version has the syntax
 ``[[intel::reqd_work_group_size(Y, X)]]``. Similarly, the one argument variant
 has syntax ``[[intel::reqd_work_group_size(X)]]``.
-In summary, in SYCL if the ``intel::reqd_work_group_size`` attribute is
-specified on a declaration along with a ``intel::num_simd_work_items``
-attribute, the work group size (the last argument) must be evenly divisible by
-the argument specified in the ``intel::num_simd_work_items``regardless of how
-many arguments req_work_group_size has.
+In summary, in SYCL if the ``intel::reqd_work_group_size`` or
+``cl::reqd_work_group_size`` attribute is specified on a declaration along with
+a ``intel::num_simd_work_items`` attribute, the required work-group size
+(``X`` dimention, which is the last dimension in the reqd_work_group_size) must
+be evenly divisible by the argument specified in the
+``intel::num_simd_work_items``.
+Fore more information, see the documentation about required work-group size.
+..`Specify a Work-Group Size`: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/optimize-your-design/resource-use/specify-a-work-group-size.html
 
 .. code-block:: c++
 
@@ -2648,25 +2653,34 @@ many arguments req_work_group_size has.
     void operator()() const {}
   };
 
-If the ``cl::reqd_work_group_size`` or ``__attribute__((reqd_work_group_size()))``
-attribute is specified on a declaration along with a ``intel::num_simd_work_items``
-attribute, the work group size (the first argument) must be evenly divisible by
-the argument specified in the ``intel::num_simd_work_items`` attribute.
-GNU and ``cl::reqd_work_group_size`` spelling of ReqdWorkGroupSizeAttr maps to
-the OpenCL semantic. The first and last argument are only swapped for the Intel
-attributes in SYCL and not the OpenCL ones.
-
-.. code-block:: c++
-
   struct func1 {
     [[intel::num_simd_work_items(4)]]
-    [[cl::reqd_work_group_size(64, 4, 3)]]
+    [[cl::reqd_work_group_size(3, 4, 64)]]
+    void operator()() const {}
+  };
+  
+  struct bar1 {
+    [[cl::reqd_work_group_size(3, 4, 64)]]
+    [[intel::num_simd_work_items(4)]]
     void operator()() const {}
   };
 
-  [[intel::num_simd_work_items(2)]]
-  __attribute__((reqd_work_group_size(4, 2, 3))) void bar();
+If the ``__attribute__((reqd_work_group_size()))`` attribute is specified on
+a declaration along with a ``intel::num_simd_work_items``
+attribute, the required work-group size (``X`` dimention, which is the first
+dimension in the reqd_work_group_size) must be evenly divisible by
+the argument specified in the ``intel::num_simd_work_items`` attribute.
+GNU spelling of ReqdWorkGroupSizeAttr maps to the OpenCL semantic. The first and
+last dimension are only swapped for the attributes in SYCL and not the OpenCL ones.
 
+.. code-block:: c++
+
+  [[intel::num_simd_work_items(2)]]
+  __attribute__((reqd_work_group_size(4, 2, 3))) void test();
+
+  __attribute__((reqd_work_group_size(4, 2, 3))) 
+  [[intel::num_simd_work_items(2)]] void test1();
+ 
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2564,14 +2564,14 @@ increments fastest in the ``reqd_work_group_size`` attribute.
     void operator()() const {}
   };
 
-  // Note, '4' is evenly divisible by '2'; in OpenCL, the first
+  // Note, '4' is evenly divisible by '2'; in SYCL, the last
   // argument to the attribute is the one which increments fastest.
   [[intel::num_simd_work_items(2)]]
-  __attribute__((reqd_work_group_size(4, 2, 3))) void test();
+  __attribute__((reqd_work_group_size(3, 2, 4))) void test();
 
-  // Note, '8' is evenly divisible by '2'; in OpenCL, the first
+  // Note, '8' is evenly divisible by '2'; in OpenCL, the last
   // argument to the attribute is the one which increments fastest.
-  __attribute__((reqd_work_group_size(8, 2, 3)))
+  __attribute__((reqd_work_group_size(3, 2, 8)))
   [intel::num_simd_work_items(2)]] void test();
 
   }];
@@ -2748,14 +2748,14 @@ in the ``reqd_work_group_size`` attribute.
     void operator()() const {}
   };
 
-  // Note, '4' is evenly divisible by '2'; in OpenCL, the first
+  // Note, '4' is evenly divisible by '2'; in SYCL, the last
   // argument to the attribute is the one which increments fastest.
   [[intel::num_simd_work_items(2)]]
-  __attribute__((reqd_work_group_size(4, 2, 3))) void test();
+  __attribute__((reqd_work_group_size(3, 2, 4))) void test();
  
-  // Note, '8' is evenly divisible by '2'; in OpenCL, the first
+  // Note, '8' is evenly divisible by '2'; in SYCL, the last
   // argument to the attribute is the one which increments fastest.
-  __attribute__((reqd_work_group_size(8, 2, 3)))
+  __attribute__((reqd_work_group_size(3, 2, 8)))
   [intel::num_simd_work_items(2)]] void test();
 
   }];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2534,14 +2534,6 @@ increments fastest in the reqd_work_group_size attribute.
     void operator()() const {}
   };
 
-  [[intel::reqd_work_group_size(5)]]
-  // identical to [[intel::reqd_work_group_size(5, 1, 1)]]
-  [[intel::num_simd_work_items(5)]] void fun() {}
-
-  [[intel::reqd_work_group_size(5, 10)]]
-  // identical to [[intel::reqd_work_group_size(5, 10, 1)]]
-  [[intel::num_simd_work_items(5)]] void fun1() {}
-
   [[cl::reqd_work_group_size(7, 10, 20)]]
   [[intel::num_simd_work_items(5)]] void fun2() {}
 
@@ -2709,14 +2701,6 @@ attribute.
     [[intel::num_simd_work_items(4)]]
     void operator()() const {}
   };
-
-  [[intel::reqd_work_group_size(5)]]
-  // identical to [[intel::reqd_work_group_size(5, 1, 1)]]
-  [[intel::num_simd_work_items(5)]] void fun() {}
-
-  [[intel::reqd_work_group_size(5, 10)]]
-  // identical to [[intel::reqd_work_group_size(5, 10, 1)]]
-  [[intel::num_simd_work_items(5)]] void fun1() {}
 
   [[cl::reqd_work_group_size(7, 10, 20)]]
   [[intel::num_simd_work_items(5)]] void fun2() {}

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2569,7 +2569,7 @@ increments fastest in the ``reqd_work_group_size`` attribute.
   [[intel::num_simd_work_items(2)]]
   __attribute__((reqd_work_group_size(3, 2, 4))) void test();
 
-  // Note, '8' is evenly divisible by '2'; in OpenCL, the last
+  // Note, '8' is evenly divisible by '2'; in SYCL, the last
   // argument to the attribute is the one which increments fastest.
   __attribute__((reqd_work_group_size(3, 2, 8)))
   [intel::num_simd_work_items(2)]] void test();

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2503,26 +2503,6 @@ device kernel, the attribute is not ignored and it is propagated to the kernel.
     [[intel::num_simd_work_items(N)]] void operator()() const {}
   };
 
-If the`` intel::reqd_work_group_size`` or ``cl::reqd_work_group_size``
-attribute is specified on a declaration along with a
-intel::num_simd_work_items attribute, the work group size attribute
-argument (the first argument) must be evenly divisible by the argument specified
-in the ``intel::num_simd_work_items`` attribute.
-
-.. code-block:: c++
-
-  struct func {
-    [[intel::num_simd_work_items(4)]]
-    [[intel::reqd_work_group_size(64, 64, 64)]]
-    void operator()() const {}
-  };
-
-  struct bar {
-    [[intel::reqd_work_group_size(64, 64, 64)]]
-    [[intel::num_simd_work_items(4)]]
-    void operator()() const {}
-  };
-
   }];
 }
 
@@ -2635,6 +2615,57 @@ In OpenCL C, this attribute is available in GNU spelling
 .. code-block:: c++
 
   __kernel __attribute__((reqd_work_group_size(8, 16, 32))) void test() {}
+
+The order of the arguments to reqd_work_group_size in SYCL and OpenCL are
+reversed. In the OpenCL syntax, ``[[cl::reqd_work_group_size(X, Y, Z)]]`` or
+(``__attribute__((reqd_work_group_size(X, Y, Z)))``), X is the index that
+increments the fastest, followed by Y, then Z. If we preserve that definition
+of X, Y, and Z, then in SYCL the attribute is specified as
+``[[intel::reqd_work_group_size(Z, Y, X)]]``. This gets more complicated in the
+case where fewer than three arguments are provided since this spelling allows
+the Y and Z arguments to be optional. In such a case it's not the ``X`` argument
+that is omitted (by the definitions of X, Y, and Z above) it's the ``Z``
+dimension that's omitted. So the two argument version has the syntax
+``[[intel::reqd_work_group_size(Y, X)]]``. Similarly, the one argument variant
+has syntax ``[[intel::reqd_work_group_size(X)]]``.
+In summary, in SYCL if the ``intel::reqd_work_group_size`` attribute is
+specified on a declaration along with a ``intel::num_simd_work_items``
+attribute, the work group size (the last argument) must be evenly divisible by
+the argument specified in the ``intel::num_simd_work_items``regardless of how
+many arguments req_work_group_size has.
+
+.. code-block:: c++
+
+  struct func {
+    [[intel::num_simd_work_items(4)]]
+    [[intel::reqd_work_group_size(3, 4, 64)]]
+    void operator()() const {}
+  };
+
+  struct bar {
+    [[intel::reqd_work_group_size(3, 4, 64)]]
+    [[intel::num_simd_work_items(4)]]
+    void operator()() const {}
+  };
+
+If the ``cl::reqd_work_group_size`` or ``__attribute__((reqd_work_group_size()))``
+attribute is specified on a declaration along with a ``intel::num_simd_work_items``
+attribute, the work group size (the first argument) must be evenly divisible by
+the argument specified in the ``intel::num_simd_work_items`` attribute.
+GNU and ``cl::reqd_work_group_size`` spelling of ReqdWorkGroupSizeAttr maps to
+the OpenCL semantic. The first and last argument are only swapped for the Intel
+attributes in SYCL and not the OpenCL ones.
+
+.. code-block:: c++
+
+  struct func1 {
+    [[intel::num_simd_work_items(4)]]
+    [[cl::reqd_work_group_size(64, 4, 3)]]
+    void operator()() const {}
+  };
+
+  [[intel::num_simd_work_items(2)]]
+  __attribute__((reqd_work_group_size(4, 2, 3))) void bar();
 
   }];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2623,7 +2623,7 @@ increments the fastest, followed by Y, then Z. If we preserve that definition
 of X, Y, and Z, then in SYCL the attribute is specified as
 ``[[intel::reqd_work_group_size(Z, Y, X)]]`` or
 ``[[cl::reqd_work_group_size(Z, Y, X)]]``. This gets more complicated in the
-case where fewer than three arguments are provided since
+-case where fewer than three arguments are provided since
 ``[[intel::reqd_work_group_size(Z, Y, X)]]`` attribute spelling allows
 the Y and Z arguments to be optional. In such a case it's not the ``X`` argument
 that is omitted (by the definitions of X, Y, and Z above) it's the ``Z``
@@ -2668,10 +2668,11 @@ Fore more information, see the documentation about required work-group size.
 If the ``__attribute__((reqd_work_group_size()))`` attribute is specified on
 a declaration along with a ``intel::num_simd_work_items``
 attribute, the required work-group size (``X`` dimention, which is the first
-dimension in the reqd_work_group_size) must be evenly divisible by
-the argument specified in the ``intel::num_simd_work_items`` attribute.
-GNU spelling of ReqdWorkGroupSizeAttr maps to the OpenCL semantic. The first and
-last dimension are only swapped for the attributes in SYCL and not the OpenCL ones.
+dimension in the reqd_work_group_size by the definitions of X, Y, and Z above)
+must be evenly divisible by the argument specified in the
+``intel::num_simd_work_items`` attribute. GNU spelling of ReqdWorkGroupSizeAttr
+maps to the OpenCL semantic. The first and last dimension are only swapped for
+the attributes in SYCL and not the OpenCL ones.
 
 .. code-block:: c++
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2503,6 +2503,11 @@ device kernel, the attribute is not ignored and it is propagated to the kernel.
     [[intel::num_simd_work_items(N)]] void operator()() const {}
   };
 
+If the ``reqd_work_group_size`` attribute is specified on a declaration along
+with ``num_simd_work_items``, the required work group size specified
+by ``num_simd_work_items`` attribute must evenly divide the index that
+increments fastest in the ``reqd_work_group_size`` attribute.
+
 The arguments to ``reqd_work_group_size`` are ordered based on which index
 increments the fastest. In OpenCL, the first argument is the index that
 increments the fastest, and in SYCL, the last argument is the index that
@@ -2514,11 +2519,6 @@ In SYCL, the attribute accepts either one, two, or three arguments; in each
 form, the last (or only) argument is the index that increments fastest.
 The number of arguments passed to the attribute must match the dimensionality
 of the kernel the attribute is applied to.
-
-If the ``reqd_work_group_size`` attribute is specified on a declaration along
-with ``num_simd_work_items``, the required work group size specified
-by ``num_simd_work_items`` attribute must evenly divide the index that
-increments fastest in the ``reqd_work_group_size`` attribute.
 
 .. code-block:: c++
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2503,7 +2503,7 @@ device kernel, the attribute is not ignored and it is propagated to the kernel.
     [[intel::num_simd_work_items(N)]] void operator()() const {}
   };
 
-The arguments to reqd_work_group_size are ordered based on which index
+The arguments to ``reqd_work_group_size`` are ordered based on which index
 increments the fastest. In OpenCL, the first argument is the index that
 increments the fastest, and in SYCL, the last argument is the index that
 increments the fastest.
@@ -2515,48 +2515,64 @@ form, the last (or only) argument is the index that increments fastest.
 The number of arguments passed to the attribute must match the dimensionality
 of the kernel the attribute is applied to.
 
-If the reqd_work_group_size attribute is specified on a declaration along
-with ``intel::num_simd_work_items``, the required work group size specified
-by ``intel::num_simd_work_items`` attribute must evenly divide the index that
-increments fastest in the reqd_work_group_size attribute.
+If the ``reqd_work_group_size`` attribute is specified on a declaration along
+with ``num_simd_work_items``, the required work group size specified
+by ``num_simd_work_items`` attribute must evenly divide the index that
+increments fastest in the ``reqd_work_group_size`` attribute.
 
 .. code-block:: c++
 
+  // Note, '64' is evenly divisible by '4'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   struct func {
     [[intel::num_simd_work_items(4)]]
-    [[intel::reqd_work_group_size(3, 4, 64)]]
+    [[intel::reqd_work_group_size(7, 4, 64)]]
     void operator()() const {}
   };
 
+  // Note, '8' is evenly divisible by '8'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   struct bar {
-    [[intel::reqd_work_group_size(3, 4, 64)]]
-    [[intel::num_simd_work_items(4)]]
+    [[intel::reqd_work_group_size(1, 1, 8)]]
+    [[intel::num_simd_work_items(8)]]
     void operator()() const {}
   };
 
-  [[cl::reqd_work_group_size(7, 10, 20)]]
+  // Note, '10' is evenly divisible by '5'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
+  [[cl::reqd_work_group_size(7, 5, 10)]]
   [[intel::num_simd_work_items(5)]] void fun2() {}
 
+  // Note, '8' is evenly divisible by '4'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   [[intel::num_simd_work_items(4)]]
   [[cl::reqd_work_group_size(5, 4, 8)]] void fun3() {}
 
+  // Note, '8' is evenly divisible by '8'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   struct func1 {
-    [[intel::num_simd_work_items(4)]]
-    [[cl::reqd_work_group_size(5, 4, 64)]]
+    [[intel::num_simd_work_items(8)]]
+    [[cl::reqd_work_group_size(1, 1, 8)]]
     void operator()() const {}
   };
 
+  // Note, '8' is evenly divisible by '4'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   struct bar1 {
-    [[cl::reqd_work_group_size(3, 4, 64)]]
+    [[cl::reqd_work_group_size(7, 4, 8)]]
     [[intel::num_simd_work_items(4)]]
     void operator()() const {}
   };
 
+  // Note, '4' is evenly divisible by '2'; in OpenCL, the first
+  // argument to the attribute is the one which increments fastest.
   [[intel::num_simd_work_items(2)]]
   __attribute__((reqd_work_group_size(4, 2, 3))) void test();
 
-  __attribute__((reqd_work_group_size(4, 2, 3)))
-  [[intel::num_simd_work_items(2)]] void test1();
+  // Note, '8' is evenly divisible by '2'; in OpenCL, the first
+  // argument to the attribute is the one which increments fastest.
+  __attribute__((reqd_work_group_size(8, 2, 3)))
+  [intel::num_simd_work_items(2)]] void test();
 
   }];
 }
@@ -2671,7 +2687,7 @@ In OpenCL C, this attribute is available in GNU spelling
 
   __kernel __attribute__((reqd_work_group_size(8, 16, 32))) void test() {}
 
-The arguments to reqd_work_group_size are ordered based on which index
+The arguments to ``reqd_work_group_size`` are ordered based on which index
 increments the fastest. In OpenCL, the first argument is the index that
 increments the fastest, and in SYCL, the last argument is the index that
 increments the fastest.
@@ -2683,49 +2699,65 @@ form, the last (or only) argument is the index that increments fastest. The
 number of arguments passed to the attribute must match the dimensionality of
 the kernel the attribute is applied to.
 
-If the reqd_work_group_size attribute is specified on a declaration along with
-num_simd_work_items, the required work group size specified by num_simd_work_items
-must evenly divide the index that increments fastest in the reqd_work_group_size
-attribute.
+If the ``reqd_work_group_size attribute`` is specified on a declaration along
+with ``num_simd_work_items``, the required work group size specified by
+``num_simd_work_items`` must evenly divide the index that increments fastest
+in the ``reqd_work_group_size`` attribute.
 
 .. code-block:: c++
 
+  // Note, '64' is evenly divisible by '4'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   struct func {
     [[intel::num_simd_work_items(4)]]
-    [[intel::reqd_work_group_size(3, 4, 64)]]
+    [[intel::reqd_work_group_size(7, 4, 64)]]
     void operator()() const {}
   };
 
+  // Note, '8' is evenly divisible by '8'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   struct bar {
-    [[intel::reqd_work_group_size(3, 4, 64)]]
-    [[intel::num_simd_work_items(4)]]
+    [[intel::reqd_work_group_size(1, 1, 8)]]
+    [[intel::num_simd_work_items(8)]]
     void operator()() const {}
   };
 
-  [[cl::reqd_work_group_size(7, 10, 20)]]
+  // Note, '10' is evenly divisible by '5'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
+  [[cl::reqd_work_group_size(7, 5, 10)]]
   [[intel::num_simd_work_items(5)]] void fun2() {}
 
+  // Note, '8' is evenly divisible by '4'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   [[intel::num_simd_work_items(4)]]
   [[cl::reqd_work_group_size(5, 4, 8)]] void fun3() {}
 
+  // Note, '8' is evenly divisible by '8'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   struct func1 {
-    [[intel::num_simd_work_items(4)]]
-    [[cl::reqd_work_group_size(5, 4, 64)]]
+    [[intel::num_simd_work_items(8)]]
+    [[cl::reqd_work_group_size(1, 1, 8)]]
     void operator()() const {}
   };
   
+  // Note, '8' is evenly divisible by '4'; in SYCL, the last
+  // argument to the attribute is the one which increments fastest.
   struct bar1 {
-    [[cl::reqd_work_group_size(3, 4, 64)]]
+    [[cl::reqd_work_group_size(7, 4, 8)]]
     [[intel::num_simd_work_items(4)]]
     void operator()() const {}
   };
 
+  // Note, '4' is evenly divisible by '2'; in OpenCL, the first
+  // argument to the attribute is the one which increments fastest.
   [[intel::num_simd_work_items(2)]]
   __attribute__((reqd_work_group_size(4, 2, 3))) void test();
-
-  __attribute__((reqd_work_group_size(4, 2, 3))) 
-  [[intel::num_simd_work_items(2)]] void test1();
  
+  // Note, '8' is evenly divisible by '2'; in OpenCL, the first
+  // argument to the attribute is the one which increments fastest.
+  __attribute__((reqd_work_group_size(8, 2, 3)))
+  [intel::num_simd_work_items(2)]] void test();
+
   }];
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3097,9 +3097,8 @@ static void handleWorkGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
       int64_t NumSimdWorkItems =
           A->getValue()->getIntegerConstantExpr(Ctx)->getSExtValue();
 
-      unsigned WorkGroupSize = S.getLangOpts().OpenCL
-		               ? XDimVal.getZExtValue()
-			       : ZDimVal.getZExtValue();
+      unsigned WorkGroupSize = S.getLangOpts().OpenCL ? XDimVal.getZExtValue()
+                                                      : ZDimVal.getZExtValue();
 
       if (WorkGroupSize % NumSimdWorkItems != 0) {
         S.Diag(A->getLocation(), diag::err_sycl_num_kernel_wrong_reqd_wg_size)
@@ -3321,9 +3320,8 @@ void Sema::AddSYCLIntelNumSimdWorkItemsAttr(Decl *D,
         if (ZDim.isInvalid())
           return;
 
-        unsigned WorkGroupSize = getLangOpts().OpenCL
-                                 ? XDimVal.getZExtValue()
-	                         : ZDimVal.getZExtValue();
+        unsigned WorkGroupSize = getLangOpts().OpenCL ? XDimVal.getZExtValue()
+                                                      : ZDimVal.getZExtValue();
 
         if (WorkGroupSize % ArgVal.getSExtValue() != 0) {
           Diag(CI.getLoc(), diag::err_sycl_num_kernel_wrong_reqd_wg_size)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3095,25 +3095,20 @@ static void handleWorkGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
     // semantics. First and last argument are only swapped for the atributes in
     // SYCL and not the OpenCL ones.
     if (const auto *A = D->getAttr<SYCLIntelNumSimdWorkItemsAttr>()) {
-      Expr *E = A->getValue();
-      if (!E->isValueDependent()) {
-        llvm::APSInt ArgVal;
-        ExprResult Res = S.VerifyIntegerConstantExpression(E, &ArgVal);
-        if (Res.isInvalid())
-          return;
-        E = Res.get();
-        bool UsesOpenCLArgOrdering =
+      int64_t NumSimdWorkItems =
+          A->getValue()->getIntegerConstantExpr(Ctx)->getSExtValue();
+
+      bool UsesOpenCLArgOrdering =
           AL.getSyntax() == AttributeCommonInfo::AS_GNU;
 
-        llvm::APSInt WorkGroupSize = UsesOpenCLArgOrdering
-                                         ? XDimVal : ZDimVal;
+      unsigned WorkGroupSize = UsesOpenCLArgOrdering ? XDimVal.getZExtValue()
+                                                     : ZDimVal.getZExtValue();
 
-        if (WorkGroupSize % ArgVal != 0) {
-          S.Diag(A->getLocation(), diag::err_sycl_num_kernel_wrong_reqd_wg_size)
-              << A << AL;
-          S.Diag(AL.getLoc(), diag::note_conflicting_attribute);
-          return;
-        }
+      if (WorkGroupSize % NumSimdWorkItems != 0) {
+        S.Diag(A->getLocation(), diag::err_sycl_num_kernel_wrong_reqd_wg_size)
+            << A << AL;
+        S.Diag(AL.getLoc(), diag::note_conflicting_attribute);
+        return;
       }
     }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3310,8 +3310,8 @@ void Sema::AddSYCLIntelNumSimdWorkItemsAttr(Decl *D,
       Expr *YDimExpr = DeclAttr->getYDim();
       Expr *ZDimExpr = DeclAttr->getZDim();
 
-      if (!XDimExpr->isValueDependent() && !YDimExpr->isValueDependent()
-	  && !ZDimExpr->isValueDependent()) {
+      if (!XDimExpr->isValueDependent() && !YDimExpr->isValueDependent() &&
+          !ZDimExpr->isValueDependent()) {
         llvm::APSInt XDimVal, YDimVal, ZDimVal;
         ExprResult XDim = VerifyIntegerConstantExpression(XDimExpr, &XDimVal);
         ExprResult YDim = VerifyIntegerConstantExpression(YDimExpr, &YDimVal);
@@ -3329,15 +3329,15 @@ void Sema::AddSYCLIntelNumSimdWorkItemsAttr(Decl *D,
           return;
         ZDimExpr = ZDim.get();
 
-        llvm::APSInt WorkGroupSize = DeclAttr->usesOpenCLArgOrdering()
-				         ? XDimVal : ZDimVal;
+        llvm::APSInt WorkGroupSize =
+            DeclAttr->usesOpenCLArgOrdering() ? XDimVal : ZDimVal;
 
         if (WorkGroupSize % ArgVal != 0) {
           Diag(CI.getLoc(), diag::err_sycl_num_kernel_wrong_reqd_wg_size)
               << CI << DeclAttr;
           Diag(DeclAttr->getLocation(), diag::note_conflicting_attribute);
           return;
-	}
+        }
       }
     }
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3094,12 +3094,6 @@ static void handleWorkGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
     // __attribute__((reqd_work_group_size)) attribute behaves the
     // OpenCL way in OpenCL mode (using the OpenCL semantics) and
     // the SYCL way in SYCL mode (using the SYCL semantics).
-    // If the declaration has a __attribute__((reqd_work_group_size))
-    // attribute, check to see if the first argument can be evenly divided
-    // by the [[intel::num_simd_work_items()]] attribute in OpenCL mode.
-    // If the declaration has a __attribute__((reqd_work_group_size))
-    // attribute, check to see if the last argument can be evenly divided
-    // by the [[intel::num_simd_work_items()]] attribute in SYCL mode.
     if (const auto *A = D->getAttr<SYCLIntelNumSimdWorkItemsAttr>()) {
       int64_t NumSimdWorkItems =
           A->getValue()->getIntegerConstantExpr(Ctx)->getSExtValue();
@@ -3306,12 +3300,6 @@ void Sema::AddSYCLIntelNumSimdWorkItemsAttr(Decl *D,
     // __attribute__((reqd_work_group_size)) attribute behaves the
     // OpenCL way in OpenCL mode (using the OpenCL semantics) and
     // the SYCL way in SYCL mode (using the SYCL semantics).
-    // If the declaration has a __attribute__((reqd_work_group_size))
-    // attribute, check to see if the first argument can be evenly divided
-    // by the [[intel::num_simd_work_items()]] attribute in OpenCL mode.
-    // If the declaration has a __attribute__((reqd_work_group_size))
-    // attribute, check to see if the last argument can be evenly divided
-    // by the [[intel::num_simd_work_items()]] attribute in SYCL mode.
     if (const auto *DeclAttr = D->getAttr<ReqdWorkGroupSizeAttr>()) {
       Expr *XDimExpr = DeclAttr->getXDim();
       Expr *YDimExpr = DeclAttr->getYDim();

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3313,7 +3313,7 @@ void Sema::AddSYCLIntelNumSimdWorkItemsAttr(Decl *D,
       Optional<llvm::APSInt> ZDimVal = DeclAttr->getZDimVal(Context);
 
       llvm::APSInt WorkGroupSize =
-	  DeclAttr->usesOpenCLArgOrdering() ? *XDimVal : *ZDimVal;
+          DeclAttr->usesOpenCLArgOrdering() ? *XDimVal : *ZDimVal;
 
       if (WorkGroupSize % ArgVal != 0) {
         Diag(CI.getLoc(), diag::err_sycl_num_kernel_wrong_reqd_wg_size)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3087,12 +3087,13 @@ static void handleWorkGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
     ZDimExpr = ZDim.get();
 
     // If the declaration has an [[intel::num_simd_work_items()]] attribute,
-    // check to see if the first argument of __attribute__((reqd_work_group_size))
-    // attribute and last argument of [[cl::reqd_work_group_size()]] or
-    // [intel::reqd_work_group_size()]] attribute can be evenly divided by
-    // the [[intel::num_simd_work_items()]] attribute. GNU spelling of
-    // ReqdWorkGroupSizeAttr maps to the OpenCL semantics. First and last
-    // argument are only swapped for the atributes in SYCL and not the OpenCL ones.
+    // check to see if the first argument of
+    // __attribute__((reqd_work_group_size)) attribute and last argument of
+    // [[cl::reqd_work_group_size()]] or [intel::reqd_work_group_size()]]
+    // attribute can be evenly divided by the [[intel::num_simd_work_items()]]
+    // attribute. GNU spelling of ReqdWorkGroupSizeAttr maps to the OpenCL
+    // semantics. First and last argument are only swapped for the atributes in
+    // SYCL and not the OpenCL ones.
     if (const auto *A = D->getAttr<SYCLIntelNumSimdWorkItemsAttr>()) {
       int64_t NumSimdWorkItems =
           A->getValue()->getIntegerConstantExpr(Ctx)->getSExtValue();
@@ -3308,9 +3309,9 @@ void Sema::AddSYCLIntelNumSimdWorkItemsAttr(Decl *D,
       const auto *DeclXExpr = dyn_cast<ConstantExpr>(DeclAttr->getXDim());
       const auto *DeclZExpr = dyn_cast<ConstantExpr>(DeclAttr->getZDim());
 
-      llvm::APSInt WorkGroupSize =
-          DeclAttr->usesOpenCLArgOrdering() ? DeclXExpr->getResultAsAPSInt() 
-	                                    : DeclZExpr->getResultAsAPSInt();
+      llvm::APSInt WorkGroupSize = DeclAttr->usesOpenCLArgOrdering()
+                                       ? DeclXExpr->getResultAsAPSInt()
+                                       : DeclZExpr->getResultAsAPSInt();
 
       if (WorkGroupSize % ArgVal != 0) {
         Diag(CI.getLoc(), diag::err_sycl_num_kernel_wrong_reqd_wg_size)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3086,7 +3086,7 @@ static void handleWorkGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
       return;
     ZDimExpr = ZDim.get();
 
-    // If the declaration has an [[intel::num_simd_work_items()]] attribute,
+    // If the declaration has a [[intel::num_simd_work_items()]] attribute,
     // check to see if the first argument of
     // __attribute__((reqd_work_group_size)) attribute and last argument of
     // [[cl::reqd_work_group_size()]] or [intel::reqd_work_group_size()]]
@@ -3096,11 +3096,10 @@ static void handleWorkGroupSize(Sema &S, Decl *D, const ParsedAttr &AL) {
       int64_t NumSimdWorkItems =
           A->getValue()->getIntegerConstantExpr(Ctx)->getSExtValue();
 
-      bool UsesOpenCLSemantics =
-          AL.getSyntax() == AttributeCommonInfo::AS_GNU;
+      bool UsesOpenCLSemantics = AL.getSyntax() == AttributeCommonInfo::AS_GNU;
 
-      unsigned WorkGroupSize = UsesOpenCLSemantics ? XDimVal.getZExtValue()
-                                                   : ZDimVal.getZExtValue();
+      unsigned WorkGroupSize =
+          UsesOpenCLSemantics ? XDimVal.getZExtValue() : ZDimVal.getZExtValue();
 
       if (WorkGroupSize % NumSimdWorkItems != 0) {
         S.Diag(A->getLocation(), diag::err_sycl_num_kernel_wrong_reqd_wg_size)

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -142,10 +142,10 @@ struct TRIFuncObjBad8 {
 
 // If the declaration has a __attribute__((reqd_work_group_size()))
 // attribute, tests that check if the work group size attribute argument
-// (the first argument) can be evenly divided by the [[intel::num_simd_work_items()]]
-// attribute. GNU spelling of ReqdWorkGroupSizeAttr maps to the OpenCL semantics.
+// (the last argument) can be evenly divided by the [[intel::num_simd_work_items()]]
+// attribute.
 [[intel::num_simd_work_items(2)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-__attribute__((reqd_work_group_size(3, 2, 4))) void func5(); // expected-note{{conflicting attribute is here}}
+__attribute__((reqd_work_group_size(4, 2, 5))) void func5(); // expected-note{{conflicting attribute is here}}
 
 // Tests for incorrect argument values for Intel FPGA num_simd_work_items and reqd_work_group_size function attributes
 struct TRIFuncObjBad9 {
@@ -210,12 +210,10 @@ struct TRIFuncObjBad18 {
 
 #endif // TRIGGER_ERROR
 // If the declaration has a [[intel::reqd_work_group_size()]]
-// or [[cl::reqd_work_group_size()]] attribute, check to see
+// or [[cl::reqd_work_group_size()]] or
+// __attribute__((reqd_work_group_size)) attribute, check to see
 // if the last argument can be evenly divided by the
 // [[intel::num_simd_work_items()]] attribute.
-// If the declaration has a __attribute__((reqd_work_group_size))
-// attribute, check to see if the first argument can be evenly
-// divided by the [[intel::num_simd_work_items()]] attribute.
 struct TRIFuncObjGood1 {
   [[intel::num_simd_work_items(4)]]
   [[intel::reqd_work_group_size(3, 64, 4)]] void
@@ -241,7 +239,7 @@ struct TRIFuncObjGood4 {
 };
 
 [[intel::num_simd_work_items(2)]]
-__attribute__((reqd_work_group_size(4,3,3))) void func6(); //OK
+__attribute__((reqd_work_group_size(3, 2, 6))) void func6(); //OK
 
 int main() {
   q.submit([&](handler &h) {

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -60,6 +60,14 @@ struct TRIFuncObjBad2 {
   operator()() const {}
 };
 
+// Tests for the default values of [[intel::reqd_work_group_size()]].
+
+// FIXME: This should be accepted instaed of error which turns out to be
+// an implementation bug that shouldn't be visible to the user as there
+// aren't really any default values. The dimensionality of the attribute
+// must match the kernel, so three different forms of the attribute
+// (one, two, and three argument) can be used instead of assuming default
+// values. This will prevent to redeclare the function with a different dimensionality.
 struct TRIFuncObjBad3 {
   [[intel::num_simd_work_items(3)]]  // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
   [[intel::reqd_work_group_size(3)]] //expected-note{{conflicting attribute is here}}
@@ -67,6 +75,12 @@ struct TRIFuncObjBad3 {
   operator()() const {}
 };
 
+// FIXME: This should be accepted instaed of error which turns out to be
+// an implementation bug that shouldn't be visible to the user as there
+// aren't really any default values. The dimensionality of the attribute
+// must match the kernel, so three different forms of the attribute
+// (one, two, and three argument) can be used instead of assuming default
+// values. This will prevent to redeclare the function with a different dimensionality.
 struct TRIFuncObjBad4 {
   [[intel::reqd_work_group_size(3)]] // expected-note{{conflicting attribute is here}}
   [[intel::num_simd_work_items(3)]]  // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
@@ -74,6 +88,12 @@ struct TRIFuncObjBad4 {
   operator()() const {}
 };
 
+// FIXME: This should be accepted instaed of error which turns out to be
+// an implementation bug that shouldn't be visible to the user as there
+// aren't really any default values. The dimensionality of the attribute
+// must match the kernel, so three different forms of the attribute
+// (one, two, and three argument) can be used instead of assuming default
+// values. This will prevent to redeclare the function with a different dimensionality.
 struct TRIFuncObjBad5 {
   [[intel::num_simd_work_items(4)]]      // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
   [[intel::reqd_work_group_size(4, 64)]] // expected-note{{conflicting attribute is here}}
@@ -81,6 +101,12 @@ struct TRIFuncObjBad5 {
   operator()() const {}
 };
 
+// FIXME: This should be accepted instaed of error which turns out to be
+// an implementation bug that shouldn't be visible to the user as there
+// aren't really any default values. The dimensionality of the attribute
+// must match the kernel, so three different forms of the attribute
+// (one, two, and three argument) can be used instead of assuming default
+// values. This will prevent to redeclare the function with a different dimensionality.
 struct TRIFuncObjBad6 {
   [[intel::reqd_work_group_size(4, 64)]] // expected-note{{conflicting attribute is here}}
   [[intel::num_simd_work_items(4)]]      // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -62,7 +62,7 @@ struct TRIFuncObjBad2 {
 
 // Tests for the default values of [[intel::reqd_work_group_size()]].
 
-// FIXME: This should be accepted instaed of error which turns out to be
+// FIXME: This should be accepted instead of error which turns out to be
 // an implementation bug that shouldn't be visible to the user as there
 // aren't really any default values. The dimensionality of the attribute
 // must match the kernel, so three different forms of the attribute
@@ -75,7 +75,7 @@ struct TRIFuncObjBad3 {
   operator()() const {}
 };
 
-// FIXME: This should be accepted instaed of error which turns out to be
+// FIXME: This should be accepted instead of error which turns out to be
 // an implementation bug that shouldn't be visible to the user as there
 // aren't really any default values. The dimensionality of the attribute
 // must match the kernel, so three different forms of the attribute
@@ -88,7 +88,7 @@ struct TRIFuncObjBad4 {
   operator()() const {}
 };
 
-// FIXME: This should be accepted instaed of error which turns out to be
+// FIXME: This should be accepted instead of error which turns out to be
 // an implementation bug that shouldn't be visible to the user as there
 // aren't really any default values. The dimensionality of the attribute
 // must match the kernel, so three different forms of the attribute
@@ -101,7 +101,7 @@ struct TRIFuncObjBad5 {
   operator()() const {}
 };
 
-// FIXME: This should be accepted instaed of error which turns out to be
+// FIXME: This should be accepted instead of error which turns out to be
 // an implementation bug that shouldn't be visible to the user as there
 // aren't really any default values. The dimensionality of the attribute
 // must match the kernel, so three different forms of the attribute

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -42,65 +42,82 @@ struct FuncObj {
 };
 
 #ifdef TRIGGER_ERROR
-// If the declaration has an [[intel::reqd_work_group_size]] or
-// [[cl::reqd_work_group_size]] attribute, tests that check if
-// the work group size attribute argument (the first argument)
-// can be evenly divided by the num_simd_work_items attribute.
+// If the declaration has a [[intel::reqd_work_group_size]]
+// attribute, tests that check if the work group size attribute
+// argument (the last argument) can be evenly divided by the
+// num_simd_work_items attribute.
 struct TRIFuncObjBad1 {
   [[intel::num_simd_work_items(3)]]        // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-  [[intel::reqd_work_group_size(5, 3, 3)]] // expected-note{{conflicting attribute is here}}
+  [[intel::reqd_work_group_size(3, 6, 5)]] // expected-note{{conflicting attribute is here}}
   void
   operator()() const {}
 };
 
 struct TRIFuncObjBad2 {
-  [[intel::reqd_work_group_size(5, 3, 3)]] // expected-note{{conflicting attribute is here}}
+  [[intel::reqd_work_group_size(3, 6, 5)]] // expected-note{{conflicting attribute is here}}
   [[intel::num_simd_work_items(3)]]        // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
   void
   operator()() const {}
 };
 
 struct TRIFuncObjBad3 {
-  [[intel::num_simd_work_items(3)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-  [[cl::reqd_work_group_size(5, 3, 3)]] // expected-note{{conflicting attribute is here}}
+  [[intel::num_simd_work_items(3)]]  // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+  [[intel::reqd_work_group_size(3)]] //expected-note{{conflicting attribute is here}}
   void
   operator()() const {}
 };
 
 struct TRIFuncObjBad4 {
-  [[cl::reqd_work_group_size(5, 3, 3)]] // expected-note{{conflicting attribute is here}}
-  [[intel::num_simd_work_items(3)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+  [[intel::reqd_work_group_size(3)]] // expected-note{{conflicting attribute is here}}
+  [[intel::num_simd_work_items(3)]]  // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
   void
   operator()() const {}
 };
 
 struct TRIFuncObjBad5 {
-  [[intel::num_simd_work_items(3)]]  // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-  [[intel::reqd_work_group_size(5)]] //expected-note{{conflicting attribute is here}}
+  [[intel::num_simd_work_items(4)]]      // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+  [[intel::reqd_work_group_size(4, 64)]] // expected-note{{conflicting attribute is here}}
   void
   operator()() const {}
 };
 
 struct TRIFuncObjBad6 {
-  [[intel::reqd_work_group_size(5)]] // expected-note{{conflicting attribute is here}}
-  [[intel::num_simd_work_items(3)]]  // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+  [[intel::reqd_work_group_size(4, 64)]] // expected-note{{conflicting attribute is here}}
+  [[intel::num_simd_work_items(4)]]      // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
   void
   operator()() const {}
 };
 
+[[intel::num_simd_work_items(2)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+[[intel::reqd_work_group_size(4, 2, 3)]] void func1(); // expected-note{{conflicting attribute is here}}
+
+// If the declaration has a [[cl::reqd_work_group_size]]
+// or __attribute__((reqd_work_group_size())) attribute,
+// tests that check if the work group size attribute argument
+// (the first argument) can be evenly divided by the num_simd_work_items
+// attribute. GNU and [[cl::reqd_work_group_size]] spelling of
+// ReqdWorkGroupSizeAttr maps to the OpenCL semantics.
+// First and last argument are only swapped for the Intel atributes in
+// SYCL and not the OpenCL ones.
 struct TRIFuncObjBad7 {
-  [[intel::num_simd_work_items(4)]]      // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-  [[intel::reqd_work_group_size(3, 64)]] // expected-note{{conflicting attribute is here}}
+  [[cl::reqd_work_group_size(5, 6, 8)]] // expected-note{{conflicting attribute is here}}
+  [[intel::num_simd_work_items(2)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
   void
   operator()() const {}
 };
 
 struct TRIFuncObjBad8 {
-  [[intel::reqd_work_group_size(3, 64)]] // expected-note{{conflicting attribute is here}}
-  [[intel::num_simd_work_items(4)]]      // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+  [[intel::num_simd_work_items(2)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+  [[cl::reqd_work_group_size(5, 6, 8)]] // expected-note{{conflicting attribute is here}}
   void
   operator()() const {}
 };
+
+[[intel::num_simd_work_items(2)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+__attribute__((reqd_work_group_size(3, 2, 4))) void func2(); // expected-note{{conflicting attribute is here}}
+
+[[intel::num_simd_work_items(2)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+[[cl::reqd_work_group_size(5, 2, 4)]] void func3(); // expected-note{{conflicting attribute is here}}
 
 // Tests for incorrect argument values for Intel FPGA num_simd_work_items and reqd_work_group_size function attributes
 struct TRIFuncObjBad9 {
@@ -164,57 +181,42 @@ struct TRIFuncObjBad18 {
 };
 
 #endif // TRIGGER_ERROR
-// If the declaration has an [[intel::reqd_work_group_size]] or
-// [[cl::reqd_work_group_size]] attribute, tests that check if
-// the work group size attribute argument (the first argument)
-// can be evenly divided by the num_simd_work_items attribute.
+// If the declaration has a [[intel::reqd_work_group_size()]]
+// attribute, check to see if the last argument can be evenly
+// divided by the num_simd_work_items attribute.
+// If the declaration has a __attribute__((reqd_work_group_size))
+// or [[cl::reqd_work_group_size()]] attribute, check to see if the
+// first argument can be evenly divided by the num_simd_work_items
+// attribute. GNU and [[cl::reqd_work_group_size()]] spelling of
+// ReqdWorkGroupSizeAttr maps to the OpenCL semantics. First and last
+// argument are only swapped for the Intel atributes in SYCL and not
+// the OpenCL ones.
 struct TRIFuncObjGood1 {
   [[intel::num_simd_work_items(4)]]
-  [[intel::reqd_work_group_size(64, 64, 5)]] void
+  [[intel::reqd_work_group_size(3, 64, 4)]] void
   operator()() const {}
 };
 
 struct TRIFuncObjGood2 {
-  [[intel::reqd_work_group_size(64, 64, 5)]]
+  [[intel::reqd_work_group_size(3, 64, 4)]]
   [[intel::num_simd_work_items(4)]] void
   operator()() const {}
 };
 
 struct TRIFuncObjGood3 {
   [[intel::num_simd_work_items(4)]]
-  [[cl::reqd_work_group_size(64, 64, 5)]] void
+  [[cl::reqd_work_group_size(4, 64, 5)]] void
   operator()() const {}
 };
 
 struct TRIFuncObjGood4 {
-  [[cl::reqd_work_group_size(64, 64, 5)]]
+  [[cl::reqd_work_group_size(4, 64, 5)]]
   [[intel::num_simd_work_items(4)]] void
   operator()() const {}
 };
 
-struct TRIFuncObjGood5 {
-  [[intel::num_simd_work_items(4)]]
-  [[intel::reqd_work_group_size(64)]] void
-  operator()() const {}
-};
-
-struct TRIFuncObjGood6 {
-  [[intel::reqd_work_group_size(64)]]
-  [[intel::num_simd_work_items(4)]] void
-  operator()() const {}
-};
-
-struct TRIFuncObjGood7 {
-  [[intel::num_simd_work_items(4)]]
-  [[intel::reqd_work_group_size(64, 5)]] void
-  operator()() const {}
-};
-
-struct TRIFuncObjGood8 {
-  [[intel::reqd_work_group_size(64, 5)]]
-  [[intel::num_simd_work_items(4)]] void
-  operator()() const {}
-};
+[[intel::num_simd_work_items(2)]]
+__attribute__((reqd_work_group_size(4,3,3))) void func4(); //OK
 
 int main() {
   q.submit([&](handler &h) {
@@ -251,27 +253,27 @@ int main() {
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
     // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 64
-    // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
+    // CHECK-NEXT:  value: Int 3
+    // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 64
     // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 5
-    // CHECK-NEXT:  IntegerLiteral{{.*}}5{{$}}
+    // CHECK-NEXT:  value: Int 4
+    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
 
     h.single_task<class test_kernel5>(TRIFuncObjGood2());
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel5
     // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 64
-    // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
+    // CHECK-NEXT:  value: Int 3
+    // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 64
     // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 5
-    // CHECK-NEXT:  IntegerLiteral{{.*}}5{{$}}
+    // CHECK-NEXT:  value: Int 4
+    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
     // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 4
@@ -285,8 +287,8 @@ int main() {
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
     // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 64
-    // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
+    // CHECK-NEXT:  value: Int 4
+    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 64
     // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
@@ -298,82 +300,14 @@ int main() {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel7
     // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 64
-    // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
+    // CHECK-NEXT:  value: Int 4
+    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 64
     // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 5
     // CHECK-NEXT:  IntegerLiteral{{.*}}5{{$}}
-    // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-
-    h.single_task<class test_kernel8>(TRIFuncObjGood5());
-    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel8
-    // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 64
-    // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-
-    h.single_task<class test_kernel9>(TRIFuncObjGood6());
-    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel9
-    // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 64
-    // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-
-    h.single_task<class test_kernel10>(TRIFuncObjGood7());
-    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel10
-    // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 64
-    // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 5
-    // CHECK-NEXT:  IntegerLiteral{{.*}}5{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-
-    h.single_task<class test_kernel11>(TRIFuncObjGood8());
-    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel11
-    // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 64
-    // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 5
-    // CHECK-NEXT:  IntegerLiteral{{.*}}5{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
     // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 4
@@ -382,49 +316,49 @@ int main() {
 #ifdef TRIGGER_ERROR
     [[intel::num_simd_work_items(0)]] int Var = 0; // expected-error{{'num_simd_work_items' attribute only applies to functions}}
 
-    h.single_task<class test_kernel12>(
+    h.single_task<class test_kernel8>(
         []() [[intel::num_simd_work_items(0)]]{}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 
-    h.single_task<class test_kernel13>(
+    h.single_task<class test_kernel9>(
         []() [[intel::num_simd_work_items(-42)]]{}); // expected-error{{'num_simd_work_items' attribute requires a positive integral compile time constant expression}}
 
-    h.single_task<class test_kernel14>(TRIFuncObjBad1());
+    h.single_task<class test_kernel10>(TRIFuncObjBad1());
 
-    h.single_task<class test_kernel15>(TRIFuncObjBad2());
+    h.single_task<class test_kernel11>(TRIFuncObjBad2());
 
-    h.single_task<class test_kernel16>(TRIFuncObjBad3());
+    h.single_task<class test_kernel12>(TRIFuncObjBad3());
 
-    h.single_task<class test_kernel17>(TRIFuncObjBad4());
+    h.single_task<class test_kernel13>(TRIFuncObjBad4());
 
-    h.single_task<class test_kernel18>(TRIFuncObjBad5());
+    h.single_task<class test_kernel14>(TRIFuncObjBad5());
 
-    h.single_task<class test_kernel19>(TRIFuncObjBad6());
+    h.single_task<class test_kernel15>(TRIFuncObjBad6());
 
-    h.single_task<class test_kernel20>(TRIFuncObjBad7());
+    h.single_task<class test_kernel16>(TRIFuncObjBad7());
 
-    h.single_task<class test_kernel21>(TRIFuncObjBad8());
+    h.single_task<class test_kernel17>(TRIFuncObjBad8());
 
-    h.single_task<class test_kernel22>(TRIFuncObjBad9());
+    h.single_task<class test_kernel18>(TRIFuncObjBad9());
 
-    h.single_task<class test_kernel23>(TRIFuncObjBad10());
+    h.single_task<class test_kernel19>(TRIFuncObjBad10());
 
-    h.single_task<class test_kernel24>(TRIFuncObjBad11());
+    h.single_task<class test_kernel20>(TRIFuncObjBad11());
 
-    h.single_task<class test_kernel25>(TRIFuncObjBad12());
+    h.single_task<class test_kernel21>(TRIFuncObjBad12());
 
-    h.single_task<class test_kernel26>(TRIFuncObjBad13());
+    h.single_task<class test_kernel22>(TRIFuncObjBad13());
 
-    h.single_task<class test_kernel27>(TRIFuncObjBad14());
+    h.single_task<class test_kernel23>(TRIFuncObjBad14());
 
-    h.single_task<class test_kernel28>(TRIFuncObjBad15());
+    h.single_task<class test_kernel24>(TRIFuncObjBad15());
 
-    h.single_task<class test_kernel29>(TRIFuncObjBad16());
+    h.single_task<class test_kernel25>(TRIFuncObjBad16());
 
-    h.single_task<class test_kernel30>(TRIFuncObjBad17());
+    h.single_task<class test_kernel26>(TRIFuncObjBad17());
 
-    h.single_task<class test_kernel31>(TRIFuncObjBad18());
+    h.single_task<class test_kernel27>(TRIFuncObjBad18());
 
-    h.single_task<class test_kernel32>(
+    h.single_task<class test_kernel28>(
         []() [[intel::num_simd_work_items(1), intel::num_simd_work_items(2)]]{}); // expected-warning{{attribute 'num_simd_work_items' is already applied with different arguments}} \
                                                                                   // expected-note {{previous attribute is here}}
 #endif // TRIGGER_ERROR

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -43,9 +43,9 @@ struct FuncObj {
 
 #ifdef TRIGGER_ERROR
 // If the declaration has a [[intel::reqd_work_group_size]]
-// attribute, tests that check if the work group size attribute
-// argument (the last argument) can be evenly divided by the
-// num_simd_work_items attribute.
+// [[cl::reqd_work_group_size]] attribute, tests that check
+// if the work group size attribute argument (the last argument)
+// can be evenly divided by the [[intel::num_simd_work_items()]] attribute.
 struct TRIFuncObjBad1 {
   [[intel::num_simd_work_items(3)]]        // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
   [[intel::reqd_work_group_size(3, 6, 5)]] // expected-note{{conflicting attribute is here}}
@@ -88,36 +88,41 @@ struct TRIFuncObjBad6 {
   operator()() const {}
 };
 
-[[intel::num_simd_work_items(2)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-[[intel::reqd_work_group_size(4, 2, 3)]] void func1(); // expected-note{{conflicting attribute is here}}
-
-// If the declaration has a [[cl::reqd_work_group_size]]
-// or __attribute__((reqd_work_group_size())) attribute,
-// tests that check if the work group size attribute argument
-// (the first argument) can be evenly divided by the num_simd_work_items
-// attribute. GNU and [[cl::reqd_work_group_size]] spelling of
-// ReqdWorkGroupSizeAttr maps to the OpenCL semantics.
-// First and last argument are only swapped for the Intel atributes in
-// SYCL and not the OpenCL ones.
 struct TRIFuncObjBad7 {
-  [[cl::reqd_work_group_size(5, 6, 8)]] // expected-note{{conflicting attribute is here}}
-  [[intel::num_simd_work_items(2)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+  [[cl::reqd_work_group_size(6, 3, 5)]] // expected-note{{conflicting attribute is here}}
+  [[intel::num_simd_work_items(3)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
   void
   operator()() const {}
 };
 
 struct TRIFuncObjBad8 {
-  [[intel::num_simd_work_items(2)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-  [[cl::reqd_work_group_size(5, 6, 8)]] // expected-note{{conflicting attribute is here}}
+  [[intel::num_simd_work_items(3)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+  [[cl::reqd_work_group_size(6, 3, 5)]] // expected-note{{conflicting attribute is here}}
   void
   operator()() const {}
 };
 
 [[intel::num_simd_work_items(2)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-__attribute__((reqd_work_group_size(3, 2, 4))) void func2(); // expected-note{{conflicting attribute is here}}
+[[intel::reqd_work_group_size(4, 2, 3)]] void func1(); // expected-note{{conflicting attribute is here}}
+
+[[intel::reqd_work_group_size(4, 2, 3)]] // expected-note{{conflicting attribute is here}}
+[[intel::num_simd_work_items(2)]] void func2(); // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
 
 [[intel::num_simd_work_items(2)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-[[cl::reqd_work_group_size(5, 2, 4)]] void func3(); // expected-note{{conflicting attribute is here}}
+[[cl::reqd_work_group_size(4, 2, 3)]] void func3(); // expected-note{{conflicting attribute is here}}
+
+[[cl::reqd_work_group_size(4, 2, 3)]] // expected-note{{conflicting attribute is here}}
+[[intel::num_simd_work_items(2)]] void func4(); // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+
+// If the declaration has a __attribute__((reqd_work_group_size()))
+// attribute, tests that check if the work group size attribute argument
+// (the first argument) can be evenly divided by the [[intel::num_simd_work_items()]]
+// attribute. GNU spelling of ReqdWorkGroupSizeAttr maps to the OpenCL semantics.
+// First and last argument are only swapped for the Intel atributes in
+// SYCL and not the OpenCL ones.
+
+[[intel::num_simd_work_items(2)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+__attribute__((reqd_work_group_size(3, 2, 4))) void func5(); // expected-note{{conflicting attribute is here}}
 
 // Tests for incorrect argument values for Intel FPGA num_simd_work_items and reqd_work_group_size function attributes
 struct TRIFuncObjBad9 {
@@ -182,15 +187,15 @@ struct TRIFuncObjBad18 {
 
 #endif // TRIGGER_ERROR
 // If the declaration has a [[intel::reqd_work_group_size()]]
-// attribute, check to see if the last argument can be evenly
-// divided by the num_simd_work_items attribute.
+// or [[cl::reqd_work_group_size()]] attribute, check to see
+// if the last argument can be evenly divided by the
+// [[intel::num_simd_work_items()]] attribute.
 // If the declaration has a __attribute__((reqd_work_group_size))
-// or [[cl::reqd_work_group_size()]] attribute, check to see if the
-// first argument can be evenly divided by the num_simd_work_items
-// attribute. GNU and [[cl::reqd_work_group_size()]] spelling of
-// ReqdWorkGroupSizeAttr maps to the OpenCL semantics. First and last
-// argument are only swapped for the Intel atributes in SYCL and not
-// the OpenCL ones.
+// attribute, check to see if the first argument can be evenly
+// divided by the [[intel::num_simd_work_items()]] attribute.
+// GNU spelling of ReqdWorkGroupSizeAttr maps to the OpenCL semantics.
+// First and last argument are only swapped for the Intel atributes in
+// SYCL and not the OpenCL ones.
 struct TRIFuncObjGood1 {
   [[intel::num_simd_work_items(4)]]
   [[intel::reqd_work_group_size(3, 64, 4)]] void
@@ -205,18 +210,18 @@ struct TRIFuncObjGood2 {
 
 struct TRIFuncObjGood3 {
   [[intel::num_simd_work_items(4)]]
-  [[cl::reqd_work_group_size(4, 64, 5)]] void
+  [[cl::reqd_work_group_size(3, 64, 4)]] void
   operator()() const {}
 };
 
 struct TRIFuncObjGood4 {
-  [[cl::reqd_work_group_size(4, 64, 5)]]
+  [[cl::reqd_work_group_size(3, 64, 4)]]
   [[intel::num_simd_work_items(4)]] void
   operator()() const {}
 };
 
 [[intel::num_simd_work_items(2)]]
-__attribute__((reqd_work_group_size(4,3,3))) void func4(); //OK
+__attribute__((reqd_work_group_size(4,3,3))) void func6(); //OK
 
 int main() {
   q.submit([&](handler &h) {
@@ -287,27 +292,27 @@ int main() {
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
     // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
+    // CHECK-NEXT:  value: Int 3
+    // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 64
     // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 5
-    // CHECK-NEXT:  IntegerLiteral{{.*}}5{{$}}
+    // CHECK-NEXT:  value: Int 4
+    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
 
     h.single_task<class test_kernel7>(TRIFuncObjGood4());
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel7
     // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
+    // CHECK-NEXT:  value: Int 3
+    // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 64
     // CHECK-NEXT:  IntegerLiteral{{.*}}64{{$}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 5
-    // CHECK-NEXT:  IntegerLiteral{{.*}}5{{$}}
+    // CHECK-NEXT:  value: Int 4
+    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
     // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 4

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -144,9 +144,6 @@ struct TRIFuncObjBad8 {
 // attribute, tests that check if the work group size attribute argument
 // (the first argument) can be evenly divided by the [[intel::num_simd_work_items()]]
 // attribute. GNU spelling of ReqdWorkGroupSizeAttr maps to the OpenCL semantics.
-// First and last argument are only swapped for the Intel atributes in
-// SYCL and not the OpenCL ones.
-
 [[intel::num_simd_work_items(2)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
 __attribute__((reqd_work_group_size(3, 2, 4))) void func5(); // expected-note{{conflicting attribute is here}}
 
@@ -219,9 +216,6 @@ struct TRIFuncObjBad18 {
 // If the declaration has a __attribute__((reqd_work_group_size))
 // attribute, check to see if the first argument can be evenly
 // divided by the [[intel::num_simd_work_items()]] attribute.
-// GNU spelling of ReqdWorkGroupSizeAttr maps to the OpenCL semantics.
-// First and last argument are only swapped for the Intel atributes in
-// SYCL and not the OpenCL ones.
 struct TRIFuncObjGood1 {
   [[intel::num_simd_work_items(4)]]
   [[intel::reqd_work_group_size(3, 64, 4)]] void

--- a/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
@@ -131,34 +131,19 @@ template <int N>
 [[intel::num_simd_work_items(2)]] void func12(); // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
 
 int check1() {
-  // no error expected
-  func6<3>();
-  //expected-note@+1{{in instantiation of function template specialization 'func6<2>' requested here}}
-  func6<2>();
-  //expected-note@+1{{in instantiation of function template specialization 'func7<4>' requested here}}
-  func7<4>();
-  // no error expected
-  func7<5>();
-  //expected-note@+1{{in instantiation of function template specialization 'func8<5>' requested here}}
-  func8<5>();
-  // no error expected
-  func8<3>();
-  //expected-note@+1{{in instantiation of function template specialization 'func9<6, 3, 5, 3>' requested here}}
-  func9<6, 3, 5, 3>();
-  // no error expected
-  func9<9, 6, 3, 3>();
-  //expected-note@+1{{in instantiation of function template specialization 'func10<6, 3, 5>' requested here}}
-  func10<6, 3, 5>();
-  // no error expected
-  func10<9, 6, 3>();
-  //expected-note@+1{{in instantiation of function template specialization 'func11<6, 4, 5>' requested here}}
-  func11<6, 4, 5>();
-  // no error expected
-  func11<8, 6, 2>();
-  //expected-note@+1{{in instantiation of function template specialization 'func12<3>' requested here}}
-  func12<3>();
-  // no error expected
-  func12<2>();
+  func6<3>(); // OK
+  func6<2>(); // expected-note {{in instantiation of function template specialization 'func6<2>' requested here}}
+  func7<4>(); // expected-note {{in instantiation of function template specialization 'func7<4>' requested here}}
+  func7<5>(); // OK
+  func8<5>(); // expected-note {{in instantiation of function template specialization 'func8<5>' requested here}}
+  func8<3>(); // OK
+  func9<6, 3, 5, 3>(); // expected-note {{in instantiation of function template specialization 'func9<6, 3, 5, 3>' requested here}}
+  func9<9, 6, 3, 3>(); // OK
+  func10<6, 3, 5>(); // expected-note {{in instantiation of function template specialization 'func10<6, 3, 5>' requested here}}
+  func10<9, 6, 3>(); // OK
+  func11<6, 4, 5>(); // expected-note {{in instantiation of function template specialization 'func11<6, 4, 5>' requested here}} 
+  func11<8, 6, 2>(); // OK
+  func12<3>(); // expected-note {{in instantiation of function template specialization 'func12<3>' requested here}} 
+  func12<2>(); // OK
   return 0;
 }
-

--- a/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-num_simd_work_items-template.cpp
@@ -96,7 +96,7 @@ int check() {
 
 // Tests for num_simd_work_items and reqd_work_group_size arguments check.
 template <int N>
-__attribute__((reqd_work_group_size(3, 6, 4))) void func6(); // expected-note{{conflicting attribute is here}}
+__attribute__((reqd_work_group_size(8, 6, 3))) void func6(); // expected-note{{conflicting attribute is here}}
 template <int N>
 [[intel::num_simd_work_items(N)]] void func6(); // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
 


### PR DESCRIPTION
The arguments to reqd_work_group_size are ordered based on which index
increments the fastest. In OpenCL, the first argument is the index that
increments the fastest, and in SYCL, the last argument is the index that
increments the fastest.

In OpenCL, all three arguments are required.

In SYCL, the attribute accepts either one, two, or three arguments; in each
form, the last (or only) argument is the index that increments fastest.
The number of arguments passed to the attribute must match the dimensionality
of the kernel the attribute is applied to.

If the reqd_work_group_size attribute is specified on a declaration along
with num_simd_work_items, the required work group size specified
by num_simd_work_items attribute must evenly divide the index that
increments fastest in the reqd_work_group_size attribute.

This patches fixes the problem on https://github.com/intel/llvm/pull/3275 where we checked the wrong argument for SYCL and OpenCL attributes.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>