### PR TITLE
[Driver][SYCL] Add support to pass -fsycl-unique-prefix

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -660,6 +660,11 @@ private:
   /// by the host compilation.
   mutable llvm::StringMap<StringRef> IntegrationFileList;
 
+  /// Unique ID used for SYCL compilations.  Each file will use a different
+  /// unique ID, but the same ID will be used for different compilation
+  /// targets.
+  mutable llvm::StringMap<StringRef> SYCLUniqueIDList;
+
 public:
   /// GetReleaseVersion - Parse (([0-9]+)(.([0-9]+)(.([0-9]+)?))?)? and
   /// return the grouped values as integers. Numbers which are not
@@ -709,6 +714,16 @@ public:
   /// getIntegrationHeader - Get the integration header file
   StringRef getIntegrationHeader(StringRef FileName) const {
     return IntegrationFileList[FileName];
+  }
+
+  /// setSYCLUniqueID - set the Unique ID that is used for all FE invocations
+  /// when performing compilations for SYCL.
+  void addSYCLUniqueID(StringRef UniqueID, StringRef FileName) const {
+    SYCLUniqueIDList.insert({FileName, UniqueID});
+  }
+  /// getSYCLUniqueID - Get the Unique ID associated with the file.
+  StringRef getSYCLUniqueID(StringRef FileName) const {
+    return SYCLUniqueIDList[FileName];
   }
 };
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5165,6 +5165,11 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       StringRef TmpFileHeader =
           C.addTempFile(C.getArgs().MakeArgString(TmpFileNameHeader));
       addIntegrationFiles(TmpFileHeader, SrcFileName);
+
+      // Create/Add the Unique ID used for each FE invocation.
+      SmallString<128> ResultID;
+      llvm::sys::fs::createUniquePath("%%%%%%%%%%%%%%%%", ResultID, false);
+      addSYCLUniqueID(Args.MakeArgString(ResultID.str()), SrcFileName);
     }
   }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5153,23 +5153,25 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
 
   handleArguments(C, Args, Inputs, Actions);
 
-  // When compiling for -fsycl, generate the integration header files that
-  // will be used during the compilation.
+  // When compiling for -fsycl, generate the integration header files and the
+  // Unique ID that will be used during the compilation.
   if (Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
     for (auto &I : Inputs) {
+      std::string SrcFileName(I.second->getAsString(Args));
+      if (I.first == types::TY_PP_C || I.first == types::TY_PP_CXX ||
+          types::isSrcFile(I.first)) {
+        // Unique ID is generated for source files and preprocessed files.
+        SmallString<128> ResultID;
+        llvm::sys::fs::createUniquePath("%%%%%%%%%%%%%%%%", ResultID, false);
+        addSYCLUniqueID(Args.MakeArgString(ResultID.str()), SrcFileName);
+      }
       if (!types::isSrcFile(I.first))
         continue;
-      std::string SrcFileName(I.second->getAsString(Args));
       std::string TmpFileNameHeader = C.getDriver().GetTemporaryPath(
           llvm::sys::path::stem(SrcFileName).str() + "-header", "h");
       StringRef TmpFileHeader =
           C.addTempFile(C.getArgs().MakeArgString(TmpFileNameHeader));
       addIntegrationFiles(TmpFileHeader, SrcFileName);
-
-      // Create/Add the Unique ID used for each FE invocation.
-      SmallString<128> ResultID;
-      llvm::sys::fs::createUniquePath("%%%%%%%%%%%%%%%%", ResultID, false);
-      addSYCLUniqueID(Args.MakeArgString(ResultID.str()), SrcFileName);
     }
   }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4597,6 +4597,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     if (Args.hasArg(options::OPT_fsycl_unnamed_lambda))
       CmdArgs.push_back("-fsycl-unnamed-lambda");
 
+    // Add the Unique ID prefix
+    StringRef UniqueID = D.getSYCLUniqueID(Input.getBaseInput());
+    if (!UniqueID.empty())
+      CmdArgs.push_back(
+          Args.MakeArgString(Twine("-fsycl-unique-prefix=") + UniqueID));
+
     // Enable generation of USM address spaces for FPGA.
     // __ENABLE_USM_ADDR_SPACE__ will be used during compilation of SYCL headers
     if (getToolChain().getTriple().getSubArch() ==

--- a/clang/test/Driver/sycl-unique-prefix.cpp
+++ b/clang/test/Driver/sycl-unique-prefix.cpp
@@ -9,3 +9,10 @@
 // CHECK_PREFIX: clang{{.*}} "-triple" "spir64-unknown-unknown-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX2:([A-z0-9]){16}]]"{{.*}} "{{.*}}_file2.cpp"
 // CHECK_PREFIX: clang{{.*}} "-triple" "spir64_gen-unknown-unknown-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX2]]"{{.*}} "{{.*}}_file2.cpp"
 // CHECK_PREFIX: clang{{.*}} "-fsycl-unique-prefix=[[PREFIX2]]"{{.*}} "-fsycl-is-host"{{.*}}  "{{.*}}_file2.cpp"
+
+/// Check for prefix with preprocessed input
+// RUN: touch %t.ii
+// RUN: %clangxx -fsycl -c %t.ii -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK_PREFIX_II %s
+// CHECK_PREFIX_II: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX:([A-z0-9]){16}]]"{{.*}} "{{.*}}.ii"
+// CHECK_PREFIX_II: clang{{.*}} "-fsycl-unique-prefix=[[PREFIX]]"{{.*}} "-fsycl-is-host"{{.*}} "{{.*}}.ii"

--- a/clang/test/Driver/sycl-unique-prefix.cpp
+++ b/clang/test/Driver/sycl-unique-prefix.cpp
@@ -1,0 +1,11 @@
+/// Test for Unique prefix setting for SYCL compilations
+// RUN: touch %t_file1.cpp
+// RUN: touch %t_file2.cpp
+// RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice,spir64_gen-unknown-unknown-sycldevice -c %t_file1.cpp %t_file2.cpp -### 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK_PREFIX %s
+// CHECK_PREFIX: clang{{.*}} "-triple" "spir64-unknown-unknown-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX1:([A-z0-9]){16}]]"{{.*}} "{{.*}}_file1.cpp"
+// CHECK_PREFIX: clang{{.*}} "-triple" "spir64_gen-unknown-unknown-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX1]]"{{.*}} "{{.*}}_file1.cpp"
+// CHECK_PREFIX: clang{{.*}} "-fsycl-unique-prefix=[[PREFIX1]]"{{.*}} "-fsycl-is-host"{{.*}} "{{.*}}_file1.cpp"
+// CHECK_PREFIX: clang{{.*}} "-triple" "spir64-unknown-unknown-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX2:([A-z0-9]){16}]]"{{.*}} "{{.*}}_file2.cpp"
+// CHECK_PREFIX: clang{{.*}} "-triple" "spir64_gen-unknown-unknown-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX2]]"{{.*}} "{{.*}}_file2.cpp"
+// CHECK_PREFIX: clang{{.*}} "-fsycl-unique-prefix=[[PREFIX2]]"{{.*}} "-fsycl-is-host"{{.*}}  "{{.*}}_file2.cpp"


### PR DESCRIPTION
When compiling for -fsycl, we need to add additional unique strings to
the front end via -fsycl-unique-prefix=prefix.  This string is generated
in the driver and is 16 characters in length.  The same prefix is used
for each target compilation for an individual source file.