### PR TITLE
[SYCL] Fix spec constants when device split is enabled

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -218,12 +218,6 @@ private:
           MBinImage->getSpecConstants();
       using SCItTy = pi::DeviceBinaryImage::PropertyRange::ConstIterator;
 
-      // get default values for specialization constants
-      const pi::DeviceBinaryImage::PropertyRange &SCDefValRange =
-          MBinImage->getSpecConstantsDefaultValues();
-
-      bool HasDefaultValues = SCDefValRange.begin() != SCDefValRange.end();
-
       // This variable is used to calculate spec constant value offset in a
       // flat byte array.
       unsigned BlobOffset = 0;
@@ -256,12 +250,19 @@ private:
           // supposed to be called from c'tor.
           MSpecConstSymMap[std::string{SCName}].push_back(
               SpecConstDescT{/*ID*/ It[0], /*CompositeOffset*/ It[1],
-                             /*Size*/ It[2], BlobOffset, HasDefaultValues});
+                             /*Size*/ It[2], BlobOffset});
           BlobOffset += /*Size*/ It[2];
           It += NumElements;
         }
       }
       MSpecConstsBlob.resize(BlobOffset);
+      //
+      // get default values for specialization constants
+      const pi::DeviceBinaryImage::PropertyRange &SCDefValRange =
+          MBinImage->getSpecConstantsDefaultValues();
+
+      const bool HasDefaultValues =
+          SCDefValRange.begin() != SCDefValRange.end();
 
       if (HasDefaultValues) {
         pi::ByteArray DefValDescriptors =

--- a/sycl/test/on-device/basic_tests/specialization_constants/device_split.cpp
+++ b/sycl/test/on-device/basic_tests/specialization_constants/device_split.cpp
@@ -1,0 +1,58 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-device-code-split=per_kernel %s -o %t.out
+// RUN: %t.out
+
+// UNSUPPORTED: cuda
+
+#include <sycl/sycl.hpp>
+
+#include <cmath>
+
+const static sycl::specialization_id<int> SpecConst1{42};
+const static sycl::specialization_id<int> SpecConst2{42};
+
+int main() {
+  sycl::queue Q;
+
+  // No support for host device so far
+  if (Q.is_host())
+    return 0;
+
+  const sycl::context Ctx = Q.get_context();
+  const sycl::device Dev = Q.get_device();
+
+  sycl::kernel_bundle KernelBundle =
+      sycl::get_kernel_bundle<sycl::bundle_state::input>(Ctx, {Dev});
+
+  KernelBundle.set_specialization_constant<SpecConst1>(1);
+  KernelBundle.set_specialization_constant<SpecConst2>(2);
+
+  {
+    auto ExecBundle = sycl::build(KernelBundle);
+    sycl::buffer<int, 1> Buf{sycl::range{1}};
+    Q.submit([&](sycl::handler &CGH) {
+      CGH.use_kernel_bundle(ExecBundle);
+      auto Acc = Buf.get_access<sycl::access::mode::read_write>(CGH);
+      CGH.single_task<class Kernel1Name>([=](sycl::kernel_handler KH) {
+        Acc[0] = KH.get_specialization_constant<SpecConst1>();
+      });
+    });
+    auto Acc = Buf.get_access<sycl::access::mode::read>();
+    assert(Acc[0] == 1);
+  }
+
+  {
+    auto ExecBundle = sycl::build(KernelBundle);
+    sycl::buffer<int, 1> Buf{sycl::range{1}};
+    Q.submit([&](sycl::handler &CGH) {
+      CGH.use_kernel_bundle(ExecBundle);
+      auto Acc = Buf.get_access<sycl::access::mode::read_write>(CGH);
+      CGH.single_task<class Kernel2Name>([=](sycl::kernel_handler KH) {
+        Acc[0] = KH.get_specialization_constant<SpecConst2>();
+      });
+    });
+    auto Acc = Buf.get_access<sycl::access::mode::read>();
+    assert(Acc[0] == 2);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
SYCL tooling performs specialization constants extraction before code
split. As a result, device image may contain properties, that describe
spec constants not present in device image. Do not advertise default
values as set to avoid incorrect API calls.