### PR TITLE
[sycl-post-link] Handle spec constants after device code split

### DIFF
--- a/llvm/test/tools/sycl-post-link/spec-constants/spec_const_and_split.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/spec_const_and_split.ll
@@ -15,7 +15,7 @@
 @SCSymID = private unnamed_addr constant [10 x i8] c"SpecConst\00", align 1
 @SCSymID2 = private unnamed_addr constant [11 x i8] c"SpecConst2\00", align 1
 ; CHECK-IR-NOT: @SCSymID
-; CHECK-IR-NOT: @SCSymID
+; CHECK-IR-NOT: @SCSymID2
 
 declare dso_local spir_func zeroext i1 @_Z33__sycl_getScalarSpecConstantValueIbET_PKc(i8 addrspace(4)*)
 

--- a/llvm/test/tools/sycl-post-link/spec-constants/spec_const_and_split.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/spec_const_and_split.ll
@@ -2,27 +2,48 @@
 ; device code splitting and specialization constant processing are
 ; requested.
 ;
+; Additionally this test checks that sycl-post-link creates specialization
+; constant property correctly: i.e. it doesn't put all specialization constants
+; into properties of each device image
+
 ; RUN: sycl-post-link -split=kernel -spec-const=rt -S %s -o %t.files.table
-; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefixes CHECK0,CHECK
-; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefixes CHECK1,CHECK
+; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefixes CHECK-IR0,CHECK-IR
+; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefixes CHECK-IR1,CHECK-IR
+; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefixes CHECK-PROP0
+; RUN: FileCheck %s -input-file=%t.files_1.prop --check-prefixes CHECK-PROP1
 
 @SCSymID = private unnamed_addr constant [10 x i8] c"SpecConst\00", align 1
-; CHECK-NOT: @SCSymID
+@SCSymID2 = private unnamed_addr constant [11 x i8] c"SpecConst2\00", align 1
+; CHECK-IR-NOT: @SCSymID
+; CHECK-IR-NOT: @SCSymID
 
 declare dso_local spir_func zeroext i1 @_Z33__sycl_getScalarSpecConstantValueIbET_PKc(i8 addrspace(4)*)
 
 define dso_local spir_kernel void @KERNEL_AAA() {
   %1 = call spir_func zeroext i1 @_Z33__sycl_getScalarSpecConstantValueIbET_PKc(i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([10 x i8], [10 x i8]* @SCSymID, i64 0, i64 0) to i8 addrspace(4)*))
-; CHECK0: %{{[0-9]+}} = call i1 @_Z20__spirv_SpecConstantib(i32 0, i1 false)
+; CHECK-IR0: %{{[0-9]+}} = call i1 @_Z20__spirv_SpecConstantib(i32 1, i1 false)
+  %2 = call spir_func zeroext i1 @_Z33__sycl_getScalarSpecConstantValueIbET_PKc(i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([11 x i8], [11 x i8]* @SCSymID2, i64 0, i64 0) to i8 addrspace(4)*))
+; CHECK-IR0: %{{[0-9]+}} = call i1 @_Z20__spirv_SpecConstantib(i32 0, i1 false)
   ret void
 }
 
 define dso_local spir_kernel void @KERNEL_BBB() {
   %1 = call spir_func zeroext i1 @_Z33__sycl_getScalarSpecConstantValueIbET_PKc(i8 addrspace(4)* addrspacecast (i8* getelementptr inbounds ([10 x i8], [10 x i8]* @SCSymID, i64 0, i64 0) to i8 addrspace(4)*))
-; CHECK1: %{{[0-9]+}} = call i1 @_Z20__spirv_SpecConstantib(i32 0, i1 false)
+; CHECK-IR1: %{{[0-9]+}} = call i1 @_Z20__spirv_SpecConstantib(i32 0, i1 false)
   ret void
 }
 
-; CHECK: !sycl.specialization-constants = !{![[#MD:]]}
+; CHECK-IR0: !sycl.specialization-constants = !{![[#MD0:]], ![[#MD1:]]}
+; CHECK-IR0: ![[#MD0:]] = !{!"SpecConst2", i32 0, i32 0, i32 1}
+; CHECK-IR0: ![[#MD1:]] = !{!"SpecConst", i32 1, i32 0, i32 1}
+;
+; CHECK-IR1: !sycl.specialization-constants = !{![[#MD0:]]}
+; CHECK-IR1: ![[#MD0:]] = !{!"SpecConst", i32 0, i32 0, i32 1}
 
-; CHECK: ![[#MD:]] = !{!"SpecConst", i32 0, i32 0, i32 1}
+; CHECK-PROP0: [SYCL/specialization constants]
+; CHECK-PROP0: SpecConst=2|
+; CHECK-PROP0: SpecConst2=2|
+;
+; CHECK-PROP1: [SYCL/specialization constants]
+; CHECK-PROP1: SpecConst=2|
+; CHECK-PROP1-NOT: SpecConst2

--- a/llvm/test/tools/sycl-post-link/spec-constants/spec_const_and_split.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/spec_const_and_split.ll
@@ -9,8 +9,10 @@
 ; RUN: sycl-post-link -split=kernel -spec-const=rt -S %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefixes CHECK-IR0,CHECK-IR
 ; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefixes CHECK-IR1,CHECK-IR
+; RUN: FileCheck %s -input-file=%t.files_2.ll --check-prefixes CHECK-IR2,CHECK-IR
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefixes CHECK-PROP0
 ; RUN: FileCheck %s -input-file=%t.files_1.prop --check-prefixes CHECK-PROP1
+; RUN: FileCheck %s -input-file=%t.files_2.prop --check-prefixes CHECK-PROP2
 
 @SCSymID = private unnamed_addr constant [10 x i8] c"SpecConst\00", align 1
 @SCSymID2 = private unnamed_addr constant [11 x i8] c"SpecConst2\00", align 1
@@ -33,12 +35,19 @@ define dso_local spir_kernel void @KERNEL_BBB() {
   ret void
 }
 
+define dso_local spir_kernel void @KERNEL_CCC() {
+; CHECK-IR2: define{{.*}}spir_kernel void @KERNEL_CCC
+  ret void
+}
+
 ; CHECK-IR0: !sycl.specialization-constants = !{![[#MD0:]], ![[#MD1:]]}
 ; CHECK-IR0: ![[#MD0:]] = !{!"SpecConst2", i32 0, i32 0, i32 1}
 ; CHECK-IR0: ![[#MD1:]] = !{!"SpecConst", i32 1, i32 0, i32 1}
 ;
 ; CHECK-IR1: !sycl.specialization-constants = !{![[#MD0:]]}
 ; CHECK-IR1: ![[#MD0:]] = !{!"SpecConst", i32 0, i32 0, i32 1}
+;
+; CHECK-IR2: !sycl.specialization-constants = !{}
 
 ; CHECK-PROP0: [SYCL/specialization constants]
 ; CHECK-PROP0: SpecConst=2|
@@ -47,3 +56,6 @@ define dso_local spir_kernel void @KERNEL_BBB() {
 ; CHECK-PROP1: [SYCL/specialization constants]
 ; CHECK-PROP1: SpecConst=2|
 ; CHECK-PROP1-NOT: SpecConst2
+;
+; CHECK-PROP2: [SYCL/specialization constants]
+; CHECK-PROP2-EMPTY:

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -549,12 +549,10 @@ static TableFiles processOneModule(std::unique_ptr<Module> M, bool IsEsimd,
   bool SpecConstsMet = false;
   bool SetSpecConstAtRT = DoSpecConst && (SpecConstLower == SC_USE_RT_VAL);
 
-  if (DoSplit) {
+  if (DoSplit)
     splitModule(*M, GlobalsSet, ResultModules);
-    // post-link always produces a code result, even if it is unmodified input
-    if (ResultModules.size() == 0)
-      ResultModules.push_back(std::move(M));
-  } else
+  // post-link always produces a code result, even if it is unmodified input
+  if (ResultModules.empty())
     ResultModules.push_back(std::move(M));
 
   if (DoSpecConst) {


### PR DESCRIPTION
Due to changes in `SpecConstantsPass` introduced by intel/llvm#3513,
device image properties for specialization constants are now computed in
a bit different way: in particular they are calculated based on metadata
generated by the pass and not by looking at the SPIR-V friendly IR
intrinsics left in the module.

Such change caused a regression: if device code split was used together
with specialization constants, each resulting device image was supplied
with list of *all* specialization constants found in the _original_
undivided module. In combination with some DPC++ RT changes it lead to
setting non-existing specialization constants.

This patch fixed the regression by performing device code split step
*before* handling specialization constants.