### PR TITLE
[SYCL] Emit diagnostics appropriately when coexisting with OpenMP

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1819,14 +1819,14 @@ public:
   // Helper routine to add a pair of Callee-Caller pair of FunctionDecl *
   // to UndefinedReachableFromSyclDevice.
   void addFDToReachableFromSyclDevice(FunctionDecl *Callee,
-                                      FunctionDecl* Caller) {
+                                      FunctionDecl *Caller) {
     UndefinedReachableFromSyclDevice.push_back(std::make_pair(Callee, Caller));
   }
   // Helper routine to check if a pair of Callee-Caller FunctionDecl *
   // is in UndefinedReachableFromSyclDevice.
   bool isFDReachableFromSyclDevice(const FunctionDecl *Callee,
                                    const FunctionDecl *Caller) {
-    for (auto It: UndefinedReachableFromSyclDevice)
+    for (auto It : UndefinedReachableFromSyclDevice)
       if (It.first == Callee && It.second == Caller)
         return true;
     return false;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1818,18 +1818,18 @@ private:
 public:
   // Helper routine to add a pair of Callee-Caller pair of FunctionDecl *
   // to UndefinedReachableFromSyclDevice.
-  void addFDToReachableFromSyclDevice(FunctionDecl *Callee,
-                                      FunctionDecl *Caller) {
+  void addFDToReachableFromSyclDevice(const FunctionDecl *Callee,
+                                      const FunctionDecl *Caller) {
     UndefinedReachableFromSyclDevice.push_back(std::make_pair(Callee, Caller));
   }
   // Helper routine to check if a pair of Callee-Caller FunctionDecl *
   // is in UndefinedReachableFromSyclDevice.
   bool isFDReachableFromSyclDevice(const FunctionDecl *Callee,
                                    const FunctionDecl *Caller) {
-    for (auto It : UndefinedReachableFromSyclDevice)
-      if (It.first == Callee && It.second == Caller)
-        return true;
-    return false;
+    return llvm::any_of(UndefinedReachableFromSyclDevice,
+                        [Callee, Caller](const CallPair &P) {
+                          return P.first == Callee && P.second == Caller;
+                        });
   }
 
   /// A generic diagnostic builder for errors which may or may not be deferred.

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1665,7 +1665,7 @@ public:
       S.finalizeOpenMPDelayedAnalysis(Caller, FD, Loc);
     // Finalize analysis of SYCL-specific constructs.
     if (Caller && S.LangOpts.SYCLIsDevice)
-      S.finalizeSYCLDelayedAnalysis(Caller, FD, Loc);
+      S.finalizeSYCLDelayedAnalysis(Caller, FD, Loc, RootReason);
     if (Caller)
       S.DeviceKnownEmittedFns[FD] = {Caller, Loc};
     // Always emit deferred diagnostics for the direct users. This does not

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18475,14 +18475,14 @@ Sema::DeviceDiagnosticReason Sema::getEmissionReason(const FunctionDecl *FD) {
   if (FD->hasAttr<SYCLDeviceAttr>() || FD->hasAttr<SYCLKernelAttr>())
     return Sema::DeviceDiagnosticReason::Sycl;
   // FIXME: Refine the logic for CUDA and OpenMP.
-  if (getLangOpts().CUDA && getLangOpts().CUDAIsDevice)
-    return Sema::DeviceDiagnosticReason::CudaDevice;
-  if (getLangOpts().CUDA && !getLangOpts().CUDAIsDevice)
-    return Sema::DeviceDiagnosticReason::CudaHost;
-  if (getLangOpts().OpenMPIsDevice)
-    return Sema::DeviceDiagnosticReason::OmpDevice;
-  if (getLangOpts().OpenMP && !getLangOpts().OpenMPIsDevice)
-    return Sema::DeviceDiagnosticReason::OmpHost;
+  if (getLangOpts().CUDA)
+    return getLangOpts().CUDAIsDevice ?
+       Sema::DeviceDiagnosticReason::CudaDevice :
+       Sema::DeviceDiagnosticReason::CudaHost;
+  if (getLangOpts().OpenMP)
+    return getLangOpts().OpenMPIsDevice ?
+        Sema::DeviceDiagnosticReason::OmpDevice :
+        Sema::DeviceDiagnosticReason::OmpHost;
   return Sema::DeviceDiagnosticReason::All;
 }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18469,11 +18469,20 @@ Decl *Sema::getObjCDeclContext() const {
 }
 
 Sema::DeviceDiagnosticReason Sema::getEmissionReason(const FunctionDecl *FD) {
+  // FIXME: This should really be a bitwise-or of the language modes.
   if (FD->hasAttr<SYCLSimdAttr>())
     return Sema::DeviceDiagnosticReason::Esimd;
-  else if (FD->hasAttr<SYCLDeviceAttr>() || FD->hasAttr<SYCLKernelAttr>())
+  if (FD->hasAttr<SYCLDeviceAttr>() || FD->hasAttr<SYCLKernelAttr>())
     return Sema::DeviceDiagnosticReason::Sycl;
-  // FIXME: Figure out the logic for OMP and CUDA.
+  // FIXME: Refine the logic for CUDA and OpenMP.
+  if (getLangOpts().CUDA && getLangOpts().CUDAIsDevice)
+    return Sema::DeviceDiagnosticReason::CudaDevice;
+  if (getLangOpts().CUDA && !getLangOpts().CUDAIsDevice)
+    return Sema::DeviceDiagnosticReason::CudaHost;
+  if (getLangOpts().OpenMPIsDevice)
+    return Sema::DeviceDiagnosticReason::OmpDevice;
+  if (getLangOpts().OpenMP && !getLangOpts().OpenMPIsDevice)
+    return Sema::DeviceDiagnosticReason::OmpHost;
   return Sema::DeviceDiagnosticReason::All;
 }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18476,13 +18476,12 @@ Sema::DeviceDiagnosticReason Sema::getEmissionReason(const FunctionDecl *FD) {
     return Sema::DeviceDiagnosticReason::Sycl;
   // FIXME: Refine the logic for CUDA and OpenMP.
   if (getLangOpts().CUDA)
-    return getLangOpts().CUDAIsDevice ?
-       Sema::DeviceDiagnosticReason::CudaDevice :
-       Sema::DeviceDiagnosticReason::CudaHost;
+    return getLangOpts().CUDAIsDevice ? Sema::DeviceDiagnosticReason::CudaDevice
+                                      : Sema::DeviceDiagnosticReason::CudaHost;
   if (getLangOpts().OpenMP)
-    return getLangOpts().OpenMPIsDevice ?
-        Sema::DeviceDiagnosticReason::OmpDevice :
-        Sema::DeviceDiagnosticReason::OmpHost;
+    return getLangOpts().OpenMPIsDevice
+               ? Sema::DeviceDiagnosticReason::OmpDevice
+               : Sema::DeviceDiagnosticReason::OmpHost;
   return Sema::DeviceDiagnosticReason::All;
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -599,7 +599,7 @@ class SingleDeviceFunctionTracker {
 
     // If this is a routine that is not defined and it does not have either
     // a SYCLKernel or SYCLDevice attribute on it, add it to the set of
-    // routines potentially reachable on device.   This is to diagnose such
+    // routines potentially reachable on device. This is to diagnose such
     // cases later in finalizeSYCLDeviceAnalysis().
     if (!CurrentDecl->isDefined() && !CurrentDecl->hasAttr<SYCLKernelAttr>() &&
         !CurrentDecl->hasAttr<SYCLDeviceAttr>())

--- a/clang/test/SemaSYCL/call-to-undefined-function.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function.cpp
@@ -1,4 +1,8 @@
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -fopenmp-simd -internal-isystem %S/Inputs -sycl-std=2020 -verify -fsyntax-only %s
+
+// This test checks whether we diagnose cases of unmarked, undefined
+// functions called on device from either kernels or sycl device functions.
 
 #include "sycl.hpp"
 


### PR DESCRIPTION
In the presence of OpenMP, calls to undefined functions get
diagnosed incorrectly in SYCL.  With this change, the diagnostic
is emitted only when the reason for the emission is SYCL.
This change leverages the diagnostic "reason" infrastructure
implemented in PR #3511.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>