### PR TITLE
[SYCL] Add the 'cl' inline namespace to the integration footer-

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4655,8 +4655,8 @@ static void EmitSpecIdShims(raw_ostream &OS, unsigned &ShimCounter,
 // function call parameters.
 static std::string EmitSpecIdShims(raw_ostream &OS, unsigned &ShimCounter,
                                    const VarDecl *VD) {
-  assert(VD->isInAnonymousNamespace() &&
-         "Function assumes this is in an anonymous namespace");
+  if (!VD->isInAnonymousNamespace())
+    return "";
   std::string RelativeName = VD->getNameAsString();
   EmitSpecIdShims(OS, ShimCounter, VD->getDeclContext(), RelativeName);
   return RelativeName;
@@ -4673,29 +4673,24 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
   unsigned ShimCounter = 0;
   for (const VarDecl *VD : SpecConstants) {
     VD = VD->getCanonicalDecl();
+    std::string TopShim = EmitSpecIdShims(OS, ShimCounter, VD);
+    OS << "__SYCL_INLINE_NAMESPACE(cl) {\n";
+    OS << "namespace sycl {\n";
+    OS << "namespace detail {\n";
+    OS << "template<>\n";
+    OS << "inline const char *get_spec_constant_symbolic_ID<";
+
     if (VD->isInAnonymousNamespace()) {
-      std::string TopShim = EmitSpecIdShims(OS, ShimCounter, VD);
-      OS << "__SYCL_INLINE_NAMESPACE(cl) {\n";
-      OS << "namespace sycl {\n";
-      OS << "namespace detail {\n";
-      OS << "template<>\n";
-      OS << "inline const char *get_spec_constant_symbolic_ID<" << TopShim
-         << ">() {\n";
-      OS << "  return \"";
-      emitSpecIDName(OS, VD);
-      OS << "\";\n";
+      OS << TopShim;
     } else {
-      OS << "__SYCL_INLINE_NAMESPACE(cl) {\n";
-      OS << "namespace sycl {\n";
-      OS << "namespace detail {\n";
-      OS << "template<>\n";
-      OS << "inline const char *get_spec_constant_symbolic_ID<::";
+      OS << "::";
       VD->printQualifiedName(OS, Policy);
-      OS << ">() {\n";
-      OS << "  return \"";
-      emitSpecIDName(OS, VD);
-      OS << "\";\n";
     }
+
+    OS << ">() {\n";
+    OS << "  return \"";
+    emitSpecIDName(OS, VD);
+    OS << "\";\n";
     OS << "}\n";
     OS << "} // namespace detail\n";
     OS << "} // namespace sycl\n";

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4675,6 +4675,7 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
     VD = VD->getCanonicalDecl();
     if (VD->isInAnonymousNamespace()) {
       std::string TopShim = EmitSpecIdShims(OS, ShimCounter, VD);
+      OS << "__SYCL_INLINE_NAMESPACE(cl) {\n";
       OS << "namespace sycl {\n";
       OS << "namespace detail {\n";
       OS << "template<>\n";
@@ -4684,6 +4685,7 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
       emitSpecIDName(OS, VD);
       OS << "\";\n";
     } else {
+      OS << "__SYCL_INLINE_NAMESPACE(cl) {\n";
       OS << "namespace sycl {\n";
       OS << "namespace detail {\n";
       OS << "template<>\n";
@@ -4697,6 +4699,7 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
     OS << "}\n";
     OS << "} // namespace detail\n";
     OS << "} // namespace sycl\n";
+    OS << "} // __SYCL_INLINE_NAMESPACE(cl)\n";
   }
 
   OS << "#include <CL/sycl/detail/spec_const_integration.hpp>\n";

--- a/clang/test/CodeGenSYCL/anonymous_integration_footer.cpp
+++ b/clang/test/CodeGenSYCL/anonymous_integration_footer.cpp
@@ -14,7 +14,8 @@ using namespace cl;
 // variable.
 struct S1 {
   static constexpr sycl::specialization_id a{1};
-  // CHECK: namespace sycl {
+  // CHECK: __SYCL_INLINE_NAMESPACE(cl) {
+  // CHECK-NEXT: namespace sycl {
   // CHECK-NEXT: namespace detail {
   // CHECK-NEXT: template<>
   // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::S1::a>() {
@@ -22,8 +23,10 @@ struct S1 {
   // CHECK-NEXT: }
   // CHECK-NEXT: } // namespace detail
   // CHECK-NEXT: } // namespace sycl
+  // CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 };
 constexpr sycl::specialization_id b{2};
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
@@ -32,7 +35,9 @@ constexpr sycl::specialization_id b{2};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace detail
 // CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 inline constexpr sycl::specialization_id c{3};
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
@@ -41,7 +46,9 @@ inline constexpr sycl::specialization_id c{3};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace detail
 // CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 static constexpr sycl::specialization_id d{4};
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
@@ -50,6 +57,7 @@ static constexpr sycl::specialization_id d{4};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace detail
 // CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace {
 struct S2 {
@@ -61,14 +69,16 @@ struct S2 {
   // CHECK-NEXT: }
   // CHECK-NEXT: } // namespace __sycl_detail
   // CHECK-NEXT: } // namespace
+  // CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
   // CHECK-NEXT: namespace sycl {
   // CHECK-NEXT: namespace detail {
   // CHECK-NEXT: template<>
   // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
   // CHECK-NEXT: }
-  // CHECK-NEXT: // namespace detail
-  // CHECK-NEXT: // namespace sycl
+  // CHECK-NEXT: } // namespace detail
+  // CHECK-NEXT: } // namespace sycl
+  // CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 };
 } // namespace
 
@@ -77,6 +87,7 @@ struct S3 {
   static constexpr sycl::specialization_id a{Val};
 };
 template class S3<1>;
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
@@ -85,7 +96,9 @@ template class S3<1>;
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace detail
 // CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 template class S3<2>;
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
@@ -94,9 +107,11 @@ template class S3<2>;
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace detail
 // CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace inner {
 constexpr sycl::specialization_id same_name{5};
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
@@ -105,8 +120,10 @@ constexpr sycl::specialization_id same_name{5};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace detail
 // CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 constexpr sycl::specialization_id same_name{6};
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
@@ -115,6 +132,7 @@ constexpr sycl::specialization_id same_name{6};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace detail
 // CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 namespace {
 constexpr sycl::specialization_id same_name{7};
 // CHECK-NEXT: namespace {
@@ -124,14 +142,16 @@ constexpr sycl::specialization_id same_name{7};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 namespace {
 namespace inner {
@@ -143,14 +163,16 @@ constexpr sycl::specialization_id same_name{8};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 } // namespace
 namespace inner {
@@ -165,27 +187,31 @@ constexpr sycl::specialization_id same_name{9};
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
 // CHECK-NEXT: } // namespace inner
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 } // namespace inner
 
 namespace outer {
 constexpr sycl::specialization_id same_name{10};
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::same_name>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 namespace {
 constexpr sycl::specialization_id same_name{11};
 // CHECK-NEXT: namespace outer {
@@ -197,14 +223,16 @@ constexpr sycl::specialization_id same_name{11};
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
 // CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace inner {
 constexpr sycl::specialization_id same_name{12};
@@ -217,14 +245,16 @@ constexpr sycl::specialization_id same_name{12};
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
 // CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace {
 // This has multiple anonymous namespaces in its declaration context, we need to
@@ -253,14 +283,16 @@ constexpr sycl::specialization_id same_name{13};
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
 // CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::__sycl_detail::__spec_id_shim_[[SHIM_ID_2]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 } // namespace inner
 } // namespace
@@ -276,14 +308,16 @@ constexpr sycl::specialization_id same_name{14};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 namespace {
 constexpr sycl::specialization_id same_name{15};
 // CHECK-NEXT: namespace {
@@ -304,15 +338,16 @@ constexpr sycl::specialization_id same_name{15};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
-
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 namespace inner {
 constexpr sycl::specialization_id same_name{16};
 // CHECK-NEXT: namespace {
@@ -333,14 +368,16 @@ constexpr sycl::specialization_id same_name{16};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID2]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 } // namespace
 } // namespace outer
@@ -349,7 +386,8 @@ constexpr sycl::specialization_id same_name{16};
 namespace outer {
 namespace inner {
 constexpr sycl::specialization_id same_name{17};
-// CHECK: namespace sycl {
+// CHECK: __SYCL_INLINE_NAMESPACE(cl) {
+// CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::inner::same_name>() {
@@ -357,6 +395,7 @@ constexpr sycl::specialization_id same_name{17};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace detail
 // CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 } // namespace outer
 

--- a/clang/test/CodeGenSYCL/anonymous_integration_footer2.cpp
+++ b/clang/test/CodeGenSYCL/anonymous_integration_footer2.cpp
@@ -13,63 +13,75 @@ using namespace cl;
 struct S1 {
   static constexpr sycl::specialization_id a{1};
 };
-// CHECK: namespace sycl {
+// CHECK: __SYCL_INLINE_NAMESPACE(cl) {
+// CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::S1::a>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 
 constexpr sycl::specialization_id b{202};
-// CHECK: namespace sycl {
+// CHECK: __SYCL_INLINE_NAMESPACE(cl) {
+// CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::b>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 inline constexpr sycl::specialization_id c{3};
-// CHECK: namespace sycl {
+// CHECK: __SYCL_INLINE_NAMESPACE(cl) {
+// CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::c>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 static constexpr sycl::specialization_id d{205};
-// CHECK: namespace sycl {
+// CHECK: __SYCL_INLINE_NAMESPACE(cl) {
+// CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::d>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace inner {
 constexpr sycl::specialization_id same_name{5};
-// CHECK: namespace sycl {
+// CHECK: __SYCL_INLINE_NAMESPACE(cl) {
+// CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::inner::same_name>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 constexpr sycl::specialization_id same_name{6};
-// CHECK: namespace sycl {
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
+// CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::same_name>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 namespace {
 constexpr sycl::specialization_id same_name{207};
 // CHECK: namespace {
@@ -79,14 +91,16 @@ constexpr sycl::specialization_id same_name{207};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 namespace {
 namespace inner {
@@ -98,14 +112,16 @@ constexpr sycl::specialization_id same_name{208};
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace __sycl_detail
 // CHECK-NEXT: } // namespace
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 } // namespace
 
@@ -123,14 +139,16 @@ constexpr sycl::specialization_id same_name{209};
 // CHECK-NEXT: } // namespace
 // CHECK-NEXT: } // inline namespace inner
 // CHECK-NEXT: } // namespace outer
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
 // CHECK-NEXT: namespace sycl {
 // CHECK-NEXT: namespace detail {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::outer::inner::__sycl_detail::__spec_id_shim_[[SHIM_ID]]()>() {
 // CHECK-NEXT: return "";
 // CHECK-NEXT: }
-// CHECK-NEXT: // namespace detail
-// CHECK-NEXT: // namespace sycl
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 }
 }
 


### PR DESCRIPTION
Vlad Romanov brought up that we'd missed this in the initial
implementation, so add it so that the 'cl' namespace is correctly
included.