### PR TITLE
[SYCL][NFC] Add missing includes

### DIFF
--- a/sycl/unittests/thread_safety/ThreadUtils.h
+++ b/sycl/unittests/thread_safety/ThreadUtils.h
@@ -1,7 +1,10 @@
 #include <detail/scheduler/scheduler.hpp>
 
-#include <thread>
-#include <vector>
+#include <condition_variable> // std::conditional_variable
+#include <mutex>              // std::mutex, std::unique_lock
+#include <thread>             // std::thread
+#include <utility>            // std::forward
+#include <vector>             // std::vector
 
 /* Single use thread barrier which makes threads wait until defined number of
  * threads reach it.


### PR DESCRIPTION
Missing includes in the file cause build failures on some
configurations.