### PR TITLE
[SYCL] Fix ABI tests failures in post-commit

### DIFF
--- a/sycl/test/abi/layout_buffer.cpp
+++ b/sycl/test/abi/layout_buffer.cpp
@@ -23,7 +23,7 @@ void foo(sycl::buffer<int, 2>) {}
 // CHECK-NEXT:  24 |             struct std::_Tuple_impl<0, class sycl::detail::SYCLMemObjAllocator *, struct std::default_delete<class sycl::detail::SYCLMemObjAllocator> > (base)
 // CHECK-NEXT:  24 |               struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::SYCLMemObjAllocator> > (base) (empty)
 // CHECK-NEXT:  24 |                 struct std::_Head_base<1, struct std::default_delete<class sycl::detail::SYCLMemObjAllocator>, true> (base) (empty)
-// CHECK-NEXT:  24 |                   struct std::default_delete<class sycl::detail::SYCLMemObjAllocator> (base) (empty)
+// CHECK-NEXT:  24 |                   struct std::default_delete<class sycl::detail::SYCLMemObjAllocator>
 // CHECK-NEXT:  24 |               struct std::_Head_base<0, class sycl::detail::SYCLMemObjAllocator *, false> (base)
 // CHECK-NEXT:  24 |                 class sycl::detail::SYCLMemObjAllocator * _M_head_impl
 // CHECK-NEXT:  32 |     class sycl::property_list MProps

--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -134,7 +134,7 @@ void foo() {
 // CHECK-NEXT: 416 |         struct std::_Tuple_impl<0, class sycl::detail::HostKernelBase *, struct std::default_delete<class sycl::detail::HostKernelBase> > (base)
 // CHECK-NEXT: 416 |           struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::HostKernelBase> > (base) (empty)
 // CHECK-NEXT: 416 |             struct std::_Head_base<1, struct std::default_delete<class sycl::detail::HostKernelBase>, true> (base) (empty)
-// CHECK-NEXT: 416 |               struct std::default_delete<class sycl::detail::HostKernelBase> (base) (empty)
+// CHECK-NEXT: 416 |               struct std::default_delete<class sycl::detail::HostKernelBase>
 // CHECK-NEXT: 416 |           struct std::_Head_base<0, class sycl::detail::HostKernelBase *, false> (base)
 // CHECK-NEXT: 416 |             class sycl::detail::HostKernelBase * _M_head_impl
 // CHECK-NEXT: 424 |   class std::unique_ptr<class sycl::detail::HostTask> MHostTask
@@ -143,7 +143,7 @@ void foo() {
 // CHECK-NEXT: 424 |         struct std::_Tuple_impl<0, class sycl::detail::HostTask *, struct std::default_delete<class sycl::detail::HostTask> > (base)
 // CHECK-NEXT: 424 |           struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::HostTask> > (base) (empty)
 // CHECK-NEXT: 424 |             struct std::_Head_base<1, struct std::default_delete<class sycl::detail::HostTask>, true> (base) (empty)
-// CHECK-NEXT: 424 |               struct std::default_delete<class sycl::detail::HostTask> (base) (empty)
+// CHECK-NEXT: 424 |               struct std::default_delete<class sycl::detail::HostTask>
 // CHECK-NEXT: 424 |           struct std::_Head_base<0, class sycl::detail::HostTask *, false> (base)
 // CHECK-NEXT: 424 |             class sycl::detail::HostTask * _M_head_impl
 // CHECK-NEXT: 432 |   detail::OSModuleHandle MOSModuleHandle
@@ -153,7 +153,7 @@ void foo() {
 // CHECK-NEXT: 440 |         struct std::_Tuple_impl<0, class sycl::detail::InteropTask *, struct std::default_delete<class sycl::detail::InteropTask> > (base)
 // CHECK-NEXT: 440 |           struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::InteropTask> > (base) (empty)
 // CHECK-NEXT: 440 |             struct std::_Head_base<1, struct std::default_delete<class sycl::detail::InteropTask>, true> (base) (empty)
-// CHECK-NEXT: 440 |               struct std::default_delete<class sycl::detail::InteropTask> (base) (empty)
+// CHECK-NEXT: 440 |               struct std::default_delete<class sycl::detail::InteropTask>
 // CHECK-NEXT: 440 |           struct std::_Head_base<0, class sycl::detail::InteropTask *, false> (base)
 // CHECK-NEXT: 440 |             class sycl::detail::InteropTask * _M_head_impl
 // CHECK-NEXT: 448 |   class std::vector<class std::shared_ptr<class sycl::detail::event_impl> > MEvents

--- a/sycl/test/abi/layout_image.cpp
+++ b/sycl/test/abi/layout_image.cpp
@@ -24,7 +24,7 @@ sycl::image<2> Img{sycl::image_channel_order::rgba, sycl::image_channel_type::fp
 // CHECK-NEXT: 24 |             struct std::_Tuple_impl<0, class sycl::detail::SYCLMemObjAllocator *, struct std::default_delete<class sycl::detail::SYCLMemObjAllocator> > (base)
 // CHECK-NEXT: 24 |               struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::SYCLMemObjAllocator> > (base) (empty)
 // CHECK-NEXT: 24 |                 struct std::_Head_base<1, struct std::default_delete<class sycl::detail::SYCLMemObjAllocator>, true> (base) (empty)
-// CHECK-NEXT: 24 |                   struct std::default_delete<class sycl::detail::SYCLMemObjAllocator> (base) (empty)
+// CHECK-NEXT: 24 |                   struct std::default_delete<class sycl::detail::SYCLMemObjAllocator>
 // CHECK-NEXT: 24 |               struct std::_Head_base<0, class sycl::detail::SYCLMemObjAllocator *, false> (base)
 // CHECK-NEXT: 24 |                 class sycl::detail::SYCLMemObjAllocator * _M_head_impl
 // CHECK-NEXT: 32 |     class sycl::property_list MProps


### PR DESCRIPTION
Recently GitHub Actions machines got support for GCC11. Update ABI
layout tests for new version of C++ headers.