### PR TITLE
[SYCL] Fix wrong checks in IsReduOptForFastReduce<> introduced in (#3…

### DIFF
--- a/sycl/include/CL/sycl/ONEAPI/reduction.hpp
+++ b/sycl/include/CL/sycl/ONEAPI/reduction.hpp
@@ -94,7 +94,7 @@ using IsReduOptForFastAtomicFetch =
 template <typename T, class BinaryOperation>
 using IsReduOptForFastReduce =
     bool_constant<((is_sgeninteger<T>::value &&
-                    (sizeof(T) == 32 || sizeof(T) == 64)) ||
+                    (sizeof(T) == 4 || sizeof(T) == 8)) ||
                    is_sgenfloat<T>::value) &&
                   (IsReduPlus<T, BinaryOperation>::value ||
                    IsReduMinimum<T, BinaryOperation>::value ||


### PR DESCRIPTION
…227)

The check added in (#3227) was supposed to return true for int32/int64,
but wrongly checked the type sizes in bits instead of bytes,
which prohibited usage of group ADD algorithm for int32/int64 in reductions.
Fixed in this patch.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>