### PR TITLE
[SYCL-PTX] Restrict OpenCL extensions to SYCL PTX

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -142,14 +142,6 @@ public:
     Opts["cl_khr_global_int32_extended_atomics"] = true;
     Opts["cl_khr_local_int32_base_atomics"] = true;
     Opts["cl_khr_local_int32_extended_atomics"] = true;
-    // PTX actually supports 64 bits operations even if the Nvidia OpenCL
-    // runtime does not report support for it.
-    // This is required for libclc to compile 64 bits atomic functions.
-    // FIXME: maybe we should have a way to control this ?
-    Opts["cl_khr_int64_base_atomics"] = true;
-    Opts["cl_khr_int64_extended_atomics"] = true;
-    Opts["cl_khr_fp16"] = true;
-    Opts["cl_khr_3d_image_writes"] = true;
   }
 
   /// \returns If a target requires an address within a target specific address
@@ -180,6 +172,18 @@ public:
     TargetInfo::adjust(Opts);
     // FIXME: Needed for compiling SYCL to PTX.
     TLSSupported = TLSSupported || Opts.SYCLIsDevice;
+
+    if (Opts.SYCLIsDevice) {
+      auto &OpenCLOpts = getSupportedOpenCLOpts();
+      // PTX actually supports 64 bits operations even if the Nvidia OpenCL
+      // runtime does not report support for it.
+      // This is required for libclc to compile 64 bits atomic functions.
+      // FIXME: maybe we should have a way to control this ?
+      OpenCLOpts["cl_khr_int64_base_atomics"] = true;
+      OpenCLOpts["cl_khr_int64_extended_atomics"] = true;
+      OpenCLOpts["cl_khr_fp16"] = true;
+      OpenCLOpts["cl_khr_3d_image_writes"] = true;
+    }
   }
 
   bool hasExtIntType() const override { return true; }

--- a/clang/test/Misc/nvptx-sycl.languageOptsOpenCL.cl
+++ b/clang/test/Misc/nvptx-sycl.languageOptsOpenCL.cl
@@ -1,0 +1,24 @@
+// REQUIRES: nvptx-registered-target
+// RUN: %clang_cc1 -fsycl-is-device -triple nvptx-unknown-unknown %s
+// RUN: %clang_cc1 -fsycl-is-device -triple nvptx64-unknown-unknown %s
+
+// OpenCL extensions enabled for NVPTX with SYCL
+#ifndef cl_khr_fp16
+#error "Missing cl_khr_fp16 define"
+#endif
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+#ifndef cl_khr_int64_base_atomics
+#error "Missing cl_khr_int64_base_atomics define"
+#endif
+#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
+
+#ifndef cl_khr_int64_extended_atomics
+#error "Missing cl_khr_int64_extended_atomics define"
+#endif
+#pragma OPENCL EXTENSION cl_khr_int64_extended_atomics : enable
+
+#ifndef cl_khr_3d_image_writes
+#error "Missing cl_khr_3d_image_writes define"
+#endif
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable

--- a/clang/test/Misc/nvptx.languageOptsOpenCL.cl
+++ b/clang/test/Misc/nvptx.languageOptsOpenCL.cl
@@ -28,30 +28,23 @@
 #endif
 #pragma OPENCL EXTENSION __cl_clang_variadic_functions : enable
 
-// TODO: Temporarily disabling the following test as a work around for the
-// SYCL codepath until the cl_khr_fp16 is restricted to only the sycldevice triple.
-// link to issue https://github.com/intel/llvm/issues/1814
-
-// #ifdef cl_khr_fp16
-// #error "Incorrect cl_khr_fp16 define"
-// #endif
+#ifdef cl_khr_fp16
+#error "Incorrect cl_khr_fp16 define"
+#endif
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+// expected-warning@-1{{unsupported OpenCL extension 'cl_khr_fp16' - ignoring}}
 
-// TODO: Temporarily disabling the following two tests as a work around for the
-// SYCL codepath until the cl_khr_int64_base_atomics and
-// cl_khr_int64_extended_atomics are restricted to only the sycldevice triple.
-
-//#ifdef cl_khr_int64_base_atomics
-//#error "Incorrect cl_khr_int64_base_atomics define"
-//#endif
+#ifdef cl_khr_int64_base_atomics
+#error "Incorrect cl_khr_int64_base_atomics define"
+#endif
 #pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
-// expectedwarning@-1{{unsupported OpenCL extension 'cl_khr_int64_base_atomics' - ignoring}}
+// expected-warning@-1{{unsupported OpenCL extension 'cl_khr_int64_base_atomics' - ignoring}}
 
-//#ifdef cl_khr_int64_extended_atomics
-//#error "Incorrect cl_khr_int64_extended_atomics define"
-//#endif
+#ifdef cl_khr_int64_extended_atomics
+#error "Incorrect cl_khr_int64_extended_atomics define"
+#endif
 #pragma OPENCL EXTENSION cl_khr_int64_extended_atomics : enable
-// expectedwarning@-1{{unsupported OpenCL extension 'cl_khr_int64_extended_atomics' - ignoring}}
+// expected-warning@-1{{unsupported OpenCL extension 'cl_khr_int64_extended_atomics' - ignoring}}
 
 // Core features in CL 1.1
 
@@ -104,18 +97,12 @@
 // expected-warning@-2{{OpenCL extension 'cl_khr_fp64' is core feature or supported optional core feature - ignoring}}
 #endif
 
-// TODO: Temporarily disabling the following test as a work around for the
-// SYCL codepath until the cl_khr_3d_image_writes is restricted to
-// only the sycldevice triple.
-
 // Core feature in CL 2.0, but not supported on nvptx
-// #ifdef cl_khr_3d_image_writes
-// #error "Incorrect cl_khr_3d_image_writes define"
-// #endif
-#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
-#if (__OPENCL_C_VERSION__ >= 200) && defined TEST_CORE_FEATURES
-// expected-warning@-2{{OpenCL extension 'cl_khr_3d_image_writes' is core feature or supported optional core feature - ignoring}}
+#ifdef cl_khr_3d_image_writes
+#error "Incorrect cl_khr_3d_image_writes define"
 #endif
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+// expected-warning@-1{{unsupported OpenCL extension 'cl_khr_3d_image_writes' - ignoring}}
 
 #ifdef cl_khr_gl_msaa_sharing
 #error "Incorrect cl_khr_gl_msaa_sharing define"

--- a/clang/test/Misc/nvptx.unsupported_core.cl
+++ b/clang/test/Misc/nvptx.unsupported_core.cl
@@ -1,7 +1,3 @@
-// TODO: Temporarily disabling the following test as a work around for the
-// SYCL codepath until the cl_khr_3d_image_writes is restricted to only
-// the sycldevice triple.
-// XFAIL: *
 // RUN: %clang_cc1 -cl-std=CL2.0 -triple nvptx-unknown-unknown -Wpedantic-core-features %s 2> %t
 // RUN: FileCheck --check-prefixes=CHECK-C < %t %s
 // RUN: %clang_cc1 -cl-std=CLC++ -triple nvptx-unknown-unknown -Wpedantic-core-features %s 2> %t


### PR DESCRIPTION
These changes restricts the enabling of `cl_khr_fp16`, `cl_khr_int64_base_atomics`, `cl_khr_int64_extended_atomics`, and `cl_khr_int64_extended_atomics` to SYCL language mode.