### PR TITLE
[SYCL] Add macro to disable range rounding for FPGA compilations

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -252,7 +252,7 @@ LANGOPT(GPUExcludeWrongSideOverloads, 1, 0, "always exclude wrong side overloads
 LANGOPT(SYCLIsDevice      , 1, 0, "Generate code for SYCL device")
 LANGOPT(SYCLIsHost        , 1, 0, "SYCL host compilation")
 LANGOPT(SYCLAllowFuncPtr  , 1, 0, "Allow function pointers in SYCL device code")
-LANGOPT(SYCLAllowFpgaFlag , 1, 0, "Allow fintelfpga flag in SYCL host and device codes")
+LANGOPT(AheadOfTimeFPGACompilation, 1, 0, "SYCL compilation with -fintelfpga flag")
 LANGOPT(SYCLStdLayoutKernelParams, 1, 0, "Enable standard layout requirement for SYCL kernel parameters")
 LANGOPT(SYCLUnnamedLambda , 1, 0, "Allow unnamed lambda SYCL kernels")
 ENUM_LANGOPT(SYCLVersion  , SYCLMajorVersion, 2, SYCL_None, "Version of the SYCL standard used")

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -263,7 +263,7 @@ LANGOPT(
     "SYCL compiler assumes value fits within MAX_INT for member function of "
     "get/operator[], get_id/operator[] and get_global_id/get_global_linear_id "
     "in SYCL class id, iterm and nd_iterm")
-LANGOPT(SYCLDisableRangeRounding, 1, 0, "Disable Parallel for range rounding")
+LANGOPT(SYCLDisableRangeRounding, 1, 0, "Disable parallel for range rounding")
 
 LANGOPT(HIPUseNewLaunchAPI, 1, 0, "Use new kernel launching API for HIP")
 

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -264,6 +264,7 @@ LANGOPT(
     "SYCL compiler assumes value fits within MAX_INT for member function of "
     "get/operator[], get_id/operator[] and get_global_id/get_global_linear_id "
     "in SYCL class id, iterm and nd_iterm")
+LANGOPT(SYCLDisableRangeRounding, 1, 0, "Disable Parallel for range rounding")
 
 LANGOPT(HIPUseNewLaunchAPI, 1, 0, "Use new kernel launching API for HIP")
 

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -252,6 +252,7 @@ LANGOPT(GPUExcludeWrongSideOverloads, 1, 0, "always exclude wrong side overloads
 LANGOPT(SYCLIsDevice      , 1, 0, "Generate code for SYCL device")
 LANGOPT(SYCLIsHost        , 1, 0, "SYCL host compilation")
 LANGOPT(SYCLAllowFuncPtr  , 1, 0, "Allow function pointers in SYCL device code")
+LANGOPT(SYCLAllowFpgaFlag , 1, 0, "Allow fintelfpga flag in SYCL host and device codes")
 LANGOPT(SYCLStdLayoutKernelParams, 1, 0, "Enable standard layout requirement for SYCL kernel parameters")
 LANGOPT(SYCLUnnamedLambda , 1, 0, "Allow unnamed lambda SYCL kernels")
 ENUM_LANGOPT(SYCLVersion  , SYCLMajorVersion, 2, SYCL_None, "Version of the SYCL standard used")

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -252,7 +252,7 @@ LANGOPT(GPUExcludeWrongSideOverloads, 1, 0, "always exclude wrong side overloads
 LANGOPT(SYCLIsDevice      , 1, 0, "Generate code for SYCL device")
 LANGOPT(SYCLIsHost        , 1, 0, "SYCL host compilation")
 LANGOPT(SYCLAllowFuncPtr  , 1, 0, "Allow function pointers in SYCL device code")
-LANGOPT(AheadOfTimeFPGACompilation, 1, 0, "SYCL compilation with -fintelfpga flag")
+LANGOPT(AheadOfTimeFPGACompilation, 1, 0, "Enables ahead-of-time compilation for FPGA")
 LANGOPT(SYCLStdLayoutKernelParams, 1, 0, "Enable standard layout requirement for SYCL kernel parameters")
 LANGOPT(SYCLUnnamedLambda , 1, 0, "Allow unnamed lambda SYCL kernels")
 ENUM_LANGOPT(SYCLVersion  , SYCLMajorVersion, 2, SYCL_None, "Version of the SYCL standard used")

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -252,7 +252,6 @@ LANGOPT(GPUExcludeWrongSideOverloads, 1, 0, "always exclude wrong side overloads
 LANGOPT(SYCLIsDevice      , 1, 0, "Generate code for SYCL device")
 LANGOPT(SYCLIsHost        , 1, 0, "SYCL host compilation")
 LANGOPT(SYCLAllowFuncPtr  , 1, 0, "Allow function pointers in SYCL device code")
-LANGOPT(AheadOfTimeFPGACompilation, 1, 0, "Enables ahead-of-time compilation for FPGA")
 LANGOPT(SYCLStdLayoutKernelParams, 1, 0, "Enable standard layout requirement for SYCL kernel parameters")
 LANGOPT(SYCLUnnamedLambda , 1, 0, "Allow unnamed lambda SYCL kernels")
 ENUM_LANGOPT(SYCLVersion  , SYCLMajorVersion, 2, SYCL_None, "Version of the SYCL standard used")

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2480,7 +2480,8 @@ defm strict_vtable_pointers : BoolFOption<"strict-vtable-pointers",
   NegFlag<SetFalse>>;
 def fstrict_overflow : Flag<["-"], "fstrict-overflow">, Group<f_Group>;
 def fintelfpga : Flag<["-"], "fintelfpga">, Group<f_Group>,
-  Flags<[CC1Option, CoreOption]>, HelpText<"Perform ahead of time compilation for FPGA">;
+  Flags<[CC1Option, CoreOption]>, HelpText<"Perform ahead of time compilation for FPGA">,
+  MarshallingInfoFlag<LangOpts<"SYCLAllowFpgaFlag">>;
 def fsycl_device_only : Flag<["-"], "fsycl-device-only">, Flags<[CoreOption]>,
   HelpText<"Compile SYCL kernels for device">;
 def fsycl_targets_EQ : CommaJoined<["-"], "fsycl-targets=">, Flags<[NoXarchOption, CC1Option, CoreOption]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2481,7 +2481,7 @@ defm strict_vtable_pointers : BoolFOption<"strict-vtable-pointers",
 def fstrict_overflow : Flag<["-"], "fstrict-overflow">, Group<f_Group>;
 def fintelfpga : Flag<["-"], "fintelfpga">, Group<f_Group>,
   Flags<[CC1Option, CoreOption]>, HelpText<"Perform ahead of time compilation for FPGA">,
-  MarshallingInfoFlag<LangOpts<"SYCLAllowFpgaFlag">>;
+  MarshallingInfoFlag<LangOpts<"AheadOfTimeFPGACompilation">>;
 def fsycl_device_only : Flag<["-"], "fsycl-device-only">, Flags<[CoreOption]>,
   HelpText<"Compile SYCL kernels for device">;
 def fsycl_targets_EQ : CommaJoined<["-"], "fsycl-targets=">, Flags<[NoXarchOption, CC1Option, CoreOption]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5769,6 +5769,9 @@ defm sycl_allow_func_ptr: BoolFOption<"sycl-allow-func-ptr",
 def fenable_sycl_dae : Flag<["-"], "fenable-sycl-dae">,
   HelpText<"Enable Dead Argument Elimination in SPIR kernels">,
   MarshallingInfoFlag<LangOpts<"EnableDAEInSpirKernels">>;
+def fsycl_disable_range_rounding : Flag<["-"], "fsycl-disable-range-rounding">,
+  HelpText<"Disable parallel for range-rounding.">,
+  MarshallingInfoFlag<LangOpts<"SYCLDisableRangeRounding">>;
 
 } // let Flags = [CC1Option, NoDriverOption]
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2480,8 +2480,7 @@ defm strict_vtable_pointers : BoolFOption<"strict-vtable-pointers",
   NegFlag<SetFalse>>;
 def fstrict_overflow : Flag<["-"], "fstrict-overflow">, Group<f_Group>;
 def fintelfpga : Flag<["-"], "fintelfpga">, Group<f_Group>,
-  Flags<[CC1Option, CoreOption]>, HelpText<"Perform ahead of time compilation for FPGA">,
-  MarshallingInfoFlag<LangOpts<"AheadOfTimeFPGACompilation">>;
+  Flags<[CC1Option, CoreOption]>, HelpText<"Perform ahead of time compilation for FPGA">;
 def fsycl_device_only : Flag<["-"], "fsycl-device-only">, Flags<[CoreOption]>,
   HelpText<"Compile SYCL kernels for device">;
 def fsycl_targets_EQ : CommaJoined<["-"], "fsycl-targets=">, Flags<[NoXarchOption, CC1Option, CoreOption]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5769,7 +5769,7 @@ def fenable_sycl_dae : Flag<["-"], "fenable-sycl-dae">,
   HelpText<"Enable Dead Argument Elimination in SPIR kernels">,
   MarshallingInfoFlag<LangOpts<"EnableDAEInSpirKernels">>;
 def fsycl_disable_range_rounding : Flag<["-"], "fsycl-disable-range-rounding">,
-  HelpText<"Disable parallel for range-rounding.">,
+  HelpText<"Disable parallel for range rounding.">,
   MarshallingInfoFlag<LangOpts<"SYCLDisableRangeRounding">>;
 
 } // let Flags = [CC1Option, NoDriverOption]

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4612,14 +4612,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
     // Disable parallel for range-rounding for anything involving FPGA
     auto SYCLTCRange = C.getOffloadToolChains<Action::OFK_SYCL>();
-    bool hasFPGA = false;
+    bool HasFPGA = false;
     for (auto TI = SYCLTCRange.first, TE = SYCLTCRange.second; TI != TE; ++TI)
       if (TI->second->getTriple().getSubArch() ==
           llvm::Triple::SPIRSubArch_fpga) {
-        hasFPGA = true;
+        HasFPGA = true;
         break;
       }
-    if (hasFPGA)
+    if (HasFPGA)
       CmdArgs.push_back("-fsycl-disable-range-rounding");
 
     // Enable generation of USM address spaces for FPGA.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4610,6 +4610,18 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back(
           Args.MakeArgString(Twine("-fsycl-unique-prefix=") + UniqueID));
 
+    // Disable parallel for range-rounding for anything involving FPGA
+    auto SYCLTCRange = C.getOffloadToolChains<Action::OFK_SYCL>();
+    bool hasFPGA = false;
+    for (auto TI = SYCLTCRange.first, TE = SYCLTCRange.second; TI != TE; ++TI)
+      if (TI->second->getTriple().getSubArch() ==
+          llvm::Triple::SPIRSubArch_fpga) {
+        hasFPGA = true;
+        break;
+      }
+    if (hasFPGA)
+      CmdArgs.push_back("-fsycl-disable-range-rounding");
+
     // Enable generation of USM address spaces for FPGA.
     // __ENABLE_USM_ADDR_SPACE__ will be used during compilation of SYCL headers
     if (getToolChain().getTriple().getSubArch() ==

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -488,8 +488,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
 
     // Set __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
     // both host and device compilations if -fintelfpga flag is present.
-    if (LangOpts.SYCLAllowFpgaFlag) {
-      Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");
+    if (LangOpts.AheadOfTimeFPGACompilation) {
+      Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__");
     }
   }
 

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -487,8 +487,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
       Builder.defineMacro("__SYCL_ID_QUERIES_FIT_IN_INT__", "1");
 
     // Set __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
-    // both host and device compilations using -fsycl-disable-range-rounding
-    // flag.
+    // both host and device compilations if -fsycl-disable-range-rounding
+    // flag is used.
     if (LangOpts.SYCLDisableRangeRounding)
       Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__");
   }

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -485,6 +485,12 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
 
     if (LangOpts.SYCLValueFitInMaxInt)
       Builder.defineMacro("__SYCL_ID_QUERIES_FIT_IN_INT__", "1");
+
+    // Enable __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
+    // all FPGA compilations.
+    if (LangOpts.SYCLAllowFpgaFlag) {
+      Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");
+    }
   }
 
   if (LangOpts.DeclareSPIRVBuiltins) {
@@ -1168,12 +1174,6 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
   if (LangOpts.SYCLIsDevice) {
     Builder.defineMacro("__SYCL_DEVICE_ONLY__", "1");
     Builder.defineMacro("SYCL_EXTERNAL", "__attribute__((sycl_device))");
-
-    // Enable __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
-    // all FPGA compilations.
-    if (TI.getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
-      Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");
-    }
 
     if (TI.getTriple().isNVPTX()) {
         Builder.defineMacro("__SYCL_NVPTX__", "1");

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -487,8 +487,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
       Builder.defineMacro("__SYCL_ID_QUERIES_FIT_IN_INT__", "1");
 
     // Set __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
-    // both host and device compilations if -fintelfpga flag is present.
-    if (LangOpts.AheadOfTimeFPGACompilation)
+    // both host and device compilations using -fsycl-disable-range-rounding flag.
+    if (LangOpts.SYCLDisableRangeRounding)
       Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__");
   }
 

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -487,7 +487,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
       Builder.defineMacro("__SYCL_ID_QUERIES_FIT_IN_INT__", "1");
 
     // Set __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
-    // both host and device compilations using -fsycl-disable-range-rounding flag.
+    // both host and device compilations using -fsycl-disable-range-rounding
+    // flag.
     if (LangOpts.SYCLDisableRangeRounding)
       Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__");
   }

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -488,9 +488,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
 
     // Set __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
     // both host and device compilations if -fintelfpga flag is present.
-    if (LangOpts.AheadOfTimeFPGACompilation) {
+    if (LangOpts.AheadOfTimeFPGACompilation)
       Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__");
-    }
   }
 
   if (LangOpts.DeclareSPIRVBuiltins) {

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -486,8 +486,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
     if (LangOpts.SYCLValueFitInMaxInt)
       Builder.defineMacro("__SYCL_ID_QUERIES_FIT_IN_INT__", "1");
 
-    // Enable __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
-    // all FPGA compilations.
+    // Set __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
+    // both host and device compilations if -fintelfpga flag is present.
     if (LangOpts.SYCLAllowFpgaFlag) {
       Builder.defineMacro("__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__", "1");
     }

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -5,6 +5,7 @@
 
 /// Check SYCL headers path
 // RUN:   %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-HEADERS-INTELFPGA %s
 // RUN:   %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-HEADERS-INTELFPGA %s
 // CHK-HEADERS-INTELFPGA: clang{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"
@@ -19,6 +20,21 @@
 // RUN:   %clangxx -### -target x86_64-unknown-linux-gnu -g0 -fsycl -fintelfpga %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-INTELFPGA-G0 %s
 // CHK-TOOLS-INTELFPGA-G0-NOT: clang{{.*}} "-debug-info-kind=limited"
+
+/// FPGA target implies -fsycl-disable-range-rounding
+// RUN:   %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
+// RUN:   %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
+// CHK-RANGE-ROUNDING: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-disable-range-rounding"
+// CHK-RANGE-ROUNDING: clang{{.*}} "-fsycl-disable-range-rounding"{{.*}} "-fsycl-is-host"
+
+/// -fsycl-disable-range-rounding is applied to all compilations if fpga is used
+// RUN:   %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice,spir64_gen-unknown-unknown-sycldevice %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING-MULTI %s
+// CHK-RANGE-ROUNDING-MULTI: clang{{.*}} "-triple" "spir64_fpga-unknown-unknown-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-disable-range-rounding"
+// CHK-RANGE-ROUNDING-MULTI: clang{{.*}} "-triple" "spir64_gen-unknown-unknown-sycldevice"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-disable-range-rounding"
+// CHK-RANGE-ROUNDING-MULTI: clang{{.*}} "-fsycl-disable-range-rounding"{{.*}} "-fsycl-is-host"
 
 /// -fintelfpga -fsycl-link tests
 // RUN:  touch %t.o

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -216,7 +216,7 @@
 // CHECK-HIP-DEV: #define __HIP__ 1
 
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device \
-// RUN:   -triple spir64-unknown-unknown -fintelfpga -o - \
+// RUN:   -triple spir64-unknown-unknown -fsycl-disable-range-rounding -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
 
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device \
@@ -230,7 +230,7 @@
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
 
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-host \
-// RUN: -triple x86_64-unknown-linux-gnu -fintelfpga -o - \
+// RUN: -triple x86_64-unknown-linux-gnu -fsycl-disable-range-rounding -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
 
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-host -o - \

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -219,6 +219,10 @@
 // RUN:   -triple spir64-unknown-unknown -fintelfpga -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
 
+// RUN: %clang_cc1 %s -E -dM -fsycl-is-device \
+// RUN:   -triple spir64_fpga-unknown-unknown-sycldevice -o - \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
+
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
 

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -223,6 +223,10 @@
 // RUN:   -triple spir64_fpga-unknown-unknown-sycldevice -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
 
+// RUN: %clang_cc1 %s -E -dM -fsycl-is-device -fsycl-disable-range-rounding \
+// RUN:   -triple spir64_fpga-unknown-unknown-sycldevice -o - \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
+
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
 

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -216,9 +216,8 @@
 // CHECK-HIP-DEV: #define __HIP__ 1
 
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device \
-// RUN:   -triple spir64_fpga-unknown-unknown-sycldevice -o - \
+// RUN:   -triple spir64-unknown-unknown -fintelfpga -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
-// CHECK-RANGE: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
 
 // RUN: %clang_cc1 %s -E -dM -fsycl-is-device -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
@@ -226,4 +225,12 @@
 // RUN: %clang_cc1 %s -E -dM -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
 
+// RUN: %clang_cc1 %s -E -dM -fsycl-is-host \
+// RUN: -triple x86_64-unknown-linux-gnu -fintelfpga -o - \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-RANGE
+
+// RUN: %clang_cc1 %s -E -dM -fsycl-is-host -o - \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-NO-RANGE
+
+// CHECK-RANGE: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1
 // CHECK-NO-RANGE-NOT: #define __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ 1


### PR DESCRIPTION
 Set SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING macro for           
1. both host and device compilations if -fsycl-disable-range-rounding flag is used.
2. all targets and HOST as well if the target (or one of targets) is FPGA.

        
This patch fixes the problems caused by https://github.com/intel/llvm/pull/3428 where it disables range rounding for FPGA target on device, 
but doesn't do the same for host compilation, which results in different assumptions about device code
between RT and compiler.

co-authored-by: Michael D Toguchi <michael.d.toguchi@intel.com>

Signed-off-by: Soumi Manna <soumi.manna@intel.com>
 