### PR TITLE
Make clang-format check version agnostic.

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Run clang-format for the patch
       run: |
-        git diff --no-color ${GITHUB_SHA}^1 ${GITHUB_SHA} --name-only -- | grep -v "/test/" | xargs git diff -U0 --no-color ${GITHUB_SHA}^1 ${GITHUB_SHA} -- | ./clang/tools/clang-format/clang-format-diff.py -p1 -binary clang-format-9 > ./clang-format.patch
+        git diff --no-color ${GITHUB_SHA}^1 ${GITHUB_SHA} --name-only -- | grep -v "/test/" | xargs git diff -U0 --no-color ${GITHUB_SHA}^1 ${GITHUB_SHA} -- | ./clang/tools/clang-format/clang-format-diff.py -p1 -binary clang-format > ./clang-format.patch
 
     # Add patch with formatting fixes to CI job artifacts
     - uses: actions/upload-artifact@v1


### PR DESCRIPTION
It looks like clang-format version in default package for Ubuntu 20 is uplifted to 10.
Let's check if we can avoid specifying exact version.