### PR TITLE
[SYCL][CUDA] Fix host task CUDA native memory handle

### DIFF
--- a/sycl/include/CL/sycl/backend/cuda.hpp
+++ b/sycl/include/CL/sycl/backend/cuda.hpp
@@ -57,5 +57,10 @@ struct interop<backend::cuda, accessor<DataT, Dimensions, AccessMode,
   using type = CUdeviceptr;
 };
 
+template <typename DataT, int Dimensions, typename AllocatorT>
+struct interop<backend::cuda, buffer<DataT, Dimensions, AllocatorT>> {
+  using type = CUdeviceptr;
+};
+
 } // namespace sycl
 } // namespace cl

--- a/sycl/include/CL/sycl/interop_handle.hpp
+++ b/sycl/include/CL/sycl/interop_handle.hpp
@@ -113,8 +113,8 @@ public:
     if (Backend != get_backend())
       throw invalid_object_error("Incorrect backend argument was passed",
                                  PI_INVALID_MEM_OBJECT);
-    return reinterpret_cast<backend_return_t<Backend, device>>(
-        getNativeDevice());
+    // C-style cast required to allow various native types
+    return (backend_return_t<Backend, device>)getNativeDevice();
 #else
     // we believe this won't be ever called on device side
     return 0;

--- a/sycl/test/on-device/basic_tests/interop/traits.cpp
+++ b/sycl/test/on-device/basic_tests/interop/traits.cpp
@@ -45,9 +45,15 @@ int main() {
                      sycl::interop<Backend, sycl::event>::type>);
 #endif
 
+// CUDA does not have a native type for platforms
+#ifndef USE_CUDA
   static_assert(
       std::is_same_v<sycl::backend_traits<Backend>::input_type<sycl::platform>,
                      sycl::interop<Backend, sycl::platform>::type>);
+  static_assert(
+      std::is_same_v<sycl::backend_traits<Backend>::return_type<sycl::platform>,
+                     sycl::interop<Backend, sycl::platform>::type>);
+#endif
 
   static_assert(
       std::is_same_v<sycl::backend_traits<Backend>::return_type<sycl::device>,
@@ -58,9 +64,6 @@ int main() {
   static_assert(
       std::is_same_v<sycl::backend_traits<Backend>::return_type<sycl::queue>,
                      sycl::interop<Backend, sycl::queue>::type>);
-  static_assert(
-      std::is_same_v<sycl::backend_traits<Backend>::return_type<sycl::platform>,
-                     sycl::interop<Backend, sycl::platform>::type>);
 
   return 0;
 }

--- a/sycl/test/on-device/basic_tests/interop/traits.cpp
+++ b/sycl/test/on-device/basic_tests/interop/traits.cpp
@@ -1,5 +1,6 @@
 // RUN: %clangxx -fsycl -DUSE_OPENCL %s
 // RUN: %clangxx -fsycl -DUSE_L0 %s
+// RUN: %clangxx -fsycl -DUSE_CUDA %s
 
 #ifdef USE_OPENCL
 #include <CL/cl.h>
@@ -15,6 +16,12 @@ constexpr auto Backend = sycl::backend::opencl;
 #include <CL/sycl/backend/level_zero.hpp>
 
 constexpr auto Backend = sycl::backend::level_zero;
+#endif
+
+#ifdef USE_CUDA
+#include <CL/sycl/backend/cuda.hpp>
+
+constexpr auto Backend = sycl::backend::cuda;
 #endif
 
 #include <sycl/sycl.hpp>

--- a/sycl/unittests/pi/cuda/test_interop_get_native.cpp
+++ b/sycl/unittests/pi/cuda/test_interop_get_native.cpp
@@ -74,12 +74,51 @@ TEST_P(CudaInteropGetNativeTests, interopTaskGetMem) {
   });
 }
 
-TEST_P(CudaInteropGetNativeTests, interopTaskGetBufferMem) {
+TEST_P(CudaInteropGetNativeTests, interopTaskGetQueue) {
   CUstream cudaStream = get_native<backend::cuda>(*syclQueue_);
   syclQueue_->submit([&](handler &cgh) {
     cgh.interop_task([=](interop_handler ih) {
       CUstream cudaInteropStream = ih.get_queue<backend::cuda>();
       ASSERT_EQ(cudaInteropStream, cudaStream);
+    });
+  });
+}
+
+TEST_P(CudaInteropGetNativeTests, hostTaskGetNativeMem) {
+  buffer<int, 1> syclBuffer(range<1>{1});
+  syclQueue_->submit([&](handler &cgh) {
+    auto syclAccessor = syclBuffer.get_access<access::mode::read>(cgh);
+    cgh.codeplay_host_task([=](interop_handle ih) {
+      CUdeviceptr cudaPtr = ih.get_native_mem<backend::cuda>(syclAccessor);
+      CUdeviceptr cudaPtrBase;
+      size_t cudaPtrSize = 0;
+      CUcontext cudaContext =
+          get_native<backend::cuda>(syclQueue_->get_context());
+      ASSERT_EQ(CUDA_SUCCESS, cuCtxPushCurrent(cudaContext));
+      ASSERT_EQ(CUDA_SUCCESS,
+                cuMemGetAddressRange(&cudaPtrBase, &cudaPtrSize, cudaPtr));
+      ASSERT_EQ(CUDA_SUCCESS, cuCtxPopCurrent(nullptr));
+      ASSERT_EQ(sizeof(int), cudaPtrSize);
+    });
+  });
+}
+
+TEST_P(CudaInteropGetNativeTests, hostTaskGetNativeQueue) {
+  CUstream cudaStream = get_native<backend::cuda>(*syclQueue_);
+  syclQueue_->submit([&](handler &cgh) {
+    cgh.codeplay_host_task([=](interop_handle ih) {
+      CUstream cudaInteropStream = ih.get_native_queue<backend::cuda>();
+      ASSERT_EQ(cudaInteropStream, cudaStream);
+    });
+  });
+}
+
+TEST_P(CudaInteropGetNativeTests, hostTaskGetNativeContext) {
+  CUcontext cudaContext = get_native<backend::cuda>(syclQueue_->get_context());
+  syclQueue_->submit([&](handler &cgh) {
+    cgh.codeplay_host_task([=](interop_handle ih) {
+      CUcontext cudaInteropContext = ih.get_native_context<backend::cuda>();
+      ASSERT_EQ(cudaInteropContext, cudaContext);
     });
   });
 }


### PR DESCRIPTION
Specializes the native type of buffers for the PI CUDA backend, allowing calls to `interop_handle::get_native_mem` with the PI CUDA backend. Adds tests for getting CUDA native objects through the interoperability handle in a host task.

Note: This does not have a test for `interop_handle::get_native_device` as it causes sporadic gtest failures. The exact cause of this will require more investigation and is outside the scope of this change.