### PR TITLE
[sycl-post-link] Fix handling of booleans in SpecConstantsPass

### DIFF
--- a/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
@@ -1,0 +1,56 @@
+; RUN: sycl-post-link -spec-const=rt -S %s --ir-output-only -o %t.ll
+; RUN: FileCheck %s --input-file=%t.ll --implicit-check-not "call i8 bitcast"
+
+; CHECK-LABEL: void @kernel_A
+; CHECK: %[[CALL:.*]] = call i8 @_Z20__spirv_SpecConstantia(i32 [[#]], i8 1)
+; CHECK: trunc i8 %[[CALL]] to i1
+;
+; CHECK-LABEL: void @kernel_B
+; CHEKC: call i8 @_Z20__spirv_SpecConstantia(i32 [[#]], i8
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown-sycldevice"
+
+%struct.spec_id_type = type { i8 }
+%struct.spec_id_type2 = type { %struct.user_type }
+%struct.user_type = type { float, i32, i8 }
+
+@name_A = private unnamed_addr addrspace(1) constant [7 x i8] c"name_A\00", align 1
+@name_B = private unnamed_addr addrspace(1) constant [7 x i8] c"name_B\00", align 1
+
+@spec_const1 = linkonce_odr addrspace(1) constant %struct.spec_id_type { i8 1 }, align 1
+@spec_const2 = linkonce_odr addrspace(1) constant %struct.spec_id_type2 { %struct.user_type { float 2.000000e+01, i32 20, i8 20 } }, align 4
+
+declare spir_func zeroext i1 @_Z37__sycl_getScalar2020SpecConstantValueIbET_PKcPKvS4_(i8 addrspace(4)*, i8 addrspace(4)*, i8 addrspace(4)*) #1
+
+declare spir_func void @_Z40__sycl_getComposite2020SpecConstantValueIN14get_spec_const13testing_types8no_cnstrEET_PKcPKvS7_(%struct.user_type addrspace(4)* sret(%struct.user_type) align 4, i8 addrspace(4)*, i8 addrspace(4)*, i8 addrspace(4)*) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* noalias nocapture writeonly, i8 addrspace(4)* noalias nocapture readonly, i64, i1 immarg) #2
+
+; Function Attrs: convergent norecurse
+define weak_odr spir_kernel void @kernel_A(i8 addrspace(1)* %_arg) #0 {
+entry:
+  %call = tail call spir_func zeroext i1 @_Z37__sycl_getScalar2020SpecConstantValueIbET_PKcPKvS4_(i8 addrspace(4)* getelementptr inbounds ([7 x i8], [7 x i8] addrspace(4)* addrspacecast ([7 x i8] addrspace(1)* @name_A to [7 x i8] addrspace(4)*), i64 0, i64 0), i8 addrspace(4)* addrspacecast (i8 addrspace(1)* getelementptr inbounds (%struct.spec_id_type, %struct.spec_id_type addrspace(1)* @spec_const1, i64 0, i32 0) to i8 addrspace(4)*), i8 addrspace(4)* null) #4
+  %frombool = zext i1 %call to i8
+  store i8 %frombool, i8 addrspace(1)* %_arg, align 1
+  ret void
+}
+
+; Function Attrs: convergent norecurse
+define weak_odr spir_kernel void @kernel_B(%struct.user_type addrspace(1)* %_arg) #2 {
+entry:
+  %ref.tmp.i = alloca %struct.user_type, align 4
+  %ref.tmp.acast.i = addrspacecast %struct.user_type addrspace(0)* %ref.tmp.i to %struct.user_type addrspace(4)*
+  call spir_func void @_Z40__sycl_getComposite2020SpecConstantValueIN14get_spec_const13testing_types8no_cnstrEET_PKcPKvS7_(%struct.user_type addrspace(4)* sret(%struct.user_type) align 4 %ref.tmp.acast.i, i8 addrspace(4)* getelementptr inbounds ([7 x i8], [7 x i8] addrspace(4)* addrspacecast ([7 x i8] addrspace(1)* @name_B to [7 x i8] addrspace(4)*), i64 0, i64 0), i8 addrspace(4)* addrspacecast (i8 addrspace(1)* bitcast (%struct.spec_id_type2 addrspace(1)* @spec_const2 to i8 addrspace(1)*) to i8 addrspace(4)*), i8 addrspace(4)* null) #4
+  %0 = bitcast %struct.user_type* %ref.tmp.i to i8*
+  %1 = bitcast %struct.user_type addrspace(1)* %_arg to i8 addrspace(1)*
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8 addrspace(4)*
+  %3 = addrspacecast i8* %0 to i8 addrspace(4)*
+  call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* noundef align 4 dereferenceable(12) %2, i8 addrspace(4)* noundef align 4 dereferenceable(12) %3, i64 12, i1 false)
+  ret void
+}
+
+attributes #0 = { convergent norecurse }
+attributes #1 = { convergent }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }

--- a/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
@@ -6,7 +6,7 @@
 ; CHECK: trunc i8 %[[CALL]] to i1
 ;
 ; CHECK-LABEL: void @kernel_B
-; CHEKC: call i8 @_Z20__spirv_SpecConstantia(i32 [[#]], i8
+; CHECK: call i8 @_Z20__spirv_SpecConstantia(i32 [[#]], i8
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown-sycldevice"

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -319,10 +319,52 @@ Instruction *emitCall(Type *RetTy, StringRef BaseFunctionName,
   auto *FT = FunctionType::get(RetTy, ArgTys, false /*isVarArg*/);
   std::string FunctionName = mangleFuncItanium(BaseFunctionName, FT);
   Module *M = InsertBefore->getFunction()->getParent();
+
+  if (RetTy->isIntegerTy(1)) {
+    assert(ArgTys.size() == 2 && "Expected a scalar spec constant");
+    // There is a problem with bool data type: depending on how it is used in
+    // source code, clang can emit it as either i1 or i8. It might lead to a
+    // situation where we need to emit call to
+    // i1 __spirv_SpecConstantia(i32, i8) function for bool spec constant and
+    // call to i8 __spirv_SpecConstantia(i32, i8) for char spec constants.
+    // Those two calls are only differ by return type and generating them both
+    // will result in something like:
+    // call i8 bitcast (i1 (i32, i8)* @_Z20__spirv_SpecConstantia to i8 (i32,
+    // i8)*)(i32 47, i8 20) and it will confuse the SPIR-V translator.
+    //
+    // In order to avoid that, we detect all situations when we need to emit
+    // i1 __spirv_SpecConstantia(i32, i8) and instead emit a call to
+    // i8 __spirv_SpecConstantia(i32, i8) followed by a trunc instruction to
+    // make types consistent with the rest of LLVM IR.
+    if (ArgTys[1]->isIntegerTy(8)) {
+      LLVMContext &Ctx = RetTy->getContext();
+      auto *NewRetTy = Type::getInt8Ty(Ctx);
+      auto *NewFT = FunctionType::get(NewRetTy, ArgTys, false /*isVarArg*/);
+      auto NewFC = M->getOrInsertFunction(FunctionName, NewFT);
+
+      auto *Call =
+          CallInst::Create(NewFT, NewFC.getCallee(), Args, "", InsertBefore);
+      return CastInst::CreateTruncOrBitCast(Call, RetTy, "tobool",
+                                            InsertBefore);
+    }
+  }
+
+  // There is one more example where call bitcast construct might appear: it
+  // would be user-defined data types, which are named differently, but their
+  // content is the same:
+  // %struct.A = { float, i32, i8, [3 x i8] }
+  // %struct.B = { float, i32, i8. [3 x i8] }
+  // If we have spec constants using both those types, we will end up with
+  // something like:
+  // %struct.A (float, i32, i8, [3 x i8])* bitcast (%struct.B (float, i32, i8,
+  // [3 x i8])* @_Z29__spirv_SpecConstantCompositefiaAa to %struct.A (float,
+  // i32, i8, [3 x i8])*) Such call of bitcast doesn't seem to confuse the
+  // translator, but still doesn't look clean in LLVM IR.
+  // FIXME: is it possible to avoid call bitcast construct for composite
+  // types? Is it necessary?
+
   FunctionCallee FC = M->getOrInsertFunction(FunctionName, FT);
-  assert(FC.getCallee() && "SPIRV intrinsic creation failed");
-  auto *Call = CallInst::Create(FT, FC.getCallee(), Args, "", InsertBefore);
-  return Call;
+  return CallInst::Create(FT, FC.getCallee(), Args, "", InsertBefore);
 }
 
 Instruction *emitSpecConstant(unsigned NumericID, Type *Ty,


### PR DESCRIPTION
There are cases when pass tries to insert calls to both
`i1 __spirv_SpecConstant(i32, i8)` and
`i8 __spirv_SpecConstant(i32, i8)`, which in fact results in generating
something like this for one of calls:
`call i8 bitcast (i1 (i32, i8)* @_Z20__spirv_SpecConstantia to i8 (i32, i8)*)(i32 47, i8 20)`.

Such `call bitcast` construct confuses SPIR-V translator: updated the
pass to avoid inserting it (at least for booleans).