### PR TITLE
[SYCL]Fixes a performance issue due to https://github.com/intel/llvm/…

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -4111,8 +4111,13 @@ pi_result piEventGetInfo(pi_event Event, pi_event_info ParamName,
       // Lock automatically releases when this goes out of scope.
       std::lock_guard<std::mutex> lock(Event->Queue->PiQueueMutex);
 
-      if (auto Res = Event->Queue->executeOpenCommandList())
-        return Res;
+      // Only do the execute of the open command list if the event that
+      // is being queried and event that is to be signalled by something
+      // currently in that open command list.
+      if (Event->Queue->ZeOpenCommandList == Event->ZeCommandList) {
+        if (auto Res = Event->Queue->executeOpenCommandList())
+          return Res;
+      }
     }
 
     ze_result_t ZeResult;


### PR DESCRIPTION
…pull/3612

This change does two things to fix the performance issue.
The first is in the level zero plugin.  Here the change is to only
close and submit the batch if the event being queried is one that
will be signalled one of the commands in the batch.

The second change is in the sycl run-time itself.  This change
prevents the event cleanup code from querying every single event
that is outstanding in the system.  This is necessary to prevent
the most recent events (which are likely to be in the plug-ins batch)
from being queried.

Both changes are required to fix the performance issue.