### PR TITLE
[Driver][SYCL] Do not add the integration header a second time for host

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4210,6 +4210,17 @@ static bool ContainsWrapperAction(const Action *A) {
   return false;
 }
 
+/// Check whether the given input tree contains any append footer actions
+static bool ContainsAppendFooterAction(const Action *A) {
+  if (isa<AppendFooterJobAction>(A))
+    return true;
+  for (const auto &AI : A->inputs())
+    if (ContainsAppendFooterAction(AI))
+      return true;
+
+  return false;
+}
+
 // Put together an external compiler compilation call which is used instead
 // of the clang invocation for the host compile of an offload compilation.
 // Enabling command line:  clang++ -fsycl -fsycl-host-compiler=<HostExe>
@@ -4643,8 +4654,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     if (!IsSYCLOffloadDevice) {
       // Add the -include option to add the integration header
       StringRef Header = D.getIntegrationHeader(Input.getBaseInput());
+      // Do not add the integration header if we are compiling after the
+      // integration footer has been applied.  Check for the append job
+      // action to determine this.
       if (types::getPreprocessedType(Input.getType()) != types::TY_INVALID &&
-          !Header.empty()) {
+          !Header.empty() && !ContainsAppendFooterAction(&JA)) {
         CmdArgs.push_back("-include");
         CmdArgs.push_back(Args.MakeArgString(Header));
         // When creating dependency information, filter out the generated

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -1,0 +1,8 @@
+/// Check compilation tool steps when using the integrated footer
+// RUN:  %clangxx -fsycl -fsycl-use-footer %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix FOOTER %s
+// FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}"
+// FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-E"{{.*}} "-o" "[[PREPROC:.+\.ii]]"
+// FOOTER: append-file{{.*}} "[[PREPROC]]" "--append=[[INTFOOTER]]" "--output=[[APPENDEDSRC:.+\.cpp]]"
+// FOOTER: clang{{.*}} "-fsycl-is-host"{{.*}} "[[APPENDEDSRC]]"
+// FOOTER-NOT: "-include" "[[INTHEADER]]"


### PR DESCRIPTION
When compiling with the integration footer enabled, we want to be sure
that the integration header is only pulled in once (during the preprocessing
step) and not during the full compilation of the source w/ appended
footer.