### PR TITLE
[SYCL][ESIMD] Remove w/a for ESIMD BE processing llvm.assume intrinsics

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -28,7 +28,6 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
-#include "llvm/IR/PatternMatch.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -1312,11 +1311,6 @@ size_t SYCLLowerESIMDPass::runOnFunction(Function &F,
     auto *CI = dyn_cast<CallInst>(&I);
     Function *Callee = nullptr;
     if (CI && (Callee = CI->getCalledFunction())) {
-      // TODO workaround for ESIMD BE until it starts supporting @llvm.assume
-      if (match(&I, PatternMatch::m_Intrinsic<Intrinsic::assume>())) {
-        ESIMDToErases.push_back(CI);
-        continue;
-      }
       StringRef Name = Callee->getName();
 
       // See if the Name represents an ESIMD intrinsic and demangle only if it

--- a/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_intrins.ll
@@ -308,18 +308,6 @@ define dso_local spir_func <16 x i32>  @FUNC_44() {
   ret <16 x i32>  %ret_val
 }
 
-; TODO LowerESIMD.cpp temporarily removes @llvm.assume, this test checks this.
-; Remove once @llvm.assume is allowed in the ESIMD BE.
-define dso_local spir_func void  @FUNC_45() {
-; CHECK-LABEL: FUNC_45
-  call void @llvm.assume(i1 1)
-; CHECK-NOT: @llvm.assume
-  ret void
-}
-; CHECK-LABEL: }
-
-declare void @llvm.assume(i1 noundef)
-
 define dso_local i32 @FUNC_46() {
 ; CHECK-LABEL: FUNC_46
 ; CHECK: %{{[0-9a-zA-Z_.]+}} = call i32 @llvm.genx.lane.id()


### PR DESCRIPTION
Now, when ESIMD BE can handle llvm.assume intrinsics, we can remove the w/a in LowerESIMD pass.