### PR TITLE
Update SYCL version and URL to the specification in documentation

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -667,8 +667,8 @@ which contains all the symbols required.
 
 * DPC++ specification:
 [https://spec.oneapi.com/versions/latest/elements/dpcpp/source/index.html](https://spec.oneapi.com/versions/latest/elements/dpcpp/source/index.html)
-* SYCL\* 1.2.1 specification:
-[www.khronos.org/registry/SYCL/specs/sycl-1.2.1.pdf](https://www.khronos.org/registry/SYCL/specs/sycl-1.2.1.pdf)
+* SYCL\* 2020 specification:
+[https://www.khronos.org/registry/SYCL/](https://www.khronos.org/registry/SYCL/)
 * oneAPI Level Zero specification:
 [https://spec.oneapi.com/versions/latest/oneL0/index.html](https://spec.oneapi.com/versions/latest/oneL0/index.html)
 


### PR DESCRIPTION
I have also the feeling that `-sycl-std=` has the value the feeling by default and so 2 places in the documentation should be updated.