### PR TITLE
[SYCL] Avoid HasDefaultValues to be set as IsSet field of SpecConstDescT

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -222,8 +222,6 @@ private:
       const pi::DeviceBinaryImage::PropertyRange &SCDefValRange =
           MBinImage->getSpecConstantsDefaultValues();
 
-      bool HasDefaultValues = SCDefValRange.begin() != SCDefValRange.end();
-
       // This variable is used to calculate spec constant value offset in a
       // flat byte array.
       unsigned BlobOffset = 0;
@@ -256,12 +254,14 @@ private:
           // supposed to be called from c'tor.
           MSpecConstSymMap[std::string{SCName}].push_back(
               SpecConstDescT{/*ID*/ It[0], /*CompositeOffset*/ It[1],
-                             /*Size*/ It[2], BlobOffset, HasDefaultValues});
+                             /*Size*/ It[2], BlobOffset});
           BlobOffset += /*Size*/ It[2];
           It += NumElements;
         }
       }
       MSpecConstsBlob.resize(BlobOffset);
+
+      bool HasDefaultValues = SCDefValRange.begin() != SCDefValRange.end();
 
       if (HasDefaultValues) {
         pi::ByteArray DefValDescriptors =

--- a/sycl/unittests/spec_constants/DefaultValues.cpp
+++ b/sycl/unittests/spec_constants/DefaultValues.cpp
@@ -205,7 +205,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
 sycl::unittest::PiImage Img = generateDefaultImage();
 sycl::unittest::PiImageArray ImgArray{Img};
 
-TEST(DefaultValues, DefaultValuesAreSet) {
+TEST(DefaultValues, DISABLED_DefaultValuesAreSet) {
   sycl::platform Plt{sycl::default_selector()};
   if (Plt.is_host()) {
     std::cerr << "Test is not supported on host, skipping\n";
@@ -238,7 +238,7 @@ TEST(DefaultValues, DefaultValuesAreSet) {
   EXPECT_EQ(SpecConstVal1, 8);
 }
 
-TEST(DefaultValues, DefaultValuesAreOverriden) {
+TEST(DefaultValues, DISABLED_DefaultValuesAreOverriden) {
   sycl::platform Plt{sycl::default_selector()};
   if (Plt.is_host()) {
     std::cerr << "Test is not supported on host, skipping\n";


### PR DESCRIPTION
Remove backward compatibility according to discussion:
https://github.com/intel/llvm/pull/3667#discussion_r631154823

This patch is expected to be merged together or before
https://github.com/intel/llvm/pull/3666