### PR TITLE
[SYCL] Fix BE setup for LIT tests

### DIFF
--- a/sycl/test/on-device/basic_tests/aspects.cpp
+++ b/sycl/test/on-device/basic_tests/aspects.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be %t.out
 
 //==--------------- aspects.cpp - SYCL device test ------------------------==//
 //

--- a/sycl/test/on-device/basic_tests/diagnostics/device-check.cpp
+++ b/sycl/test/on-device/basic_tests/diagnostics/device-check.cpp
@@ -1,17 +1,17 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=cpu %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=gpu %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=acc %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=host %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=CPU %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=GPU %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=ACC %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=HOST %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=Cpu %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=Gpu %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=Acc %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=Host %t.out
-// RUN: env SYCL_BE=%sycl_be SYCL_DEVICE_TYPE=XPU %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=cpu %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=gpu %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=acc %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=host %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=CPU %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=GPU %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=ACC %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=Cpu %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=Gpu %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=Acc %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=Host %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be SYCL_DEVICE_TYPE=XPU %t.out
 
 //==------------------- device-check.cpp --------------------------==//
 // This is a diagnostic test which ensures that
@@ -24,7 +24,6 @@
 
 using namespace cl::sycl;
 
-
 int main() {
   try {
     queue q = queue();
@@ -34,9 +33,11 @@ int main() {
   }
 
   catch (runtime_error &E) {
-    if (std::string(E.what()).find(
-        "SYCL_DEVICE_TYPE is not recognized.  Must be GPU, CPU, ACC or HOST.") ==
-        std::string::npos) {
+    if (std::string(E.what()).find("SYCL_DEVICE_TYPE is not recognized.  Must "
+                                   "be GPU, CPU, ACC or HOST.") ==
+            std::string::npos &&
+        std::string(E.what()).find("No device of requested type available.") ==
+            std::string::npos) {
       std::cout << "Test failed: received error is incorrect." << std::endl;
       return 1;
     } else {

--- a/sycl/test/on-device/basic_tests/platform.cpp
+++ b/sycl/test/on-device/basic_tests/platform.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %t.out
+// RUN: env SYCL_DEVICE_FILTER=%sycl_be %t.out
 //==--------------- platform.cpp - SYCL platform test ----------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/on-device/extensions/intel-ext-device.cpp
+++ b/sycl/test/on-device/extensions/intel-ext-device.cpp
@@ -3,6 +3,7 @@
 // RUN: env SYCL_DEVICE_FILTER=opencl:gpu %t.out
 //
 // REQUIRES: gpu
+// UNSUPPORTED: cuda
 
 //==--------- intel-ext-device.cpp - SYCL device test ------------==//
 //

--- a/sycl/test/on-device/lit.cfg.py
+++ b/sycl/test/on-device/lit.cfg.py
@@ -95,7 +95,7 @@ else:
 llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 backend=lit_config.params.get('SYCL_PLUGIN', "opencl")
 lit_config.note("Backend: {}".format(backend))
-config.substitutions.append( ('%sycl_be', { 'opencl': 'PI_OPENCL',  'cuda': 'PI_CUDA', 'level_zero': 'PI_LEVEL_ZERO'}[backend]) )
+config.substitutions.append( ('%sycl_be', backend) )
 config.substitutions.append( ('%BE_RUN_PLACEHOLDER', "env SYCL_DEVICE_FILTER={SYCL_PLUGIN} ".format(SYCL_PLUGIN=backend)) )
 config.substitutions.append( ('%RUN_ON_HOST', "env SYCL_DEVICE_FILTER=host ") )
 

--- a/sycl/test/on-device/regression/device_num.cpp
+++ b/sycl/test/on-device/regression/device_num.cpp
@@ -1,10 +1,13 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: sycl-ls
 // RUN: env SYCL_DEVICE_FILTER=0 %t.out
 // RUN: env SYCL_DEVICE_FILTER=1 %t.out
 // RUN: env SYCL_DEVICE_FILTER=2 %t.out
 // RUN: env SYCL_DEVICE_FILTER=3 %t.out
 // RUN: env SYCL_DEVICE_FILTER=4 %t.out
+
+// The test is using all available BEs but CUDA machine in CI does not have
+// functional OpenCL RT
+// UNSUPPORTED: cuda
 
 #include <CL/sycl.hpp>
 #include <iostream>

--- a/sycl/test/regression/isordered.cpp
+++ b/sycl/test/regression/isordered.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: env SYCL_DEVICE_FILTER=host %t.out
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test/regression/mad_sat.cpp
+++ b/sycl/test/regression/mad_sat.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl %s -o %t.out
-// RUN: env SYCL_DEVICE_TYPE=HOST %t.out
+// RUN: env SYCL_DEVICE_FILTER=host %t.out
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test/scheduler/DataMovement.cpp
+++ b/sycl/test/scheduler/DataMovement.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out -g
-// RUN: %t.out
+// RUN: env SYCL_DEVICE_FILTER=host %t.out
 //
 //==-------------------------- DataMovement.cpp ----------------------------==//
 //

--- a/sycl/test/scheduler/MultipleDevices.cpp
+++ b/sycl/test/scheduler/MultipleDevices.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out
-// RUN: %t.out
+// RUN: env SYCL_DEVICE_FILTER=host %t.out
 
 //===- MultipleDevices.cpp - Test checking multi-device execution --------===//
 //


### PR DESCRIPTION
 - move tests depending on BE runtime to on-device folder;
 - force host device for tests which target host;
 - use SYCL_DEVICE_FILTER in favor to SYCL_DEVICE_TYPE;
 - force SYCL BE selected in LIT framework;
 - disable test which is unstable on CUDA.