### PR TITLE
[Driver][SYCL] Do not imply defaultlib msvcrt for Linux based driver on Windows

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4663,7 +4663,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         if (AuxT.isWindowsMSVCEnvironment()) {
           CmdArgs.push_back("-D_MT");
           CmdArgs.push_back("-D_DLL");
-          CmdArgs.push_back("--dependent-lib=msvcrt");
         }
       }
     }

--- a/clang/test/Driver/sycl-MD-default.cpp
+++ b/clang/test/Driver/sycl-MD-default.cpp
@@ -5,7 +5,7 @@
 // RUN: %clangxx -### -fsycl -c -target x86_64-unknown-windows-msvc %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DEFAULT %s
 // CHK-DEFAULT-NOT: "-fsycl-is-device" {{.*}} "-D_MT" "-D_DLL"
-// CHK-DEFAULT: "-fsycl-is-host"{{.*}} "-D_MT" "-D_DLL" "--dependent-lib=msvcrt{{d*}}" {{.*}}
+// CHK-DEFAULT: "-fsycl-is-host"{{.*}} "-D_MT" "-D_DLL"
 
 // RUN: %clang_cl -### -fsycl -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DEFAULT-CL %s


### PR DESCRIPTION
When compiling for Windows target, we should only be adding the
defaultlib msvcrt directive when performing MSVC compatible compilations.
If adding msvcrt for Linux style compilations, we do not know if
the library should be the regular library or the debug library, as that
is determined by the use of /MD or /MDd.