### PR TITLE
[SYCL][ESIMD] Fix host compilation errors when sycl.hpp is not included.

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/host_util.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/host_util.hpp
@@ -33,6 +33,7 @@ namespace esimd {
 namespace emu {
 namespace detail {
 
+using half = sycl::detail::half_impl::half;
 constexpr int sat_is_on = 1;
 
 static long long abs(long long a) {

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/host_util.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/host_util.hpp
@@ -12,6 +12,8 @@
 
 #ifndef __SYCL_DEVICE_ONLY__
 
+#include <limits>
+
 #define SIMDCF_ELEMENT_SKIP(i)
 
 __SYCL_INLINE_NAMESPACE(cl) {

--- a/sycl/test/esimd/regression/esimd_hpp_wo_sycl_hpp_included.cpp
+++ b/sycl/test/esimd/regression/esimd_hpp_wo_sycl_hpp_included.cpp
@@ -3,8 +3,5 @@
 
 #include <sycl/ext/intel/experimental/esimd.hpp>
 
-#include <limits>
-#include <utility>
-
 // This test checks that host compiler can compile esimd.hpp when there is no
 // sycl.hpp included (can happen in pure-ESIMD library).

--- a/sycl/test/esimd/regression/esimd_hpp_wo_sycl_hpp_included.cpp
+++ b/sycl/test/esimd/regression/esimd_hpp_wo_sycl_hpp_included.cpp
@@ -1,0 +1,10 @@
+// RUN: %clangxx -fsycl -fsyntax-only %s
+// expected-no-diagnostics
+
+#include <sycl/ext/intel/experimental/esimd.hpp>
+
+#include <limits>
+#include <utility>
+
+// This test checks that host compiler can compile esimd.hpp when there is no
+// sycl.hpp included (can happen in pure-ESIMD library).


### PR DESCRIPTION
Signed-off-by: kbobrovs <Konstantin.S.Bobrovsky@intel.com>