### PR TITLE
[SYCL] Fix spec constants in object and executable kernel bundles

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -36,6 +36,18 @@ namespace detail {
 // of specialization constants for it
 class device_image_impl {
 public:
+  // The struct maps specialization ID to offset in the binary blob where value
+  // for this spec const should be.
+  struct SpecConstDescT {
+    unsigned int ID = 0;
+    unsigned int CompositeOffset = 0;
+    unsigned int Size = 0;
+    unsigned int BlobOffset = 0;
+    bool IsSet = false;
+  };
+
+  using SpecConstMapT = std::map<std::string, std::vector<SpecConstDescT>>;
+
   device_image_impl(const RTDeviceBinaryImage *BinImage, context Context,
                     std::vector<device> Devices, bundle_state State,
                     std::vector<kernel_id> KernelIDs, RT::PiProgram Program)
@@ -44,6 +56,16 @@ public:
         MKernelIDs(std::move(KernelIDs)) {
     updateSpecConstSymMap();
   }
+
+  device_image_impl(const RTDeviceBinaryImage *BinImage, context Context,
+                    std::vector<device> Devices, bundle_state State,
+                    std::vector<kernel_id> KernelIDs, RT::PiProgram Program,
+                    const SpecConstMapT &SpecConstMap,
+                    const std::vector<unsigned char> &SpecConstsBlob)
+      : MBinImage(BinImage), MContext(std::move(Context)),
+        MDevices(std::move(Devices)), MState(State), MProgram(Program),
+        MKernelIDs(std::move(KernelIDs)), MSpecConstsBlob(SpecConstsBlob),
+        MSpecConstSymMap(SpecConstMap) {}
 
   bool has_kernel(const kernel_id &KernelIDCand) const noexcept {
     return std::binary_search(MKernelIDs.begin(), MKernelIDs.end(),
@@ -75,16 +97,6 @@ public:
     assert(false && "Not implemented");
     return false;
   }
-
-  // The struct maps specialization ID to offset in the binary blob where value
-  // for this spec const should be.
-  struct SpecConstDescT {
-    unsigned int ID = 0;
-    unsigned int CompositeOffset = 0;
-    unsigned int Size = 0;
-    unsigned int BlobOffset = 0;
-    bool IsSet = false;
-  };
 
   bool has_specialization_constant(const char *SpecName) const noexcept {
     // Lock the mutex to prevent when one thread in the middle of writing a
@@ -182,8 +194,7 @@ public:
     return MSpecConstsBuffer;
   }
 
-  const std::map<std::string, std::vector<SpecConstDescT>> &
-  get_spec_const_data_ref() const noexcept {
+  const SpecConstMapT &get_spec_const_data_ref() const noexcept {
     return MSpecConstSymMap;
   }
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1405,7 +1405,9 @@ ProgramManager::compile(const device_image_plain &DeviceImage,
 
   DeviceImageImplPtr ObjectImpl = std::make_shared<detail::device_image_impl>(
       InputImpl->get_bin_image_ref(), InputImpl->get_context(), Devs,
-      bundle_state::object, InputImpl->get_kernel_ids_ref(), Prog);
+      bundle_state::object, InputImpl->get_kernel_ids_ref(), Prog,
+      InputImpl->get_spec_const_data_ref(),
+      InputImpl->get_spec_const_blob_ref());
 
   std::vector<pi_device> PIDevices;
   PIDevices.reserve(Devs.size());
@@ -1652,7 +1654,9 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 
   DeviceImageImplPtr ExecImpl = std::make_shared<detail::device_image_impl>(
       InputImpl->get_bin_image_ref(), Context, Devs, bundle_state::executable,
-      InputImpl->get_kernel_ids_ref(), ResProgram);
+      InputImpl->get_kernel_ids_ref(), ResProgram,
+      InputImpl->get_spec_const_data_ref(),
+      InputImpl->get_spec_const_blob_ref());
 
   return createSyclObjFromImpl<device_image_plain>(ExecImpl);
 }

--- a/sycl/test/on-device/basic_tests/specialization_constants/host_apis.cpp
+++ b/sycl/test/on-device/basic_tests/specialization_constants/host_apis.cpp
@@ -58,6 +58,8 @@ int main() {
   KernelBundle.set_specialization_constant<SpecConst2>(1);
   {
     auto ExecBundle = sycl::build(KernelBundle);
+    assert(ExecBundle.get_specialization_constant<SpecConst1>() == 1);
+    assert(ExecBundle.get_specialization_constant<SpecConst2>() == 1);
     sycl::buffer<int, 1> Buf{sycl::range{1}};
     Q.submit([&](sycl::handler &CGH) {
       CGH.use_kernel_bundle(ExecBundle);


### PR DESCRIPTION
Allow set specialization constants values to be retrieved from
kernel_bundles in object or executable states.