### PR TITLE
[SYCL] Fix post-commit failure in handler.hpp from unused-parameters.

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -885,6 +885,8 @@ private:
 #endif
 #ifdef __SYCL_DEVICE_ONLY__
     KernelFunc();
+#else
+    (void)KernelFunc;
 #endif
   }
 
@@ -899,6 +901,9 @@ private:
 #endif
 #ifdef __SYCL_DEVICE_ONLY__
     KernelFunc(KH);
+#else
+    (void)KernelFunc;
+    (void)KH;
 #endif
   }
 
@@ -913,6 +918,8 @@ private:
 #endif
 #ifdef __SYCL_DEVICE_ONLY__
     KernelFunc(detail::Builder::getElement(detail::declptr<ElementType>()));
+#else
+    (void)KernelFunc;
 #endif
   }
 
@@ -927,6 +934,9 @@ private:
 #endif
 #ifdef __SYCL_DEVICE_ONLY__
     KernelFunc(detail::Builder::getElement(detail::declptr<ElementType>()), KH);
+#else
+    (void)KernelFunc;
+    (void)KH;
 #endif
   }
 
@@ -941,6 +951,8 @@ private:
 #endif
 #ifdef __SYCL_DEVICE_ONLY__
     KernelFunc(detail::Builder::getElement(detail::declptr<ElementType>()));
+#else
+    (void)KernelFunc;
 #endif
   }
 
@@ -956,6 +968,9 @@ private:
 #endif
 #ifdef __SYCL_DEVICE_ONLY__
     KernelFunc(detail::Builder::getElement(detail::declptr<ElementType>()), KH);
+#else
+    (void)KernelFunc;
+    (void)KH;
 #endif
   }
 


### PR DESCRIPTION
The __builtin_sycl_unique_stable_name patch introduced some changes that
@romanovvlad did to make sure we properly called the kernel.  However,
the changes used the preprocessor to only call the kernel-lambda when
necessary.

This patch fixes the unused-parameter warnings that happen in host mode
by casting these values to 'void' in the else case.