### PR TITLE
[Driver][SYCL] Improve handing of integration footers when preprocessing

### DIFF
--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -1,4 +1,4 @@
-/// Check compilation tool steps when using the integrated footer
+/// Check compilation tool steps when using the integration footer
 // RUN:  %clangxx -fsycl -fsycl-use-footer %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER %s
 // FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}"
@@ -6,3 +6,21 @@
 // FOOTER: append-file{{.*}} "[[PREPROC]]" "--append=[[INTFOOTER]]" "--output=[[APPENDEDSRC:.+\.cpp]]"
 // FOOTER: clang{{.*}} "-fsycl-is-host"{{.*}} "[[APPENDEDSRC]]"
 // FOOTER-NOT: "-include" "[[INTHEADER]]"
+
+/// Preprocessed file creation with integration footer
+// RUN: %clangxx -fsycl -fsycl-use-footer -E %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix FOOTER_PREPROC_GEN %s
+// FOOTER_PREPROC_GEN: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}" "-o" "[[PREPROC_DEVICE:.+\.ii]]"
+// FOOTER_PREPROC_GEN: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-E"{{.*}} "-o" "[[PREPROC1:.+\.ii]]"
+// FOOTER_PREPROC_GEN: append-file{{.*}} "[[PREPROC1]]" "--append=[[INTFOOTER]]" "--output=[[APPENDEDSRC:.+\.cpp]]"
+// FOOTER_PREPROC_GEN: clang{{.*}} "-fsycl-is-host"{{.*}} "-E"{{.*}} "-o" "[[PREPROC_HOST:.+\.ii]]"{{.*}} "[[APPENDEDSRC]]"
+// FOOTER_PREPROC_GEN: clang-offload-bundler{{.*}} "-inputs=[[PREPROC_DEVICE]],[[PREPROC_HOST]]"
+
+/// Preprocessed file use with integration footer
+// RUN: touch %t.ii
+// RUN:  %clangxx -fsycl -fsycl-use-footer %t.ii -### 2>&1 \
+// RUN:   | FileCheck -check-prefix FOOTER_PREPROC_USE %s
+// FOOTER_PREPROC_USE: clang-offload-bundler{{.*}} "-outputs=[[HOST1:.+\.ii]],[[DEVICE_PP:.+\.ii]]"
+// FOOTER_PREPROC_USE: clang{{.*}} "-fsycl-is-device"{{.*}} "[[DEVICE_PP]]"
+// FOOTER_PREPROC_USE: clang-offload-bundler{{.*}} "-outputs=[[HOST_PP:.+\.ii]],[[DEVICE1:.+\.ii]]"
+// FOOTER_PREPROC_USE: clang{{.*}} "-fsycl-is-host"{{.*}} "[[HOST_PP]]"


### PR DESCRIPTION
When generating and consuming preprocessed files with the integration
footer enabled, we need to properly setup the tools used during each
particular step.

Generation:  preprocess host -> append footer -> preprocess again
Use: compile preprocessed file