### PR TITLE
[Doc] Enable build and deployment for Clang docs

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -24,7 +24,9 @@ jobs:
         python $GITHUB_WORKSPACE/repo/buildbot/configure.py -w $GITHUB_WORKSPACE \
         -s $GITHUB_WORKSPACE/repo -o $GITHUB_WORKSPACE/build -t Release --docs
         cmake --build . --target doxygen-sycl
+        cmake --build . --target doxygen-clang
         cmake --build . --target docs-sycl-html
+        cmake --build . --target docs-clang-html
     - name: Deploy
       env:
         SSH_KEY: ${{secrets.ACTIONS_DEPLOY_KEY}}
@@ -41,6 +43,10 @@ jobs:
         yes | \cp -rf $GITHUB_WORKSPACE/build/tools/sycl/doc/html/* .
         mkdir doxygen
         yes | \cp -rf $GITHUB_WORKSPACE/build/tools/sycl/doc/doxygen/html/* doxygen/
+        mkdir clang
+        yes | \cp -rf $GITHUB_WORKSPACE/build/tools/clang/doc/html/* clang/
+        mkdir clang_doxygen
+        yes | \cp -rf $GITHUB_WORKSPACE/build/tools/sycl/doc/doxygen/html/* clang_doxygen/
         git config --global user.name "iclsrc"
         git config --global user.email "ia.compiler.tools.git@intel.com"
         git add .

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -4543,6 +4543,7 @@ used to specify full unrolling or partial unrolling by a specified amount.
 
 def IntelReqdSubGroupSizeDocs : Documentation {
   let Category = DocCatStmt;
+  let Heading = "intel_reqd_sub_group_size";
   let Content = [{
 This attribute can be used in both OpenCL and SYCL.
 
@@ -4563,7 +4564,7 @@ to a sub-group size supported by the device, or device compilation will fail.
 
 The ``[[intel::sub_group_size(n)]]`` attribute has the same effect as the other
 attribute spellings, except that it follows the SYCL 2020 Attribute Rules. See
- the ``[[intel::named_sub_group_size(NAME)]]`` documentation for clarification.
+the ``[[intel::named_sub_group_size(NAME)]]`` documentation for clarification.
 
 This attribute is mutually exclusive with ``[[intel::named_sub_group_size(NAME)]]``
 and ``[[intel::sycl_explicit_simd]]``.

--- a/sycl/doc/index.rst
+++ b/sycl/doc/index.rst
@@ -23,6 +23,8 @@ Developing oneAPI DPC++ Compiler
    :maxdepth: 1
 
    API Reference <https://intel.github.io/llvm-docs/doxygen>
+   Clang Documentation <https://intel.github.io/llvm-docs/clang>
+   Clang API Reference <https://intel.github.io/llvm-docs/clang_doxygen>
    CompilerAndRuntimeDesign
    KernelParameterPassing
    EnvironmentVariables


### PR DESCRIPTION
This PR fixes a small problem in Clang documentation. To avoid this kind of problems in future, documentation build is added to CI. The result will also be rendered to https://intel.github.io/llvm-docs.