### PR TITLE
[clang-offload-bundler] Do not add llvm.used to the .tgtsym section

### DIFF
--- a/clang/test/Driver/clang-offload-bundler-tgtsym.c
+++ b/clang/test/Driver/clang-offload-bundler-tgtsym.c
@@ -18,6 +18,9 @@
 // CHECK-DAG: sycl-spir64.bar
 // CHECK-NOT: undefined_func
 // CHECK-NOT: static_func
+// CHECK-NOT: static_used
+// CHECK-NOT: sycl-spir64.llvm.used
+// CHECK-NOT: sycl-spir64.llvm.compiler.used
 
 extern void undefined_func(void);
 
@@ -31,3 +34,6 @@ static void static_func(void) {}
 void bar(void) {
   static_func();
 }
+
+static void static_used(void) __attribute__((used));
+static void static_used() {}


### PR DESCRIPTION
This patch changes clang-offload-bundler to skip special globals
llvm.used and llvm.compiler.used when collecting names of symbols
that are defined in the device object if it is a bitcode file.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>