### PR TITLE
[Driver][SYCL] Adjust device side compilation for -S -emit-llvm

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3904,7 +3904,10 @@ class OffloadingActionBuilder final {
       // Device compilation generates LLVM BC.
       if (CurPhase == phases::Compile) {
         for (Action *&A : SYCLDeviceActions) {
-          types::ID OutputType = types::TY_LLVM_BC;
+          types::ID OutputType = (Args.hasArg(options::OPT_S) &&
+                                  Args.hasArg(options::OPT_emit_llvm))
+                                     ? types::TY_LLVM_IR
+                                     : types::TY_LLVM_BC;
           if (SYCLDeviceOnly) {
             if (Args.hasArg(options::OPT_S))
               OutputType = types::TY_LLVM_IR;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3904,13 +3904,11 @@ class OffloadingActionBuilder final {
       // Device compilation generates LLVM BC.
       if (CurPhase == phases::Compile) {
         for (Action *&A : SYCLDeviceActions) {
-          types::ID OutputType = (Args.hasArg(options::OPT_S) &&
-                                  Args.hasArg(options::OPT_emit_llvm))
-                                     ? types::TY_LLVM_IR
-                                     : types::TY_LLVM_BC;
+          types::ID OutputType = types::TY_LLVM_BC;
+          if ((SYCLDeviceOnly || Args.hasArg(options::OPT_emit_llvm)) &&
+              Args.hasArg(options::OPT_S))
+            OutputType = types::TY_LLVM_IR;
           if (SYCLDeviceOnly) {
-            if (Args.hasArg(options::OPT_S))
-              OutputType = types::TY_LLVM_IR;
             if (Args.hasFlag(options::OPT_fno_sycl_use_bitcode,
                              options::OPT_fsycl_use_bitcode, false)) {
               auto *CompileAction =

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -38,3 +38,10 @@
 // RUN: %clangxx -### -fsycl -target x86_64-unknown-linux-gnu -fPIC %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK_SHARED %s
 // CHECK_SHARED: llc{{.*}} "-relocation-model=pic"
+
+/// -S -emit-llvm should generate textual IR for device.
+// RUN: %clangxx -### -fsycl -S -emit-llvm %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK_S_LLVM %s
+// CHECK_S_LLVM: clang{{.*}} "-fsycl-is-device"{{.*}} "-emit-llvm"{{.*}} "-o" "[[DEVICE:.+\.ll]]"
+// CHECK_S_LLVM: clang{{.*}} "-fsycl-is-host"{{.*}} "-emit-llvm"{{.*}} "-o" "[[HOST:.+\.ll]]"
+// CHECK_S_LLVM: clang-offload-bundler{{.*}} "-type=ll"{{.*}} "-inputs=[[DEVICE]],[[HOST]]"


### PR DESCRIPTION
When performing compilation with -S -emit-llvm, we were still emitting
LLVM-BC instead of the textual representation.  Make some adjustments
to generate the expected output for the device side.