### PR TITLE
[SYCL] Fix int-footer spec-const generation for deduced types.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5023,7 +5023,7 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
   Policy.SuppressTypedefs = true;
   Policy.SuppressUnwrittenScope = true;
 
-  llvm::SmallVector<const VarDecl *> VisitedSpecConstants;
+  llvm::SmallSet<const VarDecl *, 8> VisitedSpecConstants;
 
   // Used to uniquely name the 'shim's as we generate the names in each
   // anonymous namespace.
@@ -5031,16 +5031,15 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
   for (const VarDecl *VD : SpecConstants) {
     VD = VD->getCanonicalDecl();
 
-    // Skip if we've already visited this.
-    if (llvm::find(VisitedSpecConstants, VD) != VisitedSpecConstants.end())
-      continue;
-
     // Skip if this isn't a SpecIdType.  This can happen if it was a deduced
     // type.
     if (!Util::isSyclSpecIdType(VD->getType().getCanonicalType()))
       continue;
 
-    // TODO: skip if visited.
+    // Skip if we've already visited this.
+    if (llvm::find(VisitedSpecConstants, VD) != VisitedSpecConstants.end())
+      continue;
+
     VisitedSpecConstants.push_back(VD);
     std::string TopShim = EmitSpecIdShims(OS, ShimCounter, VD);
     OS << "__SYCL_INLINE_NAMESPACE(cl) {\n";

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5040,7 +5040,7 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
     if (llvm::find(VisitedSpecConstants, VD) != VisitedSpecConstants.end())
       continue;
 
-    VisitedSpecConstants.push_back(VD);
+    VisitedSpecConstants.insert(VD);
     std::string TopShim = EmitSpecIdShims(OS, ShimCounter, VD);
     OS << "__SYCL_INLINE_NAMESPACE(cl) {\n";
     OS << "namespace sycl {\n";

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4846,11 +4846,12 @@ void SYCLIntegrationFooter::addVarDecl(const VarDecl *VD) {
     return;
   // Step 1: ensure that this is of the correct type-spec-constant template
   // specialization).
-  if (!Util::isSyclSpecIdType(Ty)) {
+  if (!Util::isSyclSpecIdType(VD->getType())) {
     // Handle the case where this could be a deduced type, such as a deduction
     // guide. We have to do this here since this function, unlike most of the
     // rest of this file, is called during Sema instead of after it. We will
     // also have to filter out after deduction later.
+    QualType Ty = VD->getType().getCanonicalType();
     if (!Ty->isUndeducedType())
       return;
   }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5033,7 +5033,7 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
 
     // Skip if this isn't a SpecIdType.  This can happen if it was a deduced
     // type.
-    if (!Util::isSyclSpecIdType(VD->getType().getCanonicalType()))
+    if (!Util::isSyclSpecIdType(VD->getType()))
       continue;
 
     // Skip if we've already visited this.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4846,7 +4846,6 @@ void SYCLIntegrationFooter::addVarDecl(const VarDecl *VD) {
     return;
   // Step 1: ensure that this is of the correct type-spec-constant template
   // specialization).
-  QualType Ty = VD->getType().getCanonicalType();
   if (!Util::isSyclSpecIdType(Ty)) {
     // Handle the case where this could be a deduced type, such as a deduction
     // guide. We have to do this here since this function, unlike most of the

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5023,7 +5023,7 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
   Policy.SuppressTypedefs = true;
   Policy.SuppressUnwrittenScope = true;
 
-  llvm::SmallVector<const VarDecl*> VisitedSpecConstants;
+  llvm::SmallVector<const VarDecl *> VisitedSpecConstants;
 
   // Used to uniquely name the 'shim's as we generate the names in each
   // anonymous namespace.

--- a/clang/test/CodeGenSYCL/integration_footer.cpp
+++ b/clang/test/CodeGenSYCL/integration_footer.cpp
@@ -159,6 +159,4 @@ struct container {
 // CHECK-NOT: ::GetThing
 // CHECK-NOT: ::container::Thing
 
-
-
 // CHECK: #include <CL/sycl/detail/spec_const_integration.hpp>

--- a/clang/test/CodeGenSYCL/integration_footer.cpp
+++ b/clang/test/CodeGenSYCL/integration_footer.cpp
@@ -144,4 +144,21 @@ specialization_id<int> AnonNSSpecID;
 
 } // namespace Foo
 
+// make sure we don't emit a deduced type that isn't a spec constant.
+enum SomeEnum { SE_A };
+enum AnotherEnum : unsigned int { AE_A };
+
+template<SomeEnum E> struct GetThing{};
+template<> struct GetThing<SE_A>{
+  static constexpr auto thing = AE_A;
+};
+
+struct container {
+  static constexpr auto Thing = GetThing<SE_A>::thing;
+};
+// CHECK-NOT: ::GetThing
+// CHECK-NOT: ::container::Thing
+
+
+
 // CHECK: #include <CL/sycl/detail/spec_const_integration.hpp>


### PR DESCRIPTION
Apparently my initial implementation documented the need to do this, but
never did!  We collect SpecConstants (the vector), and add ones we don't
know if they are SpecConstants. However, the previous implementation
forgot to skip the VarDecls that were later deduced to be a different
type.