### PR TITLE
[SYCL] Suppress warning from unused variable in pi_level_zero

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -6410,6 +6410,8 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
 
 pi_result piextPluginGetOpaqueData(void *opaque_data_param,
                                    void **opaque_data_return) {
+  (void)opaque_data_param;
+  (void)opaque_data_return;
   return PI_ERROR_UNKNOWN;
 }
 


### PR DESCRIPTION
- Warning for unused variable in a newly added
piextPluginGetOpaqueData from pi_level_zero.cpp is suppressed