### PR TITLE
[SYCL][NFC] Make all of the Util::isNNNType functions auto-canonicalize

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5199,7 +5199,7 @@ bool Util::matchContext(const DeclContext *Ctx,
 
 bool Util::matchQualifiedTypeName(QualType Ty,
                                   ArrayRef<Util::DeclContextDesc> Scopes) {
-  const CXXRecordDecl *RecTy = Ty->getAsCXXRecordDecl();
+  const CXXRecordDecl *RecTy = Ty.getCanonicalType()->getAsCXXRecordDecl();
 
   if (!RecTy)
     return false; // only classes/structs supported


### PR DESCRIPTION
We only really care about picking up the record-decl that the type
refers to, so we should just remove specifiers/qualifiers for all calls.