### PR TITLE
[Driver][SYCL] Retain comments when preprocessing for integration footer

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1172,12 +1172,11 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT_C);
   Args.AddLastArg(CmdArgs, options::OPT_CC);
 
-  // When generating the using the integration footer, add the comments
+  // When preprocessing using the integration footer, add the comments
   // to the first preprocessing step.
-  if (!Args.hasArg(options::OPT_C) && JA.isOffloading(Action::OFK_SYCL) &&
+  if (JA.isOffloading(Action::OFK_SYCL) && !ContainsAppendFooterAction(&JA) &&
       Args.hasArg(options::OPT_fsycl_use_footer) &&
-      JA.isDeviceOffloading(Action::OFK_None) &&
-      !ContainsAppendFooterAction(&JA))
+      JA.isDeviceOffloading(Action::OFK_None))
     CmdArgs.push_back("-C");
 
   // Handle dependency file generation.

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -2,7 +2,7 @@
 // RUN:  %clangxx -fsycl -fsycl-use-footer %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER %s
 // FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}"
-// FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-E"{{.*}} "-o" "[[PREPROC:.+\.ii]]"
+// FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-E"{{.*}} "-C"{{.*}} "-o" "[[PREPROC:.+\.ii]]"
 // FOOTER: append-file{{.*}} "[[PREPROC]]" "--append=[[INTFOOTER]]" "--output=[[APPENDEDSRC:.+\.cpp]]"
 // FOOTER: clang{{.*}} "-fsycl-is-host"{{.*}} "[[APPENDEDSRC]]"
 // FOOTER-NOT: "-include" "[[INTHEADER]]"


### PR DESCRIPTION
When generating the source file that has the integration footer appended
too, we want to retain the comments, which will improve verification
and diagnostic information.