### PR TITLE
[SYCL] Set local size as requested by attribute

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1735,7 +1735,7 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
        RequiredWGSize[2] != 0);
   size_t *LocalSize = nullptr;
 
-  if (EnforcedLocalSize)
+  if (!HasLocalSize && EnforcedLocalSize)
     LocalSize = RequiredWGSize;
   else if (HasLocalSize)
     LocalSize = &NDRDesc.LocalSize[0];

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1735,10 +1735,27 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
        RequiredWGSize[2] != 0);
   size_t *LocalSize = nullptr;
 
-  if (!HasLocalSize && EnforcedLocalSize)
-    LocalSize = RequiredWGSize;
-  else if (HasLocalSize)
-    LocalSize = &NDRDesc.LocalSize[0];
+  if (EnforcedLocalSize && HasLocalSize) {
+    if (NDRDesc.LocalSize[0] != RequiredWGSize[0] ||
+        NDRDesc.LocalSize[1] != RequiredWGSize[1] ||
+        NDRDesc.LocalSize[2] != RequiredWGSize[2]) {
+      std::stringstream Stream;
+      Stream << "The specified local size {" << NDRDesc.LocalSize[0] << ", "
+             << NDRDesc.LocalSize[1] << ", " << NDRDesc.LocalSize[2]
+             << "} doesn't match the required work-group "
+             << "size specified in the program source {" << RequiredWGSize[0]
+             << ", " << RequiredWGSize[1] << ", " << RequiredWGSize[2] << "}";
+      throw sycl::nd_range_error(Stream.str(), PI_INVALID_WORK_GROUP_SIZE);
+    }
+  } else if (!HasLocalSize && EnforcedLocalSize) {
+    throw sycl::nd_range_error("OpenCL 1.x and 2.0 requires to pass "
+                               "local size argument even if "
+                               "required work-group size was "
+                               "specified in the program source",
+                               PI_INVALID_WORK_GROUP_SIZE);
+  }
+
+  LocalSize = &NDRDesc.LocalSize[0];
 
   pi_result Error = Plugin.call_nocheck<PiApiKind::piEnqueueKernelLaunch>(
       MQueue->getHandleRef(), Kernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1723,10 +1723,27 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
   const bool HasLocalSize = (NDRDesc.LocalSize[0] != 0);
 
   ReverseRangeDimensionsForKernel(NDRDesc);
+
+  size_t RequiredWGSize[3] = {0, 0, 0};
+  Plugin.call<PiApiKind::piKernelGetGroupInfo>(Kernel,
+      detail::getSyclObjImpl(MQueue->get_device())->getHandleRef(),
+      PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, sizeof(RequiredWGSize),
+      RequiredWGSize, /* param_value_size_ret = */ nullptr);
+
+  const bool EnforcedLocalSize = (RequiredWGSize[0] != 0 ||
+                                  RequiredWGSize[1] != 0 ||
+                                  RequiredWGSize[2] != 0);
+  size_t *LocalSize = nullptr;
+
+  if (EnforcedLocalSize)
+    LocalSize = RequiredWGSize;
+  else if (HasLocalSize)
+    LocalSize = &NDRDesc.LocalSize[0];
+
   pi_result Error = Plugin.call_nocheck<PiApiKind::piEnqueueKernelLaunch>(
       MQueue->getHandleRef(), Kernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],
-      &NDRDesc.GlobalSize[0], HasLocalSize ? &NDRDesc.LocalSize[0] : nullptr,
-      RawEvents.size(), RawEvents.empty() ? nullptr : &RawEvents[0], &Event);
+      &NDRDesc.GlobalSize[0], LocalSize, RawEvents.size(),
+      RawEvents.empty() ? nullptr : &RawEvents[0], &Event);
   return Error;
 }
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1725,14 +1725,14 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
   ReverseRangeDimensionsForKernel(NDRDesc);
 
   size_t RequiredWGSize[3] = {0, 0, 0};
-  Plugin.call<PiApiKind::piKernelGetGroupInfo>(Kernel,
-      detail::getSyclObjImpl(MQueue->get_device())->getHandleRef(),
+  Plugin.call<PiApiKind::piKernelGetGroupInfo>(
+      Kernel, detail::getSyclObjImpl(MQueue->get_device())->getHandleRef(),
       PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, sizeof(RequiredWGSize),
       RequiredWGSize, /* param_value_size_ret = */ nullptr);
 
-  const bool EnforcedLocalSize = (RequiredWGSize[0] != 0 ||
-                                  RequiredWGSize[1] != 0 ||
-                                  RequiredWGSize[2] != 0);
+  const bool EnforcedLocalSize =
+      (RequiredWGSize[0] != 0 || RequiredWGSize[1] != 0 ||
+       RequiredWGSize[2] != 0);
   size_t *LocalSize = nullptr;
 
   if (EnforcedLocalSize)

--- a/sycl/unittests/scheduler/CMakeLists.txt
+++ b/sycl/unittests/scheduler/CMakeLists.txt
@@ -12,5 +12,6 @@ add_sycl_unittest(SchedulerTests OBJECT
     StreamInitDependencyOnHost.cpp
     InOrderQueueDeps.cpp
     AllocaLinking.cpp
+    RequiredWGSize.cpp
     utils.cpp
 )


### PR DESCRIPTION
This patch fixes an error when specified local size doesn't match 
the required work-group size specified in the program source.
DPC++ RT queries `piKernelGetGroupInfo(..., PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, ...)` 
and if the result is not zero it passes it as a local size to 
`piEnqueueKernelLaunch`.