### PR TITLE
[SYCL][ESIMD][EMU] __SYCL_EXPORT fix for 'getPlugin'

### DIFF
--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -439,10 +439,8 @@ template <backend BE> const plugin &getPlugin() {
                       PI_INVALID_OPERATION);
 }
 
-template const plugin &getPlugin<backend::opencl>();
-template const plugin &getPlugin<backend::level_zero>();
-// __SYCL_EXPORT for esimd_cpu backend to use 'getPlugin' from
-// getPluginOpaqueData()
+template __SYCL_EXPORT const plugin &getPlugin<backend::opencl>();
+template __SYCL_EXPORT const plugin &getPlugin<backend::level_zero>();
 template __SYCL_EXPORT const plugin &getPlugin<backend::esimd_cpu>();
 
 // Report error and no return (keeps compiler from printing warnings).


### PR DESCRIPTION
- As 'getPlugin<>()' is exported, all instances of the function must
be explicitly prefixed with '__SYCL_EXPORT'.

- 'opencl' and 'level_zero' are changed for this export.