### PR TITLE
[SYCL][CUDA] Enable cuda_piEnqueueEventsWaitWithBarrier

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -311,6 +311,10 @@ pi_result cuda_piEnqueueEventsWait(pi_queue command_queue,
                                    pi_uint32 num_events_in_wait_list,
                                    const pi_event *event_wait_list,
                                    pi_event *event);
+pi_result cuda_piEnqueueEventsWaitWithBarrier(pi_queue command_queue,
+                                              pi_uint32 num_events_in_wait_list,
+                                              const pi_event *event_wait_list,
+                                              pi_event *event);
 pi_result cuda_piEventRelease(pi_event event);
 pi_result cuda_piEventRetain(pi_event event);
 
@@ -3279,11 +3283,33 @@ pi_result cuda_piEventRelease(pi_event event) {
 
 /// Enqueues a wait on the given CUstream for all events.
 /// See \ref enqueueEventWait
+/// TODO: Add support for multiple streams once the Event class is properly
+/// refactored.
 ///
 pi_result cuda_piEnqueueEventsWait(pi_queue command_queue,
                                    pi_uint32 num_events_in_wait_list,
                                    const pi_event *event_wait_list,
                                    pi_event *event) {
+  return cuda_piEnqueueEventsWaitWithBarrier(
+      command_queue, num_events_in_wait_list, event_wait_list, event);
+}
+
+/// Enqueues a wait on the given CUstream for all specified events (See
+/// \ref enqueueEventWaitWithBarrier.) If the events list is empty, the enqueued
+/// wait will wait on all previous events in the queue.
+///
+/// \param[in] command_queue A valid PI queue.
+/// \param[in] num_events_in_wait_list Number of events in event_wait_list.
+/// \param[in] event_wait_list Events to wait on.
+/// \param[out] event Event for when all events in event_wait_list have finished
+/// or, if event_wait_list is empty, when all previous events in the queue have
+/// finished.
+///
+/// \return TBD
+pi_result cuda_piEnqueueEventsWaitWithBarrier(pi_queue command_queue,
+                                              pi_uint32 num_events_in_wait_list,
+                                              const pi_event *event_wait_list,
+                                              pi_event *event) {
   if (!command_queue) {
     return PI_INVALID_QUEUE;
   }
@@ -3315,26 +3341,6 @@ pi_result cuda_piEnqueueEventsWait(pi_queue command_queue,
   } catch (...) {
     return PI_ERROR_UNKNOWN;
   }
-}
-
-/// Enqueues a wait on the given CUstream for all specified events (See
-/// \ref enqueueEventWait.) If the events list is empty, the enqueued wait will
-/// wait on all previous events in the queue.
-/// TODO: Implement this.
-///
-/// \param[in] command_queue A valid PI queue.
-/// \param[in] num_events_in_wait_list Number of events in event_wait_list.
-/// \param[in] event_wait_list Events to wait on.
-/// \param[out] event Event for when all events in event_wait_list have finished
-/// or, if event_wait_list is empty, when all previous events in the queue have
-/// finished.
-///
-/// \return TBD
-pi_result cuda_piEnqueueEventsWaitWithBarrier(pi_queue, pi_uint32,
-                                              const pi_event *, pi_event *) {
-  cl::sycl::detail::pi::die(
-      "cuda_piEnqueueEventsWaitWithBarrier not implemented");
-  return {};
 }
 
 /// Gets the native CUDA handle of a PI event object


### PR DESCRIPTION
This enables cuda_piEnqueueEventsWaitWithBarrier by moving the implementation of cuda_piEnqueueEventsWait and redirecting cuda_piEnqueueEventsWait to cuda_piEnqueueEventsWaitWithBarrier.

cuda_piEnqueueEventsWait will need refactored at a later time to not use the barrier version. This requires refactoring to the pi_cuda Event class which is beyond the scope of this PR.
