### PR TITLE
[SYCL] Changes to suppress some warnings

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -225,16 +225,16 @@ public:
   public:
     using ValTy = std::remove_pointer<pi_device_binary_property>::type;
 
-    class ConstIterator
-        : public std::iterator<std::input_iterator_tag, // iterator_category
-                               ValTy,                   // value_type
-                               ptrdiff_t,               // difference_type
-                               const pi_device_binary_property, // pointer
-                               pi_device_binary_property>       // reference
-    {
+   class ConstIterator {
       pi_device_binary_property Cur;
 
     public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = ValTy;
+      using difference_type = ptrdiff_t;
+      using pointer = const pi_device_binary_property;
+      using reference = pi_device_binary_property;
+
       ConstIterator(pi_device_binary_property Cur = nullptr) : Cur(Cur) {}
       ConstIterator &operator++() {
         Cur++;

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -225,7 +225,7 @@ public:
   public:
     using ValTy = std::remove_pointer<pi_device_binary_property>::type;
 
-   class ConstIterator {
+    class ConstIterator {
       pi_device_binary_property Cur;
 
     public:

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -14,6 +14,8 @@
 ///
 /// \ingroup sycl_pi_ocl
 
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+
 #include <CL/sycl/detail/cl.h>
 #include <CL/sycl/detail/pi.h>
 


### PR DESCRIPTION
When the sycl is building for the Windows 10 the MSVC is displaying warnings with std::iterator and some OpenCL deprecated functions.
The inheritance from std::iterator was removed because std::iterator was deprecated in C++ 17.
The CL_USE_DEPRECATED_OPENCL_1_2_APIS macro was defined to suppress deprecated warnings from OpenCL