### PR TITLE
[SYCL] Add support for variable templates to integration footer

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5003,8 +5003,7 @@ static void EmitSpecIdShims(raw_ostream &OS, unsigned &ShimCounter,
 // Returns a string containing the FQN of the 'top most' shim, including its
 // function call parameters.
 static std::string EmitSpecIdShims(raw_ostream &OS, unsigned &ShimCounter,
-                                   PrintingPolicy &Policy,
-                                   const VarDecl *VD) {
+                                   PrintingPolicy &Policy, const VarDecl *VD) {
   if (!VD->isInAnonymousNamespace())
     return "";
   std::string RelativeName;

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -5280,9 +5280,13 @@ VarTemplateSpecializationDecl *Sema::BuildVarTemplateInstantiation(
 
   // TODO: Set LateAttrs and StartingScope ...
 
-  return cast_or_null<VarTemplateSpecializationDecl>(
+  auto *VD = cast_or_null<VarTemplateSpecializationDecl>(
       Instantiator.VisitVarTemplateSpecializationDecl(
           VarTemplate, FromVar, TemplateArgsInfo, Converted));
+
+  addSyclVarDecl(VD);
+
+  return VD;
 }
 
 /// Instantiates a variable template specialization by completing it

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -321,6 +321,8 @@ public:
   specialization_id &operator=(const specialization_id &rhs) = delete;
   specialization_id &operator=(specialization_id &&rhs) = delete;
 
+  T getDefaultValue() const { return MDefaultValue; }
+
 private:
   T MDefaultValue;
 };

--- a/clang/test/CodeGenSYCL/integration_footer.cpp
+++ b/clang/test/CodeGenSYCL/integration_footer.cpp
@@ -159,4 +159,33 @@ struct container {
 // CHECK-NOT: ::GetThing
 // CHECK-NOT: ::container::Thing
 
+// Validate that variable templates work correctly.  Previously they printed
+// without their template arguments.
+namespace {
+struct HasVarTemplate {
+  constexpr HasVarTemplate(){}
+  template<typename T, int case_num>
+  static constexpr specialization_id<T> VarTempl{case_num};
+};
+}
+
+auto x = HasVarTemplate::VarTempl<int, 2>.getDefaultValue();
+// CHECK: namespace {
+// CHECK-NEXT: namespace __sycl_detail
+// CHECK-NEXT: static constexpr decltype(HasVarTemplate::VarTempl<int, 2>) &__spec_id_shim_[[SHIM1:[0-9]+]]() {
+// CHECK-NEXT: return HasVarTemplate::VarTempl<int, 2>;
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace __sycl_detail
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: __SYCL_INLINE_NAMESPACE(cl) {
+// CHECK-NEXT: namespace sycl {
+// CHECK-NEXT: namespace detail {
+// CHECK-NEXT: template<>
+// CHECK-NEXT: inline const char *get_spec_constant_symbolic_ID<::__sycl_detail::__spec_id_shim_[[SHIM1]]()>() {
+// CHECK-NEXT: return "____ZN12_GLOBAL__N_114HasVarTemplate8VarTemplIiLi2EEE";
+// CHECK-NEXT: }
+// CHECK-NEXT: } // namespace detail
+// CHECK-NEXT: } // namespace sycl
+// CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
+
 // CHECK: #include <CL/sycl/detail/spec_const_integration.hpp>


### PR DESCRIPTION
The integration footer didn't properly handle variable templates, which
this does.  We had to change the way we 'print' the names of the types,
since the previous version wouldn't print template arguments.