### PR TITLE
[SYCL] Fix post commit after PR 2292

### DIFF
--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -22,13 +22,13 @@
 
 cl::sycl::detail::Requirement getMockRequirement();
 
-namespace cl {
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 class Command;
 } // namespace detail
 } // namespace sycl
-} // namespace cl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
 class MockCommand : public cl::sycl::detail::Command {
 public:


### PR DESCRIPTION
This patch fixes post commit caused by incorrect declaration
of `cl` namespace:

https://github.com/intel/llvm/runs/2838178517:

```
In file included from /home/runner/work/llvm/llvm/src/sycl/unittests/scheduler/FailedCommands.cpp:10:
/home/runner/work/llvm/llvm/src/sycl/unittests/scheduler/SchedulerTestUtils.hpp:25:11: error: inline namespace reopened as a non-inline namespace [-Werror,-Winline-namespace-reopened-noninline]
namespace cl {
          ^
inline 
/home/runner/work/llvm/llvm/src/sycl/source/detail/stream_impl.hpp:20:25: note: previous definition is here
__SYCL_INLINE_NAMESPACE(cl) {
                        ^
1 error generated.
```