### PR TITLE
[SYCL] Throw exception when SYCL_DEVICE_ALLOWLIST doesn't have ":" delimiter

### DIFF
--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -70,6 +70,13 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
   const char DelimeterBtwItemsInDeviceDesc = ',';
   const char DelimeterBtwDeviceDescs = '|';
 
+  if (AllowListRaw.find(DelimeterBtwKeyAndValue, KeyStart) == std::string::npos)
+    throw sycl::runtime_error("SYCL_DEVICE_ALLOWLIST has incorrect format. For "
+                              "details, please refer to "
+                              "https://github.com/intel/llvm/blob/sycl/sycl/"
+                              "doc/EnvironmentVariables.md",
+                              PI_INVALID_VALUE);
+
   while ((KeyEnd = AllowListRaw.find(DelimeterBtwKeyAndValue, KeyStart)) !=
          std::string::npos) {
     if ((ValueStart = AllowListRaw.find_first_not_of(

--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -66,21 +66,21 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
   size_t KeyStart = 0, KeyEnd = 0, ValueStart = 0, ValueEnd = 0,
          DeviceDescIndex = 0;
 
-  const char DelimeterBtwKeyAndValue = ':';
-  const char DelimeterBtwItemsInDeviceDesc = ',';
-  const char DelimeterBtwDeviceDescs = '|';
+  const char DelimiterBtwKeyAndValue = ':';
+  const char DelimiterBtwItemsInDeviceDesc = ',';
+  const char DelimiterBtwDeviceDescs = '|';
 
-  if (AllowListRaw.find(DelimeterBtwKeyAndValue, KeyStart) == std::string::npos)
+  if (AllowListRaw.find(DelimiterBtwKeyAndValue, KeyStart) == std::string::npos)
     throw sycl::runtime_error("SYCL_DEVICE_ALLOWLIST has incorrect format. For "
                               "details, please refer to "
                               "https://github.com/intel/llvm/blob/sycl/sycl/"
                               "doc/EnvironmentVariables.md",
                               PI_INVALID_VALUE);
 
-  while ((KeyEnd = AllowListRaw.find(DelimeterBtwKeyAndValue, KeyStart)) !=
+  while ((KeyEnd = AllowListRaw.find(DelimiterBtwKeyAndValue, KeyStart)) !=
          std::string::npos) {
     if ((ValueStart = AllowListRaw.find_first_not_of(
-             DelimeterBtwKeyAndValue, KeyEnd)) == std::string::npos)
+             DelimiterBtwKeyAndValue, KeyEnd)) == std::string::npos)
       break;
     const std::string &Key = AllowListRaw.substr(KeyStart, KeyEnd - KeyStart);
 
@@ -109,11 +109,11 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
       if (std::find(SupportedKeyNamesHaveFixedValue.begin(),
                     SupportedKeyNamesHaveFixedValue.end(),
                     Key) != SupportedKeyNamesHaveFixedValue.end()) {
-        ValueEnd = AllowListRaw.find(DelimeterBtwItemsInDeviceDesc, ValueStart);
+        ValueEnd = AllowListRaw.find(DelimiterBtwItemsInDeviceDesc, ValueStart);
         // check if it is the last Key:Value pair in the device description, and
         // correct end position of that value
         if (size_t ValueEndCand =
-                AllowListRaw.find(DelimeterBtwDeviceDescs, ValueStart);
+                AllowListRaw.find(DelimiterBtwDeviceDescs, ValueStart);
             (ValueEndCand != std::string::npos) && (ValueEndCand < ValueEnd)) {
           ValueEnd = ValueEndCand;
           ShouldAllocateNewDeviceDescMap = true;
@@ -198,22 +198,22 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
                     Postfix,
                 PI_INVALID_VALUE);
         }
-        size_t NextExpectedDelimeterPos = ValueEnd + Postfix.length();
+        size_t NextExpectedDelimiterPos = ValueEnd + Postfix.length();
         // if it is not the end of the string, check that symbol next to a
-        // postfix is a delimeter (, or ;)
-        if ((AllowListRaw.length() != NextExpectedDelimeterPos) &&
-            (AllowListRaw[NextExpectedDelimeterPos] !=
-             DelimeterBtwItemsInDeviceDesc) &&
-            (AllowListRaw[NextExpectedDelimeterPos] != DelimeterBtwDeviceDescs))
+        // postfix is a delimiter (, or ;)
+        if ((AllowListRaw.length() != NextExpectedDelimiterPos) &&
+            (AllowListRaw[NextExpectedDelimiterPos] !=
+             DelimiterBtwItemsInDeviceDesc) &&
+            (AllowListRaw[NextExpectedDelimiterPos] != DelimiterBtwDeviceDescs))
           throw sycl::runtime_error(
               "Unexpected symbol on position " +
-                  std::to_string(NextExpectedDelimeterPos) + ": " +
-                  AllowListRaw[NextExpectedDelimeterPos] +
-                  ". Should be either " + DelimeterBtwItemsInDeviceDesc +
-                  " or " + DelimeterBtwDeviceDescs,
+                  std::to_string(NextExpectedDelimiterPos) + ": " +
+                  AllowListRaw[NextExpectedDelimiterPos] +
+                  ". Should be either " + DelimiterBtwItemsInDeviceDesc +
+                  " or " + DelimiterBtwDeviceDescs,
               PI_INVALID_VALUE);
 
-        if (AllowListRaw[NextExpectedDelimeterPos] == DelimeterBtwDeviceDescs)
+        if (AllowListRaw[NextExpectedDelimiterPos] == DelimiterBtwDeviceDescs)
           ShouldAllocateNewDeviceDescMap = true;
 
         Value = AllowListRaw.substr(ValueStart, ValueEnd - ValueStart);

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -256,7 +256,7 @@ TEST(ParseAllowListTests, CheckMultipleColonsBetweenKeyAndValue) {
 TEST(ParseAllowListTests, CheckExceptionIsThrownForValueWOColonDelim) {
   try {
     sycl::detail::AllowListParsedT ActualValue =
-        sycl::detail::parseAllowList("SomeValueWOColonDelimeter");
+        sycl::detail::parseAllowList("SomeValueWOColonDelimiter");
     throw std::logic_error("sycl::runtime_error didn't throw");
   } catch (sycl::runtime_error const &e) {
     EXPECT_EQ(std::string("SYCL_DEVICE_ALLOWLIST has incorrect format. For "

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -252,3 +252,19 @@ TEST(ParseAllowListTests, CheckMultipleColonsBetweenKeyAndValue) {
   sycl::detail::AllowListParsedT ExpectedValue{{{"DeviceVendorId", "0x1234"}}};
   EXPECT_EQ(ExpectedValue, ActualValue);
 }
+
+TEST(ParseAllowListTests, CheckExceptionIsThrownForValueWOColonDelim) {
+  try {
+    sycl::detail::AllowListParsedT ActualValue =
+        sycl::detail::parseAllowList("SomeValueWOColonDelimeter");
+    throw std::logic_error("sycl::runtime_error didn't throw");
+  } catch (sycl::runtime_error const &e) {
+    EXPECT_EQ(std::string("SYCL_DEVICE_ALLOWLIST has incorrect format. For "
+                          "details, please refer to "
+                          "https://github.com/intel/llvm/blob/sycl/sycl/"
+                          "doc/EnvironmentVariables.md -30 (CL_INVALID_VALUE)"),
+              e.what());
+  } catch (...) {
+    FAIL() << "Expected sycl::runtime_error";
+  }
+}


### PR DESCRIPTION
This patch improves error handling of incorrect SYCL_DEVICE_ALLOWLIST
values by adding exception for situation when SYCL_DEVICE_ALLOWLIST
doesn't have mandatory ":" delimiter.

\+ it fixes delim**e**ter -> delim**i**ter issue.