### PR TITLE
[SYCL-PTX] Add warp-reduce path in sub-group reduce

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -311,7 +311,9 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 		if( ${d} STREQUAL "none" OR ${ARCH} STREQUAL "spirv" OR ${ARCH} STREQUAL "spirv64" )
 			# FIXME: Ideally we would not be tied to a specific PTX ISA version
 			if( ${ARCH} STREQUAL nvptx OR ${ARCH} STREQUAL nvptx64 )
-				set( flags "SHELL:-Xclang -target-feature" "SHELL:-Xclang +ptx64")
+				# Disables NVVM reflection to defer to after linking
+				set( flags "SHELL:-Xclang -target-feature" "SHELL:-Xclang +ptx72"
+						 "SHELL:-march=sm_86" "SHELL:-mllvm --nvvm-reflect-enable=false")
 			endif()
 			set( arch_suffix "${t}" )
 		else()
@@ -327,12 +329,15 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 				set( t "spir64--" )
 			endif()
 			set( build_flags -O0 -finline-hint-functions )
-			set( opt_flags )
+			set( opt_flags -O3 )
 			set( spvflags --spirv-max-version=1.1 )
 		elseif( ${ARCH} STREQUAL "clspv" )
 			set( t "spir--" )
 			set( build_flags )
 			set( opt_flags -O3 )
+		elseif( ${ARCH} STREQUAL "nvptx" OR ${ARCH} STREQUAL "nvptx64" )
+			set( build_flags )
+			set( opt_flags -O3 "--nvvm-reflect-enable=false" )
 		else()
 			set( build_flags )
 			set( opt_flags -O3 )
@@ -342,6 +347,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 			TRIPLE ${t}
 			TARGET_ENV libspirv
 			COMPILE_OPT ${flags}
+			OPT_FLAGS ${opt_flags}
 			FILES ${libspirv_files}
 			ALIASES ${${d}_aliases}
 			GENERATE_TARGET "generate_convert_spirv.cl" "generate_convert_core.cl"
@@ -351,6 +357,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 			TRIPLE ${t}
 			TARGET_ENV clc
 			COMPILE_OPT ${flags}
+			OPT_FLAGS ${opt_flags}
 			FILES ${lib_files}
 			LIB_DEP libspirv-${arch_suffix}
 			ALIASES ${${d}_aliases}

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -43,7 +43,7 @@ macro(add_libclc_builtin_set arch_suffix)
   cmake_parse_arguments(ARG
     ""
     "TRIPLE;TARGET_ENV;LIB_DEP;PARENT_TARGET"
-    "FILES;ALIASES;GENERATE_TARGET;COMPILE_OPT"
+    "FILES;ALIASES;GENERATE_TARGET;COMPILE_OPT;OPT_FLAGS"
     ${ARGN})
 
   if (DEFINED ${ARG_LIB_DEP})
@@ -76,7 +76,7 @@ macro(add_libclc_builtin_set arch_suffix)
   # Add opt target
   set( builtins_opt_path "${LIBCLC_LIBRARY_OUTPUT_INTDIR}/builtins.opt.${obj_suffix}" )
   add_custom_command( OUTPUT "${builtins_opt_path}"
-    COMMAND ${LLVM_OPT} -O3 -o
+    COMMAND ${LLVM_OPT} ${ARG_OPT_FLAGS} -o
     "${builtins_opt_path}"
     "${LIBCLC_LIBRARY_OUTPUT_INTDIR}/builtins.link.${obj_suffix}"
     DEPENDS opt "builtins.link.${arch_suffix}" )


### PR DESCRIPTION
PTX introduces new warp reduction instructions with sm_80. These changes adds a path in select libclc subgroup collective functions for using these warp reduction instructions when available.

As an effect of these changes, future changes to libclc targeting nvptx can use `__nvvm_reflect` to differentiate between SM versions, allowing architecture-specific paths that will be determined after linking device code with libclc.