### PR TITLE
[SYCL][FPGA] Add support for three new kernel attributes

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2020,6 +2020,23 @@ def : MutualExclusions<[SYCLIntelFPGAIVDep,
 def : MutualExclusions<[SYCLIntelFPGAMaxConcurrency,
                         SYCLIntelFPGADisableLoopPipelining]>;
 
+def SYCLIntelFpgaPipeline : InheritableAttr {
+  let Spellings = [CXX11<"intel","fpga_pipeline">];
+  let Args = [ExprArgument<"Value", /*optional*/1>];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
+  let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
+                              ErrorDiag,
+                              "'for', 'while', 'do' statements, and functions">;
+  let Documentation = [SYCLIntelFpgaPipelineAttrDocs];
+  let IsStmtDependent = 1;
+  let SupportsNonconformingLambdaSyntax = 1;
+}
+
+def : MutualExclusions<[SYCLIntelFPGAInitiationInterval,
+                        SYCLIntelFpgaPipeline]>;
+def : MutualExclusions<[SYCLIntelFPGAMaxConcurrency,
+                        SYCLIntelFpgaPipeline]>;
+
 def SYCLIntelFPGALoopCount : StmtAttr {
   let Spellings = [CXX11<"intel", "loop_count_min">,
                    CXX11<"intel", "loop_count_max">,

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3102,6 +3102,9 @@ function, or in conjunction with ``max_interleaving``,
 ``speculated_iterations``, ``max_concurrency``, ``initiation_interval``,
 or ``ivdep``.
 
+The ``[[intel::disable_loop_pipelining`` attribute spelling
+is deprecated in favor of ``[[[intel::fpga_pipeline(n)]]``.
+
 .. code-block:: c++
 
   void foo() {
@@ -3110,6 +3113,43 @@ or ``ivdep``.
   }
 
   [[intel::disable_loop_pipelining]] void foo1() { }
+
+  }];
+}
+
+def SYCLIntelFpgaPipelineAttrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "intel::fpga_pipeline";
+  let Content = [{
+The ``intel::fpga_pipeline(N)`` attribute applies to a loop or a function.
+Allows users to disable/enable pipelining invocations of a function
+or pipelining iterations of a loop. Takes boolean parameter N where N can be
+a template parameter or constexpr. Valid values are 0 and 1.
+If used without argument, value of 1 is set implicitly, which implies
+enable pipelining. Cannot be used on the same loop or function, or in
+conjunction with ``max_concurrency`` or ``initiation_interval`` attributes.
+
+.. code-block:: c++
+
+  struct my_kernel {
+    [[intel::fpga_pipeline]]
+    // identical to [[intel::fpga_pipeline(1)]]
+    void operator()() {}
+  };
+
+  // unpipelined function
+  [[intel::fpga_pipeline(0)]] void foo() {};
+
+  template <int N>
+  class Functor {
+  public:
+    [[intel::fpga_pipeline(N)]] void operator()() const {}
+  };
+
+  void foo() {
+    int var = 0;
+    [[intel::fpga_pipeline(1)]] for (int i = 0; i < 10; ++i) var++;
+  }
 
   }];
 }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2172,6 +2172,9 @@ public:
   SYCLIntelFPGALoopCountAttr *
   BuildSYCLIntelFPGALoopCount(const AttributeCommonInfo &CI, Expr *E);
 
+  SYCLIntelFpgaPipelineAttr *
+  BuildSYCLIntelFPGAPipelineAttr(const AttributeCommonInfo &CI, Expr *E);
+
   bool CheckQualifiedFunctionForTypeId(QualType T, SourceLocation Loc);
 
   bool CheckFunctionReturnType(QualType T, SourceLocation Loc);
@@ -10413,6 +10416,11 @@ public:
   SYCLIntelMaxGlobalWorkDimAttr *
   MergeSYCLIntelMaxGlobalWorkDimAttr(Decl *D,
                                      const SYCLIntelMaxGlobalWorkDimAttr &A);
+
+  SYCLIntelFpgaPipelineAttr *MergeSYCLIntelFpgaPipelineAttr(
+      Decl *D, const SYCLIntelFpgaPipelineAttr &A);
+  void AddSYCLIntelFpgaPipelineAttr(Decl *D, const AttributeCommonInfo &CI,
+                                    Expr *E);
   /// AddAlignedAttr - Adds an aligned attribute to a particular declaration.
   void AddAlignedAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E,
                       bool IsPackExpansion);

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -611,6 +611,25 @@ MDNode *LoopInfo::createMetadata(
                             llvm::Type::getInt32Ty(Ctx), VC.second))};
     LoopProperties.push_back(MDNode::get(Ctx, Vals));
   }
+
+  if (Attrs.SYCLIntelFPGANPipelines > 0) {
+    Metadata *Vals[] = {
+        MDString::get(Ctx, "llvm.loop.intel.pipelining.enable"),
+        ConstantAsMetadata::get(
+            ConstantInt::get(llvm::Type::getInt32Ty(Ctx),
+                             Attrs.SYCLIntelFPGANPipelines))};
+    LoopProperties.push_back(MDNode::get(Ctx, Vals));
+  }
+
+  // fpga_pipeline attribute corresponds to
+  // 'llvm.loop.intel.pipelining.enable, i32 1' metadata for empty argument.
+  if (Attrs.SYCLIntelFPGAPipelineEnable) {
+    Metadata *Vals[] = {MDString::get(Ctx, "llvm.loop.intel.pipelining.enable"),
+                        ConstantAsMetadata::get(
+                            ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 1))};
+    LoopProperties.push_back(MDNode::get(Ctx, Vals));
+  }
+
   LoopProperties.insert(LoopProperties.end(), AdditionalLoopProperties.begin(),
                         AdditionalLoopProperties.end());
   return createFullUnrollMetadata(Attrs, LoopProperties, HasUserTransforms);
@@ -630,7 +649,8 @@ LoopAttributes::LoopAttributes(bool IsParallel)
       SYCLSpeculatedIterationsNIterations(0), UnrollCount(0),
       UnrollAndJamCount(0), DistributeEnable(LoopAttributes::Unspecified),
       PipelineDisabled(false), PipelineInitiationInterval(0),
-      SYCLNofusionEnable(false), MustProgress(false) {}
+      SYCLNofusionEnable(false), SYCLIntelFPGAPipelineEnable(false),
+      SYCLIntelFPGANPipelines(0), MustProgress(false) {}
 
 void LoopAttributes::clear() {
   IsParallel = false;
@@ -660,6 +680,8 @@ void LoopAttributes::clear() {
   PipelineDisabled = false;
   PipelineInitiationInterval = 0;
   SYCLNofusionEnable = false;
+  SYCLIntelFPGAPipelineEnable = false;
+  SYCLIntelFPGANPipelines = 0;
   MustProgress = false;
 }
 
@@ -695,7 +717,10 @@ LoopInfo::LoopInfo(BasicBlock *Header, const LoopAttributes &Attrs,
       Attrs.UnrollEnable == LoopAttributes::Unspecified &&
       Attrs.UnrollAndJamEnable == LoopAttributes::Unspecified &&
       Attrs.DistributeEnable == LoopAttributes::Unspecified && !StartLoc &&
-      Attrs.SYCLNofusionEnable == false && !EndLoc && !Attrs.MustProgress)
+      Attrs.SYCLNofusionEnable == false &&
+      Attrs.SYCLIntelFPGAPipelineEnable == false &&
+      Attrs.SYCLIntelFPGANPipelines == 0 &&
+      !EndLoc && !Attrs.MustProgress)
     return;
 
   TempLoopID = MDNode::getTemporary(Header->getContext(), None);
@@ -1082,6 +1107,15 @@ void LoopInfoStack::push(BasicBlock *Header, clang::ASTContext &Ctx,
 
     if (isa<SYCLIntelFPGANofusionAttr>(A))
       setSYCLNofusionEnable();
+
+    if (const auto *IntelFpgaPipeline =
+            dyn_cast<SYCLIntelFpgaPipelineAttr>(A)) {
+      if (auto *FP = IntelFpgaPipeline->getValue())
+        setSYCLIntelFPGANPipelines(
+            FP->getIntegerConstantExpr(Ctx)->getSExtValue());
+      else
+	setSYCLIntelFPGAPipelineEnable();
+    }
   }
 
   setMustProgress(MustProgress);

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -160,6 +160,12 @@ struct LoopAttributes {
   /// Flag for llvm.loop.fusion.disable metatdata.
   bool SYCLNofusionEnable;
 
+  /// Flag for llvm.loop.intel.pipelining.enable metadata.
+  bool SYCLIntelFPGAPipelineEnable;
+
+  /// Flag for llvm.loop.intel.pipelining.enable metadata.
+  unsigned SYCLIntelFPGANPipelines;
+
   /// Value for whether the loop is required to make progress.
   bool MustProgress;
 };
@@ -432,6 +438,16 @@ public:
 
   /// Set no progress for the next loop pushed.
   void setMustProgress(bool P) { StagedAttrs.MustProgress = P; }
+
+  /// Set flag of fpga_pipeline for the next loop pushed.
+  void setSYCLIntelFPGAPipelineEnable() {
+    StagedAttrs.SYCLIntelFPGAPipelineEnable = true;
+  }
+
+  /// Set value of concurrent fpga_pipeline for the next loop pushed.
+  void setSYCLIntelFPGANPipelines(unsigned C) {
+    StagedAttrs.SYCLIntelFPGANPipelines = C;
+  }
 
 private:
   /// Returns true if there is LoopInfo on the stack.

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -784,6 +784,16 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
     Fn->setMetadata("initiation_interval",
                     llvm::MDNode::get(Context, AttrMDArgs));
   }
+
+  if (const auto *A = FD->getAttr<SYCLIntelFpgaPipelineAttr>()) {
+    const auto *CE = cast<ConstantExpr>(A->getValue());
+    Optional<llvm::APSInt> ArgVal = CE->getResultAsAPSInt();
+    llvm::Metadata *AttrMDArgs[] = {
+        llvm::ConstantAsMetadata::get(
+              ArgVal->getBoolValue() ? Builder.getInt32(0) : Builder.getInt32(1))};
+    Fn->setMetadata("disable_loop_pipelining",
+                     llvm::MDNode::get(Context, AttrMDArgs));
+  }
 }
 
 /// Determine whether the function F ends with a return stmt.

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2699,6 +2699,8 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
     NewAttr = S.MergeWorkGroupSizeHintAttr(D, *A);
   else if (const auto *A = dyn_cast<SYCLIntelMaxGlobalWorkDimAttr>(Attr))
     NewAttr = S.MergeSYCLIntelMaxGlobalWorkDimAttr(D, *A);
+  else if (const auto *A = dyn_cast<SYCLIntelFpgaPipelineAttr>(Attr))
+    NewAttr = S.MergeSYCLIntelFpgaPipelineAttr(D, *A);
   else if (Attr->shouldInheritEvenIfAlreadyPresent() || !DeclHasAttr(D, Attr))
     NewAttr = cast<InheritableAttr>(Attr->clone(S.Context));
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -328,6 +328,14 @@ void Sema::CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,
     return;
   }
 
+  // Deprecate [[intel::disable_loop_pipelining]] attribute spelling in favor
+  // of the SYCL 2020 attribute spelling [[intel::fpga_pipeline]].
+  if (A.getKind() == ParsedAttr::AT_SYCLIntelFPGADisableLoopPipelining &&
+      A.hasScope() && A.getAttrName()->isStr("disable_loop_pipelining")) {
+    DiagnoseDeprecatedAttribute(A, "intel", "fpga_pipeline");
+    return;
+  }
+
   // Diagnose SYCL 2017 spellings in later SYCL modes.
   if (LangOpts.getSYCLVersion() > LangOptions::SYCL_2017) {
     // All attributes in the cl vendor namespace are deprecated in favor of a
@@ -6206,6 +6214,71 @@ static void handleSYCLIntelNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
   S.AddSYCLIntelNoGlobalWorkOffsetAttr(D, A, E);
 }
 
+// Handle [[intel:fpga_pipeline]] attribute. 
+void Sema::AddSYCLIntelFpgaPipelineAttr(Decl *D,
+                                        const AttributeCommonInfo &CI,
+                                        Expr *E) {
+  if (!E->isValueDependent()) {
+    // Validate that we have an integer constant expression and then store the
+    // converted constant expression into the semantic attribute so that we
+    // don't have to evaluate it again later.
+    llvm::APSInt ArgVal;
+    ExprResult Res = VerifyIntegerConstantExpression(E, &ArgVal);
+    if (Res.isInvalid())
+      return;
+    E = Res.get();
+
+    // Check to see if there's a duplicate attribute with different values
+    // already applied to the declaration.
+    if (const auto *DeclAttr = D->getAttr<SYCLIntelFpgaPipelineAttr>()) {
+      // If the other attribute argument is instantiation dependent, we won't
+      // have converted it to a constant expression yet and thus we test
+      // whether this is a null pointer.
+      if (const auto *DeclExpr = dyn_cast<ConstantExpr>(DeclAttr->getValue())) {
+        if (ArgVal != DeclExpr->getResultAsAPSInt()) {
+          Diag(CI.getLoc(), diag::warn_duplicate_attribute) << CI;
+          Diag(DeclAttr->getLoc(), diag::note_previous_attribute);
+        }
+        // Drop the duplicate attribute.
+        return;
+      }
+    }
+  }
+
+  D->addAttr(::new (Context) SYCLIntelFpgaPipelineAttr(Context, CI, E));
+}
+
+SYCLIntelFpgaPipelineAttr *Sema::MergeSYCLIntelFpgaPipelineAttr(
+    Decl *D, const SYCLIntelFpgaPipelineAttr &A) {
+  // Check to see if there's a duplicate attribute with different values
+  // already applied to the declaration.
+  if (const auto *DeclAttr = D->getAttr<SYCLIntelFpgaPipelineAttr>()) {
+    if (const auto *DeclExpr = dyn_cast<ConstantExpr>(DeclAttr->getValue())) {
+      if (const auto *MergeExpr = dyn_cast<ConstantExpr>(A.getValue())) {
+        if (DeclExpr->getResultAsAPSInt() != MergeExpr->getResultAsAPSInt()) {
+          Diag(DeclAttr->getLoc(), diag::warn_duplicate_attribute) << &A;
+          Diag(A.getLoc(), diag::note_previous_attribute);
+        }
+        // Do not add a duplicate attribute.
+        return nullptr;
+      }
+    }
+  }
+  return ::new (Context)
+       SYCLIntelFpgaPipelineAttr(Context, A, A.getValue());
+}
+
+static void handleSYCLIntelFpgaPipelineAttr(Sema &S, Decl *D,
+                                            const ParsedAttr &A) {
+  // If no attribute argument is specified, set to default value '1'.
+  Expr *E = A.isArgExpr(0)
+                ? A.getArgAsExpr(0)
+                : IntegerLiteral::Create(S.Context, llvm::APInt(32, 1),
+                                         S.Context.IntTy, A.getLoc());
+
+  S.AddSYCLIntelFpgaPipelineAttr(D, A, E);
+}
+
 /// Handle the [[intelfpga::doublepump]] and [[intelfpga::singlepump]]
 /// attributes.
 template <typename AttrType>
@@ -9700,6 +9773,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case ParsedAttr::AT_SYCLIntelFPGAInitiationInterval:
     handleSYCLIntelFPGAInitiationIntervalAttr(S, D, AL);
+    break;
+  case ParsedAttr::AT_SYCLIntelFpgaPipeline:
+    handleSYCLIntelFpgaPipelineAttr(S, D, AL);
     break;
   case ParsedAttr::AT_VecTypeHint:
     handleVecTypeHint(S, D, AL);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -573,7 +573,8 @@ static void collectSYCLAttributes(Sema &S, FunctionDecl *FD,
     llvm::copy_if(FD->getAttrs(), std::back_inserter(Attrs), [](Attr *A) {
       return isa<SYCLIntelLoopFuseAttr, SYCLIntelFPGAMaxConcurrencyAttr,
                  SYCLIntelFPGADisableLoopPipeliningAttr,
-                 SYCLIntelFPGAInitiationIntervalAttr>(A);
+                 SYCLIntelFPGAInitiationIntervalAttr,
+		 SYCLIntelFpgaPipelineAttr>(A);
     });
   }
 }
@@ -4097,6 +4098,7 @@ static void PropagateAndDiagnoseDeviceAttr(
   case attr::Kind::SYCLIntelFPGAMaxConcurrency:
   case attr::Kind::SYCLIntelFPGADisableLoopPipelining:
   case attr::Kind::SYCLIntelFPGAInitiationInterval:
+  case attr::Kind::SYCLIntelFpgaPipeline:
     SYCLKernel->addAttr(A);
     break;
   case attr::Kind::IntelNamedSubGroupSize:

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1096,6 +1096,8 @@ namespace {
         const SYCLIntelFPGASpeculatedIterationsAttr *SI);
     const SYCLIntelFPGALoopCountAttr *
     TransformSYCLIntelFPGALoopCountAttr(const SYCLIntelFPGALoopCountAttr *SI);
+    const SYCLIntelFpgaPipelineAttr *
+    TransformSYCLIntelFpgaPipelineAttr(const SYCLIntelFpgaPipelineAttr *SI);
 
     ExprResult TransformPredefinedExpr(PredefinedExpr *E);
     ExprResult TransformDeclRefExpr(DeclRefExpr *E);
@@ -1587,6 +1589,12 @@ TemplateInstantiator::TransformSYCLIntelFPGALoopCountAttr(
       getDerived().TransformExpr(LCA->getNTripCount()).get();
   return getSema().BuildSYCLIntelFPGALoopAttr<SYCLIntelFPGALoopCountAttr>(
       *LCA, TransformedExpr);
+}
+
+const SYCLIntelFpgaPipelineAttr *TemplateInstantiator::TransformSYCLIntelFpgaPipelineAttr(
+    const SYCLIntelFpgaPipelineAttr *PA) {
+  Expr *TransformedExpr = getDerived().TransformExpr(PA->getValue()).get();
+  return getSema().BuildSYCLIntelFPGAPipelineAttr(*PA, TransformedExpr);
 }
 
 const LoopUnrollHintAttr *TemplateInstantiator::TransformLoopUnrollHintAttr(

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -762,6 +762,16 @@ static void instantiateWorkGroupSizeHintAttr(
                              ZResult.get());
 }
 
+static void instantiateSYCLIntelFpgaPipelineAttr(
+    Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
+    const SYCLIntelFpgaPipelineAttr *A, Decl *New) {
+  EnterExpressionEvaluationContext Unevaluated(
+      S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
+  ExprResult Result = S.SubstExpr(A->getValue(), TemplateArgs);
+  if (!Result.isInvalid())
+    S.AddSYCLIntelFpgaPipelineAttr(New, *A, Result.getAs<Expr>());
+}
+
 // This doesn't take any template parameters, but we have a custom action that
 // needs to happen when the kernel itself is instantiated. We need to run the
 // ItaniumMangler to mark the names required to name this kernel.
@@ -1024,6 +1034,14 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
       instantiateWorkGroupSizeHintAttr(*this, TemplateArgs, A, New);
       continue;
     }
+
+     if (const auto *SYCLIntelFpgaPipeline =
+            dyn_cast<SYCLIntelFpgaPipelineAttr>(TmplAttr)) {
+      instantiateSYCLIntelFpgaPipelineAttr(
+          *this, TemplateArgs, SYCLIntelFpgaPipeline, New);
+      continue;
+    }
+
     // Existing DLL attribute on the instantiation takes precedence.
     if (TmplAttr->getKind() == attr::DLLExport ||
         TmplAttr->getKind() == attr::DLLImport) {

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -17,7 +17,9 @@
 // CHECK: br label %for.cond, !llvm.loop ![[MD_LCA:[0-9]+]]
 // CHECK: br label %for.cond2, !llvm.loop ![[MD_LCA_1:[0-9]+]]
 // CHECK: br label %for.cond13, !llvm.loop ![[MD_LCA_2:[0-9]+]]
-
+// CHECK: br label %for.cond, !llvm.loop ![[MD_FP:[0-9]+]]
+// CHECK: br label %for.cond2, !llvm.loop ![[MD_FP_1:[0-9]+]]
+// CHECK: br label %for.cond13, !llvm.loop ![[MD_FP_2:[0-9]+]]
 void disable_loop_pipelining() {
   int a[10];
   // CHECK: ![[MD_DLP]] = distinct !{![[MD_DLP]], ![[MP:[0-9]+]], ![[MD_dlp:[0-9]+]]}
@@ -131,6 +133,23 @@ void loop_count_control() {
       a[i] = 0;
 }
 
+template <int A>
+void fpga_pipeline() {
+  int a[10];
+  // CHECK: ![[MD_FP]] = distinct !{![[MD_FP]], ![[MP]], ![[MD_fpga_pipeline:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_fpga_pipeline]] = !{!"llvm.loop.intel.pipelining.enable", i32 1}
+  [[intel::fpga_pipeline(A)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // CHECK: ![[MD_FP_1]] = distinct !{![[MD_FP_1]], ![[MP]], ![[MD_fpga_pipeline]]}
+  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // CHECK: ![[MD_FP_2]] = distinct !{![[MD_FP_2]], ![[MP]], ![[MD_fpga_pipeline]]}
+  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+}
+
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
@@ -146,6 +165,7 @@ int main() {
     max_interleaving<3>();
     speculated_iterations<4>();
     loop_count_control<12>();
+    fpga_pipeline<1>();
   });
   return 0;
 }

--- a/clang/test/CodeGenSYCL/intel-fpga-pipeline-device.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-pipeline-device.cpp
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s
+
+// Tests for IR of Intel FPGA [[intel::fpga_pipeline]] function attribute on Device.
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
+
+class Foo {
+public:
+  [[intel::fpga_pipeline(1)]] void operator()() const {}
+};
+
+template <int SIZE>
+class Functor {
+public:
+  [[intel::fpga_pipeline(SIZE)]] void operator()() const {}
+};
+
+[[intel::fpga_pipeline(1)]] void func() {}
+
+int main() {
+  q.submit([&](handler &h) {
+    //CHECK: define dso_local spir_kernel void @{{.*}}kernel_name1() #0 !kernel_arg_buffer_location ![[NUM:[0-9]+]]  !disable_loop_pipelining ![[NUM0:[0-9]+]]
+    Foo boo;
+    h.single_task<class kernel_name1>(boo);
+
+    // CHECK: define dso_local spir_kernel void @{{.*}}kernel_name2() #0 !kernel_arg_buffer_location ![[NUM]] !disable_loop_pipelining ![[NUM0]]
+    h.single_task<class kernel_name2>(
+        []() [[intel::fpga_pipeline]]{});
+
+    // CHECK: define dso_local spir_kernel void @{{.*}}kernel_name3() #0 !kernel_arg_buffer_location ![[NUM]] !disable_loop_pipelining ![[NUM1:[0-9]+]]
+    h.single_task<class kernel_name3>(
+        []() [[intel::fpga_pipeline(0)]]{});
+
+    // CHECK: define dso_local spir_kernel void @{{.*}}kernel_name4() #0 !kernel_arg_buffer_location ![[NUM]] !disable_loop_pipelining ![[NUM0]]
+    Functor<1> f;
+    h.single_task<class kernel_name4>(f);
+
+    // CHECK: define dso_local spir_kernel void @{{.*}}test_kernel5() #0 !kernel_arg_buffer_location ![[NUM]]
+    h.single_task<class test_kernel5>(
+        []() { func(); });
+  });
+  return 0;
+}
+
+// CHECK: ![[NUM]] = !{}
+// CHECK: ![[NUM0]] = !{i32 0}
+// CHECK: ![[NUM1]] = !{i32 1}

--- a/clang/test/CodeGenSYCL/intel-fpga-pipeline-host.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-pipeline-host.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -fsycl-is-host -triple -x86_64-unknown-linux-gnu -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s
+
+// Tests for IR of Intel FPGA [[intel::fpga_pipeline]] function attribute on Host (no-op in IR-CodeGen for host-mode).
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
+  kernelFunc();
+}
+
+template <int SIZE>
+class KernelFunctor5 {
+public:
+  [[intel::fpga_pipeline(SIZE)]] void operator()() const {}
+};
+
+[[intel::fpga_pipeline]] void func1() {}
+
+void foo() {
+
+  KernelFunctor5<5> f5;
+  kernel<class kernel_name_1>(f5);
+}
+
+// CHECK-NOT: !disable_loop_pipelining

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -157,6 +157,7 @@
 // CHECK-NEXT: SYCLIntelFPGADisableLoopPipelining (SubjectMatchRule_function)
 // CHECK-NEXT: SYCLIntelFPGAInitiationInterval (SubjectMatchRule_function)
 // CHECK-NEXT: SYCLIntelFPGAMaxConcurrency (SubjectMatchRule_function)
+// CHECK-NEXT: SYCLIntelFpgaPipeline (SubjectMatchRule_function)
 // CHECK-NEXT: SYCLIntelKernelArgsRestrict (SubjectMatchRule_function)
 // CHECK-NEXT: SYCLIntelLoopFuse (SubjectMatchRule_function)
 // CHECK-NEXT: SYCLIntelMaxGlobalWorkDim (SubjectMatchRule_function)

--- a/clang/test/SemaSYCL/disable_loop_pipelining.cpp
+++ b/clang/test/SemaSYCL/disable_loop_pipelining.cpp
@@ -13,7 +13,8 @@ sycl::queue deviceQueue;
 #endif
 
 struct FuncObj {
-  [[intel::disable_loop_pipelining]] void operator()() const {}
+  [[intel::disable_loop_pipelining]] void operator()() const {} // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
 };
 
 int main() {
@@ -26,7 +27,9 @@ int main() {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel2
     // CHECK:       SYCLIntelFPGADisableLoopPipeliningAttr {{.*}}
     h.single_task<class test_kernel2>(
-        []() [[intel::disable_loop_pipelining]]{});
+        []() [[intel::disable_loop_pipelining]]{}); // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                    // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/initiation_interval.cpp
+++ b/clang/test/SemaSYCL/initiation_interval.cpp
@@ -30,6 +30,8 @@
 [[intel::initiation_interval(3)]] void func6(); // expected-warning {{attribute 'initiation_interval' is already applied with different arguments}}
 
 // Tests for Intel FPGA initiation_interval and disable_loop_pipelining attributes compatibility checks.
+// expected-warning@+4 {{attribute 'intel::disable_loop_pipelining' is deprecated}}
+// expected-note@+3 {{did you mean to use 'intel::fpga_pipeline' instead?}}
 // expected-error@+2 {{'initiation_interval' and 'disable_loop_pipelining' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
 [[intel::disable_loop_pipelining]] [[intel::initiation_interval(2)]] void func7();
@@ -41,7 +43,8 @@
 // expected-error@+3 {{'disable_loop_pipelining' and 'initiation_interval' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
 [[intel::initiation_interval(4)]] void func9();
-[[intel::disable_loop_pipelining]] void func9();
+[[intel::disable_loop_pipelining]] void func9(); // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                 // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
 
 // Tests that check template parameter support for Intel FPGA initiation_interval function attributes
 template <int N>
@@ -84,3 +87,17 @@ void test() {
   //expected-note@+1{{in instantiation of function template specialization 'func14<float>' requested here}}
   func14<float>();
 }
+
+// Tests for Intel FPGA i[[intel::initiation_interval]] and [[intel::fpga_pipeline]] attributes compatibility checks.
+// expected-error@+2 {{'initiation_interval' and 'fpga_pipeline' attributes are not compatible}}
+// expected-note@+1 {{conflicting attribute is here}}
+[[intel::fpga_pipeline(1)]] [[intel::initiation_interval(2)]] void func15();
+
+// expected-error@+2 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
+// expected-note@+1 {{conflicting attribute is here}}
+[[intel::initiation_interval(4)]] [[intel::fpga_pipeline]] void func16();
+
+// expected-error@+3 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
+// expected-note@+1 {{conflicting attribute is here}}
+[[intel::initiation_interval(4)]] void func17();
+[[intel::fpga_pipeline(0)]] void func17();

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -24,6 +24,8 @@ void foo() {
   [[intel::nofusion]] int k[10];
   // expected-error@+1{{'loop_count_avg' attribute cannot be applied to a declaration}}
   [[intel::loop_count_avg(6)]] int p[10];
+  // expected-error@+1{{'fpga_pipeline' attribute only applies to 'for', 'while', 'do' statements, and functions}}
+  [[intel::fpga_pipeline(1)]] int q[10];
 }
 
 // Test for deprecated spelling of Intel FPGA loop attributes
@@ -55,7 +57,7 @@ void foo_deprecated() {
       a[i] = 0;
 
   // expected-warning@+2 {{attribute 'intelfpga::disable_loop_pipelining' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::disable_loop_pipelining' instead?}}
+  // expected-note@+1 {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intelfpga::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
@@ -124,13 +126,16 @@ void boo() {
   // expected-error@+1 {{'loop_count_avg' attribute takes one argument}}
   [[intel::loop_count_avg(3, 6)]]  for (int i = 0; i != 10; ++i)
       a[i] = 0;
+  // expected-error@+1 {{'fpga_pipeline' attribute takes no more than 1 argument}}
+  [[intel::fpga_pipeline(1, 2)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 // Test for incorrect argument value for Intel FPGA loop attributes
 void goo() {
   int a[10];
-  // no diagnostics are expected
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
       a[i] = 0;
   // no diagnostics are expected
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
@@ -210,6 +215,19 @@ void goo() {
   // expected-error@+1 {{'loop_count_avg' attribute requires an integer constant}}
     [[intel::loop_count_avg("abc")]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+   // no diagnostics are expected
+   [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+   // no diagnostics are expected
+   [[intel::fpga_pipeline(0)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+   // expected-error@+1 {{'fpga_pipeline' attribute requires an integer constant}}
+   [[intel::fpga_pipeline("abc")]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+   //expected-error@+1 {{'fpga_pipeline' attribute requires a non-negative integral compile time constant expression}}
+   [[intel::fpga_pipeline(-1)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
 }
 
 // Test for Intel FPGA loop attributes duplication
@@ -247,9 +265,11 @@ void zoo() {
   [[intel::max_concurrency(2)]]
   [[intel::initiation_interval(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   // expected-error@+1 {{duplicate Intel FPGA loop attribute 'disable_loop_pipelining'}}
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
       a[i] = 0;
   [[intel::loop_coalesce(2)]]
   // expected-error@+2 {{duplicate Intel FPGA loop attribute 'loop_coalesce'}}
@@ -323,46 +343,89 @@ void zoo() {
   // expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count_avg'}}
   [[intel::loop_count_avg(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+  [[intel::fpga_pipeline(1)]]
+  // expected-error@+1{{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
+  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
 }
 
 // Test for Intel FPGA loop attributes compatibility
 void loop_attrs_compatibility() {
   int a[10];
   // no diagnostics are expected
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+3 {{'max_interleaving' and 'disable_loop_pipelining' attributes are not compatible}}
+  // expected-error@+4 {{'max_interleaving' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+3 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::speculated_iterations(0)]]
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
       a[i] = 0;
-  // expected-error@+3 {{'max_concurrency' and 'disable_loop_pipelining' attributes are not compatible}}
+  // expected-error@+4 {{'max_concurrency' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+3 {{'disable_loop_pipelining' and 'initiation_interval' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::initiation_interval(10)]]
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
       a[i] = 0;
-  // expected-error@+3 {{'ivdep' and 'disable_loop_pipelining' attributes are not compatible}}
+  // expected-error@+4 {{'ivdep' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::ivdep]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // no diagnostics are expected
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::nofusion]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // no diagnostics are expected
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+  [[intel::loop_count_avg(8)]]
+  for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  [[intel::loop_count_min(8)]]
+  for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  [[intel::loop_count_max(8)]]
+  for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // expected-error@+3 {{'fpga_pipeline' and 'max_concurrency' attributes are not compatible}}
+  // expected-note@+1 {{conflicting attribute is here}}
+  [[intel::max_concurrency(2)]]
+  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+  // expected-error@+3 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
+  // expected-note@+1 {{conflicting attribute is here}}
+  [[intel::initiation_interval(2)]]
+  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+  // no diagnostics are expected
+  [[intel::fpga_pipeline]]
+  [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // no diagnostics are expected
+  [[intel::fpga_pipeline]]
+  [[intel::nofusion]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // no diagnostics are expected
+  [[intel::fpga_pipeline]]
   [[intel::loop_count_avg(8)]]
   for (int i = 0; i != 10; ++i)
       a[i] = 0;
@@ -468,6 +531,19 @@ void loop_count_control_dependent() {
 
 }
 
+template <int A, int B, int C>
+void fpga_pipeline_dependent() {
+  int a[10];
+  // expected-error@+1 {{'fpga_pipeline' attribute requires a non-negative integral compile time constant expression}}
+  [[intel::fpga_pipeline(C)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
+  [[intel::fpga_pipeline(A)]]
+  [[intel::fpga_pipeline(B)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+}
+
 int main() {
   deviceQueue.submit([&](sycl::handler &h) {
     h.single_task<class kernel_function>([]() {
@@ -488,6 +564,9 @@ int main() {
 
      loop_count_control_dependent<3, 2, -1>();
       //expected-note@-1{{in instantiation of function template specialization 'loop_count_control_dependent<3, 2, -1>' requested here}}
+
+     fpga_pipeline_dependent<1, 1, -1>();
+     //expected-note@-1 +{{in instantiation of function template specialization}}
 });
   });
 

--- a/clang/test/SemaSYCL/intel-fpga-pipeline.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-pipeline.cpp
@@ -1,0 +1,61 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -Wno-return-type -Wno-sycl-2017-compat -fcxx-exceptions -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
+
+struct FuncObj {
+  [[intel::fpga_pipeline]] void operator()() const {}
+};
+
+int main() {
+  q.submit([&](handler &h) {
+    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel1
+    // CHECK:       SYCLIntelFpgaPipelineAttr {{.*}}
+    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
+    // CHECK-NEXT:  value: Int 1
+    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
+    h.single_task<class test_kernel1>(FuncObj());
+
+    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel2
+    // CHECK:       SYCLIntelFpgaPipelineAttr {{.*}}
+    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
+    // CHECK-NEXT:  value: Int 0
+    // CHECK-NEXT:  IntegerLiteral{{.*}}0{{$}}
+    h.single_task<class test_kernel2>(
+        []() [[intel::fpga_pipeline(0)]]{});
+
+    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
+    // CHECK: SYCLIntelFpgaPipelineAttr{{.*}}
+    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
+    // CHECK-NEXT:  value: Int 1
+    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
+    h.single_task<class test_kernel3>(
+        []() [[intel::fpga_pipeline(1)]]{});
+
+    // Ignore duplicate attribute.
+    h.single_task<class test_kernel4>(
+    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel4
+    // CHECK:       SYCLIntelFpgaPipelineAttr {{.*}}
+    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
+    // CHECK-NEXT:  value: Int 1
+    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
+        []() [[intel::fpga_pipeline,
+               intel::fpga_pipeline]]{});
+
+    // expected-error@+2{{integral constant expression must have integral or unscoped enumeration type, not 'const char [4]'}}
+    h.single_task<class test_kernel5>(
+        []() [[intel::fpga_pipeline("foo")]]{});
+
+    h.single_task<class test_kernel6>([]() {
+      // expected-error@+1{{'fpga_pipeline' attribute only applies to 'for', 'while', 'do' statements, and functions}}
+      [[intel::fpga_pipeline(1)]] int a;
+    });
+
+    h.single_task<class test_kernel7>(
+        []() [[intel::fpga_pipeline(0),      // expected-note {{previous attribute is here}}
+	       intel::fpga_pipeline(1)]]{});  // expected-warning{{attribute 'fpga_pipeline' is already applied with different arguments}}
+  });
+  return 0;
+}

--- a/clang/test/SemaSYCL/max-concurrency.cpp
+++ b/clang/test/SemaSYCL/max-concurrency.cpp
@@ -17,6 +17,8 @@ public:
 [[intel::max_concurrency]] void foo() {} // expected-error {{'max_concurrency' attribute takes one argument}}
 
 // Tests for Intel FPGA max_concurrency and disable_loop_pipelining function attributes compatibility.
+// expected-warning@+4 {{attribute 'intel::disable_loop_pipelining' is deprecated}}
+// expected-note@+3 {{did you mean to use 'intel::fpga_pipeline' instead?}}
 // expected-error@+2 {{'max_concurrency' and 'disable_loop_pipelining' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
 [[intel::disable_loop_pipelining]] [[intel::max_concurrency(2)]] void check();
@@ -28,7 +30,22 @@ public:
 // expected-error@+3 {{'disable_loop_pipelining' and 'max_concurrency' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
 [[intel::max_concurrency(4)]] void check2();
-[[intel::disable_loop_pipelining]] void check2();
+[[intel::disable_loop_pipelining]] void check2(); // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+		                                  // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+
+// Tests for Intel FPGA i[[intel::max_concurrency]] and [[intel::fpga_pipeline]] attributes compatibility checks.
+// expected-error@+2 {{'max_concurrency' and 'fpga_pipeline' attributes are not compatible}}
+// expected-note@+1 {{conflicting attribute is here}}
+[[intel::fpga_pipeline(1)]] [[intel::max_concurrency(2)]] void check3();
+
+// expected-error@+2 {{'fpga_pipeline' and 'max_concurrency' attributes are not compatible}}
+// expected-note@+1 {{conflicting attribute is here}}
+[[intel::max_concurrency(4)]] [[intel::fpga_pipeline]] void check4();
+
+// expected-error@+3 {{'fpga_pipeline' and 'max_concurrency' attributes are not compatible}}
+// expected-note@+1 {{conflicting attribute is here}}
+[[intel::max_concurrency(8)]] void check5();
+[[intel::fpga_pipeline(0)]] void check5();
 
 class Functor2 {
 public:

--- a/clang/test/SemaSYCL/sycl-device-intel-fpga-pipeline.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-fpga-pipeline.cpp
@@ -1,0 +1,96 @@
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+
+// Test that checks template parameter support for 'fpga_pipeline' attribute on sycl device.
+
+// Test that checks wrong function template instantiation and ensures that the type
+// is checked properly when instantiating from the template definition.
+template <typename Ty>
+// expected-error@+1{{integral constant expression must have integral or unscoped enumeration type, not 'S'}}
+[[intel::fpga_pipeline(Ty{})]] void func() {}
+
+struct S {};
+void var() {
+  //expected-note@+1{{in instantiation of function template specialization 'func<S>' requested here}}
+  func<S>();
+}
+
+// Test that checks expression is not a constant expression.
+// expected-note@+1{{declared here}}
+int foo();
+// expected-error@+2{{expression is not an integral constant expression}}
+// expected-note@+1{{non-constexpr function 'foo' cannot be used in a constant expression}}
+[[intel::fpga_pipeline(foo() + 12)]] void func1();
+
+// Test that checks expression is a constant expression.
+constexpr int bar() { return 0; }
+[[intel::fpga_pipeline(bar() + 12)]] void func2(); // OK
+
+// Test that checks template parameter suppport on member function of class template.
+template <int SIZE>
+class KernelFunctor {
+public:
+  [[intel::fpga_pipeline(SIZE)]] void operator()() {}
+};
+
+int main() {
+  KernelFunctor<1>();
+}
+
+// No diagnostic is thrown since arguments match. Silently ignore duplicate attribute.
+[[intel::fpga_pipeline]] void func3 ();
+[[intel::fpga_pipeline(1)]] void func3() {} // OK
+
+[[intel::fpga_pipeline(0)]] void func4(); // expected-note {{previous attribute is here}}
+[[intel::fpga_pipeline]] void func4();    // expected-warning{{attribute 'fpga_pipeline' is already applied with different arguments}}
+
+// No diagnostic is emitted because the arguments match.
+[[intel::fpga_pipeline(1)]] void func5();
+[[intel::fpga_pipeline(1)]] void func5() {} // OK
+
+// Diagnostic is emitted because the arguments mismatch.
+[[intel::fpga_pipeline(0)]] void func6(); // expected-note {{previous attribute is here}}
+[[intel::fpga_pipeline(1)]] void func6(); // expected-warning{{attribute 'fpga_pipeline' is already applied with different arguments}}
+
+// CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
+// CHECK: ClassTemplateSpecializationDecl {{.*}} {{.*}} class KernelFunctor definition
+// CHECK: CXXRecordDecl {{.*}} {{.*}} implicit class KernelFunctor
+// CHECK: SYCLIntelFpgaPipelineAttr {{.*}}
+// CHECK-NEXT: ConstantExpr {{.*}} 'int'
+// CHECK-NEXT: value: Int 1
+// CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}}
+// CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
+
+// Test that checks template parameter suppport on function.
+template <int N>
+[[intel::fpga_pipeline(N)]] void func6() {}
+
+template <int N>
+[[intel::fpga_pipeline(0)]] void func7();   // expected-note {{previous attribute is here}}
+template <int N>
+[[intel::fpga_pipeline(N)]] void func7() {} // expected-warning {{attribute 'fpga_pipeline' is already applied with different arguments}}
+
+int check() {
+  func6<1>();
+  func7<1>(); //expected-note {{in instantiation of function template specialization 'func7<1>' requested here}}
+  return 0;
+}
+
+// No diagnostic is emitted because the arguments match. Duplicate attribute is silently ignored.
+[[intel::fpga_pipeline(1)]]
+[[intel::fpga_pipeline(1)]] void func8() {}
+
+// CHECK: FunctionDecl {{.*}} {{.*}} func6 'void ()'
+// CHECK: TemplateArgument integral 1
+// CHECK: SYCLIntelFpgaPipelineAttr {{.*}}
+// CHECK-NEXT: ConstantExpr {{.*}} 'int'
+// CHECK-NEXT: value: Int 1
+// CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}}
+// CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
+// CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
+
+// CHECK: FunctionDecl {{.*}} {{.*}} func8 'void ()'
+// CHECK: SYCLIntelFpgaPipelineAttr {{.*}}
+// CHECK-NEXT: ConstantExpr {{.*}} 'int'
+// CHECK-NEXT: value: Int 1
+// CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}


### PR DESCRIPTION
This patch adds support for three new kernel attributes: 
1. [[intel::ip_interface_csr]]
2. [[intel::ip_interface_streaming]]
3. [[intel::ip_stall_free_return]].

**_Frontend Specifications:_**

if  the attributes are applied to a function called from a device kernel, the attributes are ignored and they do not get propagated to the kernel. The attributes can only be applied on the device, and not on the host.

**_The purpose of these attributes is as follows:_**

**ip_interface_csr:** the invocation interface of the IP component uses CSR (Control-Status Registers).
**ip_interface_streaming:** the invocation interface of the IP component supports streaming via a handshaking protocol.
**ip_stall_free_return:** applies to IP components with a streaming invocation interface. This is an optimization hint that the 
                                      return interface of the IP component will never be stalled from downstream.
 
_**LLVM IR is function metadata as follows:**_

If a kernel has ip_interface_csr, function metadata should be on the kernel function:
!ip_interface  !0
!0 = !{!”csr”}

If a kernel has ip_interface_streaming,  function metadata should be on the kernel function:
!ip_interface !0
!0 = !{!”streaming”}

If a kernel has ip_stall_free_return, function metadata should be on the kernel function:
!ip_interface !0
!0 = !{!”stall_free_return”}

If a kernel has both ip_interface_streaming and ip_stall_free_return, the function metadata should be on the kernel function:
!ip_interface !0
!0 = !{!”streaming”, !”stall_free_return”}

**_Error Messages:_**

An error should be output if the kernel attributes ip_interface_csr and ip_interface_streaming are both applied to the same kernel. The error message in this case should be:

              Error: at most one of ip_interface_csr and ip_interface_streaming can be applied to an IP component.

An error should be output if the kernel attributes ip_stall_free_return and ip_interface_csr are both applied to the same kernel,e.g.:

              Error: ip_stall_free_return cannot be applied to an IP component with a CSR interface. Please remove ip_stall_free_return or add ip_interface_streaming to your IP component.

An error should be output if the kernel attribute ip_stall_free_return is applied to a kernel, unless ip_interface_streaming is also applied, e.g.:

              Error: ip_stall_free_return requires ip_interface_streaming. Consider adding ip_interface_streaming to your IP component, or removing ip_stall_free_return.

**When a kernel has ip_stall_free_return only, The following part of the original spec can be ignored  (No IR in this case) because ip_stall_free_return requires ip_interface_streaming and error will be generated instead.** 

If a kernel has ip_stall_free_return,  function metadata should appear in the IR on the kernel function:
!ip_interface !0
!0 = !{!”stall_free_return”}

Signed-off-by: Soumi Manna <soumi.manna@intel.com>