### PR TITLE
[SYCL] Move use of __builtin_sycl_mark_kernel_name

### DIFF
--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -105,17 +105,7 @@ using make_index_sequence =
 
 template <typename T> struct KernelInfoImpl {
 private:
-  // This is necessary to ensure that any kernels we get info for are properly
-  // labeled as such before we call __builtin_sycl_unique_stable_name in a
-  // constant expression, otherwise subsequent calls to a sycl_kernel function
-  // could cause the kernel name to be altered, and change the result of the
-  // builtin.
-  // Additionally, we make this a dependency of 'n' so that we can guarantee
-  // that this is evaluated first. The builtin always returns 'true', so the
-  // 'else' branch of 'n's ternary is never evaluated.
-  static constexpr bool b = __builtin_sycl_mark_kernel_name(T);
-  static constexpr auto n = b ? __builtin_sycl_unique_stable_name(T)
-                              : __builtin_sycl_unique_stable_name(T);
+  static constexpr auto n = __builtin_sycl_unique_stable_name(T);
   template <unsigned long long... I>
   static KernelInfoData<n[I]...> impl(index_sequence<I...>) {
     return {};

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -2296,19 +2296,27 @@ private:
                                    range<Dims> NumWorkItems) {
     if constexpr (detail::isKernelLambdaCallableWithKernelHandler<
                       KernelType, TransformedArgType>()) {
-      return [=](TransformedArgType Arg, kernel_handler KH) {
+      auto Wrapper = [=](TransformedArgType Arg, kernel_handler KH) {
         if (Arg[0] >= NumWorkItems[0])
           return;
         Arg.set_allowed_range(NumWorkItems);
         KernelFunc(Arg, KH);
       };
+#ifdef __SYCL_UNNAMED_LAMBDA__
+      __builtin_sycl_mark_kernel_name(decltype(Wrapper));
+#endif
+      return Wrapper;
     } else {
-      return [=](TransformedArgType Arg) {
+      auto Wrapper = [=](TransformedArgType Arg) {
         if (Arg[0] >= NumWorkItems[0])
           return;
         Arg.set_allowed_range(NumWorkItems);
         KernelFunc(Arg);
       };
+#ifdef __SYCL_UNNAMED_LAMBDA__
+      __builtin_sycl_mark_kernel_name(decltype(Wrapper));
+#endif
+      return Wrapper;
     }
   }
 };

--- a/sycl/test/regression/unnamed-lambda.cpp
+++ b/sycl/test/regression/unnamed-lambda.cpp
@@ -1,4 +1,6 @@
-// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-device-only -c %s -o %t.temp
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -c %s -o %t.temp
+
+#include "CL/sycl.hpp"
 
 // This validates that the unnamed lambda logic in the library correctly works
 // with a new implementation of __builtin_unique_stable_name, where
@@ -6,11 +8,27 @@
 // the kernel itself, so this checks that example, which only happens when the
 // named kernel is inside another lambda.
 
-#include "CL/sycl.hpp"
-
 void foo(cl::sycl::queue queue) {
   cl::sycl::event queue_event2 = queue.submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for<class K1>(cl::sycl::range<1>{1},
                                            [=](cl::sycl::item<1> id) {});
+  });
+}
+
+// This validates the case when we use a functor instead of lambda, explicitly
+// set the kernel name and pass '-fsycl-unnamed-lambda' flag: we had a bug that
+// device compiler did not apply unique stable naming scheme for the kernel
+// name, because FE didn't mark 'class K2' as kernel name and instead marked
+// 'decltype(f)' as kernel name.
+
+class Functor {
+public:
+  void operator()(cl::sycl::item<2>) const {}
+};
+
+void bar(cl::sycl::queue queue) {
+  queue.submit([&](cl::sycl::handler &cgh) {
+    Functor f;
+    cgh.parallel_for<class K2>(cl::sycl::range<2>{1024,768}, f);
   });
 }


### PR DESCRIPTION
An attempt to fix a bug, which apparently introduced more problems than
it solved