### PR TITLE
[SYCL] Remove the __SYCL_NVPTX__ macro

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1180,8 +1180,6 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     Builder.defineMacro("SYCL_EXTERNAL", "__attribute__((sycl_device))");
 
     const llvm::Triple &DeviceTriple = TI.getTriple();
-    if (DeviceTriple.isNVPTX())
-      Builder.defineMacro("__SYCL_NVPTX__");
     const llvm::Triple::SubArchType DeviceSubArch = DeviceTriple.getSubArch();
     if (DeviceTriple.isSPIR() &&
         DeviceSubArch != llvm::Triple::SPIRSubArch_fpga)

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1181,7 +1181,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
 
     const llvm::Triple &DeviceTriple = TI.getTriple();
     if (DeviceTriple.isNVPTX())
-      Builder.defineMacro("__SYCL_NVPTX__", "1");
+      Builder.defineMacro("__SYCL_NVPTX__");
     const llvm::Triple::SubArchType DeviceSubArch = DeviceTriple.getSubArch();
     if (DeviceTriple.isSPIR() &&
         DeviceSubArch != llvm::Triple::SPIRSubArch_fpga)

--- a/clang/test/Preprocessor/sycl-macro-target-specific.cpp
+++ b/clang/test/Preprocessor/sycl-macro-target-specific.cpp
@@ -1,3 +1,16 @@
+// RUN: %clang_cc1 %s -fsycl-is-device -triple nvptx64-nvidia-nvcl-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-NVPTX %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-NVPTX-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_gen-unknown-unknown-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-NVPTX-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_x86_64-unknown-unknown-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-NVPTX-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_fpga-unknown-unknown-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-NVPTX-NEG %s
+// CHECK-NVPTX: #define __SYCL_NVPTX__
+// CHECK-NVPTX-NEG-NOT: #define __SYCL_NVPTX__
+
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -E -dM \
 // RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_gen-unknown-unknown-sycldevice -E -dM \
@@ -8,6 +21,5 @@
 // RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS-NEG %s
 // RUN: %clang_cc1 %s -fsycl-is-device -triple nvptx64-nvidia-nvcl-sycldevice -E -dM \
 // RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS-NEG %s
-
 // CHECK-SYCL-FP-ATOMICS: #define SYCL_USE_NATIVE_FP_ATOMICS
 // CHECK-SYCL-FP-ATOMICS-NEG-NOT: #define SYCL_USE_NATIVE_FP_ATOMICS

--- a/clang/test/Preprocessor/sycl-macro-target-specific.cpp
+++ b/clang/test/Preprocessor/sycl-macro-target-specific.cpp
@@ -8,8 +8,8 @@
 // RUN: | FileCheck --check-prefix=CHECK-NVPTX-NEG %s
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_fpga-unknown-unknown-sycldevice -E -dM \
 // RUN: | FileCheck --check-prefix=CHECK-NVPTX-NEG %s
-// CHECK-NVPTX: #define __SYCL_NVPTX__
-// CHECK-NVPTX-NEG-NOT: #define __SYCL_NVPTX__
+// CHECK-NVPTX: #define __NVPTX__
+// CHECK-NVPTX-NEG-NOT: #define __NVPTX__
 
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -E -dM \
 // RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s

--- a/sycl/doc/CompilerAndRuntimeDesign.md
+++ b/sycl/doc/CompilerAndRuntimeDesign.md
@@ -549,9 +549,9 @@ is then passed to the offload wrapper tool.
 ##### Checking if the compiler is targeting NVPTX
 
 When the SYCL compiler is in device mode and targeting the NVPTX backend,
-compiler defines the macro `__SYCL_NVPTX__`.
-This macro can safely be used to enable NVPTX specific code path in SYCL
-kernels.
+compiler defines the macro `__NVPTX__` alongside the
+`__SYCL_DEVICE_ONLY` macro. This macro combination can safely be used
+to enable NVPTX specific code path in SYCL kernels.
 
 *Note: this macro is defined only during the device compilation phase.*
 
@@ -567,7 +567,7 @@ Example:
 
 ```cpp
 double my_min(double x, double y) {
-#ifdef __SYCL_NVPTX__
+#if defined(__NVPTX__) && defined(__SYCL_DEVICE_ONLY__)
   // Only available if in device mode and
   // while compiling for the NVPTX target.
   return __nvvm_fmin_d(x, y);

--- a/sycl/doc/CompilerAndRuntimeDesign.md
+++ b/sycl/doc/CompilerAndRuntimeDesign.md
@@ -549,11 +549,11 @@ is then passed to the offload wrapper tool.
 ##### Checking if the compiler is targeting NVPTX
 
 When the SYCL compiler is in device mode and targeting the NVPTX backend,
-compiler defines the macro `__NVPTX__` alongside the
-`__SYCL_DEVICE_ONLY` macro. This macro combination can safely be used
-to enable NVPTX specific code path in SYCL kernels.
+the compiler defines `__SYCL_DEVICE_ONLY__` and `__NVPTX__` macros. This
+macro combination can safely be used to enable NVPTX specific code
+path in SYCL kernels.
 
-*Note: this macro is defined only during the device compilation phase.*
+*Note: these macros are defined only during the device compilation phase.*
 
 ##### NVPTX Builtins
 

--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -15,7 +15,7 @@
 
 #define __SPIRV_VAR_QUALIFIERS extern "C" const
 
-#if defined(__NVPTX__) && defined(__SYCL_DEVICE_ONLY__)
+#ifdef __NVPTX__
 
 SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_x();
 SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_y();
@@ -51,7 +51,7 @@ SYCL_EXTERNAL uint32_t __spirv_NumSubgroups();
 SYCL_EXTERNAL uint32_t __spirv_SubgroupId();
 SYCL_EXTERNAL uint32_t __spirv_SubgroupLocalInvocationId();
 
-#else // __NVPTX__ && __SYCL_DEVICE_ONLY__
+#else // __NVPTX__
 
 typedef size_t size_t_vec __attribute__((ext_vector_type(3)));
 __SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInGlobalSize;
@@ -154,7 +154,7 @@ SYCL_EXTERNAL inline uint32_t __spirv_SubgroupLocalInvocationId() {
   return __spirv_BuiltInSubgroupLocalInvocationId;
 }
 
-#endif // __NVPTX__ && __SYCL_DEVICE_ONLY__
+#endif // __NVPTX__
 
 #undef __SPIRV_VAR_QUALIFIERS
 

--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -15,7 +15,7 @@
 
 #define __SPIRV_VAR_QUALIFIERS extern "C" const
 
-#if defined(__SYCL_NVPTX__)
+#if defined(__NVPTX__) && defined(__SYCL_DEVICE_ONLY__)
 
 SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_x();
 SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_y();
@@ -51,7 +51,7 @@ SYCL_EXTERNAL uint32_t __spirv_NumSubgroups();
 SYCL_EXTERNAL uint32_t __spirv_SubgroupId();
 SYCL_EXTERNAL uint32_t __spirv_SubgroupLocalInvocationId();
 
-#else // __SYCL_NVPTX__
+#else // __NVPTX__ && __SYCL_DEVICE_ONLY__
 
 typedef size_t size_t_vec __attribute__((ext_vector_type(3)));
 __SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInGlobalSize;
@@ -154,7 +154,7 @@ SYCL_EXTERNAL inline uint32_t __spirv_SubgroupLocalInvocationId() {
   return __spirv_BuiltInSubgroupLocalInvocationId;
 }
 
-#endif // __SYCL_NVPTX__
+#endif // __NVPTX__ && __SYCL_DEVICE_ONLY__
 
 #undef __SPIRV_VAR_QUALIFIERS
 


### PR DESCRIPTION
Since the macro is identical to a combination of
`__SYCL_DEVICE_ONLY__` and `__NVPTX__`, showing up in the same
circumstances (SYCL device compilation with an NVPTX triple), drop
`__SYCL_NVPTX__` as unnecessary and solely rely on the combination of
pre-existing macros.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>