### PR TITLE
[SYCL][NFC] Fix warnings coming out of SYCL headers.

### DIFF
--- a/sycl/include/CL/sycl/sycl_span.hpp
+++ b/sycl/include/CL/sycl/sycl_span.hpp
@@ -146,7 +146,7 @@ using byte = unsigned char;
 #if defined(__SYCL_DEVICE_ONLY__)
 #define _SYCL_SPAN_ASSERT(x, m) ((void)0)
 #else
-#define _SYCL_SPAN_ASSERT(x, m) assert((x && m))
+#define _SYCL_SPAN_ASSERT(x, m) assert(((x) && m))
 #endif
 
 inline constexpr size_t dynamic_extent = SIZE_MAX;

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -454,8 +454,8 @@ __SYCL_GENERATE_CONVERT_IMPL_FOR_ROUNDING_MODE(rtn, Rtn)
             typename OpenCLT, typename OpenCLR>                                \
   detail::enable_if_t<is_float_to_int<T, R>::value &&                          \
                           (std::is_same<OpenCLR, cl_##DestType>::value ||      \
-                           std::is_same<OpenCLR, signed char>::value &&        \
-                               std::is_same<DestType, char>::value) &&         \
+                           (std::is_same<OpenCLR, signed char>::value &&       \
+                            std::is_same<DestType, char>::value)) &&           \
                           RoundingModeCondition<roundingMode>::value,          \
                       R>                                                       \
   convertImpl(T Value) {                                                       \

--- a/sycl/test/warnings/warnings.cpp
+++ b/sycl/test/warnings/warnings.cpp
@@ -1,5 +1,6 @@
 // RUN: %clangxx -fsycl --no-system-header-prefix=CL/sycl -fsyntax-only -Wall -Wextra -Wno-ignored-attributes -Wno-deprecated-declarations -Wpessimizing-move -Wunused-variable -Wmismatched-tags -Wunneeded-internal-declaration -Werror -Wno-unknown-cuda-version -Wno-unused-parameter %s -o %t.out
-
+// RUN: %clangxx -fsycl -E --no-system-header-prefix=CL/sycl %s -o %t.ii
+// RUN: %clangxx -fsycl -fsyntax-only -Wall -Wextra -Wno-ignored-attributes -Wno-deprecated-declarations -Wpessimizing-move -Wunused-variable -Wmismatched-tags -Wunneeded-internal-declaration -Werror -Wno-unknown-cuda-version -Wno-unused-parameter %t.ii -o %t.out
 #include <CL/sycl.hpp>
 
 using namespace cl::sycl;
@@ -7,11 +8,35 @@ int main() {
   vec<long, 4> newVec;
   queue myQueue;
   buffer<vec<long, 4>, 1> resultBuf{&newVec, range<1>{1}};
-  myQueue.submit([&](handler &cgh) {
+  auto event = myQueue.submit([&](handler &cgh) {
     auto writeResult = resultBuf.get_access<access::mode::write>(cgh);
     cgh.single_task<class kernel_name>([=]() {
       writeResult[0] = (vec<int, 4>{1, 2, 3, 4}).template convert<long>();
     });
   });
+  (void)event;
   return 0;
+}
+
+// explicitly instantiate a few more classes to check if there are some issues
+// with them:
+
+namespace sycl {
+
+template class buffer<vec<int, 3>, 2>;
+
+template class accessor<int, 1>;
+template class accessor<vec<float, 2>, 2, access_mode::read>;
+
+template class marray<double, 7>;
+template class marray<short, 3>;
+
+template class kernel_bundle<bundle_state::input>;
+template class kernel_bundle<bundle_state::objectj>;
+template class kernel_bundle<bundle_state::executable>;
+
+template class device_image<bundle_state::input>;
+template class device_image<bundle_state::objectj>;
+template class device_image<bundle_state::executable>;
+
 }

--- a/sycl/test/warnings/warnings.cpp
+++ b/sycl/test/warnings/warnings.cpp
@@ -1,6 +1,6 @@
-// RUN: %clangxx -fsycl --no-system-header-prefix=CL/sycl -fsyntax-only -Wall -Wextra -Wno-ignored-attributes -Wno-deprecated-declarations -Wpessimizing-move -Wunused-variable -Wmismatched-tags -Wunneeded-internal-declaration -Werror -Wno-unknown-cuda-version -Wno-unused-parameter %s -o %t.out
+// RUN: %clangxx -fsycl --no-system-header-prefix=CL/sycl -fsyntax-only -Wall -Wextra -Werror -Wno-ignored-attributes -Wno-deprecated-declarations -Wpessimizing-move -Wunused-variable -Wmismatched-tags -Wunneeded-internal-declaration -Wno-unknown-cuda-version -Wno-unused-parameter %s
 // RUN: %clangxx -fsycl -E --no-system-header-prefix=CL/sycl %s -o %t.ii
-// RUN: %clangxx -fsycl -fsyntax-only -Wall -Wextra -Wno-ignored-attributes -Wno-deprecated-declarations -Wpessimizing-move -Wunused-variable -Wmismatched-tags -Wunneeded-internal-declaration -Werror -Wno-unknown-cuda-version -Wno-unused-parameter %t.ii -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only -Wall -Wextra -Werror -Wno-ignored-attributes -Wno-deprecated-declarations -Wpessimizing-move -Wunused-variable -Wmismatched-tags -Wunneeded-internal-declaration -Wno-unknown-cuda-version -Wno-unused-parameter %t.ii
 #include <CL/sycl.hpp>
 
 using namespace cl::sycl;

--- a/sycl/test/warnings/warnings.cpp
+++ b/sycl/test/warnings/warnings.cpp
@@ -32,11 +32,11 @@ template class marray<double, 7>;
 template class marray<short, 3>;
 
 template class kernel_bundle<bundle_state::input>;
-template class kernel_bundle<bundle_state::objectj>;
+template class kernel_bundle<bundle_state::object>;
 template class kernel_bundle<bundle_state::executable>;
 
 template class device_image<bundle_state::input>;
-template class device_image<bundle_state::objectj>;
+template class device_image<bundle_state::object>;
 template class device_image<bundle_state::executable>;
 
 }


### PR DESCRIPTION
The problem was discovered in intel/llvm#3777. Fixed by wrapping `x`
`_SYCL_SPAN_ASSERT` argument into parentheses.

Example of the warning/error:
```
sycl/CL/sycl/sycl_span.hpp:515:82: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
    (static_cast <bool> ((_Count == dynamic_extent || _Count <= size() - _Offset && "Offset + count out of range in span::subspan()"))·
? void (0) : __assert_fail ("(_Count == dynamic_extent || _Count <= size() - _Offset && \"Offset + count out of range in span::subspan(
)\")", "/sycl/CL/sycl/sycl_span.hpp", 516, __extension__ __PRETTY_FUNCTION__));

sycl/CL/sycl/sycl_span.hpp:515:82: note: place parentheses around the '&&' expression· to silence this warning
```