### PR TITLE
[SYCL][NFC] Use default macro initialization where applicable

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -488,7 +488,7 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
       Builder.defineMacro("SYCL_LANGUAGE_VERSION", "202001");
 
     if (LangOpts.SYCLValueFitInMaxInt)
-      Builder.defineMacro("__SYCL_ID_QUERIES_FIT_IN_INT__", "1");
+      Builder.defineMacro("__SYCL_ID_QUERIES_FIT_IN_INT__");
 
     // Set __SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ macro for
     // both host and device compilations if -fsycl-disable-range-rounding
@@ -1176,7 +1176,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
   // Define a macro indicating that the source file is being compiled with a
   // SYCL device compiler which doesn't produce host binary.
   if (LangOpts.SYCLIsDevice) {
-    Builder.defineMacro("__SYCL_DEVICE_ONLY__", "1");
+    Builder.defineMacro("__SYCL_DEVICE_ONLY__");
     Builder.defineMacro("SYCL_EXTERNAL", "__attribute__((sycl_device))");
 
     const llvm::Triple &DeviceTriple = TI.getTriple();
@@ -1188,7 +1188,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
       Builder.defineMacro("SYCL_USE_NATIVE_FP_ATOMICS");
   }
   if (LangOpts.SYCLUnnamedLambda)
-    Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__", "1");
+    Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__");
 
   // OpenCL definitions.
   if (LangOpts.OpenCL) {


### PR DESCRIPTION
Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>