### PR TITLE
[SYCL][NFC]Lowers overhead of making plugin calls

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -163,7 +163,7 @@ template <PiApiKind PiApiOffset> struct PiFuncInfo {};
 #define _PI_API(api)                                                           \
   template <> struct PiFuncInfo<PiApiKind::api> {                              \
     using FuncPtrT = decltype(&::api);                                         \
-    inline std::string getFuncName() { return #api; }                          \
+    inline const char *getFuncName() { return #api; }                          \
     inline FuncPtrT getFuncPtr(PiPlugin MPlugin) {                             \
       return MPlugin.PiFunctionTable.api;                                      \
     }                                                                          \

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -73,13 +73,13 @@ public:
     // Emit a function_begin trace for the PI API before the call is executed.
     // If arguments need to be captured, then a data structure can be sent in
     // the per_instance_user_data field.
-    std::string PIFnName = PiCallInfo.getFuncName();
-    uint64_t CorrelationID = pi::emitFunctionBeginTrace(PIFnName.c_str());
+    const char *PIFnName = PiCallInfo.getFuncName();
+    uint64_t CorrelationID = pi::emitFunctionBeginTrace(PIFnName);
 #endif
     RT::PiResult R;
     if (pi::trace(pi::TraceLevel::PI_TRACE_CALLS)) {
       std::lock_guard<std::mutex> Guard(*TracingMutex);
-      std::string FnName = PiCallInfo.getFuncName();
+      const char *FnName = PiCallInfo.getFuncName();
       std::cout << "---> " << FnName << "(" << std::endl;
       RT::printArgs(Args...);
       R = PiCallInfo.getFuncPtr(MPlugin)(Args...);
@@ -92,7 +92,7 @@ public:
     }
 #ifdef XPTI_ENABLE_INSTRUMENTATION
     // Close the function begin with a call to function end
-    pi::emitFunctionEndTrace(CorrelationID, PIFnName.c_str());
+    pi::emitFunctionEndTrace(CorrelationID, PIFnName);
 #endif
     return R;
   }


### PR DESCRIPTION
This change lowers the overhead of plugin calls by using const
char * strings, rather than std::string.  This completely eliminates
the calls to new and delete to allocate the strings, and also
gets rid of the std:string construction/destruction.  This also
reduces the code size of the library by about 0.5 percent.

This change should be NFC in terms of user visible changes to
SYCL behavior.