### PR TITLE
Kernel name remark

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6440,6 +6440,12 @@ def err_unique_stable_id_global_storage
     : Error<"argument passed to '__builtin_sycl_unique_stable_id' must have "
             "global storage">;
 
+def remark_unique_stable_name_evaluated
+    : Remark<"'__builtin_sycl_unique_stable_%select{name|id}0' being evaluated "
+             "here">,
+      ShowInSystemHeader,
+      InGroup<DiagGroup<"unique-stable-remark">>;
+
 def warn_floatingpoint_eq : Warning<
   "comparing floating point with == or != is unsafe">,
   InGroup<DiagGroup<"float-equal">>, DefaultIgnore;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3568,6 +3568,9 @@ ExprResult Sema::BuildSYCLUniqueStableNameExpr(SourceLocation OpLoc,
                                                SourceLocation LParen,
                                                SourceLocation RParen,
                                                TypeSourceInfo *TSI) {
+  if (!TSI->getType()->isInstantiationDependentType())
+    Diag(OpLoc, diag::remark_unique_stable_name_evaluated) << 0;
+
   return SYCLUniqueStableNameExpr::Create(Context, OpLoc, LParen, RParen, TSI);
 }
 
@@ -3612,6 +3615,8 @@ ExprResult Sema::BuildSYCLUniqueStableIdExpr(SourceLocation OpLoc,
       Diag(E->getExprLoc(), diag::err_unique_stable_id_global_storage);
       return ExprError();
     }
+
+    Diag(OpLoc, diag::remark_unique_stable_name_evaluated) << 0;
   }
 
   return SYCLUniqueStableIdExpr::Create(Context, OpLoc, LParen, RParen, E);


### PR DESCRIPTION
Note the -R flag required.  This is about the best I can do. @AlexeySachkov 

 ./bin/clang -cc1 temp.cpp -fsycl-is-device -Runique-stable-remark
[129/129] Creating executable symlink bin/clang
temp.cpp:6:29: remark: '__builtin_sycl_unique_stable_name' being evaluated here [-Runique-stable-remark]
  constexpr static auto X = __builtin_sycl_unique_stable_name(T);
                            ^
temp.cpp:12:8: note: in instantiation of template class 'S<int>' requested here
  puts(S<T>::X);
       ^
temp.cpp:18:3: note: in instantiation of function template specialization 'do_thing<int>' requested here
  do_thing<int>();
  ^
temp.cpp:7:30: remark: '__builtin_sycl_unique_stable_name' being evaluated here [-Runique-stable-remark]
  constexpr static auto ID = __builtin_sycl_unique_stable_id(X);
                             ^
bash-4.2$ cat temp.cpp
int puts(const char *);


template<typename T>
struct S {
  constexpr static auto X = __builtin_sycl_unique_stable_name(T);
  constexpr static auto ID = __builtin_sycl_unique_stable_id(X);
};

template<typename T>
auto do_thing() {
  puts(S<T>::X);
  puts(S<T>::ID);
  return 0;
}

int foo() {
  do_thing<int>();
  //puts(S<int>::ID);
  //puts(S<int>::ID);
  return 0;
}
