### PR TITLE
[Driver][SYCL] Allow for known aliases to be used for -fsycl-targets

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1846,8 +1846,8 @@ void Driver::PrintHelp(bool ShowHidden) const {
 }
 
 llvm::Triple Driver::MakeSYCLDeviceTriple(StringRef TargetArch) const {
-  SmallVector<StringRef, 5> SYCLAlias = {"spir", "spir64", "spir64_fpga",
-                                         "spir64_x86_64", "spir64_gen"};
+  ArrayRef<StringRef> SYCLAlias = {"spir", "spir64", "spir64_fpga",
+                                   "spir64_x86_64", "spir64_gen"};
   if (std::find(SYCLAlias.begin(), SYCLAlias.end(), TargetArch) !=
       SYCLAlias.end()) {
     llvm::Triple TT;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -706,18 +706,6 @@ static bool isValidSYCLTriple(llvm::Triple T) {
   return true;
 }
 
-// Create a triple based off of the input provided.  Allow for short aliases
-// of known arch strings, which will be expanded to the full triple for usage
-// during the compilation.
-static llvm::Triple resolveSYCLTriple(Compilation &C, StringRef TripleStr) {
-  SmallVector<StringRef, 4> SYCLAlias = {"spir64", "spir64_fpga",
-                                         "spir64_x86_64", "spir64_gen"};
-  if (std::find(SYCLAlias.begin(), SYCLAlias.end(), TripleStr) !=
-      SYCLAlias.end())
-    return C.getDriver().MakeSYCLDeviceTriple(TripleStr);
-  return llvm::Triple(TripleStr);
-}
-
 void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
                                               InputList &Inputs) {
 
@@ -909,7 +897,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
     if (SYCLTargetsValues) {
       if (SYCLTargetsValues->getNumValues()) {
         for (StringRef Val : SYCLTargetsValues->getValues()) {
-          llvm::Triple TT(resolveSYCLTriple(C, Val));
+          llvm::Triple TT(MakeSYCLDeviceTriple(Val));
           if (!isValidSYCLTriple(TT)) {
             Diag(clang::diag::err_drv_invalid_sycl_target) << Val;
             continue;
@@ -1858,12 +1846,18 @@ void Driver::PrintHelp(bool ShowHidden) const {
 }
 
 llvm::Triple Driver::MakeSYCLDeviceTriple(StringRef TargetArch) const {
-  llvm::Triple TT;
-  TT.setArchName(TargetArch);
-  TT.setVendor(llvm::Triple::UnknownVendor);
-  TT.setOS(llvm::Triple::UnknownOS);
-  TT.setEnvironment(llvm::Triple::SYCLDevice);
-  return TT;
+  SmallVector<StringRef, 5> SYCLAlias = {"spir", "spir64", "spir64_fpga",
+                                         "spir64_x86_64", "spir64_gen"};
+  if (std::find(SYCLAlias.begin(), SYCLAlias.end(), TargetArch) !=
+      SYCLAlias.end()) {
+    llvm::Triple TT;
+    TT.setArchName(TargetArch);
+    TT.setVendor(llvm::Triple::UnknownVendor);
+    TT.setOS(llvm::Triple::UnknownOS);
+    TT.setEnvironment(llvm::Triple::SYCLDevice);
+    return TT;
+  }
+  return llvm::Triple(TargetArch);
 }
 
 // Print the help from any of the given tools which are used for AOT
@@ -4577,7 +4571,7 @@ class OffloadingActionBuilder final {
         if (SYCLTargets) {
           llvm::StringMap<StringRef> FoundNormalizedTriples;
           for (const char *Val : SYCLTargets->getValues()) {
-            llvm::Triple TT(resolveSYCLTriple(C, Val));
+            llvm::Triple TT(C.getDriver().MakeSYCLDeviceTriple(Val));
             std::string NormalizedName = TT.normalize();
 
             // Make sure we don't have a duplicate triple.

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -712,8 +712,8 @@ static bool isValidSYCLTriple(llvm::Triple T) {
 static llvm::Triple resolveSYCLTriple(Compilation &C, StringRef TripleStr) {
   SmallVector<StringRef, 4> SYCLAlias = {"spir64", "spir64_fpga",
                                          "spir64_x86_64", "spir64_gen"};
-  if (std::find(SYCLAlias.begin(), SYCLAlias.end(), TripleStr)
-          != SYCLAlias.end())
+  if (std::find(SYCLAlias.begin(), SYCLAlias.end(), TripleStr) !=
+      SYCLAlias.end())
     return C.getDriver().MakeSYCLDeviceTriple(TripleStr);
   return llvm::Triple(TripleStr);
 }

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -671,7 +671,7 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::opt::ArgList &Args,
     OptNoTriple = A->getOption().matches(Opt);
     if (A->getOption().matches(Opt_EQ)) {
       // Passing device args: -X<Opt>=<triple> -opt=val.
-      if (A->getValue() != getTripleString())
+      if (getDriver().MakeSYCLDeviceTriple(A->getValue()) != getTriple())
         // Provided triple does not match current tool chain.
         continue;
     } else if (!OptNoTriple)

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -820,6 +820,9 @@
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice,spir64_gen-unknown-unknown-sycldevice \
 // RUN:   -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device skl -cl-opt-disable" -Xsycl-target-linker=spir64-unknown-unknown-sycldevice "-cl-denorms-are-zero" %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-TOOLS-MULT-OPTS,CHK-TOOLS-MULT-OPTS-NEG %s
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64,spir64_gen \
+// RUN:   -Xsycl-target-backend=spir64_gen "-device skl -cl-opt-disable" -Xsycl-target-linker=spir64 "-cl-denorms-are-zero" %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=CHK-TOOLS-MULT-OPTS,CHK-TOOLS-MULT-OPTS-NEG %s
 // CHK-TOOLS-MULT-OPTS: clang-offload-wrapper{{.*}} "-link-opts=-cl-denorms-are-zero"{{.*}} "-target=spir64"
 // CHK-TOOLS-MULT-OPTS: ocloc{{.*}} "-device" "skl"{{.*}} "-cl-opt-disable"
 // CHK-TOOLS-MULT-OPTS-NEG-NOT: clang-offload-wrapper{{.*}} "-compile-opts=-device skl -cl-opt-disable"{{.*}} "-target=spir64"

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -96,16 +96,24 @@
 
 /// Check no error for -fsycl-targets with good triple
 // RUN:   %clang -### -fsycl-targets=spir-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
+// RUN:   %clang -### -fsycl-targets=spir64 -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
 // RUN:   %clang -### -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
+// RUN:   %clang -### -fsycl-targets=spir64_fpga -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
 // RUN:   %clang -### -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
+// RUN:   %clang -### -fsycl-targets=spir64_x86_64 -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
 // RUN:   %clang -### -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
+// RUN:   %clang -### -fsycl-targets=spir64_gen -fsycl  %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
 // RUN:   %clang_cl -### -fsycl-targets=spir-unknown-unknown-sycldevice -fsycl  %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-TRIPLE %s
-// CHK-SYCL-FPGA-TRIPLE-NOT: error: SYCL target is invalid
+// RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
+// CHK-SYCL-TARGET-NOT: error: SYCL target is invalid
 
 /// Check error for -fsycl-[add|link]-targets with bad triple
 // RUN:   %clang -### -fsycl-add-targets=spir64_bad-unknown-unknown-sycldevice:dummy.spv -fsycl  %s 2>&1 \
@@ -301,6 +309,8 @@
 /// Check separate compilation with offloading - unbundling actions
 // RUN:   touch %t.o
 // RUN:   %clang -### -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -o %t.out -lsomelib -fsycl-targets=spir64-unknown-unknown-sycldevice %t.o 2>&1 \
+// RUN:   | FileCheck -DINPUT=%t.o -check-prefix=CHK-UBACTIONS %s
+// RUN:   %clang -### -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -o %t.out -lsomelib -fsycl-targets=spir64 %t.o 2>&1 \
 // RUN:   | FileCheck -DINPUT=%t.o -check-prefix=CHK-UBACTIONS %s
 // RUN:   mkdir -p %t_dir
 // RUN:   touch %t_dir/dummy
@@ -625,9 +635,15 @@
 /// Ahead of Time compilation for fpga, gen, cpu
 // RUN:   %clang -target x86_64-unknown-linux-gnu -ccc-print-phases -fsycl-use-footer -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefixes=CHK-PHASES-AOT,CHK-PHASES-FPGA
+// RUN:   %clang -target x86_64-unknown-linux-gnu -ccc-print-phases -fsycl-use-footer -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64_fpga %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-PHASES-AOT,CHK-PHASES-FPGA
 // RUN:   %clang -target x86_64-unknown-linux-gnu -ccc-print-phases -fsycl-use-footer -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64_gen-unknown-unknown-sycldevice %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefixes=CHK-PHASES-AOT,CHK-PHASES-GEN
+// RUN:   %clang -target x86_64-unknown-linux-gnu -ccc-print-phases -fsycl-use-footer -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64_gen %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-PHASES-AOT,CHK-PHASES-GEN
 // RUN:   %clang -target x86_64-unknown-linux-gnu -ccc-print-phases -fsycl-use-footer -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %s 2>&1 \
+// RUN:    | FileCheck %s -check-prefixes=CHK-PHASES-AOT,CHK-PHASES-CPU
+// RUN:   %clang -target x86_64-unknown-linux-gnu -ccc-print-phases -fsycl-use-footer -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64_x86_64 %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefixes=CHK-PHASES-AOT,CHK-PHASES-CPU
 // CHK-PHASES-AOT: 0: input, "[[INPUT:.+\.c]]", c++, (host-sycl)
 // CHK-PHASES-AOT: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -490,11 +490,13 @@ clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice \
 ```
 
 To build simple-sycl-app ahead of time for GPU, CPU or Accelerator devices,
-specify the target architecture:
+specify the target architecture.  The examples provided use a supported
+alias for the target, representing a full triple.  Additional details can
+be found in the [Users Manual](UsersManual.md#generic-options).
 
-```-fsycl-targets=spir64_gen-unknown-unknown-sycldevice``` for GPU,  
-```-fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice``` for CPU,  
-```-fsycl-targets=spir64_fpga-unknown-unknown-sycldevice``` for Accelerator.
+```-fsycl-targets=spir64_gen``` for GPU,
+```-fsycl-targets=spir64_x86_64``` for CPU,
+```-fsycl-targets=spir64_fpga``` for Accelerator.
 
 Multiple target architectures are supported.
 
@@ -502,7 +504,7 @@ E.g., this command builds simple-sycl-app for GPU and CPU devices in
 ahead of time mode:
 
 ```bash
-clang++ -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice,spir64_x86_64-unknown-unknown-sycldevice simple-sycl-app.cpp -o simple-sycl-app-aot.exe
+clang++ -fsycl -fsycl-targets=spir64_gen,spir64_x86_64 simple-sycl-app.cpp -o simple-sycl-app-aot.exe
 ```
 
 Additionally, user can pass specific options of AOT compiler to

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -31,6 +31,8 @@ and not recommended to use in production environment.
       Intel FPGA;
     * spir64_gen-unknown-unknown-sycldevice - generate code ahead of time for
       Intel Processor Graphics;
+    Shorter aliases of the above triples can also be used:
+    * spir64, spir64_x86_64, spir64_fpga, spir64_gen
     Available in special build configuration:
     * nvptx64-nvidia-cuda-sycldevice - generate code ahead of time for CUDA
       target;


### PR DESCRIPTION
When using -fsycl-targets, usage is clumsy as we want the full triple to
be used:  spir64-unknown-unknown-sycldevice
Allow for just the 'arch' to be specified, which will be expanded:
spir64        -> spir64-unknown-unknown-sycldevice
spir64_gen    -> spir64_gen-unknown-unknown-sycldevice
spir64_fpga   -> spir64_fpga-unknown-unknown-sycldevice
spir64_x86_64 -> spir64_x86_64-unknown-unknown-sycldevice