### PR TITLE
[DOC] Group sort. Passing temporary local memory to an algorithm

### DIFF
--- a/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_sort.asciidoc
+++ b/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_sort.asciidoc
@@ -47,6 +47,7 @@ Applications can test for the existence of this macro to determine if the
 implementation supports this feature, or applications can test the macro's
 value to determine which of the extension's APIs the implementation supports.
 
+Table 1. Values of the `SYCL_EXT_ONEAPI_GROUP_SORT` macro.
 [%header,cols="1,5"]
 |===
 |Value |Description
@@ -71,7 +72,7 @@ T operator()(Group g, T val);
 
 At least one overload for `operator()` is required.
 
-Table. `operator()` for Sorters.
+Table 2. `operator()` for Sorters.
 |===
 |`operator()`|Description
 
@@ -134,32 +135,41 @@ namespace sycl::ext::oneapi {
   template<typename Compare = std::less<>>
   class default_sorter {
   public:
-    default_sorter(Compare comp = Compare());
+    template<std::size_t Extent>
+    default_sorter(sycl::span<uint8_t, Extent> scratch, Compare comp = Compare());
 
     template<typename Group, typename Ptr>
     void operator()(Group g, Ptr first, Ptr last);
 
     template<typename Group, typename T>
     T operator()(Group g, T val);
+
+    template<typename... Args>
+    static std::size_t temp_memory_size(/*unspecified*/);
   };
 
   template<typename T, radix_order Order = radix_order::ascending, unsigned int BitsPerPass = 4>
   class radix_sorter {
   public:
-    radix_sorter(const std::bitset<sizeof(T) * CHAR_BIT> mask =
-                 std::bitset<sizeof(T) * CHAR_BIT> (std::numeric_limits<unsigned long long>::max()));
+    template<std::size_t Extent>
+    radix_sorter(sycl::span<uint8_t, Extent> scratch,
+                 const std::bitset<sizeof(T) * CHAR_BIT> mask =
+                     std::bitset<sizeof(T) * CHAR_BIT> (std::numeric_limits<unsigned long long>::max()));
 
     template<typename Group, typename Ptr>
     void operator()(Group g, Ptr first, Ptr last);
 
     template<typename Group>
     T operator()(Group g, T val);
+
+    static std::size_t joint_sort_temp_memory_size(std::size_t range_size);
+    static std::size_t sort_over_group_temp_memory_size(std::size_t range_size);
   };
 
 }
 ----
 
-Table. Description of predefined Sorters.
+Table 3. Description of predefined Sorters.
 |===
 |Sorter|Description
 
@@ -167,6 +177,8 @@ Table. Description of predefined Sorters.
 default_sorter`
 |Use a default sorting method based on an implementation-defined heuristic
 using `Compare` as the binary comparison function object.
+The algorithm requires a temporary local memory that must be allocated by users.
+Size of required memory (bytes) is defined by calling the `temp_memory_size` method.
 
 |`template<typename T, radix_order Order = radix_order::ascending, unsigned int BitsPerPass = 4>
 radix_sorter`
@@ -175,17 +187,23 @@ Only arithmetic types as `T` can be passed to `radix_sorter`.
 `BitsPerPass` is a number of bits that values are split by.
 For example, if a sequence of `int32_t` is sorted using `BitsPerPass == 4` then one
 pass of the radix sort algorithm considers only 4 bits. The number of passes is `32/4=8`.
+The algorithm requires a temporary local memory that must be allocated by users.
+Size of required memory (bytes) is defined by calling the `temp_memory_size` method.
 |===
 
-Table. Constructors of the `default_sorter` class.
+Table 4. Constructors of the `default_sorter` class.
 |===
 |Constructor|Description
 
-|`default_sorter(Compare comp = Compare())`
+|`template<std::size_t Extent> default_sorter(sycl::span<uint8_t, Extent> scratch, Compare comp = Compare())`
 |Creates the `default_sorter` object using `comp`.
+Temporary local memory for the algorithm is provided using `scratch`.
+If `scratch.size()` is less than value returned by `temp_memory_size`,
+behavior of the sorting algorithm is undefined.
+
 |===
 
-Table. Member functions of the `default_sorter` class.
+Table 5. Member functions of the `default_sorter` class.
 |===
 |Member function|Description
 
@@ -193,26 +211,34 @@ Table. Member functions of the `default_sorter` class.
 void operator()(Group g, Ptr first, Ptr last)`
 |Implements a default sorting algorithm to be called by the `joint_sort` algorithm.
 
-_Complexity_: Let `N` be `last - first`. `O(N*log_2(N))` comparisons.
+_Complexity_: Let `N` be `last - first`. `O(N*log(N)*log(N))` comparisons.
 
 |`template<typename Group, typename T>
 T operator()(Group g, T val)`
 |Implements a default sorting algorithm to be called by the `sort_over_group` algorithm.
 
-_Complexity_: Let `N` be the work group size. `O(N*log_2(N))` comparisons.
+
+_Complexity_: Let `N` be the work group size. `O(N*log(N)*log(N))` comparisons.
+|`template<typename... Args>
+static std::size_t temp_memory_size(/\*unspecified*/);`
+|Returns temporary memory size (in bytes) that is required by the sorting algorithm defined by the sorter.
 |===
 
-Table. Constructors of the `radix_sorter` class.
+Table 6. Constructors of the `radix_sorter` class.
 |===
 |Constructor|Description
 
-|`radix_sorter(const std::bitset<sizeof(T) * CHAR_BIT> mask = std::bitset<sizeof(T) * CHAR_BIT>
+|`template<std::size_t Extent>
+radix_sorter(sycl::span<uint8_t, Extent> scratch, const std::bitset<sizeof(T) * CHAR_BIT> mask = std::bitset<sizeof(T) * CHAR_BIT>
 (std::numeric_limits<unsigned long long>::max()));`
 |Creates the `radix_sorter` object to sort values considering only bits
 that corresponds to 1 in `mask`.
+Temporary local memory for the algorithm is provided using `scratch`.
+If `scratch.size()` is less than value returned by `temp_memory_size`,
+behavior of the sorting algorithm is undefined.
 |===
 
-Table. Member functions of the `radix_sorter` class.
+Table 7. Member functions of the `radix_sorter` class.
 |===
 |Member function|Description
 
@@ -223,7 +249,31 @@ void operator()(Group g, Ptr first, Ptr last)`
 |`template<typename Group>
 T operator()(Group g, T val)`
 |Implements the radix sort algorithm to be called by the `sort_over_group` algorithm.
+
+|`static std::size_t
+joint_sort_temp_memory_size(std::size_t range_size)`
+|Returns temporary memory size (in bytes) that is required by the radix sort algorithm
+calling by `joint_sort`. `range_size` represents a range size for sorting: `last-first`.
+
+|`static std::size_t
+sort_over_group_temp_memory_size(std::size_t range_size)`
+|Returns temporary memory size (in bytes) that is required by the radix sort algorithm
+calling by `sort_over_group`. `range_size` represents work group size.
 |===
+
+==== Memory helper
+
+SYCL provides the following function to identify the required size for a temporary local memory that is required for some of sorting functions.
+
+[source,c++]
+----
+namespace sycl::ext::oneapi {
+    template<typename... Args>
+    std::size_t sort_memory_helper(/*unspecified*/);
+}
+----
+
+_Returns_: temporary local memory size (in bytes) that is required by a sorting algorithm.
 
 ==== Sort
 The sort function from the {cpp} standard sorts elements with respect to
@@ -241,20 +291,20 @@ position `i` in the ordered range.
 [source,c++]
 ----
 namespace sycl::ext::oneapi {
-  template <typename Group, typename Ptr>
-  void joint_sort(Group g, Ptr first, Ptr last); // (1)
+  template <typename Group, std::size_t Extent, typename Ptr>
+  void joint_sort(Group g, sycl::span<uint8_t, Extent> scratch, Ptr first, Ptr last); // (1)
 
-  template <typename Group, typename Ptr, typename Compare>
-  void joint_sort(Group g, Ptr first, Ptr last, Compare comp); // (2)
+  template <typename Group, std::size_t Extent, typename Ptr, typename Compare>
+  void joint_sort(Group g, sycl::span<uint8_t, Extent> scratch, Ptr first, Ptr last, Compare comp); // (2)
 
   template <typename Group, typename Ptr, typename Sorter>
   void joint_sort(Group g, Ptr first, Ptr last, Sorter sorter); // (3)
 
-  template <typename Group, typename T>
-  T sort_over_group(Group g, T val); // (4)
+  template <typename Group, std::size_t Extent, typename T>
+  T sort_over_group(Group g, sycl::span<uint8_t, Extent> scratch, T val); // (4)
 
-  template <typename Group, typename T, typename Compare>
-  T sort_over_group(Group g, T val, Compare comp); // (5)
+  template <typename Group, std::size_t Extent, typename T, typename Compare>
+  T sort_over_group(Group g, sycl::span<uint8_t, Extent> scratch, T val, Compare comp); // (5)
 
   template <typename Group, typename T, typename Sorter>
   T sort_over_group(Group g, T val, Sorter sorter); // (6)
@@ -265,40 +315,49 @@ _Constraints_: All functions are available only if `sycl::is_group_v<std::decay_
 is true and `Sorter` is a SYCL Sorter.
 
 _Preconditions_: `first`, `last` must be the same for all work-items in the group.
+If size of memory provided by users is less than value that returns by the function,
+behavior of the sorting algorithm is undefined.
 
-1._Effects_: Sort the elements in the range `[first, last)`.
+1._Mandates_: `scratch.size()` must not be less than value returned by `sort_memory_helper`. Otherwise, behavior is undefined.
+
+_Effects_: Sort the elements in the range `[first, last)`
+using temporary local memory from `scratch`.
 Elements are compared by `operator<`.
 
-_Complexity_: Let `N` be `last - first`. `O(N*log_2(N))` comparisons.
+_Complexity_: Let `N` be `last - first`. `O(N*log(N)*log(N))` comparisons.
 
 2._Mandates_: `comp` must satisfy the requirements of `Compare` from
-the {cpp} standard.
+the {cpp} standard. `scratch.size()` must not be less than value returned by `sort_memory_helper`. Otherwise, behavior is undefined.
 
 _Effects_: Sort the elements in the range `[first, last)` with respect to the
-binary comparison function object `comp`.
+binary comparison function object `comp` using temporary local memory from `scratch`.
 
-_Complexity_: Let `N` be `last - first`. `O(N*log_2(N))` comparisons.
+_Complexity_: Let `N` be `last - first`. `O(N*log(N)*log(N))` comparisons.
 
 3._Effects_: Equivalent to: `sorter(g, first, last)`.
 
-4._Returns_: The value returned on work-item `i` is the value in position `i`
+4._Mandates_: `scratch.size()` must not be less than value returned by `sort_memory_helper`. Otherwise, behavior is undefined.
+
+_Returns_: The value returned on work-item `i` is the value in position `i`
 of the ordered range resulting from sorting `val` from all work-items in the
-`g` group. Elements are compared by `operator<`.
+`g` group. `scratch` represents the memory that is required for the sorting algorithm.
+Elements are compared by `operator<`.
 For multi-dimensional groups, the order of work-items in the group is
 determined by their linear id.
 
-_Complexity_: Let `N` be the work group size. `O(N*log_2(N))` comparisons.
+_Complexity_: Let `N` be the work group size. `O(N*log(N)*log(N))` comparisons.
 
 5._Mandates_: `comp` must satisfy the requirements of `Compare` from
-the {cpp} standard.
+the {cpp} standard. `scratch.size()` must not be less than value returned by `sort_memory_helper`. Otherwise, behavior is undefined.
 
 _Returns_: The value returned on work-item `i` is the value in position `i`
 of the ordered range resulting from sorting `val` from all work-items in the
 `g` group with respect to the binary comparison function object `comp`.
 For multi-dimensional groups, the order of work-items in the group is
 determined by their linear id.
+`scratch` represents the memory that is required for the sorting algorithm.
 
-_Complexity_: Let `N` be the work group size. `O(N*log_2(N))` comparisons.
+_Complexity_: Let `N` be the work group size. `O(N*log(N)*log(N))` comparisons.
 
 6._Effects_: Equivalent to: `return sorter(g, val)`.
 
@@ -320,5 +379,6 @@ will be added to the Spec to be used with other Group algorithms, e.g. find, red
 [options="header"]
 |========================================
 |Rev|Date|Author|Changes
-|1|{docdate}|Andrey Fedorov|Initial public working draft
+|1|2021-04-28|Andrey Fedorov|Initial public working draft
+|2|{docdate}|Andrey Fedorov|Changes related to additional memory providing
 |========================================


### PR DESCRIPTION
Previously it was found that we need an additional local memory for more performant implementation. The proposal fixes it.
Previous version of proposal was discussed here: https://github.com/intel/llvm/pull/3514
Design review: https://github.com/intel/llvm/pull/3754

Signed-off-by: Fedorov, Andrey <andrey.fedorov@intel.com>