### PR TITLE
Support Itanium demangling of the half precision FP type.

### DIFF
--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -3898,6 +3898,17 @@ Node *AbstractManglingParser<Derived, Alloc>::parseType() {
     case 'f':
       First += 2;
       return make<NameType>("decimal32");
+    //                ::= DF <number> _
+    //            # ISO/IEC TS 18661 binary floating point type _FloatN (N bits)
+    case 'F': {
+      First += 2;
+      StringView N = parseNumber(false /*disallow negatives*/);
+      if (N.size() == 0 || look() != '_')
+        return nullptr;
+      assert((std::string(N.begin(), N.end()) == "16") && "Unknown FP type");
+      First += 1;                        // consume '_'
+      return make<NameType>("_Float16"); // use FE-supoprted spelling
+    }
     //                ::= Dh   # IEEE 754r half-precision floating point (16 bits)
     case 'h':
       First += 2;

--- a/llvm/unittests/Demangle/ItaniumDemangleTest.cpp
+++ b/llvm/unittests/Demangle/ItaniumDemangleTest.cpp
@@ -51,3 +51,24 @@ TEST(ItaniumDemangle, MethodOverride) {
   ASSERT_NE(nullptr, Parser.parse());
   EXPECT_THAT(Parser.Types, testing::ElementsAre('i', 'j', 'l'));
 }
+
+TEST(ItaniumDemangle, HalfType) {
+  struct TestParser : AbstractManglingParser<TestParser, TestAllocator> {
+    std::vector<std::string> Types;
+
+    TestParser(const char *Str)
+        : AbstractManglingParser(Str, Str + strlen(Str)) {}
+
+    Node *parseType() {
+      Node *N = AbstractManglingParser<TestParser, TestAllocator>::parseType();
+      StringView Name = N->getBaseName();
+      Types.push_back(std::string(Name.begin(), Name.end()));
+      return N;
+    }
+  };
+
+  // void f(A<_Float16>, _Float16);
+  TestParser Parser("_Z1f1AIDF16_EDF16_");
+  ASSERT_NE(nullptr, Parser.parse());
+  EXPECT_THAT(Parser.Types, testing::ElementsAre("_Float16", "A", "_Float16"));
+}


### PR DESCRIPTION
Encoded as "DF16_" by the Itanium mangler.

Equivalent upstream patch: https://reviews.llvm.org/D105048

Signed-off-by: kbobrovs <Konstantin.S.Bobrovsky@intel.com>