### PR TITLE
[SYCL] Move __ENABLE_USM_ADDR_SPACE__ initialization into FE

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4676,12 +4676,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     if (HasFPGA)
       CmdArgs.push_back("-fsycl-disable-range-rounding");
 
-    // Enable generation of USM address spaces for FPGA.
-    // __ENABLE_USM_ADDR_SPACE__ will be used during compilation of SYCL headers
-    if (getToolChain().getTriple().getSubArch() ==
-        llvm::Triple::SPIRSubArch_fpga)
-      CmdArgs.push_back("-D__ENABLE_USM_ADDR_SPACE__");
-
     // Add any options that are needed specific to SYCL offload while
     // performing the host side compilation.
     if (!IsSYCLOffloadDevice) {

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1185,9 +1185,8 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
         DeviceSubArch != llvm::Triple::SPIRSubArch_fpga)
       Builder.defineMacro("SYCL_USE_NATIVE_FP_ATOMICS");
     // Enable generation of USM address spaces for FPGA.
-    if (DeviceSubArch == llvm::Triple::SPIRSubArch_fpga) {
+    if (DeviceSubArch == llvm::Triple::SPIRSubArch_fpga)
       Builder.defineMacro("__ENABLE_USM_ADDR_SPACE__");
-    }
   }
   if (LangOpts.SYCLUnnamedLambda)
     Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__");

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1184,6 +1184,10 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     if (DeviceTriple.isSPIR() &&
         DeviceSubArch != llvm::Triple::SPIRSubArch_fpga)
       Builder.defineMacro("SYCL_USE_NATIVE_FP_ATOMICS");
+    // Enable generation of USM address spaces for FPGA.
+    if (DeviceSubArch == llvm::Triple::SPIRSubArch_fpga) {
+      Builder.defineMacro("__ENABLE_USM_ADDR_SPACE__");
+    }
   }
   if (LangOpts.SYCLUnnamedLambda)
     Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__");

--- a/clang/test/Preprocessor/sycl-macro-target-specific.cpp
+++ b/clang/test/Preprocessor/sycl-macro-target-specific.cpp
@@ -23,3 +23,16 @@
 // RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS-NEG %s
 // CHECK-SYCL-FP-ATOMICS: #define SYCL_USE_NATIVE_FP_ATOMICS
 // CHECK-SYCL-FP-ATOMICS-NEG-NOT: #define SYCL_USE_NATIVE_FP_ATOMICS
+
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_fpga-unknown-unknown-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-USM-ADDR-SPACE %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-USM-ADDR-SPACE-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_gen-unknown-unknown-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-USM-ADDR-SPACE-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_x86_64-unknown-unknown-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-USM-ADDR-SPACE-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple nvptx64-nvidia-nvcl-sycldevice -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-USM-ADDR-SPACE-NEG %s
+// CHECK-USM-ADDR-SPACE: #define __ENABLE_USM_ADDR_SPACE__
+// CHECK-USM-ADDR-SPACE-NEG-NOT: #define __ENABLE_USM_ADDR_SPACE__


### PR DESCRIPTION
Also restores unit-level testing for this target-specific macro.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>