### PR TITLE
[Driver][SYCL] Differentiate host dependency link from regular host link

### DIFF
--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -114,5 +114,5 @@ TYPE("fpga_aocr_emu",            FPGA_AOCR_EMU, INVALID,        "aocr",   phases
 TYPE("fpga_aoco",                FPGA_AOCO,    INVALID,         "aoco",   phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("fpga_dep",                 FPGA_Dependencies, INVALID,    "d",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("fpga_dep_list",            FPGA_Dependencies_List, INVALID, "txt",  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
-TYPE("dep_image",                Dependencies_Image, INVALID,   "out",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("host_dep_image",           Host_Dependencies_Image, INVALID, "out", phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("none",                     Nothing,      INVALID,         nullptr,  phases::Compile, phases::Backend, phases::Assemble, phases::Link)

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -114,4 +114,5 @@ TYPE("fpga_aocr_emu",            FPGA_AOCR_EMU, INVALID,        "aocr",   phases
 TYPE("fpga_aoco",                FPGA_AOCO,    INVALID,         "aoco",   phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("fpga_dep",                 FPGA_Dependencies, INVALID,    "d",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("fpga_dep_list",            FPGA_Dependencies_List, INVALID, "txt",  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("dep_image",                Dependencies_Image, INVALID,   "out",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("none",                     Nothing,      INVALID,         nullptr,  phases::Compile, phases::Backend, phases::Assemble, phases::Link)

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5009,8 +5009,8 @@ public:
   /// they can add it to the device linker inputs.
   void addDeviceLinkDependenciesFromHost(ActionList &LinkerInputs) {
     // Link image for reading dependencies from it.
-    auto *LA =
-        C.MakeAction<LinkJobAction>(LinkerInputs, types::TY_Dependencies_Image);
+    auto *LA = C.MakeAction<LinkJobAction>(LinkerInputs,
+                                           types::TY_Host_Dependencies_Image);
 
     // Calculate all the offload kinds used in the current compilation.
     unsigned ActiveOffloadKinds = 0u;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5009,7 +5009,8 @@ public:
   /// they can add it to the device linker inputs.
   void addDeviceLinkDependenciesFromHost(ActionList &LinkerInputs) {
     // Link image for reading dependencies from it.
-    auto *LA = C.MakeAction<LinkJobAction>(LinkerInputs, types::TY_Image);
+    auto *LA =
+        C.MakeAction<LinkJobAction>(LinkerInputs, types::TY_Dependencies_Image);
 
     // Calculate all the offload kinds used in the current compilation.
     unsigned ActiveOffloadKinds = 0u;

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -570,6 +570,14 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddAllArgValues(CmdArgs, options::OPT__SLASH_link);
 
+  // A user can add the -out: option to the /link sequence on the command line
+  // which we do not want to use when we are performing the host link when
+  // gathering dependencies used for device compilation.  Add an additional
+  // -out: to override in case it was seen.
+  if (JA.getType() == types::TY_Dependencies_Image && Output.isFilename())
+    CmdArgs.push_back(
+        Args.MakeArgString(std::string("-out:") + Output.getFilename()));
+
   // Control Flow Guard checks
   if (Arg *A = Args.getLastArg(options::OPT__SLASH_guard)) {
     StringRef GuardArgs = A->getValue();

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -574,7 +574,7 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   // which we do not want to use when we are performing the host link when
   // gathering dependencies used for device compilation.  Add an additional
   // -out: to override in case it was seen.
-  if (JA.getType() == types::TY_Dependencies_Image && Output.isFilename())
+  if (JA.getType() == types::TY_Host_Dependencies_Image && Output.isFilename())
     CmdArgs.push_back(
         Args.MakeArgString(std::string("-out:") + Output.getFilename()));
 

--- a/clang/test/Driver/sycl-intelfpga-aoco-win.cpp
+++ b/clang/test/Driver/sycl-intelfpga-aoco-win.cpp
@@ -24,7 +24,7 @@
 // CHK-FPGA-AOCO-PHASES-WIN: 10: backend, {9}, assembler, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 11: assembler, {10}, object, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 12: linker, {0, 11}, image, (host-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 13: linker, {0, 11}, dep_image, (host-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 13: linker, {0, 11}, host_dep_image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 15: input, "[[INPUTA]]", archive
 // CHK-FPGA-AOCO-PHASES-WIN: 16: clang-offload-unbundler, {15}, archive

--- a/clang/test/Driver/sycl-intelfpga-aoco-win.cpp
+++ b/clang/test/Driver/sycl-intelfpga-aoco-win.cpp
@@ -24,7 +24,7 @@
 // CHK-FPGA-AOCO-PHASES-WIN: 10: backend, {9}, assembler, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 11: assembler, {10}, object, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 12: linker, {0, 11}, image, (host-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 13: linker, {0, 11}, image, (host-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 13: linker, {0, 11}, dep_image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 15: input, "[[INPUTA]]", archive
 // CHK-FPGA-AOCO-PHASES-WIN: 16: clang-offload-unbundler, {15}, archive

--- a/clang/test/Driver/sycl-intelfpga-aoco.cpp
+++ b/clang/test/Driver/sycl-intelfpga-aoco.cpp
@@ -28,7 +28,7 @@
 // CHK-FPGA-AOCO-PHASES: 10: backend, {9}, assembler, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 11: assembler, {10}, object, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 12: linker, {0, 11}, image, (host-sycl)
-// CHK-FPGA-AOCO-PHASES: 13: linker, {0, 11}, image, (host-sycl)
+// CHK-FPGA-AOCO-PHASES: 13: linker, {0, 11}, dep_image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 15: input, "[[INPUTA]]", archive
 // CHK-FPGA-AOCO-PHASES: 16: clang-offload-unbundler, {15}, archive
@@ -61,7 +61,7 @@
 // CHK-FPGA-AOCO-PHASES-WIN: 10: backend, {9}, assembler, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 11: assembler, {10}, object, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 12: linker, {0, 11}, image, (host-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 13: linker, {0, 11}, image, (host-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 13: linker, {0, 11}, dep_image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 15: input, "[[INPUTA]]", archive
 // CHK-FPGA-AOCO-PHASES-WIN: 16: clang-offload-unbundler, {15}, archive

--- a/clang/test/Driver/sycl-intelfpga-aoco.cpp
+++ b/clang/test/Driver/sycl-intelfpga-aoco.cpp
@@ -28,7 +28,7 @@
 // CHK-FPGA-AOCO-PHASES: 10: backend, {9}, assembler, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 11: assembler, {10}, object, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 12: linker, {0, 11}, image, (host-sycl)
-// CHK-FPGA-AOCO-PHASES: 13: linker, {0, 11}, dep_image, (host-sycl)
+// CHK-FPGA-AOCO-PHASES: 13: linker, {0, 11}, host_dep_image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 15: input, "[[INPUTA]]", archive
 // CHK-FPGA-AOCO-PHASES: 16: clang-offload-unbundler, {15}, archive
@@ -61,7 +61,7 @@
 // CHK-FPGA-AOCO-PHASES-WIN: 10: backend, {9}, assembler, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 11: assembler, {10}, object, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 12: linker, {0, 11}, image, (host-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 13: linker, {0, 11}, dep_image, (host-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 13: linker, {0, 11}, host_dep_image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 15: input, "[[INPUTA]]", archive
 // CHK-FPGA-AOCO-PHASES-WIN: 16: clang-offload-unbundler, {15}, archive

--- a/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
@@ -15,7 +15,7 @@
 // RUN:  | FileCheck -check-prefix=CHECK_PHASES %s
 // CHECK_PHASES: 0: input, "[[INPUT:.+\.lib]]", object, (host-sycl)
 // CHECK_PHASES: 1: linker, {0}, image, (host-sycl)
-// CHECK_PHASES: 2: linker, {0}, image, (host-sycl)
+// CHECK_PHASES: 2: linker, {0}, dep_image, (host-sycl)
 // CHECK_PHASES: 3: clang-offload-deps, {2}, ir, (host-sycl)
 // CHECK_PHASES: 4: input, "[[INPUT]]", archive
 // CHECK_PHASES: 5: clang-offload-unbundler, {4}, archive

--- a/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
@@ -15,7 +15,7 @@
 // RUN:  | FileCheck -check-prefix=CHECK_PHASES %s
 // CHECK_PHASES: 0: input, "[[INPUT:.+\.lib]]", object, (host-sycl)
 // CHECK_PHASES: 1: linker, {0}, image, (host-sycl)
-// CHECK_PHASES: 2: linker, {0}, dep_image, (host-sycl)
+// CHECK_PHASES: 2: linker, {0}, host_dep_image, (host-sycl)
 // CHECK_PHASES: 3: clang-offload-deps, {2}, ir, (host-sycl)
 // CHECK_PHASES: 4: input, "[[INPUT]]", archive
 // CHECK_PHASES: 5: clang-offload-unbundler, {4}, archive

--- a/clang/test/Driver/sycl-intelfpga-static-lib.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib.cpp
@@ -14,7 +14,7 @@
 // RUN:  | FileCheck -check-prefix=CHECK_PHASES %s
 // CHECK_PHASES: 0: input, "[[INPUT:.+\.a]]", object, (host-sycl)
 // CHECK_PHASES: 1: linker, {0}, image, (host-sycl)
-// CHECK_PHASES: 2: linker, {0}, dep_image, (host-sycl)
+// CHECK_PHASES: 2: linker, {0}, host_dep_image, (host-sycl)
 // CHECK_PHASES: 3: clang-offload-deps, {2}, ir, (host-sycl)
 // CHECK_PHASES: 4: input, "[[INPUT]]", archive
 // CHECK_PHASES: 5: clang-offload-unbundler, {4}, archive

--- a/clang/test/Driver/sycl-intelfpga-static-lib.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib.cpp
@@ -14,7 +14,7 @@
 // RUN:  | FileCheck -check-prefix=CHECK_PHASES %s
 // CHECK_PHASES: 0: input, "[[INPUT:.+\.a]]", object, (host-sycl)
 // CHECK_PHASES: 1: linker, {0}, image, (host-sycl)
-// CHECK_PHASES: 2: linker, {0}, image, (host-sycl)
+// CHECK_PHASES: 2: linker, {0}, dep_image, (host-sycl)
 // CHECK_PHASES: 3: clang-offload-deps, {2}, ir, (host-sycl)
 // CHECK_PHASES: 4: input, "[[INPUT]]", archive
 // CHECK_PHASES: 5: clang-offload-unbundler, {4}, archive

--- a/clang/test/Driver/sycl-offload-static-lib-2.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib-2.cpp
@@ -60,7 +60,7 @@
 // STATIC_LIB_SRC: 10: backend, {9}, assembler, (host-sycl)
 // STATIC_LIB_SRC: 11: assembler, {10}, object, (host-sycl)
 // STATIC_LIB_SRC: 12: linker, {0, 11}, image, (host-sycl)
-// STATIC_LIB_SRC: 13: linker, {0, 11}, image, (host-sycl)
+// STATIC_LIB_SRC: 13: linker, {0, 11}, dep_image, (host-sycl)
 // STATIC_LIB_SRC: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // STATIC_LIB_SRC: 15: input, "[[INPUTA]]", archive
 // STATIC_LIB_SRC: 16: clang-offload-unbundler, {15}, archive

--- a/clang/test/Driver/sycl-offload-static-lib-2.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib-2.cpp
@@ -60,7 +60,7 @@
 // STATIC_LIB_SRC: 10: backend, {9}, assembler, (host-sycl)
 // STATIC_LIB_SRC: 11: assembler, {10}, object, (host-sycl)
 // STATIC_LIB_SRC: 12: linker, {0, 11}, image, (host-sycl)
-// STATIC_LIB_SRC: 13: linker, {0, 11}, dep_image, (host-sycl)
+// STATIC_LIB_SRC: 13: linker, {0, 11}, host_dep_image, (host-sycl)
 // STATIC_LIB_SRC: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // STATIC_LIB_SRC: 15: input, "[[INPUTA]]", archive
 // STATIC_LIB_SRC: 16: clang-offload-unbundler, {15}, archive

--- a/clang/test/Driver/sycl-offload-static-lib.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib.cpp
@@ -64,7 +64,7 @@
 // FOFFLOAD_STATIC_LIB_SRC: 10: backend, {9}, assembler, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 11: assembler, {10}, object, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 12: linker, {0, 11}, image, (host-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 13: linker, {0, 11}, dep_image, (host-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 13: linker, {0, 11}, host_dep_image, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 15: input, "[[INPUTA]]", archive
 // FOFFLOAD_STATIC_LIB_SRC: 16: clang-offload-unbundler, {15}, archive
@@ -133,7 +133,7 @@
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB_NOSRC_PHASES
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 0: input, "[[INPUTA:.+\.a]]", object, (host-sycl)
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 1: linker, {0}, image, (host-sycl)
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 2: linker, {0}, dep_image, (host-sycl)
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 2: linker, {0}, host_dep_image, (host-sycl)
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 3: clang-offload-deps, {2}, ir, (host-sycl)
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 4: input, "[[INPUTA]]", archive
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 5: clang-offload-unbundler, {4}, archive

--- a/clang/test/Driver/sycl-offload-static-lib.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib.cpp
@@ -64,7 +64,7 @@
 // FOFFLOAD_STATIC_LIB_SRC: 10: backend, {9}, assembler, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 11: assembler, {10}, object, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 12: linker, {0, 11}, image, (host-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 13: linker, {0, 11}, image, (host-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 13: linker, {0, 11}, dep_image, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 15: input, "[[INPUTA]]", archive
 // FOFFLOAD_STATIC_LIB_SRC: 16: clang-offload-unbundler, {15}, archive
@@ -133,7 +133,7 @@
 // RUN:   | FileCheck %s -check-prefix=FOFFLOAD_STATIC_LIB_NOSRC_PHASES
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 0: input, "[[INPUTA:.+\.a]]", object, (host-sycl)
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 1: linker, {0}, image, (host-sycl)
-// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 2: linker, {0}, image, (host-sycl)
+// FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 2: linker, {0}, dep_image, (host-sycl)
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 3: clang-offload-deps, {2}, ir, (host-sycl)
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 4: input, "[[INPUTA]]", archive
 // FOFFLOAD_STATIC_LIB_NOSRC_PHASES: 5: clang-offload-unbundler, {4}, archive

--- a/clang/test/Driver/sycl-offload-win.c
+++ b/clang/test/Driver/sycl-offload-win.c
@@ -74,7 +74,7 @@
 // FOFFLOAD_STATIC_LIB_SRC: 10: backend, {9}, assembler, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 11: assembler, {10}, object, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 12: linker, {0, 11}, image, (host-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 13: linker, {0, 11}, dep_image, (host-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 13: linker, {0, 11}, host_dep_image, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 15: input, "[[INPUTLIB]]", archive
 // FOFFLOAD_STATIC_LIB_SRC: 16: clang-offload-unbundler, {15}, archive

--- a/clang/test/Driver/sycl-offload-win.c
+++ b/clang/test/Driver/sycl-offload-win.c
@@ -74,7 +74,7 @@
 // FOFFLOAD_STATIC_LIB_SRC: 10: backend, {9}, assembler, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 11: assembler, {10}, object, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 12: linker, {0, 11}, image, (host-sycl)
-// FOFFLOAD_STATIC_LIB_SRC: 13: linker, {0, 11}, image, (host-sycl)
+// FOFFLOAD_STATIC_LIB_SRC: 13: linker, {0, 11}, dep_image, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 14: clang-offload-deps, {13}, ir, (host-sycl)
 // FOFFLOAD_STATIC_LIB_SRC: 15: input, "[[INPUTLIB]]", archive
 // FOFFLOAD_STATIC_LIB_SRC: 16: clang-offload-unbundler, {15}, archive
@@ -103,3 +103,10 @@
 // FSYCL_P: clang{{.*}} "-cc1" "-triple" "x86_64-pc-windows-msvc{{.*}}" {{.*}} "-E" {{.*}} "-o" "[[HOSTPP:.+\.ii]]"
 // FSYCL_P: clang-offload-bundler{{.*}} "-type=ii" "-targets=sycl-spir64-unknown-unknown-sycldevice,host-x86_64-pc-windows-msvc" {{.*}} "-inputs=[[DEVICEPP]],[[HOSTPP]]"
 
+// RUN: touch %t-orig.lib
+// RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl %t-orig.lib %s -### /link -out:force_out_file 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=HOSTDEP_LINK_OVERRIDE
+// HOSTDEP_LINK_OVERRIDE: link{{.*}} "-out:[[HOSTDEP_LINK_OUT:.+\.out]]"{{.*}} "-out:force_out_file" "-out:[[HOSTDEP_LINK_OUT]]"
+// HOSTDEP_LINK_OVERRIDE: clang-offload-deps{{.*}}
+// HOSTDEP_LINK_OVERRIDE: link{{.*}} "-out:[[LINK_OUT:.+\.exe]]"{{.*}} "-out:force_out_file"
+// HOSTDEP_LINK_OVERRIDE-NOT: "-out:[[LINK_OUT]]"


### PR DESCRIPTION
When performing DPC++ compilation with static archives, there is additional
work performed that gathers the host dependency information so we can
determine what device code should be pulled in.  Add an additional type
that will allow us to make heads or tails over which link step is being
performed.

This is needed to be able to override any user /link [arg] input that the
user may specify for MSVC compilations.  We do not want to honor the -out:*
information there during the host dependency link phase, as it will
override our expected output file designation.