### PR TITLE
[BuildBot] Uplift GPU RT version for Linux CI Process

### DIFF
--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -4,8 +4,8 @@ ocl_cpu_rt_ver=2021.12.6.0.19
 # https://github.com/intel/llvm/releases/download/2021-WW26/win-oclcpuexp-2021.12.6.0.19_rel.zip
 ocl_cpu_rt_ver_win=2021.12.6.0.19
 # Same GPU driver supports Level Zero and OpenCL
-# https://github.com/intel/compute-runtime/releases/tag/21.23.20043
-ocl_gpu_rt_ver=21.23.20043
+# https://github.com/intel/compute-runtime/releases/tag/21.24.20098
+ocl_gpu_rt_ver=21.24.20098
 # Same GPU driver supports Level Zero and OpenCL
 # https://downloadmirror.intel.com/30381/a08/igfx_win10_100.9466.zip
 ocl_gpu_rt_ver_win=27.20.100.9466
@@ -30,7 +30,7 @@ ocloc_ver_win=27.20.100.9168
 [DRIVER VERSIONS]
 cpu_driver_lin=2021.12.6.0.19
 cpu_driver_win=2021.12.6.0.19
-gpu_driver_lin=21.23.20043
+gpu_driver_lin=21.24.20098
 gpu_driver_win=27.20.100.9466
 fpga_driver_lin=2021.12.6.0.19
 fpga_driver_win=2021.12.6.0.19


### PR DESCRIPTION
Uplift GPU RT version for Linux to 21.24.20098

Tests changed in scope of intel/llvm-test-suite#330