### PR TITLE
[Driver][NFC] Update usage of array container used for triple aliases

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1858,8 +1858,8 @@ void Driver::PrintHelp(bool ShowHidden) const {
 }
 
 llvm::Triple Driver::MakeSYCLDeviceTriple(StringRef TargetArch) const {
-  ArrayRef<StringRef> SYCLAlias = {"spir", "spir64", "spir64_fpga",
-                                   "spir64_x86_64", "spir64_gen"};
+  SmallVector<StringRef, 5> SYCLAlias = {"spir", "spir64", "spir64_fpga",
+                                         "spir64_x86_64", "spir64_gen"};
   if (std::find(SYCLAlias.begin(), SYCLAlias.end(), TargetArch) !=
       SYCLAlias.end()) {
     llvm::Triple TT;


### PR DESCRIPTION
This class does not own the underlying data, it is
expected to be used in situations where the data resides in some
other buffer, whose lifetime extends past that of the ArrayRef. For
this reason, it is not in general safe to store an ArrayRef.
"Source: https://llvm.org/doxygen/classllvm_1_1ArrayRef.html