### PR TITLE
[SYCL][FPGA] Allow use_stall_enable_clusters attribute to kernel

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2591,6 +2591,9 @@ is ignored on the host.
 The ``intel::use_stall_enable_clusters`` attribute takes no argument and has an
 effect when applied to a function, and no effect otherwise.
 
+If ``intel::use_stall_enable_clusters`` is applied to a function called from a device
+kernel, the attribute is ignored and it is not propagated to the kernel.
+
 .. code-block:: c++
 
   class Foo {
@@ -2604,6 +2607,14 @@ effect when applied to a function, and no effect otherwise.
     [[intel::use_stall_enable_clusters]] void operator()() const {}
   };
 
+  class Functor
+  {
+      [[intel::use_stall_enable_clusters]] void operator()(item<1> item)
+      {
+          /* kernel code */
+      }
+  }
+
 The ``intel::use_stall_enable_clusters`` attribute supports a nonconforming
 behavior when applied to a lambda in the type position.
 
@@ -2613,6 +2624,11 @@ behavior when applied to a lambda in the type position.
     auto lambda = []() [[intel::use_stall_enable_clusters]]{};
     lambda();
   }
+
+  kernel<class kernel_name>(
+  []() [[intel::use_stall_enable_clusters]] {
+       /* kernel code */
+  });
 
   }];
 }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -573,7 +573,8 @@ static void collectSYCLAttributes(Sema &S, FunctionDecl *FD,
     llvm::copy_if(FD->getAttrs(), std::back_inserter(Attrs), [](Attr *A) {
       return isa<SYCLIntelLoopFuseAttr, SYCLIntelFPGAMaxConcurrencyAttr,
                  SYCLIntelFPGADisableLoopPipeliningAttr,
-                 SYCLIntelFPGAInitiationIntervalAttr>(A);
+                 SYCLIntelFPGAInitiationIntervalAttr,
+		 SYCLIntelUseStallEnableClustersAttr>(A);
     });
   }
 }
@@ -4077,6 +4078,7 @@ static void PropagateAndDiagnoseDeviceAttr(
   case attr::Kind::SYCLIntelFPGAMaxConcurrency:
   case attr::Kind::SYCLIntelFPGADisableLoopPipelining:
   case attr::Kind::SYCLIntelFPGAInitiationInterval:
+  case attr::Kind::SYCLIntelUseStallEnableClusters:
     SYCLKernel->addAttr(A);
     break;
   case attr::Kind::IntelNamedSubGroupSize:

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -574,7 +574,7 @@ static void collectSYCLAttributes(Sema &S, FunctionDecl *FD,
       return isa<SYCLIntelLoopFuseAttr, SYCLIntelFPGAMaxConcurrencyAttr,
                  SYCLIntelFPGADisableLoopPipeliningAttr,
                  SYCLIntelFPGAInitiationIntervalAttr,
-		 SYCLIntelUseStallEnableClustersAttr>(A);
+                 SYCLIntelUseStallEnableClustersAttr>(A);
     });
   }
 }

--- a/clang/test/CodeGenSYCL/stall_enable_device.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable_device.cpp
@@ -10,13 +10,13 @@
 using namespace cl::sycl;
 queue q;
 
-[[intel::use_stall_enable_clusters]] void test() {}
+[[intel::use_stall_enable_clusters]] void func() {}
 
 struct FuncObj {
   [[intel::use_stall_enable_clusters]] void operator()() const {}
 };
 
-void test1() {
+void func1() {
   auto lambda = []() [[intel::use_stall_enable_clusters]]{};
   lambda();
 }
@@ -47,17 +47,17 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel3()
     // CHECK-NOT: !stall_enable
     // CHECK-SAME: {
-    // CHECK: define {{.*}}spir_func void @{{.*}}test{{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}func{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel3>(
-        []() { test(); });
+        []() { func(); });
 
     // Test attribute is not propagated to the kernel metadata i.e. spir_kernel.
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel4()
     // CHECK-NOT: !stall_enable
     // CHECK-SAME: {
-    // CHECK: define {{.*}}spir_func void @{{.*}}test1{{.*}}(%class.{{.*}}test1{{.*}}.anon addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}func1{{.*}}(%class.{{.*}}func1{{.*}}.anon addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 !stall_enable ![[NUM4]]
     h.single_task<class test_kernel4>(
-        []() { test1(); });
+        []() { func1(); });
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel5() {{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel5>(

--- a/clang/test/CodeGenSYCL/stall_enable_device.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable_device.cpp
@@ -33,31 +33,38 @@ public:
 
 int main() {
   q.submit([&](handler &h) {
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel1() #0 !stall_enable ![[NUM4:[0-9]+]] !kernel_arg_buffer_location ![[NUM5:[0-9]+]]
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel1() {{.*}} !stall_enable ![[NUM4:[0-9]+]]
     // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(%struct.{{.*}}FuncObj addrspace(4)* align 1 dereferenceable_or_null(1) %this) #3 comdat align 2 !stall_enable ![[NUM4]]
     h.single_task<class test_kernel1>(
         FuncObj());
 
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel2() #0 !stall_enable ![[NUM4]] !kernel_arg_buffer_location ![[NUM5]]
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel2() {{.*}} !stall_enable ![[NUM4]]
     // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(%class._ZTS3Foo.Foo addrspace(4)* align 1 dereferenceable_or_null(1) %this) #3 comdat align 2 !stall_enable ![[NUM4]]
     Foo f;
     h.single_task<class test_kernel2>(f);
 
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel3() #0 !kernel_arg_buffer_location ![[NUM5]]
-    // CHECK: define {{.*}}spir_func void @_Z4testv() #3 !stall_enable ![[NUM4]]
+    // Test attribute is not propagated to the kernel metadata i.e. spir_kernel.
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel3()
+    // CHECK-NOT: !stall_enable
+    // CHECK-SAME: {
+    // CHECK: define {{.*}}spir_func void @{{.*}}test{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel3>(
         []() { test(); });
 
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel4() #0 !kernel_arg_buffer_location ![[NUM5]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}test1vENKUlvE_clEv(%class.{{.*}}test1{{.*}}.anon addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 !stall_enable ![[NUM4]]
+    // Test attribute is not propagated to the kernel metadata i.e. spir_kernel.
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel4()
+    // CHECK-NOT: !stall_enable
+    // CHECK-SAME: {
+    // CHECK: define {{.*}}spir_func void @{{.*}}test1{{.*}}(%class.{{.*}}test1{{.*}}.anon addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 !stall_enable ![[NUM4]]
     h.single_task<class test_kernel4>(
         []() { test1(); });
 
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel5() #0 !stall_enable ![[NUM4]] !kernel_arg_buffer_location ![[NUM5]]
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel5() {{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel5>(
         []() [[intel::use_stall_enable_clusters]]{});
 
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel6() #0 !stall_enable ![[NUM4]] !kernel_arg_buffer_location ![[NUM5]]
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel6() {{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}Functor{{.*}}(%class._ZTS7Functor.Functor addrspace(4)* align 1 dereferenceable_or_null(1) %this) #3 comdat align 2 !stall_enable ![[NUM4]]
     Functor f1;
     h.single_task<class test_kernel6>(f1);
   });
@@ -65,4 +72,3 @@ int main() {
 }
 
 // CHECK: ![[NUM4]] = !{i32 1}
-// CHECK: ![[NUM5]] = !{}

--- a/clang/test/CodeGenSYCL/stall_enable_device.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable_device.cpp
@@ -2,7 +2,7 @@
 
 // Tests for IR of Intel FPGA [[intel::use_stall_enable_clusters]] function attribute on Device.
 // The metadata to be attached to the functionDecl that the attribute is applied to.
-// The attributes do not get propagated to kernel metadata i.e. spir_kernel.
+// The attributes get propagated to the kernel metadata i.e. spir_kernel.
 
 #include "sycl.hpp"
 
@@ -25,30 +25,43 @@ public:
   [[intel::use_stall_enable_clusters]] void operator()() const {}
 };
 
+class Functor {
+public:
+  [[intel::use_stall_enable_clusters]] void operator()() const {}
+};
+
 int main() {
   q.submit([&](handler &h) {
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel1() #0 !kernel_arg_buffer_location ![[NUM4:[0-9]+]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(%struct.{{.*}}FuncObj addrspace(4)* align 1 dereferenceable_or_null(1) %this) #3 comdat align 2 !stall_enable ![[NUM5:[0-9]+]]
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel1() #0 !stall_enable ![[NUM4:[0-9]+]] !kernel_arg_buffer_location ![[NUM5:[0-9]+]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(%struct.{{.*}}FuncObj addrspace(4)* align 1 dereferenceable_or_null(1) %this) #3 comdat align 2 !stall_enable ![[NUM4]]
     h.single_task<class test_kernel1>(
         FuncObj());
 
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel2() #0 !kernel_arg_buffer_location ![[NUM4]]
-    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(%class._ZTS3Foo.Foo addrspace(4)* align 1 dereferenceable_or_null(1) %this) #3 comdat align 2 !stall_enable ![[NUM5]]
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel2() #0 !stall_enable ![[NUM4]] !kernel_arg_buffer_location ![[NUM5]]
+    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(%class._ZTS3Foo.Foo addrspace(4)* align 1 dereferenceable_or_null(1) %this) #3 comdat align 2 !stall_enable ![[NUM4]]
     Foo f;
     h.single_task<class test_kernel2>(f);
 
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel3() #0 !kernel_arg_buffer_location ![[NUM4]]
-    // CHECK: define {{.*}}spir_func void @_Z4testv() #3 !stall_enable ![[NUM5]]
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel3() #0 !kernel_arg_buffer_location ![[NUM5]]
+    // CHECK: define {{.*}}spir_func void @_Z4testv() #3 !stall_enable ![[NUM4]]
     h.single_task<class test_kernel3>(
         []() { test(); });
 
-    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel4() #0 !kernel_arg_buffer_location ![[NUM4]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}test1vENKUlvE_clEv(%class.{{.*}}test1{{.*}}.anon addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 !stall_enable ![[NUM5]]
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel4() #0 !kernel_arg_buffer_location ![[NUM5]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}test1vENKUlvE_clEv(%class.{{.*}}test1{{.*}}.anon addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 !stall_enable ![[NUM4]]
     h.single_task<class test_kernel4>(
         []() { test1(); });
+
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel5() #0 !stall_enable ![[NUM4]] !kernel_arg_buffer_location ![[NUM5]]
+    h.single_task<class test_kernel5>(
+        []() [[intel::use_stall_enable_clusters]]{});
+
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel6() #0 !stall_enable ![[NUM4]] !kernel_arg_buffer_location ![[NUM5]]
+    Functor f1;
+    h.single_task<class test_kernel6>(f1);
   });
   return 0;
 }
 
-// CHECK: ![[NUM4]] = !{}
-// CHECK: ![[NUM5]] = !{i32 1}
+// CHECK: ![[NUM4]] = !{i32 1}
+// CHECK: ![[NUM5]] = !{}

--- a/clang/test/CodeGenSYCL/stall_enable_device.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable_device.cpp
@@ -2,7 +2,8 @@
 
 // Tests for IR of Intel FPGA [[intel::use_stall_enable_clusters]] function attribute on Device.
 // The metadata to be attached to the functionDecl that the attribute is applied to.
-// The attributes get propagated to the kernel metadata i.e. spir_kernel.
+// The attributes get propagated to the kernel metadata i.e. spir_kernel if directly applied
+// through functors/lambda function.
 
 #include "sycl.hpp"
 

--- a/clang/test/SemaSYCL/stall_enable_device.cpp
+++ b/clang/test/SemaSYCL/stall_enable_device.cpp
@@ -37,6 +37,11 @@ void test3() {
 }
 
 // Test attribute is presented on functor.
+// CHECK: CXXRecordDecl{{.*}}referenced class Functor definition
+// CHECK: CXXRecordDecl{{.*}} implicit class Functor
+// CHECK: AccessSpecDecl{{.*}} public
+// CHECK-NEXT: CXXMethodDecl{{.*}}used operator() 'void () const'
+// CHECK-NEXT-NEXT: SYCLIntelUseStallEnableClustersAttr
 class Functor {
 public:
   [[intel::use_stall_enable_clusters]] void operator()() const {

--- a/clang/test/SemaSYCL/stall_enable_device.cpp
+++ b/clang/test/SemaSYCL/stall_enable_device.cpp
@@ -9,9 +9,10 @@ using namespace cl::sycl;
 queue q;
 
 // Test attribute is presented on function definition.
-[[intel::use_stall_enable_clusters]] void test() {}
-// CHECK: FunctionDecl{{.*}}test
-// CHECK: SYCLIntelUseStallEnableClustersAttr
+[[intel::use_stall_enable_clusters]] void func() {}
+// CHECK: FunctionDecl{{.*}}used func 'void ()'
+// CHECK-NEXT: CompoundStmt{{.*}}
+// CHECK-NEXT-NEXT: SYCLIntelUseStallEnableClustersAttr{{.*}}
 
 // Tests for incorrect argument values for Intel FPGA use_stall_enable_clusters function attribute.
 #ifdef TRIGGER_ERROR
@@ -24,7 +25,7 @@ struct FuncObj {
   [[intel::use_stall_enable_clusters]] void operator()() const {}
   // CHECK: CXXRecordDecl{{.*}}implicit struct FuncObj
   // CHECK-NEXT: CXXMethodDecl{{.*}}used operator() 'void () const'
-  // CHECK-NEXT-NEXT:SYCLIntelUseStallEnableClustersAttr
+  // CHECK-NEXT-NEXT:SYCLIntelUseStallEnableClustersAttr{{.*}}
 };
 
 // Test attribute is presented on lambda function(applied to a function type for the lambda's call operator).
@@ -33,7 +34,7 @@ void test3() {
   lambda();
   // CHECK: FunctionDecl{{.*}}test3
   // CHECK: LambdaExpr
-  // CHECK: SYCLIntelUseStallEnableClustersAttr
+  // CHECK: SYCLIntelUseStallEnableClustersAttr{{.*}}
 }
 
 // Test attribute is presented on functor.
@@ -41,7 +42,7 @@ void test3() {
 // CHECK: CXXRecordDecl{{.*}} implicit class Functor
 // CHECK: AccessSpecDecl{{.*}} public
 // CHECK-NEXT: CXXMethodDecl{{.*}}used operator() 'void () const'
-// CHECK-NEXT-NEXT: SYCLIntelUseStallEnableClustersAttr
+// CHECK-NEXT-NEXT: SYCLIntelUseStallEnableClustersAttr{{.*}}
 class Functor {
 public:
   [[intel::use_stall_enable_clusters]] void operator()() const {
@@ -66,7 +67,7 @@ int main() {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
     // CHECK-NOT:   SYCLIntelUseStallEnableClustersAttr {{.*}}
     h.single_task<class test_kernel3>(
-        []() { test(); });
+        []() { func(); });
 
     // Test attribute is applied to kernel if directly applied through functor.
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel4


### PR DESCRIPTION
This patch collects and applies the FPGA attribute intel::use_stall_enable_clusters to the callers/SYCL kernel if directly applied through functors/lambda function.

The attribute has to be applicable to all functions, which can include the SYCL kernels and ​must not be propagated up to the caller/SYCL kernel when called from a function.

This patch fixes FPGA emulator bug that was introduced on https://github.com/intel/llvm/pull/3900.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>