### PR TITLE
[Driver][SYCL] Restrict user -include file in final integration foote…

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1416,6 +1416,11 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
                                                        << A->getAsString(Args);
         }
       }
+      // Do not render -include when performing the compilation that occurs
+      // after the the integration footer has been appended.  This has already
+      // been preprocessed and should not be included again.
+      if (ContainsAppendFooterAction(&JA))
+        continue;
     } else if (A->getOption().matches(options::OPT_isystem_after)) {
       // Handling of paths which must come late.  These entries are handled by
       // the toolchain itself after the resource dir is inserted in the right

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -1,11 +1,16 @@
 /// Check compilation tool steps when using the integration footer
-// RUN:  %clangxx -fsycl %s -### 2>&1 \
+// RUN:  %clangxx -fsycl -include dummy.h %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER %s
-// FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}"
-// FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-E"{{.*}} "-C"{{.*}} "-o" "[[PREPROC:.+\.ii]]"
+// FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}"{{.*}} "-include" "dummy.h"
+// FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-E"{{.*}} "-C"{{.*}} "-include" "dummy.h"{{.*}} "-o" "[[PREPROC:.+\.ii]]"
 // FOOTER: append-file{{.*}} "[[PREPROC]]" "--append=[[INTFOOTER]]" "--output=[[APPENDEDSRC:.+\.cpp]]"
 // FOOTER: clang{{.*}} "-fsycl-is-host"{{.*}} "[[APPENDEDSRC]]"
 // FOOTER-NOT: "-include" "[[INTHEADER]]"
+
+// RUN:  %clangxx -fsycl -include dummy.h %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix FOOTER_NO_HEADER %s
+// FOOTER_NO_HEADER: append-file{{.*}}
+// FOOTER_NO_HEADER-NOT: clang{{.*}} "-include" "dummy.h"
 
 /// Preprocessed file creation with integration footer
 // RUN: %clangxx -fsycl -E %s -### 2>&1 \


### PR DESCRIPTION
…r step

When compiling with the integration footer, the host side of the compile
is performed twice.  Once for the preprocessing and again with a full
file containing the integration footer.  For any user -include file.h
files, we only want to include that during the preprocessing step and not
with the subsequent compile.