### PR TITLE
[SYCL] Changed USM copy src and dst parameter order

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -2261,10 +2261,10 @@ public:
   /// if either \param Dest or \param Src is nullptr. The behavior is undefined
   /// if any of the pointer parameters is invalid.
   ///
-  /// \param Dest is a USM pointer to the destination memory.
   /// \param Src is a USM pointer to the source memory.
+  /// \param Dest is a USM pointer to the destination memory.
   /// \param Count is a number of elements of type T to copy.
-  template <typename T> void copy(T *Dest, const T *Src, size_t Count) {
+  template <typename T> void copy(const T *Src, T *Dest, size_t Count) {
     this->memcpy(Dest, Src, Count * sizeof(T));
   }
 

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -446,11 +446,11 @@ public:
   /// if either \param Dest or \param Src is nullptr. The behavior is undefined
   /// if any of the pointer parameters is invalid.
   ///
-  /// \param Dest is a USM pointer to the destination memory.
   /// \param Src is a USM pointer to the source memory.
+  /// \param Dest is a USM pointer to the destination memory.
   /// \param Count is a number of elements of type T to copy.
   /// \return an event representing copy operation.
-  template <typename T> event copy(T *Dest, const T *Src, size_t Count) {
+  template <typename T> event copy(const T *Src, T *Dest, size_t Count) {
     return this->memcpy(Dest, Src, Count * sizeof(T));
   }
 
@@ -460,13 +460,13 @@ public:
   /// if either \param Dest or \param Src is nullptr. The behavior is undefined
   /// if any of the pointer parameters is invalid.
   ///
-  /// \param Dest is a USM pointer to the destination memory.
   /// \param Src is a USM pointer to the source memory.
+  /// \param Dest is a USM pointer to the destination memory.
   /// \param Count is a number of elements of type T to copy.
   /// \param DepEvent is an event that specifies the kernel dependencies.
   /// \return an event representing copy operation.
   template <typename T>
-  event copy(T *Dest, const T *Src, size_t Count, event DepEvent) {
+  event copy(const T *Src, T *Dest, size_t Count, event DepEvent) {
     return this->memcpy(Dest, Src, Count * sizeof(T), DepEvent);
   }
 
@@ -476,13 +476,13 @@ public:
   /// if either \param Dest or \param Src is nullptr. The behavior is undefined
   /// if any of the pointer parameters is invalid.
   ///
-  /// \param Dest is a USM pointer to the destination memory.
   /// \param Src is a USM pointer to the source memory.
+  /// \param Dest is a USM pointer to the destination memory.
   /// \param Count is a number of elements of type T to copy.
   /// \param DepEvents is a vector of events that specifies the kernel
   /// \return an event representing copy operation.
   template <typename T>
-  event copy(T *Dest, const T *Src, size_t Count,
+  event copy(const T *Src, T *Dest, size_t Count,
              const vector_class<event> &DepEvents) {
     return this->memcpy(Dest, Src, Count * sizeof(T), DepEvents);
   }


### PR DESCRIPTION
As noted in https://github.com/intel/llvm/pull/3897#issuecomment-872363647,
a spec bug was identified. The USM `copy` member functions take the `src`
and `dst` parameters in the wrong order. The order should be `(src, dst)`,
which matches the standard C++ `copy` function and matches the existing
SYCL `copy` functions that take accessor parameters.