### PR TITLE
[NFC] update int footer test for 32-bit host

### DIFF
--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -37,7 +37,7 @@
 // NO-FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-o"
 
 /// Check phases without integration footer
-// RUN: %clangxx -fsycl -fno-sycl-device-lib=all -fno-sycl-use-footer %s -ccc-print-phases 2>&1 \
+// RUN: %clangxx -fsycl -fno-sycl-device-lib=all -fno-sycl-use-footer -target x86_64-unknown-linux-gnu %s -ccc-print-phases 2>&1 \
 // RUN:   | FileCheck -check-prefix NO-FOOTER-PHASES -check-prefix COMMON-PHASES %s
 // NO-FOOTER-PHASES: 0: input, "{{.*}}", c++, (host-sycl)
 // NO-FOOTER-PHASES: [[#HOST_PREPROC:]]: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -46,7 +46,7 @@
 // NO-FOOTER-PHASES: [[#DEVICE_IR:]]: compiler, {3}, ir, (device-sycl)
 
 /// Check phases with integration footer
-// RUN: %clangxx -fsycl -fno-sycl-device-lib=all %s -ccc-print-phases 2>&1 \
+// RUN: %clangxx -fsycl -fno-sycl-device-lib=all -target x86_64-unknown-linux-gnu %s -ccc-print-phases 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER-PHASES -check-prefix COMMON-PHASES %s
 // FOOTER-PHASES: 0: input, "{{.*}}", c++, (host-sycl)
 // FOOTER-PHASES: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)


### PR DESCRIPTION
The sycl-int-footer.cpp test is relying on host settings for some of the
checks.  This can change when the host is 32-bits and the tests will
fail.  Update test to force x86_64 targets for these checks.