### PR TITLE
[SYCL] Fix Windows Shutdown Failure

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -151,7 +151,9 @@ void shutdown() {
 }
 
 #ifdef _WIN32
-BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
+extern "C" __SYCL_EXPORT BOOL WINAPI DllMain(HINSTANCE hinstDLL,
+                                             DWORD fdwReason,
+                                             LPVOID lpReserved) {
   // Perform actions based on the reason for calling.
   switch (fdwReason) {
   case DLL_PROCESS_DETACH:


### PR DESCRIPTION
The function DllMain() is missing important attribute, so shutdown was never called on Windows before.

Signed-off-by: Byoungro So <byoungro.so@intel.com>