### PR TITLE
[SYCL] Lower queue::wait() to piQueueFinish when possible

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -200,8 +200,7 @@ void event_impl::wait(
     waitInternal();
   else if (MCommand)
     detail::Scheduler::getInstance().waitForEvent(Self);
-  if (MCommand && !SYCLConfig<SYCL_DISABLE_EXECUTION_GRAPH_CLEANUP>::get())
-    detail::Scheduler::getInstance().cleanupFinishedCommands(std::move(Self));
+  cleanupCommand(std::move(Self));
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   instrumentationEpilog(TelemetryEvent, Name, StreamID, IId);
@@ -220,6 +219,12 @@ void event_impl::wait_and_throw(
   Command *Cmd = (Command *)getCommand();
   if (Cmd)
     Cmd->getQueue()->throw_asynchronous();
+}
+
+void event_impl::cleanupCommand(
+    std::shared_ptr<cl::sycl::detail::event_impl> Self) const {
+  if (MCommand && !SYCLConfig<SYCL_DISABLE_EXECUTION_GRAPH_CLEANUP>::get())
+    detail::Scheduler::getInstance().cleanupFinishedCommands(std::move(Self));
 }
 
 template <>

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -74,6 +74,12 @@ public:
   /// \param Self is a pointer to this event.
   void wait_and_throw(std::shared_ptr<cl::sycl::detail::event_impl> Self);
 
+  /// Clean up the command associated with the event. Assumes that the task this
+  /// event is associated with has been completed.
+  ///
+  /// \param Self is a pointer to this event.
+  void cleanupCommand(std::shared_ptr<cl::sycl::detail::event_impl> Self) const;
+
   /// Queries this event for profiling information.
   ///
   /// If the requested info is not available when this member function is

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -486,10 +486,14 @@ Command *Command::processDepEvent(EventImplPtr DepEvent, const DepDesc &Dep) {
   const ContextImplPtr &WorkerContext = WorkerQueue->getContextImplPtr();
 
   // 1. Async work is not supported for host device.
-  // 2. The event handle can be null in case of, for example, alloca command,
-  //    which is currently synchronous, so don't generate OpenCL event.
-  //    Though, this event isn't host one as it's context isn't host one.
-  if (DepEvent->is_host() || DepEvent->getHandleRef() == nullptr) {
+  // 2. Some types of commands do not produce PI events after they are enqueued
+  // (e.g. alloca). Note that we can't check the pi event to make that
+  // distinction since the command might still be unenqueued at this point.
+  bool PiEventExpected = !DepEvent->is_host();
+  if (auto *DepCmd = static_cast<Command *>(DepEvent->getCommand()))
+    PiEventExpected &= DepCmd->producesPiEvent();
+
+  if (!PiEventExpected) {
     // call to waitInternal() is in waitForPreparedHostEvents() as it's called
     // from enqueue process functions
     MPreparedHostDepsEvents.push_back(DepEvent);
@@ -519,6 +523,8 @@ const ContextImplPtr &Command::getWorkerContext() const {
 }
 
 const QueueImplPtr &Command::getWorkerQueue() const { return MQueue; }
+
+bool Command::producesPiEvent() const { return true; }
 
 Command *Command::addDep(DepDesc NewDep) {
   Command *ConnectionCmd = nullptr;
@@ -730,6 +736,8 @@ void AllocaCommandBase::emitInstrumentationData() {
   }
 #endif
 }
+
+bool AllocaCommandBase::producesPiEvent() const { return false; }
 
 AllocaCommand::AllocaCommand(QueueImplPtr Queue, Requirement Req,
                              bool InitFromUserData,
@@ -997,6 +1005,8 @@ void ReleaseCommand::printDot(std::ostream &Stream) const {
            << std::endl;
   }
 }
+
+bool ReleaseCommand::producesPiEvent() const { return false; }
 
 MapMemObject::MapMemObject(AllocaCommandBase *SrcAllocaCmd, Requirement Req,
                            void **DstPtr, QueueImplPtr Queue,
@@ -1391,6 +1401,8 @@ void EmptyCommand::printDot(std::ostream &Stream) const {
            << std::endl;
   }
 }
+
+bool EmptyCommand::producesPiEvent() const { return false; }
 
 void MemCpyCommandHost::printDot(std::ostream &Stream) const {
   Stream << "\"" << this << "\" [style=filled, fillcolor=\"#B6A2EB\", label=\"";
@@ -2191,6 +2203,10 @@ cl_int ExecCGCommand::enqueueImp() {
     throw runtime_error("CG type not implemented.", PI_INVALID_OPERATION);
   }
   return PI_INVALID_OPERATION;
+}
+
+bool ExecCGCommand::producesPiEvent() const {
+  return MCommandGroup->getType() != CG::CGTYPE::CODEPLAY_HOST_TASK;
 }
 
 } // namespace detail

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -189,6 +189,9 @@ public:
   /// for memory copy commands.
   virtual const QueueImplPtr &getWorkerQueue() const;
 
+  /// Returns true iff the command produces a PI event on non-host devices.
+  virtual bool producesPiEvent() const;
+
 protected:
   EventImplPtr MEvent;
   QueueImplPtr MQueue;
@@ -306,6 +309,8 @@ public:
 
   void emitInstrumentationData() override;
 
+  bool producesPiEvent() const final;
+
 private:
   cl_int enqueueImp() final;
 
@@ -323,6 +328,7 @@ public:
 
   void printDot(std::ostream &Stream) const final;
   void emitInstrumentationData() override;
+  bool producesPiEvent() const final;
 
 private:
   cl_int enqueueImp() final;
@@ -346,6 +352,8 @@ public:
   const Requirement *getRequirement() const final { return &MRequirement; }
 
   void emitInstrumentationData() override;
+
+  bool producesPiEvent() const final;
 
   void *MMemAllocation = nullptr;
 
@@ -517,6 +525,8 @@ public:
   void releaseCG() {
     MCommandGroup.release();
   }
+
+  bool producesPiEvent() const final;
 
 private:
   cl_int enqueueImp() final;

--- a/sycl/test/on-device/plugins/level_zero_batch_event_status.cpp
+++ b/sycl/test/on-device/plugins/level_zero_batch_event_status.cpp
@@ -25,10 +25,10 @@
 // CHECK:  ZE ---> zeCommandListClose
 // CHECK:  ZE ---> zeCommandQueueExecuteCommandLists
 // CHECK: ---> piEventGetInfo
-// CHECK-NOT: piEventsWait
+// CHECK-NOT: piQueueFinish
 // CHECK: ---> piEnqueueKernelLaunch
 // CHECK: ZE ---> zeCommandListAppendLaunchKernel
-// CHECK: ---> piEventsWait
+// CHECK: ---> piQueueFinish
 // Look for close and Execute after piEventsWait
 // CHECK:  ZE ---> zeCommandListClose
 // CHECK:  ZE ---> zeCommandQueueExecuteCommandLists

--- a/sycl/test/on-device/plugins/level_zero_batch_test.cpp
+++ b/sycl/test/on-device/plugins/level_zero_batch_test.cpp
@@ -86,7 +86,7 @@
 // CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB8:  ZE ---> zeCommandListClose(
 // CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKALL: ---> piEventsWait(
+// CKALL: ---> piQueueFinish(
 // CKB3:  ZE ---> zeCommandListClose(
 // CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB5:  ZE ---> zeCommandListClose(
@@ -142,7 +142,7 @@
 // CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB8:  ZE ---> zeCommandListClose(
 // CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKALL: ---> piEventsWait(
+// CKALL: ---> piQueueFinish(
 // CKB3:  ZE ---> zeCommandListClose(
 // CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB5:  ZE ---> zeCommandListClose(
@@ -198,7 +198,7 @@
 // CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB8:  ZE ---> zeCommandListClose(
 // CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKALL: ---> piEventsWait(
+// CKALL: ---> piQueueFinish(
 // CKB3:  ZE ---> zeCommandListClose(
 // CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB5:  ZE ---> zeCommandListClose(

--- a/sycl/unittests/queue/CMakeLists.txt
+++ b/sycl/unittests/queue/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_sycl_unittest(QueueTests OBJECT
   EventClear.cpp
+  Wait.cpp
 )

--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -1,0 +1,210 @@
+//==--------------------- Wait.cpp --- queue unit tests --------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+#include <detail/event_impl.hpp>
+#include <detail/scheduler/commands.hpp>
+#include <gtest/gtest.h>
+#include <helpers/PiMock.hpp>
+
+#include <memory>
+
+namespace {
+using namespace cl::sycl;
+
+struct TestCtx {
+  bool SupportOOO = true;
+  bool PiQueueFinishCalled = false;
+  int NEventsWaitedFor = 0;
+  int EventReferenceCount = 0;
+};
+static TestCtx TestContext;
+
+pi_result redefinedQueueCreate(pi_context context, pi_device device,
+                               pi_queue_properties properties,
+                               pi_queue *queue) {
+  if (!TestContext.SupportOOO &&
+      properties & PI_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) {
+    return PI_INVALID_QUEUE_PROPERTIES;
+  }
+  return PI_SUCCESS;
+}
+
+pi_result redefinedQueueRelease(pi_queue Queue) { return PI_SUCCESS; }
+
+pi_result redefinedUSMEnqueueMemset(pi_queue Queue, void *Ptr, pi_int32 Value,
+                                    size_t Count,
+                                    pi_uint32 Num_events_in_waitlist,
+                                    const pi_event *Events_waitlist,
+                                    pi_event *Event) {
+  // Provide a dummy non-nullptr value
+  TestContext.EventReferenceCount = 1;
+  *Event = reinterpret_cast<pi_event>(1);
+  return PI_SUCCESS;
+}
+pi_result redefinedEnqueueMemBufferFill(pi_queue Queue, pi_mem Buffer,
+                                        const void *Pattern, size_t PatternSize,
+                                        size_t Offset, size_t Size,
+                                        pi_uint32 NumEventsInWaitList,
+                                        const pi_event *EventWaitList,
+                                        pi_event *Event) {
+  // Provide a dummy non-nullptr value
+  TestContext.EventReferenceCount = 1;
+  *Event = reinterpret_cast<pi_event>(1);
+  return PI_SUCCESS;
+}
+
+pi_result redefinedQueueFinish(pi_queue Queue) {
+  TestContext.PiQueueFinishCalled = true;
+  return PI_SUCCESS;
+}
+pi_result redefinedEventsWait(pi_uint32 num_events,
+                              const pi_event *event_list) {
+  ++TestContext.NEventsWaitedFor;
+  return PI_SUCCESS;
+}
+
+pi_result redefinedEventGetInfo(pi_event event, pi_event_info param_name,
+                                size_t param_value_size, void *param_value,
+                                size_t *param_value_size_ret) {
+#if 0
+  EXPECT_EQ(param_name, PI_EVENT_INFO_COMMAND_EXECUTION_STATUS)
+      << "Unexpected event info requested";
+  // Report first half of events as complete.
+  // Report second half of events as running.
+  // This is important, because removal algorithm assumes that
+  // events are likely to be removed oldest first, and stops removing
+  // at the first non-completed event.
+  static int Counter = 0;
+  auto *Result = reinterpret_cast<pi_event_status *>(param_value);
+  *Result = (Counter < (ExpectedEventThreshold / 2)) ? PI_EVENT_COMPLETE
+                                                     : PI_EVENT_RUNNING;
+  Counter++;
+#endif
+  return PI_SUCCESS;
+}
+
+pi_result redefinedEventRetain(pi_event event) {
+  ++TestContext.EventReferenceCount;
+  return PI_SUCCESS;
+}
+
+pi_result redefinedEventRelease(pi_event event) {
+  --TestContext.EventReferenceCount;
+  return PI_SUCCESS;
+}
+
+bool preparePiMock(platform &Plt) {
+  if (Plt.is_host()) {
+    std::cout << "Not run on host - no PI events created in that case"
+              << std::endl;
+    return false;
+  }
+  // TODO: Skip tests for CUDA temporarily
+  if (detail::getSyclObjImpl(Plt)->getPlugin().getBackend() == backend::cuda) {
+    std::cout << "Not run on CUDA - usm is not supported for CUDA backend yet"
+              << std::endl;
+    return false;
+  }
+
+  unittest::PiMock Mock{Plt};
+  Mock.redefine<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);
+  Mock.redefine<detail::PiApiKind::piQueueRelease>(redefinedQueueRelease);
+  Mock.redefine<detail::PiApiKind::piQueueFinish>(redefinedQueueFinish);
+  Mock.redefine<detail::PiApiKind::piextUSMEnqueueMemset>(
+      redefinedUSMEnqueueMemset);
+  Mock.redefine<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
+  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferFill>(
+      redefinedEnqueueMemBufferFill);
+  Mock.redefine<detail::PiApiKind::piEventGetInfo>(redefinedEventGetInfo);
+  Mock.redefine<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
+  Mock.redefine<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
+  return true;
+}
+
+TEST(QueueWait, Finish) {
+  platform Plt{default_selector()};
+  if (!preparePiMock(Plt))
+    return;
+  context Ctx{Plt};
+  queue Q{Ctx, default_selector()};
+
+  unsigned char *HostAlloc = (unsigned char *)malloc_host(1, Ctx);
+
+  // USM API event
+  TestContext = {};
+  Q.memset(HostAlloc, 42, 1);
+  // No need to keep the event since we'll use piQueueFinish.
+  ASSERT_EQ(TestContext.EventReferenceCount, 0);
+  Q.wait();
+  ASSERT_EQ(TestContext.NEventsWaitedFor, 0);
+  ASSERT_TRUE(TestContext.PiQueueFinishCalled);
+
+  // Events with temporary ownership
+  {
+    TestContext = {};
+    buffer<int, 1> buf{range<1>(1)};
+    Q.submit([&](handler &Cgh) {
+      auto acc = buf.template get_access<access::mode::read_write>(Cgh);
+      Cgh.fill(acc, 42);
+    });
+    Q.wait();
+    // Still owned by the execution graph
+    ASSERT_EQ(TestContext.EventReferenceCount, 1);
+    ASSERT_EQ(TestContext.NEventsWaitedFor, 0);
+    ASSERT_TRUE(TestContext.PiQueueFinishCalled);
+  }
+
+  // Blocked commands
+  TestContext = {};
+  buffer<int, 1> buf{range<1>(1)};
+  event HostTaskEvent = Q.submit([&](handler &Cgh) {
+    auto acc = buf.template get_access<access::mode::read>(Cgh);
+    Cgh.host_task([=]() { (void)acc; });
+  });
+  std::shared_ptr<detail::event_impl> HostTaskEventImpl =
+      detail::getSyclObjImpl(HostTaskEvent);
+  auto *Cmd = static_cast<detail::Command *>(HostTaskEventImpl->getCommand());
+  detail::Command *EmptyTask = *Cmd->MUsers.begin();
+  ASSERT_EQ(EmptyTask->getType(), detail::Command::EMPTY_TASK);
+  HostTaskEvent.wait();
+  // Use the empty task produced by the host task to block the next commands
+  while (EmptyTask->MEnqueueStatus !=
+         detail::EnqueueResultT::SyclEnqueueSuccess)
+    continue;
+  EmptyTask->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueBlocked;
+  Q.submit([&](handler &Cgh) {
+    auto acc = buf.template get_access<access::mode::discard_write>(Cgh);
+    Cgh.fill(acc, 42);
+  });
+  Q.submit([&](handler &Cgh) {
+    auto acc = buf.template get_access<access::mode::discard_write>(Cgh);
+    Cgh.fill(acc, 42);
+  });
+  // Unblock the empty task to allow the submitted events to complete once
+  // enqueued.
+  EmptyTask->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueSuccess;
+  Q.wait();
+  // Only a single event (the last one) should be waited for here.
+  ASSERT_EQ(TestContext.NEventsWaitedFor, 1);
+  ASSERT_TRUE(TestContext.PiQueueFinishCalled);
+
+  // Test behaviour for emulating an OOO queue with multiple in-order ones.
+  TestContext = {};
+  TestContext.SupportOOO = false;
+  Q = {Ctx, default_selector()};
+  Q.memset(HostAlloc, 42, 1);
+  // The event is kept alive in this case to call wait.
+  ASSERT_EQ(TestContext.EventReferenceCount, 1);
+  Q.wait();
+  ASSERT_EQ(TestContext.EventReferenceCount, 0);
+  ASSERT_EQ(TestContext.NEventsWaitedFor, 1);
+  ASSERT_FALSE(TestContext.PiQueueFinishCalled);
+}
+
+} // namespace

--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -8,6 +8,7 @@
 
 #include <CL/sycl.hpp>
 #include <detail/event_impl.hpp>
+#include <detail/platform_impl.hpp>
 #include <detail/scheduler/commands.hpp>
 #include <gtest/gtest.h>
 #include <helpers/PiMock.hpp>
@@ -120,7 +121,12 @@ TEST(QueueWait, QueueWaitTest) {
   TestContext = {};
   Q.memset(HostAlloc, 42, 1);
   // No need to keep the event since we'll use piQueueFinish.
-  ASSERT_EQ(TestContext.EventReferenceCount, 0);
+  // FIXME ... unless the plugin is Level Zero, where there's a workaround that
+  // releases events later.
+  if (detail::getSyclObjImpl(Plt)->getPlugin().getBackend() !=
+      backend::level_zero) {
+    ASSERT_EQ(TestContext.EventReferenceCount, 0);
+  }
   Q.wait();
   ASSERT_EQ(TestContext.NEventsWaitedFor, 0);
   ASSERT_TRUE(TestContext.PiQueueFinishCalled);

--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -91,12 +91,6 @@ bool preparePiMock(platform &Plt) {
               << std::endl;
     return false;
   }
-  // TODO: Skip tests for CUDA temporarily
-  if (detail::getSyclObjImpl(Plt)->getPlugin().getBackend() == backend::cuda) {
-    std::cout << "Not run on CUDA - usm is not supported for CUDA backend yet"
-              << std::endl;
-    return false;
-  }
 
   unittest::PiMock Mock{Plt};
   Mock.redefine<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);


### PR DESCRIPTION
This patch changes the logic of queue::wait() from waiting on each
individual event in order of submission of their tasks to checking if
each event's task has been enqueued, waiting for those that haven't been
and calling piQueueFinish to take care of the rest.

Notable exceptions to this new behaviour are host queues, queues that
emulate out-of-order execution by creating multiple queues underneath
and host task events, which are run on host regardless of the queue they
are bound to.