### PR TITLE
[SYCL] Do not use current directory for JIT cache

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -37,7 +37,7 @@ subject to change. Do not rely on these variables in production code.
 | `SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING` | Any(\*) | Disables automatic rounding-up of `parallel_for` invocation ranges. |
 | `SYCL_ENABLE_PCI` | Integer | When set to 1, enables obtaining the GPU PCI address when using the Level Zero backend. The default is 0. |
 | `SYCL_HOST_UNIFIED_MEMORY` | Integer | Enforce host unified memory support or lack of it for the execution graph builder. If set to 0, it is enforced as not supported by all devices. If set to 1, it is enforced as supported by all devices. |
-| `SYCL_CACHE_DIR` | Path | Path to persistent cache root directory. Default values are `%AppData%\libsycl_cache` for Windows and `$XDG_CACHE_HOME/libsycl_cache` on Linux, if `XDG_CACHE_HOME` is not set then `$HOME/.cache/libsycl_cache`. |
+| `SYCL_CACHE_DIR` | Path | Path to persistent cache root directory. Default values are `%AppData%\libsycl_cache` for Windows and `$XDG_CACHE_HOME/libsycl_cache` on Linux, if `XDG_CACHE_HOME` is not set then `$HOME/.cache/libsycl_cache`. When none of the environment variables are set SYCL persistent cache is disabled. |
 | `SYCL_CACHE_TRACE` | Any(\*) | If the variable is set, messages are sent to std::cerr when caching events or non-blocking failures happen (e.g. unable to access cache item file). |
 | `SYCL_CACHE_DISABLE_PERSISTENT (deprecated)` | Any(\*) | Has no effect. |
 | `SYCL_CACHE_PERSISTENT` | Integer | Controls persistent device compiled code cache. Turns it on if set to '1' and turns it off if set to '0'. When cache is enabled SYCL runtime will try to cache and reuse JIT-compiled binaries. Default is off. |

--- a/sycl/doc/KernelProgramCache.md
+++ b/sycl/doc/KernelProgramCache.md
@@ -341,7 +341,9 @@ The device code image are stored on file system using structure below:
           <n>.bin
 ```
 
-- `<cache_root>` - root directory storing cache files;
+- `<cache_root>` - root directory storing cache files, that depends on
+  environment variables (see SYCL_CACHE_DIR description in the
+  [EnvironmentVariables.md](EnvironmentVariables.md));
 - `<device_hash>` - hash out of device information used to identify target
   device;
 - `<device_image_hash>` - hash made out of device image used as input for the

--- a/sycl/test/Unit/lit.cfg.py
+++ b/sycl/test/Unit/lit.cfg.py
@@ -73,5 +73,7 @@ else:
     lit_config.warning("unable to inject shared library path on '{}'"
                        .format(platform.system()))
 
+config.environment['SYCL_CACHE_DIR'] = config.llvm_obj_root + "/sycl_cache"
 config.environment['SYCL_DEVICE_FILTER'] = lit_config.params.get('SYCL_PLUGIN', "opencl") + ",host"
 lit_config.note("Backend: {}".format(config.environment['SYCL_DEVICE_FILTER']))
+lit_config.note("SYCL cache directory: {}".format(config.environment['SYCL_CACHE_DIR']))

--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -91,6 +91,8 @@ public:
       return;
     }
 
+    set_env("SYCL_CACHE_DIR", ".");
+
     Mock = std::make_unique<unittest::PiMock>(Plt);
     Dev = Plt.get_devices()[0];
     Mock->redefine<detail::PiApiKind::piProgramGetInfo>(

--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -81,6 +81,10 @@ public:
     return _putenv_s(name, value);
   }
 #endif
+  virtual void SetUp() {
+    assert(getenv("SYCL_CACHE_DIR") && "Please set SYCL_CACHE_DIR environment "
+                                       "variable pointing to cache location.");
+  }
 
   PersistenDeviceCodeCache() : Plt{default_selector()} {
 
@@ -90,8 +94,6 @@ public:
                 << Plt.get_info<info::platform::name>();
       return;
     }
-
-    set_env("SYCL_CACHE_DIR", ".");
 
     Mock = std::make_unique<unittest::PiMock>(Plt);
     Dev = Plt.get_devices()[0];

--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -251,7 +251,7 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
   // Only source file is present
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  EXPECT_EQ(!llvm::sys::fs::remove(ItemDir + "/0.bin"), true)
+  EXPECT_FALSE(llvm::sys::fs::remove(ItemDir + "/0.bin"))
       << "Failed to remove binary file";
   auto Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                                 BuildOptions);
@@ -262,7 +262,7 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
   // Only binary file is present
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  EXPECT_EQ(!llvm::sys::fs::remove(ItemDir + "/0.src"), true)
+  EXPECT_TRUE(!llvm::sys::fs::remove(ItemDir + "/0.src"))
       << "Failed to remove source file";
   Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                            BuildOptions);
@@ -280,8 +280,7 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
    */
   FileStream << 2 << 12 << "123456789012" << 23 << "1234";
   FileStream.close();
-  EXPECT_EQ(FileStream.fail(), false)
-      << "Failed to create trancated binary file";
+  EXPECT_FALSE(FileStream.fail()) << "Failed to create trancated binary file";
   Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                            BuildOptions);
   EXPECT_EQ(Res.size(), static_cast<size_t>(0))
@@ -323,10 +322,9 @@ TEST_F(PersistenDeviceCodeCache, LockFile) {
   // Create 1st cahe item
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  EXPECT_EQ(llvm::sys::fs::exists(ItemDir + "/0.bin"), true)
-      << "No file created";
+  EXPECT_TRUE(llvm::sys::fs::exists(ItemDir + "/0.bin")) << "No file created";
   std::string LockFile = ItemDir + "/0.lock";
-  EXPECT_NE(llvm::sys::fs::exists(LockFile), true) << "Cache item locked";
+  EXPECT_FALSE(llvm::sys::fs::exists(LockFile)) << "Cache item locked";
 
   // Create lock file for the 1st cache item
   { std::ofstream File{LockFile}; }
@@ -339,8 +337,7 @@ TEST_F(PersistenDeviceCodeCache, LockFile) {
   // Cache item is locked - new cache item to be created
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  EXPECT_EQ(llvm::sys::fs::exists(ItemDir + "/1.bin"), true)
-      << "No file created";
+  EXPECT_TRUE(llvm::sys::fs::exists(ItemDir + "/1.bin")) << "No file created";
 
   // Second cache item is locked, cache miss happens on read
   { std::ofstream File{ItemDir + "/1.lock"}; }
@@ -380,14 +377,12 @@ TEST_F(PersistenDeviceCodeCache, AccessDeniedForCacheDir) {
   llvm::sys::fs::remove_directories(ItemDir);
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  EXPECT_EQ(llvm::sys::fs::exists(ItemDir + "/0.bin"), true)
-      << "No file created";
+  EXPECT_TRUE(llvm::sys::fs::exists(ItemDir + "/0.bin")) << "No file created";
   llvm::sys::fs::setPermissions(ItemDir + "/0.bin", llvm::sys::fs::no_perms);
   // No access to binary file new cache item to be created
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  EXPECT_EQ(llvm::sys::fs::exists(ItemDir + "/1.bin"), true)
-      << "No file created";
+  EXPECT_TRUE(llvm::sys::fs::exists(ItemDir + "/1.bin")) << "No file created";
 
   llvm::sys::fs::setPermissions(ItemDir + "/1.bin", llvm::sys::fs::no_perms);
   auto Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},

--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -82,8 +82,9 @@ public:
   }
 #endif
   virtual void SetUp() {
-    assert(getenv("SYCL_CACHE_DIR") && "Please set SYCL_CACHE_DIR environment "
-                                       "variable pointing to cache location.");
+    EXPECT_NE(getenv("SYCL_CACHE_DIR"), nullptr)
+        << "Please set SYCL_CACHE_DIR environment variable pointing to cache "
+           "location.";
   }
 
   PersistenDeviceCodeCache() : Plt{default_selector()} {
@@ -138,8 +139,8 @@ public:
             BuildOptions);
         for (size_t i = 0; i < Res.size(); ++i) {
           for (size_t j = 0; j < Res[i].size(); ++j) {
-            assert(Res[i][j] == static_cast<char>(i) &&
-                   "Corrupted image loaded from persistent cache");
+            EXPECT_EQ(Res[i][j], static_cast<char>(i))
+                << "Corrupted image loaded from persistent cache";
           }
         }
       };
@@ -193,12 +194,13 @@ TEST_F(PersistenDeviceCodeCache, KeysWithNullTermSymbol) {
                                                    NativeProg);
   auto Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img,
                                                                 SpecConst, Key);
-  assert(Res.size() != 0 && "Failed to load cache item");
+  EXPECT_NE(Res.size(), static_cast<size_t>(0)) << "Failed to load cache item";
   for (size_t i = 0; i < Res.size(); ++i) {
-    assert(Res[i].size() != 0 && "Failed to device image");
+    EXPECT_NE(Res[i].size(), static_cast<size_t>(0))
+        << "Failed to load device image";
     for (size_t j = 0; j < Res[i].size(); ++j) {
-      assert(Res[i][j] == static_cast<char>(i) &&
-             "Corrupted image loaded from persistent cache");
+      EXPECT_EQ(Res[i][j], static_cast<unsigned char>(i))
+          << "Corrupted image loaded from persistent cache";
     }
   }
 
@@ -249,21 +251,23 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
   // Only source file is present
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  assert(!llvm::sys::fs::remove(ItemDir + "/0.bin") &&
-         "Failed to remove binary file");
+  EXPECT_EQ(!llvm::sys::fs::remove(ItemDir + "/0.bin"), true)
+      << "Failed to remove binary file";
   auto Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                                 BuildOptions);
-  assert(Res.size() == 0 && "Item with missed binary file was read");
+  EXPECT_EQ(Res.size(), static_cast<size_t>(0))
+      << "Item with missed binary file was read";
   llvm::sys::fs::remove_directories(ItemDir);
 
   // Only binary file is present
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  assert(!llvm::sys::fs::remove(ItemDir + "/0.src") &&
-         "Failed to remove source file");
+  EXPECT_EQ(!llvm::sys::fs::remove(ItemDir + "/0.src"), true)
+      << "Failed to remove source file";
   Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                            BuildOptions);
-  assert(Res.size() == 0 && "Item with missed source file was read");
+  EXPECT_EQ(Res.size(), static_cast<size_t>(0))
+      << "Item with missed source file was read";
   llvm::sys::fs::remove_directories(ItemDir);
 
   // Binary file is corrupted
@@ -276,10 +280,12 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
    */
   FileStream << 2 << 12 << "123456789012" << 23 << "1234";
   FileStream.close();
-  assert((!FileStream.fail()) && "Failed to create trancated binary file");
+  EXPECT_EQ(FileStream.fail(), false)
+      << "Failed to create trancated binary file";
   Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                            BuildOptions);
-  assert(Res.size() == 0 && "Item with corrupted binary file was read");
+  EXPECT_EQ(Res.size(), static_cast<size_t>(0))
+      << "Item with corrupted binary file was read";
 
   llvm::sys::fs::remove_directories(ItemDir);
 
@@ -292,7 +298,8 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
   }
   Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                            BuildOptions);
-  assert(Res.size() == 0 && "Item with corrupted binary file was read");
+  EXPECT_EQ(Res.size(), static_cast<size_t>(0))
+      << "Item with corrupted binary file was read";
   llvm::sys::fs::remove_directories(ItemDir);
 }
 
@@ -316,9 +323,10 @@ TEST_F(PersistenDeviceCodeCache, LockFile) {
   // Create 1st cahe item
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  assert(llvm::sys::fs::exists(ItemDir + "/0.bin") && "No file created");
+  EXPECT_EQ(llvm::sys::fs::exists(ItemDir + "/0.bin"), true)
+      << "No file created";
   std::string LockFile = ItemDir + "/0.lock";
-  assert(!llvm::sys::fs::exists(LockFile) && "Cache item locked");
+  EXPECT_NE(llvm::sys::fs::exists(LockFile), true) << "Cache item locked";
 
   // Create lock file for the 1st cache item
   { std::ofstream File{LockFile}; }
@@ -326,18 +334,20 @@ TEST_F(PersistenDeviceCodeCache, LockFile) {
   // Cache item is locked, cache miss happens on read
   auto Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                                 BuildOptions);
-  assert(Res.size() == 0 && "Locked item was read");
+  EXPECT_EQ(Res.size(), static_cast<size_t>(0)) << "Locked item was read";
 
   // Cache item is locked - new cache item to be created
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  assert(llvm::sys::fs::exists(ItemDir + "/1.bin") && "No file created");
+  EXPECT_EQ(llvm::sys::fs::exists(ItemDir + "/1.bin"), true)
+      << "No file created";
 
   // Second cache item is locked, cache miss happens on read
   { std::ofstream File{ItemDir + "/1.lock"}; }
   Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                            BuildOptions);
-  assert(Res.size() == 0 && "Locked item was read");
+
+  EXPECT_EQ(Res.size(), static_cast<size_t>(0)) << "Locked item was read";
 
   // First cache item was unlocked and successfully read
   std::remove(LockFile.c_str());
@@ -345,8 +355,8 @@ TEST_F(PersistenDeviceCodeCache, LockFile) {
                                                            BuildOptions);
   for (size_t i = 0; i < Res.size(); ++i) {
     for (size_t j = 0; j < Res[i].size(); ++j) {
-      assert(Res[i][j] == static_cast<char>(i) &&
-             "Corrupted image loaded from persistent cache");
+      EXPECT_EQ(Res[i][j], static_cast<unsigned char>(i))
+          << "Corrupted image loaded from persistent cache";
     }
   }
   llvm::sys::fs::remove_directories(ItemDir);
@@ -370,19 +380,22 @@ TEST_F(PersistenDeviceCodeCache, AccessDeniedForCacheDir) {
   llvm::sys::fs::remove_directories(ItemDir);
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  assert(llvm::sys::fs::exists(ItemDir + "/0.bin") && "No file created");
+  EXPECT_EQ(llvm::sys::fs::exists(ItemDir + "/0.bin"), true)
+      << "No file created";
   llvm::sys::fs::setPermissions(ItemDir + "/0.bin", llvm::sys::fs::no_perms);
   // No access to binary file new cache item to be created
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  assert(llvm::sys::fs::exists(ItemDir + "/1.bin") && "No file created");
+  EXPECT_EQ(llvm::sys::fs::exists(ItemDir + "/1.bin"), true)
+      << "No file created";
 
   llvm::sys::fs::setPermissions(ItemDir + "/1.bin", llvm::sys::fs::no_perms);
   auto Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                                 BuildOptions);
 
-  // No image to be read due to lack of permissions fro source file
-  assert(Res.size() == 0);
+  // No image to be read due to lack of permissions from source file
+  EXPECT_EQ(Res.size(), static_cast<size_t>(0))
+      << "Read from the file without permissions.";
 
   llvm::sys::fs::setPermissions(ItemDir + "/0.bin", llvm::sys::fs::all_perms);
   llvm::sys::fs::setPermissions(ItemDir + "/1.bin", llvm::sys::fs::all_perms);
@@ -392,8 +405,8 @@ TEST_F(PersistenDeviceCodeCache, AccessDeniedForCacheDir) {
   // Image should be successfully read
   for (size_t i = 0; i < Res.size(); ++i) {
     for (size_t j = 0; j < Res[i].size(); ++j) {
-      assert(Res[i][j] == static_cast<char>(i) &&
-             "Corrupted image loaded from persistent cache");
+      EXPECT_EQ(Res[i][j], static_cast<unsigned char>(i))
+          << "Corrupted image loaded from persistent cache";
     }
   }
   llvm::sys::fs::remove_directories(ItemDir);

--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -262,7 +262,7 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
   // Only binary file is present
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
-  EXPECT_TRUE(!llvm::sys::fs::remove(ItemDir + "/0.src"))
+  EXPECT_FALSE(llvm::sys::fs::remove(ItemDir + "/0.src"))
       << "Failed to remove source file";
   Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                            BuildOptions);


### PR DESCRIPTION
Remove storing JIT cache files to current directory when corresponding
environment variables are not set.

Complementary test change: intel/llvm-test-suite#337