### PR TITLE
[SYCL] Enable SPV_INTEL_token_type extension

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8656,6 +8656,9 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
       // lowered to CrossWorkgroup storage class that is mapped to just
       // global address space.
       ExtArg += ",+SPV_INTEL_usm_storage_classes";
+    else
+      // Don't enable several freshly added extensions on FPGA H/W
+      ExtArg += ",+SPV_INTEL_token_type";
     TranslatorArgs.push_back(TCArgs.MakeArgString(ExtArg));
   }
   for (auto I : Inputs) {

--- a/clang/test/Driver/sycl-spirv-ext.c
+++ b/clang/test/Driver/sycl-spirv-ext.c
@@ -46,7 +46,8 @@
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_variable_length_array,+SPV_INTEL_fp_fast_math_mode
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_fpga_cluster_attributes,+SPV_INTEL_loop_fuse
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_long_constant_composite
-// CHECK-DEFAULT-SAME:,+SPV_INTEL_fpga_invocation_pipelining_attributes"
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_fpga_invocation_pipelining_attributes
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_token_type"
 // CHECK-FPGA-HW: llvm-spirv{{.*}}"-spirv-ext=-all
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_add
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_min_max


### PR DESCRIPTION
Don't enable it for FPGA H/W yet.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>