### PR TITLE
[SYCL][L0] initialize properties struct .stype and .pNext

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -24,7 +24,6 @@
 #include <thread>
 #include <utility>
 
-#include <level_zero/zes_api.h>
 #include <level_zero/zet_api.h>
 
 #include "usm_allocator.hpp"
@@ -524,7 +523,7 @@ pi_result _pi_device::initialize() {
   if (numQueueGroups == 0) {
     return PI_ERROR_UNKNOWN;
   }
-  std::vector<ze_command_queue_group_properties_t> QueueProperties(
+  std::vector<ZeStruct<ze_command_queue_group_properties_t>> QueueProperties(
       numQueueGroups);
   ZE_CALL(zeDeviceGetCommandQueueGroupProperties,
           (ZeDevice, &numQueueGroups, QueueProperties.data()));
@@ -1169,7 +1168,7 @@ static bool setEnvVar(const char *name, const char *value) {
 
 pi_result _pi_platform::initialize() {
   // Cache driver properties
-  ze_driver_properties_t ZeDriverProperties;
+  ZeStruct<ze_driver_properties_t> ZeDriverProperties;
   ZE_CALL(zeDriverGetProperties, (ZeDriver, &ZeDriverProperties));
   uint32_t DriverVersion = ZeDriverProperties.driverVersion;
   // Intel Level-Zero GPU driver stores version as:
@@ -1611,16 +1610,16 @@ pi_result piDeviceGetInfo(pi_device Device, pi_device_info ParamName,
   ZE_CALL(zeDeviceGetMemoryProperties,
           (ZeDevice, &ZeAvailMemCount, ZeDeviceMemoryProperties.data()));
 
-  ze_device_image_properties_t ZeDeviceImageProperties = {};
+  ZeStruct<ze_device_image_properties_t> ZeDeviceImageProperties;
   ZE_CALL(zeDeviceGetImageProperties, (ZeDevice, &ZeDeviceImageProperties));
 
-  ze_device_module_properties_t ZeDeviceModuleProperties = {};
+  ZeStruct<ze_device_module_properties_t> ZeDeviceModuleProperties;
   ZE_CALL(zeDeviceGetModuleProperties, (ZeDevice, &ZeDeviceModuleProperties));
 
   // TODO[1.0]: there can be multiple cache properites now, adjust.
   // For now remember the first one, if any.
   uint32_t Count = 0;
-  ze_device_cache_properties_t ZeDeviceCacheProperties = {};
+  ZeStruct<ze_device_cache_properties_t> ZeDeviceCacheProperties;
   ZE_CALL(zeDeviceGetCacheProperties, (ZeDevice, &Count, nullptr));
   if (Count > 0) {
     Count = 1;
@@ -2049,7 +2048,7 @@ pi_result piDeviceGetInfo(pi_device Device, pi_device_info ParamName,
       zePrint("Set SYCL_ENABLE_PCI=1 to obtain PCI data.\n");
       return PI_INVALID_VALUE;
     }
-    zes_pci_properties_t ZeDevicePciProperties = {};
+    ZesStruct<zes_pci_properties_t> ZeDevicePciProperties;
     ZE_CALL(zesDevicePciGetProperties, (ZeDevice, &ZeDevicePciProperties));
     std::stringstream ss;
     ss << ZeDevicePciProperties.address.domain << ":"
@@ -3357,7 +3356,7 @@ static pi_result compileOrBuild(pi_program Program, pi_uint32 NumDevices,
   // Check if this module imports any symbols, which we need to know if we
   // end up linking this module later.  See comments in piProgramLink() for
   // details.
-  ze_module_properties_t ZeModuleProps;
+  ZeStruct<ze_module_properties_t> ZeModuleProps;
   ZE_CALL(zeModuleGetPropertiesMock, (ZeModule, &ZeModuleProps));
   Program->HasImports = (ZeModuleProps.flags & ZE_MODULE_PROPERTY_FLAG_IMPORTS);
 
@@ -3708,7 +3707,7 @@ pi_result piKernelGetInfo(pi_kernel Kernel, pi_kernel_info ParamName,
                           size_t *ParamValueSizeRet) {
   PI_ASSERT(Kernel, PI_INVALID_KERNEL);
 
-  ze_kernel_properties_t ZeKernelProperties = {};
+  ZeStruct<ze_kernel_properties_t> ZeKernelProperties;
   ZE_CALL(zeKernelGetProperties, (Kernel->ZeKernel, &ZeKernelProperties));
 
   ReturnHelper ReturnValue(ParamValueSize, ParamValue, ParamValueSizeRet);
@@ -3767,10 +3766,10 @@ pi_result piKernelGetGroupInfo(pi_kernel Kernel, pi_device Device,
   PI_ASSERT(Device, PI_INVALID_DEVICE);
 
   ze_device_handle_t ZeDevice = Device->ZeDevice;
-  ze_device_compute_properties_t ZeDeviceComputeProperties = {};
+  ZeStruct<ze_device_compute_properties_t> ZeDeviceComputeProperties;
   ZE_CALL(zeDeviceGetComputeProperties, (ZeDevice, &ZeDeviceComputeProperties));
 
-  ze_kernel_properties_t ZeKernelProperties = {};
+  ZeStruct<ze_kernel_properties_t> ZeKernelProperties;
   ZE_CALL(zeKernelGetProperties, (Kernel->ZeKernel, &ZeKernelProperties));
 
   ReturnHelper ReturnValue(ParamValueSize, ParamValue, ParamValueSizeRet);
@@ -3801,7 +3800,7 @@ pi_result piKernelGetGroupInfo(pi_kernel Kernel, pi_device Device,
   case PI_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE:
     return ReturnValue(pi_uint32{ZeKernelProperties.localMemSize});
   case PI_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {
-    ze_device_properties_t ZeDeviceProperties = {};
+    ZeStruct<ze_device_properties_t> ZeDeviceProperties;
     ZE_CALL(zeDeviceGetProperties, (ZeDevice, &ZeDeviceProperties));
 
     return ReturnValue(size_t{ZeDeviceProperties.physicalEUSimdWidth});
@@ -3825,7 +3824,7 @@ pi_result piKernelGetSubGroupInfo(pi_kernel Kernel, pi_device Device,
   (void)InputValueSize;
   (void)InputValue;
 
-  ze_kernel_properties_t ZeKernelProperties;
+  ZeStruct<ze_kernel_properties_t> ZeKernelProperties;
   ZE_CALL(zeKernelGetProperties, (Kernel->ZeKernel, &ZeKernelProperties));
 
   ReturnHelper ReturnValue(ParamValueSize, ParamValue, ParamValueSizeRet);
@@ -6052,7 +6051,7 @@ static pi_result USMFreeHelper(pi_context Context, void *Ptr) {
 
   // Query the device of the allocation to determine the right allocator context
   ze_device_handle_t ZeDeviceHandle;
-  ze_memory_allocation_properties_t ZeMemoryAllocationProperties = {};
+  ZeStruct<ze_memory_allocation_properties_t> ZeMemoryAllocationProperties;
 
   // Query memory type of the pointer we're freeing to determine the correct
   // way to do it(directly or via an allocator)
@@ -6166,7 +6165,7 @@ pi_result piextUSMEnqueueMemset(pi_queue Queue, void *Ptr, pi_int32 Value,
 // Helper function to check if a pointer is a device pointer.
 static bool IsDevicePointer(pi_context Context, const void *Ptr) {
   ze_device_handle_t ZeDeviceHandle;
-  ze_memory_allocation_properties_t ZeMemoryAllocationProperties = {};
+  ZeStruct<ze_memory_allocation_properties_t> ZeMemoryAllocationProperties;
 
   // Query memory type of the pointer
   ZE_CALL(zeMemGetAllocProperties,
@@ -6346,7 +6345,7 @@ pi_result piextUSMGetMemAllocInfo(pi_context Context, const void *Ptr,
   PI_ASSERT(Context, PI_INVALID_CONTEXT);
 
   ze_device_handle_t ZeDeviceHandle;
-  ze_memory_allocation_properties_t ZeMemoryAllocationProperties = {};
+  ZeStruct<ze_memory_allocation_properties_t> ZeMemoryAllocationProperties;
 
   ZE_CALL(zeMemGetAllocProperties,
           (Context->ZeContext, Ptr, &ZeMemoryAllocationProperties,

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
 
 #include "usm_allocator.hpp"
 
@@ -58,6 +59,7 @@ template <> uint32_t pi_cast(uint64_t Value) {
 // Returns the ze_structure_type_t to use in .stype of a structured descriptor.
 // Intentionally not defined; will give an error if no proper specialization
 template <class T> ze_structure_type_t getZeStructureType();
+template <class T> zes_structure_type_t getZesStructureType();
 
 template <> ze_structure_type_t getZeStructureType<ze_event_pool_desc_t>() {
   return ZE_STRUCTURE_TYPE_EVENT_POOL_DESC;
@@ -101,12 +103,58 @@ template <> ze_structure_type_t getZeStructureType<ze_event_desc_t>() {
 template <> ze_structure_type_t getZeStructureType<ze_sampler_desc_t>() {
   return ZE_STRUCTURE_TYPE_SAMPLER_DESC;
 }
+template <> ze_structure_type_t getZeStructureType<ze_driver_properties_t>() {
+  return ZE_STRUCTURE_TYPE_DRIVER_PROPERTIES;
+}
+template <> ze_structure_type_t getZeStructureType<ze_device_properties_t>() {
+  return ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+}
+template <>
+ze_structure_type_t getZeStructureType<ze_device_compute_properties_t>() {
+  return ZE_STRUCTURE_TYPE_DEVICE_COMPUTE_PROPERTIES;
+}
+template <>
+ze_structure_type_t getZeStructureType<ze_command_queue_group_properties_t>() {
+  return ZE_STRUCTURE_TYPE_COMMAND_QUEUE_GROUP_PROPERTIES;
+}
+template <>
+ze_structure_type_t getZeStructureType<ze_device_image_properties_t>() {
+  return ZE_STRUCTURE_TYPE_DEVICE_IMAGE_PROPERTIES;
+}
+template <>
+ze_structure_type_t getZeStructureType<ze_device_module_properties_t>() {
+  return ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
+}
+template <>
+ze_structure_type_t getZeStructureType<ze_device_cache_properties_t>() {
+  return ZE_STRUCTURE_TYPE_DEVICE_CACHE_PROPERTIES;
+}
+template <> ze_structure_type_t getZeStructureType<ze_module_properties_t>() {
+  return ZE_STRUCTURE_TYPE_MODULE_PROPERTIES;
+}
+template <> ze_structure_type_t getZeStructureType<ze_kernel_properties_t>() {
+  return ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES;
+}
+template <>
+ze_structure_type_t getZeStructureType<ze_memory_allocation_properties_t>() {
+  return ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+}
 
-// The helper struct to properly default initialize Level-Zero descriptor
-// structure.
+template <> zes_structure_type_t getZesStructureType<zes_pci_properties_t>() {
+  return ZES_STRUCTURE_TYPE_PCI_PROPERTIES;
+}
+
+// The helpers to properly default initialize Level-Zero descriptor and
+// properties structures.
 template <class T> struct ZeStruct : public T {
-  ZeStruct() {
+  ZeStruct() { // default initializes base class
     this->stype = getZeStructureType<T>();
+    this->pNext = nullptr;
+  }
+};
+template <class T> struct ZesStruct : public T {
+  ZesStruct() { // default initializes base class
+    this->stype = getZesStructureType<T>();
     this->pNext = nullptr;
   }
 };
@@ -244,8 +292,8 @@ struct _pi_device : _pi_object {
   int32_t ZeCopyQueueGroupIndex;
 
   // Cache the properties of the compute/copy queue groups.
-  ze_command_queue_group_properties_t ZeComputeQueueGroupProperties = {};
-  ze_command_queue_group_properties_t ZeCopyQueueGroupProperties = {};
+  ZeStruct<ze_command_queue_group_properties_t> ZeComputeQueueGroupProperties;
+  ZeStruct<ze_command_queue_group_properties_t> ZeCopyQueueGroupProperties;
 
   // This returns "true" if a copy engine is available for use.
   bool hasCopyEngine() const { return ZeCopyQueueGroupIndex >= 0; }
@@ -270,8 +318,8 @@ struct _pi_device : _pi_object {
   bool isSubDevice() { return RootDevice != nullptr; }
 
   // Cache of the immutable device properties.
-  ze_device_properties_t ZeDeviceProperties;
-  ze_device_compute_properties_t ZeDeviceComputeProperties;
+  ZeStruct<ze_device_properties_t> ZeDeviceProperties;
+  ZeStruct<ze_device_compute_properties_t> ZeDeviceComputeProperties;
 };
 
 struct _pi_context : _pi_object {

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -153,7 +153,7 @@ template <class T> struct ZeStruct : public T {
   }
 };
 template <class T> struct ZesStruct : public T {
-  ZesStruct() : T{}  { // zero initializes base struct
+  ZesStruct() : T{} { // zero initializes base struct
     this->stype = getZesStructureType<T>();
     this->pNext = nullptr;
   }

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -147,13 +147,13 @@ template <> zes_structure_type_t getZesStructureType<zes_pci_properties_t>() {
 // The helpers to properly default initialize Level-Zero descriptor and
 // properties structures.
 template <class T> struct ZeStruct : public T {
-  ZeStruct() { // default initializes base class
+  ZeStruct() : T{} { // zero initializes base struct
     this->stype = getZeStructureType<T>();
     this->pNext = nullptr;
   }
 };
 template <class T> struct ZesStruct : public T {
-  ZesStruct() { // default initializes base class
+  ZesStruct() : T{}  { // zero initializes base struct
     this->stype = getZesStructureType<T>();
     this->pNext = nullptr;
   }


### PR DESCRIPTION
Counterpart of https://github.com/intel/llvm/pull/4032.
Initializes `properties_t` structures in addition to `desc_t` ones.

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>