### PR TITLE
[SYCL] Store version in CGAdviseUSM to enable extended members

### DIFF
--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -423,13 +423,13 @@ class CGAdviseUSM : public CG {
 
 public:
   CGAdviseUSM(void *DstPtr, size_t Length,
-              vector_class<vector_class<char>> ArgsStorage,
-              vector_class<detail::AccessorImplPtr> AccStorage,
-              vector_class<shared_ptr_class<const void>> SharedPtrStorage,
-              vector_class<Requirement *> Requirements,
-              vector_class<detail::EventImplPtr> Events,
+              std::vector<std::vector<char>> ArgsStorage,
+              std::vector<detail::AccessorImplPtr> AccStorage,
+              std::vector<std::shared_ptr<const void>> SharedPtrStorage,
+              std::vector<Requirement *> Requirements,
+              std::vector<detail::EventImplPtr> Events, CGTYPE Type,
               detail::code_location loc = {})
-      : CG(ADVISE_USM, std::move(ArgsStorage), std::move(AccStorage),
+      : CG(Type, std::move(ArgsStorage), std::move(AccStorage),
            std::move(SharedPtrStorage), std::move(Requirements),
            std::move(Events), std::move(loc)),
         MDst(DstPtr), MLength(Length) {}

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -192,7 +192,7 @@ event handler::finalize() {
     CommandGroup.reset(new detail::CGAdviseUSM(
         MDstPtr, MLength, std::move(MArgsStorage), std::move(MAccStorage),
         std::move(MSharedPtrStorage), std::move(MRequirements),
-        std::move(MEvents), MCodeLoc));
+        std::move(MEvents), MCGType, MCodeLoc));
     break;
   case detail::CG::CODEPLAY_HOST_TASK:
     CommandGroup.reset(new detail::CGHostTask(
@@ -488,7 +488,7 @@ void handler::memcpy(void *Dest, const void *Src, size_t Count) {
   MSrcPtr = const_cast<void *>(Src);
   MDstPtr = Dest;
   MLength = Count;
-  MCGType = detail::CG::COPY_USM;
+  setType(detail::CG::COPY_USM);
 }
 
 void handler::memset(void *Dest, int Value, size_t Count) {
@@ -496,21 +496,21 @@ void handler::memset(void *Dest, int Value, size_t Count) {
   MDstPtr = Dest;
   MPattern.push_back(static_cast<char>(Value));
   MLength = Count;
-  MCGType = detail::CG::FILL_USM;
+  setType(detail::CG::FILL_USM);
 }
 
 void handler::prefetch(const void *Ptr, size_t Count) {
   throwIfActionIsCreated();
   MDstPtr = const_cast<void *>(Ptr);
   MLength = Count;
-  MCGType = detail::CG::PREFETCH_USM;
+  setType(detail::CG::PREFETCH_USM);
 }
 
 void handler::mem_advise(const void *Ptr, size_t Count, pi_mem_advice Advice) {
   throwIfActionIsCreated();
   MDstPtr = const_cast<void *>(Ptr);
   MLength = Count;
-  MCGType = detail::CG::ADVISE_USM;
+  setType(detail::CG::ADVISE_USM);
 
   assert(!MSharedPtrStorage.empty());
 


### PR DESCRIPTION
- In CGAdviseUSM, accept versioned type instead of hard-coding non-versioned ADVISE_USM.
- In handler, use setType to encode version and pass the versioned type to CGAdviseUSM.