### PR TITLE
[SYCL] Don't emit #include's for int-footer if it is empty.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4967,9 +4967,8 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
   Policy.SuppressTypedefs = true;
   Policy.SuppressUnwrittenScope = true;
 
-  OS << "#include <CL/sycl/detail/defines_elementary.hpp>\n";
-
   llvm::SmallSet<const VarDecl *, 8> VisitedSpecConstants;
+  bool EmittedFirstSpecConstant = false;
 
   // Used to uniquely name the 'shim's as we generate the names in each
   // anonymous namespace.
@@ -4985,6 +4984,12 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
     // Skip if we've already visited this.
     if (llvm::find(VisitedSpecConstants, VD) != VisitedSpecConstants.end())
       continue;
+
+    // We only want to emit the #includes if we have a spec-constant that needs
+    // them, so emit this one on the first time through the loop.
+    if (!EmittedFirstSpecConstant)
+      OS << "#include <CL/sycl/detail/defines_elementary.hpp>\n";
+    EmittedFirstSpecConstant = true;
 
     VisitedSpecConstants.insert(VD);
     std::string TopShim = EmitSpecIdShims(OS, ShimCounter, Policy, VD);
@@ -5011,7 +5016,8 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
     OS << "} // __SYCL_INLINE_NAMESPACE(cl)\n";
   }
 
-  OS << "#include <CL/sycl/detail/spec_const_integration.hpp>\n";
+  if (EmittedFirstSpecConstant)
+    OS << "#include <CL/sycl/detail/spec_const_integration.hpp>\n";
 
   return true;
 }

--- a/clang/test/CodeGenSYCL/empty-integration-footer.cpp
+++ b/clang/test/CodeGenSYCL/empty-integration-footer.cpp
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown-sycldevice -fsycl-int-footer=%t.h %s -emit-llvm -o %t.ll
+// RUN: FileCheck -input-file=%t.h %s --allow-empty
+
+// CHECK-NOT: #include <CL/sycl/detail/defines_elementary.hpp>
+// CHECK-NOT: #include <CL/sycl/detail/spec_const_integration.hpp>


### PR DESCRIPTION
This apparently causes some self-build issues and some potential
regressions, so it is useful to make sure that includes don't happen
unless we really need them.