### PR TITLE
[SYCL][ROCm] Fix kernel launch with multiple dimensions

### DIFF
--- a/sycl/plugins/rocm/pi_rocm.cpp
+++ b/sycl/plugins/rocm/pi_rocm.cpp
@@ -2408,7 +2408,8 @@ pi_result rocm_piEnqueueKernelLaunch(
     }
 
     retError = PI_CHECK_ERROR(hipModuleLaunchKernel(
-        hipFunc, blocksPerGrid[0], 1, 1, threadsPerBlock[0], 1, 1,
+        hipFunc, blocksPerGrid[0], blocksPerGrid[1], blocksPerGrid[2],
+        threadsPerBlock[0], threadsPerBlock[1], threadsPerBlock[2],
         kernel->get_local_size(), hipStream, argIndices.data(), nullptr));
 
     kernel->clear_local_size();


### PR DESCRIPTION
I'm not sure why these were left to `1` but this patch fixes some of the tests in [oneAPI-DirectProgramming
](https://github.com/zjin-lcf/oneAPI-DirectProgramming), such as the matrix multiply and mandelbrot samples.

With this patch the samples are now giving correct results on both AMD GPU, and on Nvidia GPU with the ROCm backend (using https://github.com/intel/llvm/pull/4049).