### PR TITLE
[SYCL][NFC] Enable EventClear test with CUDA plugin

### DIFF
--- a/sycl/unittests/queue/EventClear.cpp
+++ b/sycl/unittests/queue/EventClear.cpp
@@ -88,12 +88,6 @@ bool preparePiMock(platform &Plt) {
               << std::endl;
     return false;
   }
-  // TODO: Skip tests for CUDA temporarily
-  if (detail::getSyclObjImpl(Plt)->getPlugin().getBackend() == backend::cuda) {
-    std::cout << "Not run on CUDA - usm is not supported for CUDA backend yet"
-              << std::endl;
-    return false;
-  }
 
   unittest::PiMock Mock{Plt};
   Mock.redefine<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);


### PR DESCRIPTION
The test was disabled due to unsupported USM.