### PR TITLE
[SYCL][Driver] Do not pass -fopenmp-simd to device compilations

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6176,9 +6176,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // semantic analysis, etc.
       break;
     }
-  } else {
+  } else if (!JA.isDeviceOffloading(Action::OFK_SYCL)) {
     Args.AddLastArg(CmdArgs, options::OPT_fopenmp_simd,
                     options::OPT_fno_openmp_simd);
+    Args.AddAllArgs(CmdArgs, options::OPT_fopenmp_version_EQ);
+  } else {
     Args.AddAllArgs(CmdArgs, options::OPT_fopenmp_version_EQ);
   }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6176,11 +6176,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // semantic analysis, etc.
       break;
     }
-  } else if (!JA.isDeviceOffloading(Action::OFK_SYCL)) {
-    Args.AddLastArg(CmdArgs, options::OPT_fopenmp_simd,
-                    options::OPT_fno_openmp_simd);
-    Args.AddAllArgs(CmdArgs, options::OPT_fopenmp_version_EQ);
   } else {
+    if (!JA.isDeviceOffloading(Action::OFK_SYCL))
+      Args.AddLastArg(CmdArgs, options::OPT_fopenmp_simd,
+                      options::OPT_fno_openmp_simd);
     Args.AddAllArgs(CmdArgs, options::OPT_fopenmp_version_EQ);
   }
 

--- a/clang/test/Driver/openmp-simd-sycl-device.c
+++ b/clang/test/Driver/openmp-simd-sycl-device.c
@@ -1,0 +1,14 @@
+/// Check that -fopenmp-simd is NOT passed to the device compilation when
+/// used together with -fsycl.
+
+// REQUIRES: clang-driver
+
+// RUN: %clang -c -fsycl -fopenmp-simd -### %s 2>&1 | FileCheck %s
+// RUN: %clang -c -fopenmp-simd -fopenmp-version=50 -### %s 2>&1 | FileCheck %s --check-prefix=UNCHANGED
+
+// CHECK-NOT: "-triple" "spir64"{{.*}} "-fsycl-is-device"{{.*}} "-target=spir64"{{.*}} "-fopenmp-simd"{{.*}} "-fopenmp-version=50"
+// CHECK: "-triple"{{.*}} "-fsycl-is-host"{{.*}} "-fopenmp-simd"{{.*}}
+
+// UNCHANGED: "-triple"{{.*}} "-fopenmp-simd"{{.*}} "-fopenmp-version=50"{{.*}}
+
+void foo(long double) {}


### PR DESCRIPTION
When -fopenmp-simd is used in conjunction with -fsycl, device
compilation should not be passed -fopenmp-simd.   Otherwise, it
leads to some common cases not being able to be compiled
(such as the definition of a function with a long double parameter).
This is already done for other openmp options.