### PR TITLE
[SYCL] Add basic verification for accessor type

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11443,9 +11443,13 @@ def err_sycl_compiletime_property_duplication : Error<
   "can't apply %0 property twice to the same accessor">;
 def err_sycl_invalid_property_list_param_number : Error<
   "%0 must have exactly one template parameter">;
-def err_sycl_invalid_accessor_property_template_param : Error<
-  "sixth template parameter of the accessor must be of accessor_property_list "
-  "type">;
+def err_sycl_invalid_accessor_template_param_number : Error<
+  "accessor class template must have atleast five template parameters">;
+def err_sycl_invalid_accessor_template_param : Error<
+  "%select{second|third|fourth|fifth|sixth}0 "
+  "template parameter of the accessor class template must be of "
+  "%select{integer|access::mode enum|access::target enum"
+          "|access::placeholder enum|accessor_property_list}1 type">;
 def err_sycl_invalid_accessor_property_list_template_param : Error<
   "%select{accessor_property_list|accessor_property_list pack argument|buffer_location}0 "
   "template parameter must be a "

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -99,7 +99,7 @@ struct DeviceValueType<dataT, access::target::local> {
   using type = __attribute__((opencl_local)) dataT;
 };
 
-template <typename dataT, int dimensions, access::mode accessmode,
+template <typename dataT, int dimensions = 1, access::mode accessmode = access::mode::read_write,
           access::target accessTarget = access::target::global_buffer,
           access::placeholder isPlaceholder = access::placeholder::false_t,
           typename propertyListT = ONEAPI::accessor_property_list<>>

--- a/clang/test/SemaSYCL/accessor-format.cpp
+++ b/clang/test/SemaSYCL/accessor-format.cpp
@@ -1,0 +1,93 @@
+// RUN: %clang_cc1 -fsycl-is-device -verify -DVALID_ACCESSOR %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -DTOO_FEW_PARAM %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -DINV_PARAM_TYPE %s
+
+// Test which verifies that incorrect accessor format, in rogue
+// libraries, does not cause the compiler to crash.
+
+namespace cl {
+namespace sycl {
+namespace access {
+
+enum class target {
+  global_buffer = 2014,
+  constant_buffer,
+  local,
+  image,
+  host_buffer,
+  host_image,
+  image_array
+};
+
+enum class mode {
+  read = 1024,
+  write,
+  read_write,
+  discard_write,
+  discard_read_write,
+  atomic
+};
+
+enum class placeholder { false_t,
+                         true_t };
+} // namespace access
+
+#ifdef VALID_ACCESSOR
+template <typename DataT, int dimensions = 1,
+          access::mode AccessMode = access::mode::read_write,
+          access::target AccessTarget = access::target::global_buffer,
+          access::placeholder IsPlaceholder = access::placeholder::false_t>
+#elif TOO_FEW_PARAM
+template <typename DataT,
+          access::mode AccessMode = access::mode::read_write,
+          access::target AccessTarget = access::target::global_buffer,
+          access::placeholder IsPlaceholder = access::placeholder::false_t>
+#elif INV_PARAM_TYPE
+template <typename DataT, typename dimensions = int,
+          typename InvalidAccessModeType = int,
+          int InvalidTargetType = 0,
+          char InvalidTargetTypePlaceHolderType = 'T'>
+#endif
+class accessor {
+public:
+  void use() const {}
+
+private:
+  void __init() {}
+};
+
+} // namespace sycl
+} // namespace cl
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+
+#ifdef VALID_ACCESSOR
+  cl::sycl::accessor<int> AccessorValid;
+  cl::sycl::accessor<int, 1, 1024> AccessorValidLibInvalidUserCode; // expected-error{{value of type 'int' is not implicitly convertible to 'access::mode'}}
+  kernel_single_task<class fake_kernel>([=]() {
+    AccessorValid.use();
+  });
+#elif TOO_FEW_PARAM
+  // expected-error@#TooFewParam{{accessor class template must have atleast five template parameters}}
+  cl::sycl::accessor<int> AccessorInvalid;
+  kernel_single_task<class fake_kernel>([=]() {
+    AccessorInvalid.use(); // #TooFewParam
+  });
+#elif INV_PARAM_TYPE
+  // expected-error@#InvalidTypes{{second template parameter of the accessor class template must be of integer type}}
+  // expected-error@#InvalidTypes{{third template parameter of the accessor class template must be of access::mode enum type}}
+  // expected-error@#InvalidTypes{{fourth template parameter of the accessor class template must be of access::target enum type}}
+  // expected-error@#InvalidTypes{{fifth template parameter of the accessor class template must be of access::placeholder enum type}}
+  cl::sycl::accessor<int> AccessorInvalid;
+  kernel_single_task<class fake_kernel>([=]() {
+    AccessorInvalid.use(); // #InvalidTypes
+  });
+#endif
+
+  return 0;
+}

--- a/clang/test/SemaSYCL/buffer_location.cpp
+++ b/clang/test/SemaSYCL/buffer_location.cpp
@@ -73,22 +73,29 @@ int main() {
                          buffer_location<2>>>
       accessorF;
 #endif
+
+#ifndef TRIGGER_ERROR
   cl::sycl::kernel_single_task<class kernel_function>(
       [=]() {
-#ifndef TRIGGER_ERROR
         // expected-no-diagnostics
         Obj.use();
         accessorA.use();
         accessorB.use();
         accessorC.use();
+      });
 #else
+  cl::sycl::kernel_single_task<class invalid_accessor_one>(
+      [=]() {
         //expected-error@+1{{buffer_location template parameter must be a non-negative integer}}
         accessorD.use();
-        //expected-error@+1{{sixth template parameter of the accessor must be of accessor_property_list type}}
+        // expected-error@+1{{sixth template parameter of the accessor class template must be of accessor_property_list type}}
         accessorE.use();
+      });
+  cl::sycl::kernel_single_task<class invalid_accessor_two>(
+      [=]() {
         //expected-error@+1{{can't apply buffer_location property twice to the same accessor}}
         accessorF.use();
-#endif
       });
+#endif
   return 0;
 }


### PR DESCRIPTION
When processing accessors, we use the template parameters to make
various assumptions. It is important to ensure these parameters are
defined as expected, to prevent the compiler from crashing due to a
rogue library implementation. This patch adds basic diagnostics for
this purpose.

As a drive-by, the patch also corrects a bug in the compiler, to set
kernel function as invalid if an error has been thrown while
checking accessors.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>