### PR TITLE
[SYCL][CUDA] Skip PiCudaTests when running other plugins

### DIFF
--- a/sycl/unittests/pi/TestGetPlugin.hpp
+++ b/sycl/unittests/pi/TestGetPlugin.hpp
@@ -10,7 +10,7 @@
 #include <functional>
 
 namespace pi {
-inline cl::sycl::detail::plugin initializeAndGet(cl::sycl::backend backend) {
+inline cl::sycl::detail::plugin *initializeAndGet(cl::sycl::backend backend) {
   auto plugins = cl::sycl::detail::pi::initialize();
   auto it = std::find_if(plugins.begin(), plugins.end(),
                          [=](cl::sycl::detail::plugin p) -> bool {
@@ -19,9 +19,10 @@ inline cl::sycl::detail::plugin initializeAndGet(cl::sycl::backend backend) {
   if (it == plugins.end()) {
     std::string msg = GetBackendString(backend);
     msg += " PI plugin not found!";
-    throw std::runtime_error(msg);
+    std::cerr << "Warning: " << msg << " Tests using it will be skipped.\n";
+    return nullptr;
   }
-  return *it;
+  return &*it;
 }
 
 inline std::vector<cl::sycl::detail::plugin> initializeAndRemoveInvalid() {

--- a/sycl/unittests/pi/cuda/test_base_objects.cpp
+++ b/sycl/unittests/pi/cuda/test_base_objects.cpp
@@ -24,7 +24,14 @@ using namespace cl::sycl;
 
 class CudaBaseObjectsTest : public ::testing::Test {
 protected:
-  detail::plugin plugin = pi::initializeAndGet(backend::cuda);
+  detail::plugin *plugin = pi::initializeAndGet(backend::cuda);
+
+  void SetUp() override {
+    // skip the tests if the CUDA backend is not available
+    if (!plugin) {
+      GTEST_SKIP();
+    }
+  }
 
   CudaBaseObjectsTest() = default;
 
@@ -35,14 +42,14 @@ TEST_F(CudaBaseObjectsTest, piContextCreate) {
   pi_uint32 numPlatforms = 0;
   pi_platform platform = nullptr;
   pi_device device;
-  ASSERT_EQ(plugin.getBackend(), backend::cuda);
+  ASSERT_EQ(plugin->getBackend(), backend::cuda);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                 0, nullptr, &numPlatforms)),
             PI_SUCCESS)
       << "piPlatformsGet failed.\n";
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                 numPlatforms, &platform, nullptr)),
             PI_SUCCESS)
       << "piPlatformsGet failed.\n";
@@ -50,13 +57,13 @@ TEST_F(CudaBaseObjectsTest, piContextCreate) {
   ASSERT_GE(numPlatforms, 1u);
   ASSERT_NE(platform, nullptr);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piDevicesGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
                 platform, PI_DEVICE_TYPE_GPU, 1, &device, nullptr)),
             PI_SUCCESS)
       << "piDevicesGet failed.\n";
 
   pi_context ctxt = nullptr;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
                 nullptr, 1, &device, nullptr, nullptr, &ctxt)),
             PI_SUCCESS)
       << "piContextCreate failed.\n";
@@ -79,24 +86,24 @@ TEST_F(CudaBaseObjectsTest, piContextCreatePrimaryTrue) {
   pi_platform platform;
   pi_device device;
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                 0, nullptr, &numPlatforms)),
             PI_SUCCESS)
       << "piPlatformsGet failed.\n";
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                 numPlatforms, &platform, nullptr)),
             PI_SUCCESS)
       << "piPlatformsGet failed.\n";
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piDevicesGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
                 platform, PI_DEVICE_TYPE_GPU, 1, &device, nullptr)),
             PI_SUCCESS);
   pi_context_properties properties[] = {
       __SYCL_PI_CONTEXT_PROPERTIES_CUDA_PRIMARY, PI_TRUE, 0};
 
   pi_context ctxt;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
                 properties, 1, &device, nullptr, nullptr, &ctxt)),
             PI_SUCCESS);
   EXPECT_NE(ctxt, nullptr);
@@ -115,7 +122,7 @@ TEST_F(CudaBaseObjectsTest, piContextCreatePrimaryTrue) {
   cuErr = cuCtxGetCurrent(&current);
   ASSERT_EQ(cuErr, CUDA_SUCCESS);
   ASSERT_EQ(current, cudaContext);
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextRelease>(ctxt)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextRelease>(ctxt)),
             PI_SUCCESS);
 }
 
@@ -124,24 +131,24 @@ TEST_F(CudaBaseObjectsTest, piContextCreatePrimaryFalse) {
   pi_platform platform;
   pi_device device;
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                 0, nullptr, &numPlatforms)),
             PI_SUCCESS)
       << "piPlatformsGet failed.\n";
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                 numPlatforms, &platform, nullptr)),
             PI_SUCCESS)
       << "piPlatformsGet failed.\n";
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piDevicesGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
                 platform, PI_DEVICE_TYPE_GPU, 1, &device, nullptr)),
             PI_SUCCESS);
   pi_context_properties properties[] = {
       __SYCL_PI_CONTEXT_PROPERTIES_CUDA_PRIMARY, PI_FALSE, 0};
 
   pi_context ctxt;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
                 properties, 1, &device, nullptr, nullptr, &ctxt)),
             PI_SUCCESS);
   EXPECT_NE(ctxt, nullptr);
@@ -160,7 +167,7 @@ TEST_F(CudaBaseObjectsTest, piContextCreatePrimaryFalse) {
   cuErr = cuCtxGetCurrent(&current);
   ASSERT_EQ(cuErr, CUDA_SUCCESS);
   ASSERT_EQ(current, cudaContext);
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextRelease>(ctxt)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextRelease>(ctxt)),
             PI_SUCCESS);
 }
 
@@ -169,22 +176,22 @@ TEST_F(CudaBaseObjectsTest, piContextCreateChildThread) {
   pi_platform platform;
   pi_device device;
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                 0, nullptr, &numPlatforms)),
             PI_SUCCESS)
       << "piPlatformsGet failed.\n";
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                 numPlatforms, &platform, nullptr)),
             PI_SUCCESS)
       << "piPlatformsGet failed.\n";
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piDevicesGet>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
                 platform, PI_DEVICE_TYPE_GPU, 1, &device, nullptr)),
             PI_SUCCESS);
 
   pi_context ctxt;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
                 nullptr, 1, &device, nullptr, nullptr, &ctxt)),
             PI_SUCCESS);
   EXPECT_NE(ctxt, nullptr);
@@ -215,6 +222,6 @@ TEST_F(CudaBaseObjectsTest, piContextCreateChildThread) {
 
   callContextFromOtherThread.join();
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextRelease>(ctxt)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextRelease>(ctxt)),
             PI_SUCCESS);
 }

--- a/sycl/unittests/pi/cuda/test_commands.cpp
+++ b/sycl/unittests/pi/cuda/test_commands.cpp
@@ -21,7 +21,7 @@ using namespace cl::sycl;
 struct CudaCommandsTest : public ::testing::Test {
 
 protected:
-  detail::plugin plugin = pi::initializeAndGet(backend::cuda);
+  detail::plugin *plugin = pi::initializeAndGet(backend::cuda);
 
   pi_platform platform_;
   pi_device device_;
@@ -29,29 +29,34 @@ protected:
   pi_queue queue_;
 
   void SetUp() override {
+    // skip the tests if the CUDA backend is not available
+    if (!plugin) {
+      GTEST_SKIP();
+    }
+
     cuCtxSetCurrent(nullptr);
     pi_uint32 numPlatforms = 0;
-    ASSERT_EQ(plugin.getBackend(), backend::cuda);
+    ASSERT_EQ(plugin->getBackend(), backend::cuda);
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                   0, nullptr, &numPlatforms)),
               PI_SUCCESS)
         << "piPlatformsGet failed.\n";
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                   numPlatforms, &platform_, nullptr)),
               PI_SUCCESS)
         << "piPlatformsGet failed.\n";
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piDevicesGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
                   platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
               PI_SUCCESS);
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextCreate>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
                   nullptr, 1, &device_, nullptr, nullptr, &context_)),
               PI_SUCCESS);
     ASSERT_NE(context_, nullptr);
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueCreate>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
                   context_, device_, 0, &queue_)),
               PI_SUCCESS);
     ASSERT_NE(queue_, nullptr);
@@ -60,8 +65,10 @@ protected:
   }
 
   void TearDown() override {
-    plugin.call<detail::PiApiKind::piQueueRelease>(queue_);
-    plugin.call<detail::PiApiKind::piContextRelease>(context_);
+    if (plugin) {
+      plugin->call<detail::PiApiKind::piQueueRelease>(queue_);
+      plugin->call<detail::PiApiKind::piContextRelease>(context_);
+    }
   }
 
   CudaCommandsTest() = default;
@@ -77,15 +84,15 @@ TEST_F(CudaCommandsTest, PIEnqueueReadBufferBlocking) {
 
   pi_mem memObj;
   ASSERT_EQ(
-      (plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+      (plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
           context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj, nullptr)),
       PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
                 queue_, memObj, true, 0, bytes, data, 0, nullptr, nullptr)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferRead>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferRead>(
                 queue_, memObj, true, 0, bytes, output, 0, nullptr, nullptr)),
             PI_SUCCESS);
 
@@ -107,22 +114,22 @@ TEST_F(CudaCommandsTest, PIEnqueueReadBufferNonBlocking) {
 
   pi_mem memObj;
   ASSERT_EQ(
-      (plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+      (plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
           context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj, nullptr)),
       PI_SUCCESS);
 
   pi_event cpIn, cpOut;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
                 queue_, memObj, false, 0, bytes, data, 0, nullptr, &cpIn)),
             PI_SUCCESS);
   ASSERT_NE(cpIn, nullptr);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferRead>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferRead>(
                 queue_, memObj, false, 0, bytes, output, 0, nullptr, &cpOut)),
             PI_SUCCESS);
   ASSERT_NE(cpOut, nullptr);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEventsWait>(1, &cpOut)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEventsWait>(1, &cpOut)),
             PI_SUCCESS);
 
   bool isSame =

--- a/sycl/unittests/pi/cuda/test_kernels.cpp
+++ b/sycl/unittests/pi/cuda/test_kernels.cpp
@@ -24,35 +24,40 @@ using namespace cl::sycl;
 struct CudaKernelsTest : public ::testing::Test {
 
 protected:
-  detail::plugin plugin = pi::initializeAndGet(backend::cuda);
+  detail::plugin *plugin = pi::initializeAndGet(backend::cuda);
   pi_platform platform_;
   pi_device device_;
   pi_context context_;
   pi_queue queue_;
 
   void SetUp() override {
-    pi_uint32 numPlatforms = 0;
-    ASSERT_EQ(plugin.getBackend(), backend::cuda);
+    // skip the tests if the CUDA backend is not available
+    if (!plugin) {
+      GTEST_SKIP();
+    }
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+    pi_uint32 numPlatforms = 0;
+    ASSERT_EQ(plugin->getBackend(), backend::cuda);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                   0, nullptr, &numPlatforms)),
               PI_SUCCESS)
         << "piPlatformsGet failed.\n";
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                   numPlatforms, &platform_, nullptr)),
               PI_SUCCESS)
         << "piPlatformsGet failed.\n";
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piDevicesGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
                   platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
               PI_SUCCESS);
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextCreate>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
                   nullptr, 1, &device_, nullptr, nullptr, &context_)),
               PI_SUCCESS);
     ASSERT_NE(context_, nullptr);
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueCreate>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
                   context_, device_, 0, &queue_)),
               PI_SUCCESS);
     ASSERT_NE(queue_, nullptr);
@@ -60,9 +65,11 @@ protected:
   }
 
   void TearDown() override {
-    plugin.call<detail::PiApiKind::piDeviceRelease>(device_);
-    plugin.call<detail::PiApiKind::piQueueRelease>(queue_);
-    plugin.call<detail::PiApiKind::piContextRelease>(context_);
+    if (plugin) {
+      plugin->call<detail::PiApiKind::piDeviceRelease>(device_);
+      plugin->call<detail::PiApiKind::piQueueRelease>(queue_);
+      plugin->call<detail::PiApiKind::piContextRelease>(context_);
+    }
   }
 
   CudaKernelsTest() = default;
@@ -132,17 +139,17 @@ TEST_F(CudaKernelsTest, PICreateProgramAndKernel) {
 
   pi_program prog;
   pi_int32 binary_status = PI_SUCCESS;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
                 context_, 1, &device_, nullptr,
                 (const unsigned char **)&ptxSource, &binary_status, &prog)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramBuild>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramBuild>(
                 prog, 1, &device_, "", nullptr, nullptr)),
             PI_SUCCESS);
 
   pi_kernel kern;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelCreate>(
                 prog, "_Z8myKernelPi", &kern)),
             PI_SUCCESS);
   ASSERT_NE(kern, nullptr);
@@ -155,23 +162,23 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSimple) {
   /// use it at some point in the future, pass it anyway and check the result.
   /// Same goes for all the other tests in this file.
   pi_int32 binary_status = PI_SUCCESS;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
                 context_, 1, &device_, nullptr,
                 (const unsigned char **)&ptxSource, &binary_status, &prog)),
             PI_SUCCESS);
   ASSERT_EQ(binary_status, PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramBuild>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramBuild>(
                 prog, 1, &device_, "", nullptr, nullptr)),
             PI_SUCCESS);
 
   pi_kernel kern;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelCreate>(
                 prog, "_Z8myKernelPi", &kern)),
             PI_SUCCESS);
 
   int number = 10;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelSetArg>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
                 kern, 0, sizeof(int), &number)),
             PI_SUCCESS);
   const auto &kernArgs = kern->get_arg_indices();
@@ -184,23 +191,23 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwice) {
 
   pi_program prog;
   pi_int32 binary_status = PI_SUCCESS;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
                 context_, 1, &device_, nullptr,
                 (const unsigned char **)&ptxSource, &binary_status, &prog)),
             PI_SUCCESS);
   ASSERT_EQ(binary_status, PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramBuild>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramBuild>(
                 prog, 1, &device_, "", nullptr, nullptr)),
             PI_SUCCESS);
 
   pi_kernel kern;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelCreate>(
                 prog, "_Z8myKernelPi", &kern)),
             PI_SUCCESS);
 
   int number = 10;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelSetArg>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
                 kern, 0, sizeof(int), &number)),
             PI_SUCCESS);
   const auto &kernArgs = kern->get_arg_indices();
@@ -209,7 +216,7 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwice) {
   ASSERT_EQ(storedValue, number);
 
   int otherNumber = 934;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelSetArg>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
                 kern, 0, sizeof(int), &otherNumber)),
             PI_SUCCESS);
   const auto &kernArgs2 = kern->get_arg_indices();
@@ -222,29 +229,29 @@ TEST_F(CudaKernelsTest, PIKernelSetMemObj) {
 
   pi_program prog;
   pi_int32 binary_status = PI_SUCCESS;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
                 context_, 1, &device_, nullptr,
                 (const unsigned char **)&ptxSource, &binary_status, &prog)),
             PI_SUCCESS);
   ASSERT_EQ(binary_status, PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramBuild>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramBuild>(
                 prog, 1, &device_, "", nullptr, nullptr)),
             PI_SUCCESS);
 
   pi_kernel kern;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelCreate>(
                 prog, "_Z8myKernelPi", &kern)),
             PI_SUCCESS);
 
   size_t memSize = 1024u;
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
                 nullptr)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelSetArg>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
                 kern, 0, sizeof(pi_mem), &memObj)),
             PI_SUCCESS);
   const auto &kernArgs = kern->get_arg_indices();
@@ -257,29 +264,29 @@ TEST_F(CudaKernelsTest, PIkerneldispatch) {
 
   pi_program prog;
   pi_int32 binary_status = PI_SUCCESS;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
                 context_, 1, &device_, nullptr,
                 (const unsigned char **)&ptxSource, &binary_status, &prog)),
             PI_SUCCESS);
   ASSERT_EQ(binary_status, PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramBuild>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramBuild>(
                 prog, 1, &device_, "", nullptr, nullptr)),
             PI_SUCCESS);
 
   pi_kernel kern;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelCreate>(
                 prog, "_Z8myKernelPi", &kern)),
             PI_SUCCESS);
 
   size_t memSize = 1024u;
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
                 nullptr)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piextKernelSetArgMemObj>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piextKernelSetArgMemObj>(
                 kern, 0, &memObj)),
             PI_SUCCESS);
 
@@ -287,12 +294,12 @@ TEST_F(CudaKernelsTest, PIkerneldispatch) {
   size_t globalWorkOffset[] = {0};
   size_t globalWorkSize[] = {1};
   size_t localWorkSize[] = {1};
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueKernelLaunch>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueKernelLaunch>(
                 queue_, kern, workDim, globalWorkOffset, globalWorkSize,
                 localWorkSize, 0, nullptr, nullptr)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
             PI_SUCCESS);
 }
 
@@ -300,39 +307,39 @@ TEST_F(CudaKernelsTest, PIkerneldispatchTwo) {
 
   pi_program prog;
   pi_int32 binary_status = PI_SUCCESS;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
                 context_, 1, &device_, nullptr,
                 (const unsigned char **)&twoParams, &binary_status, &prog)),
             PI_SUCCESS);
   ASSERT_EQ(binary_status, PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramBuild>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramBuild>(
                 prog, 1, &device_, "", nullptr, nullptr)),
             PI_SUCCESS);
 
   pi_kernel kern;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelCreate>(
                 prog, "twoParamKernel", &kern)),
             PI_SUCCESS);
 
   size_t memSize = 1024u;
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
                 nullptr)),
             PI_SUCCESS);
 
   pi_mem memObj2;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj2,
                 nullptr)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piextKernelSetArgMemObj>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piextKernelSetArgMemObj>(
                 kern, 0, &memObj)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piextKernelSetArgMemObj>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piextKernelSetArgMemObj>(
                 kern, 1, &memObj2)),
             PI_SUCCESS);
 
@@ -340,14 +347,14 @@ TEST_F(CudaKernelsTest, PIkerneldispatchTwo) {
   size_t globalWorkOffset[] = {0};
   size_t globalWorkSize[] = {1};
   size_t localWorkSize[] = {1};
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueKernelLaunch>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueKernelLaunch>(
                 queue_, kern, workDim, globalWorkOffset, globalWorkSize,
                 localWorkSize, 0, nullptr, nullptr)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
             PI_SUCCESS);
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj2)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj2)),
             PI_SUCCESS);
 }
 
@@ -356,23 +363,23 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwiceOneLocal) {
   pi_program prog;
   pi_int32 binary_status = PI_SUCCESS;
   ASSERT_EQ(
-      (plugin.call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
+      (plugin->call_nocheck<detail::PiApiKind::piProgramCreateWithBinary>(
           context_, 1, &device_, nullptr,
           (const unsigned char **)&threeParamsTwoLocal, &binary_status, &prog)),
       PI_SUCCESS);
   ASSERT_EQ(binary_status, PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piProgramBuild>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piProgramBuild>(
                 prog, 1, &device_, "", nullptr, nullptr)),
             PI_SUCCESS);
 
   pi_kernel kern;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelCreate>(
                 prog, "twoParamKernelLocal", &kern)),
             PI_SUCCESS);
 
   int number = 10;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelSetArg>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
                 kern, 0, sizeof(int), &number)),
             PI_SUCCESS);
   const auto &kernArgs = kern->get_arg_indices();
@@ -380,7 +387,7 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwiceOneLocal) {
   int storedValue = *(static_cast<const int *>(kernArgs[0]));
   ASSERT_EQ(storedValue, number);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelSetArg>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
                 kern, 1, sizeof(int), nullptr)),
             PI_SUCCESS);
   const auto &kernArgs2 = kern->get_arg_indices();
@@ -388,7 +395,7 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwiceOneLocal) {
   storedValue = *(static_cast<const int *>(kernArgs2[1]));
   ASSERT_EQ(storedValue, 0);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piKernelSetArg>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
                 kern, 2, sizeof(int), nullptr)),
             PI_SUCCESS);
   const auto &kernArgs3 = kern->get_arg_indices();

--- a/sycl/unittests/pi/cuda/test_mem_obj.cpp
+++ b/sycl/unittests/pi/cuda/test_mem_obj.cpp
@@ -22,39 +22,46 @@ using namespace cl::sycl;
 struct CudaTestMemObj : public ::testing::Test {
 
 protected:
-  detail::plugin plugin = pi::initializeAndGet(backend::cuda);
+  detail::plugin *plugin = pi::initializeAndGet(backend::cuda);
 
   pi_platform platform_;
   pi_device device_;
   pi_context context_;
 
   void SetUp() override {
+    // skip the tests if the CUDA backend is not available
+    if (!plugin) {
+      GTEST_SKIP();
+    }
+
     cuCtxSetCurrent(nullptr);
     pi_uint32 numPlatforms = 0;
-    ASSERT_EQ(plugin.getBackend(), backend::cuda);
+    ASSERT_EQ(plugin->getBackend(), backend::cuda);
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                   0, nullptr, &numPlatforms)),
               PI_SUCCESS)
         << "piPlatformsGet failed.\n";
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                   numPlatforms, &platform_, nullptr)),
               PI_SUCCESS)
         << "piPlatformsGet failed.\n";
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piDevicesGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
                   platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
               PI_SUCCESS);
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextCreate>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
                   nullptr, 1, &device_, nullptr, nullptr, &context_)),
               PI_SUCCESS);
     EXPECT_NE(context_, nullptr);
   }
 
   void TearDown() override {
-    plugin.call<detail::PiApiKind::piDeviceRelease>(device_);
-    plugin.call<detail::PiApiKind::piContextRelease>(context_);
+    if (plugin) {
+      plugin->call<detail::PiApiKind::piDeviceRelease>(device_);
+      plugin->call<detail::PiApiKind::piContextRelease>(context_);
+    }
   }
 
   CudaTestMemObj() = default;
@@ -65,24 +72,24 @@ protected:
 TEST_F(CudaTestMemObj, piMemBufferCreateSimple) {
   const size_t memSize = 1024u;
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
                 nullptr)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
             PI_SUCCESS);
 }
 
 TEST_F(CudaTestMemObj, piMemBufferAllocHost) {
   const size_t memSize = 1024u;
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW | PI_MEM_FLAGS_HOST_PTR_ALLOC,
                 memSize, nullptr, &memObj, nullptr)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
             PI_SUCCESS);
 }
 
@@ -106,13 +113,13 @@ TEST_F(CudaTestMemObj, piMemBufferCreateNoActiveContext) {
   // The context object is passed, even if its not active it should be used
   // to allocate the memory object
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
                 nullptr)),
             PI_SUCCESS);
   ASSERT_NE(memObj, nullptr);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
             PI_SUCCESS);
 }
 
@@ -121,38 +128,38 @@ TEST_F(CudaTestMemObj, piMemBufferPinnedMappedRead) {
   const int value = 20;
 
   pi_queue queue;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
                 context_, device_, 0, &queue)),
             PI_SUCCESS);
   ASSERT_NE(queue, nullptr);
   ASSERT_EQ(queue->get_context(), context_);
 
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW | PI_MEM_FLAGS_HOST_PTR_ALLOC,
                 memSize, nullptr, &memObj, nullptr)),
             PI_SUCCESS);
 
   ASSERT_EQ(
-      (plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
+      (plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
           queue, memObj, true, 0, sizeof(int), &value, 0, nullptr, nullptr)),
       PI_SUCCESS);
 
   int *host_ptr = nullptr;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
                 queue, memObj, true, PI_MAP_READ, 0, sizeof(int), 0, nullptr,
                 nullptr, (void **)&host_ptr)),
             PI_SUCCESS);
 
   ASSERT_EQ(*host_ptr, value);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemUnmap>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemUnmap>(
                 queue, memObj, host_ptr, 0, nullptr, nullptr)),
             PI_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
             PI_SUCCESS);
-  plugin.call<detail::PiApiKind::piQueueRelease>(queue);
+  plugin->call<detail::PiApiKind::piQueueRelease>(queue);
 }
 
 TEST_F(CudaTestMemObj, piMemBufferPinnedMappedWrite) {
@@ -160,39 +167,39 @@ TEST_F(CudaTestMemObj, piMemBufferPinnedMappedWrite) {
   const int value = 30;
 
   pi_queue queue;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
                 context_, device_, 0, &queue)),
             PI_SUCCESS);
   ASSERT_NE(queue, nullptr);
   ASSERT_EQ(queue->get_context(), context_);
 
   pi_mem memObj;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
                 context_, PI_MEM_FLAGS_ACCESS_RW | PI_MEM_FLAGS_HOST_PTR_ALLOC,
                 memSize, nullptr, &memObj, nullptr)),
             PI_SUCCESS);
 
   int *host_ptr = nullptr;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
                 queue, memObj, true, PI_MAP_WRITE, 0, sizeof(int), 0, nullptr,
                 nullptr, (void **)&host_ptr)),
             PI_SUCCESS);
 
   *host_ptr = value;
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemUnmap>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemUnmap>(
                 queue, memObj, host_ptr, 0, nullptr, nullptr)),
             PI_SUCCESS);
 
   int read_value = 0;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piEnqueueMemBufferRead>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferRead>(
                 queue, memObj, true, 0, sizeof(int), &read_value, 0, nullptr,
                 nullptr)),
             PI_SUCCESS);
 
   ASSERT_EQ(read_value, value);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
             PI_SUCCESS);
-  plugin.call<detail::PiApiKind::piQueueRelease>(queue);
+  plugin->call<detail::PiApiKind::piQueueRelease>(queue);
 }

--- a/sycl/unittests/pi/cuda/test_queue.cpp
+++ b/sycl/unittests/pi/cuda/test_queue.cpp
@@ -24,38 +24,45 @@ using namespace sycl;
 struct CudaTestQueue : public ::testing::TestWithParam<platform> {
 
 protected:
-  detail::plugin plugin = pi::initializeAndGet(backend::cuda);
+  detail::plugin *plugin = pi::initializeAndGet(backend::cuda);
 
   pi_platform platform_;
   pi_device device_;
   pi_context context_;
 
   void SetUp() override {
-    pi_uint32 numPlatforms = 0;
-    ASSERT_EQ(plugin.getBackend(), backend::cuda);
+    // skip the tests if the CUDA backend is not available
+    if (!plugin) {
+      GTEST_SKIP();
+    }
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+    pi_uint32 numPlatforms = 0;
+    ASSERT_EQ(plugin->getBackend(), backend::cuda);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                   0, nullptr, &numPlatforms)),
               PI_SUCCESS)
         << "piPlatformsGet failed.\n";
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piPlatformsGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
                   numPlatforms, &platform_, nullptr)),
               PI_SUCCESS)
         << "piPlatformsGet failed.\n";
 
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piDevicesGet>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
                   platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
               PI_SUCCESS);
-    ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piContextCreate>(
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
                   nullptr, 1, &device_, nullptr, nullptr, &context_)),
               PI_SUCCESS);
     EXPECT_NE(context_, nullptr);
   }
 
   void TearDown() override {
-    plugin.call<detail::PiApiKind::piDeviceRelease>(device_);
-    plugin.call<detail::PiApiKind::piContextRelease>(context_);
+    if (plugin) {
+      plugin->call<detail::PiApiKind::piDeviceRelease>(device_);
+      plugin->call<detail::PiApiKind::piContextRelease>(context_);
+    }
   }
 
   CudaTestQueue() = default;
@@ -65,7 +72,7 @@ protected:
 
 TEST_F(CudaTestQueue, PICreateQueueSimple) {
   pi_queue queue;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
                 context_, device_, 0, &queue)),
             PI_SUCCESS);
   ASSERT_NE(queue, nullptr);
@@ -76,13 +83,13 @@ TEST_F(CudaTestQueue, PICreateQueueSimple) {
   cuStreamGetFlags(stream, &flags);
   ASSERT_EQ(flags, CU_STREAM_NON_BLOCKING);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
             PI_SUCCESS);
 }
 
 TEST_F(CudaTestQueue, PIQueueFinishSimple) {
   pi_queue queue;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
                 context_, device_, 0, &queue)),
             PI_SUCCESS);
   ASSERT_NE(queue, nullptr);
@@ -90,18 +97,18 @@ TEST_F(CudaTestQueue, PIQueueFinishSimple) {
   // todo: post work on queue, ensure the results are valid and the work is
   // complete after piQueueFinish?
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueFinish>(queue)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueFinish>(queue)),
             PI_SUCCESS);
 
   ASSERT_EQ(cuStreamQuery(queue->get()), CUDA_SUCCESS);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
             PI_SUCCESS);
 }
 
 TEST_F(CudaTestQueue, PICreateQueueSimpleDefault) {
   pi_queue queue;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
                 context_, device_, __SYCL_PI_CUDA_USE_DEFAULT_STREAM, &queue)),
             PI_SUCCESS);
   ASSERT_NE(queue, nullptr);
@@ -112,13 +119,13 @@ TEST_F(CudaTestQueue, PICreateQueueSimpleDefault) {
   cuStreamGetFlags(stream, &flags);
   ASSERT_EQ(flags, CU_STREAM_DEFAULT);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
             PI_SUCCESS);
 }
 
 TEST_F(CudaTestQueue, PICreateQueueSyncWithDefault) {
   pi_queue queue;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
                 context_, device_, __SYCL_PI_CUDA_SYNC_WITH_DEFAULT, &queue)),
             PI_SUCCESS);
   ASSERT_NE(queue, nullptr);
@@ -129,13 +136,13 @@ TEST_F(CudaTestQueue, PICreateQueueSyncWithDefault) {
   cuStreamGetFlags(stream, &flags);
   ASSERT_NE(flags, CU_STREAM_NON_BLOCKING);
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
             PI_SUCCESS);
 }
 
 TEST_F(CudaTestQueue, PICreateQueueInterop) {
   pi_queue queue;
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueCreate>(
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
                 context_, device_, 0, &queue)),
             PI_SUCCESS);
   ASSERT_NE(queue, nullptr);
@@ -148,7 +155,7 @@ TEST_F(CudaTestQueue, PICreateQueueInterop) {
   ASSERT_EQ(res, CUDA_SUCCESS);
   EXPECT_EQ(cuCtx, context_->get());
 
-  ASSERT_EQ((plugin.call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueRelease>(queue)),
             PI_SUCCESS);
 }
 


### PR DESCRIPTION
This fixes an issue where if the cuda plugin is enabled and lit tests
for another plugin are run, it will try to run PiCudaTests, and all of
them will assert since the device filter will be set to a non-cuda
plugin and the tests request a cuda device.

So instead of asserting this patch makes the PiCudaTests get marked as
skipped if there is no cuda device found.