### PR TITLE
[SYCL] Omit TemplatedDecl from int-footer for a VarTemplateDecl

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1421,7 +1421,10 @@ Decl *TemplateDeclInstantiator::VisitVarDecl(VarDecl *D,
   if (Var->isStaticLocal())
     SemaRef.CheckStaticLocalForDllExport(Var);
 
-  SemaRef.addSyclVarDecl(Var);
+  // Only add this if we aren't instantiating a variable template.  We'll end up
+  // adding the VarTemplateSpecializationDecl later.
+  if (!InstantiatingVarTemplate)
+    SemaRef.addSyclVarDecl(Var);
   return Var;
 }
 

--- a/clang/test/CodeGenSYCL/integration_footer.cpp
+++ b/clang/test/CodeGenSYCL/integration_footer.cpp
@@ -190,4 +190,14 @@ auto x = HasVarTemplate::VarTempl<int, 2>.getDefaultValue();
 // CHECK-NEXT: } // namespace sycl
 // CHECK-NEXT: } // __SYCL_INLINE_NAMESPACE(cl)
 
+template <typename T> struct GlobalWrapper {
+  template<int Value> static constexpr specialization_id<T> sc{Value};
+};
+
+auto &y = GlobalWrapper<int>::template sc<20>;
+
+// Should not generate the uninstantiated template.
+// CHECK-NOT: inline const char *get_spec_constant_symbolic_ID_impl<::GlobalWrapper<int>::sc>()
+// CHECK: inline const char *get_spec_constant_symbolic_ID_impl<::GlobalWrapper<int>::sc<20>>()
+
 // CHECK: #include <CL/sycl/detail/spec_const_integration.hpp>


### PR DESCRIPTION
The hook we had always added the VarDecl when it was visited, however
when evaluating a VarTemplateDecl, Clang creates a VarDecl to represent
the declaration as a child of the VarTemplateDecl. We don't need to
capture it in our collection since the VarTemplateSpecializationDecl
will provide the info we need.

If we DON'T do this, we end up having 2 specializations for the
specialization_id, one of which is invalid.