### PR TITLE
[SYCL] Pass bound arch to unbundler

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4151,8 +4151,10 @@ class OffloadingActionBuilder final {
         }
         for (unsigned I = 0; I < ToolChains.size(); ++I) {
           SYCLDeviceActions.push_back(UA);
-          UA->registerDependentActionInfo(
-            ToolChains[I], /*BoundArch=*/StringRef(), Action::OFK_SYCL);
+          withBoundArchForToolChain(ToolChains[I], [&](const char *BoundArch) {
+            UA->registerDependentActionInfo(ToolChains[I], BoundArch,
+                                            Action::OFK_SYCL);
+          });
         }
         return ABRT_Success;
       }


### PR DESCRIPTION
This commit propagates the bound arch to the clang unbundler for SYCL actions.

This fixes the tests disabled in https://github.com/intel/llvm-test-suite/pull/349 (reverted with https://github.com/intel/llvm-test-suite/pull/365) and resolves https://github.com/intel/llvm/issues/4079.