### PR TITLE
[SYCL] Add new SYCL attribute readonly

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1261,6 +1261,14 @@ def SYCLSimdAccessorPtr : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+// Used to mark readonly accessors. It is not to be used directly in the source.
+def SYCLAccessorReadonly : Attr {
+  // This attribute has no spellings as it is only ever created implicitly.
+  let Spellings = [];
+  let SemaHandler = 0;
+  let Documentation = [Undocumented];
+}
+
 // The attribute denotes that it is a function written in a scalar fashion, which
 // is used in ESIMD context and needs to be vectorized by a vector backend compiler.
 // For now, this attribute will be used only in internal implementation of

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -2672,6 +2672,9 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
     unsigned FirstIRArg, NumIRArgs;
     std::tie(FirstIRArg, NumIRArgs) = IRFunctionArgs.getIRArgs(ArgNo);
 
+    if (Arg->hasAttr<SYCLAccessorReadonlyAttr>())
+      Fn->getArg(FirstIRArg)->addAttr(llvm::Attribute::ReadOnly);
+
     switch (ArgI.getKind()) {
     case ABIArgInfo::InAlloca: {
       assert(NumIRArgs == 0);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1110,12 +1110,12 @@ static bool isReadOnlyAccessor(const TemplateArgument &AccessModeArg) {
       AccessModeArg.getIntegralType()->castAs<EnumType>();
   EnumDecl *ED = AccessModeArgEnumType->getDecl();
 
-  auto IsReadOnly = llvm::find_if(ED->enumerators(), [&](EnumConstantDecl *E) {
-    return E->getName() == "read" &&
-           E->getInitVal() == AccessModeArg.getAsIntegral();
+  auto ReadOnly = llvm::find_if(ED->enumerators(), [&](EnumConstantDecl *E) {
+    return E->getName() == "read";
   });
 
-  return (IsReadOnly != ED->enumerator_end()) ? true : false;
+  return (ReadOnly != ED->enumerator_end()) &&
+         (*ReadOnly)->getInitVal() == AccessModeArg.getAsIntegral();
 }
 
 // anonymous namespace so these don't get linkage.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1110,10 +1110,8 @@ static bool isReadOnlyAccessor(const TemplateArgument AccessModeArg) {
       AccessModeArg.getIntegralType()->castAs<EnumType>();
 
   for (auto *E : AccessModeArgEnumType->getDecl()->enumerators())
-    if (E->getName() == "read" &&
-        E->getInitVal() == AccessModeArg.getAsIntegral())
-      return true;
-
+    if (E->getName() == "read")
+      return E->getInitVal() == AccessModeArg.getAsIntegral();
   return false;
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1108,13 +1108,14 @@ static ParmVarDecl *getSyclKernelHandlerArg(FunctionDecl *KernelCallerFunc) {
 static bool isReadOnlyAccessor(const TemplateArgument &AccessModeArg) {
   const auto *AccessModeArgEnumType =
       AccessModeArg.getIntegralType()->castAs<EnumType>();
-  EnumDecl *ED = AccessModeArgEnumType->getDecl();
+  const EnumDecl *ED = AccessModeArgEnumType->getDecl();
 
-  auto ReadOnly = llvm::find_if(ED->enumerators(), [&](EnumConstantDecl *E) {
-    return E->getName() == "read";
-  });
+  auto ReadOnly =
+      llvm::find_if(ED->enumerators(), [&](const EnumConstantDecl *E) {
+        return E->getName() == "read";
+      });
 
-  return (ReadOnly != ED->enumerator_end()) &&
+  return ReadOnly != ED->enumerator_end() &&
          (*ReadOnly)->getInitVal() == AccessModeArg.getAsIntegral();
 }
 
@@ -2125,7 +2126,7 @@ public:
     // Get access mode of accessor.
     const auto *AccessorSpecializationDecl =
         cast<ClassTemplateSpecializationDecl>(RecordDecl);
-    const TemplateArgument AccessModeArg =
+    const TemplateArgument &AccessModeArg =
         AccessorSpecializationDecl->getTemplateArgs().get(2);
 
     // Don't do -1 here because we count on this to be the first parameter added
@@ -2155,7 +2156,7 @@ public:
     // Get access mode of accessor.
     const auto *AccessorSpecializationDecl =
         cast<ClassTemplateSpecializationDecl>(RecordDecl);
-    const TemplateArgument AccessModeArg =
+    const TemplateArgument &AccessModeArg =
         AccessorSpecializationDecl->getTemplateArgs().get(2);
 
     llvm::StringLiteral MethodName = KernelDecl->hasAttr<SYCLSimdAttr>()

--- a/clang/test/CodeGenSYCL/accessor-readonly-invalid-lib.cpp
+++ b/clang/test/CodeGenSYCL/accessor-readonly-invalid-lib.cpp
@@ -1,0 +1,90 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+//
+// Test which verifies that readonly attribute is generated for unexpected access mode value.
+
+// Dummy library with unexpected access::mode enum value.
+namespace cl {
+namespace sycl {
+
+namespace access {
+
+enum class target {
+  global_buffer = 2014,
+  constant_buffer,
+  local,
+  image,
+  host_buffer,
+  host_image,
+  image_array
+};
+
+enum class mode {
+  read = 2024,
+  write,
+  read_write,
+  discard_write,
+  discard_read_write,
+  atomic
+};
+
+enum class placeholder {
+  false_t,
+  true_t
+};
+
+} // namespace access
+
+template <int dim>
+struct id {
+  template <typename... T>
+  id(T... args) {} // fake constructor
+private:
+  int Data;
+};
+
+template <int dim>
+struct range {
+  template <typename... T>
+  range(T... args) {} // fake constructor
+private:
+  int Data;
+};
+
+template <int dim>
+struct _ImplT {
+  range<dim> AccessRange;
+  range<dim> MemRange;
+  id<dim> Offset;
+};
+
+template <typename dataT, int dimensions, access::mode accessmode,
+          access::target accessTarget = access::target::global_buffer,
+          access::placeholder isPlaceholder = access::placeholder::false_t>
+class accessor {
+
+public:
+  void use(void) const {}
+  _ImplT<dimensions> impl;
+
+private:
+  void __init(__attribute__((opencl_global)) dataT *Ptr, range<dimensions> AccessRange,
+              range<dimensions> MemRange, id<dimensions> Offset) {}
+};
+
+} // namespace sycl
+} // namespace cl
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  cl::sycl::accessor<int, 1, cl::sycl::access::mode::read> Acc;
+  // CHECK: spir_kernel{{.*}}fake_kernel
+  // CHECK-SAME: readonly
+  kernel_single_task<class fake_kernel>([=]() {
+    Acc.use();
+  });
+  return 0;
+}

--- a/clang/test/CodeGenSYCL/accessor-readonly.cpp
+++ b/clang/test/CodeGenSYCL/accessor-readonly.cpp
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+
+// Test to check that readonly attribute is applied to accessors with access mode read.
+
+#include "Inputs/sycl.hpp"
+
+// CHECK-NOT: spir_kernel{{.*}}f0_kernel{{.*}}readonly
+void f0(cl::sycl::queue &myQueue, cl::sycl::buffer<int, 1> &in_buf, cl::sycl::buffer<int, 1> &out_buf) {
+  myQueue.submit([&](cl::sycl::handler &cgh) {
+    auto write_acc = out_buf.get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.single_task<class f0_kernel>([write_acc] {});
+  });
+}
+
+// CHECK: spir_kernel{{.*}}f1_kernel
+// CHECK-NOT: readonly
+// CHECK-SAME: %_arg_{{.*}}%_arg_1{{.*}}%_arg_2{{.*}}%_arg_3
+// CHECK-SAME:  readonly %_arg_4
+void f1(cl::sycl::queue &myQueue, cl::sycl::buffer<int, 1> &in_buf, cl::sycl::buffer<int, 1> &out_buf) {
+  myQueue.submit([&](cl::sycl::handler &cgh) {
+    auto write_acc = out_buf.get_access<cl::sycl::access::mode::write>(cgh);
+    auto read_acc = in_buf.get_access<cl::sycl::access::mode::read>(cgh);
+    cgh.single_task<class f1_kernel>([write_acc, read_acc] {});
+  });
+}
+
+// CHECK: spir_kernel{{.*}}f2_kernel
+// CHECK-SAME: readonly %_arg_
+// CHECK-NOT: readonly
+// CHECK-SAME: %_arg_8
+void f2(cl::sycl::queue &myQueue, cl::sycl::buffer<int, 1> &in_buf, cl::sycl::buffer<int, 1> &out_buf) {
+  myQueue.submit([&](cl::sycl::handler &cgh) {
+    auto read_acc = in_buf.get_access<cl::sycl::access::mode::read>(cgh);
+    auto write_acc = out_buf.get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.single_task<class f2_kernel>([read_acc, write_acc] {});
+  });
+}

--- a/clang/test/CodeGenSYCL/accessor_inheritance.cpp
+++ b/clang/test/CodeGenSYCL/accessor_inheritance.cpp
@@ -26,11 +26,11 @@ int main() {
 // CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE6kernel
 // CHECK-SAME: i32 [[ARG_A:%[a-zA-Z0-9_]+]],
 // CHECK-SAME: i32 [[ARG_B:%[a-zA-Z0-9_]+]],
-// CHECK-SAME: i8 addrspace(1)* [[ACC1_DATA:%[a-zA-Z0-9_]+]],
+// CHECK-SAME: i8 addrspace(1)* readonly [[ACC1_DATA:%[a-zA-Z0-9_]+]],
 // CHECK-SAME: %[[RANGE_TYPE]]* byval(%[[RANGE_TYPE]]) align 4 [[ACC1_RANGE1:%[a-zA-Z0-9_]+]],
 // CHECK-SAME: %[[RANGE_TYPE]]* byval(%[[RANGE_TYPE]]) align 4 [[ACC1_RANGE2:%[a-zA-Z0-9_]+]],
 // CHECK-SAME: %[[ID_TYPE]]* byval(%[[ID_TYPE]]) align 4 [[ACC1_ID:%[a-zA-Z0-9_]+]],
-// CHECK-SAME: i8 addrspace(1)* [[ACC2_DATA:%[a-zA-Z0-9_]+]],
+// CHECK-SAME: i8 addrspace(1)* readonly [[ACC2_DATA:%[a-zA-Z0-9_]+]],
 // CHECK-SAME: %[[RANGE_TYPE]]* byval(%[[RANGE_TYPE]]) align 4 [[ACC2_RANGE1:%[a-zA-Z0-9_]+]],
 // CHECK-SAME: %[[RANGE_TYPE]]* byval(%[[RANGE_TYPE]]) align 4 [[ACC2_RANGE2:%[a-zA-Z0-9_]+]],
 // CHECK-SAME: %[[ID_TYPE]]* byval(%[[ID_TYPE]]) align 4 [[ACC2_ID:%[a-zA-Z0-9_]+]],


### PR DESCRIPTION
If a SYCL accessor is templated on access::mode::read, then represent
this in LLVM IR as the readonly attribute applied on the kernel argument
corresponding to the accessor.

Co-author : Jeffrey Mott <<jeffrey.t.mott@intel.com>>

Signed-off-by: Elizabeth Andrews <<elizabeth.andrews@intel.com>>