### PR TITLE
[cherry-pick] Fix the Clang documentation builder; NFC.

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5837,11 +5837,14 @@ provided it declares the right formal arguments.
 
 In most respects, this is similar to the ``swiftcall`` attribute, except for
 the following:
+
 - A parameter may be marked ``swift_async_context``, ``swift_context``
   or ``swift_indirect_result`` (with the same restrictions on parameter
   ordering as ``swiftcall``) but the parameter attribute
   ``swift_error_result`` is not permitted.
+
 - A ``swiftasynccall`` function must have return type ``void``.
+
 - Within a ``swiftasynccall`` function, a call to a ``swiftasynccall``
   function that is the immediate operand of a ``return`` statement is
   guaranteed to be performed as a tail call. This syntax is allowed even


### PR DESCRIPTION
It was broken three days ago by the changes in D95561.

This is a cherry-pick of community commit https://github.com/llvm/llvm-project/commit/f042e0a0f88391c611002e55afec5c37604b5819 to fix broken CI pipeline.