### PR TITLE
[NFC] Fix libdevice dependencies list

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -34,7 +34,7 @@ add_custom_command(OUTPUT ${devicelib-obj-file}
                            ${CMAKE_CURRENT_SOURCE_DIR}/crt_wrapper.cpp
                            -o ${devicelib-obj-file}
                    MAIN_DEPENDENCY crt_wrapper.cpp
-                   DEPENDS wrapper.h device.h spirv_vars.h clang clang-offload-bundler
+                   DEPENDS wrapper.h device.h spirv_vars.h sycl-compiler
                    VERBATIM)
 
 set(devicelib-obj-complex ${obj_binary_dir}/libsycl-complex.${lib-suffix})
@@ -44,7 +44,7 @@ add_custom_command(OUTPUT ${devicelib-obj-complex}
                            ${CMAKE_CURRENT_SOURCE_DIR}/complex_wrapper.cpp
                            -o ${devicelib-obj-complex}
                    MAIN_DEPENDENCY complex_wrapper.cpp
-                   DEPENDS device_complex.h device.h clang clang-offload-bundler
+                   DEPENDS device_complex.h device.h sycl-compiler
                    VERBATIM)
 
 set(devicelib-obj-complex-fp64 ${obj_binary_dir}/libsycl-complex-fp64.${lib-suffix})
@@ -54,7 +54,7 @@ add_custom_command(OUTPUT ${devicelib-obj-complex-fp64}
                            ${CMAKE_CURRENT_SOURCE_DIR}/complex_wrapper_fp64.cpp
                            -o ${devicelib-obj-complex-fp64}
                    MAIN_DEPENDENCY complex_wrapper_fp64.cpp
-                   DEPENDS device_complex.h device.h clang clang-offload-bundler
+                   DEPENDS device_complex.h device.h sycl-compiler
                    VERBATIM)
 
 set(devicelib-obj-cmath ${obj_binary_dir}/libsycl-cmath.${lib-suffix})
@@ -64,7 +64,7 @@ add_custom_command(OUTPUT ${devicelib-obj-cmath}
                            ${CMAKE_CURRENT_SOURCE_DIR}/cmath_wrapper.cpp
                            -o ${devicelib-obj-cmath}
                    MAIN_DEPENDENCY cmath_wrapper.cpp
-                   DEPENDS device_math.h device.h clang clang-offload-bundler
+                   DEPENDS device_math.h device.h sycl-compiler
                    VERBATIM)
 
 set(devicelib-obj-cmath-fp64 ${obj_binary_dir}/libsycl-cmath-fp64.${lib-suffix})
@@ -74,7 +74,7 @@ add_custom_command(OUTPUT ${devicelib-obj-cmath-fp64}
                            ${CMAKE_CURRENT_SOURCE_DIR}/cmath_wrapper_fp64.cpp
                            -o ${devicelib-obj-cmath-fp64}
                    MAIN_DEPENDENCY cmath_wrapper_fp64.cpp
-                   DEPENDS device_math.h device.h clang clang-offload-bundler
+                   DEPENDS device_math.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cassert.spv
@@ -83,7 +83,7 @@ add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cassert.spv
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cassert.cpp
                            -o ${spv_binary_dir}/libsycl-fallback-cassert.spv
                    MAIN_DEPENDENCY fallback-cassert.cpp
-                   DEPENDS wrapper.h device.h clang spirv_vars.h llvm-spirv
+                   DEPENDS wrapper.h device.h spirv_vars.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cstring.spv
@@ -92,7 +92,7 @@ add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cstring.spv
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cstring.cpp
                            -o ${spv_binary_dir}/libsycl-fallback-cstring.spv
                    MAIN_DEPENDENCY fallback-cstring.cpp
-                   DEPENDS wrapper.h device.h clang spirv_vars.h llvm-spirv
+                   DEPENDS wrapper.h device.h spirv_vars.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cassert.${lib-suffix}
@@ -101,7 +101,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cassert.${lib-suffi
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cassert.cpp
                            -o ${obj_binary_dir}/libsycl-fallback-cassert.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cassert.cpp
-                   DEPENDS wrapper.h device.h clang spirv_vars.h clang-offload-bundler
+                   DEPENDS wrapper.h device.h spirv_vars.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cstring.${lib-suffix}
@@ -110,7 +110,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cstring.${lib-suffi
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cstring.cpp
                            -o ${obj_binary_dir}/libsycl-fallback-cstring.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cstring.cpp
-                   DEPENDS wrapper.h device.h clang spirv_vars.h clang-offload-bundler
+                   DEPENDS wrapper.h device.h spirv_vars.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-complex.spv
@@ -119,7 +119,7 @@ add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-complex.spv
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex.cpp
                            -o ${spv_binary_dir}/libsycl-fallback-complex.spv
                    MAIN_DEPENDENCY fallback-complex.cpp
-                   DEPENDS device_math.h device_complex.h device.h clang llvm-spirv
+                   DEPENDS device_math.h device_complex.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-complex.${lib-suffix}
@@ -128,7 +128,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-complex.${lib-suffi
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex.cpp
                            -o ${obj_binary_dir}/libsycl-fallback-complex.${lib-suffix}
                    MAIN_DEPENDENCY fallback-complex.cpp
-                   DEPENDS device_math.h device_complex.h device.h clang clang-offload-bundler
+                   DEPENDS device_math.h device_complex.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-complex-fp64.spv
@@ -137,7 +137,7 @@ add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-complex-fp64.spv
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex-fp64.cpp
                            -o ${spv_binary_dir}/libsycl-fallback-complex-fp64.spv
                    MAIN_DEPENDENCY fallback-complex-fp64.cpp
-                   DEPENDS device_math.h device_complex.h device.h clang llvm-spirv
+                   DEPENDS device_math.h device_complex.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
@@ -146,7 +146,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-complex-fp64.${lib-
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-complex-fp64.cpp
                            -o ${obj_binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
                    MAIN_DEPENDENCY fallback-complex-fp64.cpp
-                   DEPENDS device_math.h device_complex.h device.h clang clang-offload-bundler
+                   DEPENDS device_math.h device_complex.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cmath.spv
@@ -155,7 +155,7 @@ add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cmath.spv
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath.cpp
                            -o ${spv_binary_dir}/libsycl-fallback-cmath.spv
                    MAIN_DEPENDENCY fallback-cmath.cpp
-                   DEPENDS device_math.h device.h clang llvm-spirv
+                   DEPENDS device_math.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cmath.${lib-suffix}
@@ -164,7 +164,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cmath.${lib-suffix}
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath.cpp
                            -o ${obj_binary_dir}/libsycl-fallback-cmath.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cmath.cpp
-                   DEPENDS device_math.h device.h clang clang-offload-bundler
+                   DEPENDS device_math.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cmath-fp64.spv
@@ -173,7 +173,7 @@ add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-cmath-fp64.spv
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath-fp64.cpp
                            -o ${spv_binary_dir}/libsycl-fallback-cmath-fp64.spv
                    MAIN_DEPENDENCY fallback-cmath-fp64.cpp
-                   DEPENDS device_math.h device.h clang llvm-spirv
+                   DEPENDS device_math.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
@@ -182,7 +182,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-cmath-fp64.${lib-su
                            ${CMAKE_CURRENT_SOURCE_DIR}/fallback-cmath-fp64.cpp
                            -o ${obj_binary_dir}/libsycl-fallback-cmath-fp64.${lib-suffix}
                    MAIN_DEPENDENCY fallback-cmath-fp64.cpp
-                   DEPENDS device_math.h device.h clang clang-offload-bundler
+                   DEPENDS device_math.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-itt-stubs.${lib-suffix}
@@ -191,7 +191,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-itt-stubs.${lib-suffix}
                            ${CMAKE_CURRENT_SOURCE_DIR}/itt_stubs.cpp
                            -o ${obj_binary_dir}/libsycl-itt-stubs.${lib-suffix}
                    MAIN_DEPENDENCY itt_stubs.cpp
-                   DEPENDS device_itt.h spirv_vars.h device.h clang clang-offload-bundler
+                   DEPENDS device_itt.h spirv_vars.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-itt-compiler-wrappers.${lib-suffix}
@@ -200,7 +200,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-itt-compiler-wrappers.${lib-
                            ${CMAKE_CURRENT_SOURCE_DIR}/itt_compiler_wrappers.cpp
                            -o ${obj_binary_dir}/libsycl-itt-compiler-wrappers.${lib-suffix}
                    MAIN_DEPENDENCY itt_compiler_wrappers.cpp
-                   DEPENDS device_itt.h spirv_vars.h device.h clang clang-offload-bundler
+                   DEPENDS device_itt.h spirv_vars.h device.h sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-itt-user-wrappers.${lib-suffix}
@@ -209,7 +209,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-itt-user-wrappers.${lib-suff
                            ${CMAKE_CURRENT_SOURCE_DIR}/itt_user_wrappers.cpp
                            -o ${obj_binary_dir}/libsycl-itt-user-wrappers.${lib-suffix}
                    MAIN_DEPENDENCY itt_user_wrappers.cpp
-                   DEPENDS device_itt.h spirv_vars.h device.h clang clang-offload-bundler
+                   DEPENDS device_itt.h spirv_vars.h device.h sycl-compiler
                    VERBATIM)
 
 set(devicelib-obj-itt-files
@@ -258,12 +258,12 @@ endif()
 set(install_dest_lib lib${LLVM_LIBDIR_SUFFIX})
 
 install(FILES ${devicelib-obj-file}
-	      ${obj_binary_dir}/libsycl-fallback-cassert.${lib-suffix}
-	      ${obj_binary_dir}/libsycl-fallback-cstring.${lib-suffix}
+              ${obj_binary_dir}/libsycl-fallback-cassert.${lib-suffix}
+              ${obj_binary_dir}/libsycl-fallback-cstring.${lib-suffix}
               ${devicelib-obj-complex}
-	      ${obj_binary_dir}/libsycl-fallback-complex.${lib-suffix}
+              ${obj_binary_dir}/libsycl-fallback-complex.${lib-suffix}
               ${devicelib-obj-complex-fp64}
-	      ${obj_binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
+              ${obj_binary_dir}/libsycl-fallback-complex-fp64.${lib-suffix}
               ${devicelib-obj-cmath}
               ${obj_binary_dir}/libsycl-fallback-cmath.${lib-suffix}
               ${devicelib-obj-cmath-fp64}

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -176,9 +176,8 @@ if (SYCL_ENABLE_XPTI_TRACING)
 endif()
 
 # SYCL toolchain builds all components: compiler, libraries, headers, etc.
-add_custom_target( sycl-toolchain
-  DEPENDS ${SYCL_RT_LIBS}
-          append-file
+add_custom_target(sycl-compiler
+  DEPENDS append-file
           clang
           clang-offload-wrapper
           clang-offload-bundler
@@ -193,8 +192,12 @@ add_custom_target( sycl-toolchain
           llvm-link
           llvm-objcopy
           sycl-post-link
-          sycl-ls
           opencl-aot
+)
+add_custom_target( sycl-toolchain
+  DEPENDS ${SYCL_RT_LIBS}
+          sycl-compiler
+          sycl-ls
           ${XPTIFW_LIBS}
   COMMENT "Building SYCL compiler toolchain..."
 )


### PR DESCRIPTION
Compilation in SYCL mode involves a lot of tools, which must be built
before compiler is used.