### PR TITLE
[SYCL] Construct context from first device in unit tests

### DIFF
--- a/sycl/unittests/kernel-and-program/DeviceInfo.cpp
+++ b/sycl/unittests/kernel-and-program/DeviceInfo.cpp
@@ -64,7 +64,7 @@ TEST_F(DeviceInfoTest, GetDeviceUUID) {
     return;
   }
 
-  context Ctx{Plt};
+  context Ctx{Plt.get_devices()[0]};
   TestContext.reset(new TestCtx(Ctx));
 
   device Dev = Ctx.get_devices()[0];

--- a/sycl/unittests/kernel-and-program/KernelInfo.cpp
+++ b/sycl/unittests/kernel-and-program/KernelInfo.cpp
@@ -123,7 +123,7 @@ TEST_F(KernelInfoTest, GetPrivateMemUsage) {
     return;
   }
 
-  context Ctx{Plt};
+  context Ctx{Plt.get_devices()[0]};
   program Prg{Ctx};
   TestContext.reset(new TestCtx(Ctx));
 

--- a/sycl/unittests/kernel-and-program/KernelRelease.cpp
+++ b/sycl/unittests/kernel-and-program/KernelRelease.cpp
@@ -103,7 +103,7 @@ TEST(KernelReleaseTest, GetKernelRelease) {
   Mock.redefine<detail::PiApiKind::piKernelSetExecInfo>(
       redefinedKernelSetExecInfo);
 
-  context Ctx{Plt};
+  context Ctx{Plt.get_devices()[0]};
   TestContext.reset(new TestCtx(Ctx));
 
   program Prg{Ctx};

--- a/sycl/unittests/queue/EventClear.cpp
+++ b/sycl/unittests/queue/EventClear.cpp
@@ -108,7 +108,7 @@ TEST(QueueEventClear, ClearOnQueueWait) {
   if (!preparePiMock(Plt))
     return;
 
-  context Ctx{Plt};
+  context Ctx{Plt.get_devices()[0]};
   TestContext.reset(new TestCtx(Ctx));
   queue Q{Ctx, default_selector()};
 
@@ -129,7 +129,7 @@ TEST(QueueEventClear, CleanupOnThreshold) {
   if (!preparePiMock(Plt))
     return;
 
-  context Ctx{Plt};
+  context Ctx{Plt.get_devices()[0]};
   TestContext.reset(new TestCtx(Ctx));
   queue Q{Ctx, default_selector()};
 

--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -112,7 +112,7 @@ TEST(QueueWait, QueueWaitTest) {
   platform Plt{default_selector()};
   if (!preparePiMock(Plt))
     return;
-  context Ctx{Plt};
+  context Ctx{Plt.get_devices()[0]};
   queue Q{Ctx, default_selector()};
 
   unsigned char *HostAlloc = (unsigned char *)malloc_host(1, Ctx);

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -79,9 +79,9 @@ TEST_F(SchedulerTest, CommandsWaitForEvents) {
   Mock.redefine<detail::PiApiKind::piEventRelease>(retainReleaseFunc);
   Mock.redefine<detail::PiApiKind::piEventGetInfo>(getEventInfoFunc);
 
-  context Ctx1{Plt};
+  context Ctx1{Plt.get_devices()[0]};
   queue Q1{Ctx1, Selector};
-  context Ctx2{Plt};
+  context Ctx2{Plt.get_devices()[0]};
   queue Q2{Ctx2, Selector};
 
   TestContext.reset(new TestCtx(Q1, Q2));

--- a/sycl/unittests/scheduler/InOrderQueueDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueDeps.cpp
@@ -97,7 +97,7 @@ TEST_F(SchedulerTest, InOrderQueueDeps) {
   Mock.redefine<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
   Mock.redefine<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
 
-  context Ctx{Plt};
+  context Ctx{Plt.get_devices()[0]};
   queue InOrderQueue{Ctx, Selector, property::queue::in_order()};
   cl::sycl::detail::QueueImplPtr InOrderQueueImpl =
       detail::getSyclObjImpl(InOrderQueue);


### PR DESCRIPTION
This is because multiple devices in a context is not supported with AOT
compiling, which is always used for the CUDA and ROCm pluginis, and
constructing the context from the platform may result in multiple
devices in the context if there are multiple devices available on the
system.

These tests are run with a device filter so this will only happen
when there is multiple devices of the same type. Which also means that
it should always be fine to take the first device from the platform as
it should still be of the expected device type.