### PR TITLE
[SYCL] sRGB device info fix

### DIFF
--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -184,9 +184,11 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
   case PI_DEVICE_INFO_UUID:
   case PI_DEVICE_INFO_ATOMIC_64:
     return PI_INVALID_VALUE;
-  case PI_DEVICE_INFO_IMAGE_SRGB:
+  case PI_DEVICE_INFO_IMAGE_SRGB: {
+    cl_bool result = true;
+    std::memcpy(paramValue, &result, sizeof(cl_bool));
     return PI_SUCCESS;
-
+  }
   default:
     cl_int result = clGetDeviceInfo(
         cast<cl_device_id>(device), cast<cl_device_info>(paramName),


### PR DESCRIPTION
fix for overlooked side-effect of setting return value for sRGB device info.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>