### PR TITLE
[SYCL] Fix the error with namespaces caused during rebase of #4014

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1396,8 +1396,8 @@ public:
       this->finalize();
       handler CopyHandler(QueueCopy, MIsHost);
       CopyHandler.saveCodeLoc(MCodeLoc);
-      ONEAPI::detail::reduSaveFinalResultToUserMem<KernelName>(CopyHandler,
-                                                               Redu);
+      ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(CopyHandler,
+                                                                    Redu);
       MLastEvent = CopyHandler.finalize();
     }
   }


### PR DESCRIPTION
During rebase of #4014 one of calls to
ONEAPI::detail::reduSaveFinalResultToUserMem was left as is,
while the implementation was moved to ext::oneapi::detail namespace.
That caused errors during compilation of parallel_for(range,reduction,func)
Fixed it here.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>