### PR TITLE
[SYCL] Revert queue::wait() to its old behaviour with Level Zero

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -263,41 +263,54 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
     WeakEvents.swap(MEventsWeak);
     SharedEvents.swap(MEventsShared);
   }
+  const detail::plugin &Plugin = getPlugin();
   // If the queue is either a host one or does not support OOO (and we use
   // multiple in-order queues as a result of that), wait for each event
   // directly. Otherwise, only wait for unenqueued or host task events, starting
   // from the latest submitted task in order to minimize total amount of calls,
   // then handle the rest with piQueueFinish.
-  bool SupportsPiFinish = !is_host() && MSupportOOO;
-  for (auto EventImplWeakPtrIt = WeakEvents.rbegin();
-       EventImplWeakPtrIt != WeakEvents.rend(); ++EventImplWeakPtrIt) {
-    if (std::shared_ptr<event_impl> EventImplSharedPtr =
-            EventImplWeakPtrIt->lock()) {
-      // A nullptr PI event indicates that piQueueFinish will not cover it,
-      // either because it's a host task event or an unenqueued one.
-      if (!SupportsPiFinish || nullptr == EventImplSharedPtr->getHandleRef()) {
-        EventImplSharedPtr->wait(EventImplSharedPtr);
-      }
-    }
-  }
-  if (SupportsPiFinish) {
-    const detail::plugin &Plugin = getPlugin();
-    Plugin.call<detail::PiApiKind::piQueueFinish>(getHandleRef());
+  // TODO the new workflow has worse performance with Level Zero, keep the old
+  // behavior until this is addressed
+  if (Plugin.getBackend() == backend::level_zero) {
     for (std::weak_ptr<event_impl> &EventImplWeakPtr : WeakEvents)
       if (std::shared_ptr<event_impl> EventImplSharedPtr =
               EventImplWeakPtr.lock())
-        EventImplSharedPtr->cleanupCommand(EventImplSharedPtr);
-    // FIXME these events are stored for level zero until as a workaround,
-    // remove once piEventRelease no longer calls wait on the event in the
-    // plugin.
-    if (Plugin.getBackend() == backend::level_zero) {
-      SharedEvents.clear();
-    }
-    assert(SharedEvents.empty() && "Queues that support calling piQueueFinish "
-                                   "shouldn't have shared events");
-  } else {
+        EventImplSharedPtr->wait(EventImplSharedPtr);
     for (event &Event : SharedEvents)
       Event.wait();
+  } else {
+    bool SupportsPiFinish = !is_host() && MSupportOOO;
+    for (auto EventImplWeakPtrIt = WeakEvents.rbegin();
+         EventImplWeakPtrIt != WeakEvents.rend(); ++EventImplWeakPtrIt) {
+      if (std::shared_ptr<event_impl> EventImplSharedPtr =
+              EventImplWeakPtrIt->lock()) {
+        // A nullptr PI event indicates that piQueueFinish will not cover it,
+        // either because it's a host task event or an unenqueued one.
+        if (!SupportsPiFinish ||
+            nullptr == EventImplSharedPtr->getHandleRef()) {
+          EventImplSharedPtr->wait(EventImplSharedPtr);
+        }
+      }
+    }
+    if (SupportsPiFinish) {
+      Plugin.call<detail::PiApiKind::piQueueFinish>(getHandleRef());
+      for (std::weak_ptr<event_impl> &EventImplWeakPtr : WeakEvents)
+        if (std::shared_ptr<event_impl> EventImplSharedPtr =
+                EventImplWeakPtr.lock())
+          EventImplSharedPtr->cleanupCommand(EventImplSharedPtr);
+      // FIXME these events are stored for level zero until as a workaround,
+      // remove once piEventRelease no longer calls wait on the event in the
+      // plugin.
+      if (Plugin.getBackend() == backend::level_zero) {
+        SharedEvents.clear();
+      }
+      assert(SharedEvents.empty() &&
+             "Queues that support calling piQueueFinish "
+             "shouldn't have shared events");
+    } else {
+      for (event &Event : SharedEvents)
+        Event.wait();
+    }
   }
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   instrumentationEpilog(TelemetryEvent, Name, StreamID, IId);

--- a/sycl/test/on-device/plugins/level_zero_batch_event_status.cpp
+++ b/sycl/test/on-device/plugins/level_zero_batch_event_status.cpp
@@ -25,10 +25,10 @@
 // CHECK:  ZE ---> zeCommandListClose
 // CHECK:  ZE ---> zeCommandQueueExecuteCommandLists
 // CHECK: ---> piEventGetInfo
-// CHECK-NOT: piQueueFinish
+// CHECK-NOT: piEventsWait
 // CHECK: ---> piEnqueueKernelLaunch
 // CHECK: ZE ---> zeCommandListAppendLaunchKernel
-// CHECK: ---> piQueueFinish
+// CHECK: ---> piEventsWait
 // Look for close and Execute after piEventsWait
 // CHECK:  ZE ---> zeCommandListClose
 // CHECK:  ZE ---> zeCommandQueueExecuteCommandLists

--- a/sycl/test/on-device/plugins/level_zero_batch_test.cpp
+++ b/sycl/test/on-device/plugins/level_zero_batch_test.cpp
@@ -86,7 +86,7 @@
 // CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB8:  ZE ---> zeCommandListClose(
 // CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKALL: ---> piQueueFinish(
+// CKALL: ---> piEventsWait(
 // CKB3:  ZE ---> zeCommandListClose(
 // CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB5:  ZE ---> zeCommandListClose(
@@ -142,7 +142,7 @@
 // CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB8:  ZE ---> zeCommandListClose(
 // CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKALL: ---> piQueueFinish(
+// CKALL: ---> piEventsWait(
 // CKB3:  ZE ---> zeCommandListClose(
 // CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB5:  ZE ---> zeCommandListClose(
@@ -198,7 +198,7 @@
 // CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB8:  ZE ---> zeCommandListClose(
 // CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKALL: ---> piQueueFinish(
+// CKALL: ---> piEventsWait(
 // CKB3:  ZE ---> zeCommandListClose(
 // CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
 // CKB5:  ZE ---> zeCommandListClose(

--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -92,6 +92,14 @@ bool preparePiMock(platform &Plt) {
               << std::endl;
     return false;
   }
+  // TODO remove once queue:wait() is lowered to PiQueueFinish with level zero
+  // as well.
+  if (detail::getSyclObjImpl(Plt)->getPlugin().getBackend() ==
+      backend::level_zero) {
+    std::cout << "Not run on Level Zero, old behavior is kept there temporarily"
+              << std::endl;
+    return false;
+  }
 
   unittest::PiMock Mock{Plt};
   Mock.redefine<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);


### PR DESCRIPTION
Revert the behaviour of queue::wait() to calling event::wait() on all
events associated with it for Level Zero backend due to significant
performance regressions introduced with that change.