### PR TITLE
[SYCL] Add missing <cstring> header to spirv.hpp

### DIFF
--- a/sycl/include/CL/sycl/detail/spirv.hpp
+++ b/sycl/include/CL/sycl/detail/spirv.hpp
@@ -15,6 +15,7 @@
 #include <CL/sycl/detail/type_traits.hpp>
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/memory_enums.hpp>
+#include <cstring>
 #include <sycl/ext/oneapi/atomic_enums.hpp>
 
 #ifdef __SYCL_DEVICE_ONLY__


### PR DESCRIPTION
The changes in #3815 introduced calls to std::memcpy without including
\<cstring\>, causing some tests to fail.

Signed-off-by: John Pennycook <john.pennycook@intel.com>