### PR TITLE
[SYCL] Return the correct status info for host_task event

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -295,9 +295,9 @@ event_impl::get_info<info::event::command_execution_status>() const {
     return get_event_info<info::event::command_execution_status>::get(
         this->getHandleRef(), this->getPlugin());
   }
-  return MState.load() == HES_Complete
-             ? info::event_command_status::complete
-             : sycl::info::event_command_status::submitted;
+  return MHostEvent && MState.load() != HES_Complete
+             ? sycl::info::event_command_status::submitted
+             : info::event_command_status::complete;
 }
 
 static uint64_t getTimestamp() {

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -295,7 +295,9 @@ event_impl::get_info<info::event::command_execution_status>() const {
     return get_event_info<info::event::command_execution_status>::get(
         this->getHandleRef(), this->getPlugin());
   }
-  return info::event_command_status::complete;
+  return MState.load() == HES_Complete
+             ? info::event_command_status::complete
+             : sycl::info::event_command_status::submitted;
 }
 
 static uint64_t getTimestamp() {


### PR DESCRIPTION
The method get_info<info::event::command_execution_status> returned
'completed' status for all events associated with host tasks.
Fixed it here.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>