### PR TITLE
[SYCL] Revert barrier deprecation note

### DIFF
--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -112,7 +112,6 @@ public:
                                 get_offset());
   }
 
-  __SYCL2020_DEPRECATED("use sycl::group_barrier() free function instead")
   void barrier(access::fence_space accessSpace =
                    access::fence_space::global_and_local) const {
     uint32_t flags = detail::getSPIRVMemorySemanticsMask(accessSpace);

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -116,8 +116,6 @@ int main() {
     CGH.parallel_for<class Test>(
         sycl::nd_range<1>{sycl::range{10}, sycl::range{10}, sycl::range{1}},
         [](sycl::nd_item<1> it) {
-          // expected-warning@+1{{'barrier' is deprecated: use sycl::group_barrier() free function instead}}
-          it.barrier();
           // expected-warning@+2{{'mem_fence' is deprecated: use sycl::group_barrier() free function instead}}
           // expected-warning@+1{{'mem_fence<sycl::access::mode::read_write>' is deprecated: use sycl::group_barrier() free function instead}}
           it.mem_fence();


### PR DESCRIPTION
New barrier is different from SYCL 1.2.1 and is known to cause
performance regressions on some configurations. Remove deprecation
notice from older barrier until the issue is sorted out.