### PR TITLE
[SYCL] Correct int-header emission with type aliases

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4435,6 +4435,7 @@ public:
     Policy.adjustForCPlusPlusFwdDecl();
     Policy.SuppressTypedefs = true;
     Policy.SuppressUnwrittenScope = true;
+    Policy.PrintCanonicalTypes = true;
   }
 
   void Visit(QualType T) {

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -3,7 +3,7 @@
 #define ATTR_SYCL_KERNEL __attribute__((sycl_kernel))
 
 // Dummy runtime classes to model SYCL API.
-namespace cl {
+inline namespace cl {
 namespace sycl {
 struct sampler_impl {
 #ifdef __SYCL_DEVICE_ONLY__
@@ -60,6 +60,8 @@ enum class address_space : int {
   local_space
 };
 } // namespace access
+using access::target;
+using access_mode = access::mode;
 
 namespace property {
 

--- a/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-srcpos-kernel.cpp
@@ -29,11 +29,11 @@ int main() {
 // CHECK: call spir_func void {{.*}}6__init{{.*}} !dbg [[LINE_A0]]
 // CHECK: call spir_func void @_ZZ4mainENKUlvE_clEv{{.*}} !dbg [[LINE_B0:![0-9]+]]
 // CHECK: ret void, !dbg [[LINE_C0:![0-9]+]]
-// CHECK: [[FILE:![0-9]+]] = !DIFile(filename: "{{.*}}debug-info-srcpos-kernel.cpp"{{.*}})
 // CHECK: [[KERNEL]] = {{.*}}!DISubprogram(name: "{{.*}}19use_kernel_for_test"
-// CHECK-SAME: scope: [[FILE]]
-// CHECK-SAME: file: [[FILE]]
+// CHECK-SAME: scope: [[FILE:![0-9]+]],
+// CHECK-SAME: file: [[FILE]],
 // CHECK-SAME: flags: DIFlagArtificial | DIFlagPrototyped
+// CHECK: [[FILE]] = !DIFile(filename: "{{.*}}debug-info-srcpos-kernel.cpp"{{.*}})
 // CHECK: [[LINE_A0]] = !DILocation(line: 15,{{.*}}scope: [[KERNEL]]
 // CHECK: [[LINE_B0]] = !DILocation(line: 16,{{.*}}scope: [[BLOCK:![0-9]+]]
 // CHECK: [[BLOCK]] = distinct !DILexicalBlock(scope: [[KERNEL]]

--- a/clang/test/CodeGenSYCL/int_header_enum_type_alias.cpp
+++ b/clang/test/CodeGenSYCL/int_header_enum_type_alias.cpp
@@ -9,14 +9,14 @@
 // print the actual name, not the alias name.
 
 // CHECK: Forward declarations of templated kernel function types:
-// CHECK: inline namespace cl { namespace sycl { namespace access {
-// CHECK: enum class mode : int;
-// CHECK: }}}
-// CHECK: inline namespace cl { namespace sycl { namespace access {
-// CHECK: enum class target : int;
-// CHECK: }}}
+// CHECK-NEXT: inline namespace cl { namespace sycl { namespace access {
+// CHECK-NEXT: enum class mode : int;
+// CHECK-NEXT: }}}
+// CHECK-NEXT: inline namespace cl { namespace sycl { namespace access {
+// CHECK-NEXT: enum class target : int;
+// CHECK-NEXT: }}}
 // This is the important line, we make sure we look through the type alias.
-// CHECK: template <sycl::access::mode mode, sycl::access::target target> struct get_kernel;
+// CHECK-NEXT: template <sycl::access::mode mode, sycl::access::target target> struct get_kernel;
 
 // The key here is that we are accessing these types via the type alias.
 template<sycl::access_mode mode, sycl::target target>

--- a/clang/test/CodeGenSYCL/int_header_enum_type_alias.cpp
+++ b/clang/test/CodeGenSYCL/int_header_enum_type_alias.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -fsycl-int-header=%t.h %s -o %t.out
+// RUN: FileCheck -input-file=%t.h %s
+
+#include "sycl.hpp"
+// Test to ensure that the integration header doesn't get confused by type
+// aliases. The sycl::access::target and sycl::access::mode scoped enums
+// were brought into the 'sycl' namespace (as target and acccess_mode) via
+// type aliases, which confused the int-header printer.  Make sure we correctly
+// print the actual name, not the alias name.
+
+// CHECK: Forward declarations of templated kernel function types:
+// CHECK: inline namespace cl { namespace sycl { namespace access {
+// CHECK: enum class mode : int;
+// CHECK: }}}
+// CHECK: inline namespace cl { namespace sycl { namespace access {
+// CHECK: enum class target : int;
+// CHECK: }}}
+// This is the important line, we make sure we look through the type alias.
+// CHECK: template <sycl::access::mode mode, sycl::access::target target> struct get_kernel;
+
+// The key here is that we are accessing these types via the type alias.
+template<sycl::access_mode mode, sycl::target target>
+struct get_kernel{};
+
+void foo() {
+  using kernel_name = get_kernel<sycl::access_mode::read,
+                                 sycl::target::host_buffer>;
+  sycl::kernel_single_task<kernel_name>([](){});
+}


### PR DESCRIPTION
Enums weren't correctly being printed when hidden by a type-alias, which
caused the integration header to not properly compile.  This was made
worse by the fact that the two enums in the test were exposed as type
aliases in the sycl headers for 2020.

This patch makes sure we always print the canonical name, rather than
having to try to figure out what type aliases need to be printed in
forward declarations.