### PR TITLE
[Driver] Fix default MSVC version setting for -fms-compatibilty-version

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4639,7 +4639,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                                              MSVT.getAsString()));
       else {
         const char *LowestMSVCSupported =
-            "191025017"; // VS2017 v15.0 (initial release)
+            "19.10.25017"; // VS2017 v15.0 (initial release)
         CmdArgs.push_back(Args.MakeArgString(
             Twine("-fms-compatibility-version=") + LowestMSVCSupported));
       }


### PR DESCRIPTION
The input for -fms-compatibilty-version is expected to be of format:
Major[.Minor[.Micro[.Build]]]
Minor can only be 2 digits, Micro can only be 5, and 'build' is ignored.