### PR TITLE
[Driver][SYCL] Enable way to emit int-footer source to a specific dir

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2635,6 +2635,9 @@ def fsycl_host_compiler_options_EQ : Joined<["-"], "fsycl-host-compiler-options=
 def fno_sycl_use_footer : Flag<["-"], "fno-sycl-use-footer">, Flags<[CoreOption]>,
   HelpText<"Disable usage of the integration footer during SYCL enabled "
    "compilations.">;
+def fsycl_footer_path_EQ : Joined<["-"], "fsycl-footer-path=">,
+  Flags<[CoreOption]>, HelpText<"Specify the location of the temporary "
+  "integration footer source file.">;
 def fsyntax_only : Flag<["-"], "fsyntax-only">,
   Flags<[NoXarchOption,CoreOption,CC1Option,FC1Option]>, Group<Action_Group>;
 def ftabstop_EQ : Joined<["-"], "ftabstop=">, Group<f_Group>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2637,7 +2637,7 @@ def fno_sycl_use_footer : Flag<["-"], "fno-sycl-use-footer">, Flags<[CoreOption]
    "compilations.">;
 def fsycl_footer_path_EQ : Joined<["-"], "fsycl-footer-path=">,
   Flags<[CoreOption]>, HelpText<"Specify the location of the temporary "
-  "integration footer source file.">;
+  "source file with the included integration footer.">;
 def fsyntax_only : Flag<["-"], "fsyntax-only">,
   Flags<[NoXarchOption,CoreOption,CC1Option,FC1Option]>, Group<Action_Group>;
 def ftabstop_EQ : Joined<["-"], "ftabstop=">, Group<f_Group>;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6758,8 +6758,9 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     if (Arg *A = C.getArgs().getLastArg(options::OPT_fsycl_footer_path_EQ)) {
       SmallString<128> OutName(A->getValue());
       StringRef BaseName = llvm::sys::path::filename(BaseInput);
-      std::string TmpName = GetTemporaryPath(llvm::sys::path::stem(BaseName),
-          types::getTypeTempSuffix(JA.getType()));
+      std::string TmpName =
+          GetTemporaryPath(llvm::sys::path::stem(BaseName),
+                           types::getTypeTempSuffix(JA.getType()));
       llvm::sys::path::append(OutName, llvm::sys::path::filename(TmpName));
       return C.addTempFile(C.getArgs().MakeArgString(OutName));
     }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6753,6 +6753,18 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
         &JA);
   }
 
+  // Redirect output for the generated source + integration footer.
+  if (isa<AppendFooterJobAction>(JA) && !isSaveTempsEnabled()) {
+    if (Arg *A = C.getArgs().getLastArg(options::OPT_fsycl_footer_path_EQ)) {
+      SmallString<128> OutName(A->getValue());
+      StringRef BaseName = llvm::sys::path::filename(BaseInput);
+      std::string TmpName = GetTemporaryPath(llvm::sys::path::stem(BaseName),
+          types::getTypeTempSuffix(JA.getType()));
+      llvm::sys::path::append(OutName, llvm::sys::path::filename(TmpName));
+      return C.addTempFile(C.getArgs().MakeArgString(OutName));
+    }
+  }
+
   // Default to writing to stdout?
   if (AtTopLevel && !CCGenDiagnostics && HasPreprocessOutput(JA)) {
     return "-";

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6770,8 +6770,7 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
         Suffixed += '.';
         Suffixed += Suffix;
         llvm::sys::path::append(OutName, Suffixed.c_str());
-      }
-      else {
+      } else {
         TmpName = GetTemporaryPath(llvm::sys::path::stem(BaseName),
                                    types::getTypeTempSuffix(JA.getType()));
         llvm::sys::path::append(OutName, llvm::sys::path::filename(TmpName));

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6754,14 +6754,28 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
   }
 
   // Redirect output for the generated source + integration footer.
-  if (isa<AppendFooterJobAction>(JA) && !isSaveTempsEnabled()) {
+  if (isa<AppendFooterJobAction>(JA)) {
     if (Arg *A = C.getArgs().getLastArg(options::OPT_fsycl_footer_path_EQ)) {
       SmallString<128> OutName(A->getValue());
       StringRef BaseName = llvm::sys::path::filename(BaseInput);
-      std::string TmpName =
-          GetTemporaryPath(llvm::sys::path::stem(BaseName),
-                           types::getTypeTempSuffix(JA.getType()));
-      llvm::sys::path::append(OutName, llvm::sys::path::filename(TmpName));
+      std::string TmpName;
+      if (isSaveTempsEnabled()) {
+        // Retain the location specified by the user with -save-temps.
+        const char *Suffix = types::getTypeTempSuffix(JA.getType());
+        std::string::size_type End = std::string::npos;
+        if (!types::appendSuffixForType(JA.getType()))
+          End = BaseName.rfind('.');
+        SmallString<128> Suffixed(BaseName.substr(0, End));
+        Suffixed += OffloadingPrefix;
+        Suffixed += '.';
+        Suffixed += Suffix;
+        llvm::sys::path::append(OutName, Suffixed.c_str());
+      }
+      else {
+        TmpName = GetTemporaryPath(llvm::sys::path::stem(BaseName),
+                                   types::getTypeTempSuffix(JA.getType()));
+        llvm::sys::path::append(OutName, llvm::sys::path::filename(TmpName));
+      }
       return C.addTempFile(C.getArgs().MakeArgString(OutName));
     }
   }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6758,7 +6758,6 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     if (Arg *A = C.getArgs().getLastArg(options::OPT_fsycl_footer_path_EQ)) {
       SmallString<128> OutName(A->getValue());
       StringRef BaseName = llvm::sys::path::filename(BaseInput);
-      std::string TmpName;
       if (isSaveTempsEnabled()) {
         // Retain the location specified by the user with -save-temps.
         const char *Suffix = types::getTypeTempSuffix(JA.getType());
@@ -6771,8 +6770,9 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
         Suffixed += Suffix;
         llvm::sys::path::append(OutName, Suffixed.c_str());
       } else {
-        TmpName = GetTemporaryPath(llvm::sys::path::stem(BaseName),
-                                   types::getTypeTempSuffix(JA.getType()));
+        std::string TmpName =
+            GetTemporaryPath(llvm::sys::path::stem(BaseName),
+                             types::getTypeTempSuffix(JA.getType()));
         llvm::sys::path::append(OutName, llvm::sys::path::filename(TmpName));
       }
       return C.addTempFile(C.getArgs().MakeArgString(OutName));

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -60,3 +60,9 @@
 // COMMON-PHASES: [[#OFFLOAD+9]]: file-table-tform, {[[#OFFLOAD+6]], [[#OFFLOAD+8]]}, tempfiletable, (device-sycl)
 // COMMON-PHASES: [[#OFFLOAD+10]]: clang-offload-wrapper, {[[#OFFLOAD+9]]}, object, (device-sycl)
 // COMMON-PHASES: [[#OFFLOAD+11]]: offload, "host-sycl (x86_64-{{.*}})" {[[#OFFLOAD+4]]}, "device-sycl (spir64-unknown-unknown-sycldevice)" {[[#OFFLOAD+10]]}, image
+
+/// Test for -fsycl-footer-path=<dir>
+// RUN:  %clangxx -fsycl -fsycl-footer-path=/dummy/path %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix FOOTER_PATH %s
+// FOOTER_PATH: append-file{{.*}} "--output=/dummy/path/[[APPENDEDSRC:.+\.cpp]]"
+// FOOTER_PATH: clang{{.*}} "-x" "c++" "/dummy/path/[[APPENDEDSRC]]"

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -62,7 +62,7 @@
 // COMMON-PHASES: [[#OFFLOAD+11]]: offload, "host-sycl (x86_64-{{.*}})" {[[#OFFLOAD+4]]}, "device-sycl (spir64-unknown-unknown-sycldevice)" {[[#OFFLOAD+10]]}, image
 
 /// Test for -fsycl-footer-path=<dir>
-// RUN:  %clangxx -fsycl -fsycl-footer-path=/dummy/path %s -### 2>&1 \
+// RUN:  %clangxx -fsycl -fsycl-footer-path=dummy_dir %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER_PATH %s
-// FOOTER_PATH: append-file{{.*}} "--output=/dummy/path/[[APPENDEDSRC:.+\.cpp]]"
-// FOOTER_PATH: clang{{.*}} "-x" "c++" "/dummy/path/[[APPENDEDSRC]]"
+// FOOTER_PATH: append-file{{.*}} "--output=dummy_dir{{(/|\\\\)}}[[APPENDEDSRC:.+\.cpp]]"
+// FOOTER_PATH: clang{{.*}} "-x" "c++" "dummy_dir{{(/|\\\\)}}[[APPENDEDSRC]]"


### PR DESCRIPTION
During an -fsycl enabled build, we use an integration footer during the
host portion of the compilation.  This requires to create a temporary
file that is based on the original source file and contains the generated
footer.

Some build systems recognize this additional file that is being generated
and is not part of any expected generated dependency.  Introduce an option
that allows the user to specify the location in which this new source
file is created so the build system can properly track and recognize its
creation.  The new option is -fsycl-footer-path=<path>