### PR TITLE
[SYCL] Fix some Doxygen build warnings

### DIFF
--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -106,6 +106,7 @@ public:
   /// PropList.
   ///
   /// \param Platform is an instance of SYCL platform.
+  /// \param AsyncHandler is an instance of async_handler.
   /// \param PropList is an instance of property_list.
   explicit context(const platform &Platform, async_handler AsyncHandler,
                    const property_list &PropList = {});

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -1145,7 +1145,7 @@ __SYCL_EXPORT pi_result piclProgramCreateWithSource(pi_context context,
 ///                      succesfully or not, for each device in device_list.
 ///                      binary_status is ignored if it is null and otherwise
 ///                      it must be an array of num_devices elements.
-/// \param program is the PI program created from the program binaries.
+/// \param ret_program is the PI program created from the program binaries.
 __SYCL_EXPORT pi_result piProgramCreateWithBinary(
     pi_context context, pi_uint32 num_devices, const pi_device *device_list,
     const size_t *lengths, const unsigned char **binaries,
@@ -1559,8 +1559,8 @@ using pi_usm_migration_flags = _pi_usm_migration_flags;
 ///
 /// \param result_ptr contains the allocated memory
 /// \param context is the pi_context
-/// \param pi_usm_mem_properties are optional allocation properties
-/// \param size_t is the size of the allocation
+/// \param properties are optional allocation properties
+/// \param size is the size of the allocation
 /// \param alignment is the desired alignment of the allocation
 __SYCL_EXPORT pi_result piextUSMHostAlloc(void **result_ptr, pi_context context,
                                           pi_usm_mem_properties *properties,
@@ -1571,8 +1571,8 @@ __SYCL_EXPORT pi_result piextUSMHostAlloc(void **result_ptr, pi_context context,
 /// \param result_ptr contains the allocated memory
 /// \param context is the pi_context
 /// \param device is the device the memory will be allocated on
-/// \param pi_usm_mem_properties are optional allocation properties
-/// \param size_t is the size of the allocation
+/// \param properties are optional allocation properties
+/// \param size is the size of the allocation
 /// \param alignment is the desired alignment of the allocation
 __SYCL_EXPORT pi_result piextUSMDeviceAlloc(void **result_ptr,
                                             pi_context context,
@@ -1585,8 +1585,8 @@ __SYCL_EXPORT pi_result piextUSMDeviceAlloc(void **result_ptr,
 /// \param result_ptr contains the allocated memory
 /// \param context is the pi_context
 /// \param device is the device the memory will be allocated on
-/// \param pi_usm_mem_properties are optional allocation properties
-/// \param size_t is the size of the allocation
+/// \param properties are optional allocation properties
+/// \param size is the size of the allocation
 /// \param alignment is the desired alignment of the allocation
 __SYCL_EXPORT pi_result piextUSMSharedAlloc(void **result_ptr,
                                             pi_context context,
@@ -1676,7 +1676,7 @@ __SYCL_EXPORT pi_result piextUSMEnqueueMemAdvise(pi_queue queue,
 /// \param param_name is the type of query to perform
 /// \param param_value_size is the size of the result in bytes
 /// \param param_value is the result
-/// \param param_value_ret is how many bytes were written
+/// \param param_value_size_ret is how many bytes were written
 __SYCL_EXPORT pi_result piextUSMGetMemAllocInfo(
     pi_context context, const void *ptr, pi_mem_info param_name,
     size_t param_value_size, void *param_value, size_t *param_value_size_ret);

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4647,7 +4647,7 @@ pi_result cuda_piextUSMEnqueueMemAdvise(pi_queue queue, const void *ptr,
 /// \param param_name is the type of query to perform
 /// \param param_value_size is the size of the result in bytes
 /// \param param_value is the result
-/// \param param_value_ret is how many bytes were written
+/// \param param_value_size_ret is how many bytes were written
 pi_result cuda_piextUSMGetMemAllocInfo(pi_context context, const void *ptr,
                                        pi_mem_info param_name,
                                        size_t param_value_size,

--- a/sycl/source/detail/program_impl.hpp
+++ b/sycl/source/detail/program_impl.hpp
@@ -45,6 +45,7 @@ public:
   /// with the context.
   ///
   /// \param Context is a pointer to SYCL context impl.
+  /// \param PropList is an instance of property_list.
   explicit program_impl(ContextImplPtr Context, const property_list &PropList);
 
   /// Constructs an instance of SYCL program for the provided DeviceList.
@@ -55,6 +56,7 @@ public:
   ///
   /// \param Context is a pointer to SYCL context impl.
   /// \param DeviceList is a list of SYCL devices.
+  /// \param PropList is an instance of property_list.
   program_impl(ContextImplPtr Context, std::vector<device> DeviceList,
                const property_list &PropList);
 
@@ -72,6 +74,7 @@ public:
   ///
   /// \param ProgramList is a list of program_impl instances.
   /// \param LinkOptions is a string containing valid OpenCL link options.
+  /// \param PropList is an instance of property_list.
   program_impl(std::vector<std::shared_ptr<program_impl>> ProgramList,
                std::string LinkOptions, const property_list &PropList);
 

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -432,14 +432,14 @@ public:
 
   /// Allocate buffers in the pool for a provided stream
   ///
-  /// \param Pointer to the stream object
-  /// \param Size of the stream buffer
-  /// \param Size of the flush buffer for a single work item
+  /// \param Impl to the stream object
+  /// \param StreamBufferSize of the stream buffer
+  /// \param FlushBufferSize of the flush buffer for a single work item
   void allocateStreamBuffers(stream_impl *, size_t, size_t);
 
   /// Deallocate all stream buffers in the pool
   ///
-  /// \param Pointer to the stream object
+  /// \param Impl to the stream object
   void deallocateStreamBuffers(stream_impl *);
 
   QueueImplPtr getDefaultHostQueue() { return DefaultHostQueue; }
@@ -737,7 +737,6 @@ protected:
     /// Enqueues the command and all its dependencies.
     ///
     /// \param EnqueueResult is set to specific status if enqueue failed.
-    /// \param GraphReadLock read-lock which is already acquired for reading
     /// \return true if the command is successfully enqueued.
     ///
     /// The function may unlock and lock GraphReadLock as needed. Upon return

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -325,8 +325,8 @@ void *aligned_alloc(size_t Alignment, size_t Size, const queue &Q, alloc Kind,
 /// Query the allocation type from a USM pointer
 /// Returns alloc::host for all pointers in a host context.
 ///
-/// \param ptr is the USM pointer to query
-/// \param ctxt is the sycl context the ptr was allocated in
+/// \param Ptr is the USM pointer to query
+/// \param Ctxt is the sycl context the ptr was allocated in
 alloc get_pointer_type(const void *Ptr, const context &Ctxt) {
   if (!Ptr)
     return alloc::unknown;
@@ -375,8 +375,8 @@ alloc get_pointer_type(const void *Ptr, const context &Ctxt) {
 
 /// Queries the device against which the pointer was allocated
 ///
-/// \param ptr is the USM pointer to query
-/// \param ctxt is the sycl context the ptr was allocated in
+/// \param Ptr is the USM pointer to query
+/// \param Ctxt is the sycl context the ptr was allocated in
 device get_pointer_device(const void *Ptr, const context &Ctxt) {
   // Check if ptr is a valid USM pointer
   if (get_pointer_type(Ptr, Ctxt) == alloc::unknown)


### PR DESCRIPTION
This is done as a part of https://github.com/intel/llvm/issues/4140

* Changed several parameter types to parameter argument names (under \param tag)
* Renamed parameter names as they were changes in code, but not in documentation comment