### PR TITLE
[SYCL][LIBCLC] Add atan and cbrt for amdgcn-amdhsa

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/SOURCES
+++ b/libclc/amdgcn-amdhsa/libspirv/SOURCES
@@ -5,3 +5,5 @@ synchronization/barrier.cl
 math/cos.cl
 math/sin.cl
 math/sqrt.cl
+math/atan.cl
+math/cbrt.cl

--- a/libclc/amdgcn-amdhsa/libspirv/math/atan.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/math/atan.cl
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <clcmacro.h>
+#include <spirv/spirv.h>
+
+double __ocml_atan_f64(double);
+float __ocml_atan_f32(float);
+
+#define __CLC_FUNCTION __spirv_ocl_atan
+#define __CLC_BUILTIN __ocml_atan
+#define __CLC_BUILTIN_F __CLC_XCONCAT(__CLC_BUILTIN, _f32)
+#define __CLC_BUILTIN_D __CLC_XCONCAT(__CLC_BUILTIN, _f64)
+#include <math/unary_builtin.inc>

--- a/libclc/amdgcn-amdhsa/libspirv/math/cbrt.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/math/cbrt.cl
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <clcmacro.h>
+#include <spirv/spirv.h>
+
+double __ocml_cbrt_f64(double);
+float __ocml_cbrt_f32(float);
+
+#define __CLC_FUNCTION __spirv_ocl_cbrt
+#define __CLC_BUILTIN __ocml_cbrt
+#define __CLC_BUILTIN_F __CLC_XCONCAT(__CLC_BUILTIN, _f32)
+#define __CLC_BUILTIN_D __CLC_XCONCAT(__CLC_BUILTIN, _f64)
+#include <math/unary_builtin.inc>


### PR DESCRIPTION
Use AMD's `__ocml` functions to implement cbrt and atan spir-v builtins.