### PR TITLE
[SYCL][CUDA] Cuda plugin improvement to run small kernels

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -245,15 +245,16 @@ int getAttribute(pi_device device, CUdevice_attribute attribute) {
 // The default threadsPerBlock only require handling the first work_dim
 // dimension.
 void guessLocalWorkSize(int *threadsPerBlock, const size_t *global_work_size,
-                        const size_t maxThreadsPerBlock[3], pi_kernel kernel) {
+                        const size_t maxThreadsPerBlock[3], pi_kernel kernel,
+                        pi_uint32 local_size) {
   assert(threadsPerBlock != nullptr);
   assert(global_work_size != nullptr);
   assert(kernel != nullptr);
   int recommendedBlockSize, minGrid;
 
   PI_CHECK_ERROR(cuOccupancyMaxPotentialBlockSize(
-      &minGrid, &recommendedBlockSize, kernel->get(), NULL,
-      kernel->get_local_size(), maxThreadsPerBlock[0]));
+      &minGrid, &recommendedBlockSize, kernel->get(), NULL, local_size,
+      maxThreadsPerBlock[0]));
 
   (void)minGrid; // Not used, avoid warnings
 
@@ -667,6 +668,10 @@ public:
 //-- PI API implementation
 extern "C" {
 
+pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
+                               size_t param_value_size, void *param_value,
+                               size_t *param_value_size_ret);
+
 /// Obtains the CUDA platform.
 /// There is only one CUDA platform, and contains all devices on the system.
 /// Triggers the CUDA Driver initialization (cuInit) the first time, so this
@@ -709,6 +714,25 @@ pi_result cuda_piPlatformsGet(pi_uint32 num_entries, pi_platform *platforms,
               err = PI_CHECK_ERROR(cuDeviceGet(&device, i));
               platformId.devices_.emplace_back(
                   new _pi_device{device, &platformId});
+              {
+                const auto &dev = platformId.devices_.back().get();
+                size_t maxWorkGroupSize = 0u;
+                size_t maxThreadsPerBlock[3] = {};
+                pi_result retError = cuda_piDeviceGetInfo(
+                    dev, PI_DEVICE_INFO_MAX_WORK_ITEM_SIZES,
+                    sizeof(maxThreadsPerBlock), maxThreadsPerBlock, nullptr);
+                assert(retError == PI_SUCCESS);
+                (void)retError;
+
+                retError = cuda_piDeviceGetInfo(
+                    dev, PI_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
+                    sizeof(maxWorkGroupSize), &maxWorkGroupSize, nullptr);
+                assert(retError == PI_SUCCESS);
+
+                dev->save_max_work_item_sizes(sizeof(maxThreadsPerBlock),
+                                              maxThreadsPerBlock);
+                dev->save_max_work_group_size(maxWorkGroupSize);
+              }
             }
           } catch (const std::bad_alloc &) {
             // Signal out-of-memory situation
@@ -2535,6 +2559,7 @@ pi_result cuda_piEnqueueKernelLaunch(
   size_t maxThreadsPerBlock[3] = {};
   size_t reqdThreadsPerBlock[3] = {};
   bool providedLocalWorkGroupSize = (local_work_size != nullptr);
+  pi_uint32 local_size = kernel->get_local_size();
 
   {
     pi_result retError = cuda_piKernelGetGroupInfo(
@@ -2543,16 +2568,9 @@ pi_result cuda_piEnqueueKernelLaunch(
         sizeof(reqdThreadsPerBlock), reqdThreadsPerBlock, nullptr);
     assert(retError == PI_SUCCESS);
 
-    retError = cuda_piDeviceGetInfo(
-        command_queue->device_, PI_DEVICE_INFO_MAX_WORK_ITEM_SIZES,
-        sizeof(maxThreadsPerBlock), maxThreadsPerBlock, nullptr);
-    assert(retError == PI_SUCCESS);
-    (void)retError;
-
-    retError = cuda_piDeviceGetInfo(
-        command_queue->device_, PI_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
-        sizeof(maxWorkGroupSize), &maxWorkGroupSize, nullptr);
-    assert(retError == PI_SUCCESS);
+    maxWorkGroupSize = command_queue->device_->get_max_work_group_size();
+    command_queue->device_->get_max_work_item_sizes(sizeof(maxThreadsPerBlock),
+                                                    maxThreadsPerBlock);
 
     if (providedLocalWorkGroupSize) {
       auto isValid = [&](int dim) {
@@ -2580,7 +2598,7 @@ pi_result cuda_piEnqueueKernelLaunch(
       }
     } else {
       guessLocalWorkSize(threadsPerBlock, global_work_size, maxThreadsPerBlock,
-                         kernel);
+                         kernel, local_size);
     }
   }
 
@@ -2605,8 +2623,10 @@ pi_result cuda_piEnqueueKernelLaunch(
     CUstream cuStream = command_queue->get();
     CUfunction cuFunc = kernel->get();
 
-    retError = cuda_piEnqueueEventsWait(command_queue, num_events_in_wait_list,
-                                        event_wait_list, nullptr);
+    if (event_wait_list) {
+      retError = cuda_piEnqueueEventsWait(
+          command_queue, num_events_in_wait_list, event_wait_list, nullptr);
+    }
 
     // Set the implicit global offset parameter if kernel has offset variant
     if (kernel->get_with_offset_parameter()) {
@@ -2624,7 +2644,7 @@ pi_result cuda_piEnqueueKernelLaunch(
                                       cuda_implicit_offset);
     }
 
-    auto argIndices = kernel->get_arg_indices();
+    auto &argIndices = kernel->get_arg_indices();
 
     if (event) {
       retImplEv = std::unique_ptr<_pi_event>(_pi_event::make_native(
@@ -2634,14 +2654,13 @@ pi_result cuda_piEnqueueKernelLaunch(
 
     retError = PI_CHECK_ERROR(cuLaunchKernel(
         cuFunc, blocksPerGrid[0], blocksPerGrid[1], blocksPerGrid[2],
-        threadsPerBlock[0], threadsPerBlock[1], threadsPerBlock[2],
-        kernel->get_local_size(), cuStream, argIndices.data(), nullptr));
-    kernel->clear_local_size();
-    if (event) {
-      retError = retImplEv->record();
-    }
+        threadsPerBlock[0], threadsPerBlock[1], threadsPerBlock[2], local_size,
+        cuStream, const_cast<void **>(argIndices.data()), nullptr));
+    if (local_size != 0)
+      kernel->clear_local_size();
 
     if (event) {
+      retError = retImplEv->record();
       *event = retImplEv.release();
     }
   } catch (pi_result err) {

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -72,6 +72,10 @@ private:
   std::atomic_uint32_t refCount_;
   pi_platform platform_;
 
+  static constexpr pi_uint32 max_work_item_dimensions = 3u;
+  size_t max_work_item_sizes[max_work_item_dimensions];
+  int max_work_group_size;
+
 public:
   _pi_device(native_type cuDevice, pi_platform platform)
       : cuDevice_(cuDevice), refCount_{1}, platform_(platform) {}
@@ -81,6 +85,22 @@ public:
   pi_uint32 get_reference_count() const noexcept { return refCount_; }
 
   pi_platform get_platform() const noexcept { return platform_; };
+
+  void save_max_work_item_sizes(size_t size,
+                                size_t *save_max_work_item_sizes) noexcept {
+    memcpy(max_work_item_sizes, save_max_work_item_sizes, size);
+  };
+
+  void save_max_work_group_size(int value) noexcept {
+    max_work_group_size = value;
+  };
+
+  void get_max_work_item_sizes(size_t ret_size,
+                               size_t *ret_max_work_item_sizes) const noexcept {
+    memcpy(ret_max_work_item_sizes, max_work_item_sizes, ret_size);
+  };
+
+  int get_max_work_group_size() const noexcept { return max_work_group_size; };
 };
 
 /// PI context mapping to a CUDA context object.
@@ -623,7 +643,7 @@ struct _pi_kernel {
       std::fill(std::begin(offsetPerIndex_), std::end(offsetPerIndex_), 0);
     }
 
-    args_index_t get_indices() const noexcept { return indices_; }
+    const args_index_t &get_indices() const noexcept { return indices_; }
 
     pi_uint32 get_local_size() const {
       return std::accumulate(std::begin(offsetPerIndex_),
@@ -689,7 +709,7 @@ struct _pi_kernel {
     args_.set_implicit_offset(size, implicitOffset);
   }
 
-  arguments::args_index_t get_arg_indices() const {
+  const arguments::args_index_t &get_arg_indices() const {
     return args_.get_indices();
   }
 


### PR DESCRIPTION
This patch aims to improve run of small kernels.
`cuda_piEnqueueKernelLaunch()` spends a significant portion of its time in 2 `cuda_piDeviceGetInfo()` calls, which are all 4 `cuDeviceGetAttribute()` calls to the cuda device for each submission. This information can be obtained once when taking devices in `cuda_piPlatformsGet()` which will significantly reduce the submission time.

Other improvements:
-  reduce unnecessary `cuda_piEnqueueEventsWait()` with `ScopedContext` creation/deletion and with additional `cuCtxGetCurrent()` call to cuda device if `event_wait_list` is empty.
- reduce the number of `clear_local_size()` calls with expensive `std::fill()`, do it in case if it is really needed.
- reduce double computation time with expensive `std::accumulate()` in `get_local_size()` in cases where you go to `guessLocalWorkSize()`.
- reduce the time spent on vector copying by `get_arg_indices()`.

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>