### PR TITLE
[SYCL] Fast launch of kernels that have no dependencies

### DIFF
--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -542,6 +542,7 @@ private:
   std::unique_ptr<detail::CG> MCommandGroup;
 
   friend class Command;
+  friend class Scheduler;
 };
 
 class UpdateHostRequirementCommand : public Command {

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -86,6 +86,59 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
         initStream(Stream, Queue);
       }
     }
+
+    if (CommandGroup->MRequirements.size() + CommandGroup->MEvents.size() ==
+        0) {
+      ExecCGCommand *NewCmd(
+          new ExecCGCommand(std::move(CommandGroup), std::move(Queue)));
+      if (!NewCmd)
+        throw runtime_error("Out of host memory", PI_OUT_OF_HOST_MEMORY);
+      NewEvent = NewCmd->getEvent();
+
+      auto CleanUp = [&]() {
+        NewEvent->setCommand(nullptr);
+        delete NewCmd;
+      };
+
+      if (MGraphBuilder
+              .MPrintOptionsArray[GraphBuilder::PrintOptions::BeforeAddCG])
+        MGraphBuilder.printGraphAsDot("before_addCG");
+      if (MGraphBuilder
+              .MPrintOptionsArray[GraphBuilder::PrintOptions::AfterAddCG])
+        MGraphBuilder.printGraphAsDot("after_addCG");
+
+      try {
+#ifdef XPTI_ENABLE_INSTRUMENTATION
+        NewCmd->emitInstrumentation(xpti::trace_task_begin, nullptr);
+#endif
+
+        cl_int Res = NewCmd->enqueueImp();
+
+        // Emit this correlation signal before the task end
+        NewCmd->emitEnqueuedEventSignal(NewEvent->getHandleRef());
+#ifdef XPTI_ENABLE_INSTRUMENTATION
+        NewCmd->emitInstrumentation(xpti::trace_task_end, nullptr);
+#endif
+
+        if (CL_SUCCESS != Res)
+          throw runtime_error("Enqueue process failed.", PI_INVALID_OPERATION);
+        else if (NewEvent->is_host() || NewEvent->getHandleRef() == nullptr)
+          NewEvent->setComplete();
+      } catch (...) {
+        // enqueueImp() func and if statement above may throw an exception,
+        // so destroy required resources to avoid memory leak
+        CleanUp();
+        std::rethrow_exception(std::current_exception());
+      }
+
+      CleanUp();
+
+      for (auto StreamImplPtr : Streams) {
+        StreamImplPtr->flush();
+      }
+
+      return NewEvent;
+    }
   }
 
   {

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -612,6 +612,7 @@ protected:
                                         const ContextImplPtr &Context);
 
     friend class Command;
+    friend class Scheduler;
 
   private:
     friend class ::MockScheduler;


### PR DESCRIPTION
This patch aims to reduce the time for the specific case when the kernel doesn't have any dependencies. 
If the kernel doesn't use accessors, then the vector `MRequirements` is empty.
If the kernel doesn't depend on other events, then the vector `MEvents` is empty.
In most cases this is the kernel that uses USM memory only, for such cases, the patch is intended.

Since the vectors `MRequirements` and `MEvents` are empty for `ExecCGCommand`, `ExecCGCommand` of such kernel doesn't affect the command graph and is not added as a node.
Since this command doesn't depend on the graph in any way, it can be safely executed independently, without going through the mechanism of placing it into the queue, which in this case is meaningless. Thus, the command can be executed instantly.

This significantly saves time that could be wasted in:
-   a lot of extra checks trying to add a command to the graph using 1 write-mutex to the graph.
-   many extra checks in queuing process using 1 read-mutex and 1 write-mutex.

Here `printGraphAsDot` is useless because the graph isn't changed and this is used only to support the old behavior, and this can be removed if desired.

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>