### PR TITLE
[SYCL] Remove extra creating of sycl objects

### DIFF
--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -256,7 +256,8 @@ void program_impl::build_with_kernel_name(std::string KernelName,
     MProgramAndKernelCachingAllowed = true;
     MBuildOptions = BuildOptions;
     MProgram = ProgramManager::getInstance().getBuiltPIProgram(
-        Module, get_context(), get_devices()[0], KernelName, this,
+        Module, detail::getSyclObjImpl(get_context()),
+        detail::getSyclObjImpl(get_devices()[0]), KernelName, this,
         /*JITCompilationIsRequired=*/(!BuildOptions.empty()));
     const detail::plugin &Plugin = getPlugin();
     Plugin.call<PiApiKind::piProgramRetain>(MProgram);
@@ -440,8 +441,8 @@ RT::PiKernel program_impl::get_pi_kernel(const std::string &KernelName) const {
   if (is_cacheable()) {
     std::tie(Kernel, std::ignore) =
         ProgramManager::getInstance().getOrCreateKernel(
-            MProgramModuleHandle, get_context(), get_devices()[0], KernelName,
-            this);
+            MProgramModuleHandle, detail::getSyclObjImpl(get_context()),
+            detail::getSyclObjImpl(get_devices()[0]), KernelName, this);
     getPlugin().call<PiApiKind::piKernelRetain>(Kernel);
   } else {
     const detail::plugin &Plugin = getPlugin();

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -412,22 +412,18 @@ static void applyOptionsFromEnvironment(std::string &CompileOpts,
   }
 }
 
-RT::PiProgram ProgramManager::getBuiltPIProgram(OSModuleHandle M,
-                                                const context &Context,
-                                                const device &Device,
-                                                const std::string &KernelName,
-                                                const program_impl *Prg,
-                                                bool JITCompilationIsRequired) {
+RT::PiProgram ProgramManager::getBuiltPIProgram(
+    OSModuleHandle M, const ContextImplPtr &ContextImpl,
+    const DeviceImplPtr &DeviceImpl, const std::string &KernelName,
+    const program_impl *Prg, bool JITCompilationIsRequired) {
   // TODO: Make sure that KSIds will be different for the case when the same
   // kernel built with different options is present in the fat binary.
   KernelSetId KSId = getKernelSetId(M, KernelName);
 
-  const ContextImplPtr Ctx = getSyclObjImpl(Context);
-
   using PiProgramT = KernelProgramCache::PiProgramT;
   using ProgramCacheT = KernelProgramCache::ProgramCacheT;
 
-  KernelProgramCache &Cache = Ctx->getKernelProgramCache();
+  KernelProgramCache &Cache = ContextImpl->getKernelProgramCache();
 
   auto AcquireF = [](KernelProgramCache &Cache) {
     return Cache.acquireCachedPrograms();
@@ -448,13 +444,16 @@ RT::PiProgram ProgramManager::getBuiltPIProgram(OSModuleHandle M,
   if (Prg)
     Prg->stableSerializeSpecConstRegistry(SpecConsts);
 
-  auto BuildF = [this, &M, &KSId, &Context, &Device, Prg, &CompileOpts,
+  auto BuildF = [this, &M, &KSId, &ContextImpl, &DeviceImpl, Prg, &CompileOpts,
                  &LinkOpts, &JITCompilationIsRequired, SpecConsts] {
+    auto Context = createSyclObjFromImpl<context>(ContextImpl);
+    auto Device = createSyclObjFromImpl<device>(DeviceImpl);
+
     const RTDeviceBinaryImage &Img =
         getDeviceImage(M, KSId, Context, Device, JITCompilationIsRequired);
 
     applyOptionsFromImage(CompileOpts, LinkOpts, Img);
-    ContextImplPtr ContextImpl = getSyclObjImpl(Context);
+
     const detail::plugin &Plugin = ContextImpl->getPlugin();
     RT::PiProgram NativePrg;
 
@@ -510,7 +509,8 @@ RT::PiProgram ProgramManager::getBuiltPIProgram(OSModuleHandle M,
     return BuiltProgram.release();
   };
 
-  const RT::PiDevice PiDevice = getRawSyclObjImpl(Device)->getHandleRef();
+  const RT::PiDevice PiDevice = DeviceImpl->getHandleRef();
+
   auto BuildResult = getOrBuild<PiProgramT, compile_program_error>(
       Cache,
       std::make_pair(std::make_pair(std::move(SpecConsts), KSId),
@@ -520,23 +520,23 @@ RT::PiProgram ProgramManager::getBuiltPIProgram(OSModuleHandle M,
 }
 
 std::pair<RT::PiKernel, std::mutex *> ProgramManager::getOrCreateKernel(
-    OSModuleHandle M, const context &Context, const device &Device,
-    const std::string &KernelName, const program_impl *Prg) {
+    OSModuleHandle M, const ContextImplPtr &Context,
+    const DeviceImplPtr &Device, const std::string &KernelName,
+    const program_impl *Prg) {
   if (DbgProgMgr > 0) {
     std::cerr << ">>> ProgramManager::getOrCreateKernel(" << M << ", "
-              << getRawSyclObjImpl(Context) << ", " << getRawSyclObjImpl(Device)
-              << ", " << KernelName << ")\n";
+              << Context.get() << ", " << Device.get() << ", " << KernelName
+              << ")\n";
   }
 
   RT::PiProgram Program =
       getBuiltPIProgram(M, Context, Device, KernelName, Prg);
-  const ContextImplPtr Ctx = getSyclObjImpl(Context);
 
   using PiKernelT = KernelProgramCache::PiKernelT;
   using KernelCacheT = KernelProgramCache::KernelCacheT;
   using KernelByNameT = KernelProgramCache::KernelByNameT;
 
-  KernelProgramCache &Cache = Ctx->getKernelProgramCache();
+  KernelProgramCache &Cache = Context->getKernelProgramCache();
 
   auto AcquireF = [](KernelProgramCache &Cache) {
     return Cache.acquireKernelsPerProgramCache();
@@ -545,12 +545,12 @@ std::pair<RT::PiKernel, std::mutex *> ProgramManager::getOrCreateKernel(
       [&Program](const Locked<KernelCacheT> &LockedCache) -> KernelByNameT & {
     return LockedCache.get()[Program];
   };
-  auto BuildF = [&Program, &KernelName, &Ctx] {
+  auto BuildF = [&Program, &KernelName, &Context] {
     PiKernelT *Result = nullptr;
 
     // TODO need some user-friendly error/exception
     // instead of currently obscure one
-    const detail::plugin &Plugin = Ctx->getPlugin();
+    const detail::plugin &Plugin = Context->getPlugin();
     Plugin.call<PiApiKind::piKernelCreate>(Program, KernelName.c_str(),
                                            &Result);
 
@@ -1161,8 +1161,9 @@ uint32_t ProgramManager::getDeviceLibReqMask(const RTDeviceBinaryImage &Img) {
 // TODO consider another approach with storing the masks in the integration
 // header instead.
 ProgramManager::KernelArgMask ProgramManager::getEliminatedKernelArgMask(
-    OSModuleHandle M, const context &Context, const device &Device,
-    pi::PiProgram NativePrg, const std::string &KernelName, bool KnownProgram) {
+    OSModuleHandle M, const ContextImplPtr &ContextImpl,
+    const DeviceImplPtr &DeviceImpl, pi::PiProgram NativePrg,
+    const std::string &KernelName, bool KnownProgram) {
   // If instructed to use a spv file, assume no eliminated arguments.
   if (m_UseSpvFile && M == OSUtil::ExeModuleHandle)
     return {};
@@ -1196,6 +1197,9 @@ ProgramManager::KernelArgMask ProgramManager::getEliminatedKernelArgMask(
       return {};
     std::rethrow_exception(std::current_exception());
   }
+
+  auto Context = createSyclObjFromImpl<context>(ContextImpl);
+  auto Device = createSyclObjFromImpl<device>(DeviceImpl);
   RTDeviceBinaryImage &Img = getDeviceImage(M, KSId, Context, Device);
   {
     std::lock_guard<std::mutex> Lock(MNativeProgramsMutex);

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -48,6 +48,8 @@ static constexpr uint32_t inline ITTSpecConstId = 0xFF747469;
 
 class context_impl;
 using ContextImplPtr = std::shared_ptr<context_impl>;
+class device_impl;
+using DeviceImplPtr = std::shared_ptr<device_impl>;
 class program_impl;
 // DeviceLibExt is shared between sycl runtime and sycl-post-link tool.
 // If any update is made here, need to sync with DeviceLibExt definition
@@ -91,8 +93,9 @@ public:
   ///        once the function returns.
   /// \param JITCompilationIsRequired If JITCompilationIsRequired is true
   ///        add a check that kernel is compiled, otherwise don't add the check.
-  RT::PiProgram getBuiltPIProgram(OSModuleHandle M, const context &Context,
-                                  const device &Device,
+  RT::PiProgram getBuiltPIProgram(OSModuleHandle M,
+                                  const ContextImplPtr &ContextImpl,
+                                  const DeviceImplPtr &DeviceImpl,
                                   const std::string &KernelName,
                                   const program_impl *Prg = nullptr,
                                   bool JITCompilationIsRequired = false);
@@ -104,9 +107,9 @@ public:
                                   bool JITCompilationIsRequired = false);
 
   std::pair<RT::PiKernel, std::mutex *>
-  getOrCreateKernel(OSModuleHandle M, const context &Context,
-                    const device &Device, const std::string &KernelName,
-                    const program_impl *Prg);
+  getOrCreateKernel(OSModuleHandle M, const ContextImplPtr &ContextImpl,
+                    const DeviceImplPtr &DeviceImpl,
+                    const std::string &KernelName, const program_impl *Prg);
 
   RT::PiProgram getPiProgramFromPiKernel(RT::PiKernel Kernel,
                                          const ContextImplPtr Context);
@@ -143,10 +146,12 @@ public:
   /// \param KnownProgram indicates whether the PI program is guaranteed to
   ///        be known to program manager (built with its API) or not (not
   ///        cacheable or constructed with interoperability).
-  KernelArgMask
-  getEliminatedKernelArgMask(OSModuleHandle M, const context &Context,
-                             const device &Device, pi::PiProgram NativePrg,
-                             const std::string &KernelName, bool KnownProgram);
+  KernelArgMask getEliminatedKernelArgMask(OSModuleHandle M,
+                                           const ContextImplPtr &ContextImpl,
+                                           const DeviceImplPtr &DeviceImpl,
+                                           pi::PiProgram NativePrg,
+                                           const std::string &KernelName,
+                                           bool KnownProgram);
 
   // The function returns a vector of SYCL device images that are compiled with
   // the required state and at least one device from the passed list of devices.

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -145,6 +145,8 @@ public:
 
   const ContextImplPtr &getContextImplPtr() const { return MContext; }
 
+  const DeviceImplPtr &getDeviceImplPtr() const { return MDevice; }
+
   /// \return an associated SYCL device.
   device get_device() const { return createSyclObjFromImpl<device>(MDevice); }
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -211,7 +211,7 @@ public:
       // we're ready to call the user-defined lambda now
       if (HostTask.MHostTask->isInteropTask()) {
         interop_handle IH{MReqToMem, HostTask.MQueue,
-                          getSyclObjImpl(HostTask.MQueue->get_device()),
+                          HostTask.MQueue->getDeviceImplPtr(),
                           HostTask.MQueue->getContextImplPtr()};
 
         HostTask.MHostTask->call(IH);
@@ -309,7 +309,7 @@ Command::Command(CommandType Type, QueueImplPtr Queue)
     : MQueue(std::move(Queue)), MType(Type) {
   MEvent.reset(new detail::event_impl(MQueue));
   MEvent->setCommand(this);
-  MEvent->setContextImpl(detail::getSyclObjImpl(MQueue->get_context()));
+  MEvent->setContextImpl(MQueue->getContextImplPtr());
   MEnqueueStatus = EnqueueResultT::SyclEnqueueReady;
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
@@ -786,8 +786,8 @@ cl_int AllocaCommand::enqueueImp() {
   // TODO: Check if it is correct to use std::move on stack variable and
   // delete it RawEvents below.
   MMemAllocation = MemoryManager::allocate(
-      detail::getSyclObjImpl(MQueue->get_context()), getSYCLMemObj(),
-      MInitFromUserData, HostPtr, std::move(EventImpls), Event);
+      MQueue->getContextImplPtr(), getSYCLMemObj(), MInitFromUserData, HostPtr,
+      std::move(EventImpls), Event);
 
   return CL_SUCCESS;
 }
@@ -868,10 +868,9 @@ cl_int AllocaSubBufCommand::enqueueImp() {
   RT::PiEvent &Event = MEvent->getHandleRef();
 
   MMemAllocation = MemoryManager::allocateMemSubBuffer(
-      detail::getSyclObjImpl(MQueue->get_context()),
-      MParentAlloca->getMemAllocation(), MRequirement.MElemSize,
-      MRequirement.MOffsetInBytes, MRequirement.MAccessRange,
-      std::move(EventImpls), Event);
+      MQueue->getContextImplPtr(), MParentAlloca->getMemAllocation(),
+      MRequirement.MElemSize, MRequirement.MOffsetInBytes,
+      MRequirement.MAccessRange, std::move(EventImpls), Event);
 
   return CL_SUCCESS;
 }
@@ -957,8 +956,7 @@ cl_int ReleaseCommand::enqueueImp() {
                                     : MAllocaCmd->getQueue();
 
     EventImplPtr UnmapEventImpl(new event_impl(Queue));
-    UnmapEventImpl->setContextImpl(
-        detail::getSyclObjImpl(Queue->get_context()));
+    UnmapEventImpl->setContextImpl(Queue->getContextImplPtr());
     RT::PiEvent &UnmapEvent = UnmapEventImpl->getHandleRef();
 
     void *Src = CurAllocaIsHost
@@ -980,10 +978,9 @@ cl_int ReleaseCommand::enqueueImp() {
   if (SkipRelease)
     Command::waitForEvents(MQueue, EventImpls, Event);
   else {
-    MemoryManager::release(detail::getSyclObjImpl(MQueue->get_context()),
-                           MAllocaCmd->getSYCLMemObj(),
-                           MAllocaCmd->getMemAllocation(),
-                           std::move(EventImpls), Event);
+    MemoryManager::release(
+        MQueue->getContextImplPtr(), MAllocaCmd->getSYCLMemObj(),
+        MAllocaCmd->getMemAllocation(), std::move(EventImpls), Event);
   }
   return CL_SUCCESS;
 }
@@ -1133,7 +1130,7 @@ MemCpyCommand::MemCpyCommand(Requirement SrcReq,
       MSrcAllocaCmd(SrcAllocaCmd), MDstReq(std::move(DstReq)),
       MDstAllocaCmd(DstAllocaCmd) {
   if (!MSrcQueue->is_host())
-    MEvent->setContextImpl(detail::getSyclObjImpl(MSrcQueue->get_context()));
+    MEvent->setContextImpl(MSrcQueue->getContextImplPtr());
 
   emitInstrumentationDataProxy();
 }
@@ -1273,7 +1270,7 @@ MemCpyCommandHost::MemCpyCommandHost(Requirement SrcReq,
       MSrcQueue(SrcQueue), MSrcReq(std::move(SrcReq)),
       MSrcAllocaCmd(SrcAllocaCmd), MDstReq(std::move(DstReq)), MDstPtr(DstPtr) {
   if (!MSrcQueue->is_host())
-    MEvent->setContextImpl(detail::getSyclObjImpl(MSrcQueue->get_context()));
+    MEvent->setContextImpl(MSrcQueue->getContextImplPtr());
 
   emitInstrumentationDataProxy();
 }
@@ -1746,8 +1743,7 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
     ++NextTrueIndex;
   }
 
-  adjustNDRangePerKernel(NDRDesc, Kernel,
-                         *(detail::getSyclObjImpl(MQueue->get_device())));
+  adjustNDRangePerKernel(NDRDesc, Kernel, *(MQueue->getDeviceImplPtr()));
 
   // Remember this information before the range dimensions are reversed
   const bool HasLocalSize = (NDRDesc.LocalSize[0] != 0);
@@ -1756,7 +1752,7 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
 
   size_t RequiredWGSize[3] = {0, 0, 0};
   Plugin.call<PiApiKind::piKernelGetGroupInfo>(
-      Kernel, detail::getSyclObjImpl(MQueue->get_device())->getHandleRef(),
+      Kernel, MQueue->getDeviceImplPtr()->getHandleRef(),
       PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, sizeof(RequiredWGSize),
       RequiredWGSize, /* param_value_size_ret = */ nullptr);
 
@@ -1971,7 +1967,8 @@ cl_int ExecCGCommand::enqueueImp() {
         ExecKernel->getKernelBundle();
 
     // Run OpenCL kernel
-    sycl::context Context = MQueue->get_context();
+    auto ContextImpl = MQueue->getContextImplPtr();
+    auto DeviceImpl = MQueue->getDeviceImplPtr();
     RT::PiKernel Kernel = nullptr;
     std::mutex *KernelMutex = nullptr;
     RT::PiProgram Program = nullptr;
@@ -2003,7 +2000,7 @@ cl_int ExecCGCommand::enqueueImp() {
               /*PropList=*/{}, Program);
     } else if (nullptr != ExecKernel->MSyclKernel) {
       assert(ExecKernel->MSyclKernel->get_info<info::kernel::context>() ==
-             Context);
+             MQueue->get_context());
       Kernel = ExecKernel->MSyclKernel->getHandleRef();
 
       auto SyclProg = detail::getSyclObjImpl(
@@ -2013,16 +2010,15 @@ cl_int ExecCGCommand::enqueueImp() {
         RT::PiKernel FoundKernel = nullptr;
         std::tie(FoundKernel, KernelMutex) =
             detail::ProgramManager::getInstance().getOrCreateKernel(
-                ExecKernel->MOSModuleHandle,
-                ExecKernel->MSyclKernel->get_info<info::kernel::context>(),
-                MQueue->get_device(), ExecKernel->MKernelName, SyclProg.get());
+                ExecKernel->MOSModuleHandle, ContextImpl, DeviceImpl,
+                ExecKernel->MKernelName, SyclProg.get());
         assert(FoundKernel == Kernel);
       } else
         KnownProgram = false;
     } else {
       std::tie(Kernel, KernelMutex) =
           detail::ProgramManager::getInstance().getOrCreateKernel(
-              ExecKernel->MOSModuleHandle, Context, MQueue->get_device(),
+              ExecKernel->MOSModuleHandle, ContextImpl, DeviceImpl,
               ExecKernel->MKernelName, nullptr);
       MQueue->getPlugin().call<PiApiKind::piKernelGetInfo>(
           Kernel, PI_KERNEL_INFO_PROGRAM, sizeof(RT::PiProgram), &Program,
@@ -2035,8 +2031,8 @@ cl_int ExecCGCommand::enqueueImp() {
         !ExecKernel->MSyclKernel->isCreatedFromSource()) {
       EliminatedArgMask =
           detail::ProgramManager::getInstance().getEliminatedKernelArgMask(
-              ExecKernel->MOSModuleHandle, Context, MQueue->get_device(),
-              Program, ExecKernel->MKernelName, KnownProgram);
+              ExecKernel->MOSModuleHandle, ContextImpl, DeviceImpl, Program,
+              ExecKernel->MKernelName, KnownProgram);
     }
     if (KernelMutex != nullptr) {
       // For cacheable kernels, we use per-kernel mutex
@@ -2053,8 +2049,7 @@ cl_int ExecCGCommand::enqueueImp() {
     if (PI_SUCCESS != Error) {
       // If we have got non-success error code, let's analyze it to emit nice
       // exception explaining what was wrong
-      const device_impl &DeviceImpl =
-          *(detail::getSyclObjImpl(MQueue->get_device()));
+      const device_impl &DeviceImpl = *(MQueue->getDeviceImplPtr());
       return detail::enqueue_kernel_launch::handleError(Error, DeviceImpl,
                                                         Kernel, NDRDesc);
     }


### PR DESCRIPTION
The main idea of this patch is to reduce the time of getting the implementation object pointer for sycl::context and sycl::device and creating their SYCL objects.

Inside RT library we spend o lot of time doing unnecessary actions converting the context impl to SYCL context and vice versa, we also do it for device impl.

The main idea of the patch is based on the fact that in the end, in all internal calls to the library, we are interested in the impl objects, not SYCL objects. The SYCL objects should only be used as a public API. Thereby we significantly save time on unnecessary conversions.
This patch doesn't fix all of these issues, but it starts this trend.

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>