### PR TITLE
[SYCL][ROCm] Fix building libclc for AMD

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/synchronization/barrier.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/synchronization/barrier.cl
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/clc.h>
 #include <spirv/spirv.h>
 
 void __clc_amdgcn_s_waitcnt(unsigned flags);


### PR DESCRIPTION
This file uses `cl_mem_fence_flags`, `CLK_GLOBAL_MEM_FENCE`,
`CLK_LOCAL_MEM_FENCE`, which are defined by `clc.h`.

It wasn't included because when this file was written the OpenCL headers
were implicitely included, this has changed so now including the header
is necessary. See the discussion on #4133 for more details.