### PR TITLE
[SYCL] Fix linkage of sycl-ls for Debug Windows builds

### DIFF
--- a/sycl/tools/sycl-ls/CMakeLists.txt
+++ b/sycl/tools/sycl-ls/CMakeLists.txt
@@ -4,7 +4,7 @@ target_include_directories(sycl-ls PRIVATE "${sycl_inc_dir}")
 
 set(sycl_lib sycl)
 string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type_lower)
-if (WIN32 AND "${build_type_lower}" MATCHES "Debug")
+if (WIN32 AND "${build_type_lower}" MATCHES "debug")
   set(sycl_lib sycld)
 endif()
 

--- a/sycl/tools/sycl-ls/CMakeLists.txt
+++ b/sycl/tools/sycl-ls/CMakeLists.txt
@@ -1,9 +1,16 @@
 add_executable(sycl-ls sycl-ls.cpp)
 add_dependencies(sycl-ls sycl)
 target_include_directories(sycl-ls PRIVATE "${sycl_inc_dir}")
+
+set(sycl_lib sycl)
+string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type_lower)
+if (WIN32 AND "${build_type_lower}" MATCHES "Debug")
+  set(sycl_lib sycld)
+endif()
+
 target_link_libraries(sycl-ls
   PRIVATE
-    sycl
+    ${sycl_lib}
     OpenCL-Headers
 )
 install(TARGETS sycl-ls


### PR DESCRIPTION
MSVC distinguishes debug and release versions of STL. Link with the correct library to avoid crashes.