### PR TITLE
[SYCL] Restore the correct initialization for _statically_coalesce_val

### DIFF
--- a/sycl/include/sycl/ext/intel/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_lsu.hpp
@@ -90,7 +90,7 @@ private:
   static constexpr uint8_t _cache = (_cache_val > 0) ? CACHE : 0;
 
   static constexpr int32_t _statically_coalesce_val =
-      _GetValue<statically_coalesce_impl<0>, _mem_access_params...>::value;
+      _GetValue<statically_coalesce_impl<1>, _mem_access_params...>::value;
   static constexpr uint8_t _dont_statically_coalesce =
       _statically_coalesce_val == 0 ? STATICALLY_COALESCE : 0;
 


### PR DESCRIPTION
Patch https://github.com/intel/llvm/pull/3957 introduces `_statically_coalesce_val` in fpga_lsu.cpp like this:

```
_GetValue<statically_coalesce_impl<1>, _mem_access_params...>::value;
```

During merge conflict resolution in https://github.com/intel/llvm/pull/4014 it was change accidentally to

```
_GetValue<statically_coalesce_impl<0>, _mem_access_params...>::value;
```

Restoring the right value.