### PR TITLE
[SYCL][LIBCLC] Add subgroup builtins for AMDGCN

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/SOURCES
+++ b/libclc/amdgcn-amdhsa/libspirv/SOURCES
@@ -7,3 +7,7 @@ math/sin.cl
 math/sqrt.cl
 math/atan.cl
 math/cbrt.cl
+workitem/get_max_sub_group_size.cl
+workitem/get_num_sub_groups.cl
+workitem/get_sub_group_id.cl
+workitem/get_sub_group_size.cl

--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <spirv/spirv.h>
+
+// FIXME: Remove the following workaround once the clang change is released.
+// This is for backward compatibility with older clang which does not define
+// __AMDGCN_WAVEFRONT_SIZE. It does not consider -mwavefrontsize64.
+// See:
+// https://github.com/intel/llvm/blob/sycl/clang/lib/Basic/Targets/AMDGPU.h#L414
+// and:
+// https://github.com/intel/llvm/blob/sycl/clang/lib/Basic/Targets/AMDGPU.cpp#L421
+#ifndef __AMDGCN_WAVEFRONT_SIZE
+#if __gfx1010__ || __gfx1011__ || __gfx1012__ || __gfx1030__ || __gfx1031__
+#define __AMDGCN_WAVEFRONT_SIZE 32
+#else
+#define __AMDGCN_WAVEFRONT_SIZE 64
+#endif
+#endif
+
+_CLC_DEF _CLC_OVERLOAD uint __spirv_SubgroupMaxSize() {
+  return __AMDGCN_WAVEFRONT_SIZE;
+}

--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_num_sub_groups.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_num_sub_groups.cl
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <spirv/spirv.h>
+
+_CLC_DEF _CLC_OVERLOAD uint __spirv_NumSubgroups() {
+  size_t size_x = __spirv_WorkgroupSize_x();
+  size_t size_y = __spirv_WorkgroupSize_y();
+  size_t size_z = __spirv_WorkgroupSize_z();
+  uint sg_size = __spirv_SubgroupMaxSize();
+  uint linear_size = size_z * size_y * size_x;
+  return (linear_size + sg_size - 1) / sg_size;
+}

--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_num_sub_groups.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_num_sub_groups.cl
@@ -13,6 +13,6 @@ _CLC_DEF _CLC_OVERLOAD uint __spirv_NumSubgroups() {
   size_t size_y = __spirv_WorkgroupSize_y();
   size_t size_z = __spirv_WorkgroupSize_z();
   uint sg_size = __spirv_SubgroupMaxSize();
-  uint linear_size = size_z * size_y * size_x;
-  return (linear_size + sg_size - 1) / sg_size;
+  size_t linear_size = size_z * size_y * size_x;
+  return (uint)((linear_size + sg_size - 1) / sg_size);
 }

--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_sub_group_id.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_sub_group_id.cl
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <spirv/spirv.h>
+
+_CLC_DEF _CLC_OVERLOAD uint __spirv_SubgroupId() {
+  size_t id_x = __spirv_LocalInvocationId_x();
+  size_t id_y = __spirv_LocalInvocationId_y();
+  size_t id_z = __spirv_LocalInvocationId_z();
+  size_t size_x = __spirv_WorkgroupSize_x();
+  size_t size_y = __spirv_WorkgroupSize_y();
+  size_t size_z = __spirv_WorkgroupSize_z();
+  uint sg_size = __spirv_SubgroupMaxSize();
+  return (id_z * size_y * size_x + id_y * size_x + id_x) / sg_size;
+}

--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_sub_group_size.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_sub_group_size.cl
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <spirv/spirv.h>
+
+_CLC_DEF _CLC_OVERLOAD uint __spirv_SubgroupSize() {
+  if (__spirv_SubgroupId() != __spirv_NumSubgroups() - 1) {
+    return __spirv_SubgroupMaxSize();
+  }
+  size_t size_x = __spirv_WorkgroupSize_x();
+  size_t size_y = __spirv_WorkgroupSize_y();
+  size_t size_z = __spirv_WorkgroupSize_z();
+  uint linear_size = size_z * size_y * size_x;
+  uint uniform_groups = __spirv_NumSubgroups() - 1;
+  uint uniform_size = __spirv_SubgroupMaxSize() * uniform_groups;
+  return linear_size - uniform_size;
+}

--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_sub_group_size.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_sub_group_size.cl
@@ -15,8 +15,8 @@ _CLC_DEF _CLC_OVERLOAD uint __spirv_SubgroupSize() {
   size_t size_x = __spirv_WorkgroupSize_x();
   size_t size_y = __spirv_WorkgroupSize_y();
   size_t size_z = __spirv_WorkgroupSize_z();
-  uint linear_size = size_z * size_y * size_x;
-  uint uniform_groups = __spirv_NumSubgroups() - 1;
-  uint uniform_size = __spirv_SubgroupMaxSize() * uniform_groups;
+  size_t linear_size = size_z * size_y * size_x;
+  size_t uniform_groups = __spirv_NumSubgroups() - 1;
+  size_t uniform_size = __spirv_SubgroupMaxSize() * uniform_groups;
   return linear_size - uniform_size;
 }


### PR DESCRIPTION
This patch brings in support for the following builtins: 
* `__spirv_SubgroupMaxSize`
* `__spirv_NumSubgroups`
* `__spirv_SubgroupId`
*  `__spirv_SubgroupSize`

The implementation follows that of HIP.