### PR TITLE
[SYCL] Fix is_error_code_enum template specialization.

### DIFF
--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -202,5 +202,5 @@ public:
 } // __SYCL_INLINE_NAMESPACE(cl)
 
 namespace std {
-template <> struct is_error_condition_enum<cl::sycl::errc> : true_type {};
+template <> struct is_error_code_enum<cl::sycl::errc> : true_type {};
 } // namespace std

--- a/sycl/test/basic_tests/exceptions-SYCL-2020.cpp
+++ b/sycl/test/basic_tests/exceptions-SYCL-2020.cpp
@@ -72,6 +72,10 @@ int main() {
   assert(std::string("SYCL").compare(ec.category().name()) == 0 &&
          "error code category name should be SYCL");
 
+  // Test enum
+  static_assert(std::is_error_code_enum<sycl::errc>::value, "errc enum should identify as error code");
+  static_assert(!std::is_error_condition_enum<sycl::errc>::value, "errc enum should not identify as error condition");
+
   std::cout << "OK" << std::endl;
   return 0;
 }


### PR DESCRIPTION
Switch identifier to is_error_code_enum .
Signed-off-by: Chris Perkins <chris.perkins@intel.com>