### PR TITLE
[SYCL] Correctly track sycl executable's dependencies in cmake

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -219,6 +219,10 @@ add_subdirectory( plugins )
 add_subdirectory(tools)
 
 if(SYCL_INCLUDE_TESTS)
+  if(NOT LLVM_INCLUDE_TESTS)
+      message(FATAL_ERROR
+        "Can't build SYCL tests without LLVM_INCLUDE_TESTS enabled.")
+  endif()
   if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include/gtest/gtest.h)
     add_subdirectory(unittests)
     list(APPEND SYCL_TEST_DEPS SYCLUnitTests)

--- a/sycl/cmake/modules/AddSYCLExecutable.cmake
+++ b/sycl/cmake/modules/AddSYCLExecutable.cmake
@@ -35,10 +35,8 @@ macro(add_sycl_executable ARG_TARGET_NAME)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND_EXPAND_LISTS)
   add_dependencies(${ARG_TARGET_NAME}_exec sycl-toolchain)
-  foreach(_lib in ${ARG_LIBRARIES})
-    if (TARGET _lib)
-      add_dependencies(${ARG_TARGET_NAME}_exec _lib)
-    endif()
+  foreach(_lib ${ARG_LIBRARIES})
+    add_dependencies(${ARG_TARGET_NAME}_exec _lib)
   endforeach()
 
   foreach(_dep ${ARG_DEPENDANTS})


### PR DESCRIPTION
This is the result of the discussion here: https://reviews.llvm.org/D104848 the change into the upstream LLVM is not required and the problem is fixed with only the patch in SYCL's CMake.
(A re-work of: https://github.com/intel/llvm/pull/3964).
