### PR TITLE
[clang-offload-bundler] Do not add globals with constant address space to .tgtsym list

### DIFF
--- a/clang/test/Driver/clang-offload-bundler-tgtsym.c
+++ b/clang/test/Driver/clang-offload-bundler-tgtsym.c
@@ -21,6 +21,9 @@
 // CHECK-NOT: static_used
 // CHECK-NOT: sycl-spir64.llvm.used
 // CHECK-NOT: sycl-spir64.llvm.compiler.used
+// CHECK-NOT: sycl-spir64.const_as
+
+const __attribute__((opencl_constant)) char const_as[] = "abc";
 
 extern void undefined_func(void);
 


### PR DESCRIPTION
To avoid an invalid address space cast when a reference to such global
value is added to the llvm.used which has global address space.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>