### PR TITLE
[Driver][SYCL] Update header inclusion for source + footer

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1418,6 +1418,10 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
     A->render(Args, CmdArgs);
   }
 
+  Args.AddAllArgs(CmdArgs,
+                  {options::OPT_D, options::OPT_U, options::OPT_I_Group,
+                   options::OPT_F, options::OPT_index_header_map});
+
   // The file being compiled that contains the integration footer is not being
   // compiled in the directory of the original source.  Add that directory
   // as an -internal-isystem option so we can properly find potential headers
@@ -1426,18 +1430,14 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
     SmallString<128> SourcePath(Inputs[0].getBaseInput());
     llvm::sys::path::remove_filename(SourcePath);
     if (!SourcePath.empty()) {
-      CmdArgs.push_back("-internal-isystem");
+      CmdArgs.push_back("-I");
       CmdArgs.push_back(Args.MakeArgString(SourcePath));
     } else if (llvm::ErrorOr<std::string> CWD =
                    D.getVFS().getCurrentWorkingDirectory()) {
-      CmdArgs.push_back("-internal-isystem");
+      CmdArgs.push_back("-I");
       CmdArgs.push_back(Args.MakeArgString(*CWD));
     }
   }
-
-  Args.AddAllArgs(CmdArgs,
-                  {options::OPT_D, options::OPT_U, options::OPT_I_Group,
-                   options::OPT_F, options::OPT_index_header_map});
 
   // Add -Wp, and -Xpreprocessor if using the preprocessor.
 

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -1,9 +1,9 @@
 /// Check compilation tool steps when using the integration footer
-// RUN:  %clangxx -fsycl -include dummy.h %/s -### 2>&1 \
-// RUN:   | FileCheck -check-prefix FOOTER %s -DSRCDIR=%/S
+// RUN:  %clangxx -fsycl -I cmdline/dir -include dummy.h %/s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix FOOTER %s -DSRCDIR=%/S -DCMDDIR=cmdline/dir
 // FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}"{{.*}} "-include" "dummy.h"
 // FOOTER: append-file{{.*}} "[[INPUTFILE:.+\.cpp]]" "--append=[[INTFOOTER]]" "--orig-filename=[[INPUTFILE]]" "--output=[[APPENDEDSRC:.+\.cpp]]"
-// FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-include" "dummy.h"{{.*}} "-internal-isystem" "[[SRCDIR]]"
+// FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-include" "dummy.h"{{.*}} "-I" "cmdline/dir" "-I" "[[SRCDIR]]"
 // FOOTER-NOT: "-include" "[[INTHEADER]]"
 
 /// Preprocessed file creation with integration footer


### PR DESCRIPTION
Instead of using -internal-isystem for the source location header inclusion,
use -I as a user header, but be sure it is placed after user defined -I
locations.