### PR TITLE
[SYCL] Correct some driver diagnostic wording

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -79,8 +79,9 @@ def warn_drv_unknown_cuda_version: Warning<
   InGroup<CudaUnknownVersion>;
 def err_drv_cuda_host_arch : Error<"unsupported architecture '%0' for host compilation.">;
 def err_drv_no_sycl_libspirv : Error<
-  "cannot find `libspirv-nvptx64--nvidiacl.bc`. Provide path to libspirv library via "
-  "-fsycl-libspirv-path, or pass -fno-sycl-libspirv to build without linking with libspirv.">;
+  "cannot find 'libspirv-nvptx64--nvidiacl.bc'; provide path to libspirv "
+  "library via '-fsycl-libspirv-path', or pass '-fno-sycl-libspirv' to build "
+  "without linking with libspirv">;
 def err_drv_mix_cuda_hip : Error<"Mixed Cuda and HIP compilation is not supported.">;
 def err_drv_bad_target_id : Error<"Invalid target ID: %0 (A target ID is a processor name "
   "followed by an optional list of predefined features post-fixed by a plus or minus sign deliminated "
@@ -285,12 +286,12 @@ def err_drv_omp_host_target_not_supported : Error<
 def err_drv_expecting_fopenmp_with_fopenmp_targets : Error<
   "The option -fopenmp-targets must be used in conjunction with a -fopenmp option compatible with offloading, please use -fopenmp=libomp or -fopenmp=libiomp5.">;
 def err_drv_expecting_fsycl_with_sycl_opt : Error<
-  "The option %0 must be used in conjunction with -fsycl to enable offloading.">;
+  "'%0' must be used in conjunction with '-fsycl' to enable offloading">;
 def err_drv_fsycl_with_c_type : Error<
-  "The option '%0' must not be used in conjunction with '-fsycl', which expects C++ source.">;
+  "'%0' must not be used in conjunction with '-fsycl', which expects C++ source">;
 def warn_drv_sycl_offload_target_duplicate : Warning<
-  "The SYCL offloading target '%0' is similar to target '%1' already specified - will be ignored.">,
-  InGroup<SyclTarget>;
+  "SYCL offloading target '%0' is similar to target '%1' already specified; "
+  "will be ignored">, InGroup<SyclTarget>;
 def err_drv_omp_offload_target_missingbcruntime : Error<
   "No library '%0' found in the default clang lib directory or in LIBRARY_PATH. Please use --libomptarget-%1-bc-path to specify %1 bitcode library.">;
 def err_drv_omp_offload_target_bcruntime_not_found : Error<"Bitcode library '%0' does not exist.">;

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -44,19 +44,19 @@
 // RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL %s
 // RUN:   %clang_cl -### -fsycl-targets=spir64-unknown-unknown-sycldevice  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL %s
-// CHK-NO-FSYCL: error: The option -fsycl-targets must be used in conjunction with -fsycl to enable offloading.
+// CHK-NO-FSYCL: error: '-fsycl-targets' must be used in conjunction with '-fsycl' to enable offloading
 // RUN:   %clang -### -fsycl-link-targets=spir64-unknown-unknown-sycldevice  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-LINK-TGTS %s
-// CHK-NO-FSYCL-LINK-TGTS: error: The option -fsycl-link-targets must be used in conjunction with -fsycl to enable offloading.
+// CHK-NO-FSYCL-LINK-TGTS: error: '-fsycl-link-targets' must be used in conjunction with '-fsycl' to enable offloading
 // RUN:   %clang -### -fsycl-add-targets=spir64-unknown-unknown-sycldevice  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-ADD %s
-// CHK-NO-FSYCL-ADD: error: The option -fsycl-add-targets must be used in conjunction with -fsycl to enable offloading.
+// CHK-NO-FSYCL-ADD: error: '-fsycl-add-targets' must be used in conjunction with '-fsycl' to enable offloading
 // RUN:   %clang -### -fsycl-link  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-LINK %s
-// CHK-NO-FSYCL-LINK: error: The option -fsycl-link must be used in conjunction with -fsycl to enable offloading.
+// CHK-NO-FSYCL-LINK: error: '-fsycl-link' must be used in conjunction with '-fsycl' to enable offloading
 // RUN:   %clang -### -fintelfpga  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-FINTELFPGA %s
-// CHK-NO-FSYCL-FINTELFPGA: error: The option -fintelfpga must be used in conjunction with -fsycl to enable offloading.
+// CHK-NO-FSYCL-FINTELFPGA: error: '-fintelfpga' must be used in conjunction with '-fsycl' to enable offloading
 
 /// ###########################################################################
 
@@ -142,7 +142,7 @@
 /// Check warning for duplicate offloading targets.
 // RUN:   %clang -### -ccc-print-phases -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice,spir64-unknown-unknown-sycldevice  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DUPLICATES %s
-// CHK-DUPLICATES: warning: The SYCL offloading target 'spir64-unknown-unknown-sycldevice' is similar to target 'spir64-unknown-unknown-sycldevice' already specified - will be ignored.
+// CHK-DUPLICATES: warning: SYCL offloading target 'spir64-unknown-unknown-sycldevice' is similar to target 'spir64-unknown-unknown-sycldevice' already specified; will be ignored
 
 /// ###########################################################################
 
@@ -916,7 +916,7 @@
 // RUN: %clangxx -### -c -fsycl -xc %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
 // RUN: %clangxx -### -c -fsycl -xc-header %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
 // RUN: %clangxx -### -c -fsycl -xcpp-output %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
-// CHECK_XC_FSYCL: The option '-x c{{.*}}' must not be used in conjunction with '-fsycl'
+// CHECK_XC_FSYCL: '-x c{{.*}}' must not be used in conjunction with '-fsycl'
 
 // -std=c++17 check (check all 3 compilations)
 // RUN: %clangxx -### -c -fsycl -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD %s


### PR DESCRIPTION
Clang diagnostics do not start with a capital letter or use trailing
punctuation. This corrects some of the SYCL diagnostics accordingly,
but more work needs to be done upstream for other diagnostics in the
file.