### PR TITLE
[SYCL][Doc] Clarify that uniform is immutable

### DIFF
--- a/sycl/doc/extensions/Uniform/Uniform.asciidoc
+++ b/sycl/doc/extensions/Uniform/Uniform.asciidoc
@@ -110,8 +110,28 @@ namespace experimental {
 
 template <class T>
 class uniform {
+public:
   explicit uniform(T x) noexcept;
-  operator T() const;
+  operator const T() const;
+
+  uniform& operator=(const uniform&) = delete;
+
+  /* Other explicitly deleted operators improve error messages
+     if a user incorrectly attempts to modify a uniform */
+  uniform& operator+=(const T&) = delete;
+  uniform& operator-=(const T&) = delete;
+  uniform& operator*=(const T&) = delete;
+  uniform& operator/=(const T&) = delete;
+  uniform& operator%=(const T&) = delete;
+  uniform& operator&=(const T&) = delete;
+  uniform& operator|=(const T&) = delete;
+  uniform& operator^=(const T&) = delete;
+  uniform& operator<<=(const T&) = delete;
+  uniform& operator>>=(const T&) = delete;
+  uniform& operator++() = delete;
+  uniform& operator++(int) = delete;
+  uniform& operator--() = delete;
+  uniform& operator--(int) = delete;
 };
 
 } // namespace experimental
@@ -181,6 +201,7 @@ float x = array[sycl::ext::oneapi::experimental::uniform(index)];
 |========================================
 |Rev|Date|Author|Changes
 |1|2021-04-23|John Pennycook|*Initial public working draft*
+|2|2021-08-03|John Pennycook|*Add const and deleted operators*
 |========================================
 
 //************************************************************************


### PR DESCRIPTION
We received feedback from the oneAPI TAB that it was not immediately
obvious that the uniform class is immutable. The changes here are an
attempt to clarify this:

- The implicit conversion operator returns "const T", reflecting that
  the user is not getting a reference to the underlying data.

- The assignment operator is deleted, preventing the user from
  accidentally assigning one uniform object to another.

- Other operators that users might accidentally call on a uniform
  of a fundamental type (e.g. += on a uniform<int>) are explicitly
  deleted; the intent here is to give a simplified error message (rather
  than a complex C++ diagnostic) that signals the operator is
  deliberately not supported (rather than accidentally missing or
  unimplemented).

Signed-off-by: John Pennycook <john.pennycook@intel.com>