### PR TITLE
[SYCL] Add lock for non-cached kernel when setting arguments for launching

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -128,6 +128,7 @@ set(SYCL_SOURCES
     "detail/kernel_impl.cpp"
     "detail/kernel_program_cache.cpp"
     "detail/memory_manager.cpp"
+    "detail/non_cached_kernel_lock.cpp"
     "detail/platform_impl.cpp"
     "detail/program_impl.cpp"
     "detail/program_manager/program_manager.cpp"

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -16,6 +16,7 @@
 #include <CL/sycl/stl.hpp>
 #include <detail/device_impl.hpp>
 #include <detail/kernel_program_cache.hpp>
+#include <detail/non_cached_kernel_lock.hpp>
 #include <detail/platform_impl.hpp>
 #include <detail/program_manager/program_manager.hpp>
 
@@ -159,6 +160,10 @@ public:
 
   KernelProgramCache &getKernelProgramCache() const;
 
+  Locked<RT::PiKernel> getNonCachedKernelLock(RT::PiKernel &K) const {
+    return MNonCachedKernelLock.lockKernel(K);
+  }
+
   /// Returns true if and only if context contains the given device.
   bool hasDevice(std::shared_ptr<detail::device_impl> Device) const;
 
@@ -177,6 +182,7 @@ private:
   std::map<std::pair<DeviceLibExt, RT::PiDevice>, RT::PiProgram>
       MCachedLibPrograms;
   mutable KernelProgramCache MKernelProgramCache;
+  mutable NonCachedKernelLock MNonCachedKernelLock;
 };
 
 } // namespace detail

--- a/sycl/source/detail/non_cached_kernel_lock.cpp
+++ b/sycl/source/detail/non_cached_kernel_lock.cpp
@@ -1,0 +1,22 @@
+#include "non_cached_kernel_lock.hpp"
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace detail {
+
+NonCachedKernelLock::~NonCachedKernelLock() {}
+
+Locked<RT::PiKernel> NonCachedKernelLock::lockKernel(RT::PiKernel &K) {
+  std::mutex &Mtx = Map[K];
+
+  return {K, Mtx};
+}
+
+// static
+bool NonCachedKernelLock::Compare(RT::PiKernel Lhs, RT::PiKernel Rhs) {
+  return Lhs < Rhs;
+}
+
+} // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/non_cached_kernel_lock.cpp
+++ b/sycl/source/detail/non_cached_kernel_lock.cpp
@@ -7,7 +7,9 @@ namespace detail {
 NonCachedKernelLock::~NonCachedKernelLock() {}
 
 Locked<RT::PiKernel> NonCachedKernelLock::lockKernel(RT::PiKernel &K) {
+  std::unique_lock<std::mutex> MapLock{MapMtx};
   std::mutex &Mtx = Map[K];
+  MapLock.unlock();
 
   return {K, Mtx};
 }

--- a/sycl/source/detail/non_cached_kernel_lock.cpp
+++ b/sycl/source/detail/non_cached_kernel_lock.cpp
@@ -12,11 +12,6 @@ Locked<RT::PiKernel> NonCachedKernelLock::lockKernel(RT::PiKernel &K) {
   return {K, Mtx};
 }
 
-// static
-bool NonCachedKernelLock::Compare(RT::PiKernel Lhs, RT::PiKernel Rhs) {
-  return Lhs < Rhs;
-}
-
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/non_cached_kernel_lock.hpp
+++ b/sycl/source/detail/non_cached_kernel_lock.hpp
@@ -18,8 +18,6 @@ public:
   Locked<RT::PiKernel> lockKernel(RT::PiKernel &K);
 
 private:
-  static bool Compare(RT::PiKernel Lhs, RT::PiKernel Rhs);
-
   using KernelLockMapT = std::map<RT::PiKernel, std::mutex>;
 
   KernelLockMapT Map{std::less<RT::PiKernel>{}};

--- a/sycl/source/detail/non_cached_kernel_lock.hpp
+++ b/sycl/source/detail/non_cached_kernel_lock.hpp
@@ -20,6 +20,7 @@ public:
 private:
   using KernelLockMapT = std::map<RT::PiKernel, std::mutex>;
 
+  std::mutex MapMtx;
   KernelLockMapT Map{std::less<RT::PiKernel>{}};
 };
 

--- a/sycl/source/detail/non_cached_kernel_lock.hpp
+++ b/sycl/source/detail/non_cached_kernel_lock.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <CL/sycl/detail/common.hpp>
+#include <CL/sycl/detail/locked.hpp>
+#include <CL/sycl/detail/pi.hpp>
+//#include <detail/kernel_impl.hpp>
+
+#include <map>
+#include <mutex>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace detail {
+
+//class context_impl;
+
+class NonCachedKernelLock {
+public:
+  ~NonCachedKernelLock();
+
+  Locked<RT::PiKernel> lockKernel(RT::PiKernel &K);
+
+private:
+  static bool Compare(RT::PiKernel Lhs, RT::PiKernel Rhs);
+
+  using KernelLockMapT = std::map<RT::PiKernel, std::mutex>;
+
+  KernelLockMapT Map{std::less<RT::PiKernel>{}};
+
+//  ContextPtr MParentContext;
+};
+
+} // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/non_cached_kernel_lock.hpp
+++ b/sycl/source/detail/non_cached_kernel_lock.hpp
@@ -3,7 +3,6 @@
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/locked.hpp>
 #include <CL/sycl/detail/pi.hpp>
-//#include <detail/kernel_impl.hpp>
 
 #include <map>
 #include <mutex>
@@ -11,8 +10,6 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
-
-//class context_impl;
 
 class NonCachedKernelLock {
 public:
@@ -26,8 +23,6 @@ private:
   using KernelLockMapT = std::map<RT::PiKernel, std::mutex>;
 
   KernelLockMapT Map{std::less<RT::PiKernel>{}};
-
-//  ContextPtr MParentContext;
 };
 
 } // namespace detail

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2017,6 +2017,8 @@ cl_int ExecCGCommand::enqueueImp() {
       } else
         KnownProgram = false;
     } else {
+      // FIXME should validate if any use-case leads here as in such a case
+      // Kernel handle remains nullptr
       std::tie(Kernel, KernelMutex) =
           detail::ProgramManager::getInstance().getOrCreateKernel(
               ExecKernel->MOSModuleHandle, ContextImpl, DeviceImpl,
@@ -2042,6 +2044,7 @@ cl_int ExecCGCommand::enqueueImp() {
           SetKernelParamsAndLaunch(ExecKernel, DeviceImageImpl, Kernel, NDRDesc,
                                    RawEvents, Event, EliminatedArgMask);
     } else {
+      Locked<RT::PiKernel> Lock = ContextImpl->getNonCachedKernelLock(Kernel);
       Error =
           SetKernelParamsAndLaunch(ExecKernel, DeviceImageImpl, Kernel, NDRDesc,
                                    RawEvents, Event, EliminatedArgMask);


### PR DESCRIPTION
Tested in intel/llvm-test-suite#397