### PR TITLE
[SYCL] Adjust vector size using worst-case estimate

### DIFF
--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -407,6 +407,9 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
 // The argument can take up more space to store additional information about
 // MAccessRange, MMemoryRange, and MOffset added with addArgsForGlobalAccessor.
 // We use the worst-case estimate because the lifetime of the vector is short.
+// In processArg the kind_stream case introduces the maximum number of
+// additional arguments. The case adds additional 12 arguments to the currently
+// processed argument, hence worst-case estimate is 12+1=13.
 // TODO: the constant can be removed if the size of MArgs will be calculated at
 // compile time.
 inline constexpr size_t MaxNumAdditionalArgs = 13;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -409,7 +409,7 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
 // We use the worst-case estimate because the lifetime of the vector is short.
 // TODO: the constant can be removed if the size of MArgs will be calculated at
 // compile time.
-inline constexpr size_t MaxNumAdditionalArgs = 12;
+inline constexpr size_t MaxNumAdditionalArgs = 13;
 
 void handler::extractArgsAndReqs() {
   assert(MKernel && "MKernel is not initialized");

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -404,6 +404,13 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
   }
 }
 
+// The argument can take up more space to store additional information about
+// MAccessRange, MMemoryRange, and MOffset added with addArgsForGlobalAccessor.
+// We use the worst-case estimate because the lifetime of the vector is short.
+// TODO: the constant can be removed if the size of MArgs will be calculated at
+// compile time.
+const size_t MaxNumAdditionalArgs = 12;
+
 void handler::extractArgsAndReqs() {
   assert(MKernel && "MKernel is not initialized");
   std::vector<detail::ArgDesc> UnPreparedArgs = std::move(MArgs);
@@ -416,6 +423,7 @@ void handler::extractArgsAndReqs() {
       });
 
   const bool IsKernelCreatedFromSource = MKernel->isCreatedFromSource();
+  MArgs.reserve(MaxNumAdditionalArgs * UnPreparedArgs.size());
 
   size_t IndexShift = 0;
   for (size_t I = 0; I < UnPreparedArgs.size(); ++I) {
@@ -440,6 +448,8 @@ void handler::extractArgsAndReqsFromLambda(
     const detail::kernel_param_desc_t *KernelArgs, bool IsESIMD) {
   const bool IsKernelCreatedFromSource = false;
   size_t IndexShift = 0;
+  MArgs.reserve(MaxNumAdditionalArgs * KernelArgsNum);
+
   for (size_t I = 0; I < KernelArgsNum; ++I) {
     void *Ptr = LambdaPtr + KernelArgs[I].offset;
     const detail::kernel_param_kind_t &Kind = KernelArgs[I].kind;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -409,7 +409,7 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
 // We use the worst-case estimate because the lifetime of the vector is short.
 // TODO: the constant can be removed if the size of MArgs will be calculated at
 // compile time.
-const size_t MaxNumAdditionalArgs = 12;
+inline constexpr size_t MaxNumAdditionalArgs = 12;
 
 void handler::extractArgsAndReqs() {
   assert(MKernel && "MKernel is not initialized");


### PR DESCRIPTION
This patch aims to avoid wasting time on multiple reallocations when processing the extracted kernel arguments due to the fact that the vector size is zero at the beginning.
The size of MArgs is adjusted using a worst-case estimate.

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>