### PR TITLE
[ESIMD] Allow non-const private statics in ESIMD kernels

### DIFF
--- a/clang/test/SemaSYCL/esimd-private-statics.cpp
+++ b/clang/test/SemaSYCL/esimd-private-statics.cpp
@@ -5,7 +5,11 @@
 
 static __attribute__((opencl_private)) __attribute__((sycl_explicit_simd)) int esimdPrivStatic;
 
+struct S {
+  static __attribute__((opencl_private)) __attribute__((sycl_explicit_simd)) int esimdPrivStaticMember;
+};
+
 __attribute__((sycl_device)) __attribute__((sycl_explicit_simd)) void usage() {
-  // expected-note@+1{{called by}}
   esimdPrivStatic = 42;
+  S::esimdPrivStaticMember = 42;
 }

--- a/clang/test/SemaSYCL/esimd-private-statics.cpp
+++ b/clang/test/SemaSYCL/esimd-private-statics.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -pedantic %s
+// expected-no-diagnostics
+
+// This test checks that non-const statics are allowed for ESIMD
+
+static __attribute__((opencl_private)) __attribute__((sycl_explicit_simd)) int esimdPrivStatic;
+
+__attribute__((sycl_device)) __attribute__((sycl_explicit_simd)) void usage() {
+  // expected-note@+1{{called by}}
+  esimdPrivStatic = 42;
+}


### PR DESCRIPTION
ESIMD already allows using private non-const globals in kernels.
This patch allows using private non-const statics for ESIMD.

This patch allows users to use static keyword to distinguish
global variables accross multiple translation units, e.g.:

// a.cpp
ESIMD_PRIVATE ESIMD_REGISTER(X) simd<T, N> GRF;
// b.cpp
ESIMD_PRIVATE ESIMD_REGISTER(Y) simd<T, N> GRF;

Linker will raise a validation of the ODR rule in this case.
To fix it we can declare those two variables as `static` without
changing their names.