### PR TITLE
[SYCL] Pass RewriteSingleElementVectors to GenXSPIRVWriterAdaptor

### DIFF
--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -14,7 +14,7 @@ if (NOT TARGET LLVMGenXIntrinsics)
   if (NOT DEFINED LLVMGenXIntrinsics_SOURCE_DIR)
     message(STATUS "vc-intrinsics are missing. Will try to download them from github.com")
 
-    set( LLVMGenXIntrinsics_GIT_TAG 19e6ddafc545bc96ceaacbf7c81cacbff59a39b6 )
+    set( LLVMGenXIntrinsics_GIT_TAG 05d3f3d2b9ae59d32893976e0e76415fec1108b9 )
 
     include(FetchContent)
     FetchContent_Declare(vc-intrinsics

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -702,7 +702,7 @@ static void LowerEsimdConstructs(Module &M) {
     MPM.add(createInstructionCombiningPass());
     MPM.add(createDeadCodeEliminationPass());
   }
-  MPM.add(createGenXSPIRVWriterAdaptorPass(/*RewriteTypes=*/true));
+  MPM.add(createGenXSPIRVWriterAdaptorPass(/*RewriteTypes=*/true, /*RewriteSingleElementVectors=*/true));
   MPM.run(M);
 }
 


### PR DESCRIPTION
SPIRV specification does not support single element vectors.
This change rewrites all such vectors as scalars before passing
LLVM IR to the translator.