### PR TITLE
[SYCL] Fix ABI break caused by changes in CG and CGTYPE

### DIFF
--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -137,7 +137,7 @@ constexpr unsigned char getCGTypeVersion(unsigned int Type) {
 }
 
 /// Base class for all types of command groups.
-class CommandGroup {
+class CG {
 public:
   // Used to version CG and handler classes. Using unsigned char as the version
   // is encoded in the highest byte of CGType value. So it is not possible to
@@ -149,7 +149,7 @@ public:
   };
 
   /// Type of the command group.
-  enum CGType : unsigned int {
+  enum CGTYPE : unsigned int {
     None = 0,
     Kernel = 1,
     CopyAccToPtr = 2,
@@ -168,12 +168,11 @@ public:
     AdviseUSM = 15,
   };
 
-  CommandGroup(CGType Type, std::vector<std::vector<char>> ArgsStorage,
-               std::vector<detail::AccessorImplPtr> AccStorage,
-               std::vector<std::shared_ptr<const void>> SharedPtrStorage,
-               std::vector<Requirement *> Requirements,
-               std::vector<detail::EventImplPtr> Events,
-               detail::code_location loc = {})
+  CG(CGTYPE Type, std::vector<std::vector<char>> ArgsStorage,
+     std::vector<detail::AccessorImplPtr> AccStorage,
+     std::vector<std::shared_ptr<const void>> SharedPtrStorage,
+     std::vector<Requirement *> Requirements,
+     std::vector<detail::EventImplPtr> Events, detail::code_location loc = {})
       : MType(Type), MArgsStorage(std::move(ArgsStorage)),
         MAccStorage(std::move(AccStorage)),
         MSharedPtrStorage(std::move(SharedPtrStorage)),
@@ -189,9 +188,9 @@ public:
     MColumn = loc.columnNumber();
   }
 
-  CommandGroup(CommandGroup &&CG) = default;
+  CG(CG &&CommandGroup) = default;
 
-  CGType getType() { return static_cast<CGType>(getUnversionedCGType(MType)); }
+  CGTYPE getType() { return static_cast<CGTYPE>(getUnversionedCGType(MType)); }
 
   CG_VERSION getVersion() {
     return static_cast<CG_VERSION>(getCGTypeVersion(MType));
@@ -207,10 +206,10 @@ public:
     return convertToExtendedMembers(MSharedPtrStorage[0]);
   }
 
-  virtual ~CommandGroup() = default;
+  virtual ~CG() = default;
 
 private:
-  CGType MType;
+  CGTYPE MType;
   // The following storages are needed to ensure that arguments won't die while
   // we are using them.
   /// Storage for standard layout arguments.
@@ -235,7 +234,7 @@ public:
 };
 
 /// "Execute kernel" command group class.
-class CGExecKernel : public CommandGroup {
+class CGExecKernel : public CG {
 public:
   /// Stores ND-range description.
   NDRDescT MNDRDesc;
@@ -256,17 +255,16 @@ public:
                std::vector<ArgDesc> Args, std::string KernelName,
                detail::OSModuleHandle OSModuleHandle,
                std::vector<std::shared_ptr<detail::stream_impl>> Streams,
-               CGType Type, detail::code_location loc = {})
-      : CommandGroup(Type, std::move(ArgsStorage), std::move(AccStorage),
-                     std::move(SharedPtrStorage), std::move(Requirements),
-                     std::move(Events), std::move(loc)),
+               CGTYPE Type, detail::code_location loc = {})
+      : CG(Type, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MNDRDesc(std::move(NDRDesc)), MHostKernel(std::move(HKernel)),
         MSyclKernel(std::move(SyclKernel)), MArgs(std::move(Args)),
         MKernelName(std::move(KernelName)), MOSModuleHandle(OSModuleHandle),
         MStreams(std::move(Streams)) {
-    assert(
-        (getType() == CGType::RunOnHostIntel || getType() == CGType::Kernel) &&
-        "Wrong type of exec kernel CG.");
+    assert((getType() == RunOnHostIntel || getType() == Kernel) &&
+           "Wrong type of exec kernel CG.");
   }
 
   std::vector<ArgDesc> getArguments() const { return MArgs; }
@@ -291,28 +289,28 @@ public:
 };
 
 /// "Copy memory" command group class.
-class CGCopy : public CommandGroup {
+class CGCopy : public CG {
   void *MSrc;
   void *MDst;
 
 public:
-  CGCopy(CGType CopyType, void *Src, void *Dst,
+  CGCopy(CGTYPE CopyType, void *Src, void *Dst,
          std::vector<std::vector<char>> ArgsStorage,
          std::vector<detail::AccessorImplPtr> AccStorage,
          std::vector<std::shared_ptr<const void>> SharedPtrStorage,
          std::vector<Requirement *> Requirements,
          std::vector<detail::EventImplPtr> Events,
          detail::code_location loc = {})
-      : CommandGroup(CopyType, std::move(ArgsStorage), std::move(AccStorage),
-                     std::move(SharedPtrStorage), std::move(Requirements),
-                     std::move(Events), std::move(loc)),
+      : CG(CopyType, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MSrc(Src), MDst(Dst) {}
   void *getSrc() { return MSrc; }
   void *getDst() { return MDst; }
 };
 
 /// "Fill memory" command group class.
-class CGFill : public CommandGroup {
+class CGFill : public CG {
 public:
   std::vector<char> MPattern;
   Requirement *MPtr;
@@ -324,16 +322,15 @@ public:
          std::vector<Requirement *> Requirements,
          std::vector<detail::EventImplPtr> Events,
          detail::code_location loc = {})
-      : CommandGroup(CGType::Fill, std::move(ArgsStorage),
-                     std::move(AccStorage), std::move(SharedPtrStorage),
-                     std::move(Requirements), std::move(Events),
-                     std::move(loc)),
+      : CG(Fill, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MPattern(std::move(Pattern)), MPtr((Requirement *)Ptr) {}
   Requirement *getReqToFill() { return MPtr; }
 };
 
 /// "Update host" command group class.
-class CGUpdateHost : public CommandGroup {
+class CGUpdateHost : public CG {
   Requirement *MPtr;
 
 public:
@@ -343,17 +340,16 @@ public:
                std::vector<Requirement *> Requirements,
                std::vector<detail::EventImplPtr> Events,
                detail::code_location loc = {})
-      : CommandGroup(CGType::UpdateHost, std::move(ArgsStorage),
-                     std::move(AccStorage), std::move(SharedPtrStorage),
-                     std::move(Requirements), std::move(Events),
-                     std::move(loc)),
+      : CG(UpdateHost, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MPtr((Requirement *)Ptr) {}
 
   Requirement *getReqToUpdate() { return MPtr; }
 };
 
 /// "Copy USM" command group class.
-class CGCopyUSM : public CommandGroup {
+class CGCopyUSM : public CG {
   void *MSrc;
   void *MDst;
   size_t MLength;
@@ -366,10 +362,9 @@ public:
             std::vector<Requirement *> Requirements,
             std::vector<detail::EventImplPtr> Events,
             detail::code_location loc = {})
-      : CommandGroup(CGType::CopyUSM, std::move(ArgsStorage),
-                     std::move(AccStorage), std::move(SharedPtrStorage),
-                     std::move(Requirements), std::move(Events),
-                     std::move(loc)),
+      : CG(CopyUSM, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MSrc(Src), MDst(Dst), MLength(Length) {}
 
   void *getSrc() { return MSrc; }
@@ -378,7 +373,7 @@ public:
 };
 
 /// "Fill USM" command group class.
-class CGFillUSM : public CommandGroup {
+class CGFillUSM : public CG {
   std::vector<char> MPattern;
   void *MDst;
   size_t MLength;
@@ -391,10 +386,9 @@ public:
             std::vector<Requirement *> Requirements,
             std::vector<detail::EventImplPtr> Events,
             detail::code_location loc = {})
-      : CommandGroup(CGType::FillUSM, std::move(ArgsStorage),
-                     std::move(AccStorage), std::move(SharedPtrStorage),
-                     std::move(Requirements), std::move(Events),
-                     std::move(loc)),
+      : CG(FillUSM, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MPattern(std::move(Pattern)), MDst(DstPtr), MLength(Length) {}
   void *getDst() { return MDst; }
   size_t getLength() { return MLength; }
@@ -402,7 +396,7 @@ public:
 };
 
 /// "Prefetch USM" command group class.
-class CGPrefetchUSM : public CommandGroup {
+class CGPrefetchUSM : public CG {
   void *MDst;
   size_t MLength;
 
@@ -414,17 +408,16 @@ public:
                 std::vector<Requirement *> Requirements,
                 std::vector<detail::EventImplPtr> Events,
                 detail::code_location loc = {})
-      : CommandGroup(CGType::PrefetchUSM, std::move(ArgsStorage),
-                     std::move(AccStorage), std::move(SharedPtrStorage),
-                     std::move(Requirements), std::move(Events),
-                     std::move(loc)),
+      : CG(PrefetchUSM, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MDst(DstPtr), MLength(Length) {}
   void *getDst() { return MDst; }
   size_t getLength() { return MLength; }
 };
 
 /// "Advise USM" command group class.
-class CGAdviseUSM : public CommandGroup {
+class CGAdviseUSM : public CG {
   void *MDst;
   size_t MLength;
 
@@ -434,11 +427,11 @@ public:
               std::vector<detail::AccessorImplPtr> AccStorage,
               std::vector<std::shared_ptr<const void>> SharedPtrStorage,
               std::vector<Requirement *> Requirements,
-              std::vector<detail::EventImplPtr> Events, CGType Type,
+              std::vector<detail::EventImplPtr> Events, CGTYPE Type,
               detail::code_location loc = {})
-      : CommandGroup(Type, std::move(ArgsStorage), std::move(AccStorage),
-                     std::move(SharedPtrStorage), std::move(Requirements),
-                     std::move(Events), std::move(loc)),
+      : CG(Type, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MDst(DstPtr), MLength(Length) {}
   void *getDst() { return MDst; }
   size_t getLength() { return MLength; }
@@ -454,7 +447,7 @@ public:
   }
 };
 
-class CGInteropTask : public CommandGroup {
+class CGInteropTask : public CG {
 public:
   std::unique_ptr<InteropTask> MInteropTask;
 
@@ -463,15 +456,15 @@ public:
                 std::vector<detail::AccessorImplPtr> AccStorage,
                 std::vector<std::shared_ptr<const void>> SharedPtrStorage,
                 std::vector<Requirement *> Requirements,
-                std::vector<detail::EventImplPtr> Events, CGType Type,
+                std::vector<detail::EventImplPtr> Events, CGTYPE Type,
                 detail::code_location loc = {})
-      : CommandGroup(Type, std::move(ArgsStorage), std::move(AccStorage),
-                     std::move(SharedPtrStorage), std::move(Requirements),
-                     std::move(Events), std::move(loc)),
+      : CG(Type, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MInteropTask(std::move(InteropTask)) {}
 };
 
-class CGHostTask : public CommandGroup {
+class CGHostTask : public CG {
 public:
   std::unique_ptr<HostTask> MHostTask;
   // queue for host-interop task
@@ -488,16 +481,16 @@ public:
              std::vector<detail::AccessorImplPtr> AccStorage,
              std::vector<std::shared_ptr<const void>> SharedPtrStorage,
              std::vector<Requirement *> Requirements,
-             std::vector<detail::EventImplPtr> Events, CGType Type,
+             std::vector<detail::EventImplPtr> Events, CGTYPE Type,
              detail::code_location loc = {})
-      : CommandGroup(Type, std::move(ArgsStorage), std::move(AccStorage),
-                     std::move(SharedPtrStorage), std::move(Requirements),
-                     std::move(Events), std::move(loc)),
+      : CG(Type, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MHostTask(std::move(HostTask)), MQueue(Queue), MContext(Context),
         MArgs(std::move(Args)) {}
 };
 
-class CGBarrier : public CommandGroup {
+class CGBarrier : public CG {
 public:
   std::vector<detail::EventImplPtr> MEventsWaitWithBarrier;
 
@@ -506,11 +499,11 @@ public:
             std::vector<detail::AccessorImplPtr> AccStorage,
             std::vector<std::shared_ptr<const void>> SharedPtrStorage,
             std::vector<Requirement *> Requirements,
-            std::vector<detail::EventImplPtr> Events, CGType Type,
+            std::vector<detail::EventImplPtr> Events, CGTYPE Type,
             detail::code_location loc = {})
-      : CommandGroup(Type, std::move(ArgsStorage), std::move(AccStorage),
-                     std::move(SharedPtrStorage), std::move(Requirements),
-                     std::move(Events), std::move(loc)),
+      : CG(Type, std::move(ArgsStorage), std::move(AccStorage),
+           std::move(SharedPtrStorage), std::move(Requirements),
+           std::move(Events), std::move(loc)),
         MEventsWaitWithBarrier(std::move(EventsWaitWithBarrier)) {}
 };
 

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -343,20 +343,18 @@ private:
     return Storage;
   }
 
-  void setType(detail::CommandGroup::CGType Type) {
-    constexpr detail::CommandGroup::CG_VERSION Version =
-        detail::CommandGroup::CG_VERSION::V1;
-    MCGType = static_cast<detail::CommandGroup::CGType>(
+  void setType(detail::CG::CGTYPE Type) {
+    constexpr detail::CG::CG_VERSION Version = detail::CG::CG_VERSION::V1;
+    MCGType = static_cast<detail::CG::CGTYPE>(
         getVersionedCGType(Type, static_cast<int>(Version)));
   }
 
-  detail::CommandGroup::CGType getType() {
-    return static_cast<detail::CommandGroup::CGType>(
-        getUnversionedCGType(MCGType));
+  detail::CG::CGTYPE getType() {
+    return static_cast<detail::CG::CGTYPE>(getUnversionedCGType(MCGType));
   }
 
   void throwIfActionIsCreated() {
-    if (detail::CommandGroup::None != getType())
+    if (detail::CG::None != getType())
       throw sycl::runtime_error("Attempt to set multiple actions for the "
                                 "command group. Command group must consist of "
                                 "a single kernel or explicit memory operation.",
@@ -852,7 +850,7 @@ private:
       MNDRDesc.set(std::move(AdjustedRange));
       StoreLambda<KName, decltype(Wrapper), Dims, TransformedArgType>(
           std::move(Wrapper));
-      setType(detail::CommandGroup::Kernel);
+      setType(detail::CG::Kernel);
 #endif
     } else
 #endif // !__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ &&                     \
@@ -866,7 +864,7 @@ private:
       MNDRDesc.set(std::move(NumWorkItems));
       StoreLambda<NameT, KernelType, Dims, TransformedArgType>(
           std::move(KernelFunc));
-      setType(detail::CommandGroup::Kernel);
+      setType(detail::CG::Kernel);
 #endif
     }
   }
@@ -885,7 +883,7 @@ private:
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NumWorkItems);
     MNDRDesc.set(std::move(NumWorkItems));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
     extractArgsAndReqs();
     MKernelName = getKernelName();
   }
@@ -1084,7 +1082,7 @@ private:
 
     MHostTask.reset(new detail::HostTask(std::move(Func)));
 
-    setType(detail::CommandGroup::CodeplayHostTask);
+    setType(detail::CG::CodeplayHostTask);
   }
 
 public:
@@ -1231,7 +1229,7 @@ public:
     MNDRDesc.set(range<1>{1});
 
     StoreLambda<NameT, KernelType, /*Dims*/ 0, void>(KernelFunc);
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
 #endif
   }
 
@@ -1275,7 +1273,7 @@ public:
     MArgs = std::move(MAssociatedAccesors);
     MHostKernel.reset(
         new detail::HostKernel<FuncT, void, 1, void>(std::move(Func)));
-    setType(detail::CommandGroup::RunOnHostIntel);
+    setType(detail::CG::RunOnHostIntel);
   }
 
   template <typename FuncT>
@@ -1338,7 +1336,7 @@ public:
     detail::checkValueRange<Dims>(NumWorkItems, WorkItemOffset);
     MNDRDesc.set(std::move(NumWorkItems), std::move(WorkItemOffset));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
 #endif
   }
 
@@ -1369,7 +1367,7 @@ public:
     detail::checkValueRange<Dims>(ExecutionRange);
     MNDRDesc.set(std::move(ExecutionRange));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
 #endif
   }
 
@@ -1701,7 +1699,7 @@ public:
     detail::checkValueRange<Dims>(NumWorkGroups);
     MNDRDesc.setNumWorkGroups(NumWorkGroups);
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -1736,7 +1734,7 @@ public:
     detail::checkValueRange<Dims>(ExecRange);
     MNDRDesc.set(std::move(ExecRange));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -1753,7 +1751,7 @@ public:
     // known constant
     MNDRDesc.set(range<1>{1});
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
     extractArgsAndReqs();
     MKernelName = getKernelName();
   }
@@ -1787,7 +1785,7 @@ public:
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NumWorkItems, WorkItemOffset);
     MNDRDesc.set(std::move(NumWorkItems), std::move(WorkItemOffset));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
     extractArgsAndReqs();
     MKernelName = getKernelName();
   }
@@ -1806,7 +1804,7 @@ public:
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NDRange);
     MNDRDesc.set(std::move(NDRange));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
     extractArgsAndReqs();
     MKernelName = getKernelName();
   }
@@ -1829,7 +1827,7 @@ public:
     // known constant
     MNDRDesc.set(range<1>{1});
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
@@ -1846,7 +1844,7 @@ public:
   template <typename FuncT> void interop_task(FuncT Func) {
 
     MInteropTask.reset(new detail::InteropTask(std::move(Func)));
-    setType(detail::CommandGroup::CodeplayInteropTask);
+    setType(detail::CG::CodeplayInteropTask);
   }
 
   /// Defines and invokes a SYCL kernel function for the specified range.
@@ -1871,7 +1869,7 @@ public:
     detail::checkValueRange<Dims>(NumWorkItems);
     MNDRDesc.set(std::move(NumWorkItems));
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
@@ -1907,7 +1905,7 @@ public:
     detail::checkValueRange<Dims>(NumWorkItems, WorkItemOffset);
     MNDRDesc.set(std::move(NumWorkItems), std::move(WorkItemOffset));
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
@@ -1942,7 +1940,7 @@ public:
     detail::checkValueRange<Dims>(NDRange);
     MNDRDesc.set(std::move(NDRange));
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
@@ -1982,7 +1980,7 @@ public:
     MNDRDesc.setNumWorkGroups(NumWorkGroups);
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -2022,7 +2020,7 @@ public:
     MNDRDesc.set(std::move(ExecRange));
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     StoreLambda<NameT, KernelType, Dims, LambdaArgType>(std::move(KernelFunc));
-    setType(detail::CommandGroup::Kernel);
+    setType(detail::CG::Kernel);
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -2105,7 +2103,7 @@ public:
       return;
     }
 #endif
-    setType(detail::CommandGroup::CopyAccToPtr);
+    setType(detail::CG::CopyAccToPtr);
 
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Src;
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
@@ -2144,7 +2142,7 @@ public:
       return;
     }
 #endif
-    setType(detail::CommandGroup::CopyPtrToAcc);
+    setType(detail::CG::CopyPtrToAcc);
 
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Dst;
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
@@ -2189,7 +2187,7 @@ public:
            "The destination accessor does not fit the copied memory.");
     if (copyAccToAccHelper(Src, Dst))
       return;
-    setType(detail::CommandGroup::CopyAccToAcc);
+    setType(detail::CG::CopyAccToAcc);
 
     detail::AccessorBaseHost *AccBaseSrc = (detail::AccessorBaseHost *)&Src;
     detail::AccessorImplPtr AccImplSrc = detail::getSyclObjImpl(*AccBaseSrc);
@@ -2219,7 +2217,7 @@ public:
     throwIfActionIsCreated();
     static_assert(isValidTargetForExplicitOp(AccessTarget),
                   "Invalid accessor target for the update_host method.");
-    setType(detail::CommandGroup::UpdateHost);
+    setType(detail::CG::UpdateHost);
 
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Acc;
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
@@ -2251,7 +2249,7 @@ public:
                   "Invalid accessor target for the fill method.");
     if (!MIsHost && (((Dims == 1) && isConstOrGlobal(AccessTarget)) ||
                      isImageOrImageArray(AccessTarget))) {
-      setType(detail::CommandGroup::Fill);
+      setType(detail::CG::Fill);
 
       detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Dst;
       detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
@@ -2296,7 +2294,7 @@ public:
   /// complete state.
   void barrier() {
     throwIfActionIsCreated();
-    setType(detail::CommandGroup::Barrier);
+    setType(detail::CG::Barrier);
   }
 
   /// Prevents any commands submitted afterward to this queue from executing
@@ -2384,7 +2382,7 @@ private:
   /// Type of the command group, e.g. kernel, fill. Can also encode version.
   /// Use getType and setType methods to access this variable unless
   /// manipulations with version are required
-  detail::CommandGroup::CGType MCGType = detail::CommandGroup::None;
+  detail::CG::CGTYPE MCGType = detail::CG::None;
   /// Pointer to the source host memory or accessor(depending on command type).
   void *MSrcPtr = nullptr;
   /// Pointer to the dest host memory or accessor(depends on command type).

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -203,8 +203,7 @@ public:
   void operator()() const {
     waitForEvents();
 
-    assert(MThisCmd->getCG().getType() ==
-           CommandGroup::CGType::CodeplayHostTask);
+    assert(MThisCmd->getCG().getType() == CG::CGTYPE::CodeplayHostTask);
 
     CGHostTask &HostTask = static_cast<CGHostTask &>(MThisCmd->getCG());
 
@@ -1215,13 +1214,13 @@ AllocaCommandBase *ExecCGCommand::getAllocaForReq(Requirement *Req) {
 }
 
 std::vector<StreamImplPtr> ExecCGCommand::getStreams() const {
-  if (MCommandGroup->getType() == CommandGroup::Kernel)
+  if (MCommandGroup->getType() == CG::Kernel)
     return ((CGExecKernel *)MCommandGroup.get())->getStreams();
   return {};
 }
 
 void ExecCGCommand::clearStreams() {
-  if (MCommandGroup->getType() == CommandGroup::Kernel)
+  if (MCommandGroup->getType() == CG::Kernel)
     ((CGExecKernel *)MCommandGroup.get())->clearStreams();
 }
 
@@ -1447,36 +1446,36 @@ void UpdateHostRequirementCommand::emitInstrumentationData() {
 #endif
 }
 
-static std::string cgTypeToString(detail::CommandGroup::CGType Type) {
+static std::string cgTypeToString(detail::CG::CGTYPE Type) {
   switch (Type) {
-  case detail::CommandGroup::Kernel:
+  case detail::CG::Kernel:
     return "Kernel";
     break;
-  case detail::CommandGroup::UpdateHost:
+  case detail::CG::UpdateHost:
     return "update_host";
     break;
-  case detail::CommandGroup::Fill:
+  case detail::CG::Fill:
     return "fill";
     break;
-  case detail::CommandGroup::CopyAccToAcc:
+  case detail::CG::CopyAccToAcc:
     return "copy acc to acc";
     break;
-  case detail::CommandGroup::CopyAccToPtr:
+  case detail::CG::CopyAccToPtr:
     return "copy acc to ptr";
     break;
-  case detail::CommandGroup::CopyPtrToAcc:
+  case detail::CG::CopyPtrToAcc:
     return "copy ptr to acc";
     break;
-  case detail::CommandGroup::CopyUSM:
+  case detail::CG::CopyUSM:
     return "copy usm";
     break;
-  case detail::CommandGroup::FillUSM:
+  case detail::CG::FillUSM:
     return "fill usm";
     break;
-  case detail::CommandGroup::PrefetchUSM:
+  case detail::CG::PrefetchUSM:
     return "prefetch usm";
     break;
-  case detail::CommandGroup::CodeplayHostTask:
+  case detail::CG::CodeplayHostTask:
     return "host task";
     break;
   default:
@@ -1485,7 +1484,7 @@ static std::string cgTypeToString(detail::CommandGroup::CGType Type) {
   }
 }
 
-ExecCGCommand::ExecCGCommand(std::unique_ptr<detail::CommandGroup> CommandGroup,
+ExecCGCommand::ExecCGCommand(std::unique_ptr<detail::CG> CommandGroup,
                              QueueImplPtr Queue)
     : Command(CommandType::RUN_CG, std::move(Queue)),
       MCommandGroup(std::move(CommandGroup)) {
@@ -1502,7 +1501,7 @@ void ExecCGCommand::emitInstrumentationData() {
   bool HasSourceInfo = false;
   std::string KernelName, FromSource;
   switch (MCommandGroup->getType()) {
-  case detail::CommandGroup::Kernel: {
+  case detail::CG::Kernel: {
     auto KernelCG =
         reinterpret_cast<detail::CGExecKernel *>(MCommandGroup.get());
 
@@ -1589,7 +1588,7 @@ void ExecCGCommand::printDot(std::ostream &Stream) const {
   Stream << "EXEC CG ON " << deviceToString(MQueue->get_device()) << "\\n";
 
   switch (MCommandGroup->getType()) {
-  case detail::CommandGroup::Kernel: {
+  case detail::CG::Kernel: {
     auto KernelCG =
         reinterpret_cast<detail::CGExecKernel *>(MCommandGroup.get());
     Stream << "Kernel name: ";
@@ -1795,7 +1794,7 @@ void DispatchNativeKernel(void *Blob) {
 }
 
 cl_int ExecCGCommand::enqueueImp() {
-  if (getCG().getType() != CommandGroup::CGType::CodeplayHostTask)
+  if (getCG().getType() != CG::CGTYPE::CodeplayHostTask)
     waitForPreparedHostEvents();
   std::vector<EventImplPtr> EventImpls = MPreparedDepsEvents;
   auto RawEvents = getPiEvents(EventImpls);
@@ -1804,11 +1803,11 @@ cl_int ExecCGCommand::enqueueImp() {
 
   switch (MCommandGroup->getType()) {
 
-  case CommandGroup::CGType::UpdateHost: {
+  case CG::CGTYPE::UpdateHost: {
     throw runtime_error("Update host should be handled by the Scheduler.",
                         PI_INVALID_OPERATION);
   }
-  case CommandGroup::CGType::CopyAccToPtr: {
+  case CG::CGTYPE::CopyAccToPtr: {
     CGCopy *Copy = (CGCopy *)MCommandGroup.get();
     Requirement *Req = (Requirement *)Copy->getSrc();
     AllocaCommandBase *AllocaCmd = getAllocaForReq(Req);
@@ -1823,7 +1822,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::CopyPtrToAcc: {
+  case CG::CGTYPE::CopyPtrToAcc: {
     CGCopy *Copy = (CGCopy *)MCommandGroup.get();
     Requirement *Req = (Requirement *)(Copy->getDst());
     AllocaCommandBase *AllocaCmd = getAllocaForReq(Req);
@@ -1840,7 +1839,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::CopyAccToAcc: {
+  case CG::CGTYPE::CopyAccToAcc: {
     CGCopy *Copy = (CGCopy *)MCommandGroup.get();
     Requirement *ReqSrc = (Requirement *)(Copy->getSrc());
     Requirement *ReqDst = (Requirement *)(Copy->getDst());
@@ -1857,7 +1856,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::Fill: {
+  case CG::CGTYPE::Fill: {
     CGFill *Fill = (CGFill *)MCommandGroup.get();
     Requirement *Req = (Requirement *)(Fill->getReqToFill());
     AllocaCommandBase *AllocaCmd = getAllocaForReq(Req);
@@ -1870,7 +1869,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::RunOnHostIntel: {
+  case CG::CGTYPE::RunOnHostIntel: {
     CGExecKernel *HostTask = (CGExecKernel *)MCommandGroup.get();
 
     // piEnqueueNativeKernel takes arguments blob which is passes to user
@@ -1941,7 +1940,7 @@ cl_int ExecCGCommand::enqueueImp() {
           "Enqueueing run_on_host_intel task has failed.", Error);
     }
   }
-  case CommandGroup::CGType::Kernel: {
+  case CG::CGTYPE::Kernel: {
     CGExecKernel *ExecKernel = (CGExecKernel *)MCommandGroup.get();
 
     NDRDescT &NDRDesc = ExecKernel->MNDRDesc;
@@ -2057,21 +2056,21 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return PI_SUCCESS;
   }
-  case CommandGroup::CGType::CopyUSM: {
+  case CG::CGTYPE::CopyUSM: {
     CGCopyUSM *Copy = (CGCopyUSM *)MCommandGroup.get();
     MemoryManager::copy_usm(Copy->getSrc(), MQueue, Copy->getLength(),
                             Copy->getDst(), std::move(RawEvents), Event);
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::FillUSM: {
+  case CG::CGTYPE::FillUSM: {
     CGFillUSM *Fill = (CGFillUSM *)MCommandGroup.get();
     MemoryManager::fill_usm(Fill->getDst(), MQueue, Fill->getLength(),
                             Fill->getFill(), std::move(RawEvents), Event);
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::PrefetchUSM: {
+  case CG::CGTYPE::PrefetchUSM: {
     CGPrefetchUSM *Prefetch = (CGPrefetchUSM *)MCommandGroup.get();
     MemoryManager::prefetch_usm(Prefetch->getDst(), MQueue,
                                 Prefetch->getLength(), std::move(RawEvents),
@@ -2079,14 +2078,14 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::AdviseUSM: {
+  case CG::CGTYPE::AdviseUSM: {
     CGAdviseUSM *Advise = (CGAdviseUSM *)MCommandGroup.get();
     MemoryManager::advise_usm(Advise->getDst(), MQueue, Advise->getLength(),
                               Advise->getAdvice(), std::move(RawEvents), Event);
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::CodeplayInteropTask: {
+  case CG::CGTYPE::CodeplayInteropTask: {
     const detail::plugin &Plugin = MQueue->getPlugin();
     CGInteropTask *ExecInterop = (CGInteropTask *)MCommandGroup.get();
     // Wait for dependencies to complete before dispatching work on the host
@@ -2114,7 +2113,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::CodeplayHostTask: {
+  case CG::CGTYPE::CodeplayHostTask: {
     CGHostTask *HostTask = static_cast<CGHostTask *>(MCommandGroup.get());
 
     for (ArgDesc &Arg : HostTask->MArgs) {
@@ -2169,7 +2168,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return CL_SUCCESS;
   }
-  case CommandGroup::CGType::Barrier: {
+  case CG::CGTYPE::Barrier: {
     if (MQueue->get_device().is_host()) {
       // NOP for host device.
       return PI_SUCCESS;
@@ -2180,7 +2179,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return PI_SUCCESS;
   }
-  case CommandGroup::CGType::BarrierWaitlist: {
+  case CG::CGTYPE::BarrierWaitlist: {
     CGBarrier *Barrier = static_cast<CGBarrier *>(MCommandGroup.get());
     std::vector<detail::EventImplPtr> Events = Barrier->MEventsWaitWithBarrier;
     if (MQueue->get_device().is_host() || Events.empty()) {
@@ -2195,14 +2194,14 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return PI_SUCCESS;
   }
-  case CommandGroup::CGType::None:
+  case CG::CGTYPE::None:
     throw runtime_error("CG type not implemented.", PI_INVALID_OPERATION);
   }
   return PI_INVALID_OPERATION;
 }
 
 bool ExecCGCommand::producesPiEvent() const {
-  return MCommandGroup->getType() != CommandGroup::CGType::CodeplayHostTask;
+  return MCommandGroup->getType() != CG::CGTYPE::CodeplayHostTask;
 }
 
 } // namespace detail

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -502,8 +502,7 @@ private:
 /// operation.
 class ExecCGCommand : public Command {
 public:
-  ExecCGCommand(std::unique_ptr<detail::CommandGroup> CommandGroup,
-                QueueImplPtr Queue);
+  ExecCGCommand(std::unique_ptr<detail::CG> CommandGroup, QueueImplPtr Queue);
 
   std::vector<StreamImplPtr> getStreams() const;
 
@@ -512,7 +511,7 @@ public:
   void printDot(std::ostream &Stream) const final;
   void emitInstrumentationData() final;
 
-  detail::CommandGroup &getCG() const { return *MCommandGroup; }
+  detail::CG &getCG() const { return *MCommandGroup; }
 
   // MEmptyCmd is only employed if this command refers to host-task.
   // The mechanism of lookup for single EmptyCommand amongst users of
@@ -540,7 +539,7 @@ private:
       NDRDescT &NDRDesc, std::vector<RT::PiEvent> &RawEvents,
       RT::PiEvent &Event, ProgramManager::KernelArgMask EliminatedArgMask);
 
-  std::unique_ptr<detail::CommandGroup> MCommandGroup;
+  std::unique_ptr<detail::CG> MCommandGroup;
 
   friend class Command;
   friend class Scheduler;

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -68,14 +68,12 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
   }
 }
 
-EventImplPtr
-Scheduler::addCG(std::unique_ptr<detail::CommandGroup> CommandGroup,
-                 QueueImplPtr Queue) {
+EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
+                              QueueImplPtr Queue) {
   EventImplPtr NewEvent = nullptr;
-  const bool IsKernel = CommandGroup->getType() == CommandGroup::Kernel;
+  const bool IsKernel = CommandGroup->getType() == CG::Kernel;
   std::vector<Command *> AuxiliaryCmds;
-  const bool IsHostKernel =
-      CommandGroup->getType() == CommandGroup::RunOnHostIntel;
+  const bool IsHostKernel = CommandGroup->getType() == CG::RunOnHostIntel;
   std::vector<StreamImplPtr> Streams;
 
   if (IsKernel) {
@@ -149,11 +147,11 @@ Scheduler::addCG(std::unique_ptr<detail::CommandGroup> CommandGroup,
 
     Command *NewCmd = nullptr;
     switch (CommandGroup->getType()) {
-    case CommandGroup::UpdateHost:
+    case CG::UpdateHost:
       NewCmd = MGraphBuilder.addCGUpdateHost(std::move(CommandGroup),
                                              DefaultHostQueue, AuxiliaryCmds);
       break;
-    case CommandGroup::CodeplayHostTask:
+    case CG::CodeplayHostTask:
       NewCmd = MGraphBuilder.addCG(std::move(CommandGroup), DefaultHostQueue,
                                    AuxiliaryCmds);
       break;

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -363,7 +363,7 @@ public:
   ///
   /// \param CommandGroup is a unique_ptr to a command group to be added.
   /// \return an event object to wait on for command group completion.
-  EventImplPtr addCG(std::unique_ptr<detail::CommandGroup> CommandGroup,
+  EventImplPtr addCG(std::unique_ptr<detail::CG> CommandGroup,
                      QueueImplPtr Queue);
 
   /// Registers a command group, that copies most recent memory to the memory
@@ -479,14 +479,14 @@ protected:
     /// \sa queue::submit, Scheduler::addCG
     ///
     /// \return a command that represents command group execution.
-    Command *addCG(std::unique_ptr<detail::CommandGroup> CommandGroup,
-                   QueueImplPtr Queue, std::vector<Command *> &ToEnqueue);
+    Command *addCG(std::unique_ptr<detail::CG> CommandGroup, QueueImplPtr Queue,
+                   std::vector<Command *> &ToEnqueue);
 
     /// Registers a \ref CG "command group" that updates host memory to the
     /// latest state.
     ///
     /// \return a command that represents command group execution.
-    Command *addCGUpdateHost(std::unique_ptr<detail::CommandGroup> CommandGroup,
+    Command *addCGUpdateHost(std::unique_ptr<detail::CG> CommandGroup,
                              QueueImplPtr HostQueue,
                              std::vector<Command *> &ToEnqueue);
 

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -106,7 +106,7 @@ event handler::finalize() {
 
   // Kernel_bundles could not be used before CGType version 1
   if (getCGTypeVersion(MCGType) >
-      static_cast<unsigned int>(detail::CommandGroup::CG_VERSION::V0)) {
+      static_cast<unsigned int>(detail::CG::CG_VERSION::V0)) {
     // If there were uses of set_specialization_constant build the kernel_bundle
     std::shared_ptr<detail::kernel_bundle_impl> KernelBundleImpPtr =
         getOrInsertHandlerKernelBundle(/*Insert=*/false);
@@ -131,10 +131,10 @@ event handler::finalize() {
     }
   }
 
-  std::unique_ptr<detail::CommandGroup> CommandGroup;
+  std::unique_ptr<detail::CG> CommandGroup;
   switch (getType()) {
-  case detail::CommandGroup::Kernel:
-  case detail::CommandGroup::RunOnHostIntel: {
+  case detail::CG::Kernel:
+  case detail::CG::RunOnHostIntel: {
     CommandGroup.reset(new detail::CGExecKernel(
         std::move(MNDRDesc), std::move(MHostKernel), std::move(MKernel),
         std::move(MArgsStorage), std::move(MAccStorage),
@@ -144,71 +144,71 @@ event handler::finalize() {
         MCodeLoc));
     break;
   }
-  case detail::CommandGroup::CodeplayInteropTask:
+  case detail::CG::CodeplayInteropTask:
     CommandGroup.reset(new detail::CGInteropTask(
         std::move(MInteropTask), std::move(MArgsStorage),
         std::move(MAccStorage), std::move(MSharedPtrStorage),
         std::move(MRequirements), std::move(MEvents), MCGType, MCodeLoc));
     break;
-  case detail::CommandGroup::CopyAccToPtr:
-  case detail::CommandGroup::CopyPtrToAcc:
-  case detail::CommandGroup::CopyAccToAcc:
+  case detail::CG::CopyAccToPtr:
+  case detail::CG::CopyPtrToAcc:
+  case detail::CG::CopyAccToAcc:
     CommandGroup.reset(new detail::CGCopy(
         MCGType, MSrcPtr, MDstPtr, std::move(MArgsStorage),
         std::move(MAccStorage), std::move(MSharedPtrStorage),
         std::move(MRequirements), std::move(MEvents), MCodeLoc));
     break;
-  case detail::CommandGroup::Fill:
+  case detail::CG::Fill:
     CommandGroup.reset(new detail::CGFill(
         std::move(MPattern), MDstPtr, std::move(MArgsStorage),
         std::move(MAccStorage), std::move(MSharedPtrStorage),
         std::move(MRequirements), std::move(MEvents), MCodeLoc));
     break;
-  case detail::CommandGroup::UpdateHost:
+  case detail::CG::UpdateHost:
     CommandGroup.reset(new detail::CGUpdateHost(
         MDstPtr, std::move(MArgsStorage), std::move(MAccStorage),
         std::move(MSharedPtrStorage), std::move(MRequirements),
         std::move(MEvents), MCodeLoc));
     break;
-  case detail::CommandGroup::CopyUSM:
+  case detail::CG::CopyUSM:
     CommandGroup.reset(new detail::CGCopyUSM(
         MSrcPtr, MDstPtr, MLength, std::move(MArgsStorage),
         std::move(MAccStorage), std::move(MSharedPtrStorage),
         std::move(MRequirements), std::move(MEvents), MCodeLoc));
     break;
-  case detail::CommandGroup::FillUSM:
+  case detail::CG::FillUSM:
     CommandGroup.reset(new detail::CGFillUSM(
         std::move(MPattern), MDstPtr, MLength, std::move(MArgsStorage),
         std::move(MAccStorage), std::move(MSharedPtrStorage),
         std::move(MRequirements), std::move(MEvents), MCodeLoc));
     break;
-  case detail::CommandGroup::PrefetchUSM:
+  case detail::CG::PrefetchUSM:
     CommandGroup.reset(new detail::CGPrefetchUSM(
         MDstPtr, MLength, std::move(MArgsStorage), std::move(MAccStorage),
         std::move(MSharedPtrStorage), std::move(MRequirements),
         std::move(MEvents), MCodeLoc));
     break;
-  case detail::CommandGroup::AdviseUSM:
+  case detail::CG::AdviseUSM:
     CommandGroup.reset(new detail::CGAdviseUSM(
         MDstPtr, MLength, std::move(MArgsStorage), std::move(MAccStorage),
         std::move(MSharedPtrStorage), std::move(MRequirements),
         std::move(MEvents), MCGType, MCodeLoc));
     break;
-  case detail::CommandGroup::CodeplayHostTask:
+  case detail::CG::CodeplayHostTask:
     CommandGroup.reset(new detail::CGHostTask(
         std::move(MHostTask), MQueue, MQueue->getContextImplPtr(),
         std::move(MArgs), std::move(MArgsStorage), std::move(MAccStorage),
         std::move(MSharedPtrStorage), std::move(MRequirements),
         std::move(MEvents), MCGType, MCodeLoc));
     break;
-  case detail::CommandGroup::Barrier:
-  case detail::CommandGroup::BarrierWaitlist:
+  case detail::CG::Barrier:
+  case detail::CG::BarrierWaitlist:
     CommandGroup.reset(new detail::CGBarrier(
         std::move(MEventsWaitWithBarrier), std::move(MArgsStorage),
         std::move(MAccStorage), std::move(MSharedPtrStorage),
         std::move(MRequirements), std::move(MEvents), MCGType, MCodeLoc));
     break;
-  case detail::CommandGroup::None:
+  case detail::CG::None:
     if (detail::pi::trace(detail::pi::TraceLevel::PI_TRACE_ALL)) {
       std::cout << "WARNING: An empty command group is submitted." << std::endl;
     }
@@ -476,7 +476,7 @@ std::string handler::getKernelName() {
 
 void handler::barrier(const std::vector<event> &WaitList) {
   throwIfActionIsCreated();
-  MCGType = detail::CommandGroup::BarrierWaitlist;
+  MCGType = detail::CG::BarrierWaitlist;
   MEventsWaitWithBarrier.resize(WaitList.size());
   std::transform(
       WaitList.begin(), WaitList.end(), MEventsWaitWithBarrier.begin(),
@@ -488,7 +488,7 @@ void handler::memcpy(void *Dest, const void *Src, size_t Count) {
   MSrcPtr = const_cast<void *>(Src);
   MDstPtr = Dest;
   MLength = Count;
-  setType(detail::CommandGroup::CopyUSM);
+  setType(detail::CG::CopyUSM);
 }
 
 void handler::memset(void *Dest, int Value, size_t Count) {
@@ -496,21 +496,21 @@ void handler::memset(void *Dest, int Value, size_t Count) {
   MDstPtr = Dest;
   MPattern.push_back(static_cast<char>(Value));
   MLength = Count;
-  setType(detail::CommandGroup::FillUSM);
+  setType(detail::CG::FillUSM);
 }
 
 void handler::prefetch(const void *Ptr, size_t Count) {
   throwIfActionIsCreated();
   MDstPtr = const_cast<void *>(Ptr);
   MLength = Count;
-  setType(detail::CommandGroup::PrefetchUSM);
+  setType(detail::CG::PrefetchUSM);
 }
 
 void handler::mem_advise(const void *Ptr, size_t Count, int Advice) {
   throwIfActionIsCreated();
   MDstPtr = const_cast<void *>(Ptr);
   MLength = Count;
-  setType(detail::CommandGroup::AdviseUSM);
+  setType(detail::CG::AdviseUSM);
 
   assert(!MSharedPtrStorage.empty());
 

--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -116,7 +116,7 @@ void foo() {
 // CHECK-NEXT: 344 |       std::__shared_ptr<class sycl::detail::kernel_impl, __gnu_cxx::_S_atomic>::element_type * _M_ptr
 // CHECK-NEXT: 352 |       class std::__shared_count<__gnu_cxx::_S_atomic> _M_refcount
 // CHECK-NEXT: 352 |         _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
-// CHECK-NEXT: 360 |   detail::class CommandGroup::CGType MCGType
+// CHECK-NEXT: 360 |   detail::class CG::CGTYPE MCGType
 // CHECK-NEXT: 368 |   void * MSrcPtr
 // CHECK-NEXT: 376 |   void * MDstPtr
 // CHECK-NEXT: 384 |   size_t MLength

--- a/sycl/test/abi/vtable.cpp
+++ b/sycl/test/abi/vtable.cpp
@@ -49,13 +49,13 @@ void foo(sycl::detail::pi::DeviceBinaryImage &Img) { Img.print(); }
 // CHECK-NEXT:   4 | sycl::detail::pi::DeviceBinaryImage::~DeviceBinaryImage() [complete]
 // CHECK-NEXT:   5 | sycl::detail::pi::DeviceBinaryImage::~DeviceBinaryImage() [deleting]
 
-void foo(sycl::detail::CommandGroup *CG) { delete CG; }
-// CHECK:    Vtable for 'sycl::detail::CommandGroup' (4 entries).
+void foo(sycl::detail::CG *CG) { delete CG; }
+// CHECK:    Vtable for 'sycl::detail::CG' (4 entries).
 // CHECK-NEXT:   0 | offset_to_top (0)
-// CHECK-NEXT:   1 | sycl::detail::CommandGroup RTTI
-// CHECK-NEXT:       -- (sycl::detail::CommandGroup, 0) vtable address --
-// CHECK-NEXT:   2 | sycl::detail::CommandGroup::~CommandGroup() [complete]
-// CHECK-NEXT:   3 | sycl::detail::CommandGroup::~CommandGroup() [deleting]
+// CHECK-NEXT:   1 | sycl::detail::CG RTTI
+// CHECK-NEXT:       -- (sycl::detail::CG, 0) vtable address --
+// CHECK-NEXT:   2 | sycl::detail::CG::~CG() [complete]
+// CHECK-NEXT:   3 | sycl::detail::CG::~CG() [deleting]
 
 void foo(sycl::detail::PropertyWithDataBase *Prop) { delete Prop; }
 // CHECK:    Vtable for 'sycl::detail::PropertyWithDataBase' (4 entries).

--- a/sycl/test/regression/check_simple_name_collisions.cpp
+++ b/sycl/test/regression/check_simple_name_collisions.cpp
@@ -20,7 +20,6 @@
 #define BUFFER
 #define IMAGE 
 #define UNDEFINED
-#define CG
 
 #include <CL/sycl.hpp>
 

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -146,7 +146,7 @@ public:
   }
 
   cl::sycl::detail::Command *
-  addCG(std::unique_ptr<cl::sycl::detail::CommandGroup> CommandGroup,
+  addCG(std::unique_ptr<cl::sycl::detail::CG> CommandGroup,
         cl::sycl::detail::QueueImplPtr Queue,
         std::vector<cl::sycl::detail::Command *> &ToEnqueue) {
     return MGraphBuilder.addCG(std::move(CommandGroup), Queue, ToEnqueue);

--- a/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
+++ b/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
@@ -18,7 +18,7 @@ public:
   MockHandler(shared_ptr_class<detail::queue_impl> Queue, bool IsHost)
       : sycl::handler(Queue, IsHost) {}
 
-  void setType(detail::CommandGroup::CGType Type) {
+  void setType(detail::CG::CGTYPE Type) {
     static_cast<sycl::handler *>(this)->MCGType = Type;
   }
 
@@ -38,12 +38,12 @@ public:
     sycl::handler::addStream(Stream);
   }
 
-  unique_ptr_class<detail::CommandGroup> finalize() {
+  unique_ptr_class<detail::CG> finalize() {
     auto CGH = static_cast<sycl::handler *>(this);
-    unique_ptr_class<detail::CommandGroup> CommandGroup;
+    unique_ptr_class<detail::CG> CommandGroup;
     switch (CGH->MCGType) {
-    case detail::CommandGroup::Kernel:
-    case detail::CommandGroup::RunOnHostIntel: {
+    case detail::CG::Kernel:
+    case detail::CG::RunOnHostIntel: {
       CommandGroup.reset(new detail::CGExecKernel(
           std::move(CGH->MNDRDesc), std::move(CGH->MHostKernel),
           std::move(CGH->MKernel), std::move(CGH->MArgsStorage),
@@ -97,7 +97,7 @@ TEST_F(SchedulerTest, StreamInitDependencyOnHost) {
 
   // Emulating processing of command group function
   MockHandler MockCGH(HQueueImpl, true);
-  MockCGH.setType(detail::CommandGroup::Kernel);
+  MockCGH.setType(detail::CG::Kernel);
 
   auto EmptyKernel = [](sycl::nd_item<1>) {};
   MockCGH
@@ -118,7 +118,7 @@ TEST_F(SchedulerTest, StreamInitDependencyOnHost) {
   ASSERT_TRUE(!!FlushBufMemObjPtr)
       << "Memory object for stream flush buffer not initialized";
 
-  unique_ptr_class<detail::CommandGroup> MainCG = MockCGH.finalize();
+  unique_ptr_class<detail::CG> MainCG = MockCGH.finalize();
 
   // Emulate call of Scheduler::addCG
   vector_class<detail::StreamImplPtr> Streams =


### PR DESCRIPTION
Fix ABI break on windows by adding back old names for CG and CGTYPE