### PR TITLE
[Driver][SYCL] Update minimum MSVC value supported

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4634,13 +4634,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-fms-extensions");
       CmdArgs.push_back("-fms-compatibility");
       CmdArgs.push_back("-fdelayed-template-parsing");
-      VersionTuple MSVT = TC.computeMSVCVersion(&D, Args);
+      VersionTuple MSVT = C.getDefaultToolChain().computeMSVCVersion(&D, Args);
       if (!MSVT.empty())
         CmdArgs.push_back(Args.MakeArgString("-fms-compatibility-version=" +
                                              MSVT.getAsString()));
       else {
-        const char *LowestMSVCSupported =
-            "19.10.25017"; // VS2017 v15.0 (initial release)
+        const char *LowestMSVCSupported = "19.16.27023"; // VS2017 v15.9
         CmdArgs.push_back(Args.MakeArgString(
             Twine("-fms-compatibility-version=") + LowestMSVCSupported));
       }

--- a/clang/test/Driver/windows-compat-sycl-args.cpp
+++ b/clang/test/Driver/windows-compat-sycl-args.cpp
@@ -6,3 +6,7 @@
 // This test checks that the driver passes -fdelayed-template-parsing
 // and -fms-compatibility on Windows for SYCL, both of which are needed for
 // successful compilation of C++ code constructs used in header files.
+
+// Check that the compatibility version is set according to triple for device
+// RUN: %clang_cl -### -fsycl-device-only --target=x86_64-unknown-windows-msvc19.29.0 -c %s 2>&1 | FileCheck %s -check-prefix=COMPAT_VERSION
+// COMPAT_VERSION: -fms-compatibility-version=19.29.0


### PR DESCRIPTION
Align default minimum MSVC version setting used for Windows and properly
set the computed value using the expected MSVC toolchain.