### PR TITLE
[SYCL] small updates to SYCL 2020 Exception support. 

### DIFF
--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -169,20 +169,21 @@ class __SYCL2020_DEPRECATED(
 };
 
 enum class errc : unsigned int {
-  runtime = 0,
-  kernel = 1,
-  accessor = 2,
-  nd_range = 3,
-  event = 4,
-  kernel_argument = 5,
-  build = 6,
-  invalid = 7,
-  memory_allocation = 8,
-  platform = 9,
-  profiling = 10,
-  feature_not_supported = 11,
-  kernel_not_supported = 12,
-  backend_mismatch = 13,
+  success = 0,
+  runtime = 1,
+  kernel = 2,
+  accessor = 3,
+  nd_range = 4,
+  event = 5,
+  kernel_argument = 6,
+  build = 7,
+  invalid = 8,
+  memory_allocation = 9,
+  platform = 10,
+  profiling = 11,
+  feature_not_supported = 12,
+  kernel_not_supported = 13,
+  backend_mismatch = 14,
 };
 
 /// Constructs an error code using e and sycl_category()
@@ -193,7 +194,7 @@ __SYCL_EXPORT const std::error_category &sycl_category() noexcept;
 namespace detail {
 class __SYCL_EXPORT SYCLCategory : public std::error_category {
 public:
-  const char *name() const noexcept override { return "SYCL"; }
+  const char *name() const noexcept override { return "sycl"; }
   std::string message(int) const override { return "SYCL Error"; }
 };
 } // namespace detail

--- a/sycl/test/basic_tests/exceptions-SYCL-2020.cpp
+++ b/sycl/test/basic_tests/exceptions-SYCL-2020.cpp
@@ -11,7 +11,7 @@ int main() {
   const char *emptyCharPtr = "";
 
   // Going to set the error code values to each of the enum (0-12).
-  exception ex1(make_error_code(errc::runtime), emptyStr);
+  exception ex1(make_error_code(errc::runtime), emptyStr); // errc::runtime == 1
   exception ex2(make_error_code(errc::kernel), emptyCharPtr);
   exception ex3(make_error_code(errc::accessor));
   exception ex4(static_cast<int>(errc::nd_range), sycl_category(), emptyStr);
@@ -34,7 +34,8 @@ int main() {
                            ex7, ex8, ex9, ex10, ex11, ex12};
   for (int i = 0; i < 12; i++) {
     exception ex = v[i];
-    assert(ex.code().value() == i && "unexpected error_code.value() retrieved");
+    assert(ex.code().value() == i + 1 &&
+           "unexpected error_code.value() retrieved");
     assert(ex.category() == sycl_category() && "expected SYCL error category");
     if (i < 6) {
       assert(!ex.has_context() &&
@@ -63,14 +64,14 @@ int main() {
   assert(strcmp(ex_string2.what(), testCharPtr) == 0);
 
   // Test sycl_category.
-  assert(std::string("SYCL").compare(sycl_category().name()) == 0 &&
-         "sycl_category name should be SYCL");
+  assert(std::string("sycl").compare(sycl_category().name()) == 0 &&
+         "sycl_category name should be 'sycl'");
 
   // Test make_error_code.
   std::error_code ec = make_error_code(errc::feature_not_supported);
   assert(ec.value() == static_cast<int>(errc::feature_not_supported));
-  assert(std::string("SYCL").compare(ec.category().name()) == 0 &&
-         "error code category name should be SYCL");
+  assert(std::string("sycl").compare(ec.category().name()) == 0 &&
+         "error code category name should be 'sycl'");
 
   // Test enum
   static_assert(std::is_error_code_enum<sycl::errc>::value, "errc enum should identify as error code");


### PR DESCRIPTION
Change of capitalization of sycl_category::name()  to match SYCL 2020 spec.  Also including new 'sycl::errc::success' enumeration accepted by Khronos.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>