### PR TITLE
[SYCL] Ensure int-header fwd decls work with references

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4459,6 +4459,12 @@ public:
     InnerTypeVisitor::Visit(T.getTypePtr());
   }
 
+  void VisitReferenceType(const ReferenceType *RT) {
+    // Our forward declarations don't care about references, so we should just
+    // ignore the reference and continue on.
+    Visit(RT->getPointeeType());
+  }
+
   void Visit(const TemplateArgument &TA) {
     if (TA.isNull())
       return;

--- a/clang/test/CodeGenSYCL/int_header_reference_fwd_decl.cpp
+++ b/clang/test/CodeGenSYCL/int_header_reference_fwd_decl.cpp
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -fsycl-int-header=%t.h %s -o %t.out
+// RUN: FileCheck -input-file=%t.h %s
+
+// This test validates that we handle reference types properly in forward
+// declarations, the bug was that the PassedAsRefType didn't get forward
+// declared, so it resulted in a compile error during host compile. SO, we make
+// sure that we properly forward declare the type (and any template children!).
+
+#include <sycl.hpp>
+
+// CHECK: // Forward declarations of templated kernel function types:
+// CHECK-NEXT: namespace WrapsType {
+// CHECK-NEXT: struct InsidePassedAsRef;
+// CHECK-NEXT: }
+// CHECK: namespace WrapsType {
+// CHECK-NEXT: template <typename T> struct PassedAsRef;
+// CHECK-NEXT: }
+// CHECK: template <typename T> class Wrapper;
+
+namespace WrapsType {
+  struct InsidePassedAsRef{};
+  template<typename T>
+  struct PassedAsRef{};
+}
+
+template<typename T>
+class Wrapper{};
+
+void foo() {
+  using namespace WrapsType;
+  using KernelName = Wrapper<PassedAsRef<InsidePassedAsRef>&>;
+  sycl::kernel_single_task<KernelName>([]{});
+}


### PR DESCRIPTION
We weren't properly descending down into reference types, so we ended up
not forward declaring any types that were referred to only as a
reference type.  This patch ensures we do so, just like we did with
pointer-type.