### PR TITLE
[CODEOWNERS ] Add new code owner for the Clang driver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 clang/ @premanandrao @elizabethandrews @AaronBallman
 
 # Driver
-clang/**/Driver @mdtoguchi @AGindinson
+clang/**/Driver @mdtoguchi @AGindinson @hchilama
 
 # LLVM-SPIRV translator
 llvm-spirv/ @AlexeySotkin @AlexeySachkov


### PR DESCRIPTION
Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>