### PR TITLE
[SYCL] Correctly form the integration header for non-base-ascii char

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4684,6 +4684,25 @@ public:
   }
 };
 
+static void OutputStableNameChar(raw_ostream &O, char C) {
+  // If it is reliably printable, print in the integration header as a
+  // character. Else just print it as the integral representation.
+  if (C >= ' ' && C <= '~')
+    O << '\'' << C << '\'';
+  else
+    O << static_cast<short>(C);
+}
+
+static void OutputStableNameInChars(raw_ostream &O, StringRef Name) {
+  assert(Name.size() > 0);
+  OutputStableNameChar(O, Name[0]);
+
+  for (char C : Name.substr(1)) {
+    O << ", ";
+    OutputStableNameChar(O, C);
+  }
+}
+
 void SYCLIntegrationHeader::emit(raw_ostream &O) {
   O << "// This is auto-generated SYCL integration header.\n";
   O << "\n";
@@ -4782,10 +4801,8 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     const size_t N = K.Params.size();
     if (K.IsUnnamedKernel) {
       O << "template <> struct KernelInfoData<";
-      O << "'" << K.StableName.front();
-      for (char c : StringRef(K.StableName).substr(1))
-        O << "', '" << c;
-      O << "'> {\n";
+      OutputStableNameInChars(O, K.StableName);
+      O << "> {\n";
     } else {
       O << "template <> struct KernelInfo<";
       SYCLKernelNameTypePrinter Printer(O, Policy);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4687,14 +4687,14 @@ public:
 static void OutputStableNameChar(raw_ostream &O, char C) {
   // If it is reliably printable, print in the integration header as a
   // character. Else just print it as the integral representation.
-  if (C >= ' ' && C <= '~')
+  if (llvm::isPrint(C))
     O << '\'' << C << '\'';
   else
     O << static_cast<short>(C);
 }
 
 static void OutputStableNameInChars(raw_ostream &O, StringRef Name) {
-  assert(Name.size() > 0);
+  assert(!Name.empty() && "Expected a nonempty string!");
   OutputStableNameChar(O, Name[0]);
 
   for (char C : Name.substr(1)) {

--- a/clang/test/CodeGenSYCL/int_header_ext_ascii.cpp
+++ b/clang/test/CodeGenSYCL/int_header_ext_ascii.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -fsycl-int-header=%t.h %s -o %t.out
+// RUN: FileCheck -input-file=%t.h %s
+
+#include "sycl.hpp"
+
+// Test ensures that we can properly handle unnamed kernels with extended-ascii
+// characters in it. Non ASCII characters aren't allowed in
+
+struct ΩßPolicyßΩ {
+  void operator()() const {}
+};
+
+void use() {
+  ΩßPolicyßΩ Functor;
+
+  sycl::handler h;
+  h.single_task(Functor);
+}
+
+// CHECK: // Forward declarations of templated kernel function types:
+// CHECK: struct KernelInfoData<'_', 'Z', 'T', 'S', '1', '4', -50, -87, -61, -97, 'P', 'o', 'l', 'i', 'c', 'y', -61, -97, -50, -87> {
+// CHECK: static constexpr const char* getName() { return "_ZTS14ΩßPolicyßΩ"; }

--- a/clang/test/CodeGenSYCL/int_header_ext_ascii.cpp
+++ b/clang/test/CodeGenSYCL/int_header_ext_ascii.cpp
@@ -4,7 +4,7 @@
 #include "sycl.hpp"
 
 // Test ensures that we can properly handle unnamed kernels with extended-ascii
-// characters in it. Non ASCII characters aren't allowed in
+// characters in it.
 
 struct ΩßPolicyßΩ {
   void operator()() const {}


### PR DESCRIPTION
Unnamed kernels use the mangled name, which in some cases can contain an
arbitrary 'char' byte when unpacked using the integer_seq in the header.

Because identifiers can be a pretty massive set of unicode characters,
make sure that we can encode them properly.  We do this by being really
conservative and limiting ourselves to only printing as a
single-quote-delimited character literal when it is one of the
base-ascii printable characters, otherwise emit it as a signed integer
literal instead.