### PR TITLE
[Driver][SYCL] Use -fsycl-footer-path for the header location

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5366,6 +5366,14 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
           llvm::sys::path::stem(SrcFileName).str() + "-footer", "h");
       StringRef TmpFileFooter =
           C.addTempFile(C.getArgs().MakeArgString(TmpFileNameFooter));
+      // Use of -fsycl-footer-path puts the integration footer into that
+      // specified location.
+      if (Arg *A = C.getArgs().getLastArg(options::OPT_fsycl_footer_path_EQ)) {
+        SmallString<128> OutName(A->getValue());
+        llvm::sys::path::append(OutName,
+                                llvm::sys::path::filename(TmpFileNameFooter));
+        TmpFileFooter = C.addTempFile(C.getArgs().MakeArgString(OutName));
+      }
       addIntegrationFiles(TmpFileHeader, TmpFileFooter, SrcFileName);
     }
   }

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -64,5 +64,6 @@
 /// Test for -fsycl-footer-path=<dir>
 // RUN:  %clangxx -fsycl -fsycl-footer-path=dummy_dir %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER_PATH %s
-// FOOTER_PATH: append-file{{.*}} "--output=dummy_dir{{(/|\\\\)}}[[APPENDEDSRC:.+\.cpp]]"
+// FOOTER_PATH: append-file{{.*}} "--append=dummy_dir{{(/|\\\\)}}{{.*}}-footer-{{.*}}.h"
+// FOOTER_PATH-SAME: "--output=dummy_dir{{(/|\\\\)}}[[APPENDEDSRC:.+\.cpp]]"
 // FOOTER_PATH: clang{{.*}} "-x" "c++" "dummy_dir{{(/|\\\\)}}[[APPENDEDSRC]]"


### PR DESCRIPTION
When the user specifies -fsycl-footer-path, not only use the location for
the source + footer file, but also generate the integration footer there.