### PR TITLE
[SYCL] Delay kernel naming until after all pending instantiations

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -13328,7 +13328,7 @@ private:
   // We need to store the list of the sycl_kernel functions and their associated
   // generated OpenCL Kernels so we can go back and re-name these after the
   // fact.
-  llvm::SmallVector<std::pair<const FunctionDecl * , FunctionDecl * >>
+  llvm::SmallVector<std::pair<const FunctionDecl *, FunctionDecl *>>
       SyclKernelsToOpenCLKernels;
 
   // Used to suppress diagnostics during kernel construction, since these were

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -335,9 +335,8 @@ public:
 
   ///  Signals that subsequent parameter descriptor additions will go to
   ///  the kernel with given name. Starts new kernel invocation descriptor.
-  void startKernel(StringRef KernelName, QualType KernelNameType,
-                   StringRef KernelStableName, SourceLocation Loc, bool IsESIMD,
-                   bool IsUnnamedKernel);
+  void startKernel(const FunctionDecl *SyclKernel, QualType KernelNameType,
+                   SourceLocation Loc, bool IsESIMD, bool IsUnnamedKernel);
 
   /// Adds a kernel parameter descriptor to current kernel invocation
   /// descriptor.
@@ -349,6 +348,17 @@ public:
 
   /// Registers a specialization constant to emit info for it into the header.
   void addSpecConstant(StringRef IDName, QualType IDType);
+
+  /// Update the names of a kernel description based on its SyclKernel.
+  void updateKernelNames(const FunctionDecl *SyclKernel, StringRef Name,
+                         StringRef StableName) {
+    auto Itr = llvm::find_if(KernelDescs, [SyclKernel](const KernelDesc &KD) {
+      return KD.SyclKernel == SyclKernel;
+    });
+
+    assert(Itr != KernelDescs.end() && "Unknown kernel description");
+    Itr->updateKernelNames(Name, StableName);
+  }
 
   /// Note which free functions (this_id, this_item, etc) are called within the
   /// kernel
@@ -385,6 +395,9 @@ private:
 
   // Kernel invocation descriptor
   struct KernelDesc {
+    /// sycl_kernel function associated with this kernel.
+    const FunctionDecl *SyclKernel;
+
     /// Kernel name.
     std::string Name;
 
@@ -410,11 +423,15 @@ private:
     // hasn't provided an explicit name for.
     bool IsUnnamedKernel;
 
-    KernelDesc(StringRef Name, QualType NameType, StringRef StableName,
+    KernelDesc(const FunctionDecl *SyclKernel, QualType NameType,
                SourceLocation KernelLoc, bool IsESIMD, bool IsUnnamedKernel)
-        : Name(Name), NameType(NameType), StableName(StableName),
-          KernelLocation(KernelLoc), IsESIMDKernel(IsESIMD),
-          IsUnnamedKernel(IsUnnamedKernel) {}
+        : SyclKernel(SyclKernel), NameType(NameType), KernelLocation(KernelLoc),
+          IsESIMDKernel(IsESIMD), IsUnnamedKernel(IsUnnamedKernel) {}
+
+    void updateKernelNames(StringRef Name, StringRef StableName) {
+      this->Name = Name.str();
+      this->StableName = StableName.str();
+    }
   };
 
   /// Returns the latest invocation descriptor started by
@@ -13308,12 +13325,23 @@ private:
   std::unique_ptr<SYCLIntegrationHeader> SyclIntHeader;
   std::unique_ptr<SYCLIntegrationFooter> SyclIntFooter;
 
+  // We need to store the list of the sycl_kernel functions and their associated
+  // generated OpenCL Kernels so we can go back and re-name these after the
+  // fact.
+  llvm::SmallVector<std::pair<const FunctionDecl * , FunctionDecl * >>
+      SyclKernelsToOpenCLKernels;
+
   // Used to suppress diagnostics during kernel construction, since these were
   // already emitted earlier. Diagnosing during Kernel emissions also skips the
   // useful notes that shows where the kernel was called.
   bool DiagnosingSYCLKernel = false;
 
 public:
+  void addSyclOpenCLKernel(const FunctionDecl *SyclKernel,
+                           FunctionDecl *OpenCLKernel) {
+    SyclKernelsToOpenCLKernels.emplace_back(SyclKernel, OpenCLKernel);
+  }
+
   void addSyclDeviceDecl(Decl *d) { SyclDeviceDecls.insert(d); }
   llvm::SetVector<Decl *> &syclDeviceDecls() { return SyclDeviceDecls; }
 
@@ -13355,6 +13383,7 @@ public:
   void checkSYCLDeviceVarDecl(VarDecl *Var);
   void copySYCLKernelAttrs(const CXXRecordDecl *KernelObj);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
+  void SetSYCLKernelNames();
   void MarkDevices();
 
   /// Get the number of fields or captures within the parsed type.

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1085,6 +1085,9 @@ void Sema::ActOnEndOfTranslationUnitFragment(TUFragmentKind Kind) {
   }
 
   if (getLangOpts().SYCLIsDevice) {
+    // Set the names of the kernels, now that the names have settled down. This
+    // needs to happen before we generate the integration headers.
+    SetSYCLKernelNames();
     // Emit SYCL integration header for current translation unit if needed
     if (SyclIntHeader != nullptr)
       SyclIntHeader->emit(getLangOpts().SYCLIntHeader);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1075,7 +1075,7 @@ static QualType calculateKernelNameType(ASTContext &Ctx,
 // Gets a name for the OpenCL kernel function, calculated from the first
 // template argument of the kernel caller function.
 static std::pair<std::string, std::string>
-constructKernelName(Sema &S, FunctionDecl *KernelCallerFunc,
+constructKernelName(Sema &S, const FunctionDecl *KernelCallerFunc,
                     MangleContext &MC) {
   QualType KernelNameType =
       calculateKernelNameType(S.getASTContext(), KernelCallerFunc);
@@ -2035,28 +2035,26 @@ class SyclKernelDeclCreator : public SyclKernelFieldHandler {
   }
 
   static void setKernelImplicitAttrs(ASTContext &Context, FunctionDecl *FD,
-                                     StringRef Name, bool IsSIMDKernel) {
+                                     bool IsSIMDKernel) {
     // Set implicit attributes.
     FD->addAttr(OpenCLKernelAttr::CreateImplicit(Context));
-    FD->addAttr(AsmLabelAttr::CreateImplicit(Context, Name));
     FD->addAttr(ArtificialAttr::CreateImplicit(Context));
     if (IsSIMDKernel)
       FD->addAttr(SYCLSimdAttr::CreateImplicit(Context));
   }
 
-  static FunctionDecl *createKernelDecl(ASTContext &Ctx, StringRef Name,
-                                        SourceLocation Loc, bool IsInline,
-                                        bool IsSIMDKernel) {
+  static FunctionDecl *createKernelDecl(ASTContext &Ctx, SourceLocation Loc,
+                                        bool IsInline, bool IsSIMDKernel) {
     // Create this with no prototype, and we can fix this up after we've seen
     // all the params.
     FunctionProtoType::ExtProtoInfo Info(CC_OpenCLKernel);
     QualType FuncType = Ctx.getFunctionType(Ctx.VoidTy, {}, Info);
 
     FunctionDecl *FD = FunctionDecl::Create(
-        Ctx, Ctx.getTranslationUnitDecl(), Loc, Loc, &Ctx.Idents.get(Name),
+        Ctx, Ctx.getTranslationUnitDecl(), Loc, Loc, DeclarationName(),
         FuncType, Ctx.getTrivialTypeSourceInfo(Ctx.VoidTy), SC_None);
     FD->setImplicitlyInline(IsInline);
-    setKernelImplicitAttrs(Ctx, FD, Name, IsSIMDKernel);
+    setKernelImplicitAttrs(Ctx, FD, IsSIMDKernel);
 
     // Add kernel to translation unit to see it in AST-dump.
     Ctx.getTranslationUnitDecl()->addDecl(FD);
@@ -2065,12 +2063,14 @@ class SyclKernelDeclCreator : public SyclKernelFieldHandler {
 
 public:
   static constexpr const bool VisitInsideSimpleContainers = false;
-  SyclKernelDeclCreator(Sema &S, StringRef Name, SourceLocation Loc,
-                        bool IsInline, bool IsSIMDKernel)
+  SyclKernelDeclCreator(Sema &S, SourceLocation Loc, bool IsInline,
+                        bool IsSIMDKernel, FunctionDecl *SYCLKernel)
       : SyclKernelFieldHandler(S),
-        KernelDecl(createKernelDecl(S.getASTContext(), Name, Loc, IsInline,
-                                    IsSIMDKernel)),
-        FuncContext(SemaRef, KernelDecl) {}
+        KernelDecl(
+            createKernelDecl(S.getASTContext(), Loc, IsInline, IsSIMDKernel)),
+        FuncContext(SemaRef, KernelDecl) {
+    S.addSyclOpenCLKernel(SYCLKernel, KernelDecl);
+        }
 
   ~SyclKernelDeclCreator() {
     ASTContext &Ctx = SemaRef.getASTContext();
@@ -3367,11 +3367,10 @@ public:
   static constexpr const bool VisitInsideSimpleContainers = false;
   SyclKernelIntHeaderCreator(Sema &S, SYCLIntegrationHeader &H,
                              const CXXRecordDecl *KernelObj, QualType NameType,
-                             StringRef Name, StringRef StableName,
                              FunctionDecl *KernelFunc)
       : SyclKernelFieldHandler(S), Header(H) {
     bool IsSIMDKernel = isESIMDKernelType(KernelObj);
-    Header.startKernel(Name, NameType, StableName, KernelObj->getLocation(),
+    Header.startKernel(KernelFunc, NameType, KernelObj->getLocation(),
                        IsSIMDKernel, IsSYCLUnnamedKernel(S, KernelFunc));
     setThisItemIsCalled(KernelFunc);
   }
@@ -3866,6 +3865,29 @@ void Sema::copySYCLKernelAttrs(const CXXRecordDecl *KernelObj) {
   }
 }
 
+void Sema::SetSYCLKernelNames() {
+  std::unique_ptr<MangleContext> MangleCtx(
+      getASTContext().createMangleContext());
+  // We assume the list of KernelDescs is the complete list of kernels needing
+  // to be rewritten.
+  for (const std::pair<const FunctionDecl *, FunctionDecl *> Pair :
+       SyclKernelsToOpenCLKernels) {
+    std::string CalculatedName, StableName;
+    std::tie(CalculatedName, StableName) =
+        constructKernelName(*this, Pair.first, *MangleCtx);
+    StringRef KernelName(
+        IsSYCLUnnamedKernel(*this, Pair.first) ? StableName : CalculatedName);
+
+    getSyclIntegrationHeader().updateKernelNames(Pair.first, KernelName,
+                                                 StableName);
+
+    // Set name of generated kernel.
+    Pair.second->setDeclName(&Context.Idents.get(KernelName));
+    // Update the AsmLabel for this generated kernel.
+    Pair.second->addAttr(AsmLabelAttr::CreateImplicit(Context, KernelName));
+  }
+}
+
 // Generates the OpenCL kernel using KernelCallerFunc (kernel caller
 // function) defined is SYCL headers.
 // Generated OpenCL kernel contains the body of the kernel caller function,
@@ -3899,30 +3921,30 @@ void Sema::ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc,
   if (KernelObj->isInvalidDecl())
     return;
 
-  // Calculate both names, since Integration headers need both.
-  std::string CalculatedName, StableName;
-  std::tie(CalculatedName, StableName) =
-      constructKernelName(*this, KernelCallerFunc, MC);
-  StringRef KernelName(IsSYCLUnnamedKernel(*this, KernelCallerFunc)
-                           ? StableName
-                           : CalculatedName);
+  {
+    // Do enough to calculate the StableName for the purposes of the hackery
+    // below for __pf_kernel_wrapper. Placed in a scope so that we don't
+    // accidentially use these values below, before the names are stabililzed.
+    std::string CalculatedName, StableName;
+    std::tie(CalculatedName, StableName) =
+        constructKernelName(*this, KernelCallerFunc, MC);
 
-  // Attributes of a user-written SYCL kernel must be copied to the internally
-  // generated alternative kernel, identified by a known string in its name.
-  if (StableName.find("__pf_kernel_wrapper") != std::string::npos)
-    copySYCLKernelAttrs(KernelObj);
+    // Attributes of a user-written SYCL kernel must be copied to the internally
+    // generated alternative kernel, identified by a known string in its name.
+    if (StableName.find("__pf_kernel_wrapper") != std::string::npos)
+      copySYCLKernelAttrs(KernelObj);
+  }
 
   bool IsSIMDKernel = isESIMDKernelType(KernelObj);
 
-  SyclKernelDeclCreator kernel_decl(*this, KernelName, KernelObj->getLocation(),
-                                    KernelCallerFunc->isInlined(),
-                                    IsSIMDKernel);
+  SyclKernelDeclCreator kernel_decl(*this, KernelObj->getLocation(),
+                                    KernelCallerFunc->isInlined(), IsSIMDKernel,
+                                    KernelCallerFunc);
   SyclKernelBodyCreator kernel_body(*this, kernel_decl, KernelObj,
                                     KernelCallerFunc);
   SyclKernelIntHeaderCreator int_header(
       *this, getSyclIntegrationHeader(), KernelObj,
-      calculateKernelNameType(Context, KernelCallerFunc), KernelName,
-      StableName, KernelCallerFunc);
+      calculateKernelNameType(Context, KernelCallerFunc), KernelCallerFunc);
 
   SyclKernelIntFooterCreator int_footer(*this, getSyclIntegrationFooter());
   SyclOptReportCreator opt_report(*this, kernel_decl, KernelObj->getLocation());
@@ -4841,11 +4863,13 @@ bool SYCLIntegrationHeader::emit(StringRef IntHeaderName) {
   return true;
 }
 
-void SYCLIntegrationHeader::startKernel(
-    StringRef KernelName, QualType KernelNameType, StringRef KernelStableName,
-    SourceLocation KernelLocation, bool IsESIMDKernel, bool IsUnnamedKernel) {
-  KernelDescs.emplace_back(KernelName, KernelNameType, KernelStableName,
-                           KernelLocation, IsESIMDKernel, IsUnnamedKernel);
+void SYCLIntegrationHeader::startKernel(const FunctionDecl *SyclKernel,
+                                        QualType KernelNameType,
+                                        SourceLocation KernelLocation,
+                                        bool IsESIMDKernel,
+                                        bool IsUnnamedKernel) {
+  KernelDescs.emplace_back(SyclKernel, KernelNameType, KernelLocation,
+                           IsESIMDKernel, IsUnnamedKernel);
 }
 
 void SYCLIntegrationHeader::addParamDesc(kernel_param_kind_t Kind, int Info,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2070,7 +2070,7 @@ public:
             createKernelDecl(S.getASTContext(), Loc, IsInline, IsSIMDKernel)),
         FuncContext(SemaRef, KernelDecl) {
     S.addSyclOpenCLKernel(SYCLKernel, KernelDecl);
-        }
+  }
 
   ~SyclKernelDeclCreator() {
     ASTContext &Ctx = SemaRef.getASTContext();

--- a/clang/test/CodeGenSYCL/unique_unnamed_kernels.cpp
+++ b/clang/test/CodeGenSYCL/unique_unnamed_kernels.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-sycldevice -IInputs -emit-llvm %s -o - | FileCheck %s
+// This test ensures that we don't generate a kernel before we have instantiated
+// all the kernel declarations, which can change the name of a kernel in the
+// unnamed kernel case. Previously we would have duplicate manglings of the
+// below example, because the marking of 'lambda' as a kernel changed the name
+// of the kernel before it.
+
+#include "Inputs/sycl.hpp"
+
+int main() {
+  sycl::handler h;
+  auto lambda = []() {};
+  h.single_task([]() {});
+  h.single_task(lambda);
+}
+
+// Make sure the kernels are instantiated in the correct order, and named
+// correctly.
+// CHECK: define{{.*}}spir_kernel void @_ZTSZ4mainEUlvE10001_()
+// CHECK: define{{.*}}spir_kernel void @_ZTSZ4mainEUlvE10000_()
+

--- a/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
@@ -70,5 +70,5 @@ int main() {
 // Check kernel wrapper attributes
 
 // CHECK: OpenCLKernelAttr {{.*}} Implicit
-// CHECK: AsmLabelAttr {{.*}} Implicit "{{.*}}kernel_wrapper{{.*}}"
 // CHECK: ArtificialAttr {{.*}} Implicit
+// CHECK: AsmLabelAttr {{.*}} Implicit "{{.*}}kernel_wrapper{{.*}}"

--- a/clang/test/SemaSYCL/check-direct-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/check-direct-attribute-propagation.cpp
@@ -76,12 +76,14 @@ int main() {
     // CHECK:       FunctionDecl {{.*}}test_kernel1
     // CHECK:       SYCLSimdAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLKernelAttr {{.*}} Implicit
+    // CHECK-NEXT:  AsmLabelAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLSimdAttr
     h.single_task<class test_kernel1>(
         FuncObj());
     // CHECK:       FunctionDecl {{.*}}test_kernel2
     // CHECK:       SYCLSimdAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLKernelAttr {{.*}} Implicit
+    // CHECK-NEXT:  AsmLabelAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLSimdAttr
     h.single_task<class test_kernel2>(
         []() [[intel::sycl_explicit_simd]]{});
@@ -90,6 +92,7 @@ int main() {
     // CHECK:      FunctionDecl {{.*}}test_kernel3
     // CHECK:      SYCLSimdAttr {{.*}} Implicit
     // CHECK-NEXT: SYCLKernelAttr {{.*}} Implicit
+    // CHECK-NEXT:  AsmLabelAttr {{.*}} Implicit
     // CHECK-NEXT: SYCLSimdAttr
     // CHECK-NOT:  SYCLSimdAttr
     h.single_task<class test_kernel3>(

--- a/clang/test/SemaSYCL/sycl-esimd-ast.cpp
+++ b/clang/test/SemaSYCL/sycl-esimd-ast.cpp
@@ -17,6 +17,7 @@ int main() {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel1
     // CHECK:       SYCLSimdAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLKernelAttr {{.*}} Implicit
+    // CHECK-NEXT:  AsmLabelAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLSimdAttr {{.*}}
     h.single_task<class test_kernel1>(
         FuncObj());
@@ -24,6 +25,7 @@ int main() {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel2
     // CHECK:       SYCLSimdAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLKernelAttr {{.*}} Implicit
+    // CHECK-NEXT:  AsmLabelAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLSimdAttr {{.*}}
     h.single_task<class test_kernel2>(
         []() [[intel::sycl_explicit_simd]]{});
@@ -32,6 +34,7 @@ int main() {
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
     // CHECK:       SYCLSimdAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLKernelAttr {{.*}} Implicit
+    // CHECK-NEXT:  AsmLabelAttr {{.*}} Implicit
     // CHECK-NEXT:  SYCLSimdAttr {{.*}}
     // CHECK-NEXT:  SYCLSimdAttr {{.*}}
     h.single_task<class test_kernel3>(


### PR DESCRIPTION
If we do Kernel naming too early, the kernel names haven't
"settled" down enough for our names to be correct. This can result in a
compile failure where two kernels end up getting the same name without a
good reason.  This patch separates the naming of a kernel from the
constructing of a kernel, and calls it 'later'.