### PR TITLE
[SYCL] Fix (reduction + range + USM) case

### DIFF
--- a/sycl/include/CL/sycl/reduction.hpp
+++ b/sycl/include/CL/sycl/reduction.hpp
@@ -51,7 +51,7 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 template <typename T, typename BinaryOperation>
 std::enable_if_t<
     has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, true>>
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, true>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
@@ -66,7 +66,7 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename BinaryOperation>
 std::enable_if_t<
     !has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, true>>
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, true>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -92,7 +92,7 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 /// the given USM pointer \p Var, reduction identity value \p Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
-ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, true>
+ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, true>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -2034,7 +2034,7 @@ reduction(accessor<T, Dims, AccMode, access::target::global_buffer, IsPH> &Acc,
 /// the computed reduction must be stored \param VarPtr, identity value
 /// \param Identity, and the binary operation used in the reduction.
 template <typename T, class BinaryOperation>
-detail::reduction_impl<T, BinaryOperation, 0, true>
+detail::reduction_impl<T, BinaryOperation, 1, true>
 reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
   return {VarPtr, Identity, BOp};
 }
@@ -2046,7 +2046,7 @@ reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
 /// The identity value is not passed to this version as it is statically known.
 template <typename T, class BinaryOperation>
 std::enable_if_t<detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-                 detail::reduction_impl<T, BinaryOperation, 0, true>>
+                 detail::reduction_impl<T, BinaryOperation, 1, true>>
 reduction(T *VarPtr, BinaryOperation) {
   return {VarPtr};
 }


### PR DESCRIPTION
0-dimensional accessors were used under the hood of reductions implementations,
which caused compilation errors on tests using reduction+range+USM.

While the more brief fix is to fix range+USM, the safer and more correct fix
is to use 1-dim accessors instead of 0-dim acc.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>