### PR TITLE
[SYCL] Specialize errc for backends.

### DIFF
--- a/sycl/include/CL/sycl/backend.hpp
+++ b/sycl/include/CL/sycl/backend.hpp
@@ -39,6 +39,10 @@ template <backend Backend, typename T> struct BackendReturn {
   // TODO replace usage of interop with specializations.
   using type = typename interop<Backend, T>::type;
 };
+
+// TODO each backend can have its own custom errc enumeration
+// but the details for this are not fully specified yet
+enum class backend_errc : unsigned int {};
 } // namespace detail
 
 template <backend Backend> class backend_traits {
@@ -49,7 +53,7 @@ public:
   template <class T>
   using return_type = typename detail::BackendReturn<Backend, T>::type;
 
-  using errc = sycl::errc;
+  using errc = detail::backend_errc;
 };
 
 template <backend Backend, typename SyclType>

--- a/sycl/include/CL/sycl/backend.hpp
+++ b/sycl/include/CL/sycl/backend.hpp
@@ -49,7 +49,7 @@ public:
   template <class T>
   using return_type = typename detail::BackendReturn<Backend, T>::type;
 
-  // TODO define errc once SYCL2020-style exceptions are supported.
+  using errc = sycl::errc;
 };
 
 template <backend Backend, typename SyclType>

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -186,8 +186,7 @@ enum class errc : unsigned int {
   backend_mismatch = 13,
 };
 
-template<backend B>
-using errc_for = typename backend_traits<B>::errc;
+template<backend B> using errc_for = typename backend_traits<B>::errc;
 
 /// Constructs an error code using e and sycl_category()
 __SYCL_EXPORT std::error_code make_error_code(sycl::errc E) noexcept;

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -12,6 +12,7 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/export.hpp>
+#include <CL/sycl/backend_types.hpp>
 #include <CL/sycl/detail/pi.h>
 #include <CL/sycl/stl.hpp>
 
@@ -184,6 +185,9 @@ enum class errc : unsigned int {
   kernel_not_supported = 12,
   backend_mismatch = 13,
 };
+
+template<backend B>
+using errc_for = typename backend_traits<B>::errc;
 
 /// Constructs an error code using e and sycl_category()
 __SYCL_EXPORT std::error_code make_error_code(sycl::errc E) noexcept;

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -10,9 +10,9 @@
 
 // 4.9.2 Exception Class Interface
 
+#include <CL/sycl/backend_types.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/export.hpp>
-#include <CL/sycl/backend_types.hpp>
 #include <CL/sycl/detail/pi.h>
 #include <CL/sycl/stl.hpp>
 

--- a/sycl/include/CL/sycl/exception.hpp
+++ b/sycl/include/CL/sycl/exception.hpp
@@ -186,7 +186,7 @@ enum class errc : unsigned int {
   backend_mismatch = 13,
 };
 
-template<backend B> using errc_for = typename backend_traits<B>::errc;
+template <backend B> using errc_for = typename backend_traits<B>::errc;
 
 /// Constructs an error code using e and sycl_category()
 __SYCL_EXPORT std::error_code make_error_code(sycl::errc E) noexcept;

--- a/sycl/test/basic_tests/exceptions-SYCL-2020.cpp
+++ b/sycl/test/basic_tests/exceptions-SYCL-2020.cpp
@@ -76,6 +76,27 @@ int main() {
   static_assert(std::is_error_code_enum<sycl::errc>::value, "errc enum should identify as error code");
   static_assert(!std::is_error_condition_enum<sycl::errc>::value, "errc enum should not identify as error condition");
 
+  // Test errc_for and backends. Should compile without complaint.
+  constexpr int EC = 1;
+  sycl::backend_traits<sycl::backend::opencl>::errc OclErrc{EC};
+  sycl::errc SyclErrc1 = sycl::errc_for<sycl::backend::opencl>(OclErrc);
+  (void)SyclErrc1;
+  sycl::backend_traits<sycl::backend::level_zero>::errc L0Errc{EC};
+  sycl::errc SyclErrc2 = sycl::errc_for<sycl::backend::level_zero>(L0Errc);
+  (void)SyclErrc2;
+  sycl::backend_traits<sycl::backend::host>::errc HostErrc{EC};
+  sycl::errc SyclErrc3 = sycl::errc_for<sycl::backend::level_zero>(HostErrc);
+  (void)SyclErrc3;
+  sycl::backend_traits<sycl::backend::cuda>::errc CudaErrc{EC};
+  sycl::errc SyclErrc4 = sycl::errc_for<sycl::backend::cuda>(CudaErrc);
+  (void)SyclErrc4;
+  sycl::backend_traits<sycl::backend::esimd_cpu>::errc EsimdErrc{EC};
+  sycl::errc SyclErrc5 = sycl::errc_for<sycl::backend::esimd_cpu>(EsimdErrc);
+  (void)SyclErrc5;
+  sycl::backend_traits<sycl::backend::rocm>::errc RocmErrc{EC};
+  sycl::errc SyclErrc6 = sycl::errc_for<sycl::backend::rocm>(RocmErrc);
+  (void)SyclErrc6;
+
   std::cout << "OK" << std::endl;
   return 0;
 }

--- a/sycl/test/basic_tests/exceptions-SYCL-2020.cpp
+++ b/sycl/test/basic_tests/exceptions-SYCL-2020.cpp
@@ -78,24 +78,24 @@ int main() {
 
   // Test errc_for and backends. Should compile without complaint.
   constexpr int EC = 1;
-  sycl::backend_traits<sycl::backend::opencl>::errc OclErrc{EC};
-  sycl::errc SyclErrc1 = sycl::errc_for<sycl::backend::opencl>(OclErrc);
-  (void)SyclErrc1;
-  sycl::backend_traits<sycl::backend::level_zero>::errc L0Errc{EC};
-  sycl::errc SyclErrc2 = sycl::errc_for<sycl::backend::level_zero>(L0Errc);
-  (void)SyclErrc2;
-  sycl::backend_traits<sycl::backend::host>::errc HostErrc{EC};
-  sycl::errc SyclErrc3 = sycl::errc_for<sycl::backend::level_zero>(HostErrc);
-  (void)SyclErrc3;
-  sycl::backend_traits<sycl::backend::cuda>::errc CudaErrc{EC};
-  sycl::errc SyclErrc4 = sycl::errc_for<sycl::backend::cuda>(CudaErrc);
-  (void)SyclErrc4;
-  sycl::backend_traits<sycl::backend::esimd_cpu>::errc EsimdErrc{EC};
-  sycl::errc SyclErrc5 = sycl::errc_for<sycl::backend::esimd_cpu>(EsimdErrc);
-  (void)SyclErrc5;
-  sycl::backend_traits<sycl::backend::rocm>::errc RocmErrc{EC};
-  sycl::errc SyclErrc6 = sycl::errc_for<sycl::backend::rocm>(RocmErrc);
-  (void)SyclErrc6;
+  sycl::backend_traits<sycl::backend::opencl>::errc someOpenCLErrCode{EC};
+  sycl::errc_for<sycl::backend::opencl> anotherOpenCLErrCode{EC};
+  assert(someOpenCLErrCode == anotherOpenCLErrCode);
+  sycl::backend_traits<sycl::backend::level_zero>::errc someL0ErrCode{EC};
+  sycl::errc_for<sycl::backend::level_zero> anotherL0ErrCode{EC};
+  assert(someL0ErrCode == anotherL0ErrCode);
+  sycl::backend_traits<sycl::backend::host>::errc someHOSTErrCode{EC};
+  sycl::errc_for<sycl::backend::host> anotherHOSTErrCode{EC};
+  assert(someHOSTErrCode == anotherHOSTErrCode);
+  sycl::backend_traits<sycl::backend::cuda>::errc someCUDAErrCode{EC};
+  sycl::errc_for<sycl::backend::cuda> anotherCUDAErrCode{EC};
+  assert(someCUDAErrCode == anotherCUDAErrCode);
+  sycl::backend_traits<sycl::backend::esimd_cpu>::errc someESIMDErrCode{EC};
+  sycl::errc_for<sycl::backend::esimd_cpu> anotherESIMDErrCode{EC};
+  assert(someESIMDErrCode == anotherESIMDErrCode);
+  sycl::backend_traits<sycl::backend::rocm>::errc someROCMErrCode{EC};
+  sycl::errc_for<sycl::backend::rocm> anotherROCMErrCode{EC};
+  assert(someROCMErrCode == anotherROCMErrCode);
 
   std::cout << "OK" << std::endl;
   return 0;


### PR DESCRIPTION
specialization of errc for backends.  errc_for added as well for SYCL 2020 spec compliance.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>