### PR TITLE
[SYCL] Make vec and marray constructors constexpr

### DIFF
--- a/sycl/include/CL/sycl/marray.hpp
+++ b/sycl/include/CL/sycl/marray.hpp
@@ -60,7 +60,7 @@ public:
   template <
       typename... ArgTN, typename = EnableIfSuitableTypes<ArgTN...>,
       typename = typename std::enable_if<sizeof...(ArgTN) == NumElements>::type>
-  constexpr marray(const ArgTN &...Args) : MData{Args...} {}
+  constexpr marray(const ArgTN &... Args) : MData{Args...} {}
 
   constexpr marray(const marray<Type, NumElements> &Rhs) {
     for (std::size_t I = 0; I < NumElements; ++I) {

--- a/sycl/include/CL/sycl/marray.hpp
+++ b/sycl/include/CL/sycl/marray.hpp
@@ -49,9 +49,9 @@ private:
       conjunction<TypeChecker<ArgTN, DataT>...>::value>::type;
 
 public:
-  marray() : MData{} {}
+  constexpr marray() : MData{} {}
 
-  explicit marray(const Type &Arg) {
+  explicit constexpr marray(const Type &Arg) {
     for (std::size_t I = 0; I < NumElements; ++I) {
       MData[I] = Arg;
     }
@@ -60,15 +60,15 @@ public:
   template <
       typename... ArgTN, typename = EnableIfSuitableTypes<ArgTN...>,
       typename = typename std::enable_if<sizeof...(ArgTN) == NumElements>::type>
-  marray(const ArgTN &... Args) : MData{Args...} {}
+  constexpr marray(const ArgTN &...Args) : MData{Args...} {}
 
-  marray(const marray<Type, NumElements> &Rhs) {
+  constexpr marray(const marray<Type, NumElements> &Rhs) {
     for (std::size_t I = 0; I < NumElements; ++I) {
       MData[I] = Rhs.MData[I];
     }
   }
 
-  marray(marray<Type, NumElements> &&Rhs) {
+  constexpr marray(marray<Type, NumElements> &&Rhs) {
     for (std::size_t I = 0; I < NumElements; ++I) {
       MData[I] = Rhs.MData[I];
     }

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -754,22 +754,22 @@ public:
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<4, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
-		const Ty Arg3)
+                const Ty Arg3)
       : m_Data{Arg0, Arg1, Arg2, Arg3} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<8, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
-		const DataT Arg3, const DataT Arg4, const DataT Arg5,
-		const DataT Arg6, const DataT Arg7)
+                const DataT Arg3, const DataT Arg4, const DataT Arg5,
+                const DataT Arg6, const DataT Arg7)
       : m_Data{Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<16, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
-		const DataT Arg3, const DataT Arg4, const DataT Arg5,
-		const DataT Arg6, const DataT Arg7, const DataT Arg8,
-		const DataT Arg9, const DataT ArgA, const DataT ArgB,
-		const DataT ArgC, const DataT ArgD, const DataT ArgE,
-	       	const DataT ArgF)
+                const DataT Arg3, const DataT Arg4, const DataT Arg5,
+                const DataT Arg6, const DataT Arg7, const DataT Arg8,
+                const DataT Arg9, const DataT ArgA, const DataT ArgB,
+                const DataT ArgC, const DataT ArgD, const DataT ArgE,
+                const DataT ArgF)
       : m_Data{Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7,
                Arg8, Arg9, ArgA, ArgB, ArgC, ArgD, ArgE, ArgF} {}
 #endif

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -745,27 +745,31 @@ public:
       std::is_convertible<T, DataT>::value && NumElements == IdxNum, DataT>;
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<2, Ty> Arg0,
-      const EnableIfNotHostHalf<Ty> Arg1)
+                const EnableIfNotHostHalf<Ty> Arg1)
       : m_Data{Arg0, Arg1} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<3, Ty> Arg0,
-      const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2)
+                const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2)
       : m_Data{Arg0, Arg1, Arg2} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<4, Ty> Arg0,
-      const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2, const Ty Arg3)
+                const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
+		const Ty Arg3)
       : m_Data{Arg0, Arg1, Arg2, Arg3} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<8, Ty> Arg0,
-      const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2, const DataT Arg3,
-      const DataT Arg4, const DataT Arg5, const DataT Arg6, const DataT Arg7)
+                const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
+		const DataT Arg3, const DataT Arg4, const DataT Arg5,
+		const DataT Arg6, const DataT Arg7)
       : m_Data{Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<16, Ty> Arg0,
-      const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2, const DataT Arg3,
-      const DataT Arg4, const DataT Arg5, const DataT Arg6, const DataT Arg7,
-      const DataT Arg8, const DataT Arg9, const DataT ArgA, const DataT ArgB,
-      const DataT ArgC, const DataT ArgD, const DataT ArgE, const DataT ArgF)
+                const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
+		const DataT Arg3, const DataT Arg4, const DataT Arg5,
+		const DataT Arg6, const DataT Arg7, const DataT Arg8,
+		const DataT Arg9, const DataT ArgA, const DataT ArgB,
+		const DataT ArgC, const DataT ArgD, const DataT ArgE,
+	       	const DataT ArgF)
       : m_Data{Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7,
                Arg8, Arg9, ArgA, ArgB, ArgC, ArgD, ArgE, ArgF} {}
 #endif
@@ -774,7 +778,7 @@ public:
   // base types are match and that the NumElements == sum of lengths of args.
   template <typename... argTN, typename = EnableIfSuitableTypes<argTN...>,
             typename = EnableIfSuitableNumElements<argTN...>>
-  constexpr vec(const argTN &...args) {
+  constexpr vec(const argTN &... args) {
     vaargCtorHelper(0, args...);
   }
 

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -650,7 +650,7 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
   vec(const vec &Rhs) = default;
 #else
-  vec(const vec &Rhs) : m_Data(Rhs.m_Data) {}
+  constexpr vec(const vec &Rhs) : m_Data(Rhs.m_Data) {}
 #endif
 
   vec(vec &&Rhs) = default;
@@ -682,7 +682,7 @@ public:
       T>;
 
   template <typename Ty = DataT>
-  explicit vec(const EnableIfNotHostHalf<Ty> &arg) {
+  explicit constexpr vec(const EnableIfNotHostHalf<Ty> &arg) {
     m_Data = (DataType)arg;
   }
 
@@ -696,7 +696,8 @@ public:
     return *this;
   }
 
-  template <typename Ty = DataT> explicit vec(const EnableIfHostHalf<Ty> &arg) {
+  template <typename Ty = DataT>
+  explicit constexpr vec(const EnableIfHostHalf<Ty> &arg) {
     for (int i = 0; i < NumElements; ++i) {
       setValue(i, arg);
     }
@@ -714,7 +715,7 @@ public:
     return *this;
   }
 #else
-  explicit vec(const DataT &arg) {
+  explicit constexpr vec(const DataT &arg) {
     for (int i = 0; i < NumElements; ++i) {
       setValue(i, arg);
     }
@@ -743,24 +744,24 @@ public:
   using EnableIfMultipleElems = typename detail::enable_if_t<
       std::is_convertible<T, DataT>::value && NumElements == IdxNum, DataT>;
   template <typename Ty = DataT>
-  vec(const EnableIfMultipleElems<2, Ty> Arg0,
+  constexpr vec(const EnableIfMultipleElems<2, Ty> Arg0,
       const EnableIfNotHostHalf<Ty> Arg1)
       : m_Data{Arg0, Arg1} {}
   template <typename Ty = DataT>
-  vec(const EnableIfMultipleElems<3, Ty> Arg0,
+  constexpr vec(const EnableIfMultipleElems<3, Ty> Arg0,
       const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2)
       : m_Data{Arg0, Arg1, Arg2} {}
   template <typename Ty = DataT>
-  vec(const EnableIfMultipleElems<4, Ty> Arg0,
+  constexpr vec(const EnableIfMultipleElems<4, Ty> Arg0,
       const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2, const Ty Arg3)
       : m_Data{Arg0, Arg1, Arg2, Arg3} {}
   template <typename Ty = DataT>
-  vec(const EnableIfMultipleElems<8, Ty> Arg0,
+  constexpr vec(const EnableIfMultipleElems<8, Ty> Arg0,
       const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2, const DataT Arg3,
       const DataT Arg4, const DataT Arg5, const DataT Arg6, const DataT Arg7)
       : m_Data{Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7} {}
   template <typename Ty = DataT>
-  vec(const EnableIfMultipleElems<16, Ty> Arg0,
+  constexpr vec(const EnableIfMultipleElems<16, Ty> Arg0,
       const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2, const DataT Arg3,
       const DataT Arg4, const DataT Arg5, const DataT Arg6, const DataT Arg7,
       const DataT Arg8, const DataT Arg9, const DataT ArgA, const DataT ArgB,
@@ -773,7 +774,7 @@ public:
   // base types are match and that the NumElements == sum of lengths of args.
   template <typename... argTN, typename = EnableIfSuitableTypes<argTN...>,
             typename = EnableIfSuitableNumElements<argTN...>>
-  vec(const argTN &... args) {
+  constexpr vec(const argTN &...args) {
     vaargCtorHelper(0, args...);
   }
 
@@ -792,7 +793,7 @@ public:
             typename = typename detail::enable_if_t<
                 std::is_same<vector_t_, vector_t>::value &&
                 !std::is_same<vector_t_, DataT>::value>>
-  vec(vector_t openclVector) : m_Data(openclVector) {}
+  constexpr vec(vector_t openclVector) : m_Data(openclVector) {}
   operator vector_t() const { return m_Data; }
 #endif
 

--- a/sycl/test/basic_tests/SYCL-2020-spec-constants.cpp
+++ b/sycl/test/basic_tests/SYCL-2020-spec-constants.cpp
@@ -37,6 +37,14 @@ constexpr sycl::specialization_id<uint64_t> uint64_id(8);
 // constexpr sycl::specialization_id<half> half_id(9.0);
 constexpr sycl::specialization_id<float> float_id(10.0);
 constexpr sycl::specialization_id<double> double_id(11.0);
+constexpr sycl::marray<double, 5> ma;
+constexpr sycl::specialization_id<sycl::marray<double, 5>> marray_id5(11.0);
+constexpr sycl::specialization_id<sycl::marray<double, 1>> marray_id1(11.0);
+constexpr sycl::specialization_id<sycl::marray<double, 5>> marray_id_def(ma);
+constexpr sycl::vec<double, 4> v{};
+constexpr sycl::specialization_id<sycl::vec<double, 4>> vec_id_def(v);
+constexpr sycl::specialization_id<sycl::vec<double, 1>> vec_id1(11.0);
+constexpr sycl::specialization_id<sycl::vec<double, 4>> vec_id4(11.0);
 
 struct composite {
   int a;


### PR DESCRIPTION
The change is required for specialization constant implementation and
was added to the SYCL 2020 specification (KhronosGroup/SYCL-Docs#133)