### PR TITLE
[SYCL] Apply Level Zero batching workaround more selectively

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1106,7 +1106,8 @@ bool UnMapMemObject::producesPiEvent() const {
   // an event waitlist and Level Zero plugin attempts to batch these commands,
   // so the execution of kernel B starts only on step 4. This workaround
   // restores the old behavior in this case until this is resolved.
-  return MQueue->getPlugin().getBackend() != backend::level_zero;
+  return MQueue->getPlugin().getBackend() != backend::level_zero ||
+         MEvent->getHandleRef() != nullptr;
 }
 
 cl_int UnMapMemObject::enqueueImp() {
@@ -1202,7 +1203,8 @@ bool MemCpyCommand::producesPiEvent() const {
   // so the execution of kernel B starts only on step 4. This workaround
   // restores the old behavior in this case until this is resolved.
   return MQueue->is_host() ||
-         MQueue->getPlugin().getBackend() != backend::level_zero;
+         MQueue->getPlugin().getBackend() != backend::level_zero ||
+         MEvent->getHandleRef() != nullptr;
 }
 
 cl_int MemCpyCommand::enqueueImp() {


### PR DESCRIPTION
The original version of the workaround was applied too broadly, which
was harmful to perfromance of some use-cases.
Add a check that completely replicates the old behavior on Level Zero.