### PR TITLE
[SYCL] Don't canonicalize self-referential NTTPs in a fwd decl.

### DIFF
--- a/clang/include/clang/AST/PrettyPrinter.h
+++ b/clang/include/clang/AST/PrettyPrinter.h
@@ -324,7 +324,7 @@ struct PrintingPolicy {
   /// is:
   ///   \code
   ///   TemplateTypeParmType 'type-parameter-0-0'
-  ///   \endcode.
+  ///   \endcode
   unsigned SkipCanonicalizationOfTemplateTypeParms : 1;
 
   /// Whether to print an InjectedClassNameType with template arguments or as

--- a/clang/include/clang/AST/PrettyPrinter.h
+++ b/clang/include/clang/AST/PrettyPrinter.h
@@ -75,7 +75,9 @@ struct PrintingPolicy {
         MSVCFormatting(false), ConstantsAsWritten(false),
         SuppressImplicitBase(false), FullyQualifiedName(false),
         SuppressDefinition(false), SuppressDefaultTemplateArguments(false),
-        PrintCanonicalTypes(false), PrintInjectedClassNameWithArguments(true) {}
+        PrintCanonicalTypes(false),
+        SkipCanonicalizationOfTemplateTypeParms(false),
+        PrintInjectedClassNameWithArguments(true) {}
 
   /// Adjust this printing policy for cases where it's known that we're
   /// printing C++ code (for instance, if AST dumping reaches a C++-only
@@ -310,6 +312,20 @@ struct PrintingPolicy {
 
   /// Whether to print types as written or canonically.
   unsigned PrintCanonicalTypes : 1;
+
+  /// Whether to skip the canonicalization (when PrintCanonicalTypes is set) for
+  /// TemplateTypeParmTypes. This has no effect if PrintCanonicalTypes isn't
+  /// set. This is useful for non-type-template-parameters, since the canonical
+  /// version of:
+  ///   \code
+  ///   TemplateTypeParmType '_Tp'
+  ///     TemplateTypeParm '_Tp'
+  ///   \endcode
+  /// is:
+  ///   \code
+  ///   TemplateTypeParmType 'type-parameter-0-0'
+  ///   \endcode.
+  unsigned SkipCanonicalizationOfTemplateTypeParms : 1;
 
   /// Whether to print an InjectedClassNameType with template arguments or as
   /// written. When a template argument is unnamed, printing it results in

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -167,7 +167,9 @@ void TypePrinter::spaceBeforePlaceHolder(raw_ostream &OS) {
 
 static SplitQualType splitAccordingToPolicy(QualType QT,
                                             const PrintingPolicy &Policy) {
-  if (Policy.PrintCanonicalTypes)
+  if ((!Policy.SkipCanonicalizationOfTemplateTypeParms ||
+       !QT->isTemplateTypeParmType()) &&
+      Policy.PrintCanonicalTypes)
     QT = QT.getCanonicalType();
   return QT.split();
 }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4451,6 +4451,7 @@ public:
     Policy.SuppressTypedefs = true;
     Policy.SuppressUnwrittenScope = true;
     Policy.PrintCanonicalTypes = true;
+    Policy.SkipCanonicalizationOfTemplateTypeParms = true;
   }
 
   void Visit(QualType T) {

--- a/clang/test/CodeGenSYCL/int_header_nttp.cpp
+++ b/clang/test/CodeGenSYCL/int_header_nttp.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -fsycl-int-header=%t.h %s -o %t.out
+// RUN: FileCheck -input-file=%t.h %s
+
+#include "sycl.hpp"
+// Test to ensue that we properly output the forward declarations of
+// non-type-template-parameters when they refer to another template parameter.
+
+// CHECK: Forward declarations of templated kernel function types:
+// CHECK-NEXT: template <typename T, T nttp> struct SelfReferentialNTTP;
+// CHECK-NEXT: template <typename U, int nttp> struct NonSelfRef;
+
+template<typename T, T nttp>
+struct SelfReferentialNTTP {};
+
+using Foo = int;
+
+template<typename U, Foo nttp>
+struct NonSelfRef {};
+
+void foo() {
+  sycl::kernel_single_task<SelfReferentialNTTP<int, 1>>([](){});
+  sycl::kernel_single_task<NonSelfRef<int, 1>>([](){});
+}


### PR DESCRIPTION
The canonical version of a self-referential
non-type-template-parameter's type is a placeholder typically, so skip
doing it so we actually get a valid forward declaration.

This shouldn't affect normal canonicalization, since the type being
printed is actually canonicalized (see the Foo->int example), but the
TemplateTypeParmType WILL be skipped.