### PR TITLE
[SYCL][ROCm] Fix rocm_piPlatformsGet when there are no devices

### DIFF
--- a/sycl/plugins/rocm/pi_rocm.cpp
+++ b/sycl/plugins/rocm/pi_rocm.cpp
@@ -696,7 +696,12 @@ pi_result rocm_piPlatformsGet(pi_uint32 num_entries, pi_platform *platforms,
             return;
           }
           int numDevices = 0;
-          err = PI_CHECK_ERROR(hipGetDeviceCount(&numDevices));
+          hipError_t hipErrorCode = hipGetDeviceCount(&numDevices);
+          if (hipErrorCode == hipErrorNoDevice) {
+            numPlatforms = 0;
+            return;
+          }
+          err = PI_CHECK_ERROR(hipErrorCode);
           if (numDevices == 0) {
             numPlatforms = 0;
             return;


### PR DESCRIPTION
hipGetDeviceCount [returns the hipErrorNoDevice error](https://rocm-developer-tools.github.io/HIP/group__Device.html#ga8555d5c76d88c50ddbf54ae70b568394) when there are no
available devices. Instead of treating it as a PI error, we now properly
report that the platform is not available.

Before:

```
$ sycl-ls

PI HIP ERROR:
        Value:           100
        Name:            hipErrorNoDevice
        Description:     hipErrorNoDevice
        Function:        operator()
        Source Location: /nethome/aland/intel-sycl/llvm/sycl/plugins/rocm/pi_rocm.cpp:699

[opencl:0] GPU : Intel(R) OpenCL HD Graphics 3.0 [1.0.0]
[opencl:1] GPU : Intel(R) OpenCL HD Graphics 3.0 [1.0.0]
[level_zero:0] GPU : Intel(R) Level-Zero 1.1 [1.1.0]
[level_zero:1] GPU : Intel(R) Level-Zero 1.1 [1.1.0]
[host:0] HOST: SYCL host platform 1.2 [1.2]
```

After:

```
$ sycl-ls
[opencl:0] GPU : Intel(R) OpenCL HD Graphics 3.0 [1.0.0]
[opencl:1] GPU : Intel(R) OpenCL HD Graphics 3.0 [1.0.0]
[level_zero:0] GPU : Intel(R) Level-Zero 1.1 [1.1.0]
[level_zero:1] GPU : Intel(R) Level-Zero 1.1 [1.1.0]
[host:0] HOST: SYCL host platform 1.2 [1.2]
```