### PR TITLE
[SYCL] Fix error: too few template arguments for class template 'instance'

### DIFF
--- a/sycl/include/CL/sycl/properties/accessor_properties.hpp
+++ b/sycl/include/CL/sycl/properties/accessor_properties.hpp
@@ -48,7 +48,7 @@ namespace ext {
 namespace intel {
 namespace property {
 struct buffer_location {
-  template <int A> struct instance {
+  template <int A = 1> struct instance {
     template <int B>
     constexpr bool operator==(const buffer_location::instance<B> &) const {
       return A == B;

--- a/sycl/include/CL/sycl/properties/accessor_properties.hpp
+++ b/sycl/include/CL/sycl/properties/accessor_properties.hpp
@@ -48,7 +48,7 @@ namespace ext {
 namespace intel {
 namespace property {
 struct buffer_location {
-  template <int A = 1> struct instance {
+  template <int A = 0> struct instance {
     template <int B>
     constexpr bool operator==(const buffer_location::instance<B> &) const {
       return A == B;

--- a/sycl/test/regression/check_default_instance.cpp
+++ b/sycl/test/regression/check_default_instance.cpp
@@ -1,0 +1,12 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+
+#include <CL/sycl.hpp>
+
+int main() {
+  sycl::ext::oneapi::accessor_property_list PL{
+      sycl::ext::intel::buffer_location<1>};
+  static_assert(PL.has_property<sycl::ext::intel::property::buffer_location>(),
+                "instance dont work");
+  return 0;
+}

--- a/sycl/test/regression/check_default_instance.cpp
+++ b/sycl/test/regression/check_default_instance.cpp
@@ -7,6 +7,6 @@ int main() {
   sycl::ext::oneapi::accessor_property_list PL{
       sycl::ext::intel::buffer_location<1>};
   static_assert(PL.has_property<sycl::ext::intel::property::buffer_location>(),
-                "instance dont work");
+                "Property not found");
   return 0;
 }


### PR DESCRIPTION
Add default argument for class template 'instance' to prevent errors associated with the loss of the arguments at compile time.