### PR TITLE
[SYCL] Fix a -Wrange-loop-construct warning in #4296

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3870,7 +3870,7 @@ void Sema::SetSYCLKernelNames() {
       getASTContext().createMangleContext());
   // We assume the list of KernelDescs is the complete list of kernels needing
   // to be rewritten.
-  for (const std::pair<const FunctionDecl *, FunctionDecl *> Pair :
+  for (const std::pair<const FunctionDecl *, FunctionDecl *> &Pair :
        SyclKernelsToOpenCLKernels) {
     std::string CalculatedName, StableName;
     std::tie(CalculatedName, StableName) =


### PR DESCRIPTION
This warns for creating a copy of the pair (which I figured was cheap
enough to copy, but *shrug*), so this fails us on the Werror build.
Pass by reference instead.