### PR TITLE
[ESIMD] Fixed is_simd_view_v type trait

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
@@ -142,6 +142,9 @@ template <typename BaseTy, typename RegionTy>
 struct is_simd_view_type<detail::simd_view_impl<BaseTy, RegionTy>>
     : std::true_type {};
 
+template <typename BaseTy, typename RegionTy>
+struct is_simd_view_type<simd_view<BaseTy, RegionTy>> : std::true_type {};
+
 template <typename Ty>
 struct is_simd_view_v
     : std::integral_constant<bool,

--- a/sycl/test/esimd/esimd-util-compiler-eval.cpp
+++ b/sycl/test/esimd/esimd-util-compiler-eval.cpp
@@ -4,6 +4,7 @@
 #include "CL/sycl.hpp"
 #include "sycl/ext/intel/experimental/esimd.hpp"
 
+using namespace sycl::ext::intel::experimental::esimd;
 using namespace sycl::ext::intel::experimental::esimd::detail;
 
 static_assert(getNextPowerOf2<0>() == 0, "");
@@ -15,3 +16,11 @@ static_assert(log2<0>() == 0, "");
 static_assert(log2<1>() == 0, "");
 static_assert(log2<7>() == 2, "");
 static_assert(log2<1024 * 1024>() == 20, "");
+
+using BaseTy = simd<float, 4>;
+using RegionTy = region1d_t<float, 2, 1>;
+using RegionTy1 = region_base_1<false, float, 1, 1>;
+static_assert(is_simd_view_v<simd_view_impl<BaseTy, RegionTy>>::value, "");
+static_assert(is_simd_view_v<simd_view<BaseTy, RegionTy>>::value, "");
+static_assert(is_simd_view_v<simd_view<BaseTy, RegionTy1>>::value, "");
+static_assert(!is_simd_view_v<BaseTy>::value, "");


### PR DESCRIPTION
This fixes compile-time recognizing whether a type is a `simd_view` type. Previously it only returned `true` for the base class, i.e. `simd_view_impl`.