### PR TITLE
[SYCL] Fix PIMock initialization in unit tests

### DIFF
--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -148,8 +148,8 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
         // check that values of keys, which should have some fixed format, are
         // valid. E.g., for BackendName key, the allowed values are only ones
         // described in SyclBeMap
-        ValidateEnumValues(BackendNameKeyName, SyclBeMap);
-        ValidateEnumValues(DeviceTypeKeyName, SyclDeviceTypeMap);
+        ValidateEnumValues(BackendNameKeyName, getSyclBeMap());
+        ValidateEnumValues(DeviceTypeKeyName, getSyclDeviceTypeMap());
 
         if (Key == DeviceVendorIdKeyName) {
           // DeviceVendorId should have hex format
@@ -310,7 +310,7 @@ void applyAllowList(std::vector<RT::PiDevice> &PiDevices,
 
   // get BackendName value and put it to DeviceDesc
   sycl::backend Backend = Plugin.getBackend();
-  for (const auto &SyclBe : SyclBeMap) {
+  for (const auto &SyclBe : getSyclBeMap()) {
     if (SyclBe.second == Backend) {
       DeviceDesc.emplace(BackendNameKeyName, SyclBe.first);
       break;
@@ -336,7 +336,7 @@ void applyAllowList(std::vector<RT::PiDevice> &PiDevices,
                                             sizeof(RT::PiDeviceType),
                                             &PiDevType, nullptr);
     sycl::info::device_type DeviceType = pi::cast<info::device_type>(PiDevType);
-    for (const auto &SyclDeviceType : SyclDeviceTypeMap) {
+    for (const auto &SyclDeviceType : getSyclDeviceTypeMap()) {
       if (SyclDeviceType.second == DeviceType) {
         const auto &DeviceTypeValue = SyclDeviceType.first;
         DeviceDesc[DeviceTypeKeyName] = DeviceTypeValue;

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -111,6 +111,30 @@ void dumpConfig() {
 #undef CONFIG
 }
 
-} // __SYCL_INLINE_NAMESPACE(cl)
-} // namespace sycl
+// Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST
+const std::array<std::pair<std::string, info::device_type>, 5> &
+getSyclDeviceTypeMap() {
+  static const std::array<std::pair<std::string, info::device_type>, 5>
+      SyclDeviceTypeMap = {{{"host", info::device_type::host},
+                            {"cpu", info::device_type::cpu},
+                            {"gpu", info::device_type::gpu},
+                            {"acc", info::device_type::accelerator},
+                            {"*", info::device_type::all}}};
+  return SyclDeviceTypeMap;
+}
+
+// Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST
+const std::array<std::pair<std::string, backend>, 6> &getSyclBeMap() {
+  static const std::array<std::pair<std::string, backend>, 6> SyclBeMap = {
+      {{"host", backend::host},
+       {"opencl", backend::opencl},
+       {"level_zero", backend::level_zero},
+       {"cuda", backend::cuda},
+       {"rocm", backend::rocm},
+       {"*", backend::all}}};
+  return SyclBeMap;
+}
+
 } // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -177,21 +177,11 @@ public:
 };
 
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST
-static const std::array<std::pair<std::string, info::device_type>, 5>
-    SyclDeviceTypeMap = {{{"host", info::device_type::host},
-                          {"cpu", info::device_type::cpu},
-                          {"gpu", info::device_type::gpu},
-                          {"acc", info::device_type::accelerator},
-                          {"*", info::device_type::all}}};
+const std::array<std::pair<std::string, info::device_type>, 5> &
+getSyclDeviceTypeMap();
 
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST
-static const std::array<std::pair<std::string, backend>, 6> SyclBeMap = {
-    {{"host", backend::host},
-     {"opencl", backend::opencl},
-     {"level_zero", backend::level_zero},
-     {"cuda", backend::cuda},
-     {"rocm", backend::rocm},
-     {"*", backend::all}}};
+const std::array<std::pair<std::string, backend>, 6> &getSyclBeMap();
 
 template <> class SYCLConfig<SYCL_DEVICE_FILTER> {
   using BaseT = SYCLConfigBase<SYCL_DEVICE_FILTER>;

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -30,11 +30,11 @@ device_filter::device_filter(const std::string &FilterString) {
 
   // Handle the optional 1st field of the filter, backend
   // Check if the first entry matches with a known backend type
-  auto It =
-      std::find_if(std::begin(SyclBeMap), std::end(SyclBeMap), findElement);
+  auto It = std::find_if(std::begin(getSyclBeMap()), std::end(getSyclBeMap()),
+                         findElement);
   // If no match is found, set the backend type backend::all
   // which actually means 'any backend' will be a match.
-  if (It == SyclBeMap.end())
+  if (It == getSyclBeMap().end())
     Backend = backend::all;
   else {
     Backend = It->second;
@@ -49,11 +49,11 @@ device_filter::device_filter(const std::string &FilterString) {
   if (Cursor >= FilterString.size()) {
     DeviceType = info::device_type::all;
   } else {
-    auto Iter = std::find_if(std::begin(SyclDeviceTypeMap),
-                             std::end(SyclDeviceTypeMap), findElement);
+    auto Iter = std::find_if(std::begin(getSyclDeviceTypeMap()),
+                             std::end(getSyclDeviceTypeMap()), findElement);
     // If no match is found, set device_type 'all',
     // which actually means 'any device_type' will be a match.
-    if (Iter == SyclDeviceTypeMap.end())
+    if (Iter == getSyclDeviceTypeMap().end())
       DeviceType = info::device_type::all;
     else {
       DeviceType = Iter->second;

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <detail/allowlist.hpp>
-#include <detail/config.hpp> // for SyclBeMap and SyclDeviceTypeMap
+#include <detail/config.hpp> // for getSyclBeMap() and getSyclDeviceTypeMap()
 
 #include <gtest/gtest.h>
 
@@ -157,7 +157,7 @@ TEST(ParseAllowListTests, CheckMissingClosedDoubleCurlyBracesAreHandled) {
 
 TEST(ParseAllowListTests, CheckAllValidBackendNameValuesAreProcessed) {
   std::string AllowList;
-  for (const auto &SyclBe : sycl::detail::SyclBeMap) {
+  for (const auto &SyclBe : sycl::detail::getSyclBeMap()) {
     if (!AllowList.empty())
       AllowList += "|";
     AllowList += "BackendName:" + SyclBe.first;
@@ -173,7 +173,7 @@ TEST(ParseAllowListTests, CheckAllValidBackendNameValuesAreProcessed) {
 
 TEST(ParseAllowListTests, CheckAllValidDeviceTypeValuesAreProcessed) {
   std::string AllowList;
-  for (const auto &SyclDeviceType : sycl::detail::SyclDeviceTypeMap) {
+  for (const auto &SyclDeviceType : sycl::detail::getSyclDeviceTypeMap()) {
     if (!AllowList.empty())
       AllowList += "|";
     AllowList += "DeviceType:" + SyclDeviceType.first;

--- a/sycl/unittests/pi/EnqueueMemTest.cpp
+++ b/sycl/unittests/pi/EnqueueMemTest.cpp
@@ -105,10 +105,9 @@ protected:
   }
 };
 
-static std::vector<detail::plugin> Plugins = pi::initializeAndRemoveInvalid();
-
 INSTANTIATE_TEST_CASE_P(
-    EnqueueMemTestImpl, EnqueueMemTest, testing::ValuesIn(Plugins),
+    EnqueueMemTestImpl, EnqueueMemTest,
+    testing::ValuesIn(pi::initializeAndRemoveInvalid()),
     [](const testing::TestParamInfo<EnqueueMemTest::ParamType> &info) {
       return pi::GetBackendString(info.param.getBackend());
     });

--- a/sycl/unittests/pi/PlatformTest.cpp
+++ b/sycl/unittests/pi/PlatformTest.cpp
@@ -62,10 +62,9 @@ protected:
   }
 };
 
-static std::vector<detail::plugin> Plugins = pi::initializeAndRemoveInvalid();
-
 INSTANTIATE_TEST_CASE_P(
-    PlatformTestImpl, PlatformTest, testing::ValuesIn(Plugins),
+    PlatformTestImpl, PlatformTest,
+    testing::ValuesIn(pi::initializeAndRemoveInvalid()),
     [](const testing::TestParamInfo<PlatformTest::ParamType> &info) {
       return pi::GetBackendString(info.param.getBackend());
     });


### PR DESCRIPTION
The problem comes from global initialization which is dependent on
another global which happens to be not initialized yet in this case
(the order is non-deterministic by standard).

Global variables causing the issue are moved to static locals in free
functions. That allows to avoid initialization races on usages.