### PR TITLE
[SYCL][Doc] Modernize LocalMemory extension

### DIFF
--- a/sycl/doc/extensions/LocalMemory/LocalMemory.asciidoc
+++ b/sycl/doc/extensions/LocalMemory/LocalMemory.asciidoc
@@ -1,4 +1,4 @@
-= SYCL_INTEL_local_memory
+= SYCL_EXT_ONEAPI_LOCAL_MEMORY
 
 :source-highlighter: coderay
 :coderay-linenums-mode: table
@@ -33,13 +33,9 @@ GitHub does not render image icons.
 This document describes an extension enabling the declaration of local memory
 objects at the kernel functor scope.
 
-== Name Strings
-
-+SYCL_INTEL_local_memory+
-
 == Notice
 
-Copyright (c) 2020 Intel Corporation.  All rights reserved.
+Copyright (c) 2021 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -60,17 +56,33 @@ Revision: 1
 
 == Contact
 
-John Pennycook, Intel (john 'dot' pennycook 'at' intel 'dot' com)
-Roland Schulz, Intel (roland 'dot' schulz 'at' intel 'dot' com)
+John Pennycook, Intel (john 'dot' pennycook 'at' intel 'dot' com) +
+Roland Schulz, Intel (roland 'dot' schulz 'at' intel 'dot' com) +
 
 == Contributors
 
-Felipe de Azevedo Piovezan, Intel
-Michael Kinsner, Intel
+Felipe de Azevedo Piovezan, Intel +
+Michael Kinsner, Intel +
 
 == Dependencies
 
-This extension is written against the SYCL 1.2.1 specification, revision 6.
+This extension is written against the SYCL 2020 specification, Revision 3.
+
+== Feature Test Macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification section 6.3.3 "Feature test macros".  Therefore, an
+implementation supporting this extension must predefine the macro
+`SYCL_EXT_ONEAPI_LOCAL_MEMORY` to one of the values defined in the table below.
+Applications can test for the existence of this macro to determine if the
+implementation supports this feature, or applications can test the macro's
+value to determine which of the extension's APIs the implementation supports.
+
+[%header,cols="1,5"]
+|===
+|Value |Description
+|1     |Initial extension version.  Base features are supported.
+|===
 
 == Overview
 
@@ -103,59 +115,24 @@ This extension introduces a concept of group-local memory, with semantics
 similar to OpenCL kernel-scope `local` variables and C++ `thread_local`
 variables.
 
-== Modifications of SYCL 1.2.1 Specification
+== Allocating Local Memory
 
-=== Modify sentence in Section 3.5.2.1 Access to memory
+The `sycl::ext::oneapi::group_local_memory` and
+`sycl::ext::oneapi::group_local_memory_for_overwrite` functions can be used to
+allocate group-local memory at the kernel functor scope of a work-group data
+parallel kernel.
 
-==== From:
+NOTE: The restriction that group-local variables must be defined at kernel
+functor scope may be lifted in a future version of this extension.
 
-To allocate local memory within a kernel, the user can either pass a
-`cl::sycl::local_accessor` object to the kernel as a parameter, or can define a
-variable in work-group scope inside `cl::sycl::parallel_for_work_group`.
-
-==== To:
-
-To allocate local memory within a kernel, the user can:
-
-* Pass a `cl::sycl::local_accessor` object to the kernel as a parameter.
-* Define a variable in work-group scope inside `cl::sycl::parallel_for_work_group`.
-* Define a group-local variable at the kernel functor scope of a work-group
-data parallel kernel using the `group_local_memory` or
-`group_local_memory_for_overwrite` functions.
-
-[_Note_ - The restriction that group-local variables must be defined at kernel
-functor scope may be lifted in a future version of this extension.]
-
-==== Extend Section 4.8.5.2
-
-==== Include paragraphs:
-
-The `nd_range` variant of `parallel_for` also enables the declaration of
-group-local variables; those variables are allocated in the an address space
-accessible by all work-items in the group and are shared by all work-items of a
-work-group.
-
-[source,c++]
-----
-myQueue.submit([&](handler &cgh) {
-  cgh.parallel_for<class example_kernel>(
-      nd_range<1>(range<1>(128), range<1>(32)), [=](nd_item<1> item) {
-        multi_ptr<int[64], access::address_space::local_space> ptr = group_local_memory<int[64]>(item.get_group());
-        auto& ref = *ptr;
-        ref[2 * item.get_local_linear_id()] = 42;
-      });
-});
-----
-
-The example above creates a kernel with four work-groups, each containing 32
-work-items. An `int[64]` object is defined as a group-local variable, and
-each work-item in the work-group obtains a `multi_ptr` to the same variable.
-
-There are two interfaces for defining group-local variables:
+Group-local memory is allocated in an address space accessible by all
+work-items in the group, and is shared by all work-items of the group.
 
 [source,c++]
 ----
 namespace sycl {
+namespace ext {
+namespace oneapi {
 
 template <typename T, typename Group, typename... Args>
 multi_ptr<T, Group::address_space> group_local_memory(Group g, Args&&... args);
@@ -163,10 +140,10 @@ multi_ptr<T, Group::address_space> group_local_memory(Group g, Args&&... args);
 template <typename T, typename Group>
 multi_ptr<T, Group::address_space> group_local_memory_for_overwrite(Group g);
 
+} // namespace oneapi
+} // namespace ext
 } // namespace sycl
 ----
-
-==== Add table: Functions for defining group-local variables
 
 [frame="topbot",options="header,footer"]
 |======================
@@ -184,25 +161,42 @@ the group have completed execution of the kernel.
 All arguments in _args_ must be the same for all work-items in the group.
 
 `Group` must be `sycl::group`, and `T` must be trivially destructible.
-[_Note_ - These restrictions may be lifted in a future version of this
-extension.]
 
 |`template <typename T, typename Group>
  multi_ptr<T, Group::address_space> group_local_memory_for_overwrite(Group g)` |
 Constructs an object of type `T` in an address space accessible by all
 work-items in group _g_, using default initialization.  The object is
-initialized pon or before the first call to `group_local_memory`.  The storage
+initialized upon or before the first call to `group_local_memory`.  The storage
 for the object is allocated upon or before the first call to
 `group_local_memory`, and deallocated when all work-items in the group have
 completed execution of the kernel.
 
-All arguments in _args_ must be the same for all work-items in the group.
-
 `Group` must be `sycl::group`, and `T` must be trivially destructible.
-[_Note_ - These restrictions may be lifted in a future version of this
-extension.]
 
 |======================
+
+NOTE: The restrictions on supported types for `Group` and `T` may be lifted
+in a future version of this extension.
+
+== Example Usage
+
+This non-normative section shows some example usages of the extension.
+
+[source,c++]
+----
+myQueue.submit([&](handler &h) {
+  h.parallel_for(
+    nd_range<1>(range<1>(128), range<1>(32)), [=](nd_item<1> item) {
+      multi_ptr<int[64], access::address_space::local_space> ptr = group_local_memory<int[64]>(item.get_group());
+      auto& ref = *ptr;
+      ref[2 * item.get_local_linear_id()] = 42;
+    });
+});
+----
+
+The example above creates a kernel with four work-groups, each containing 32
+work-items. An `int[64]` object is defined in group-local memory, and
+each work-item in the work-group obtains a `multi_ptr` to the same allocation.
 
 == Issues
 
@@ -215,7 +209,7 @@ None.
 [options="header"]
 |========================================
 |Rev|Date|Author|Changes
-|1|2020-08-18|John Pennycook|*Initial public working draft*
+|1|2021-08-12|John Pennycook|*Initial public working draft*
 |========================================
 
 //************************************************************************

--- a/sycl/doc/extensions/LocalMemory/LocalMemory.asciidoc
+++ b/sycl/doc/extensions/LocalMemory/LocalMemory.asciidoc
@@ -149,6 +149,7 @@ multi_ptr<T, Group::address_space> group_local_memory_for_overwrite(Group g);
  multi_ptr<T, Group::address_space> group_local_memory(Group g, Args&&... args)` |
 Constructs an object of type `T` in an address space accessible by all
 work-items in group _g_, forwarding _args_ to the constructor's parameter list.
+If _args_ is empty, the object is value initialized.
 The constructor is called once per group, upon or before the first call to
 `group_local_memory`.  The storage for the object is allocated upon or before
 the first call to `group_local_memory`, and deallocated when all work-items in

--- a/sycl/doc/extensions/LocalMemory/LocalMemory.asciidoc
+++ b/sycl/doc/extensions/LocalMemory/LocalMemory.asciidoc
@@ -27,9 +27,6 @@ NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are
 trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc.
 used by permission by Khronos.
 
-NOTE: This document is better viewed when rendered as html with asciidoctor.
-GitHub does not render image icons.
-
 This document describes an extension enabling the declaration of local memory
 objects at the kernel functor scope.
 
@@ -51,7 +48,6 @@ products.
 
 == Version
 
-Built On: {docdate} +
 Revision: 1
 
 == Contact

--- a/sycl/doc/extensions/LocalMemory/README.md
+++ b/sycl/doc/extensions/LocalMemory/README.md
@@ -1,3 +1,0 @@
-# SYCL_INTEL_local_memory
-
-A free function enabling the declaration of local memory objects at kernel function scope.

--- a/sycl/doc/extensions/README.md
+++ b/sycl/doc/extensions/README.md
@@ -27,7 +27,7 @@ DPC++ extensions status:
 | [SYCL_INTEL_reqd_work_group_size](ReqdWorkGroupSize/SYCL_INTEL_reqd_work_group_size.asciidoc)                               | Supported(OpenCL: CPU, GPU)               | |
 | [SPV_INTEL_function_pointers](SPIRV/SPV_INTEL_function_pointers.asciidoc)                                                   | Supported(OpenCL: CPU, GPU; HOST)         | |
 | [SPV_INTEL_inline_assembly](SPIRV/SPV_INTEL_inline_assembly.asciidoc)                                                       | Supported(OpenCL: GPU)                    | |
-| [SYCL_INTEL_local_memory](LocalMemory/SYCL_INTEL_local_memory.asciidoc)                                                     | Proposal                                  | |
+| [SYCL_INTEL_local_memory](LocalMemory/LocalMemory.asciidoc)                                                                 | Proposal                                  | |
 | [SYCL_INTEL_static_local_memory_query](StaticLocalMemoryQuery/SYCL_INTEL_static_local_memory_query.asciidoc)                | Proposal                                  | |
 | [SYCL_INTEL_sub_group_algorithms](SubGroupAlgorithms/SYCL_INTEL_sub_group_algorithms.asciidoc)                              | Partially supported(OpenCL: CPU, GPU)     | Features from SYCL_INTEL_group_algorithms extended to sub-groups |
 | [Sub-groups for NDRange Parallelism](SubGroupNDRange/SubGroupNDRange.md)                                                    | Deprecated(OpenCL: CPU, GPU)              | |

--- a/sycl/doc/extensions/README.md
+++ b/sycl/doc/extensions/README.md
@@ -27,7 +27,7 @@ DPC++ extensions status:
 | [SYCL_INTEL_reqd_work_group_size](ReqdWorkGroupSize/SYCL_INTEL_reqd_work_group_size.asciidoc)                               | Supported(OpenCL: CPU, GPU)               | |
 | [SPV_INTEL_function_pointers](SPIRV/SPV_INTEL_function_pointers.asciidoc)                                                   | Supported(OpenCL: CPU, GPU; HOST)         | |
 | [SPV_INTEL_inline_assembly](SPIRV/SPV_INTEL_inline_assembly.asciidoc)                                                       | Supported(OpenCL: GPU)                    | |
-| [SYCL_INTEL_local_memory](LocalMemory/LocalMemory.asciidoc)                                                                 | Proposal                                  | |
+| [LocalMemory](LocalMemory/LocalMemory.asciidoc)                                                                             | Proposal                                  | |
 | [SYCL_INTEL_static_local_memory_query](StaticLocalMemoryQuery/SYCL_INTEL_static_local_memory_query.asciidoc)                | Proposal                                  | |
 | [SYCL_INTEL_sub_group_algorithms](SubGroupAlgorithms/SYCL_INTEL_sub_group_algorithms.asciidoc)                              | Partially supported(OpenCL: CPU, GPU)     | Features from SYCL_INTEL_group_algorithms extended to sub-groups |
 | [Sub-groups for NDRange Parallelism](SubGroupNDRange/SubGroupNDRange.md)                                                    | Deprecated(OpenCL: CPU, GPU)              | |


### PR DESCRIPTION
Brings LocalMemory extension in line with other extensions:
- Written against SYCL 2020
- Feature test macro
- sycl::ext::oneapi namespace

This commit replaces the old SYCL 1.2.1 extension completely
in favor of a SYCL 2020 extension, because the SYCL 1.2.1 extension
has not yet been marked implemented.

Signed-off-by: John Pennycook <john.pennycook@intel.com>