### PR TITLE
[SYCL][XPTI] Finalize XPTI streams

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -26,14 +26,6 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
-// We define a sycl stream name and this will be used by the instrumentation
-// framework
-constexpr const char *SYCL_STREAM_NAME = "sycl";
-// Stream name being used for traces generated from the SYCL plugin layer
-constexpr const char *SYCL_PICALL_STREAM_NAME = "sycl.pi";
-// Stream name being used for traces generated from PI calls. This stream
-// contains information about function arguments.
-constexpr const char *SYCL_PIDEBUGCALL_STREAM_NAME = "sycl.pi.debug";
 // Data structure that captures the user code location information using the
 // builtin capabilities of the compiler
 struct code_location {

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -20,6 +20,7 @@
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 #include "xpti_trace_framework.hpp"
 #include <atomic>
+#include <detail/xpti_registry.hpp>
 #include <sstream>
 #endif
 

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -14,6 +14,7 @@
 #include <detail/plugin.hpp>
 #include <detail/program_manager/program_manager.hpp>
 #include <detail/scheduler/scheduler.hpp>
+#include <detail/xpti_registry.hpp>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -69,6 +70,10 @@ std::vector<plugin> &GlobalHandler::getPlugins() {
 device_filter_list &
 GlobalHandler::getDeviceFilterList(const std::string &InitValue) {
   return getOrCreate(MDeviceFilterList, InitValue);
+}
+
+XPTIRegistry &GlobalHandler::getXPTIRegistry() {
+  return getOrCreate(MXPTIRegistry);
 }
 
 std::mutex &GlobalHandler::getHandlerExtendedMembersMutex() {

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -22,6 +22,7 @@ class ProgramManager;
 class Sync;
 class plugin;
 class device_filter_list;
+class XPTIRegistry;
 
 using PlatformImplPtr = std::shared_ptr<platform_impl>;
 
@@ -56,6 +57,7 @@ public:
   std::mutex &getFilterMutex();
   std::vector<plugin> &getPlugins();
   device_filter_list &getDeviceFilterList(const std::string &InitValue);
+  XPTIRegistry &getXPTIRegistry();
   std::mutex &getHandlerExtendedMembersMutex();
 
 private:
@@ -82,6 +84,7 @@ private:
   InstWithLock<std::mutex> MFilterMutex;
   InstWithLock<std::vector<plugin>> MPlugins;
   InstWithLock<device_filter_list> MDeviceFilterList;
+  InstWithLock<XPTIRegistry> MXPTIRegistry;
   // The mutex for synchronizing accesses to handlers extended members
   InstWithLock<std::mutex> MHandlerExtendedMembersMutex;
 };

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -21,6 +21,7 @@
 #include <detail/config.hpp>
 #include <detail/global_handler.hpp>
 #include <detail/plugin.hpp>
+#include <detail/xpti_registry.hpp>
 
 #include <bitset>
 #include <cstdarg>
@@ -461,12 +462,8 @@ static void initializePlugins(std::vector<plugin> *Plugins) {
   uint8_t StreamID = xptiRegisterStream(SYCL_STREAM_NAME);
   //  Let all tool plugins know that a stream by the name of 'sycl' has been
   //  initialized and will be generating the trace stream.
-  //
-  //                                           +--- Minor version #
-  //            Major version # ------+        |   Version string
-  //                                  |        |       |
-  //                                  v        v       v
-  xptiInitialize(SYCL_STREAM_NAME, GMajVer, GMinVer, GVerStr);
+  GlobalHandler::instance().getXPTIRegistry().initializeStream(
+      SYCL_STREAM_NAME, GMajVer, GMinVer, GVerStr);
   // Create a tracepoint to indicate the graph creation
   xpti::payload_t GraphPayload("application_graph");
   uint64_t GraphInstanceNo;
@@ -481,14 +478,16 @@ static void initializePlugins(std::vector<plugin> *Plugins) {
   }
 
   // Let subscribers know a new stream is being initialized
-  xptiInitialize(SYCL_PICALL_STREAM_NAME, GMajVer, GMinVer, GVerStr);
+  GlobalHandler::instance().getXPTIRegistry().initializeStream(
+      SYCL_PICALL_STREAM_NAME, GMajVer, GMinVer, GVerStr);
   xpti::payload_t PIPayload("Plugin Interface Layer");
   uint64_t PiInstanceNo;
   GPICallEvent =
       xptiMakeEvent("PI Layer", &PIPayload, xpti::trace_algorithm_event,
                     xpti_at::active, &PiInstanceNo);
 
-  xptiInitialize(SYCL_PIDEBUGCALL_STREAM_NAME, GMajVer, GMinVer, GVerStr);
+  GlobalHandler::instance().getXPTIRegistry().initializeStream(
+      SYCL_PIDEBUGCALL_STREAM_NAME, GMajVer, GMinVer, GVerStr);
   xpti::payload_t PIArgPayload(
       "Plugin Interface Layer (with function arguments)");
   uint64_t PiArgInstanceNo;

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -18,6 +18,7 @@
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 #include "xpti_trace_framework.hpp"
+#include <detail/xpti_registry.hpp>
 #include <sstream>
 #endif
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -44,6 +44,7 @@
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 #include "xpti_trace_framework.hpp"
+#include <detail/xpti_registry.hpp>
 #endif
 
 __SYCL_INLINE_NAMESPACE(cl) {

--- a/sycl/source/detail/xpti_registry.hpp
+++ b/sycl/source/detail/xpti_registry.hpp
@@ -46,9 +46,11 @@ public:
   }
 
   ~XPTIRegistry() {
+#ifdef XPTI_ENABLE_INSTRUMENTATION
     for (const auto &StreamName : MActiveStreams) {
       xptiFinalize(StreamName.c_str());
     }
+#endif // XPTI_ENABLE_INSTRUMENTATION
   }
 
 private:

--- a/sycl/source/detail/xpti_registry.hpp
+++ b/sycl/source/detail/xpti_registry.hpp
@@ -1,0 +1,59 @@
+//==---------- xpti_registry.hpp ----- XPTI Stream Registry ----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+#ifdef XPTI_ENABLE_INSTRUMENTATION
+// Include the headers necessary for emitting
+// traces using the trace framework
+#include "xpti_trace_framework.h"
+#endif
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace detail {
+// We define a sycl stream name and this will be used by the instrumentation
+// framework
+inline constexpr const char *SYCL_STREAM_NAME = "sycl";
+// Stream name being used for traces generated from the SYCL plugin layer
+inline constexpr const char *SYCL_PICALL_STREAM_NAME = "sycl.pi";
+// Stream name being used for traces generated from PI calls. This stream
+// contains information about function arguments.
+inline constexpr const char *SYCL_PIDEBUGCALL_STREAM_NAME = "sycl.pi.debug";
+
+class XPTIRegistry {
+public:
+  /// Notifies XPTI subscribers about new stream.
+  ///
+  /// \param StreamName is a name of newly initialized stream.
+  /// \param MajVer is a stream major version.
+  /// \param MinVer is a stream minor version.
+  /// \param VerStr is a string of "MajVer.MinVer" format.
+  void initializeStream(const std::string &StreamName, uint32_t MajVer,
+                        uint32_t MinVer, const std::string &VerStr) {
+#ifdef XPTI_ENABLE_INSTRUMENTATION
+    MActiveStreams.insert(StreamName);
+    xptiInitialize(StreamName.c_str(), MajVer, MinVer, VerStr.c_str());
+#endif // XPTI_ENABLE_INSTRUMENTATION
+  }
+
+  ~XPTIRegistry() {
+    for (const auto &StreamName : MActiveStreams) {
+      xptiFinalize(StreamName.c_str());
+    }
+  }
+
+private:
+  std::unordered_set<std::string> MActiveStreams;
+};
+} // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)


### PR DESCRIPTION
SYCL Runtime must call xptiFinalize for every stream it reports.
To ensure that finalize is called, add a notion of XPTIRegistry,
that collects active stream names, and invokes xptiFinalize upon
SYCL Runtime shutdown.