### PR TITLE
[ESIMD] Applied CRTP to simd_view_impl class

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
@@ -295,6 +295,9 @@ public:
 
 #undef DEF_UNARY_OP
 
+  // negation operator
+  auto operator!() { return *this == 0; }
+
   // Operator ++, --
   Derived &operator++() {
     *this += 1;

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
@@ -25,9 +25,10 @@ namespace detail {
 /// It is an internal class implementing basic functionality of simd_view.
 ///
 /// \ingroup sycl_esimd
-template <typename BaseTy, typename RegionTy> class simd_view_impl {
+template <typename BaseTy, typename RegionTy, typename Derived>
+class simd_view_impl {
   template <typename, int> friend class simd;
-  template <typename, typename> friend class simd_view_impl;
+  template <typename, typename, typename> friend class simd_view_impl;
 
 public:
   static_assert(!detail::is_simd_view_v<BaseTy>::value);
@@ -51,6 +52,9 @@ public:
 
   /// @{
   /// Constructors.
+
+private:
+  Derived &cast_this_to_derived() { return reinterpret_cast<Derived &>(*this); }
 
 protected:
   simd_view_impl(BaseTy &Base, RegionTy Region)
@@ -109,9 +113,9 @@ public:
   }
 
   /// Write to this object.
-  simd_view_impl &write(const value_type &Val) {
+  Derived &write(const value_type &Val) {
     M_base.writeRegion(M_region, Val.data());
-    return *this;
+    return cast_this_to_derived();
   }
 
   /// @{
@@ -129,9 +133,9 @@ public:
 
   /// View this object in a different element type.
   template <typename EltTy> auto bit_cast_view() {
-    using TopRegionTy = detail::compute_format_type_t<simd_view_impl, EltTy>;
+    using TopRegionTy = detail::compute_format_type_t<Derived, EltTy>;
     using NewRegionTy = std::pair<TopRegionTy, RegionTy>;
-    using RetTy = simd_view_impl<BaseTy, NewRegionTy>;
+    using RetTy = simd_view<BaseTy, NewRegionTy>;
     TopRegionTy TopReg(0);
     return RetTy{this->M_base, std::make_pair(TopReg, M_region)};
   }
@@ -145,9 +149,9 @@ public:
   /// View as a 2-dimensional simd_view.
   template <typename EltTy, int Height, int Width> auto bit_cast_view() {
     using TopRegionTy =
-        detail::compute_format_type_2d_t<simd_view_impl, EltTy, Height, Width>;
+        detail::compute_format_type_2d_t<Derived, EltTy, Height, Width>;
     using NewRegionTy = std::pair<TopRegionTy, RegionTy>;
-    using RetTy = simd_view_impl<BaseTy, NewRegionTy>;
+    using RetTy = simd_view<BaseTy, NewRegionTy>;
     TopRegionTy TopReg(0, 0);
     return RetTy{this->M_base, std::make_pair(TopReg, M_region)};
   }
@@ -164,12 +168,12 @@ public:
   /// \tparam Stride is the element distance between two consecutive elements.
   /// \param Offset is the starting element offset.
   /// \return the representing region object.
-  template <int Size, int Stride, typename T = simd_view_impl,
+  template <int Size, int Stride, typename T = Derived,
             typename = sycl::detail::enable_if_t<T::is1D()>>
   auto select(uint16_t Offset = 0) {
     using TopRegionTy = region1d_t<element_type, Size, Stride>;
     using NewRegionTy = std::pair<TopRegionTy, RegionTy>;
-    using RetTy = simd_view_impl<BaseTy, NewRegionTy>;
+    using RetTy = simd_view<BaseTy, NewRegionTy>;
     TopRegionTy TopReg(Offset);
     return RetTy{this->M_base, std::make_pair(TopReg, M_region)};
   }
@@ -186,21 +190,20 @@ public:
   /// \param OffsetY is the starting element offset in Y-dimension.
   /// \return the representing region object.
   template <int SizeY, int StrideY, int SizeX, int StrideX,
-            typename T = simd_view_impl,
+            typename T = Derived,
             typename = sycl::detail::enable_if_t<T::is2D()>>
   auto select(uint16_t OffsetY = 0, uint16_t OffsetX = 0) {
     using TopRegionTy =
         region2d_t<element_type, SizeY, StrideY, SizeX, StrideX>;
     using NewRegionTy = std::pair<TopRegionTy, RegionTy>;
-    using RetTy = simd_view_impl<BaseTy, NewRegionTy>;
+    using RetTy = simd_view<BaseTy, NewRegionTy>;
     TopRegionTy TopReg(OffsetY, OffsetX);
     return RetTy{this->M_base, std::make_pair(TopReg, M_region)};
   }
 
 #define DEF_BINOP(BINOP, OPASSIGN)                                             \
-  template <class T1 = simd_view_impl,                                         \
-            class = std::enable_if_t<T1::length != 1>>                         \
-  ESIMD_INLINE friend auto operator BINOP(const simd_view_impl &X,             \
+  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
+  ESIMD_INLINE friend auto operator BINOP(const Derived &X,                    \
                                           const value_type &Y) {               \
     using ComputeTy = detail::compute_type_t<value_type>;                      \
     auto V0 =                                                                  \
@@ -209,10 +212,9 @@ public:
     auto V2 = V0 BINOP V1;                                                     \
     return ComputeTy(V2);                                                      \
   }                                                                            \
-  template <class T1 = simd_view_impl,                                         \
-            class = std::enable_if_t<T1::length != 1>>                         \
+  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
   ESIMD_INLINE friend auto operator BINOP(const value_type &X,                 \
-                                          const simd_view_impl &Y) {           \
+                                          const Derived &Y) {                  \
     using ComputeTy = detail::compute_type_t<value_type>;                      \
     auto V0 = detail::convert<typename ComputeTy::vector_type>(X.data());      \
     auto V1 =                                                                  \
@@ -220,20 +222,20 @@ public:
     auto V2 = V0 BINOP V1;                                                     \
     return ComputeTy(V2);                                                      \
   }                                                                            \
-  ESIMD_INLINE friend auto operator BINOP(const simd_view_impl &X,             \
-                                          const simd_view_impl &Y) {           \
+  ESIMD_INLINE friend auto operator BINOP(const Derived &X,                    \
+                                          const Derived &Y) {                  \
     return (X BINOP Y.read());                                                 \
   }                                                                            \
-  simd_view_impl &operator OPASSIGN(const value_type &RHS) {                   \
+  Derived &operator OPASSIGN(const value_type &RHS) {                          \
     using ComputeTy = detail::compute_type_t<value_type>;                      \
     auto V0 = detail::convert<typename ComputeTy::vector_type>(read().data()); \
     auto V1 = detail::convert<typename ComputeTy::vector_type>(RHS.data());    \
     auto V2 = V0 BINOP V1;                                                     \
     auto V3 = detail::convert<vector_type>(V2);                                \
     write(V3);                                                                 \
-    return *this;                                                              \
+    return cast_this_to_derived();                                             \
   }                                                                            \
-  simd_view_impl &operator OPASSIGN(const simd_view_impl &RHS) {               \
+  Derived &operator OPASSIGN(const Derived &RHS) {                             \
     return (*this OPASSIGN RHS.read());                                        \
   }
 
@@ -246,34 +248,32 @@ public:
 #undef DEF_BINOP
 
 #define DEF_BITWISE_OP(BITWISE_OP, OPASSIGN)                                   \
-  template <class T1 = simd_view_impl,                                         \
-            class = std::enable_if_t<T1::length != 1>>                         \
-  ESIMD_INLINE friend auto operator BITWISE_OP(const simd_view_impl &X,        \
+  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
+  ESIMD_INLINE friend auto operator BITWISE_OP(const Derived &X,               \
                                                const value_type &Y) {          \
     static_assert(std::is_integral<element_type>(), "not integral type");      \
     auto V2 = X.read().data() BITWISE_OP Y.data();                             \
     return simd<element_type, length>(V2);                                     \
   }                                                                            \
-  template <class T1 = simd_view_impl,                                         \
-            class = std::enable_if_t<T1::length != 1>>                         \
+  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
   ESIMD_INLINE friend auto operator BITWISE_OP(const value_type &X,            \
-                                               const simd_view_impl &Y) {      \
+                                               const Derived &Y) {             \
     static_assert(std::is_integral<element_type>(), "not integral type");      \
     auto V2 = X.data() BITWISE_OP Y.read().data();                             \
     return simd<element_type, length>(V2);                                     \
   }                                                                            \
-  ESIMD_INLINE friend auto operator BITWISE_OP(const simd_view_impl &X,        \
-                                               const simd_view_impl &Y) {      \
+  ESIMD_INLINE friend auto operator BITWISE_OP(const Derived &X,               \
+                                               const Derived &Y) {             \
     return (X BITWISE_OP Y.read());                                            \
   }                                                                            \
-  simd_view_impl &operator OPASSIGN(const value_type &RHS) {                   \
+  Derived &operator OPASSIGN(const value_type &RHS) {                          \
     static_assert(std::is_integral<element_type>(), "not integeral type");     \
     auto V2 = read().data() BITWISE_OP RHS.data();                             \
     auto V3 = detail::convert<vector_type>(V2);                                \
     write(V3);                                                                 \
-    return *this;                                                              \
+    return cast_this_to_derived();                                             \
   }                                                                            \
-  simd_view_impl &operator OPASSIGN(const simd_view_impl &RHS) {               \
+  Derived &operator OPASSIGN(const Derived &RHS) {                             \
     return (*this OPASSIGN RHS.read());                                        \
   }
   DEF_BITWISE_OP(&, &=)
@@ -296,18 +296,18 @@ public:
 #undef DEF_UNARY_OP
 
   // Operator ++, --
-  simd_view_impl &operator++() {
+  Derived &operator++() {
     *this += 1;
-    return *this;
+    return cast_this_to_derived();
   }
   value_type operator++(int) {
     value_type Ret(read());
     operator++();
     return Ret;
   }
-  simd_view_impl &operator--() {
+  Derived &operator--() {
     *this -= 1;
-    return *this;
+    return cast_this_to_derived();
   }
   value_type operator--(int) {
     value_type Ret(read());
@@ -317,7 +317,7 @@ public:
 
   /// Reference a row from a 2D region.
   /// \return a 1D region.
-  template <typename T = simd_view_impl,
+  template <typename T = Derived,
             typename = sycl::detail::enable_if_t<T::is2D()>>
   auto row(int i) {
     return select<1, 0, getSizeX(), 1>(i, 0)
@@ -326,14 +326,14 @@ public:
 
   /// Reference a column from a 2D region.
   /// \return a 2D region.
-  template <typename T = simd_view_impl,
+  template <typename T = Derived,
             typename = sycl::detail::enable_if_t<T::is2D()>>
   auto column(int i) {
     return select<getSizeY(), 1, 1, 0>(0, i);
   }
 
   /// Read a single element from a 1D region, by value only.
-  template <typename T = simd_view_impl,
+  template <typename T = Derived,
             typename = sycl::detail::enable_if_t<T::is1D()>>
   element_type operator[](int i) const {
     const auto v = read();
@@ -341,7 +341,7 @@ public:
   }
 
   /// Read a single element from a 1D region, by value only.
-  template <typename T = simd_view_impl,
+  template <typename T = Derived,
             typename = sycl::detail::enable_if_t<T::is1D()>>
   __SYCL_DEPRECATED("use operator[] form.")
   element_type operator()(int i) const {

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
@@ -296,7 +296,7 @@ public:
 #undef DEF_UNARY_OP
 
   // negation operator
-  auto operator!() { return *this == 0; }
+  auto operator!() { return cast_this_to_derived() == 0; }
 
   // Operator ++, --
   Derived &operator++() {

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
@@ -25,11 +25,9 @@ namespace intel {
 namespace experimental {
 namespace esimd {
 
-// simd and simd_view_impl forward declarations
+// simd and simd_view forward declarations
 template <typename Ty, int N> class simd;
-namespace detail {
-template <typename BaseTy, typename RegionTy> class simd_view_impl;
-} // namespace detail
+template <typename BaseTy, typename RegionTy> class simd_view;
 
 namespace detail {
 
@@ -90,7 +88,7 @@ struct compute_format_type<simd<Ty, N>, EltTy> {
 };
 
 template <typename BaseTy, typename RegionTy, typename EltTy>
-struct compute_format_type<detail::simd_view_impl<BaseTy, RegionTy>, EltTy> {
+struct compute_format_type<simd_view<BaseTy, RegionTy>, EltTy> {
   using ShapeTy = typename shape_type<RegionTy>::type;
   static constexpr int Size = ShapeTy::Size_in_bytes / sizeof(EltTy);
   static constexpr int Stride = 1;
@@ -118,8 +116,8 @@ struct compute_format_type_2d<simd<Ty, N>, EltTy, Height, Width> {
 
 template <typename BaseTy, typename RegionTy, typename EltTy, int Height,
           int Width>
-struct compute_format_type_2d<detail::simd_view_impl<BaseTy, RegionTy>, EltTy,
-                              Height, Width> {
+struct compute_format_type_2d<simd_view<BaseTy, RegionTy>, EltTy, Height,
+                              Width> {
   using ShapeTy = typename shape_type<RegionTy>::type;
   static constexpr int Prod = ShapeTy::Size_in_bytes / sizeof(EltTy);
   static_assert(Prod == Width * Height, "size mismatch");
@@ -139,10 +137,6 @@ using compute_format_type_2d_t =
 template <typename Ty> struct is_simd_view_type : std::false_type {};
 
 template <typename BaseTy, typename RegionTy>
-struct is_simd_view_type<detail::simd_view_impl<BaseTy, RegionTy>>
-    : std::true_type {};
-
-template <typename BaseTy, typename RegionTy>
 struct is_simd_view_type<simd_view<BaseTy, RegionTy>> : std::true_type {};
 
 template <typename Ty>
@@ -157,8 +151,7 @@ template <typename Ty, int N>
 struct is_simd_type<simd<Ty, N>> : std::true_type {};
 
 template <typename BaseTy, typename RegionTy>
-struct is_simd_type<detail::simd_view_impl<BaseTy, RegionTy>> : std::true_type {
-};
+struct is_simd_type<simd_view<BaseTy, RegionTy>> : std::true_type {};
 
 template <typename Ty>
 struct is_simd_v
@@ -170,7 +163,7 @@ template <typename Ty, int N> struct element_type<simd<Ty, N>> {
   using type = Ty;
 };
 template <typename BaseTy, typename RegionTy>
-struct element_type<detail::simd_view_impl<BaseTy, RegionTy>> {
+struct element_type<simd_view<BaseTy, RegionTy>> {
   using type = typename RegionTy::element_type;
 };
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
@@ -25,12 +25,14 @@ namespace esimd {
 ///
 /// \ingroup sycl_esimd
 template <typename BaseTy, typename RegionTy>
-class simd_view : public detail::simd_view_impl<BaseTy, RegionTy> {
+class simd_view : public detail::simd_view_impl<BaseTy, RegionTy,
+                                                simd_view<BaseTy, RegionTy>> {
   template <typename, int> friend class simd;
-  // template <typename, typename> friend class simd_view;
+  template <typename, typename, typename> friend class detail::simd_view_impl;
 
 public:
-  using BaseClass = detail::simd_view_impl<BaseTy, RegionTy>;
+  using BaseClass =
+      detail::simd_view_impl<BaseTy, RegionTy, simd_view<BaseTy, RegionTy>>;
   using ShapeTy = typename shape_type<RegionTy>::type;
   static constexpr int length = ShapeTy::Size_x * ShapeTy::Size_y;
 
@@ -107,12 +109,15 @@ public:
 template <typename BaseTy>
 class simd_view<BaseTy, region_base_1<typename BaseTy::element_type>>
     : public detail::simd_view_impl<
-          BaseTy, region_base_1<typename BaseTy::element_type>> {
+          BaseTy, region_base_1<typename BaseTy::element_type>,
+          simd_view<BaseTy, region_base_1<typename BaseTy::element_type>>> {
   template <typename, int> friend class simd;
+  template <typename, typename, typename> friend class detail::simd_view_impl;
 
 public:
   using RegionTy = region_base_1<typename BaseTy::element_type>;
-  using BaseClass = detail::simd_view_impl<BaseTy, RegionTy>;
+  using BaseClass =
+      detail::simd_view_impl<BaseTy, RegionTy, simd_view<BaseTy, RegionTy>>;
   using ShapeTy = typename shape_type<RegionTy>::type;
   static constexpr int length = ShapeTy::Size_x * ShapeTy::Size_y;
   static_assert(1 == length, "length of this view is not equal to 1");
@@ -121,10 +126,8 @@ public:
   using element_type = typename ShapeTy::element_type;
 
 private:
-  simd_view(BaseTy &Base, RegionTy Region)
-      : detail::simd_view_impl<BaseTy, RegionTy>(Base, Region) {}
-  simd_view(BaseTy &&Base, RegionTy Region)
-      : detail::simd_view_impl<BaseTy, RegionTy>(Base, Region) {}
+  simd_view(BaseTy &Base, RegionTy Region) : BaseClass(Base, Region) {}
+  simd_view(BaseTy &&Base, RegionTy Region) : BaseClass(Base, Region) {}
 
 public:
   operator element_type() const { return (*this)[0]; }

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
@@ -92,9 +92,6 @@ public:
   DEF_RELOP(!=)
 
 #undef DEF_RELOP
-
-  // negation operator
-  auto operator!() { return *this == 0; }
 };
 
 /// This is a specialization of simd_view class with a single element.
@@ -148,9 +145,6 @@ public:
   DEF_RELOP(!=)
 
 #undef DEF_RELOP
-
-  // negation operator
-  auto operator!() { return *this == 0; }
 };
 
 } // namespace esimd

--- a/sycl/test/esimd/esimd-util-compiler-eval.cpp
+++ b/sycl/test/esimd/esimd-util-compiler-eval.cpp
@@ -20,7 +20,10 @@ static_assert(log2<1024 * 1024>() == 20, "");
 using BaseTy = simd<float, 4>;
 using RegionTy = region1d_t<float, 2, 1>;
 using RegionTy1 = region_base_1<float>;
-static_assert(is_simd_view_v<simd_view_impl<BaseTy, RegionTy>>::value, "");
+static_assert(
+    !is_simd_view_v<
+        simd_view_impl<BaseTy, RegionTy, simd_view<BaseTy, RegionTy>>>::value,
+    "");
 static_assert(is_simd_view_v<simd_view<BaseTy, RegionTy>>::value, "");
 static_assert(is_simd_view_v<simd_view<BaseTy, RegionTy1>>::value, "");
 static_assert(!is_simd_view_v<BaseTy>::value, "");

--- a/sycl/test/esimd/simd_view.cpp
+++ b/sycl/test/esimd/simd_view.cpp
@@ -129,10 +129,10 @@ void test_simd_view_impl_api_ret_types() SYCL_ESIMD_FUNCTION {
           // 1, 1>, region_base<false, float, 1, 0, 2, 1>>>
   static_assert(detail::is_simd_view_v<decltype(v1)>::value, "");
 
-  auto v_int = x.bit_cast_view<int>();
-  static_assert(detail::is_simd_view_v<decltype(v_int)>::value, "");
-  auto v_int_2D = x.bit_cast_view<int, 2, 2>();
-  static_assert(detail::is_simd_view_v<decltype(v_int_2D)>::value, "");
+  auto v2_int = v2.bit_cast_view<int>();
+  static_assert(detail::is_simd_view_v<decltype(v2_int)>::value, "");
+  auto v2_int_2D = v2.bit_cast_view<int, 1, 1>();
+  static_assert(detail::is_simd_view_v<decltype(v2_int_2D)>::value, "");
 
   auto v3 = x.select<2, 1>(2);
   auto &v4 = (v1 += v3);

--- a/sycl/test/esimd/simd_view.cpp
+++ b/sycl/test/esimd/simd_view.cpp
@@ -117,6 +117,29 @@ SYCL_ESIMD_FUNCTION void bar() {
   foo(v0.select<8, 1>(0)); // rvalue
 }
 
+// This test checks that simd_view_impl APIs return objects of derived class.
+// I.e. they never return objects of simd_view_impl class.
+void test_simd_view_impl_api_ret_types() SYCL_ESIMD_FUNCTION {
+  simd<float, 4> x = 0;
+  auto v1 =
+      x.select<2, 1>(0); // simd_view<simd<float, 4>, region1d_t<float, 2, 1>>
+  static_assert(detail::is_simd_view_v<decltype(v1)>::value, "");
+  auto v2 = v1.select<1, 1>(
+      0); // simd_view<simd<float, 4>, std::pair<region_base<false, float, 1, 0,
+          // 1, 1>, region_base<false, float, 1, 0, 2, 1>>>
+  static_assert(detail::is_simd_view_v<decltype(v1)>::value, "");
+
+  auto v_int = x.bit_cast_view<int>();
+  static_assert(detail::is_simd_view_v<decltype(v_int)>::value, "");
+  auto v_int_2D = x.bit_cast_view<int, 2, 2>();
+  static_assert(detail::is_simd_view_v<decltype(v_int_2D)>::value, "");
+
+  auto v3 = x.select<2, 1>(2);
+  auto &v4 = (v1 += v3);
+  static_assert(detail::is_simd_view_v<decltype(v4)>::value, "");
+  static_assert(detail::is_simd_view_v<decltype(++v4)>::value, "");
+}
+
 void test_simd_view_subscript() SYCL_ESIMD_FUNCTION {
   simd<int, 4> v = 1;
   auto vv = v.select<2, 1>(0);


### PR DESCRIPTION
CRTP - Curiously Recurring Template Pattern.

The main goal of the change is that it would not be possible
to generate objects of simd_view_impl class. To achieve
that we need to force simd_view_impl APIs to return objects
of the derived class.

This change is needed for implementing writeable subscript
 operator in simd_view.