### PR TITLE
[SYCL] Create kernel bundle when non-native specialization constants are unset

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -551,6 +551,13 @@ private:
       // arguments.
       MArgs = std::move(MAssociatedAccesors);
     }
+
+    // If the kernel lambda is callable with a kernel_handler argument, manifest
+    // the associated kernel handler.
+    if (detail::isKernelLambdaCallableWithKernelHandler<KernelType,
+                                                        LambdaArgType>()) {
+      getOrInsertHandlerKernelBundle(/*Insert=*/true);
+    }
   }
 
   /// Checks whether it is possible to copy the source shape to the destination

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1754,15 +1754,10 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
             "device",
             PI_INVALID_OPERATION);
       }
-      if (DeviceImageImpl != nullptr) {
-        RT::PiMem SpecConstsBuffer =
-            DeviceImageImpl->get_spec_const_buffer_ref();
-        Plugin.call<PiApiKind::piextKernelSetArgMemObj>(Kernel, NextTrueIndex,
-                                                        &SpecConstsBuffer);
-      } else {
-        Plugin.call<PiApiKind::piextKernelSetArgMemObj>(Kernel, NextTrueIndex,
-                                                        nullptr);
-      }
+      assert(DeviceImageImpl != nullptr);
+      RT::PiMem SpecConstsBuffer = DeviceImageImpl->get_spec_const_buffer_ref();
+      Plugin.call<PiApiKind::piextKernelSetArgMemObj>(Kernel, NextTrueIndex,
+                                                      &SpecConstsBuffer);
       break;
     }
     }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -108,8 +108,13 @@ event handler::finalize() {
   if (getCGTypeVersion(MCGType) >
       static_cast<unsigned int>(detail::CG::CG_VERSION::V0)) {
     // If there were uses of set_specialization_constant build the kernel_bundle
+    bool HasSpecConstArgs =
+        std::any_of(MArgs.begin(), MArgs.end(), [](detail::ArgDesc Arg) {
+          return Arg.MType == detail::kernel_param_kind_t::
+                                  kind_specialization_constants_buffer;
+        });
     std::shared_ptr<detail::kernel_bundle_impl> KernelBundleImpPtr =
-        getOrInsertHandlerKernelBundle(/*Insert=*/false);
+        getOrInsertHandlerKernelBundle(/*Insert=*/HasSpecConstArgs);
     if (KernelBundleImpPtr) {
       switch (KernelBundleImpPtr->get_bundle_state()) {
       case bundle_state::input: {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -108,13 +108,8 @@ event handler::finalize() {
   if (getCGTypeVersion(MCGType) >
       static_cast<unsigned int>(detail::CG::CG_VERSION::V0)) {
     // If there were uses of set_specialization_constant build the kernel_bundle
-    bool HasSpecConstArgs =
-        std::any_of(MArgs.begin(), MArgs.end(), [](detail::ArgDesc Arg) {
-          return Arg.MType == detail::kernel_param_kind_t::
-                                  kind_specialization_constants_buffer;
-        });
     std::shared_ptr<detail::kernel_bundle_impl> KernelBundleImpPtr =
-        getOrInsertHandlerKernelBundle(/*Insert=*/HasSpecConstArgs);
+        getOrInsertHandlerKernelBundle(/*Insert=*/false);
     if (KernelBundleImpPtr) {
       switch (KernelBundleImpPtr->get_bundle_state()) {
       case bundle_state::input: {


### PR DESCRIPTION
The kernel bundle carrying the device memory used for specialization constants on systems that do not support specialization constants natively was only initialized if a specialization constant was either written to or read from prior to kernel execution. These changes either forces the creation of a kernel bundle if the kernel has a specialization constant argument and a kernel bundle does not exist already.