### PR TITLE
[SYCL][L0] Always set CommandList in _pi_context::getAvailableCommandList

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -876,7 +876,11 @@ pi_result _pi_context::getAvailableCommandList(
 
         ze_fence_handle_t ZeFence;
         ZE_CALL(zeFenceCreate, (ZeCommandQueue, &ZeFenceDesc, &ZeFence));
-        Queue->CommandListMap[ZeCommandList] = {ZeFence, true, CopyQueueIndex};
+        CommandList =
+            Queue->CommandListMap
+                .emplace(ZeCommandList,
+                         pi_command_list_info_t{ZeFence, true, CopyQueueIndex})
+                .first;
       }
       ZeCommandListCache.pop_front();
       return PI_SUCCESS;


### PR DESCRIPTION
When adding a command list from the cache to the map, we were not returning the newly-inserted element via `CommandList` reference.

Thus, the _pi_context::getAvailableCommandList function was returning `PI_SUCCESS`, but `CommandList` was left uninitialized, leading to a segfault when the command list is used later (in my case, in `enqueueMemFillHelper`).

Introduced in PR #4248.


I can't come up with a concise reproducer, since the bug is triggered for me in a multi-threaded application with a lot of set-up code. Example stack-trace:

```
#0  0x00007fffebc224a2 in enqueueMemFillHelper (CommandType=PI_COMMAND_TYPE_MEM_BUFFER_FILL, Queue=0x5fffd401fe50, Ptr=0x755695d30000, Pattern=0x5fffd4107960, PatternSize=4, Size=768, NumEventsInWaitList=6, 
    EventWaitList=0x5fffd4375250, Event=0x5fffd40647d0) at /nethome/aland/intel-sycl/llvm/sycl/plugins/level_zero/pi_level_zero.cpp:5245
#1  0x00007fffebc2208d in piEnqueueMemBufferFill (Queue=0x5fffd401fe50, Buffer=0x5fffd4086640, Pattern=0x5fffd4107960, PatternSize=4, Offset=0, Size=768, NumEventsInWaitList=6, EventWaitList=0x5fffd4375250, Event=0x5fffd40647d0)
    at /nethome/aland/intel-sycl/llvm/sycl/plugins/level_zero/pi_level_zero.cpp:5274
#2  0x00007fffec7c2fa6 in cl::sycl::detail::plugin::call_nocheck<(cl::sycl::detail::PiApiKind)84, _pi_queue*, _pi_mem*, char const*, unsigned long, unsigned long, unsigned long, unsigned long, _pi_event**, _pi_event**> (this=0x771e10, 
    Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0)
    at /nethome/aland/intel-sycl/llvm/sycl/source/detail/plugin.hpp:161
#3  0x00007fffec7b0bd5 in cl::sycl::detail::plugin::call<(cl::sycl::detail::PiApiKind)84, _pi_queue*, _pi_mem*, char const*, unsigned long, unsigned long, unsigned long, unsigned long, _pi_event**, _pi_event**> (this=0x771e10, 
    Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0, Args=0x5fffd40647d0)
    at /nethome/aland/intel-sycl/llvm/sycl/source/detail/plugin.hpp:178
#4  0x00007fffec7aec37 in cl::sycl::detail::MemoryManager::fill (SYCLMemObj=0x5fffd40807e0, Mem=0x5fffd4086640, Queue=..., PatternSize=4, Pattern=0x5fffd4107960 "", Dim=1, Range=..., Offset=..., ElementSize=4, DepEvents=..., 
    OutEvent=@0x5fffd40647d0: 0x5fffd47a9d80) at /nethome/aland/intel-sycl/llvm/sycl/source/detail/memory_manager.cpp:572
#5  0x00007fffec851bb1 in cl::sycl::detail::ExecCGCommand::enqueueImp (this=0x5fffd40a42e0) at /nethome/aland/intel-sycl/llvm/sycl/source/detail/scheduler/commands.cpp:1904
#6  0x00007fffec8481a0 in cl::sycl::detail::Command::enqueue (this=0x5fffd40a42e0, EnqueueResult=..., Blocking=cl::sycl::detail::NON_BLOCKING) at /nethome/aland/intel-sycl/llvm/sycl/source/detail/scheduler/commands.cpp:638
#7  0x00007fffec887083 in cl::sycl::detail::Scheduler::GraphProcessor::enqueueCommand (Cmd=0x5fffd40a42e0, EnqueueResult=..., Blocking=cl::sycl::detail::NON_BLOCKING)
    at /nethome/aland/intel-sycl/llvm/sycl/source/detail/scheduler/graph_processor.cpp:111
#8  0x00007fffec87bec0 in cl::sycl::detail::Scheduler::addCG (this=0x77ddf0, CommandGroup=..., Queue=...) at /nethome/aland/intel-sycl/llvm/sycl/source/detail/scheduler/scheduler.cpp:203
#9  0x00007fffec8c803b in cl::sycl::handler::finalize (this=0x5fffea4eb3b8) at /nethome/aland/intel-sycl/llvm/sycl/source/handler.cpp:226
#10 0x00007fffec8fbf68 in cl::sycl::detail::queue_impl::submit_impl(std::function<void (cl::sycl::handler&)> const&, std::shared_ptr<cl::sycl::detail::queue_impl> const&, cl::sycl::detail::code_location const&) (this=0x5fffd401ed00, 
    CGF=..., Self=..., Loc=...) at /nethome/aland/intel-sycl/llvm/sycl/source/detail/queue_impl.hpp:409
#11 0x00007fffec8fbcab in cl::sycl::detail::queue_impl::submit(std::function<void (cl::sycl::handler&)> const&, std::shared_ptr<cl::sycl::detail::queue_impl> const&, cl::sycl::detail::code_location const&) (this=0x5fffd401ed00, 
    CGF=..., Self=..., Loc=...) at /nethome/aland/intel-sycl/llvm/sycl/source/detail/queue_impl.hpp:199
#12 0x00007fffec8fb0f8 in cl::sycl::queue::submit_impl(std::function<void (cl::sycl::handler&)>, cl::sycl::detail::code_location const&) (this=0x5fffea4eb888, CGH=..., CodeLoc=...)
    at /nethome/aland/intel-sycl/llvm/sycl/source/queue.cpp:127
#13 0x00007ffff0afcd41 in cl::sycl::queue::submit<gmx::internal::fillSyclBufferWithNull<float>(cl::sycl::buffer<float, 1, cl::sycl::detail::aligned_allocator<char>, void>&, unsigned long, unsigned long, cl::sycl::queue)::{lambda(cl::sycl::handler&)#1}>(gmx::internal::fillSyclBufferWithNull<float>(cl::sycl::buffer<float, 1, cl::sycl::detail::aligned_allocator<char>, void>&, unsigned long, unsigned long, cl::sycl::queue)::{lambda(cl::sycl::handler&)#1}, cl::sycl::detail::code_location const&) (this=0x5fffea4eb888, CGF=..., CodeLoc=...) at /nethome/aland/modules/intel-llvm/20210813-80d02e7014-deb/bin/../include/sycl/CL/sycl/queue.hpp:226
#14 The rest of the stack trace is the application code.
```
