### PR TITLE
[SYCL] Enable parallel execution of llvm-foreach commands under an option

### DIFF
--- a/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
@@ -6,13 +6,17 @@
 ; RUN: echo "%t2.tgt" >> %t.list
 ; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
 ; RUN: FileCheck < %t.res %s
-; CHECK: [[FIRST:.+1.tgt]]
-; CHECK: [[SECOND:.+2.tgt]]
+; RUN: llvm-foreach --parallel-exec --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
+; RUN: FileCheck < %t.res %s
+; CHECK-DAG: [[FIRST:.+1.tgt]]
+; CHECK-DAG: [[SECOND:.+2.tgt]]
 ;
 ; RUN: llvm-foreach --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
-; CHECK-LIST: [[FIRST:.+\.out]]
-; CHECK-LIST: [[SECOND:.+\.out]]
+; RUN: llvm-foreach --parallel-exec --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
+; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
+; CHECK-LIST-DAG: [[FIRST:.+\.out]]
+; CHECK-LIST-DAG: [[SECOND:.+\.out]]
 ; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- FileCheck --input-file="{}" %s --check-prefix=CHECK-CONTENT
 ; CHECK-CONTENT: Content of
 
@@ -22,5 +26,7 @@
 ; RUN: echo "%t4.tgt" >> %t1.list
 ; RUN: llvm-foreach --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment="%t_out.prj" -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
-; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]] -another-arg={{.+}}_out.prj
-; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]] -another-arg={{.+}}_out.prj_1
+; RUN: llvm-foreach --parallel-exec --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment="%t_out.prj" -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
+; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
+; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]] -another-arg={{.+}}_out.prj
+; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]] -another-arg={{.+}}_out.prj_1

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
@@ -4,16 +4,19 @@
 ; RUN: echo 'Content of second file' > %t2.tgt
 ; RUN: echo "%t1.tgt" > %t.list
 ; RUN: echo "%t2.tgt" >> %t.list
-; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
-; RUN: FileCheck < %t.res %s
-; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
+; RUN: llvm-foreach --jobs=2 --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
 ; RUN: FileCheck < %t.res %s
 ; CHECK-DAG: [[FIRST:.+1.tgt]]
 ; CHECK-DAG: [[SECOND:.+2.tgt]]
-;
+
+; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
+; RUN: FileCheck < %t.res %s --check-prefix=CHECK-ORDER
+; CHECK-ORDER: [[FIRST:.+1.tgt]]
+; CHECK-ORDER: [[SECOND:.+2.tgt]]
+
 ; RUN: llvm-foreach --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
-; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
+; RUN: llvm-foreach --jobs=2 --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; CHECK-LIST-DAG: [[FIRST:.+\.out]]
 ; CHECK-LIST-DAG: [[SECOND:.+\.out]]
@@ -26,7 +29,7 @@
 ; RUN: echo "%t4.tgt" >> %t1.list
 ; RUN: llvm-foreach --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment="%t_out.prj" -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
-; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment="%t_out.prj" -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
+; RUN: llvm-foreach --jobs=2 --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment="%t_out.prj" -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
 ; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]] -another-arg={{.+}}_out.prj
 ; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]] -another-arg={{.+}}_out.prj_1
@@ -35,9 +38,9 @@
 ; RUN: echo "%t2.tgt" >> %t2.list
 ; RUN: echo "%t3.tgt" >> %t2.list
 ; RUN: echo "%t4.tgt" >> %t2.list
-; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-file-list=%t2.list -- echo "{}" > %t2.res
-; RUN: FileCheck < %t2.res %s --check-prefix=CHECK-PARALLEL-EXEC
-; CHECK-PARALLEL-EXEC-DAG: [[FIRST:.+1.tgt]]
-; CHECK-PARALLEL-EXEC-DAG: [[SECOND:.+2.tgt]]
-; CHECK-PARALLEL-EXEC-DAG: [[THIRD:.+3.tgt]]
-; CHECK-PARALLEL-EXEC-DAG: [[FOURTH:.+4.tgt]]
+; RUN: llvm-foreach -j 2 --in-replace="{}" --in-file-list=%t2.list -- echo "{}" > %t2.res
+; RUN: FileCheck < %t2.res %s --check-prefix=CHECK-PARALLEL-JOBS
+; CHECK-PARALLEL-JOBS-DAG: [[FIRST:.+1.tgt]]
+; CHECK-PARALLEL-JOBS-DAG: [[SECOND:.+2.tgt]]
+; CHECK-PARALLEL-JOBS-DAG: [[THIRD:.+3.tgt]]
+; CHECK-PARALLEL-JOBS-DAG: [[FOURTH:.+4.tgt]]

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
@@ -6,14 +6,14 @@
 ; RUN: echo "%t2.tgt" >> %t.list
 ; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
 ; RUN: FileCheck < %t.res %s
-; RUN: llvm-foreach --parallel-exec --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
+; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
 ; RUN: FileCheck < %t.res %s
 ; CHECK-DAG: [[FIRST:.+1.tgt]]
 ; CHECK-DAG: [[SECOND:.+2.tgt]]
 ;
 ; RUN: llvm-foreach --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
-; RUN: llvm-foreach --parallel-exec --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
+; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; CHECK-LIST-DAG: [[FIRST:.+\.out]]
 ; CHECK-LIST-DAG: [[SECOND:.+\.out]]
@@ -26,7 +26,18 @@
 ; RUN: echo "%t4.tgt" >> %t1.list
 ; RUN: llvm-foreach --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment="%t_out.prj" -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
-; RUN: llvm-foreach --parallel-exec --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment="%t_out.prj" -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
+; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment="%t_out.prj" -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
 ; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]] -another-arg={{.+}}_out.prj
 ; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]] -another-arg={{.+}}_out.prj_1
+
+; RUN: echo "%t1.tgt" > %t2.list
+; RUN: echo "%t2.tgt" >> %t2.list
+; RUN: echo "%t3.tgt" >> %t2.list
+; RUN: echo "%t4.tgt" >> %t2.list
+; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-file-list=%t2.list -- echo "{}" > %t2.res
+; RUN: FileCheck < %t2.res %s --check-prefix=CHECK-PARALLEL-EXEC
+; CHECK-PARALLEL-EXEC-DAG: [[FIRST:.+1.tgt]]
+; CHECK-PARALLEL-EXEC-DAG: [[SECOND:.+2.tgt]]
+; CHECK-PARALLEL-EXEC-DAG: [[THIRD:.+3.tgt]]
+; CHECK-PARALLEL-EXEC-DAG: [[FOURTH:.+4.tgt]]

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
@@ -18,8 +18,8 @@
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; RUN: llvm-foreach --jobs=2 --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- cp "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
-; CHECK-LIST-DAG: [[FIRST:.+\.out]]
-; CHECK-LIST-DAG: [[SECOND:.+\.out]]
+; CHECK-LIST: [[FIRST:.+\.out]]
+; CHECK-LIST: [[SECOND:.+\.out]]
 ; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- FileCheck --input-file="{}" %s --check-prefix=CHECK-CONTENT
 ; CHECK-CONTENT: Content of
 

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-lin.ll
@@ -20,8 +20,10 @@
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; CHECK-LIST: [[FIRST:.+\.out]]
 ; CHECK-LIST: [[SECOND:.+\.out]]
-; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- FileCheck --input-file="{}" %s --check-prefix=CHECK-CONTENT
-; CHECK-CONTENT: Content of
+; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- cat "{}" > %t.order
+; RUN: FileCheck < %t.order %s --check-prefix=CHECK-CONTENT
+; CHECK-CONTENT: Content of first file
+; CHECK-CONTENT-NEXT: Content of second file
 
 ; RUN: echo 'something' > %t3.tgt
 ; RUN: echo 'something again' > %t4.tgt

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
@@ -20,7 +20,7 @@
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; CHECK-LIST: [[FIRST:.+\.out]]
 ; CHECK-LIST: [[SECOND:.+\.out]]
-; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- type "{}" > %t.order
+; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- cat "{}" > %t.order
 ; RUN: FileCheck < %t.order %s --check-prefix=CHECK-CONTENT
 ; CHECK-CONTENT: Content of first file
 ; CHECK-CONTENT-NEXT: Content of second file

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
@@ -4,16 +4,19 @@
 ; RUN: echo 'Content of second file' > %t2.tgt
 ; RUN: echo "%t1.tgt" > %t.list
 ; RUN: echo "%t2.tgt" >> %t.list
-; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
-; RUN: FileCheck < %t.res %s
-; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
+; RUN: llvm-foreach --jobs=2 --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
 ; RUN: FileCheck < %t.res %s
 ; CHECK-DAG: [[FIRST:.+1.tgt]]
 ; CHECK-DAG: [[SECOND:.+2.tgt]]
-;
+
+; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
+; RUN: FileCheck < %t.res %s --check-prefix=CHECK-ORDER
+; CHECK-ORDER: [[FIRST:.+1.tgt]]
+; CHECK-ORDER: [[SECOND:.+2.tgt]]
+
 ; RUN: llvm-foreach --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- xcopy /y "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
-; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- xcopy /y "{}" %t
+; RUN: llvm-foreach --jobs=2 --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- xcopy /y "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; CHECK-LIST-DAG: [[FIRST:.+\.out]]
 ; CHECK-LIST-DAG: [[SECOND:.+\.out]]
@@ -26,7 +29,7 @@
 ; RUN: echo "%t4.tgt" >> %t1.list
 ; RUN: llvm-foreach --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment=%t_out.prj -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
-; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment=%t_out.prj -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
+; RUN: llvm-foreach --jobs=2 --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment=%t_out.prj -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
 ; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]] -another-arg={{.+}}_out.prj
 ; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]] -another-arg={{.+}}_out.prj_1
@@ -35,9 +38,9 @@
 ; RUN: echo "%t2.tgt" >> %t2.list
 ; RUN: echo "%t3.tgt" >> %t2.list
 ; RUN: echo "%t4.tgt" >> %t2.list
-; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-file-list=%t2.list -- echo "{}" > %t2.res
-; RUN: FileCheck < %t2.res %s --check-prefix=CHECK-PARALLEL-EXEC
-; CHECK-PARALLEL-EXEC-DAG: [[FIRST:.+1.tgt]]
-; CHECK-PARALLEL-EXEC-DAG: [[SECOND:.+2.tgt]]
-; CHECK-PARALLEL-EXEC-DAG: [[THIRD:.+3.tgt]]
-; CHECK-PARALLEL-EXEC-DAG: [[FOURTH:.+4.tgt]]
+; RUN: llvm-foreach --jobs=2 --in-replace="{}" --in-file-list=%t2.list -- echo "{}" > %t2.res
+; RUN: FileCheck < %t2.res %s --check-prefix=CHECK-PARALLEL-JOBS
+; CHECK-PARALLEL-JOBS-DAG: [[FIRST:.+1.tgt]]
+; CHECK-PARALLEL-JOBS-DAG: [[SECOND:.+2.tgt]]
+; CHECK-PARALLEL-JOBS-DAG: [[THIRD:.+3.tgt]]
+; CHECK-PARALLEL-JOBS-DAG: [[FOURTH:.+4.tgt]]

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
@@ -6,13 +6,17 @@
 ; RUN: echo "%t2.tgt" >> %t.list
 ; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
 ; RUN: FileCheck < %t.res %s
-; CHECK: [[FIRST:.+1.tgt]]
-; CHECK: [[SECOND:.+2.tgt]]
+; RUN: llvm-foreach --parallel-exec --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
+; RUN: FileCheck < %t.res %s
+; CHECK-DAG: [[FIRST:.+1.tgt]]
+; CHECK-DAG: [[SECOND:.+2.tgt]]
 ;
 ; RUN: llvm-foreach --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- xcopy /y "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
-; CHECK-LIST: [[FIRST:.+\.out]]
-; CHECK-LIST: [[SECOND:.+\.out]]
+; RUN: llvm-foreach --parallel-exec --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- xcopy /y "{}" %t
+; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
+; CHECK-LIST-DAG: [[FIRST:.+\.out]]
+; CHECK-LIST-DAG: [[SECOND:.+\.out]]
 ; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- FileCheck --input-file="{}" %s --check-prefix=CHECK-CONTENT
 ; CHECK-CONTENT: Content of
 
@@ -22,5 +26,7 @@
 ; RUN: echo "%t4.tgt" >> %t1.list
 ; RUN: llvm-foreach --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment=%t_out.prj -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
-; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]] -another-arg={{.+}}_out.prj
-; CHECK-DOUBLE-LISTS: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]] -another-arg={{.+}}_out.prj_1
+; RUN: llvm-foreach --parallel-exec --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment=%t_out.prj -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
+; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
+; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]] -another-arg={{.+}}_out.prj
+; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]] -another-arg={{.+}}_out.prj_1

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
@@ -18,10 +18,12 @@
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; RUN: llvm-foreach --jobs=2 --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- xcopy /y "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
-; CHECK-LIST-DAG: [[FIRST:.+\.out]]
-; CHECK-LIST-DAG: [[SECOND:.+\.out]]
-; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- FileCheck --input-file="{}" %s --check-prefix=CHECK-CONTENT
-; CHECK-CONTENT: Content of
+; CHECK-LIST: [[FIRST:.+\.out]]
+; CHECK-LIST: [[SECOND:.+\.out]]
+; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.out.list -- type "{}" > %t.order
+; RUN: FileCheck < %t.order %s --check-prefix=CHECK-CONTENT
+; CHECK-CONTENT: Content of first file
+; CHECK-CONTENT-NEXT: Content of second file
 
 ; RUN: echo 'something' > %t3.tgt
 ; RUN: echo 'something again' > %t4.tgt

--- a/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
+++ b/llvm/test/tools/llvm-foreach/llvm-foreach-win.ll
@@ -6,14 +6,14 @@
 ; RUN: echo "%t2.tgt" >> %t.list
 ; RUN: llvm-foreach --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
 ; RUN: FileCheck < %t.res %s
-; RUN: llvm-foreach --parallel-exec --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
+; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-file-list=%t.list -- echo "{}" > %t.res
 ; RUN: FileCheck < %t.res %s
 ; CHECK-DAG: [[FIRST:.+1.tgt]]
 ; CHECK-DAG: [[SECOND:.+2.tgt]]
 ;
 ; RUN: llvm-foreach --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- xcopy /y "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
-; RUN: llvm-foreach --parallel-exec --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- xcopy /y "{}" %t
+; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --out-replace=%t --out-ext=out --in-file-list=%t.list --out-file-list=%t.out.list -- xcopy /y "{}" %t
 ; RUN: FileCheck < %t.out.list %s --check-prefix=CHECK-LIST
 ; CHECK-LIST-DAG: [[FIRST:.+\.out]]
 ; CHECK-LIST-DAG: [[SECOND:.+\.out]]
@@ -26,7 +26,18 @@
 ; RUN: echo "%t4.tgt" >> %t1.list
 ; RUN: llvm-foreach --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment=%t_out.prj -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
-; RUN: llvm-foreach --parallel-exec --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment=%t_out.prj -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
+; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-replace="inrep" --in-file-list=%t.list --in-file-list=%t1.list --out-increment=%t_out.prj -- echo -first-part-of-arg={}.out -first-part-of-arg=inrep.out -another-arg=%t_out.prj > %t1.res
 ; RUN: FileCheck < %t1.res %s --check-prefix=CHECK-DOUBLE-LISTS
 ; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[FIRST:.+1.tgt.out]] -first-part-of-arg=[[THIRD:.+3.tgt.out]] -another-arg={{.+}}_out.prj
 ; CHECK-DOUBLE-LISTS-DAG: -first-part-of-arg=[[SECOND:.+2.tgt.out]] -first-part-of-arg=[[FOURTH:.+4.tgt.out]] -another-arg={{.+}}_out.prj_1
+
+; RUN: echo "%t1.tgt" > %t2.list
+; RUN: echo "%t2.tgt" >> %t2.list
+; RUN: echo "%t3.tgt" >> %t2.list
+; RUN: echo "%t4.tgt" >> %t2.list
+; RUN: llvm-foreach --parallel-exec=2 --in-replace="{}" --in-file-list=%t2.list -- echo "{}" > %t2.res
+; RUN: FileCheck < %t2.res %s --check-prefix=CHECK-PARALLEL-EXEC
+; CHECK-PARALLEL-EXEC-DAG: [[FIRST:.+1.tgt]]
+; CHECK-PARALLEL-EXEC-DAG: [[SECOND:.+2.tgt]]
+; CHECK-PARALLEL-EXEC-DAG: [[THIRD:.+3.tgt]]
+; CHECK-PARALLEL-EXEC-DAG: [[FOURTH:.+4.tgt]]

--- a/llvm/test/tools/llvm-foreach/retain-return-val.c
+++ b/llvm/test/tools/llvm-foreach/retain-return-val.c
@@ -18,6 +18,6 @@
 // RUN: chmod 777 %t2.sh
 // RUN: %t2.sh
 // RUN: FileCheck < %t.res %s
-// CHECK-DAG: Content of first file
-// CHECK-DAG: Content of second file
+// CHECK: Content of first file
+// CHECK: Content of second file
 // CHECK: 21

--- a/llvm/test/tools/llvm-foreach/retain-return-val.c
+++ b/llvm/test/tools/llvm-foreach/retain-return-val.c
@@ -18,6 +18,6 @@
 // RUN: chmod 777 %t2.sh
 // RUN: %t2.sh
 // RUN: FileCheck < %t.res %s
-// CHECK: Content of first file
-// CHECK: Content of second file
+// CHECK-DAG: Content of first file
+// CHECK-DAG: Content of second file
 // CHECK: 21

--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -283,9 +283,10 @@ int main(int argc, char **argv) {
   }
 
   // Wait for all commands to be executed.
-  if (int Result = checkIfJobsAreFinished(JobsSubmitted, /*BlockingWait*/ true))
-    Res = Result;
-  assert(JobsSubmitted.empty());
+  while (!JobsSubmitted.empty())
+    if (int Result =
+            checkIfJobsAreFinished(JobsSubmitted, /*BlockingWait*/ true))
+      Res = Result;
 
   if (!OutputFileList.empty()) {
     OS.close();

--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/SystemUtils.h"
+#include "llvm/Support/Threading.h"
 
 #include <list>
 #include <vector>
@@ -196,9 +197,12 @@ int main(int argc, char **argv) {
 
   if (!ExecuteInParallel)
     error("Number of parallel threads should be a positive integer");
-  if (ExecuteInParallel > 16) {
-    ExecuteInParallel = 16;
-    errs() << "llvm-foreach: adjusted number of threads to 16 (max available)";
+
+  size_t MaxSafeNumThreads = optimal_concurrency().compute_thread_count();
+  if (ExecuteInParallel > MaxSafeNumThreads) {
+    ExecuteInParallel = MaxSafeNumThreads;
+    outs() << "llvm-foreach: adjusted number of threads to "
+           << MaxSafeNumThreads << " (max safe available).\n";
   }
 
   std::error_code EC;

--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -73,7 +73,7 @@ static cl::opt<std::string> OutIncrement{
 static cl::opt<unsigned int> ExecuteInParallel{
     "parallel-exec",
     cl::Optional,
-    cl::init(1),
+    cl::init(4),
     cl::desc("Specify the number of threads for launching input commands in "
              "parallel mode"),
 };

--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -93,7 +93,7 @@ static void error(std::error_code EC, const Twine &Prefix) {
 }
 
 // With BlockingWait=false this function just goes through the all
-// submitted jobs to check if one of them has finished.
+// submitted jobs to check if some of them have finished.
 int checkIfJobsAreFinished(std::list<sys::ProcessInfo> &JobsSubmitted,
                            bool BlockingWait = true) {
   std::string ErrMsg;


### PR DESCRIPTION
This improvement should speed up toolchain execution by launching underlying llvm-foreach commands in parallel.
The feature is available under `--jobs`/`-j` option that should be passed to the command line of llvm-foreach.