### PR TITLE
[SYCL] Deprecate half from global namespace

### DIFF
--- a/sycl/include/CL/sycl/aliases.hpp
+++ b/sycl/include/CL/sycl/aliases.hpp
@@ -24,12 +24,6 @@ class half;
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
 
-// FIXME: line below exports 'half' into global namespace, which seems incorrect
-// However, SYCL 1.2.1 spec considers 'half' to be a fundamental C++ data type
-// which doesn't exist within the 'cl::sycl' namespace.
-// Related spec issue: KhronosGroup/SYCL-Docs#40
-using half = cl::sycl::detail::half_impl::half;
-
 #define __SYCL_MAKE_VECTOR_ALIAS(ALIAS, TYPE, N)                               \
   using ALIAS##N = cl::sycl::vec<TYPE, N>;
 

--- a/sycl/include/CL/sycl/aliases.hpp
+++ b/sycl/include/CL/sycl/aliases.hpp
@@ -24,6 +24,9 @@ class half;
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
 
+using half __SYCL2020_DEPRECATED("use 'sycl::half' instead") =
+    cl::sycl::detail::half_impl::half;
+
 #define __SYCL_MAKE_VECTOR_ALIAS(ALIAS, TYPE, N)                               \
   using ALIAS##N = cl::sycl::vec<TYPE, N>;
 

--- a/sycl/source/detail/builtins_geometric.cpp
+++ b/sycl/source/detail/builtins_geometric.cpp
@@ -28,7 +28,7 @@ __SYCL_EXPORT s::cl_double Dot(s::vec<double, 1>, s::vec<double, 1>);
 __SYCL_EXPORT s::cl_double Dot(s::cl_double2, s::cl_double2);
 __SYCL_EXPORT s::cl_double Dot(s::cl_double3, s::cl_double3);
 __SYCL_EXPORT s::cl_double Dot(s::cl_double4, s::cl_double4);
-__SYCL_EXPORT s::cl_half Dot(s::vec<half, 1>, s::vec<half, 1>);
+__SYCL_EXPORT s::cl_half Dot(s::vec<s::half, 1>, s::vec<s::half, 1>);
 __SYCL_EXPORT s::cl_half Dot(s::cl_half2, s::cl_half2);
 __SYCL_EXPORT s::cl_half Dot(s::cl_half3, s::cl_half3);
 __SYCL_EXPORT s::cl_half Dot(s::cl_half4, s::cl_half4);
@@ -158,7 +158,7 @@ __SYCL_EXPORT s::cl_double length(s::vec<double, 1> p) { return __length(p); }
 __SYCL_EXPORT s::cl_double length(s::cl_double2 p) { return __length(p); }
 __SYCL_EXPORT s::cl_double length(s::cl_double3 p) { return __length(p); }
 __SYCL_EXPORT s::cl_double length(s::cl_double4 p) { return __length(p); }
-__SYCL_EXPORT s::cl_half length(s::vec<half, 1> p) { return __length(p); }
+__SYCL_EXPORT s::cl_half length(s::vec<s::half, 1> p) { return __length(p); }
 __SYCL_EXPORT s::cl_half length(s::cl_half2 p) { return __length(p); }
 __SYCL_EXPORT s::cl_half length(s::cl_half3 p) { return __length(p); }
 __SYCL_EXPORT s::cl_half length(s::cl_half4 p) { return __length(p); }
@@ -197,7 +197,8 @@ __SYCL_EXPORT s::cl_double distance(s::cl_double4 p0, s::cl_double4 p1) {
 __SYCL_EXPORT s::cl_half distance(s::cl_half p0, s::cl_half p1) {
   return length(p0 - p1);
 }
-__SYCL_EXPORT s::cl_float distance(s::vec<half, 1> p0, s::vec<half, 1> p1) {
+__SYCL_EXPORT s::cl_float distance(s::vec<s::half, 1> p0,
+                                   s::vec<s::half, 1> p1) {
   return length(p0 - p1);
 }
 __SYCL_EXPORT s::cl_half distance(s::cl_half2 p0, s::cl_half2 p1) {

--- a/sycl/test/basic_tests/aliases.cpp
+++ b/sycl/test/basic_tests/aliases.cpp
@@ -26,8 +26,7 @@ namespace s = cl::sycl;
   ASSERT(s::int, int, N)                                                       \
   ASSERT(s::long, long, N)                                                     \
   ASSERT(s::float, float, N)                                                   \
-  ASSERT(s::double, double, N)                                                 \
-  ASSERT(s::half, half, N);
+  ASSERT(s::double, double, N);
 
 // cl_char, cl_uchar, cl_short, cl_ushort, cl_int, cl_uint, cl_long, cl_ulong,
 // cl_float, cl_double and cl_half

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -33,7 +33,7 @@ template <typename T> inline void checkVectorsWithN() {
 }
 
 inline void checkVectors() {
-  checkVectorsWithN<half>();
+  checkVectorsWithN<s::half>();
   checkVectorsWithN<float>();
   checkVectorsWithN<double>();
   checkVectorsWithN<char>();

--- a/sycl/test/basic_tests/vectors/vectors.cpp
+++ b/sycl/test/basic_tests/vectors/vectors.cpp
@@ -46,7 +46,7 @@ template <typename From> void check_convert_from() {
   check_signed_unsigned_convert_to<From, int>();
   check_signed_unsigned_convert_to<From, long>();
   check_signed_unsigned_convert_to<From, long long>();
-  check_signed_unsigned_convert_to<From, half>();
+  check_signed_unsigned_convert_to<From, sycl::half>();
   check_signed_unsigned_convert_to<From, float>();
   check_signed_unsigned_convert_to<From, double>();
 }
@@ -122,7 +122,7 @@ int main() {
   check_convert_from<int>();
   check_convert_from<long>();
   check_convert_from<long long>();
-  check_convert_from<half>();
+  check_convert_from<sycl::half>();
   check_convert_from<float>();
   check_convert_from<double>();
 

--- a/sycl/test/regression/isordered.cpp
+++ b/sycl/test/regression/isordered.cpp
@@ -21,8 +21,8 @@ int main() {
         double inputData_1D(0.3);
         resultPtr[1] = cl::sycl::isordered(inputData_0D, inputData_1D);
 
-        half inputData_0H(0.3);
-        half inputData_1H(0.9);
+        sycl::half inputData_0H(0.3);
+        sycl::half inputData_1H(0.9);
         resultPtr[2] = cl::sycl::isordered(inputData_0H, inputData_1H);
       });
     });

--- a/sycl/test/type_traits/integer_n_bit.cpp
+++ b/sycl/test/type_traits/integer_n_bit.cpp
@@ -31,8 +31,8 @@ using TypeList =
                  uint64_t, s::vec<int8_t, 2>, s::vec<int16_t, 2>,
                  s::vec<int32_t, 2>, s::vec<int64_t, 2>, s::vec<uint8_t, 2>,
                  s::vec<uint16_t, 2>, s::vec<uint32_t, 2>, s::vec<uint64_t, 2>,
-                 bool, float, double, half, s::vec<float, 2>, s::vec<double, 2>,
-                 s::vec<half, 2>>;
+                 bool, float, double, s::half, s::vec<float, 2>,
+                 s::vec<double, 2>, s::vec<s::half, 2>>;
 
 int main() {
   check<d::is_igeninteger8bit, TypeList,

--- a/sycl/test/type_traits/type_traits.cpp
+++ b/sycl/test/type_traits/type_traits.cpp
@@ -133,21 +133,21 @@ int main() {
   test_is_integral<s::int2>();
   test_is_integral<float, false>();
   test_is_integral<s::float2, false>();
-  test_is_integral<half, false>();
+  test_is_integral<s::half, false>();
   test_is_integral<s::half2, false>();
 
   test_is_floating_point<int, false>();
   test_is_floating_point<s::int2, false>();
   test_is_floating_point<float>();
   test_is_floating_point<s::float2>();
-  test_is_floating_point<half>();
+  test_is_floating_point<s::half>();
   test_is_floating_point<s::half2>();
 
   test_is_arithmetic<int>();
   test_is_arithmetic<s::int2>();
   test_is_arithmetic<float>();
   test_is_arithmetic<s::float2>();
-  test_is_arithmetic<half>();
+  test_is_arithmetic<s::half>();
   test_is_arithmetic<s::half2>();
 
   test_make_type_t<int, d::gtl::scalar_unsigned_int_list, unsigned int>();
@@ -155,7 +155,7 @@ int main() {
   test_make_type_t<s::cl_int3, d::gtl::scalar_unsigned_int_list, s::cl_uint3>();
   test_make_type_t<s::cl_int3, d::gtl::scalar_float_list, s::cl_float3>();
 
-  test_make_larger_t<half, float>();
+  test_make_larger_t<s::half, float>();
   test_make_larger_t<s::half3, s::float3>();
   test_make_larger_t<float, double>();
   test_make_larger_t<s::float3, s::double3>();

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -152,5 +152,9 @@ int main() {
   auto SL = sycl::INTEL::source_language::opencl_c;
   (void)SL;
 
+  // expected-warning@+1{{'half' is deprecated: use 'sycl::half' instead}}
+  half H;
+  (void)H;
+
   return 0;
 }


### PR DESCRIPTION
KhronosGroup/SYCL-Docs#40 fix was submitted.

Complementary E2E tests intel/llvm-test-suite#413
Fix to CTS KhronosGroup/SYCL-CTS#154