### PR TITLE
[SYCL] Fix free function queries for host device

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5302,10 +5302,17 @@ bool Util::isSyclFunction(const FunctionDecl *FD, StringRef Name) {
   if (DC->isTranslationUnit())
     return false;
 
-  std::array<DeclContextDesc, 2> Scopes = {
+  std::array<DeclContextDesc, 2> ScopesSycl = {
       Util::MakeDeclContextDesc(Decl::Kind::Namespace, "cl"),
       Util::MakeDeclContextDesc(Decl::Kind::Namespace, "sycl")};
-  return matchContext(DC, Scopes);
+  std::array<DeclContextDesc, 5> ScopesOneapiExp = {
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "cl"),
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "sycl"),
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "ext"),
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "oneapi"),
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "experimental")};
+
+  return matchContext(DC, ScopesSycl) || matchContext(DC, ScopesOneapiExp);
 }
 
 bool Util::isAccessorPropertyListType(QualType Ty) {

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -120,13 +120,6 @@ struct no_alias {
 } // namespace oneapi
 } // namespace ext
 
-namespace ext {
-namespace oneapi {
-template <typename... properties>
-class accessor_property_list {};
-} // namespace oneapi
-} // namespace ext
-
 template <int dim>
 struct id {
   template <typename... T>
@@ -145,6 +138,20 @@ private:
   // kernel wrapper
   int Data;
 };
+
+namespace ext {
+namespace oneapi {
+template <typename... properties>
+class accessor_property_list {};
+namespace experimental {
+template <int Dims> item<Dims>
+this_item() { return item<Dims>{}; }
+
+template <int Dims> id<Dims>
+this_id() { return id<Dims>{}; }
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
 
 template <int Dims> item<Dims>
 this_item() { return item<Dims>{}; }

--- a/clang/test/CodeGenSYCL/parallel_for_this_item.cpp
+++ b/clang/test/CodeGenSYCL/parallel_for_this_item.cpp
@@ -12,10 +12,14 @@
 // CHECK-NEXT: const char* const kernel_names[] = {
 // CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3GNU",
 // CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3EMU",
+// CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3COW",
 // CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3OWL",
 // CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3RAT",
+// CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3CAT",
 // CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3FOX",
-// CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3BEE"
+// CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3PIG",
+// CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3BEE",
+// CHECK-NEXT:   "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3DOG"
 // CHECK-NEXT: };
 
 // CHECK:template <> struct KernelInfo<GNU> {
@@ -37,6 +41,22 @@
 // CHECK-NEXT:template <> struct KernelInfo<EMU> {
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
 // CHECK-NEXT:    static constexpr const char* getName() { return "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3EMU"; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr unsigned getNumParams() { return 0; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const kernel_param_desc_t& getParamDesc(unsigned i) {
+// CHECK-NEXT:    return kernel_signatures[i+0];
+// CHECK-NEXT:  }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:  static constexpr bool isESIMD() { return 0; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsThisItem() { return 1; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 1; }
+// CHECK-NEXT:};
+// CHECK-NEXT:template <> struct KernelInfo<COW> {
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const char* getName() { return "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3COW"; }
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
 // CHECK-NEXT:    static constexpr unsigned getNumParams() { return 0; }
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
@@ -82,9 +102,41 @@
 // CHECK-NEXT: __SYCL_DLL_LOCAL
 // CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 1; }
 // CHECK-NEXT:};
+// CHECK-NEXT:template <> struct KernelInfo<CAT> {
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const char* getName() { return "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3CAT"; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr unsigned getNumParams() { return 0; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const kernel_param_desc_t& getParamDesc(unsigned i) {
+// CHECK-NEXT:    return kernel_signatures[i+0];
+// CHECK-NEXT: }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:  static constexpr bool isESIMD() { return 0; }
+// CHECK-NEXT: __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsThisItem() { return 1; }
+// CHECK-NEXT: __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 1; }
+// CHECK-NEXT:};
 // CHECK-NEXT:template <> struct KernelInfo<FOX> {
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
 // CHECK-NEXT:    static constexpr const char* getName() { return "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3FOX"; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr unsigned getNumParams() { return 0; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const kernel_param_desc_t& getParamDesc(unsigned i) {
+// CHECK-NEXT:    return kernel_signatures[i+0];
+// CHECK-NEXT: }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:  static constexpr bool isESIMD() { return 0; }
+// CHECK-NEXT: __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsThisItem() { return 0; }
+// CHECK-NEXT: __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 1; }
+// CHECK-NEXT:};
+// CHECK-NEXT:template <> struct KernelInfo<PIG> {
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const char* getName() { return "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3PIG"; }
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
 // CHECK-NEXT:    static constexpr unsigned getNumParams() { return 0; }
 // CHECK-NEXT:  __SYCL_DLL_LOCAL
@@ -114,6 +166,22 @@
 // CHECK-NEXT: __SYCL_DLL_LOCAL
 // CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 1; }
 // CHECK-NEXT:};
+// CHECK-NEXT:template <> struct KernelInfo<DOG> {
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const char* getName() { return "_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E3DOG"; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr unsigned getNumParams() { return 0; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr const kernel_param_desc_t& getParamDesc(unsigned i) {
+// CHECK-NEXT:    return kernel_signatures[i+0];
+// CHECK-NEXT:  }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool isESIMD() { return 0; }
+// CHECK-NEXT:  __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsThisItem() { return 1; }
+// CHECK-NEXT: __SYCL_DLL_LOCAL
+// CHECK-NEXT:    static constexpr bool callsAnyThisFreeFunction() { return 1; }
+// CHECK-NEXT:};
 
 #include "sycl.hpp"
 
@@ -121,6 +189,8 @@ using namespace cl::sycl;
 
 SYCL_EXTERNAL item<1> g() { return this_item<1>(); }
 SYCL_EXTERNAL item<1> f() { return g(); }
+SYCL_EXTERNAL item<1> s() { return ext::oneapi::experimental::this_item<1>(); }
+SYCL_EXTERNAL item<1> h() { return s(); }
 
 // This is a similar-looking this_item function but not the real one.
 template <int Dims> item<Dims> this_item(int i) { return item<1>{i}; }
@@ -142,6 +212,11 @@ int main() {
     cgh.parallel_for<class EMU>(range<1>(1),
                                 [=](::item<1> I) { this_item<1>(); });
 
+    // This kernel calls sycl::ext::oneapi::experimental::this_item
+    cgh.parallel_for<class COW>(range<1>(1), [=](::item<1> I) {
+      ext::oneapi::experimental::this_item<1>();
+    });
+
     // This kernel does not call sycl::this_item
     cgh.parallel_for<class OWL>(range<1>(1), [=](id<1> I) {
       class C c;
@@ -151,11 +226,24 @@ int main() {
     // This kernel calls sycl::this_item
     cgh.parallel_for<class RAT>(range<1>(1), [=](id<1> I) { f(); });
 
+    // This kernel calls sycl::ext::oneapi::experimental::this_item
+    cgh.parallel_for<class CAT>(range<1>(1), [=](id<1> I) { s(); });
+
     // This kernel does not call sycl::this_item, but does call this_id
     cgh.parallel_for<class FOX>(range<1>(1), [=](id<1> I) { this_id<1>(); });
 
+    // This kernel calls sycl::ext::oneapi::experimental::this_id
+    cgh.parallel_for<class PIG>(range<1>(1), [=](id<1> I) {
+      ext::oneapi::experimental::this_id<1>();
+    });
+
     // This kernel calls sycl::this_item
     cgh.parallel_for<class BEE>(range<1>(1), [=](auto I) { this_item<1>(); });
+
+    // This kernel calls sycl::ext::oneapi::experimental::this_item
+    cgh.parallel_for<class DOG>(range<1>(1), [=](auto I) {
+      ext::oneapi::experimental::this_item<1>();
+    });
   });
 
   return 0;

--- a/clang/test/CodeGenSYCL/parallel_for_this_item.cpp
+++ b/clang/test/CodeGenSYCL/parallel_for_this_item.cpp
@@ -227,7 +227,7 @@ int main() {
     cgh.parallel_for<class RAT>(range<1>(1), [=](id<1> I) { f(); });
 
     // This kernel calls sycl::ext::oneapi::experimental::this_item
-    cgh.parallel_for<class CAT>(range<1>(1), [=](id<1> I) { s(); });
+    cgh.parallel_for<class CAT>(range<1>(1), [=](id<1> I) { h(); });
 
     // This kernel does not call sycl::this_item, but does call this_id
     cgh.parallel_for<class FOX>(range<1>(1), [=](id<1> I) { this_id<1>(); });


### PR DESCRIPTION
https://github.com/intel/llvm/pull/4090 moved free function queries to a different namespace. Host device implementation actually relies on integration header to extract information about free function queries and set the appropriate values.