### PR TITLE
[SYCL] Fix SYCL config processing for DPC++ RT

### DIFF
--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -33,9 +33,6 @@ namespace detail {
 #include "detail/config.def"
 #undef CONFIG
 
-constexpr int MAX_CONFIG_NAME = 256;
-constexpr int MAX_CONFIG_VALUE = 256;
-
 static void initValue(const char *Key, const char *Value) {
 #define CONFIG(Name, MaxSize, CompileTimeDef)                                  \
   if (0 == strncmp(Key, SYCLConfigBase<Name>::MConfigName, MAX_CONFIG_NAME)) { \

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -33,7 +33,8 @@ namespace detail {
 #include "detail/config.def"
 #undef CONFIG
 
-#define MAX_CONFIG_NAME 256
+constexpr int MAX_CONFIG_NAME = 256;
+constexpr int MAX_CONFIG_VALUE = 256;
 
 static void initValue(const char *Key, const char *Value) {
 #define CONFIG(Name, MaxSize, CompileTimeDef)                                  \
@@ -62,8 +63,7 @@ void readConfig() {
   }
 
   if (File.is_open()) {
-    // TODO: Use max size from macro instead of 256
-    char Key[MAX_CONFIG_NAME] = {0}, Value[256] = {0};
+    char Key[MAX_CONFIG_NAME] = {0}, Value[MAX_CONFIG_VALUE] = {0};
     std::string BufString;
     std::size_t Position = std::string::npos;
     while (!File.eof()) {
@@ -73,38 +73,61 @@ void readConfig() {
       // TODO: Skip spaces before and after '='
       std::getline(File, BufString);
       if (File.fail()) {
+        // Fail to process the line.
         File.clear(File.rdstate() & ~std::ios_base::failbit);
         File.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         throw sycl::exception(
             make_error_code(errc::runtime),
-            "An error occurred on the execution of getline().");
+            "An error occurred while attempting to read a line");
       }
+      // Skip lines with a length = 0 | which have a comment | don't have "="
       if ((BufString.length() == 0) ||
           (BufString.find("#") != std::string::npos) ||
           (BufString.find("=") == std::string::npos)) {
         continue;
       }
+      // Finding the position of '='
       Position = BufString.find("=");
+      // Checking that the variable name is less than MAX_CONFIG_NAME and more
+      // than zero character
       if ((Position <= MAX_CONFIG_NAME) && (Position > 0)) {
-        if ((BufString.length() - (Position + 1) <= 256) &&
+        // Checking for spaces at the beginning and end of the line,
+        // before and after '='
+        if ((BufString[0] == ' ') ||
+            (BufString[BufString.length() - 1] == ' ') ||
+            (BufString[Position - 1] == ' ') ||
+            (BufString[Position + 1] == ' ')) {
+          throw sycl::exception(make_error_code(errc::runtime),
+                                "SPACE found at the beginning/end of the line "
+                                "or before/after '='");
+        }
+        // Checking that the value is less than MAX_CONFIG_VALUE and
+        // more than zero character
+        if ((BufString.length() - (Position + 1) <= MAX_CONFIG_VALUE) &&
             (BufString.length() != Position + 1)) {
+          // Creating pairs of (key, value)
           BufString.copy(Key, Position, 0);
           Key[Position] = '\0';
-          BufString.copy(Value, BufString.length() - Position - 1,
+          BufString.copy(Value, BufString.length() - (Position + 1),
                          Position + 1);
-          Value[BufString.length() - Position - 1] = '\0';
+          Value[BufString.length() - (Position + 1)] = '\0';
         } else {
-          throw sycl::exception(make_error_code(errc::runtime),
-                                "The value contains more than 256 characters "
-                                "or does not contain them at all.");
+          throw sycl::exception(
+              make_error_code(errc::runtime),
+              "The value contains more than " +
+                  std::to_string(MAX_CONFIG_VALUE) +
+                  " characters or does not contain them at all");
         }
       } else {
-        throw sycl::exception(
-            make_error_code(errc::runtime),
-            "Variable name is more than 256 or less than one character.");
+        throw sycl::exception(make_error_code(errc::runtime),
+                              "Variable name is more than " +
+                                  std::to_string(MAX_CONFIG_NAME) +
+                                  " or less than one character");
       }
+      // Handle '\r' by nullifying it
       if ('\r' == Value[BufString.length() - Position - 3])
         Value[BufString.length() - Position - 3] = '\0';
+
       initValue(Key, Value);
     }
   }

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -159,6 +159,6 @@ void dumpConfig() {
 #undef CONFIG
 }
 
-} // namespace detail
-} // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
+} // namespace sycl
+} // namespace detail

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -72,7 +72,7 @@ void readConfig() {
       // ConfigName=Value
       // TODO: Skip spaces before and after '='
       std::getline(File, BufString);
-      if (File.fail()) {
+      if  (File.fail() && !File.eof()) {
         // Fail to process the line.
         File.clear(File.rdstate() & ~std::ios_base::failbit);
         File.ignore(std::numeric_limits<std::streamsize>::max(), '\n');

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -72,7 +72,7 @@ void readConfig() {
       // ConfigName=Value
       // TODO: Skip spaces before and after '='
       std::getline(File, BufString);
-      if  (File.fail() && !File.eof()) {
+      if (File.fail() && !File.eof()) {
         // Fail to process the line.
         File.clear(File.rdstate() & ~std::ios_base::failbit);
         File.ignore(std::numeric_limits<std::streamsize>::max(), '\n');

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -43,6 +43,9 @@ constexpr bool ConfigFromCompileDefEnabled = false;
 constexpr bool ConfigFromCompileDefEnabled = true;
 #endif // DISABLE_CONFIG_FROM_COMPILE_TIME
 
+constexpr int MAX_CONFIG_NAME = 256;
+constexpr int MAX_CONFIG_VALUE = 256;
+
 // Enum of config IDs for accessing other arrays
 enum ConfigID {
   START = 0,

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -58,7 +58,7 @@ constexpr const char *getStrOrNullptr(const char *Str) {
 }
 
 // Intializes configs from the configuration file
-void readConfig();
+void readConfig(bool ForceInitialization = false);
 
 template <ConfigID Config> class SYCLConfigBase;
 

--- a/sycl/test/regression/check_config_processing.cpp
+++ b/sycl/test/regression/check_config_processing.cpp
@@ -1,35 +1,8 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 //
-// RUN: env TEST=SPACE_AT_FIRST_POSITION %t.out > %t1.conf
-// RUN: env TEST=EXCESS_SPACE env SYCL_CONFIG_FILE_NAME=%t1.conf %t.out
-//
-// RUN: env TEST=SPACE_AT_LAST_POSITION %t.out > %t2.conf
-// RUN: env TEST=EXCESS_SPACE env SYCL_CONFIG_FILE_NAME=%t2.conf %t.out
-//
-// RUN: env TEST=SPACE_BEFORE_ASSIGNMENT %t.out > %t3.conf
-// RUN: env TEST=EXCESS_SPACE env SYCL_CONFIG_FILE_NAME=%t3.conf %t.out
-//
-// RUN: env TEST=SPACE_AFTER_ASSIGNMENT %t.out > %t4.conf
-// RUN: env TEST=EXCESS_SPACE env SYCL_CONFIG_FILE_NAME=%t4.conf %t.out
-//
-// RUN: env TEST=VARIABLE_NAME_BIGGER_THAN_MAX_CONFIG_NAME %t.out > %t5.conf
-// RUN: env TEST=INCORRECT_VARIABLE_NAME env SYCL_CONFIG_FILE_NAME=%t5.conf %t.out
-//
-// RUN: env TEST=VARIABLE_WITHOUT_NAME %t.out > %t6.conf
-// RUN: env TEST=INCORRECT_VARIABLE_NAME env SYCL_CONFIG_FILE_NAME=%t6.conf %t.out
-//
-// RUN: env TEST=VARIABLE_VALUE_BIGGER_THAN_MAX_CONFIG_VALUE %t.out > %t7.conf
-// RUN: env TEST=INCORRECT_VARIABLE_VALUE env SYCL_CONFIG_FILE_NAME=%t7.conf %t.out
-//
-// RUN: env TEST=VARIABLE_WITHOUT_VALUE %t.out > %t8.conf
-// RUN: env TEST=INCORRECT_VARIABLE_VALUE env SYCL_CONFIG_FILE_NAME=%t8.conf %t.out
-//
-// RUN: env TEST=COMPLEX_CONFIG %t.out > %t9.conf
-// RUN: env TEST=INCORRECT_VARIABLE_VALUE env SYCL_CONFIG_FILE_NAME=%t9.conf %t.out
-//
-// RUN: env TEST=SET_CORRECT_ENVIRONMENT %t.out > %t10.conf
-// RUN: env TEST=CORRECT_CONFIG_FILE env SYCL_CONFIG_FILE_NAME=%t10.conf %t.out
-// RUN: ls | grep dot
+// RUN: env TEST=SET_CORRECT_ENVIRONMENT %t.out > %t.conf
+// RUN: env TEST=CORRECT_CONFIG_FILE env SYCL_CONFIG_FILE_NAME=%t.conf %t.out
+// RUN: ls *.dot
 // RUN: rm *.dot
 
 #include <CL/sycl.hpp>
@@ -37,118 +10,20 @@
 #include <regex>
 
 int main() {
-  std::string testEnvVarValue;
-  if (getenv("TEST")) {
-    testEnvVarValue = getenv("TEST");
-  } else {
-    throw sycl::exception(sycl::make_error_code(sycl::errc::runtime),
-                          "Environment is not found");
-  }
+  std::string testEnvVarValue = getenv("TEST");
 
   // Сonfig creation
-  if (testEnvVarValue == "SPACE_AT_FIRST_POSITION") {
-    std::cout << " a=b" << std::endl;
-    return 0;
-  }
-  if (testEnvVarValue == "SPACE_AT_LAST_POSITION") {
-    std::cout << "a=b " << std::endl;
-    return 0;
-  }
-  if (testEnvVarValue == "SPACE_BEFORE_ASSIGNMENT") {
-    std::cout << "a =b" << std::endl;
-    return 0;
-  }
-  if (testEnvVarValue == "SPACE_AFTER_ASSIGNMENT") {
-    std::cout << "a= b" << std::endl;
-    return 0;
-  }
-  if (testEnvVarValue == "VARIABLE_NAME_BIGGER_THAN_MAX_CONFIG_NAME") {
-    // Max variable name is 256 characters
-    for (int i = 0; i <= 256; i++)
-      std::cout << "a";
-    std::cout << "=b" << std::endl;
-    return 0;
-  }
-  if (testEnvVarValue == "VARIABLE_WITHOUT_NAME") {
-    std::cout << "=b" << std::endl;
-    return 0;
-  }
-  if (testEnvVarValue == "VARIABLE_VALUE_BIGGER_THAN_MAX_CONFIG_VALUE") {
-    // Max variable value contains 256 or 1024 characters
-    std::cout << "a=";
-    for (int i = 0; i <= 1024; i++)
-      std::cout << "b";
-    std::cout << std::endl;
-    return 0;
-  }
-  if (testEnvVarValue == "VARIABLE_WITHOUT_VALUE") {
-    std::cout << "a=" << std::endl;
-    return 0;
-  }
-  if (testEnvVarValue == "COMPLEX_CONFIG") {
-    // To check that the processing reaches "a="
-    std::cout << "#\n"
-              << "  #\n"
-              << "#a=b"
-              << "\n\n\n"
-              << "a\n"
-              << " aaa \n"
-              << "a=b\n"
-              << "a=\n"
-              << std::endl;
-    return 0;
-  }
   if (testEnvVarValue == "SET_CORRECT_ENVIRONMENT") {
     std::cout << "#\n"
               << "#abc\n"
               << "# abc = cba \r\n"
               << "\r\n"
-              << "SYCL_PRINT_EXECUTION_GRAPH=always" << std::endl;
+              << "SYCL_PRINT_EXECUTION_GRAPH=always\r\n"
+              << std::endl;
     return 0;
   }
 
   // Config check
-  if (testEnvVarValue == "EXCESS_SPACE") {
-    try {
-      auto device = sycl::device{sycl::default_selector{}};
-    } catch (sycl::exception &e) {
-      std::string errorMessage = e.what();
-      if (errorMessage ==
-          "SPACE found at the beginning/end of the line or before/after '='") {
-        return 0;
-      } else {
-        throw e;
-      }
-    }
-  }
-  if (testEnvVarValue == "INCORRECT_VARIABLE_NAME") {
-    try {
-      auto device = sycl::device{sycl::default_selector{}};
-    } catch (sycl::exception &e) {
-      std::string errorMessage = e.what();
-      std::regex regular(
-          "Variable name is more than ([\\d]+) or less than one character");
-      if (std::regex_match(errorMessage, regular)) {
-        return 0;
-      } else {
-        throw e;
-      }
-    }
-  }
-  if (testEnvVarValue == "INCORRECT_VARIABLE_VALUE") {
-    try {
-      auto device = sycl::device{sycl::default_selector{}};
-    } catch (sycl::exception &e) {
-      std::string errorMessage = e.what();
-      std::regex regular("The value contains more than ([\\d]+) characters or "
-                         "does not contain them at all");
-      if (std::regex_match(errorMessage, regular)) {
-        return 0;
-      } else {
-        throw e;
-      }
-    }
-  }
   if (testEnvVarValue == "CORRECT_CONFIG_FILE") {
     sycl::buffer<int, 1> Buf(sycl::range<1>{1});
     auto Acc = Buf.get_access<sycl::access::mode::read>();

--- a/sycl/test/regression/check_config_processing.cpp
+++ b/sycl/test/regression/check_config_processing.cpp
@@ -1,0 +1,158 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+//
+// RUN: env TEST=SPACE_AT_FIRST_POSITION %t.out > %t1.conf
+// RUN: env TEST=EXCESS_SPACE env SYCL_CONFIG_FILE_NAME=%t1.conf %t.out
+//
+// RUN: env TEST=SPACE_AT_LAST_POSITION %t.out > %t2.conf
+// RUN: env TEST=EXCESS_SPACE env SYCL_CONFIG_FILE_NAME=%t2.conf %t.out
+//
+// RUN: env TEST=SPACE_BEFORE_ASSIGNMENT %t.out > %t3.conf
+// RUN: env TEST=EXCESS_SPACE env SYCL_CONFIG_FILE_NAME=%t3.conf %t.out
+//
+// RUN: env TEST=SPACE_AFTER_ASSIGNMENT %t.out > %t4.conf
+// RUN: env TEST=EXCESS_SPACE env SYCL_CONFIG_FILE_NAME=%t4.conf %t.out
+//
+// RUN: env TEST=VARIABLE_NAME_BIGGER_THAN_MAX_CONFIG_NAME %t.out > %t5.conf
+// RUN: env TEST=INCORRECT_VARIABLE_NAME env SYCL_CONFIG_FILE_NAME=%t5.conf %t.out
+//
+// RUN: env TEST=VARIABLE_WITHOUT_NAME %t.out > %t6.conf
+// RUN: env TEST=INCORRECT_VARIABLE_NAME env SYCL_CONFIG_FILE_NAME=%t6.conf %t.out
+//
+// RUN: env TEST=VARIABLE_VALUE_BIGGER_THAN_MAX_CONFIG_VALUE %t.out > %t7.conf
+// RUN: env TEST=INCORRECT_VARIABLE_VALUE env SYCL_CONFIG_FILE_NAME=%t7.conf %t.out
+//
+// RUN: env TEST=VARIABLE_WITHOUT_VALUE %t.out > %t8.conf
+// RUN: env TEST=INCORRECT_VARIABLE_VALUE env SYCL_CONFIG_FILE_NAME=%t8.conf %t.out
+//
+// RUN: env TEST=COMPLEX_CONFIG %t.out > %t9.conf
+// RUN: env TEST=INCORRECT_VARIABLE_VALUE env SYCL_CONFIG_FILE_NAME=%t9.conf %t.out
+//
+// RUN: env TEST=SET_CORRECT_ENVIRONMENT %t.out > %t10.conf
+// RUN: env TEST=CORRECT_CONFIG_FILE env SYCL_CONFIG_FILE_NAME=%t10.conf %t.out
+// RUN: ls | grep dot
+// RUN: rm *.dot
+
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <regex>
+
+int main() {
+  std::string testEnvVarValue;
+  if (getenv("TEST")) {
+    testEnvVarValue = getenv("TEST");
+  } else {
+    throw sycl::exception(sycl::make_error_code(sycl::errc::runtime),
+                          "Environment is not found");
+  }
+
+  // Сonfig creation
+  if (testEnvVarValue == "SPACE_AT_FIRST_POSITION") {
+    std::cout << " a=b" << std::endl;
+    return 0;
+  }
+  if (testEnvVarValue == "SPACE_AT_LAST_POSITION") {
+    std::cout << "a=b " << std::endl;
+    return 0;
+  }
+  if (testEnvVarValue == "SPACE_BEFORE_ASSIGNMENT") {
+    std::cout << "a =b" << std::endl;
+    return 0;
+  }
+  if (testEnvVarValue == "SPACE_AFTER_ASSIGNMENT") {
+    std::cout << "a= b" << std::endl;
+    return 0;
+  }
+  if (testEnvVarValue == "VARIABLE_NAME_BIGGER_THAN_MAX_CONFIG_NAME") {
+    // Max variable name is 256 characters
+    for (int i = 0; i <= 256; i++)
+      std::cout << "a";
+    std::cout << "=b" << std::endl;
+    return 0;
+  }
+  if (testEnvVarValue == "VARIABLE_WITHOUT_NAME") {
+    std::cout << "=b" << std::endl;
+    return 0;
+  }
+  if (testEnvVarValue == "VARIABLE_VALUE_BIGGER_THAN_MAX_CONFIG_VALUE") {
+    // Max variable value contains 256 or 1024 characters
+    std::cout << "a=";
+    for (int i = 0; i <= 1024; i++)
+      std::cout << "b";
+    std::cout << std::endl;
+    return 0;
+  }
+  if (testEnvVarValue == "VARIABLE_WITHOUT_VALUE") {
+    std::cout << "a=" << std::endl;
+    return 0;
+  }
+  if (testEnvVarValue == "COMPLEX_CONFIG") {
+    // To check that the processing reaches "a="
+    std::cout << "#\n"
+              << "  #\n"
+              << "#a=b"
+              << "\n\n\n"
+              << "a\n"
+              << " aaa \n"
+              << "a=b\n"
+              << "a=\n"
+              << std::endl;
+    return 0;
+  }
+  if (testEnvVarValue == "SET_CORRECT_ENVIRONMENT") {
+    std::cout << "#\n"
+              << "#abc\n"
+              << "# abc = cba \r\n"
+              << "\r\n"
+              << "SYCL_PRINT_EXECUTION_GRAPH=always" << std::endl;
+    return 0;
+  }
+
+  // Config check
+  if (testEnvVarValue == "EXCESS_SPACE") {
+    try {
+      auto device = sycl::device{sycl::default_selector{}};
+    } catch (sycl::exception &e) {
+      std::string errorMessage = e.what();
+      if (errorMessage ==
+          "SPACE found at the beginning/end of the line or before/after '='") {
+        return 0;
+      } else {
+        throw e;
+      }
+    }
+  }
+  if (testEnvVarValue == "INCORRECT_VARIABLE_NAME") {
+    try {
+      auto device = sycl::device{sycl::default_selector{}};
+    } catch (sycl::exception &e) {
+      std::string errorMessage = e.what();
+      std::regex regular(
+          "Variable name is more than ([\\d]+) or less than one character");
+      if (std::regex_match(errorMessage, regular)) {
+        return 0;
+      } else {
+        throw e;
+      }
+    }
+  }
+  if (testEnvVarValue == "INCORRECT_VARIABLE_VALUE") {
+    try {
+      auto device = sycl::device{sycl::default_selector{}};
+    } catch (sycl::exception &e) {
+      std::string errorMessage = e.what();
+      std::regex regular("The value contains more than ([\\d]+) characters or "
+                         "does not contain them at all");
+      if (std::regex_match(errorMessage, regular)) {
+        return 0;
+      } else {
+        throw e;
+      }
+    }
+  }
+  if (testEnvVarValue == "CORRECT_CONFIG_FILE") {
+    sycl::buffer<int, 1> Buf(sycl::range<1>{1});
+    auto Acc = Buf.get_access<sycl::access::mode::read>();
+    return 0;
+  }
+  throw std::logic_error("Environment is incorrect");
+}

--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -10,6 +10,7 @@ endforeach()
 include(AddSYCLUnitTest)
 
 add_subdirectory(allowlist)
+add_subdirectory(config)
 add_subdirectory(misc)
 add_subdirectory(pi)
 add_subdirectory(kernel-and-program)

--- a/sycl/unittests/config/CMakeLists.txt
+++ b/sycl/unittests/config/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Enable exception handling for these unit tests
+set(LLVM_REQUIRES_EH 1)
+add_sycl_unittest(ConfigTests OBJECT 
+    ConfigTests.cpp
+)

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -93,7 +93,7 @@ TEST(ConfigTests, CheckConfigProcessing) {
   // Check variable name bigger than MAX_CONFIG_NAME
   File.open("conf.txt");
   if (File.is_open()) {
-    for (int i = 0; i <= 256; i++) {
+    for (int i = 0; i <= sycl::detail::MAX_CONFIG_NAME; i++) {
       File << "a";
     }
     File << "=b" << std::endl;
@@ -132,7 +132,7 @@ TEST(ConfigTests, CheckConfigProcessing) {
   File.open("conf.txt");
   if (File.is_open()) {
     File << "a=";
-    for (int i = 0; i <= 1024; i++) {
+    for (int i = 0; i <= sycl::detail::MAX_CONFIG_VALUE; i++) {
       File << "b";
     }
     File << std::endl;

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -186,46 +186,46 @@ TEST(ConfigTests, CheckConfigProcessing) {
   // Check simple correct config processing
   File.open("conf.txt");
   if (File.is_open()) {
-    File << "SYCL_DEVICE_ALLOWLIST=1" << std::endl;
+    File << "SYCL_PRINT_EXECUTION_GRAPH=before_addCG" << std::endl;
     File.close();
   }
   sycl::detail::readConfig(true);
-  EXPECT_EQ(
-      std::string("1"),
-      sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
+  EXPECT_EQ(std::string("before_addCG"),
+            sycl::detail::SYCLConfig<
+                sycl::detail::SYCL_PRINT_EXECUTION_GRAPH>::get());
 
   // Check correct config processing
   File.open("conf.txt");
   if (File.is_open()) {
     File << "#a\r\n # b \r\n #a=b\r\n # a = "
-            "b\r\n\r\nSYCL_DEVICE_ALLOWLIST=2\r\n"
+            "b\r\n\r\nSYCL_PRINT_EXECUTION_GRAPH=after_addCG\r\n"
          << std::endl;
     File.close();
   }
   sycl::detail::readConfig(true);
-  EXPECT_EQ(
-      std::string("2"),
-      sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
+  EXPECT_EQ(std::string("after_addCG"),
+            sycl::detail::SYCLConfig<
+                sycl::detail::SYCL_PRINT_EXECUTION_GRAPH>::get());
 
   // Check multi assignment
   File.open("conf.txt");
   if (File.is_open()) {
-    File << "a=b\r\nb=c\nSYCL_DEVICE_ALLOWLIST=3\r\nc=d";
+    File << "a=b\r\nb=c\nSYCL_PRINT_EXECUTION_GRAPH=before_addCopyBack\r\nc=d";
     File.close();
   }
   sycl::detail::readConfig(true);
-  EXPECT_EQ(
-      std::string("3"),
-      sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
+  EXPECT_EQ(std::string("before_addCopyBack"),
+            sycl::detail::SYCLConfig<
+                sycl::detail::SYCL_PRINT_EXECUTION_GRAPH>::get());
 
   // Check assignment with comment
   File.open("conf.txt");
   if (File.is_open()) {
-    File << "SYCL_DEVICE_ALLOWLIST=4 #comment\r\n";
+    File << "SYCL_PRINT_EXECUTION_GRAPH=after_addCopyBack #comment\r\n";
     File.close();
   }
   sycl::detail::readConfig(true);
-  EXPECT_EQ(
-      std::string("4"),
-      sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
+  EXPECT_EQ(std::string("after_addCopyBack"),
+            sycl::detail::SYCLConfig<
+                sycl::detail::SYCL_PRINT_EXECUTION_GRAPH>::get());
 }

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -10,13 +10,20 @@
 #include <gtest/gtest.h>
 #include <regex>
 
-TEST(ConfigTests, CheckSpaceAtFirstPosition) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << " a=b" << std::endl;
-    file.close();
-  }
+TEST(ConfigTests, CheckConfigProcessing) {
+#ifdef _WIN32
+  _putenv_s("SYCL_CONFIG_FILE_NAME", "conf.txt");
+#else
   setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+#endif
+
+  // Check SPACE at first position
+  std::ofstream File;
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << " a=b" << std::endl;
+    File.close();
+  }
   try {
     sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
     throw std::logic_error("sycl::exception didn't throw");
@@ -26,17 +33,15 @@ TEST(ConfigTests, CheckSpaceAtFirstPosition) {
             "SPACE found at the beginning/end of the line or before/after '='"),
         e.what());
   } catch (...) {
-    FAIL() << "Expected sycl::exception";
+    FAIL() << "Check SPACE at first position failed";
   }
-}
 
-TEST(ConfigTests, CheckSpaceAtLastPosition) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "a=b " << std::endl;
-    file.close();
+  // Check SPACE at last position
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "a=b " << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   try {
     sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
     throw std::logic_error("sycl::exception didn't throw");
@@ -46,17 +51,15 @@ TEST(ConfigTests, CheckSpaceAtLastPosition) {
             "SPACE found at the beginning/end of the line or before/after '='"),
         e.what());
   } catch (...) {
-    FAIL() << "Expected sycl::exception";
+    FAIL() << "Check SPACE at last position failed";
   }
-}
 
-TEST(ConfigTests, CheckSpaceBeforeAssignment) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "a =b" << std::endl;
-    file.close();
+  // Check SPACE before assignment
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "a =b" << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   try {
     sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
     throw std::logic_error("sycl::exception didn't throw");
@@ -66,17 +69,15 @@ TEST(ConfigTests, CheckSpaceBeforeAssignment) {
             "SPACE found at the beginning/end of the line or before/after '='"),
         e.what());
   } catch (...) {
-    FAIL() << "Expected sycl::exception";
+    FAIL() << "Check SPACE before assignment failed";
   }
-}
 
-TEST(ConfigTests, CheckSpaceAfterAssignment) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "a= b" << std::endl;
-    file.close();
+  // Check SPACE after assignment
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "a= b" << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   try {
     sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
     throw std::logic_error("sycl::exception didn't throw");
@@ -86,20 +87,18 @@ TEST(ConfigTests, CheckSpaceAfterAssignment) {
             "SPACE found at the beginning/end of the line or before/after '='"),
         e.what());
   } catch (...) {
-    FAIL() << "Expected sycl::exception";
+    FAIL() << "Check SPACE after assignment failed";
   }
-}
 
-TEST(ConfigTests, CheckVariableNameBiggerThanMaxConfigName) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
+  // Check variable name bigger than MAX_CONFIG_NAME
+  File.open("conf.txt");
+  if (File.is_open()) {
     for (int i = 0; i <= 256; i++) {
-      file << "a";
+      File << "a";
     }
-    file << "=b" << std::endl;
-    file.close();
+    File << "=b" << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   try {
     sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
     throw std::logic_error("sycl::exception didn't throw");
@@ -109,41 +108,36 @@ TEST(ConfigTests, CheckVariableNameBiggerThanMaxConfigName) {
         std::regex(
             "Variable name is more than ([\\d]+) or less than one character")));
   } catch (...) {
-    FAIL() << "Expected sycl::exception";
+    FAIL() << "Check variable name bigger than MAX_CONFIG_NAME failed";
   }
-}
 
-TEST(ConfigTests, CheckVariableWithoutName) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "=b" << std::endl;
-    file.close();
+  // Check variable without name
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "=b" << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   try {
     sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
     throw std::logic_error("sycl::exception didn't throw");
   } catch (sycl::exception &e) {
     EXPECT_TRUE(std::regex_match(
-        e.what(),
-        std::regex(
-            "Variable name is more than ([\\d]+) or less than one character")));
+        e.what(), std::regex("Variable name is more than ([\\d]+) or less "
+                             "than one character")));
   } catch (...) {
-    FAIL() << "Expected sycl::exception";
+    FAIL() << "Check variable without name failed";
   }
-}
 
-TEST(ConfigTests, CheckVariableValueBiggerThanMaxConfigValue) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "a=";
+  // Check variable value bigger than MAX_CONFIG_VALUE
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "a=";
     for (int i = 0; i <= 1024; i++) {
-      file << "b";
+      File << "b";
     }
-    file << std::endl;
-    file.close();
+    File << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   try {
     sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
     throw std::logic_error("sycl::exception didn't throw");
@@ -152,17 +146,15 @@ TEST(ConfigTests, CheckVariableValueBiggerThanMaxConfigValue) {
         e.what(), std::regex("The value contains more than ([\\d]+) characters "
                              "or does not contain them at all")));
   } catch (...) {
-    FAIL() << "Expected sycl::exception";
+    FAIL() << "Check variable value bigger than MAX_CONFIG_VALUE failed";
   }
-}
 
-TEST(ConfigTests, CheckVariableWithoutValue) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "a=" << std::endl;
-    file.close();
+  // Check variable without value
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "a=" << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   try {
     sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
     throw std::logic_error("sycl::exception didn't throw");
@@ -171,17 +163,15 @@ TEST(ConfigTests, CheckVariableWithoutValue) {
         e.what(), std::regex("The value contains more than ([\\d]+) characters "
                              "or does not contain them at all")));
   } catch (...) {
-    FAIL() << "Expected sycl::exception";
+    FAIL() << "Check variable without value failed";
   }
-}
 
-TEST(ConfigTests, CheckIncorrectComplexConfigProcessing) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "#\n   #\r\n#a=b\n\n\na\r\n aaa \r\na=b\r\na=\r" << std::endl;
-    file.close();
+  // Check incorrect complex config processing
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "#\n   #\r\n#a=b\n\n\na\r\n aaa \r\na=b\r\na=\r" << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   try {
     sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
     throw std::logic_error("sycl::exception didn't throw");
@@ -190,58 +180,50 @@ TEST(ConfigTests, CheckIncorrectComplexConfigProcessing) {
         e.what(), std::regex("The value contains more than ([\\d]+) characters "
                              "or does not contain them at all")));
   } catch (...) {
-    FAIL() << "Expected sycl::exception";
+    FAIL() << "Check incorrect complex config processing failed";
   }
-}
 
-TEST(ConfigTests, CheckSimpleCorrectConfigProcessing) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "SYCL_DEVICE_ALLOWLIST=1" << std::endl;
-    file.close();
+  // Check simple correct config processing
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "SYCL_DEVICE_ALLOWLIST=1" << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   sycl::detail::readConfig(true);
   EXPECT_EQ(
       std::string("1"),
       sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
-}
 
-TEST(ConfigTests, CheckCorrectConfigProcessing) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file
-        << "#a\r\n # b \r\n #a=b\r\n # a = b\r\n\r\nSYCL_DEVICE_ALLOWLIST=2\r\n"
-        << std::endl;
-    file.close();
+  // Check correct config processing
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "#a\r\n # b \r\n #a=b\r\n # a = "
+            "b\r\n\r\nSYCL_DEVICE_ALLOWLIST=2\r\n"
+         << std::endl;
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   sycl::detail::readConfig(true);
   EXPECT_EQ(
       std::string("2"),
       sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
-}
 
-TEST(ConfigTests, CheckMultiAssignment) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "a=b\r\nb=c\nSYCL_DEVICE_ALLOWLIST=3\r\nc=d";
-    file.close();
+  // Check multi assignment
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "a=b\r\nb=c\nSYCL_DEVICE_ALLOWLIST=3\r\nc=d";
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   sycl::detail::readConfig(true);
   EXPECT_EQ(
       std::string("3"),
       sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
-}
 
-TEST(ConfigTests, CheckAssignmentWithComment) {
-  std::ofstream file("conf.txt");
-  if (file.is_open()) {
-    file << "SYCL_DEVICE_ALLOWLIST=4 #comment\r\n";
-    file.close();
+  // Check assignment with comment
+  File.open("conf.txt");
+  if (File.is_open()) {
+    File << "SYCL_DEVICE_ALLOWLIST=4 #comment\r\n";
+    File.close();
   }
-  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
   sycl::detail::readConfig(true);
   EXPECT_EQ(
       std::string("4"),

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -1,0 +1,249 @@
+//==------- ConfigTests.cpp --- SYCL config processing unit test -----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <detail/config.hpp>
+#include <gtest/gtest.h>
+#include <regex>
+
+TEST(ConfigTests, CheckSpaceAtFirstPosition) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << " a=b" << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  try {
+    sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
+    throw std::logic_error("sycl::exception didn't throw");
+  } catch (sycl::exception &e) {
+    EXPECT_EQ(
+        std::string(
+            "SPACE found at the beginning/end of the line or before/after '='"),
+        e.what());
+  } catch (...) {
+    FAIL() << "Expected sycl::exception";
+  }
+}
+
+TEST(ConfigTests, CheckSpaceAtLastPosition) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "a=b " << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  try {
+    sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
+    throw std::logic_error("sycl::exception didn't throw");
+  } catch (sycl::exception &e) {
+    EXPECT_EQ(
+        std::string(
+            "SPACE found at the beginning/end of the line or before/after '='"),
+        e.what());
+  } catch (...) {
+    FAIL() << "Expected sycl::exception";
+  }
+}
+
+TEST(ConfigTests, CheckSpaceBeforeAssignment) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "a =b" << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  try {
+    sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
+    throw std::logic_error("sycl::exception didn't throw");
+  } catch (sycl::exception &e) {
+    EXPECT_EQ(
+        std::string(
+            "SPACE found at the beginning/end of the line or before/after '='"),
+        e.what());
+  } catch (...) {
+    FAIL() << "Expected sycl::exception";
+  }
+}
+
+TEST(ConfigTests, CheckSpaceAfterAssignment) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "a= b" << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  try {
+    sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
+    throw std::logic_error("sycl::exception didn't throw");
+  } catch (sycl::exception &e) {
+    EXPECT_EQ(
+        std::string(
+            "SPACE found at the beginning/end of the line or before/after '='"),
+        e.what());
+  } catch (...) {
+    FAIL() << "Expected sycl::exception";
+  }
+}
+
+TEST(ConfigTests, CheckVariableNameBiggerThanMaxConfigName) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    for (int i = 0; i <= 256; i++) {
+      file << "a";
+    }
+    file << "=b" << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  try {
+    sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
+    throw std::logic_error("sycl::exception didn't throw");
+  } catch (sycl::exception &e) {
+    EXPECT_TRUE(std::regex_match(
+        e.what(),
+        std::regex(
+            "Variable name is more than ([\\d]+) or less than one character")));
+  } catch (...) {
+    FAIL() << "Expected sycl::exception";
+  }
+}
+
+TEST(ConfigTests, CheckVariableWithoutName) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "=b" << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  try {
+    sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
+    throw std::logic_error("sycl::exception didn't throw");
+  } catch (sycl::exception &e) {
+    EXPECT_TRUE(std::regex_match(
+        e.what(),
+        std::regex(
+            "Variable name is more than ([\\d]+) or less than one character")));
+  } catch (...) {
+    FAIL() << "Expected sycl::exception";
+  }
+}
+
+TEST(ConfigTests, CheckVariableValueBiggerThanMaxConfigValue) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "a=";
+    for (int i = 0; i <= 1024; i++) {
+      file << "b";
+    }
+    file << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  try {
+    sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
+    throw std::logic_error("sycl::exception didn't throw");
+  } catch (sycl::exception &e) {
+    EXPECT_TRUE(std::regex_match(
+        e.what(), std::regex("The value contains more than ([\\d]+) characters "
+                             "or does not contain them at all")));
+  } catch (...) {
+    FAIL() << "Expected sycl::exception";
+  }
+}
+
+TEST(ConfigTests, CheckVariableWithoutValue) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "a=" << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  try {
+    sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
+    throw std::logic_error("sycl::exception didn't throw");
+  } catch (sycl::exception &e) {
+    EXPECT_TRUE(std::regex_match(
+        e.what(), std::regex("The value contains more than ([\\d]+) characters "
+                             "or does not contain them at all")));
+  } catch (...) {
+    FAIL() << "Expected sycl::exception";
+  }
+}
+
+TEST(ConfigTests, CheckIncorrectComplexConfigProcessing) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "#\n   #\r\n#a=b\n\n\na\r\n aaa \r\na=b\r\na=\r" << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  try {
+    sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get();
+    throw std::logic_error("sycl::exception didn't throw");
+  } catch (sycl::exception &e) {
+    EXPECT_TRUE(std::regex_match(
+        e.what(), std::regex("The value contains more than ([\\d]+) characters "
+                             "or does not contain them at all")));
+  } catch (...) {
+    FAIL() << "Expected sycl::exception";
+  }
+}
+
+TEST(ConfigTests, CheckSimpleCorrectConfigProcessing) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "SYCL_DEVICE_ALLOWLIST=1" << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  sycl::detail::readConfig(true);
+  EXPECT_EQ(
+      std::string("1"),
+      sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
+}
+
+TEST(ConfigTests, CheckCorrectConfigProcessing) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file
+        << "#a\r\n # b \r\n #a=b\r\n # a = b\r\n\r\nSYCL_DEVICE_ALLOWLIST=2\r\n"
+        << std::endl;
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  sycl::detail::readConfig(true);
+  EXPECT_EQ(
+      std::string("2"),
+      sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
+}
+
+TEST(ConfigTests, CheckMultiAssignment) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "a=b\r\nb=c\nSYCL_DEVICE_ALLOWLIST=3\r\nc=d";
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  sycl::detail::readConfig(true);
+  EXPECT_EQ(
+      std::string("3"),
+      sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
+}
+
+TEST(ConfigTests, CheckAssignmentWithComment) {
+  std::ofstream file("conf.txt");
+  if (file.is_open()) {
+    file << "SYCL_DEVICE_ALLOWLIST=4 #comment\r\n";
+    file.close();
+  }
+  setenv("SYCL_CONFIG_FILE_NAME", "conf.txt", 1);
+  sycl::detail::readConfig(true);
+  EXPECT_EQ(
+      std::string("4"),
+      sycl::detail::SYCLConfig<sycl::detail::SYCL_DEVICE_ALLOWLIST>::get());
+}


### PR DESCRIPTION
Fix SYCL configuration file processing for DPCPP runtime.
The reason for this change is that the config for SYCL broke from the simplest changes, for example, from a comment in the config. Without these changes, it was a dangerous code that may fail and even don't send an error.
What's new: 
1) Rewritten line processing;
2) Supported format: 
ConfigName=Value #comment;
3) Skip lines which do not contain variables;
4) Throw error message if variable is incorrect;
5) Several tests for new functionality.