### PR TITLE
[SYCL][libclc] Fix remangled libclc files not being correctly installed

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -395,4 +395,16 @@ install(DIRECTORY ${LIBCLC_LIBRARY_OUTPUT_INTDIR}
 				COMPONENT clc-builtins
 				FILES_MATCHING PATTERN "clc-*")
 
+if( LIBCLC_GENERATE_REMANGLED_VARIANTS )
+	install(DIRECTORY ${LIBCLC_LIBRARY_OUTPUT_INTDIR}
+					DESTINATION lib${LLVM_LIBDIR_SUFFIX}
+					COMPONENT libspirv-builtins
+					FILES_MATCHING PATTERN "remangled-*libspirv-*")
+
+	install(DIRECTORY ${LIBCLC_LIBRARY_OUTPUT_INTDIR}
+					DESTINATION lib${LLVM_LIBDIR_SUFFIX}
+					COMPONENT clc-builtins
+					FILES_MATCHING PATTERN "remangled-*clc-*")
+endif()
+
 add_subdirectory(test)


### PR DESCRIPTION
The remangled libclc bitcode files were not being moved into the install directory. These changes ensure that the libclc variants are correctly configured to be copied into the install directory, if remangled variants are enabled.