### PR TITLE
[SYCL] Added handling of async exceptions in event::wait_and_throw()

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -211,8 +211,8 @@ void event_impl::wait_and_throw(
     std::shared_ptr<cl::sycl::detail::event_impl> Self) {
   Command *Cmd = static_cast<Command *>(Self->getCommand());
   QueueImplPtr submittedQueue = nullptr;
-  if (subCmd)
-    submittedQueue = subCmd->getSubmittedQueue();
+  if (Cmd)
+    submittedQueue = Cmd->getSubmittedQueue();
 
   wait(Self);
 

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -209,7 +209,7 @@ void event_impl::wait(
 
 void event_impl::wait_and_throw(
     std::shared_ptr<cl::sycl::detail::event_impl> Self) {
-  Command *subCmd = static_cast<Command *>(Self->getCommand());
+  Command *Cmd = static_cast<Command *>(Self->getCommand());
   QueueImplPtr submittedQueue = nullptr;
   if (subCmd)
     submittedQueue = subCmd->getSubmittedQueue();

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -209,16 +209,21 @@ void event_impl::wait(
 
 void event_impl::wait_and_throw(
     std::shared_ptr<cl::sycl::detail::event_impl> Self) {
+  Command *subCmd = static_cast<Command *>(Self->getCommand());
+  QueueImplPtr submittedQueue = nullptr;
+  if (subCmd)
+    submittedQueue = subCmd->getSubmittedQueue();
+
   wait(Self);
+
   for (auto &EventImpl :
        detail::Scheduler::getInstance().getWaitList(std::move(Self))) {
     Command *Cmd = (Command *)EventImpl->getCommand();
     if (Cmd)
-      Cmd->getQueue()->throw_asynchronous();
+      Cmd->getSubmittedQueue()->throw_asynchronous();
   }
-  Command *Cmd = (Command *)getCommand();
-  if (Cmd)
-    Cmd->getQueue()->throw_asynchronous();
+  if (submittedQueue)
+    submittedQueue->throw_asynchronous();
 }
 
 void event_impl::cleanupCommand(

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -310,6 +310,7 @@ void Command::waitForEvents(QueueImplPtr Queue,
 
 Command::Command(CommandType Type, QueueImplPtr Queue)
     : MQueue(std::move(Queue)), MType(Type) {
+  MSubmittedQueue = MQueue;
   MEvent.reset(new detail::event_impl(MQueue));
   MEvent->setCommand(this);
   MEvent->setContextImpl(MQueue->getContextImplPtr());
@@ -1532,7 +1533,8 @@ ExecCGCommand::ExecCGCommand(std::unique_ptr<detail::CG> CommandGroup,
                              QueueImplPtr Queue)
     : Command(CommandType::RUN_CG, std::move(Queue)),
       MCommandGroup(std::move(CommandGroup)) {
-
+  if (MCommandGroup->getType() == detail::CG::CodeplayHostTask) 
+    MSubmittedQueue = static_cast<detail::CGHostTask *>(MCommandGroup.get())->MQueue;
   emitInstrumentationDataProxy();
 }
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1533,8 +1533,9 @@ ExecCGCommand::ExecCGCommand(std::unique_ptr<detail::CG> CommandGroup,
                              QueueImplPtr Queue)
     : Command(CommandType::RUN_CG, std::move(Queue)),
       MCommandGroup(std::move(CommandGroup)) {
-  if (MCommandGroup->getType() == detail::CG::CodeplayHostTask) 
-    MSubmittedQueue = static_cast<detail::CGHostTask *>(MCommandGroup.get())->MQueue;
+  if (MCommandGroup->getType() == detail::CG::CodeplayHostTask)
+    MSubmittedQueue =
+        static_cast<detail::CGHostTask *>(MCommandGroup.get())->MQueue;
   emitInstrumentationDataProxy();
 }
 

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -138,6 +138,8 @@ public:
 
   const QueueImplPtr &getQueue() const { return MQueue; }
 
+  const QueueImplPtr &getSubmittedQueue() const { return MSubmittedQueue; }
+
   const EventImplPtr &getEvent() const { return MEvent; }
 
   // Methods needed to support SYCL instrumentation
@@ -195,6 +197,7 @@ public:
 protected:
   EventImplPtr MEvent;
   QueueImplPtr MQueue;
+  QueueImplPtr MSubmittedQueue;
 
   /// Dependency events prepared for waiting by backend.
   /// See processDepEvent for details.


### PR DESCRIPTION
Event::wait_and_throw() used async exception handling not from submitted queue that takes all of the exceptions and async handler, but from default host queue. By this patch event::wait_and_throw() uses submitted queue for the exception handling.
The test : https://github.com/intel/llvm-test-suite/pull/420
Signed-off-by: mdimakov <maxim.dimakov@intel.com>