### PR TITLE
[SYCL][ROCm] Skip new unsupported test from ROCm testing

### DIFF
--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -109,6 +109,11 @@ TEST(KernelBundle, KernelBundleAndItsDevImageStateConsistency) {
     return;
   }
 
+  if (Plt.get_backend() == sycl::backend::rocm) {
+    std::cout << "Test is not supported on ROCm platform, skipping\n";
+    return;
+  }
+
   sycl::unittest::PiMock Mock{Plt};
   setupDefaultMockAPIs(Mock);
 


### PR DESCRIPTION
This was introduced in #4350 and just like the CUDA plugin it is also
not supported by the ROCm plugin.