### PR TITLE
[SYCL] Fix test regressions caused by conflicting changes

### DIFF
--- a/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
+++ b/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
@@ -61,6 +61,13 @@ pi_result redefinedEventGetInfo(pi_event event, pi_event_info param_name,
   return PI_SUCCESS;
 }
 
+static pi_result redefinedUSMEnqueueMemset(pi_queue, void *, pi_int32, size_t,
+                                           pi_uint32, const pi_event *,
+                                           pi_event *event) {
+  *event = reinterpret_cast<pi_event>(new int{});
+  return PI_SUCCESS;
+}
+
 TEST(GetNative, GetNativeHandle) {
   platform Plt{default_selector()};
   if (Plt.get_backend() != backend::opencl) {
@@ -83,6 +90,8 @@ TEST(GetNative, GetNativeHandle) {
   Mock.redefine<detail::PiApiKind::piDeviceRetain>(redefinedDeviceRetain);
   Mock.redefine<detail::PiApiKind::piProgramRetain>(redefinedProgramRetain);
   Mock.redefine<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
+  Mock.redefine<detail::PiApiKind::piextUSMEnqueueMemset>(
+      redefinedUSMEnqueueMemset);
 
   default_selector Selector;
   context Context(Plt);

--- a/sycl/unittests/helpers/CommonRedefinitions.hpp
+++ b/sycl/unittests/helpers/CommonRedefinitions.hpp
@@ -106,13 +106,17 @@ inline pi_result redefinedEventsWaitCommon(pi_uint32 num_events,
 }
 
 inline pi_result redefinedEventReleaseCommon(pi_event event) {
+  if (event != nullptr)
+    delete reinterpret_cast<int *>(event);
   return PI_SUCCESS;
 }
 
 inline pi_result redefinedEnqueueKernelLaunchCommon(
     pi_queue, pi_kernel, pi_uint32, const size_t *, const size_t *,
-    const size_t *, pi_uint32, const pi_event *, pi_event *) {
+    const size_t *, pi_uint32, const pi_event *, pi_event *event) {
+  *event = reinterpret_cast<pi_event>(new int{});
   return PI_SUCCESS;
+  ;
 }
 
 inline pi_result redefinedKernelGetGroupInfoCommon(

--- a/sycl/unittests/helpers/CommonRedefinitions.hpp
+++ b/sycl/unittests/helpers/CommonRedefinitions.hpp
@@ -116,7 +116,6 @@ inline pi_result redefinedEnqueueKernelLaunchCommon(
     const size_t *, pi_uint32, const pi_event *, pi_event *event) {
   *event = reinterpret_cast<pi_event>(new int{});
   return PI_SUCCESS;
-  ;
 }
 
 inline pi_result redefinedKernelGetGroupInfoCommon(

--- a/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
@@ -110,5 +110,6 @@ TEST_F(SchedulerTest, InOrderQueueHostTaskDeps) {
       })
       .wait();
 
+  std::cout << GEventsWaitCounter << "\n";
   EXPECT_TRUE(GEventsWaitCounter == 1);
 }

--- a/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
@@ -110,6 +110,5 @@ TEST_F(SchedulerTest, InOrderQueueHostTaskDeps) {
       })
       .wait();
 
-  std::cout << GEventsWaitCounter << "\n";
   EXPECT_TRUE(GEventsWaitCounter == 1);
 }


### PR DESCRIPTION
https://github.com/intel/llvm/pull/4369 prevents empty events from being waited on. Change test mocks to generate some event object for PI calls.