### PR TITLE
[Driver][SYCL] Update dependency file generation with the integration…

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5488,6 +5488,16 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
         break;
       }
 
+      // When performing -fsycl based compilations and generating dependency
+      // information, perform a specific dependency generation compilation which
+      // is not based on the source + footer compilation.
+      if (Phase == phases::Preprocess && Args.hasArg(options::OPT_fsycl) &&
+          Args.hasArg(options::OPT_M_Group) &&
+          !Args.hasArg(options::OPT_fno_sycl_use_footer)) {
+        Actions.push_back(
+            C.MakeAction<PreprocessJobAction>(Current, types::TY_Dependencies));
+      }
+
       // FIXME: Should we include any prior module file outputs as inputs of
       // later actions in the same command line?
 

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -67,3 +67,30 @@
 // FOOTER_PATH: append-file{{.*}} "--append=dummy_dir{{(/|\\\\)}}{{.*}}-footer-{{.*}}.h"
 // FOOTER_PATH-SAME: "--output=dummy_dir{{(/|\\\\)}}[[APPENDEDSRC:.+\.cpp]]"
 // FOOTER_PATH: clang{{.*}} "-x" "c++" "dummy_dir{{(/|\\\\)}}[[APPENDEDSRC]]"
+
+/// Check behaviors for dependency generation
+// RUN:  %clangxx -fsycl -MD -c %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix DEP_GEN -DINPUTFILE=%/s %s
+// DEP_GEN:  clang{{.*}} "-Eonly"
+// DEP_GEN-SAME: "-dependency-file"
+// DEP_GEN-SAME: "-MT"
+// DEP_GEN-SAME: "-x" "c++" "[[INPUTFILE]]"
+// DEP_GEN: append-file{{.*}}
+// DEP_GEN-NOT: clang{{.*}} "-dependency-file"
+
+/// Dependency generation phases
+// RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl -MD -c %s -ccc-print-phases 2>&1 \
+// RUN:   | FileCheck -check-prefix DEP_GEN_PHASES -DINPUTFILE=%/s %s
+// DEP_GEN_PHASES: 0: input, "[[INPUTFILE]]", c++, (host-sycl)
+// DEP_GEN_PHASES: 1: preprocessor, {0}, dependencies
+// DEP_GEN_PHASES: 2: input, "[[INPUTFILE]]", c++, (device-sycl)
+// DEP_GEN_PHASES: 3: preprocessor, {2}, c++-cpp-output, (device-sycl)
+// DEP_GEN_PHASES: 4: compiler, {3}, ir, (device-sycl)
+// DEP_GEN_PHASES: 5: offload, "device-sycl (spir64-unknown-unknown-sycldevice)" {4}, ir
+// DEP_GEN_PHASES: 6: append-footer, {0}, c++, (host-sycl)
+// DEP_GEN_PHASES: 7: preprocessor, {6}, c++-cpp-output, (host-sycl)
+// DEP_GEN_PHASES: 8: offload, "host-sycl (x86_64-unknown-linux-gnu)" {7}, "device-sycl (spir64-unknown-unknown-sycldevice)" {4}, c++-cpp-output
+// DEP_GEN_PHASES: 9: compiler, {8}, ir, (host-sycl)
+// DEP_GEN_PHASES: 10: backend, {9}, assembler, (host-sycl)
+// DEP_GEN_PHASES: 11: assembler, {10}, object, (host-sycl)
+// DEP_GEN_PHASES: 12: clang-offload-bundler, {5, 11}, object, (host-sycl)

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -295,11 +295,11 @@
 /// -fintelfpga dependency file check with host .d enabled
 // RUN: %clangxx -### -MMD -fsycl -fintelfpga -Xshardware %t-1.cpp %t-2.cpp 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK-FPGA-DEP-FILES-HOST %s
-// CHK-FPGA-DEP-FILES-HOST: clang{{.*}} "-dependency-file" "[[INPUT1:.+\.d]]" "-MT" "{{.*}}.o"
-// CHK-FPGA-DEP-FILES-HOST: clang{{.*}} "-dependency-file" "[[INPUT2:.+\.d]]" "-MT" "{{.*}}.o"
+// CHK-FPGA-DEP-FILES-HOST: clang{{.*}} "-triple" "spir64_fpga-unknown-unknown-sycldevice"{{.*}} "-dependency-file" "[[INPUT1:.+\.d]]" "-MT" "{{.*}}.o"
+// CHK-FPGA-DEP-FILES-HOST: clang{{.*}} "-triple" "spir64_fpga-unknown-unknown-sycldevice"{{.*}} "-dependency-file" "[[INPUT2:.+\.d]]" "-MT" "{{.*}}.o"
 // CHK-FPGA-DEP-FILES-HOST: aoc{{.*}} "-dep-files={{.*}}[[INPUT1]],{{.*}}[[INPUT2]]"
-// CHK-FPGA-DEP-FILES-HOST: clang{{.*}} "-fsycl-is-host"{{.*}} "-dependency-file"
-// CHK-FPGA-DEP-FILES-HOST: clang{{.*}} "-fsycl-is-host"{{.*}} "-dependency-file"
+// CHK-FPGA-DEP-FILES-HOST: clang{{.*}} "-fsycl-is-host"{{.*}}
+// CHK-FPGA-DEP-FILES-HOST: clang{{.*}} "-fsycl-is-host"{{.*}}
 
 /// -fintelfpga dependency file generation test to object
 // RUN: %clangxx -### -fsycl -fintelfpga -target x86_64-unknown-linux-gnu %t-1.cpp %t-2.cpp -c 2>&1 \
@@ -321,7 +321,7 @@
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-DEP-FILES3,CHK-FPGA-DEP-FILES3-LIN %s
 // RUN: %clang_cl -### --target=x86_64-pc-windows-msvc -fsycl -fintelfpga %t-1.cpp -c -Fodummy.obj 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-DEP-FILES3,CHK-FPGA-DEP-FILES3-WIN %s
-// CHK-FPGA-DEP-FILES3: clang{{.*}} "-dependency-file" "[[OUTPUT:.+\.d]]"
+// CHK-FPGA-DEP-FILES3: clang{{.*}} "-triple" "spir64_fpga-unknown-unknown-sycldevice"{{.*}} "-dependency-file" "[[OUTPUT:.+\.d]]"
 // CHK-FPGA-DEP-FILES3-LIN: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_fpga-unknown-unknown-sycldevice,host-x86_64-unknown-linux-gnu,sycl-fpga_dep" {{.*}} "-inputs={{.*}}.bc,{{.*}}.o,[[OUTPUT]]"
 // CHK-FPGA-DEP-FILES3-WIN: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_fpga-unknown-unknown-sycldevice,host-x86_64-pc-windows-msvc,sycl-fpga_dep" {{.*}} "-inputs={{.*}}.bc,{{.*}}.obj,[[OUTPUT]]"
 


### PR DESCRIPTION
… footer

When generating dependency information and compiling the source + footer
file, the generated dependency information did not match the actual source
file that needs to be checked.

Update the compilation behavior when we are generating dependency information
with the source + footer so we do an additional specific dependency creation
step (preprocess only) against the original source file which is used instead
of the source + footer compilation.