### PR TITLE
[SYCL][ROCm] Build lld when ROCm for AMD is enabled

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -61,6 +61,9 @@ def do_configure(args):
         if args.rocm_platform == 'AMD':
             llvm_targets_to_build += ';AMDGPU'
             libclc_targets_to_build += ';amdgcn--;amdgcn--amdhsa'
+
+            # The ROCm plugin for AMD uses lld for linking
+            llvm_enable_projects += ';lld'
         elif args.rocm_platform == 'NVIDIA' and not args.cuda:
             llvm_targets_to_build += ';NVPTX'
             libclc_targets_to_build += ';nvptx64--;nvptx64--nvidiacl'

--- a/sycl/plugins/rocm/CMakeLists.txt
+++ b/sycl/plugins/rocm/CMakeLists.txt
@@ -41,6 +41,9 @@ if("${SYCL_BUILD_PI_ROCM_PLATFORM}" STREQUAL "AMD")
 
   # Set HIP define to select AMD platform
   target_compile_definitions(pi_rocm PRIVATE __HIP_PLATFORM_AMD__)
+
+  # Make sure lld is built as part of the toolchain
+  add_dependencies(sycl-toolchain lld)
  elseif("${SYCL_BUILD_PI_ROCM_PLATFORM}" STREQUAL "NVIDIA")
   # Import CUDA libraries
   find_package(CUDA REQUIRED)


### PR DESCRIPTION
This patch ensures `lld` is built by default when the `pi_rocm` plugin for AMD is enabled as `lld` is required for linking with that setup.

This should address: #4390