### PR TITLE
[Driver][SYCL] Allow for -o output with dependency generation

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5866,6 +5866,9 @@ void Driver::BuildJobs(Compilation &C) const {
   // we are also generating .o files. So we allow more than one output file in
   // this case as well.
   //
+  // Preprocessing job performed for -fsycl enabled compilation specifically
+  // for dependency generation (TY_Dependencies)
+  //
   if (FinalOutput) {
     unsigned NumOutputs = 0;
     unsigned NumIfsOutputs = 0;
@@ -5876,7 +5879,10 @@ void Driver::BuildJobs(Compilation &C) const {
              A->getKind() == clang::driver::Action::CompileJobClass &&
              0 == NumIfsOutputs++) ||
             (A->getKind() == Action::BindArchClass && A->getInputs().size() &&
-             A->getInputs().front()->getKind() == Action::IfsMergeJobClass)))
+             A->getInputs().front()->getKind() == Action::IfsMergeJobClass) ||
+            (A->getKind() == Action::PreprocessJobClass &&
+             A->getType() == types::TY_Dependencies &&
+             C.getArgs().hasArg(options::OPT_fsycl))))
         ++NumOutputs;
 
     if (NumOutputs > 1) {

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -94,3 +94,8 @@
 // DEP_GEN_PHASES: 10: backend, {9}, assembler, (host-sycl)
 // DEP_GEN_PHASES: 11: assembler, {10}, object, (host-sycl)
 // DEP_GEN_PHASES: 12: clang-offload-bundler, {5, 11}, object, (host-sycl)
+
+/// Allow for -o and preprocessing
+// RUN:  %clangxx -fsycl -MD -c %s -o dummy -### 2>&1 \
+// RUN:   | FileCheck -check-prefix DEP_GEN_OUT_ERROR %s
+// DEP_GEN_OUT_ERROR-NOT: cannot specify -o when generating multiple output files


### PR DESCRIPTION
Previous fix to for dependency generation with -fsycl caused a problem
when emitting an output file and dependency info.  This was causing a
multiple output error, due to the extra preprocess step which is counted
as a compilation step.  Allow for this new step to not count as an
official output step.