### PR TITLE
[SYCL] Added __SYCL_INTERNAL_API macro

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -43,9 +43,10 @@ function(add_sycl_rt_library LIB_NAME)
     target_link_libraries(${LIB_NAME} PRIVATE ${ARG_XPTI_LIB})
   endif()
 
-  target_compile_definitions(${LIB_OBJ_NAME} PRIVATE __SYCL_BUILD_SYCL_DLL )
-  
+  target_compile_definitions(${LIB_OBJ_NAME} PRIVATE __SYCL_INTERNAL_API )
+
   if (MSVC)
+    target_compile_definitions(${LIB_OBJ_NAME} PRIVATE __SYCL_BUILD_SYCL_DLL )
     target_link_libraries(${LIB_NAME} PRIVATE shlwapi)
   else()
     target_compile_options(${LIB_OBJ_NAME} PUBLIC


### PR DESCRIPTION
It will be used for the deprecating some features - we need to remove API but not ABI. New macro is added because with __SYCL_BUILD_SYCL_DLL the problems on windows are arisen if this macro is defined anywhere but DPCPP RT Lib. This macro added to avoid these problems
Signed-off-by: mdimakov <maxim.dimakov@intel.com>