### PR TITLE
An attempt to resolve one more issue with unnamed lambdas

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5177,6 +5177,8 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
   if (EmittedFirstSpecConstant)
     OS << "#include <CL/sycl/detail/spec_const_integration.hpp>\n";
 
+  OS << "#include <CL/sycl/detail/kernel-info-integration.hpp>\n";
+
   return true;
 }
 

--- a/sycl/include/CL/sycl/detail/cg_types.hpp
+++ b/sycl/include/CL/sycl/detail/cg_types.hpp
@@ -285,8 +285,9 @@ public:
   template <class ArgT = KernelArgType>
   typename detail::enable_if_t<std::is_same<ArgT, sycl::id<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using KI = detail::KernelInfo<KernelName>;
-    constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
+//    using KI = detail::KernelInfo<KernelName>;
+    auto KI = detail::getKernelInfoStruct<KernelName>();
+    bool StoreLocation = KI.callsAnyThisFreeFunction();
 
     sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
     sycl::id<Dims> Offset;
@@ -318,8 +319,9 @@ public:
   typename detail::enable_if_t<
       std::is_same<ArgT, item<Dims, /*Offset=*/false>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using KI = detail::KernelInfo<KernelName>;
-    constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
+//    using KI = detail::KernelInfo<KernelName>;
+    auto KI = detail::getKernelInfoStruct<KernelName>();
+    bool StoreLocation = KI.callsAnyThisFreeFunction();
 
     sycl::id<Dims> ID;
     sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
@@ -343,8 +345,9 @@ public:
   typename detail::enable_if_t<
       std::is_same<ArgT, item<Dims, /*Offset=*/true>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using KI = detail::KernelInfo<KernelName>;
-    constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
+//    using KI = detail::KernelInfo<KernelName>;
+    auto KI = detail::getKernelInfoStruct<KernelName>();
+    bool StoreLocation = KI.callsAnyThisFreeFunction();
 
     sycl::range<Dims> Range(InitializedVal<Dims, range>::template get<0>());
     sycl::id<Dims> Offset;
@@ -375,8 +378,9 @@ public:
   template <class ArgT = KernelArgType>
   typename detail::enable_if_t<std::is_same<ArgT, nd_item<Dims>>::value>
   runOnHost(const NDRDescT &NDRDesc) {
-    using KI = detail::KernelInfo<KernelName>;
-    constexpr bool StoreLocation = KI::callsAnyThisFreeFunction();
+//    using KI = detail::KernelInfo<KernelName>;
+    auto KI = detail::getKernelInfoStruct<KernelName>();
+    bool StoreLocation = KI.callsAnyThisFreeFunction();
 
     sycl::range<Dims> GroupSize(InitializedVal<Dims, range>::template get<0>());
     for (int I = 0; I < Dims; ++I) {

--- a/sycl/include/CL/sycl/detail/kernel-info-integration.hpp
+++ b/sycl/include/CL/sycl/detail/kernel-info-integration.hpp
@@ -1,0 +1,91 @@
+
+//==---------------------- spec_const_integration.hpp ----------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+// This header file must not be included to any DPC++ headers.
+// This header file should only be included to integration footer.
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace detail {
+
+template <char...> struct KernelInfoData {
+  static constexpr unsigned getNumParams() { return 0; }
+  static const kernel_param_desc_t &getParamDesc(int Idx) {
+    static kernel_param_desc_t Dummy;
+    return Dummy;
+  }
+  static constexpr const char *getName() { return ""; }
+  static constexpr bool isESIMD() { return 0; }
+  static constexpr bool callsThisItem() { return false; }
+  static constexpr bool callsAnyThisFreeFunction() { return false; }
+};
+
+// C++14 like index_sequence and make_index_sequence
+// not needed C++14 members (value_type, size) not implemented
+template <class T, T...> struct integer_sequence {};
+template <unsigned long long... I>
+using index_sequence = integer_sequence<unsigned long long, I...>;
+template <unsigned long long N>
+using make_index_sequence =
+    __make_integer_seq<integer_sequence, unsigned long long, N>;
+
+template <typename T> struct KernelInfoImpl {
+private:
+  static constexpr auto n = __builtin_sycl_unique_stable_name(T);
+  template <unsigned long long... I>
+  static KernelInfoData<n[I]...> impl(index_sequence<I...>) {
+    return {};
+  }
+
+public:
+  using type = decltype(impl(make_index_sequence<__builtin_strlen(n)>{}));
+};
+
+// For named kernels, this structure is specialized in the integration header.
+// For unnamed kernels, KernelInfoData is specialized in the integration header,
+// and this picks it up via the KernelInfoImpl. For non-existent kernels, this
+// will also pick up a KernelInfoData (as SubKernelInfo) via KernelInfoImpl, but
+// it will instead get the unspecialized case, defined above.
+template <class KernelNameType> struct KernelInfo {
+  using SubKernelInfo = typename KernelInfoImpl<KernelNameType>::type;
+  static constexpr unsigned getNumParams() {
+    return SubKernelInfo::getNumParams();
+  }
+  static const kernel_param_desc_t &getParamDesc(int Idx) {
+    return SubKernelInfo::getParamDesc(Idx);
+  }
+  static constexpr const char *getName() { return SubKernelInfo::getName(); }
+  static constexpr bool isESIMD() { return SubKernelInfo::isESIMD(); }
+  static constexpr bool callsThisItem() {
+    return SubKernelInfo::callsThisItem();
+  }
+  static constexpr bool callsAnyThisFreeFunction() {
+    return SubKernelInfo::callsAnyThisFreeFunction();
+  }
+};
+
+template<class KernelNameType> KernelInfoStruct getKernelInfoStruct() {
+  KernelInfoStruct ret;
+  ret.Name = KernelInfo<KernelNameType>::getName();
+  ret.NumParams = KernelInfo<KernelNameType>::getNumParams();
+  ret.ESIMD = KernelInfo<KernelNameType>::isESIMD();
+  ret.ThisItem = KernelInfo<KernelNameType>::callsThisItem();
+  ret.ThisFreeFunction = KernelInfo<KernelNameType>::callsAnyThisFreeFunction();
+  return ret;
+}
+
+template<class KernelNameType> const kernel_param_desc_t &getKernelParamDesc(int Idx) {
+  return KernelInfo<KernelNameType>::getParamDesc(Idx);
+}
+
+} // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -77,63 +77,28 @@ template <class KernelNameType> struct KernelInfo {
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
 };
+template<class KernelNameType> const char *getKernelName();
 #else
-template <char...> struct KernelInfoData {
-  static constexpr unsigned getNumParams() { return 0; }
-  static const kernel_param_desc_t &getParamDesc(int Idx) {
-    static kernel_param_desc_t Dummy;
-    return Dummy;
-  }
-  static constexpr const char *getName() { return ""; }
-  static constexpr bool isESIMD() { return 0; }
-  static constexpr bool callsThisItem() { return false; }
-  static constexpr bool callsAnyThisFreeFunction() { return false; }
-};
+template <char...> struct KernelInfoData;
+template <class KernelNameType> struct KernelInfo;
 
-// C++14 like index_sequence and make_index_sequence
-// not needed C++14 members (value_type, size) not implemented
-template <class T, T...> struct integer_sequence {};
-template <unsigned long long... I>
-using index_sequence = integer_sequence<unsigned long long, I...>;
-template <unsigned long long N>
-using make_index_sequence =
-    __make_integer_seq<integer_sequence, unsigned long long, N>;
 
-template <typename T> struct KernelInfoImpl {
-private:
-  static constexpr auto n = __builtin_sycl_unique_stable_name(T);
-  template <unsigned long long... I>
-  static KernelInfoData<n[I]...> impl(index_sequence<I...>) {
-    return {};
-  }
-
-public:
-  using type = decltype(impl(make_index_sequence<__builtin_strlen(n)>{}));
-};
-
-// For named kernels, this structure is specialized in the integration header.
-// For unnamed kernels, KernelInfoData is specialized in the integration header,
-// and this picks it up via the KernelInfoImpl. For non-existent kernels, this
-// will also pick up a KernelInfoData (as SubKernelInfo) via KernelInfoImpl, but
-// it will instead get the unspecialized case, defined above.
-template <class KernelNameType> struct KernelInfo {
-  using SubKernelInfo = typename KernelInfoImpl<KernelNameType>::type;
-  static constexpr unsigned getNumParams() {
-    return SubKernelInfo::getNumParams();
-  }
-  static const kernel_param_desc_t &getParamDesc(int Idx) {
-    return SubKernelInfo::getParamDesc(Idx);
-  }
-  static constexpr const char *getName() { return SubKernelInfo::getName(); }
-  static constexpr bool isESIMD() { return SubKernelInfo::isESIMD(); }
-  static constexpr bool callsThisItem() {
-    return SubKernelInfo::callsThisItem();
-  }
-  static constexpr bool callsAnyThisFreeFunction() {
-    return SubKernelInfo::callsAnyThisFreeFunction();
-  }
-};
 #endif //__SYCL_UNNAMED_LAMBDA__
+struct KernelInfoStruct {
+  unsigned NumParams = 0;
+  const char *Name = nullptr;
+  bool ESIMD = false;
+  bool ThisItem = false;
+  bool ThisFreeFunction = false;
+
+  unsigned getNumParams() { return NumParams; }
+  const char *getName() { return Name; }
+  bool isESIMD() { return ESIMD; }
+  bool callsThisItem() { return ThisItem; }
+  bool callsAnyThisFreeFunction() { return ThisFreeFunction; }
+};
+template<class KernelNameType> KernelInfoStruct getKernelInfoStruct();
+template<class KernelNameType> kernel_param_desc_t &getKernelParamDesc(int Idx);
 
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/kernel_bundle.hpp
+++ b/sycl/include/CL/sycl/kernel_bundle.hpp
@@ -345,8 +345,9 @@ private:
 
 /// \returns the kernel_id associated with the KernelName
 template <typename KernelName> kernel_id get_kernel_id() {
-  using KI = sycl::detail::KernelInfo<KernelName>;
-  return sycl::kernel_id(KI::getName());
+//  using KI = sycl::detail::KernelInfo<KernelName>;
+  auto KI = sycl::detail::getKernelInfoStruct<KernelName>();
+  return sycl::kernel_id(KI.getName());
 }
 
 /// \returns a vector with all kernel_id's defined in the application

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -157,9 +157,10 @@ public:
   /// \param CompileOptions is a string of valid OpenCL compile options.
   template <typename KernelT>
   void compile_with_kernel_type(std::string CompileOptions = "") {
+    auto KI = detail::getKernelInfoStruct<KernelT>();
     detail::OSModuleHandle M = detail::OSUtil::getOSModuleHandle(
-        detail::KernelInfo<KernelT>::getName());
-    compile_with_kernel_name(detail::KernelInfo<KernelT>::getName(),
+        KI.getName());
+    compile_with_kernel_name(KI.getName(),
                              CompileOptions, M);
   }
 
@@ -194,9 +195,10 @@ public:
   /// \param BuildOptions is a string containing OpenCL compile options.
   template <typename KernelT>
   void build_with_kernel_type(std::string BuildOptions = "") {
+    auto KI = detail::getKernelInfoStruct<KernelT>();
     detail::OSModuleHandle M = detail::OSUtil::getOSModuleHandle(
-        detail::KernelInfo<KernelT>::getName());
-    build_with_kernel_name(detail::KernelInfo<KernelT>::getName(), BuildOptions,
+        KI.getName());
+    build_with_kernel_name(KI.getName(), BuildOptions,
                            M);
   }
 
@@ -236,7 +238,8 @@ public:
   ///
   /// \return true if the SYCL kernel is available.
   template <typename KernelT> bool has_kernel() const {
-    return has_kernel(detail::KernelInfo<KernelT>::getName(),
+    auto KI = detail::getKernelInfoStruct<KernelT>();
+    return has_kernel(KI.getName(),
                       /*IsCreatedFromSource*/ false);
   }
 
@@ -258,7 +261,8 @@ public:
   ///
   /// \return a valid instance of SYCL kernel.
   template <typename KernelT> kernel get_kernel() const {
-    return get_kernel(detail::KernelInfo<KernelT>::getName(),
+    auto KI = detail::getKernelInfoStruct<KernelT>();
+    return get_kernel(KI.getName(),
                       /*IsCreatedFromSource*/ false);
   }
 

--- a/sycl/test/regression/another-unnamed-lambda-case.cpp
+++ b/sycl/test/regression/another-unnamed-lambda-case.cpp
@@ -1,0 +1,9 @@
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t.out
+#include <sycl.hpp>
+int main()
+{
+  auto w = [](auto i){};
+    sycl::queue q;
+    q.parallel_for(10, [](auto i){});
+    q.parallel_for(10, w);
+}


### PR DESCRIPTION
The idea is to postpone `KernelInfo` instantiation until after we have seen all kernels in a source file