### PR TITLE
[ESIMD][NFC] Refactored simd_view bitwise and relational ops

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
@@ -202,31 +202,6 @@ public:
   }
 
 #define DEF_BINOP(BINOP, OPASSIGN)                                             \
-  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
-  ESIMD_INLINE friend auto operator BINOP(const Derived &X,                    \
-                                          const value_type &Y) {               \
-    using ComputeTy = detail::compute_type_t<value_type>;                      \
-    auto V0 =                                                                  \
-        detail::convert<typename ComputeTy::vector_type>(X.read().data());     \
-    auto V1 = detail::convert<typename ComputeTy::vector_type>(Y.data());      \
-    auto V2 = V0 BINOP V1;                                                     \
-    return ComputeTy(V2);                                                      \
-  }                                                                            \
-  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
-  ESIMD_INLINE friend auto operator BINOP(const Derived &X,                    \
-                                          const element_type &Y) {             \
-    return X BINOP(value_type) Y;                                              \
-  }                                                                            \
-  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
-  ESIMD_INLINE friend auto operator BINOP(const value_type &X,                 \
-                                          const Derived &Y) {                  \
-    using ComputeTy = detail::compute_type_t<value_type>;                      \
-    auto V0 = detail::convert<typename ComputeTy::vector_type>(X.data());      \
-    auto V1 =                                                                  \
-        detail::convert<typename ComputeTy::vector_type>(Y.read().data());     \
-    auto V2 = V0 BINOP V1;                                                     \
-    return ComputeTy(V2);                                                      \
-  }                                                                            \
   ESIMD_INLINE friend auto operator BINOP(const Derived &X,                    \
                                           const Derived &Y) {                  \
     return (X BINOP Y.read());                                                 \
@@ -253,25 +228,6 @@ public:
 #undef DEF_BINOP
 
 #define DEF_BITWISE_OP(BITWISE_OP, OPASSIGN)                                   \
-  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
-  ESIMD_INLINE friend auto operator BITWISE_OP(const Derived &X,               \
-                                               const value_type &Y) {          \
-    static_assert(std::is_integral<element_type>(), "not integral type");      \
-    auto V2 = X.read().data() BITWISE_OP Y.data();                             \
-    return simd<element_type, length>(V2);                                     \
-  }                                                                            \
-  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
-  ESIMD_INLINE friend auto operator BITWISE_OP(const Derived &X,               \
-                                               const element_type &Y) {        \
-    return X BITWISE_OP(value_type) Y;                                         \
-  }                                                                            \
-  template <class T1 = Derived, class = std::enable_if_t<T1::length != 1>>     \
-  ESIMD_INLINE friend auto operator BITWISE_OP(const value_type &X,            \
-                                               const Derived &Y) {             \
-    static_assert(std::is_integral<element_type>(), "not integral type");      \
-    auto V2 = X.data() BITWISE_OP Y.read().data();                             \
-    return simd<element_type, length>(V2);                                     \
-  }                                                                            \
   ESIMD_INLINE friend auto operator BITWISE_OP(const Derived &X,               \
                                                const Derived &Y) {             \
     return (X BITWISE_OP Y.read());                                            \

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
@@ -80,8 +80,7 @@ public:
   }                                                                            \
   ESIMD_INLINE friend auto operator BINOP(const simd_view &X,                  \
                                           const element_type &Y) {             \
-    return X BINOP(value_type)                                                 \
-    Y;                                                                         \
+    return X BINOP(value_type) Y;                                              \
   }                                                                            \
   ESIMD_INLINE friend auto operator BINOP(const value_type &X,                 \
                                           const simd_view &Y) {                \
@@ -110,8 +109,7 @@ public:
   }                                                                            \
   ESIMD_INLINE friend auto operator BITWISE_OP(const simd_view &X,             \
                                                const element_type &Y) {        \
-    return X BITWISE_OP(value_type)                                            \
-    Y;                                                                         \
+    return X BITWISE_OP(value_type) Y;                                         \
   }                                                                            \
   ESIMD_INLINE friend auto operator BITWISE_OP(const value_type &X,            \
                                                const simd_view &Y) {           \

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
@@ -68,6 +68,66 @@ public:
     return *this;
   }
 
+#define DEF_BINOP(BINOP, OPASSIGN)                                             \
+  ESIMD_INLINE friend auto operator BINOP(const simd_view &X,                  \
+                                          const value_type &Y) {               \
+    using ComputeTy = detail::compute_type_t<value_type>;                      \
+    auto V0 =                                                                  \
+        detail::convert<typename ComputeTy::vector_type>(X.read().data());     \
+    auto V1 = detail::convert<typename ComputeTy::vector_type>(Y.data());      \
+    auto V2 = V0 BINOP V1;                                                     \
+    return ComputeTy(V2);                                                      \
+  }                                                                            \
+  ESIMD_INLINE friend auto operator BINOP(const simd_view &X,                  \
+                                          const element_type &Y) {             \
+    return X BINOP(value_type)                                                 \
+    Y;                                                                         \
+  }                                                                            \
+  ESIMD_INLINE friend auto operator BINOP(const value_type &X,                 \
+                                          const simd_view &Y) {                \
+    using ComputeTy = detail::compute_type_t<value_type>;                      \
+    auto V0 = detail::convert<typename ComputeTy::vector_type>(X.data());      \
+    auto V1 =                                                                  \
+        detail::convert<typename ComputeTy::vector_type>(Y.read().data());     \
+    auto V2 = V0 BINOP V1;                                                     \
+    return ComputeTy(V2);                                                      \
+  }
+
+  DEF_BINOP(+, +=)
+  DEF_BINOP(-, -=)
+  DEF_BINOP(*, *=)
+  DEF_BINOP(/, /=)
+  DEF_BINOP(%, %=)
+
+#undef DEF_BINOP
+
+#define DEF_BITWISE_OP(BITWISE_OP, OPASSIGN)                                   \
+  ESIMD_INLINE friend auto operator BITWISE_OP(const simd_view &X,             \
+                                               const value_type &Y) {          \
+    static_assert(std::is_integral<element_type>(), "not integral type");      \
+    auto V2 = X.read().data() BITWISE_OP Y.data();                             \
+    return simd<element_type, length>(V2);                                     \
+  }                                                                            \
+  ESIMD_INLINE friend auto operator BITWISE_OP(const simd_view &X,             \
+                                               const element_type &Y) {        \
+    return X BITWISE_OP(value_type)                                            \
+    Y;                                                                         \
+  }                                                                            \
+  ESIMD_INLINE friend auto operator BITWISE_OP(const value_type &X,            \
+                                               const simd_view &Y) {           \
+    static_assert(std::is_integral<element_type>(), "not integral type");      \
+    auto V2 = X.data() BITWISE_OP Y.read().data();                             \
+    return simd<element_type, length>(V2);                                     \
+  }
+
+  DEF_BITWISE_OP(&, &=)
+  DEF_BITWISE_OP(|, |=)
+  DEF_BITWISE_OP(^, ^=)
+  DEF_BITWISE_OP(>>, >>=)
+  DEF_BITWISE_OP(<<, <<=)
+
+#undef DEF_BITWISE_OP
+
 #define DEF_RELOP(RELOP)                                                       \
   ESIMD_INLINE friend simd<uint16_t, length> operator RELOP(                   \
       const simd_view &X, const value_type &Y) {                               \


### PR DESCRIPTION
This patch removes versions of operators from the base class (simd_view_impl)
that are guarded by SFINAE and puts them into the appropriate template
specialization.