### PR TITLE
[clang-offload-bundler] Add an option for adding .tgtsym section to fat object

### DIFF
--- a/clang/test/Driver/clang-offload-bundler-tgtsym.c
+++ b/clang/test/Driver/clang-offload-bundler-tgtsym.c
@@ -23,6 +23,11 @@
 // CHECK-NOT: sycl-spir64.llvm.compiler.used
 // CHECK-NOT: sycl-spir64.const_as
 
+// RUN: clang-offload-bundler --add-target-symbols-to-bundled-object=false -type=o -targets=host-%itanium_abi_triple,openmp-x86_64-pc-linux-gnu,sycl-spir64 -inputs=%t.o,%t.tgt1,%t.tgt2 -outputs=%t.fat.no.tgtsym.o
+// RUN: llvm-readobj --string-dump=.tgtsym %t.fat.no.tgtsym.o | FileCheck %s --check-prefix CHECK-NO-TGTSYM
+
+// CHECK-NO-TGTSYM-NOT: String dump of section '.tgtsym':
+
 const __attribute__((opencl_constant)) char const_as[] = "abc";
 
 extern void my_printf(__attribute__((opencl_constant)) const char *fmt);

--- a/clang/test/Driver/clang-offload-bundler.c
+++ b/clang/test/Driver/clang-offload-bundler.c
@@ -33,6 +33,7 @@
 // CK-HELP: {{.*}}one. The resulting file can also be unbundled into different files by
 // CK-HELP: {{.*}}this tool if -unbundle is provided.
 // CK-HELP: {{.*}}USAGE: clang-offload-bundler [options]
+// CK-HELP: {{.*}}-add-target-symbols-to-bundled-object {{.*}}- Add .tgtsym section with target symbol names to the output file when bundling object files.
 // CK-HELP: {{.*}}-allow-missing-bundles {{.*}}- Create empty files if bundles are missing when unbundling
 // CK-HELP: {{.*}}-inputs=<string>  - [<input file>,...]
 // CK-HELP: {{.*}}-list {{.*}}- List bundle IDs in the bundled file.


### PR DESCRIPTION
This patch adds a new option --add-target-symbols-to-bundled-object (true by
default) to the clang-offload-bundler which controls adding .tgtsym section
to the output file when bundling object files. This option can be used for
disabling adding .tgtsym section to fat objects.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>