### PR TITLE
[SYCL] Remove sycl::byte from tests

### DIFF
--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -93,9 +93,6 @@ int main() {
   // Check the size and alignment of the SYCL vectors.
   checkVectors();
 
-  // Table 4.93: Additional scalar data types supported by SYCL.
-  static_assert(sizeof(s::byte) == sizeof(int8_t), "");
-
   // Table 4.94: Scalar data type aliases supported by SYCL
   static_assert(is_same<s::cl_bool, decltype(0 != 1)>::value, "");
   checkSizeForSignedIntegral<s::cl_char, sizeof(int8_t)>();

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -130,10 +130,6 @@ int main() {
         });
   });
 
-  // expected-warning@+1{{'byte' is deprecated: use std::byte instead}}
-  sycl::byte B;
-  (void)B;
-
   // expected-warning@+1{{'max_constant_buffer_size' is deprecated: max_constant_buffer_size is deprecated}}
   auto MCBS = sycl::info::device::max_constant_buffer_size;
   (void)MCBS;


### PR DESCRIPTION
sycl::byte is deprecated and is removed in the https://github.com/intel/llvm/pull/4424. Tests are updated accordingly to this change
Signed-off-by: mdimakov <maxim.dimakov@intel.com>