### PR TITLE
[SYCL] Remove handler::codeplay_host_task from tests

### DIFF
--- a/sycl/unittests/pi/cuda/test_interop_get_native.cpp
+++ b/sycl/unittests/pi/cuda/test_interop_get_native.cpp
@@ -88,7 +88,7 @@ TEST_P(CudaInteropGetNativeTests, hostTaskGetNativeMem) {
   buffer<int, 1> syclBuffer(range<1>{1});
   syclQueue_->submit([&](handler &cgh) {
     auto syclAccessor = syclBuffer.get_access<access::mode::read>(cgh);
-    cgh.codeplay_host_task([=](interop_handle ih) {
+    cgh.host_task([=](interop_handle ih) {
       CUdeviceptr cudaPtr = ih.get_native_mem<backend::cuda>(syclAccessor);
       CUdeviceptr cudaPtrBase;
       size_t cudaPtrSize = 0;
@@ -106,7 +106,7 @@ TEST_P(CudaInteropGetNativeTests, hostTaskGetNativeMem) {
 TEST_P(CudaInteropGetNativeTests, hostTaskGetNativeQueue) {
   CUstream cudaStream = get_native<backend::cuda>(*syclQueue_);
   syclQueue_->submit([&](handler &cgh) {
-    cgh.codeplay_host_task([=](interop_handle ih) {
+    cgh.host_task([=](interop_handle ih) {
       CUstream cudaInteropStream = ih.get_native_queue<backend::cuda>();
       ASSERT_EQ(cudaInteropStream, cudaStream);
     });
@@ -116,7 +116,7 @@ TEST_P(CudaInteropGetNativeTests, hostTaskGetNativeQueue) {
 TEST_P(CudaInteropGetNativeTests, hostTaskGetNativeContext) {
   CUcontext cudaContext = get_native<backend::cuda>(syclQueue_->get_context());
   syclQueue_->submit([&](handler &cgh) {
-    cgh.codeplay_host_task([=](interop_handle ih) {
+    cgh.host_task([=](interop_handle ih) {
       CUcontext cudaInteropContext = ih.get_native_context<backend::cuda>();
       ASSERT_EQ(cudaInteropContext, cudaContext);
     });

--- a/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
@@ -106,7 +106,7 @@ TEST_F(SchedulerTest, InOrderQueueHostTaskDeps) {
   InOrderQueue
       .submit([&](sycl::handler &CGH) {
         CGH.use_kernel_bundle(ExecBundle);
-        CGH.codeplay_host_task([=] {});
+        CGH.host_task([=] {});
       })
       .wait();
 


### PR DESCRIPTION
handler::codeplay_host_task is deprecated and is removed in the https://github.com/intel/llvm/pull/4426
Changes in lit tests : https://github.com/intel/llvm-test-suite/pull/428
Signed-off-by: mdimakov <maxim.dimakov@intel.com>