### PR TITLE
[sycl-post-link] Fix dangling pointers in scalar defaults

### DIFF
--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -337,10 +337,10 @@ void collectCompositeElementsDefaultValuesRecursive(
         std::copy_n(reinterpret_cast<char *>(&v), NumBytes,
                     std::back_inserter(DefaultValues));
       } else {
-        assert(false && "Unexpected constant floating point type");
+        llvm_unreachable("Unexpected constant floating point type");
       }
     } else {
-      assert(false && "Unexpected constant scalar type");
+      llvm_unreachable("Unexpected constant scalar type");
     }
     Offset += NumBytes;
   }

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -320,24 +320,28 @@ void collectCompositeElementsDefaultValuesRecursive(
   } else { // Assume that we encountered some scalar element
     int NumBytes = Ty->getScalarSizeInBits() / CHAR_BIT +
                    (Ty->getScalarSizeInBits() % 8 != 0);
-    char *CharPtr = nullptr;
 
     if (auto IntConst = dyn_cast<ConstantInt>(C)) {
       auto Val = IntConst->getValue().getZExtValue();
-      CharPtr = reinterpret_cast<char *>(&Val);
+      std::copy_n(reinterpret_cast<char *>(&Val), NumBytes,
+                  std::back_inserter(DefaultValues));
     } else if (auto FPConst = dyn_cast<ConstantFP>(C)) {
       auto Val = FPConst->getValue();
 
       if (NumBytes == 4) {
         float v = Val.convertToFloat();
-        CharPtr = reinterpret_cast<char *>(&v);
+        std::copy_n(reinterpret_cast<char *>(&v), NumBytes,
+                    std::back_inserter(DefaultValues));
       } else if (NumBytes == 8) {
         double v = Val.convertToDouble();
-        CharPtr = reinterpret_cast<char *>(&v);
+        std::copy_n(reinterpret_cast<char *>(&v), NumBytes,
+                    std::back_inserter(DefaultValues));
+      } else {
+        assert(false && "Unexpected constant floating point type");
       }
+    } else {
+      assert(false && "Unexpected constant scalar type");
     }
-    assert(CharPtr && "Unexpected constant type");
-    std::copy_n(CharPtr, NumBytes, std::back_inserter(DefaultValues));
     Offset += NumBytes;
   }
 }


### PR DESCRIPTION
Scalar default values for specialization constants were copied through dangling pointers which could cause incorrect default values to be stored in specialization constant metadata.

SYCL/SpecConstants/2020/handler-api-aot-cpu.cpp in https://github.com/intel/llvm-test-suite/pull/361 tests this. Following these changes `XFAIL: *` can be removed.