### PR TITLE
[SYCL] Add template argument for buffer allocator

### DIFF
--- a/sycl/include/CL/sycl/backend.hpp
+++ b/sycl/include/CL/sycl/backend.hpp
@@ -191,7 +191,7 @@ typename std::enable_if<
 }
 
 template <backend Backend, typename T, int Dimensions = 1,
-          typename AllocatorT = buffer_allocator>
+          typename AllocatorT = buffer_allocator<detail::remove_const_t<T>>>
 typename std::enable_if<detail::InteropFeatureSupportMap<Backend>::MakeBuffer ==
                             true,
                         buffer<T, Dimensions, AllocatorT>>::type

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -31,10 +31,11 @@ template <int dimensions> class range;
 /// \sa sycl_api_acc
 ///
 /// \ingroup sycl_api
-template <typename T, int dimensions = 1,
-          typename AllocatorT = cl::sycl::buffer_allocator,
-          typename = typename detail::enable_if_t<(dimensions > 0) &&
-                                                  (dimensions <= 3)>>
+template <
+    typename T, int dimensions = 1,
+    typename AllocatorT = cl::sycl::buffer_allocator<detail::remove_const_t<T>>,
+    typename =
+        typename detail::enable_if_t<(dimensions > 0) && (dimensions <= 3)>>
 class buffer {
 public:
   using value_type = T;

--- a/sycl/include/CL/sycl/detail/buffer_impl.hpp
+++ b/sycl/include/CL/sycl/detail/buffer_impl.hpp
@@ -35,6 +35,7 @@ class buffer;
 template <typename DataT, int Dimensions, access::mode AccessMode>
 class host_accessor;
 
+template <typename T = char>
 using buffer_allocator = detail::sycl_memory_object_allocator;
 
 namespace detail {

--- a/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
+++ b/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
@@ -203,11 +203,12 @@ TEST_F(SchedulerTest, NoHostUnifiedMemory) {
     cl_mem MockInteropBuffer = reinterpret_cast<cl_mem>(1);
     context InteropContext = Q.get_context();
     InteropPiContext = detail::getSyclObjImpl(InteropContext)->getHandleRef();
-    std::shared_ptr<detail::buffer_impl> BufI = std::make_shared<
-        detail::buffer_impl>(
-        MockInteropBuffer, Q.get_context(), /*BufSize*/ 8,
-        make_unique_ptr<detail::SYCLMemObjAllocatorHolder<buffer_allocator>>(),
-        event());
+    std::shared_ptr<detail::buffer_impl> BufI =
+        std::make_shared<detail::buffer_impl>(
+            MockInteropBuffer, Q.get_context(), /*BufSize*/ 8,
+            make_unique_ptr<
+                detail::SYCLMemObjAllocatorHolder<buffer_allocator<size_t>>>(),
+            event());
 
     detail::Requirement Req = getMockRequirement();
     Req.MSYCLMemObj = BufI.get();


### PR DESCRIPTION
According to SYCL 2020 spec, buffer_allocator is templated on the data
type. However, the current implementation doesn't take template
argument. This patch adds template argument to buffer_allocator.