### PR TITLE
[Driver][SYCL] Do not set default device code split mode for FPGA

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8920,7 +8920,8 @@ void SYCLPostLink::ConstructJob(Compilation &C, const JobAction &JA,
       // split must be off
       assert(StringRef(A->getValue()) == "off");
   } else if (getToolChain().getTriple().getArchName() != "spir64_fpga") {
-    // auto is the default split mode
+    // for FPGA targets, off is the default split mode,
+    // otherwise auto is the default split mode
     addArgs(CmdArgs, TCArgs, {"-split=auto"});
   }
   // OPT_fsycl_device_code_split is not checked as it is an alias to

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8919,7 +8919,7 @@ void SYCLPostLink::ConstructJob(Compilation &C, const JobAction &JA,
     else
       // split must be off
       assert(StringRef(A->getValue()) == "off");
-  } else {
+  } else if (getToolChain().getTriple().getArchName() != "spir64_fpga") {
     // auto is the default split mode
     addArgs(CmdArgs, TCArgs, {"-split=auto"});
   }

--- a/clang/test/Driver/sycl-offload-with-split.c
+++ b/clang/test/Driver/sycl-offload-with-split.c
@@ -297,14 +297,14 @@
 // CHK-NO-SPLIT-NOT: sycl-post-link{{.*}} -split{{.*}}
 
 // Check no device code split mode is passed to sycl-post-link when -fsycl-device-code-split is not set and the target is FPGA
-// RUN:   %clang -### -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
+// RUN:   %clang -### -fsycl -fsycl-targets=spir64_fpga-unknown-unknown %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
 
 // Check device code split mode is honored when -fsycl-device-code-split is set and the target is FPGA
-// RUN:   %clang -### -fsycl -fsycl-device-code-split -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
-// RUN:   %clang -### -fsycl -fsycl-device-code-split=auto -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
-// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-ONE-KERNEL
-// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-PER-SOURCE
-// RUN:   %clang -### -fsycl -fsycl-device-code-split=off -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
+// RUN:   %clang -### -fsycl -fsycl-device-code-split -fsycl-targets=spir64_fpga-unknown-unknown %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=auto -fsycl-targets=spir64_fpga-unknown-unknown %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=spir64_fpga-unknown-unknown %s 2>&1 | FileCheck %s -check-prefixes=CHK-ONE-KERNEL
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_fpga-unknown-unknown %s 2>&1 | FileCheck %s -check-prefixes=CHK-PER-SOURCE
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=off -fsycl-targets=spir64_fpga-unknown-unknown %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
 
 // Check ESIMD device code split.
 // RUN:   %clang    -### -fsycl %s 2>&1 | FileCheck %s -check-prefixes=CHK-ESIMD-SPLIT

--- a/clang/test/Driver/sycl-offload-with-split.c
+++ b/clang/test/Driver/sycl-offload-with-split.c
@@ -296,6 +296,16 @@
 // RUN:    | FileCheck %s -check-prefixes=CHK-NO-SPLIT
 // CHK-NO-SPLIT-NOT: sycl-post-link{{.*}} -split{{.*}}
 
+// Check no device code split mode is passed to sycl-post-link when -fsycl-device-code-split is not set but -fintelfpga is set
+// RUN:   %clang -### -fsycl -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
+
+// Check device code split mode is honored when both -fsycl-device-code-split and -fintelfpga are set
+// RUN:   %clang -### -fsycl -fsycl-device-code-split -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=auto -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_kernel -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-ONE-KERNEL
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_source -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-PER-SOURCE
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=off -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
+
 // Check ESIMD device code split.
 // RUN:   %clang    -### -fsycl %s 2>&1 | FileCheck %s -check-prefixes=CHK-ESIMD-SPLIT
 // RUN:   %clang_cl -### -fsycl %s 2>&1 | FileCheck %s -check-prefixes=CHK-ESIMD-SPLIT

--- a/clang/test/Driver/sycl-offload-with-split.c
+++ b/clang/test/Driver/sycl-offload-with-split.c
@@ -296,15 +296,15 @@
 // RUN:    | FileCheck %s -check-prefixes=CHK-NO-SPLIT
 // CHK-NO-SPLIT-NOT: sycl-post-link{{.*}} -split{{.*}}
 
-// Check no device code split mode is passed to sycl-post-link when -fsycl-device-code-split is not set but -fintelfpga is set
-// RUN:   %clang -### -fsycl -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
+// Check no device code split mode is passed to sycl-post-link when -fsycl-device-code-split is not set and the target is FPGA
+// RUN:   %clang -### -fsycl -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
 
-// Check device code split mode is honored when both -fsycl-device-code-split and -fintelfpga are set
-// RUN:   %clang -### -fsycl -fsycl-device-code-split -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
-// RUN:   %clang -### -fsycl -fsycl-device-code-split=auto -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
-// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_kernel -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-ONE-KERNEL
-// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_source -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-PER-SOURCE
-// RUN:   %clang -### -fsycl -fsycl-device-code-split=off -fintelfpga %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
+// Check device code split mode is honored when -fsycl-device-code-split is set and the target is FPGA
+// RUN:   %clang -### -fsycl -fsycl-device-code-split -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=auto -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-AUTO
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-ONE-KERNEL
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-PER-SOURCE
+// RUN:   %clang -### -fsycl -fsycl-device-code-split=off -fsycl-targets=spir64_fpga-unknown-unknown-sycldevice %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT
 
 // Check ESIMD device code split.
 // RUN:   %clang    -### -fsycl %s 2>&1 | FileCheck %s -check-prefixes=CHK-ESIMD-SPLIT


### PR DESCRIPTION
The Driver passes default device code split mode (-split=auto) to
sycl-post-link when -fsycl-device-code-split is not set. This should
not be applied for FPGA, because FPGA is using SYCL_EXTERNAL for
some of their library configurations but auto device code split mode
impacts this behavior.

Signed-off-by: Qichao Gu <qichao.gu@intel.com>