### PR TITLE
[Build] Allow libclc-remangler to build with shared libs

### DIFF
--- a/libclc/utils/libclc-remangler/CMakeLists.txt
+++ b/libclc/utils/libclc-remangler/CMakeLists.txt
@@ -2,6 +2,8 @@
 set(LLVM_LINK_COMPONENTS
   BitWriter
   BitReader
+  Core
+  Demangle
   Support
   )
 


### PR DESCRIPTION
Fix build with BUILD_SHARED_LIBS=ON

Signed-off-by: Victor Lomuller <victor@codeplay.com>