### PR TITLE
[SYCL] Add deprecation warnings for unstable keys of SYCL_DEVICE_ALLOWLIST

### DIFF
--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -77,6 +77,12 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
                               "doc/EnvironmentVariables.md",
                               PI_INVALID_VALUE);
 
+  const std::string &DeprecatedKeyNameDeviceName = DeviceNameKeyName;
+  const std::string &DeprecatedKeyNamePlatformName = PlatformNameKeyName;
+
+  bool IsDeprecatedKeyNameDeviceNameWasUsed = false;
+  bool IsDeprecatedKeyNamePlatformNameWasUsed = false;
+
   while ((KeyEnd = AllowListRaw.find(DelimiterBtwKeyAndValue, KeyStart)) !=
          std::string::npos) {
     if ((ValueStart = AllowListRaw.find_first_not_of(
@@ -94,6 +100,13 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
           "https://github.com/intel/llvm/blob/sycl/sycl/doc/"
           "EnvironmentVariables.md",
           PI_INVALID_VALUE);
+    }
+
+    if (Key == DeprecatedKeyNameDeviceName) {
+      IsDeprecatedKeyNameDeviceNameWasUsed = true;
+    }
+    if (Key == DeprecatedKeyNamePlatformName) {
+      IsDeprecatedKeyNamePlatformNameWasUsed = true;
     }
 
     bool ShouldAllocateNewDeviceDescMap = false;
@@ -239,6 +252,27 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
       ++DeviceDescIndex;
       AllowListParsed.emplace_back();
     }
+  }
+
+  if (IsDeprecatedKeyNameDeviceNameWasUsed &&
+      IsDeprecatedKeyNamePlatformNameWasUsed) {
+    std::cerr << "\nWARNING: " << DeprecatedKeyNameDeviceName << " and "
+              << DeprecatedKeyNamePlatformName
+              << " in SYCL_DEVICE_ALLOWLIST are deprecated. ";
+  } else if (IsDeprecatedKeyNameDeviceNameWasUsed) {
+    std::cerr << "\nWARNING: " << DeprecatedKeyNameDeviceName
+              << " in SYCL_DEVICE_ALLOWLIST is deprecated. ";
+  } else if (IsDeprecatedKeyNamePlatformNameWasUsed) {
+    std::cerr << "\nWARNING: " << DeprecatedKeyNamePlatformName
+              << " in SYCL_DEVICE_ALLOWLIST is deprecated. ";
+  }
+  if (IsDeprecatedKeyNameDeviceNameWasUsed ||
+      IsDeprecatedKeyNamePlatformNameWasUsed) {
+    std::cerr << "Please use " << BackendNameKeyName << ", "
+              << DeviceTypeKeyName << " and " << DeviceVendorIdKeyName
+              << " instead. For details, please refer to "
+                 "https://github.com/intel/llvm/blob/sycl/sycl/doc/"
+                 "EnvironmentVariables.md\n\n";
   }
 
   return AllowListParsed;

--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -256,19 +256,19 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
 
   if (IsDeprecatedKeyNameDeviceNameWasUsed &&
       IsDeprecatedKeyNamePlatformNameWasUsed) {
-    std::cerr << "\nWARNING: " << DeprecatedKeyNameDeviceName << " and "
+    std::cout << "\nWARNING: " << DeprecatedKeyNameDeviceName << " and "
               << DeprecatedKeyNamePlatformName
               << " in SYCL_DEVICE_ALLOWLIST are deprecated. ";
   } else if (IsDeprecatedKeyNameDeviceNameWasUsed) {
-    std::cerr << "\nWARNING: " << DeprecatedKeyNameDeviceName
+    std::cout << "\nWARNING: " << DeprecatedKeyNameDeviceName
               << " in SYCL_DEVICE_ALLOWLIST is deprecated. ";
   } else if (IsDeprecatedKeyNamePlatformNameWasUsed) {
-    std::cerr << "\nWARNING: " << DeprecatedKeyNamePlatformName
+    std::cout << "\nWARNING: " << DeprecatedKeyNamePlatformName
               << " in SYCL_DEVICE_ALLOWLIST is deprecated. ";
   }
   if (IsDeprecatedKeyNameDeviceNameWasUsed ||
       IsDeprecatedKeyNamePlatformNameWasUsed) {
-    std::cerr << "Please use " << BackendNameKeyName << ", "
+    std::cout << "Please use " << BackendNameKeyName << ", "
               << DeviceTypeKeyName << " and " << DeviceVendorIdKeyName
               << " instead. For details, please refer to "
                  "https://github.com/intel/llvm/blob/sycl/sycl/doc/"

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -267,3 +267,48 @@ TEST(ParseAllowListTests, CheckExceptionIsThrownForValueWOColonDelim) {
     FAIL() << "Expected sycl::runtime_error";
   }
 }
+
+TEST(ParseAllowListTests, CheckDeviceNameDeprecationWarning) {
+  testing::internal::CaptureStderr();
+  sycl::detail::parseAllowList("DeviceName:{{regex}}");
+  std::string ActualOutput = testing::internal::GetCapturedStderr();
+  EXPECT_EQ("\nWARNING: DeviceName in SYCL_DEVICE_ALLOWLIST is deprecated. "
+            "Please use BackendName, DeviceType and DeviceVendorId instead. "
+            "For details, please refer to "
+            "https://github.com/intel/llvm/blob/sycl/sycl/doc/"
+            "EnvironmentVariables.md\n\n",
+            ActualOutput);
+}
+
+TEST(ParseAllowListTests, CheckPlatformNameDeprecationWarning) {
+  testing::internal::CaptureStderr();
+  sycl::detail::parseAllowList("PlatformName:{{regex}}");
+  std::string ActualOutput = testing::internal::GetCapturedStderr();
+  EXPECT_EQ("\nWARNING: PlatformName in SYCL_DEVICE_ALLOWLIST is deprecated. "
+            "Please use BackendName, DeviceType and DeviceVendorId instead. "
+            "For details, please refer to "
+            "https://github.com/intel/llvm/blob/sycl/sycl/doc/"
+            "EnvironmentVariables.md\n\n",
+            ActualOutput);
+}
+
+TEST(ParseAllowListTests, CheckDeviceNameAndPlatformNameDeprecationWarning) {
+  testing::internal::CaptureStderr();
+  sycl::detail::parseAllowList("DeviceName:{{regex}},PlatformName:{{regex}}");
+  std::string ActualOutput = testing::internal::GetCapturedStderr();
+  EXPECT_EQ("\nWARNING: DeviceName and PlatformName in SYCL_DEVICE_ALLOWLIST "
+            "are deprecated. Please use BackendName, DeviceType and "
+            "DeviceVendorId instead. For details, please refer to "
+            "https://github.com/intel/llvm/blob/sycl/sycl/doc/"
+            "EnvironmentVariables.md\n\n",
+            ActualOutput);
+}
+
+TEST(ParseAllowListTests, CheckNoDeprecationWarningForNotDeprecatedKeys) {
+  testing::internal::CaptureStderr();
+  sycl::detail::parseAllowList(
+      "BackendName:level_zero,DeviceType:gpu,DeviceVendorId:0x0000,"
+      "DriverVersion:{{regex1}},PlatformVersion:{{regex2}}");
+  std::string ActualOutput = testing::internal::GetCapturedStderr();
+  EXPECT_EQ("", ActualOutput);
+}

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -269,9 +269,9 @@ TEST(ParseAllowListTests, CheckExceptionIsThrownForValueWOColonDelim) {
 }
 
 TEST(ParseAllowListTests, CheckDeviceNameDeprecationWarning) {
-  testing::internal::CaptureStderr();
+  testing::internal::CaptureStdout();
   sycl::detail::parseAllowList("DeviceName:{{regex}}");
-  std::string ActualOutput = testing::internal::GetCapturedStderr();
+  std::string ActualOutput = testing::internal::GetCapturedStdout();
   EXPECT_EQ("\nWARNING: DeviceName in SYCL_DEVICE_ALLOWLIST is deprecated. "
             "Please use BackendName, DeviceType and DeviceVendorId instead. "
             "For details, please refer to "
@@ -281,9 +281,9 @@ TEST(ParseAllowListTests, CheckDeviceNameDeprecationWarning) {
 }
 
 TEST(ParseAllowListTests, CheckPlatformNameDeprecationWarning) {
-  testing::internal::CaptureStderr();
+  testing::internal::CaptureStdout();
   sycl::detail::parseAllowList("PlatformName:{{regex}}");
-  std::string ActualOutput = testing::internal::GetCapturedStderr();
+  std::string ActualOutput = testing::internal::GetCapturedStdout();
   EXPECT_EQ("\nWARNING: PlatformName in SYCL_DEVICE_ALLOWLIST is deprecated. "
             "Please use BackendName, DeviceType and DeviceVendorId instead. "
             "For details, please refer to "
@@ -293,9 +293,9 @@ TEST(ParseAllowListTests, CheckPlatformNameDeprecationWarning) {
 }
 
 TEST(ParseAllowListTests, CheckDeviceNameAndPlatformNameDeprecationWarning) {
-  testing::internal::CaptureStderr();
+  testing::internal::CaptureStdout();
   sycl::detail::parseAllowList("DeviceName:{{regex}},PlatformName:{{regex}}");
-  std::string ActualOutput = testing::internal::GetCapturedStderr();
+  std::string ActualOutput = testing::internal::GetCapturedStdout();
   EXPECT_EQ("\nWARNING: DeviceName and PlatformName in SYCL_DEVICE_ALLOWLIST "
             "are deprecated. Please use BackendName, DeviceType and "
             "DeviceVendorId instead. For details, please refer to "
@@ -305,10 +305,10 @@ TEST(ParseAllowListTests, CheckDeviceNameAndPlatformNameDeprecationWarning) {
 }
 
 TEST(ParseAllowListTests, CheckNoDeprecationWarningForNotDeprecatedKeys) {
-  testing::internal::CaptureStderr();
+  testing::internal::CaptureStdout();
   sycl::detail::parseAllowList(
       "BackendName:level_zero,DeviceType:gpu,DeviceVendorId:0x0000,"
       "DriverVersion:{{regex1}},PlatformVersion:{{regex2}}");
-  std::string ActualOutput = testing::internal::GetCapturedStderr();
+  std::string ActualOutput = testing::internal::GetCapturedStdout();
   EXPECT_EQ("", ActualOutput);
 }


### PR DESCRIPTION
This patch adds deprecation warnings for DeviceName and PlatformName
keys of SYCL_DEVICE_ALLOWLIST and suggests using stable BackendName,
DeviceType and DeviceVendorId keys instead of them