### PR TITLE
[SYCL][CUDA] Fix context clearing in PiCuda tests

### DIFF
--- a/sycl/unittests/pi/cuda/CudaUtils.hpp
+++ b/sycl/unittests/pi/cuda/CudaUtils.hpp
@@ -1,0 +1,20 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cuda.h>
+
+namespace pi {
+
+// utility function to clear the CUDA context stack
+inline void clearCudaContext() {
+  CUcontext ctxt = nullptr;
+  do {
+    cuCtxSetCurrent(nullptr);
+    cuCtxGetCurrent(&ctxt);
+  } while (ctxt != nullptr);
+}
+
+} // namespace pi

--- a/sycl/unittests/pi/cuda/test_commands.cpp
+++ b/sycl/unittests/pi/cuda/test_commands.cpp
@@ -10,8 +10,8 @@
 
 #include <cuda.h>
 
-#include "TestGetPlugin.hpp"
 #include "CudaUtils.hpp"
+#include "TestGetPlugin.hpp"
 #include <CL/sycl.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <detail/plugin.hpp>

--- a/sycl/unittests/pi/cuda/test_commands.cpp
+++ b/sycl/unittests/pi/cuda/test_commands.cpp
@@ -11,6 +11,7 @@
 #include <cuda.h>
 
 #include "TestGetPlugin.hpp"
+#include "CudaUtils.hpp"
 #include <CL/sycl.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <detail/plugin.hpp>
@@ -34,7 +35,7 @@ protected:
       GTEST_SKIP();
     }
 
-    cuCtxSetCurrent(nullptr);
+    pi::clearCudaContext();
     pi_uint32 numPlatforms = 0;
     ASSERT_EQ(plugin->getBackend(), backend::cuda);
 

--- a/sycl/unittests/pi/cuda/test_contexts.cpp
+++ b/sycl/unittests/pi/cuda/test_contexts.cpp
@@ -14,8 +14,8 @@
 
 #include <cuda.h>
 
-#include "TestGetPlugin.hpp"
 #include "CudaUtils.hpp"
+#include "TestGetPlugin.hpp"
 #include <CL/sycl.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <detail/plugin.hpp>

--- a/sycl/unittests/pi/cuda/test_contexts.cpp
+++ b/sycl/unittests/pi/cuda/test_contexts.cpp
@@ -15,6 +15,7 @@
 #include <cuda.h>
 
 #include "TestGetPlugin.hpp"
+#include "CudaUtils.hpp"
 #include <CL/sycl.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <detail/plugin.hpp>
@@ -63,7 +64,7 @@ protected:
 
 TEST_F(CudaContextsTest, ContextLifetime) {
   // start with no active context
-  cuCtxSetCurrent(nullptr);
+  pi::clearCudaContext();
 
   // create a context
   pi_context context;
@@ -149,7 +150,7 @@ TEST_F(CudaContextsTest, ContextLifetimeExisting) {
 // still able to work correctly in that thread.
 TEST_F(CudaContextsTest, ContextThread) {
   // start with no active context
-  cuCtxSetCurrent(nullptr);
+  pi::clearCudaContext();
 
   // create two PI contexts
   pi_context context1;

--- a/sycl/unittests/pi/cuda/test_mem_obj.cpp
+++ b/sycl/unittests/pi/cuda/test_mem_obj.cpp
@@ -11,6 +11,7 @@
 #include <cuda.h>
 
 #include "TestGetPlugin.hpp"
+#include "CudaUtils.hpp"
 #include <CL/sycl.hpp>
 #include <CL/sycl/detail/cuda_definitions.hpp>
 #include <CL/sycl/detail/pi.hpp>
@@ -34,7 +35,7 @@ protected:
       GTEST_SKIP();
     }
 
-    cuCtxSetCurrent(nullptr);
+    pi::clearCudaContext();
     pi_uint32 numPlatforms = 0;
     ASSERT_EQ(plugin->getBackend(), backend::cuda);
 

--- a/sycl/unittests/pi/cuda/test_mem_obj.cpp
+++ b/sycl/unittests/pi/cuda/test_mem_obj.cpp
@@ -10,8 +10,8 @@
 
 #include <cuda.h>
 
-#include "TestGetPlugin.hpp"
 #include "CudaUtils.hpp"
+#include "TestGetPlugin.hpp"
 #include <CL/sycl.hpp>
 #include <CL/sycl/detail/cuda_definitions.hpp>
 #include <CL/sycl/detail/pi.hpp>


### PR DESCRIPTION
`cuCtxSetCurrent(nullptr)` will only discard the top of the context
stack so the current context may still not be `nullptr` after this.

To fix this, this patch introduces a small utility function to pop the
entire context stack when we're trying to reset it in the tests.

As discussed on:
* https://github.com/intel/llvm/pull/4442#discussion_r701205458