### PR TITLE
[SYCL] Fix warning in integration header about empty array.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4823,6 +4823,15 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     }
     O << "\n";
   }
+
+  // Sentinel in place for 2 reasons:
+  // 1- to make sure we don't get a warning because this collection is empty.
+  // 2- to provide an obvious value that we can use when debugging to see that
+  //    we have left valid kernel information.
+  // integer-field values are negative, so they are obviously invalid, notable
+  // enough to 'stick out' and 'negative enough' to not be easily reachable by a
+  // mathematical error.
+  O << "  { kernel_param_kind_t::kind_invalid, -987654321, -987654321 }, \n";
   O << "};\n\n";
 
   O << "// Specializations of KernelInfo for kernel function types:\n";

--- a/clang/test/CodeGenSYCL/int-header-empty-signatures.cpp
+++ b/clang/test/CodeGenSYCL/int-header-empty-signatures.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -fsycl-int-header=%t.h %s -fsyntax-only
+// RUN: FileCheck -input-file=%t.h %s
+// This testv validates that we don't generate an empty 'kernel_signatures' in
+// the case where there are no kernel fields. This is to avoid a warning in the
+// integration header.
+
+// CHECK: static constexpr
+// CHECK-NEXT: const char* const kernel_names[] = {
+// CHECK-NEXT:   "_ZTSZ4mainE1K"
+// CHECK-NEXT: };
+
+// CHECK: static constexpr
+// CHECK-NEXT: const kernel_param_desc_t kernel_signatures[] = {
+// CHECK-NEXT: //--- _ZTSZ4mainE1K
+// CHECK-EMPTY:
+// CHECK-NEXT:   { kernel_param_kind_t::kind_invalid, -987654321, -987654321 },
+// CHECK-NEXT: };
+
+#include "Inputs/sycl.hpp"
+
+using namespace cl::sycl;
+
+int main() {
+  // captureless kernel lambda results in no fields.
+  kernel_single_task<class K>([]{});
+}

--- a/clang/test/CodeGenSYCL/int-header-empty-signatures.cpp
+++ b/clang/test/CodeGenSYCL/int-header-empty-signatures.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -fsycl-int-header=%t.h %s -fsyntax-only
 // RUN: FileCheck -input-file=%t.h %s
-// This testv validates that we don't generate an empty 'kernel_signatures' in
+// This test validates that we don't generate an empty 'kernel_signatures' in
 // the case where there are no kernel fields. This is to avoid a warning in the
 // integration header.
 

--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -48,6 +48,7 @@
 // CHECK-NEXT:  { kernel_param_kind_t::kind_accessor, 4062, 40 },
 // CHECK-NEXT:  { kernel_param_kind_t::kind_accessor, 4062, 52 },
 // CHECK-EMPTY:
+// CHECK-NEXT:  { kernel_param_kind_t::kind_invalid, -987654321, -987654321 },
 // CHECK-NEXT: };
 //
 // CHECK: template <> struct KernelInfo<first_kernel> {

--- a/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
@@ -23,6 +23,7 @@
 // CHECK-NEXT:   { kernel_param_kind_t::kind_accessor, 4062, 0 },
 // CHECK-NEXT:   { kernel_param_kind_t::kind_accessor, 4062, 12 },
 // CHECK-EMPTY:
+// CHECK-NEXT:   { kernel_param_kind_t::kind_invalid, -987654321, -987654321 },
 // CHECK-NEXT: };
 
 // CHECK: template <> struct KernelInfo<kernel_A> {

--- a/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
@@ -23,6 +23,7 @@
 // CHECK-NEXT:   { kernel_param_kind_t::kind_accessor, 4062, 0 },
 // CHECK-NEXT:   { kernel_param_kind_t::kind_accessor, 4062, 12 },
 // CHECK-EMPTY:
+// CHECK-NEXT:   { kernel_param_kind_t::kind_invalid, -987654321, -987654321 },
 // CHECK-NEXT: };
 
 // CHECK: template <> struct KernelInfo<kernel_C> {

--- a/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
@@ -29,6 +29,7 @@
 // CHECK-NEXT: //--- _ZTSZ4mainE8kernel_D
 // CHECK-NEXT:   { kernel_param_kind_t::kind_std_layout, 48, 0 },
 // CHECK-EMPTY:
+// CHECK-NEXT:   { kernel_param_kind_t::kind_invalid, -987654321, -987654321 },
 // CHECK-NEXT: };
 
 // CHECK: template <> struct KernelInfo<kernel_B> {

--- a/clang/test/CodeGenSYCL/struct_kernel_param.cpp
+++ b/clang/test/CodeGenSYCL/struct_kernel_param.cpp
@@ -14,6 +14,7 @@
 // CHECK-NEXT:  { kernel_param_kind_t::kind_std_layout, 8, 32 },
 // CHECK-NEXT:  { kernel_param_kind_t::kind_std_layout, 12, 40 },
 // CHECK-EMPTY:
+// CHECK-NEXT:  { kernel_param_kind_t::kind_invalid, -987654321, -987654321 },
 // CHECK-NEXT:};
 
 // This test checks if compiler accepts structures as kernel parameters.

--- a/clang/test/CodeGenSYCL/union-kernel-param-ih.cpp
+++ b/clang/test/CodeGenSYCL/union-kernel-param-ih.cpp
@@ -22,6 +22,7 @@
 // CHECK-NEXT:   //--- _ZTSZ4mainE8kernel_A
 // CHECK-NEXT:  { kernel_param_kind_t::kind_std_layout, 12, 0 },
 // CHECK-EMPTY:
+// CHECK-NEXT:  { kernel_param_kind_t::kind_invalid, -987654321, -987654321 },
 // CHECK-NEXT:};
 
 // CHECK: template <> struct KernelInfo<kernel_A> {

--- a/clang/test/CodeGenSYCL/wrapped-accessor.cpp
+++ b/clang/test/CodeGenSYCL/wrapped-accessor.cpp
@@ -19,6 +19,7 @@
 // CHECK-NEXT: //--- _ZTSZ4mainE14wrapped_access
 // CHECK-NEXT:   { kernel_param_kind_t::kind_accessor, 4062, 0 },
 // CHECK-EMPTY:
+// CHECK-NEXT:   { kernel_param_kind_t::kind_invalid, -987654321, -987654321 },
 // CHECK-NEXT: };
 
 // CHECK: template <> struct KernelInfo<wrapped_access> {

--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -29,6 +29,7 @@ enum class kernel_param_kind_t {
   kind_pointer = 3,
   kind_specialization_constants_buffer = 4,
   kind_stream = 5,
+  kind_invalid = 0xf, // not a valid kernel kind
 };
 
 // describes a kernel parameter
@@ -44,6 +45,8 @@ struct kernel_param_desc_t {
   // object
   int offset;
 };
+
+
 
 // Translates specialization constant type to its name.
 template <class Name> struct SpecConstantInfo {

--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -46,8 +46,6 @@ struct kernel_param_desc_t {
   int offset;
 };
 
-
-
 // Translates specialization constant type to its name.
 template <class Name> struct SpecConstantInfo {
   static constexpr const char *getName() { return ""; }

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1792,6 +1792,9 @@ pi_result ExecCGCommand::SetKernelParamsAndLaunch(
                                                       &SpecConstsBuffer);
       break;
     }
+    case kernel_param_kind_t::kind_invalid:
+      throw runtime_error("Invalid kernel param kind", PI_INVALID_VALUE);
+      break;
     }
   };
 

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -404,6 +404,9 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
         Index + IndexShift);
     break;
   }
+  case kernel_param_kind_t::kind_invalid:
+    throw runtime_error("Invalid kernel param kind", PI_INVALID_VALUE);
+    break;
   }
 }
 


### PR DESCRIPTION
The kernel_signatures array represents the list of fields for the
kernels. When no kernel has a field, this causes a warning about the
array being empty.

This patch adds a 'dummy' value at the end of the array that serves 2
purposes:
1- to suppress this warning.
2- to be obvious when the runtime ends up 1 past the end of the valid
array.