### PR TITLE
[SYCL] Add deprecation warnings to info::device/platform::extensions

### DIFF
--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -25,14 +25,13 @@ namespace info {
 // Information descriptors
 // A.1 Platform information descriptors
 enum class platform {
-  profile     = PI_PLATFORM_INFO_PROFILE,
-  version     = PI_PLATFORM_INFO_VERSION,
-  name        = PI_PLATFORM_INFO_NAME,
-  vendor      = PI_PLATFORM_INFO_VENDOR,
+  profile = PI_PLATFORM_INFO_PROFILE,
+  version = PI_PLATFORM_INFO_VERSION,
+  name = PI_PLATFORM_INFO_NAME,
+  vendor = PI_PLATFORM_INFO_VENDOR,
   extensions __SYCL2020_DEPRECATED(
       "platform::extensions is deprecated, use device::get_info() with"
-      " info::device::aspects instead.") =
-      PI_PLATFORM_INFO_EXTENSIONS,
+      " info::device::aspects instead.") = PI_PLATFORM_INFO_EXTENSIONS,
 };
 
 // A.2 Context information desctiptors

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -30,8 +30,8 @@ enum class platform {
   name        = PI_PLATFORM_INFO_NAME,
   vendor      = PI_PLATFORM_INFO_VENDOR,
   extensions __SYCL2020_DEPRECATED(
-      "platform::extensions is deprecated, use device::get_info() with
-      info::device::aspects instead.") =
+      "platform::extensions is deprecated, use device::get_info() with"
+      " info::device::aspects instead.") =
       PI_PLATFORM_INFO_EXTENSIONS,
 };
 
@@ -117,8 +117,8 @@ enum class device : cl_device_info {
   version = CL_DEVICE_VERSION,
   opencl_c_version = CL_DEVICE_OPENCL_C_VERSION,
   extensions __SYCL2020_DEPRECATED(
-      "device::extensions is deprecated, use info::device::aspects
-      instead.") = CL_DEVICE_EXTENSIONS,
+      "device::extensions is deprecated, use info::device::aspects"
+      " instead.") = CL_DEVICE_EXTENSIONS,
   printf_buffer_size = CL_DEVICE_PRINTF_BUFFER_SIZE,
   preferred_interop_user_sync = CL_DEVICE_PREFERRED_INTEROP_USER_SYNC,
   parent_device = CL_DEVICE_PARENT_DEVICE,

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -29,7 +29,10 @@ enum class platform {
   version     = PI_PLATFORM_INFO_VERSION,
   name        = PI_PLATFORM_INFO_NAME,
   vendor      = PI_PLATFORM_INFO_VENDOR,
-  extensions  = PI_PLATFORM_INFO_EXTENSIONS,
+  extensions __SYCL2020_DEPRECATED(
+      "platform::extensions is deprecated, use device::get_info() with
+      info::device::aspects instead.") =
+      PI_PLATFORM_INFO_EXTENSIONS,
 };
 
 // A.2 Context information desctiptors
@@ -113,7 +116,9 @@ enum class device : cl_device_info {
   profile = CL_DEVICE_PROFILE,
   version = CL_DEVICE_VERSION,
   opencl_c_version = CL_DEVICE_OPENCL_C_VERSION,
-  extensions = CL_DEVICE_EXTENSIONS,
+  extensions __SYCL2020_DEPRECATED(
+      "device::extensions is deprecated, use info::device::aspects
+      instead.") = CL_DEVICE_EXTENSIONS,
   printf_buffer_size = CL_DEVICE_PRINTF_BUFFER_SIZE,
   preferred_interop_user_sync = CL_DEVICE_PREFERRED_INTEROP_USER_SYNC,
   parent_device = CL_DEVICE_PARENT_DEVICE,

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -141,6 +141,12 @@ int main() {
   auto MCA = sycl::info::device::max_constant_args;
   (void)MCA;
 
+  // expected-warning@+1{{'extensions' is deprecated: platform::extensions is deprecated, use device::get_info() with info::device::aspects instead.}}
+  auto PE = sycl::info::platform::extensions;
+
+  // expected-warning@+1{{'extensions' is deprecated: device::extensions is deprecated, use info::device::aspects instead.}}
+  auto DE = sycl::info::device::extensions;
+
   // expected-warning@+4{{'ONEAPI' is deprecated: use 'ext::oneapi' instead}}
   // expected-warning@+3{{'atomic_fence' is deprecated: use sycl::atomic_fence instead}}
   // expected-warning@+2{{'ONEAPI' is deprecated: use 'ext::oneapi' instead}}


### PR DESCRIPTION
info::device/platform::extensions are deprecated in SYCL 2020, added warnings to them
Signed-off-by: mdimakov maxim.dimakov@intel.com