### PR TITLE
[SYCL] Predefine SYCL macros with vendor strings

### DIFF
--- a/sycl/include/CL/sycl.hpp
+++ b/sycl/include/CL/sycl.hpp
@@ -16,6 +16,7 @@
 #include <CL/sycl/buffer.hpp>
 #include <CL/sycl/builtins.hpp>
 #include <CL/sycl/context.hpp>
+#include <CL/sycl/define_vendors.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/device_selector.hpp>
 #include <CL/sycl/event.hpp>

--- a/sycl/include/CL/sycl/define_vendors.hpp
+++ b/sycl/include/CL/sycl/define_vendors.hpp
@@ -1,0 +1,13 @@
+//==---------- define_vendors.hpp ----- Preprocessor directives ------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#define SYCL_IMPLEMENTATION_ONEAPI
+#define SYCL_FEATURE_SET_FULL
+#define SYCL_IMPLEMENTATION_INTEL

--- a/sycl/test/basic_tests/define_vendors.cpp
+++ b/sycl/test/basic_tests/define_vendors.cpp
@@ -1,0 +1,16 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+#include <CL/sycl.hpp>
+
+#if !defined(SYCL_IMPLEMENTATION_ONEAPI)
+#error SYCL_IMPLEMENTATION_ONEAPI is not defined
+#endif
+
+#if !defined(SYCL_FEATURE_SET_FULL)
+#error SYCL_FEATURE_SET_FULL is not defined
+#endif
+
+#if !defined(SYCL_IMPLEMENTATION_INTEL)
+#error SYCL_IMPLEMENTATION_INTEL is not defined
+#endif
+
+int main(void) { return 0; }

--- a/sycl/test/basic_tests/define_vendors.cpp
+++ b/sycl/test/basic_tests/define_vendors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -c -o %t.out
 #include <CL/sycl.hpp>
 
 #if !defined(SYCL_IMPLEMENTATION_ONEAPI)
@@ -12,5 +12,3 @@
 #if !defined(SYCL_IMPLEMENTATION_INTEL)
 #error SYCL_IMPLEMENTATION_INTEL is not defined
 #endif
-
-int main(void) { return 0; }


### PR DESCRIPTION
The SYCL 2020 specification requires at least one macro of the form SYCL_IMPLEMENTATION_"vendorstring" to be predefined, which allows applications to check if they compile with this provider's implementation.

Our vendorstrings are SYCL_IMPLEMENTATION_ONEAPI and SYCL_IMPLEMENTATION_INTEL. The SYCL_FEATURE_SET_FULL macro is mandated by section 5.6. "Preprocessor directives and macros" of the SYCL 2020 specification.