### PR TITLE
Revert "[SYCL] Remove sycl::byte alias"

### DIFF
--- a/sycl/include/CL/sycl/aliases.hpp
+++ b/sycl/include/CL/sycl/aliases.hpp
@@ -68,6 +68,7 @@ using half __SYCL2020_DEPRECATED("use 'sycl::half' instead") =
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
+using byte __SYCL2020_DEPRECATED("use std::byte instead") = std::uint8_t;
 using schar = signed char;
 using uchar = unsigned char;
 using ushort = unsigned short;

--- a/sycl/include/CL/sycl/detail/image_impl.hpp
+++ b/sycl/include/CL/sycl/detail/image_impl.hpp
@@ -21,6 +21,7 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
+
 // forward declarations
 enum class image_channel_order : unsigned int;
 enum class image_channel_type : unsigned int;
@@ -35,7 +36,7 @@ class handler;
 namespace detail {
 
 // utility functions and typedefs for image_impl
-using image_allocator = aligned_allocator<unsigned char>;
+using image_allocator = aligned_allocator<byte>;
 
 // utility function: Returns the Number of Channels for a given Order.
 __SYCL_EXPORT uint8_t getImageNumberChannels(image_channel_order Order);

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -59,7 +59,9 @@ enum class image_channel_type : unsigned int {
   fp32 = 14
 };
 
-using image_allocator = detail::aligned_allocator<unsigned char>;
+using byte = unsigned char;
+
+using image_allocator = detail::aligned_allocator<byte>;
 
 /// Defines a shared image data.
 ///

--- a/sycl/include/CL/sycl/sycl_span.hpp
+++ b/sycl/include/CL/sycl/sycl_span.hpp
@@ -138,6 +138,9 @@ template<class Container>
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
+// byte is unsigned char at sycl/image.hpp:58
+using byte = unsigned char;
+
 // asserts suppressed for device compatibility.
 // TODO: enable
 #if defined(__SYCL_DEVICE_ONLY__)
@@ -381,17 +384,16 @@ public:
     return rev_iterator(begin());
   }
 
-  _SYCL_SPAN_INLINE_VISIBILITY
-  span<const std::byte, _Extent * sizeof(element_type)>
+  _SYCL_SPAN_INLINE_VISIBILITY span<const byte, _Extent * sizeof(element_type)>
   __as_bytes() const noexcept {
-    return span<const std::byte, _Extent * sizeof(element_type)>{
-        reinterpret_cast<const std::byte *>(data()), size_bytes()};
+    return span<const byte, _Extent * sizeof(element_type)>{
+        reinterpret_cast<const byte *>(data()), size_bytes()};
   }
 
-  _SYCL_SPAN_INLINE_VISIBILITY span<std::byte, _Extent * sizeof(element_type)>
+  _SYCL_SPAN_INLINE_VISIBILITY span<byte, _Extent * sizeof(element_type)>
   __as_writable_bytes() const noexcept {
-    return span<std::byte, _Extent * sizeof(element_type)>{
-        reinterpret_cast<std::byte *>(data()), size_bytes()};
+    return span<byte, _Extent * sizeof(element_type)>{
+        reinterpret_cast<byte *>(data()), size_bytes()};
   }
 
 private:
@@ -575,14 +577,14 @@ public:
     return rev_iterator(begin());
   }
 
-  _SYCL_SPAN_INLINE_VISIBILITY span<const std::byte, dynamic_extent>
+  _SYCL_SPAN_INLINE_VISIBILITY span<const byte, dynamic_extent>
   __as_bytes() const noexcept {
-    return {reinterpret_cast<const std::byte *>(data()), size_bytes()};
+    return {reinterpret_cast<const byte *>(data()), size_bytes()};
   }
 
-  _SYCL_SPAN_INLINE_VISIBILITY span<std::byte, dynamic_extent>
+  _SYCL_SPAN_INLINE_VISIBILITY span<byte, dynamic_extent>
   __as_writable_bytes() const noexcept {
-    return {reinterpret_cast<std::byte *>(data()), size_bytes()};
+    return {reinterpret_cast<byte *>(data()), size_bytes()};
   }
 
 private:

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -93,6 +93,9 @@ int main() {
   // Check the size and alignment of the SYCL vectors.
   checkVectors();
 
+  // Table 4.93: Additional scalar data types supported by SYCL.
+  static_assert(sizeof(s::byte) == sizeof(int8_t), "");
+
   // Table 4.94: Scalar data type aliases supported by SYCL
   static_assert(is_same<s::cl_bool, decltype(0 != 1)>::value, "");
   checkSizeForSignedIntegral<s::cl_char, sizeof(int8_t)>();

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -130,6 +130,10 @@ int main() {
         });
   });
 
+  // expected-warning@+1{{'byte' is deprecated: use std::byte instead}}
+  sycl::byte B;
+  (void)B;
+
   // expected-warning@+1{{'max_constant_buffer_size' is deprecated: max_constant_buffer_size is deprecated}}
   auto MCBS = sycl::info::device::max_constant_buffer_size;
   (void)MCBS;


### PR DESCRIPTION
It was decided that we should not remove sycl::byte now. Reverts intel/llvm#4424 