### PR TITLE
[SYCL][NFC] Update comment on default code split behavior

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4768,7 +4768,7 @@ class OffloadingActionBuilder final {
       auto *DeviceCodeSplitArg =
           Args.getLastArg(options::OPT_fsycl_device_code_split_EQ);
       // -fsycl-device-code-split is an alias to
-      // -fsycl-device-code-split=per_source
+      // -fsycl-device-code-split=auto
       DeviceCodeSplit = DeviceCodeSplitArg &&
                         DeviceCodeSplitArg->getValue() != StringRef("off");
       // Gather information about the SYCL Ahead of Time targets.  The targets


### PR DESCRIPTION
Since `auto` value introduction for `-fsycl-device-code-split`
in commit 184d258b902aaf28bbc7b9c787ac4ed082640610 (#2827),
it stands as the default code split mechanism.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>