### PR TITLE
[SYCL][Matrix][Query] Add the unsigned int variants

### DIFF
--- a/sycl/include/sycl/ext/oneapi/matrix/static-query.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/static-query.hpp
@@ -5,6 +5,20 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // ===--------------------------------------------------------------------=== //
+// This file implements the static query interface for the joint_matrix
+// experimental extension. AMX, DPAS and different other TPUs support different
+// logical sizes and types. The query interface is used to validate user code
+// and inform them about supported types, sizes, scope, and layouts by the
+// current implementation. Note that this query interface is a compile-time
+// query, so there will be no runtime errors. The query interface provides
+// three functionalities:
+// 1- At compile time, inform the user whether a specific
+// combination is valid or not.
+// 2- Construct the matrices using a default shape
+// if user does not provide a combination
+// 3- General query interface for sizes, types,
+// static/dynamic, scope. This is needed to void padding by the user,
+// for tuning, and efficient code generation if used by a library.
 
 #pragma once
 

--- a/sycl/include/sycl/ext/oneapi/matrix/static-query.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/static-query.hpp
@@ -311,14 +311,14 @@ struct tpu_params<tpu::dpas, void, void, void, M, N, K> {
       {0, 0, 0, mt::uint8, mt::uint8, mt::sint32, 2, 8, 32},
       {0, 0, 0, mt::uint8, mt::uint8, mt::sint32, 4, 8, 32},
       {0, 0, 0, mt::uint8, mt::uint8, mt::sint32, 8, 8, 32},
-      {0, 0, 0, mt::fp16, mt::fp16, mt::fp64, 1, 8, 16},
-      {0, 0, 0, mt::fp16, mt::fp16, mt::fp64, 2, 8, 16},
-      {0, 0, 0, mt::fp16, mt::fp16, mt::fp64, 4, 8, 16},
-      {0, 0, 0, mt::fp16, mt::fp16, mt::fp64, 8, 8, 16},
-      {0, 0, 0, mt::bf16, mt::bf16, mt::fp64, 1, 8, 16},
-      {0, 0, 0, mt::bf16, mt::bf16, mt::fp64, 2, 8, 16},
-      {0, 0, 0, mt::bf16, mt::bf16, mt::fp64, 4, 8, 16},
-      {0, 0, 0, mt::bf16, mt::bf16, mt::fp64, 8, 8, 16},
+      {0, 0, 0, mt::fp16, mt::fp16, mt::fp32, 1, 8, 16},
+      {0, 0, 0, mt::fp16, mt::fp16, mt::fp32, 2, 8, 16},
+      {0, 0, 0, mt::fp16, mt::fp16, mt::fp32, 4, 8, 16},
+      {0, 0, 0, mt::fp16, mt::fp16, mt::fp32, 8, 8, 16},
+      {0, 0, 0, mt::bf16, mt::bf16, mt::fp32, 1, 8, 16},
+      {0, 0, 0, mt::bf16, mt::bf16, mt::fp32, 2, 8, 16},
+      {0, 0, 0, mt::bf16, mt::bf16, mt::fp32, 4, 8, 16},
+      {0, 0, 0, mt::bf16, mt::bf16, mt::fp32, 8, 8, 16},
   };
   static constexpr int num_combinations =
       sizeof(combinations) / sizeof(combination);
@@ -368,15 +368,15 @@ struct tpu_params<tpu::dpas, Ta, Tb, Tc, 0, 0, 0,
     uint32_t nsize;
     uint32_t ksize;
   };
+  using mt = matrix_type;
   static constexpr combination combinations[] = {
-      {0, 0, 0, matrix_type(NULL), matrix_type(NULL), matrix_type(NULL), 1, 8,
-       (sizeof(Ta) == 1) ? 32 : 16},
-      {0, 0, 0, matrix_type(NULL), matrix_type(NULL), matrix_type(NULL), 2, 8,
-       (sizeof(Ta) == 1) ? 32 : 16},
-      {0, 0, 0, matrix_type(NULL), matrix_type(NULL), matrix_type(NULL), 4, 8,
-       (sizeof(Ta) == 1) ? 32 : 16},
-      {0, 0, 0, matrix_type(NULL), matrix_type(NULL), matrix_type(NULL), 8, 8,
-       (sizeof(Ta) == 1) ? 32 : 16},
+      // The types used in the initialization below are fake and not used. In
+      // this case, users already chose the types, they are only looking for the
+      // sizes
+      {0, 0, 0, mt::bf8, mt::bf8, mt::bf8, 1, 8, (sizeof(Ta) == 1) ? 32 : 16},
+      {0, 0, 0, mt::bf8, mt::bf8, mt::bf8, 2, 8, (sizeof(Ta) == 1) ? 32 : 16},
+      {0, 0, 0, mt::bf8, mt::bf8, mt::bf8, 4, 8, (sizeof(Ta) == 1) ? 32 : 16},
+      {0, 0, 0, mt::bf8, mt::bf8, mt::bf8, 8, 8, (sizeof(Ta) == 1) ? 32 : 16},
   };
   static constexpr int num_combinations =
       sizeof(combinations) / sizeof(combination);

--- a/sycl/test/matrix/query.cpp
+++ b/sycl/test/matrix/query.cpp
@@ -23,7 +23,7 @@ void query_amx() {
   std::cout << "sizes of AMX tpu_params chosen by the user are: M " << dmsize
             << " N " << dnsize << " K " << dksize << std::endl;
 
-  // types are given, generate default sizes
+  // Sizes-only query: types are given, generate default sizes
   using myparams2 = tpu_params<tpu::amx, int8_t, int8_t, int>;
   myparams2 p;
   dmsize = myparams2::defaultM;
@@ -34,7 +34,8 @@ void query_amx() {
             << p.num_combinations << std::endl;
 
   // general query: types are not given
-  constexpr tpu_params myparams3 = tpu_params<tpu::amx>();
+  tpu_params<tpu::amx> myparams3;
+
   std::cout << "AMX query num combinations: " << myparams3.num_combinations
             << std::endl;
 
@@ -83,7 +84,7 @@ void query_dpas() {
   std::cout << "sizes of DPAS tpu_params chosen by the user are: M " << dmsize
             << " N " << dnsize << " K " << dksize << std::endl;
 
-  // types are given, generate default sizes
+  // sizes-only query: types are given, generate default sizes
   using myparams2 = tpu_params<tpu::dpas, int8_t, int8_t, int>;
   myparams2 p;
   dmsize = myparams2::defaultM;
@@ -93,8 +94,14 @@ void query_dpas() {
             << " K " << dksize << "\n DPAS int8 num combinations is "
             << p.num_combinations << std::endl;
 
+  dmsize = myparams2::combinations[0].msize;
+  dnsize = myparams2::combinations[0].nsize;
+  dksize = myparams2::combinations[0].ksize;
+  std::cout << "one of DPAS combination sizes  is: M " << dmsize << " N "
+            << dnsize << " K " << dksize << std::endl;
+
   // general query: types are not given
-  constexpr tpu_params myparams3 = tpu_params<tpu::dpas>();
+  tpu_params<tpu::dpas> myparams3;
   std::cout << "DPAS query num combinations: " << myparams3.num_combinations
             << std::endl;
 


### PR DESCRIPTION
The unsigned variants of the mad matrix instructions has been added recently to the implementation. 
So this PR updates the query support to add these new mad instructions support. 