### PR TITLE
[SYCL] Add half constexpr default constructor

### DIFF
--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -261,6 +261,9 @@ private:
 
 } // namespace host_half_impl
 
+template <typename T>
+struct builtins_helper;
+
 namespace half_impl {
 class half;
 
@@ -311,7 +314,7 @@ template <int NumElements> struct half_vec {
 
 class half {
 public:
-  half() = default;
+  __SYCL_CONSTEXPR_HALF half() : Data(0.0f) {};
   constexpr half(const half &) = default;
   constexpr half(half &&) = default;
 
@@ -383,6 +386,7 @@ public:
   }
 
   template <typename Key> friend struct std::hash;
+  template <typename T> friend struct cl::sycl::detail::builtins_helper;
 private:
   StorageT Data;
 };


### PR DESCRIPTION
Add default constexpr constructor for half class. 
Due to bitselect built-in uses union with half specialization, but object of a class without trivial constructor cannot be a member of union, the builtins_helper struct was added. This struct allow to use host half class instead of main half class in the builtin.

Signed-off-by: mdimakov <maxim.dimakov@intel.com>