### PR TITLE
[SYCL] Throw runtime error when requested kernel ID is missing

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1262,7 +1262,10 @@ kernel_id ProgramManager::getSYCLKernelID(const std::string &KernelName) {
   std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
 
   auto KernelID = m_KernelIDs.find(KernelName);
-  assert(KernelID != m_KernelIDs.end() && "Kernel ID missing");
+  if (KernelID == m_KernelIDs.end()) {
+    throw runtime_error("No kernel found with the specified name",
+                        PI_INVALID_KERNEL_NAME);
+  }
   return KernelID->second;
 }
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1262,10 +1262,10 @@ kernel_id ProgramManager::getSYCLKernelID(const std::string &KernelName) {
   std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
 
   auto KernelID = m_KernelIDs.find(KernelName);
-  if (KernelID == m_KernelIDs.end()) {
+  if (KernelID == m_KernelIDs.end())
     throw runtime_error("No kernel found with the specified name",
                         PI_INVALID_KERNEL_NAME);
-  }
+
   return KernelID->second;
 }
 

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -269,3 +269,28 @@ TEST(KernelID, KernelIDHasKernel) {
   EXPECT_TRUE(InputBundle7.has_kernel(TestKernel2ID));
   EXPECT_TRUE(InputBundle7.has_kernel(TestKernel3ID));
 }
+
+TEST(KernelID, InvalidKernelName) {
+  sycl::platform Plt{sycl::default_selector()};
+  if (Plt.is_host()) {
+    std::cout << "Test is not supported on host, skipping\n";
+    return; // test is not supported on host.
+  }
+
+  if (Plt.get_backend() == sycl::backend::cuda) {
+    std::cout << "Test is not supported on CUDA platform, skipping\n";
+    return;
+  }
+
+  sycl::unittest::PiMock Mock{Plt};
+  setupDefaultMockAPIs(Mock);
+
+  try {
+    sycl::get_kernel_id<class NotAKernel>();
+    throw std::logic_error("sycl::runtime_error didn't throw");
+  } catch (sycl::runtime_error const &e) {
+    EXPECT_EQ(std::string("No kernel found with the specified name"), e.what());
+  } catch (...) {
+    FAIL() << "Expected sycl::runtime_error";
+  }
+}

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -289,7 +289,9 @@ TEST(KernelID, InvalidKernelName) {
     sycl::get_kernel_id<class NotAKernel>();
     throw std::logic_error("sycl::runtime_error didn't throw");
   } catch (sycl::runtime_error const &e) {
-    EXPECT_EQ(std::string("No kernel found with the specified name"), e.what());
+    EXPECT_EQ(std::string("No kernel found with the specified name -46 "
+                          "(CL_INVALID_KERNEL_NAME)"),
+              e.what());
   } catch (...) {
     FAIL() << "Expected sycl::runtime_error";
   }


### PR DESCRIPTION
As per the SYCL 2020 specification, a diagnostic must be issued when `get_kernel_id` is called with an unrecognized kernel name. This patch adds such a diagnostic.