### PR TITLE
[SYCL] Enable -fgpu-inline-threshold for SYCL offload

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7126,7 +7126,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (IsHIP)
     CmdArgs.push_back("-fcuda-allow-variadic-functions");
 
-  if (IsCudaDevice || IsHIPDevice) {
+  if (IsCudaDevice || IsHIPDevice || IsSYCLOffloadDevice) {
     StringRef InlineThresh =
         Args.getLastArgValue(options::OPT_fgpu_inline_threshold_EQ);
     if (!InlineThresh.empty()) {

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -36,3 +36,12 @@
 // RUN:   | FileCheck -check-prefix=CHECK-DAE %s
 // CHECK-DAE: clang{{.*}} "-fenable-sycl-dae"
 // CHECK-DAE: sycl-post-link{{.*}} "-emit-param-info"
+
+// Check "-fgpu-inline-threshold" is passed to the front-end:
+// RUN:   %clang -### -fsycl -fgpu-inline-threshold=100000 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-THRESH %s
+// CHECK-THRESH: "-mllvm" "-inline-threshold=100000"
+
+// RUN:   %clang -### -fsycl %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-THRESH %s
+// CHECK-NO-THRESH-NOT: "-mllvm" "-inline-threshold

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -81,6 +81,14 @@ and not recommended to use in production environment.
     * nd_item class get_global_id()/get_global_linear_id() member functions
     Enabled by default.
 
+
+**`-fgpu-inline-threshold=<n>`**
+
+    Sets the inline threshold for device compilation to <n>. Note that this
+    option only affects the behaviour of the DPC++ compiler, not target-
+    specific compilers (e.g. OpenCL/Level Zero/Nvidia/AMD target compilers)
+    which may or may not perform additional inlining.
+
 ## Target toolchain options
 
 **`-Xsycl-target-backend=<T> "options"`**

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -88,6 +88,7 @@ and not recommended to use in production environment.
     option only affects the behaviour of the DPC++ compiler, not target-
     specific compilers (e.g. OpenCL/Level Zero/Nvidia/AMD target compilers)
     which may or may not perform additional inlining.
+    Default value is 225.
 
 ## Target toolchain options
 


### PR DESCRIPTION
Minor change to enable -fgpu-inline-threshold when compiling SYCL device code.