### PR TITLE
[SYCL][CUDA] reduces time of getting reqdThreadsPerBlock for each submit

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2576,13 +2576,11 @@ pi_result cuda_piEnqueueKernelLaunch(
   int threadsPerBlock[3] = {32, 1, 1};
   size_t maxWorkGroupSize = 0u;
   size_t maxThreadsPerBlock[3] = {};
-  size_t reqdThreadsPerBlock[3] = {};
   bool providedLocalWorkGroupSize = (local_work_size != nullptr);
   pi_uint32 local_size = kernel->get_local_size();
 
   {
-    kernel->get_reqd_threads_per_block(sizeof(reqdThreadsPerBlock),
-                                       reqdThreadsPerBlock);
+    size_t *reqdThreadsPerBlock = kernel->reqdThreadsPerBlock_;
     maxWorkGroupSize = command_queue->device_->get_max_work_group_size();
     command_queue->device_->get_max_work_item_sizes(sizeof(maxThreadsPerBlock),
                                                     maxThreadsPerBlock);

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -673,11 +673,6 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
                                size_t param_value_size, void *param_value,
                                size_t *param_value_size_ret);
 
-pi_result cuda_piKernelGetGroupInfo(pi_kernel kernel, pi_device device,
-                                    pi_kernel_group_info param_name,
-                                    size_t param_value_size, void *param_value,
-                                    size_t *param_value_size_ret);
-
 /// Obtains the CUDA platform.
 /// There is only one CUDA platform, and contains all devices on the system.
 /// Triggers the CUDA Driver initialization (cuInit) the first time, so this
@@ -2407,17 +2402,6 @@ pi_result cuda_piKernelCreate(pi_program program, const char *kernel_name,
   } catch (...) {
     retErr = PI_OUT_OF_HOST_MEMORY;
   }
-
-  pi_device device = program->get_context()->get_device();
-  pi_kernel piKernel = retKernel.get();
-  size_t reqdThreadsPerBlock[3] = {};
-  pi_result retError = cuda_piKernelGetGroupInfo(
-      piKernel, device, PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE,
-      sizeof(reqdThreadsPerBlock), reqdThreadsPerBlock, nullptr);
-  assert(retError == PI_SUCCESS);
-
-  piKernel->save_reqd_threads_per_block(sizeof(reqdThreadsPerBlock),
-                                        reqdThreadsPerBlock);
 
   *kernel = retKernel.release();
   return retErr;

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2420,7 +2420,6 @@ pi_result cuda_piKernelCreate(pi_program program, const char *kernel_name,
                                         reqdThreadsPerBlock);
 
   *kernel = retKernel.release();
-
   return retErr;
 }
 

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -725,11 +725,6 @@ struct _pi_kernel {
                               size_t *save_reqd_threads_per_block) noexcept {
     std::memcpy(reqdThreadsPerBlock_, save_reqd_threads_per_block, size);
   };
-
-  void get_reqd_threads_per_block(
-      size_t ret_size, size_t *ret_reqd_threads_per_block) const noexcept {
-    std::memcpy(ret_reqd_threads_per_block, reqdThreadsPerBlock_, ret_size);
-  };
 };
 
 /// Implementation of samplers for CUDA

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -47,6 +47,10 @@ pi_result cuda_piMemRetain(pi_mem);
 pi_result cuda_piMemRelease(pi_mem);
 pi_result cuda_piKernelRetain(pi_kernel);
 pi_result cuda_piKernelRelease(pi_kernel);
+pi_result cuda_piKernelGetGroupInfo(pi_kernel kernel, pi_device device,
+                                    pi_kernel_group_info param_name,
+                                    size_t param_value_size, void *param_value,
+                                    size_t *param_value_size_ret);
 /// \endcond
 }
 
@@ -660,11 +664,22 @@ struct _pi_kernel {
         name_{name}, context_{ctxt}, program_{program}, refCount_{1} {
     cuda_piProgramRetain(program_);
     cuda_piContextRetain(context_);
+    /// Note: this code assumes that there is only one device per context
+    pi_result retError = cuda_piKernelGetGroupInfo(
+        this, ctxt->get_device(), PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE,
+        sizeof(reqdThreadsPerBlock_), reqdThreadsPerBlock_, nullptr);
+    assert(retError == PI_SUCCESS);
   }
 
   _pi_kernel(CUfunction func, const char *name, pi_program program,
              pi_context ctxt)
-      : _pi_kernel{func, nullptr, name, program, ctxt} {}
+      : _pi_kernel{func, nullptr, name, program, ctxt} {
+    /// Note: this code assumes that there is only one device per context
+    pi_result retError = cuda_piKernelGetGroupInfo(
+        this, ctxt->get_device(), PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE,
+        sizeof(reqdThreadsPerBlock_), reqdThreadsPerBlock_, nullptr);
+    assert(retError == PI_SUCCESS);
+  }
 
   ~_pi_kernel()
   {
@@ -719,12 +734,6 @@ struct _pi_kernel {
   pi_uint32 get_local_size() const noexcept { return args_.get_local_size(); }
 
   void clear_local_size() { args_.clear_local_size(); }
-
-  void
-  save_reqd_threads_per_block(size_t size,
-                              size_t *save_reqd_threads_per_block) noexcept {
-    std::memcpy(reqdThreadsPerBlock_, save_reqd_threads_per_block, size);
-  };
 };
 
 /// Implementation of samplers for CUDA

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -581,18 +581,8 @@ struct _pi_kernel {
   pi_program program_;
   std::atomic_uint32_t refCount_;
 
-  static constexpr pi_uint32 reqdThreadsPerBlock_dimensions = 3u;
-  size_t reqdThreadsPerBlock[reqdThreadsPerBlock_dimensions];
-
-  void save_reqdThreadsPerBlock(size_t size,
-                                size_t *save_reqdThreadsPerBlock) noexcept {
-    memcpy(reqdThreadsPerBlock, save_reqdThreadsPerBlock, size);
-  };
-
-  void get_reqdThreadsPerBlock(size_t ret_size,
-                               size_t *ret_reqdThreadsPerBlock) const noexcept {
-    memcpy(ret_reqdThreadsPerBlock, reqdThreadsPerBlock, ret_size);
-  };
+  static constexpr pi_uint32 REQD_THREADS_PER_BLOCK_DIMENSIONS = 3u;
+  size_t reqdThreadsPerBlock_[REQD_THREADS_PER_BLOCK_DIMENSIONS];
 
   /// Structure that holds the arguments to the kernel.
   /// Note earch argument size is known, since it comes
@@ -729,6 +719,17 @@ struct _pi_kernel {
   pi_uint32 get_local_size() const noexcept { return args_.get_local_size(); }
 
   void clear_local_size() { args_.clear_local_size(); }
+
+  void
+  save_reqd_threads_per_block(size_t size,
+                              size_t *save_reqd_threads_per_block) noexcept {
+    std::memcpy(reqdThreadsPerBlock_, save_reqd_threads_per_block, size);
+  };
+
+  void get_reqd_threads_per_block(
+      size_t ret_size, size_t *ret_reqd_threads_per_block) const noexcept {
+    std::memcpy(ret_reqd_threads_per_block, reqdThreadsPerBlock_, ret_size);
+  };
 };
 
 /// Implementation of samplers for CUDA

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -581,6 +581,19 @@ struct _pi_kernel {
   pi_program program_;
   std::atomic_uint32_t refCount_;
 
+  static constexpr pi_uint32 reqdThreadsPerBlock_dimensions = 3u;
+  size_t reqdThreadsPerBlock[reqdThreadsPerBlock_dimensions];
+
+  void save_reqdThreadsPerBlock(size_t size,
+                                size_t *save_reqdThreadsPerBlock) noexcept {
+    memcpy(reqdThreadsPerBlock, save_reqdThreadsPerBlock, size);
+  };
+
+  void get_reqdThreadsPerBlock(size_t ret_size,
+                               size_t *ret_reqdThreadsPerBlock) const noexcept {
+    memcpy(ret_reqdThreadsPerBlock, reqdThreadsPerBlock, ret_size);
+  };
+
   /// Structure that holds the arguments to the kernel.
   /// Note earch argument size is known, since it comes
   /// from the kernel signature.


### PR DESCRIPTION
the patch reduces the time of getting reqdThreadsPerBlock for each submit.

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>