### PR TITLE
[SYCL] Add amdgcn to libclc test targets

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -54,6 +54,7 @@ set( LIBCLC_TARGETS_ALL
 set( LIBCLC_TEST_TARGETS_ALL
   nvptx--nvidiacl
   nvptx64--nvidiacl
+  amdgcn--amdhsa
 )
 
 set( LIBCLC_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR} )

--- a/libclc/test/binding/ocl/acos.cl
+++ b/libclc/test/binding/ocl/acos.cl
@@ -11,6 +11,8 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
+// XFAIL: amdgcn
+
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/asin.cl
+++ b/libclc/test/binding/ocl/asin.cl
@@ -11,6 +11,8 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
+// XFAIL: amdgcn
+
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/cos.cl
+++ b/libclc/test/binding/ocl/cos.cl
@@ -11,6 +11,8 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
+// XFAIL: amdgcn
+
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/sin.cl
+++ b/libclc/test/binding/ocl/sin.cl
@@ -11,6 +11,8 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
+// XFAIL: amdgcn
+
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/sincos.cl
+++ b/libclc/test/binding/ocl/sincos.cl
@@ -11,6 +11,8 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
+// XFAIL: amdgcn
+
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/sqrt.cl
+++ b/libclc/test/binding/ocl/sqrt.cl
@@ -11,6 +11,8 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
+// XFAIL: amdgcn
+
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/lit.cfg.py
+++ b/libclc/test/lit.cfg.py
@@ -38,17 +38,23 @@ cpu = [] if cpu == '' else ["-mcpu=" + cpu]
 
 llvm_config.use_default_substitutions()
 
-llvm_config.use_clang(additional_flags=["-fno-builtin",
-                                        "-I", libclc_inc,
-                                        "-target", target,
-                                        "-Xclang",
-                                        "-fdeclare-spirv-builtins",
-                                        "-Xclang",
-                                        "-mlink-builtin-bitcode",
-                                        "-Xclang",
-                                        os.path.join(config.llvm_libs_dir,
-                                                     "clc",
-                                                     builtins)] + cpu)
+clang_flags = [
+  "-fno-builtin",
+  "-I", libclc_inc,
+  "-target", target,
+  "-Xclang", "-fdeclare-spirv-builtins",
+  "-Xclang", "-mlink-builtin-bitcode",
+  "-Xclang", os.path.join(config.llvm_libs_dir, "clc", builtins)
+]
+
+if target == 'amdgcn--amdhsa':
+    config.available_features.add('amdgcn')
+
+    # libclc for amdgcn is currently built for tahiti which doesn't support
+    # fp16 so disable the extension for the tests
+    clang_flags += ['-Xclang', '-cl-ext=-cl_khr_fp16']
+
+llvm_config.use_clang(additional_flags=clang_flags + cpu)
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 


### PR DESCRIPTION
With this patch `check-libclc` runs the tests on AMD targets as well and passes.

I have marked as `XFAIL` existing failures that will need to be investigated further.