### PR TITLE
[Driver][SYCL] Improve default header search for source+footer compil…

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1434,18 +1434,18 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
 
   // The file being compiled that contains the integration footer is not being
   // compiled in the directory of the original source.  Add that directory
-  // as an -I option so we can properly find potential headers there.  The
-  // original source search directory should also be placed before any user
+  // as an -iquote option so we can properly find potential user headers there.
+  // The original source search directory should also be placed before any user
   // search directories.
   if (ContainsAppendFooterAction(&JA)) {
     SmallString<128> SourcePath(Inputs[0].getBaseInput());
     llvm::sys::path::remove_filename(SourcePath);
     if (!SourcePath.empty()) {
-      CmdArgs.push_back("-I");
+      CmdArgs.push_back("-iquote");
       CmdArgs.push_back(Args.MakeArgString(SourcePath));
     } else if (llvm::ErrorOr<std::string> CWD =
                    D.getVFS().getCurrentWorkingDirectory()) {
-      CmdArgs.push_back("-I");
+      CmdArgs.push_back("-iquote");
       CmdArgs.push_back(Args.MakeArgString(*CWD));
     }
   }
@@ -4424,11 +4424,11 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
   SmallString<128> SourcePath(InputFile.getBaseInput());
   llvm::sys::path::remove_filename(SourcePath);
   if (!SourcePath.empty()) {
-    HostCompileArgs.push_back("-I");
+    HostCompileArgs.push_back(IsMSVCHostCompiler ? "-I" : "-iquote");
     HostCompileArgs.push_back(TCArgs.MakeArgString(SourcePath));
   } else if (llvm::ErrorOr<std::string> CWD =
                  TC.getDriver().getVFS().getCurrentWorkingDirectory()) {
-    HostCompileArgs.push_back("-I");
+    HostCompileArgs.push_back(IsMSVCHostCompiler ? "-I" : "-iquote");
     HostCompileArgs.push_back(TCArgs.MakeArgString(*CWD));
   }
 

--- a/clang/test/Driver/sycl-host-compiler.cpp
+++ b/clang/test/Driver/sycl-host-compiler.cpp
@@ -5,7 +5,7 @@
 // RUN: %clangxx -fsycl -fsycl-host-compiler=/some/dir/g++ %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_COMPILER %s
 // HOST_COMPILER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer={{.*}}"
-// HOST_COMPILER: g++{{.*}} "-c" "-include" "[[INTHEADER]]" "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"{{.*}} "-o" "[[HOSTOBJ:.+\.o]]"{{.*}}
+// HOST_COMPILER: g++{{.*}} "-c" "-include" "[[INTHEADER]]" "-iquote" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"{{.*}} "-o" "[[HOSTOBJ:.+\.o]]"{{.*}}
 // HOST_COMPILER: ld{{.*}} "[[HOSTOBJ]]"
 
 // RUN: %clang_cl -fsycl -fsycl-host-compiler=/some/dir/cl %s -### 2>&1 \

--- a/clang/test/Driver/sycl-int-footer.cpp
+++ b/clang/test/Driver/sycl-int-footer.cpp
@@ -3,7 +3,7 @@
 // RUN:   | FileCheck -check-prefix FOOTER %s -DSRCDIR=%/S -DCMDDIR=cmdline/dir
 // FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}"{{.*}} "-include" "dummy.h"
 // FOOTER: append-file{{.*}} "[[INPUTFILE:.+\.cpp]]" "--append=[[INTFOOTER]]" "--orig-filename=[[INPUTFILE]]" "--output=[[APPENDEDSRC:.+\.cpp]]"
-// FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-include" "dummy.h"{{.*}} "-I" "[[SRCDIR]]" "-I" "cmdline/dir"
+// FOOTER: clang{{.*}} "-include" "[[INTHEADER]]"{{.*}} "-fsycl-is-host"{{.*}} "-include" "dummy.h"{{.*}} "-iquote" "[[SRCDIR]]" "-I" "cmdline/dir"
 // FOOTER-NOT: "-include" "[[INTHEADER]]"
 
 /// Preprocessed file creation with integration footer


### PR DESCRIPTION
…ations

When compiling the generated source+footer file, use -iquote for the searching
so that #include <file> are not impacted.  This matches the expected default
behaviors for source location header searches.