### PR TITLE
[SYCL][FPGA] Remove deprecated attribute functionality

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1346,7 +1346,7 @@ def SYCLIntelKernelArgsRestrict : InheritableAttr {
 }
 
 def SYCLIntelNumSimdWorkItems : InheritableAttr {
-  let Spellings = [CXX11<"intel","num_simd_work_items">];
+  let Spellings = [CXX11<"intel", "num_simd_work_items">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
@@ -1355,7 +1355,7 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
 }
 
 def SYCLIntelUseStallEnableClusters : InheritableAttr {
-  let Spellings = [CXX11<"intel","use_stall_enable_clusters">];
+  let Spellings = [CXX11<"intel", "use_stall_enable_clusters">];
   let LangOpts = [SYCLIsHost, SYCLIsDevice];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelUseStallEnableClustersAttrDocs];
@@ -1363,7 +1363,7 @@ def SYCLIntelUseStallEnableClusters : InheritableAttr {
 }
 
 def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
-  let Spellings = [CXX11<"intel","scheduler_target_fmax_mhz">];
+  let Spellings = [CXX11<"intel", "scheduler_target_fmax_mhz">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
@@ -1372,7 +1372,7 @@ def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
 }
 
 def SYCLIntelMaxWorkGroupSize : InheritableAttr {
-  let Spellings = [CXX11<"intel","max_work_group_size">];
+  let Spellings = [CXX11<"intel", "max_work_group_size">];
   let Args = [ExprArgument<"XDim">,
               ExprArgument<"YDim">,
               ExprArgument<"ZDim">];
@@ -1397,7 +1397,7 @@ def SYCLIntelMaxWorkGroupSize : InheritableAttr {
 }
 
 def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
-  let Spellings = [CXX11<"intel","max_global_work_dim">];
+  let Spellings = [CXX11<"intel", "max_global_work_dim">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
@@ -1406,7 +1406,7 @@ def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
 }
 
 def SYCLIntelNoGlobalWorkOffset : InheritableAttr {
-  let Spellings = [CXX11<"intel","no_global_work_offset">];
+  let Spellings = [CXX11<"intel", "no_global_work_offset">];
   let Args = [ExprArgument<"Value", /*optional*/1>];
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
@@ -1928,7 +1928,7 @@ def Mode : Attr {
 }
 
 def SYCLIntelFPGAIVDep : StmtAttr {
-  let Spellings = [CXX11<"intel","ivdep">];
+  let Spellings = [CXX11<"intel", "ivdep">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Args = [
@@ -1973,7 +1973,7 @@ def SYCLIntelFPGAIVDep : StmtAttr {
 }
 
 def SYCLIntelFPGAInitiationInterval : DeclOrStmtAttr {
-  let Spellings = [CXX11<"intel","ii">,
+  let Spellings = [CXX11<"intel", "ii">,
                    CXX11<"intel", "initiation_interval">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
                               ErrorDiag,
@@ -1986,7 +1986,7 @@ def SYCLIntelFPGAInitiationInterval : DeclOrStmtAttr {
 }
 
 def SYCLIntelFPGAMaxConcurrency : DeclOrStmtAttr {
-  let Spellings = [CXX11<"intel","max_concurrency">];
+  let Spellings = [CXX11<"intel", "max_concurrency">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
                              ErrorDiag,
                              "'for', 'while', 'do' statements, and functions">;
@@ -1998,7 +1998,7 @@ def SYCLIntelFPGAMaxConcurrency : DeclOrStmtAttr {
 }
 
 def SYCLIntelFPGALoopCoalesce : StmtAttr {
-  let Spellings = [CXX11<"intel","loop_coalesce">];
+  let Spellings = [CXX11<"intel", "loop_coalesce">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Args = [ExprArgument<"NExpr", /*opt*/1>];
@@ -2008,7 +2008,7 @@ def SYCLIntelFPGALoopCoalesce : StmtAttr {
 }
 
 def SYCLIntelFPGADisableLoopPipelining : DeclOrStmtAttr {
-  let Spellings = [CXX11<"intel","disable_loop_pipelining">];
+  let Spellings = [CXX11<"intel", "disable_loop_pipelining">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
                               ErrorDiag,
                               "'for', 'while', 'do' statements, and functions">;
@@ -2043,7 +2043,7 @@ def : MutualExclusions<[SYCLIntelFPGAMaxConcurrency,
                         SYCLIntelFPGADisableLoopPipelining]>;
 
 def SYCLIntelFPGAMaxInterleaving : StmtAttr {
-  let Spellings = [CXX11<"intel","max_interleaving">];
+  let Spellings = [CXX11<"intel", "max_interleaving">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Args = [ExprArgument<"NExpr">];
@@ -2055,7 +2055,7 @@ def : MutualExclusions<[SYCLIntelFPGADisableLoopPipelining,
                         SYCLIntelFPGAMaxInterleaving]>;
 
 def SYCLIntelFPGASpeculatedIterations : StmtAttr {
-  let Spellings = [CXX11<"intel","speculated_iterations">];
+  let Spellings = [CXX11<"intel", "speculated_iterations">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Args = [ExprArgument<"NExpr">];
@@ -2155,7 +2155,7 @@ def : MutualExclusions<[IntelFPGADoublePump, IntelFPGASinglePump,
 
 // One integral argument.
 def IntelFPGABankWidth : InheritableAttr {
-  let Spellings = [CXX11<"intel","bankwidth">];
+  let Spellings = [CXX11<"intel", "bankwidth">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
@@ -2165,7 +2165,7 @@ def IntelFPGABankWidth : InheritableAttr {
 def : MutualExclusions<[IntelFPGARegister, IntelFPGABankWidth]>;
 
 def IntelFPGANumBanks : InheritableAttr {
-  let Spellings = [CXX11<"intel","numbanks">];
+  let Spellings = [CXX11<"intel", "numbanks">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
@@ -2174,7 +2174,7 @@ def IntelFPGANumBanks : InheritableAttr {
 }
 
 def IntelFPGAPrivateCopies : InheritableAttr {
-  let Spellings = [CXX11<"intel","private_copies">];
+  let Spellings = [CXX11<"intel", "private_copies">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[IntelFPGALocalNonConstVar, Field], ErrorDiag>;
@@ -2184,7 +2184,7 @@ def : MutualExclusions<[IntelFPGARegister, IntelFPGAPrivateCopies]>;
 
 // Two string arguments.
 def IntelFPGAMerge : Attr {
-  let Spellings = [CXX11<"intel","merge">];
+  let Spellings = [CXX11<"intel", "merge">];
   let Args = [StringArgument<"Name">, StringArgument<"Direction">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
@@ -2194,7 +2194,7 @@ def IntelFPGAMerge : Attr {
 def : MutualExclusions<[IntelFPGARegister, IntelFPGAMerge]>;
 
 def IntelFPGAMaxReplicates : InheritableAttr {
-  let Spellings = [CXX11<"intel","max_replicates">];
+  let Spellings = [CXX11<"intel", "max_replicates">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
@@ -2204,7 +2204,7 @@ def IntelFPGAMaxReplicates : InheritableAttr {
 def : MutualExclusions<[IntelFPGARegister, IntelFPGAMaxReplicates]>;
 
 def IntelFPGASimpleDualPort : Attr {
-  let Spellings = [CXX11<"intel","simple_dual_port">];
+  let Spellings = [CXX11<"intel", "simple_dual_port">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
@@ -2240,7 +2240,7 @@ def : MutualExclusions<[IntelFPGARegister, IntelFPGABankBits]>;
 def : MutualExclusions<[IntelFPGARegister, IntelFPGANumBanks]>;
 
 def IntelFPGAForcePow2Depth : InheritableAttr {
-  let Spellings = [CXX11<"intel","force_pow2_depth">];
+  let Spellings = [CXX11<"intel", "force_pow2_depth">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1355,7 +1355,7 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
 }
 
 def SYCLIntelUseStallEnableClusters : InheritableAttr {
-  let Spellings = [CXX11<"intel", "use_stall_enable_clusters">];
+  let Spellings = [CXX11<"intel","use_stall_enable_clusters">];
   let LangOpts = [SYCLIsHost, SYCLIsDevice];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelUseStallEnableClustersAttrDocs];

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1346,8 +1346,7 @@ def SYCLIntelKernelArgsRestrict : InheritableAttr {
 }
 
 def SYCLIntelNumSimdWorkItems : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","num_simd_work_items">,
-                   CXX11<"intel","num_simd_work_items">];
+  let Spellings = [CXX11<"intel","num_simd_work_items">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
@@ -1364,8 +1363,7 @@ def SYCLIntelUseStallEnableClusters : InheritableAttr {
 }
 
 def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","scheduler_target_fmax_mhz">,
-                   CXX11<"intel","scheduler_target_fmax_mhz">];
+  let Spellings = [CXX11<"intel","scheduler_target_fmax_mhz">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
@@ -1374,8 +1372,7 @@ def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
 }
 
 def SYCLIntelMaxWorkGroupSize : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","max_work_group_size">,
-                   CXX11<"intel","max_work_group_size">];
+  let Spellings = [CXX11<"intel","max_work_group_size">];
   let Args = [ExprArgument<"XDim">,
               ExprArgument<"YDim">,
               ExprArgument<"ZDim">];
@@ -1400,8 +1397,7 @@ def SYCLIntelMaxWorkGroupSize : InheritableAttr {
 }
 
 def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","max_global_work_dim">,
-                   CXX11<"intel","max_global_work_dim">];
+  let Spellings = [CXX11<"intel","max_global_work_dim">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
@@ -1410,8 +1406,7 @@ def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
 }
 
 def SYCLIntelNoGlobalWorkOffset : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","no_global_work_offset">,
-                   CXX11<"intel","no_global_work_offset">];
+  let Spellings = [CXX11<"intel","no_global_work_offset">];
   let Args = [ExprArgument<"Value", /*optional*/1>];
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
@@ -1933,8 +1928,7 @@ def Mode : Attr {
 }
 
 def SYCLIntelFPGAIVDep : StmtAttr {
-  let Spellings = [CXX11<"intelfpga","ivdep">,
-                   CXX11<"intel","ivdep">];
+  let Spellings = [CXX11<"intel","ivdep">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Args = [
@@ -1979,8 +1973,7 @@ def SYCLIntelFPGAIVDep : StmtAttr {
 }
 
 def SYCLIntelFPGAInitiationInterval : DeclOrStmtAttr {
-  let Spellings = [CXX11<"intelfpga","ii">,
-                   CXX11<"intel","ii">,
+  let Spellings = [CXX11<"intel","ii">,
                    CXX11<"intel", "initiation_interval">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
                               ErrorDiag,
@@ -1993,8 +1986,7 @@ def SYCLIntelFPGAInitiationInterval : DeclOrStmtAttr {
 }
 
 def SYCLIntelFPGAMaxConcurrency : DeclOrStmtAttr {
-  let Spellings = [CXX11<"intelfpga","max_concurrency">,
-                   CXX11<"intel","max_concurrency">];
+  let Spellings = [CXX11<"intel","max_concurrency">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
                              ErrorDiag,
                              "'for', 'while', 'do' statements, and functions">;
@@ -2006,8 +1998,7 @@ def SYCLIntelFPGAMaxConcurrency : DeclOrStmtAttr {
 }
 
 def SYCLIntelFPGALoopCoalesce : StmtAttr {
-  let Spellings = [CXX11<"intelfpga","loop_coalesce">,
-                   CXX11<"intel","loop_coalesce">];
+  let Spellings = [CXX11<"intel","loop_coalesce">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Args = [ExprArgument<"NExpr", /*opt*/1>];
@@ -2017,8 +2008,7 @@ def SYCLIntelFPGALoopCoalesce : StmtAttr {
 }
 
 def SYCLIntelFPGADisableLoopPipelining : DeclOrStmtAttr {
-  let Spellings = [CXX11<"intelfpga","disable_loop_pipelining">,
-                   CXX11<"intel","disable_loop_pipelining">];
+  let Spellings = [CXX11<"intel","disable_loop_pipelining">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt, Function],
                               ErrorDiag,
                               "'for', 'while', 'do' statements, and functions">;
@@ -2053,8 +2043,7 @@ def : MutualExclusions<[SYCLIntelFPGAMaxConcurrency,
                         SYCLIntelFPGADisableLoopPipelining]>;
 
 def SYCLIntelFPGAMaxInterleaving : StmtAttr {
-  let Spellings = [CXX11<"intelfpga","max_interleaving">,
-                   CXX11<"intel","max_interleaving">];
+  let Spellings = [CXX11<"intel","max_interleaving">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Args = [ExprArgument<"NExpr">];
@@ -2066,8 +2055,7 @@ def : MutualExclusions<[SYCLIntelFPGADisableLoopPipelining,
                         SYCLIntelFPGAMaxInterleaving]>;
 
 def SYCLIntelFPGASpeculatedIterations : StmtAttr {
-  let Spellings = [CXX11<"intelfpga","speculated_iterations">,
-                   CXX11<"intel","speculated_iterations">];
+  let Spellings = [CXX11<"intel","speculated_iterations">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Args = [ExprArgument<"NExpr">];
@@ -2120,8 +2108,7 @@ def IntelFPGALocalOrStaticVar : SubsetSubject<Var,
                               "local variables, static variables">;
 
 def IntelFPGADoublePump : Attr {
-  let Spellings = [CXX11<"intelfpga", "doublepump">,
-                   CXX11<"intel", "doublepump">];
+  let Spellings = [CXX11<"intel", "doublepump">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
@@ -2129,8 +2116,7 @@ def IntelFPGADoublePump : Attr {
 }
 
 def IntelFPGASinglePump : Attr {
-  let Spellings = [CXX11<"intelfpga", "singlepump">,
-                   CXX11<"intel", "singlepump">];
+  let Spellings = [CXX11<"intel", "singlepump">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
@@ -2138,8 +2124,7 @@ def IntelFPGASinglePump : Attr {
 }
 
 def IntelFPGAMemory : Attr {
-  let Spellings = [CXX11<"intelfpga", "memory">,
-                   CXX11<"intel", "fpga_memory">];
+  let Spellings = [CXX11<"intel", "fpga_memory">];
   let Args = [EnumArgument<"Kind", "MemoryKind",
                            ["MLAB", "BLOCK_RAM", ""],
                            ["MLAB", "BlockRAM", "Default"], 1>];
@@ -2159,8 +2144,7 @@ def IntelFPGAMemory : Attr {
 }
 
 def IntelFPGARegister : Attr {
-  let Spellings = [CXX11<"intelfpga", "register">,
-                   CXX11<"intel", "fpga_register">];
+  let Spellings = [CXX11<"intel", "fpga_register">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
@@ -2171,8 +2155,7 @@ def : MutualExclusions<[IntelFPGADoublePump, IntelFPGASinglePump,
 
 // One integral argument.
 def IntelFPGABankWidth : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","bankwidth">,
-                   CXX11<"intel","bankwidth">];
+  let Spellings = [CXX11<"intel","bankwidth">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
@@ -2182,8 +2165,7 @@ def IntelFPGABankWidth : InheritableAttr {
 def : MutualExclusions<[IntelFPGARegister, IntelFPGABankWidth]>;
 
 def IntelFPGANumBanks : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","numbanks">,
-                   CXX11<"intel","numbanks">];
+  let Spellings = [CXX11<"intel","numbanks">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
@@ -2192,8 +2174,7 @@ def IntelFPGANumBanks : InheritableAttr {
 }
 
 def IntelFPGAPrivateCopies : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","private_copies">,
-                   CXX11<"intel","private_copies">];
+  let Spellings = [CXX11<"intel","private_copies">];
   let Args = [ExprArgument<"Value">];
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[IntelFPGALocalNonConstVar, Field], ErrorDiag>;
@@ -2203,8 +2184,7 @@ def : MutualExclusions<[IntelFPGARegister, IntelFPGAPrivateCopies]>;
 
 // Two string arguments.
 def IntelFPGAMerge : Attr {
-  let Spellings = [CXX11<"intelfpga","merge">,
-                   CXX11<"intel","merge">];
+  let Spellings = [CXX11<"intel","merge">];
   let Args = [StringArgument<"Name">, StringArgument<"Direction">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalOrStaticVar,
                               Field], ErrorDiag>;
@@ -2214,8 +2194,7 @@ def IntelFPGAMerge : Attr {
 def : MutualExclusions<[IntelFPGARegister, IntelFPGAMerge]>;
 
 def IntelFPGAMaxReplicates : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","max_replicates">,
-                   CXX11<"intel","max_replicates">];
+  let Spellings = [CXX11<"intel","max_replicates">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
@@ -2225,8 +2204,7 @@ def IntelFPGAMaxReplicates : InheritableAttr {
 def : MutualExclusions<[IntelFPGARegister, IntelFPGAMaxReplicates]>;
 
 def IntelFPGASimpleDualPort : Attr {
-  let Spellings = [CXX11<"intelfpga","simple_dual_port">,
-                   CXX11<"intel","simple_dual_port">];
+  let Spellings = [CXX11<"intel","simple_dual_port">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
@@ -2251,8 +2229,7 @@ def SYCLIntelPipeIO : Attr {
 
 // Variadic integral arguments.
 def IntelFPGABankBits : Attr {
-  let Spellings = [CXX11<"intelfpga", "bank_bits">,
-                   CXX11<"intel", "bank_bits">];
+  let Spellings = [CXX11<"intel", "bank_bits">];
   let Args = [VariadicExprArgument<"Args">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
@@ -2263,8 +2240,7 @@ def : MutualExclusions<[IntelFPGARegister, IntelFPGABankBits]>;
 def : MutualExclusions<[IntelFPGARegister, IntelFPGANumBanks]>;
 
 def IntelFPGAForcePow2Depth : InheritableAttr {
-  let Spellings = [CXX11<"intelfpga","force_pow2_depth">,
-                   CXX11<"intel","force_pow2_depth">];
+  let Spellings = [CXX11<"intel","force_pow2_depth">];
   let Args = [ExprArgument<"Value">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -182,7 +182,7 @@ void check_ast()
   // No diagnostic is emitted because the arguments match.
   // Duplicate attribute is silently ignored.
   //CHECK: VarDecl{{.*}}var_bankwidth 'int'
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit Default
   //CHECK: IntelFPGABankWidthAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 16
@@ -194,7 +194,7 @@ void check_ast()
   // No diagnostic is emitted because the arguments match.
   // Duplicate attribute is silently ignored.
   //CHECK: VarDecl{{.*}}var_numbanks 'int'
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit Default
   //CHECK: IntelFPGANumBanksAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 8
@@ -431,7 +431,7 @@ void diagnostics()
 
   // Checking of different argument values.
   //CHECK: VarDecl{{.*}}bw_bw 'unsigned int [64]'
-  //CHECK:IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK:IntelFPGAMemoryAttr{{.*}}Implicit Default
   //CHECK: IntelFPGABankWidthAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 8
@@ -510,7 +510,7 @@ void diagnostics()
   unsigned int nb_reg[64];
 
   //CHECK: VarDecl{{.*}}nb_nb 'unsigned int [64]'
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit Default
   //CHECK:IntelFPGANumBanksAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 8
@@ -598,7 +598,7 @@ void diagnostics()
   //CHECK: VarDecl{{.*}} bb_reg 'unsigned int [4]'
   //CHECK: IntelFPGANumBanksAttr{{.*}}Implicit
   //CHECK-NEXT: IntegerLiteral{{.*}}'int' 4
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit Default
   //CHECK: IntelFPGABankBitsAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 2

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -182,7 +182,7 @@ void check_ast()
   // No diagnostic is emitted because the arguments match.
   // Duplicate attribute is silently ignored.
   //CHECK: VarDecl{{.*}}var_bankwidth 'int'
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit memory Default
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGABankWidthAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 16
@@ -194,7 +194,7 @@ void check_ast()
   // No diagnostic is emitted because the arguments match.
   // Duplicate attribute is silently ignored.
   //CHECK: VarDecl{{.*}}var_numbanks 'int'
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit memory Default
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGANumBanksAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 8
@@ -210,9 +210,10 @@ void diagnostics()
   //CHECK: VarDecl{{.*}}doublepump
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGADoublePumpAttr
-  //expected-warning@+2 {{attribute 'intelfpga::doublepump' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::doublepump' instead?}}
-  [[intelfpga::doublepump]] unsigned int doublepump[64];
+  [[intel::doublepump]] unsigned int doublepump[64];
+
+  //expected-warning@+1 {{unknown attribute 'doublepump' ignored}}
+  [[intelfpga::doublepump]] unsigned int doublepump_var[64];
 
   //expected-error@+2{{attributes are not compatible}}
   [[intel::doublepump]]
@@ -234,9 +235,10 @@ void diagnostics()
   //CHECK: VarDecl{{.*}}singlepump
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGASinglePumpAttr
-  //expected-warning@+2 {{attribute 'intelfpga::singlepump' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::singlepump' instead?}}
-  [[intelfpga::singlepump]] unsigned int singlepump[64];
+  [[intel::singlepump]] unsigned int singlepump[64];
+
+  //expected-warning@+1 {{unknown attribute 'singlepump' ignored}}
+  [[intelfpga::singlepump]] unsigned int singlepump_var[64];
 
   //expected-error@+1{{attributes are not compatible}}
   [[intel::singlepump, intel::doublepump]]
@@ -256,9 +258,10 @@ void diagnostics()
   // **fpga_register
   //CHECK: VarDecl{{.*}}reg
   //CHECK: IntelFPGARegisterAttr
-  //expected-warning@+2 {{attribute 'intelfpga::register' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::fpga_register' instead?}}
-  [[intelfpga::register]] unsigned int reg[64];
+  [[intel::fpga_register]] unsigned int reg[64];
+
+  //expected-warning@+1 {{unknown attribute 'register' ignored}}
+  [[intelfpga::register]] unsigned int reg_var[64];
 
   //expected-warning@+1{{attribute 'fpga_register' is already applied}}
   [[intel::fpga_register]] [[intel::fpga_register]] unsigned int reg_reg[64];
@@ -347,9 +350,7 @@ void diagnostics()
   // **memory
   //CHECK: VarDecl{{.*}}memory
   //CHECK: IntelFPGAMemoryAttr
-  //expected-warning@+2 {{attribute 'intelfpga::memory' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::fpga_memory' instead?}}
-  [[intelfpga::memory]] unsigned int memory[64];
+  [[intel::fpga_memory]] unsigned int memory[64];
 
   //expected-error@+2{{attributes are not compatible}}
   [[intel::fpga_memory]]
@@ -360,6 +361,9 @@ void diagnostics()
   //expected-warning@+1{{attribute 'fpga_memory' is already applied}}
   [[intel::fpga_memory]] [[intel::fpga_memory]] unsigned int mem_mem[64];
 
+  //expected-warning@+1 {{unknown attribute 'memory' ignored}}
+  [[intelfpga::memory]] unsigned int memory_var[64];
+
   // bankwidth
   //CHECK: VarDecl{{.*}}bankwidth
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
@@ -367,9 +371,10 @@ void diagnostics()
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: value:{{.*}}4
   //CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-  //expected-warning@+2 {{attribute 'intelfpga::bankwidth' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::bankwidth' instead?}}
-  [[intelfpga::bankwidth(4)]] unsigned int bankwidth[32];
+  [[intel::bankwidth(4)]] unsigned int bankwidth[32];
+
+  //expected-warning@+1 {{unknown attribute 'bankwidth' ignored}}
+  [[intelfpga::bankwidth(4)]] unsigned int bankwidth_var[32];
 
   // Checking of incompatible attributes.
   //expected-error@+2{{attributes are not compatible}}
@@ -386,9 +391,10 @@ void diagnostics()
   //CHECK: ConstantExpr
   //CHECK-NEXT: value:{{.*}}2
   //CHECK: IntegerLiteral{{.*}}2{{$}}
-  //expected-warning@+2 {{attribute 'intelfpga::max_replicates' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::max_replicates' instead?}}
-  [[intelfpga::max_replicates(2)]] unsigned int max_replicates[64];
+  [[intel::max_replicates(2)]] unsigned int max_replicates[64];
+
+  //expected-warning@+1 {{unknown attribute 'max_replicates' ignored}}
+  [[intelfpga::max_replicates(2)]] unsigned int max_replicates_var[64];
 
   // Checking of different argument values.
   //expected-warning@+2{{attribute 'max_replicates' is already applied with different arguments}}
@@ -413,9 +419,10 @@ void diagnostics()
   //CHECK: VarDecl{{.*}}dual_port
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGASimpleDualPortAttr
-  //expected-warning@+2 {{attribute 'intelfpga::simple_dual_port' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::simple_dual_port' instead?}}
-  [[intelfpga::simple_dual_port]] unsigned int dual_port[64];
+  [[intel::simple_dual_port]] unsigned int dual_port[64];
+
+  //expected-warning@+1 {{unknown attribute 'simple_dual_port' ignored}}
+  [[intelfpga::simple_dual_port]] unsigned int dual_port_var[64];
 
   //expected-note@+1 {{conflicting attribute is here}}
   [[intel::fpga_register]]
@@ -424,7 +431,7 @@ void diagnostics()
 
   // Checking of different argument values.
   //CHECK: VarDecl{{.*}}bw_bw 'unsigned int [64]'
-  //CHECK:IntelFPGAMemoryAttr{{.*}}Implicit memory Default
+  //CHECK:IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGABankWidthAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 8
@@ -458,9 +465,10 @@ void diagnostics()
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: value:{{.*}}8
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  //expected-warning@+2 {{attribute 'intelfpga::private_copies' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::private_copies' instead?}}
-  [[intelfpga::private_copies(8)]] unsigned int private_copies[64];
+  [[intel::private_copies(8)]] unsigned int private_copies[64];
+
+  //expected-warning@+1 {{unknown attribute 'private_copies' ignored}}
+  [[intelfpga::private_copies(8)]] unsigned int private_copies_var[64];
 
   // Checking of incompatible attributes.
   //expected-error@+2{{attributes are not compatible}}
@@ -493,9 +501,7 @@ void diagnostics()
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: value:{{.*}}8
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
-  //expected-warning@+2 {{attribute 'intelfpga::numbanks' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::numbanks' instead?}}
-  [[intelfpga::numbanks(8)]] unsigned int numbanks[32];
+  [[intel::numbanks(8)]] unsigned int numbanks[32];
 
   //expected-error@+2{{attributes are not compatible}}
   [[intel::numbanks(16)]]
@@ -504,7 +510,7 @@ void diagnostics()
   unsigned int nb_reg[64];
 
   //CHECK: VarDecl{{.*}}nb_nb 'unsigned int [64]'
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit memory Default
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK:IntelFPGANumBanksAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 8
@@ -531,13 +537,17 @@ void diagnostics()
   //expected-error@+1{{requires a positive integral compile time constant expression}}
   [[intel::numbanks(0)]] unsigned int nb_zero[64];
 
+  //expected-warning@+1 {{unknown attribute 'numbanks' ignored}}
+  [[intelfpga::numbanks(8)]] unsigned int numbanks_var[32];
+
   // merge
   //CHECK: VarDecl{{.*}}merge_depth
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGAMergeAttr{{.*}}"mrg1" "depth"{{$}}
-  //expected-warning@+2 {{attribute 'intelfpga::merge' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::merge' instead?}}
-  [[intelfpga::merge("mrg1", "depth")]] unsigned int merge_depth[64];
+  [[intel::merge("mrg1", "depth")]] unsigned int merge_depth[64];
+
+  //expected-warning@+1 {{unknown attribute 'merge' ignored}}
+  [[intelfpga::merge("mrg1", "depth")]] unsigned int merge_depth_var[64];
 
   //expected-error@+2{{attributes are not compatible}}
   [[intel::merge("mrg1", "depth")]]
@@ -583,14 +593,12 @@ void diagnostics()
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: value:{{.*}}5
   //CHECK-NEXT: IntegerLiteral{{.*}}5{{$}}
-  //expected-warning@+2 {{attribute 'intelfpga::bank_bits' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::bank_bits' instead?}}
-  [[intelfpga::bank_bits(2, 3, 4, 5)]] unsigned int bankbits[64];
+  [[intel::bank_bits(2, 3, 4, 5)]] unsigned int bankbits[64];
 
   //CHECK: VarDecl{{.*}} bb_reg 'unsigned int [4]'
   //CHECK: IntelFPGANumBanksAttr{{.*}}Implicit
   //CHECK-NEXT: IntegerLiteral{{.*}}'int' 4
-  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit memory Default
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
   //CHECK: IntelFPGABankBitsAttr
   //CHECK-NEXT: ConstantExpr{{.*}}'int'
   //CHECK-NEXT: value: Int 2
@@ -638,6 +646,9 @@ void diagnostics()
   //expected-error@+1{{'bank_bits' attribute requires a non-negative integral compile time constant expression}}
   [[intel::bank_bits(-1)]] unsigned int bb_negative_arg[4];
 
+  //expected-warning@+1 {{unknown attribute 'bank_bits' ignored}}
+  [[intelfpga::bank_bits(2, 3, 4, 5)]] unsigned int bankbits_var[64];
+
   // force_pow2_depth
   //CHECK: VarDecl{{.*}}arr_force_p2d_0
   //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit
@@ -645,9 +656,10 @@ void diagnostics()
   //CHECK: ConstantExpr
   //CHECK-NEXT: value:{{.*}}0
   //CHECK: IntegerLiteral{{.*}}0{{$}}
-  //expected-warning@+2 {{attribute 'intelfpga::force_pow2_depth' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::force_pow2_depth' instead?}}
-  [[intelfpga::force_pow2_depth(0)]] unsigned int arr_force_p2d_0[64];
+  [[intel::force_pow2_depth(0)]] unsigned int arr_force_p2d_0[64];
+
+  //expected-warning@+1 {{unknown attribute 'force_pow2_depth' ignored}}
+  [[intelfpga::force_pow2_depth(0)]] unsigned int arr_force_p2d_0_var[64];
 
   //expected-error@+1{{'force_pow2_depth' attribute requires integer constant between 0 and 1 inclusive}}
   [[intel::force_pow2_depth(-1)]] unsigned int force_p2d_below_min[64];

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -29,13 +29,11 @@ void foo() {
 // Test for deprecated spelling of Intel FPGA loop attributes
 void foo_deprecated() {
   int a[10];
-  // expected-warning@+2 {{attribute 'intelfpga::ivdep' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::ivdep' instead?}}
+  // expected-warning@+1 {{unknown attribute 'ivdep' ignored}}
   [[intelfpga::ivdep(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-warning@+2 {{attribute 'intelfpga::ii' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::initiation_interval' instead?}}
+  // expected-warning@+1 {{unknown attribute 'ii' ignored}}
   [[intelfpga::ii(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
@@ -44,28 +42,23 @@ void foo_deprecated() {
   [[intel::ii(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-warning@+2 {{attribute 'intelfpga::max_concurrency' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::max_concurrency' instead?}}
+  // expected-warning@+1 {{unknown attribute 'max_concurrency' ignored}}
   [[intelfpga::max_concurrency(4)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-warning@+2 {{attribute 'intelfpga::max_interleaving' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::max_interleaving' instead?}}
+  // expected-warning@+1 {{unknown attribute 'max_interleaving' ignored}}
   [[intelfpga::max_interleaving(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-warning@+2 {{attribute 'intelfpga::disable_loop_pipelining' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::disable_loop_pipelining' instead?}}
+  // expected-warning@+1 {{unknown attribute 'disable_loop_pipelining' ignored}}
   [[intelfpga::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-warning@+2 {{attribute 'intelfpga::loop_coalesce' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::loop_coalesce' instead?}}
+  // expected-warning@+1 {{unknown attribute 'loop_coalesce' ignored}}
   [[intelfpga::loop_coalesce(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-warning@+2 {{attribute 'intelfpga::speculated_iterations' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::speculated_iterations' instead?}}
+  // expected-warning@+1 {{unknown attribute 'speculated_iterations' ignored}}
   [[intelfpga::speculated_iterations(6)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset.cpp
@@ -5,10 +5,11 @@
 using namespace cl::sycl;
 queue q;
 
+//expected-warning@+1 {{unknown attribute 'no_global_work_offset' ignored}}
+[[intelfpga::no_global_work_offset]] void RemovedSpell();
+
 struct FuncObj {
-  //expected-warning@+2 {{attribute 'intelfpga::no_global_work_offset' is deprecated}}
-  //expected-note@+1 {{did you mean to use 'intel::no_global_work_offset' instead?}}
-  [[intelfpga::no_global_work_offset]] void operator()() const {}
+  [[intel::no_global_work_offset]] void operator()() const {}
 };
 
 int main() {

--- a/clang/test/SemaSYCL/intel-max-global-work-dim-device.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim-device.cpp
@@ -28,8 +28,7 @@ struct FuncObj {
 };
 
 struct Func {
-  // expected-warning@+2 {{attribute 'intelfpga::max_global_work_dim' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::max_global_work_dim' instead?}}
+  // expected-warning@+1 {{unknown attribute 'max_global_work_dim' ignored}}
   [[intelfpga::max_global_work_dim(2)]] void operator()() const {}
 };
 
@@ -245,10 +244,8 @@ int main() {
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 2
     // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-    // expected-warning@+3 {{attribute 'intelfpga::max_global_work_dim' is deprecated}}
-    // expected-note@+2 {{did you mean to use 'intel::max_global_work_dim' instead?}}
     h.single_task<class test_kernel2>(
-        []() [[intelfpga::max_global_work_dim(2)]]{});
+        []() [[intel::max_global_work_dim(2)]]{});
 
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
     // CHECK:       SYCLIntelMaxGlobalWorkDimAttr {{.*}}

--- a/clang/test/SemaSYCL/intel-max-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size-device.cpp
@@ -28,8 +28,7 @@ struct FuncObj {
 };
 
 struct Func {
-  // expected-warning@+2 {{attribute 'intelfpga::max_work_group_size' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::max_work_group_size' instead?}}
+  // expected-warning@+1 {{unknown attribute 'max_work_group_size' ignored}}
   [[intelfpga::max_work_group_size(1, 1, 1)]] void operator()() const {}
 };
 
@@ -69,10 +68,8 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 8
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
-    // expected-warning@+3 {{attribute 'intelfpga::max_work_group_size' is deprecated}}
-    // expected-note@+2 {{did you mean to use 'intel::max_work_group_size' instead?}}
     h.single_task<class test_kernel2>(
-        []() [[intelfpga::max_work_group_size(8, 8, 8)]]{});
+        []() [[intel::max_work_group_size(8, 8, 8)]]{});
 
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
     // CHECK:       SYCLIntelMaxWorkGroupSizeAttr {{.*}}

--- a/clang/test/SemaSYCL/num_simd_work_items_device.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_device.cpp
@@ -13,10 +13,11 @@ struct FuncObj {
   operator()() const {}
 };
 
+// expected-warning@+1 {{unknown attribute 'num_simd_work_items' ignored}}
+[[intelfpga::num_simd_work_items(22)]] void RemoveSpelling();
+
 struct FuncObj {
-  // expected-warning@+2 {{attribute 'intelfpga::num_simd_work_items' is deprecated}}
-  // expected-note@+1 {{did you mean to use 'intel::num_simd_work_items' instead?}}
-  [[intelfpga::num_simd_work_items(42)]] void
+  [[intel::num_simd_work_items(42)]] void
   operator()() const {}
 };
 
@@ -256,10 +257,8 @@ int main() {
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 8
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
-    // expected-warning@+3 {{attribute 'intelfpga::num_simd_work_items' is deprecated}}
-    // expected-note@+2 {{did you mean to use 'intel::num_simd_work_items' instead?}}
     h.single_task<class test_kernel2>(
-        []() [[intelfpga::num_simd_work_items(8)]]{});
+        []() [[intel::num_simd_work_items(8)]]{});
 
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
     // CHECK:       SYCLIntelNumSimdWorkItemsAttr {{.*}}

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz.cpp
@@ -2,9 +2,8 @@
 
 // Test that checks scheduler_target_fmax_mhz attribute support on Function.
 
-// Test for deprecated spelling of scheduler_target_fmax_mhz attribute.
-// expected-warning@+2 {{attribute 'intelfpga::scheduler_target_fmax_mhz' is deprecated}}
-// expected-note@+1 {{did you mean to use 'intel::scheduler_target_fmax_mhz' instead?}}
+// Test for removed deprecated spelling of scheduler_target_fmax_mhz attribute.
+// expected-warning@+1 {{unknown attribute 'scheduler_target_fmax_mhz' ignored}}
 [[intelfpga::scheduler_target_fmax_mhz(2)]] void deprecate() {}
 
 // Tests for incorrect argument values for Intel FPGA scheduler_target_fmax_mhz function attribute.


### PR DESCRIPTION
Several FPGA specific attributes in the intelfpga vendor namespace were deprecated in favor of a name in the intel vendor namespace on PR https://github.com/intel/llvm/pull/2568. 

Specifically, we deprecated the
[[intelfpga::attr]] spellings in favor of [[intel::fpga_attr]],
[[intelfpga::register]] spelling in favor of [[intel::fpga_register]], and 
[[intelfpga::memory]] spelling in favor of [[intel::fpga_memory]].

This patch 

1. removes the deprecated functionality for the intelfpga:: spellings.
    The affected attributes are:
    intelfpga::num_simd_work_items
    intelfpga::max_work_group_size
    intelfpga::max_global_work_dim
    intelfpga::no_global_work_offset
    intelfpga::ivdep
    intelfpga::ii
    intelfpga::max_concurrency
    intelfpga::loop_coalesce
    intelfpga::disable_loop_pipelining
    intelfpga::max_interleaving
    intelfpga::speculated_iterations
    intelfpga::doublepump
    intelfpga::singlepump
    intelfpga::memory
    intelfpga::register
    intelfpga::bankwidth
    intelfpga::numbanks
    intelfpga::private_copies
    intelfpga::merge
    intelfpga::max_replicates
    intelfpga::simple_dual_port
    intelfpga::bank_bits
    intelfpga::force_pow2_depth
    intelfpga::scheduler_target_fmax_mhz

2. Updates tests so that tests use at least one removed spelling of each attributes and now shows a warning with unknown attribute spelling.

Signed-off-by: Soumi Manna soumi.manna@intel.com