### PR TITLE
[SYCL] Remove unnecessary kernel ID protector mutex

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1038,7 +1038,6 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
       // ... or create the set first if it hasn't been
       KernelSetId KSId = getNextKernelSetId();
       {
-        std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
         for (_pi_offload_entry EntriesIt = EntriesB; EntriesIt != EntriesE;
              ++EntriesIt) {
           auto Result = KSIdMap.insert(std::make_pair(EntriesIt->name, KSId));
@@ -1259,16 +1258,12 @@ static bool compatibleWithDevice(RTDeviceBinaryImage *BinImage,
 }
 
 kernel_id ProgramManager::getSYCLKernelID(const std::string &KernelName) {
-  std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
-
   auto KernelID = m_KernelIDs.find(KernelName);
   assert(KernelID != m_KernelIDs.end() && "Kernel ID missing");
   return KernelID->second;
 }
 
 std::vector<kernel_id> ProgramManager::getAllSYCLKernelIDs() {
-  std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
-
   std::vector<sycl::kernel_id> AllKernelIDs;
   AllKernelIDs.reserve(m_KernelIDs.size());
   for (std::pair<std::string, kernel_id> KernelID : m_KernelIDs) {
@@ -1329,7 +1324,6 @@ ProgramManager::getSYCLDeviceImagesWithCompatibleState(
       pi_device_binary DevBin =
           const_cast<pi_device_binary>(&BinImage->getRawData());
       {
-        std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
         for (_pi_offload_entry EntriesIt = DevBin->EntriesBegin;
              EntriesIt != DevBin->EntriesEnd; ++EntriesIt) {
           auto KernelID = m_KernelIDs.find(EntriesIt->name);

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -275,6 +275,7 @@ private:
   /// Maps names of kernels to their unique kernel IDs.
   /// TODO: Use std::unordered_set with transparent hash and equality functions
   ///       when C++20 is enabled for the runtime library.
+  /// Write access is only allowed during start-up (addImages).
   std::unordered_map<std::string, kernel_id> m_KernelIDs;
 
   // Keeps track of pi_program to image correspondence. Needed for:

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -275,14 +275,7 @@ private:
   /// Maps names of kernels to their unique kernel IDs.
   /// TODO: Use std::unordered_set with transparent hash and equality functions
   ///       when C++20 is enabled for the runtime library.
-  /// Access must be guarded by the m_KernelIDsMutex mutex
   std::unordered_map<std::string, kernel_id> m_KernelIDs;
-
-  /// Protects kernel ID cache.
-  /// NOTE: This may be acquired while \ref Sync::getGlobalLock() is held so to
-  /// avoid deadlocks care must be taken not to acquire
-  /// \ref Sync::getGlobalLock() while holding this mutex.
-  std::mutex m_KernelIDsMutex;
 
   // Keeps track of pi_program to image correspondence. Needed for:
   // - knowing which specialization constants are used in the program and


### PR DESCRIPTION
The kernel ID cache is only written to during `ProgramManager::addImages` which is done at the start of program execution. All subsequent accesses to the kernel ID cache are reads. As such, the mutex that protects the kernel ID cache is only guarding reads, which adds an unnecessary overhead.