### PR TITLE
[SYCL] Align id and range class implementation with SYCL specification

### DIFF
--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -48,8 +48,7 @@ public:
 
   /* The following constructor is only available in the id struct
    * specialization where: dimensions==1 */
-  template <int N = dimensions> 
-  id(ParamTy<N, 1, size_t> dim0) : base(dim0) {}
+  template <int N = dimensions> id(ParamTy<N, 1, size_t> dim0) : base(dim0) {}
 
   template <int N = dimensions>
   id(ParamTy<N, 1, const range<dimensions>> &range_size)
@@ -86,7 +85,7 @@ public:
   id(ParamTy<N, 3, const item<dimensions, with_offset>> &item)
       : base(item.get_id(0), item.get_id(1), item.get_id(2)) {}
 
-  __SYCL_DEPRECATED("range() conversion is deprecated") 
+  __SYCL_DEPRECATED("range() conversion is deprecated")
   explicit operator range<dimensions>() const {
     range<dimensions> result(
         detail::InitializedVal<dimensions, range>::template get<0>());
@@ -145,8 +144,8 @@ public:
 
 // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
 #define __SYCL_GEN_OPT_BASE(op)                                                \
-  friend id<dimensions> operator op(                                           \
-      const id<dimensions> &lhs, const id<dimensions> &rhs) {                  \
+  friend id<dimensions> operator op(const id<dimensions> &lhs,                 \
+                                    const id<dimensions> &rhs) {               \
     id<dimensions> result;                                                     \
     for (int i = 0; i < dimensions; ++i) {                                     \
       result.common_array[i] = lhs.common_array[i] op rhs.common_array[i];     \
@@ -179,8 +178,8 @@ public:
 #else
 #define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
-  friend id<dimensions> operator op(                                           \
-            const id<dimensions> &lhs, const size_t &rhs) {                    \
+  friend id<dimensions> operator op(const id<dimensions> &lhs,                 \
+                                    const size_t &rhs) {                       \
     id<dimensions> result;                                                     \
     for (int i = 0; i < dimensions; ++i) {                                     \
       result.common_array[i] = lhs.common_array[i] op rhs;                     \
@@ -219,8 +218,8 @@ public:
 
 // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
 #define __SYCL_GEN_OPT(op)                                                     \
-  friend id<dimensions> &operator op(                                          \
-            id<dimensions> &lhs, const id<dimensions> &rhs) {                  \
+  friend id<dimensions> &operator op(id<dimensions> &lhs,                      \
+                                     const id<dimensions> &rhs) {              \
     for (int i = 0; i < dimensions; ++i) {                                     \
       lhs.common_array[i] op rhs.common_array[i];                              \
     }                                                                          \
@@ -254,7 +253,7 @@ public:
       result.common_array[i] = (op rhs.common_array[i]);                       \
     }                                                                          \
     return result;                                                             \
-  }                                                                            \
+  }
 
   __SYCL_GEN_OPT(+)
   __SYCL_GEN_OPT(-)
@@ -265,10 +264,10 @@ public:
 #define __SYCL_GEN_OPT(op)                                                     \
   friend id<dimensions> &operator op(id<dimensions> &rhs) {                    \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      op rhs.common_array[i];                            \
+      op rhs.common_array[i];                                                  \
     }                                                                          \
     return rhs;                                                                \
-  }                                                                            \
+  }
 
   __SYCL_GEN_OPT(++)
   __SYCL_GEN_OPT(--)
@@ -284,7 +283,7 @@ public:
       op lhs.common_array[i];                                                  \
     }                                                                          \
     return old_lhs;                                                            \
-  }                                                                            \
+  }
 
   __SYCL_GEN_OPT(++)
   __SYCL_GEN_OPT(--)

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -48,7 +48,8 @@ public:
 
   /* The following constructor is only available in the id struct
    * specialization where: dimensions==1 */
-  template <int N = dimensions> id(ParamTy<N, 1, size_t> dim0) : base(dim0) {}
+  template <int N = dimensions> 
+  id(ParamTy<N, 1, size_t> dim0) : base(dim0) {}
 
   template <int N = dimensions>
   id(ParamTy<N, 1, const range<dimensions>> &range_size)
@@ -85,6 +86,7 @@ public:
   id(ParamTy<N, 3, const item<dimensions, with_offset>> &item)
       : base(item.get_id(0), item.get_id(1), item.get_id(2)) {}
 
+  __SYCL_DEPRECATED("range() conversion is deprecated") 
   explicit operator range<dimensions>() const {
     range<dimensions> result(
         detail::InitializedVal<dimensions, range>::template get<0>());
@@ -143,10 +145,11 @@ public:
 
 // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
 #define __SYCL_GEN_OPT_BASE(op)                                                \
-  id<dimensions> operator op(const id<dimensions> &rhs) const {                \
+  friend id<dimensions> operator op(                                           \
+      const id<dimensions> &lhs, const id<dimensions> &rhs) {                  \
     id<dimensions> result;                                                     \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      result.common_array[i] = this->common_array[i] op rhs.common_array[i];   \
+      result.common_array[i] = lhs.common_array[i] op rhs.common_array[i];     \
     }                                                                          \
     return result;                                                             \
   }
@@ -156,10 +159,11 @@ public:
 #define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
   template <typename T>                                                        \
-  EnableIfIntegral<T, id<dimensions>> operator op(const T &rhs) const {        \
+  friend EnableIfIntegral<T, id<dimensions>> operator op(                      \
+      const id<dimensions> &lhs, const T &rhs) {                               \
     id<dimensions> result;                                                     \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      result.common_array[i] = this->common_array[i] op rhs;                   \
+      result.common_array[i] = lhs.common_array[i] op rhs;                     \
     }                                                                          \
     return result;                                                             \
   }                                                                            \
@@ -175,10 +179,11 @@ public:
 #else
 #define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
-  id<dimensions> operator op(const size_t &rhs) const {                        \
+  friend id<dimensions> operator op(                                           \
+            const id<dimensions> &lhs, const size_t &rhs) {                    \
     id<dimensions> result;                                                     \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      result.common_array[i] = this->common_array[i] op rhs;                   \
+      result.common_array[i] = lhs.common_array[i] op rhs;                     \
     }                                                                          \
     return result;                                                             \
   }                                                                            \
@@ -214,17 +219,18 @@ public:
 
 // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
 #define __SYCL_GEN_OPT(op)                                                     \
-  id<dimensions> &operator op(const id<dimensions> &rhs) {                     \
+  friend id<dimensions> &operator op(                                          \
+            id<dimensions> &lhs, const id<dimensions> &rhs) {                  \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      this->common_array[i] op rhs.common_array[i];                            \
+      lhs.common_array[i] op rhs.common_array[i];                              \
     }                                                                          \
-    return *this;                                                              \
+    return lhs;                                                                \
   }                                                                            \
-  id<dimensions> &operator op(const size_t &rhs) {                             \
+  friend id<dimensions> &operator op(id<dimensions> &lhs, const size_t &rhs) { \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      this->common_array[i] op rhs;                                            \
+      lhs.common_array[i] op rhs;                                              \
     }                                                                          \
-    return *this;                                                              \
+    return lhs;                                                                \
   }
 
   __SYCL_GEN_OPT(+=)
@@ -237,6 +243,51 @@ public:
   __SYCL_GEN_OPT(&=)
   __SYCL_GEN_OPT(|=)
   __SYCL_GEN_OPT(^=)
+
+#undef __SYCL_GEN_OPT
+
+// OP is unary +, -
+#define __SYCL_GEN_OPT(op)                                                     \
+  friend id<dimensions> operator op(const id<dimensions> &rhs) {               \
+    id<dimensions> result;                                                     \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      result.common_array[i] = (op rhs.common_array[i]);                       \
+    }                                                                          \
+    return result;                                                             \
+  }                                                                            \
+
+  __SYCL_GEN_OPT(+)
+  __SYCL_GEN_OPT(-)
+
+#undef __SYCL_GEN_OPT
+
+// OP is prefix ++, --
+#define __SYCL_GEN_OPT(op)                                                     \
+  friend id<dimensions> &operator op(id<dimensions> &rhs) {                    \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      op rhs.common_array[i];                            \
+    }                                                                          \
+    return rhs;                                                                \
+  }                                                                            \
+
+  __SYCL_GEN_OPT(++)
+  __SYCL_GEN_OPT(--)
+
+#undef __SYCL_GEN_OPT
+
+// OP is postfix ++, --
+#define __SYCL_GEN_OPT(op)                                                     \
+  friend id<dimensions> operator op(id<dimensions> &lhs, int) {                \
+    id<dimensions> old_lhs;                                                    \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      old_lhs.common_array[i] = lhs.common_array[i];                           \
+      op lhs.common_array[i];                                                  \
+    }                                                                          \
+    return old_lhs;                                                            \
+  }                                                                            \
+
+  __SYCL_GEN_OPT(++)
+  __SYCL_GEN_OPT(--)
 
 #undef __SYCL_GEN_OPT
 

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -63,8 +63,8 @@ public:
 
 // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
 #define __SYCL_GEN_OPT_BASE(op)                                                \
-    friend range<dimensions> operator op(                                      \
-      const range<dimensions> &lhs, const range<dimensions> &rhs) {            \
+  friend range<dimensions> operator op(const range<dimensions> &lhs,           \
+                                       const range<dimensions> &rhs) {         \
     range<dimensions> result(lhs);                                             \
     for (int i = 0; i < dimensions; ++i) {                                     \
       result.common_array[i] = lhs.common_array[i] op rhs.common_array[i];     \
@@ -72,9 +72,9 @@ public:
     return result;                                                             \
   }
 
-  #ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
-// Enable operators with integral types only
-  #define __SYCL_GEN_OPT(op)                                                   \
+#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+  // Enable operators with integral types only
+#define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
   template <typename T>                                                        \
   friend IntegralType<T, range<dimensions>> operator op(                       \
@@ -94,26 +94,26 @@ public:
     }                                                                          \
     return result;                                                             \
   }
-  #else
-  #define __SYCL_GEN_OPT(op)                                                   \
+#else
+#define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
-  friend range<dimensions> operator op(                                        \
-      const range<dimensions> &lhs, const size_t &rhs) {                       \
+  friend range<dimensions> operator op(const range<dimensions> &lhs,           \
+                                       const size_t &rhs) {                    \
     range<dimensions> result(lhs);                                             \
     for (int i = 0; i < dimensions; ++i) {                                     \
       result.common_array[i] = lhs.common_array[i] op rhs;                     \
     }                                                                          \
     return result;                                                             \
   }                                                                            \
-  friend range<dimensions> operator op(                                        \
-      const size_t &lhs, const range<dimensions> &rhs) {                       \
+  friend range<dimensions> operator op(const size_t &lhs,                      \
+                                       const range<dimensions> &rhs) {         \
     range<dimensions> result(rhs);                                             \
     for (int i = 0; i < dimensions; ++i) {                                     \
       result.common_array[i] = lhs op rhs.common_array[i];                     \
     }                                                                          \
     return result;                                                             \
   }
-  #endif // __SYCL_DISABLE_ID_TO_INT_CONV__
+#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 
   __SYCL_GEN_OPT(+)
   __SYCL_GEN_OPT(-)
@@ -137,15 +137,15 @@ public:
 
 // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
 #define __SYCL_GEN_OPT(op)                                                     \
-  friend range<dimensions> &operator op(                                       \
-      range<dimensions> &lhs, const range<dimensions> &rhs) {                  \
+  friend range<dimensions> &operator op(range<dimensions> &lhs,                \
+                                        const range<dimensions> &rhs) {        \
     for (int i = 0; i < dimensions; ++i) {                                     \
       lhs.common_array[i] op rhs[i];                                           \
     }                                                                          \
     return lhs;                                                                \
   }                                                                            \
-  friend range<dimensions> &operator op(                                       \
-      range<dimensions> &lhs, const size_t &rhs) {                             \
+  friend range<dimensions> &operator op(range<dimensions> &lhs,                \
+                                        const size_t &rhs) {                   \
     for (int i = 0; i < dimensions; ++i) {                                     \
       lhs.common_array[i] op rhs;                                              \
     }                                                                          \
@@ -209,7 +209,6 @@ public:
   __SYCL_GEN_OPT(--)
 
 #undef __SYCL_GEN_OPT
-
 
 private:
   friend class handler;

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -47,14 +47,6 @@ public:
         size_t dim2)
       : base(dim0, dim1, dim2) {}
 
-  explicit operator id<dimensions>() const {
-    id<dimensions> result;
-    for (int i = 0; i < dimensions; ++i) {
-      result[i] = this->get(i);
-    }
-    return result;
-  }
-
   size_t size() const {
     size_t size = 1;
     for (int i = 0; i < dimensions; ++i) {
@@ -70,19 +62,26 @@ public:
   range() = delete;
 
 // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-#define __SYCL_GEN_OPT(op)                                                     \
-  range<dimensions> operator op(const range<dimensions> &rhs) const {          \
-    range<dimensions> result(*this);                                           \
+#define __SYCL_GEN_OPT_BASE(op)                                                \
+    friend range<dimensions> operator op(                                      \
+      const range<dimensions> &lhs, const range<dimensions> &rhs) {            \
+    range<dimensions> result(lhs);                                             \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      result.common_array[i] = this->common_array[i] op rhs.common_array[i];   \
+      result.common_array[i] = lhs.common_array[i] op rhs.common_array[i];     \
     }                                                                          \
     return result;                                                             \
-  }                                                                            \
+  }
+
+  #ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+// Enable operators with integral types only
+  #define __SYCL_GEN_OPT(op)                                                   \
+  __SYCL_GEN_OPT_BASE(op)                                                      \
   template <typename T>                                                        \
-  IntegralType<T, range<dimensions>> operator op(const T &rhs) const {         \
-    range<dimensions> result(*this);                                           \
+  friend IntegralType<T, range<dimensions>> operator op(                       \
+      const range<dimensions> &lhs, const T &rhs) {                            \
+    range<dimensions> result(lhs);                                             \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      result.common_array[i] = this->common_array[i] op rhs;                   \
+      result.common_array[i] = lhs.common_array[i] op rhs;                     \
     }                                                                          \
     return result;                                                             \
   }                                                                            \
@@ -95,6 +94,26 @@ public:
     }                                                                          \
     return result;                                                             \
   }
+  #else
+  #define __SYCL_GEN_OPT(op)                                                   \
+  __SYCL_GEN_OPT_BASE(op)                                                      \
+  friend range<dimensions> operator op(                                        \
+      const range<dimensions> &lhs, const size_t &rhs) {                       \
+    range<dimensions> result(lhs);                                             \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      result.common_array[i] = lhs.common_array[i] op rhs;                     \
+    }                                                                          \
+    return result;                                                             \
+  }                                                                            \
+  friend range<dimensions> operator op(                                        \
+      const size_t &lhs, const range<dimensions> &rhs) {                       \
+    range<dimensions> result(rhs);                                             \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      result.common_array[i] = lhs op rhs.common_array[i];                     \
+    }                                                                          \
+    return result;                                                             \
+  }
+  #endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 
   __SYCL_GEN_OPT(+)
   __SYCL_GEN_OPT(-)
@@ -114,20 +133,23 @@ public:
   __SYCL_GEN_OPT(>=)
 
 #undef __SYCL_GEN_OPT
+#undef __SYCL_GEN_OPT_BASE
 
 // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
 #define __SYCL_GEN_OPT(op)                                                     \
-  range<dimensions> &operator op(const range<dimensions> &rhs) {               \
+  friend range<dimensions> &operator op(                                       \
+      range<dimensions> &lhs, const range<dimensions> &rhs) {                  \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      this->common_array[i] op rhs[i];                                         \
+      lhs.common_array[i] op rhs[i];                                           \
     }                                                                          \
-    return *this;                                                              \
+    return lhs;                                                                \
   }                                                                            \
-  range<dimensions> &operator op(const size_t &rhs) {                          \
+  friend range<dimensions> &operator op(                                       \
+      range<dimensions> &lhs, const size_t &rhs) {                             \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      this->common_array[i] op rhs;                                            \
+      lhs.common_array[i] op rhs;                                              \
     }                                                                          \
-    return *this;                                                              \
+    return lhs;                                                                \
   }
 
   __SYCL_GEN_OPT(+=)
@@ -142,6 +164,52 @@ public:
   __SYCL_GEN_OPT(^=)
 
 #undef __SYCL_GEN_OPT
+
+// OP is unary +, -
+#define __SYCL_GEN_OPT(op)                                                     \
+  friend range<dimensions> operator op(const range<dimensions> &rhs) {         \
+    range<dimensions> result(rhs);                                             \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      result.common_array[i] = (op rhs.common_array[i]);                       \
+    }                                                                          \
+    return result;                                                             \
+  }
+
+  __SYCL_GEN_OPT(+)
+  __SYCL_GEN_OPT(-)
+
+#undef __SYCL_GEN_OPT
+
+// OP is prefix ++, --
+#define __SYCL_GEN_OPT(op)                                                     \
+  friend range<dimensions> &operator op(range<dimensions> &rhs) {              \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      op rhs.common_array[i];                                                  \
+    }                                                                          \
+    return rhs;                                                                \
+  }
+
+  __SYCL_GEN_OPT(++)
+  __SYCL_GEN_OPT(--)
+
+#undef __SYCL_GEN_OPT
+
+// OP is postfix ++, --
+#define __SYCL_GEN_OPT(op)                                                     \
+  friend range<dimensions> operator op(range<dimensions> &lhs, int) {          \
+    range<dimensions> old_lhs(lhs);                                            \
+    for (int i = 0; i < dimensions; ++i) {                                     \
+      /*old_lhs.common_array[i] = lhs.common_array[i];*/                       \
+      op lhs.common_array[i];                                                  \
+    }                                                                          \
+    return old_lhs;                                                            \
+  }
+
+  __SYCL_GEN_OPT(++)
+  __SYCL_GEN_OPT(--)
+
+#undef __SYCL_GEN_OPT
+
 
 private:
   friend class handler;

--- a/sycl/include/CL/sycl/range.hpp
+++ b/sycl/include/CL/sycl/range.hpp
@@ -199,7 +199,6 @@ public:
   friend range<dimensions> operator op(range<dimensions> &lhs, int) {          \
     range<dimensions> old_lhs(lhs);                                            \
     for (int i = 0; i < dimensions; ++i) {                                     \
-      /*old_lhs.common_array[i] = lhs.common_array[i];*/                       \
       op lhs.common_array[i];                                                  \
     }                                                                          \
     return old_lhs;                                                            \

--- a/sycl/test/basic_tests/id.cpp
+++ b/sycl/test/basic_tests/id.cpp
@@ -465,9 +465,7 @@ int main() {
     assert((two_dim_id--) == (two_dim_id_copy + 1));
     assert((three_dim_id++) == (three_dim_id_copy));
     assert((three_dim_id--) == (three_dim_id_copy + 1));
-
   }
-
 
 #undef numValue
 #endif // __SYCL_DISABLE_ID_TO_INT_CONV__

--- a/sycl/test/basic_tests/id.cpp
+++ b/sycl/test/basic_tests/id.cpp
@@ -437,6 +437,38 @@ int main() {
           (number_5 == numValue));
   }
 
+  {
+    cl::sycl::id<1> one_dim_id(64);
+    cl::sycl::id<1> one_dim_id_copy(64);
+    cl::sycl::id<2> two_dim_id(64, 1);
+    cl::sycl::id<2> two_dim_id_copy(64, 1);
+    cl::sycl::id<3> three_dim_id(64, 1, 2);
+    cl::sycl::id<3> three_dim_id_copy(64, 1, 2);
+
+    assert((+one_dim_id) == one_dim_id);
+    assert(-(-one_dim_id) == one_dim_id);
+    assert((+two_dim_id) == two_dim_id);
+    assert(-(-two_dim_id) == two_dim_id);
+    assert((+three_dim_id) == three_dim_id);
+    assert(-(-three_dim_id) == three_dim_id);
+
+    assert((++one_dim_id) == (one_dim_id_copy + 1));
+    assert((--one_dim_id) == (one_dim_id_copy));
+    assert((++two_dim_id) == (two_dim_id_copy + 1));
+    assert((--two_dim_id) == (two_dim_id_copy));
+    assert((++three_dim_id) == (three_dim_id_copy + 1));
+    assert((--three_dim_id) == (three_dim_id_copy));
+
+    assert((one_dim_id++) == (one_dim_id_copy));
+    assert((one_dim_id--) == (one_dim_id_copy + 1));
+    assert((two_dim_id++) == (two_dim_id_copy));
+    assert((two_dim_id--) == (two_dim_id_copy + 1));
+    assert((three_dim_id++) == (three_dim_id_copy));
+    assert((three_dim_id--) == (three_dim_id_copy + 1));
+
+  }
+
+
 #undef numValue
 #endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 }

--- a/sycl/test/basic_tests/id.cpp
+++ b/sycl/test/basic_tests/id.cpp
@@ -437,20 +437,26 @@ int main() {
           (number_5 == numValue));
   }
 
+#undef numValue
+#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
+
   {
     cl::sycl::id<1> one_dim_id(64);
+    cl::sycl::id<1> one_dim_id_neg(-64);
     cl::sycl::id<1> one_dim_id_copy(64);
     cl::sycl::id<2> two_dim_id(64, 1);
+    cl::sycl::id<2> two_dim_id_neg(-64, -1);
     cl::sycl::id<2> two_dim_id_copy(64, 1);
     cl::sycl::id<3> three_dim_id(64, 1, 2);
+    cl::sycl::id<3> three_dim_id_neg(-64, -1, -2);
     cl::sycl::id<3> three_dim_id_copy(64, 1, 2);
 
     assert((+one_dim_id) == one_dim_id);
-    assert(-(-one_dim_id) == one_dim_id);
+    assert(-one_dim_id == one_dim_id_neg);
     assert((+two_dim_id) == two_dim_id);
-    assert(-(-two_dim_id) == two_dim_id);
+    assert(-two_dim_id == two_dim_id_neg);
     assert((+three_dim_id) == three_dim_id);
-    assert(-(-three_dim_id) == three_dim_id);
+    assert(-three_dim_id == three_dim_id_neg);
 
     assert((++one_dim_id) == (one_dim_id_copy + 1));
     assert((--one_dim_id) == (one_dim_id_copy));
@@ -466,7 +472,4 @@ int main() {
     assert((three_dim_id++) == (three_dim_id_copy));
     assert((three_dim_id--) == (three_dim_id_copy + 1));
   }
-
-#undef numValue
-#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 }

--- a/sycl/test/basic_tests/range.cpp
+++ b/sycl/test/basic_tests/range.cpp
@@ -34,4 +34,30 @@ int main() {
   assert(three_dim_range.get(2) ==2);
   assert(three_dim_range[2] ==2);
   cout << "three_dim_range passed " << endl;
+
+  cl::sycl::range<1> one_dim_range_copy(64);
+  cl::sycl::range<2> two_dim_range_copy(64, 1);
+  cl::sycl::range<3> three_dim_range_copy(64, 1, 2);
+
+  assert((+one_dim_range) == one_dim_range);
+  assert(-(-one_dim_range) == one_dim_range);
+  assert((+two_dim_range) == two_dim_range);
+  assert(-(-two_dim_range) == two_dim_range);
+  assert((+three_dim_range) == three_dim_range);
+  assert(-(-three_dim_range) == three_dim_range);
+
+  assert((++one_dim_range) == (one_dim_range_copy + 1));
+  assert((--one_dim_range) == (one_dim_range_copy));
+  assert((++two_dim_range) == (two_dim_range_copy + 1));
+  assert((--two_dim_range) == (two_dim_range_copy));
+  assert((++three_dim_range) == (three_dim_range_copy + 1));
+  assert((--three_dim_range) == (three_dim_range_copy));
+
+  assert((one_dim_range++) == (one_dim_range_copy));
+  assert((one_dim_range--) == (one_dim_range_copy + 1));
+  assert((two_dim_range++) == (two_dim_range_copy));
+  assert((two_dim_range--) == (two_dim_range_copy + 1));
+  assert((three_dim_range++) == (three_dim_range_copy));
+  assert((three_dim_range--) == (three_dim_range_copy + 1));
+
 }

--- a/sycl/test/basic_tests/range.cpp
+++ b/sycl/test/basic_tests/range.cpp
@@ -35,16 +35,19 @@ int main() {
   assert(three_dim_range[2] ==2);
   cout << "three_dim_range passed " << endl;
 
+  cl::sycl::range<1> one_dim_range_neg(-64);
   cl::sycl::range<1> one_dim_range_copy(64);
+  cl::sycl::range<2> two_dim_range_neg(-64, -1);
   cl::sycl::range<2> two_dim_range_copy(64, 1);
   cl::sycl::range<3> three_dim_range_copy(64, 1, 2);
+  cl::sycl::range<3> three_dim_range_neg(-64, -1, -2);
 
   assert((+one_dim_range) == one_dim_range);
-  assert(-(-one_dim_range) == one_dim_range);
+  assert(-one_dim_range == one_dim_range_neg);
   assert((+two_dim_range) == two_dim_range);
-  assert(-(-two_dim_range) == two_dim_range);
+  assert(-two_dim_range == two_dim_range_neg);
   assert((+three_dim_range) == three_dim_range);
-  assert(-(-three_dim_range) == three_dim_range);
+  assert(-three_dim_range == three_dim_range_neg);
 
   assert((++one_dim_range) == (one_dim_range_copy + 1));
   assert((--one_dim_range) == (one_dim_range_copy));

--- a/sycl/test/basic_tests/range.cpp
+++ b/sycl/test/basic_tests/range.cpp
@@ -59,5 +59,4 @@ int main() {
   assert((two_dim_range--) == (two_dim_range_copy + 1));
   assert((three_dim_range++) == (three_dim_range_copy));
   assert((three_dim_range--) == (three_dim_range_copy + 1));
-
 }

--- a/sycl/test/warnings/conversion_deprecation.cpp
+++ b/sycl/test/warnings/conversion_deprecation.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test/warnings/conversion_deprecation.cpp
+++ b/sycl/test/warnings/conversion_deprecation.cpp
@@ -6,9 +6,9 @@
 #include <CL/sycl.hpp>
 
 int main() {
-    cl::sycl::id<1> id_obj(64);
-    // expected-warning@+1 {{'operator range' is deprecated: range() conversion is deprecated}}
-    (void)(cl::sycl::range<1>)id_obj;
+  cl::sycl::id<1> id_obj(64);
+  // expected-warning@+1 {{'operator range' is deprecated: range() conversion is deprecated}}
+  (void)(cl::sycl::range<1>) id_obj;
 
-    return 0;
+  return 0;
 }

--- a/sycl/test/warnings/conversion_deprecation.cpp
+++ b/sycl/test/warnings/conversion_deprecation.cpp
@@ -1,0 +1,14 @@
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -sycl-std=2020 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -sycl-std=2017 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -sycl-std=1.2.1 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+
+#include <CL/sycl.hpp>
+
+int main() {
+    cl::sycl::id<1> id_obj(64);
+    // expected-warning@+1 {{'operator range' is deprecated: range() conversion is deprecated}}
+    (void)(cl::sycl::range<1>)id_obj;
+
+    return 0;
+}

--- a/sycl/test/warnings/conversion_deprecation.cpp
+++ b/sycl/test/warnings/conversion_deprecation.cpp
@@ -1,7 +1,4 @@
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -sycl-std=2020 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
 // RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -sycl-std=2017 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -sycl-std=1.2.1 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
 
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
"range" and "id" did not correspond to the SYCL 2020 specification: the binary operators were corrected, the necessary operators were added, unnecessary operators were deprecated.