### PR TITLE
[SYCL][HIP] Add missing check-sycl-hip skips

### DIFF
--- a/sycl/test/extensions/bfloat16.cpp
+++ b/sycl/test/extensions/bfloat16.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=%sycl_triple -S %s -o - | FileCheck %s
 
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_amd
 
 #include <sycl/ext/intel/experimental/bfloat16.hpp>
 #include <sycl/sycl.hpp>

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -118,6 +118,11 @@ TEST(KernelID, FreeKernelIDEqualsKernelBundleId) {
     return;
   }
 
+  if (Plt.get_backend() == sycl::backend::hip) {
+    std::cout << "Test is not supported on HIP platform, skipping\n";
+    return;
+  }
+
   sycl::unittest::PiMock Mock{Plt};
   setupDefaultMockAPIs(Mock);
 
@@ -156,6 +161,11 @@ TEST(KernelID, KernelBundleKernelIDsIntersectAll) {
     return;
   }
 
+  if (Plt.get_backend() == sycl::backend::hip) {
+    std::cout << "Test is not supported on HIP platform, skipping\n";
+    return;
+  }
+
   sycl::unittest::PiMock Mock{Plt};
   setupDefaultMockAPIs(Mock);
 
@@ -187,6 +197,11 @@ TEST(KernelID, KernelIDHasKernel) {
 
   if (Plt.get_backend() == sycl::backend::cuda) {
     std::cout << "Test is not supported on CUDA platform, skipping\n";
+    return;
+  }
+
+  if (Plt.get_backend() == sycl::backend::hip) {
+    std::cout << "Test is not supported on HIP platform, skipping\n";
     return;
   }
 

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -366,6 +366,11 @@ TEST(Assert, TestPositive) {
       printf("Test is not supported on CUDA platform, skipping\n");
       return;
     }
+
+    if (Plt.get_backend() == sycl::backend::hip) {
+      printf("Test is not supported on HIP platform, skipping\n");
+      return;
+    }
   }
 
 #ifndef _WIN32


### PR DESCRIPTION
These match CUDA plugin skips.

The `KernelID` and `assert` tests use SPIRV binaries which are not
supported by the HIP plugin. The `bfloat16` extension is also not
yet supported by the HIP plugin.