### PR TITLE
[Driver][SYCL] Improve object file recognition processing with linker…

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7757,6 +7757,8 @@ bool clang::driver::isOptimizationLevelFast(const ArgList &Args) {
 }
 
 bool clang::driver::isObjectFile(std::string FileName) {
+  if (llvm::sys::fs::is_directory(FileName))
+    return false;
   if (!llvm::sys::path::has_extension(FileName))
     // Any file with no extension should be considered an Object. Take into
     // account -lsomelib library filenames.

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -112,3 +112,14 @@
 // RUN:    | FileCheck -check-prefixes=SYCL_TARGET_OPT_AOT %s
 // SYCL_TARGET_OPT_AOT-NOT: error: cannot deduce implicit triple value for '-Xsycl-target-backend'
 // SYCL_TARGET_OPT_AOT: {{opencl-aot|ocloc|aoc}}{{.*}} "-DFOO"
+
+/// Do not process directories when checking for default sections in fat objs
+// RUN:  %clangxx -### -Wl,-rpath,%S -fsycl -fsycl-targets=spir64_x86_64 %t_empty.o %s 2>&1 \
+// RUN:    | FileCheck -check-prefix NO_DIR_CHECK %s
+// RUN:  %clangxx -### -Xlinker -rpath -Xlinker %S -fsycl -fsycl-targets=spir64_fpga %t_empty.o %s 2>&1 \
+// RUN:    | FileCheck -check-prefix NO_DIR_CHECK %s
+// RUN:  %clangxx -### -Wl,-rpath,%S -fsycl -fsycl-targets=spir64_gen %t_empty.o %s 2>&1 \
+// RUN:    | FileCheck -check-prefix NO_DIR_CHECK %s
+// RUN:  %clangxx -### -Wl,-rpath,%S -fsycl -fintelfpga %t_empty.o %s 2>&1 \
+// RUN:    | FileCheck -check-prefix NO_DIR_CHECK %s
+// NO_DIR_CHECK-NOT: clang-offload-bundler: error: '{{.*}}': Is a directory


### PR DESCRIPTION
… args

When processing linker arguments, we need to be sure that any items like
-rpath DIR are not processed as a file.  Add a check to not recognize DIR
as an object as it is a directory.