### PR TITLE
[SYCL] Simple fix for building on Windows.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -847,7 +847,7 @@ static const int ZeMaxCommandListCacheSize = [] {
 }();
 
 // Configuration of the command-list batching.
-typedef struct {
+typedef struct CommandListBatchConfig {
   // Default value of 0. This specifies to use dynamic batch size adjustment.
   // Other values will try to collect specified amount of commands.
   pi_uint32 Size{0};


### PR DESCRIPTION
overlooked struct typename causing Windows to emit a warning, which leads to build failure. Simple fix restores Win buildability.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>