### PR TITLE
[SYCL][L0] Fix mismatched ZE call count

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1536,8 +1536,10 @@ pi_result piPlatformsGet(pi_uint32 NumEntries, pi_platform *Platforms,
         ZeCallCount = new std::map<const char *, int>;
       }
     });
-  } catch (...) {
+  } catch (const std::bad_alloc &) {
     return PI_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return PI_ERROR_UNKNOWN;
   }
 
   if (NumEntries == 0 && Platforms != nullptr) {

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1529,7 +1529,7 @@ pi_result piPlatformsGet(pi_uint32 NumEntries, pi_platform *Platforms,
     PrintPiTrace = true;
   }
 
-  if (ZeDebug & ZE_DEBUG_CALL_COUNT) {
+  if ((ZeDebug & ZE_DEBUG_CALL_COUNT) && !ZeCallCount) {
     ZeCallCount = new std::map<const char *, int>;
   }
 

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -137,9 +137,6 @@ static pi_result mapError(ze_result_t ZeResult) {
   return It->second;
 }
 
-// This will count the calls to Level-Zero
-static std::map<const char *, int> *ZeCallCount = nullptr;
-
 // Trace a call to Level-Zero RT
 #define ZE_CALL(ZeName, ZeArgs)                                                \
   {                                                                            \
@@ -183,6 +180,14 @@ static void zePrint(const char *Format, ...) {
     va_end(Args);
   }
 }
+
+// This will count the calls to Level-Zero
+static std::map<const char *, int> *ZeCallCount = [] {
+  if (ZeDebug & ZE_DEBUG_CALL_COUNT) {
+    return new std::map<const char *, int>;
+  }
+  return (std::map<const char *, int> *)nullptr;
+}();
 
 // Helper function to implement zeHostSynchronize.
 // The behavior is to avoid infinite wait during host sync under ZE_DEBUG.
@@ -1527,10 +1532,6 @@ pi_result piPlatformsGet(pi_uint32 NumEntries, pi_platform *Platforms,
   static const int PiTraceValue = PiTrace ? std::stoi(PiTrace) : 0;
   if (PiTraceValue == -1) { // Means print all PI traces
     PrintPiTrace = true;
-  }
-
-  if ((ZeDebug & ZE_DEBUG_CALL_COUNT) && !ZeCallCount) {
-    ZeCallCount = new std::map<const char *, int>;
   }
 
   if (NumEntries == 0 && Platforms != nullptr) {

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1530,10 +1530,15 @@ pi_result piPlatformsGet(pi_uint32 NumEntries, pi_platform *Platforms,
   }
 
   static std::once_flag ZeCallCountInitialized;
-  std::call_once(ZeCallCountInitialized, []() {
-    if (ZeDebug & ZE_DEBUG_CALL_COUNT)
-      ZeCallCount = new std::map<const char *, int>;
-  });
+  try {
+    std::call_once(ZeCallCountInitialized, []() {
+      if (ZeDebug & ZE_DEBUG_CALL_COUNT) {
+        ZeCallCount = new std::map<const char *, int>;
+      }
+    });
+  } catch (...) {
+    return PI_OUT_OF_HOST_MEMORY;
+  }
 
   if (NumEntries == 0 && Platforms != nullptr) {
     return PI_INVALID_VALUE;


### PR DESCRIPTION
We should create ZeCallCount map only once.

Signed-off-by: Byoungro So <byoungro.so@intel.com>