### PR TITLE
[SYCL][NFC] Fix a link in spec constants readme document

### DIFF
--- a/sycl/doc/extensions/SpecConstants/README.md
+++ b/sycl/doc/extensions/SpecConstants/README.md
@@ -56,7 +56,7 @@ instance, setting new values and rebuilding it via
 `sc0.get()` and  `sc1.get()` within thhe device code with the corresponding
 constant values (`sc_vals[i][0]` and `sc_vals[i][1]`). Full runnable example
 can be found on
-[github](https://github.com/intel/llvm/blob/sycl/sycl/test/on-device/spec_const/spec_const_redefine.cpp).
+[github](https://github.com/intel/llvm-test-suite/blob/intel/SYCL/SpecConstants/1.2.1/spec_const_redefine.cpp).
 
 Specialization constants can be used in programs compiled Ahead-Of-Time, in this
 case a specialization constant takes default value for its type (as specified by


### PR DESCRIPTION
The test referenced by the doc has been moved to llvm-test-suite a while
ago, update the link accordingly.