### PR TITLE
[SYCL] Ignore usm prefetch dummy flag

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -1560,6 +1560,9 @@ typedef enum : pi_bitfield {
   PI_MEM_ALLOC_FLAGS = CL_MEM_ALLOC_FLAGS_INTEL
 } _pi_usm_mem_properties;
 
+// Flag is used for piProgramUSMEnqueuePrefetch. PI_USM_MIGRATION_TBD0 is a
+// placeholder for future developments and should not change the behaviour of
+// piProgramUSMEnqueuePrefetch
 typedef enum : pi_bitfield {
   PI_USM_MIGRATION_TBD0 = (1 << 0)
 } _pi_usm_migration_flags;

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4589,13 +4589,15 @@ pi_result cuda_piextUSMEnqueueMemcpy(pi_queue queue, pi_bool blocking,
   return result;
 }
 
+// flags is currently ignored as it is a placeholder for future features
 pi_result cuda_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
                                        size_t size,
                                        pi_usm_migration_flags flags,
                                        pi_uint32 num_events_in_waitlist,
                                        const pi_event *events_waitlist,
                                        pi_event *event) {
-  assert(queue != nullptr);
+  assert(!(flags & ~PI_USM_MIGRATION_TBD0), PI_INVALID_VALUE)
+      assert(queue != nullptr);
   assert(ptr != nullptr);
   CUstream cuStream = queue->get();
   pi_result result = PI_SUCCESS;

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4596,8 +4596,10 @@ pi_result cuda_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
                                        pi_uint32 num_events_in_waitlist,
                                        const pi_event *events_waitlist,
                                        pi_event *event) {
-  assert(!(flags & ~PI_USM_MIGRATION_TBD0), PI_INVALID_VALUE)
-      assert(queue != nullptr);
+
+  if (!(flags & ~PI_USM_MIGRATION_TBD0))
+    return PI_INVALID_VALUE;
+  assert(queue != nullptr);
   assert(ptr != nullptr);
   CUstream cuStream = queue->get();
   pi_result result = PI_SUCCESS;

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4589,7 +4589,6 @@ pi_result cuda_piextUSMEnqueueMemcpy(pi_queue queue, pi_bool blocking,
   return result;
 }
 
-// flags is currently ignored as it is a placeholder for future features
 pi_result cuda_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
                                        size_t size,
                                        pi_usm_migration_flags flags,
@@ -4597,7 +4596,8 @@ pi_result cuda_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
                                        const pi_event *events_waitlist,
                                        pi_event *event) {
 
-  if (!(flags & ~PI_USM_MIGRATION_TBD0))
+  // flags is currently unused so fail if set
+  if (flags != 0)
     return PI_INVALID_VALUE;
   assert(queue != nullptr);
   assert(ptr != nullptr);

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4601,10 +4601,6 @@ pi_result cuda_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
   pi_result result = PI_SUCCESS;
   std::unique_ptr<_pi_event> event_ptr{nullptr};
 
-  // TODO implement handling the flags once the expected behaviour
-  // of piextUSMEnqueuePrefetch is detailed in the USM extension
-  assert(flags == 0u);
-
   try {
     ScopedContext active(queue->get_context());
     result = cuda_piEnqueueEventsWait(queue, num_events_in_waitlist,

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -4426,14 +4426,14 @@ pi_result hip_piextUSMEnqueueMemcpy(pi_queue queue, pi_bool blocking,
   return result;
 }
 
-// flags is currently ignored as it is a placeholder for future features
 pi_result hip_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
                                       size_t size, pi_usm_migration_flags flags,
                                       pi_uint32 num_events_in_waitlist,
                                       const pi_event *events_waitlist,
                                       pi_event *event) {
 
-  if (!(flags & ~PI_USM_MIGRATION_TBD0))
+  // flags is currently unused so fail if set
+  if (flags != 0)
     return PI_INVALID_VALUE;
   assert(queue != nullptr);
   assert(ptr != nullptr);

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -4426,12 +4426,14 @@ pi_result hip_piextUSMEnqueueMemcpy(pi_queue queue, pi_bool blocking,
   return result;
 }
 
+// flags is currently ignored as it is a placeholder for future features
 pi_result hip_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
                                       size_t size, pi_usm_migration_flags flags,
                                       pi_uint32 num_events_in_waitlist,
                                       const pi_event *events_waitlist,
                                       pi_event *event) {
 
+  assert(!(flags & ~PI_USM_MIGRATION_TBD0));
   assert(queue != nullptr);
   assert(ptr != nullptr);
   hipStream_t hipStream = queue->get();

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -4433,7 +4433,8 @@ pi_result hip_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
                                       const pi_event *events_waitlist,
                                       pi_event *event) {
 
-  assert(!(flags & ~PI_USM_MIGRATION_TBD0));
+  if (!(flags & ~PI_USM_MIGRATION_TBD0))
+    return PI_INVALID_VALUE;
   assert(queue != nullptr);
   assert(ptr != nullptr);
   hipStream_t hipStream = queue->get();

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -4438,10 +4438,6 @@ pi_result hip_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
   pi_result result = PI_SUCCESS;
   std::unique_ptr<_pi_event> event_ptr{nullptr};
 
-  // TODO implement handling the flags once the expected behaviour
-  // of piextUSMEnqueuePrefetch is detailed in the USM extension
-  assert(flags == 0u);
-
   try {
     ScopedContext active(queue->get_context());
     result = hip_piEnqueueEventsWait(queue, num_events_in_waitlist,

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -6628,13 +6628,14 @@ pi_result piextUSMEnqueueMemcpy(pi_queue Queue, pi_bool Blocking, void *DstPtr,
 /// @param NumEventsInWaitlist is the number of events to wait on
 /// @param EventsWaitlist is an array of events to wait on
 /// @param Event is the event that represents this operation
-// flags is currently ignored as it is a placeholder for future features
 pi_result piextUSMEnqueuePrefetch(pi_queue Queue, const void *Ptr, size_t Size,
                                   pi_usm_migration_flags Flags,
                                   pi_uint32 NumEventsInWaitList,
                                   const pi_event *EventWaitList,
                                   pi_event *Event) {
-  PI_ASSERT(!(Flags & ~PI_USM_MIGRATION_TBD0), PI_INVALID_VALUE);
+
+  // flags is currently unused so fail if set
+  PI_ASSERT(Flags == 0, PI_INVALID_VALUE);
   PI_ASSERT(Queue, PI_INVALID_QUEUE);
   PI_ASSERT(Event, PI_INVALID_EVENT);
 

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -6628,11 +6628,13 @@ pi_result piextUSMEnqueueMemcpy(pi_queue Queue, pi_bool Blocking, void *DstPtr,
 /// @param NumEventsInWaitlist is the number of events to wait on
 /// @param EventsWaitlist is an array of events to wait on
 /// @param Event is the event that represents this operation
+// flags is currently ignored as it is a placeholder for future features
 pi_result piextUSMEnqueuePrefetch(pi_queue Queue, const void *Ptr, size_t Size,
                                   pi_usm_migration_flags Flags,
                                   pi_uint32 NumEventsInWaitList,
                                   const pi_event *EventWaitList,
                                   pi_event *Event) {
+  PI_ASSERT(!(Flags & ~PI_USM_MIGRATION_TBD0), PI_INVALID_VALUE);
   PI_ASSERT(Queue, PI_INVALID_QUEUE);
   PI_ASSERT(Event, PI_INVALID_EVENT);
 

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -6633,7 +6633,6 @@ pi_result piextUSMEnqueuePrefetch(pi_queue Queue, const void *Ptr, size_t Size,
                                   pi_uint32 NumEventsInWaitList,
                                   const pi_event *EventWaitList,
                                   pi_event *Event) {
-  PI_ASSERT(!(Flags & ~PI_USM_MIGRATION_TBD0), PI_INVALID_VALUE);
   PI_ASSERT(Queue, PI_INVALID_QUEUE);
   PI_ASSERT(Event, PI_INVALID_EVENT);
 

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -1014,7 +1014,8 @@ pi_result piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr, size_t size,
   (void)ptr;
   (void)size;
 
-  assert(!(flags & ~PI_USM_MIGRATION_TBD0));
+  if (!(flags & ~PI_USM_MIGRATION_TBD0))
+    return PI_INVALID_VALUE;
 
   return cast<pi_result>(clEnqueueMarkerWithWaitList(
       cast<cl_command_queue>(queue), num_events_in_waitlist,

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -1005,6 +1005,7 @@ pi_result piextUSMEnqueueMemcpy(pi_queue queue, pi_bool blocking, void *dst_ptr,
 /// \param num_events_in_waitlist is the number of events to wait on
 /// \param events_waitlist is an array of events to wait on
 /// \param event is the event that represents this operation
+// flags is currently ignored as it is a placeholder for future features
 pi_result piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr, size_t size,
                                   pi_usm_migration_flags flags,
                                   pi_uint32 num_events_in_waitlist,
@@ -1012,7 +1013,8 @@ pi_result piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr, size_t size,
                                   pi_event *event) {
   (void)ptr;
   (void)size;
-  (void)flags;
+
+  assert(!(flags & ~PI_USM_MIGRATION_TBD0));
 
   return cast<pi_result>(clEnqueueMarkerWithWaitList(
       cast<cl_command_queue>(queue), num_events_in_waitlist,

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -1005,7 +1005,6 @@ pi_result piextUSMEnqueueMemcpy(pi_queue queue, pi_bool blocking, void *dst_ptr,
 /// \param num_events_in_waitlist is the number of events to wait on
 /// \param events_waitlist is an array of events to wait on
 /// \param event is the event that represents this operation
-// flags is currently ignored as it is a placeholder for future features
 pi_result piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr, size_t size,
                                   pi_usm_migration_flags flags,
                                   pi_uint32 num_events_in_waitlist,
@@ -1014,7 +1013,8 @@ pi_result piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr, size_t size,
   (void)ptr;
   (void)size;
 
-  if (!(flags & ~PI_USM_MIGRATION_TBD0))
+  // flags is currently unused so fail if set
+  if (flags != 0)
     return PI_INVALID_VALUE;
 
   return cast<pi_result>(clEnqueueMarkerWithWaitList(

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -698,7 +698,7 @@ void MemoryManager::prefetch_usm(void *Mem, QueueImplPtr Queue, size_t Length,
   } else {
     const detail::plugin &Plugin = Queue->getPlugin();
     Plugin.call<PiApiKind::piextUSMEnqueuePrefetch>(
-        Queue->getHandleRef(), Mem, Length, PI_USM_MIGRATION_TBD0,
+        Queue->getHandleRef(), Mem, Length, _pi_usm_migration_flags(0),
         DepEvents.size(), DepEvents.data(), &OutEvent);
   }
 }


### PR DESCRIPTION
Patch removes assertions in pi_cuda, pi_hip, and pi_level_zero which fail based upon the flag given to the function.
`prefetch_usm` function now does not pass flag to PI.
The flag is a placeholder and should be ignored.

This is a follow up PR from issue #4467 