### PR TITLE
[clang-offload-wrapper] Do not create .tgtimg section with -emit-reg-funcs=0

### DIFF
--- a/clang/test/Driver/clang-offload-wrapper.c
+++ b/clang/test/Driver/clang-offload-wrapper.c
@@ -191,6 +191,7 @@
 // CHECK-IR1: [[DESCTY:%.+]] = type { i16, i16, [[IMAGETY]]*, [[ENTTY]]*, [[ENTTY]]* }
 // CHECK-IR1-NOT: @llvm.global_ctors
 // CHECK-IR1-NOT: @llvm.global_dtors
+// CHECK-IR1-NOT: section ".tgtimg"
 // CHECK-IR1: @.sycl_offloading.lalala = constant [[DESCTY]] { i16 {{[0-9]+}}, i16 1, [[IMAGETY]]* getelementptr inbounds ([1 x [[IMAGETY]]], [1 x [[IMAGETY]]]* @.sycl_offloading.device_images, i64 0, i64 0), [[ENTTY]]* null, [[ENTTY]]* null }
 
 // -------

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -997,26 +997,29 @@ private:
         ImagesInits.push_back(ConstantStruct::get(
             getDeviceImageTy(), Fbin.first, Fbin.second, EntriesB, EntriesE));
 
-      // Create an object that holds <address, size> pair for the device image
-      // and put it into a .tgtimg section. This section can be used for finding
-      // and extracting all device images from the fat binary after linking.
-      Type *IntPtrTy = M.getDataLayout().getIntPtrType(C);
-      auto *ImgInfoArr = ConstantArray::get(
-          ArrayType::get(IntPtrTy, 2),
-          {ConstantExpr::getPointerCast(Fbin.first, IntPtrTy),
-           ConstantInt::get(IntPtrTy, Bin->getBufferSize())});
-      auto *ImgInfoVar = new GlobalVariable(
-          M, ImgInfoArr->getType(), /*isConstant*/ true,
-          GlobalVariable::InternalLinkage, ImgInfoArr,
-          Twine(OffloadKindTag) + Twine(ImgId) + Twine(".info"));
-      ImgInfoVar->setAlignment(
-          MaybeAlign(M.getDataLayout().getTypeStoreSize(IntPtrTy) * 2u));
-      ImgInfoVar->setUnnamedAddr(GlobalValue::UnnamedAddr::Local);
-      ImgInfoVar->setSection(".tgtimg");
+      if (EmitRegFuncs) {
+        // Create an object that holds <address, size> pair for the device image
+        // and put it into a .tgtimg section. This section can be used for
+        // finding and extracting all device images from the fat binary after
+        // linking.
+        Type *IntPtrTy = M.getDataLayout().getIntPtrType(C);
+        auto *ImgInfoArr = ConstantArray::get(
+            ArrayType::get(IntPtrTy, 2),
+            {ConstantExpr::getPointerCast(Fbin.first, IntPtrTy),
+             ConstantInt::get(IntPtrTy, Bin->getBufferSize())});
+        auto *ImgInfoVar = new GlobalVariable(
+            M, ImgInfoArr->getType(), /*isConstant*/ true,
+            GlobalVariable::InternalLinkage, ImgInfoArr,
+            Twine(OffloadKindTag) + Twine(ImgId) + Twine(".info"));
+        ImgInfoVar->setAlignment(
+            MaybeAlign(M.getDataLayout().getTypeStoreSize(IntPtrTy) * 2u));
+        ImgInfoVar->setUnnamedAddr(GlobalValue::UnnamedAddr::Local);
+        ImgInfoVar->setSection(".tgtimg");
 
-      // Add image info to the used list to force it to be emitted to the
-      // object.
-      appendToUsed(M, ImgInfoVar);
+        // Add image info to the used list to force it to be emitted to the
+        // object.
+        appendToUsed(M, ImgInfoVar);
+      }
 
       ImgId++;
     }


### PR DESCRIPTION
With -emit-reg-funcs=0 wrapped images will not be registered at offloading
runtime, therefore they also should not be added to the .tgtimg section.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>