### PR TITLE
[SYCL][CI] Provide --ci-defaults option for config script

### DIFF
--- a/.github/workflows/linux_post_commit.yml
+++ b/.github/workflows/linux_post_commit.yml
@@ -42,7 +42,7 @@ jobs:
          mkdir -p $GITHUB_WORKSPACE/build
          cd $GITHUB_WORKSPACE/build
          python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
-         -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release $ARGS
+         -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release --ci-defaults $ARGS
      - name: Compile
        run: |
          python3 $GITHUB_WORKSPACE/src/buildbot/compile.py -w  $GITHUB_WORKSPACE \

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -41,6 +41,11 @@ def do_configure(args):
 
     sycl_enable_xpti_tracing = 'ON'
 
+    if args.ci_defaults:
+        print("#############################################")
+        print("# Default CI configuration will be applied. #")
+        print("#############################################")
+
     # replace not append, so ARM ^ X86
     if args.arm:
         llvm_targets_to_build = 'ARM;AArch64'
@@ -193,6 +198,7 @@ def main():
     parser.add_argument("--libcxx-library", metavar="LIBCXX_LIBRARY_PATH", help="libcxx library path")
     parser.add_argument("--use-lld", action="store_true", help="Use LLD linker for build")
     parser.add_argument("--llvm-external-projects", help="Add external projects to build. Add as comma seperated list.")
+    parser.add_argument("--ci-defaults", action="store_true", help="Enable default CI parameters")
     args = parser.parse_args()
 
     print("args:{}".format(args))


### PR DESCRIPTION
Default options for CI and user build environments have different
requirements. New option will be used by CI to get strict set of options,
like enabling -Werror. Running script without arguments will set sensible
defaults for those, who are building compiler toolchain for use, rather
than contributing to this project.

At the moment this option is nop.