### PR TITLE
[SYCL] - target::device enumeration value

### DIFF
--- a/sycl/include/CL/sycl/access/access.hpp
+++ b/sycl/include/CL/sycl/access/access.hpp
@@ -21,7 +21,8 @@ enum class target {
   image = 2017,
   host_buffer = 2018,
   host_image = 2019,
-  image_array = 2020
+  image_array = 2020,
+  device = global_buffer,
 };
 
 enum class mode {

--- a/sycl/test/basic_tests/accessor/target_device.cpp
+++ b/sycl/test/basic_tests/accessor/target_device.cpp
@@ -1,0 +1,29 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+
+// This short test simply confirms that target::device
+// is supported correctly.
+// TODO: delete this test and test the functionality
+// over in llvm-test-suite along with the other changes
+// needed to support the SYCL 2020 target updates.
+
+#include <CL/sycl.hpp>
+
+int main() {
+  sycl::queue testQueue;
+  sycl::range<1> ndRng(1);
+  int kernelResult;
+  {
+    sycl::buffer<int, 1> buffer(&kernelResult, ndRng);
+
+    testQueue.submit([&](sycl::handler &cgh) {
+      auto ptr = buffer.get_access<sycl::access_mode::read_write,
+                                   sycl::target::device>(cgh);
+      cgh.single_task<class kernel>([=]() { ptr[0] = 5; });
+    });
+  } // ~buffer
+
+  // std::cout << "kernelResult should be 5: " << kernelResult << std::endl;
+  assert(kernelResult == 5);
+
+  return 0;
+}


### PR DESCRIPTION
initial quick realization of target::device enumeration value.  More work required to realize full SYCL 2020 changes to target values.

@romanovvlad , this PR realizes the minimum changes needed to get target::device working, helping clear the way for https://github.com/intel/llvm/issues/3969.    

But the SYCL 2020 spec not only adds this enumeration value, it also adds `host_task` and deprecates all the other existing values. To do this properly, would entail marking those as deprecated, updating our code base in about a hundred places where we use `target::global_buffer` now to use `target::device` instead, as well as whatever is required for `target::host_task` , and more tests.   That'll take more time. But since you need target::device ASAP, this should serve in the short term. 

Signed-off-by: Chris Perkins <chris.perkins@intel.com>