### PR TITLE
[SYCL] Fix unqiue_ptr out-of-memory checks in scheduler

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -453,9 +453,9 @@ Scheduler::GraphBuilder::addCopyBack(Requirement *Req,
   AllocaCommandBase *SrcAllocaCmd =
       findAllocaForReq(Record, Req, Record->MCurContext);
 
-  std::unique_ptr<MemCpyCommandHost> MemCpyCmdUniquePtr(new MemCpyCommandHost(
+  auto MemCpyCmdUniquePtr = std::make_unique<MemCpyCommandHost>(
       *SrcAllocaCmd->getRequirement(), SrcAllocaCmd, *Req, &Req->MData,
-      SrcAllocaCmd->getQueue(), std::move(HostQueue)));
+      SrcAllocaCmd->getQueue(), std::move(HostQueue));
 
   if (!MemCpyCmdUniquePtr)
     throw runtime_error("Out of host memory", PI_OUT_OF_HOST_MEMORY);
@@ -886,8 +886,7 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
   const std::vector<detail::EventImplPtr> &Events = CommandGroup->MEvents;
   const CG::CGTYPE CGType = CommandGroup->getType();
 
-  std::unique_ptr<ExecCGCommand> NewCmd(
-      new ExecCGCommand(std::move(CommandGroup), Queue));
+  auto NewCmd = std::make_unique<ExecCGCommand>(std::move(CommandGroup), Queue);
   if (!NewCmd)
     throw runtime_error("Out of host memory", PI_OUT_OF_HOST_MEMORY);
 
@@ -1183,7 +1182,7 @@ Command *Scheduler::GraphBuilder::connectDepEvent(Command *const Cmd,
   // construct Host Task type command manually and make it depend on DepEvent
   ExecCGCommand *ConnectCmd = nullptr;
 
-  {
+  try {
     std::unique_ptr<detail::HostTask> HT(new detail::HostTask);
     std::unique_ptr<detail::CG> ConnectCG(new detail::CGHostTask(
         std::move(HT), /* Queue = */ {}, /* Context = */ {}, /* Args = */ {},
@@ -1193,10 +1192,9 @@ Command *Scheduler::GraphBuilder::connectDepEvent(Command *const Cmd,
         /* Payload */ {}));
     ConnectCmd = new ExecCGCommand(
         std::move(ConnectCG), Scheduler::getInstance().getDefaultHostQueue());
-  }
-
-  if (!ConnectCmd)
+  } catch (const std::bad_alloc &) {
     throw runtime_error("Out of host memory", PI_OUT_OF_HOST_MEMORY);
+  }
 
   if (Command *DepCmd = reinterpret_cast<Command *>(DepEvent->getCommand()))
     DepCmd->addUser(ConnectCmd);


### PR DESCRIPTION
Select places in the scheduler incorrectly assumes a unique pointer to be null when explicit allocations passed as parameter fails due to the host being out of memory. These changes correct these assumptions through the use of std::make_unique.

Additionally, Scheduler::GraphBuilder::connectDepEvent assumed the same for a raw pointer, whilst not checking the creation of its constituent unique pointers. Allocation here is now governed by a catch of `std::bad_alloc`.