### PR TITLE
[SYCL] Issue an error when streaming an std::byte

### DIFF
--- a/sycl/include/CL/sycl/stream.hpp
+++ b/sycl/include/CL/sycl/stream.hpp
@@ -958,6 +958,16 @@ private:
                                   const h_item<Dimensions> &RHS);
 };
 
+#if __cplusplus >= 201703L
+// Byte (has to be converted to a numeric value)
+template <typename T>
+inline std::enable_if_t<std::is_same<T, std::byte>::value, const stream &>
+operator<<(const stream &, const T &) {
+  static_assert(std::is_integral<T>(),
+                "Convert the byte to a numeric value using std::to_integer");
+}
+#endif // __cplusplus >= 201703L
+
 // Character
 inline const stream &operator<<(const stream &Out, const char C) {
   detail::write(Out.GlobalFlushBuf, Out.FlushBufferSize, Out.WIOffset, &C, 1);

--- a/sycl/test/basic_tests/stream/byte.cpp
+++ b/sycl/test/basic_tests/stream/byte.cpp
@@ -1,0 +1,13 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s -o %t.out
+// expected-error@CL/sycl/stream.hpp:* {{Convert the byte to a numeric value using std::to_integer}}
+
+#include <CL/sycl.hpp>
+
+int main() {
+  sycl::queue q;
+  q.submit([](auto &h) {
+    sycl::stream os(1024, 256, h);
+    h.single_task([=] { os << std::byte(2) << "\n"; });
+  });
+  q.wait();
+}


### PR DESCRIPTION
This is not allowed by standard C++ and the SYCL 2020 spec.