### PR TITLE
[SYCL][CUDA][libclc] Fix incorrectly mangled names

### DIFF
--- a/libclc/ptx-nvidiacl/libspirv/images/image.cl
+++ b/libclc/ptx-nvidiacl/libspirv/images/image.cl
@@ -973,7 +973,7 @@ _CLC_DEFINE_IMAGE_SAMPLED_READ_BUILTIN(half, DF16_, 3, int4, Dv4_i, float4)
 #undef _CLC_DEFINE_IMAGE_SAMPLED_READ_BUILTIN
 
 // Size Queries
-_CLC_DECL int _Z22__spirv_ImageQuerySizeIDv2_i14ocl_image1d_roET_T0_(
+_CLC_DECL int _Z22__spirv_ImageQuerySizeIDv1_i14ocl_image1d_roET_T0_(
     read_only image1d_t image) {
   return __nvvm_suq_width_1i(image);
 }
@@ -985,10 +985,10 @@ _CLC_DECL int2 _Z22__spirv_ImageQuerySizeIDv2_i14ocl_image2d_roET_T0_(
   return (int2)(width, height);
 }
 
-_CLC_DECL int4 _Z22__spirv_ImageQuerySizeIDv2_i14ocl_image3d_roET_T0_(
+_CLC_DECL int3 _Z22__spirv_ImageQuerySizeIDv3_i14ocl_image3d_roET_T0_(
     read_only image3d_t image) {
   int width = __nvvm_suq_width_3i(image);
   int height = __nvvm_suq_height_3i(image);
   int depth = __nvvm_suq_depth_3i(image);
-  return (int4)(width, height, depth, 0);
+  return (int3)(width, height, depth);
 }


### PR DESCRIPTION
Fixes #4500. There are some manually mangled names for querying image sizes in libclc that are incorrect. Information on return types from mangled name does not match the actual return type. In one case the return type also seem to be wrong - this one is needed in the failed CTS test.