### PR TITLE
[SYCL] Fix bit_cast for half type

### DIFF
--- a/sycl/include/CL/sycl/bit_cast.hpp
+++ b/sycl/include/CL/sycl/bit_cast.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <CL/sycl/aliases.hpp>
+
 #include <type_traits>
 
 #if __cpp_lib_bit_cast
@@ -20,6 +22,15 @@ namespace sycl {
 // forward decl
 namespace detail {
 inline void memcpy(void *Dst, const void *Src, std::size_t Size);
+
+template <typename Type> struct type_helper {
+  using T = Type;
+};
+
+template <> struct type_helper <sycl::half> {
+  using T = uint16_t;
+};
+
 }
 
 template <typename To, typename From>
@@ -41,7 +52,7 @@ constexpr
 #if __has_builtin(__builtin_bit_cast)
   return __builtin_bit_cast(To, from);
 #else  // __has_builtin(__builtin_bit_cast)
-  static_assert(std::is_trivially_default_constructible<To>::value,
+  static_assert(std::is_trivially_default_constructible<typename detail::type_helper<To>::T>::value,
                 "To must be trivially default constructible");
   To to;
   sycl::detail::memcpy(&to, &from, sizeof(To));

--- a/sycl/include/CL/sycl/bit_cast.hpp
+++ b/sycl/include/CL/sycl/bit_cast.hpp
@@ -23,17 +23,18 @@ namespace detail {
 inline void memcpy(void *Dst, const void *Src, std::size_t Size);
 
 namespace half_impl {
-  class half;
+class half;
 }
 using half = cl::sycl::detail::half_impl::half;
 
 template <typename T>
 #ifdef __SYCL_DEVICE_ONLY__
-using lowering_half_type = typename std::conditional<
-    std::is_same<T, half>::value, _Float16, T>::type;
+using lowering_half_type =
+    typename std::conditional<std::is_same<T, half>::value, _Float16, T>::type;
 #else
-using lowering_half_type = typename std::conditional<
-    std::is_same<T, half>::value, std::uint16_t, T>::type;
+using lowering_half_type =
+    typename std::conditional<std::is_same<T, half>::value, std::uint16_t,
+                              T>::type;
 #endif
 }
 

--- a/sycl/include/CL/sycl/bit_cast.hpp
+++ b/sycl/include/CL/sycl/bit_cast.hpp
@@ -23,14 +23,9 @@ namespace sycl {
 namespace detail {
 inline void memcpy(void *Dst, const void *Src, std::size_t Size);
 
-template <typename Type> struct type_helper {
-  using T = Type;
-};
+template <typename Type> struct type_helper { using T = Type; };
 
-template <> struct type_helper <sycl::half> {
-  using T = uint16_t;
-};
-
+template <> struct type_helper<sycl::half> { using T = uint16_t; };
 }
 
 template <typename To, typename From>
@@ -52,7 +47,8 @@ constexpr
 #if __has_builtin(__builtin_bit_cast)
   return __builtin_bit_cast(To, from);
 #else  // __has_builtin(__builtin_bit_cast)
-  static_assert(std::is_trivially_default_constructible<typename detail::type_helper<To>::T>::value,
+  static_assert(std::is_trivially_default_constructible<
+                    typename detail::type_helper<To>::T>::value,
                 "To must be trivially default constructible");
   To to;
   sycl::detail::memcpy(&to, &from, sizeof(To));

--- a/sycl/test/regression/bit_cast.cpp
+++ b/sycl/test/regression/bit_cast.cpp
@@ -1,0 +1,13 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// The purpose of this test is to check that the following code can be
+// successfully compiled
+
+#include <CL/sycl.hpp>
+
+int main() {
+  sycl::half x;
+  int16_t a = sycl::bit_cast<int16_t>(x);
+  sycl::bit_cast<sycl::half>(a);
+
+  return 0;
+}

--- a/sycl/test/regression/bit_cast.cpp
+++ b/sycl/test/regression/bit_cast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -fsycl-host-compiler-options='-std=c++17' %s -o %t.out
 // The purpose of this test is to check that the following code can be
 // successfully compiled
 

--- a/sycl/test/regression/bit_cast.hpp
+++ b/sycl/test/regression/bit_cast.hpp
@@ -1,4 +1,3 @@
-// RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -fsycl-host-compiler-options='-std=c++17' %s -o %t.out
 // The purpose of this test is to check that the following code can be
 // successfully compiled
 

--- a/sycl/test/regression/bit_cast_lin.cpp
+++ b/sycl/test/regression/bit_cast_lin.cpp
@@ -1,0 +1,4 @@
+// RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -fsycl-host-compiler-options='-std=c++17' %s -o %t.out
+// UNSUPPORTED: windows
+
+#include "bit_cast.hpp"

--- a/sycl/test/regression/bit_cast_win.cpp
+++ b/sycl/test/regression/bit_cast_win.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='-std=c++17' %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17' %s -o %t.out
 // UNSUPPORTED: linux
 
 #include "bit_cast.hpp"

--- a/sycl/test/regression/bit_cast_win.cpp
+++ b/sycl/test/regression/bit_cast_win.cpp
@@ -1,0 +1,4 @@
+// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='-std=c++17' %s -o %t.out
+// UNSUPPORTED: linux
+
+#include "bit_cast.hpp"


### PR DESCRIPTION
After removing of half type trivial default constructor the bit_cast to sycl::half became impossible. Added helper struct for that case
Signed-off-by: mdimakov <maxim.dimakov@intel.com>