### PR TITLE
[SYCL][Doc] Fix some broken links in docs

### DIFF
--- a/sycl/doc/conf.py
+++ b/sycl/doc/conf.py
@@ -15,6 +15,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 import datetime
+from docutils import nodes
 
 # -- Project information -----------------------------------------------------
 
@@ -51,11 +52,11 @@ exclude_patterns = ['extensions/*']
 suppress_warnings = [ 'misc.highlighting_failure' ]
 
 def on_missing_reference(app, env, node, contnode):
-    if node['reftype'] == 'any':
-        contnode['refuri'] = "https://github.com/intel/llvm/tree/sycl/sycl/doc/" + node['reftarget']
-        return contnode
-    else:
-        return None
+    new_target = "https://github.com/intel/llvm/tree/sycl/sycl/doc/" + node['reftarget']
+
+    newnode = nodes.reference('', '', internal=False, refuri=new_target)
+    newnode.append(contnode)
+    return newnode
 
 def setup(app):
     app.connect('missing-reference', on_missing_reference)


### PR DESCRIPTION
This fixes some of broken links in https://intel.github.io/llvm-docs/. Links described in https://github.com/intel/llvm/issues/4474 are broken due to a bug in markdown parser we use, and will not be fixed by this patch.