### PR TITLE
[Driver][SYCL] Fixup arguments to llc call for PIC and code-model

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8544,9 +8544,10 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     if (PICLevel > 0 || TCArgs.hasArg(options::OPT_shared)) {
       LlcArgs.push_back("-relocation-model=pic");
     }
-    if (IsPIE) {
-      LlcArgs.push_back("-enable-pie");
-    }
+    if (Arg *A = C.getArgs().getLastArg(options::OPT_mcmodel_EQ))
+      LlcArgs.push_back(
+          TCArgs.MakeArgString(Twine("--code-model=") + A->getValue()));
+
     SmallString<128> LlcPath(C.getDriver().Dir);
     llvm::sys::path::append(LlcPath, "llc");
     const char *Llc = C.getArgs().MakeArgString(LlcPath);

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -39,7 +39,16 @@
 // RUN:   | FileCheck -check-prefix=CHECK_SHARED %s
 // RUN: %clangxx -### -fsycl -target x86_64-unknown-linux-gnu -fPIC %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK_SHARED %s
+// RUN: %clangxx -### -fsycl -target x86_64-unknown-linux-gnu -fPIE %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK_SHARED %s
 // CHECK_SHARED: llc{{.*}} "-relocation-model=pic"
+
+/// check for code-model settings for llc device wrap compilation
+// RUN: %clangxx -### -fsycl -target x86_64-unknown-linux-gnu -mcmodel=large %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK_CODE_MODEL -DARG=large %s
+// RUN: %clangxx -### -fsycl -target x86_64-unknown-linux-gnu -mcmodel=medium %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK_CODE_MODEL -DARG=medium %s
+// CHECK_CODE_MODEL: llc{{.*}} "--code-model=[[ARG]]"
 
 /// -S -emit-llvm should generate textual IR for device.
 // RUN: %clangxx -### -fsycl -S -emit-llvm %s 2>&1 \


### PR DESCRIPTION
When calling 'llc' for wrapping the device binaries, fix a problem with
-fPIE and also enable -mcmodel=arg hooks