### PR TITLE
[Driver][SYCL] Fix -fsycl-help output when redirected

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1938,21 +1938,23 @@ void Driver::PrintSYCLToolHelp(const Compilation &C) const {
     llvm::outs() << "Emitting help information for " << std::get<1>(HA) << '\n'
         << "Use triple of '" << std::get<0>(HA).normalize() <<
         "' to enable ahead of time compilation\n";
+    // Flush out the buffer before calling the external tool.
+    llvm::outs().flush();
     std::vector<StringRef> ToolArgs = {std::get<1>(HA), std::get<2>(HA),
                                        std::get<3>(HA)};
     SmallString<128> ExecPath(
         C.getDefaultToolChain().GetProgramPath(std::get<1>(HA).data()));
-    auto ToolBinary = llvm::sys::findProgramByName(ExecPath);
-    if (ToolBinary.getError()) {
-      C.getDriver().Diag(diag::err_drv_command_failure) << ExecPath;
-      continue;
-    }
     // do not run the tools with -###.
     if (C.getArgs().hasArg(options::OPT__HASH_HASH_HASH)) {
       llvm::errs() << "\"" << ExecPath << "\" \"" << ToolArgs[1] << "\"";
       if (!ToolArgs[2].empty())
         llvm::errs() << " \"" << ToolArgs[2] << "\"";
       llvm::errs() << "\n";
+      continue;
+    }
+    auto ToolBinary = llvm::sys::findProgramByName(ExecPath);
+    if (ToolBinary.getError()) {
+      C.getDriver().Diag(diag::err_drv_command_failure) << ExecPath;
       continue;
     }
     // Run the Tool.

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -97,11 +97,21 @@
 // SYCL-HELP-BADARG: unsupported argument 'foo' to option 'fsycl-help='
 // SYCL-HELP-GEN: Emitting help information for ocloc
 // SYCL-HELP-GEN: Use triple of 'spir64_gen-unknown-unknown' to enable ahead of time compilation
-// SYCL-HELP-FPGA-OUT: "[[DIR]]{{[/\\]+}}aoc" "-help" "-sycl"
 // SYCL-HELP-FPGA: Emitting help information for aoc
 // SYCL-HELP-FPGA: Use triple of 'spir64_fpga-unknown-unknown' to enable ahead of time compilation
+// SYCL-HELP-FPGA-OUT: "[[DIR]]{{[/\\]+}}aoc" "-help" "-sycl"
 // SYCL-HELP-CPU: Emitting help information for opencl-aot
 // SYCL-HELP-CPU: Use triple of 'spir64_x86_64-unknown-unknown' to enable ahead of time compilation
+
+// -fsycl-help redirect to file should retain proper information ordering
+// RUN: %clang -### -fsycl-help %s > %t.help-out 2>&1
+// RUN: FileCheck %s -check-prefix SYCL_HELP_ORDER --input-file=%t.help-out
+// SYCL_HELP_ORDER: Emitting help information for ocloc
+// SYCL_HELP_ORDER: ocloc" "--help"
+// SYCL_HELP_ORDER: Emitting help information for aoc
+// SYCL_HELP_ORDER: aoc" "-help" "-sycl"
+// SYCL_HELP_ORDER: Emitting help information for opencl-aot
+// SYCL_HELP_ORDER: opencl-aot" "--help"
 
 // -fsycl-id-queries-fit-in-int
 // RUN: %clang -### -fsycl -fsycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=ID_QUERIES

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -107,11 +107,11 @@
 // RUN: %clang -### -fsycl-help %s > %t.help-out 2>&1
 // RUN: FileCheck %s -check-prefix SYCL_HELP_ORDER --input-file=%t.help-out
 // SYCL_HELP_ORDER: Emitting help information for ocloc
-// SYCL_HELP_ORDER: ocloc" "--help"
+// SYCL_HELP_ORDER: ocloc{{(\.exe)?}}" "--help"
 // SYCL_HELP_ORDER: Emitting help information for aoc
-// SYCL_HELP_ORDER: aoc" "-help" "-sycl"
+// SYCL_HELP_ORDER: aoc{{(\.exe)?}}" "-help" "-sycl"
 // SYCL_HELP_ORDER: Emitting help information for opencl-aot
-// SYCL_HELP_ORDER: opencl-aot" "--help"
+// SYCL_HELP_ORDER: opencl-aot{{(\.exe)?}}" "--help"
 
 // -fsycl-id-queries-fit-in-int
 // RUN: %clang -### -fsycl -fsycl-id-queries-fit-in-int  %s 2>&1 | FileCheck %s --check-prefix=ID_QUERIES


### PR DESCRIPTION
When using -fsycl-help and redirecting the output, flush out the
informational strings before the actual tool output so the output
ordering is logical when viewed.