### PR TITLE
[SYCL] Avoid re-computing group_range in nd_item class

### DIFF
--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -82,12 +82,11 @@ public:
   }
 
   range<dimensions> get_group_range() const {
-    return Group.get_global_range() / Group.get_local_range();
+    return Group.get_group_range();
   }
 
   size_t __SYCL_ALWAYS_INLINE get_group_range(int dimension) const {
-    size_t Range =
-        Group.get_global_range(dimension) / Group.get_local_range(dimension);
+    size_t Range = Group.get_group_range(dimension);
     __SYCL_ASSUME_INT(Range);
     return Range;
   }

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -81,9 +81,7 @@ public:
     return Id;
   }
 
-  range<dimensions> get_group_range() const {
-    return Group.get_group_range();
-  }
+  range<dimensions> get_group_range() const { return Group.get_group_range(); }
 
   size_t __SYCL_ALWAYS_INLINE get_group_range(int dimension) const {
     size_t Range = Group.get_group_range(dimension);


### PR DESCRIPTION
This fix is mostly NFC.
Instead of doing costly division operations and re-computing the group_range
inside nd_item class, it is better to call group::get_group_range() that
does not do divisions as the group class keeps the group_range
as a pre-computed field.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>