### PR TITLE
[clang-offload-extract] Ignore zero padding in .tgtimg section

### DIFF
--- a/clang/test/Driver/clang-offload-extract.c
+++ b/clang/test/Driver/clang-offload-extract.c
@@ -23,7 +23,7 @@
 // RUN: echo 'Target image 1' > %t.bin0
 // RUN: echo 'Target image 2' > %t.bin1
 // RUN: clang-offload-wrapper -kind=openmp -target=tg0 %t.bin0 -kind=sycl -target=tg1 %t.bin1 -o %t.wrapped.bc
-// RUN: %clang %s %t.wrapped.bc -o %t.fat.bin
+// RUN: %clang -fdeclspec %s %t.wrapped.bc -o %t.fat.bin
 
 //
 // Extract target images.
@@ -41,6 +41,11 @@
 //
 // Some code so that we can build an offload executable from this file.
 //
+#pragma section(".tgtimg", read)
+__declspec(allocate(".tgtimg"))
+__declspec(align(sizeof(void*) * 2))
+const void* padding[2] = {0, 0};
+
 #ifdef _WIN32
 char __start_omp_offloading_entries = 1;
 char __stop_omp_offloading_entries = 1;

--- a/clang/tools/clang-offload-extract/ClangOffloadExtract.cpp
+++ b/clang/tools/clang-offload-extract/ClangOffloadExtract.cpp
@@ -124,6 +124,10 @@ int main(int argc, const char **argv) {
         DataOrErr->size() / sizeof(ImgInfoTy));
 
     for (auto &Img : ImgInfo) {
+      // Ignore zero padding that can be inserted by the linker.
+      if (!Img.Addr)
+        continue;
+
       // Find section which contains this image.
       // TODO: can use more efficient algorithm than linear search. For example
       // sections and images could be sorted by address then one pass performed


### PR DESCRIPTION
This patch changes clang-offload-extract to ignore zero padding
when reading .tgtimg section contents. Such padding can be added
to the section by (msvc) linker.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>