### PR TITLE
[sycl-post-link] Adds property listing exported functions

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8941,6 +8941,7 @@ void SYCLPostLink::ConstructJob(Compilation &C, const JobAction &JA,
     // Symbol file and specialization constant info generation is mandatory -
     // add options unconditionally
     addArgs(CmdArgs, TCArgs, {"-symbols"});
+    addArgs(CmdArgs, TCArgs, {"-emit-exported-symbols"});
     addArgs(CmdArgs, TCArgs, {"-split-esimd"});
     addArgs(CmdArgs, TCArgs, {"-lower-esimd"});
   }

--- a/clang/test/Driver/sycl-device-lib.cpp
+++ b/clang/test/Driver/sycl-device-lib.cpp
@@ -125,7 +125,7 @@
 // RUN:   | FileCheck %s -check-prefix=SYCL_LLVM_LINK_NO_DEVICE_LIB
 // SYCL_LLVM_LINK_NO_DEVICE_LIB: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-device"
 // SYCL_LLVM_LINK_NO_DEVICE_LIB-NOT: llvm-link{{.*}}  "-only-needed"
-// SYCL_LLVM_LINK_NO_DEVICE_LIB: sycl-post-link{{.*}}  "-symbols" "-split-esimd" "-lower-esimd" "-O2" "-spec-const=rt" "-o" "{{.*}}.table" "{{.*}}.bc"
+// SYCL_LLVM_LINK_NO_DEVICE_LIB: sycl-post-link{{.*}}  "-symbols" "-emit-exported-symbols" "-split-esimd" "-lower-esimd" "-O2" "-spec-const=rt" "-o" "{{.*}}.table" "{{.*}}.bc"
 
 /// ###########################################################################
 /// test llvm-link behavior for special user input whose filename resembles SYCL device library

--- a/llvm/include/llvm/Support/PropertySetIO.h
+++ b/llvm/include/llvm/Support/PropertySetIO.h
@@ -191,6 +191,7 @@ public:
   static constexpr char SYCL_PROGRAM_METADATA[] = "SYCL/program metadata";
   static constexpr char SYCL_MISC_PROP[] = "SYCL/misc properties";
   static constexpr char SYCL_ASSERT_USED[] = "SYCL/assert used";
+  static constexpr char SYCL_EXPORTED_SYMBOLS[] = "SYCL/exported symbols";
 
   // Function for bulk addition of an entire property set under given category
   // (property set name).

--- a/llvm/lib/Support/PropertySetIO.cpp
+++ b/llvm/lib/Support/PropertySetIO.cpp
@@ -200,6 +200,7 @@ constexpr char PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO[];
 constexpr char PropertySetRegistry::SYCL_PROGRAM_METADATA[];
 constexpr char PropertySetRegistry::SYCL_MISC_PROP[];
 constexpr char PropertySetRegistry::SYCL_ASSERT_USED[];
+constexpr char PropertySetRegistry::SYCL_EXPORTED_SYMBOLS[];
 
 } // namespace util
 } // namespace llvm

--- a/llvm/test/tools/sycl-post-link/emit_exported_symbols.ll
+++ b/llvm/test/tools/sycl-post-link/emit_exported_symbols.ll
@@ -1,0 +1,129 @@
+; This test checks that the post-link tool generates list of exported symbols.
+;
+; Global scope
+; RUN: sycl-post-link -symbols -emit-exported-symbols -S %s -o %t.global.files.table
+; RUN: FileCheck %s -input-file=%t.global.files.table --check-prefixes CHECK-GLOBAL-TABLE
+; RUN: FileCheck %s -input-file=%t.global.files_0.prop --check-prefixes CHECK-GLOBAL-PROP
+;
+; Per-module split
+; RUN: sycl-post-link -symbols -split=source -emit-exported-symbols -S %s -o %t.per_module.files.table
+; RUN: FileCheck %s -input-file=%t.per_module.files.table --check-prefixes CHECK-PERMODULE-TABLE
+; RUN: FileCheck %s -input-file=%t.per_module.files_0.prop --check-prefixes CHECK-PERMODULE-0-PROP
+; RUN: FileCheck %s -input-file=%t.per_module.files_1.prop --check-prefixes CHECK-PERMODULE-1-PROP
+; RUN: FileCheck %s -input-file=%t.per_module.files_2.prop --check-prefixes CHECK-KERNELONLY-PROP
+;
+; Per-kernel split
+; RUN: sycl-post-link -symbols -split=kernel -emit-exported-symbols -S %s -o %t.per_kernel.files.table
+; RUN: FileCheck %s -input-file=%t.per_kernel.files.table --check-prefixes CHECK-PERKERNEL-TABLE
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_0.prop --check-prefixes CHECK-PERKERNEL-0-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_1.prop --check-prefixes CHECK-PERKERNEL-1-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_2.prop --check-prefixes CHECK-PERKERNEL-2-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_3.prop --check-prefixes CHECK-KERNELONLY-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_4.prop --check-prefixes CHECK-KERNELONLY-PROP
+
+target triple = "spir64-unknown-unknown"
+
+define dso_local spir_kernel void @SpirKernel1(float %arg1) #0 {
+entry:
+  ret void
+}
+
+define dso_local spir_kernel void @SpirKernel2(float %arg1) #2 {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @ExportedSpirFunc1(float %arg1) #0 {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @ExportedSpirFunc2(i32 %arg1, i32 %arg2) #1 {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @ExportedSpirFunc3(float %arg1) #0 {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @NotExportedSpirFunc1(float %arg1) {
+entry:
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="a.cpp" }
+attributes #1 = { "sycl-module-id"="b.cpp" }
+attributes #2 = { "sycl-module-id"="c.cpp" }
+
+; Global scope
+; CHECK-GLOBAL-PROP: [SYCL/exported symbols]
+; CHECK-GLOBAL-PROP-NEXT: ExportedSpirFunc1
+; CHECK-GLOBAL-PROP-NEXT: ExportedSpirFunc2
+; CHECK-GLOBAL-PROP-NEXT: ExportedSpirFunc3
+; CHECK-GLOBAL-PROP-NOT: SpirKernel1
+; CHECK-GLOBAL-PROP-NOT: NotExportedSpirFunc1
+
+; CHECK-GLOBAL-TABLE: [Code|Properties|Symbols]
+; CHECK-GLOBAL-TABLE-NEXT: {{.*}}global.files_0.prop
+; CHECK-GLOBAL-TABLE-EMPTY:
+
+; Per-module split
+; CHECK-PERMODULE-0-PROP: [SYCL/exported symbols]
+; CHECK-PERMODULE-0-PROP-NEXT: ExportedSpirFunc1
+; CHECK-PERMODULE-0-PROP-NEXT: ExportedSpirFunc3
+; CHECK-PERMODULE-0-PROP-NOT: ExportedSpirFunc2
+; CHECK-PERMODULE-0-PROP-NOT: SpirKernel1
+; CHECK-PERMODULE-0-PROP-NOT: NotExportedSpirFunc1
+
+; CHECK-PERMODULE-1-PROP: [SYCL/exported symbols]
+; CHECK-PERMODULE-1-PROP-NEXT: ExportedSpirFunc2
+; CHECK-PERMODULE-1-PROP-NOT: ExportedSpirFunc1
+; CHECK-PERMODULE-1-PROP-NOT: ExportedSpirFunc3
+; CHECK-PERMODULE-1-PROP-NOT: SpirKernel1
+; CHECK-PERMODULE-1-PROP-NOT: NotExportedSpirFunc1
+
+; CHECK-PERMODULE-TABLE: [Code|Properties|Symbols]
+; CHECK-PERMODULE-TABLE-NEXT: {{.*}}per_module.files_0.prop
+; CHECK-PERMODULE-TABLE-NEXT: {{.*}}per_module.files_1.prop
+; CHECK-PERMODULE-TABLE-NEXT: {{.*}}per_module.files_2.prop
+; CHECK-PERMODULE-TABLE-EMPTY:
+
+; Per-kernel split
+; CHECK-PERKERNEL-0-PROP: [SYCL/exported symbols]
+; CHECK-PERKERNEL-0-PROP-NEXT: ExportedSpirFunc1
+; CHECK-PERKERNEL-0-PROP-NOT: ExportedSpirFunc2
+; CHECK-PERKERNEL-0-PROP-NOT: ExportedSpirFunc3
+; CHECK-PERKERNEL-0-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-0-PROP-NOT: NotExportedSpirFunc1
+
+; CHECK-PERKERNEL-1-PROP: [SYCL/exported symbols]
+; CHECK-PERKERNEL-1-PROP-NEXT: ExportedSpirFunc2
+; CHECK-PERKERNEL-1-PROP-NOT: ExportedSpirFunc1
+; CHECK-PERKERNEL-1-PROP-NOT: ExportedSpirFunc3
+; CHECK-PERKERNEL-1-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-1-PROP-NOT: NotExportedSpirFunc1
+
+; CHECK-PERKERNEL-2-PROP: [SYCL/exported symbols]
+; CHECK-PERKERNEL-2-PROP-NEXT: ExportedSpirFunc3
+; CHECK-PERKERNEL-2-PROP-NOT: ExportedSpirFunc1
+; CHECK-PERKERNEL-2-PROP-NOT: ExportedSpirFunc2
+; CHECK-PERKERNEL-2-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-2-PROP-NOT: NotExportedSpirFunc1
+
+; CHECK-PERKERNEL-TABLE: [Code|Properties|Symbols]
+; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_0.prop
+; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_1.prop
+; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_2.prop
+; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_3.prop
+; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_4.prop
+; CHECK-PERKERNEL-TABLE-EMPTY:
+
+; Kernel-only generated modules should have no exported Symbols
+; CHECK-KERNELONLY-PROP-NOT: [SYCL/exported symbols]
+; CHECK-KERNELONLY-PROP-NOT: ExportedSpirFunc3
+; CHECK-KERNELONLY-PROP-NOT: ExportedSpirFunc1
+; CHECK-KERNELONLY-PROP-NOT: ExportedSpirFunc2
+; CHECK-KERNELONLY-PROP-NOT: SpirKernel1
+; CHECK-KERNELONLY-PROP-NOT: NotExportedSpirFunc1

--- a/llvm/test/tools/sycl-post-link/emit_exported_symbols.ll
+++ b/llvm/test/tools/sycl-post-link/emit_exported_symbols.ll
@@ -2,19 +2,16 @@
 ;
 ; Global scope
 ; RUN: sycl-post-link -symbols -emit-exported-symbols -S %s -o %t.global.files.table
-; RUN: FileCheck %s -input-file=%t.global.files.table --check-prefixes CHECK-GLOBAL-TABLE
 ; RUN: FileCheck %s -input-file=%t.global.files_0.prop --check-prefixes CHECK-GLOBAL-PROP
 ;
 ; Per-module split
 ; RUN: sycl-post-link -symbols -split=source -emit-exported-symbols -S %s -o %t.per_module.files.table
-; RUN: FileCheck %s -input-file=%t.per_module.files.table --check-prefixes CHECK-PERMODULE-TABLE
 ; RUN: FileCheck %s -input-file=%t.per_module.files_0.prop --check-prefixes CHECK-PERMODULE-0-PROP
 ; RUN: FileCheck %s -input-file=%t.per_module.files_1.prop --check-prefixes CHECK-PERMODULE-1-PROP
 ; RUN: FileCheck %s -input-file=%t.per_module.files_2.prop --check-prefixes CHECK-KERNELONLY-PROP
 ;
 ; Per-kernel split
 ; RUN: sycl-post-link -symbols -split=kernel -emit-exported-symbols -S %s -o %t.per_kernel.files.table
-; RUN: FileCheck %s -input-file=%t.per_kernel.files.table --check-prefixes CHECK-PERKERNEL-TABLE
 ; RUN: FileCheck %s -input-file=%t.per_kernel.files_0.prop --check-prefixes CHECK-PERKERNEL-0-PROP
 ; RUN: FileCheck %s -input-file=%t.per_kernel.files_1.prop --check-prefixes CHECK-PERKERNEL-1-PROP
 ; RUN: FileCheck %s -input-file=%t.per_kernel.files_2.prop --check-prefixes CHECK-PERKERNEL-2-PROP
@@ -65,10 +62,6 @@ attributes #2 = { "sycl-module-id"="c.cpp" }
 ; CHECK-GLOBAL-PROP-NOT: SpirKernel1
 ; CHECK-GLOBAL-PROP-NOT: NotExportedSpirFunc1
 
-; CHECK-GLOBAL-TABLE: [Code|Properties|Symbols]
-; CHECK-GLOBAL-TABLE-NEXT: {{.*}}global.files_0.prop
-; CHECK-GLOBAL-TABLE-EMPTY:
-
 ; Per-module split
 ; CHECK-PERMODULE-0-PROP: [SYCL/exported symbols]
 ; CHECK-PERMODULE-0-PROP-NEXT: ExportedSpirFunc1
@@ -83,12 +76,6 @@ attributes #2 = { "sycl-module-id"="c.cpp" }
 ; CHECK-PERMODULE-1-PROP-NOT: ExportedSpirFunc3
 ; CHECK-PERMODULE-1-PROP-NOT: SpirKernel1
 ; CHECK-PERMODULE-1-PROP-NOT: NotExportedSpirFunc1
-
-; CHECK-PERMODULE-TABLE: [Code|Properties|Symbols]
-; CHECK-PERMODULE-TABLE-NEXT: {{.*}}per_module.files_0.prop
-; CHECK-PERMODULE-TABLE-NEXT: {{.*}}per_module.files_1.prop
-; CHECK-PERMODULE-TABLE-NEXT: {{.*}}per_module.files_2.prop
-; CHECK-PERMODULE-TABLE-EMPTY:
 
 ; Per-kernel split
 ; CHECK-PERKERNEL-0-PROP: [SYCL/exported symbols]
@@ -111,14 +98,6 @@ attributes #2 = { "sycl-module-id"="c.cpp" }
 ; CHECK-PERKERNEL-2-PROP-NOT: ExportedSpirFunc2
 ; CHECK-PERKERNEL-2-PROP-NOT: SpirKernel1
 ; CHECK-PERKERNEL-2-PROP-NOT: NotExportedSpirFunc1
-
-; CHECK-PERKERNEL-TABLE: [Code|Properties|Symbols]
-; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_0.prop
-; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_1.prop
-; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_2.prop
-; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_3.prop
-; CHECK-PERKERNEL-TABLE-NEXT: {{.*}}per_kernel.files_4.prop
-; CHECK-PERKERNEL-TABLE-EMPTY:
 
 ; Kernel-only generated modules should have no exported Symbols
 ; CHECK-KERNELONLY-PROP-NOT: [SYCL/exported symbols]

--- a/llvm/test/tools/sycl-post-link/emit_exported_symbols.ll
+++ b/llvm/test/tools/sycl-post-link/emit_exported_symbols.ll
@@ -2,30 +2,30 @@
 ;
 ; Global scope
 ; RUN: sycl-post-link -symbols -emit-exported-symbols -S %s -o %t.global.files.table
-; RUN: FileCheck %s -input-file=%t.global.files_0.prop --check-prefixes CHECK-GLOBAL-PROP
+; RUN: FileCheck %s -input-file=%t.global.files_0.prop --implicit-check-not="NotExported" --check-prefix=CHECK-GLOBAL-PROP
 ;
 ; Per-module split
 ; RUN: sycl-post-link -symbols -split=source -emit-exported-symbols -S %s -o %t.per_module.files.table
-; RUN: FileCheck %s -input-file=%t.per_module.files_0.prop --check-prefixes CHECK-PERMODULE-0-PROP
-; RUN: FileCheck %s -input-file=%t.per_module.files_1.prop --check-prefixes CHECK-PERMODULE-1-PROP
-; RUN: FileCheck %s -input-file=%t.per_module.files_2.prop --check-prefixes CHECK-KERNELONLY-PROP
+; RUN: FileCheck %s -input-file=%t.per_module.files_0.prop -implicit-check-not="NotExported" --check-prefix=CHECK-PERMODULE-0-PROP
+; RUN: FileCheck %s -input-file=%t.per_module.files_1.prop -implicit-check-not="NotExported" --check-prefix=CHECK-PERMODULE-1-PROP
+; RUN: FileCheck %s -input-file=%t.per_module.files_2.prop -implicit-check-not="NotExported" --check-prefix=CHECK-KERNELONLY-PROP
 ;
 ; Per-kernel split
 ; RUN: sycl-post-link -symbols -split=kernel -emit-exported-symbols -S %s -o %t.per_kernel.files.table
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_0.prop --check-prefixes CHECK-PERKERNEL-0-PROP
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_1.prop --check-prefixes CHECK-PERKERNEL-1-PROP
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_2.prop --check-prefixes CHECK-PERKERNEL-2-PROP
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_3.prop --check-prefixes CHECK-KERNELONLY-PROP
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_4.prop --check-prefixes CHECK-KERNELONLY-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_0.prop --implicit-check-not="NotExported" --check-prefix=CHECK-PERKERNEL-0-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_1.prop --implicit-check-not="NotExported" --check-prefix=CHECK-PERKERNEL-1-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_2.prop --implicit-check-not="NotExported" --check-prefix=CHECK-PERKERNEL-2-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_3.prop --implicit-check-not="NotExported" --check-prefix=CHECK-KERNELONLY-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_4.prop --implicit-check-not="NotExported" --check-prefix=CHECK-KERNELONLY-PROP
 
 target triple = "spir64-unknown-unknown"
 
-define dso_local spir_kernel void @SpirKernel1(float %arg1) #0 {
+define dso_local spir_kernel void @NotExportedSpirKernel1(float %arg1) #0 {
 entry:
   ret void
 }
 
-define dso_local spir_kernel void @SpirKernel2(float %arg1) #2 {
+define dso_local spir_kernel void @NotExportedSpirKernel2(float %arg1) #2 {
 entry:
   ret void
 }
@@ -59,50 +59,36 @@ attributes #2 = { "sycl-module-id"="c.cpp" }
 ; CHECK-GLOBAL-PROP-NEXT: ExportedSpirFunc1
 ; CHECK-GLOBAL-PROP-NEXT: ExportedSpirFunc2
 ; CHECK-GLOBAL-PROP-NEXT: ExportedSpirFunc3
-; CHECK-GLOBAL-PROP-NOT: SpirKernel1
-; CHECK-GLOBAL-PROP-NOT: NotExportedSpirFunc1
 
 ; Per-module split
 ; CHECK-PERMODULE-0-PROP: [SYCL/exported symbols]
 ; CHECK-PERMODULE-0-PROP-NEXT: ExportedSpirFunc1
 ; CHECK-PERMODULE-0-PROP-NEXT: ExportedSpirFunc3
 ; CHECK-PERMODULE-0-PROP-NOT: ExportedSpirFunc2
-; CHECK-PERMODULE-0-PROP-NOT: SpirKernel1
-; CHECK-PERMODULE-0-PROP-NOT: NotExportedSpirFunc1
 
 ; CHECK-PERMODULE-1-PROP: [SYCL/exported symbols]
 ; CHECK-PERMODULE-1-PROP-NEXT: ExportedSpirFunc2
 ; CHECK-PERMODULE-1-PROP-NOT: ExportedSpirFunc1
 ; CHECK-PERMODULE-1-PROP-NOT: ExportedSpirFunc3
-; CHECK-PERMODULE-1-PROP-NOT: SpirKernel1
-; CHECK-PERMODULE-1-PROP-NOT: NotExportedSpirFunc1
 
 ; Per-kernel split
 ; CHECK-PERKERNEL-0-PROP: [SYCL/exported symbols]
 ; CHECK-PERKERNEL-0-PROP-NEXT: ExportedSpirFunc1
 ; CHECK-PERKERNEL-0-PROP-NOT: ExportedSpirFunc2
 ; CHECK-PERKERNEL-0-PROP-NOT: ExportedSpirFunc3
-; CHECK-PERKERNEL-0-PROP-NOT: SpirKernel1
-; CHECK-PERKERNEL-0-PROP-NOT: NotExportedSpirFunc1
 
 ; CHECK-PERKERNEL-1-PROP: [SYCL/exported symbols]
 ; CHECK-PERKERNEL-1-PROP-NEXT: ExportedSpirFunc2
 ; CHECK-PERKERNEL-1-PROP-NOT: ExportedSpirFunc1
 ; CHECK-PERKERNEL-1-PROP-NOT: ExportedSpirFunc3
-; CHECK-PERKERNEL-1-PROP-NOT: SpirKernel1
-; CHECK-PERKERNEL-1-PROP-NOT: NotExportedSpirFunc1
 
 ; CHECK-PERKERNEL-2-PROP: [SYCL/exported symbols]
 ; CHECK-PERKERNEL-2-PROP-NEXT: ExportedSpirFunc3
 ; CHECK-PERKERNEL-2-PROP-NOT: ExportedSpirFunc1
 ; CHECK-PERKERNEL-2-PROP-NOT: ExportedSpirFunc2
-; CHECK-PERKERNEL-2-PROP-NOT: SpirKernel1
-; CHECK-PERKERNEL-2-PROP-NOT: NotExportedSpirFunc1
 
 ; Kernel-only generated modules should have no exported Symbols
 ; CHECK-KERNELONLY-PROP-NOT: [SYCL/exported symbols]
 ; CHECK-KERNELONLY-PROP-NOT: ExportedSpirFunc3
 ; CHECK-KERNELONLY-PROP-NOT: ExportedSpirFunc1
 ; CHECK-KERNELONLY-PROP-NOT: ExportedSpirFunc2
-; CHECK-KERNELONLY-PROP-NOT: SpirKernel1
-; CHECK-KERNELONLY-PROP-NOT: NotExportedSpirFunc1

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -827,10 +827,14 @@ static TableFiles processOneModule(std::unique_ptr<Module> M, bool IsEsimd,
   }
 
   {
-    ImagePropSaveInfo ImgPSInfo = {
-        true,          DoSpecConst,         SetSpecConstAtRT,
-        SpecConstsMet, EmitKernelParamInfo, EmitProgramMetadata,
-        EmitExportedSymbols, IsEsimd};
+    ImagePropSaveInfo ImgPSInfo = {true,
+                                   DoSpecConst,
+                                   SetSpecConstAtRT,
+                                   SpecConstsMet,
+                                   EmitKernelParamInfo,
+                                   EmitProgramMetadata,
+                                   EmitExportedSymbols,
+                                   IsEsimd};
     string_vector Files =
         saveDeviceImageProperty(ResultModules, GlobalsSet, ImgPSInfo);
     std::copy(Files.begin(), Files.end(),

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -714,7 +714,10 @@ static const uint8_t PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL = 4;
 #define __SYCL_PI_PROPERTY_SET_PROGRAM_METADATA "SYCL/program metadata"
 /// PropertySetRegistry::SYCL_MISC_PROP defined in PropertySetIO.h
 #define __SYCL_PI_PROPERTY_SET_SYCL_MISC_PROP "SYCL/misc properties"
+/// PropertySetRegistry::SYCL_ASSERT_USED defined in PropertySetIO.h
 #define __SYCL_PI_PROPERTY_SET_SYCL_ASSERT_USED "SYCL/assert used"
+/// PropertySetRegistry::SYCL_EXPORTED_SYMBOLS defined in PropertySetIO.h
+#define __SYCL_PI_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS "SYCL/exported symbols"
 
 /// Program metadata tags recognized by the PI backends. For kernels the tag
 /// must appear after the kernel name.


### PR DESCRIPTION
These changes make sycl-post-link generate a list of exported functions as properties for each generated module. This is enabled through the -emit-exported-symbols option.

The properties follow the naming proposed in the [Dynamic linking of device code](https://github.com/intel/llvm/blob/sycl/sycl/doc/SharedLibraries.md#sycl-post-link-changes) documentation.