### PR TITLE
[SYCL] Add support for std::byte to vec class 

### DIFF
--- a/sycl/include/CL/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_lists.hpp
@@ -292,9 +292,7 @@ using byte_list = type_list<std::byte>;
 
 using vector_byte_list =
     type_list<vec<std::byte, 1>, vec<std::byte, 2>, vec<std::byte, 3>,
-              vec<std::byte, 4>, vec<std::byte, 8>,
-              vec<std::byte, 16>>;
-
+              vec<std::byte, 4>, vec<std::byte, 8>, vec<std::byte, 16>>;
 
 // integer types
 using scalar_signed_integer_list = type_list<
@@ -322,14 +320,13 @@ using scalar_unsigned_integer_list =
               scalar_unsigned_short_list, scalar_unsigned_int_list,
               scalar_unsigned_long_list, scalar_unsigned_longlong_list>;
 
-using vector_unsigned_integer_list =
-    type_list<conditional_t<std::is_unsigned<char>::value,
-                            type_list<vector_default_char_list,
-                                      vector_unsigned_char_list>,
-                            vector_unsigned_char_list>,
-              vector_unsigned_short_list, vector_unsigned_int_list,
-              vector_unsigned_long_list, vector_unsigned_longlong_list,
-              vector_byte_list>;
+using vector_unsigned_integer_list = type_list<
+    conditional_t<
+        std::is_unsigned<char>::value,
+        type_list<vector_default_char_list, vector_unsigned_char_list>,
+        vector_unsigned_char_list>,
+    vector_unsigned_short_list, vector_unsigned_int_list,
+    vector_unsigned_long_list, vector_unsigned_longlong_list, vector_byte_list>;
 
 using unsigned_integer_list =
     type_list<scalar_unsigned_integer_list, vector_unsigned_integer_list>;

--- a/sycl/include/CL/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_lists.hpp
@@ -322,19 +322,21 @@ using scalar_unsigned_integer_list =
               scalar_unsigned_short_list, scalar_unsigned_int_list,
               scalar_unsigned_long_list, scalar_unsigned_longlong_list
 #if __cplusplus >= 201703L
-              ,scalar_byte_list
+              ,
+              scalar_byte_list
 #endif
               >;
 
-using vector_unsigned_integer_list = type_list<
-    conditional_t<
-        std::is_unsigned<char>::value,
-        type_list<vector_default_char_list, vector_unsigned_char_list>,
-        vector_unsigned_char_list>,
-    vector_unsigned_short_list, vector_unsigned_int_list,
-    vector_unsigned_long_list, vector_unsigned_longlong_list
+using vector_unsigned_integer_list =
+    type_list<conditional_t<std::is_unsigned<char>::value,
+                            type_list<vector_default_char_list,
+                                      vector_unsigned_char_list>,
+                            vector_unsigned_char_list>,
+              vector_unsigned_short_list, vector_unsigned_int_list,
+              vector_unsigned_long_list, vector_unsigned_longlong_list
 #if __cplusplus >= 201703L
-              ,vector_byte_list
+              ,
+              vector_byte_list
 #endif
               >;
 

--- a/sycl/include/CL/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_lists.hpp
@@ -12,6 +12,8 @@
 #include <CL/sycl/detail/stl_type_traits.hpp>
 #include <CL/sycl/detail/type_list.hpp>
 
+#include <cstddef>
+
 // Generic type name description, which serves as a description for all valid
 // types of parameters to kernel functions
 
@@ -285,6 +287,15 @@ using vector_long_integer_list = type_list<vector_signed_long_integer_list,
 using long_integer_list =
     type_list<scalar_long_integer_list, vector_long_integer_list>;
 
+// std::byte
+using byte_list = type_list<std::byte>;
+
+using vector_byte_list =
+    type_list<vec<std::byte, 1>, vec<std::byte, 2>, vec<std::byte, 3>,
+              vec<std::byte, 4>, vec<std::byte, 8>,
+              vec<std::byte, 16>>;
+
+
 // integer types
 using scalar_signed_integer_list = type_list<
     conditional_t<std::is_signed<char>::value,
@@ -317,7 +328,8 @@ using vector_unsigned_integer_list =
                                       vector_unsigned_char_list>,
                             vector_unsigned_char_list>,
               vector_unsigned_short_list, vector_unsigned_int_list,
-              vector_unsigned_long_list, vector_unsigned_longlong_list>;
+              vector_unsigned_long_list, vector_unsigned_longlong_list,
+              vector_byte_list>;
 
 using unsigned_integer_list =
     type_list<scalar_unsigned_integer_list, vector_unsigned_integer_list>;

--- a/sycl/include/CL/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_lists.hpp
@@ -287,12 +287,14 @@ using vector_long_integer_list = type_list<vector_signed_long_integer_list,
 using long_integer_list =
     type_list<scalar_long_integer_list, vector_long_integer_list>;
 
+#if __cplusplus >= 201703L
 // std::byte
-using byte_list = type_list<std::byte>;
+using scalar_byte_list = type_list<std::byte>;
 
 using vector_byte_list =
     type_list<vec<std::byte, 1>, vec<std::byte, 2>, vec<std::byte, 3>,
               vec<std::byte, 4>, vec<std::byte, 8>, vec<std::byte, 16>>;
+#endif
 
 // integer types
 using scalar_signed_integer_list = type_list<
@@ -318,7 +320,11 @@ using scalar_unsigned_integer_list =
                                       scalar_unsigned_char_list>,
                             scalar_unsigned_char_list>,
               scalar_unsigned_short_list, scalar_unsigned_int_list,
-              scalar_unsigned_long_list, scalar_unsigned_longlong_list>;
+              scalar_unsigned_long_list, scalar_unsigned_longlong_list
+#if __cplusplus >= 201703L
+              ,scalar_byte_list
+#endif
+              >;
 
 using vector_unsigned_integer_list = type_list<
     conditional_t<
@@ -326,7 +332,11 @@ using vector_unsigned_integer_list = type_list<
         type_list<vector_default_char_list, vector_unsigned_char_list>,
         vector_unsigned_char_list>,
     vector_unsigned_short_list, vector_unsigned_int_list,
-    vector_unsigned_long_list, vector_unsigned_longlong_list, vector_byte_list>;
+    vector_unsigned_long_list, vector_unsigned_longlong_list
+#if __cplusplus >= 201703L
+              ,vector_byte_list
+#endif
+              >;
 
 using unsigned_integer_list =
     type_list<scalar_unsigned_integer_list, vector_unsigned_integer_list>;

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -98,18 +98,14 @@ struct elem {
 
 namespace detail {
 
-template<typename T> struct vec_helper {
+template <typename T> struct vec_helper {
   using RetType = T;
-  static constexpr RetType get(T value) {
-    return value;
-  }
+  static constexpr RetType get(T value) { return value; }
 };
 
-template<> struct vec_helper<std::byte> {
+template <> struct vec_helper<std::byte> {
   using RetType = std::uint8_t;
-  static constexpr RetType get(std::byte value) {
-    return (RetType)value;
-  }
+  static constexpr RetType get(std::byte value) { return (RetType)value; }
   static constexpr std::byte get(std::uint8_t value) {
     return (std::byte)value;
   }
@@ -528,8 +524,7 @@ class RoundedRangeKernelWithKH;
 
 } // namespace detail
 
-template <typename T>
-using vec_data = detail::vec_helper<T>;
+template <typename T> using vec_data = detail::vec_helper<T>;
 
 template <typename T>
 using vec_data_t = typename detail::vec_helper<T>::RetType;
@@ -689,9 +684,10 @@ public:
 
   // W/o this, things like "vec<char,*> = vec<signed char, *>" doesn't work.
   template <typename Ty = DataT>
-  typename detail::enable_if_t<!std::is_same<Ty, rel_t>::value &&
-                                   std::is_convertible<vec_data_t<Ty>, rel_t>::value,
-                               vec &>
+  typename detail::enable_if_t<
+      !std::is_same<Ty, rel_t>::value &&
+          std::is_convertible<vec_data_t<Ty>, rel_t>::value,
+      vec &>
   operator=(const vec<rel_t, NumElements> &Rhs) {
     *this = Rhs.template as<vec>();
     return *this;
@@ -780,22 +776,23 @@ public:
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<3, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2)
-      : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1), vec_data<Ty>::get(Arg2)} {}
+      : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1),
+               vec_data<Ty>::get(Arg2)} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<4, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
                 const Ty Arg3)
       : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1),
-      vec_data<Ty>::get(Arg2), vec_data<Ty>::get(Arg3)} {}
+               vec_data<Ty>::get(Arg2), vec_data<Ty>::get(Arg3)} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<8, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
                 const DataT Arg3, const DataT Arg4, const DataT Arg5,
                 const DataT Arg6, const DataT Arg7)
       : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1),
-      vec_data<Ty>::get(Arg2), vec_data<Ty>::get(Arg3),
-      vec_data<Ty>::get(Arg4), vec_data<Ty>::get(Arg5),
-      vec_data<Ty>::get(Arg6), vec_data<Ty>::get(Arg7)} {}
+               vec_data<Ty>::get(Arg2), vec_data<Ty>::get(Arg3),
+               vec_data<Ty>::get(Arg4), vec_data<Ty>::get(Arg5),
+               vec_data<Ty>::get(Arg6), vec_data<Ty>::get(Arg7)} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<16, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
@@ -805,13 +802,13 @@ public:
                 const DataT ArgC, const DataT ArgD, const DataT ArgE,
                 const DataT ArgF)
       : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1),
-      vec_data<Ty>::get(Arg2), vec_data<Ty>::get(Arg3),
-      vec_data<Ty>::get(Arg4), vec_data<Ty>::get(Arg5),
-      vec_data<Ty>::get(Arg6), vec_data<Ty>::get(Arg7),
-      vec_data<Ty>::get(Arg8), vec_data<Ty>::get(Arg9),
-      vec_data<Ty>::get(ArgA), vec_data<Ty>::get(ArgB),
-      vec_data<Ty>::get(ArgC), vec_data<Ty>::get(ArgD),
-      vec_data<Ty>::get(ArgE), vec_data<Ty>::get(ArgF)} {}
+               vec_data<Ty>::get(Arg2), vec_data<Ty>::get(Arg3),
+               vec_data<Ty>::get(Arg4), vec_data<Ty>::get(Arg5),
+               vec_data<Ty>::get(Arg6), vec_data<Ty>::get(Arg7),
+               vec_data<Ty>::get(Arg8), vec_data<Ty>::get(Arg9),
+               vec_data<Ty>::get(ArgA), vec_data<Ty>::get(ArgB),
+               vec_data<Ty>::get(ArgC), vec_data<Ty>::get(ArgD),
+               vec_data<Ty>::get(ArgE), vec_data<Ty>::get(ArgF)} {}
 #endif
 
   // Constructor from values of base type or vec of base type. Checks that
@@ -866,10 +863,10 @@ public:
     using OpenCLR = detail::ConvertToOpenCLType_t<vec_data_t<convertT>>;
     for (size_t I = 0; I < NumElements; ++I) {
       Result.setValue(
-          I,
-          vec_data<convertT>::get(detail::convertImpl<vec_data_t<DataT>,
-                              vec_data_t<convertT>, roundingMode, OpenCLT, OpenCLR>(
-              vec_data<DataT>::get(getValue(I)))));
+          I, vec_data<convertT>::get(
+                 detail::convertImpl<vec_data_t<DataT>, vec_data_t<convertT>,
+                                     roundingMode, OpenCLT, OpenCLR>(
+                     vec_data<DataT>::get(getValue(I)))));
     }
     return Result;
   }
@@ -997,7 +994,7 @@ public:
   template <typename T>                                                        \
   typename detail::enable_if_t<                                                \
       std::is_convertible<DataT, T>::value &&                                  \
-          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                        \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
@@ -1025,7 +1022,7 @@ public:
   template <typename T>                                                        \
   typename detail::enable_if_t<                                                \
       std::is_convertible<DataT, T>::value &&                                  \
-          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                        \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
@@ -1082,10 +1079,11 @@ public:
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
-  typename detail::enable_if_t<std::is_convertible<T, DataT>::value &&         \
-                                   (std::is_fundamental<vec_data_t<T>>::value ||           \
-                                    std::is_same<T, half>::value),             \
-                               vec<rel_t, NumElements>>                        \
+  typename detail::enable_if_t<                                                \
+      std::is_convertible<T, DataT>::value &&                                  \
+          (std::is_fundamental<vec_data_t<T>>::value ||                        \
+           std::is_same<T, half>::value),                                      \
+      vec<rel_t, NumElements>>                                                 \
   operator RELLOGOP(const T &Rhs) const {                                      \
     return *this RELLOGOP vec(static_cast<const DataT &>(Rhs));                \
   }
@@ -1094,15 +1092,17 @@ public:
   vec<rel_t, NumElements> operator RELLOGOP(const vec &Rhs) const {            \
     vec<rel_t, NumElements> Ret;                                               \
     for (size_t I = 0; I < NumElements; ++I) {                                 \
-      Ret.setValue(I, -(vec_data<DataT>::get(getValue(I)) RELLOGOP vec_data<DataT>::get(Rhs.getValue(I))));                \
+      Ret.setValue(I, -(vec_data<DataT>::get(getValue(I))                      \
+                            RELLOGOP vec_data<DataT>::get(Rhs.getValue(I))));  \
     }                                                                          \
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
-  typename detail::enable_if_t<std::is_convertible<T, DataT>::value &&         \
-                                   (std::is_fundamental<vec_data_t<T>>::value ||           \
-                                    std::is_same<T, half>::value),             \
-                               vec<rel_t, NumElements>>                        \
+  typename detail::enable_if_t<                                                \
+      std::is_convertible<T, DataT>::value &&                                  \
+          (std::is_fundamental<vec_data_t<T>>::value ||                        \
+           std::is_same<T, half>::value),                                      \
+      vec<rel_t, NumElements>>                                                 \
   operator RELLOGOP(const T &Rhs) const {                                      \
     return *this RELLOGOP vec(static_cast<const DataT &>(Rhs));                \
   }
@@ -1124,12 +1124,12 @@ public:
 #endif
 #define __SYCL_UOP(UOP, OPASSIGN)                                              \
   vec &operator UOP() {                                                        \
-    *this OPASSIGN vec_data<DataT>::get(1);                                                          \
+    *this OPASSIGN vec_data<DataT>::get(1);                                    \
     return *this;                                                              \
   }                                                                            \
   vec operator UOP(int) {                                                      \
     vec Ret(*this);                                                            \
-    *this OPASSIGN vec_data<DataT>::get(1);                                                          \
+    *this OPASSIGN vec_data<DataT>::get(1);                                    \
     return Ret;                                                                \
   }
 
@@ -1179,8 +1179,7 @@ public:
 #else
     vec Ret;
     for (size_t I = 0; I < NumElements; ++I)
-      Ret.setValue(I, vec_data<DataT>::get(
-                        +vec_data<DataT>::get(getValue(I))));
+      Ret.setValue(I, vec_data<DataT>::get(+vec_data<DataT>::get(getValue(I))));
     return Ret;
 #endif
   }
@@ -1193,8 +1192,7 @@ public:
 #else
     vec Ret;
     for (size_t I = 0; I < NumElements; ++I)
-      Ret.setValue(I, vec_data<DataT>::get(
-                        -vec_data<DataT>::get(getValue(I))));
+      Ret.setValue(I, vec_data<DataT>::get(-vec_data<DataT>::get(getValue(I))));
     return Ret;
 #endif
   }
@@ -1262,13 +1260,13 @@ private:
   template <int Num = NumElements, typename Ty = int,
             typename = typename detail::enable_if_t<1 != Num>>
   constexpr void setValue(EnableIfHostHalf<Ty> Index, const DataT &Value, int) {
-    m_Data.s[Index] = vec_data<DataT>::get(Value);      // how do we check enableifhosthalf for int? why?
+    m_Data.s[Index] = vec_data<DataT>::get(Value);
   }
 
   template <int Num = NumElements, typename Ty = int,
             typename = typename detail::enable_if_t<1 != Num>>
   DataT getValue(EnableIfHostHalf<Ty> Index, int) const {
-    return vec_data<DataT>::get(m_Data.s[Index]);     // the same question as above
+    return vec_data<DataT>::get(m_Data.s[Index]);
   }
 #else  // __SYCL_USE_EXT_VECTOR_TYPE__
   template <int Num = NumElements,
@@ -1540,7 +1538,8 @@ public:
 #undef __SYCL_UOP
 
   template <typename T = DataT>
-  typename detail::enable_if_t<std::is_integral<vec_data_t<T>>::value, vec_t> operator~() {
+  typename detail::enable_if_t<std::is_integral<vec_data_t<T>>::value, vec_t>
+  operator~() {
     vec_t Tmp = *this;
     return ~Tmp;
   }
@@ -1923,8 +1922,9 @@ private:
       return m_Vector->getValue(Idxs[Index]);
     }
     auto Op = OperationCurrentT<vec_data_t<CommonDataT>>();
-    return vec_data<CommonDataT>::get(Op(vec_data<CommonDataT>::get(m_LeftOperation.getValue(Index)),
-              vec_data<CommonDataT>::get(m_RightOperation.getValue(Index))));
+    return vec_data<CommonDataT>::get(
+        Op(vec_data<CommonDataT>::get(m_LeftOperation.getValue(Index)),
+           vec_data<CommonDataT>::get(m_RightOperation.getValue(Index))));
   }
 
   template <int IdxNum = getNumElements()>
@@ -1934,8 +1934,9 @@ private:
       return m_Vector->getValue(Idxs[Index]);
     }
     auto Op = OperationCurrentT<vec_data_t<DataT>>();
-    return vec_data<DataT>::get(Op(vec_data<DataT>::get(m_LeftOperation.getValue(Index)),
-              vec_data<DataT>::get(m_RightOperation.getValue(Index))));
+    return vec_data<DataT>::get(
+        Op(vec_data<DataT>::get(m_LeftOperation.getValue(Index)),
+           vec_data<DataT>::get(m_RightOperation.getValue(Index))));
   }
 
   template <template <typename> class Operation, typename RhsOperation>
@@ -1944,7 +1945,8 @@ private:
     std::array<int, getNumElements()> Idxs{Indexes...};
     for (size_t I = 0; I < Idxs.size(); ++I) {
       DataT Res = vec_data<DataT>::get(
-        Op(vec_data<DataT>::get(m_Vector->getValue(Idxs[I])), vec_data<DataT>::get(Rhs.getValue(I))));
+          Op(vec_data<DataT>::get(m_Vector->getValue(Idxs[I])),
+             vec_data<DataT>::get(Rhs.getValue(I))));
       m_Vector->setValue(Idxs[I], Res);
     }
   }
@@ -1973,7 +1975,7 @@ private:
 #define __SYCL_BINOP(BINOP)                                                    \
   template <typename T, int Num>                                               \
   typename detail::enable_if_t<                                                \
-      std::is_fundamental<vec_data_t<T>>::value ||                                         \
+      std::is_fundamental<vec_data_t<T>>::value ||                             \
           std::is_same<typename detail::remove_const_t<T>, half>::value,       \
       vec<T, Num>>                                                             \
   operator BINOP(const T &Lhs, const vec<T, Num> &Rhs) {                       \
@@ -1985,7 +1987,7 @@ private:
             int Num = sizeof...(Indexes)>                                      \
   typename detail::enable_if_t<                                                \
       std::is_convertible<T, T1>::value &&                                     \
-          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                        \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec<T1, Num>>                                                            \
   operator BINOP(                                                              \
@@ -2028,7 +2030,7 @@ __SYCL_BINOP(<<)
   template <typename T, typename DataT, int Num>                               \
   typename detail::enable_if_t<                                                \
       std::is_convertible<T, DataT>::value &&                                  \
-          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                        \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec<detail::rel_t<DataT>, Num>>                                          \
   operator RELLOGOP(const T &Lhs, const vec<DataT, Num> &Rhs) {                \
@@ -2040,7 +2042,7 @@ __SYCL_BINOP(<<)
             int Num = sizeof...(Indexes)>                                      \
   typename detail::enable_if_t<                                                \
       std::is_convertible<T, T1>::value &&                                     \
-          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                        \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec<detail::rel_t<T1>, Num>>                                             \
   operator RELLOGOP(                                                           \

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -98,6 +98,23 @@ struct elem {
 
 namespace detail {
 
+template<typename T> struct vec_helper {
+  using RetType = T;
+  static constexpr RetType get(T value) {
+    return value;
+  }
+};
+
+template<> struct vec_helper<std::byte> {
+  using RetType = std::uint8_t;
+  static constexpr RetType get(std::byte value) {
+    return (RetType)value;
+  }
+  static constexpr std::byte get(std::uint8_t value) {
+    return (std::byte)value;
+  }
+};
+
 template <typename VecT, typename OperationLeftT, typename OperationRightT,
           template <typename> class OperationCurrentT, int... Indexes>
 class SwizzleOp;
@@ -120,8 +137,8 @@ using rel_t = typename detail::conditional_t<
 template <typename T> class GetOp {
 public:
   using DataT = T;
-  DataT getValue(size_t) const { return 0; }
-  DataT operator()(DataT, DataT) { return 0; }
+  DataT getValue(size_t) const { return (DataT)0; }
+  DataT operator()(DataT, DataT) { return (DataT)0; }
 };
 
 // Special type for working SwizzleOp with scalars, stores a scalar and gives
@@ -511,6 +528,12 @@ class RoundedRangeKernelWithKH;
 
 } // namespace detail
 
+template <typename T>
+using vec_data = detail::vec_helper<T>;
+
+template <typename T>
+using vec_data_t = typename detail::vec_helper<T>::RetType;
+
 #if defined(_WIN32) && (_MSC_VER)
 // MSVC Compiler doesn't allow using of function arguments with alignment
 // requirements. MSVC Compiler Error C2719: 'parameter': formal parameter with
@@ -667,7 +690,7 @@ public:
   // W/o this, things like "vec<char,*> = vec<signed char, *>" doesn't work.
   template <typename Ty = DataT>
   typename detail::enable_if_t<!std::is_same<Ty, rel_t>::value &&
-                                   std::is_convertible<Ty, rel_t>::value,
+                                   std::is_convertible<vec_data_t<Ty>, rel_t>::value,
                                vec &>
   operator=(const vec<rel_t, NumElements> &Rhs) {
     *this = Rhs.template as<vec>();
@@ -690,16 +713,16 @@ public:
 
   template <typename Ty = DataT>
   explicit constexpr vec(const EnableIfNotHostHalf<Ty> &arg) {
-    m_Data = (DataType)arg;
+    m_Data = (DataType)vec_data<Ty>::get(arg);
   }
 
   template <typename Ty = DataT>
   typename detail::enable_if_t<
-      std::is_fundamental<Ty>::value ||
+      std::is_fundamental<vec_data_t<Ty>>::value ||
           std::is_same<typename detail::remove_const_t<Ty>, half>::value,
       vec &>
   operator=(const EnableIfNotHostHalf<Ty> &Rhs) {
-    m_Data = (DataType)Rhs;
+    m_Data = (DataType)vec_data<Ty>::get(Rhs);
     return *this;
   }
 
@@ -712,7 +735,7 @@ public:
 
   template <typename Ty = DataT>
   typename detail::enable_if_t<
-      std::is_fundamental<Ty>::value ||
+      std::is_fundamental<vec_data_t<Ty>>::value ||
           std::is_same<typename detail::remove_const_t<Ty>, half>::value,
       vec &>
   operator=(const EnableIfHostHalf<Ty> &Rhs) {
@@ -730,7 +753,7 @@ public:
 
   template <typename Ty = DataT>
   typename detail::enable_if_t<
-      std::is_fundamental<Ty>::value ||
+      std::is_fundamental<vec_data_t<Ty>>::value ||
           std::is_same<typename detail::remove_const_t<Ty>, half>::value,
       vec &>
   operator=(const DataT &Rhs) {
@@ -753,22 +776,26 @@ public:
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<2, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1)
-      : m_Data{Arg0, Arg1} {}
+      : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1)} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<3, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2)
-      : m_Data{Arg0, Arg1, Arg2} {}
+      : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1), vec_data<Ty>::get(Arg2)} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<4, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
                 const Ty Arg3)
-      : m_Data{Arg0, Arg1, Arg2, Arg3} {}
+      : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1),
+      vec_data<Ty>::get(Arg2), vec_data<Ty>::get(Arg3)} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<8, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
                 const DataT Arg3, const DataT Arg4, const DataT Arg5,
                 const DataT Arg6, const DataT Arg7)
-      : m_Data{Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7} {}
+      : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1),
+      vec_data<Ty>::get(Arg2), vec_data<Ty>::get(Arg3),
+      vec_data<Ty>::get(Arg4), vec_data<Ty>::get(Arg5),
+      vec_data<Ty>::get(Arg6), vec_data<Ty>::get(Arg7)} {}
   template <typename Ty = DataT>
   constexpr vec(const EnableIfMultipleElems<16, Ty> Arg0,
                 const EnableIfNotHostHalf<Ty> Arg1, const DataT Arg2,
@@ -777,8 +804,14 @@ public:
                 const DataT Arg9, const DataT ArgA, const DataT ArgB,
                 const DataT ArgC, const DataT ArgD, const DataT ArgE,
                 const DataT ArgF)
-      : m_Data{Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7,
-               Arg8, Arg9, ArgA, ArgB, ArgC, ArgD, ArgE, ArgF} {}
+      : m_Data{vec_data<Ty>::get(Arg0), vec_data<Ty>::get(Arg1),
+      vec_data<Ty>::get(Arg2), vec_data<Ty>::get(Arg3),
+      vec_data<Ty>::get(Arg4), vec_data<Ty>::get(Arg5),
+      vec_data<Ty>::get(Arg6), vec_data<Ty>::get(Arg7),
+      vec_data<Ty>::get(Arg8), vec_data<Ty>::get(Arg9),
+      vec_data<Ty>::get(ArgA), vec_data<Ty>::get(ArgB),
+      vec_data<Ty>::get(ArgC), vec_data<Ty>::get(ArgD),
+      vec_data<Ty>::get(ArgE), vec_data<Ty>::get(ArgF)} {}
 #endif
 
   // Constructor from values of base type or vec of base type. Checks that
@@ -811,7 +844,7 @@ public:
   // Available only when: NumElements == 1
   template <int N = NumElements>
   operator typename detail::enable_if_t<N == 1, DataT>() const {
-    return m_Data;
+    return vec_data<DataT>::get(m_Data);
   }
 
   __SYCL2020_DEPRECATED("get_count() is deprecated, please use size() instead")
@@ -825,17 +858,18 @@ public:
   template <typename convertT,
             rounding_mode roundingMode = rounding_mode::automatic>
   vec<convertT, NumElements> convert() const {
-    static_assert(std::is_integral<convertT>::value ||
+    static_assert(std::is_integral<vec_data_t<convertT>>::value ||
                       detail::is_floating_point<convertT>::value,
                   "Unsupported convertT");
     vec<convertT, NumElements> Result;
-    using OpenCLT = detail::ConvertToOpenCLType_t<DataT>;
-    using OpenCLR = detail::ConvertToOpenCLType_t<convertT>;
+    using OpenCLT = detail::ConvertToOpenCLType_t<vec_data_t<DataT>>;
+    using OpenCLR = detail::ConvertToOpenCLType_t<vec_data_t<convertT>>;
     for (size_t I = 0; I < NumElements; ++I) {
       Result.setValue(
           I,
-          detail::convertImpl<DataT, convertT, roundingMode, OpenCLT, OpenCLR>(
-              getValue(I)));
+          vec_data<convertT>::get(detail::convertImpl<vec_data_t<DataT>,
+                              vec_data_t<convertT>, roundingMode, OpenCLT, OpenCLR>(
+              vec_data<DataT>::get(getValue(I)))));
     }
     return Result;
   }
@@ -963,7 +997,7 @@ public:
   template <typename T>                                                        \
   typename detail::enable_if_t<                                                \
       std::is_convertible<DataT, T>::value &&                                  \
-          (std::is_fundamental<T>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
@@ -991,7 +1025,7 @@ public:
   template <typename T>                                                        \
   typename detail::enable_if_t<                                                \
       std::is_convertible<DataT, T>::value &&                                  \
-          (std::is_fundamental<T>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
@@ -1049,7 +1083,7 @@ public:
   }                                                                            \
   template <typename T>                                                        \
   typename detail::enable_if_t<std::is_convertible<T, DataT>::value &&         \
-                                   (std::is_fundamental<T>::value ||           \
+                                   (std::is_fundamental<vec_data_t<T>>::value ||           \
                                     std::is_same<T, half>::value),             \
                                vec<rel_t, NumElements>>                        \
   operator RELLOGOP(const T &Rhs) const {                                      \
@@ -1060,13 +1094,13 @@ public:
   vec<rel_t, NumElements> operator RELLOGOP(const vec &Rhs) const {            \
     vec<rel_t, NumElements> Ret;                                               \
     for (size_t I = 0; I < NumElements; ++I) {                                 \
-      Ret.setValue(I, -(getValue(I) RELLOGOP Rhs.getValue(I)));                \
+      Ret.setValue(I, -(vec_data<DataT>::get(getValue(I)) RELLOGOP vec_data<DataT>::get(Rhs.getValue(I))));                \
     }                                                                          \
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
   typename detail::enable_if_t<std::is_convertible<T, DataT>::value &&         \
-                                   (std::is_fundamental<T>::value ||           \
+                                   (std::is_fundamental<vec_data_t<T>>::value ||           \
                                     std::is_same<T, half>::value),             \
                                vec<rel_t, NumElements>>                        \
   operator RELLOGOP(const T &Rhs) const {                                      \
@@ -1090,12 +1124,12 @@ public:
 #endif
 #define __SYCL_UOP(UOP, OPASSIGN)                                              \
   vec &operator UOP() {                                                        \
-    *this OPASSIGN 1;                                                          \
+    *this OPASSIGN vec_data<DataT>::get(1);                                                          \
     return *this;                                                              \
   }                                                                            \
   vec operator UOP(int) {                                                      \
     vec Ret(*this);                                                            \
-    *this OPASSIGN 1;                                                          \
+    *this OPASSIGN vec_data<DataT>::get(1);                                                          \
     return Ret;                                                                \
   }
 
@@ -1106,7 +1140,7 @@ public:
   // Available only when: dataT != cl_float && dataT != cl_double
   // && dataT != cl_half
   template <typename T = DataT>
-  typename detail::enable_if_t<std::is_integral<T>::value, vec>
+  typename detail::enable_if_t<std::is_integral<vec_data_t<T>>::value, vec>
   operator~() const {
 // Use __SYCL_DEVICE_ONLY__ macro because cast to OpenCL vector type is defined
 // by SYCL device compiler only.
@@ -1145,7 +1179,8 @@ public:
 #else
     vec Ret;
     for (size_t I = 0; I < NumElements; ++I)
-      Ret.setValue(I, +getValue(I));
+      Ret.setValue(I, vec_data<DataT>::get(
+                        +vec_data<DataT>::get(getValue(I))));
     return Ret;
 #endif
   }
@@ -1158,7 +1193,8 @@ public:
 #else
     vec Ret;
     for (size_t I = 0; I < NumElements; ++I)
-      Ret.setValue(I, -getValue(I));
+      Ret.setValue(I, vec_data<DataT>::get(
+                        -vec_data<DataT>::get(getValue(I))));
     return Ret;
 #endif
   }
@@ -1214,50 +1250,50 @@ private:
             typename = typename detail::enable_if_t<1 != Num>>
   constexpr void setValue(EnableIfNotHostHalf<Ty> Index, const DataT &Value,
                           int) {
-    m_Data[Index] = Value;
+    m_Data[Index] = vec_data<DataT>::get(Value);
   }
 
   template <int Num = NumElements, typename Ty = int,
             typename = typename detail::enable_if_t<1 != Num>>
   DataT getValue(EnableIfNotHostHalf<Ty> Index, int) const {
-    return m_Data[Index];
+    return vec_data<DataT>::get(m_Data[Index]);
   }
 
   template <int Num = NumElements, typename Ty = int,
             typename = typename detail::enable_if_t<1 != Num>>
   constexpr void setValue(EnableIfHostHalf<Ty> Index, const DataT &Value, int) {
-    m_Data.s[Index] = Value;
+    m_Data.s[Index] = vec_data<DataT>::get(Value);      // how do we check enableifhosthalf for int? why?
   }
 
   template <int Num = NumElements, typename Ty = int,
             typename = typename detail::enable_if_t<1 != Num>>
   DataT getValue(EnableIfHostHalf<Ty> Index, int) const {
-    return m_Data.s[Index];
+    return vec_data<DataT>::get(m_Data.s[Index]);     // the same question as above
   }
 #else  // __SYCL_USE_EXT_VECTOR_TYPE__
   template <int Num = NumElements,
             typename = typename detail::enable_if_t<1 != Num>>
   constexpr void setValue(int Index, const DataT &Value, int) {
-    m_Data.s[Index] = Value;
+    m_Data.s[Index] = vec_data<DataT>::get(Value);
   }
 
   template <int Num = NumElements,
             typename = typename detail::enable_if_t<1 != Num>>
   DataT getValue(int Index, int) const {
-    return m_Data.s[Index];
+    return vec_data<DataT>::get(m_Data.s[Index]);
   }
 #endif // __SYCL_USE_EXT_VECTOR_TYPE__
 
   template <int Num = NumElements,
             typename = typename detail::enable_if_t<1 == Num>>
   constexpr void setValue(int, const DataT &Value, float) {
-    m_Data = Value;
+    m_Data = vec_data<DataT>::get(Value);
   }
 
   template <int Num = NumElements,
             typename = typename detail::enable_if_t<1 == Num>>
   DataT getValue(int, float) const {
-    return m_Data;
+    return vec_data<DataT>::get(m_Data);
   }
 
   // Special proxies as specialization is not allowed in class scope.
@@ -1397,13 +1433,13 @@ class SwizzleOp {
   template <typename T>
   using EnableIfScalarType = typename detail::enable_if_t<
       std::is_convertible<DataT, T>::value &&
-      (std::is_fundamental<T>::value ||
+      (std::is_fundamental<vec_data_t<T>>::value ||
        std::is_same<typename detail::remove_const_t<T>, half>::value)>;
 
   template <typename T>
   using EnableIfNoScalarType = typename detail::enable_if_t<
       !std::is_convertible<DataT, T>::value ||
-      !(std::is_fundamental<T>::value ||
+      !(std::is_fundamental<vec_data_t<T>>::value ||
         std::is_same<typename detail::remove_const_t<T>, half>::value)>;
 
   template <int... Indices>
@@ -1504,7 +1540,7 @@ public:
 #undef __SYCL_UOP
 
   template <typename T = DataT>
-  typename detail::enable_if_t<std::is_integral<T>::value, vec_t> operator~() {
+  typename detail::enable_if_t<std::is_integral<vec_data_t<T>>::value, vec_t> operator~() {
     vec_t Tmp = *this;
     return ~Tmp;
   }
@@ -1886,9 +1922,9 @@ private:
       std::array<int, getNumElements()> Idxs{Indexes...};
       return m_Vector->getValue(Idxs[Index]);
     }
-    auto Op = OperationCurrentT<CommonDataT>();
-    return Op(m_LeftOperation.getValue(Index),
-              m_RightOperation.getValue(Index));
+    auto Op = OperationCurrentT<vec_data_t<CommonDataT>>();
+    return vec_data<CommonDataT>::get(Op(vec_data<CommonDataT>::get(m_LeftOperation.getValue(Index)),
+              vec_data<CommonDataT>::get(m_RightOperation.getValue(Index))));
   }
 
   template <int IdxNum = getNumElements()>
@@ -1897,17 +1933,18 @@ private:
       std::array<int, getNumElements()> Idxs{Indexes...};
       return m_Vector->getValue(Idxs[Index]);
     }
-    auto Op = OperationCurrentT<DataT>();
-    return Op(m_LeftOperation.getValue(Index),
-              m_RightOperation.getValue(Index));
+    auto Op = OperationCurrentT<vec_data_t<DataT>>();
+    return vec_data<DataT>::get(Op(vec_data<DataT>::get(m_LeftOperation.getValue(Index)),
+              vec_data<DataT>::get(m_RightOperation.getValue(Index))));
   }
 
   template <template <typename> class Operation, typename RhsOperation>
   void operatorHelper(const RhsOperation &Rhs) {
-    Operation<DataT> Op;
+    Operation<vec_data_t<DataT>> Op;
     std::array<int, getNumElements()> Idxs{Indexes...};
     for (size_t I = 0; I < Idxs.size(); ++I) {
-      DataT Res = Op(m_Vector->getValue(Idxs[I]), Rhs.getValue(I));
+      DataT Res = vec_data<DataT>::get(
+        Op(vec_data<DataT>::get(m_Vector->getValue(Idxs[I])), vec_data<DataT>::get(Rhs.getValue(I))));
       m_Vector->setValue(Idxs[I], Res);
     }
   }
@@ -1936,7 +1973,7 @@ private:
 #define __SYCL_BINOP(BINOP)                                                    \
   template <typename T, int Num>                                               \
   typename detail::enable_if_t<                                                \
-      std::is_fundamental<T>::value ||                                         \
+      std::is_fundamental<vec_data_t<T>>::value ||                                         \
           std::is_same<typename detail::remove_const_t<T>, half>::value,       \
       vec<T, Num>>                                                             \
   operator BINOP(const T &Lhs, const vec<T, Num> &Rhs) {                       \
@@ -1948,7 +1985,7 @@ private:
             int Num = sizeof...(Indexes)>                                      \
   typename detail::enable_if_t<                                                \
       std::is_convertible<T, T1>::value &&                                     \
-          (std::is_fundamental<T>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec<T1, Num>>                                                            \
   operator BINOP(                                                              \
@@ -1991,7 +2028,7 @@ __SYCL_BINOP(<<)
   template <typename T, typename DataT, int Num>                               \
   typename detail::enable_if_t<                                                \
       std::is_convertible<T, DataT>::value &&                                  \
-          (std::is_fundamental<T>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec<detail::rel_t<DataT>, Num>>                                          \
   operator RELLOGOP(const T &Lhs, const vec<DataT, Num> &Rhs) {                \
@@ -2003,7 +2040,7 @@ __SYCL_BINOP(<<)
             int Num = sizeof...(Indexes)>                                      \
   typename detail::enable_if_t<                                                \
       std::is_convertible<T, T1>::value &&                                     \
-          (std::is_fundamental<T>::value ||                                    \
+          (std::is_fundamental<vec_data_t<T>>::value ||                                    \
            std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec<detail::rel_t<T1>, Num>>                                             \
   operator RELLOGOP(                                                           \
@@ -2165,6 +2202,12 @@ using select_apply_cl_t =
         __SYCL_GET_CL_TYPE(int, num), __SYCL_GET_CL_TYPE(long, num)>;          \
   };
 
+#define __SYCL_DECLARE_BYTE_CONVERTER(num)                                     \
+  template <> class BaseCLTypeConverter<std::byte, num> {                      \
+  public:                                                                      \
+    using DataType = __SYCL_GET_CL_TYPE(uchar, num);                           \
+  };
+
 #define __SYCL_DECLARE_HALF_CONVERTER(base, num)                               \
   template <> class BaseCLTypeConverter<base, num> {                           \
   public:                                                                      \
@@ -2181,6 +2224,12 @@ using select_apply_cl_t =
   template <> class BaseCLTypeConverter<bool, 1> {                             \
   public:                                                                      \
     using DataType = bool;                                                     \
+  };
+
+#define __SYCL_DECLARE_SCALAR_BYTE_CONVERTER                                   \
+  template <> class BaseCLTypeConverter<std::byte, 1> {                        \
+  public:                                                                      \
+    using DataType = __SYCL_GET_SCALAR_CL_TYPE(uchar);                         \
   };
 
 #define __SYCL_DECLARE_SCALAR_CONVERTER(base)                                  \
@@ -2275,9 +2324,19 @@ using select_apply_cl_t =
   __SYCL_DECLARE_SCALAR_BOOL_CONVERTER                                         \
   } // namespace detail
 
+#define __SYCL_DECLARE_BYTE_VECTOR_CONVERTER                                   \
+  namespace detail {                                                           \
+  __SYCL_DECLARE_BYTE_CONVERTER(2)                                             \
+  __SYCL_DECLARE_BYTE_CONVERTER(3)                                             \
+  __SYCL_DECLARE_BYTE_CONVERTER(4)                                             \
+  __SYCL_DECLARE_BYTE_CONVERTER(8)                                             \
+  __SYCL_DECLARE_BYTE_CONVERTER(16)                                            \
+  __SYCL_DECLARE_SCALAR_BYTE_CONVERTER                                         \
+  }
 __SYCL_DECLARE_VECTOR_CONVERTERS(char)
 __SYCL_DECLARE_SCHAR_VECTOR_CONVERTERS
 __SYCL_DECLARE_BOOL_VECTOR_CONVERTERS
+__SYCL_DECLARE_BYTE_VECTOR_CONVERTER
 __SYCL_DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(uchar)
 __SYCL_DECLARE_SIGNED_INTEGRAL_VECTOR_CONVERTERS(short)
 __SYCL_DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(ushort)
@@ -2302,6 +2361,9 @@ __SYCL_DECLARE_FLOAT_VECTOR_CONVERTERS(double)
 #undef __SYCL_DECLARE_SCALAR_SCHAR_CONVERTER
 #undef __SYCL_DECLARE_BOOL_VECTOR_CONVERTERS
 #undef __SYCL_DECLARE_BOOL_CONVERTER
+#undef __SYCL_DECLARE_BYTE_VECTOR_CONVERTER
+#undef __SYCL_DECLARE_BYTE_CONVERTER
+#undef __SYCL_DECLARE_SCALAR_BYTE_CONVERTER
 #undef __SYCL_DECLARE_SCALAR_BOOL_CONVERTER
 #undef __SYCL_USE_EXT_VECTOR_TYPE__
 

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -103,6 +103,7 @@ template <typename T> struct vec_helper {
   static constexpr RetType get(T value) { return value; }
 };
 
+#if __cplusplus >= 201703L
 template <> struct vec_helper<std::byte> {
   using RetType = std::uint8_t;
   static constexpr RetType get(std::byte value) { return (RetType)value; }
@@ -110,6 +111,7 @@ template <> struct vec_helper<std::byte> {
     return (std::byte)value;
   }
 };
+#endif
 
 template <typename VecT, typename OperationLeftT, typename OperationRightT,
           template <typename> class OperationCurrentT, int... Indexes>
@@ -1165,7 +1167,7 @@ public:
 #else
     vec<rel_t, NumElements> Ret;
     for (size_t I = 0; I < NumElements; ++I) {
-      Ret.setValue(I, !getValue(I));
+      Ret.setValue(I, !vec_data<DataT>::get(getValue(I)));
     }
     return Ret;
 #endif
@@ -2204,12 +2206,13 @@ using select_apply_cl_t =
         __SYCL_GET_CL_TYPE(int, num), __SYCL_GET_CL_TYPE(long, num)>;          \
   };
 
+#if __cplusplus >= 201703L
 #define __SYCL_DECLARE_BYTE_CONVERTER(num)                                     \
   template <> class BaseCLTypeConverter<std::byte, num> {                      \
   public:                                                                      \
     using DataType = __SYCL_GET_CL_TYPE(uchar, num);                           \
   };
-
+#endif
 #define __SYCL_DECLARE_HALF_CONVERTER(base, num)                               \
   template <> class BaseCLTypeConverter<base, num> {                           \
   public:                                                                      \
@@ -2228,12 +2231,13 @@ using select_apply_cl_t =
     using DataType = bool;                                                     \
   };
 
+#if __cplusplus >= 201703L
 #define __SYCL_DECLARE_SCALAR_BYTE_CONVERTER                                   \
   template <> class BaseCLTypeConverter<std::byte, 1> {                        \
   public:                                                                      \
     using DataType = __SYCL_GET_SCALAR_CL_TYPE(uchar);                         \
   };
-
+#endif
 #define __SYCL_DECLARE_SCALAR_CONVERTER(base)                                  \
   template <> class BaseCLTypeConverter<base, 1> {                             \
   public:                                                                      \
@@ -2326,6 +2330,7 @@ using select_apply_cl_t =
   __SYCL_DECLARE_SCALAR_BOOL_CONVERTER                                         \
   } // namespace detail
 
+#if __cplusplus >= 201703L
 #define __SYCL_DECLARE_BYTE_VECTOR_CONVERTER                                   \
   namespace detail {                                                           \
   __SYCL_DECLARE_BYTE_CONVERTER(2)                                             \
@@ -2335,10 +2340,13 @@ using select_apply_cl_t =
   __SYCL_DECLARE_BYTE_CONVERTER(16)                                            \
   __SYCL_DECLARE_SCALAR_BYTE_CONVERTER                                         \
   }
+#endif
 __SYCL_DECLARE_VECTOR_CONVERTERS(char)
 __SYCL_DECLARE_SCHAR_VECTOR_CONVERTERS
 __SYCL_DECLARE_BOOL_VECTOR_CONVERTERS
+#if __cplusplus >= 201703L
 __SYCL_DECLARE_BYTE_VECTOR_CONVERTER
+#endif
 __SYCL_DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(uchar)
 __SYCL_DECLARE_SIGNED_INTEGRAL_VECTOR_CONVERTERS(short)
 __SYCL_DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(ushort)
@@ -2363,9 +2371,11 @@ __SYCL_DECLARE_FLOAT_VECTOR_CONVERTERS(double)
 #undef __SYCL_DECLARE_SCALAR_SCHAR_CONVERTER
 #undef __SYCL_DECLARE_BOOL_VECTOR_CONVERTERS
 #undef __SYCL_DECLARE_BOOL_CONVERTER
+#if __cplusplus >= 201703L
 #undef __SYCL_DECLARE_BYTE_VECTOR_CONVERTER
 #undef __SYCL_DECLARE_BYTE_CONVERTER
 #undef __SYCL_DECLARE_SCALAR_BYTE_CONVERTER
+#endif
 #undef __SYCL_DECLARE_SCALAR_BOOL_CONVERTER
 #undef __SYCL_USE_EXT_VECTOR_TYPE__
 


### PR DESCRIPTION
sycl::byte is deprecated and std::byte must be used instead. sycl::vec has unsigned char data under the hood when sycl::byte (the sycl::byte is alias to uint8_t) is used.
I added helper struct for explicit casting std::byte to uint8_t and vice versa. When std::byte is used in sycl::vec, vec's realization will use uint8_t for all the operations.
The test : https://github.com/intel/llvm-test-suite/pull/478
Signed-off-by: mdimakov <maxim.dimakov@intel.com>