### PR TITLE
[sycl-post-link] Fix out-of-bound access in the tool

### DIFF
--- a/llvm/test/tools/sycl-post-link/no-args-to-eliminate.ll
+++ b/llvm/test/tools/sycl-post-link/no-args-to-eliminate.ll
@@ -1,0 +1,33 @@
+; This test ensures that sycl-post-link doesn't crash when kernel parameter
+; optimization info metadata is empty
+;
+; RUN: sycl-post-link -emit-param-info -S %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.prop
+;
+; CHECK: [SYCL/kernel param opt]
+; // Nothing should be here
+; CHECK-EMPTY:
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: norecurse
+define weak_odr dso_local spir_kernel void @_ZTSZ4mainEUlT_E0_() local_unnamed_addr #0  !kernel_arg_buffer_location !6 !spir_kernel_omit_args !6 {
+entry:
+  ret void
+}
+
+attributes #0 = { norecurse "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="d.cpp" "uniform-work-group-size"="true" }
+
+!opencl.spir.version = !{!0}
+!spirv.Source = !{!1}
+!llvm.ident = !{!2, !3}
+!llvm.module.flags = !{!4, !5}
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 4, i32 100000}
+!2 = !{!"clang version 14.0.0"}
+!3 = !{!"clang version 14.0.0"}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"frame-pointer", i32 2}
+!6 = !{}

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -576,7 +576,10 @@ static string_vector saveDeviceImageProperty(
 
       for (const auto &NameInfoPair : PInfo) {
         const llvm::BitVector &Bits = NameInfoPair.second;
-        const llvm::ArrayRef<uintptr_t> Arr = NameInfoPair.second.getData();
+        if (Bits.empty())
+          continue; // Nothing to add
+
+        const llvm::ArrayRef<uintptr_t> Arr = Bits.getData();
         const unsigned char *Data =
             reinterpret_cast<const unsigned char *>(Arr.begin());
         llvm::util::PropertyValue::SizeTy DataBitSize = Bits.size();


### PR DESCRIPTION
Added an early exit into a loop over results of
`SPIRKernelParamOptInfoAnalysis` pass to avoid accessing an empty
`llvm::BitVector` at index 0.