### PR TITLE
[Driver][SYCL] Do not consider non-archive files for FPGA binary checks

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2779,6 +2779,10 @@ bool hasFPGABinary(Compilation &C, std::string Object, types::ID Type) {
   if (!llvm::sys::fs::exists(Object))
     return false;
 
+  // Only static archives are valid FPGA Binaries for unbundling.
+  if (!isStaticArchiveFile(Object))
+    return false;
+
   // Temporary names for the output.
   llvm::Triple TT;
   TT.setArchName(types::getTypeName(Type));

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -479,3 +479,10 @@
 // CHK-TOOLS-IMPLIED-OPTS-NOT: clang{{.*}} "-fsycl-is-device"{{.*}} "-O0"
 // CHK-TOOLS-IMPLIED-OPTS: sycl-post-link{{.*}} "-O2"
 // CHK-TOOLS-IMPLIED-OPTS: aoc{{.*}} "-g" "-DFOO1" "-DFOO2"
+
+/// shared objects should not be checked for FPGA contents
+// RUN: touch %t.so
+// RUN: %clangxx -fsycl -fintelfpga %t.so -### 2>&1 \
+// RUN:   | FileCheck -check-prefix=ERROR_BUNDLE_CHECK %s
+// ERROR_BUNDLE_CHECK-NOT: clang-offload-bundler{{.*}} "-targets=sycl-fpga_aoc{{(x|r|r_emu|o)}}-intel-unknown"{{.*}} "-check-section"
+// ERROR_BUNDLE_CHECK-NOT: error: file too small to be an archive


### PR DESCRIPTION
When performing bundle checks for AOC* type archives, only check for known
static archive files.  Checking anything else may result in unexpected
diagnostics from the bundler tool checking mechanism