### PR TITLE
[XPTIFW] Fix Clang compiler warning

### DIFF
--- a/xptifw/include/xpti_string_table.hpp
+++ b/xptifw/include/xpti_string_table.hpp
@@ -195,8 +195,7 @@ public:
   using st_forward_t = std::unordered_map<std::string, int32_t>;
   using st_reverse_t = std::unordered_map<int32_t, const char *>;
 
-  StringTable(int size = 4096)
-      : MStringToID(size), MIDToString(size), MTableSize(size) {
+  StringTable(int size = 4096) : MStringToID(size), MIDToString(size) {
     MIds = 1;
 #ifdef XPTI_STATISTICS
     MInsertions = 0;
@@ -331,7 +330,6 @@ private:
   safe_int32_t MIds;         ///< Thread-safe ID generator
   st_forward_t MStringToID;  ///< Forward lookup hash map
   st_reverse_t MIDToString;  ///< Reverse lookup hash map
-  int32_t MTableSize;        ///< Initial table size of the hash-map
   std::mutex MMutex;         ///< Mutex required for double-check pattern
                              ///< Replace with reader-writer lock in C++14
   safe_int32_t MStrings;     ///< The count of strings in the table

--- a/xptifw/unit_test/xpti_correctness_tests.cpp
+++ b/xptifw/unit_test/xpti_correctness_tests.cpp
@@ -259,12 +259,12 @@ TEST_F(xptiCorrectnessTest, xptiInitializeForUserDefinedTracePointTypes) {
   // We will test functionality of a subscriber
   // without actually creating a plugin
   uint8_t StreamID = xptiRegisterStream("test_foo");
-  typedef enum {
+  enum {
     extn1_begin = XPTI_TRACE_POINT_BEGIN(0),
     extn1_end = XPTI_TRACE_POINT_END(0),
     extn2_begin = XPTI_TRACE_POINT_BEGIN(1),
     extn2_end = XPTI_TRACE_POINT_END(1)
-  } tp_extension_t;
+  };
 
   auto TTType = xptiRegisterUserDefinedTracePoint("test_foo_tool", extn1_begin);
   auto Result = xptiRegisterCallback(StreamID, TTType, tpCallback);
@@ -287,12 +287,12 @@ TEST_F(xptiCorrectnessTest,
   xptiForceSetTraceEnabled(true);
 
   uint8_t StreamID = xptiRegisterStream("test_foo");
-  typedef enum {
+  enum {
     extn1_begin = XPTI_TRACE_POINT_BEGIN(0),
     extn1_end = XPTI_TRACE_POINT_END(0),
     extn2_begin = XPTI_TRACE_POINT_BEGIN(1),
     extn2_end = XPTI_TRACE_POINT_END(1)
-  } tp_extension_t;
+  };
 
   auto TTType1 =
       xptiRegisterUserDefinedTracePoint("test_foo_tool", extn1_begin);
@@ -470,12 +470,12 @@ TEST_F(xptiCorrectnessTest, xptiUserDefinedEventTypes) {
   xptiForceSetTraceEnabled(true);
 
   (void)xptiRegisterStream("test_foo");
-  typedef enum {
+  enum {
     extn_ev1 = XPTI_EVENT(0),
     extn_ev2 = XPTI_EVENT(1),
     extn_ev3 = XPTI_EVENT(2),
     extn_ev4 = XPTI_EVENT(3)
-  } event_extension_t;
+  };
 
   auto EventType1 = xptiRegisterUserDefinedEventType("test_foo_tool", extn_ev1);
   auto EventType2 = xptiRegisterUserDefinedEventType("test_foo_tool", extn_ev2);


### PR DESCRIPTION
Remove unused private field and local typedef, reported by Clang. GCC doesn't support similar warnings.