### PR TITLE
[XPTIFW] Fix shared libs configuration

### DIFF
--- a/xptifw/unit_test/CMakeLists.txt
+++ b/xptifw/unit_test/CMakeLists.txt
@@ -49,8 +49,8 @@ target_include_directories(XPTIFWUnitTests SYSTEM PRIVATE
   ${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include
 )
 
-if (TARGET Support)
-  set(SUPPORT_LIB Support)
+if (TARGET LLVMSupport)
+  set(SUPPORT_LIB LLVMSupport)
 endif()
 
 target_link_libraries(XPTIFWUnitTests PRIVATE


### PR DESCRIPTION
LLVM's Google Test library requires LLVM Support. Typically it is linked statically, but in case of shared libs configuration users are required to manually specify link dependency. In other LLVM sub-projects there's usually some sort of helper function (like `add_llvm_library`), that automatically prepends `LLVM` prefix. But XPTIFW has requirement to be buildable both in-tree and out-of-tree. With the wrong library name (`Support`) if's body was skipped, but since the Support library was statically linked with gtest, it was not required. Post-commit job with shared libs exposed this mistake.