### PR TITLE
[SYCL] Exclude exported symbols from kernel bundles

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -369,6 +369,7 @@ public:
     return AssertUsed;
   }
   const PropertyRange &getProgramMetadata() const { return ProgramMetadata; }
+  const PropertyRange &getExportedSymbols() const { return ExportedSymbols; }
   virtual ~DeviceBinaryImage() {}
 
 protected:
@@ -381,6 +382,7 @@ protected:
   DeviceBinaryImage::PropertyRange DeviceLibReqMask;
   DeviceBinaryImage::PropertyRange KernelParamOptInfo;
   DeviceBinaryImage::PropertyRange ProgramMetadata;
+  DeviceBinaryImage::PropertyRange ExportedSymbols;
 };
 
 /// Tries to determine the device binary image foramat. Returns

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -369,7 +369,13 @@ public:
     return AssertUsed;
   }
   const PropertyRange &getProgramMetadata() const { return ProgramMetadata; }
-  const PropertyRange &getExportedSymbols() const { return ExportedSymbols; }
+  const PropertyRange getExportedSymbols() const {
+    // We can't have this variable as a class member, since it would break
+    // the ABI backwards compatibility.
+    DeviceBinaryImage::PropertyRange ExportedSymbols;
+    ExportedSymbols.init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS);
+    return ExportedSymbols;
+  }
   virtual ~DeviceBinaryImage() {}
 
 protected:
@@ -382,7 +388,6 @@ protected:
   DeviceBinaryImage::PropertyRange DeviceLibReqMask;
   DeviceBinaryImage::PropertyRange KernelParamOptInfo;
   DeviceBinaryImage::PropertyRange ProgramMetadata;
-  DeviceBinaryImage::PropertyRange ExportedSymbols;
 };
 
 /// Tries to determine the device binary image foramat. Returns

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -709,6 +709,8 @@ void DeviceBinaryImage::init(pi_device_binary Bin) {
   DeviceLibReqMask.init(Bin, __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK);
   KernelParamOptInfo.init(Bin, __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
   ProgramMetadata.init(Bin, __SYCL_PI_PROPERTY_SET_PROGRAM_METADATA);
+  ExportedSymbols.init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS);
+
 }
 
 } // namespace pi

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -709,7 +709,6 @@ void DeviceBinaryImage::init(pi_device_binary Bin) {
   DeviceLibReqMask.init(Bin, __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK);
   KernelParamOptInfo.init(Bin, __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
   ProgramMetadata.init(Bin, __SYCL_PI_PROPERTY_SET_PROGRAM_METADATA);
-  ExportedSymbols.init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS);
 }
 
 } // namespace pi

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -710,7 +710,6 @@ void DeviceBinaryImage::init(pi_device_binary Bin) {
   KernelParamOptInfo.init(Bin, __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
   ProgramMetadata.init(Bin, __SYCL_PI_PROPERTY_SET_PROGRAM_METADATA);
   ExportedSymbols.init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS);
-
 }
 
 } // namespace pi

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1059,6 +1059,12 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
       KernelSetId KSId = getNextKernelSetId();
       {
         std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
+
+        // Register all exported symbols
+        auto ExportedSymbols = Img->getExportedSymbols();
+        for (const pi_device_binary_property &ExportedSymbol : ExportedSymbols)
+          m_ExportedSymbols.insert(ExportedSymbol->Name);
+
         for (_pi_offload_entry EntriesIt = EntriesB; EntriesIt != EntriesE;
              ++EntriesIt) {
           auto Result = KSIdMap.insert(std::make_pair(EntriesIt->name, KSId));
@@ -1073,6 +1079,13 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
             m_ServiceKernels.insert(EntriesIt->name);
             continue;
           }
+
+          // Skip creating unique kernel ID if it is an exported device
+          // function. Exported device functions appear in the offload entries
+          // among kernels, but are identifiable by being listed in properties.
+          if (m_ExportedSymbols.find(EntriesIt->name) !=
+              m_ExportedSymbols.end())
+            continue;
 
           // ... and create a unique kernel ID for the entry
           std::shared_ptr<detail::kernel_id_impl> KernelIDImpl =
@@ -1373,9 +1386,11 @@ ProgramManager::getSYCLDeviceImagesWithCompatibleState(
           auto KernelID = m_KernelIDs.find(EntriesIt->name);
 
           if (KernelID == m_KernelIDs.end()) {
-            // Service kernels do not have kernel IDs
-            assert(m_ServiceKernels.find(EntriesIt->name) !=
-                       m_ServiceKernels.end() &&
+            // Service kernels and exported symbols do not have kernel IDs
+            assert((m_ServiceKernels.find(EntriesIt->name) !=
+                        m_ServiceKernels.end() ||
+                    m_ExportedSymbols.find(EntriesIt->name) !=
+                        m_ExportedSymbols.end()) &&
                    "Kernel ID in device binary missing from cache");
             continue;
           }

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -299,6 +299,11 @@ private:
   /// Access must be guarded by the m_KernelIDsMutex mutex.
   std::unordered_set<std::string> m_ServiceKernels;
 
+  /// Caches all exported symbols to allow faster lookup when excluding these
+  // from kernel bundles.
+  /// Access must be guarded by the m_KernelIDsMutex mutex.
+  std::unordered_set<std::string> m_ExportedSymbols;
+
   // Keeps track of pi_program to image correspondence. Needed for:
   // - knowing which specialization constants are used in the program and
   //   injecting their current values before compiling the SPIR-V; the binary


### PR DESCRIPTION
Because exported device functions are interspersed with kernels in the offload entries they are thought to be kernels in device images. These changes use the list of exported symbols generated by sycl-post-link to filter out the exported device functions when creating device images.