### PR TITLE
[SYCL] Fix an error on host when big image is used on opencl:gpu

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -668,32 +668,82 @@ inline cl_uint get_device_info_host<info::device::max_write_image_args>() {
 
 template <>
 inline size_t get_device_info_host<info::device::image2d_max_width>() {
-  // current value is the required minimum
-  return 8192;
+  // SYCL guarantees at least 8192. Some devices already known to provide more
+  // than that (i.e. it is 16384 for opencl:gpu), which may create issues during
+  // image object allocation on host.
+  // Using any fixed number (i.e. 16384) brings the risk of having similar
+  // issues on newer devices in future. Thus it does not make sense limiting
+  // the returned value on host. Practially speaking the returned value on host
+  // depends only on memory required for the image, which also depends on
+  // the image channel_type and the image height. Both are not known in this
+  // query, thus it becomes user's responsibility to choose proper image
+  // parameters depending on similar query to (non-host device) and amount
+  // of available/allocatable memory.
+  return INT_MAX;
 }
 
 template <>
 inline size_t get_device_info_host<info::device::image2d_max_height>() {
-  // current value is the required minimum
-  return 8192;
+  // SYCL guarantees at least 8192. Some devices already known to provide more
+  // than that (i.e. it is 16384 for opencl:gpu), which may create issues during
+  // image object allocation on host.
+  // Using any fixed number (i.e. 16384) brings the risk of having similar
+  // issues on newer devices in future. Thus it does not make sense limiting
+  // the returned value on host. Practially speaking the returned value on host
+  // depends only on memory required for the image, which also depends on
+  // the image channel_type and the image width. Both are not known in this
+  // query, thus it becomes user's responsibility to choose proper image
+  // parameters depending on similar query to (non-host device) and amount
+  // of available/allocatable memory.
+  return INT_MAX;
 }
 
 template <>
 inline size_t get_device_info_host<info::device::image3d_max_width>() {
-  // current value is the required minimum
-  return 2048;
+  // SYCL guarantees at least 8192. Some devices already known to provide more
+  // than that (i.e. it is 16384 for opencl:gpu), which may create issues during
+  // image object allocation on host.
+  // Using any fixed number (i.e. 16384) brings the risk of having similar
+  // issues on newer devices in future. Thus it does not make sense limiting
+  // the returned value on host. Practially speaking the returned value on host
+  // depends only on memory required for the image, which also depends on
+  // the image channel_type and the image height/depth. Both are not known
+  // in this query, thus it becomes user's responsibility to choose proper image
+  // parameters depending on similar query to (non-host device) and amount
+  // of available/allocatable memory.
+  return INT_MAX;
 }
 
 template <>
 inline size_t get_device_info_host<info::device::image3d_max_height>() {
-  // current value is the required minimum
-  return 2048;
+  // SYCL guarantees at least 8192. Some devices already known to provide more
+  // than that (i.e. it is 16384 for opencl:gpu), which may create issues during
+  // image object allocation on host.
+  // Using any fixed number (i.e. 16384) brings the risk of having similar
+  // issues on newer devices in future. Thus it does not make sense limiting
+  // the returned value on host. Practially speaking the returned value on host
+  // depends only on memory required for the image, which also depends on
+  // the image channel_type and the image width/depth. Both are not known
+  // in this query, thus it becomes user's responsibility to choose proper image
+  // parameters depending on similar query to (non-host device) and amount
+  // of available/allocatable memory.
+  return INT_MAX;
 }
 
 template <>
 inline size_t get_device_info_host<info::device::image3d_max_depth>() {
-  // current value is the required minimum
-  return 2048;
+  // SYCL guarantees at least 8192. Some devices already known to provide more
+  // than that (i.e. it is 16384 for opencl:gpu), which may create issues during
+  // image object allocation on host.
+  // Using any fixed number (i.e. 16384) brings the risk of having similar
+  // issues on newer devices in future. Thus it does not make sense limiting
+  // the returned value on host. Practially speaking the returned value on host
+  // depends only on memory required for the image, which also depends on
+  // the image channel_type and the image height/width, which are not known
+  // in this query, thus it becomes user's responsibility to choose proper image
+  // parameters depending on similar query to (non-host device) and amount
+  // of available/allocatable memory.
+  return INT_MAX;
 }
 
 template <>

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -329,7 +329,7 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
           getDevices(Context), Desc.image_width))
     throw invalid_parameter_error(
         "For a 1D/2D image/image array, the width must be a Value >= 1 and "
-        "<= CL_DEVICE_IMAGE2D_MAX_WIDTH.",
+        "<= info::device::image2d_max_width",
         PI_INVALID_VALUE);
 
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE3D) &&
@@ -337,7 +337,7 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
           getDevices(Context), Desc.image_width))
     throw invalid_parameter_error(
         "For a 3D image, the width must be a Value >= 1 and <= "
-        "CL_DEVICE_IMAGE3D_MAX_WIDTH",
+        "info::device::image3d_max_width",
         PI_INVALID_VALUE);
 
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE2D,
@@ -346,7 +346,7 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
           getDevices(Context), Desc.image_height))
     throw invalid_parameter_error("For a 2D image or image array, the height "
                                   "must be a Value >= 1 and <= "
-                                  "CL_DEVICE_IMAGE2D_MAX_HEIGHT",
+                                  "info::device::image2d_max_height",
                                   PI_INVALID_VALUE);
 
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE3D) &&
@@ -354,7 +354,7 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
           getDevices(Context), Desc.image_height))
     throw invalid_parameter_error(
         "For a 3D image, the heightmust be a Value >= 1 and <= "
-        "CL_DEVICE_IMAGE3D_MAX_HEIGHT",
+        "info::device::image3d_max_height",
         PI_INVALID_VALUE);
 
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE3D) &&
@@ -362,7 +362,7 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
           getDevices(Context), Desc.image_depth))
     throw invalid_parameter_error(
         "For a 3D image, the depth must be a Value >= 1 and <= "
-        "CL_DEVICE_IMAGE3D_MAX_DEPTH",
+        "info::device::image2d_max_depth",
         PI_INVALID_VALUE);
 
   if (checkAny(Desc.image_type, PI_MEM_TYPE_IMAGE1D_ARRAY,
@@ -371,7 +371,7 @@ bool image_impl<Dimensions>::checkImageDesc(const RT::PiMemImageDesc &Desc,
           getDevices(Context), Desc.image_array_size))
     throw invalid_parameter_error(
         "For a 1D and 2D image array, the array_size must be a "
-        "Value >= 1 and <= CL_DEVICE_IMAGE_MAX_ARRAY_SIZE.",
+        "Value >= 1 and <= info::device::image_max_array_size.",
         PI_INVALID_VALUE);
 
   if ((nullptr == UserPtr) && (0 != Desc.image_row_pitch))


### PR DESCRIPTION
An exception was thrown on host because during the host allocation
the image seemed too big for host even though the target device
could process such big image. Because the limits to image height,
width,depth are arbitrary on HOST, they have been relaxed to MAX_INT.

The existing check for image sizes is still sufficient when image
is passed to device because the image parameters are verified twice:
one time for host and another time for device.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>