### PR TITLE
[SYCL] device::create_sub_devices exceptions conform to SYCL 2020 spec.  

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -114,7 +114,7 @@ static inline std::string codeToString(cl_int code) {
 
 #ifndef SYCL_SUPPRESS_EXCEPTIONS
 #include <CL/sycl/exception.hpp>
-
+// SYCL 1.2.1 exceptions
 #define __SYCL_REPORT_OCL_ERR_TO_EXC(expr, exc)                                \
   {                                                                            \
     auto code = expr;                                                          \
@@ -132,16 +132,35 @@ static inline std::string codeToString(cl_int code) {
 #define __SYCL_REPORT_OCL_ERR_TO_EXC_BASE(code)                                \
   __SYCL_REPORT_OCL_ERR_TO_STREAM(code)
 #endif
+// SYCL 2020 exceptions
+#define __SYCL_REPORT_OCL_ERR_TO_EXC_VIA_ERRC(expr, errc)                      \
+  {                                                                            \
+    auto code = expr;                                                          \
+    if (code != CL_SUCCESS) {                                                  \
+      throw sycl::exception(sycl::make_error_code(errc),                       \
+                            __SYCL_OCL_ERROR_REPORT +                          \
+                                cl::sycl::detail::codeToString(code));         \
+    }                                                                          \
+  }
+#define __SYCL_REPORT_OCL_ERR_TO_EXC_THROW_VIA_ERRC(code, errc)                \
+  __SYCL_REPORT_OCL_ERR_TO_EXC_VIA_ERRC(code, errc)
 
 #ifdef __SYCL_SUPPRESS_OCL_ERROR_REPORT
+// SYCL 1.2.1 exceptions
 #define __SYCL_CHECK_OCL_CODE(X) (void)(X)
 #define __SYCL_CHECK_OCL_CODE_THROW(X, EXC) (void)(X)
 #define __SYCL_CHECK_OCL_CODE_NO_EXC(X) (void)(X)
+// SYCL 2020 exceptions
+#define __SYCL_CHECK_OCL_CODE_THROW_VIA_ERRC(X, ERRC) (void)(X)
 #else
+// SYCL 1.2.1 exceptions
 #define __SYCL_CHECK_OCL_CODE(X) __SYCL_REPORT_OCL_ERR_TO_EXC_BASE(X)
 #define __SYCL_CHECK_OCL_CODE_THROW(X, EXC)                                    \
   __SYCL_REPORT_OCL_ERR_TO_EXC_THROW(X, EXC)
 #define __SYCL_CHECK_OCL_CODE_NO_EXC(X) __SYCL_REPORT_OCL_ERR_TO_STREAM(X)
+// SYCL 2020 exceptions
+#define __SYCL_CHECK_OCL_CODE_THROW_VIA_ERRC(X, ERRC)                          \
+  __SYCL_REPORT_OCL_ERR_TO_EXC_THROW_VIA_ERRC(X, ERRC)
 #endif
 
 __SYCL_INLINE_NAMESPACE(cl) {

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -132,7 +132,7 @@ device_impl::create_sub_devices(const cl_device_partition_property *Properties,
   std::vector<RT::PiDevice> SubDevices(SubDevicesCount);
   pi_uint32 ReturnedSubDevices = 0;
   const detail::plugin &Plugin = getPlugin();
-  Plugin.call<cl::sycl::device_error, PiApiKind::piDevicePartition>(
+  Plugin.call<sycl::errc::invalid, PiApiKind::piDevicePartition>(
       MDevice, Properties, SubDevicesCount, SubDevices.data(),
       &ReturnedSubDevices);
   // TODO: check that returned number of sub-devices matches what was

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -132,9 +132,9 @@ device_impl::create_sub_devices(const cl_device_partition_property *Properties,
   std::vector<RT::PiDevice> SubDevices(SubDevicesCount);
   pi_uint32 ReturnedSubDevices = 0;
   const detail::plugin &Plugin = getPlugin();
-  Plugin.call<PiApiKind::piDevicePartition>(MDevice, Properties,
-                                            SubDevicesCount, SubDevices.data(),
-                                            &ReturnedSubDevices);
+  Plugin.call<cl::sycl::device_error, PiApiKind::piDevicePartition>(
+      MDevice, Properties, SubDevicesCount, SubDevices.data(),
+      &ReturnedSubDevices);
   // TODO: check that returned number of sub-devices matches what was
   // requested, otherwise this walk below is wrong.
   //

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -179,6 +179,14 @@ public:
     checkPiResult(Err);
   }
 
+  // CP - #1
+  /// \throw exception subclass Exception if the call was not successful.
+  template <typename Exception, PiApiKind PiApiOffset, typename... ArgsT>
+  void call(ArgsT... Args) const {
+    RT::PiResult Err = call_nocheck<PiApiOffset>(Args...);
+    checkPiResult<Exception>(Err);
+  }
+
   backend getBackend(void) const { return MBackend; }
   void *getLibraryHandle() const { return MLibraryHandle; }
   void *getLibraryHandle() { return MLibraryHandle; }

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -112,6 +112,11 @@ public:
     __SYCL_CHECK_OCL_CODE_THROW(pi_result, Exception);
   }
 
+  /// \throw SYCL 2020 exception(errc) if pi_result is not PI_SUCCESS
+  template <sycl::errc errc> void checkPiResult(RT::PiResult pi_result) const {
+    __SYCL_CHECK_OCL_CODE_THROW_VIA_ERRC(pi_result, errc);
+  }
+
   void reportPiError(RT::PiResult pi_result, const char *context) const {
     if (pi_result != PI_SUCCESS) {
       throw cl::sycl::runtime_error(
@@ -179,12 +184,11 @@ public:
     checkPiResult(Err);
   }
 
-  // CP - #1
-  /// \throw exception subclass Exception if the call was not successful.
-  template <typename Exception, PiApiKind PiApiOffset, typename... ArgsT>
+  /// \throw sycl::exceptions(errc) if the call was not successful.
+  template <sycl::errc errc, PiApiKind PiApiOffset, typename... ArgsT>
   void call(ArgsT... Args) const {
     RT::PiResult Err = call_nocheck<PiApiOffset>(Args...);
-    checkPiResult<Exception>(Err);
+    checkPiResult<errc>(Err);
   }
 
   backend getBackend(void) const { return MBackend; }


### PR DESCRIPTION
According to the SYCL 2020 spec `device::create_sub_devices` should throw an exception with either `errc::feature_not_supported` or `errc::invalid` error codes.  The `feature_not_supported` side is working fine. But for invalid values, we presently just lean on the default exception thrown by `plugin::call()` which is always a `runtime_error`  exception subclass. Here we are adding new specializations for `plugin::call()` and `plugin::checkPiResult` that accept `sycl::errc` values and using those specializations from `device::create_sub_devices()` 