### PR TITLE
[SYCL] Make kernel_bundle interop more conformant

### DIFF
--- a/sycl/include/CL/sycl/backend/opencl.hpp
+++ b/sycl/include/CL/sycl/backend/opencl.hpp
@@ -16,6 +16,8 @@
 #include <CL/sycl/detail/cl.h>
 #include <CL/sycl/kernel_bundle.hpp>
 
+#include <vector>
+
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
@@ -75,8 +77,7 @@ struct BackendInput<backend::opencl, kernel_bundle<State>> {
 
 template <bundle_state State>
 struct BackendReturn<backend::opencl, kernel_bundle<State>> {
-  // TODO: Per SYCL 2020 this should be std::vector<cl_program>
-  using type = cl_program;
+  using type = std::vector<cl_program>;
 };
 
 template <> struct BackendInput<backend::opencl, kernel> {

--- a/sycl/include/CL/sycl/kernel_bundle.hpp
+++ b/sycl/include/CL/sycl/kernel_bundle.hpp
@@ -311,10 +311,9 @@ public:
 
   template <backend Backend>
   __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  std::vector<typename backend_traits<Backend>::template return_type<
-      kernel_bundle<State>>> get_native() {
-    std::vector<typename backend_traits<Backend>::template return_type<
-        kernel_bundle<State>>>
+  typename backend_traits<Backend>::template return_type<
+      kernel_bundle<State>> get_native() const {
+    typename backend_traits<Backend>::template return_type<kernel_bundle<State>>
         ReturnValue;
     ReturnValue.reserve(std::distance(begin(), end()));
 

--- a/sycl/include/CL/sycl/kernel_bundle.hpp
+++ b/sycl/include/CL/sycl/kernel_bundle.hpp
@@ -311,20 +311,8 @@ public:
 
   template <backend Backend>
   __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  typename backend_traits<Backend>::template return_type<
-      kernel_bundle<State>> get_native() const {
-    typename backend_traits<Backend>::template return_type<kernel_bundle<State>>
-        ReturnValue;
-    ReturnValue.reserve(std::distance(begin(), end()));
-
-    for (const device_image<State> &DevImg : *this) {
-      ReturnValue.push_back(
-          detail::pi::cast<typename backend_traits<
-              Backend>::template return_type<kernel_bundle<State>>>(
-              DevImg.getNative()));
-    }
-
-    return ReturnValue;
+  auto get_native() const -> backend_return_t<Backend, kernel_bundle<State>> {
+    return getNative<Backend>();
   }
 
 private:


### PR DESCRIPTION
Mark kernel bundle's `get_native` as `const` to fix `sycl::get_native` compilation issues, fix incorrect kernel bundle trait.
Tests: https://github.com/intel/llvm-test-suite/pull/489