### PR TITLE
[SYCL] Tie BoundArch to Toolchain 

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -60,6 +60,7 @@
 #include "clang/Driver/Tool.h"
 #include "clang/Driver/ToolChain.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringExtras.h"
@@ -681,21 +682,22 @@ static bool isValidSYCLTriple(llvm::Triple T) {
   return true;
 }
 
-static void addSYCLDefaultTriple(Compilation &C,
+static bool addSYCLDefaultTriple(Compilation &C,
                                  SmallVectorImpl<llvm::Triple> &SYCLTriples) {
   if (!C.getDriver().isSYCLDefaultTripleImplied())
-    return;
+    return false;
   for (const auto &SYCLTriple : SYCLTriples) {
     if (SYCLTriple.getSubArch() == llvm::Triple::NoSubArch &&
         SYCLTriple.isSPIR())
-      return;
+      return false;
     // If we encounter a known non-spir* target, do not add the default triple.
     if (SYCLTriple.isNVPTX() || SYCLTriple.isAMDGCN())
-      return;
+      return false;
   }
   // Add the default triple as it was not found.
   llvm::Triple DefaultTriple = C.getDriver().MakeSYCLDeviceTriple("spir64");
   SYCLTriples.insert(SYCLTriples.begin(), DefaultTriple);
+  return true;
 }
 
 void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
@@ -3986,8 +3988,26 @@ class OffloadingActionBuilder final {
     /// Flag to signal if the user requested device code split.
     bool DeviceCodeSplit = false;
 
+    /// List of offload device toolchain, bound arch needed to track for
+    /// different binary constructions.
+    /// POD to hold information about a SYCL device action.
+    /// Each Action is bound to a <TC, arch> pair,
+    /// we keep them together under a struct for clarity.
+    struct DeviceTargetInfo {
+      DeviceTargetInfo(const ToolChain *TC, const char *BA)
+          : TC(TC), BoundArch(BA) {}
+
+      const ToolChain *TC;
+      const char *BoundArch;
+    };
+    SmallVector<DeviceTargetInfo, 4> SYCLTargetInfoList;
+
     /// The SYCL actions for the current input.
-    ActionList SYCLDeviceActions;
+    /// One action per triple/boundarch.
+    SmallVector<Action *, 4> SYCLDeviceActions;
+
+    /// The liker inputs obtained for each input/toolchain/arch.
+    SmallVector<ActionList, 4> DeviceLinkerInputs;
 
     /// The SYCL link binary if it was generated for the current input.
     Action *SYCLLinkBinary = nullptr;
@@ -3998,14 +4018,8 @@ class OffloadingActionBuilder final {
     /// SYCL ahead of time compilation inputs
     SmallVector<std::pair<llvm::Triple, const char *>, 8> SYCLAOTInputs;
 
-    /// The linker inputs obtained for each toolchain.
-    SmallVector<ActionList, 8> DeviceLinkerInputs;
-
-    /// The compiler inputs obtained for each toolchain
-    Action * DeviceCompilerInput = nullptr;
-
-    /// List of offload device triples needed to track for different toolchain
-    /// construction. Does not track AOT binary inputs triples.
+    /// List of offload device triples as provided on the CLI.
+    /// Does not track AOT binary inputs triples.
     SmallVector<llvm::Triple, 4> SYCLTripleList;
 
     /// Type of output file for FPGA device compilation.
@@ -4019,7 +4033,7 @@ class OffloadingActionBuilder final {
 
     /// List of GPU architectures to use in this compilation with NVPTX/AMDGCN
     /// targets.
-    SmallVector<std::pair<llvm::Triple, std::string>, 8> GpuArchList;
+    SmallVector<std::pair<llvm::Triple, const char *>, 8> GpuArchList;
 
     /// Build the last steps for CUDA after all BC files have been linked.
     JobAction *finalizeNVPTXDependences(Action *Input, const llvm::Triple &TT) {
@@ -4060,7 +4074,7 @@ class OffloadingActionBuilder final {
                                    llvm::function_ref<void(const char *)> Op) {
       for (auto &A : GpuArchList) {
         if (TC->getTriple() == A.first) {
-          Op(Args.MakeArgString(A.second.c_str()));
+          Op(Args.MakeArgString(A.second));
           return;
         }
       }
@@ -4100,33 +4114,31 @@ class OffloadingActionBuilder final {
 
       // Device compilation generates LLVM BC.
       if (CurPhase == phases::Compile) {
-        for (Action *&A : SYCLDeviceActions) {
-          types::ID OutputType = types::TY_LLVM_BC;
-          if ((SYCLDeviceOnly || Args.hasArg(options::OPT_emit_llvm)) &&
-              Args.hasArg(options::OPT_S))
-            OutputType = types::TY_LLVM_IR;
-          if (SYCLDeviceOnly) {
-            if (Args.hasFlag(options::OPT_fno_sycl_use_bitcode,
-                             options::OPT_fsycl_use_bitcode, false)) {
-              auto *CompileAction =
-                  C.MakeAction<CompileJobAction>(A, types::TY_LLVM_BC);
-              A = C.MakeAction<SPIRVTranslatorJobAction>(CompileAction,
-                                                         types::TY_SPIRV);
-              continue;
+        if (!SYCLTargetInfoList.empty()) {
+          Action *DeviceCompilerInput = nullptr;
+          for (Action *&A : SYCLDeviceActions) {
+            types::ID OutputType = types::TY_LLVM_BC;
+            if ((SYCLDeviceOnly || Args.hasArg(options::OPT_emit_llvm)) &&
+                Args.hasArg(options::OPT_S))
+              OutputType = types::TY_LLVM_IR;
+            if (SYCLDeviceOnly) {
+              if (Args.hasFlag(options::OPT_fno_sycl_use_bitcode,
+                               options::OPT_fsycl_use_bitcode, false)) {
+                auto *CompileAction =
+                    C.MakeAction<CompileJobAction>(A, types::TY_LLVM_BC);
+                A = C.MakeAction<SPIRVTranslatorJobAction>(CompileAction,
+                                                           types::TY_SPIRV);
+                continue;
+              }
             }
+            A = C.MakeAction<CompileJobAction>(A, OutputType);
+            DeviceCompilerInput = A;
           }
-          A = C.MakeAction<CompileJobAction>(A, OutputType);
-          DeviceCompilerInput = A;
+          const DeviceTargetInfo &DevTarget = SYCLTargetInfoList.back();
+          DA.add(*DeviceCompilerInput, *DevTarget.TC, DevTarget.BoundArch,
+                 Action::OFK_SYCL);
+          return SYCLDeviceOnly ? ABRT_Ignore_Host : ABRT_Success;
         }
-        const auto *TC = ToolChains.front();
-        const char *BoundArch = nullptr;
-        if (TC->getTriple().isNVPTX() || TC->getTriple().isAMDGCN())
-          BoundArch = GpuArchList.front().second.c_str();
-        DA.add(*DeviceCompilerInput, *TC, BoundArch, Action::OFK_SYCL);
-        // Clear the input file, it is already a dependence to a host
-        // action.
-        DeviceCompilerInput = nullptr;
-        return SYCLDeviceOnly ? ABRT_Ignore_Host : ABRT_Success;
       }
 
       // Backend/Assemble actions are obsolete for the SYCL device side
@@ -4136,12 +4148,17 @@ class OffloadingActionBuilder final {
       // The host only depends on device action in the linking phase, when all
       // the device images have to be embedded in the host image.
       if (CurPhase == phases::Link) {
-        assert(ToolChains.size() == DeviceLinkerInputs.size() &&
-               "Toolchains and linker inputs sizes do not match.");
-        auto LI = DeviceLinkerInputs.begin();
-        for (auto *A : SYCLDeviceActions) {
-          LI->push_back(A);
-          ++LI;
+        if (!SYCLDeviceActions.empty()) {
+          assert(SYCLDeviceActions.size() == DeviceLinkerInputs.size() &&
+                 "Device action and device linker inputs sizes do not match.");
+
+          for (auto TargetAction :
+               llvm::zip(DeviceLinkerInputs, SYCLDeviceActions)) {
+            ActionList &LinkerList = std::get<0>(TargetAction);
+            Action *A = std::get<1>(TargetAction);
+
+            LinkerList.push_back(A);
+          }
         }
 
         // With -fsycl-link-targets, we will take the unbundled binaries
@@ -4247,9 +4264,11 @@ class OffloadingActionBuilder final {
         if (IA->getType() == types::TY_Object && !isObjectFile(InputName))
           return ABRT_Inactive;
 
-        for (unsigned I = 0; I < ToolChains.size(); ++I)
+        for (auto &TargetInfo : SYCLTargetInfoList) {
+          (void)TargetInfo;
           SYCLDeviceActions.push_back(
               C.MakeAction<InputAction>(IA->getInputArg(), IA->getType()));
+        }
         return ABRT_Success;
       }
 
@@ -4280,12 +4299,11 @@ class OffloadingActionBuilder final {
               FPGAObjectInputs.push_back(IA);
           }
         }
-        for (unsigned I = 0; I < ToolChains.size(); ++I) {
+        // Create 1 device action per triple/bound arch
+        for (auto &TargetInfo : SYCLTargetInfoList) {
           SYCLDeviceActions.push_back(UA);
-          withBoundArchForToolChain(ToolChains[I], [&](const char *BoundArch) {
-            UA->registerDependentActionInfo(ToolChains[I], BoundArch,
-                                            Action::OFK_SYCL);
-          });
+          UA->registerDependentActionInfo(TargetInfo.TC, TargetInfo.BoundArch,
+                                          Action::OFK_SYCL);
         }
         return ABRT_Success;
       }
@@ -4312,18 +4330,19 @@ class OffloadingActionBuilder final {
         return;
 
       // We should always have an action for each input.
-      assert(SYCLDeviceActions.size() == ToolChains.size() &&
-             "Number of SYCL actions and toolchains do not match.");
+      assert(SYCLDeviceActions.size() == SYCLTargetInfoList.size() &&
+             "Number of SYCL actions and toolchains/boundarch pairs do not "
+             "match.");
 
       // Append all device actions followed by the proper offload action.
-      auto TI = ToolChains.begin();
-      for (auto *A : SYCLDeviceActions) {
+      for (auto TargetActionInfo :
+           llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
+        Action *A = std::get<0>(TargetActionInfo);
+        DeviceTargetInfo &TargetInfo = std::get<1>(TargetActionInfo);
+
         OffloadAction::DeviceDependences Dep;
-        withBoundArchForToolChain(*TI, [&](const char *BoundArch) {
-          Dep.add(*A, **TI, BoundArch, Action::OFK_SYCL);
-        });
+        Dep.add(*A, *TargetInfo.TC, TargetInfo.BoundArch, Action::OFK_SYCL);
         AL.push_back(C.MakeAction<OffloadAction>(Dep, A->getType()));
-        ++TI;
       }
       // We no longer need the action stored in this builder.
       SYCLDeviceActions.clear();
@@ -4428,23 +4447,24 @@ class OffloadingActionBuilder final {
     }
 
     void appendLinkDependences(OffloadAction::DeviceDependences &DA) override {
-      assert(ToolChains.size() == DeviceLinkerInputs.size() &&
-             "Toolchains and linker inputs sizes do not match.");
-
-      // Append a new link action for each device.
-      auto TC = ToolChains.begin();
-
-      unsigned I = 0;
-      for (auto &LI : DeviceLinkerInputs) {
+      // DeviceLinkerInputs holds binaries per ToolChain (TC) / bound-arch pair
+      // The following will loop link and post process for each TC / bound-arch
+      // to produce a final binary.
+      // They will be bundled per TC before being sent to the Offload Wrapper.
+      llvm::MapVector<const ToolChain *, ActionList> LinkedInputs;
+      for (auto LinkInputEnum : enumerate(DeviceLinkerInputs)) {
+        auto &LI = LinkInputEnum.value();
+        const ToolChain *TC = SYCLTargetInfoList[LinkInputEnum.index()].TC;
+        const char *BoundArch =
+            SYCLTargetInfoList[LinkInputEnum.index()].BoundArch;
 
         auto TripleIt = llvm::find_if(SYCLTripleList, [&](auto &SYCLTriple) {
-          return SYCLTriple == (*TC)->getTriple();
+          return SYCLTriple == TC->getTriple();
         });
         if (TripleIt == SYCLTripleList.end()) {
           // If the toolchain's triple is absent in this "main" triple
           // collection, this means it was created specifically for one of
           // the SYCL AOT inputs. Those will be handled separately.
-          ++TC;
           continue;
         }
         if (LI.empty())
@@ -4453,16 +4473,18 @@ class OffloadingActionBuilder final {
 
         ActionList DeviceLibObjects;
         ActionList LinkObjects;
-        auto TT = SYCLTripleList[I];
-        auto isNVPTX = (*TC)->getTriple().isNVPTX();
-        auto isAMDGCN = (*TC)->getTriple().isAMDGCN();
-        auto isSPIR = (*TC)->getTriple().isSPIR();
+        auto TT = TC->getTriple();
+        auto isNVPTX = TC->getTriple().isNVPTX();
+        auto isAMDGCN = TC->getTriple().isAMDGCN();
+        auto isSPIR = TC->getTriple().isSPIR();
         bool isSpirvAOT = TT.getSubArch() == llvm::Triple::SPIRSubArch_fpga ||
                           TT.getSubArch() == llvm::Triple::SPIRSubArch_gen ||
                           TT.getSubArch() == llvm::Triple::SPIRSubArch_x86_64;
         for (const auto &Input : LI) {
           if (TT.getSubArch() == llvm::Triple::SPIRSubArch_fpga &&
               types::isFPGA(Input->getType())) {
+            assert(BoundArch == nullptr &&
+                   "fpga triple bounded arch not nullptr");
             // FPGA aoco does not go through the link, everything else does.
             if (Input->getType() == types::TY_FPGA_AOCO) {
               DeviceLibObjects.push_back(Input);
@@ -4472,11 +4494,11 @@ class OffloadingActionBuilder final {
             // directly to the backend compilation step (aocr) or wrapper (aocx)
             Action *FPGAAOTAction;
             if (Input->getType() == types::TY_FPGA_AOCR ||
-                Input->getType() == types::TY_FPGA_AOCR_EMU)
+                Input->getType() == types::TY_FPGA_AOCR_EMU) {
               // Generate AOCX/AOCR
               FPGAAOTAction =
                   C.MakeAction<BackendCompileJobAction>(Input, FPGAOutType);
-            else if (Input->getType() == types::TY_FPGA_AOCX)
+            } else if (Input->getType() == types::TY_FPGA_AOCX)
               FPGAAOTAction = Input;
             else
               llvm_unreachable("Unexpected FPGA input type.");
@@ -4487,11 +4509,11 @@ class OffloadingActionBuilder final {
                 FileTableTformJobAction::COL_CODE);
             auto *DeviceWrappingAction = C.MakeAction<OffloadWrapperJobAction>(
                 RenameAction, types::TY_Object);
-            DA.add(*DeviceWrappingAction, **TC, /*BoundArch=*/nullptr,
-                   Action::OFK_SYCL);
+            DA.add(*DeviceWrappingAction, *TC, BoundArch, Action::OFK_SYCL);
             continue;
-          } else if (!types::isFPGA(Input->getType()))
+          } else if (!types::isFPGA(Input->getType())) {
             LinkObjects.push_back(Input);
+          }
         }
         if (LinkObjects.empty())
           continue;
@@ -4560,7 +4582,7 @@ class OffloadingActionBuilder final {
         // AOT compilation.
         if (isSPIR) {
           SYCLDeviceLibLinked = addSYCLDeviceLibs(
-              *TC, FullLinkObjects, true,
+              TC, FullLinkObjects, true,
               C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment());
         }
 
@@ -4574,7 +4596,6 @@ class OffloadingActionBuilder final {
         // reflects whether current target is ahead-of-time and can't support
         // runtime setting of specialization constants
         bool isAOT = isNVPTX || isAMDGCN || isSpirvAOT;
-        // TODO support device code split for NVPTX target
 
         ActionList WrapperInputs;
         // post link is not optional - even if not splitting, always need to
@@ -4598,9 +4619,9 @@ class OffloadingActionBuilder final {
         if (isNVPTX || isAMDGCN) {
           JobAction *FinAction =
               isNVPTX ? finalizeNVPTXDependences(ExtractIRFilesAction,
-                                                 (*TC)->getTriple())
+                                                 TC->getTriple())
                       : finalizeAMDGCNDependences(ExtractIRFilesAction,
-                                                  (*TC)->getTriple());
+                                                  TC->getTriple());
           auto *ForEachWrapping = C.MakeAction<ForEachWrappingAction>(
               ExtractIRFilesAction, FinAction);
 
@@ -4663,14 +4684,12 @@ class OffloadingActionBuilder final {
             WrapperInputs, types::TY_Object);
 
         if (isSpirvAOT)
-          DA.add(*DeviceWrappingAction, **TC, /*BoundArch=*/nullptr,
+          DA.add(*DeviceWrappingAction, *TC, /*BoundArch=*/nullptr,
                  Action::OFK_SYCL);
         else
-          withBoundArchForToolChain(*TC, [&](const char *BoundArch) {
-            DA.add(*DeviceWrappingAction, **TC, BoundArch, Action::OFK_SYCL);
+          withBoundArchForToolChain(TC, [&](const char *BoundArch) {
+            DA.add(*DeviceWrappingAction, *TC, BoundArch, Action::OFK_SYCL);
           });
-        ++TC;
-        ++I;
       }
 
       for (auto &SAI : SYCLAOTInputs) {
@@ -4699,15 +4718,12 @@ class OffloadingActionBuilder final {
     }
 
     void addDeviceLinkDependencies(OffloadDepsJobAction *DA) override {
-      for (unsigned I = 0; I < ToolChains.size(); ++I) {
-        // Register dependent toolchain.
-        withBoundArchForToolChain(ToolChains[I], [&](const char *BoundArch) {
-          DA->registerDependentActionInfo(ToolChains[I], BoundArch,
-                                          Action::OFK_SYCL);
-        });
-
-        // Add deps output to linker inputs.
+      unsigned I = 0;
+      for (auto &TargetInfo : SYCLTargetInfoList) {
+        DA->registerDependentActionInfo(TargetInfo.TC, TargetInfo.BoundArch,
+                                        Action::OFK_SYCL);
         DeviceLinkerInputs[I].push_back(DA);
+        I++;
       }
     }
 
@@ -4756,7 +4772,7 @@ class OffloadingActionBuilder final {
         // TODO: Support --no-cuda-gpu-arch, --{,no-}cuda-gpu-arch=all.
         if (ParsedArg &&
             ParsedArg->getOption().matches(options::OPT_offload_arch_EQ)) {
-          llvm::StringRef ArchStr = ParsedArg->getValue(0);
+          const char *ArchStr = ParsedArg->getValue(0);
           if (TargetBE->isNVPTX()) {
             // CUDA arch also applies to AMDGCN ...
             CudaArch Arch = StringToCudaArch(ArchStr);
@@ -4788,7 +4804,7 @@ class OffloadingActionBuilder final {
         if (Triple.isNVPTX() && llvm::none_of(GpuArchList, [&](auto &P) {
               return P.first.isNVPTX();
             })) {
-          llvm::StringRef DefaultArch = CudaArchToString(CudaArch::SM_50);
+          const char *DefaultArch = CudaArchToString(CudaArch::SM_50);
           GpuArchList.emplace_back(Triple, DefaultArch);
         }
 
@@ -4812,6 +4828,10 @@ class OffloadingActionBuilder final {
            ++TI)
         ToolChains.push_back(TI->second);
 
+      // Nothing to offload if no SYCL Toolchain
+      if (ToolChains.empty())
+        return false;
+
       Arg *SYCLLinkTargets = Args.getLastArg(
                                   options::OPT_fsycl_link_targets_EQ);
       WrapDeviceOnlyBinary = Args.hasArg(options::OPT_fsycl_link_EQ);
@@ -4830,8 +4850,10 @@ class OffloadingActionBuilder final {
           options::OPT_fsycl, options::OPT_fno_sycl, false);
       bool SYCLfpgaTriple = false;
       bool ShouldAddDefaultTriple = true;
+      bool GpuInitHasErrors = false;
       if (SYCLTargets || SYCLAddTargets) {
         if (SYCLTargets) {
+          // Fill SYCLTripleList
           llvm::StringMap<StringRef> FoundNormalizedTriples;
           for (const char *Val : SYCLTargets->getValues()) {
             llvm::Triple TT(C.getDriver().MakeSYCLDeviceTriple(Val));
@@ -4850,6 +4872,26 @@ class OffloadingActionBuilder final {
             if (TT.getSubArch() == llvm::Triple::SPIRSubArch_fpga)
               SYCLfpgaTriple = true;
           }
+
+          // Fill GpuArchList, end if there are issues in initializingGpuArchMap
+          GpuInitHasErrors = initializeGpuArchMap();
+          if (GpuInitHasErrors)
+            return true;
+
+          int I = 0;
+          // Fill SYCLTargetInfoList
+          for (auto TT : SYCLTripleList) {
+            auto TCIt = llvm::find_if(
+                ToolChains, [&](auto &TC) { return TT == TC->getTriple(); });
+            assert(TCIt != ToolChains.end() &&
+                   "Toolchain was not created for this platform");
+            if (!TT.isNVPTX() && !TT.isAMDGCN())
+              SYCLTargetInfoList.emplace_back(*TCIt, nullptr);
+            else {
+              SYCLTargetInfoList.emplace_back(*TCIt, GpuArchList[I].second);
+              ++I;
+            }
+          }
         }
         if (SYCLAddTargets) {
           for (StringRef Val : SYCLAddTargets->getValues()) {
@@ -4859,8 +4901,13 @@ class OffloadingActionBuilder final {
             // into the final binary.
             std::pair<StringRef, StringRef> I = Val.split(':');
             llvm::Triple TT(I.first);
-            const char *TF = C.getArgs().MakeArgString(I.second);
 
+            auto TCIt = llvm::find_if(
+                ToolChains, [&](auto &TC) { return TT == TC->getTriple(); });
+            assert(TCIt != ToolChains.end() &&
+                   "Toolchain was not created for this platform");
+
+            const char *TF = C.getArgs().MakeArgString(I.second);
             // populate the AOT binary inputs vector.
             SYCLAOTInputs.push_back(std::make_pair(TT, TF));
             ShouldAddDefaultTriple = false;
@@ -4871,8 +4918,13 @@ class OffloadingActionBuilder final {
         bool SYCLfpga = C.getInputArgs().hasArg(options::OPT_fintelfpga);
         // -fsycl -fintelfpga implies spir64_fpga
         const char *SYCLTargetArch = SYCLfpga ? "spir64_fpga" : "spir64";
-        SYCLTripleList.push_back(
-            C.getDriver().MakeSYCLDeviceTriple(SYCLTargetArch));
+        llvm::Triple TT = C.getDriver().MakeSYCLDeviceTriple(SYCLTargetArch);
+        auto TCIt = llvm::find_if(
+            ToolChains, [&](auto &TC) { return TT == TC->getTriple(); });
+        assert(TCIt != ToolChains.end() &&
+               "Toolchain was not created for this platform");
+        SYCLTripleList.push_back(TT);
+        SYCLTargetInfoList.emplace_back(*TCIt, nullptr);
         if (SYCLfpga)
           SYCLfpgaTriple = true;
       }
@@ -4908,11 +4960,25 @@ class OffloadingActionBuilder final {
         }
       }
 
-      DeviceLinkerInputs.resize(ToolChains.size());
-      bool GpuInitHasErrors = initializeGpuArchMap();
-      if (ShouldAddDefaultTriple)
-        addSYCLDefaultTriple(C, SYCLTripleList);
-      return GpuInitHasErrors;
+      if (ShouldAddDefaultTriple) {
+        if (addSYCLDefaultTriple(C, SYCLTripleList)) {
+          // If a SYCLDefaultTriple is added to SYCLTripleList,
+          // add new target to SYCLTargetInfoList
+          llvm::Triple TT = SYCLTripleList.front();
+          auto TCIt = llvm::find_if(
+              ToolChains, [&](auto &TC) { return TT == TC->getTriple(); });
+          SYCLTargetInfoList.emplace_back(*TCIt, nullptr);
+        }
+      }
+      if (SYCLTargetInfoList.empty()) {
+        // If there are no SYCL Targets add the front toolchain, this is for
+        // `-fsycl-device-only` is provided with no `fsycl` or when all dummy
+        // targets are given
+        const auto *TC = ToolChains.front();
+        SYCLTargetInfoList.emplace_back(TC, nullptr);
+      }
+      DeviceLinkerInputs.resize(SYCLTargetInfoList.size());
+      return false;
     }
 
     bool canUseBundlerUnbundler() const override {
@@ -6947,12 +7013,12 @@ InputInfo Driver::BuildJobsForActionNoCache(
       llvm::errs() << "] \n";
     }
   } else {
-    if (UnbundlingResults.empty())
+    if (UnbundlingResults.empty()) {
       T->ConstructJob(
           C, *JA, Result, InputInfos,
           C.getArgsForToolChain(TC, BoundArch, JA->getOffloadingDeviceKind()),
           LinkingOutput);
-    else
+    } else
       T->ConstructJobMultipleOutputs(
           C, *JA, UnbundlingResults, InputInfos,
           C.getArgsForToolChain(TC, BoundArch, JA->getOffloadingDeviceKind()),

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4007,7 +4007,7 @@ class OffloadingActionBuilder final {
     /// One action per triple/boundarch.
     SmallVector<Action *, 4> SYCLDeviceActions;
 
-    /// The liker inputs obtained for each input/toolchain/arch.
+    /// The linker inputs obtained for each input/toolchain/arch.
     SmallVector<ActionList, 4> DeviceLinkerInputs;
 
     /// The SYCL link binary if it was generated for the current input.

--- a/clang/test/Driver/sycl-offload-with-split.c
+++ b/clang/test/Driver/sycl-offload-with-split.c
@@ -245,7 +245,7 @@
 // CHK-PHASE-MULTI-TARG: 3: input, "[[INPUT]]", c++, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 4: preprocessor, {3}, c++-cpp-output, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 5: compiler, {4}, ir, (device-sycl)
-// CHK-PHASE-MULTI-TARG: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (spir64-unknown-unknown)" {5}, c++-cpp-output
+// CHK-PHASE-MULTI-TARG: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (spir64_gen-unknown-unknown)" {5}, c++-cpp-output
 // CHK-PHASE-MULTI-TARG: 7: compiler, {6}, ir, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 8: backend, {7}, assembler, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 9: assembler, {8}, object, (host-sycl)

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -565,22 +565,19 @@
 // CHK-ADD-TARGETS-REG-MUL: 8: backend, {7}, assembler, (host-sycl)
 // CHK-ADD-TARGETS-REG-MUL: 9: assembler, {8}, object, (host-sycl)
 // CHK-ADD-TARGETS-REG-MUL: 10: linker, {9}, image, (host-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 11: input, "[[INPUT]]", c++, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 12: preprocessor, {11}, c++-cpp-output, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 13: compiler, {12}, ir, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 14: linker, {13}, ir, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 15: sycl-post-link, {14}, tempfiletable, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 16: file-table-tform, {15}, tempfilelist, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 17: llvm-spirv, {16}, tempfilelist, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 18: file-table-tform, {15, 17}, tempfiletable, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 19: clang-offload-wrapper, {18}, object, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 20: input, "dummy.aocx", sycl-fatbin, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 21: clang-offload-wrapper, {20}, object, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 22: input, "dummy_Gen9core.bin", sycl-fatbin, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 23: clang-offload-wrapper, {22}, object, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 24: input, "dummy.ir", sycl-fatbin, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 25: clang-offload-wrapper, {24}, object, (device-sycl)
-// CHK-ADD-TARGETS-REG-MUL: 26: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown)" {19}, "device-sycl (spir64_fpga-unknown-unknown)" {21}, "device-sycl (spir64_gen-unknown-unknown)" {23}, "device-sycl (spir64_x86_64-unknown-unknown)" {25}, image
+// CHK-ADD-TARGETS-REG-MUL: 11: linker, {5}, ir, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 12: sycl-post-link, {11}, tempfiletable, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 13: file-table-tform, {12}, tempfilelist, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 14: llvm-spirv, {13}, tempfilelist, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 15: file-table-tform, {12, 14}, tempfiletable, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 16: clang-offload-wrapper, {15}, object, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 17: input, "dummy.aocx", sycl-fatbin, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 18: clang-offload-wrapper, {17}, object, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 19: input, "dummy_Gen9core.bin", sycl-fatbin, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 20: clang-offload-wrapper, {19}, object, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 21: input, "dummy.ir", sycl-fatbin, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 22: clang-offload-wrapper, {21}, object, (device-sycl)
+// CHK-ADD-TARGETS-REG-MUL: 23: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown)" {16}, "device-sycl (spir64_fpga-unknown-unknown)" {18}, "device-sycl (spir64_gen-unknown-unknown)" {20}, "device-sycl (spir64_x86_64-unknown-unknown)" {22}, image
 
 /// ###########################################################################
 
@@ -833,7 +830,7 @@
 // CHK-PHASE-MULTI-TARG: 3: input, "[[INPUT]]", c++, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 4: preprocessor, {3}, c++-cpp-output, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 5: compiler, {4}, ir, (device-sycl)
-// CHK-PHASE-MULTI-TARG: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (spir64-unknown-unknown)" {5}, c++-cpp-output
+// CHK-PHASE-MULTI-TARG: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (spir64_gen-unknown-unknown)" {5}, c++-cpp-output
 // CHK-PHASE-MULTI-TARG: 7: compiler, {6}, ir, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 8: backend, {7}, assembler, (host-sycl)
 // CHK-PHASE-MULTI-TARG: 9: assembler, {8}, object, (host-sycl)
@@ -865,6 +862,194 @@
 // CHK-PHASE-MULTI-TARG: 35: file-table-tform, {31, 34}, tempfiletable, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 36: clang-offload-wrapper, {35}, object, (device-sycl)
 // CHK-PHASE-MULTI-TARG: 37: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown)" {19}, "device-sycl (spir64_fpga-unknown-unknown)" {29}, "device-sycl (spir64_gen-unknown-unknown)" {36}, image
+
+/// ###########################################################################
+
+/// Verify that triple-boundarch pairs are correct with multi-targetting
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64 -ccc-print-phases %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-PHASE-MULTI-TARG-BOUND-ARCH %s
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 0: input, "[[INPUT:.+\.c]]", c++, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 1: append-footer, {0}, c++, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 2: preprocessor, {1}, c++-cpp-output, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 3: input, "[[INPUT]]", c++, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 4: preprocessor, {3}, c++-cpp-output, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 5: compiler, {4}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (spir64-unknown-unknown)" {5}, c++-cpp-output
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 7: compiler, {6}, ir, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 8: backend, {7}, assembler, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 9: assembler, {8}, object, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 10: linker, {9}, image, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 11: input, "[[INPUT]]", c++, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 12: preprocessor, {11}, c++-cpp-output, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 13: compiler, {12}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 14: linker, {13}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 15: sycl-post-link, {14}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 16: file-table-tform, {15}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 17: backend, {16}, assembler, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 18: assembler, {17}, object, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 19: linker, {17, 18}, cuda-fatbin, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 20: foreach, {16, 19}, cuda-fatbin, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 21: file-table-tform, {15, 20}, tempfiletable, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 22: clang-offload-wrapper, {21}, object, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 23: linker, {5}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 24: input, "{{.*}}libsycl-crt.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 25: clang-offload-unbundler, {24}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 26: input, "{{.*}}libsycl-complex.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 27: clang-offload-unbundler, {26}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 28: input, "{{.*}}libsycl-complex-fp64.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 29: clang-offload-unbundler, {28}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 30: input, "{{.*}}libsycl-cmath.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 31: clang-offload-unbundler, {30}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 32: input, "{{.*}}libsycl-cmath-fp64.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 33: clang-offload-unbundler, {32}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 34: input, "{{.*}}libsycl-fallback-cassert.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 35: clang-offload-unbundler, {34}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 36: input, "{{.*}}libsycl-fallback-cstring.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 37: clang-offload-unbundler, {36}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 38: input, "{{.*}}libsycl-fallback-complex.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 39: clang-offload-unbundler, {38}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 40: input, "{{.*}}libsycl-fallback-complex-fp64.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 41: clang-offload-unbundler, {40}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 42: input, "{{.*}}libsycl-fallback-cmath.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 43: clang-offload-unbundler, {42}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 44: input, "{{.*}}libsycl-fallback-cmath-fp64.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 45: clang-offload-unbundler, {44}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 46: linker, {23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 47: sycl-post-link, {46}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 48: file-table-tform, {47}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 49: llvm-spirv, {48}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 50: file-table-tform, {47, 49}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 51: clang-offload-wrapper, {50}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 52: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {22}, "device-sycl (spir64-unknown-unknown)" {51}, image
+
+/// Check the behaviour however with swapped -fsycl-targets
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64,nvptx64-nvidia-cuda -ccc-print-phases %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED %s
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 0: input, "[[INPUT:.+\.c]]", c++, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 1: append-footer, {0}, c++, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 2: preprocessor, {1}, c++-cpp-output, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 3: input, "[[INPUT]]", c++, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 4: preprocessor, {3}, c++-cpp-output, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 5: compiler, {4}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {5}, c++-cpp-output
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 7: compiler, {6}, ir, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 8: backend, {7}, assembler, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 9: assembler, {8}, object, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 10: linker, {9}, image, (host-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 11: input, "[[INPUT]]", c++, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 12: preprocessor, {11}, c++-cpp-output, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 13: compiler, {12}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 14: linker, {13}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 15: input, "{{.*}}libsycl-crt.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 16: clang-offload-unbundler, {15}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 17: input, "{{.*}}libsycl-complex.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 18: clang-offload-unbundler, {17}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 19: input, "{{.*}}libsycl-complex-fp64.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 20: clang-offload-unbundler, {19}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 21: input, "{{.*}}libsycl-cmath.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 22: clang-offload-unbundler, {21}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 23: input, "{{.*}}libsycl-cmath-fp64.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 24: clang-offload-unbundler, {23}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 25: input, "{{.*}}libsycl-fallback-cassert.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 26: clang-offload-unbundler, {25}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 27: input, "{{.*}}libsycl-fallback-cstring.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 28: clang-offload-unbundler, {27}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 29: input, "{{.*}}libsycl-fallback-complex.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 30: clang-offload-unbundler, {29}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 31: input, "{{.*}}libsycl-fallback-complex-fp64.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 32: clang-offload-unbundler, {31}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 33: input, "{{.*}}libsycl-fallback-cmath.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 34: clang-offload-unbundler, {33}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 35: input, "{{.*}}libsycl-fallback-cmath-fp64.o", object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 36: clang-offload-unbundler, {35}, object
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 37: linker, {14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 38: sycl-post-link, {37}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 39: file-table-tform, {38}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 40: llvm-spirv, {39}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 41: file-table-tform, {38, 40}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 42: clang-offload-wrapper, {41}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 43: linker, {5}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 44: sycl-post-link, {43}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 45: file-table-tform, {44}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 46: backend, {45}, assembler, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 47: assembler, {46}, object, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 48: linker, {46, 47}, cuda-fatbin, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 49: foreach, {45, 48}, cuda-fatbin, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 50: file-table-tform, {44, 49}, tempfiletable, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 51: clang-offload-wrapper, {50}, object, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 52: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown)" {42}, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {51}, image
+
+/// ###########################################################################
+
+// Check if valid bound arch behaviour occurs when compiling for spir-v,nvidia-gpu, and amd-gpu
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64,nvptx-nvidia-cuda,amdgcn-amd-amdhsa -Xsycl-target-backend=nvptx-nvidia-cuda --offload-arch=sm_75 -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908 -ccc-print-phases %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD %s
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 0: input, "[[INPUT:.+\.c]]", c++, (host-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 1: append-footer, {0}, c++, (host-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 2: preprocessor, {1}, c++-cpp-output, (host-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 3: input, "[[INPUT]]", c++, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 4: preprocessor, {3}, c++-cpp-output, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 5: compiler, {4}, ir, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (amdgcn-amd-amdhsa:gfx908)" {5}, c++-cpp-output
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 7: compiler, {6}, ir, (host-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 8: backend, {7}, assembler, (host-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 9: assembler, {8}, object, (host-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 10: linker, {9}, image, (host-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 11: input, "[[INPUT]]", c++, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 12: preprocessor, {11}, c++-cpp-output, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 13: compiler, {12}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 14: linker, {13}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 15: input, "{{.*}}libsycl-crt.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 16: clang-offload-unbundler, {15}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 17: input, "{{.*}}libsycl-complex.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 18: clang-offload-unbundler, {17}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 19: input, "{{.*}}libsycl-complex-fp64.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 20: clang-offload-unbundler, {19}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 21: input, "{{.*}}libsycl-cmath.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 22: clang-offload-unbundler, {21}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 23: input, "{{.*}}libsycl-cmath-fp64.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 24: clang-offload-unbundler, {23}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 25: input, "{{.*}}libsycl-fallback-cassert.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 26: clang-offload-unbundler, {25}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 27: input, "{{.*}}libsycl-fallback-cstring.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 28: clang-offload-unbundler, {27}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 29: input, "{{.*}}libsycl-fallback-complex.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 30: clang-offload-unbundler, {29}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 31: input, "{{.*}}libsycl-fallback-complex-fp64.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 32: clang-offload-unbundler, {31}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 33: input, "{{.*}}libsycl-fallback-cmath.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 34: clang-offload-unbundler, {33}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 35: input, "{{.*}}libsycl-fallback-cmath-fp64.o", object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 36: clang-offload-unbundler, {35}, object
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 37: linker, {14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36}, ir, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 38: sycl-post-link, {37}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 39: file-table-tform, {38}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 40: llvm-spirv, {39}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 41: file-table-tform, {38, 40}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 42: clang-offload-wrapper, {41}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 43: input, "[[INPUT]]", c++, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 44: preprocessor, {43}, c++-cpp-output, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 45: compiler, {44}, ir, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 46: linker, {45}, ir, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 47: sycl-post-link, {46}, ir, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 48: file-table-tform, {47}, ir, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 49: backend, {48}, assembler, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 50: assembler, {49}, object, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 51: linker, {49, 50}, cuda-fatbin, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 52: foreach, {48, 51}, cuda-fatbin, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 53: file-table-tform, {47, 52}, tempfiletable, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 54: clang-offload-wrapper, {53}, object, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 55: linker, {5}, ir, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 56: sycl-post-link, {55}, ir, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 57: file-table-tform, {56}, ir, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 58: backend, {57}, assembler, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 59: assembler, {58}, object, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 60: linker, {59}, image, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 61: linker, {60}, hip-fatbin, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 62: foreach, {57, 61}, hip-fatbin, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 63: file-table-tform, {56, 62}, tempfiletable, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 64: clang-offload-wrapper, {63}, object, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 65: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown)" {42}, "device-sycl (nvptx-nvidia-cuda:sm_75)" {54}, "device-sycl (amdgcn-amd-amdhsa:gfx908)" {64}, image
 
 /// ###########################################################################
 /// Verify that -save-temps does not crash

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -866,7 +866,7 @@
 /// ###########################################################################
 
 /// Verify that triple-boundarch pairs are correct with multi-targetting
-// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64 -ccc-print-phases %s 2>&1 \
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -fsycl-targets=nvptx64-nvidia-cuda,spir64 -ccc-print-phases %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-PHASE-MULTI-TARG-BOUND-ARCH %s
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH: 0: input, "[[INPUT:.+\.c]]", c++, (host-sycl)
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH: 1: append-footer, {0}, c++, (host-sycl)
@@ -892,38 +892,15 @@
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH: 21: file-table-tform, {15, 20}, tempfiletable, (device-sycl, sm_50)
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH: 22: clang-offload-wrapper, {21}, object, (device-sycl, sm_50)
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH: 23: linker, {5}, ir, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 24: input, "{{.*}}libsycl-crt.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 25: clang-offload-unbundler, {24}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 26: input, "{{.*}}libsycl-complex.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 27: clang-offload-unbundler, {26}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 28: input, "{{.*}}libsycl-complex-fp64.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 29: clang-offload-unbundler, {28}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 30: input, "{{.*}}libsycl-cmath.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 31: clang-offload-unbundler, {30}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 32: input, "{{.*}}libsycl-cmath-fp64.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 33: clang-offload-unbundler, {32}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 34: input, "{{.*}}libsycl-fallback-cassert.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 35: clang-offload-unbundler, {34}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 36: input, "{{.*}}libsycl-fallback-cstring.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 37: clang-offload-unbundler, {36}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 38: input, "{{.*}}libsycl-fallback-complex.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 39: clang-offload-unbundler, {38}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 40: input, "{{.*}}libsycl-fallback-complex-fp64.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 41: clang-offload-unbundler, {40}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 42: input, "{{.*}}libsycl-fallback-cmath.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 43: clang-offload-unbundler, {42}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 44: input, "{{.*}}libsycl-fallback-cmath-fp64.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 45: clang-offload-unbundler, {44}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 46: linker, {23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45}, ir, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 47: sycl-post-link, {46}, tempfiletable, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 48: file-table-tform, {47}, tempfilelist, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 49: llvm-spirv, {48}, tempfilelist, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 50: file-table-tform, {47, 49}, tempfiletable, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 51: clang-offload-wrapper, {50}, object, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 52: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {22}, "device-sycl (spir64-unknown-unknown)" {51}, image
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 24: sycl-post-link, {23}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 25: file-table-tform, {24}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 26: llvm-spirv, {25}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 27: file-table-tform, {24, 26}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 28: clang-offload-wrapper, {27}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH: 29: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {22}, "device-sycl (spir64-unknown-unknown)" {28}, image
 
 /// Check the behaviour however with swapped -fsycl-targets
-// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64,nvptx64-nvidia-cuda -ccc-print-phases %s 2>&1 \
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64,nvptx64-nvidia-cuda -ccc-print-phases %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED %s
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 0: input, "[[INPUT:.+\.c]]", c++, (host-sycl)
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 1: append-footer, {0}, c++, (host-sycl)
@@ -940,49 +917,26 @@
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 12: preprocessor, {11}, c++-cpp-output, (device-sycl)
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 13: compiler, {12}, ir, (device-sycl)
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 14: linker, {13}, ir, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 15: input, "{{.*}}libsycl-crt.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 16: clang-offload-unbundler, {15}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 17: input, "{{.*}}libsycl-complex.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 18: clang-offload-unbundler, {17}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 19: input, "{{.*}}libsycl-complex-fp64.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 20: clang-offload-unbundler, {19}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 21: input, "{{.*}}libsycl-cmath.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 22: clang-offload-unbundler, {21}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 23: input, "{{.*}}libsycl-cmath-fp64.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 24: clang-offload-unbundler, {23}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 25: input, "{{.*}}libsycl-fallback-cassert.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 26: clang-offload-unbundler, {25}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 27: input, "{{.*}}libsycl-fallback-cstring.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 28: clang-offload-unbundler, {27}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 29: input, "{{.*}}libsycl-fallback-complex.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 30: clang-offload-unbundler, {29}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 31: input, "{{.*}}libsycl-fallback-complex-fp64.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 32: clang-offload-unbundler, {31}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 33: input, "{{.*}}libsycl-fallback-cmath.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 34: clang-offload-unbundler, {33}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 35: input, "{{.*}}libsycl-fallback-cmath-fp64.o", object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 36: clang-offload-unbundler, {35}, object
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 37: linker, {14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36}, ir, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 38: sycl-post-link, {37}, tempfiletable, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 39: file-table-tform, {38}, tempfilelist, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 40: llvm-spirv, {39}, tempfilelist, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 41: file-table-tform, {38, 40}, tempfiletable, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 42: clang-offload-wrapper, {41}, object, (device-sycl)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 43: linker, {5}, ir, (device-sycl, sm_50)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 44: sycl-post-link, {43}, ir, (device-sycl, sm_50)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 45: file-table-tform, {44}, ir, (device-sycl, sm_50)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 46: backend, {45}, assembler, (device-sycl, sm_50)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 47: assembler, {46}, object, (device-sycl, sm_50)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 48: linker, {46, 47}, cuda-fatbin, (device-sycl, sm_50)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 49: foreach, {45, 48}, cuda-fatbin, (device-sycl, sm_50)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 50: file-table-tform, {44, 49}, tempfiletable, (device-sycl, sm_50)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 51: clang-offload-wrapper, {50}, object, (device-sycl, sm_50)
-// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 52: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown)" {42}, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {51}, image
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 15: sycl-post-link, {14}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 16: file-table-tform, {15}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 17: llvm-spirv, {16}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 18: file-table-tform, {15, 17}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 19: clang-offload-wrapper, {18}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 20: linker, {5}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 21: sycl-post-link, {20}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 22: file-table-tform, {21}, ir, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 23: backend, {22}, assembler, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 24: assembler, {23}, object, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 25: linker, {23, 24}, cuda-fatbin, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 26: foreach, {22, 25}, cuda-fatbin, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 27: file-table-tform, {21, 26}, tempfiletable, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 28: clang-offload-wrapper, {27}, object, (device-sycl, sm_50)
+// CHK-PHASE-MULTI-TARG-BOUND-ARCH-FLIPPED: 29: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown)" {19}, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {28}, image
 
 /// ###########################################################################
 
 // Check if valid bound arch behaviour occurs when compiling for spir-v,nvidia-gpu, and amd-gpu
-// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64,nvptx-nvidia-cuda,amdgcn-amd-amdhsa -Xsycl-target-backend=nvptx-nvidia-cuda --offload-arch=sm_75 -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908 -ccc-print-phases %s 2>&1 \
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64,nvptx-nvidia-cuda,amdgcn-amd-amdhsa -Xsycl-target-backend=nvptx-nvidia-cuda --offload-arch=sm_75 -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908 -ccc-print-phases %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD %s
 // CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 0: input, "[[INPUT:.+\.c]]", c++, (host-sycl)
 // CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 1: append-footer, {0}, c++, (host-sycl)
@@ -999,57 +953,34 @@
 // CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 12: preprocessor, {11}, c++-cpp-output, (device-sycl)
 // CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 13: compiler, {12}, ir, (device-sycl)
 // CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 14: linker, {13}, ir, (device-sycl)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 15: input, "{{.*}}libsycl-crt.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 16: clang-offload-unbundler, {15}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 17: input, "{{.*}}libsycl-complex.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 18: clang-offload-unbundler, {17}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 19: input, "{{.*}}libsycl-complex-fp64.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 20: clang-offload-unbundler, {19}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 21: input, "{{.*}}libsycl-cmath.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 22: clang-offload-unbundler, {21}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 23: input, "{{.*}}libsycl-cmath-fp64.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 24: clang-offload-unbundler, {23}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 25: input, "{{.*}}libsycl-fallback-cassert.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 26: clang-offload-unbundler, {25}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 27: input, "{{.*}}libsycl-fallback-cstring.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 28: clang-offload-unbundler, {27}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 29: input, "{{.*}}libsycl-fallback-complex.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 30: clang-offload-unbundler, {29}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 31: input, "{{.*}}libsycl-fallback-complex-fp64.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 32: clang-offload-unbundler, {31}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 33: input, "{{.*}}libsycl-fallback-cmath.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 34: clang-offload-unbundler, {33}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 35: input, "{{.*}}libsycl-fallback-cmath-fp64.o", object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 36: clang-offload-unbundler, {35}, object
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 37: linker, {14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36}, ir, (device-sycl)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 38: sycl-post-link, {37}, tempfiletable, (device-sycl)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 39: file-table-tform, {38}, tempfilelist, (device-sycl)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 40: llvm-spirv, {39}, tempfilelist, (device-sycl)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 41: file-table-tform, {38, 40}, tempfiletable, (device-sycl)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 42: clang-offload-wrapper, {41}, object, (device-sycl)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 43: input, "[[INPUT]]", c++, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 44: preprocessor, {43}, c++-cpp-output, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 45: compiler, {44}, ir, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 46: linker, {45}, ir, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 47: sycl-post-link, {46}, ir, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 48: file-table-tform, {47}, ir, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 49: backend, {48}, assembler, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 50: assembler, {49}, object, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 51: linker, {49, 50}, cuda-fatbin, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 52: foreach, {48, 51}, cuda-fatbin, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 53: file-table-tform, {47, 52}, tempfiletable, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 54: clang-offload-wrapper, {53}, object, (device-sycl, sm_75)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 55: linker, {5}, ir, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 56: sycl-post-link, {55}, ir, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 57: file-table-tform, {56}, ir, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 58: backend, {57}, assembler, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 59: assembler, {58}, object, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 60: linker, {59}, image, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 61: linker, {60}, hip-fatbin, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 62: foreach, {57, 61}, hip-fatbin, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 63: file-table-tform, {56, 62}, tempfiletable, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 64: clang-offload-wrapper, {63}, object, (device-sycl, gfx908)
-// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 65: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown)" {42}, "device-sycl (nvptx-nvidia-cuda:sm_75)" {54}, "device-sycl (amdgcn-amd-amdhsa:gfx908)" {64}, image
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 15: sycl-post-link, {14}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 16: file-table-tform, {15}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 17: llvm-spirv, {16}, tempfilelist, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 18: file-table-tform, {15, 17}, tempfiletable, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 19: clang-offload-wrapper, {18}, object, (device-sycl)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 20: input, "[[INPUT]]", c++, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 21: preprocessor, {20}, c++-cpp-output, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 22: compiler, {21}, ir, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 23: linker, {22}, ir, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 24: sycl-post-link, {23}, ir, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 25: file-table-tform, {24}, ir, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 26: backend, {25}, assembler, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 27: assembler, {26}, object, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 28: linker, {26, 27}, cuda-fatbin, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 29: foreach, {25, 28}, cuda-fatbin, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 30: file-table-tform, {24, 29}, tempfiletable, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 31: clang-offload-wrapper, {30}, object, (device-sycl, sm_75)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 32: linker, {5}, ir, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 33: sycl-post-link, {32}, ir, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 34: file-table-tform, {33}, ir, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 35: backend, {34}, assembler, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 36: assembler, {35}, object, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 37: linker, {36}, image, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 38: linker, {37}, hip-fatbin, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 39: foreach, {34, 38}, hip-fatbin, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 40: file-table-tform, {33, 39}, tempfiletable, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 41: clang-offload-wrapper, {40}, object, (device-sycl, gfx908)
+// CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 42: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64-unknown-unknown)" {19}, "device-sycl (nvptx-nvidia-cuda:sm_75)" {31}, "device-sycl (amdgcn-amd-amdhsa:gfx908)" {41}, image
 
 /// ###########################################################################
 /// Verify that -save-temps does not crash

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -68,7 +68,7 @@
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_OBJ %s
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %S/Inputs/SYCL/objlin64.o %s 2>&1 \
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_OBJ %s
-// IMPLIED_DEVICE_OBJ: clang-offload-bundler{{.*}} "-type=o"{{.*}} "-targets=sycl-spir64_{{.*}}-unknown-unknown,{{.*}}sycl-spir64-unknown-unknown"{{.*}} "-unbundle"
+// IMPLIED_DEVICE_OBJ: clang-offload-bundler{{.*}} "-type=o"{{.*}} "-targets=host-x86_64-unknown-linux-gnu,sycl-spir64_{{.*}}-unknown-unknown,{{.*}}sycl-spir64-unknown-unknown"{{.*}} "-unbundle"
 
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64 %S/Inputs/SYCL/liblin64.a %s 2>&1 \
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_LIB %s

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -68,7 +68,7 @@
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_OBJ %s
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %S/Inputs/SYCL/objlin64.o %s 2>&1 \
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_OBJ %s
-// IMPLIED_DEVICE_OBJ: clang-offload-bundler{{.*}} "-type=o"{{.*}} "-targets={{.*}}sycl-spir64-unknown-unknown,sycl-spir64_{{.*}}-unknown-unknown"{{.*}} "-unbundle"
+// IMPLIED_DEVICE_OBJ: clang-offload-bundler{{.*}} "-type=o"{{.*}} "-targets=sycl-spir64_{{.*}}-unknown-unknown,{{.*}}sycl-spir64-unknown-unknown"{{.*}} "-unbundle"
 
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64 %S/Inputs/SYCL/liblin64.a %s 2>&1 \
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_LIB %s
@@ -78,7 +78,7 @@
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_LIB %s
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fintelfpga %S/Inputs/SYCL/liblin64.a %s 2>&1 \
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_LIB %s
-// IMPLIED_DEVICE_LIB: clang-offload-bundler{{.*}} "-type=a"{{.*}} "-targets=sycl-spir64-unknown-unknown,sycl-spir64_{{.*}}-unknown-unknown"{{.*}} "-unbundle"
+// IMPLIED_DEVICE_LIB: clang-offload-bundler{{.*}} "-type=a"{{.*}} "-targets=sycl-spir64_{{.*}}-unknown-unknown,sycl-spir64-unknown-unknown"{{.*}} "-unbundle"
 
 /// Check that the default device triple is not used with -fno-sycl-link-spirv
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-link-spirv -fsycl-targets=spir64_x86_64 %S/Inputs/SYCL/objlin64.o %s 2>&1 \


### PR DESCRIPTION
These changes implement SYCLTargetInfoList which stores both the toolchain and the bound arch. This prevents BoundArchs being incorrectly assigned when actions and dependencies are created. This sets up the possibility of having multiple BoundArchs per triple as a future development. 
This fixes an issue where spirv and nvptx swap BoundArch's, causing failure cases. #3631
This patch should also resolve #4662

Some tests were changed in sycl-offload-with-split.c where the output from the device compilation phase was being used as an input by the wrong device. 3 tests are also introduced, two check the ordering behaviour of the triples and the bounded arch. The third checks for behaviour when targetting spirv, nvptx, and amdgcn.