### PR TITLE
[SYCL] Add HIP arch argument for lit tests

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -32,6 +32,7 @@ def do_configure(args):
     sycl_build_pi_esimd_cpu = 'OFF'
     sycl_build_pi_hip = 'OFF'
     sycl_build_pi_hip_platform = 'AMD'
+    sycl_clang_extra_flags = ''
     sycl_werror = 'ON'
     llvm_enable_assertions = 'ON'
     llvm_enable_doxygen = 'OFF'
@@ -67,6 +68,8 @@ def do_configure(args):
         if args.hip_platform == 'AMD':
             llvm_targets_to_build += ';AMDGPU'
             libclc_targets_to_build += ';amdgcn--;amdgcn--amdhsa'
+            if args.hip_amd_arch:
+                sycl_clang_extra_flags += "-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch="+args.hip_amd_arch
 
             # The HIP plugin for AMD uses lld for linking
             llvm_enable_projects += ';lld'
@@ -126,7 +129,8 @@ def do_configure(args):
         "-DSYCL_ENABLE_XPTI_TRACING={}".format(sycl_enable_xpti_tracing),
         "-DLLVM_ENABLE_LLD={}".format(llvm_enable_lld),
         "-DSYCL_BUILD_PI_ESIMD_CPU={}".format(sycl_build_pi_esimd_cpu),
-        "-DXPTI_ENABLE_WERROR={}".format(xpti_enable_werror)
+        "-DXPTI_ENABLE_WERROR={}".format(xpti_enable_werror),
+        "-DSYCL_CLANG_EXTRA_FLAGS={}".format(sycl_clang_extra_flags)
     ]
 
     if args.l0_headers and args.l0_loader:
@@ -188,6 +192,7 @@ def main():
     parser.add_argument("--cuda", action='store_true', help="switch from OpenCL to CUDA")
     parser.add_argument("--hip", action='store_true', help="switch from OpenCL to HIP")
     parser.add_argument("--hip-platform", type=str, choices=['AMD', 'NVIDIA'], default='AMD', help="choose hardware platform for HIP backend")
+    parser.add_argument("--hip-amd-arch", type=str, help="Sets AMD gpu architecture for llvm lit tests, this is only needed for the HIP backend and AMD platform")
     parser.add_argument("--arm", action='store_true', help="build ARM support rather than x86")
     parser.add_argument("--enable-esimd-cpu-emulation", action='store_true', help="build with ESIMD_CPU emulation support")
     parser.add_argument("--no-assertions", action='store_true', help="build without assertions")

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -488,9 +488,9 @@ If CUDA support has been built, it is tested only if there are CUDA devices
 available.
 
 If testing with HIP for AMD make sure to specify the GPU being used
-by adding `-Xsycl-target-backend=amdgcn-amd-amdhsa
---offload-arch=<target>` to the CMake variable
-`SYCL_CLANG_EXTRA_FLAGS`.
+by adding `-hip-amd-arch=<target>`to buildbot/configure.py or add 
+`-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=<target>` 
+to the CMake variable `SYCL_CLANG_EXTRA_FLAGS`.
 
 #### Run DPC++ E2E test suite
 

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -109,6 +109,7 @@ if triple == 'amdgcn-amd-amdhsa':
     if not re.match('.*--offload-arch.*', config.sycl_clang_extra_flags):
         raise Exception("Error: missing --offload-arch flag when trying to "  \
                         "run lit tests for AMD GPU, please add "              \
+                        "--hip-amd-arch=<target> to buildbot/configure.py or add"  \
                         "`-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=<target>` to " \
                         "the CMake variable SYCL_CLANG_EXTRA_FLAGS")
 


### PR DESCRIPTION
When using the HIP backend for an AMD platform the gpu's architecture must be sepcified with `-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=<target>`. This patch adds an option to `buildbot/configure.py` which allows the user to state the gpu architecture for lit tests when running `check-sycl-hip`. 
Relevant messages and docs are updated within the patch.

Edit:
This patch is needed even if the tests do not run on hardware, as the amd architecture must be specified for compilation.