### PR TITLE
[SYCL][ESIMD] Fix logic and arithmetic operators for simd_view with scalar

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
@@ -290,8 +290,7 @@ namespace __SEIEE {
             class = std::enable_if_t<                                          \
                 __SEIEED::is_any_simd_view_type_v<SimdViewT2> && COND>>        \
   inline auto operator BINOP(T1 LHS, const SimdViewT2 &RHS) {                  \
-    using SimdT = typename SimdViewT2::value_type;                             \
-    return SimdT(LHS) BINOP RHS.read();                                        \
+    return LHS BINOP RHS.read();                                               \
   }                                                                            \
                                                                                \
   /* simd_view BINOP SCALAR */                                                 \
@@ -301,8 +300,7 @@ namespace __SEIEE {
             class = std::enable_if_t<                                          \
                 __SEIEED::is_any_simd_view_type_v<SimdViewT1> && COND>>        \
   inline auto operator BINOP(const SimdViewT1 &LHS, T2 RHS) {                  \
-    using SimdT = typename SimdViewT1::value_type;                             \
-    return LHS.read() BINOP SimdT(RHS);                                        \
+    return LHS.read() BINOP RHS;                                               \
   }
 
 #define __ESIMD_BITWISE_OP_FILTER                                              \

--- a/sycl/test/esimd/simd_view_bin_op.cpp
+++ b/sycl/test/esimd/simd_view_bin_op.cpp
@@ -11,7 +11,7 @@ simd<short, 4> test1(int X, simd<short, 16> Y) __attribute__((sycl_device)) {
   // CHECK-LABEL: test1
   // CHECK-SAME: i32 [[X:%.+]],
   // CHECK-NOT: trunc i32 [[X]] to i16
-  return Y.select<4, 1>(0) * X;
+  return X * Y.select<4, 1>(0);
 }
 
 simd<short, 4> test2(int X, simd<short, 16> Y) __attribute__((sycl_device)) {

--- a/sycl/test/esimd/simd_view_bin_op.cpp
+++ b/sycl/test/esimd/simd_view_bin_op.cpp
@@ -1,0 +1,22 @@
+// RUN: %clangxx -fsycl -fsycl-device-only -S -emit-llvm -x c++ %s -o - | FileCheck %s
+
+// This test checks that arithmetic opration on simd_view and scalar does not
+// truncate scalar to the view's element type.
+
+#include <sycl/ext/intel/experimental/esimd.hpp>
+
+using namespace sycl::ext::intel::experimental::esimd;
+
+simd<short, 4> test1(int X, simd<short, 16> Y) __attribute__((sycl_device)) {
+  // CHECK-LABEL: test1
+  // CHECK-SAME: i32 [[X:%.+]],
+  // CHECK-NOT: trunc i32 [[X]] to i16
+  return Y.select<4, 1>(0) * X;
+}
+
+simd<short, 4> test2(int X, simd<short, 16> Y) __attribute__((sycl_device)) {
+  // CHECK-LABEL: test2
+  // CHECK-SAME: i32 [[X:%.+]],
+  // CHECK-NOT: trunc i32 [[X]] to i16
+  return Y.select<4, 1>(0) * X;
+}


### PR DESCRIPTION
These operators should call corresponding operator for simd_obj_imp with
scalar instead of constructing simd object from input scalar themselves.
simd_obj_impl operators will do the necessary type promotion for operands
if needed which is not done in the current implementation.