### PR TITLE
[NFC][SYCL] Remove outdated FIXME comment from SemaSYCL.cpp

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2952,8 +2952,6 @@ class SyclKernelBodyCreator : public SyclKernelFieldHandler {
     CollectionInitExprs.push_back(ILE);
   }
 
-  // FIXME Avoid creation of kernel obj clone.
-  // See https://github.com/intel/llvm/issues/1544 for details.
   static VarDecl *createKernelObjClone(ASTContext &Ctx, DeclContext *DC,
                                        const CXXRecordDecl *KernelObj) {
     TypeSourceInfo *TSInfo =


### PR DESCRIPTION
We've undertood that with current OpenCL limitations kernel
object cannot be passed via kernel arguments, so the clone is required.
Mentioned GitHub issue was closed a long time ago.