### PR TITLE
[SYCL] Fix backwards compatibility for libraries in archive format

### DIFF
--- a/clang/tools/clang-offload-deps/ClangOffloadDeps.cpp
+++ b/clang/tools/clang-offload-deps/ClangOffloadDeps.cpp
@@ -167,11 +167,33 @@ int main(int argc, const char **argv) {
     for (StringRef Symbol = DataOrErr.get(); !Symbol.empty();) {
       unsigned Len = strlen(Symbol.data());
 
+      // TODO: Consider storing Targets and Kinds in a single map-like struct,
+      // possibly reusing ClangOffloadBundler's 'OffloadTargetInfo'.
+      auto KindsIter = Kinds.begin();
       for (const std::string &Target : Targets) {
         std::string Prefix = Target + ".";
         if (Symbol.startswith(Prefix))
           Target2Symbols[Target].insert(
               Symbol.substr(Prefix.size(), Len - Prefix.size()));
+        else if (KindsIter->equals("sycl")) {
+          // FIXME: Temporary solution for supporting libraries produced by old
+          // versions of SYCL toolchain. Old versions used triples with
+          // 'sycldevice' environment component of the triple, whereas new
+          // toolchain use 'unknown' value for that triple component.
+          // We check for the legacy 'sycldevice' variant upon the negative
+          // check for a SYCL triple with 'unknown' environment.
+          std::string LegacyPrefix(Target);
+          // In case vendor and OS are not set for this target, fill these with
+          // 'unknown' so that our target has the "canonical" form of:
+          // <kind>-<arch>-<vendor>-<os>-<sycldevice>
+          while (StringRef(LegacyPrefix).count("-") < 3)
+            LegacyPrefix += "-unknown";
+          LegacyPrefix += "-sycldevice.";
+          if (Symbol.startswith(LegacyPrefix))
+            Target2Symbols[Target].insert(
+                Symbol.substr(LegacyPrefix.size(), Len - LegacyPrefix.size()));
+        }
+        ++KindsIter;
       }
 
       Symbol = Symbol.drop_front(Len + 1u);


### PR DESCRIPTION
With `-sycldevice` triple environment removal (as performed in
intel/llvm#3929), backwards compatibility has been enforced for SYCL
objects/object-format libraries only. To ensure that `.a` libraries
(archives) built by older compiler versions are usable with newer
compiler version, adjust `clang-offload-deps` to consider
`-sycldevice`-marked symbols when encountering a SYCL target.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>