### PR TITLE
[SYCL][ESIMD] Fix compare operators for simd_view with scalar

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
@@ -392,9 +392,7 @@ __ESIMD_DEF_SIMD_VIEW_BIN_OP(||, __SEIEED::is_simd_mask_type_v<SimdT1>)
             class = std::enable_if_t<__SEIEED::is_vectorizable_v<T2> && COND>> \
   inline auto operator CMPOP(const __SEIEE::simd_view<SimdT1, RegionT1> &LHS,  \
                              T2 RHS) {                                         \
-    using SimdValueT =                                                         \
-        typename __SEIEE::simd_view<SimdT1, RegionT1>::value_type;             \
-    return LHS.read() CMPOP SimdValueT(RHS);                                   \
+    return LHS.read() CMPOP RHS;                                               \
   }                                                                            \
                                                                                \
   /* SCALAR CMPOP simd_view */                                                 \
@@ -402,9 +400,7 @@ __ESIMD_DEF_SIMD_VIEW_BIN_OP(||, __SEIEED::is_simd_mask_type_v<SimdT1>)
             class = std::enable_if_t<__SEIEED::is_vectorizable_v<T1> && COND>> \
   inline auto operator CMPOP(                                                  \
       T1 LHS, const __SEIEE::simd_view<SimdT2, RegionT2> &RHS) {               \
-    using SimdValueT =                                                         \
-        typename __SEIEE::simd_view<SimdT2, RegionT2>::value_type;             \
-    return SimdValueT(LHS) CMPOP RHS.read();                                   \
+    return LHS CMPOP RHS.read();                                               \
   }
 
 // Equality comparison is defined for views of all simd_obj_impl derivatives.

--- a/sycl/test/esimd/simd_view_bin_op.cpp
+++ b/sycl/test/esimd/simd_view_bin_op.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -S -emit-llvm -x c++ %s -o - | FileCheck %s
 
-// This test checks that arithmetic opration on simd_view and scalar does not
-// truncate scalar to the view's element type.
+// This test checks that arithmetic or compare operation on simd_view and
+// scalar does not truncate scalar to the view's element type.
 
 #include <sycl/ext/intel/experimental/esimd.hpp>
 
@@ -19,4 +19,18 @@ simd<short, 4> test2(int X, simd<short, 16> Y) __attribute__((sycl_device)) {
   // CHECK-SAME: i32 [[X:%.+]],
   // CHECK-NOT: trunc i32 [[X]] to i16
   return Y.select<4, 1>(0) * X;
+}
+
+simd_mask<4> test3(int X, simd<short, 16> Y) __attribute__((sycl_device)) {
+  // CHECK-LABEL: test3
+  // CHECK-SAME: i32 [[X:%.+]],
+  // CHECK-NOT: trunc i32 [[X]] to i16
+  return X < Y.select<4, 1>(0);
+}
+
+simd_mask<4> test4(int X, simd<short, 16> Y) __attribute__((sycl_device)) {
+  // CHECK-LABEL: test4
+  // CHECK-SAME: i32 [[X:%.+]],
+  // CHECK-NOT: trunc i32 [[X]] to i16
+  return Y.select<4, 1>(0) < X;
 }


### PR DESCRIPTION
These operators should call corresponding operator for simd_obj_imp with
scalar instead of constructing simd object from input scalar themselves.
simd_obj_impl operators will do the necessary type promotion for operands
if needed which is not done in the current implementation.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>