### PR TITLE
[SYCL][HIP] Fix sycl-ls with HIP devices

### DIFF
--- a/sycl/include/CL/sycl/backend_types.hpp
+++ b/sycl/include/CL/sycl/backend_types.hpp
@@ -25,9 +25,9 @@ enum class backend : char {
   level_zero __SYCL2020_DEPRECATED("use 'ext_oneapi_level_zero' instead") =
       ext_oneapi_level_zero,
   cuda = 3,
-  all = 4,
-  esimd_cpu = 5,
-  hip = 6,
+  hip = 4,
+  all = 5,
+  esimd_cpu = 6,
 };
 
 template <backend Backend, typename SYCLObjectT> struct interop;


### PR DESCRIPTION
The issue is that `sycl-ls` uses the backend type enum value to index an
array of the size of `all`, which when used on a system with HIP devices
available would cause out of bounds accesses.