### PR TITLE
[SYCL][NFC] Replace INT_MAX with std::numeric_limits<std::size_t>::max()

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -679,7 +679,7 @@ inline size_t get_device_info_host<info::device::image2d_max_width>() {
   // query, thus it becomes user's responsibility to choose proper image
   // parameters depending on similar query to (non-host device) and amount
   // of available/allocatable memory.
-  return INT_MAX;
+  return std::numeric_limits<std::size_t>::max();
 }
 
 template <>
@@ -695,7 +695,7 @@ inline size_t get_device_info_host<info::device::image2d_max_height>() {
   // query, thus it becomes user's responsibility to choose proper image
   // parameters depending on similar query to (non-host device) and amount
   // of available/allocatable memory.
-  return INT_MAX;
+  return std::numeric_limits<std::size_t>::max();
 }
 
 template <>
@@ -711,7 +711,7 @@ inline size_t get_device_info_host<info::device::image3d_max_width>() {
   // in this query, thus it becomes user's responsibility to choose proper image
   // parameters depending on similar query to (non-host device) and amount
   // of available/allocatable memory.
-  return INT_MAX;
+  return std::numeric_limits<std::size_t>::max();
 }
 
 template <>
@@ -727,7 +727,7 @@ inline size_t get_device_info_host<info::device::image3d_max_height>() {
   // in this query, thus it becomes user's responsibility to choose proper image
   // parameters depending on similar query to (non-host device) and amount
   // of available/allocatable memory.
-  return INT_MAX;
+  return std::numeric_limits<std::size_t>::max();
 }
 
 template <>
@@ -743,7 +743,7 @@ inline size_t get_device_info_host<info::device::image3d_max_depth>() {
   // in this query, thus it becomes user's responsibility to choose proper image
   // parameters depending on similar query to (non-host device) and amount
   // of available/allocatable memory.
-  return INT_MAX;
+  return std::numeric_limits<std::size_t>::max();
 }
 
 template <>


### PR DESCRIPTION
The fix is made in the routines returning max image sizes on HOST.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>