### PR TITLE
[SYCL] extract_bits function is specified to be const. Updating declaration.

### DIFF
--- a/sycl/doc/extensions/SubGroupMask/SubGroupMask.asciidoc
+++ b/sycl/doc/extensions/SubGroupMask/SubGroupMask.asciidoc
@@ -274,7 +274,7 @@ struct sub_group_mask {
   void insert_bits(const T &bits, id<1> pos = 0);
 
   template <typename T>
-  void extract_bits(T &out, id<1> pos = 0);
+  void extract_bits(T &out, id<1> pos = 0) const;
 
   void set();
   void set(id<1> id, bool value = true);

--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -124,7 +124,7 @@ struct sub_group_mask {
 
   template <typename Type,
             typename = sycl::detail::enable_if_t<std::is_integral<Type>::value>>
-  void extract_bits(Type &bits, id<1> pos = 0) {
+  void extract_bits(Type &bits, id<1> pos = 0) const {
     uint32_t Res = Bits;
     if (pos.get(0) < size()) {
       if (pos.get(0) > 0) {

--- a/sycl/test/extensions/sub_group_mask.cpp
+++ b/sycl/test/extensions/sub_group_mask.cpp
@@ -77,12 +77,17 @@ int main() {
   b.insert_bits(sycl::marray<char, 8>{1, 2, 4, 8, 16, 32, 64, 128}, 5);
   assert(!b[18] && !b[20] && !b[22] && !b[24] && !b[30] && !b[16] && b[3] &&
          b[5] && b[14] && b[23]);
-  char r;
+  char r, rbc;
+  const auto b_const{b};
   b.extract_bits(r);
+  b_const.extract_bits(rbc);
   assert(r == 0b00101000);
-  long r2 = -1;
+  assert(rbc == 0b00101000);
+  long r2 = -1, r2bc = -1;
   b.extract_bits(r2, 16);
+  b_const.extract_bits(r2bc, 16);
   assert(r2 == 128);
+  assert(r2bc == 128);
   b[31] = true;
   sycl::marray<char, 6> r3{-1};
   b.extract_bits(r3, 14);


### PR DESCRIPTION
extract_bits function is specified to be const. Updating declaration.
The spec for SubGroupMask ( https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/SubGroupMask/SubGroupMask.asciidoc ) has extract_bits as const.  Simple update to declaration. 
Signed-off-by: Chris Perkins <chris.perkins@intel.com>