### PR TITLE
[SYCL] Fix device aspect check in has_kernel_bundle

### DIFF
--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -181,7 +181,7 @@ bool has_kernel_bundle_impl(const context &Ctx, const std::vector<device> &Devs,
                           "Not all devices are associated with the context or "
                           "vector of devices is empty");
 
-  bool DeviceHasRequireAspectForState = false;
+  bool DeviceHasRequireAspectForState = true;
   if (bundle_state::input == State) {
     DeviceHasRequireAspectForState =
         std::all_of(Devs.begin(), Devs.end(), [](const device &Dev) {


### PR DESCRIPTION
Fix device aspect check in has_kernel_bundle so that it does not fail
for executable bundle states.