### PR TITLE
[SYCL] Fix crash on lvalue reference to function pointer

### DIFF
--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -652,7 +652,11 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
     const ReferenceType *RTy = cast<ReferenceType>(Ty);
     QualType ETy = RTy->getPointeeType();
     llvm::Type *PointeeType = ConvertTypeForMem(ETy);
-    unsigned AS = Context.getTargetAddressSpace(ETy);
+    unsigned AS =
+        (getContext().getLangOpts().SYCLIsDevice) && PointeeType->isFunctionTy()
+            ? getDataLayout().getProgramAddressSpace()
+            : Context.getTargetAddressSpace(ETy);
+
     ResultType = llvm::PointerType::get(PointeeType, AS);
     break;
   }

--- a/clang/test/CodeGenSYCL/invoke-function-addrspace.cpp
+++ b/clang/test/CodeGenSYCL/invoke-function-addrspace.cpp
@@ -8,14 +8,14 @@
 using namespace cl::sycl;
 queue q;
 
-// CHECK: define linkonce_odr spir_func i32 @{{.*}}invoke_function{{.*}}(i32 () addrspace(4)* %f)
+// CHECK: define linkonce_odr spir_func i32 @{{.*}}invoke_function{{.*}}(i32 ()* %f)
 template <typename Callable>
 auto invoke_function(Callable &&f) {
-  // CHECK: %f.addr = alloca i32 () addrspace(4)*, align 8
-  // CHECK: %f.addr.ascast = addrspacecast i32 () addrspace(4)** %f.addr to i32 () addrspace(4)* addrspace(4)*
-  // CHECK: store i32 () addrspace(4)* %f, i32 () addrspace(4)* addrspace(4)* %f.addr.ascast, align 8
-  // CHECK: %0 = load i32 () addrspace(4)*, i32 () addrspace(4)* addrspace(4)* %f.addr.ascast, align 8
-  // CHECK: %call = call spir_func addrspace(4) i32 %0()
+  // CHECK: %f.addr = alloca i32 ()*, align 8
+  // CHECK: %f.addr.ascast = addrspacecast i32 ()** %f.addr to i32 ()* addrspace(4)*
+  // CHECK: store i32 ()* %f, i32 ()* addrspace(4)* %f.addr.ascast, align 8
+  // CHECK: load i32 ()*, i32 ()* addrspace(4)* %f.addr.ascast, align 8
+  // CHECK: %call = call spir_func i32 %0()
   return f();
 }
 

--- a/clang/test/SemaSYCL/function-pointer-reference.cpp
+++ b/clang/test/SemaSYCL/function-pointer-reference.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64 -fsyntax-only -verify %s
+//
+// Test which checks that lvalue reference to function pointer does not
+// crash
+
+// expected-no-diagnostics
+#include "Inputs/sycl.hpp"
+
+int f() { return 0; }
+
+void foo() {
+  cl::sycl::kernel_single_task<class Kernel>([=]() {
+    int (*p)() = f;
+    int (&r)() = *p;
+  });
+}


### PR DESCRIPTION
Lvalue reference to function pointer was crashing due to an
address space mismatch. Function pointer was emitted with
address space 4. This is incorrect. In SPIR-V, function
pointer has address space 0, not 4.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>