### PR TITLE
[SYCL] Avoid rebuilding sycl library every time

### DIFF
--- a/sycl/.gitignore
+++ b/sycl/.gitignore
@@ -1,1 +1,0 @@
-include/CL/sycl/version.hpp

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -98,14 +98,23 @@ set(sycl_inc_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(sycl_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/source)
 set(sycl_plugin_dir ${CMAKE_CURRENT_SOURCE_DIR}/plugins)
 string(TIMESTAMP __SYCL_COMPILER_VERSION "%Y%m%d")
-set(version_header "${sycl_inc_dir}/CL/sycl/version.hpp")
-configure_file("${version_header}.in" "${version_header}")
 
 # Copy SYCL headers from sources to build directory
-add_custom_target(sycl-headers ALL
-COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir}/sycl ${SYCL_INCLUDE_BUILD_DIR}/sycl
-COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir}/CL ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL
-COMMENT "Copying SYCL headers ...")
+add_custom_target(sycl-headers
+  DEPENDS ${SYCL_INCLUDE_BUILD_DIR}/sycl
+          ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL)
+
+add_custom_command(
+  OUTPUT  ${SYCL_INCLUDE_BUILD_DIR}/sycl
+          ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL
+  DEPENDS ${sycl_inc_dir}/sycl
+          ${sycl_inc_dir}/CL
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir}/sycl ${SYCL_INCLUDE_BUILD_DIR}/sycl
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir}/CL ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL
+  COMMENT "Copying SYCL headers ...")
+
+configure_file("${sycl_inc_dir}/CL/sycl/version.hpp.in" "${SYCL_INCLUDE_BUILD_DIR}/CL/sycl/version.hpp")
+
 
 # Copy SYCL headers from sources to install directory
 install(DIRECTORY "${sycl_inc_dir}/sycl" DESTINATION ${SYCL_INCLUDE_DIR} COMPONENT sycl-headers)

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -103,7 +103,6 @@ function(add_sycl_rt_library LIB_NAME)
 endfunction(add_sycl_rt_library)
 
 set(SYCL_SOURCES
-    "${sycl_inc_dir}/CL/sycl.hpp"
     "backend/opencl.cpp"
     "backend/level_zero.cpp"
     "backend.cpp"

--- a/xpti/CMakeLists.txt
+++ b/xpti/CMakeLists.txt
@@ -77,11 +77,16 @@ set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 add_subdirectory(src)
 
 if (LLVM_BINARY_DIR)
-  add_custom_target(xpti-headers ALL
+  add_custom_target(xpti-headers
+    DEPENDS ${LLVM_BINARY_DIR}/include/xpti)
+
+  add_custom_command(
+    OUTPUT  ${LLVM_BINARY_DIR}/include/xpti
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/include/xpti
     COMMAND ${CMAKE_COMMAND} -E copy_directory
       ${CMAKE_CURRENT_SOURCE_DIR}/include/xpti
       ${LLVM_BINARY_DIR}/include/xpti
-    COMMENT "Copying XPTI headers..."
+    COMMENT "Copying XPTI headers ..."
   )
   add_dependencies(xpti xpti-headers)
 endif()


### PR DESCRIPTION
SYCL/XPTI headers were copyied every time the build has triggered. That
invalidates all compilation that depend on them. As result, SYCL library
and some other targets were rebuilt on every build. This change makes
CMake copy header only they have changed.
Also version.hpp file is generated directly in build directory to avoid
copy step.
Remove redundant include of header as source file.