### PR TITLE
[SYCL][FPGA] Adding function wrapper for function-level loop fusion attributes

### DIFF
--- a/sycl/include/sycl/ext/intel/fpga_extensions.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_extensions.hpp
@@ -9,5 +9,6 @@
 #pragma once
 #include <sycl/ext/intel/fpga_device_selector.hpp>
 #include <sycl/ext/intel/fpga_lsu.hpp>
+#include <sycl/ext/intel/fpga_loop_fuse.hpp>
 #include <sycl/ext/intel/fpga_reg.hpp>
 #include <sycl/ext/intel/pipes.hpp>

--- a/sycl/include/sycl/ext/intel/fpga_loop_fuse.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_loop_fuse.hpp
@@ -1,0 +1,28 @@
+//==--------- fpga_loop_fuse.hpp --- SYCL FPGA Loop Fuse Extension ---------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace ext {
+namespace intel {
+
+template<int _N = 1, typename _F>
+void fpga_loop_fuse [[intel::loop_fuse(_N)]] (_F f) {
+  f();
+}
+
+template<int _N = 1, typename _F>
+void fpga_loop_fuse_independent [[intel::loop_fuse_independent(_N)]] (_F f) {
+  f();
+}
+
+} // namespace intel
+} // namespace ext
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)


### PR DESCRIPTION
The function attributes [[intel::loop_fuse(N)]] and
[[intel::loop_fuse_independent(N)]] are being replaced by equivalent
function wrappers by the inclusion of a header file.

These attributes can be accessed now by
sycl::ext::intel::fpga_loop_fuse<N>(F) and
sycl::ext::intel::fpga_loop_fuse_independent<N>(F) for a function or
lambda F.