### PR TITLE
[SYCL][ESIMD] Fix for an assertion when lowering esimd_unpack_mask

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -789,7 +789,8 @@ static void translateUnPackMask(CallInst &CI) {
   if (Width > N) {
     llvm::Type *Ty = llvm::IntegerType::get(Context, N);
     Arg0 = Builder.CreateTrunc(Arg0, Ty);
-    cast<llvm::Instruction>(Arg0)->setDebugLoc(CI.getDebugLoc());
+    if (auto *Trunc = dyn_cast<llvm::Instruction>(Arg0))
+      Trunc->setDebugLoc(CI.getDebugLoc());
   }
   assert(Arg0->getType()->getPrimitiveSizeInBits() == N);
   Arg0 = Builder.CreateBitCast(

--- a/llvm/test/SYCLLowerIR/esimd_lower_crash_zext.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_crash_zext.ll
@@ -13,3 +13,13 @@ define spir_func <32 x i16> @_Z3foov() {
 }
 
 declare dso_local spir_func <32 x i16> @_Z19__esimd_unpack_maskILi32EEN2cl4sycl5INTEL3gpu11vector_typeItXT_EE4typeEj(i32)
+
+define spir_func <16 x i16> @_Z3barv() {
+; CHECK-LABEL: @_Z3barv(
+; CHECK:    ret <16 x i16> zext (<16 x i1> bitcast (<1 x i16> <i16 15> to <16 x i1>) to <16 x i16>)
+;
+  %call.i.i = call spir_func <16 x i16> @_Z19__esimd_unpack_maskILi16EEN2cl4sycl3ext5intel12experimental5esimd6detail11vector_typeItXT_EE4typeEj(i32 15)
+  ret <16 x i16> %call.i.i
+}
+
+declare dso_local spir_func <16 x i16> @_Z19__esimd_unpack_maskILi16EEN2cl4sycl3ext5intel12experimental5esimd6detail11vector_typeItXT_EE4typeEj(i32)


### PR DESCRIPTION
esimd_unpack_mask call with a constant argument may trigger an assertion in
ESIMD lowering pass when it tries to cast a constant value to instruction.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>