### PR TITLE
Draft: [SYCL] Adds pass for enforcing by-value kernel arguments

### DIFF
--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Transforms/IPO/Internalize.h"
+#include "llvm/Transforms/Utils/SYCLForceArgumentsByval.h"
 
 #include <memory>
 using namespace clang;
@@ -320,6 +321,7 @@ namespace clang {
         PrettyStackTraceString CrashInfo("Pre-linking SYCL passes");
         legacy::PassManager PreLinkingSyclPasses;
         PreLinkingSyclPasses.add(llvm::createSYCLLowerWGScopePass());
+        PreLinkingSyclPasses.add(llvm::createSYCLForceArgumentsByvalPass());
         PreLinkingSyclPasses.run(*getModule());
       }
 

--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -435,6 +435,7 @@ void initializeStripSymbolsPass(PassRegistry&);
 void initializeStructurizeCFGLegacyPassPass(PassRegistry &);
 void initializeSYCLLowerWGScopeLegacyPassPass(PassRegistry &);
 void initializeSYCLLowerESIMDLegacyPassPass(PassRegistry &);
+void initializeSYCLForceArgumentsByvalLegacyPassPass(PassRegistry &);
 void initializeSPIRITTAnnotationsLegacyPassPass(PassRegistry &);
 void initializeESIMDLowerLoadStorePass(PassRegistry &);
 void initializeESIMDLowerVecArgLegacyPassPass(PassRegistry &);

--- a/llvm/include/llvm/LinkAllPasses.h
+++ b/llvm/include/llvm/LinkAllPasses.h
@@ -56,6 +56,7 @@
 #include "llvm/Transforms/Scalar/InstSimplifyPass.h"
 #include "llvm/Transforms/Scalar/Scalarizer.h"
 #include "llvm/Transforms/Utils.h"
+#include "llvm/Transforms/Utils/SYCLForceArgumentsByval.h"
 #include "llvm/Transforms/Utils/SymbolRewriter.h"
 #include "llvm/Transforms/Utils/UnifyFunctionExitNodes.h"
 #include "llvm/Transforms/Vectorize.h"
@@ -204,6 +205,7 @@ namespace {
       (void) llvm::createMergeICmpsLegacyPass();
       (void) llvm::createExpandMemCmpPass();
       (void) llvm::createExpandVectorPredicationPass();
+      (void)llvm::createSYCLForceArgumentsByvalPass();
       (void)llvm::createSYCLLowerWGScopePass();
       (void)llvm::createSYCLLowerESIMDPass();
       (void)llvm::createESIMDLowerLoadStorePass();

--- a/llvm/include/llvm/Transforms/Utils/SYCLForceArgumentsByval.h
+++ b/llvm/include/llvm/Transforms/Utils/SYCLForceArgumentsByval.h
@@ -1,0 +1,30 @@
+//===- SYCLForceArgumentsByval.h - forces kernel arguments to be by value -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_TRANSFORMS_UTILS_SYCLFORCEARGUMENTSBYVAL_H
+#define CLANG_TRANSFORMS_UTILS_SYCLFORCEARGUMENTSBYVAL_H
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class SYCLForceArgumentsByvalPass
+    : public PassInfoMixin<SYCLForceArgumentsByvalPass> {
+public:
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+};
+
+FunctionPass *createSYCLForceArgumentsByvalPass();
+
+} // namespace llvm
+
+#endif // CLANG_TRANSFORMS_UTILS_SYCLFORCEARGUMENTSBYVAL_H

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -233,6 +233,7 @@
 #include "llvm/Transforms/Utils/MetaRenamer.h"
 #include "llvm/Transforms/Utils/NameAnonGlobals.h"
 #include "llvm/Transforms/Utils/RelLookupTableConverter.h"
+#include "llvm/Transforms/Utils/SYCLForceArgumentsByval.h"
 #include "llvm/Transforms/Utils/StripGCRelocates.h"
 #include "llvm/Transforms/Utils/StripNonLineTableDebugInfo.h"
 #include "llvm/Transforms/Utils/SymbolRewriter.h"

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -361,6 +361,7 @@ FUNCTION_PASS("tsan", ThreadSanitizerPass())
 FUNCTION_PASS("memprof", MemProfilerPass())
 FUNCTION_PASS("LowerWGScope", SYCLLowerWGScopePass())
 FUNCTION_PASS("ESIMDLowerLoadStore", ESIMDLowerLoadStorePass())
+FUNCTION_PASS("ForceArgumentsByval", SYCLForceArgumentsByvalPass())
 #undef FUNCTION_PASS
 
 #ifndef FUNCTION_PASS_WITH_PARAMS

--- a/llvm/lib/Transforms/Utils/CMakeLists.txt
+++ b/llvm/lib/Transforms/Utils/CMakeLists.txt
@@ -68,6 +68,7 @@ add_llvm_component_library(LLVMTransformUtils
   SizeOpts.cpp
   SplitModule.cpp
   StripNonLineTableDebugInfo.cpp
+  SYCLForceArgumentsByval.cpp
   SymbolRewriter.cpp
   UnifyFunctionExitNodes.cpp
   UnifyLoopExits.cpp

--- a/llvm/lib/Transforms/Utils/SYCLForceArgumentsByval.cpp
+++ b/llvm/lib/Transforms/Utils/SYCLForceArgumentsByval.cpp
@@ -1,0 +1,89 @@
+//=== SYCLForceArgumentsByval.cpp - forces kernel arguments to be by value ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Simple pass to enforce by-value passing of arguments in SYCL kernels.
+// If a pointer argument of a kernel does not have the byval attribute and it in
+// addrspace(0) it will be given a new byval attribute with a type corresponding
+// to its elements.
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/Utils/SYCLForceArgumentsByval.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Module.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "sycl-force-args-byval"
+
+namespace {
+class SYCLForceArgumentsByvalLegacyPass : public FunctionPass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  SYCLForceArgumentsByvalLegacyPass() : FunctionPass(ID) {
+    initializeSYCLForceArgumentsByvalLegacyPassPass(
+        *PassRegistry::getPassRegistry());
+  }
+
+  // run the LowerWGScope pass on the specified module
+  bool runOnFunction(Function &F) override {
+    FunctionAnalysisManager FAM;
+    auto PA = Impl.run(F, FAM);
+    return !PA.areAllPreserved();
+  }
+
+private:
+  SYCLForceArgumentsByvalPass Impl;
+};
+} // namespace
+
+char SYCLForceArgumentsByvalLegacyPass::ID = 0;
+INITIALIZE_PASS(SYCLForceArgumentsByvalLegacyPass, "SYCLForceArgumentsByval",
+                "Force SYCL Kernel Arguments By Value", false, false)
+
+// Public interface to the SYCLForceArgumentsByvalPass.
+FunctionPass *llvm::createSYCLForceArgumentsByvalPass() {
+  return new SYCLForceArgumentsByvalLegacyPass();
+}
+
+PreservedAnalyses
+SYCLForceArgumentsByvalPass::run(Function &F, FunctionAnalysisManager &FAM) {
+
+  // Byval arguments should only be forced on kernel arguments
+  if (F.getCallingConv() != CallingConv::SPIR_KERNEL) {
+    return PreservedAnalyses::all();
+  }
+
+  bool Changed = false;
+
+  for (Argument &Arg : F.args()) {
+    // Ignore arguments that are already by-value
+    if (Arg.hasByValAttr())
+      continue;
+
+    // Ignore non-pointer types and pointers with address spaces other than
+    // addrspace(0). Pointers with other address spaces are assumed to be SYCL
+    // accessors.
+    auto ArgT = Arg.getType();
+    if (!ArgT->isPointerTy() || cast<PointerType>(ArgT)->getAddressSpace())
+      continue;
+
+    Arg.addAttrs(
+        llvm::AttrBuilder().addByValAttr(ArgT->getPointerElementType()));
+    Changed = true;
+  }
+
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm/tools/opt/opt.cpp
+++ b/llvm/tools/opt/opt.cpp
@@ -576,6 +576,7 @@ int main(int argc, char **argv) {
   initializeReplaceWithVeclibLegacyPass(Registry);
   initializeSYCLLowerWGScopeLegacyPassPass(Registry);
   initializeSYCLLowerESIMDLegacyPassPass(Registry);
+  initializeSYCLForceArgumentsByvalLegacyPassPass(Registry);
   initializeSPIRITTAnnotationsLegacyPassPass(Registry);
   initializeESIMDLowerLoadStorePass(Registry);
   initializeESIMDLowerVecArgLegacyPassPass(Registry);


### PR DESCRIPTION
These changes add a simple pass for enforcing that device copyable types are correctly marked as passed by-value in the arguments of kernels. This affects primarily non-trivially copyable types that have been
specified as device copyable through specialization of is_device_copyable.