### PR TITLE
[ESIMD] Fix build error showed with disabled asserts

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerESIMD.cpp
@@ -885,15 +885,14 @@ static Instruction *generateGenXCall(ExtractElementInst *EEI,
                 EEI->getModule(), ID, FixedVectorType::get(I32Ty, MAX_DIMS))
           : GenXIntrinsic::getGenXDeclaration(EEI->getModule(), ID);
 
-  std::string ResultName =
-      (Twine(EEI->getNameOrAsOperand()) + "." + FullIntrinName).str();
+  std::string ResultName = (Twine(EEI->getName()) + "." + FullIntrinName).str();
   Instruction *Inst = IntrinsicInst::Create(NewFDecl, {}, ResultName, EEI);
   Inst->setDebugLoc(EEI->getDebugLoc());
 
   if (IsVectorCall) {
     Type *I32Ty = Type::getInt32Ty(EEI->getModule()->getContext());
     std::string ExtractName =
-        (Twine(Inst->getNameOrAsOperand()) + ".ext." + Twine(IndexValue)).str();
+        (Twine(Inst->getName()) + ".ext." + Twine(IndexValue)).str();
     Inst = ExtractElementInst::Create(Inst, ConstantInt::get(I32Ty, IndexValue),
                                       ExtractName, EEI);
     Inst->setDebugLoc(EEI->getDebugLoc());


### PR DESCRIPTION
Surprisingly Instruction->getNameOrAsOperand() is not defined when
asserts are disabled. Replaced that method usage with getName() method.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>