### PR TITLE
[SYCL] Exclude current directory from DLL search path

### DIFF
--- a/sycl/source/detail/windows_pi.cpp
+++ b/sycl/source/detail/windows_pi.cpp
@@ -8,6 +8,7 @@
 
 #include <CL/sycl/detail/defines.hpp>
 
+#include <cassert>
 #include <string>
 #include <windows.h>
 #include <winreg.h>


### PR DESCRIPTION
Change plugin loading mechanism to better align with Microsoft guidelines.