### PR TITLE
[CODEOWNERS] Add codeowners for SPIR-V specs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@ sycl/ @intel/llvm-reviewers-runtime
 sycl/ReleaseNotes.md @pvchupin @tfzhu
 sycl/doc/ @pvchupin @bader
 sycl/doc/extensions/ @intel/dpcpp-specification-reviewers
+sycl/doc/SPIRV @AlexeySotkin @bashbaug @mbelicki
 
 # Sub-groups
 sycl/include/CL/sycl/detail/spirv.hpp @Pennycook @AlexeySachkov


### PR DESCRIPTION
Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>