### PR TITLE
[SYCL] Enforces exception on empty device vector in sycl::link

### DIFF
--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -158,6 +158,10 @@ public:
       std::vector<device> Devs, const property_list &PropList)
       : MDevices(std::move(Devs)) {
 
+    if (MDevices.empty())
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "Vector of devices is empty");
+
     if (ObjectBundles.empty())
       return;
 
@@ -184,11 +188,10 @@ public:
                                                         Dev);
               });
         });
-    if (MDevices.empty() || !AllDevsAssociatedWithInputBundles)
-      throw sycl::exception(
-          make_error_code(errc::invalid),
-          "Not all devices are in the set of associated "
-          "devices for input bundles or vector of devices is empty");
+    if (!AllDevsAssociatedWithInputBundles)
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "Not all devices are in the set of associated "
+                            "devices for input bundles");
 
     // TODO: Unify with c'tor for sycl::comile and sycl::build by calling
     // sycl::join on vector of kernel_bundles

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -564,3 +564,65 @@ TEST(KernelBundle, UseKernelBundleWrongContextPrimaryQueueAndSecondaryQueue) {
     FAIL() << "Unexpected exception was thrown in submit.";
   }
 }
+
+TEST(KernelBundle, EmptyDevicesKernelBundleLinkException) {
+  sycl::platform Plt{sycl::default_selector()};
+  if (Plt.is_host()) {
+    std::cerr << "Test is not supported on host, skipping\n";
+    return;
+  }
+
+  if (Plt.get_backend() == sycl::backend::cuda) {
+    std::cerr << "Test is not supported on CUDA platform, skipping\n";
+    return;
+  }
+
+  if (Plt.get_backend() == sycl::backend::hip) {
+    std::cout << "Test is not supported on HIP platform, skipping\n";
+    return;
+  }
+
+  sycl::unittest::PiMock Mock{Plt};
+  setupDefaultMockAPIs(Mock);
+
+  const sycl::device Dev = Plt.get_devices()[0];
+  sycl::queue Queue{Dev};
+  const sycl::context Ctx = Queue.get_context();
+
+  auto EmptyKernelBundle =
+      sycl::get_kernel_bundle<sycl::bundle_state::object>(Ctx, {Dev}, {});
+
+  std::vector<sycl::device> EmptyDevices{};
+
+  // Case without an object bundle.
+  try {
+    auto LinkBundle = sycl::link(EmptyKernelBundle, EmptyDevices);
+    FAIL() << "No exception was thrown.";
+  } catch (const sycl::exception &e) {
+    ASSERT_EQ(e.code().value(), static_cast<int>(sycl::errc::invalid))
+        << "sycl::exception code was not the expected "
+           "sycl::errc::invalid.";
+    // Expected path
+  } catch (...) {
+    FAIL() << "Unexpected exception was thrown in sycl::link.";
+  }
+
+  sycl::kernel_bundle KernelBundle =
+      sycl::get_kernel_bundle<TestKernel, sycl::bundle_state::input>(Ctx,
+                                                                     {Dev});
+
+  auto ObjBundle = sycl::compile(KernelBundle, KernelBundle.get_devices());
+  EXPECT_FALSE(ObjBundle.empty()) << "Expect non-empty obj kernel bundle";
+
+  try {
+    auto LinkBundle = sycl::link(ObjBundle, EmptyDevices);
+    FAIL() << "No exception was thrown.";
+  } catch (const sycl::exception &e) {
+    ASSERT_EQ(e.code().value(), static_cast<int>(sycl::errc::invalid))
+        << "sycl::exception code was not the expected "
+           "sycl::errc::invalid.";
+    // Expected path
+  } catch (...) {
+    FAIL() << "Unexpected exception was thrown in sycl::link.";
+  }
+}


### PR DESCRIPTION
The SYCL 2020 specification states that sycl::link must fail with a SYCL exception with errc::invalid if the vector of devices is empty. However the implementation of sycl::link skips this check if the list of kernel bundle objects is empty as well. These changes move the aforementioned check for devices earlier in the implementation of sycl::link and throws an exception even if there are no kernel bundle objects specified.