### PR TITLE
[SYCL] Map sampler addressing mode differently depending on L0 version.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -226,6 +226,7 @@ struct _pi_platform {
   // Cache versions info from zeDriverGetProperties.
   std::string ZeDriverVersion;
   std::string ZeDriverApiVersion;
+  ze_api_version_t ZeApiVersion;
 
   // Cache driver extensions
   std::unordered_map<std::string, uint32_t> zeDriverExtensionMap;


### PR DESCRIPTION
Level Zero runtime with API version 1.2 and lower has a bug:
ZE_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER is implemented as
"clamp to edge" and ZE_SAMPLER_ADDRESS_MODE_CLAMP is implemented as
"clamp to border", i.e. logic is flipped. Starting from API version
1.3 this problem is going to be fixed. That's why check for API
version to set an address mode in the Level Zero plugin.