### PR TITLE
[ESIMD] Add 'const' specifier to non-modifier methods

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
@@ -112,7 +112,7 @@ public:
 
   template <class T1 = simd_mask_impl,
             class = std::enable_if_t<T1::length == 1>>
-  operator bool() {
+  operator bool() const {
     return base_type::data()[0] != 0;
   }
 };

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_obj_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_obj_impl.hpp
@@ -317,7 +317,7 @@ public:
 
   /// \tparam Rep is number of times region has to be replicated.
   /// \return replicated simd_obj_impl instance.
-  template <int Rep> resize_a_simd_type_t<Derived, Rep * N> replicate() {
+  template <int Rep> resize_a_simd_type_t<Derived, Rep * N> replicate() const {
     return replicate<Rep, N>(0);
   }
 
@@ -327,7 +327,7 @@ public:
   /// \return replicated simd_obj_impl instance.
   template <int Rep, int W>
   __SYCL_DEPRECATED("use simd_obj_impl::replicate_w")
-  resize_a_simd_type_t<Derived, Rep * W> replicate(uint16_t Offset) {
+  resize_a_simd_type_t<Derived, Rep * W> replicate(uint16_t Offset) const {
     return replicate_w<Rep, W>(Offset);
   }
 
@@ -336,7 +336,7 @@ public:
   /// \param Offset is offset in number of elements in src region.
   /// \return replicated simd_obj_impl instance.
   template <int Rep, int W>
-  resize_a_simd_type_t<Derived, Rep * W> replicate_w(uint16_t Offset) {
+  resize_a_simd_type_t<Derived, Rep * W> replicate_w(uint16_t Offset) const {
     return replicate_vs_w_hs<Rep, 0, W, 1>(Offset);
   }
 
@@ -347,7 +347,7 @@ public:
   /// \return replicated simd_obj_impl instance.
   template <int Rep, int VS, int W>
   __SYCL_DEPRECATED("use simd_obj_impl::replicate_vs_w")
-  resize_a_simd_type_t<Derived, Rep * W> replicate(uint16_t Offset) {
+  resize_a_simd_type_t<Derived, Rep * W> replicate(uint16_t Offset) const {
     return replicate_vs_w<Rep, VS, W>(Offset);
   }
 
@@ -357,7 +357,7 @@ public:
   /// \param Offset offset in number of elements in src region.
   /// \return replicated simd_obj_impl instance.
   template <int Rep, int VS, int W>
-  resize_a_simd_type_t<Derived, Rep * W> replicate_vs_w(uint16_t Offset) {
+  resize_a_simd_type_t<Derived, Rep * W> replicate_vs_w(uint16_t Offset) const {
     return replicate_vs_w_hs<Rep, VS, W, 1>(Offset);
   }
 
@@ -369,7 +369,7 @@ public:
   /// \return replicated simd_obj_impl instance.
   template <int Rep, int VS, int W, int HS>
   __SYCL_DEPRECATED("use simd_obj_impl::replicate_vs_w_hs")
-  resize_a_simd_type_t<Derived, Rep * W> replicate(uint16_t Offset) {
+  resize_a_simd_type_t<Derived, Rep * W> replicate(uint16_t Offset) const {
     return replicate_vs_w_hs<Rep, VS, W, HS>(Offset);
   }
 
@@ -380,7 +380,8 @@ public:
   /// \param Offset is offset in number of elements in src region.
   /// \return replicated simd_obj_impl instance.
   template <int Rep, int VS, int W, int HS>
-  resize_a_simd_type_t<Derived, Rep * W> replicate_vs_w_hs(uint16_t Offset) {
+  resize_a_simd_type_t<Derived, Rep * W>
+  replicate_vs_w_hs(uint16_t Offset) const {
     return __esimd_rdregion<Ty, N, Rep * W, VS, W, HS, N>(data(),
                                                           Offset * sizeof(Ty));
   }
@@ -390,8 +391,8 @@ public:
   ///
   /// \return 1 if any element is set, 0 otherwise.
   template <typename T1 = Ty,
-            typename = sycl::detail::enable_if_t<std::is_integral<T1>::value>>
-  uint16_t any() {
+            typename = std::enable_if_t<std::is_integral<T1>::value>>
+  uint16_t any() const {
     return __esimd_any<Ty, N>(data());
   }
 
@@ -399,8 +400,8 @@ public:
   ///
   /// \return 1 if all elements are set, 0 otherwise.
   template <typename T1 = Ty,
-            typename = sycl::detail::enable_if_t<std::is_integral<T1>::value>>
-  uint16_t all() {
+            typename = std::enable_if_t<std::is_integral<T1>::value>>
+  uint16_t all() const {
     return __esimd_all<Ty, N>(data());
   }
 
@@ -499,7 +500,7 @@ public:
   /// elements in this object.
   /// @param addr the memory address to copy from. Must be a pointer to the
   /// global address space, otherwise behavior is undefined.
-  ESIMD_INLINE void copy_from(const Ty *const addr) SYCL_ESIMD_FUNCTION;
+  ESIMD_INLINE void copy_from(const Ty *addr) SYCL_ESIMD_FUNCTION;
 
   /// Copy a contiguous block of data from memory into this simd_obj_impl
   /// object. The amount of memory copied equals the total size of vector
@@ -515,7 +516,7 @@ public:
   /// Copy all vector elements of this object into a contiguous block in memory.
   /// @param addr the memory address to copy to. Must be a pointer to the
   /// global address space, otherwise behavior is undefined.
-  ESIMD_INLINE void copy_to(Ty *addr) SYCL_ESIMD_FUNCTION;
+  ESIMD_INLINE void copy_to(Ty *addr) const SYCL_ESIMD_FUNCTION;
 
   /// Copy all vector elements of this object into a contiguous block in memory.
   /// Destination memory location is represented via a global accessor and
@@ -525,7 +526,7 @@ public:
   template <typename AccessorT>
   ESIMD_INLINE EnableIfAccessor<AccessorT, accessor_mode_cap::can_write,
                                 sycl::access::target::global_buffer, void>
-  copy_to(AccessorT acc, uint32_t offset) SYCL_ESIMD_FUNCTION;
+  copy_to(AccessorT acc, uint32_t offset) const SYCL_ESIMD_FUNCTION;
 
   /// @} // Memory operations
 
@@ -634,7 +635,8 @@ protected:
 // ----------- Outlined implementations of simd_obj_impl class APIs.
 
 template <typename T, int N, class T1, class SFINAE>
-void simd_obj_impl<T, N, T1, SFINAE>::copy_from(const T *const Addr) {
+void simd_obj_impl<T, N, T1, SFINAE>::copy_from(const T *Addr)
+    SYCL_ESIMD_FUNCTION {
   constexpr unsigned Sz = sizeof(T) * N;
   static_assert(Sz >= OperandSize::OWORD,
                 "block size must be at least 1 oword");
@@ -655,7 +657,8 @@ template <typename T, int N, class T1, class SFINAE>
 template <typename AccessorT>
 ESIMD_INLINE EnableIfAccessor<AccessorT, accessor_mode_cap::can_read,
                               sycl::access::target::global_buffer, void>
-simd_obj_impl<T, N, T1, SFINAE>::copy_from(AccessorT acc, uint32_t offset) {
+simd_obj_impl<T, N, T1, SFINAE>::copy_from(AccessorT acc, uint32_t offset)
+    SYCL_ESIMD_FUNCTION {
   constexpr unsigned Sz = sizeof(T) * N;
   static_assert(Sz >= OperandSize::OWORD,
                 "block size must be at least 1 oword");
@@ -675,7 +678,8 @@ simd_obj_impl<T, N, T1, SFINAE>::copy_from(AccessorT acc, uint32_t offset) {
 }
 
 template <typename T, int N, class T1, class SFINAE>
-void simd_obj_impl<T, N, T1, SFINAE>::copy_to(T *addr) {
+void simd_obj_impl<T, N, T1, SFINAE>::copy_to(T *addr) const
+    SYCL_ESIMD_FUNCTION {
   constexpr unsigned Sz = sizeof(T) * N;
   static_assert(Sz >= OperandSize::OWORD,
                 "block size must be at least 1 oword");
@@ -694,7 +698,8 @@ template <typename T, int N, class T1, class SFINAE>
 template <typename AccessorT>
 ESIMD_INLINE EnableIfAccessor<AccessorT, accessor_mode_cap::can_write,
                               sycl::access::target::global_buffer, void>
-simd_obj_impl<T, N, T1, SFINAE>::copy_to(AccessorT acc, uint32_t offset) {
+simd_obj_impl<T, N, T1, SFINAE>::copy_to(AccessorT acc, uint32_t offset) const
+    SYCL_ESIMD_FUNCTION {
   constexpr unsigned Sz = sizeof(T) * N;
   static_assert(Sz >= OperandSize::OWORD,
                 "block size must be at least 1 oword");

--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -71,12 +71,13 @@ __esimd_abs_common_internal(simd<T1, SZ> src0, int flag = saturation_off) {
 }
 
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value,
-    typename sycl::detail::remove_const_t<T0>>
-__esimd_abs_common_internal(T1 src0, int flag = saturation_off) {
-  typedef typename sycl::detail::remove_const_t<T0> TT0;
-  typedef typename sycl::detail::remove_const_t<T1> TT1;
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<T0>::value &&
+                                      detail::is_esimd_scalar<T1>::value,
+                                  std::remove_const_t<T0>>
+    __esimd_abs_common_internal(T1 src0, int flag = saturation_off) {
+  using TT0 = std::remove_const_t<T0>;
+  using TT1 = std::remove_const_t<T1>;
 
   simd<TT1, 1> Src0 = src0;
   simd<TT0, 1> Result = __esimd_abs_common_internal<TT0>(Src0, flag);
@@ -93,9 +94,8 @@ __esimd_abs_common_internal(T1 src0, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return vector of absolute values.
 template <typename T0, typename T1, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    !std::is_same<typename sycl::detail::remove_const_t<T0>,
-                  typename sycl::detail::remove_const_t<T1>>::value,
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
+    !std::is_same<std::remove_const_t<T0>, std::remove_const_t<T1>>::value,
     simd<T0, SZ>>
 esimd_abs(simd<T1, SZ> src0, int flag = saturation_off) {
   return detail::__esimd_abs_common_internal<T0, T1, SZ>(src0.data(), flag);
@@ -109,12 +109,11 @@ esimd_abs(simd<T1, SZ> src0, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return absolute value.
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    !std::is_same<typename sycl::detail::remove_const_t<T0>,
-                  typename sycl::detail::remove_const_t<T1>>::value &&
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
+    !std::is_same<std::remove_const_t<T0>, std::remove_const_t<T1>>::value &&
         detail::is_esimd_scalar<T0>::value &&
         detail::is_esimd_scalar<T1>::value,
-    typename sycl::detail::remove_const_t<T0>>
+    std::remove_const_t<T0>>
 esimd_abs(T1 src0, int flag = saturation_off) {
   return detail::__esimd_abs_common_internal<T0, T1>(src0, flag);
 }
@@ -143,9 +142,8 @@ ESIMD_NODEBUG ESIMD_INLINE simd<T1, SZ> esimd_abs(simd<T1, SZ> src0,
 /// values: saturation_on/saturation_off.
 /// @return absolute value.
 template <typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_esimd_scalar<T1>::value,
-    typename sycl::detail::remove_const_t<T1>>
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<T1>::value,
+                                            std::remove_const_t<T1>>
 esimd_abs(T1 src0, int flag = saturation_off) {
   return detail::__esimd_abs_common_internal<T1, T1>(src0, flag);
 }
@@ -161,12 +159,11 @@ esimd_abs(T1 src0, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return vector of shifted left values.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
-                                           std::is_integral<T1>::value &&
-                                           std::is_integral<U>::value,
-                                       simd<T0, SZ>>
-    esimd_shl(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<std::is_integral<T0>::value &&
+                                                std::is_integral<T1>::value &&
+                                                std::is_integral<U>::value,
+                                            simd<T0, SZ>>
+esimd_shl(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
   using ComputationTy = detail::computation_type_t<decltype(src0), U>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
@@ -208,11 +205,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// values: saturation_on/saturation_off.
 /// @return shifted left value.
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename sycl::detail::remove_const_t<T0>>
+    std::remove_const_t<T0>>
 esimd_shl(T1 src0, T2 src1, int flag = saturation_off) {
   using ComputationTy = detail::computation_type_t<T1, T2>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -232,12 +229,11 @@ esimd_shl(T1 src0, T2 src1, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return vector of shifted right values.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
-                                           std::is_integral<T1>::value &&
-                                           std::is_integral<U>::value,
-                                       simd<T0, SZ>>
-    esimd_shr(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<std::is_integral<T0>::value &&
+                                                std::is_integral<T1>::value &&
+                                                std::is_integral<U>::value,
+                                            simd<T0, SZ>>
+esimd_shr(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
   using ComputationTy = detail::computation_type_t<decltype(src0), U>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
@@ -260,11 +256,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// values: saturation_on/saturation_off.
 /// @return shifted right value.
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename sycl::detail::remove_const_t<T0>>
+    std::remove_const_t<T0>>
 esimd_shr(T1 src0, T2 src1, int flag = saturation_off) {
   using ComputationTy = detail::computation_type_t<T1, T2>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -282,7 +278,7 @@ esimd_shr(T1 src0, T2 src1, int flag = saturation_off) {
 /// the input vector \p src0 shall be rotated.
 /// @return vector of rotated elements.
 template <typename T0, typename T1, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<T0>::value && std::is_integral<T1>::value, simd<T0, SZ>>
 esimd_rol(simd<T1, SZ> src0, simd<T1, SZ> src1) {
   return __esimd_rol<T0, T1, SZ>(src0.data(), src1.data());
@@ -297,12 +293,11 @@ esimd_rol(simd<T1, SZ> src0, simd<T1, SZ> src1) {
 /// @param src1 the number of bit positions the input vector shall be rotated.
 /// @return vector of rotated elements.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
-                                           std::is_integral<T1>::value &&
-                                           std::is_integral<U>::value,
-                                       simd<T0, SZ>>
-    esimd_rol(simd<T1, SZ> src0, U src1) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<std::is_integral<T0>::value &&
+                                                std::is_integral<T1>::value &&
+                                                std::is_integral<U>::value,
+                                            simd<T0, SZ>>
+esimd_rol(simd<T1, SZ> src0, U src1) {
   using ComputationTy = detail::computation_type_t<decltype(src0), U>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
@@ -317,11 +312,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// @param src1 the number of bit positions the input vector shall be rotated.
 /// @return rotated left value.
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename sycl::detail::remove_const_t<T0>>
+    std::remove_const_t<T0>>
 esimd_rol(T1 src0, T2 src1) {
   using ComputationTy = detail::computation_type_t<T1, T2>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -339,7 +334,7 @@ esimd_rol(T1 src0, T2 src1) {
 /// the input vector \p src0 shall be rotated.
 /// @return vector of rotated elements.
 template <typename T0, typename T1, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<T0>::value && std::is_integral<T1>::value, simd<T0, SZ>>
 esimd_ror(simd<T1, SZ> src0, simd<T1, SZ> src1) {
   return __esimd_ror<T0, T1, SZ>(src0.data(), src1.data());
@@ -354,12 +349,11 @@ esimd_ror(simd<T1, SZ> src0, simd<T1, SZ> src1) {
 /// @param src1 the number of bit positions the input vector shall be rotated.
 /// @return vector of rotated elements.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
-                                           std::is_integral<T1>::value &&
-                                           std::is_integral<U>::value,
-                                       simd<T0, SZ>>
-    esimd_ror(simd<T1, SZ> src0, U src1) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<std::is_integral<T0>::value &&
+                                                std::is_integral<T1>::value &&
+                                                std::is_integral<U>::value,
+                                            simd<T0, SZ>>
+esimd_ror(simd<T1, SZ> src0, U src1) {
   using ComputationTy = detail::computation_type_t<decltype(src0), U>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
   typename detail::simd_type<ComputationTy>::type Src1 = src1;
@@ -374,11 +368,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// @param src1 the number of bit positions the input vector shall be rotated.
 /// @return rotated right value.
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename sycl::detail::remove_const_t<T0>>
+    std::remove_const_t<T0>>
 esimd_ror(T1 src0, T2 src1) {
   using ComputationTy = detail::computation_type_t<T1, T2>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -398,12 +392,11 @@ esimd_ror(T1 src0, T2 src1) {
 /// values: saturation_on/saturation_off.
 /// @return vector of shifted elements.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
-                                           std::is_integral<T1>::value &&
-                                           std::is_integral<U>::value,
-                                       simd<T0, SZ>>
-    esimd_lsr(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<std::is_integral<T0>::value &&
+                                                std::is_integral<T1>::value &&
+                                                std::is_integral<U>::value,
+                                            simd<T0, SZ>>
+esimd_lsr(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
   using IntermedTy = detail::computation_type_t<T1, T1>;
   typedef typename std::make_unsigned<IntermedTy>::type ComputationTy;
   simd<ComputationTy, SZ> Src0 = src0;
@@ -426,11 +419,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// values: saturation_on/saturation_off.
 /// @return shifted value.
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename sycl::detail::remove_const_t<T0>>
+    std::remove_const_t<T0>>
 esimd_lsr(T1 src0, T2 src1, int flag = saturation_off) {
   using ComputationTy = detail::computation_type_t<T1, T2>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -450,12 +443,11 @@ esimd_lsr(T1 src0, T2 src1, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return vector of shifted elements.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_integral<T0>::value &&
-                                           std::is_integral<T1>::value &&
-                                           std::is_integral<U>::value,
-                                       simd<T0, SZ>>
-    esimd_asr(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<std::is_integral<T0>::value &&
+                                                std::is_integral<T1>::value &&
+                                                std::is_integral<U>::value,
+                                            simd<T0, SZ>>
+esimd_asr(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
   using IntermedTy = detail::computation_type_t<T1, T1>;
   typedef typename std::make_signed<IntermedTy>::type ComputationTy;
   simd<ComputationTy, SZ> Src0 = src0;
@@ -478,11 +470,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// values: saturation_on/saturation_off.
 /// @return shifted value.
 template <typename T0, typename T1, typename T2>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         detail::is_esimd_scalar<T2>::value && std::is_integral<T0>::value &&
         std::is_integral<T1>::value && std::is_integral<T2>::value,
-    typename sycl::detail::remove_const_t<T0>>
+    std::remove_const_t<T0>>
 esimd_asr(T1 src0, T2 src1, int flag = saturation_off) {
   using ComputationTy = detail::computation_type_t<T1, T2>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -495,11 +487,11 @@ esimd_asr(T1 src0, T2 src1, int flag = saturation_off) {
 #ifndef ESIMD_HAS_LONG_LONG
 // use mulh instruction for high half
 template <typename T0, typename T1, typename U, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_dword_type<T0>::value &&
-                                           detail::is_dword_type<T1>::value &&
-                                           detail::is_dword_type<U>::value,
-                                       simd<T0, SZ>>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_dword_type<T0>::value &&
+                                      detail::is_dword_type<T1>::value &&
+                                      detail::is_dword_type<U>::value,
+                                  simd<T0, SZ>>
     esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
   using ComputationTy = detail::computation_type_t<decltype(src0), U>;
   typename detail::simd_type<ComputationTy>::type Src0 = src0;
@@ -516,7 +508,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 // We need to special case SZ==1 to avoid "error: when select size is 1, the
 // stride must also be 1" on the selects.
 template <typename T0, typename T1, typename U, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_dword_type<T0>::value && detail::is_dword_type<T1>::value &&
         detail::is_dword_type<U>::value && SZ == 1,
     simd<T0, SZ>>
@@ -529,7 +521,7 @@ esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
 }
 
 template <typename T0, typename T1, typename U, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_dword_type<T0>::value && detail::is_dword_type<T1>::value &&
         detail::is_dword_type<U>::value && SZ != 1,
     simd<T0, SZ>>
@@ -545,19 +537,18 @@ esimd_imul(simd<T0, SZ> &rmd, simd<T1, SZ> src0, U src1) {
 // TODO: document
 template <typename T0, typename T1, typename U, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<U>::value,
-                                       simd<T0, SZ>>
+    std::enable_if_t<detail::is_esimd_scalar<U>::value, simd<T0, SZ>>
     esimd_imul(simd<T0, SZ> &rmd, U src0, simd<T1, SZ> src1) {
   return esimd_imul(rmd, src1, src0);
 }
 
 // TODO: document
 template <typename T0, typename T, typename U>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value &&
-                                           detail::is_esimd_scalar<U>::value &&
-                                           detail::is_esimd_scalar<T0>::value,
-                                       T0>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<T>::value &&
+                                      detail::is_esimd_scalar<U>::value &&
+                                      detail::is_esimd_scalar<T0>::value,
+                                  T0>
     esimd_imul(simd<T0, 1> &rmd, T src0, U src1) {
   simd<T, 1> src_0 = src0;
   simd<U, 1> src_1 = src1;
@@ -573,7 +564,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// @param src1 the divisor scalar value.
 /// @return vector of quotient elements.
 template <typename T, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<T>::value && std::is_integral<U>::value, simd<T, SZ>>
 esimd_quot(simd<T, SZ> src0, U src1) {
   return src0 / src1;
@@ -586,10 +577,10 @@ esimd_quot(simd<T, SZ> src0, U src1) {
 /// @param src1 the divisor.
 /// @return quotient value.
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         std::is_integral<T0>::value && std::is_integral<T1>::value,
-    typename sycl::detail::remove_const_t<T0>>
+    std::remove_const_t<T0>>
 esimd_quot(T0 src0, T1 src1) {
   return src0 / src1;
 }
@@ -602,7 +593,7 @@ esimd_quot(T0 src0, T1 src1) {
 /// @param src1 the divisor scalar value.
 /// @return vector of elements after applying modulo operation.
 template <typename T, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<T>::value && std::is_integral<U>::value, simd<T, SZ>>
 esimd_mod(simd<T, SZ> src0, U src1) {
   return src0 % src1;
@@ -615,10 +606,10 @@ esimd_mod(simd<T, SZ> src0, U src1) {
 /// @param src1 the divisor.
 /// @return Modulo value.
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value &&
         std::is_integral<T0>::value && std::is_integral<T1>::value,
-    typename sycl::detail::remove_const_t<T0>>
+    std::remove_const_t<T0>>
 esimd_mod(T0 src0, T1 src1) {
   return src0 % src1;
 }
@@ -632,7 +623,7 @@ esimd_mod(T0 src0, T1 src1) {
 /// @param src1 the divisor scalar value.
 /// @return vector of quotient elements.
 template <typename T, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<T>::value && std::is_integral<U>::value, simd<T, SZ>>
 esimd_div(simd<T, SZ> &remainder, simd<T, SZ> src0, U src1) {
   remainder = src0 % src1;
@@ -649,10 +640,9 @@ esimd_div(simd<T, SZ> &remainder, simd<T, SZ> src0, U src1) {
 /// @return vector of quotient elements.
 template <typename T, int SZ, typename U>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_integral<T>::value &&
-                                           std::is_integral<U>::value &&
-                                           detail::is_esimd_scalar<U>::value,
-                                       simd<T, SZ>>
+    std::enable_if_t<std::is_integral<T>::value && std::is_integral<U>::value &&
+                         detail::is_esimd_scalar<U>::value,
+                     simd<T, SZ>>
     esimd_div(simd<T, SZ> &remainder, U src0, simd<T, SZ> src1) {
   remainder = src0 % src1;
   return src0 / src1;
@@ -668,12 +658,12 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// @param src1 the divisor scalar value.
 /// @return scalar quotient value.
 template <typename RT, typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_esimd_scalar<RT>::value && detail::is_esimd_scalar<T0>::value &&
-        detail::is_esimd_scalar<T1>::value,
-    typename sycl::detail::remove_const_t<RT>>
-esimd_div(simd<typename std::remove_const<RT>, 1> &remainder, T0 src0,
-          T1 src1) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<RT>::value &&
+                                      detail::is_esimd_scalar<T0>::value &&
+                                      detail::is_esimd_scalar<T1>::value,
+                                  std::remove_const_t<RT>>
+    esimd_div(simd<std::remove_const_t<RT>, 1> &remainder, T0 src0, T1 src1) {
   remainder[0] = src0 % src1;
   return src0 / src1;
 }
@@ -719,8 +709,7 @@ esimd_max(simd<T, SZ> src0, simd<T, SZ> src1, int flag = saturation_off) {
 /// @return vector of component-wise maximum elements.
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value,
-                                       simd<T, SZ>>
+    std::enable_if_t<detail::is_esimd_scalar<T>::value, simd<T, SZ>>
     esimd_max(simd<T, SZ> src0, T src1, int flag = saturation_off) {
   simd<T, SZ> Src1 = src1;
   simd<T, SZ> Result = esimd_max<T>(src0, Src1, flag);
@@ -739,8 +728,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// @return vector of component-wise maximum elements.
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value,
-                                       simd<T, SZ>>
+    std::enable_if_t<detail::is_esimd_scalar<T>::value, simd<T, SZ>>
     esimd_max(T src0, simd<T, SZ> src1, int flag = saturation_off) {
   simd<T, SZ> Src0 = src0;
   simd<T, SZ> Result = esimd_max<T>(Src0, src1, flag);
@@ -756,8 +744,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// values: saturation_on/saturation_off.
 /// @return maximum value between the two inputs.
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value, T>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<T>::value, T>
     esimd_max(T src0, T src1, int flag = saturation_off) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Src1 = src1;
@@ -806,8 +794,7 @@ esimd_min(simd<T, SZ> src0, simd<T, SZ> src1, int flag = saturation_off) {
 /// @return vector of component-wise minimum elements.
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value,
-                                       simd<T, SZ>>
+    std::enable_if_t<detail::is_esimd_scalar<T>::value, simd<T, SZ>>
     esimd_min(simd<T, SZ> src0, T src1, int flag = saturation_off) {
   simd<T, SZ> Src1 = src1;
   simd<T, SZ> Result = esimd_min<T>(src0, Src1, flag);
@@ -826,8 +813,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// @return vector of component-wise minimum elements.
 template <typename T, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value,
-                                       simd<T, SZ>>
+    std::enable_if_t<detail::is_esimd_scalar<T>::value, simd<T, SZ>>
     esimd_min(T src0, simd<T, SZ> src1, int flag = saturation_off) {
   simd<T, SZ> Src0 = src0;
   simd<T, SZ> Result = esimd_min<T>(Src0, src1, flag);
@@ -843,8 +829,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// values: saturation_on/saturation_off.
 /// @return minimum value between the two inputs.
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_esimd_scalar<T>::value, T>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<T>::value, T>
     esimd_min(T src0, T src1, int flag = saturation_off) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Src1 = src1;
@@ -1024,13 +1010,13 @@ esimd_line(float P, float Q, simd<T, SZ> src1, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return vector of elements.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_fp_or_dword_type<T1>::value &&
-        std::is_floating_point<T1>::value &&
-        detail::is_fp_or_dword_type<U>::value &&
-        std::is_floating_point<U>::value,
-    simd<T0, SZ>>
-esimd_dp2(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_fp_or_dword_type<T1>::value &&
+                                      std::is_floating_point<T1>::value &&
+                                      detail::is_fp_or_dword_type<U>::value &&
+                                      std::is_floating_point<U>::value,
+                                  simd<T0, SZ>>
+    esimd_dp2(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
   simd<float, SZ> Src1 = src1;
@@ -1056,13 +1042,13 @@ esimd_dp2(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return vector of elements.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_fp_or_dword_type<T1>::value &&
-        std::is_floating_point<T1>::value &&
-        detail::is_fp_or_dword_type<U>::value &&
-        std::is_floating_point<U>::value,
-    simd<T0, SZ>>
-esimd_dp3(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_fp_or_dword_type<T1>::value &&
+                                      std::is_floating_point<T1>::value &&
+                                      detail::is_fp_or_dword_type<U>::value &&
+                                      std::is_floating_point<U>::value,
+                                  simd<T0, SZ>>
+    esimd_dp3(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
   simd<float, SZ> Src1 = src1;
@@ -1089,13 +1075,13 @@ esimd_dp3(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return vector of elements.
 template <typename T0, typename T1, int SZ, typename U>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_fp_or_dword_type<T1>::value &&
-        std::is_floating_point<T1>::value &&
-        detail::is_fp_or_dword_type<U>::value &&
-        std::is_floating_point<U>::value,
-    simd<T0, SZ>>
-esimd_dp4(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_fp_or_dword_type<T1>::value &&
+                                      std::is_floating_point<T1>::value &&
+                                      detail::is_fp_or_dword_type<U>::value &&
+                                      std::is_floating_point<U>::value,
+                                  simd<T0, SZ>>
+    esimd_dp4(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
   simd<T1, SZ> Src1 = src1;
@@ -1123,12 +1109,13 @@ esimd_dp4(simd<T1, SZ> src0, U src1, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return vector of elements.
 template <typename T, typename U, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_fp_or_dword_type<T>::value && std::is_floating_point<T>::value &&
-        detail::is_fp_or_dword_type<U>::value &&
-        std::is_floating_point<U>::value,
-    simd<T, SZ>>
-esimd_dph(simd<T, SZ> src0, U src1, int flag = saturation_off) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_fp_or_dword_type<T>::value &&
+                                      std::is_floating_point<T>::value &&
+                                      detail::is_fp_or_dword_type<U>::value &&
+                                      std::is_floating_point<U>::value,
+                                  simd<T, SZ>>
+    esimd_dph(simd<T, SZ> src0, U src1, int flag = saturation_off) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
   simd<float, SZ> Src1 = src1;
@@ -1155,10 +1142,10 @@ esimd_dph(simd<T, SZ> src0, U src1, int flag = saturation_off) {
 /// values: saturation_on/saturation_off.
 /// @return resulting vector from linear equation operation.
 template <typename T, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_fp_or_dword_type<T>::value &&
-                                           std::is_floating_point<T>::value,
-                                       simd<T, SZ>>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_fp_or_dword_type<T>::value &&
+                                      std::is_floating_point<T>::value,
+                                  simd<T, SZ>>
     esimd_line(simd<T, 4> src0, simd<T, SZ> src1, int flag = saturation_off) {
   static_assert(SZ % 4 == 0, "result size is not a multiple of 4");
 
@@ -1187,10 +1174,10 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// values: saturation_on/saturation_off.
 /// @return resulting vector from linear equation operation.
 template <typename T, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<detail::is_fp_or_dword_type<T>::value &&
-                                           std::is_floating_point<T>::value,
-                                       simd<T, SZ>>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_fp_or_dword_type<T>::value &&
+                                      std::is_floating_point<T>::value,
+                                  simd<T, SZ>>
     esimd_line(float P, float Q, simd<T, SZ> src1, int flag = saturation_off) {
   simd<T, 4> Src0 = P;
   Src0(3) = Q;
@@ -1232,10 +1219,11 @@ ESIMD_NODEBUG ESIMD_INLINE simd<RT, SZ> esimd_lzd(simd<T0, SZ> src0,
 }
 
 template <typename RT, typename T0>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_esimd_scalar<RT>::value && detail::is_esimd_scalar<T0>::value,
-    typename sycl::detail::remove_const_t<RT>>
-esimd_lzd(T0 src0, int flag = saturation_off) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<RT>::value &&
+                                      detail::is_esimd_scalar<T0>::value,
+                                  std::remove_const_t<RT>>
+    esimd_lzd(T0 src0, int flag = saturation_off) {
   simd<T0, 1> Src0 = src0;
   simd<RT, 1> Result = esimd_lzd<RT>(Src0);
   return Result[0];
@@ -1273,12 +1261,13 @@ esimd_lrp(simd<float, SZ> src0, U src1, V src2, int flag = saturation_off) {
 // If the gen is not specified we warn the programmer that they are potentially
 // using less efficient implementation.
 template <typename T, int SZ, typename U, typename V>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_fp_or_dword_type<T>::value && std::is_floating_point<T>::value &&
-        detail::is_fp_or_dword_type<U>::value &&
-        std::is_floating_point<U>::value,
-    simd<T, SZ>>
-esimd_lrp(simd<T, SZ> src0, U src1, V src2, int flag = saturation_off) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_fp_or_dword_type<T>::value &&
+                                      std::is_floating_point<T>::value &&
+                                      detail::is_fp_or_dword_type<U>::value &&
+                                      std::is_floating_point<U>::value,
+                                  simd<T, SZ>>
+    esimd_lrp(simd<T, SZ> src0, U src1, V src2, int flag = saturation_off) {
 
   simd<float, SZ> Src1 = src1;
   simd<float, SZ> Src2 = src2;
@@ -1327,10 +1316,11 @@ ESIMD_NODEBUG ESIMD_INLINE simd<T0, SZ> esimd_bf_reverse(simd<T1, SZ> src0) {
 }
 
 template <typename T0, typename T1>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T1>::value,
-    typename sycl::detail::remove_const_t<T0>>
-esimd_bf_reverse(T1 src0) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<T0>::value &&
+                                      detail::is_esimd_scalar<T1>::value,
+                                  std::remove_const_t<T0>>
+    esimd_bf_reverse(T1 src0) {
   simd<T1, 1> Src0 = src0;
   simd<T0, 1> Result = esimd_bf_reverse<T0>(Src0);
   return Result[0];
@@ -1338,9 +1328,8 @@ esimd_bf_reverse(T1 src0) {
 
 // esimd_bf_insert
 template <typename T0, typename T1, int SZ, typename U, typename V, typename W>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_integral<T1>::value,
-                                       simd<T0, SZ>>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<std::is_integral<T1>::value, simd<T0, SZ>>
     esimd_bf_insert(U src0, V src1, W src2, simd<T1, SZ> src3) {
   typedef typename detail::dword_type<T1> DT1;
   static_assert(std::is_integral<DT1>::value && sizeof(DT1) == sizeof(int),
@@ -1354,10 +1343,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2, typename T3, typename T4>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T4>::value,
-    typename sycl::detail::remove_const_t<T0>>
-esimd_bf_insert(T1 src0, T2 src1, T3 src2, T4 src3) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<T0>::value &&
+                                      detail::is_esimd_scalar<T4>::value,
+                                  std::remove_const_t<T0>>
+    esimd_bf_insert(T1 src0, T2 src1, T3 src2, T4 src3) {
   simd<T4, 1> Src3 = src3;
   simd<T0, 1> Result = esimd_bf_insert<T0>(src0, src1, src2, Src3);
   return Result[0];
@@ -1365,9 +1355,8 @@ esimd_bf_insert(T1 src0, T2 src1, T3 src2, T4 src3) {
 
 // esimd_bf_extract
 template <typename T0, typename T1, int SZ, typename U, typename V>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_integral<T1>::value,
-                                       simd<T0, SZ>>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<std::is_integral<T1>::value, simd<T0, SZ>>
     esimd_bf_extract(U src0, V src1, simd<T1, SZ> src2) {
   typedef typename detail::dword_type<T1> DT1;
   static_assert(std::is_integral<DT1>::value && sizeof(DT1) == sizeof(int),
@@ -1380,10 +1369,11 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T0, typename T1, typename T2, typename T3>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    detail::is_esimd_scalar<T0>::value && detail::is_esimd_scalar<T3>::value,
-    typename sycl::detail::remove_const_t<T0>>
-esimd_bf_extract(T1 src0, T2 src1, T3 src2) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<detail::is_esimd_scalar<T0>::value &&
+                                      detail::is_esimd_scalar<T3>::value,
+                                  std::remove_const_t<T0>>
+    esimd_bf_extract(T1 src0, T2 src1, T3 src2) {
   simd<T3, 1> Src2 = src2;
   simd<T0, 1> Result = esimd_bf_extract<T0>(src0, src1, Src2);
   return Result[0];
@@ -1466,8 +1456,7 @@ ESIMD_INTRINSIC_DEF(double, ieee_sqrt, sqrt_ieee)
   }                                                                            \
   template <int SZ, typename U>                                                \
   ESIMD_NODEBUG ESIMD_INLINE                                                   \
-      typename sycl::detail::enable_if_t<detail::is_esimd_scalar<U>::value,    \
-                                         simd<ftype, SZ>>                      \
+      std::enable_if_t<detail::is_esimd_scalar<U>::value, simd<ftype, SZ>>     \
           esimd_##name(U src0, simd<ftype, SZ> src1,                           \
                        int flag = saturation_off) {                            \
     simd<ftype, SZ> Src0 = src0;                                               \
@@ -1501,9 +1490,8 @@ esimd_sincos(simd<float, SZ> &dstcos, U src0, int flag = saturation_off) {
 #define ESIMD_HDR_CONST_PI 3.1415926535897932384626433832795
 
 template <typename T, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value,
-                                       simd<T, SZ>>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<std::is_floating_point<T>::value, simd<T, SZ>>
     esimd_atan(simd<T, SZ> src0, int flag = saturation_off) {
   simd<T, SZ> Src0 = esimd_abs(src0);
 
@@ -1533,9 +1521,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value, T>
-    esimd_atan(T src0, int flag = saturation_off) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<std::is_floating_point<T>::value, T>
+esimd_atan(T src0, int flag = saturation_off) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Result = esimd_atan(Src0, flag);
   return Result[0];
@@ -1544,9 +1531,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 // esimd_acos
 
 template <typename T, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value,
-                                       simd<T, SZ>>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<std::is_floating_point<T>::value, simd<T, SZ>>
     esimd_acos(simd<T, SZ> src0, int flag = saturation_off) {
   simd<T, SZ> Src0 = esimd_abs(src0);
 
@@ -1578,9 +1564,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value, T>
-    esimd_acos(T src0, int flag = saturation_off) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<std::is_floating_point<T>::value, T>
+esimd_acos(T src0, int flag = saturation_off) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Result = esimd_acos(Src0, flag);
   return Result[0];
@@ -1589,9 +1574,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 // esimd_asin
 
 template <typename T, int SZ>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value,
-                                       simd<T, SZ>>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<std::is_floating_point<T>::value, simd<T, SZ>>
     esimd_asin(simd<T, SZ> src0, int flag = saturation_off) {
   simd_mask<SZ> Neg = src0 < T(0.0);
 
@@ -1607,9 +1591,8 @@ ESIMD_NODEBUG ESIMD_INLINE
 }
 
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<std::is_floating_point<T>::value, T>
-    esimd_asin(T src0, int flag = saturation_off) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<std::is_floating_point<T>::value, T>
+esimd_asin(T src0, int flag = saturation_off) {
   simd<T, 1> Src0 = src0;
   simd<T, 1> Result = esimd_asin(Src0, flag);
   return Result[0];
@@ -1644,24 +1627,22 @@ ESIMD_INTRINSIC_DEF(rndz)
 #undef ESIMD_INTRINSIC_DEF
 
 template <int N>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<(N == 8 || N == 16 || N == 32), uint>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<(N == 8 || N == 16 || N == 32), uint>
     esimd_pack_mask(simd_mask<N> src0) {
   return __esimd_pack_mask<N>(src0.data());
 }
 
 template <int N>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<(N == 8 || N == 16 || N == 32),
-                                       simd_mask<N>>
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<(N == 8 || N == 16 || N == 32), simd_mask<N>>
     esimd_unpack_mask(uint src0) {
   return __esimd_unpack_mask<N>(src0);
 }
 
 template <int N>
-ESIMD_NODEBUG ESIMD_INLINE
-    typename sycl::detail::enable_if_t<(N != 8 && N != 16 && N < 32), uint>
-    esimd_pack_mask(simd_mask<N> src0) {
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<(N != 8 && N != 16 && N < 32), uint>
+esimd_pack_mask(simd_mask<N> src0) {
   simd_mask<(N < 8 ? 8 : N < 16 ? 16 : 32)> src_0 = 0;
   src_0.template select<N, 1>() = src0.template bit_cast_view<ushort>();
   return esimd_pack_mask(src_0);
@@ -1674,7 +1655,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// @return an \c uint, where each bit is set if the corresponding element of
 /// the source operand is non-zero and unset otherwise.
 template <typename T, int N>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_type<T, ushort, uint> && (N > 0 && N <= 32), uint>
 esimd_ballot(simd<T, N> mask) {
   simd_mask<N> cmp = (mask != 0);
@@ -1693,18 +1674,19 @@ esimd_ballot(simd<T, N> mask) {
 /// @return a vector of \c uint32_t, where each element is set to bit count of
 ///     the corresponding element of the source operand.
 template <typename T, int N>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    std::is_integral<T>::value && sizeof(T) <= 4, simd<uint32_t, N>>
-esimd_cbit(simd<T, N> src) {
+ESIMD_NODEBUG
+    ESIMD_INLINE std::enable_if_t<std::is_integral<T>::value && sizeof(T) <= 4,
+                                  simd<uint32_t, N>>
+    esimd_cbit(simd<T, N> src) {
   return __esimd_cbit<T, N>(src.data());
 }
 
 /// Scalar version of \c esimd_cbit - both input and output are scalars rather
 /// than vectors.
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    std::is_integral<T>::value && sizeof(T) <= 4, uint32_t>
-esimd_cbit(T src) {
+ESIMD_NODEBUG ESIMD_INLINE
+    std::enable_if_t<std::is_integral<T>::value && sizeof(T) <= 4, uint32_t>
+    esimd_cbit(T src) {
   simd<T, 1> Src = src;
   simd<uint32_t, 1> Result = esimd_cbit(Src);
   return Result[0];
@@ -1715,7 +1697,7 @@ esimd_cbit(T src) {
 /// @param src0 input simd_view object of size 1.
 /// @return scalar number of bits set.
 template <typename BaseTy, typename RegionTy>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<
         typename simd_view<BaseTy, RegionTy>::element_type>::value &&
         (sizeof(typename simd_view<BaseTy, RegionTy>::element_type) <= 4) &&
@@ -1736,18 +1718,18 @@ esimd_cbit(simd_view<BaseTy, RegionTy> src) {
 ///     source operand. \c 0xFFFFffff is returned for an element equal to \c 0.
 /// Find component-wise the first bit from LSB side
 template <typename T, int N>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    std::is_integral<T>::value && (sizeof(T) == 4), simd<T, N>>
-esimd_fbl(simd<T, N> src) {
+ESIMD_NODEBUG ESIMD_INLINE
+    std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4), simd<T, N>>
+    esimd_fbl(simd<T, N> src) {
   return __esimd_fbl<T, N>(src.data());
 }
 
 /// Scalar version of \c esimd_fbl - both input and output are scalars rather
 /// than vectors.
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    std::is_integral<T>::value && (sizeof(T) == 4), T>
-esimd_fbl(T src) {
+ESIMD_NODEBUG ESIMD_INLINE
+    std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4), T>
+    esimd_fbl(T src) {
   simd<T, 1> Src = src;
   simd<T, 1> Result = esimd_fbl(Src);
   return Result[0];
@@ -1759,7 +1741,7 @@ esimd_fbl(T src) {
 /// @return scalar number of the first bit set starting from the least
 /// significant bit.
 template <typename BaseTy, typename RegionTy>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<
         typename simd_view<BaseTy, RegionTy>::element_type>::value &&
         (sizeof(typename simd_view<BaseTy, RegionTy>::element_type) == 4) &&
@@ -1780,7 +1762,7 @@ esimd_fbl(simd_view<BaseTy, RegionTy> src) {
 ///     source operand. \c 0xFFFFffff is returned for an element equal to \c 0
 ///     or \c -1.
 template <typename T, int N>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<T>::value && std::is_signed<T>::value && (sizeof(T) == 4),
     simd<T, N>>
 esimd_fbh(simd<T, N> src) {
@@ -1794,7 +1776,7 @@ esimd_fbh(simd<T, N> src) {
 ///     is set to the number first bit set in corresponding element of the
 ///     source operand. \c 0xFFFFffff is returned for an element equal to \c 0.
 template <typename T, int N>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<T>::value && !std::is_signed<T>::value && (sizeof(T) == 4),
     simd<T, N>>
 esimd_fbh(simd<T, N> src) {
@@ -1804,9 +1786,9 @@ esimd_fbh(simd<T, N> src) {
 /// Scalar version of \c esimd_fbh - both input and output are scalars rather
 /// than vectors.
 template <typename T>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
-    std::is_integral<T>::value && (sizeof(T) == 4), T>
-esimd_fbh(T src) {
+ESIMD_NODEBUG ESIMD_INLINE
+    std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4), T>
+    esimd_fbh(T src) {
   simd<T, 1> Src = src;
   simd<T, 1> Result = esimd_fbh(Src);
   return Result[0];
@@ -1818,7 +1800,7 @@ esimd_fbh(T src) {
 /// @return scalar number of the first bit set starting from the most
 /// significant bit.
 template <typename BaseTy, typename RegionTy>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     std::is_integral<
         typename simd_view<BaseTy, RegionTy>::element_type>::value &&
         (sizeof(typename simd_view<BaseTy, RegionTy>::element_type) == 4) &&
@@ -1844,7 +1826,7 @@ esimd_fbh(simd_view<BaseTy, RegionTy> src) {
 /// Returns simd vector of the dp4a operation result.
 ///
 template <typename T1, typename T2, typename T3, typename T4, int N>
-ESIMD_NODEBUG ESIMD_INLINE typename sycl::detail::enable_if_t<
+ESIMD_NODEBUG ESIMD_INLINE std::enable_if_t<
     detail::is_dword_type<T1>::value && detail::is_dword_type<T2>::value &&
         detail::is_dword_type<T3>::value && detail::is_dword_type<T4>::value,
     simd<T1, N>>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -122,12 +122,11 @@ ESIMD_INLINE ESIMD_NODEBUG SurfaceIndex get_surface_index(AccessorTy acc) {
 /// \ingroup sycl_esimd
 template <typename T, int n, int ElemsPerAddr = 1,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
-ESIMD_INLINE ESIMD_NODEBUG
-    typename std::enable_if_t<((n == 8 || n == 16 || n == 32) &&
-                               (ElemsPerAddr == 1 || ElemsPerAddr == 2 ||
-                                ElemsPerAddr == 4)),
-                              simd<T, n * ElemsPerAddr>>
-    gather(T *p, simd<uint32_t, n> offsets, simd_mask<n> pred = 1) {
+ESIMD_INLINE ESIMD_NODEBUG std::enable_if_t<
+    ((n == 8 || n == 16 || n == 32) &&
+     (ElemsPerAddr == 1 || ElemsPerAddr == 2 || ElemsPerAddr == 4)),
+    simd<T, n * ElemsPerAddr>>
+gather(const T *p, simd<uint32_t, n> offsets, simd_mask<n> pred = 1) {
 
   simd<uint64_t, n> offsets_i = convert<uint64_t>(offsets);
   simd<uint64_t, n> addrs(reinterpret_cast<uint64_t>(p));
@@ -172,13 +171,11 @@ ESIMD_INLINE ESIMD_NODEBUG
 /// \ingroup sycl_esimd
 template <typename T, int n, int ElemsPerAddr = 1,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
-ESIMD_INLINE ESIMD_NODEBUG
-    typename std::enable_if_t<((n == 8 || n == 16 || n == 32) &&
-                               (ElemsPerAddr == 1 || ElemsPerAddr == 2 ||
-                                ElemsPerAddr == 4)),
-                              void>
-    scatter(T *p, simd<T, n * ElemsPerAddr> vals, simd<uint32_t, n> offsets,
-            simd_mask<n> pred = 1) {
+ESIMD_INLINE ESIMD_NODEBUG std::enable_if_t<
+    ((n == 8 || n == 16 || n == 32) &&
+     (ElemsPerAddr == 1 || ElemsPerAddr == 2 || ElemsPerAddr == 4))>
+scatter(T *p, simd<T, n * ElemsPerAddr> vals, simd<uint32_t, n> offsets,
+        simd_mask<n> pred = 1) {
   simd<uint64_t, n> offsets_i = convert<uint64_t>(offsets);
   simd<uint64_t, n> addrs(reinterpret_cast<uint64_t>(p));
   addrs = addrs + offsets_i;
@@ -222,7 +219,7 @@ ESIMD_INLINE ESIMD_NODEBUG
 template <typename T, int n, CacheHint L1H = CacheHint::None,
           CacheHint L3H = CacheHint::None>
 __SYCL_DEPRECATED("use simd::copy_from.")
-ESIMD_INLINE ESIMD_NODEBUG simd<T, n> block_load(const T *const addr) {
+ESIMD_INLINE ESIMD_NODEBUG simd<T, n> block_load(const T *addr) {
   constexpr unsigned Sz = sizeof(T) * n;
   static_assert(Sz >= detail::OperandSize::OWORD,
                 "block size must be at least 1 oword");
@@ -282,11 +279,10 @@ ESIMD_INLINE ESIMD_NODEBUG
 namespace detail {
 template <typename T, int N, typename AccessorTy, bool ScaleOffset = false,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
-ESIMD_INLINE ESIMD_NODEBUG
-    typename std::enable_if_t<(sizeof(T) <= 4) &&
-                                  (N == 1 || N == 8 || N == 16 || N == 32) &&
-                                  !std::is_pointer<AccessorTy>::value,
-                              void>
+ESIMD_INLINE
+    ESIMD_NODEBUG std::enable_if_t<(sizeof(T) <= 4) &&
+                                   (N == 1 || N == 8 || N == 16 || N == 32) &&
+                                   !std::is_pointer<AccessorTy>::value>
     scatter_impl(AccessorTy acc, simd<T, N> vals, simd<uint32_t, N> offsets,
                  uint32_t glob_offset, simd_mask<N> pred) {
   constexpr int TypeSizeLog2 = detail::ElemsPerAddrEncoding<sizeof(T)>();
@@ -317,13 +313,12 @@ ESIMD_INLINE ESIMD_NODEBUG
 
 template <typename T, int N, typename AccessorTy, bool ScaleOffset = false,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
-ESIMD_INLINE ESIMD_NODEBUG
-    typename std::enable_if_t<(sizeof(T) <= 4) &&
-                                  (N == 1 || N == 8 || N == 16 || N == 32) &&
-                                  !std::is_pointer<AccessorTy>::value,
-                              simd<T, N>>
-    gather_impl(AccessorTy acc, simd<uint32_t, N> offsets, uint32_t glob_offset,
-                simd_mask<N> pred) {
+ESIMD_INLINE ESIMD_NODEBUG std::enable_if_t<
+    (sizeof(T) <= 4) && (N == 1 || N == 8 || N == 16 || N == 32) &&
+        !std::is_pointer<AccessorTy>::value,
+    simd<T, N>>
+gather_impl(AccessorTy acc, simd<uint32_t, N> offsets, uint32_t glob_offset,
+            simd_mask<N> pred) {
 
   constexpr int TypeSizeLog2 = detail::ElemsPerAddrEncoding<sizeof(T)>();
   // TODO (performance) use hardware-supported scale once BE supports it
@@ -373,13 +368,12 @@ ESIMD_INLINE ESIMD_NODEBUG
 /// \ingroup sycl_esimd
 template <typename T, int N, typename AccessorTy,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
-ESIMD_INLINE ESIMD_NODEBUG
-    typename std::enable_if_t<(sizeof(T) <= 4) &&
-                                  (N == 1 || N == 8 || N == 16 || N == 32) &&
-                                  !std::is_pointer<AccessorTy>::value,
-                              simd<T, N>>
-    gather(AccessorTy acc, simd<uint32_t, N> offsets, uint32_t glob_offset = 0,
-           simd_mask<N> pred = 1) {
+ESIMD_INLINE ESIMD_NODEBUG std::enable_if_t<
+    (sizeof(T) <= 4) && (N == 1 || N == 8 || N == 16 || N == 32) &&
+        !std::is_pointer<AccessorTy>::value,
+    simd<T, N>>
+gather(AccessorTy acc, simd<uint32_t, N> offsets, uint32_t glob_offset = 0,
+       simd_mask<N> pred = 1) {
 
   return detail::gather_impl<T, N, AccessorTy, true, L1H, L3H>(
       acc, offsets, glob_offset, pred);
@@ -406,11 +400,10 @@ ESIMD_INLINE ESIMD_NODEBUG
 /// \ingroup sycl_esimd
 template <typename T, int N, typename AccessorTy,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
-ESIMD_INLINE ESIMD_NODEBUG
-    typename std::enable_if_t<(sizeof(T) <= 4) &&
-                                  (N == 1 || N == 8 || N == 16 || N == 32) &&
-                                  !std::is_pointer<AccessorTy>::value,
-                              void>
+ESIMD_INLINE
+    ESIMD_NODEBUG std::enable_if_t<(sizeof(T) <= 4) &&
+                                   (N == 1 || N == 8 || N == 16 || N == 32) &&
+                                   !std::is_pointer<AccessorTy>::value>
     scatter(AccessorTy acc, simd<T, N> vals, simd<uint32_t, N> offsets,
             uint32_t glob_offset = 0, simd_mask<N> pred = 1) {
 
@@ -450,10 +443,10 @@ ESIMD_INLINE ESIMD_NODEBUG void scalar_store(AccessorTy acc, uint32_t offset,
 /// \ingroup sycl_esimd
 template <typename T, int N, rgba_channel_mask Mask,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
-ESIMD_INLINE ESIMD_NODEBUG
-    typename std::enable_if_t<(N == 16 || N == 32) && (sizeof(T) == 4),
-                              simd<T, N * get_num_channels_enabled(Mask)>>
-    gather_rgba(T *p, simd<uint32_t, N> offsets, simd_mask<N> pred = 1) {
+ESIMD_INLINE
+    ESIMD_NODEBUG std::enable_if_t<(N == 16 || N == 32) && (sizeof(T) == 4),
+                                   simd<T, N * get_num_channels_enabled(Mask)>>
+    gather_rgba(const T *p, simd<uint32_t, N> offsets, simd_mask<N> pred = 1) {
 
   simd<uint64_t, N> offsets_i = convert<uint64_t>(offsets);
   simd<uint64_t, N> addrs(reinterpret_cast<uint64_t>(p));
@@ -468,9 +461,9 @@ ESIMD_INLINE ESIMD_NODEBUG
 template <typename T, int n, rgba_channel_mask Mask,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
 __SYCL_DEPRECATED("use gather_rgba.")
-ESIMD_INLINE ESIMD_NODEBUG typename std::enable_if_t<
+ESIMD_INLINE ESIMD_NODEBUG std::enable_if_t<
     (n == 16 || n == 32) && (sizeof(T) == 4),
-    simd<T, n * get_num_channels_enabled(Mask)>> gather4(T *p,
+    simd<T, n * get_num_channels_enabled(Mask)>> gather4(const T *p,
                                                          simd<uint32_t, n>
                                                              offsets,
                                                          simd_mask<n> pred =
@@ -491,8 +484,8 @@ ESIMD_INLINE ESIMD_NODEBUG typename std::enable_if_t<
 /// \ingroup sycl_esimd
 template <typename T, int N, rgba_channel_mask Mask,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
-ESIMD_INLINE ESIMD_NODEBUG
-    typename std::enable_if_t<(N == 16 || N == 32) && (sizeof(T) == 4), void>
+ESIMD_INLINE
+    ESIMD_NODEBUG std::enable_if_t<(N == 16 || N == 32) && (sizeof(T) == 4)>
     scatter_rgba(T *p, simd<T, N * get_num_channels_enabled(Mask)> vals,
                  simd<uint32_t, N> offsets, simd_mask<N> pred = 1) {
   simd<uint64_t, N> offsets_i = convert<uint64_t>(offsets);
@@ -507,10 +500,10 @@ ESIMD_INLINE ESIMD_NODEBUG
 template <typename T, int n, rgba_channel_mask Mask,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
 __SYCL_DEPRECATED("use scatter_rgba.")
-ESIMD_INLINE ESIMD_NODEBUG typename std::enable_if_t<
-    (n == 16 || n == 32) && (sizeof(T) == 4),
-    void> scatter4(T *p, simd<T, n * get_num_channels_enabled(Mask)> vals,
-                   simd<uint32_t, n> offsets, simd_mask<n> pred = 1) {
+ESIMD_INLINE ESIMD_NODEBUG
+    std::enable_if_t<(n == 16 || n == 32) && sizeof(T) == 4> scatter4(
+        T *p, simd<T, n * get_num_channels_enabled(Mask)> vals,
+        simd<uint32_t, n> offsets, simd_mask<n> pred = 1) {
   scatter_rgba<T, n, Mask, L1H, L3H>(p, vals, offsets, pred);
 }
 
@@ -618,7 +611,7 @@ constexpr bool check_atomic() {
 template <atomic_op Op, typename T, int n, CacheHint L1H = CacheHint::None,
           CacheHint L3H = CacheHint::None>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if_t<detail::check_atomic<Op, T, n, 0>(), simd<T, n>>
+    std::enable_if_t<detail::check_atomic<Op, T, n, 0>(), simd<T, n>>
     flat_atomic(T *p, simd<unsigned, n> offset, simd_mask<n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
   simd<uintptr_t, n> offset_i1 = convert<uintptr_t>(offset);
@@ -631,7 +624,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 template <atomic_op Op, typename T, int n, CacheHint L1H = CacheHint::None,
           CacheHint L3H = CacheHint::None>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if_t<detail::check_atomic<Op, T, n, 1>(), simd<T, n>>
+    std::enable_if_t<detail::check_atomic<Op, T, n, 1>(), simd<T, n>>
     flat_atomic(T *p, simd<unsigned, n> offset, simd<T, n> src0,
                 simd_mask<n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
@@ -646,7 +639,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 template <atomic_op Op, typename T, int n, CacheHint L1H = CacheHint::None,
           CacheHint L3H = CacheHint::None>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if_t<detail::check_atomic<Op, T, n, 2>(), simd<T, n>>
+    std::enable_if_t<detail::check_atomic<Op, T, n, 2>(), simd<T, n>>
     flat_atomic(T *p, simd<unsigned, n> offset, simd<T, n> src0,
                 simd<T, n> src1, simd_mask<n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
@@ -728,7 +721,7 @@ __SYCL_DEPRECATED("use slm_gather.")
 ESIMD_INLINE ESIMD_NODEBUG
     std::enable_if_t<(n == 1 || n == 8 || n == 16 || n == 32),
                      simd<T, n>> slm_load(simd<uint32_t, n> offsets,
-                                          simd<uint16_t, n> pred = 1) {
+                                          simd_mask<n> pred = 1) {
   return slm_gather<T, n>(offsets, pred);
 }
 
@@ -756,7 +749,7 @@ slm_scatter(simd<T, n> vals, simd<uint32_t, n> offsets, simd_mask<n> pred = 1) {
 template <typename T, int n>
 __SYCL_DEPRECATED("use slm_scatter.")
 ESIMD_INLINE ESIMD_NODEBUG std::enable_if_t<(n == 16 || n == 32)> slm_store(
-    simd<T, n> vals, simd<uint32_t, n> offsets, simd<uint16_t, n> pred = 1) {
+    simd<T, n> vals, simd<uint32_t, n> offsets, simd_mask<n> pred = 1) {
   slm_scatter<T, n>(vals, offsets, pred);
 }
 
@@ -783,7 +776,7 @@ template <typename T, int N, rgba_channel_mask Mask>
 ESIMD_INLINE ESIMD_NODEBUG
     std::enable_if_t<(N == 8 || N == 16 || N == 32) && (sizeof(T) == 4),
                      simd<T, N * get_num_channels_enabled(Mask)>>
-    slm_gather_rgba(simd<uint32_t, N> offsets, simd<uint16_t, N> pred = 1) {
+    slm_gather_rgba(simd<uint32_t, N> offsets, simd_mask<N> pred = 1) {
 
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
   return __esimd_gather4_scaled<T, N, decltype(si), Mask>(
@@ -875,7 +868,7 @@ ESIMD_INLINE ESIMD_NODEBUG void slm_block_store(uint32_t offset,
 /// SLM atomic, zero source operand: inc and dec.
 template <atomic_op Op, typename T, int n>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if_t<detail::check_atomic<Op, T, n, 0>(), simd<T, n>>
+    std::enable_if_t<detail::check_atomic<Op, T, n, 0>(), simd<T, n>>
     slm_atomic(simd<uint32_t, n> offsets, simd_mask<n> pred) {
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
   return __esimd_dword_atomic0<Op, T, n>(pred.data(), si, offsets.data());
@@ -884,7 +877,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// SLM atomic, one source operand, add/sub/min/max etc.
 template <atomic_op Op, typename T, int n>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if_t<detail::check_atomic<Op, T, n, 1>(), simd<T, n>>
+    std::enable_if_t<detail::check_atomic<Op, T, n, 1>(), simd<T, n>>
     slm_atomic(simd<uint32_t, n> offsets, simd<T, n> src0, simd_mask<n> pred) {
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
   return __esimd_dword_atomic1<Op, T, n>(pred.data(), si, offsets.data(),
@@ -894,7 +887,7 @@ ESIMD_NODEBUG ESIMD_INLINE
 /// SLM atomic, two source operands.
 template <atomic_op Op, typename T, int n>
 ESIMD_NODEBUG ESIMD_INLINE
-    typename std::enable_if_t<detail::check_atomic<Op, T, n, 2>(), simd<T, n>>
+    std::enable_if_t<detail::check_atomic<Op, T, n, 2>(), simd<T, n>>
     slm_atomic(simd<uint32_t, n> offsets, simd<T, n> src0, simd<T, n> src1,
                simd_mask<n> pred) {
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());


### PR DESCRIPTION
This patch also included some NFC changes removing the old sycl::detail
utilities that temporarily substituted standard c++14 type-trait utilities.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>