### PR TITLE
[SYCL] Include backend-specific header if exists

### DIFF
--- a/sycl/include/CL/sycl/feature_test.hpp.in
+++ b/sycl/include/CL/sycl/feature_test.hpp.in
@@ -49,7 +49,7 @@ namespace sycl {
 } // __SYCL_INLINE_NAMESPACE(cl)
 
 #include <CL/sycl/backend/opencl.hpp>
-// Level Zero backend header depeneds on external headers and should be
+// Level Zero backend header depends on external headers and should be
 // included by user application directly
 // #include <sycl/ext/oneapi/backend/level_zero.hpp>
 


### PR DESCRIPTION
https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:headers-and-namespaces
introduces the backend specific headers "sycl/backend/<backend_name>.hpp"
CTS tests assume that if backend macro is defined (e.g. SYCL_BACKEND_OPENCL)
it is fully functional without extra includes. So the patch adds
include of the backend specific header when the backend is enabled.

The change  should fix the recent massive failure of CTS tests with the error:
```implicit instantiation of undefined template 'sycl::interop<sycl::backend::opencl, sycl::platform>'```
