### PR TITLE
[SYCL] Release global shared implementation pointers early

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -89,10 +89,8 @@ std::mutex &GlobalHandler::getHandlerExtendedMembersMutex() {
   return getOrCreate(MHandlerExtendedMembersMutex);
 }
 
-void shutdown() {
-  // First, release resources, that may access plugins.
-  GlobalHandler::instance().MScheduler.Inst.reset(nullptr);
-  GlobalHandler::instance().MProgramManager.Inst.reset(nullptr);
+void releaseSharedGlobalHandles() {
+  // Release shared-pointers to SYCL objects.
 #ifndef _WIN32
   GlobalHandler::instance().MPlatformToDefaultContextCache.Inst.reset(nullptr);
 #else
@@ -104,6 +102,12 @@ void shutdown() {
   GlobalHandler::instance().MPlatformToDefaultContextCache.Inst.release();
 #endif
   GlobalHandler::instance().MPlatformCache.Inst.reset(nullptr);
+}
+
+void shutdown() {
+  // First, release resources, that may access plugins.
+  GlobalHandler::instance().MScheduler.Inst.reset(nullptr);
+  GlobalHandler::instance().MProgramManager.Inst.reset(nullptr);
 
   // Call to GlobalHandler::instance().getPlugins() initializes plugins. If
   // user application has loaded SYCL runtime, and never called any APIs,
@@ -131,6 +135,7 @@ extern "C" __SYCL_EXPORT BOOL WINAPI DllMain(HINSTANCE hinstDLL,
   // Perform actions based on the reason for calling.
   switch (fdwReason) {
   case DLL_PROCESS_DETACH:
+    releaseSharedGlobalHandles();
     shutdown();
     break;
   case DLL_PROCESS_ATTACH:
@@ -141,6 +146,14 @@ extern "C" __SYCL_EXPORT BOOL WINAPI DllMain(HINSTANCE hinstDLL,
   return TRUE; // Successful DLL_PROCESS_ATTACH.
 }
 #else
+// Release shared SYCL object implementation handles at normal destructor
+// priority to avoid the global handler from keeping the objects alive after
+// the backends have destroyed any state they may rely on to correctly handle
+// further operations.
+__attribute__((destructor)) static void syclPreunload() {
+  releaseSharedGlobalHandles();
+}
+
 // Setting low priority on destructor ensures it runs after all other global
 // destructors. Priorities 0-100 are reserved by the compiler. The priority
 // value 110 allows SYCL users to run their destructors after runtime library

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -69,6 +69,7 @@ public:
   std::mutex &getHandlerExtendedMembersMutex();
 
 private:
+  friend void releaseSharedGlobalHandles();
   friend void shutdown();
 
   // Constructor and destructor are declared out-of-line to allow incomplete


### PR DESCRIPTION
Currently the global handler keeps shared pointers to SYCL object implementations alive until an intentionally late destruction. Backends that rely on global state may destroy its global state prior to the global handler releasing its references to SYCL object implementations that are in turn keeping backend objects alive.
These changes enforce a release of the global handler's references to globally tracked SYCL objects at regular global destructor time to avoid the objects unintentionally staying alive for too long.