### PR TITLE
[NFC] Update sycl-instrumentation.c test to use local sysroot

### DIFF
--- a/clang/test/Driver/sycl-instrumentation.c
+++ b/clang/test/Driver/sycl-instrumentation.c
@@ -4,10 +4,10 @@
 /// 1. A SPIR-V-based environment must be targetted
 /// 2. The corresponding Driver option must be enabled explicitly
 
-// RUN: %clangxx -fsycl -fsycl-instrument-device-code -fsycl-targets=spir64 -### %s 2>&1 \
+// RUN: %clangxx -fsycl -fsycl-instrument-device-code --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-SPIRV,CHECK-HOST %s
 /// -fno-sycl-device-lib mustn't affect the linkage of ITT libraries
-// RUN: %clangxx -fsycl -fsycl-instrument-device-code -fno-sycl-device-lib=all -fsycl-targets=spir64 -### %s 2>&1 \
+// RUN: %clangxx -fsycl -fsycl-instrument-device-code --sysroot=%S/Inputs/SYCL -fno-sycl-device-lib=all -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-SPIRV %s
 
 // CHECK-SPIRV: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-instrument-device-code"


### PR DESCRIPTION
Use the local testing SYCL root for finding the libsycl-itt device
objects, as not all builds will be creating the objects for the test
to properly pass.