### PR TITLE
[LIBCLC][PTX] Fix logical bug in mul_hi for smaller datatypes

### DIFF
--- a/libclc/ptx-nvidiacl/libspirv/integer/mul_hi.cl
+++ b/libclc/ptx-nvidiacl/libspirv/integer/mul_hi.cl
@@ -30,7 +30,8 @@ _CLC_OVERLOAD _CLC_DEF ulong __spirv_ocl_u_mul_hi(ulong x, ulong y) {
 
 #define __CLC_MUL_HI_IMPL(BGENTYPE, SPV_MUL_HI, GENTYPE, GENSIZE)              \
   _CLC_OVERLOAD _CLC_DEF GENTYPE SPV_MUL_HI(GENTYPE x, GENTYPE y) {            \
-    return (GENTYPE)SPV_MUL_HI((BGENTYPE)(((BGENTYPE)x) << GENSIZE), (BGENTYPE)y);         \
+    return (GENTYPE)SPV_MUL_HI((BGENTYPE)(((BGENTYPE)x) << GENSIZE),           \
+                               (BGENTYPE)y);                                   \
   }
 
 __CLC_MUL_HI_IMPL(short, __spirv_ocl_s_mul_hi, char, 8)


### PR DESCRIPTION
Fixing incorrect implementation of mul_hi for smaller datatypes in ptx-nvidiacl.