### PR TITLE
[SYCL][NFC] Fix attribute documentation formatting

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -417,11 +417,11 @@ The types that own this attribute are excluded from device-copyable and other
 type-legalization steps.
 
 .. code-block:: c++
-  class __attribute__((sycl_special_class)) accessor {
 
-private:
-  void __init() {}
-};
+  class __attribute__((sycl_special_class)) accessor {
+    private:
+      void __init() {}
+  };
   }];
 }
 


### PR DESCRIPTION
Doxygen reports following warning (treated as an error by CI system):

> clang/docs/AttributeReference.rst:7004:Error in "code-block" directive:
> maximum 1 argument(s) allowed, 5 supplied.
> 
> .. code-block:: c++
>   class __attribute__((sycl_special_class)) accessor {
> 

The problem here seems to be that `code-block` mark must be followed by
an empty line.

This patch also fixes code indentation.