### PR TITLE
[SYCL][CUDA][HIP] Update CUDA and HIP libspirv file diagnostic errors

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -90,16 +90,9 @@ def warn_drv_partially_supported_cuda_version: Warning<
   InGroup<CudaUnknownVersion>;
 def err_drv_cuda_host_arch : Error<
   "unsupported architecture '%0' for host compilation">;
-def err_drv_no_sycl_cuda_libspirv : Error<
-  "cannot find suitable 'libspirv-nvptx64--nvidiacl.bc' variant; provide path to "
-  "libspirv library via '-fsycl-libspirv-path' or pass '-fno-sycl-libspirv' to " 
-  "build without linking with libspirv. Provide path to "
-  "'remangled-l64-signed_char.libspirv-nvptx64--nvidiacl.bc' for Linux " 
-  "or 'remangled-l32-signed_char.libspirv-nvptx64--nvidiacl.bc' for Windows">;
-def err_drv_no_sycl_hip_libspirv : Error<
-  "cannot find 'remangled-l64-signed_char.libspirv-amdgcn--amdhsa.bc'; provide path " 
-  "to libspirv library via '-fsycl-libspirv-path', or pass '-fno-sycl-libspirv' to "
-  "build without linking with libspirv">;
+def err_drv_no_sycl_libspirv : Error<
+  "cannot find '%0'; provide path to libspirv library via '-fsycl-libspirv-path' or " 
+  "pass '-fno-sycl-libspirv' to build without linking with libspirv.">;
 def err_drv_mix_cuda_hip : Error<
   "mixed CUDA and HIP compilation is not supported">;
 def err_drv_bad_target_id : Error<

--- a/clang/lib/Driver/ToolChains/HIP.cpp
+++ b/clang/lib/Driver/ToolChains/HIP.cpp
@@ -240,6 +240,10 @@ HIPToolChain::HIPToolChain(const Driver &D, const llvm::Triple &Triple,
   getProgramPaths().push_back(getDriver().Dir);
 }
 
+static const char *getLibSpirvTargetName(const ToolChain &HostTC) {
+  return "remangled-l64-signed_char.libspirv-amdgcn--amdhsa.bc";
+}
+
 void HIPToolChain::addClangTargetOptions(
     const llvm::opt::ArgList &DriverArgs,
     llvm::opt::ArgStringList &CC1Args,
@@ -309,8 +313,7 @@ void HIPToolChain::addClangTargetOptions(
       llvm::sys::path::append(WithInstallPath, Twine("../../../share/clc"));
       LibraryPaths.emplace_back(WithInstallPath.c_str());
 
-      std::string LibSpirvTargetName =
-          "remangled-l64-signed_char.libspirv-amdgcn--amdhsa.bc";
+      std::string LibSpirvTargetName = getLibSpirvTargetName(HostTC);
       for (StringRef LibraryPath : LibraryPaths) {
         SmallString<128> LibSpirvTargetFile(LibraryPath);
         llvm::sys::path::append(LibSpirvTargetFile, LibSpirvTargetName);
@@ -322,7 +325,8 @@ void HIPToolChain::addClangTargetOptions(
     }
 
     if (LibSpirvFile.empty()) {
-      getDriver().Diag(diag::err_drv_no_sycl_hip_libspirv);
+      getDriver().Diag(diag::err_drv_no_sycl_libspirv)
+          << getLibSpirvTargetName(HostTC);
       return;
     }
 

--- a/clang/test/Driver/sycl-libspirv-invalid.cpp
+++ b/clang/test/Driver/sycl-libspirv-invalid.cpp
@@ -3,25 +3,31 @@
 // UNSUPPORTED: system-windows
 
 // RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
-// RUN: -fsycl-targets=nvptx64-nvidia-nvcl --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
+// RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc %s 2>&1 \
 // RUN: | FileCheck --check-prefix=ERR-CUDA %s
-// ERR-CUDA: cannot find suitable 'libspirv-nvptx64--nvidiacl.bc' variant
+// ERR-CUDA: cannot find 'remangled-l64-signed_char.libspirv-nvptx64--nvidiacl.bc'
+
+// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-windows-msvc -fsycl \
+// RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
+// RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc %s 2>&1 \
+// RUN: | FileCheck --check-prefix=ERR-CUDA-WIN %s
+// ERR-CUDA-WIN: cannot find 'remangled-l32-signed_char.libspirv-nvptx64--nvidiacl.bc'
 
 // RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
-// RUN: -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
+// RUN: -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc %s 2>&1 \
 // RUN: | FileCheck --check-prefix=ERR-HIP %s
 // ERR-HIP: cannot find 'remangled-l64-signed_char.libspirv-amdgcn--amdhsa.bc'
 
 // RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
-// RUN: -fsycl-targets=nvptx64-nvidia-nvcl --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
+// RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck --check-prefix=OK-CUDA %s
-// OK-CUDA-NOT: cannot find suitable 'libspirv-nvptx64--nvidiacl.bc' variant
+// OK-CUDA-NOT: cannot find suitable 'remangled-l64-signed_char.libspirv-nvptx64--nvidiacl.bc'
 
 // RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
-// RUN: -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
+// RUN: -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck --check-prefix=OK-HIP %s
 // OK-HIP-NOT: cannot find 'remangled-l64-signed_char.libspirv-amdgcn--amdhsa.bc'


### PR DESCRIPTION
This patch updates CUDA and HIP's diagnostic errors for libspirv.
Currently, they do not reflect that the libspirv file becomes remangled and is looking for different variants depending upon the OS.
The HIP error also throws the same error as CUDA creating an incorrect message.

This patch resolves these two problems and creates adds HIP tests for the error messages.

This is proposed as a solution to fix #4370 