### PR TITLE
[SYCL] Define SYCL_DISABLE_FALLBACK_ASSERT macro

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1198,8 +1198,10 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
         DeviceSubArch != llvm::Triple::SPIRSubArch_fpga)
       Builder.defineMacro("SYCL_USE_NATIVE_FP_ATOMICS");
     // Enable generation of USM address spaces for FPGA.
-    if (DeviceSubArch == llvm::Triple::SPIRSubArch_fpga)
+    if (DeviceSubArch == llvm::Triple::SPIRSubArch_fpga) {
       Builder.defineMacro("__ENABLE_USM_ADDR_SPACE__");
+      Builder.defineMacro("SYCL_DISABLE_FALLBACK_ASSERT");
+    }
   }
   if (LangOpts.SYCLUnnamedLambda)
     Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__");

--- a/clang/test/Preprocessor/sycl-macro-target-specific.cpp
+++ b/clang/test/Preprocessor/sycl-macro-target-specific.cpp
@@ -36,3 +36,16 @@
 // RUN: | FileCheck --check-prefix=CHECK-USM-ADDR-SPACE-NEG %s
 // CHECK-USM-ADDR-SPACE: #define __ENABLE_USM_ADDR_SPACE__
 // CHECK-USM-ADDR-SPACE-NEG-NOT: #define __ENABLE_USM_ADDR_SPACE__
+
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_fpga-unknown-unknown -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-DISABLE-FALLBACK-ASSERT %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64-unknown-unknown -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-DISABLE-FALLBACK-ASSERT-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_gen-unknown-unknown -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-DISABLE-FALLBACK-ASSERT-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_x86_64-unknown-unknown -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-DISABLE-FALLBACK-ASSERT-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple nvptx64-nvidia-nvcl -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-DISABLE-FALLBACK-ASSERT-NEG %s
+// CHECK-DISABLE-FALLBACK-ASSERT: #define SYCL_DISABLE_FALLBACK_ASSERT
+// CHECK-DISABLE-FALLBACK-ASSERT-NEG-NOT: #define SYCL_DISABLE_FALLBACK_ASSERT


### PR DESCRIPTION
Define SYCL_DISABLE_FALLBACK_ASSERT for FPGA

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>