### PR TITLE
[ESIMD] Fix is_esimd_arithmetic_type internal problem.

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
@@ -179,12 +179,12 @@ struct is_esimd_arithmetic_type : std::false_type {};
 
 template <class Ty>
 struct is_esimd_arithmetic_type<
-    Ty, __esimd_void_t<decltype(std::declval<Ty>() + std::declval<Ty>()),
+    Ty, __esimd_void_t<std::enable_if_t<std::is_arithmetic_v<Ty>>,
+                       decltype(std::declval<Ty>() + std::declval<Ty>()),
                        decltype(std::declval<Ty>() - std::declval<Ty>()),
                        decltype(std::declval<Ty>() * std::declval<Ty>()),
                        decltype(std::declval<Ty>() / std::declval<Ty>())>>
-    : std::conditional_t<std::is_arithmetic_v<Ty>, std::true_type,
-                         std::false_type> {};
+    : std::true_type {};
 
 template <typename Ty>
 static inline constexpr bool is_esimd_arithmetic_type_v =

--- a/sycl/test/esimd/regression/is_esimd_arithmetic_type.cpp
+++ b/sycl/test/esimd/regression/is_esimd_arithmetic_type.cpp
@@ -1,0 +1,31 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+
+// Check that is_esimd_arithmetic_type works as expected on simd and simd_view
+// types.
+
+#include <sycl/ext/intel/experimental/esimd.hpp>
+
+using namespace sycl::ext::intel::experimental::esimd;
+
+constexpr bool foo0() {
+  return __SEIEED::is_esimd_arithmetic_type_v<simd<int, 8>>;
+}
+
+constexpr bool foo1() {
+  return __SEIEED::is_esimd_arithmetic_type_v<
+      simd_view<simd<int, 8>, region1d_t<int, 8, 1>>>;
+}
+
+SYCL_EXTERNAL void foo() SYCL_ESIMD_FUNCTION {
+  static_assert(!foo0() && !foo1(), "");
+}
+
+// This models original user code where compilation failure occurred.
+// Similar code exists in operators.cpp, but somehow presence of '^='
+// operation (commented out below) hid the problem and compiler did not fail.
+SYCL_EXTERNAL auto foo2(simd<char, 8> x, simd<char, 8> x1,
+                        simd<char, 8> y) SYCL_ESIMD_FUNCTION {
+  //{ auto k = x1 ^= x1; }
+  { auto v = x ^ y; }
+}


### PR DESCRIPTION
In some cases 'computation_type_t' meta-function call lead to call to this
template <class Ty> struct is_esimd_arithmetic_type<
    Ty, __esimd_void_t<std::enable_if_t<std::is_arithmetic_v<Ty>>,
                       decltype(std::declval<Ty>() + std::declval<Ty>()),
					   ...>>
meta-function with Ty being a simd type, which caused
decltype(std::declval<Ty>() + std::declval<Ty>()) to fail (it is not supposed to
be invoked with a simd type).

The fix is to enable SFINAE in is_esimd_arithmetic_type in the case when std::is_arithmetic_v<Ty> is false, and therefore the second partial specialization of is_esimd_arithmetic_type won't participate in resolution.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>