### PR TITLE
[SYCL] Disable std::byte code by _HAS_STD_BYTE

### DIFF
--- a/sycl/include/CL/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_lists.hpp
@@ -287,7 +287,7 @@ using vector_long_integer_list = type_list<vector_signed_long_integer_list,
 using long_integer_list =
     type_list<scalar_long_integer_list, vector_long_integer_list>;
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 // std::byte
 using scalar_byte_list = type_list<std::byte>;
 
@@ -321,7 +321,7 @@ using scalar_unsigned_integer_list =
                             scalar_unsigned_char_list>,
               scalar_unsigned_short_list, scalar_unsigned_int_list,
               scalar_unsigned_long_list, scalar_unsigned_longlong_list
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
               ,
               scalar_byte_list
 #endif
@@ -334,7 +334,7 @@ using vector_unsigned_integer_list =
                             vector_unsigned_char_list>,
               vector_unsigned_short_list, vector_unsigned_int_list,
               vector_unsigned_long_list, vector_unsigned_longlong_list
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
               ,
               vector_byte_list
 #endif

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -433,7 +433,7 @@ struct select_cl_mptr_or_vector_or_scalar;
 // which is not supported on device
 template <typename T> struct TypeHelper { using RetType = T; };
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 template <> struct TypeHelper<std::byte> { using RetType = std::uint8_t; };
 #endif
 

--- a/sycl/include/CL/sycl/stream.hpp
+++ b/sycl/include/CL/sycl/stream.hpp
@@ -958,7 +958,7 @@ private:
                                   const h_item<Dimensions> &RHS);
 };
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 // Byte (has to be converted to a numeric value)
 template <typename T>
 inline std::enable_if_t<std::is_same<T, std::byte>::value, const stream &>

--- a/sycl/include/CL/sycl/stream.hpp
+++ b/sycl/include/CL/sycl/stream.hpp
@@ -326,11 +326,12 @@ EnableIfFP<T, unsigned> floatingPointToDecStr(T AbsVal, char *Digits,
     for (unsigned I = 0; I < FractionLength; ++I)
       Digits[Offset++] = digitToChar(FractionDigits[I]);
 
+    auto AbsExp = Exp < 0 ? -Exp : Exp;
     // Exponent part
     Digits[Offset++] = 'e';
     Digits[Offset++] = Exp >= 0 ? '+' : '-';
-    Digits[Offset++] = digitToChar(abs(Exp) / 10);
-    Digits[Offset++] = digitToChar(abs(Exp) % 10);
+    Digits[Offset++] = digitToChar(AbsExp) / 10);
+    Digits[Offset++] = digitToChar(AbsExp) % 10);
   } else { // normal mode
     if (Exp < 0) {
       Digits[Offset++] = '0';

--- a/sycl/include/CL/sycl/stream.hpp
+++ b/sycl/include/CL/sycl/stream.hpp
@@ -330,8 +330,8 @@ EnableIfFP<T, unsigned> floatingPointToDecStr(T AbsVal, char *Digits,
     // Exponent part
     Digits[Offset++] = 'e';
     Digits[Offset++] = Exp >= 0 ? '+' : '-';
-    Digits[Offset++] = digitToChar(AbsExp) / 10);
-    Digits[Offset++] = digitToChar(AbsExp) % 10);
+    Digits[Offset++] = digitToChar(AbsExp / 10);
+    Digits[Offset++] = digitToChar(AbsExp % 10);
   } else { // normal mode
     if (Exp < 0) {
       Digits[Offset++] = '0';

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -103,7 +103,7 @@ template <typename T> struct vec_helper {
   static constexpr RetType get(T value) { return value; }
 };
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 template <> struct vec_helper<std::byte> {
   using RetType = std::uint8_t;
   static constexpr RetType get(std::byte value) { return (RetType)value; }
@@ -2206,7 +2206,7 @@ using select_apply_cl_t =
         __SYCL_GET_CL_TYPE(int, num), __SYCL_GET_CL_TYPE(long, num)>;          \
   };
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 #define __SYCL_DECLARE_BYTE_CONVERTER(num)                                     \
   template <> class BaseCLTypeConverter<std::byte, num> {                      \
   public:                                                                      \
@@ -2231,7 +2231,7 @@ using select_apply_cl_t =
     using DataType = bool;                                                     \
   };
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 #define __SYCL_DECLARE_SCALAR_BYTE_CONVERTER                                   \
   template <> class BaseCLTypeConverter<std::byte, 1> {                        \
   public:                                                                      \
@@ -2330,7 +2330,7 @@ using select_apply_cl_t =
   __SYCL_DECLARE_SCALAR_BOOL_CONVERTER                                         \
   } // namespace detail
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 #define __SYCL_DECLARE_BYTE_VECTOR_CONVERTER                                   \
   namespace detail {                                                           \
   __SYCL_DECLARE_BYTE_CONVERTER(2)                                             \
@@ -2344,7 +2344,7 @@ using select_apply_cl_t =
 __SYCL_DECLARE_VECTOR_CONVERTERS(char)
 __SYCL_DECLARE_SCHAR_VECTOR_CONVERTERS
 __SYCL_DECLARE_BOOL_VECTOR_CONVERTERS
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 __SYCL_DECLARE_BYTE_VECTOR_CONVERTER
 #endif
 __SYCL_DECLARE_UNSIGNED_INTEGRAL_VECTOR_CONVERTERS(uchar)
@@ -2371,7 +2371,7 @@ __SYCL_DECLARE_FLOAT_VECTOR_CONVERTERS(double)
 #undef __SYCL_DECLARE_SCALAR_SCHAR_CONVERTER
 #undef __SYCL_DECLARE_BOOL_VECTOR_CONVERTERS
 #undef __SYCL_DECLARE_BOOL_CONVERTER
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 #undef __SYCL_DECLARE_BYTE_VECTOR_CONVERTER
 #undef __SYCL_DECLARE_BYTE_CONVERTER
 #undef __SYCL_DECLARE_SCALAR_BYTE_CONVERTER

--- a/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 #include <CL/sycl/detail/group_sort_impl.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {

--- a/sycl/include/sycl/ext/oneapi/group_sort.hpp
+++ b/sycl/include/sycl/ext/oneapi/group_sort.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 #include <CL/sycl/detail/defines_elementary.hpp>
 #include <CL/sycl/detail/group_sort_impl.hpp>
 #include <CL/sycl/detail/type_traits.hpp>

--- a/sycl/test/regression/disabled_std_byte.cpp
+++ b/sycl/test/regression/disabled_std_byte.cpp
@@ -1,7 +1,6 @@
 // RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -D_HAS_STD_BYTE=0 %s -Xclang -verify-ignore-unexpected=note,warning
 // RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note,warning
 // expected-no-diagnostics
-using namespace ::std;
 #include <CL/sycl.hpp>
 #include <algorithm>
 #ifdef _WIN32

--- a/sycl/test/regression/disabled_std_byte.cpp
+++ b/sycl/test/regression/disabled_std_byte.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -D_HAS_STD_BYTE=0 %s -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note,warning
+// expected-no-diagnostics
+using namespace ::std;
+#include <CL/sycl.hpp>
+#include <algorithm>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+int main() { return 0; }

--- a/sycl/test/regression/disabled_std_byte.cpp
+++ b/sycl/test/regression/disabled_std_byte.cpp
@@ -2,9 +2,5 @@
 // RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note,warning
 // expected-no-diagnostics
 #include <CL/sycl.hpp>
-#include <algorithm>
-#ifdef _WIN32
-#include <windows.h>
-#endif
 
 int main() { return 0; }

--- a/sycl/test/regression/disabled_std_byte.cpp
+++ b/sycl/test/regression/disabled_std_byte.cpp
@@ -2,5 +2,3 @@
 // RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note,warning
 // expected-no-diagnostics
 #include <CL/sycl.hpp>
-
-int main() { return 0; }


### PR DESCRIPTION
MS VS allows to disable std::byte type using _HAS_STD_BYTE=0
(https://devblogs.microsoft.com/cppblog/c17-features-and-stl-fixes-in-vs-2017-15-3/).

This patch disables SYCL code which relies on this type in this case.