### PR TITLE
[CI] Correctly create user in Docker containers

### DIFF
--- a/devops/containers/ubuntu2004_base.Dockerfile
+++ b/devops/containers/ubuntu2004_base.Dockerfile
@@ -14,6 +14,10 @@ RUN apt update && apt install -yqq \
       python3-distutils \
       python-is-python3
 
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
 RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh


### PR DESCRIPTION
By default Ubuntu sets an arbitrary UID value, that is different from host system. When CI passes default UID value of 1001, some of LLVM tools fail to discover user home directory. As a result, a few LITs fail. This patch fixes UID and GID to those, that are used by GitHub Actions by default.