### PR TITLE
[SYCL] Reduce overhead on command creation in specific case

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1747,7 +1747,7 @@ static pi_result SetKernelParamsAndLaunch(
     RT::PiKernel Kernel, NDRDescT &NDRDesc, std::vector<RT::PiEvent> &RawEvents,
     const EventImplPtr &EventImpl,
     const ProgramManager::KernelArgMask &EliminatedArgMask,
-    std::function<void *(Requirement *Req)> getMemAllocationFunc) {
+    const std::function<void *(Requirement *Req)> &getMemAllocationFunc) {
   const detail::plugin &Plugin = Queue->getPlugin();
 
   auto setFunc = [&Plugin, Kernel, &DeviceImageImpl, &getMemAllocationFunc,
@@ -1757,6 +1757,8 @@ static pi_result SetKernelParamsAndLaunch(
       break;
     case kernel_param_kind_t::kind_accessor: {
       Requirement *Req = (Requirement *)(Arg.MPtr);
+      assert(getMemAllocationFunc != nullptr &&
+             "The function should not be nullptr as we followed the path for which accessors are used");
       RT::PiMem MemArg = (RT::PiMem)getMemAllocationFunc(Req);
       if (Plugin.getBackend() == backend::opencl) {
         Plugin.call<PiApiKind::piKernelSetArg>(Kernel, NextTrueIndex,
@@ -1893,7 +1895,7 @@ cl_int enqueueImpKernel(
     const std::shared_ptr<detail::kernel_impl> &MSyclKernel,
     const std::string &KernelName, const detail::OSModuleHandle &OSModuleHandle,
     std::vector<RT::PiEvent> &RawEvents, const EventImplPtr &EventImpl,
-    std::function<void *(Requirement *Req)> getMemAllocationFunc) {
+    const std::function<void *(Requirement *Req)> &getMemAllocationFunc) {
 
   // Run OpenCL kernel
   auto ContextImpl = Queue->getContextImplPtr();

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1758,7 +1758,8 @@ static pi_result SetKernelParamsAndLaunch(
     case kernel_param_kind_t::kind_accessor: {
       Requirement *Req = (Requirement *)(Arg.MPtr);
       assert(getMemAllocationFunc != nullptr &&
-             "The function should not be nullptr as we followed the path for which accessors are used");
+             "The function should not be nullptr as we followed the path for "
+             "which accessors are used");
       RT::PiMem MemArg = (RT::PiMem)getMemAllocationFunc(Req);
       if (Plugin.getBackend() == backend::opencl) {
         Plugin.call<PiApiKind::piKernelSetArg>(Kernel, NextTrueIndex,

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -503,6 +503,18 @@ private:
   void **MDstPtr = nullptr;
 };
 
+cl_int enqueueImpKernel(
+    const QueueImplPtr &Queue, NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
+    const std::unique_ptr<HostKernelBase> &HostKernel,
+    const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
+    const std::shared_ptr<detail::kernel_impl> &MSyclKernel,
+    const std::string &KernelName, const detail::OSModuleHandle &OSModuleHandle,
+    std::vector<RT::PiEvent> &RawEvents, const EventImplPtr &EventImpl,
+    std::function<void *(Requirement *Req)> getMemAllocationFunc,
+    std::function<cl_int(NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
+                         const std::unique_ptr<HostKernelBase> &HostKernel)>
+        RunKernelOnHost);
+
 /// The exec CG command enqueues execution of kernel or explicit memory
 /// operation.
 class ExecCGCommand : public Command {
@@ -537,13 +549,6 @@ private:
   cl_int enqueueImp() final;
 
   AllocaCommandBase *getAllocaForReq(Requirement *Req);
-
-  pi_result SetKernelParamsAndLaunch(
-      CGExecKernel *ExecKernel,
-      std::shared_ptr<device_image_impl> DeviceImageImpl, RT::PiKernel Kernel,
-      NDRDescT &NDRDesc, std::vector<RT::PiEvent> &RawEvents,
-      RT::PiEvent &Event,
-      const ProgramManager::KernelArgMask &EliminatedArgMask);
 
   std::unique_ptr<detail::CG> MCommandGroup;
 

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -509,7 +509,7 @@ cl_int enqueueImpKernel(
     const std::shared_ptr<detail::kernel_impl> &MSyclKernel,
     const std::string &KernelName, const detail::OSModuleHandle &OSModuleHandle,
     std::vector<RT::PiEvent> &RawEvents, const EventImplPtr &EventImpl,
-    std::function<void *(Requirement *Req)> getMemAllocationFunc);
+    const std::function<void *(Requirement *Req)> &getMemAllocationFunc);
 
 /// The exec CG command enqueues execution of kernel or explicit memory
 /// operation.

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -549,7 +549,6 @@ private:
   std::unique_ptr<detail::CG> MCommandGroup;
 
   friend class Command;
-  friend class Scheduler;
 };
 
 class UpdateHostRequirementCommand : public Command {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -505,15 +505,11 @@ private:
 
 cl_int enqueueImpKernel(
     const QueueImplPtr &Queue, NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
-    const std::unique_ptr<HostKernelBase> &HostKernel,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
     const std::shared_ptr<detail::kernel_impl> &MSyclKernel,
     const std::string &KernelName, const detail::OSModuleHandle &OSModuleHandle,
     std::vector<RT::PiEvent> &RawEvents, const EventImplPtr &EventImpl,
-    std::function<void *(Requirement *Req)> getMemAllocationFunc,
-    std::function<cl_int(NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
-                         const std::unique_ptr<HostKernelBase> &HostKernel)>
-        RunKernelOnHost);
+    std::function<void *(Requirement *Req)> getMemAllocationFunc);
 
 /// The exec CG command enqueues execution of kernel or explicit memory
 /// operation.

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -85,59 +85,6 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
         initStream(Stream, Queue);
       }
     }
-
-    if (CommandGroup->MRequirements.size() + CommandGroup->MEvents.size() ==
-        0) {
-      ExecCGCommand *NewCmd(
-          new ExecCGCommand(std::move(CommandGroup), std::move(Queue)));
-      if (!NewCmd)
-        throw runtime_error("Out of host memory", PI_OUT_OF_HOST_MEMORY);
-      NewEvent = NewCmd->getEvent();
-
-      auto CleanUp = [&]() {
-        NewEvent->setCommand(nullptr);
-        delete NewCmd;
-      };
-
-      if (MGraphBuilder
-              .MPrintOptionsArray[GraphBuilder::PrintOptions::BeforeAddCG])
-        MGraphBuilder.printGraphAsDot("before_addCG");
-      if (MGraphBuilder
-              .MPrintOptionsArray[GraphBuilder::PrintOptions::AfterAddCG])
-        MGraphBuilder.printGraphAsDot("after_addCG");
-
-      try {
-#ifdef XPTI_ENABLE_INSTRUMENTATION
-        NewCmd->emitInstrumentation(xpti::trace_task_begin, nullptr);
-#endif
-
-        cl_int Res = NewCmd->enqueueImp();
-
-        // Emit this correlation signal before the task end
-        NewCmd->emitEnqueuedEventSignal(NewEvent->getHandleRef());
-#ifdef XPTI_ENABLE_INSTRUMENTATION
-        NewCmd->emitInstrumentation(xpti::trace_task_end, nullptr);
-#endif
-
-        if (CL_SUCCESS != Res)
-          throw runtime_error("Enqueue process failed.", PI_INVALID_OPERATION);
-        else if (NewEvent->is_host() || NewEvent->getHandleRef() == nullptr)
-          NewEvent->setComplete();
-      } catch (...) {
-        // enqueueImp() func and if statement above may throw an exception,
-        // so destroy required resources to avoid memory leak
-        CleanUp();
-        std::rethrow_exception(std::current_exception());
-      }
-
-      CleanUp();
-
-      for (auto StreamImplPtr : Streams) {
-        StreamImplPtr->flush();
-      }
-
-      return NewEvent;
-    }
   }
 
   {

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -612,7 +612,6 @@ protected:
                                         const ContextImplPtr &Context);
 
     friend class Command;
-    friend class Scheduler;
 
   private:
     friend class ::MockScheduler;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -121,7 +121,8 @@ event handler::finalize() {
         kernel_bundle<bundle_state::executable> ExecBundle = build(
             detail::createSyclObjFromImpl<kernel_bundle<bundle_state::input>>(
                 KernelBundleImpPtr));
-        setHandlerKernelBundle(detail::getSyclObjImpl(ExecBundle));
+        KernelBundleImpPtr = detail::getSyclObjImpl(ExecBundle);
+        setHandlerKernelBundle(KernelBundleImpPtr);
         break;
       }
       case bundle_state::executable:

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -22,8 +22,6 @@
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/commands.hpp>
 #include <detail/scheduler/scheduler.hpp>
-#include <detail/scheduler/scheduler_helpers.hpp>
-#include <detail/stream_impl.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -137,11 +135,11 @@ event handler::finalize() {
   }
 
   const auto &type = getType();
-  // if user does not add a new dependency to the dependency graph, i.e.
-  // the graph is not changed, then this faster path is used to submit the
-  // kernel
   if (type == detail::CG::Kernel &&
       MRequirements.size() + MEvents.size() + MStreamStorage.size() == 0) {
+    // if user does not add a new dependency to the dependency graph, i.e.
+    // the graph is not changed, then this faster path is used to submit kernel
+    // bypassing scheduler and avoiding CommandGroup, Command objects creation.
 
     std::vector<RT::PiEvent> RawEvents;
     detail::EventImplPtr NewEvent =


### PR DESCRIPTION
The changes make even more performance optimization for calling kernels that have no dependencies, starting in the https://github.com/intel/llvm/pull/4188. Since the specific kernel doesn't change the execution command graph then the time spent on allocation/deallocation objects of the `ExecCGCommand` and `CGExecKernel` classes can be reduced by simply not creating them and directly calling kernel submission function(i.e `enqueueImpKernel`).

`case CG::CGTYPE::Kernel` from `ExecCGCommand::enqueueImp()` took a little refactoring to extract the code into a separate function - `enqueueImpKernel`, which can be called without creating the command.

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>