### PR TITLE
[SYCL] Re-enable SemaSYCL/sycl-dllimport-dllexport

### DIFF
--- a/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
+++ b/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
@@ -1,11 +1,10 @@
-// XFAIL: *
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -fms-extensions \
 // RUN: -aux-triple x86_64-unknown-linux-gnu -fsycl-is-device \
 // RUN: -fsyntax-only -Wno-sycl-2017-compat -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
 // check random triple aux-triple with sycl-device
 
 // RUN: %clang_cc1 -triple spir64-unknown-windows -Wno-sycl-2017-compat -fsyntax-only \
-// RUN: -fms-extensions -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: -fms-extensions -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck --check-prefixes CHECKALL %s
 // check without -aux-triple but sycl-device
 
 // RUN: %clang_cc1 -triple spir64-unknown-windows \
@@ -43,10 +42,9 @@ int  __declspec(dllexport) foo(int a) {
 }
 // expected-note@+1 {{'bar' declared here}}
 SYCL_EXTERNAL int __declspec(dllimport) bar();
-// expected-note@+2 {{previous attribute is here}}
 // expected-note@+1 {{previous declaration is here}}
-int __declspec(dllimport) foobar();
-int foobar()  // expected-warning {{'foobar' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+int __declspec(dllimport) foobar(); // expected-note {{'foobar' declared here}}
+int foobar()  // expected-warning {{'foobar' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
 {
   return 10;
 }
@@ -62,7 +60,7 @@ int main() {
   kernel_single_task<class fake_kernel>([]() {
     foo(10);// expected-no-error
     bar(); // expected-error {{SYCL kernel cannot call a dllimport function}}
-    foobar(); // expected-no-error
+    foobar(); // expected-error {{SYCL kernel cannot call a dllimport function}}
   });
   bar();  // expected-no-error
   return 0;


### PR DESCRIPTION
The test was XFAIL-ed after pulldown some time ago.
This fixes https://github.com/intel/llvm/issues/2758