### PR TITLE
[SYCL] Create static shared-release handler after loading plugins

### DIFF
--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -68,8 +68,10 @@ public:
   XPTIRegistry &getXPTIRegistry();
   std::mutex &getHandlerExtendedMembersMutex();
 
+  static void registerDefaultContextReleaseHandler();
+
 private:
-  friend void releaseSharedGlobalHandles();
+  friend void releaseDefaultContexts();
   friend void shutdown();
 
   // Constructor and destructor are declared out-of-line to allow incomplete

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -127,6 +127,16 @@ std::vector<platform> platform_impl::get_platforms() {
     }
   }
 
+  // Register default context release handler after plugins have been loaded and
+  // after the first calls to each plugin. This initializes a function-local
+  // variable that should be destroyed before any global variables in the
+  // plugins are destroyed. This is done after the first call to the backends to
+  // ensure any lazy-loaded dependencies are loaded prior to the handler
+  // variable's initialization. Note: The default context release handler is not
+  // guaranteed to be destroyed before function-local static variables as they
+  // may be initialized after.
+  GlobalHandler::registerDefaultContextReleaseHandler();
+
   // The host platform should always be available unless not allowed by the
   // SYCL_DEVICE_FILTER
   detail::device_filter_list *FilterList =


### PR DESCRIPTION
To enforce default contexts to be released before global variables in plugins and associated libraries, these changes intializes
a function-local static variable after the plugins have been loaded. Due to the guarantees of std::exit the destructor of the new
function-local variable will be called before the destructor of all global variables initialized prior to the function-local static
variable's initialization. 