### PR TITLE
[CI] Disable repo lockdown

### DIFF
--- a/.github/workflows/repo-lockdown.yml
+++ b/.github/workflows/repo-lockdown.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   action:
     runs-on: ubuntu-latest
+    if: github.repository == 'llvm/llvm-project'
     steps:
       - uses: dessant/repo-lockdown@v2
         with:


### PR DESCRIPTION
Disable repo lockdown action, that came from upstream LLVM, because we actually accept pull-requests.