### PR TITLE
[SYCL][Driver] Enable SPV_INTEL_hw_thread_queries extension

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8871,7 +8871,8 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
       // Don't enable several freshly added extensions on FPGA H/W
       ExtArg += ",+SPV_INTEL_token_type"
                 ",+SPV_INTEL_bfloat16_conversion"
-                ",+SPV_INTEL_joint_matrix";
+                ",+SPV_INTEL_joint_matrix"
+                ",+SPV_INTEL_hw_thread_queries";
     TranslatorArgs.push_back(TCArgs.MakeArgString(ExtArg));
   }
   for (auto I : Inputs) {

--- a/clang/test/Driver/sycl-spirv-ext.c
+++ b/clang/test/Driver/sycl-spirv-ext.c
@@ -53,7 +53,8 @@
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_runtime_aligned
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_token_type
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_bfloat16_conversion
-// CHECK-DEFAULT-SAME:,+SPV_INTEL_joint_matrix"
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_joint_matrix
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_hw_thread_queries"
 // CHECK-FPGA-HW: llvm-spirv{{.*}}"-spirv-ext=-all
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_add
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_min_max


### PR DESCRIPTION
It enables a SPIR-V extension added here:
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1245

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>