### PR TITLE
[SYCL] Use empty kernel bundle in make_kernel

### DIFF
--- a/sycl/include/CL/sycl/backend.hpp
+++ b/sycl/include/CL/sycl/backend.hpp
@@ -217,9 +217,8 @@ kernel
 make_kernel(const typename backend_traits<Backend>::template input_type<kernel>
                 &BackendObject,
             const context &TargetContext) {
-  return detail::make_kernel(
-      TargetContext, get_kernel_bundle<bundle_state::executable>(TargetContext),
-      detail::pi::cast<pi_native_handle>(BackendObject), false, Backend);
+  return detail::make_kernel(detail::pi::cast<pi_native_handle>(BackendObject),
+                             TargetContext, Backend);
 }
 
 template <backend Backend, bundle_state State>

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -247,7 +247,8 @@ kernel make_kernel(const context &TargetContext,
 kernel make_kernel(pi_native_handle NativeHandle, const context &TargetContext,
                    backend Backend) {
   return make_kernel(TargetContext,
-                     get_kernel_bundle<bundle_state::executable>(TargetContext),
+                     get_kernel_bundle<bundle_state::executable>(
+                         TargetContext, std::vector<kernel_id>{}),
                      NativeHandle, false, Backend);
 }
 


### PR DESCRIPTION
Calling make_kernel may inadverdently build other kernels than the one requested which may cause unexpected behavior. These changes make make_kernel use an empty kernel bundle in the default variant.