### PR TITLE
[SYCL] Improve error diagnostic for invalid SYCL kernel name

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11435,8 +11435,8 @@ def err_invalid_std_type_in_sycl_kernel : Error<"%0 is an invalid kernel name, "
                                           "%q1 is declared in the 'std' namespace ">;
 
 def err_sycl_kernel_incorrectly_named : Error<
-  "%select{non-forward-declarable type %1 is invalid; provide a forward "
-  "declarable kernel name at namespace scope"
+  "%select{%1 is invalid; kernel name should be forward declarable "
+  "at namespace scope"
   "|unscoped enum %1 requires fixed underlying type"
   "|unnamed type %1 is invalid; provide a kernel name, or use "
   "'-fsycl-unnamed-lambda' to enable unnamed kernel lambdas"

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11435,7 +11435,8 @@ def err_invalid_std_type_in_sycl_kernel : Error<"%0 is an invalid kernel name, "
                                           "%q1 is declared in the 'std' namespace ">;
 
 def err_sycl_kernel_incorrectly_named : Error<
-  "%select{%1 should be globally visible"
+  "%select{non-forward-declarable type %1 is invalid; provide a forward "
+  "declarable kernel name at namespace scope"
   "|unscoped enum %1 requires fixed underlying type"
   "|unnamed type %1 is invalid; provide a kernel name, or use "
   "'-fsycl-unnamed-lambda' to enable unnamed kernel lambdas"

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3511,7 +3511,8 @@ public:
           if (Tag->isCompleteDefinition()) {
             S.Diag(KernelInvocationFuncLoc,
                    diag::err_sycl_kernel_incorrectly_named)
-                << /* kernel name should be forward declarable at namespace scope */ 0
+		<< /* kernel name should be forward declarable at namespace
+                      scope */ 0
                 << KernelNameType;
             IsInvalid = true;
           } else {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3511,7 +3511,7 @@ public:
           if (Tag->isCompleteDefinition()) {
             S.Diag(KernelInvocationFuncLoc,
                    diag::err_sycl_kernel_incorrectly_named)
-                << /* non-forward-declarable type is invalid */ 0
+                << /* kernel name should be forward declarable at namespace scope */ 0
                 << KernelNameType;
             IsInvalid = true;
           } else {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3508,13 +3508,11 @@ public:
           }
           // Check if the declaration is completely defined within a
           // function or class/struct.
-
           if (Tag->isCompleteDefinition()) {
             S.Diag(KernelInvocationFuncLoc,
                    diag::err_sycl_kernel_incorrectly_named)
-                << /* kernel name should be globally visible */ 0
+                << /* non-forward-declarable type is invalid */ 0
                 << KernelNameType;
-
             IsInvalid = true;
           } else {
             S.Diag(KernelInvocationFuncLoc, diag::warn_sycl_implicit_decl);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3511,9 +3511,9 @@ public:
           if (Tag->isCompleteDefinition()) {
             S.Diag(KernelInvocationFuncLoc,
                    diag::err_sycl_kernel_incorrectly_named)
-		<< /* kernel name should be forward declarable at namespace
-                      scope */ 0
-                << KernelNameType;
+                << /* kernel name should be forward declarable at namespace
+                      scope */
+                0 << KernelNameType;
             IsInvalid = true;
           } else {
             S.Diag(KernelInvocationFuncLoc, diag::warn_sycl_implicit_decl);

--- a/clang/test/SemaSYCL/implicit_kernel_type.cpp
+++ b/clang/test/SemaSYCL/implicit_kernel_type.cpp
@@ -23,10 +23,10 @@ int main() {
   queue q;
 
 #if defined(WARN)
-  // expected-error@#KernelSingleTask {{'InvalidKernelName1' should be globally visible}}
+  // expected-error@#KernelSingleTask {{non-forward-declarable type 'InvalidKernelName1' is invalid; provide a forward declarable kernel name at namespace scope}}
   // expected-note@+7 {{in instantiation of function template specialization}}
 #elif defined(ERROR)
-  // expected-error@#KernelSingleTask {{'InvalidKernelName1' should be globally visible}}
+  // expected-error@#KernelSingleTask {{non-forward-declarable type 'InvalidKernelName1' is invalid; provide a forward declarable kernel name at namespace scope}}
   // expected-note@+4 {{in instantiation of function template specialization}}
 #endif
   class InvalidKernelName1 {};

--- a/clang/test/SemaSYCL/implicit_kernel_type.cpp
+++ b/clang/test/SemaSYCL/implicit_kernel_type.cpp
@@ -22,17 +22,14 @@ class myWrapper2;
 int main() {
   queue q;
 
-#if defined(WARN)
-  // expected-error@#KernelSingleTask {{non-forward-declarable type 'InvalidKernelName1' is invalid; provide a forward declarable kernel name at namespace scope}}
-  // expected-note@+7 {{in instantiation of function template specialization}}
-#elif defined(ERROR)
-  // expected-error@#KernelSingleTask {{non-forward-declarable type 'InvalidKernelName1' is invalid; provide a forward declarable kernel name at namespace scope}}
-  // expected-note@+4 {{in instantiation of function template specialization}}
-#endif
+#if defined(ERROR)
   class InvalidKernelName1 {};
+  // expected-error@#KernelSingleTask {{'InvalidKernelName1' is invalid; kernel name should be forward declarable at namespace scope}}
+  // expected-note@+2 {{in instantiation of function template specialization}}
   q.submit([&](handler &h) {
     h.single_task<InvalidKernelName1>([]() {});
   });
+#endif
 
 #if defined(WARN)
   // expected-warning@#KernelSingleTask {{SYCL 1.2.1 specification requires an explicit forward declaration for a kernel type name; your program may not be portable}}

--- a/clang/test/SemaSYCL/implicit_kernel_type.cpp
+++ b/clang/test/SemaSYCL/implicit_kernel_type.cpp
@@ -22,14 +22,12 @@ class myWrapper2;
 int main() {
   queue q;
 
-#if defined(ERROR)
   class InvalidKernelName1 {};
   // expected-error@#KernelSingleTask {{'InvalidKernelName1' is invalid; kernel name should be forward declarable at namespace scope}}
   // expected-note@+2 {{in instantiation of function template specialization}}
   q.submit([&](handler &h) {
     h.single_task<InvalidKernelName1>([]() {});
   });
-#endif
 
 #if defined(WARN)
   // expected-warning@#KernelSingleTask {{SYCL 1.2.1 specification requires an explicit forward declaration for a kernel type name; your program may not be portable}}

--- a/clang/test/SemaSYCL/nested-anon-and-std-ns.cpp
+++ b/clang/test/SemaSYCL/nested-anon-and-std-ns.cpp
@@ -37,7 +37,7 @@ public:
       h.single_task<ValidNS::StructinValidNS>([] {});
     });
 
-    // expected-error@#KernelSingleTask {{'ParentStruct::ChildStruct' should be globally visible}}
+    // expected-error@#KernelSingleTask {{non-forward-declarable type 'ParentStruct::ChildStruct' is invalid; provide a forward declarable kernel name at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<ParentStruct::ChildStruct>([] {});

--- a/clang/test/SemaSYCL/nested-anon-and-std-ns.cpp
+++ b/clang/test/SemaSYCL/nested-anon-and-std-ns.cpp
@@ -37,7 +37,7 @@ public:
       h.single_task<ValidNS::StructinValidNS>([] {});
     });
 
-    // expected-error@#KernelSingleTask {{non-forward-declarable type 'ParentStruct::ChildStruct' is invalid; provide a forward declarable kernel name at namespace scope}}
+    // expected-error@#KernelSingleTask {{'ParentStruct::ChildStruct' is invalid; kernel name should be forward declarable at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<ParentStruct::ChildStruct>([] {});

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -32,27 +32,27 @@ private:
 public:
   void test() {
     cl::sycl::queue q;
-    // expected-error@#KernelSingleTask {{'InvalidKernelName1' should be globally visible}}
+    // expected-error@#KernelSingleTask {{non-forward-declarable type 'InvalidKernelName1' is invalid; provide a forward declarable kernel name at namespace scope}}
     // expected-note@+3{{in instantiation of function template specialization}}
     class InvalidKernelName1 {};
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidKernelName1>([] {});
     });
 
-    // expected-error@#KernelSingleTask {{'namespace1::KernelName<InvalidKernelName2>' should be globally visible}}
+    // expected-error@#KernelSingleTask {{non-forward-declarable type 'namespace1::KernelName<InvalidKernelName2>' is invalid; provide a forward declarable kernel name at namespace scope}}
     // expected-note@+3{{in instantiation of function template specialization}}
     class InvalidKernelName2 {};
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidKernelName2>>([] {});
     });
 
-    // expected-error@#KernelSingleTask {{'MyWrapper::InvalidKernelName0' should be globally visible}}
+    // expected-error@#KernelSingleTask {{non-forward-declarable type 'MyWrapper::InvalidKernelName0' is invalid; provide a forward declarable kernel name at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidKernelName0>([] {});
     });
 
-    // expected-error@#KernelSingleTask {{'namespace1::KernelName<MyWrapper::InvalidKernelName3>' should be globally visible}}
+    // expected-error@#KernelSingleTask {{non-forward-declarable type 'namespace1::KernelName<MyWrapper::InvalidKernelName3>' is invalid; provide a forward declarable kernel name at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidKernelName3>>([] {});
@@ -70,19 +70,19 @@ public:
     });
 
     using InvalidAlias = InvalidKernelName4;
-    // expected-error@#KernelSingleTask {{'MyWrapper::InvalidKernelName4' should be globally visible}}
+    // expected-error@#KernelSingleTask {{non-forward-declarable type 'MyWrapper::InvalidKernelName4' is invalid; provide a forward declarable kernel name at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidAlias>([] {});
     });
 
     using InvalidAlias1 = InvalidKernelName5;
-    // expected-error@#KernelSingleTask {{'namespace1::KernelName<MyWrapper::InvalidKernelName5>' should be globally visible}}
+    // expected-error@#KernelSingleTask {{non-forward-declarable type 'namespace1::KernelName<MyWrapper::InvalidKernelName5>' is invalid; provide a forward declarable kernel name at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidAlias1>>([] {});
     });
-    // expected-error@#KernelSingleTask {{'Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>' should be globally visible}}
+    // expected-error@#KernelSingleTask {{non-forward-declarable type 'Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>' is invalid; provide a forward declarable kernel name at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>>([] {});

--- a/clang/test/SemaSYCL/unnamed-kernel.cpp
+++ b/clang/test/SemaSYCL/unnamed-kernel.cpp
@@ -32,27 +32,27 @@ private:
 public:
   void test() {
     cl::sycl::queue q;
-    // expected-error@#KernelSingleTask {{non-forward-declarable type 'InvalidKernelName1' is invalid; provide a forward declarable kernel name at namespace scope}}
+    // expected-error@#KernelSingleTask {{'InvalidKernelName1' is invalid; kernel name should be forward declarable at namespace scope}}
     // expected-note@+3{{in instantiation of function template specialization}}
     class InvalidKernelName1 {};
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidKernelName1>([] {});
     });
 
-    // expected-error@#KernelSingleTask {{non-forward-declarable type 'namespace1::KernelName<InvalidKernelName2>' is invalid; provide a forward declarable kernel name at namespace scope}}
+    // expected-error@#KernelSingleTask {{'namespace1::KernelName<InvalidKernelName2>' is invalid; kernel name should be forward declarable at namespace scope}}
     // expected-note@+3{{in instantiation of function template specialization}}
     class InvalidKernelName2 {};
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidKernelName2>>([] {});
     });
 
-    // expected-error@#KernelSingleTask {{non-forward-declarable type 'MyWrapper::InvalidKernelName0' is invalid; provide a forward declarable kernel name at namespace scope}}
+    // expected-error@#KernelSingleTask {{'MyWrapper::InvalidKernelName0' is invalid; kernel name should be forward declarable at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidKernelName0>([] {});
     });
 
-    // expected-error@#KernelSingleTask {{non-forward-declarable type 'namespace1::KernelName<MyWrapper::InvalidKernelName3>' is invalid; provide a forward declarable kernel name at namespace scope}}
+    // expected-error@#KernelSingleTask {{'namespace1::KernelName<MyWrapper::InvalidKernelName3>' is invalid; kernel name should be forward declarable at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidKernelName3>>([] {});
@@ -70,19 +70,19 @@ public:
     });
 
     using InvalidAlias = InvalidKernelName4;
-    // expected-error@#KernelSingleTask {{non-forward-declarable type 'MyWrapper::InvalidKernelName4' is invalid; provide a forward declarable kernel name at namespace scope}}
+    // expected-error@#KernelSingleTask {{'MyWrapper::InvalidKernelName4' is invalid; kernel name should be forward declarable at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<InvalidAlias>([] {});
     });
 
     using InvalidAlias1 = InvalidKernelName5;
-    // expected-error@#KernelSingleTask {{non-forward-declarable type 'namespace1::KernelName<MyWrapper::InvalidKernelName5>' is invalid; provide a forward declarable kernel name at namespace scope}}
+    // expected-error@#KernelSingleTask {{'namespace1::KernelName<MyWrapper::InvalidKernelName5>' is invalid; kernel name should be forward declarable at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<namespace1::KernelName<InvalidAlias1>>([] {});
     });
-    // expected-error@#KernelSingleTask {{non-forward-declarable type 'Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>' is invalid; provide a forward declarable kernel name at namespace scope}}
+    // expected-error@#KernelSingleTask {{'Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>' is invalid; kernel name should be forward declarable at namespace scope}}
     // expected-note@+2{{in instantiation of function template specialization}}
     q.submit([&](cl::sycl::handler &h) {
       h.single_task<Templated_kernel_name2<Templated_kernel_name<InvalidKernelName1>>>([] {});


### PR DESCRIPTION
According to SYCL 2020 spec:
The kernel name must be forward declarable at namespace scope (including global namespace scope) and may not be forward declared other than at namespace scope.

The use of nested struct-case (where the name IS globally visible but just not forward-declarable) in a SYCL kernel name currently generates invalid error message: 

error: '{{.*}}' should be globally visible

This patch modifies the error diagnostic message when the kernel name is declared at non-namespace scope (i.e. Inside a function or class/struct).

Signed-off-by: Soumi Manna <soumi.manna@intel.com>