### PR TITLE
[SYCL][NFC] Improve sycl-instrumentation test for Windows

### DIFF
--- a/clang/test/Driver/sycl-instrumentation.c
+++ b/clang/test/Driver/sycl-instrumentation.c
@@ -4,10 +4,12 @@
 /// 1. A SPIR-V-based environment must be targetted
 /// 2. The corresponding Driver option must be enabled explicitly
 
-// RUN: %clangxx -fsycl -fsycl-instrument-device-code --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -### %s 2>&1 \
+/// FIXME: Force linux targets to allow for the libraries to be found.  Dummy
+/// inputs for --sysroot should be updated to work better for Windows.
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-instrument-device-code --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-SPIRV,CHECK-HOST %s
 /// -fno-sycl-device-lib mustn't affect the linkage of ITT libraries
-// RUN: %clangxx -fsycl -fsycl-instrument-device-code --sysroot=%S/Inputs/SYCL -fno-sycl-device-lib=all -fsycl-targets=spir64 -### %s 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-instrument-device-code --sysroot=%S/Inputs/SYCL -fno-sycl-device-lib=all -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-SPIRV %s
 
 // CHECK-SPIRV: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-instrument-device-code"


### PR DESCRIPTION
Adjust test to work better in Windows type environments by forcing
the target to be Linux.  This allows the dummy device libs to be
found.