### PR TITLE
[SYCL]Remove unwanted check for value dependency of const vars

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10593,8 +10593,7 @@ public:
                                           Expr *E);
 
   bool checkNSReturnsRetainedReturnType(SourceLocation loc, QualType type);
-  bool checkAllowedSYCLInitializer(VarDecl *VD,
-                                   bool CheckValueDependent = false);
+  bool checkAllowedSYCLInitializer(VarDecl *VD);
 
   //===--------------------------------------------------------------------===//
   // C++ Coroutines TS

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10594,7 +10594,6 @@ public:
 
   bool checkNSReturnsRetainedReturnType(SourceLocation loc, QualType type);
   bool checkAllowedSYCLInitializer(VarDecl *VD);
-
   //===--------------------------------------------------------------------===//
   // C++ Coroutines TS
   //

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -249,8 +249,7 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
       // Disallow const statics and globals that are not zero-initialized
       // or constant-initialized.
       else if (IsRuntimeEvaluated && IsConst && VD->hasGlobalStorage() &&
-               !VD->isConstexpr() &&
-               !checkAllowedSYCLInitializer(VD))
+               !VD->isConstexpr() && !checkAllowedSYCLInitializer(VD))
         SYCLDiagIfDeviceCode(*Locs.begin(), diag::err_sycl_restrict)
             << Sema::KernelConstStaticVariable;
     } else if (auto *FDecl = dyn_cast<FunctionDecl>(D)) {

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -250,7 +250,7 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
       // or constant-initialized.
       else if (IsRuntimeEvaluated && IsConst && VD->hasGlobalStorage() &&
                !VD->isConstexpr() &&
-               !checkAllowedSYCLInitializer(VD, /*CheckValueDependent =*/true))
+               !checkAllowedSYCLInitializer(VD))
         SYCLDiagIfDeviceCode(*Locs.begin(), diag::err_sycl_restrict)
             << Sema::KernelConstStaticVariable;
     } else if (auto *FDecl = dyn_cast<FunctionDecl>(D)) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4132,7 +4132,7 @@ void Sema::finalizeSYCLDelayedAnalysis(const FunctionDecl *Caller,
   }
 }
 
-bool Sema::checkAllowedSYCLInitializer(VarDecl *VD, bool CheckValueDependent) {
+bool Sema::checkAllowedSYCLInitializer(VarDecl *VD) {
   assert(getLangOpts().SYCLIsDevice &&
          "Should only be called during SYCL compilation");
 
@@ -4140,7 +4140,7 @@ bool Sema::checkAllowedSYCLInitializer(VarDecl *VD, bool CheckValueDependent) {
     return true;
 
   const Expr *Init = VD->getInit();
-  bool ValueDependent = CheckValueDependent && Init->isValueDependent();
+  bool ValueDependent = Init->isValueDependent();
   bool isConstantInit =
       Init && !ValueDependent && Init->isConstantInitializer(Context, false);
   if (!VD->isConstexpr() && Init && !ValueDependent && !isConstantInit)

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -319,7 +319,14 @@ namespace ext {
 namespace oneapi {
 namespace experimental {
 template <typename T, typename ID = T>
-class spec_constant {};
+class spec_constant {
+public:
+  spec_constant() {}
+  explicit constexpr spec_constant(T defaultVal) : DefaultValue(defaultVal) {}
+
+private:
+  T DefaultValue;
+};
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext

--- a/clang/test/SemaSYCL/spec-const-value-dependent-crash.cpp
+++ b/clang/test/SemaSYCL/spec-const-value-dependent-crash.cpp
@@ -2,8 +2,6 @@
 // This test checks that Clang doesn't crash if a specialization constant is
 // value dependent.
 
-
-
 #include "sycl.hpp"
 sycl::queue myQueue;
 

--- a/clang/test/SemaSYCL/spec-const-value-dependent-crash.cpp
+++ b/clang/test/SemaSYCL/spec-const-value-dependent-crash.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -ast-dump -sycl-std=2020 %s | FileCheck %s
+// This test checks that Clang doesn't crash if a specialization constant is
+// value dependent.
+
+
+
+#include "sycl.hpp"
+sycl::queue myQueue;
+
+int main() {
+   constexpr int default_val = 20;
+   cl::sycl::ext::oneapi::experimental::spec_constant<int, class MyInt32Const> SC(default_val);
+  
+  myQueue.submit([&](sycl::handler &h) {
+    h.single_task<class kernel_sc>(
+        [=] {
+          cl::sycl::ext::oneapi::experimental::spec_constant<int, class MyInt32Const> res = SC;
+        });
+  });
+  return 0;
+}
+
+// CHECK: FunctionDecl {{.*}}kernel_sc{{.*}} 'void ()'
+// CHECK: VarDecl {{.*}}'(lambda at {{.*}}'
+// CHECK-NEXT: InitListExpr {{.*}}'(lambda at {{.*}}'
+// CHECK-NEXT: CXXConstructExpr {{.*}}'cl::sycl::ext::oneapi::experimental::spec_constant<int, class MyInt32Const>':'sycl::ext::oneapi::experimental::spec_constant<int, MyInt32Const>' 'void ()'


### PR DESCRIPTION
Removed `CheckValueDependent`  from the parameter list of function `bool checkAllowedSYCLInitializer(VarDecl *VD,
                                   bool CheckValueDependent = false);`

Setting this value to `false` by default causes compiler crash during initialization of `constexprs` that are value dependent, because in [L4143](https://github.com/intel/llvm/pull/4870/files#diff-a07ededf6f50832d6f6e956321f97097ff85197e06a3edc9063af88f02d467e2L4143) `ValueDependent` will be `false` irrespective of `Init->isValueDependent()`'s value. 

`ValueDependent` is then switched to `true` [here](https://github.com/intel/llvm/pull/4870/files#diff-a07ededf6f50832d6f6e956321f97097ff85197e06a3edc9063af88f02d467e2L4145) which is incorrect.

The assert in Init->isConstantInitializer(Context, false) is triggered since we never truly checked if the var is valuedependent or not.