### PR TITLE
[Driver][SYCL] Adjust device target triple when compiling for 32-bits

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1017,10 +1017,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
     // For -fsycl-device-only, we also setup the implied triple as needed.
     StringRef SYCLTargetArch;
     if (C.getInputArgs().hasArg(options::OPT_fsycl_device_only))
-      if (C.getDefaultToolChain().getTriple().getArch() == llvm::Triple::x86)
-        SYCLTargetArch = "spir";
-      else
-        SYCLTargetArch = "spir64";
+      SYCLTargetArch = "spir64";
     else if (HasValidSYCLRuntime)
       // Triple for -fintelfpga is spir64_fpga.
       SYCLTargetArch = SYCLfpga ? "spir64_fpga" : "spir64";

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -69,7 +69,7 @@
 // RUN:  | FileCheck --check-prefix=DEVICE-32 %s
 // RUN: %clang_cl -fsycl-device-only --target=i386-unknown-linux-gnu -### %s 2>&1 \
 // RUN:  | FileCheck --check-prefix=DEVICE-32 %s
-// DEVICE-32: clang{{.*}} "-triple" "spir-unknown-unknown" "-aux-triple" "i386-unknown-linux-gnu"
+// DEVICE-32: clang{{.*}} "-triple" "spir64-unknown-unknown" "-aux-triple" "i386-unknown-linux-gnu"
 
 /// Verify that the sycl header directory is before /usr/include
 // RUN: %clangxx -### -fsycl-device-only %s 2>&1 | FileCheck %s --check-prefix=HEADER_ORDER

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -222,7 +222,8 @@ and not recommended to use in production environment.
 
 **`-fsycl-device-only`**
 
-    Compile only device part of the code and ignore host part.
+    Compile only device part of the code and ignore host part. If specified
+    without -fsycl-targets=<arg>, spir64 is the default triple.
 
 **`-f[no-]sycl-use-bitcode`** [EXPERIMENTAL]
 


### PR DESCRIPTION
When compiling for 32-bit targets with either a 32-bit hosted compiler
or using and explicit target parameter, always generate to spir64
targets for the device.  We were only doing this for -fsycl-device-only
so match things up across the board.