### PR TITLE
[SYCL] Fix hexadecimal byte streaming in device binary properties

### DIFF
--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -547,7 +547,7 @@ std::ostream &operator<<(std::ostream &Out, const DeviceBinaryProperty &P) {
     std::ios_base::fmtflags FlagsBackup = Out.flags();
     Out << std::hex;
     for (const auto &Byte : BA) {
-      Out << "0x" << Byte << " ";
+      Out << "0x" << static_cast<unsigned>(Byte) << " ";
     }
     Out.flags(FlagsBackup);
     break;


### PR DESCRIPTION
Using the streaming operator with DeviceBinaryProperty that contains a byte array will try to write the bytes as hexadecimal values to the associated stream. However, std::hex only converts integer values whilst the bytes the operator writes are chars. These changes cast the chars to integer values to ensure that the values are correctly written with hexadecimal representation.