### PR TITLE
[SYCL] Implements SYCL 2020 property traits

### DIFF
--- a/sycl/include/CL/sycl/properties/accessor_properties.hpp
+++ b/sycl/include/CL/sycl/properties/accessor_properties.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/property_helper.hpp>
+#include <CL/sycl/properties/property_traits.hpp>
 #include <sycl/ext/oneapi/accessor_property_list.hpp>
 #include <type_traits>
 
@@ -110,6 +111,69 @@ struct is_compile_time_property<sycl::ext::intel::property::buffer_location>
     : std::true_type {};
 } // namespace oneapi
 } // namespace ext
+
+// Forward declaration
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+class accessor;
+template <typename DataT, int Dimensions, access::mode AccessMode>
+class host_accessor;
+
+// Accessor property trait specializations
+template <> struct is_property<property::noinit> : std::true_type {};
+template <> struct is_property<property::no_init> : std::true_type {};
+template <>
+struct is_property<ext::oneapi::property::no_offset> : std::true_type {};
+template <>
+struct is_property<ext::oneapi::property::no_alias> : std::true_type {};
+template <>
+struct is_property<ext::intel::property::buffer_location> : std::true_type {};
+
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+struct is_property_of<property::noinit,
+                      accessor<DataT, Dimensions, AccessMode, AccessTarget,
+                               IsPlaceholder, PropertyListT>> : std::true_type {
+};
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+struct is_property_of<property::no_init,
+                      accessor<DataT, Dimensions, AccessMode, AccessTarget,
+                               IsPlaceholder, PropertyListT>> : std::true_type {
+};
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+struct is_property_of<ext::oneapi::property::no_offset,
+                      accessor<DataT, Dimensions, AccessMode, AccessTarget,
+                               IsPlaceholder, PropertyListT>> : std::true_type {
+};
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+struct is_property_of<ext::oneapi::property::no_alias,
+                      accessor<DataT, Dimensions, AccessMode, AccessTarget,
+                               IsPlaceholder, PropertyListT>> : std::true_type {
+};
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+struct is_property_of<ext::intel::property::buffer_location,
+                      accessor<DataT, Dimensions, AccessMode, AccessTarget,
+                               IsPlaceholder, PropertyListT>> : std::true_type {
+};
+
+template <typename DataT, int Dimensions, access::mode AccessMode>
+struct is_property_of<property::noinit,
+                      host_accessor<DataT, Dimensions, AccessMode>>
+    : std::true_type {};
+template <typename DataT, int Dimensions, access::mode AccessMode>
+struct is_property_of<property::no_init,
+                      host_accessor<DataT, Dimensions, AccessMode>>
+    : std::true_type {};
 
 namespace detail {
 template <int I>

--- a/sycl/include/CL/sycl/properties/accessor_properties.hpp
+++ b/sycl/include/CL/sycl/properties/accessor_properties.hpp
@@ -117,6 +117,9 @@ template <typename DataT, int Dimensions, access::mode AccessMode,
           access::target AccessTarget, access::placeholder IsPlaceholder,
           typename PropertyListT>
 class accessor;
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder>
+class image_accessor;
 template <typename DataT, int Dimensions, access::mode AccessMode>
 class host_accessor;
 
@@ -165,6 +168,19 @@ struct is_property_of<ext::intel::property::buffer_location,
                       accessor<DataT, Dimensions, AccessMode, AccessTarget,
                                IsPlaceholder, PropertyListT>> : std::true_type {
 };
+
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder>
+struct is_property_of<
+    property::noinit,
+    image_accessor<DataT, Dimensions, AccessMode, AccessTarget, IsPlaceholder>>
+    : std::true_type {};
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder>
+struct is_property_of<
+    property::no_init,
+    image_accessor<DataT, Dimensions, AccessMode, AccessTarget, IsPlaceholder>>
+    : std::true_type {};
 
 template <typename DataT, int Dimensions, access::mode AccessMode>
 struct is_property_of<property::noinit,

--- a/sycl/include/CL/sycl/properties/buffer_properties.hpp
+++ b/sycl/include/CL/sycl/properties/buffer_properties.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/property_helper.hpp>
+#include <CL/sycl/properties/property_traits.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -64,5 +65,43 @@ class use_pinned_host_memory : public sycl::detail::DataLessProperty<
 } // namespace property
 } // namespace oneapi
 } // namespace ext
+
+// Forward declaration
+template <typename T, int Dimensions, typename AllocatorT, typename Enable>
+class buffer;
+
+// Buffer property trait specializations
+template <>
+struct is_property<property::buffer::use_host_ptr> : std::true_type {};
+template <> struct is_property<property::buffer::use_mutex> : std::true_type {};
+template <>
+struct is_property<property::buffer::context_bound> : std::true_type {};
+template <>
+struct is_property<property::buffer::mem_channel> : std::true_type {};
+template <>
+struct is_property<ext::oneapi::property::buffer::use_pinned_host_memory>
+    : std::true_type {};
+
+template <typename T, int Dimensions, typename AllocatorT>
+struct is_property_of<property::buffer::use_host_ptr,
+                      buffer<T, Dimensions, AllocatorT, void>>
+    : std::true_type {};
+template <typename T, int Dimensions, typename AllocatorT>
+struct is_property_of<property::buffer::use_mutex,
+                      buffer<T, Dimensions, AllocatorT, void>>
+    : std::true_type {};
+template <typename T, int Dimensions, typename AllocatorT>
+struct is_property_of<property::buffer::context_bound,
+                      buffer<T, Dimensions, AllocatorT, void>>
+    : std::true_type {};
+template <typename T, int Dimensions, typename AllocatorT>
+struct is_property_of<property::buffer::mem_channel,
+                      buffer<T, Dimensions, AllocatorT, void>>
+    : std::true_type {};
+template <typename T, int Dimensions, typename AllocatorT>
+struct is_property_of<ext::oneapi::property::buffer::use_pinned_host_memory,
+                      buffer<T, Dimensions, AllocatorT, void>>
+    : std::true_type {};
+
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/properties/context_properties.hpp
+++ b/sycl/include/CL/sycl/properties/context_properties.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/property_helper.hpp>
+#include <CL/sycl/properties/property_traits.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -21,5 +22,18 @@ class use_primary_context
 } // namespace cuda
 } // namespace context
 } // namespace property
+
+// Forward declaration
+class context;
+
+// Context property trait specializations
+template <>
+struct is_property<property::context::cuda::use_primary_context>
+    : std::true_type {};
+
+template <>
+struct is_property_of<property::context::cuda::use_primary_context, context>
+    : std::true_type {};
+
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/properties/image_properties.hpp
+++ b/sycl/include/CL/sycl/properties/image_properties.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/property_helper.hpp>
+#include <CL/sycl/properties/property_traits.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -40,5 +41,26 @@ private:
 };
 } // namespace image
 } // namespace property
+
+// Forward declaration
+template <int Dimensions, typename AllocatorT> class image;
+
+// Image property trait specializations
+template <>
+struct is_property<property::image::use_host_ptr> : std::true_type {};
+template <> struct is_property<property::image::use_mutex> : std::true_type {};
+template <>
+struct is_property<property::image::context_bound> : std::true_type {};
+
+template <int Dimensions, typename AllocatorT>
+struct is_property_of<property::image::use_host_ptr,
+                      image<Dimensions, AllocatorT>> : std::true_type {};
+template <int Dimensions, typename AllocatorT>
+struct is_property_of<property::image::use_mutex, image<Dimensions, AllocatorT>>
+    : std::true_type {};
+template <int Dimensions, typename AllocatorT>
+struct is_property_of<property::image::context_bound,
+                      image<Dimensions, AllocatorT>> : std::true_type {};
+
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/properties/property_traits.hpp
+++ b/sycl/include/CL/sycl/properties/property_traits.hpp
@@ -1,0 +1,32 @@
+//==------------ property_traits.hpp --- SYCL property traits --------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+
+// Property traits
+template <typename propertyT> struct is_property : public std::false_type {};
+
+template <typename propertyT, typename syclObjectT>
+struct is_property_of : public std::false_type {};
+
+#if __cplusplus > 201402L
+
+template <typename propertyT>
+inline constexpr bool is_property_v = is_property<propertyT>::value;
+
+template <typename propertyT, typename syclObjectT>
+inline constexpr bool is_property_of_v =
+    is_property_of<propertyT, syclObjectT>::value;
+
+#endif
+
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/properties/property_traits.hpp
+++ b/sycl/include/CL/sycl/properties/property_traits.hpp
@@ -17,16 +17,12 @@ template <typename propertyT> struct is_property : public std::false_type {};
 template <typename propertyT, typename syclObjectT>
 struct is_property_of : public std::false_type {};
 
-#if __cplusplus > 201402L
-
 template <typename propertyT>
-inline constexpr bool is_property_v = is_property<propertyT>::value;
+__SYCL_INLINE_CONSTEXPR bool is_property_v = is_property<propertyT>::value;
 
 template <typename propertyT, typename syclObjectT>
-inline constexpr bool is_property_of_v =
+__SYCL_INLINE_CONSTEXPR bool is_property_of_v =
     is_property_of<propertyT, syclObjectT>::value;
-
-#endif
 
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/properties/queue_properties.hpp
+++ b/sycl/include/CL/sycl/properties/queue_properties.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/detail/property_helper.hpp>
+#include <CL/sycl/properties/property_traits.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -23,5 +24,26 @@ class use_default_stream
 } // namespace cuda
 } // namespace queue
 } // namespace property
+
+// Forward declaration
+class queue;
+
+// Queue property trait specializations
+template <> struct is_property<property::queue::in_order> : std::true_type {};
+template <>
+struct is_property<property::queue::enable_profiling> : std::true_type {};
+template <>
+struct is_property<property::queue::cuda::use_default_stream> : std::true_type {
+};
+
+template <>
+struct is_property_of<property::queue::in_order, queue> : std::true_type {};
+template <>
+struct is_property_of<property::queue::enable_profiling, queue>
+    : std::true_type {};
+template <>
+struct is_property_of<property::queue::cuda::use_default_stream, queue>
+    : std::true_type {};
+
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/properties/reduction_properties.hpp
+++ b/sycl/include/CL/sycl/properties/reduction_properties.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/property_helper.hpp>
+#include <CL/sycl/properties/property_traits.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -19,5 +20,11 @@ class initialize_to_identity
     : public detail::DataLessProperty<detail::InitializeToIdentity> {};
 } // namespace reduction
 } // namespace property
+
+// Reduction property trait specializations
+template <>
+struct is_property<property::reduction::initialize_to_identity>
+    : std::true_type {};
+
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/property_list.hpp
+++ b/sycl/include/CL/sycl/property_list.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/property_list_base.hpp>
+#include <CL/sycl/properties/property_traits.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -28,10 +29,8 @@ class property_list : protected detail::PropertyListBase {
   template <typename... Tail> struct AllProperties : std::true_type {};
   template <typename T, typename... Tail>
   struct AllProperties<T, Tail...>
-      : detail::conditional_t<
-            std::is_base_of<detail::DataLessPropertyBase, T>::value ||
-                std::is_base_of<detail::PropertyWithDataBase, T>::value,
-            AllProperties<Tail...>, std::false_type> {};
+      : detail::conditional_t<is_property<T>::value, AllProperties<Tail...>,
+                              std::false_type> {};
 
 public:
   template <typename... PropsT, typename = typename detail::enable_if_t<

--- a/sycl/test/basic_tests/property_traits.cpp
+++ b/sycl/test/basic_tests/property_traits.cpp
@@ -179,7 +179,6 @@ int main() {
   // Invalid properties with invalid object type
   CHECK_IS_NOT_PROPERTY_OF(NotAProperty, NotASYCLObject);
 
-#if __cplusplus > 201402L
   //----------------------------------------------------------------------------
   // is_property_v positive tests
   //----------------------------------------------------------------------------
@@ -312,5 +311,4 @@ int main() {
 
   // Invalid properties with invalid object type
   CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, NotASYCLObject);
-#endif
 }

--- a/sycl/test/basic_tests/property_traits.cpp
+++ b/sycl/test/basic_tests/property_traits.cpp
@@ -74,6 +74,16 @@ int main() {
       accessor<sycl::half, 2, access_mode::write, target::host_buffer,
                access::placeholder::false_t>);
 
+  // Image-accessor is_property_of
+  CHECK_IS_PROPERTY_OF(
+      property::noinit,
+      image_accessor<float, 1, access_mode::write, target::device,
+                     access::placeholder::true_t>);
+  CHECK_IS_PROPERTY_OF(
+      property::no_init,
+      image_accessor<unsigned long, 2, access_mode::read, target::host_buffer,
+                     access::placeholder::true_t>);
+
   // Host-accessor is_property_of
   CHECK_IS_PROPERTY_OF(property::noinit,
                        host_accessor<float, 1, access_mode::write>);
@@ -147,6 +157,16 @@ int main() {
       ext::intel::property::buffer_location,
       accessor<sycl::half, 2, access_mode::write, target::host_buffer,
                access::placeholder::false_t>);
+
+  // Image-accessor is_property_of_v
+  CHECK_IS_PROPERTY_OF_V(
+      property::noinit,
+      image_accessor<float, 1, access_mode::write, target::device,
+                     access::placeholder::true_t>);
+  CHECK_IS_PROPERTY_OF_V(
+      property::no_init,
+      image_accessor<unsigned long, 2, access_mode::read, target::host_buffer,
+                     access::placeholder::true_t>);
 
   // Host-ccessor is_property_of_v
   CHECK_IS_PROPERTY_OF_V(property::noinit,

--- a/sycl/test/basic_tests/property_traits.cpp
+++ b/sycl/test/basic_tests/property_traits.cpp
@@ -1,4 +1,5 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -c
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
 
 #include <CL/sycl.hpp>
 #include <cassert>

--- a/sycl/test/basic_tests/property_traits.cpp
+++ b/sycl/test/basic_tests/property_traits.cpp
@@ -1,0 +1,180 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -c
+
+#include <CL/sycl.hpp>
+#include <cassert>
+
+#define CHECK_IS_PROPERTY(PROP)                                                \
+  static_assert(is_property<PROP>::value,                                      \
+                "no specialization of is_property for " #PROP)
+
+#define CHECK_IS_PROPERTY_V(PROP)                                              \
+  static_assert(is_property_v<PROP>,                                           \
+                "no specialization of is_property_v for " #PROP)
+
+#define CHECK_IS_PROPERTY_OF(PROP, ...)                                        \
+  static_assert(is_property_of<PROP, __VA_ARGS__>::value,                      \
+                "no specialization of is_property_of for " #PROP               \
+                " and " #__VA_ARGS__)
+
+#define CHECK_IS_PROPERTY_OF_V(PROP, ...)                                      \
+  static_assert(is_property_of_v<PROP, __VA_ARGS__>,                           \
+                "no specialization of is_property_of_v for " #PROP             \
+                " and " #__VA_ARGS__)
+
+using namespace cl::sycl;
+
+int main() {
+  // Accessor is_property
+  CHECK_IS_PROPERTY(property::noinit);
+  CHECK_IS_PROPERTY(property::no_init);
+  CHECK_IS_PROPERTY(ext::oneapi::property::no_offset);
+  CHECK_IS_PROPERTY(ext::oneapi::property::no_alias);
+  CHECK_IS_PROPERTY(ext::intel::property::buffer_location);
+
+  // Buffer is_property
+  CHECK_IS_PROPERTY(property::buffer::use_host_ptr);
+  CHECK_IS_PROPERTY(property::buffer::use_mutex);
+  CHECK_IS_PROPERTY(property::buffer::context_bound);
+  CHECK_IS_PROPERTY(property::buffer::mem_channel);
+  CHECK_IS_PROPERTY(ext::oneapi::property::buffer::use_pinned_host_memory);
+
+  // Context is_property
+  CHECK_IS_PROPERTY(property::context::cuda::use_primary_context);
+
+  // Image is_property
+  CHECK_IS_PROPERTY(property::image::use_host_ptr);
+  CHECK_IS_PROPERTY(property::image::use_mutex);
+  CHECK_IS_PROPERTY(property::image::context_bound);
+
+  // Queue is_property
+  CHECK_IS_PROPERTY(property::queue::in_order);
+  CHECK_IS_PROPERTY(property::queue::enable_profiling);
+  CHECK_IS_PROPERTY(property::queue::cuda::use_default_stream);
+
+  // Reduction is_property
+  CHECK_IS_PROPERTY(property::reduction::initialize_to_identity);
+
+  // Accessor is_property_of
+  CHECK_IS_PROPERTY_OF(property::noinit,
+                       accessor<float, 1, access_mode::write, target::device,
+                                access::placeholder::true_t>);
+  CHECK_IS_PROPERTY_OF(
+      property::no_init,
+      accessor<unsigned long, 2, access_mode::read, target::host_buffer,
+               access::placeholder::true_t>);
+  CHECK_IS_PROPERTY_OF(ext::oneapi::property::no_offset,
+                       accessor<long, 3, access_mode::read_write, target::local,
+                                access::placeholder::false_t>);
+  CHECK_IS_PROPERTY_OF(ext::oneapi::property::no_alias,
+                       accessor<bool, 1, access_mode::read, target::device,
+                                access::placeholder::true_t>);
+  CHECK_IS_PROPERTY_OF(
+      ext::intel::property::buffer_location,
+      accessor<sycl::half, 2, access_mode::write, target::host_buffer,
+               access::placeholder::false_t>);
+
+  // Host-accessor is_property_of
+  CHECK_IS_PROPERTY_OF(property::noinit,
+                       host_accessor<float, 1, access_mode::write>);
+  CHECK_IS_PROPERTY_OF(property::no_init,
+                       accessor<unsigned long, 2, access_mode::read>);
+
+  // Buffer is_property_of
+  CHECK_IS_PROPERTY_OF(property::buffer::use_host_ptr, buffer<int, 2>);
+  CHECK_IS_PROPERTY_OF(property::buffer::use_mutex, buffer<char, 1>);
+  CHECK_IS_PROPERTY_OF(property::buffer::context_bound, buffer<float, 1>);
+  CHECK_IS_PROPERTY_OF(property::buffer::mem_channel, buffer<double, 3>);
+  CHECK_IS_PROPERTY_OF(ext::oneapi::property::buffer::use_pinned_host_memory,
+                       buffer<unsigned int, 2>);
+
+  // Context is_property_of
+  CHECK_IS_PROPERTY_OF(property::context::cuda::use_primary_context, context);
+
+  // Image is_property_of
+  CHECK_IS_PROPERTY_OF(property::image::use_host_ptr, image<1>);
+  CHECK_IS_PROPERTY_OF(property::image::use_mutex, image<2>);
+  CHECK_IS_PROPERTY_OF(property::image::context_bound, image<3>);
+
+  // Queue is_property_of
+  CHECK_IS_PROPERTY_OF(property::queue::in_order, queue);
+  CHECK_IS_PROPERTY_OF(property::queue::enable_profiling, queue);
+  CHECK_IS_PROPERTY_OF(property::queue::cuda::use_default_stream, queue);
+
+#if __cplusplus > 201402L
+  // Accessor is_property_v
+  CHECK_IS_PROPERTY_V(property::noinit);
+  CHECK_IS_PROPERTY_V(property::no_init);
+  CHECK_IS_PROPERTY_V(ext::oneapi::property::no_offset);
+  CHECK_IS_PROPERTY_V(ext::oneapi::property::no_alias);
+  CHECK_IS_PROPERTY_V(ext::intel::property::buffer_location);
+
+  // Buffer is_property_v
+  CHECK_IS_PROPERTY_V(property::buffer::use_host_ptr);
+  CHECK_IS_PROPERTY_V(property::buffer::use_mutex);
+  CHECK_IS_PROPERTY_V(property::buffer::context_bound);
+  CHECK_IS_PROPERTY_V(property::buffer::mem_channel);
+  CHECK_IS_PROPERTY_V(ext::oneapi::property::buffer::use_pinned_host_memory);
+
+  // Context is_property_v
+  CHECK_IS_PROPERTY_V(property::context::cuda::use_primary_context);
+
+  // Image is_property_v
+  CHECK_IS_PROPERTY_V(property::image::use_host_ptr);
+  CHECK_IS_PROPERTY_V(property::image::use_mutex);
+  CHECK_IS_PROPERTY_V(property::image::context_bound);
+
+  // Queue is_property_v
+  CHECK_IS_PROPERTY_V(property::queue::in_order);
+  CHECK_IS_PROPERTY_V(property::queue::enable_profiling);
+  CHECK_IS_PROPERTY_V(property::queue::cuda::use_default_stream);
+
+  // Accessor is_property_of_v
+  CHECK_IS_PROPERTY_OF_V(property::noinit,
+                         accessor<float, 1, access_mode::write, target::device,
+                                  access::placeholder::true_t>);
+  CHECK_IS_PROPERTY_OF_V(
+      property::no_init,
+      accessor<unsigned long, 2, access_mode::read, target::host_buffer,
+               access::placeholder::true_t>);
+  CHECK_IS_PROPERTY_OF_V(ext::oneapi::property::no_offset,
+                         accessor<long, 3, access_mode::read_write,
+                                  target::local, access::placeholder::false_t>);
+  CHECK_IS_PROPERTY_OF_V(ext::oneapi::property::no_alias,
+                         accessor<bool, 1, access_mode::read, target::device,
+                                  access::placeholder::true_t>);
+  CHECK_IS_PROPERTY_OF_V(
+      ext::intel::property::buffer_location,
+      accessor<sycl::half, 2, access_mode::write, target::host_buffer,
+               access::placeholder::false_t>);
+
+  // Host-ccessor is_property_of_v
+  CHECK_IS_PROPERTY_OF_V(property::noinit,
+                         host_accessor<float, 1, access_mode::write>);
+  CHECK_IS_PROPERTY_OF_V(property::no_init,
+                         accessor<unsigned long, 2, access_mode::read>);
+
+  // Buffer is_property_of_v
+  CHECK_IS_PROPERTY_OF_V(property::buffer::use_host_ptr, buffer<int, 2>);
+  CHECK_IS_PROPERTY_OF_V(property::buffer::use_mutex, buffer<char, 1>);
+  CHECK_IS_PROPERTY_OF_V(property::buffer::context_bound, buffer<float, 1>);
+  CHECK_IS_PROPERTY_OF_V(property::buffer::mem_channel, buffer<double, 3>);
+  CHECK_IS_PROPERTY_OF_V(ext::oneapi::property::buffer::use_pinned_host_memory,
+                         buffer<unsigned int, 2>);
+
+  // Context is_property_of_v
+  CHECK_IS_PROPERTY_OF_V(property::context::cuda::use_primary_context, context);
+
+  // Image is_property_of_v
+  CHECK_IS_PROPERTY_OF_V(property::image::use_host_ptr, image<1>);
+  CHECK_IS_PROPERTY_OF_V(property::image::use_mutex, image<2>);
+  CHECK_IS_PROPERTY_OF_V(property::image::context_bound, image<3>);
+
+  // Queue is_property_of_v
+  CHECK_IS_PROPERTY_OF_V(property::queue::in_order, queue);
+  CHECK_IS_PROPERTY_OF_V(property::queue::enable_profiling, queue);
+  CHECK_IS_PROPERTY_OF_V(property::queue::cuda::use_default_stream, queue);
+
+  // Reduction is_property_v
+  CHECK_IS_PROPERTY_V(property::reduction::initialize_to_identity);
+#endif
+}

--- a/sycl/test/basic_tests/property_traits.cpp
+++ b/sycl/test/basic_tests/property_traits.cpp
@@ -26,7 +26,6 @@ using namespace cl::sycl;
 
 int main() {
   // Accessor is_property
-  CHECK_IS_PROPERTY(property::noinit);
   CHECK_IS_PROPERTY(property::no_init);
   CHECK_IS_PROPERTY(ext::oneapi::property::no_offset);
   CHECK_IS_PROPERTY(ext::oneapi::property::no_alias);
@@ -56,9 +55,6 @@ int main() {
   CHECK_IS_PROPERTY(property::reduction::initialize_to_identity);
 
   // Accessor is_property_of
-  CHECK_IS_PROPERTY_OF(property::noinit,
-                       accessor<float, 1, access_mode::write, target::device,
-                                access::placeholder::true_t>);
   CHECK_IS_PROPERTY_OF(
       property::no_init,
       accessor<unsigned long, 2, access_mode::read, target::host_buffer,
@@ -76,17 +72,11 @@ int main() {
 
   // Image-accessor is_property_of
   CHECK_IS_PROPERTY_OF(
-      property::noinit,
-      image_accessor<float, 1, access_mode::write, target::device,
-                     access::placeholder::true_t>);
-  CHECK_IS_PROPERTY_OF(
       property::no_init,
       image_accessor<unsigned long, 2, access_mode::read, target::host_buffer,
                      access::placeholder::true_t>);
 
   // Host-accessor is_property_of
-  CHECK_IS_PROPERTY_OF(property::noinit,
-                       host_accessor<float, 1, access_mode::write>);
   CHECK_IS_PROPERTY_OF(property::no_init,
                        accessor<unsigned long, 2, access_mode::read>);
 
@@ -113,7 +103,6 @@ int main() {
 
 #if __cplusplus > 201402L
   // Accessor is_property_v
-  CHECK_IS_PROPERTY_V(property::noinit);
   CHECK_IS_PROPERTY_V(property::no_init);
   CHECK_IS_PROPERTY_V(ext::oneapi::property::no_offset);
   CHECK_IS_PROPERTY_V(ext::oneapi::property::no_alias);
@@ -140,9 +129,6 @@ int main() {
   CHECK_IS_PROPERTY_V(property::queue::cuda::use_default_stream);
 
   // Accessor is_property_of_v
-  CHECK_IS_PROPERTY_OF_V(property::noinit,
-                         accessor<float, 1, access_mode::write, target::device,
-                                  access::placeholder::true_t>);
   CHECK_IS_PROPERTY_OF_V(
       property::no_init,
       accessor<unsigned long, 2, access_mode::read, target::host_buffer,
@@ -160,17 +146,11 @@ int main() {
 
   // Image-accessor is_property_of_v
   CHECK_IS_PROPERTY_OF_V(
-      property::noinit,
-      image_accessor<float, 1, access_mode::write, target::device,
-                     access::placeholder::true_t>);
-  CHECK_IS_PROPERTY_OF_V(
       property::no_init,
       image_accessor<unsigned long, 2, access_mode::read, target::host_buffer,
                      access::placeholder::true_t>);
 
   // Host-ccessor is_property_of_v
-  CHECK_IS_PROPERTY_OF_V(property::noinit,
-                         host_accessor<float, 1, access_mode::write>);
   CHECK_IS_PROPERTY_OF_V(property::no_init,
                          accessor<unsigned long, 2, access_mode::read>);
 

--- a/sycl/test/basic_tests/property_traits.cpp
+++ b/sycl/test/basic_tests/property_traits.cpp
@@ -22,9 +22,34 @@
                 "no specialization of is_property_of_v for " #PROP             \
                 " and " #__VA_ARGS__)
 
+#define CHECK_IS_NOT_PROPERTY(PROP)                                            \
+  static_assert(!is_property<PROP>::value,                                     \
+                "no specialization of is_property for " #PROP)
+
+#define CHECK_IS_NOT_PROPERTY_V(PROP)                                          \
+  static_assert(!is_property_v<PROP>,                                          \
+                "no specialization of is_property_v for " #PROP)
+
+#define CHECK_IS_NOT_PROPERTY_OF(PROP, ...)                                    \
+  static_assert(!is_property_of<PROP, __VA_ARGS__>::value,                     \
+                "no specialization of is_property_of for " #PROP               \
+                " and " #__VA_ARGS__)
+
+#define CHECK_IS_NOT_PROPERTY_OF_V(PROP, ...)                                  \
+  static_assert(!is_property_of_v<PROP, __VA_ARGS__>,                          \
+                "no specialization of is_property_of_v for " #PROP             \
+                " and " #__VA_ARGS__)
+
+class NotAProperty {};
+class NotASYCLObject {};
+
 using namespace cl::sycl;
 
 int main() {
+  //----------------------------------------------------------------------------
+  // is_property positive tests
+  //----------------------------------------------------------------------------
+
   // Accessor is_property
   CHECK_IS_PROPERTY(property::no_init);
   CHECK_IS_PROPERTY(ext::oneapi::property::no_offset);
@@ -54,6 +79,16 @@ int main() {
   // Reduction is_property
   CHECK_IS_PROPERTY(property::reduction::initialize_to_identity);
 
+  //----------------------------------------------------------------------------
+  // is_property negative tests
+  //----------------------------------------------------------------------------
+
+  CHECK_IS_NOT_PROPERTY(NotAProperty);
+
+  //----------------------------------------------------------------------------
+  // is_property_of positive tests
+  //----------------------------------------------------------------------------
+
   // Accessor is_property_of
   CHECK_IS_PROPERTY_OF(
       property::no_init,
@@ -78,7 +113,7 @@ int main() {
 
   // Host-accessor is_property_of
   CHECK_IS_PROPERTY_OF(property::no_init,
-                       accessor<unsigned long, 2, access_mode::read>);
+                       host_accessor<unsigned long, 2, access_mode::read>);
 
   // Buffer is_property_of
   CHECK_IS_PROPERTY_OF(property::buffer::use_host_ptr, buffer<int, 2>);
@@ -101,7 +136,54 @@ int main() {
   CHECK_IS_PROPERTY_OF(property::queue::enable_profiling, queue);
   CHECK_IS_PROPERTY_OF(property::queue::cuda::use_default_stream, queue);
 
+  //----------------------------------------------------------------------------
+  // is_property_of positive tests
+  //----------------------------------------------------------------------------
+
+  // Valid properties with invalid object type
+  CHECK_IS_NOT_PROPERTY_OF(property::no_init, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(ext::oneapi::property::no_offset, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(ext::oneapi::property::no_alias, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(ext::intel::property::buffer_location,
+                           NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::no_init, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::no_init, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::buffer::use_host_ptr, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::buffer::use_mutex, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::buffer::context_bound, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::buffer::mem_channel, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(
+      ext::oneapi::property::buffer::use_pinned_host_memory, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::context::cuda::use_primary_context,
+                           NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::image::use_host_ptr, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::image::use_mutex, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::image::context_bound, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::queue::in_order, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::queue::enable_profiling, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF(property::queue::cuda::use_default_stream,
+                           NotASYCLObject);
+
+  // Invalid properties with valid object type
+  CHECK_IS_NOT_PROPERTY_OF(NotAProperty, accessor<int, 1>);
+  CHECK_IS_NOT_PROPERTY_OF(
+      NotAProperty,
+      image_accessor<float, 2, access_mode::read, target::host_buffer,
+                     access::placeholder::true_t>);
+  CHECK_IS_NOT_PROPERTY_OF(NotAProperty, host_accessor<char, 2>);
+  CHECK_IS_NOT_PROPERTY_OF(NotAProperty, buffer<int, 2>);
+  CHECK_IS_NOT_PROPERTY_OF(NotAProperty, context);
+  CHECK_IS_NOT_PROPERTY_OF(NotAProperty, image<1>);
+  CHECK_IS_NOT_PROPERTY_OF(NotAProperty, queue);
+
+  // Invalid properties with invalid object type
+  CHECK_IS_NOT_PROPERTY_OF(NotAProperty, NotASYCLObject);
+
 #if __cplusplus > 201402L
+  //----------------------------------------------------------------------------
+  // is_property_v positive tests
+  //----------------------------------------------------------------------------
+
   // Accessor is_property_v
   CHECK_IS_PROPERTY_V(property::no_init);
   CHECK_IS_PROPERTY_V(ext::oneapi::property::no_offset);
@@ -128,6 +210,16 @@ int main() {
   CHECK_IS_PROPERTY_V(property::queue::enable_profiling);
   CHECK_IS_PROPERTY_V(property::queue::cuda::use_default_stream);
 
+  //----------------------------------------------------------------------------
+  // is_property_v negative tests
+  //----------------------------------------------------------------------------
+
+  CHECK_IS_NOT_PROPERTY_V(NotAProperty);
+
+  //----------------------------------------------------------------------------
+  // is_property_of_v positive tests
+  //----------------------------------------------------------------------------
+
   // Accessor is_property_of_v
   CHECK_IS_PROPERTY_OF_V(
       property::no_init,
@@ -150,9 +242,9 @@ int main() {
       image_accessor<unsigned long, 2, access_mode::read, target::host_buffer,
                      access::placeholder::true_t>);
 
-  // Host-ccessor is_property_of_v
+  // Host-accessor is_property_of_v
   CHECK_IS_PROPERTY_OF_V(property::no_init,
-                         accessor<unsigned long, 2, access_mode::read>);
+                         host_accessor<unsigned long, 2, access_mode::read>);
 
   // Buffer is_property_of_v
   CHECK_IS_PROPERTY_OF_V(property::buffer::use_host_ptr, buffer<int, 2>);
@@ -177,5 +269,48 @@ int main() {
 
   // Reduction is_property_v
   CHECK_IS_PROPERTY_V(property::reduction::initialize_to_identity);
+
+  //----------------------------------------------------------------------------
+  // is_property_of positive tests
+  //----------------------------------------------------------------------------
+
+  // Valid properties with invalid object type
+  CHECK_IS_NOT_PROPERTY_OF_V(property::no_init, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(ext::oneapi::property::no_offset, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(ext::oneapi::property::no_alias, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(ext::intel::property::buffer_location,
+                             NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::no_init, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::no_init, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::buffer::use_host_ptr, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::buffer::use_mutex, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::buffer::context_bound, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::buffer::mem_channel, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(
+      ext::oneapi::property::buffer::use_pinned_host_memory, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::context::cuda::use_primary_context,
+                             NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::image::use_host_ptr, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::image::use_mutex, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::image::context_bound, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::queue::in_order, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::queue::enable_profiling, NotASYCLObject);
+  CHECK_IS_NOT_PROPERTY_OF_V(property::queue::cuda::use_default_stream,
+                             NotASYCLObject);
+
+  // Invalid properties with valid object type
+  CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, accessor<int, 1>);
+  CHECK_IS_NOT_PROPERTY_OF_V(
+      NotAProperty,
+      image_accessor<float, 2, access_mode::read, target::host_buffer,
+                     access::placeholder::true_t>);
+  CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, host_accessor<char, 2>);
+  CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, buffer<int, 2>);
+  CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, context);
+  CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, image<1>);
+  CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, queue);
+
+  // Invalid properties with invalid object type
+  CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, NotASYCLObject);
 #endif
 }


### PR DESCRIPTION
SYCL 2020 introduces the `is_property` and `is_property_of` traits for marking valid properties and the SYCL objects they can be used as properties for. These changes add the following:
 1. The `is_property` and `is_property_of` trait classes and the associated `is_property_v` and `is_property_of_v` shortcuts.
 2. Specializations of the new trait classes for all existing SYCL properties.
 3. Adjustment of the restriction for the `property_list` ctor using `is_property`.