### PR TITLE
Draft: [SYCL] Add noexcept to has_property

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -390,7 +390,7 @@ public:
         impl, range<1>{sz / sizeof(ReinterpretT)}, OffsetInBytes, IsSubBuffer);
   }
 
-  template <typename propertyT> bool has_property() const {
+  template <typename propertyT> bool has_property() const noexcept {
     return impl->template has_property<propertyT>();
   }
 

--- a/sycl/include/CL/sycl/context.hpp
+++ b/sycl/include/CL/sycl/context.hpp
@@ -175,7 +175,7 @@ public:
   /// Checks if this context has a property of type propertyT.
   ///
   /// \return true if this context has a property of type propertyT.
-  template <typename propertyT> bool has_property() const;
+  template <typename propertyT> bool has_property() const noexcept;
 
   /// Gets the specified property of this context.
   ///

--- a/sycl/include/CL/sycl/detail/property_list_base.hpp
+++ b/sycl/include/CL/sycl/detail/property_list_base.hpp
@@ -60,7 +60,7 @@ protected:
   template <typename PropT>
   typename detail::enable_if_t<
       std::is_base_of<DataLessPropertyBase, PropT>::value, bool>
-  has_property_helper() const {
+  has_property_helper() const noexcept {
     const int PropKind = static_cast<int>(PropT::getKind());
     if (PropKind > detail::DataLessPropKind::LastKnownDataLessPropKind)
       return false;
@@ -70,7 +70,7 @@ protected:
   template <typename PropT>
   typename detail::enable_if_t<
       std::is_base_of<PropertyWithDataBase, PropT>::value, bool>
-  has_property_helper() const {
+  has_property_helper() const noexcept {
     const int PropKind = static_cast<int>(PropT::getKind());
     for (const std::shared_ptr<PropertyWithDataBase> &Prop : MPropsWithData)
       if (Prop->isSame(PropKind))

--- a/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
+++ b/sycl/include/CL/sycl/detail/sycl_mem_obj_t.hpp
@@ -102,7 +102,8 @@ public:
     return (getSize() + AllocatorValueSize - 1) / AllocatorValueSize;
   }
 
-  template <typename propertyT> __SYCL_DLL_LOCAL bool has_property() const {
+  template <typename propertyT>
+  __SYCL_DLL_LOCAL bool has_property() const noexcept {
     return MProps.has_property<propertyT>();
   }
 

--- a/sycl/include/CL/sycl/image.hpp
+++ b/sycl/include/CL/sycl/image.hpp
@@ -250,7 +250,7 @@ public:
   bool operator!=(const image &rhs) const { return !(*this == rhs); }
 
   /* -- property interface members -- */
-  template <typename propertyT> bool has_property() const {
+  template <typename propertyT> bool has_property() const noexcept {
     return impl->template has_property<propertyT>();
   }
 

--- a/sycl/include/CL/sycl/program.hpp
+++ b/sycl/include/CL/sycl/program.hpp
@@ -123,7 +123,7 @@ public:
   /// Checks if this program has a property of type propertyT.
   ///
   /// \return true if this context has a property of type propertyT.
-  template <typename propertyT> bool has_property() const;
+  template <typename propertyT> bool has_property() const noexcept;
 
   /// Gets the specified property of this program.
   ///

--- a/sycl/include/CL/sycl/property_list.hpp
+++ b/sycl/include/CL/sycl/property_list.hpp
@@ -48,7 +48,7 @@ public:
     return get_property_helper<PropT>();
   }
 
-  template <typename PropT> bool has_property() const {
+  template <typename PropT> bool has_property() const noexcept {
     return has_property_helper<PropT>();
   }
 

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -422,7 +422,7 @@ public:
 
   /// \return true if the queue was constructed with property specified by
   /// PropertyT.
-  template <typename PropertyT> bool has_property() const;
+  template <typename PropertyT> bool has_property() const noexcept;
 
   /// \return a copy of the property of type PropertyT that the queue was
   /// constructed with. If the queue was not constructed with the PropertyT

--- a/sycl/include/CL/sycl/sampler.hpp
+++ b/sycl/include/CL/sycl/sampler.hpp
@@ -87,7 +87,7 @@ public:
   /// Checks if this sampler has a property of type propertyT.
   ///
   /// \return true if this sampler has a property of type propertyT.
-  template <typename propertyT> bool has_property() const;
+  template <typename propertyT> bool has_property() const noexcept;
 
   /// Gets the specified property of this sampler.
   ///

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -98,7 +98,8 @@ context::context(cl_context ClContext, async_handler AsyncHandler) {
 #undef __SYCL_PARAM_TRAITS_SPEC
 
 #define __SYCL_PARAM_TRAITS_SPEC(param_type)                                   \
-  template <> __SYCL_EXPORT bool context::has_property<param_type>() const {   \
+  template <>                                                                  \
+  __SYCL_EXPORT bool context::has_property<param_type>() const noexcept {      \
     return impl->has_property<param_type>();                                   \
   }
 #include <CL/sycl/detail/properties_traits.def>

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -74,7 +74,7 @@ public:
   /// Checks if this context_impl has a property of type propertyT.
   ///
   /// \return true if this context_impl has a property of type propertyT.
-  template <typename propertyT> bool has_property() const {
+  template <typename propertyT> bool has_property() const noexcept {
     return MPropList.has_property<propertyT>();
   }
 

--- a/sycl/source/detail/program_impl.hpp
+++ b/sycl/source/detail/program_impl.hpp
@@ -105,7 +105,7 @@ public:
   /// Checks if this program_impl has a property of type propertyT.
   ///
   /// \return true if this program_impl has a property of type propertyT.
-  template <typename propertyT> bool has_property() const {
+  template <typename propertyT> bool has_property() const noexcept {
     return MPropList.has_property<propertyT>();
   }
 

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -341,7 +341,7 @@ public:
 
   /// \return true if the queue was constructed with property specified by
   /// PropertyT.
-  template <typename propertyT> bool has_property() const {
+  template <typename propertyT> bool has_property() const noexcept {
     return MPropList.has_property<propertyT>();
   }
 

--- a/sycl/source/detail/sampler_impl.hpp
+++ b/sycl/source/detail/sampler_impl.hpp
@@ -42,7 +42,7 @@ public:
   /// Checks if this sampler_impl has a property of type propertyT.
   ///
   /// \return true if this sampler_impl has a property of type propertyT.
-  template <typename propertyT> bool has_property() const {
+  template <typename propertyT> bool has_property() const noexcept {
     return MPropList.has_property<propertyT>();
   }
 

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -115,7 +115,8 @@ program::get_info() const {
 #undef __SYCL_PARAM_TRAITS_SPEC
 
 #define __SYCL_PARAM_TRAITS_SPEC(param_type)                                   \
-  template <> __SYCL_EXPORT bool program::has_property<param_type>() const {   \
+  template <>                                                                  \
+  __SYCL_EXPORT bool program::has_property<param_type>() const noexcept {      \
     return impl->has_property<param_type>();                                   \
   }
 #include <CL/sycl/detail/properties_traits.def>

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -167,7 +167,7 @@ queue::get_info() const {
 
 #undef __SYCL_PARAM_TRAITS_SPEC
 
-template <typename PropertyT> bool queue::has_property() const {
+template <typename PropertyT> bool queue::has_property() const noexcept {
   return impl->has_property<PropertyT>();
 }
 
@@ -176,7 +176,7 @@ template <typename PropertyT> PropertyT queue::get_property() const {
 }
 
 template __SYCL_EXPORT bool
-queue::has_property<property::queue::enable_profiling>() const;
+queue::has_property<property::queue::enable_profiling>() const noexcept;
 template __SYCL_EXPORT property::queue::enable_profiling
 queue::get_property<property::queue::enable_profiling>() const;
 

--- a/sycl/source/sampler.cpp
+++ b/sycl/source/sampler.cpp
@@ -44,7 +44,8 @@ bool sampler::operator!=(const sampler &rhs) const {
 }
 
 #define __SYCL_PARAM_TRAITS_SPEC(param_type)                                   \
-  template <> __SYCL_EXPORT bool sampler::has_property<param_type>() const {   \
+  template <>                                                                  \
+  __SYCL_EXPORT bool sampler::has_property<param_type>() const noexcept {      \
     return impl->has_property<param_type>();                                   \
   }
 #include <CL/sycl/detail/properties_traits.def>


### PR DESCRIPTION
SYCL 2020 adds noexcept to has_property on SYCL objects that take property_list arguments. This changes adjust the existing implementation accordingly.