### PR TITLE
[NFC][SYCL] Update testing dependencies for append-file

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -111,6 +111,7 @@ if( NOT CLANG_BUILT_STANDALONE )
   list(APPEND CLANG_TEST_DEPS
     llvm-config
     FileCheck count not
+    append-file
     llc
     llvm-ar
     llvm-as

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -53,6 +53,7 @@ set(LLVM_TEST_DEPENDS
           FileCheck
           LLVMHello
           UnitTests
+          append-file
           bugpoint
           count
           file-table-tform


### PR DESCRIPTION
Certain tests are dependent on the append-file tool for a successful run.
Add the dependencies so the binary is available when needed.