### PR TITLE
[Driver][SYCL] Do not emit IR when using -fsyntax-only

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4145,6 +4145,8 @@ class OffloadingActionBuilder final {
               continue;
             }
           }
+          if (Args.hasArg(options::OPT_fsyntax_only))
+            OutputType = types::TY_Nothing;
           A = C.MakeAction<CompileJobAction>(A, OutputType);
           DeviceCompilerInput = A;
         }

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -1103,3 +1103,9 @@
 // RUN:   %clang -### -fsycl -ffreestanding %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INCOMPATIBILITY %s
 // CHK-INCOMPATIBILITY: error: The option -fsycl conflicts with -ffreestanding
+
+/// Using -fsyntax-only with -fsycl should not emit IR
+// RUN:   %clang -### -fsycl -fsyntax-only %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=CHK-FSYNTAX-ONLY,CHK-NO-EMIT-IR %s
+// CHK-FSYNTAX-ONLY: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"{{.*}} "-fsyntax-only"
+// CHK-NO-EMIT-IR-NOT: "-emit-llvm-bc"


### PR DESCRIPTION
When using -fsyntax-only with -fsycl, IR should not be emitted.

Signed-off-by: Qichao Gu <qichao.gu@intel.com>