### PR TITLE
[SYCL] Make sure that bound arch is set when using preprocessor

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4122,7 +4122,11 @@ class OffloadingActionBuilder final {
             // header.
             Action *CompileAction =
                 C.MakeAction<CompileJobAction>(A, types::TY_Nothing);
-            DA.add(*CompileAction, *ToolChains.front(), nullptr,
+            // Make sure that bound arch is also passed, as it might be
+            // required, for example in: CudaToolChain::addClangTargetOptions.
+            assert(!SYCLTargetInfoList.empty() && "Expected target info.");
+            const auto *BoundArch = SYCLTargetInfoList.back().BoundArch;
+            DA.add(*CompileAction, *ToolChains.front(), BoundArch,
                    Action::OFK_SYCL);
           }
           return SYCLDeviceOnly ? ABRT_Ignore_Host : ABRT_Success;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4113,7 +4113,10 @@ class OffloadingActionBuilder final {
             Args.getLastArg(options::OPT__SLASH_EP, options::OPT__SLASH_P) ||
             Args.getLastArg(options::OPT_M, options::OPT_MM);
         if (IsPreprocessOnly) {
-          for (Action *&A : SYCLDeviceActions) {
+          for (auto TargetActionInfo :
+               llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
+            Action *&A = std::get<0>(TargetActionInfo);
+            auto &TargetInfo = std::get<1>(TargetActionInfo);
             A = C.getDriver().ConstructPhaseAction(C, Args, CurPhase, A,
                                                    AssociatedOffloadKind);
             if (SYCLDeviceOnly)
@@ -4122,11 +4125,7 @@ class OffloadingActionBuilder final {
             // header.
             Action *CompileAction =
                 C.MakeAction<CompileJobAction>(A, types::TY_Nothing);
-            // If the bound arch is provided make sure to propagate it.
-            const char *BoundArch = !SYCLTargetInfoList.empty()
-                                        ? SYCLTargetInfoList.back().BoundArch
-                                        : nullptr;
-            DA.add(*CompileAction, *ToolChains.front(), BoundArch,
+            DA.add(*CompileAction, *TargetInfo.TC, TargetInfo.BoundArch,
                    Action::OFK_SYCL);
           }
           return SYCLDeviceOnly ? ABRT_Ignore_Host : ABRT_Success;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4122,10 +4122,10 @@ class OffloadingActionBuilder final {
             // header.
             Action *CompileAction =
                 C.MakeAction<CompileJobAction>(A, types::TY_Nothing);
-            // Make sure that bound arch is also passed, as it might be
-            // required, for example in: CudaToolChain::addClangTargetOptions.
-            assert(!SYCLTargetInfoList.empty() && "Expected target info.");
-            const auto *BoundArch = SYCLTargetInfoList.back().BoundArch;
+            // If the bound arch is provided make sure to propagate it.
+            const char *BoundArch = !SYCLTargetInfoList.empty()
+                                        ? SYCLTargetInfoList.back().BoundArch
+                                        : nullptr;
             DA.add(*CompileAction, *ToolChains.front(), BoundArch,
                    Action::OFK_SYCL);
           }

--- a/clang/test/Driver/sycl-offload-nvptx.cpp
+++ b/clang/test/Driver/sycl-offload-nvptx.cpp
@@ -72,3 +72,10 @@ N.)
 // CHK-PHASES: 18: file-table-tform, {12, 17}, tempfiletable, (device-sycl, sm_35)
 // CHK-PHASES: 19: clang-offload-wrapper, {18}, object, (device-sycl, sm_35)
 // CHK-PHASES: 20: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (nvptx64-nvidia-cuda:sm_35)" {19}, image
+
+/// Check calling preprocessor only
+// RUN: %clangxx -E -fsycl -fsycl-targets=nvptx64-nvidia-cuda -ccc-print-phases %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-PREPROC %s
+// CHK-PREPROC: 1: preprocessor, {0}, c++-cpp-output, (device-sycl, sm_[[CUDA_VERSION:[0-9.]+]])
+// CHK-PREPROC: 2: offload, "device-sycl (nvptx64-nvidia-cuda:sm_[[CUDA_VERSION]])" {1}, c++-cpp-output
+// CHK-PREPROC: 4: compiler, {1}, none, (device-sycl, sm_[[CUDA_VERSION]])


### PR DESCRIPTION
With this patch the bound arch is correctly propagated through the phases:

```
      +- 0: input, "./../tickets/dashE/woof.cpp", c++, (device-sycl, sm_50)
   +- 1: preprocessor, {0}, c++-cpp-output, (device-sycl, sm_50)
+- 2: offload, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {1}, c++-cpp-output
|        +- 3: input, "./../tickets/dashE/woof.cpp", c++, (host-sycl)
|        |- 4: compiler, {1}, none, (device-sycl, sm_50)
|     +- 5: offload, "host-sycl (x86_64-unknown-linux-gnu)" {3}, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {4}, c++
|  +- 6: append-footer, {5}, c++, (host-sycl)
|- 7: preprocessor, {6}, c++-cpp-output, (host-sycl)
8: clang-offload-bundler, {2, 7}, c++-cpp-output, (host-sycl)
```

Previously the `compiler` phase (`4`) was lacking the bound arch, which is the root cause of https://github.com/intel/llvm/issues/4758:

```
 |- 4: compiler, {1}, none, (device-sycl)
```

Resolves: https://github.com/intel/llvm/issues/4758

Previous discussion in: https://github.com/intel/llvm/pull/4805