### PR TITLE
[SYCL][CUDA] Set cuda_piextUSMEnqueuePrefetch to fail for windows

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4651,6 +4651,14 @@ pi_result cuda_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
                                        const pi_event *events_waitlist,
                                        pi_event *event) {
 
+// CUDA has an issue with cuMemPrefetchAsync returning cudaErrorInvalidDevice
+// for Windows machines
+// TODO: Remove when fix is found
+#ifdef _MSC_VER
+  cl::sycl::detail::pi::die(
+      "cuda_piextUSMEnqueuePrefetch does not currently work on Windows");
+#endif
+
   // flags is currently unused so fail if set
   if (flags != 0)
     return PI_INVALID_VALUE;


### PR DESCRIPTION
`cuMemPrefetchAsync` currently has issues on Windows machines, this appears to be a problem with CUDA and not the plugins usage of the function.
I think `cuda_piextUSMEnqueuePrefetch` which uses `cuMemPrefetchAsync` should be set to fail for windows and send a message to the user that this functionality is not available on windows devices.

More details: https://github.com/intel/llvm/issues/4809