### PR TITLE
[SYCL] Check if the underlying buffer type is device copyable

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -14,6 +14,7 @@
 #include <CL/sycl/exception.hpp>
 #include <CL/sycl/property_list.hpp>
 #include <CL/sycl/stl.hpp>
+#include <CL/sycl/types.hpp>
 #include <sycl/ext/oneapi/accessor_property_list.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
@@ -44,6 +45,10 @@ template <typename T, int dimensions = 1,
           typename __Enabled = typename detail::enable_if_t<(dimensions > 0) &&
                                                             (dimensions <= 3)>>
 class buffer {
+  static_assert(
+      is_device_copyable<T>::value,
+      "The underlying data type of a buffer 'T' must be device copyable");
+
 public:
   using value_type = T;
   using reference = value_type &;

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -2420,13 +2420,11 @@ struct is_device_copyable<sycl::marray<T, N>,
                           std::enable_if_t<is_device_copyable<T>::value>>
     : std::true_type {};
 
-// vec is device copyable on host if element type is device copyable,
-// on device vec is trivially copyable and therefore is device copyable too.
+// vec is device copyable on host, on device vec is trivially copyable
+// and therefore is device copyable too.
 #ifndef __SYCL_DEVICE_ONLY__
 template <typename T, int N>
-struct is_device_copyable<sycl::vec<T, N>,
-                          std::enable_if_t<is_device_copyable<T>::value>>
-    : std::true_type {};
+struct is_device_copyable<sycl::vec<T, N>> : std::true_type {};
 #endif
 
 namespace detail {

--- a/sycl/include/CL/sycl/types.hpp
+++ b/sycl/include/CL/sycl/types.hpp
@@ -2420,6 +2420,15 @@ struct is_device_copyable<sycl::marray<T, N>,
                           std::enable_if_t<is_device_copyable<T>::value>>
     : std::true_type {};
 
+// vec is device copyable on host if element type is device copyable,
+// on device vec is trivially copyable and therefore is device copyable too.
+#ifndef __SYCL_DEVICE_ONLY__
+template <typename T, int N>
+struct is_device_copyable<sycl::vec<T, N>,
+                          std::enable_if_t<is_device_copyable<T>::value>>
+    : std::true_type {};
+#endif
+
 namespace detail {
 template <typename T, typename = void>
 struct IsDeprecatedDeviceCopyable : std::false_type {};

--- a/sycl/test/basic_tests/buffer/buffer_for_not_device_copyable.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_for_not_device_copyable.cpp
@@ -3,7 +3,7 @@
 #include <sycl/sycl.hpp>
 #include <string>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 int main() {
   static_assert(is_device_copyable_v<int>);

--- a/sycl/test/basic_tests/buffer/buffer_for_not_device_copyable.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_for_not_device_copyable.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note,warning
 
-#include <sycl/sycl.hpp>
 #include <string>
+#include <sycl/sycl.hpp>
 
 using namespace sycl;
 

--- a/sycl/test/basic_tests/buffer/buffer_for_not_device_copyable.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_for_not_device_copyable.cpp
@@ -6,11 +6,17 @@
 using namespace cl::sycl;
 
 int main() {
+  static_assert(is_device_copyable_v<int>);
   std::vector<int> iv(5, 1);
   buffer b1(iv.data(), range<1>(5));
 
-  static_assert(!sycl::is_device_copyable_v<std::string>);
+  static_assert(!is_device_copyable_v<std::string>);
   std::vector<std::string> sv{"hello", "sycl", "world"};
   buffer b2(sv.data(), range<1>(3));
   //expected-error@CL/sycl/buffer.hpp:* {{"The underlying data type of a buffer 'T' must be device copyable"}}
+
+  static_assert(is_device_copyable<sycl::vec<int, 4>>::value);
+  vec<int, 4> iVec;
+  buffer b3(&iVec, range<1>(1));
+  return 0;
 }

--- a/sycl/test/basic_tests/buffer/buffer_for_not_device_copyable.cpp
+++ b/sycl/test/basic_tests/buffer/buffer_for_not_device_copyable.cpp
@@ -1,0 +1,16 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note,warning
+
+#include <sycl/sycl.hpp>
+#include <string>
+
+using namespace cl::sycl;
+
+int main() {
+  std::vector<int> iv(5, 1);
+  buffer b1(iv.data(), range<1>(5));
+
+  static_assert(!sycl::is_device_copyable_v<std::string>);
+  std::vector<std::string> sv{"hello", "sycl", "world"};
+  buffer b2(sv.data(), range<1>(3));
+  //expected-error@CL/sycl/buffer.hpp:* {{"The underlying data type of a buffer 'T' must be device copyable"}}
+}


### PR DESCRIPTION
The implementation should diagnose an error if the underlying type "T"
of a buffer is not device copyable. The spec says that this is
a requirement for all buffers. It does not make any exception for
buffers that are used only on the host:

"The underlying data type of a buffer T must be device copyable as
defined in Section 3.13.1."

(https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:buffers)