### PR TITLE
[SYCL] Generate and install stripped PDBs for SYCL libraries

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -11,6 +11,7 @@ option(SYCL_ADD_DEV_VERSION_POSTFIX "Adds -V postfix to version string" ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(AddSYCLExecutable)
+include(SYCLUtils)
 
 set(SYCL_MAJOR_VERSION 5)
 set(SYCL_MINOR_VERSION 4)
@@ -48,6 +49,9 @@ if(MSVC)
   # Skip asynchronous C++ exceptions catching and assume "extern C" functions
   # never throw C++ exceptions.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+  # Add PDB debug information
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
+  add_link_options("/DEBUG")
 endif()
 
 # Get clang's version

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -49,9 +49,15 @@ if(MSVC)
   # Skip asynchronous C++ exceptions catching and assume "extern C" functions
   # never throw C++ exceptions.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+
   # Add PDB debug information
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
-  add_link_options("/DEBUG")
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  include(LLVMCheckLinkerFlag)
+  llvm_check_linker_flag(CXX "/DEBUG" LINKER_SUPPORTS_DEBUG)
+  if(LINKER_SUPPORTS_DEBUG)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
+    add_link_options("/DEBUG")
+  endif()
 endif()
 
 # Get clang's version

--- a/sycl/cmake/modules/SYCLUtils.cmake
+++ b/sycl/cmake/modules/SYCLUtils.cmake
@@ -1,0 +1,13 @@
+# add_stripped_pdb(TARGET_NAME)
+#
+# Will add option for generating stripped PDB file and install the generated
+# file as ${ARG_TARGET_NAME}.pdb in bin folder.
+# NOTE: LLD does not currently support /PDBSTRIPPED so the PDB file is optional.
+macro(add_stripped_pdb ARG_TARGET_NAME)
+  target_link_options(${ARG_TARGET_NAME} PRIVATE "/PDBSTRIPPED:${ARG_TARGET_NAME}.stripped.pdb")
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TARGET_NAME}.stripped.pdb"
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+          RENAME "${ARG_TARGET_NAME}.pdb"
+          COMPONENT ${ARG_TARGET_NAME}
+          OPTIONAL)
+endmacro()

--- a/sycl/cmake/modules/SYCLUtils.cmake
+++ b/sycl/cmake/modules/SYCLUtils.cmake
@@ -1,13 +1,21 @@
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+include(LLVMCheckLinkerFlag)
+
 # add_stripped_pdb(TARGET_NAME)
 #
 # Will add option for generating stripped PDB file and install the generated
 # file as ${ARG_TARGET_NAME}.pdb in bin folder.
 # NOTE: LLD does not currently support /PDBSTRIPPED so the PDB file is optional.
 macro(add_stripped_pdb ARG_TARGET_NAME)
-  target_link_options(${ARG_TARGET_NAME} PRIVATE "/PDBSTRIPPED:${ARG_TARGET_NAME}.stripped.pdb")
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TARGET_NAME}.stripped.pdb"
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
-          RENAME "${ARG_TARGET_NAME}.pdb"
-          COMPONENT ${ARG_TARGET_NAME}
-          OPTIONAL)
+  llvm_check_linker_flag(CXX "/PDBSTRIPPED:${ARG_TARGET_NAME}.stripped.pdb"
+                         LINKER_SUPPORTS_PDBSTRIPPED)
+  if(LINKER_SUPPORTS_PDBSTRIPPED)
+    target_link_options(${ARG_TARGET_NAME}
+                        PRIVATE "/PDBSTRIPPED:${ARG_TARGET_NAME}.stripped.pdb")
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TARGET_NAME}.stripped.pdb"
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+            RENAME "${ARG_TARGET_NAME}.pdb"
+            COMPONENT ${ARG_TARGET_NAME}
+            OPTIONAL)
+  endif()
 endmacro()

--- a/sycl/plugins/cuda/CMakeLists.txt
+++ b/sycl/plugins/cuda/CMakeLists.txt
@@ -49,6 +49,8 @@ if (MSVC)
   # by defining __SYCL_BUILD_SYCL_DLL, we can use __declspec(dllexport)
   # which are individually tagged for all pi* symbols in pi.h
   target_compile_definitions(pi_cuda PRIVATE __SYCL_BUILD_SYCL_DLL)
+  # Install stripped PDB
+  add_stripped_pdb(pi_cuda)
 else()
   # we set the visibility of all symbols 'hidden' by default.
   # In pi.h file, we set exported symbols with visibility==default individually

--- a/sycl/plugins/esimd_emulator/CMakeLists.txt
+++ b/sycl/plugins/esimd_emulator/CMakeLists.txt
@@ -105,6 +105,8 @@ if (MSVC)
   # by defining __SYCL_BUILD_SYCL_DLL, we can use __declspec(dllexport)
   # which are individually tagged for all pi* symbols in pi.h
   target_compile_definitions(pi_esimd_emulator PRIVATE __SYCL_BUILD_SYCL_DLL)
+  # Install stripped PDB
+  add_stripped_pdb(pi_esimd_emulator)
 else()
   # we set the visibility of all symbols 'hidden' by default.
   # In pi.h file, we set exported symbols with visibility==default individually

--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -114,6 +114,8 @@ if (MSVC)
   # by defining __SYCL_BUILD_SYCL_DLL, we can use __declspec(dllexport)
   # which are individually tagged for all pi* symbols in pi.h
   target_compile_definitions(pi_level_zero PRIVATE __SYCL_BUILD_SYCL_DLL)
+  # Install stripped PDB
+  add_stripped_pdb(pi_level_zero)
 else()
   # we set the visibility of all symbols 'hidden' by default.
   # In pi.h file, we set exported symbols with visibility==default individually

--- a/sycl/plugins/opencl/CMakeLists.txt
+++ b/sycl/plugins/opencl/CMakeLists.txt
@@ -32,6 +32,8 @@ if (MSVC)
   # by defining __SYCL_BUILD_SYCL_DLL, we can use __declspec(dllexport)
   # which are individually tagged for all pi* symbols in pi.h
   target_compile_definitions(pi_opencl PRIVATE __SYCL_BUILD_SYCL_DLL)
+  # Install stripped PDB
+  add_stripped_pdb(pi_opencl)
 else()
   # we set the visibility of all symbols 'hidden' by default.
   # In pi.h file, we set exported symbols with visibility==default individually

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -48,6 +48,8 @@ function(add_sycl_rt_library LIB_NAME)
   if (MSVC)
     target_compile_definitions(${LIB_OBJ_NAME} PRIVATE __SYCL_BUILD_SYCL_DLL )
     target_link_libraries(${LIB_NAME} PRIVATE shlwapi)
+    # Install stripped PDB
+    add_stripped_pdb(${LIB_NAME})
   else()
     target_compile_options(${LIB_OBJ_NAME} PUBLIC
                            -fvisibility=hidden -fvisibility-inlines-hidden)


### PR DESCRIPTION
Adds stripped PDB files for SYCL library and the PI plugins when building with MSVC. Full PDB files will also be generated, but only the stripped variants will be installed.

The stripped PDB files will only be generated and installed if the used linker supports the /PDBSTRIPPED option. LLD does not currently support this option. If the stripped PDB is not generated, no PDB files are installed for the SYCL libraries and PI plugins.