### PR TITLE
[SYCL][libdevice] Get rid of builtins for memcpy memset in libdevice

### DIFF
--- a/libdevice/fallback-cstring.cpp
+++ b/libdevice/fallback-cstring.cpp
@@ -10,14 +10,121 @@
 #include <cstdint>
 
 #ifdef __SPIR__
+
+static void *__devicelib_memcpy_uint8_aligned(void *dest, const void *src,
+                                              size_t n) {
+  if (dest == NULL || src == NULL || n == 0)
+    return dest;
+
+  uint8_t *dest_uint8 = reinterpret_cast<uint8_t *>(dest);
+  const uint8_t *src_uint8 = reinterpret_cast<const uint8_t *>(src);
+  for (size_t idx = 0; idx < n; ++idx) {
+    dest_uint8[idx] = src_uint8[idx];
+  }
+
+  return dest;
+}
+
+static void *__devicelib_memcpy_uint32_aligned(void *dest, const void *src,
+                                               size_t n) {
+  if (dest == NULL || src == NULL || n == 0)
+    return dest;
+
+  uint32_t *dest_addr = reinterpret_cast<uint32_t *>(dest);
+  const uint32_t *src_addr = reinterpret_cast<const uint32_t *>(src);
+  while (n >= sizeof(uint32_t)) {
+    *dest_addr++ = *src_addr++;
+    n -= sizeof(uint32_t);
+  }
+
+  __devicelib_memcpy_uint8_aligned(dest_addr, src_addr, n);
+  return dest;
+}
+
 DEVICE_EXTERN_C
 void *__devicelib_memcpy(void *dest, const void *src, size_t n) {
-  return __builtin_memcpy(dest, src, n);
+  if (dest == NULL || src == NULL || n == 0)
+    return dest;
+
+  unsigned long dest_addr = reinterpret_cast<unsigned long>(dest);
+  unsigned long src_addr = reinterpret_cast<unsigned long>(src);
+  size_t dest_uint32_mod = dest_addr % alignof(uint32_t);
+  size_t src_uint32_mod = src_addr % alignof(uint32_t);
+
+  if (dest_uint32_mod != src_uint32_mod)
+    return __devicelib_memcpy_uint8_aligned(dest, src, n);
+
+  if (dest_uint32_mod == 0)
+    return __devicelib_memcpy_uint32_aligned(dest, src, n);
+
+  size_t head_ua_len = sizeof(uint32_t) - dest_uint32_mod;
+  if (head_ua_len >= n)
+    return __devicelib_memcpy_uint8_aligned(dest, src, n);
+  else {
+    __devicelib_memcpy_uint8_aligned(dest, src, head_ua_len);
+    void *dest_aligned_addr = reinterpret_cast<void *>(dest_addr + head_ua_len);
+    const void *src_aligned_addr =
+        reinterpret_cast<const void *>(src_addr + head_ua_len);
+    n -= head_ua_len;
+    __devicelib_memcpy_uint32_aligned(dest_aligned_addr, src_aligned_addr, n);
+  }
+
+  return dest;
+}
+
+static void *__devicelib_memset_uint8_aligned(void *dest, int c, size_t n) {
+  if (dest == NULL || n == 0)
+    return dest;
+
+  char *dest_addr = reinterpret_cast<char *>(dest);
+  while (n > 0) {
+    *dest_addr++ = c;
+    --n;
+  }
+  return dest;
+}
+
+static void *__devicelib_memset_uint32_aligned(void *dest, int c, size_t n) {
+  if (dest == NULL || n == 0)
+    return dest;
+
+  uint32_t *dest_addr = reinterpret_cast<uint32_t *>(dest);
+  uint8_t temp = static_cast<uint8_t>(c);
+  uint32_t memset_udw = 0;
+  uint8_t *memset_udw_ptr = reinterpret_cast<uint8_t *>(&memset_udw);
+  for (size_t idx = 0; idx < 4; ++idx)
+    memset_udw_ptr[idx] = temp;
+
+  while (n >= sizeof(uint32_t)) {
+    *dest_addr++ = memset_udw;
+    n -= sizeof(uint32_t);
+  }
+
+  __devicelib_memset_uint8_aligned(dest_addr, c, n);
+  return dest;
 }
 
 DEVICE_EXTERN_C
 void *__devicelib_memset(void *dest, int c, size_t n) {
-  return __builtin_memset(dest, c, n);
+  if (dest == NULL || n == 0)
+    return dest;
+
+  unsigned long memset_dest_addr = reinterpret_cast<unsigned long>(dest);
+  size_t dest_uint32_mod = memset_dest_addr % alignof(uint32_t);
+  if (dest_uint32_mod != 0) {
+    size_t head_ua_len = sizeof(uint32_t) - dest_uint32_mod;
+    if (head_ua_len >= n)
+      return __devicelib_memset_uint8_aligned(dest, c, n);
+    else {
+      __devicelib_memset_uint8_aligned(dest, c, head_ua_len);
+      n -= head_ua_len;
+      memset_dest_addr += head_ua_len;
+    }
+  }
+
+  __devicelib_memset_uint32_aligned(reinterpret_cast<void *>(memset_dest_addr),
+                                    c, n);
+  return dest;
 }
 
 static int __devicelib_memcmp_uint8_aligned(const void *s1, const void *s2,
@@ -26,9 +133,9 @@ static int __devicelib_memcmp_uint8_aligned(const void *s1, const void *s2,
   const uint8_t *s2_uint8_ptr = reinterpret_cast<const uint8_t *>(s2);
   while (n > 0) {
     if (*s1_uint8_ptr == *s2_uint8_ptr) {
-      s1_uint8_ptr++;
-      s2_uint8_ptr++;
-      n--;
+      ++s1_uint8_ptr;
+      ++s2_uint8_ptr;
+      --n;
     } else {
       return *s1_uint8_ptr - *s2_uint8_ptr;
     }
@@ -74,6 +181,8 @@ int __devicelib_memcmp(const void *s1, const void *s2, size_t n) {
     return __devicelib_memcmp_uint32_aligned(s1, s2, n);
 
   size_t head_ua_len = sizeof(uint32_t) - s1_uint32_mod;
+  if (head_ua_len >= n)
+    return __devicelib_memcmp_uint8_aligned(s1, s2, n);
   int head_cmp = __devicelib_memcmp_uint8_aligned(s1, s2, head_ua_len);
   if (head_cmp == 0) {
     const uint8_t *s1_aligned_ptr = reinterpret_cast<const uint8_t *>(s1);

--- a/libdevice/fallback-cstring.cpp
+++ b/libdevice/fallback-cstring.cpp
@@ -18,9 +18,8 @@ static void *__devicelib_memcpy_uint8_aligned(void *dest, const void *src,
 
   uint8_t *dest_uint8 = reinterpret_cast<uint8_t *>(dest);
   const uint8_t *src_uint8 = reinterpret_cast<const uint8_t *>(src);
-  for (size_t idx = 0; idx < n; ++idx) {
+  for (size_t idx = 0; idx < n; ++idx)
     dest_uint8[idx] = src_uint8[idx];
-  }
 
   return dest;
 }
@@ -37,6 +36,7 @@ static void *__devicelib_memcpy_uint32_aligned(void *dest, const void *src,
   size_t idx;
   for (idx = 0; idx < copy_num; ++idx)
     dest_addr[idx] = src_addr[idx];
+
   __devicelib_memcpy_uint8_aligned(&dest_addr[idx], &src_addr[idx],
                                    tailing_bytes);
   return dest;
@@ -61,14 +61,13 @@ void *__devicelib_memcpy(void *dest, const void *src, size_t n) {
   size_t head_ua_len = sizeof(uint32_t) - dest_uint32_mod;
   if (head_ua_len >= n)
     return __devicelib_memcpy_uint8_aligned(dest, src, n);
-  else {
-    __devicelib_memcpy_uint8_aligned(dest, src, head_ua_len);
-    void *dest_aligned_addr = reinterpret_cast<void *>(dest_addr + head_ua_len);
-    const void *src_aligned_addr =
-        reinterpret_cast<const void *>(src_addr + head_ua_len);
-    n -= head_ua_len;
-    __devicelib_memcpy_uint32_aligned(dest_aligned_addr, src_aligned_addr, n);
-  }
+
+  __devicelib_memcpy_uint8_aligned(dest, src, head_ua_len);
+  void *dest_aligned_addr = reinterpret_cast<void *>(dest_addr + head_ua_len);
+  const void *src_aligned_addr =
+      reinterpret_cast<const void *>(src_addr + head_ua_len);
+  n -= head_ua_len;
+  __devicelib_memcpy_uint32_aligned(dest_aligned_addr, src_aligned_addr, n);
 
   return dest;
 }
@@ -78,9 +77,8 @@ static void *__devicelib_memset_uint8_aligned(void *dest, int c, size_t n) {
     return dest;
 
   uint8_t *dest_addr = reinterpret_cast<uint8_t *>(dest);
-  for (size_t idx = 0; idx < n; ++idx) {
+  for (size_t idx = 0; idx < n; ++idx)
     dest_addr[idx] = static_cast<uint8_t>(c);
-  }
 
   return dest;
 }
@@ -138,9 +136,7 @@ static int __devicelib_memcmp_uint8_aligned(const void *s1, const void *s2,
   const uint8_t *s2_uint8_ptr = reinterpret_cast<const uint8_t *>(s2);
 
   for (size_t idx = 0; idx < n; ++idx) {
-    if (s1_uint8_ptr[idx] == s2_uint8_ptr[idx])
-      continue;
-    else
+    if (s1_uint8_ptr[idx] != s2_uint8_ptr[idx])
       return s1_uint8_ptr[idx] - s2_uint8_ptr[idx];
   }
 
@@ -172,9 +168,9 @@ static int __devicelib_memcmp_uint32_aligned(const void *s1, const void *s2,
 
   if (tailing_bytes == 0)
     return 0;
-  else
-    return __devicelib_memcmp_uint8_aligned(
-        &s1_uint32_ptr[cmp_num], &s2_uint32_ptr[cmp_num], tailing_bytes);
+
+  return __devicelib_memcmp_uint8_aligned(
+      &s1_uint32_ptr[cmp_num], &s2_uint32_ptr[cmp_num], tailing_bytes);
 }
 
 DEVICE_EXTERN_C


### PR DESCRIPTION
Previously, memcpy and memset are implemented in libdevice by calling
to __builtin_memcpy and __builtin_memset. Such code will lead to
infinite loop if underying CPU runtime implements memcpy/set builtin by
calling memcpy, memset. The function call chain is following:
In libdevice:
memcpy(dest, src, n) {
  return __devicelib_memcpy(dest, src, n);
}

__devicelib_memcpy(dest, src, n) {
  return __builtin_memcpy(dest, src, n);
}

In CPU runtime:
Handing of __builtin_memcpy<-------------------|
                  |				                         |
		  |				                         |
		  |---->memcpy------>__devicelib_memcpy
In order to fix this, we have to provide implementation for memcpy/set
without using __builtin_*.