### PR TITLE
[Driver][SYCL] Do not enable exception handling for device

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -437,6 +437,10 @@ static bool addExceptionArgs(const ArgList &Args, types::ID InputType,
     return false;
   }
 
+  if (Triple.isSPIR())
+    // spir targets do not support exception handling.
+    return false;
+
   // See if the user explicitly enabled exceptions.
   bool EH = Args.hasFlag(options::OPT_fexceptions, options::OPT_fno_exceptions,
                          false);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7825,7 +7825,7 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
 
   const Driver &D = getToolChain().getDriver();
   EHFlags EH = parseClangCLEHFlags(D, Args);
-  if (!isNVPTX && (EH.Synch || EH.Asynch)) {
+  if (!isNVPTX && !isSPIR && (EH.Synch || EH.Asynch)) {
     if (types::isCXX(InputType))
       CmdArgs.push_back("-fcxx-exceptions");
     CmdArgs.push_back("-fexceptions");

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -132,3 +132,9 @@
 // RUN:  %clangxx -### -Wl,-rpath,%S -fsycl -fintelfpga %t_empty.o %s 2>&1 \
 // RUN:    | FileCheck -check-prefix NO_DIR_CHECK %s
 // NO_DIR_CHECK-NOT: clang-offload-bundler: error: '{{.*}}': Is a directory
+
+/// Check that exception handline is disabled for device for Windows
+// RUN: %clang_cl -### -fsycl -EHsc -c %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHECK_EXCEPTIONS %s
+// CHECK_EXCEPTIONS-NOT: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}} "-fcxx-exceptions" "-fexceptions"
+// CHECK_EXCEPTIONS: clang{{.*}} "-fsycl-is-host"{{.*}} "-fcxx-exceptions" "-fexceptions"

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -128,5 +128,13 @@
 // RUN: %clang -### -fsycl  %s 2>&1 | FileCheck %s --check-prefix=DEFAULT_STD
 // RUN: %clangxx -### -fsycl %s 2>&1 | FileCheck %s --check-prefix=DEFAULT_STD
 // RUN: %clang_cl -### -fsycl -- %s 2>&1 | FileCheck %s --check-prefix=DEFAULT_STD
-
 // DEFAULT_STD: "-sycl-std=2020"
+
+// spir targets should not imply exception handling, also we should not enable
+// if passed on the command line.
+// RUN: %clangxx -### -fsycl -c %s 2>&1 | FileCheck %s --check-prefixes=EXCEPTION,EXCEPTION_HOST
+// RUN: %clangxx -### -fsycl -fexceptions -c %s 2>&1 | FileCheck %s --check-prefixes=EXCEPTION,EXCEPTION_HOST
+// RUN: %clangxx -### -fsycl -fsycl-device-only -c %s 2>&1 | FileCheck %s --check-prefix=EXCEPTION
+// RUN: %clangxx -### -target spir64-unknown-unknown -c %s 2>&1 | FileCheck %s --check-prefix=EXCEPTION
+// EXCEPTION-NOT: clang{{.*}} "-fsycl-is-device"{{.*}} "-fcxx-exceptions" "-fexceptions"
+// EXCEPTION_HOST: clang{{.*}} "-fsycl-is-host"{{.*}} "-fcxx-exceptions" "-fexceptions"


### PR DESCRIPTION
When using /EHsc on Windows or -fexceptions on Linux, we were enabling exception
handling for the device compilation.  Disable this, as exception handling is not supported
for device.