### PR TITLE
[SYCL][HIP] Check total local size before kernel launch

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2536,6 +2536,11 @@ pi_result hip_piEnqueueKernelLaunch(
     }
   }
 
+  if (maxWorkGroupSize <
+      size_t(threadsPerBlock[0] * threadsPerBlock[1] * threadsPerBlock[2])) {
+    return PI_INVALID_WORK_GROUP_SIZE;
+  }
+
   int blocksPerGrid[3] = {1, 1, 1};
 
   for (size_t i = 0; i < work_dim; i++) {


### PR DESCRIPTION
This is the exact same check as in the CUDA plugin however it was missing from the HIP plugin apparently.

This fixes the llvm-test-suite test `DeprecatedFeatures/parallel_for_range.cpp` with HIP.