### PR TITLE
[SYCL][Driver] Improve `-save-temps` for SYCL mode

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5578,13 +5578,9 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
         auto *OptO = C.getArgs().getLastArg(options::OPT_o);
         OutFileDir = (OptO ? OptO->getValues()[0] : "");
         llvm::sys::path::remove_filename(OutFileDir);
+        if (!OutFileDir.empty())
+          OutFileDir.append(llvm::sys::path::get_separator());
       }
-      // If in `SaveTempsCwd` mode, or `remove_filename` returned an empty
-      // string use CWD, otherwise append separator.
-      if (OutFileDir.empty())
-        llvm::sys::path::native(OutFileDir = "./");
-      else
-        OutFileDir.append(llvm::sys::path::get_separator());
     }
     for (auto &I : Inputs) {
       std::string SrcFileName(I.second->getAsString(Args));

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5579,10 +5579,12 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
         OutFileDir = (OptO ? OptO->getValues()[0] : "");
         llvm::sys::path::remove_filename(OutFileDir);
       }
-      // If in `SaveTempsCwd`, or `remove_filename` returned an empty string
-      // use CWD.
+      // If in `SaveTempsCwd` mode, or `remove_filename` returned an empty
+      // string use CWD, otherwise append separator.
       if (OutFileDir.empty())
         llvm::sys::path::native(OutFileDir = "./");
+      else
+        OutFileDir.append(llvm::sys::path::get_separator());
     }
     for (auto &I : Inputs) {
       std::string SrcFileName(I.second->getAsString(Args));

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5592,7 +5592,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
 
       std::string TmpFileNameHeader;
       std::string TmpFileNameFooter;
-      auto StemedSrcFileName = llvm::sys::path::stem(SrcFileName).str();
+      auto StemmedSrcFileName = llvm::sys::path::stem(SrcFileName).str();
       if (IsSaveTemps) {
         TmpFileNameHeader.append(C.getDriver().GetUniquePath(
             OutFileDir.c_str() + StemedSrcFileName + "-header", "h"));

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -123,6 +123,20 @@ void SYCL::constructLLVMForeachCommand(Compilation &C, const JobAction &JA,
   if (!ParallelJobs.empty())
     ForeachArgs.push_back(C.getArgs().MakeArgString("--jobs=" + ParallelJobs));
 
+  SmallString<128> OutputDirName(
+      T->getToolChain().GetFilePath(OutputFileName.c_str()).c_str());
+  if (C.getDriver().isSaveTempsEnabled()) {
+    llvm::sys::path::remove_filename(OutputDirName);
+    // Use the current dir if the `GetFilePath` returns empty string, which is
+    // the case when the `OutputFileName` does not contain any directory
+    // information. This is necessary for `llvm-foreach`, as it would disregard
+    // the parameter otherwise.
+    if (OutputDirName.empty())
+      llvm::sys::path::native(OutputDirName = "./");
+    ForeachArgs.push_back(
+        C.getArgs().MakeArgString("--out-dir=" + OutputDirName));
+  }
+
   ForeachArgs.push_back(C.getArgs().MakeArgString("--"));
   ForeachArgs.push_back(
       C.getArgs().MakeArgString(InputCommand->getExecutable()));

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -123,14 +123,17 @@ void SYCL::constructLLVMForeachCommand(Compilation &C, const JobAction &JA,
   if (!ParallelJobs.empty())
     ForeachArgs.push_back(C.getArgs().MakeArgString("--jobs=" + ParallelJobs));
 
-  SmallString<128> OutputDirName(
-      T->getToolChain().GetFilePath(OutputFileName.c_str()).c_str());
   if (C.getDriver().isSaveTempsEnabled()) {
-    llvm::sys::path::remove_filename(OutputDirName);
-    // Use the current dir if the `GetFilePath` returns empty string, which is
-    // the case when the `OutputFileName` does not contain any directory
-    // information. This is necessary for `llvm-foreach`, as it would disregard
-    // the parameter otherwise.
+    SmallString<128> OutputDirName;
+    if (C.getDriver().isSaveTempsObj()) {
+      OutputDirName =
+          T->getToolChain().GetFilePath(OutputFileName.c_str()).c_str();
+      llvm::sys::path::remove_filename(OutputDirName);
+    }
+    // Use the current dir if the `GetFilePath` returned en empty string, which
+    // is the case when the `OutputFileName` does not contain any directory
+    // information, or if in CWD mode. This is necessary for `llvm-foreach`, as
+    // it would disregard the parameter otherwise.
     if (OutputDirName.empty())
       llvm::sys::path::native(OutputDirName = "./");
     ForeachArgs.push_back(

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -133,9 +133,11 @@ void SYCL::constructLLVMForeachCommand(Compilation &C, const JobAction &JA,
     // Use the current dir if the `GetFilePath` returned en empty string, which
     // is the case when the `OutputFileName` does not contain any directory
     // information, or if in CWD mode. This is necessary for `llvm-foreach`, as
-    // it would disregard the parameter otherwise.
+    // it would disregard the parameter without it. Otherwise append separator.
     if (OutputDirName.empty())
       llvm::sys::path::native(OutputDirName = "./");
+    else
+      OutputDirName.append(llvm::sys::path::get_separator());
     ForeachArgs.push_back(
         C.getArgs().MakeArgString("--out-dir=" + OutputDirName));
   }

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -1148,3 +1148,7 @@
 /// Verify that -save-temps puts header/footer in a correct place
 // RUN: %clang -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-DIR
 // CHECK-SAVE-TEMPS-DIR: clang{{.*}} "-fsycl-int-header=./sycl-offload-header-{{[a-z0-9]*}}.h"{{.*}}"-fsycl-int-footer=./sycl-offload-footer-{{[a-z0-9]*}}.h"
+
+/// Verify that -save-temps=obj respects the -o dir
+// RUN: %clang -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps=obj -o /proc/self/cwd/sycl-offload %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-OBJ-DIR
+// CHECK-SAVE-TEMPS-OBJ-DIR: clang{{.*}} "-fsycl-int-header=/proc/self/cwd/sycl-offload-header-{{[a-z0-9]*}}.h"{{.*}}"-fsycl-int-footer=/proc/self/cwd/sycl-offload-footer-{{[a-z0-9]*}}.h"

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -1150,5 +1150,5 @@
 // CHECK-SAVE-TEMPS-DIR: clang{{.*}} "-fsycl-int-header=sycl-offload-header-{{[a-z0-9]*}}.h"{{.*}}"-fsycl-int-footer=sycl-offload-footer-{{[a-z0-9]*}}.h"
 
 /// Verify that -save-temps=obj respects the -o dir
-// RUN: %clang -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps=obj -o /proc/self/cwd/sycl-offload %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-OBJ-DIR
-// CHECK-SAVE-TEMPS-OBJ-DIR: clang{{.*}} "-fsycl-int-header=/proc/self/cwd/sycl-offload-header-{{[a-z0-9]*}}.h"{{.*}}"-fsycl-int-footer=/proc/self/cwd/sycl-offload-footer-{{[a-z0-9]*}}.h"
+// RUN: %clang -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps=obj -o %S %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-OBJ-DIR
+// CHECK-SAVE-TEMPS-OBJ-DIR: clang{{.*}}-fsycl-int-header={{.*[/\\]+clang[/\\]+test[/\\]+sycl-offload-header-[a-z0-9]*}}.h{{.*}}-fsycl-int-footer={{.*[/\\]+clang[/\\]+test[/\\]+sycl-offload-footer-[a-z0-9]*}}.h

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -1143,3 +1143,8 @@
 // RUN:   | FileCheck -check-prefixes=CHK-FSYNTAX-ONLY %s
 // CHK-FSYNTAX-ONLY-NOT: "-emit-llvm-bc"
 // CHK-FSYNTAX-ONLY: "-fsyntax-only"
+
+/// ###########################################################################
+/// Verify that -save-temps puts header/footer in a correct place
+// RUN: %clang -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-DIR
+// CHECK-SAVE-TEMPS-DIR: clang{{.*}} "-fsycl-int-header=./sycl-offload-header-{{[a-z0-9]*}}.h"{{.*}}"-fsycl-int-footer=./sycl-offload-footer-{{[a-z0-9]*}}.h"

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -1147,7 +1147,7 @@
 /// ###########################################################################
 /// Verify that -save-temps puts header/footer in a correct place
 // RUN: %clang -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-DIR
-// CHECK-SAVE-TEMPS-DIR: clang{{.*}} "-fsycl-int-header=./sycl-offload-header-{{[a-z0-9]*}}.h"{{.*}}"-fsycl-int-footer=./sycl-offload-footer-{{[a-z0-9]*}}.h"
+// CHECK-SAVE-TEMPS-DIR: clang{{.*}} "-fsycl-int-header=sycl-offload-header-{{[a-z0-9]*}}.h"{{.*}}"-fsycl-int-footer=sycl-offload-footer-{{[a-z0-9]*}}.h"
 
 /// Verify that -save-temps=obj respects the -o dir
 // RUN: %clang -fsycl -fno-sycl-device-lib=all -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps=obj -o /proc/self/cwd/sycl-offload %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-OBJ-DIR


### PR DESCRIPTION
Make sure that `header` and `footer` files as well as the output of `llvm-foreach` (such as  `asm` and `fatbin` for CUDA) stay in the output directory.

As discussed here: https://github.com/intel/llvm/discussions/4752

I'm unsure if that is a canonical way of getting the directory, as it relies on the output file's directory (not absolute) or the current dir.