### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1540,6 +1540,7 @@ void CodeGenFunction::GenerateCode(GlobalDecl GD, llvm::Function *Fn,
   StartFunction(GD, ResTy, Fn, FnInfo, Args, Loc, BodyRange.getBegin());
 
   SyclOptReportHandler &SyclOptReport = CGM.getDiags().getSYCLOptReport();
+  assert(Fn && "Function cannot be null");
   if (SyclOptReport.HasOptReportInfo(FD)) {
     llvm::OptimizationRemarkEmitter ORE(Fn);
     for (auto ORI : llvm::enumerate(SyclOptReport.GetInfo(FD))) {

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1540,8 +1540,7 @@ void CodeGenFunction::GenerateCode(GlobalDecl GD, llvm::Function *Fn,
   StartFunction(GD, ResTy, Fn, FnInfo, Args, Loc, BodyRange.getBegin());
 
   SyclOptReportHandler &SyclOptReport = CGM.getDiags().getSYCLOptReport();
-  assert(Fn && "Function cannot be null");
-  if (SyclOptReport.HasOptReportInfo(FD)) {
+  if (Fn && SyclOptReport.HasOptReportInfo(FD)) {
     llvm::OptimizationRemarkEmitter ORE(Fn);
     for (auto ORI : llvm::enumerate(SyclOptReport.GetInfo(FD))) {
       llvm::DiagnosticLocation DL =


### PR DESCRIPTION
Found via a static-analysis tool:
Pointer may be dereferenced after it was positively checked for NULL

Inside GenerateCode() function:

if (FD->isInlineBuiltinDeclaration() && Fn) {} ----> Pointer 'Fn' checked for NULL here

if (SyclOptReport.HasOptReportInfo(FD)) {
    llvm::OptimizationRemarkEmitter ORE(Fn); ---> Pointer 'Fn' is dereferenced by passing argument 1 to function "OptimizationRemarkEmitter" 

This patch checks Pointer 'Fn' inside routine to resolve the bug.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>