### PR TITLE
[SYCL] Correct configuration of the SYCL headers dependency

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -111,12 +111,12 @@ file(GLOB_RECURSE HEADERS_IN_CL_DIR CONFIGURE_DEPENDS "${sycl_inc_dir}/CL/*")
 
 # Copy SYCL headers from sources to build directory
 add_custom_target(sycl-headers
-  DEPENDS ${SYCL_INCLUDE_BUILD_DIR}/sycl
+  DEPENDS ${SYCL_INCLUDE_BUILD_DIR}/sycl/ext
           ${SYCL_INCLUDE_BUILD_DIR}/sycl/sycl.hpp
           ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL)
 
 add_custom_command(
-  OUTPUT  ${SYCL_INCLUDE_BUILD_DIR}/sycl
+  OUTPUT  ${SYCL_INCLUDE_BUILD_DIR}/sycl/ext
           ${SYCL_INCLUDE_BUILD_DIR}/sycl/sycl.hpp
           ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL
   DEPENDS ${HEADERS_IN_SYCL_DIR}


### PR DESCRIPTION
In certain local environments, SYCL headers were not copied into the
build directory during the initial configuration of the build directory.
This corrupted the structure of the build outputs and led to failures in
the `check-sycl` target. The problem was likely due to the violation of
the CMake recommendations for `add_custom_command()` usage:
> Do not list the output in more than one independent target that may
> build in parallel or the two instances of the rule may conflict
> instead use the add_custom_target() command to drive the command and
> make the other targets depend on that one).

(See https://cmake.org/cmake/help/latest/command/add_custom_command.html#generating-files)

List all `sycl/include/sycl` subdirectories explicitly to avoid the
duplicate usage of the output by the other file copying command.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>