### PR TITLE
[SYCL] Fix the unused parameter warnings in the level_zero backend

### DIFF
--- a/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
+++ b/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
@@ -123,6 +123,7 @@ inline context make_context<backend::ext_oneapi_level_zero>(
     const backend_input_t<backend::ext_oneapi_level_zero, context>
         &BackendObject,
     const async_handler &Handler) {
+  (void)Handler;
   return ext::oneapi::level_zero::make_context(
       BackendObject.DeviceList,
       detail::pi::cast<pi_native_handle>(BackendObject.NativeHandle),
@@ -134,6 +135,7 @@ template <>
 inline queue make_queue<backend::ext_oneapi_level_zero>(
     const backend_input_t<backend::ext_oneapi_level_zero, queue> &BackendObject,
     const context &TargetContext, const async_handler Handler) {
+  (void)Handler;
   return ext::oneapi::level_zero::make_queue(
       TargetContext,
       detail::pi::cast<pi_native_handle>(BackendObject.NativeHandle),


### PR DESCRIPTION
When the compiler is built with -Werror argument, the following errors
occur:

include/sycl/ext/oneapi/backend/level_zero.hpp:125:26: error: unused parameter 'Handler' [-Werror,-Wunused-parameter]
    const async_handler &Handler) {
                         ^
include/sycl/ext/oneapi/backend/level_zero.hpp:136:55: error: unused parameter 'Handler' [-Werror,-Wunused-parameter]
    const context &TargetContext, const async_handler Handler) {
                                                      ^
2 errors generated.

In order to not break the API, the parameters is still declared in the
function's signatures but marked as unused via the (void)Handler
expressions.