### PR TITLE
[SYCL][CUDA][libclc] Implement nextafter for sycl::half in generic/.

### DIFF
--- a/libclc/generic/libspirv/math/half_nextafter.inc
+++ b/libclc/generic/libspirv/math/half_nextafter.inc
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HALF_NEXTAFTER_INC
+#define HALF_NEXTAFTER_INC
+
+#include <clcmacro.h>
+#include <math/math.h>
+#include <spirv/spirv.h>
+
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+_CLC_OVERLOAD _CLC_DEF half __spirv_ocl_nextafter(half x, half y) {
+  // NaNs
+  if (x != x)
+    return x;
+  if (y != y)
+    return y;
+  // Parity
+  if (x == y)
+    return x;
+
+  short *a = (short *)&x;
+  short *b = (short *)&y;
+  // Checking for sign digit
+  if (*a & 0x8000)
+    *a = 0x8000 - *a;
+  if (*b & 0x8000)
+    *b = 0x8000 - *b;
+  // Increment / decrement
+  *a += (*a < *b) ? 1 : -1;
+  // Undo the sign flip if necessary
+  *a = (*a < 0) ? 0x8000 - *a : *a;
+  return x;
+}
+
+_CLC_BINARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, half, __spirv_ocl_nextafter, half,
+                      half)
+
+#endif
+
+#endif

--- a/libclc/generic/libspirv/math/nextafter.cl
+++ b/libclc/generic/libspirv/math/nextafter.cl
@@ -20,3 +20,6 @@ _CLC_DEFINE_BINARY_BUILTIN(double, __spirv_ocl_nextafter, __builtin_nextafter,
                            double, double)
 
 #endif
+
+#include "half_nextafter.inc"
+

--- a/libclc/generic/libspirv/math/nextafter.cl
+++ b/libclc/generic/libspirv/math/nextafter.cl
@@ -22,4 +22,3 @@ _CLC_DEFINE_BINARY_BUILTIN(double, __spirv_ocl_nextafter, __builtin_nextafter,
 #endif
 
 #include "half_nextafter.inc"
-

--- a/libclc/ptx-nvidiacl/libspirv/math/nextafter.cl
+++ b/libclc/ptx-nvidiacl/libspirv/math/nextafter.cl
@@ -8,9 +8,9 @@
 
 #include <spirv/spirv.h>
 
+#include "utils.h"
 #include <../../include/libdevice.h>
 #include <clcmacro.h>
-#include "utils.h"
 
 #define __CLC_FUNCTION __spirv_ocl_nextafter
 #define __CLC_BUILTIN __nv_nextafter
@@ -33,4 +33,3 @@ _CLC_DEFINE_BINARY_BUILTIN(double, __CLC_FUNCTION, __CLC_BUILTIN_D, double,
 #include "../../../generic/libspirv/math/half_nextafter.inc"
 
 #endif
-

--- a/libclc/ptx-nvidiacl/libspirv/math/nextafter.cl
+++ b/libclc/ptx-nvidiacl/libspirv/math/nextafter.cl
@@ -10,8 +10,27 @@
 
 #include <../../include/libdevice.h>
 #include <clcmacro.h>
+#include "utils.h"
 
 #define __CLC_FUNCTION __spirv_ocl_nextafter
 #define __CLC_BUILTIN __nv_nextafter
 #define __CLC_BUILTIN_F __CLC_XCONCAT(__CLC_BUILTIN, f)
-#include <math/binary_builtin.inc>
+#define __CLC_BUILTIN_D __CLC_BUILTIN
+
+_CLC_DEFINE_BINARY_BUILTIN(float, __CLC_FUNCTION, __CLC_BUILTIN_F, float, float)
+
+#ifndef __FLOAT_ONLY
+
+#ifdef cl_khr_fp64
+
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+
+_CLC_DEFINE_BINARY_BUILTIN(double, __CLC_FUNCTION, __CLC_BUILTIN_D, double,
+                           double)
+
+#endif
+
+#include "../../../generic/libspirv/math/half_nextafter.inc"
+
+#endif
+


### PR DESCRIPTION
sycl::nextafter(half,half) was defaulting to sycl::nextafter(float,float) which does not return the next half. 

Software implementation written in libclc/generic and #included into ptx-nvidiacl.