### PR TITLE
[SYCL][Doc] Deprecate SubGroup extension

### DIFF
--- a/sycl/doc/extensions/README.md
+++ b/sycl/doc/extensions/README.md
@@ -31,7 +31,7 @@ DPC++ extensions status:
 | [SYCL_INTEL_static_local_memory_query](StaticLocalMemoryQuery/SYCL_INTEL_static_local_memory_query.asciidoc)                | Proposal                                  | |
 | [SYCL_INTEL_sub_group_algorithms](SubGroupAlgorithms/SYCL_INTEL_sub_group_algorithms.asciidoc)                              | Partially supported(OpenCL: CPU, GPU)     | Features from SYCL_INTEL_group_algorithms extended to sub-groups |
 | [Sub-groups for NDRange Parallelism](SubGroupNDRange/SubGroupNDRange.md)                                                    | Deprecated(OpenCL: CPU, GPU)              | |
-| [Sub-groups](SubGroup/SYCL_INTEL_sub_group.asciidoc)                                                                        | Partially supported(OpenCL)               | Not supported: auto/stable sizes, stable query, compiler flags |
+| [Sub-groups](SubGroup/SYCL_INTEL_sub_group.asciidoc)                                                                        | Deprecated                                | |
 | [SYCL_INTEL_unnamed_kernel_lambda](UnnamedKernelLambda/SYCL_INTEL_unnamed_kernel_lambda.asciidoc)                           | Supported(OpenCL)                         | |
 | [Unified Shared Memory](USM/USM.adoc)                                                                                       | Supported(OpenCL)                         | |
 | [Use Pinned Memory Property](UsePinnedMemoryProperty/UsePinnedMemoryPropery.adoc)                                           | Supported                                 | |

--- a/sycl/doc/extensions/SubGroup/SYCL_INTEL_sub_group.asciidoc
+++ b/sycl/doc/extensions/SubGroup/SYCL_INTEL_sub_group.asciidoc
@@ -17,7 +17,7 @@
 :language: {basebackend@docbook:c++:cpp}
 
 == Introduction
-IMPORTANT: This specification is a draft.
+IMPORTANT: The functionality introduced by this extension is deprecated in favor of the standard sub-group functionality outlined in [Section 4.9.1.8 "sub_group_class"](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sub-group-class), [Section 4.17.3 "Group functions"](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:group-functions) and [Section 4.17.4 "Group algorithms library"](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:algorithms) of the SYCL 2020 Specification, Revision 3. All functionality related to a device's "primary" sub-group size will be redefined in a future extension written against SYCL 2020.
 
 NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by permission by Khronos.
 

--- a/sycl/doc/extensions/SubGroup/SYCL_INTEL_sub_group.asciidoc
+++ b/sycl/doc/extensions/SubGroup/SYCL_INTEL_sub_group.asciidoc
@@ -17,7 +17,7 @@
 :language: {basebackend@docbook:c++:cpp}
 
 == Introduction
-IMPORTANT: The functionality introduced by this extension is deprecated in favor of the standard sub-group functionality outlined in [Section 4.9.1.8 "sub_group_class"](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sub-group-class), [Section 4.17.3 "Group functions"](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:group-functions) and [Section 4.17.4 "Group algorithms library"](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:algorithms) of the SYCL 2020 Specification, Revision 3. All functionality related to a device's "primary" sub-group size will be redefined in a future extension written against SYCL 2020.
+IMPORTANT: The functionality introduced by this extension is deprecated in favor of the standard sub-group functionality outlined in https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sub-group-class[Section 4.9.1.8 "sub_group_class"], https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:group-functions[Section 4.17.3 "Group functions"] and https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:algorithms[Section 4.17.4 "Group algorithms library"] of the SYCL 2020 Specification, Revision 3. All functionality related to a device's "primary" sub-group size will be redefined in a future extension written against SYCL 2020.
 
 NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by permission by Khronos.
 


### PR DESCRIPTION
All functionality introduced by this extension that is currently
implemented in DPC++ has equivalent functionality in SYCL 2020:
- The sub_group class
- The group functions (e.g. broadcast, barrier)
- The group algorithms (e.g. permutes, shifts, reductions)

All functionality related to "primary" sub-group sizes is not
implemented. Rather than maintain a list of which features are
extensions and which are implemented, now seems a good chance to
deprecate the whole extension. The "primary" sub-group size
functionality will be reintroduced as an extension against SYCL 2020,
aligned with more recent developments (e.g. using compile-time
properties instead of new attributes).

Signed-off-by: John Pennycook <john.pennycook@intel.com>