### PR TITLE
[SYCL][Doc] Deprecate GroupAlgorithms extension

### DIFF
--- a/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
+++ b/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc
@@ -17,7 +17,14 @@
 :language: {basebackend@docbook:c++:cpp}
 
 == Introduction
-IMPORTANT: This specification is a draft.
+IMPORTANT: This functionality introduced by this extension is deprecated in
+favor of the standard functionality outlined in
+https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:group-functions[Section
+4.17.3 "Group functions"] and
+https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:algorithms[Section
+4.17.4 "Group algorithms library"] of the SYCL 2020 Specification, Revision 3.
+Note that the "leader" algorithm proposed here is not a free-function in SYCL
+2020, but a member function of the `group` and `sub_group` classes.
 
 NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by permission by Khronos.
 

--- a/sycl/doc/extensions/README.md
+++ b/sycl/doc/extensions/README.md
@@ -14,7 +14,7 @@ DPC++ extensions status:
 | [SYCL_INTEL_device_specific_kernel_queries](DeviceSpecificKernelQueries/SYCL_INTEL_device_specific_kernel_queries.asciidoc) | Proposal                                  | |
 | [SYCL_INTEL_enqueue_barrier](EnqueueBarrier/enqueue_barrier.asciidoc)                                                       | Supported(OpenCL, Level Zero)             | |
 | [SYCL_INTEL_extended_atomics](ExtendedAtomics/SYCL_INTEL_extended_atomics.asciidoc)                                         | Supported(OpenCL: CPU, GPU)               | |
-| [SYCL_INTEL_group_algorithms](GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc)                                         | Supported(OpenCL; CUDA)                   | |
+| [SYCL_INTEL_group_algorithms](GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc)                                         | Deprecated                                | |
 | [GroupMask](GroupMask/GroupMask.asciidoc)                                                                                   | Proposal                                  | |
 | [FPGA selector](IntelFPGA/FPGASelector.md)                                                                                  | Supported                                 | |
 | [FPGA reg](IntelFPGA/FPGAReg.md)                                                                                            | Supported(OpenCL: ACCELERATOR)            | |


### PR DESCRIPTION
All functionality introduced by this extension has equivalent
functionality in SYCL 2020.

Signed-off-by: John Pennycook <john.pennycook@intel.com>