### PR TITLE
[SYCL][DOC] Proposal to generalize async_work_group_copy to include sub-group

### DIFF
--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -43,11 +43,10 @@ SYCL specification refer to that revision.
 
 ## Introduction
 
-This document proposes `async_group_copy`, which will generalize
+This document proposes the `async_group_copy` group collective function, which will generalize
 `async_work_group_copy` to work with sub-groups as well as work-groups.
-A `wait_for` function will also be also be added to block until the memory
-copy is complete and to ensure memory consistency for the group, this will use
-the same groups as `async_group_copy`.
+A `wait_for` group collective function is also introduced as a corresponding generalization for `sycl::group::wait_for`.  The purpose of `wait_for` is to block further execution of work-items that are part of the group until the memory
+copy is complete.
 
 ## Feature test macro
 
@@ -66,10 +65,9 @@ to determine which of the extension’s APIs the implementation supports.
 |===
 
 
-## New `async_group_copy` function.
-`async_group_copy` will work very similarly to `async_work_group_copy`, but
-with the ability to utilize individual sub-groups. The group will be provided
-as a template parameter, in the same fashion as `group_barrier`.
+## New `async_group_copy` group collective function.
+`async_group_copy` extends the functionality of `sycl::group::async_work_group_copy` to sub-groups. The group/sub-group will be provided
+as a template parameter, in the same fashion as other group collectives such as `group_barrier`.
 `async_group_copy` is intended as a potential optimization, and may add more
 overhead than a simple synchronous implementation in some cases.
 
@@ -100,7 +98,8 @@ following properties:
   arguments, otherwise the behaviour is undefined.
 * All work-items of the group are required to call the function in convergent
   control flow, otherwise the behaviour is undefined.
-* The type of `dataT` must be trivially copyable as defined by the C++ core language or a specialization of `sycl::vec`.
+* If the work-items of the group have diverged then the group should be re-converged prior to calls to `group_async_copy` via a call to the `sycl::barrier` group collective.
+* The type of `dataT` must either be trivially copyable, as defined by the C++ core language, or a specialization of `sycl::vec`.
 * The copy is only guaranteed to be complete after `wait_for` has been called on the
   returned `async_copy_event` and has completed.
 * `src_stride` and `dst_stride` must be non-zero `size_t` values.
@@ -147,10 +146,10 @@ async_copy_event<Group> async_group_copy(Group group, sycl::global_ptr<dataT> sr
 } // namespace sycl::ext::oneapi::experimental
 ```
 
-## New `wait_for` function
+## New `wait_for` group collective function
 `wait_for` will work very similarly to `nd_item::wait_for` or `group::wait_for`,
 but with the ability to utilize individual sub-groups. The group will be linked
-to the `async_copy_event` so `wait_for` and `async_group_copy` use the same group.
+to the `async_copy_event` argument of `wait_for`, so invocations of `wait_for` and `async_group_copy` must use the same group when the `async_copy_event` used as an argument in `wait_for` was returned by the `async_group_copy` invocation.
 
 `wait_for` will block until all the asychronous copies represented by the
 `async_copy_event` arguments are complete. Copies performed with `async_group_copy`

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -43,9 +43,9 @@ SYCL specification refer to that revision.
 
 ## Introduction
 
-This document proposes the `async_group_copy` group collective function, which will generalize
-`async_work_group_copy` to work with sub-groups as well as work-groups.
-A `wait_for` group collective function is also introduced as a corresponding generalization for `sycl::group::wait_for`.  The purpose of `wait_for` is to block further execution of work-items that are part of the group until the memory
+This document proposes the `joint_async_copy` group function, which will generalize
+`sycl::group::async_work_group_copy` to work with sub-groups as well as work-groups.
+A `wait_for` group function is also introduced as a corresponding generalization for `sycl::group::wait_for`.  The purpose of `wait_for` is to block further execution of work-items that are part of the group until the memory
 copy is complete.
 
 ## Feature test macro
@@ -65,18 +65,19 @@ to determine which of the extension’s APIs the implementation supports.
 |===
 
 
-## New `async_group_copy` group collective function.
-`async_group_copy` extends the functionality of `sycl::group::async_work_group_copy` to sub-groups. The group/sub-group will be provided
-as a template parameter, in the same fashion as other group collectives such as `group_barrier`.
-`async_group_copy` is intended as a potential optimization, and may add more
+## New `joint_async_copy` group collective function.
+`joint_async_copy` extends the functionality of `sycl::group::async_work_group_copy` to sub-groups. A group/sub-group must be provided
+as a parameter, in the same fashion as other group functions such as `group_barrier`.
+`joint_async_copy` is intended as a potential optimization, and may add more
 overhead than a simple synchronous implementation in some cases.
+The behavior of `joint_async_copy` for `sycl::group` must match the expected behavior of the SYCL and OpenCL `async_work_group_copy` function.
 
-`async_group_copy` will asynchronously copy a given number of values of type
+`joint_async_copy` will asynchronously copy a given number of values of type
 `dataT` from global memory to local memory or from local memory to global
-memory. If an asynchronous copy is not supported then `async_group_copy` will
+memory. If an asynchronous copy is not supported then `joint_async_copy` will
 fall back on a synchronous copy.
 
-`async_group_copy` will return an `async_copy_event` that can be used with `wait_for`
+`joint_async_copy` will return an `async_copy_event` that can be used with `wait_for`
 to block until the copy has completed.
 
 When copying from global memory to local memory an optional stride, `src_stride`,
@@ -87,7 +88,7 @@ When copying from local memory to global memory an optional stride, `dest_stride
 can be provided. For 0 &le; i &lt; `count`, the value located at src[i] will be
 copied to dest[i*`dest_stride`]. 
 
-`async_group_copy` is a free function with the
+`joint_async_copy` is a free function with the
 following properties:
 
 * The work-items will not necessarily be synchronized, so must have a
@@ -95,11 +96,11 @@ following properties:
 * The order of operations is implementation defined.
 * The method of copy is implementation defined.
 * All work-items of the group are required to call the function with the same
-  arguments, otherwise the behaviour is undefined.
-* All work-items of the group are required to call the function in convergent
-  control flow, otherwise the behaviour is undefined.
-* If the work-items of the group have diverged then the group should be re-converged prior to calls to `group_async_copy` via a call to the `sycl::barrier` group collective.
-* The type of `dataT` must either be trivially copyable, as defined by the C++ core language, or a specialization of `sycl::vec`.
+  arguments, otherwise the behavior is undefined.
+* All work-items of the group are not required to call the function in convergent
+  control flow, however performance may be negatively affected if the function is not called in convergent control flow.
+* If the work-items of the group have diverged then it is recommended that the group should be re-converged prior to calls to `joint_async_copy` via a call to `sycl::barrier`.
+* The type of `dataT` must either any scalar or vector type, as defined by the C++ core language, or a specialization of `sycl::vec`.
 * The copy is only guaranteed to be complete after `wait_for` has been called on the
   returned `async_copy_event` and has completed.
 * `src_stride` and `dst_stride` must be non-zero `size_t` values.
@@ -133,26 +134,26 @@ struct src_stride {
 };
 
 template <typename Group, typename dataT>
-async_copy_event<Group> async_group_copy(Group group, sycl::local_ptr<dataT> src, sycl::global_ptr<dataT> dest, size_t count);
+async_copy_event<Group> joint_async_copy(Group group, sycl::local_ptr<dataT> src, sycl::global_ptr<dataT> dest, size_t count);
 
 template <typename Group, typename dataT>
-async_copy_event<Group> async_group_copy(Group group, sycl::global_ptr<dataT> src, sycl::local_ptr<dataT> dest, size_t count);
+async_copy_event<Group> joint_async_copy(Group group, sycl::global_ptr<dataT> src, sycl::local_ptr<dataT> dest, size_t count);
 
 template <typename Group, typename dataT>
-async_copy_event<Group> async_group_copy(Group group, sycl::local_ptr<dataT> src, sycl::global_ptr<dataT> dest, size_t count, dest_stride destStride);
+async_copy_event<Group> joint_async_copy(Group group, sycl::local_ptr<dataT> src, sycl::global_ptr<dataT> dest, size_t count, dest_stride destStride);
 
 template <typename Group, typename dataT>
-async_copy_event<Group> async_group_copy(Group group, sycl::global_ptr<dataT> src, sycl::local_ptr<dataT> dest, size_t count, src_stride srcStride);
+async_copy_event<Group> joint_async_copy(Group group, sycl::global_ptr<dataT> src, sycl::local_ptr<dataT> dest, size_t count, src_stride srcStride);
 } // namespace sycl::ext::oneapi::experimental
 ```
 
 ## New `wait_for` group collective function
 `wait_for` will work very similarly to `nd_item::wait_for` or `group::wait_for`,
 but with the ability to utilize individual sub-groups. The group will be linked
-to the `async_copy_event` argument of `wait_for`, so invocations of `wait_for` and `async_group_copy` must use the same group when the `async_copy_event` used as an argument in `wait_for` was returned by the `async_group_copy` invocation.
+to the `async_copy_event` argument of `wait_for`, so invocations of `wait_for` and `joint_async_copy` must use the same group when the `async_copy_event` used as an argument in `wait_for` was returned by the `joint_async_copy` invocation.
 
 `wait_for` will block until all the asychronous copies represented by the
-`async_copy_event` arguments are complete. Copies performed with `async_group_copy`
+`async_copy_event` arguments are complete. Copies performed with `joint_async_copy`
 are not guaranteed to be complete until `wait_for` has been called with the returned
 `async_copy_event`, so the data cannot be read reliably before that. `wait_for` will also act
 as a group barrier to ensure memory consistency between the work-items of the group.
@@ -160,9 +161,9 @@ as a group barrier to ensure memory consistency between the work-items of the gr
 `wait_for` is a free function with the following properties:
 
 * All work-items of the group are required to call the function in convergent
-  control flow, otherwise the behaviour is undefined.
+  control flow, otherwise the behavior is undefined.
 * All instances of `eventTN` are of template type `async_copy_event` with the same specialization.
-* All work-items of the group are required to call the function with `async_copy_event` arguments representing the same copies, in the same order, otherwise the behaviour is undefined.
+* All work-items of the group are required to call the function with `async_copy_event` arguments representing the same copies, in the same order, otherwise the behavior is undefined.
 
 
 ```c++
@@ -184,6 +185,9 @@ NOTE: When using a stride other than 1, the size of the type must be known so th
 
 NOTE: A SPIR-V extension could be proposed that will add an instruction for asynchronous copy of trivally copyable types of arbitrary shape (size in bytes).
 
+2. `joint_async_copy` has the limitation that it can only copy `count` elements of contiguous memory. This is insufficient for certain applications such as an efficient Matrix Multiply Add kernel where the memory may not be contiguous.  non-contiguous asynchronous copies could be supported by the addition of a sibling group function, `async_copy_over_group`.
+
+3. `joint_async_copy` is incompatible with an interpretation of the definition of SYCL group functions as "synchronization points", whereby all group functions require a barrier synchronization at the beginning of their execution. The definition of SYCL group functions should be clarified as discussed in https://gitlab.khronos.org/sycl/Specification/-/issues/576. The DPC++ implementation of `joint_reduce` is also inconsistent with this interpretation of a strict synchronization point, which can severely impact performance, even though these functions implement performance optimizations. It should be carefully considered whether to define subsets of SYCL group functions which adhere to different rules: i.e. those which require strict synchronization points, as defined by the previously discussed interpretation, and those that don't. If certain group functions do not require their implementation to include preliminary calls to a barrier function then it should be made clear to the user that unexpected behavior may occur following the usage of such functions that does not properly take the lack of a preliminary barrier into account.
 ## Revision History
 
 [frame="none",options="header"]

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -70,9 +70,9 @@ to determine which of the extension’s APIs the implementation supports.
 as a parameter, in the same fashion as other group functions such as `group_barrier`.
 `joint_async_copy` is intended as a potential optimization, and may add more
 overhead than a simple synchronous implementation in some cases.
-The behavior of `joint_async_copy` for `sycl::group` must match the expected behavior of the SYCL and OpenCL `async_work_group_copy` function.
+The behavior of `joint_async_copy` for `sycl::group` must match the expected behavior of the SYCL and OpenCL `async_work_group_copy` functions.
 
-`joint_async_copy` will asynchronously copy a given number of values of type
+`joint_async_copy` will asynchronously copy a given number of elements of type
 `dataT` from global memory to local memory or from local memory to global
 memory. If an asynchronous copy is not supported then `joint_async_copy` will
 fall back on a synchronous copy.
@@ -81,17 +81,17 @@ fall back on a synchronous copy.
 to block until the copy has completed.
 
 When copying from global memory to local memory an optional stride, `src_stride`,
-can be provided. For 0 &le; i &lt; `count`, the value copied to dest[i] will be
+can be provided. For 0 &le; i &lt; `count`, the element copied to dest[i] will be
 src[i*`src_stride`]. 
 
 When copying from local memory to global memory an optional stride, `dest_stride`,
-can be provided. For 0 &le; i &lt; `count`, the value located at src[i] will be
+can be provided. For 0 &le; i &lt; `count`, the element located at src[i] will be
 copied to dest[i*`dest_stride`]. 
 
 `joint_async_copy` is a free function with the
 following properties:
 
-* The work-items will not necessarily be synchronized, so must have a
+* The work-items will not necessarily be synchronized, so should have a
   consistent view of the memory before the invocation.
 * The order of operations is implementation defined.
 * The method of copy is implementation defined.
@@ -167,10 +167,9 @@ as a group barrier to ensure memory consistency between the work-items of the gr
 
 
 ```c++
-namespace sycl::ext::oneapi::experimental {
 template <typename Group, typename... eventT>
 std::enable_if_t<sycl::is_group_v<Group> &&
-(std::is_same_v<eventT, async_copy_event<Group>> && ...)>
+(sycl::detail::is_same_v<eventT, async_copy_event<Group>> && ...)>
 wait_for(Group, eventT... Events);
 }  // namespace sycl
 ```
@@ -179,7 +178,7 @@ wait_for(Group, eventT... Events);
 
 1. Implementing asynchronous copies for trivially copyable types that do not fit with SPIR-Vs OpGroupAsyncCopy.
 
-NOTE: When using a stride other than 1, the size of the type must be known so the spacing between the values can be calculated. OpGroupAsyncCopy provides no way with to specify the size of the type so if the data cannot be reinterpreted as a scalar or vector of integer type or floating-point type then the type cannot be used with OpGroupAsyncCopy.
+NOTE: When using a stride other than 1, the size of the type must be known so the spacing between the elements can be calculated. OpGroupAsyncCopy provides no way with to specify the size of the type so if the data cannot be reinterpreted as a scalar or vector of integer type or floating-point type then the type cannot be used with OpGroupAsyncCopy.
 
 *RESOLUTION*: Fall back on a synchronous copy.
 
@@ -188,6 +187,7 @@ NOTE: A SPIR-V extension could be proposed that will add an instruction for asyn
 2. `joint_async_copy` has the limitation that it can only copy `count` elements of contiguous memory. This is insufficient for certain applications such as an efficient Matrix Multiply Add kernel where the memory may not be contiguous.  non-contiguous asynchronous copies could be supported by the addition of a sibling group function, `async_copy_over_group`.
 
 3. `joint_async_copy` is incompatible with an interpretation of the definition of SYCL group functions as "synchronization points", whereby all group functions require a barrier synchronization at the beginning of their execution. The definition of SYCL group functions should be clarified as discussed in https://gitlab.khronos.org/sycl/Specification/-/issues/576. The DPC++ implementation of `joint_reduce` is also inconsistent with this interpretation of a strict synchronization point, which can severely impact performance, even though these functions implement performance optimizations. It should be carefully considered whether to define subsets of SYCL group functions which adhere to different rules: i.e. those which require strict synchronization points, as defined by the previously discussed interpretation, and those that don't. If certain group functions do not require their implementation to include preliminary calls to a barrier function then it should be made clear to the user that unexpected behavior may occur following the usage of such functions that does not properly take the lack of a preliminary barrier into account.
+
 ## Revision History
 
 [frame="none",options="header"]

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -41,10 +41,11 @@ SYCL specification refer to that revision.
 
 ## Introduction
 
-This document proposes `async_group_copy`, which will generalize 
-`async_work_group_copy` to work with sub-groups as well as work-groups. 
+This document proposes `async_group_copy`, which will generalize
+`async_work_group_copy` to work with sub-groups as well as work-groups.
 A `wait_for` function will also be also be added to block until the memory
-copy is complete and to ensure memory consistency for the group.
+copy is complete and to ensure memory consistency for the group, this will use
+the same groups as `async_group_copy`.
 
 ## Feature test macro
 
@@ -64,22 +65,22 @@ to determine which of the extension’s APIs the implementation supports.
 
 
 ## New `async_group_copy` function.
-`async_group_copy` will work very similarly to `async_work_group_copy`, but 
-with the ability to utilize individual sub-groups. The group will be provided 
+`async_group_copy` will work very similarly to `async_work_group_copy`, but
+with the ability to utilize individual sub-groups. The group will be provided
 as a template parameter, in the same fashion as `group_barrier`.
-`async_group_copy` is intended as a potential optimization, and may add more 
+`async_group_copy` is intended as a potential optimization, and may add more
 overhead than a simple synchronous implementation in some cases.
 
 `async_group_copy` will asynchronously copy a given number of values of type
 `dataT` from global memory to local memory or from local memory to global
-memory. If an asynchorous copy is not supported then it will fall back on a
-synchronous copy. `async_group_copy` is a free function with the following
-properties:
+memory. If an asynchorous copy is not supported then `async_group_copy` will
+fall back on a synchronous copy. `async_group_copy` is a free function with the
+following properties:
 
 * The work-items will not necessarily be synchronized, so must have a
   consistent view of the memory before the invocation.
 * The order of operations is not specified.
-* All work-items of the group are required to call the function with the same 
+* All work-items of the group are required to call the function with the same
   arguments, otherwise the behaviour is undefined.
 * All work-items of the group are required to call the function in convergent
   control flow, otherwise the behaviour is undefined.
@@ -97,7 +98,7 @@ line with other SYCL copy functions.
 namespace sycl::ext::oneapi {
 
 struct dest_stride {
-       std::size_t value;       
+       std::size_t value;
 };
 
 struct src_stride {
@@ -120,19 +121,19 @@ device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src
 
 ## New `wait_for` function
 `wait_for` will work very similarly to `nd_item::wait_for` or `group::wait_for`,
-but with the ability to utilize individual sub-groups. The group will be provided 
-as a template parameter, in the same fashion as `group_barrier`.  
+but with the ability to utilize individual sub-groups. The group will be provided
+as a template parameter, in the same fashion as `group_barrier`.
 
-`wait_for` will block until the the asychronous copy represented by the 
-`device_event` is complete. Data written to a location by `async_group_copy`
+`wait_for` will block until all the asychronous copies represented by the
+`device_event` arguments are complete. Data written to a location by `async_group_copy`
 should not be read until `wait_for` has been called with the returned
 `device_event`. `wait_for` will also act as a group barrier to ensure memory
 consistency between the work-items of the group.
 
 `wait_for` is a free function with the following properties:
 
-* The group should be the same as the group used in the invocation of 
-  `async_group_copy` that returned the `device_event` or the behaviour is undefined.
+* The group should be the same as the group used in all invocations of
+  `async_group_copy` that returned the `device_event` arguments or the behaviour is undefined.
 * All work-items of the group are required to call the function in convergent
   control flow, otherwise the behaviour is undefined.
 

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -1,0 +1,115 @@
+# Async Group Copy Extension for DPC++: SYCL_EXT_ONEAPI_ASYNC_GROUP_COPY
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+:dpcpp: pass:[DPC++]
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+
+:blank: pass:[ +]
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+
+== Notice
+
+Copyright (c) 2021-2021 Intel Corporation.  All rights reserved.
+
+IMPORTANT: This specification is a draft.
+
+NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are
+trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc.
+used by permission by Khronos.
+
+This extension is written against the SYCL 2020 revision 3 specification.  All
+references below to the "core SYCL specification" or to section numbers in the
+SYCL specification refer to that revision.
+
+## Contributors
+
+* Gordon Brown
+* Tadej Ciglaric
+* Jack Kirk
+* Finlay Marno
+
+## Introduction
+
+This document proposes that `async_work_group_copy` be deprecated and replaced 
+with `async_group_copy`. `async_group_copy` is a non-member function, in line
+with the other group functions, which generalizes `async_work_group_copy` to
+also work with sub-groups.
+
+## Feature test macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification section 6.3.3 "Feature test macros". Therefore, an implementation
+supporting this extension must predefine the macro
+SYCL_EXT_ONEAPI_ASYNC_GROUP_COPY to one of the values defined in the table
+below. Applications can test for the existence of this macro to determine if the
+implementation supports this feature, or applications can test the macro’s value
+to determine which of the extension’s APIs the implementation supports.
+
+[%header,cols="1,5"]
+|===
+|Value |Description
+|1     |Initial extension implementation.
+|===
+
+
+## New `async_group_copy` function.
+Currently the `nd_item` and `group` classes have the member function
+`async_work_group_copy`. These will be deprecated in favor of a single function 
+`async_group_copy` that will have the group as a template parameter, much
+like `group_barrier`.
+
+`async_group_copy` methods would be valid for groups `group` and `sub_group`.
+Note that the destination and source arguments have been have been swapped to be
+more in line with other SYCL copy functions.
+```c++
+namespace sycl::ext::oneapi {
+template <typename Group, typename dataT>
+device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t numElements);
+
+template <typename Group, typename dataT>
+device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t numElements);
+
+template <typename Group, typename dataT>
+device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t numElements, size_t destStride);
+
+template <typename Group, typename dataT>
+device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t numElements, size_t srcStride);
+} // namespace sycl::ext::oneapi
+```
+
+## Change to `device_event::wait` function
+`device_event::wait` will be modified to take the group that will be synchronized in the wait.
+This will be valid for the same groups as `async_group_copy` i.e. `group` or `sub_group`.
+For NVIDIA architectures of sm_80 or higher, the group will be blocked until all
+outstanding async_group_copy requests are completed.
+
+```c++
+namespace sycl {
+  class device_event {
+  ...
+  public:
+    template <typename Group>
+    void ext_oneapi_wait(Group group) noexcept;
+  ...
+  };
+}  // namespace sycl
+```
+
+## Revision History
+
+[frame="none",options="header"]
+|======================
+|Rev |Date       |Author        |Changes
+|1   |2021-11-08 |Finlay Marno  |Initial working draft.
+|======================

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -41,10 +41,10 @@ SYCL specification refer to that revision.
 
 ## Introduction
 
-This document proposes that `async_work_group_copy` be deprecated and replaced 
-with `async_group_copy`. `async_group_copy` is a non-member function, in line
-with the other group functions, which generalizes `async_work_group_copy` to
-also work with sub-groups.
+This document proposes `async_group_copy`, which will generalize 
+`async_work_group_copy` to work with sub-groups as well as work-groups. 
+A `wait_for` function will also be also be added to block until the memory
+copy is complete and to ensure memory consistency for the group.
 
 ## Feature test macro
 
@@ -64,16 +64,46 @@ to determine which of the extension’s APIs the implementation supports.
 
 
 ## New `async_group_copy` function.
-Currently the `nd_item` and `group` classes have the member function
-`async_work_group_copy`. These will be deprecated in favor of a single function 
-`async_group_copy` that will have the group as a template parameter, much
-like `group_barrier`.
+`async_group_copy` will work very similarly to `async_work_group_copy`, but 
+with the ability to utilize individual sub-groups. The group will be provided 
+as a template parameter, in the same fashion as `group_barrier`.
+`async_group_copy` is intended as a potential optimization, and may add more 
+overhead than a simple synchronous implementation in some cases.
 
-`async_group_copy` methods would be valid for groups `group` and `sub_group`.
-Note that the destination and source arguments have been swapped to be
-more in line with other SYCL copy functions.
+`async_group_copy` will asynchronously copy a given number of values of type
+`dataT` from global memory to local memory or from local memory to global
+memory. If an asynchorous copy is not supported then it will fall back on a
+synchronous copy. `async_group_copy` is a free function with the following
+properties:
+
+* The work-items will not necessarily be synchronized, so must have a
+  consistent view of the memory before the invocation.
+* The order of operations is not specified.
+* All work-items of the group are required to call the function with the same 
+  arguments, otherwise the behaviour is undefined.
+* All work-items of the group are required to call the function in convergent
+  control flow, otherwise the behaviour is undefined.
+* The type of `dataT` should be a scalar or vector type.
+* The data written by `async_group_copy` should not be read until `wait_for`
+  has been called on the returned `device_event`.
+
+The structs `dest_stride` and `src_stride` have been introduced to reduce errors
+when specifying the stride.
+
+Note that the destination and source arguments have been swapped to be more in
+line with other SYCL copy functions.
+
 ```c++
 namespace sycl::ext::oneapi {
+
+struct dest_stride {
+       std::size_t value;       
+};
+
+struct src_stride {
+       std::size_t value;
+};
+
 template <typename Group, typename dataT>
 device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count);
 
@@ -81,28 +111,39 @@ template <typename Group, typename dataT>
 device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count);
 
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count, size_t destStride);
+device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count, dest_stride destStride);
 
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count, size_t srcStride);
+device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count, src_stride srcStride);
 } // namespace sycl::ext::oneapi
 ```
 
-## Change to `device_event::wait` function
-`device_event::wait` will be modified to take the group that will be synchronized in the wait.
-This will be valid for the same groups as `async_group_copy` i.e. `group` or `sub_group`.
+## New `wait_for` function
+`wait_for` will work very similarly to `nd_item::wait_for` or `group::wait_for`,
+but with the ability to utilize individual sub-groups. The group will be provided 
+as a template parameter, in the same fashion as `group_barrier`.  
+
+`wait_for` will block until the the asychronous copy represented by the 
+`device_event` is complete. Data written to a location by `async_group_copy`
+should not be read until `wait_for` has been called with the returned
+`device_event`. `wait_for` will also act as a group barrier to ensure memory
+consistency between the work-items of the group.
+
+`wait_for` is a free function with the following properties:
+
+* The group should be the same as the group used in the invocation of 
+  `async_group_copy` that returned the `device_event` or the behaviour is undefined.
+* All work-items of the group are required to call the function in convergent
+  control flow, otherwise the behaviour is undefined.
+
+
 NOTE: For NVIDIA architectures of sm_80 or higher, the group will be blocked until all
 outstanding async_group_copy requests are completed.
 
 ```c++
-namespace sycl {
-  class device_event {
-  ...
-  public:
-    template <typename Group>
-    void ext_oneapi_wait(Group group) noexcept;
-  ...
-  };
+namespace sycl::ext::oneapi {
+    template <typename Group, typename eventTN>
+    void wait_for(Group group, eventTN... Events) noexcept;
 }  // namespace sycl
 ```
 

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -28,7 +28,7 @@ NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are
 trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc.
 used by permission by Khronos.
 
-This extension is written against the SYCL 2020 revision 3 specification.  All
+This extension is written against the SYCL 2020 revision 4 specification.  All
 references below to the "core SYCL specification" or to section numbers in the
 SYCL specification refer to that revision.
 
@@ -70,28 +70,28 @@ Currently the `nd_item` and `group` classes have the member function
 like `group_barrier`.
 
 `async_group_copy` methods would be valid for groups `group` and `sub_group`.
-Note that the destination and source arguments have been have been swapped to be
+Note that the destination and source arguments have been swapped to be
 more in line with other SYCL copy functions.
 ```c++
 namespace sycl::ext::oneapi {
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t numElements);
+device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count);
 
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t numElements);
+device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count);
 
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t numElements, size_t destStride);
+device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count, size_t destStride);
 
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t numElements, size_t srcStride);
+device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count, size_t srcStride);
 } // namespace sycl::ext::oneapi
 ```
 
 ## Change to `device_event::wait` function
 `device_event::wait` will be modified to take the group that will be synchronized in the wait.
 This will be valid for the same groups as `async_group_copy` i.e. `group` or `sub_group`.
-For NVIDIA architectures of sm_80 or higher, the group will be blocked until all
+NOTE: For NVIDIA architectures of sm_80 or higher, the group will be blocked until all
 outstanding async_group_copy requests are completed.
 
 ```c++

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -76,19 +76,36 @@ overhead than a simple synchronous implementation in some cases.
 `async_group_copy` will asynchronously copy a given number of values of type
 `dataT` from global memory to local memory or from local memory to global
 memory. If an asynchronous copy is not supported then `async_group_copy` will
-fall back on a synchronous copy. `async_group_copy` is a free function with the
+fall back on a synchronous copy.
+
+`async_group_copy` will return an `async_copy_event` that can be used with `wait_for`
+to block until the copy has completed.
+
+When copying from global memory to local memory an optional stride, `src_stride`,
+can be provided. For 0 <= i < `count`, the value copied to dest[i] will be
+src[i*`src_stride`]. 
+
+When copying from local memory to global memory an optional stride, `dest_stride`,
+can be provided. For 0 <= i < `count`, the value located at src[i] will be
+copied to dest[i*`dest_stride`]. 
+
+`async_group_copy` is a free function with the
 following properties:
 
 * The work-items will not necessarily be synchronized, so must have a
   consistent view of the memory before the invocation.
-* The order of operations is not specified.
+* The order of operations is implementation defined.
+* The method of copy is implementation defined.
 * All work-items of the group are required to call the function with the same
   arguments, otherwise the behaviour is undefined.
 * All work-items of the group are required to call the function in convergent
   control flow, otherwise the behaviour is undefined.
-* The type of `dataT` should be a scalar or vector type.
-* The data written by `async_group_copy` should not be read until `wait_for`
-  has been called on the returned `device_event`.
+* The type of `dataT` must be trivially copyable as defined by the C++ core language.
+* The copy is only guaranteed to be complete after `wait_for` has been called on the
+  returned `async_copy_event` and has completed.
+* `src_stride` and `dst_stride` must be non-zero `size_t` values.
+* The default value for `src_stride` and `dest_stride` is 1.
+* The number of work-items in the group does not need to be equal to `count`.
 
 The structs `dest_stride` and `src_stride` have been introduced to reduce errors
 when specifying the stride.
@@ -100,6 +117,14 @@ functions in SYCL 2020.
 ```c++
 namespace sycl::ext::oneapi::experimental {
 
+template <typename Group, std::enable_if_t<sycl::is_group<Group>::value, bool> = true>
+class async_copy_event {
+private:
+  ...
+public:
+    using group = Group;
+};
+
 struct dest_stride {
        std::size_t value;
 };
@@ -109,45 +134,41 @@ struct src_stride {
 };
 
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count);
+async_copy_event<Group> async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count);
 
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count);
+async_copy_event<Group> async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count);
 
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count, dest_stride destStride);
+async_copy_event<Group> async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count, dest_stride destStride);
 
 template <typename Group, typename dataT>
-device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count, src_stride srcStride);
+async_copy_event<Group> async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count, src_stride srcStride);
 } // namespace sycl::ext::oneapi::experimental
 ```
 
 ## New `wait_for` function
 `wait_for` will work very similarly to `nd_item::wait_for` or `group::wait_for`,
-but with the ability to utilize individual sub-groups. The group will be provided
-as a template parameter, in the same fashion as `group_barrier`.
+but with the ability to utilize individual sub-groups. The group will be linked
+to the `async_copy_event` so `wait_for` and `async_group_copy` use the same group.
 
 `wait_for` will block until all the asychronous copies represented by the
-`device_event` arguments are complete. Data written to a location by `async_group_copy`
-should not be read until `wait_for` has been called with the returned
-`device_event`. `wait_for` will also act as a group barrier to ensure memory
-consistency between the work-items of the group.
+`async_copy_event` arguments are complete. Copies performed with `async_group_copy`
+are not guaranteed to be complete until `wait_for` has been called with the returned
+`async_copy_event`, so the data cannot be read reliably before that. `wait_for` will also act
+as a group barrier to ensure memory consistency between the work-items of the group.
 
 `wait_for` is a free function with the following properties:
 
-* The group should be the same as the group used in all invocations of
-  `async_group_copy` that returned the `device_event` arguments or the behaviour is undefined.
 * All work-items of the group are required to call the function in convergent
   control flow, otherwise the behaviour is undefined.
+* All instances of `eventTN` are of template type `async_copy_event` with the same specialization.
 
-
-NOTE: For NVIDIA architectures of sm_80 or higher, the group will be blocked until all
-outstanding async_group_copy requests are completed.
 
 ```c++
 namespace sycl::ext::oneapi::experimental {
-    template <typename Group, typename eventTN>
-    void wait_for(Group group, eventTN... Events) noexcept;
+template <typename group, typename... eventTN>
+std::enable_if_t<(std::is_same_v<eventTN,async_copy_event<group>> && ...)> wait_for(eventTN... Events);
 }  // namespace sycl
 ```
 

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -23,6 +23,7 @@
 Copyright (c) 2021-2021 Intel Corporation.  All rights reserved.
 
 IMPORTANT: This specification is a draft.
+
 NOTE: The APIs described in this specification are experimental. Future versions of this extension may change these APIs in ways that are incompatible with the versions described here.
 
 NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -23,6 +23,7 @@
 Copyright (c) 2021-2021 Intel Corporation.  All rights reserved.
 
 IMPORTANT: This specification is a draft.
+IMPORTANT: This specification is experimental.
 
 NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are
 trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc.
@@ -73,7 +74,7 @@ overhead than a simple synchronous implementation in some cases.
 
 `async_group_copy` will asynchronously copy a given number of values of type
 `dataT` from global memory to local memory or from local memory to global
-memory. If an asynchorous copy is not supported then `async_group_copy` will
+memory. If an asynchronous copy is not supported then `async_group_copy` will
 fall back on a synchronous copy. `async_group_copy` is a free function with the
 following properties:
 
@@ -91,11 +92,12 @@ following properties:
 The structs `dest_stride` and `src_stride` have been introduced to reduce errors
 when specifying the stride.
 
-Note that the destination and source arguments have been swapped to be more in
-line with other SYCL copy functions.
+NOTE: The order of the destination and source arguments differs from the SYCL
+1.2.1 `async_work_group_copy` function to be more in line with other copy
+functions in SYCL 2020.
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
 
 struct dest_stride {
        std::size_t value;
@@ -116,7 +118,7 @@ device_event async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src,
 
 template <typename Group, typename dataT>
 device_event async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count, src_stride srcStride);
-} // namespace sycl::ext::oneapi
+} // namespace sycl::ext::oneapi::experimental
 ```
 
 ## New `wait_for` function
@@ -142,7 +144,7 @@ NOTE: For NVIDIA architectures of sm_80 or higher, the group will be blocked unt
 outstanding async_group_copy requests are completed.
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
     template <typename Group, typename eventTN>
     void wait_for(Group group, eventTN... Events) noexcept;
 }  // namespace sycl

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -23,7 +23,7 @@
 Copyright (c) 2021-2021 Intel Corporation.  All rights reserved.
 
 IMPORTANT: This specification is a draft.
-IMPORTANT: This specification is experimental.
+NOTE: The APIs described in this specification are experimental. Future versions of this extension may change these APIs in ways that are incompatible with the versions described here.
 
 NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are
 trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc.

--- a/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
+++ b/sycl/doc/extensions/AsyncGroupCopy/async_group_copy.asciidoc
@@ -82,11 +82,11 @@ fall back on a synchronous copy.
 to block until the copy has completed.
 
 When copying from global memory to local memory an optional stride, `src_stride`,
-can be provided. For 0 <= i < `count`, the value copied to dest[i] will be
+can be provided. For 0 &le; i &lt; `count`, the value copied to dest[i] will be
 src[i*`src_stride`]. 
 
 When copying from local memory to global memory an optional stride, `dest_stride`,
-can be provided. For 0 <= i < `count`, the value located at src[i] will be
+can be provided. For 0 &le; i &lt; `count`, the value located at src[i] will be
 copied to dest[i*`dest_stride`]. 
 
 `async_group_copy` is a free function with the
@@ -100,7 +100,7 @@ following properties:
   arguments, otherwise the behaviour is undefined.
 * All work-items of the group are required to call the function in convergent
   control flow, otherwise the behaviour is undefined.
-* The type of `dataT` must be trivially copyable as defined by the C++ core language.
+* The type of `dataT` must be trivially copyable as defined by the C++ core language or a specialization of `sycl::vec`.
 * The copy is only guaranteed to be complete after `wait_for` has been called on the
   returned `async_copy_event` and has completed.
 * `src_stride` and `dst_stride` must be non-zero `size_t` values.
@@ -134,16 +134,16 @@ struct src_stride {
 };
 
 template <typename Group, typename dataT>
-async_copy_event<Group> async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count);
+async_copy_event<Group> async_group_copy(Group group, sycl::local_ptr<dataT> src, sycl::global_ptr<dataT> dest, size_t count);
 
 template <typename Group, typename dataT>
-async_copy_event<Group> async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count);
+async_copy_event<Group> async_group_copy(Group group, sycl::global_ptr<dataT> src, sycl::local_ptr<dataT> dest, size_t count);
 
 template <typename Group, typename dataT>
-async_copy_event<Group> async_group_copy(Group group, sycl::decorated_local_ptr<dataT> src, sycl::decorated_global_ptr<dataT> dest, size_t count, dest_stride destStride);
+async_copy_event<Group> async_group_copy(Group group, sycl::local_ptr<dataT> src, sycl::global_ptr<dataT> dest, size_t count, dest_stride destStride);
 
 template <typename Group, typename dataT>
-async_copy_event<Group> async_group_copy(Group group, sycl::decorated_global_ptr<dataT> src, sycl::decorated_local_ptr<dataT> dest, size_t count, src_stride srcStride);
+async_copy_event<Group> async_group_copy(Group group, sycl::global_ptr<dataT> src, sycl::local_ptr<dataT> dest, size_t count, src_stride srcStride);
 } // namespace sycl::ext::oneapi::experimental
 ```
 
@@ -163,14 +163,27 @@ as a group barrier to ensure memory consistency between the work-items of the gr
 * All work-items of the group are required to call the function in convergent
   control flow, otherwise the behaviour is undefined.
 * All instances of `eventTN` are of template type `async_copy_event` with the same specialization.
+* All work-items of the group are required to call the function with `async_copy_event` arguments representing the same copies, in the same order, otherwise the behaviour is undefined.
 
 
 ```c++
 namespace sycl::ext::oneapi::experimental {
-template <typename group, typename... eventTN>
-std::enable_if_t<(std::is_same_v<eventTN,async_copy_event<group>> && ...)> wait_for(eventTN... Events);
+template <typename Group, typename... eventT>
+std::enable_if_t<sycl::is_group_v<Group> &&
+(std::is_same_v<eventT, async_copy_event<Group>> && ...)>
+wait_for(Group, eventT... Events);
 }  // namespace sycl
 ```
+
+## Issues
+
+1. Implementing asynchronous copies for trivially copyable types that do not fit with SPIR-Vs OpGroupAsyncCopy.
+
+NOTE: When using a stride other than 1, the size of the type must be known so the spacing between the values can be calculated. OpGroupAsyncCopy provides no way with to specify the size of the type so if the data cannot be reinterpreted as a scalar or vector of integer type or floating-point type then the type cannot be used with OpGroupAsyncCopy.
+
+*RESOLUTION*: Fall back on a synchronous copy.
+
+NOTE: A SPIR-V extension could be proposed that will add an instruction for asynchronous copy of trivally copyable types of arbitrary shape (size in bytes).
 
 ## Revision History
 


### PR DESCRIPTION
This proposal generalizes `async_work_group_copy` from the `nd_item` and `group` classes, so it can be used with sub groups.

Implementation at #4907 and accompanying tests at intel/llvm-test-suite#552

Signed-off-by: Finlay Marno finlay.marno@codeplay.com