### PR TITLE
[SYCL] Move cl::sycl::atomic_ref into the sycl:: namespace

### DIFF
--- a/sycl/include/CL/sycl/atomic_ref.hpp
+++ b/sycl/include/CL/sycl/atomic_ref.hpp
@@ -22,7 +22,6 @@
 #endif
 #include <type_traits>
 
-__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
 
@@ -673,4 +672,3 @@ public:
 };
 
 } // namespace sycl
-} // __SYCL_INLINE_NAMESPACE(cl)


### PR DESCRIPTION
This fix the following issue: the SYCL 2020 specification defines
the atomic_ref template class in the sycl:: namespace, not in the
cl::sycl:: one.