### PR TITLE
[SYCL][NFC] Clean up test behavior dependent on device objects and target arch

### DIFF
--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -194,7 +194,6 @@
 // RUN:   | FileCheck -DARCH=spir64_fpga -check-prefixes=CHK-UNUSED-ARG-WARNING,CHK-TARGET %s
 // CHK-UNUSED-ARG-WARNING-NOT: clang{{.*}} warning: argument unused during compilation: '-Xsycl-target-frontend={{.*}} -DFOO'
 // CHK-TARGET: clang{{.*}} "-cc1" "-triple" "[[ARCH]]-unknown-unknown"{{.*}} "-D" "FOO"
-// CHK-TARGET: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-[[ARCH]]-unknown-unknown"
 
 /// ###########################################################################
 

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -1137,7 +1137,7 @@
 // CHK-INCOMPATIBILITY: error: The option -fsycl conflicts with -ffreestanding
 
 /// Using -fsyntax-only with -fsycl should not emit IR
-// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsyntax-only %s 2>&1 \
+// RUN:   %clang -### -fsycl -fsyntax-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-FSYNTAX-ONLY,CHK-NO-EMIT-IR %s
-// CHK-FSYNTAX-ONLY: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"{{.*}} "-fsyntax-only"
+// CHK-FSYNTAX-ONLY: clang{{.*}} "-cc1" "-triple" "spir{{.*}}-unknown-unknown"{{.*}} "-fsyntax-only"
 // CHK-NO-EMIT-IR-NOT: "-emit-llvm-bc"

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -1138,6 +1138,8 @@
 
 /// Using -fsyntax-only with -fsycl should not emit IR
 // RUN:   %clang -### -fsycl -fsyntax-only %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=CHK-FSYNTAX-ONLY,CHK-NO-EMIT-IR %s
-// CHK-FSYNTAX-ONLY: clang{{.*}} "-cc1" "-triple" "spir{{.*}}-unknown-unknown"{{.*}} "-fsyntax-only"
-// CHK-NO-EMIT-IR-NOT: "-emit-llvm-bc"
+// RUN:   | FileCheck -check-prefixes=CHK-FSYNTAX-ONLY %s
+// RUN:   %clang -### -fsycl -fsycl-device-only -fsyntax-only %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=CHK-FSYNTAX-ONLY %s
+// CHK-FSYNTAX-ONLY-NOT: "-emit-llvm-bc"
+// CHK-FSYNTAX-ONLY: "-fsyntax-only"

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -1137,7 +1137,7 @@
 // CHK-INCOMPATIBILITY: error: The option -fsycl conflicts with -ffreestanding
 
 /// Using -fsyntax-only with -fsycl should not emit IR
-// RUN:   %clang -### -fsycl -fsyntax-only %s 2>&1 \
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsyntax-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-FSYNTAX-ONLY,CHK-NO-EMIT-IR %s
 // CHK-FSYNTAX-ONLY: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"{{.*}} "-fsyntax-only"
 // CHK-NO-EMIT-IR-NOT: "-emit-llvm-bc"


### PR DESCRIPTION
Clean up sycl-offload.c test that is expecting device objects to be
built.  The check being performed here is for passing along of
-Xsycl-target-fronted options, so the check for an unbundle is not
necessary.