### PR TITLE
[SYCL] Fix memory leak in online compiler

### DIFF
--- a/sycl/source/detail/online_compiler/online_compiler.cpp
+++ b/sycl/source/detail/online_compiler/online_compiler.cpp
@@ -160,16 +160,13 @@ compileToSPIRV(const std::string &Source, sycl::info::device_type DeviceType,
                       &SourceName, 0, nullptr, nullptr, nullptr, &NumOutputs,
                       &Outputs, &OutputLengths, &OutputNames);
 
-  byte *SpirV = nullptr;
+  std::vector<byte> SpirV;
   std::string CompileLog;
-  size_t SpirVSize = 0;
   for (uint32_t I = 0; I < NumOutputs; I++) {
     size_t NameLen = strlen(OutputNames[I]);
     if (NameLen >= 4 && strstr(OutputNames[I], ".spv") != nullptr &&
         Outputs[I] != nullptr) {
-      SpirVSize = OutputLengths[I];
-      SpirV = new byte[SpirVSize];
-      std::memcpy(SpirV, Outputs[I], SpirVSize);
+      SpirV = std::vector<byte>(Outputs[I], Outputs[I] + OutputLengths[I]);
     } else if (!strcmp(OutputNames[I], "stdout.log")) {
       CompileLog = std::string(reinterpret_cast<const char *>(Outputs[I]));
     }
@@ -184,13 +181,13 @@ compileToSPIRV(const std::string &Source, sycl::info::device_type DeviceType,
   if (CompileError)
     throw online_compile_error("ocloc reported compilation errors: {\n" +
                                CompileLog + "\n}");
-  if (!SpirV)
+  if (SpirV.empty())
     throw online_compile_error(
         "Unexpected output: ocloc did not return SPIR-V");
   if (MemFreeError)
     throw online_compile_error("ocloc cannot safely free resources");
 
-  return std::vector<byte>(SpirV, SpirV + SpirVSize);
+  return SpirV;
 }
 } // namespace detail
 

--- a/sycl/source/detail/online_compiler/online_compiler.cpp
+++ b/sycl/source/detail/online_compiler/online_compiler.cpp
@@ -166,6 +166,7 @@ compileToSPIRV(const std::string &Source, sycl::info::device_type DeviceType,
     size_t NameLen = strlen(OutputNames[I]);
     if (NameLen >= 4 && strstr(OutputNames[I], ".spv") != nullptr &&
         Outputs[I] != nullptr) {
+      assert(SpirV.size() == 0 && "More than one SPIR-V output found.");
       SpirV = std::vector<byte>(Outputs[I], Outputs[I] + OutputLengths[I]);
     } else if (!strcmp(OutputNames[I], "stdout.log")) {
       CompileLog = std::string(reinterpret_cast<const char *>(Outputs[I]));


### PR DESCRIPTION
The experimental online compiler may leak memory in compileToSPIRV. These changes address this leak by storing the SPIR-V binary information directly in the vector that will later be returned.