### PR TITLE
[SYCL] Fix sycl::span type deduction

### DIFF
--- a/sycl/include/CL/sycl/sycl_span.hpp
+++ b/sycl/include/CL/sycl/sycl_span.hpp
@@ -608,7 +608,8 @@ as_writable_bytes(span<_Tp, _Extent> __s) noexcept
 }
 
 //  Deduction guides
-template <class _Tp, size_t _Sz> span(_Tp (&)[_Sz])->span<_Tp, _Sz>;
+template <class _Tp, size_t _Sz>
+span(_Tp (&)[_Sz]) -> span<_Tp, dynamic_extent>;
 
 template <class _Tp, size_t _Sz> span(std::array<_Tp, _Sz> &)->span<_Tp, _Sz>;
 

--- a/sycl/include/CL/sycl/sycl_span.hpp
+++ b/sycl/include/CL/sycl/sycl_span.hpp
@@ -608,6 +608,9 @@ as_writable_bytes(span<_Tp, _Extent> __s) noexcept
 }
 
 //  Deduction guides
+
+// array arg deduction guide. dynamic_extent arg used solely to select
+// the correct template. The _Sz will be used as Extent template value.
 template <class _Tp, size_t _Sz>
 span(_Tp (&)[_Sz]) -> span<_Tp, dynamic_extent>;
 

--- a/sycl/include/CL/sycl/sycl_span.hpp
+++ b/sycl/include/CL/sycl/sycl_span.hpp
@@ -609,8 +609,8 @@ as_writable_bytes(span<_Tp, _Extent> __s) noexcept
 
 //  Deduction guides
 
-// array arg deduction guide. dynamic_extent arg used solely to select
-// the correct template. The _Sz will be used as Extent template value.
+// array arg deduction guide. dynamic_extent arg used to select
+// the correct template. The _Sz will be used for the __size of the span.
 template <class _Tp, size_t _Sz>
 span(_Tp (&)[_Sz]) -> span<_Tp, dynamic_extent>;
 


### PR DESCRIPTION
The sycl::span does not correctly deduce the type from an array argument.  Here we fix this by adjusting the deduction guide to select the correct specialization (that has array support). The tests on llvm-test-suite are being updated as well. ( https://github.com/intel/llvm-test-suite/pull/572 )

Signed-off-by: Chris Perkins <chris.perkins@intel.com>