### PR TITLE
[SYCL] Allow ::printf only for CUDA

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -410,8 +410,11 @@ static bool IsSyclMathFunc(unsigned BuiltinID) {
 bool Sema::isKnownGoodSYCLDecl(const Decl *D) {
   if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
     const IdentifierInfo *II = FD->getIdentifier();
-    if (FD->getBuiltinID() == Builtin::BIprintf)
-      return true;
+    // Allow to use `::printf` only for CUDA.
+    if (Context.getTargetInfo().getTriple().isNVPTX()) {
+      if (FD->getBuiltinID() == Builtin::BIprintf)
+        return true;
+    }
     const DeclContext *DC = FD->getDeclContext();
     if (II && II->isStr("__spirv_ocl_printf") &&
         !FD->isDefined() &&

--- a/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
@@ -47,6 +47,8 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc(); //expected-note 2+ {{called by 'kernel_single_task}}
 }
 
+extern "C" int printf(const char* fmt, ...);
+
 int main() {
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
   kernel_single_task<class fake_kernel>([]() { foo(6); });
@@ -58,6 +60,10 @@ int main() {
   kernel_single_task<class fake_kernel>([]() { A::__spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
   kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
+
+  // Check that default printf is not allowed.
+  //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  kernel_single_task<class fake_kernel>([]() { printf("Hello world! %d%d\n", 4, 2); });
 #elif defined(PRINTF_INVALID_DEF)
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
   kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });

--- a/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
@@ -47,7 +47,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc(); //expected-note 2+ {{called by 'kernel_single_task}}
 }
 
-extern "C" int printf(const char* fmt, ...);
+extern "C" int printf(const char *fmt, ...);
 
 int main() {
   //expected-error@+1 {{SYCL kernel cannot call a variadic function}}


### PR DESCRIPTION
`printf` built-in as-is won't be properly converted into SPIR-V and will cause
JIT compilation errors in OpenCL backends.