### PR TITLE
[SYCL][LIBCLC] Add double version of sin/cos.

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/math/cos.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/math/cos.cl
@@ -8,7 +8,15 @@
 
 #include <spirv/spirv.h>
 
+float __ocml_cos_f32(float);
+double __ocml_cos_f64(double);
+
 _CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_fp32_t
 __spirv_ocl_cos(__clc_fp32_t In) {
-  return __builtin_amdgcn_cosf(In);
+  return __ocml_cos_f32(In);
+}
+
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_fp64_t
+__spirv_ocl_cos(__clc_fp64_t In) {
+  return __ocml_cos_f64(In);
 }

--- a/libclc/amdgcn-amdhsa/libspirv/math/sin.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/math/sin.cl
@@ -8,7 +8,15 @@
 
 #include <spirv/spirv.h>
 
+float __ocml_sin_f32(float);
+double __ocml_sin_f64(double);
+
 _CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_fp32_t
 __spirv_ocl_sin(__clc_fp32_t In) {
-  return __builtin_amdgcn_sinf(In);
+  return __ocml_sin_f32(In);
+}
+
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_fp64_t
+__spirv_ocl_sin(__clc_fp64_t In) {
+  return __ocml_sin_f64(In);
 }


### PR DESCRIPTION
Also fix the float variant, avoid using the builtin as it boils down to
the vector variant of the instruction and is not fit for the purpose.

This is to unblock work, while https://github.com/intel/llvm/pull/4864 is reviewed.