### PR TITLE
Add SYCL 2020 info::device::built_in_kernel_ids support

### DIFF
--- a/sycl/include/CL/sycl/info/device_traits.def
+++ b/sycl/include/CL/sycl/info/device_traits.def
@@ -58,6 +58,7 @@ __SYCL_PARAM_TRAITS_SPEC(device, is_linker_available, bool)
 __SYCL_PARAM_TRAITS_SPEC(device, execution_capabilities,
                   std::vector<info::execution_capability>)
 __SYCL_PARAM_TRAITS_SPEC(device, queue_profiling, bool)
+__SYCL_PARAM_TRAITS_SPEC(device, built_in_kernel_ids, std::vector<kernel_id>)
 __SYCL_PARAM_TRAITS_SPEC(device, built_in_kernels, std::vector<std::string>)
 __SYCL_PARAM_TRAITS_SPEC(device, platform, cl::sycl::platform)
 __SYCL_PARAM_TRAITS_SPEC(device, name, std::string)

--- a/sycl/include/CL/sycl/info/info_desc.hpp
+++ b/sycl/include/CL/sycl/info/info_desc.hpp
@@ -20,6 +20,7 @@ class program;
 #endif
 class device;
 class platform;
+class kernel_id;
 
 // TODO: stop using OpenCL directly, use PI.
 namespace info {
@@ -109,7 +110,8 @@ enum class device : cl_device_info {
   is_linker_available = CL_DEVICE_LINKER_AVAILABLE,
   execution_capabilities = CL_DEVICE_EXECUTION_CAPABILITIES,
   queue_profiling = CL_DEVICE_QUEUE_PROPERTIES,
-  built_in_kernels = CL_DEVICE_BUILT_IN_KERNELS,
+  built_in_kernels __SYCL2020_DEPRECATED("use built_in_kernel_ids instead") =
+      CL_DEVICE_BUILT_IN_KERNELS,
   platform = CL_DEVICE_PLATFORM,
   name = CL_DEVICE_NAME,
   vendor = CL_DEVICE_VENDOR,
@@ -136,6 +138,7 @@ enum class device : cl_device_info {
   sub_group_sizes = CL_DEVICE_SUB_GROUP_SIZES_INTEL,
   partition_type_property,
   kernel_kernel_pipe_support,
+  built_in_kernel_ids,
   // USM
   usm_device_allocations = PI_USM_DEVICE_SUPPORT,
   usm_host_allocations = PI_USM_HOST_SUPPORT,

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -10,6 +10,7 @@
 
 #include <CL/sycl/aspects.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/kernel_bundle.hpp>
 #include <CL/sycl/stl.hpp>
 #include <detail/device_info.hpp>
 #include <detail/platform_impl.hpp>

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -178,6 +178,10 @@ public:
   // in SYCL device images.
   std::vector<kernel_id> getAllSYCLKernelIDs();
 
+  // The function returns the unique SYCL kernel identifier associated with a
+  // built-in kernel name.
+  kernel_id getBuiltInKernelID(const std::string &KernelName);
+
   // The function returns a vector of SYCL device images that are compiled with
   // the required state and at least one device from the passed list of devices.
   std::vector<device_image_plain>
@@ -326,6 +330,13 @@ private:
   // from kernel bundles.
   /// Access must be guarded by the m_KernelIDsMutex mutex.
   std::unordered_set<std::string> m_ExportedSymbols;
+
+  /// Maps names of built-in kernels to their unique kernel IDs.
+  /// Access must be guarded by the m_BuiltInKernelIDsMutex mutex.
+  std::unordered_map<std::string, kernel_id> m_BuiltInKernelIDs;
+
+  /// Protects built-in kernel ID cache.
+  std::mutex m_BuiltInKernelIDsMutex;
 
   // Keeps track of pi_program to image correspondence. Needed for:
   // - knowing which specialization constants are used in the program and

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -134,6 +134,10 @@ int main() {
   auto MCA = sycl::info::device::max_constant_args;
   (void)MCA;
 
+  // expected-warning@+1{{'built_in_kernels' is deprecated: use built_in_kernel_ids instead}}
+  auto BIK = sycl::info::device::built_in_kernels;
+  (void)BIK;
+
   // expected-warning@+1{{'extensions' is deprecated: platform::extensions is deprecated, use device::get_info() with info::device::aspects instead.}}
   auto PE = sycl::info::platform::extensions;
 


### PR DESCRIPTION
- Add `ProgramManager::getBuiltInKernelID`, which generates and caches built-in kernel IDs.
- Use that API to generate or look up built-in kernel IDs, when queried.
- Throw an exception in program manager when actually trying to use built-in kernels, since they are not yet fully supported.
- Add SYCL 2020 deprecation warning for `built_in_kernels` (old query).