### PR TITLE
[libclc] Delete the wrong name in the SOURCE file, and add a new file

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/SOURCES
+++ b/libclc/amdgcn-amdhsa/libspirv/SOURCES
@@ -23,13 +23,11 @@ math/expm1.cl
 math/fabs.cl
 math/fdim.cl
 math/floor.cl
-math/fma.cl
 math/fmax.cl
 math/fmin.cl
 math/fmod.cl
 math/frexp.cl
 math/hypot.cl
-math/ilogb.cl
 math/ldexp.cl
 math/lgamma.cl
 math/log.cl

--- a/libclc/amdgcn-amdhsa/libspirv/math/ldexp.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/math/ldexp.cl
@@ -14,11 +14,6 @@
 double __ocml_ldexp_f64(double, int);
 float __ocml_ldexp_f32(float, int);
 
-#define __CLC_FUNCTION __spirv_ocl_ldexp
-#define __CLC_BUILTIN __ocml_ldexp
-#define __CLC_BUILTIN_F __CLC_XCONCAT(__CLC_BUILTIN, _f32)
-#define __CLC_BUILTIN_D __CLC_XCONCAT(__CLC_BUILTIN, _f64)
-
 _CLC_DEFINE_BINARY_BUILTIN(float, __spirv_ocl_ldexp, __ocml_ldexp_f32, float, int)
 _CLC_DEFINE_BINARY_BUILTIN(float, __spirv_ocl_ldexp, __ocml_ldexp_f32, float, uint)
 

--- a/libclc/amdgcn-amdhsa/libspirv/math/sinh.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/math/sinh.cl
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <clcmacro.h>
+#include <spirv/spirv.h>
+ 
+double __ocml_sinh_f64(double);
+float __ocml_sinh_f32(float);
+ 
+#define __CLC_FUNCTION __spirv_ocl_sinh
+#define __CLC_BUILTIN __ocml_sinh
+#define __CLC_BUILTIN_F __CLC_XCONCAT(__CLC_BUILTIN, _f32)
+#define __CLC_BUILTIN_D __CLC_XCONCAT(__CLC_BUILTIN, _f64)
+#include <math/unary_builtin.inc>
+


### PR DESCRIPTION
Remove the unimplemented file name in the SOURCE file: ‘ilogb’ and 'fma'. At the same time, I added the sinh.cl file to ensure correct compilation.In addition, I deleted the redundant code in ‘ldexp’.