### PR TITLE
[SYCL][NFC] Update tests for device split code mode

### DIFF
--- a/clang/test/Driver/sycl-offload-with-split.c
+++ b/clang/test/Driver/sycl-offload-with-split.c
@@ -310,7 +310,7 @@
 // RUN:    | FileCheck %s -check-prefixes=CHK-NO-SPLIT
 // RUN:   %clang_cl -### -fsycl -fsycl-device-code-split -fsycl-device-code-split=off %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefixes=CHK-NO-SPLIT
-// CHK-NO-SPLIT-NOT: sycl-post-link{{.*}} -split{{.*}}
+// CHK-NO-SPLIT-NOT: sycl-post-link{{.*}} "-split={{.*}}
 
 // Check no device code split mode is passed to sycl-post-link when -fsycl-device-code-split is not set and the target is FPGA
 // RUN:   %clang -### -fsycl -fsycl-targets=spir64_fpga-unknown-unknown %s 2>&1 | FileCheck %s -check-prefixes=CHK-NO-SPLIT


### PR DESCRIPTION
CHK-NO-SPLIT-NOT is not able to actually validate tests due to defect
in the pattern.
Update the macro to make it work effectively.

Signed-off-by: Qichao Gu <qichao.gu@intel.com>