### PR TITLE
[WIP][SYCL] Make sycl-post-link process split modules sequentially, simplify.

### DIFF
--- a/llvm/include/llvm/Support/SimpleTable.h
+++ b/llvm/include/llvm/Support/SimpleTable.h
@@ -81,6 +81,7 @@ public:
 
 public:
   SimpleTable() = default;
+  SimpleTable(ArrayRef<StringRef> ColNames);
   static Expected<UPtrTy> create(ArrayRef<StringRef> ColNames);
   static Expected<UPtrTy> create(int NColumns);
   int getNumColumns() const { return static_cast<int>(ColumnNames.size()); }

--- a/llvm/lib/Support/SimpleTable.cpp
+++ b/llvm/lib/Support/SimpleTable.cpp
@@ -38,6 +38,15 @@ StringRef SimpleTable::Row::getCell(StringRef ColName,
   return (I >= 0) ? Cells[I] : DefaultVal;
 }
 
+SimpleTable::SimpleTable(ArrayRef<StringRef> ColNames) {
+  for (auto N : ColNames)
+    if (Error Err = addColumnName(N)) {
+      constexpr char Msg[] = "SimpleTable::SimpleTable internal error";
+      assert(false && Msg);
+      throw Msg;
+    }
+}
+
 Expected<SimpleTable::UPtrTy>
 SimpleTable::create(ArrayRef<StringRef> ColNames) {
   auto Res = std::make_unique<SimpleTable>();

--- a/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/spec_const_and_split.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/spec_const_and_split.ll
@@ -55,5 +55,6 @@ define dso_local spir_kernel void @KERNEL_CCC() {
 ; CHECK-PROP1: SpecConst=2|
 ; CHECK-PROP1-NOT: SpecConst2
 ;
-; CHECK-PROP2: [SYCL/specialization constants]
-; CHECK-PROP2: [SYCL/specialization constants default values]
+; There are no specialization constants in module 2 (created for KERNEL_CCC):
+; CHECK-PROP2-NOT: [SYCL/specialization constants]
+; CHECK-PROP2-NOT: [SYCL/specialization constants default values]

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-esimd-split-per-kernel.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-esimd-split-per-kernel.ll
@@ -1,9 +1,9 @@
 ; RUN: sycl-post-link -split-esimd -split=kernel -S %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table
-; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-SYCL-IR-0
-; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-SYCL-IR-1
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-ESIMD-IR-0
 ; RUN: FileCheck %s -input-file=%t_esimd_1.ll --check-prefixes CHECK-ESIMD-IR-1
+; RUN: FileCheck %s -input-file=%t_2.ll --check-prefixes CHECK-SYCL-IR-0
+; RUN: FileCheck %s -input-file=%t_3.ll --check-prefixes CHECK-SYCL-IR-1
 
 ; This test checks that after we split SYCL and ESIMD kernels into
 ; separate modules, we split those two modules further according to
@@ -52,10 +52,10 @@ attributes #1 = { "sycl-module-id"="a.cpp" }
 !3 = !{}
 
 ; CHECK: [Code|Properties]
-; CHECK: {{.*}}_0.ll|{{.*}}_0.prop
-; CHECK: {{.*}}_1.ll|{{.*}}_1.prop
 ; CHECK: {{.*}}_esimd_0.ll|{{.*}}_esimd_0.prop
 ; CHECK: {{.*}}_esimd_1.ll|{{.*}}_esimd_1.prop
+; CHECK: {{.*}}_2.ll|{{.*}}_2.prop
+; CHECK: {{.*}}_3.ll|{{.*}}_3.prop
 
 ; CHECK-SYCL-IR-0-DAG: define dso_local spir_kernel void @SYCL_kernel1()
 ; CHECK-SYCL-IR-0-DAG: declare dso_local spir_func i64 @_Z28__spirv_GlobalInvocationId_xv()


### PR DESCRIPTION
- Split module extraction is now done sequentially, not keeping all
  modules resulting from split alive in RAM.
- Post link actions are separated into clear parts simplifying the logic
- Initial support for keeping SYCL and ESIMD code in the same module, needed
  for invoke_simd.
- Add convenience constructor to SimpleTable.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>