### PR TITLE
[XPTI][SYCL] Minor fixes to CMakeLists.txt

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -126,12 +126,10 @@ string(REPLACE "${sycl_inc_dir}" "${SYCL_INCLUDE_BUILD_DIR}"
 # Copy SYCL headers from sources to build directory
 add_custom_target(sycl-headers
   DEPENDS ${OUT_HEADERS_IN_SYCL_DIR}
-          ${SYCL_INCLUDE_BUILD_DIR}/sycl/sycl.hpp
           ${OUT_HEADERS_IN_CL_DIR})
 
 add_custom_command(
   OUTPUT  ${OUT_HEADERS_IN_SYCL_DIR}
-          ${SYCL_INCLUDE_BUILD_DIR}/sycl/sycl.hpp
           ${OUT_HEADERS_IN_CL_DIR}
   DEPENDS ${HEADERS_IN_SYCL_DIR}
           ${HEADERS_IN_CL_DIR}

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -118,17 +118,21 @@ configure_file("${feature_header}.in" "${feature_header}")
 # TODO: detect and process remove header/directory case
 file(GLOB_RECURSE HEADERS_IN_SYCL_DIR CONFIGURE_DEPENDS "${sycl_inc_dir}/sycl/*")
 file(GLOB_RECURSE HEADERS_IN_CL_DIR CONFIGURE_DEPENDS "${sycl_inc_dir}/CL/*")
+string(REPLACE "${sycl_inc_dir}" "${SYCL_INCLUDE_BUILD_DIR}"
+  OUT_HEADERS_IN_SYCL_DIR "${HEADERS_IN_SYCL_DIR}")
+string(REPLACE "${sycl_inc_dir}" "${SYCL_INCLUDE_BUILD_DIR}"
+  OUT_HEADERS_IN_CL_DIR "${HEADERS_IN_CL_DIR}")
 
 # Copy SYCL headers from sources to build directory
 add_custom_target(sycl-headers
-  DEPENDS ${SYCL_INCLUDE_BUILD_DIR}/sycl
+  DEPENDS ${OUT_HEADERS_IN_SYCL_DIR}
           ${SYCL_INCLUDE_BUILD_DIR}/sycl/sycl.hpp
-          ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL)
+          ${OUT_HEADERS_IN_CL_DIR})
 
 add_custom_command(
-  OUTPUT  ${SYCL_INCLUDE_BUILD_DIR}/sycl
+  OUTPUT  ${OUT_HEADERS_IN_SYCL_DIR}
           ${SYCL_INCLUDE_BUILD_DIR}/sycl/sycl.hpp
-          ${SYCL_INCLUDE_BUILD_DIR}/sycl/CL
+          ${OUT_HEADERS_IN_CL_DIR}
   DEPENDS ${HEADERS_IN_SYCL_DIR}
           ${HEADERS_IN_CL_DIR}
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${sycl_inc_dir}/sycl ${SYCL_INCLUDE_BUILD_DIR}/sycl

--- a/xpti/CMakeLists.txt
+++ b/xpti/CMakeLists.txt
@@ -79,10 +79,7 @@ add_subdirectory(src)
 if (LLVM_BINARY_DIR)
   file(GLOB_RECURSE XPTI_HEADERS_LIST CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/xpti/*")
   add_custom_target(xpti-headers
-    DEPENDS ${LLVM_BINARY_DIR}/include/xpti)
-
-  add_custom_command(
-    OUTPUT  ${LLVM_BINARY_DIR}/include/xpti
+    BYPRODUCTS ${LLVM_BINARY_DIR}/include/xpti
     DEPENDS ${XPTI_HEADERS_LIST}
     COMMAND ${CMAKE_COMMAND} -E copy_directory
       ${CMAKE_CURRENT_SOURCE_DIR}/include/xpti

--- a/xpti/CMakeLists.txt
+++ b/xpti/CMakeLists.txt
@@ -78,8 +78,13 @@ add_subdirectory(src)
 
 if (LLVM_BINARY_DIR)
   file(GLOB_RECURSE XPTI_HEADERS_LIST CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/xpti/*")
+  string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${LLVM_BINARY_DIR}"
+    XPTI_HEADERS_OUT_LIST "${XPTI_HEADERS_LIST}")
   add_custom_target(xpti-headers
-    BYPRODUCTS ${LLVM_BINARY_DIR}/include/xpti
+    DEPENDS ${XPTI_HEADERS_OUT_LIST})
+
+  add_custom_command(
+    OUTPUT  ${XPTI_HEADERS_OUT_LIST}
     DEPENDS ${XPTI_HEADERS_LIST}
     COMMAND ${CMAKE_COMMAND} -E copy_directory
       ${CMAKE_CURRENT_SOURCE_DIR}/include/xpti

--- a/xptifw/unit_test/CMakeLists.txt
+++ b/xptifw/unit_test/CMakeLists.txt
@@ -38,7 +38,7 @@ if (NOT DEFINED LLVM_EXTERNAL_XPTIFW_SOURCE_DIR)
   endif()
 endif()
 
-add_executable(XPTIFWUnitTests
+add_executable(XPTIFWUnitTests EXCLUDE_FROM_ALL
   xpti_api_tests.cpp
   xpti_correctness_tests.cpp
 )


### PR DESCRIPTION
Improve headers copying mechanisms and exclude XPTI unit tests from all targets by default.