### PR TITLE
[SYCL][HIP] Remove arg assert in LowerWGScope

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerWGScope.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerWGScope.cpp
@@ -623,7 +623,9 @@ using CaptureDesc = std::pair<AllocaInst *, GetElementPtrInst *>;
 static void fixupPrivateMemoryPFWILambdaCaptures(CallInst *PFWICall) {
   // Lambda object is always the last argument to the PFWI lambda function:
   auto NArgs = PFWICall->arg_size();
-  assert(PFWICall->arg_size() > 1 && "invalid PFWI call");
+  if (PFWICall->arg_size() == 1)
+    return;
+
   Value *LambdaObj =
       PFWICall->getArgOperand(NArgs - 1 /*lambda object parameter*/);
   // First go through all stores through the LambdaObj pointer - those are
@@ -912,7 +914,7 @@ GlobalVariable *spirv::createWGLocalVariable(Module &M, Type *T,
 // Return a value equals to 0 if and only if the local linear id is 0.
 Value *spirv::genPseudoLocalID(Instruction &Before, const Triple &TT) {
   Module &M = *Before.getModule();
-  if (TT.isNVPTX()) {
+  if (TT.isNVPTX() || TT.isAMDGCN()) {
     LLVMContext &Ctx = Before.getContext();
     Type *RetTy = getSizeTTy(M);
 


### PR DESCRIPTION
This PR removes the assert for `parallel_for_work_items` with one argument. AMD correctly optimises away empty lambda arguments as a result only 1 argument is passed to the parallel_work_itme function. As a result this triggers the assert in `fixupPrivateMemoryPFWILambdaCaptures` as the number of arguments is equal to 1. 

This PR enables tests `SpecConstants/2020/kernel_lambda_with_kernel_handler_arg.cpp` and `SpecConstants/2020/non_native/aot_w_kernel_handler_wo_spec_consts.cpp` for the HIP backend.