### PR TITLE
[LIBCLC] Fix config.h include

### DIFF
--- a/libclc/generic/include/config.h
+++ b/libclc/generic/include/config.h
@@ -20,6 +20,8 @@
  * THE SOFTWARE.
  */
 
+#include <func.h>
+
 _CLC_DECL bool __clc_subnormals_disabled();
 _CLC_DECL bool __clc_fp16_subnormals_supported();
 _CLC_DECL bool __clc_fp32_subnormals_supported();

--- a/libclc/generic/include/config.h
+++ b/libclc/generic/include/config.h
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-#include <func.h>
+#include "func.h"
 
 _CLC_DECL bool __clc_subnormals_disabled();
 _CLC_DECL bool __clc_fp16_subnormals_supported();


### PR DESCRIPTION
This is fixing building libclc for `amdgcn-amdhsa`.

It showed up in the `ldexp.cl` builtin.

The issue is that `_CLC_DECL` is declared in `func.h` and in other files
`config.h` relies on other `func.h` being included first. This is
confusing and error prone so include `func.h` directly in `config.h`
instead.