### PR TITLE
[SYCL] Account for extern "C++" blocks in name validation

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5153,7 +5153,7 @@ bool Util::matchContext(const DeclContext *Ctx,
   }
   return Ctx->isTranslationUnit() ||
          (Ctx->isExternCXXContext() &&
-             Ctx->getEnclosingNamespaceContext()->isTranslationUnit());
+          Ctx->getEnclosingNamespaceContext()->isTranslationUnit());
 }
 
 bool Util::matchQualifiedTypeName(QualType Ty,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5151,7 +5151,9 @@ bool Util::matchContext(const DeclContext *Ctx,
       return false;
     Ctx = Ctx->getParent();
   }
-  return Ctx->isTranslationUnit();
+  return Ctx->isTranslationUnit() ||
+         (Ctx->isExternCXXContext() &&
+             Ctx->getEnclosingNamespaceContext()->isTranslationUnit());
 }
 
 bool Util::matchQualifiedTypeName(QualType Ty,

--- a/clang/test/SemaSYCL/extern_cpp_decl.cpp
+++ b/clang/test/SemaSYCL/extern_cpp_decl.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify -fsyntax-only %s
+
+// Verify that declaration context validation techniques account for
+// header files wrapped in extern "C++" declaration blocks.
+
+// expected-no-diagnostics
+
+extern "C++" {
+#include "Inputs/sycl.hpp"
+}
+
+using namespace cl::sycl;
+
+int main() {
+  accessor<int, 1, access::mode::read_write> ok_acc;
+
+  kernel_single_task<class use_local>(
+      [=]() {
+        ok_acc.use();
+      });
+}


### PR DESCRIPTION
When validating a name declared in scopes such as
cl::sycl::kernel_handler, we were assuming that the top-level
declaration context would be Decl::TranslationUnit.  This is
not the case when the header file is wrapped explicitly in
extern "C++" blocks.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>