### PR TITLE
[SYCL] Re-implement handler::interop_task

### DIFF
--- a/sycl/include/CL/sycl/detail/cg.hpp
+++ b/sycl/include/CL/sycl/detail/cg.hpp
@@ -21,7 +21,6 @@
 #include <CL/sycl/group.hpp>
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/interop_handle.hpp>
-#include <CL/sycl/interop_handler.hpp>
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/nd_item.hpp>
 #include <CL/sycl/range.hpp>
@@ -167,7 +166,7 @@ public:
     CopyUSM = 10,
     FillUSM = 11,
     PrefetchUSM = 12,
-    CodeplayInteropTask = 13,
+    CodeplayInteropTask = 13, // TODO: Use CodeplayHostTask instead
     CodeplayHostTask = 14,
     AdviseUSM = 15,
   };
@@ -451,7 +450,7 @@ public:
   }
 };
 
-class CGInteropTask : public CG {
+/*class CGInteropTask : public CG {
 public:
   std::unique_ptr<InteropTask> MInteropTask;
 
@@ -466,7 +465,7 @@ public:
            std::move(SharedPtrStorage), std::move(Requirements),
            std::move(Events), std::move(loc)),
         MInteropTask(std::move(InteropTask)) {}
-};
+};*/
 
 class CGHostTask : public CG {
 public:

--- a/sycl/include/CL/sycl/detail/cg_types.hpp
+++ b/sycl/include/CL/sycl/detail/cg_types.hpp
@@ -13,7 +13,6 @@
 #include <CL/sycl/group.hpp>
 #include <CL/sycl/id.hpp>
 #include <CL/sycl/interop_handle.hpp>
-#include <CL/sycl/interop_handler.hpp>
 #include <CL/sycl/kernel.hpp>
 #include <CL/sycl/kernel_handler.hpp>
 #include <CL/sycl/nd_item.hpp>
@@ -215,15 +214,6 @@ public:
   // Used to extract captured variables.
   virtual char *getPtr() = 0;
   virtual ~HostKernelBase() = default;
-};
-
-class InteropTask {
-  std::function<void(cl::sycl::interop_handler)> MFunc;
-
-public:
-  InteropTask(std::function<void(cl::sycl::interop_handler)> Func)
-      : MFunc(Func) {}
-  void call(cl::sycl::interop_handler &h) { MFunc(h); }
 };
 
 class HostTask {

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1931,8 +1931,7 @@ public:
   template <typename FuncT>
   __SYCL_DEPRECATED("interop_task() is deprecated, use host_task() instead")
   void interop_task(FuncT Func) {
-
-    MInteropTask.reset(new detail::InteropTask(std::move(Func)));
+    MInteropTask.reset(new detail::HostTask(std::move(Func)));
     setType(detail::CG::CodeplayInteropTask);
   }
 
@@ -2515,8 +2514,10 @@ private:
   /// Storage for lambda/function when using HostTask
   std::unique_ptr<detail::HostTask> MHostTask;
   detail::OSModuleHandle MOSModuleHandle = detail::OSUtil::ExeModuleHandle;
-  // Storage for a lambda or function when using InteropTasks
-  std::unique_ptr<detail::InteropTask> MInteropTask;
+  // Storage for a lambda or function when using old InteropTasks, new HostTask,
+  // required to preserve the object size
+  // TODO remove in the abi break window after removing the interop_task method
+  std::unique_ptr<detail::HostTask> MInteropTask;
   /// The list of events that order this operation.
   std::vector<detail::EventImplPtr> MEvents;
   /// The list of valid SYCL events that need to complete

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2191,34 +2191,37 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return CL_SUCCESS;
   }
-/*  case CG::CGTYPE::CodeplayInteropTask: {
-    const detail::plugin &Plugin = MQueue->getPlugin();
-    CGInteropTask *ExecInterop = (CGInteropTask *)MCommandGroup.get();
-    // Wait for dependencies to complete before dispatching work on the host
-    // TODO: Use a callback to dispatch the interop task instead of waiting for
-    //  the event
-    if (!RawEvents.empty()) {
-      Plugin.call<PiApiKind::piEventsWait>(RawEvents.size(), &RawEvents[0]);
-    }
-    std::vector<interop_handler::ReqToMem> ReqMemObjs;
-    // Extract the Mem Objects for all Requirements, to ensure they are available if
-    // a user ask for them inside the interop task scope
-    const auto& HandlerReq = ExecInterop->MRequirements;
-    std::for_each(std::begin(HandlerReq), std::end(HandlerReq), [&](Requirement* Req) {
-      AllocaCommandBase *AllocaCmd = getAllocaForReq(Req);
-      auto MemArg = reinterpret_cast<pi_mem>(AllocaCmd->getMemAllocation());
-      interop_handler::ReqToMem ReqToMem = std::make_pair(Req, MemArg);
-      ReqMemObjs.emplace_back(ReqToMem);
-    });
+    /*  case CG::CGTYPE::CodeplayInteropTask: {
+        const detail::plugin &Plugin = MQueue->getPlugin();
+        CGInteropTask *ExecInterop = (CGInteropTask *)MCommandGroup.get();
+        // Wait for dependencies to complete before dispatching work on the host
+        // TODO: Use a callback to dispatch the interop task instead of waiting
+      for
+        //  the event
+        if (!RawEvents.empty()) {
+          Plugin.call<PiApiKind::piEventsWait>(RawEvents.size(), &RawEvents[0]);
+        }
+        std::vector<interop_handler::ReqToMem> ReqMemObjs;
+        // Extract the Mem Objects for all Requirements, to ensure they are
+      available if
+        // a user ask for them inside the interop task scope
+        const auto& HandlerReq = ExecInterop->MRequirements;
+        std::for_each(std::begin(HandlerReq), std::end(HandlerReq),
+      [&](Requirement* Req) { AllocaCommandBase *AllocaCmd =
+      getAllocaForReq(Req); auto MemArg =
+      reinterpret_cast<pi_mem>(AllocaCmd->getMemAllocation());
+          interop_handler::ReqToMem ReqToMem = std::make_pair(Req, MemArg);
+          ReqMemObjs.emplace_back(ReqToMem);
+        });
 
-    std::sort(std::begin(ReqMemObjs), std::end(ReqMemObjs));
-    interop_handler InteropHandler(std::move(ReqMemObjs), MQueue);
-    ExecInterop->MInteropTask->call(InteropHandler);
-    Plugin.call<PiApiKind::piEnqueueEventsWait>(MQueue->getHandleRef(), 0,
-                                                nullptr, &Event);
+        std::sort(std::begin(ReqMemObjs), std::end(ReqMemObjs));
+        interop_handler InteropHandler(std::move(ReqMemObjs), MQueue);
+        ExecInterop->MInteropTask->call(InteropHandler);
+        Plugin.call<PiApiKind::piEnqueueEventsWait>(MQueue->getHandleRef(), 0,
+                                                    nullptr, &Event);
 
-    return CL_SUCCESS;
-  }*/
+        return CL_SUCCESS;
+      }*/
   case CG::CGTYPE::CodeplayHostTask: {
     CGHostTask *HostTask = static_cast<CGHostTask *>(MCommandGroup.get());
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2191,7 +2191,7 @@ cl_int ExecCGCommand::enqueueImp() {
 
     return CL_SUCCESS;
   }
-  case CG::CGTYPE::CodeplayInteropTask: {
+/*  case CG::CGTYPE::CodeplayInteropTask: {
     const detail::plugin &Plugin = MQueue->getPlugin();
     CGInteropTask *ExecInterop = (CGInteropTask *)MCommandGroup.get();
     // Wait for dependencies to complete before dispatching work on the host
@@ -2218,7 +2218,7 @@ cl_int ExecCGCommand::enqueueImp() {
                                                 nullptr, &Event);
 
     return CL_SUCCESS;
-  }
+  }*/
   case CG::CGTYPE::CodeplayHostTask: {
     CGHostTask *HostTask = static_cast<CGHostTask *>(MCommandGroup.get());
 

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -235,12 +235,12 @@ event handler::finalize() {
         std::move(MStreamStorage), MCGType, MCodeLoc));
     break;
   }
-/*  case detail::CG::CodeplayInteropTask:
-    CommandGroup.reset(new detail::CGInteropTask(
-        std::move(MInteropTask), std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), MCGType, MCodeLoc));
-    break;*/
+    /*  case detail::CG::CodeplayInteropTask:
+        CommandGroup.reset(new detail::CGInteropTask(
+            std::move(MInteropTask), std::move(MArgsStorage),
+            std::move(MAccStorage), std::move(MSharedPtrStorage),
+            std::move(MRequirements), std::move(MEvents), MCGType, MCodeLoc));
+        break;*/
   case detail::CG::CopyAccToPtr:
   case detail::CG::CopyPtrToAcc:
   case detail::CG::CopyAccToAcc:

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -235,12 +235,12 @@ event handler::finalize() {
         std::move(MStreamStorage), MCGType, MCodeLoc));
     break;
   }
-  case detail::CG::CodeplayInteropTask:
+/*  case detail::CG::CodeplayInteropTask:
     CommandGroup.reset(new detail::CGInteropTask(
         std::move(MInteropTask), std::move(MArgsStorage),
         std::move(MAccStorage), std::move(MSharedPtrStorage),
         std::move(MRequirements), std::move(MEvents), MCGType, MCodeLoc));
-    break;
+    break;*/
   case detail::CG::CopyAccToPtr:
   case detail::CG::CopyPtrToAcc:
   case detail::CG::CopyAccToAcc:


### PR DESCRIPTION
The deprecated method handler::interop_task uses the also deprecated
class sycl::detail::InteropTask that also uses the deprecated
sycl::interop_handler. When the libsycl.so library is being
compiled, a lot of warnings about deprecation are generated. To get
the warnings rid off, the method handler::interop_task is re-implemented
to use sycl::detail::HostTask instead.