### PR TITLE
[LIBCLC] Improve CMake dependency tracking

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -91,7 +91,7 @@ macro(add_libclc_builtin_set arch_suffix)
     COMMAND prepare_builtins -o
     "${builtins_obj_path}"
     "$<TARGET_PROPERTY:opt.${obj_suffix},TARGET_FILE>"
-    DEPENDS "opt.${obj_suffix}"
+    DEPENDS "${builtins_opt_path}"
             prepare_builtins )
   add_custom_target( "prepare-${obj_suffix}" ALL
     DEPENDS "${builtins_obj_path}" )
@@ -122,7 +122,7 @@ macro(add_libclc_builtin_set arch_suffix)
           --long-width=${long_width}
           --char-signedness=${signedness}
           "$<TARGET_PROPERTY:prepare-${obj_suffix},TARGET_FILE>"
-          DEPENDS "prepare-${obj_suffix}" libclc-remangler )
+          DEPENDS "${builtins_obj_path}" libclc-remangler )
         add_custom_target( "remangled-${long_width}-${signedness}_char.${obj_suffix}" ALL
           DEPENDS "${builtins_remangle_path}" )
         set_target_properties("remangled-${long_width}-${signedness}_char.${obj_suffix}"


### PR DESCRIPTION
This is (hopefully) resolving an issue where after changing the
implementation of some built-ins in libclc the changes wouldn't get
picked up correctly by CMake and the old implementation would still be
used and a clean build would be required.

As far as I can tell what was happening is that CMake would properly
rebuild up until the `opt` stage but wouldn't do the `prepare_builtins`
or `remangle` stages, leaving the old bitcode for these, and that is the
libraries that are used by clang.

The problem seems to be with how the dependencies are specified between
these two, dependencies between custom commands and custom targets are
really tricky with CMake and it seems like the way it was setup didn't
work.

The most reliable way of connecting multiple custom commands, especially
in the same file like here, is to just use the `OUTPUT` argument of the
previous custom command as a `DEPENDS` in the next one. So I've updated
these two stages to work like that, and now as far as I can tell the
dependencies are picked up properly.