### PR TITLE
[SYCL][XPTI] Enable code location info when NDEBUG is not defined

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -24,30 +24,46 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+
+#if !defined(NDEBUG) && (_MSC_VER > 1929 || __has_builtin(__builtin_FILE))
+#define __XPTI_FILE_NAME __builtin_FILE()
+#else
+#define __XPTI_FILE_NAME nullptr
+#endif
+
+#if _MSC_VER > 1929 || __has_builtin(__builtin_FUNCTION)
+#define __XPTI_FUNCTION __builtin_FUNCTION()
+#else
+#define __XPTI_FUNCTION nullptr
+#endif
+
+#if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
+#define __XPTI_LINE __builtin_LINE()
+#else
+#define __XPTI_LINE 0
+#endif
+
+#if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
+#define __XPTI_COLUMN __builtin_COLUMN()
+#else
+#define __XPTI_COLUMN 0
+#endif
+
 // Data structure that captures the user code location information using the
 // builtin capabilities of the compiler
 struct code_location {
-#ifdef _MSC_VER
-  // Since MSVC does not support the required builtins, we
-  // implement the version with "unknown"s which is handled
-  // correctly by the instrumentation
-  static constexpr code_location current(const char *fileName = nullptr,
-                                         const char *funcName = nullptr,
-                                         unsigned long lineNo = 0,
-                                         unsigned long columnNo = 0) noexcept {
-    return code_location(fileName, funcName, lineNo, columnNo);
-  }
-#else
-  // FIXME Having a nullptr for fileName here is a short-term solution to
-  // workaround leak of full paths in builds
   static constexpr code_location
-  current(const char *fileName = nullptr,
-          const char *funcName = __builtin_FUNCTION(),
-          unsigned long lineNo = __builtin_LINE(),
-          unsigned long columnNo = 0) noexcept {
+  current(const char *fileName = __XPTI_FILE_NAME,
+          const char *funcName = __XPTI_FUNCTION,
+          unsigned long lineNo = __XPTI_LINE,
+          unsigned long columnNo = __XPTI_COLUMN) noexcept {
     return code_location(fileName, funcName, lineNo, columnNo);
   }
-#endif
+
+#undef __XPTI_FILE_NAME
+#undef __XPTI_FUNCTION
+#undef __XPTI_LINE
+#undef __XPTI_COLUMN
 
   constexpr code_location(const char *file, const char *func, int line,
                           int col) noexcept

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -26,44 +26,44 @@ namespace sycl {
 namespace detail {
 
 #if !defined(NDEBUG) && (_MSC_VER > 1929 || __has_builtin(__builtin_FILE))
-#define __XPTI_FILE_NAME __builtin_FILE()
+#define __CODELOC_FILE_NAME __builtin_FILE()
 #else
-#define __XPTI_FILE_NAME nullptr
+#define __CODELOC_FILE_NAME nullptr
 #endif
 
 #if _MSC_VER > 1929 || __has_builtin(__builtin_FUNCTION)
-#define __XPTI_FUNCTION __builtin_FUNCTION()
+#define __CODELOC_FUNCTION __builtin_FUNCTION()
 #else
-#define __XPTI_FUNCTION nullptr
+#define __CODELOC_FUNCTION nullptr
 #endif
 
 #if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
-#define __XPTI_LINE __builtin_LINE()
+#define __CODELOC_LINE __builtin_LINE()
 #else
-#define __XPTI_LINE 0
+#define __CODELOC_LINE 0
 #endif
 
 #if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
-#define __XPTI_COLUMN __builtin_COLUMN()
+#define __CODELOC_COLUMN __builtin_COLUMN()
 #else
-#define __XPTI_COLUMN 0
+#define __CODELOC_COLUMN 0
 #endif
 
 // Data structure that captures the user code location information using the
 // builtin capabilities of the compiler
 struct code_location {
   static constexpr code_location
-  current(const char *fileName = __XPTI_FILE_NAME,
-          const char *funcName = __XPTI_FUNCTION,
-          unsigned long lineNo = __XPTI_LINE,
-          unsigned long columnNo = __XPTI_COLUMN) noexcept {
+  current(const char *fileName = __CODELOC_FILE_NAME,
+          const char *funcName = __CODELOC_FUNCTION,
+          unsigned long lineNo = __CODELOC_LINE,
+          unsigned long columnNo = __CODELOC_COLUMN) noexcept {
     return code_location(fileName, funcName, lineNo, columnNo);
   }
 
-#undef __XPTI_FILE_NAME
-#undef __XPTI_FUNCTION
-#undef __XPTI_LINE
-#undef __XPTI_COLUMN
+#undef __CODELOC_FILE_NAME
+#undef __CODELOC_FUNCTION
+#undef __CODELOC_LINE
+#undef __CODELOC_COLUMN
 
   constexpr code_location(const char *file, const char *func, int line,
                           int col) noexcept

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -11,13 +11,13 @@ int main() {
   auto code_loc = sycl::detail::code_location::current();
   const char *funcName = "main";
 #ifdef NDEBUG
-  if (code_loc.fileName() != nullptr) 
+  if (code_loc.fileName() != nullptr)
     return 1;
-  if (code_loc.functionName() != funcName) 
+  if (code_loc.functionName() != funcName)
     return 1;
-  if (code_loc.lineNumber() != 11) 
+  if (code_loc.lineNumber() != 11)
     return 1;
-  if (code_loc.columnNumber() != 19) 
+  if (code_loc.columnNumber() != 19)
     return 1;
 #else
   assert((code_loc.fileName() != nullptr));

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -1,0 +1,41 @@
+// RUN: %clangxx -fsycl -DNDEBUG %s -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %t.out
+
+#include <CL/sycl.hpp>
+#include <cassert>
+#include <iostream>
+
+int main() {
+    auto code_loc = sycl::detail::code_location::current();
+    const char* currentFunction = "main";
+    #ifdef NDEBUG
+    if (code_loc.fileName() != nullptr) {
+        return 1;
+    }
+    if (code_loc.functionName() != currentFunction) {
+        return 1;
+    }
+    if (code_loc.lineNumber() != 11) {
+        return 1;
+    }
+    if (code_loc.columnNumber() != 21){
+        return 1;
+    }
+    //std::cout << "NDEBUG asserts passed" << std::endl;
+    #else
+    assert((code_loc.fileName() != nullptr));
+    std::string str = code_loc.fileName();
+    assert(((str.find("code_location.cpp") != std::string::npos) && "Filename is wrong"));
+    assert((code_loc.functionName() != nullptr));
+    str = code_loc.functionName();
+    assert(((str.find(currentFunction) != std::string::npos) && "Function name is wrong"));
+    assert((code_loc.lineNumber() != 0));
+    assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
+    assert((code_loc.columnNumber() != 0));
+    assert(((code_loc.columnNumber() == 21) && "Column number is wrong"));
+    //std::cout << "asserts without NDEBUG passed" << std::endl;
+    #endif
+    return 0;
+}

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -8,34 +8,36 @@
 #include <iostream>
 
 int main() {
-    auto code_loc = sycl::detail::code_location::current();
-    const char* currentFunction = "main";
-    #ifdef NDEBUG
-    if (code_loc.fileName() != nullptr) {
-        return 1;
-    }
-    if (code_loc.functionName() != currentFunction) {
-        return 1;
-    }
-    if (code_loc.lineNumber() != 11) {
-        return 1;
-    }
-    if (code_loc.columnNumber() != 21){
-        return 1;
-    }
-    //std::cout << "NDEBUG asserts passed" << std::endl;
-    #else
-    assert((code_loc.fileName() != nullptr));
-    std::string str = code_loc.fileName();
-    assert(((str.find("code_location.cpp") != std::string::npos) && "Filename is wrong"));
-    assert((code_loc.functionName() != nullptr));
-    str = code_loc.functionName();
-    assert(((str.find(currentFunction) != std::string::npos) && "Function name is wrong"));
-    assert((code_loc.lineNumber() != 0));
-    assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
-    assert((code_loc.columnNumber() != 0));
-    assert(((code_loc.columnNumber() == 21) && "Column number is wrong"));
-    //std::cout << "asserts without NDEBUG passed" << std::endl;
-    #endif
-    return 0;
+  auto code_loc = sycl::detail::code_location::current();
+  const char *currentFunction = "main";
+#ifdef NDEBUG
+  if (code_loc.fileName() != nullptr) {
+    return 1;
+  }
+  if (code_loc.functionName() != currentFunction) {
+    return 1;
+  }
+  if (code_loc.lineNumber() != 11) {
+    return 1;
+  }
+  if (code_loc.columnNumber() != 21) {
+    return 1;
+  }
+// std::cout << "NDEBUG asserts passed" << std::endl;
+#else
+  assert((code_loc.fileName() != nullptr));
+  std::string str = code_loc.fileName();
+  assert(((str.find("code_location.cpp") != std::string::npos) &&
+          "Filename is wrong"));
+  assert((code_loc.functionName() != nullptr));
+  str = code_loc.functionName();
+  assert(((str.find(currentFunction) != std::string::npos) &&
+          "Function name is wrong"));
+  assert((code_loc.lineNumber() != 0));
+  assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
+  assert((code_loc.columnNumber() != 0));
+  assert(((code_loc.columnNumber() == 21) && "Column number is wrong"));
+// std::cout << "asserts without NDEBUG passed" << std::endl;
+#endif
+  return 0;
 }

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -9,21 +9,12 @@
 
 int main() {
   auto code_loc = sycl::detail::code_location::current();
-  const char *currentFunction = "main";
+  const char* funcName = "main";
 #ifdef NDEBUG
-  if (code_loc.fileName() != nullptr) {
-    return 1;
-  }
-  if (code_loc.functionName() != currentFunction) {
-    return 1;
-  }
-  if (code_loc.lineNumber() != 11) {
-    return 1;
-  }
-  if (code_loc.columnNumber() != 21) {
-    return 1;
-  }
-// std::cout << "NDEBUG asserts passed" << std::endl;
+  if (code_loc.fileName() != nullptr) return 1;
+  if (code_loc.functionName() != funcName) return 1;
+  if (code_loc.lineNumber() != 11) return 1;
+  if (code_loc.columnNumber() != 19) return 1;
 #else
   assert((code_loc.fileName() != nullptr));
   std::string str = code_loc.fileName();
@@ -31,13 +22,12 @@ int main() {
           "Filename is wrong"));
   assert((code_loc.functionName() != nullptr));
   str = code_loc.functionName();
-  assert(((str.find(currentFunction) != std::string::npos) &&
+  assert(((str.find(funcName) != std::string::npos) &&
           "Function name is wrong"));
   assert((code_loc.lineNumber() != 0));
   assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
   assert((code_loc.columnNumber() != 0));
-  assert(((code_loc.columnNumber() == 21) && "Column number is wrong"));
-// std::cout << "asserts without NDEBUG passed" << std::endl;
+  assert(((code_loc.columnNumber() == 19) && "Column number is wrong"));
 #endif
   return 0;
-}
+} 

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -9,12 +9,16 @@
 
 int main() {
   auto code_loc = sycl::detail::code_location::current();
-  const char* funcName = "main";
+  const char *funcName = "main";
 #ifdef NDEBUG
-  if (code_loc.fileName() != nullptr) return 1;
-  if (code_loc.functionName() != funcName) return 1;
-  if (code_loc.lineNumber() != 11) return 1;
-  if (code_loc.columnNumber() != 19) return 1;
+  if (code_loc.fileName() != nullptr) 
+    return 1;
+  if (code_loc.functionName() != funcName) 
+    return 1;
+  if (code_loc.lineNumber() != 11) 
+    return 1;
+  if (code_loc.columnNumber() != 19) 
+    return 1;
 #else
   assert((code_loc.fileName() != nullptr));
   std::string str = code_loc.fileName();
@@ -22,12 +26,12 @@ int main() {
           "Filename is wrong"));
   assert((code_loc.functionName() != nullptr));
   str = code_loc.functionName();
-  assert(((str.find(funcName) != std::string::npos) &&
-          "Function name is wrong"));
+  assert(
+      ((str.find(funcName) != std::string::npos) && "Function name is wrong"));
   assert((code_loc.lineNumber() != 0));
   assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
   assert((code_loc.columnNumber() != 0));
   assert(((code_loc.columnNumber() == 19) && "Column number is wrong"));
 #endif
   return 0;
-} 
+}


### PR DESCRIPTION
Allow users to opt-out of extended debugging information by specifying NDEBUG macro.