### PR TITLE
[BuildBot] Add option to set compile target

### DIFF
--- a/buildbot/compile.py
+++ b/buildbot/compile.py
@@ -31,7 +31,7 @@ def do_compile(args):
         "cmake",
         "--build", abs_obj_dir,
         "--",
-        "deploy-sycl-toolchain",
+        args.build_target,
         "-j", str(cpu_count)]
 
     if args.verbose:
@@ -58,6 +58,7 @@ def main():
     parser.add_argument("-o", "--obj-dir", metavar="OBJ_DIR", help="build directory")
     parser.add_argument("-j", "--build-parallelism", metavar="BUILD_PARALLELISM", help="build parallelism")
     parser.add_argument("-v", "--verbose", action='store_true', help="verbose build output")
+    parser.add_argument("-t", "--build-target", metavar="BUILD_TARGET", default="deploy-sycl-toolchain", help="set build target")
 
     args = parser.parse_args()
 

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -116,6 +116,13 @@ flags can be found by launching the script with `--help`):
 * `-o` -> Path to build directory
 * `--cmake-gen` -> Set build system type (e.g. `--cmake-gen "Unix Makefiles"`)
 
+You can use the following flags with `compile.py` (full list of available flags
+can be found by launching the script with `--help`):
+
+* `-o` -> Path to build directory
+* `-t` -> Build target (e.g., `clang` or `llvm-spirv`). Default is `deploy-sycl-toolchain`
+* `-j`, `--build-parallelism` -> Number of threads to use for compilation
+
 **Please note** that no data about flags is being shared between `configure.py` and
 `compile.py` scripts, which means that if you configured your build to be
 placed in non-default directory using `-o` flag, you must also specify this flag

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -120,7 +120,7 @@ You can use the following flags with `compile.py` (full list of available flags
 can be found by launching the script with `--help`):
 
 * `-o` -> Path to build directory
-* `-t` -> Build target (e.g., `clang` or `llvm-spirv`). Default is `deploy-sycl-toolchain`
+* `-t`, `--build-target` -> Build target (e.g., `clang` or `llvm-spirv`). Default is `deploy-sycl-toolchain`
 * `-j`, `--build-parallelism` -> Number of threads to use for compilation
 
 **Please note** that no data about flags is being shared between `configure.py` and


### PR DESCRIPTION
Sometimes you don't need to build all the SYCL toolchain - added option to set
the needed build target.