### PR TITLE
[SYCL][CUDA][libclc] Fixes atomics for below sm_60

### DIFF
--- a/buildbot/dependency.conf
+++ b/buildbot/dependency.conf
@@ -4,8 +4,8 @@ ocl_cpu_rt_ver=2021.12.9.0.24
 # https://github.com/intel/llvm/releases/download/2021-WW40/win-oclcpuexp-2021.12.9.0.24_rel.zip
 ocl_cpu_rt_ver_win=2021.12.9.0.24
 # Same GPU driver supports Level Zero and OpenCL
-# https://github.com/intel/compute-runtime/releases/tag/21.44.21506
-ocl_gpu_rt_ver=21.44.21506
+# https://github.com/intel/compute-runtime/releases/tag/21.46.21636
+ocl_gpu_rt_ver=21.46.21636
 # Same GPU driver supports Level Zero and OpenCL
 # https://downloadmirror.intel.com/677976/igfx_win_100.9955.zip
 ocl_gpu_rt_ver_win=30.0.100.9955
@@ -30,7 +30,7 @@ ocloc_ver_win=27.20.100.9168
 [DRIVER VERSIONS]
 cpu_driver_lin=2021.12.9.0.24
 cpu_driver_win=2021.12.9.0.24
-gpu_driver_lin=21.44.21506
+gpu_driver_lin=21.46.21636
 gpu_driver_win=30.0.100.9955
 fpga_driver_lin=2021.12.9.0.24
 fpga_driver_win=2021.12.9.0.24

--- a/libclc/ptx-nvidiacl/libspirv/SOURCES
+++ b/libclc/ptx-nvidiacl/libspirv/SOURCES
@@ -1,3 +1,4 @@
+reflect.ll
 atomic/loadstore_helpers.ll
 cl_khr_int64_extended_atomics/minmax_helpers.ll
 integer/mul24.cl

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
@@ -16,7 +16,7 @@ int __clc_nvvm_reflect_arch();
   switch (scope) {                                                             \
   case Subgroup:                                                               \
   case Workgroup: {                                                            \
-    if(__clc_nvvm_reflect_arch() >= 600){                              \
+    if (__clc_nvvm_reflect_arch() >= 600) {                                    \
       TYPE_NV res =                                                            \
            __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(      \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);         \
@@ -30,7 +30,7 @@ int __clc_nvvm_reflect_arch();
   }                                                                            \
   case CrossDevice:                                                            \
   default: {                                                                   \
-    if(__clc_nvvm_reflect_arch() >= 600){                              \
+    if (__clc_nvvm_reflect_arch() >= 600) {                                    \
       TYPE_NV res =                                                            \
            __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(      \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);         \
@@ -55,17 +55,17 @@ Memory order is stored in the lowest 5 bits */                                  
       __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                      \
                                        ADDR_SPACE, ADDR_SPACE_NV, )                                                                                             \
     case Acquire:                                                                                                                                               \
-      if(__clc_nvvm_reflect_arch() >= 700){                                                                                                             \
+      if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                                   \
         __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
                                          ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                                                   \
       }                                                                                                                                                         \
     case Release:                                                                                                                                               \
-      if(__clc_nvvm_reflect_arch() >= 700){                                                                                                             \
+      if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                                   \
         __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
                                          ADDR_SPACE, ADDR_SPACE_NV, _release)                                                                                   \
       }                                                                                                                                                         \
     case AcquireRelease:                                                                                                                                        \
-      if(__clc_nvvm_reflect_arch() >= 700){                                                                                                             \
+      if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                                   \
         __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
                                          ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                                                   \
       }                                                                                                                                                         \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
@@ -9,27 +9,33 @@
 #include <spirv/spirv.h>
 #include <spirv/spirv_types.h>
 
+int __nvvm_reflect(const char __constant *);
+
 #define __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,   \
                                          ADDR_SPACE, ADDR_SPACE_NV, ORDER)     \
   switch (scope) {                                                             \
   case Subgroup:                                                               \
   case Workgroup: {                                                            \
-    TYPE_NV res =                                                              \
-        __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(        \
-            (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);           \
-    return *(TYPE *)&res;                                                      \
+    if(__nvvm_reflect("__CUDA_ARCH") >= 600){                                  \
+      TYPE_NV res =                                                            \
+           __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(      \
+              (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);         \
+      return *(TYPE *)&res;                                                    \
+    }                                                                          \
   }                                                                            \
   case Device: {                                                               \
-    TYPE_NV res = __nvvm_atom##ORDER##_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(  \
+    TYPE_NV res = __nvvm_atom##ORDER##_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(   \
         (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);               \
     return *(TYPE *)&res;                                                      \
   }                                                                            \
   case CrossDevice:                                                            \
   default: {                                                                   \
-    TYPE_NV res =                                                              \
-        __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(        \
-            (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);           \
-    return *(TYPE *)&res;                                                      \
+    if(__nvvm_reflect("__CUDA_ARCH") >= 600){                                  \
+      TYPE_NV res =                                                            \
+           __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(      \
+              (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);         \
+      return *(TYPE *)&res;                                                    \
+    }                                                                          \
   }                                                                            \
   }
 
@@ -49,16 +55,22 @@ Memory order is stored in the lowest 5 bits */                                  
       __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                      \
                                        ADDR_SPACE, ADDR_SPACE_NV, )                                                                                             \
     case Acquire:                                                                                                                                               \
-      __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                      \
-                                       ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                                                     \
+      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                                                                 \
+        __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
+                                         ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                                                   \
+      }                                                                                                                                                         \
     case Release:                                                                                                                                               \
-      __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                      \
-                                       ADDR_SPACE, ADDR_SPACE_NV, _release)                                                                                     \
-    default:                                                                                                                                                    \
+      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                                                                 \
+        __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
+                                         ADDR_SPACE, ADDR_SPACE_NV, _release)                                                                                   \
+      }                                                                                                                                                         \
     case AcquireRelease:                                                                                                                                        \
-      __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                      \
-                                       ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                                                     \
+      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                                                                 \
+        __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
+                                         ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                                                   \
+      }                                                                                                                                                         \
     }                                                                                                                                                           \
+    __builtin_trap();                                                                                                                                           \
   }
 
 #define __CLC_NVVM_ATOMIC_CAS(TYPE, TYPE_MANGLED, TYPE_NV, TYPE_MANGLED_NV,    \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
@@ -9,14 +9,14 @@
 #include <spirv/spirv.h>
 #include <spirv/spirv_types.h>
 
-int __nvvm_reflect(const char __constant *);
+int __clc_nvvm_reflect_arch();
 
 #define __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,   \
                                          ADDR_SPACE, ADDR_SPACE_NV, ORDER)     \
   switch (scope) {                                                             \
   case Subgroup:                                                               \
   case Workgroup: {                                                            \
-    if(__nvvm_reflect("__CUDA_ARCH") >= 600){                                  \
+    if(__clc_nvvm_reflect_arch() >= 600){                              \
       TYPE_NV res =                                                            \
            __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(      \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);         \
@@ -30,7 +30,7 @@ int __nvvm_reflect(const char __constant *);
   }                                                                            \
   case CrossDevice:                                                            \
   default: {                                                                   \
-    if(__nvvm_reflect("__CUDA_ARCH") >= 600){                                  \
+    if(__clc_nvvm_reflect_arch() >= 600){                              \
       TYPE_NV res =                                                            \
            __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(      \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);         \
@@ -55,22 +55,23 @@ Memory order is stored in the lowest 5 bits */                                  
       __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                      \
                                        ADDR_SPACE, ADDR_SPACE_NV, )                                                                                             \
     case Acquire:                                                                                                                                               \
-      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                                                                 \
+      if(__clc_nvvm_reflect_arch() >= 700){                                                                                                             \
         __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
                                          ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                                                   \
       }                                                                                                                                                         \
     case Release:                                                                                                                                               \
-      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                                                                 \
+      if(__clc_nvvm_reflect_arch() >= 700){                                                                                                             \
         __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
                                          ADDR_SPACE, ADDR_SPACE_NV, _release)                                                                                   \
       }                                                                                                                                                         \
     case AcquireRelease:                                                                                                                                        \
-      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                                                                 \
+      if(__clc_nvvm_reflect_arch() >= 700){                                                                                                             \
         __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
                                          ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                                                   \
       }                                                                                                                                                         \
     }                                                                                                                                                           \
     __builtin_trap();                                                                                                                                           \
+    __builtin_unreachable();                                                                                                                                    \
   }
 
 #define __CLC_NVVM_ATOMIC_CAS(TYPE, TYPE_MANGLED, TYPE_NV, TYPE_MANGLED_NV,    \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
@@ -12,15 +12,19 @@
 #include <spirv/spirv.h>
 #include <spirv/spirv_types.h>
 
+int __nvvm_reflect(const char __constant *);
+
 #define __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,       \
                                      ADDR_SPACE, ADDR_SPACE_NV, ORDER)         \
   switch (scope) {                                                             \
   case Subgroup:                                                               \
   case Workgroup: {                                                            \
-    TYPE_NV res =                                                              \
-        __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(         \
-            (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);                \
-    return *(TYPE *)&res;                                                      \
+    if(__nvvm_reflect("__CUDA_ARCH") >= 600){                                  \
+      TYPE_NV res =                                                            \
+          __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(       \
+              (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);              \
+      return *(TYPE *)&res;                                                    \
+    }                                                                          \
   }                                                                            \
   case Device: {                                                               \
     TYPE_NV res = __nvvm_atom##ORDER##_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(   \
@@ -29,10 +33,12 @@
   }                                                                            \
   case CrossDevice:                                                            \
   default: {                                                                   \
-    TYPE_NV res =                                                              \
-        __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(         \
-            (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);                \
-    return *(TYPE *)&res;                                                      \
+    if(__nvvm_reflect("__CUDA_ARCH") >= 600){                                  \
+      TYPE_NV res =                                                            \
+          __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(       \
+              (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);              \
+      return *(TYPE *)&res;                                                    \
+    }                                                                          \
   }                                                                            \
   }
 
@@ -48,19 +54,25 @@ Memory order is stored in the lowest 5 bits */                                  
     unsigned int order = semantics & 0x1F;                                                                                   \
     switch (order) {                                                                                                         \
     case None:                                                                                                               \
-      __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                       \
-                                   ADDR_SPACE, ADDR_SPACE_NV, )                                                              \
+        __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
+                                    ADDR_SPACE, ADDR_SPACE_NV, )                                                             \
     case Acquire:                                                                                                            \
-      __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                       \
-                                   ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                      \
+      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                              \
+        __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
+                                     ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                    \
+      }                                                                                                                      \
     case Release:                                                                                                            \
-      __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                       \
-                                   ADDR_SPACE, ADDR_SPACE_NV, _release)                                                      \
-    default:                                                                                                                 \
+      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                              \
+        __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
+                                     ADDR_SPACE, ADDR_SPACE_NV, _release)                                                    \
+      }                                                                                                                      \
     case AcquireRelease:                                                                                                     \
-      __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                       \
-                                   ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                      \
+      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                              \
+        __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
+                                     ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                    \
+      }                                                                                                                      \
     }                                                                                                                        \
+    __builtin_trap();                                                                                                        \
   }
 
 #define __CLC_NVVM_ATOMIC(TYPE, TYPE_MANGLED, TYPE_NV, TYPE_MANGLED_NV, OP,    \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
@@ -12,14 +12,14 @@
 #include <spirv/spirv.h>
 #include <spirv/spirv_types.h>
 
-int __nvvm_reflect(const char __constant *);
+extern int __clc_nvvm_reflect_arch();
 
 #define __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,       \
                                      ADDR_SPACE, ADDR_SPACE_NV, ORDER)         \
   switch (scope) {                                                             \
   case Subgroup:                                                               \
   case Workgroup: {                                                            \
-    if(__nvvm_reflect("__CUDA_ARCH") >= 600){                                  \
+    if(__clc_nvvm_reflect_arch() >= 600){                              \
       TYPE_NV res =                                                            \
           __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(       \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);              \
@@ -33,7 +33,7 @@ int __nvvm_reflect(const char __constant *);
   }                                                                            \
   case CrossDevice:                                                            \
   default: {                                                                   \
-    if(__nvvm_reflect("__CUDA_ARCH") >= 600){                                  \
+    if(__clc_nvvm_reflect_arch() >= 600){                              \
       TYPE_NV res =                                                            \
           __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(       \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);              \
@@ -57,22 +57,23 @@ Memory order is stored in the lowest 5 bits */                                  
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                     ADDR_SPACE, ADDR_SPACE_NV, )                                                             \
     case Acquire:                                                                                                            \
-      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                              \
+      if(__clc_nvvm_reflect_arch() >= 700){                                                                              \
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                      ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                    \
       }                                                                                                                      \
     case Release:                                                                                                            \
-      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                              \
+      if(__clc_nvvm_reflect_arch() >= 700){                                                                              \
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                      ADDR_SPACE, ADDR_SPACE_NV, _release)                                                    \
       }                                                                                                                      \
     case AcquireRelease:                                                                                                     \
-      if(__nvvm_reflect("__CUDA_ARCH") >= 700){                                                                              \
+      if(__clc_nvvm_reflect_arch() >= 700){                                                                              \
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                      ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                    \
       }                                                                                                                      \
     }                                                                                                                        \
     __builtin_trap();                                                                                                        \
+    __builtin_unreachable();                                                                                                 \
   }
 
 #define __CLC_NVVM_ATOMIC(TYPE, TYPE_MANGLED, TYPE_NV, TYPE_MANGLED_NV, OP,    \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
@@ -19,7 +19,7 @@ extern int __clc_nvvm_reflect_arch();
   switch (scope) {                                                             \
   case Subgroup:                                                               \
   case Workgroup: {                                                            \
-    if(__clc_nvvm_reflect_arch() >= 600){                                      \
+    if (__clc_nvvm_reflect_arch() >= 600) {                                    \
       TYPE_NV res =                                                            \
           __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(       \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);              \
@@ -33,7 +33,7 @@ extern int __clc_nvvm_reflect_arch();
   }                                                                            \
   case CrossDevice:                                                            \
   default: {                                                                   \
-    if(__clc_nvvm_reflect_arch() >= 600){                                      \
+    if (__clc_nvvm_reflect_arch() >= 600) {                                    \
       TYPE_NV res =                                                            \
           __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(       \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);              \
@@ -57,17 +57,17 @@ Memory order is stored in the lowest 5 bits */                                  
       __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                       \
                                    ADDR_SPACE, ADDR_SPACE_NV, )                                                              \
     case Acquire:                                                                                                            \
-      if(__clc_nvvm_reflect_arch() >= 700){                                                                                  \
+      if (__clc_nvvm_reflect_arch() >= 700) {                                                                                \
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                      ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                    \
       }                                                                                                                      \
     case Release:                                                                                                            \
-      if(__clc_nvvm_reflect_arch() >= 700){                                                                                  \
+      if (__clc_nvvm_reflect_arch() >= 700) {                                                                                \
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                      ADDR_SPACE, ADDR_SPACE_NV, _release)                                                    \
       }                                                                                                                      \
     case AcquireRelease:                                                                                                     \
-      if(__clc_nvvm_reflect_arch() >= 700){                                                                                  \
+      if (__clc_nvvm_reflect_arch() >= 700) {                                                                                \
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                      ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                    \
       }                                                                                                                      \

--- a/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
+++ b/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
@@ -191,7 +191,7 @@ __clc__SubgroupBitwiseAny(uint op, bool predicate, bool *carry) {
   _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT TYPE __CLC_APPEND(                    \
       __clc__Subgroup, NAME)(uint op, TYPE x, TYPE * carry) {                  \
     /* Fast path for warp reductions for sm_80+ */                             \
-    if (__clc_nvvm_reflect_arch() >= 800 && op == Reduce) {                      \
+    if (__clc_nvvm_reflect_arch() >= 800 && op == Reduce) {                    \
       TYPE result = __nvvm_redux_sync_##REDUX_OP(x, __clc__membermask());      \
       *carry = result;                                                         \
       return result;                                                           \

--- a/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
+++ b/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
@@ -12,7 +12,7 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
-int __nvvm_reflect(const char __constant *);
+int __clc_nvvm_reflect_arch();
 
 // CLC helpers
 __local bool *
@@ -191,7 +191,7 @@ __clc__SubgroupBitwiseAny(uint op, bool predicate, bool *carry) {
   _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT TYPE __CLC_APPEND(                    \
       __clc__Subgroup, NAME)(uint op, TYPE x, TYPE * carry) {                  \
     /* Fast path for warp reductions for sm_80+ */                             \
-    if (__nvvm_reflect("__CUDA_ARCH") >= 800 && op == Reduce) {                \
+    if (__clc_nvvm_reflect_arch() >= 800 && op == Reduce) {                      \
       TYPE result = __nvvm_redux_sync_##REDUX_OP(x, __clc__membermask());      \
       *carry = result;                                                         \
       return result;                                                           \

--- a/libclc/ptx-nvidiacl/libspirv/reflect.ll
+++ b/libclc/ptx-nvidiacl/libspirv/reflect.ll
@@ -1,0 +1,8 @@
+@str = private addrspace(1) constant [12 x i8] c"__CUDA_ARCH\00"
+
+declare i32 @__nvvm_reflect(i8*)
+
+define i32 @__clc_nvvm_reflect_arch() alwaysinline {
+  %reflect = call i32 @__nvvm_reflect(i8* addrspacecast (i8 addrspace(1)* getelementptr inbounds ([12 x i8], [12 x i8] addrspace(1)* @str, i32 0, i32 0) to i8*))
+  ret i32 %reflect
+}


### PR DESCRIPTION
Fixes #5008. Fixes libclc implementation of CUDA atomics by using `__nvvm_reflect()` so as not to emit intrinsics that are unsupported on target sm version. If atomics are called with semantic order or scope that is not supported, `__builtin_trap()` is called instead.