### PR TITLE
[SYCL][SPIRV] Fix return type of relational builtins

### DIFF
--- a/clang/lib/Sema/SPIRVBuiltins.td
+++ b/clang/lib/Sema/SPIRVBuiltins.td
@@ -860,9 +860,9 @@ foreach name = ["IsNan", "IsInf", "IsFinite", "IsNormal", "SignBitSet"] in {
   def : SPVBuiltin<name, [Bool, Float], Attr.Const>;
   def : SPVBuiltin<name, [Bool, Double], Attr.Const>;
   def : SPVBuiltin<name, [Bool, Half], Attr.Const>;
-  def : SPVBuiltin<name, [GenTypeSCharVecNoScalar, GenTypeFloatVecNoScalar], Attr.Const>;
-  def : SPVBuiltin<name, [GenTypeSCharVecNoScalar, GenTypeDoubleVecNoScalar], Attr.Const>;
-  def : SPVBuiltin<name, [GenTypeSCharVecNoScalar, GenTypeHalfVecNoScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeIntVecNoScalar, GenTypeFloatVecNoScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeLongVecNoScalar, GenTypeDoubleVecNoScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeShortVecNoScalar, GenTypeHalfVecNoScalar], Attr.Const>;
 }
 
 foreach name = ["LessOrGreater",
@@ -876,9 +876,9 @@ foreach name = ["LessOrGreater",
   def : SPVBuiltin<name, [Bool, Float, Float], Attr.Const>;
   def : SPVBuiltin<name, [Bool, Double, Double], Attr.Const>;
   def : SPVBuiltin<name, [Bool, Half, Half], Attr.Const>;
-  def : SPVBuiltin<name, [GenTypeSCharVecNoScalar, GenTypeFloatVecNoScalar, GenTypeFloatVecNoScalar], Attr.Const>;
-  def : SPVBuiltin<name, [GenTypeSCharVecNoScalar, GenTypeDoubleVecNoScalar, GenTypeDoubleVecNoScalar], Attr.Const>;
-  def : SPVBuiltin<name, [GenTypeSCharVecNoScalar, GenTypeHalfVecNoScalar, GenTypeHalfVecNoScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeIntVecNoScalar, GenTypeFloatVecNoScalar, GenTypeFloatVecNoScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeLongVecNoScalar, GenTypeDoubleVecNoScalar, GenTypeDoubleVecNoScalar], Attr.Const>;
+  def : SPVBuiltin<name, [GenTypeShortVecNoScalar, GenTypeHalfVecNoScalar, GenTypeHalfVecNoScalar], Attr.Const>;
 }
 
 foreach name = ["BitCount"] in {

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -1103,8 +1103,7 @@ fast_normalize(T p) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isequal(T x, T y) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_FOrdEqual<detail::rel_ret_t<T>>(x, y));
+  return __sycl_std::__invoke_FOrdEqual<detail::rel_ret_t<T>>(x, y);
 }
 
 // bool isnotequal (half x, half y)
@@ -1115,8 +1114,7 @@ detail::rel_ret_t<T> isequal(T x, T y) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isnotequal(T x, T y) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_FUnordNotEqual<detail::rel_ret_t<T>>(x, y));
+  return __sycl_std::__invoke_FUnordNotEqual<detail::rel_ret_t<T>>(x, y);
 }
 
 // bool isgreater (half x, half y)
@@ -1127,8 +1125,7 @@ detail::rel_ret_t<T> isnotequal(T x, T y) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isgreater(T x, T y) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_FOrdGreaterThan<detail::rel_ret_t<T>>(x, y));
+  return __sycl_std::__invoke_FOrdGreaterThan<detail::rel_ret_t<T>>(x, y);
 }
 
 // bool isgreaterequal (half x, half y)
@@ -1139,8 +1136,7 @@ detail::rel_ret_t<T> isgreater(T x, T y) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isgreaterequal(T x, T y) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_FOrdGreaterThanEqual<detail::rel_ret_t<T>>(x, y));
+  return __sycl_std::__invoke_FOrdGreaterThanEqual<detail::rel_ret_t<T>>(x, y);
 }
 
 // bool isless (half x, half y)
@@ -1151,8 +1147,7 @@ detail::rel_ret_t<T> isgreaterequal(T x, T y) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isless(T x, T y) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_FOrdLessThan<detail::rel_ret_t<T>>(x, y));
+  return __sycl_std::__invoke_FOrdLessThan<detail::rel_ret_t<T>>(x, y);
 }
 
 // bool islessequal (half x, half y)
@@ -1163,8 +1158,7 @@ detail::rel_ret_t<T> isless(T x, T y) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> islessequal(T x, T y) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_FOrdLessThanEqual<detail::rel_ret_t<T>>(x, y));
+  return __sycl_std::__invoke_FOrdLessThanEqual<detail::rel_ret_t<T>>(x, y);
 }
 
 // bool islessgreater (half x, half y)
@@ -1175,8 +1169,7 @@ detail::rel_ret_t<T> islessequal(T x, T y) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> islessgreater(T x, T y) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_LessOrGreater<detail::rel_ret_t<T>>(x, y));
+  return __sycl_std::__invoke_LessOrGreater<detail::rel_ret_t<T>>(x, y);
 }
 
 // bool isfinite (half x)
@@ -1187,8 +1180,7 @@ detail::rel_ret_t<T> islessgreater(T x, T y) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isfinite(T x) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_IsFinite<detail::rel_ret_t<T>>(x));
+  return __sycl_std::__invoke_IsFinite<detail::rel_ret_t<T>>(x);
 }
 
 // bool isinf (half x)
@@ -1199,8 +1191,7 @@ detail::rel_ret_t<T> isfinite(T x) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isinf(T x) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_IsInf<detail::rel_ret_t<T>>(x));
+  return __sycl_std::__invoke_IsInf<detail::rel_ret_t<T>>(x);
 }
 
 // bool isnan (half x)
@@ -1211,8 +1202,7 @@ detail::rel_ret_t<T> isinf(T x) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isnan(T x) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_IsNan<detail::rel_ret_t<T>>(x));
+  return __sycl_std::__invoke_IsNan<detail::rel_ret_t<T>>(x);
 }
 
 // bool isnormal (half x)
@@ -1223,8 +1213,7 @@ detail::rel_ret_t<T> isnan(T x) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isnormal(T x) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_IsNormal<detail::rel_ret_t<T>>(x));
+  return __sycl_std::__invoke_IsNormal<detail::rel_ret_t<T>>(x);
 }
 
 // bool isordered (half x)
@@ -1235,8 +1224,7 @@ detail::rel_ret_t<T> isnormal(T x) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isordered(T x, T y) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_Ordered<detail::rel_ret_t<T>>(x, y));
+  return __sycl_std::__invoke_Ordered<detail::rel_ret_t<T>>(x, y);
 }
 
 // bool isunordered (half x, half y)
@@ -1247,8 +1235,7 @@ detail::rel_ret_t<T> isordered(T x, T y) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> isunordered(T x, T y) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_Unordered<detail::rel_ret_t<T>>(x, y));
+  return __sycl_std::__invoke_Unordered<detail::rel_ret_t<T>>(x, y);
 }
 
 // bool signbit (half x)
@@ -1259,8 +1246,7 @@ detail::rel_ret_t<T> isunordered(T x, T y) __NOEXC {
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
 detail::rel_ret_t<T> signbit(T x) __NOEXC {
-  return detail::RelConverter<T>::apply(
-      __sycl_std::__invoke_SignBitSet<detail::rel_ret_t<T>>(x));
+  return __sycl_std::__invoke_SignBitSet<detail::rel_ret_t<T>>(x);
 }
 
 // int any (sigeninteger x)

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -1095,170 +1095,170 @@ fast_normalize(T p) __NOEXC {
 }
 
 /* --------------- 4.13.7 Relational functions. Device version --------------*/
-// int isequal (half x, half y)
+// bool isequal (half x, half y)
 // shortn isequal (halfn x, halfn y)
 // igeninteger32bit isequal (genfloatf x, genfloatf y)
-// int isequal (double x,double y);
+// bool isequal (double x,double y);
 // longn isequal (doublen x, doublen y)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isequal(T x, T y) __NOEXC {
+detail::rel_ret_t<T> isequal(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdEqual<detail::rel_ret_t<T>>(x, y));
 }
 
-// int isnotequal (half x, half y)
+// bool isnotequal (half x, half y)
 // shortn isnotequal (halfn x, halfn y)
 // igeninteger32bit isnotequal (genfloatf x, genfloatf y)
-// int isnotequal (double x, double y)
+// bool isnotequal (double x, double y)
 // longn isnotequal (doublen x, doublen y)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isnotequal(T x, T y) __NOEXC {
+detail::rel_ret_t<T> isnotequal(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FUnordNotEqual<detail::rel_ret_t<T>>(x, y));
 }
 
-// int isgreater (half x, half y)
+// bool isgreater (half x, half y)
 // shortn isgreater (halfn x, halfn y)
 // igeninteger32bit isgreater (genfloatf x, genfloatf y)
-// int isgreater (double x, double y)
+// bool isgreater (double x, double y)
 // longn isgreater (doublen x, doublen y)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isgreater(T x, T y) __NOEXC {
+detail::rel_ret_t<T> isgreater(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdGreaterThan<detail::rel_ret_t<T>>(x, y));
 }
 
-// int isgreaterequal (half x, half y)
+// bool isgreaterequal (half x, half y)
 // shortn isgreaterequal (halfn x, halfn y)
 // igeninteger32bit isgreaterequal (genfloatf x, genfloatf y)
-// int isgreaterequal (double x, double y)
+// bool isgreaterequal (double x, double y)
 // longn isgreaterequal (doublen x, doublen y)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isgreaterequal(T x, T y) __NOEXC {
+detail::rel_ret_t<T> isgreaterequal(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdGreaterThanEqual<detail::rel_ret_t<T>>(x, y));
 }
 
-// int isless (half x, half y)
+// bool isless (half x, half y)
 // shortn isless (halfn x, halfn y)
 // igeninteger32bit isless (genfloatf x, genfloatf y)
-// int isless (long x, long y)
+// bool isless (long x, long y)
 // longn isless (doublen x, doublen y)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isless(T x, T y) __NOEXC {
+detail::rel_ret_t<T> isless(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdLessThan<detail::rel_ret_t<T>>(x, y));
 }
 
-// int islessequal (half x, half y)
+// bool islessequal (half x, half y)
 // shortn islessequal (halfn x, halfn y)
 // igeninteger32bit islessequal (genfloatf x, genfloatf y)
-// int islessequal (double x, double y)
+// bool islessequal (double x, double y)
 // longn islessequal (doublen x, doublen y)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> islessequal(T x, T y) __NOEXC {
+detail::rel_ret_t<T> islessequal(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_FOrdLessThanEqual<detail::rel_ret_t<T>>(x, y));
 }
 
-// int islessgreater (half x, half y)
+// bool islessgreater (half x, half y)
 // shortn islessgreater (halfn x, halfn y)
 // igeninteger32bit islessgreater (genfloatf x, genfloatf y)
-// int islessgreater (double x, double y)
+// bool islessgreater (double x, double y)
 // longn islessgreater (doublen x, doublen y)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> islessgreater(T x, T y) __NOEXC {
+detail::rel_ret_t<T> islessgreater(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_LessOrGreater<detail::rel_ret_t<T>>(x, y));
 }
 
-// int isfinite (half x)
+// bool isfinite (half x)
 // shortn isfinite (halfn x)
 // igeninteger32bit isfinite (genfloatf x)
-// int isfinite (double x)
+// bool isfinite (double x)
 // longn isfinite (doublen x)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isfinite(T x) __NOEXC {
+detail::rel_ret_t<T> isfinite(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_IsFinite<detail::rel_ret_t<T>>(x));
 }
 
-// int isinf (half x)
+// bool isinf (half x)
 // shortn isinf (halfn x)
 // igeninteger32bit isinf (genfloatf x)
-// int isinf (double x)
+// bool isinf (double x)
 // longn isinf (doublen x)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isinf(T x) __NOEXC {
+detail::rel_ret_t<T> isinf(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_IsInf<detail::rel_ret_t<T>>(x));
 }
 
-// int isnan (half x)
+// bool isnan (half x)
 // shortn isnan (halfn x)
 // igeninteger32bit isnan (genfloatf x)
-// int isnan (double x)
+// bool isnan (double x)
 // longn isnan (doublen x)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isnan(T x) __NOEXC {
+detail::rel_ret_t<T> isnan(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_IsNan<detail::rel_ret_t<T>>(x));
 }
 
-// int isnormal (half x)
+// bool isnormal (half x)
 // shortn isnormal (halfn x)
 // igeninteger32bit isnormal (genfloatf x)
-// int isnormal (double x)
+// bool isnormal (double x)
 // longn isnormal (doublen x)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isnormal(T x) __NOEXC {
+detail::rel_ret_t<T> isnormal(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_IsNormal<detail::rel_ret_t<T>>(x));
 }
 
-// int isordered (half x)
+// bool isordered (half x)
 // shortn isordered (halfn x, halfn y)
 // igeninteger32bit isordered (genfloatf x, genfloatf y)
-// int isordered (double x, double y)
+// bool isordered (double x, double y)
 // longn isordered (doublen x, doublen y)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isordered(T x, T y) __NOEXC {
+detail::rel_ret_t<T> isordered(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_Ordered<detail::rel_ret_t<T>>(x, y));
 }
 
-// int isunordered (half x, half y)
+// bool isunordered (half x, half y)
 // shortn isunordered (halfn x, halfn y)
 // igeninteger32bit isunordered (genfloatf x, genfloatf y)
-// int isunordered (double x, double y)
+// bool isunordered (double x, double y)
 // longn isunordered (doublen x, doublen y)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> isunordered(T x, T y) __NOEXC {
+detail::rel_ret_t<T> isunordered(T x, T y) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_Unordered<detail::rel_ret_t<T>>(x, y));
 }
 
-// int signbit (half x)
+// bool signbit (half x)
 // shortn signbit (halfn x)
 // igeninteger32bit signbit (genfloatf x)
-// int signbit (double)
+// bool signbit (double)
 // longn signbit (doublen x)
 template <typename T,
           typename = detail::enable_if_t<detail::is_genfloat<T>::value, T>>
-detail::common_rel_ret_t<T> signbit(T x) __NOEXC {
+detail::rel_ret_t<T> signbit(T x) __NOEXC {
   return detail::RelConverter<T>::apply(
       __sycl_std::__invoke_SignBitSet<detail::rel_ret_t<T>>(x));
 }

--- a/sycl/include/CL/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_traits.hpp
@@ -541,29 +541,6 @@ template <typename T>
 using rel_sign_bit_test_arg_t =
     typename RelationalTestForSignBitType<T>::argument_type;
 
-template <typename T, typename Enable = void> struct RelConverter;
-
-template <typename T>
-struct RelConverter<
-    T, typename detail::enable_if_t<TryToGetElementType<T>::value>> {
-  static const int N = T::size();
-  using ret_t = rel_ret_t<T>;
-  static ret_t apply(ret_t value) { return value; }
-};
-
-template <typename T>
-struct RelConverter<
-    T, typename detail::enable_if_t<!TryToGetElementType<T>::value>> {
-  using R = rel_ret_t<T>;
-#ifdef __SYCL_DEVICE_ONLY__
-  using value_t = bool;
-#else
-  using value_t = R;
-#endif
-
-  static R apply(value_t value) { return value; }
-};
-
 template <typename T> static constexpr T max_v() {
   return (std::numeric_limits<T>::max)();
 }

--- a/sycl/test/check_device_code/builtin-relational.cpp
+++ b/sycl/test/check_device_code/builtin-relational.cpp
@@ -1,0 +1,100 @@
+// RUN: %clangxx -I %sycl_include -S -emit-llvm -fsycl-device-only -fsycl-unnamed-lambda -Xclang -disable-llvm-passes %s -o - | FileCheck %s
+
+#include <CL/sycl.hpp>
+
+int main() {
+  using namespace sycl;
+  queue q;
+  q.single_task([] {
+    half h(0.);
+    half2 h2(0., 0.);
+    half4 h4(0., 0., 0., 0.);
+    half8 h8(0., 0., 0., 0., 0., 0., 0., 0.);
+    half16 h16(0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.);
+
+    float f(0.);
+    float2 f2(0., 0.);
+    float4 f4(0., 0., 0., 0.);
+    float8 f8(0., 0., 0., 0., 0., 0., 0., 0.);
+    float16 f16(0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.);
+
+    double d(0.);
+    double2 d2(0., 0.);
+    double4 d4(0., 0., 0., 0.);
+    double8 d8(0., 0., 0., 0., 0., 0., 0., 0.);
+    double16 d16(0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                 0.);
+
+    {
+      // CHECK: call spir_func zeroext i1 @_Z13__spirv_IsNanDF16_(
+      (void)isnan(h);
+      // CHECK: call spir_func <2 x i16> @_Z13__spirv_IsNanDv2_DF16_(
+      (void)isnan(h2);
+      // CHECK: call spir_func <4 x i16> @_Z13__spirv_IsNanDv4_DF16_(
+      (void)isnan(h4);
+      // CHECK: call spir_func <8 x i16> @_Z13__spirv_IsNanDv8_DF16_(
+      (void)isnan(h8);
+      // CHECK: call spir_func <16 x i16> @_Z13__spirv_IsNanDv16_DF16_(
+      (void)isnan(h16);
+
+      // CHECK: call spir_func zeroext i1 @_Z13__spirv_IsNanf(
+      (void)isnan(f);
+      // CHECK: call spir_func <2 x i32> @_Z13__spirv_IsNanDv2_f(
+      (void)isnan(f2);
+      // CHECK: call spir_func <4 x i32> @_Z13__spirv_IsNanDv4_f(
+      (void)isnan(f4);
+      // CHECK: call spir_func <8 x i32> @_Z13__spirv_IsNanDv8_f(
+      (void)isnan(f8);
+      // CHECK: call spir_func <16 x i32> @_Z13__spirv_IsNanDv16_f(
+      (void)isnan(f16);
+
+      // CHECK: call spir_func zeroext i1 @_Z13__spirv_IsNand(
+      (void)isnan(d);
+      // CHECK: call spir_func <2 x i64> @_Z13__spirv_IsNanDv2_d(
+      (void)isnan(d2);
+      // CHECK: call spir_func <4 x i64> @_Z13__spirv_IsNanDv4_d(
+      (void)isnan(d4);
+      // CHECK: call spir_func <8 x i64> @_Z13__spirv_IsNanDv8_d(
+      (void)isnan(d8);
+      // CHECK: call spir_func <16 x i64> @_Z13__spirv_IsNanDv16_d(
+      (void)isnan(d16);
+    }
+
+    {
+      // CHECK: call spir_func zeroext i1 @_Z21__spirv_LessOrGreaterDF16_DF16_(
+      (void)islessgreater(h, h);
+      // CHECK: call spir_func <2 x i16> @_Z21__spirv_LessOrGreaterDv2_DF16_S_(
+      (void)islessgreater(h2, h2);
+      // CHECK: call spir_func <4 x i16> @_Z21__spirv_LessOrGreaterDv4_DF16_S_(
+      (void)islessgreater(h4, h4);
+      // CHECK: call spir_func <8 x i16> @_Z21__spirv_LessOrGreaterDv8_DF16_S_(
+      (void)islessgreater(h8, h8);
+      // CHECK: call spir_func <16 x i16> @_Z21__spirv_LessOrGreaterDv16_DF16_S_(
+      (void)islessgreater(h16, h16);
+
+      // CHECK: call spir_func zeroext i1 @_Z21__spirv_LessOrGreaterff(
+      (void)islessgreater(f, f);
+      // CHECK: call spir_func <2 x i32> @_Z21__spirv_LessOrGreaterDv2_fS_(
+      (void)islessgreater(f2, f2);
+      // CHECK: call spir_func <4 x i32> @_Z21__spirv_LessOrGreaterDv4_fS_(
+      (void)islessgreater(f4, f4);
+      // CHECK: call spir_func <8 x i32> @_Z21__spirv_LessOrGreaterDv8_fS_(
+      (void)islessgreater(f8, f8);
+      // CHECK: call spir_func <16 x i32> @_Z21__spirv_LessOrGreaterDv16_fS_(
+      (void)islessgreater(f16, f16);
+
+      // CHECK: call spir_func zeroext i1 @_Z21__spirv_LessOrGreaterdd(
+      (void)islessgreater(d, d);
+      // CHECK: call spir_func <2 x i64> @_Z21__spirv_LessOrGreaterDv2_dS_(
+      (void)islessgreater(d2, d2);
+      // CHECK: call spir_func <4 x i64> @_Z21__spirv_LessOrGreaterDv4_dS_(
+      (void)islessgreater(d4, d4);
+      // CHECK: call spir_func <8 x i64> @_Z21__spirv_LessOrGreaterDv8_dS_(
+      (void)islessgreater(d8, d8);
+      // CHECK: call spir_func <16 x i64> @_Z21__spirv_LessOrGreaterDv16_dS_(
+      (void)islessgreater(d16, d16);
+    }
+  });
+
+  return 0;
+}

--- a/sycl/test/check_device_code/builtin-relational.cpp
+++ b/sycl/test/check_device_code/builtin-relational.cpp
@@ -1,98 +1,101 @@
-// RUN: %clangxx -I %sycl_include -S -emit-llvm -fsycl-device-only -fsycl-unnamed-lambda -Xclang -disable-llvm-passes %s -o - | FileCheck %s
+// RUN: %clangxx -I %sycl_include -S -emit-llvm -fsycl-device-only -Xclang -disable-llvm-passes %s -o - | FileCheck %s
+//
+// Check relational builtin function type.
 
 #include <CL/sycl.hpp>
 
 int main() {
-  using namespace sycl;
-  queue q;
+  sycl::queue q;
   q.single_task([] {
-    half h(0.);
-    half2 h2(0., 0.);
-    half4 h4(0., 0., 0., 0.);
-    half8 h8(0., 0., 0., 0., 0., 0., 0., 0.);
-    half16 h16(0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.);
+    sycl::half h(0.);
+    sycl::half2 h2(0., 0.);
+    sycl::half4 h4(0., 0., 0., 0.);
+    sycl::half8 h8(0., 0., 0., 0., 0., 0., 0., 0.);
+    sycl::half16 h16(0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                     0.);
 
     float f(0.);
-    float2 f2(0., 0.);
-    float4 f4(0., 0., 0., 0.);
-    float8 f8(0., 0., 0., 0., 0., 0., 0., 0.);
-    float16 f16(0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.);
+    sycl::float2 f2(0., 0.);
+    sycl::float4 f4(0., 0., 0., 0.);
+    sycl::float8 f8(0., 0., 0., 0., 0., 0., 0., 0.);
+    sycl::float16 f16(0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                      0., 0.);
 
     double d(0.);
-    double2 d2(0., 0.);
-    double4 d4(0., 0., 0., 0.);
-    double8 d8(0., 0., 0., 0., 0., 0., 0., 0.);
-    double16 d16(0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
-                 0.);
+    sycl::double2 d2(0., 0.);
+    sycl::double4 d4(0., 0., 0., 0.);
+    sycl::double8 d8(0., 0., 0., 0., 0., 0., 0., 0.);
+    sycl::double16 d16(0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                       0., 0.);
 
     {
       // CHECK: call spir_func zeroext i1 @_Z13__spirv_IsNanDF16_(
-      (void)isnan(h);
+      (void)sycl::isnan(h);
       // CHECK: call spir_func <2 x i16> @_Z13__spirv_IsNanDv2_DF16_(
-      (void)isnan(h2);
+      (void)sycl::isnan(h2);
       // CHECK: call spir_func <4 x i16> @_Z13__spirv_IsNanDv4_DF16_(
-      (void)isnan(h4);
+      (void)sycl::isnan(h4);
       // CHECK: call spir_func <8 x i16> @_Z13__spirv_IsNanDv8_DF16_(
-      (void)isnan(h8);
+      (void)sycl::isnan(h8);
       // CHECK: call spir_func <16 x i16> @_Z13__spirv_IsNanDv16_DF16_(
-      (void)isnan(h16);
+      (void)sycl::isnan(h16);
 
       // CHECK: call spir_func zeroext i1 @_Z13__spirv_IsNanf(
-      (void)isnan(f);
+      (void)sycl::isnan(f);
       // CHECK: call spir_func <2 x i32> @_Z13__spirv_IsNanDv2_f(
-      (void)isnan(f2);
+      (void)sycl::isnan(f2);
       // CHECK: call spir_func <4 x i32> @_Z13__spirv_IsNanDv4_f(
-      (void)isnan(f4);
+      (void)sycl::isnan(f4);
       // CHECK: call spir_func <8 x i32> @_Z13__spirv_IsNanDv8_f(
-      (void)isnan(f8);
+      (void)sycl::isnan(f8);
       // CHECK: call spir_func <16 x i32> @_Z13__spirv_IsNanDv16_f(
-      (void)isnan(f16);
+      (void)sycl::isnan(f16);
 
       // CHECK: call spir_func zeroext i1 @_Z13__spirv_IsNand(
-      (void)isnan(d);
+      (void)sycl::isnan(d);
       // CHECK: call spir_func <2 x i64> @_Z13__spirv_IsNanDv2_d(
-      (void)isnan(d2);
+      (void)sycl::isnan(d2);
       // CHECK: call spir_func <4 x i64> @_Z13__spirv_IsNanDv4_d(
-      (void)isnan(d4);
+      (void)sycl::isnan(d4);
       // CHECK: call spir_func <8 x i64> @_Z13__spirv_IsNanDv8_d(
-      (void)isnan(d8);
+      (void)sycl::isnan(d8);
       // CHECK: call spir_func <16 x i64> @_Z13__spirv_IsNanDv16_d(
-      (void)isnan(d16);
+      (void)sycl::isnan(d16);
     }
 
     {
       // CHECK: call spir_func zeroext i1 @_Z21__spirv_LessOrGreaterDF16_DF16_(
-      (void)islessgreater(h, h);
+      (void)sycl::islessgreater(h, h);
       // CHECK: call spir_func <2 x i16> @_Z21__spirv_LessOrGreaterDv2_DF16_S_(
-      (void)islessgreater(h2, h2);
+      (void)sycl::islessgreater(h2, h2);
       // CHECK: call spir_func <4 x i16> @_Z21__spirv_LessOrGreaterDv4_DF16_S_(
-      (void)islessgreater(h4, h4);
+      (void)sycl::islessgreater(h4, h4);
       // CHECK: call spir_func <8 x i16> @_Z21__spirv_LessOrGreaterDv8_DF16_S_(
-      (void)islessgreater(h8, h8);
+      (void)sycl::islessgreater(h8, h8);
       // CHECK: call spir_func <16 x i16> @_Z21__spirv_LessOrGreaterDv16_DF16_S_(
-      (void)islessgreater(h16, h16);
+      (void)sycl::islessgreater(h16, h16);
 
       // CHECK: call spir_func zeroext i1 @_Z21__spirv_LessOrGreaterff(
-      (void)islessgreater(f, f);
+      (void)sycl::islessgreater(f, f);
       // CHECK: call spir_func <2 x i32> @_Z21__spirv_LessOrGreaterDv2_fS_(
-      (void)islessgreater(f2, f2);
+      (void)sycl::islessgreater(f2, f2);
       // CHECK: call spir_func <4 x i32> @_Z21__spirv_LessOrGreaterDv4_fS_(
-      (void)islessgreater(f4, f4);
+      (void)sycl::islessgreater(f4, f4);
       // CHECK: call spir_func <8 x i32> @_Z21__spirv_LessOrGreaterDv8_fS_(
-      (void)islessgreater(f8, f8);
+      (void)sycl::islessgreater(f8, f8);
       // CHECK: call spir_func <16 x i32> @_Z21__spirv_LessOrGreaterDv16_fS_(
-      (void)islessgreater(f16, f16);
+      (void)sycl::islessgreater(f16, f16);
 
       // CHECK: call spir_func zeroext i1 @_Z21__spirv_LessOrGreaterdd(
-      (void)islessgreater(d, d);
+      (void)sycl::islessgreater(d, d);
       // CHECK: call spir_func <2 x i64> @_Z21__spirv_LessOrGreaterDv2_dS_(
-      (void)islessgreater(d2, d2);
+      (void)sycl::islessgreater(d2, d2);
       // CHECK: call spir_func <4 x i64> @_Z21__spirv_LessOrGreaterDv4_dS_(
-      (void)islessgreater(d4, d4);
+      (void)sycl::islessgreater(d4, d4);
       // CHECK: call spir_func <8 x i64> @_Z21__spirv_LessOrGreaterDv8_dS_(
-      (void)islessgreater(d8, d8);
+      (void)sycl::islessgreater(d8, d8);
       // CHECK: call spir_func <16 x i64> @_Z21__spirv_LessOrGreaterDv16_dS_(
-      (void)islessgreater(d16, d16);
+      (void)sycl::islessgreater(d16, d16);
     }
   });
 


### PR DESCRIPTION
E.g. islessgreater(double16, double16) should return long16.