### PR TITLE
[SYCL] Make sure that SYCL_BUILD_PI_HIP_PLATFORM matches buildbot's case

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -243,6 +243,11 @@ option(SYCL_INCLUDE_TESTS
   "Generate build targets for the SYCL unit tests."
   ${LLVM_INCLUDE_TESTS})
 
+# Ensure that HIP platform is uppercase, to match buildbot's output.
+if(NOT "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "")
+  string(TOUPPER ${SYCL_BUILD_PI_HIP_PLATFORM} SYCL_BUILD_PI_HIP_PLATFORM)
+endif()
+
 # Plugin Library
 add_subdirectory( plugins )
 


### PR DESCRIPTION
A follow up to https://github.com/intel/llvm/pull/4163#discussion_r674920044

`buildbot` script only allows `NVIDIA` capitalise the variable in case user spelled it differently.