### PR TITLE
[sycl-post-link] Fix memory growth on module split

### DIFF
--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -363,7 +363,7 @@ EntryPointNamesGroups groupEntryPoints(const Module &M,
 
   EntryPointNamesGroups EntryPointsGroups;
   EntryPointsGroups.reserve(EntryPointsGroupsMap.size());
-  for (auto& Group : EntryPointsGroupsMap)
+  for (auto &Group : EntryPointsGroupsMap)
     EntryPointsGroups.push_back(std::move(Group.second));
 
   // No entry points met, record this.
@@ -818,8 +818,7 @@ public:
     // Actual reduce memory mode will be turned on in case if number of modules
     // to split is greater than initial splits limit.
     SplitParams.ReduceMemUsage &=
-        (SplitParams.IsSplit &&
-         SplitGroups.size() > SplitsInContextLimit);
+        (SplitParams.IsSplit && SplitGroups.size() > SplitsInContextLimit);
 
     if (SplitParams.ReduceMemUsage) {
       // Make source module bitcode buffer for re-reading it in a new context.


### PR DESCRIPTION
Module splitting is performed via llvm::CloneModule() call. When cloning module
MDNode* instances for split module are allocated in source module's LLVMContext
and kept in memory after split module is destroyed. In case if there are
a lot of split modules and/or they have a lot of metadata nodes it may lead to
memory overflow.
Add optional mode which periodically creates new context and split modules in
that context. It fixes memory growth, but at the cost of greatly increased
processing time.
This mode is off by default and can be turned on via option
'-reduce-memory-usage=true'.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>