### PR TITLE
[Driver] Add parsing support for /options:strict, new in Visual Studio 2022 version 17.0 RC2

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6577,6 +6577,7 @@ def _SLASH_hotpatch : CLFlag<"hotpatch">;
 def _SLASH_kernel : CLFlag<"kernel">;
 def _SLASH_LN : CLFlag<"LN">;
 def _SLASH_MP : CLJoined<"MP">;
+def _SLASH_options : CLJoined<"options:">;
 def _SLASH_Qfast_transcendentals : CLFlag<"Qfast_transcendentals">;
 def _SLASH_QIfist : CLFlag<"QIfist">;
 def _SLASH_Qimprecise_fwaits : CLFlag<"Qimprecise_fwaits">;

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -492,6 +492,7 @@
 // RUN:     /ofoo.obj \
 // RUN:     /openmp \
 // RUN:     /openmp:experimental \
+// RUN:     /options:strict \
 // RUN:     /Qfast_transcendentals \
 // RUN:     /QIfist \
 // RUN:     /Qimprecise_fwaits \


### PR DESCRIPTION
Visual Studio 2022 version 17.0 RC2 has a new option /options:strict.
Although it's not supported by clang-cl, we add this parsing support
so clang-cl will not treat it as the "/o" option.

Signed-off-by: Qichao Gu <qichao.gu@intel.com>