### PR TITLE
[SYCL][XPTI] Fix incorrect ifdef breaking gcc build

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -43,7 +43,7 @@ namespace detail {
 #define __CODELOC_LINE 0
 #endif
 
-#if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
+#if _MSC_VER > 1929 || __has_builtin(__builtin_COLUMN)
 #define __CODELOC_COLUMN __builtin_COLUMN()
 #else
 #define __CODELOC_COLUMN 0


### PR DESCRIPTION
This was introduced in #5023, and broke the build with recent gcc
(11.1), as gcc doesn't implement `__builtin_COLUMN` (according to
LanguageExtensions.rst).

The `ifdef` was simply checking for the wrong one, the build works fine
with this patch.