### PR TITLE
[SYCL] Conditionally enable diagnosing that requires integration header

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -273,7 +273,7 @@ LANGOPT(
     "get/operator[], get_id/operator[] and get_global_id/get_global_linear_id "
     "in SYCL class id, iterm and nd_iterm")
 LANGOPT(SYCLDisableRangeRounding, 1, 0, "Disable parallel for range rounding")
-LANGOPT(SYCLEnableIntHeader, 1, 0, "Enable diagnostics based on SYCL integration header")
+LANGOPT(SYCLEnableIntHeaderDiags, 1, 0, "Enable diagnostics based on SYCL integration header")
 
 LANGOPT(HIPUseNewLaunchAPI, 1, 0, "Use new kernel launching API for HIP")
 

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -273,7 +273,8 @@ LANGOPT(
     "get/operator[], get_id/operator[] and get_global_id/get_global_linear_id "
     "in SYCL class id, iterm and nd_iterm")
 LANGOPT(SYCLDisableRangeRounding, 1, 0, "Disable parallel for range rounding")
-LANGOPT(SYCLEnableIntHeaderDiags, 1, 0, "Enable diagnostics based on SYCL integration header")
+LANGOPT(SYCLEnableIntHeaderDiags, 1, 0, "Enable diagnostics that require the "
+        "SYCL integration header")
 
 LANGOPT(HIPUseNewLaunchAPI, 1, 0, "Use new kernel launching API for HIP")
 

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -273,6 +273,7 @@ LANGOPT(
     "get/operator[], get_id/operator[] and get_global_id/get_global_linear_id "
     "in SYCL class id, iterm and nd_iterm")
 LANGOPT(SYCLDisableRangeRounding, 1, 0, "Disable parallel for range rounding")
+LANGOPT(SYCLEnableIntHeader, 1, 0, "Enable diagnostics based on SYCL integration header")
 
 LANGOPT(HIPUseNewLaunchAPI, 1, 0, "Use new kernel launching API for HIP")
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6057,7 +6057,7 @@ def fenable_sycl_dae : Flag<["-"], "fenable-sycl-dae">,
 def fsycl_disable_range_rounding : Flag<["-"], "fsycl-disable-range-rounding">,
   HelpText<"Disable parallel for range rounding.">,
   MarshallingInfoFlag<LangOpts<"SYCLDisableRangeRounding">>;
-def fsycl_enable_int_header: Flag<["-"], "fsycl-enable-int-header-diags">,
+def fsycl_enable_int_header_diags: Flag<["-"], "fsycl-enable-int-header-diags">,
   HelpText<"Enable diagnostics based on SYCL integration header.">,
   MarshallingInfoFlag<LangOpts<"SYCLEnableIntHeaderDiags">>;
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6057,6 +6057,9 @@ def fenable_sycl_dae : Flag<["-"], "fenable-sycl-dae">,
 def fsycl_disable_range_rounding : Flag<["-"], "fsycl-disable-range-rounding">,
   HelpText<"Disable parallel for range rounding.">,
   MarshallingInfoFlag<LangOpts<"SYCLDisableRangeRounding">>;
+def fsycl_enable_int_header: Flag<["-"], "fsycl-enable-int-header">,
+  HelpText<"Enable diagnostics based on SYCL integration header.">,
+  MarshallingInfoFlag<LangOpts<"SYCLEnableIntHeader">>;
 
 } // let Flags = [CC1Option, NoDriverOption]
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6057,9 +6057,9 @@ def fenable_sycl_dae : Flag<["-"], "fenable-sycl-dae">,
 def fsycl_disable_range_rounding : Flag<["-"], "fsycl-disable-range-rounding">,
   HelpText<"Disable parallel for range rounding.">,
   MarshallingInfoFlag<LangOpts<"SYCLDisableRangeRounding">>;
-def fsycl_enable_int_header: Flag<["-"], "fsycl-enable-int-header">,
+def fsycl_enable_int_header: Flag<["-"], "fsycl-enable-int-header-diags">,
   HelpText<"Enable diagnostics based on SYCL integration header.">,
-  MarshallingInfoFlag<LangOpts<"SYCLEnableIntHeader">>;
+  MarshallingInfoFlag<LangOpts<"SYCLEnableIntHeaderDiags">>;
 
 } // let Flags = [CC1Option, NoDriverOption]
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6058,7 +6058,7 @@ def fsycl_disable_range_rounding : Flag<["-"], "fsycl-disable-range-rounding">,
   HelpText<"Disable parallel for range rounding.">,
   MarshallingInfoFlag<LangOpts<"SYCLDisableRangeRounding">>;
 def fsycl_enable_int_header_diags: Flag<["-"], "fsycl-enable-int-header-diags">,
-  HelpText<"Enable diagnostics based on SYCL integration header.">,
+  HelpText<"Enable diagnostics that require the SYCL integration header.">,
   MarshallingInfoFlag<LangOpts<"SYCLEnableIntHeaderDiags">>;
 
 } // let Flags = [CC1Option, NoDriverOption]

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4853,6 +4853,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         // header file.
         CmdArgs.push_back("-dependency-filter");
         CmdArgs.push_back(Args.MakeArgString(Header));
+
+        // Since this is host compilation and integration header is included,
+        // enable integration header based diagnostics.
+        CmdArgs.push_back("-fsycl-enable-int-header");
       }
       // Let the FE know we are doing a SYCL offload compilation, but we are
       // doing the host pass.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4854,9 +4854,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-dependency-filter");
         CmdArgs.push_back(Args.MakeArgString(Header));
 
-        // Since this is host compilation and integration header is included,
-        // enable integration header based diagnostics.
-        CmdArgs.push_back("-fsycl-enable-int-header");
+        // Since this is a host compilation and the integration header is
+        // included, enable the integration header based diagnostics.
+        CmdArgs.push_back("-fsycl-enable-int-header-diags");
       }
       // Let the FE know we are doing a SYCL offload compilation, but we are
       // doing the host pass.

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -491,6 +491,13 @@ static bool FixupInvocation(CompilerInvocation &Invocation,
     Diags.Report(diag::err_drv_argument_not_allowed_with) << "-fsycl-is-device"
                                                           << "-fsycl-is-host";
 
+  // SYCLEnableIntHeader implies SYCLIsHost. Error if
+  // -fsycl-enable-int-header-diags is passed without -fsycl-is-host.
+  if (LangOpts.SYCLEnableIntHeaderDiags && !LangOpts.SYCLIsHost)
+    Diags.Report(diag::err_opt_not_valid_without_opt)
+        << "-fsycl-enable-int-header-diags"
+        << "-fsycl-is-host";
+
   if (Args.hasArg(OPT_fgnu89_inline) && LangOpts.CPlusPlus)
     Diags.Report(diag::err_drv_argument_not_allowed_with)
         << "-fgnu89-inline" << GetInputKindName(IK);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3528,7 +3528,9 @@ public:
           // case will resolve to ::main::KernelName1 (instead of
           // ::KernelName1). Since this is not visible to runtime code that
           // submits kernels, this is invalid.
-          if (Tag->isCompleteDefinition() || S.getLangOpts().SYCLIsHost) {
+          if (Tag->isCompleteDefinition() ||
+              (S.getLangOpts().SYCLIsHost &&
+               S.getLangOpts().SYCLEnableIntHeader)) {
             S.Diag(KernelInvocationFuncLoc,
                    diag::err_sycl_kernel_incorrectly_named)
                 << /* kernel name should be forward declarable at namespace

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3529,8 +3529,7 @@ public:
           // ::KernelName1). Since this is not visible to runtime code that
           // submits kernels, this is invalid.
           if (Tag->isCompleteDefinition() ||
-              (S.getLangOpts().SYCLIsHost &&
-               S.getLangOpts().SYCLEnableIntHeader)) {
+              S.getLangOpts().SYCLEnableIntHeaderDiags) {
             S.Diag(KernelInvocationFuncLoc,
                    diag::err_sycl_kernel_incorrectly_named)
                 << /* kernel name should be forward declarable at namespace

--- a/clang/test/CodeGenSYCL/loop_fusion_host.cpp
+++ b/clang/test/CodeGenSYCL/loop_fusion_host.cpp
@@ -5,14 +5,6 @@ __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();
 }
 
-// This test uses SYCL host only mode without integration header, so
-// forward declare used kernel name class, otherwise it will be diagnosed by
-// the diagnostic implemented in https://github.com/intel/llvm/pull/4945.
-// The error happens because in host mode it is assumed that all kernel names
-// are forward declared at global or namespace scope because of integration
-// header.
-class kernel_name_1;
-
 template <int SIZE>
 class KernelFunctor5 {
 public:

--- a/clang/test/CodeGenSYCL/stall_enable_host.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable_host.cpp
@@ -2,14 +2,6 @@
 
 // Tests for IR of Intel FPGA [[intel::use_stall_enable_clusters]] function attribute on Host (no-op in IR-CodeGen for host-mode).
 
-// This test uses SYCL host only mode without integration header, so
-// forward declare used kernel name class, otherwise it will be diagnosed by
-// the diagnostic implemented in https://github.com/intel/llvm/pull/4945.
-// The error happens because in host mode it is assumed that all kernel names
-// are forward declared at global or namespace scope because of integration
-// header.
-class kernel_name_1;
-
 [[intel::use_stall_enable_clusters]] void test() {}
 
 void test1() {

--- a/clang/test/Frontend/sycl-int-header-diags.cpp
+++ b/clang/test/Frontend/sycl-int-header-diags.cpp
@@ -1,0 +1,7 @@
+// Test that we disallow -fsycl-enable-int-header-diags without -fsycl-is-host.
+
+// RUN: not %clang_cc1 -fsycl-enable-int-header-diags %s 2>&1 | FileCheck --check-prefix=ERROR %s
+// RUN: not %clang_cc1 -fsycl-is-device -fsycl-enable-int-header-diags %s 2>&1 | FileCheck --check-prefix=ERROR %s
+
+// ERROR: error: option '-fsycl-enable-int-header-diags' cannot be specified without '-fsycl-is-host'
+

--- a/clang/test/Frontend/sycl-int-header-diags.cpp
+++ b/clang/test/Frontend/sycl-int-header-diags.cpp
@@ -4,4 +4,3 @@
 // RUN: not %clang_cc1 -fsycl-is-device -fsycl-enable-int-header-diags %s 2>&1 | FileCheck --check-prefix=ERROR %s
 
 // ERROR: error: option '-fsycl-enable-int-header-diags' cannot be specified without '-fsycl-is-host'
-

--- a/clang/test/SemaSYCL/non-fwd-declarable-kernel-name.cpp
+++ b/clang/test/SemaSYCL/non-fwd-declarable-kernel-name.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fno-sycl-unnamed-lambda -fsyntax-only -sycl-std=2020 -fsycl-int-header=%t.h %s
-// RUN: %clang_cc1 -fsycl-is-host -DHEADER_FLAG -fsycl-enable-int-header -internal-isystem %S/Inputs -fno-sycl-unnamed-lambda -fsyntax-only -verify -include %t.h %s
+// RUN: %clang_cc1 -fsycl-is-host -DHEADER_FLAG -fsycl-enable-int-header-diags -internal-isystem %S/Inputs -fno-sycl-unnamed-lambda -fsyntax-only -verify -include %t.h %s
 // RUN: %clang_cc1 -fsycl-is-host -DNO_HEADER_FLAG -internal-isystem %S/Inputs -fno-sycl-unnamed-lambda -fsyntax-only -verify -include %t.h %s
 
 // This test verifies that incorrect kernel names are diagnosed correctly if

--- a/clang/test/SemaSYCL/non-fwd-declarable-kernel-name.cpp
+++ b/clang/test/SemaSYCL/non-fwd-declarable-kernel-name.cpp
@@ -1,7 +1,13 @@
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fno-sycl-unnamed-lambda -fsyntax-only -sycl-std=2020 -fsycl-int-header=%t.h %s
-// RUN: %clang_cc1 -fsycl-is-host -internal-isystem %S/Inputs -fno-sycl-unnamed-lambda -fsyntax-only -verify -include %t.h %s
+// RUN: %clang_cc1 -fsycl-is-host -DHEADER_FLAG -fsycl-enable-int-header -internal-isystem %S/Inputs -fno-sycl-unnamed-lambda -fsyntax-only -verify -include %t.h %s
+// RUN: %clang_cc1 -fsycl-is-host -DNO_HEADER_FLAG -internal-isystem %S/Inputs -fno-sycl-unnamed-lambda -fsyntax-only -verify -include %t.h %s
 
-// This test verifies that incorrect kernel names are diagnosed correctly.
+// This test verifies that incorrect kernel names are diagnosed correctly if
+// integration header is included.
+
+#ifdef NO_HEADER_FLAG
+// expected-no-diagnostics
+#endif // NO_HEADER_FLAG
 
 #include "sycl.hpp"
 
@@ -29,18 +35,24 @@ int main() {
   });
 
   class NotOk;
+#ifdef HEADER_FLAG
   // expected-error@#KernelSingleTask {{'NotOk' is invalid; kernel name should be forward declarable at namespace scope}}
-  // expected-note@+2 {{in instantiation of function template specialization}}
+  // expected-note@+3 {{in instantiation of function template specialization}}
+#endif // HEADER_FLAG
   q.submit([&](handler &h) {
     h.single_task<class NotOk>([]() { function(); });
   });
+#ifdef HEADER_FLAG
   // expected-error@#KernelSingleTask {{'myWrapper::insideStruct' is invalid; kernel name should be forward declarable at namespace scope}}
-  // expected-note@+2 {{in instantiation of function template specialization}}
+  // expected-note@+3 {{in instantiation of function template specialization}}
+#endif // HEADER_FLAG
   q.submit([&](handler &h) {
     h.single_task<class myWrapper::insideStruct>([]() { function(); });
   });
+#ifdef HEADER_FLAG
   // expected-error@#KernelSingleTask {{'RandomTemplate<NotOk>' is invalid; kernel name should be forward declarable at namespace scope}}
-  // expected-note@+2 {{in instantiation of function template specialization}}
+  // expected-note@+3 {{in instantiation of function template specialization}}
+#endif // HEADER_FLAG
   q.submit([&](handler &h) {
     h.single_task<RandomTemplate<NotOk>>([]() { function(); });
   });

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -6,14 +6,6 @@
 #include <CL/sycl.hpp>
 #include <sycl/ext/intel/online_compiler.hpp>
 
-// This test uses SYCL host only mode without integration header, so
-// forward declare used kernel name class, otherwise it will be diagnosed by
-// the diagnostic implemented in https://github.com/intel/llvm/pull/4945.
-// The error happens because in host mode it is assumed that all kernel names
-// are forward declared at global or namespace scope because of integration
-// header.
-class Test;
-
 int main() {
   cl_context ClCtx;
   // expected-error@+1 {{no matching constructor for initialization of 'sycl::context'}}


### PR DESCRIPTION
https://github.com/intel/llvm/pull/4945 introduced a new diagnostic that
works correcly only if integration header is included. However it is
possible that `-fsycl-is-host` flag can be used without integration
header, so the diagnostic should be issued only if integration header is
incuded. This patch adds new cc1 option that helps to understand that.