### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3238,7 +3238,7 @@ public:
     assert(ClassTy && "Type must be a C++ record type");
     if (Util::isSyclType(FieldTy, "accessor", true /*Tmp*/)) {
       const auto *AccTy =
-          dyn_cast<ClassTemplateSpecializationDecl>(FieldTy->getAsRecordDecl());
+          cast<ClassTemplateSpecializationDecl>(FieldTy->getAsRecordDecl());
       assert(AccTy->getTemplateArgs().size() >= 2 &&
              "Incorrect template args for Accessor Type");
       int Dims = static_cast<int>(


### PR DESCRIPTION
Found via a static-analysis tool:
Result of function that may return NULL will be dereferenced

Inside handleSyclSpecialType() in SemaSYCL.cpp file:
```
if (Util::isSyclType(FieldTy, "accessor", true /*Tmp*/)) {
  const auto *AccTy =
      dyn_cast<ClassTemplateSpecializationDecl>(FieldTy->getAsRecordDecl()); --->Pointer 'AccTy'
      returned from call to function 'dyn_cast<clang::ClassTemplateSpecializationDecl,clang::RecordDecl>' may be NULL

  assert(AccTy->getTemplateArgs().size() >= 2 && --> Pointer 'AccTy' will be dereferenced here
         "Incorrect template args for Accessor Type");
```
This patch checks cast<> instead of dyn_cast<> so that the 'cast' above should assert on null or wrong type.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>