### PR TITLE
[SYCL] Add a built-in kernel test

### DIFF
--- a/sycl/unittests/kernel-and-program/DeviceInfo.cpp
+++ b/sycl/unittests/kernel-and-program/DeviceInfo.cpp
@@ -108,10 +108,10 @@ TEST_F(DeviceInfoTest, BuiltInKernelIDs) {
 
   auto ids = Dev.get_info<info::device::built_in_kernel_ids>();
 
-  EXPECT_EQ(ids.size(), 3u);
-  EXPECT_EQ(ids[0].get_name(), std::string{"Kernel0"});
-  EXPECT_EQ(ids[1].get_name(), std::string{"Kernel1"});
-  EXPECT_EQ(ids[2].get_name(), std::string{"Kernel2"});
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_STREQ(ids[0].get_name(), "Kernel0");
+  EXPECT_STREQ(ids[1].get_name(), "Kernel1");
+  EXPECT_STREQ(ids[2].get_name(), "Kernel2");
 
   errc val = errc::success;
   std::string msg;

--- a/sycl/unittests/kernel-and-program/DeviceInfo.cpp
+++ b/sycl/unittests/kernel-and-program/DeviceInfo.cpp
@@ -19,6 +19,8 @@ struct TestCtx {
 
   context &Ctx;
   bool UUIDInfoCalled = false;
+
+  std::string BuiltInKernels;
 };
 } // namespace
 
@@ -31,6 +33,13 @@ static pi_result redefinedDeviceGetInfo(pi_device device,
                                         size_t *param_value_size_ret) {
   if (param_name == PI_DEVICE_INFO_UUID) {
     TestContext->UUIDInfoCalled = true;
+  } else if (param_name == PI_DEVICE_INFO_BUILT_IN_KERNELS) {
+    if (param_value_size_ret) {
+      *param_value_size_ret = TestContext->BuiltInKernels.size() + 1;
+    } else if (param_value) {
+      char *dst = static_cast<char *>(param_value);
+      dst[TestContext->BuiltInKernels.copy(dst, param_value_size)] = '\0';
+    }
   }
 
   return PI_SUCCESS;
@@ -84,4 +93,36 @@ TEST_F(DeviceInfoTest, GetDeviceUUID) {
   EXPECT_EQ(sizeof(UUID), 16 * sizeof(unsigned char))
       << "Expect device UUID to be "
       << "of 16 bytes";
+}
+
+TEST_F(DeviceInfoTest, BuiltInKernelIDs) {
+  if (Plt.is_host()) {
+    return;
+  }
+
+  context Ctx{Plt.get_devices()[0]};
+  TestContext.reset(new TestCtx(Ctx));
+  TestContext->BuiltInKernels = "Kernel0;Kernel1;Kernel2";
+
+  device Dev = Ctx.get_devices()[0];
+
+  auto ids = Dev.get_info<info::device::built_in_kernel_ids>();
+
+  EXPECT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0].get_name(), std::string{"Kernel0"});
+  EXPECT_EQ(ids[1].get_name(), std::string{"Kernel1"});
+  EXPECT_EQ(ids[2].get_name(), std::string{"Kernel2"});
+
+  errc val = errc::success;
+  std::string msg;
+  try {
+    get_kernel_bundle<bundle_state::executable>(Ctx, {Dev}, ids);
+  } catch (sycl::exception &e) {
+    val = errc(e.code().value());
+    msg = e.what();
+  }
+
+  EXPECT_EQ(val, errc::kernel_argument);
+  EXPECT_EQ(
+      msg, "Attempting to use a built-in kernel. They are not fully supported");
 }


### PR DESCRIPTION
- Check `device::get_info<info::device::built_in_kernel_ids>`.
- Check that an attempt to get a kernel bundle with built-in kernels leads to an exception, since they are not yet fully supported.

The above functionality was added in #4996.