### PR TITLE
[SYCL] Allow library mismatch for libdevice host object on Win32

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -27,6 +27,10 @@ set(compile_opts
   -sycl-std=2017
   )
 
+if (WIN32)
+	set(compile_opts "-D_ALLOW_RUNTIME_LIBRARY_MISMATCH ${compile_opts}")
+endif()
+
 set(devicelib-obj-file ${obj_binary_dir}/libsycl-crt.${lib-suffix})
 add_custom_command(OUTPUT ${devicelib-obj-file}
                    COMMAND ${clang} -fsycl -c

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -28,7 +28,7 @@ set(compile_opts
   )
 
 if (WIN32)
-	set(compile_opts "-D_ALLOW_RUNTIME_LIBRARY_MISMATCH ${compile_opts}")
+  set(compile_opts "-D_ALLOW_RUNTIME_LIBRARY_MISMATCH ${compile_opts}")
 endif()
 
 set(devicelib-obj-file ${obj_binary_dir}/libsycl-crt.${lib-suffix})

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -28,7 +28,7 @@ set(compile_opts
   )
 
 if (WIN32)
-  set(compile_opts "-D_ALLOW_RUNTIME_LIBRARY_MISMATCH ${compile_opts}")
+  list(APPEND compile_opts -D_ALLOW_RUNTIME_LIBRARY_MISMATCH)
 endif()
 
 set(devicelib-obj-file ${obj_binary_dir}/libsycl-crt.${lib-suffix})


### PR DESCRIPTION
VC++ yvals.h header file sets up linker directives like this:
  /FAILIFMISMATCH:RuntimeLibrary=MT_StaticRelease

This will break linking, if the final standard libraries linked
to the program have different configuration. Since the host part
of libdevice objects is empty, we do not care about the mismatch
checking.

Signed-off-by: jinge90 <ge.jin@intel.com>