### PR TITLE
[SYCL] Use incude/sycl/CL as the target to check copied headers

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -120,7 +120,7 @@ file(GLOB_RECURSE HEADERS_IN_SYCL_DIR CONFIGURE_DEPENDS "${sycl_inc_dir}/sycl/*"
 file(GLOB_RECURSE HEADERS_IN_CL_DIR CONFIGURE_DEPENDS "${sycl_inc_dir}/CL/*")
 string(REPLACE "${sycl_inc_dir}" "${SYCL_INCLUDE_BUILD_DIR}"
   OUT_HEADERS_IN_SYCL_DIR "${HEADERS_IN_SYCL_DIR}")
-string(REPLACE "${sycl_inc_dir}" "${SYCL_INCLUDE_BUILD_DIR}"
+string(REPLACE "${sycl_inc_dir}/CL" "${SYCL_INCLUDE_BUILD_DIR}/sycl/CL"
   OUT_HEADERS_IN_CL_DIR "${HEADERS_IN_CL_DIR}")
 
 # Copy SYCL headers from sources to build directory


### PR DESCRIPTION
When the sycl-headers target calls the copy_directory command, the
command sees that the ${OUT_HEADERS_IN_CL_DIR} output already exists
and the files are already there. Before the patch, the command
looked for the include/CL directory, not include/sycl/CL one, there was
no such directory and the headers were copied again and again.

Now when we ask CMake to build the sycl-headers target twice, the
'Copying SYCL headers ...' message is displayed only after the first
time.

Co-authored-by: tcreech-intel <timothy.m.creech@intel.com>