### PR TITLE
[SYCL][FPGA][NFC] Update [[intel::use_stall_enable_clusters]] attribute

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3560,18 +3560,10 @@ static void handleSYCLIntelNumSimdWorkItemsAttr(Sema &S, Decl *D,
 }
 
 // Handles use_stall_enable_clusters
-static void handleUseStallEnableClustersAttr(Sema &S, Decl *D,
-                                             const ParsedAttr &Attr) {
-  if (D->isInvalidDecl())
-    return;
-
-  unsigned NumArgs = Attr.getNumArgs();
-  if (NumArgs > 0) {
-    S.Diag(Attr.getLoc(), diag::warn_attribute_too_many_arguments) << Attr << 0;
-    return;
-  }
-
-  handleSimpleAttribute<SYCLIntelUseStallEnableClustersAttr>(S, D, Attr);
+static void handleSYCLIntelUseStallEnableClustersAttr(Sema &S, Decl *D,
+                                                      const ParsedAttr &A) {
+  D->addAttr(::new (S.Context)
+                 SYCLIntelUseStallEnableClustersAttr(S.Context, A));
 }
 
 // Handles disable_loop_pipelining attribute.
@@ -9979,7 +9971,7 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     handleSYCLIntelNoGlobalWorkOffsetAttr(S, D, AL);
     break;
   case ParsedAttr::AT_SYCLIntelUseStallEnableClusters:
-    handleUseStallEnableClustersAttr(S, D, AL);
+    handleSYCLIntelUseStallEnableClustersAttr(S, D, AL);
     break;
   case ParsedAttr::AT_SYCLIntelLoopFuse:
     handleSYCLIntelLoopFuseAttr(S, D, AL);


### PR DESCRIPTION
This patch refactors [[intel::use_stall_enable_clusters]] attribute:

           1. Uses automatic diagnostic checking when passing the wrong
              number of arguments and this behavior is more consistent with other attributes

           2. The attribute has no arguments, So this only returns
              the attribute itself instead of
              handleSimpleAttribute<SYCLIntelUseStallEnableClustersAttr>

           3. Existing test (SemaSYCL/stall_enable_device.cpp) shows
              the behavior of automatic diagnostic checking when passing
              the wrong number of arguments

              Example:
              [[intel::use_stall_enable_clusters(1)]] void test1() {} 
              // expected-error{{'use_stall_enable_clusters' attribute takes no arguments}}

Signed-off-by: Soumi Manna <soumi.manna@intel.com>