### PR TITLE
[CI] Do not build containers on each commit

### DIFF
--- a/.github/workflows/sycl_containers.yaml
+++ b/.github/workflows/sycl_containers.yaml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - sycl
+    paths:
+      - 'devops/containers/**'
 
 jobs:
   base_image_ubuntu2004:
@@ -18,21 +20,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Check if dependencies have changed
-        id: deps_changed
-        shell: bash {0}
-        run: |
-          git diff --exit-code HEAD~1 -- devops/containers/ubuntu2004_base.Dockerfile
-          echo "::set-output name=flag::$?"
       - name: Login to GitHub Container Registry
-        if: ${{ (github.event_name != 'push') || steps.deps_changed.outputs.flag}}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Container
-        if: ${{ (github.event_name != 'push') || steps.deps_changed.outputs.flag}}
         uses: docker/build-push-action@v2
         with:
           push: true
@@ -52,21 +46,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Check if dependencies have changed
-        id: deps_changed
-        shell: bash {0}
-        run: |
-          git diff --exit-code HEAD~1 -- devops/containers/ubuntu2004_intel_drivers.Dockerfile
-          echo "::set-output name=flag::$?"
       - name: Login to GitHub Container Registry
-        if: ${{ (github.event_name != 'push') || steps.deps_changed.outputs.flag}}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Container
-        if: ${{ (github.event_name != 'push') || steps.deps_changed.outputs.flag}}
         uses: docker/build-push-action@v2
         with:
           push: true


### PR DESCRIPTION
Restrict push trigger only to commits that affect `devops/containers/**`: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-positive-and-negative-patterns-1