### PR TITLE
[CI] Add libclc tests to pre- and post-commit validation

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -137,6 +137,10 @@ jobs:
       if: always()
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-xptifw
+    - name: check-libclc
+      if: always()
+      run: |
+        cmake --build $GITHUB_WORKSPACE/build --target check-libclc
     - name: Install
       # TODO replace utility installation with a single CMake target
       run: |

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -43,6 +43,8 @@ def do_configure(args):
     sycl_enable_xpti_tracing = 'ON'
     xpti_enable_werror = 'ON'
 
+    build_libclc = False
+
     if args.ci_defaults:
         print("#############################################")
         print("# Default CI configuration will be applied. #")
@@ -50,6 +52,8 @@ def do_configure(args):
 
         # For clang-format and clang-tidy
         llvm_enable_projects += ";clang-tools-extra"
+        # libclc is required for CI validation
+        build_libclc = True
 
     # replace not append, so ARM ^ X86
     if args.arm:
@@ -59,7 +63,7 @@ def do_configure(args):
         sycl_build_pi_esimd_emulator = 'ON'
 
     if args.cuda or args.hip:
-        llvm_enable_projects += ';libclc'
+        build_libclc = True
 
     if args.cuda:
         llvm_targets_to_build += ';NVPTX'
@@ -100,6 +104,9 @@ def do_configure(args):
 
     if args.use_lld:
       llvm_enable_lld = 'ON'
+
+    if build_libclc:
+        llvm_enable_projects += ';libclc'
 
     install_dir = os.path.join(abs_obj_dir, "install")
 

--- a/libclc/test/binding/ocl/acos.cl
+++ b/libclc/test/binding/ocl/acos.cl
@@ -11,8 +11,6 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
-// XFAIL: amdgcn
-
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/asin.cl
+++ b/libclc/test/binding/ocl/asin.cl
@@ -11,8 +11,6 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
-// XFAIL: amdgcn
-
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/cos.cl
+++ b/libclc/test/binding/ocl/cos.cl
@@ -11,8 +11,6 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
-// XFAIL: amdgcn
-
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/sin.cl
+++ b/libclc/test/binding/ocl/sin.cl
@@ -11,8 +11,6 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
-// XFAIL: amdgcn
-
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/sincos.cl
+++ b/libclc/test/binding/ocl/sincos.cl
@@ -11,8 +11,6 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
-// XFAIL: amdgcn
-
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z

--- a/libclc/test/binding/ocl/sqrt.cl
+++ b/libclc/test/binding/ocl/sqrt.cl
@@ -11,8 +11,6 @@
 
 // RUN: %clang -emit-llvm -S -o - %s | FileCheck %s
 
-// XFAIL: amdgcn
-
 #include <spirv/spirv_types.h>
 
 // CHECK-NOT: declare {{.*}} @_Z


### PR DESCRIPTION
Run `check-libclc` as part of continues integration system. Time-wise it shouldn't be noticeable, on an `mi100` node it takes ~3.5sec.

Also adjust `XFAIL`s.