### PR TITLE
Fix bad error message when q.single_task() is used instead of q.submit()

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -24,30 +24,46 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+
+#if !defined(NDEBUG) && (_MSC_VER > 1929 || __has_builtin(__builtin_FILE))
+#define __XPTI_FILE_NAME __builtin_FILE()
+#else
+#define __XPTI_FILE_NAME nullptr
+#endif
+
+#if _MSC_VER > 1929 || __has_builtin(__builtin_FUNCTION)
+#define __XPTI_FUNCTION __builtin_FUNCTION()
+#else
+#define __XPTI_FUNCTION nullptr
+#endif
+
+#if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
+#define __XPTI_LINE __builtin_LINE()
+#else
+#define __XPTI_LINE 0
+#endif
+
+#if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
+#define __XPTI_COLUMN __builtin_COLUMN()
+#else
+#define __XPTI_COLUMN 0
+#endif
+
 // Data structure that captures the user code location information using the
 // builtin capabilities of the compiler
 struct code_location {
-#ifdef _MSC_VER
-  // Since MSVC does not support the required builtins, we
-  // implement the version with "unknown"s which is handled
-  // correctly by the instrumentation
-  static constexpr code_location current(const char *fileName = nullptr,
-                                         const char *funcName = nullptr,
-                                         unsigned long lineNo = 0,
-                                         unsigned long columnNo = 0) noexcept {
-    return code_location(fileName, funcName, lineNo, columnNo);
-  }
-#else
-  // FIXME Having a nullptr for fileName here is a short-term solution to
-  // workaround leak of full paths in builds
   static constexpr code_location
-  current(const char *fileName = nullptr,
-          const char *funcName = __builtin_FUNCTION(),
-          unsigned long lineNo = __builtin_LINE(),
-          unsigned long columnNo = 0) noexcept {
+  current(const char *fileName = __XPTI_FILE_NAME,
+          const char *funcName = __XPTI_FUNCTION,
+          unsigned long lineNo = __XPTI_LINE,
+          unsigned long columnNo = __XPTI_COLUMN) noexcept {
     return code_location(fileName, funcName, lineNo, columnNo);
   }
-#endif
+
+#undef __XPTI_FILE_NAME
+#undef __XPTI_FUNCTION
+#undef __XPTI_LINE
+#undef __XPTI_COLUMN
 
   constexpr code_location(const char *file, const char *func, int line,
                           int col) noexcept

--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -26,44 +26,44 @@ namespace sycl {
 namespace detail {
 
 #if !defined(NDEBUG) && (_MSC_VER > 1929 || __has_builtin(__builtin_FILE))
-#define __XPTI_FILE_NAME __builtin_FILE()
+#define __CODELOC_FILE_NAME __builtin_FILE()
 #else
-#define __XPTI_FILE_NAME nullptr
+#define __CODELOC_FILE_NAME nullptr
 #endif
 
 #if _MSC_VER > 1929 || __has_builtin(__builtin_FUNCTION)
-#define __XPTI_FUNCTION __builtin_FUNCTION()
+#define __CODELOC_FUNCTION __builtin_FUNCTION()
 #else
-#define __XPTI_FUNCTION nullptr
+#define __CODELOC_FUNCTION nullptr
 #endif
 
 #if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
-#define __XPTI_LINE __builtin_LINE()
+#define __CODELOC_LINE __builtin_LINE()
 #else
-#define __XPTI_LINE 0
+#define __CODELOC_LINE 0
 #endif
 
 #if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
-#define __XPTI_COLUMN __builtin_COLUMN()
+#define __CODELOC_COLUMN __builtin_COLUMN()
 #else
-#define __XPTI_COLUMN 0
+#define __CODELOC_COLUMN 0
 #endif
 
 // Data structure that captures the user code location information using the
 // builtin capabilities of the compiler
 struct code_location {
   static constexpr code_location
-  current(const char *fileName = __XPTI_FILE_NAME,
-          const char *funcName = __XPTI_FUNCTION,
-          unsigned long lineNo = __XPTI_LINE,
-          unsigned long columnNo = __XPTI_COLUMN) noexcept {
+  current(const char *fileName = __CODELOC_FILE_NAME,
+          const char *funcName = __CODELOC_FUNCTION,
+          unsigned long lineNo = __CODELOC_LINE,
+          unsigned long columnNo = __CODELOC_COLUMN) noexcept {
     return code_location(fileName, funcName, lineNo, columnNo);
   }
 
-#undef __XPTI_FILE_NAME
-#undef __XPTI_FUNCTION
-#undef __XPTI_LINE
-#undef __XPTI_COLUMN
+#undef __CODELOC_FILE_NAME
+#undef __CODELOC_FUNCTION
+#undef __CODELOC_LINE
+#undef __CODELOC_COLUMN
 
   constexpr code_location(const char *file, const char *func, int line,
                           int col) noexcept

--- a/sycl/include/CL/sycl/queue.hpp
+++ b/sycl/include/CL/sycl/queue.hpp
@@ -688,8 +688,10 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(_KERNELFUNCPARAM(KernelFunc) _CODELOCPARAM(&CodeLoc)) {
+    static_assert((detail::check_fn_signature<detail::remove_reference_t<KernelType>, void()>::value ||
+    detail::check_fn_signature<detail::remove_reference_t<KernelType>, void(kernel_handler)>::value),
+    "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead");
     _CODELOCARG(&CodeLoc);
-
     return submit(
         [&](handler &CGH) {
           CGH.template single_task<KernelName, KernelType>(KernelFunc);
@@ -705,6 +707,9 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(event DepEvent,
                     _KERNELFUNCPARAM(KernelFunc) _CODELOCPARAM(&CodeLoc)) {
+    static_assert((detail::check_fn_signature <detail::remove_reference_t<KernelType>, void()>::value || 
+    detail::check_fn_signature<detail::remove_reference_t<KernelType>, void(kernel_handler)>::value), 
+    "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead");
     _CODELOCARG(&CodeLoc);
     return submit(
         [&](handler &CGH) {
@@ -723,6 +728,9 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(const std::vector<event> &DepEvents,
                     _KERNELFUNCPARAM(KernelFunc) _CODELOCPARAM(&CodeLoc)) {
+    static_assert((detail::check_fn_signature<detail::remove_reference_t<KernelType>, void()>::value ||
+    detail::check_fn_signature<detail::remove_reference_t<KernelType>, void(kernel_handler)>::value),
+    "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead");
     _CODELOCARG(&CodeLoc);
     return submit(
         [&](handler &CGH) {

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -11,13 +11,13 @@ int main() {
   auto code_loc = sycl::detail::code_location::current();
   const char *funcName = "main";
 #ifdef NDEBUG
-  if (code_loc.fileName() != nullptr) 
+  if (code_loc.fileName() != nullptr)
     return 1;
-  if (code_loc.functionName() != funcName) 
+  if (code_loc.functionName() != funcName)
     return 1;
-  if (code_loc.lineNumber() != 11) 
+  if (code_loc.lineNumber() != 11)
     return 1;
-  if (code_loc.columnNumber() != 19) 
+  if (code_loc.columnNumber() != 19)
     return 1;
 #else
   assert((code_loc.fileName() != nullptr));

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -1,0 +1,41 @@
+// RUN: %clangxx -fsycl -DNDEBUG %s -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %t.out
+
+#include <CL/sycl.hpp>
+#include <cassert>
+#include <iostream>
+
+int main() {
+    auto code_loc = sycl::detail::code_location::current();
+    const char* currentFunction = "main";
+    #ifdef NDEBUG
+    if (code_loc.fileName() != nullptr) {
+        return 1;
+    }
+    if (code_loc.functionName() != currentFunction) {
+        return 1;
+    }
+    if (code_loc.lineNumber() != 11) {
+        return 1;
+    }
+    if (code_loc.columnNumber() != 21){
+        return 1;
+    }
+    //std::cout << "NDEBUG asserts passed" << std::endl;
+    #else
+    assert((code_loc.fileName() != nullptr));
+    std::string str = code_loc.fileName();
+    assert(((str.find("code_location.cpp") != std::string::npos) && "Filename is wrong"));
+    assert((code_loc.functionName() != nullptr));
+    str = code_loc.functionName();
+    assert(((str.find(currentFunction) != std::string::npos) && "Function name is wrong"));
+    assert((code_loc.lineNumber() != 0));
+    assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
+    assert((code_loc.columnNumber() != 0));
+    assert(((code_loc.columnNumber() == 21) && "Column number is wrong"));
+    //std::cout << "asserts without NDEBUG passed" << std::endl;
+    #endif
+    return 0;
+}

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -8,34 +8,36 @@
 #include <iostream>
 
 int main() {
-    auto code_loc = sycl::detail::code_location::current();
-    const char* currentFunction = "main";
-    #ifdef NDEBUG
-    if (code_loc.fileName() != nullptr) {
-        return 1;
-    }
-    if (code_loc.functionName() != currentFunction) {
-        return 1;
-    }
-    if (code_loc.lineNumber() != 11) {
-        return 1;
-    }
-    if (code_loc.columnNumber() != 21){
-        return 1;
-    }
-    //std::cout << "NDEBUG asserts passed" << std::endl;
-    #else
-    assert((code_loc.fileName() != nullptr));
-    std::string str = code_loc.fileName();
-    assert(((str.find("code_location.cpp") != std::string::npos) && "Filename is wrong"));
-    assert((code_loc.functionName() != nullptr));
-    str = code_loc.functionName();
-    assert(((str.find(currentFunction) != std::string::npos) && "Function name is wrong"));
-    assert((code_loc.lineNumber() != 0));
-    assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
-    assert((code_loc.columnNumber() != 0));
-    assert(((code_loc.columnNumber() == 21) && "Column number is wrong"));
-    //std::cout << "asserts without NDEBUG passed" << std::endl;
-    #endif
-    return 0;
+  auto code_loc = sycl::detail::code_location::current();
+  const char *currentFunction = "main";
+#ifdef NDEBUG
+  if (code_loc.fileName() != nullptr) {
+    return 1;
+  }
+  if (code_loc.functionName() != currentFunction) {
+    return 1;
+  }
+  if (code_loc.lineNumber() != 11) {
+    return 1;
+  }
+  if (code_loc.columnNumber() != 21) {
+    return 1;
+  }
+// std::cout << "NDEBUG asserts passed" << std::endl;
+#else
+  assert((code_loc.fileName() != nullptr));
+  std::string str = code_loc.fileName();
+  assert(((str.find("code_location.cpp") != std::string::npos) &&
+          "Filename is wrong"));
+  assert((code_loc.functionName() != nullptr));
+  str = code_loc.functionName();
+  assert(((str.find(currentFunction) != std::string::npos) &&
+          "Function name is wrong"));
+  assert((code_loc.lineNumber() != 0));
+  assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
+  assert((code_loc.columnNumber() != 0));
+  assert(((code_loc.columnNumber() == 21) && "Column number is wrong"));
+// std::cout << "asserts without NDEBUG passed" << std::endl;
+#endif
+  return 0;
 }

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -9,21 +9,12 @@
 
 int main() {
   auto code_loc = sycl::detail::code_location::current();
-  const char *currentFunction = "main";
+  const char* funcName = "main";
 #ifdef NDEBUG
-  if (code_loc.fileName() != nullptr) {
-    return 1;
-  }
-  if (code_loc.functionName() != currentFunction) {
-    return 1;
-  }
-  if (code_loc.lineNumber() != 11) {
-    return 1;
-  }
-  if (code_loc.columnNumber() != 21) {
-    return 1;
-  }
-// std::cout << "NDEBUG asserts passed" << std::endl;
+  if (code_loc.fileName() != nullptr) return 1;
+  if (code_loc.functionName() != funcName) return 1;
+  if (code_loc.lineNumber() != 11) return 1;
+  if (code_loc.columnNumber() != 19) return 1;
 #else
   assert((code_loc.fileName() != nullptr));
   std::string str = code_loc.fileName();
@@ -31,13 +22,12 @@ int main() {
           "Filename is wrong"));
   assert((code_loc.functionName() != nullptr));
   str = code_loc.functionName();
-  assert(((str.find(currentFunction) != std::string::npos) &&
+  assert(((str.find(funcName) != std::string::npos) &&
           "Function name is wrong"));
   assert((code_loc.lineNumber() != 0));
   assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
   assert((code_loc.columnNumber() != 0));
-  assert(((code_loc.columnNumber() == 21) && "Column number is wrong"));
-// std::cout << "asserts without NDEBUG passed" << std::endl;
+  assert(((code_loc.columnNumber() == 19) && "Column number is wrong"));
 #endif
   return 0;
-}
+} 

--- a/sycl/test/basic_tests/code_location.cpp
+++ b/sycl/test/basic_tests/code_location.cpp
@@ -9,12 +9,16 @@
 
 int main() {
   auto code_loc = sycl::detail::code_location::current();
-  const char* funcName = "main";
+  const char *funcName = "main";
 #ifdef NDEBUG
-  if (code_loc.fileName() != nullptr) return 1;
-  if (code_loc.functionName() != funcName) return 1;
-  if (code_loc.lineNumber() != 11) return 1;
-  if (code_loc.columnNumber() != 19) return 1;
+  if (code_loc.fileName() != nullptr) 
+    return 1;
+  if (code_loc.functionName() != funcName) 
+    return 1;
+  if (code_loc.lineNumber() != 11) 
+    return 1;
+  if (code_loc.columnNumber() != 19) 
+    return 1;
 #else
   assert((code_loc.fileName() != nullptr));
   std::string str = code_loc.fileName();
@@ -22,12 +26,12 @@ int main() {
           "Filename is wrong"));
   assert((code_loc.functionName() != nullptr));
   str = code_loc.functionName();
-  assert(((str.find(funcName) != std::string::npos) &&
-          "Function name is wrong"));
+  assert(
+      ((str.find(funcName) != std::string::npos) && "Function name is wrong"));
   assert((code_loc.lineNumber() != 0));
   assert(((code_loc.lineNumber() == 11) && "Line number is wrong"));
   assert((code_loc.columnNumber() != 0));
   assert(((code_loc.columnNumber() == 19) && "Column number is wrong"));
 #endif
   return 0;
-} 
+}

--- a/sycl/test/basic_tests/single_task_error_message.cpp
+++ b/sycl/test/basic_tests/single_task_error_message.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -Xclang -verify-ignore-unexpected=error -o - %s
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -o - %s
 #include <CL/sycl.hpp>
 #include <iostream>
 int main(){
@@ -8,21 +8,10 @@ int main(){
         int sum  = 0;
         sycl::queue myQueue{};
         {
-            auto bufA   = sycl::buffer(&varA, sycl::range{1});
-            auto bufB   = sycl::buffer(&varB, sycl::range{1});
-            auto bufSum = sycl::buffer(&sum, sycl::range{1});
             myQueue.single_task([&](sycl::handler &cgh) {
-                // expected-error-re@CL/sycl/queue.hpp:691 {{static_assert failed due to requirement 'detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:14:33), void ()>::value || detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:14:33), void (sycl::kernel_handler)>::value' "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead"}}
-                    auto accessorA      = sycl::accessor(bufA, cgh, sycl::read_only);
-                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
-                    auto accessorB      = sycl::accessor(bufB, cgh, sycl::read_only);
-                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
-                    auto accessorResult = sycl::accessor(bufSum, cgh, sycl::write_only);
-                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
-                    cgh.single_task([=] {
-                        accessorResult[0] = accessorA[0] + accessorB[0];
-                    });
-                })
+                // expected-error-re@CL/sycl/queue.hpp:691 {{static_assert failed due to requirement '{{.*}}' "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead"}}
+                // expected-error-re@CL/sycl/detail/cg_types.hpp:191 {{no matching function for call to object of type '(lambda at {{.*}}single_task_error_message.cpp:{{.*}})'}}
+            })
             .wait();
         }
     }
@@ -32,22 +21,11 @@ int main(){
         int sum  = 0;
         sycl::queue myQueue{};
         {
-            auto bufA   = sycl::buffer(&varA, sycl::range{1});
-            auto bufB   = sycl::buffer(&varB, sycl::range{1});
-            auto bufSum = sycl::buffer(&sum, sycl::range{1});
             sycl::event e {};
             myQueue.single_task(e, [&](sycl::handler &cgh) {
-                // expected-error-re@CL/sycl/queue.hpp:710 {{static_assert failed due to requirement 'detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:39:36), void ()>::value || detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:39:36), void (sycl::kernel_handler)>::value' "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead"}}
-                    auto accessorA      = sycl::accessor(bufA, cgh, sycl::read_only);
-                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
-                    auto accessorB      = sycl::accessor(bufB, cgh, sycl::read_only);
-                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
-                    auto accessorResult = sycl::accessor(bufSum, cgh, sycl::write_only);
-                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
-                    cgh.single_task([=] {
-                        accessorResult[0] = accessorA[0] + accessorB[0];
-                    });
-                })
+                // expected-error-re@CL/sycl/queue.hpp:710 {{static_assert failed due to requirement '{{.*}}' "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead"}}
+                // expected-error-re@CL/sycl/detail/cg_types.hpp:191 {{no matching function for call to object of type '(lambda at {{.*}}single_task_error_message.cpp:{{.*}})'}}
+            })
             .wait();
         }
     }
@@ -57,22 +35,11 @@ int main(){
         int sum  = 0;
         sycl::queue myQueue{};
         {
-            auto bufA   = sycl::buffer(&varA, sycl::range{1});
-            auto bufB   = sycl::buffer(&varB, sycl::range{1});
-            auto bufSum = sycl::buffer(&sum, sycl::range{1});
             std::vector<sycl::event> vector_event;
             myQueue.single_task(vector_event, [&](sycl::handler &cgh) {
-                // expected-error-re@CL/sycl/queue.hpp:731 {{static_assert failed due to requirement 'detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:64:47), void ()>::value || detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:64:47), void (sycl::kernel_handler)>::value' "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead"}}
-                    auto accessorA      = sycl::accessor(bufA, cgh, sycl::read_only);
-                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
-                    auto accessorB      = sycl::accessor(bufB, cgh, sycl::read_only);
-                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
-                    auto accessorResult = sycl::accessor(bufSum, cgh, sycl::write_only);
-                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
-                    cgh.single_task([=] {
-                        accessorResult[0] = accessorA[0] + accessorB[0];
-                    });
-                })
+                // expected-error-re@CL/sycl/queue.hpp:731 {{static_assert failed due to requirement '{{.*}}' "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead"}}
+                // expected-error-re@CL/sycl/detail/cg_types.hpp:191 {{no matching function for call to object of type '(lambda at {{.*}}single_task_error_message.cpp:{{.*}})'}}
+            })
             .wait();
         }
     }

--- a/sycl/test/basic_tests/single_task_error_message.cpp
+++ b/sycl/test/basic_tests/single_task_error_message.cpp
@@ -1,0 +1,79 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -Xclang -verify-ignore-unexpected=error -o - %s
+#include <CL/sycl.hpp>
+#include <iostream>
+int main(){
+    {
+        int varA = 42;
+        int varB = 42;
+        int sum  = 0;
+        sycl::queue myQueue{};
+        {
+            auto bufA   = sycl::buffer(&varA, sycl::range{1});
+            auto bufB   = sycl::buffer(&varB, sycl::range{1});
+            auto bufSum = sycl::buffer(&sum, sycl::range{1});
+            myQueue.single_task([&](sycl::handler &cgh) {
+                // expected-error-re@CL/sycl/queue.hpp:691 {{static_assert failed due to requirement 'detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:14:33), void ()>::value || detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:14:33), void (sycl::kernel_handler)>::value' "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead"}}
+                    auto accessorA      = sycl::accessor(bufA, cgh, sycl::read_only);
+                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
+                    auto accessorB      = sycl::accessor(bufB, cgh, sycl::read_only);
+                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
+                    auto accessorResult = sycl::accessor(bufSum, cgh, sycl::write_only);
+                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
+                    cgh.single_task([=] {
+                        accessorResult[0] = accessorA[0] + accessorB[0];
+                    });
+                })
+            .wait();
+        }
+    }
+    {
+        int varA = 42;
+        int varB = 42;
+        int sum  = 0;
+        sycl::queue myQueue{};
+        {
+            auto bufA   = sycl::buffer(&varA, sycl::range{1});
+            auto bufB   = sycl::buffer(&varB, sycl::range{1});
+            auto bufSum = sycl::buffer(&sum, sycl::range{1});
+            sycl::event e {};
+            myQueue.single_task(e, [&](sycl::handler &cgh) {
+                // expected-error-re@CL/sycl/queue.hpp:710 {{static_assert failed due to requirement 'detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:39:36), void ()>::value || detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:39:36), void (sycl::kernel_handler)>::value' "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead"}}
+                    auto accessorA      = sycl::accessor(bufA, cgh, sycl::read_only);
+                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
+                    auto accessorB      = sycl::accessor(bufB, cgh, sycl::read_only);
+                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
+                    auto accessorResult = sycl::accessor(bufSum, cgh, sycl::write_only);
+                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
+                    cgh.single_task([=] {
+                        accessorResult[0] = accessorA[0] + accessorB[0];
+                    });
+                })
+            .wait();
+        }
+    }
+    {
+        int varA = 42;
+        int varB = 42;
+        int sum  = 0;
+        sycl::queue myQueue{};
+        {
+            auto bufA   = sycl::buffer(&varA, sycl::range{1});
+            auto bufB   = sycl::buffer(&varB, sycl::range{1});
+            auto bufSum = sycl::buffer(&sum, sycl::range{1});
+            std::vector<sycl::event> vector_event;
+            myQueue.single_task(vector_event, [&](sycl::handler &cgh) {
+                // expected-error-re@CL/sycl/queue.hpp:731 {{static_assert failed due to requirement 'detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:64:47), void ()>::value || detail::check_fn_signature<(lambda at {{.*}}single_task_error_message.cpp:64:47), void (sycl::kernel_handler)>::value' "sycl::queue.single_task() requires a kernel instead of command group. Use queue.submit() instead"}}
+                    auto accessorA      = sycl::accessor(bufA, cgh, sycl::read_only);
+                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
+                    auto accessorB      = sycl::accessor(bufB, cgh, sycl::read_only);
+                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
+                    auto accessorResult = sycl::accessor(bufSum, cgh, sycl::write_only);
+                    // expected-error@-1 {{'sycl::buffer<int, 1, sycl::detail::aligned_allocator<char>, void> &' cannot be used as the type of a kernel parameter}}
+                    cgh.single_task([=] {
+                        accessorResult[0] = accessorA[0] + accessorB[0];
+                    });
+                })
+            .wait();
+        }
+    }
+}


### PR DESCRIPTION
This patch implements more informative error message when user tries to put command group in q.sigle_task() instead of kernel. 