### PR TITLE
[SYCL] Fix copy-paste error failing to guard the right builtin

### DIFF
--- a/sycl/include/CL/sycl/detail/common.hpp
+++ b/sycl/include/CL/sycl/detail/common.hpp
@@ -43,7 +43,7 @@ namespace detail {
 #define __CODELOC_LINE 0
 #endif
 
-#if _MSC_VER > 1929 || __has_builtin(__builtin_LINE)
+#if _MSC_VER > 1929 || __has_builtin(__builtin_COLUMN)
 #define __CODELOC_COLUMN __builtin_COLUMN()
 #else
 #define __CODELOC_COLUMN 0


### PR DESCRIPTION
I got on Ubuntu 21.10 and GCC 11.2
```
[2481/3144] Building CXX object tools/sycl/source/CMakeFiles/sycl_object.dir/detail/accessor_impl.cpp.o
FAILED: tools/sycl/source/CMakeFiles/sycl_object.dir/detail/accessor_impl.cpp.o 
/usr/bin/c++ -DCL_TARGET_OPENCL_VERSION=220 -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -DXPTI_ENABLE_INSTRUMENTATION -DXPTI_STATIC_LIBRARY -D_DEBUG -D_GLIBCXX_ASSERTIONS=1 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__SYCL_INTERNAL_API -Itools/sycl/source -I/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/sycl/source -Iinclude -I/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/llvm/include -I/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/xpti/include -I/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/sycl/include -isystem _deps/ocl-headers-src -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wmisleading-indentation -fdiagnostics-color -ffunction-sections -fdata-sections -Wall -Wextra -Wno-deprecated-declarations -Werror -O3 -DNDEBUG -UNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden -std=c++17 -MD -MT tools/sycl/source/CMakeFiles/sycl_object.dir/detail/accessor_impl.cpp.o -MF tools/sycl/source/CMakeFiles/sycl_object.dir/detail/accessor_impl.cpp.o.d -o tools/sycl/source/CMakeFiles/sycl_object.dir/detail/accessor_impl.cpp.o -c /home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/sycl/source/detail/accessor_impl.cpp
In file included from /home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/sycl/include/CL/sycl/access/access.hpp:10,
                 from /home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/sycl/include/CL/sycl/detail/accessor_impl.hpp:11,
                 from /home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/sycl/source/detail/accessor_impl.cpp:9:
/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/sycl/include/CL/sycl/detail/common.hpp:47:26: error: ‘__builtin_COLUMN’ was not declared in this scope; did you mean ‘__builtin_round’?
   47 | #define __CODELOC_COLUMN __builtin_COLUMN()
      |                          ^~~~~~~~~~~~~~~~
/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/sycl/include/CL/sycl/detail/common.hpp:59:36: note: in expansion of macro ‘__CODELOC_COLUMN’
   59 |           unsigned long columnNo = __CODELOC_COLUMN) noexcept {
      |                                    ^~~~~~~~~~~~~~~~
```
Do you have a CI running with something like this?