### PR TITLE
[SYCL][NFC] Fix special member functions for GCC 11.2 and C++20

### DIFF
--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -171,10 +171,7 @@ public:
 
   nd_item &operator=(nd_item &&rhs) = default;
 
-  bool operator==(const nd_item &rhs) const {
-    return (rhs.localItem == this->localItem) &&
-           (rhs.globalItem == this->globalItem) && (rhs.Group == this->Group);
-  }
+  bool operator==(const nd_item &rhs) const = default;
 
   bool operator!=(const nd_item &rhs) const {
     return !((*this) == rhs);

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -171,9 +171,12 @@ public:
 
   nd_item &operator=(nd_item &&rhs) = default;
 
-  bool operator==(const nd_item &rhs) const = default;
+  bool operator==(const nd_item &rhs) const {
+    return (rhs.localItem == this->localItem) &&
+           (rhs.globalItem == this->globalItem) && (rhs.Group == this->Group);
+  }
 
-  bool operator!=(const nd_item &rhs) const = default;
+  bool operator!=(const nd_item &rhs) const { return !((*this) == rhs); }
 
 protected:
   friend class detail::Builder;

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -173,9 +173,7 @@ public:
 
   bool operator==(const nd_item &rhs) const = default;
 
-  bool operator!=(const nd_item &rhs) const {
-    return !((*this) == rhs);
-  }
+  bool operator!=(const nd_item &rhs) const = default;
 
 protected:
   friend class detail::Builder;

--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -163,20 +163,20 @@ public:
     Group.wait_for(events...);
   }
 
-  nd_item<dimensions>(const nd_item<dimensions> &rhs) = default;
+  nd_item(const nd_item &rhs) = default;
 
-  nd_item<dimensions>(nd_item<dimensions> &&rhs) = default;
+  nd_item(nd_item &&rhs) = default;
 
-  nd_item<dimensions> &operator=(const nd_item<dimensions> &rhs) = default;
+  nd_item &operator=(const nd_item &rhs) = default;
 
-  nd_item<dimensions> &operator=(nd_item<dimensions> &&rhs) = default;
+  nd_item &operator=(nd_item &&rhs) = default;
 
-  bool operator==(const nd_item<dimensions> &rhs) const {
+  bool operator==(const nd_item &rhs) const {
     return (rhs.localItem == this->localItem) &&
            (rhs.globalItem == this->globalItem) && (rhs.Group == this->Group);
   }
 
-  bool operator!=(const nd_item<dimensions> &rhs) const {
+  bool operator!=(const nd_item &rhs) const {
     return !((*this) == rhs);
   }
 


### PR DESCRIPTION
I got an issue while compiling the SYCL runtime on Ubuntu 21.10 G++ 11.2 and C++20.
Please add more modern configurations to your GitHub Actions to test at least with the latest compilers and latest languages.
While SYCL 2020 requires at least a C++17 compiler, it should not break with C++20 or C++2b.