### PR TITLE
[SYCL][CUDA] Use full mask for barrier and sync instructions

### DIFF
--- a/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
+++ b/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
@@ -42,11 +42,10 @@ __clc__get_group_scratch_float() __asm("__clc__get_group_scratch_float");
 __local double *
 __clc__get_group_scratch_double() __asm("__clc__get_group_scratch_double");
 
-_CLC_DEF _CLC_CONVERGENT uint __clc__membermask() {
-  uint FULL_MASK = 0xFFFFFFFF;
-  uint max_size = __spirv_SubgroupMaxSize();
-  uint sg_size = __spirv_SubgroupSize();
-  return FULL_MASK >> (max_size - sg_size);
+_CLC_DEF uint inline __clc__membermask() {
+  // use a full mask as sync operations are required to be convergent and
+  // exited threads can safely be in the mask
+  return 0xFFFFFFFF;
 }
 
 #define __CLC_SUBGROUP_SHUFFLE_I32(TYPE)                                       \

--- a/libclc/ptx-nvidiacl/libspirv/synchronization/barrier.cl
+++ b/libclc/ptx-nvidiacl/libspirv/synchronization/barrier.cl
@@ -18,10 +18,9 @@ _CLC_OVERLOAD _CLC_DEF _CLC_CONVERGENT void
 __spirv_ControlBarrier(unsigned int scope, unsigned int memory,
                        unsigned int semantics) {
   if (scope == Subgroup) {
-    uint FULL_MASK = 0xFFFFFFFF;
-    uint max_size = __spirv_SubgroupMaxSize();
-    uint sg_size = __spirv_SubgroupSize();
-    __nvvm_bar_warp_sync(FULL_MASK >> (max_size - sg_size));
+    // use a full mask as barriers are required to be convergent and exited
+    // threads can safely be in the mask
+    __nvvm_bar_warp_sync(0xFFFFFFFF);
   } else {
     __syncthreads();
   }

--- a/sycl/include/CL/sycl/detail/spirv.hpp
+++ b/sycl/include/CL/sycl/detail/spirv.hpp
@@ -491,10 +491,9 @@ using EnableIfVectorShuffle =
 
 #ifdef __NVPTX__
 inline uint32_t membermask() {
-  uint32_t FULL_MASK = 0xFFFFFFFF;
-  uint32_t max_size = __spirv_SubgroupMaxSize();
-  uint32_t sg_size = __spirv_SubgroupSize();
-  return FULL_MASK >> (max_size - sg_size);
+  // use a full mask as sync operations are required to be convergent and exited
+  // threads can safely be in the mask
+  return 0xFFFFFFFF;
 }
 #endif
 


### PR DESCRIPTION
This is solving #4504

It is safe to have exited or inactive threads in the membermask, so the
full mask is valid even in the case where a sub-group is smaller than
the warp.