### PR TITLE
[SYCL][FPGA][NFC] Update disable_loop_pipelining attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2024,6 +2024,7 @@ def SYCLIntelFPGADisableLoopPipelining : DeclOrStmtAttr {
   let IsStmtDependent = 1;
   let Documentation = [SYCLIntelFPGADisableLoopPipeliningAttrDocs];
   let SupportsNonconformingLambdaSyntax = 1;
+  let SimpleHandler = 1;
 }
 def : MutualExclusions<[SYCLIntelFPGAInitiationInterval,
                         SYCLIntelFPGADisableLoopPipelining]>;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3566,13 +3566,6 @@ static void handleSYCLIntelUseStallEnableClustersAttr(Sema &S, Decl *D,
                  SYCLIntelUseStallEnableClustersAttr(S.Context, A));
 }
 
-// Handles disable_loop_pipelining attribute.
-static void handleSYCLIntelFPGADisableLoopPipeliningAttr(Sema &S, Decl *D,
-                                                         const ParsedAttr &A) {
-  D->addAttr(::new (S.Context)
-                 SYCLIntelFPGADisableLoopPipeliningAttr(S.Context, A));
-}
-
 // Handles initiation_interval attribute.
 void Sema::AddSYCLIntelFPGAInitiationIntervalAttr(Decl *D,
                                                   const AttributeCommonInfo &CI,
@@ -9975,9 +9968,6 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case ParsedAttr::AT_SYCLIntelLoopFuse:
     handleSYCLIntelLoopFuseAttr(S, D, AL);
-    break;
-  case ParsedAttr::AT_SYCLIntelFPGADisableLoopPipelining:
-    handleSYCLIntelFPGADisableLoopPipeliningAttr(S, D, AL);
     break;
   case ParsedAttr::AT_SYCLIntelFPGAInitiationInterval:
     handleSYCLIntelFPGAInitiationIntervalAttr(S, D, AL);


### PR DESCRIPTION
This patch simplifies support for disable_loop_pipelining attribute by setting SimpleHandler = 1 in Attr.td instead of using static handler function in SemaDeclAttr.cpp file. This behavior is more consistent and aligns with other community attributes.

No functionality or tests change with the improvement.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>