### PR TITLE
[CI] Provide libclc targets to build and test

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -15,6 +15,9 @@ def do_configure(args):
 
     llvm_external_projects = 'sycl;llvm-spirv;opencl;libdevice;xpti;xptifw'
 
+    libclc_amd_target_names = ';amdgcn--;amdgcn--amdhsa'
+    libclc_nvidia_target_names = 'nvptx64--;nvptx64--nvidiacl'
+
     if args.llvm_external_projects:
         llvm_external_projects += ";" + args.llvm_external_projects.replace(",", ";")
 
@@ -55,14 +58,14 @@ def do_configure(args):
 
     if args.cuda:
         llvm_targets_to_build += ';NVPTX'
-        libclc_targets_to_build = 'nvptx64--;nvptx64--nvidiacl'
+        libclc_targets_to_build = libclc_nvidia_target_names
         libclc_gen_remangled_variants = 'ON'
         sycl_build_pi_cuda = 'ON'
 
     if args.hip:
         if args.hip_platform == 'AMD':
             llvm_targets_to_build += ';AMDGPU'
-            libclc_targets_to_build += ';amdgcn--;amdgcn--amdhsa'
+            libclc_targets_to_build += libclc_amd_target_names
             if args.hip_amd_arch:
                 sycl_clang_extra_flags += "-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch="+args.hip_amd_arch
 
@@ -70,7 +73,7 @@ def do_configure(args):
             llvm_enable_projects += ';lld'
         elif args.hip_platform == 'NVIDIA' and not args.cuda:
             llvm_targets_to_build += ';NVPTX'
-            libclc_targets_to_build += ';nvptx64--;nvptx64--nvidiacl'
+            libclc_targets_to_build += libclc_nvidia_target_names
         libclc_gen_remangled_variants = 'ON'
 
         sycl_build_pi_hip_platform = args.hip_platform
@@ -109,10 +112,10 @@ def do_configure(args):
         if 'NVPTX' not in llvm_targets_to_build:
             llvm_targets_to_build += ';NVPTX'
         # Add both NVIDIA and AMD libclc targets
-        if 'amdgcn--;amdgcn--amdhsa' not in libclc_targets_to_build:
-            libclc_targets_to_build += ';amdgcn--;amdgcn--amdhsa'
-        if 'nvptx64--;nvptx64--nvidiacl' not in libclc_targets_to_build:
-            libclc_targets_to_build += ';nvptx64--;nvptx64--nvidiacl'
+        if libclc_amd_target_names not in libclc_targets_to_build:
+            libclc_targets_to_build += libclc_amd_target_names
+        if libclc_nvidia_target_names not in libclc_targets_to_build:
+            libclc_targets_to_build += libclc_nvidia_target_names
 
     install_dir = os.path.join(abs_obj_dir, "install")
 

--- a/libclc/test/CMakeLists.txt
+++ b/libclc/test/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBCLC_TEST_DEPS
   llvm-dis
   not
   clang
+  count
 )
 
 add_custom_target(check-libclc)

--- a/libclc/test/lit.cfg.py
+++ b/libclc/test/lit.cfg.py
@@ -44,7 +44,8 @@ clang_flags = [
   "-target", target,
   "-Xclang", "-fdeclare-spirv-builtins",
   "-Xclang", "-mlink-builtin-bitcode",
-  "-Xclang", os.path.join(config.llvm_libs_dir, "clc", builtins)
+  "-Xclang", os.path.join(config.llvm_libs_dir, "clc", builtins),
+  "-nogpulib"
 ]
 
 if target == 'amdgcn--amdhsa':


### PR DESCRIPTION
Follow up to https://github.com/intel/llvm/pull/5062

This PR ensures that `libclc` is built and tested against:
*  `amdgcn--;amdgcn--amdhsa`
* `nvptx64--;nvptx64--nvidiacl`