### PR TITLE
[SYCL] Fix the test to not depend on a specific line.

### DIFF
--- a/sycl/test/basic_tests/single_task_error_message.cpp
+++ b/sycl/test/basic_tests/single_task_error_message.cpp
@@ -10,8 +10,8 @@ int main() {
     {
       myQueue
           .single_task([&](sycl::handler &cgh) {
-            // expected-error-re@CL/sycl/queue.hpp:691 {{static_assert failed due to requirement '{{.*}}' "sycl::queue.single_task() requires a kernel instead of command group.{{.*}} Use queue.submit() instead"}}
-            // expected-error-re@CL/sycl/detail/cg_types.hpp:191 {{no matching function for call to object of type '(lambda at {{.*}}single_task_error_message.cpp:{{.*}})'}}
+            // expected-error-re@CL/sycl/queue.hpp:* {{static_assert failed due to requirement '{{.*}}' "sycl::queue.single_task() requires a kernel instead of command group.{{.*}} Use queue.submit() instead"}}
+            // expected-error-re@CL/sycl/detail/cg_types.hpp:* {{no matching function for call to object of type '(lambda at {{.*}}single_task_error_message.cpp:{{.*}})'}}
           })
           .wait();
     }
@@ -26,8 +26,8 @@ int main() {
       myQueue
           .single_task(e,
                        [&](sycl::handler &cgh) {
-                         // expected-error-re@CL/sycl/queue.hpp:714 {{static_assert failed due to requirement '{{.*}}' "sycl::queue.single_task() requires a kernel instead of command group.{{.*}} Use queue.submit() instead"}}
-                         // expected-error-re@CL/sycl/detail/cg_types.hpp:191 {{no matching function for call to object of type '(lambda at {{.*}}single_task_error_message.cpp:{{.*}})'}}
+                         // expected-error-re@CL/sycl/queue.hpp:* {{static_assert failed due to requirement '{{.*}}' "sycl::queue.single_task() requires a kernel instead of command group.{{.*}} Use queue.submit() instead"}}
+                         // expected-error-re@CL/sycl/detail/cg_types.hpp:* {{no matching function for call to object of type '(lambda at {{.*}}single_task_error_message.cpp:{{.*}})'}}
                        })
           .wait();
     }
@@ -42,8 +42,8 @@ int main() {
       myQueue
           .single_task(vector_event,
                        [&](sycl::handler &cgh) {
-                         // expected-error-re@CL/sycl/queue.hpp:739 {{static_assert failed due to requirement '{{.*}}' "sycl::queue.single_task() requires a kernel instead of command group.{{.*}} Use queue.submit() instead"}}
-                         // expected-error-re@CL/sycl/detail/cg_types.hpp:191 {{no matching function for call to object of type '(lambda at {{.*}}single_task_error_message.cpp:{{.*}})'}}
+                         // expected-error-re@CL/sycl/queue.hpp:* {{static_assert failed due to requirement '{{.*}}' "sycl::queue.single_task() requires a kernel instead of command group.{{.*}} Use queue.submit() instead"}}
+                         // expected-error-re@CL/sycl/detail/cg_types.hpp:* {{no matching function for call to object of type '(lambda at {{.*}}single_task_error_message.cpp:{{.*}})'}}
                        })
           .wait();
     }


### PR DESCRIPTION
Modifications of `sycl/queue.hpp` and `sycl/detail/cg_types.hpp` files can lead to failing `test/basic_tests/single_task_error_message.cpp` test each time for other developers.
It is a good practice to update the test to not depend on the specific code line numbers.

Signed-off-by: Alexander Flegontov <alexander.flegontov@intel.com>