### PR TITLE
[SYCL] Fix corner case: USM, 2nd CG depends_on 1st

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -116,7 +116,7 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
     EnqueueResultT Res;
     bool Enqueued;
 
-    auto CleanUp = [&](bool ExceptionHappened = false) {
+    auto CleanUp = [&]() {
       if (NewCmd && (NewCmd->MDeps.size() == 0 && NewCmd->MUsers.size() == 0 &&
                      NewCmd->getPreparedHostDepsEvents().size() == 0)) {
         if (Type == CG::RunOnHostIntel)

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -119,6 +119,10 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
     auto CleanUp = [&]() {
       if (NewCmd && (NewCmd->MDeps.size() == 0 && NewCmd->MUsers.size() == 0 &&
                      NewCmd->getPreparedHostDepsEvents().size() == 0)) {
+        // Calling assert to prevent cleaning up of the command which enqueue
+        // status is not successfull
+        assert(NewCmd->isSuccessfullyEnqueued());
+
         if (Type == CG::RunOnHostIntel)
           static_cast<ExecCGCommand *>(NewCmd)->releaseCG();
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -122,10 +122,8 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
         if (Type == CG::RunOnHostIntel)
           static_cast<ExecCGCommand *>(NewCmd)->releaseCG();
 
-        if (ExceptionHappened) {
-          NewEvent->setCommand(nullptr);
-          delete NewCmd;
-        }
+        NewEvent->setCommand(nullptr);
+        delete NewCmd;
       }
     };
 
@@ -138,7 +136,7 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
       } catch (...) {
         // enqueueCommand() func and if statement above may throw an exception,
         // so destroy required resources to avoid memory leak
-        CleanUp(/*ExceptionHappened = */ true);
+        CleanUp();
         std::rethrow_exception(std::current_exception());
       }
     }
@@ -153,7 +151,7 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
       } catch (...) {
         // enqueueCommand() func and if statement above may throw an exception,
         // so destroy required resources to avoid memory leak
-        CleanUp(/*ExceptionHappened = */ true);
+        CleanUp();
         std::rethrow_exception(std::current_exception());
       }
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -137,7 +137,7 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
       } catch (...) {
         // enqueueCommand() func and if statement above may throw an exception,
         // so destroy required resources to avoid memory leak
-        CleanUp(/*ExceptionHappened = */true);
+        CleanUp(/*ExceptionHappened = */ true);
         std::rethrow_exception(std::current_exception());
       }
     }
@@ -152,7 +152,7 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
       } catch (...) {
         // enqueueCommand() func and if statement above may throw an exception,
         // so destroy required resources to avoid memory leak
-        CleanUp(/*ExceptionHappened = */true);
+        CleanUp(/*ExceptionHappened = */ true);
         std::rethrow_exception(std::current_exception());
       }
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -117,7 +117,8 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
     bool Enqueued;
 
     auto CleanUp = [&](bool ExceptionHappened = false) {
-      if (NewCmd && (NewCmd->MDeps.size() == 0 && NewCmd->MUsers.size() == 0)) {
+      if (NewCmd && (NewCmd->MDeps.size() == 0 && NewCmd->MUsers.size() == 0 &&
+                     NewCmd->getPreparedHostDepsEvents().size() == 0)) {
         if (Type == CG::RunOnHostIntel)
           static_cast<ExecCGCommand *>(NewCmd)->releaseCG();
 


### PR DESCRIPTION
This patch fixes corner case where during USM, there are two CGs
from two different queues and contexts, and second CG `depends_on` first CG.
There are no memory dependencies between these two CGs. Without this patch,
kernel from second CG didn't run. This is happened because command containing
non-empty MPreparedHostDepsEvents was cleaned up, but shouldn't.

Test in intel/llvm-test-suite: https://github.com/intel/llvm-test-suite/pull/604
