### PR TITLE
[SYCL][CUDA] Don't enqueue an event wait on same CUDA stream

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -473,7 +473,10 @@ pi_result enqueueEventWait(pi_queue queue, pi_event event) {
   // for native events, the cuStreamWaitEvent call is used.
   // This makes all future work submitted to stream wait for all
   // work captured in event.
-  return PI_CHECK_ERROR(cuStreamWaitEvent(queue->get(), event->get(), 0));
+  if (queue->get() != event->get_queue()->get()) {
+    return PI_CHECK_ERROR(cuStreamWaitEvent(queue->get(), event->get(), 0));
+  }
+  return PI_SUCCESS;
 }
 
 _pi_program::_pi_program(pi_context ctxt)


### PR DESCRIPTION
Because CUDA streams are in order, a `cuStreamWaitEvent` on a `CUstream` with which the `CUevent` is already associated is semantically a no op. This patch removes the small runtime overhead associated with submitting the unnecessary wait.