### PR TITLE
[CI] Add container users to video group

### DIFF
--- a/.github/workflows/sycl_containers.yaml
+++ b/.github/workflows/sycl_containers.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and Push Container
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_base:${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_base:latest
@@ -56,7 +56,7 @@ jobs:
       - name: Build and Push Container
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_build:${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_build:latest
@@ -82,7 +82,7 @@ jobs:
       - name: Build and Push Container
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:latest-${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:latest

--- a/.github/workflows/sycl_containers.yaml
+++ b/.github/workflows/sycl_containers.yaml
@@ -23,21 +23,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Container
-        uses: docker/build-push-action@v2
+        uses: ./devops/actions/build_container
         with:
           push: ${{ github.event_name != 'pull_request' }}
+          file: ubuntu2004_base
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_base:${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_base:latest
-          context: ${{ github.workspace }}/devops
-          file: ${{ github.workspace }}/devops/containers/ubuntu2004_base.Dockerfile
   build_image_ubuntu2004:
     if: github.repository == 'intel/llvm'
     name: Build Ubuntu Docker image
@@ -47,44 +42,36 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Container
-        uses: docker/build-push-action@v2
+        uses: ./devops/actions/build_container
         with:
           push: ${{ github.event_name != 'pull_request' }}
+          file: ubuntu2004_build
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_build:${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_build:latest
-          context: ${{ github.workspace }}/devops
-          file: ${{ github.workspace }}/devops/containers/ubuntu2004_build.Dockerfile
   # This job produces a Docker container with the latest versions of Intel
   # drivers, that can be found on GitHub.
   drivers_image_ubuntu2004:
     if: github.repository == 'intel/llvm'
     name: Intel Drivers Ubuntu 20.04 Docker image
     runs-on: ubuntu-latest
+    needs: base_image_ubuntu2004
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Container
-        uses: docker/build-push-action@v2
+        uses: ./devops/actions/build_container
         with:
           push: ${{ github.event_name != 'pull_request' }}
+          file: ubuntu2004_intel_drivers
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:latest-${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:latest
-          context: ${{ github.workspace }}/devops
-          file: ${{ github.workspace }}/devops/containers/ubuntu2004_intel_drivers.Dockerfile
+

--- a/.github/workflows/sycl_containers.yaml
+++ b/.github/workflows/sycl_containers.yaml
@@ -9,6 +9,9 @@ on:
       - sycl
     paths:
       - 'devops/containers/**'
+  pull_request:
+    paths:
+      - 'devops/containers/**'
 
 jobs:
   base_image_ubuntu2004:
@@ -29,7 +32,7 @@ jobs:
       - name: Build and Push Container
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: ${{ github.event != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_base:${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_base:latest
@@ -53,7 +56,7 @@ jobs:
       - name: Build and Push Container
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: ${{ github.event != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_build:${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_build:latest
@@ -79,7 +82,7 @@ jobs:
       - name: Build and Push Container
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: ${{ github.event != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:latest-${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:latest

--- a/devops/actions/build_container/action.yml
+++ b/devops/actions/build_container/action.yml
@@ -1,0 +1,42 @@
+name: 'Build Docker container'
+description: 'Build Docker container in a standard way'
+
+inputs:
+  build-args:
+    description: "List of build-time variables"
+    required: false
+  tags:
+    description: "List of tags"
+    required: true
+  push:
+    description: "Whether to push Docker image or not"
+    required: false
+    default: false
+  username:
+    description: "Registry user name"
+    required: true
+  password:
+    description: "Registry user password"
+    required: true
+  file:
+    description: "Dockerfile"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+  - name: Login to GitHub Container Registry
+    uses: docker/login-action@v1
+    with:
+      registry: ghcr.io
+      username: ${{ inputs.username }}
+      password: ${{ inputs.password }}
+  - name: Build and Push Container
+    uses: docker/build-push-action@v2
+    with:
+      push: ${{ inputs.push }}
+      tags: ${{ inputs.tags }}
+      build-args: ${{ inputs.build_args }}
+      context: ${{ github.workspace }}/devops
+      file: ${{ github.workspace }}/devops/containers/${{ inputs.file }}.Dockerfile
+

--- a/devops/containers/ubuntu2004_base.Dockerfile
+++ b/devops/containers/ubuntu2004_base.Dockerfile
@@ -13,6 +13,8 @@ RUN /install.sh
 # discover user home directory and fail a few LIT tests. Fixes UID and GID to
 # 1001, that is used as default by GitHub Actions.
 RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video group so that it can access GPU
+RUN usermod -aG video sycl
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 

--- a/devops/containers/ubuntu2004_build.Dockerfile
+++ b/devops/containers/ubuntu2004_build.Dockerfile
@@ -22,6 +22,8 @@ RUN apt install -yqq libnuma-dev wget gnupg2 && \
 # discover user home directory and fail a few LIT tests. Fixes UID and GID to
 # 1001, that is used as default by GitHub Actions.
 RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video group so that it can access GPU
+RUN usermod -aG video sycl
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 


### PR DESCRIPTION
Accessing `/dev/dri` device (GPU) requires user to be in `video` group. Change containers to include `sycl` user into the group.

Also change workflow to build containers in pre-commit without pushing to the registry to make sure containers are still buildable.