### PR TITLE
Remove PR disable template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,0 @@
-# **DO NOT FILE A PULL REQUEST**
-
-We are in the process of a github migration.  Please do not create a pull request as this could interfere with the process.


### PR DESCRIPTION
Community pulldown introduced a new file to the repo, that disables pull request. While LLVM community chooses Phabricator as main tool for accepting contributions, Intel uses GitHub and Pull Requests for this downstream fork. This patch removes misleading template from this fork.