### PR TITLE
[SYCL] Add element size argument to piKernelSetArg

### DIFF
--- a/sycl/include/CL/sycl/detail/cg_types.hpp
+++ b/sycl/include/CL/sycl/detail/cg_types.hpp
@@ -27,13 +27,15 @@ namespace detail {
 class ArgDesc {
 public:
   ArgDesc(cl::sycl::detail::kernel_param_kind_t Type, void *Ptr, int Size,
-          int Index)
-      : MType(Type), MPtr(Ptr), MSize(Size), MIndex(Index) {}
+          int Index, int ElemSize = 0)
+      : MType(Type), MPtr(Ptr), MSize(Size), MIndex(Index),
+        MElemSize(ElemSize) {}
 
   cl::sycl::detail::kernel_param_kind_t MType;
   void *MPtr;
   int MSize;
   int MIndex;
+  int MElemSize;
 };
 
 // The structure represents NDRange - global, local sizes, global offset and

--- a/sycl/include/CL/sycl/detail/pi.h
+++ b/sycl/include/CL/sycl/detail/pi.h
@@ -1262,7 +1262,8 @@ __SYCL_EXPORT pi_result piKernelCreate(pi_program program,
                                        pi_kernel *ret_kernel);
 
 __SYCL_EXPORT pi_result piKernelSetArg(pi_kernel kernel, pi_uint32 arg_index,
-                                       size_t arg_size, const void *arg_value);
+                                       size_t arg_size, const void *arg_value,
+                                       size_t arg_align = 0);
 
 __SYCL_EXPORT pi_result piKernelGetInfo(pi_kernel kernel,
                                         pi_kernel_info param_name,

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2453,7 +2453,8 @@ pi_result cuda_piKernelCreate(pi_program program, const char *kernel_name,
 }
 
 pi_result cuda_piKernelSetArg(pi_kernel kernel, pi_uint32 arg_index,
-                              size_t arg_size, const void *arg_value) {
+                              size_t arg_size, const void *arg_value,
+                              size_t arg_align) {
 
   assert(kernel != nullptr);
   pi_result retErr = PI_SUCCESS;
@@ -2461,7 +2462,7 @@ pi_result cuda_piKernelSetArg(pi_kernel kernel, pi_uint32 arg_index,
     if (arg_value) {
       kernel->set_kernel_arg(arg_index, arg_size, arg_value);
     } else {
-      kernel->set_kernel_local_arg(arg_index, arg_size);
+      kernel->set_kernel_local_arg(arg_index, arg_size, arg_align);
     }
   } catch (pi_result err) {
     retErr = err;

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -636,9 +636,13 @@ struct _pi_kernel {
       offsetPerIndex_[index] = localSize;
     }
 
-    void add_local_arg(size_t index, size_t size) {
+    void add_local_arg(size_t index, size_t size, size_t align) {
       size_t localOffset = this->get_local_size();
-      add_arg(index, sizeof(size_t), (const void *)&(localOffset), size);
+      if (localOffset % align != 0) {
+        localOffset = localOffset + align - (localOffset % align);
+      }
+      add_arg(index, sizeof(size_t), (const void *)&(localOffset),
+              size + (localOffset - this->get_local_size()));
     }
 
     void set_implicit_offset(size_t size, std::uint32_t *implicitOffset) {
@@ -719,8 +723,8 @@ struct _pi_kernel {
     args_.add_arg(index, size, arg);
   }
 
-  void set_kernel_local_arg(int index, size_t size) {
-    args_.add_local_arg(index, size);
+  void set_kernel_local_arg(int index, size_t size, size_t arg_align) {
+    args_.add_local_arg(index, size, arg_align);
   }
 
   void set_implicit_offset_arg(size_t size, std::uint32_t *implicitOffset) {

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2408,7 +2408,9 @@ pi_result hip_piKernelCreate(pi_program program, const char *kernel_name,
 }
 
 pi_result hip_piKernelSetArg(pi_kernel kernel, pi_uint32 arg_index,
-                             size_t arg_size, const void *arg_value) {
+                             size_t arg_size, const void *arg_value,
+                             size_t arg_align) {
+  (void)arg_align;
 
   assert(kernel != nullptr);
   pi_result retErr = PI_SUCCESS;

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -4250,8 +4250,8 @@ pi_result piKernelCreate(pi_program Program, const char *KernelName,
 }
 
 pi_result piKernelSetArg(pi_kernel Kernel, pi_uint32 ArgIndex, size_t ArgSize,
-                         const void *ArgValue) {
-
+                         const void *ArgValue, size_t ArgAlign) {
+  (void)ArgAlign;
   // OpenCL: "the arg_value pointer can be NULL or point to a NULL value
   // in which case a NULL value will be used as the value for the argument
   // declared as a pointer to global or constant memory in the kernel"

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -523,6 +523,14 @@ pi_result piextKernelSetArgSampler(pi_kernel kernel, pi_uint32 arg_index,
                      sizeof(cl_sampler), cast<const cl_sampler *>(arg_value)));
 }
 
+pi_result piextKernelSetArg(pi_kernel kernel, pi_uint32 arg_index,
+                            size_t arg_size, const void *arg_value,
+                            size_t arg_align) {
+  (void)arg_align;
+  return cast<pi_result>(clSetKernelArg(
+      cast<cl_kernel>(kernel), cast<cl_uint>(arg_index), arg_size, arg_value));
+}
+
 pi_result piextKernelCreateWithNativeHandle(pi_native_handle nativeHandle,
                                             pi_context, pi_program, bool,
                                             pi_kernel *piKernel) {
@@ -1409,7 +1417,7 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextProgramCreateWithNativeHandle, piextProgramCreateWithNativeHandle)
   // Kernel
   _PI_CL(piKernelCreate, piKernelCreate)
-  _PI_CL(piKernelSetArg, clSetKernelArg)
+  _PI_CL(piKernelSetArg, piextKernelSetArg)
   _PI_CL(piKernelGetInfo, clGetKernelInfo)
   _PI_CL(piKernelGetGroupInfo, piKernelGetGroupInfo)
   _PI_CL(piKernelGetSubGroupInfo, piKernelGetSubGroupInfo)

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1762,8 +1762,8 @@ static pi_result SetKernelParamsAndLaunch(
              "which accessors are used");
       RT::PiMem MemArg = (RT::PiMem)getMemAllocationFunc(Req);
       if (Plugin.getBackend() == backend::opencl) {
-        Plugin.call<PiApiKind::piKernelSetArg>(Kernel, NextTrueIndex,
-                                               sizeof(RT::PiMem), &MemArg);
+        Plugin.call<PiApiKind::piKernelSetArg>(
+            Kernel, NextTrueIndex, sizeof(RT::PiMem), &MemArg, Arg.MElemSize);
       } else {
         Plugin.call<PiApiKind::piextKernelSetArgMemObj>(Kernel, NextTrueIndex,
                                                         &MemArg);
@@ -1772,7 +1772,7 @@ static pi_result SetKernelParamsAndLaunch(
     }
     case kernel_param_kind_t::kind_std_layout: {
       Plugin.call<PiApiKind::piKernelSetArg>(Kernel, NextTrueIndex, Arg.MSize,
-                                             Arg.MPtr);
+                                             Arg.MPtr, Arg.MElemSize);
       break;
     }
     case kernel_param_kind_t::kind_sampler: {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -447,7 +447,7 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
       for (int I = 0; I < Dims; ++I)
         SizeInBytes *= Size[I];
       MArgs.emplace_back(kernel_param_kind_t::kind_std_layout, nullptr,
-                         SizeInBytes, Index + IndexShift);
+                         SizeInBytes, Index + IndexShift, LAcc->MElemSize);
       if (!IsKernelCreatedFromSource) {
         ++IndexShift;
         const size_t SizeAccField = Dims * sizeof(Size[0]);

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -232,7 +232,8 @@ redefinedMemBufferCreate(pi_context context, pi_mem_flags flags, size_t size,
 static pi_result redefinedMemRelease(pi_mem mem) { return PI_SUCCESS; }
 
 static pi_result redefinedKernelSetArg(pi_kernel kernel, pi_uint32 arg_index,
-                                       size_t arg_size, const void *arg_value) {
+                                       size_t arg_size, const void *arg_value,
+                                       size_t arg_align) {
   return PI_SUCCESS;
 }
 

--- a/sycl/unittests/pi/cuda/test_kernels.cpp
+++ b/sycl/unittests/pi/cuda/test_kernels.cpp
@@ -236,7 +236,7 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSimple) {
 
   int number = 10;
   ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
-                kern, 0, sizeof(int), &number)),
+                kern, 0, sizeof(int), &number, 0)),
             PI_SUCCESS);
   const auto &kernArgs = kern->get_arg_indices();
   ASSERT_EQ(kernArgs.size(), (size_t)1 + NUM_IMPLICIT_ARGS);
@@ -266,7 +266,7 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwice) {
 
   int number = 10;
   ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
-                kern, 0, sizeof(int), &number)),
+                kern, 0, sizeof(int), &number, 0)),
             PI_SUCCESS);
   const auto &kernArgs = kern->get_arg_indices();
   ASSERT_GT(kernArgs.size(), (size_t)0 + NUM_IMPLICIT_ARGS);
@@ -275,7 +275,7 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwice) {
 
   int otherNumber = 934;
   ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
-                kern, 0, sizeof(int), &otherNumber)),
+                kern, 0, sizeof(int), &otherNumber, 0)),
             PI_SUCCESS);
   const auto &kernArgs2 = kern->get_arg_indices();
   ASSERT_EQ(kernArgs2.size(), (size_t)1 + NUM_IMPLICIT_ARGS);
@@ -311,7 +311,7 @@ TEST_F(CudaKernelsTest, PIKernelSetMemObj) {
             PI_SUCCESS);
 
   ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
-                kern, 0, sizeof(pi_mem), &memObj)),
+                kern, 0, sizeof(pi_mem), &memObj, 0)),
             PI_SUCCESS);
   const auto &kernArgs = kern->get_arg_indices();
   ASSERT_EQ(kernArgs.size(), (size_t)1 + NUM_IMPLICIT_ARGS);
@@ -441,7 +441,7 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwiceOneLocal) {
 
   int number = 10;
   ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
-                kern, 0, sizeof(int), &number)),
+                kern, 0, sizeof(int), &number, 0)),
             PI_SUCCESS);
   const auto &kernArgs = kern->get_arg_indices();
   ASSERT_GT(kernArgs.size(), (size_t)0 + NUM_IMPLICIT_ARGS);
@@ -449,7 +449,7 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwiceOneLocal) {
   ASSERT_EQ(storedValue, number);
 
   ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
-                kern, 1, sizeof(int), nullptr)),
+                kern, 1, sizeof(int), nullptr, 0)),
             PI_SUCCESS);
   const auto &kernArgs2 = kern->get_arg_indices();
   ASSERT_EQ(kernArgs2.size(), (size_t)2 + NUM_IMPLICIT_ARGS);
@@ -457,7 +457,7 @@ TEST_F(CudaKernelsTest, PIKernelArgumentSetTwiceOneLocal) {
   ASSERT_EQ(storedValue, 0);
 
   ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piKernelSetArg>(
-                kern, 2, sizeof(int), nullptr)),
+                kern, 2, sizeof(int), nullptr, 0)),
             PI_SUCCESS);
   const auto &kernArgs3 = kern->get_arg_indices();
   ASSERT_EQ(kernArgs3.size(), (size_t)3 + NUM_IMPLICIT_ARGS);


### PR DESCRIPTION
This patch comes from an attempt to fix #5007.

The issue there is that for local kernel argument the CUDA plugin uses
CUDA dynamic shared memory, which gives us a single chunk of shared
memory to work with.

The CUDA plugin then lays out all the local kernel arguments
consecutively in this single chunk of memory.

And this can cause issues because simply laying the arguments out one
after the other can result in misaligned arguments. In #5007 for example
there is an `int` argument followed by a `double4` argument, so the
`double4` argument ends up with the wrong alignment, only being aligned
on a 4 bytes boundary following from the `int`.

It is possible to adjust this and fixup the alignment when laying out
the local kernel arguments in the CUDA plugin, however before this patch
the only information in the plugin would be the total size of local
memory required for the given arguments, which doesn't tell us anything
about the required alignment.

So this patch propagates the size of the elements inside of the
local accessor all the way down to the PI plugin through
`piKernelSetArg`, and tweaks the local argument layout in the CUDA
plugin to use the type size as alignment for local kernel arguments.

I'm not entirely sure if this is the best approach so feedback on this would be appreciated, this patch may also need to be refined for naming and/or position of the extra argument, however it does fix the issue in #5007 