### PR TITLE
[SYCL][CUDA] Fix alignment of local arguments

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -647,8 +647,10 @@ struct _pi_kernel {
       const size_t alignment = std::min(max_alignment, size);
 
       // align the argument
-      size_t alignedLocalOffset =
-          localOffset + alignment - (localOffset % alignment);
+      size_t alignedLocalOffset = localOffset;
+      if (localOffset % alignment != 0) {
+        alignedLocalOffset += alignment - (localOffset % alignment);
+      }
 
       add_arg(index, sizeof(size_t), (const void *)&(alignedLocalOffset),
               size + (alignedLocalOffset - localOffset));

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -650,7 +650,8 @@ struct _pi_kernel {
       size_t alignedLocalOffset =
           localOffset + alignment - (localOffset % alignment);
 
-      add_arg(index, sizeof(size_t), (const void *)&(alignedLocalOffset), size);
+      add_arg(index, sizeof(size_t), (const void *)&(alignedLocalOffset),
+              size + (alignedLocalOffset - localOffset));
     }
 
     void set_implicit_offset(size_t size, std::uint32_t *implicitOffset) {

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -638,7 +638,19 @@ struct _pi_kernel {
 
     void add_local_arg(size_t index, size_t size) {
       size_t localOffset = this->get_local_size();
-      add_arg(index, sizeof(size_t), (const void *)&(localOffset), size);
+
+      // maximum required alignment is the size of the largest vector type
+      const size_t max_alignment = sizeof(double) * 16;
+
+      // for arguments smaller than the maximum alignment simply align to the
+      // size of the argument
+      const size_t alignment = std::min(max_alignment, size);
+
+      // align the argument
+      size_t alignedLocalOffset =
+          localOffset + alignment - (localOffset % alignment);
+
+      add_arg(index, sizeof(size_t), (const void *)&(alignedLocalOffset), size);
     }
 
     void set_implicit_offset(size_t size, std::uint32_t *implicitOffset) {


### PR DESCRIPTION
The issue there is that for local kernel argument the CUDA plugin uses
CUDA dynamic shared memory, which gives us a single chunk of shared
memory to work with.

The CUDA plugin then lays out all the local kernel arguments
consecutively in this single chunk of memory.

And this can cause issues because simply laying the arguments out one
after the other can result in misaligned arguments.

So this patch is changing the argument layout to align them to the
maximum necessary alignment which is the size of the largest vector
type. Additionally if there is a local buffer smaller than this maximum
alignment, the size of that buffer is simply used for alignment.

This addresses #5007 for CUDA backend.

See also the discussion on #5104 for alternative solution, that may be
more efficient but would require a more intrusive ABI changing patch.