### PR TITLE
[SYCL] Report deferred diagnostics in function templates

### DIFF
--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1808,7 +1808,6 @@ public:
         FirstDiag = false;
       }
     }
-    return;
   }
 };
 } // namespace

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1770,8 +1770,15 @@ public:
   // Emit any deferred diagnostics for FD
   void emitDeferredDiags(FunctionDecl *FD, bool ShowCallStack) {
     auto It = S.DeviceDeferredDiags.find(FD);
-    if (It == S.DeviceDeferredDiags.end())
+    if (It == S.DeviceDeferredDiags.end()) {
+      // If this is a template instantiation, check if its declaration
+      // is on the deferred diagnostics stack.
+      if (FD->isTemplateInstantiation()) {
+        FD = FD->getTemplateInstantiationPattern();
+        emitDeferredDiags(FD, ShowCallStack);
+      }
       return;
+    }
     bool HasWarningOrError = false;
     bool FirstDiag = true;
     for (Sema::DeviceDeferredDiagnostic &D : It->second) {
@@ -1801,6 +1808,7 @@ public:
         FirstDiag = false;
       }
     }
+    return;
   }
 };
 } // namespace

--- a/clang/test/CodeGenSYCL/static-var-address-space.cpp
+++ b/clang/test/CodeGenSYCL/static-var-address-space.cpp
@@ -1,13 +1,5 @@
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 #include "Inputs/sycl.hpp"
-struct C {
-  static int c;
-};
-
-template <typename T>
-struct D {
-  static T d;
-};
 
 template <typename T>
 void test() {
@@ -15,12 +7,6 @@ void test() {
   static const int a = 0;
   // CHECK: @_ZZ4testIiEvvE1b = linkonce_odr addrspace(1) constant i32 0, comdat, align 4
   static const T b = T(0);
-  // CHECK: @_ZN1C1cE = external addrspace(1) global i32, align 4
-  C::c = 10;
-  const C struct_c;
-  // CHECK: @_ZN1DIiE1dE = external addrspace(1) global i32, align 4
-  D<int>::d = 11;
-  const D<int> struct_d;
 }
 
 int main() {

--- a/clang/test/SemaSYCL/sycl-device-const-static.cpp
+++ b/clang/test/SemaSYCL/sycl-device-const-static.cpp
@@ -58,6 +58,23 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc(U<Base>::s2);
 }
 
+struct C {
+  static int c;
+};
+
+template <typename T>
+struct D {
+  static T d;
+};
+
+template <typename T>
+void test() {
+  // expected-error@+1{{SYCL kernel cannot use a non-const static data variable}}
+  C::c = 10;
+  // expected-error@+1{{SYCL kernel cannot use a non-const static data variable}}
+  D<int>::d = 11;
+}
+
 int main() {
   static int s2;
   kernel_single_task<class fake_kernel>([](S s4) {
@@ -66,6 +83,7 @@ int main() {
     s4.foo();
     // expected-error@+1{{SYCL kernel cannot use a non-const static data variable}}
     static int s3;
+    test<int>();
   });
 
   return 0;

--- a/clang/test/SemaSYCL/sycl-device-const-static.cpp
+++ b/clang/test/SemaSYCL/sycl-device-const-static.cpp
@@ -51,6 +51,7 @@ void usage() {
 
 template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
+  // expected-error@+1{{SYCL kernel cannot use a non-const static data variable}}
   static int z;
   // expected-note-re@+3{{called by 'kernel_single_task<fake_kernel, (lambda at {{.*}})>}}
   // expected-note-re@+2{{called by 'kernel_single_task<fake_kernel, (lambda at {{.*}})>}}
@@ -66,6 +67,9 @@ template <typename T>
 struct D {
   static T d;
 };
+
+template <typename T>
+T D<T>::d = T();
 
 template <typename T>
 void test() {

--- a/clang/test/SemaSYCL/sycl-device-template-diag.cpp
+++ b/clang/test/SemaSYCL/sycl-device-template-diag.cpp
@@ -7,8 +7,6 @@
 
 using namespace cl::sycl;
 queue q;
-template <typename h>
-h *malloc_shared();
 
 int global_value = -1;
 

--- a/clang/test/SemaSYCL/sycl-device-template-diag.cpp
+++ b/clang/test/SemaSYCL/sycl-device-template-diag.cpp
@@ -23,14 +23,5 @@ void kernel_wrapper() {
 }
 
 int main() {
-  int *x = malloc_shared<int>();
-  kernel_handler kh;
-  q.submit([&](handler &h) {
-    h.single_task<class mykern>([=](auto g) {
-      // expected-error@+1{{SYCL kernel cannot use a non-const global variable}}
-      x[3] = global_value;
-    },
-                                kh);
-  });
   kernel_wrapper<int>();
 }

--- a/clang/test/SemaSYCL/sycl-device-template-diag.cpp
+++ b/clang/test/SemaSYCL/sycl-device-template-diag.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s -internal-isystem %S/Inputs 
+
+// This test verifies that we generate deferred diagnostics when
+// such diagnostics are in a function template.
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
+template <typename h> h *malloc_shared() ;
+
+int global_value = -1;
+
+template<typename T>
+void kernel_wrapper() {
+  q.submit([&] (handler &h) {
+    h.single_task([=] {
+      // expected-error@+1{{SYCL kernel cannot use a non-const global variable}}
+      (void)global_value;
+    });
+  });
+}
+
+int main() {
+  int *x = malloc_shared<int>();
+  kernel_handler kh;
+  q.submit([&](handler &h) {
+    h.single_task<class mykern>([=](auto g) {
+      // expected-error@+1{{SYCL kernel cannot use a non-const global variable}}
+      x[3] = global_value;
+    }, kh);
+  });
+  kernel_wrapper<int>();
+}

--- a/clang/test/SemaSYCL/sycl-device-template-diag.cpp
+++ b/clang/test/SemaSYCL/sycl-device-template-diag.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s -internal-isystem %S/Inputs 
+// RUN: %clang_cc1 -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s -internal-isystem %S/Inputs
 
 // This test verifies that we generate deferred diagnostics when
 // such diagnostics are in a function template.

--- a/clang/test/SemaSYCL/sycl-device-template-diag.cpp
+++ b/clang/test/SemaSYCL/sycl-device-template-diag.cpp
@@ -7,13 +7,13 @@
 
 using namespace cl::sycl;
 queue q;
-template <typename h> h *malloc_shared() ;
+template <typename h> h *malloc_shared();
 
 int global_value = -1;
 
-template<typename T>
+template <typename T>
 void kernel_wrapper() {
-  q.submit([&] (handler &h) {
+  q.submit([&](handler &h) {
     h.single_task([=] {
       // expected-error@+1{{SYCL kernel cannot use a non-const global variable}}
       (void)global_value;
@@ -28,7 +28,8 @@ int main() {
     h.single_task<class mykern>([=](auto g) {
       // expected-error@+1{{SYCL kernel cannot use a non-const global variable}}
       x[3] = global_value;
-    }, kh);
+    },
+                                kh);
   });
   kernel_wrapper<int>();
 }

--- a/clang/test/SemaSYCL/sycl-device-template-diag.cpp
+++ b/clang/test/SemaSYCL/sycl-device-template-diag.cpp
@@ -7,7 +7,8 @@
 
 using namespace cl::sycl;
 queue q;
-template <typename h> h *malloc_shared();
+template <typename h>
+h *malloc_shared();
 
 int global_value = -1;
 

--- a/clang/test/SemaSYCL/wrong-address-taking.cpp
+++ b/clang/test/SemaSYCL/wrong-address-taking.cpp
@@ -45,14 +45,12 @@ void basicUsage() {
 
 template <typename T> void templatedContext() {
 
-  // FIXME: this is likely not diagnosed because of a common problem among
-  // deferred diagnostics. They don't work from templated context if the
-  // problematic code doesn't depend on a template parameter. See
-  // https://github.com/intel/llvm/pull/5114 for an explanation of the problem
-  // and possible solution.
+  // expected-error@+1 {{taking address of a function not marked with 'intel::device_indirectly_callable' attribute is not allowed in SYCL device code}}
   int (*p)(int) = &badFoo;
+  // expected-error@+1 {{taking address of a function not marked with 'intel::device_indirectly_callable' attribute is not allowed in SYCL device code}}
   auto p1 = &ForMembers::badMember;
 
+  // expected-error@+2 {{taking address of a function not marked with 'intel::device_indirectly_callable' attribute is not allowed in SYCL device code}}
   // expected-note@+1 {{called by 'templatedContext<int>'}}
   templateCaller1<badFoo>(1);
 }


### PR DESCRIPTION
Under some circumstances, deferred diagnostics were not
emitted for usages within a template function.  This was
because the FunctionDecl associated with the diagnostic
was that of the template declaration, but at the point of
emitting the diagnostic, the FunctionDecl in the call chain
was that of the template instantiation.

Signed-off-by: Premanand M Rao <premanand.m.rao@intel.com>