### PR TITLE
[ESIMD] Add infra to support half, bfloat, etc, support sycl::half.

### DIFF
--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -35,6 +35,10 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
+namespace ext::intel::experimental::esimd::detail {
+class WrapperElementTypeProxy;
+}
+
 namespace detail {
 
 inline __SYCL_CONSTEXPR_HALF uint16_t float2Half(const float &Val) {
@@ -255,6 +259,9 @@ public:
   // Initialize underlying data
   constexpr explicit half_v2(uint16_t x) : Buf(x) {}
 
+  friend class sycl::ext::intel::experimental::esimd::detail::
+      WrapperElementTypeProxy;
+
 private:
   uint16_t Buf;
 };
@@ -390,6 +397,9 @@ public:
   }
 
   template <typename Key> friend struct std::hash;
+
+  friend class sycl::ext::intel::experimental::esimd::detail::
+      WrapperElementTypeProxy;
 
 private:
   StorageT Data;

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -35,9 +35,18 @@
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-namespace ext::intel::experimental::esimd::detail {
+
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
+namespace detail {
 class WrapperElementTypeProxy;
-}
+} // namespace detail
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 
 namespace detail {
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
@@ -29,6 +29,9 @@
 #define ESIMD_REGISTER(n) __attribute__((register_num(n)))
 
 #define __ESIMD_API ESIMD_NODEBUG ESIMD_INLINE
+
+#define __ESIMD_UNSUPPORTED_ON_HOST
+
 #else // __SYCL_DEVICE_ONLY__
 #define SYCL_ESIMD_KERNEL
 #define SYCL_ESIMD_FUNCTION
@@ -41,6 +44,9 @@
 #define ESIMD_REGISTER(n)
 
 #define __ESIMD_API ESIMD_INLINE
+
+#define __ESIMD_UNSUPPORTED_ON_HOST throw cl::sycl::feature_not_supported()
+
 #endif // __SYCL_DEVICE_ONLY__
 
 // Mark a function being noinline

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/elem_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/elem_type_traits.hpp
@@ -152,7 +152,7 @@ struct element_type_traits<T, std::enable_if_t<is_vectorizable_v<T>>> {
 // These are default implementations for wrapper types with native cpp
 // operations support for their corresponding raw type.
 template <class WrapperTy, class StdTy, int N>
-vector_type_t<__raw_t<WrapperTy>, N>
+ESIMD_INLINE vector_type_t<__raw_t<WrapperTy>, N>
 __esimd_convertvector_to(vector_type_t<StdTy, N> Val)
 #ifdef __SYCL_DEVICE_ONLY__
     ; // needs to be implemented for WrapperTy's for which
@@ -165,7 +165,7 @@ __esimd_convertvector_to(vector_type_t<StdTy, N> Val)
 #endif // __SYCL_DEVICE_ONLY__
 
 template <class WrapperTy, class StdTy, int N>
-vector_type_t<StdTy, N>
+ESIMD_INLINE vector_type_t<StdTy, N>
 __esimd_convertvector_from(vector_type_t<__raw_t<WrapperTy>, N> Val)
 #ifdef __SYCL_DEVICE_ONLY__
     ; // needs to be implemented for WrapperTy's for which
@@ -668,12 +668,12 @@ struct element_type_traits<T, std::enable_if_t<std::is_same_v<T, sycl::half>>> {
 
 using half_raw = __raw_t<sycl::half>;
 
-template <>
+template <> ESIMD_INLINE
 sycl::half __esimd_wrapper_type_bitcast_to<sycl::half>(half_raw Val) {
   return WrapperElementTypeProxy::bitcast_to_half(Val);
 }
 
-template <>
+template <> ESIMD_INLINE
 half_raw __esimd_wrapper_type_bitcast_from<sycl::half>(sycl::half Val) {
   return WrapperElementTypeProxy::bitcast_from_half(Val);
 }

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/elem_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/elem_type_traits.hpp
@@ -668,13 +668,15 @@ struct element_type_traits<T, std::enable_if_t<std::is_same_v<T, sycl::half>>> {
 
 using half_raw = __raw_t<sycl::half>;
 
-template <> ESIMD_INLINE
-sycl::half __esimd_wrapper_type_bitcast_to<sycl::half>(half_raw Val) {
+template <>
+ESIMD_INLINE sycl::half
+__esimd_wrapper_type_bitcast_to<sycl::half>(half_raw Val) {
   return WrapperElementTypeProxy::bitcast_to_half(Val);
 }
 
-template <> ESIMD_INLINE
-half_raw __esimd_wrapper_type_bitcast_from<sycl::half>(sycl::half Val) {
+template <>
+ESIMD_INLINE half_raw
+__esimd_wrapper_type_bitcast_from<sycl::half>(sycl::half Val) {
   return WrapperElementTypeProxy::bitcast_from_half(Val);
 }
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/elem_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/elem_type_traits.hpp
@@ -106,21 +106,9 @@ enum class BinOp {
   log_and
 };
 
-enum class CmpOp {
-  lt,
-  lte,
-  gte,
-  gt,
-  eq,
-  ne
-};
+enum class CmpOp { lt, lte, gte, gt, eq, ne };
 
-enum class UnaryOp {
-  minus,
-  plus,
-  bit_not,
-  log_not
-};
+enum class UnaryOp { minus, plus, bit_not, log_not };
 
 // If given type is a special "wrapper" element type.
 template <class T>
@@ -276,8 +264,7 @@ ESIMD_INLINE DstRawVecTy convert_vector(SrcRawVecTy Val) {
   }
 }
 
-template <class Ty>
-ESIMD_INLINE __raw_t<Ty> bitcast_to_raw_type(Ty Val) {
+template <class Ty> ESIMD_INLINE __raw_t<Ty> bitcast_to_raw_type(Ty Val) {
   if constexpr (!is_wrapper_elem_type_v<Ty>) {
     return Val;
   } else {
@@ -285,8 +272,7 @@ ESIMD_INLINE __raw_t<Ty> bitcast_to_raw_type(Ty Val) {
   }
 }
 
-template <class Ty>
-ESIMD_INLINE Ty bitcast_to_wrapper_type(__raw_t<Ty> Val) {
+template <class Ty> ESIMD_INLINE Ty bitcast_to_wrapper_type(__raw_t<Ty> Val) {
   if constexpr (!is_wrapper_elem_type_v<Ty>) {
     return Val;
   } else {
@@ -454,8 +440,8 @@ ESIMD_INLINE RawVecT vector_binary_op(RawVecT X, RawVecT Y) {
 template <UnaryOp Op, class T> ESIMD_INLINE T __esimd_unary_op(T X);
 
 template <UnaryOp Op, class T,
-  class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
-  ESIMD_INLINE T unary_op_default(T X) {
+          class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
+ESIMD_INLINE T unary_op_default(T X) {
   static_assert(element_type_traits<T>::use_native_cpp_ops);
   using T1 = __raw_t<T>;
   T1 X1 = bitcast_to_raw_type(X);
@@ -473,8 +459,8 @@ template <UnaryOp Op, class T> ESIMD_INLINE T __esimd_unary_op(T X) {
 }
 
 template <UnaryOp Op, class T,
-  class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
-  ESIMD_INLINE T unary_op(T X) {
+          class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
+ESIMD_INLINE T unary_op(T X) {
   if constexpr (element_type_traits<T>::use_native_cpp_ops) {
     return unary_op_default<Op>(X);
   } else {
@@ -484,7 +470,8 @@ template <UnaryOp Op, class T,
 
 // --- Vector versions of unary operations
 
-template <UnaryOp Op, class ElemT, int N, class RawVecT = __rv_t<__hlp<ElemT, N>>>
+template <UnaryOp Op, class ElemT, int N,
+          class RawVecT = __rv_t<__hlp<ElemT, N>>>
 ESIMD_INLINE RawVecT vector_unary_op_default(RawVecT X) {
   static_assert(element_type_traits<ElemT>::use_native_cpp_ops);
   return unary_op_default_impl<Op, RawVecT>(X);
@@ -493,7 +480,8 @@ ESIMD_INLINE RawVecT vector_unary_op_default(RawVecT X) {
 // Default (inefficient) implementation of a vector unary operation, which
 // involves conversion to an std C++ type, performing the op and converting
 // back.
-template <UnaryOp Op, class ElemT, int N, class RawVecT = __rv_t<__hlp<ElemT, N>>>
+template <UnaryOp Op, class ElemT, int N,
+          class RawVecT = __rv_t<__hlp<ElemT, N>>>
 ESIMD_INLINE RawVecT __esimd_vector_unary_op(RawVecT X) {
   using T1 = typename element_type_traits<ElemT>::EnclosingCppT;
   using VecT1 = vector_type_t<T1, N>;
@@ -501,7 +489,8 @@ ESIMD_INLINE RawVecT __esimd_vector_unary_op(RawVecT X) {
   return convert_vector<ElemT, T1, N>(vector_unary_op_default<Op, T1, N>(X1));
 }
 
-template <UnaryOp Op, class ElemT, int N, class RawVecT = __rv_t<__hlp<ElemT, N>>>
+template <UnaryOp Op, class ElemT, int N,
+          class RawVecT = __rv_t<__hlp<ElemT, N>>>
 ESIMD_INLINE RawVecT vector_unary_op(RawVecT X) {
   if constexpr (element_type_traits<ElemT>::use_native_cpp_ops) {
     return vector_unary_op_default<Op, ElemT, N>(X);
@@ -690,8 +679,7 @@ half_raw __esimd_wrapper_type_bitcast_from<sycl::half>(sycl::half Val) {
 }
 
 template <>
-struct is_esimd_arithmetic_type<__raw_t<sycl::half>, void>
-    : std::true_type {};
+struct is_esimd_arithmetic_type<__raw_t<sycl::half>, void> : std::true_type {};
 
 // Misc
 inline std::ostream &operator<<(std::ostream &O, sycl::half const &rhs) {

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/elem_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/elem_type_traits.hpp
@@ -1,0 +1,568 @@
+//==------------ - elem_type_traits.hpp - DPC++ Explicit SIMD API ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// This header provides:
+// - meta interfaces ("traits") which must be implemented to supoprt
+//   non-standard element types, such as sycl::half or sycl::bfloat16
+// - interfaces for performing various C++ operations on the types (+, *,...)
+//   and their default implementations.
+// - interfaces for performing conversions to/from the types and their default
+//   implementations.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/ext/intel/experimental/esimd/detail/types.hpp>
+
+#include <CL/sycl/half_type.hpp>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
+namespace detail {
+
+enum class BinOp {
+  ARITH_FIRST,
+  add = ARITH_FIRST,
+  sub,
+  mul,
+  div,
+  rem,
+  ARITH_LAST = rem,
+  BIT_FIRST,
+  shl = BIT_FIRST,
+  shr,
+  BIT_LOG,
+  bit_or = BIT_LOG,
+  bit_and,
+  bit_xor,
+  BIT_LST = bit_xor,
+  LOG_FIRST,
+  log_or = LOG_FIRST,
+  log_and,
+  LOG_LAST = log_and
+};
+
+enum class CmpOp {
+  CMP_FIRST,
+  lt = CMP_FIRST,
+  lte,
+  gte,
+  gt,
+  EQ_CMP_FIRST,
+  eq = EQ_CMP_FIRST,
+  ne,
+  CMP_LAST = ne
+};
+
+// If this element type is a special "wrapper" type. Such wrapper types, e.g.
+// sycl::half, bfloat etc, are used to represent non-standard element types in
+// user code.
+template <class T>
+static inline constexpr bool is_wrapper_elem_type_v =
+    std::is_same_v<T, sycl::half>;
+
+template <class T>
+static inline constexpr bool is_valid_simd_elem_type_v =
+    (is_vectorizable_v<T> || is_wrapper_elem_type_v<T>);
+
+struct invalid_storage_element_type;
+
+template <class T, class SFINAE> struct element_type_traits {
+  // The raw element type of the underlying clang vector used as a
+  // storage.
+  using StorageT = invalid_storage_element_type;
+  // A starndard C++ type which this one can be converted to/from.
+  // The conversions are usually H/W-supported, and the C++ type can
+  // represent the entire range of values of this type.
+  using EnclosingCppT = void;
+  // Whether a value or clang vector value the raw element type can be used
+  // directly as operand to std C++ operations.
+  static inline constexpr bool use_native_cpp_ops = true;
+};
+
+template <class T>
+struct element_type_traits<T, std::enable_if_t<is_vectorizable_v<T>>> {
+  using StorageT = T;
+  using EnclosingCppT = T;
+  static inline constexpr bool use_native_cpp_ops = true;
+};
+
+template <class T>
+using element_storage_t = typename element_type_traits<T>::StorageT;
+
+// --- Type conversions
+
+// Low-level conversion functions to and from a wrapper ("user") element type.
+// Must be implemented for each supported
+// <wrapper element type, C++ std type pair>.
+
+// These are default implementations for wrapper types with native cpp
+// operations support for their corresponding storage type.
+template <class WrapperTy, class StdTy, int N>
+vector_type_t<element_storage_t<WrapperTy>, N>
+__esimd_convertvector_to(vector_type_t<StdTy, N> Val)
+#ifdef __SYCL_DEVICE_ONLY__
+    ; // needs to be implemented for WrapperTy's for which
+      // element_type_traits<WrapperTy>::use_native_cpp_ops is false.
+#else
+{
+  // TODO implement for host
+  throw sycl::feature_not_supported();
+}
+#endif // __SYCL_DEVICE_ONLY__
+
+template <class WrapperTy, class StdTy, int N>
+vector_type_t<StdTy, N>
+__esimd_convertvector_from(vector_type_t<element_storage_t<WrapperTy>, N> Val)
+#ifdef __SYCL_DEVICE_ONLY__
+    ; // needs to be implemented for WrapperTy's for which
+      // element_type_traits<WrapperTy>::use_native_cpp_ops is false.
+#else
+{
+  // TODO implement for host
+  throw sycl::feature_not_supported();
+}
+#endif // __SYCL_DEVICE_ONLY__
+
+// TODO should be replaced by std::bit_cast once C++20 is supported.
+template <class WrapperTy>
+WrapperTy __esimd_wrapper_type_bitcast_to(element_storage_t<WrapperTy> Val);
+template <class WrapperTy>
+element_storage_t<WrapperTy> __esimd_wrapper_type_bitcast_from(WrapperTy Val);
+
+template <class WrapperTy, class StdTy> struct wrapper_type_converter {
+  using RawTy = element_storage_t<WrapperTy>;
+
+  template <int N>
+  ESIMD_INLINE static vector_type_t<RawTy, N>
+  to_vector(vector_type_t<StdTy, N> Val) {
+    if constexpr (element_type_traits<WrapperTy>::use_native_cpp_ops) {
+      return __builtin_convertvector(Val, vector_type_t<RawTy, N>);
+    } else {
+      return __esimd_convertvector_to<WrapperTy, StdTy, N>(Val);
+    }
+  }
+
+  template <int N>
+  ESIMD_INLINE static vector_type_t<StdTy, N>
+  from_vector(vector_type_t<RawTy, N> Val) {
+    if constexpr (element_type_traits<WrapperTy>::use_native_cpp_ops) {
+      return __builtin_convertvector(Val, vector_type_t<StdTy, N>);
+    } else {
+      return __esimd_convertvector_from<WrapperTy, StdTy, N>(Val);
+    }
+  }
+};
+
+// Converts a storage representation of a simd vector with element type
+// SrcWrapperTy to a storage representation of a simd vector with element type
+// DstWrapperTy.
+template <class DstWrapperTy, class SrcWrapperTy, int N,
+          class DstRawVecTy = vector_type_t<element_storage_t<DstWrapperTy>, N>,
+          class SrcRawVecTy = vector_type_t<element_storage_t<SrcWrapperTy>, N>>
+ESIMD_INLINE DstRawVecTy convert_vector(SrcRawVecTy Val) {
+  if constexpr (std::is_same_v<SrcWrapperTy, DstWrapperTy>) {
+    return Val;
+  } else if constexpr (!detail::is_wrapper_elem_type_v<SrcWrapperTy> &&
+                       !detail::is_wrapper_elem_type_v<DstWrapperTy>) {
+    return __builtin_convertvector(Val, DstRawVecTy);
+  } else {
+    using DstStdT = typename element_type_traits<DstWrapperTy>::EnclosingCppT;
+    using SrcStdT = typename element_type_traits<SrcWrapperTy>::EnclosingCppT;
+
+    using SrcWTC = wrapper_type_converter<SrcWrapperTy, SrcStdT>;
+    using DstWTC = wrapper_type_converter<DstWrapperTy, DstStdT>;
+
+    using CommonT = computation_type_t<DstStdT, SrcStdT>;
+    using CommonVecT = vector_type_t<CommonT, N>;
+    using DstStdVecT = vector_type_t<DstStdT, N>;
+
+    CommonVecT TmpVal;
+
+    // element_storage_t<SrcWrapperTy>
+    //                                |
+    //                                SrcWrapperTy -- SrcStdT --\
+    //                                                          CommonT
+    //                                DstWrapperTy -- DstStdT --/
+    //                                |
+    // element_storage_t<DstWrapperTy>
+
+    if constexpr (std::is_same_v<CommonT, SrcWrapperTy>) {
+      TmpVal = std::move(Val);
+    } else {
+      TmpVal = convert<CommonVecT>(SrcWTC::template from_vector<N>(Val));
+    }
+    if constexpr (std::is_same_v<DstWrapperTy, CommonT>) {
+      return TmpVal;
+    } else {
+      return DstWTC::template to_vector<N>(convert<DstStdVecT>(TmpVal));
+    }
+  }
+}
+
+template <class Ty>
+ESIMD_INLINE element_storage_t<Ty> bitcast_to_storage_type(Ty Val) {
+  if constexpr (!is_wrapper_elem_type_v<Ty>) {
+    return Val;
+  } else {
+    return __esimd_wrapper_type_bitcast_from<Ty>(Val);
+  }
+}
+
+template <class Ty>
+ESIMD_INLINE Ty bitcast_to_wrapper_type(element_storage_t<Ty> Val) {
+  if constexpr (!is_wrapper_elem_type_v<Ty>) {
+    return Val;
+  } else {
+    return __esimd_wrapper_type_bitcast_to<Ty>(Val);
+  }
+}
+
+// Converts a scalar value from given source type to destination type. Both
+// types can be non-std element types, in which case additional non-C++
+// conversions happen if the types are different.
+// NOTE: this is not symmetric with convert_vector, which inputs and outputs
+// raw (storage) vector types.
+template <class DstWrapperTy, class SrcWrapperTy,
+          class DstRawTy = element_storage_t<DstWrapperTy>,
+          class SrcRawTy = element_storage_t<SrcWrapperTy>>
+ESIMD_INLINE DstWrapperTy convert_scalar(SrcWrapperTy Val) {
+  if constexpr (std::is_same_v<SrcWrapperTy, DstWrapperTy>) {
+    return Val;
+  } else if constexpr (!detail::is_wrapper_elem_type_v<SrcWrapperTy> &&
+                       !is_wrapper_elem_type_v<DstWrapperTy>) {
+    return static_cast<DstRawTy>(Val);
+  } else {
+    vector_type_t<SrcRawTy, 1> V0 = bitcast_to_storage_type<SrcWrapperTy>(Val);
+    vector_type_t<DstRawTy, 1> V1 =
+        convert_vector<DstWrapperTy, SrcWrapperTy, 1>(V0);
+    return bitcast_to_wrapper_type<DstWrapperTy>(V1[0]);
+  }
+}
+
+template <BinOp Op, class T> T binary_op_default_impl(T X, T Y) {
+  T Res{};
+  if constexpr (Op == BinOp::add)
+    Res = X + Y;
+  else if constexpr (Op == BinOp::sub)
+    Res = X - Y;
+  else if constexpr (Op == BinOp::mul)
+    Res = X * Y;
+  else if constexpr (Op == BinOp::div)
+    Res = X / Y;
+  else if constexpr (Op == BinOp::rem)
+    Res = X % Y;
+  else if constexpr (Op == BinOp::shl)
+    Res = X << Y;
+  else if constexpr (Op == BinOp::shr)
+    Res = X >> Y;
+  else if constexpr (Op == BinOp::bit_or)
+    Res = X | Y;
+  else if constexpr (Op == BinOp::bit_and)
+    Res = X & Y;
+  else if constexpr (Op == BinOp::bit_xor)
+    Res = X ^ Y;
+  else if constexpr (Op == BinOp::log_or)
+    Res = X || Y;
+  else if constexpr (Op == BinOp::log_and)
+    Res = X && Y;
+  return Res;
+}
+
+template <CmpOp Op, class T> auto comparison_op_default_impl(T X, T Y) {
+  decltype(X < Y) Res{};
+  if constexpr (Op == CmpOp::lt)
+    Res = X < Y;
+  else if constexpr (Op == CmpOp::lte)
+    Res = X <= Y;
+  else if constexpr (Op == CmpOp::eq)
+    Res = X == Y;
+  else if constexpr (Op == CmpOp::ne)
+    Res = X != Y;
+  else if constexpr (Op == CmpOp::gte)
+    Res = X >= Y;
+  else if constexpr (Op == CmpOp::gt)
+    Res = X > Y;
+  return Res;
+}
+
+namespace {
+template <class ElemT, int N> struct __hlp {
+  using RawElemT = element_storage_t<ElemT>;
+  using RawVecT = vector_type_t<RawElemT, N>;
+  using BinopT = decltype(std::declval<RawVecT>() + std::declval<RawVecT>());
+  using CmpT = decltype(std::declval<RawVecT>() < std::declval<RawVecT>());
+};
+
+template <class Hlp> using __re_t = typename Hlp::RawElemT;
+template <class Hlp> using __rv_t = typename Hlp::RawVecT;
+template <class Hlp> using __cmp_t = typename Hlp::CmpT;
+} // namespace
+
+// --- Scalar versions of binary operations
+
+template <BinOp Op, class T> ESIMD_INLINE T __esimd_binary_op(T X, T Y);
+
+template <BinOp Op, class T,
+          class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
+ESIMD_INLINE T binary_op_default(T X, T Y) {
+  static_assert(element_type_traits<T>::use_native_cpp_ops);
+  using T1 = element_storage_t<T>;
+  T1 X1 = bitcast_to_storage_type(X);
+  T1 Y1 = bitcast_to_storage_type(Y);
+  T1 Res = binary_op_default_impl<Op>(X1, Y1);
+  return bitcast_to_wrapper_type<T>(Res);
+}
+
+template <BinOp Op, class T,
+          class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
+ESIMD_INLINE T binary_op(T X, T Y) {
+  if constexpr (element_type_traits<T>::use_native_cpp_ops) {
+    return binary_op_default<Op>(X, Y);
+  } else {
+    return __esimd_binary_op<Op>(X, Y);
+  }
+}
+
+// Default (inefficient) implementation of a scalar binary operation, which
+// involves conversion to an std C++ type, performing the op and converting
+// back.
+template <BinOp Op, class T> ESIMD_INLINE T __esimd_binary_op(T X, T Y) {
+  using T1 = typename element_type_traits<T>::EnclosingCppT;
+  T1 X1 = convert_scalar<T1, T>(X);
+  T1 Y1 = convert_scalar<T1, T>(Y);
+  return convert_scalar<T>(binary_op_default<Op, T1>(X1, Y1));
+}
+
+// --- Vector versions of binary operations
+
+template <BinOp Op, class ElemT, int N, class RawVecT = __rv_t<__hlp<ElemT, N>>>
+ESIMD_INLINE RawVecT vector_binary_op_default(RawVecT X, RawVecT Y) {
+  static_assert(element_type_traits<ElemT>::use_native_cpp_ops);
+  return binary_op_default_impl<Op, RawVecT>(X, Y);
+}
+
+// Default (inefficient) implementation of a vector binary operation, which
+// involves conversion to an std C++ type, performing the op and converting
+// back.
+template <BinOp Op, class ElemT, int N, class RawVecT = __rv_t<__hlp<ElemT, N>>>
+ESIMD_INLINE RawVecT __esimd_vector_binary_op(RawVecT X, RawVecT Y) {
+  using T1 = element_type_traits<ElemT>::EnclosingCppT;
+  using VecT1 = vector_type_t<T1, N>;
+  VecT1 X1 = convert_vector<T1, ElemT, N>(X);
+  VecT1 Y1 = convert_vector<T1, ElemT, N>(Y);
+  return convert_vector<ElemT, T1, N>(
+      vector_binary_op_default<Op, T1, N>(X1, Y1));
+}
+
+template <BinOp Op, class ElemT, int N, class RawVecT = __rv_t<__hlp<ElemT, N>>>
+ESIMD_INLINE RawVecT vector_binary_op(RawVecT X, RawVecT Y) {
+  if constexpr (element_type_traits<ElemT>::use_native_cpp_ops) {
+    return vector_binary_op_default<Op, ElemT, N>(X, Y);
+  } else {
+    return __esimd_vector_binary_op<Op, ElemT, N>(X, Y);
+  }
+}
+
+// --- Vector versions of comparison operations
+
+template <CmpOp Op, class ElemT, int N, class H = __hlp<ElemT, N>,
+          class RetT = __cmp_t<H>, class RawVecT = __rv_t<H>>
+ESIMD_INLINE RetT vector_comparison_op_default(RawVecT X, RawVecT Y) {
+  static_assert(element_type_traits<ElemT>::use_native_cpp_ops);
+  return comparison_op_default_impl<Op, RawVecT>(X, Y);
+}
+
+// Default (inefficient) implementation of a vector comparison operation, which
+// involves conversion to an std C++ type, performing the op and converting
+// back.
+template <CmpOp Op, class ElemT, int N, class H = __hlp<ElemT, N>,
+          class RetT = __cmp_t<H>, class RawVecT = __rv_t<H>>
+ESIMD_INLINE RetT __esimd_vector_comparison_op(RawVecT X, RawVecT Y) {
+  using T1 = element_type_traits<ElemT>::EnclosingCppT;
+  using VecT1 = vector_type_t<T1, N>;
+  VecT1 X1 = convert_vector<T1, ElemT, N>(X);
+  VecT1 Y1 = convert_vector<T1, ElemT, N>(Y);
+  return convert_vector<element_type_t<RetT>, T1>(
+      vector_comparison_op_default<Op, T1, N>(X1, Y1));
+}
+
+template <CmpOp Op, class ElemT, int N, class H = __hlp<ElemT, N>,
+          class RetT = __cmp_t<H>, class RawVecT = __rv_t<H>>
+ESIMD_INLINE RetT vector_comparison_op(RawVecT X, RawVecT Y) {
+  if constexpr (element_type_traits<ElemT>::use_native_cpp_ops) {
+    return vector_comparison_op_default<Op, ElemT, N>(X, Y);
+  } else {
+    return __esimd_vector_comparison_op<Op, ElemT, N>(X, Y);
+  }
+}
+
+// Proxy class to access bit representation of a wrapper type both on host and
+// device.
+// TODO add this functionality to sycl type implementation? With C++20,
+// std::bit_cast should be a good replacement.
+class WrapperElementTypeProxy {
+public:
+  template <class T = sycl::half>
+  static inline element_storage_t<T> bitcast_from_half(T Val) {
+#ifdef __SYCL_DEVICE_ONLY__
+    return Val.Data;
+#else
+    return Val.Data.Buf;
+#endif // __SYCL_DEVICE_ONLY__
+  }
+
+  template <class T = sycl::half>
+  static inline T bitcast_to_half(element_storage_t<T> Bits) {
+#ifndef __SYCL_DEVICE_ONLY__
+    return sycl::half{Bits};
+#else
+    sycl::half Res;
+    Res.Data = Bits;
+    return Res;
+#endif // __SYCL_DEVICE_ONLY__
+  }
+};
+
+// Both std:: variants of the check fail for _Float16, so need a w/a
+// template <typename T>
+// static inline constexpr bool is_floating_point_v =
+// std::is_floating_point_v<element_type_traits<T>::EnclosingCppT>;
+//
+// template <typename T>
+// static inline constexpr bool is_arithmetic_v =
+// std::is_arithmetic_v<element_type_traits<T>::EnclosingCppT>;
+
+// @{
+// Get computation type of a binary operator given its operand types:
+// - if both types are arithmetic - return CPP's "common real type" of the
+//   computation (matches C++)
+// - if both types are simd types, they must be of the same length N,
+//   and the returned type is simd<T, N>, where N is the "common real type" of
+//   the element type of the operands (diverges from clang)
+// - otherwise, one type is simd and another is arithmetic - the simd type is
+//   returned (matches clang)
+
+struct invalid_computation_type;
+
+template <class T1, class T2, class SFINAE = void> struct computation_type {
+  using type = invalid_computation_type;
+};
+
+template <class T1, class T2>
+struct computation_type<T1, T2,
+                        std::enable_if_t<is_valid_simd_elem_type_v<T1> &&
+                                         is_valid_simd_elem_type_v<T2>>> {
+  template <class T> using __tr = element_type_traits<T>;
+  template <class T>
+  using __native_t = std::conditional_t<__tr<T>::use_native_cpp_ops,
+                                        typename __tr<T>::StorageT,
+                                        typename __tr<T>::EnclosingCppT>;
+
+  using type =
+      decltype(std::declval<__native_t<T1>>() + std::declval<__native_t<T2>>());
+};
+
+template <class T1, class T2>
+struct computation_type<
+    T1, T2,
+    std::enable_if_t<is_simd_like_type_v<T1> || is_simd_like_type_v<T2>>> {
+private:
+  using Ty1 = typename element_type<T1>::type;
+  using Ty2 = typename element_type<T2>::type;
+  using EltTy = typename computation_type<Ty1, Ty2>::type;
+  static constexpr int N1 = is_simd_like_type_v<T1> ? T1::length : 0;
+  static constexpr int N2 = is_simd_like_type_v<T2> ? T2::length : 0;
+  static_assert((N1 == N2) || ((N1 & N2) == 0), "size mismatch");
+  static constexpr int N = N1 ? N1 : N2;
+
+public:
+  using type = simd<EltTy, N1>;
+};
+
+template <class T1, class T2 = T1>
+using computation_type_t =
+    typename computation_type<remove_cvref_t<T1>, remove_cvref_t<T2>>::type;
+
+// @}
+
+////////////////////////////////////////////////////////////////////////////////
+// sycl::half traits
+////////////////////////////////////////////////////////////////////////////////
+
+#ifdef __SYCL_DEVICE_ONLY__
+using half = _Float16;
+#else
+using half = uint16_t;
+#endif // __SYCL_DEVICE_ONLY__
+
+template <class T>
+struct element_type_traits<T, std::enable_if_t<std::is_same_v<T, sycl::half>>> {
+  using EnclosingCppT = float;
+  // Can't use sycl::detail::half_impl::StorageT as it still maps to struct on
+  // host (even though the struct is a trivial wrapper around uint16_t), and for
+  // ESIMD we need a type which can be an element of clang vector.
+#ifdef __SYCL_DEVICE_ONLY__
+  using StorageT = sycl::detail::half_impl::StorageT;
+  // On device, operations on half are translated to operations on _Float16,
+  // which is natively supported by the device compiler
+  static inline constexpr bool use_native_cpp_ops = true;
+#else
+  using StorageT = uint16_t;
+  // On host, we can't use native Cpp '+', '-' etc. over uint16_t to emulate the
+  // operations on half type.
+  static inline constexpr bool use_native_cpp_ops = false;
+#endif // __SYCL_DEVICE_ONLY__
+};
+
+using half_raw = element_storage_t<sycl::half>;
+
+template <>
+sycl::half __esimd_wrapper_type_bitcast_to<sycl::half>(half_raw Val) {
+  return WrapperElementTypeProxy::bitcast_to_half(Val);
+}
+
+template <>
+half_raw __esimd_wrapper_type_bitcast_from<sycl::half>(sycl::half Val) {
+  return WrapperElementTypeProxy::bitcast_from_half(Val);
+}
+
+template <>
+struct is_esimd_arithmetic_type<element_storage_t<sycl::half>, void>
+    : std::true_type {};
+
+// Misc
+inline std::ostream &operator<<(std::ostream &O, half const &rhs) {
+  O << static_cast<float>(rhs);
+  return O;
+}
+
+inline std::istream &operator>>(std::istream &I, half &rhs) {
+  float ValFloat = 0.0f;
+  I >> ValFloat;
+  rhs = ValFloat;
+  return I;
+}
+
+// The only other place which needs to be updated to support a new type is
+// the is_wrapper_elem_type_v template constexpr var.
+
+////////////////////////////////////////////////////////////////////////////////
+// sycl::bfloat16 traits
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace detail
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/intrin.hpp
@@ -139,12 +139,15 @@ namespace experimental {
 namespace esimd {
 namespace detail {
 
+template <class T> using __st = element_storage_t<T>;
+
 /// read from a basic region of a vector, return a vector
 template <typename BT, int BN, typename RTy>
-__SEIEED::vector_type_t<typename RTy::element_type, RTy::length> ESIMD_INLINE
-readRegion(const __SEIEED::vector_type_t<BT, BN> &Base, RTy Region) {
-  using ElemTy = typename RTy::element_type;
-  auto Base1 = bitcast<ElemTy, BT, BN>(Base);
+__SEIEED::vector_type_t<__st<typename RTy::element_type>, RTy::length>
+    ESIMD_INLINE readRegion(const __SEIEED::vector_type_t<__st<BT>, BN> &Base,
+                            RTy Region) {
+  using ElemTy = __st<typename RTy::element_type>;
+  auto Base1 = bitcast<ElemTy, __st<BT>, BN>(Base);
   constexpr int Bytes = BN * sizeof(BT);
   if constexpr (Bytes == RTy::Size_in_bytes)
     // This is a no-op format.
@@ -163,14 +166,14 @@ readRegion(const __SEIEED::vector_type_t<BT, BN> &Base, RTy Region) {
 
 /// read from a nested region of a vector, return a vector
 template <typename BT, int BN, typename T, typename U>
-ESIMD_INLINE __SEIEED::vector_type_t<typename T::element_type, T::length>
-readRegion(const __SEIEED::vector_type_t<BT, BN> &Base,
+ESIMD_INLINE __SEIEED::vector_type_t<__st<typename T::element_type>, T::length>
+readRegion(const __SEIEED::vector_type_t<__st<BT>, BN> &Base,
            std::pair<T, U> Region) {
   // parent-region type
   using PaTy = typename shape_type<U>::type;
   constexpr int BN1 = PaTy::length;
   using BT1 = typename PaTy::element_type;
-  using ElemTy = typename T::element_type;
+  using ElemTy = __st<typename T::element_type>;
   // Recursively read the base
   auto Base1 = readRegion<BT, BN>(Base, Region.second);
   if constexpr (!T::Is_2D || BN1 * sizeof(BT1) == T::Size_in_bytes)
@@ -178,7 +181,7 @@ readRegion(const __SEIEED::vector_type_t<BT, BN> &Base,
     return readRegion<BT1, BN1>(Base1, Region.first);
   else {
     static_assert(T::Is_2D);
-    static_assert(std::is_same<ElemTy, BT1>::value);
+    static_assert(std::is_same<ElemTy, __st<BT1>>::value);
     // To read a 2D region, we need the parent region
     // Read full rows with non-trivial vertical and horizontal stride = 1.
     constexpr int M = T::Size_y * PaTy::Size_x;

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/intrin.hpp
@@ -139,7 +139,7 @@ namespace experimental {
 namespace esimd {
 namespace detail {
 
-template <class T> using __st = element_storage_t<T>;
+template <class T> using __st = __raw_t<T>;
 
 /// read from a basic region of a vector, return a vector
 template <typename BT, int BN, typename RTy>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
@@ -198,12 +198,13 @@ __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, BinOp::div, __ESIMD_ARITH_OP_FILTER)
       using PromotedT = computation_type_t<T1, T2>;                            \
       /* vector_comparison_op returns vector_type_t<Ti, N>, where Ti is        \
        * integer type */                                                       \
-      /* of the same bit size as PromotedT */                                                                            \
+      /* of the same bit size as PromotedT */                                  \
       auto Res = vector_comparison_op<CMPOP_ID, PromotedT, N>(                 \
           __SEIEED::convert_vector<PromotedT, T1, N>(LHS.data()),              \
           __SEIEED::convert_vector<PromotedT, T2, N>(RHS.data()));             \
+      using ResElemT = element_type_t<decltype(Res)>;                          \
       return __SEIEE::simd_mask<N>(                                            \
-          __SEIEED::convert_vector<simd_mask_elem_type, PromotedT, N>(Res) &   \
+          __SEIEED::convert_vector<simd_mask_elem_type, ResElemT, N>(Res) &    \
           MaskVecT(1));                                                        \
     } else {                                                                   \
       /* this is comparison of masks, don't perform type promotion */          \

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
@@ -62,7 +62,6 @@
 // stop further lookup, leaving just non-viable sycl::operator < etc. on the
 // table).
 namespace __SEIEED {
-template <class T> using __st = element_storage_t<T>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // simd_obj_impl global operators
@@ -76,11 +75,11 @@ template <class T> using __st = element_storage_t<T>;
   template <class T1, class T2, int N, template <class, int> class SimdT,      \
             class SimdTx = SimdT<T1, N>, class = std::enable_if_t<COND>>       \
   inline auto operator BINOP(                                                  \
-      const __SEIEED::simd_obj_impl<__st<T1>, N, SimdT<T1, N>> &LHS,           \
-      const __SEIEED::simd_obj_impl<__st<T2>, N, SimdT<T2, N>> &RHS) {         \
+      const __SEIEED::simd_obj_impl<__raw_t<T1>, N, SimdT<T1, N>> &LHS,           \
+      const __SEIEED::simd_obj_impl<__raw_t<T2>, N, SimdT<T2, N>> &RHS) {         \
     if constexpr (__SEIEED::is_simd_type_v<SimdT<T1, N>>) {                    \
       using PromotedT = __SEIEED::computation_type_t<T1, T2>;                  \
-      /* vector_binary_op returns SimdT<PromotedT, N>::vector_type */          \
+      /* vector_binary_op returns SimdT<PromotedT, N>::raw_vector_type */          \
       SimdT<PromotedT, N> Res = vector_binary_op<BINOP_ID, PromotedT, N>(      \
           __SEIEED::convert_vector<PromotedT, T1, N>(LHS.data()),              \
           __SEIEED::convert_vector<PromotedT, T2, N>(RHS.data()));             \
@@ -96,7 +95,7 @@ template <class T> using __st = element_storage_t<T>;
   template <class T1, int N1, template <class, int> class SimdT1, class T2,    \
             class SimdTx = SimdT1<T1, N1>, class = std::enable_if_t<COND>>     \
   inline auto operator BINOP(                                                  \
-      const __SEIEED::simd_obj_impl<__st<T1>, N1, SimdT1<T1, N1>> &LHS,        \
+      const __SEIEED::simd_obj_impl<__raw_t<T1>, N1, SimdT1<T1, N1>> &LHS,        \
       T2 RHS) {                                                                \
     if constexpr (__SEIEED::is_simd_type_v<SimdT1<T1, N1>>) {                  \
       /* convert the SCALAR to vector type and reuse the basic operation over  \
@@ -114,7 +113,7 @@ template <class T> using __st = element_storage_t<T>;
             class SimdTx = SimdT2<T2, N2>, class = std::enable_if_t<COND>>     \
   inline auto operator BINOP(                                                  \
       T1 LHS,                                                                  \
-      const __SEIEED::simd_obj_impl<__st<T2>, N2, SimdT2<T2, N2>> &RHS) {      \
+      const __SEIEED::simd_obj_impl<__raw_t<T2>, N2, SimdT2<T2, N2>> &RHS) {      \
     if constexpr (__SEIEED::is_simd_type_v<SimdT2<T2, N2>>) {                  \
       /* convert the SCALAR to vector type and reuse the basic operation over  \
        * simd objects */                                                       \
@@ -163,9 +162,9 @@ __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, BinOp::div, __ESIMD_ARITH_OP_FILTER)
   template <class T1, class T2, int N, template <class, int> class SimdT,      \
             class SimdTx = SimdT<T1, N>, class = std::enable_if_t<COND>>       \
   inline __SEIEE::simd_mask<N> operator CMPOP(                                 \
-      const __SEIEED::simd_obj_impl<__st<T1>, N, SimdT<T1, N>> &LHS,           \
-      const __SEIEED::simd_obj_impl<__st<T2>, N, SimdT<T2, N>> &RHS) {         \
-    using MaskVecT = typename __SEIEE::simd_mask<N>::vector_type;              \
+      const __SEIEED::simd_obj_impl<__raw_t<T1>, N, SimdT<T1, N>> &LHS,           \
+      const __SEIEED::simd_obj_impl<__raw_t<T2>, N, SimdT<T2, N>> &RHS) {         \
+    using MaskVecT = typename __SEIEE::simd_mask<N>::raw_vector_type;              \
                                                                                \
     if constexpr (is_simd_type_v<SimdT<T1, N>>) {                              \
       using PromotedT = computation_type_t<T1, T2>;                            \
@@ -193,7 +192,7 @@ __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, BinOp::div, __ESIMD_ARITH_OP_FILTER)
             class = std::enable_if_t<                                          \
                 __SEIEED::is_valid_simd_elem_type_v<T2> && COND>>              \
   inline __SEIEE::simd_mask<N1> operator CMPOP(                                \
-      const __SEIEED::simd_obj_impl<__st<T1>, N1, SimdT1<T1, N1>> &LHS,        \
+      const __SEIEED::simd_obj_impl<__raw_t<T1>, N1, SimdT1<T1, N1>> &LHS,        \
       T2 RHS) {                                                                \
     if constexpr (__SEIEED::is_simd_type_v<SimdT1<T1, N1>>)                    \
       /* simd case */                                                          \
@@ -210,7 +209,7 @@ __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, BinOp::div, __ESIMD_ARITH_OP_FILTER)
                 __SEIEED::is_valid_simd_elem_type_v<T1> && COND>>              \
   inline __SEIEE::simd_mask<N2> operator CMPOP(                                \
       T1 LHS,                                                                  \
-      const __SEIEED::simd_obj_impl<__st<T2>, N2, SimdT2<T2, N2>> &RHS) {      \
+      const __SEIEED::simd_obj_impl<__raw_t<T2>, N2, SimdT2<T2, N2>> &RHS) {      \
     if constexpr (__SEIEED::is_simd_type_v<SimdT2<T2, N2>>)                    \
       /* simd case */                                                          \
       return SimdT2<T1, N2>(LHS) CMPOP RHS;                                    \

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
@@ -64,33 +64,6 @@
 namespace __SEIEED {
 template <class T> using __st = element_storage_t<T>;
 
-#if 0
-  enum class BinOp {
-  ARITH_FIRST, add=ARITH_FIRST, sub, mul, div, rem, ARITH_LAST=rem,
-  BIT_FIRST, shl=BIT_FIRST, shr, BIT_LOG, bit_or=BIT_LOG, bit_and, bit_xor, BIT_LST=bit_xor,
-  LOG_FIRST, log_or=LOG_FIRST, log_and, LOG_LAST=log_and,
-  CMP_FIRST, lt=CMP_FIRST, lte, gte, gt, EQ_CMP_FIRST, eq=EQ_CMP_FIRST, ne, CMP_LAST=ne
-};
-
-#define __ESIMD_BIN_OP_IMPL(OpEum, OpSym)                                      \
-  if constexpr (BinOp::OpEnum == Op)                                           \
-  return (LHS)OpSym(RHS)
-
-#define __ESIMD_BIN_OP_HALF_IMPL
-
-template <class UserElemT, class VecT, BinOp Op>
-ESIMD_INLINE VecT bin_op_impl(VecT LHS, VecT RHS) {
-  if constexpr (std::is_same_v<UserElemT, sycl::half>) {
-    return half_bin_op_impl(LHS, RHS);
-  } else {
-    __ESIMD_BIN_OP_IMPL(add, +);
-    __ESIMD_BIN_OP_IMPL(sub, -);
-    __ESIMD_BIN_OP_IMPL(mul, *);
-    __ESIMD_BIN_OP_IMPL(div, /);
-    __ESIMD_BIN_OP_IMPL(rem, %);
-  }
-}
-#endif
 ////////////////////////////////////////////////////////////////////////////////
 // simd_obj_impl global operators
 ////////////////////////////////////////////////////////////////////////////////

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
@@ -75,11 +75,11 @@ namespace __SEIEED {
   template <class T1, class T2, int N, template <class, int> class SimdT,      \
             class SimdTx = SimdT<T1, N>, class = std::enable_if_t<COND>>       \
   inline auto operator BINOP(                                                  \
-      const __SEIEED::simd_obj_impl<__raw_t<T1>, N, SimdT<T1, N>> &LHS,           \
-      const __SEIEED::simd_obj_impl<__raw_t<T2>, N, SimdT<T2, N>> &RHS) {         \
+      const __SEIEED::simd_obj_impl<__raw_t<T1>, N, SimdT<T1, N>> &LHS,        \
+      const __SEIEED::simd_obj_impl<__raw_t<T2>, N, SimdT<T2, N>> &RHS) {      \
     if constexpr (__SEIEED::is_simd_type_v<SimdT<T1, N>>) {                    \
       using PromotedT = __SEIEED::computation_type_t<T1, T2>;                  \
-      /* vector_binary_op returns SimdT<PromotedT, N>::raw_vector_type */          \
+      /* vector_binary_op returns SimdT<PromotedT, N>::raw_vector_type */      \
       SimdT<PromotedT, N> Res = vector_binary_op<BINOP_ID, PromotedT, N>(      \
           __SEIEED::convert_vector<PromotedT, T1, N>(LHS.data()),              \
           __SEIEED::convert_vector<PromotedT, T2, N>(RHS.data()));             \
@@ -95,7 +95,7 @@ namespace __SEIEED {
   template <class T1, int N1, template <class, int> class SimdT1, class T2,    \
             class SimdTx = SimdT1<T1, N1>, class = std::enable_if_t<COND>>     \
   inline auto operator BINOP(                                                  \
-      const __SEIEED::simd_obj_impl<__raw_t<T1>, N1, SimdT1<T1, N1>> &LHS,        \
+      const __SEIEED::simd_obj_impl<__raw_t<T1>, N1, SimdT1<T1, N1>> &LHS,     \
       T2 RHS) {                                                                \
     if constexpr (__SEIEED::is_simd_type_v<SimdT1<T1, N1>>) {                  \
       /* convert the SCALAR to vector type and reuse the basic operation over  \
@@ -113,7 +113,7 @@ namespace __SEIEED {
             class SimdTx = SimdT2<T2, N2>, class = std::enable_if_t<COND>>     \
   inline auto operator BINOP(                                                  \
       T1 LHS,                                                                  \
-      const __SEIEED::simd_obj_impl<__raw_t<T2>, N2, SimdT2<T2, N2>> &RHS) {      \
+      const __SEIEED::simd_obj_impl<__raw_t<T2>, N2, SimdT2<T2, N2>> &RHS) {   \
     if constexpr (__SEIEED::is_simd_type_v<SimdT2<T2, N2>>) {                  \
       /* convert the SCALAR to vector type and reuse the basic operation over  \
        * simd objects */                                                       \
@@ -162,9 +162,9 @@ __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, BinOp::div, __ESIMD_ARITH_OP_FILTER)
   template <class T1, class T2, int N, template <class, int> class SimdT,      \
             class SimdTx = SimdT<T1, N>, class = std::enable_if_t<COND>>       \
   inline __SEIEE::simd_mask<N> operator CMPOP(                                 \
-      const __SEIEED::simd_obj_impl<__raw_t<T1>, N, SimdT<T1, N>> &LHS,           \
-      const __SEIEED::simd_obj_impl<__raw_t<T2>, N, SimdT<T2, N>> &RHS) {         \
-    using MaskVecT = typename __SEIEE::simd_mask<N>::raw_vector_type;              \
+      const __SEIEED::simd_obj_impl<__raw_t<T1>, N, SimdT<T1, N>> &LHS,        \
+      const __SEIEED::simd_obj_impl<__raw_t<T2>, N, SimdT<T2, N>> &RHS) {      \
+    using MaskVecT = typename __SEIEE::simd_mask<N>::raw_vector_type;          \
                                                                                \
     if constexpr (is_simd_type_v<SimdT<T1, N>>) {                              \
       using PromotedT = computation_type_t<T1, T2>;                            \
@@ -192,7 +192,7 @@ __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, BinOp::div, __ESIMD_ARITH_OP_FILTER)
             class = std::enable_if_t<                                          \
                 __SEIEED::is_valid_simd_elem_type_v<T2> && COND>>              \
   inline __SEIEE::simd_mask<N1> operator CMPOP(                                \
-      const __SEIEED::simd_obj_impl<__raw_t<T1>, N1, SimdT1<T1, N1>> &LHS,        \
+      const __SEIEED::simd_obj_impl<__raw_t<T1>, N1, SimdT1<T1, N1>> &LHS,     \
       T2 RHS) {                                                                \
     if constexpr (__SEIEED::is_simd_type_v<SimdT1<T1, N1>>)                    \
       /* simd case */                                                          \
@@ -209,7 +209,7 @@ __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, BinOp::div, __ESIMD_ARITH_OP_FILTER)
                 __SEIEED::is_valid_simd_elem_type_v<T1> && COND>>              \
   inline __SEIEE::simd_mask<N2> operator CMPOP(                                \
       T1 LHS,                                                                  \
-      const __SEIEED::simd_obj_impl<__raw_t<T2>, N2, SimdT2<T2, N2>> &RHS) {      \
+      const __SEIEED::simd_obj_impl<__raw_t<T2>, N2, SimdT2<T2, N2>> &RHS) {   \
     if constexpr (__SEIEED::is_simd_type_v<SimdT2<T2, N2>>)                    \
       /* simd case */                                                          \
       return SimdT2<T1, N2>(LHS) CMPOP RHS;                                    \

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <sycl/ext/intel/experimental/esimd/detail/elem_type_traits.hpp>
 #include <sycl/ext/intel/experimental/esimd/detail/simd_obj_impl.hpp>
 #include <sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp>
 #include <sycl/ext/intel/experimental/esimd/detail/types.hpp>
@@ -61,27 +62,56 @@
 // stop further lookup, leaving just non-viable sycl::operator < etc. on the
 // table).
 namespace __SEIEED {
+template <class T> using __st = element_storage_t<T>;
 
+#if 0
+  enum class BinOp {
+  ARITH_FIRST, add=ARITH_FIRST, sub, mul, div, rem, ARITH_LAST=rem,
+  BIT_FIRST, shl=BIT_FIRST, shr, BIT_LOG, bit_or=BIT_LOG, bit_and, bit_xor, BIT_LST=bit_xor,
+  LOG_FIRST, log_or=LOG_FIRST, log_and, LOG_LAST=log_and,
+  CMP_FIRST, lt=CMP_FIRST, lte, gte, gt, EQ_CMP_FIRST, eq=EQ_CMP_FIRST, ne, CMP_LAST=ne
+};
+
+#define __ESIMD_BIN_OP_IMPL(OpEum, OpSym)                                      \
+  if constexpr (BinOp::OpEnum == Op)                                           \
+  return (LHS)OpSym(RHS)
+
+#define __ESIMD_BIN_OP_HALF_IMPL
+
+template <class UserElemT, class VecT, BinOp Op>
+ESIMD_INLINE VecT bin_op_impl(VecT LHS, VecT RHS) {
+  if constexpr (std::is_same_v<UserElemT, sycl::half>) {
+    return half_bin_op_impl(LHS, RHS);
+  } else {
+    __ESIMD_BIN_OP_IMPL(add, +);
+    __ESIMD_BIN_OP_IMPL(sub, -);
+    __ESIMD_BIN_OP_IMPL(mul, *);
+    __ESIMD_BIN_OP_IMPL(div, /);
+    __ESIMD_BIN_OP_IMPL(rem, %);
+  }
+}
+#endif
 ////////////////////////////////////////////////////////////////////////////////
 // simd_obj_impl global operators
 ////////////////////////////////////////////////////////////////////////////////
 
 // ========= simd_obj_impl bitwise logic and arithmetic operators
 
-#define __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(BINOP, COND)                          \
+#define __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(BINOP, BINOP_ID, COND)                \
                                                                                \
   /* simd_obj_impl BINOP simd_obj_impl */                                      \
   template <class T1, class T2, int N, template <class, int> class SimdT,      \
             class SimdTx = SimdT<T1, N>, class = std::enable_if_t<COND>>       \
   inline auto operator BINOP(                                                  \
-      const __SEIEED::simd_obj_impl<T1, N, SimdT<T1, N>> &LHS,                 \
-      const __SEIEED::simd_obj_impl<T2, N, SimdT<T2, N>> &RHS) {               \
+      const __SEIEED::simd_obj_impl<__st<T1>, N, SimdT<T1, N>> &LHS,           \
+      const __SEIEED::simd_obj_impl<__st<T2>, N, SimdT<T2, N>> &RHS) {         \
     if constexpr (__SEIEED::is_simd_type_v<SimdT<T1, N>>) {                    \
-      using SimdPromotedT =                                                    \
-          __SEIEED::computation_type_t<SimdT<T1, N>, SimdT<T2, N>>;            \
-      using VecT = typename SimdPromotedT::vector_type;                        \
-      return SimdPromotedT(__SEIEED::convert<VecT>(LHS.data())                 \
-                               BINOP __SEIEED::convert<VecT>(RHS.data()));     \
+      using PromotedT = __SEIEED::computation_type_t<T1, T2>;                  \
+      /* vector_binary_op returns SimdT<PromotedT, N>::vector_type */          \
+      SimdT<PromotedT, N> Res = vector_binary_op<BINOP_ID, PromotedT, N>(      \
+          __SEIEED::convert_vector<PromotedT, T1, N>(LHS.data()),              \
+          __SEIEED::convert_vector<PromotedT, T2, N>(RHS.data()));             \
+      return Res;                                                              \
     } else {                                                                   \
       /* for SimdT=simd_mask_impl T1 and T2 are both equal to                  \
        * simd_mask_elem_type */                                                \
@@ -93,7 +123,8 @@ namespace __SEIEED {
   template <class T1, int N1, template <class, int> class SimdT1, class T2,    \
             class SimdTx = SimdT1<T1, N1>, class = std::enable_if_t<COND>>     \
   inline auto operator BINOP(                                                  \
-      const __SEIEED::simd_obj_impl<T1, N1, SimdT1<T1, N1>> &LHS, T2 RHS) {    \
+      const __SEIEED::simd_obj_impl<__st<T1>, N1, SimdT1<T1, N1>> &LHS,        \
+      T2 RHS) {                                                                \
     if constexpr (__SEIEED::is_simd_type_v<SimdT1<T1, N1>>) {                  \
       /* convert the SCALAR to vector type and reuse the basic operation over  \
        * simd objects */                                                       \
@@ -109,7 +140,8 @@ namespace __SEIEED {
   template <class T1, class T2, int N2, template <class, int> class SimdT2,    \
             class SimdTx = SimdT2<T2, N2>, class = std::enable_if_t<COND>>     \
   inline auto operator BINOP(                                                  \
-      T1 LHS, const __SEIEED::simd_obj_impl<T2, N2, SimdT2<T2, N2>> &RHS) {    \
+      T1 LHS,                                                                  \
+      const __SEIEED::simd_obj_impl<__st<T2>, N2, SimdT2<T2, N2>> &RHS) {      \
     if constexpr (__SEIEED::is_simd_type_v<SimdT2<T2, N2>>) {                  \
       /* convert the SCALAR to vector type and reuse the basic operation over  \
        * simd objects */                                                       \
@@ -122,27 +154,28 @@ namespace __SEIEED {
 
 #define __ESIMD_BITWISE_OP_FILTER                                              \
   std::is_integral_v<T1> &&std::is_integral_v<T2>
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(^, __ESIMD_BITWISE_OP_FILTER)
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(|, __ESIMD_BITWISE_OP_FILTER)
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(&, __ESIMD_BITWISE_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(^, BinOp::bit_xor, __ESIMD_BITWISE_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(|, BinOp::bit_or, __ESIMD_BITWISE_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(&, BinOp::bit_and, __ESIMD_BITWISE_OP_FILTER)
 #undef __ESIMD_BITWISE_OP_FILTER
 
 #define __ESIMD_SHIFT_OP_FILTER                                                \
   std::is_integral_v<T1> &&std::is_integral_v<T2>                              \
       &&__SEIEED::is_simd_type_v<SimdTx>
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(%, __ESIMD_SHIFT_OP_FILTER)
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(<<, __ESIMD_SHIFT_OP_FILTER)
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(>>, __ESIMD_SHIFT_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(%, BinOp::rem, __ESIMD_SHIFT_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(<<, BinOp::shl, __ESIMD_SHIFT_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(>>, BinOp::shr, __ESIMD_SHIFT_OP_FILTER)
 #undef __ESIMD_SHIFT_OP_FILTER
 
 #define __ESIMD_ARITH_OP_FILTER                                                \
-  __SEIEED::is_vectorizable_v<T1> &&__SEIEED::is_vectorizable_v<T2>            \
-      &&__SEIEED::is_simd_type_v<SimdTx>
+  __SEIEED::is_valid_simd_elem_type_v<T1>                                      \
+      &&__SEIEED::is_valid_simd_elem_type_v<T2>                                \
+          &&__SEIEED::is_simd_type_v<SimdTx>
 
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(+, __ESIMD_ARITH_OP_FILTER)
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(-, __ESIMD_ARITH_OP_FILTER)
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(*, __ESIMD_ARITH_OP_FILTER)
-__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, __ESIMD_ARITH_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(+, BinOp::add, __ESIMD_ARITH_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(-, BinOp::sub, __ESIMD_ARITH_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(*, BinOp::mul, __ESIMD_ARITH_OP_FILTER)
+__ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, BinOp::div, __ESIMD_ARITH_OP_FILTER)
 #undef __ESIMD_ARITH_OP_FILTER
 
 #undef __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP
@@ -151,24 +184,27 @@ __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, __ESIMD_ARITH_OP_FILTER)
 // Both simd and simd_mask will match simd_obj_impl argument when resolving
 // operator overloads.
 
-#define __ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(CMPOP, COND)                          \
+#define __ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(CMPOP, CMPOP_ID, COND)                \
                                                                                \
   /* simd_obj_impl CMPOP simd_obj_impl */                                      \
   template <class T1, class T2, int N, template <class, int> class SimdT,      \
             class SimdTx = SimdT<T1, N>, class = std::enable_if_t<COND>>       \
   inline __SEIEE::simd_mask<N> operator CMPOP(                                 \
-      const __SEIEED::simd_obj_impl<T1, N, SimdT<T1, N>> &LHS,                 \
-      const __SEIEED::simd_obj_impl<T2, N, SimdT<T2, N>> &RHS) {               \
+      const __SEIEED::simd_obj_impl<__st<T1>, N, SimdT<T1, N>> &LHS,           \
+      const __SEIEED::simd_obj_impl<__st<T2>, N, SimdT<T2, N>> &RHS) {         \
     using MaskVecT = typename __SEIEE::simd_mask<N>::vector_type;              \
                                                                                \
-    if constexpr (__SEIEED::is_simd_type_v<SimdT<T1, N>>) {                    \
-      using PromSimdT =                                                        \
-          __SEIEED::computation_type_t<SimdT<T1, N>, SimdT<T2, N>>;            \
-      using PromVecT = typename PromSimdT::vector_type;                        \
-      auto ResVec = __SEIEED::convert<PromVecT>(LHS.data())                    \
-          CMPOP __SEIEED::convert<PromVecT>(RHS.data());                       \
-      return __SEIEE::simd_mask<N>(__SEIEED::convert<MaskVecT>(ResVec) &       \
-                                   MaskVecT(1));                               \
+    if constexpr (is_simd_type_v<SimdT<T1, N>>) {                              \
+      using PromotedT = computation_type_t<T1, T2>;                            \
+      /* vector_comparison_op returns vector_type_t<Ti, N>, where Ti is        \
+       * integer type */                                                       \
+      /* of the same bit size as PromotedT */                                                                            \
+      auto Res = vector_comparison_op<CMPOP_ID, PromotedT, N>(                 \
+          __SEIEED::convert_vector<PromotedT, T1, N>(LHS.data()),              \
+          __SEIEED::convert_vector<PromotedT, T2, N>(RHS.data()));             \
+      return __SEIEE::simd_mask<N>(                                            \
+          __SEIEED::convert_vector<simd_mask_elem_type, PromotedT, N>(Res) &   \
+          MaskVecT(1));                                                        \
     } else {                                                                   \
       /* this is comparison of masks, don't perform type promotion */          \
       auto ResVec = LHS.data() CMPOP RHS.data();                               \
@@ -180,49 +216,57 @@ __ESIMD_DEF_SIMD_OBJ_IMPL_BIN_OP(/, __ESIMD_ARITH_OP_FILTER)
   /* simd_obj_impl CMPOP SCALAR */                                             \
   template <class T1, int N1, template <class, int> class SimdT1, class T2,    \
             class SimdTx = SimdT1<T1, N1>,                                     \
-            class = std::enable_if_t<__SEIEED::is_vectorizable_v<T2> && COND>> \
+            class = std::enable_if_t<                                          \
+                __SEIEED::is_valid_simd_elem_type_v<T2> && COND>>              \
   inline __SEIEE::simd_mask<N1> operator CMPOP(                                \
-      const __SEIEED::simd_obj_impl<T1, N1, SimdT1<T1, N1>> &LHS, T2 RHS) {    \
+      const __SEIEED::simd_obj_impl<__st<T1>, N1, SimdT1<T1, N1>> &LHS,        \
+      T2 RHS) {                                                                \
     if constexpr (__SEIEED::is_simd_type_v<SimdT1<T1, N1>>)                    \
       /* simd case */                                                          \
       return LHS CMPOP SimdT1<T2, N1>(RHS);                                    \
     else                                                                       \
       /* simd_mask case - element type is fixed */                             \
-      return LHS CMPOP SimdT1<T1, N1>((T1)RHS);                                \
+      return LHS CMPOP SimdT1<T1, N1>(convert_scalar<T1>(RHS));                \
   }                                                                            \
                                                                                \
   /* SCALAR CMPOP simd_obj_impl */                                             \
   template <class T1, class T2, int N2, template <class, int> class SimdT2,    \
             class SimdTx = SimdT2<T2, N2>,                                     \
-            class = std::enable_if_t<__SEIEED::is_vectorizable_v<T1> && COND>> \
+            class = std::enable_if_t<                                          \
+                __SEIEED::is_valid_simd_elem_type_v<T1> && COND>>              \
   inline __SEIEE::simd_mask<N2> operator CMPOP(                                \
-      T1 LHS, const __SEIEED::simd_obj_impl<T2, N2, SimdT2<T2, N2>> &RHS) {    \
+      T1 LHS,                                                                  \
+      const __SEIEED::simd_obj_impl<__st<T2>, N2, SimdT2<T2, N2>> &RHS) {      \
     if constexpr (__SEIEED::is_simd_type_v<SimdT2<T2, N2>>)                    \
       /* simd case */                                                          \
       return SimdT2<T1, N2>(LHS) CMPOP RHS;                                    \
     else                                                                       \
       /* simd_mask case - element type is fixed */                             \
-      return SimdT2<T2, N2>((T2)LHS) CMPOP RHS;                                \
+      return SimdT2<T2, N2>(convert_scalar<T2>(LHS)) CMPOP RHS;                \
   }
 
 // Equality comparison is defined for all simd_obj_impl subclasses.
-__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(==, true)
-__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(!=, true)
+__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(==, CmpOp::eq, true)
+__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(!=, CmpOp::ne, true)
 
 // Relational operators are defined only for the simd type.
-__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(<, __SEIEED::is_simd_type_v<SimdTx>)
-__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(>, __SEIEED::is_simd_type_v<SimdTx>)
-__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(<=, __SEIEED::is_simd_type_v<SimdTx>)
-__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(>=, __SEIEED::is_simd_type_v<SimdTx>)
+__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(<, CmpOp::lt, __SEIEED::is_simd_type_v<SimdTx>)
+__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(>, CmpOp::gt, __SEIEED::is_simd_type_v<SimdTx>)
+__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(<=, CmpOp::lte,
+                                 __SEIEED::is_simd_type_v<SimdTx>)
+__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(>=, CmpOp::gte,
+                                 __SEIEED::is_simd_type_v<SimdTx>)
 
 // Logical operators are defined only for the simd_mask type
-__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(&&, __SEIEED::is_simd_mask_type_v<SimdTx>)
-__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(||, __SEIEED::is_simd_mask_type_v<SimdTx>)
+__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(&&, BinOp::log_and,
+                                 __SEIEED::is_simd_mask_type_v<SimdTx>)
+__ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP(||, BinOp::log_or,
+                                 __SEIEED::is_simd_mask_type_v<SimdTx>)
 
 #undef __ESIMD_DEF_SIMD_OBJ_IMPL_CMP_OP
 } // namespace __SEIEED
 
-namespace __SEIEE {
+namespace __SEIEED {
 ////////////////////////////////////////////////////////////////////////////////
 // simd_view global operators
 ////////////////////////////////////////////////////////////////////////////////
@@ -320,8 +364,8 @@ __ESIMD_DEF_SIMD_VIEW_BIN_OP(>>, __ESIMD_SHIFT_OP_FILTER)
 #undef __ESIMD_SHIFT_OP_FILTER
 
 #define __ESIMD_ARITH_OP_FILTER                                                \
-  __SEIEED::is_simd_type_v<SimdT1> &&__SEIEED::is_vectorizable_v<T1>           \
-      &&__SEIEED::is_vectorizable_v<T2>
+  __SEIEED::is_simd_type_v<SimdT1> &&__SEIEED::is_valid_simd_elem_type_v<T1>   \
+      &&__SEIEED::is_valid_simd_elem_type_v<T2>
 
 __ESIMD_DEF_SIMD_VIEW_BIN_OP(+, __ESIMD_ARITH_OP_FILTER)
 __ESIMD_DEF_SIMD_VIEW_BIN_OP(-, __ESIMD_ARITH_OP_FILTER)
@@ -364,32 +408,33 @@ __ESIMD_DEF_SIMD_VIEW_BIN_OP(||, __SEIEED::is_simd_mask_type_v<SimdT1>)
   }                                                                            \
                                                                                \
   /* simd_view CMPOP simd_obj_impl */                                          \
-  template <class SimdT1, class RegionT1, class T2, int N2, class SimdT2,      \
+  template <class SimdT1, class RegionT1, class RawT2, int N2, class SimdT2,   \
             class = std::enable_if_t<                                          \
                 (__SEIEE::shape_type<RegionT1>::length == N2) &&               \
                 (__SEIEED::is_simd_type_v<SimdT1> ==                           \
                  __SEIEED::is_simd_type_v<SimdT2>)&&COND>>                     \
   inline __SEIEE::simd_mask<N2> operator CMPOP(                                \
       const __SEIEE::simd_view<SimdT1, RegionT1> &LHS,                         \
-      const __SEIEED::simd_obj_impl<T2, N2, SimdT2> &RHS) {                    \
+      const __SEIEED::simd_obj_impl<RawT2, N2, SimdT2> &RHS) {                 \
     return LHS.read() CMPOP SimdT2(RHS.data());                                \
   }                                                                            \
                                                                                \
   /* simd_obj_impl CMPOP simd_view */                                          \
-  template <class T1, int N1, class SimdT1, class SimdT2, class RegionT2,      \
+  template <class RawT1, int N1, class SimdT1, class SimdT2, class RegionT2,   \
             class = std::enable_if_t<                                          \
                 (__SEIEE::shape_type<RegionT2>::length == N1) &&               \
                 (__SEIEED::is_simd_type_v<SimdT1> ==                           \
                  __SEIEED::is_simd_type_v<SimdT2>)&&COND>>                     \
   inline __SEIEE::simd_mask<N1> operator CMPOP(                                \
-      const __SEIEED::simd_obj_impl<T1, N1, SimdT1> &LHS,                      \
+      const __SEIEED::simd_obj_impl<RawT1, N1, SimdT1> &LHS,                   \
       const __SEIEE::simd_view<SimdT2, RegionT2> &RHS) {                       \
     return SimdT1(LHS.data()) CMPOP RHS.read();                                \
   }                                                                            \
                                                                                \
   /* simd_view CMPOP SCALAR */                                                 \
   template <class SimdT1, class RegionT1, class T2,                            \
-            class = std::enable_if_t<__SEIEED::is_vectorizable_v<T2> && COND>> \
+            class = std::enable_if_t<                                          \
+                __SEIEED::is_valid_simd_elem_type_v<T2> && COND>>              \
   inline auto operator CMPOP(const __SEIEE::simd_view<SimdT1, RegionT1> &LHS,  \
                              T2 RHS) {                                         \
     return LHS.read() CMPOP RHS;                                               \
@@ -397,7 +442,8 @@ __ESIMD_DEF_SIMD_VIEW_BIN_OP(||, __SEIEED::is_simd_mask_type_v<SimdT1>)
                                                                                \
   /* SCALAR CMPOP simd_view */                                                 \
   template <class T1, class SimdT2, class RegionT2, class SimdT1 = SimdT2,     \
-            class = std::enable_if_t<__SEIEED::is_vectorizable_v<T1> && COND>> \
+            class = std::enable_if_t<                                          \
+                __SEIEED::is_valid_simd_elem_type_v<T1> && COND>>              \
   inline auto operator CMPOP(                                                  \
       T1 LHS, const __SEIEE::simd_view<SimdT2, RegionT2> &RHS) {               \
     return LHS CMPOP RHS.read();                                               \
@@ -415,4 +461,4 @@ __ESIMD_DEF_SIMD_VIEW_CMP_OP(>=, __SEIEED::is_simd_type_v<SimdT1>)
 
 #undef __ESIMD_DEF_SIMD_VIEW_CMP_OP
 
-} // namespace __SEIEE
+} // namespace __SEIEED

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
@@ -57,7 +57,7 @@ public:
 
   /// Construct from an array. To allow e.g. simd_mask<N> m({1,0,0,1,...}).
   template <int N1, class = std::enable_if_t<N1 == N>>
-  simd_mask_impl(const raw_element_type(&&Arr)[N1]) {
+  simd_mask_impl(const raw_element_type (&&Arr)[N1]) {
     base_type::template init_from_array<N1>(std::move(Arr));
   }
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
@@ -35,6 +35,7 @@ class simd_mask_impl
 
 public:
   using element_type = T;
+  using user_element_type = T;
   using vector_type = typename base_type::vector_type;
   static_assert(std::is_same_v<vector_type, simd_mask_storage_t<N>> &&
                 "mask impl type mismatch");

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
@@ -34,10 +34,10 @@ class simd_mask_impl
   using base_type = detail::simd_obj_impl<T, N, simd_mask_impl<T, N>>;
 
 public:
+  using raw_element_type = T;
   using element_type = T;
-  using user_element_type = T;
-  using vector_type = typename base_type::vector_type;
-  static_assert(std::is_same_v<vector_type, simd_mask_storage_t<N>> &&
+  using raw_vector_type = typename base_type::raw_vector_type;
+  static_assert(std::is_same_v<raw_vector_type, simd_mask_storage_t<N>> &&
                 "mask impl type mismatch");
 
   simd_mask_impl() = default;
@@ -49,7 +49,7 @@ public:
 
   /// Implicit conversion constructor from a raw vector object.
   // TODO this should be made inaccessible from user code.
-  simd_mask_impl(const vector_type &Val) : base_type(Val) {}
+  simd_mask_impl(const raw_vector_type &Val) : base_type(Val) {}
 
   /// Initializer list constructor.
   __SYCL_DEPRECATED("use constructor from array, e.g: simd_mask<3> x({0,1,1});")
@@ -57,7 +57,7 @@ public:
 
   /// Construct from an array. To allow e.g. simd_mask<N> m({1,0,0,1,...}).
   template <int N1, class = std::enable_if_t<N1 == N>>
-  simd_mask_impl(const element_type(&&Arr)[N1]) {
+  simd_mask_impl(const raw_element_type(&&Arr)[N1]) {
     base_type::template init_from_array<N1>(std::move(Arr));
   }
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
@@ -315,9 +315,8 @@ public:
                                       is_simd_type_v<BaseTy>)&&(length ==
                                                                 SimdT::length)>>
   Derived &operator=(const simd_obj_impl<T, N, SimdT> &Other) {
-    return write(
-        convert_vector<element_type, typename SimdT::element_type, N>(
-            Other.data()));
+    return write(convert_vector<element_type, typename SimdT::element_type, N>(
+        Other.data()));
   }
 
   template <class T1, class = std::enable_if_t<is_valid_simd_elem_type_v<T1>>>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/type_format.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/type_format.hpp
@@ -29,10 +29,6 @@ template <typename Ty, int N, typename EltTy,
 struct compute_format_type<SimdT<Ty, N>, EltTy>
     : compute_format_type_impl<Ty, N, EltTy> {};
 
-template <typename Ty, int N, typename EltTy, class SimdT>
-struct compute_format_type<simd_obj_impl<Ty, N, SimdT>, EltTy>
-    : compute_format_type_impl<Ty, N, EltTy> {};
-
 template <typename BaseTy, typename RegionTy, typename EltTy>
 struct compute_format_type<simd_view<BaseTy, RegionTy>, EltTy> {
   using ShapeTy = typename shape_type<RegionTy>::type;
@@ -63,11 +59,6 @@ struct compute_format_type_2d_impl {
 template <typename Ty, int N, typename EltTy, int Height, int Width,
           template <typename, int> class SimdT>
 struct compute_format_type_2d<SimdT<Ty, N>, EltTy, Height, Width>
-    : compute_format_type_2d_impl<Ty, N, EltTy, Height, Width> {};
-
-template <typename Ty, int N, typename EltTy, int Height, int Width,
-          class SimdT>
-struct compute_format_type_2d<simd_obj_impl<Ty, N, SimdT>, EltTy, Height, Width>
     : compute_format_type_2d_impl<Ty, N, EltTy, Height, Width> {};
 
 template <typename BaseTy, typename RegionTy, typename EltTy, int Height,

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/type_format.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/type_format.hpp
@@ -1,0 +1,103 @@
+//==-------------- types.hpp - DPC++ Explicit SIMD API ---------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Meta-functions to compute compile-time element type of a simd_view resulting
+// from format operations.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/ext/intel/experimental/esimd/detail/types.hpp>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
+namespace detail {
+
+template <typename BaseTy, typename EltTy> struct compute_format_type;
+
+template <typename Ty, int N, typename EltTy> struct compute_format_type_impl {
+  static constexpr int Size = sizeof(Ty) * N / sizeof(EltTy);
+  static constexpr int Stride = 1;
+  using type = region1d_t<EltTy, Size, Stride>;
+};
+
+template <typename Ty, int N, typename EltTy,
+          template <typename, int> class SimdT>
+struct compute_format_type<SimdT<Ty, N>, EltTy>
+    : compute_format_type_impl<Ty, N, EltTy> {};
+
+template <typename Ty, int N, typename EltTy, class SimdT>
+struct compute_format_type<simd_obj_impl<Ty, N, SimdT>, EltTy>
+    : compute_format_type_impl<Ty, N, EltTy> {};
+
+template <typename BaseTy, typename RegionTy, typename EltTy>
+struct compute_format_type<simd_view<BaseTy, RegionTy>, EltTy> {
+  using ShapeTy = typename shape_type<RegionTy>::type;
+  static constexpr int Size = ShapeTy::Size_in_bytes / sizeof(EltTy);
+  static constexpr int Stride = 1;
+  using type = region1d_t<EltTy, Size, Stride>;
+};
+
+template <typename Ty, typename EltTy>
+using compute_format_type_t = typename compute_format_type<Ty, EltTy>::type;
+
+// Compute the simd_view type of a 2D format operation.
+template <typename BaseTy, typename EltTy, int Height, int Width>
+struct compute_format_type_2d;
+
+template <typename Ty, int N, typename EltTy, int Height, int Width>
+struct compute_format_type_2d_impl {
+  static constexpr int Prod = sizeof(Ty) * N / sizeof(EltTy);
+  static_assert(Prod == Width * Height, "size mismatch");
+
+  static constexpr int SizeX = Width;
+  static constexpr int StrideX = 1;
+  static constexpr int SizeY = Height;
+  static constexpr int StrideY = 1;
+  using type = region2d_t<EltTy, SizeY, StrideY, SizeX, StrideX>;
+};
+
+template <typename Ty, int N, typename EltTy, int Height, int Width,
+          template <typename, int> class SimdT>
+struct compute_format_type_2d<SimdT<Ty, N>, EltTy, Height, Width>
+    : compute_format_type_2d_impl<Ty, N, EltTy, Height, Width> {};
+
+template <typename Ty, int N, typename EltTy, int Height, int Width,
+          class SimdT>
+struct compute_format_type_2d<simd_obj_impl<Ty, N, SimdT>, EltTy, Height, Width>
+    : compute_format_type_2d_impl<Ty, N, EltTy, Height, Width> {};
+
+template <typename BaseTy, typename RegionTy, typename EltTy, int Height,
+          int Width>
+struct compute_format_type_2d<simd_view<BaseTy, RegionTy>, EltTy, Height,
+                              Width> {
+  using ShapeTy = typename shape_type<RegionTy>::type;
+  static constexpr int Prod = ShapeTy::Size_in_bytes / sizeof(EltTy);
+  static_assert(Prod == Width * Height, "size mismatch");
+
+  static constexpr int SizeX = Width;
+  static constexpr int StrideX = 1;
+  static constexpr int SizeY = Height;
+  static constexpr int StrideY = 1;
+  using type = region2d_t<EltTy, SizeY, StrideY, SizeX, StrideX>;
+};
+
+template <typename Ty, typename EltTy, int Height, int Width>
+using compute_format_type_2d_t =
+    typename compute_format_type_2d<Ty, EltTy, Height, Width>::type;
+
+} // namespace detail
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/type_format.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/type_format.hpp
@@ -14,12 +14,7 @@
 #include <sycl/ext/intel/experimental/esimd/detail/types.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
-namespace sycl {
-namespace ext {
-namespace intel {
-namespace experimental {
-namespace esimd {
-namespace detail {
+namespace __SEIEED {
 
 template <typename BaseTy, typename EltTy> struct compute_format_type;
 
@@ -94,10 +89,5 @@ template <typename Ty, typename EltTy, int Height, int Width>
 using compute_format_type_2d_t =
     typename compute_format_type_2d<Ty, EltTy, Height, Width>::type;
 
-} // namespace detail
-} // namespace esimd
-} // namespace experimental
-} // namespace intel
-} // namespace ext
-} // namespace sycl
+} // namespace __SEIEED
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
@@ -43,6 +43,13 @@ namespace detail {
 
 namespace csd = cl::sycl::detail;
 
+template <int N> using uint_type_t =
+  std::conditional_t<N == 1, uint8_t,
+  std::conditional_t<N == 2, uint16_t,
+  std::conditional_t<N == 4, uint32_t,
+  std::conditional_t<N == 8, uint64_t, void>>>>;
+
+
 // forward declarations of major internal simd classes
 template <typename Ty, int N> class simd_mask_impl;
 template <typename ElT, int N, class Derived, class SFINAE = void>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
@@ -310,6 +310,26 @@ struct element_type<T, std::enable_if_t<is_clang_vector_type_v<T>>> {
 };
 
 template <typename T> using element_type_t = typename element_type<T>::type;
+
+// Determine element type of simd_obj_impl's Derived type w/o having to have
+// complete instantiation of the Derived type (is required by element_type_t,
+// hence can't be used here).
+template <class T> struct simd_like_obj_info;
+template <class T, int N> struct simd_like_obj_info<simd<T, N>> {
+  using type = T;
+  static inline constexpr int length = N;
+};
+template <class T, int N> struct simd_like_obj_info<simd_mask_impl<T, N>> {
+  using type = simd_mask_elem_type; // equals T
+  static inline constexpr int length = N;
+};
+
+template <typename T>
+using simd_like_obj_element_type_t = typename simd_like_obj_info<T>::type;
+template <typename T>
+static inline constexpr int simd_like_obj_length =
+    simd_like_obj_info<T>::length;
+
 // @}
 
 template <typename To, typename From>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
@@ -43,12 +43,13 @@ namespace detail {
 
 namespace csd = cl::sycl::detail;
 
-template <int N> using uint_type_t =
-  std::conditional_t<N == 1, uint8_t,
-  std::conditional_t<N == 2, uint16_t,
-  std::conditional_t<N == 4, uint32_t,
-  std::conditional_t<N == 8, uint64_t, void>>>>;
-
+template <int N>
+using uint_type_t = std::conditional_t<
+    N == 1, uint8_t,
+    std::conditional_t<
+        N == 2, uint16_t,
+        std::conditional_t<N == 4, uint32_t,
+                           std::conditional_t<N == 8, uint64_t, void>>>>;
 
 // forward declarations of major internal simd classes
 template <typename Ty, int N> class simd_mask_impl;
@@ -332,11 +333,6 @@ std::enable_if_t<is_clang_vector_type_v<To> && is_clang_vector_type_v<From>, To>
     return __builtin_convertvector(Val, To);
   }
 }
-
-// template <typename To, typename From, int N>
-// vector_type_t<To, N> convert(vector_type_t<From, N> Val) {
-//   return convert<vector_type_t<To, N>>(Val);
-// }
 
 /// Base case for checking if a type U is one of the types.
 template <typename U> constexpr bool is_type() { return false; }

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/types.hpp
@@ -149,17 +149,15 @@ struct is_simd_obj_impl_derivative<simd_obj_impl<RawT, N, Derived>>
     : public std::true_type {};
 
 template <class T, class SFINAE = void> struct element_type_traits;
-template <class T> using __raw_t = typename __SEIEED::element_type_traits<T>::RawT;
-
+template <class T>
+using __raw_t = typename __SEIEED::element_type_traits<T>::RawT;
 
 // Specialization for all other types.
 template <typename T, int N, template <typename, int> class Derived>
 struct is_simd_obj_impl_derivative<Derived<T, N>>
     : public std::conditional_t<
-          std::is_base_of_v<
-              simd_obj_impl<__raw_t<T>, N,
+          std::is_base_of_v<simd_obj_impl<__raw_t<T>, N, Derived<T, N>>,
                             Derived<T, N>>,
-              Derived<T, N>>,
           std::true_type, std::false_type> {};
 
 // Convenience shortcut.
@@ -173,15 +171,14 @@ inline constexpr bool is_simd_obj_impl_derivative_v =
 template <class SimdT, int Ndst> struct resize_a_simd_type;
 
 // Specialization for the simd_obj_impl type.
-template <typename T, int Nsrc, int Ndst,
-          template <typename, int> class SimdT>
-struct resize_a_simd_type<simd_obj_impl<__raw_t<T>, Nsrc, SimdT<T, Nsrc>>, Ndst> {
+template <typename T, int Nsrc, int Ndst, template <typename, int> class SimdT>
+struct resize_a_simd_type<simd_obj_impl<__raw_t<T>, Nsrc, SimdT<T, Nsrc>>,
+                          Ndst> {
   using type = simd_obj_impl<__raw_t<T>, Ndst, SimdT<T, Ndst>>;
 };
 
 // Specialization for the simd_obj_impl type derivatives.
-template <typename T, int Nsrc, int Ndst,
-          template <typename, int> class SimdT>
+template <typename T, int Nsrc, int Ndst, template <typename, int> class SimdT>
 struct resize_a_simd_type<SimdT<T, Nsrc>, Ndst> {
   using type = SimdT<T, Ndst>;
 };
@@ -199,8 +196,8 @@ template <class SimdT, typename NewElemT> struct convert_simd_elem_type;
 // Specialization for the simd_obj_impl type.
 template <typename OldElemT, int N, typename NewElemT,
           template <typename, int> class SimdT>
-struct convert_simd_elem_type<simd_obj_impl<__raw_t<OldElemT>, N, SimdT<OldElemT, N>>,
-                              NewElemT> {
+struct convert_simd_elem_type<
+    simd_obj_impl<__raw_t<OldElemT>, N, SimdT<OldElemT, N>>, NewElemT> {
   using type = simd_obj_impl<__raw_t<NewElemT>, N, SimdT<NewElemT, N>>;
 };
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/util.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/util.hpp
@@ -15,10 +15,6 @@
 
 #include <type_traits>
 
-#define __SEIEED sycl::ext::intel::experimental::esimd::detail
-#define __SEIEE sycl::ext::intel::experimental::esimd
-#define __SEIEEED sycl::ext::intel::experimental::esimd::emu::detail
-
 #ifdef __SYCL_DEVICE_ONLY__
 #define __ESIMD_INTRIN SYCL_EXTERNAL SYCL_ESIMD_FUNCTION
 #else
@@ -91,10 +87,6 @@ template <typename T> struct is_esimd_vector : public std::false_type {};
 
 template <typename T, int N>
 struct is_esimd_vector<simd<T, N>> : public std::true_type {};
-
-template <typename T>
-using is_esimd_scalar =
-    typename std::bool_constant<cl::sycl::detail::is_arithmetic<T>::value>;
 
 template <typename T, int N>
 using is_hw_int_type =

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/util.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/util.hpp
@@ -111,7 +111,7 @@ using is_fp_or_dword_type =
 
 /// Convert types into vector types
 template <typename T> struct simd_type { using type = simd<T, 1>; };
-template <typename T, int N> struct simd_type<vector_type<T, N>> {
+template <typename T, int N> struct simd_type<raw_vector_type<T, N>> {
   using type = simd<T, N>;
 };
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -301,8 +301,7 @@ __ESIMD_API simd<Tx, n> block_load(AccessorTy acc, uint32_t offset,
 /// \ingroup sycl_esimd
 // TODO the above note about cache hints applies to this API as well.
 template <typename Tx, int n, CacheHint L1H = CacheHint::None,
-          CacheHint L3H = CacheHint::None,
-          class T = detail::__raw_t<Tx>>
+          CacheHint L3H = CacheHint::None, class T = detail::__raw_t<Tx>>
 __ESIMD_API void block_store(Tx *p, simd<Tx, n> vals) {
   detail::IfNotNone<L1H, L3H>::warn();
   constexpr unsigned Sz = sizeof(T) * n;
@@ -719,8 +718,7 @@ constexpr bool check_atomic() {
 
 /// USM address atomic update, version with no source operands: \c inc and \c
 /// dec. \ingroup sycl_esimd
-template <atomic_op Op, typename Tx, int n,
-          class T = detail::__raw_t<Tx>>
+template <atomic_op Op, typename Tx, int n, class T = detail::__raw_t<Tx>>
 __ESIMD_API std::enable_if_t<detail::check_atomic<Op, Tx, n, 0>(), simd<Tx, n>>
 atomic_update(Tx *p, simd<unsigned, n> offset, simd_mask<n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
@@ -742,8 +740,7 @@ __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 0>(),
 
 /// USM address atomic update, version with one source operand: e.g. \c add, \c
 /// sub. \ingroup sycl_esimd
-template <atomic_op Op, typename Tx, int n,
-          class T = detail::__raw_t<Tx>>
+template <atomic_op Op, typename Tx, int n, class T = detail::__raw_t<Tx>>
 __ESIMD_API std::enable_if_t<detail::check_atomic<Op, Tx, n, 1>(), simd<Tx, n>>
 atomic_update(Tx *p, simd<unsigned, n> offset, simd<Tx, n> src0,
               simd_mask<n> pred) {
@@ -767,8 +764,7 @@ __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 1>(),
 
 /// USM address atomic update, version with two source operands: e.g. \c
 /// cmpxchg. \ingroup sycl_esimd
-template <atomic_op Op, typename Tx, int n,
-          class T = detail::__raw_t<Tx>>
+template <atomic_op Op, typename Tx, int n, class T = detail::__raw_t<Tx>>
 __ESIMD_API std::enable_if_t<detail::check_atomic<Op, Tx, n, 2>(), simd<Tx, n>>
 atomic_update(Tx *p, simd<unsigned, n> offset, simd<Tx, n> src0,
               simd<Tx, n> src1, simd_mask<n> pred) {
@@ -1012,13 +1008,11 @@ __ESIMD_API void slm_block_store(uint32_t offset, simd<T, n> vals) {
                 "block size must be at most 8 owords");
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
   // offset in genx.oword.st is in owords
-  __esimd_oword_st<detail::__raw_t<T>, n>(si, offset >> 4,
-                                                    vals.data());
+  __esimd_oword_st<detail::__raw_t<T>, n>(si, offset >> 4, vals.data());
 }
 
 /// SLM atomic update operation, no source operands: \c inc and \c dec.
-template <atomic_op Op, typename Tx, int n,
-          class T = detail::__raw_t<Tx>>
+template <atomic_op Op, typename Tx, int n, class T = detail::__raw_t<Tx>>
 __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 0>(), simd<Tx, n>>
 slm_atomic_update(simd<uint32_t, n> offsets, simd_mask<n> pred) {
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
@@ -1034,8 +1028,7 @@ __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 0>(),
 }
 
 /// SLM atomic update operation, one source operand: e.g. \c add, \c sub.
-template <atomic_op Op, typename Tx, int n,
-          class T = detail::__raw_t<Tx>>
+template <atomic_op Op, typename Tx, int n, class T = detail::__raw_t<Tx>>
 __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 1>(), simd<Tx, n>>
 slm_atomic_update(simd<uint32_t, n> offsets, simd<Tx, n> src0,
                   simd_mask<n> pred) {
@@ -1054,8 +1047,7 @@ __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 1>(),
 }
 
 /// SLM atomic, two source operands.
-template <atomic_op Op, typename Tx, int n,
-          class T = detail::__raw_t<Tx>>
+template <atomic_op Op, typename Tx, int n, class T = detail::__raw_t<Tx>>
 __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 2>(), simd<Tx, n>>
 slm_atomic_update(simd<uint32_t, n> offsets, simd<Tx, n> src0, simd<Tx, n> src1,
                   simd_mask<n> pred) {

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -137,13 +137,14 @@ __ESIMD_API SurfaceIndex get_surface_index(AccessorTy acc) {
 //
 /// Flat-address gather.
 /// \ingroup sycl_esimd
-template <typename T, int n, int ElemsPerAddr = 1,
-          CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None>
+template <typename Tx, int n, int ElemsPerAddr = 1,
+          CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None,
+          class T = detail::element_storage_t<Tx>>
 __ESIMD_API std::enable_if_t<((n == 8 || n == 16 || n == 32) &&
                               (ElemsPerAddr == 1 || ElemsPerAddr == 2 ||
                                ElemsPerAddr == 4)),
-                             simd<T, n * ElemsPerAddr>>
-gather(const T *p, simd<uint32_t, n> offsets, simd_mask<n> pred = 1) {
+                             simd<Tx, n * ElemsPerAddr>>
+gather(const Tx *p, simd<uint32_t, n> offsets, simd_mask<n> pred = 1) {
   detail::IfNotNone<L1H, L3H>::warn();
   simd<uint64_t, n> offsets_i = convert<uint64_t>(offsets);
   simd<uint64_t, n> addrs(reinterpret_cast<uint64_t>(p));
@@ -177,11 +178,12 @@ gather(const T *p, simd<uint32_t, n> offsets, simd_mask<n> pred = 1) {
 
 /// Flat-address scatter.
 /// \ingroup sycl_esimd
-template <typename T, int n, int ElemsPerAddr = 1>
+template <typename Tx, int n, int ElemsPerAddr = 1,
+          class T = detail::element_storage_t<Tx>>
 __ESIMD_API std::enable_if_t<((n == 8 || n == 16 || n == 32) &&
                               (ElemsPerAddr == 1 || ElemsPerAddr == 2 ||
                                ElemsPerAddr == 4))>
-scatter(T *p, simd<uint32_t, n> offsets, simd<T, n * ElemsPerAddr> vals,
+scatter(Tx *p, simd<uint32_t, n> offsets, simd<Tx, n * ElemsPerAddr> vals,
         simd_mask<n> pred = 1) {
   simd<uint64_t, n> offsets_i = convert<uint64_t>(offsets);
   simd<uint64_t, n> addrs(reinterpret_cast<uint64_t>(p));
@@ -231,10 +233,11 @@ __ESIMD_API std::enable_if_t<((n == 8 || n == 16 || n == 32) &&
 
 /// Flat-address block-load.
 /// \ingroup sycl_esimd
-template <typename T, int n, typename Flags = vector_aligned_tag,
+template <typename Tx, int n, typename Flags = vector_aligned_tag,
           CacheHint L1H = CacheHint::None, CacheHint L3H = CacheHint::None,
+          class T = detail::element_storage_t<Tx>,
           typename = std::enable_if_t<is_simd_flag_type_v<Flags>>>
-__ESIMD_API simd<T, n> block_load(const T *addr, Flags = {}) {
+__ESIMD_API simd<Tx, n> block_load(const Tx *addr, Flags = {}) {
   detail::IfNotNone<L1H, L3H>::warn();
   constexpr unsigned Sz = sizeof(T) * n;
   static_assert(Sz >= detail::OperandSize::OWORD,
@@ -257,10 +260,12 @@ __ESIMD_API simd<T, n> block_load(const T *addr, Flags = {}) {
 
 /// Accessor-based block-load.
 /// \ingroup sycl_esimd
-template <typename T, int n, typename AccessorTy,
+template <typename Tx, int n, typename AccessorTy,
           typename Flags = vector_aligned_tag,
-          typename = std::enable_if_t<is_simd_flag_type_v<Flags>>>
-__ESIMD_API simd<T, n> block_load(AccessorTy acc, uint32_t offset, Flags = {}) {
+          typename = std::enable_if_t<is_simd_flag_type_v<Flags>>,
+          class T = detail::element_storage_t<Tx>>
+__ESIMD_API simd<Tx, n> block_load(AccessorTy acc, uint32_t offset,
+                                   Flags = {}) {
   constexpr unsigned Sz = sizeof(T) * n;
   static_assert(Sz >= detail::OperandSize::OWORD,
                 "block size must be at least 1 oword");
@@ -295,9 +300,10 @@ __ESIMD_API simd<T, n> block_load(AccessorTy acc, uint32_t offset, Flags = {}) {
 /// Flat-address block-store.
 /// \ingroup sycl_esimd
 // TODO the above note about cache hints applies to this API as well.
-template <typename T, int n, CacheHint L1H = CacheHint::None,
-          CacheHint L3H = CacheHint::None>
-__ESIMD_API void block_store(T *p, simd<T, n> vals) {
+template <typename Tx, int n, CacheHint L1H = CacheHint::None,
+          CacheHint L3H = CacheHint::None,
+          class T = detail::element_storage_t<Tx>>
+__ESIMD_API void block_store(Tx *p, simd<Tx, n> vals) {
   detail::IfNotNone<L1H, L3H>::warn();
   constexpr unsigned Sz = sizeof(T) * n;
   static_assert(Sz >= detail::OperandSize::OWORD,
@@ -315,8 +321,10 @@ __ESIMD_API void block_store(T *p, simd<T, n> vals) {
 
 /// Accessor-based block-store.
 /// \ingroup sycl_esimd
-template <typename T, int n, typename AccessorTy>
-__ESIMD_API void block_store(AccessorTy acc, uint32_t offset, simd<T, n> vals) {
+template <typename Tx, int n, typename AccessorTy,
+          class T = detail::element_storage_t<Tx>>
+__ESIMD_API void block_store(AccessorTy acc, uint32_t offset,
+                             simd<Tx, n> vals) {
   constexpr unsigned Sz = sizeof(T) * n;
   static_assert(Sz >= detail::OperandSize::OWORD,
                 "block size must be at least 1 oword");
@@ -350,14 +358,18 @@ ESIMD_INLINE
   // TODO (performance) use hardware-supported scale once BE supports it
   constexpr int16_t scale = 0;
   const auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  constexpr bool IsHalfT = std::is_same_v<T, sycl::half>;
 
   if constexpr (sizeof(T) < 4) {
-    static_assert(std::is_integral<T>::value,
+    using Tint = std::conditional_t<IsHalfT, uint16_t, T>;
+    static_assert(std::is_integral_v<Tint>,
                   "only integral 1- & 2-byte types are supported");
+    using Treal = element_storage_t<T>;
+    simd<Tint, N> vals_int = bitcast<Tint, Treal, N>(std::move(vals).data());
     using PromoT =
-        typename sycl::detail::conditional_t<std::is_signed<T>::value, int32_t,
-                                             uint32_t>;
-    const simd<PromoT, N> promo_vals = convert<PromoT>(vals);
+        typename sycl::detail::conditional_t<std::is_signed<Tint>::value,
+                                             int32_t, uint32_t>;
+    const simd<PromoT, N> promo_vals = convert<PromoT>(std::move(vals_int));
     __esimd_scatter_scaled<PromoT, N, decltype(si), TypeSizeLog2, scale>(
         pred.data(), si, glob_offset, offsets.data(), promo_vals.data());
   } else {
@@ -378,18 +390,26 @@ gather_impl(AccessorTy acc, simd<uint32_t, N> offsets, uint32_t glob_offset,
   // TODO (performance) use hardware-supported scale once BE supports it
   constexpr uint32_t scale = 0;
   const auto si = get_surface_index(acc);
+  constexpr bool IsHalfT = std::is_same_v<T, sycl::half>;
 
   if constexpr (sizeof(T) < 4) {
-    static_assert(std::is_integral<T>::value,
+    using Tint = std::conditional_t<IsHalfT, uint16_t, T>;
+    static_assert(std::is_integral<Tint>::value,
                   "only integral 1- & 2-byte types are supported");
     using PromoT =
-        typename sycl::detail::conditional_t<std::is_signed<T>::value, int32_t,
-                                             uint32_t>;
+        typename sycl::detail::conditional_t<std::is_signed<Tint>::value,
+                                             int32_t, uint32_t>;
     const simd<PromoT, N> promo_vals =
         __esimd_gather_masked_scaled2<PromoT, N, decltype(si), TypeSizeLog2,
                                       scale>(si, glob_offset, offsets.data(),
                                              pred.data());
-    return convert<T>(promo_vals);
+    auto Res = convert<Tint>(promo_vals);
+
+    if constexpr (IsHalfT) {
+      return detail::bitcast<detail::half, uint16_t, N>(Res.data());
+    } else {
+      return Res;
+    }
   } else {
     return __esimd_gather_masked_scaled2<T, N, decltype(si), TypeSizeLog2,
                                          scale>(si, glob_offset, offsets.data(),
@@ -537,10 +557,11 @@ __ESIMD_API void scalar_store1(AccessorTy acc, uint32_t offset, T val) {
 /// @param offsets byte-offsets within the \p buffer to be gathered.
 /// @param pred predication control used for masking lanes.
 /// \ingroup sycl_esimd
-template <typename T, int N, rgba_channel_mask Mask>
+template <typename Tx, int N, rgba_channel_mask Mask,
+          class T = detail::element_storage_t<Tx>>
 __ESIMD_API std::enable_if_t<(N == 16 || N == 32) && (sizeof(T) == 4),
-                             simd<T, N * get_num_channels_enabled(Mask)>>
-gather_rgba(const T *p, simd<uint32_t, N> offsets, simd_mask<N> pred = 1) {
+                             simd<Tx, N * get_num_channels_enabled(Mask)>>
+gather_rgba(const Tx *p, simd<uint32_t, N> offsets, simd_mask<N> pred = 1) {
 
   simd<uint64_t, N> offsets_i = convert<uint64_t>(offsets);
   simd<uint64_t, N> addrs(reinterpret_cast<uint64_t>(p));
@@ -576,10 +597,11 @@ __ESIMD_API std::enable_if_t<
 /// @param offsets byte-offsets within the \p buffer to be written.
 /// @param pred predication control used for masking lanes.
 /// \ingroup sycl_esimd
-template <typename T, int N, rgba_channel_mask Mask>
+template <typename Tx, int N, rgba_channel_mask Mask,
+          class T = detail::element_storage_t<Tx>>
 __ESIMD_API std::enable_if_t<(N == 16 || N == 32) && (sizeof(T) == 4)>
-scatter_rgba(T *p, simd<uint32_t, N> offsets,
-             simd<T, N * get_num_channels_enabled(Mask)> vals,
+scatter_rgba(Tx *p, simd<uint32_t, N> offsets,
+             simd<Tx, N * get_num_channels_enabled(Mask)> vals,
              simd_mask<N> pred = 1) {
   simd<uint64_t, N> offsets_i = convert<uint64_t>(offsets);
   simd<uint64_t, N> addrs(reinterpret_cast<uint64_t>(p));
@@ -656,8 +678,8 @@ constexpr bool check_atomic() {
       static_assert(NumSrc == 1, "One source operand is expected");
       return false;
     }
-    if constexpr (!is_type<T, float, sycl::detail::half_impl::StorageT>()) {
-      static_assert((is_type<T, float, sycl::detail::half_impl::StorageT>()),
+    if constexpr (!is_type<T, float, detail::half>()) {
+      static_assert((is_type<T, float, detail::half>()),
                     "Type F or HF is expected");
       return false;
     }
@@ -677,8 +699,8 @@ constexpr bool check_atomic() {
       return false;
     }
     if constexpr (Op == atomic_op::fcmpwr &&
-                  !is_type<T, float, sycl::detail::half_impl::StorageT>()) {
-      static_assert((is_type<T, float, sycl::detail::half_impl::StorageT>()),
+                  !is_type<T, float, detail::half>()) {
+      static_assert((is_type<T, float, detail::half>()),
                     "Type F or HF is expected");
       return false;
     }
@@ -699,9 +721,10 @@ constexpr bool check_atomic() {
 
 /// USM address atomic update, version with no source operands: \c inc and \c
 /// dec. \ingroup sycl_esimd
-template <atomic_op Op, typename T, int n>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 0>(), simd<T, n>>
-atomic_update(T *p, simd<unsigned, n> offset, simd_mask<n> pred) {
+template <atomic_op Op, typename Tx, int n,
+          class T = detail::element_storage_t<Tx>>
+__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 0>(), simd<Tx, n>>
+atomic_update(Tx *p, simd<unsigned, n> offset, simd_mask<n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
   simd<uintptr_t, n> offset_i1 = convert<uintptr_t>(offset);
   vAddr += offset_i1;
@@ -721,9 +744,10 @@ __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 0>(),
 
 /// USM address atomic update, version with one source operand: e.g. \c add, \c
 /// sub. \ingroup sycl_esimd
-template <atomic_op Op, typename T, int n>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 1>(), simd<T, n>>
-atomic_update(T *p, simd<unsigned, n> offset, simd<T, n> src0,
+template <atomic_op Op, typename Tx, int n,
+          class T = detail::element_storage_t<Tx>>
+__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 1>(), simd<Tx, n>>
+atomic_update(Tx *p, simd<unsigned, n> offset, simd<Tx, n> src0,
               simd_mask<n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
   simd<uintptr_t, n> offset_i1 = convert<uintptr_t>(offset);
@@ -745,10 +769,11 @@ __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 1>(),
 
 /// USM address atomic update, version with two source operands: e.g. \c
 /// cmpxchg. \ingroup sycl_esimd
-template <atomic_op Op, typename T, int n>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 2>(), simd<T, n>>
-atomic_update(T *p, simd<unsigned, n> offset, simd<T, n> src0, simd<T, n> src1,
-              simd_mask<n> pred) {
+template <atomic_op Op, typename Tx, int n,
+          class T = detail::element_storage_t<Tx>>
+__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 2>(), simd<Tx, n>>
+atomic_update(Tx *p, simd<unsigned, n> offset, simd<Tx, n> src0,
+              simd<Tx, n> src1, simd_mask<n> pred) {
   simd<uintptr_t, n> vAddr(reinterpret_cast<uintptr_t>(p));
   simd<uintptr_t, n> offset_i1 = convert<uintptr_t>(offset);
   vAddr += offset_i1;
@@ -972,7 +997,7 @@ __ESIMD_API simd<T, n> slm_block_load(uint32_t offset) {
                 "block size must be at most 16 owords");
 
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
-  return __esimd_oword_ld<T, n>(si, offset >> 4);
+  return __esimd_oword_ld<detail::element_storage_t<T>, n>(si, offset >> 4);
 }
 
 /// SLM block-store.
@@ -987,15 +1012,16 @@ __ESIMD_API void slm_block_store(uint32_t offset, simd<T, n> vals) {
                 "block must be 1, 2, 4 or 8 owords long");
   static_assert(Sz <= 8 * detail::OperandSize::OWORD,
                 "block size must be at most 8 owords");
-
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
   // offset in genx.oword.st is in owords
-  __esimd_oword_st<T, n>(si, offset >> 4, vals.data());
+  __esimd_oword_st<detail::element_storage_t<T>, n>(si, offset >> 4,
+                                                    vals.data());
 }
 
 /// SLM atomic update operation, no source operands: \c inc and \c dec.
-template <atomic_op Op, typename T, int n>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 0>(), simd<T, n>>
+template <atomic_op Op, typename Tx, int n,
+          class T = detail::element_storage_t<Tx>>
+__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 0>(), simd<Tx, n>>
 slm_atomic_update(simd<uint32_t, n> offsets, simd_mask<n> pred) {
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
   return __esimd_dword_atomic0<Op, T, n>(pred.data(), si, offsets.data());
@@ -1010,9 +1036,10 @@ __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 0>(),
 }
 
 /// SLM atomic update operation, one source operand: e.g. \c add, \c sub.
-template <atomic_op Op, typename T, int n>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 1>(), simd<T, n>>
-slm_atomic_update(simd<uint32_t, n> offsets, simd<T, n> src0,
+template <atomic_op Op, typename Tx, int n,
+          class T = detail::element_storage_t<Tx>>
+__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 1>(), simd<Tx, n>>
+slm_atomic_update(simd<uint32_t, n> offsets, simd<Tx, n> src0,
                   simd_mask<n> pred) {
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
   return __esimd_dword_atomic1<Op, T, n>(pred.data(), si, offsets.data(),
@@ -1029,9 +1056,10 @@ __ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 1>(),
 }
 
 /// SLM atomic, two source operands.
-template <atomic_op Op, typename T, int n>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 2>(), simd<T, n>>
-slm_atomic_update(simd<uint32_t, n> offsets, simd<T, n> src0, simd<T, n> src1,
+template <atomic_op Op, typename Tx, int n,
+          class T = detail::element_storage_t<Tx>>
+__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, n, 2>(), simd<Tx, n>>
+slm_atomic_update(simd<uint32_t, n> offsets, simd<Tx, n> src0, simd<Tx, n> src1,
                   simd_mask<n> pred) {
   const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
   return __esimd_dword_atomic2<Op, T, n>(pred.data(), si, offsets.data(),

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
@@ -75,7 +75,7 @@ public:
                 (T::length == 1) && detail::is_valid_simd_elem_type_v<To>>>
   operator To() const {
     __esimd_dbg_print(operator To());
-    return convert_scalar<To, element_type>(base_type::data()[0]);
+    return detail::convert_scalar<To, element_type>(base_type::data()[0]);
   }
 
   /// @{

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
@@ -40,16 +40,16 @@ namespace esimd {
 /// \ingroup sycl_esimd
 template <typename Ty, int N>
 class simd : public detail::simd_obj_impl<
-                 detail::element_storage_t<Ty>, N, simd<Ty, N>,
+                 detail::__raw_t<Ty>, N, simd<Ty, N>,
                  std::enable_if_t<detail::is_valid_simd_elem_type_v<Ty>>> {
   using base_type =
-      detail::simd_obj_impl<detail::element_storage_t<Ty>, N, simd<Ty, N>>;
+      detail::simd_obj_impl<detail::__raw_t<Ty>, N, simd<Ty, N>>;
 
 public:
   using base_type::base_type;
-  using user_element_type = Ty;
-  using element_type = typename base_type::element_type;
-  using vector_type = typename base_type::vector_type;
+  using element_type = Ty;
+  using raw_element_type = typename base_type::raw_element_type;
+  using raw_vector_type = typename base_type::raw_vector_type;
   static constexpr int length = N;
 
   // Implicit conversion constructor from another simd object of the same
@@ -59,7 +59,7 @@ public:
                                      (length == SimdT::length)>>
   simd(const SimdT &RHS)
       : base_type(
-            detail::convert_vector<Ty, typename SimdT::user_element_type, N>(
+            detail::convert_vector<Ty, detail::element_type_t<SimdT>, N>(
                 RHS.data())) {
     __esimd_dbg_print(simd(const SimdT &RHS));
   }
@@ -74,11 +74,10 @@ public:
   /// Type conversion for simd<T, 1> into T.
   template <class To, class T = simd,
             class = sycl::detail::enable_if_t<
-                (T::length == 1) && (detail::is_vectorizable_v<To> ||
-                                     detail::is_wrapper_elem_type_v<To>)>>
+                (T::length == 1) && detail::is_valid_simd_elem_type_v<To>>>
   operator To() const {
     __esimd_dbg_print(operator To());
-    return (To)base_type::data()[0];
+    return convert_scalar<To, element_type>(base_type::data()[0]);
   }
 
   /// @{
@@ -106,15 +105,15 @@ public:
   }
   /// @}
 
-#define __ESIMD_DEF_SIMD_ARITH_UNARY_OP(ARITH_UNARY_OP)                        \
+#define __ESIMD_DEF_SIMD_ARITH_UNARY_OP(ARITH_UNARY_OP, ID)                    \
   template <class T1 = Ty> simd operator ARITH_UNARY_OP() const {              \
     static_assert(!std::is_unsigned_v<T1>,                                     \
                   #ARITH_UNARY_OP "doesn't apply to unsigned types");          \
-    return simd(ARITH_UNARY_OP(base_type::data()));                            \
+    return simd{detail::vector_unary_op<detail::UnaryOp::ID, T1, N>(base_type::data())};                            \
   }
 
-  __ESIMD_DEF_SIMD_ARITH_UNARY_OP(-)
-  __ESIMD_DEF_SIMD_ARITH_UNARY_OP(+)
+  __ESIMD_DEF_SIMD_ARITH_UNARY_OP(-, minus)
+  __ESIMD_DEF_SIMD_ARITH_UNARY_OP(+, plus)
 #undef __ESIMD_DEF_SIMD_ARITH_UNARY_OP
 };
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
@@ -42,8 +42,7 @@ template <typename Ty, int N>
 class simd : public detail::simd_obj_impl<
                  detail::__raw_t<Ty>, N, simd<Ty, N>,
                  std::enable_if_t<detail::is_valid_simd_elem_type_v<Ty>>> {
-  using base_type =
-      detail::simd_obj_impl<detail::__raw_t<Ty>, N, simd<Ty, N>>;
+  using base_type = detail::simd_obj_impl<detail::__raw_t<Ty>, N, simd<Ty, N>>;
 
 public:
   using base_type::base_type;
@@ -58,9 +57,8 @@ public:
             class = std::enable_if_t<__SEIEED::is_simd_type_v<SimdT> &&
                                      (length == SimdT::length)>>
   simd(const SimdT &RHS)
-      : base_type(
-            detail::convert_vector<Ty, detail::element_type_t<SimdT>, N>(
-                RHS.data())) {
+      : base_type(detail::convert_vector<Ty, detail::element_type_t<SimdT>, N>(
+            RHS.data())) {
     __esimd_dbg_print(simd(const SimdT &RHS));
   }
 
@@ -109,7 +107,8 @@ public:
   template <class T1 = Ty> simd operator ARITH_UNARY_OP() const {              \
     static_assert(!std::is_unsigned_v<T1>,                                     \
                   #ARITH_UNARY_OP "doesn't apply to unsigned types");          \
-    return simd{detail::vector_unary_op<detail::UnaryOp::ID, T1, N>(base_type::data())};                            \
+    return simd{detail::vector_unary_op<detail::UnaryOp::ID, T1, N>(           \
+        base_type::data())};                                                   \
   }
 
   __ESIMD_DEF_SIMD_ARITH_UNARY_OP(-, minus)

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
@@ -58,7 +58,9 @@ public:
             class = std::enable_if_t<__SEIEED::is_simd_type_v<SimdT> &&
                                      (length == SimdT::length)>>
   simd(const SimdT &RHS)
-      : base_type(__builtin_convertvector(RHS.data(), vector_type)) {
+      : base_type(
+            detail::convert_vector<Ty, typename SimdT::user_element_type, N>(
+                RHS.data())) {
     __esimd_dbg_print(simd(const SimdT &RHS));
   }
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd.hpp
@@ -71,7 +71,7 @@ public:
     __esimd_dbg_print(simd(T1 Val));
   }
 
-  /// Implicit conversion for simd<T, 1> into T.
+  /// Type conversion for simd<T, 1> into T.
   template <class To, class T = simd,
             class = sycl::detail::enable_if_t<
                 (T::length == 1) && (detail::is_vectorizable_v<To> ||

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
@@ -119,22 +119,22 @@ public:
 ///   bool b = v[0] > v[1] && v[2] < 42;
 ///
 /// \ingroup sycl_esimd
-template <typename BaseTy>
-class simd_view<BaseTy, region1d_scalar_t<typename BaseTy::element_type>>
-    : public detail::simd_view_impl<
-          BaseTy, region1d_scalar_t<typename BaseTy::element_type>> {
+template <typename BaseTy, class ViewedElemT>
+class simd_view<BaseTy, region1d_scalar_t<ViewedElemT>>
+    : public detail::simd_view_impl<BaseTy, region1d_scalar_t<ViewedElemT>> {
   template <typename, int, class, class> friend class detail::simd_obj_impl;
   template <typename, typename> friend class detail::simd_view_impl;
 
 public:
-  using RegionTy = region1d_scalar_t<typename BaseTy::element_type>;
+  using RegionTy = region1d_scalar_t<ViewedElemT>;
   using BaseClass = detail::simd_view_impl<BaseTy, RegionTy>;
   using ShapeTy = typename shape_type<RegionTy>::type;
   static constexpr int length = ShapeTy::Size_x * ShapeTy::Size_y;
   static_assert(1 == length, "length of this view is not equal to 1");
+  static_assert(std::is_same_v<typename ShapeTy::element_type, ViewedElemT>);
   /// The element type of this class, which could be different from the element
   /// type of the base object type.
-  using element_type = typename ShapeTy::element_type;
+  using element_type = ViewedElemT;
   using base_type = BaseTy;
   template <typename ElT, int N>
   using get_simd_t = typename BaseClass::template get_simd_t<ElT, N>;
@@ -174,26 +174,23 @@ public:
 ///   simd<int, 4> v = 1;
 ///   auto v1 = v.select<2, 1>(0);
 ///   auto v2 = v1[0]; // simd_view of a nested region for a single element
-template <typename BaseTy, typename NestedRegion>
-class simd_view<
-    BaseTy,
-    std::pair<region1d_scalar_t<typename BaseTy::element_type>, NestedRegion>>
+template <typename BaseTy, typename NestedRegion, class ViewedElemT>
+class simd_view<BaseTy, std::pair<region1d_scalar_t<ViewedElemT>, NestedRegion>>
     : public detail::simd_view_impl<
-          BaseTy, std::pair<region1d_scalar_t<typename BaseTy::element_type>,
-                            NestedRegion>> {
+          BaseTy, std::pair<region1d_scalar_t<ViewedElemT>, NestedRegion>> {
   template <typename, int> friend class simd;
   template <typename, typename> friend class detail::simd_view_impl;
 
 public:
-  using RegionTy =
-      std::pair<region1d_scalar_t<typename BaseTy::element_type>, NestedRegion>;
+  using RegionTy = std::pair<region1d_scalar_t<ViewedElemT>, NestedRegion>;
   using BaseClass = detail::simd_view_impl<BaseTy, RegionTy>;
   using ShapeTy = typename shape_type<RegionTy>::type;
   static constexpr int length = ShapeTy::Size_x * ShapeTy::Size_y;
   static_assert(1 == length, "length of this view is not equal to 1");
+  static_assert(std::is_same_v<typename ShapeTy::element_type, ViewedElemT>);
   /// The element type of this class, which could be different from the element
   /// type of the base object type.
-  using element_type = typename ShapeTy::element_type;
+  using element_type = ViewedElemT;
 
 private:
   simd_view(BaseTy &Base, RegionTy Region) : BaseClass(Base, Region) {}

--- a/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/simd_view.hpp
@@ -175,18 +175,18 @@ public:
 ///   auto v1 = v.select<2, 1>(0);
 ///   auto v2 = v1[0]; // simd_view of a nested region for a single element
 template <typename BaseTy, typename NestedRegion>
-class simd_view<BaseTy,
-                std::pair<region1d_scalar_t<typename BaseTy::element_type>,
-                          NestedRegion>>
+class simd_view<
+    BaseTy,
+    std::pair<region1d_scalar_t<typename BaseTy::element_type>, NestedRegion>>
     : public detail::simd_view_impl<
-          BaseTy,
-          std::pair<region1d_scalar_t<typename BaseTy::element_type>,
-                    NestedRegion>> {
+          BaseTy, std::pair<region1d_scalar_t<typename BaseTy::element_type>,
+                            NestedRegion>> {
   template <typename, int> friend class simd;
   template <typename, typename> friend class detail::simd_view_impl;
 
 public:
-  using RegionTy = std::pair<region1d_scalar_t<typename BaseTy::element_type>, NestedRegion>;
+  using RegionTy =
+      std::pair<region1d_scalar_t<typename BaseTy::element_type>, NestedRegion>;
   using BaseClass = detail::simd_view_impl<BaseTy, RegionTy>;
   using ShapeTy = typename shape_type<RegionTy>::type;
   static constexpr int length = ShapeTy::Size_x * ShapeTy::Size_y;

--- a/sycl/test/esimd/flat_atomic.cpp
+++ b/sycl/test/esimd/flat_atomic.cpp
@@ -27,12 +27,14 @@ void kernel1(uint32_t *ptr) SYCL_ESIMD_FUNCTION {
   flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, 32>(ptr, offsets, v1, 1);
 }
 
-void kernel2(uint32_t *ptr) SYCL_ESIMD_FUNCTION {
+template <class T> void kernel2(T *ptr) SYCL_ESIMD_FUNCTION {
   simd<uint32_t, 32> offsets(0, 1);
-  simd<uint32_t, 32> v1(0, 1);
+  simd<T, 32> v1(0, 1);
 
-  atomic_update<atomic_op::cmpxchg, uint32_t, 32>(ptr, offsets, v1, v1, 1);
+  atomic_update<atomic_op::cmpxchg, T, 32>(ptr, offsets, v1, v1, 1);
   // deprecated form:
-  flat_atomic<EsimdAtomicOpType::ATOMIC_CMPXCHG, uint32_t, 32>(ptr, offsets, v1,
-                                                               v1, 1);
+  flat_atomic<EsimdAtomicOpType::ATOMIC_CMPXCHG, T, 32>(ptr, offsets, v1, v1,
+                                                        1);
 }
+
+template void kernel2<uint32_t>(uint32_t *) SYCL_ESIMD_FUNCTION;

--- a/sycl/test/esimd/intrins_trans.cpp
+++ b/sycl/test/esimd/intrins_trans.cpp
@@ -179,9 +179,9 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
 //   level of testing strength
 // 2. Test cases above should be refactored not to use user-level APIs like
 //   gather and use __esimd* calls instead.
-template <class T, int N> using vec = typename simd<T, N>::vector_type;
+template <class T, int N> using vec = typename simd<T, N>::raw_vector_type;
 
-template <int N> using mask = typename simd_mask<N>::vector_type;
+template <int N> using mask = typename simd_mask<N>::raw_vector_type;
 
 SYCL_EXTERNAL void use(const vec<float, 8> &x) SYCL_ESIMD_FUNCTION;
 SYCL_EXTERNAL void use(const vec<int, 8> &x) SYCL_ESIMD_FUNCTION;

--- a/sycl/test/esimd/simd.cpp
+++ b/sycl/test/esimd/simd.cpp
@@ -7,103 +7,135 @@
 
 using namespace sycl::ext::intel::experimental::esimd;
 
-bool test_simd_ctors() SYCL_ESIMD_FUNCTION {
-  simd<int, 16> v0 = 1;
-  simd<int, 16> v1(v0);
-  simd<int, 16> v2(simd<int, 16>(0, 1));
-  const simd<int, 16> v3{0, 2, 4, 6, 1, 3, 5, 7};
+template <class T> bool test_simd_ctors() SYCL_ESIMD_FUNCTION {
+  simd<T, 16> v0 = 1;
+  simd<T, 16> v1(v0);
+  simd<T, 16> v2(simd<T, 16>(0, 1));
+  const simd<T, 16> v3{0, 2, 4, 6, 1, 3, 5, 7};
   return v0[0] + v1[1] + v2[2] + v3[3] == 1 + 1 + 2 + 6;
 }
 
-void test_simd_class_traits() SYCL_ESIMD_FUNCTION {
-  static_assert(std::is_default_constructible<simd<int, 4>>::value,
+template bool test_simd_ctors<int>() SYCL_ESIMD_FUNCTION;
+template bool test_simd_ctors<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> void test_simd_class_traits() SYCL_ESIMD_FUNCTION {
+  static_assert(std::is_default_constructible<simd<T, 4>>::value,
                 "type trait mismatch");
-  static_assert(std::is_trivially_default_constructible<simd<int, 4>>::value,
+  static_assert(std::is_trivially_default_constructible<simd<T, 4>>::value,
                 "type trait mismatch");
-  static_assert(std::is_copy_constructible<simd<int, 4>>::value,
+  static_assert(std::is_copy_constructible<simd<T, 4>>::value,
                 "type trait mismatch");
-  static_assert(!std::is_trivially_copy_constructible<simd<int, 4>>::value,
+  static_assert(!std::is_trivially_copy_constructible<simd<T, 4>>::value,
                 "type trait mismatch");
-  static_assert(std::is_move_constructible<simd<int, 4>>::value,
+  static_assert(std::is_move_constructible<simd<T, 4>>::value,
                 "type trait mismatch");
-  static_assert(!std::is_trivially_move_constructible<simd<int, 4>>::value,
+  static_assert(!std::is_trivially_move_constructible<simd<T, 4>>::value,
                 "type trait mismatch");
-  static_assert(std::is_copy_assignable<simd<int, 4>>::value,
+  static_assert(std::is_copy_assignable<simd<T, 4>>::value,
                 "type trait mismatch");
-  static_assert(std::is_trivially_copy_assignable<simd<int, 4>>::value,
+  static_assert(std::is_trivially_copy_assignable<simd<T, 4>>::value,
                 "type trait mismatch");
-  static_assert(std::is_move_assignable<simd<int, 4>>::value,
+  static_assert(std::is_move_assignable<simd<T, 4>>::value,
                 "type trait mismatch");
-  static_assert(std::is_trivially_move_assignable<simd<int, 4>>::value,
+  static_assert(std::is_trivially_move_assignable<simd<T, 4>>::value,
                 "type trait mismatch");
 }
+
+template void test_simd_class_traits<int>() SYCL_ESIMD_FUNCTION;
+template void test_simd_class_traits<sycl::half>() SYCL_ESIMD_FUNCTION;
 
 void test_conversion() SYCL_ESIMD_FUNCTION {
   simd<int, 32> v = 3;
   simd<float, 32> f = v;
   simd<char, 32> c = f;
-  simd<char, 16> c1 = f.select<16, 1>(0);
-  c.select<32, 1>(0) = f;
+  simd<sycl::half, 32> h = c;
+  simd<char, 16> c1 = h.template select<16, 1>(0);
+  c.template select<32, 1>(0) = f;
+  h.template select<7, 1>(3) =
+      v.template select<22, 1>(0).template select<7, 3>(1);
   f = v + static_cast<simd<int, 32>>(c);
 }
 
-bool test_1d_select() SYCL_ESIMD_FUNCTION {
-  simd<int, 32> v = 0;
-  v.select<8, 1>(0) = 1;
-  v.select<8, 1>(8) = 2;
-  v.select<8, 1>(16) = 3;
-  v.select<8, 1>(24) = 4;
+template <class T> bool test_1d_select() SYCL_ESIMD_FUNCTION {
+  simd<T, 32> v = 0;
+  v.template select<8, 1>(0) = 1;
+  v.template select<8, 1>(8) = 2;
+  v.template select<8, 1>(16) = 3;
+  v.template select<8, 1>(24) = 4;
   return v[0] + v[8] + v[16] + v[24] == (1 + 2 + 3 + 4);
 }
 
+template bool test_1d_select<int>() SYCL_ESIMD_FUNCTION;
+template bool test_1d_select<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T1, class T2, class T3>
 bool test_simd_format() SYCL_ESIMD_FUNCTION {
-  simd<int, 16> v{0, 1, 2, 3, 4, 5, 6, 7};
-  auto ref1 = v.bit_cast_view<short>();
-  auto ref2 = v.bit_cast_view<double>();
-  auto ref3 = v.bit_cast_view<short, 8, 4>();
+  simd<T1, 16> v{0, 1, 2, 3, 4, 5, 6, 7};
+  auto ref1 = v.template bit_cast_view<T2>();
+  auto ref2 = v.template bit_cast_view<T3>();
+  auto ref3 = v.template bit_cast_view<T2, 8, 4>();
   return (decltype(ref1)::length == 32) && (decltype(ref2)::length == 8) &&
          (decltype(ref3)::getSizeX() == 4) && (decltype(ref3)::getSizeY() == 8);
 }
 
-bool test_simd_select(int a) SYCL_ESIMD_FUNCTION {
+template bool test_simd_format<int, short, double>() SYCL_ESIMD_FUNCTION;
+template bool
+test_simd_format<uint32_t, sycl::half, uint64_t>() SYCL_ESIMD_FUNCTION;
+
+template <class T1, class T2> bool test_simd_select(T1 a) SYCL_ESIMD_FUNCTION {
   {
-    simd<float, 32> f = a;
-    simd<char, 32> c1 = 2;
-    c1.select<16, 1>(0) = f.select<16, 1>(0);
-    c1.select<16, 1>(0).select<16, 1>(0) = f.select<16, 1>(0).select<16, 1>(0);
+    simd<T1, 32> f = a;
+    simd<T2, 32> c1 = 2;
+    c1.template select<16, 1>(0) = f.template select<16, 1>(0);
+    c1.template select<16, 1>(0).template select<16, 1>(0) =
+        f.template select<16, 1>(0).template select<16, 1>(0);
   }
   {
-    simd<int, 16> v(0, 1);
-    auto ref0 = v.select<4, 2>(1);            // r{1, 3, 5, 7}
-    auto ref1 = v.bit_cast_view<int, 4, 4>(); // 0,1,2,3;
-                                              // 4,5,6,7;
-                                              // 8,9,10,11;
-                                              // 12,13,14,15
-    auto ref2 = ref1.select<2, 1, 2, 2>(0, 1);
-    return ref0[0] == 1 && decltype(ref2)::getSizeX() == 2 &&
-           decltype(ref2)::getStrideY() == 1;
+    simd<T1, 16> v(0, 1);
+    auto ref0 = v.template select<4, 2>(1);           // r{1, 3, 5, 7}
+    auto ref1 = v.template bit_cast_view<T1, 4, 4>(); // 0,1,2,3;
+                                                      // 4,5,6,7;
+                                                      // 8,9,10,11;
+                                                      // 12,13,14,15
+    auto ref2 = ref1.template select<2, 1, 2, 2>(0, 1);
+    return (ref0[0] == 1) && (decltype(ref2)::getSizeX() == 2) &&
+           (decltype(ref2)::getStrideY() == 1);
   }
+  return false;
 }
 
-bool test_2d_offset() SYCL_ESIMD_FUNCTION {
-  simd<int, 16> v = 0;
-  auto ref = v.bit_cast_view<short, 8, 4>();
-  return ref.select<2, 2, 2, 2>(2, 1).getOffsetX() == 1 &&
-         ref.select<2, 2, 2, 2>(2, 1).getOffsetY() == 2;
+template bool test_simd_select<float, char>(float) SYCL_ESIMD_FUNCTION;
+template bool
+    test_simd_select<uint64_t, sycl::half>(uint64_t) SYCL_ESIMD_FUNCTION;
+
+template <class T1, class T2> bool test_2d_offset() SYCL_ESIMD_FUNCTION {
+  simd<T1, 16> v = 0;
+  auto ref = v.template bit_cast_view<T2, 8, 4>();
+  return ref.template select<2, 2, 2, 2>(2, 1).getOffsetX() == 1 &&
+         ref.template select<2, 2, 2, 2>(2, 1).getOffsetY() == 2;
 }
 
+template bool test_2d_offset<int, short>() SYCL_ESIMD_FUNCTION;
+template bool test_2d_offset<sycl::half, uint8_t>() SYCL_ESIMD_FUNCTION;
+
+template <class T1, class T2>
 bool test_simd_bin_op_promotion() SYCL_ESIMD_FUNCTION {
-  simd<short, 8> v0 = std::numeric_limits<short>::max();
-  simd<short, 8> v1 = 1;
-  simd<int, 8> v2 = v0 + v1;
+  simd<T2, 8> v0 = std::numeric_limits<T2>::max();
+  simd<T2, 8> v1 = 1;
+  simd<T1, 8> v2 = v0 + v1;
   return v2[0] == 32768;
 }
 
-bool test_simd_bin_ops() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0 = 1;
-  simd<int, 8> v1 = 2;
+template bool test_simd_bin_op_promotion<int, short>() SYCL_ESIMD_FUNCTION;
+template bool
+test_simd_bin_op_promotion<sycl::half, uint64_t>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_simd_bin_ops() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0 = 1;
+  simd<T, 8> v1 = 2;
   v0 += v1;
-  v0 %= v1;
+  if constexpr (std::is_integral_v<T>)
+    v0 %= v1;
   v0 = 2 - v0;
   v0 -= v1;
   v0 -= 2;
@@ -114,101 +146,142 @@ bool test_simd_bin_ops() SYCL_ESIMD_FUNCTION {
   return v0[0] == 1;
 }
 
-bool test_simd_unary_ops() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0 = 1;
-  simd<int, 8> v1 = 2;
-  v0 <<= v1;
+template bool test_simd_bin_ops<int>() SYCL_ESIMD_FUNCTION;
+template bool test_simd_bin_ops<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_simd_unary_ops() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0 = 1;
+  simd<T, 8> v1 = 2;
+  if constexpr (std::is_integral_v<T>)
+    v0 <<= v1;
   v1 = -v0;
-  v0 = ~v1;
+  if constexpr (std::is_integral_v<T>)
+    v0 = ~v1;
   return v1[0] == 1;
 }
 
-bool test_nested_1d_select() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> r0(0, 1);
+template bool test_simd_unary_ops<int>() SYCL_ESIMD_FUNCTION;
+template bool test_simd_unary_ops<sycl::half>() SYCL_ESIMD_FUNCTION;
 
-  auto r1 = r0.select<4, 2>(0);
-  auto r2 = r1.select<2, 2>(0);
-  auto r3 = r2.select<1, 0>(1);
+template <class T> bool test_nested_1d_select() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> r0(0, 1);
+
+  auto r1 = r0.template select<4, 2>(0);
+  auto r2 = r1.template select<2, 2>(0);
+  auto r3 = r2.template select<1, 0>(1);
   r3 = 37;
 
   return r0[4] == 37;
 }
 
-bool test_format_1d_read() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> r = 0x0FF00F0F;
-  auto rl = r.bit_cast_view<short>();
-  auto rl2 = rl.select<8, 2>(0); // 0F0F
-  auto rh = r.bit_cast_view<short>();
-  auto rh2 = rh.select<8, 2>(1); // 0FF0
+template bool test_nested_1d_select<int>() SYCL_ESIMD_FUNCTION;
+template bool test_nested_1d_select<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T1, class T2> bool test_format_1d_read() SYCL_ESIMD_FUNCTION {
+  simd<T1, 8> r = 0x0FF00F0F;
+  auto rl = r.template bit_cast_view<T2>();
+  auto rl2 = rl.template select<8, 2>(0); // 0F0F
+  auto rh = r.template bit_cast_view<T2>();
+  auto rh2 = rh.template select<8, 2>(1); // 0FF0
   return rl2[0] == 0x0F0F && rh2[0] == 0x0FF0;
 }
 
-bool test_format_1d_write() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> r;
-  auto rl = r.bit_cast_view<short>();
-  auto rl2 = rl.select<8, 2>(0);
-  auto rh = r.bit_cast_view<short>();
-  auto rh2 = rh.select<8, 2>(1);
+template bool test_format_1d_read<int, short>() SYCL_ESIMD_FUNCTION;
+template bool test_format_1d_read<sycl::half, uint8_t>() SYCL_ESIMD_FUNCTION;
+
+template <class T1, class T2> bool test_format_1d_write() SYCL_ESIMD_FUNCTION {
+  simd<T1, 8> r;
+  auto rl = r.template bit_cast_view<T2>();
+  auto rl2 = rl.template select<8, 2>(0);
+  auto rh = r.template bit_cast_view<T2>();
+  auto rh2 = rh.template select<8, 2>(1);
   rh2 = 0x0F, rl2 = 0xF0;
   return r[0] == 0x0FF0;
 }
 
+template bool test_format_1d_write<int, short>() SYCL_ESIMD_FUNCTION;
+template bool test_format_1d_write<sycl::half, uint64_t>() SYCL_ESIMD_FUNCTION;
+
+template <class T1, class T2>
 bool test_format_1d_read_write_nested() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v = 0;
-  auto r1 = v.bit_cast_view<short>();
-  auto r11 = r1.select<8, 1>(0);
-  auto r12 = r11.bit_cast_view<int>();
-  auto r2 = v.bit_cast_view<short>();
-  auto r21 = r2.select<8, 1>(8);
-  auto r22 = r21.bit_cast_view<int>();
+  simd<T1, 32> v = 0;
+  auto r1 = v.template bit_cast_view<T2>();
+  auto r11 = r1.template select<8, 1>(0);
+  auto r12 = r11.template bit_cast_view<T1>();
+  auto r2 = v.template bit_cast_view<T2>();
+  auto r21 = r2.template select<8, 1>(8);
+  auto r22 = r21.template bit_cast_view<T1>();
   r12 += 1, r22 += 2;
   return v[0] == 1 && v[4] == 2;
 }
 
-bool test_format_2d_read() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0(0, 1);
-  auto r1 = v0.bit_cast_view<int, 2, 4>();
-  simd<int, 4> v1 = r1.select<1, 0, 4, 1>(1, 0).read(); // second row
+template bool
+test_format_1d_read_write_nested<int, short>() SYCL_ESIMD_FUNCTION;
+template bool
+test_format_1d_read_write_nested<sycl::half, uint64_t>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_format_2d_read() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0(0, 1);
+  auto r1 = v0.template bit_cast_view<T, 2, 4>();
+  simd<T, 4> v1 = r1.template select<1, 0, 4, 1>(1, 0).read(); // second row
   return v1[0] == 4;
 }
 
-bool test_format_2d_write() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0(0, 1);
-  auto r1 = v0.bit_cast_view<int, 2, 4>();
-  r1.select<1, 0, 4, 1>(1, 0) = 37;
+template bool test_format_2d_read<int>() SYCL_ESIMD_FUNCTION;
+template bool test_format_2d_read<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_format_2d_write() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0(0, 1);
+  auto r1 = v0.template bit_cast_view<T, 2, 4>();
+  r1.template select<1, 0, 4, 1>(1, 0) = 37;
   return v0[4] == 37;
 }
 
-bool test_select_rvalue() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0(0, 1);
-  v0.select<4, 2>(1).select<2, 2>(0) = 37;
+template bool test_format_2d_write<int>() SYCL_ESIMD_FUNCTION;
+template bool test_format_2d_write<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_select_rvalue() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0(0, 1);
+  v0.template select<4, 2>(1).template select<2, 2>(0) = 37;
   return v0[5] == 37;
 }
 
-auto test_format_1d_write_rvalue() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0 = 0x0F0F0F0F;
-  v0.bit_cast_view<short>().select<8, 2>(0) = 0x0E0E;
+template bool test_select_rvalue<int>() SYCL_ESIMD_FUNCTION;
+template bool test_select_rvalue<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_format_1d_write_rvalue() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0 = 0x0F0F0F0F;
+  v0.template bit_cast_view<short>().template select<8, 2>(0) = 0x0E0E;
   return v0[2] == 0x0E0E0E0E;
 }
 
-bool test_format_2d_write_rvalue() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0(0, 1);
-  v0.bit_cast_view<int, 2, 4>().select<1, 0, 4, 1>(0, 0) = 37;
+template bool test_format_1d_write_rvalue<int>() SYCL_ESIMD_FUNCTION;
+template bool test_format_1d_write_rvalue<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_format_2d_write_rvalue() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0(0, 1);
+  v0.template bit_cast_view<T, 2, 4>().template select<1, 0, 4, 1>(0, 0) = 37;
   return v0[3] == 37;
 }
 
-auto test_format_2d_read_rvalue() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0(0, 1);
-  auto r1 = v0.bit_cast_view<int, 2, 4>()
-                .select<1, 0, 4, 1>(1, 0)
-                .bit_cast_view<int>()
-                .select<2, 2>(1);
+template bool test_format_2d_write_rvalue<int>() SYCL_ESIMD_FUNCTION;
+template bool test_format_2d_write_rvalue<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_format_2d_read_rvalue() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0(0, 1);
+  auto r1 = v0.template bit_cast_view<T, 2, 4>()
+                .template select<1, 0, 4, 1>(1, 0)
+                .template bit_cast_view<T>()
+                .template select<2, 2>(1);
   return r1[0] == 5;
 }
 
-bool test_row_read_write() SYCL_ESIMD_FUNCTION {
-  simd<int, 16> v0(0, 1);
-  auto m = v0.bit_cast_view<int, 4, 4>();
+template bool test_format_2d_read_rvalue<int>() SYCL_ESIMD_FUNCTION;
+template bool test_format_2d_read_rvalue<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_row_read_write() SYCL_ESIMD_FUNCTION {
+  simd<T, 16> v0(0, 1);
+  auto m = v0.template bit_cast_view<T, 4, 4>();
 
   auto r0 = m.row(0); // 0 1 2 3
   auto r1 = m.row(1); // 4 5 6 7
@@ -221,9 +294,12 @@ bool test_row_read_write() SYCL_ESIMD_FUNCTION {
   return r0[0] == 8 && r1[0] == 16;
 }
 
-bool test_column_read_write() SYCL_ESIMD_FUNCTION {
-  simd<int, 4> v0(0, 1);
-  auto m = v0.bit_cast_view<int, 2, 2>();
+template bool test_row_read_write<int>() SYCL_ESIMD_FUNCTION;
+template bool test_row_read_write<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_column_read_write() SYCL_ESIMD_FUNCTION {
+  simd<T, 4> v0(0, 1);
+  auto m = v0.template bit_cast_view<T, 2, 2>();
 
   auto c0 = m.column(0); // 0 2
   auto c1 = m.column(1); // 1 3
@@ -234,43 +310,61 @@ bool test_column_read_write() SYCL_ESIMD_FUNCTION {
   return v0[0] == 1 && v0[3] == 4;
 }
 
-bool test_replicate() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0(0, 1);
-  auto v0_rep = v0.replicate<1>();
+template bool test_column_read_write<int>() SYCL_ESIMD_FUNCTION;
+template bool test_column_read_write<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_replicate() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0(0, 1);
+  auto v0_rep = v0.template replicate<1>();
 
   return v0[0] == v0_rep[0] && v0[7] == v0_rep[7];
 }
 
-bool test_replicate1() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0(0, 1);
-  auto v0_rep = v0.replicate_w<4, 2>(2);
+template bool test_replicate<int>() SYCL_ESIMD_FUNCTION;
+template bool test_replicate<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_replicate1() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0(0, 1);
+  auto v0_rep = v0.template replicate_w<4, 2>(2);
 
   return v0[2] == v0_rep[2] && v0[3] == v0_rep[5];
 }
 
-bool test_replicate2() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0(0, 1);
-  auto v0_rep = v0.replicate_vs_w<2, 4, 2>(1);
+template bool test_replicate1<int>() SYCL_ESIMD_FUNCTION;
+template bool test_replicate1<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_replicate2() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0(0, 1);
+  auto v0_rep = v0.template replicate_vs_w<2, 4, 2>(1);
 
   return v0_rep[0] == v0[1] && v0_rep[1] == v0[2] && v0_rep[2] == v0[5];
 }
 
-bool test_replicate3() SYCL_ESIMD_FUNCTION {
-  simd<int, 8> v0(0, 1);
-  auto v0_rep = v0.replicate_vs_w_hs<2, 4, 2, 2>(1);
+template bool test_replicate2<int>() SYCL_ESIMD_FUNCTION;
+template bool test_replicate2<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T> bool test_replicate3() SYCL_ESIMD_FUNCTION {
+  simd<T, 8> v0(0, 1);
+  auto v0_rep = v0.template replicate_vs_w_hs<2, 4, 2, 2>(1);
 
   return v0_rep[0] == v0[1] && v0_rep[1] == v0[3] && v0_rep[2] == v0[5];
 }
 
-bool test_simd_iselect() SYCL_ESIMD_FUNCTION {
-  simd<int, 16> v(0, 1);
-  simd<ushort, 8> a(0, 2);
+template bool test_replicate3<int>() SYCL_ESIMD_FUNCTION;
+template bool test_replicate3<sycl::half>() SYCL_ESIMD_FUNCTION;
+
+template <class T1, class T2> bool test_simd_iselect() SYCL_ESIMD_FUNCTION {
+  simd<T1, 16> v(0, 1);
+  simd<T2, 8> a(0, 2);
   auto data = v.iselect(a);
   data += 16;
-  v.iupdate(a, data, simd_mask<8>(1));
-  auto ref = v.select<8, 2>(0);
+  v.template iupdate(a, data, simd_mask<8>(1));
+  auto ref = v.template select<8, 2>(0);
   return ref[0] == 16 && ref[14] == 32;
 }
+
+template bool test_simd_iselect<int, ushort>() SYCL_ESIMD_FUNCTION;
+template bool test_simd_iselect<sycl::half, ushort>() SYCL_ESIMD_FUNCTION;
 
 void test_simd_binop_honor_int_promo() SYCL_ESIMD_FUNCTION {
   simd<short, 32> a;


### PR DESCRIPTION
- implement infrastructure for non-standard element type support
  to support a new type, the following must be implemented:
  * element type traits for the new type
  * scalar and vector conversions to/from selected std C++ type
  * std operations (or default with promotion to std C++ type can be used)
- esimd::simd<sycl::half, N> can now be used on host and device
  * most of the operations, except extended math are supported for half
 
Complementary E2E tests update - https://github.com/intel/llvm-test-suite/pull/640