### PR TITLE
Revert "[CI] Disable pack and upload steps"

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -154,10 +154,8 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target install-clang-tidy
 
     - name: Pack
-      if: false
       run: tar -cJf llvm_sycl.tar.xz -C $GITHUB_WORKSPACE/build/install .
     - name: Upload artifacts
-      if: false
       uses: actions/upload-artifact@v1
       with:
         name: sycl_linux_${{ fromJSON(needs.configure.outputs.params).build_artifact_suffix }}


### PR DESCRIPTION
Reverts intel/llvm#5119

The issue was on GitHub side, it is now resolved. 
Due to server side changes, longer jobs were cancelled. Removing two steps from the workflow helped to reduce the duration of pre-commit testing just enough to be under that limit. See https://github.com/actions/runner/issues/1546 for more info.