### PR TITLE
[CI] Use clang-format from nightly builds

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -9,6 +9,8 @@ jobs:
   lint:
     # TODO use nightly builds of SYCL to get clang-format
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/intel/llvm/sycl_ubuntu2004_nightly:no-drivers
     steps:
     - name: Get clang-format first
       run: sudo apt-get install -yqq clang-format

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -12,13 +12,9 @@ jobs:
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2004_nightly:no-drivers
     steps:
-    - name: Get clang-format first
-      run: sudo apt-get install -yqq clang-format
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
-
     - name: Run clang-format
       uses: ./devops/actions/clang-format
 

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   lint:
-    # TODO use nightly builds of SYCL to get clang-format
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2004_nightly:no-drivers


### PR DESCRIPTION
[Contributing guide](https://github.com/intel/llvm/blob/sycl/CONTRIBUTING.md) suggests using the same version of clang-format, that is build from tip of this repository. That caused problems in the past, where the newer clang-format does the job differently to what's being used in CI. This patch switches to default clang-format installation to the one, that comes with nightly builds. This would allow us to minimize the impact of different clang-format versions.