### PR TITLE
[CI] Install cm-compiler in drivers image

### DIFF
--- a/devops/containers/ubuntu2004_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2004_intel_drivers.Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG compute_runtime_tag=latest
 ARG igc_tag=latest
+ARG cm_tag=latest
 ARG tbb_tag=latest
 ARG fpgaemu_tag=latest
 ARG cpu_tag=latest
@@ -15,7 +16,7 @@ RUN apt update && apt install -yqq wget
 
 COPY scripts/get_release.py /
 
-# Install IGC and NEO
+# Install IGC, CM and NEO
 RUN python3 /get_release.py intel/intel-graphics-compiler $igc_tag \
   | grep ".*deb" \
   | wget -qi - && \
@@ -23,6 +24,9 @@ RUN python3 /get_release.py intel/intel-graphics-compiler $igc_tag \
   | grep -E ".*((deb)|(sum))" \
   | wget -qi - && \
   sha256sum -c *.sum &&\
+  python3 /get_release.py intel/cm-compiler $cm_tag \
+  | grep ".*deb" \
+  | wget -qi - && \
   dpkg -i *.deb && rm *.deb *.sum
 
 RUN mkdir /runtimes


### PR DESCRIPTION
At least one test in llvm-test-suite uses C for metal. Deploy required components to run it.