### PR TITLE
[CI] Refactor workflow files

### DIFF
--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'
+  pull_request:
+    paths:
+      - 'devops/containers/ubuntu2004_preinstalled.Dockerfile'
+      - '.github/workflows/sycl_nightly.yml'
 
 jobs:
   ubuntu2004_build_test:

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'intel/llvm'
     uses: intel/llvm/.github/workflows/sycl_linux_build_and_test.yml@sycl
     with:
-      build_runs_on: sycl-precommit-linux
+      build_runs_on: build
       build_github_cache: true
       build_cache_root: "/__w/"
       build_artifact_suffix: default

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -28,33 +28,30 @@ jobs:
       with:
         name: sycl_linux_default
         path: devops/
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+    - name: Build and Push Container (with drivers)
+      uses: ./devops/actions/build_container
       with:
-        registry: ghcr.io
+        push: ${{ github.event_name != 'pull_request' }}
+        file: ubuntu2004_preinstalled
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and Push Container (with drivers)
-      uses: docker/build-push-action@v2
-      with:
-        push: true
         build-args: |
           base_image=ghcr.io/intel/llvm/ubuntu2004_intel_drivers
           base_tag=latest
         tags: |
           ghcr.io/${{ github.repository }}/sycl_ubuntu2004_nightly:${{ github.sha }}
           ghcr.io/${{ github.repository }}/sycl_ubuntu2004_nightly:latest
-        context: ${{ github.workspace }}/devops
-        file: ${{ github.workspace }}/devops/containers/ubuntu2004_preinstalled.Dockerfile
     - name: Build and Push Container (no drivers)
-      uses: docker/build-push-action@v2
+      uses: ./devops/actions/build_container
       with:
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
+        file: ubuntu2004_preinstalled
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
         build-args: |
           base_image=ghcr.io/intel/llvm/ubuntu2004_base
           base_tag=latest
         tags: |
           ghcr.io/${{ github.repository }}/sycl_ubuntu2004_nightly:no-drivers-${{ github.sha }}
           ghcr.io/${{ github.repository }}/sycl_ubuntu2004_nightly:no-drivers
-        context: ${{ github.workspace }}/devops
-        file: ${{ github.workspace }}/devops/containers/ubuntu2004_preinstalled.Dockerfile
+

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       build_cache_root: "/__w/llvm"
       build_github_cache: true
-      build_artifact_suffix: default
+      build_artifact_suffix: build
   linux_no_assert:
     name: Linux (no assert)
     uses: intel/llvm/.github/workflows/sycl_linux_build_and_test.yml@sycl

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -25,7 +25,7 @@ jobs:
     if: always() && (success() || contains(github.event.pull_request.labels.*.name, 'ignore-lint'))
     uses: intel/llvm/.github/workflows/sycl_linux_build_and_test.yml@sycl
     with:
-      build_runs_on: "sycl-precommit-linux"
+      build_runs_on: "build"
       build_cache_root: "/__w/"
       build_cache_size: "8G"
       build_artifact_suffix: "default"


### PR DESCRIPTION
Use "build" label to dispatch compiler build jobs to build machines.
Use `build_container` action in Nightly workflow for unification with other container jobs.