### PR TITLE
[SYCL][HIP] Fix platform query in USM alloc info

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -4755,7 +4755,7 @@ pi_result hip_piextUSMGetMemAllocInfo(pi_context context, const void *ptr,
           static_cast<int *>(hipPointerAttributeType.devicePointer);
       value = *devicePointer;
       pi_platform platform;
-      result = hip_piPlatformsGet(0, &platform, nullptr);
+      result = hip_piPlatformsGet(1, &platform, nullptr);
       pi_device device = platform->devices_[value].get();
       return getInfo(param_value_size, param_value, param_value_size_ret,
                      device);


### PR DESCRIPTION
This fixes the `USM/pointer_query.cpp` test from `llvm-test-suite`.

Using `0` when trying to query platforms is invalid, so this would cause
segmentation faults.