### PR TITLE
[Docker] Add workarounds for two SYCL issues

### DIFF
--- a/devops/containers/ubuntu2004_preinstalled.Dockerfile
+++ b/devops/containers/ubuntu2004_preinstalled.Dockerfile
@@ -4,7 +4,11 @@ ARG base_image=ghcr.io/intel/llvm/ubuntu2004_intel_drivers
 FROM $base_image:$base_tag
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
-ADD llvm_sycl.tar.xz /usr
+RUN mkdir -p /opt/sycl
+ADD llvm_sycl.tar.xz /opt/sycl
+
+ENV PATH /opt/sycl/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -8,4 +8,6 @@ apt update && apt install -yqq \
       git \
       python3 \
       python3-distutils \
-      python-is-python3
+      python-is-python3 \
+      ocl-icd-libopencl1 \
+      vim


### PR DESCRIPTION
First issue is that SYCL runtime requires libOpenCL.so for correct functioning, which is typically built with the rest of compiler toolchain, but never gets deployed to installation directory.
Second issue is described in https://github.com/intel/llvm/issues/5142, which breaks SYCL toolchain if it's installed to `/usr`.
Also add vim to the image for convenience of local work/debugging.