### PR TITLE
[SYCL][HIP] Fix max constant memory device query

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -1320,10 +1320,13 @@ pi_result hip_piDeviceGetInfo(pi_device device, pi_device_info param_name,
         hipDeviceGetAttribute(&constant_memory,
                               hipDeviceAttributeTotalConstantMemory,
                               device->get()) == hipSuccess);
-    cl::sycl::detail::pi::assertion(constant_memory >= 0);
 
+    // hipDeviceGetAttribute takes a int*, however the size of the constant
+    // memory on AMD GPU may be larger than what can fit in the positive part
+    // of a signed integer, so we need to cast it to unsigned before returning
+    // the value.
     return getInfo(param_value_size, param_value, param_value_size_ret,
-                   pi_uint64(constant_memory));
+                   pi_uint64(static_cast<unsigned int>(constant_memory)));
   }
   case PI_DEVICE_INFO_MAX_CONSTANT_ARGS: {
     // TODO: is there a way to retrieve this from HIP driver API?

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -1315,18 +1315,19 @@ pi_result hip_piDeviceGetInfo(pi_device device, pi_device_info param_name,
                    pi_uint64{bytes});
   }
   case PI_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE: {
-    int constant_memory = 0;
-    cl::sycl::detail::pi::assertion(
-        hipDeviceGetAttribute(&constant_memory,
-                              hipDeviceAttributeTotalConstantMemory,
-                              device->get()) == hipSuccess);
+    unsigned int constant_memory = 0;
 
     // hipDeviceGetAttribute takes a int*, however the size of the constant
     // memory on AMD GPU may be larger than what can fit in the positive part
-    // of a signed integer, so we need to cast it to unsigned before returning
-    // the value.
+    // of a signed integer, so use an unsigned integer and cast the pointer to
+    // int*.
+    cl::sycl::detail::pi::assertion(
+        hipDeviceGetAttribute(reinterpret_cast<int *>(&constant_memory),
+                              hipDeviceAttributeTotalConstantMemory,
+                              device->get()) == hipSuccess);
+
     return getInfo(param_value_size, param_value, param_value_size_ret,
-                   pi_uint64(static_cast<unsigned int>(constant_memory)));
+                   pi_uint64(constant_memory));
   }
   case PI_DEVICE_INFO_MAX_CONSTANT_ARGS: {
     // TODO: is there a way to retrieve this from HIP driver API?


### PR DESCRIPTION
This fixes the `Basic/info.cpp` test for HIP AMD.

The issue here is that AMD GPU report a very large constant memory
(confirmed using `clinfo` as well). But the HIP entry point to query
that information takes a `int*`. So the value will show up as negative,
even though it's the correct value.

So remove the assertion on if the value is positive and cast it back to
`unsigned` before returning it.