### PR TITLE
[LIBCLC] Fix NaN value for doubles

### DIFF
--- a/libclc/generic/lib/math/nan.inc
+++ b/libclc/generic/lib/math/nan.inc
@@ -5,7 +5,7 @@
 #if __CLC_FPSIZE == 64
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE nan(__CLC_XCONCAT(ulong, __CLC_VECSIZE) code)
 {
-	return __CLC_AS_GENTYPE(code | 0x7ff0000000000000ul);
+	return __CLC_AS_GENTYPE(code | 0x7ff8000000000000ul);
 }
 #elif __CLC_FPSIZE == 32
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE nan(__CLC_XCONCAT(uint, __CLC_VECSIZE) code)

--- a/libclc/generic/libspirv/math/nan.inc
+++ b/libclc/generic/libspirv/math/nan.inc
@@ -12,7 +12,7 @@
 #if __CLC_FPSIZE == 64
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE
 __spirv_ocl_nan(__CLC_XCONCAT(ulong, __CLC_VECSIZE) code) {
-  return __CLC_AS_GENTYPE(code | 0x7ff0000000000000ul);
+  return __CLC_AS_GENTYPE(code | 0x7ff8000000000000ul);
 }
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE
 __spirv_ocl_nan(__CLC_XCONCAT(long, __CLC_VECSIZE) code) {


### PR DESCRIPTION
A NaN is a floating point value with all exponent bits set to 1 and any
non-zero fraction, and the sign bit can be set or not.

For doubles the floating point is represented as one sign bit, eleven
exponent bits, and the fraction bits, so the value before this patch
breaks down as follows:

```
0x7ff0000000000000

0b0111111111110000000000000000000000000000000000000000000000000000

0b0 11111111111 0000000000000000000000000000000000000000000000000000
```

As you can see this value has all zeroes in the exponent, it is
therefore not a NaN.

Comparing to the value used for single precision, knowing that single
precision follows the same rule but has only 8 bits of exponent:

```
0x7fc00000

0b01111111110000000000000000000000

0b0 11111111 10000000000000000000000
```

As you can see the value used for single precision has all exponent bits
set to one and the most significant bit of the fraction set to one,
therefore it is indeed a NaN.

And so the correct value for the NaN constant for doubles is actually:

```
0b0 11111111111 1000000000000000000000000000000000000000000000000000

0b0111111111111000000000000000000000000000000000000000000000000000

0x7ff8000000000000
```

Which is what this patch is updating the constant to be.

The constant for half precision also correctly follows this pattern.

This fixes the `llvm-test-suite` `nan.cpp` test with the CUDA plugin.