### PR TITLE
[LIBCLC] Adding functionality for in-kernel asserts for CUDA backend

### DIFF
--- a/libclc/ptx-nvidiacl/libspirv/SOURCES
+++ b/libclc/ptx-nvidiacl/libspirv/SOURCES
@@ -1,3 +1,4 @@
+assert/__assert_fail.cl
 reflect.ll
 atomic/loadstore_helpers.ll
 cl_khr_int64_extended_atomics/minmax_helpers.ll

--- a/libclc/ptx-nvidiacl/libspirv/assert/__assert_fail.cl
+++ b/libclc/ptx-nvidiacl/libspirv/assert/__assert_fail.cl
@@ -1,0 +1,9 @@
+#include <spirv/spirv.h>
+
+void __assertfail(const char *__message, const char *__file, unsigned __line,
+                  const char *__function);
+
+_CLC_DECL void __assert_fail(const char *expr, const char *file,
+                             unsigned int line, const char *func) {
+  __assertfail(expr, file, line, func);
+}


### PR DESCRIPTION
Adding functionality for in-kernel asserts with CUDA backend.

Responding to https://github.com/intel/llvm/issues/3385.