### PR TITLE
[SYCL][Doc] Add HIP backend to the filter selector

### DIFF
--- a/sycl/doc/extensions/FilterSelector/FilterSelector.adoc
+++ b/sycl/doc/extensions/FilterSelector/FilterSelector.adoc
@@ -30,8 +30,9 @@ Every element of the triple is optional, but a filter must contain at least one 
 
 |`cuda`
 |`host`
-| `opencl`
+|`opencl`
 |`level_zero`
+|`hip`
 |====
 
 .Supported Device Types


### PR DESCRIPTION
HIP backed support has been added with https://github.com/intel/llvm/pull/5171.