### PR TITLE
[CI] Enable LLVM test suite for precommit jobs

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -30,4 +30,4 @@ jobs:
       build_cache_size: "8G"
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
-
+      lts_config: "hip_amdgpu;ocl_x64"


### PR DESCRIPTION
Enable HIP and OCL CPU LLVM test suite jobs in pre-commit testing